### PR TITLE
fix(overlay): auto-provision the per-agent directory overlay (stillborn new agents)

### DIFF
--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -151,7 +151,41 @@ leak vector (previous-run state contaminates the next run):
 
 **Declarative auto-create (sac).** sac drives overlay provisioning
 from the spec so new peers don't require a manual
-`apptainer overlay create` setup step:
+`apptainer overlay create` setup step. Two overlay FORMS, each with its
+own provisioning path:
+
+**(a) Directory overlay** — the fleet default (persistent per-agent
+`$HOME`, package installs, caches). Declared either as the modeled field
+or as a raw_arg, in EITHER spelling apptainer accepts:
+
+```yaml
+spec:
+  apptainer:
+    overlay: ~/.scitex/agent-container/containers/overlays/<agent>/
+    # …or, under relaxed mode, via the escape hatch:
+    raw_args:
+      - --overlay=/abs/path/overlays/<agent>/   # =-joined, or
+      - --overlay                               # space-separated
+      - /abs/path/overlays/<agent>/
+```
+
+sac **auto-provisions** it before every launch, idempotently, creating
+`<overlay>/`, `<overlay>/upper/` and `<overlay>/work/` (mode 0755) —
+see `runtimes/_apptainer_overlay.ensure_overlay_dirs`, called from
+`build_run_argv`, the one choke point both the SDK and TUI runtimes pass
+through. This is a hard precondition, not a nicety: apptainer creates
+`upper/` and `work/` itself but **`lstat()`s the overlay root and refuses
+to create it**, so a missing root is a fatal
+`while loading overlay images: failed to open overlay image … no such
+file or directory`. Before this was explicit, the fleet's overlays existed
+only as a side-effect of the `to_home` upper-home materialisation, whose
+resolver read only the space-separated spelling — so a brand-new agent
+scaffolded with the `=`-joined spelling was **stillborn**. If the overlay
+still cannot be created (unwritable parent), sac raises
+`OverlayProvisionError` naming the path and the exact `mkdir -p` fix,
+rather than letting apptainer die with a raw FATAL.
+
+**(b) Sized image overlay** — a loopback ext3 file:
 
 ```yaml
 spec:
@@ -169,7 +203,10 @@ Semantics:
   `FileNotFoundError` (operator must pre-create).
 - `overlay_size` empty + overlay missing → sac raises
   `FileNotFoundError` early with a helpful message instead of letting
-  apptainer fail cryptically at exec time.
+  apptainer fail cryptically at exec time. (Directory overlays never
+  reach this branch — they are auto-provisioned per (a). `overlay_size`,
+  an `.img`/`.ext3`/`.sif` suffix, or an existing non-directory at the
+  path are what mark an overlay as an IMAGE; sac never `mkdir`s one.)
 - K/KB units are explicitly rejected — apptainer's
   `overlay create --size` takes integer MB.
 

--- a/src/scitex_agent_container/_lifecycle/_startup_failed.py
+++ b/src/scitex_agent_container/_lifecycle/_startup_failed.py
@@ -113,6 +113,13 @@ def classify_apptainer_failure(stdout: str, stderr: str) -> tuple[str, str]:
 
       * ``"mount source ... doesn't exist"`` → ``"apptainer_mount_failed"``
         — the historical clew case + most SAC-from-SAC bind-rewrite gaps.
+      * ``"failed to open overlay image"`` → ``"overlay_missing"``
+        — the agent's per-agent directory overlay does not exist on the
+        host. sac now provisions it before every launch
+        (``runtimes/_apptainer_overlay.ensure_overlay_dirs``), so this
+        should be unreachable; if it fires anyway the overlay path is
+        outside sac's control (e.g. a hand-edited raw_arg pointing at an
+        unwritable location) and the hint names the fix.
       * ``"image ... is not a valid SIF image"`` → ``"sif_invalid"``
         — the host SIF path is wrong / partial download / wrong arch.
       * ``"No space left on device"`` → ``"disk_full"``.
@@ -121,6 +128,21 @@ def classify_apptainer_failure(stdout: str, stderr: str) -> tuple[str, str]:
     later only needs a regex + hint pair.
     """
     blob = (stdout or "") + "\n" + (stderr or "")
+    # Checked BEFORE disk_full: an overlay FATAL can mention the overlay
+    # *image* path while the real cause is the missing directory.
+    if "failed to open overlay image" in blob or "while loading overlay images" in blob:
+        return (
+            "overlay_missing",
+            "the agent's apptainer overlay directory does not exist (or is "
+            "not readable) on the host. Apptainer creates <overlay>/upper "
+            "and <overlay>/work itself, but NEVER the overlay root — that "
+            "must exist before `apptainer exec`. sac auto-provisions it at "
+            "launch (runtimes/_apptainer_overlay.ensure_overlay_dirs); if "
+            "you are seeing this, create the path named in the FATAL line by "
+            "hand — `mkdir -p <overlay>/upper <overlay>/work` — or repoint "
+            "spec.apptainer.overlay (or the --overlay raw_arg) at a path "
+            "this user can write.",
+        )
     if "mount source" in blob and "doesn't exist" in blob:
         return (
             "apptainer_mount_failed",

--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from ..config import AgentConfig
 from ._apptainer_argv_guard import validate_flag_argv
-from ._apptainer_build import _create_overlay_image
+from ._apptainer_overlay import ensure_overlay_dirs, overlay_flags
 
 # ----------------------------------------------------------------------
 # Module-level constants (moved from _apptainer_runtime, re-exported
@@ -86,6 +86,21 @@ def build_run_argv(
     # discovery works without manual operator config.
     home_host = state_dir.expanduser() / "home"
     home_host.mkdir(parents=True, exist_ok=True)
+
+    # Overlay precondition — idempotent, fail-loud, form-agnostic.
+    # Apptainer CREATES `<overlay>/upper` + `<overlay>/work`, but it
+    # lstat()s the overlay ROOT and refuses to create THAT: a missing root
+    # is a hard FATAL ("failed to open overlay image ... no such file or
+    # directory") that sac's lifecycle classifier could only label
+    # `container_creation_unknown`. Nothing used to guarantee the root
+    # existed — the fleet's overlays exist only as an INCIDENTAL side-effect
+    # of deploy_to_home_overlay's `<overlay>/upper/<home>` mkdir(parents=True),
+    # which is gated on a resolver blind to the `--overlay=<path>` (=-joined)
+    # spelling that `sac agents create --template ...` emits. A brand-new
+    # agent was therefore STILLBORN. Provision it EXPLICITLY here — the one
+    # choke point every apptainer launch (SDK + TUI) passes through — reading
+    # BOTH raw_args spellings. See _apptainer_overlay.
+    ensure_overlay_dirs(config)
 
     # Relaxed-overlay double-bind fix: when a directory overlay
     # materialises the to_home tree into the overlay upper-home, THAT
@@ -236,43 +251,14 @@ def build_run_argv(
             argv.append("--nv")
         if getattr(ap, "rocm", False):
             argv.append("--rocm")
-        # Writable overlay — lets the agent install packages, write
-        # caches and persist state while the base SIF stays
-        # immutable. Resolution: absolute path used as-is; relative
-        # paths are interpreted against the workdir.
-        #
-        # Declarative auto-create (see docs/isolation.md §7):
-        # ``spec.apptainer.overlay_size`` + the default
-        # ``overlay_create_if_missing=True`` flag drives
-        # ``apptainer overlay create --size <MB> <path>`` when the
-        # overlay file is missing. Without ``overlay_size`` we fail
-        # loudly here (FileNotFoundError) instead of letting
-        # apptainer error cryptically at exec time.
-        overlay = getattr(ap, "overlay", "") or ""
-        if overlay:
-            overlay_p = Path(overlay).expanduser()
-            if not overlay_p.is_absolute():
-                overlay_p = Path(config.workdir).expanduser() / overlay_p
-            if not overlay_p.exists():
-                overlay_size = getattr(ap, "overlay_size", "") or ""
-                create_ok = getattr(ap, "overlay_create_if_missing", True)
-                if overlay_size and create_ok:
-                    _create_overlay_image(overlay_p, overlay_size)
-                elif overlay_size:
-                    raise FileNotFoundError(
-                        f"overlay {overlay_p} missing and "
-                        "overlay_create_if_missing=false; pre-create with "
-                        "`apptainer overlay create --size <MB> <path>` or "
-                        "flip overlay_create_if_missing back to true."
-                    )
-                else:
-                    raise FileNotFoundError(
-                        f"overlay {overlay_p} missing; set "
-                        "spec.apptainer.overlay_size (e.g. '5G') for "
-                        "declarative auto-create, or pre-create with "
-                        "`apptainer overlay create`."
-                    )
-            argv += ["--overlay", str(overlay_p)]
+        # Writable overlay (spec.apptainer.overlay) — path resolution,
+        # declarative sized-image auto-create and the ``--overlay`` flag
+        # itself now live in _apptainer_overlay, alongside the directory-
+        # overlay provisioning already run above, so every overlay concern
+        # sits in ONE module. Mirrors the tmpfs_workdir_flags /
+        # nested_build_flags / auth_argv extraction pattern below. No-op
+        # for raw_args-declared overlays (passed through verbatim).
+        argv += overlay_flags(config)
 
     # Sized /tmp scratch (spec.apptainer.tmpfs_size, default "2G").
     # A --containall container otherwise gets a 64 MB session tmpfs

--- a/src/scitex_agent_container/runtimes/_apptainer_overlay.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_overlay.py
@@ -1,0 +1,299 @@
+"""Idempotent provisioning of an agent's apptainer DIRECTORY overlay.
+
+Root cause this module closes (2026-07-13): creating + starting a BRAND-NEW
+agent died in the ``container_creation`` phase with a raw apptainer FATAL::
+
+    FATAL: while loading overlay images: failed to open overlay image
+    <...>/containers/overlays/<agent>/: failed to retrieve path for <...>:
+    lstat <...>: no such file or directory
+
+Apptainer's directory-overlay contract: it creates the ``upper/`` + ``work/``
+subdirectories itself, but it ``lstat()``s the overlay ROOT and refuses to
+create that — a missing root is a hard, non-recoverable FATAL.
+
+Until now NOTHING in sac ensured the root existed. The fleet's overlays came
+into being only as an INCIDENTAL side-effect of
+:func:`._to_home_overlay.deploy_to_home_overlay`, whose
+``<overlay>/upper/<container_home>/`` ``mkdir(parents=True)`` happens to create
+the root on the way down. That side-effect is gated on
+:func:`._to_home_overlay._resolve_overlay_dir`, which recognises an overlay
+only as ``spec.apptainer.overlay`` or as the SPACE-SEPARATED raw_args pair
+``["--overlay", "<path>"]``. Every fleet spec authored by hand happened to use
+that spelling, so the accident held.
+
+An agent scaffolded from the ``_template_python_developer`` dir-template
+instead declares the ``=``-JOINED spelling ``--overlay=<path>`` — which
+apptainer accepts identically. sac's resolver saw nothing, the mkdir
+side-effect never fired, the overlay root was never created, and the launch
+was stillborn.
+
+This module makes the precondition EXPLICIT, form-agnostic and idempotent:
+:func:`ensure_overlay_dirs` is called from ``build_run_argv`` — the single
+choke point EVERY apptainer launch passes through (SDK runner and TUI alike) —
+and creates ``<overlay>/``, ``<overlay>/upper/`` and ``<overlay>/work/`` with
+the same layout and permissions the live fleet's overlays carry. It reads BOTH
+raw_args spellings, so no future spec shape can silently regress to a
+stillborn start.
+
+Scope: DIRECTORY overlays only. A sized loopback IMAGE overlay
+(``spec.apptainer.overlay_size``, or an ``.img`` / ``.ext3`` / ``.sif`` path)
+remains the business of :func:`._apptainer_build._create_overlay_image` —
+``mkdir``-ing a directory at an image path would break that path outright.
+
+Fail-loud: an overlay we cannot create raises :class:`OverlayProvisionError`
+naming the exact path and the exact command to create it by hand, rather than
+letting apptainer die with a FATAL that sac's lifecycle classifier can only
+label ``container_creation_unknown``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Apptainer's directory-overlay layout: the writable layer lives in ``upper/``
+# and the overlayfs scratch area in ``work/`` (``apptainer overlay create``).
+OVERLAY_UPPER_DIRNAME = "upper"
+OVERLAY_WORK_DIRNAME = "work"
+
+# Permissions the live fleet's overlays actually carry — verified on
+# scitex-scholar / figrecipe / scitex-clew (root, upper and work are all
+# 0755). Provisioning to the same mode keeps a sac-created overlay
+# indistinguishable from the ones apptainer created in place.
+OVERLAY_DIR_MODE = 0o755
+
+# Path suffixes that mark a loopback IMAGE overlay — never a directory.
+_IMAGE_SUFFIXES = (".img", ".ext3", ".sif")
+
+# The apptainer flag whose value is the overlay path.
+_OVERLAY_FLAG = "--overlay"
+
+
+class OverlayProvisionError(RuntimeError):
+    """A declared directory overlay could not be provisioned.
+
+    Carries the offending path and the exact remediation command — the
+    constitution's fail-fast/fail-loud/actionable-hint contract. Raised
+    from :func:`ensure_overlay_dirs` before ``apptainer exec`` is ever
+    reached, so the operator sees THIS instead of a raw apptainer FATAL.
+    """
+
+
+def raw_arg_value(raw_args, flag: str) -> str:
+    """Return the value of ``flag`` in an apptainer argv list.
+
+    Handles BOTH spellings apptainer itself accepts:
+
+    * space-separated — ``["--overlay", "/path"]``
+    * ``=``-joined    — ``["--overlay=/path"]``
+
+    Returns ``""`` when the flag is absent or carries no value. sac read only
+    the first spelling for years; the second silently resolved to "no overlay
+    declared" and cost the fleet a stillborn agent (see the module docstring).
+    First occurrence wins, mirroring a left-to-right argv scan.
+    """
+    raw = [str(a) for a in (raw_args or [])]
+    prefix = f"{flag}="
+    for i, arg in enumerate(raw):
+        if arg == flag:
+            return raw[i + 1].strip() if i + 1 < len(raw) else ""
+        if arg.startswith(prefix):
+            return arg[len(prefix) :].strip()
+    return ""
+
+
+def resolve_overlay_declaration(config) -> Path | None:
+    """Resolve the overlay path apptainer will actually receive, or ``None``.
+
+    Form-agnostic — mirrors apptainer's own argv parsing:
+
+      1. ``spec.apptainer.overlay`` (the modeled field), else
+      2. ``--overlay <path>`` / ``--overlay=<path>`` in
+         ``spec.apptainer.raw_args`` (the escape hatch relaxed specs use).
+
+    Relative paths resolve against ``spec.workdir``, matching how
+    ``build_run_argv`` resolves the modeled field. Returns ``None`` when no
+    overlay is declared at all.
+
+    Distinct from :func:`._to_home_overlay._resolve_overlay_dir`, which answers
+    a different question — "does sac back the container ``$HOME`` with this
+    overlay's upper layer?" — and is deliberately narrower (see that module).
+    THIS function answers "what path does apptainer get?", so it must accept
+    every spelling apptainer does.
+    """
+    ap = getattr(config, "apptainer", None)
+    if ap is None:
+        return None
+    declared = (getattr(ap, "overlay", "") or "").strip()
+    if not declared:
+        declared = raw_arg_value(getattr(ap, "raw_args", None), _OVERLAY_FLAG)
+    if not declared:
+        return None
+    path = Path(declared).expanduser()
+    if not path.is_absolute():
+        workdir = (getattr(config, "workdir", "") or "").strip()
+        if not workdir:
+            return None
+        path = Path(workdir).expanduser() / path
+    return path
+
+
+def is_image_overlay(path: Path, overlay_size: str = "") -> bool:
+    """True iff ``path`` denotes a loopback IMAGE overlay, not a directory.
+
+    An image overlay is built by ``apptainer overlay create --size`` (see
+    :func:`._apptainer_build._create_overlay_image`) and must NEVER be
+    ``mkdir``-ed — doing so would shadow the image path with a directory and
+    break that auto-create path. Three independent signals, any one decisive:
+
+      * the path exists and is NOT a directory (a real image file already),
+      * ``spec.apptainer.overlay_size`` is set — the explicit "this is a sized
+        image, auto-create it" contract, or
+      * the path carries an image suffix (``.img`` / ``.ext3`` / ``.sif``).
+    """
+    if path.exists() and not path.is_dir():
+        return True
+    if (overlay_size or "").strip():
+        return True
+    return path.suffix.lower() in _IMAGE_SUFFIXES
+
+
+def ensure_overlay_dirs(config) -> Path | None:
+    """Idempotently provision the agent's DIRECTORY overlay; return its root.
+
+    Creates ``<overlay>/``, ``<overlay>/upper/`` and ``<overlay>/work/`` when
+    missing. A fully-provisioned overlay is left completely untouched — no
+    ``chmod`` of an existing directory, so an operator (or the agent itself)
+    may legitimately have tightened it. Returns ``None`` when the spec declares
+    no overlay, or declares an IMAGE overlay (not ours to create).
+
+    Called from ``build_run_argv`` so EVERY apptainer launch establishes the
+    precondition immediately before ``apptainer exec``, regardless of runtime
+    (SDK / TUI) and regardless of which spelling the spec used.
+
+    Raises:
+        OverlayProvisionError: the overlay could not be created — names the
+            exact path and the exact ``mkdir -p`` command that fixes it.
+    """
+    root = resolve_overlay_declaration(config)
+    if root is None:
+        return None
+
+    ap = getattr(config, "apptainer", None)
+    overlay_size = (getattr(ap, "overlay_size", "") or "") if ap is not None else ""
+    if is_image_overlay(root, overlay_size):
+        return None
+
+    upper = root / OVERLAY_UPPER_DIRNAME
+    work = root / OVERLAY_WORK_DIRNAME
+    name = getattr(config, "name", "") or "<unknown>"
+
+    created: list[str] = []
+    try:
+        for target in (root, upper, work):
+            if target.is_dir():
+                continue
+            target.mkdir(parents=True, exist_ok=True)
+            os.chmod(target, OVERLAY_DIR_MODE)
+            created.append(str(target))
+    except OSError as exc:
+        raise OverlayProvisionError(
+            f"apptainer overlay {root} could not be provisioned ({exc}). "
+            f"Agent {name!r} declares this DIRECTORY overlay, and apptainer "
+            "FATALs at container creation ('failed to open overlay image ... "
+            "no such file or directory') unless the directory EXISTS before "
+            "`apptainer exec`. Fix ONE of: (1) create it by hand — "
+            f"`mkdir -p {upper} {work}` — or (2) repoint the overlay "
+            "(spec.apptainer.overlay, or the --overlay raw_arg) at a path "
+            "this user can write."
+        ) from exc
+
+    if created:
+        logger.info(
+            "overlay: provisioned directory overlay %s for agent %s (created: %s)",
+            root,
+            name,
+            ", ".join(created),
+        )
+    return root
+
+
+def overlay_flags(config) -> list[str]:
+    """Return the curated ``--overlay`` argv flags for the MODELED spec field.
+
+    Extracted verbatim from ``build_run_argv`` (which crossed the 512-line cap)
+    so that every overlay concern — path resolution, directory provisioning,
+    sized-image auto-create and argv emission — lives in ONE module. Mirrors
+    the sibling ``tmpfs_workdir_flags`` / ``nested_build_flags`` / ``auth_argv``
+    extraction pattern that ``build_run_argv`` already follows.
+
+    A writable overlay lets the agent install packages, write caches and
+    persist state while the base SIF stays immutable. Resolution: an absolute
+    path is used as-is; a relative path resolves against ``spec.workdir``.
+
+    Declarative auto-create (see ``docs/isolation.md`` §7): for a sized IMAGE
+    overlay, ``spec.apptainer.overlay_size`` plus the default
+    ``overlay_create_if_missing=True`` drives ``apptainer overlay create
+    --size <MB> <path>`` when the image file is missing. Without
+    ``overlay_size`` we fail loudly (``FileNotFoundError``) rather than let
+    apptainer error cryptically at exec time.
+
+    DIRECTORY overlays never reach the missing-path branch: they are
+    provisioned up-front by :func:`ensure_overlay_dirs`, which
+    ``build_run_argv`` calls before it assembles any flags.
+
+    Returns ``[]`` when ``spec.apptainer.overlay`` is unset — a raw_args
+    overlay (``--overlay`` / ``--overlay=``) is passed through verbatim by
+    ``build_run_argv`` and needs no curated flag here.
+    """
+    ap = getattr(config, "apptainer", None)
+    if ap is None:
+        return []
+    overlay = getattr(ap, "overlay", "") or ""
+    if not overlay:
+        return []
+
+    overlay_p = Path(overlay).expanduser()
+    if not overlay_p.is_absolute():
+        overlay_p = Path(config.workdir).expanduser() / overlay_p
+
+    if not overlay_p.exists():
+        overlay_size = getattr(ap, "overlay_size", "") or ""
+        create_ok = getattr(ap, "overlay_create_if_missing", True)
+        if overlay_size and create_ok:
+            from ._apptainer_build import _create_overlay_image
+
+            _create_overlay_image(overlay_p, overlay_size)
+        elif overlay_size:
+            raise FileNotFoundError(
+                f"overlay {overlay_p} missing and "
+                "overlay_create_if_missing=false; pre-create with "
+                "`apptainer overlay create --size <MB> <path>` or "
+                "flip overlay_create_if_missing back to true."
+            )
+        else:
+            raise FileNotFoundError(
+                f"overlay {overlay_p} missing; set "
+                "spec.apptainer.overlay_size (e.g. '5G') for "
+                "declarative auto-create, or pre-create with "
+                "`apptainer overlay create`."
+            )
+    return ["--overlay", str(overlay_p)]
+
+
+__all__ = [
+    "OVERLAY_DIR_MODE",
+    "OVERLAY_UPPER_DIRNAME",
+    "OVERLAY_WORK_DIRNAME",
+    "OverlayProvisionError",
+    "ensure_overlay_dirs",
+    "is_image_overlay",
+    "overlay_flags",
+    "raw_arg_value",
+    "resolve_overlay_declaration",
+]
+
+# EOF

--- a/src/scitex_agent_container/runtimes/_cct_token_pool.py
+++ b/src/scitex_agent_container/runtimes/_cct_token_pool.py
@@ -42,10 +42,14 @@ token deliberately NEVER rides an ``--env`` argv flag (visible in
 ``/proc/<pid>/cmdline``) and its VALUE is never logged — log lines carry
 only the slot NAME, the pool source path(s), and the agent name.
 
-Fail-loud contract: when the channel is requested and NO token resolves,
-a scitex-logging ERROR names the pool source, the tried slot names, and
-the three fixes. The start itself proceeds (Telegram is a comms rail, not
-a boot dependency) — but the absence is loud, never silent.
+Loud-but-honest contract: when the channel is requested and NO token
+resolves, a scitex-logging WARNING names the pool source, the tried slot
+names, and the fixes. The start itself proceeds — Telegram is a comms rail,
+not a boot dependency — so the absence is loud but never silent, and never
+DRESSED UP AS A STARTUP FAILURE. It used to log at ERROR, which made every
+brand-new agent (no bot yet, by definition) look stillborn in its boot log
+next to the genuinely fatal lines; WARNING + an explicit "the agent starts
+normally" sentence keeps the signal without the false alarm.
 """
 
 from __future__ import annotations
@@ -184,9 +188,11 @@ def ensure_cct_bot_token(config, dest: Path) -> None:
     Called from :func:`._to_home.deploy_to_home` AFTER the ``.envrc``
     cascade fold, so an explicit hand-authored mapping always wins. No-op
     when the spec does not request ``server:claude-code-telegrammer``.
-    Never raises for a missing token — it ERRORs loudly (scitex-logging)
-    with the pool path and the fix instead. The token VALUE is never
-    logged; only slot names, paths, and the agent name appear.
+    Never raises for a missing token — it WARNs (scitex-logging) with the
+    pool path and the fixes instead, and says in so many words that the
+    agent starts normally: a missing bot token degrades one comms rail, it
+    does not fail a boot. The token VALUE is never logged; only slot names,
+    paths, and the agent name appear.
     """
     claude_spec = getattr(config, "claude", None)
     channels = list(getattr(claude_spec, "channels", None) or [])
@@ -242,15 +248,19 @@ def ensure_cct_bot_token(config, dest: Path) -> None:
             )
             return
 
-    _logger().error(
-        "cct: NO bot token for agent %r although spec.claude.channels "
-        "requests %r. Tried pool slot(s) %s against the pool (%s). The "
-        "telegrammer MCP will start WITHOUT a token — the bot is dead until "
-        "fixed. Fix ONE of: (1) add %s<SLOT>=<token> for slot %r to a "
-        "secrets file listed in %s (canonical pool; restart `sac listen` "
-        "afterwards if it provides the env), (2) set spec.apptainer.env "
-        "%s: <existing-slot> to reuse another project's bot, or (3) export "
-        "%s via the project's .envrc (%s/.envrc).",
+    _logger().warning(
+        "cct: no Telegram bot token for agent %r although spec.claude.channels "
+        "requests %r. Tried pool slot(s) %s against the pool (%s). THE AGENT "
+        "STARTS NORMALLY — this is NOT a startup failure; only the Telegram "
+        "rail is down (the telegrammer MCP comes up without a token, so the "
+        "bot stays silent until a token is provided). Expected for a "
+        "brand-new agent that has no bot yet. To wire one up, do ONE of: "
+        "(1) add %s<SLOT>=<token> for slot %r to a secrets file listed in %s "
+        "(canonical pool; restart `sac listen` afterwards if it provides the "
+        "env), (2) set spec.apptainer.env %s: <existing-slot> to reuse "
+        "another project's bot, or (3) export %s via the project's .envrc "
+        "(%s/.envrc). Or drop %r from spec.claude.channels if this agent "
+        "needs no Telegram rail.",
         agent_name,
         _TELEGRAMMER_CHANNEL,
         ", ".join(f"{_POOL_PREFIX}{c}" for c in candidates) or "(none)",
@@ -261,6 +271,7 @@ def ensure_cct_bot_token(config, dest: Path) -> None:
         _SLOT_OVERRIDE_VAR,
         _TOKEN_VAR,
         workdir or "<workdir>",
+        _TELEGRAMMER_CHANNEL,
     )
 
 

--- a/src/scitex_agent_container/runtimes/_to_home_overlay.py
+++ b/src/scitex_agent_container/runtimes/_to_home_overlay.py
@@ -82,6 +82,26 @@ def _resolve_overlay_dir(config: AgentConfig) -> Path | None:
     no overlay is declared, or when the declared overlay path exists but is
     not a directory (e.g. an ``.img`` loopback image we cannot write into
     from the host).
+
+    DELIBERATELY NARROW — do not "fix" this to also read the ``=``-joined
+    ``--overlay=<path>`` spelling without reading this paragraph first.
+    This resolver does NOT answer "what overlay does apptainer get?" (that is
+    :func:`._apptainer_overlay.resolve_overlay_declaration`, which accepts
+    every spelling and drives provisioning). It answers a POLICY question:
+    "does sac back the container ``$HOME`` with this overlay's upper layer,
+    instead of with the workspace-home bind?" — see ``_apptainer_build_argv``'s
+    ``_overlay_backs_home``. Widening it therefore MIGRATES the ``$HOME`` of
+    every live agent whose spec uses the ``=``-joined spelling, from
+    ``<state>/home/`` to ``<overlay>/upper/home/agent/`` — a different, older
+    tree, so the agent would resume from a stale ``.claude/`` (session
+    history, ``.claude.json``). Verified 2026-07-13: ``paper-scitex-clew``
+    (``=``-joined) actively writes its workspace home while its overlay upper
+    home is a week stale, whereas ``scitex-scholar`` (space-separated) is
+    overlay-backed. That migration needs an operator decision and a
+    seed-the-upper-home step; it is NOT a parser bugfix. The stillborn-agent
+    bug this narrowness once caused (the overlay dir never being created) is
+    fixed at the correct layer — :func:`._apptainer_overlay.ensure_overlay_dirs`
+    — and no longer depends on what this function sees.
     """
     ap = getattr(config, "apptainer", None)
     if ap is None:

--- a/tests/scitex_agent_container/_lifecycle/test__startup_failed.py
+++ b/tests/scitex_agent_container/_lifecycle/test__startup_failed.py
@@ -68,6 +68,31 @@ def test_classify_disk_full_for_enospc() -> None:
     assert kind == "disk_full"
 
 
+def test_classify_overlay_missing_from_stillborn_agent_trace() -> None:
+    # Arrange — the verbatim FATAL a brand-new agent hit when its per-agent
+    # overlay dir did not exist (2026-07-13). It used to fall through to
+    # container_creation_unknown — a raw apptainer FATAL with no fix.
+    stderr = (
+        "FATAL:   while loading overlay images: failed to open overlay image "
+        "/home/u/.scitex/agent-container/containers/overlays/new-agent/: "
+        "failed to retrieve path for /.../overlays/new-agent/: lstat "
+        "/.../overlays/new-agent: no such file or directory"
+    )
+    # Act
+    kind, _ = classify_apptainer_failure(stdout="", stderr=stderr)
+    # Assert
+    assert kind == "overlay_missing"
+
+
+def test_classify_overlay_missing_hint_names_the_mkdir_fix() -> None:
+    # Arrange
+    stderr = "FATAL:   while loading overlay images: failed to open overlay image /x/"
+    # Act
+    _, hint = classify_apptainer_failure(stdout="", stderr=stderr)
+    # Assert — constitution: never ship a FATAL without an actionable hint.
+    assert "mkdir -p" in hint
+
+
 def test_classify_unknown_kind_for_unrecognised_blob() -> None:
     # Arrange
     stderr = "something we have never seen before, panic"

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -1070,3 +1070,93 @@ def test_build_run_argv_nested_build_masks_subuid(tmp_path) -> None:
     )
     # Assert — the /etc/subuid mask rides through to the full argv.
     assert ":/etc/subuid" in joined
+
+
+# ---------------------------------------------------------------------------
+# Overlay auto-provisioning — a BRAND-NEW agent must not be stillborn
+#
+# `sac agents create <name> --template python_developer --start` wrote a valid
+# spec, then the start FATAL'd in apptainer's container_creation phase:
+#
+#   FATAL: while loading overlay images: failed to open overlay image
+#   <...>/overlays/<name>/: ... no such file or directory
+#
+# The per-agent overlay directory was never created. Nothing in sac created it:
+# the fleet's overlays existed only as an incidental side-effect of
+# deploy_to_home_overlay, whose resolver reads only the SPACE-SEPARATED
+# `--overlay <path>` raw_arg — while the dir-template emits the `=`-JOINED
+# `--overlay=<path>` spelling apptainer accepts equally. build_run_argv now
+# provisions the overlay explicitly (ensure_overlay_dirs), for both spellings.
+# ---------------------------------------------------------------------------
+
+
+def _overlay_spec(overlay_dir: Path) -> str:
+    """The apptainer raw_args shape ``_template_python_developer`` emits.
+
+    Note the ``=``-JOINED ``--overlay=<path>/`` spelling (with the template's
+    trailing slash) — the exact token that used to resolve to "no overlay
+    declared" inside sac while apptainer read it just fine.
+    """
+    return _BASE_SPEC.format(extra="").replace(
+        "    binds: []\n",
+        "    binds: []\n"
+        "    relaxed: true\n"
+        "    raw_args:\n"
+        "      - --userns\n"
+        "      - --containall\n"
+        "      - --home=/home/agent\n"
+        f"      - --overlay={overlay_dir}/\n",
+    )
+
+
+def test_build_run_argv_provisions_overlay_root_for_new_agent(tmp_path) -> None:
+    # Arrange — brand-new agent: the overlay does not exist yet.
+    overlay = tmp_path / "overlays" / "brand-new"
+    spec = _write_spec(tmp_path, _overlay_spec(overlay))
+    config = load_config(str(spec))
+    # Act
+    build_run_argv(
+        config, state_dir=tmp_path / "state", sif_path=Path("/img/sac.sif"), tui=True
+    )
+    # Assert — the root apptainer lstat()s (and refuses to create) now exists.
+    assert overlay.is_dir()
+
+
+def test_build_run_argv_provisions_overlay_upper_for_new_agent(tmp_path) -> None:
+    # Arrange
+    overlay = tmp_path / "overlays" / "brand-new"
+    spec = _write_spec(tmp_path, _overlay_spec(overlay))
+    config = load_config(str(spec))
+    # Act
+    build_run_argv(
+        config, state_dir=tmp_path / "state", sif_path=Path("/img/sac.sif"), tui=True
+    )
+    # Assert — same layout every live fleet overlay carries.
+    assert (overlay / "upper").is_dir()
+
+
+def test_build_run_argv_provisions_overlay_work_for_new_agent(tmp_path) -> None:
+    # Arrange
+    overlay = tmp_path / "overlays" / "brand-new"
+    spec = _write_spec(tmp_path, _overlay_spec(overlay))
+    config = load_config(str(spec))
+    # Act
+    build_run_argv(
+        config, state_dir=tmp_path / "state", sif_path=Path("/img/sac.sif"), tui=True
+    )
+    # Assert
+    assert (overlay / "work").is_dir()
+
+
+def test_build_run_argv_passes_raw_args_overlay_through_verbatim(tmp_path) -> None:
+    # Arrange — provisioning must not ALSO emit a curated --overlay flag
+    # (a duplicate would change which layer apptainer stacks).
+    overlay = tmp_path / "overlays" / "brand-new"
+    spec = _write_spec(tmp_path, _overlay_spec(overlay))
+    config = load_config(str(spec))
+    # Act
+    argv = build_run_argv(
+        config, state_dir=tmp_path / "state", sif_path=Path("/img/sac.sif"), tui=True
+    )
+    # Assert — exactly the operator's own `=`-joined token, once.
+    assert argv.count(f"--overlay={overlay}/") == 1

--- a/tests/scitex_agent_container/runtimes/test__apptainer_overlay.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_overlay.py
@@ -1,0 +1,398 @@
+"""Tests for apptainer overlay provisioning (:mod:`_apptainer_overlay`).
+
+Regression cover for the 2026-07-13 stillborn-agent bug: `sac agents create
+<name> --template python_developer --start` wrote a valid spec, then the START
+died in apptainer's container_creation phase with
+
+    FATAL: while loading overlay images: failed to open overlay image
+    <...>/containers/overlays/<name>/: ... no such file or directory
+
+because NOTHING in sac ever created the per-agent overlay directory. The fleet's
+overlays existed only as an incidental side-effect of ``deploy_to_home_overlay``,
+whose resolver reads only the SPACE-SEPARATED ``--overlay <path>`` raw_arg — and
+the dir-template emits the ``=``-JOINED ``--overlay=<path>`` spelling that
+apptainer accepts equally. The resolver saw nothing, the side-effect never fired,
+the agent was stillborn.
+
+The pinned behaviour: a brand-new agent's overlay is auto-provisioned (root +
+``upper/`` + ``work/``) before ``apptainer exec``, for BOTH spellings; an
+unprovisionable overlay fails LOUD with the exact path and the exact fix, never
+a raw apptainer FATAL.
+
+PA-306 no-mocks: real ``AgentConfig`` / ``ApptainerSpec`` against real
+``tmp_path`` directories. STX-TQ002 AAA markers, STX-TQ007 one assert per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import ApptainerSpec
+from scitex_agent_container.runtimes._apptainer_overlay import (
+    OVERLAY_DIR_MODE,
+    OverlayProvisionError,
+    ensure_overlay_dirs,
+    is_image_overlay,
+    overlay_flags,
+    raw_arg_value,
+    resolve_overlay_declaration,
+)
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _cfg(
+    tmp_path: Path,
+    *,
+    raw_args: list[str] | None = None,
+    overlay: str = "",
+    overlay_size: str = "",
+) -> AgentConfig:
+    """Real AgentConfig whose apptainer block declares an overlay however
+    the caller likes — modeled field, or either raw_args spelling."""
+    cfg = AgentConfig(name="brand-new", runtime="tui", workdir=str(tmp_path))
+    cfg.apptainer = ApptainerSpec(
+        relaxed=True,
+        raw_args=list(raw_args or []),
+        overlay=overlay,
+        overlay_size=overlay_size,
+    )
+    return cfg
+
+
+def _template_raw_args(overlay_dir: Path) -> list[str]:
+    """The EXACT raw_args shape ``_template_python_developer`` emits — the
+    ``=``-joined spelling that used to resolve to "no overlay declared"."""
+    return [
+        "--userns",
+        "--containall",
+        "--home=/home/agent",
+        f"--overlay={overlay_dir}/",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# raw_arg_value — both spellings apptainer accepts
+# ---------------------------------------------------------------------------
+
+
+def test_raw_arg_value_reads_space_separated_spelling() -> None:
+    # Arrange — the hand-authored fleet spec shape.
+    raw = ["--containall", "--overlay", "/ov", "--userns"]
+    # Act
+    value = raw_arg_value(raw, "--overlay")
+    # Assert
+    assert value == "/ov"
+
+
+def test_raw_arg_value_reads_equals_joined_spelling() -> None:
+    # Arrange — the dir-template shape sac used to be BLIND to (the bug).
+    raw = ["--containall", "--overlay=/ov", "--userns"]
+    # Act
+    value = raw_arg_value(raw, "--overlay")
+    # Assert
+    assert value == "/ov"
+
+
+def test_raw_arg_value_returns_empty_when_flag_absent() -> None:
+    # Arrange
+    raw = ["--containall", "--userns"]
+    # Act
+    value = raw_arg_value(raw, "--overlay")
+    # Assert
+    assert value == ""
+
+
+def test_raw_arg_value_returns_empty_for_dangling_flag() -> None:
+    # Arrange — trailing flag with no value must not IndexError.
+    raw = ["--containall", "--overlay"]
+    # Act
+    value = raw_arg_value(raw, "--overlay")
+    # Assert
+    assert value == ""
+
+
+# ---------------------------------------------------------------------------
+# resolve_overlay_declaration — what apptainer will actually receive
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_declaration_finds_equals_joined_raw_arg(tmp_path: Path) -> None:
+    # Arrange — the stillborn-agent spec shape.
+    overlay = tmp_path / "overlays" / "brand-new"
+    cfg = _cfg(tmp_path, raw_args=_template_raw_args(overlay))
+    # Act
+    resolved = resolve_overlay_declaration(cfg)
+    # Assert — trailing slash normalised away by Path.
+    assert resolved == overlay
+
+
+def test_resolve_declaration_finds_space_separated_raw_arg(tmp_path: Path) -> None:
+    # Arrange — the live fleet's hand-authored shape.
+    overlay = tmp_path / "overlays" / "scholar"
+    cfg = _cfg(tmp_path, raw_args=["--overlay", str(overlay)])
+    # Act
+    resolved = resolve_overlay_declaration(cfg)
+    # Assert
+    assert resolved == overlay
+
+
+def test_resolve_declaration_prefers_modeled_field(tmp_path: Path) -> None:
+    # Arrange — the inline `full` template uses spec.apptainer.overlay.
+    overlay = tmp_path / "modeled"
+    cfg = _cfg(tmp_path, overlay=str(overlay), raw_args=["--overlay", "/ignored"])
+    # Act
+    resolved = resolve_overlay_declaration(cfg)
+    # Assert
+    assert resolved == overlay
+
+
+def test_resolve_declaration_anchors_relative_path_to_workdir(tmp_path: Path) -> None:
+    # Arrange
+    cfg = _cfg(tmp_path, overlay="rel-ov")
+    # Act
+    resolved = resolve_overlay_declaration(cfg)
+    # Assert
+    assert resolved == tmp_path / "rel-ov"
+
+
+def test_resolve_declaration_none_when_no_overlay_declared(tmp_path: Path) -> None:
+    # Arrange
+    cfg = _cfg(tmp_path, raw_args=["--containall"])
+    # Act
+    resolved = resolve_overlay_declaration(cfg)
+    # Assert
+    assert resolved is None
+
+
+# ---------------------------------------------------------------------------
+# is_image_overlay — never mkdir over a loopback image
+# ---------------------------------------------------------------------------
+
+
+def test_is_image_overlay_true_for_img_suffix(tmp_path: Path) -> None:
+    # Arrange
+    candidate = tmp_path / "ov.img"
+    # Act
+    verdict = is_image_overlay(candidate)
+    # Assert
+    assert verdict is True
+
+
+def test_is_image_overlay_true_when_overlay_size_declared(tmp_path: Path) -> None:
+    # Arrange — overlay_size IS the "sized loopback image" contract.
+    candidate = tmp_path / "sized"
+    # Act
+    verdict = is_image_overlay(candidate, overlay_size="5G")
+    # Assert
+    assert verdict is True
+
+
+def test_is_image_overlay_true_for_existing_file(tmp_path: Path) -> None:
+    # Arrange — an image already created by `apptainer overlay create`.
+    image = tmp_path / "already"
+    image.write_bytes(b"")
+    # Act
+    verdict = is_image_overlay(image)
+    # Assert
+    assert verdict is True
+
+
+def test_is_image_overlay_false_for_plain_directory_path(tmp_path: Path) -> None:
+    # Arrange
+    candidate = tmp_path / "overlays" / "brand-new"
+    # Act
+    verdict = is_image_overlay(candidate)
+    # Assert
+    assert verdict is False
+
+
+# ---------------------------------------------------------------------------
+# ensure_overlay_dirs — THE regression: brand-new agent gets an overlay
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_creates_overlay_root_for_equals_joined_spec(tmp_path: Path) -> None:
+    # Arrange — the EXACT spec shape that FATAL'd apptainer.
+    overlay = tmp_path / "overlays" / "brand-new"
+    cfg = _cfg(tmp_path, raw_args=_template_raw_args(overlay))
+    # Act
+    ensure_overlay_dirs(cfg)
+    # Assert — the root apptainer lstat()s now exists.
+    assert overlay.is_dir()
+
+
+def test_ensure_creates_upper_dir(tmp_path: Path) -> None:
+    # Arrange
+    overlay = tmp_path / "overlays" / "brand-new"
+    cfg = _cfg(tmp_path, raw_args=_template_raw_args(overlay))
+    # Act
+    ensure_overlay_dirs(cfg)
+    # Assert — same layout every live fleet overlay carries.
+    assert (overlay / "upper").is_dir()
+
+
+def test_ensure_creates_work_dir(tmp_path: Path) -> None:
+    # Arrange
+    overlay = tmp_path / "overlays" / "brand-new"
+    cfg = _cfg(tmp_path, raw_args=_template_raw_args(overlay))
+    # Act
+    ensure_overlay_dirs(cfg)
+    # Assert
+    assert (overlay / "work").is_dir()
+
+
+def test_ensure_provisions_dirs_with_fleet_permissions(tmp_path: Path) -> None:
+    # Arrange — live overlays (scitex-scholar, figrecipe, …) are all 0755.
+    overlay = tmp_path / "overlays" / "brand-new"
+    cfg = _cfg(tmp_path, raw_args=_template_raw_args(overlay))
+    # Act
+    ensure_overlay_dirs(cfg)
+    # Assert
+    assert (overlay / "upper").stat().st_mode & 0o777 == OVERLAY_DIR_MODE
+
+
+def test_ensure_also_provisions_space_separated_spec(tmp_path: Path) -> None:
+    # Arrange — the fleet's other spelling must be provisioned too.
+    overlay = tmp_path / "overlays" / "scholar"
+    cfg = _cfg(tmp_path, raw_args=["--overlay", str(overlay)])
+    # Act
+    ensure_overlay_dirs(cfg)
+    # Assert
+    assert (overlay / "work").is_dir()
+
+
+def test_ensure_also_provisions_modeled_overlay_field(tmp_path: Path) -> None:
+    # Arrange — the inline `full` template's spec.apptainer.overlay.
+    overlay = tmp_path / "overlays" / "modeled"
+    cfg = _cfg(tmp_path, overlay=f"{overlay}/")
+    # Act
+    ensure_overlay_dirs(cfg)
+    # Assert
+    assert (overlay / "upper").is_dir()
+
+
+def test_ensure_returns_the_overlay_root(tmp_path: Path) -> None:
+    # Arrange
+    overlay = tmp_path / "overlays" / "brand-new"
+    cfg = _cfg(tmp_path, raw_args=_template_raw_args(overlay))
+    # Act
+    resolved = ensure_overlay_dirs(cfg)
+    # Assert
+    assert resolved == overlay
+
+
+def test_ensure_is_idempotent_across_restarts(tmp_path: Path) -> None:
+    # Arrange — an agent restarts; its overlay carries accumulated state.
+    overlay = tmp_path / "overlays" / "brand-new"
+    cfg = _cfg(tmp_path, raw_args=_template_raw_args(overlay))
+    ensure_overlay_dirs(cfg)
+    (overlay / "upper" / "keep-me").write_text("state\n", encoding="utf-8")
+    # Act — second start must not disturb the existing overlay.
+    ensure_overlay_dirs(cfg)
+    # Assert
+    assert (overlay / "upper" / "keep-me").read_text(encoding="utf-8") == "state\n"
+
+
+def test_ensure_leaves_existing_overlay_permissions_untouched(tmp_path: Path) -> None:
+    # Arrange — operator (or the agent) tightened its own overlay.
+    overlay = tmp_path / "overlays" / "brand-new"
+    cfg = _cfg(tmp_path, raw_args=_template_raw_args(overlay))
+    ensure_overlay_dirs(cfg)
+    (overlay / "upper").chmod(0o700)
+    # Act
+    ensure_overlay_dirs(cfg)
+    # Assert — no chmod of a dir that already exists.
+    assert (overlay / "upper").stat().st_mode & 0o777 == 0o700
+
+
+def test_ensure_noop_without_any_overlay_declaration(tmp_path: Path) -> None:
+    # Arrange — a spec with no overlay at all.
+    cfg = _cfg(tmp_path, raw_args=["--containall"])
+    # Act
+    resolved = ensure_overlay_dirs(cfg)
+    # Assert
+    assert resolved is None
+
+
+def test_ensure_never_mkdirs_a_sized_image_overlay(tmp_path: Path) -> None:
+    # Arrange — overlay_size means `apptainer overlay create` owns this path;
+    # a directory here would shadow the image and break that path outright.
+    image = tmp_path / "ov.img"
+    cfg = _cfg(tmp_path, overlay=str(image), overlay_size="100M")
+    # Act
+    ensure_overlay_dirs(cfg)
+    # Assert
+    assert not image.exists()
+
+
+def test_ensure_fails_loud_naming_the_path_when_unprovisionable(
+    tmp_path: Path,
+) -> None:
+    # Arrange — overlay parent is a FILE, so mkdir cannot succeed.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a dir\n", encoding="utf-8")
+    overlay = blocker / "brand-new"
+    cfg = _cfg(tmp_path, raw_args=_template_raw_args(overlay))
+    # Act
+    # Assert — the actionable hint names the exact path, not a raw FATAL.
+    with pytest.raises(OverlayProvisionError, match=str(overlay)):
+        ensure_overlay_dirs(cfg)
+
+
+def test_ensure_failure_hint_carries_the_mkdir_command(tmp_path: Path) -> None:
+    # Arrange
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a dir\n", encoding="utf-8")
+    cfg = _cfg(tmp_path, raw_args=_template_raw_args(blocker / "brand-new"))
+    # Act — capture the message; a pytest.raises here would be a 2nd assertion.
+    message = ""
+    try:
+        ensure_overlay_dirs(cfg)
+    except OverlayProvisionError as exc:
+        message = str(exc)
+    # Assert — constitution: always give an actionable hint.
+    assert "mkdir -p" in message
+
+
+# ---------------------------------------------------------------------------
+# overlay_flags — the curated --overlay flag for the MODELED field
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_flags_emits_flag_for_provisioned_directory(tmp_path: Path) -> None:
+    # Arrange
+    overlay = tmp_path / "overlays" / "modeled"
+    cfg = _cfg(tmp_path, overlay=str(overlay))
+    ensure_overlay_dirs(cfg)
+    # Act
+    flags = overlay_flags(cfg)
+    # Assert
+    assert flags == ["--overlay", str(overlay)]
+
+
+def test_overlay_flags_empty_for_raw_args_only_overlay(tmp_path: Path) -> None:
+    # Arrange — raw_args overlays pass through verbatim; no curated flag, so
+    # the launch never carries a DUPLICATE --overlay.
+    overlay = tmp_path / "overlays" / "brand-new"
+    cfg = _cfg(tmp_path, raw_args=_template_raw_args(overlay))
+    # Act
+    flags = overlay_flags(cfg)
+    # Assert
+    assert flags == []
+
+
+def test_overlay_flags_fails_loud_for_missing_image_overlay(tmp_path: Path) -> None:
+    # Arrange — image overlay, no overlay_size → nothing can create it.
+    cfg = _cfg(tmp_path, overlay=str(tmp_path / "ov.img"))
+    # Act
+    # Assert
+    with pytest.raises(FileNotFoundError, match="overlay_size"):
+        overlay_flags(cfg)
+
+# EOF

--- a/tests/scitex_agent_container/runtimes/test__cct_token_pool.py
+++ b/tests/scitex_agent_container/runtimes/test__cct_token_pool.py
@@ -268,7 +268,7 @@ def test_injected_env_file_is_owner_only(
 # ---------------------------------------------------------------------------
 
 
-def test_missing_token_logs_error(
+def test_missing_token_logs_warning(
     tmp_path: Path,
     secrets_envrc: None,
     caplog: pytest.LogCaptureFixture,
@@ -278,13 +278,48 @@ def test_missing_token_logs_error(
     dest = tmp_path / "home"
     dest.mkdir()
     # Act
-    with caplog.at_level(scitex_logging.ERROR):
+    with caplog.at_level(scitex_logging.WARNING):
         ensure_cct_bot_token(_cfg("zz-missing-fixture"), dest)
-    # Assert — LOUD error names the agent (never silent absence).
+    # Assert — LOUD warning names the agent (never silent absence).
     assert "zz-missing-fixture" in caplog.text
 
 
-def test_missing_token_error_names_pool_source(
+def test_missing_token_never_logs_at_error_level(
+    tmp_path: Path,
+    secrets_envrc: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Arrange — a brand-new agent has no bot yet BY DEFINITION. Logging that
+    # at ERROR made every fresh agent's boot log read like a startup failure
+    # next to the genuinely fatal lines. It is a degraded comms rail, not a
+    # dead boot: WARNING, never ERROR.
+    os.environ.pop(_SECRETS_VAR, None)
+    dest = tmp_path / "home"
+    dest.mkdir()
+    # Act
+    with caplog.at_level(scitex_logging.DEBUG):
+        ensure_cct_bot_token(_cfg("zz-missing-fixture"), dest)
+    # Assert
+    assert not [r for r in caplog.records if r.levelno >= scitex_logging.ERROR]
+
+
+def test_missing_token_warning_says_the_agent_still_starts(
+    tmp_path: Path,
+    secrets_envrc: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Arrange — the message must SAY it is non-fatal, not merely be non-fatal.
+    os.environ.pop(_SECRETS_VAR, None)
+    dest = tmp_path / "home"
+    dest.mkdir()
+    # Act
+    with caplog.at_level(scitex_logging.WARNING):
+        ensure_cct_bot_token(_cfg("zz-missing-fixture"), dest)
+    # Assert
+    assert "NOT a startup failure" in caplog.text
+
+
+def test_missing_token_warning_names_pool_source(
     tmp_path: Path,
     secrets_envrc: None,
     caplog: pytest.LogCaptureFixture,
@@ -294,7 +329,7 @@ def test_missing_token_error_names_pool_source(
     dest = tmp_path / "home"
     dest.mkdir()
     # Act
-    with caplog.at_level(scitex_logging.ERROR):
+    with caplog.at_level(scitex_logging.WARNING):
         ensure_cct_bot_token(_cfg("zz-missing-fixture"), dest)
     # Assert — the operator is told WHERE the pool lives.
     assert "SAC_SECRETS_ENVRC" in caplog.text


### PR DESCRIPTION
## The bug

`sac agents create <name> --template python_developer --start` (and the MCP
`agent_create(..., start=True)`) wrote a valid spec, then the START died in
apptainer's `container_creation` phase:

```
FATAL: while loading overlay images: failed to open overlay image
  /home/ywatanabe/.scitex/agent-container/containers/overlays/scitex-agentic-journal/:
  failed to retrieve path for .../overlays/scitex-agentic-journal/:
  lstat .../overlays/scitex-agentic-journal: no such file or directory
```

sac's own lifecycle classifier could only label it `container_creation_unknown`
and hand the operator a raw apptainer FATAL. This blocked launching maintainer
agents for leaf packages that have none (`scitex-agentic-journal`, `scitex-ui`).

## Root cause

**Nothing in sac ever created the per-agent overlay directory.**

Apptainer creates `<overlay>/upper` and `<overlay>/work` itself, but it
`lstat()`s the overlay **root** and refuses to create it — a missing root is a
hard FATAL.

The fleet's overlays exist only as an **incidental side-effect** of
`_to_home_overlay.deploy_to_home_overlay` (`_to_home_overlay.py:148`), whose
`<overlay>/upper/<container_home>` `mkdir(parents=True)` creates the root on the
way down. That side-effect is gated on `_resolve_overlay_dir`
(`_to_home_overlay.py:86-109`), which recognises an overlay **only** as:

1. the modeled `spec.apptainer.overlay` field, or
2. the **space-separated** raw_args pair `["--overlay", "<path>"]`.

Every hand-authored fleet spec happens to use spelling (2), so the accident
held. The `_template_python_developer` dir-template — what `sac agents create
--template python_developer` copies — emits the **`=`-joined** spelling
`--overlay=<path>`, which apptainer accepts identically and sac was blind to.

Resolver saw nothing → the `mkdir` never fired → the overlay root was never
created → the agent was **stillborn**.

Verified against the real spec:

| resolver | result for `scitex-agentic-journal` |
|---|---|
| old `_resolve_overlay_dir` | `None` (blind) |
| new `resolve_overlay_declaration` | `.../overlays/scitex-agentic-journal` |
| that path on disk | did not exist |

## The fix

Make the precondition **explicit, form-agnostic and idempotent**. New
`runtimes/_apptainer_overlay.py` now owns every overlay concern:

- `raw_arg_value()` — reads **both** `--overlay <p>` and `--overlay=<p>`.
- `resolve_overlay_declaration()` — "what path does apptainer actually get?"
- `ensure_overlay_dirs()` — idempotently creates `<overlay>/`, `<overlay>/upper/`
  and `<overlay>/work/` at mode `0755` — the layout and mode **verified** on the
  live fleet's overlays (scitex-scholar, figrecipe, scitex-clew). An existing
  overlay is left completely untouched (no `chmod`).
- `overlay_flags()` — the curated `--overlay` flag + sized-image auto-create,
  **extracted** from `build_run_argv` (which sat exactly at the 512-line cap).
  Mirrors the existing `tmpfs_workdir_flags` / `nested_build_flags` / `auth_argv`
  pattern.

`build_run_argv` calls `ensure_overlay_dirs()` — the **one choke point every
apptainer launch passes through** (SDK runner and TUI alike) — so no runtime and
no spec spelling can regress to a stillborn start.

Image overlays (`overlay_size`, or an `.img`/`.ext3`/`.sif` path) are never
`mkdir`-ed; they stay with `apptainer overlay create`.

### Fail-loud (constitution)

- An overlay that cannot be created raises `OverlayProvisionError` naming the
  **exact path** and the **exact `mkdir -p` command**.
- `classify_apptainer_failure` now maps the apptainer overlay FATAL to kind
  `overlay_missing` with an actionable hint, instead of falling through to
  `container_creation_unknown` + a raw FATAL.

### Boot noise

A brand-new agent has no Telegram bot **by definition**, but `_cct_token_pool`
logged that at `ERROR`, so every fresh agent's boot log read like a startup
failure. Downgraded to `WARNING`, reworded to state explicitly that the agent
starts normally — a missing bot token degrades one comms rail, it does not fail
a boot.

## Deliberately NOT changed

`_resolve_overlay_dir` still reads only the space-separated spelling, and the
module now documents **why** so nobody "fixes" it blind.

It does not answer "what overlay does apptainer get?" — it answers a **policy**
question: *"does sac back the container `$HOME` with this overlay's upper layer,
instead of with the workspace-home bind?"* Widening it would **migrate the
`$HOME` of every live `=`-joined agent** from `<state>/home/` to
`<overlay>/upper/home/agent/` — a different, older tree — so the agent would
resume from a stale `.claude/` (session history, `.claude.json`).

Measured 2026-07-13:

| agent | spelling | writes its `$HOME` to | overlay upper-home |
|---|---|---|---|
| `scitex-scholar` | space-separated | overlay upper (Jul 13, live) | current |
| `paper-scitex-clew` | `=`-joined | workspace home (Jul 12, live) | **Jul 5, stale** |

That migration needs an operator decision plus a seed-the-upper-home step; it is
not a parser bugfix. The stillborn bug no longer depends on what that function
sees.

## Tests

- **29 new** in `test__apptainer_overlay.py` — both spellings, modeled field,
  relative-path anchoring, idempotency across restarts, existing-permissions
  untouched, image-overlay never `mkdir`-ed, fail-loud hint carries the path and
  the `mkdir -p`.
- **4 end-to-end** in `test__apptainer_build_argv.py` — a brand-new agent with
  the exact `_template_python_developer` raw_args gets its overlay root + `upper`
  + `work` provisioned by `build_run_argv`, and the operator's `=`-joined token
  is passed through exactly once (no duplicate `--overlay`).
- **2** classifier tests (`overlay_missing` kind + `mkdir -p` hint).
- **4** cct-token tests (WARNING not ERROR; message states the agent still starts).

## Docs

`docs/isolation.md` section 7 now documents **both** overlay forms and corrects
the now-stale "`overlay_size` empty + overlay missing → sac raises" bullet, which
was only ever true for image overlays.
