### PR TITLE
fix(cli): sac agents list default = running-only + real runtime account

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -13,6 +13,15 @@ from __future__ import annotations
 from ..._state.registry import Registry
 from ...config import load_config
 
+# Account-column resolvers live in the sibling ``_agent_list_account``
+# (512-line cap split). Re-imported here so the bare-name call sites in
+# ``get_agent_list_data`` — and the test seams that rebind
+# ``_al._safe_account_for`` / ``_al._runtime_account_for`` — keep working.
+from ._agent_list_account import (  # noqa: F401
+    _runtime_account_for,
+    _safe_account_for,
+)
+
 
 def _safe_port_for(name: str) -> int | None:
     """Return the agent's claimed a2a port, or None on any failure.
@@ -31,35 +40,6 @@ def _safe_port_for(name: str) -> int | None:
         return port_allocator.get_port(name)
     except Exception:  # stx-allow: fallback (reason: see inline comment)
         return None
-
-
-def _safe_account_for(cfg) -> str:
-    """Resolve the agent's effective Anthropic-account label.
-
-    Surfaces which account the agent authenticates as (operator request
-    4581) so the operator can spot agents sharing one account — and thus
-    one server-side rate limit. Resolution mirrors the runtime auth
-    precedence: agent ``spec.env`` override → host shared OAuth identity
-    → ``default``/``unknown`` fallback. See
-    ``_account.agent_account.resolve_agent_account_label`` for the rule.
-
-    Tolerant: a missing config or any resolver hiccup maps to
-    ``"unknown"`` so the list command never crashes on account lookup.
-    """
-    # stx-allow: fallback (reason: list output must never crash on an
-    # account-resolution hiccup; ``"unknown"`` cell is the right UX.)
-    try:
-        from ..._account.agent_account import resolve_agent_account_label
-
-        env = getattr(cfg, "env", None) if cfg is not None else None
-        assigned = (
-            getattr(getattr(cfg, "claude", None), "account", "") or None
-            if cfg is not None
-            else None
-        )
-        return resolve_agent_account_label(env, assigned_account=assigned)
-    except Exception:  # stx-allow: fallback (reason: see inline comment)
-        return "unknown"
 
 
 def _movement_fields(name: str) -> dict:
@@ -335,6 +315,18 @@ def get_agent_list_data(
         # state.db by hand. ``None`` when no claim exists (agent never
         # started under the allocator, or sidecar-disabled spec).
         a2a_port = _safe_port_for(name)
+        # Which Anthropic account this agent authenticates as. Agents
+        # sharing one label share one server-side rate limit. For a RUNNING
+        # agent prefer the ACTUAL runtime account (read from its per-agent
+        # ``<runtime>/home/.claude.json``) over the spec-derived label —
+        # pool-based agents all resolve to the same host-OAuth spec label
+        # otherwise, hiding the load-balanced per-agent pick. Called as a
+        # bare name so a test can rebind ``_al._runtime_account_for``.
+        account_label = _safe_account_for(cfg)
+        if status_val == "running":
+            runtime_label = _runtime_account_for(name)
+            if runtime_label:
+                account_label = runtime_label
         row: dict = {
             "name": name,
             "status": status_val,
@@ -344,9 +336,7 @@ def get_agent_list_data(
             "host": host_label,
             "path": spec_path,
             "a2a_port": a2a_port,
-            # Which Anthropic account this agent authenticates as.
-            # Agents sharing one label share one server-side rate limit.
-            "account": _safe_account_for(cfg),
+            "account": account_label,
         }
         # Operator mandate (lead a2a 1781e82a, 2026-06-14): surface
         # session.jsonl movement + last heartbeat at the per-row level

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_account.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_account.py
@@ -1,0 +1,102 @@
+"""Account-column resolution for the agent list.
+
+Extracted from :mod:`_agent_list` (which sits at the 512-line per-file
+cap) so the two Account-column resolvers live together in one focused
+module. :mod:`_agent_list` re-imports both names so existing
+``_al._safe_account_for`` / ``_al._runtime_account_for`` access (and the
+test swap seams that rebind them) keep working unchanged.
+
+Two resolvers, used in tandem by ``get_agent_list_data``:
+
+* :func:`_safe_account_for` — the SPEC-derived label (env override →
+  ``spec.claude.account`` pin → host shared OAuth identity). This is what
+  every row showed before; for a pool-based agent (no ``account`` pin) it
+  collapses to the one host OAuth email, so the whole column reads the
+  same account.
+* :func:`_runtime_account_for` — the ACTUAL account a RUNNING agent is
+  authenticated as, read from its own ``<runtime>/home/.claude.json``.
+  This is what makes the column reflect the per-agent load-balanced pick.
+"""
+
+from __future__ import annotations
+
+
+def _safe_account_for(cfg) -> str:
+    """Resolve the agent's effective Anthropic-account label.
+
+    Surfaces which account the agent authenticates as (operator request
+    4581) so the operator can spot agents sharing one account — and thus
+    one server-side rate limit. Resolution mirrors the runtime auth
+    precedence: agent ``spec.env`` override → host shared OAuth identity
+    → ``default``/``unknown`` fallback. See
+    ``_account.agent_account.resolve_agent_account_label`` for the rule.
+
+    Tolerant: a missing config or any resolver hiccup maps to
+    ``"unknown"`` so the list command never crashes on account lookup.
+    """
+    # stx-allow: fallback (reason: list output must never crash on an
+    # account-resolution hiccup; ``"unknown"`` cell is the right UX.)
+    try:
+        from ..._account.agent_account import resolve_agent_account_label
+
+        env = getattr(cfg, "env", None) if cfg is not None else None
+        assigned = (
+            getattr(getattr(cfg, "claude", None), "account", "") or None
+            if cfg is not None
+            else None
+        )
+        return resolve_agent_account_label(env, assigned_account=assigned)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return "unknown"
+
+
+def _runtime_account_for(name: str) -> str | None:
+    """Resolve the ACTUAL Anthropic account a RUNNING agent uses, or None.
+
+    :func:`_safe_account_for` reads the agent's SPEC, which for the fleet's
+    pool-based agents (``spec.claude.credentials_files`` with no singular
+    ``spec.claude.account`` pin) has no account to resolve — so it falls
+    through to the HOST's shared OAuth identity, and EVERY such agent reads
+    as the same account (the operator's TG-1490 complaint: every row shows
+    one email). But the runtime quota-aware picker
+    (:func:`_creds.pick_healthy_account`, ``spread_key=<agent>``) binds a
+    DIFFERENT pool account per agent at container start, so the live pick
+    genuinely VARIES. Claude Code writes that picked account's identity
+    into the agent's OWN ``<runtime>/home/.claude.json`` (``oauthAccount.
+    emailAddress``), which is host-readable through the per-agent
+    runtime-home bind. This reads THAT so the Account column reflects what
+    a live agent is really authenticated as.
+
+    Returns the resolved account label, or ``None`` when no per-agent
+    runtime identity is resolvable (agent never started, no runtime dir,
+    or auth not yet written) — the caller then falls back to the
+    spec-derived :func:`_safe_account_for` label. Never raises.
+    """
+    # stx-allow: fallback (reason: the runtime-account probe is best-effort
+    # enrichment for the list column; ANY resolution hiccup degrades to
+    # None so the caller uses the spec label — it must never crash the list.)
+    try:
+        from pathlib import Path
+
+        from ..._account.agent_account import _match_saved_account
+        from ..._account.credentials import read_credentials_metadata
+        from ..._lifecycle._session_movement import resolve_state_dir
+
+        state_dir = resolve_state_dir(name)
+        if state_dir is None:
+            return None
+        # The picked account's identity lives in the agent's OWN
+        # ``<runtime>/home/.claude.json`` (oauthAccount), read directly here.
+        runtime_home = state_dir / "home"
+        if not (runtime_home / ".claude.json").is_file():
+            return None
+        email = read_credentials_metadata(home=runtime_home).get("email_address")
+        if not (isinstance(email, str) and email):
+            return None
+        # Match the email against the HOST account store so the label form
+        # (``<slug> (<email>)``) is consistent with the spec-derived rows
+        # (``_safe_account_for``); a non-matching email shows bare.
+        saved = _match_saved_account(email, Path.home(), None)
+        return f"{saved} ({email})" if saved else email
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
@@ -63,6 +63,49 @@ def _is_ghost_row(row: dict) -> bool:
     return any("File not found" in str(e) for e in errors)
 
 
+def _print_hidden_footer(
+    status_hidden: dict[str, int],
+    hidden_ghosts: int,
+    *,
+    none_running: bool,
+) -> None:
+    """Print the default-view footer summarising the hidden non-running rows.
+
+    ``status_hidden`` maps a status word (``stopped`` / ``invalid`` /
+    ``defined`` / ``unknown``) to how many rows of it were hidden;
+    ``hidden_ghosts`` is the count of dead spec-missing registry ghosts.
+    ``defined`` is rendered as ``definitions`` (the template/definition rows
+    the operator called out). Emits nothing when nothing was hidden.
+    """
+    # Canonical order + human labels; any residual status is appended as-is.
+    order = [
+        ("stopped", "stopped"),
+        ("defined", "definitions"),
+        ("invalid", "invalid"),
+        ("unknown", "unknown"),
+    ]
+    known = {key for key, _ in order}
+    parts: list[str] = []
+    for key, word in order:
+        n = status_hidden.get(key, 0)
+        if n:
+            parts.append(f"{n} {word}")
+    for key, n in status_hidden.items():
+        if key not in known and n:
+            parts.append(f"{n} {key}")
+    if hidden_ghosts:
+        parts.append(f"{hidden_ghosts} stale")
+    if not parts:
+        return
+    summary = ", ".join(parts)
+    if none_running:
+        console.print(
+            f"[dim]No running agents ({summary} hidden — -v for all).[/dim]"
+        )
+    else:
+        console.print(f"[dim]({summary} hidden — -v for all)[/dim]")
+
+
 def print_agent_list(
     registry: Registry,
     capability: str | None = None,
@@ -72,12 +115,18 @@ def print_agent_list(
     verbose: bool = False,
     show_all: bool = False,
 ) -> None:
-    """Print a rich table of all registered agents.
+    """Print a rich table of registered agents.
 
-    By default shows only active agents (dead spec-missing registry ghosts
-    are hidden — see :func:`_is_ghost_row`) and omits the full spec ``Path``
-    column (it folds every row to 10+ lines). ``show_all=True`` includes the
-    ghosts; ``verbose=True`` adds the ``Path`` column back.
+    DEFAULT (no flags): show ONLY ``status="running"`` agents with their
+    Account — the stopped / invalid / definition roster and the per-agent
+    validation-error blocks are an unusable wall on a real fleet (operator
+    TG 1490-1495). A one-line footer counts what was hidden.
+
+    ``verbose=True`` (``-v``) restores the FULL list — every status
+    (running/stopped/invalid/definition) PLUS the per-agent validation-error
+    detail — and adds the spec ``Path`` column. ``show_all=True`` (``--all``)
+    also shows the full list AND additionally includes dead spec-missing
+    registry ghosts (see :func:`_is_ghost_row`), which stay hidden otherwise.
     """
     from ._agent_list import get_agent_list_data
 
@@ -88,15 +137,32 @@ def print_agent_list(
         console.print("[dim]No agents found (registry empty, no specs on disk).[/dim]")
         return
 
-    hidden = 0
+    # `--all` reveals dead spec-missing registry ghosts; hidden otherwise.
+    hidden_ghosts = 0
     if not show_all:
         kept = [r for r in data if not _is_ghost_row(r)]
-        hidden = len(data) - len(kept)
+        hidden_ghosts = len(data) - len(kept)
         data = kept
+
+    # DEFAULT view shows ONLY running agents; `-v`/`--all` show the full
+    # roster. Tally the hidden non-running rows by status for the footer.
+    show_full = verbose or show_all
+    status_hidden: dict[str, int] = {}
+    if not show_full:
+        running = [r for r in data if r.get("status") == "running"]
+        for r in data:
+            st = r.get("status") or "unknown"
+            if st != "running":
+                status_hidden[st] = status_hidden.get(st, 0) + 1
+        data = running
+
     if not data:
-        console.print(
-            "[dim]No active agents (all hidden as stale; --all to show).[/dim]"
-        )
+        if show_full:
+            console.print(
+                "[dim]No active agents (all hidden as stale; --all to show).[/dim]"
+            )
+        else:
+            _print_hidden_footer(status_hidden, hidden_ghosts, none_running=True)
         return
 
     table = Table(title="Agents")
@@ -156,17 +222,28 @@ def print_agent_list(
         table.add_row(*cells)
 
     console.print(table)
-    if hidden:
+
+    # Footer. DEFAULT view: summarise every hidden non-running row + ghosts.
+    # FULL view (`-v`/`--all`): only note hidden ghosts when `-v` alone.
+    if not show_full:
+        _print_hidden_footer(status_hidden, hidden_ghosts, none_running=False)
+    elif hidden_ghosts:
         console.print(
-            f"[dim]({hidden} stale/ghost agent(s) hidden — --all to show, "
-            "-v for paths)[/dim]"
+            f"[dim]({hidden_ghosts} stale/ghost agent(s) hidden — --all to "
+            "show, -v for paths)[/dim]"
         )
-    # Full error text follows the table so the operator can copy-paste.
-    for row in data:
-        if row.get("validation_errors"):
-            console.print(f"[bold red]✗ {row['name']}[/bold red] validation errors:")
-            for err in row["validation_errors"]:
-                console.print(f"    [red]- {err}[/red]")
+
+    # Full per-agent validation-error text — FULL view only. In the default
+    # view these blocks (repeated dozens of times on a real fleet) are the
+    # wall the operator asked us to remove; they belong behind `-v`/`--all`.
+    if show_full:
+        for row in data:
+            if row.get("validation_errors"):
+                console.print(
+                    f"[bold red]✗ {row['name']}[/bold red] validation errors:"
+                )
+                for err in row["validation_errors"]:
+                    console.print(f"    [red]- {err}[/red]")
 
 
 def _extract_damaged_fields(errors: list[str]) -> list[str]:

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -176,16 +176,19 @@ def _format_claude_account_block(meta: dict) -> list[str]:
     "verbose",
     is_flag=True,
     default=False,
-    help="Fleet view: add the full spec.yaml Path column (off by default — "
-    "it folds every row to 10+ lines).",
+    help="Fleet view: show the FULL list — every status "
+    "(running/stopped/invalid/definition) WITH per-agent validation-error "
+    "detail and the spec.yaml Path column. The default view shows only "
+    "running agents (the full roster is an unusable wall on a real fleet).",
 )
 @click.option(
     "--all",
     "show_all",
     is_flag=True,
     default=False,
-    help="Fleet view: include stale/ghost agents (dead registry entries whose "
-    "spec file is gone). Hidden by default.",
+    help="Fleet view: like -v (full roster + validation detail) AND "
+    "additionally include stale/ghost agents (dead registry entries whose "
+    "spec file is gone). Both are hidden by default.",
 )
 @click.option(
     "--snapshot",

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
@@ -596,12 +596,14 @@ def test_print_agent_list_renders_status_word_for_running_agent(capsys, tmp_path
 
 
 def test_print_agent_list_prints_full_validation_errors_under_table(capsys, tmp_path):
-    # Arrange — invalid spec triggers real validate_config errors mentioning spec.runtime.
+    # Arrange — invalid spec triggers real validate_config errors mentioning
+    # spec.runtime. The per-agent error blocks now live in the FULL (`-v`)
+    # view; the default view hides them (operator TG 1490-1495).
     spec = _write_invalid_spec(tmp_path / "x")
     registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
     # Act
     with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
-        print_agent_list(registry)
+        print_agent_list(registry, verbose=True)
     # Assert
     assert "spec.runtime" in capsys.readouterr().out
 
@@ -1032,3 +1034,225 @@ def test_print_agent_list_default_omits_path_column(capsys, tmp_path):
         print_agent_list(registry)
     # Assert
     assert "Path" not in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Default view = RUNNING-ONLY (operator TG 1490-1495). The full
+# stopped/invalid/definition roster + the per-agent validation-error blocks
+# are an unusable wall by default; they move behind -v/--all. The default
+# view shows only running agents with their Account, plus a hidden-count
+# footer.
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _swap_runtime_account(impl: Callable[[str], str | None]) -> Iterator[None]:
+    """Swap ``_al._runtime_account_for`` for a real callable (not a mock)."""
+    saved = _al._runtime_account_for
+    _al._runtime_account_for = impl  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _al._runtime_account_for = saved  # type: ignore[assignment]
+
+
+@contextmanager
+def _state_root_set_to(path: Path) -> Iterator[None]:
+    """Rebind the runner's DEFAULT_STATE_ROOT to a real tmp Path.
+
+    ``resolve_state_dir`` → ``state_dir_for`` reads this module constant at
+    call time, so pointing it at a seeded tmp tree lets us exercise the REAL
+    ``_runtime_account_for`` resolution on real files (no mock).
+    """
+    import scitex_agent_container._runners._session_state as _ss
+
+    saved = _ss.DEFAULT_STATE_ROOT
+    _ss.DEFAULT_STATE_ROOT = path  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _ss.DEFAULT_STATE_ROOT = saved  # type: ignore[assignment]
+
+
+def _running_plus_defined_and_invalid(tmp_path):
+    """One RUNNING registry agent + one defined + one invalid on-disk agent."""
+    good = _write_valid_spec(tmp_path / "runner")
+    registry = _FakeRegistry(
+        [{"name": "runner", "config": str(good), "screen": "s", "started_at": "ts"}]
+    )
+    def_spec = _write_valid_spec(tmp_path / "def1")
+    bad_spec = _write_invalid_spec(tmp_path / "bad1")
+
+    def _discover() -> list[tuple[str, Path]]:
+        return [("def1", def_spec), ("bad1", bad_spec)]
+
+    return registry, _discover
+
+
+def test_print_agent_list_default_shows_running_agent(capsys, tmp_path):
+    # Arrange
+    registry, discover = _running_plus_defined_and_invalid(tmp_path)
+    # Act — default view.
+    with _swap_discover(discover), _swap_probe(lambda cfg: True):
+        print_agent_list(registry)
+    # Assert
+    assert "runner" in capsys.readouterr().out
+
+
+def test_print_agent_list_default_hides_definition_and_invalid(capsys, tmp_path):
+    # Arrange
+    registry, discover = _running_plus_defined_and_invalid(tmp_path)
+    # Act
+    with _swap_discover(discover), _swap_probe(lambda cfg: True):
+        print_agent_list(registry)
+    # Assert — the definition ("def1") + invalid ("bad1") rows are hidden.
+    out = capsys.readouterr().out
+    assert "def1" not in out and "bad1" not in out
+
+
+def test_print_agent_list_default_footer_counts_hidden(capsys, tmp_path):
+    # Arrange
+    registry, discover = _running_plus_defined_and_invalid(tmp_path)
+    # Act
+    with _swap_discover(discover), _swap_probe(lambda cfg: True):
+        print_agent_list(registry)
+    # Assert — footer names both hidden categories.
+    out = capsys.readouterr().out
+    assert "definitions" in out and "invalid" in out and "hidden" in out
+
+
+def test_print_agent_list_default_omits_validation_blocks(capsys, tmp_path):
+    # Arrange — the invalid agent's real spec.runtime error block must NOT
+    # print in the default view (the wall the operator asked us to remove).
+    registry, discover = _running_plus_defined_and_invalid(tmp_path)
+    # Act
+    with _swap_discover(discover), _swap_probe(lambda cfg: True):
+        print_agent_list(registry)
+    # Assert
+    assert "spec.runtime" not in capsys.readouterr().out
+
+
+def test_print_agent_list_default_hides_stopped_agent(capsys, tmp_path):
+    # Arrange — a single registered-but-stopped agent (probe False).
+    spec = _write_valid_spec(tmp_path / "stopper")
+    registry = _FakeRegistry([{"name": "stopper", "config": str(spec)}])
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: False):
+        print_agent_list(registry)
+    # Assert — no table (name absent); footer reports the hidden stopped one.
+    out = capsys.readouterr().out
+    assert "stopper" not in out and "stopped" in out and "No running agents" in out
+
+
+def test_print_agent_list_verbose_includes_stopped_agent(capsys, tmp_path):
+    # Arrange — same stopped agent; -v restores the full roster.
+    spec = _write_valid_spec(tmp_path / "stopper")
+    registry = _FakeRegistry([{"name": "stopper", "config": str(spec)}])
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: False):
+        print_agent_list(registry, verbose=True)
+    # Assert
+    assert "stopper" in capsys.readouterr().out
+
+
+def test_print_agent_list_verbose_includes_definition_and_validation(capsys, tmp_path):
+    # Arrange
+    registry, discover = _running_plus_defined_and_invalid(tmp_path)
+    # Act — -v shows every status AND the per-agent validation-error detail.
+    with _swap_discover(discover), _swap_probe(lambda cfg: True):
+        print_agent_list(registry, verbose=True)
+    # Assert
+    out = capsys.readouterr().out
+    assert "def1" in out and "spec.runtime" in out
+
+
+# ---------------------------------------------------------------------------
+# Account column = ACTUAL runtime account for running agents (operator TG
+# 1490-1495). Pool-based agents (``credentials_files`` with no ``account``
+# pin) all resolve to the same host-OAuth spec label; the runtime picker
+# binds a different pool account per agent, and its identity is host-readable
+# from ``<runtime>/home/.claude.json``. A running row prefers that; a
+# non-running row (no live auth) keeps the spec label.
+# ---------------------------------------------------------------------------
+
+
+def test_get_data_running_row_prefers_runtime_account(tmp_path):
+    # Arrange
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
+    # Act — running (probe True): runtime account wins over the spec label.
+    with (
+        _swap_discover(_no_discover),
+        _swap_probe(lambda cfg: True),
+        _swap_account(lambda cfg: "spec-label (host@example.com)"),
+        _swap_runtime_account(lambda name: "runtime-pick@example.com"),
+    ):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert out[0]["account"] == "runtime-pick@example.com"
+
+
+def test_get_data_stopped_row_uses_spec_account_not_runtime(tmp_path):
+    # Arrange
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
+    # Act — stopped (probe False): the runtime probe is NOT consulted.
+    with (
+        _swap_discover(_no_discover),
+        _swap_probe(lambda cfg: False),
+        _swap_account(lambda cfg: "spec-label"),
+        _swap_runtime_account(lambda name: "should-not-be-used@example.com"),
+    ):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert out[0]["account"] == "spec-label"
+
+
+def test_get_data_running_row_falls_back_to_spec_when_runtime_unresolved(tmp_path):
+    # Arrange — runtime resolver returns None (agent auth not written yet).
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
+    # Act
+    with (
+        _swap_discover(_no_discover),
+        _swap_probe(lambda cfg: True),
+        _swap_account(lambda cfg: "spec-fallback"),
+        _swap_runtime_account(lambda name: None),
+    ):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert out[0]["account"] == "spec-fallback"
+
+
+def test_runtime_account_for_reads_per_agent_oauth_email(tmp_path):
+    # Arrange — a REAL per-agent runtime home with the picked account's
+    # identity written into <runtime>/home/.claude.json (no mock).
+    import json as _json
+
+    root = tmp_path / "runtime"
+    home = root / "myagent" / "home"
+    (home / ".claude").mkdir(parents=True)
+    (home / ".claude" / ".credentials.json").write_text(
+        _json.dumps(
+            {"claudeAiOauth": {"accessToken": "sk-ant-x", "expiresAt": 9_999_999_999_000}}
+        )
+    )
+    (home / ".claude.json").write_text(
+        _json.dumps({"oauthAccount": {"emailAddress": "runtime-pick@example.com"}})
+    )
+    # Act — HOME→tmp so the saved-account match reads an empty store (the
+    # email maps to no saved account) → the bare runtime email is returned.
+    with _state_root_set_to(root), _home_set_to(tmp_path):
+        label = _al._runtime_account_for("myagent")
+    # Assert
+    assert label == "runtime-pick@example.com"
+
+
+def test_runtime_account_for_returns_none_without_runtime_dir(tmp_path):
+    # Arrange — no runtime dir seeded → resolver must return None so the
+    # caller falls back to the spec label.
+    # Act
+    with _state_root_set_to(tmp_path / "empty"):
+        result = _al._runtime_account_for("no-such-runtime-agent")
+    # Assert
+    assert result is None

--- a/tests/scitex_agent_container/cli_pkg/test_status_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_status_cmds.py
@@ -374,12 +374,14 @@ def test_status_fleet_table_exits_zero(tmp_registry):
 
 
 def test_status_fleet_table_includes_registered_agent(tmp_path, tmp_registry):
-    # Arrange
+    # Arrange — a registered agent that is NOT running in the test env
+    # (no tmux/container). The DEFAULT view shows only running agents
+    # (operator TG 1490-1495), so the full roster is behind ``-v``.
     spec = _write_spec(tmp_path, "table-agent")
     _register(tmp_registry, "table-agent", spec)
     runner = CliRunner()
     # Act
-    result = runner.invoke(status, [])
+    result = runner.invoke(status, ["-v"])
     # Assert
     assert "table-agent" in result.output
 


### PR DESCRIPTION
## Problem (operator TG 1490-1495)

The default `sac agents list` was an unusable wall: dozens of `stopped`,
`invalid` (`x spec.host: 'local' is BANNED` + missing required fields), and
`definition` rows, PLUS per-agent validation-error blocks repeated dozens of
times. And every row's Account read `ywata1989-gmail-com`, which looked wrong.

## Changes

**1. Default view = running-only.** `sac agents list` (no flags) now shows
ONLY `status=running` agents with their Account, and a one-line footer:

```
No running agents (33 stopped, 46 definitions, 15 invalid, 1 stale hidden -- -v for all).
```

The per-agent validation-error blocks are removed from the default view.

**2. `-v`/`--verbose` = full list.** Restores every status
(running/stopped/invalid/definition) WITH the per-agent validation-error
detail and the `Path` column (today's behavior). `--all` still additionally
reveals dead spec-missing registry ghosts. The `--json` path is unchanged
(unfiltered — terse/fleet_watch consumers rely on the full roster).

**3. Account column now shows the REAL runtime account for running agents.**
Finding: it was showing the SPEC/host default. 93/98 fleet specs use a
`credentials_files` POOL with **no** `spec.claude.account` pin, so
`_safe_account_for` fell through to the host shared OAuth identity and every
pool agent read as the same account. The runtime picker
(`pick_healthy_account`, `spread_key=<agent>`) binds a *different* pool account
per agent at start — its identity is host-readable from the agent's own
`<runtime>/home/.claude.json` (`oauthAccount`). New `_runtime_account_for`
reads that for RUNNING agents, falling back to the spec label when a live
agent's auth isn't yet written. Verified live on the real fleet:

```
figrecipe    running   ywata1989-gmail-com (ywata1989@gmail.com)
neurovista   running   wyusuuke-gmail-com (wyusuuke@gmail.com)   <- varies
scitex-io    running   ywata1989-gmail-com (ywata1989@gmail.com)
scitex-dsp   running   ywata1989-gmail-com (...)   <- spec fallback (no runtime oauth yet)
```

Account-column resolvers extracted into `_agent_list_account.py` (512-line cap).

## Tests (no mocks)

`tests/.../cli_pkg/_helpers/test__agent_list.py` + `test_status_cmds.py`
(109 passing). New: default hides stopped/definition/invalid + omits the
validation blocks and shows the footer; `-v` includes them; running rows
prefer the runtime account (real per-agent `<runtime>/home/.claude.json`),
stopped rows keep the spec label. Also verified `sac agents list` /
`sac agents list -v` on the real fleet from the worktree.

## Risk to double-check

The runtime-account read parses each running agent's `<runtime>/home/.claude.json`
per list invocation (bounded to displayed running rows). It is fully
try/except-guarded (degrades to the spec label; never crashes the list), but
adds a per-running-agent file read to the human table path (`--json` untouched).

Generated with [Claude Code](https://claude.com/claude-code)
