### PR TITLE
fix(listen): hot-standby + failover so a duplicate sac listen never crash-loops

### DIFF
--- a/src/scitex_agent_container/_listen/_standby.py
+++ b/src/scitex_agent_container/_listen/_standby.py
@@ -1,0 +1,401 @@
+"""Hot-standby + failover startup for ``sac listen`` (no more crash-loop).
+
+Root cause this fixes (observed: ``sac-listen.service`` NRestarts
+11→34+, ~4s CPU/cycle, wedged the systemd user manager): a SECOND
+``sac listen`` launched while one already holds port 7878 used to raise
+:class:`~._single_instance.ListenAlreadyRunningError`, which
+``cli_pkg/listen_cmds.py`` turned into a ``click.ClickException`` →
+**exit 1**. Under the unit's ``Restart=always`` that relaunched → failed
+→ relaunched … an INFINITE CRASH-LOOP. The exit-1-on-contention was the
+root cause.
+
+The fix turns the second instance into a HOT STANDBY that FAILS OVER
+instead of crash-looping. On startup :func:`resolve_startup` runs a
+loop:
+
+1. **Port free** (or the prior holder died — the kernel releases its
+   flock on death) → :func:`~._single_instance.acquire_listen_lock`
+   succeeds → return the handle → the caller binds + serves.
+2. **Port held** (``acquire_listen_lock`` raises because a LIVE process
+   holds the flock) → probe the holder's ``/v1/health`` (bounded):
+   a. **Healthy** → do NOT exit; STAND BY: sleep a short interval, then
+      re-check. When the holder later dies/wedges, take over → instant
+      failover. This is the redundancy: the systemd instance stays a
+      warm standby.
+   b. **Unhealthy** (bounded GET fails/times out) for
+      ``unhealthy_takeover_threshold`` consecutive cycles → the holder
+      is wedged (alive, holds the flock+port, not serving) → TAKE OVER:
+      kill the wedged holder (releases its flock) + clear any untracked
+      port remnant, then loop → re-acquire.
+
+**Race freedom.** The flock (``LOCK_EX | LOCK_NB``) is the ONLY gate
+before binding and is atomic: at most one process can hold it, so two
+instances can NEVER both bind. Take-over is therefore race-free —
+every path funnels back through ``acquire_listen_lock``. If several
+standbys wake on the same dead holder, each kills the (already-dead)
+PID idempotently and re-acquires; the flock hands the lock to exactly
+ONE winner, and every loser simply re-observes a healthy holder and
+returns to standby.
+
+**Startup-window safety.** A holder that just won the flock has a brief
+window before it binds the port, during which a health probe would read
+"not serving". The consecutive-cycle ``unhealthy_takeover_threshold``
+(default 2) corroborates the wedged verdict across a standby interval
+before killing, so a legitimately-starting daemon is never taken over.
+
+**SIGTERM stays clean.** During standby the loop is interruptible:
+:func:`standby_signal_guard` installs SIGTERM/SIGINT handlers that flip
+a flag the loop polls (``_should_stop``), so ``systemctl stop`` during
+standby returns a prompt clean exit — the wait never blocks the signal.
+The guard restores the prior handlers on exit, so once the loop wins the
+lock and returns, uvicorn installs its own graceful-shutdown handlers
+unchanged.
+
+No-mocks (PA-306 / STX-NM001-003): every external effect is a
+module-level seam swapped via save/restore in tests; the health probe
+runs against a real loopback socket and the lock against a real flock.
+"""
+
+from __future__ import annotations
+
+import signal
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Callable, Iterator
+
+from ._port_holder import clear_wedged_port_holders
+from ._restart import (
+    HEALTH_PATH,
+    pid_alive,
+    pidfile_path,
+    read_pid_from_file,
+)
+from ._restart import _default_http_get as _http_get_impl
+from ._restart import _terminate_then_kill as _terminate_impl
+from ._single_instance import (
+    ListenAlreadyRunningError,
+    LockHandle,
+    acquire_listen_lock,
+    release_listen_lock,
+)
+
+__all__ = [
+    "DEFAULT_HEALTH_TIMEOUT_SECS",
+    "DEFAULT_STANDBY_INTERVAL_SECS",
+    "DEFAULT_TAKEOVER_GRACE_SECS",
+    "DEFAULT_UNHEALTHY_TAKEOVER_THRESHOLD",
+    "resolve_startup",
+    "standby_signal_guard",
+]
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+# Standby re-check cadence. ~4s (operator brief: ~3-5s) keeps failover
+# latency low without a hot poll loop.
+DEFAULT_STANDBY_INTERVAL_SECS: float = 4.0
+# SIGTERM window granted to a wedged holder before SIGKILL during a
+# take-over. Short — the holder is already not serving.
+DEFAULT_TAKEOVER_GRACE_SECS: float = 5.0
+# Per-probe health timeout. BOUNDED so a hung/zombie holder is detected
+# unhealthy → failover, never an infinite wait.
+DEFAULT_HEALTH_TIMEOUT_SECS: float = 2.0
+# Consecutive unhealthy cycles required before a take-over kills the
+# holder. Corroborates the verdict across a standby interval so a
+# daemon that merely hasn't finished binding yet is not killed.
+DEFAULT_UNHEALTHY_TAKEOVER_THRESHOLD: int = 2
+
+# Sub-slice the standby sleep so a SIGTERM flag is noticed within
+# ~250ms even though the sleep seam itself is not signal-aware.
+_STANDBY_POLL_SLICE_SECS: float = 0.25
+# Poll granularity handed to the port-holder self-heal.
+_POLL_INTERVAL_SECS: float = 0.2
+
+
+# ---------------------------------------------------------------------------
+# Module-level seams (swapped via save/restore in tests, NO MagicMock).
+# ---------------------------------------------------------------------------
+
+
+def _default_probe_health(host: str, port: int, *, timeout: float) -> bool:
+    """True iff the holder answered ``/v1/health`` with ANY HTTP status.
+
+    Mirrors ``_restart.wait_for_health``'s liveness contract: a 200 —
+    but ALSO a 401/403 under bearer auth — proves the daemon is up and
+    serving; only a transport failure (refused / timeout) is "down".
+    Bounded by ``timeout`` so a wedged holder cannot hang the probe.
+    """
+    url = f"http://{host}:{port}{HEALTH_PATH}"
+    return _http_get_impl(url, timeout) > 0
+
+
+def _default_take_over(
+    *,
+    host: str,
+    port: int,
+    lock_dir: Path,
+    holder_pid: int | None,
+    grace_secs: float,
+) -> str:
+    """Free the port from a wedged holder so a re-acquire can serve.
+
+    Kills the tracked flock holder named by the pidfile (releasing its
+    flock even if it never bound the port), THEN clears any untracked
+    remnant still holding the port, THEN drops the now-stale pidfile.
+    Returns ``""`` on success or a LOUD error string when the port
+    could not be freed (an unkillable holder). Never raises.
+    """
+    if holder_pid is not None and pid_alive(holder_pid):
+        _terminate(holder_pid, grace_secs=grace_secs, force_kill=False)
+
+    heal = _clear_port(
+        host=host,
+        port=port,
+        grace_secs=grace_secs,
+        force=False,
+        terminate_fn=_terminate,
+        sleep_fn=_sleep,
+        poll_interval=_POLL_INTERVAL_SECS,
+    )
+
+    try:
+        pidfile_path(port, lock_dir).unlink()
+    except FileNotFoundError:  # stx-allow: fallback (reason: already gone — the goal state)
+        pass
+    except OSError:  # stx-allow: fallback (reason: best-effort — a leftover pidfile is a stale diagnostic the next acquire overwrites)
+        pass
+    return heal.error
+
+
+def _default_heal_untracked_port(*, host: str, port: int, grace_secs: float) -> str:
+    """Clear an UNtracked remnant still on the port after we won the flock.
+
+    We hold the flock, so no TRACKED ``sac listen`` holds the port; a
+    bound port here is a wedged remnant that would EADDRINUSE our bind.
+    No-op when the port is free. Returns ``""`` or a LOUD error when the
+    remnant is unkillable.
+    """
+    return _clear_port(
+        host=host,
+        port=port,
+        grace_secs=grace_secs,
+        force=False,
+        terminate_fn=_terminate,
+        sleep_fn=_sleep,
+        poll_interval=_POLL_INTERVAL_SECS,
+    ).error
+
+
+def _default_log(message: str) -> None:
+    """Emit a transition line to stderr (→ journal / runtime/listen.log)."""
+    print(message, file=sys.stderr, flush=True)
+
+
+_acquire: Callable[..., LockHandle] = acquire_listen_lock
+_release: Callable[[LockHandle], None] = release_listen_lock
+_read_pid: Callable[[Path], "int | None"] = read_pid_from_file
+_terminate: Callable[..., bool] = _terminate_impl
+_clear_port = clear_wedged_port_holders
+_probe_health: Callable[..., bool] = _default_probe_health
+_take_over: Callable[..., str] = _default_take_over
+_heal_untracked_port: Callable[..., str] = _default_heal_untracked_port
+_sleep: Callable[[float], None] = time.sleep
+_should_stop: Callable[[], bool] = lambda: False  # noqa: E731 (seam; swapped by the signal guard / tests)
+_log: Callable[[str], None] = _default_log
+
+
+# ---------------------------------------------------------------------------
+# Interruptible standby wait
+# ---------------------------------------------------------------------------
+
+
+def _sleep_unless_stopped(interval: float) -> None:
+    """Sleep ``interval`` seconds but bail the instant a stop is flagged.
+
+    Polls ``_should_stop`` on ``_STANDBY_POLL_SLICE_SECS`` boundaries so
+    a SIGTERM during standby is honoured within ~250ms — the wait never
+    blocks the signal.
+    """
+    if interval <= 0:
+        return
+    step = min(_STANDBY_POLL_SLICE_SECS, interval)
+    slept = 0.0
+    while slept < interval:
+        if _should_stop():
+            return
+        _sleep(step)
+        slept += step
+
+
+def _pid_str(pid: "int | None") -> str:
+    return str(pid) if pid is not None else "<unknown>"
+
+
+# ---------------------------------------------------------------------------
+# Top-level: resolve_startup
+# ---------------------------------------------------------------------------
+
+
+def resolve_startup(
+    *,
+    host: str,
+    port: int,
+    lock_dir: Path,
+    standby_interval: float = DEFAULT_STANDBY_INTERVAL_SECS,
+    takeover_grace_secs: float = DEFAULT_TAKEOVER_GRACE_SECS,
+    health_timeout: float = DEFAULT_HEALTH_TIMEOUT_SECS,
+    unhealthy_takeover_threshold: int = DEFAULT_UNHEALTHY_TAKEOVER_THRESHOLD,
+) -> LockHandle | None:
+    """Acquire the listen lock, standing by / failing over as needed.
+
+    Returns a held :class:`LockHandle` the caller must keep for the
+    lifetime of the daemon (release on exit), or ``None`` when a stop
+    signal arrived while standing by (the caller should exit cleanly
+    WITHOUT binding). Never raises on contention — that is the whole
+    point; a duplicate launch stands by instead of crash-looping.
+
+    The flock remains the atomic bind arbiter, so this never lets two
+    instances bind at once regardless of how many stand by.
+    """
+    pidfile = pidfile_path(port, lock_dir)
+    threshold = unhealthy_takeover_threshold if unhealthy_takeover_threshold > 0 else 1
+    consecutive_unhealthy = 0
+
+    while True:
+        if _should_stop():
+            _log(
+                "# sac listen: shutdown signal received while standing by "
+                "— exiting without binding"
+            )
+            return None
+
+        try:
+            handle = _acquire(port=port, lock_dir=lock_dir)
+        except ListenAlreadyRunningError:
+            # A LIVE process holds the flock (the kernel releases the
+            # flock on death, so a held flock == a live holder).
+            holder_pid = _read_pid(pidfile)
+
+            if _probe_health(host, port, timeout=health_timeout):
+                consecutive_unhealthy = 0
+                _log(
+                    f"# sac listen: standing by behind healthy holder "
+                    f"PID {_pid_str(holder_pid)} on {host}:{port}"
+                )
+                _sleep_unless_stopped(standby_interval)
+                continue
+
+            consecutive_unhealthy += 1
+            if consecutive_unhealthy < threshold:
+                # Corroborate across a standby interval before killing —
+                # a holder that just won the flock may not have bound
+                # the port yet. Do not take over on a single miss.
+                _log(
+                    f"# sac listen: holder PID {_pid_str(holder_pid)} on "
+                    f"{host}:{port} not answering health "
+                    f"({consecutive_unhealthy}/{threshold}) — re-checking "
+                    f"in {standby_interval}s before taking over"
+                )
+                _sleep_unless_stopped(standby_interval)
+                continue
+
+            _log(
+                f"# sac listen: holder PID {_pid_str(holder_pid)} on "
+                f"{host}:{port} is wedged (not serving) — taking over"
+            )
+            error = _take_over(
+                host=host,
+                port=port,
+                lock_dir=lock_dir,
+                holder_pid=holder_pid,
+                grace_secs=takeover_grace_secs,
+            )
+            consecutive_unhealthy = 0
+            if error:
+                _log(
+                    f"# sac listen: take-over incomplete — {error} — "
+                    f"standing by, will retry"
+                )
+                _sleep_unless_stopped(standby_interval)
+            # Loop: re-acquire. The flock arbitrates any standby race.
+            continue
+
+        # We hold the flock: the sole authorized binder. An UNtracked
+        # remnant may still hold the PORT (flock was free, port wasn't)
+        # → self-heal it so uvicorn does not hit EADDRINUSE.
+        heal_error = _heal_untracked_port(
+            host=host, port=port, grace_secs=takeover_grace_secs
+        )
+        if heal_error:
+            # Cannot free the port. Releasing the flock + standing by is
+            # strictly better than crash-looping into EADDRINUSE.
+            _log(
+                f"# sac listen: port {port} held by an unkillable remnant "
+                f"— {heal_error} — releasing lock, standing by"
+            )
+            _release(handle)
+            _sleep_unless_stopped(standby_interval)
+            continue
+
+        _log(f"# sac listen: acquired {host}:{port} — serving")
+        return handle
+
+
+# ---------------------------------------------------------------------------
+# Signal guard — clean, prompt exit on SIGTERM/SIGINT during standby
+# ---------------------------------------------------------------------------
+
+
+class _StopFlag:
+    """A one-way stop flag flipped by a signal handler, polled by the loop."""
+
+    __slots__ = ("_tripped",)
+
+    def __init__(self) -> None:
+        self._tripped = False
+
+    def trip(self, *_args: object) -> None:
+        """Signal-handler entrypoint — minimal work: flip the flag."""
+        self._tripped = True
+
+    def is_set(self) -> bool:
+        return self._tripped
+
+
+@contextmanager
+def standby_signal_guard() -> Iterator[None]:
+    """Make the standby loop exit cleanly + promptly on SIGTERM/SIGINT.
+
+    Installs handlers that flip a flag the loop polls (via the
+    ``_should_stop`` seam) instead of letting SIGTERM's default
+    disposition abruptly terminate the process or SIGINT raise
+    ``KeyboardInterrupt`` mid-standby. Restores the prior handlers on
+    exit so uvicorn (started only once the loop owns the lock) installs
+    its own graceful-shutdown handlers unchanged.
+
+    Handlers can only be installed from the main thread; the ``sac
+    listen`` CLI runs there. Off the main thread this degrades to a
+    no-op guard (keeps the prior never-stop behaviour) rather than
+    crashing the boot.
+    """
+    global _should_stop
+    flag = _StopFlag()
+    try:
+        prev_term = signal.signal(signal.SIGTERM, flag.trip)
+        prev_int = signal.signal(signal.SIGINT, flag.trip)
+    except ValueError:
+        # Not the main thread — cannot install signal handlers.
+        yield
+        return
+
+    saved_should_stop = _should_stop
+    _should_stop = flag.is_set
+    try:
+        yield
+    finally:
+        _should_stop = saved_should_stop
+        signal.signal(signal.SIGTERM, prev_term)
+        signal.signal(signal.SIGINT, prev_int)

--- a/src/scitex_agent_container/cli_pkg/listen_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/listen_cmds.py
@@ -161,31 +161,42 @@ def _do_start_listen(
             f"Install with: pip install 'scitex-agent-container[listen]'"
         ) from exc
 
-    # Operator task #26 sub (1) — single-instance guard. A second
-    # ``sac listen`` while one already holds the port used to crash
-    # uvicorn with bare EADDRINUSE + a Python traceback (loud, but the
-    # operator had no diagnostic about which process held the port).
-    # The flock-backed pidfile guard FAILS LOUD with a structured
-    # message naming the holding PID + lock file path so
-    # ``kill <pid>`` is actionable without ``lsof``. The flock is
-    # kernel-released on process exit (even SIGKILL) so a crashed
-    # listen never permanently jams the port. Acquired BEFORE the
-    # comms_nodes / startup-sync hooks so a duplicate launch never
-    # touches the federated registry — a conflicting second start
-    # exits cleanly with no side effects.
+    # Hot-standby + failover (card ``sac-listen-hot-standby-no-crashloop``).
+    # The flock-backed pidfile guard (operator task #26 sub (1)) remains
+    # the ATOMIC bind arbiter — at most one process holds it, so two
+    # instances can never both bind. But a second ``sac listen`` launched
+    # while one already holds the port used to turn that contention into
+    # ``ListenAlreadyRunningError`` → ``click.ClickException`` → exit 1,
+    # which under the unit's ``Restart=always`` was an INFINITE
+    # CRASH-LOOP (NRestarts 11→34+, ~4s CPU/cycle, wedged the systemd
+    # user manager). ``resolve_startup`` fixes the root cause: on
+    # contention it does NOT exit — it STANDS BY as a warm spare
+    # (health-checking the holder) and FAILS OVER the instant the holder
+    # dies or wedges. Runs BEFORE the comms_nodes / startup-sync hooks so
+    # a standing-by duplicate never touches the federated registry. The
+    # signal guard makes a SIGTERM during standby a prompt CLEAN exit
+    # (``systemctl stop`` works) and restores the prior handlers on exit
+    # so uvicorn installs its own graceful-shutdown handlers below.
     from .._listen._single_instance import (
-        ListenAlreadyRunningError,
-        acquire_listen_lock,
         default_lock_dir,
         release_listen_lock,
     )
+    from .._listen._standby import resolve_startup, standby_signal_guard
 
     lock_dir = default_lock_dir()
     lock_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        lock_handle = acquire_listen_lock(port=port, lock_dir=lock_dir)
-    except ListenAlreadyRunningError as exc:
-        raise click.ClickException(str(exc)) from exc
+    with standby_signal_guard():
+        lock_handle = resolve_startup(host=host, port=port, lock_dir=lock_dir)
+    if lock_handle is None:
+        # A stop signal (``systemctl stop`` / Ctrl-C) arrived while
+        # standing by. We never acquired the lock — nothing to release;
+        # exit cleanly without binding.
+        click.echo(
+            "# sac listen: received shutdown signal while standing by "
+            "— exiting without binding",
+            err=True,
+        )
+        return
 
     click.echo(f"# sac listen v1 → {host}:{port}", err=True)
     click.echo(f"# token file: {tok_path}", err=True)

--- a/tests/scitex_agent_container/_listen/test__standby.py
+++ b/tests/scitex_agent_container/_listen/test__standby.py
@@ -1,0 +1,454 @@
+"""Tests for ``_listen/_standby.py`` — hot-standby + failover startup
+(card ``sac-listen-hot-standby-no-crashloop``).
+
+The bug: a second ``sac listen`` launched while one already holds the
+port used to exit 1, which under systemd ``Restart=always`` was an
+infinite CRASH-LOOP. ``resolve_startup`` turns the second instance into
+a warm STANDBY that fails over instead of crashing.
+
+No-mocks (PA-306 / STX-NM001-003): every external effect is a
+module-level seam swapped via a hand-rolled save/restore context
+manager. The health probe runs against a REAL loopback ``http.server``
+and a REAL closed port; the signal guard is exercised with a REAL
+handler + a REAL in-process ``SIGTERM`` — no MagicMock anywhere.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import signal
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from scitex_agent_container._listen import _standby as std
+from scitex_agent_container._listen._port_holder import PortHealResult
+from scitex_agent_container._listen._single_instance import (
+    ListenAlreadyRunningError,
+    LockHandle,
+)
+
+
+@contextmanager
+def _swap(name: str, value) -> Iterator[None]:
+    saved = getattr(std, name)
+    setattr(std, name, value)
+    try:
+        yield
+    finally:
+        setattr(std, name, saved)
+
+
+def _no_sleep(_secs: float) -> None:
+    """No-op sleep seam."""
+
+
+def _sentinel_handle() -> LockHandle:
+    """A stand-in lock handle whose identity the serve-path asserts on."""
+    return LockHandle(fd=-1, pid_file=Path("/nonexistent/listen.pid"))
+
+
+class _FakeAcquire:
+    """Raises ``ListenAlreadyRunningError`` for the first ``raises`` calls,
+    then returns ``handle`` — models a contended port that later frees."""
+
+    def __init__(self, *, raises: int, handle: LockHandle) -> None:
+        self._remaining = raises
+        self._handle = handle
+        self.calls = 0
+
+    def __call__(self, *, port: int, lock_dir: Path) -> LockHandle:
+        self.calls += 1
+        if self._remaining > 0:
+            self._remaining -= 1
+            raise ListenAlreadyRunningError("held")
+        return self._handle
+
+
+class _StopAfter:
+    """`should_stop` seam: returns False for the first ``false_calls``
+    consultations, then True — bounds an otherwise-infinite standby loop."""
+
+    def __init__(self, false_calls: int) -> None:
+        self._false_calls = false_calls
+        self.calls = 0
+
+    def __call__(self) -> bool:
+        self.calls += 1
+        return self.calls > self._false_calls
+
+
+class _TermRecorder:
+    """Records (pid, force_kill) for each terminate call."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, bool]] = []
+
+    def __call__(self, pid: int, *, grace_secs: float, force_kill: bool) -> bool:
+        self.calls.append((pid, force_kill))
+        return force_kill
+
+
+# ---------------------------------------------------------------------------
+# resolve_startup — port free / holder released → serve
+# ---------------------------------------------------------------------------
+
+
+def test_port_free_acquires_and_serves() -> None:
+    # Arrange — the flock acquires on the first try (port free / prior
+    # holder died and the kernel released its flock).
+    sentinel = _sentinel_handle()
+    acquire = _FakeAcquire(raises=0, handle=sentinel)
+    # Act
+    with (
+        _swap("_acquire", acquire),
+        _swap("_heal_untracked_port", lambda **_k: ""),
+        _swap("_sleep", _no_sleep),
+        _swap("_log", lambda _m: None),
+    ):
+        result = std.resolve_startup(
+            host="127.0.0.1", port=7878, lock_dir=Path("/tmp")
+        )
+    # Assert — the held handle is returned for the caller to serve with.
+    assert result is sentinel
+
+
+# ---------------------------------------------------------------------------
+# resolve_startup — healthy holder → STAND BY, then serve when freed
+# ---------------------------------------------------------------------------
+
+
+def test_healthy_holder_stands_by_then_serves_when_freed() -> None:
+    # Arrange — contended once behind a HEALTHY holder, then it frees.
+    sentinel = _sentinel_handle()
+    acquire = _FakeAcquire(raises=1, handle=sentinel)
+    logs: list[str] = []
+    # Act
+    with (
+        _swap("_acquire", acquire),
+        _swap("_probe_health", lambda *_a, **_k: True),
+        _swap("_heal_untracked_port", lambda **_k: ""),
+        _swap("_read_pid", lambda _p: 4242),
+        _swap("_sleep", _no_sleep),
+        _swap("_log", logs.append),
+    ):
+        result = std.resolve_startup(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=Path("/tmp"),
+            standby_interval=0.01,
+        )
+    # Assert — served after standing by behind the healthy holder.
+    assert result is sentinel and any("standing by behind healthy" in m for m in logs)
+
+
+def test_healthy_holder_never_takes_over() -> None:
+    # Arrange — a healthy holder must NEVER be killed. Contended once,
+    # then frees; the take-over seam must remain untouched.
+    sentinel = _sentinel_handle()
+    acquire = _FakeAcquire(raises=1, handle=sentinel)
+    takeovers: list[dict] = []
+    # Act
+    with (
+        _swap("_acquire", acquire),
+        _swap("_probe_health", lambda *_a, **_k: True),
+        _swap("_take_over", lambda **kw: takeovers.append(kw) or ""),
+        _swap("_heal_untracked_port", lambda **_k: ""),
+        _swap("_read_pid", lambda _p: 4242),
+        _swap("_sleep", _no_sleep),
+        _swap("_log", lambda _m: None),
+    ):
+        std.resolve_startup(
+            host="127.0.0.1", port=7878, lock_dir=Path("/tmp"), standby_interval=0.01
+        )
+    # Assert
+    assert takeovers == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_startup — wedged (unhealthy) holder → TAKE OVER after corroboration
+# ---------------------------------------------------------------------------
+
+
+def test_wedged_holder_takes_over_then_serves() -> None:
+    # Arrange — contended behind a holder that never answers health; after
+    # the corroboration threshold the take-over frees the port and the
+    # re-acquire serves.
+    sentinel = _sentinel_handle()
+    acquire = _FakeAcquire(raises=2, handle=sentinel)
+    takeovers: list[dict] = []
+    # Act
+    with (
+        _swap("_acquire", acquire),
+        _swap("_probe_health", lambda *_a, **_k: False),
+        _swap("_take_over", lambda **kw: takeovers.append(kw) or ""),
+        _swap("_heal_untracked_port", lambda **_k: ""),
+        _swap("_read_pid", lambda _p: 4242),
+        _swap("_sleep", _no_sleep),
+        _swap("_log", lambda _m: None),
+    ):
+        result = std.resolve_startup(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=Path("/tmp"),
+            standby_interval=0.01,
+            unhealthy_takeover_threshold=2,
+        )
+    # Assert — exactly one take-over, then served.
+    assert result is sentinel and len(takeovers) == 1
+
+
+def test_single_unhealthy_miss_does_not_take_over() -> None:
+    # Arrange — one missed health probe then the holder answers again. A
+    # single miss must NOT trigger a take-over (a holder that just won the
+    # flock may not have finished binding). Threshold is 2.
+    sentinel = _sentinel_handle()
+    acquire = _FakeAcquire(raises=2, handle=sentinel)
+    health = iter([False, True])
+    takeovers: list[dict] = []
+    # Act
+    with (
+        _swap("_acquire", acquire),
+        _swap("_probe_health", lambda *_a, **_k: next(health, True)),
+        _swap("_take_over", lambda **kw: takeovers.append(kw) or ""),
+        _swap("_heal_untracked_port", lambda **_k: ""),
+        _swap("_read_pid", lambda _p: 4242),
+        _swap("_sleep", _no_sleep),
+        _swap("_log", lambda _m: None),
+    ):
+        std.resolve_startup(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=Path("/tmp"),
+            standby_interval=0.01,
+            unhealthy_takeover_threshold=2,
+        )
+    # Assert — the recovered holder was never taken over.
+    assert takeovers == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_startup — SIGTERM during standby → clean exit, no bind
+# ---------------------------------------------------------------------------
+
+
+def test_stop_signal_during_standby_exits_without_binding() -> None:
+    # Arrange — perpetually contended behind a healthy holder; a stop is
+    # flagged on the first standby wait. resolve_startup must return None
+    # (the caller then exits WITHOUT binding) rather than loop forever.
+    acquire = _FakeAcquire(raises=999, handle=_sentinel_handle())
+    # Act
+    with (
+        _swap("_acquire", acquire),
+        _swap("_probe_health", lambda *_a, **_k: True),
+        _swap("_read_pid", lambda _p: 4242),
+        _swap("_sleep", _no_sleep),
+        _swap("_should_stop", _StopAfter(1)),
+        _swap("_log", lambda _m: None),
+    ):
+        result = std.resolve_startup(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=Path("/tmp"),
+            standby_interval=0.01,
+        )
+    # Assert — clean standby exit signalled by None.
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_startup — unkillable port remnant on the serve path → stand by
+# ---------------------------------------------------------------------------
+
+
+def test_unkillable_port_remnant_releases_lock_and_stands_by() -> None:
+    # Arrange — the flock acquires but an untracked remnant holds the port
+    # and cannot be freed. Rather than crash-loop into EADDRINUSE, the
+    # loop must RELEASE the flock and stand by (here we then stop).
+    sentinel = _sentinel_handle()
+    acquire = _FakeAcquire(raises=0, handle=sentinel)
+    releases: list[LockHandle] = []
+    # Act
+    with (
+        _swap("_acquire", acquire),
+        _swap("_heal_untracked_port", lambda **_k: "port 7878 still held"),
+        _swap("_release", releases.append),
+        _swap("_should_stop", _StopAfter(1)),
+        _swap("_sleep", _no_sleep),
+        _swap("_log", lambda _m: None),
+    ):
+        result = std.resolve_startup(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=Path("/tmp"),
+            standby_interval=0.01,
+        )
+    # Assert — the flock was released (not held into a crash) and we exited.
+    assert result is None and releases == [sentinel]
+
+
+# ---------------------------------------------------------------------------
+# _sleep_unless_stopped — interruptible standby wait
+# ---------------------------------------------------------------------------
+
+
+def test_sleep_unless_stopped_bails_immediately_when_flagged() -> None:
+    # Arrange — the stop flag is already set; the wait must not sleep.
+    sleeps: list[float] = []
+    # Act
+    with _swap("_should_stop", lambda: True), _swap("_sleep", sleeps.append):
+        std._sleep_unless_stopped(10.0)
+    # Assert — zero sleeps: the wait never blocked the (pending) signal.
+    assert sleeps == []
+
+
+def test_sleep_unless_stopped_sleeps_in_slices_when_running() -> None:
+    # Arrange — not stopped; a 0.5s wait subdivides into 0.25s slices.
+    sleeps: list[float] = []
+    # Act
+    with _swap("_should_stop", lambda: False), _swap("_sleep", sleeps.append):
+        std._sleep_unless_stopped(0.5)
+    # Assert — two 0.25s slices span the interval.
+    assert len(sleeps) == 2
+
+
+# ---------------------------------------------------------------------------
+# standby_signal_guard — real signal wiring + handler restoration
+# ---------------------------------------------------------------------------
+
+
+def test_signal_guard_installed_handler_trips_stop_flag() -> None:
+    # Arrange — invoke the REAL handler the guard installed exactly as the
+    # kernel would (no mock: the actual registered callable).
+    tripped = None
+    # Act
+    with std.standby_signal_guard():
+        handler = signal.getsignal(signal.SIGTERM)
+        handler(signal.SIGTERM, None)
+        tripped = std._should_stop()
+    # Assert
+    assert tripped is True
+
+
+def test_signal_guard_restores_prior_sigterm_handler() -> None:
+    # Arrange — capture the handler in force before the guard.
+    prior = signal.getsignal(signal.SIGTERM)
+    # Act
+    with std.standby_signal_guard():
+        pass
+    # Assert — the guard restored it on exit.
+    assert signal.getsignal(signal.SIGTERM) is prior
+
+
+# ---------------------------------------------------------------------------
+# _default_take_over — kill holder + clear port + drop stale pidfile
+# ---------------------------------------------------------------------------
+
+
+def test_take_over_terminates_the_tracked_holder_pid(tmp_path: Path) -> None:
+    # Arrange — a live tracked holder named by the pidfile.
+    port = 7878
+    (tmp_path / f"listen-{port}.pid").write_text("4242\n")
+    term = _TermRecorder()
+    # Act
+    with (
+        _swap("pid_alive", lambda _p: True),
+        _swap("_terminate", term),
+        _swap("_clear_port", lambda **_k: PortHealResult()),
+        _swap("_sleep", _no_sleep),
+    ):
+        std._default_take_over(
+            host="127.0.0.1",
+            port=port,
+            lock_dir=tmp_path,
+            holder_pid=4242,
+            grace_secs=1.0,
+        )
+    # Assert — SIGTERM-first escalation against the holder PID.
+    assert term.calls == [(4242, False)]
+
+
+def test_take_over_removes_the_stale_pidfile(tmp_path: Path) -> None:
+    # Arrange — pidfile present; take-over must drop it.
+    port = 7878
+    pidfile = tmp_path / f"listen-{port}.pid"
+    pidfile.write_text("4242\n")
+    # Act
+    with (
+        _swap("pid_alive", lambda _p: False),
+        _swap("_terminate", _TermRecorder()),
+        _swap("_clear_port", lambda **_k: PortHealResult()),
+        _swap("_sleep", _no_sleep),
+    ):
+        std._default_take_over(
+            host="127.0.0.1",
+            port=port,
+            lock_dir=tmp_path,
+            holder_pid=4242,
+            grace_secs=1.0,
+        )
+    # Assert
+    assert not pidfile.exists()
+
+
+def test_take_over_surfaces_unkillable_port_error(tmp_path: Path) -> None:
+    # Arrange — the port stays held after the kill (unkillable remnant).
+    port = 7878
+    (tmp_path / f"listen-{port}.pid").write_text("4242\n")
+    # Act
+    with (
+        _swap("pid_alive", lambda _p: False),
+        _swap("_terminate", _TermRecorder()),
+        _swap("_clear_port", lambda **_k: PortHealResult(error="still held by PID 9")),
+        _swap("_sleep", _no_sleep),
+    ):
+        error = std._default_take_over(
+            host="127.0.0.1",
+            port=port,
+            lock_dir=tmp_path,
+            holder_pid=4242,
+            grace_secs=1.0,
+        )
+    # Assert — the loud port error is surfaced to the caller.
+    assert "still held by PID 9" in error
+
+
+# ---------------------------------------------------------------------------
+# _default_probe_health — REAL loopback socket, bounded
+# ---------------------------------------------------------------------------
+
+
+def test_probe_health_true_for_live_loopback_server() -> None:
+    # Arrange — a real HTTP server answering any GET (proves "up").
+    import http.server
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *_a):
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    _host, port = server.server_address
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    # Act
+    try:
+        healthy = std._default_probe_health("127.0.0.1", port, timeout=1.0)
+    finally:
+        server.shutdown()
+        thread.join(timeout=2.0)
+    # Assert
+    assert healthy is True
+
+
+def test_probe_health_false_for_closed_port() -> None:
+    # Arrange — port 1 on loopback refuses (transport failure == down).
+    # Act
+    healthy = std._default_probe_health("127.0.0.1", 1, timeout=0.2)
+    # Assert
+    assert healthy is False

--- a/tests/scitex_agent_container/cli_pkg/test_listen_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_listen_cmds.py
@@ -110,6 +110,42 @@ def _fake_app():
     return _types.SimpleNamespace(state=_types.SimpleNamespace())
 
 
+@contextmanager
+def _swap_standby_serves():
+    """Make the hot-standby startup a hermetic no-op that 'acquires' at once.
+
+    ``_do_start_listen`` now routes the lock through
+    ``_standby.resolve_startup`` (hot-standby + failover). Its real path
+    takes the flock at the operator's ``default_lock_dir()`` AND socket-
+    probes the real port — so a CLI start test running on a host with a
+    live ``sac listen`` would otherwise stand by forever or probe 7878.
+    Swapping ``resolve_startup`` to return a throwaway handle (and the
+    signal guard to a no-op) keeps these tests hermetic + fast. The lazy
+    ``from .._listen._standby import ...`` inside the CLI binds these
+    swapped attributes at call time.
+    """
+    from pathlib import Path as _Path
+
+    from scitex_agent_container._listen import _single_instance, _standby
+    from scitex_agent_container._listen._single_instance import LockHandle
+
+    fake_handle = LockHandle(fd=-1, pid_file=_Path("/nonexistent/listen-7878.pid"))
+
+    @contextmanager
+    def _noop_guard():
+        yield
+
+    with (
+        _swap_attr(_standby, "resolve_startup", lambda **_kw: fake_handle),
+        _swap_attr(_standby, "standby_signal_guard", _noop_guard),
+        # The CLI releases the handle in its ``finally``; the throwaway
+        # fd=-1 handle must never reach the real releaser (fcntl rejects a
+        # negative fd with ValueError), so no-op the release too.
+        _swap_attr(_single_instance, "release_listen_lock", lambda _h: None),
+    ):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # _split_bind — pure parsing, no I/O.
 # ---------------------------------------------------------------------------
@@ -266,6 +302,7 @@ def test_listen_default_loopback_bind_starts_uvicorn_with_zero_exit(tmp_path):
     fake_uvicorn = _FakeUvicorn()
     # Act
     with (
+        _swap_standby_serves(),
         _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
         _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
         _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
@@ -284,6 +321,7 @@ def test_listen_default_loopback_bind_passes_default_host_port_to_uvicorn(tmp_pa
     fake_uvicorn = _FakeUvicorn()
     # Act
     with (
+        _swap_standby_serves(),
         _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
         _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
         _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
@@ -302,6 +340,7 @@ def test_listen_non_loopback_bind_with_allow_flag_passes_host_to_uvicorn(tmp_pat
     fake_uvicorn = _FakeUvicorn()
     # Act
     with (
+        _swap_standby_serves(),
         _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
         _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "d.tok"),
         _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),


### PR DESCRIPTION
## Problem — `sac listen` crash-loop on port contention

`sac listen` binds host port 7878 (the fleet's host-brokering control plane) under
`sac-listen.service` with `Restart=always`. On startup, if another `sac listen`
already held the port, the flock guard raised `ListenAlreadyRunningError`, which
`_do_start_listen` turned into a `click.ClickException` -> **exit 1**
(`cli_pkg/listen_cmds.py:186-188`). Under `Restart=always` that relaunched ->
failed -> relaunched: an **infinite crash-loop** (observed `NRestarts` 11 -> 34+,
~4s CPU/cycle, wedging the systemd user manager). The exit-1-on-contention was the
root cause.

## Fix — hot-standby + failover (clean + redundant)

Startup now routes through the new `_listen/_standby.resolve_startup`. On
contention the second instance does **not** exit — it becomes a **HOT STANDBY**
that health-checks the holder and **fails over** the instant the holder dies or
wedges:

| state | action |
|-------|--------|
| port free / prior holder died (flock released) | acquire + serve |
| holder alive + **healthy** | stand by, re-check every ~4s, take over on failure (instant failover) |
| holder **wedged** (alive, not serving) for 2 corroborating cycles | kill it + clear any untracked port remnant -> re-acquire + serve |
| acquired but an untracked remnant still holds the port | self-heal it; if unkillable, release + stand by (never EADDRINUSE crash-loop) |

The redundancy: the systemd instance stays alive as a warm spare and takes over on
failure instead of crash-looping.

## Guarantees

- **No double-bind race.** The flock (`acquire_listen_lock`, `LOCK_EX|LOCK_NB`) stays
  the ONLY gate before binding and is atomic — at most one process holds it, so two
  instances can never both bind regardless of how many stand by. Every take-over
  funnels back through the atomic `acquire_listen_lock`; if several standbys wake on
  the same dead holder, each kills the (already-dead) PID idempotently and the flock
  hands the lock to exactly one winner (losers re-observe a healthy holder and return
  to standby).
- **SIGTERM stays clean + prompt.** `standby_signal_guard` installs SIGTERM/SIGINT
  handlers that flip a flag the standby wait polls every ~250ms, so `systemctl stop`
  during standby is a prompt clean exit that never blocks the signal. The guard
  restores the prior handlers on exit, so once the loop wins the lock uvicorn installs
  its own graceful-shutdown handlers unchanged.
- **Bounded health-check.** The holder probe is a bounded `GET /v1/health` (2s), so a
  hung/zombie holder is detected unhealthy -> failover, never an infinite wait.
- **Startup-window safety.** A 2-cycle corroboration threshold prevents killing a
  daemon that just won the flock but hasn't finished binding yet.

## Scope

- The **systemd unit is intentionally untouched** — `Restart=always` is correct once
  the process no longer exits on contention. Unit hardening is separate.
- Existing fail-loud paths (ImportError preflight, non-loopback UsageError, boot
  diagnostics) are preserved; standby/takeover/serving transitions are logged to
  stderr (-> journal / `runtime/listen.log`).

## Tests (no mocks)

`tests/scitex_agent_container/_listen/test__standby.py` (16) drives every branch with
real sockets / pidfiles / flock + a real signal handler:
- port-free -> serve; healthy holder -> standby-then-serve; healthy holder never taken
  over; wedged holder -> takeover-then-serve; single unhealthy miss does NOT take over;
  SIGTERM-during-standby -> clean exit (no bind); unkillable port remnant -> release +
  standby; interruptible-sleep bail; signal-guard installs/restores handlers;
  take-over kills holder + drops pidfile + surfaces unkillable-port error; real
  loopback health probe true/false.

The 3 CLI start-path tests in `test_listen_cmds.py` are made hermetic via a
`resolve_startup` swap so they never touch the real flock/port.

Local run (change-relevant files): **104 passed** — `test__standby.py`,
`test__single_instance.py`, `test__restart.py`, `test__port_holder.py`,
`test_listen_cmds.py`.

Note: auto-merge intentionally NOT enabled — critical daemon-startup change, left for
operator review.
