### PR TITLE
fix(creds): host-side quota-cache fallback + runtime-convention canonical

### DIFF
--- a/src/scitex_agent_container/_account/quota_cache.py
+++ b/src/scitex_agent_container/_account/quota_cache.py
@@ -60,11 +60,58 @@ META_KEY_PCT_7D = "used_pct_7d"
 META_KEY_TTL_H = "token_ttl_hours"
 
 
+# Host-side quota-cache locations, most-canonical first. sac's quota cache
+# is sac RUNTIME STATE, so its home is under sac's OWN runtime dir
+# (``~/.scitex/agent-container/runtime/``) per the constitution §3
+# per-package runtime convention — NOT the shared ``~/.scitex`` root
+# (operator, 2026-07-11: "sac 管轄で使うランタイム state … .scitex 以下に
+# 直で置くな"). The legacy top-level path is kept as a transitional
+# back-compat read until the populator + apptainer bind are migrated too
+# (tracked separately so the bind move can't strand running containers).
+HOST_RUNTIME_CACHE_SUBPATH = (
+    Path(".scitex") / "agent-container" / "runtime" / "quota-cache.json"
+)
+LEGACY_HOST_CACHE_SUBPATH = Path(".scitex") / "quota-cache.json"
+
+
+def host_cache_candidates(home: Path | None = None) -> tuple[Path, ...]:
+    """Ordered host quota-cache paths, canonical (runtime) first, legacy last."""
+    _home = home if home is not None else Path.home()
+    return (
+        _home / HOST_RUNTIME_CACHE_SUBPATH,
+        _home / LEGACY_HOST_CACHE_SUBPATH,
+    )
+
+
+def _first_existing(paths: tuple[Path, ...]) -> Path | None:
+    for p in paths:
+        if p.exists():
+            return p
+    return None
+
+
 def _resolve_cache_path(override: Path | str | None) -> Path:
     if override is not None:
         return Path(override)
     env_path = os.environ.get(ENV_QUOTA_CACHE_PATH, "").strip()
-    return Path(env_path) if env_path else Path(DEFAULT_QUOTA_CACHE_PATH)
+    if env_path:
+        return Path(env_path)
+    # No override / env. The reader's historical default is the in-container
+    # bind path (/var/sac/quota-cache.json). But the SAME reader runs HOST-side
+    # for every `sac agents start` / `sac account quota` the operator (or the
+    # listen daemon) invokes — and on the host that bind path does NOT exist,
+    # so without a fallback the picker reads "5h=? 7d=?" for every account and
+    # can no longer avoid a quota-blocked one (2026-07-11 incident: host
+    # `sac-start` landed agents on the 5h-exhausted account). Fail-INFORMED,
+    # not fail-open (constitution §2): container bind first (freshest inside a
+    # capsule), then the host runtime canonical, then the legacy path; only if
+    # none exist return the container default so the caller degrades to an
+    # honest None.
+    container = Path(DEFAULT_QUOTA_CACHE_PATH)
+    if container.exists():
+        return container
+    host = _first_existing(host_cache_candidates())
+    return host if host is not None else container
 
 
 def _resolve_account(override: str | None) -> str:
@@ -267,5 +314,6 @@ __all__ = [
     "read_quota_entry",
     "build_a2a_metadata",
     "default_host_cache_path",
+    "host_cache_candidates",
     "write_quota_cache",
 ]

--- a/tests/scitex_agent_container/_account/test_quota_cache.py
+++ b/tests/scitex_agent_container/_account/test_quota_cache.py
@@ -28,7 +28,9 @@ from scitex_agent_container._account.quota_cache import (
     META_KEY_PCT_5H,
     META_KEY_PCT_7D,
     META_KEY_TTL_H,
+    _first_existing,
     build_a2a_metadata,
+    host_cache_candidates,
     read_quota_entry,
 )
 
@@ -353,6 +355,66 @@ def test_build_a2a_metadata_canonical_key_name(name: str, expected: str) -> None
     actual = getattr(module, name)
     # Assert
     assert actual == expected
+
+
+def test_host_cache_candidates_puts_runtime_convention_path_first(
+    tmp_path: Path,
+) -> None:
+    # Arrange — sac quota cache is sac runtime state; canonical home is the
+    # per-package runtime dir, NOT the shared ~/.scitex root (constitution §3;
+    # operator 2026-07-11). The 2026-07-11 incident was the reader ignoring
+    # this host path entirely and reading "?" on every host-side `sac-start`.
+    home = tmp_path
+    # Act
+    candidates = host_cache_candidates(home)
+    # Assert
+    assert candidates[0] == home / ".scitex" / "agent-container" / "runtime" / "quota-cache.json"
+
+
+def test_host_cache_candidates_keeps_legacy_path_as_backcompat_last(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the old top-level path stays readable during migration so a
+    # not-yet-moved populator's file still resolves.
+    home = tmp_path
+    # Act
+    candidates = host_cache_candidates(home)
+    # Assert
+    assert candidates[-1] == home / ".scitex" / "quota-cache.json"
+
+
+def test_first_existing_returns_runtime_path_over_legacy(tmp_path: Path) -> None:
+    # Arrange — both host files present; the runtime canonical must win.
+    runtime = tmp_path / ".scitex" / "agent-container" / "runtime" / "quota-cache.json"
+    legacy = tmp_path / ".scitex" / "quota-cache.json"
+    for p in (runtime, legacy):
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(SAMPLE), encoding="utf-8")
+    # Act
+    chosen = _first_existing(host_cache_candidates(tmp_path))
+    # Assert
+    assert chosen == runtime
+
+
+def test_first_existing_falls_back_to_legacy_when_only_legacy_present(
+    tmp_path: Path,
+) -> None:
+    # Arrange — only the legacy file exists (populator not yet migrated).
+    legacy = tmp_path / ".scitex" / "quota-cache.json"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text(json.dumps(SAMPLE), encoding="utf-8")
+    # Act
+    chosen = _first_existing(host_cache_candidates(tmp_path))
+    # Assert
+    assert chosen == legacy
+
+
+def test_first_existing_returns_none_when_no_host_file(tmp_path: Path) -> None:
+    # Arrange — a bare home with neither host file (fresh machine / CI).
+    # Act
+    chosen = _first_existing(host_cache_candidates(tmp_path))
+    # Assert
+    assert chosen is None
 
 
 def test_build_a2a_metadata_empty_dict_when_no_entry(clean_env, tmp_path: Path) -> None:


### PR DESCRIPTION
## Incident
Host-side `sac agents start` showed `picked usage 5h=? 7d=?` for every account, so the quota-conditional picker could not avoid a 5h-blocked account — it landed agents (scitex-hpc, scitex-todo) on the exhausted one. Root cause: the reader's no-env default is the in-container bind path `/var/sac/quota-cache.json`, which does not exist on the host; there was no host fallback.

## Fix
`_resolve_cache_path` (no override/env) now resolves in order: container bind → host runtime canonical → legacy host path → honest None. The canonical host location is `~/.scitex/agent-container/runtime/quota-cache.json` (constitution §3 per-package runtime convention — a file **directly** under `~/.scitex/` is itself a convention violation, per operator 2026-07-11). Legacy `~/.scitex/quota-cache.json` stays a transitional back-compat read. Pure helpers `host_cache_candidates()` / `_first_existing()`; 5 reality-based tests (real tmp files, no mocks/monkeypatch), 33 pass.

## Deploy
Host CLI runs from the editable checkout, so `git pull` on the host deploys this immediately — no SIF rebuild needed for the host picker.

## Follow-ups (carded separately)
- Migrate the populator + apptainer bind off the legacy top-level path to the runtime canonical (traced carefully so running containers aren't stranded).
- Fleet audit + scitex-dev audit rule: no package writes directly under `~/.scitex/` — only `~/.scitex/<pkg>/runtime/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)