### PR TITLE
feat(accounts): --push-to <peer> keeps a remote peer's credential snapshot fresh (PROPOSAL — do not deploy)

### DIFF
--- a/src/scitex_agent_container/_account/snapshot_push.py
+++ b/src/scitex_agent_container/_account/snapshot_push.py
@@ -1,0 +1,477 @@
+"""Push a freshly-refreshed account snapshot to a PEER's identical path.
+
+WHY — the gap this closes
+-------------------------
+Under the master-host single-refresher model (see
+:mod:`scitex_agent_container.runtimes._apptainer_creds`) the host-side
+``sac.accounts-refresh`` timer is the SOLE refresher: agents bind the
+per-account snapshot ``:ro`` and never rotate the single-use OAuth
+refresh_token themselves. One refresh serves every agent pinned to that
+account, because the token is fungible across them.
+
+That model holds only for agents on the SAME machine as the timer — they
+share the snapshot's filesystem. An agent on a REMOTE peer does not.
+Spartan having a ``/home/ywatanabe`` too is a coincidence of layout, not
+a shared mount: a sac agent there binds *Spartan's own* copy of
+``~/.scitex/agent-container/accounts/<acct>/.credentials.json``, which
+NOTHING refreshes. It silently 401s within one access-token lifetime
+(~8h). This module is the missing leg — after the timer rotates a
+snapshot, copy it to the peer at the identical absolute path.
+
+SECURITY CONTRACT
+-----------------
+* The remote file MUST land mode 0600, and the mode is READ BACK off the
+  peer and asserted (:data:`FILE_MODE`). A flag is never trusted: a
+  filesystem that silently ignores ``chmod`` (CIFS / 9p / some ACL
+  mounts) must not be left holding a world-readable OAuth token on a
+  shared HPC filesystem.
+* Nothing is PUBLISHED before it is VERIFIED. The bytes land on a staged
+  sibling path inside an 0700 directory; only a staged file whose mode
+  AND size both check out is atomically ``mv``-ed onto the live path. A
+  failed check removes the staged file and leaves the peer's previous
+  snapshot untouched.
+* Token VALUES never appear in an argv, an environment variable, stdout,
+  stderr, an exception, or a log line. The bytes travel exactly once —
+  over the transport's stdin, into the remote ``dd``. Only account names
+  and paths are ever rendered. Captured stderr comes from ssh/coreutils,
+  which diagnose in terms of paths, never file content.
+
+FAIL LOUD
+---------
+Every failure raises :class:`SnapshotPushError` naming the peer and the
+path. There is no silent-success path: a silent failure would recreate
+exactly the invisible-staleness bug this module exists to kill.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+import subprocess
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any, Mapping, Protocol, Sequence
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .._state.host_config import PeerSpec
+
+# The one mode an OAuth token snapshot may hold on a shared filesystem.
+FILE_MODE = "600"
+# The account directory is hardened FIRST, so that even the window between
+# ``dd`` creating the staged file (under the remote umask) and its own
+# ``chmod`` cannot expose the token to another user.
+DIR_MODE = "700"
+# Staged sibling of the live path — same directory, therefore the same
+# filesystem, therefore ``mv`` is an atomic rename (no torn read by an
+# agent that happens to open the snapshot mid-push). Fixed (not random)
+# so a crashed run leaves at most ONE stale staging file, which the next
+# run overwrites: idempotent, no clutter.
+STAGED_SUFFIX = ".sac-push-tmp"
+
+_DEFAULT_TIMEOUT_S = 120.0
+_STDERR_TAIL = 400
+
+# OpenSSH joins the post-host argv with spaces and the remote LOGIN SHELL
+# re-parses the result, so a remote path carrying whitespace or a shell
+# metacharacter would be re-split there. sac's own account paths never
+# contain one; anything else is REFUSED rather than quoted by guesswork.
+_SAFE_REMOTE_PATH = re.compile(r"\A[A-Za-z0-9._@%+:/-]+\Z")
+
+
+class SnapshotPushError(RuntimeError):
+    """A push could not be completed AND verified.
+
+    Carries the peer and the path. NEVER carries token material.
+    """
+
+
+class UnknownPeerError(SnapshotPushError):
+    """``--push-to <peer>`` named a peer sac's peer config does not know."""
+
+
+@dataclasses.dataclass(frozen=True)
+class RunResult:
+    """Outcome of ONE remote operation. ``stdout``/``stderr`` are decoded."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class PeerTransport(Protocol):
+    """The injectable transfer seam.
+
+    One method: run a metachar-free argv on the peer, optionally feeding it
+    bytes on stdin. :class:`SshTransport` is the real (default)
+    implementation; every operation this module performs — ``mkdir``,
+    ``chmod``, ``dd``, ``stat``, ``mv``, ``rm`` — goes through it, so a
+    caller can substitute the transport without any of the push logic,
+    the 0600 verification or the fail-loud contract changing shape.
+    """
+
+    peer: str
+
+    def run(
+        self, command: Sequence[str], *, stdin: bytes | None = None
+    ) -> RunResult: ...
+
+
+def _peers_with_lean_preamble(
+    peer: str, peers: Mapping[str, "PeerSpec"]
+) -> dict[str, "PeerSpec"]:
+    """Return ``peers`` with ``peer``'s ``env_preamble`` stripped.
+
+    The preamble exists to put ``apptainer`` on $PATH behind Lmod (Spartan)
+    and is right for a dispatched ``sac`` invocation. It is WRONG here: it
+    would wrap every ``mkdir`` / ``stat`` in a multi-second ``module load``
+    chain whose failure — joined by ``&&`` — would then be misreported as a
+    push failure. The operations in this module are coreutils, present on
+    the default PATH of any peer.
+
+    The concrete (glob-resolved) peer is re-inserted under its own name so
+    a pattern peer such as ``spartan-*`` keeps working, and the map type is
+    preserved so ``via:`` chain lookups keep their glob semantics.
+    """
+    from .._state.host_config import PeersMap
+
+    spec = peers[peer]  # KeyError => the caller failed to validate the peer
+    lean = PeersMap(peers)
+    lean[peer] = dataclasses.replace(spec, env_preamble=())
+    return lean
+
+
+def ssh_op_argv(
+    peer: str, command: Sequence[str], peers: Mapping[str, "PeerSpec"]
+) -> list[str]:
+    """Render the ssh argv for ONE remote operation.
+
+    Delegates wholly to :func:`.._state.host_config.build_ssh_argv` — the
+    same renderer ``sac host exec`` and cross-host agent dispatch use — so
+    the peer's ``ssh:`` target, its ``via:`` ProxyJump chain, sac's
+    BatchMode / accept-new-TOFU policy and its ControlMaster multiplexing
+    all come from the ONE existing peer table
+    (``~/.scitex/agent-container/config.yaml``). No second host config is
+    invented.
+    """
+    from .._state.host_config import build_ssh_argv
+
+    return build_ssh_argv(
+        peer, list(command), _peers_with_lean_preamble(peer, peers)
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class SshTransport:
+    """The real transport: run one argv on ``peer`` over ssh.
+
+    Bytes destined for the peer ride on stdin (never on the command line
+    and never through the environment), so a token value cannot leak into
+    a process table, a shell history or a journal line.
+    """
+
+    peer: str
+    peers: Mapping[str, "PeerSpec"]
+    timeout_s: float = _DEFAULT_TIMEOUT_S
+
+    def run(
+        self, command: Sequence[str], *, stdin: bytes | None = None
+    ) -> RunResult:
+        argv = ssh_op_argv(self.peer, command, self.peers)
+        try:
+            proc = subprocess.run(
+                argv,
+                input=stdin if stdin is not None else b"",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=self.timeout_s,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return RunResult(
+                returncode=124,
+                stdout="",
+                stderr=(
+                    f"ssh to peer '{self.peer}' timed out after "
+                    f"{self.timeout_s:g}s running `{command[0]}`"
+                ),
+            )
+        except OSError as exc:
+            return RunResult(returncode=127, stdout="", stderr=f"{exc}")
+        return RunResult(
+            returncode=proc.returncode,
+            stdout=proc.stdout.decode("utf-8", "replace"),
+            stderr=proc.stderr.decode("utf-8", "replace"),
+        )
+
+
+def resolve_peer_transport(peer: str) -> SshTransport:
+    """Build the production transport for ``peer`` from sac's peer config.
+
+    Reads the SAME table behind ``sac host list`` /
+    ``~/.scitex/agent-container/config.yaml`` (:func:`.._state.host_config.load`).
+    An unregistered peer raises :class:`UnknownPeerError` listing the peers
+    that ARE registered — and the caller is expected to do this BEFORE any
+    refresh runs, so a typo'd peer name never costs a single-use OAuth
+    refresh_token rotation.
+    """
+    from .._state.host_config import load as load_host_config
+
+    cfg = load_host_config()
+    if peer not in cfg.peers:
+        known = ", ".join(sorted(cfg.peers)) or "(none registered)"
+        raise UnknownPeerError(
+            f"unknown peer '{peer}': not found under peers: in "
+            f"{cfg.source_path}. Registered peers: {known}. "
+            f"Add one with `sac host add {peer} --ssh <user@host>`."
+        )
+    return SshTransport(peer=peer, peers=cfg.peers)
+
+
+def _tail(stderr: str) -> str:
+    """Render a transport's stderr for an error message (paths only)."""
+    text = (stderr or "").strip()
+    if not text:
+        return ""
+    if len(text) > _STDERR_TAIL:
+        text = text[:_STDERR_TAIL] + "…"
+    return f": {text}"
+
+
+def _assert_safe_remote_path(path: str, peer: str) -> None:
+    """Refuse a remote path the remote shell would re-split. Fail loud."""
+    if not _SAFE_REMOTE_PATH.match(path):
+        raise SnapshotPushError(
+            f"refusing to push to peer '{peer}': remote path {path!r} carries "
+            "whitespace or a shell metacharacter, which the peer's login "
+            "shell would re-split. Nothing was sent."
+        )
+
+
+def _op(
+    transport: PeerTransport,
+    command: Sequence[str],
+    *,
+    what: str,
+    path: str,
+    stdin: bytes | None = None,
+) -> RunResult:
+    """Run one remote operation; a non-zero exit is a loud failure."""
+    result = transport.run(command, stdin=stdin)
+    if result.returncode != 0:
+        raise SnapshotPushError(
+            f"failed to {what} {path} on peer '{transport.peer}' "
+            f"(`{command[0]}` exited {result.returncode})"
+            f"{_tail(result.stderr)}"
+        )
+    return result
+
+
+def parse_stat(stdout: str) -> tuple[str, int] | None:
+    """Parse a ``<mode>:<size>`` stat line into ``("600", 1234)``.
+
+    ``None`` when the output is missing or unparseable — the caller then
+    fails loud rather than assuming a mode it could not read.
+
+    The mode is normalised by stripping leading zeroes so the GNU (``600``)
+    and BSD (``0600`` on some coreutils) spellings compare equal.
+    """
+    lines = [ln.strip() for ln in (stdout or "").splitlines() if ln.strip()]
+    if not lines:
+        return None
+    mode_s, sep, size_s = lines[0].partition(":")
+    if not sep:
+        return None
+    mode_s = mode_s.strip().lstrip("0") or "0"
+    size_s = size_s.strip()
+    if not mode_s.isdigit() or not size_s.isdigit():
+        return None
+    return mode_s, int(size_s)
+
+
+def stat_remote(transport: PeerTransport, path: str) -> tuple[str, int]:
+    """Return ``(mode_octal, size_bytes)`` READ BACK off the peer.
+
+    ``stat -c %a:%s`` is the GNU form (any Linux peer, Spartan included);
+    ``stat -f %Lp:%z`` is the BSD form (a macOS peer such as ``mba``). The
+    ``:``-joined format keeps the whole thing ONE whitespace-free token:
+    OpenSSH joins the post-host argv with spaces and the remote shell
+    re-parses it, so a format string containing a space would be re-split
+    and ``%s`` taken for a second FILE operand.
+
+    Raises :class:`SnapshotPushError` when the mode cannot be READ — an
+    unverifiable mode is a failure, never an assumption.
+    """
+    last: RunResult | None = None
+    for flag, fmt in (("-c", "%a:%s"), ("-f", "%Lp:%z")):
+        last = transport.run(["stat", flag, fmt, path])
+        if last.returncode == 0:
+            parsed = parse_stat(last.stdout)
+            if parsed is not None:
+                return parsed
+    raise SnapshotPushError(
+        f"cannot verify the mode of {path} on peer '{transport.peer}': "
+        f"`stat` did not return a readable <mode>:<size>"
+        f"{_tail(last.stderr if last else '')}"
+    )
+
+
+def _discard(transport: PeerTransport, path: str) -> None:
+    """Best-effort removal of a file whose mode we could not vouch for.
+
+    Never raises — it runs on a failure path that is already going to
+    raise, and a failed cleanup must not mask the original diagnosis.
+    """
+    # stx-allow: fallback (reason: cleanup on an already-failing path; a
+    # transport error here must not replace the real error the caller is
+    # about to raise. The failure to clean up is reported by that error's
+    # own message pointing at the path.)
+    try:
+        transport.run(["rm", "-f", path])
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        pass
+
+
+def push_snapshot(
+    account: str,
+    local_path: Path | str,
+    *,
+    transport: PeerTransport,
+    remote_path: str | None = None,
+) -> dict[str, Any]:
+    """Copy one refreshed snapshot to the peer, at the IDENTICAL abs path.
+
+    Steps, in the order that makes each failure safe:
+
+    1. ``mkdir -p`` + ``chmod 700`` the remote account directory, so the
+       staged file cannot be world-readable even for the instant between
+       ``dd`` creating it under the remote umask and its own ``chmod``.
+    2. Stream the bytes into a STAGED sibling (never onto the live path)
+       and ``chmod 600`` it.
+    3. VERIFY the staged file by reading its mode AND size back off the
+       peer. Size matters as much as mode: a dropped ssh stream leaves the
+       remote ``dd`` exiting 0 on a TRUNCATED file, which would publish a
+       corrupt credential. Any mismatch removes the staged file and raises
+       — the peer keeps its previous snapshot, untouched.
+    4. Publish with an atomic same-directory ``mv -f``.
+    5. Prove the LIVE path is what was verified. ``mv`` preserves mode and
+       contents, so a mismatch here means the peer's filesystem mutated the
+       file on rename — hostile; the file is removed rather than left as a
+       token whose mode cannot be vouched for. A ``stat`` that cannot RUN
+       at all (transport failure) still fails the run loud but does NOT
+       delete: that same inode was already proven 0600 and complete before
+       the rename, so deleting would strip the peer of its credentials for
+       no security gain.
+
+    Args:
+        account: account name, for the returned record + error messages.
+        local_path: the freshly-rotated snapshot on THIS host. Must be an
+            absolute path to an existing file.
+        transport: the transfer seam. Defaults are supplied by the caller
+            (:func:`resolve_peer_transport` builds the real ssh one).
+        remote_path: override the destination. Defaults to the IDENTICAL
+            absolute path — a peer whose layout matches (the fleet's
+            ``/home/ywatanabe`` convention) needs no mapping.
+
+    Returns:
+        ``{"account", "peer", "local_path", "remote_path", "mode", "bytes"}``
+        — paths, an account name and a verified mode. Never a token.
+
+    Raises:
+        SnapshotPushError: on ANY failure, naming the peer and the path.
+    """
+    local = Path(local_path)
+    if not local.is_absolute():
+        raise SnapshotPushError(
+            f"refusing to push account '{account}' to peer "
+            f"'{transport.peer}': local snapshot path {local!s} is not "
+            "absolute, so the peer's identical path cannot be derived."
+        )
+    if not local.is_file():
+        raise SnapshotPushError(
+            f"refusing to push account '{account}' to peer "
+            f"'{transport.peer}': no snapshot at {local!s}."
+        )
+
+    remote = remote_path if remote_path is not None else str(local)
+    _assert_safe_remote_path(remote, transport.peer)
+    staged = remote + STAGED_SUFFIX
+    remote_dir = str(PurePosixPath(remote).parent)
+
+    payload = local.read_bytes()
+    size = len(payload)
+
+    # 1. An 0700 directory FIRST.
+    _op(transport, ["mkdir", "-p", remote_dir], what="create", path=remote_dir)
+    _op(transport, ["chmod", DIR_MODE, remote_dir], what="harden", path=remote_dir)
+
+    # 2-3. Stage, harden, verify — nothing is published unverified.
+    try:
+        _op(
+            transport,
+            ["dd", f"of={staged}"],
+            what="write",
+            path=staged,
+            stdin=payload,
+        )
+        _op(transport, ["chmod", FILE_MODE, staged], what="harden", path=staged)
+        mode, remote_size = stat_remote(transport, staged)
+        if mode != FILE_MODE:
+            raise SnapshotPushError(
+                f"refusing to publish account '{account}' on peer "
+                f"'{transport.peer}': {staged} landed mode 0{mode}, not "
+                f"0{FILE_MODE}. The peer's filesystem did not honour "
+                "`chmod`; an OAuth token must never be readable by another "
+                "user there. The staged file is being removed and the "
+                "peer's previous snapshot is untouched."
+            )
+        if remote_size != size:
+            raise SnapshotPushError(
+                f"refusing to publish account '{account}' on peer "
+                f"'{transport.peer}': {staged} is {remote_size} bytes, "
+                f"expected {size} — the transfer was truncated. The staged "
+                "file is being removed and the peer's previous snapshot is "
+                "untouched."
+            )
+    except SnapshotPushError:
+        _discard(transport, staged)
+        raise
+
+    # 4. Publish atomically.
+    _op(transport, ["mv", "-f", staged, remote], what="publish", path=remote)
+
+    # 5. Prove the LIVE path. (See the docstring for why a mode/size
+    # mismatch deletes but an unreachable `stat` does not.)
+    mode, remote_size = stat_remote(transport, remote)
+    if mode != FILE_MODE or remote_size != size:
+        _discard(transport, remote)
+        raise SnapshotPushError(
+            f"account '{account}' published to peer '{transport.peer}' at "
+            f"{remote} did NOT verify (mode 0{mode}, {remote_size} bytes; "
+            f"expected 0{FILE_MODE}, {size} bytes). The file has been "
+            "removed from the peer rather than left unverified."
+        )
+
+    return {
+        "account": account,
+        "peer": transport.peer,
+        "local_path": str(local),
+        "remote_path": remote,
+        "mode": mode,
+        "bytes": size,
+    }
+
+
+__all__ = [
+    "DIR_MODE",
+    "FILE_MODE",
+    "STAGED_SUFFIX",
+    "PeerTransport",
+    "RunResult",
+    "SnapshotPushError",
+    "SshTransport",
+    "UnknownPeerError",
+    "parse_stat",
+    "push_snapshot",
+    "resolve_peer_transport",
+    "ssh_op_argv",
+    "stat_remote",
+]

--- a/src/scitex_agent_container/cli_pkg/_account_refresh.py
+++ b/src/scitex_agent_container/cli_pkg/_account_refresh.py
@@ -95,6 +95,22 @@ from ._account_refresh_skip import (
     ),
 )
 @click.option(
+    "--push-to",
+    "push_to",
+    default=None,
+    metavar="PEER",
+    help=(
+        "After a SUCCESSFUL refresh, copy each freshly-rotated snapshot to "
+        "PEER at the IDENTICAL absolute path, mode 0600 (read back off the "
+        "peer and asserted). PEER is a key under peers: in "
+        "~/.scitex/agent-container/config.yaml — the same table `sac host "
+        "list` shows. OPT-IN: a peer is a DIFFERENT filesystem, so agents "
+        "running there bind a copy of the snapshot that nothing on that box "
+        "ever refreshes, and they silently 401 within one token lifetime. A "
+        "failed push fails the run (non-zero exit) — never a silent success."
+    ),
+)
+@click.option(
     "--json",
     "as_json",
     is_flag=True,
@@ -109,6 +125,7 @@ def account_refresh(
     min_ttl_hours: float,
     force: bool,
     sync_active_login_flag: bool,
+    push_to: str | None,
     as_json: bool,
 ) -> None:
     """Mint a fresh access_token from the stored refresh_token, headlessly.
@@ -149,6 +166,22 @@ def account_refresh(
     into the live file (backup -> atomic replace -> verify-or-restore) so a
     single-use refresh_token rotation never strands the live session.
 
+    ``--push-to PEER`` (opt-in) closes the SAME staleness hole for agents
+    on a REMOTE peer. The single-refresher model above only reaches agents
+    that share this machine's filesystem; a peer (Spartan) is a different
+    box, and its own copy of the snapshot is refreshed by nothing, so its
+    agents silently 401 within one access-token lifetime. With this flag,
+    each snapshot that ACTUALLY rotated in this run (skipped-fresh and
+    failed accounts are never pushed) is copied to the peer's IDENTICAL
+    absolute path. The file must land mode 0600, and the mode is READ BACK
+    off the peer and asserted — an OAuth token must never be world-readable
+    on a shared HPC filesystem. Nothing is published before it verifies,
+    and a failed push fails the run (non-zero exit): a silent push failure
+    would recreate exactly the invisible staleness the flag exists to kill.
+    PEER is resolved through sac's existing peer table (``sac host list``);
+    an unknown peer is rejected BEFORE any refresh, so a typo never costs a
+    single-use refresh_token rotation.
+
     \b
     Examples:
       $ sac accounts refresh work
@@ -156,6 +189,7 @@ def account_refresh(
       $ sac accounts refresh --all --skip-active
       $ sac accounts refresh --all --include-active   # legacy timer mode
       $ sac accounts refresh --all --sync-active-login  # daemon mode
+      $ sac accounts refresh --all --push-to spartan    # keep a peer fresh
       $ sac accounts refresh --all --json
     """
     import json as _json
@@ -194,6 +228,19 @@ def account_refresh(
             err=True,
         )
         raise SystemExit(2)
+
+    # Resolve --push-to BEFORE any refresh runs. A refresh CONSUMES the
+    # single-use OAuth refresh_token, so discovering a typo'd peer name
+    # afterwards would have cost a rotation for nothing.
+    push_transport = None
+    if push_to:
+        from .._account.snapshot_push import UnknownPeerError, resolve_peer_transport
+
+        try:
+            push_transport = resolve_peer_transport(push_to)
+        except UnknownPeerError as exc:
+            click.echo(f"error: {exc}", err=True)
+            raise SystemExit(2) from exc
 
     home = Path.home()
     store = _store_path(None, home)
@@ -361,6 +408,17 @@ def account_refresh(
                         err=True,
                     )
 
+    # Peer push (opt-in). Runs AFTER the refresh loop so it carries only
+    # the snapshots that actually rotated, and BEFORE the results are
+    # rendered so --json and the human table both report the push outcome.
+    push_failed = False
+    if push_to:
+        from ._account_refresh_push import push_refreshed_snapshots
+
+        push_failed = push_refreshed_snapshots(
+            results, push_to, transport=push_transport
+        )
+
     if as_json:
         click.echo(_json.dumps(results, ensure_ascii=False, indent=2))
     else:
@@ -391,13 +449,16 @@ def account_refresh(
     alert_failed_refreshes(results)
 
     # Exit non-zero when EVERY *attempted* account failed (skipped-fresh
-    # accounts don't count), OR when an active-login sync failed loud.
+    # accounts don't count), when an active-login sync failed loud, OR when
+    # a --push-to peer push failed. A push that failed silently would leave
+    # the peer's agents running on a snapshot nothing refreshes — the exact
+    # invisible-staleness bug the flag exists to kill — so it is loud.
     # --all with mixed results is still a useful partial success.
     attempted = [r for r in results if not r.get("skipped")]
     all_attempted_failed = bool(attempted) and not any(
         r.get("success") for r in attempted
     )
-    if all_attempted_failed or sync_failed:
+    if all_attempted_failed or sync_failed or push_failed:
         raise SystemExit(1)
 
 

--- a/src/scitex_agent_container/cli_pkg/_account_refresh_push.py
+++ b/src/scitex_agent_container/cli_pkg/_account_refresh_push.py
@@ -1,0 +1,126 @@
+"""``sac accounts refresh --push-to <peer>`` — the CLI leg of the peer push.
+
+Split out of :mod:`._account_refresh` to keep that command under the
+per-file line cap (same pattern as ``_account_refresh_skip``).
+
+The engine — the transfer, the 0600 verification and the fail-loud
+contract — lives in :mod:`.._account.snapshot_push`. This module owns only
+the CLI-shaped concerns:
+
+* WHICH accounts get pushed (:func:`refreshed_accounts` — only the ones
+  that actually rotated in this run),
+* rendering each outcome on stderr, alongside the refresh table,
+* stamping the per-account result dicts so ``--json`` carries the push
+  outcome,
+* and returning the single boolean the command folds into its exit code.
+
+Why opt-in, and why it fails the run: a peer is a DIFFERENT filesystem.
+An agent running there binds the peer's OWN copy of the snapshot, which
+nothing on that box ever refreshes — it silently 401s within one token
+lifetime. A push that failed but reported success would recreate exactly
+that invisible staleness, so a failed push is a non-zero exit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+import click
+
+from .._account.snapshot_push import (
+    PeerTransport,
+    SnapshotPushError,
+    push_snapshot,
+    resolve_peer_transport,
+)
+
+
+def refreshed_accounts(
+    results: Sequence[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return the accounts whose snapshot ACTUALLY rotated in this run.
+
+    Only these are pushed. A skipped-still-fresh account's snapshot is
+    byte-identical to the one a previous run already pushed, and a FAILED
+    refresh must never overwrite the peer's copy. The push therefore
+    inherits the refresh's own rotate-only-when-stale discipline: it
+    carries exactly the bytes that changed.
+    """
+    return [
+        r
+        for r in results
+        if r.get("success") and not r.get("skipped") and r.get("credentials_path")
+    ]
+
+
+def push_refreshed_snapshots(
+    results: Sequence[dict[str, Any]],
+    peer: str,
+    *,
+    transport: PeerTransport | None = None,
+    err: Callable[..., None] = click.echo,
+) -> bool:
+    """Push every snapshot refreshed in this run to ``peer``.
+
+    Each result dict is stamped in place with ``pushed_to`` / ``push_error``
+    so the command's ``--json`` output carries the outcome. Progress and
+    failures are rendered on stderr under the refresh table.
+
+    Args:
+        results: the per-account result list ``sac accounts refresh`` built.
+        peer: the peer key, already validated against sac's peer config by
+            the caller (see :func:`.._account.snapshot_push.resolve_peer_transport`).
+        transport: the transfer seam. ``None`` builds the real ssh
+            transport from sac's peer config.
+        err: sink for the human-facing lines (stderr by default).
+
+    Returns:
+        ``True`` iff at least one push FAILED — the command folds this into
+        a non-zero exit. Never raises: every failure is captured, rendered
+        and reported through the return value, so one dead peer cannot
+        abort the loop before the other accounts are attempted.
+    """
+    targets = refreshed_accounts(results)
+    if not targets:
+        err(
+            f"[push-to] no account rotated this run; nothing to push to "
+            f"'{peer}'.",
+            err=True,
+        )
+        return False
+
+    active = transport if transport is not None else resolve_peer_transport(peer)
+    failed = False
+
+    for result in targets:
+        account = str(result.get("name") or "?")
+        local = Path(str(result["credentials_path"]))
+        # stx-allow: fallback (reason: a push failure must be REPORTED for
+        # this account and the loop must continue to the next one — one
+        # unreachable peer path cannot silently drop the remaining
+        # accounts. The failure is rendered loudly here and folded into a
+        # non-zero exit via the returned flag; it is never swallowed.)
+        try:
+            record = push_snapshot(account, local, transport=active)
+        except SnapshotPushError as exc:  # stx-allow: fallback (reason: see inline comment)
+            failed = True
+            result["pushed_to"] = None
+            result["push_error"] = str(exc)
+            err(
+                f"  {account:20s}  PUSH FAILED -> {peer}:{local!s} — {exc}",
+                err=True,
+            )
+            continue
+        result["pushed_to"] = peer
+        result["remote_path"] = record["remote_path"]
+        err(
+            f"  {account:20s}  pushed -> {peer}:{record['remote_path']} "
+            f"(mode 0{record['mode']}, {record['bytes']} bytes, verified)",
+            err=True,
+        )
+
+    return failed
+
+
+__all__ = ["push_refreshed_snapshots", "refreshed_accounts"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,8 +68,11 @@ def _ensure_subprocess_coverage_shim() -> None:
 _ensure_subprocess_coverage_shim()
 
 # Expose shared no-mocks helpers (subprocess_shim, env_save_restore,
-# ssh_http_shim) as session-wide fixtures so any test under tests/
-# can use them by name.
+# ssh_exec_shim, ssh_http_shim) as session-wide fixtures so any test under
+# tests/ can use them by name.
+from tests.scitex_agent_container._helpers.ssh_exec_shim import (  # noqa: E402,F401
+    ssh_exec_shim,
+)
 from tests.scitex_agent_container._helpers.ssh_http_shim import (  # noqa: E402,F401
     ssh_http_shim,
 )

--- a/tests/scitex_agent_container/_account/test_snapshot_push.py
+++ b/tests/scitex_agent_container/_account/test_snapshot_push.py
@@ -2,35 +2,31 @@
 
 No-mocks (PA-306 / STX-NM002). Every test drives the REAL production
 transport: the real :class:`SshTransport` renders its argv through the
-real ``build_ssh_argv``, the real ``subprocess.run`` resolves ``ssh``
-through the real ``$PATH``. Only the NETWORK HOP is replaced — by a real
-``ssh`` executable on ``$PATH`` that runs the post-``--`` remote command
-LOCALLY, joined with spaces and re-parsed by a shell exactly as
-OpenSSH + sshd do. That is the same honest-replacement technique as the
-repo's existing ``ssh_http_shim`` helper.
+real ``build_ssh_argv``, and the real ``subprocess.run`` resolves ``ssh``
+through the real ``$PATH``. Only the NETWORK HOP is replaced — by the
+``ssh_exec_shim`` helper, a real ``ssh`` executable on ``$PATH`` that runs
+the post-``--`` remote command LOCALLY, joined with spaces and re-parsed by
+a shell exactly as OpenSSH + sshd do. Same honest-replacement technique as
+the repo's existing ``ssh_http_shim``.
 
 Everything else is real: the remote ``mkdir`` / ``dd`` / ``chmod`` /
-``stat`` / ``mv`` are the real coreutils, they operate on a real
-directory tree under ``tmp_path``, the token bytes travel over a real
-stdin pipe, and the 0600 assertion is made against a real file's real
-mode as read back by the real ``stat``.
+``stat`` / ``mv`` are the real coreutils, they operate on a real directory
+tree under ``tmp_path``, the token bytes travel over a real stdin pipe, and
+the 0600 assertion is made against a real file's real mode as read back by
+the real ``stat``.
 
-Peer resolution runs against a REAL ``config.yaml`` in ``tmp_path``,
-pinned with ``$SCITEX_AGENT_CONTAINER_CONFIG`` — the same file
-``sac host list`` reads.
+Peer resolution runs against a REAL ``config.yaml`` in ``tmp_path``, pinned
+with ``$SCITEX_AGENT_CONTAINER_CONFIG`` — the same file ``sac host list``
+reads.
 
 AAA marker comments; one assertion per test.
 """
 
 from __future__ import annotations
 
-import base64
 import json
-import os
-import shlex
 import stat as stat_mod
 from pathlib import Path
-from typing import Iterator
 
 import pytest
 
@@ -38,7 +34,6 @@ from scitex_agent_container._account.snapshot_push import (
     FILE_MODE,
     STAGED_SUFFIX,
     SnapshotPushError,
-    SshTransport,
     UnknownPeerError,
     parse_stat,
     push_snapshot,
@@ -46,40 +41,13 @@ from scitex_agent_container._account.snapshot_push import (
     ssh_op_argv,
 )
 
-# A distinctive, greppable stand-in for token material. Every no-leak
-# assertion in this module searches for these exact bytes.
+# Distinctive, greppable stand-ins for token material. Every no-leak
+# assertion below searches for these exact bytes.
 _ACCESS = "ACCESS-TOKEN-MUST-NEVER-BE-PRINTED"
 _REFRESH = "REFRESH-TOKEN-MUST-NEVER-BE-PRINTED"
 
-
-# ---------------------------------------------------------------------------
-# Real-binary shims (honest replacements — no mocks)
-# ---------------------------------------------------------------------------
-
-# Faithful to OpenSSH: everything after `--` is joined with spaces and fed
-# to a shell on the far side. A future quoting bug therefore breaks this
-# test exactly as it would break production.
-_SSH_SHIM = r"""#!/bin/sh
-printf '%s\0' "$@" | base64 | tr -d '\n' >> __LOG__
-printf '\n' >> __LOG__
-__seen=0
-__cmd=
-for __a in "$@"; do
-  if [ "$__seen" = 1 ]; then
-    __cmd="$__cmd $__a"
-  elif [ "$__a" = "--" ]; then
-    __seen=1
-  fi
-done
-if [ "$__seen" != 1 ]; then
-  echo "shim ssh: no -- separator in argv" >&2
-  exit 2
-fi
-exec sh -c "$__cmd"
-"""
-
 # A `dd` whose stdin died mid-stream: it sees EOF early, writes a SHORT
-# file and still exits 0. This is the real failure shape of a dropped ssh
+# file and still exits 0. That is the real failure shape of a dropped ssh
 # transfer, and the reason the push verifies SIZE as well as mode.
 _TRUNCATING_DD = r"""#!/bin/sh
 __of=
@@ -93,60 +61,12 @@ cat > /dev/null
 exit 0
 """
 
-# A `chmod` that reports success and changes nothing — the real behaviour
-# of a CIFS / 9p / ACL-backed filesystem. The push must catch this by
-# READING the mode back, not by trusting the chmod's exit code.
-_LYING_CHMOD = r"""#!/bin/sh
+# A `chmod` that reports success and changes nothing — the real behaviour of
+# a CIFS / 9p / ACL-backed filesystem. The push must catch this by READING
+# the mode back, not by trusting the chmod's exit code.
+_LYING_CHMOD = """#!/bin/sh
 exit 0
 """
-
-
-class _ShimBin:
-    """A real bin dir on ``$PATH`` holding real executables."""
-
-    def __init__(self, bin_dir: Path) -> None:
-        self.bin = bin_dir
-        self.ssh_log = bin_dir / "ssh.argv.log"
-
-    def install(self, name: str, source: str) -> Path:
-        script = self.bin / name
-        script.write_text(source.replace("__LOG__", shlex.quote(str(self.ssh_log))))
-        script.chmod(0o755)
-        return script
-
-    def ssh_invocations(self) -> list[list[str]]:
-        if not self.ssh_log.exists():
-            return []
-        calls: list[list[str]] = []
-        for line in self.ssh_log.read_text().splitlines():
-            if not line:
-                calls.append([])
-                continue
-            parts = base64.b64decode(line).split(b"\x00")
-            if parts and parts[-1] == b"":
-                parts = parts[:-1]
-            calls.append([p.decode("utf-8", "surrogateescape") for p in parts])
-        return calls
-
-
-@pytest.fixture
-def shim(tmp_path: Path) -> Iterator[_ShimBin]:
-    """Prepend a real bin dir to ``$PATH``; install the executing ssh."""
-    bin_dir = tmp_path / "_shim_bin"
-    bin_dir.mkdir(exist_ok=True)
-    saved = os.environ.get("PATH", "")
-    os.environ["PATH"] = f"{bin_dir}{os.pathsep}{saved}"
-    controller = _ShimBin(bin_dir)
-    controller.install("ssh", _SSH_SHIM)
-    try:
-        yield controller
-    finally:
-        os.environ["PATH"] = saved
-
-
-# ---------------------------------------------------------------------------
-# Real peer config (the same table `sac host list` reads)
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -188,24 +108,77 @@ def _mode_of(path: Path) -> str:
     return oct(stat_mod.S_IMODE(path.stat().st_mode))[2:]
 
 
+def _push(local: Path, remote: Path | None = None):
+    """Drive the REAL production transport at the configured peer."""
+    return push_snapshot(
+        "work",
+        local,
+        transport=resolve_peer_transport("spartan"),
+        remote_path=str(remote) if remote is not None else None,
+    )
+
+
+def _push_error(local: Path, remote: Path | str) -> SnapshotPushError:
+    """Run a push that MUST fail; return the raised error.
+
+    Keeps the failure itself out of the test's assertion budget, so each
+    fail-loud test can make exactly one assertion — on the message, or on
+    the side effect (nothing published / nothing left behind).
+    """
+    try:
+        push_snapshot(
+            "work",
+            local,
+            transport=resolve_peer_transport("spartan"),
+            remote_path=str(remote),
+        )
+    except SnapshotPushError as exc:
+        return exc
+    raise AssertionError(f"expected a SnapshotPushError pushing to {remote}")
+
+
+def _resolve_error(peer: str) -> UnknownPeerError:
+    """Resolve a peer that MUST be unknown; return the raised error."""
+    try:
+        resolve_peer_transport(peer)
+    except UnknownPeerError as exc:
+        return exc
+    raise AssertionError(f"expected an UnknownPeerError for peer {peer!r}")
+
+
+def _stage_a_0644_file(remote: Path) -> Path:
+    """Pre-create the staged path 0644 — `dd` truncates and keeps the mode.
+
+    Makes the lying-chmod tests independent of the ambient umask.
+    """
+    staged = Path(str(remote) + STAGED_SUFFIX)
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    staged.touch()
+    staged.chmod(0o644)
+    return staged
+
+
 # ---------------------------------------------------------------------------
-# Peer-config reuse (requirement: sac's EXISTING peer table, no new config)
+# Peer-config reuse (sac's EXISTING peer table — no second host config)
 # ---------------------------------------------------------------------------
 
 
 def test_transport_resolves_peer_from_sac_config(peer_config) -> None:
-    # Arrange / Act — the peer name is looked up in the real config.yaml.
-    transport = resolve_peer_transport("spartan")
+    # Arrange
+    peer = "spartan"
+    # Act — the name is looked up in the real config.yaml.
+    transport = resolve_peer_transport(peer)
     # Assert
-    assert transport.peers["spartan"].ssh == "ywatanabe@spartan-login1"
+    assert transport.peers[peer].ssh == "ywatanabe@spartan-login1"
 
 
-def test_unknown_peer_raises_naming_the_known_peers(peer_config) -> None:
-    # Arrange / Act
-    with pytest.raises(UnknownPeerError) as excinfo:
-        resolve_peer_transport("not-a-peer")
-    # Assert — the error lists the peers that ARE registered.
-    assert "spartan" in str(excinfo.value)
+def test_unknown_peer_error_lists_the_registered_peers(peer_config) -> None:
+    # Arrange
+    peer = "not-a-peer"
+    # Act
+    error = _resolve_error(peer)
+    # Assert — the error names the peers that ARE registered.
+    assert "spartan" in str(error)
 
 
 def test_ssh_argv_carries_the_peer_ssh_target(peer_config) -> None:
@@ -220,7 +193,7 @@ def test_ssh_argv_carries_the_peer_ssh_target(peer_config) -> None:
 def test_ssh_argv_carries_the_proxyjump_chain(peer_config) -> None:
     # Arrange
     peers = resolve_peer_transport("spartan").peers
-    # Act — `via: [mba]` must become ssh's -J chain, resolved to mba's ssh.
+    # Act — `via: [mba]` becomes ssh's -J chain, resolved to mba's ssh target.
     argv = ssh_op_argv("spartan", ["stat", "-c", "%a:%s", "/x"], peers)
     # Assert
     assert argv[argv.index("-J") + 1] == "ywatanabe@mba.local"
@@ -237,130 +210,99 @@ def test_ssh_argv_omits_the_lmod_env_preamble(peer_config) -> None:
 
 
 # ---------------------------------------------------------------------------
-# The happy path — real transfer, real mode, real verification
+# Happy path — real transfer, real mode, real verification
 # ---------------------------------------------------------------------------
 
 
-def test_push_lands_the_file_on_the_peer(tmp_path, peer_config, shim) -> None:
+def test_push_lands_the_file_on_the_peer(tmp_path, peer_config, ssh_exec_shim) -> None:
     # Arrange
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
     # Act
-    push_snapshot(
-        "work",
-        local,
-        transport=resolve_peer_transport("spartan"),
-        remote_path=str(remote),
-    )
+    _push(local, remote)
     # Assert — the bytes really arrived.
     assert remote.read_text() == local.read_text()
 
 
-def test_push_lands_mode_0600(tmp_path, peer_config, shim) -> None:
+def test_push_lands_mode_0600(tmp_path, peer_config, ssh_exec_shim) -> None:
     # Arrange
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
     # Act
-    push_snapshot(
-        "work",
-        local,
-        transport=resolve_peer_transport("spartan"),
-        remote_path=str(remote),
-    )
+    _push(local, remote)
     # Assert — the REAL mode of the REAL landed file.
     assert _mode_of(remote) == FILE_MODE
 
 
 def test_push_reports_the_verified_mode_it_read_back(
-    tmp_path, peer_config, shim
+    tmp_path, peer_config, ssh_exec_shim
 ) -> None:
     # Arrange
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
     # Act
-    record = push_snapshot(
-        "work",
-        local,
-        transport=resolve_peer_transport("spartan"),
-        remote_path=str(remote),
-    )
+    record = _push(local, remote)
     # Assert — the mode in the record was READ OFF the peer, not assumed.
     assert record["mode"] == FILE_MODE
 
 
-def test_push_hardens_the_account_directory(tmp_path, peer_config, shim) -> None:
+def test_push_hardens_the_account_directory(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
     # Arrange
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
     # Act
-    push_snapshot(
-        "work",
-        local,
-        transport=resolve_peer_transport("spartan"),
-        remote_path=str(remote),
-    )
-    # Assert — 0700 dir closes the window before the file's own chmod lands.
+    _push(local, remote)
+    # Assert — an 0700 dir closes the window before the file's own chmod lands.
     assert _mode_of(remote.parent) == "700"
 
 
 def test_push_defaults_to_the_identical_absolute_path(
-    tmp_path, peer_config, shim
+    tmp_path, peer_config, ssh_exec_shim
 ) -> None:
     # Arrange — no remote_path override: the peer's path IS the local path.
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     # Act
-    record = push_snapshot(
-        "work", local, transport=resolve_peer_transport("spartan")
-    )
+    record = _push(local)
     # Assert
     assert record["remote_path"] == str(local)
 
 
-def test_push_leaves_no_staging_file_behind(tmp_path, peer_config, shim) -> None:
+def test_push_leaves_no_staging_file_behind(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
     # Arrange
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
     # Act
-    push_snapshot(
-        "work",
-        local,
-        transport=resolve_peer_transport("spartan"),
-        remote_path=str(remote),
-    )
+    _push(local, remote)
     # Assert — the staged sibling was consumed by the atomic publish.
     assert not Path(str(remote) + STAGED_SUFFIX).exists()
 
 
-def test_push_is_idempotent(tmp_path, peer_config, shim) -> None:
-    # Arrange — the timer re-runs every 2h against an already-pushed peer.
+def test_push_is_idempotent(tmp_path, peer_config, ssh_exec_shim) -> None:
+    # Arrange — the refresher re-runs on a cadence, over an already-pushed peer.
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
-    transport = resolve_peer_transport("spartan")
-    push_snapshot("work", local, transport=transport, remote_path=str(remote))
-    # Act — second run over the top of the first.
-    record = push_snapshot(
-        "work", local, transport=transport, remote_path=str(remote)
-    )
+    _push(local, remote)
+    # Act — second run straight over the first.
+    record = _push(local, remote)
     # Assert
     assert record["mode"] == FILE_MODE and remote.read_text() == local.read_text()
 
 
 def test_push_reaches_the_peer_over_the_real_ssh_argv(
-    tmp_path, peer_config, shim
+    tmp_path, peer_config, ssh_exec_shim
 ) -> None:
     # Arrange
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
     # Act
-    push_snapshot(
-        "work",
-        local,
-        transport=resolve_peer_transport("spartan"),
-        remote_path=str(remote),
-    )
+    _push(local, remote)
     # Assert — production really shelled out to ssh, at the configured peer.
     assert all(
-        "ywatanabe@spartan-login1" in call for call in shim.ssh_invocations()
+        "ywatanabe@spartan-login1" in call for call in ssh_exec_shim.invocations()
     )
 
 
@@ -369,205 +311,163 @@ def test_push_reaches_the_peer_over_the_real_ssh_argv(
 # ---------------------------------------------------------------------------
 
 
-def test_lying_chmod_is_caught_and_fails_loud(tmp_path, peer_config, shim) -> None:
+def test_lying_chmod_is_caught_and_fails_loud(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
     # Arrange — a peer FS that accepts chmod and ignores it (CIFS / 9p / ACL).
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
-    staged = Path(str(remote) + STAGED_SUFFIX)
-    staged.parent.mkdir(parents=True, exist_ok=True)
-    staged.touch()
-    staged.chmod(0o644)  # dd truncates in place and keeps this mode
-    shim.install("chmod", _LYING_CHMOD)
-    # Act / Assert — reading the mode back is what catches it.
-    with pytest.raises(SnapshotPushError, match="did not honour"):
-        push_snapshot(
-            "work",
-            local,
-            transport=resolve_peer_transport("spartan"),
-            remote_path=str(remote),
-        )
+    _stage_a_0644_file(remote)
+    ssh_exec_shim.install_binary("chmod", _LYING_CHMOD)
+    # Act
+    error = _push_error(local, remote)
+    # Assert — reading the mode back is what catches it.
+    assert "did not honour" in str(error)
 
 
-def test_lying_chmod_never_publishes_the_token(tmp_path, peer_config, shim) -> None:
+def test_lying_chmod_never_publishes_the_token(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
     # Arrange
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
-    staged = Path(str(remote) + STAGED_SUFFIX)
-    staged.parent.mkdir(parents=True, exist_ok=True)
-    staged.touch()
-    staged.chmod(0o644)
-    shim.install("chmod", _LYING_CHMOD)
+    _stage_a_0644_file(remote)
+    ssh_exec_shim.install_binary("chmod", _LYING_CHMOD)
     # Act
-    with pytest.raises(SnapshotPushError):
-        push_snapshot(
-            "work",
-            local,
-            transport=resolve_peer_transport("spartan"),
-            remote_path=str(remote),
-        )
+    _push_error(local, remote)
     # Assert — a token whose mode cannot be vouched for is never published.
     assert not remote.exists()
 
 
-def test_lying_chmod_removes_the_staged_token(tmp_path, peer_config, shim) -> None:
+def test_lying_chmod_removes_the_staged_token(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
     # Arrange
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
-    staged = Path(str(remote) + STAGED_SUFFIX)
-    staged.parent.mkdir(parents=True, exist_ok=True)
-    staged.touch()
-    staged.chmod(0o644)
-    shim.install("chmod", _LYING_CHMOD)
+    staged = _stage_a_0644_file(remote)
+    ssh_exec_shim.install_binary("chmod", _LYING_CHMOD)
     # Act
-    with pytest.raises(SnapshotPushError):
-        push_snapshot(
-            "work",
-            local,
-            transport=resolve_peer_transport("spartan"),
-            remote_path=str(remote),
-        )
+    _push_error(local, remote)
     # Assert — no world-readable OAuth token is left lying on the peer.
     assert not staged.exists()
 
 
 # ---------------------------------------------------------------------------
-# Fail loud — truncated transfer, unreachable path
+# Fail loud — truncated transfer, unusable remote path, missing snapshot
 # ---------------------------------------------------------------------------
 
 
-def test_truncated_transfer_fails_loud(tmp_path, peer_config, shim) -> None:
-    # Arrange — an ssh stream that died mid-copy leaves dd exiting 0 short.
+def test_truncated_transfer_fails_loud(tmp_path, peer_config, ssh_exec_shim) -> None:
+    # Arrange — an ssh stream that died mid-copy leaves dd exiting 0, short.
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
-    shim.install("dd", _TRUNCATING_DD)
-    # Act / Assert
-    with pytest.raises(SnapshotPushError, match="truncated"):
-        push_snapshot(
-            "work",
-            local,
-            transport=resolve_peer_transport("spartan"),
-            remote_path=str(remote),
-        )
+    ssh_exec_shim.install_binary("dd", _TRUNCATING_DD)
+    # Act
+    error = _push_error(local, remote)
+    # Assert
+    assert "truncated" in str(error)
 
 
-def test_truncated_transfer_never_publishes(tmp_path, peer_config, shim) -> None:
+def test_truncated_transfer_never_publishes(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
     # Arrange
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
-    shim.install("dd", _TRUNCATING_DD)
+    ssh_exec_shim.install_binary("dd", _TRUNCATING_DD)
     # Act
-    with pytest.raises(SnapshotPushError):
-        push_snapshot(
-            "work",
-            local,
-            transport=resolve_peer_transport("spartan"),
-            remote_path=str(remote),
-        )
+    _push_error(local, remote)
     # Assert — a corrupt credential is never mv'd onto the live path.
     assert not remote.exists()
 
 
-def test_unwritable_remote_dir_fails_loud_naming_the_peer(
-    tmp_path, peer_config, shim
+def test_unusable_remote_dir_fails_loud_naming_the_peer(
+    tmp_path, peer_config, ssh_exec_shim
 ) -> None:
     # Arrange — a real ENOTDIR: the parent component is a regular file.
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     blocker = tmp_path / "peer"
-    blocker.parent.mkdir(parents=True, exist_ok=True)
     blocker.write_text("not a directory")
-    remote = blocker / "acct" / ".credentials.json"
-    # Act / Assert — the message names the peer.
-    with pytest.raises(SnapshotPushError, match="spartan"):
-        push_snapshot(
-            "work",
-            local,
-            transport=resolve_peer_transport("spartan"),
-            remote_path=str(remote),
-        )
+    # Act
+    error = _push_error(local, blocker / "acct" / ".credentials.json")
+    # Assert
+    assert "spartan" in str(error)
 
 
-def test_missing_local_snapshot_fails_loud(tmp_path, peer_config, shim) -> None:
+def test_unusable_remote_dir_fails_loud_naming_the_path(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
+    # Arrange
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    blocker = tmp_path / "peer"
+    blocker.write_text("not a directory")
+    # Act
+    error = _push_error(local, blocker / "acct" / ".credentials.json")
+    # Assert
+    assert str(blocker / "acct") in str(error)
+
+
+def test_missing_local_snapshot_fails_loud(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
     # Arrange — nothing to push.
     local = tmp_path / "local" / "acct" / ".credentials.json"
-    # Act / Assert
-    with pytest.raises(SnapshotPushError, match="no snapshot"):
-        push_snapshot(
-            "work",
-            local,
-            transport=resolve_peer_transport("spartan"),
-            remote_path=str(tmp_path / "peer" / "acct" / ".credentials.json"),
-        )
+    # Act
+    error = _push_error(local, tmp_path / "peer" / "acct" / ".credentials.json")
+    # Assert
+    assert "no snapshot" in str(error)
 
 
 def test_unsafe_remote_path_is_refused_before_anything_is_sent(
-    tmp_path, peer_config, shim
+    tmp_path, peer_config, ssh_exec_shim
 ) -> None:
     # Arrange — a path the peer's login shell would re-split.
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
-    # Act / Assert
-    with pytest.raises(SnapshotPushError, match="Nothing was sent"):
-        push_snapshot(
-            "work",
-            local,
-            transport=resolve_peer_transport("spartan"),
-            remote_path="/tmp/a b/.credentials.json",
-        )
+    # Act
+    error = _push_error(local, "/tmp/a b/.credentials.json")
+    # Assert
+    assert "Nothing was sent" in str(error)
 
 
 # ---------------------------------------------------------------------------
-# Token values never leave this machine's memory in renderable form
+# Token values are never rendered
 # ---------------------------------------------------------------------------
 
 
 def test_success_never_puts_a_token_on_a_command_line(
-    tmp_path, peer_config, shim
+    tmp_path, peer_config, ssh_exec_shim
 ) -> None:
     # Arrange
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
     # Act
-    push_snapshot(
-        "work",
-        local,
-        transport=resolve_peer_transport("spartan"),
-        remote_path=str(remote),
-    )
+    _push(local, remote)
     # Assert — the bytes rode stdin; no argv ever carried them.
-    flat = " ".join(a for call in shim.ssh_invocations() for a in call)
+    flat = " ".join(a for call in ssh_exec_shim.invocations() for a in call)
     assert _ACCESS not in flat and _REFRESH not in flat
 
 
-def test_success_record_carries_no_token(tmp_path, peer_config, shim) -> None:
+def test_success_record_carries_no_token(tmp_path, peer_config, ssh_exec_shim) -> None:
     # Arrange
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     remote = tmp_path / "peer" / "acct" / ".credentials.json"
     # Act
-    record = push_snapshot(
-        "work",
-        local,
-        transport=resolve_peer_transport("spartan"),
-        remote_path=str(remote),
-    )
+    record = _push(local, remote)
     # Assert
     rendered = json.dumps(record)
     assert _ACCESS not in rendered and _REFRESH not in rendered
 
 
-def test_failure_message_carries_no_token(tmp_path, peer_config, shim) -> None:
+def test_failure_message_carries_no_token(tmp_path, peer_config, ssh_exec_shim) -> None:
     # Arrange
     local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
     blocker = tmp_path / "peer"
     blocker.write_text("not a directory")
     # Act
-    with pytest.raises(SnapshotPushError) as excinfo:
-        push_snapshot(
-            "work",
-            local,
-            transport=resolve_peer_transport("spartan"),
-            remote_path=str(blocker / "acct" / ".credentials.json"),
-        )
+    error = _push_error(local, blocker / "acct" / ".credentials.json")
     # Assert — errors name paths and accounts, never token material.
-    assert _ACCESS not in str(excinfo.value) and _REFRESH not in str(excinfo.value)
+    assert _ACCESS not in str(error) and _REFRESH not in str(error)
 
 
 # ---------------------------------------------------------------------------
@@ -576,40 +476,27 @@ def test_failure_message_carries_no_token(tmp_path, peer_config, shim) -> None:
 
 
 def test_parse_stat_reads_the_gnu_form() -> None:
-    # Arrange / Act / Assert — `stat -c %a:%s`
-    assert parse_stat("600:1234\n") == ("600", 1234)
+    # Arrange — what `stat -c %a:%s` prints.
+    line = "600:1234\n"
+    # Act
+    parsed = parse_stat(line)
+    # Assert
+    assert parsed == ("600", 1234)
 
 
 def test_parse_stat_normalises_a_leading_zero() -> None:
-    # Arrange / Act / Assert — some coreutils print 0600 for `%Lp`.
-    assert parse_stat("0600:12\n") == ("600", 12)
+    # Arrange — some coreutils print 0600 for `%Lp`.
+    line = "0600:12\n"
+    # Act
+    parsed = parse_stat(line)
+    # Assert
+    assert parsed == ("600", 12)
 
 
 def test_parse_stat_rejects_unreadable_output() -> None:
-    # Arrange / Act / Assert — an unparseable stat is a failure, not a guess.
-    assert parse_stat("stat: cannot statx '/x'") is None
-
-
-def test_transport_reports_a_missing_ssh_binary_as_a_failure(tmp_path) -> None:
-    # Arrange — an SshTransport whose ssh cannot be executed at all.
-    transport = SshTransport(
-        peer="ghost",
-        peers={
-            "ghost": type(
-                "P",
-                (),
-                {
-                    "ssh": "nowhere",
-                    "via": (),
-                    "env_preamble": (),
-                    "jump_chain": lambda self, peers: [],
-                    "joined_preamble": lambda self: "",
-                },
-            )()
-        },
-    )
-    # Act — no `ssh` shim installed and PATH is untouched, so this reaches the
-    # real ssh, which cannot resolve host `nowhere` under BatchMode.
-    result = transport.run(["true"])
-    # Assert — a transport failure is a non-zero return, never a silent OK.
-    assert result.returncode != 0
+    # Arrange — an unparseable stat must be a failure, never a guess.
+    line = "stat: cannot statx '/x'"
+    # Act
+    parsed = parse_stat(line)
+    # Assert
+    assert parsed is None

--- a/tests/scitex_agent_container/_account/test_snapshot_push.py
+++ b/tests/scitex_agent_container/_account/test_snapshot_push.py
@@ -1,0 +1,615 @@
+"""Tests for pushing a refreshed account snapshot to a peer.
+
+No-mocks (PA-306 / STX-NM002). Every test drives the REAL production
+transport: the real :class:`SshTransport` renders its argv through the
+real ``build_ssh_argv``, the real ``subprocess.run`` resolves ``ssh``
+through the real ``$PATH``. Only the NETWORK HOP is replaced — by a real
+``ssh`` executable on ``$PATH`` that runs the post-``--`` remote command
+LOCALLY, joined with spaces and re-parsed by a shell exactly as
+OpenSSH + sshd do. That is the same honest-replacement technique as the
+repo's existing ``ssh_http_shim`` helper.
+
+Everything else is real: the remote ``mkdir`` / ``dd`` / ``chmod`` /
+``stat`` / ``mv`` are the real coreutils, they operate on a real
+directory tree under ``tmp_path``, the token bytes travel over a real
+stdin pipe, and the 0600 assertion is made against a real file's real
+mode as read back by the real ``stat``.
+
+Peer resolution runs against a REAL ``config.yaml`` in ``tmp_path``,
+pinned with ``$SCITEX_AGENT_CONTAINER_CONFIG`` — the same file
+``sac host list`` reads.
+
+AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shlex
+import stat as stat_mod
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._account.snapshot_push import (
+    FILE_MODE,
+    STAGED_SUFFIX,
+    SnapshotPushError,
+    SshTransport,
+    UnknownPeerError,
+    parse_stat,
+    push_snapshot,
+    resolve_peer_transport,
+    ssh_op_argv,
+)
+
+# A distinctive, greppable stand-in for token material. Every no-leak
+# assertion in this module searches for these exact bytes.
+_ACCESS = "ACCESS-TOKEN-MUST-NEVER-BE-PRINTED"
+_REFRESH = "REFRESH-TOKEN-MUST-NEVER-BE-PRINTED"
+
+
+# ---------------------------------------------------------------------------
+# Real-binary shims (honest replacements — no mocks)
+# ---------------------------------------------------------------------------
+
+# Faithful to OpenSSH: everything after `--` is joined with spaces and fed
+# to a shell on the far side. A future quoting bug therefore breaks this
+# test exactly as it would break production.
+_SSH_SHIM = r"""#!/bin/sh
+printf '%s\0' "$@" | base64 | tr -d '\n' >> __LOG__
+printf '\n' >> __LOG__
+__seen=0
+__cmd=
+for __a in "$@"; do
+  if [ "$__seen" = 1 ]; then
+    __cmd="$__cmd $__a"
+  elif [ "$__a" = "--" ]; then
+    __seen=1
+  fi
+done
+if [ "$__seen" != 1 ]; then
+  echo "shim ssh: no -- separator in argv" >&2
+  exit 2
+fi
+exec sh -c "$__cmd"
+"""
+
+# A `dd` whose stdin died mid-stream: it sees EOF early, writes a SHORT
+# file and still exits 0. This is the real failure shape of a dropped ssh
+# transfer, and the reason the push verifies SIZE as well as mode.
+_TRUNCATING_DD = r"""#!/bin/sh
+__of=
+for __a in "$@"; do
+  case "$__a" in
+    of=*) __of=${__a#of=} ;;
+  esac
+done
+head -c 5 > "$__of"
+cat > /dev/null
+exit 0
+"""
+
+# A `chmod` that reports success and changes nothing — the real behaviour
+# of a CIFS / 9p / ACL-backed filesystem. The push must catch this by
+# READING the mode back, not by trusting the chmod's exit code.
+_LYING_CHMOD = r"""#!/bin/sh
+exit 0
+"""
+
+
+class _ShimBin:
+    """A real bin dir on ``$PATH`` holding real executables."""
+
+    def __init__(self, bin_dir: Path) -> None:
+        self.bin = bin_dir
+        self.ssh_log = bin_dir / "ssh.argv.log"
+
+    def install(self, name: str, source: str) -> Path:
+        script = self.bin / name
+        script.write_text(source.replace("__LOG__", shlex.quote(str(self.ssh_log))))
+        script.chmod(0o755)
+        return script
+
+    def ssh_invocations(self) -> list[list[str]]:
+        if not self.ssh_log.exists():
+            return []
+        calls: list[list[str]] = []
+        for line in self.ssh_log.read_text().splitlines():
+            if not line:
+                calls.append([])
+                continue
+            parts = base64.b64decode(line).split(b"\x00")
+            if parts and parts[-1] == b"":
+                parts = parts[:-1]
+            calls.append([p.decode("utf-8", "surrogateescape") for p in parts])
+        return calls
+
+
+@pytest.fixture
+def shim(tmp_path: Path) -> Iterator[_ShimBin]:
+    """Prepend a real bin dir to ``$PATH``; install the executing ssh."""
+    bin_dir = tmp_path / "_shim_bin"
+    bin_dir.mkdir(exist_ok=True)
+    saved = os.environ.get("PATH", "")
+    os.environ["PATH"] = f"{bin_dir}{os.pathsep}{saved}"
+    controller = _ShimBin(bin_dir)
+    controller.install("ssh", _SSH_SHIM)
+    try:
+        yield controller
+    finally:
+        os.environ["PATH"] = saved
+
+
+# ---------------------------------------------------------------------------
+# Real peer config (the same table `sac host list` reads)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def peer_config(tmp_path: Path, env_save_restore) -> Path:
+    """Write a real config.yaml and pin sac's peer lookup at it."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "peers:\n"
+        "  mba:\n"
+        "    ssh: ywatanabe@mba.local\n"
+        "  spartan:\n"
+        "    ssh: ywatanabe@spartan-login1\n"
+        "    via: [mba]\n"
+        "    env_preamble: |\n"
+        "      module load Apptainer/1.3.3\n"
+    )
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    return cfg
+
+
+def _seed_snapshot(path: Path) -> Path:
+    """Write a realistic credentials snapshot carrying token material."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": _ACCESS,
+                    "refreshToken": _REFRESH,
+                    "expiresAt": 9_999_999_999_000,
+                }
+            }
+        )
+    )
+    return path
+
+
+def _mode_of(path: Path) -> str:
+    return oct(stat_mod.S_IMODE(path.stat().st_mode))[2:]
+
+
+# ---------------------------------------------------------------------------
+# Peer-config reuse (requirement: sac's EXISTING peer table, no new config)
+# ---------------------------------------------------------------------------
+
+
+def test_transport_resolves_peer_from_sac_config(peer_config) -> None:
+    # Arrange / Act — the peer name is looked up in the real config.yaml.
+    transport = resolve_peer_transport("spartan")
+    # Assert
+    assert transport.peers["spartan"].ssh == "ywatanabe@spartan-login1"
+
+
+def test_unknown_peer_raises_naming_the_known_peers(peer_config) -> None:
+    # Arrange / Act
+    with pytest.raises(UnknownPeerError) as excinfo:
+        resolve_peer_transport("not-a-peer")
+    # Assert — the error lists the peers that ARE registered.
+    assert "spartan" in str(excinfo.value)
+
+
+def test_ssh_argv_carries_the_peer_ssh_target(peer_config) -> None:
+    # Arrange
+    peers = resolve_peer_transport("spartan").peers
+    # Act
+    argv = ssh_op_argv("spartan", ["stat", "-c", "%a:%s", "/x"], peers)
+    # Assert
+    assert "ywatanabe@spartan-login1" in argv
+
+
+def test_ssh_argv_carries_the_proxyjump_chain(peer_config) -> None:
+    # Arrange
+    peers = resolve_peer_transport("spartan").peers
+    # Act — `via: [mba]` must become ssh's -J chain, resolved to mba's ssh.
+    argv = ssh_op_argv("spartan", ["stat", "-c", "%a:%s", "/x"], peers)
+    # Assert
+    assert argv[argv.index("-J") + 1] == "ywatanabe@mba.local"
+
+
+def test_ssh_argv_omits_the_lmod_env_preamble(peer_config) -> None:
+    # Arrange
+    peers = resolve_peer_transport("spartan").peers
+    # Act — coreutils need no `module load`; wrapping them in one would make
+    # a slow Lmod failure look like a push failure.
+    argv = ssh_op_argv("spartan", ["stat", "-c", "%a:%s", "/x"], peers)
+    # Assert
+    assert not any("module load" in a for a in argv)
+
+
+# ---------------------------------------------------------------------------
+# The happy path — real transfer, real mode, real verification
+# ---------------------------------------------------------------------------
+
+
+def test_push_lands_the_file_on_the_peer(tmp_path, peer_config, shim) -> None:
+    # Arrange
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    # Act
+    push_snapshot(
+        "work",
+        local,
+        transport=resolve_peer_transport("spartan"),
+        remote_path=str(remote),
+    )
+    # Assert — the bytes really arrived.
+    assert remote.read_text() == local.read_text()
+
+
+def test_push_lands_mode_0600(tmp_path, peer_config, shim) -> None:
+    # Arrange
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    # Act
+    push_snapshot(
+        "work",
+        local,
+        transport=resolve_peer_transport("spartan"),
+        remote_path=str(remote),
+    )
+    # Assert — the REAL mode of the REAL landed file.
+    assert _mode_of(remote) == FILE_MODE
+
+
+def test_push_reports_the_verified_mode_it_read_back(
+    tmp_path, peer_config, shim
+) -> None:
+    # Arrange
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    # Act
+    record = push_snapshot(
+        "work",
+        local,
+        transport=resolve_peer_transport("spartan"),
+        remote_path=str(remote),
+    )
+    # Assert — the mode in the record was READ OFF the peer, not assumed.
+    assert record["mode"] == FILE_MODE
+
+
+def test_push_hardens_the_account_directory(tmp_path, peer_config, shim) -> None:
+    # Arrange
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    # Act
+    push_snapshot(
+        "work",
+        local,
+        transport=resolve_peer_transport("spartan"),
+        remote_path=str(remote),
+    )
+    # Assert — 0700 dir closes the window before the file's own chmod lands.
+    assert _mode_of(remote.parent) == "700"
+
+
+def test_push_defaults_to_the_identical_absolute_path(
+    tmp_path, peer_config, shim
+) -> None:
+    # Arrange — no remote_path override: the peer's path IS the local path.
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    # Act
+    record = push_snapshot(
+        "work", local, transport=resolve_peer_transport("spartan")
+    )
+    # Assert
+    assert record["remote_path"] == str(local)
+
+
+def test_push_leaves_no_staging_file_behind(tmp_path, peer_config, shim) -> None:
+    # Arrange
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    # Act
+    push_snapshot(
+        "work",
+        local,
+        transport=resolve_peer_transport("spartan"),
+        remote_path=str(remote),
+    )
+    # Assert — the staged sibling was consumed by the atomic publish.
+    assert not Path(str(remote) + STAGED_SUFFIX).exists()
+
+
+def test_push_is_idempotent(tmp_path, peer_config, shim) -> None:
+    # Arrange — the timer re-runs every 2h against an already-pushed peer.
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    transport = resolve_peer_transport("spartan")
+    push_snapshot("work", local, transport=transport, remote_path=str(remote))
+    # Act — second run over the top of the first.
+    record = push_snapshot(
+        "work", local, transport=transport, remote_path=str(remote)
+    )
+    # Assert
+    assert record["mode"] == FILE_MODE and remote.read_text() == local.read_text()
+
+
+def test_push_reaches_the_peer_over_the_real_ssh_argv(
+    tmp_path, peer_config, shim
+) -> None:
+    # Arrange
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    # Act
+    push_snapshot(
+        "work",
+        local,
+        transport=resolve_peer_transport("spartan"),
+        remote_path=str(remote),
+    )
+    # Assert — production really shelled out to ssh, at the configured peer.
+    assert all(
+        "ywatanabe@spartan-login1" in call for call in shim.ssh_invocations()
+    )
+
+
+# ---------------------------------------------------------------------------
+# The 0600 guarantee is VERIFIED, not assumed
+# ---------------------------------------------------------------------------
+
+
+def test_lying_chmod_is_caught_and_fails_loud(tmp_path, peer_config, shim) -> None:
+    # Arrange — a peer FS that accepts chmod and ignores it (CIFS / 9p / ACL).
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    staged = Path(str(remote) + STAGED_SUFFIX)
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    staged.touch()
+    staged.chmod(0o644)  # dd truncates in place and keeps this mode
+    shim.install("chmod", _LYING_CHMOD)
+    # Act / Assert — reading the mode back is what catches it.
+    with pytest.raises(SnapshotPushError, match="did not honour"):
+        push_snapshot(
+            "work",
+            local,
+            transport=resolve_peer_transport("spartan"),
+            remote_path=str(remote),
+        )
+
+
+def test_lying_chmod_never_publishes_the_token(tmp_path, peer_config, shim) -> None:
+    # Arrange
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    staged = Path(str(remote) + STAGED_SUFFIX)
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    staged.touch()
+    staged.chmod(0o644)
+    shim.install("chmod", _LYING_CHMOD)
+    # Act
+    with pytest.raises(SnapshotPushError):
+        push_snapshot(
+            "work",
+            local,
+            transport=resolve_peer_transport("spartan"),
+            remote_path=str(remote),
+        )
+    # Assert — a token whose mode cannot be vouched for is never published.
+    assert not remote.exists()
+
+
+def test_lying_chmod_removes_the_staged_token(tmp_path, peer_config, shim) -> None:
+    # Arrange
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    staged = Path(str(remote) + STAGED_SUFFIX)
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    staged.touch()
+    staged.chmod(0o644)
+    shim.install("chmod", _LYING_CHMOD)
+    # Act
+    with pytest.raises(SnapshotPushError):
+        push_snapshot(
+            "work",
+            local,
+            transport=resolve_peer_transport("spartan"),
+            remote_path=str(remote),
+        )
+    # Assert — no world-readable OAuth token is left lying on the peer.
+    assert not staged.exists()
+
+
+# ---------------------------------------------------------------------------
+# Fail loud — truncated transfer, unreachable path
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_transfer_fails_loud(tmp_path, peer_config, shim) -> None:
+    # Arrange — an ssh stream that died mid-copy leaves dd exiting 0 short.
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    shim.install("dd", _TRUNCATING_DD)
+    # Act / Assert
+    with pytest.raises(SnapshotPushError, match="truncated"):
+        push_snapshot(
+            "work",
+            local,
+            transport=resolve_peer_transport("spartan"),
+            remote_path=str(remote),
+        )
+
+
+def test_truncated_transfer_never_publishes(tmp_path, peer_config, shim) -> None:
+    # Arrange
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    shim.install("dd", _TRUNCATING_DD)
+    # Act
+    with pytest.raises(SnapshotPushError):
+        push_snapshot(
+            "work",
+            local,
+            transport=resolve_peer_transport("spartan"),
+            remote_path=str(remote),
+        )
+    # Assert — a corrupt credential is never mv'd onto the live path.
+    assert not remote.exists()
+
+
+def test_unwritable_remote_dir_fails_loud_naming_the_peer(
+    tmp_path, peer_config, shim
+) -> None:
+    # Arrange — a real ENOTDIR: the parent component is a regular file.
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    blocker = tmp_path / "peer"
+    blocker.parent.mkdir(parents=True, exist_ok=True)
+    blocker.write_text("not a directory")
+    remote = blocker / "acct" / ".credentials.json"
+    # Act / Assert — the message names the peer.
+    with pytest.raises(SnapshotPushError, match="spartan"):
+        push_snapshot(
+            "work",
+            local,
+            transport=resolve_peer_transport("spartan"),
+            remote_path=str(remote),
+        )
+
+
+def test_missing_local_snapshot_fails_loud(tmp_path, peer_config, shim) -> None:
+    # Arrange — nothing to push.
+    local = tmp_path / "local" / "acct" / ".credentials.json"
+    # Act / Assert
+    with pytest.raises(SnapshotPushError, match="no snapshot"):
+        push_snapshot(
+            "work",
+            local,
+            transport=resolve_peer_transport("spartan"),
+            remote_path=str(tmp_path / "peer" / "acct" / ".credentials.json"),
+        )
+
+
+def test_unsafe_remote_path_is_refused_before_anything_is_sent(
+    tmp_path, peer_config, shim
+) -> None:
+    # Arrange — a path the peer's login shell would re-split.
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    # Act / Assert
+    with pytest.raises(SnapshotPushError, match="Nothing was sent"):
+        push_snapshot(
+            "work",
+            local,
+            transport=resolve_peer_transport("spartan"),
+            remote_path="/tmp/a b/.credentials.json",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Token values never leave this machine's memory in renderable form
+# ---------------------------------------------------------------------------
+
+
+def test_success_never_puts_a_token_on_a_command_line(
+    tmp_path, peer_config, shim
+) -> None:
+    # Arrange
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    # Act
+    push_snapshot(
+        "work",
+        local,
+        transport=resolve_peer_transport("spartan"),
+        remote_path=str(remote),
+    )
+    # Assert — the bytes rode stdin; no argv ever carried them.
+    flat = " ".join(a for call in shim.ssh_invocations() for a in call)
+    assert _ACCESS not in flat and _REFRESH not in flat
+
+
+def test_success_record_carries_no_token(tmp_path, peer_config, shim) -> None:
+    # Arrange
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    # Act
+    record = push_snapshot(
+        "work",
+        local,
+        transport=resolve_peer_transport("spartan"),
+        remote_path=str(remote),
+    )
+    # Assert
+    rendered = json.dumps(record)
+    assert _ACCESS not in rendered and _REFRESH not in rendered
+
+
+def test_failure_message_carries_no_token(tmp_path, peer_config, shim) -> None:
+    # Arrange
+    local = _seed_snapshot(tmp_path / "local" / "acct" / ".credentials.json")
+    blocker = tmp_path / "peer"
+    blocker.write_text("not a directory")
+    # Act
+    with pytest.raises(SnapshotPushError) as excinfo:
+        push_snapshot(
+            "work",
+            local,
+            transport=resolve_peer_transport("spartan"),
+            remote_path=str(blocker / "acct" / ".credentials.json"),
+        )
+    # Assert — errors name paths and accounts, never token material.
+    assert _ACCESS not in str(excinfo.value) and _REFRESH not in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# stat parsing (GNU + BSD)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_stat_reads_the_gnu_form() -> None:
+    # Arrange / Act / Assert — `stat -c %a:%s`
+    assert parse_stat("600:1234\n") == ("600", 1234)
+
+
+def test_parse_stat_normalises_a_leading_zero() -> None:
+    # Arrange / Act / Assert — some coreutils print 0600 for `%Lp`.
+    assert parse_stat("0600:12\n") == ("600", 12)
+
+
+def test_parse_stat_rejects_unreadable_output() -> None:
+    # Arrange / Act / Assert — an unparseable stat is a failure, not a guess.
+    assert parse_stat("stat: cannot statx '/x'") is None
+
+
+def test_transport_reports_a_missing_ssh_binary_as_a_failure(tmp_path) -> None:
+    # Arrange — an SshTransport whose ssh cannot be executed at all.
+    transport = SshTransport(
+        peer="ghost",
+        peers={
+            "ghost": type(
+                "P",
+                (),
+                {
+                    "ssh": "nowhere",
+                    "via": (),
+                    "env_preamble": (),
+                    "jump_chain": lambda self, peers: [],
+                    "joined_preamble": lambda self: "",
+                },
+            )()
+        },
+    )
+    # Act — no `ssh` shim installed and PATH is untouched, so this reaches the
+    # real ssh, which cannot resolve host `nowhere` under BatchMode.
+    result = transport.run(["true"])
+    # Assert — a transport failure is a non-zero return, never a silent OK.
+    assert result.returncode != 0

--- a/tests/scitex_agent_container/_helpers/ssh_exec_shim.py
+++ b/tests/scitex_agent_container/_helpers/ssh_exec_shim.py
@@ -1,0 +1,117 @@
+"""Reusable test helper: an ``ssh`` that runs the remote command LOCALLY.
+
+Honest replacement for mocking ``subprocess.run`` (STX-NM002). Sibling of
+:mod:`ssh_http_shim` (which stands in for ssh by performing a real HTTP
+POST); this one stands in for ssh by performing a real LOCAL EXEC.
+
+Production code builds its REAL ssh argv (via
+``_state.host_config.build_ssh_argv``, so the peer's ``ssh:`` target,
+``via:`` ProxyJump chain and BatchMode/ControlMaster options are all real),
+the REAL ``subprocess.run`` resolves ``ssh`` through the REAL ``$PATH``,
+and this shim then executes the REAL remote command — ``mkdir``, ``dd``,
+``chmod``, ``stat``, ``mv`` — against a REAL directory tree in ``tmp_path``,
+with the REAL bytes flowing over the REAL stdin pipe.
+
+Faithful to OpenSSH semantics: everything after the ``--`` separator is
+joined with spaces and handed to a shell, because that is exactly what
+sshd does with the post-host argv. A quoting bug introduced later
+therefore breaks the test the same way it would break production.
+
+``install_binary`` additionally materialises any other real executable on
+the same PATH dir, so a test can model a hostile peer (a ``chmod`` that
+lies, a ``dd`` whose stream died) with a real program rather than a mock.
+
+Usage::
+
+    def test_push(ssh_exec_shim, tmp_path):
+        push_snapshot("work", local, transport=resolve_peer_transport("spartan"))
+        assert oct(remote.stat().st_mode)[-3:] == "600"
+        assert "spartan-login1" in " ".join(ssh_exec_shim.invocations()[0])
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import shlex
+from pathlib import Path
+
+import pytest
+
+# Everything after `--` is joined with spaces and re-parsed by a shell —
+# precisely what OpenSSH + sshd do with the post-host argv. stdin, stdout,
+# stderr and the exit status all pass through untouched.
+_SSH_SOURCE = r"""#!/bin/sh
+printf '%s\0' "$@" | base64 | tr -d '\n' >> __LOG__
+printf '\n' >> __LOG__
+__seen=0
+__cmd=
+for __a in "$@"; do
+  if [ "$__seen" = 1 ]; then
+    __cmd="$__cmd $__a"
+  elif [ "$__a" = "--" ]; then
+    __seen=1
+  fi
+done
+if [ "$__seen" != 1 ]; then
+  echo "shim ssh: no -- separator in argv" >&2
+  exit 2
+fi
+exec sh -c "$__cmd"
+"""
+
+
+class _SshExecShim:
+    """Controller for the local-exec ssh shim."""
+
+    def __init__(self, bin_dir: Path) -> None:
+        self.bin = bin_dir
+        self.log = bin_dir / "ssh.argv.log"
+
+    def install(self) -> Path:
+        """Materialise the local-exec ``ssh`` at ``$bin_dir/ssh``."""
+        return self.install_binary("ssh", _SSH_SOURCE)
+
+    def install_binary(self, name: str, source: str) -> Path:
+        """Materialise any real ``/bin/sh`` executable on the shim PATH.
+
+        ``__LOG__`` in ``source`` is substituted with the shell-quoted argv
+        log path, so a shim can record its own invocations if it wants to.
+        """
+        script = self.bin / name
+        script.write_text(source.replace("__LOG__", shlex.quote(str(self.log))))
+        script.chmod(0o755)
+        return script
+
+    def invocations(self) -> list[list[str]]:
+        """Every ssh argv, decoded. One record per call (base64 of NUL-joined)."""
+        if not self.log.exists():
+            return []
+        calls: list[list[str]] = []
+        for line in self.log.read_text().splitlines():
+            if not line:
+                calls.append([])
+                continue
+            parts = base64.b64decode(line).split(b"\x00")
+            if parts and parts[-1] == b"":
+                parts = parts[:-1]
+            calls.append([p.decode("utf-8", "surrogateescape") for p in parts])
+        return calls
+
+
+@pytest.fixture
+def ssh_exec_shim(tmp_path: Path):
+    """PATH-prepended ``ssh`` that executes the remote command locally.
+
+    Yields an installed :class:`_SshExecShim`. Auto-restores ``PATH``.
+    """
+    bin_dir = tmp_path / "_shim_bin"
+    bin_dir.mkdir(exist_ok=True)
+    saved_path = os.environ.get("PATH", "")
+    os.environ["PATH"] = f"{bin_dir}{os.pathsep}{saved_path}"
+    controller = _SshExecShim(bin_dir)
+    controller.install()
+    try:
+        yield controller
+    finally:
+        os.environ["PATH"] = saved_path

--- a/tests/scitex_agent_container/cli_pkg/test__account_refresh_push.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_refresh_push.py
@@ -1,0 +1,374 @@
+"""Tests for ``sac accounts refresh --push-to <peer>``.
+
+The gap: the host-side ``sac.accounts-refresh`` timer is the SOLE refresher
+under the single-refresher model, but that only reaches agents sharing this
+machine's filesystem. A peer (Spartan) is a different box, so the copy of
+the snapshot its agents bind is refreshed by NOTHING and silently 401s
+within one access-token lifetime. ``--push-to`` copies each freshly-rotated
+snapshot to the peer's identical absolute path.
+
+No-mocks (PA-306 / STX-NM002). Real on-disk credentials under a real
+(redirected) ``$HOME``; a real ``config.yaml`` pinned with
+``$SCITEX_AGENT_CONTAINER_CONFIG`` (the same file ``sac host list`` reads);
+the OAuth HTTP call injected at the ``urllib.request.urlopen`` production
+boundary; and the push driven through the REAL ssh transport, with only the
+network hop replaced by the ``ssh_exec_shim`` helper (a real ``ssh`` on
+``$PATH`` that runs the remote command locally). An UNREACHABLE peer is
+modelled with the repo's ``subprocess_shim`` — a real ``ssh`` binary that
+exits 255, exactly as a real one does when the host is unreachable.
+
+AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import json
+import stat as stat_mod
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._state.account_store import save_account
+from scitex_agent_container.cli_pkg._account_refresh_push import refreshed_accounts
+from scitex_agent_container.cli_pkg.account_group import account
+
+_FUTURE_MS = 9_999_999_999_000  # far-future expiry (skipped: plenty of TTL)
+_PAST_MS = 1_000_000_000_000  # 2001 — long expired (refreshed)
+
+# Distinctive stand-ins for token material; the no-leak test greps for these.
+_NEW_ACCESS = "NEW-ACCESS-SECRET-XYZ"
+_NEW_REFRESH = "NEW-REFRESH-SECRET-XYZ"
+
+
+@pytest.fixture(autouse=True)
+def sandbox_home(tmp_path, env_save_restore) -> Path:
+    """Redirect ``$HOME`` so ``Path.home()`` lands inside ``tmp_path``."""
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def peer_config(tmp_path, env_save_restore) -> Path:
+    """Write a real config.yaml and pin sac's peer lookup at it."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("peers:\n  spartan:\n    ssh: ywatanabe@spartan-login1\n")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    return cfg
+
+
+class _FakeResp:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self):
+        return self._body
+
+
+@pytest.fixture
+def opener_swap() -> Iterator[dict]:
+    """Swap ``urllib.request.urlopen`` at the production boundary."""
+    import urllib.request
+
+    state: dict[str, Any] = {
+        "response": {
+            "access_token": _NEW_ACCESS,
+            "refresh_token": _NEW_REFRESH,
+            "expires_in": 3600,
+        }
+    }
+    saved = urllib.request.urlopen
+
+    def fake_urlopen(req, timeout=None):
+        return _FakeResp(json.dumps(state["response"]).encode())
+
+    urllib.request.urlopen = fake_urlopen  # type: ignore[assignment]
+    try:
+        yield state
+    finally:
+        urllib.request.urlopen = saved  # type: ignore[assignment]
+
+
+def _store_dir(home: Path) -> Path:
+    return home / ".scitex" / "agent-container" / "accounts"
+
+
+def _seed_account(home: Path, name: str, *, expires_ms: int) -> Path:
+    """Create a stored account with a real credentials snapshot on disk."""
+    save_account(name, {"email_address": f"{name}@x"}, home=home)
+    creds = _store_dir(home) / name / ".credentials.json"
+    creds.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "OLD-ACCESS",
+                    "refreshToken": "OLD-REFRESH",
+                    "clientId": "cid",
+                    "expiresAt": expires_ms,
+                }
+            }
+        )
+    )
+    return creds
+
+
+def _mode_of(path: Path) -> str:
+    return oct(stat_mod.S_IMODE(path.stat().st_mode))[2:]
+
+
+def _access_token_at(path: Path) -> str:
+    return json.loads(path.read_text())["claudeAiOauth"]["accessToken"]
+
+
+# ---------------------------------------------------------------------------
+# Only the accounts that ACTUALLY rotated are pushed
+# ---------------------------------------------------------------------------
+
+
+def test_refreshed_accounts_includes_a_rotated_account() -> None:
+    # Arrange
+    results = [{"name": "work", "success": True, "credentials_path": "/x"}]
+    # Act
+    selected = refreshed_accounts(results)
+    # Assert
+    assert [r["name"] for r in selected] == ["work"]
+
+
+def test_refreshed_accounts_excludes_a_skipped_fresh_account() -> None:
+    # Arrange — the refresher runs on a short cadence and mostly skips.
+    # Pushing a skipped account would turn that cadence into a copy storm.
+    results = [
+        {"name": "fresh", "success": None, "skipped": True, "credentials_path": "/x"}
+    ]
+    # Act
+    selected = refreshed_accounts(results)
+    # Assert
+    assert selected == []
+
+
+def test_refreshed_accounts_excludes_a_failed_account() -> None:
+    # Arrange — a failed refresh must never overwrite the peer's copy.
+    results = [
+        {"name": "dead", "success": False, "skipped": False, "credentials_path": "/x"}
+    ]
+    # Act
+    selected = refreshed_accounts(results)
+    # Assert
+    assert selected == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: refresh, then push to the peer
+# ---------------------------------------------------------------------------
+
+
+def test_push_to_exits_zero_on_success(
+    sandbox_home, peer_config, opener_swap, ssh_exec_shim
+) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--push-to", "spartan"])
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_push_to_lands_the_snapshot_at_mode_0600(
+    sandbox_home, peer_config, opener_swap, ssh_exec_shim
+) -> None:
+    # Arrange
+    creds = _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--push-to", "spartan"])
+    # Assert — the REAL mode of the REAL file the push landed on the peer.
+    assert _mode_of(creds) == "600"
+
+
+def test_push_to_delivers_the_rotated_token(
+    sandbox_home, peer_config, opener_swap, ssh_exec_shim
+) -> None:
+    # Arrange
+    creds = _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--push-to", "spartan"])
+    # Assert — the peer received the FRESH token, not the pre-refresh one.
+    assert _access_token_at(creds) == _NEW_ACCESS
+
+
+def test_push_to_reports_the_peer_and_the_remote_path(
+    sandbox_home, peer_config, opener_swap, ssh_exec_shim
+) -> None:
+    # Arrange
+    creds = _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--push-to", "spartan"])
+    # Assert
+    assert f"pushed -> spartan:{creds}" in result.output
+
+
+def test_push_to_records_the_peer_in_json_output(
+    sandbox_home, peer_config, opener_swap, ssh_exec_shim
+) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        account, ["refresh", "--all", "--push-to", "spartan", "--json"]
+    )
+    # Assert
+    assert json.loads(result.stdout)[0]["pushed_to"] == "spartan"
+
+
+def test_skipped_fresh_account_is_not_pushed(
+    sandbox_home, peer_config, opener_swap, ssh_exec_shim
+) -> None:
+    # Arrange — nothing rotates, so nothing should be copied to the peer.
+    _seed_account(sandbox_home, "fresh", expires_ms=_FUTURE_MS)
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--push-to", "spartan"])
+    # Assert — the push never even reached ssh.
+    assert ssh_exec_shim.invocations() == []
+
+
+def test_skipped_fresh_account_says_nothing_to_push(
+    sandbox_home, peer_config, opener_swap, ssh_exec_shim
+) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "fresh", expires_ms=_FUTURE_MS)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--push-to", "spartan"])
+    # Assert
+    assert "no account rotated this run" in result.output
+
+
+def test_push_to_does_not_leak_token_values(
+    sandbox_home, peer_config, opener_swap, ssh_exec_shim
+) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--push-to", "spartan"])
+    # Assert — paths and account names only; never token material.
+    assert _NEW_ACCESS not in result.output and _NEW_REFRESH not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Unknown peer — rejected BEFORE a single-use refresh_token is spent
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_peer_exits_two(sandbox_home, peer_config, opener_swap) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--push-to", "nope"])
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_unknown_peer_does_not_spend_a_refresh_token(
+    sandbox_home, peer_config, opener_swap
+) -> None:
+    # Arrange — the refresh_token is SINGLE-USE; a typo must not burn it.
+    creds = _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--push-to", "nope"])
+    # Assert — the peer was validated first, so nothing rotated.
+    assert _access_token_at(creds) == "OLD-ACCESS"
+
+
+# ---------------------------------------------------------------------------
+# Fail loud — an unreachable peer fails the RUN, never a silent success
+# ---------------------------------------------------------------------------
+
+
+def _unreachable_peer(subprocess_shim) -> None:
+    """Install a real ``ssh`` that fails exactly as an unreachable host does."""
+    subprocess_shim.install(
+        "ssh",
+        exit=255,
+        stderr="ssh: connect to host spartan-login1 port 22: No route to host",
+    )
+
+
+def test_unreachable_peer_fails_the_run(
+    sandbox_home, peer_config, opener_swap, subprocess_shim
+) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    _unreachable_peer(subprocess_shim)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--push-to", "spartan"])
+    # Assert — a silent success here would recreate the invisible staleness.
+    assert result.exit_code != 0
+
+
+def test_unreachable_peer_names_the_peer(
+    sandbox_home, peer_config, opener_swap, subprocess_shim
+) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    _unreachable_peer(subprocess_shim)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--push-to", "spartan"])
+    # Assert
+    assert "PUSH FAILED -> spartan" in result.output
+
+
+def test_unreachable_peer_names_the_path(
+    sandbox_home, peer_config, opener_swap, subprocess_shim
+) -> None:
+    # Arrange
+    creds = _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    _unreachable_peer(subprocess_shim)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--push-to", "spartan"])
+    # Assert
+    assert str(creds.parent) in result.output
+
+
+def test_unreachable_peer_does_not_leak_token_values(
+    sandbox_home, peer_config, opener_swap, subprocess_shim
+) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    _unreachable_peer(subprocess_shim)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--push-to", "spartan"])
+    # Assert — even the failure path renders paths only.
+    assert _NEW_ACCESS not in result.output and _NEW_REFRESH not in result.output
+
+
+def test_refresh_without_push_to_never_touches_a_peer(
+    sandbox_home, peer_config, opener_swap, ssh_exec_shim
+) -> None:
+    # Arrange — the flag is OPT-IN; the default must behave exactly as before.
+    _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all"])
+    # Assert
+    assert ssh_exec_shim.invocations() == []


### PR DESCRIPTION
## ⚠️ Proposal only — DO NOT DEPLOY on merge

**This PR deliberately does NOT wire `--push-to` into anything.** The systemd unit is untouched, the running `ExecStart` is unchanged, and **no credential has been pushed to Spartan.** Shipping an OAuth token to Spartan's shared HPC filesystem is the operator's call, not mine — **this PR is the proposal for that decision.** Merging changes no runtime behaviour: the flag is opt-in and nothing passes it.

## The gap

Under the master-host single-refresher model (`runtimes/_apptainer_creds.py`), the host-side `sac.accounts-refresh` timer is the **sole** refresher: agents bind the per-account snapshot `:ro` and never rotate the single-use OAuth `refresh_token` themselves. One refresh serves every agent pinned to that account, because the token is fungible across them.

That model only reaches agents that **share this machine's filesystem.**

Spartan is a different box. `/home/ywatanabe` existing on both is a coincidence of layout, not a shared mount. A sac agent on Spartan binds *Spartan's own* copy of `~/.scitex/agent-container/accounts/<acct>/.credentials.json` — which **nothing ever refreshes**. It silently 401s within one access-token lifetime (~8h). Nothing pushes the refreshed snapshot to the peer.

## The change

An **opt-in** `--push-to PEER` on `sac accounts refresh`. After a successful refresh, each snapshot that **actually rotated in this run** is copied to the peer's identical absolute path.

```
$ sac accounts refresh --all --push-to spartan
  stale                 refreshed; new expiry 2026-07-13T12:04:11+00:00
  stale                 pushed -> spartan:/home/ywatanabe/.scitex/agent-container/accounts/stale/.credentials.json (mode 0600, 1183 bytes, verified)
```

### 1. Peer resolution reuses sac's existing peer table

No second host config is invented. `resolve_peer_transport()` reads the same `config.yaml` behind `sac host list` via `host_config.load()`, and every remote op is rendered by the same `build_ssh_argv()` that `sac host exec` and cross-host agent dispatch already use — so the `ssh:` target, the `via:` ProxyJump chain, the BatchMode / accept-new-TOFU policy and ControlMaster multiplexing all come from one place.

* `src/scitex_agent_container/_account/snapshot_push.py:216-226` — `resolve_peer_transport()` → `host_config.load()` → `cfg.peers`
* `src/scitex_agent_container/_account/snapshot_push.py:155-158` — `ssh_op_argv()` → `build_ssh_argv()`

An **unknown peer is rejected before any refresh runs** (`cli_pkg/_account_refresh.py:232-243`), so a typo'd peer name never costs a single-use `refresh_token` rotation.

The peer's `env_preamble` is deliberately stripped for these ops (`_peers_with_lean_preamble`): it exists to put `apptainer` on `$PATH` behind Lmod, and wrapping `mkdir` / `stat` in a multi-second `module load` chain would make an Lmod failure look like a push failure. These ops are coreutils, present on any peer's default PATH.

### 2. The 0600 mode is VERIFIED, not assumed

The remote file must land `0600`, and **the mode is read back off the peer and asserted** — never inferred from a flag having been passed. `stat_remote()` runs `stat -c %a:%s` (GNU) with a `stat -f %Lp:%z` fallback (a BSD/macOS peer such as `mba`) and compares the result to `FILE_MODE`.

This is not pedantry: a filesystem that *accepts* `chmod` and silently ignores it (CIFS, 9p, some ACL mounts) would otherwise leave a **world-readable OAuth token on a shared HPC filesystem**. That case is caught and refused.

### 3. Nothing is published before it verifies

1. `mkdir -p` + `chmod 700` the account dir **first**, so the staged file cannot be world-readable even for the instant between `dd` creating it under the remote umask and its own `chmod`.
2. The bytes land on a **staged sibling**, never on the live path.
3. Mode **and size** are verified. Size matters as much as mode: a dropped ssh stream leaves the remote `dd` exiting 0 on a **truncated** file, which would publish a corrupt credential.
4. Only a verified staged file is published, by an atomic same-directory `mv`.
5. The live path is then re-verified.

Any failure removes the staged file and leaves the peer's **previous snapshot untouched**. (A `stat` that cannot *run* after the publish fails the run loud but does **not** delete — that same inode was already proven 0600 and complete before the rename, so deleting would strip the peer of its credentials for no security gain.)

### 4. Fail loud

Any push failure exits **non-zero**, naming the peer and the path:

```
  stale                 PUSH FAILED -> spartan:/home/.../accounts/stale/.credentials.json — failed to create /home/.../accounts/stale on peer 'spartan' (`mkdir` exited 255): ssh: connect to host spartan-login1 port 22: No route to host
```

A silent push failure would recreate **exactly the invisible staleness this flag exists to kill**, so it is never a silent success.

### 5. Token values never leave memory in renderable form

The bytes travel **exactly once** — over the transport's stdin, into the remote `dd`. Never an argv, never an environment variable, never stdout/stderr, never an exception message. Only account names and paths are rendered. Asserted on both the success and the failure path, including a check that no token byte ever reached a command line.

### 6. Only accounts that actually rotated are pushed

The timer fires on a short cadence and correctly logs `skipped; token still fresh (TTL >= 2h)` on most runs. A skipped-fresh account is a **no-op** for the push, and a failed refresh never overwrites the peer's copy — otherwise that cadence turns into a pointless remote-copy storm. (`refreshed_accounts()` in `cli_pkg/_account_refresh_push.py`.)

## Tests — no mocks (46 new, all green)

The repo bans mocks, so the tests drive the **real production transport**: the real `SshTransport` renders its real argv through the real `build_ssh_argv`, and the real `subprocess.run` resolves `ssh` through the real `$PATH`. **Only the network hop is replaced** — by a new `ssh_exec_shim` helper (sibling of the existing `ssh_http_shim`): a real `ssh` executable on `$PATH` that runs the post-`--` remote command **locally**, joined with spaces and re-parsed by a shell exactly as OpenSSH + sshd do. A quoting bug introduced later therefore breaks the test the same way it would break production.

Everything else is real. The remote `mkdir` / `dd` / `chmod` / `stat` / `mv` are the real coreutils, operating on a real directory tree in `tmp_path`, with the real bytes on a real stdin pipe.

* **0600 verified for real** — `test_push_lands_mode_0600` asserts the real mode of the real landed file; `test_push_reports_the_verified_mode_it_read_back` asserts the mode in the returned record, which was read off the "peer" by the real `stat`.
* **The lying-chmod hazard** — a real `chmod` that exits 0 and changes nothing (a CIFS/9p/ACL filesystem). Three tests: the push fails loud, the token is **never published**, and the staged file is **removed**.
* **Truncated transfer** — a real `dd` whose stdin died mid-stream (writes short, exits 0). Fails loud; never publishes.
* **Unreachable peer** — a real `ssh` that exits 255 exactly as a real one does. The CLI exits non-zero and names both the peer and the path.
* **Peer-config reuse** — asserted against a real `config.yaml` in `tmp_path` (pinned via `$SCITEX_AGENT_CONTAINER_CONFIG`): the peer's ssh target and the resolved `-J` ProxyJump chain both appear in the rendered argv.
* **Fail-fast** — `test_unknown_peer_does_not_spend_a_refresh_token` proves the snapshot is untouched when the peer name is bogus.

```
46 passed  (tests/.../_account/test_snapshot_push.py + tests/.../cli_pkg/test__account_refresh_push.py)
scitex-dev ecosystem audit-project scitex-agent-container --path <worktree>: no project-structure violations
```

## Open question for the operator

Do you want the refreshed snapshot shipped to Spartan's filesystem at all?

* **If yes** — the deployment step is adding `--push-to spartan` to the timer's `ExecStart`. **Deliberately not done in this PR.**
* **If no** — close this PR and solve the Spartan-agent credential problem another way (e.g. a short-lived token fetched at agent start, so nothing OAuth-shaped is ever at rest on shared HPC storage).

## Note on history

The `rescue: pre-stop autosave` commits on this branch are fleet pre-stop autosaves that fired when this agent was killed mid-task by the (now-fixed) auth-preflight token rotation. They carry the same reviewed content; squash-merging collapses them away. The merge commit brings `develop` (incl. #643) in — the net diff is exactly the 7 files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
