### PR TITLE
fix(tests): load-independent floors for parallel-start timing (unblock v0.21.13)

### DIFF
--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_parallel.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_parallel.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os
 import stat
+import time
 from pathlib import Path
 
 import pytest
@@ -172,25 +173,36 @@ class TestRunParallelTargets:
         assert attempted == set(targets)
 
     def test_concurrency_cap_respected(self, sac_shim):
-        # Arrange — cap=2 with 4 targets each sleeping 0.5s: the 3rd
-        # launch cannot START until one of the first two has finished,
-        # so its timestamp is >= ~0.5s after the earliest.
+        # Arrange — cap=2 over 4 targets, each child sleeping 0.5s, forces
+        # TWO serial waves ({a,b} then {c,d}), so the whole call takes
+        # >= ~1.0s; an unbounded pool would finish the single wave in ~0.5s.
         targets = ["a", "b", "c", "d"]
-        # Act
+        # Act — assert the wall-clock FLOOR, not per-child exec-time gaps.
+        # The floor is load-independent (load only makes children slower, so
+        # elapsed only grows); the old starts[2]-starts[0] exec-gap flaked in
+        # the CI SIF when a cold first child started slower than a warm third.
+        t0 = time.monotonic()
         run_parallel_targets(targets, **_kwargs(concurrency=2, stagger=0.0))
-        # Assert
-        starts = sorted(ts for ts, _ in _read_calls(sac_shim))
-        assert starts[2] - starts[0] >= 400
+        elapsed = time.monotonic() - t0
+        # Assert — two waves of a 0.5s child => >= ~1.0s (0.9s tolerance).
+        assert elapsed >= 0.9
 
     def test_stagger_spacing_applied(self, sac_shim):
-        # Arrange — stagger=0.3s between submissions with ample
-        # concurrency: consecutive launches are at least ~0.3s apart.
+        # Arrange — stagger=0.3s between submissions. run_parallel_targets
+        # sleeps `stagger` in the MAIN thread between each pool.submit, so the
+        # whole call takes AT LEAST (N-1)*stagger regardless of child exec
+        # latency. That floor is load-independent (load only adds); measuring
+        # the per-child exec-time gap instead (the old starts[1]-starts[0])
+        # flaked in the CI SIF when a cold first child ran slower than a warm
+        # second, compressing the measured gap below the real submission spacing.
         targets = ["a", "b", "c"]
+        stagger = 0.3
         # Act
-        run_parallel_targets(targets, **_kwargs(concurrency=3, stagger=0.3))
-        # Assert
-        starts = sorted(ts for ts, _ in _read_calls(sac_shim))
-        assert starts[1] - starts[0] >= 250
+        t0 = time.monotonic()
+        run_parallel_targets(targets, **_kwargs(concurrency=3, stagger=stagger))
+        elapsed = time.monotonic() - t0
+        # Assert — cumulative stagger floor: (N-1) sleeps of `stagger`.
+        assert elapsed >= (len(targets) - 1) * stagger - 0.05
 
     def test_nonzero_exit_when_a_target_fails(self, sac_shim):
         # Arrange — the ``boom`` target makes the shim exit 7; capture the


### PR DESCRIPTION
## Why
The v0.21.13 release run (Spartan CI SIF) failed on one flaky test:
```
FAILED test__start_parallel.py::test_stagger_spacing_applied
  - assert (… - …) >= 250   # measured 163ms; py3.13 passed, 3.11/3.12 failed
```
It (and its sibling `test_concurrency_cap_respected`) asserted the gap between child subprocess **exec** times (shim-recorded). Under SIF load a cold first child starts slower than a warm later one, compressing the measured exec-gap below the real spacing the code applies. The GitHub-hosted PR matrix couldn't catch it (passed 3.12 there); only the loaded SIF exposed it.

## Fix
The stagger and cap invariants are guaranteed by **main-thread sleeps** and the pool cap, so assert the wall-clock **floor** — load can only push elapsed *up*, never below it:
- stagger: `elapsed >= (N-1)*stagger` (cumulative inter-submit sleeps)
- cap=2 over 4× 0.5s children ⇒ two serial waves ⇒ `elapsed >= 0.9s`

Same load-independent philosophy as #622; covers the two timing tests #622 missed. **No mocks** — preserves the file's real-subprocess contract.

## Verified
17/17 local (py3.12, working interpreter). The real gate is the SIF re-run after merge.

Test-only; no production source touched.