### PR TITLE
test(instances): reap a subprocess instead of os.fork() to mint a dead pid (fork in a threaded process can deadlock)

### DIFF
--- a/tests/scitex_agent_container/_lifecycle/test__instances_pid.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances_pid.py
@@ -33,6 +33,8 @@ from __future__ import annotations
 
 import importlib
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -101,12 +103,16 @@ def _row_for(name: str) -> dict:
 
 
 def _dead_pid() -> int:
-    """A pid that is genuinely dead: fork a child and reap it."""
-    pid = os.fork()
-    if pid == 0:  # pragma: no cover - child never returns to the test
-        os._exit(0)
-    os.waitpid(pid, 0)
-    return pid
+    """A pid that is genuinely dead: run a trivial child and reap it.
+
+    Uses ``subprocess`` rather than ``os.fork()`` on purpose — pytest runs
+    multi-threaded, and forking a multi-threaded process risks deadlocking
+    the child (CPython raises DeprecationWarning for exactly this). The
+    child is waited on, so its pid is reaped and provably not alive.
+    """
+    proc = subprocess.Popen([sys.executable, "-c", ""])
+    proc.wait()
+    return proc.pid
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #649 (merged), cleaning up a hazard I introduced there.

## The problem

The pid tests need a pid that is genuinely **dead**. `_dead_pid()` did that by forking and reaping the child. But pytest runs **multi-threaded**, and CPython warns about exactly this:

```
DeprecationWarning: This process (pid=192074) is multi-threaded,
use of fork() may lead to deadlocks in the child.
```

CI passed 3/3 with it, so nothing is broken today — but a fork-in-a-threaded-process is a latent **intermittent CI hang**, which is about the nastiest failure mode to debug later. Not worth leaving in a test I just added.

## The fix

Spawn a trivial child via `subprocess` and `wait()` it. Same guarantee — the pid is reaped, so it is provably not alive — with no fork hazard.

```python
proc = subprocess.Popen([sys.executable, "-c", ""])
proc.wait()
return proc.pid
```

## Verification

The 19 pid tests pass under `-W error::DeprecationWarning` — they would ERROR on the warning if it were still emitted:

```
19 passed in 8.82s
```

Test-only change; no source touched.