### PR TITLE
feat(accounts): readable JST Since, relative reset hints, fix fleet 7d-capacity semantics

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
@@ -13,11 +13,11 @@ percentages; the table holds only what the bars cannot express"):
 2. The Stored-accounts table — exactly ``Account | Status | Last
    Update`` (:func:`._account_list_render.render_stored_table`).
 3. The usage-bars block — per-account 5h/7d bars, each percentage
-   carrying its compact reset hint (``29% (→09:19)`` /
-   ``66% (→Sun 21h)``), plus the rolling-window legend when a row has
+   carrying its compact relative reset hint (``29% (in 4h05m)`` /
+   ``66% (in 2d 3h)``), plus the rolling-window legend when a row has
    no cached reset timestamps
    (:mod:`._account_usage_bars` / :func:`._account_list_render.rolling_legend_line`).
-4. The one-line fleet effective-utilization figure.
+4. The one-line fleet 7-day capacity-used figure.
 
 The JSON path (``sac accounts list --json``) is schema-stable and keeps
 ``email_address`` / ``plan_label`` / the raw usage payload for machine
@@ -58,20 +58,21 @@ def account_list(as_json: bool, refresh: bool) -> None:
     exactly Account | Status | Last Update — the status cell carries
     the live token TTL (``VALID +2h26m``) — while the monospace
     usage-bars block below it owns the 5h/7d percentages, each with
-    its compact per-window reset hint (``29% (→09:19)`` /
-    ``66% (→Sun 21h)``), followed by a single fleet
-    effective-utilization line.
+    its compact relative reset hint (``29% (in 4h05m)`` /
+    ``66% (in 2d 3h)``), followed by a single fleet 7-day
+    capacity-used line.
 
     \b
-    Fleet effective utilization
-      A reset-horizon-weighted fleet figure. Per account, over a 7-day
-      planning window W: frac_before_reset = clamp(reset_horizon, 0, W)/W
-      and effective% = frac_before_reset * used_pct_7d. So an account at
-      100% that resets in 1 day (eff ~14%) contributes far more usable
-      weekly capacity than one at 100% resetting in 6 days (eff ~86%).
-      The reset horizon is the true 7d-window reset (reset_at_7d); when
-      absent it defaults to the full window (eff = used_pct_7d). The
-      fleet figure is the mean over accounts with cached usage.
+    Fleet 7d capacity used
+      How much of the fleet's weekly capacity was actually consumed over
+      the trailing 7 days — a capacity-planning signal: ~100% ⇒ the
+      fleet is saturated (add an account); low ⇒ over-provisioned (drop
+      one). It is the arithmetic mean of the accounts' 7d-window
+      utilisation (the same used_pct_7d the 7d bars show), over the
+      accounts with cached usage. The API exposes utilisation
+      percentages (not absolute quotas), so the mean of the percentages
+      is the aggregate; when quotas match it equals total-used /
+      total-available.
 
     \b
     Example:
@@ -90,7 +91,10 @@ def account_list(as_json: bool, refresh: bool) -> None:
         render_stored_table,
         rolling_legend_line,
     )
-    from ._account_usage_bars import fleet_effective_line, render_usage_bars_block
+    from ._account_usage_bars import (
+        fleet_capacity_used_line,
+        render_usage_bars_block,
+    )
     from ._helpers import console
     from .status_cmds import _format_claude_account_block
 
@@ -149,7 +153,7 @@ def account_list(as_json: bool, refresh: bool) -> None:
     # guessing.
     if needs_rolling_legend(rows):
         click.echo(rolling_legend_line())
-    click.echo(fleet_effective_line(rows))
+    click.echo(fleet_capacity_used_line(rows))
 
 
 def register_list_command(group: click.Group) -> None:

--- a/src/scitex_agent_container/cli_pkg/_account_list_format.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_format.py
@@ -20,13 +20,13 @@ Concerns covered:
 3. :func:`format_as_of_short` — render an As-of (Last-Update)
    timestamp as ``Sun 21h``.
 
-4. :func:`format_reset_hhmm` / :func:`format_reset_day_hour` —
-   render the per-window reset timestamp the Anthropic OAuth usage
-   API returns (``resets_at`` → ``reset_at_5h`` / ``reset_at_7d``).
-   Consumed by the usage-bars block (operator directive 2026-07-11:
-   the bars own the percentages AND their reset hints; the table
-   holds only what the bars cannot express) to surface ``(→21:05)``
-   and ``(→Sun 17h)`` next to each bar's percentage.
+The per-window reset hints on the usage-bars block used to live here
+(``format_reset_hhmm`` / ``format_reset_day_hour``, absolute
+``→HH:MM`` / ``→Day HHh``). The operator (2026-07-13) switched them to
+the time REMAINING until reset (``in 4h05m`` / ``in 2d 3h``), rendered
+by the shared :func:`~._timefmt.format_relative_until` — see
+:mod:`._timefmt`, the SSOT for the JST wall clock and relative-duration
+formatting that ``sac accounts list`` (and ``sac agents list``) share.
 """
 
 from __future__ import annotations
@@ -217,69 +217,9 @@ def format_as_of_short(
     return local.strftime("%a %Hh")
 
 
-# ---------------------------------------------------------------------------
-# Reset-time hints for the usage-bars lines (operator directives 2026-06-09
-# gripe #2 and 2026-07-11 dedupe: hints live next to the bars' percentages)
-# ---------------------------------------------------------------------------
-
-
-def format_reset_hhmm(
-    reset_iso: str | datetime | None,
-    *,
-    env: dict[str, str] | None = None,
-) -> str:
-    """Render a 5h-window reset timestamp as ``→HH:MM`` (local-tz).
-
-    Operator gripe #2 (2026-06-09): ``5h%`` never said WHEN the
-    rolling window resets. Since the 2026-07-11 dedupe directive the
-    hint renders next to the 5h usage BAR (the table no longer
-    carries percentages at all) and must stay COMPACT — the operator's
-    verbatim example is ``29% (→09:19)``, so the old per-cell
-    ``(in Xh Ym)`` countdown qualifier was dropped together with the
-    table cells it annotated.
-
-    Returns ``""`` when the timestamp is missing/unparseable so the
-    caller can fall back to the bare percentage rather than
-    fabricate a value. Never raises.
-    """
-    dt = _coerce_dt(reset_iso)
-    if dt is None:
-        return ""
-    tz = local_timezone(env)
-    local = dt.astimezone(tz) if tz is not None else dt.astimezone()
-    return f"→{local.strftime('%H:%M')}"
-
-
-def format_reset_day_hour(
-    reset_iso: str | datetime | None,
-    *,
-    env: dict[str, str] | None = None,
-) -> str:
-    """Render a 7d-window reset timestamp as ``→Day HHh`` (local-tz).
-
-    Operator gripe #2 (2026-06-09): ``7d%`` never said WHEN the
-    rolling 7-day window resets. Since the 2026-07-11 dedupe
-    directive the hint renders next to the 7d usage BAR and must
-    stay COMPACT — the operator's verbatim example is
-    ``66% (→Sun 21h)``, so the old ``(in Xd Yh Zm)`` countdown
-    qualifier was dropped together with the table cells it
-    annotated.
-
-    Returns ``""`` on missing/unparseable input — never fabricates.
-    """
-    dt = _coerce_dt(reset_iso)
-    if dt is None:
-        return ""
-    tz = local_timezone(env)
-    local = dt.astimezone(tz) if tz is not None else dt.astimezone()
-    return f"→{local.strftime('%a %Hh')}"
-
-
 __all__ = [
     "format_as_of_short",
     "format_dt_local",
-    "format_reset_day_hour",
-    "format_reset_hhmm",
     "format_snapshot_age",
     "format_ttl_live",
     "local_timezone",

--- a/src/scitex_agent_container/cli_pkg/_account_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_render.py
@@ -14,10 +14,12 @@ This module now holds the THREE pieces that need on-disk state:
    feeds into the renderer or the JSON path.
 
 Pure formatting helpers (``local_timezone``, ``format_dt_local``,
-``format_ttl_live``, ``format_snapshot_age``, ``format_as_of_short``,
-``format_reset_hhmm``, ``format_reset_day_hour``) are re-exported from
-:mod:`._account_list_format` so existing callers (and the historical
-test surface) keep importing them from this module without churn.
+``format_ttl_live``, ``format_snapshot_age``, ``format_as_of_short``)
+are re-exported from :mod:`._account_list_format` so existing callers
+(and the historical test surface) keep importing them from this module
+without churn. The per-window reset hints on the usage-bars block are
+now the shared :func:`~._timefmt.format_relative_until` (relative
+time-until-reset).
 
 Layout note (operator directive 2026-07-11): the Stored-accounts table
 and the usage-bars block below it used to DUPLICATE the 5h%/7d%
@@ -26,9 +28,10 @@ holds only what the bars cannot express" — so the table is exactly
 ``Account | Status | Last Update`` (the ID column was renamed
 ``Account``; the Email column was dropped because IDs are
 email-derived slugs, and the Plan column was dropped outright), while
-the per-window reset hints (``→HH:MM`` / ``→Day HHh``, 2026-06-09
-gripe #2) moved from the removed 5h%/7d% cells onto the usage-bars
-lines (see :mod:`._account_usage_bars`). The JSON output path
+the per-window reset hints (relative ``in Xh Ym`` / ``in Xd Yh``,
+2026-06-09 gripe #2 + 2026-07-13 relative switch) moved from the
+removed 5h%/7d% cells onto the usage-bars lines (see
+:mod:`._account_usage_bars`). The JSON output path
 (``sac accounts list --json``) is NOT touched — its schema (including
 ``email_address`` and ``plan_label``) stays the machine-readable
 contract downstream consumers parse.
@@ -46,8 +49,6 @@ from rich.table import Table
 from ._account_list_format import (
     format_as_of_short,
     format_dt_local,
-    format_reset_day_hour,
-    format_reset_hhmm,
     format_snapshot_age,
     format_ttl_live,
     local_timezone,
@@ -178,11 +179,11 @@ def rolling_legend_line() -> str:
     Per the 2026-06-09 task contract: "リセットのアンカーが取れない
     場合は列凡例/ヘッダで5h=直近5時間ローリング, 7d=直近7日ローリン
     グと明示". Printed below the usage-bars block (which owns the
-    percentages and their ``(→...)`` reset hints since 2026-07-11).
+    percentages and their ``(in ...)`` reset hints since 2026-07-11).
     """
     return (
         "Legend: 5h = rolling 5-hour window; 7d = rolling 7-day window. "
-        "(→HH:MM / →Day HHh next to the % marks the next reset.)"
+        "(in Xh Ym / in Xd Yh next to the % is the time until the next reset.)"
     )
 
 
@@ -335,8 +336,6 @@ __all__ = [
     "build_stored_rows",
     "format_as_of_short",
     "format_dt_local",
-    "format_reset_day_hour",
-    "format_reset_hhmm",
     "format_snapshot_age",
     "format_ttl_live",
     "local_timezone",

--- a/src/scitex_agent_container/cli_pkg/_account_usage_bars.py
+++ b/src/scitex_agent_container/cli_pkg/_account_usage_bars.py
@@ -1,4 +1,4 @@
-"""ASCII usage bars + fleet "effective utilization" for ``sac accounts list``.
+"""ASCII usage bars + fleet 7-day capacity figure for ``sac accounts list``.
 
 Operator gripe (2026-07-09): "テーブルが見にくい" — the stored-accounts
 rich table packs the 5h%/7d% numbers into terse cells that are hard to
@@ -11,72 +11,63 @@ BELOW the existing table:
    visible at a glance and the bars line up vertically across accounts.
    Since the 2026-07-11 dedupe directive ("the bars own the
    percentages; the table holds only what the bars cannot express")
-   each percentage also carries the compact per-window reset hint
-   (``→HH:MM`` for 5h, ``→Day HHh`` for 7d — 2026-06-09 gripe #2)
-   that used to clutter the Stored-accounts table cells::
+   each percentage also carries a compact per-window reset hint. The
+   operator (2026-07-13) wants that hint to read as the time REMAINING
+   until the window resets — relative, not an absolute wall-clock —
+   ``(in 4h05m)`` for the 5h window, ``(in 2d 3h)`` for the 7d window::
 
-       wyusuuke-gmail-com   5h [██████░░░░░░░░░░░░░░]  29% (→09:19)   7d [█████████████░░░░░░░]  66% (→Sun 21h)
-       ywatanabe-scitex-ai  5h [███░░░░░░░░░░░░░░░░░]  14%            7d [███░░░░░░░░░░░░░░░░░]  15% (→Mon 09h)
+       wyusuuke-gmail-com   5h [██████░░░░░░░░░░░░░░]  29% (in 4h05m)   7d [█████████████░░░░░░░]  66% (in 2d 3h)
+       ywatanabe-scitex-ai  5h [███░░░░░░░░░░░░░░░░░]  14%              7d [███░░░░░░░░░░░░░░░░░]  15% (in 5d 0h)
 
    A bar for an account with no cached usage renders a same-width
    ``[      no data       ]`` placeholder rather than crashing; a
    window with no cached ``reset_at`` renders no hint (the missing
    5h hint is space-padded so the 7d bars stay vertically aligned).
+   The relative hints are rendered by the shared
+   :func:`~._timefmt.format_relative_until` (SSOT with the JST wall-clock
+   helper used by the ``Since`` line).
 
-2. A one-line **fleet effective-utilization** figure that factors each
-   account's 7-day-window reset horizon into a single fleet number:
+2. A one-line **fleet 7-day capacity-used** figure — how much of the
+   fleet's weekly capacity was actually consumed over the trailing 7
+   days, a capacity-planning signal (≈100 % ⇒ saturated ⇒ add an
+   account; low ⇒ over-provisioned ⇒ drop one)::
 
-       Fleet effective utilization: 71% (3 accounts)
+       Fleet 7d capacity used: 64% (3 accounts)
 
-Effective-utilization formula
------------------------------
-For each account, over a planning window ``W`` (default 168 h = 7 days,
-matching the 7-day rolling window):
+Fleet 7d capacity-used formula
+------------------------------
+The figure is the arithmetic **mean of the accounts' ``used_pct_7d``**
+(the same 7-day-window utilisation the 7d bars show), over the accounts
+that have a cached ``used_pct_7d``. Accounts with no usage data are
+excluded from both the mean and the ``(N accounts)`` count; the figure
+is ``None`` (CLI prints ``unavailable``) when no account has data.
 
-    frac_before_reset = clamp(reset_horizon_hours, 0, W) / W
-    effective_util%   = frac_before_reset * used_pct_7d
+Why the mean of the percentages (and not total-used / total-available)?
+The Anthropic OAuth usage API returns a *percentage-utilisation* model
+(``used_pct_7d`` ∈ [0, 100]) with NO absolute token quota — the raw
+``limit_tokens_7d`` is ``None``. So total-used / total-available is not
+computable from the available data, and the mean of the per-account
+percentages is the only well-defined aggregate. When the accounts share
+the same weekly quota (same plan tier) it equals total-used /
+total-available exactly; if quotas differ it is a per-account-weighted
+average, which still tracks the operator's add-/drop-an-account intent.
 
-Rationale: an account currently at ``used_pct_7d`` frees its whole
-weekly allowance again once its 7-day window rolls over. So only the
-portion of the planning window BEFORE that reset is "occupied" at the
-current utilisation; after the reset the account is back near 0 % for
-the rest of the window. An account at 100 % that resets in 1 day
-(``frac ≈ 0.14`` → ``eff ≈ 14 %``) therefore contributes far more usable
-weekly capacity than one at 100 % that resets in 6 days
-(``frac ≈ 0.86`` → ``eff ≈ 86 %``).
-
-The **reset horizon** is the true 7-day-window reset (``reset_at_7d``
-from the Anthropic OAuth usage API, carried on
-:class:`~._account_list_render.AccountRow`). When an account has no
-``reset_at_7d`` cached (older cache / API outage), the horizon is
-treated as the full window (``frac = 1`` → ``eff = used_pct_7d``): a
-conservative "assume no reset within the window" default that never
-understates utilisation.
-
-The **fleet** figure is the arithmetic mean of the per-account
-effective utilisations over the accounts that have a cached
-``used_pct_7d`` (accounts with no usage data are excluded from the mean
-and from the ``(N accounts)`` count). ``None`` when no account has
-usage data — the CLI then prints ``unavailable`` instead of a number.
-
-NB: this deliberately does NOT use the quota-cache ``ttl_h`` field —
-that is the OAuth *access-token* TTL (typically ~2 h), not the 7-day
-usage-window reset, so weighting by it would collapse every account's
-effective utilisation to near-zero regardless of real usage.
+This REPLACES the earlier reset-horizon-weighted "effective utilization"
+figure (removed 2026-07-13): weighting each account's 7d% by how soon
+its window resets collapsed a fleet reading 17/88/88 (mean ≈ 64 %) down
+to ~15 %, which the operator found misleading — a fleet at 88 % is
+saturated regardless of when the window happens to roll over.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import TYPE_CHECKING, Iterable
 
-from ._account_list_format import format_reset_day_hour, format_reset_hhmm
+from ._timefmt import format_relative_until
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from ._account_list_render import AccountRow
-
-# Planning window the effective-utilisation formula amortises over.
-WEEK_HOURS: float = 7.0 * 24.0
 
 # Bar glyphs — plain box-drawing blocks that render in any UTF-8 terminal
 # (already used across the codebase's TUI/quota output).
@@ -128,7 +119,7 @@ def _pct_label(pct: float | None) -> str:
 
 
 def _wrap_hint(hint: str) -> str:
-    """Parenthesise a non-empty reset hint: ``→09:19`` → ``(→09:19)``."""
+    """Parenthesise a non-empty reset hint: ``in 4h05m`` → ``(in 4h05m)``."""
     return f"({hint})" if hint else ""
 
 
@@ -145,10 +136,10 @@ def render_usage_bar_line(
 ) -> str:
     """One aligned account line, operator-example shape:
 
-    ``<label>  5h [..]  29% (→09:19)   7d [..]  66% (→Sun 21h)``
+    ``<label>  5h [..]  29% (in 4h05m)   7d [..]  66% (in 2d 3h)``
 
     ``hint_5h`` / ``hint_7d`` are pre-wrapped display strings (e.g.
-    ``(→09:19)``) or ``""`` when the window has no cached reset.
+    ``(in 4h05m)``) or ``""`` when the window has no cached reset.
     ``hint_5h_width`` is the block-level max width of the 5h hints; a
     row whose own hint is shorter (or missing) pads with spaces so the
     ``7d`` bars stay vertically aligned across accounts. The trailing
@@ -170,15 +161,20 @@ def render_usage_bars_block(
     rows: Iterable["AccountRow"],
     *,
     width: int = _DEFAULT_BAR_WIDTH,
+    now: datetime | None = None,
 ) -> str:
     """Render the full usage-bars block (header + one line per account).
 
-    Each line carries the compact per-window reset hints
-    (``(→HH:MM)`` / ``(→Day HHh)``) computed from the row's
-    ``reset_at_5h`` / ``reset_at_7d`` — the 2026-07-11 dedupe
-    directive moved them here from the Stored-accounts table cells.
-    The 5h hints are padded to one block-level width so mixed
-    hint/no-hint rows keep the 7d bars vertically aligned.
+    Each line carries the compact per-window reset hints as the time
+    REMAINING until the window resets (``(in 4h05m)`` for 5h,
+    ``(in 2d 3h)`` for 7d), computed from the row's ``reset_at_5h`` /
+    ``reset_at_7d`` via the shared :func:`~._timefmt.format_relative_until`
+    (operator 2026-07-13: relative time-until-reset, not an absolute
+    wall-clock). The 5h hints are padded to one block-level width so
+    mixed hint/no-hint rows keep the 7d bars vertically aligned.
+
+    ``now`` is an injection seam for the current instant (tests pass a
+    fixed value); it defaults to real wall-clock time.
 
     Returns ``""`` for an empty ``rows`` iterable so the caller can skip
     printing the section entirely.
@@ -187,8 +183,12 @@ def render_usage_bars_block(
     if not row_list:
         return ""
     label_width = max(len(r.name) for r in row_list)
-    hints_5h = [_wrap_hint(format_reset_hhmm(r.reset_at_5h)) for r in row_list]
-    hints_7d = [_wrap_hint(format_reset_day_hour(r.reset_at_7d)) for r in row_list]
+    hints_5h = [
+        _wrap_hint(format_relative_until(r.reset_at_5h, now=now)) for r in row_list
+    ]
+    hints_7d = [
+        _wrap_hint(format_relative_until(r.reset_at_7d, now=now)) for r in row_list
+    ]
     hint_5h_width = max(len(h) for h in hints_5h)
     lines = ["Usage bars (5h / 7d out of 100%):"]
     for r, hint_5h, hint_7d in zip(row_list, hints_5h, hints_7d):
@@ -208,115 +208,48 @@ def render_usage_bars_block(
 
 
 # ---------------------------------------------------------------------------
-# Effective-utilisation formula (pure)
+# Fleet 7-day capacity-used aggregate (pure)
 # ---------------------------------------------------------------------------
 
 
-def effective_utilization_pct(
-    used_pct_7d: float,
-    reset_horizon_hours: float | None,
-    *,
-    window_hours: float = WEEK_HOURS,
-) -> float:
-    """Per-account effective utilisation weighted by the reset horizon.
-
-    ``frac_before_reset = clamp(reset_horizon_hours, 0, window) / window``
-    then ``effective = frac_before_reset * used_pct_7d``.
-
-    ``reset_horizon_hours`` of ``None`` (no cached reset) means "assume
-    no reset inside the window" → ``frac = 1`` → returns ``used_pct_7d``
-    unchanged. See the module docstring for the full rationale.
-    """
-    if window_hours <= 0:
-        return float(used_pct_7d)
-    if reset_horizon_hours is None:
-        frac = 1.0
-    else:
-        frac = max(0.0, min(float(reset_horizon_hours), window_hours)) / window_hours
-    return frac * float(used_pct_7d)
-
-
-def fleet_effective_utilization(
-    pairs: Iterable[tuple[float | None, float | None]],
-    *,
-    window_hours: float = WEEK_HOURS,
+def fleet_7d_capacity_used(
+    values: Iterable[float | None],
 ) -> tuple[float | None, int]:
-    """Aggregate effective utilisation across accounts.
+    """Mean 7-day utilisation across the accounts that have usage data.
 
-    ``pairs`` is an iterable of ``(used_pct_7d, reset_horizon_hours)``.
-    Entries whose ``used_pct_7d`` is ``None`` are excluded (no data).
-    Returns ``(mean_effective_pct, n_accounts_counted)``; the mean is
-    ``None`` (and ``n`` is ``0``) when no entry has usage data.
+    ``values`` is an iterable of per-account ``used_pct_7d`` (0-100) or
+    ``None``. ``None`` entries (no cached usage) are excluded from BOTH
+    the mean and the returned count. Returns ``(mean_pct, n_counted)``;
+    the mean is ``None`` (and ``n`` is ``0``) when no account has data.
+
+    See the module docstring for why the mean of the per-account
+    percentages is the correct aggregate (the API exposes utilisation
+    percentages, not absolute token quotas).
     """
-    effs: list[float] = []
-    for used_pct_7d, horizon in pairs:
-        if used_pct_7d is None:
-            continue
-        effs.append(
-            effective_utilization_pct(
-                used_pct_7d, horizon, window_hours=window_hours
-            )
-        )
-    if not effs:
+    used = [float(v) for v in values if v is not None]
+    if not used:
         return None, 0
-    return sum(effs) / len(effs), len(effs)
+    return sum(used) / len(used), len(used)
 
 
-# ---------------------------------------------------------------------------
-# AccountRow adapters (glue the pure formula to the CLI's row model)
-# ---------------------------------------------------------------------------
+def fleet_capacity_used_line(rows: Iterable["AccountRow"]) -> str:
+    """Format the fleet 7-day capacity-used line for the CLI.
 
-
-def _reset_horizon_hours(
-    reset_at_iso: str | None, *, now: datetime | None = None
-) -> float | None:
-    """Hours from ``now`` until ``reset_at_iso``; ``None`` if unparseable/absent.
-
-    Past resets clamp to ``0.0`` (the window is due to roll over
-    imminently). Naive timestamps are treated as UTC. Never raises.
+    ``Fleet 7d capacity used: 64% (3 accounts)`` — the arithmetic mean
+    of the accounts' 7-day-window utilisation (the same ``used_pct_7d``
+    the 7d bars show) — or ``Fleet 7d capacity used: unavailable (no
+    usage data)`` when no account has a cached 7-day utilisation.
     """
-    if not reset_at_iso:
-        return None
-    # stx-allow: fallback (reason: a malformed cached reset timestamp must
-    # degrade to "no horizon" rather than crash `sac accounts list`.)
-    try:
-        dt = datetime.fromisoformat(reset_at_iso)
-    except (ValueError, TypeError):
-        return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    now_dt = now or datetime.now(timezone.utc)
-    if now_dt.tzinfo is None:
-        now_dt = now_dt.replace(tzinfo=timezone.utc)
-    hours = (dt - now_dt).total_seconds() / 3600.0
-    return max(0.0, hours)
-
-
-def fleet_effective_line(
-    rows: Iterable["AccountRow"], *, now: datetime | None = None
-) -> str:
-    """Format the fleet effective-utilisation line for the CLI.
-
-    ``Fleet effective utilization: 71% (3 accounts)`` — or
-    ``Fleet effective utilization: unavailable (no usage data)`` when
-    no account has a cached 7-day utilisation.
-    """
-    pairs = [
-        (r.used_pct_7d, _reset_horizon_hours(r.reset_at_7d, now=now))
-        for r in rows
-    ]
-    pct, n = fleet_effective_utilization(pairs)
+    pct, n = fleet_7d_capacity_used(r.used_pct_7d for r in rows)
     if pct is None:
-        return "Fleet effective utilization: unavailable (no usage data)"
+        return "Fleet 7d capacity used: unavailable (no usage data)"
     noun = "account" if n == 1 else "accounts"
-    return f"Fleet effective utilization: {int(round(pct))}% ({n} {noun})"
+    return f"Fleet 7d capacity used: {int(round(pct))}% ({n} {noun})"
 
 
 __all__ = [
-    "WEEK_HOURS",
-    "effective_utilization_pct",
-    "fleet_effective_line",
-    "fleet_effective_utilization",
+    "fleet_7d_capacity_used",
+    "fleet_capacity_used_line",
     "render_usage_bar",
     "render_usage_bar_line",
     "render_usage_bars_block",

--- a/src/scitex_agent_container/cli_pkg/_timefmt.py
+++ b/src/scitex_agent_container/cli_pkg/_timefmt.py
@@ -1,0 +1,164 @@
+"""Shared wall-clock time formatting for the sac CLI (single SSOT).
+
+Two operator-facing time renderers that MORE THAN ONE CLI surface needs,
+kept here so every surface consumes one implementation instead of
+hand-rolling a private copy:
+
+1. :func:`format_jst` — render an ISO-8601 timestamp (or ``datetime``)
+   as a compact, human-readable Japan-time wall clock
+   ``YYYY-MM-DD HH:MM (JST)``. The raw ``...T...Z`` ISO string the
+   credential / usage APIs return is unreadable at a glance
+   (``2025-05-30T19:59:34.010055Z``); this is what the ``Since`` line of
+   ``sac accounts list`` — and the ``Started`` column of
+   ``sac agents list`` — should show instead. The zone is fixed to
+   ``Asia/Tokyo`` (the fleet operator's wall clock) and the ``(JST)``
+   abbreviation is DERIVED from the resolved tzinfo (``%Z``), never
+   hard-coded, so it stays self-consistent if the zone is ever changed.
+
+2. :func:`format_relative_until` — render the time REMAINING until a
+   future timestamp as ``in 4h05m`` / ``in 2d 3h`` / ``now``. Used by
+   the usage-bars block of ``sac accounts list`` for the per-window
+   reset hints: the operator wants "how long until the window resets"
+   (relative), not the absolute wall clock of the reset instant.
+
+Both helpers are pure (no I/O; the only clock read is the INJECTABLE
+``now`` on :func:`format_relative_until`) and never raise — a
+malformed/absent timestamp degrades to the caller-supplied ``empty``
+sentinel rather than crashing the CLI table it feeds.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone, tzinfo
+
+# The fleet operator's wall clock. An IANA name (not a fixed offset) so
+# the abbreviation (``JST``) is derived from the stdlib tz database via
+# ``strftime("%Z")`` rather than hard-coded — see the module docstring.
+_JST_IANA = "Asia/Tokyo"
+
+
+def _jst_tzinfo() -> tzinfo:
+    """Return the ``Asia/Tokyo`` tzinfo, degrading to a fixed +09:00.
+
+    Uses the stdlib ``zoneinfo`` so no third-party dependency creeps in.
+    If the host has no ``tzdata`` for the zone (a locale-stripped
+    container), fall back to a NAMED fixed +09:00 offset whose ``%Z``
+    still renders ``JST`` — so the caller's format string never has to
+    hard-code the abbreviation on either path.
+    """
+    # stx-allow: fallback (reason: a tzdata-less host must still render a
+    # readable JST wall clock rather than crash `sac accounts list`; the
+    # named fixed-offset fallback keeps %Z == "JST".)
+    try:
+        from zoneinfo import ZoneInfo
+
+        return ZoneInfo(_JST_IANA)
+    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment)
+        return timezone(timedelta(hours=9), "JST")
+
+
+def _coerce_dt(value: str | datetime | None) -> datetime | None:
+    """Coerce ``value`` to an aware datetime; ``None`` on any failure.
+
+    Naive datetimes / ISO strings are assumed UTC (matches what the
+    credential + usage JSON writers emit). A trailing ``Z`` is
+    normalised to ``+00:00`` first so ``datetime.fromisoformat`` accepts
+    the common ``...T...Z`` API shape on every supported Python.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    # stx-allow: fallback (reason: the ISO parser is strict; a malformed
+    # cached timestamp must render as the caller's empty sentinel rather
+    # than crash the CLI surface it feeds.)
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def format_jst(value: str | datetime | None, *, empty: str = "-") -> str:
+    """Render ``value`` as ``YYYY-MM-DD HH:MM (JST)`` in Japan time.
+
+    Args:
+        value: ISO-8601 string (``2025-05-30T19:59:34.010055Z``), an
+            aware/naive ``datetime``, or ``None``. Naive inputs are
+            assumed UTC.
+        empty: What to return for ``None`` / empty / unparseable input.
+
+    Returns:
+        ``"2025-05-31 04:59 (JST)"`` for a valid instant, else ``empty``.
+        The ``(JST)`` abbreviation is derived from the resolved tzinfo
+        (``%Z``), not hard-coded.
+    """
+    dt = _coerce_dt(value)
+    if dt is None:
+        return empty
+    local = dt.astimezone(_jst_tzinfo())
+    abbrev = local.strftime("%Z") or "JST"
+    return f"{local.strftime('%Y-%m-%d %H:%M')} ({abbrev})"
+
+
+def _humanize_until(seconds: int) -> str:
+    """Render a positive second delta as ``in 2d 3h`` / ``in 4h05m`` / ``in 7m``.
+
+    Picks the two most-significant units so the hint stays compact:
+    days+hours beyond a day, hours+minutes within a day (zero-padded
+    minutes so ``4h05m`` stays fixed-width), bare minutes under the hour.
+    A non-positive delta (reset already due) renders ``now``.
+    """
+    if seconds <= 0:
+        return "now"
+    days, rem = divmod(seconds, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes = rem // 60
+    if days:
+        return f"in {days}d {hours}h"
+    if hours:
+        return f"in {hours}h{minutes:02d}m"
+    if minutes:
+        return f"in {minutes}m"
+    return "in <1m"
+
+
+def format_relative_until(
+    value: str | datetime | None,
+    *,
+    now: datetime | None = None,
+    empty: str = "",
+) -> str:
+    """Render the time remaining until ``value`` as ``in 4h05m`` / ``in 2d 3h``.
+
+    Args:
+        value: A FUTURE ISO-8601 string / datetime (e.g. a rolling-window
+            ``resets_at``), or ``None``.
+        now: Injection seam for the current instant (tests pass a fixed
+            value). Defaults to ``datetime.now(timezone.utc)``. A naive
+            ``now`` is assumed UTC.
+        empty: What to return for ``None`` / empty / unparseable input.
+
+    Returns:
+        ``"in 4h05m"`` (< 1 day), ``"in 2d 3h"`` (>= 1 day), ``"in 7m"``
+        (< 1 hour), ``"now"`` (already due), else ``empty``.
+    """
+    dt = _coerce_dt(value)
+    if dt is None:
+        return empty
+    now_dt = now or datetime.now(timezone.utc)
+    if now_dt.tzinfo is None:
+        now_dt = now_dt.replace(tzinfo=timezone.utc)
+    delta = int((dt - now_dt).total_seconds())
+    return _humanize_until(delta)
+
+
+__all__ = [
+    "format_jst",
+    "format_relative_until",
+]

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -19,6 +19,7 @@ from ._helpers import (
     console,
     print_agent_list,
 )
+from ._timefmt import format_jst
 
 
 def _status_via_host_listen(name: str) -> None:
@@ -116,7 +117,11 @@ def _format_claude_account_block(meta: dict) -> list[str]:
         extra_line = "disabled"
         if extra_reason:
             extra_line += f" (reason: {extra_reason})"
-    since = _fmt(meta.get("subscription_created_at"))
+    # Operator 2026-07-13: the raw ``...T...Z`` ISO stamp is unreadable;
+    # render it as a JST wall clock (``YYYY-MM-DD HH:MM (JST)``) via the
+    # shared _timefmt SSOT. ``format_jst`` already returns ``-`` for a
+    # missing/unparseable value, matching the ``_fmt`` fallback above.
+    since = format_jst(meta.get("subscription_created_at"))
 
     return [
         "Claude Code account",

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -490,30 +490,6 @@ class TestSkillsSpec:
         finally:
             Path(path).unlink()
 
-    @pytest.mark.skip(
-        reason="v3-realign: spec.skills was removed (skills now live "
-        "under to_home/.claude/skills/ per §3)."
-    )
-    def test_skills_from_yaml_loads_required(self):
-        # Arrange
-        pass
-        # Act
-        pass
-        # Assert
-        pass
-
-    @pytest.mark.skip(
-        reason="v3-realign: spec.skills was removed (skills now live "
-        "under to_home/.claude/skills/ per §3)."
-    )
-    def test_skills_partial_required_only_set(self):
-        # Arrange
-        pass
-        # Act
-        pass
-        # Assert
-        pass
-
 
 @pytest.fixture
 def claude_md_setup_tmpdir():
@@ -764,26 +740,7 @@ class TestCleanupClaudeMd:
 # ``TestAgentConfigRemote`` / ``TestLoginShellDefault`` /
 # ``test_remote_from_yaml_loads_host`` blocks were removed wholesale —
 # they exercised behaviour that no longer exists. Cross-host placement
-# is via ``spec.host`` (see ``HostsSpec`` tests below).
-
-
-@pytest.mark.skip(reason="v3-realign: spec.remote was removed (§2).")
-def test_remote_full_spec_loads_port():
-    """Remote spec with all fields specified (legacy)."""
-    # Arrange
-    pass
-    # Act
-    pass
-    # Assert
-    pass
-
-
-@pytest.mark.skip(reason="v3-realign: spec.remote was removed (§2).")
-def test_login_shell_from_yaml_can_be_false():
-    """login_shell can be set to False in YAML (legacy)."""
-    # Arrange
-    pass
-    # Act
-    pass
-    # Assert
-    pass
+# is via ``spec.host`` (see ``HostsSpec`` tests below). The legacy
+# ``test_remote_full_spec_loads_port`` / ``test_login_shell_from_yaml_can_be_false``
+# skipped stubs were removed too (2026-07-13) — perpetually-skipped
+# placeholders for removed spec.remote fields, flagged by STX-TQ001.

--- a/tests/scitex_agent_container/cli_pkg/test__account_list_render.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_list_render.py
@@ -44,8 +44,6 @@ from scitex_agent_container.cli_pkg._account_list_render import (
     build_stored_rows,
     format_as_of_short,
     format_dt_local,
-    format_reset_day_hour,
-    format_reset_hhmm,
     format_snapshot_age,
     format_ttl_live,
     local_timezone,
@@ -430,8 +428,9 @@ def test_render_stored_table_omits_reset_hints():
     now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
     # Act
     out = render_stored_table_to_str(rows, now=now)
-    # Assert
-    assert "(→" not in out
+    # Assert — no reset hint marker (relative ``(in .../now)``) leaks into
+    # the table; the hints live on the usage-bars lines.
+    assert "(in " not in out and "(now)" not in out
 
 
 _TWO_ROW_TABLE_ROWS = [
@@ -523,97 +522,6 @@ def test_render_stored_table_shows_snapshot_age_in_last_update():
     out = render_stored_table_to_str(rows, now=now)
     # Assert — `(3m)` appears in the Last Update column.
     assert "(3m)" in out
-
-
-# ---------------------------------------------------------------------------
-# 2026-06-09 task — per-window reset hint on 5h% / 7d% cells
-# ---------------------------------------------------------------------------
-
-
-def test_format_reset_hhmm_renders_arrow_hhmm(env_save_restore):
-    """``format_reset_hhmm`` emits ``→HH:MM`` in the operator's local tz."""
-    # Arrange — 12:05 UTC = 21:05 JST.
-    env_save_restore.set("TZ", "Asia/Tokyo")
-    # Act
-    rendered = format_reset_hhmm("2026-05-31T12:05:00+00:00")
-    # Assert
-    assert rendered == "→21:05"
-
-
-def test_format_reset_hhmm_none_returns_empty():
-    # Arrange
-    value = None
-    # Act
-    rendered = format_reset_hhmm(value)
-    # Assert
-    assert rendered == ""
-
-
-def test_format_reset_hhmm_unparseable_returns_empty():
-    """A malformed reset timestamp must NOT crash the table — empty string."""
-    # Arrange
-    value = "not-a-timestamp"
-    # Act
-    rendered = format_reset_hhmm(value)
-    # Assert
-    assert rendered == ""
-
-
-def test_format_reset_day_hour_renders_arrow_day_hour(env_save_restore):
-    """``format_reset_day_hour`` emits ``→Day HHh`` in the operator's local tz."""
-    # Arrange — 2026-06-04 08:00 UTC = 2026-06-04 17:00 JST → Thu 17h.
-    env_save_restore.set("TZ", "Asia/Tokyo")
-    # Act
-    rendered = format_reset_day_hour("2026-06-04T08:00:00+00:00")
-    # Assert
-    assert rendered == "→Thu 17h"
-
-
-def test_format_reset_day_hour_none_returns_empty():
-    # Arrange
-    value = None
-    # Act
-    rendered = format_reset_day_hour(value)
-    # Assert
-    assert rendered == ""
-
-
-def test_format_reset_day_hour_unparseable_returns_empty():
-    # Arrange
-    value = "not-a-timestamp"
-    # Act
-    rendered = format_reset_day_hour(value)
-    # Assert
-    assert rendered == ""
-
-
-# ---------------------------------------------------------------------------
-# 2026-07-11 dedupe directive — the reset hint must stay COMPACT (the
-# operator's verbatim bar example is ``29% (→09:19)`` / ``66% (→Sun 21h)``).
-# The former per-cell ``(in Xh Ym)`` countdown qualifier (P3, op 12866) was
-# dropped together with the table cells it annotated, so a FUTURE reset must
-# render exactly like a past one: bare ``→HH:MM`` / ``→Day HHh``.
-# ---------------------------------------------------------------------------
-
-
-def test_format_reset_hhmm_future_reset_stays_compact(env_save_restore):
-    """A reset far in the future renders the bare ``→HH:MM`` — no countdown."""
-    # Arrange — 12:05 UTC = 21:05 JST, a century out from any real clock.
-    env_save_restore.set("TZ", "Asia/Tokyo")
-    # Act
-    rendered = format_reset_hhmm("2126-05-31T12:05:00+00:00")
-    # Assert
-    assert rendered == "→21:05"
-
-
-def test_format_reset_day_hour_future_reset_stays_compact(env_save_restore):
-    """A far-future reset renders the bare ``→Day HHh`` — no countdown."""
-    # Arrange — 08:00 UTC = 17:00 JST, a century out from any real clock.
-    env_save_restore.set("TZ", "Asia/Tokyo")
-    # Act
-    rendered = format_reset_day_hour("2126-06-04T08:00:00+00:00")
-    # Assert — bare →Day HHh shape; no ``(in ...)`` qualifier appended.
-    assert rendered.startswith("→") and rendered.endswith(" 17h") and "(" not in rendered
 
 
 def test_needs_rolling_legend_true_when_row_lacks_both_resets():
@@ -1123,30 +1031,42 @@ def test_cli_list_json_carries_through_reset_at_7d(sandbox_home):
 
 
 def test_cli_list_human_shows_reset_hint_when_cache_has_reset_at(sandbox_home):
-    """End-to-end: cache → renderer → operator sees ``42% (→...)``.
+    """End-to-end: cache → renderer → operator sees ``42% (in ...)``.
 
     Gripe #2 of the 2026-06-09 task, relocated by the 2026-07-11
-    dedupe directive: when the per-account cache carries
+    dedupe directive and switched to a RELATIVE time-until-reset by
+    the 2026-07-13 directive: when the per-account cache carries
     ``reset_at_5h``, the human output must show the inline reset hint
-    — now on the usage-bars line rather than a table cell. We don't
-    pin a specific local time (tests run on hosts in arbitrary
-    timezones) — only the arrow marker, which is the renderer's
-    unambiguous reset signal.
+    on the usage-bars line. We seed a FAR-FUTURE reset so the relative
+    hint is deterministically ``(in ...)`` regardless of when the test
+    runs (a past reset renders ``(now)``); the exact duration is
+    wall-clock-dependent, so we assert only on the ``(in `` marker.
     """
     # Arrange — full account + a credentials snapshot so the live
-    # fetcher path is taken; with no real OAuth token the fetcher
-    # falls back to the cached ``usage.json`` we seed below.
+    # fetcher path is taken; with no real OAuth token the fetcher falls
+    # back to the cached ``usage.json``. Overwrite that cache with a
+    # far-future reset so the relative hint is a stable ``(in ...)``.
     _seed_account_with_full_usage_cache(sandbox_home)
     accts = sandbox_home / ".scitex" / "agent-container" / "accounts" / "work"
     (accts / ".credentials.json").write_text(
         json.dumps({"claudeAiOauth": {"subscriptionType": "pro"}})
     )
+    (accts / "usage.json").write_text(
+        json.dumps(
+            {
+                "used_pct_5h": 42.0,
+                "used_pct_7d": 15.0,
+                "reset_at_5h": "2126-05-31T12:05:00+00:00",
+                "reset_at_7d": "2126-06-04T08:00:00+00:00",
+                "fetched_at": "2126-05-31T12:11:00+00:00",
+                "as_of": "2126-05-31T12:11:00+00:00",
+            }
+        )
+    )
     runner = CliRunner()
     # Act
     result = runner.invoke(account, ["list"])
-    # Assert — bullet-2 contract: the inline arrow marker reaches the
-    # operator. The exact local time depends on the host TZ; assert
-    # on the marker shape so the test is timezone-independent.
-    assert "(→" in result.output, (
+    # Assert — the inline relative reset hint reaches the operator.
+    assert "(in " in result.output, (
         f"missing inline reset hint in human output:\n{result.output}"
     )

--- a/tests/scitex_agent_container/cli_pkg/test__account_usage_bars.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_usage_bars.py
@@ -1,8 +1,8 @@
-"""Tests for the ``sac accounts list`` usage-bars + fleet-effective surface.
+"""Tests for the ``sac accounts list`` usage-bars + fleet-capacity surface.
 
 PA-306 no-mocks: every test drives the real pure helpers with known
 inputs and asserts exact strings / computed aggregates. The
-bar-rendering and effective-utilization functions take no I/O and an
+bar-rendering and fleet-capacity functions take no I/O and an
 injectable ``now``, so no monkeypatching of the clock or filesystem is
 needed.
 """
@@ -13,10 +13,8 @@ from datetime import datetime, timezone
 
 from scitex_agent_container.cli_pkg._account_list_render import AccountRow
 from scitex_agent_container.cli_pkg._account_usage_bars import (
-    WEEK_HOURS,
-    effective_utilization_pct,
-    fleet_effective_line,
-    fleet_effective_utilization,
+    fleet_7d_capacity_used,
+    fleet_capacity_used_line,
     render_usage_bar,
     render_usage_bar_line,
     render_usage_bars_block,
@@ -134,7 +132,7 @@ def test_render_usage_bar_line_shows_7d_window():
 # ---------------------------------------------------------------------------
 # 2026-07-11 dedupe directive — the bars own the reset hints (moved off the
 # Stored-accounts table). Operator's verbatim example shape:
-#   ... 5h [..]  29% (→09:19)   7d [..]  66% (→Sun 21h)
+#   ... 5h [..]  29% (in 4h05m)   7d [..]  66% (in 2d 3h)
 # ---------------------------------------------------------------------------
 
 
@@ -148,11 +146,11 @@ def test_render_usage_bar_line_appends_5h_reset_hint():
         66.0,
         label_width=10,
         width=20,
-        hint_5h="(→09:19)",
-        hint_7d="(→Sun 21h)",
+        hint_5h="(in 4h05m)",
+        hint_7d="(in 2d 3h)",
     )
     # Assert — operator's verbatim 5h shape.
-    assert "29% (→09:19)" in line
+    assert "29% (in 4h05m)" in line
 
 
 def test_render_usage_bar_line_appends_7d_reset_hint():
@@ -165,11 +163,11 @@ def test_render_usage_bar_line_appends_7d_reset_hint():
         66.0,
         label_width=10,
         width=20,
-        hint_5h="(→09:19)",
-        hint_7d="(→Sun 21h)",
+        hint_5h="(in 4h05m)",
+        hint_7d="(in 2d 3h)",
     )
     # Assert — operator's verbatim 7d shape.
-    assert "66% (→Sun 21h)" in line
+    assert "66% (in 2d 3h)" in line
 
 
 def test_render_usage_bar_line_without_hints_has_no_parens():
@@ -184,13 +182,13 @@ def test_render_usage_bar_line_without_hints_has_no_parens():
 
 def test_render_usage_bar_line_pads_missing_5h_hint_to_block_width():
     """A hint-less row pads the 5h slot so the 7d bars stay aligned."""
-    # Arrange — a sibling row in the block has an 8-char 5h hint.
+    # Arrange — a sibling row in the block has a 10-char 5h hint.
     with_hint = render_usage_bar_line(
-        "aa", 29.0, 66.0, label_width=4, width=20, hint_5h="(→09:19)", hint_5h_width=8
+        "aa", 29.0, 66.0, label_width=4, width=20, hint_5h="(in 4h05m)", hint_5h_width=10
     )
     # Act
     without_hint = render_usage_bar_line(
-        "bbbb", 14.0, 15.0, label_width=4, width=20, hint_5h="", hint_5h_width=8
+        "bbbb", 14.0, 15.0, label_width=4, width=20, hint_5h="", hint_5h_width=10
     )
     # Assert — "7d [" starts at the same column in both lines.
     assert with_hint.index("7d [") == without_hint.index("7d [")
@@ -255,6 +253,11 @@ def test_render_usage_bars_block_no_data_row_renders_placeholder():
     assert "no data" in block
 
 
+# Fixed clock so the relative reset hints are deterministic (operator
+# 2026-07-13: the hint is the time REMAINING until reset, not a wall-clock).
+_HINT_NOW = datetime(2026, 7, 12, 0, 0, 0, tzinfo=timezone.utc)
+
+
 def _hinted_bar_rows() -> list[AccountRow]:
     """One row with both resets cached, one with neither (mixed block)."""
     return [
@@ -265,9 +268,9 @@ def _hinted_bar_rows() -> list[AccountRow]:
             used_pct_5h=29.0,
             used_pct_7d=66.0,
             snapshot_as_of=None,
-            # Sun 2026-07-12 00:19 UTC = 09:19 JST; 12:00 UTC = Sun 21h JST.
-            reset_at_5h="2026-07-12T00:19:00+00:00",
-            reset_at_7d="2026-07-12T12:00:00+00:00",
+            # From _HINT_NOW: +4h05m → "in 4h05m"; +2d3h → "in 2d 3h".
+            reset_at_5h="2026-07-12T04:05:00+00:00",
+            reset_at_7d="2026-07-14T03:00:00+00:00",
         ),
         AccountRow(
             name="ywata1989-gmail-com",
@@ -280,157 +283,104 @@ def _hinted_bar_rows() -> list[AccountRow]:
     ]
 
 
-def test_render_usage_bars_block_carries_5h_reset_hint(env_save_restore):
-    """Block-level: ``reset_at_5h`` renders the operator's ``29% (→09:19)``."""
+def test_render_usage_bars_block_carries_5h_reset_hint():
+    """Block-level: ``reset_at_5h`` renders the operator's ``29% (in 4h05m)``."""
     # Arrange
-    env_save_restore.set("TZ", "Asia/Tokyo")
     rows = _hinted_bar_rows()
     # Act
-    block = render_usage_bars_block(rows, width=20)
+    block = render_usage_bars_block(rows, width=20, now=_HINT_NOW)
     # Assert
-    assert "29% (→09:19)" in block
+    assert "29% (in 4h05m)" in block
 
 
-def test_render_usage_bars_block_carries_7d_reset_hint(env_save_restore):
-    """Block-level: ``reset_at_7d`` renders the operator's ``66% (→Sun 21h)``."""
+def test_render_usage_bars_block_carries_7d_reset_hint():
+    """Block-level: ``reset_at_7d`` renders the operator's ``66% (in 2d 3h)``."""
     # Arrange
-    env_save_restore.set("TZ", "Asia/Tokyo")
     rows = _hinted_bar_rows()
     # Act
-    block = render_usage_bars_block(rows, width=20)
+    block = render_usage_bars_block(rows, width=20, now=_HINT_NOW)
     # Assert
-    assert "66% (→Sun 21h)" in block
+    assert "66% (in 2d 3h)" in block
 
 
-def test_render_usage_bars_block_aligns_7d_bars_across_mixed_hints(
-    env_save_restore,
-):
+def test_render_usage_bars_block_aligns_7d_bars_across_mixed_hints():
     """A hint-less row pads its 5h slot — 7d bars align across the block."""
     # Arrange
-    env_save_restore.set("TZ", "Asia/Tokyo")
     rows = _hinted_bar_rows()
     # Act
-    block = render_usage_bars_block(rows, width=20)
+    block = render_usage_bars_block(rows, width=20, now=_HINT_NOW)
     starts = {ln.index("7d [") for ln in block.splitlines() if "7d [" in ln}
     # Assert — one distinct start column means the 7d bars line up.
     assert len(starts) == 1, f"7d bars misaligned across rows: {starts}\n{block}"
 
 
 # ---------------------------------------------------------------------------
-# effective_utilization_pct — per-account reset-horizon weighting
+# fleet_7d_capacity_used — plain mean of the accounts' 7d utilisation
+# (operator 2026-07-13: over the trailing 7 days, how much of the fleet's
+# capacity was actually used — NOT reset-horizon-weighted).
 # ---------------------------------------------------------------------------
 
 
-def test_effective_util_none_horizon_returns_raw_pct():
-    # Arrange — no reset horizon → assume no reset within the window.
-    used = 100.0
+def test_fleet_7d_capacity_counts_three_accounts():
+    # Arrange — the operator's worked example: 7d = 17, 88, 88.
+    values = [17.0, 88.0, 88.0]
     # Act
-    eff = effective_utilization_pct(used, None)
-    # Assert
-    assert eff == 100.0
-
-
-def test_effective_util_reset_in_one_day_at_100():
-    # Arrange — 100% resetting in 24h over a 168h window → 24/168*100.
-    used = 100.0
-    # Act
-    eff = effective_utilization_pct(used, 24.0, window_hours=WEEK_HOURS)
-    # Assert
-    assert round(eff, 4) == round(24.0 / 168.0 * 100.0, 4)
-
-
-def test_effective_util_reset_in_six_days_higher_than_one_day():
-    # Arrange — the rationale: later reset ⇒ higher effective util.
-    one_day = effective_utilization_pct(100.0, 24.0)
-    # Act
-    six_days = effective_utilization_pct(100.0, 6 * 24.0)
-    # Assert
-    assert six_days > one_day
-
-
-def test_effective_util_horizon_beyond_window_caps_at_raw():
-    # Arrange — horizon > window clamps frac to 1.0 → raw pct.
-    used = 80.0
-    # Act
-    eff = effective_utilization_pct(used, 1000.0, window_hours=WEEK_HOURS)
-    # Assert
-    assert eff == 80.0
-
-
-def test_effective_util_past_reset_zero_horizon_is_zero():
-    # Arrange — reset already due (horizon 0) → 0% effective utilisation.
-    used = 100.0
-    # Act
-    eff = effective_utilization_pct(used, 0.0)
-    # Assert
-    assert eff == 0.0
-
-
-# ---------------------------------------------------------------------------
-# fleet_effective_utilization — aggregate
-# ---------------------------------------------------------------------------
-
-
-def test_fleet_effective_counts_three_accounts():
-    # Arrange — the operator's real 3-account fleet: d7 = 99, 15, 100.
-    pairs = [(99.0, None), (15.0, None), (100.0, None)]
-    # Act
-    _pct, n = fleet_effective_utilization(pairs)
+    _pct, n = fleet_7d_capacity_used(values)
     # Assert
     assert n == 3
 
 
-def test_fleet_effective_mean_of_three_no_horizon_is_71():
-    # Arrange — mean(99, 15, 100) = 71.33% → "71%".
-    pairs = [(99.0, None), (15.0, None), (100.0, None)]
+def test_fleet_7d_capacity_mean_of_17_88_88_is_64():
+    # Arrange — mean(17, 88, 88) = 64.33% → "64%" (NOT the old 15%).
+    values = [17.0, 88.0, 88.0]
     # Act
-    pct, _n = fleet_effective_utilization(pairs)
+    pct, _n = fleet_7d_capacity_used(values)
     # Assert
-    assert int(round(pct)) == 71
+    assert int(round(pct)) == 64
 
 
-def test_fleet_effective_skips_none_usage_accounts_count():
+def test_fleet_7d_capacity_skips_none_usage_accounts_count():
     # Arrange — an account with no usage data is excluded from the count.
-    pairs = [(100.0, None), (None, None), (50.0, None)]
+    values = [100.0, None, 50.0]
     # Act
-    _pct, n = fleet_effective_utilization(pairs)
+    _pct, n = fleet_7d_capacity_used(values)
     # Assert
     assert n == 2
 
 
-def test_fleet_effective_skips_none_usage_accounts_mean():
+def test_fleet_7d_capacity_skips_none_usage_accounts_mean():
     # Arrange — mean over the two accounts that DO have usage.
-    pairs = [(100.0, None), (None, None), (50.0, None)]
+    values = [100.0, None, 50.0]
     # Act
-    pct, _n = fleet_effective_utilization(pairs)
+    pct, _n = fleet_7d_capacity_used(values)
     # Assert
     assert pct == 75.0
 
 
-def test_fleet_effective_all_none_returns_none():
+def test_fleet_7d_capacity_all_none_returns_none():
     # Arrange
-    pairs = [(None, None), (None, 24.0)]
+    values = [None, None]
     # Act
-    pct, _n = fleet_effective_utilization(pairs)
+    pct, _n = fleet_7d_capacity_used(values)
     # Assert
     assert pct is None
 
 
-def test_fleet_effective_all_none_counts_zero():
+def test_fleet_7d_capacity_all_none_counts_zero():
     # Arrange
-    pairs = [(None, None), (None, 24.0)]
+    values = [None, None]
     # Act
-    _pct, n = fleet_effective_utilization(pairs)
+    _pct, n = fleet_7d_capacity_used(values)
     # Assert
     assert n == 0
 
 
 # ---------------------------------------------------------------------------
-# fleet_effective_line — CLI-facing formatting over AccountRow
+# fleet_capacity_used_line — CLI-facing formatting over AccountRow
 # ---------------------------------------------------------------------------
 
 
-def _row(name: str, d7: float | None, reset_at_7d: str | None) -> AccountRow:
+def _row(name: str, d7: float | None) -> AccountRow:
     return AccountRow(
         name=name,
         freshness_state="VALID",
@@ -438,43 +388,52 @@ def _row(name: str, d7: float | None, reset_at_7d: str | None) -> AccountRow:
         used_pct_5h=0.0,
         used_pct_7d=d7,
         snapshot_as_of=None,
-        reset_at_7d=reset_at_7d,
     )
 
 
-def test_fleet_effective_line_three_accounts_no_reset():
-    # Arrange — matches the operator's fleet; no reset_at → mean of d7.
-    rows = [_row("a", 99.0, None), _row("b", 15.0, None), _row("c", 100.0, None)]
+def test_fleet_capacity_line_operator_example_reads_64():
+    # Arrange — the operator's worked fleet: 7d = 17, 88, 88 → 64% (not 15%).
+    rows = [_row("a", 17.0), _row("b", 88.0), _row("c", 88.0)]
     # Act
-    line = fleet_effective_line(rows)
+    line = fleet_capacity_used_line(rows)
     # Assert
-    assert line == "Fleet effective utilization: 71% (3 accounts)"
+    assert line == "Fleet 7d capacity used: 64% (3 accounts)"
 
 
-def test_fleet_effective_line_singular_account_noun():
+def test_fleet_capacity_line_singular_account_noun():
     # Arrange
-    rows = [_row("solo", 42.0, None)]
+    rows = [_row("solo", 42.0)]
     # Act
-    line = fleet_effective_line(rows)
+    line = fleet_capacity_used_line(rows)
     # Assert — singular "account", not "accounts".
-    assert line == "Fleet effective utilization: 42% (1 account)"
+    assert line == "Fleet 7d capacity used: 42% (1 account)"
 
 
-def test_fleet_effective_line_unavailable_when_no_usage():
+def test_fleet_capacity_line_unavailable_when_no_usage():
     # Arrange
-    rows = [_row("a", None, None), _row("b", None, None)]
+    rows = [_row("a", None), _row("b", None)]
     # Act
-    line = fleet_effective_line(rows)
+    line = fleet_capacity_used_line(rows)
     # Assert
-    assert line == "Fleet effective utilization: unavailable (no usage data)"
+    assert line == "Fleet 7d capacity used: unavailable (no usage data)"
 
 
-def test_fleet_effective_line_weights_by_reset_horizon():
-    # Arrange — one account at 100% resetting in 24h over a 168h window.
-    now = datetime(2026, 7, 9, 0, 0, tzinfo=timezone.utc)
-    reset_in_24h = datetime(2026, 7, 10, 0, 0, tzinfo=timezone.utc).isoformat()
-    rows = [_row("a", 100.0, reset_in_24h)]
+def test_fleet_capacity_line_ignores_reset_horizon():
+    # Arrange — an account at 100% whose 7d window resets in 24h. The OLD
+    # reset-horizon weighting collapsed this to ~14%; the capacity figure
+    # is the plain 7d% regardless of when the window rolls over.
+    rows = [
+        AccountRow(
+            name="a",
+            freshness_state="VALID",
+            freshness_hours=2.0,
+            used_pct_5h=0.0,
+            used_pct_7d=100.0,
+            snapshot_as_of=None,
+            reset_at_7d="2026-07-10T00:00:00+00:00",
+        )
+    ]
     # Act
-    line = fleet_effective_line(rows, now=now)
-    # Assert — 24/168*100 = 14.28 → "14%".
-    assert line == "Fleet effective utilization: 14% (1 account)"
+    line = fleet_capacity_used_line(rows)
+    # Assert — 100%, not the old horizon-weighted 14%.
+    assert line == "Fleet 7d capacity used: 100% (1 account)"

--- a/tests/scitex_agent_container/cli_pkg/test__timefmt.py
+++ b/tests/scitex_agent_container/cli_pkg/test__timefmt.py
@@ -1,0 +1,181 @@
+"""Tests for the shared ``cli_pkg._timefmt`` time-format SSOT.
+
+No-mocks: both helpers are pure and take an injectable ``now`` (for the
+relative one), so every case drives the real function with a known
+instant and asserts the exact string. ``format_jst`` fixes the zone to
+``Asia/Tokyo`` so no env/TZ juggling is needed for a deterministic
+result.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from scitex_agent_container.cli_pkg._timefmt import (
+    format_jst,
+    format_relative_until,
+)
+
+# ---------------------------------------------------------------------------
+# format_jst — readable JST wall clock
+# ---------------------------------------------------------------------------
+
+
+def test_format_jst_converts_utc_iso_to_jst_wall_clock():
+    # Arrange — the operator's real ``Since`` value (19:59:34 UTC).
+    value = "2025-05-30T19:59:34.010055Z"
+    # Act
+    rendered = format_jst(value)
+    # Assert — 19:59 UTC + 9h = 04:59 JST the next day.
+    assert rendered == "2025-05-31 04:59 (JST)"
+
+
+def test_format_jst_carries_derived_jst_abbreviation():
+    # Arrange
+    value = "2025-05-30T19:59:34Z"
+    # Act
+    rendered = format_jst(value)
+    # Assert — the abbreviation is present (derived from the tz, %Z).
+    assert rendered.endswith("(JST)")
+
+
+def test_format_jst_date_only_input_lands_at_0900_jst():
+    # Arrange — a bare date parses as 00:00 UTC.
+    value = "2024-01-01"
+    # Act
+    rendered = format_jst(value)
+    # Assert — 00:00 UTC + 9h = 09:00 JST, same date.
+    assert rendered == "2024-01-01 09:00 (JST)"
+
+
+def test_format_jst_aware_datetime_input():
+    # Arrange — an aware datetime, not a string.
+    value = datetime(2026, 3, 1, 3, 0, 0, tzinfo=timezone.utc)
+    # Act
+    rendered = format_jst(value)
+    # Assert — 03:00 UTC + 9h = 12:00 JST.
+    assert rendered == "2026-03-01 12:00 (JST)"
+
+
+def test_format_jst_naive_datetime_assumed_utc():
+    # Arrange — a naive datetime is treated as UTC.
+    value = datetime(2026, 3, 1, 3, 0, 0)
+    # Act
+    rendered = format_jst(value)
+    # Assert
+    assert rendered == "2026-03-01 12:00 (JST)"
+
+
+def test_format_jst_none_returns_dash():
+    # Arrange
+    value = None
+    # Act
+    rendered = format_jst(value)
+    # Assert
+    assert rendered == "-"
+
+
+def test_format_jst_empty_string_returns_dash():
+    # Arrange
+    value = "   "
+    # Act
+    rendered = format_jst(value)
+    # Assert
+    assert rendered == "-"
+
+
+def test_format_jst_unparseable_returns_dash():
+    # Arrange
+    value = "not-a-timestamp"
+    # Act
+    rendered = format_jst(value)
+    # Assert
+    assert rendered == "-"
+
+
+def test_format_jst_custom_empty_sentinel():
+    # Arrange — caller can override the missing-value sentinel.
+    value = None
+    # Act
+    rendered = format_jst(value, empty="n/a")
+    # Assert
+    assert rendered == "n/a"
+
+
+# ---------------------------------------------------------------------------
+# format_relative_until — time remaining until a future instant
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 7, 12, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_relative_hours_minutes_shape():
+    # Arrange — +4h05m from now (the operator's 5h example).
+    value = "2026-07-12T04:05:00+00:00"
+    # Act
+    rendered = format_relative_until(value, now=_NOW)
+    # Assert
+    assert rendered == "in 4h05m"
+
+
+def test_relative_days_hours_shape():
+    # Arrange — +2d3h from now (the operator's 7d example).
+    value = "2026-07-14T03:00:00+00:00"
+    # Act
+    rendered = format_relative_until(value, now=_NOW)
+    # Assert
+    assert rendered == "in 2d 3h"
+
+
+def test_relative_minutes_only_under_one_hour():
+    # Arrange — +42m from now.
+    value = "2026-07-12T00:42:00+00:00"
+    # Act
+    rendered = format_relative_until(value, now=_NOW)
+    # Assert
+    assert rendered == "in 42m"
+
+
+def test_relative_sub_minute_is_less_than_one_minute():
+    # Arrange — +30s from now.
+    value = "2026-07-12T00:00:30+00:00"
+    # Act
+    rendered = format_relative_until(value, now=_NOW)
+    # Assert
+    assert rendered == "in <1m"
+
+
+def test_relative_past_instant_is_now():
+    # Arrange — a reset already due (in the past).
+    value = "2026-07-11T00:00:00+00:00"
+    # Act
+    rendered = format_relative_until(value, now=_NOW)
+    # Assert
+    assert rendered == "now"
+
+
+def test_relative_parses_z_suffix():
+    # Arrange — the raw ``...Z`` API shape must parse.
+    value = "2026-07-12T04:05:00Z"
+    # Act
+    rendered = format_relative_until(value, now=_NOW)
+    # Assert
+    assert rendered == "in 4h05m"
+
+
+def test_relative_none_returns_empty_string():
+    # Arrange — no cached reset → empty hint (caller omits it).
+    value = None
+    # Act
+    rendered = format_relative_until(value, now=_NOW)
+    # Assert
+    assert rendered == ""
+
+
+def test_relative_unparseable_returns_empty_string():
+    # Arrange
+    value = "not-a-timestamp"
+    # Act
+    rendered = format_relative_until(value, now=_NOW)
+    # Assert
+    assert rendered == ""

--- a/tests/scitex_agent_container/cli_pkg/test_status_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_status_cmds.py
@@ -226,6 +226,30 @@ def test_format_account_block_renders_subscription_created_at(_full_meta):
     assert "2024-01-01" in joined
 
 
+def test_format_account_block_renders_since_in_jst():
+    # Arrange — the raw ``...T...Z`` API stamp must render as a readable
+    # JST wall clock (operator 2026-07-13), not the unreadable ISO string.
+    meta = {
+        "email_address": "x@y.com",
+        "subscription_created_at": "2025-05-30T19:59:34.010055Z",
+    }
+    # Act
+    lines = _format_claude_account_block(meta)
+    since_line = next(line for line in lines if "Since" in line)
+    # Assert — 19:59 UTC + 9h = 04:59 JST the next day.
+    assert since_line.rstrip().endswith("2025-05-31 04:59 (JST)")
+
+
+def test_format_account_block_since_missing_renders_dash():
+    # Arrange — no subscription_created_at → the Since cell is a bare dash.
+    meta = {"email_address": "x@y.com"}
+    # Act
+    lines = _format_claude_account_block(meta)
+    since_line = next(line for line in lines if "Since" in line)
+    # Assert
+    assert since_line.rstrip().endswith("-")
+
+
 def test_format_account_block_header_present(_full_meta):
     # Arrange
     meta = _full_meta


### PR DESCRIPTION
## What

Three operator-requested improvements to `sac accounts list` (2026-07-13), all in that command's render path.

### 1. Readable JST `Since`
The `Since` field printed a raw ISO stamp (`2025-05-30T19:59:34.010055Z`). It now renders as `YYYY-MM-DD HH:MM (JST)` (e.g. `2025-05-31 04:59 (JST)`). The zone is `zoneinfo("Asia/Tokyo")` and the `(JST)` abbreviation is **derived from the tz object** (`strftime("%Z")`), not hard-coded.

### 2. Relative reset hints (5h AND 7d)
The usage-bars reset hints were absolute wall-clocks (`→09:19` / `→Sun 21h`). They now show the time **remaining** until the window resets: `29% (in 4h05m)` for the 5h bar, `66% (in 2d 3h)` for the 7d bar. Applied to 7d too — it was clean via a single adaptive `format_relative_until` helper (days+hours ≥ 1d, else hours+minutes, else minutes; `now` for a past/due reset).

### 3. Fix `Fleet effective utilization` semantics (the important one)
**Current formula** (`_account_usage_bars.py`): per account `effective% = clamp(reset_horizon_hours, 0, 168h)/168h × used_pct_7d`, then the mean across accounts. That reset-horizon weighting is exactly why it printed **15%** while the 7d bars read 17/88/88 (mean ≈ 64%): the two 88% accounts' windows reset soon, so their `frac_before_reset` was small (≈0.14) and each contributed only ~12%, dragging the fleet number to ~15%.

**New**: `Fleet 7d capacity used: 64% (3 accounts)` — the plain arithmetic mean of `used_pct_7d` across accounts that have usage. On 17/88/88 → **64%** (was 15%). It reads as a capacity-planning signal: ≈100% ⇒ saturated ⇒ add an account; low ⇒ over-provisioned ⇒ drop one. Relabelled from "Fleet effective utilization" so the number matches its meaning.

**avg vs total (not ambiguous):** the Anthropic OAuth usage API exposes utilisation *percentages* (`used_pct_7d` ∈ [0,100]); the absolute weekly quota (`limit_tokens_7d`) is `None`, so total-used / total-available is **not computable** from the data. The mean of the per-account percentages is therefore the only well-defined aggregate (and equals total-used / total-available when the accounts share a quota tier). Re-aggregates the same 7d numbers the bars already show — **no new network calls**.

## SSOT
New shared `cli_pkg/_timefmt.py` (`format_jst` + `format_relative_until`) so this surface and the forthcoming `sac agents list` Started-column JST work consume one implementation instead of a hand-rolled private copy (none was merged yet — searched for `zoneinfo`/`Asia/Tokyo`/`JST`/`_timefmt`). The Started-column change should `from ._timefmt import format_jst`.

Removed the now-dead reset-horizon machinery (`effective_utilization_pct`, `fleet_effective_utilization`, `WEEK_HOURS`, `_reset_horizon_hours`) and the absolute reset-hint helpers (`format_reset_hhmm`, `format_reset_day_hour`).

## Tests
No mocks — pure helpers driven with known inputs + real on-disk account fixtures (PA-306 style). **214 passing** across the touched `cli_pkg` tests, including the operator's exact 17/88/88 → 64% case, singular/plural/unavailable line shapes, and an end-to-end relative-hint CLI test (far-future reset ⇒ deterministic `(in ...)`). New `test__timefmt.py` covers the shared helpers (JST conversion incl. the operator's timestamp, date-only, None/unparseable; relative `in 4h05m` / `in 2d 3h` / `in 7m` / `now`).

Verified live against real credentials: `sac accounts list` prints `Since: 2025-05-04 15:41 (JST)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
