### PR TITLE
fix(send): broker the in-container peer lookup to the host — agent_send declared every live peer "stopped"

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_send.py
+++ b/src/scitex_agent_container/cli_pkg/_send.py
@@ -150,20 +150,71 @@ def send_to_agent(
 
     from .._network.peer import PeerError
     from .._state.state_db import _resolve_host
+    from ._send_broker import (
+        PeerLookupUnavailable,
+        resolve_send_endpoint_via_host,
+        should_broker_peer_lookup,
+    )
     from ._send_resolve import resolve_send_endpoint
 
     current_host = _resolve_host(None)
-    # Resolve the LIVE endpoint the same way ``a2a_send`` / the listen
-    # forwarder do: active ``instances`` row port first, then the durable
-    # ``port_allocator`` claim that survives a health-monitor restart.
-    # Gating ONLY on the instances row (the old behaviour) caused the
-    # "registry split-brain": a locally-running agent whose row went stale
-    # (supervisor restart via ``runtime.start``, stale-lease clear) showed
-    # ``a2a_port=null`` here even while ``a2a_send`` reached it on the bus.
-    # See :mod:`._send_resolve` for the full root-cause writeup.
-    endpoint = resolve_send_endpoint(name, current_host=current_host)
+
+    # --- Resolve WHERE the peer is ----------------------------------------
+    # IN A CONTAINER the local state.db is a private, effectively empty
+    # per-agent bridge DB that holds no row for ANY other agent, so the local
+    # resolver below reports every peer as "not running" — measured
+    # 2026-07-14: ``scitex-scholar`` came back ``stopped / pid=null /
+    # a2a_port=null`` while the host's registry held ``pid=1777985
+    # a2a_port=19037 ended_at=NULL`` for it and the agent had messaged us 90
+    # seconds earlier. Broker the lookup to the host's ``sac listen`` — the
+    # SAME door ``agent_status`` already goes through — so we read the real
+    # fleet registry. See :mod:`._send_broker`.
+    #
+    # On a BARE HOST this is inert: ``should_broker_peer_lookup()`` is False
+    # and the local resolver runs exactly as before.
+    brokered = None
+    if should_broker_peer_lookup():
+        try:
+            endpoint, brokered = resolve_send_endpoint_via_host(
+                name, current_host=current_host
+            )
+        except PeerLookupUnavailable as exc:
+            # We could not ASK the host. That is UNKNOWN — not dead. We refuse
+            # to fall back to the blind local read, because its empty result
+            # would masquerade as death, which is the bug we are fixing.
+            return _unknown_lookup_payload(name, exc, current_host=current_host)
+    else:
+        # Resolve the LIVE endpoint the same way ``a2a_send`` / the listen
+        # forwarder do: active ``instances`` row port first, then the durable
+        # ``port_allocator`` claim that survives a health-monitor restart.
+        # Gating ONLY on the instances row (the old behaviour) caused the
+        # "registry split-brain": a locally-running agent whose row went stale
+        # (supervisor restart via ``runtime.start``, stale-lease clear) showed
+        # ``a2a_port=null`` here even while ``a2a_send`` reached it on the bus.
+        # See :mod:`._send_resolve` for the full root-cause writeup.
+        endpoint = resolve_send_endpoint(name, current_host=current_host)
+
     a2a_port = endpoint.a2a_port
     peer_host = endpoint.host if endpoint.host != current_host else ""
+
+    if endpoint.source == "host_broker_unknown_agent":
+        # The HOST — which can see the whole fleet — has no agent by this
+        # name. This is the one definitive negative in the brokered path.
+        return {
+            "status": "error",
+            "error": (
+                f"agent {name!r} is not in the host fleet registry "
+                f"(the host's `sac listen` returned 404 for it) — check the "
+                f"name, or the agent was never registered on this host"
+            ),
+            "diagnosis": diagnose_send_failure(
+                name,
+                a2a_port=None,
+                peer_host=current_host,
+                current_host=current_host,
+                brokered=brokered,
+            ),
+        }
     if endpoint.row is None and endpoint.source == "none":
         # No active instances row AND no durable allocator claim → the
         # agent is genuinely not running anywhere this host can see.
@@ -175,24 +226,38 @@ def send_to_agent(
                 a2a_port=None,
                 peer_host=current_host,
                 current_host=current_host,
+                brokered=brokered,
             ),
         }
     if a2a_port is None:
-        # A row exists but neither it nor the allocator carries a usable
-        # port (sidecar-disabled spec, or a row written before the port
-        # was resolved). Loud — there is no /v1/turn to reach.
-        return {
-            "status": "error",
-            "error": (
+        # No usable port. Loud — there is no /v1/turn to reach. The message
+        # names the SOURCE of the verdict, so a reader never has to guess
+        # whether it came from the real fleet registry or a blind local read.
+        if endpoint.source == "host_broker_no_port":
+            error = (
+                f"agent {name!r} is registered on the host, but the host fleet "
+                f"registry holds no a2a port claim for it (a claim is released "
+                f"only at `sac agents stop` / --force); there is no /v1/turn "
+                f"to reach"
+            )
+        else:
+            # A row exists but neither it nor the allocator carries a usable
+            # port (sidecar-disabled spec, or a row written before the port
+            # was resolved).
+            error = (
                 f"agent {name!r} has no a2a_port recorded "
                 f"(no active instances-row port and no port_allocator "
                 f"claim); cannot reach /v1/turn"
-            ),
+            )
+        return {
+            "status": "error",
+            "error": error,
             "diagnosis": diagnose_send_failure(
                 name,
                 a2a_port=None,
                 peer_host=peer_host or current_host,
                 current_host=current_host,
+                brokered=brokered,
             ),
         }
     if peer_host and peer_host != current_host:
@@ -246,6 +311,7 @@ def send_to_agent(
             current_host=current_host,
             url=url,
             metadata_extras=metadata_extras,
+            brokered=brokered,
         )
 
     try:
@@ -266,6 +332,7 @@ def send_to_agent(
             a2a_port=a2a_port,
             peer_host=peer_host,
             current_host=current_host,
+            brokered=brokered,
         )
         if "timeout" in msg.lower():
             return {
@@ -293,6 +360,30 @@ def send_to_agent(
     }
 
 
+def _unknown_lookup_payload(
+    name: str,
+    exc: Exception,
+    *,
+    current_host: str,
+) -> dict[str, Any]:
+    """Payload for "the host broker could not be asked" — UNKNOWN, not dead.
+
+    The one thing this must never do is render an unperformed lookup as a
+    stopped agent. ``registry_status`` comes back ``"unknown: …"``,
+    ``pid_alive`` and ``boot_complete`` stay ``None``, and the message names
+    the broker as the thing that failed — not the agent.
+    """
+    from ._send_diagnosis_brokered import unknown_lookup_diagnosis
+
+    return {
+        "status": "error",
+        "error": str(exc),
+        "diagnosis": unknown_lookup_diagnosis(
+            name, current_host=current_host, reason=str(exc)
+        ),
+    }
+
+
 def _dispatch_nonblocking(
     name: str,
     prompt: str,
@@ -302,6 +393,7 @@ def _dispatch_nonblocking(
     current_host: str,
     url: str,
     metadata_extras: dict[str, Any],
+    brokered: Any = None,
 ) -> dict[str, Any]:
     """Validate reachability, then return a non-blocking dispatch payload.
 
@@ -331,11 +423,20 @@ def _dispatch_nonblocking(
         a2a_port=a2a_port,
         peer_host=peer_host,
         current_host=current_host,
+        brokered=brokered,
     )
 
     # Fail loud on demonstrable unreachability (local probes only — a
     # cross-host port we cannot probe stays None and is NOT treated as
     # unreachable, which would be a false-positive failure).
+    #
+    # Both gates fire ONLY on an explicit ``False`` — never on ``None``.
+    # That is the whole discipline: a probe we could not run leaves ``None``
+    # and must not be read as a failed probe. On the brokered (in-container)
+    # path ``pid_alive`` is deliberately always ``None`` — the host status
+    # route exposes no pid, and importing a STALE one would make
+    # ``os.kill(pid, 0)`` report a healthy, restarted agent as dead. See
+    # :mod:`._send_diagnosis_brokered`.
     if diagnosis.get("pid_alive") is False:
         return {
             "status": "error",
@@ -346,11 +447,24 @@ def _dispatch_nonblocking(
             "diagnosis": diagnosis,
         }
     if diagnosis.get("port_reachable") is False:
+        # An unbound /v1/turn port means THIS TRANSPORT cannot carry the turn.
+        # It does NOT mean the agent is dead, and the old wording here ("it is
+        # not booted or the sidecar crashed") asserted exactly that. Measured
+        # on the live fleet 2026-07-14: only 5 of 47 registered agents had
+        # /v1/turn bound at all — the other 41 held a port claim with nothing
+        # listening, and several of them answered a2a messages that same
+        # minute. Saying "crashed" here would hand the caller a death verdict
+        # whose remedy (`--force --fresh`) destroys a healthy, working agent.
         return {
             "status": "error",
             "error": (
-                f"agent {name!r} sidecar is not listening on port {a2a_port}; "
-                "it is not booted or the sidecar crashed — cannot dispatch"
+                f"agent {name!r}: nothing is listening on a2a port {a2a_port}, "
+                f"so the /v1/turn transport cannot deliver this turn. This is "
+                f"NOT a death verdict — most agents in this fleet never bind "
+                f"/v1/turn and are reached over the a2a subscriber channel "
+                f"instead. Deliver with `sac a2a send {name} ...` (or the "
+                f"a2a_send tool), which does not require this port. Do NOT "
+                f"force-restart the agent on this signal"
             ),
             "diagnosis": diagnosis,
         }

--- a/src/scitex_agent_container/cli_pkg/_send_broker.py
+++ b/src/scitex_agent_container/cli_pkg/_send_broker.py
@@ -1,0 +1,339 @@
+"""Host-brokered peer lookup for the send read path (in-container blindness fix).
+
+The bug
+-------
+Inside an apptainer SIF, ``$HOME`` is ``/home/agent`` (not the operator's
+home) and ``SCITEX_AGENT_CONTAINER_STATE_DB`` points at a PER-AGENT bridge
+DB (e.g. ``/state/<name>/state.db``). So ``open_db(None)`` resolves to a
+private, effectively empty store that holds NO rows for any other agent.
+
+Every local-DB read in the send path therefore comes back empty, and the
+caller renders that emptiness as *death*. Measured 2026-07-14 from inside
+the ``scitex-agent-container`` SIF::
+
+    resolve_send_endpoint("scitex-scholar")
+        -> a2a_port=None, source="none", row=None
+    send_to_agent("scitex-scholar")
+        -> {"status": "error", "error": "agent 'scitex-scholar' not running",
+            "diagnosis": {"registry_status": "stopped", "pid": null,
+                          "a2a_port": null, "boot_complete": false}}
+
+…while the HOST's shared registry, at the same moment, held a live row for
+that agent (``pid=1777985  a2a_port=19037  ended_at=NULL``) and the agent
+had messaged the caller 90 seconds earlier. The lookup was never performed
+against the real fleet registry — and "I could not check" was rendered as
+"the agent is stopped".
+
+The fix
+-------
+Reuse the EXISTING in-SIF broker seam. :func:`agent_status` already solves
+this correctly: when it detects a SIF it proxies ``GET /agents/<name>/status``
+to the host's ``sac listen`` via
+:func:`_lifecycle._in_sif_http_client.host_listen_call` (see
+``cli_pkg/status_cmds.py::_status_via_host_listen``), which reads the real
+fleet registry on the bare host. This module routes the SEND path's peer
+lookup through that same door — same client, same URL, same bearer, same
+server-side auth gate. No second mechanism, no reimplemented client.
+
+Fail-loud / never-fabricate-death invariants
+--------------------------------------------
+These are the whole point of the module; they are not decoration.
+
+* **Broker unreachable → UNKNOWN, never DEAD.** A transport failure raises
+  :class:`PeerLookupUnavailable`. We do NOT fall back to the blind local
+  read, because that read is precisely what reports a live agent as
+  "stopped". Reporting a live agent dead because we could not ask IS the
+  bug.
+* **A refusal is not a death certificate.** A 403 (ACL) / 5xx / unparseable
+  body means we were prevented from learning the answer — also
+  :class:`PeerLookupUnavailable` (UNKNOWN).
+* **Only the HOST may pronounce an agent absent.** A 404 from the host is
+  the one definitive negative: the fleet registry has no such agent.
+* **Hints are not verdicts.** The host's ``status`` field (e.g.
+  ``"startup_failed"``) is carried through as a HINT ONLY. Those markers go
+  stale and are never reconciled — measured 2026-07-14, ``scitex-writer``
+  reported ``startup_failed`` from a marker ~2 days old while its host row
+  held ``pid=1772715 / ended_at=NULL`` and it answered an a2a message that
+  same turn. A stale marker MUST NOT render a live agent unreachable.
+
+Why the caution is asymmetric: the remedy for a "dead" verdict is
+DESTRUCTIVE (``--force --fresh``). A false red kills a healthy, working
+agent; a false green merely wastes a round-trip. When the evidence does not
+support a conclusion, refuse to conclude.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, NamedTuple
+
+from ._send_resolve import ResolvedEndpoint
+
+__all__ = [
+    "BrokeredPeer",
+    "PeerLookupUnavailable",
+    "lookup_peer_via_host",
+    "resolve_send_endpoint_via_host",
+    "should_broker_peer_lookup",
+]
+
+# The peer lookup is a single small GET against a loopback server; it must
+# never be the thing that makes a send feel slow. Deliberately far below the
+# 30s default of the shared client.
+_DEFAULT_TIMEOUT_S = 10.0
+
+
+class PeerLookupUnavailable(RuntimeError):
+    """The peer's state could NOT BE READ — the verdict is UNKNOWN, not DEAD.
+
+    Raised when the host broker could not be asked, or answered in a way that
+    withholds the fact we needed (transport failure, ACL refusal, 5xx,
+    unparseable body).
+
+    This is emphatically **not** "the agent is stopped". The caller MUST
+    surface it as unknown-state and MUST NOT fall back to the blind local
+    read, whose empty result would masquerade as death.
+
+    Attributes:
+        url: The URL that was attempted (``None`` when the failure happened
+            before a URL could be built).
+        http_status: The host's HTTP status, when one was received.
+        kind: The host's structured failure tag (e.g. ``"acl_deny"``), when
+            the body carried one.
+        body: The parsed response body, verbatim, when one was received.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        url: str | None = None,
+        http_status: int | None = None,
+        kind: str | None = None,
+        body: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.url = url
+        self.http_status = http_status
+        self.kind = kind
+        self.body = body
+
+
+class BrokeredPeer(NamedTuple):
+    """What the HOST fleet registry knows about a peer.
+
+    ``known`` is ``False`` only for the host's definitive 404 — the fleet
+    registry has no agent by that name. Every other "we don't know" case
+    raises :class:`PeerLookupUnavailable` instead of landing here, so a
+    ``BrokeredPeer`` always represents an ANSWER, never a shrug.
+
+    ``a2a_port`` is the durable port claim the host holds for the agent
+    (released only at ``agent_stop`` / ``--force``), so a non-``None`` value
+    is real evidence the agent is up.
+
+    ``host_status`` is the host's ``status`` field (e.g. ``"startup_failed"``)
+    — a HINT for the operator, NEVER a liveness verdict. See the module
+    docstring: these markers go stale and nothing reconciles them.
+    """
+
+    known: bool
+    a2a_port: int | None
+    host: str | None
+    host_status: str | None
+    body: dict
+
+
+def should_broker_peer_lookup() -> bool:
+    """True iff the peer lookup must be brokered to the host ``sac listen``.
+
+    Mirrors the decision ``agent_spawn`` and ``agent_status`` already make:
+    in a SIF *and* the apptainer runtime injected a listen URL to broker to.
+
+    The ``SAC_LISTEN_BASE_URL`` half of the predicate is not belt-and-braces
+    — it is load-bearing. ``sac-from-sac`` / bare-host shells can carry a
+    stale ``SINGULARITY_CONTAINER`` with no host listen to talk to, and
+    brokering there would turn a working local read into a stillborn one.
+    ``status_cmds.py`` learned this the hard way (PR#316); we reuse the same
+    guard rather than re-discover it.
+
+    Resolved through :func:`_env.getenv` — the SAME resolver
+    :func:`_in_sif_http_client.host_listen_call` uses — so the guard and the
+    client can never disagree about whether a base URL exists.
+    """
+    from .._env import getenv
+    from .._lifecycle._in_sif_broker import is_in_sif
+
+    if not is_in_sif():
+        return False
+    return bool((getenv("LISTEN_BASE_URL", "") or "").strip())
+
+
+def _host_from_turn_url(turn_url: Any) -> str | None:
+    """Extract the hostname from the host's ``turn_url``, else ``None``.
+
+    ``GET /agents/<name>/status`` carries the agent's endpoint as a derived
+    ``turn_url`` (``http://<host>:<port>/v1/turn``) rather than a bare host
+    field, so that is where the peer's host comes from.
+    """
+    if not isinstance(turn_url, str) or not turn_url:
+        return None
+    from urllib.parse import urlsplit
+
+    try:
+        return urlsplit(turn_url).hostname or None
+    except ValueError:
+        # stx-allow: fallback (reason: a malformed turn_url costs us only the
+        # host field — the caller falls back to the local canonical host. It
+        # must never escalate into a fabricated "agent is dead".)
+        return None
+
+
+def _coerce_port(value: Any) -> int | None:
+    """Return a positive int port, else ``None`` (``bool`` rejected explicitly)."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
+
+
+def lookup_peer_via_host(
+    name: str,
+    *,
+    base_url: str | None = None,
+    bearer: str | None = None,
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    opener: Callable | None = None,
+) -> BrokeredPeer:
+    """Ask the host ``sac listen`` what it knows about ``name``.
+
+    Routes ``GET /agents/<name>/status`` through
+    :func:`_lifecycle._in_sif_http_client.host_listen_call` — the same client,
+    URL and bearer ``agent_status`` uses. The host's ``BearerAuthMiddleware``
+    and lineage ACL remain the authority; nothing here weakens or bypasses
+    them, and a refusal is surfaced (as UNKNOWN), never worked around.
+
+    Returns:
+        :class:`BrokeredPeer` — an ANSWER from the host. ``known=False`` only
+        for the host's definitive 404.
+
+    Raises:
+        PeerLookupUnavailable: When the answer could not be obtained
+            (transport failure, ACL refusal, 5xx, non-dict body). The verdict
+            is UNKNOWN — the caller must not render it as "stopped".
+    """
+    from .._lifecycle._in_sif_http_client import (
+        HostListenTransportError,
+        host_listen_call,
+    )
+
+    try:
+        http_status, body = host_listen_call(
+            "GET",
+            f"/agents/{name}/status",
+            base_url=base_url,
+            bearer=bearer,
+            timeout_s=timeout_s,
+            opener=opener,
+        )
+    except HostListenTransportError as exc:
+        raise PeerLookupUnavailable(
+            f"cannot determine whether agent {name!r} is running: the host "
+            f"listen broker is unreachable ({exc}). Verdict: UNKNOWN — this "
+            f"is NOT evidence the agent is stopped, and it must not be acted "
+            f"on as though it were. Refusing to fall back to the "
+            f"container-local registry, which cannot see any peer and would "
+            f"report every one of them dead.",
+            url=exc.url,
+        ) from exc
+
+    if http_status == 404:
+        # The one definitive negative: the HOST — which can see the whole
+        # fleet — has no agent by this name.
+        return BrokeredPeer(
+            known=False,
+            a2a_port=None,
+            host=None,
+            host_status=None,
+            body=body if isinstance(body, dict) else {},
+        )
+
+    if not (200 <= http_status < 300) or not isinstance(body, dict):
+        kind = body.get("kind") if isinstance(body, dict) else None
+        raise PeerLookupUnavailable(
+            f"cannot determine whether agent {name!r} is running: the host "
+            f"listen answered GET /agents/{name}/status with HTTP "
+            f"{http_status} (kind={kind!r}). Verdict: UNKNOWN — we were "
+            f"prevented from learning the agent's state, which is NOT the "
+            f"same as learning that it is stopped.",
+            http_status=http_status,
+            kind=kind if isinstance(kind, str) else None,
+            body=body,
+        )
+
+    raw_status = body.get("status")
+    return BrokeredPeer(
+        known=True,
+        a2a_port=_coerce_port(body.get("a2a_port")),
+        host=_host_from_turn_url(body.get("turn_url")),
+        host_status=raw_status if isinstance(raw_status, str) else None,
+        body=body,
+    )
+
+
+def resolve_send_endpoint_via_host(
+    name: str,
+    *,
+    current_host: str,
+    base_url: str | None = None,
+    bearer: str | None = None,
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    opener: Callable | None = None,
+) -> tuple[ResolvedEndpoint, BrokeredPeer]:
+    """Brokered twin of :func:`_send_resolve.resolve_send_endpoint`.
+
+    Returns the SAME :class:`ResolvedEndpoint` shape the local resolver
+    returns, so the caller's downstream logic is identical on both paths;
+    only ``source`` differs, which is deliberate — provenance must be visible
+    in the payload, so nobody has to guess whether a verdict came from the
+    blind container DB or the real fleet registry.
+
+    ``source`` values:
+      * ``"host_broker"`` — the host holds a live port claim for the agent.
+      * ``"host_broker_no_port"`` — the host knows the agent but holds no
+        port claim for it.
+      * ``"host_broker_unknown_agent"`` — the host's 404: no such agent.
+
+    The :class:`BrokeredPeer` is returned alongside so the caller can thread
+    the host's facts into the diagnosis WITHOUT a second HTTP round-trip.
+
+    Raises:
+        PeerLookupUnavailable: propagated from :func:`lookup_peer_via_host`.
+            The caller must render this as UNKNOWN, never as "not running".
+    """
+    peer = lookup_peer_via_host(
+        name,
+        base_url=base_url,
+        bearer=bearer,
+        timeout_s=timeout_s,
+        opener=opener,
+    )
+    if not peer.known:
+        return (
+            ResolvedEndpoint(
+                a2a_port=None,
+                host=current_host,
+                source="host_broker_unknown_agent",
+                row=None,
+            ),
+            peer,
+        )
+    source = "host_broker" if peer.a2a_port is not None else "host_broker_no_port"
+    return (
+        ResolvedEndpoint(
+            a2a_port=peer.a2a_port,
+            host=peer.host or current_host,
+            source=source,
+            row=None,
+        ),
+        peer,
+    )

--- a/src/scitex_agent_container/cli_pkg/_send_diagnosis.py
+++ b/src/scitex_agent_container/cli_pkg/_send_diagnosis.py
@@ -118,6 +118,7 @@ def diagnose_send_failure(
     peer_host: str,
     current_host: str,
     now: float | None = None,
+    brokered: Any = None,
 ) -> dict[str, Any]:
     """Gather state-of-the-agent at the moment a send failed.
 
@@ -125,6 +126,17 @@ def diagnose_send_failure(
     ``error`` payload. Every field is explicit — an un-gatherable value
     becomes ``"unreadable: <reason>"`` / ``"unknown"`` / ``None``, never
     a silent healthy-looking default.
+
+    Inside a container the local ``state.db`` is a private, effectively
+    empty per-agent bridge DB, so EVERY field gathered below would be a
+    fabrication about a peer ("stopped", ``pid: null``, ``boot_complete:
+    false``). On that path the facts are sourced from the HOST fleet
+    registry instead, via the same broker door ``agent_status`` uses — see
+    :mod:`._send_broker` / :mod:`._send_diagnosis_brokered`. ``brokered``
+    lets the caller pass an already-fetched
+    :class:`._send_broker.BrokeredPeer` so one send costs one lookup, not
+    two. On a bare host none of this engages and the local gathering below
+    runs exactly as it always has.
 
     Fields
     ------
@@ -154,7 +166,42 @@ def diagnose_send_failure(
     peer_host: ``row["host"]`` — the host the turn was POSTed to.
     current_host: lead-side resolved host.
     now: wall-clock override for deterministic tests.
+    brokered: a pre-fetched :class:`._send_broker.BrokeredPeer`. When
+        ``None`` and we are in a container, the host is asked here.
     """
+    # --- in-container: source the facts from the HOST fleet registry -------
+    # The local reads below cannot see a single peer from inside a SIF, and
+    # their emptiness renders as death. Ask the host instead.
+    from ._send_broker import PeerLookupUnavailable, should_broker_peer_lookup
+
+    if brokered is None and should_broker_peer_lookup():
+        from ._send_broker import lookup_peer_via_host
+
+        try:
+            brokered = lookup_peer_via_host(name)
+        except PeerLookupUnavailable as exc:
+            # Could not ask → UNKNOWN. Explicitly NOT "stopped": falling back
+            # to the blind local read here would recreate the exact bug.
+            from ._send_diagnosis_brokered import unknown_lookup_diagnosis
+
+            return unknown_lookup_diagnosis(
+                name,
+                current_host=current_host,
+                reason=str(exc),
+                a2a_port=a2a_port,
+            )
+    if brokered is not None:
+        from ._send_diagnosis_brokered import brokered_diagnosis
+
+        return brokered_diagnosis(
+            name,
+            a2a_port=a2a_port,
+            peer_host=peer_host,
+            current_host=current_host,
+            peer=brokered,
+        )
+
+    # --- bare host: unchanged local gathering ------------------------------
     now = time.time() if now is None else now
     is_local = (not peer_host) or peer_host == current_host
 

--- a/src/scitex_agent_container/cli_pkg/_send_diagnosis_brokered.py
+++ b/src/scitex_agent_container/cli_pkg/_send_diagnosis_brokered.py
@@ -1,0 +1,219 @@
+"""Diagnosis built from the HOST fleet registry, for the in-container send path.
+
+Companion to :mod:`._send_diagnosis`. That module gathers its facts from the
+LOCAL ``state.db``; inside an apptainer SIF that database is a private,
+effectively empty per-agent bridge DB, so every field it produces about a
+PEER is a fabrication:
+
+    registry_status: "stopped"   <- no row (because we cannot see any row)
+    pid:             null
+    boot_complete:   false       <- no heartbeat (because we cannot see one)
+
+This module produces the same ``diagnosis`` dict from the answer the HOST's
+``sac listen`` gave us (:mod:`._send_broker`), and — where the host does not
+expose a fact — says ``unknown`` instead of inventing a healthy-looking or
+dead-looking default.
+
+The one rule that governs every choice here
+-------------------------------------------
+**Absence of evidence is not death.** A field we could not measure is
+``None`` / ``"unknown: …"``, never ``False`` and never ``"stopped"``. The
+remedy an operator (or an agent) reaches for on a "dead" verdict is
+DESTRUCTIVE — ``--force --fresh`` — so a false red kills a healthy, working
+agent while a false green merely costs a round-trip. The asymmetry is
+deliberate.
+
+Two facts, both measured on the live fleet 2026-07-14, are why this module
+refuses to promote hints into verdicts:
+
+* **The pid is deliberately NOT fetched.** ``GET /agents/<name>/status`` does
+  not carry one, and sourcing it from the registry list would import a
+  *stale* pid: a health-monitor restart gives the agent a new pid without
+  refreshing the recorded row, so ``os.kill(stale_pid, 0)`` returns False for
+  an agent that is running perfectly. That would trip the caller's
+  ``pid_alive is False`` gate and declare a live agent dead. ``pid_alive``
+  therefore stays ``None`` (UNKNOWN) on this path — a refusal, not an
+  oversight.
+
+* **An unbound /v1/turn port is NOT death.** Of the 47 agents the host knew,
+  only 5 had their ``/v1/turn`` port bound; the other 41 — including agents
+  that answered a2a messages that same minute — held a port claim with
+  nothing listening on it. Most of this fleet is reached over the a2a
+  subscriber channel, which does not require that port. So an unreachable
+  port means "this transport cannot carry the turn", never "the agent is
+  gone".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["brokered_diagnosis", "unknown_lookup_diagnosis"]
+
+# The host status route exposes no heartbeat; be explicit about the gap
+# rather than emitting a ``None`` the caller could read as "idle".
+_NO_HEARTBEAT = "unknown: not exposed by host listen GET /agents/<name>/status"
+
+_HOST_STATUS_NOTE = (
+    "HINT ONLY — never a liveness verdict. The host's STARTUP_FAILED marker "
+    "is written once and never reconciled, so it goes stale: measured "
+    "2026-07-14, scitex-writer reported 'startup_failed' from a ~2-day-old "
+    "marker while its host row held a live pid and it answered an a2a message "
+    "that same turn. Do not conclude death from this field."
+)
+
+
+def unknown_lookup_diagnosis(
+    name: str,
+    *,
+    current_host: str,
+    reason: str,
+    a2a_port: int | None = None,
+) -> dict[str, Any]:
+    """The diagnosis for "we could not ask the host" — UNKNOWN, not dead.
+
+    Every liveness field is explicitly unknown. Note what is NOT here:
+    ``registry_status`` is *not* ``"stopped"``, ``pid_alive`` is *not*
+    ``False``, ``boot_complete`` is *not* ``False``. Rendering "I could not
+    check" as "the agent is stopped" is the precise bug this whole change
+    exists to kill; reproducing it in the failure path would be absurd.
+    """
+    return {
+        "agent": name,
+        "host": current_host,
+        "is_local": None,
+        "a2a_port": a2a_port,
+        "lookup_source": "host_broker",
+        "lookup_error": reason,
+        "registry_status": f"unknown: {reason}",
+        "pid": None,
+        "pid_alive": None,
+        "last_activity": None,
+        "heartbeat_state": None,
+        "heartbeat_age_seconds": None,
+        "boot_complete": None,
+        "port_reachable": None,
+        "likely_causes": (
+            "the host listen broker could not be asked, so this agent's state "
+            "is UNKNOWN — it may well be alive and working. Absence of "
+            "evidence is NOT death: do not stop, force-restart or reap the "
+            "agent on the strength of this result. Restore the broker on the "
+            "host (`sac listen restart`) and retry the lookup."
+        ),
+    }
+
+
+def brokered_diagnosis(
+    name: str,
+    *,
+    a2a_port: int | None,
+    peer_host: str,
+    current_host: str,
+    peer: Any,
+    port_probe: Any = None,
+) -> dict[str, Any]:
+    """Build the ``diagnosis`` dict from the HOST's answer about ``name``.
+
+    Args:
+        peer: The :class:`._send_broker.BrokeredPeer` the host returned.
+        port_probe: The TCP-reachability probe to use for the agent's
+            ``/v1/turn`` port — injected so tests drive this without opening
+            a socket. Defaults to :func:`._send_diagnosis._port_reachable`.
+            Its result is recorded as a HINT about the *transport*, and is
+            never allowed to become a verdict about the *agent*.
+    """
+    if port_probe is None:
+        from ._send_diagnosis import _port_reachable as port_probe
+
+    is_local = (not peer_host) or peer_host == current_host
+    diagnosis: dict[str, Any] = {
+        "agent": name,
+        "host": peer_host or current_host,
+        "is_local": is_local,
+        "a2a_port": a2a_port,
+        # Provenance is part of the answer: a reader must never have to guess
+        # whether a verdict came from the blind container-local DB or from the
+        # real fleet registry on the host.
+        "lookup_source": "host_broker",
+        "registry_source": "host listen GET /agents/<name>/status",
+    }
+
+    if not peer.known:
+        diagnosis["registry_status"] = "not_found"
+    elif peer.a2a_port is not None:
+        # The host holds a durable a2a-port claim. Claims are released only at
+        # ``agent stop`` / ``--force``, so this is real evidence of life.
+        diagnosis["registry_status"] = "running"
+    else:
+        diagnosis["registry_status"] = "stopped"
+
+    # pid: withheld on purpose — see the module docstring. UNKNOWN, not False.
+    diagnosis["pid"] = None
+    diagnosis["pid_alive"] = None
+    diagnosis["last_activity"] = None
+    diagnosis["heartbeat_state"] = _NO_HEARTBEAT
+    diagnosis["heartbeat_age_seconds"] = None
+    # boot_complete: the host route carries no heartbeat, so we cannot know.
+    # ``False`` here would be a lie that reads as "never booted".
+    diagnosis["boot_complete"] = None
+
+    session_id = peer.body.get("session_id") if isinstance(peer.body, dict) else None
+    if session_id is not None:
+        diagnosis["session_id"] = session_id
+    if peer.host_status:
+        diagnosis["host_status"] = peer.host_status
+        diagnosis["host_status_note"] = _HOST_STATUS_NOTE
+
+    if not isinstance(a2a_port, int) or a2a_port <= 0 or not is_local:
+        diagnosis["port_reachable"] = None
+    else:
+        diagnosis["port_reachable"] = port_probe(a2a_port)
+
+    diagnosis["likely_causes"] = _interpret_brokered(diagnosis)
+    return diagnosis
+
+
+def _interpret_brokered(diagnosis: dict[str, Any]) -> str:
+    """Plain-language reading of the host's answer. Never concludes death
+    from a hint."""
+    registry = diagnosis.get("registry_status")
+    port = diagnosis.get("a2a_port")
+    reachable = diagnosis.get("port_reachable")
+    name = diagnosis.get("agent")
+
+    if registry == "not_found":
+        return (
+            "the host fleet registry has no agent by this name — check the "
+            "spelling, or the agent was never registered on this host"
+        )
+    if registry == "stopped":
+        return (
+            "the host fleet registry holds no a2a-port claim for this agent, "
+            "and a claim is released only at `sac agents stop` / --force — so "
+            "it is very likely stopped. This is the HOST's answer about the "
+            "real fleet, not a container-local guess"
+        )
+
+    # registry == "running": the host holds a live port claim.
+    if reachable is False:
+        return (
+            f"the agent IS live in the host fleet registry (it holds a2a port "
+            f"{port}), but nothing is listening on that port, so the /v1/turn "
+            f"transport cannot carry this turn. This is NOT a death verdict "
+            f"and must not be acted on as one: most agents in this fleet never "
+            f"bind /v1/turn (measured 2026-07-14: only 5 of 47 had it bound) "
+            f"and are reached over the a2a subscriber channel instead. Deliver "
+            f"with `sac a2a send {name} ...` (or the a2a_send tool), which does "
+            f"not require this port. Do NOT force-restart the agent on this "
+            f"signal — that would kill a healthy, working agent"
+        )
+    if reachable is True:
+        return (
+            "agent is live in the host fleet registry and its /v1/turn sidecar "
+            "is accepting connections; if the turn still fails, the agent is "
+            "alive and the failure is downstream of delivery"
+        )
+    return (
+        "agent is live in the host fleet registry; its /v1/turn port was not "
+        "probed from here, so reachability of that transport is UNKNOWN"
+    )

--- a/tests/scitex_agent_container/cli_pkg/test__send_broker.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send_broker.py
@@ -1,0 +1,517 @@
+"""Tests for the host-brokered peer lookup on the send read path.
+
+The bug being pinned
+--------------------
+Inside a container ``$HOME`` is ``/home/agent`` and
+``SCITEX_AGENT_CONTAINER_STATE_DB`` points at a private per-agent bridge DB,
+so ``open_db(None)`` resolves to a store with no rows for any other agent.
+``send_to_agent`` read that empty store and reported EVERY peer as dead.
+Measured 2026-07-14 from inside the SIF::
+
+    send_to_agent("scitex-scholar")
+      -> error "agent 'scitex-scholar' not running"
+         registry_status="stopped", pid=null, a2a_port=null, boot_complete=false
+
+while the host's registry held ``pid=1777985  a2a_port=19037  ended_at=NULL``
+for that same agent, at that same moment.
+
+What these tests hold down
+--------------------------
+1. In a container the lookup is brokered to the host and a LIVE peer is
+   reachable again (the regression that started this).
+2. "I could not check" is NEVER rendered as "the agent is stopped" — an
+   unreachable broker, an ACL refusal and a 5xx all yield UNKNOWN.
+3. Hints are never promoted to death verdicts: a stale ``startup_failed``
+   marker does not hide a live port, and an UNBOUND ``/v1/turn`` port does
+   not make ``pid_alive`` / ``boot_complete`` false. (Measured 2026-07-14:
+   only 5 of 47 live fleet agents had ``/v1/turn`` bound at all — a
+   port-bind death gate would have condemned 41 healthy agents, whose
+   "remedy" ``--force --fresh`` is destructive.)
+4. On a BARE HOST nothing is brokered — the local read path is untouched.
+
+PA-306 / STX-NM002: no mocks, no monkeypatch. A REAL in-process HTTP server
+stands in for the host ``sac listen`` (same shape as
+``test__send_in_sif_auto_fallback.py``), reached over the REAL urllib stack,
+and the REAL ``send_to_agent`` is driven end to end. State.db is redirected
+to a tmp sandbox so no test ever reads the live fleet registry.
+STX-TQ007: one fact per test. STX-TQ002: AAA.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import socket
+import socketserver
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.cli_pkg._send import send_to_agent
+from scitex_agent_container.cli_pkg._send_broker import (
+    PeerLookupUnavailable,
+    lookup_peer_via_host,
+    resolve_send_endpoint_via_host,
+    should_broker_peer_lookup,
+)
+
+_LOCAL_HOST = "test-host"
+
+
+def _closed_port() -> int:
+    """Return a port number that nothing is listening on."""
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _status_body(**over) -> bytes:
+    """A ``GET /agents/<name>/status`` body in the host's real shape."""
+    body = {
+        "name": "peer",
+        "spec_path": "/specs/peer.yaml",
+        "workdir": "/work",
+        "session_id": None,
+        "state_dir": "/state/peer",
+        "a2a_port": None,
+        "turn_url": None,
+        "role": "worker",
+    }
+    body.update(over)
+    return json.dumps(body).encode()
+
+
+@pytest.fixture
+def fake_host_listen(env_save_restore, tmp_path):
+    """A REAL HTTP server standing in for the host ``sac listen``.
+
+    Also puts the process in the in-container state the fix keys off
+    (``APPTAINER_CONTAINER`` + ``SAC_LISTEN_BASE_URL``) and redirects
+    state.db to a tmp sandbox, so the blind local read the bug came from is
+    empty here too — exactly as it is inside a real SIF.
+    """
+    responses: list[tuple[int, bytes]] = []
+    captured: list[str] = []
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            captured.append(self.path)
+            status, body = (
+                responses.pop(0) if responses else (200, _status_body())
+            )
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args, **kw):  # noqa: ARG002
+            return
+
+    server = socketserver.TCPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    env_save_restore.set("SAC_LISTEN_BASE_URL", f"http://127.0.0.1:{port}")
+    env_save_restore.set("SAC_LISTEN_BEARER", "test-bearer")
+    env_save_restore.set("APPTAINER_CONTAINER", "/path/to/test.sif")
+    env_save_restore.set("SAC_HOST", _LOCAL_HOST)
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
+    )
+
+    class _Ctl:
+        # The server's own port is guaranteed BOUND — hand it out as a live
+        # agent's a2a port so the reachability probe measures a real socket.
+        live_port = port
+
+        @property
+        def captured(self) -> list[str]:
+            return captured
+
+        def enqueue(self, status: int, body: bytes) -> None:
+            responses.append((status, body))
+
+    try:
+        yield _Ctl()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+
+@pytest.fixture
+def fresh_lead_creds_path(tmp_path) -> Path:
+    """Fresh OAuth creds so ``preflight_send_creds`` passes deterministically."""
+    creds = tmp_path / ".credentials.json"
+    creds.write_text(
+        json.dumps(
+            {"claudeAiOauth": {"expiresAt": int((time.time() + 3600) * 1000)}}
+        )
+    )
+    return creds
+
+
+# ---------------------------------------------------------------------------
+# should_broker_peer_lookup — the bare-host path must stay untouched
+# ---------------------------------------------------------------------------
+
+
+def test_bare_host_does_not_broker(env_save_restore):
+    # Arrange — no SIF markers: an ordinary host shell.
+    env_save_restore.delete("APPTAINER_CONTAINER")
+    env_save_restore.delete("SINGULARITY_CONTAINER")
+    env_save_restore.set("SAC_LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    # Act
+    brokering = should_broker_peer_lookup()
+    # Assert — bare host keeps the local read path.
+    assert brokering is False
+
+
+def test_in_sif_without_listen_url_does_not_broker(env_save_restore):
+    # Arrange — a stale SINGULARITY_CONTAINER with no host listen to talk to
+    # (the sac-from-sac / bare-host footgun status_cmds hit in PR#316).
+    env_save_restore.set("APPTAINER_CONTAINER", "/path/to/test.sif")
+    env_save_restore.delete("SAC_LISTEN_BASE_URL")
+    # Act
+    brokering = should_broker_peer_lookup()
+    # Assert — no URL to broker to → do not broker.
+    assert brokering is False
+
+
+def test_in_sif_with_listen_url_brokers(fake_host_listen):
+    # Arrange — fixture puts us in the real in-container state.
+    # Act
+    brokering = should_broker_peer_lookup()
+    # Assert
+    assert brokering is True
+
+
+# ---------------------------------------------------------------------------
+# lookup_peer_via_host — the host's answer
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_returns_the_port_the_host_reports(fake_host_listen):
+    # Arrange — the host knows this agent holds port 19037 (scholar's real one).
+    fake_host_listen.enqueue(
+        200,
+        _status_body(
+            a2a_port=19037, turn_url="http://ywata-note-win:19037/v1/turn"
+        ),
+    )
+    # Act
+    peer = lookup_peer_via_host("scitex-scholar")
+    # Assert — the port the blind local read could never see.
+    assert peer.a2a_port == 19037
+
+
+def test_lookup_uses_the_agent_status_door(fake_host_listen):
+    # Arrange
+    fake_host_listen.enqueue(200, _status_body(a2a_port=1))
+    # Act
+    lookup_peer_via_host("scitex-scholar")
+    # Assert — the SAME door agent_status uses; no second mechanism.
+    assert fake_host_listen.captured == ["/agents/scitex-scholar/status"]
+
+
+def test_lookup_reports_host_404_as_not_known(fake_host_listen):
+    # Arrange — the host, which sees the whole fleet, has no such agent.
+    fake_host_listen.enqueue(404, b'{"error":"no such agent"}')
+    # Act
+    peer = lookup_peer_via_host("ghost")
+    # Assert — the one definitive negative.
+    assert peer.known is False
+
+
+def test_stale_startup_failed_marker_does_not_hide_the_live_port(fake_host_listen):
+    # Arrange — scitex-writer, measured 2026-07-14: a ~2-day-old
+    # startup_failed marker while the agent was alive and answering a2a.
+    fake_host_listen.enqueue(
+        200,
+        _status_body(
+            status="startup_failed",
+            a2a_port=19014,
+            turn_url="http://ywata-note-win:19014/v1/turn",
+        ),
+    )
+    # Act
+    peer = lookup_peer_via_host("scitex-writer")
+    # Assert — the marker is a HINT; it must not suppress the live endpoint.
+    assert peer.a2a_port == 19014
+
+
+def test_startup_failed_is_carried_as_a_hint_only(fake_host_listen):
+    # Arrange
+    fake_host_listen.enqueue(200, _status_body(status="startup_failed", a2a_port=1))
+    # Act
+    peer = lookup_peer_via_host("scitex-writer")
+    # Assert — surfaced for the operator, but it is not the verdict field.
+    assert peer.host_status == "startup_failed"
+
+
+# ---------------------------------------------------------------------------
+# Could-not-ask → UNKNOWN. Never "stopped".
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_broker_raises_rather_than_reporting_stopped(
+    env_save_restore, tmp_path
+):
+    # Arrange — in a SIF, but the host listen is down.
+    env_save_restore.set("APPTAINER_CONTAINER", "/path/to/test.sif")
+    env_save_restore.set(
+        "SAC_LISTEN_BASE_URL", f"http://127.0.0.1:{_closed_port()}"
+    )
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
+    )
+
+    # Act
+    def _lookup():
+        lookup_peer_via_host("scitex-scholar")
+
+    # Assert — refuses to answer rather than guessing "dead".
+    with pytest.raises(PeerLookupUnavailable):
+        _lookup()
+
+
+def test_acl_deny_raises_rather_than_reporting_stopped(fake_host_listen):
+    # Arrange — the host refuses to tell us (403). We were prevented from
+    # learning the state; that is not the same as learning it is stopped.
+    fake_host_listen.enqueue(
+        403, b'{"error":"ACL deny","kind":"acl_deny","reason":"cross-lineage"}'
+    )
+
+    # Act
+    def _lookup():
+        lookup_peer_via_host("scitex-scholar")
+
+    # Assert
+    with pytest.raises(PeerLookupUnavailable):
+        _lookup()
+
+
+def test_acl_deny_preserves_the_hosts_kind(fake_host_listen):
+    # Arrange
+    fake_host_listen.enqueue(
+        403, b'{"error":"ACL deny","kind":"acl_deny","reason":"cross-lineage"}'
+    )
+    captured: Exception | None = None
+    # Act
+    try:
+        lookup_peer_via_host("scitex-scholar")
+    except PeerLookupUnavailable as exc:
+        captured = exc
+    # Assert — the gate's refusal is surfaced verbatim, never worked around.
+    assert getattr(captured, "kind", None) == "acl_deny"
+
+
+# ---------------------------------------------------------------------------
+# resolve_send_endpoint_via_host — provenance is visible in the result
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_endpoint_is_tagged_host_broker(fake_host_listen):
+    # Arrange
+    fake_host_listen.enqueue(
+        200, _status_body(a2a_port=19037, turn_url="http://peer-host:19037/v1/turn")
+    )
+    # Act
+    endpoint, _peer = resolve_send_endpoint_via_host(
+        "scitex-scholar", current_host=_LOCAL_HOST
+    )
+    # Assert — a reader can always tell the fleet registry from a blind read.
+    assert endpoint.source == "host_broker"
+
+
+def test_resolved_endpoint_carries_the_peers_host(fake_host_listen):
+    # Arrange
+    fake_host_listen.enqueue(
+        200, _status_body(a2a_port=19037, turn_url="http://peer-host:19037/v1/turn")
+    )
+    # Act
+    endpoint, _peer = resolve_send_endpoint_via_host(
+        "scitex-scholar", current_host=_LOCAL_HOST
+    )
+    # Assert
+    assert endpoint.host == "peer-host"
+
+
+# ---------------------------------------------------------------------------
+# send_to_agent — the regression, driven end to end through the real function
+# ---------------------------------------------------------------------------
+
+
+def test_live_peer_is_reachable_from_inside_a_container(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange — the host reports a live agent on a port that IS bound.
+    # Before the fix this returned: error "agent 'peer' not running".
+    port = fake_host_listen.live_port
+    fake_host_listen.enqueue(
+        200,
+        _status_body(a2a_port=port, turn_url=f"http://{_LOCAL_HOST}:{port}/v1/turn"),
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — the fleet can talk to itself again.
+    assert result["status"] == "dispatched"
+
+
+def test_dispatch_targets_the_port_the_host_reported(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange
+    port = fake_host_listen.live_port
+    fake_host_listen.enqueue(
+        200,
+        _status_body(a2a_port=port, turn_url=f"http://{_LOCAL_HOST}:{port}/v1/turn"),
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — the endpoint came from the fleet registry, not the empty local DB.
+    assert result["a2a_port"] == port
+
+
+def test_unreachable_broker_never_reports_the_peer_stopped(
+    env_save_restore, tmp_path, fresh_lead_creds_path
+):
+    # Arrange — in a SIF; the host listen is down, so we cannot check.
+    env_save_restore.set("APPTAINER_CONTAINER", "/path/to/test.sif")
+    env_save_restore.set("SAC_HOST", _LOCAL_HOST)
+    env_save_restore.set(
+        "SAC_LISTEN_BASE_URL", f"http://127.0.0.1:{_closed_port()}"
+    )
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — UNKNOWN, not dead. "I could not check" must never render as
+    # "the agent is stopped" — that is the bug, and its remedy is destructive.
+    assert result["diagnosis"]["registry_status"].startswith("unknown")
+
+
+def test_unreachable_broker_names_the_broker_as_the_failure(
+    env_save_restore, tmp_path, fresh_lead_creds_path
+):
+    # Arrange
+    env_save_restore.set("APPTAINER_CONTAINER", "/path/to/test.sif")
+    env_save_restore.set("SAC_HOST", _LOCAL_HOST)
+    env_save_restore.set(
+        "SAC_LISTEN_BASE_URL", f"http://127.0.0.1:{_closed_port()}"
+    )
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — fail honestly: the BROKER is what is unreachable, not the agent.
+    assert "broker is unreachable" in result["error"]
+
+
+def test_unbound_turn_port_still_reports_the_agent_running(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange — the live-fleet norm: the host holds a port claim but nothing
+    # listens on it (41 of 47 agents, measured 2026-07-14). Those agents are
+    # alive and answer over the a2a subscriber channel.
+    fake_host_listen.enqueue(
+        200,
+        _status_body(
+            a2a_port=_closed_port(),
+            turn_url=f"http://{_LOCAL_HOST}:1/v1/turn",
+        ),
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — an unbound port is a TRANSPORT fact, not a death certificate.
+    assert result["diagnosis"]["registry_status"] == "running"
+
+
+def test_unbound_turn_port_does_not_fabricate_a_dead_pid(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange
+    fake_host_listen.enqueue(
+        200,
+        _status_body(
+            a2a_port=_closed_port(),
+            turn_url=f"http://{_LOCAL_HOST}:1/v1/turn",
+        ),
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — UNKNOWN (None), never False. A False here trips the caller's
+    # pid_alive death gate and condemns a healthy agent.
+    assert result["diagnosis"]["pid_alive"] is None
+
+
+def test_unbound_turn_port_does_not_fabricate_a_failed_boot(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange
+    fake_host_listen.enqueue(
+        200,
+        _status_body(
+            a2a_port=_closed_port(),
+            turn_url=f"http://{_LOCAL_HOST}:1/v1/turn",
+        ),
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — the host route carries no heartbeat, so boot state is UNKNOWN.
+    assert result["diagnosis"]["boot_complete"] is None
+
+
+def test_unbound_turn_port_error_does_not_claim_the_agent_crashed(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange
+    fake_host_listen.enqueue(
+        200,
+        _status_body(
+            a2a_port=_closed_port(),
+            turn_url=f"http://{_LOCAL_HOST}:1/v1/turn",
+        ),
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — the old wording ("it is not booted or the sidecar crashed") was
+    # a death verdict whose remedy destroys a working agent.
+    assert "crashed" not in result["error"]
+
+
+def test_host_404_is_reported_as_not_found_not_stopped(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange — the host genuinely has no agent by this name.
+    fake_host_listen.enqueue(404, b'{"error":"no such agent"}')
+    # Act
+    result = send_to_agent(
+        "ghost", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert
+    assert result["diagnosis"]["registry_status"] == "not_found"


### PR DESCRIPTION
## The bug: an agent in a container cannot see any other agent

Inside a SIF, `$HOME` is `/home/agent` (not the operator's home) and
`SCITEX_AGENT_CONTAINER_STATE_DB` points at a **private per-agent bridge DB**
(`/state/<name>/state.db`). So `open_db(None)` resolves to a store that holds no
rows for *any* other agent. The send read path read that empty store — and
rendered its emptiness as **death**.

This is why agents keep asking the human operator to relay messages for them.

### The measured contradiction (2026-07-14)

In-container, `send_to_agent("scitex-scholar")` returned:

```
error:           "agent 'scitex-scholar' not running"
registry_status: stopped
pid:             null
a2a_port:        null
boot_complete:   false
```

The **HOST's shared registry, at that same moment**, said:

```
scitex-scholar   pid=1777985   a2a_port=19037   ended_at=NULL
```

...its tmux session was alive, and it had messaged the caller **90 seconds
earlier**. The lookup was never performed against the real fleet registry, and
"I could not check" was rendered as "the agent is stopped".

## The fix: reuse the broker seam `agent_status` already uses

`agent_status` solves this correctly: in a SIF it proxies
`GET /agents/<name>/status` to the host's `sac listen` via
`_in_sif_http_client.host_listen_call`
(`status_cmds.py::_status_via_host_listen`), so it reads the **real fleet
registry**. This PR routes the *send* path's peer lookup through that **same
door** — same client, same URL, same bearer, same server-side auth gate. No
second mechanism, no reimplemented client.

- **Bare host: unchanged.** `should_broker_peer_lookup()` is `False` there and
  the local resolver runs exactly as before. It mirrors `agent_spawn`'s decision
  (`is_in_sif()`), plus the `SAC_LISTEN_BASE_URL` guard `status_cmds` learned the
  hard way in PR#316.
- **ACL/bearer: untouched.** A 403 is surfaced as UNKNOWN, never worked around.

## Absence of evidence is not death

The remedy for a "dead" verdict is **destructive** (`--force --fresh`). A false
red kills a healthy, working agent; a false green merely costs a round-trip. The
caution here is deliberately asymmetric.

| Signal | Before | Now |
|---|---|---|
| Broker unreachable / ACL deny / 5xx | *(read blind DB -> "stopped")* | `PeerLookupUnavailable` -> `registry_status: "unknown: ..."`. **No** fallback to the blind local read. |
| `pid` | stale pid -> `pid_alive: False` -> "crashed" | **Deliberately not sourced.** The status route exposes none, and a *stale* pid makes `os.kill(pid,0)` condemn a healthy restarted agent. `pid_alive` stays `None`. |
| `boot_complete` | `false` (no heartbeat visible) | `None` — the route carries no heartbeat, so it is UNKNOWN. |
| stale `startup_failed` marker | would mask the agent | HINT only. It no longer hides a live port. |
| `/v1/turn` port not bound | error: *"it is not booted or the sidecar crashed"* | A **transport** fact, not a death certificate. Points at the a2a rail instead. |

### Two traps this PR deliberately does not walk into

1. **The `startup_failed` marker is a liar.** `scitex-writer` reported
   `startup_failed` from a **~2-day-old** marker while its host row held
   `pid=1772715 / ended_at=NULL` and it answered an a2a message that same turn.
   Nothing reconciles those markers (fallout from #642).

2. **"Port not bound" is not death.** Measured across the live fleet: **only 5 of
   47 registered agents have `/v1/turn` bound at all.** The other 41 hold a port
   claim with nothing listening — and are alive, answering over the a2a
   subscriber channel. A port-bind death gate would have condemned 41 healthy
   agents.

## Verification (real fleet, from inside the container)

`scitex-todo`, which previously returned **"agent not running"**, now:

```json
{"status": "dispatched", "agent": "scitex-todo",
 "url": "http://127.0.0.1:19015/v1/turn", "a2a_port": 19015,
 "delivered_subscriber_count": 1}
```

`scitex-scholar` now resolves its real port (19037), reports
`registry_status: running`, `pid_alive: null`, `boot_complete: null`, and an
error that names the *transport* rather than pronouncing the agent dead.

## Tests

22 new tests, **no mocks** — a **real in-process HTTP server** stands in for the
host `sac listen` (same shape as `test__send_in_sif_auto_fallback.py`), reached
over the real urllib stack, driving the **real `send_to_agent`** end to end.
`state.db` is redirected to a tmp sandbox so no test ever reads the live fleet
registry.

Local: **77 passed** (22 new + the existing send / resolve / in-SIF suites).
`ruff check --select F401,F811 src/ tests/` -> clean.

## Known gap (follow-up, NOT fixed here)

`send_to_agent` targets `/v1/turn`, which **41 of 47 fleet agents never bind**.
This PR makes the verdict *honest* for those agents (and points at the working
a2a rail) but does not re-plumb the delivery transport — that is a separate
design decision about which rail is canonical, and it should be made
deliberately rather than smuggled into a lookup fix.
`_listen/_agent_exec_send.py:133-145` shows the host's own send route has the
same dependency: it tries `forward_to_live_runner` (needs the port), then falls
back to `claude --resume <sid>`, and 409s when there is no `session_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
