### PR TITLE
fix(restart,listen): stop failing loud instead of reporting a restart that did not happen; stop asserting a listen cause nobody measured

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_listen_probe.py
+++ b/src/scitex_agent_container/_lifecycle/_listen_probe.py
@@ -1,0 +1,208 @@
+"""MEASURE the listen daemon before naming what is wrong with it.
+
+Shared by :mod:`._restart_client` and :mod:`._spawn_client`: when a
+brokered POST to the host ``sac listen`` gets no HTTP response, this
+module answers the ONLY question the caller can actually settle — *is
+the daemon down, or is it up and serving while the AUTHENTICATED route
+is wedged?* — by probing the cheap unauthenticated path.
+
+THE BUG THIS CLOSES (card ``sac-restart-prints-success-after-start-failed``,
+2026-07-14). An agent trying to recover a peer got::
+
+    cannot reach listen at 'http://127.0.0.1:7878' (timed out) — the host
+    listen broker is unreachable; it may be flapping. Restart it on the
+    host with `sac listen restart`.
+
+Every clause after the parenthesis was invented. The reporter measured::
+
+    GET  /health           (unauthenticated) -> HTTP 401 in 0.18s, twice
+    GET  /agents           (with bearer)     -> no response in 10s
+    POST /agents/<n>/restart (with bearer)   -> no response in 25s
+
+The daemon was UP and answering in under a fifth of a second. It was not
+"unreachable" and there was not one shred of evidence for "flapping" — a
+word that asserts a process is crash-looping, which nobody had looked at.
+A timeout on ONE route licenses a claim about THAT ROUTE, and nothing more.
+
+WHY THE SPLIT IS REAL (it is not an accident of routing)
+--------------------------------------------------------
+``BearerAuthMiddleware.PUBLIC_PATHS`` exempts ``/v1/health``, and both
+that route and the middleware's own 401 are ``async`` — they answer ON the
+event loop. Every AUTHENTICATED route dispatches through the shared worker
+pool. So a pool exhausted by stacked-up work wedges the authed routes while
+the public path stays fast: exactly the 0.18s-401 / 25s-timeout split that
+was observed. (Root cause of that exhaustion — abandoned heartbeat ticks
+leaking zombie threads into the pool — is fixed in PR #647; this module is
+about not LYING when it happens again for some other reason.)
+
+CONTRACT: any HTTP response at all — 200, 401, 403, 404 — proves the daemon
+is UP and serving HTTP. Only the ABSENCE of an HTTP exchange (connection
+refused / DNS / timeout) is evidence of "unreachable". We report what we
+measured and never more than that: the word "flapping" appears nowhere in
+this module's output, because nothing here can observe a crash loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "HealthProbe",
+    "probe_listen_health",
+    "transport_failure_message",
+]
+
+# The one path ``BearerAuthMiddleware`` exempts (``PUBLIC_PATHS``), served
+# by an ``async`` handler that never touches the shared worker pool.
+HEALTH_PATH = "/v1/health"
+
+# The probe must be CHEAP: it runs inside the failure path of a request
+# that has ALREADY timed out, so it must not add another long wait. A
+# healthy listen answers /v1/health in ~0.2s; 5s is 25x that.
+_DEFAULT_PROBE_TIMEOUT_S = 5.0
+
+
+@dataclass(frozen=True)
+class HealthProbe:
+    """What an UNAUTHENTICATED ``GET /v1/health`` actually did.
+
+    ``serving`` is the load-bearing field and it means exactly one thing:
+    an HTTP response arrived. NOT "the daemon is healthy" — a 401 is a
+    perfectly good proof of serving. Callers must not upgrade it into a
+    broader claim.
+    """
+
+    serving: bool
+    status: int | None
+    elapsed_s: float
+    error: str | None
+    url: str
+
+    def evidence(self) -> str:
+        """One line of what we measured — quotable in an error message."""
+        if self.serving:
+            return (
+                f"an unauthenticated GET {self.url} answered HTTP "
+                f"{self.status} in {self.elapsed_s:.2f}s"
+            )
+        return (
+            f"an unauthenticated GET {self.url} also got no HTTP response "
+            f"({self.error}) after {self.elapsed_s:.2f}s"
+        )
+
+
+def probe_listen_health(
+    base: str,
+    *,
+    timeout_s: float = _DEFAULT_PROBE_TIMEOUT_S,
+    opener: Optional[Callable] = None,
+) -> HealthProbe:
+    """GET ``{base}/v1/health`` with NO Authorization header. Never raises.
+
+    Deliberately unauthenticated: sending the bearer would route the probe
+    through the very code path we are trying to rule in or out, and would
+    hang with it. The point is to exercise the path that CANNOT be wedged
+    by a starved worker pool.
+    """
+    url = f"{base.rstrip('/')}{HEALTH_PATH}"
+    opener_fn = opener if opener is not None else urlrequest.urlopen
+    req = urlrequest.Request(url, method="GET", headers={"Accept": "application/json"})
+    started = time.monotonic()
+    try:
+        with opener_fn(req, timeout=timeout_s) as resp:
+            resp.read()
+            status = int(getattr(resp, "status", 200))
+        return HealthProbe(
+            serving=True,
+            status=status,
+            elapsed_s=time.monotonic() - started,
+            error=None,
+            url=url,
+        )
+    except urlerror.HTTPError as exc:
+        # A RESPONSE. 401/403/404 all prove the daemon is up and serving —
+        # the reporter's own evidence was a 401. HTTPError subclasses
+        # URLError, so this MUST be caught first or a serving daemon would
+        # be misfiled as unreachable (the exact bug, one level down).
+        return HealthProbe(
+            serving=True,
+            status=int(getattr(exc, "code", 0)) or None,
+            elapsed_s=time.monotonic() - started,
+            error=None,
+            url=url,
+        )
+    except (urlerror.URLError, OSError, ValueError) as exc:
+        # No HTTP exchange at all: connection refused / DNS / timeout.
+        return HealthProbe(
+            serving=False,
+            status=None,
+            elapsed_s=time.monotonic() - started,
+            error=str(getattr(exc, "reason", None) or exc),
+            url=url,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: this probe runs INSIDE another failure path — it exists to IMPROVE an error message and must never replace it with a crash. Any unexpected failure degrades to an honest "could not measure".)  # noqa: BLE001
+        logger.warning("listen health probe raised unexpectedly: %s", exc)
+        return HealthProbe(
+            serving=False,
+            status=None,
+            elapsed_s=time.monotonic() - started,
+            error=f"probe failed: {exc}",
+            url=url,
+        )
+
+
+def transport_failure_message(
+    *,
+    verb: str,
+    name: str,
+    base: str,
+    route: str,
+    exc: BaseException,
+    timeout_s: float,
+    probe: HealthProbe,
+) -> str:
+    """The honest message for a brokered POST that got no HTTP response.
+
+    Two cases, and they are the two the caller can actually TELL APART:
+
+      * the daemon answered the cheap path → it is UP; the AUTHENTICATED
+        route is what failed. Say that, and only that.
+      * the daemon answered nothing at all → it is genuinely unreachable.
+        Say that, and still do not speculate about *why*.
+
+    ``verb`` is the operation ("restart" / "spawn"), ``route`` the path
+    that timed out (e.g. ``POST /agents/x/restart``).
+    """
+    if probe.serving:
+        return (
+            f"{verb} of {name!r} failed: {route} to {base!r} got no response "
+            f"within {timeout_s:.0f}s ({exc}).\n"
+            f"MEASURED (not guessed): {probe.evidence()} — so the listen "
+            f"daemon is UP and serving. The daemon is NOT down and this is "
+            f"NOT a 'broker unreachable' failure: it is the AUTHENTICATED "
+            f"route that did not answer.\n"
+            f"Why the two differ: authenticated routes dispatch through "
+            f"listen's shared worker pool; the public {HEALTH_PATH} path is "
+            f"served on the event loop and never touches it. A pool exhausted "
+            f"by stacked-up work therefore wedges one and leaves the other "
+            f"fast.\n"
+            f"Fix: `sac listen restart` on the host clears the wedged pool. "
+            f"If it recurs, the host's sac predates the fix for the heartbeat "
+            f"ticks that leaked threads into that pool (PR #647) — upgrade sac "
+            f"on the host."
+        )
+    return (
+        f"{verb} of {name!r} failed: cannot reach listen at {base!r} ({exc}).\n"
+        f"MEASURED (not guessed): {probe.evidence()} — nothing is serving HTTP "
+        f"at this URL, so the daemon is DOWN or the URL/port is wrong.\n"
+        f"Fix: start it on the host with `sac listen restart` (an atomic "
+        f"stop-clean-relaunch) and retry; escalate to the operator only if it "
+        f"stays down."
+    )

--- a/src/scitex_agent_container/_lifecycle/_restart_client.py
+++ b/src/scitex_agent_container/_lifecycle/_restart_client.py
@@ -276,13 +276,35 @@ def request_restart(
         # A 401/403 is NOT routed here (HTTPError is caught above first),
         # so an authenticated-but-rejected request never gets misreported
         # as 'cannot reach / timed out'.
-        logger.warning("restart_client: POST %s transport error: %s", url, exc)
+        #
+        # MEASURE before naming the cause. This used to assert "the host
+        # listen broker is unreachable; it may be flapping" — a diagnosis
+        # nobody had measured, and (2026-07-14) a WRONG one: the daemon was
+        # answering an unauthenticated GET in 0.18s while this authenticated
+        # POST hung. Probe the cheap public path and let the EVIDENCE pick
+        # the message. See ._listen_probe.
+        from ._listen_probe import probe_listen_health, transport_failure_message
+
+        probe = probe_listen_health(base, opener=opener)
+        logger.warning(
+            "restart_client: POST %s transport error: %s (probe: listen "
+            "serving=%s status=%s in %.2fs)",
+            url,
+            exc,
+            probe.serving,
+            probe.status,
+            probe.elapsed_s,
+        )
         raise RestartRequestError(
-            f"restart of {name!r} failed: cannot reach listen at {base!r} "
-            f"({exc}) — the host listen broker is unreachable; it may be "
-            f"flapping. Restart it on the host with `sac listen restart` (an "
-            f"atomic stop-clean-relaunch) and retry; escalate to the operator "
-            f"only if it stays down."
+            transport_failure_message(
+                verb="restart",
+                name=name,
+                base=base,
+                route=f"POST /agents/{name}/restart",
+                exc=exc,
+                timeout_s=timeout_s,
+                probe=probe,
+            )
         ) from exc
 
     parsed = _parse_body(raw)

--- a/src/scitex_agent_container/_lifecycle/_spawn_client.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_client.py
@@ -390,17 +390,38 @@ def request_spawn(
         ) from exc
     except (urlerror.URLError, OSError, ValueError) as exc:
         # No HTTP exchange happened — connection refused / DNS / timeout.
-        # This (and only this) is a genuine "unreachable" condition. A
-        # 401/403 is NOT routed here: ``HTTPError`` (a URLError subclass)
+        # A 401/403 is NOT routed here: ``HTTPError`` (a URLError subclass)
         # is caught above first, so an authenticated-but-rejected request
         # never gets misreported as 'cannot reach / timed out'.
-        logger.warning("spawn_client: POST %s transport error: %s", url, exc)
+        #
+        # But "no response on THIS route" is NOT yet "the daemon is
+        # unreachable" — the authenticated routes dispatch through listen's
+        # shared worker pool and the public health path does not, so one can
+        # hang while the other answers in 0.18s (observed 2026-07-14). The
+        # old text asserted "unreachable; it may be flapping" and was WRONG.
+        # Probe the cheap public path and let the EVIDENCE pick the message.
+        from ._listen_probe import probe_listen_health, transport_failure_message
+
+        probe = probe_listen_health(base, opener=opener)
+        logger.warning(
+            "spawn_client: POST %s transport error: %s (probe: listen "
+            "serving=%s status=%s in %.2fs)",
+            url,
+            exc,
+            probe.serving,
+            probe.status,
+            probe.elapsed_s,
+        )
         raise SpawnRequestError(
-            f"spawn of {child_name!r} failed: cannot reach listen at {base!r} "
-            f"({exc}) — the host listen broker is unreachable; it may be "
-            f"flapping. Restart it on the host with `sac listen restart` (an "
-            f"atomic stop-clean-relaunch) and retry; escalate to the operator "
-            f"only if it stays down."
+            transport_failure_message(
+                verb="spawn",
+                name=child_name,
+                base=base,
+                route="POST /agents",
+                exc=exc,
+                timeout_s=timeout_s,
+                probe=probe,
+            )
         ) from exc
 
     parsed = _parse_body(raw)

--- a/src/scitex_agent_container/_lifecycle/_stop.py
+++ b/src/scitex_agent_container/_lifecycle/_stop.py
@@ -23,18 +23,14 @@ from ._runtime_select import _get_runtime
 logger = logging.getLogger(__name__)
 
 # Default upper bound on how long ``agent_restart`` will wait for the
-# previous runtime to actually exit before starting the new one. Tuned
-# for apptainer healthy teardown (~0.5–2 s); 15 s leaves comfortable
-# headroom for a loaded host. The race this closes: new container boots
-# while the old one still holds /home/agent overlay + per-agent stdio MCP
-# child still holds its PID lock file → new bun child's ``acquireLock``
-# sees the live old PID and exits 1 → claude silently drops the MCP.
+# previous runtime to actually exit before ESCALATING to SIGKILL (see
+# :mod:`._stop_escalate`). Tuned for apptainer healthy teardown
+# (~0.5–2 s); 15 s leaves comfortable headroom for a loaded host. The
+# race this closes: new container boots while the old one still holds
+# /home/agent overlay + per-agent stdio MCP child still holds its PID
+# lock file → new bun child's ``acquireLock`` sees the live old PID and
+# exits 1 → claude silently drops the MCP.
 _DEFAULT_WAIT_FOR_STOP_TIMEOUT_S = 15.0
-# Poll interval while waiting. 0.25 s is small enough that a 1-second
-# teardown costs <=4 polls; large enough that a healthy host doesn't
-# spend measurable CPU on the loop. ``sleep_fn`` controls real-time
-# behavior; tests pass ``_no_sleep`` to spin as fast as Python allows.
-_WAIT_FOR_STOP_POLL_INTERVAL_S = 0.25
 
 
 def agent_stop(
@@ -177,56 +173,6 @@ def agent_stop_all(
     return results
 
 
-def _wait_for_previous_runtime_to_exit(
-    name: str,
-    config_path: str,
-    *,
-    runtime_factory: Optional[Callable[[AgentConfig], Any]],
-    sleep_fn: Callable[[float], None],
-    timeout_s: float,
-) -> bool:
-    """Block until the previous runtime instance is no longer running.
-
-    Returns True if the runtime stopped cleanly within ``timeout_s``,
-    False on timeout (caller proceeds anyway after a LOUD warning — see
-    ``agent_restart`` docstring for the race this closes). ``timeout_s
-    <= 0`` skips the gate entirely (legacy ``sleep_fn(2)`` behaviour,
-    preserved for callers that want the bypass).
-    """
-    if timeout_s <= 0:
-        sleep_fn(2)
-        return True
-    # Load once: config is stable across the gate and re-loading per poll
-    # would multiply YAML parsing on a busy host.
-    try:
-        config = load_config(config_path)
-    except Exception:  # stx-allow: fallback (reason: YAML may have been edited mid-restart; fall back to the legacy fixed sleep instead of blocking the restart on a transient parse error — the new container will surface the real error when it boots)
-        sleep_fn(2)
-        return True
-    factory = runtime_factory or _get_runtime
-    runtime = factory(config)
-    deadline = time.monotonic() + timeout_s
-    while runtime.is_running(config):
-        if time.monotonic() >= deadline:
-            logger.warning(
-                "agent_restart for %r: previous runtime still running after "
-                "%.2fs (SIGTERM ignored or teardown hung); proceeding to "
-                "start anyway. WARNING: this may trigger the apptainer "
-                'double-mount race ("destination is already in the mount '
-                'point list") and stdio-MCP lock-file contention (the '
-                "standalone bun telegrammer poller exits 1 on lock held by "
-                "the orphaned previous PID, claude then silently drops the "
-                "MCP). If %r repeatedly fails to honor SIGTERM, investigate "
-                "the runtime stop path (see ApptainerContainerRuntime.stop).",
-                name,
-                timeout_s,
-                name,
-            )
-            return False
-        sleep_fn(_WAIT_FOR_STOP_POLL_INTERVAL_S)
-    return True
-
-
 def agent_restart(
     name: str,
     registry: Registry | None = None,
@@ -265,22 +211,36 @@ def agent_restart(
     Teardown gate (2026-06-07, bug #42 — telegrammer drops after restart):
     Between ``agent_stop`` (which sends SIGTERM and returns immediately —
     ``ApptainerContainerRuntime.stop`` says "No wait loop yet — sac's
-    outer lifecycle does its own poll") and ``agent_start``, this function
-    now polls ``runtime.is_running`` until False or
-    ``wait_for_stop_timeout_s`` elapses. The legacy fixed ``sleep_fn(2)``
-    was the SOLE settle window — it raced the apptainer teardown on a
-    loaded host. Operator-visible symptom: the new container booted while
-    the old one still held the ``/home/agent`` overlay (apptainer warned
-    "destination is already in the mount point list"), AND the old SDK's
-    per-agent stdio MCP child (the standalone bun telegrammer poller)
-    was still alive holding ``$HOME/.claude-code-telegrammer-*/...lock``.
-    The new bun child's ``acquireLock`` then hit ``process.kill(old_pid,
-    0)`` SUCCESS → ``process.exit(1)``, claude silently marked the MCP
-    failed and never retried it. ``sac`` + Mermaid MCPs reloaded fine
-    (no inter-instance lock for those), masking the bug as "only Telegram
-    broke." On timeout we LOG LOUD (so a stuck previous instance is
-    self-diagnosing from stdout.log) and proceed — silently spinning
-    forever locks the operator out of restart entirely.
+    outer lifecycle does its own poll") and ``agent_start``,
+    :func:`._stop_escalate.ensure_previous_runtime_down` polls
+    ``runtime.is_running`` until False or ``wait_for_stop_timeout_s``
+    elapses. The legacy fixed ``sleep_fn(2)`` was the SOLE settle window —
+    it raced the apptainer teardown on a loaded host. Operator-visible
+    symptom: the new container booted while the old one still held the
+    ``/home/agent`` overlay (apptainer warned "destination is already in
+    the mount point list"), AND the old SDK's per-agent stdio MCP child
+    (the standalone bun telegrammer poller) was still alive holding
+    ``$HOME/.claude-code-telegrammer-*/...lock``. The new bun child's
+    ``acquireLock`` then hit ``process.kill(old_pid, 0)`` SUCCESS →
+    ``process.exit(1)``, claude silently marked the MCP failed and never
+    retried it. ``sac`` + Mermaid MCPs reloaded fine (no inter-instance
+    lock for those), masking the bug as "only Telegram broke."
+
+    Gate ESCALATES, then FAILS LOUD (2026-07-14 — restart printed success
+    over a DOWN agent): on grace-timeout the gate used to log LOUD and
+    proceed into the start anyway. That WARN literally predicted the
+    collision ("previous runtime still running ... proceeding to start
+    anyway") which then happened ("duplicate session 'tui-neurovista'"),
+    after which the CLI printed "Agent 'neurovista' restarted" over an
+    agent that was left DOWN. A stop that could not stop the thing must
+    not walk into a start that is guaranteed to collide with it. The gate
+    now escalates SIGTERM → SIGKILL (the normal forced-stop contract,
+    aimed at ``runtime.agent_pid`` — the TUI PANE pid, not the launcher
+    that already exited), re-verifies with the runtime's OWN
+    ``is_running``, and raises :class:`._stop_escalate.StopEscalationError`
+    when it still cannot confirm the agent is down — so ``agent_start``
+    below is never reached and no success line is printed. See
+    :mod:`._stop_escalate`.
 
     Args:
         name: Agent name.
@@ -293,15 +253,20 @@ def agent_restart(
             :func:`config.resolve_config`). Injected for tests so the
             no-registry-row fallback can be exercised against a real
             on-disk spec without monkeypatching internals.
-        wait_for_stop_timeout_s: Upper bound on the previous-runtime
-            readiness gate (see "Teardown gate" above). Default 15 s —
-            ~10× a healthy apptainer teardown. Set to 0 to skip the gate
-            entirely (legacy behaviour, retained for tests of unrelated
-            code paths).
+        wait_for_stop_timeout_s: SIGTERM grace for the previous-runtime
+            gate (see "Teardown gate" above) before it escalates to
+            SIGKILL. Default 15 s — ~10× a healthy apptainer teardown.
+            Set to 0 to skip the gate entirely (legacy behaviour,
+            retained for tests of unrelated code paths).
 
     Raises:
         RuntimeError: When ``name`` has neither a registry row NOR a
             resolvable spec — a genuinely unknown agent.
+        StopEscalationError: When the previous runtime survived both
+            SIGTERM and SIGKILL. The start leg is NOT run (it would
+            collide with the survivor), so the agent is left as it was —
+            still UP as the OLD process — and the caller reports a
+            FAILED restart rather than a fictional success.
     """
     # Lazy import breaks the ``_start`` <-> ``_stop`` cycle.
     from ._start import agent_start
@@ -361,7 +326,11 @@ def agent_restart(
         runtime_factory=runtime_factory,
         handover_mod=handover_mod,
     )
-    _wait_for_previous_runtime_to_exit(
+    # Escalate (SIGKILL) or RAISE — never "proceed to start anyway" into a
+    # collision this gate already knows is coming. See ._stop_escalate.
+    from ._stop_escalate import ensure_previous_runtime_down
+
+    ensure_previous_runtime_down(
         name,
         config_path,
         runtime_factory=runtime_factory,
@@ -405,19 +374,23 @@ def agent_restart(
     # guard, which is *idempotent for a plain `sac agents start`* (an
     # already-running agent is "fine, it's up") and therefore RETURNS TRUE. For
     # a restart that verdict is a LIE: the caller asked for a new process and
-    # got the old one. The failure mode is not theoretical — it happens exactly
-    # when the stop leg above could not kill the old runtime (SIGTERM ignored,
-    # ``_wait_for_previous_runtime_to_exit`` returned False and we proceeded
-    # anyway). Then: stale session survives -> start no-ops -> returns True ->
-    # the CLI prints "Agent '<name>' restarted". The operator hit precisely
-    # this on neurovista: he believed it had relaunched on freshly-picked
-    # credentials, was in fact still talking to the OLD process on its OLD
-    # token, saw "Login expired", and went diagnosing a credential store that
-    # was entirely healthy.
+    # got the old one. The failure mode was not theoretical — it happened
+    # exactly when the stop leg could not kill the old runtime (SIGTERM
+    # ignored) and the gate PROCEEDED ANYWAY. Then: stale session survives ->
+    # start no-ops -> returns True -> the CLI prints "Agent '<name>' restarted".
+    # The operator hit precisely this on neurovista: he believed it had
+    # relaunched on freshly-picked credentials, was in fact still talking to the
+    # OLD process on its OLD token, saw "Login expired", and went diagnosing a
+    # credential store that was entirely healthy.
     #
-    # So a restart FORCES: the force branch tears the stale session down first,
-    # which both makes the restart actually happen and makes a genuine failure
-    # report as a failure.
+    # Belt AND braces, because they fail differently:
+    #   * the GATE above (``ensure_previous_runtime_down``) means we only reach
+    #     this line once the previous runtime is CONFIRMED down — a survivor
+    #     raises instead of falling through into a guaranteed collision;
+    #   * ``force=True`` here means that even a session the gate could not SEE
+    #     (a runtime whose ``is_running`` reads False while a stale tmux session
+    #     lingers) is torn down by the start leg rather than silently no-op'd
+    #     into a fictional success.
     return agent_start(
         config_path,
         registry,

--- a/src/scitex_agent_container/_lifecycle/_stop_escalate.py
+++ b/src/scitex_agent_container/_lifecycle/_stop_escalate.py
@@ -1,0 +1,323 @@
+"""The restart's stop leg, made honest: SIGTERM → SIGKILL → fail loud.
+
+Extracted from :mod:`._stop` (512-line cap) so the whole "is the previous
+runtime ACTUALLY down?" decision lives in ONE testable place.
+
+THE BUG THIS CLOSES (operator terminal, 2026-07-14, card
+``sac-restart-prints-success-after-start-failed``)::
+
+    WARN: previous runtime still running after 15.00s (SIGTERM ignored...);
+          proceeding to start anyway.
+    FAIL: duplicate session 'tui-neurovista' — agent already running.
+    Agent 'neurovista' restarted        <-- IT WAS NOT
+
+Read those three lines in order. The stop leg PREDICTED the collision
+("still running"), shrugged, and walked into it; the collision then
+happened exactly as predicted; and the restart reported success over an
+agent that was left DOWN. The gate had all the information needed to stop
+— and used it only to narrate the failure it was about to cause.
+
+The old ``_wait_for_previous_runtime_to_exit`` returned ``False`` on
+timeout and its ONLY caller (``agent_restart``) discarded the value. A
+verdict nobody reads is not a verdict.
+
+WHY ESCALATE (SIGKILL) RATHER THAN ONLY FAIL LOUD
+-------------------------------------------------
+A restart's contract is to REPLACE the process, and the standard contract
+for a forced stop everywhere else in the industry is SIGTERM, a grace
+window, then SIGKILL (systemd ``TimeoutStopSec``, ``docker stop``,
+kubelet). sac already had the SIGTERM and the 15 s grace; the escalation
+step was simply missing. Refusing to escalate would mean sac cannot
+restart an agent whose claude TUI is wedged mid-render and no longer
+reaping signals — which is precisely the population that most needs a
+restart. So: escalate FIRST, and fail loud only when the escalation
+itself cannot be confirmed.
+
+Both halves are required. Escalation without the fail-loud is just a
+longer path to the same lie (SIGKILL can fail: no resolvable pid on a
+remote/containerised runtime, an EPERM, or a process wedged in
+uninterruptible-``D`` I/O where SIGKILL cannot land until the syscall
+returns). Fail-loud without escalation would abort restarts that a single
+``kill -9`` would have fixed.
+
+KILL THE RIGHT PROCESS
+----------------------
+:meth:`RuntimeBase.agent_pid` — NOT the launcher. For a TUI agent the
+launcher spawns the tmux session and exits within seconds; the LONG-LIVED
+process is the pane pid (the pane's ``bash -c`` ``exec``s apptainer, and
+``exec`` keeps the pid). SIGKILLing a launcher pid would look right in the
+log and do nothing — and, pids being reused, could kill an unrelated
+process. ``agent_pid`` is contractually the same signal the runtime's own
+``is_running`` keys its verdict on, so "the thing we killed" and "the thing
+that is still running" cannot drift apart. A runtime that cannot name a
+local pid (docker / SSHRemote) returns ``None`` — honestly unknown — and we
+fail loud instead of guessing.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import time
+from typing import Any, Callable, Optional
+
+from ..config import AgentConfig, load_config
+from ._runtime_select import _get_runtime
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "StopEscalationError",
+    "ensure_previous_runtime_down",
+    "escalate_to_sigkill",
+    "long_lived_pid",
+]
+
+# How long to wait for the runtime to read as stopped AFTER SIGKILL.
+# SIGKILL is not negotiable, but reaping is not instantaneous: the kernel
+# tears the process down and (for a TUI agent) tmux must then notice the
+# pane died and close the session. 5 s is ~50x the observed teardown.
+_DEFAULT_SIGKILL_SETTLE_S = 5.0
+# Poll interval for both the SIGTERM grace and the post-SIGKILL settle.
+_POLL_INTERVAL_S = 0.25
+
+
+class StopEscalationError(RuntimeError):
+    """The previous runtime survived SIGTERM *and* SIGKILL.
+
+    Raised INSTEAD of proceeding into a start leg that is now GUARANTEED to
+    collide with the survivor (duplicate session) — the collision the old
+    code predicted in a WARN and then caused. Carries ``name`` / ``pid`` so
+    a structured caller can act without re-parsing the message.
+    """
+
+    def __init__(self, message: str, *, name: str, pid: int | None = None) -> None:
+        super().__init__(message)
+        self.name = name
+        self.pid = pid
+
+
+def long_lived_pid(runtime: Any, config: AgentConfig) -> int | None:
+    """The runtime's LONG-LIVED pid, or ``None`` when it cannot be named.
+
+    Thin, defensive read of the :meth:`RuntimeBase.agent_pid` seam.
+    ``None`` is an honest "unknown" and the caller MUST treat it as "cannot
+    escalate" — never as "nothing to kill".
+
+    Refuses to hand back a pid that must never be signalled:
+
+      * ``pid <= 0`` — ``os.kill(0, SIGKILL)`` signals sac's ENTIRE process
+        group and ``os.kill(-1, ...)`` signals every process this user owns.
+        A runtime bug that returned 0 would otherwise turn one wedged agent
+        into a fleet-wide massacre.
+      * our own pid — sac would kill itself mid-restart.
+    """
+    getter = getattr(runtime, "agent_pid", None)
+    if getter is None:
+        return None
+    try:
+        pid = getter(config)
+    except Exception:  # stx-allow: fallback (reason: a pid-probe hiccup is "unknown", never a fabricated pid — a wrong/reused pid would get an unrelated process SIGKILLed)
+        logger.warning(
+            "stop-escalation: agent_pid() probe failed for %r; cannot escalate",
+            getattr(config, "name", "?"),
+            exc_info=True,
+        )
+        return None
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return None
+    if pid == os.getpid():
+        logger.error(
+            "stop-escalation: agent_pid() returned OUR OWN pid (%s) for %r — "
+            "refusing to SIGKILL sac itself. This is a runtime bug.",
+            pid,
+            getattr(config, "name", "?"),
+        )
+        return None
+    return pid
+
+
+def _send_sigkill(pid: int, *, kill_fn: Callable[[int, int], None]) -> bool:
+    """SIGKILL ``pid``. True iff the signal landed or the process was gone.
+
+    ``ProcessLookupError`` is SUCCESS: the goal is "that process is not
+    running", and it already is not. ``PermissionError`` / ``OSError`` are
+    honest failures — we could not kill it, so we must not claim we did.
+    """
+    try:
+        kill_fn(pid, signal.SIGKILL)
+        return True
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        logger.error(
+            "stop-escalation: not permitted to SIGKILL pid %s (owned by "
+            "another user?) — cannot force the previous runtime down.",
+            pid,
+        )
+        return False
+    except OSError:
+        logger.error(
+            "stop-escalation: SIGKILL of pid %s failed", pid, exc_info=True
+        )
+        return False
+
+
+def _poll_until_stopped(
+    runtime: Any,
+    config: AgentConfig,
+    *,
+    sleep_fn: Callable[[float], None],
+    timeout_s: float,
+    poll_interval_s: float = _POLL_INTERVAL_S,
+) -> bool:
+    """True as soon as ``runtime.is_running`` reads False; False on timeout."""
+    deadline = time.monotonic() + timeout_s
+    while runtime.is_running(config):
+        if time.monotonic() >= deadline:
+            return False
+        sleep_fn(poll_interval_s)
+    return True
+
+
+def escalate_to_sigkill(
+    name: str,
+    config: AgentConfig,
+    runtime: Any,
+    *,
+    sleep_fn: Callable[[float], None],
+    settle_s: float = _DEFAULT_SIGKILL_SETTLE_S,
+    kill_fn: Callable[[int, int], None] = os.kill,
+) -> tuple[bool, int | None]:
+    """SIGKILL the runtime's long-lived process; VERIFY it actually died.
+
+    Returns ``(stopped, pid)``. ``stopped`` is the runtime's OWN verdict
+    after the kill (``is_running`` read False within ``settle_s``) — never
+    "we sent the signal, so it must be down". ``pid`` is what we killed, or
+    ``None`` when the runtime could not name one (in which case no signal
+    was sent and ``stopped`` reflects the runtime as it stands).
+    """
+    pid = long_lived_pid(runtime, config)
+    if pid is None:
+        logger.error(
+            "stop-escalation: %r ignored SIGTERM and its runtime cannot name a "
+            "long-lived pid (agent_pid() -> None), so there is nothing to "
+            "SIGKILL. Not starting a replacement over a survivor.",
+            name,
+        )
+        return runtime.is_running(config) is False, None
+    logger.warning(
+        "stop-escalation: %r ignored SIGTERM — escalating to SIGKILL on pid %s "
+        "(the runtime's long-lived process, the same pid its is_running() keys "
+        "on). This is the normal forced-stop contract: TERM, grace, KILL.",
+        name,
+        pid,
+    )
+    if not _send_sigkill(pid, kill_fn=kill_fn):
+        return False, pid
+    return (
+        _poll_until_stopped(runtime, config, sleep_fn=sleep_fn, timeout_s=settle_s),
+        pid,
+    )
+
+
+def _remedy(name: str, config: AgentConfig, pid: int | None) -> str:
+    """Operator remedy that ACTUALLY works, sized to what we observed.
+
+    Deliberately NOT ``sac agents restart`` — when this fires, that is the
+    very command that just failed, so recommending it loops the operator
+    back into the failure (the same reasoning as ``tui_session``'s
+    duplicate-session guard).
+    """
+    lines: list[str] = []
+    if pid is not None:
+        lines.append(
+            f"  ps -o pid,ppid,stat,wchan,cmd -p {pid}"
+            f"   # STAT 'D' = uninterruptible I/O: SIGKILL cannot land until "
+            f"the syscall returns"
+        )
+    # "" and "tui" both select TuiSessionRuntime (see _runtime_select).
+    if (getattr(config, "runtime", "") or "").strip().lower() in ("", "tui"):
+        lines.append(f"  tmux kill-session -t tui-{name}")
+    lines.append(f"  sac agents start {name} -y --fresh")
+    return "\n".join(lines)
+
+
+def ensure_previous_runtime_down(
+    name: str,
+    config_path: str,
+    *,
+    runtime_factory: Optional[Callable[[AgentConfig], Any]],
+    sleep_fn: Callable[[float], None],
+    timeout_s: float,
+    settle_s: float = _DEFAULT_SIGKILL_SETTLE_S,
+    kill_fn: Callable[[int, int], None] = os.kill,
+) -> None:
+    """Guarantee the previous runtime is DOWN, or raise.
+
+    The restart's stop-leg gate. Returns normally ONLY when the runtime's
+    own ``is_running`` reads False — i.e. when the start leg can safely
+    replace it. Raises :class:`StopEscalationError` otherwise, so
+    ``agent_restart`` never walks into the duplicate-session collision and
+    never reports a restart that did not happen.
+
+      1. Poll ``is_running`` for ``timeout_s`` (the SIGTERM grace the
+         preceding ``agent_stop`` opened).
+      2. Still up → SIGKILL the long-lived pid, poll again for ``settle_s``.
+      3. STILL up → raise, loudly, with a remedy that works.
+
+    ``timeout_s <= 0`` skips the gate entirely (legacy fixed-sleep
+    behaviour, retained for callers that want the bypass), as does an
+    unloadable spec — a YAML edited mid-restart must not block the restart;
+    the new container surfaces the real parse error when it boots.
+    """
+    if timeout_s <= 0:
+        sleep_fn(2)
+        return
+    # Load once: the config is stable across the gate, and re-loading per
+    # poll would multiply YAML parsing on a busy host.
+    try:
+        config = load_config(config_path)
+    except Exception:  # stx-allow: fallback (reason: YAML may have been edited mid-restart; fall back to the legacy fixed sleep instead of blocking the restart on a transient parse error — the new container surfaces the real error when it boots)
+        sleep_fn(2)
+        return
+    factory = runtime_factory or _get_runtime
+    runtime = factory(config)
+
+    if _poll_until_stopped(runtime, config, sleep_fn=sleep_fn, timeout_s=timeout_s):
+        return
+
+    stopped, pid = escalate_to_sigkill(
+        name,
+        config,
+        runtime,
+        sleep_fn=sleep_fn,
+        settle_s=settle_s,
+        kill_fn=kill_fn,
+    )
+    if stopped:
+        logger.warning(
+            "stop-escalation: %r is down after SIGKILL (pid %s). The restart "
+            "continues; the agent had to be force-killed, which means its "
+            "runtime stop path did not honour SIGTERM — worth investigating "
+            "(see ApptainerContainerRuntime.stop / TuiSessionRuntime.stop).",
+            name,
+            pid,
+        )
+        return
+
+    killed = "SIGKILL" if pid is not None else "no pid to SIGKILL"
+    raise StopEscalationError(
+        f"restart of {name!r} ABORTED: the previous runtime is STILL RUNNING "
+        f"after SIGTERM ({timeout_s:.1f}s grace) and {killed}"
+        + (f" (pid {pid}, {settle_s:.1f}s settle)" if pid is not None else "")
+        + f" — its own is_running() still reports True.\n"
+        f"NOT starting a replacement: the start leg would collide with the "
+        f"survivor (duplicate session {name!r}) and the restart would then "
+        f"report success over a process that never died. {name!r} is still UP "
+        f"as the OLD process on its OLD credentials — it was NOT restarted.\n"
+        f"Diagnose, then recover:\n" + _remedy(name, config, pid),
+        name=name,
+        pid=pid,
+    )

--- a/src/scitex_agent_container/_runners/_session_conversation.py
+++ b/src/scitex_agent_container/_runners/_session_conversation.py
@@ -253,7 +253,7 @@ async def run_conversation(
         # stopped responding after restart) leaves a self-diagnosing
         # trail in stdout.log. The corresponding ``apptainer_restart``
         # mount + lock race that originally caused this is closed in
-        # ``_lifecycle/_stop.py::_wait_for_previous_runtime_to_exit``;
+        # ``_lifecycle/_stop_escalate.py::ensure_previous_runtime_down``;
         # this log is the OBSERVABILITY half so a regression of either
         # the race or the SDK's per-MCP launch is visible without
         # bouncing the agent or attaching to its stderr.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/44_agent-to-agent-recovery.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/44_agent-to-agent-recovery.md
@@ -108,10 +108,26 @@ ACL allows the dev/researcher groups):
   context-inheriting fork of a running agent is `agent_twin`.
 
 Escalate to the operator **only** when the host listen broker itself is
-down — a transport timeout / connection-refused on the spawn, which the
-enriched `cannot reach listen …` error now flags with the fix
-(`sac listen restart`). Anything short of a dead broker is yours to do,
-not the operator's to queue.
+down. Note what that does and does not mean: a **timeout on one route is
+not proof the daemon is down**. Authenticated routes dispatch through
+listen's shared worker pool; the public `/v1/health` path is served on the
+event loop and never touches it — so a starved pool wedges the authed
+routes while `/v1/health` still answers in milliseconds (observed
+2026-07-14: an unauthenticated GET answered in 0.18s while the
+authenticated POST hung for 25s).
+
+You do not have to reason about this: the spawn/restart clients now
+**probe the unauthenticated path before naming a cause** and say which
+case they measured —
+
+- *"the listen daemon is UP and serving … it is the AUTHENTICATED route
+  that did not answer"* → the daemon is alive; `sac listen restart` on the
+  host clears the wedged pool. Not an operator escalation.
+- *"cannot reach listen … nothing is serving HTTP at this URL"* → genuinely
+  down or the wrong URL/port. `sac listen restart`, then escalate only if
+  it stays down.
+
+Anything short of a dead broker is yours to do, not the operator's to queue.
 
 ## Imitate this
 

--- a/tests/scitex_agent_container/_lifecycle/test__listen_probe.py
+++ b/tests/scitex_agent_container/_lifecycle/test__listen_probe.py
@@ -1,0 +1,251 @@
+"""Tests for the honest listen diagnosis — no mocks.
+
+The production module exposes an injectable ``opener`` callable that
+defaults to ``urllib.request.urlopen``; tests pass hand-rolled openers
+returning real ``urllib``-shaped response objects (the same no-mocks
+pattern as ``test__restart_client`` / ``test__spawn_client``).
+
+What is being pinned here is a HONESTY contract, and it is worth stating
+plainly. The old message asserted "the host listen broker is unreachable;
+it may be flapping" on ANY transport failure. The reporter measured the
+opposite: ``GET /health`` answered HTTP 401 in 0.18s (twice) while the
+authenticated POST hung for 25s. The daemon was UP. So:
+
+  * ANY HTTP response — including a 401 — proves the daemon is serving.
+  * Only the ABSENCE of an HTTP exchange is evidence of "unreachable".
+  * "flapping" is never asserted, because nothing here can observe a
+    crash loop.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import io
+from urllib import error as urlerror
+
+from scitex_agent_container._lifecycle._listen_probe import (
+    HealthProbe,
+    probe_listen_health,
+    transport_failure_message,
+)
+
+_BASE = "http://127.0.0.1:7878"
+
+
+class _FakeResp:
+    """A real callable response object matching the urllib contract."""
+
+    def __init__(self, body: bytes = b"{}", status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _opener_returning(status: int = 200):
+    """Build (opener, captured) — the opener records the request it saw."""
+    captured: dict = {}
+
+    def opener(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = {k.lower(): v for k, v in dict(req.headers).items()}
+        captured["timeout"] = timeout
+        return _FakeResp(status=status)
+
+    return opener, captured
+
+
+def _opener_raising(exc: Exception):
+    def opener(req, timeout=None):
+        raise exc
+
+    return opener
+
+
+def _http_error(status: int) -> urlerror.HTTPError:
+    return urlerror.HTTPError(
+        f"{_BASE}/v1/health", status, "nope", {}, io.BytesIO(b"")
+    )
+
+
+# ---------------------------------------------------------------------------
+# probe_listen_health — what did the daemon ACTUALLY do?
+# ---------------------------------------------------------------------------
+
+
+def test_probe_reads_http_200_as_serving() -> None:
+    # Arrange
+    opener, _ = _opener_returning(status=200)
+    # Act
+    probe = probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert probe.serving is True
+
+
+def test_probe_reads_http_401_as_serving() -> None:
+    # Arrange — the reporter's exact evidence: an unauthenticated GET got a
+    # 401 in 0.18s. A 401 is a RESPONSE: the daemon is up and serving.
+    opener = _opener_raising(_http_error(401))
+    # Act
+    probe = probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert probe.serving is True
+
+
+def test_probe_keeps_the_http_status_it_saw() -> None:
+    # Arrange
+    opener = _opener_raising(_http_error(401))
+    # Act
+    probe = probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert probe.status == 401
+
+
+def test_probe_reads_connection_refused_as_not_serving() -> None:
+    # Arrange — no HTTP exchange at all. THIS, and only this, is
+    # "unreachable".
+    opener = _opener_raising(urlerror.URLError("connection refused"))
+    # Act
+    probe = probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert probe.serving is False
+
+
+def test_probe_hits_the_public_health_path() -> None:
+    # Arrange — /v1/health is the ONE path BearerAuthMiddleware exempts.
+    opener, captured = _opener_returning()
+    # Act
+    probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert captured["url"] == f"{_BASE}/v1/health"
+
+
+def test_probe_sends_no_authorization_header() -> None:
+    # Arrange — the probe must exercise the path that CANNOT be wedged by a
+    # starved worker pool. Sending the bearer would route it through the very
+    # code it is trying to rule out, and it would hang with it.
+    opener, captured = _opener_returning()
+    # Act
+    probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert "authorization" not in captured["headers"]
+
+
+def test_probe_uses_a_short_timeout() -> None:
+    # Arrange — the probe runs INSIDE a failure path that already burned its
+    # own timeout; it must not add another 60s wait.
+    opener, captured = _opener_returning()
+    # Act
+    probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert captured["timeout"] <= 5.0
+
+
+def test_probe_never_raises_on_unexpected_error() -> None:
+    # Arrange — a probe that exists to improve an error message must never
+    # replace it with a crash of its own.
+    opener = _opener_raising(RuntimeError("something exotic"))
+    # Act
+    probe = probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert probe.serving is False
+
+
+# ---------------------------------------------------------------------------
+# transport_failure_message — say what was measured, and nothing more
+# ---------------------------------------------------------------------------
+
+
+def _message(probe: HealthProbe) -> str:
+    return transport_failure_message(
+        verb="restart",
+        name="neurovista",
+        base=_BASE,
+        route="POST /agents/neurovista/restart",
+        exc=TimeoutError("timed out"),
+        timeout_s=60.0,
+        probe=probe,
+    )
+
+
+_SERVING = HealthProbe(
+    serving=True,
+    status=401,
+    elapsed_s=0.18,
+    error=None,
+    url=f"{_BASE}/v1/health",
+)
+_DEAD = HealthProbe(
+    serving=False,
+    status=None,
+    elapsed_s=0.01,
+    error="connection refused",
+    url=f"{_BASE}/v1/health",
+)
+
+
+def test_message_says_daemon_is_up_when_it_answered() -> None:
+    # Arrange — daemon answered the cheap path; the authed route hung.
+    # Act
+    message = _message(_SERVING)
+    # Assert
+    assert "the listen daemon is UP and serving" in message
+
+
+def test_message_blames_the_authenticated_route_not_the_daemon() -> None:
+    # Arrange
+    # Act
+    message = _message(_SERVING)
+    # Assert
+    assert "it is the AUTHENTICATED route that did not answer" in message.replace(
+        "\n", " "
+    )
+
+
+def test_message_quotes_the_measurement_it_made() -> None:
+    # Arrange
+    # Act
+    message = _message(_SERVING)
+    # Assert — the evidence is IN the message, so the operator can check it.
+    assert "answered HTTP 401 in 0.18s" in message
+
+
+def test_message_never_claims_flapping_when_daemon_answers() -> None:
+    # Arrange — the word asserts a crash loop. Nothing here observed one.
+    # Act
+    message = _message(_SERVING)
+    # Assert
+    assert "flapping" not in message
+
+
+def test_message_never_claims_flapping_when_daemon_is_down() -> None:
+    # Arrange — even a genuinely dead daemon is not evidence of FLAPPING.
+    # Act
+    message = _message(_DEAD)
+    # Assert
+    assert "flapping" not in message
+
+
+def test_message_says_cannot_reach_when_nothing_answered() -> None:
+    # Arrange — no HTTP exchange on either route: genuinely unreachable.
+    # Act
+    message = _message(_DEAD)
+    # Assert
+    assert "cannot reach listen" in message
+
+
+def test_message_keeps_the_listen_restart_remedy_when_down() -> None:
+    # Arrange
+    # Act
+    message = _message(_DEAD)
+    # Assert
+    assert "sac listen restart" in message

--- a/tests/scitex_agent_container/_lifecycle/test__restart_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__restart_client.py
@@ -339,7 +339,8 @@ def test_transport_error_keeps_status_none(listen_env) -> None:
 
 
 def test_transport_error_message_carries_broker_hint(listen_env) -> None:
-    # Arrange — listen unreachable (connection refused etc.).
+    # Arrange — listen unreachable (connection refused etc.): the health
+    # probe gets nothing either, so "cannot reach" is the MEASURED verdict.
     listen_env("LISTEN_BASE_URL", "http://host:9100")
     opener = _opener_raising(urlerror.URLError("connection refused"))
     message = ""
@@ -352,6 +353,73 @@ def test_transport_error_message_carries_broker_hint(listen_env) -> None:
     # detail AND appends the cause+fix hint naming `sac listen restart`, so a
     # broker-down restart is a dead-end no longer.
     assert "cannot reach listen" in message and "sac listen restart" in message
+
+
+# ---------------------------------------------------------------------------
+# The authenticated route is wedged while the daemon is UP (2026-07-14).
+#
+# The reporter measured:
+#   GET  /health             (unauthenticated) -> HTTP 401 in 0.18s, twice
+#   POST /agents/<n>/restart (with bearer)     -> no response in 25s
+#
+# The old message asserted "the host listen broker is unreachable; it may be
+# flapping" — a diagnosis nobody had measured, and the wrong one. A timeout on
+# ONE route licenses a claim about THAT ROUTE and nothing more.
+# ---------------------------------------------------------------------------
+
+
+def _opener_wedged_authed_route():
+    """Real opener: the authenticated POST hangs; GET /v1/health answers fast.
+
+    This is the production split — authed routes dispatch through listen's
+    shared worker pool, the public health path is served on the event loop.
+    """
+
+    def opener(req, timeout=None):
+        if req.get_method() == "GET" and req.full_url.endswith("/v1/health"):
+            return _FakeResp(b'{"ok": true}', 200)
+        raise urlerror.URLError(TimeoutError("timed out"))
+
+    return opener
+
+
+def test_wedged_authed_route_reports_daemon_up(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    message = ""
+    # Act
+    try:
+        request_restart("peer", opener=_opener_wedged_authed_route())
+    except RestartRequestError as exc:
+        message = str(exc)
+    # Assert — the daemon answered the cheap path; say so.
+    assert "the listen daemon is UP and serving" in message
+
+
+def test_wedged_authed_route_never_claims_flapping(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    message = ""
+    # Act
+    try:
+        request_restart("peer", opener=_opener_wedged_authed_route())
+    except RestartRequestError as exc:
+        message = str(exc)
+    # Assert — nothing here observed a crash loop, so nothing may assert one.
+    assert "flapping" not in message
+
+
+def test_wedged_authed_route_never_claims_unreachable(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    message = ""
+    # Act
+    try:
+        request_restart("peer", opener=_opener_wedged_authed_route())
+    except RestartRequestError as exc:
+        message = str(exc)
+    # Assert — it was reached; it just did not answer THIS route.
+    assert "cannot reach listen" not in message
 
 
 def test_non_dict_2xx_body_raises_restart_request_error(listen_env) -> None:

--- a/tests/scitex_agent_container/_lifecycle/test__restart_preflight_integration.py
+++ b/tests/scitex_agent_container/_lifecycle/test__restart_preflight_integration.py
@@ -53,7 +53,21 @@ def registry(tmp_path: Path) -> Registry:
 
 
 class _FakeRuntime:
-    """Recording runtime double (is_running / start / stop)."""
+    """Recording runtime double (is_running / start / stop).
+
+    ``stop`` really stops it — i.e. ``is_running`` reads False afterwards.
+    That is not a convenience: a runtime whose ``is_running`` stays True
+    after a stop and a full SIGTERM grace is a runtime whose stop FAILED,
+    and ``agent_restart``'s teardown gate now (correctly) refuses to start
+    a replacement over such a survivor — it escalates to SIGKILL and, when
+    it still cannot confirm the agent is down, raises (see
+    ``_lifecycle/_stop_escalate.py``; the operator's 2026-07-14
+    "Agent 'neurovista' restarted" over a DOWN agent is what that closes).
+    The cases in this module are about the CREDENTIAL PRE-FLIGHT, so their
+    runtime must model a HEALTHY teardown; a stop that silently does
+    nothing would have them exercising the wedged-teardown path by
+    accident.
+    """
 
     def __init__(self, *, running: bool = False, start_result: bool = True) -> None:
         self.running = running
@@ -66,10 +80,12 @@ class _FakeRuntime:
 
     def start(self, config: Any, **_kw: Any) -> bool:
         self.start_calls.append(config)
+        self.running = True
         return self.start_result
 
     def stop(self, config: Any) -> None:
         self.stop_calls.append(config)
+        self.running = False
 
     def logs(self, config: Any, lines: int) -> str:
         return ""

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
@@ -467,6 +467,67 @@ def test_transport_error_message_carries_broker_hint(listen_env) -> None:
     assert "cannot reach listen" in message and "sac listen restart" in message
 
 
+# ---------------------------------------------------------------------------
+# The authenticated route is wedged while the daemon is UP (2026-07-14).
+#
+# Measured on the live host: an unauthenticated GET answered HTTP 401 in
+# 0.18s (twice) while the authenticated POST hung. The old message asserted
+# "the host listen broker is unreachable; it may be flapping" — unmeasured,
+# and wrong. Authed routes dispatch through listen's shared worker pool; the
+# public /v1/health path is served on the event loop and never touches it.
+# ---------------------------------------------------------------------------
+
+
+def _opener_wedged_authed_route():
+    """Real opener: the authenticated POST hangs; GET /v1/health answers fast."""
+
+    def opener(req, timeout=None):
+        if req.get_method() == "GET" and req.full_url.endswith("/v1/health"):
+            return _FakeResp(b'{"ok": true}', 200)
+        raise urlerror.URLError(TimeoutError("timed out"))
+
+    return opener
+
+
+def test_wedged_authed_route_reports_daemon_up(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    message = ""
+    # Act
+    try:
+        request_spawn("c", opener=_opener_wedged_authed_route())
+    except SpawnRequestError as exc:
+        message = str(exc)
+    # Assert
+    assert "the listen daemon is UP and serving" in message
+
+
+def test_wedged_authed_route_never_claims_flapping(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    message = ""
+    # Act
+    try:
+        request_spawn("c", opener=_opener_wedged_authed_route())
+    except SpawnRequestError as exc:
+        message = str(exc)
+    # Assert — nothing here observed a crash loop, so nothing may assert one.
+    assert "flapping" not in message
+
+
+def test_wedged_authed_route_never_claims_unreachable(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    message = ""
+    # Act
+    try:
+        request_spawn("c", opener=_opener_wedged_authed_route())
+    except SpawnRequestError as exc:
+        message = str(exc)
+    # Assert
+    assert "cannot reach listen" not in message
+
+
 def test_non_dict_2xx_body_raises_spawn_request_error(listen_env) -> None:
     # Arrange — server returns a JSON array instead of an object; must
     # fail loud rather than silently corrupt the caller's downstream use.

--- a/tests/scitex_agent_container/_lifecycle/test__stop_escalate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__stop_escalate.py
@@ -1,0 +1,625 @@
+"""Tests for the restart's stop-leg escalation — no mocks, real processes.
+
+The agent that survives SIGTERM is a REAL OS child process that REALLY
+installs ``signal.SIG_IGN`` for SIGTERM, so the operator's bug shape
+("previous runtime still running after 15.00s — SIGTERM ignored") is
+REPRODUCED rather than simulated. The escalation then sends a REAL
+SIGKILL through the REAL ``os.kill``, and the test asserts on the REAL
+child's exit status (``-signal.SIGKILL``). Nothing about the kill path is
+faked — a fake here would prove nothing, since the entire question is
+whether sac kills the right process for real.
+
+The runtimes are hand-rolled real classes implementing the production
+``RuntimeBase`` surface (the pidless one subclasses ``RuntimeBase`` so its
+``agent_pid`` IS the production default, not a test re-implementation).
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from scitex_agent_container._lifecycle._stop_escalate import (
+    StopEscalationError,
+    ensure_previous_runtime_down,
+    escalate_to_sigkill,
+    long_lived_pid,
+)
+from scitex_agent_container.config import AgentConfig, load_config
+from scitex_agent_container.runtimes.base import RuntimeBase
+
+# A child that IGNORES SIGTERM — the exact behaviour that made the stop leg
+# give up. It announces readiness on stdout so the test never races the
+# handler installation (a SIGTERM delivered before ``SIG_IGN`` is armed
+# would kill it and silently invalidate the whole test).
+_SIGTERM_DEAF = (
+    "import signal, sys, time\n"
+    "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+    "sys.stdout.write('armed\\n')\n"
+    "sys.stdout.flush()\n"
+    "time.sleep(300)\n"
+)
+
+
+def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+def _write_spec(tmp_path: Path, *, name: str = "alpha", runtime: str = "tui") -> Path:
+    """A real, validator-passing v3 spec at ``<tmp>/<name>/spec.yaml``.
+
+    ``load_config`` derives the agent name from the parent directory
+    (dir-as-SSoT), so the file must live at ``<name>/spec.yaml``.
+    """
+    agent_dir = tmp_path / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        f"  runtime: {runtime}\n"
+        "  host: ${HOSTNAME}\n"
+        f"  workdir: {tmp_path / 'work'}\n"
+        "  apptainer:\n"
+        "    image: /x.sif\n"
+        "    binds: []\n"
+        "  claude:\n"
+        "    model: sonnet\n"
+        "  health:\n"
+        "    enabled: true\n"
+        "    interval: 60\n"
+        "  restart:\n"
+        "    policy: on-failure\n"
+        "    max_retries: 3\n"
+        "  hooks:\n"
+        "    pre_start: []\n"
+        "    post_start: []\n"
+        "    pre_stop: []\n"
+        "    post_stop: []\n"
+    )
+    return spec
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path: Path) -> Iterator[None]:
+    """Redirect HOME so nothing here can read or write the LIVE fleet state.
+
+    Production code resolves ``~/.scitex/agent-container/...`` via
+    ``Path.home()``. Without this, the suite would read the developer's real
+    registry — passing locally and failing in CI, where no fleet exists.
+    """
+    prev = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = prev
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> AgentConfig:
+    return load_config(str(_write_spec(tmp_path)))
+
+
+@pytest.fixture
+def deaf_proc() -> Iterator[subprocess.Popen]:
+    """A REAL child process that ignores SIGTERM. Always reaped."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _SIGTERM_DEAF],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    if proc.stdout is not None:
+        proc.stdout.readline()  # blocks until SIG_IGN is armed
+    try:
+        yield proc
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait(timeout=10)
+        if proc.stdout is not None:
+            proc.stdout.close()
+
+
+class _RealProcessRuntime(RuntimeBase):
+    """A runtime whose agent IS a real OS process.
+
+    ``stop`` sends a REAL SIGTERM (which the deaf child ignores),
+    ``is_running`` reads the REAL process state, and ``agent_pid`` reports
+    the REAL long-lived pid — the seam the escalation aims SIGKILL at.
+    """
+
+    def __init__(self, proc: subprocess.Popen) -> None:
+        self._proc = proc
+        self.stop_calls = 0
+        self.start_calls = 0
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        self.start_calls += 1
+        return True
+
+    def stop(self, config: AgentConfig) -> bool:
+        self.stop_calls += 1
+        self._proc.terminate()  # a REAL SIGTERM
+        return True
+
+    def is_running(self, config: AgentConfig) -> bool:
+        return self._proc.poll() is None
+
+    def logs(self, config: AgentConfig, lines: int = 50) -> str:
+        return ""
+
+    def agent_pid(self, config: AgentConfig) -> int | None:
+        return self._proc.pid
+
+
+class _PidlessRuntime(RuntimeBase):
+    """Alive, and cannot name a local pid — the docker / SSHRemote shape.
+
+    ``agent_pid`` is NOT overridden: this exercises the REAL
+    ``RuntimeBase.agent_pid`` default (``None`` = honestly unknown), which
+    is precisely the case where escalation is impossible.
+    """
+
+    def __init__(self) -> None:
+        self.start_calls = 0
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        self.start_calls += 1
+        return True
+
+    def stop(self, config: AgentConfig) -> bool:
+        return False
+
+    def is_running(self, config: AgentConfig) -> bool:
+        return True
+
+    def logs(self, config: AgentConfig, lines: int = 50) -> str:
+        return ""
+
+
+class _UnkillableRuntime(RuntimeBase):
+    """Names a pid, but nothing makes it stop (SIGKILL wedged in D-state).
+
+    ``kill_fn`` is injected by the caller as a real recording callable, so
+    no real process is signalled and the "SIGKILL landed but the process is
+    STILL there" branch is reachable deterministically.
+    """
+
+    def __init__(self, pid: int) -> None:
+        self._pid = pid
+        self.signals: list[int] = []
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        return True
+
+    def stop(self, config: AgentConfig) -> bool:
+        return False
+
+    def is_running(self, config: AgentConfig) -> bool:
+        return True
+
+    def logs(self, config: AgentConfig, lines: int = 50) -> str:
+        return ""
+
+    def agent_pid(self, config: AgentConfig) -> int | None:
+        return self._pid
+
+
+class _StoppedRuntime(RuntimeBase):
+    """Already down — the healthy teardown."""
+
+    def __init__(self) -> None:
+        self.pid_reads = 0
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        return True
+
+    def stop(self, config: AgentConfig) -> bool:
+        return True
+
+    def is_running(self, config: AgentConfig) -> bool:
+        return False
+
+    def logs(self, config: AgentConfig, lines: int = 50) -> str:
+        return ""
+
+    def agent_pid(self, config: AgentConfig) -> int | None:
+        self.pid_reads += 1
+        return 1234
+
+
+# ---------------------------------------------------------------------------
+# long_lived_pid — the seam that decides WHAT gets SIGKILLed
+# ---------------------------------------------------------------------------
+
+
+def test_long_lived_pid_reports_the_real_process_pid(
+    config: AgentConfig, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange
+    runtime = _RealProcessRuntime(deaf_proc)
+    # Act
+    pid = long_lived_pid(runtime, config)
+    # Assert
+    assert pid == deaf_proc.pid
+
+
+def test_long_lived_pid_is_none_without_the_seam(config: AgentConfig) -> None:
+    # Arrange — the production RuntimeBase default (docker / SSHRemote).
+    runtime = _PidlessRuntime()
+    # Act
+    pid = long_lived_pid(runtime, config)
+    # Assert — honestly unknown, never a guess.
+    assert pid is None
+
+
+def test_long_lived_pid_refuses_pid_zero(config: AgentConfig) -> None:
+    # Arrange — os.kill(0, SIGKILL) would signal sac's ENTIRE process group;
+    # a runtime bug returning 0 must never become a fleet-wide massacre.
+    runtime = _UnkillableRuntime(pid=0)
+    # Act
+    pid = long_lived_pid(runtime, config)
+    # Assert
+    assert pid is None
+
+
+def test_long_lived_pid_refuses_negative_pid(config: AgentConfig) -> None:
+    # Arrange — os.kill(-1, ...) signals every process this user owns.
+    runtime = _UnkillableRuntime(pid=-1)
+    # Act
+    pid = long_lived_pid(runtime, config)
+    # Assert
+    assert pid is None
+
+
+def test_long_lived_pid_refuses_our_own_pid(config: AgentConfig) -> None:
+    # Arrange — sac must not SIGKILL itself mid-restart.
+    runtime = _UnkillableRuntime(pid=os.getpid())
+    # Act
+    pid = long_lived_pid(runtime, config)
+    # Assert
+    assert pid is None
+
+
+# ---------------------------------------------------------------------------
+# escalate_to_sigkill — a REAL SIGKILL against a REAL SIGTERM-deaf process
+# ---------------------------------------------------------------------------
+
+
+def test_escalation_really_kills_the_sigterm_deaf_process(
+    config: AgentConfig, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange — the real bug shape: SIGTERM is sent and IGNORED.
+    runtime = _RealProcessRuntime(deaf_proc)
+    runtime.stop(config)
+    # Act — real os.kill, no injected kill_fn.
+    escalate_to_sigkill(config.name, config, runtime, sleep_fn=_no_sleep)
+    # Assert — the REAL child died of a REAL SIGKILL.
+    assert deaf_proc.wait(timeout=10) == -signal.SIGKILL
+
+
+def test_escalation_reports_stopped_after_the_kill(
+    config: AgentConfig, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange
+    runtime = _RealProcessRuntime(deaf_proc)
+    runtime.stop(config)
+    # Act
+    stopped, _pid = escalate_to_sigkill(
+        config.name, config, runtime, sleep_fn=_no_sleep
+    )
+    # Assert — the verdict is the runtime's OWN is_running, post-kill.
+    assert stopped is True
+
+
+def test_escalation_reports_the_pid_it_killed(
+    config: AgentConfig, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange
+    runtime = _RealProcessRuntime(deaf_proc)
+    # Act
+    _stopped, pid = escalate_to_sigkill(
+        config.name, config, runtime, sleep_fn=_no_sleep
+    )
+    # Assert
+    assert pid == deaf_proc.pid
+
+
+def test_escalation_cannot_kill_without_a_pid(config: AgentConfig) -> None:
+    # Arrange — a runtime that is UP and cannot name a pid.
+    runtime = _PidlessRuntime()
+    # Act
+    stopped, _pid = escalate_to_sigkill(
+        config.name, config, runtime, sleep_fn=_no_sleep
+    )
+    # Assert — no signal was sent and the agent is still up: NOT stopped.
+    assert stopped is False
+
+
+def test_escalation_sends_sigkill_not_sigterm(config: AgentConfig) -> None:
+    # Arrange — a real recording kill callable (injection seam, not a mock).
+    runtime = _UnkillableRuntime(pid=999_000)
+    # Act
+    escalate_to_sigkill(
+        config.name,
+        config,
+        runtime,
+        sleep_fn=_no_sleep,
+        settle_s=0.01,
+        kill_fn=lambda pid, sig: runtime.signals.append(sig),
+    )
+    # Assert — the escalation is a KILL; the TERM already failed.
+    assert runtime.signals == [signal.SIGKILL]
+
+
+def test_escalation_reports_not_stopped_when_kill_does_not_land(
+    config: AgentConfig,
+) -> None:
+    # Arrange — SIGKILL "delivered" but the process is still there
+    # (uninterruptible D-state I/O).
+    runtime = _UnkillableRuntime(pid=999_000)
+    # Act
+    stopped, _pid = escalate_to_sigkill(
+        config.name,
+        config,
+        runtime,
+        sleep_fn=_no_sleep,
+        settle_s=0.01,
+        kill_fn=lambda pid, sig: runtime.signals.append(sig),
+    )
+    # Assert — we sent the signal, but we do NOT claim it worked.
+    assert stopped is False
+
+
+# ---------------------------------------------------------------------------
+# ensure_previous_runtime_down — the gate: escalate, else RAISE (never proceed)
+# ---------------------------------------------------------------------------
+
+
+def _gate(
+    tmp_path: Path,
+    runtime: Any,
+    *,
+    timeout_s: float = 0.05,
+    settle_s: float = 5.0,
+    kill_fn: Any = os.kill,
+    name: str = "alpha",
+) -> None:
+    """Act helper: run the REAL gate against ``runtime``.
+
+    ``timeout_s`` (the SIGTERM grace) is tiny so the test is fast. ``settle_s``
+    keeps the PRODUCTION default: SIGKILLing a REAL process and seeing it reaped
+    is not instantaneous, and a sub-100ms settle here would flake on a loaded
+    host — which would be the test lying about a kill that did in fact work.
+    Tests that assert the RAISE path pass a small ``settle_s`` explicitly,
+    because in those the process is deliberately never going to die.
+    """
+    ensure_previous_runtime_down(
+        name,
+        str(tmp_path / name / "spec.yaml"),
+        runtime_factory=lambda _c: runtime,
+        sleep_fn=_no_sleep,
+        timeout_s=timeout_s,
+        settle_s=settle_s,
+        kill_fn=kill_fn,
+    )
+
+
+def test_gate_returns_silently_when_runtime_already_stopped(tmp_path: Path) -> None:
+    # Arrange
+    _write_spec(tmp_path)
+    runtime = _StoppedRuntime()
+    # Act
+    _gate(tmp_path, runtime)
+    # Assert — a healthy teardown never reaches the kill path.
+    assert runtime.pid_reads == 0
+
+
+def test_gate_escalates_and_kills_the_deaf_runtime(
+    tmp_path: Path, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange — SIGTERM sent and ignored; the grace will expire.
+    _write_spec(tmp_path)
+    runtime = _RealProcessRuntime(deaf_proc)
+    runtime.stop(load_config(str(tmp_path / "alpha" / "spec.yaml")))
+    # Act
+    _gate(tmp_path, runtime)
+    # Assert — the survivor is REALLY dead, so the start leg cannot collide.
+    assert deaf_proc.wait(timeout=10) == -signal.SIGKILL
+
+
+def test_gate_raises_when_runtime_cannot_be_stopped(tmp_path: Path) -> None:
+    # Arrange — up, and impossible to kill (no nameable pid).
+    _write_spec(tmp_path)
+    # Act
+    call = lambda: _gate(tmp_path, _PidlessRuntime())  # noqa: E731
+    # Assert — the gate REFUSES to fall through into a guaranteed collision.
+    with pytest.raises(StopEscalationError):
+        call()
+
+
+def test_gate_error_says_the_agent_was_not_restarted(tmp_path: Path) -> None:
+    # Arrange
+    _write_spec(tmp_path)
+    message = ""
+    # Act
+    try:
+        _gate(tmp_path, _PidlessRuntime())
+    except StopEscalationError as exc:
+        message = str(exc)
+    # Assert — the old code printed "restarted" here; the message must say
+    # the opposite, in the operator's own terms.
+    assert "was NOT restarted" in message
+
+
+def test_gate_error_names_the_still_running_agent(tmp_path: Path) -> None:
+    # Arrange
+    _write_spec(tmp_path, name="neurovista")
+    message = ""
+    # Act
+    try:
+        _gate(tmp_path, _PidlessRuntime(), name="neurovista")
+    except StopEscalationError as exc:
+        message = str(exc)
+    # Assert
+    assert "neurovista" in message
+
+
+def test_gate_error_carries_a_remedy_that_works(tmp_path: Path) -> None:
+    # Arrange — a TUI agent (the neurovista shape).
+    _write_spec(tmp_path, name="neurovista", runtime="tui")
+    message = ""
+    # Act
+    try:
+        _gate(tmp_path, _PidlessRuntime(), name="neurovista")
+    except StopEscalationError as exc:
+        message = str(exc)
+    # Assert — NOT `sac agents restart` (the command that just failed).
+    assert "tmux kill-session -t tui-neurovista" in message
+
+
+def test_gate_error_carries_the_pid_it_could_not_kill(tmp_path: Path) -> None:
+    # Arrange
+    _write_spec(tmp_path)
+    runtime = _UnkillableRuntime(pid=999_000)
+    captured: object = None
+    # Act
+    try:
+        _gate(
+            tmp_path,
+            runtime,
+            settle_s=0.05,
+            kill_fn=lambda pid, sig: runtime.signals.append(sig),
+        )
+    except StopEscalationError as exc:
+        captured = exc.pid
+    # Assert — structured, so a caller need not re-parse the message.
+    assert captured == 999_000
+
+
+def test_gate_bypasses_entirely_on_zero_timeout(tmp_path: Path) -> None:
+    # Arrange — the legacy fixed-sleep bypass, retained for callers that
+    # deliberately skip the gate. A running runtime must NOT raise here.
+    _write_spec(tmp_path)
+    runtime = _PidlessRuntime()
+    # Act
+    _gate(tmp_path, runtime, timeout_s=0.0)
+    # Assert — reaching this line at all is the contract (no raise).
+    assert runtime.is_running(load_config(str(tmp_path / "alpha" / "spec.yaml")))
+
+
+# ---------------------------------------------------------------------------
+# agent_restart — the whole chain, end to end.
+#
+# The operator's terminal, 2026-07-14:
+#
+#   WARN: previous runtime still running after 15.00s (SIGTERM ignored...);
+#         proceeding to start anyway.
+#   FAIL: duplicate session 'tui-neurovista' — agent already running.
+#   Agent 'neurovista' restarted        <-- IT WAS NOT
+#
+# Two contracts, one per failure mode of the stop leg:
+#   * the survivor CAN be killed  -> kill it, then really restart;
+#   * the survivor CANNOT be killed -> RAISE. Never start (the start would
+#     collide with it), never report success.
+# ---------------------------------------------------------------------------
+
+
+class _FakeHandover:
+    """Real collaborator matching the handover module surface."""
+
+    def ensure_instance_uuid(self, config: AgentConfig) -> str:
+        return "fake-uuid"
+
+    def hydrate_from_hub(self, config: AgentConfig) -> bool:
+        return True
+
+    def push_pre_stop_snapshot(
+        self, config: AgentConfig, payload: dict | None = None
+    ) -> bool:
+        return True
+
+    def start_failback_poller(self, config: AgentConfig) -> None:
+        return None
+
+
+def _restart(tmp_path: Path, runtime: Any, *, name: str = "alpha") -> bool:
+    """Act helper: drive the REAL ``agent_restart`` against ``runtime``."""
+    from scitex_agent_container._lifecycle import lifecycle as lc
+    from scitex_agent_container._state.registry import Registry
+
+    registry = Registry(registry_dir=tmp_path / "reg")
+    registry.add(name, str(tmp_path / name / "spec.yaml"), f"cld-{name}")
+    return lc.agent_restart(
+        name,
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        sleep_fn=_no_sleep,
+        handover_mod=_FakeHandover(),
+        # The credential pre-flight is a separate production seam with its own
+        # suite; injecting a real no-op callable keeps THIS test about the stop
+        # leg (and off the network).
+        successor_auth_check=lambda _path: None,
+        wait_for_stop_timeout_s=0.05,
+    )
+
+
+def test_restart_kills_the_runtime_that_ignored_sigterm(
+    tmp_path: Path, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange — the neurovista shape: a REAL process that ignores SIGTERM.
+    _write_spec(tmp_path)
+    # Act
+    _restart(tmp_path, _RealProcessRuntime(deaf_proc))
+    # Assert — the previous runtime is REALLY gone, so the new one cannot
+    # collide with it ("duplicate session") on the way up.
+    assert deaf_proc.wait(timeout=10) == -signal.SIGKILL
+
+
+def test_restart_starts_the_replacement_after_escalating(
+    tmp_path: Path, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange
+    _write_spec(tmp_path)
+    runtime = _RealProcessRuntime(deaf_proc)
+    # Act
+    _restart(tmp_path, runtime)
+    # Assert — escalation is not an abort: the restart still restarts.
+    assert runtime.start_calls == 1
+
+
+def test_restart_raises_when_the_survivor_cannot_be_killed(tmp_path: Path) -> None:
+    # Arrange — up, and unkillable (no nameable pid).
+    _write_spec(tmp_path)
+    # Act
+    call = lambda: _restart(tmp_path, _PidlessRuntime())  # noqa: E731
+    # Assert — the old code returned True here and the CLI printed
+    # "Agent 'neurovista' restarted" over an agent that was left DOWN.
+    with pytest.raises(StopEscalationError):
+        call()
+
+
+def test_restart_never_starts_over_a_surviving_runtime(tmp_path: Path) -> None:
+    # Arrange
+    _write_spec(tmp_path)
+    runtime = _PidlessRuntime()
+    # Act
+    try:
+        _restart(tmp_path, runtime)
+    except StopEscalationError:
+        pass
+    # Assert — the gate must not walk into the collision it just predicted.
+    assert runtime.start_calls == 0

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -1680,18 +1680,38 @@ def test_agent_restart_polls_is_running_until_false(
 # ---------------------------------------------------------------------------
 
 
+# A previous runtime that will NOT die: ``is_running`` stays True forever and
+# ``FakeRuntime`` never overrides ``agent_pid``, so the escalation has nothing
+# to SIGKILL. This is the shape that produced the operator's 2026-07-14
+# terminal:
+#
+#   WARN: previous runtime still running after 15.00s (SIGTERM ignored...);
+#         proceeding to start anyway.
+#   FAIL: duplicate session 'tui-neurovista' — agent already running.
+#   Agent 'neurovista' restarted        <-- IT WAS NOT
+#
+# The gate PREDICTED the collision, proceeded into it, and the restart then
+# reported success over an agent that was left DOWN. These cases used to
+# assert exactly that behaviour ("returns True", "starts anyway"); they now
+# assert its opposite. A stop that could not stop the thing must not report
+# success and must not start a replacement that is guaranteed to collide.
+
+
 def _build_unkillable_setup(
     tmp_path: Path, registry: Registry, caplog: Any
 ) -> _StaggeredRuntime:
     """Arrange helper: previous runtime whose ``is_running`` stays True
-    forever; caplog routed to the stop module so WARN records are
-    captured for the warning-content assertion.
+    forever and which cannot name a pid to kill; caplog routed to the
+    escalation module so its WARN records are captured.
     """
     import logging as _logging
 
     spec = _write_spec(tmp_path)
     registry.add("alpha", str(spec), "cld-alpha")
-    caplog.set_level(_logging.WARNING, logger="scitex_agent_container._lifecycle._stop")
+    caplog.set_level(
+        _logging.WARNING,
+        logger="scitex_agent_container._lifecycle._stop_escalate",
+    )
     return _StaggeredRuntime(stages=[True])
 
 
@@ -1711,39 +1731,52 @@ def _restart_alpha_with_short_wait(
     )
 
 
-def test_agent_restart_returns_true_when_previous_runtime_will_not_exit(
+def test_agent_restart_raises_when_previous_runtime_will_not_exit(
     tmp_path: Path, registry: Registry, caplog: Any
 ) -> None:
     # Arrange
+    from scitex_agent_container._lifecycle._stop_escalate import StopEscalationError
+
     runtime = _build_unkillable_setup(tmp_path, registry, caplog)
     # Act
-    ok = _restart_alpha_with_short_wait(runtime, registry)
-    # Assert
-    assert ok is True
+    call = lambda: _restart_alpha_with_short_wait(runtime, registry)  # noqa: E731
+    # Assert — it used to return True here, and the CLI printed "restarted".
+    with pytest.raises(StopEscalationError):
+        call()
 
 
-def test_agent_restart_starts_new_runtime_when_previous_runtime_will_not_exit(
+def test_agent_restart_does_not_start_when_previous_runtime_will_not_exit(
     tmp_path: Path, registry: Registry, caplog: Any
 ) -> None:
     # Arrange
+    from scitex_agent_container._lifecycle._stop_escalate import StopEscalationError
+
     runtime = _build_unkillable_setup(tmp_path, registry, caplog)
     # Act
-    _restart_alpha_with_short_wait(runtime, registry)
-    # Assert
-    assert len(runtime.start_calls) == 1
+    try:
+        _restart_alpha_with_short_wait(runtime, registry)
+    except StopEscalationError:
+        pass
+    # Assert — starting here is what caused the duplicate-session collision.
+    assert len(runtime.start_calls) == 0
 
 
 def test_agent_restart_warns_about_still_running_previous_runtime(
     tmp_path: Path, registry: Registry, caplog: Any
 ) -> None:
     # Arrange
+    from scitex_agent_container._lifecycle._stop_escalate import StopEscalationError
+
     runtime = _build_unkillable_setup(tmp_path, registry, caplog)
     # Act
-    _restart_alpha_with_short_wait(runtime, registry)
+    try:
+        _restart_alpha_with_short_wait(runtime, registry)
+    except StopEscalationError:
+        pass
     messages = " ".join(rec.getMessage() for rec in caplog.records)
-    # Assert — a WARN log mentions the race so a future "telegrammer
-    # dropped after restart" recurrence is self-diagnosing from stdout.log.
-    assert "still running" in messages or "SIGTERM" in messages
+    # Assert — a WARN log still names the SIGTERM-deaf runtime, so a
+    # recurrence stays self-diagnosing from stdout.log.
+    assert "SIGTERM" in messages
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two bugs from one family: **sac telling the operator something it had not verified.** Both were reported with excellent evidence by scitex-writer on card `sac-restart-prints-success-after-start-failed-20260714`. That family cost the fleet a multi-day outage this week, so both are fixed at the point where the truth is *measurable*, not where it is *narratable*.

---

## Bug 1 — `stop` predicted the collision it was about to cause, then caused it

The operator's actual terminal:

```
WARN: previous runtime still running after 15.00s (SIGTERM ignored...); proceeding to start anyway.
FAIL: duplicate session 'tui-neurovista' — agent already running.
Agent 'neurovista' restarted        <-- IT WAS NOT
```

Read those three lines in order. The stop leg **predicted** the collision, shrugged, walked into it; the collision happened exactly as predicted; and the restart reported success over an agent left **DOWN**. The operator then went hunting a credential store that was perfectly healthy, because he was still talking to the OLD process on its OLD token.

Mechanically: `_wait_for_previous_runtime_to_exit` returned `False` on timeout and its only caller — `agent_restart` — **discarded the return value**. A verdict nobody reads is not a verdict. (PR #642 made the *start* leg pass `force=True`; that does not fix a *stop* leg that gives up, and it did not.)

### The choice: escalate **and** fail loud — both, in that order

The task offered escalation *or* fail-loud. Both are required, because they fail differently:

* **Escalate first.** A restart's contract is to REPLACE the process, and the standard forced-stop contract everywhere else in the industry is SIGTERM → grace → SIGKILL (systemd `TimeoutStopSec`, `docker stop`, kubelet). sac already had the SIGTERM and the 15 s grace; **only the escalation step was missing.** Refusing to escalate would mean sac cannot restart an agent whose claude TUI is wedged mid-render and no longer reaping signals — precisely the population that most needs a restart.
* **Then fail loud.** Escalation *alone* would be a longer path to the same lie, because SIGKILL can fail: a runtime that cannot name a local pid (docker / SSHRemote → `agent_pid() → None`), an `EPERM`, or a process wedged in uninterruptible `D`-state I/O where SIGKILL cannot land until the syscall returns. When we cannot **confirm** the agent is down, we raise `StopEscalationError` — `agent_start` is never reached, and no success line is printed over a survivor.

### Killing the right thing

The escalation targets **`RuntimeBase.agent_pid`** — for a TUI agent the tmux **PANE pid** (the pane's `bash -c` `exec`s apptainer, and `exec` keeps the pid, so the pane pid *is* the long-lived `apptainer exec … claude` process). **Not the launcher**, which returns within seconds: SIGKILLing it would look right in the log and do nothing — and, pids being reused, could kill an unrelated process. `agent_pid` is contractually the same signal the runtime's own `is_running` keys on, so "what we killed" and "what is still running" cannot drift apart.

Safety guards: never signal `pid <= 0` (`os.kill(0, SIGKILL)` signals sac's **entire process group**; `-1` signals every process the user owns) and never our own pid.

### What it says now vs. before

| | before | now |
|---|---|---|
| survivor is killable | `WARN … proceeding to start anyway` → collision → **"Agent 'x' restarted"** | `WARN … escalating to SIGKILL on pid N (the runtime's long-lived process)` → really dead → really restarted |
| survivor is unkillable | **"Agent 'x' restarted"** (a lie) | `restart of 'x' ABORTED: the previous runtime is STILL RUNNING after SIGTERM (15.0s grace) and SIGKILL (pid N, 5.0s settle) — its own is_running() still reports True.`<br>`NOT starting a replacement: the start leg would collide with the survivor … 'x' is still UP as the OLD process on its OLD credentials — it was NOT restarted.`<br>+ a remedy that **works** (`ps -o …stat… -p N` to spot a `D`-state wedge; `tmux kill-session -t tui-x`; `sac agents start x -y --fresh`) — deliberately **not** `sac agents restart`, the command that just failed. |

The CLI already refuses to print green on a `False`/raise, so this surfaces as a red error and exit 1.

---

## Bug 2 — the listen error asserted a cause nobody measured

```
cannot reach listen at 'http://127.0.0.1:7878' (timed out) — the host listen broker is
unreachable; it may be flapping. Restart it on the host with `sac listen restart`.
```

Every clause after the parenthesis was invented, and the diagnosis was **wrong**. The reporter measured:

```
GET  /health             (unauthenticated) -> HTTP 401 in 0.18s, twice
GET  /agents             (with bearer)     -> no response in 10s
POST /agents/<n>/restart (with bearer)     -> no response in 25s
```

The daemon was **UP**, answering in under a fifth of a second. Not "unreachable", and not one shred of evidence for "flapping" — a word that asserts a crash loop, which nobody had looked at.

**The split is real, not an accident of routing:** `BearerAuthMiddleware.PUBLIC_PATHS` exempts `/v1/health`, and both that route and the middleware's own 401 are `async` — served on the event loop. Every *authenticated* route dispatches through the shared worker pool. A pool exhausted by stacked-up work wedges the authed routes while the public path stays fast. (The exhaustion itself — abandoned heartbeat ticks stacking zombie threads — is fixed in #647. This PR is about not *lying* when it happens again for some other reason.)

Both `_restart_client` and `_spawn_client` now **probe the cheap unauthenticated path before concluding**, and the evidence picks the message.

### What it says now vs. before

| measured | before | now |
|---|---|---|
| daemon answers `/v1/health`, authed route hangs | "the host listen broker is **unreachable**; it **may be flapping**" | `MEASURED (not guessed): an unauthenticated GET …/v1/health answered HTTP 401 in 0.18s — so the listen daemon is UP and serving. The daemon is NOT down and this is NOT a 'broker unreachable' failure: it is the AUTHENTICATED route that did not answer.` + why the two differ + `sac listen restart` clears the wedged pool (and: upgrade the host if it predates #647). |
| nothing answers at all | same text (indistinguishable) | `cannot reach listen … MEASURED (not guessed): an unauthenticated GET …/v1/health also got no HTTP response (connection refused) — nothing is serving HTTP at this URL, so the daemon is DOWN or the URL/port is wrong.` (remedy unchanged) |

**The word "flapping" now appears nowhere in this path** — nothing here can observe a crash loop, so nothing may assert one. Contract: *any* HTTP response (200/401/403/404) proves the daemon is serving; only the **absence** of an HTTP exchange is evidence of "unreachable".

The `44_agent-to-agent-recovery` skill taught agents the wrong inference ("a transport timeout ⇒ the broker is down") — that is the doc the reporting agent was following, so it is corrected here too.

---

## Tests — real seams, no mocks

* The SIGTERM-deaf agent is a **REAL OS child process** that **really** installs `signal.SIG_IGN` for SIGTERM (announcing readiness on stdout so the test cannot race the handler). The escalation sends a **real** SIGKILL through the **real** `os.kill`, and the test asserts on the **real** child's exit status (`-signal.SIGKILL`). The entire question is whether sac kills the right process *for real* — a fake could not answer it.
* `_PidlessRuntime` subclasses the production `RuntimeBase` so its `agent_pid` **is** the real default (`None`), not a test re-implementation.
* The listen probe is driven through the **real** `request_restart` / `request_spawn` via their existing injectable `opener` seam, with an opener that reproduces the production split (POST hangs, `GET /v1/health` answers).
* Three tests in `test_lifecycle.py` **asserted the old bug** (`returns True`, `starts anyway`). They now assert its opposite.
* HOME is redirected to `tmp_path` in the new suite — nothing reads the live fleet registry (which would pass locally and fail in CI).

Local: **93 passed** (`test__stop_escalate`, `test__listen_probe`, `test__restart_client`, `test__spawn_client`) and **83 passed** (`test_lifecycle`), both verified importing from the worktree, not the installed package.
