### PR TITLE
fix(listen): resolve sac binary via sys.executable, not systemd PATH

### DIFF
--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -16,11 +16,11 @@ import path keeps working unchanged.
 from __future__ import annotations
 
 import os
-import shutil
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from .._sac_binary import SacBinaryNotFoundError, sac_binary
 from ._acl import check_spawn, deny_response
 from ._agent_exec_liveness import _probe_post_ack_liveness
 from ._agent_exec_send import _find_claude_binary, agent_send
@@ -158,7 +158,18 @@ async def agents_start(request: Request) -> JSONResponse:
             # to a different caller is loudly rejected.
             return JSONResponse({"error": str(exc)}, status_code=409)
 
-    sac_bin = shutil.which("sac") or "sac"
+    try:
+        sac_bin = sac_binary()
+    except SacBinaryNotFoundError as exc:
+        # Resolution-time failure (bug root cause, see _sac_binary.py):
+        # surface a structured, diagnosable error instead of building an
+        # unresolvable argv that would later die deep inside a subprocess
+        # call as an opaque FileNotFoundError / 500. Shape mirrors
+        # ``host_exec``'s error responses (``_host_exec.py``).
+        return JSONResponse(
+            {"name": name, "error": f"{type(exc).__name__}: {exc}"},
+            status_code=500,
+        )
     # ``agents`` (plural) is the canonical command group; the singular
     # ``agent`` form was removed in the F-CS13 rename and the host CLI
     # no longer exposes it (verified 2026-06-01 by the SAC-from-SAC
@@ -220,12 +231,23 @@ async def agents_start(request: Request) -> JSONResponse:
     # would serialize everything for no safety gain).
     from ._credential_refresh_lock import run_brokered_launch
 
-    proc = await run_brokered_launch(
-        inner_argv,
-        child_env,
-        foreground=bool(foreground),
-        one_shot=bool(one_shot),
-    )
+    try:
+        proc = await run_brokered_launch(
+            inner_argv,
+            child_env,
+            foreground=bool(foreground),
+            one_shot=bool(one_shot),
+        )
+    except OSError as exc:
+        # Launch-time failure (e.g. the resolved sac_bin vanished between
+        # resolution and exec, or any other subprocess-creation error).
+        # Never let this propagate as an unhandled exception → opaque
+        # framework 500; surface it structured, same shape as the
+        # resolution-failure branch above / host_exec's error responses.
+        return JSONResponse(
+            {"name": name, "error": f"{type(exc).__name__}: {exc}"},
+            status_code=500,
+        )
     if proc.returncode != 0:
         # PR-1 — stillborn agent observability. The subprocess can exit
         # non-zero for many reasons, including apptainer FATAL on a bind

--- a/src/scitex_agent_container/_listen/_agent_restart.py
+++ b/src/scitex_agent_container/_listen/_agent_restart.py
@@ -28,11 +28,11 @@ from __future__ import annotations
 
 import asyncio
 import os
-import shutil
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from .._sac_binary import SacBinaryNotFoundError, sac_binary
 from ._acl import check_lineage_acl, deny_response
 
 __all__ = ["agent_restart"]
@@ -99,7 +99,18 @@ async def agent_restart(request: Request) -> JSONResponse:
     # / falsey) keeps the byte-identical plain-restart argv below.
     fresh = bool(body.get("fresh"))
 
-    sac_bin = shutil.which("sac") or "sac"
+    try:
+        sac_bin = sac_binary()
+    except SacBinaryNotFoundError as exc:
+        # Resolution-time failure (bug root cause, see _sac_binary.py):
+        # surface a structured, diagnosable error instead of building an
+        # unresolvable argv that would later die deep inside a subprocess
+        # call as an opaque FileNotFoundError / 500. Shape mirrors
+        # ``host_exec``'s error responses (``_host_exec.py``).
+        return JSONResponse(
+            {"name": name, "error": f"{type(exc).__name__}: {exc}"},
+            status_code=500,
+        )
     # ``agents`` (plural) is the canonical group; ``--yes`` skips the
     # interactive guard (this POST IS the confirmation) and ``--json``
     # gives a parseable envelope — exactly the argv ``agent_restart`` MCP
@@ -116,12 +127,23 @@ async def agent_restart(request: Request) -> JSONResponse:
     else:
         inner_argv = [sac_bin, "agents", "restart", name, "--yes", "--json"]
 
-    proc = await asyncio.create_subprocess_exec(
-        *inner_argv,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=child_env,
-    )
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *inner_argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=child_env,
+        )
+    except OSError as exc:
+        # Launch-time failure (e.g. the resolved sac_bin vanished between
+        # resolution and exec, or any other subprocess-creation error).
+        # Never let this propagate as an unhandled exception → opaque
+        # framework 500; surface it structured, same shape as the
+        # resolution-failure branch above / host_exec's error responses.
+        return JSONResponse(
+            {"name": name, "error": f"{type(exc).__name__}: {exc}"},
+            status_code=500,
+        )
     out, err = await proc.communicate()
     stdout = out.decode("utf-8", errors="replace") if out else ""
     stderr = err.decode("utf-8", errors="replace") if err else ""

--- a/src/scitex_agent_container/_listen/_restart.py
+++ b/src/scitex_agent_container/_listen/_restart.py
@@ -54,6 +54,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from .._sac_binary import SacBinaryNotFoundError, sac_binary
 from ._port_holder import (
     PortHealResult,
     clear_wedged_port_holders,
@@ -430,7 +431,10 @@ def restart_listen(
                 took_systemd_path=True,
             )
     else:
-        argv = sac_listen_argv or ["sac", "listen"]
+        try:
+            argv = sac_listen_argv or [sac_binary(), "listen"]
+        except SacBinaryNotFoundError as exc:
+            return _fail(error=f"cannot resolve sac binary: {exc}")
         try:
             _run_subprocess(
                 argv,

--- a/src/scitex_agent_container/_sac_binary.py
+++ b/src/scitex_agent_container/_sac_binary.py
@@ -1,0 +1,101 @@
+"""Single source of truth for resolving the ``sac`` executable path for
+subprocess/argv construction (as opposed to the SDK MCP-sidecar resolver in
+``runtimes/_sdk_channels.py::_resolve_sac_binary``, which has a different
+candidate list — ``$SAC_BIN`` env override + a known container path — and is
+not consulted here).
+
+BACKGROUND (incident 2026-07, ``sac-listen`` PATH bug): ``sac listen`` runs
+as a systemd ``--user`` service whose ``ExecStart`` uses an absolute path to
+the venv's ``sac`` binary — that part is correct. But code INSIDE the
+daemon that shells out to spawn/restart other agents used to resolve the
+child's ``sac`` via ``shutil.which("sac")``, which searches the DAEMON
+PROCESS's own ``PATH`` — i.e. systemd-user's default inherited PATH, which
+does NOT include the venv's ``bin/`` directory (systemd ``--user`` units
+never source ``~/.bashrc``/``~/.bash_profile``). When ``shutil.which("sac")``
+returned ``None``, the old code fell back to the literal string ``"sac"``,
+and the eventual ``subprocess.run(["sac", ...])`` died with
+``FileNotFoundError: [Errno 2] No such file or directory: 'sac'`` —
+uncaught, surfacing to HTTP callers as an opaque 500.
+
+This module fixes both halves of that bug:
+
+  1. Try ``shutil.which("sac")`` — the standard ``PATH`` lookup. In the
+     buggy systemd scenario this already returns ``None`` (that's the bug),
+     so this step is a no-op there; it exists so callers that legitimately
+     rely on ``PATH`` (a shell that sourced the right venv, or a test that
+     prepends a fake binary to ``PATH`` — see
+     ``tests/scitex_agent_container/_helpers/subprocess_shim.py``, used
+     throughout the ``_listen`` test suite) keep getting exactly what they
+     asked for.
+  2. Fall back to the executable NEXT TO ``sys.executable`` — this is
+     guaranteed to be the SAME venv the running process itself is in
+     (mirrors the pattern the systemd ``ExecStart=`` line already relies
+     on) and sidesteps ``PATH`` entirely. This is what actually fixes the
+     reported bug: under systemd ``--user``, step 1 fails, so this step
+     resolves the daemon's own venv ``sac`` regardless of the inherited
+     ``PATH``.
+  3. If NEITHER resolves, raise ``SacBinaryNotFoundError`` — a clear,
+     actionable error raised at RESOLUTION time, instead of silently
+     producing an unresolvable ``"sac"`` argv that only fails later, deep
+     inside a subprocess call, as an opaque ``FileNotFoundError``.
+
+Every call site in ``src/`` that used to write
+``shutil.which("sac") or "sac"`` (or an equivalent bare-``"sac"`` argv
+literal) should import :func:`sac_binary` from here instead.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+__all__ = ["SacBinaryNotFoundError", "sac_binary"]
+
+
+class SacBinaryNotFoundError(RuntimeError):
+    """Raised when the ``sac`` executable cannot be resolved.
+
+    Neither ``PATH`` nor a sibling of ``sys.executable`` found it — any
+    subprocess argv built from the caller would be unresolvable. Fix:
+    install ``sac`` into the current venv, or put it on ``PATH``.
+    """
+
+
+def sac_binary() -> str:
+    """Resolve a path to the ``sac`` executable for use as ``argv[0]`` of a
+    subprocess.
+
+    Resolution order (first hit wins):
+
+      1. ``shutil.which("sac")`` — standard ``PATH`` lookup.
+      2. ``Path(sys.executable).with_name("sac")`` — the sibling of the
+         CURRENT process's Python interpreter, i.e. the console script a
+         venv install places next to its ``python``. Consulted only when
+         step 1 misses, but this is exactly what makes the resolution
+         PATH-independent for the systemd ``--user`` case: the daemon's
+         inherited ``PATH`` lacks the venv's ``bin/``, ``shutil.which``
+         returns ``None``, and this fallback still finds the daemon's own
+         ``sac`` because it is colocated with ``sys.executable``
+         regardless of ``PATH``.
+
+    Raises
+    ------
+    SacBinaryNotFoundError
+        Neither candidate resolved. Fail loud here rather than let a bare
+        unresolvable ``"sac"`` string reach ``subprocess.run``/
+        ``subprocess.exec`` and die later as an opaque ``FileNotFoundError``.
+    """
+    found = shutil.which("sac")
+    if found:
+        return found
+
+    sibling = Path(sys.executable).with_name("sac")
+    if sibling.exists():
+        return str(sibling)
+
+    raise SacBinaryNotFoundError(
+        "cannot locate the 'sac' executable: not found next to "
+        f"sys.executable ({sys.executable!r}) and not on PATH. Install sac "
+        "into this interpreter's venv, or ensure it is on PATH."
+    )

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_parallel.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_parallel.py
@@ -32,7 +32,6 @@ one-shot / resume / dry-run / params-file) is in play.
 
 from __future__ import annotations
 
-import shutil
 import subprocess
 import sys
 import time
@@ -42,6 +41,7 @@ from typing import Callable
 
 import click
 
+from ..._sac_binary import sac_binary as _sac_binary
 from .._helpers import console
 
 
@@ -53,15 +53,6 @@ class _Result:
     returncode: int
     stdout: str
     stderr: str
-
-
-def _sac_binary() -> str:
-    """Resolve the ``sac`` entry point (PATH, else the literal name).
-
-    Mirrors ``_listen/_agent_exec.py::agents_start`` which uses
-    ``shutil.which("sac") or "sac"`` — the brokered-spawn call site.
-    """
-    return shutil.which("sac") or "sac"
 
 
 def build_child_argv(

--- a/tests/scitex_agent_container/test__sac_binary.py
+++ b/tests/scitex_agent_container/test__sac_binary.py
@@ -1,0 +1,146 @@
+"""Tests for the shared sac-executable resolver (``_sac_binary.py``).
+
+Regression coverage for the systemd ``--user`` PATH bug: ``sac listen``
+runs as a systemd ``--user`` service whose inherited PATH does not include
+the venv's ``bin/`` directory (systemd ``--user`` units never source
+``~/.bashrc``/``~/.bash_profile``). Code inside the daemon that shells out
+to spawn/restart other agents used to resolve the child ``sac`` via
+``shutil.which("sac") or "sac"``, silently falling back to an unresolvable
+bare ``"sac"`` argv that only died later, deep inside ``subprocess.run``,
+as an opaque ``FileNotFoundError`` — surfacing to HTTP callers as a bare
+500 with zero diagnostic detail.
+
+``sac_binary()`` fixes this by raising loudly, AT RESOLUTION TIME, when
+neither PATH nor a ``sys.executable`` sibling resolves — see
+``scitex_agent_container/_sac_binary.py`` for the full resolution-order
+rationale (PATH first so PATH-shimmed tests / non-venv installs keep
+working, then the ``sys.executable`` sibling, which is what actually
+fixes the systemd bug since PATH lookup already fails there).
+
+PA-306: no mocks / no ``monkeypatch`` fixture. Every fixture here is a
+plain save/restore of real process state (``os.environ["PATH"]``,
+``sys.executable``) — the same pattern ``tests/conftest.py``'s
+``env_save_restore`` fixture uses for env vars.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._sac_binary import SacBinaryNotFoundError, sac_binary
+
+
+@pytest.fixture
+def real_executable_save_restore():
+    """Save/restore ``sys.executable`` — no monkeypatch (PA-306).
+
+    ``sys.executable`` is process-global interpreter state; the resolver
+    reads it directly, so exercising the "no sibling sac" branch requires
+    pointing it at a controlled fake interpreter path for the test.
+    """
+    saved = sys.executable
+    try:
+        yield
+    finally:
+        sys.executable = saved
+
+
+@pytest.fixture
+def unresolvable_sac(tmp_path: Path, env_save_restore, real_executable_save_restore):
+    """Real PATH scrubbed to an empty dir + ``sys.executable`` pointed at
+    an interpreter with no sibling ``sac`` — the exact production failure
+    shape (systemd ``--user`` PATH lacks the venv's ``bin/``, so neither
+    resolution branch finds anything)."""
+    empty_bin = tmp_path / "empty_bin"
+    empty_bin.mkdir()
+    no_sac_dir = tmp_path / "no_sac_here"
+    no_sac_dir.mkdir()
+    fake_python = no_sac_dir / "python3"
+    fake_python.write_text("#!/bin/sh\n")
+    fake_python.chmod(0o755)
+    env_save_restore.set("PATH", str(empty_bin))
+    sys.executable = str(fake_python)
+
+
+class TestSacBinaryRaisesLoudly:
+    """The bug-fix contract: an unresolvable ``sac`` must raise, never
+    silently return a bare ``"sac"`` argv token."""
+
+    def test_raises_sac_binary_not_found(self, unresolvable_sac):
+        # Arrange — fixture scrubs PATH and points sys.executable at an
+        # interpreter dir with no sibling `sac` (the systemd --user
+        # daemon's actual failure shape).
+        # Act
+        # Assert
+        with pytest.raises(SacBinaryNotFoundError, match=r"(?i)sac"):
+            sac_binary()
+
+    def test_error_message_names_sys_executable(self, unresolvable_sac):
+        # Arrange — the message must name sys.executable so an operator
+        # can actually diagnose which interpreter/venv is missing `sac`.
+        expected = re.escape(sys.executable)
+        # Act
+        # Assert
+        with pytest.raises(SacBinaryNotFoundError, match=expected):
+            sac_binary()
+
+    def test_does_not_return_bare_sac_string(self, unresolvable_sac):
+        # Arrange
+        result: str | None
+        # Act — the historical bug: a silent fallback to the literal "sac"
+        # string, which then dies unresolvable deep inside subprocess.run.
+        try:
+            result = sac_binary()
+        except SacBinaryNotFoundError:
+            result = None
+        # Assert
+        assert result != "sac"
+
+
+class TestSacBinaryResolutionOrder:
+    """Both successful resolution branches, pinned independently."""
+
+    def test_resolves_via_path_when_sys_executable_has_no_sibling(
+        self, tmp_path: Path, env_save_restore, real_executable_save_restore
+    ):
+        # Arrange — real `sac` shim on PATH; sys.executable points at an
+        # interpreter dir with NO sibling `sac`, so PATH is the only hit.
+        fake_sac = tmp_path / "bin" / "sac"
+        fake_sac.parent.mkdir()
+        fake_sac.write_text("#!/bin/sh\nexit 0\n")
+        fake_sac.chmod(0o755)
+        env_save_restore.set("PATH", str(fake_sac.parent))
+        no_sac_dir = tmp_path / "no_sac_here"
+        no_sac_dir.mkdir()
+        sys.executable = str(no_sac_dir / "python3")
+        # Act
+        resolved = sac_binary()
+        # Assert
+        assert resolved == str(fake_sac)
+
+    def test_falls_back_to_sys_executable_sibling_when_path_misses(
+        self, tmp_path: Path, env_save_restore, real_executable_save_restore
+    ):
+        # Arrange — empty PATH (the systemd --user bug shape) + a `sac`
+        # console script colocated with sys.executable (the venv shape the
+        # daemon's own ExecStart= relies on).
+        empty_bin = tmp_path / "empty_bin"
+        empty_bin.mkdir()
+        env_save_restore.set("PATH", str(empty_bin))
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        fake_python = venv_bin / "python3"
+        fake_python.write_text("#!/bin/sh\n")
+        fake_python.chmod(0o755)
+        fake_sac = venv_bin / "sac"
+        fake_sac.write_text("#!/bin/sh\nexit 0\n")
+        fake_sac.chmod(0o755)
+        sys.executable = str(fake_python)
+        # Act
+        resolved = sac_binary()
+        # Assert
+        assert resolved == str(fake_sac)


### PR DESCRIPTION
## Root cause

`sac listen` runs as a systemd `--user` service; its `ExecStart=` correctly
uses an absolute path to the venv's `sac` binary. But code *inside* the
daemon that shells out to spawn/restart other agents resolved the child's
`sac` via `shutil.which("sac")` — which searches the **daemon process's own
PATH**, i.e. systemd `--user`'s inherited default, which does not include
the venv's `bin/` (systemd `--user` units never source `~/.bashrc` /
`~/.bash_profile`). When `shutil.which("sac")` returned `None`, the old code
silently fell back to the literal string `"sac"`, and the eventual
`subprocess.run(["sac", ...])` died with `FileNotFoundError`, uncaught,
surfacing to HTTP callers as an opaque 500 with zero diagnostic detail.
Every `agent_start`/`agent_spawn` call across the fleet broke as a result.

## Fix

A single shared resolver, `_sac_binary.sac_binary()`:

1. `shutil.which("sac")` — standard PATH lookup, kept first so PATH-shimmed
   tests and non-venv installs keep working unchanged.
2. `Path(sys.executable).with_name("sac")` — the sibling of the *current*
   process's interpreter. This is what actually fixes the systemd bug: PATH
   lookup already fails there, but this always finds the daemon's own venv
   `sac` regardless of PATH, mirroring the pattern `ExecStart=` already
   relies on.
3. Neither resolves → raise `SacBinaryNotFoundError` at **resolution time**,
   instead of silently building an unresolvable `"sac"` argv that only dies
   later, deep inside `subprocess.run`, as an opaque `FileNotFoundError`.

Applied at all four call sites with the bug (grepped the whole package, not
just the three originally reported):

- `_listen/_agent_exec.py` (`agents_start`)
- `_listen/_agent_restart.py` (`agent_restart`)
- `_listen/_restart.py` (`restart_listen`'s `sac_listen_argv` fallback)
- `cli_pkg/lifecycle/_start_parallel.py` — had its own local duplicate of
  the same `shutil.which(...) or "sac"` pattern; deduplicated into the
  shared resolver.

`_agent_exec.py` and `_agent_restart.py` also wrap the resolution and
subprocess-launch calls so a `SacBinaryNotFoundError` or launch-time
`OSError` returns a structured JSON error body (matching `host_exec`'s
error shape) instead of propagating as an unhandled-exception 500.

## Tests

`tests/scitex_agent_container/test__sac_binary.py` — real filesystem
fixtures (save/restore `PATH` and `sys.executable`), no mocks per this
repo's convention. Pins both resolution branches plus the raise-loudly
contract.

**Local run: 685 passed, 1 warning** (`test__sac_binary.py` + the complete
`_listen/` suite) — via a disposable venv on this container. Getting a
clean run took a few environment workarounds unrelated to the code itself
(a container-wide `UV_PROJECT_ENVIRONMENT` override needed overriding, and
the `dev` extras group needed installing separately for pytest) — noting
this only so a reviewer isn't confused if CI's environment behaves
differently; the code and tests themselves are unaffected.

## Context

You already have an interim systemd PATH drop-in in place mitigating the
fleet-wide impact, so this is the durable root-cause fix, not
urgent-hotfix pressure. Per your own request: please review with `rtk
proxy gh pr diff` (unfiltered) rather than the default filtered path — a
separate rtk diff-mangling bug was found this session (card
`rtk-gh-pr-diff-review-mangling`) that silently drops real code hunks from
the default filtered view.

Not merging this myself — leaving that to your review.