### PR TITLE
feat(tui-auth): prompt-anchored auth-banner matcher + `sac agents auth-status`

### DIFF
--- a/src/scitex_agent_container/_runners/_tmux/auth_status.py
+++ b/src/scitex_agent_container/_runners/_tmux/auth_status.py
@@ -1,0 +1,237 @@
+"""Prompt-anchored TUI auth-banner detector (near-prompt + distance-frozen).
+
+WHY THIS EXISTS
+    The TUI watchdog is the SOLE safety net for the 2026-07-11 auth-death
+    class — a stale in-memory OAuth token that only a restart clears (see
+    ``_runners/_auth_failure``). It must SEE the ``tui-<agent>`` fleet AND
+    tell a REAL "Login expired * Please run /login" banner apart from an
+    agent merely QUOTING that phrase while it discusses the incident.
+
+    The naive matcher (``_state/_meta/pane._classify_pane_state``) flags the
+    phrase ANYWHERE on the pane, so an agent replying about the incident
+    false-positives (verified live 2026-07-12: 3 of 4 flagged agents were
+    prose, 1 was the real frozen ``scitex-hpc``). This module is the
+    hardened replacement — it separates REAL from PROSE with two
+    prompt-anchored signals:
+
+      1. NEAR-PROMPT — a banner counts only when it sits in the conversation
+         TAIL: the last :data:`TAIL_LINES` non-chrome lines directly above
+         the input-prompt line (located via
+         :func:`prompts.prompt_line_index`). A banner higher in scrollback —
+         where a quoting agent's own later output pushes it — is ignored.
+      2. DISTANCE-FROZEN — the banner's DISTANCE from the prompt (count of
+         non-chrome lines between it and the prompt) is tracked across runs
+         in caller-held LOCAL STATE. A REAL wedged agent is frozen: the same
+         banner kind at the same distance on two consecutive captures. A
+         working/prose agent produces output, so the distance CHANGES (or the
+         banner leaves the tail) — never frozen.
+
+    Both signals REUSE the tested, NBSP-aware prompt detector in
+    ``prompts.py`` rather than re-deriving the prompt glyph. Everything here
+    is a pure function of pane text + a small state dict — no tmux, no I/O —
+    so it is unit-testable against captured panes without mocks. Live capture
+    + ``tui-`` session enumeration live in the ``sac agents auth-status`` CLI
+    command (``cli_pkg/_auth_status``).
+
+MAINTENANCE
+    The banner strings + chrome patterns below mirror what Anthropic's Ink
+    TUI renders, which changes between releases. When a real banner stops
+    being flagged (or prose starts being flagged), update ``_AUTH_STARTS`` /
+    ``_VOLATILE_RE`` here and add the captured pane as a fixture.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .prompts import prompt_line_index
+
+__all__ = [
+    "AuthProbe",
+    "TAIL_LINES",
+    "banner_kind",
+    "evaluate",
+    "is_stuck",
+    "probe_pane",
+    "probe_to_state",
+]
+
+# Near-prompt window: a banner is judged REAL only when it is among the last N
+# non-chrome conversation lines directly above the input prompt. ~6 mirrors the
+# operator's "last ~6 non-chrome lines" refinement (TG 1507, 2026-07-12).
+TAIL_LINES = 6
+
+# Left-side TUI decoration stripped before a line is matched, so a rendered
+# result like "  |_  Login expired * Please run /login" is judged on the text
+# after the marker. The result/spinner/quote glyphs come verbatim from the
+# proven dotfiles matcher; `` `` (NBSP) is included because Claude's Ink
+# TUI renders the gap after the "⎿" result marker as a NBSP, not an ASCII
+# space — a real 2026-07-11 capture reads ``⎿  Please run /login``, so
+# leaving NBSP out of the strip set left the text starting with " Please"
+# and the banner went undetected (regression-guarded by the head-mba fixture).
+_MARKERS = " \t" + chr(0xA0) + "⎿✻●·│┃─⏺└╭>❯'\"`|*-"
+
+# A line is a SYSTEM auth banner when, after its left decoration is stripped,
+# it STARTS WITH one of these canonical Claude-rendered auth phrases. Anchoring
+# on the START (not a bare substring) is what rejects prose: an agent line like
+# '* figrecipe died in a "Login expired" loop' strips to "figrecipe died ...",
+# which starts with none of these. (The near-prompt + distance layers handle
+# the harder case — a VERBATIM banner quote — since a quote sits up in
+# scrollback and the pane keeps moving.)
+_AUTH_STARTS = (
+    "Not logged in",
+    "Login expired",
+    "Session expired",
+    "Please run /login",
+    "Please re-run /login",
+    "Invalid API key",
+    "Invalid authentication credentials",
+    "OAuth token has expired",
+    "OAuth token expired",
+    "Authentication failed",
+    "Credit balance is too low",
+)
+
+# Standalone HTTP auth-rejection line (401 Unauthorized / 403 Forbidden). 429
+# (rate limit) is deliberately excluded — a restart does not fix a rate wall.
+_API_AUTH_RE = re.compile(r"^API Error:\s*(?:401|403)\b")
+
+# Structural chrome: a horizontal box-drawing separator (the rule below the
+# conversation / above the prompt box). Whole line is box-drawing + whitespace.
+_SEPARATOR_RE = re.compile(r"^[─-╿\s]+$")
+
+# Volatile status chrome — lines whose text changes even when NOTHING new
+# happens (gauges, elapsed clocks, spinners, the 0s-turn "Sauteed for 0s"
+# marker of a wedged /loop agent, token counters, rotating tips, the status
+# bar). Excluded from the conversation tail + the distance count so a cosmetic
+# spinner tick is never mistaken for the agent producing real output.
+_VOLATILE_RE = re.compile(
+    r"Usage\s|Context\s"  # full gauge rows
+    r"|ctx:\s*\d+%|\b\d+h:\s*\d+%"  # compact status bar
+    r"|\(\s*\d+h\s*\d+m|\(\s*\d+m\s*\d+s|\(\s*\d+s\b"  # elapsed clocks
+    r"|\bfor \d+s\b"  # "* Sauteed for 0s" 0s-turn spinner
+    r"|esc to interrupt|ctrl\+[a-z]"
+    r"|Running scheduled task"
+    r"|tokens\)|Tip:|bypass permissions"
+)
+
+
+def _strip_markers(line: str) -> str:
+    """Drop left TUI decoration + trailing whitespace from a captured line.
+
+    ``_MARKERS`` includes the NBSP (U+00A0) that Claude's Ink TUI renders as
+    the gap after the ``⎿`` result marker, so ``⎿  Please run /login``
+    strips cleanly to ``Please run /login ...`` (see ``_MARKERS`` note).
+    """
+    return line.lstrip(_MARKERS).rstrip()
+
+
+def banner_kind(line: str) -> str | None:
+    """Normalised auth-banner identity for ``line``, or ``None`` if not a banner.
+
+    Returns the matched canonical phrase (e.g. ``"Login expired"``) or
+    ``"API Error: 4xx"`` — deliberately NORMALISED, not the raw line, so a
+    volatile ``request_id`` / timestamp / 401 JSON body embedded in the banner
+    does not defeat the cross-run frozen comparison (a wedged ``/loop`` agent
+    re-renders the SAME banner with a NEW request id every wakeup).
+    """
+    s = _strip_markers(line)
+    for phrase in _AUTH_STARTS:
+        if s.startswith(phrase):
+            return phrase
+    if _API_AUTH_RE.match(s):
+        return "API Error: 4xx"
+    return None
+
+
+def _is_chrome(line: str) -> bool:
+    """True for a blank line, a separator rule, or a volatile status line."""
+    s = line.strip()
+    if not s:
+        return True
+    if _SEPARATOR_RE.match(s):
+        return True
+    return bool(_VOLATILE_RE.search(line))
+
+
+@dataclass(frozen=True)
+class AuthProbe:
+    """One capture's verdict.
+
+    ``prompt_found`` — an input-prompt line was located at all.
+    ``present``      — a system auth banner sits in the near-prompt tail.
+    ``distance``     — non-chrome lines between that banner and the prompt
+                       (0 = directly above); ``None`` when no banner.
+    ``banner``       — the normalised banner kind (see :func:`banner_kind`).
+    """
+
+    prompt_found: bool
+    present: bool
+    distance: int | None
+    banner: str | None
+
+
+def probe_pane(pane: str) -> AuthProbe:
+    """Probe one captured pane for a near-prompt auth banner.
+
+    Anchors on the bottom-most prompt line, walks the non-chrome conversation
+    lines above it, and reports the banner NEAREST the prompt within the last
+    :data:`TAIL_LINES` of them (if any) plus its distance from the prompt.
+    """
+    lines = pane.splitlines()
+    p = prompt_line_index(pane)
+    if p is None:
+        return AuthProbe(prompt_found=False, present=False, distance=None, banner=None)
+    # Non-chrome conversation lines strictly above the prompt, keeping their
+    # original indices so distance is measured in real screen lines.
+    convo = [(i, ln) for i, ln in enumerate(lines[:p]) if not _is_chrome(ln)]
+    tail = convo[-TAIL_LINES:]
+    banner_at: int | None = None
+    banner: str | None = None
+    for i, ln in tail:  # ascending index → last hit is NEAREST the prompt
+        kind = banner_kind(ln)
+        if kind is not None:
+            banner_at, banner = i, kind
+    if banner_at is None:
+        return AuthProbe(prompt_found=True, present=False, distance=None, banner=None)
+    distance = sum(1 for (j, _ln) in convo if j > banner_at)
+    return AuthProbe(prompt_found=True, present=True, distance=distance, banner=banner)
+
+
+def probe_to_state(probe: AuthProbe) -> dict:
+    """Serialise a probe to the minimal dict a caller persists between runs."""
+    return {
+        "present": probe.present,
+        "distance": probe.distance,
+        "banner": probe.banner,
+    }
+
+
+def is_stuck(probe: AuthProbe, prev: dict | None) -> bool:
+    """Frozen decision: banner present now AND unchanged since the previous run.
+
+    STUCK requires a prior state (never fires on first sight) whose banner was
+    present at the SAME distance and of the SAME kind. A changed distance —
+    the agent produced output — or an absent/renamed banner is NOT stuck.
+    """
+    if not probe.present or probe.distance is None:
+        return False
+    if not prev or not prev.get("present"):
+        return False
+    return prev.get("distance") == probe.distance and prev.get("banner") == probe.banner
+
+
+def evaluate(pane: str | None, prev: dict | None) -> tuple[AuthProbe, bool]:
+    """``(probe, stuck)`` for a capture and the previous run's state dict.
+
+    An uncapturable pane (``None``) is the clear, never-stuck result — the
+    honest "could not read" outcome, never a false LOGIN-REQUIRED.
+    """
+    if pane is None:
+        return (
+            AuthProbe(prompt_found=False, present=False, distance=None, banner=None),
+            False,
+        )
+    probe = probe_pane(pane)
+    return probe, is_stuck(probe, prev)

--- a/src/scitex_agent_container/_runners/_tmux/prompts.py
+++ b/src/scitex_agent_container/_runners/_tmux/prompts.py
@@ -223,6 +223,32 @@ def _detect_compose_pending_unsent(content: str) -> bool:
     return bool(re.search(r"❯[ \t\xa0]+\S", content))
 
 
+# The Claude Code Ink TUI input-prompt marker (U+276F). The gap after it may
+# be an ASCII space, a tab, or a NBSP (U+00A0) — see
+# :func:`_detect_compose_pending_unsent`. Exposed as a named constant so
+# prompt-anchored consumers (e.g. the auth-status matcher) locate the input
+# line the SAME, NBSP-aware way instead of re-deriving the glyph.
+PROMPT_MARKER = "❯"  # ❯
+
+
+def prompt_line_index(content: str) -> int | None:
+    """Return the 0-based line index of the TUI input-prompt line, else ``None``.
+
+    The prompt line is the one whose stripped text STARTS with the Ink prompt
+    marker ``❯`` (:data:`PROMPT_MARKER`). A captured pane can show several — a
+    scrollback echo of an earlier prompt box sits above the live one — so the
+    LAST (bottom-most) match wins: the live input field is always the lowest
+    prompt on screen. Anchoring on the stripped-line START (not a bare
+    substring) means a ``❯`` that appears mid-sentence in agent prose does not
+    masquerade as the prompt.
+    """
+    idx: int | None = None
+    for i, line in enumerate(content.splitlines()):
+        if line.strip().startswith(PROMPT_MARKER):
+            idx = i
+    return idx
+
+
 def _detect_done(content: str) -> bool:
     """Check if claude is at the main input prompt (all TUI prompts done).
 

--- a/src/scitex_agent_container/_runners/_tmux/prompts.py
+++ b/src/scitex_agent_container/_runners/_tmux/prompts.py
@@ -105,7 +105,7 @@ def _detect_press_enter_continue(content: str) -> bool:
     (per pane-state-patterns.md: classify against last 5 visible lines only).
     Excluded: active tool calls and numbered radio selectors.
     """
-    lines = [l for l in content.splitlines() if l.strip()]
+    lines = [ln for ln in content.splitlines() if ln.strip()]
     last = "\n".join(lines[-5:]) if lines else ""
     has_enter_cue = (
         "Press Enter to continue" in last

--- a/src/scitex_agent_container/cli_pkg/_auth_status.py
+++ b/src/scitex_agent_container/cli_pkg/_auth_status.py
@@ -1,0 +1,199 @@
+"""``sac agents auth-status`` — which running TUI agents are login-stuck.
+
+The reliable, prompt-anchored replacement for the operator's ad-hoc auth
+health check (TG 1497: "a command to see if any running agent shows
+login-required"). For each live ``tui-<agent>`` tmux session it captures the
+pane TWICE (``--interval`` apart), runs the near-prompt + distance-frozen
+matcher (:mod:`.._runners._tmux.auth_status`), and prints OK / LOGIN-REQUIRED.
+
+LOGIN-REQUIRED means: a SYSTEM auth banner sits in the conversation tail
+directly above the input prompt AND it did not move between the two captures
+(frozen) — i.e. the agent is wedged on "Login expired * Please run /login",
+not merely discussing or quoting it. Exit code is 1 when any agent is
+LOGIN-REQUIRED so cron / CI can alarm.
+"""
+
+from __future__ import annotations
+
+import json as json_mod
+import subprocess
+import sys
+import time
+
+import click
+from rich.table import Table
+
+from .._runners._tmux.auth_status import evaluate, probe_to_state
+from ._helpers import _json_flag, console
+
+# The TUI runtime names its sessions ``tui-<agent>`` on the DEFAULT tmux server
+# (``runtimes/tui_session.session_name_for``) — NOT the ``-L sac`` server that
+# ``_runners/_tmux/pane_capture`` targets — so we enumerate + capture on the
+# server the live fleet actually runs on.
+_TUI_PREFIX = "tui-"
+
+
+def _list_tui_sessions() -> list[str]:
+    """Live ``tui-<agent>`` tmux sessions on the default server (sorted)."""
+    # stx-allow: fallback (reason: tmux may be absent or have no server; an
+    # empty list is the correct "nothing to check" result, never a crash)
+    try:
+        out = subprocess.run(
+            ["tmux", "list-sessions", "-F", "#{session_name}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:  # stx-allow: fallback (reason: catch-all — see comment above)
+        return []
+    if out.returncode != 0:
+        return []
+    return sorted(s for s in out.stdout.split() if s.startswith(_TUI_PREFIX))
+
+
+def _capture(session: str) -> str | None:
+    """Capture a session's visible pane; ``None`` on any error.
+
+    Reuses the capture SHAPE of ``pane_capture`` (``-p -J`` — ``-J`` joins a
+    banner wrapped across physical lines) but on the default server + ``tui-``
+    session where the live fleet runs. ``None`` lets the matcher distinguish
+    "uncapturable" from "clean pane".
+    """
+    # stx-allow: fallback (reason: the session can vanish between list and
+    # capture; None is the honest "could not read" sentinel — never a crash)
+    try:
+        out = subprocess.run(
+            ["tmux", "capture-pane", "-t", session, "-p", "-J"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:  # stx-allow: fallback (reason: catch-all — see comment above)
+        return None
+    return out.stdout if out.returncode == 0 else None
+
+
+def _agent_of(session: str) -> str:
+    return session[len(_TUI_PREFIX) :]
+
+
+def evaluate_agents(
+    captures: dict[str, tuple[str | None, str | None]],
+) -> list[dict]:
+    """Pure core: map ``agent -> (pane_run1, pane_run2)`` to verdict rows.
+
+    Run 1 seeds each agent's local state; run 2 is judged against it, so a
+    banner that stayed at the SAME distance across the two reads (frozen)
+    yields ``login_required``; a banner that moved — or none at all — is
+    ``ok``. Kept free of tmux so it is unit-testable against captured panes
+    (no mocks). Rows are sorted by agent name for stable output.
+    """
+    rows: list[dict] = []
+    for name in sorted(captures):
+        pane1, pane2 = captures[name]
+        probe1, _ = evaluate(pane1, None)
+        probe2, stuck = evaluate(pane2, probe_to_state(probe1))
+        present = probe2.present or probe1.present
+        verdict = "login_required" if stuck else "ok"
+        note = ""
+        if verdict == "ok" and present:
+            note = "banner seen but moving (working/quoting)"
+        elif not probe2.prompt_found and pane2 is not None:
+            note = "no prompt line found"
+        rows.append(
+            {
+                "agent": name,
+                "verdict": verdict,
+                "banner_present": probe2.present,
+                "distance": probe2.distance,
+                "banner": probe2.banner,
+                "captured": pane2 is not None,
+                "note": note,
+            }
+        )
+    return rows
+
+
+def _render_table(rows: list[dict]) -> None:
+    table = Table(title="TUI agent auth-status")
+    table.add_column("agent", style="bold")
+    table.add_column("status")
+    table.add_column("distance", justify="right")
+    table.add_column("banner")
+    table.add_column("note", overflow="fold")
+    for r in rows:
+        login = r["verdict"] == "login_required"
+        status = "LOGIN-REQUIRED" if login else "OK"
+        style = "red" if login else "green"
+        dist = "-" if r["distance"] is None else str(r["distance"])
+        table.add_row(
+            r["agent"],
+            f"[{style}]{status}[/{style}]",
+            dist,
+            r["banner"] or "-",
+            r["note"] or "",
+        )
+    console.print(table)
+
+
+@click.command(name="auth-status")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output as JSON.",
+)
+@click.option(
+    "--interval",
+    "interval",
+    type=float,
+    default=4.0,
+    show_default=True,
+    help="Seconds between the two pane captures used for the frozen check.",
+)
+@click.pass_context
+def auth_status(ctx: click.Context, as_json: bool, interval: float) -> None:
+    """Report each RUNNING TUI agent as OK or LOGIN-REQUIRED.
+
+    Captures every live ``tui-<agent>`` pane twice (``--interval`` apart) and
+    flags an agent only when a system auth banner sits directly above its
+    prompt AND stays frozen across the two reads — so an agent QUOTING the
+    banner while it works is never mistaken for a wedged one. Exits 1 if any
+    agent needs login.
+
+    \b
+    Example:
+      $ sac agents auth-status
+      $ sac agents auth-status --json --interval 6
+    """
+    use_json = _json_flag(ctx, as_json)
+    sessions = _list_tui_sessions()
+    if not sessions:
+        if use_json:
+            click.echo(json_mod.dumps({"agents": [], "login_required": 0}))
+        else:
+            console.print("[dim](no running tui-* agents on this host)[/dim]")
+        return
+    run1 = {_agent_of(s): _capture(s) for s in sessions}
+    time.sleep(max(0.0, interval))
+    run2 = {_agent_of(s): _capture(s) for s in sessions}
+    captures = {name: (run1.get(name), run2.get(name)) for name in run1}
+    rows = evaluate_agents(captures)
+    stuck = [r for r in rows if r["verdict"] == "login_required"]
+    if use_json:
+        click.echo(
+            json_mod.dumps({"agents": rows, "login_required": len(stuck)}, indent=2)
+        )
+    else:
+        _render_table(rows)
+        if stuck:
+            console.print(
+                f"[red]{len(stuck)} agent(s) need login: "
+                f"{', '.join(r['agent'] for r in stuck)}[/red]"
+            )
+    if stuck:
+        sys.exit(1)
+
+
+__all__ = ["auth_status", "evaluate_agents"]

--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -54,7 +54,7 @@ class _AgentsGroup(HelpRecursiveGroup):
             ["create", "start", "twin", "stop", "restart", "delete", "forget", "spawn-from-here"],
         ),
         ("Interact", ["send", "attach"]),
-        ("Inspect", ["list", "status", "health", "tail", "recall"]),
+        ("Inspect", ["list", "status", "health", "auth-status", "tail", "recall"]),
         ("Preflight", ["check"]),
         ("Discovery", ["find"]),
         ("Account", ["accounts"]),
@@ -107,6 +107,13 @@ agent_group.add_command(_rebind(_status_impl, "list"))
 agent_group.add_command(_rebind(_status_impl, "status"))
 agent_group.add_command(_rebind(_tail_impl, "tail"))
 agent_group.add_command(_rebind(_health_impl, "health"))
+# `auth-status` — prompt-anchored TUI login-stuck report (near-prompt banner +
+# distance-frozen across two captures). The reliable version of the operator's
+# ad-hoc auth health check; distinct from `health` (per-agent heartbeat/
+# watchdog). See cli_pkg/_auth_status + _runners/_tmux/auth_status.
+from ._auth_status import auth_status as _auth_status_impl  # noqa: E402
+
+agent_group.add_command(_auth_status_impl)
 
 # Verb leaves
 agent_group.add_command(_rebind(_find_impl, "find"))

--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 import click
 
 from ._agent_prune_claude import prune_claude as _prune_claude_impl
+from ._create import create as _create_impl
 from ._explain import explain as _explain_impl
 from ._helpers import HelpRecursiveGroup
-from ._create import create as _create_impl
 from .agents_prune_claude import archive_claude_bloat as _archive_claude_bloat_impl
 from .build_cmds import check as _check_impl
 from .info_cmds import find as _find_impl

--- a/tests/scitex_agent_container/_runners/_tmux/test_auth_status.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test_auth_status.py
@@ -1,0 +1,377 @@
+"""Prompt-anchored TUI auth-banner matcher — near-prompt + distance-frozen.
+
+Exercises the hardened matcher (``_runners/_tmux/auth_status``) against BOTH
+real cases from the 2026-07-12 live verification:
+
+  * scitex-hpc  — a REAL wedged agent: the "Login expired * Please run /login"
+    banner sits directly above the prompt and stays frozen (same kind, same
+    distance) across two captures even as the 0s-turn spinner ticks
+    → LOGIN-REQUIRED.
+  * scitex-todo — a PROSE false-positive: the agent quotes the banner while
+    replying about the incident, with more output after it, so the banner is
+    high in scrollback (outside the near-prompt tail) and the pane keeps
+    moving → OK.
+
+Plus the real captured pane fixture (``auth_error_head-mba_v2.1.114.txt``) so
+the matcher is proven against Anthropic's actual rendering, not a guess.
+
+No mocks: every case is a pure function call on captured pane text.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._runners._tmux import prompts as P
+from scitex_agent_container._runners._tmux.auth_status import (
+    TAIL_LINES,
+    banner_kind,
+    evaluate,
+    is_stuck,
+    probe_pane,
+    probe_to_state,
+)
+
+_REAL_PANE = (
+    Path(__file__).parents[2]
+    / "fixtures"
+    / "pane_states"
+    / "auth_error_head-mba_v2.1.114.txt"
+)
+
+# --------------------------------------------------------------------------
+# Fixtures — captured-pane shapes (verbatim TUI rendering).
+# --------------------------------------------------------------------------
+
+# REAL wedged agent (scitex-hpc): banner directly above the prompt; the
+# volatile 0s-turn spinner sits between it and the prompt (must be stripped so
+# distance stays 0). Two runs differ ONLY in the spinner verb — still frozen.
+_HPC_1 = """\
+● Login expired · Please run /login
+✻ Sautéed for 0s
+────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────
+  Opus 4.8 | ctx:56% | 5h:49%
+  ⏵⏵ bypass permissions on (shift+tab to cycle)
+"""
+_HPC_2 = _HPC_1.replace("Sautéed for 0s", "Simmered for 0s")
+
+# PROSE false-positive (scitex-todo): the exact banner is QUOTED high in the
+# conversation, then the agent keeps replying — so it is outside the last
+# TAIL_LINES non-chrome lines above the prompt.
+_PROSE_HIGH = """\
+● Investigating the fleet auth incident now. The system banner was:
+  ⎿  Login expired · Please run /login
+● I checked every flagged agent against the real rendering.
+  Two were false positives — they quoted the phrase in prose while
+  actively replying to operator DMs, pane still moving.
+  The one real case was scitex-hpc: frozen, banner right above the
+  prompt, zero-second turns on every /loop wakeup.
+  The distinguisher is distance-from-prompt plus a cross-run frozen check.
+  I am drafting the hardened matcher in the sac package now.
+  It reuses prompts for the prompt anchor and pane capture for the read.
+────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────
+  [Opus 4.8 | Max] │ scitex-todo git:(develop)
+  Context ██░░░░░░░░ 23% │ Usage ███░░░░░░░ 33% (1h 50m / 5h)
+"""
+
+# Banner IS in the near-prompt tail but the pane MOVES (agent produced a new
+# line) → distance changes → NOT frozen. Exercises the distance refinement.
+_MOVING_1 = """\
+● Login expired · Please run /login
+  Retrying the scheduled task now.
+────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────
+  Opus 4.8 | ctx:56% | 5h:49%
+"""
+_MOVING_2 = """\
+● Login expired · Please run /login
+  Retrying the scheduled task now.
+  Still failing with the same banner.
+────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────
+  Opus 4.8 | ctx:56% | 5h:49%
+"""
+
+# Healthy idle agent — no banner anywhere.
+_HEALTHY = """\
+  I'll continue with the coverage fix now.
+────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────
+  [Sonnet 5 | Max] │ fix-coverage git:(fix/cov*)
+  Context ██░░░░░░░░ 19% │ Usage ██░░░░░░░░ 24% (1h 32m / 5h)
+  ⏵⏵ bypass permissions on · 1 shell · ← for agents
+"""
+
+# Classic discuss-the-incident prose: every trigger phrase, none at line-start.
+_PROSE_INLINE = """\
+● figrecipe died in a "Login expired" loop; the banner said Please run /login
+  but a valid token existed. invalid_grant / authentication_error are the
+  server-side symptoms. I flagged 2 agents showing Login expired on screen.
+────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────
+  [Opus 4.8 | Max] │ scitex-agent-container git:(develop)
+  Context ██░░░░░░░░ 23% │ Usage ███░░░░░░░ 33% (1h 50m / 5h)
+"""
+
+
+# --------------------------------------------------------------------------
+# prompt_line_index — the reused prompt anchor.
+# --------------------------------------------------------------------------
+
+
+def test_prompt_line_index_picks_bottom_most_prompt():
+    # Arrange
+    pane = "❯\n────\nold output\n────\n❯\n────\n"
+    # Act
+    idx = P.prompt_line_index(pane)
+    # Assert
+    assert idx == 4
+
+
+def test_prompt_line_index_ignores_mid_sentence_marker():
+    # Arrange
+    pane = "  the banner sits above the ❯ prompt when frozen\nplain line\n"
+    # Act
+    idx = P.prompt_line_index(pane)
+    # Assert
+    assert idx is None
+
+
+def test_prompt_line_index_real_pane_lands_on_prompt_line():
+    # Arrange
+    pane = _REAL_PANE.read_text(encoding="utf-8")
+    # Act
+    idx = P.prompt_line_index(pane)
+    # Assert
+    assert pane.splitlines()[idx].strip().startswith("❯")
+
+
+def test_prompt_line_index_real_pane_picks_bottom_box():
+    # Arrange
+    lines = _REAL_PANE.read_text(encoding="utf-8").splitlines()
+    # Act
+    idx = P.prompt_line_index("\n".join(lines))
+    # Assert
+    assert idx == max(i for i, ln in enumerate(lines) if ln.strip().startswith("❯"))
+
+
+# --------------------------------------------------------------------------
+# banner_kind — start-anchored, prose-rejecting.
+# --------------------------------------------------------------------------
+
+
+def test_banner_kind_login_expired_after_marker_strip():
+    # Arrange
+    line = "  ⎿  Login expired · Please run /login"
+    # Act
+    kind = banner_kind(line)
+    # Assert
+    assert kind == "Login expired"
+
+
+def test_banner_kind_not_logged_in_with_bullet_marker():
+    # Arrange
+    line = "● Not logged in · Please run /login"
+    # Act
+    kind = banner_kind(line)
+    # Assert
+    assert kind == "Not logged in"
+
+
+def test_banner_kind_please_run_login_with_trailing_401():
+    # Arrange
+    line = '  ⎿  Please run /login · API Error: 401 {"type":"error"}'
+    # Act
+    kind = banner_kind(line)
+    # Assert
+    assert kind == "Please run /login"
+
+
+def test_banner_kind_standalone_api_error_401():
+    # Arrange
+    line = '  API Error: 401 {"type":"error"}'
+    # Act
+    kind = banner_kind(line)
+    # Assert
+    assert kind == "API Error: 4xx"
+
+
+def test_banner_kind_rejects_prose_mentioning_the_phrase():
+    # Arrange
+    line = '● figrecipe died in a "Login expired" loop; Please run /login'
+    # Act
+    kind = banner_kind(line)
+    # Assert
+    assert kind is None
+
+
+def test_banner_kind_ignores_rate_limit_429():
+    # Arrange
+    line = "  API Error: 429 rate_limit"
+    # Act
+    kind = banner_kind(line)
+    # Assert
+    assert kind is None
+
+
+# --------------------------------------------------------------------------
+# probe_pane — near-prompt tail membership + distance.
+# --------------------------------------------------------------------------
+
+
+def test_probe_real_wedged_banner_present_at_distance_zero():
+    # Arrange
+    pane = _HPC_1
+    # Act
+    probe = probe_pane(pane)
+    # Assert
+    assert (probe.present, probe.distance, probe.banner) == (True, 0, "Login expired")
+
+
+def test_probe_prose_quote_high_is_outside_tail():
+    # Arrange
+    pane = _PROSE_HIGH
+    # Act
+    probe = probe_pane(pane)
+    # Assert
+    assert (probe.present, probe.distance) == (False, None)
+
+
+def test_probe_inline_prose_is_not_a_banner():
+    # Arrange
+    pane = _PROSE_INLINE
+    # Act
+    probe = probe_pane(pane)
+    # Assert
+    assert probe.present is False
+
+
+def test_probe_healthy_pane_has_no_banner():
+    # Arrange
+    pane = _HEALTHY
+    # Act
+    probe = probe_pane(pane)
+    # Assert
+    assert probe.present is False
+
+
+def test_probe_real_captured_fixture_flags_banner():
+    # Arrange
+    pane = _REAL_PANE.read_text(encoding="utf-8")
+    # Act
+    probe = probe_pane(pane)
+    # Assert
+    assert (probe.present, probe.banner) == (True, "Please run /login")
+
+
+def test_probe_real_captured_fixture_banner_within_tail():
+    # Arrange
+    pane = _REAL_PANE.read_text(encoding="utf-8")
+    # Act
+    probe = probe_pane(pane)
+    # Assert
+    assert probe.distance is not None and probe.distance <= TAIL_LINES
+
+
+# --------------------------------------------------------------------------
+# is_stuck / evaluate — the cross-run distance-frozen decision.
+# --------------------------------------------------------------------------
+
+
+def test_first_capture_is_never_stuck():
+    # Arrange
+    pane = _HPC_1
+    # Act
+    _probe, stuck = evaluate(pane, None)
+    # Assert
+    assert stuck is False
+
+
+def test_frozen_banner_across_two_runs_is_stuck():
+    # Arrange
+    probe1, _ = evaluate(_HPC_1, None)
+    # Act
+    probe2, stuck = evaluate(_HPC_2, probe_to_state(probe1))
+    # Assert
+    assert (stuck, probe2.distance == probe1.distance) == (True, True)
+
+
+def test_moving_banner_in_tail_is_not_stuck():
+    # Arrange
+    probe1, _ = evaluate(_MOVING_1, None)
+    # Act
+    probe2, stuck = evaluate(_MOVING_2, probe_to_state(probe1))
+    # Assert
+    assert (probe1.distance, probe2.distance, stuck) == (1, 2, False)
+
+
+def test_moving_banner_stays_present_in_tail():
+    # Arrange
+    probe1, _ = evaluate(_MOVING_1, None)
+    # Act
+    probe2, _stuck = evaluate(_MOVING_2, probe_to_state(probe1))
+    # Assert
+    assert (probe1.present, probe2.present) == (True, True)
+
+
+def test_prose_quote_never_stuck_across_runs():
+    # Arrange
+    probe1, _ = evaluate(_PROSE_HIGH, None)
+    # Act
+    _probe2, stuck = evaluate(_PROSE_HIGH, probe_to_state(probe1))
+    # Assert
+    assert stuck is False
+
+
+def test_real_fixture_frozen_two_reads_is_stuck():
+    # Arrange
+    pane = _REAL_PANE.read_text(encoding="utf-8")
+    probe1, _ = evaluate(pane, None)
+    # Act
+    _probe2, stuck = evaluate(pane, probe_to_state(probe1))
+    # Assert
+    assert stuck is True
+
+
+def test_is_stuck_without_prior_state_is_false():
+    # Arrange
+    probe = probe_pane(_HPC_1)
+    # Act
+    stuck = is_stuck(probe, None)
+    # Assert
+    assert stuck is False
+
+
+def test_is_stuck_with_matching_prior_state_is_true():
+    # Arrange
+    probe = probe_pane(_HPC_1)
+    # Act
+    stuck = is_stuck(probe, probe_to_state(probe))
+    # Assert
+    assert stuck is True
+
+
+def test_uncapturable_pane_probe_is_not_present():
+    # Arrange
+    prev = {"present": True, "distance": 0, "banner": "Login expired"}
+    # Act
+    probe, _stuck = evaluate(None, prev)
+    # Assert
+    assert probe.present is False
+
+
+def test_uncapturable_pane_is_never_stuck():
+    # Arrange
+    prev = {"present": True, "distance": 0, "banner": "Login expired"}
+    # Act
+    _probe, stuck = evaluate(None, prev)
+    # Assert
+    assert stuck is False

--- a/tests/scitex_agent_container/cli_pkg/test__auth_status.py
+++ b/tests/scitex_agent_container/cli_pkg/test__auth_status.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from click.testing import CliRunner
 
-from scitex_agent_container.cli_pkg._auth_status import auth_status, evaluate_agents
+from scitex_agent_container.cli_pkg._auth_status import evaluate_agents
 from scitex_agent_container.cli_pkg.agent_group import agent_group
 
 # Wedged: banner directly above the prompt, identical on both reads → frozen.

--- a/tests/scitex_agent_container/cli_pkg/test__auth_status.py
+++ b/tests/scitex_agent_container/cli_pkg/test__auth_status.py
@@ -1,0 +1,76 @@
+"""`sac agents auth-status` command core — the pure `evaluate_agents` mapper
+plus command registration/help.
+
+`evaluate_agents` turns each agent's two captured panes into an OK /
+LOGIN-REQUIRED verdict via the near-prompt + distance-frozen matcher. These
+tests use compact captured-pane fixtures (the matcher itself is exercised in
+depth in ``_runners/_tmux/test_auth_status.py``); here we confirm the
+command-level real-vs-prose separation and the wiring. No mocks: pure calls +
+a real Click invocation.
+"""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._auth_status import auth_status, evaluate_agents
+from scitex_agent_container.cli_pkg.agent_group import agent_group
+
+# Wedged: banner directly above the prompt, identical on both reads → frozen.
+_STUCK = "● Login expired · Please run /login\n────────\n❯\n────────\n  ctx:1%\n"
+# Healthy: no banner.
+_OK = "  continuing the task now\n────────\n❯\n────────\n  ctx:1%\n"
+
+
+def test_evaluate_agents_flags_frozen_banner_as_login_required():
+    # Arrange
+    captures = {"scitex-hpc": (_STUCK, _STUCK)}
+    # Act
+    row = evaluate_agents(captures)[0]
+    # Assert
+    assert row["verdict"] == "login_required"
+
+
+def test_evaluate_agents_marks_clean_pane_ok():
+    # Arrange
+    captures = {"figrecipe": (_OK, _OK)}
+    # Act
+    row = evaluate_agents(captures)[0]
+    # Assert
+    assert row["verdict"] == "ok"
+
+
+def test_evaluate_agents_uncapturable_agent_is_ok_and_uncaptured():
+    # Arrange
+    captures = {"gone": (None, None)}
+    # Act
+    row = evaluate_agents(captures)[0]
+    # Assert
+    assert (row["verdict"], row["captured"]) == ("ok", False)
+
+
+def test_evaluate_agents_sorts_rows_by_agent_name():
+    # Arrange
+    captures = {"zeta": (_OK, _OK), "alpha": (_OK, _OK)}
+    # Act
+    names = [r["agent"] for r in evaluate_agents(captures)]
+    # Assert
+    assert names == ["alpha", "zeta"]
+
+
+def test_auth_status_command_registered_under_agents_group():
+    # Arrange
+    group = agent_group
+    # Act
+    registered = "auth-status" in group.commands
+    # Assert
+    assert registered is True
+
+
+def test_auth_status_help_renders_interval_option():
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(agent_group, ["auth-status", "--help"])
+    # Assert
+    assert result.exit_code == 0 and "--interval" in result.output


### PR DESCRIPTION
## Why

The current TUI auth matcher flags a \`Login expired · Please run /login\` banner **anywhere** on the pane, so agents **quoting** the banner while discussing the 2026-07-11 auth incident get false-flagged. Verified live 2026-07-12: \`--report\` flagged 4 agents; **3 were prose false-positives** (scitex-todo quoted it 3× while replying to DMs), **1 was real** (scitex-hpc: frozen, banner directly above \`❯\`, 0-second \`/loop\` turns).

The distinguisher: **REAL** = banner in the conversation tail directly above the prompt **and frozen**; **PROSE** = banner higher in scrollback with more output after it, pane still moving.

## What (all in the sac package, PR-gated — the live dotfiles watchdog is untouched)

**1. Matcher** — \`_runners/_tmux/auth_status.py\` (pure, no tmux, unit-testable):
- **reuses** \`prompts.prompt_line_index\` (NBSP-aware \`❯\` anchor, added to \`prompts.py\`) to find the input line — does not re-derive prompt detection;
- matches the banner **only in the conversation TAIL** (last ~6 non-chrome lines above the prompt), never in higher scrollback;
- tracks the banner's **distance** from the prompt + its **kind** in caller-held **local state**; **STUCK = banner in tail AND distance unchanged across two runs** (frozen). A changing distance = agent producing output → OK. Volatile chrome (spinners/gauges/the 0s-turn \`for 0s\` marker) is stripped so a cosmetic tick never reads as movement.

**2. \`sac agents auth-status\`** — \`cli_pkg/_auth_status.py\`: captures each live \`tui-<agent>\` pane **twice** (\`--interval\` apart), runs the matcher, prints OK / LOGIN-REQUIRED (table or \`--json\`), exits 1 if any agent needs login. Distinct from the existing \`sac agents health\` (per-agent heartbeat/watchdog).

**3. Tests (no mocks)** — 32 passing:
- \`test_auth_status.py\` — matcher: scitex-hpc frozen → LOGIN-REQUIRED, scitex-todo prose-quote-high → OK, banner-in-tail-but-moving → OK, and the **real captured** \`auth_error_head-mba_v2.1.114.txt\` fixture;
- \`cli_pkg/test__auth_status.py\` — \`evaluate_agents\` verdict mapping + command registration/help.

## Key finding / deviation from card spec

The card said "reuse \`pane_capture.py\` for capture", but **\`pane_capture.py\` targets the wrong tmux server/session for the live TUI fleet** (\`sac-<name>\` on \`-L sac\` — a different runtime). The live TUI agents run as \`tui-<name>\` on the **default** server (confirmed via \`runtimes/tui_session.session_name_for\` + \`TmuxManager\`). The command therefore captures on the default server with \`tui-\` sessions, reusing pane_capture's \`-p -J\` **shape** but the correct target. Prompt-detection reuse (\`prompts.py\`) is as specified.

Not included: the card's optional \`42_tui-pattern-recognition.md\` skill (documentation, outside the delegated build scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)