### PR TITLE
fix(listen): detached/deferred self-restart — no more deadlock 502

### DIFF
--- a/src/scitex_agent_container/_listen/_agent_restart.py
+++ b/src/scitex_agent_container/_listen/_agent_restart.py
@@ -22,12 +22,25 @@ Shape mirrors ``agents_start`` exactly:
     uses for ``sac agents start``) and return its rc + stdout + stderr
     as JSON. A non-zero rc is surfaced as 502 (the gate passed but the
     bare-host restart itself failed), never swallowed.
+
+SELF-RESTART special case (caller IS the target): shelling the restart
+SYNCHRONOUSLY would DEADLOCK — the stop-half cannot complete while the
+CALLING process is still blocked awaiting this HTTP response, so the
+start-half sees "already running -> no-op" and returns a confusing 502
+(incident 2026-07-12). When the resolved ``caller`` equals ``name`` the
+handler instead spawns a fully-detached, deferred bounce (``setsid`` +
+``start_new_session``) that sleeps a few seconds so THIS response flushes
+first, then force-bounces the agent, and returns ``202`` with
+``self_restart="scheduled"`` immediately. An external / admin restart
+(caller is None, or caller != name) keeps the synchronous path unchanged.
 """
 
 from __future__ import annotations
 
 import asyncio
 import os
+import shlex
+import subprocess
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -36,6 +49,92 @@ from .._sac_binary import SacBinaryNotFoundError, sac_binary
 from ._acl import check_lineage_acl, deny_response
 
 __all__ = ["agent_restart"]
+
+
+# Delay (seconds) before a DETACHED self-restart bounce actually fires.
+# Long enough for THIS handler's 202 to flush over the wire to the caller's
+# MCP client and for that restart tool-call to unwind CLEANLY before the
+# caller's own process is bounced — the self-restart deadlock is precisely
+# that the caller cannot die while it is still awaiting this very response.
+# Short enough that the heal is prompt (the corrected-dependency use case
+# wants the fresh process back quickly). 3s sits comfortably above a
+# localhost/LAN round-trip yet well under any human's patience.
+_SELF_RESTART_DELAY_S = 3
+
+
+def _build_detached_restart_argv(
+    sac_bin: str,
+    name: str,
+    *,
+    fresh: bool,
+    delay_s: int,
+    log_path: str,
+) -> list[str]:
+    """Build the fully-detached, deferred self-restart command (PURE — no I/O).
+
+    Returned as a ``setsid sh -c '<inner>'`` argv so the constructed command
+    is unit-assertable WITHOUT spawning anything. ``<inner>`` is::
+
+        sleep <delay_s>; ( echo <marker>; date -Is; <bounce> ) >> <log> 2>&1
+
+    * ``sleep <delay_s>`` defers the bounce past this handler's 202 flush so
+      the caller's restart tool-call returns cleanly before the caller is
+      bounced (see :data:`_SELF_RESTART_DELAY_S`).
+    * ``<bounce>`` is the FORCED restart. ``sac agents restart`` exposes no
+      ``--force`` flag (confirmed: ``cli_pkg/lifecycle/_restart.py`` defines
+      none) and its start-leg runs without force, so a still-running agent
+      trips "already running -> no-op -> use --force" — the exact confusing
+      502 of the deadlock. The deterministic stop-if-running bounce is
+      instead ``sac agents start <name> --force`` (the mechanism the
+      ``fresh`` path already uses): ``--force`` stops any live instance
+      first, and with NO session flag the session then follows the SPEC
+      policy — byte-identical to what a plain ``sac agents restart``
+      resolves (``_lifecycle/_stop.py::agent_restart`` calls
+      ``agent_start(session_override=None)``) — so a resuming (non-fresh)
+      restart is preserved. ``--fresh`` is appended only for a fresh
+      (no-resume) bounce, mirroring the synchronous fresh path verbatim.
+    * stdout+stderr are appended to ``log_path`` (NEVER ``/dev/null``) so the
+      bounce that necessarily outlives this process is debuggable post-hoc.
+
+    ``setsid`` (util-linux — on every host; the twin TTL-stop relies on it
+    too) starts a new session so the child survives BOTH this handler's
+    return AND the caller's imminent death.
+    """
+    bounce = [sac_bin, "agents", "start", name, "--force"]
+    if fresh:
+        bounce.append("--fresh")
+    bounce.append("--json")
+    bounce_str = " ".join(shlex.quote(tok) for tok in bounce)
+    marker = shlex.quote(
+        f"=== sac self-restart name={name} fresh={fresh} delay={int(delay_s)}s ==="
+    )
+    inner = (
+        f"sleep {int(delay_s)}; "
+        f"( echo {marker}; date -Is; {bounce_str} ) >> {shlex.quote(log_path)} 2>&1"
+    )
+    return ["setsid", "sh", "-c", inner]
+
+
+def _spawn_detached(argv: list[str], *, env: dict[str, str]) -> None:
+    """Fire-and-forget spawn of ``argv``, fully detached from this process.
+
+    ``start_new_session=True`` (belt-and-suspenders with the ``setsid`` in
+    ``argv``) severs the child from this handler's session / process-group so
+    it survives the caller's imminent bounce; stdin is ``/dev/null`` and the
+    child's stdout/stderr are already redirected to the log file inside the
+    shell command, so they are ``DEVNULL`` here. A dedicated module-level
+    seam so tests record the argv WITHOUT forking a real bouncer — the same
+    save/restore-seam idiom ``_listen/_restart.py`` uses for ``_kill`` /
+    ``_run_subprocess``.
+    """
+    subprocess.Popen(
+        argv,
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
 
 
 async def agent_restart(request: Request) -> JSONResponse:
@@ -63,6 +162,13 @@ async def agent_restart(request: Request) -> JSONResponse:
 
     On allow, shell ``sac agents restart <name> --yes --json`` on the
     bare host and return its rc + stdout + stderr. rc != 0 → 502.
+
+    Self-restart (resolved ``caller`` == ``name``): the synchronous shell
+    would deadlock (the caller cannot die while awaiting this response), so
+    the bounce is instead handed to a detached, deferred child and the
+    handler returns ``202`` + ``self_restart="scheduled"`` at once. Honours
+    ``fresh``: the detached child force-bounces with ``sac agents start
+    <name> --force`` (resume, spec-policy session) or ``--force --fresh``.
     """
     name = request.path_params["name"]
 
@@ -120,6 +226,60 @@ async def agent_restart(request: Request) -> JSONResponse:
     child_env = dict(os.environ)
     child_env.pop("APPTAINER_CONTAINER", None)
     child_env.pop("SINGULARITY_CONTAINER", None)
+
+    # SELF-RESTART (resolved caller IS the target): a synchronous
+    # ``sac agents restart <self>`` DEADLOCKS — the stop-half cannot complete
+    # while the CALLING process is still blocked awaiting THIS response, so the
+    # start-half sees "already running -> no-op" and returns a confusing 502
+    # (incident 2026-07-12: scitex-dev self-restarting to reload a corrected
+    # dependency). Hand the bounce to a fully-detached, deferred child that
+    # (a) survives the caller's death, (b) sleeps so THIS 202 flushes + the
+    # caller's tool-call unwinds FIRST, then (c) force-bounces — and return 202
+    # immediately. ``caller`` is the already-resolved identity (an unspoofable
+    # per-node bearer, else the body ``caller`` claim); an external / admin
+    # restart (caller is None, OR caller != name) is UNAFFECTED and keeps the
+    # byte-identical synchronous path below.
+    if caller is not None and caller == name:
+        from .._lifecycle._session_reset import _runtime_state_dir
+
+        log_path = _runtime_state_dir(name) / "self-restart.log"
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError:  # stx-allow: fallback (reason: the log dir is best-effort — a failed mkdir must not abort the heal; the bounce still fires and its own shell redirect surfaces any write failure)
+            pass
+        detached_argv = _build_detached_restart_argv(
+            sac_bin,
+            name,
+            fresh=fresh,
+            delay_s=_SELF_RESTART_DELAY_S,
+            log_path=str(log_path),
+        )
+        try:
+            _spawn_detached(detached_argv, env=child_env)
+        except OSError as exc:
+            # Launch-time failure of the detached bouncer itself — surface it
+            # structured (never a fake "scheduled"), same shape as the
+            # resolution-/launch-failure branches on the synchronous path.
+            return JSONResponse(
+                {"name": name, "error": f"{type(exc).__name__}: {exc}"},
+                status_code=500,
+            )
+        return JSONResponse(
+            {
+                "name": name,
+                "self_restart": "scheduled",
+                "fresh": fresh,
+                "detail": (
+                    f"self-restart of {name!r} scheduled (detached, "
+                    f"~{_SELF_RESTART_DELAY_S}s); this process will be bounced "
+                    f"shortly. The call returned cleanly; the bounce happens "
+                    f"after."
+                ),
+                "log": str(log_path),
+            },
+            status_code=202,
+        )
+
     if fresh:
         # New session, no resume: stop-then-start fresh. ``start`` accepts
         # --force (stop if running), --fresh (never --continue) and --json.

--- a/tests/scitex_agent_container/_listen/test_server_restart_route.py
+++ b/tests/scitex_agent_container/_listen/test_server_restart_route.py
@@ -21,11 +21,15 @@ from __future__ import annotations
 
 import json
 import os
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator
 
 import pytest
 from starlette.testclient import TestClient
 
+from scitex_agent_container._listen import _agent_restart as restart_handler_mod
+from scitex_agent_container._listen._agent_restart import _build_detached_restart_argv
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._state.state_db_nodes import (
     mint_node_token,
@@ -132,3 +136,209 @@ def test_restart_researcher_to_developer_not_403(client, isolated_env):
     response = client.post("/agents/scitex-todo/restart", headers=headers)
     # Assert
     assert response.status_code != 403
+
+
+# ---------------------------------------------------------------------------
+# _build_detached_restart_argv — PURE builder (no spawn, no mocks, PA-306).
+# The self-restart argv is asserted here directly, per the "structure the
+# code so the argv is assert-able" contract — never by bouncing a real agent.
+# ---------------------------------------------------------------------------
+
+_SAC = "/opt/venv-sac/bin/sac"
+_LOG = "/run/agent-x/self-restart.log"
+
+
+def test_build_detached_argv_starts_with_setsid():
+    # Arrange — non-fresh (resume) bounce for agent-x.
+    name = "agent-x"
+    # Act
+    argv = _build_detached_restart_argv(_SAC, name, fresh=False, delay_s=3, log_path=_LOG)
+    # Assert — detachment is via setsid (child survives the caller's death).
+    assert argv[0] == "setsid"
+
+
+def test_build_detached_argv_is_setsid_sh_dash_c():
+    # Arrange
+    name = "agent-x"
+    # Act
+    argv = _build_detached_restart_argv(_SAC, name, fresh=False, delay_s=3, log_path=_LOG)
+    # Assert — the deferred command is carried as a single sh -c program.
+    assert argv[:3] == ["setsid", "sh", "-c"]
+
+
+def test_build_detached_argv_nonfresh_forces_start_without_fresh():
+    # Arrange — non-fresh (resume) bounce.
+    name = "agent-x"
+    # Act
+    argv = _build_detached_restart_argv(_SAC, name, fresh=False, delay_s=3, log_path=_LOG)
+    # Assert — `agents start --force` (spec-policy session == plain restart),
+    # NO --fresh: the resuming restart is preserved.
+    assert "agents start agent-x --force --json" in argv[-1] and "--fresh" not in argv[-1]
+
+
+def test_build_detached_argv_fresh_appends_fresh_flag():
+    # Arrange — fresh (no-resume) bounce.
+    name = "agent-x"
+    # Act
+    argv = _build_detached_restart_argv(_SAC, name, fresh=True, delay_s=3, log_path=_LOG)
+    # Assert
+    assert "agents start agent-x --force --fresh --json" in argv[-1]
+
+
+def test_build_detached_argv_defers_by_the_delay():
+    # Arrange
+    name = "agent-x"
+    # Act
+    argv = _build_detached_restart_argv(_SAC, name, fresh=False, delay_s=5, log_path=_LOG)
+    # Assert — sleeps FIRST so THIS handler's 202 flushes to the caller.
+    assert argv[-1].startswith("sleep 5;")
+
+
+def test_build_detached_argv_logs_to_file_not_devnull():
+    # Arrange
+    name = "agent-x"
+    # Act
+    argv = _build_detached_restart_argv(_SAC, name, fresh=False, delay_s=3, log_path=_LOG)
+    # Assert — post-hoc debuggable: appended to the log, never /dev/null.
+    assert _LOG in argv[-1] and "/dev/null" not in argv[-1]
+
+
+def test_build_detached_argv_names_the_agent_in_the_bounce():
+    # Arrange
+    name = "agent-x"
+    # Act
+    argv = _build_detached_restart_argv(_SAC, name, fresh=False, delay_s=3, log_path=_LOG)
+    # Assert — the forced bounce targets exactly this agent.
+    assert "start agent-x --force" in argv[-1]
+
+
+# ---------------------------------------------------------------------------
+# Self-restart handler wiring — caller IS the target → detached 202, no
+# deadlock. The one OS-spawn seam is swapped (hand-rolled save/restore, the
+# same idiom as test__restart.py's `_swap`) so no real bouncer forks; the
+# argv is asserted from the recorder AND (independently) above.
+# ---------------------------------------------------------------------------
+
+
+class _SpawnRecorder:
+    """Records ``_spawn_detached(argv, *, env)`` calls WITHOUT forking a real
+    process (a real detached bouncer would outlive the test and act on the
+    live system). Signature-compatible with the seam it replaces.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[str], dict]] = []
+
+    def __call__(self, argv, *, env):
+        self.calls.append((list(argv), dict(env)))
+
+
+@contextmanager
+def _swap(name: str, value) -> Iterator[None]:
+    """Replace ``_agent_restart.<name>`` for the block (PA-306: hand-rolled
+    seam, no MagicMock / no monkeypatch)."""
+    saved = getattr(restart_handler_mod, name)
+    setattr(restart_handler_mod, name, value)
+    try:
+        yield
+    finally:
+        setattr(restart_handler_mod, name, saved)
+
+
+def test_self_restart_returns_202(client, isolated_env):
+    # Arrange — alice restarts alice (caller == target). Swap sac_binary (so
+    # the test is hermetic w.r.t. the install layout) + the spawn seam.
+    recorder = _SpawnRecorder()
+    headers = _node_headers("alice")
+    # Act
+    with _swap("sac_binary", lambda: "/fake/sac"), _swap("_spawn_detached", recorder):
+        response = client.post("/agents/alice/restart", headers=headers)
+    # Assert — clean 202, NOT the confusing 502 the sync path produced.
+    assert response.status_code == 202
+
+
+def test_self_restart_body_marks_scheduled(client, isolated_env):
+    # Arrange
+    recorder = _SpawnRecorder()
+    headers = _node_headers("alice")
+    # Act
+    with _swap("sac_binary", lambda: "/fake/sac"), _swap("_spawn_detached", recorder):
+        response = client.post("/agents/alice/restart", headers=headers)
+    body = json.loads(response.content)
+    # Assert
+    assert body["self_restart"] == "scheduled"
+
+
+def test_self_restart_spawns_detached_setsid_bounce(client, isolated_env):
+    # Arrange
+    recorder = _SpawnRecorder()
+    headers = _node_headers("alice")
+    # Act
+    with _swap("sac_binary", lambda: "/fake/sac"), _swap("_spawn_detached", recorder):
+        client.post("/agents/alice/restart", headers=headers)
+    argv = recorder.calls[0][0]
+    # Assert — a detached (setsid) forced bounce naming the agent was spawned.
+    assert argv[0] == "setsid" and "agents start alice --force --json" in argv[-1]
+
+
+def test_self_restart_fresh_bounce_carries_fresh_flag(client, isolated_env):
+    # Arrange — fresh=true self-restart → detached bounce carries --fresh.
+    recorder = _SpawnRecorder()
+    headers = _node_headers("alice")
+    # Act
+    with _swap("sac_binary", lambda: "/fake/sac"), _swap("_spawn_detached", recorder):
+        client.post("/agents/alice/restart", headers=headers, json={"fresh": True})
+    # Assert
+    assert "agents start alice --force --fresh --json" in recorder.calls[0][0][-1]
+
+
+def test_self_restart_bounce_env_strips_apptainer_marker(client, isolated_env):
+    # Arrange — the detached bounce must inherit the in-SIF-stripped env so it
+    # never re-brokers back into a container (same recursion guard as sync).
+    recorder = _SpawnRecorder()
+    headers = _node_headers("alice")
+    os.environ["APPTAINER_CONTAINER"] = "/some/parent.sif"
+    try:
+        # Act
+        with _swap("sac_binary", lambda: "/fake/sac"), _swap(
+            "_spawn_detached", recorder
+        ):
+            client.post("/agents/alice/restart", headers=headers)
+    finally:
+        os.environ.pop("APPTAINER_CONTAINER", None)
+    # Assert
+    assert "APPTAINER_CONTAINER" not in recorder.calls[0][1]
+
+
+# ---------------------------------------------------------------------------
+# External / admin restart (caller != target) — the synchronous path is
+# UNCHANGED: the self-restart branch is skipped, NO detached bounce spawns.
+# ---------------------------------------------------------------------------
+
+
+def test_admin_restart_caller_none_does_not_self_schedule(client, isolated_env):
+    # Arrange — host bearer resolves caller to None (admin); target is a ghost.
+    # Only the spawn seam is swapped (sac_binary is left real so the sync
+    # bare-host shell runs exactly as before); the recorder proves the
+    # self-restart branch was NOT taken.
+    recorder = _SpawnRecorder()
+    # Act
+    with _swap("_spawn_detached", recorder):
+        response = client.post("/agents/ghost/restart", headers=_host_headers())
+    body = json.loads(response.content)
+    # Assert — synchronous path: no detached bounce, no self_restart marker.
+    assert recorder.calls == [] and "self_restart" not in body
+
+
+def test_node_caller_restarting_peer_does_not_self_schedule(client, isolated_env):
+    # Arrange — neurovista restarts scitex-todo (mesh-allowed, caller != name):
+    # the self-restart branch must be skipped, sync path taken.
+    record_comms_policy(name="neurovista", group_name="researcher")
+    record_comms_policy(name="scitex-todo", group_name="developer")
+    recorder = _SpawnRecorder()
+    headers = _node_headers("neurovista")
+    # Act
+    with _swap("_spawn_detached", recorder):
+        response = client.post("/agents/scitex-todo/restart", headers=headers)
+    # Assert — an allowed cross-agent restart never self-schedules.
+    assert recorder.calls == [] and response.status_code != 403


### PR DESCRIPTION
## Incident

Self-restart of a running agent is broken. When an agent calls the MCP tool `agent_restart(name=<itself>)` (resolved caller == target), the host `sac listen` returns a confusing **502**: `Agent 'X' is already running. No-op. Use --force.` (plus a mixed `SUCC: X started` line). Reported by the **scitex-dev** agent on 2026-07-12 while trying to self-restart to pick up a corrected dependency that needed a fresh process.

## Root cause

`src/scitex_agent_container/_listen/_agent_restart.py::agent_restart` shelled `sac agents restart <name> --yes --json` **synchronously** (`asyncio.create_subprocess_exec` + `await proc.communicate()`). When caller == target this **deadlocks**: the stop-half cannot complete while the CALLING process is still blocked awaiting this very HTTP response, so the start-half sees "already running -> no-op" and returns the confusing 502.

## Fix — detached/deferred self-restart

When the already-resolved `caller` equals `name`, the handler now:

1. Builds a **fully-detached** bounce (`setsid` + `start_new_session=True`) that survives BOTH this handler's return AND the caller's imminent death.
2. **Defers** it ~3s (`_SELF_RESTART_DELAY_S`) via `sleep` so THIS HTTP response flushes and the caller's MCP call unwinds cleanly BEFORE its process is bounced.
3. Force-bounces via **`sac agents start <name> --force [--fresh] --json`** — `sac agents restart` exposes no `--force` and its start-leg lacks force (the exact "already running" source); `start --force` is the deterministic stop-if-running mechanism the `fresh` path already used, and with **no session flag** the session follows the **spec policy** — byte-identical to what a plain `sac agents restart` resolves (`_lifecycle/_stop.py::agent_restart` calls `agent_start(session_override=None)`), so a resuming (non-fresh) restart is preserved. `--fresh` is appended only when `fresh=true`.
4. Returns **`202 Accepted`** immediately with `{name, self_restart: "scheduled", fresh, detail, log}`.

The detached run's stdout+stderr are appended to `<runtime>/<name>/self-restart.log` (never `/dev/null`) for post-hoc debugging.

**External / admin restart** (caller is `None`, OR caller != name) keeps the synchronous path **byte-for-byte unchanged**.

## Forced-bounce argv / delay / detachment

- **argv (non-fresh):** `setsid sh -c 'sleep 3; ( echo <marker>; date -Is; <sac> agents start <name> --force --json ) >> <log> 2>&1'` — `--fresh` inserted for the fresh case.
- **delay 3s:** above a localhost/LAN round-trip so the 202 flushes + the caller's tool-call unwinds first; well under a human's patience so the heal is prompt.
- **detachment:** `setsid` in the argv (assert-able) + `start_new_session=True` on the `Popen` (belt-and-suspenders), stdin `/dev/null`, in-SIF env markers stripped (same recursion guard as the sync path).

## Tests

`tests/scitex_agent_container/_listen/test_server_restart_route.py` (+14):

- **7 pure, mock-free** `_build_detached_restart_argv` tests — setsid prefix, `start --force` (no `--fresh` for resume), `--fresh` for fresh, `sleep <delay>` deferral, logs-to-file-not-`/dev/null`, names the agent.
- **5 handler-wiring** tests — caller==name → `202` + `self_restart=="scheduled"`, detached setsid argv captured via a hand-rolled spawn seam (PA-306: no MagicMock/monkeypatch, no real bounce), `--fresh` propagation, in-SIF env stripping.
- **2 external-path regression** tests — caller `None` (host bearer) and caller!=name (mesh-allowed) both skip the self-restart branch (no detached bounce) and keep the synchronous path.

**18/18** pass in the file; **67** related restart tests (client, MCP tool, `sac listen restart` daemon) still pass — no regression. Touches only the self-restart fix + its test.

## Risks

- **Delay tuning:** too short risks bouncing the caller before the 202 reaches it (its MCP call would error with a reset); 3s is comfortably safe for localhost/LAN. Too long merely delays the heal.
- **Detached lifecycle:** the bounce is a `setsid` child reparented to init — if the host `sac listen` restarts during the `sleep`, the child is **unaffected** (it is not a child of the daemon). It is a best-effort timer that does NOT survive a host reboot during the sleep window (same soft-cap property as the twin TTL-stop).
- **Caller's in-flight work is lost** — intentional: the caller explicitly asked to be restarted, so its current turn/context is bounced (a non-fresh restart resumes the conversation via spec policy; a fresh one does not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
