### PR TITLE
ci: bound the pytest matrix with timeout-minutes: 30 — a hung leg had no ceiling

### DIFF
--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -13,6 +13,20 @@ jobs:
   test:
     name: pytest-matrix-on-ubuntu-py${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    # A hung leg used to run to GitHub's 6-HOUR default. This has bitten
+    # twice, both times invisibly — nothing failed, a job simply never
+    # finished:
+    #   * PR #594 burned 1h39m42s before the platform killed it, and the
+    #     run was then misread for days as "the self-hosted runners are
+    #     slow" (it never touched one — it was cancelled mid-run by a
+    #     repository transfer).
+    #   * A duplicate py3.11 leg hung for 40+ min while its two siblings
+    #     finished in 11, and — because these three are the REQUIRED
+    #     status checks on `main` — it held the v0.21.14 release PR at
+    #     mergeStateStatus=BLOCKED with every check actually passing.
+    # These jobs take ~11-12 min. 30 is ~2.5x headroom: generous for a
+    # slow runner, decisive against a hang.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The pytest matrix has **no `timeout-minutes`**, so a hung leg runs to GitHub's **6-hour default**.

This has bitten **twice**, and both times *invisibly* — nothing **failed**, a job simply never **finished**:

1. **PR #594's leg burned 1h39m42s** before the platform killed it. That run was then misread for days as evidence that *"the self-hosted Spartan runners are slow."* **It never touched one** — it ran on `ubuntu-latest` and was cancelled mid-run by a repository transfer. A missing timeout manufactured a false conclusion that stalled the CI migration.

2. **A duplicate `py3.11` leg hung 40+ minutes** while its two siblings finished in 11. Because those three legs are the **required status checks on `main`**, it held the **v0.21.14 release PR** at `mergeStateStatus=BLOCKED` — with every check on the head SHA actually **passing**.

The tempting fix in case 2 was `gh pr merge --admin` to force past it. That would have "worked" and taught us nothing. The defect is here.

## The change

```yaml
timeout-minutes: 30
```

These legs take **~11–12 min**. 30 gives ~2.5x headroom — generous for a slow runner, decisive against a hang.

## Why standalone

Extracted deliberately from the draft self-hosted-runner migration (#650), which also carries this line but is **correctly blocked** on scitex-hpc restoring the Spartan runner's cores (it silently dropped **48 → 1**). A hang ceiling should not wait on a capacity negotiation.