### PR TITLE
test(config): remove 4 dead @pytest.mark.skip stubs unblocking develop CI (STX-TQ001)

### DIFF
--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -490,30 +490,6 @@ class TestSkillsSpec:
         finally:
             Path(path).unlink()
 
-    @pytest.mark.skip(
-        reason="v3-realign: spec.skills was removed (skills now live "
-        "under to_home/.claude/skills/ per §3)."
-    )
-    def test_skills_from_yaml_loads_required(self):
-        # Arrange
-        pass
-        # Act
-        pass
-        # Assert
-        pass
-
-    @pytest.mark.skip(
-        reason="v3-realign: spec.skills was removed (skills now live "
-        "under to_home/.claude/skills/ per §3)."
-    )
-    def test_skills_partial_required_only_set(self):
-        # Arrange
-        pass
-        # Act
-        pass
-        # Assert
-        pass
-
 
 @pytest.fixture
 def claude_md_setup_tmpdir():
@@ -765,25 +741,3 @@ class TestCleanupClaudeMd:
 # ``test_remote_from_yaml_loads_host`` blocks were removed wholesale —
 # they exercised behaviour that no longer exists. Cross-host placement
 # is via ``spec.host`` (see ``HostsSpec`` tests below).
-
-
-@pytest.mark.skip(reason="v3-realign: spec.remote was removed (§2).")
-def test_remote_full_spec_loads_port():
-    """Remote spec with all fields specified (legacy)."""
-    # Arrange
-    pass
-    # Act
-    pass
-    # Assert
-    pass
-
-
-@pytest.mark.skip(reason="v3-realign: spec.remote was removed (§2).")
-def test_login_shell_from_yaml_can_be_false():
-    """login_shell can be set to False in YAML (legacy)."""
-    # Arrange
-    pass
-    # Act
-    pass
-    # Assert
-    pass


### PR DESCRIPTION
## Problem

`tests/develop/test_audit.py::test_audit_all_clean` fails on **every**
develop PR's pytest-matrix (py3.11/12/13) — a develop-level breakage every
PR inherits (confirmed on PRs that don't touch the offending file). The
last green `tests` check on develop is stale (it ran before a scitex-dev
release).

**Root cause:** a scitex-dev release (the audit tool, installed unpinned
via `scitex-dev>=0.17.12` floor-only) added rule **STX-TQ001** (PA-307 §3),
which flags `@pytest.mark.skip` placeholder tests with empty `pass` bodies
as "no assertion". Four such stubs in `tests/integration/test_config.py`
trip it.

## Fix

Delete the 4 dead skip-stubs. Each documents a feature already **removed**
in the v3-realign and never runs (skip-marked), so removing them is
legitimate dead-code cleanup that clears the STX-TQ001 violations — no live
feature loses coverage:

| Stub | Removed feature (evidence) |
| --- | --- |
| `test_skills_from_yaml_loads_required` | `spec.skills` authoring rejected by `_V3_REMOVED_FIELDS["skills"]` in `config/_validation.py` (enforced at validate time). `parse_skills` survives only to inject the fleet base-default and is unreachable with a user-authored `skills:` block. |
| `test_skills_partial_required_only_set` | same as above |
| `test_remote_full_spec_loads_port` | `RemoteSpec` + the `spec.remote` block deleted in WI-6 (see `config/_types.py` note); `spec.remote` rejected by `_V3_REMOVED_FIELDS["remote"]`. |
| `test_login_shell_from_yaml_can_be_false` | `login_shell` was a legacy `RemoteSpec` field; gone with `RemoteSpec`. No live `login_shell` in the schema. |

## Verification

- `tests/integration/test_config.py` -> **52 passed** (no breakage; imports intact).
- `scitex-dev linter check-files tests/integration/test_config.py --severity error` -> **"All files clean"** (the exact STX-TQ001 rule `test_audit_all_clean` runs, now passing).
- The full `test_audit_all_clean` couldn't complete locally (the `scitex-dev ecosystem audit-all` subprocess exceeds the test's 550s cap on this loaded host — a timing artifact, not an audit violation); CI runners audit within their budget.

Scope: **only** the 4 dead stubs are removed (46-line deletion, no other
change). The `scitex-dev` floor-pin policy is intentionally left untouched.
