### PR TITLE
feat(agents-list): local-tz Started + resolved Host columns + perf fixes

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_list_format.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_format.py
@@ -115,6 +115,49 @@ def format_dt_local(
     return dt.astimezone(tz).isoformat(timespec="seconds")
 
 
+# Display timezone for the ``sac agents list`` Started column. PINNED to
+# Asia/Tokyo (the operator's zone) rather than the host's system-local tz,
+# because the host is WSL and may report UTC — the Started column must show
+# JST regardless of host config (operator TG 2026-07-13). Override with the
+# ``SAC_DISPLAY_TZ`` env var (any IANA zone name, e.g. ``America/New_York``).
+_DEFAULT_DISPLAY_TZ = "Asia/Tokyo"
+_DISPLAY_TZ_ENV = "SAC_DISPLAY_TZ"
+
+
+def format_dt_display_tz(
+    iso_or_dt: str | datetime | None,
+    *,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Render an ISO-8601 UTC timestamp as ``YYYY-MM-DD HH:MM (TZ)`` in the
+    pinned DISPLAY timezone (default ``Asia/Tokyo`` → ``JST``).
+
+    The ``sac agents list`` Started column: a SPACE (not the ISO ``T``)
+    separates date and time, seconds are dropped, and the timezone
+    abbreviation — DERIVED from the tz object, e.g. ``JST`` (never a
+    hardcoded label) — is shown in parentheses in place of the bare ``Z``.
+    Unlike :func:`format_dt_local` (operator-local ``TZ`` precedence) this
+    PINS the zone to ``SAC_DISPLAY_TZ`` / :data:`_DEFAULT_DISPLAY_TZ`, so a
+    UTC-configured WSL host still shows JST (operator TG 2026-07-13). The
+    ``--json`` path keeps the raw ISO ``...Z`` untouched for scripts.
+
+    Returns ``"-"`` for ``None`` / empty / unparseable input. Reuses the
+    same ``_coerce_dt`` (naive → UTC) + ``_resolve_tz`` (stdlib ``zoneinfo``)
+    SSOT the accounts formatters use.
+    """
+    dt = _coerce_dt(iso_or_dt)
+    if dt is None:
+        return "-"
+    src = env if env is not None else os.environ
+    name = (src.get(_DISPLAY_TZ_ENV) or "").strip() or _DEFAULT_DISPLAY_TZ
+    tz = _resolve_tz(name) or _resolve_tz(_DEFAULT_DISPLAY_TZ)
+    # zoneinfo unavailable (no tzdata on the host) → render in UTC so the
+    # column still shows a stable, labelled timestamp rather than crashing.
+    local = dt.astimezone(tz) if tz is not None else dt.astimezone(timezone.utc)
+    abbrev = local.strftime("%Z") or local.strftime("%z") or "UTC"
+    return f"{local.strftime('%Y-%m-%d %H:%M')} ({abbrev})"
+
+
 def _coerce_dt(value: str | datetime | None) -> datetime | None:
     """Coerce ``value`` to an aware datetime; ``None`` on any failure."""
     if value is None:

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -22,6 +22,9 @@ from ._agent_list_account import (  # noqa: F401
     _safe_account_for,
 )
 
+# Host-DISPLAY resolution (Host column) — sibling module, 512-line cap split.
+from ._agent_list_host import _host_display_for, _resolve_display_host
+
 
 def _safe_port_for(name: str) -> int | None:
     """Return the agent's claimed a2a port, or None on any failure.
@@ -169,6 +172,9 @@ def get_agent_list_data(
     from concurrent.futures import TimeoutError as _FuturesTimeout
 
     entries = registry.list_all()
+
+    # Host DISPLAY column hostname, resolved ONCE (test-swappable seam).
+    display_host = _resolve_display_host()
 
     # First pass: resolve configs + filter.
     # F-CS17 stage 3b: there are no longer "remote" agents from sac's
@@ -334,6 +340,7 @@ def get_agent_list_data(
             "multiplexer": multiplexer,
             "started_at": started,
             "host": host_label,
+            "host_display": _host_display_for(host_label, display_host),
             "path": spec_path,
             "a2a_port": a2a_port,
             "account": account_label,
@@ -404,6 +411,7 @@ def get_agent_list_data(
             "multiplexer": getattr(cfg, "runtime", None) if cfg else None,
             "started_at": "-",
             "host": "local",
+            "host_display": _host_display_for("local", display_host),
             "path": str(spec_path),
             "a2a_port": _safe_port_for(name),
             "account": _safe_account_for(cfg),

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -26,23 +26,34 @@ from ._agent_list_account import (  # noqa: F401
 from ._agent_list_host import _host_display_for, _resolve_display_host
 
 
-def _safe_port_for(name: str) -> int | None:
-    """Return the agent's claimed a2a port, or None on any failure.
+def _all_port_claims() -> dict[str, int]:
+    """Return ``{agent_name: a2a_port}`` for every claim, in ONE db read.
 
-    Used by Layer-6 of auto-port-allocation to surface the allocated
-    port in ``sac agents list`` output. Tolerant: a missing state.db,
-    schema-not-yet-initialized error, or unknown name all map to
-    ``None`` so the list command never fails because of port lookup.
+    Replaces the former per-agent ``_safe_port_for`` (``get_port`` per row)
+    in ``sac agents list``: each ``get_port`` opened + init-schema'd the
+    state.db ~3x (~62ms/agent on a full host); ``list_claims`` does it once.
+    Callers look the port up per row from the returned dict. Tolerant: any
+    failure maps to an empty map so the list never crashes on a port-lookup
+    hiccup (rows render ``—``).
     """
     # stx-allow: fallback (reason: list output must never crash on a
-    # port-allocator hiccup; ``None`` cell rendered as ``—`` is the
-    # right UX.)
+    # port-allocator hiccup; an empty map rendered as ``—`` is the right UX.)
     try:
         from ..._state import port_allocator
 
-        return port_allocator.get_port(name)
+        return {c["name"]: c["port"] for c in port_allocator.list_claims()}
     except Exception:  # stx-allow: fallback (reason: see inline comment)
-        return None
+        return {}
+
+
+# The always-present movement trio in its empty shape — the tolerant fallback
+# AND what a PERF-deferred (hidden, non-running) row carries in place of the
+# movement IO. One definition so the two paths can never drift.
+_MOVEMENT_DEFAULTS: dict = {
+    "session_jsonl_bytes": 0,
+    "session_jsonl_last_write": "",
+    "heartbeat_at": "",
+}
 
 
 def _movement_fields(name: str) -> dict:
@@ -68,11 +79,7 @@ def _movement_fields(name: str) -> dict:
 
         return status_movement_fields(resolve_state_dir(name))
     except Exception:  # stx-allow: fallback (reason: see inline comment)
-        return {
-            "session_jsonl_bytes": 0,
-            "session_jsonl_last_write": "",
-            "heartbeat_at": "",
-        }
+        return dict(_MOVEMENT_DEFAULTS)
 
 
 def _probe_local(cfg) -> bool | None:
@@ -139,11 +146,21 @@ def get_agent_list_data(
     tags: str | None = None,
     remote_probe_timeout_s: float = 2.0,
     max_parallel_probes: int = 8,
+    running_only: bool = False,
 ) -> list[dict]:
     """Get agent list as plain dicts for JSON or table output.
 
     Args:
         registry: The agent registry to query.
+        running_only: PERF hint from the DEFAULT human view, which discards
+            every non-running row before rendering. When True, the heavy
+            per-row enrichment (account resolution + session-movement IO) is
+            SKIPPED for rows that are not ``running`` — they still get a
+            correct ``status`` (so the hidden-count footer is right) but a
+            blank ``account`` + default movement fields. The ``--json`` and
+            ``-v`` / ``--all`` paths leave this False so every row stays fully
+            enriched (they show non-running rows). Default False preserves the
+            original all-rows-enriched behaviour.
         capability: If set, only include agents whose ``capabilities`` label
             contains this value (comma-separated matching).
         machine: If set, only include agents whose ``machine`` label matches.
@@ -175,6 +192,10 @@ def get_agent_list_data(
 
     # Host DISPLAY column hostname, resolved ONCE (test-swappable seam).
     display_host = _resolve_display_host()
+
+    # A2A ports for ALL agents in ONE db read (was a per-agent get_port that
+    # re-opened + re-init-schema'd state.db ~3x each). Looked up per row.
+    port_claims = _all_port_claims()
 
     # First pass: resolve configs + filter.
     # F-CS17 stage 3b: there are no longer "remote" agents from sac's
@@ -304,11 +325,16 @@ def get_agent_list_data(
         else:
             status_val = "running" if is_running else "stopped"
 
+        # FIX (no double-parse): a config that ``load_config`` ACCEPTED is
+        # valid by construction — ``load_config`` runs ``validate_raw`` and
+        # RAISES on any error — so cfg-not-None ⇒ zero errors. Only
+        # RE-VALIDATE (a second open+parse of the same file) when the load
+        # FAILED, to recover the error list for the YAML column.
         errors: list[str] = []
-        if config_path:
+        if config_path and cfg is None:
             from ...config._validation import validate_config
 
-            try:  # stx-allow: fallback (validator raise → treat exception as a single error)
+            try:  # stx-allow: fallback (validator raise → single error)
                 errors = validate_config(str(config_path))
             except Exception as exc:
                 errors = [str(exc)]
@@ -316,23 +342,26 @@ def get_agent_list_data(
         # key on the row for backward-compat JSON consumers.
         host_label = "local"
         spec_path = str(config_path) if config_path else ""
-        # Layer-6: surface the auto-allocated a2a port so operators can
-        # see which IPC port the sidecar is bound to without grepping
-        # state.db by hand. ``None`` when no claim exists (agent never
-        # started under the allocator, or sidecar-disabled spec).
-        a2a_port = _safe_port_for(name)
-        # Which Anthropic account this agent authenticates as. Agents
-        # sharing one label share one server-side rate limit. For a RUNNING
-        # agent prefer the ACTUAL runtime account (read from its per-agent
-        # ``<runtime>/home/.claude.json``) over the spec-derived label —
-        # pool-based agents all resolve to the same host-OAuth spec label
-        # otherwise, hiding the load-balanced per-agent pick. Called as a
-        # bare name so a test can rebind ``_al._runtime_account_for``.
-        account_label = _safe_account_for(cfg)
-        if status_val == "running":
-            runtime_label = _runtime_account_for(name)
-            if runtime_label:
-                account_label = runtime_label
+        # a2a port from the ONE-query claims map. ``None`` when no claim
+        # exists (agent never started under the allocator).
+        a2a_port = port_claims.get(name)
+        # PERF: the running-only default view discards non-running rows, so
+        # skip their account resolution + movement IO. ``status`` is already
+        # computed, so the hidden-count footer stays correct.
+        deferred = running_only and status_val != "running"
+        # Which Anthropic account this agent authenticates as. For a RUNNING
+        # agent prefer the ACTUAL runtime account (its per-agent
+        # ``<runtime>/home/.claude.json``) over the spec-derived label — pool
+        # agents share one host-OAuth spec label otherwise. Bare names so a
+        # test can rebind ``_al._safe_account_for`` / ``_al._runtime_account_for``.
+        if deferred:
+            account_label = ""
+        else:
+            account_label = _safe_account_for(cfg)
+            if status_val == "running":
+                runtime_label = _runtime_account_for(name)
+                if runtime_label:
+                    account_label = runtime_label
         row: dict = {
             "name": name,
             "status": status_val,
@@ -346,12 +375,11 @@ def get_agent_list_data(
             "account": account_label,
         }
         # Operator mandate (lead a2a 1781e82a, 2026-06-14): surface
-        # session.jsonl movement + last heartbeat at the per-row level
-        # of ``sac agents status --json`` so the kick-cycle reads
-        # MOVEMENT without scraping the SDK heartbeat.json out of band.
-        # All three keys are always present; missing-data renders as
-        # ``0`` / ``""``.
-        row.update(_movement_fields(name))
+        # session.jsonl movement + last heartbeat per row of ``sac agents
+        # status --json``. All three keys are ALWAYS present; a deferred
+        # (hidden, non-running) row gets the default empty shape instead of
+        # the movement IO.
+        row.update(dict(_MOVEMENT_DEFAULTS) if deferred else _movement_fields(name))
         if errors:
             row["validation_errors"] = errors
         if liveness_unknown:
@@ -397,13 +425,22 @@ def get_agent_list_data(
                 continue
         if tags and not _label_list_contains(labels, "tags", tags):
             continue
-        # stx-allow: fallback (validator may raise on unparseable yaml;
-        # treat as "invalid" with the exception text as the only error)
-        try:
-            errors = validate_config(str(spec_path))
-        except Exception as exc:
-            errors = [str(exc)]
+        # FIX (no double-parse): a spec that ``load_config`` accepted is
+        # valid ⇒ "defined". Only RE-VALIDATE the ones that FAILED to load,
+        # to split "invalid" from "defined" and recover their error list.
+        errors = []
+        if cfg is None:
+            # stx-allow: fallback (validator may raise on unparseable yaml;
+            # treat as "invalid" with the exception text as the only error)
+            try:
+                errors = validate_config(str(spec_path))
+            except Exception as exc:
+                errors = [str(exc)]
         status = "invalid" if errors else "defined"
+        # PERF: defined agents are never ``running`` — in the running-only
+        # default view they are all hidden, so skip their account + movement
+        # enrichment (status is enough for the footer count).
+        deferred = running_only
         row: dict = {
             "name": name,
             "status": status,
@@ -413,10 +450,10 @@ def get_agent_list_data(
             "host": "local",
             "host_display": _host_display_for("local", display_host),
             "path": str(spec_path),
-            "a2a_port": _safe_port_for(name),
-            "account": _safe_account_for(cfg),
+            "a2a_port": port_claims.get(name),
+            "account": "" if deferred else _safe_account_for(cfg),
         }
-        row.update(_movement_fields(name))
+        row.update(dict(_MOVEMENT_DEFAULTS) if deferred else _movement_fields(name))
         if errors:
             row["validation_errors"] = errors
         if labels:
@@ -425,76 +462,14 @@ def get_agent_list_data(
     return results
 
 
-def _is_self_peer_marker(spec_path: "Path") -> bool:  # noqa: F821
-    """Return True iff ``spec_path`` is a self-peer registration marker.
-
-    ``agents/self/spec.yaml`` (see ``_listen/_self_peers.py``) is a
-    DELIBERATELY schema-incompatible file — it registers the running
-    listen's own runtime identity, not a launchable Agent, and its own
-    header says ``DO NOT add apiVersion or spec:``. Running the generic
-    Agent validator against it always reports it "invalid" (missing
-    apiVersion/kind/spec, unknown top-level fields) even though it is
-    working exactly as designed. Reuses the SAME predicate the listen
-    merge already uses to recognize this file, so there is one place
-    that knows what a self-peer marker looks like.
-
-    Tolerant: any read/parse failure returns False (falls through to
-    normal defined-agent handling) rather than raising — matches this
-    module's existing crash-tolerance convention.
-    """
-    # stx-allow: fallback (reason: classification hiccup must not hide or
-    # misclassify a spec; falling through to normal validation is safe)
-    try:
-        import yaml
-
-        from ..._listen._self_peers import is_self_peer_spec
-
-        blob = yaml.safe_load(spec_path.read_text())
-        return is_self_peer_spec(blob)
-    except Exception:  # stx-allow: fallback (reason: see inline comment)
-        return False
-
-
-def _discover_defined_agents() -> "list[tuple[str, Path]]":  # noqa: F821
-    """Walk the user-scope (and project-scope, when in a git repo)
-    ``agents/`` tree and return ``(name, spec.yaml path)`` pairs for
-    every agent declared on disk. Tolerant of partial state — a
-    directory without a ``spec.yaml`` is skipped silently. Self-peer
-    registration markers (see :func:`_is_self_peer_marker`) are NOT
-    agents and are excluded here at the source, rather than surfacing
-    as a spuriously "invalid" agent downstream.
-    """
-    from pathlib import Path as _Path
-
-    pairs: list[tuple[str, _Path]] = []
-    seen: set[str] = set()
-
-    roots: list[_Path] = []
-    # stx-allow: fallback (project-scope is optional; absent → skip)
-    try:
-        from scitex_config._ecosystem import local_state as _ls
-
-        project = _ls.find_project_scope("agent-container")
-        if project is not None:
-            roots.append(project / "agents")
-    except Exception:
-        pass
-    roots.append(_Path.home() / ".scitex" / "agent-container" / "agents")
-
-    for root in roots:
-        if not root.is_dir():
-            continue
-        for child in sorted(root.iterdir()):
-            if not child.is_dir() or child.name in seen:
-                continue
-            spec = child / "spec.yaml"
-            if not spec.is_file():
-                continue
-            if _is_self_peer_marker(spec):
-                continue
-            pairs.append((child.name, spec))
-            seen.add(child.name)
-    return pairs
+# Defined-on-disk discovery lives in the sibling ``_agent_list_discover``
+# module (512-line cap split). Re-imported so the bare-name call site
+# ``_discover_defined_agents()`` above and the test seams
+# ``_al._discover_defined_agents`` / ``_al._is_self_peer_marker`` resolve.
+from ._agent_list_discover import (  # noqa: E402,F401
+    _discover_defined_agents,
+    _is_self_peer_marker,
+)
 
 
 # Presentation layer lives in the sibling ``_agent_list_render`` module

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
@@ -1,0 +1,83 @@
+"""Defined-on-disk agent discovery for ``sac agents list``.
+
+Split out of ``_agent_list.py`` (512-line cap) so the filesystem-walk concern
+lives beside its siblings ``_agent_list_account`` / ``_agent_list_render`` /
+``_agent_list_host``. ``_agent_list`` re-imports both names, so the bare-name
+call site ``_discover_defined_agents()`` in ``get_agent_list_data`` and the
+test seams ``_al._discover_defined_agents`` / ``_al._is_self_peer_marker``
+keep resolving unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _is_self_peer_marker(spec_path: Path) -> bool:
+    """Return True iff ``spec_path`` is a self-peer registration marker.
+
+    ``agents/self/spec.yaml`` (see ``_listen/_self_peers.py``) is a
+    DELIBERATELY schema-incompatible file — it registers the running
+    listen's own runtime identity, not a launchable Agent, and its own
+    header says ``DO NOT add apiVersion or spec:``. Running the generic
+    Agent validator against it always reports it "invalid" (missing
+    apiVersion/kind/spec, unknown top-level fields) even though it is
+    working exactly as designed. Reuses the SAME predicate the listen
+    merge already uses to recognize this file, so there is one place
+    that knows what a self-peer marker looks like.
+
+    Tolerant: any read/parse failure returns False (falls through to
+    normal defined-agent handling) rather than raising — matches this
+    module's existing crash-tolerance convention.
+    """
+    # stx-allow: fallback (reason: classification hiccup must not hide or
+    # misclassify a spec; falling through to normal validation is safe)
+    try:
+        import yaml
+
+        from ..._listen._self_peers import is_self_peer_spec
+
+        blob = yaml.safe_load(spec_path.read_text())
+        return is_self_peer_spec(blob)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return False
+
+
+def _discover_defined_agents() -> list[tuple[str, Path]]:
+    """Walk the user-scope (and project-scope, when in a git repo)
+    ``agents/`` tree and return ``(name, spec.yaml path)`` pairs for
+    every agent declared on disk. Tolerant of partial state — a
+    directory without a ``spec.yaml`` is skipped silently. Self-peer
+    registration markers (see :func:`_is_self_peer_marker`) are NOT
+    agents and are excluded here at the source, rather than surfacing
+    as a spuriously "invalid" agent downstream.
+    """
+    pairs: list[tuple[str, Path]] = []
+    seen: set[str] = set()
+
+    roots: list[Path] = []
+    # stx-allow: fallback (project-scope is optional; absent → skip)
+    try:
+        from scitex_config._ecosystem import local_state as _ls
+
+        project = _ls.find_project_scope("agent-container")
+        if project is not None:
+            roots.append(project / "agents")
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        pass
+    roots.append(Path.home() / ".scitex" / "agent-container" / "agents")
+
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for child in sorted(root.iterdir()):
+            if not child.is_dir() or child.name in seen:
+                continue
+            spec = child / "spec.yaml"
+            if not spec.is_file():
+                continue
+            if _is_self_peer_marker(spec):
+                continue
+            pairs.append((child.name, spec))
+            seen.add(child.name)
+    return pairs

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_host.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_host.py
@@ -1,0 +1,49 @@
+"""Host-DISPLAY resolution for the ``sac agents list`` Host column.
+
+Split out of ``_agent_list.py`` (already at the 512-line per-file cap) so
+the tiny host-display concern lives next to its siblings
+``_agent_list_account`` (Account column) and ``_agent_list_render`` (table).
+
+``host: local`` was banned on the spec-INPUT side (operator 2026-07-10;
+the ``${HOSTNAME}`` placeholder replaced it), but list rows still carry the
+``"local"`` sentinel in their ``host`` field. These helpers resolve the
+machine's canonical hostname for DISPLAY while leaving the raw ``host``
+sentinel intact for backward-compat consumers (``_is_ghost_row`` keys on
+``host == "local"`` to recognise a LOCAL agent).
+"""
+
+from __future__ import annotations
+
+
+def _resolve_display_host() -> str:
+    """Resolve THIS machine's canonical hostname for the Host DISPLAY column.
+
+    Uses the SAME resolver ``${HOSTNAME}`` expands through —
+    :func:`config._host.resolve_hostname` (``SCITEX_AGENT_CONTAINER_HOSTNAME``
+    env → ``config.yaml`` alias → ``hostname -s``) — so the displayed Host
+    (e.g. ``ywata-note-win``) matches what a freshly-created spec records.
+    Tolerant: any resolution failure degrades to the socket short-name, then
+    to ``"local"``, so the list command never crashes on a hostname hiccup.
+    """
+    # stx-allow: fallback (reason: hostname resolution must never crash the
+    # list command; degrade to the socket short-name, then the raw sentinel.)
+    try:
+        from ...config._host import resolve_hostname
+
+        return resolve_hostname()
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        import socket
+
+        return socket.gethostname().split(".")[0] or "local"
+
+
+def _host_display_for(host_raw: str | None, resolved: str) -> str:
+    """Map a row's raw ``host`` to its DISPLAY value.
+
+    The ``"local"`` / ``"localhost"`` / empty sentinels resolve to the
+    machine's canonical hostname (``resolved``); any concrete host label
+    passes through unchanged (forward-safe if a real host is ever set).
+    """
+    if host_raw in ("local", "localhost", "", None):
+        return resolved
+    return host_raw

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
@@ -15,6 +15,7 @@ import click
 from rich.table import Table
 
 from ..._state.registry import Registry
+from .._account_list_format import format_dt_display_tz
 from ._console import console
 
 __all__ = [
@@ -195,15 +196,26 @@ def print_agent_list(
     }
     for row in data:
         col = cmap.get(row["status"], "white")
-        host = row.get("host") or "local"
-        host_cell = host if host in ("local", "") else f"[cyan]{host}[/cyan]"
+        # Host column: show the RESOLVED machine hostname (e.g. ``ywata-note-win``)
+        # from ``host_display`` (set by get_agent_list_data), not the raw
+        # ``"local"`` sentinel. Fall back to the raw host, then the sentinel.
+        host = row.get("host_display") or row.get("host") or "local"
+        host_cell = f"[cyan]{host}[/cyan]"
         errors = row.get("validation_errors") or []
         yaml_cell = (
             f"[bold red]✗ {', '.join(_extract_damaged_fields(errors)) or 'errors'}[/bold red]"
             if errors
             else "[green]✓[/green]"
         )
-        started = row["started_at"] if row["started_at"] not in ("-", "?") else "—"
+        # Started column: render the registry's raw ISO-8601 UTC stamp as a
+        # pinned-tz ``YYYY-MM-DD HH:MM (JST)`` for readability (operator TG
+        # 2026-07-13); the ``--json`` path keeps the raw ISO. Sentinels
+        # ("-"/"?") stay an em-dash.
+        raw_started = row["started_at"]
+        if raw_started in ("-", "?"):
+            started = "—"
+        else:
+            started = format_dt_display_tz(raw_started)
         account_cell = row.get("account") or "—"
         # Drop the ``(email)`` parenthetical in the default (compact) view so
         # the row stays one line; --verbose keeps the full ``name (email)``.

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
@@ -131,8 +131,15 @@ def print_agent_list(
     """
     from ._agent_list import get_agent_list_data
 
+    # PERF: the default view discards non-running rows, so let the data layer
+    # skip their account/movement enrichment. `-v`/`--all` show every row, so
+    # they must stay fully enriched.
     data = get_agent_list_data(
-        registry, capability=capability, machine=machine, tags=tags
+        registry,
+        capability=capability,
+        machine=machine,
+        tags=tags,
+        running_only=not (verbose or show_all),
     )
     if not data:
         console.print("[dim]No agents found (registry empty, no specs on disk).[/dim]")

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_host_display.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_host_display.py
@@ -1,0 +1,350 @@
+"""Tests for the Host + Started DISPLAY columns of ``sac agents list``.
+
+Covers two operator display fixes (2026-07-13):
+
+* Host column — the literal ``"local"`` sentinel is resolved to the machine's
+  canonical hostname for DISPLAY (``host_display``), while the raw ``host``
+  field keeps ``"local"`` for backward-compat consumers (``_is_ghost_row``).
+* Started column — the raw ISO-8601 UTC stamp is rendered in the pinned
+  display timezone (``YYYY-MM-DD HH:MM (JST)``); the ``--json`` path keeps the
+  raw ISO untouched.
+
+No mocks: a hand-rolled ``_FakeRegistry`` (same shape as the real one), real
+``spec.yaml`` files under ``tmp_path`` exercised by the real
+``load_config`` / ``validate_config``, and save/restore swaps of real module
+attributes — mirroring the sibling ``test__agent_list`` conventions.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+from scitex_agent_container.cli_pkg._helpers._agent_list import (
+    get_agent_list_data,
+    print_agent_list,
+    print_agent_list_json,
+)
+from scitex_agent_container.cli_pkg._helpers._agent_list_host import (
+    _host_display_for,
+    _resolve_display_host,
+)
+
+_STARTED_ISO = "2026-07-12T21:36:30Z"
+
+
+# ---------------------------------------------------------------------------
+# Real-fake registry + save/restore swap seams (no mocks).
+# ---------------------------------------------------------------------------
+
+
+class _FakeRegistry:
+    """Hand-rolled stand-in for ``Registry`` — same shape as the real one."""
+
+    def __init__(self, entries: list[dict]) -> None:
+        self._entries = entries
+
+    def list_all(self) -> list[dict]:
+        return list(self._entries)
+
+
+@contextmanager
+def _swap_probe(impl: Callable[[Any], bool | None]) -> Iterator[None]:
+    """Swap ``_probe_local`` on BOTH the module + parent-package re-export."""
+    import scitex_agent_container.cli_pkg._helpers as _pkg
+
+    saved_al = _al._probe_local
+    saved_pkg = getattr(_pkg, "_probe_local", None)
+    _al._probe_local = impl  # type: ignore[assignment]
+    _pkg._probe_local = impl  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _al._probe_local = saved_al  # type: ignore[assignment]
+        if saved_pkg is None:
+            delattr(_pkg, "_probe_local")
+        else:
+            _pkg._probe_local = saved_pkg  # type: ignore[assignment]
+
+
+@contextmanager
+def _swap_discover(impl: Callable[[], list[tuple[str, Path]]]) -> Iterator[None]:
+    """Swap ``_al._discover_defined_agents`` for a real callable."""
+    saved = _al._discover_defined_agents
+    _al._discover_defined_agents = impl  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _al._discover_defined_agents = saved  # type: ignore[assignment]
+
+
+@contextmanager
+def _swap_display_host(value: str) -> Iterator[None]:
+    """Swap ``_al._resolve_display_host`` to a fixed hostname (real callable).
+
+    ``get_agent_list_data`` calls it as a bare module global, so rebinding
+    ``_al._resolve_display_host`` makes the resolved hostname deterministic
+    without touching the machine's real ``socket.gethostname()``.
+    """
+    saved = _al._resolve_display_host
+    _al._resolve_display_host = lambda: value  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _al._resolve_display_host = saved  # type: ignore[assignment]
+
+
+@contextmanager
+def _env_set(key: str, value: str) -> Iterator[None]:
+    """Set an env var for the block, restore prior value on exit."""
+    saved = os.environ.get(key)
+    os.environ[key] = value
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+
+
+def _no_discover() -> list[tuple[str, Path]]:
+    return []
+
+
+def _write_valid_spec(dir_: Path) -> Path:
+    """Write a minimal real v3 spec.yaml the real loader/validator accept."""
+    dir_.mkdir(parents=True, exist_ok=True)
+    spec = dir_ / "spec.yaml"
+    spec.write_text(
+        "\n".join(
+            [
+                "apiVersion: scitex-agent-container/v3",
+                "kind: Agent",
+                "metadata: {}",
+                "spec:",
+                "  runtime: apptainer",
+                "  host: ${HOSTNAME}",
+                "  workdir: /home/agent/work",
+                "  apptainer:",
+                "    image: /x.sif",
+                "    binds: []",
+                "  claude:",
+                "    model: sonnet",
+                "  health:",
+                "    enabled: true",
+                "    interval: 60",
+                "  restart:",
+                "    policy: on-failure",
+                "    max_retries: 3",
+            ]
+        )
+        + "\n"
+    )
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# _host_display_for — pure sentinel → hostname mapping.
+# ---------------------------------------------------------------------------
+
+
+def test_host_display_for_local_resolves_to_hostname():
+    # Arrange
+    resolved = "ywata-note-win"
+    # Act
+    out = _host_display_for("local", resolved)
+    # Assert
+    assert out == "ywata-note-win"
+
+
+def test_host_display_for_localhost_resolves_to_hostname():
+    # Arrange
+    resolved = "ywata-note-win"
+    # Act
+    out = _host_display_for("localhost", resolved)
+    # Assert
+    assert out == "ywata-note-win"
+
+
+def test_host_display_for_empty_resolves_to_hostname():
+    # Arrange
+    resolved = "ywata-note-win"
+    # Act
+    out = _host_display_for("", resolved)
+    # Assert
+    assert out == "ywata-note-win"
+
+
+def test_host_display_for_none_resolves_to_hostname():
+    # Arrange
+    resolved = "ywata-note-win"
+    # Act
+    out = _host_display_for(None, resolved)
+    # Assert
+    assert out == "ywata-note-win"
+
+
+def test_host_display_for_concrete_host_passes_through():
+    # Arrange — a real host label is forward-safe: it must NOT be overwritten.
+    resolved = "ywata-note-win"
+    # Act
+    out = _host_display_for("spartan-bm159", resolved)
+    # Assert
+    assert out == "spartan-bm159"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_display_host — tolerant, never raises, returns a real string.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_display_host_returns_nonempty_string():
+    # Arrange
+    # (no setup — reads the real machine identity via the tolerant resolver)
+    # Act
+    out = _resolve_display_host()
+    # Assert
+    assert isinstance(out, str) and out
+
+
+# ---------------------------------------------------------------------------
+# get_agent_list_data — host_display added, raw host kept.
+# ---------------------------------------------------------------------------
+
+
+def test_registered_row_carries_resolved_host_display(tmp_path):
+    # Arrange
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry([{"name": "x", "config": str(spec), "started_at": "ts"}])
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True), _swap_display_host(
+        "ywata-note-win"
+    ):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert out[0]["host_display"] == "ywata-note-win"
+
+
+def test_registered_row_keeps_raw_host_local_for_backward_compat(tmp_path):
+    # Arrange — the raw ``host`` sentinel must stay "local" so _is_ghost_row and
+    # any script keying on it keep working.
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry([{"name": "x", "config": str(spec), "started_at": "ts"}])
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True), _swap_display_host(
+        "ywata-note-win"
+    ):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert out[0]["host"] == "local"
+
+
+def test_defined_row_carries_resolved_host_display(tmp_path):
+    # Arrange — an on-disk (defined, not registered) agent.
+    spec = _write_valid_spec(tmp_path / "ondisk")
+    registry = _FakeRegistry([])
+
+    def _discover() -> list[tuple[str, Path]]:
+        return [("ondisk", spec)]
+
+    # Act
+    with _swap_discover(_discover), _swap_display_host("ywata-note-win"):
+        out = get_agent_list_data(registry)
+    # Assert
+    row = next(r for r in out if r["name"] == "ondisk")
+    assert row["host_display"] == "ywata-note-win"
+
+
+def test_defined_row_keeps_raw_host_local(tmp_path):
+    # Arrange
+    spec = _write_valid_spec(tmp_path / "ondisk")
+    registry = _FakeRegistry([])
+
+    def _discover() -> list[tuple[str, Path]]:
+        return [("ondisk", spec)]
+
+    # Act
+    with _swap_discover(_discover), _swap_display_host("ywata-note-win"):
+        out = get_agent_list_data(registry)
+    # Assert
+    row = next(r for r in out if r["name"] == "ondisk")
+    assert row["host"] == "local"
+
+
+def test_json_row_exposes_both_host_and_host_display(tmp_path, capsys):
+    # Arrange — --json consumers get the raw sentinel AND the resolved name.
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True), _swap_display_host(
+        "ywata-note-win"
+    ):
+        print_agent_list_json(registry)
+    # Assert
+    data = json.loads(capsys.readouterr().out)
+    assert data[0]["host"] == "local" and data[0]["host_display"] == "ywata-note-win"
+
+
+# ---------------------------------------------------------------------------
+# started_at raw ISO is preserved in the data / --json path.
+# ---------------------------------------------------------------------------
+
+
+def test_json_started_at_keeps_raw_iso(tmp_path, capsys):
+    # Arrange — only the human table converts; --json keeps the raw ISO stamp.
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry(
+        [{"name": "x", "config": str(spec), "started_at": _STARTED_ISO}]
+    )
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True), _swap_display_host(
+        "ywata-note-win"
+    ):
+        print_agent_list_json(registry)
+    # Assert
+    data = json.loads(capsys.readouterr().out)
+    assert data[0]["started_at"] == _STARTED_ISO
+
+
+# ---------------------------------------------------------------------------
+# print_agent_list (human table) — Host + Started rendering.
+# ---------------------------------------------------------------------------
+
+
+def test_print_agent_list_renders_resolved_hostname_in_host_column(tmp_path, capsys):
+    # Arrange — a wide terminal so no column is squeezed out.
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry(
+        [{"name": "x", "config": str(spec), "started_at": _STARTED_ISO}]
+    )
+    # Act
+    with _env_set("COLUMNS", "240"), _swap_discover(_no_discover), _swap_probe(
+        lambda cfg: True
+    ), _swap_display_host("ywata-note-win"):
+        print_agent_list(registry)
+    # Assert — the resolved hostname shows, not the literal "local" sentinel.
+    out = capsys.readouterr().out
+    assert "ywata-note-win" in out
+
+
+def test_print_agent_list_started_column_renders_pinned_jst(tmp_path, capsys):
+    # Arrange — pin the display tz to Asia/Tokyo and give the table full width.
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry(
+        [{"name": "x", "config": str(spec), "started_at": _STARTED_ISO}]
+    )
+    # Act
+    with _env_set("SAC_DISPLAY_TZ", "Asia/Tokyo"), _env_set(
+        "COLUMNS", "240"
+    ), _swap_discover(_no_discover), _swap_probe(lambda cfg: True), _swap_display_host(
+        "ywata-note-win"
+    ):
+        print_agent_list(registry)
+    # Assert — 21:36 UTC renders as 06:36 JST the next day; raw ISO is gone.
+    out = capsys.readouterr().out
+    assert "2026-07-13 06:36 (JST)" in out and _STARTED_ISO not in out

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_perf.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_perf.py
@@ -1,0 +1,290 @@
+"""Perf-behaviour tests for `sac agents list` (`get_agent_list_data`).
+
+Three profiler-driven fixes, each asserted by real behaviour (no mocks — the
+seams are save/restore swaps of real module attributes with real callables):
+
+1. Ports come from ONE `port_allocator.list_claims()` call, not a per-agent
+   `get_port()`.
+2. `validate_config` is NOT re-called when `load_config` already succeeded
+   (a loaded config is valid by construction) — only when the load failed.
+3. `running_only=True` DEFERS account + movement enrichment for rows the
+   default view will hide (non-running), while keeping them for running rows;
+   `running_only=False` enriches every row (the `--json` / `-v` contract).
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+from scitex_agent_container.cli_pkg._helpers._agent_list import get_agent_list_data
+
+
+class _FakeRegistry:
+    def __init__(self, entries: list[dict]) -> None:
+        self._entries = entries
+
+    def list_all(self) -> list[dict]:
+        return list(self._entries)
+
+
+@contextmanager
+def _swap_probe(impl: Callable[[Any], bool | None]) -> Iterator[None]:
+    import scitex_agent_container.cli_pkg._helpers as _pkg
+
+    saved_al = _al._probe_local
+    saved_pkg = getattr(_pkg, "_probe_local", None)
+    _al._probe_local = impl  # type: ignore[assignment]
+    _pkg._probe_local = impl  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _al._probe_local = saved_al  # type: ignore[assignment]
+        if saved_pkg is None:
+            delattr(_pkg, "_probe_local")
+        else:
+            _pkg._probe_local = saved_pkg  # type: ignore[assignment]
+
+
+@contextmanager
+def _swap_attr(obj: object, name: str, impl: object) -> Iterator[None]:
+    saved = getattr(obj, name)
+    setattr(obj, name, impl)
+    try:
+        yield
+    finally:
+        setattr(obj, name, saved)
+
+
+def _no_discover() -> list[tuple[str, Path]]:
+    return []
+
+
+def _write_valid_spec(dir_: Path) -> Path:
+    dir_.mkdir(parents=True, exist_ok=True)
+    spec = dir_ / "spec.yaml"
+    spec.write_text(
+        "\n".join(
+            [
+                "apiVersion: scitex-agent-container/v3",
+                "kind: Agent",
+                "metadata: {}",
+                "spec:",
+                "  runtime: apptainer",
+                "  host: ${HOSTNAME}",
+                "  workdir: /home/agent/work",
+                "  apptainer:",
+                "    image: /x.sif",
+                "    binds: []",
+                "  claude:",
+                "    model: sonnet",
+                "  health:",
+                "    enabled: true",
+                "    interval: 60",
+                "  restart:",
+                "    policy: on-failure",
+                "    max_retries: 3",
+            ]
+        )
+        + "\n"
+    )
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# FIX 1 — one list_claims() call, not per-agent get_port().
+# ---------------------------------------------------------------------------
+
+
+def test_ports_come_from_a_single_list_claims_call(tmp_path):
+    # Arrange — two registered agents; count list_claims + get_port calls.
+    from scitex_agent_container._state import port_allocator
+
+    calls = {"list_claims": 0, "get_port": 0}
+
+    def _fake_list_claims(**_kw):
+        calls["list_claims"] += 1
+        return [{"name": "a", "port": 19001, "claimed_at": "t"}]
+
+    def _fake_get_port(_name, **_kw):
+        calls["get_port"] += 1
+        return 42
+
+    spec_a = _write_valid_spec(tmp_path / "a")
+    spec_b = _write_valid_spec(tmp_path / "b")
+    registry = _FakeRegistry(
+        [{"name": "a", "config": str(spec_a)}, {"name": "b", "config": str(spec_b)}]
+    )
+    # Act
+    with _swap_attr(port_allocator, "list_claims", _fake_list_claims), _swap_attr(
+        port_allocator, "get_port", _fake_get_port
+    ), _swap_probe(lambda cfg: True):
+        with _swap_attr(_al, "_discover_defined_agents", _no_discover):
+            out = get_agent_list_data(registry)
+    # Assert — exactly one bulk query for two agents; no per-agent get_port.
+    assert calls == {"list_claims": 1, "get_port": 0}
+
+
+def test_port_from_claims_map_lands_on_the_row(tmp_path):
+    # Arrange
+    from scitex_agent_container._state import port_allocator
+
+    def _fake_list_claims(**_kw):
+        return [{"name": "a", "port": 19001, "claimed_at": "t"}]
+
+    spec_a = _write_valid_spec(tmp_path / "a")
+    registry = _FakeRegistry([{"name": "a", "config": str(spec_a)}])
+    # Act
+    with _swap_attr(port_allocator, "list_claims", _fake_list_claims), _swap_probe(
+        lambda cfg: True
+    ), _swap_attr(_al, "_discover_defined_agents", _no_discover):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert out[0]["a2a_port"] == 19001
+
+
+def test_port_none_when_agent_has_no_claim(tmp_path):
+    # Arrange — claims map has no entry for this agent.
+    from scitex_agent_container._state import port_allocator
+
+    spec_a = _write_valid_spec(tmp_path / "a")
+    registry = _FakeRegistry([{"name": "a", "config": str(spec_a)}])
+    # Act
+    with _swap_attr(port_allocator, "list_claims", lambda **_k: []), _swap_probe(
+        lambda cfg: True
+    ), _swap_attr(_al, "_discover_defined_agents", _no_discover):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert out[0]["a2a_port"] is None
+
+
+# ---------------------------------------------------------------------------
+# FIX 2 — no redundant re-validate when load_config already succeeded.
+# ---------------------------------------------------------------------------
+
+
+def test_validate_config_skipped_when_load_succeeds(tmp_path):
+    # Arrange — count explicit validate_config calls from the list builder.
+    from scitex_agent_container.config import _validation
+
+    calls = {"n": 0}
+
+    def _counting_validate(path):
+        calls["n"] += 1
+        return []
+
+    spec = _write_valid_spec(tmp_path / "a")
+    registry = _FakeRegistry([{"name": "a", "config": str(spec)}])
+    # Act
+    with _swap_attr(_validation, "validate_config", _counting_validate), _swap_probe(
+        lambda cfg: True
+    ), _swap_attr(_al, "_discover_defined_agents", _no_discover):
+        out = get_agent_list_data(registry)
+    # Assert — a valid, loaded config is not re-parsed/re-validated.
+    assert calls["n"] == 0 and out[0]["status"] == "running"
+
+
+def test_validate_config_called_when_load_fails(tmp_path):
+    # Arrange — a missing config path: load_config raises, so the error list
+    # must be recovered via validate_config.
+    from scitex_agent_container.config import _validation
+
+    calls = {"n": 0}
+
+    def _counting_validate(path):
+        calls["n"] += 1
+        return ["stub-error"]
+
+    missing = tmp_path / "gone" / "spec.yaml"
+    registry = _FakeRegistry([{"name": "a", "config": str(missing)}])
+    # Act
+    with _swap_attr(_validation, "validate_config", _counting_validate), _swap_attr(
+        _al, "_discover_defined_agents", _no_discover
+    ):
+        out = get_agent_list_data(registry)
+    # Assert — load failed → validate_config consulted exactly once.
+    assert calls["n"] == 1 and out[0]["validation_errors"] == ["stub-error"]
+
+
+# ---------------------------------------------------------------------------
+# FIX 3 — running_only defers account + movement for hidden (non-running) rows.
+# ---------------------------------------------------------------------------
+
+
+def test_running_only_enriches_the_running_row(tmp_path):
+    # Arrange
+    spec = _write_valid_spec(tmp_path / "a")
+    registry = _FakeRegistry([{"name": "a", "config": str(spec)}])
+    # Act
+    with _swap_probe(lambda cfg: True), _swap_attr(
+        _al, "_safe_account_for", lambda cfg: "ACCT"
+    ), _swap_attr(_al, "_runtime_account_for", lambda name: None), _swap_attr(
+        _al, "_discover_defined_agents", _no_discover
+    ):
+        out = get_agent_list_data(registry, running_only=True)
+    # Assert — a shown (running) row keeps its account.
+    assert out[0]["account"] == "ACCT"
+
+
+def test_running_only_defers_account_for_stopped_row(tmp_path):
+    # Arrange
+    spec = _write_valid_spec(tmp_path / "a")
+    registry = _FakeRegistry([{"name": "a", "config": str(spec)}])
+    # Act
+    with _swap_probe(lambda cfg: False), _swap_attr(
+        _al, "_safe_account_for", lambda cfg: "ACCT"
+    ), _swap_attr(_al, "_discover_defined_agents", _no_discover):
+        out = get_agent_list_data(registry, running_only=True)
+    # Assert — a hidden (stopped) row skips account resolution.
+    assert out[0]["account"] == ""
+
+
+def test_running_only_false_still_enriches_stopped_row(tmp_path):
+    # Arrange — the --json / -v contract: every row stays enriched.
+    spec = _write_valid_spec(tmp_path / "a")
+    registry = _FakeRegistry([{"name": "a", "config": str(spec)}])
+    # Act
+    with _swap_probe(lambda cfg: False), _swap_attr(
+        _al, "_safe_account_for", lambda cfg: "ACCT"
+    ), _swap_attr(_al, "_discover_defined_agents", _no_discover):
+        out = get_agent_list_data(registry, running_only=False)
+    # Assert
+    assert out[0]["account"] == "ACCT"
+
+
+def test_deferred_row_keeps_the_movement_key_contract(tmp_path):
+    # Arrange — deferred rows must still carry the always-present movement trio.
+    spec = _write_valid_spec(tmp_path / "a")
+    registry = _FakeRegistry([{"name": "a", "config": str(spec)}])
+    # Act
+    with _swap_probe(lambda cfg: False), _swap_attr(
+        _al, "_safe_account_for", lambda cfg: "ACCT"
+    ), _swap_attr(_al, "_discover_defined_agents", _no_discover):
+        out = get_agent_list_data(registry, running_only=True)
+    # Assert
+    row = out[0]
+    assert (
+        row["session_jsonl_bytes"] == 0
+        and row["session_jsonl_last_write"] == ""
+        and row["heartbeat_at"] == ""
+    )
+
+
+def test_running_only_defers_defined_agent_account(tmp_path):
+    # Arrange — a defined-on-disk agent is never running → hidden by default.
+    spec = _write_valid_spec(tmp_path / "ondisk")
+
+    def _discover() -> list[tuple[str, Path]]:
+        return [("ondisk", spec)]
+
+    registry = _FakeRegistry([])
+    # Act
+    with _swap_attr(_al, "_safe_account_for", lambda cfg: "ACCT"), _swap_attr(
+        _al, "_discover_defined_agents", _discover
+    ):
+        out = get_agent_list_data(registry, running_only=True)
+    # Assert
+    row = next(r for r in out if r["name"] == "ondisk")
+    assert row["account"] == "" and row["status"] == "defined"

--- a/tests/scitex_agent_container/cli_pkg/test__account_list_format_display_tz.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_list_format_display_tz.py
@@ -1,0 +1,129 @@
+"""Tests for ``format_dt_display_tz`` — the ``sac agents list`` Started column
+pinned-timezone formatter.
+
+No mocks: the function is pure and takes an injected ``env`` dict, so every
+case is exercised with real ISO input + a real env mapping and asserted on
+the real ``zoneinfo`` conversion. The test environment resolves ``Asia/Tokyo``
+/ ``America/New_York`` (the sibling ``test__account_list_render`` suite already
+asserts JST/EST conversions), so the pinned-JST default is deterministic here.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.cli_pkg._account_list_format import format_dt_display_tz
+
+# A fixed UTC instant used across cases: 2026-07-12 21:36:30 UTC.
+_UTC_ISO = "2026-07-12T21:36:30Z"
+
+
+def test_defaults_to_pinned_jst_when_no_env_override():
+    # Arrange — empty env: no SAC_DISPLAY_TZ → the Asia/Tokyo default applies,
+    # independent of the process's own TZ (the WSL host may be UTC).
+    src = {}
+    # Act
+    out = format_dt_display_tz(_UTC_ISO, env=src)
+    # Assert — 21:36 UTC = 06:36 JST the next calendar day.
+    assert out == "2026-07-13 06:36 (JST)"
+
+
+def test_uses_space_separator_not_iso_t():
+    # Arrange
+    src = {}
+    # Act
+    out = format_dt_display_tz(_UTC_ISO, env=src)
+    # Assert — the date-time portion (before the tz paren) uses a space, not
+    # the ISO "T" separator. (The "T" in "(JST)" is not the separator.)
+    dt_part = out.rsplit(" (", 1)[0]
+    assert " " in dt_part and "T" not in dt_part
+
+
+def test_drops_seconds_minute_precision():
+    # Arrange
+    src = {}
+    # Act
+    out = format_dt_display_tz(_UTC_ISO, env=src)
+    # Assert — the source seconds (:30) must not appear; only HH:MM colon.
+    assert ":30" not in out and out.count(":") == 1
+
+
+def test_timezone_abbrev_in_parentheses():
+    # Arrange
+    src = {}
+    # Act
+    out = format_dt_display_tz(_UTC_ISO, env=src)
+    # Assert — the derived abbreviation is shown in parens (JST), not a bare Z.
+    assert out.endswith("(JST)") and "Z" not in out
+
+
+def test_env_override_changes_zone_to_utc():
+    # Arrange — SAC_DISPLAY_TZ pins UTC.
+    src = {"SAC_DISPLAY_TZ": "UTC"}
+    # Act
+    out = format_dt_display_tz(_UTC_ISO, env=src)
+    # Assert — no conversion; UTC label derived from the tz object.
+    assert out == "2026-07-12 21:36 (UTC)"
+
+
+def test_env_override_abbrev_is_derived_not_hardcoded():
+    # Arrange — a non-JST zone must yield ITS abbreviation, proving "(JST)"
+    # is derived from the tz object, never a hardcoded label.
+    src = {"SAC_DISPLAY_TZ": "America/New_York"}
+    # Act
+    out = format_dt_display_tz(_UTC_ISO, env=src)
+    # Assert — 21:36 UTC on 2026-07-12 is 17:36 EDT (summer, DST).
+    assert out == "2026-07-12 17:36 (EDT)" and "JST" not in out
+
+
+def test_blank_env_override_falls_back_to_default_jst():
+    # Arrange — an empty SAC_DISPLAY_TZ must not blank the zone.
+    src = {"SAC_DISPLAY_TZ": "   "}
+    # Act
+    out = format_dt_display_tz(_UTC_ISO, env=src)
+    # Assert — the default Asia/Tokyo still applies.
+    assert out.endswith("(JST)")
+
+
+def test_naive_timestamp_is_assumed_utc():
+    # Arrange — a naive (no-tz) stamp is treated as UTC (matches what the
+    # registry / JSON path writes with the trailing Z).
+    naive = "2026-07-12T21:36:30"
+    # Act
+    out = format_dt_display_tz(naive, env={})
+    # Assert — same JST result as the Z-suffixed form.
+    assert out == "2026-07-13 06:36 (JST)"
+
+
+def test_none_input_returns_dash():
+    # Arrange
+    value = None
+    # Act
+    out = format_dt_display_tz(value, env={})
+    # Assert
+    assert out == "-"
+
+
+def test_empty_string_returns_dash():
+    # Arrange
+    value = ""
+    # Act
+    out = format_dt_display_tz(value, env={})
+    # Assert
+    assert out == "-"
+
+
+def test_sentinel_dash_returns_dash():
+    # Arrange — the registry's "not started" sentinel must not crash / mis-parse.
+    value = "-"
+    # Act
+    out = format_dt_display_tz(value, env={})
+    # Assert
+    assert out == "-"
+
+
+def test_unparseable_input_returns_dash():
+    # Arrange — a garbage stamp must degrade to the dash, never raise.
+    value = "not-a-timestamp"
+    # Act
+    out = format_dt_display_tz(value, env={})
+    # Assert
+    assert out == "-"


### PR DESCRIPTION
## Summary

Operator-requested UX + performance work on the `sac agents list` fleet view.
The command is `status_cmds.status` (bound as both `list` and `status` in
`agent_group.py`); the fleet table is assembled by `get_agent_list_data`
(`_helpers/_agent_list.py`) and rendered by `print_agent_list`
(`_helpers/_agent_list_render.py`). Two commits: the display fixes, then the
perf fixes + a small refactor.

## Display fixes

### `Started` column: local-tz, human-readable
- **Before:** raw ISO-8601 UTC, e.g. `2026-07-12T21:36:30Z`.
- **After (human table):** `YYYY-MM-DD HH:MM (JST)`, e.g. `2026-07-13 06:36 (JST)`.
- Zone is **pinned to `Asia/Tokyo`** via new `SAC_DISPLAY_TZ` env override
  (default `Asia/Tokyo`), not the host's system-local tz (the WSL host may
  report UTC). The `JST` abbreviation is derived from the tz object, never
  hardcoded. **`--json` keeps the raw ISO `...Z`** untouched.
- New pure formatter `format_dt_display_tz` in `_account_list_format.py` reuses
  that module's existing `_coerce_dt` + `_resolve_tz` (stdlib `zoneinfo`) SSOT.

### `Host` column: real hostname, not `local`
- **Before:** literal `local` for every agent. **After:** resolved hostname
  (e.g. `ywata-note-win`), via `config._host.resolve_hostname` — the same
  resolver the banned `host: local` -> `${HOSTNAME}` input-side change uses.
- The raw `host` field stays `local` for backward-compat consumers
  (`_is_ghost_row` keys on it); a new `host_display` field carries the resolved
  value. `--json` now exposes **both**.

## Performance fixes (profiler-driven; no async, no new datastore)

1. **Ports in ONE query.** Per-agent `_safe_port_for` -> `_all_port_claims()`
   once via `port_allocator.list_claims()`. Each old `get_port()` re-opened +
   init-schema'd state.db ~3x (~62ms/agent).
2. **No double YAML parse.** `load_config` already validates + RAISES, so a
   loaded config is valid by construction; the separate `validate_config`
   (~88ms/row, a second open+parse) now runs **only when the load failed**.
3. **Defer enrichment past the running-filter.** New `running_only` param: the
   default view discards non-running rows, so it skips their account +
   movement enrichment (status still computed → footer counts stay correct).
   `--json` / `-v` pass `running_only=False` → every row fully enriched
   (contract unchanged). *Honest note:* `load_config` + the liveness probe
   can't be deferred (they decide running-vs-hidden), so the realised win is
   the account+movement deferral, not the full per-row cost.

Refactor: `_agent_list.py` was at the 512-line cap, so the defined-on-disk
discovery moved to a new `_agent_list_discover.py` sibling (re-imported; call
site + test seams unchanged).

## `login-req` (auth-dead) status — deferred (cost-fork)
Not in this PR. The core `running`-vs-`login-req` ask hits a design fork:
**no cheap persisted auth verdict exists.** The TUI auth watchdog
(`~/.scitex/agent-container/bin/auth-heal.py` + `tui_auth_detect.py`, dotfiles)
is a **cron that detects and RESTARTS** — it persists no queryable per-agent
verdict. The in-repo package matcher (`_runners/_tmux/auth_status.py`, via
`sac agents auth-status`) is **on-demand only** and needs a **double tmux pane
capture (~4s apart)**. Skill `42_tui-auth-watchdog.md`: *"They are not wired
together yet."* No `login_required`/auth field exists in the state DB. Surfacing
it default-visible needs a persistence + cadence decision — reported separately,
not guessed. `agents list` stays fast.

## Tests (no mocks; real registry / spec.yaml / zoneinfo / port_allocator)
- `test__account_list_format_display_tz.py` (12): pinned-JST default,
  `SAC_DISPLAY_TZ` override + derived abbrev, minute precision, naive=UTC,
  sentinels/unparseable → `-`.
- `test__agent_list_host_display.py` (16): `host_display` added + raw `host`
  kept (registered/defined/`--json`), Started renders JST, raw ISO in `--json`.
- `test__agent_list_perf.py` (10): ports from ONE `list_claims()`;
  `validate_config` skipped on load-success / called on load-failure;
  `running_only` defers account+movement for stopped+defined rows, keeps them
  for running rows and for `running_only=False`.
- Regression green (235 total): `test__agent_list.py`,
  `test__account_list_render.py`, `test_status_cmds.py`, `test_port_allocator.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
