### PR TITLE
fix(creds): quota-conditional account pick — avoid 5h-blocked accounts, load-balance the fleet

### DIFF
--- a/src/scitex_agent_container/_creds/__init__.py
+++ b/src/scitex_agent_container/_creds/__init__.py
@@ -8,11 +8,14 @@ answers the agent-start question:
     Given ``spec.claude.account`` (or no preference), WHICH stored
     account should this agent actually run on right now?
 
-Phase 1 (this module): pick a non-expired snapshot — see
-:func:`._pick_healthy.pick_healthy_account`. Cap-state probing is
-not cheaply detectable from disk, so a non-expired snapshot reads
-as healthy; 5h/7d cap-induced 429s are still surfaced from claude
-in-turn — the picker only avoids *known-stale* auth at boot.
+Freshness (a non-expired snapshot) is the hard gate — see
+:func:`._pick_healthy.pick_healthy_account`. On top of it the pick is
+quota-CONDITIONAL, read cache-only from the bound ``quota-cache.json``
+(:mod:`._quota_rank`): avoid accounts at ≥ ~95% of their 5h window
+(blocked-now — they 429 immediately) and ≥ ~90% of their 7d window
+(near-capped), and load-balance the remaining healthy tier across the
+fleet via per-agent weighted rendezvous hashing. Quota state is a
+preference, never a gate — in-turn 429s still surface from claude.
 """
 
 from __future__ import annotations
@@ -20,6 +23,8 @@ from __future__ import annotations
 from ._pick_healthy import (
     AccountHealth,
     NoHealthyAccountError,
+    account_5h_usage,
+    account_7d_usage,
     account_health,
     pick_healthy_account,
 )
@@ -27,6 +32,8 @@ from ._pick_healthy import (
 __all__ = [
     "AccountHealth",
     "NoHealthyAccountError",
+    "account_5h_usage",
+    "account_7d_usage",
     "account_health",
     "pick_healthy_account",
 ]

--- a/src/scitex_agent_container/_creds/_pick_healthy.py
+++ b/src/scitex_agent_container/_creds/_pick_healthy.py
@@ -19,19 +19,25 @@ Scope (Phase 1, deliberately small)
 * Health is *snapshot freshness*: a non-expired ``claudeAiOauth.
   expiresAt`` (the same field :mod:`_account.creds_sync` already
   reads) → ``VALID``. EXPIRED / ABSENT → unhealthy.
-* Account-pool Phase 1 — *quota-aware* pick: among the token-fresh
-  candidates, prefer the one with the most 7d headroom (lowest 7d
-  utilisation %), read from the cached ``quota-cache.json`` the
-  apptainer runtime already binds (see :mod:`_account.quota_cache`).
-  This is a cheap, *cache-only* read — NO live Claude API call, so it
-  never burns account quota at boot. The ``preferred`` account is kept
-  when it is fresh and not near-capped (< 90% 7d), to minimise churn;
-  otherwise the fresh candidate with the lowest 7d% wins. Accounts at
-  or above ~90% 7d are avoided *unless* nothing else is fresh
-  (headroom is a preference, not a hard gate). Cap-induced 429s still
-  surface from claude in-turn (runtime failover is Phase 2); the
-  picker only steers away from *known-stale* auth and *known-capped*
-  accounts at boot.
+* Account-pool Phase 2 — *quota-conditional* pick with fleet
+  load-balancing: per-account 5h and 7d utilisation are read from the
+  cached ``quota-cache.json`` the apptainer runtime already binds (see
+  :mod:`_account.quota_cache`) — a cheap, *cache-only* read, NO live
+  Claude API call, so it never burns account quota at boot. The two
+  axes carry different rules (see :mod:`._quota_rank`): an account at
+  ≥ ~95% of its **5h** window is *blocked-now* (429s immediately) and
+  is avoided while any fresh alternative is unblocked; an account at
+  ≥ ~90% **7d** is *near-capped* (the existing avoidance). The
+  ``preferred`` account is kept only when it is fresh AND not
+  blocked-now AND not near-capped, to minimise churn. Otherwise the
+  best tier of fresh candidates competes: with a ``spread_key`` (the
+  agent name) the winner is chosen by 7d-headroom-weighted rendezvous
+  hashing so a bulk fleet restart SPREADS agents across healthy
+  accounts instead of stacking them all onto one; without a spread key
+  the lowest-7d% candidate wins (legacy order). Both thresholds are
+  preferences, not hard gates — a boot is only ever blocked on
+  freshness. Cap-induced 429s still surface from claude in-turn
+  (runtime failover is a later phase).
 * GRACEFUL DEGRADATION: the quota cache is best-effort. When it is
   absent / stale / unreadable for an account (or entirely — e.g. a
   host whose cron has not populated it yet), that account degrades to
@@ -60,8 +66,14 @@ from pathlib import Path
 from typing import Mapping
 
 from .._account.creds_sync import _read_oauth_expiry_seconds
-from .._account.quota_cache import read_quota_entry
 from .._state.account_store import _store_path
+from ._quota_rank import (
+    BLOCKED_5H_PCT,
+    NEAR_CAP_7D_PCT,
+    account_5h_usage,
+    account_7d_usage,
+    pick_ranked,
+)
 
 # Health states for one account's snapshot. Mirrors
 # :class:`_account.creds_sync.Freshness` but anchored on a *name* so the
@@ -70,15 +82,10 @@ _VALID = "VALID"
 _EXPIRED = "EXPIRED"
 _ABSENT = "ABSENT"
 
-# Account-pool Phase 1: 7d-utilisation threshold above which an account
-# is treated as "near-capped — avoid unless no fresh alternative". The
-# incident that drove this (2026-07): 2/3 accounts sat at 96-99% weekly
-# cap while a 3rd had ~12% headroom, yet agents kept booting onto the
-# capped ones. 90% leaves a working margin before the hard weekly wall.
-# Headroom is a *preference*, not a hard gate — see
-# :func:`pick_healthy_account` (an all-near-capped fleet still boots on
-# the least-used fresh account rather than failing).
-_NEAR_CAP_PCT = 90.0
+# Thresholds live in ._quota_rank (shared with the ranking); the local
+# aliases keep this module's public parameter defaults stable.
+_NEAR_CAP_PCT = NEAR_CAP_7D_PCT
+_BLOCKED_5H_PCT = BLOCKED_5H_PCT
 
 
 class NoHealthyAccountError(RuntimeError):
@@ -190,93 +197,6 @@ def _format_states(healths: list[AccountHealth]) -> str:
     return ", ".join(parts) if parts else "(no candidates)"
 
 
-def _coerce_pct(value: object) -> float | None:
-    """Return *value* as a float utilisation %, or ``None`` if not numeric.
-
-    ``bool`` is explicitly rejected (a ``bool`` is an ``int`` in Python)
-    so ``True`` never surfaces as ``1.0%`` — mirrors
-    :func:`_account.quota_cache._is_number`.
-    """
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return None
-    return float(value)
-
-
-def account_7d_usage(
-    name: str,
-    *,
-    usage_7d: Mapping[str, float] | None = None,
-    quota_cache_path: Path | str | None = None,
-) -> float | None:
-    """Return one account's cached 7d utilisation %, or ``None``.
-
-    Reads the ``d7`` field of the account's entry in the bound
-    ``quota-cache.json`` via :func:`_account.quota_cache.read_quota_entry`
-    (which never raises — a missing / stale / unreadable cache, or no
-    matching entry, all collapse to ``None``). ``None`` is the caller's
-    signal to degrade to freshness-only for *that* account.
-
-    Parameters
-    ----------
-    name
-        The stored-account dirname (e.g. ``ywatanabe-scitex-ai``). The
-        cache is keyed on the first dash-segment, so the dirname resolves
-        the same entry the a2a-metadata path uses.
-    usage_7d
-        Test-injectable override: a mapping of account-name → 7d %.
-        When provided, it is consulted INSTEAD of the on-disk cache (a
-        missing key reads as ``None`` — degrade for that account). This
-        mirrors the module's ``store_dir`` / ``home`` / ``now`` override
-        idiom so tests need no real ``quota-cache.json`` and no network.
-    quota_cache_path
-        Override the cache file path passed to
-        :func:`read_quota_entry`. Ignored when ``usage_7d`` is given.
-    """
-    if usage_7d is not None:
-        return _coerce_pct(usage_7d.get(name))
-    entry = read_quota_entry(account=name, cache_path=quota_cache_path)
-    if entry is None:
-        return None
-    return _coerce_pct(entry.get("d7"))
-
-
-def _pick_most_headroom(
-    fresh: list[AccountHealth],
-    usage: dict[str, float | None],
-) -> str:
-    """Return the fresh account name with the MOST 7d headroom.
-
-    ``fresh`` is the token-fresh shortlist in candidate order (already
-    filtered to :attr:`AccountHealth.is_healthy`); ``usage`` maps each
-    name to its 7d % or ``None`` (unknown).
-
-    Rule (graceful degradation):
-
-    * Among fresh accounts whose 7d % is *known*, pick the LOWEST
-      (most headroom); ties break by candidate order — deterministic so
-      two simultaneous boots agree.
-    * If NO fresh account has a known usage (cache absent / empty for
-      the whole fleet), fall back to the legacy freshness-only behavior:
-      the first fresh account in candidate order.
-
-    Accounts with unknown usage therefore never displace a known-headroom
-    account, and never crash the pick — they simply degrade to
-    freshness-only ordering. Headroom is a *preference*: even when every
-    known account is near-capped, this returns the least-used fresh one
-    (never raises here — the fail-loud path is "nothing fresh", handled
-    by the caller).
-    """
-    known = [
-        (usage[h.name], idx, h.name)
-        for idx, h in enumerate(fresh)
-        if usage.get(h.name) is not None
-    ]
-    if known:
-        known.sort()
-        return known[0][2]
-    return fresh[0].name
-
-
 def pick_healthy_account(
     preferred: str | None,
     *,
@@ -284,37 +204,43 @@ def pick_healthy_account(
     store_dir: Path | None = None,
     home: Path | None = None,
     now: float | None = None,
+    usage_5h: Mapping[str, float] | None = None,
     usage_7d: Mapping[str, float] | None = None,
     quota_cache_path: Path | str | None = None,
     near_cap_pct: float = _NEAR_CAP_PCT,
+    blocked_5h_pct: float = _BLOCKED_5H_PCT,
+    spread_key: str | None = None,
 ) -> str:
     """Return the stored-account name an agent should run on right now.
 
-    Preference order (account-pool Phase 1 — quota-aware)
-    -----------------------------------------------------
+    Preference order (account-pool Phase 2 — quota-conditional)
+    -----------------------------------------------------------
     1. ``preferred`` (typically ``spec.claude.account``) when its
        snapshot is :attr:`AccountHealth.is_healthy` AND it is NOT
-       near-capped — i.e. its cached 7d utilisation is below
-       ``near_cap_pct``, OR is unknown (cache absent/stale for it, so we
-       degrade to freshness-only and keep it). This minimises churn.
-    2. Otherwise, the token-fresh candidate with the MOST 7d headroom
-       (lowest cached 7d %). Accounts with an unknown 7d % degrade to
-       freshness-only ordering (candidate order) and never displace a
-       known-headroom account. Ties break by candidate order (when
-       ``candidates`` is explicit) or alphabetically (auto-discovered)
-       — deterministic so two simultaneous starts pick the same account.
+       blocked-now (cached 5h utilisation below ``blocked_5h_pct``, or
+       unknown) AND it is NOT near-capped (cached 7d utilisation below
+       ``near_cap_pct``, or unknown). Unknown quota degrades to
+       freshness-only and keeps the preferred — this minimises churn;
+       we only rotate off ``preferred`` on *known* bad quota.
+    2. Otherwise, the best tier of token-fresh candidates competes —
+       see :func:`._quota_rank.pick_ranked`: unblocked-now beats
+       5h-blocked, 7d-headroom beats near-capped, known 7d beats
+       unknown. Within the winning tier, a ``spread_key`` selects by
+       7d-headroom-weighted rendezvous hashing (per-agent deterministic
+       fleet spread); without one the lowest 7d % wins (ties: lowest
+       5h %, then candidate order).
 
-    Headroom is a *preference*, not a hard gate: when every fresh
-    candidate is near-capped, the least-used fresh one is still returned
-    (a boot is never blocked on quota — only on there being NOTHING
-    token-fresh, which stays fail-loud).
+    Quota is a *preference*, not a hard gate: when every fresh
+    candidate is blocked or near-capped, the least-bad fresh one is
+    still returned (a boot is never blocked on quota — only on there
+    being NOTHING token-fresh, which stays fail-loud).
 
     Parameters
     ----------
     preferred
         The agent's pinned account (``spec.claude.account``). ``None``
         / empty means "no preference" — the picker hands back the
-        highest-headroom fresh candidate instead of raising.
+        ranked winner instead of raising.
     candidates
         Optional explicit candidate shortlist. ``None`` (default) walks
         every stored account directory on disk. An EMPTY list is
@@ -325,19 +251,32 @@ def pick_healthy_account(
         cascade (see :func:`_account.account_store._store_path`);
         ``home=None`` uses ``Path.home()``; ``now=None`` uses
         ``time.time()``.
-    usage_7d
-        Test-injectable per-account 7d utilisation % (name → pct). When
-        ``None`` (default, the boot path), each candidate's 7d % is read
-        from the bound ``quota-cache.json`` via
-        :func:`account_7d_usage`. A missing key / missing cache reads as
-        "unknown" → freshness-only degradation for that account.
+    usage_5h, usage_7d
+        Test-injectable per-account utilisation % (name → pct). When
+        ``None`` (default, the boot path), each candidate's 5h/7d % is
+        read from the bound ``quota-cache.json`` via
+        :func:`._quota_rank.account_5h_usage` /
+        :func:`._quota_rank.account_7d_usage`. A missing key / missing
+        cache reads as "unknown" → per-account degradation.
     quota_cache_path
         Override the quota-cache path (passed through to
-        :func:`read_quota_entry`). Ignored when ``usage_7d`` is given.
+        :func:`_account.quota_cache.read_quota_entry`). Ignored when
+        the corresponding ``usage_*`` override is given.
     near_cap_pct
         The 7d % at/above which an account is "near-capped — avoid
-        unless no fresh alternative". Defaults to :data:`_NEAR_CAP_PCT`
-        (90). Exposed for tests.
+        unless no better fresh alternative". Defaults to
+        :data:`._quota_rank.NEAR_CAP_7D_PCT` (90). Exposed for tests.
+    blocked_5h_pct
+        The 5h % at/above which an account is "blocked-now — cannot
+        serve requests until its 5h window resets". Defaults to
+        :data:`._quota_rank.BLOCKED_5H_PCT` (95). Exposed for tests.
+    spread_key
+        Fleet load-balancing key — pass the AGENT NAME so concurrent
+        boots of *different* agents spread across the eligible accounts
+        (weighted by 7d headroom) instead of all computing the same
+        "best" one. ``None`` / empty keeps the legacy single-winner
+        ordering. The same key always maps to the same account while
+        quota tiers are unchanged (no churn across restarts).
 
     Returns
     -------
@@ -350,7 +289,8 @@ def pick_healthy_account(
         When no candidate is :attr:`AccountHealth.is_healthy`. The
         message names every candidate's state. NEVER falls back to
         a stale snapshot, and NEVER raised merely because accounts are
-        near-capped (quota is a preference, freshness is the gate).
+        blocked/near-capped (quota is a preference, freshness is the
+        gate).
     """
     _home = home if home is not None else Path.home()
 
@@ -390,36 +330,55 @@ def pick_healthy_account(
             "them, then `sac accounts sync-live`, then restart the agent."
         )
 
-    # Per-account 7d utilisation for the fresh shortlist. Best-effort:
-    # an unknown value (cache absent/stale) degrades to freshness-only
-    # for that account (never blocks a boot).
-    usage: dict[str, float | None] = {
+    # Per-account 5h + 7d utilisation for the fresh shortlist. Best-
+    # effort: an unknown value (cache absent/stale) degrades per account
+    # (never blocks a boot).
+    u5: dict[str, float | None] = {
+        h.name: account_5h_usage(
+            h.name, usage_5h=usage_5h, quota_cache_path=quota_cache_path
+        )
+        for h in fresh
+    }
+    u7: dict[str, float | None] = {
         h.name: account_7d_usage(
             h.name, usage_7d=usage_7d, quota_cache_path=quota_cache_path
         )
         for h in fresh
     }
 
-    # 1. Preferred wins when it is fresh AND has headroom (or its usage
-    #    is unknown → degrade to freshness-only, keep it). Minimises
-    #    churn: only rotate off `preferred` when we KNOW it is near-capped.
+    # 1. Preferred wins when it is fresh AND not blocked-now (5h) AND
+    #    not near-capped (7d); unknown quota keeps it (degrade to
+    #    freshness-only). Minimises churn: only rotate off `preferred`
+    #    on KNOWN bad quota.
     if pref:
         h = by_name.get(pref)
         if h is not None and h.is_healthy:
-            pref_usage = usage.get(pref)
-            if pref_usage is None or pref_usage < near_cap_pct:
+            pref_5h = u5.get(pref)
+            pref_7d = u7.get(pref)
+            blocked_now = pref_5h is not None and pref_5h >= blocked_5h_pct
+            near_capped = pref_7d is not None and pref_7d >= near_cap_pct
+            if not blocked_now and not near_capped:
                 return pref
 
-    # 2. Otherwise pick the fresh candidate with the most 7d headroom
-    #    (lowest known usage), degrading to freshness-only order when the
-    #    cache is unavailable. Headroom is a preference, not a hard gate:
-    #    an all-near-capped fleet still returns the least-used fresh one.
-    return _pick_most_headroom(fresh, usage)
+    # 2. Otherwise the conditional ranking picks among the fresh set —
+    #    unblocked beats 5h-blocked, headroom beats near-capped, and a
+    #    spread_key load-balances the winning tier across the fleet.
+    #    Quota is a preference, not a hard gate: an all-blocked fleet
+    #    still returns the least-bad fresh account.
+    return pick_ranked(
+        [h.name for h in fresh],
+        u5,
+        u7,
+        spread_key=spread_key,
+        near_cap_pct=near_cap_pct,
+        blocked_5h_pct=blocked_5h_pct,
+    )
 
 
 __all__ = [
     "AccountHealth",
     "NoHealthyAccountError",
+    "account_5h_usage",
     "account_7d_usage",
     "account_health",
     "pick_healthy_account",

--- a/src/scitex_agent_container/_creds/_quota_rank.py
+++ b/src/scitex_agent_container/_creds/_quota_rank.py
@@ -1,0 +1,216 @@
+"""Quota-conditional ranking + fleet load-balancing for the account picker.
+
+Split out of :mod:`._pick_healthy` (512-line module limit). This module
+owns the QUOTA side of the pick — reading per-account 5h/7d utilisation
+from the cached ``quota-cache.json`` and turning it into a *conditional*
+ranking — while ``_pick_healthy`` keeps the freshness gate and the
+public :func:`~._pick_healthy.pick_healthy_account` entry point.
+
+Why conditional (2026-07 incident, ``sac-restart --all-running``)
+-----------------------------------------------------------------
+The Phase-1 pick ordered fresh accounts by a single scalar — 7d % —
+and kept the ``preferred`` entry whenever it was below the 7d near-cap.
+Two failure modes followed on the same restart:
+
+* an account at **100% of its 5h window** (cannot run *now*, resets in
+  hours) was selected because its 7d % looked fine (60% < 90%);
+* every agent in the fleet computed the same deterministic answer, so
+  a bulk restart stacked ALL agents onto that one account while two
+  accounts with 0% 5h sat idle.
+
+The two quota axes mean different things and need different rules:
+
+* **5h % ("can it run NOW")** — an account at/above
+  :data:`BLOCKED_5H_PCT` is *blocked-now*: it 429s immediately and
+  recovers within ≤5h. Never pick it while any fresh alternative is
+  unblocked; never keep a blocked-now ``preferred``.
+* **7d % ("sustained budget")** — the existing
+  :data:`NEAR_CAP_7D_PCT` avoidance, plus a *weight* for spreading:
+  more weekly headroom → proportionally more of the fleet.
+
+Ranking (lexicographic tiers, then in-tier choice)
+--------------------------------------------------
+Fresh candidates are partitioned by ``(blocked_now, near_capped_7d,
+d7_unknown)`` and only the best non-empty tier competes. Unknown values
+degrade per account (an absent/stale cache never blocks a boot): an
+unknown 5h % reads as "not blocked", an unknown 7d % sorts behind every
+known one (known headroom is never displaced by a guess).
+
+Within the winning tier:
+
+* with a ``spread_key`` (the agent name) — **weighted rendezvous
+  hashing**: score every account by a stable per-(agent, account) hash
+  scaled by its 7d headroom and take the max. Deterministic for a given
+  agent (same pick on every restart while quota tiers are unchanged →
+  no churn), but *different* agents land on *different* accounts in
+  proportion to headroom — the load-balancing the incident demanded.
+  ``hashlib`` (not ``hash()``) so the mapping survives interpreter
+  restarts and PYTHONHASHSEED.
+* without a ``spread_key`` — the legacy deterministic order: lowest
+  7d %, then lowest 5h %, then candidate order.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from pathlib import Path
+from typing import Mapping
+
+from .._account.quota_cache import read_quota_entry
+
+# 7d-utilisation threshold above which an account is "near-capped —
+# avoid unless no better fresh alternative". See _pick_healthy's module
+# docstring for the incident history. A preference, never a hard gate.
+NEAR_CAP_7D_PCT = 90.0
+
+# 5h-utilisation threshold at/above which an account is "blocked-now":
+# it cannot serve requests immediately (429 until the 5h window
+# resets). 95 rather than 100 because the cache is cron-refreshed and
+# lags live usage by minutes — an account reading 95%+ is realistically
+# at the wall by boot time. Also a preference (an all-blocked fleet
+# still boots on the least-bad account), never a hard gate.
+BLOCKED_5H_PCT = 95.0
+
+
+def _coerce_pct(value: object) -> float | None:
+    """Return *value* as a float utilisation %, or ``None`` if not numeric.
+
+    ``bool`` is explicitly rejected (a ``bool`` is an ``int`` in Python)
+    so ``True`` never surfaces as ``1.0%`` — mirrors
+    :func:`_account.quota_cache._is_number`.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _account_usage_pct(
+    name: str,
+    field: str,
+    *,
+    override: Mapping[str, float] | None = None,
+    quota_cache_path: Path | str | None = None,
+) -> float | None:
+    """Return one account's cached utilisation % for *field*, or ``None``.
+
+    ``field`` is the quota-cache entry key (``"h5"`` / ``"d7"``). Reads
+    via :func:`_account.quota_cache.read_quota_entry` (never raises — a
+    missing / stale / unreadable cache, or no matching entry, all
+    collapse to ``None``). ``None`` is the caller's signal to degrade
+    for *that* account.
+
+    ``override`` is the test-injection seam: a name → pct mapping
+    consulted INSTEAD of the on-disk cache (a missing key reads as
+    ``None``). Mirrors the ``store_dir`` / ``home`` / ``now`` idiom in
+    ``_pick_healthy`` so tests need no real ``quota-cache.json``.
+    """
+    if override is not None:
+        return _coerce_pct(override.get(name))
+    entry = read_quota_entry(account=name, cache_path=quota_cache_path)
+    if entry is None:
+        return None
+    return _coerce_pct(entry.get(field))
+
+
+def account_5h_usage(
+    name: str,
+    *,
+    usage_5h: Mapping[str, float] | None = None,
+    quota_cache_path: Path | str | None = None,
+) -> float | None:
+    """One account's cached 5h utilisation % (``h5``), or ``None``."""
+    return _account_usage_pct(
+        name, "h5", override=usage_5h, quota_cache_path=quota_cache_path
+    )
+
+
+def account_7d_usage(
+    name: str,
+    *,
+    usage_7d: Mapping[str, float] | None = None,
+    quota_cache_path: Path | str | None = None,
+) -> float | None:
+    """One account's cached 7d utilisation % (``d7``), or ``None``."""
+    return _account_usage_pct(
+        name, "d7", override=usage_7d, quota_cache_path=quota_cache_path
+    )
+
+
+def _hrw_score(spread_key: str, name: str, weight: float) -> float:
+    """Weighted rendezvous (HRW) score for one (agent, account) pair.
+
+    Standard weighted-HRW: map the pair to a uniform ``u ∈ (0, 1)`` via
+    a stable hash, score ``-weight / ln(u)``; the caller takes the max.
+    Properties this buys: per-agent deterministic (no churn across
+    restarts), fleet-wide spread proportional to ``weight``, and
+    minimal reshuffling when an account enters/leaves the eligible tier
+    (only that account's agents move).
+    """
+    digest = hashlib.sha256(f"{spread_key}\x00{name}".encode("utf-8")).digest()
+    u = (int.from_bytes(digest[:8], "big") + 0.5) / 2.0**64
+    return -weight / math.log(u)
+
+
+def pick_ranked(
+    names: list[str],
+    usage_5h: Mapping[str, float | None],
+    usage_7d: Mapping[str, float | None],
+    *,
+    spread_key: str | None = None,
+    near_cap_pct: float = NEAR_CAP_7D_PCT,
+    blocked_5h_pct: float = BLOCKED_5H_PCT,
+) -> str:
+    """Return the best account among *names* (all token-fresh, non-empty).
+
+    ``usage_5h`` / ``usage_7d`` map each name to its cached utilisation
+    % or ``None`` (unknown). See the module docstring for the tier
+    rules; this never raises on quota state (fail-loud for "nothing
+    fresh" lives in the caller).
+    """
+
+    def tier(name: str) -> tuple[bool, bool, bool]:
+        h5 = usage_5h.get(name)
+        d7 = usage_7d.get(name)
+        blocked_now = h5 is not None and h5 >= blocked_5h_pct
+        near_capped = d7 is not None and d7 >= near_cap_pct
+        return (blocked_now, near_capped, d7 is None)
+
+    best = min(tier(n) for n in names)
+    group = [n for n in names if tier(n) == best]
+    if len(group) == 1:
+        return group[0]
+
+    if spread_key:
+
+        def weight(name: str) -> float:
+            d7 = usage_7d.get(name)
+            if d7 is None:
+                return 1.0
+            return max(1.0, 100.0 - d7)
+
+        return max(group, key=lambda n: _hrw_score(spread_key, n, weight(n)))
+
+    # Legacy deterministic order (no spread requested): most 7d headroom,
+    # then most 5h headroom, then candidate order. Unknowns sort last via
+    # +inf so a known value always wins inside the tie-break.
+    def sort_key(item: tuple[int, str]) -> tuple[float, float, int]:
+        idx, name = item
+        d7 = usage_7d.get(name)
+        h5 = usage_5h.get(name)
+        return (
+            d7 if d7 is not None else math.inf,
+            h5 if h5 is not None else math.inf,
+            idx,
+        )
+
+    return min(enumerate(group), key=lambda it: sort_key(it))[1]
+
+
+__all__ = [
+    "BLOCKED_5H_PCT",
+    "NEAR_CAP_7D_PCT",
+    "account_5h_usage",
+    "account_7d_usage",
+    "pick_ranked",
+]

--- a/src/scitex_agent_container/_lifecycle/_start_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_start_preflight.py
@@ -105,6 +105,7 @@ def _rotate_among_credentials_files(
     *,
     log_stream: Any = None,
     now: float | None = None,
+    usage_5h: Mapping[str, float] | None = None,
     usage_7d: Mapping[str, float] | None = None,
     quota_cache_path: Path | str | None = None,
 ) -> None:
@@ -114,13 +115,25 @@ def _rotate_among_credentials_files(
     the singular ``spec.claude.credentials_file`` treated as a 1-element
     pool). Each entry's account SLUG is its parent-dir name. We hand the
     slug list to :func:`_creds.pick_healthy_account` so the SAME
-    quota-aware pick used for named accounts (PR #583 — prefer the
-    token-fresh account with the most 7d weekly-cap headroom) chooses
-    among exactly the listed accounts, then collapse the pool down to the
-    picked entry by writing it into ``config.claude.credentials_file`` —
-    the field every downstream auth path (``runtimes._apptainer_auth.
-    auth_argv`` / ``credentials_file_bind``) already resolves. Downstream
-    binding is therefore UNCHANGED; this only decides WHICH file it binds.
+    quota-conditional pick used for named accounts chooses among exactly
+    the listed accounts — token freshness as the hard gate, then avoid
+    5h-blocked and 7d-near-capped accounts, then LOAD-BALANCE the
+    winning tier across the fleet (``spread_key=config.name`` →
+    7d-headroom-weighted rendezvous hash, so a bulk restart spreads
+    agents over the healthy accounts instead of stacking them all onto
+    one; see :mod:`_creds._quota_rank`). The pool is then collapsed down
+    to the picked entry by writing it into
+    ``config.claude.credentials_file`` — the field every downstream auth
+    path (``runtimes._apptainer_auth.auth_argv`` /
+    ``credentials_file_bind``) already resolves. Downstream binding is
+    therefore UNCHANGED; this only decides WHICH file it binds.
+
+    ``preferred`` (churn minimisation) is ONLY a genuine pin: the spec's
+    ``claude.account`` when it is one of the listed slugs, else the slug
+    of the currently-effective ``credentials_file`` when it is listed.
+    The first listed entry is deliberately NOT treated as preferred —
+    that made every fleet agent "prefer" the same account and defeated
+    the spread (2026-07 ``sac-restart --all-running`` incident).
 
     Health probing reads each slug's snapshot from the pool's common
     parent-of-parent directory (``store_dir``) so the freshness/quota
@@ -153,33 +166,52 @@ def _rotate_among_credentials_files(
     )
 
     claude = config.claude
-    # Preferred = the currently-effective account when it is one of the
-    # listed slugs (minimise churn); else the first listed entry.
+    # Preferred = a GENUINE pin only: the spec's named account when it is
+    # one of the listed slugs, else the currently-effective
+    # credentials_file's slug when it is listed. NOT the first listed
+    # entry — see the docstring (fleet-stacking incident).
     account = str(getattr(claude, "account", "") or "").strip()
-    preferred = account if account in slugs else slugs[0]
+    prior = str(getattr(claude, "credentials_file", "") or "").strip()
+    prior_slug = _slug_of_credentials_file(Path(prior)) if prior else ""
+    if account in slugs:
+        preferred: str | None = account
+    elif prior_slug in slugs:
+        preferred = prior_slug
+    else:
+        preferred = None
 
     picked = pick_healthy_account(
         preferred,
         candidates=slugs,
         store_dir=store_dir,
         now=now,
+        usage_5h=usage_5h,
         usage_7d=usage_7d,
         quota_cache_path=quota_cache_path,
+        spread_key=config.name,
     )
 
     picked_path = next(p for slug, p in entries if slug == picked)
-    prior = str(getattr(claude, "credentials_file", "") or "").strip()
     claude.credentials_file = str(picked_path)
 
     if str(picked_path) == prior:
         return  # 1-element / already-selected pool — no change, no log.
 
+    from .._creds import account_5h_usage, account_7d_usage
+
+    h5 = account_5h_usage(picked, usage_5h=usage_5h, quota_cache_path=quota_cache_path)
+    d7 = account_7d_usage(picked, usage_7d=usage_7d, quota_cache_path=quota_cache_path)
+
+    def fmt(v: float | None) -> str:
+        return "?" if v is None else f"{v:.0f}%"
+
     stream = log_stream if log_stream is not None else sys.stderr
     print(
         f"[sac:creds] agent '{config.name}' selected credentials_files pool "
         f"entry: account {picked!r} ({picked_path}) among {len(slugs)} listed "
-        f"credentials_files (quota-aware pick — token-fresh account with the "
-        f"most 7d headroom)",
+        f"credentials_files (quota-conditional pick — token-fresh, avoids "
+        f"5h-blocked and 7d-near-capped accounts, load-balanced per agent; "
+        f"picked usage 5h={fmt(h5)} 7d={fmt(d7)})",
         file=stream,
     )
 
@@ -189,6 +221,7 @@ def _rotate_to_healthy_account(
     *,
     log_stream: Any = None,
     now: float | None = None,
+    usage_5h: Mapping[str, float] | None = None,
     usage_7d: Mapping[str, float] | None = None,
     quota_cache_path: Path | str | None = None,
 ) -> None:
@@ -208,19 +241,21 @@ def _rotate_to_healthy_account(
        pinned fleet agents — previously such agents bypassed the pick
        entirely (this function returned early on empty ``account``).
 
-    2. **Named account** — ``spec.claude.account`` non-empty. Existing
-       behaviour, unchanged: keep the pinned account when its snapshot is
-       healthy; rotate ``config.claude.account`` to the fresh account with
-       the most 7d headroom otherwise. For an unpinned agent (no pool, no
-       account) the runtime continues to bind the host's live
-       ``.credentials.json`` untouched.
+    2. **Named account** — ``spec.claude.account`` non-empty. Keep the
+       pinned account when its snapshot is healthy AND its quota is not
+       known-bad (5h-blocked / 7d-near-capped); otherwise rotate
+       ``config.claude.account`` to the ranked fresh account
+       (load-balanced per agent — ``spread_key=config.name``). For an
+       unpinned agent (no pool, no account) the runtime continues to
+       bind the host's live ``.credentials.json`` untouched.
 
     In every case a total absence of a usable (non-expired) snapshot
     raises :class:`_creds.NoHealthyAccountError` (fail loud, no silent
     stale-token launch). See :mod:`scitex_agent_container._creds.
-    _pick_healthy` for the health model. The ``now`` / ``usage_7d`` /
-    ``quota_cache_path`` params are the same test-injection seams
-    ``pick_healthy_account`` exposes; production passes ``None``.
+    _pick_healthy` for the health model. The ``now`` / ``usage_5h`` /
+    ``usage_7d`` / ``quota_cache_path`` params are the same
+    test-injection seams ``pick_healthy_account`` exposes; production
+    passes ``None``.
     """
     claude = getattr(config, "claude", None)
 
@@ -234,12 +269,13 @@ def _rotate_to_healthy_account(
             pool,
             log_stream=log_stream,
             now=now,
+            usage_5h=usage_5h,
             usage_7d=usage_7d,
             quota_cache_path=quota_cache_path,
         )
         return
 
-    # 2. Named account (legacy CREDS-PHASE1 path — unchanged).
+    # 2. Named account (legacy CREDS-PHASE1 path).
     pinned = getattr(claude, "account", "") or ""
     if not pinned:
         return  # unpinned agent — host live OAuth, untouched.
@@ -247,7 +283,12 @@ def _rotate_to_healthy_account(
     from .._creds import pick_healthy_account
 
     picked = pick_healthy_account(
-        pinned, now=now, usage_7d=usage_7d, quota_cache_path=quota_cache_path
+        pinned,
+        now=now,
+        usage_5h=usage_5h,
+        usage_7d=usage_7d,
+        quota_cache_path=quota_cache_path,
+        spread_key=config.name,
     )
     if picked == pinned:
         return  # pinned is healthy — no rotation, no log line.
@@ -256,9 +297,9 @@ def _rotate_to_healthy_account(
     stream = log_stream if log_stream is not None else sys.stderr
     print(
         f"[sac:creds] agent '{config.name}' rotated account: "
-        f"{pinned!r} -> {picked!r} (pinned account unhealthy or "
-        f"near weekly cap; rotated to the fresh account with the most "
-        f"7d headroom)",
+        f"{pinned!r} -> {picked!r} (pinned account stale, 5h-blocked, or "
+        f"near its weekly cap; rotated to a fresh account with headroom, "
+        f"load-balanced per agent)",
         file=stream,
     )
 

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -9,11 +9,11 @@ from typing import Any, Dict
 # Phase-3 ACL dataclasses (kept in a sibling module under the per-file
 # line cap; re-exported here for the :class:`AgentConfig` field defaults).
 from ._acl_types import CommsSpec, LineageSpec  # noqa: E402,F401
-from ._provider_types import AgentProvider, DEFAULT_AGENT_PROVIDER, ProviderSpec
 
 # ApptainerSpec extracted to a sibling module (per-file line cap);
 # re-exported here so ``from ...config._types import ApptainerSpec`` resolves.
 from ._apptainer_spec import ApptainerSpec  # noqa: E402,F401
+from ._provider_types import DEFAULT_AGENT_PROVIDER, AgentProvider, ProviderSpec
 
 
 @dataclass
@@ -113,8 +113,9 @@ class ClaudeSpec:
     credentials_file: str = ""
     # Account POOL: a list of host paths to ``.credentials.json`` files
     # (one per saved account). When non-empty, the start pre-flight picks
-    # ONE of them QUOTA-AWARE — the token-fresh account with the most 7d
-    # weekly-cap headroom (see ``_creds.pick_healthy_account`` +
+    # ONE of them QUOTA-CONDITIONAL — token-fresh, avoiding 5h-blocked
+    # and 7d-near-capped accounts, load-balanced across the fleet per
+    # agent name (see ``_creds.pick_healthy_account`` +
     # ``_lifecycle._start_preflight._rotate_to_healthy_account``) — and
     # binds the PICKED file exactly as if it had been named in the singular
     # ``credentials_file`` field. Each entry's ACCOUNT SLUG is its parent

--- a/tests/scitex_agent_container/_creds/test__pick_healthy.py
+++ b/tests/scitex_agent_container/_creds/test__pick_healthy.py
@@ -446,3 +446,223 @@ def test_pick_ignores_quota_when_only_capped_account_is_fresh(
     )
     # Assert
     assert picked == "ywatanabe-scitex-ai"
+
+
+# ---------------------------------------------------------------------------
+# pick_healthy_account — account-pool Phase 2: the 5h axis ("blocked-now")
+#
+# 2026-07 incident: an account at 100% of its 5h window (429s immediately)
+# was picked because its 7d % looked fine. The 5h axis is injected via the
+# ``usage_5h`` override, mirroring ``usage_7d``.
+# ---------------------------------------------------------------------------
+
+
+def _write_three_fresh(home: Path) -> None:
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    _write_snapshot(home, "ywata1989-gmail-com", _future_ms())
+    _write_snapshot(home, "ywatanabe-scitex-ai", _future_ms())
+
+
+_THREE = ["wyusuuke-gmail-com", "ywata1989-gmail-com", "ywatanabe-scitex-ai"]
+
+
+def test_pick_rotates_off_preferred_at_5h_cap_despite_7d_headroom(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — the incident verbatim: preferred is token-fresh with 7d
+    # headroom (60% < 90%) but sits at 100% of its 5h window; two
+    # alternatives are idle. The preferred must be rotated off.
+    home = _isolate_home
+    _write_three_fresh(home)
+    # Act
+    picked = pick_healthy_account(
+        "wyusuuke-gmail-com",
+        candidates=_THREE,
+        home=home,
+        usage_5h={
+            "wyusuuke-gmail-com": 100.0,
+            "ywata1989-gmail-com": 0.0,
+            "ywatanabe-scitex-ai": 0.0,
+        },
+        usage_7d={
+            "wyusuuke-gmail-com": 60.0,
+            "ywata1989-gmail-com": 25.0,
+            "ywatanabe-scitex-ai": 2.0,
+        },
+    )
+    # Assert — no spread key → deterministic lowest-7d winner.
+    assert picked == "ywatanabe-scitex-ai"
+
+
+def test_pick_skips_5h_blocked_candidate_with_best_7d_headroom(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — no preference; the lowest-7d candidate is 5h-blocked, so
+    # the next-lowest UNBLOCKED one must win (blocked-now beats headroom).
+    home = _isolate_home
+    _write_three_fresh(home)
+    # Act
+    picked = pick_healthy_account(
+        None,
+        candidates=_THREE,
+        home=home,
+        usage_5h={
+            "wyusuuke-gmail-com": 0.0,
+            "ywata1989-gmail-com": 0.0,
+            "ywatanabe-scitex-ai": 97.0,
+        },
+        usage_7d={
+            "wyusuuke-gmail-com": 60.0,
+            "ywata1989-gmail-com": 25.0,
+            "ywatanabe-scitex-ai": 2.0,
+        },
+    )
+    # Assert
+    assert picked == "ywata1989-gmail-com"
+
+
+def test_pick_returns_least_weekly_used_when_every_account_5h_blocked(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — the whole fleet is at its 5h wall. Blocked-now is a
+    # preference, not a hard gate: the pick still returns (lowest 7d),
+    # never raises.
+    home = _isolate_home
+    _write_three_fresh(home)
+    # Act
+    picked = pick_healthy_account(
+        None,
+        candidates=_THREE,
+        home=home,
+        usage_5h={
+            "wyusuuke-gmail-com": 100.0,
+            "ywata1989-gmail-com": 96.0,
+            "ywatanabe-scitex-ai": 99.0,
+        },
+        usage_7d={
+            "wyusuuke-gmail-com": 60.0,
+            "ywata1989-gmail-com": 25.0,
+            "ywatanabe-scitex-ai": 2.0,
+        },
+    )
+    # Assert
+    assert picked == "ywatanabe-scitex-ai"
+
+
+def test_pick_keeps_preferred_when_its_5h_usage_unknown(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — preferred is fresh, 7d fine, and its 5h % is absent from
+    # the cache. Unknown quota degrades to freshness-only for that
+    # account: keep the preferred (only rotate on KNOWN bad quota).
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _future_ms())
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    # Act
+    picked = pick_healthy_account(
+        "ywatanabe-scitex-ai",
+        candidates=["ywatanabe-scitex-ai", "wyusuuke-gmail-com"],
+        home=home,
+        usage_5h={"wyusuuke-gmail-com": 0.0},  # preferred deliberately absent
+        usage_7d={"ywatanabe-scitex-ai": 40.0, "wyusuuke-gmail-com": 10.0},
+    )
+    # Assert
+    assert picked == "ywatanabe-scitex-ai"
+
+
+# ---------------------------------------------------------------------------
+# pick_healthy_account — fleet load-balancing via spread_key
+#
+# A bulk restart must not stack every agent onto the same "best" account:
+# with ``spread_key`` (the agent name) the winning tier is spread by
+# 7d-headroom-weighted rendezvous hashing — deterministic per agent,
+# different across agents.
+# ---------------------------------------------------------------------------
+
+
+def test_pick_with_spread_key_is_deterministic_per_agent(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — two eligible accounts; the same agent name must map to
+    # the same account on every boot (no churn across restarts).
+    home = _isolate_home
+    _write_three_fresh(home)
+
+    def _pick_once() -> str:
+        return pick_healthy_account(
+            None,
+            candidates=_THREE,
+            home=home,
+            usage_5h={n: 0.0 for n in _THREE},
+            usage_7d={
+                "wyusuuke-gmail-com": 95.0,
+                "ywata1989-gmail-com": 25.0,
+                "ywatanabe-scitex-ai": 2.0,
+            },
+            spread_key="claude-code-telegrammer",
+        )
+
+    # Act
+    first = _pick_once()
+    second = _pick_once()
+    # Assert
+    assert first == second
+
+
+def test_pick_spread_distributes_fleet_across_eligible_accounts(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — two accounts with comparable headroom; a 12-agent fleet
+    # must land on BOTH (the incident: all agents stacked onto one).
+    home = _isolate_home
+    _write_three_fresh(home)
+    usage_7d = {
+        "wyusuuke-gmail-com": 95.0,  # near-capped — out of the tier
+        "ywata1989-gmail-com": 25.0,
+        "ywatanabe-scitex-ai": 2.0,
+    }
+    # Act
+    picks = {
+        pick_healthy_account(
+            None,
+            candidates=_THREE,
+            home=home,
+            usage_5h={n: 0.0 for n in _THREE},
+            usage_7d=usage_7d,
+            spread_key=f"agent-{i}",
+        )
+        for i in range(12)
+    }
+    # Assert
+    assert picks == {"ywata1989-gmail-com", "ywatanabe-scitex-ai"}
+
+
+def test_pick_spread_never_selects_a_5h_blocked_account(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — one account is at its 5h wall; no agent in a 12-name
+    # fleet may land on it while unblocked alternatives exist.
+    home = _isolate_home
+    _write_three_fresh(home)
+    # Act
+    picks = [
+        pick_healthy_account(
+            None,
+            candidates=_THREE,
+            home=home,
+            usage_5h={
+                "wyusuuke-gmail-com": 100.0,
+                "ywata1989-gmail-com": 0.0,
+                "ywatanabe-scitex-ai": 0.0,
+            },
+            usage_7d={
+                "wyusuuke-gmail-com": 60.0,
+                "ywata1989-gmail-com": 25.0,
+                "ywatanabe-scitex-ai": 2.0,
+            },
+            spread_key=f"agent-{i}",
+        )
+        for i in range(12)
+    ]
+    # Assert
+    assert "wyusuuke-gmail-com" not in picks

--- a/tests/scitex_agent_container/_creds/test__quota_rank.py
+++ b/tests/scitex_agent_container/_creds/test__quota_rank.py
@@ -1,0 +1,180 @@
+"""Tests for ``_creds._quota_rank`` (conditional ranking + fleet spread).
+
+No mocks (PA-306): utilisation is injected through the documented
+``usage_5h`` / ``usage_7d`` override mappings and, for the cache-read
+helpers, a real JSON file under ``tmp_path``. AAA markers (TQ002),
+descriptive names (TQ003), one assertion per test (TQ007).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scitex_agent_container._creds._quota_rank import (
+    account_5h_usage,
+    account_7d_usage,
+    pick_ranked,
+)
+
+# ---------------------------------------------------------------------------
+# account_5h_usage / account_7d_usage — cache field readers
+# ---------------------------------------------------------------------------
+
+
+def _write_cache(tmp_path: Path) -> Path:
+    cache = tmp_path / "quota-cache.json"
+    cache.write_text(
+        json.dumps(
+            {
+                "written_at": 1.0,
+                "accounts": {
+                    "wyusuuke@gmail.com": {
+                        "short": "wyusuuke",
+                        "h5": 100.0,
+                        "d7": 60.0,
+                        "ttl_h": 7.9,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return cache
+
+
+def test_account_5h_usage_reads_h5_field_from_cache(tmp_path: Path) -> None:
+    # Arrange
+    cache = _write_cache(tmp_path)
+    # Act
+    pct = account_5h_usage("wyusuuke-gmail-com", quota_cache_path=cache)
+    # Assert
+    assert pct == 100.0
+
+
+def test_account_7d_usage_reads_d7_field_from_cache(tmp_path: Path) -> None:
+    # Arrange
+    cache = _write_cache(tmp_path)
+    # Act
+    pct = account_7d_usage("wyusuuke-gmail-com", quota_cache_path=cache)
+    # Assert
+    assert pct == 60.0
+
+
+def test_account_5h_usage_returns_none_when_cache_missing(tmp_path: Path) -> None:
+    # Arrange
+    missing = tmp_path / "no-such-cache.json"
+    # Act
+    pct = account_5h_usage("wyusuuke-gmail-com", quota_cache_path=missing)
+    # Assert
+    assert pct is None
+
+
+def test_account_5h_usage_override_bypasses_cache(tmp_path: Path) -> None:
+    # Arrange
+    cache = _write_cache(tmp_path)  # says 100 — override must win
+    # Act
+    pct = account_5h_usage(
+        "wyusuuke-gmail-com",
+        usage_5h={"wyusuuke-gmail-com": 3.0},
+        quota_cache_path=cache,
+    )
+    # Assert
+    assert pct == 3.0
+
+
+# ---------------------------------------------------------------------------
+# pick_ranked — conditional tiers
+# ---------------------------------------------------------------------------
+
+_ABC = ["acct-a", "acct-b", "acct-c"]
+
+
+def test_pick_ranked_prefers_unblocked_over_5h_blocked() -> None:
+    # Arrange — acct-a has the most 7d headroom but is at its 5h wall.
+    usage_5h = {"acct-a": 100.0, "acct-b": 0.0, "acct-c": 0.0}
+    usage_7d = {"acct-a": 2.0, "acct-b": 25.0, "acct-c": 60.0}
+    # Act
+    picked = pick_ranked(_ABC, usage_5h, usage_7d)
+    # Assert — blocked-now loses to any unblocked candidate.
+    assert picked == "acct-b"
+
+
+def test_pick_ranked_prefers_headroom_over_near_capped() -> None:
+    # Arrange — no 5h data at all (degrades to "not blocked").
+    usage_7d = {"acct-a": 95.0, "acct-b": 40.0, "acct-c": 91.0}
+    # Act
+    picked = pick_ranked(_ABC, {}, usage_7d)
+    # Assert
+    assert picked == "acct-b"
+
+
+def test_pick_ranked_known_7d_beats_unknown_within_a_tier() -> None:
+    # Arrange — acct-a has no cache entry; a known-headroom account is
+    # never displaced by a guess.
+    usage_7d = {"acct-b": 40.0}
+    # Act
+    picked = pick_ranked(["acct-a", "acct-b"], {}, usage_7d)
+    # Assert
+    assert picked == "acct-b"
+
+
+def test_pick_ranked_all_unknown_falls_back_to_candidate_order() -> None:
+    # Arrange — no quota data anywhere: legacy freshness-only order.
+    names = list(_ABC)
+    # Act
+    picked = pick_ranked(names, {}, {})
+    # Assert
+    assert picked == "acct-a"
+
+
+def test_pick_ranked_ties_on_7d_break_by_lower_5h() -> None:
+    # Arrange — equal 7d; the account with more 5h headroom wins.
+    usage_5h = {"acct-a": 80.0, "acct-b": 10.0}
+    usage_7d = {"acct-a": 30.0, "acct-b": 30.0}
+    # Act
+    picked = pick_ranked(["acct-a", "acct-b"], usage_5h, usage_7d)
+    # Assert
+    assert picked == "acct-b"
+
+
+# ---------------------------------------------------------------------------
+# pick_ranked — spread_key (weighted rendezvous hashing)
+# ---------------------------------------------------------------------------
+
+
+def test_pick_ranked_spread_is_stable_for_one_key() -> None:
+    # Arrange
+    usage_7d = {"acct-a": 25.0, "acct-b": 2.0}
+    # Act
+    picks = {
+        pick_ranked(["acct-a", "acct-b"], {}, usage_7d, spread_key="agent-x")
+        for _ in range(5)
+    }
+    # Assert — one key always maps to one account.
+    assert len(picks) == 1
+
+
+def test_pick_ranked_spread_covers_both_accounts_across_keys() -> None:
+    # Arrange
+    usage_7d = {"acct-a": 25.0, "acct-b": 2.0}
+    # Act
+    picks = {
+        pick_ranked(["acct-a", "acct-b"], {}, usage_7d, spread_key=f"agent-{i}")
+        for i in range(12)
+    }
+    # Assert — a fleet does not stack onto a single account.
+    assert picks == {"acct-a", "acct-b"}
+
+
+def test_pick_ranked_spread_weights_toward_more_7d_headroom() -> None:
+    # Arrange — acct-b has ~10x the weekly headroom of acct-a; over a
+    # large fleet it must serve the strict majority.
+    usage_7d = {"acct-a": 90.0, "acct-b": 2.0}
+    # Act
+    picks = [
+        pick_ranked(["acct-a", "acct-b"], {}, usage_7d, spread_key=f"agent-{i}")
+        for i in range(100)
+    ]
+    # Assert
+    assert picks.count("acct-b") > picks.count("acct-a")

--- a/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
@@ -76,9 +76,12 @@ def _make_pool_config(name: str, paths: list[Path]) -> AgentConfig:
 # ---------------------------------------------------------------------------
 
 
-def test_pool_picks_most_headroom_fresh_entry(_isolate_home: Path) -> None:
-    # Arrange — 3 fresh accounts; the FIRST (preferred) is near-capped so
-    # the pick must rotate off it to the lowest-7d fresh sibling.
+def test_pool_rotates_off_near_capped_entry_to_a_healthy_sibling(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — 3 fresh accounts; the first is near-capped so the pick
+    # must land on one of the two healthy siblings (WHICH one is the
+    # per-agent load-balancing hash's choice, so assert the set).
     home = _isolate_home
     p_a = _write_snapshot(home, "acct-a", _future_ms())
     p_b = _write_snapshot(home, "acct-b", _future_ms())
@@ -90,8 +93,8 @@ def test_pool_picks_most_headroom_fresh_entry(_isolate_home: Path) -> None:
         log_stream=io.StringIO(),
         usage_7d={"acct-a": 95.0, "acct-b": 10.0, "acct-c": 40.0},
     )
-    # Assert — acct-b has the most 7d headroom → its file is bound.
-    assert cfg.claude.credentials_file == str(p_b)
+    # Assert — the near-capped acct-a is avoided.
+    assert cfg.claude.credentials_file in {str(p_b), str(p_c)}
 
 
 def test_pool_selection_emits_a_one_line_notice(_isolate_home: Path) -> None:
@@ -195,3 +198,127 @@ def test_no_pool_no_pin_leaves_credentials_file_empty(_isolate_home: Path) -> No
     _rotate_to_healthy_account(cfg, log_stream=log)
     # Assert — host live OAuth path untouched.
     assert cfg.claude.credentials_file == "" and cfg.claude.account == ""
+
+
+# ---------------------------------------------------------------------------
+# 5h axis — a pool entry at its 5h wall cannot run NOW and must be avoided
+# (2026-07 `sac-restart --all-running` incident: 100%-5h account picked
+# because its 7d % looked fine).
+# ---------------------------------------------------------------------------
+
+
+def test_pool_avoids_entry_at_its_5h_cap_despite_7d_headroom(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — the first entry is fresh with 7d headroom but at 100% of
+    # its 5h window; the two others are idle.
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _future_ms())
+    p_b = _write_snapshot(home, "acct-b", _future_ms())
+    p_c = _write_snapshot(home, "acct-c", _future_ms())
+    cfg = _make_pool_config("alpha", [p_a, p_b, p_c])
+    # Act
+    _rotate_to_healthy_account(
+        cfg,
+        log_stream=io.StringIO(),
+        usage_5h={"acct-a": 100.0, "acct-b": 0.0, "acct-c": 0.0},
+        usage_7d={"acct-a": 60.0, "acct-b": 25.0, "acct-c": 2.0},
+    )
+    # Assert — the blocked-now entry is never bound while others are idle.
+    assert cfg.claude.credentials_file in {str(p_b), str(p_c)}
+
+
+def test_pool_still_boots_when_every_entry_is_5h_blocked(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — the whole pool is at its 5h wall. Quota is a preference:
+    # the boot must still bind SOME fresh entry rather than fail.
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _future_ms())
+    p_b = _write_snapshot(home, "acct-b", _future_ms())
+    cfg = _make_pool_config("alpha", [p_a, p_b])
+    # Act
+    _rotate_to_healthy_account(
+        cfg,
+        log_stream=io.StringIO(),
+        usage_5h={"acct-a": 100.0, "acct-b": 98.0},
+        usage_7d={"acct-a": 60.0, "acct-b": 25.0},
+    )
+    # Assert
+    assert cfg.claude.credentials_file in {str(p_a), str(p_b)}
+
+
+# ---------------------------------------------------------------------------
+# Fleet load-balancing — a bulk restart must SPREAD agents across the
+# healthy entries instead of stacking every agent onto the same one.
+# ---------------------------------------------------------------------------
+
+
+def test_pool_spreads_a_fleet_of_agents_across_healthy_entries(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — two healthy entries with comparable headroom and a
+    # 12-agent fleet listing the SAME pool (the incident shape).
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _future_ms())
+    p_b = _write_snapshot(home, "acct-b", _future_ms())
+    # Act
+    picks = set()
+    for i in range(12):
+        cfg = _make_pool_config(f"agent-{i}", [p_a, p_b])
+        _rotate_to_healthy_account(
+            cfg,
+            log_stream=io.StringIO(),
+            usage_5h={"acct-a": 0.0, "acct-b": 0.0},
+            usage_7d={"acct-a": 25.0, "acct-b": 2.0},
+        )
+        picks.add(cfg.claude.credentials_file)
+    # Assert — both accounts serve part of the fleet.
+    assert picks == {str(p_a), str(p_b)}
+
+
+def test_pool_keeps_currently_effective_entry_when_it_is_healthy(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — the agent's credentials_file already points at a listed,
+    # healthy, un-capped entry: churn minimisation must keep it even if
+    # a sibling has more headroom.
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _future_ms())
+    p_b = _write_snapshot(home, "acct-b", _future_ms())
+    cfg = _make_pool_config("alpha", [p_a, p_b])
+    cfg.claude.credentials_file = str(p_a)
+    # Act
+    _rotate_to_healthy_account(
+        cfg,
+        log_stream=io.StringIO(),
+        usage_5h={"acct-a": 10.0, "acct-b": 0.0},
+        usage_7d={"acct-a": 40.0, "acct-b": 2.0},
+    )
+    # Assert — no rotation off a healthy current entry.
+    assert cfg.claude.credentials_file == str(p_a)
+
+
+def test_pool_first_listed_entry_is_not_implicitly_preferred(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — no pin, no current file. Pre-fix, slugs[0] was treated as
+    # "preferred" and kept whenever below the 7d near-cap — which stacked
+    # every fleet agent onto the first listed account. With both entries
+    # equally idle, a 12-agent fleet must now spread instead.
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _future_ms())
+    p_b = _write_snapshot(home, "acct-b", _future_ms())
+    # Act
+    picks = set()
+    for i in range(12):
+        cfg = _make_pool_config(f"agent-{i}", [p_a, p_b])
+        _rotate_to_healthy_account(
+            cfg,
+            log_stream=io.StringIO(),
+            usage_5h={"acct-a": 0.0, "acct-b": 0.0},
+            usage_7d={"acct-a": 30.0, "acct-b": 30.0},
+        )
+        picks.add(cfg.claude.credentials_file)
+    # Assert
+    assert picks == {str(p_a), str(p_b)}


### PR DESCRIPTION
## Problem (2026-07 `sac-restart --all-running` incident)

Every agent in a bulk restart was bound to `wyusuuke-gmail-com` — an account at **100% of its 5h window** (429s immediately, `⚠ Limit reached (resets 2h 35m)` in-pane) — while two accounts at 0% 5h sat idle. Two compounding bugs:

1. **The pick only read the 7d axis.** The preferred-account keep-rule checked `d7 < 90%` only; 60% 7d looked fine, the 100% 5h was invisible.
2. **`slugs[0]` was implicitly 'preferred'.** Every fleet agent listing the same `credentials_files` pool computed the same winner, so the whole fleet stacked onto one account.

## Fix

New `_creds/_quota_rank.py` (conditional criteria, not a scalar sort):

- **Tiers** — token freshness stays the ONLY hard gate (fail-loud when nothing fresh). Then: not-5h-blocked (≥95% = blocked-now) beats blocked; not-7d-near-capped (≥90%) beats capped; known 7d beats unknown. Quota never blocks a boot — an all-blocked fleet still gets the least-bad fresh account.
- **Fleet load-balancing** — within the winning tier, `spread_key` (the agent name) picks by **7d-headroom-weighted rendezvous hashing**: deterministic per agent (no churn across restarts), but different agents spread across accounts proportionally to weekly headroom. Without a spread key: legacy lowest-7d order.
- **Preferred = genuine pin only** — the spec's `claude.account` or the currently-effective `credentials_file` when listed; never the first pool entry. Kept only when fresh AND not blocked-now AND not near-capped (unknown quota keeps it — rotate only on *known* bad quota).
- The `[sac:creds]` log line now states the real criteria and the picked account's 5h/7d usage (the old one claimed 'most 7d headroom' while doing the opposite).

## Verification

- 634 tests pass (`tests/.../_creds` + `tests/.../_lifecycle`), including new regression tests for the incident, 5h-blocked avoidance, all-blocked-still-boots, spread determinism/coverage, and `slugs[0]`-not-preferred.
- `scitex-dev ecosystem audit-all --severity error`: clean.
- Simulation with today's exact quota numbers (wyusuuke 100%/60%, ywata1989 0%/25%, ywatanabe 0%/2%) across 8 real agent names: wyusuuke never picked; fleet splits 5/3 between ywatanabe-scitex-ai and ywata1989 — weighted toward the account with more weekly headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)