### PR TITLE
docs(skills): agent-to-agent recovery skill (44 + 45)

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/44_agent-to-agent-recovery.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/44_agent-to-agent-recovery.md
@@ -1,0 +1,107 @@
+---
+description: |
+  [TOPIC] Agent-to-agent recovery — WHEN to use each fleet self-heal mechanism (prompt / tmux client-command / MCP tool / hook) to un-wedge a peer from YOUR session, so agents recover each other into fleet resilience.
+  [DETAILS] A wedged agent (auth-expired, MCP disconnected, stuck mid-turn) can be recovered agent-to-agent without the operator. Four mechanisms, one decision tree keyed on the TARGET's state: PROMPT (cct/a2a to a live main loop), CLIENT-COMMAND (`tmux send-keys -l` into a live TUI pane — bypasses registry/MCP; full recipe in the companion [45_agent-to-agent-recovery-tmux.md](45_agent-to-agent-recovery-tmux.md)), MCP (`agent_status` for the verdict, `agent_send` to deliver — but heed the in-container read-path caveat below), and HOOK/cron (the auth-heal watchdog and friends). Load before recovering a peer or before trusting a cross-agent "down" verdict. Grounds in source: `cli_pkg/status_cmds.py` (status brokers to host-listen; health does not), `cli_pkg/_send_resolve.py`, `_state/state_db.py`, `runtimes/_tui_outbound.py`.
+tags: [scitex-agent-container-agent-to-agent-recovery, recovery, a2a, tmux, watchdog]
+---
+
+# Agent-to-agent recovery (self-heal a wedged peer)
+
+When a fleet agent is wedged — auth-expired, MCP disconnected, stuck
+mid-turn — you can recover it **from your own session**, agent-to-agent,
+without waiting for the operator. There are **four** mechanisms; each has
+a clear WHEN. Pick by the TARGET's state, cheapest first.
+
+## Decision tree — pick by the target's state
+
+| Target state | Use | Why |
+|---|---|---|
+| **Responsive** — main loop alive, draining its inbox | **Prompt** (cct reply / `a2a_send`) | it reasons + acts agentically; cheapest |
+| **Wedged**, but its TUI pane is alive (auth banner, stuck prompt, MCP dialog) | **Client-command** (`tmux send-keys -l`) | bypasses registry / MCP / `agent_send`; keystrokes land on the screen |
+| Need a **structured** status or action AND the target resolves | **MCP** (`agent_status` = verdict, `agent_send` = deliver) | programmatic — but heed the read-path caveat in §3 |
+| **Recurring / systemic** — should not need a trigger | **Hook / cron** | fires on its own (auth-heal watchdog, format enforcement, drift) |
+
+Escalate down the table only as needed: a responsive agent takes a
+prompt; a prompt that queues unread means the loop is wedged → go to the
+client-command.
+
+## 1. Prompt — natural language to a LIVE main loop
+
+FIRST choice when the agent is merely **idle**, not wedged. Send a
+natural-language instruction to the target's main loop — a cct Telegram
+reply, or `a2a_send` (see [07_a2a-protocol.md](07_a2a-protocol.md),
+[29_progress-reporting-to-lead.md](29_progress-reporting-to-lead.md)).
+The agent reads it on its next turn, reasons, and acts. **Requires a
+responsive agent:** if the main loop is not draining its inbox the prompt
+just queues unread — that is the signal to escalate to the client-command.
+
+## 2. Client-command — tmux keystrokes into the pane
+
+Use when the agent is **wedged but its TUI pane is alive** — an auth
+banner, a stuck prompt, or an MCP dialog you must drive. This works
+**regardless of registry / MCP / `agent_send` state**: it talks straight
+to the screen, so it is immune to the read-path caveat in §3. **This is
+THE reliable last-resort recovery.**
+
+TUI agents run in tmux session **`tui-<name>` on the DEFAULT server**
+(SDK auto-accept panes are `sac-<name>` on `-L sac` — a different
+concern; see [42_tui-auth-watchdog.md](42_tui-auth-watchdog.md) §6).
+Always confirm the live session name with `tmux ls` first.
+
+The **`-l` (literal) flag is REQUIRED** for the containerized Ink/React
+`claude` TUI — without it, keystrokes silently do not land. The full
+recipe (capture-before → send `-l` → submit Enter → capture-after) and
+the `/mcp`-reconnect-via-tmux sequence live in the companion
+[45_agent-to-agent-recovery-tmux.md](45_agent-to-agent-recovery-tmux.md).
+Reach for it whenever a prompt and `agent_send` both fail to move the agent.
+
+## 3. MCP tool — structured, but mind the in-container read-path
+
+`agent_send` / `agent_status` / `a2a_send` are the structured,
+programmatic surface — BEST when the target resolves. But there is a
+**live gotcha** about WHICH datastore they read.
+
+**Caveat — run FROM INSIDE a container:**
+
+| Command | Reads | Cross-agent verdict |
+|---|---|---|
+| `agent_status` | brokers to the **host listen** (`_status_via_host_listen`, `status_cmds.py`) → real fleet registry | **trustworthy** |
+| `agent_send` · `agents health` · `sac db query --agent` | the **per-agent** `state.db` bound at `/state/<name>` — only that agent's turn-bridge ledgers, NOT the fleet registry | **MIS-REPORTS** other live agents as `stopped` / `not running` / `not found` |
+
+Why: `agents health` builds a local `Registry()` and returns
+*"Agent '<name>' not found"* for any peer (no host-listen broker —
+`status_cmds.py::health`), and `agent_send` resolves the endpoint from
+the local `instances` / port-allocator tables (`_send_resolve.py`,
+`_state/state_db.py`). Only `status` brokers to the host.
+
+**RULE:** for a cross-agent verdict from inside a container, trust
+**`agent_status`** (or read the host
+`~/.scitex/agent-container/runtime/state.db` directly). Do **NOT** trust
+an in-container `agent_send` / `agents health` "down" verdict — verify it
+before acting on it. (A fix is carded: give `agents health` the same host
+broker `status` has, and route `agent_send` via the host listen.)
+
+## 4. Hook / cron — automated, unattended, systemic
+
+For recovery that should fire **without any human or agent trigger**: the
+auth-heal watchdog restarts auth-wedged agents (see
+[42_tui-auth-watchdog.md](42_tui-auth-watchdog.md) /
+[43_tui-auth-watchdog-maintenance.md](43_tui-auth-watchdog-maintenance.md)),
+plus format enforcement and drift detection. This is the mechanism a
+recurring failure mode graduates to — once a manual recovery repeats,
+encode it here so no one has to notice next time.
+
+## Imitate this
+
+Every mechanism above is peer-agnostic: any agent can run it on any other
+agent. That symmetry is what makes the fleet self-healing — when you
+recover a peer you are also demonstrating the recovery the next agent
+will copy.
+
+## See also
+
+- [45_agent-to-agent-recovery-tmux.md](45_agent-to-agent-recovery-tmux.md) — the `tmux send-keys -l` recipe + `/mcp` reconnect (mechanism 2 in depth)
+- [42_tui-auth-watchdog.md](42_tui-auth-watchdog.md) / [43_tui-auth-watchdog-maintenance.md](43_tui-auth-watchdog-maintenance.md) — the auth watchdog (mechanism 4) + `tui-<name>` topology
+- [07_a2a-protocol.md](07_a2a-protocol.md) — `a2a_send` bus transport (mechanisms 1/3)
+- [19_full-agent-troubleshooting.md](19_full-agent-troubleshooting.md) — stuck-peer recovery + reaper
+- [27_credentials-relogin.md](27_credentials-relogin.md) / [28_credential-refresh.md](28_credential-refresh.md) — auth recovery a restart applies

--- a/src/scitex_agent_container/_skills/scitex-agent-container/45_agent-to-agent-recovery-tmux.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/45_agent-to-agent-recovery-tmux.md
@@ -1,0 +1,98 @@
+---
+description: |
+  [TOPIC] The `tmux send-keys -l` recovery recipe — inject keystrokes into a wedged agent's live TUI pane (auth banner / stuck prompt / MCP dialog); the companion HOW to mechanism 2 in [44_agent-to-agent-recovery.md](44_agent-to-agent-recovery.md).
+  [DETAILS] Hard-won recipe for the containerized Ink/React `claude` TUI: the `-l` (literal) flag is REQUIRED or keystrokes silently do not land; capture-before → `send-keys -l '<text>'` → `send-keys Enter` (a SEPARATE call, NOT `-l`) → capture-after to confirm the pane changed. Plus the `/mcp`-reconnect-via-tmux sequence and its `-32000` failure → full session restart. Target session is `tui-<name>` on the DEFAULT tmux server (source-verified; always confirm the live name with `tmux ls`). Read [44_agent-to-agent-recovery.md](44_agent-to-agent-recovery.md) for WHEN to reach for this vs a prompt / MCP / hook.
+tags: [scitex-agent-container-agent-to-agent-recovery-tmux, recovery, tmux, tui, mcp]
+---
+
+# Agent-to-agent recovery — the tmux keystroke recipe
+
+Companion to [44_agent-to-agent-recovery.md](44_agent-to-agent-recovery.md)
+(mechanism 2). Use this when a peer is **wedged but its TUI pane is alive**
+and both a prompt and `agent_send` have failed to move it. It talks
+straight to the screen, so it is immune to the in-container read-path
+caveat (44 §3).
+
+## Target the right pane
+
+TUI agents run in tmux session **`tui-<name>`** on the **DEFAULT** server
+(no `-L`) — source-verified in `runtimes/_tui_turn_bridge_lifecycle.py`
+and `_tui_turn_bridge_port.py`. SDK auto-accept panes are `sac-<name>` on
+the `-L sac` server — a *different* concern (see
+[42_tui-auth-watchdog.md](42_tui-auth-watchdog.md) §6); do not aim the
+recovery at `-L sac`. **Always confirm the live name first** — the
+convention is fixed but the running set is not:
+
+```bash
+tmux ls                                # sessions on the default server
+tmux capture-pane -t tui-<name> -p     # exactly what the agent sees now
+```
+
+## The recipe — `-l` is REQUIRED
+
+The containerized Ink/React `claude` TUI **ignores non-literal
+send-keys** — without `-l` the keystrokes silently do NOT land (the pane
+stays byte-identical). Always split the TEXT (literal, `-l`) from the
+SUBMIT (a named key, NOT `-l`), and verify by capturing before and after:
+
+```bash
+# 1. capture BEFORE — your baseline
+tmux capture-pane -t tui-<name> -p > /tmp/before.txt
+
+# 2. send the TEXT literally (-l). No trailing newline here.
+tmux send-keys -t tui-<name> -l 'your instruction text'
+
+# 3. SUBMIT — Enter as a NAMED key, a SEPARATE call, NOT -l
+tmux send-keys -t tui-<name> Enter
+
+# 4. capture AFTER — confirm the pane actually changed
+tmux capture-pane -t tui-<name> -p > /tmp/after.txt
+```
+
+If `before.txt` and `after.txt` are identical, the keystrokes did not
+land — the usual cause is a forgotten `-l` on step 2, or the wrong
+session name. Re-check `tmux ls`, then retry.
+
+## MCP reconnect via tmux
+
+When a peer's MCP server has dropped (its tools error out mid-session),
+drive the in-session reconnect from its pane. The `/mcp` command opens a
+modal server dialog; navigate it with arrow keys + Enter (exact key count
+depends on how many servers are listed, so capture-after each step):
+
+```bash
+tmux send-keys -t tui-<name> -l '/mcp'   # open the MCP-server dialog
+tmux send-keys -t tui-<name> Enter
+# navigate (arrow keys) to the FAILED server, Enter to select,
+# then choose Reconnect — verify with capture-pane between steps:
+tmux send-keys -t tui-<name> Down
+tmux send-keys -t tui-<name> Enter
+```
+
+**`-32000` — when in-session reconnect fails.** A telegrammer MCP
+reconnect can come back with a JSON-RPC `-32000` error; the in-session
+`/mcp` reconnect then cannot recover it. The fix is a **full session
+restart**, which re-spawns the MCP fresh:
+
+```bash
+sac agents restart <name>    # in-container: agent_restart / the host broker
+```
+
+Prefer a plain `restart` over `--fresh` unless the agent is wedged on a
+boot prompt whose queued input keeps returning (then `restart --fresh`).
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| pane byte-identical after send | missing `-l` on the text, or wrong session | re-check `tmux ls`; resend text with `-l` |
+| text appears but nothing runs | Enter sent WITH `-l` (typed, not a keypress) | send `Enter` as a separate call, no `-l` |
+| `/mcp` reconnect returns `-32000` | MCP process unrecoverable in-session | `sac agents restart <name>` (re-spawns MCP) |
+| `can't find session` / `no server` | TUI session not running / wrong server | agent may be SDK not TUI, or down — check `agent_status` |
+
+## See also
+
+- [44_agent-to-agent-recovery.md](44_agent-to-agent-recovery.md) — WHEN to use this vs prompt / MCP / hook (the decision tree + the read-path caveat)
+- [42_tui-auth-watchdog.md](42_tui-auth-watchdog.md) / [43_tui-auth-watchdog-maintenance.md](43_tui-auth-watchdog-maintenance.md) — `tui-<name>` vs `sac-<name>` topology, the `tmux capture-pane` matcher
+- [03_auto-accept.md](03_auto-accept.md) — the `-L sac` startup-prompt pane (do NOT target it for recovery)
+- [27_credentials-relogin.md](27_credentials-relogin.md) / [28_credential-refresh.md](28_credential-refresh.md) — auth recovery a restart applies

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -79,6 +79,8 @@ session inside Apptainer (local or remote via SSH), observe via
 - [13_observability.md](13_observability.md) — `sac agents status` JSON contract
 - [42_tui-auth-watchdog.md](42_tui-auth-watchdog.md) — TUI auth-banner detection contract (§1–4)
 - [43_tui-auth-watchdog-maintenance.md](43_tui-auth-watchdog-maintenance.md) — package matcher, auth-heal guards + extend-matcher runbook (§5–6)
+- [44_agent-to-agent-recovery.md](44_agent-to-agent-recovery.md) — recover a wedged peer: prompt/tmux/MCP/hook decision tree
+- [45_agent-to-agent-recovery-tmux.md](45_agent-to-agent-recovery-tmux.md) — the `tmux send-keys -l` recovery recipe + `/mcp` reconnect
 
 ### Lessons
 - [40_troubleshooting.md](40_troubleshooting.md) — Common issues and debugging
@@ -94,12 +96,7 @@ session inside Apptainer (local or remote via SSH), observe via
 
 ## 30-second start
 
-```bash
-pip install scitex-agent-container
-# Each agent lives in its own dir; the dir name is the agent name.
-mkdir -p ~/.scitex/agent-container/agents/my-agent
-$EDITOR ~/.scitex/agent-container/agents/my-agent/spec.yaml   # see 01_config-v3.md
-sac agents start my-agent          # daemon by default; --foreground streams stdio
-sac agents list my-agent --json    # status view
-sac agents tail my-agent           # render session.jsonl transcript
-```
+See [02_quick-start.md](02_quick-start.md) — `pip install
+scitex-agent-container`, drop a `spec.yaml` under
+`~/.scitex/agent-container/agents/<name>/`, then `sac agents start
+<name>` / `list` / `tail`.


### PR DESCRIPTION
## What

A new sac skill documenting **WHEN to use each fleet-recovery mechanism** so an
agent can un-wedge a peer *from its own session* — agent-to-agent — and agents
imitate each other into fleet resilience. Split into two leaves (same pattern as
42/43) to stay within the SK-401 leaf budget:

- **`44_agent-to-agent-recovery.md`** — a **decision tree keyed on the target's
  state** + the four mechanisms:
  1. **Prompt** (cct reply / `a2a_send`) — for a live, responsive main loop.
  2. **Client-command** (`tmux send-keys -l`) — for a wedged-but-pane-alive agent;
     bypasses registry/MCP.
  3. **MCP tool** (`agent_status` / `agent_send`) — structured, with the
     in-container **read-path caveat** (below).
  4. **Hook / cron** — recurring/systemic self-healing (the auth-heal watchdog).
- **`45_agent-to-agent-recovery-tmux.md`** — the hard-won `tmux send-keys -l`
  recipe (literal flag REQUIRED; capture-before/after; Enter as a separate
  keypress), `/mcp` reconnect via tmux, and the `-32000` → full-restart fallback.

## Verify-first (grounded in source, not recollection)

- **Read-path caveat is real and precise.** `cli_pkg/status_cmds.py`: the
  `status` command brokers to the host listen when in-SIF
  (`_status_via_host_listen`, lines ~285-289) → reads the **real fleet
  registry**; `health` (lines ~420-427) builds a local `Registry()` and returns
  *"Agent '<name>' not found"* with **no** host broker. `cli_pkg/_send_resolve.py`
  resolves `agent_send`'s endpoint from the local `instances` / port-allocator
  tables (`_state/state_db.py`), and `runtimes/_tui_outbound.py` documents the
  per-agent `state.db` bound at `/state/<name>`. So from inside a container,
  `agent_send` / `agents health` / `db query --agent` mis-report peers as down;
  **only `agent_status` is trustworthy** for a cross-agent verdict.
- **tmux pane convention verified from source, not asserted blind.** TUI agents
  live in session `tui-<name>` on the **default** server
  (`runtimes/_tui_turn_bridge_lifecycle.py:206`, `_tui_turn_bridge_port.py:160`);
  `sac-<name>` on `-L sac` is the auto-accept pane (a different concern, 42/43
  §6). `Enter` is a separate `send_keys_fn("Enter")` call in
  `runtimes/_tui_compose.py:444`, matching the "Enter is NOT `-l`" rule.
  I could **not** enumerate live panes from the worktree (`tmux ls` returned
  nothing here), so the skill documents `tui-<name>` as source-verified and
  instructs the reader to **confirm the live name with `tmux ls`** rather than
  asserting a running session.

## SKILL.md budget

Both leaves are linked from `SKILL.md` (SK-302). To fit the two new links within
the **SK-301 6 KB / 120-line** budget, I replaced the redundant `30-second start`
code block (it duplicated the already-linked `02_quick-start.md`, and §3 says
SKILL.md is an index) with a one-line pointer. Result: **6107 bytes / 102 lines**
(within 6144 / 120).

## Audit

`audit-skills` run **directly against this worktree's tree** (the installed CLI
resolves the site-packages copy, so I called the engine with `skills_dir=` the
worktree): **0 violations**. Leaf sizes: 44 = 6975 B / 107 lines, 45 = 5261 B /
98 lines (budget 10240 / 200).

## Proposal — where the startup pointer should live (NOT wired here)

Per the ask, this PR ships **only the skill leaves**; wiring a startup pointer is
higher blast radius, so I propose rather than implement:

- **Recommended:** one bullet in the **universal agent baseline**
  (`/home/agent/.claude/CLAUDE.md`, "Agent baseline — universal safety"), e.g.
  *"If a peer agent is wedged, recover it — see sac skill `44_agent-to-agent-recovery`
  (prompt / tmux / MCP / hook decision tree)."* Rationale: recovery is
  **role-agnostic** and this file is the one context **every** container agent
  loads, so it seeds the "imitate each other" behaviour fleet-wide.
- **Alternative (lower blast radius per change, needs a sac code change):** add
  the pointer to sac's **per-agent CLAUDE.md compose / boot skill list** so every
  started agent gets it automatically.

Recommendation: the baseline `CLAUDE.md` bullet — smallest, highest-leverage,
one line. Happy to wire whichever the operator prefers in a follow-up.
