### PR TITLE
fix(off_loop): stop orphaning blocking calls into the SHARED default executor — the 3.11 CI hang, and a live `sac listen` wedge

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_off_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_off_loop.py
@@ -15,22 +15,57 @@ error logged. A full silent fleet-comms outage.
 
 This helper makes that class of bug impossible: every blocking call a
 loop makes goes through :func:`run_blocking`, which (1) dispatches the
-call to a thread via ``run_in_executor`` so it never occupies the loop
-thread, and (2) wraps it in ``asyncio.wait_for`` so a wedged call can
-never hang forever — it raises :class:`asyncio.TimeoutError` after
-``timeout_s`` and the caller logs + degrades instead of blocking the
-fleet.
+call to a thread so it never occupies the loop thread, and (2) wraps it
+in ``asyncio.wait_for`` so a wedged call can never hang forever — it
+raises :class:`asyncio.TimeoutError` after ``timeout_s`` and the caller
+logs + degrades instead of blocking the fleet.
+
+DEDICATED THREADS, NOT THE SHARED DEFAULT EXECUTOR
+--------------------------------------------------
+The dispatch deliberately spawns a fresh daemon thread per call instead
+of ``loop.run_in_executor(None, ...)``. That is not a style choice — the
+executor form reintroduced, by a longer route, the exact fleet-comms
+hang this module exists to prevent:
+
+A ``concurrent.futures`` future whose function is ALREADY RUNNING cannot
+be cancelled. So when ``wait_for`` times out, the worker thread is NOT
+stopped — it keeps running the wedged call forever, permanently holding
+its slot in the event loop's *shared* default ``ThreadPoolExecutor``.
+That pool is only ``min(32, os.cpu_count() + 4)`` threads — just 6-8 on
+a 2-4 core CI runner. Six background loops (tui/sdk heartbeat, liveness
+tick, bind watchdog, gh CI poll, periodic drive) each abandon a thread
+every time a tick overruns, so the pool drains steadily. Once it is
+empty, EVERY other user of the default executor starves — and the rest
+of the codebase reaches that same pool through *unbounded*
+``asyncio.to_thread`` calls (the ``/agents`` spawn handler's brokered
+launch, ``_host_exec``, ``_agent_exec_send``, ``_forward``). Those have
+no ``wait_for`` to save them: they queue behind the wedged threads and
+hang FOREVER. Measured: after ``max_workers`` timed-out ``run_blocking``
+calls, a trivial ``to_thread(lambda: "ok")`` never runs at all. This is
+version-independent (reproduced identically on 3.11 and 3.12); it simply
+bites soonest where the pool is smallest, which is why it surfaced as an
+intermittent "only on the CI runner" hang of the pytest suite.
+
+A dedicated daemon thread per call restores the intended semantics: an
+abandoned call leaks exactly ONE thread (unavoidable — Python cannot
+kill a thread blocked in a syscall) and can never starve anything else.
+The threads are daemons, so a wedged probe also cannot hold interpreter
+exit open.
 
 Fail-loud (operator: "when failure occurs, fail loud"): a timeout is
 returned to the caller as an explicit exception (or, via
 :func:`run_blocking_or`, a sentinel default + a logged ERROR naming the
-op), never silently swallowed into an indistinguishable success.
+op), never silently swallowed into an indistinguishable success. The
+count of still-wedged abandoned calls is tracked and logged loudly once
+it crosses :data:`_ABANDONED_WARN_THRESHOLD`, so a genuinely stuck host
+is visible instead of quietly leaking threads.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from typing import Any, Callable, TypeVar
 
 logger = logging.getLogger(__name__)
@@ -44,6 +79,45 @@ T = TypeVar("T")
 # take the whole fleet's comms down.
 DEFAULT_BLOCKING_TIMEOUT_S = 5.0
 
+# Abandoned calls still running past their deadline. A couple is normal on
+# a loaded host (a slow probe that eventually returns); a persistently high
+# count means a genuinely stuck subprocess/socket and is worth an ERROR.
+_ABANDONED_WARN_THRESHOLD = 8
+
+_abandoned_lock = threading.Lock()
+_abandoned_count = 0
+
+
+def abandoned_call_count() -> int:
+    """Off-loop calls that timed out and whose thread is STILL running.
+
+    Diagnostic gauge for the fail-loud path (and the regression test that
+    pins "an abandoned call must not starve unrelated off-loop work").
+    """
+    with _abandoned_lock:
+        return _abandoned_count
+
+
+def _mark_abandoned(op: str) -> None:
+    global _abandoned_count
+    with _abandoned_lock:
+        _abandoned_count += 1
+        current = _abandoned_count
+    if current >= _ABANDONED_WARN_THRESHOLD:
+        logger.error(
+            "off_loop: %d abandoned blocking calls are STILL wedged (latest: "
+            "%s). Each leaks one daemon thread. A stuck subprocess "
+            "(gh/tmux/ssh) or an unresponsive host is the usual cause.",
+            current,
+            op,
+        )
+
+
+def _clear_abandoned() -> None:
+    global _abandoned_count
+    with _abandoned_lock:
+        _abandoned_count -= 1
+
 
 async def run_blocking(
     fn: Callable[..., T],
@@ -53,21 +127,70 @@ async def run_blocking(
 ) -> T:
     """Run a blocking ``fn(*args, **kwargs)`` off the loop, bounded.
 
-    The call is dispatched to the default thread-pool executor so it
-    never occupies the event-loop thread, and bounded by ``timeout_s``
-    via :func:`asyncio.wait_for`. Raises :class:`asyncio.TimeoutError`
-    if the call does not finish in time (the underlying thread is left
-    to finish/abandon — we do NOT join it, so a wedged child can never
-    block the loop). Any exception ``fn`` raises propagates unchanged.
+    The call is dispatched to a DEDICATED daemon thread — never the event
+    loop's shared default executor — so it neither occupies the loop
+    thread nor competes for the pool that ``asyncio.to_thread`` callers
+    depend on. It is bounded by ``timeout_s`` via :func:`asyncio.wait_for`
+    and raises :class:`asyncio.TimeoutError` if the call does not finish
+    in time. The underlying thread is left to finish/abandon — we do NOT
+    join it, so a wedged child can never block the loop; because the
+    thread is private to this call, abandoning it starves nothing (see the
+    module docstring: doing this on the shared executor is what made a
+    wedged probe hang the whole process). Any exception ``fn`` raises
+    propagates unchanged.
     """
     loop = asyncio.get_running_loop()
+    future: asyncio.Future[T] = loop.create_future()
+    op = getattr(fn, "__name__", "call")
+    # Guards the abandoned/finished handoff so a call that completes at the
+    # same instant its deadline fires is counted exactly once.
+    state_lock = threading.Lock()
+    finished = False
+    abandoned = False
 
-    def _call() -> T:
-        return fn(*args, **kwargs)
+    def _deliver(result: Any, exc: BaseException | None) -> None:
+        # On the loop thread. If wait_for already timed out it cancelled the
+        # future and moved on — there is no awaiter left to deliver to.
+        if future.done():
+            return
+        if exc is not None:
+            future.set_exception(exc)
+        else:
+            future.set_result(result)
 
-    return await asyncio.wait_for(
-        loop.run_in_executor(None, _call), timeout=timeout_s
-    )
+    def _runner() -> None:
+        nonlocal finished
+        result: Any = None
+        exc: BaseException | None = None
+        try:
+            result = fn(*args, **kwargs)
+        except BaseException as caught:  # stx-allow: fallback (reason: relayed verbatim to the awaiter, never swallowed)
+            exc = caught
+        with state_lock:
+            finished = True
+            was_abandoned = abandoned
+        if was_abandoned:
+            # We outlived our deadline; nobody is waiting. Just stop counting.
+            _clear_abandoned()
+            return
+        try:
+            loop.call_soon_threadsafe(_deliver, result, exc)
+        except RuntimeError:  # stx-allow: fallback (reason: loop already closed — the awaiter is long gone; dropping the result is correct)
+            pass
+
+    threading.Thread(
+        target=_runner, name=f"sac-off-loop-{op}", daemon=True
+    ).start()
+    try:
+        return await asyncio.wait_for(future, timeout=timeout_s)
+    except asyncio.TimeoutError:
+        with state_lock:
+            newly_abandoned = not finished
+            if newly_abandoned:
+                abandoned = True
+        if newly_abandoned:
+            _mark_abandoned(op)
+        raise
 
 
 async def run_blocking_or(
@@ -105,6 +228,7 @@ async def run_blocking_or(
 
 __all__ = [
     "DEFAULT_BLOCKING_TIMEOUT_S",
+    "abandoned_call_count",
     "run_blocking",
     "run_blocking_or",
 ]

--- a/tests/scitex_agent_container/_lifecycle/test__off_loop.py
+++ b/tests/scitex_agent_container/_lifecycle/test__off_loop.py
@@ -1,0 +1,198 @@
+"""``_off_loop`` — bounded off-loop dispatch, and the starvation regression.
+
+The regression these pin (CI hang, 2026-07-13, runs 29274230213 /
+29273968878): ``run_blocking`` used to dispatch through
+``loop.run_in_executor(None, ...)`` — the event loop's SHARED default
+``ThreadPoolExecutor``. A ``concurrent.futures`` future that is already
+running cannot be cancelled, so when ``wait_for`` timed out the worker
+thread kept running the wedged call forever and permanently held its slot
+in that shared pool. The pool is only ``min(32, os.cpu_count() + 4)``
+threads (6-8 on a 2-4 core CI runner), and six listen background loops
+abandon a thread every time a tick overruns. Once the pool was drained,
+every OTHER user of the default executor starved — including the
+*unbounded* ``asyncio.to_thread`` calls in the ``/agents`` spawn handler,
+``_host_exec``, ``_agent_exec_send`` and ``_forward``, which have no
+``wait_for`` to rescue them and so hung FOREVER. That is what killed the
+pytest suite (a test would print its name and never finish) and, in
+production, would wedge brokered spawns while the listen daemon silently
+degraded every probe to its fallback.
+
+NO MOCKS — a real ``threading.Event`` that is never set makes a real call
+block in a real thread; the assertions are on real dispatch behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+
+import pytest
+
+from scitex_agent_container._lifecycle._off_loop import (
+    abandoned_call_count,
+    run_blocking,
+    run_blocking_or,
+)
+
+
+def _default_pool_size() -> int:
+    """Size of the event loop's default ThreadPoolExecutor."""
+    return min(32, (os.cpu_count() or 1) + 4)
+
+
+async def _abandon_a_pools_worth(wedge) -> None:
+    """Time out enough wedged calls to drain the default executor.
+
+    Uses ``run_blocking_or`` (degrades, never raises) so the arrange phase
+    of a test carries no assertion of its own.
+    """
+    for _ in range(_default_pool_size() + 4):
+        await run_blocking_or(wedge, default=None, op="wedged probe", timeout_s=0.05)
+
+
+@pytest.fixture
+def wedge():
+    """A callable that blocks until the test releases it. Always released."""
+    released = threading.Event()
+
+    def blocker() -> str:
+        released.wait()
+        return "unblocked"
+
+    try:
+        yield blocker
+    finally:
+        # Let every abandoned daemon thread exit instead of leaking into
+        # the rest of the session.
+        released.set()
+
+
+# ---------------------------------------------------------------------------
+# Baseline contract.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_returns_the_value():
+    # Arrange
+    def seven() -> int:
+        return 7
+
+    # Act
+    got = await run_blocking(seven)
+    # Assert
+    assert got == 7
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_propagates_the_exception_unchanged():
+    # Arrange
+    def boom() -> None:
+        raise ValueError("kaboom")
+
+    # Act
+    call = run_blocking(boom)
+    # Assert
+    with pytest.raises(ValueError, match="kaboom"):
+        await call
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_times_out_on_a_wedged_call(wedge):
+    # Arrange
+    timeout_s = 0.2
+    # Act
+    call = run_blocking(wedge, timeout_s=timeout_s)
+    # Assert
+    with pytest.raises(asyncio.TimeoutError):
+        await call
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_or_degrades_to_default_on_timeout(wedge):
+    # Arrange
+    sentinel = "fallback"
+    # Act
+    got = await run_blocking_or(wedge, default=sentinel, op="probe", timeout_s=0.2)
+    # Assert
+    assert got == sentinel
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_leaves_the_event_loop_free_to_run(wedge):
+    """The loop must keep ticking while a blocking call is in flight."""
+    # Arrange
+    task = asyncio.create_task(
+        run_blocking_or(wedge, default=None, op="probe", timeout_s=1.0)
+    )
+    ticks = 0
+    # Act
+    while not task.done():
+        await asyncio.sleep(0.01)
+        ticks += 1
+    # Assert
+    assert ticks > 5
+
+
+# ---------------------------------------------------------------------------
+# THE REGRESSION — an abandoned call must starve nothing.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_abandoned_calls_do_not_starve_asyncio_to_thread(wedge):
+    """Abandon more calls than the default pool holds; ``to_thread`` must live.
+
+    This is the exact shape of the CI hang: the ``/agents`` handler awaits an
+    UNBOUNDED ``asyncio.to_thread`` for its brokered launch. Before the fix,
+    the abandoned ``run_blocking`` threads owned every slot of the shared
+    default executor and this ``to_thread`` never ran — the request never
+    returned and the test hung forever.
+    """
+    # Arrange
+    await _abandon_a_pools_worth(wedge)
+
+    def healthy() -> str:
+        return "ok"
+
+    # Act
+    try:
+        got = await asyncio.wait_for(asyncio.to_thread(healthy), timeout=10.0)
+    except asyncio.TimeoutError:
+        got = "STARVED: to_thread never ran — queued behind abandoned threads"
+    # Assert
+    assert got == "ok"
+
+
+@pytest.mark.asyncio
+async def test_abandoned_calls_do_not_starve_later_run_blocking(wedge):
+    """A healthy probe must still run after a pool's worth of wedged ones.
+
+    Otherwise every listen background loop degrades to its fallback forever:
+    heartbeats stop, the liveness tick goes blind, and nothing says why.
+    """
+    # Arrange
+    await _abandon_a_pools_worth(wedge)
+
+    def healthy() -> str:
+        return "healthy"
+
+    # Act
+    got = await run_blocking_or(
+        healthy, default="STARVED: healthy probe never ran", op="probe", timeout_s=10.0
+    )
+    # Assert
+    assert got == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_abandoned_call_count_reports_the_wedged_calls(wedge):
+    """The fail-loud gauge counts calls whose thread is still stuck."""
+    # Arrange
+    before = abandoned_call_count()
+    # Act
+    for _ in range(3):
+        await run_blocking_or(wedge, default=None, op="wedged probe", timeout_s=0.05)
+    # Assert
+    assert abandoned_call_count() == before + 3


### PR DESCRIPTION
## The hanging test

There isn't one — and that's the point. **Two different tests hung in two different runs**, which is why this read as "flaky CI":

| run | last test to print its nodeid, never its result |
|---|---|
| 29274230213 | `_listen/test__agent_exec_subprocess.py::test_agents_start_shells_plural_agents_form` |
| 29273968878 | `_lifecycle/test__tui_heartbeat_loop.py::test_one_batched_probe_serves_the_whole_fleet` |

Both hang in the **same place**, and it is not in either test. It is in `_lifecycle/_off_loop.py`.

## The blocked frame

Reproduced on **CPython 3.11.15**, importing from the worktree, `-X faulthandler`, SIGABRT on the wedged process:

```
Thread 0x71a9ff7376c0  <-- THE HANG
  threading.py:1139 in _wait_for_tstate_lock
  threading.py:1119 in join                       <-- joining a worker thread
  concurrent/futures/thread.py:235 in shutdown    <-- ThreadPoolExecutor.shutdown(wait=True)
  asyncio/base_events.py:580 in _do_shutdown      <-- loop.shutdown_default_executor()

Thread 0x71a9b234f6c0 (x20)  <-- WHAT IT IS JOINING
  threading.py:629 in wait                        <-- the wedged call, still running
  src/scitex_agent_container/_lifecycle/_off_loop.py:185 in _call
  concurrent/futures/thread.py:83 in _worker      <-- default-executor worker
```

## Root cause — PRODUCTION CODE, not test code

`run_blocking` dispatched through `loop.run_in_executor(None, ...)` — the event loop's **shared default `ThreadPoolExecutor`**. A `concurrent.futures` future that is **already running cannot be cancelled**, so when its `wait_for` timed out the worker thread was *not* stopped. It kept running the wedged call forever, **still owned by the pool**. The old docstring even said so: *"the underlying thread is left to finish/abandon — we do NOT join it"* — true of the loop, false of the pool.

Six background loops (`_tui_heartbeat_loop`, `_sdk_heartbeat_loop`, `_liveness_tick`, `_bind_watchdog`, `_github_ci_poll_loop`, `_periodic_drive_loop`) abandon a thread every time a tick overruns. Two fatal consequences:

**1. Pool starvation — version-INDEPENDENT.** The pool is only `min(32, cpu_count+4)`: **6-8 threads on a 2-4 core runner** (20 on my 16-core box — which is why it barely reproduces locally). The rest of the codebase reaches that *same* pool through **unbounded `asyncio.to_thread`** — the `/agents` brokered spawn, `_host_exec`, `_agent_exec_send`, `_forward`. Those have no `wait_for` to rescue them, so they **queue forever**. Measured on 3.11 *and* 3.12: after `max_workers` timeouts, a trivial `to_thread(lambda: "ok")` **never runs at all**.

This is not hypothetical. `_tui_heartbeat_loop.py:274-284` already documents it:
> *"zombie threads … hold worker slots in the SHARED default executor that `agent_restart` / `host_exec` / `liveness_tick` also dispatch through, **which is how a slow heartbeat degraded into a fleet-wide comms outage**."*

That was band-aided with an overlap guard on **that one loop**. The other five kept bleeding the pool.

**2. Shutdown join-forever — 3.11 ONLY. This is the CI hang.**

Executor workers are **non-daemon**, and loop close joins them. Verified against the real interpreters:

| | **3.11.15** | **3.12.3** |
|---|---|---|
| `shutdown_default_executor` | `(self)` — **no timeout** | `(self, timeout=None)` |
| `asyncio.constants.THREAD_JOIN_TIMEOUT` | ***absent*** | **300** |
| `Runner.close()` | `shutdown_default_executor()` → **joins FOREVER** | `...(THREAD_JOIN_TIMEOUT)` → warns, moves on |

**That is the entire "only on 3.11" mystery.** Same defect on every version; only 3.11 turns an orphaned thread into an *infinite* join. pytest printed the nodeid, the join never returned, the job ran to the 30-min cap. `pytest-timeout` cannot save it — the join is *below* pytest, in a non-daemon thread.

**Production impact:** the fleet runs 3.11. A wedged probe means `sac listen` **cannot shut down** (hangs on SIGTERM), *and* brokered spawns/sends hang forever once the pool drains.

## The fix

Dispatch each call to a **dedicated daemon thread**, never the shared pool.

- Abandoning a call now leaks exactly **one** thread (unavoidable — Python cannot kill a thread blocked in a syscall) and **starves nothing**.
- Daemon + outside the pool ⇒ **never joined** at loop close. Neither the suite nor `sac listen` can hang on shutdown.
- Adds a fail-loud `abandoned_call_count()` gauge + ERROR past a threshold, so a genuinely stuck host is visible instead of quietly leaking.

Batching (#647) is untouched; no test is skipped, deleted, or weakened.

## Verification — 3.11.15, `__file__` inside the worktree

| | pre-fix | post-fix |
|---|---|---|
| stuck `asyncio_*` executor threads | **20** | **0** |
| healthy call after N timeouts | ***never ran*** | **0.00 s** |
| the two hang-site tests | **hung forever** (traceback above) | **23 passed in 7.64 s, exit 0** |

`tests/.../_lifecycle/test__off_loop.py` is new — the module guarding the fleet against comms hangs had **zero tests**, which is how this shipped. Its two starvation tests were confirmed to **fail against the old dispatch**.