### PR TITLE
refactor(accounts): dedupe `sac accounts list` — bars own percentages, table slims to Account|Status|Last Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **refactor(accounts): `sac accounts list` — dedupe table vs usage
+  bars** (operator directive 2026-07-11: "Stored accounts と Usage
+  bars で duplicated info を出すな / Usage bars で書けないものだけ
+  Stored Accounts に書け / ID <-> Email 対応は要らない；Plan も
+  いらない"). Presentation-layer only; the `--json` schema is
+  untouched (still carries `email_address`, `plan_label`, raw usage):
+  - Stored-accounts table is now exactly
+    `Account | Status | Last Update` — the Email column (IDs are
+    email-derived slugs), the Plan column and the 5h%/7d% columns
+    (which duplicated the bars and wrapped the table at normal
+    terminal widths) are gone. Status keeps the live token TTL
+    (`VALID +2h26m`).
+  - The usage-bars block owns the percentages AND gains the compact
+    per-window reset hints that used to clutter the table cells:
+    `5h [██████░░░░░░░░░░░░░░]  29% (→09:19)   7d [...]  66% (→Sun 21h)`.
+    Missing 5h hints are space-padded so the 7d bars stay vertically
+    aligned. The `(in Xh Ym)` countdown qualifier was dropped with
+    the table cells it annotated (the bars stay compact per the
+    operator's verbatim example).
+  - The rolling-window legend now prints below the bars (the surface
+    it explains); the fleet effective-utilization footer and the
+    single-account "Claude Code account" header block are unchanged.
+  - `account_group.py` extraction: the `list` command body moved to
+    `cli_pkg/_account_list_cmd.py` (`register_list_command`), the
+    same pattern as `_account_refresh.py`, keeping the group
+    orchestrator under the per-file line cap.
+
 ## [0.21.11] — 2026-06-09
 
 PATCH release. Re-cut of v0.21.10's accounts-list redesign after the

--- a/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
@@ -1,0 +1,163 @@
+"""``sac accounts list`` — the CLI command body.
+
+Split out of ``account_group.py`` to keep that orchestrator under the
+per-file line cap; the command is attached onto the ``account`` group at
+import time via :func:`register_list_command` (same pattern as
+``_account_refresh.register_refresh_command``).
+
+Human-output layout (operator directive 2026-07-11 — "the bars own the
+percentages; the table holds only what the bars cannot express"):
+
+1. The single-account "Claude Code account" header block (active
+   credentials; untouched by the 2026-07-11 redesign).
+2. The Stored-accounts table — exactly ``Account | Status | Last
+   Update`` (:func:`._account_list_render.render_stored_table`).
+3. The usage-bars block — per-account 5h/7d bars, each percentage
+   carrying its compact reset hint (``29% (→09:19)`` /
+   ``66% (→Sun 21h)``), plus the rolling-window legend when a row has
+   no cached reset timestamps
+   (:mod:`._account_usage_bars` / :func:`._account_list_render.rolling_legend_line`).
+4. The one-line fleet effective-utilization figure.
+
+The JSON path (``sac accounts list --json``) is schema-stable and keeps
+``email_address`` / ``plan_label`` / the raw usage payload for machine
+consumers.
+"""
+
+from __future__ import annotations
+
+import click
+
+
+@click.command("list")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a JSON array on stdout instead of human prose.",
+)
+@click.option(
+    "--refresh",
+    "--live",
+    "refresh",
+    is_flag=True,
+    default=False,
+    help=(
+        "Force a fresh upstream usage fetch by discarding the per-account "
+        "usage.json cache before rendering. Without this flag the 5-min "
+        "cache is consulted to avoid hammering the API; the Last Update "
+        "column always shows the snapshot age so a stale number is obvious."
+    ),
+)
+def account_list(as_json: bool, refresh: bool) -> None:
+    """List stored accounts and show the currently active one.
+
+    The human view splits its two surfaces without duplication
+    (operator directive 2026-07-11): the Stored-accounts table is
+    exactly Account | Status | Last Update — the status cell carries
+    the live token TTL (``VALID +2h26m``) — while the monospace
+    usage-bars block below it owns the 5h/7d percentages, each with
+    its compact per-window reset hint (``29% (→09:19)`` /
+    ``66% (→Sun 21h)``), followed by a single fleet
+    effective-utilization line.
+
+    \b
+    Fleet effective utilization
+      A reset-horizon-weighted fleet figure. Per account, over a 7-day
+      planning window W: frac_before_reset = clamp(reset_horizon, 0, W)/W
+      and effective% = frac_before_reset * used_pct_7d. So an account at
+      100% that resets in 1 day (eff ~14%) contributes far more usable
+      weekly capacity than one at 100% resetting in 6 days (eff ~86%).
+      The reset horizon is the true 7d-window reset (reset_at_7d); when
+      absent it defaults to the full window (eff = used_pct_7d). The
+      fleet figure is the mean over accounts with cached usage.
+
+    \b
+    Example:
+      $ sac account list
+      $ sac account list --json
+      $ sac account list --refresh    # force upstream usage% refetch
+    """
+    import json as _json
+
+    from .._account.credentials import read_credentials_metadata
+    from .._state.account_store import list_accounts
+    from ._account_list_render import (
+        build_stored_json,
+        build_stored_rows,
+        needs_rolling_legend,
+        render_stored_table,
+        rolling_legend_line,
+    )
+    from ._account_usage_bars import fleet_effective_line, render_usage_bars_block
+    from ._helpers import console
+    from .status_cmds import _format_claude_account_block
+
+    accounts = list_accounts()
+
+    if as_json:
+        # stx-allow: fallback (reason: malformed credentials JSON tolerated)
+        try:
+            active = read_credentials_metadata()
+        except (OSError, _json.JSONDecodeError):
+            active = {}
+        click.echo(
+            _json.dumps(
+                {
+                    "active": active,
+                    "stored": build_stored_json(accounts, refresh=refresh),
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        return
+
+    # Active credentials block
+    # stx-allow: fallback (reason: malformed credentials JSON tolerated; section omitted on error)
+    try:
+        active_meta = read_credentials_metadata()
+    except (OSError, _json.JSONDecodeError):
+        active_meta = {}
+    lines = _format_claude_account_block(active_meta)
+    for line in lines:
+        console.print(line)
+    if lines:
+        console.print("")
+
+    if not accounts:
+        click.echo(
+            "No accounts stored. Use: scitex-agent-container account save <name>"
+        )
+        return
+    rows = build_stored_rows(accounts, refresh=refresh)
+    console.print(render_stored_table(rows))
+    # Operator directive 2026-07-11: the bars own the percentages AND
+    # their reset hints; the table above holds only what the bars
+    # cannot express. Emitted via click.echo (NOT console.print) so
+    # the `[..]` bar brackets render literally instead of being parsed
+    # as rich markup.
+    bars_block = render_usage_bars_block(rows)
+    if bars_block:
+        click.echo("")
+        click.echo(bars_block)
+    # When the upstream usage API didn't return per-row reset
+    # timestamps (older caches / API outage), the per-line `(→...)`
+    # hint can't render. Print a one-line legend below the bars so the
+    # operator still sees the rolling-window contract instead of
+    # guessing.
+    if needs_rolling_legend(rows):
+        click.echo(rolling_legend_line())
+    click.echo(fleet_effective_line(rows))
+
+
+def register_list_command(group: click.Group) -> None:
+    """Attach the ``list`` command onto the ``account`` group."""
+    group.add_command(account_list)
+
+
+__all__ = [
+    "account_list",
+    "register_list_command",
+]

--- a/src/scitex_agent_container/cli_pkg/_account_list_format.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_format.py
@@ -23,8 +23,10 @@ Concerns covered:
 4. :func:`format_reset_hhmm` / :func:`format_reset_day_hour` —
    render the per-window reset timestamp the Anthropic OAuth usage
    API returns (``resets_at`` → ``reset_at_5h`` / ``reset_at_7d``).
-   Used by the 5h%/7d% cells to surface ``(→21:05)`` and
-   ``(→Sun 17h)`` reset hints.
+   Consumed by the usage-bars block (operator directive 2026-07-11:
+   the bars own the percentages AND their reset hints; the table
+   holds only what the bars cannot express) to surface ``(→21:05)``
+   and ``(→Sun 17h)`` next to each bar's percentage.
 """
 
 from __future__ import annotations
@@ -216,7 +218,8 @@ def format_as_of_short(
 
 
 # ---------------------------------------------------------------------------
-# Reset-time hints for the 5h% / 7d% cells (operator gripe #2, 2026-06-09)
+# Reset-time hints for the usage-bars lines (operator directives 2026-06-09
+# gripe #2 and 2026-07-11 dedupe: hints live next to the bars' percentages)
 # ---------------------------------------------------------------------------
 
 
@@ -224,24 +227,19 @@ def format_reset_hhmm(
     reset_iso: str | datetime | None,
     *,
     env: dict[str, str] | None = None,
-    now: datetime | None = None,
 ) -> str:
-    """Render a 5h-window reset timestamp as ``→HH:MM (in 2h 14m)`` (local-tz).
+    """Render a 5h-window reset timestamp as ``→HH:MM`` (local-tz).
 
     Operator gripe #2 (2026-06-09): ``5h%`` never said WHEN the
-    rolling window resets. P3 follow-up (operator 12866, lead a2a
-    b1be44d0): the absolute time alone forces the operator to
-    compute the remaining-time delta by hand. Now appends a
-    countdown ``(in Xh Ym)`` qualifier so the operator sees the
-    delta and the wall clock in the same cell.
-
-    ``now`` is an injection seam for tests; defaults to ``datetime.
-    now(tz)`` at call time. Past resets render the time without the
-    qualifier (the API hasn't observed the rollover yet — surfacing
-    "0s / -3m" would be louder than useful).
+    rolling window resets. Since the 2026-07-11 dedupe directive the
+    hint renders next to the 5h usage BAR (the table no longer
+    carries percentages at all) and must stay COMPACT — the operator's
+    verbatim example is ``29% (→09:19)``, so the old per-cell
+    ``(in Xh Ym)`` countdown qualifier was dropped together with the
+    table cells it annotated.
 
     Returns ``""`` when the timestamp is missing/unparseable so the
-    caller can fall back to the bare percentage cell rather than
+    caller can fall back to the bare percentage rather than
     fabricate a value. Never raises.
     """
     dt = _coerce_dt(reset_iso)
@@ -249,30 +247,23 @@ def format_reset_hhmm(
         return ""
     tz = local_timezone(env)
     local = dt.astimezone(tz) if tz is not None else dt.astimezone()
-    delta_hint = _format_countdown_delta(local, now=now)
-    head = f"→{local.strftime('%H:%M')}"
-    return f"{head} ({delta_hint})" if delta_hint else head
+    return f"→{local.strftime('%H:%M')}"
 
 
 def format_reset_day_hour(
     reset_iso: str | datetime | None,
     *,
     env: dict[str, str] | None = None,
-    now: datetime | None = None,
 ) -> str:
-    """Render a 7d-window reset timestamp as ``→Day HHh (in 1d 4h 23m)``.
+    """Render a 7d-window reset timestamp as ``→Day HHh`` (local-tz).
 
     Operator gripe #2 (2026-06-09): ``7d%`` never said WHEN the
-    rolling 7-day window resets. P3 follow-up (operator 12866):
-    appends a countdown ``(in Xd Yh Zm)`` qualifier so the operator
-    sees both the wall day-hour and the time-until-reset in the
-    same cell. The day-of-week prefix already pins the absolute
-    side; the qualifier covers the "is that THIS Sun or NEXT Sun"
-    ambiguity directly.
-
-    ``now`` is an injection seam for tests; defaults to ``datetime.
-    now(tz)`` at call time. Past resets render without the
-    qualifier — the API hasn't observed the rollover yet.
+    rolling 7-day window resets. Since the 2026-07-11 dedupe
+    directive the hint renders next to the 7d usage BAR and must
+    stay COMPACT — the operator's verbatim example is
+    ``66% (→Sun 21h)``, so the old ``(in Xd Yh Zm)`` countdown
+    qualifier was dropped together with the table cells it
+    annotated.
 
     Returns ``""`` on missing/unparseable input — never fabricates.
     """
@@ -281,54 +272,7 @@ def format_reset_day_hour(
         return ""
     tz = local_timezone(env)
     local = dt.astimezone(tz) if tz is not None else dt.astimezone()
-    delta_hint = _format_countdown_delta(local, now=now)
-    head = f"→{local.strftime('%a %Hh')}"
-    return f"{head} ({delta_hint})" if delta_hint else head
-
-
-def _format_countdown_delta(target: datetime, *, now: datetime | None = None) -> str:
-    """Render ``in Xd Yh Zm`` for the gap between ``now`` and ``target``.
-
-    Used by :func:`format_reset_hhmm` / :func:`format_reset_day_hour`
-    to append a delta-from-now to the rendered reset timestamp.
-
-    Output by remaining magnitude:
-      * ``target`` already past   → ``""`` (caller falls through).
-      * ``< 60 s``                → ``"in <1m"``.
-      * ``< 60 m``                → ``"in Ym"``.
-      * ``< 24 h``                → ``"in Xh Ym"`` (Ym dropped when zero).
-      * ``>= 24 h``               → ``"in Dd Xh Ym"`` (zero Y/m dropped
-                                    only at the tail; "in 1d 0h 5m"
-                                    keeps the 0h so the unit grid stays
-                                    aligned).
-
-    ``now`` defaults to ``datetime.now(target.tzinfo)`` so the
-    subtraction is timezone-aware. Returns ``""`` whenever the
-    delta cannot be rendered (None inputs, parse failure, past).
-    """
-    if target is None:
-        return ""
-    n = now if now is not None else datetime.now(target.tzinfo)
-    delta = target - n
-    total = int(delta.total_seconds())
-    if total <= 0:
-        return ""
-    if total < 60:
-        return "in <1m"
-    minutes_total = total // 60
-    if minutes_total < 60:
-        return f"in {minutes_total}m"
-    hours_total = minutes_total // 60
-    minutes_part = minutes_total - hours_total * 60
-    if hours_total < 24:
-        return (
-            f"in {hours_total}h {minutes_part}m"
-            if minutes_part
-            else f"in {hours_total}h"
-        )
-    days = hours_total // 24
-    hours_part = hours_total - days * 24
-    return f"in {days}d {hours_part}h {minutes_part}m"
+    return f"→{local.strftime('%a %Hh')}"
 
 
 __all__ = [

--- a/src/scitex_agent_container/cli_pkg/_account_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_render.py
@@ -19,13 +19,19 @@ Pure formatting helpers (``local_timezone``, ``format_dt_local``,
 :mod:`._account_list_format` so existing callers (and the historical
 test surface) keep importing them from this module without churn.
 
-Header note (2026-06-09 task): the human renderer's last column was
-renamed ``As-of`` → ``Last Update`` because the operator could not
-parse the abbreviation. The 5h%/7d% cells now carry an inline reset
-hint (``→HH:MM`` for 5h, ``→Day HHh`` for 7d) computed from the
-Anthropic OAuth usage API's ``resets_at`` field. The JSON output path
-(``sac accounts list --json``) is NOT touched — its schema stays the
-machine-readable contract downstream consumers parse.
+Layout note (operator directive 2026-07-11): the Stored-accounts table
+and the usage-bars block below it used to DUPLICATE the 5h%/7d%
+numbers. The rule now is "the bars own the percentages; the table
+holds only what the bars cannot express" — so the table is exactly
+``Account | Status | Last Update`` (the ID column was renamed
+``Account``; the Email column was dropped because IDs are
+email-derived slugs, and the Plan column was dropped outright), while
+the per-window reset hints (``→HH:MM`` / ``→Day HHh``, 2026-06-09
+gripe #2) moved from the removed 5h%/7d% cells onto the usage-bars
+lines (see :mod:`._account_usage_bars`). The JSON output path
+(``sac accounts list --json``) is NOT touched — its schema (including
+``email_address`` and ``plan_label``) stays the machine-readable
+contract downstream consumers parse.
 """
 
 from __future__ import annotations
@@ -58,38 +64,37 @@ class AccountRow:
 
     The dataclass keeps the renderer pure (no I/O, no time calls), so a
     test can hand-roll a row and assert the exact cells without
-    monkeypatching the clock.
+    monkeypatching the clock. It feeds BOTH human surfaces of
+    ``sac accounts list``: the Stored-accounts table (name + status +
+    last update) and the usage-bars block (percentages + reset hints).
+    The former ``email`` / ``plan_label`` / ``tier`` fields were
+    dropped with the 2026-07-11 dedupe directive — neither surface
+    renders them any more (the JSON path keeps them via
+    :func:`build_stored_json`).
 
     Attributes
     ----------
     name
-        Account ID (stored slug, e.g. ``ywatanabe-scitex-ai``).
-    email
-        Display email or ``(no email)`` placeholder.
-    plan_label
-        Human plan label (``Pro`` / ``Max 5x`` / ``Max 20x`` / ``?``).
-    tier
-        Rate-limit tier slug.
+        Account ID (stored slug, e.g. ``ywatanabe-scitex-ai``; the
+        slugs are email-derived, which is why the table needs no
+        separate Email column).
     freshness_state
         ``"VALID"`` / ``"EXPIRED"`` / ``"ABSENT"``.
     freshness_hours
         Signed hours to expiry, or ``None`` for ABSENT.
     used_pct_5h, used_pct_7d
-        Float percentages or ``None``.
+        Float percentages or ``None`` (rendered by the bars block).
     snapshot_as_of
         ISO-8601 string from the usage cache, or ``None``.
     reset_at_5h, reset_at_7d
         ISO-8601 reset timestamps from the Anthropic OAuth usage API
         (``resets_at`` field, parsed by :mod:`._account.claude_usage`).
         ``None`` when the API did not return them (older caches /
-        outages); the renderer falls back to the bare percentage cell
-        in that case rather than fabricating a value.
+        outages); the bars block then omits the reset hint for that
+        window rather than fabricating a value.
     """
 
     name: str
-    email: str
-    plan_label: str
-    tier: str
     freshness_state: str
     freshness_hours: float | None
     used_pct_5h: float | None
@@ -102,28 +107,6 @@ class AccountRow:
 # ---------------------------------------------------------------------------
 # Table renderer
 # ---------------------------------------------------------------------------
-
-
-def _fmt_pct(value: float | None) -> str:
-    """Render a percentage as ``42%``; ``None`` → ``-``."""
-    return "-" if value is None else f"{float(value):.0f}%"
-
-
-def _fmt_pct_with_reset(value: float | None, hint: str) -> str:
-    """Combine percentage + reset hint: ``42% (→21:05)`` / ``-`` / ``42%``.
-
-    ``hint`` is the output of :func:`format_reset_hhmm` or
-    :func:`format_reset_day_hour` — empty string when the API didn't
-    return a reset timestamp, in which case the cell is just ``42%``
-    (and the column header carries the ``(rolling)`` qualifier so the
-    operator still knows it's a rolling window).
-    """
-    if value is None:
-        return "-"
-    pct = f"{float(value):.0f}%"
-    if not hint:
-        return pct
-    return f"{pct} ({hint})"
 
 
 def _fmt_status(state: str, hours: float | None) -> str:
@@ -149,38 +132,28 @@ def render_stored_table(
     """Build a ``rich.table.Table`` for the Stored-accounts block.
 
     Columns (left-to-right):
-      ID | Email | Plan | Status(+TTL) | 5h% | 7d% | Last Update
+      Account | Status | Last Update
 
-    The 5h% / 7d% cells carry an inline reset hint when the upstream
-    Anthropic usage API returned one for that row (operator gripe #2
-    of 2026-06-09: "いつ区切りが戻るのか分からない"). When the API
-    did NOT return any reset timestamps, the operator still needs to
-    know the windows are ROLLING (not calendar-day) — for that case
-    the CLI prints a one-line legend below the table; see
-    :func:`needs_rolling_legend` / :func:`rolling_legend_line`. The
-    column header stays compact (``5h%`` / ``7d%``) so the table fits
-    in a typical operator terminal.
+    Operator directive 2026-07-11: the table holds ONLY what the
+    usage-bars block below it cannot express — the account slug, the
+    credential status with its live token TTL (``VALID +2h26m``), and
+    the usage-snapshot freshness. The 5h%/7d% columns (duplicating the
+    bars), the Email column (IDs are email-derived slugs) and the Plan
+    column were removed; the per-window reset hints moved onto the
+    bars lines (:mod:`._account_usage_bars`).
 
     ``now`` is an injection seam so the snapshot-age tests can drive
     the Last-Update cell deterministically without monkeypatching
     ``datetime.now``.
     """
     table = Table(title="Stored accounts", title_justify="left", show_lines=False)
-    table.add_column("ID", style="bold")
-    table.add_column("Email")
-    table.add_column("Plan")
-    table.add_column("Status(+TTL)")
-    table.add_column("5h%", justify="right")
-    table.add_column("7d%", justify="right")
+    table.add_column("Account", style="bold")
+    table.add_column("Status")
     table.add_column("Last Update")
     for r in rows:
         table.add_row(
             r.name,
-            r.email,
-            f"{r.plan_label} [{r.tier}]",
             _fmt_status(r.freshness_state, r.freshness_hours),
-            _fmt_pct_with_reset(r.used_pct_5h, format_reset_hhmm(r.reset_at_5h)),
-            _fmt_pct_with_reset(r.used_pct_7d, format_reset_day_hour(r.reset_at_7d)),
             _fmt_last_update_cell(r.snapshot_as_of, now=now),
         )
     return table
@@ -190,9 +163,9 @@ def needs_rolling_legend(rows: list[AccountRow]) -> bool:
     """Return True iff at least one row lacks BOTH reset_at fields.
 
     Used by the CLI to decide whether to print the explanatory legend
-    below the table. When EVERY row has a per-row reset hint, the
-    legend would be redundant — the cells already carry the
-    information.
+    below the usage-bars block. When EVERY row has a per-line reset
+    hint, the legend would be redundant — the bars lines already carry
+    the information.
     """
     if not rows:
         return False
@@ -204,7 +177,8 @@ def rolling_legend_line() -> str:
 
     Per the 2026-06-09 task contract: "リセットのアンカーが取れない
     場合は列凡例/ヘッダで5h=直近5時間ローリング, 7d=直近7日ローリン
-    グと明示". English wording matches the rest of the table.
+    グと明示". Printed below the usage-bars block (which owns the
+    percentages and their ``(→...)`` reset hints since 2026-07-11).
     """
     return (
         "Legend: 5h = rolling 5-hour window; 7d = rolling 7-day window. "
@@ -297,29 +271,27 @@ def usage_for_account(acct_meta: dict, *, refresh: bool = False) -> dict | None:
 def build_stored_rows(
     accounts: list[dict], *, refresh: bool = False
 ) -> list[AccountRow]:
-    """Convert stored-account dicts into :class:`AccountRow` for the table.
+    """Convert stored-account dicts into :class:`AccountRow` for rendering.
 
-    Pure orchestration: pulls plan/tier (offline), credential freshness
-    (live recompute from ``expiresAt`` on every call), and usage% (cached
-    or re-fetched depending on ``refresh``). Also carries through the
-    per-window ``reset_at_5h`` / ``reset_at_7d`` so the cells can render
-    the inline reset hint (gripe #2 of 2026-06-09).
+    Pure orchestration: pulls credential freshness (live recompute from
+    ``expiresAt`` on every call) and usage% (cached or re-fetched
+    depending on ``refresh``). Also carries through the per-window
+    ``reset_at_5h`` / ``reset_at_7d`` so the usage-bars block can render
+    the inline reset hint (gripe #2 of 2026-06-09; moved from the table
+    cells onto the bars by the 2026-07-11 dedupe directive). Plan/tier
+    are no longer resolved here — no human surface renders them (the
+    JSON path keeps them via :func:`build_stored_json`).
     """
     from .._account.creds_sync import account_freshness
-    from .._state.account_store import read_account_plan
 
     rows: list[AccountRow] = []
     for acct in accounts:
         name = acct["name"]
-        plan = read_account_plan(name)
         fresh = account_freshness(name)
         usage = usage_for_account(acct, refresh=refresh) or {}
         rows.append(
             AccountRow(
                 name=name,
-                email=acct.get("email_address") or "(no email)",
-                plan_label=plan.get("plan_label") or "?",
-                tier=plan.get("rate_limit_tier") or "?",
                 freshness_state=fresh.state,
                 freshness_hours=fresh.hours,
                 used_pct_5h=usage.get("used_pct_5h"),

--- a/src/scitex_agent_container/cli_pkg/_account_usage_bars.py
+++ b/src/scitex_agent_container/cli_pkg/_account_usage_bars.py
@@ -8,13 +8,20 @@ BELOW the existing table:
 
 1. A monospace **usage-bars block** — one fixed-width horizontal bar per
    window (5h short window + 7d window) per account, so utilisation is
-   visible at a glance and the bars line up vertically across accounts::
+   visible at a glance and the bars line up vertically across accounts.
+   Since the 2026-07-11 dedupe directive ("the bars own the
+   percentages; the table holds only what the bars cannot express")
+   each percentage also carries the compact per-window reset hint
+   (``→HH:MM`` for 5h, ``→Day HHh`` for 7d — 2026-06-09 gripe #2)
+   that used to clutter the Stored-accounts table cells::
 
-       ywatanabe-scitex-ai   5h [░░░░░░░░░░░░░░░░░░░░]    0%   7d [████████████████████]  100%
-       ywata1989-gmail-com   5h [███░░░░░░░░░░░░░░░░░░]   14%   7d [███░░░░░░░░░░░░░░░░░░]   15%
+       wyusuuke-gmail-com   5h [██████░░░░░░░░░░░░░░]  29% (→09:19)   7d [█████████████░░░░░░░]  66% (→Sun 21h)
+       ywatanabe-scitex-ai  5h [███░░░░░░░░░░░░░░░░░]  14%            7d [███░░░░░░░░░░░░░░░░░]  15% (→Mon 09h)
 
    A bar for an account with no cached usage renders a same-width
-   ``[      no data       ]`` placeholder rather than crashing.
+   ``[      no data       ]`` placeholder rather than crashing; a
+   window with no cached ``reset_at`` renders no hint (the missing
+   5h hint is space-padded so the 7d bars stay vertically aligned).
 
 2. A one-line **fleet effective-utilization** figure that factors each
    account's 7-day-window reset horizon into a single fleet number:
@@ -62,6 +69,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Iterable
+
+from ._account_list_format import format_reset_day_hour, format_reset_hhmm
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from ._account_list_render import AccountRow
@@ -118,6 +127,11 @@ def _pct_label(pct: float | None) -> str:
     return f"{int(round(max(0.0, min(100.0, float(pct)))))}%".rjust(4)
 
 
+def _wrap_hint(hint: str) -> str:
+    """Parenthesise a non-empty reset hint: ``→09:19`` → ``(→09:19)``."""
+    return f"({hint})" if hint else ""
+
+
 def render_usage_bar_line(
     label: str,
     pct_5h: float | None,
@@ -125,15 +139,31 @@ def render_usage_bar_line(
     *,
     label_width: int,
     width: int = _DEFAULT_BAR_WIDTH,
+    hint_5h: str = "",
+    hint_7d: str = "",
+    hint_5h_width: int = 0,
 ) -> str:
-    """One aligned account line: ``<label>  5h [..] NN%   7d [..] NN%``."""
+    """One aligned account line, operator-example shape:
+
+    ``<label>  5h [..]  29% (→09:19)   7d [..]  66% (→Sun 21h)``
+
+    ``hint_5h`` / ``hint_7d`` are pre-wrapped display strings (e.g.
+    ``(→09:19)``) or ``""`` when the window has no cached reset.
+    ``hint_5h_width`` is the block-level max width of the 5h hints; a
+    row whose own hint is shorter (or missing) pads with spaces so the
+    ``7d`` bars stay vertically aligned across accounts. The trailing
+    7d hint needs no padding — nothing follows it.
+    """
     bar5 = render_usage_bar(pct_5h, width=width)
     bar7 = render_usage_bar(pct_7d, width=width)
-    return (
-        f"  {label.ljust(label_width)}  "
-        f"5h {bar5} {_pct_label(pct_5h)}   "
-        f"7d {bar7} {_pct_label(pct_7d)}"
-    )
+    seg_5h = f"5h {bar5} {_pct_label(pct_5h)}"
+    pad_5h = max(hint_5h_width, len(hint_5h))
+    if pad_5h:
+        seg_5h += f" {hint_5h.ljust(pad_5h)}"
+    seg_7d = f"7d {bar7} {_pct_label(pct_7d)}"
+    if hint_7d:
+        seg_7d += f" {hint_7d}"
+    return f"  {label.ljust(label_width)}  {seg_5h}   {seg_7d}"
 
 
 def render_usage_bars_block(
@@ -143,6 +173,13 @@ def render_usage_bars_block(
 ) -> str:
     """Render the full usage-bars block (header + one line per account).
 
+    Each line carries the compact per-window reset hints
+    (``(→HH:MM)`` / ``(→Day HHh)``) computed from the row's
+    ``reset_at_5h`` / ``reset_at_7d`` — the 2026-07-11 dedupe
+    directive moved them here from the Stored-accounts table cells.
+    The 5h hints are padded to one block-level width so mixed
+    hint/no-hint rows keep the 7d bars vertically aligned.
+
     Returns ``""`` for an empty ``rows`` iterable so the caller can skip
     printing the section entirely.
     """
@@ -150,8 +187,11 @@ def render_usage_bars_block(
     if not row_list:
         return ""
     label_width = max(len(r.name) for r in row_list)
+    hints_5h = [_wrap_hint(format_reset_hhmm(r.reset_at_5h)) for r in row_list]
+    hints_7d = [_wrap_hint(format_reset_day_hour(r.reset_at_7d)) for r in row_list]
+    hint_5h_width = max(len(h) for h in hints_5h)
     lines = ["Usage bars (5h / 7d out of 100%):"]
-    for r in row_list:
+    for r, hint_5h, hint_7d in zip(row_list, hints_5h, hints_7d):
         lines.append(
             render_usage_bar_line(
                 r.name,
@@ -159,6 +199,9 @@ def render_usage_bars_block(
                 r.used_pct_7d,
                 label_width=label_width,
                 width=width,
+                hint_5h=hint_5h,
+                hint_7d=hint_7d,
+                hint_5h_width=hint_5h_width,
             )
         )
     return "\n".join(lines)

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -131,122 +131,14 @@ def account_save(name: str, email: str | None, dry_run: bool, yes: bool) -> None
     )
 
 
-@account.command("list")
-@click.option(
-    "--json",
-    "as_json",
-    is_flag=True,
-    default=False,
-    help="Emit a JSON array on stdout instead of human prose.",
-)
-@click.option(
-    "--refresh",
-    "--live",
-    "refresh",
-    is_flag=True,
-    default=False,
-    help=(
-        "Force a fresh upstream usage fetch by discarding the per-account "
-        "usage.json cache before rendering. Without this flag the 5-min "
-        "cache is consulted to avoid hammering the API; the Last Update "
-        "column always shows the snapshot age so a stale number is obvious."
-    ),
-)
-def account_list(as_json: bool, refresh: bool) -> None:
-    """List stored accounts and show the currently active one.
+# ---------------------------------------------------------------------------
+# list — Stored-accounts table + usage bars + fleet line. Lives in its own
+# module (per-file line cap) since the 2026-07-11 dedupe redesign; attached
+# onto the group at import time like refresh / sync-live.
+# ---------------------------------------------------------------------------
+from ._account_list_cmd import register_list_command
 
-    Below the table the human view prints (a) a monospace usage-bars
-    block — a fixed-width ASCII bar per account for the 5h and 7d
-    windows so utilisation is scannable at a glance — and (b) a single
-    fleet effective-utilization line.
-
-    \b
-    Fleet effective utilization
-      A reset-horizon-weighted fleet figure. Per account, over a 7-day
-      planning window W: frac_before_reset = clamp(reset_horizon, 0, W)/W
-      and effective% = frac_before_reset * used_pct_7d. So an account at
-      100% that resets in 1 day (eff ~14%) contributes far more usable
-      weekly capacity than one at 100% resetting in 6 days (eff ~86%).
-      The reset horizon is the true 7d-window reset (reset_at_7d); when
-      absent it defaults to the full window (eff = used_pct_7d). The
-      fleet figure is the mean over accounts with cached usage.
-
-    \b
-    Example:
-      $ sac account list
-      $ sac account list --json
-      $ sac account list --refresh    # force upstream usage% refetch
-    """
-    import json as _json
-
-    from .._account.credentials import read_credentials_metadata
-    from .._state.account_store import list_accounts
-    from ._account_list_render import (
-        build_stored_json,
-        build_stored_rows,
-        needs_rolling_legend,
-        render_stored_table,
-        rolling_legend_line,
-    )
-    from ._account_usage_bars import fleet_effective_line, render_usage_bars_block
-    from ._helpers import console
-    from .status_cmds import _format_claude_account_block
-
-    accounts = list_accounts()
-
-    if as_json:
-        # stx-allow: fallback (reason: malformed credentials JSON tolerated)
-        try:
-            active = read_credentials_metadata()
-        except (OSError, _json.JSONDecodeError):
-            active = {}
-        click.echo(
-            _json.dumps(
-                {
-                    "active": active,
-                    "stored": build_stored_json(accounts, refresh=refresh),
-                },
-                ensure_ascii=False,
-                indent=2,
-            )
-        )
-        return
-
-    # Active credentials block
-    # stx-allow: fallback (reason: malformed credentials JSON tolerated; section omitted on error)
-    try:
-        active_meta = read_credentials_metadata()
-    except (OSError, _json.JSONDecodeError):
-        active_meta = {}
-    lines = _format_claude_account_block(active_meta)
-    for line in lines:
-        console.print(line)
-    if lines:
-        console.print("")
-
-    if not accounts:
-        click.echo(
-            "No accounts stored. Use: scitex-agent-container account save <name>"
-        )
-        return
-    rows = build_stored_rows(accounts, refresh=refresh)
-    console.print(render_stored_table(rows))
-    # When the upstream usage API didn't return per-row reset
-    # timestamps (older caches / API outage), the per-cell `(→...)`
-    # hint can't render. Print a one-line legend so the operator
-    # still sees the rolling-window contract instead of guessing.
-    if needs_rolling_legend(rows):
-        console.print(rolling_legend_line())
-    # Operator readability ask (2026-07-09): a monospace usage-bars
-    # block + a single reset-horizon-weighted fleet figure below the
-    # table. Emitted via click.echo (NOT console.print) so the `[..]`
-    # bar brackets render literally instead of being parsed as rich
-    # markup.
-    bars_block = render_usage_bars_block(rows)
-    if bars_block:
-        click.echo("")
-        click.echo(bars_block)
-    click.echo(fleet_effective_line(rows))
+register_list_command(account)
 
 
 @account.command("delete")

--- a/tests/scitex_agent_container/cli_pkg/test__account_list_render.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_list_render.py
@@ -14,9 +14,13 @@ The renderer module is the bullet-1/2/3 fix surface:
   the % so a stale number is obvious.
 * bullet 3 — ``rich.table.Table`` with aligned columns, short
   ``Last Update`` (renamed from ``As-of`` per the 2026-06-09 operator
-  ask). Per-row 5h%/7d% cells carry an inline ``→HH:MM`` /
-  ``→Day HHh`` reset hint when the upstream Anthropic usage API
-  returned a ``resets_at`` timestamp for that window.
+  ask).
+* 2026-07-11 dedupe directive — the table is exactly
+  ``Account | Status | Last Update`` (no Email / Plan / 5h% / 7d%
+  columns); the compact ``→HH:MM`` / ``→Day HHh`` reset hints render
+  in the usage-bars block instead (asserted in
+  ``test__account_usage_bars.py``), and the ``(in Xh Ym)`` countdown
+  qualifier was dropped together with the table cells it annotated.
 
 The ``--refresh`` flag is asserted via the CLI surface (click invocation)
 with a real fake fetcher injected through a temporary monkey of the
@@ -344,35 +348,95 @@ def test_format_as_of_short_under_8_chars(env_save_restore):
     assert len(rendered) <= 8
 
 
+def _table_row(**overrides) -> AccountRow:
+    """Arrange helper: a representative row; kwargs override any field."""
+    base: dict = dict(
+        name="work",
+        freshness_state="VALID",
+        freshness_hours=2.8,
+        used_pct_5h=42.0,
+        used_pct_7d=15.0,
+        snapshot_as_of="2026-05-31T12:11:00+00:00",
+    )
+    base.update(overrides)
+    return AccountRow(**base)
+
+
 def test_render_stored_table_has_column_headers():
+    """The 2026-07-11 contract: exactly Account | Status | Last Update."""
     # Arrange — one row.
+    rows = [_table_row()]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert — every column header is present.
+    for col in ("Account", "Status", "Last Update"):
+        assert col in out, f"missing column header: {col!r}\n---\n{out}"
+
+
+def test_render_stored_table_omits_email_column():
+    """Operator directive 2026-07-11: IDs are email-derived slugs — no Email."""
+    # Arrange
+    rows = [_table_row()]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert
+    assert "Email" not in out
+
+
+def test_render_stored_table_omits_plan_column():
+    """Operator directive 2026-07-11: Plan is JSON-only — not in the table."""
+    # Arrange
+    rows = [_table_row()]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert
+    assert "Plan" not in out
+
+
+def test_render_stored_table_omits_usage_pct_columns():
+    """The bars own the percentages — no 5h%/7d% duplication in the table."""
+    # Arrange
+    rows = [_table_row()]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert
+    assert "5h%" not in out and "7d%" not in out
+
+
+def test_render_stored_table_omits_percentage_cells():
+    """A row WITH cached usage still renders no percentage in the table."""
+    # Arrange
+    rows = [_table_row(used_pct_5h=42.0, used_pct_7d=15.0)]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert
+    assert "42%" not in out and "15%" not in out
+
+
+def test_render_stored_table_omits_reset_hints():
+    """Reset hints render on the bars lines now — never in the table."""
+    # Arrange — a row that HAS both reset timestamps cached.
     rows = [
-        AccountRow(
-            name="work",
-            email="w@example.com",
-            plan_label="Max 20x",
-            tier="default_claude_max_20x",
-            freshness_state="VALID",
-            freshness_hours=2.8,
-            used_pct_5h=42.0,
-            used_pct_7d=15.0,
-            snapshot_as_of="2026-05-31T12:11:00+00:00",
+        _table_row(
+            reset_at_5h="2026-05-31T12:05:00+00:00",
+            reset_at_7d="2026-06-04T08:00:00+00:00",
         ),
     ]
     now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
     # Act
     out = render_stored_table_to_str(rows, now=now)
-    # Assert — every column header is present.
-    for col in ("ID", "Email", "Plan", "Status(+TTL)", "5h%", "7d%", "Last Update"):
-        assert col in out, f"missing column header: {col!r}\n---\n{out}"
+    # Assert
+    assert "(→" not in out
 
 
 _TWO_ROW_TABLE_ROWS = [
     AccountRow(
         name="aa",
-        email="a@example.com",
-        plan_label="Pro",
-        tier="default_claude_pro",
         freshness_state="VALID",
         freshness_hours=1.0,
         used_pct_5h=10.0,
@@ -381,9 +445,6 @@ _TWO_ROW_TABLE_ROWS = [
     ),
     AccountRow(
         name="bbbb",
-        email="bbbb@example.com",
-        plan_label="Max 20x",
-        tier="default_claude_max_20x",
         freshness_state="EXPIRED",
         freshness_hours=-5.0,
         used_pct_5h=None,
@@ -428,19 +489,7 @@ def test_render_stored_table_columns_are_uniformly_separated():
 
 def _as_of_short_form_table_out() -> str:
     """Render a 1-row table whose As-of carries microseconds for short-form tests."""
-    rows = [
-        AccountRow(
-            name="work",
-            email="w@example.com",
-            plan_label="Pro",
-            tier="default_claude_pro",
-            freshness_state="VALID",
-            freshness_hours=2.8,
-            used_pct_5h=42.0,
-            used_pct_7d=15.0,
-            snapshot_as_of="2026-05-31T12:11:23.756321+00:00",
-        ),
-    ]
+    rows = [_table_row(snapshot_as_of="2026-05-31T12:11:23.756321+00:00")]
     now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
     return render_stored_table_to_str(rows, now=now)
 
@@ -465,22 +514,10 @@ def test_render_stored_table_as_of_strips_microseconds(env_save_restore):
     assert "756321" not in out
 
 
-def test_render_stored_table_shows_age_next_to_pct():
-    """The bullet-2 contract: snapshot age MUST appear next to the %."""
+def test_render_stored_table_shows_snapshot_age_in_last_update():
+    """The bullet-2 contract: snapshot age renders in the Last Update cell."""
     # Arrange
-    rows = [
-        AccountRow(
-            name="work",
-            email="w@example.com",
-            plan_label="Pro",
-            tier="default_claude_pro",
-            freshness_state="VALID",
-            freshness_hours=2.8,
-            used_pct_5h=42.0,
-            used_pct_7d=15.0,
-            snapshot_as_of="2026-05-31T12:11:00+00:00",
-        ),
-    ]
+    rows = [_table_row()]
     now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
     # Act
     out = render_stored_table_to_str(rows, now=now)
@@ -551,190 +588,38 @@ def test_format_reset_day_hour_unparseable_returns_empty():
 
 
 # ---------------------------------------------------------------------------
-# P3 task — countdown delta on the per-window reset hint (op 12866 / lead a2a
-# b1be44d0). The 5h / 7d reset cells now carry an ``(in Xh Ym)`` /
-# ``(in Xd Yh Zm)`` qualifier so the operator sees the wall time AND the
-# time-until-reset in the same cell. ``now`` is injected so tests are
-# deterministic.
+# 2026-07-11 dedupe directive — the reset hint must stay COMPACT (the
+# operator's verbatim bar example is ``29% (→09:19)`` / ``66% (→Sun 21h)``).
+# The former per-cell ``(in Xh Ym)`` countdown qualifier (P3, op 12866) was
+# dropped together with the table cells it annotated, so a FUTURE reset must
+# render exactly like a past one: bare ``→HH:MM`` / ``→Day HHh``.
 # ---------------------------------------------------------------------------
 
 
-def test_format_reset_hhmm_appends_countdown_delta_under_one_hour(env_save_restore):
-    # Arrange — 12:05 UTC = 21:05 JST; now = 10:55 UTC (= 19:55 JST) →
-    # delta = 1h10m → "in 1h 10m".
+def test_format_reset_hhmm_future_reset_stays_compact(env_save_restore):
+    """A reset far in the future renders the bare ``→HH:MM`` — no countdown."""
+    # Arrange — 12:05 UTC = 21:05 JST, a century out from any real clock.
     env_save_restore.set("TZ", "Asia/Tokyo")
-    now = datetime(2026, 5, 31, 10, 55, tzinfo=timezone.utc)
     # Act
-    rendered = format_reset_hhmm("2026-05-31T12:05:00+00:00", now=now)
-    # Assert
-    assert rendered == "→21:05 (in 1h 10m)"
-
-
-def test_format_reset_hhmm_omits_minute_when_zero(env_save_restore):
-    # Arrange — exactly 2h ahead.
-    env_save_restore.set("TZ", "Asia/Tokyo")
-    now = datetime(2026, 5, 31, 10, 5, tzinfo=timezone.utc)
-    # Act
-    rendered = format_reset_hhmm("2026-05-31T12:05:00+00:00", now=now)
-    # Assert
-    assert rendered == "→21:05 (in 2h)"
-
-
-def test_format_reset_hhmm_uses_in_under_one_min_for_sub_minute_delta(
-    env_save_restore,
-):
-    # Arrange — only 30 seconds out.
-    env_save_restore.set("TZ", "Asia/Tokyo")
-    now = datetime(2026, 5, 31, 12, 4, 30, tzinfo=timezone.utc)
-    # Act
-    rendered = format_reset_hhmm("2026-05-31T12:05:00+00:00", now=now)
-    # Assert
-    assert rendered == "→21:05 (in <1m)"
-
-
-def test_format_reset_hhmm_drops_delta_when_target_already_past(
-    env_save_restore,
-):
-    # Arrange — reset already in the past; cell falls back to bare time.
-    env_save_restore.set("TZ", "Asia/Tokyo")
-    now = datetime(2026, 5, 31, 13, 0, tzinfo=timezone.utc)
-    # Act
-    rendered = format_reset_hhmm("2026-05-31T12:05:00+00:00", now=now)
+    rendered = format_reset_hhmm("2126-05-31T12:05:00+00:00")
     # Assert
     assert rendered == "→21:05"
 
 
-def test_format_reset_day_hour_appends_multi_day_countdown(env_save_restore):
-    # Arrange — 2026-06-04 08:00 UTC = 2026-06-04 17:00 JST → Thu 17h.
-    # now = 2026-06-03 03:36 UTC → delta = 1d 4h 24m → "in 1d 4h 24m".
+def test_format_reset_day_hour_future_reset_stays_compact(env_save_restore):
+    """A far-future reset renders the bare ``→Day HHh`` — no countdown."""
+    # Arrange — 08:00 UTC = 17:00 JST, a century out from any real clock.
     env_save_restore.set("TZ", "Asia/Tokyo")
-    now = datetime(2026, 6, 3, 3, 36, tzinfo=timezone.utc)
     # Act
-    rendered = format_reset_day_hour("2026-06-04T08:00:00+00:00", now=now)
-    # Assert
-    assert rendered == "→Thu 17h (in 1d 4h 24m)"
-
-
-def test_format_reset_day_hour_drops_delta_when_target_already_past(
-    env_save_restore,
-):
-    # Arrange — reset is in the past for this fake now.
-    env_save_restore.set("TZ", "Asia/Tokyo")
-    now = datetime(2026, 6, 5, 8, 0, tzinfo=timezone.utc)
-    # Act
-    rendered = format_reset_day_hour("2026-06-04T08:00:00+00:00", now=now)
-    # Assert
-    assert rendered == "→Thu 17h"
-
-
-def test_format_reset_day_hour_handles_under_one_day_delta(env_save_restore):
-    # Arrange — same-day reset still uses Day Hh prefix; delta falls in
-    # the ``X h Y m`` branch.
-    env_save_restore.set("TZ", "Asia/Tokyo")
-    # 2026-06-04 08:00 UTC = 17:00 JST (Thu 17h); now = 2026-06-04
-    # 05:00 UTC = 14:00 JST → delta = 3h.
-    now = datetime(2026, 6, 4, 5, 0, tzinfo=timezone.utc)
-    # Act
-    rendered = format_reset_day_hour("2026-06-04T08:00:00+00:00", now=now)
-    # Assert
-    assert rendered == "→Thu 17h (in 3h)"
-
-
-def test_render_stored_table_5h_cell_carries_reset_hint(env_save_restore):
-    """5h% cell renders ``42% (→HH:MM)`` when ``reset_at_5h`` is present."""
-    # Arrange — 12:05 UTC = 21:05 JST.
-    env_save_restore.set("TZ", "Asia/Tokyo")
-    rows = [
-        AccountRow(
-            name="work",
-            email="w@example.com",
-            plan_label="Pro",
-            tier="default_claude_pro",
-            freshness_state="VALID",
-            freshness_hours=2.8,
-            used_pct_5h=42.0,
-            used_pct_7d=15.0,
-            snapshot_as_of="2026-05-31T12:11:00+00:00",
-            reset_at_5h="2026-05-31T12:05:00+00:00",
-            reset_at_7d=None,
-        ),
-    ]
-    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
-    # Act
-    out = render_stored_table_to_str(rows, now=now)
-    # Assert — operator example shape from the 2026-06-09 task.
-    assert "42% (→21:05)" in out
-
-
-def test_render_stored_table_7d_cell_carries_reset_hint(env_save_restore):
-    """7d% cell renders ``15% (→Day HHh)`` when ``reset_at_7d`` is present."""
-    # Arrange — 2026-06-04 08:00 UTC = 2026-06-04 17:00 JST = Thu 17h.
-    env_save_restore.set("TZ", "Asia/Tokyo")
-    rows = [
-        AccountRow(
-            name="work",
-            email="w@example.com",
-            plan_label="Pro",
-            tier="default_claude_pro",
-            freshness_state="VALID",
-            freshness_hours=2.8,
-            used_pct_5h=42.0,
-            used_pct_7d=15.0,
-            snapshot_as_of="2026-05-31T12:11:00+00:00",
-            reset_at_5h=None,
-            reset_at_7d="2026-06-04T08:00:00+00:00",
-        ),
-    ]
-    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
-    # Act
-    out = render_stored_table_to_str(rows, now=now)
-    # Assert
-    assert "15% (→Thu 17h)" in out
-
-
-def test_render_stored_table_falls_back_to_bare_pct_when_no_reset_5h():
-    """No ``reset_at_5h`` → cell is just ``42%``; no fabricated reset hint."""
-    # Arrange
-    rows = [
-        AccountRow(
-            name="work",
-            email="w@example.com",
-            plan_label="Pro",
-            tier="default_claude_pro",
-            freshness_state="VALID",
-            freshness_hours=2.8,
-            used_pct_5h=42.0,
-            used_pct_7d=None,
-            snapshot_as_of="2026-05-31T12:11:00+00:00",
-            reset_at_5h=None,
-            reset_at_7d=None,
-        ),
-    ]
-    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
-    # Act
-    out = render_stored_table_to_str(rows, now=now)
-    # Assert — bare percentage, no `(→` arrow that would fake a reset.
-    assert "42%" in out and "(→" not in out
+    rendered = format_reset_day_hour("2126-06-04T08:00:00+00:00")
+    # Assert — bare →Day HHh shape; no ``(in ...)`` qualifier appended.
+    assert rendered.startswith("→") and rendered.endswith(" 17h") and "(" not in rendered
 
 
 def test_needs_rolling_legend_true_when_row_lacks_both_resets():
     """When a row carries neither reset_at, the CLI needs the legend line."""
     # Arrange
-    rows = [
-        AccountRow(
-            name="work",
-            email="w@example.com",
-            plan_label="Pro",
-            tier="default_claude_pro",
-            freshness_state="VALID",
-            freshness_hours=2.8,
-            used_pct_5h=42.0,
-            used_pct_7d=15.0,
-            snapshot_as_of="2026-05-31T12:11:00+00:00",
-            reset_at_5h=None,
-            reset_at_7d=None,
-        ),
-    ]
+    rows = [_table_row(reset_at_5h=None, reset_at_7d=None)]
     # Act
     need = needs_rolling_legend(rows)
     # Assert
@@ -742,19 +627,10 @@ def test_needs_rolling_legend_true_when_row_lacks_both_resets():
 
 
 def test_needs_rolling_legend_false_when_every_row_has_resets():
-    """Per-row hint already discloses the rolling contract — no legend needed."""
+    """Per-line hint already discloses the rolling contract — no legend needed."""
     # Arrange
     rows = [
-        AccountRow(
-            name="work",
-            email="w@example.com",
-            plan_label="Pro",
-            tier="default_claude_pro",
-            freshness_state="VALID",
-            freshness_hours=2.8,
-            used_pct_5h=42.0,
-            used_pct_7d=15.0,
-            snapshot_as_of="2026-05-31T12:11:00+00:00",
+        _table_row(
             reset_at_5h="2026-05-31T12:05:00+00:00",
             reset_at_7d="2026-06-04T08:00:00+00:00",
         ),
@@ -785,36 +661,6 @@ def test_rolling_legend_line_explains_both_windows():
     assert "5h" in legend and "7d" in legend and "rolling" in legend
 
 
-def test_render_stored_table_header_stays_compact_when_no_reset():
-    """The 5h%/7d% column headers stay compact (no ``(rolling)`` cram).
-
-    Width gripe #3: don't blow up the header. The rolling-contract
-    disclosure now lives in a one-line legend printed by the CLI
-    below the table; the table header is just ``5h%`` / ``7d%``.
-    """
-    # Arrange — neither row has reset_at.
-    rows = [
-        AccountRow(
-            name="work",
-            email="w@example.com",
-            plan_label="Pro",
-            tier="default_claude_pro",
-            freshness_state="VALID",
-            freshness_hours=2.8,
-            used_pct_5h=42.0,
-            used_pct_7d=15.0,
-            snapshot_as_of="2026-05-31T12:11:00+00:00",
-            reset_at_5h=None,
-            reset_at_7d=None,
-        ),
-    ]
-    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
-    # Act
-    out = render_stored_table_to_str(rows, now=now)
-    # Assert — bare headers; no ``(rolling)`` smashed into the column.
-    assert "5h% (rolling)" not in out and "7d% (rolling)" not in out
-
-
 # ---------------------------------------------------------------------------
 # Gripe #1 of the 2026-06-09 operator ask: ``As-of`` was unreadable.
 # Pin the renamed header on both sides — the new name MUST appear and
@@ -826,19 +672,7 @@ def test_render_stored_table_header_stays_compact_when_no_reset():
 
 def _build_last_update_header_inputs() -> tuple[list[AccountRow], datetime]:
     """Arrange helper: build the (rows, now) pair for the header-rename cases."""
-    rows = [
-        AccountRow(
-            name="work",
-            email="w@example.com",
-            plan_label="Pro",
-            tier="default_claude_pro",
-            freshness_state="VALID",
-            freshness_hours=2.8,
-            used_pct_5h=42.0,
-            used_pct_7d=15.0,
-            snapshot_as_of="2026-05-31T12:11:00+00:00",
-        ),
-    ]
+    rows = [_table_row()]
     now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
     return rows, now
 
@@ -863,38 +697,29 @@ def test_render_stored_table_header_omits_legacy_as_of():
     assert "As-of" not in out
 
 
-def test_render_stored_table_width_fits_120_cols(env_save_restore):
-    """Operator gripe #3: the table must stay readable on ~120 cols.
+def test_render_stored_table_width_fits_80_cols(env_save_restore):
+    """Operator gripe 2026-07-11: the old 7-column table wrapped horribly.
 
-    Renders a representative row with both reset hints + day-hour
-    Last-Update + multi-character TTL. Each line of the rich-drawn
-    table must fit within the explicit 120-column width budget the
-    renderer is asked to honour.
+    The deduped 3-column table (Account | Status | Last Update) must
+    fit a standard 80-column terminal even with a real-length account
+    slug, a multi-character TTL and a day-hour Last-Update cell.
     """
-    # Arrange — JST so the reset hints carry the operator's wall clock.
+    # Arrange — JST so Last-Update carries the operator's wall clock.
     env_save_restore.set("TZ", "Asia/Tokyo")
     rows = [
-        AccountRow(
+        _table_row(
             name="ywatanabe-scitex-ai",
-            email="ywatanabe@scitex.ai",
-            plan_label="Max 20x",
-            tier="default_claude_max_20x",
-            freshness_state="VALID",
-            freshness_hours=2.8,
-            used_pct_5h=42.0,
-            used_pct_7d=15.0,
-            snapshot_as_of="2026-05-31T12:11:00+00:00",
             reset_at_5h="2026-05-31T12:05:00+00:00",
             reset_at_7d="2026-06-04T08:00:00+00:00",
         ),
     ]
     now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
     # Act
-    out = render_stored_table_to_str(rows, now=now, width=120)
+    out = render_stored_table_to_str(rows, now=now, width=80)
     lines = out.splitlines()
-    # Assert — every rendered line must fit in 120 columns.
-    over = [(i, len(ln)) for i, ln in enumerate(lines) if len(ln) > 120]
-    assert not over, f"lines exceed 120 cols: {over}\n---\n{out}"
+    # Assert — every rendered line must fit in 80 columns.
+    over = [(i, len(ln)) for i, ln in enumerate(lines) if len(ln) > 80]
+    assert not over, f"lines exceed 80 cols: {over}\n---\n{out}"
 
 
 # ---------------------------------------------------------------------------
@@ -1149,8 +974,8 @@ def test_cli_list_human_renders_table_columns(sandbox_home):
     runner = CliRunner()
     # Act
     result = runner.invoke(account, ["list"])
-    # Assert — column headers from the rich table.
-    for col in ("ID", "Email", "Plan", "Status(+TTL)", "5h%", "7d%", "Last Update"):
+    # Assert — the 2026-07-11 three-column contract from the rich table.
+    for col in ("Account", "Status", "Last Update"):
         assert col in result.output, f"missing column {col!r}:\n{result.output}"
 
 
@@ -1300,11 +1125,13 @@ def test_cli_list_json_carries_through_reset_at_7d(sandbox_home):
 def test_cli_list_human_shows_reset_hint_when_cache_has_reset_at(sandbox_home):
     """End-to-end: cache → renderer → operator sees ``42% (→...)``.
 
-    The bullet-2 contract of the 2026-06-09 task: when the per-account
-    cache carries ``reset_at_5h``, the human-rendered table cell must
-    show the inline reset hint. We don't pin a specific local time
-    (tests run on hosts in arbitrary timezones) — only the arrow
-    marker, which is the renderer's unambiguous reset signal.
+    Gripe #2 of the 2026-06-09 task, relocated by the 2026-07-11
+    dedupe directive: when the per-account cache carries
+    ``reset_at_5h``, the human output must show the inline reset hint
+    — now on the usage-bars line rather than a table cell. We don't
+    pin a specific local time (tests run on hosts in arbitrary
+    timezones) — only the arrow marker, which is the renderer's
+    unambiguous reset signal.
     """
     # Arrange — full account + a credentials snapshot so the live
     # fetcher path is taken; with no real OAuth token the fetcher
@@ -1321,5 +1148,5 @@ def test_cli_list_human_shows_reset_hint_when_cache_has_reset_at(sandbox_home):
     # operator. The exact local time depends on the host TZ; assert
     # on the marker shape so the test is timezone-independent.
     assert "(→" in result.output, (
-        f"missing inline reset hint in human table:\n{result.output}"
+        f"missing inline reset hint in human output:\n{result.output}"
     )

--- a/tests/scitex_agent_container/cli_pkg/test__account_usage_bars.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_usage_bars.py
@@ -131,6 +131,71 @@ def test_render_usage_bar_line_shows_7d_window():
     assert "7d [" in line and "99%" in line
 
 
+# ---------------------------------------------------------------------------
+# 2026-07-11 dedupe directive — the bars own the reset hints (moved off the
+# Stored-accounts table). Operator's verbatim example shape:
+#   ... 5h [..]  29% (→09:19)   7d [..]  66% (→Sun 21h)
+# ---------------------------------------------------------------------------
+
+
+def test_render_usage_bar_line_appends_5h_reset_hint():
+    # Arrange — pre-wrapped hints as the block passes them.
+    label = "acct"
+    # Act
+    line = render_usage_bar_line(
+        label,
+        29.0,
+        66.0,
+        label_width=10,
+        width=20,
+        hint_5h="(→09:19)",
+        hint_7d="(→Sun 21h)",
+    )
+    # Assert — operator's verbatim 5h shape.
+    assert "29% (→09:19)" in line
+
+
+def test_render_usage_bar_line_appends_7d_reset_hint():
+    # Arrange
+    label = "acct"
+    # Act
+    line = render_usage_bar_line(
+        label,
+        29.0,
+        66.0,
+        label_width=10,
+        width=20,
+        hint_5h="(→09:19)",
+        hint_7d="(→Sun 21h)",
+    )
+    # Assert — operator's verbatim 7d shape.
+    assert "66% (→Sun 21h)" in line
+
+
+def test_render_usage_bar_line_without_hints_has_no_parens():
+    """No cached reset → no fabricated hint; the line stays hint-free."""
+    # Arrange
+    label = "acct"
+    # Act
+    line = render_usage_bar_line(label, 14.0, 99.0, label_width=10, width=20)
+    # Assert
+    assert "(" not in line
+
+
+def test_render_usage_bar_line_pads_missing_5h_hint_to_block_width():
+    """A hint-less row pads the 5h slot so the 7d bars stay aligned."""
+    # Arrange — a sibling row in the block has an 8-char 5h hint.
+    with_hint = render_usage_bar_line(
+        "aa", 29.0, 66.0, label_width=4, width=20, hint_5h="(→09:19)", hint_5h_width=8
+    )
+    # Act
+    without_hint = render_usage_bar_line(
+        "bbbb", 14.0, 15.0, label_width=4, width=20, hint_5h="", hint_5h_width=8
+    )
+    # Assert — "7d [" starts at the same column in both lines.
+    assert with_hint.index("7d [") == without_hint.index("7d [")
+
+
 def test_render_usage_bars_block_empty_rows_is_empty_string():
     # Arrange
     rows: list[AccountRow] = []
@@ -145,9 +210,6 @@ def _two_bar_rows() -> list[AccountRow]:
     return [
         AccountRow(
             name="wyusuuke-gmail-com",
-            email="w@x",
-            plan_label="Max 20x",
-            tier="t",
             freshness_state="VALID",
             freshness_hours=2.0,
             used_pct_5h=0.0,
@@ -156,9 +218,6 @@ def _two_bar_rows() -> list[AccountRow]:
         ),
         AccountRow(
             name="ywata1989-gmail-com",
-            email="y@x",
-            plan_label="Pro",
-            tier="t",
             freshness_state="VALID",
             freshness_hours=2.0,
             used_pct_5h=14.0,
@@ -183,9 +242,6 @@ def test_render_usage_bars_block_no_data_row_renders_placeholder():
     rows = [
         AccountRow(
             name="cold",
-            email="c@x",
-            plan_label="?",
-            tier="?",
             freshness_state="ABSENT",
             freshness_hours=None,
             used_pct_5h=None,
@@ -197,6 +253,67 @@ def test_render_usage_bars_block_no_data_row_renders_placeholder():
     block = render_usage_bars_block(rows)
     # Assert
     assert "no data" in block
+
+
+def _hinted_bar_rows() -> list[AccountRow]:
+    """One row with both resets cached, one with neither (mixed block)."""
+    return [
+        AccountRow(
+            name="wyusuuke-gmail-com",
+            freshness_state="VALID",
+            freshness_hours=2.4,
+            used_pct_5h=29.0,
+            used_pct_7d=66.0,
+            snapshot_as_of=None,
+            # Sun 2026-07-12 00:19 UTC = 09:19 JST; 12:00 UTC = Sun 21h JST.
+            reset_at_5h="2026-07-12T00:19:00+00:00",
+            reset_at_7d="2026-07-12T12:00:00+00:00",
+        ),
+        AccountRow(
+            name="ywata1989-gmail-com",
+            freshness_state="VALID",
+            freshness_hours=2.0,
+            used_pct_5h=14.0,
+            used_pct_7d=15.0,
+            snapshot_as_of=None,
+        ),
+    ]
+
+
+def test_render_usage_bars_block_carries_5h_reset_hint(env_save_restore):
+    """Block-level: ``reset_at_5h`` renders the operator's ``29% (→09:19)``."""
+    # Arrange
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    rows = _hinted_bar_rows()
+    # Act
+    block = render_usage_bars_block(rows, width=20)
+    # Assert
+    assert "29% (→09:19)" in block
+
+
+def test_render_usage_bars_block_carries_7d_reset_hint(env_save_restore):
+    """Block-level: ``reset_at_7d`` renders the operator's ``66% (→Sun 21h)``."""
+    # Arrange
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    rows = _hinted_bar_rows()
+    # Act
+    block = render_usage_bars_block(rows, width=20)
+    # Assert
+    assert "66% (→Sun 21h)" in block
+
+
+def test_render_usage_bars_block_aligns_7d_bars_across_mixed_hints(
+    env_save_restore,
+):
+    """A hint-less row pads its 5h slot — 7d bars align across the block."""
+    # Arrange
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    rows = _hinted_bar_rows()
+    # Act
+    block = render_usage_bars_block(rows, width=20)
+    starts = {ln.index("7d [") for ln in block.splitlines() if "7d [" in ln}
+    # Assert — one distinct start column means the 7d bars line up.
+    assert len(starts) == 1, f"7d bars misaligned across rows: {starts}\n{block}"
 
 
 # ---------------------------------------------------------------------------
@@ -316,9 +433,6 @@ def test_fleet_effective_all_none_counts_zero():
 def _row(name: str, d7: float | None, reset_at_7d: str | None) -> AccountRow:
     return AccountRow(
         name=name,
-        email=f"{name}@x",
-        plan_label="Pro",
-        tier="t",
         freshness_state="VALID",
         freshness_hours=2.0,
         used_pct_5h=0.0,

--- a/tests/scitex_agent_container/cli_pkg/test_account_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_account_group.py
@@ -266,7 +266,9 @@ def test_account_list_shows_first_account_name(sandbox_home):
     assert "work" in result.output
 
 
-def test_account_list_shows_first_account_email(sandbox_home):
+def test_account_list_omits_stored_email(sandbox_home):
+    """Operator directive 2026-07-11: IDs are email-derived slugs, so the
+    stored-account email renders in ``--json`` only — never in the table."""
     # Arrange
     save_account("work", {"email_address": "w@example.com"}, home=sandbox_home)
     save_account("personal", {}, home=sandbox_home)
@@ -274,7 +276,7 @@ def test_account_list_shows_first_account_email(sandbox_home):
     # Act
     result = runner.invoke(account, ["list"])
     # Assert
-    assert "w@example.com" in result.output
+    assert "w@example.com" not in result.output
 
 
 def test_account_list_shows_second_account_name(sandbox_home):
@@ -288,7 +290,8 @@ def test_account_list_shows_second_account_name(sandbox_home):
     assert "personal" in result.output
 
 
-def test_account_list_uses_no_email_placeholder(sandbox_home):
+def test_account_list_omits_no_email_placeholder(sandbox_home):
+    """With the Email column gone (2026-07-11), its placeholder is gone too."""
     # Arrange
     save_account("work", {"email_address": "w@example.com"}, home=sandbox_home)
     save_account("personal", {}, home=sandbox_home)
@@ -296,7 +299,7 @@ def test_account_list_uses_no_email_placeholder(sandbox_home):
     # Act
     result = runner.invoke(account, ["list"])
     # Assert
-    assert "(no email)" in result.output
+    assert "(no email)" not in result.output
 
 
 def test_account_list_json_exits_zero(sandbox_home):
@@ -734,7 +737,9 @@ def _write_plan_snapshot(home: Path, name: str, *, subscription: str, tier: str)
     )
 
 
-def test_account_list_human_shows_offline_plan_label(sandbox_home):
+def test_account_list_human_omits_plan_label(sandbox_home):
+    """Operator directive 2026-07-11: Plan is ``--json``-only — never in
+    the human view (neither table nor bars)."""
     # Arrange
     _write_plan_snapshot(
         sandbox_home, "work", subscription="max", tier="default_claude_max_20x"
@@ -743,7 +748,7 @@ def test_account_list_human_shows_offline_plan_label(sandbox_home):
     # Act
     result = runner.invoke(account, ["list"])
     # Assert
-    assert "Max 20x" in result.output
+    assert "Max 20x" not in result.output
 
 
 def _invoke_account_list_with_no_usage_cache(sandbox_home) -> str:
@@ -755,35 +760,55 @@ def _invoke_account_list_with_no_usage_cache(sandbox_home) -> str:
     return runner.invoke(account, ["list"]).output
 
 
-def test_account_list_human_shows_5h_pct_column_when_no_cache(sandbox_home):
-    """Rich table emits the ``5h%`` column header even when usage is absent."""
+def test_account_list_human_omits_5h_pct_column(sandbox_home):
+    """The table has no ``5h%`` column since 2026-07-11 — bars own the %."""
     # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
     home = sandbox_home
     # Act
     output = _invoke_account_list_with_no_usage_cache(home)
     # Assert
-    assert "5h%" in output
+    assert "5h%" not in output
 
 
-def test_account_list_human_shows_7d_pct_column_when_no_cache(sandbox_home):
-    """Rich table emits the ``7d%`` column header even when usage is absent."""
+def test_account_list_human_shows_5h_bar_when_no_cache(sandbox_home):
+    """The usage-bars block emits a 5h bar even when usage is absent."""
     # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
     home = sandbox_home
     # Act
     output = _invoke_account_list_with_no_usage_cache(home)
     # Assert
-    assert "7d%" in output
+    assert "5h [" in output
 
 
-def test_account_list_human_shows_dash_cells_when_no_cache(sandbox_home):
-    """Empty-data cells render as ``-`` (rich table) when usage is absent."""
+def test_account_list_human_shows_7d_bar_when_no_cache(sandbox_home):
+    """The usage-bars block emits a 7d bar even when usage is absent."""
     # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
     home = sandbox_home
     # Act
     output = _invoke_account_list_with_no_usage_cache(home)
-    # Assert — the prior ``usage: —`` was a flat-line format; the new
-    # renderer emits one cell per metric, with ``-`` for missing values.
+    # Assert
+    assert "7d [" in output
+
+
+def test_account_list_human_shows_dash_last_update_when_no_cache(sandbox_home):
+    """The Last Update cell renders ``-`` (rich table) when usage is absent."""
+    # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
+    home = sandbox_home
+    # Act
+    output = _invoke_account_list_with_no_usage_cache(home)
+    # Assert — no snapshot → the Last Update cell is a bare dash.
     assert " - " in output
+
+
+def test_account_list_human_prints_legend_after_bars_when_no_reset(sandbox_home):
+    """With no cached reset timestamps the rolling-window legend prints
+    BELOW the usage-bars block it explains (2026-07-11 relocation)."""
+    # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
+    home = sandbox_home
+    # Act
+    output = _invoke_account_list_with_no_usage_cache(home)
+    # Assert — bars section first, legend after it.
+    assert output.index("Usage bars") < output.index("Legend:")
 
 
 def test_account_list_json_includes_plan_label(sandbox_home):


### PR DESCRIPTION
## Summary

Operator UX directive (2026-07-11 07:30 JST, verbatim): "Stored accounts と Usage bars で duplicated info を出すな / Usage bars で書けないものだけ Stored Accounts に書け / ID <-> Email 対応は要らない；Plan もいらない"

Presentation-layer only — the `sac accounts list --json` schema is untouched (still carries `email_address`, `plan_label`, raw usage payload).

- **Stored-accounts table → exactly `Account | Status | Last Update`.** Email column dropped (IDs are email-derived slugs), Plan dropped, 5h%/7d% columns dropped (they duplicated the bars and wrapped the table at normal terminal widths). Status keeps the live token TTL (`VALID +2h26m`).
- **Usage bars own the percentages and gain the compact reset hints** that used to clutter the table cells: `29% (→09:19)` / `66% (→Sun 21h)`, matching the operator's verbatim example. A row missing its 5h hint is space-padded so the 7d bars stay vertically aligned. The `(in Xh Ym)` countdown qualifier was dropped together with the table cells it annotated (bars stay compact per the example).
- Rolling-window legend now prints below the bars (the surface it explains); `Fleet effective utilization` footer unchanged; the single-account "Claude Code account" header block untouched.
- `account_group.py` was at the 512-line cap, so the `list` command body moved to `cli_pkg/_account_list_cmd.py` (`register_list_command`), the same extraction pattern as `_account_refresh.py` / `_account_login.py`.
- `AccountRow` drops the now-unrendered `email` / `plan_label` / `tier` fields; `build_stored_rows` no longer does the per-account plan read (JSON path keeps its own).

## Before (real render, develop @ b01af884, 120-col budget)

```text
Stored accounts
┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃ ID                ┃ Email            ┃ Plan     ┃ Status(+TTL) ┃               5h% ┃              7d% ┃ Last Update  ┃
┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ wyusuuke-gmail-c… │ wyusuuke@gmail.… │ Max 20x  │ VALID +2h26m │   29% (→09:19 (in │    66% (→Sun 21h │ Sat 16h (3m) │
│                   │                  │          │              │       1d 1h 33m)) │ (in 1d 13h 14m)) │              │
│ ywatanabe-scitex… │ ywatanabe@scite… │ Max 20x  │ VALID +1h12m │               14% │    15% (→Mon 09h │ Sat 16h (5m) │
│                   │                  │          │              │                   │  (in 2d 1h 14m)) │              │
│ ywata1989-gmail-… │ ywata1989@gmail… │ Pro      │ ABSENT       │                 - │                - │ -            │
└───────────────────┴──────────────────┴──────────┴──────────────┴───────────────────┴──────────────────┴──────────────┘

Usage bars (5h / 7d out of 100%):
  wyusuuke-gmail-com   5h [██████░░░░░░░░░░░░░░]  29%   7d [█████████████░░░░░░░]  66%
  ywatanabe-scitex-ai  5h [███░░░░░░░░░░░░░░░░░]  14%   7d [███░░░░░░░░░░░░░░░░░]  15%
  ywata1989-gmail-com  5h [      no data       ]    ?   7d [      no data       ]    ?
Legend: 5h = rolling 5-hour window; 7d = rolling 7-day window. (→HH:MM / →Day HHh next to the % marks the next reset.)
Fleet effective utilization: 7% (2 accounts)
```

Every ID/email truncated, 5h%/7d% cells wrap onto two lines, and the same percentages appear twice.

## After (real render, this branch, same data)

```text
Stored accounts
┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃ Account             ┃ Status       ┃ Last Update  ┃
┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ wyusuuke-gmail-com  │ VALID +2h26m │ Sat 16h (3m) │
│ ywatanabe-scitex-ai │ VALID +1h12m │ Sat 16h (5m) │
│ ywata1989-gmail-com │ ABSENT       │ -            │
└─────────────────────┴──────────────┴──────────────┘

Usage bars (5h / 7d out of 100%):
  wyusuuke-gmail-com   5h [██████░░░░░░░░░░░░░░]  29% (→09:19)   7d [█████████████░░░░░░░]  66% (→Sun 21h)
  ywatanabe-scitex-ai  5h [███░░░░░░░░░░░░░░░░░]  14%            7d [███░░░░░░░░░░░░░░░░░]  15% (→Mon 09h)
  ywata1989-gmail-com  5h [      no data       ]    ?            7d [      no data       ]    ?
Legend: 5h = rolling 5-hour window; 7d = rolling 7-day window. (→HH:MM / →Day HHh next to the % marks the next reset.)
Fleet effective utilization: 7% (2 accounts)
```

## Testing

- `tests/scitex_agent_container/cli_pkg/test__account_list_render.py` + `test__account_usage_bars.py` + `test_account_group.py`: **165 passed** (new contract pinned: 3-column headers, Email/Plan/%/hint omission from the table, bar-line hints incl. the operator's exact `29% (→09:19)` / `66% (→Sun 21h)` shapes, mixed-hint 7d alignment, legend-below-bars ordering, 80-col table width budget).
- `tests/scitex_agent_container/_account/test_credentials.py` (JSON-path schema stability): **134 passed**.
- `scitex-dev ecosystem audit-all scitex-agent-container --path <worktree>`: audit-mcp-tools / audit-skills / audit-python-apis / audit-project all SUCC. `audit-cli` reports `not-auditable: unknown` in this container (auditor cannot resolve the installed CLI dist; not caused by this change — no CLI nouns/verbs were added or renamed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
