### PR TITLE
chore(release): v0.21.15 — the shared executor leaked threads until nothing could run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,76 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.15] — 2026-07-14
+
+Honesty release. Every fix here is the same bug wearing a different face:
+**something reported a state it had not observed.** The headline (#658) is
+the one that had been doing real damage for weeks while looking like
+"flaky CI".
+
+### Fixed
+- **The shared executor leaked threads until nothing could run (#658).**
+  `_off_loop.run_blocking` dispatched via `loop.run_in_executor(None, …)`
+  — the event loop's **shared default `ThreadPoolExecutor`**. A
+  `concurrent.futures` future that is *already running* **cannot be
+  cancelled**, so when the `wait_for` timed out the worker thread was
+  never stopped: it kept running the wedged call forever, still holding
+  its slot in the pool. Six background loops did this on every
+  overrunning tick.
+  The default pool is only `min(32, cpu_count + 4)` — **6–8 threads** on
+  a small host — and `asyncio.to_thread` uses **that same pool**. So once
+  enough slots were gone, *a task that needs a thread simply never runs*:
+  a trivial `to_thread(lambda: "ok")` never executed. That is why
+  `sac listen` answered `/health` in 0.18s while **every authenticated
+  route hung** (the fast path never touches the executor), why brokered
+  spawns stalled, and — on Python 3.11, which is what the fleet runs —
+  why `sac listen` **could not shut down at all**: pool workers are
+  non-daemon, `shutdown_default_executor()` has no timeout before 3.12,
+  and loop close joined an orphaned thread forever.
+  Fix: a dedicated **daemon** thread per call. An abandoned call now
+  leaks exactly one thread (you cannot kill a running thread in Python)
+  but **starves nothing**, and outside the pool it is never joined at
+  shutdown. Adds an `abandoned_call_count()` gauge, because a silent leak
+  is how this survived. `_off_loop.py` had **zero tests** — that is how it
+  shipped; the new starvation tests were confirmed to *fail* against the
+  old dispatch.
+  This one defect had been misread for weeks as "CI is slow", "the
+  runners are slow", and "cancelled means flaky". It also **ghosted the
+  v0.21.14 release** (the tag pushed; PyPI got nothing).
+- **`agent_send` declared every live peer "stopped" (#657).** In a
+  container `$HOME` is `/home/agent`, so the peer lookup resolved a
+  private, empty state DB and reported `not running` for agents that were
+  answering messages at that moment. It now brokers to the host `sac
+  listen` through the same door `agent_status` and `agent_spawn` already
+  use. Bare-host behaviour unchanged. An unreachable broker, an ACL deny,
+  or a 5xx now yields **UNKNOWN — never "stopped"**: failing to *ask*
+  is not evidence of death.
+- **`restart` reported a restart that never happened (#656).** The stop
+  leg warned "previous runtime still running … proceeding to start
+  anyway", walked into the duplicate-session collision it had just
+  predicted, and printed success over the survivor. It now escalates
+  SIGTERM → SIGKILL against the tmux **pane** pid (the launcher exits
+  immediately; killing it would look like a fix and do nothing) and
+  raises `StopEscalationError` rather than starting on top of a live
+  process.
+- **`listen` asserted a cause nobody measured (#656).** "the broker is
+  unreachable; it may be flapping" was emitted on any transport timeout —
+  while the daemon was up and serving. Both clients now probe the
+  unauthenticated `/v1/health` **before** naming a cause, and say which
+  case they actually observed. The word "flapping" appears nowhere in
+  that path: nothing on it can see a crash loop, so nothing on it may
+  claim one.
+- **A tmux-green agent could hide a dead token (#646).** `sac agents
+  list` now surfaces **auth-failed** as distinct from `running` — a live
+  session wrapper is not evidence the Claude inside it can make an API
+  call. `--all-running` reaches auth-failed agents for `stop` too, not
+  just `restart`.
+- **Tests read and wrote the live fleet registry (#641).** An isolation
+  fixture set `$HOME`, but the DB path is a module-level constant
+  computed at **import** time — an env override cannot redirect it. The
+  fixture only *looked* like isolation while the tests hit the real
+  registry. Both read-paths are now redirected.
+
 ### Added
 - **`sac ports`** — read-only port-hygiene inventory. One command shows
   every port sac uses with live status: the `sac listen` control-plane

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.14"
+version = "0.21.15"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Honesty release. Every fix this cycle is the same bug wearing a different face: **something reported a state it had not observed.**

## The headline (#658)

`_off_loop.run_blocking` dispatched into the event loop's **shared default ThreadPoolExecutor**. A `concurrent.futures` future that is *already running* **cannot be cancelled** — so when the `wait_for` timed out, the worker thread was never stopped. It kept running the wedged call forever, still holding its pool slot. Six background loops did this on every overrunning tick.

The pool is `min(32, cpu_count+4)` — **6–8 threads** on a small host — and `asyncio.to_thread` uses **that same pool**. Once the slots were gone, *a task that needs a thread simply never runs*.

That explains, all at once:
- `sac listen` answering `/health` in 0.18s while **every authenticated route hung** (the fast path never touches the executor) — reported independently by two agents;
- brokered spawns stalling;
- on **Python 3.11, which the fleet runs**, `sac listen` being **unable to shut down at all** (pool workers are non-daemon; `shutdown_default_executor()` gained a timeout only in 3.12, so loop close joined an orphaned thread forever);
- the CI hang that had been misread for weeks as "flaky CI" / "the runners are slow", and which **ghosted the v0.21.14 release** (tag pushed, PyPI got nothing).

**The codebase already knew.** `_tui_heartbeat_loop.py` names the mechanism, names the consequence — *"which is how a slow heartbeat degraded into a fleet-wide comms outage"* — calls the leak *"deliberate"*, and the remedy applied was **a lock on that one loop** while five others kept draining the same pool. `_off_loop.py` itself had **zero tests**. That is how it shipped.

Fix: a dedicated **daemon** thread per call. An abandoned call leaks exactly one thread (unkillable in Python) but **starves nothing**, and outside the pool it is never joined at shutdown. Adds `abandoned_call_count()` — a silent leak is how this survived.

**Verified:** develop's py3.11 leg went **green in 10 min** (was CANCELLED at 35). The separate `uvicorn loopback did not start in 5s` failure passed in the same run — it was never a second bug: a server that "did not start" is a task that never got a thread.

## Also in this cycle

- **#657** — `agent_send` declared every live peer "stopped" (in-container $HOME resolved a private empty DB). Now brokers to the host. Unreachable broker → **UNKNOWN, never "stopped"**.
- **#656** — `restart` reported a restart that never happened; `listen` asserted "it may be flapping" without measuring. Both fixed; "flapping" appears nowhere in that path.
- **#646** — a tmux-green agent could hide a dead token. `sac agents list` now surfaces auth-failed.
- **#641** — `sac ports`; plus tests that were reading *and writing* the live fleet registry through a fixture that only looked like isolation.
- **#655** — the pytest matrix had no `timeout-minutes`. Adding one is what made the hang **visible** — it did not fix it, it produced the evidence.

Not included: #644 (liveness-tick), still finishing CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)