### PR TITLE
fix(tests): stop the apptainer build shim littering the repo root with `--fakeroot`

### DIFF
--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -83,25 +83,46 @@ def state_root(tmp_path: Path, env_save_restore, home_redirect: Path) -> Path:
 @pytest.fixture
 def apptainer_on_path(subprocess_shim) -> Path:
     """Install a fake ``apptainer`` binary on ``$PATH`` that, when
-    invoked as ``apptainer build <out.sif> <src>``, creates the output
-    file. Otherwise it's a no-op (exit 0).
+    invoked as ``apptainer build [--fakeroot] <out.sif> <src>``, creates
+    the output file. Otherwise it's a no-op (exit 0).
 
     ``shutil.which("apptainer")`` finds this binary by a real PATH
     lookup — no ``which`` monkeypatching.
+
+    The SIF is located by SCANNING the post-``build`` args for the first
+    ``.sif`` positional — never by a fixed index. Production's build argv
+    carries an OPTIONAL ``--fakeroot``: ``_build_argv_prefix`` appends it
+    whenever the host has ``/etc/sub{u,g}id`` mappings for a non-root
+    user — true on the GitHub runner AND inside the agent container — so
+    ``sys.argv[2]`` is that FLAG, not the SIF. Writing that index blindly
+    made this shim create a 1-NULL-byte file literally named
+    ``--fakeroot`` in the launch cwd, i.e. the REPO ROOT under pytest.
+    The project audit then correctly failed it (PS-103
+    top-level-junk-file) and reddened every PR, while the 9.6k tests
+    themselves stayed green — self-inflicted, self-detected.
+
+    A relative target is refused outright (exit 2) so this class of bug
+    can never silently litter the repo root again: a future drift fails
+    the test loudly instead of dropping junk next to ``pyproject.toml``.
     """
     bin_dir = subprocess_shim._bin
     script = bin_dir / "apptainer"
-    # Argv layout for build: ["build", "<sif>", "<src>"]. The shim
-    # *writes the .sif file* so production's `sif_path.is_file()` check
-    # passes after the call returns — honest end-to-end behaviour.
+    # The shim *writes the .sif file* so production's `sif_path.is_file()`
+    # check passes after the call returns — honest end-to-end behaviour.
     body = (
         f"#!{sys.executable}\n"
         "import json, sys\n"
         "from pathlib import Path\n"
         f"with open({_q(str(bin_dir / 'apptainer.argv.jsonl'))}, 'a') as fh:\n"
         "    fh.write(json.dumps(sys.argv[1:]) + '\\n')\n"
-        "if len(sys.argv) >= 3 and sys.argv[1] == 'build':\n"
-        "    Path(sys.argv[2]).write_bytes(b'\\x00')\n"
+        "args = sys.argv[1:]\n"
+        "if args[:1] == ['build']:\n"
+        "    sif = next((a for a in args[1:] if a.endswith('.sif')), None)\n"
+        "    if sif is not None:\n"
+        "        if not Path(sif).is_absolute():\n"
+        "            sys.stderr.write('shim refuses relative SIF path: ' + sif)\n"
+        "            sys.exit(2)\n"
+        "        Path(sif).write_bytes(b'\\x00')\n"
         "sys.exit(0)\n"
     )
     script.write_text(body)
@@ -500,6 +521,58 @@ def test_argv_forwards_autonomous_max_turns_value(tmp_path: Path) -> None:
     )
     # Assert
     assert inner[inner.index("--autonomous-max-turns") + 1] == "7"
+
+
+# ---------------------------------------------------------------------------
+# apptainer_on_path shim — must never litter the launch cwd
+#
+# Regression guard for the CI-blocking stray `--fakeroot` file. Production's
+# build argv is `apptainer build [--fakeroot] <sif> <src>`; the shim used to
+# write `sys.argv[2]` blindly, which IS `--fakeroot` whenever the host has
+# /etc/sub{u,g}id mappings. Under pytest the launch cwd is the repo root, so
+# the shim dropped a 1-NULL-byte `--fakeroot` file next to pyproject.toml and
+# the project audit (PS-103 top-level-junk-file) failed every PR.
+# ---------------------------------------------------------------------------
+
+
+def test_build_shim_never_creates_flag_named_file_in_cwd(
+    tmp_path: Path, apptainer_on_path: Path
+) -> None:
+    # Arrange — the REAL production build argv shape: --fakeroot sits
+    # where a fixed-index shim would expect the SIF.
+    sif = tmp_path / "out.sif"
+    cwd = tmp_path / "launch"
+    cwd.mkdir()
+    argv = [str(apptainer_on_path), "build", "--fakeroot", str(sif), "docker://x"]
+    # Act — run from a scratch cwd; the old shim littered it here.
+    subprocess.run(argv, cwd=cwd, check=True)
+    # Assert
+    assert not (cwd / "--fakeroot").exists()
+
+
+def test_build_shim_materialises_sif_behind_fakeroot_flag(
+    tmp_path: Path, apptainer_on_path: Path
+) -> None:
+    # Arrange — the SIF must still be found (by scan, not by index) so
+    # production's post-build `sif_path.is_file()` check stays honest.
+    sif = tmp_path / "out.sif"
+    argv = [str(apptainer_on_path), "build", "--fakeroot", str(sif), "docker://x"]
+    # Act
+    subprocess.run(argv, cwd=tmp_path, check=True)
+    # Assert
+    assert sif.read_bytes() == b"\x00"
+
+
+def test_build_shim_refuses_relative_sif_target(
+    tmp_path: Path, apptainer_on_path: Path
+) -> None:
+    # Arrange — a relative SIF would resolve against the launch cwd (the
+    # repo root under pytest). The shim must refuse it, not write it.
+    argv = [str(apptainer_on_path), "build", "relative.sif", "docker://x"]
+    # Act
+    result = subprocess.run(argv, cwd=tmp_path, capture_output=True)
+    # Assert
+    assert result.returncode == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The CI blocker

All three `pytest-matrix` jobs fail on every PR. Out of **9,636 tests exactly one** fails, and it is the in-job project audit gate (`tests/develop/test_audit.py`):

```
= 1 failed, 9636 passed, 54 skipped, 23 deselected =
ERRO: [E] [PS-103 §1 top-level-junk-file] .../--fakeroot: top-level file: --fakeroot
```

Self-inflicted, self-detected: the test suite **creates** the junk file, then the audit — running later in the same pytest session — correctly flags it.

## Root cause

`tests/scitex_agent_container/runtimes/test__apptainer_runtime.py:103-104` — the `apptainer_on_path` fake-binary fixture:

```python
"if len(sys.argv) >= 3 and sys.argv[1] == 'build':\n"
"    Path(sys.argv[2]).write_bytes(b'\\x00')\n"
```

It assumed the build argv was `["build", "<sif>", "<src>"]`. But production's `_build_argv_prefix` (`_apptainer_build.py:120-123`) appends an **optional** `--fakeroot`:

```python
argv = low_priority_build_prefix() + ["apptainer", "build"]
if _should_use_fakeroot_for_build():
    argv.append("--fakeroot")
```

`_should_use_fakeroot_for_build()` returns True whenever the user is non-root **and** has `/etc/sub{u,g}id` mappings — true on the GitHub runner *and* inside the agent container. So `sys.argv[2]` is the **flag**, not the SIF, and the shim wrote a 1-NULL-byte file literally named `--fakeroot` into its launch cwd — which under pytest is the **repo root**.

Not a production bug: `apptainer build --fakeroot <sif> <src>` is a perfectly valid argv, and the `_apptainer_argv_guard` (which covers `exec` flag-value swallowing) is unrelated.

## The fix

Test-only. Locate the SIF by **scanning** the post-`build` args for the first `.sif` positional — exactly as the sibling shim in `test__apptainer_build_fakeroot.py` already does correctly — and **refuse a relative target outright (exit 2)** so a future drift fails the test loudly instead of silently littering the repo root.

Three regression tests pin it: no flag-named file in cwd, the SIF is still materialised behind the flag, and a relative target is refused.

`--fakeroot` is deliberately **not** added to the audit `root-whitelist` — the audit is right; the file should not exist.

## Verification

Ran the polluting subset **and** the audit gate in one pytest session (CI's exact order), from cwd = repo root, with `PYTHONPATH` pinned to this worktree's `src` (confirmed the import resolves into the worktree, not the installed `/opt/venv-sac` copy):

```
env PYTHONPATH="$WT/src" /opt/venv-sac/bin/python -m pytest \
  "$WT/tests/scitex_agent_container/runtimes/" \
  "$WT/tests/develop/test_audit.py" --rootdir="$WT" -q
```

- Before: `git status` → `?? --fakeroot` (1 byte, `b'\x00'`), audit fails PS-103.
- After: **no `--fakeroot`**, `git status` clean apart from the intended edit, **1394 passed** (+3 new tests), and **PS-103 is gone**.

The audit gate still reports `§4b` / `§6a` **locally only** — a control run on the *pristine* tree reproduces them identically, and they come from an unreleased local `scitex-dev 0.26.1.dev9` whose rules the released PyPI version CI installs (`scitex-dev>=0.17.12`) does not have. CI's audit reported *only* PS-103, which this PR removes.