### PR TITLE
release: v0.21.13 — bump + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.13] — 2026-07-11
+
+First PyPI release since 0.21.11. v0.21.12 is a ghost tag (like v0.21.10
+before it): its self-hosted release pipeline failed on a since-fixed
+audit finding and nothing was published; its content (explicit spec
+fields, no hidden defaults) ships here. This release also carries the
+2026-07-10/11 incident-response wave.
+
+### Fixed
+- **Account-pool outage root cause** (#610): the OAuth token-refresh
+  endpoint moved (`console.anthropic.com` → `platform.claude.com`);
+  every refresh 404'd and was misreported as "refresh token rejected".
+  Correct URL + `$SAC_ANTHROPIC_OAUTH_TOKEN_URL` override, honest
+  transport-vs-rejected failure classes, loud per-account refresh
+  alarms on every timer run, self-diagnosing picker errors, and the
+  credential bind flipped `:ro` → `:rw`.
+- **Quota-aware account pick** (#611): avoid 5h-blocked and
+  7d-near-capped accounts; load-balance the fleet per agent.
+- **`sac accounts list` dedupe** (#614): usage bars own the
+  percentages (now with compact reset hints); the table slims to
+  Account | Status | Last Update; Email/Plan columns removed.
+
+### Added
+- **`sac accounts login <name>`** (#608): semi-automated `claude /login`
+  re-auth — only the browser-authorize step stays human.
+- **Host-field routing** (#609): `host: local` banned with migration
+  hints; `${HOSTNAME}` load-time resolution; transparent remote
+  dispatch for lifecycle verbs when `spec.host` names a registered
+  peer; fail-loud on unknown hosts.
+- **Heavy-job demotion guard** (#612, P1 incident closure): baseline
+  hook blocking undemoted image builds/mksquashfs/mass compression
+  with the corrected `nice -n 19 ionice -c 2 -n 7` education; builds
+  self-demote by default (#605) and warn remote-first under load.
+- **Twin spawning** (#613): context-inheriting fork of a running agent
+  (CLI verb + MCP tool + skill + ADR) — ephemeral cleaners or
+  persistent companions; twins write under their own name.
+- **Deterministic CCT bot-token pool injection** (#615): agent start
+  resolves the Telegram bot token from the pool into `$HOME/.env`
+  (0600, never argv, never logged); loud error naming the pool source
+  when a channel-requesting spec has no token. Root `.envrc` untracked
+  from the public repo (`.envrc.example` ships instead).
+
+### Changed
+- **Release pipeline moved to GitHub-hosted runners** (#616): the
+  Spartan self-hosted SIF pipeline was a fail-quiet dependency;
+  publishing now uses standard PyPI OIDC trusted publishing
+  (org-transfer publisher config fixed 2026-07-11).
+- **Load-time advisories route through scitex-logging** (#607) for
+  consistent fleet-wide warning/error color coding.
+
 ## [0.21.11] — 2026-06-09
 
 PATCH release. Re-cut of v0.21.10's accounts-list redesign after the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.12"
+version = "0.21.13"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump 0.21.12 → 0.21.13 + CHANGELOG entry covering the 2026-07-10/11 incident-response wave (OAuth endpoint root fix, quota-aware pick, host routing, heavy-job guard, twin spawning, bot-token pool injection, accounts-list dedupe, GitHub-hosted release pipeline). v0.21.12 documented as a ghost tag per the v0.21.10 precedent.

Tag v0.21.13 will be pushed on develop AFTER this and the four wave PRs (twin spawning #613, accounts-list dedupe #614, bot-token pool #615, release-pipeline move #616) are all merged — the tag then fires the new GitHub-hosted release workflow (test → build → PyPI OIDC publish → GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)