### PR TITLE
feat(agents-stop): bulk selection flags (--all-running/--all-registry/--all), shared with restart

### DIFF
--- a/examples/07_stop_and_remove.sh
+++ b/examples/07_stop_and_remove.sh
@@ -35,8 +35,14 @@
 #   sac agents stop <name>                    # graceful: SDK quit-turn then SIGTERM
 #   sac agents stop a b c                     # multiple in parallel
 #   sac agents stop <name> --force            # tolerate stale state files
-#   sac agents stop --all                     # every registered, running agent
+#   sac agents stop --all-running -y          # the LIVE fleet (incident panic button)
+#   sac agents stop --all-registry -y         # EVERY registered agent, stopped ones too
+#   sac agents stop --all -y                  # back-compat alias for --all-registry
+#   sac agents stop --all-running --dry-run   # preview the blast radius (no -y needed)
 #   sac agents delete <name> -y               # remove registry entry + state dir
+#
+# The selection flags are the SAME three `sac agents restart` takes, with the
+# same semantics and the same -y gate — the two fleet verbs share one surface.
 #
 # Three-stage shutdown sequence sac follows:
 #   1. POST a "quit" turn to the SDK so any in-flight tool call has a
@@ -59,7 +65,9 @@ echo '  # → quit-turn sent; instance stopped; state files cleaned'
 echo
 echo "── (B) Stop all (panic button) ──"
 echo '$ apptainer instance stop --all'
-echo '$ sac agents stop --all'
+echo '$ sac agents stop --all-running --dry-run   # preview: what WOULD go down'
+echo '$ sac agents stop --all-running -y          # commit: down the live fleet'
+echo '  # → a deliberately-stopped agent stays stopped; --all-registry takes those too'
 
 echo
 echo "── (C) Force-stop a wedged agent ──"

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_restart.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_restart.py
@@ -39,6 +39,12 @@ from ...config._resolve import resolve_with_prefix
 from .._helpers import agent_name_complete, console
 from ._dispatch import try_dispatch_remote
 from ._host_routing import spec_host_fallback_peer
+from ._selection import (
+    _enumerate_fleet,
+    _enumerate_running,
+    bulk_selection_options,
+    resolve_selection,
+)
 
 
 def _dispatch_remote_restart(peer: str, row: dict, peers: dict, name: str) -> dict:
@@ -154,56 +160,6 @@ def _bypass_base_url_available() -> bool:
     except RestartRequestError:
         return False
     return True
-
-
-def _enumerate_fleet() -> list[str]:
-    """Return every agent name ``sac agents list`` shows (the ``--all-registry`` set).
-
-    Reuses the SAME data function the ``list`` command uses
-    (:func:`cli_pkg._helpers.get_agent_list_data`) so ``--all-registry`` is
-    exactly "everything ``sac agents list`` shows" — registered/running
-    agents plus on-disk-defined ones — with no separate enumeration path to
-    drift. Order-preserving de-dup by name.
-    """
-    from .._helpers import get_agent_list_data
-    from ..._state.registry import Registry
-
-    seen: set[str] = set()
-    names: list[str] = []
-    for row in get_agent_list_data(Registry()):
-        name = row.get("name")
-        if name and name not in seen:
-            seen.add(name)
-            names.append(name)
-    return names
-
-
-def _enumerate_running() -> list[str]:
-    """Return only the agents that are currently RUNNING (the ``--all-running`` set).
-
-    Reuses the SAME data function — and therefore the SAME liveness — the
-    ``list`` / ``status`` commands use
-    (:func:`cli_pkg._helpers.get_agent_list_data`), keeping only rows whose
-    ``status`` probe read ``"running"`` (identity-based liveness: the
-    session exists AND its pane process is alive — see
-    ``_agent_list._probe_local``). Rows that are ``stopped`` / ``unknown`` /
-    ``defined`` / ``invalid`` are excluded, so a plain ``restart --all-running``
-    never wakes an agent the operator had deliberately stopped. No separate
-    liveness rule is invented here. Order-preserving de-dup by name.
-    """
-    from .._helpers import get_agent_list_data
-    from ..._state.registry import Registry
-
-    seen: set[str] = set()
-    names: list[str] = []
-    for row in get_agent_list_data(Registry()):
-        if row.get("status") != "running":
-            continue
-        name = row.get("name")
-        if name and name not in seen:
-            seen.add(name)
-            names.append(name)
-    return names
 
 
 def _restart_one(name: str, *, as_json: bool, fresh: bool) -> tuple[dict, bool]:
@@ -327,41 +283,7 @@ def _restart_one(name: str, *, as_json: bool, fresh: bool) -> tuple[dict, bool]:
     required=False,
     shell_complete=agent_name_complete,
 )
-@click.option(
-    "--all-running",
-    "all_running",
-    is_flag=True,
-    default=False,
-    help=(
-        "Restart ONLY the agents that are currently RUNNING (live session). "
-        "The least-surprising choice for 'restart the live fleet' — a "
-        "deliberately-stopped agent stays stopped. Mutually exclusive with "
-        "explicit NAME arguments and with --all-registry. Still requires "
-        "-y/--yes."
-    ),
-)
-@click.option(
-    "--all-registry",
-    "all_registry",
-    is_flag=True,
-    default=False,
-    help=(
-        "Restart EVERY agent 'sac agents list' shows — INCLUDING stopped "
-        "ones. Mutually exclusive with explicit NAME arguments and with "
-        "--all-running. Still requires -y/--yes."
-    ),
-)
-@click.option(
-    "--all",
-    "all_alias",
-    is_flag=True,
-    default=False,
-    help=(
-        "Backward-compat alias for --all-registry (restarts stopped agents "
-        "too). Prefer the explicit flags: --all-running restarts only the "
-        "live fleet; --all-registry restarts every registered agent."
-    ),
-)
+@bulk_selection_options("restart")
 @click.option(
     "--dry-run",
     "dry_run",
@@ -434,40 +356,23 @@ def restart(
       $ sac agents restart foo --dry-run
       $ sac agents restart foo --json
     """
-    # ``--all`` is a backward-compat alias for ``--all-registry`` (do not
-    # break cron/callers that still pass the old flag). The remaining
-    # selection modes are mutually exclusive with each other.
-    registry_mode = all_registry or all_alias
-    running_mode = all_running
-    if registry_mode and running_mode:
-        raise click.UsageError(
-            "--all-running and --all-registry (--all) are mutually exclusive; "
-            "pass exactly one selection flag."
-        )
-    batch_mode = registry_mode or running_mode
-
-    if batch_mode and names:
-        raise click.UsageError(
-            "A selection flag (--all-running / --all-registry / --all) cannot "
-            "be combined with explicit agent NAME arguments."
-        )
-
-    if batch_mode:
-        targets = _enumerate_running() if running_mode else _enumerate_fleet()
-        if not targets:
-            if as_json:
-                click.echo(_json.dumps([]))
-            else:
-                console.print("[dim]No agents found to restart.[/dim]")
-            return
-    else:
-        targets = list(names)
-
-    if not targets:
-        raise click.UsageError(
-            "Missing argument 'NAME...'. Pass one or more agent names, or a "
-            "selection flag (--all-running / --all-registry / --all)."
-        )
+    # Selection semantics (flags, mutual exclusion, enumeration) are SHARED
+    # with ``sac agents stop`` — see ``_selection.resolve_selection``. The
+    # enumerators are passed in so this module keeps its own swappable seam.
+    targets, batch_mode = resolve_selection(
+        names,
+        all_running=all_running,
+        all_registry=all_registry,
+        all_alias=all_alias,
+        enumerate_running=_enumerate_running,
+        enumerate_fleet=_enumerate_fleet,
+    )
+    if batch_mode and not targets:
+        if as_json:
+            click.echo(_json.dumps([]))
+        else:
+            console.print("[dim]No agents found to restart.[/dim]")
+        return
 
     if dry_run:
         for name in targets:

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_selection.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_selection.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Shared bulk-selection surface for the destructive fleet verbs.
+
+``sac agents restart`` and ``sac agents stop`` are the two verbs an
+operator reaches for during an incident, and they MUST offer the same
+selection surface — the operator's live terminal (2026-07-13)::
+
+    $ sac agents stop --all
+    Error: No such option: --all
+    $ sac agents stop
+    Error: Missing argument 'TARGETS...'.
+
+``restart`` had bulk selection; ``stop`` had none, so there was no way to
+bring the fleet down. That asymmetry is the bug this module removes: both
+verbs now import the SAME flags, the SAME enumeration, and the SAME
+mutual-exclusion rules from here, so the two surfaces cannot drift apart
+again.
+
+The three flags (identical for both verbs):
+
+* ``--all-running``  — only agents with a LIVE session. The
+  least-surprising "act on the live fleet" choice: an agent the operator
+  deliberately stopped stays stopped.
+* ``--all-registry`` — every registered agent, INCLUDING stopped ones.
+* ``--all``          — backward-compat alias for ``--all-registry``.
+
+All three are mutually exclusive with explicit name arguments and with
+each other, and all three still require ``-y/--yes`` (the confirmation
+guard on a fleet-wide destructive op is not weakened by bulk selection).
+``--dry-run`` composes with them and needs no ``-y`` — it is the safety
+valve for previewing what a fleet-wide op WOULD touch.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import click
+
+
+def _enumerate_fleet() -> list[str]:
+    """Return every agent name ``sac agents list`` shows (the ``--all-registry`` set).
+
+    Reuses the SAME data function the ``list`` command uses
+    (:func:`cli_pkg._helpers.get_agent_list_data`) so ``--all-registry`` is
+    exactly "everything ``sac agents list`` shows" — registered/running
+    agents plus on-disk-defined ones — with no separate enumeration path to
+    drift. Order-preserving de-dup by name.
+    """
+    from ..._state.registry import Registry
+    from .._helpers import get_agent_list_data
+
+    seen: set[str] = set()
+    names: list[str] = []
+    for row in get_agent_list_data(Registry()):
+        name = row.get("name")
+        if name and name not in seen:
+            seen.add(name)
+            names.append(name)
+    return names
+
+
+def _enumerate_running() -> list[str]:
+    """Return only the agents that are currently RUNNING (the ``--all-running`` set).
+
+    Reuses the SAME data function — and therefore the SAME liveness — the
+    ``list`` / ``status`` commands use
+    (:func:`cli_pkg._helpers.get_agent_list_data`), keeping only rows whose
+    ``status`` probe read ``"running"`` (identity-based liveness: the
+    session exists AND its pane process is alive — see
+    ``_agent_list._probe_local``). Rows that are ``stopped`` / ``unknown`` /
+    ``defined`` / ``invalid`` are excluded, so a plain ``--all-running``
+    never touches an agent the operator had deliberately stopped. No separate
+    liveness rule is invented here. Order-preserving de-dup by name.
+    """
+    from ..._state.registry import Registry
+    from .._helpers import get_agent_list_data
+
+    seen: set[str] = set()
+    names: list[str] = []
+    for row in get_agent_list_data(Registry()):
+        if row.get("status") != "running":
+            continue
+        name = row.get("name")
+        if name and name not in seen:
+            seen.add(name)
+            names.append(name)
+    return names
+
+
+def bulk_selection_options(verb: str, noun: str = "NAME") -> Callable:
+    """Attach the three shared selection flags to a click command.
+
+    ``verb`` is the command's own verb (``"restart"`` / ``"stop"``) and
+    ``noun`` the metavar of its positional argument — both only ever reach
+    the HELP TEXT, so the flag names, defaults and destinations stay
+    byte-identical across the two verbs by construction.
+
+    The options are applied bottom-up (``--all`` first) so the resulting
+    ``--help`` ordering is ``--all-running``, ``--all-registry``, ``--all``
+    — the same order a reader of the source sees.
+    """
+    verb_title = verb.capitalize()
+
+    def _decorate(fn: Callable) -> Callable:
+        fn = click.option(
+            "--all",
+            "all_alias",
+            is_flag=True,
+            default=False,
+            help=(
+                f"Backward-compat alias for --all-registry ({verb}s stopped "
+                f"agents too). Prefer the explicit flags: --all-running "
+                f"{verb}s only the live fleet; --all-registry {verb}s every "
+                f"registered agent."
+            ),
+        )(fn)
+        fn = click.option(
+            "--all-registry",
+            "all_registry",
+            is_flag=True,
+            default=False,
+            help=(
+                f"{verb_title} EVERY agent 'sac agents list' shows — INCLUDING "
+                f"stopped ones. Mutually exclusive with explicit {noun} "
+                f"arguments and with --all-running. Still requires -y/--yes."
+            ),
+        )(fn)
+        fn = click.option(
+            "--all-running",
+            "all_running",
+            is_flag=True,
+            default=False,
+            help=(
+                f"{verb_title} ONLY the agents that are currently RUNNING (live "
+                f"session). The least-surprising choice for '{verb} the live "
+                f"fleet' — a deliberately-stopped agent stays stopped. Mutually "
+                f"exclusive with explicit {noun} arguments and with "
+                f"--all-registry. Still requires -y/--yes."
+            ),
+        )(fn)
+        return fn
+
+    return _decorate
+
+
+def resolve_selection(
+    names: tuple[str, ...],
+    *,
+    all_running: bool,
+    all_registry: bool,
+    all_alias: bool,
+    enumerate_running: Callable[[], list[str]],
+    enumerate_fleet: Callable[[], list[str]],
+    noun: str = "NAME",
+    metavar: str = "NAME...",
+) -> tuple[list[str], bool]:
+    """Resolve positional names + selection flags into ``(targets, batch_mode)``.
+
+    The single source of truth for what the three flags MEAN, so ``restart``
+    and ``stop`` cannot disagree. Raises :class:`click.UsageError` (exit 2)
+    on every ambiguous invocation:
+
+      * more than one selection mode (``--all-running`` with
+        ``--all-registry`` / ``--all``);
+      * a selection flag combined with explicit names — the operator must
+        not be able to half-mean "these two AND everything";
+      * neither names nor a selection flag — a bare ``sac agents stop`` keeps
+        failing LOUD rather than silently stopping the whole fleet.
+
+    ``enumerate_running`` / ``enumerate_fleet`` are passed in (rather than
+    called directly) so each command keeps its own module-level enumeration
+    seam — the attribute the tests swap — while the SELECTION LOGIC itself
+    stays shared here.
+
+    Returns the target list plus a ``batch_mode`` flag. An EMPTY target list
+    with ``batch_mode`` True means "a selection flag matched nothing", which
+    is not an error — the caller reports it and exits 0.
+    """
+    # ``--all`` is a backward-compat alias for ``--all-registry`` (do not
+    # break cron/callers that still pass the old flag). The remaining
+    # selection modes are mutually exclusive with each other.
+    registry_mode = all_registry or all_alias
+    running_mode = all_running
+    if registry_mode and running_mode:
+        raise click.UsageError(
+            "--all-running and --all-registry (--all) are mutually exclusive; "
+            "pass exactly one selection flag."
+        )
+    batch_mode = registry_mode or running_mode
+
+    if batch_mode and names:
+        raise click.UsageError(
+            "A selection flag (--all-running / --all-registry / --all) cannot "
+            f"be combined with explicit agent {noun} arguments."
+        )
+
+    if not batch_mode:
+        if not names:
+            raise click.UsageError(
+                f"Missing argument '{metavar}'. Pass one or more agent names, "
+                "or a selection flag (--all-running / --all-registry / --all)."
+            )
+        return list(names), False
+
+    targets = enumerate_running() if running_mode else enumerate_fleet()
+    return targets, True
+
+
+__all__ = [
+    "_enumerate_fleet",
+    "_enumerate_running",
+    "bulk_selection_options",
+    "resolve_selection",
+]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_stop.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_stop.py
@@ -2,6 +2,15 @@
 # -*- coding: utf-8 -*-
 """``sac agents stop`` — stop one or more running agents.
 
+Bulk selection: ``--all-running`` (the live fleet — the incident panic
+button), ``--all-registry`` (every registered agent) and ``--all`` (a
+back-compat alias for ``--all-registry``). The flags, their semantics and
+their mutual-exclusion rules are SHARED with ``sac agents restart`` via
+:mod:`._selection`, so the two destructive fleet verbs cannot drift apart
+(before this, ``stop`` had no bulk selection at all and an operator trying
+to bring the fleet down during an incident hit ``Error: No such option:
+--all``). ``--dry-run`` composes with all three and needs no ``-y``.
+
 Cross-host dispatch: when an agent's active ``state.db.instances`` row
 records ``host != current_host``, ``stop`` ssh's into the peer and runs
 ``sac agents stop <name> --json`` there, then updates the lead-side row
@@ -36,6 +45,12 @@ from .._helpers import agent_name_complete, console
 from ._common import _iter_agent_yamls
 from ._dispatch import try_dispatch_remote
 from ._host_routing import spec_host_fallback_peer
+from ._selection import (
+    _enumerate_fleet,
+    _enumerate_running,
+    bulk_selection_options,
+    resolve_selection,
+)
 
 # Stable exit_reason marker for the release-on-unreachable path so a
 # follow-up audit can grep state.db for stale-binding releases and
@@ -159,11 +174,13 @@ def _dispatch_remote_stop(peer: str, row: dict, peers: dict, name: str) -> dict:
 @click.command()
 @click.argument(
     "targets",
+    metavar="TARGETS...",
     type=str,
     nargs=-1,
-    required=True,
+    required=False,
     shell_complete=agent_name_complete,
 )
+@bulk_selection_options("stop", noun="TARGET")
 @click.option(
     "--force",
     "force",
@@ -198,6 +215,9 @@ def _dispatch_remote_stop(peer: str, row: dict, peers: dict, name: str) -> dict:
 )
 def stop(
     targets: tuple[str, ...],
+    all_running: bool,
+    all_registry: bool,
+    all_alias: bool,
     force: bool,
     dry_run: bool,
     yes: bool,
@@ -207,26 +227,72 @@ def stop(
 
     Each TARGET is an agent name, a YAML path, or a directory containing
     ``<name>/<name>.yaml`` agent layouts. Multiple targets may be given.
+    Instead of naming targets, pass a selection flag:
+
+    \b
+      --all-running   stop ONLY currently-running agents (the live fleet)
+      --all-registry  stop EVERY registered agent (INCLUDING stopped)
+      --all           backward-compat alias for --all-registry
+
+    The flags mirror ``sac agents restart`` exactly: mutually exclusive with
+    each other and with explicit TARGETs, and still gated on ``-y/--yes``.
+    ``--all-running`` is the incident panic button — it never touches an
+    agent that was already deliberately stopped. Agents are stopped
+    independently: one failing does not abort the rest, and the command
+    exits non-zero if ANY stop failed.
 
     \b
     Example:
-      $ sac agent stop foo
-      $ sac agent stop foo bar baz
-      $ sac agent stop ~/.scitex/agent-container/agents/   # whole dir = bulk
-      $ sac agent stop foo --dry-run
-      $ sac agent stop foo --json
+      $ sac agents stop foo
+      $ sac agents stop foo bar baz
+      $ sac agents stop ~/.scitex/agent-container/agents/   # whole dir = bulk
+      $ sac agents stop --all-running --dry-run   # preview the blast radius
+      $ sac agents stop --all-running -y          # down the live fleet
+      $ sac agents stop --all-registry -y --force # + tolerate stale state
+      $ sac agents stop foo --json
     """
+    # Selection semantics (flag names, mutual exclusion, enumeration) are
+    # SHARED with ``sac agents restart`` — see ``_selection.resolve_selection``.
+    # The enumerators are passed in so this module keeps its own swappable
+    # seam. A bare ``sac agents stop`` (no TARGETs, no flag) raises a
+    # UsageError here rather than silently stopping the fleet.
+    resolved, batch_mode = resolve_selection(
+        targets,
+        all_running=all_running,
+        all_registry=all_registry,
+        all_alias=all_alias,
+        enumerate_running=_enumerate_running,
+        enumerate_fleet=_enumerate_fleet,
+        noun="TARGET",
+        metavar="TARGETS...",
+    )
+    if batch_mode and not resolved:
+        # A selection flag that matched nothing is not an error. Under
+        # --json this emits zero envelopes: stop's JSON contract is ONE
+        # object per target (not an array — ``_dispatch_remote_stop``
+        # parses a single object from a peer's stdout), so zero targets
+        # correctly yields zero objects.
+        if not as_json:
+            console.print("[dim]No agents found to stop.[/dim]")
+        return
+
     # Classify targets: directory targets expand to all <name>/<name>.yaml
     # under them; non-directory targets are agent names or YAML paths.
+    # Batch-selected names come from the registry and are never paths, so
+    # they skip the probe — a cwd directory that happens to share an agent's
+    # name must not hijack a fleet selection.
     single_targets: list[str] = []
     bulk_yamls_from_dirs: list[str] = []
-    for t in targets:
-        p = Path(t).expanduser()
-        if p.is_dir():
-            for _name, yp in _iter_agent_yamls(p):
-                bulk_yamls_from_dirs.append(yp)
-        else:
-            single_targets.append(t)
+    if batch_mode:
+        single_targets = list(resolved)
+    else:
+        for t in resolved:
+            p = Path(t).expanduser()
+            if p.is_dir():
+                for _name, yp in _iter_agent_yamls(p):
+                    bulk_yamls_from_dirs.append(yp)
+            else:
+                single_targets.append(t)
 
     if dry_run:
         for t in single_targets:
@@ -234,6 +300,20 @@ def stop(
         for yp in bulk_yamls_from_dirs:
             click.echo(f"[dry-run] would stop agent at '{yp}'")
         return
+
+    # A fleet-wide selection flag is destructive: still require -y/--yes.
+    if batch_mode and not yes:
+        if len(single_targets) == 1:
+            click.echo(
+                f"Refusing to stop agent '{single_targets[0]}' without --yes/-y.",
+                err=True,
+            )
+        else:
+            click.echo(
+                f"Refusing to stop {len(single_targets)} agents without --yes/-y.",
+                err=True,
+            )
+        raise SystemExit(2)
 
     # Refuse bulk stop without --yes/-y when directory targets resolved to ≥2 yamls.
     if len(bulk_yamls_from_dirs) > 1 and not yes:

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__stop.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__stop.py
@@ -650,3 +650,284 @@ def test_no_force_on_unreachable_peer_message_surfaces_peer_diagnostic(
     result = runner.invoke(stop, ["clew"])
     # Assert
     assert "pam_slurm_adopt" in result.output or "peer-x" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Bulk selection flags (operator incident 2026-07-13). ``sac agents stop
+# --all`` failed with "No such option: --all" and a bare ``sac agents stop``
+# with "Missing argument 'TARGETS...'", so there was NO way to bring the fleet
+# down mid-incident — while ``sac agents restart`` had bulk selection all
+# along. ``stop`` now shares restart's surface (--all-running / --all-registry
+# / --all) through ``_selection``. The enumeration seams are swapped so these
+# tests never read the real registry.
+# ---------------------------------------------------------------------------
+
+
+def _recorder(stopped: list):
+    """Recording stand-in for ``agent_stop`` (a real callable, not a mock)."""
+
+    def _stop(name, force=False):
+        stopped.append(name)
+        return True
+
+    return _stop
+
+
+def test_all_running_stops_only_the_running_agents():
+    # Arrange — --all-running must enumerate via the RUNNING-only seam.
+    stopped: list = []
+    runner = CliRunner()
+    # Act
+    with (
+        _swap("_enumerate_running", lambda: ["live-1", "live-2"]),
+        _swap("_enumerate_fleet", lambda: ["live-1", "live-2", "stopped-3"]),
+        _swap("agent_stop", _recorder(stopped)),
+    ):
+        runner.invoke(stop, ["--all-running", "-y"])
+    # Assert — the deliberately-stopped agent is never touched.
+    assert stopped == ["live-1", "live-2"]
+
+
+def test_all_registry_stops_every_registered_agent():
+    # Arrange — --all-registry must enumerate via the full-fleet seam.
+    stopped: list = []
+    runner = CliRunner()
+    # Act
+    with (
+        _swap("_enumerate_running", lambda: ["live-1"]),
+        _swap("_enumerate_fleet", lambda: ["live-1", "stopped-2"]),
+        _swap("agent_stop", _recorder(stopped)),
+    ):
+        runner.invoke(stop, ["--all-registry", "-y"])
+    # Assert — stopped agents are included too.
+    assert stopped == ["live-1", "stopped-2"]
+
+
+def test_all_alias_matches_all_registry_behaviour():
+    # Arrange — --all is the back-compat alias for --all-registry, exactly as
+    # in ``sac agents restart``: it enumerates the FULL fleet.
+    stopped: list = []
+    runner = CliRunner()
+    # Act
+    with (
+        _swap("_enumerate_running", lambda: ["live-1"]),
+        _swap("_enumerate_fleet", lambda: ["live-1", "stopped-2"]),
+        _swap("agent_stop", _recorder(stopped)),
+    ):
+        runner.invoke(stop, ["--all", "-y"])
+    # Assert — --all == --all-registry.
+    assert stopped == ["live-1", "stopped-2"]
+
+
+def test_all_running_and_all_registry_together_is_usage_error():
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(stop, ["--all-running", "--all-registry", "-y"])
+    # Assert — the two selection modes are mutually exclusive (exit 2).
+    assert result.exit_code == 2 and "mutually exclusive" in result.output
+
+
+def test_all_running_and_all_alias_together_is_usage_error():
+    # Arrange — --all aliases --all-registry, so it conflicts just the same.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(stop, ["--all-running", "--all", "-y"])
+    # Assert
+    assert result.exit_code == 2 and "mutually exclusive" in result.output
+
+
+def test_selection_flag_with_explicit_targets_is_usage_error():
+    # Arrange — "these two AND everything" must never be half-meant.
+    runner = CliRunner()
+    # Act
+    with _swap("_enumerate_running", lambda: ["live-1"]):
+        result = runner.invoke(stop, ["--all-running", "alpha", "-y"])
+    # Assert
+    assert result.exit_code == 2 and "cannot be combined" in result.output
+
+
+def test_bare_stop_without_targets_or_selection_flag_is_usage_error():
+    # Arrange — the operator's repro: a bare `sac agents stop` must keep
+    # failing LOUD rather than silently stopping the whole fleet.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(stop, [])
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_bare_stop_error_names_the_selection_flags():
+    # Arrange — the loud failure should also teach the way out.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(stop, [])
+    # Assert
+    assert "--all-running" in result.output
+
+
+def test_all_running_without_yes_refuses_exit_two():
+    # Arrange — bulk stop stays gated on -y/--yes.
+    runner = CliRunner()
+    # Act
+    with _swap("_enumerate_running", lambda: ["live-1", "live-2"]):
+        result = runner.invoke(stop, ["--all-running"])
+    # Assert
+    assert result.exit_code == 2 and "Refusing to stop 2 agents" in result.output
+
+
+def test_all_running_without_yes_stops_no_agent():
+    # Arrange — the confirmation guard must actually PREVENT the stops.
+    stopped: list = []
+    runner = CliRunner()
+    # Act
+    with (
+        _swap("_enumerate_running", lambda: ["live-1", "live-2"]),
+        _swap("agent_stop", _recorder(stopped)),
+    ):
+        runner.invoke(stop, ["--all-running"])
+    # Assert
+    assert stopped == []
+
+
+def test_all_running_dry_run_exits_zero_without_yes():
+    # Arrange — --dry-run is the safety valve for a fleet-wide op: it must
+    # compose with the selection flags and need no -y.
+    runner = CliRunner()
+    # Act
+    with _swap("_enumerate_running", lambda: ["live-1", "live-2"]):
+        result = runner.invoke(stop, ["--all-running", "--dry-run"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_all_running_dry_run_lists_every_selected_target():
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap("_enumerate_running", lambda: ["live-1", "live-2"]):
+        result = runner.invoke(stop, ["--all-running", "--dry-run"])
+    # Assert — the operator sees the full blast radius before committing.
+    assert (
+        "would stop agent 'live-1'" in result.output
+        and "would stop agent 'live-2'" in result.output
+    )
+
+
+def test_all_running_dry_run_stops_no_agent():
+    # Arrange — a preview must not touch the fleet.
+    stopped: list = []
+    runner = CliRunner()
+    # Act
+    with (
+        _swap("_enumerate_running", lambda: ["live-1", "live-2"]),
+        _swap("agent_stop", _recorder(stopped)),
+    ):
+        runner.invoke(stop, ["--all-running", "--dry-run"])
+    # Assert
+    assert stopped == []
+
+
+def test_all_registry_dry_run_lists_the_stopped_agents_too():
+    # Arrange — --dry-run must preview the FULL-fleet selection as well.
+    runner = CliRunner()
+    # Act
+    with _swap("_enumerate_fleet", lambda: ["live-1", "stopped-2"]):
+        result = runner.invoke(stop, ["--all-registry", "--dry-run"])
+    # Assert
+    assert "would stop agent 'stopped-2'" in result.output
+
+
+def test_bulk_one_failure_exits_nonzero():
+    # Arrange — any failed stop must surface as a non-zero exit (as restart does).
+    def _boom(name, force=False):
+        if name == "bad":
+            raise RuntimeError("boom")
+        return True
+
+    runner = CliRunner()
+    # Act
+    with (
+        _swap("_enumerate_running", lambda: ["ok-1", "bad"]),
+        _swap("agent_stop", _boom),
+    ):
+        result = runner.invoke(stop, ["--all-running", "-y"])
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_bulk_one_failure_still_attempts_the_remaining_agents():
+    # Arrange — a mid-fleet failure must not abort the rest of the shutdown.
+    seen: list = []
+
+    def _flaky(name, force=False):
+        seen.append(name)
+        if name == "bad":
+            raise RuntimeError("boom")
+        return True
+
+    runner = CliRunner()
+    # Act
+    with (
+        _swap("_enumerate_running", lambda: ["ok-1", "bad", "ok-2"]),
+        _swap("agent_stop", _flaky),
+    ):
+        runner.invoke(stop, ["--all-running", "-y"])
+    # Assert
+    assert seen == ["ok-1", "bad", "ok-2"]
+
+
+def test_selection_matching_nothing_exits_zero():
+    # Arrange — "the live fleet is already down" is not an error.
+    runner = CliRunner()
+    # Act
+    with _swap("_enumerate_running", lambda: []):
+        result = runner.invoke(stop, ["--all-running", "-y"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_selection_matching_nothing_reports_no_agents_found():
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap("_enumerate_running", lambda: []):
+        result = runner.invoke(stop, ["--all-running", "-y"])
+    # Assert
+    assert "No agents found to stop" in result.output
+
+
+def test_bulk_json_emits_one_envelope_per_stopped_agent():
+    # Arrange — stop's JSON contract is ONE object per target (not restart's
+    # array): the cross-host dispatcher parses a single object from a peer.
+    import json as _json
+
+    runner = CliRunner()
+    # Act
+    with (
+        _swap("_enumerate_running", lambda: ["live-1", "live-2"]),
+        _swap("agent_stop", _recorder([])),
+    ):
+        result = runner.invoke(stop, ["--all-running", "-y", "--json"])
+    payloads = [_json.loads(ln) for ln in result.output.strip().splitlines() if ln]
+    # Assert
+    assert [p["name"] for p in payloads] == ["live-1", "live-2"]
+
+
+def test_stop_exposes_the_same_selection_flags_as_restart():
+    # Arrange — the whole point: the two destructive fleet verbs must not
+    # drift apart again. Adding a selection flag to one verb only fails here.
+    from scitex_agent_container.cli_pkg.lifecycle._restart import restart
+
+    def _selection_flags(command):
+        return sorted(
+            opt
+            for param in command.params
+            for opt in getattr(param, "opts", ())
+            if opt.startswith("--all")
+        )
+
+    # Act
+    stop_flags = _selection_flags(stop)
+    # Assert
+    assert stop_flags == _selection_flags(restart)


### PR DESCRIPTION
## The gap

`sac agents restart` has had bulk selection for a while. `sac agents stop` had **none** — so during an incident today the operator could not bring the fleet down:

```
$ sac agents stop --all
Error: No such option: --all
$ sac agents stop
Error: Missing argument 'TARGETS...'.
```

That asymmetry between the two destructive fleet verbs is the bug.

It is worse than a missing nicety: `examples/07_stop_and_remove.sh` has been advertising `sac agents stop --all` as the panic button ("every registered, running agent") the whole time. The flag was **documented but never implemented**.

## The fix

`stop` now takes the **same three flags** as `restart`, with the same semantics, the same mutual exclusion, and the same `-y` gate:

| flag | meaning |
|---|---|
| `--all-running` | only agents with a LIVE session — the panic button. An agent deliberately stopped stays stopped. |
| `--all-registry` | every agent `sac agents list` shows, INCLUDING stopped ones. |
| `--all` | backward-compat alias for `--all-registry` (as in `restart`). |

## Shared, not copied

Copying the flags is *how the two verbs drifted apart in the first place*, so both now import them from a new **`cli_pkg/lifecycle/_selection.py`**, which owns:

- the three click options (`bulk_selection_options(verb, noun)` — help text is verb-interpolated, so the flag names/dests are identical *by construction*),
- the enumeration — `_enumerate_fleet` / `_enumerate_running` moved here **verbatim** from `_restart.py` and re-exported from it, so existing import paths and the tests' swap seams keep working,
- `resolve_selection(...)` — the single source of truth for mutual exclusion and what each flag *means*.

Guarantees that this introduced no drift:

- **`restart --help` is byte-identical** before and after the refactor (diffed the worktree against the installed pre-refactor sac).
- All **51 existing restart tests pass unchanged** — including the ones that swap `restart_mod._enumerate_running`, which proves the seam survived the move.
- A new test asserts **both verbs expose the same `--all*` surface**, so adding a selection flag to one verb alone now fails CI.

## Behaviour notes

- `TARGETS` is optional **only** when a selection flag is given. A bare `sac agents stop` still **fails loud** (now naming the flags) rather than silently stopping the fleet.
- `-y` is required for **bulk only**. A single `sac agents stop <name>` keeps working without it — this is load-bearing: `_dispatch_remote_stop` shells exactly that argv (`sac agents stop <name> --json`) for cross-host stops, so requiring `-y` universally would have broken cross-host dispatch.
- `--dry-run` composes with the flags and needs no `-y` — the safety valve for previewing a fleet-wide op. Exercised by tests (lists every target, stops nothing, exits 0).
- Any failed stop still exits non-zero; one failure does not abort the rest.
- Bulk-selected names bypass the directory/YAML-path probe, so a cwd directory that happens to share an agent's name cannot hijack a fleet selection.
- Empty selection ("the fleet is already down") is not an error: exit 0.

## Live proof (operator's exact repro)

```
$ sac agents stop --all --dry-run
[dry-run] would stop agent 'archive-target'
[dry-run] would stop agent 'healthy-target'
... exit=0                       # was: Error: No such option: --all

$ sac agents stop
Error: Missing argument 'TARGETS...'. Pass one or more agent names, or a
selection flag (--all-running / --all-registry / --all).      exit=2

$ sac agents stop --all-running --all-registry -y
Error: --all-running and --all-registry (--all) are mutually exclusive;
pass exactly one selection flag.                              exit=2
```

## Tests

18 new tests in `test__stop.py` (AAA markers, one assertion each, `CliRunner` against the real command, no mocks) covering: running-only vs registry selection, the `--all` alias, both mutual-exclusion pairs, flag+explicit-target, bare-stop-still-fails-loud, the `-y` guard (refuses **and** stops nothing), `--dry-run` × bulk (lists all / stops nothing / needs no `-y`), non-zero exit on partial failure, mid-fleet failure not aborting the rest, empty selection, the per-target JSON envelope contract, and the two-verb flag-parity check.

`101 passed` (50 stop + 51 restart). Ruff CI lint (`--select F401,F811`) clean.

## Side benefit

Extracting the helpers drops `_restart.py` from **511 → 416** lines. It was sitting one line under the 512-line limit and literally could not have grown.