### PR TITLE
release: v0.21.15 — the shared executor leaked threads until nothing could run

### DIFF
--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -13,6 +13,20 @@ jobs:
   test:
     name: pytest-matrix-on-ubuntu-py${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    # A hung leg used to run to GitHub's 6-HOUR default. This has bitten
+    # twice, both times invisibly — nothing failed, a job simply never
+    # finished:
+    #   * PR #594 burned 1h39m42s before the platform killed it, and the
+    #     run was then misread for days as "the self-hosted runners are
+    #     slow" (it never touched one — it was cancelled mid-run by a
+    #     repository transfer).
+    #   * A duplicate py3.11 leg hung for 40+ min while its two siblings
+    #     finished in 11, and — because these three are the REQUIRED
+    #     status checks on `main` — it held the v0.21.14 release PR at
+    #     mergeStateStatus=BLOCKED with every check actually passing.
+    # These jobs take ~11-12 min. 30 is ~2.5x headroom: generous for a
+    # slow runner, decisive against a hang.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,76 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.15] — 2026-07-14
+
+Honesty release. Every fix here is the same bug wearing a different face:
+**something reported a state it had not observed.** The headline (#658) is
+the one that had been doing real damage for weeks while looking like
+"flaky CI".
+
+### Fixed
+- **The shared executor leaked threads until nothing could run (#658).**
+  `_off_loop.run_blocking` dispatched via `loop.run_in_executor(None, …)`
+  — the event loop's **shared default `ThreadPoolExecutor`**. A
+  `concurrent.futures` future that is *already running* **cannot be
+  cancelled**, so when the `wait_for` timed out the worker thread was
+  never stopped: it kept running the wedged call forever, still holding
+  its slot in the pool. Six background loops did this on every
+  overrunning tick.
+  The default pool is only `min(32, cpu_count + 4)` — **6–8 threads** on
+  a small host — and `asyncio.to_thread` uses **that same pool**. So once
+  enough slots were gone, *a task that needs a thread simply never runs*:
+  a trivial `to_thread(lambda: "ok")` never executed. That is why
+  `sac listen` answered `/health` in 0.18s while **every authenticated
+  route hung** (the fast path never touches the executor), why brokered
+  spawns stalled, and — on Python 3.11, which is what the fleet runs —
+  why `sac listen` **could not shut down at all**: pool workers are
+  non-daemon, `shutdown_default_executor()` has no timeout before 3.12,
+  and loop close joined an orphaned thread forever.
+  Fix: a dedicated **daemon** thread per call. An abandoned call now
+  leaks exactly one thread (you cannot kill a running thread in Python)
+  but **starves nothing**, and outside the pool it is never joined at
+  shutdown. Adds an `abandoned_call_count()` gauge, because a silent leak
+  is how this survived. `_off_loop.py` had **zero tests** — that is how it
+  shipped; the new starvation tests were confirmed to *fail* against the
+  old dispatch.
+  This one defect had been misread for weeks as "CI is slow", "the
+  runners are slow", and "cancelled means flaky". It also **ghosted the
+  v0.21.14 release** (the tag pushed; PyPI got nothing).
+- **`agent_send` declared every live peer "stopped" (#657).** In a
+  container `$HOME` is `/home/agent`, so the peer lookup resolved a
+  private, empty state DB and reported `not running` for agents that were
+  answering messages at that moment. It now brokers to the host `sac
+  listen` through the same door `agent_status` and `agent_spawn` already
+  use. Bare-host behaviour unchanged. An unreachable broker, an ACL deny,
+  or a 5xx now yields **UNKNOWN — never "stopped"**: failing to *ask*
+  is not evidence of death.
+- **`restart` reported a restart that never happened (#656).** The stop
+  leg warned "previous runtime still running … proceeding to start
+  anyway", walked into the duplicate-session collision it had just
+  predicted, and printed success over the survivor. It now escalates
+  SIGTERM → SIGKILL against the tmux **pane** pid (the launcher exits
+  immediately; killing it would look like a fix and do nothing) and
+  raises `StopEscalationError` rather than starting on top of a live
+  process.
+- **`listen` asserted a cause nobody measured (#656).** "the broker is
+  unreachable; it may be flapping" was emitted on any transport timeout —
+  while the daemon was up and serving. Both clients now probe the
+  unauthenticated `/v1/health` **before** naming a cause, and say which
+  case they actually observed. The word "flapping" appears nowhere in
+  that path: nothing on it can see a crash loop, so nothing on it may
+  claim one.
+- **A tmux-green agent could hide a dead token (#646).** `sac agents
+  list` now surfaces **auth-failed** as distinct from `running` — a live
+  session wrapper is not evidence the Claude inside it can make an API
+  call. `--all-running` reaches auth-failed agents for `stop` too, not
+  just `restart`.
+- **Tests read and wrote the live fleet registry (#641).** An isolation
+  fixture set `$HOME`, but the DB path is a module-level constant
+  computed at **import** time — an env override cannot redirect it. The
+  fixture only *looked* like isolation while the tests hit the real
+  registry. Both read-paths are now redirected.
+
 ### Added
 - **`sac ports`** — read-only port-hygiene inventory. One command shows
   every port sac uses with live status: the `sac listen` control-plane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`sac ports`** — read-only port-hygiene inventory. One command shows
+  every port sac uses with live status: the `sac listen` control-plane
+  port (default 7878, resolved from `listen.port`) with its pidfile, and
+  every a2a sidecar port CLAIM read in ONE `port_allocator.list_claims()`
+  query (the same one-shot API `sac agents list` uses). Liveness is a
+  bounded TCP-connect probe (`--timeout`, default 0.3s, run
+  concurrently) so the command can never hang. Flags **CONFLICT** (two
+  owners on one port) and **ORPHAN** (a claim with nothing listening),
+  and prints a reference map of the scitex/sac port-assignment scheme
+  (7878 · a2a range · the 3129X GUI/dashboard block). `--json` emits a
+  machine-readable envelope. Mutates nothing — no claim is created,
+  released, or changed.
+
 ## [0.21.14] — 2026-07-13
 
 Incident-response release. The headline fix (#642) closes a fleet-wide

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.14"
+version = "0.21.15"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/_account/auth_failure_reason.py
+++ b/src/scitex_agent_container/_account/auth_failure_reason.py
@@ -1,0 +1,136 @@
+"""WHY an agent's auth is failing: REVOKED, or genuinely EXPIRED?
+
+THE LYING ERROR MESSAGE
+    Claude Code renders EVERY 401 as ``Login expired · Please run /login``.
+    On this fleet that text is usually **false**, and the falsehood is exactly
+    why the bug survived so long: it names a cause that did not happen and
+    prescribes a remedy that is not needed.
+
+    What actually happens (proven 2026-07-13, four agents died at once): the
+    credential file is shared, an agent runs its own OAuth refresh, that refresh
+    consumes the **single-use** ``refresh_token`` and rotates the access token —
+    and every OTHER process still holding the previous access token is
+    instantly **REVOKED**. Nothing expired. The token was taken away.
+
+THE DISCRIMINATOR (cheap, and decisive)
+    Read the agent's on-disk credential and compare ``claudeAiOauth.expiresAt``
+    to now:
+
+    * **expiresAt in the FUTURE** — the credential on disk is perfectly VALID, a
+      fresh process would authenticate with it right now, and yet this agent is
+      401-ing. The only way both can be true is that the token it holds IN
+      MEMORY is no longer the token on disk: it was rotated out from under it.
+      ⇒ ``revoked``. Remedy: **restart** — the agent re-reads the (valid) file
+      and recovers. No human, no re-login.
+    * **expiresAt in the PAST** — the credential really is past its lifetime.
+      ⇒ ``expired``. Remedy: **login** — new credentials must actually be minted.
+
+    That distinction is the whole value of this module: it is the difference
+    between a 5-second automated restart and dragging the operator out of bed to
+    re-authenticate. The banner cannot tell you which; ``expiresAt`` can.
+
+WHAT THIS MODULE WILL NOT DO
+    It does not claim an agent's auth IS failing — that is the watchdog's job
+    (it reads the pane; see ``_runners._tmux.auth_status``). This module only
+    explains a failure the watchdog has ALREADY established. Asked about a
+    healthy agent it would happily answer ``revoked``, which would be nonsense:
+    a valid on-disk credential is the NORMAL state. Diagnose only what is broken.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+__all__ = [
+    "REASON_EXPIRED",
+    "REASON_REVOKED",
+    "REASON_UNKNOWN",
+    "credential_path_for",
+    "diagnose_reason",
+    "remedy_for",
+]
+
+# The credential really is past ``expiresAt`` — a genuine expiry.
+REASON_EXPIRED = "expired"
+# The credential on disk is VALID, yet the agent 401s ⇒ the token it holds in
+# memory was rotated away by somebody else's refresh. NOT an expiry.
+REASON_REVOKED = "revoked"
+# No readable credential / no numeric ``expiresAt`` ⇒ we genuinely do not know.
+# We say so rather than guessing: a confident wrong cause is what got us here.
+REASON_UNKNOWN = "unknown"
+
+_REMEDY = {
+    # Re-reading the (already-valid) credential file is all that is needed, and
+    # only a restart makes the process do that — Claude Code never re-reads it.
+    REASON_REVOKED: "restart",
+    # Nothing on disk can authenticate; new credentials must be minted.
+    REASON_EXPIRED: "login",
+    # Restart first: it is cheap, safe, and cures the common (revoked) case. If
+    # the agent comes back still failing, it is the expired case in disguise.
+    REASON_UNKNOWN: "restart",
+}
+
+
+def remedy_for(reason: str) -> str:
+    """``"restart"`` or ``"login"`` — what actually fixes this failure."""
+    return _REMEDY.get(reason, "restart")
+
+
+def credential_path_for(config: object, *, home: Path | None = None) -> Path:
+    """The host-side ``.credentials.json`` that ``config``'s agent authenticates with.
+
+    Mirrors ``runtimes._apptainer_creds.resolve_cred_file``'s resolution — an
+    agent pinned to ``spec.claude.account`` reads that account's snapshot;
+    everyone else reads the host live file — but NEVER raises. That resolver
+    deliberately fails loudly (``PinnedAccountError``) on an absent/expired
+    snapshot because it gates agent START. We are only DESCRIBING an already-
+    broken agent, and an exception here would take out the whole fleet view.
+
+    ``home`` is the real filesystem root to resolve against (default: the actual
+    ``Path.home()``). It threads straight into ``account_store._store_path``,
+    which already takes ``home`` for exactly this reason — so a test can point
+    the whole resolution at a ``tmp_path`` holding real credential bytes instead
+    of patching the module's internals.
+    """
+    base = home if home is not None else Path.home()
+    account = getattr(getattr(config, "claude", None), "account", "") or ""
+    if not account:
+        return base / ".claude" / ".credentials.json"
+    from .._state.account_store import _store_path
+
+    return _store_path(None, base) / account / ".credentials.json"
+
+
+def diagnose_reason(
+    config: object,
+    *,
+    now: float | None = None,
+    home: Path | None = None,
+) -> str:
+    """Why is THIS agent's auth failing? One of the three ``REASON_*`` above.
+
+    Call only for an agent the watchdog has already flagged (see the module
+    docstring: a valid credential is the normal state, so this would answer
+    ``revoked`` for a perfectly healthy agent).
+
+    ``now`` and ``home`` are real-collaborator injection seams (wall clock,
+    filesystem root); production passes neither.
+
+    Never raises: an unreadable or malformed credential yields
+    :data:`REASON_UNKNOWN`, because "I could not tell" is a true statement and
+    a fabricated cause is not.
+    """
+    # stx-allow: fallback (reason: this only ANNOTATES an already-detected
+    # failure; a config/store hiccup must degrade to "unknown", never crash the
+    # watchdog or the agent list.)
+    try:
+        from .creds_sync import _read_oauth_expiry_seconds
+
+        expiry = _read_oauth_expiry_seconds(credential_path_for(config, home=home))
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return REASON_UNKNOWN
+    if expiry is None:
+        return REASON_UNKNOWN
+    reference = now if now is not None else time.time()
+    return REASON_EXPIRED if expiry <= reference else REASON_REVOKED

--- a/src/scitex_agent_container/_lifecycle/_listen_probe.py
+++ b/src/scitex_agent_container/_lifecycle/_listen_probe.py
@@ -1,0 +1,208 @@
+"""MEASURE the listen daemon before naming what is wrong with it.
+
+Shared by :mod:`._restart_client` and :mod:`._spawn_client`: when a
+brokered POST to the host ``sac listen`` gets no HTTP response, this
+module answers the ONLY question the caller can actually settle — *is
+the daemon down, or is it up and serving while the AUTHENTICATED route
+is wedged?* — by probing the cheap unauthenticated path.
+
+THE BUG THIS CLOSES (card ``sac-restart-prints-success-after-start-failed``,
+2026-07-14). An agent trying to recover a peer got::
+
+    cannot reach listen at 'http://127.0.0.1:7878' (timed out) — the host
+    listen broker is unreachable; it may be flapping. Restart it on the
+    host with `sac listen restart`.
+
+Every clause after the parenthesis was invented. The reporter measured::
+
+    GET  /health           (unauthenticated) -> HTTP 401 in 0.18s, twice
+    GET  /agents           (with bearer)     -> no response in 10s
+    POST /agents/<n>/restart (with bearer)   -> no response in 25s
+
+The daemon was UP and answering in under a fifth of a second. It was not
+"unreachable" and there was not one shred of evidence for "flapping" — a
+word that asserts a process is crash-looping, which nobody had looked at.
+A timeout on ONE route licenses a claim about THAT ROUTE, and nothing more.
+
+WHY THE SPLIT IS REAL (it is not an accident of routing)
+--------------------------------------------------------
+``BearerAuthMiddleware.PUBLIC_PATHS`` exempts ``/v1/health``, and both
+that route and the middleware's own 401 are ``async`` — they answer ON the
+event loop. Every AUTHENTICATED route dispatches through the shared worker
+pool. So a pool exhausted by stacked-up work wedges the authed routes while
+the public path stays fast: exactly the 0.18s-401 / 25s-timeout split that
+was observed. (Root cause of that exhaustion — abandoned heartbeat ticks
+leaking zombie threads into the pool — is fixed in PR #647; this module is
+about not LYING when it happens again for some other reason.)
+
+CONTRACT: any HTTP response at all — 200, 401, 403, 404 — proves the daemon
+is UP and serving HTTP. Only the ABSENCE of an HTTP exchange (connection
+refused / DNS / timeout) is evidence of "unreachable". We report what we
+measured and never more than that: the word "flapping" appears nowhere in
+this module's output, because nothing here can observe a crash loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "HealthProbe",
+    "probe_listen_health",
+    "transport_failure_message",
+]
+
+# The one path ``BearerAuthMiddleware`` exempts (``PUBLIC_PATHS``), served
+# by an ``async`` handler that never touches the shared worker pool.
+HEALTH_PATH = "/v1/health"
+
+# The probe must be CHEAP: it runs inside the failure path of a request
+# that has ALREADY timed out, so it must not add another long wait. A
+# healthy listen answers /v1/health in ~0.2s; 5s is 25x that.
+_DEFAULT_PROBE_TIMEOUT_S = 5.0
+
+
+@dataclass(frozen=True)
+class HealthProbe:
+    """What an UNAUTHENTICATED ``GET /v1/health`` actually did.
+
+    ``serving`` is the load-bearing field and it means exactly one thing:
+    an HTTP response arrived. NOT "the daemon is healthy" — a 401 is a
+    perfectly good proof of serving. Callers must not upgrade it into a
+    broader claim.
+    """
+
+    serving: bool
+    status: int | None
+    elapsed_s: float
+    error: str | None
+    url: str
+
+    def evidence(self) -> str:
+        """One line of what we measured — quotable in an error message."""
+        if self.serving:
+            return (
+                f"an unauthenticated GET {self.url} answered HTTP "
+                f"{self.status} in {self.elapsed_s:.2f}s"
+            )
+        return (
+            f"an unauthenticated GET {self.url} also got no HTTP response "
+            f"({self.error}) after {self.elapsed_s:.2f}s"
+        )
+
+
+def probe_listen_health(
+    base: str,
+    *,
+    timeout_s: float = _DEFAULT_PROBE_TIMEOUT_S,
+    opener: Optional[Callable] = None,
+) -> HealthProbe:
+    """GET ``{base}/v1/health`` with NO Authorization header. Never raises.
+
+    Deliberately unauthenticated: sending the bearer would route the probe
+    through the very code path we are trying to rule in or out, and would
+    hang with it. The point is to exercise the path that CANNOT be wedged
+    by a starved worker pool.
+    """
+    url = f"{base.rstrip('/')}{HEALTH_PATH}"
+    opener_fn = opener if opener is not None else urlrequest.urlopen
+    req = urlrequest.Request(url, method="GET", headers={"Accept": "application/json"})
+    started = time.monotonic()
+    try:
+        with opener_fn(req, timeout=timeout_s) as resp:
+            resp.read()
+            status = int(getattr(resp, "status", 200))
+        return HealthProbe(
+            serving=True,
+            status=status,
+            elapsed_s=time.monotonic() - started,
+            error=None,
+            url=url,
+        )
+    except urlerror.HTTPError as exc:
+        # A RESPONSE. 401/403/404 all prove the daemon is up and serving —
+        # the reporter's own evidence was a 401. HTTPError subclasses
+        # URLError, so this MUST be caught first or a serving daemon would
+        # be misfiled as unreachable (the exact bug, one level down).
+        return HealthProbe(
+            serving=True,
+            status=int(getattr(exc, "code", 0)) or None,
+            elapsed_s=time.monotonic() - started,
+            error=None,
+            url=url,
+        )
+    except (urlerror.URLError, OSError, ValueError) as exc:
+        # No HTTP exchange at all: connection refused / DNS / timeout.
+        return HealthProbe(
+            serving=False,
+            status=None,
+            elapsed_s=time.monotonic() - started,
+            error=str(getattr(exc, "reason", None) or exc),
+            url=url,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: this probe runs INSIDE another failure path — it exists to IMPROVE an error message and must never replace it with a crash. Any unexpected failure degrades to an honest "could not measure".)  # noqa: BLE001
+        logger.warning("listen health probe raised unexpectedly: %s", exc)
+        return HealthProbe(
+            serving=False,
+            status=None,
+            elapsed_s=time.monotonic() - started,
+            error=f"probe failed: {exc}",
+            url=url,
+        )
+
+
+def transport_failure_message(
+    *,
+    verb: str,
+    name: str,
+    base: str,
+    route: str,
+    exc: BaseException,
+    timeout_s: float,
+    probe: HealthProbe,
+) -> str:
+    """The honest message for a brokered POST that got no HTTP response.
+
+    Two cases, and they are the two the caller can actually TELL APART:
+
+      * the daemon answered the cheap path → it is UP; the AUTHENTICATED
+        route is what failed. Say that, and only that.
+      * the daemon answered nothing at all → it is genuinely unreachable.
+        Say that, and still do not speculate about *why*.
+
+    ``verb`` is the operation ("restart" / "spawn"), ``route`` the path
+    that timed out (e.g. ``POST /agents/x/restart``).
+    """
+    if probe.serving:
+        return (
+            f"{verb} of {name!r} failed: {route} to {base!r} got no response "
+            f"within {timeout_s:.0f}s ({exc}).\n"
+            f"MEASURED (not guessed): {probe.evidence()} — so the listen "
+            f"daemon is UP and serving. The daemon is NOT down and this is "
+            f"NOT a 'broker unreachable' failure: it is the AUTHENTICATED "
+            f"route that did not answer.\n"
+            f"Why the two differ: authenticated routes dispatch through "
+            f"listen's shared worker pool; the public {HEALTH_PATH} path is "
+            f"served on the event loop and never touches it. A pool exhausted "
+            f"by stacked-up work therefore wedges one and leaves the other "
+            f"fast.\n"
+            f"Fix: `sac listen restart` on the host clears the wedged pool. "
+            f"If it recurs, the host's sac predates the fix for the heartbeat "
+            f"ticks that leaked threads into that pool (PR #647) — upgrade sac "
+            f"on the host."
+        )
+    return (
+        f"{verb} of {name!r} failed: cannot reach listen at {base!r} ({exc}).\n"
+        f"MEASURED (not guessed): {probe.evidence()} — nothing is serving HTTP "
+        f"at this URL, so the daemon is DOWN or the URL/port is wrong.\n"
+        f"Fix: start it on the host with `sac listen restart` (an atomic "
+        f"stop-clean-relaunch) and retry; escalate to the operator only if it "
+        f"stays down."
+    )

--- a/src/scitex_agent_container/_lifecycle/_off_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_off_loop.py
@@ -15,22 +15,57 @@ error logged. A full silent fleet-comms outage.
 
 This helper makes that class of bug impossible: every blocking call a
 loop makes goes through :func:`run_blocking`, which (1) dispatches the
-call to a thread via ``run_in_executor`` so it never occupies the loop
-thread, and (2) wraps it in ``asyncio.wait_for`` so a wedged call can
-never hang forever — it raises :class:`asyncio.TimeoutError` after
-``timeout_s`` and the caller logs + degrades instead of blocking the
-fleet.
+call to a thread so it never occupies the loop thread, and (2) wraps it
+in ``asyncio.wait_for`` so a wedged call can never hang forever — it
+raises :class:`asyncio.TimeoutError` after ``timeout_s`` and the caller
+logs + degrades instead of blocking the fleet.
+
+DEDICATED THREADS, NOT THE SHARED DEFAULT EXECUTOR
+--------------------------------------------------
+The dispatch deliberately spawns a fresh daemon thread per call instead
+of ``loop.run_in_executor(None, ...)``. That is not a style choice — the
+executor form reintroduced, by a longer route, the exact fleet-comms
+hang this module exists to prevent:
+
+A ``concurrent.futures`` future whose function is ALREADY RUNNING cannot
+be cancelled. So when ``wait_for`` times out, the worker thread is NOT
+stopped — it keeps running the wedged call forever, permanently holding
+its slot in the event loop's *shared* default ``ThreadPoolExecutor``.
+That pool is only ``min(32, os.cpu_count() + 4)`` threads — just 6-8 on
+a 2-4 core CI runner. Six background loops (tui/sdk heartbeat, liveness
+tick, bind watchdog, gh CI poll, periodic drive) each abandon a thread
+every time a tick overruns, so the pool drains steadily. Once it is
+empty, EVERY other user of the default executor starves — and the rest
+of the codebase reaches that same pool through *unbounded*
+``asyncio.to_thread`` calls (the ``/agents`` spawn handler's brokered
+launch, ``_host_exec``, ``_agent_exec_send``, ``_forward``). Those have
+no ``wait_for`` to save them: they queue behind the wedged threads and
+hang FOREVER. Measured: after ``max_workers`` timed-out ``run_blocking``
+calls, a trivial ``to_thread(lambda: "ok")`` never runs at all. This is
+version-independent (reproduced identically on 3.11 and 3.12); it simply
+bites soonest where the pool is smallest, which is why it surfaced as an
+intermittent "only on the CI runner" hang of the pytest suite.
+
+A dedicated daemon thread per call restores the intended semantics: an
+abandoned call leaks exactly ONE thread (unavoidable — Python cannot
+kill a thread blocked in a syscall) and can never starve anything else.
+The threads are daemons, so a wedged probe also cannot hold interpreter
+exit open.
 
 Fail-loud (operator: "when failure occurs, fail loud"): a timeout is
 returned to the caller as an explicit exception (or, via
 :func:`run_blocking_or`, a sentinel default + a logged ERROR naming the
-op), never silently swallowed into an indistinguishable success.
+op), never silently swallowed into an indistinguishable success. The
+count of still-wedged abandoned calls is tracked and logged loudly once
+it crosses :data:`_ABANDONED_WARN_THRESHOLD`, so a genuinely stuck host
+is visible instead of quietly leaking threads.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from typing import Any, Callable, TypeVar
 
 logger = logging.getLogger(__name__)
@@ -44,6 +79,45 @@ T = TypeVar("T")
 # take the whole fleet's comms down.
 DEFAULT_BLOCKING_TIMEOUT_S = 5.0
 
+# Abandoned calls still running past their deadline. A couple is normal on
+# a loaded host (a slow probe that eventually returns); a persistently high
+# count means a genuinely stuck subprocess/socket and is worth an ERROR.
+_ABANDONED_WARN_THRESHOLD = 8
+
+_abandoned_lock = threading.Lock()
+_abandoned_count = 0
+
+
+def abandoned_call_count() -> int:
+    """Off-loop calls that timed out and whose thread is STILL running.
+
+    Diagnostic gauge for the fail-loud path (and the regression test that
+    pins "an abandoned call must not starve unrelated off-loop work").
+    """
+    with _abandoned_lock:
+        return _abandoned_count
+
+
+def _mark_abandoned(op: str) -> None:
+    global _abandoned_count
+    with _abandoned_lock:
+        _abandoned_count += 1
+        current = _abandoned_count
+    if current >= _ABANDONED_WARN_THRESHOLD:
+        logger.error(
+            "off_loop: %d abandoned blocking calls are STILL wedged (latest: "
+            "%s). Each leaks one daemon thread. A stuck subprocess "
+            "(gh/tmux/ssh) or an unresponsive host is the usual cause.",
+            current,
+            op,
+        )
+
+
+def _clear_abandoned() -> None:
+    global _abandoned_count
+    with _abandoned_lock:
+        _abandoned_count -= 1
+
 
 async def run_blocking(
     fn: Callable[..., T],
@@ -53,21 +127,70 @@ async def run_blocking(
 ) -> T:
     """Run a blocking ``fn(*args, **kwargs)`` off the loop, bounded.
 
-    The call is dispatched to the default thread-pool executor so it
-    never occupies the event-loop thread, and bounded by ``timeout_s``
-    via :func:`asyncio.wait_for`. Raises :class:`asyncio.TimeoutError`
-    if the call does not finish in time (the underlying thread is left
-    to finish/abandon — we do NOT join it, so a wedged child can never
-    block the loop). Any exception ``fn`` raises propagates unchanged.
+    The call is dispatched to a DEDICATED daemon thread — never the event
+    loop's shared default executor — so it neither occupies the loop
+    thread nor competes for the pool that ``asyncio.to_thread`` callers
+    depend on. It is bounded by ``timeout_s`` via :func:`asyncio.wait_for`
+    and raises :class:`asyncio.TimeoutError` if the call does not finish
+    in time. The underlying thread is left to finish/abandon — we do NOT
+    join it, so a wedged child can never block the loop; because the
+    thread is private to this call, abandoning it starves nothing (see the
+    module docstring: doing this on the shared executor is what made a
+    wedged probe hang the whole process). Any exception ``fn`` raises
+    propagates unchanged.
     """
     loop = asyncio.get_running_loop()
+    future: asyncio.Future[T] = loop.create_future()
+    op = getattr(fn, "__name__", "call")
+    # Guards the abandoned/finished handoff so a call that completes at the
+    # same instant its deadline fires is counted exactly once.
+    state_lock = threading.Lock()
+    finished = False
+    abandoned = False
 
-    def _call() -> T:
-        return fn(*args, **kwargs)
+    def _deliver(result: Any, exc: BaseException | None) -> None:
+        # On the loop thread. If wait_for already timed out it cancelled the
+        # future and moved on — there is no awaiter left to deliver to.
+        if future.done():
+            return
+        if exc is not None:
+            future.set_exception(exc)
+        else:
+            future.set_result(result)
 
-    return await asyncio.wait_for(
-        loop.run_in_executor(None, _call), timeout=timeout_s
-    )
+    def _runner() -> None:
+        nonlocal finished
+        result: Any = None
+        exc: BaseException | None = None
+        try:
+            result = fn(*args, **kwargs)
+        except BaseException as caught:  # stx-allow: fallback (reason: relayed verbatim to the awaiter, never swallowed)
+            exc = caught
+        with state_lock:
+            finished = True
+            was_abandoned = abandoned
+        if was_abandoned:
+            # We outlived our deadline; nobody is waiting. Just stop counting.
+            _clear_abandoned()
+            return
+        try:
+            loop.call_soon_threadsafe(_deliver, result, exc)
+        except RuntimeError:  # stx-allow: fallback (reason: loop already closed — the awaiter is long gone; dropping the result is correct)
+            pass
+
+    threading.Thread(
+        target=_runner, name=f"sac-off-loop-{op}", daemon=True
+    ).start()
+    try:
+        return await asyncio.wait_for(future, timeout=timeout_s)
+    except asyncio.TimeoutError:
+        with state_lock:
+            newly_abandoned = not finished
+            if newly_abandoned:
+                abandoned = True
+        if newly_abandoned:
+            _mark_abandoned(op)
+        raise
 
 
 async def run_blocking_or(
@@ -105,6 +228,7 @@ async def run_blocking_or(
 
 __all__ = [
     "DEFAULT_BLOCKING_TIMEOUT_S",
+    "abandoned_call_count",
     "run_blocking",
     "run_blocking_or",
 ]

--- a/src/scitex_agent_container/_lifecycle/_restart_client.py
+++ b/src/scitex_agent_container/_lifecycle/_restart_client.py
@@ -276,13 +276,35 @@ def request_restart(
         # A 401/403 is NOT routed here (HTTPError is caught above first),
         # so an authenticated-but-rejected request never gets misreported
         # as 'cannot reach / timed out'.
-        logger.warning("restart_client: POST %s transport error: %s", url, exc)
+        #
+        # MEASURE before naming the cause. This used to assert "the host
+        # listen broker is unreachable; it may be flapping" — a diagnosis
+        # nobody had measured, and (2026-07-14) a WRONG one: the daemon was
+        # answering an unauthenticated GET in 0.18s while this authenticated
+        # POST hung. Probe the cheap public path and let the EVIDENCE pick
+        # the message. See ._listen_probe.
+        from ._listen_probe import probe_listen_health, transport_failure_message
+
+        probe = probe_listen_health(base, opener=opener)
+        logger.warning(
+            "restart_client: POST %s transport error: %s (probe: listen "
+            "serving=%s status=%s in %.2fs)",
+            url,
+            exc,
+            probe.serving,
+            probe.status,
+            probe.elapsed_s,
+        )
         raise RestartRequestError(
-            f"restart of {name!r} failed: cannot reach listen at {base!r} "
-            f"({exc}) — the host listen broker is unreachable; it may be "
-            f"flapping. Restart it on the host with `sac listen restart` (an "
-            f"atomic stop-clean-relaunch) and retry; escalate to the operator "
-            f"only if it stays down."
+            transport_failure_message(
+                verb="restart",
+                name=name,
+                base=base,
+                route=f"POST /agents/{name}/restart",
+                exc=exc,
+                timeout_s=timeout_s,
+                probe=probe,
+            )
         ) from exc
 
     parsed = _parse_body(raw)

--- a/src/scitex_agent_container/_lifecycle/_spawn_client.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_client.py
@@ -390,17 +390,38 @@ def request_spawn(
         ) from exc
     except (urlerror.URLError, OSError, ValueError) as exc:
         # No HTTP exchange happened — connection refused / DNS / timeout.
-        # This (and only this) is a genuine "unreachable" condition. A
-        # 401/403 is NOT routed here: ``HTTPError`` (a URLError subclass)
+        # A 401/403 is NOT routed here: ``HTTPError`` (a URLError subclass)
         # is caught above first, so an authenticated-but-rejected request
         # never gets misreported as 'cannot reach / timed out'.
-        logger.warning("spawn_client: POST %s transport error: %s", url, exc)
+        #
+        # But "no response on THIS route" is NOT yet "the daemon is
+        # unreachable" — the authenticated routes dispatch through listen's
+        # shared worker pool and the public health path does not, so one can
+        # hang while the other answers in 0.18s (observed 2026-07-14). The
+        # old text asserted "unreachable; it may be flapping" and was WRONG.
+        # Probe the cheap public path and let the EVIDENCE pick the message.
+        from ._listen_probe import probe_listen_health, transport_failure_message
+
+        probe = probe_listen_health(base, opener=opener)
+        logger.warning(
+            "spawn_client: POST %s transport error: %s (probe: listen "
+            "serving=%s status=%s in %.2fs)",
+            url,
+            exc,
+            probe.serving,
+            probe.status,
+            probe.elapsed_s,
+        )
         raise SpawnRequestError(
-            f"spawn of {child_name!r} failed: cannot reach listen at {base!r} "
-            f"({exc}) — the host listen broker is unreachable; it may be "
-            f"flapping. Restart it on the host with `sac listen restart` (an "
-            f"atomic stop-clean-relaunch) and retry; escalate to the operator "
-            f"only if it stays down."
+            transport_failure_message(
+                verb="spawn",
+                name=child_name,
+                base=base,
+                route="POST /agents",
+                exc=exc,
+                timeout_s=timeout_s,
+                probe=probe,
+            )
         ) from exc
 
     parsed = _parse_body(raw)

--- a/src/scitex_agent_container/_lifecycle/_stop.py
+++ b/src/scitex_agent_container/_lifecycle/_stop.py
@@ -23,18 +23,14 @@ from ._runtime_select import _get_runtime
 logger = logging.getLogger(__name__)
 
 # Default upper bound on how long ``agent_restart`` will wait for the
-# previous runtime to actually exit before starting the new one. Tuned
-# for apptainer healthy teardown (~0.5–2 s); 15 s leaves comfortable
-# headroom for a loaded host. The race this closes: new container boots
-# while the old one still holds /home/agent overlay + per-agent stdio MCP
-# child still holds its PID lock file → new bun child's ``acquireLock``
-# sees the live old PID and exits 1 → claude silently drops the MCP.
+# previous runtime to actually exit before ESCALATING to SIGKILL (see
+# :mod:`._stop_escalate`). Tuned for apptainer healthy teardown
+# (~0.5–2 s); 15 s leaves comfortable headroom for a loaded host. The
+# race this closes: new container boots while the old one still holds
+# /home/agent overlay + per-agent stdio MCP child still holds its PID
+# lock file → new bun child's ``acquireLock`` sees the live old PID and
+# exits 1 → claude silently drops the MCP.
 _DEFAULT_WAIT_FOR_STOP_TIMEOUT_S = 15.0
-# Poll interval while waiting. 0.25 s is small enough that a 1-second
-# teardown costs <=4 polls; large enough that a healthy host doesn't
-# spend measurable CPU on the loop. ``sleep_fn`` controls real-time
-# behavior; tests pass ``_no_sleep`` to spin as fast as Python allows.
-_WAIT_FOR_STOP_POLL_INTERVAL_S = 0.25
 
 
 def agent_stop(
@@ -177,56 +173,6 @@ def agent_stop_all(
     return results
 
 
-def _wait_for_previous_runtime_to_exit(
-    name: str,
-    config_path: str,
-    *,
-    runtime_factory: Optional[Callable[[AgentConfig], Any]],
-    sleep_fn: Callable[[float], None],
-    timeout_s: float,
-) -> bool:
-    """Block until the previous runtime instance is no longer running.
-
-    Returns True if the runtime stopped cleanly within ``timeout_s``,
-    False on timeout (caller proceeds anyway after a LOUD warning — see
-    ``agent_restart`` docstring for the race this closes). ``timeout_s
-    <= 0`` skips the gate entirely (legacy ``sleep_fn(2)`` behaviour,
-    preserved for callers that want the bypass).
-    """
-    if timeout_s <= 0:
-        sleep_fn(2)
-        return True
-    # Load once: config is stable across the gate and re-loading per poll
-    # would multiply YAML parsing on a busy host.
-    try:
-        config = load_config(config_path)
-    except Exception:  # stx-allow: fallback (reason: YAML may have been edited mid-restart; fall back to the legacy fixed sleep instead of blocking the restart on a transient parse error — the new container will surface the real error when it boots)
-        sleep_fn(2)
-        return True
-    factory = runtime_factory or _get_runtime
-    runtime = factory(config)
-    deadline = time.monotonic() + timeout_s
-    while runtime.is_running(config):
-        if time.monotonic() >= deadline:
-            logger.warning(
-                "agent_restart for %r: previous runtime still running after "
-                "%.2fs (SIGTERM ignored or teardown hung); proceeding to "
-                "start anyway. WARNING: this may trigger the apptainer "
-                'double-mount race ("destination is already in the mount '
-                'point list") and stdio-MCP lock-file contention (the '
-                "standalone bun telegrammer poller exits 1 on lock held by "
-                "the orphaned previous PID, claude then silently drops the "
-                "MCP). If %r repeatedly fails to honor SIGTERM, investigate "
-                "the runtime stop path (see ApptainerContainerRuntime.stop).",
-                name,
-                timeout_s,
-                name,
-            )
-            return False
-        sleep_fn(_WAIT_FOR_STOP_POLL_INTERVAL_S)
-    return True
-
-
 def agent_restart(
     name: str,
     registry: Registry | None = None,
@@ -265,22 +211,36 @@ def agent_restart(
     Teardown gate (2026-06-07, bug #42 — telegrammer drops after restart):
     Between ``agent_stop`` (which sends SIGTERM and returns immediately —
     ``ApptainerContainerRuntime.stop`` says "No wait loop yet — sac's
-    outer lifecycle does its own poll") and ``agent_start``, this function
-    now polls ``runtime.is_running`` until False or
-    ``wait_for_stop_timeout_s`` elapses. The legacy fixed ``sleep_fn(2)``
-    was the SOLE settle window — it raced the apptainer teardown on a
-    loaded host. Operator-visible symptom: the new container booted while
-    the old one still held the ``/home/agent`` overlay (apptainer warned
-    "destination is already in the mount point list"), AND the old SDK's
-    per-agent stdio MCP child (the standalone bun telegrammer poller)
-    was still alive holding ``$HOME/.claude-code-telegrammer-*/...lock``.
-    The new bun child's ``acquireLock`` then hit ``process.kill(old_pid,
-    0)`` SUCCESS → ``process.exit(1)``, claude silently marked the MCP
-    failed and never retried it. ``sac`` + Mermaid MCPs reloaded fine
-    (no inter-instance lock for those), masking the bug as "only Telegram
-    broke." On timeout we LOG LOUD (so a stuck previous instance is
-    self-diagnosing from stdout.log) and proceed — silently spinning
-    forever locks the operator out of restart entirely.
+    outer lifecycle does its own poll") and ``agent_start``,
+    :func:`._stop_escalate.ensure_previous_runtime_down` polls
+    ``runtime.is_running`` until False or ``wait_for_stop_timeout_s``
+    elapses. The legacy fixed ``sleep_fn(2)`` was the SOLE settle window —
+    it raced the apptainer teardown on a loaded host. Operator-visible
+    symptom: the new container booted while the old one still held the
+    ``/home/agent`` overlay (apptainer warned "destination is already in
+    the mount point list"), AND the old SDK's per-agent stdio MCP child
+    (the standalone bun telegrammer poller) was still alive holding
+    ``$HOME/.claude-code-telegrammer-*/...lock``. The new bun child's
+    ``acquireLock`` then hit ``process.kill(old_pid, 0)`` SUCCESS →
+    ``process.exit(1)``, claude silently marked the MCP failed and never
+    retried it. ``sac`` + Mermaid MCPs reloaded fine (no inter-instance
+    lock for those), masking the bug as "only Telegram broke."
+
+    Gate ESCALATES, then FAILS LOUD (2026-07-14 — restart printed success
+    over a DOWN agent): on grace-timeout the gate used to log LOUD and
+    proceed into the start anyway. That WARN literally predicted the
+    collision ("previous runtime still running ... proceeding to start
+    anyway") which then happened ("duplicate session 'tui-neurovista'"),
+    after which the CLI printed "Agent 'neurovista' restarted" over an
+    agent that was left DOWN. A stop that could not stop the thing must
+    not walk into a start that is guaranteed to collide with it. The gate
+    now escalates SIGTERM → SIGKILL (the normal forced-stop contract,
+    aimed at ``runtime.agent_pid`` — the TUI PANE pid, not the launcher
+    that already exited), re-verifies with the runtime's OWN
+    ``is_running``, and raises :class:`._stop_escalate.StopEscalationError`
+    when it still cannot confirm the agent is down — so ``agent_start``
+    below is never reached and no success line is printed. See
+    :mod:`._stop_escalate`.
 
     Args:
         name: Agent name.
@@ -293,15 +253,20 @@ def agent_restart(
             :func:`config.resolve_config`). Injected for tests so the
             no-registry-row fallback can be exercised against a real
             on-disk spec without monkeypatching internals.
-        wait_for_stop_timeout_s: Upper bound on the previous-runtime
-            readiness gate (see "Teardown gate" above). Default 15 s —
-            ~10× a healthy apptainer teardown. Set to 0 to skip the gate
-            entirely (legacy behaviour, retained for tests of unrelated
-            code paths).
+        wait_for_stop_timeout_s: SIGTERM grace for the previous-runtime
+            gate (see "Teardown gate" above) before it escalates to
+            SIGKILL. Default 15 s — ~10× a healthy apptainer teardown.
+            Set to 0 to skip the gate entirely (legacy behaviour,
+            retained for tests of unrelated code paths).
 
     Raises:
         RuntimeError: When ``name`` has neither a registry row NOR a
             resolvable spec — a genuinely unknown agent.
+        StopEscalationError: When the previous runtime survived both
+            SIGTERM and SIGKILL. The start leg is NOT run (it would
+            collide with the survivor), so the agent is left as it was —
+            still UP as the OLD process — and the caller reports a
+            FAILED restart rather than a fictional success.
     """
     # Lazy import breaks the ``_start`` <-> ``_stop`` cycle.
     from ._start import agent_start
@@ -361,7 +326,11 @@ def agent_restart(
         runtime_factory=runtime_factory,
         handover_mod=handover_mod,
     )
-    _wait_for_previous_runtime_to_exit(
+    # Escalate (SIGKILL) or RAISE — never "proceed to start anyway" into a
+    # collision this gate already knows is coming. See ._stop_escalate.
+    from ._stop_escalate import ensure_previous_runtime_down
+
+    ensure_previous_runtime_down(
         name,
         config_path,
         runtime_factory=runtime_factory,
@@ -405,19 +374,23 @@ def agent_restart(
     # guard, which is *idempotent for a plain `sac agents start`* (an
     # already-running agent is "fine, it's up") and therefore RETURNS TRUE. For
     # a restart that verdict is a LIE: the caller asked for a new process and
-    # got the old one. The failure mode is not theoretical — it happens exactly
-    # when the stop leg above could not kill the old runtime (SIGTERM ignored,
-    # ``_wait_for_previous_runtime_to_exit`` returned False and we proceeded
-    # anyway). Then: stale session survives -> start no-ops -> returns True ->
-    # the CLI prints "Agent '<name>' restarted". The operator hit precisely
-    # this on neurovista: he believed it had relaunched on freshly-picked
-    # credentials, was in fact still talking to the OLD process on its OLD
-    # token, saw "Login expired", and went diagnosing a credential store that
-    # was entirely healthy.
+    # got the old one. The failure mode was not theoretical — it happened
+    # exactly when the stop leg could not kill the old runtime (SIGTERM
+    # ignored) and the gate PROCEEDED ANYWAY. Then: stale session survives ->
+    # start no-ops -> returns True -> the CLI prints "Agent '<name>' restarted".
+    # The operator hit precisely this on neurovista: he believed it had
+    # relaunched on freshly-picked credentials, was in fact still talking to the
+    # OLD process on its OLD token, saw "Login expired", and went diagnosing a
+    # credential store that was entirely healthy.
     #
-    # So a restart FORCES: the force branch tears the stale session down first,
-    # which both makes the restart actually happen and makes a genuine failure
-    # report as a failure.
+    # Belt AND braces, because they fail differently:
+    #   * the GATE above (``ensure_previous_runtime_down``) means we only reach
+    #     this line once the previous runtime is CONFIRMED down — a survivor
+    #     raises instead of falling through into a guaranteed collision;
+    #   * ``force=True`` here means that even a session the gate could not SEE
+    #     (a runtime whose ``is_running`` reads False while a stale tmux session
+    #     lingers) is torn down by the start leg rather than silently no-op'd
+    #     into a fictional success.
     return agent_start(
         config_path,
         registry,

--- a/src/scitex_agent_container/_lifecycle/_stop_escalate.py
+++ b/src/scitex_agent_container/_lifecycle/_stop_escalate.py
@@ -1,0 +1,323 @@
+"""The restart's stop leg, made honest: SIGTERM → SIGKILL → fail loud.
+
+Extracted from :mod:`._stop` (512-line cap) so the whole "is the previous
+runtime ACTUALLY down?" decision lives in ONE testable place.
+
+THE BUG THIS CLOSES (operator terminal, 2026-07-14, card
+``sac-restart-prints-success-after-start-failed``)::
+
+    WARN: previous runtime still running after 15.00s (SIGTERM ignored...);
+          proceeding to start anyway.
+    FAIL: duplicate session 'tui-neurovista' — agent already running.
+    Agent 'neurovista' restarted        <-- IT WAS NOT
+
+Read those three lines in order. The stop leg PREDICTED the collision
+("still running"), shrugged, and walked into it; the collision then
+happened exactly as predicted; and the restart reported success over an
+agent that was left DOWN. The gate had all the information needed to stop
+— and used it only to narrate the failure it was about to cause.
+
+The old ``_wait_for_previous_runtime_to_exit`` returned ``False`` on
+timeout and its ONLY caller (``agent_restart``) discarded the value. A
+verdict nobody reads is not a verdict.
+
+WHY ESCALATE (SIGKILL) RATHER THAN ONLY FAIL LOUD
+-------------------------------------------------
+A restart's contract is to REPLACE the process, and the standard contract
+for a forced stop everywhere else in the industry is SIGTERM, a grace
+window, then SIGKILL (systemd ``TimeoutStopSec``, ``docker stop``,
+kubelet). sac already had the SIGTERM and the 15 s grace; the escalation
+step was simply missing. Refusing to escalate would mean sac cannot
+restart an agent whose claude TUI is wedged mid-render and no longer
+reaping signals — which is precisely the population that most needs a
+restart. So: escalate FIRST, and fail loud only when the escalation
+itself cannot be confirmed.
+
+Both halves are required. Escalation without the fail-loud is just a
+longer path to the same lie (SIGKILL can fail: no resolvable pid on a
+remote/containerised runtime, an EPERM, or a process wedged in
+uninterruptible-``D`` I/O where SIGKILL cannot land until the syscall
+returns). Fail-loud without escalation would abort restarts that a single
+``kill -9`` would have fixed.
+
+KILL THE RIGHT PROCESS
+----------------------
+:meth:`RuntimeBase.agent_pid` — NOT the launcher. For a TUI agent the
+launcher spawns the tmux session and exits within seconds; the LONG-LIVED
+process is the pane pid (the pane's ``bash -c`` ``exec``s apptainer, and
+``exec`` keeps the pid). SIGKILLing a launcher pid would look right in the
+log and do nothing — and, pids being reused, could kill an unrelated
+process. ``agent_pid`` is contractually the same signal the runtime's own
+``is_running`` keys its verdict on, so "the thing we killed" and "the thing
+that is still running" cannot drift apart. A runtime that cannot name a
+local pid (docker / SSHRemote) returns ``None`` — honestly unknown — and we
+fail loud instead of guessing.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import time
+from typing import Any, Callable, Optional
+
+from ..config import AgentConfig, load_config
+from ._runtime_select import _get_runtime
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "StopEscalationError",
+    "ensure_previous_runtime_down",
+    "escalate_to_sigkill",
+    "long_lived_pid",
+]
+
+# How long to wait for the runtime to read as stopped AFTER SIGKILL.
+# SIGKILL is not negotiable, but reaping is not instantaneous: the kernel
+# tears the process down and (for a TUI agent) tmux must then notice the
+# pane died and close the session. 5 s is ~50x the observed teardown.
+_DEFAULT_SIGKILL_SETTLE_S = 5.0
+# Poll interval for both the SIGTERM grace and the post-SIGKILL settle.
+_POLL_INTERVAL_S = 0.25
+
+
+class StopEscalationError(RuntimeError):
+    """The previous runtime survived SIGTERM *and* SIGKILL.
+
+    Raised INSTEAD of proceeding into a start leg that is now GUARANTEED to
+    collide with the survivor (duplicate session) — the collision the old
+    code predicted in a WARN and then caused. Carries ``name`` / ``pid`` so
+    a structured caller can act without re-parsing the message.
+    """
+
+    def __init__(self, message: str, *, name: str, pid: int | None = None) -> None:
+        super().__init__(message)
+        self.name = name
+        self.pid = pid
+
+
+def long_lived_pid(runtime: Any, config: AgentConfig) -> int | None:
+    """The runtime's LONG-LIVED pid, or ``None`` when it cannot be named.
+
+    Thin, defensive read of the :meth:`RuntimeBase.agent_pid` seam.
+    ``None`` is an honest "unknown" and the caller MUST treat it as "cannot
+    escalate" — never as "nothing to kill".
+
+    Refuses to hand back a pid that must never be signalled:
+
+      * ``pid <= 0`` — ``os.kill(0, SIGKILL)`` signals sac's ENTIRE process
+        group and ``os.kill(-1, ...)`` signals every process this user owns.
+        A runtime bug that returned 0 would otherwise turn one wedged agent
+        into a fleet-wide massacre.
+      * our own pid — sac would kill itself mid-restart.
+    """
+    getter = getattr(runtime, "agent_pid", None)
+    if getter is None:
+        return None
+    try:
+        pid = getter(config)
+    except Exception:  # stx-allow: fallback (reason: a pid-probe hiccup is "unknown", never a fabricated pid — a wrong/reused pid would get an unrelated process SIGKILLed)
+        logger.warning(
+            "stop-escalation: agent_pid() probe failed for %r; cannot escalate",
+            getattr(config, "name", "?"),
+            exc_info=True,
+        )
+        return None
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return None
+    if pid == os.getpid():
+        logger.error(
+            "stop-escalation: agent_pid() returned OUR OWN pid (%s) for %r — "
+            "refusing to SIGKILL sac itself. This is a runtime bug.",
+            pid,
+            getattr(config, "name", "?"),
+        )
+        return None
+    return pid
+
+
+def _send_sigkill(pid: int, *, kill_fn: Callable[[int, int], None]) -> bool:
+    """SIGKILL ``pid``. True iff the signal landed or the process was gone.
+
+    ``ProcessLookupError`` is SUCCESS: the goal is "that process is not
+    running", and it already is not. ``PermissionError`` / ``OSError`` are
+    honest failures — we could not kill it, so we must not claim we did.
+    """
+    try:
+        kill_fn(pid, signal.SIGKILL)
+        return True
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        logger.error(
+            "stop-escalation: not permitted to SIGKILL pid %s (owned by "
+            "another user?) — cannot force the previous runtime down.",
+            pid,
+        )
+        return False
+    except OSError:
+        logger.error(
+            "stop-escalation: SIGKILL of pid %s failed", pid, exc_info=True
+        )
+        return False
+
+
+def _poll_until_stopped(
+    runtime: Any,
+    config: AgentConfig,
+    *,
+    sleep_fn: Callable[[float], None],
+    timeout_s: float,
+    poll_interval_s: float = _POLL_INTERVAL_S,
+) -> bool:
+    """True as soon as ``runtime.is_running`` reads False; False on timeout."""
+    deadline = time.monotonic() + timeout_s
+    while runtime.is_running(config):
+        if time.monotonic() >= deadline:
+            return False
+        sleep_fn(poll_interval_s)
+    return True
+
+
+def escalate_to_sigkill(
+    name: str,
+    config: AgentConfig,
+    runtime: Any,
+    *,
+    sleep_fn: Callable[[float], None],
+    settle_s: float = _DEFAULT_SIGKILL_SETTLE_S,
+    kill_fn: Callable[[int, int], None] = os.kill,
+) -> tuple[bool, int | None]:
+    """SIGKILL the runtime's long-lived process; VERIFY it actually died.
+
+    Returns ``(stopped, pid)``. ``stopped`` is the runtime's OWN verdict
+    after the kill (``is_running`` read False within ``settle_s``) — never
+    "we sent the signal, so it must be down". ``pid`` is what we killed, or
+    ``None`` when the runtime could not name one (in which case no signal
+    was sent and ``stopped`` reflects the runtime as it stands).
+    """
+    pid = long_lived_pid(runtime, config)
+    if pid is None:
+        logger.error(
+            "stop-escalation: %r ignored SIGTERM and its runtime cannot name a "
+            "long-lived pid (agent_pid() -> None), so there is nothing to "
+            "SIGKILL. Not starting a replacement over a survivor.",
+            name,
+        )
+        return runtime.is_running(config) is False, None
+    logger.warning(
+        "stop-escalation: %r ignored SIGTERM — escalating to SIGKILL on pid %s "
+        "(the runtime's long-lived process, the same pid its is_running() keys "
+        "on). This is the normal forced-stop contract: TERM, grace, KILL.",
+        name,
+        pid,
+    )
+    if not _send_sigkill(pid, kill_fn=kill_fn):
+        return False, pid
+    return (
+        _poll_until_stopped(runtime, config, sleep_fn=sleep_fn, timeout_s=settle_s),
+        pid,
+    )
+
+
+def _remedy(name: str, config: AgentConfig, pid: int | None) -> str:
+    """Operator remedy that ACTUALLY works, sized to what we observed.
+
+    Deliberately NOT ``sac agents restart`` — when this fires, that is the
+    very command that just failed, so recommending it loops the operator
+    back into the failure (the same reasoning as ``tui_session``'s
+    duplicate-session guard).
+    """
+    lines: list[str] = []
+    if pid is not None:
+        lines.append(
+            f"  ps -o pid,ppid,stat,wchan,cmd -p {pid}"
+            f"   # STAT 'D' = uninterruptible I/O: SIGKILL cannot land until "
+            f"the syscall returns"
+        )
+    # "" and "tui" both select TuiSessionRuntime (see _runtime_select).
+    if (getattr(config, "runtime", "") or "").strip().lower() in ("", "tui"):
+        lines.append(f"  tmux kill-session -t tui-{name}")
+    lines.append(f"  sac agents start {name} -y --fresh")
+    return "\n".join(lines)
+
+
+def ensure_previous_runtime_down(
+    name: str,
+    config_path: str,
+    *,
+    runtime_factory: Optional[Callable[[AgentConfig], Any]],
+    sleep_fn: Callable[[float], None],
+    timeout_s: float,
+    settle_s: float = _DEFAULT_SIGKILL_SETTLE_S,
+    kill_fn: Callable[[int, int], None] = os.kill,
+) -> None:
+    """Guarantee the previous runtime is DOWN, or raise.
+
+    The restart's stop-leg gate. Returns normally ONLY when the runtime's
+    own ``is_running`` reads False — i.e. when the start leg can safely
+    replace it. Raises :class:`StopEscalationError` otherwise, so
+    ``agent_restart`` never walks into the duplicate-session collision and
+    never reports a restart that did not happen.
+
+      1. Poll ``is_running`` for ``timeout_s`` (the SIGTERM grace the
+         preceding ``agent_stop`` opened).
+      2. Still up → SIGKILL the long-lived pid, poll again for ``settle_s``.
+      3. STILL up → raise, loudly, with a remedy that works.
+
+    ``timeout_s <= 0`` skips the gate entirely (legacy fixed-sleep
+    behaviour, retained for callers that want the bypass), as does an
+    unloadable spec — a YAML edited mid-restart must not block the restart;
+    the new container surfaces the real parse error when it boots.
+    """
+    if timeout_s <= 0:
+        sleep_fn(2)
+        return
+    # Load once: the config is stable across the gate, and re-loading per
+    # poll would multiply YAML parsing on a busy host.
+    try:
+        config = load_config(config_path)
+    except Exception:  # stx-allow: fallback (reason: YAML may have been edited mid-restart; fall back to the legacy fixed sleep instead of blocking the restart on a transient parse error — the new container surfaces the real error when it boots)
+        sleep_fn(2)
+        return
+    factory = runtime_factory or _get_runtime
+    runtime = factory(config)
+
+    if _poll_until_stopped(runtime, config, sleep_fn=sleep_fn, timeout_s=timeout_s):
+        return
+
+    stopped, pid = escalate_to_sigkill(
+        name,
+        config,
+        runtime,
+        sleep_fn=sleep_fn,
+        settle_s=settle_s,
+        kill_fn=kill_fn,
+    )
+    if stopped:
+        logger.warning(
+            "stop-escalation: %r is down after SIGKILL (pid %s). The restart "
+            "continues; the agent had to be force-killed, which means its "
+            "runtime stop path did not honour SIGTERM — worth investigating "
+            "(see ApptainerContainerRuntime.stop / TuiSessionRuntime.stop).",
+            name,
+            pid,
+        )
+        return
+
+    killed = "SIGKILL" if pid is not None else "no pid to SIGKILL"
+    raise StopEscalationError(
+        f"restart of {name!r} ABORTED: the previous runtime is STILL RUNNING "
+        f"after SIGTERM ({timeout_s:.1f}s grace) and {killed}"
+        + (f" (pid {pid}, {settle_s:.1f}s settle)" if pid is not None else "")
+        + f" — its own is_running() still reports True.\n"
+        f"NOT starting a replacement: the start leg would collide with the "
+        f"survivor (duplicate session {name!r}) and the restart would then "
+        f"report success over a process that never died. {name!r} is still UP "
+        f"as the OLD process on its OLD credentials — it was NOT restarted.\n"
+        f"Diagnose, then recover:\n" + _remedy(name, config, pid),
+        name=name,
+        pid=pid,
+    )

--- a/src/scitex_agent_container/_runners/_session_conversation.py
+++ b/src/scitex_agent_container/_runners/_session_conversation.py
@@ -253,7 +253,7 @@ async def run_conversation(
         # stopped responding after restart) leaves a self-diagnosing
         # trail in stdout.log. The corresponding ``apptainer_restart``
         # mount + lock race that originally caused this is closed in
-        # ``_lifecycle/_stop.py::_wait_for_previous_runtime_to_exit``;
+        # ``_lifecycle/_stop_escalate.py::ensure_previous_runtime_down``;
         # this log is the OBSERVABILITY half so a regression of either
         # the race or the SDK's per-MCP launch is visible without
         # bouncing the agent or attaching to its stderr.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/42_tui-auth-watchdog.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/42_tui-auth-watchdog.md
@@ -35,9 +35,16 @@ There are **two** implementations. Do not confuse them.
 | | LIVE watchdog | PACKAGE matcher |
 |---|---|---|
 | File | `~/.scitex/agent-container/bin/tui_auth_detect.py` (dotfiles-tracked) | `src/scitex_agent_container/_runners/_tmux/auth_status.py` (merged PR #627) |
-| Consumed by | `auth-heal.py` **cron** — the actual running safety net | `sac agents auth-status` — **on-demand** CLI check |
+| Consumed by | `auth-heal.py` **cron** — the actual running safety net | `sac agents auth-status` — on-demand check **and the cache WRITER** |
 | Corroboration | frozen **whole-pane SHA-1 signature** across two runs | frozen **(banner-kind, distance-from-prompt)** across two runs + near-prompt gating |
-| Status | **this is what protects the fleet today** | hardened on-demand check + intended future replacement |
+| Status | **this is what protects the fleet today** | hardened check + intended future replacement |
+
+The package matcher does not only report — it **writes**. Its verdict is
+persisted, and `sac agents list` reads that cache, which is what lets the fleet
+view show `auth-failed` instead of a reassuring green `running`. That contract
+(what gets written, how a verdict ages, and why the status says `auth-failed`
+rather than repeating Claude's misleading *"Login expired"*) is in
+[46_agents-list-auth-cache.md](46_agents-list-auth-cache.md).
 
 **They are not wired together yet.** The near-prompt / distance heuristic
 (§5, in [43_tui-auth-watchdog-maintenance.md](43_tui-auth-watchdog-maintenance.md)) lives **only** in the package matcher; the LIVE cron watchdog still

--- a/src/scitex_agent_container/_skills/scitex-agent-container/44_agent-to-agent-recovery.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/44_agent-to-agent-recovery.md
@@ -108,10 +108,26 @@ ACL allows the dev/researcher groups):
   context-inheriting fork of a running agent is `agent_twin`.
 
 Escalate to the operator **only** when the host listen broker itself is
-down — a transport timeout / connection-refused on the spawn, which the
-enriched `cannot reach listen …` error now flags with the fix
-(`sac listen restart`). Anything short of a dead broker is yours to do,
-not the operator's to queue.
+down. Note what that does and does not mean: a **timeout on one route is
+not proof the daemon is down**. Authenticated routes dispatch through
+listen's shared worker pool; the public `/v1/health` path is served on the
+event loop and never touches it — so a starved pool wedges the authed
+routes while `/v1/health` still answers in milliseconds (observed
+2026-07-14: an unauthenticated GET answered in 0.18s while the
+authenticated POST hung for 25s).
+
+You do not have to reason about this: the spawn/restart clients now
+**probe the unauthenticated path before naming a cause** and say which
+case they measured —
+
+- *"the listen daemon is UP and serving … it is the AUTHENTICATED route
+  that did not answer"* → the daemon is alive; `sac listen restart` on the
+  host clears the wedged pool. Not an operator escalation.
+- *"cannot reach listen … nothing is serving HTTP at this URL"* → genuinely
+  down or the wrong URL/port. `sac listen restart`, then escalate only if
+  it stays down.
+
+Anything short of a dead broker is yours to do, not the operator's to queue.
 
 ## Imitate this
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/46_agents-list-auth-cache.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/46_agents-list-auth-cache.md
@@ -1,0 +1,71 @@
+---
+description: |
+  [TOPIC] Why `sac agents list` can show `auth-failed` — the persisted auth-verdict cache (`agent_auth_state`) that `sac agents auth-status` writes and the fleet view reads, so a tmux-green agent can no longer hide a dead token.
+  [DETAILS] Continues [42_tui-auth-watchdog.md](42_tui-auth-watchdog.md): the pane matcher's verdict is UPSERTed into the `agent_auth_state` table in `state.db` (`_state/auth_state.py`) and `sac agents list` reads that cache instead of probing auth inline (two pane captures seconds apart per agent would undo the list's latency budget). Covers the three properties that keep the cache from lying (only observed agents are written; verdicts carry `checked_at` and go STALE; a verdict older than the agent's `started_at` is discarded), and why the status asserts the VERIFIABLE `auth-failed` rather than Claude's misleading "Login expired" banner — with the `expiresAt`-based `revoked` / `expired` / `unknown` cause table (`_account/auth_failure_reason.py`) that separates an automated restart from waking the operator for a re-login. Load before touching `auth_state.py`, `auth_failure_reason.py`, `sac agents auth-status`, or the `sac agents list` status column.
+tags: [scitex-agent-container-agents-list-auth-cache, auth, list, cache, staleness]
+---
+
+# `sac agents list` and the persisted auth verdict
+
+Companion to [42_tui-auth-watchdog.md](42_tui-auth-watchdog.md) (the detection
+contract). That leaf explains how a wedged TUI agent is *detected*; this one
+explains how the detection reaches the **fleet view**, so an operator reading
+`sac agents list` sees the truth without running anything else.
+
+The problem being solved: a `tmux` session stays perfectly green while the
+Claude inside it is auth-dead and will never do another thing. On 2026-07-13 an
+agent had to be checked by hand for exactly this.
+
+## The verdict is PERSISTED — that is what makes `sac agents list` honest
+
+`sac agents auth-status` is not only a report; it **writes**. Every verdict it
+reaches is UPSERTed into the `agent_auth_state` table in `state.db`
+(`_state/auth_state.py`), and `sac agents list` **reads that cache** — it never
+probes auth inline, because detection costs two pane captures seconds apart per
+agent and would undo PR #635's latency work. A failing agent therefore shows in
+the fleet view as its own status, `auth-failed`, instead of a reassuring green
+`running`. **So run `auth-status` on a timer: the freshness of that table is
+exactly the freshness of the fleet view's auth column.**
+
+Three properties keep the cache from lying:
+
+- **Only observed agents are written.** An agent whose pane could not be
+  captured produced no evidence; recording "fine" for it would manufacture the
+  false green this whole system exists to abolish.
+- **Verdicts age.** Each row carries `checked_at`; the list marks anything older
+  than 15 min STALE and says so, rather than presenting it as current truth. If
+  nothing has refreshed the table at all, the list says *that* too — green then
+  means only "tmux is up".
+- **A restart invalidates the past.** A verdict older than the agent's current
+  `started_at` describes a dead incarnation and is discarded, so a just-restarted
+  agent is not still branded broken.
+
+`auth-failed` is a LIVE status, not a dead one: the agent's session and process
+are up, it simply cannot call the API. Every consumer must therefore ask
+`is_live_status()` rather than compare against `"running"` — which is why
+`sac agents restart --all-running` still reaches an `auth-failed` agent. It is
+precisely the agent that most needs restarting.
+
+## Say what is VERIFIABLE: `auth-failed`, not "login expired"
+
+Claude Code renders **every** 401 as `Login expired · Please run /login`. On this
+fleet that text is usually **false**, and believing it is why the bug survived
+weeks. The mechanism (proven 2026-07-13, four agents lost at once — accounts were
+valid for another +4h56m..+7h28m and quota was at 14%): a sibling process ran an
+OAuth refresh, consumed the **single-use** `refresh_token`, rotated the access
+token, and thereby **REVOKED** the token every other process still held. Nothing
+expired. sac's own restart pre-flight was one such refresher (fixed in PR #642).
+
+So the status asserts only what the pane proves — *this agent cannot call the
+API* — and the CAUSE is diagnosed separately from `claudeAiOauth.expiresAt`
+(`_account/auth_failure_reason.py`):
+
+| `expiresAt` | reason | what actually fixes it |
+|---|---|---|
+| in the **future** — the on-disk credential is VALID, yet the agent 401s ⇒ its in-memory token was rotated away | `revoked` | **restart** (it re-reads the good file; Claude Code never re-reads it by itself) |
+| in the **past** — nothing on disk can authenticate | `expired` | **login** (new credentials must be minted) |
+| unreadable / no numeric `expiresAt` | `unknown` | restart first — cheap, safe, and cures the common case |
+
+That distinction is the payoff: it separates a 5-second automated restart from
+waking the operator for a re-login. The banner cannot tell you which; `expiresAt`
+can.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -46,8 +46,8 @@ session inside Apptainer (local or remote via SSH), observe via
 - [01_config-v3.md](01_config-v3.md) — v3 format; dir-as-SSoT
 - [02_multiplexer.md](02_multiplexer.md) — vestigial; lead-only tmux wrap
 - [03_auto-accept.md](03_auto-accept.md) — modular prompt handlers
-- [04_resource-management.md](04_resource-management.md) — resource management
-- [05_resource-heartbeat.md](05_resource-heartbeat.md) — resource heartbeat
+- [04_resource-management.md](04_resource-management.md)
+- [05_resource-heartbeat.md](05_resource-heartbeat.md)
 - [06_env-injection-ports.md](06_env-injection-ports.md) — four env-injection ports
 - [07_a2a-protocol.md](07_a2a-protocol.md) — native A2A protocol (`sac a2a serve`)
 - [07_a2a-protocol-extension-fields.md](07_a2a-protocol-extension-fields.md) — `x-scitex-agent-container.*` AgentCard fields
@@ -77,10 +77,11 @@ session inside Apptainer (local or remote via SSH), observe via
 
 ### Reference
 - [13_observability.md](13_observability.md) — `sac agents status` JSON contract
-- [42_tui-auth-watchdog.md](42_tui-auth-watchdog.md) — TUI auth-banner detection contract (§1–4)
-- [43_tui-auth-watchdog-maintenance.md](43_tui-auth-watchdog-maintenance.md) — package matcher, auth-heal guards + extend-matcher runbook (§5–6)
-- [44_agent-to-agent-recovery.md](44_agent-to-agent-recovery.md) — recover a wedged peer: prompt/tmux/MCP/hook decision tree
-- [45_agent-to-agent-recovery-tmux.md](45_agent-to-agent-recovery-tmux.md) — the `tmux send-keys -l` recovery recipe + `/mcp` reconnect
+- [42](42_tui-auth-watchdog.md) — TUI auth-banner detection contract (§1–4)
+- [43](43_tui-auth-watchdog-maintenance.md) — package matcher, auth-heal guards + extend-matcher runbook (§5–6)
+- [44](44_agent-to-agent-recovery.md) — recover a wedged peer: prompt/tmux/MCP/hook decision tree
+- [45](45_agent-to-agent-recovery-tmux.md) — the `tmux send-keys -l` recovery recipe + `/mcp` reconnect
+- [46](46_agents-list-auth-cache.md) — persisted auth verdict → `auth-failed` in the fleet view
 
 ### Lessons
 - [40_troubleshooting.md](40_troubleshooting.md) — Common issues and debugging

--- a/src/scitex_agent_container/_state/auth_state.py
+++ b/src/scitex_agent_container/_state/auth_state.py
@@ -1,0 +1,384 @@
+"""Cached per-agent auth verdict — "is this tmux-GREEN agent actually working?"
+
+WHY THIS EXISTS
+    **tmux-up is not operational.** An agent whose API calls are being rejected
+    sits at its prompt under an auth banner forever: the tmux session exists and
+    its pane process is alive, so every liveness probe reads ``running`` — GREEN
+    — while the agent does exactly nothing. Claude Code never re-reads the
+    credentials file, so only a RESTART clears it. On a fleet of ~30 agents
+    sharing one OAuth account this is the dominant silent-failure mode, and
+    until now ``sac agents list`` could not tell a green-and-working agent apart
+    from a green-and-dead one. That has cost the operator real time — and on
+    2026-07-13 it took out four agents at once, including the one writing this.
+
+WHAT WE ASSERT, AND WHAT WE DO NOT
+    The stored fact is ``auth_failed``: *this agent cannot authenticate to the
+    API*. That is what the watchdog can actually verify (a frozen auth-rejection
+    banner on the agent's own pane), and it is all we claim.
+
+    We deliberately do NOT call it "login required" or "token expired". Claude
+    Code renders every 401 as ``Login expired · Please run /login``, and on this
+    fleet that text is usually a LIE: nothing expired — a sibling agent's OAuth
+    refresh consumed the single-use ``refresh_token`` and rotated the access
+    token, REVOKING the one this agent still held in memory. The remedy is a
+    restart, not a login. Believing the banner is precisely why the bug survived
+    so long, so this module records the verifiable FAILURE and stores the CAUSE
+    separately, as a diagnosis (``reason`` ∈ revoked / expired / unknown; see
+    ``_account.auth_failure_reason``) rather than as an assumption.
+
+READ CHEAP, WRITE CAREFULLY
+    :func:`list_auth_states` is on the ``sac agents list`` hot path, which
+    PR #635 just spent real effort making fast (it was ~296ms/row). So the read
+    opens the db ONCE, runs ONE ``SELECT``, and **never initialises schema** — a
+    reader that ran DDL would take a write lock on every ``sac agents list``. A
+    missing db / missing table / any sqlite hiccup returns ``{}`` ("nobody has
+    been checked yet"): the list can neither crash nor stall on a cache miss.
+    The WRITE path (:func:`record_auth_checks`) owns the DDL and runs at
+    watchdog cadence, so its cost does not matter.
+
+A CACHE IS NOT TRUTH — IT HAS AN AGE
+    An ``auth_failed`` from 6 hours ago is far weaker evidence than one from 60
+    seconds ago and must never be rendered as fresh truth. Every row carries
+    ``checked_at``, and two rules keep the cache honest:
+
+    * **STALE** — a verdict older than :data:`STALE_AFTER_S` is still shown (it
+      is the only evidence there is, and nothing self-heals) but is FLAGGED as
+      weak rather than asserted. See :func:`is_stale`.
+    * **SUPERSEDED** — a verdict taken BEFORE the agent's current ``started_at``
+      describes a PREVIOUS incarnation and is discarded outright. This is what
+      stops a just-restarted, now-healthy agent from still reading
+      ``auth-failed`` until the next watchdog sweep. See :func:`verdict_for`.
+
+    Both rules live in :func:`verdict_for`, a PURE function of (cached row,
+    started_at, now) — so the reader's honesty is unit-testable without a
+    database, and the read stays a single dict lookup per agent.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .state_db import DEFAULT_DB_PATH, init_schema, now_iso, open_db
+
+__all__ = [
+    "STALE_AFTER_S",
+    "age_seconds",
+    "clear_auth_state",
+    "get_auth_state",
+    "is_stale",
+    "list_auth_states",
+    "parse_ts",
+    "record_auth_check",
+    "record_auth_checks",
+    "verdict_for",
+]
+
+# A cached verdict older than this is STALE — shown, but marked as weak evidence
+# rather than asserted as current truth. 15 min is several times a healthy
+# watchdog period, so a working watchdog never trips it; a watchdog that has
+# actually STOPPED becomes visible precisely because every verdict ages past it
+# (the fleet's green then honestly reads "unverified" instead of "fine").
+STALE_AFTER_S = 900.0
+
+# Matches ``state_db.now_iso()`` and the registry's ``started_at`` — the same
+# second-resolution ISO-8601 UTC 'Z' stamp, so the two are directly comparable
+# in :func:`verdict_for`'s SUPERSEDED check.
+_TS_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS agent_auth_state (
+    name         TEXT PRIMARY KEY,
+    auth_failed  INTEGER NOT NULL,
+    checked_at   TEXT NOT NULL,
+    banner       TEXT,
+    reason       TEXT,
+    note         TEXT
+);
+"""
+
+_COLUMNS = "name, auth_failed, checked_at, banner, reason, note"
+
+
+def _resolve_db_path(db_path: Path | None) -> Path:
+    """The state.db this module reads/writes (``None`` → the process default)."""
+    return Path(db_path) if db_path else DEFAULT_DB_PATH
+
+
+def _ensure_schema(db_path: Path | None) -> None:
+    """Create ``agent_auth_state`` if missing — WRITE path only.
+
+    Deliberately NOT called by :func:`list_auth_states`: a reader that ran DDL
+    would take a write lock on state.db every time an operator typed
+    ``sac agents list``.
+    """
+    init_schema(db_path)
+    with open_db(db_path) as conn:
+        conn.executescript(_SCHEMA)
+
+
+def _row_to_state(row: sqlite3.Row) -> dict:
+    """One db row → the plain cached-verdict dict the readers consume."""
+    return {
+        "auth_failed": bool(row["auth_failed"]),
+        "checked_at": row["checked_at"] or "",
+        "banner": row["banner"] or None,
+        "reason": row["reason"] or "",
+        "note": row["note"] or "",
+    }
+
+
+# --- write path (the watchdog) ----------------------------------------------
+
+
+def record_auth_checks(
+    checks: list[dict],
+    *,
+    checked_at: str | None = None,
+    db_path: Path | None = None,
+) -> int:
+    """UPSERT a batch of auth verdicts. Returns how many rows were written.
+
+    ``checks`` is a list of ``{"name", "auth_failed", "banner"?, "reason"?,
+    "note"?}``. Called by the auth watchdog (``sac agents auth-status``) with
+    every agent whose pane it actually MANAGED TO READ.
+
+    Pass ONLY agents that were genuinely observed. An agent that could not be
+    read has produced NO evidence, and writing ``auth_failed=False`` for it
+    would assert "auth is fine" on the strength of nothing — the exact species
+    of comfortable lie this feature exists to kill. Leaving its previous row
+    untouched is the honest outcome: the stamp simply ages, and the reader marks
+    it stale.
+    """
+    if not checks:
+        return 0
+    stamp = checked_at or now_iso()
+    _ensure_schema(db_path)
+    written = 0
+    with open_db(db_path) as conn:
+        for check in checks:
+            name = str(check.get("name") or "").strip()
+            if not name:
+                continue
+            conn.execute(
+                f"INSERT INTO agent_auth_state ({_COLUMNS}) "
+                "VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(name) DO UPDATE SET "
+                "auth_failed=excluded.auth_failed, "
+                "checked_at=excluded.checked_at, "
+                "banner=excluded.banner, "
+                "reason=excluded.reason, "
+                "note=excluded.note",
+                (
+                    name,
+                    1 if check.get("auth_failed") else 0,
+                    stamp,
+                    check.get("banner") or None,
+                    check.get("reason") or "",
+                    check.get("note") or "",
+                ),
+            )
+            written += 1
+    return written
+
+
+def record_auth_check(
+    name: str,
+    auth_failed: bool,
+    *,
+    banner: str | None = None,
+    reason: str = "",
+    note: str = "",
+    checked_at: str | None = None,
+    db_path: Path | None = None,
+) -> None:
+    """UPSERT ONE agent's auth verdict (thin wrapper over the batch write)."""
+    record_auth_checks(
+        [
+            {
+                "name": name,
+                "auth_failed": auth_failed,
+                "banner": banner,
+                "reason": reason,
+                "note": note,
+            }
+        ],
+        checked_at=checked_at,
+        db_path=db_path,
+    )
+
+
+def clear_auth_state(name: str, *, db_path: Path | None = None) -> bool:
+    """Drop ``name``'s cached verdict. Idempotent; True iff a row was deleted."""
+    _ensure_schema(db_path)
+    with open_db(db_path) as conn:
+        cur = conn.execute("DELETE FROM agent_auth_state WHERE name=?", (name,))
+        return cur.rowcount > 0
+
+
+# --- read path (``sac agents list`` — keep this CHEAP) -----------------------
+
+
+def list_auth_states(*, db_path: Path | None = None) -> dict[str, dict]:
+    """``{agent_name: verdict}`` for every cached check, in ONE db read.
+
+    The ``sac agents list`` read. Mirrors the one-query shape of
+    ``port_allocator.list_claims()`` and is deliberately the cheapest thing that
+    can work: ONE connect, ONE ``SELECT``, and NO ``init_schema`` (see
+    :func:`_ensure_schema` for why a reader must not run DDL).
+
+    Tolerant by design — a state.db that does not exist yet, an
+    ``agent_auth_state`` table no watchdog has ever created, or any sqlite
+    hiccup all return ``{}``: "nobody has been checked". Every row then renders
+    as never-checked, which is the honest answer. This must never crash, and
+    never stall, ``sac agents list``.
+    """
+    path = _resolve_db_path(db_path)
+    # Guard BEFORE connecting: sqlite3.connect() CREATES a missing file, and a
+    # READ has no business materialising an empty state.db on a fresh host.
+    if not path.is_file():
+        return {}
+    # stx-allow: fallback (reason: the auth cache ENRICHES the agent list; a db
+    # that is missing/locked/schema-less means "not checked yet", never a failed
+    # `sac agents list`.)
+    try:
+        conn = sqlite3.connect(path, timeout=5.0)
+    except sqlite3.Error:  # stx-allow: fallback (reason: see inline comment)
+        return {}
+    try:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(f"SELECT {_COLUMNS} FROM agent_auth_state").fetchall()
+    except sqlite3.Error:  # stx-allow: fallback (reason: table not created yet — no watchdog has run on this host)
+        return {}
+    finally:
+        conn.close()
+    return {str(r["name"]): _row_to_state(r) for r in rows}
+
+
+def get_auth_state(name: str, *, db_path: Path | None = None) -> dict | None:
+    """One agent's cached verdict, or ``None`` when it has never been checked."""
+    return list_auth_states(db_path=db_path).get(name)
+
+
+# --- staleness (a cache is not truth — it has an age) ------------------------
+
+
+def parse_ts(stamp: str | None) -> datetime | None:
+    """Parse an ISO-8601 UTC ``Z`` stamp; ``None`` when absent/unparseable.
+
+    Tolerates the sentinels the registry uses for "no value" (``-`` / ``?``) and
+    an ISO stamp carrying a real offset, so a hand-edited or differently-stamped
+    row degrades to "unknown age" rather than raising.
+    """
+    if not stamp or stamp in ("-", "?"):
+        return None
+    try:
+        return datetime.strptime(stamp, _TS_FMT).replace(tzinfo=timezone.utc)
+    except ValueError:
+        pass
+    try:  # stx-allow: fallback (reason: tolerate an offset-carrying ISO stamp)
+        parsed = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+    except ValueError:  # stx-allow: fallback (reason: unparseable ⇒ unknown age, never a raise)
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def age_seconds(checked_at: str | None, *, now: datetime | None = None) -> float | None:
+    """Seconds since ``checked_at``; ``None`` when absent/unparseable.
+
+    Never negative: a stamp from the future (clock skew between the watchdog host
+    and the reader) clamps to 0 rather than rendering as "-3s ago".
+    """
+    parsed = parse_ts(checked_at)
+    if parsed is None:
+        return None
+    reference = now or datetime.now(timezone.utc)
+    return max(0.0, (reference - parsed).total_seconds())
+
+
+def is_stale(
+    checked_at: str | None,
+    *,
+    now: datetime | None = None,
+    stale_after_s: float = STALE_AFTER_S,
+) -> bool:
+    """True when the verdict is older than ``stale_after_s`` — weak evidence.
+
+    An absent/unparseable stamp is NOT "stale": it is *no evidence at all*, a
+    different state the readers render as "never checked". Callers discriminate
+    on ``auth_checked_at`` being empty, not on this flag.
+    """
+    age = age_seconds(checked_at, now=now)
+    return age is not None and age > stale_after_s
+
+
+def verdict_for(
+    state: dict | None,
+    *,
+    started_at: str | None = None,
+    now: datetime | None = None,
+    stale_after_s: float = STALE_AFTER_S,
+) -> dict:
+    """The PURE read-side rule: cached row + agent start-time → row auth fields.
+
+    Returns the seven keys every agent-list row carries, ALWAYS all present::
+
+        {"auth_failed": bool,           # the cached verdict (False if none)
+         "auth_checked_at": str,        # "" ⇒ never checked (no evidence)
+         "auth_check_age_s": int|None,  # None ⇒ never checked
+         "auth_check_stale": bool,      # verdict is old ⇒ weak evidence
+         "auth_banner": str|None,       # what was on the pane
+         "auth_reason": str,            # revoked / expired / unknown
+         "auth_remedy": str}            # restart / login
+
+    Two honesty rules are enforced here, and only here:
+
+    * **SUPERSEDED** — a verdict stamped BEFORE ``started_at`` was taken on a
+      PREVIOUS incarnation of this agent and is DISCARDED (reported as
+      never-checked). Restart is the cure for the common (revoked) failure, so
+      without this rule the operator would restart a wedged agent, fix it, and
+      STILL be told ``auth-failed`` until the next watchdog sweep — the cache
+      would be lying at the exact moment he acted on it. Being purely read-side,
+      it holds no matter HOW the agent was restarted (CLI, host-listen broker,
+      tmux respawn): there is no start-path to instrument, and therefore none to
+      forget.
+    * **STALE** — an old-but-current verdict is KEPT (nothing self-heals, so it
+      remains the best evidence available) and FLAGGED, so the reader can show it
+      as weak rather than assert it.
+    """
+    if not state or not state.get("checked_at"):
+        return _no_verdict()
+    checked_at = str(state["checked_at"])
+    started = parse_ts(started_at)
+    checked = parse_ts(checked_at)
+    if started is not None and checked is not None and checked < started:
+        # The verdict predates this incarnation — it describes an agent that no
+        # longer exists, and says nothing about the process running now.
+        return _no_verdict()
+    from .._account.auth_failure_reason import REASON_UNKNOWN, remedy_for
+
+    age = age_seconds(checked_at, now=now)
+    reason = str(state.get("reason") or REASON_UNKNOWN)
+    return {
+        "auth_failed": bool(state.get("auth_failed")),
+        "auth_checked_at": checked_at,
+        "auth_check_age_s": None if age is None else int(age),
+        "auth_check_stale": is_stale(checked_at, now=now, stale_after_s=stale_after_s),
+        "auth_banner": state.get("banner") or None,
+        "auth_reason": reason,
+        "auth_remedy": remedy_for(reason),
+    }
+
+
+def _no_verdict() -> dict:
+    """The never-checked shape — no evidence, so no claim about this agent."""
+    return {
+        "auth_failed": False,
+        "auth_checked_at": "",
+        "auth_check_age_s": None,
+        "auth_check_stale": False,
+        "auth_banner": None,
+        "auth_reason": "",
+        "auth_remedy": "",
+    }

--- a/src/scitex_agent_container/cli_pkg/_auth_status.py
+++ b/src/scitex_agent_container/cli_pkg/_auth_status.py
@@ -1,16 +1,30 @@
-"""``sac agents auth-status`` — which running TUI agents are login-stuck.
+"""``sac agents auth-status`` — which running TUI agents cannot reach the API.
 
-The reliable, prompt-anchored replacement for the operator's ad-hoc auth
-health check (TG 1497: "a command to see if any running agent shows
-login-required"). For each live ``tui-<agent>`` tmux session it captures the
-pane TWICE (``--interval`` apart), runs the near-prompt + distance-frozen
-matcher (:mod:`.._runners._tmux.auth_status`), and prints OK / LOGIN-REQUIRED.
+The reliable, prompt-anchored auth health check (TG 1497: "a command to see if
+any running agent shows login-required"). For each live ``tui-<agent>`` tmux
+session it captures the pane TWICE (``--interval`` apart), runs the near-prompt
++ distance-frozen matcher (:mod:`.._runners._tmux.auth_status`), and prints OK /
+AUTH-FAILED. Exit code is 1 when any agent is failing, so cron / CI can alarm.
 
-LOGIN-REQUIRED means: a SYSTEM auth banner sits in the conversation tail
+AUTH-FAILED means: a SYSTEM auth-rejection banner sits in the conversation tail
 directly above the input prompt AND it did not move between the two captures
-(frozen) — i.e. the agent is wedged on "Login expired * Please run /login",
-not merely discussing or quoting it. Exit code is 1 when any agent is
-LOGIN-REQUIRED so cron / CI can alarm.
+(frozen) — i.e. the agent is genuinely wedged, not merely discussing or quoting
+the incident.
+
+It does NOT mean "the token expired", and this command will not say so. Claude
+Code renders every 401 as ``Login expired · Please run /login``; on this fleet
+that text is usually FALSE (a sibling agent's OAuth refresh consumed the
+single-use refresh_token and REVOKED the token this one still held in memory —
+nothing expired, and a restart, not a login, is the cure). So we report the
+verifiable fact — *this agent cannot authenticate* — and diagnose the CAUSE
+separately, from ``expiresAt`` (:mod:`.._account.auth_failure_reason`).
+
+THIS COMMAND IS THE WRITER. Detection is expensive (two pane captures, seconds
+apart, for every agent), so ``sac agents list`` must never do it inline. Instead
+each verdict is PERSISTED here (:func:`persist_verdicts` → the
+``agent_auth_state`` table) and the list simply READS that cache. Run this on a
+timer; the list then shows, for free, which green agents are actually working —
+and how old that evidence is.
 """
 
 from __future__ import annotations
@@ -82,11 +96,11 @@ def evaluate_agents(
 ) -> list[dict]:
     """Pure core: map ``agent -> (pane_run1, pane_run2)`` to verdict rows.
 
-    Run 1 seeds each agent's local state; run 2 is judged against it, so a
-    banner that stayed at the SAME distance across the two reads (frozen)
-    yields ``login_required``; a banner that moved — or none at all — is
-    ``ok``. Kept free of tmux so it is unit-testable against captured panes
-    (no mocks). Rows are sorted by agent name for stable output.
+    Run 1 seeds each agent's local state; run 2 is judged against it, so a banner
+    that stayed at the SAME distance across the two reads (frozen) yields
+    ``auth_failed``; a banner that moved — or none at all — is ``ok``. Kept free
+    of tmux so it is unit-testable against captured panes (no mocks). Rows are
+    sorted by agent name for stable output.
     """
     rows: list[dict] = []
     for name in sorted(captures):
@@ -94,7 +108,7 @@ def evaluate_agents(
         probe1, _ = evaluate(pane1, None)
         probe2, stuck = evaluate(pane2, probe_to_state(probe1))
         present = probe2.present or probe1.present
-        verdict = "login_required" if stuck else "ok"
+        verdict = "auth_failed" if stuck else "ok"
         note = ""
         if verdict == "ok" and present:
             note = "banner seen but moving (working/quoting)"
@@ -114,22 +128,119 @@ def evaluate_agents(
     return rows
 
 
+def _config_for(name: str):
+    """Load ``name``'s spec so its credential file can be located; else ``None``.
+
+    ``None`` is a SAFE answer, not a failure: ``credential_path_for(None)``
+    resolves to the host live ``~/.claude/.credentials.json``, which is exactly
+    what an agent with no pinned ``spec.claude.account`` authenticates with — the
+    common case. Only a PINNED agent needs its spec read, and for those the
+    registry lookup below is what supplies it.
+    """
+    # stx-allow: fallback (reason: the spec is used only to LOCATE a credential
+    # file for the cause diagnosis; an unreadable one degrades to the host live
+    # file, never to a failed watchdog run.)
+    try:
+        from .._state.registry import Registry
+        from ..config import load_config
+
+        entry = Registry().get(name) or {}
+        path = entry.get("config")
+        return load_config(str(path)) if path else None
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+
+
+def diagnose_agents(rows: list[dict], *, now: float | None = None) -> list[dict]:
+    """Annotate each FAILING row with WHY it fails and what actually fixes it.
+
+    Adds ``reason`` (revoked / expired / unknown) and ``remedy`` (restart /
+    login) to the auth-failed rows by comparing the agent's on-disk credential
+    ``expiresAt`` against now — see :mod:`.._account.auth_failure_reason` for why
+    that comparison is decisive, and why it is worth far more than the banner's
+    own (usually wrong) explanation.
+
+    Healthy rows get an empty reason. A valid credential is the NORMAL state, so
+    "diagnosing" a working agent would confidently report ``revoked`` about
+    nothing at all. Only what is broken gets explained.
+    """
+    from .._account.auth_failure_reason import diagnose_reason, remedy_for
+
+    for row in rows:
+        if row.get("verdict") != "auth_failed":
+            row["reason"] = ""
+            row["remedy"] = ""
+            continue
+        reason = diagnose_reason(_config_for(row["agent"]), now=now)
+        row["reason"] = reason
+        row["remedy"] = remedy_for(reason)
+    return rows
+
+
+def persist_verdicts(rows: list[dict], *, db_path=None) -> int:
+    """Cache these verdicts in state.db so ``sac agents list`` can READ them.
+
+    The write half of the whole feature: detection is far too expensive to run
+    per row of an agent listing, so it happens HERE, once, and the list reads
+    what we leave behind.
+
+    Only agents whose pane was genuinely CAPTURED are written. An agent we could
+    not read produced no evidence, and recording "auth is fine" for it would
+    manufacture exactly the false green this feature exists to abolish. Leaving
+    its previous row to age — and be marked stale by the reader — is the honest
+    outcome.
+
+    Tolerant: a failed write warns on stderr and is never raised. The operator
+    ran this to LEARN something; a state.db hiccup must not throw away a
+    completed scan or make the command exit non-zero for the wrong reason.
+    """
+    observed = [r for r in rows if r.get("captured")]
+    if not observed:
+        return 0
+    # stx-allow: fallback (reason: the scan already SUCCEEDED; a cache-write
+    # hiccup must not fail the command or discard the operator's result.)
+    try:
+        from .._state.auth_state import record_auth_checks
+
+        return record_auth_checks(
+            [
+                {
+                    "name": r["agent"],
+                    "auth_failed": r.get("verdict") == "auth_failed",
+                    "banner": r.get("banner"),
+                    "reason": r.get("reason") or "",
+                    "note": r.get("note") or "",
+                }
+                for r in observed
+            ],
+            db_path=db_path,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        click.echo(
+            f"warning: could not cache auth verdicts ({exc}); "
+            "`sac agents list` will show them as never-checked",
+            err=True,
+        )
+        return 0
+
+
 def _render_table(rows: list[dict]) -> None:
     table = Table(title="TUI agent auth-status")
     table.add_column("agent", style="bold")
     table.add_column("status")
-    table.add_column("distance", justify="right")
+    table.add_column("cause")
+    table.add_column("fix")
     table.add_column("banner")
     table.add_column("note", overflow="fold")
     for r in rows:
-        login = r["verdict"] == "login_required"
-        status = "LOGIN-REQUIRED" if login else "OK"
-        style = "red" if login else "green"
-        dist = "-" if r["distance"] is None else str(r["distance"])
+        failed = r["verdict"] == "auth_failed"
+        status = "AUTH-FAILED" if failed else "OK"
+        style = "red" if failed else "green"
         table.add_row(
             r["agent"],
             f"[{style}]{status}[/{style}]",
-            dist,
+            r.get("reason") or "-",
+            r.get("remedy") or "-",
             r["banner"] or "-",
             r["note"] or "",
         )
@@ -154,13 +265,18 @@ def _render_table(rows: list[dict]) -> None:
 )
 @click.pass_context
 def auth_status(ctx: click.Context, as_json: bool, interval: float) -> None:
-    """Report each RUNNING TUI agent as OK or LOGIN-REQUIRED.
+    """Report each RUNNING TUI agent as OK or AUTH-FAILED, and cache the result.
 
     Captures every live ``tui-<agent>`` pane twice (``--interval`` apart) and
-    flags an agent only when a system auth banner sits directly above its
-    prompt AND stays frozen across the two reads — so an agent QUOTING the
-    banner while it works is never mistaken for a wedged one. Exits 1 if any
-    agent needs login.
+    flags an agent only when a system auth banner sits directly above its prompt
+    AND stays frozen across the two reads — so an agent QUOTING the banner while
+    it works is never mistaken for a wedged one. Each failure is then diagnosed
+    from the agent's credential ``expiresAt`` as ``revoked`` (its token was
+    rotated away by a sibling's refresh → restart it) or ``expired`` (→ log in).
+
+    Every verdict is written to state.db, which is where ``sac agents list``
+    reads its auth column from — so running this on a timer is what keeps the
+    fleet view honest. Exits 1 if any agent's auth is failing.
 
     \b
     Example:
@@ -171,7 +287,7 @@ def auth_status(ctx: click.Context, as_json: bool, interval: float) -> None:
     sessions = _list_tui_sessions()
     if not sessions:
         if use_json:
-            click.echo(json_mod.dumps({"agents": [], "login_required": 0}))
+            click.echo(json_mod.dumps({"agents": [], "auth_failed": 0}))
         else:
             console.print("[dim](no running tui-* agents on this host)[/dim]")
         return
@@ -179,21 +295,25 @@ def auth_status(ctx: click.Context, as_json: bool, interval: float) -> None:
     time.sleep(max(0.0, interval))
     run2 = {_agent_of(s): _capture(s) for s in sessions}
     captures = {name: (run1.get(name), run2.get(name)) for name in run1}
-    rows = evaluate_agents(captures)
-    stuck = [r for r in rows if r["verdict"] == "login_required"]
+    rows = diagnose_agents(evaluate_agents(captures))
+    persist_verdicts(rows)
+    stuck = [r for r in rows if r["verdict"] == "auth_failed"]
     if use_json:
-        click.echo(
-            json_mod.dumps({"agents": rows, "login_required": len(stuck)}, indent=2)
-        )
+        click.echo(json_mod.dumps({"agents": rows, "auth_failed": len(stuck)}, indent=2))
     else:
         _render_table(rows)
         if stuck:
             console.print(
-                f"[red]{len(stuck)} agent(s) need login: "
+                f"[red]{len(stuck)} agent(s) cannot authenticate: "
                 f"{', '.join(r['agent'] for r in stuck)}[/red]"
             )
     if stuck:
         sys.exit(1)
 
 
-__all__ = ["auth_status", "evaluate_agents"]
+__all__ = [
+    "auth_status",
+    "diagnose_agents",
+    "evaluate_agents",
+    "persist_verdicts",
+]

--- a/src/scitex_agent_container/cli_pkg/_helpers/__init__.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/__init__.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         _extract_damaged_fields,
         _probe_local,
         get_agent_list_data,
+        is_live_status,
         print_agent_list,
         print_agent_list_json,
     )
@@ -42,6 +43,7 @@ __all__ = [
     "agent_name_complete",
     "console",
     "get_agent_list_data",
+    "is_live_status",
     "print_agent_list",
     "print_agent_list_json",
     "renamed_redirect",
@@ -56,6 +58,7 @@ _LAZY_ATTR_SOURCES = {
     "_extract_damaged_fields": "._agent_list",
     "_probe_local": "._agent_list",
     "get_agent_list_data": "._agent_list",
+    "is_live_status": "._agent_list",
     "print_agent_list": "._agent_list",
     "print_agent_list_json": "._agent_list",
     "agent_name_complete": "._completion",

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -22,6 +22,19 @@ from ._agent_list_account import (  # noqa: F401
     _safe_account_for,
 )
 
+# Auth status (``auth-failed`` vs plain green ``running``) — sibling module.
+# tmux-up is NOT operational: an agent whose API calls are all being rejected
+# stays green forever. ``resolve_auth`` reads the WATCHDOG'S CACHED verdict;
+# nothing here ever probes auth inline (that would cost minutes — see
+# ``_agent_list_auth``).
+from ._agent_list_auth import (  # noqa: F401
+    LIVE_STATUSES,
+    STATUS_AUTH_FAILED,
+    all_auth_states,
+    is_live_status,
+    resolve_auth,
+)
+
 # Host-DISPLAY resolution (Host column) — sibling module, 512-line cap split.
 from ._agent_list_host import _host_display_for, _resolve_display_host
 
@@ -197,6 +210,12 @@ def get_agent_list_data(
     # re-opened + re-init-schema'd state.db ~3x each). Looked up per row.
     port_claims = _all_port_claims()
 
+    # Cached AUTH verdicts for ALL agents in ONE db read, same shape as the
+    # port claims above. The watchdog wrote these; we only read them. Never
+    # probe auth per row — the real check captures each pane twice, seconds
+    # apart, and would turn this command into a multi-minute wait.
+    auth_states = all_auth_states()
+
     # First pass: resolve configs + filter.
     # F-CS17 stage 3b: there are no longer "remote" agents from sac's
     # POV. Every agent is a container on this host. Cross-host work
@@ -325,6 +344,13 @@ def get_agent_list_data(
         else:
             status_val = "running" if is_running else "stopped"
 
+        # tmux-up != OPERATIONAL. A liveness probe says only that the session
+        # and its pane process exist — an agent whose every API call is being
+        # rejected satisfies that and is doing NOTHING. Fold the watchdog's
+        # CACHED verdict in, so such a row reads ``auth-failed`` (with the age
+        # of the evidence) instead of a reassuring green ``running``.
+        auth, status_val = resolve_auth(name, auth_states, started, status_val)
+
         # FIX (no double-parse): a config that ``load_config`` ACCEPTED is
         # valid by construction — ``load_config`` runs ``validate_raw`` and
         # RAISES on any error — so cfg-not-None ⇒ zero errors. Only
@@ -345,12 +371,15 @@ def get_agent_list_data(
         # a2a port from the ONE-query claims map. ``None`` when no claim
         # exists (agent never started under the allocator).
         a2a_port = port_claims.get(name)
-        # PERF: the running-only default view discards non-running rows, so
-        # skip their account resolution + movement IO. ``status`` is already
-        # computed, so the hidden-count footer stays correct.
-        deferred = running_only and status_val != "running"
-        # Which Anthropic account this agent authenticates as. For a RUNNING
-        # agent prefer the ACTUAL runtime account (its per-agent
+        # PERF: the running-only default view discards non-LIVE rows, so skip
+        # their account resolution + movement IO. ``status`` is already
+        # computed, so the hidden-count footer stays correct. Gate on
+        # ``is_live_status`` (not ``!= "running"``): a ``login-required`` row is
+        # SHOWN in the default view, so deferring its enrichment would blank out
+        # its Account — and that account is precisely the one that is dead.
+        deferred = running_only and not is_live_status(status_val)
+        # Which Anthropic account this agent authenticates as. For a LIVE agent
+        # prefer the ACTUAL runtime account (its per-agent
         # ``<runtime>/home/.claude.json``) over the spec-derived label — pool
         # agents share one host-OAuth spec label otherwise. Bare names so a
         # test can rebind ``_al._safe_account_for`` / ``_al._runtime_account_for``.
@@ -358,7 +387,7 @@ def get_agent_list_data(
             account_label = ""
         else:
             account_label = _safe_account_for(cfg)
-            if status_val == "running":
+            if is_live_status(status_val):
                 runtime_label = _runtime_account_for(name)
                 if runtime_label:
                     account_label = runtime_label
@@ -388,87 +417,32 @@ def get_agent_list_data(
             row["labels"] = labels
         results.append(row)
 
-    # Merge in agents that are *defined* on disk but absent from the
-    # registry. Filesystem is the canonical "defined" surface; the
-    # registry is a runtime cache of started/stopped state. An agent
-    # that was deleted from the registry (or never started) should
-    # still show up so the operator can spot it.
-    #
-    # While walking, also yaml-validate each spec — broken yamls
-    # surface as status="invalid" rather than silently hiding, so the
-    # operator notices the agent won't actually start before they
-    # discover it via a confusing `sac agent start` traceback.
-    from ...config._validation import validate_config
-
-    registered = {r["name"] for r in results}
-    for name, spec_path in _discover_defined_agents():
-        if name in registered:
-            continue
-        labels: dict[str, str] = {}
-        cfg = None
-        # stx-allow: fallback (defined-row labels are best-effort; a
-        # broken yaml still surfaces with status=invalid + empty labels)
-        try:
-            cfg = load_config(str(spec_path))
-            labels = cfg.labels
-        except Exception:
-            pass
-        if machine and labels.get("machine") != machine:
-            continue
-        if capability:
-            caps = [
-                c.strip()
-                for c in labels.get("capabilities", "").split(",")
-                if c.strip()
-            ]
-            if capability not in caps:
-                continue
-        if tags and not _label_list_contains(labels, "tags", tags):
-            continue
-        # FIX (no double-parse): a spec that ``load_config`` accepted is
-        # valid ⇒ "defined". Only RE-VALIDATE the ones that FAILED to load,
-        # to split "invalid" from "defined" and recover their error list.
-        errors = []
-        if cfg is None:
-            # stx-allow: fallback (validator may raise on unparseable yaml;
-            # treat as "invalid" with the exception text as the only error)
-            try:
-                errors = validate_config(str(spec_path))
-            except Exception as exc:
-                errors = [str(exc)]
-        status = "invalid" if errors else "defined"
-        # PERF: defined agents are never ``running`` — in the running-only
-        # default view they are all hidden, so skip their account + movement
-        # enrichment (status is enough for the footer count).
-        deferred = running_only
-        row: dict = {
-            "name": name,
-            "status": status,
-            "screen": "-",
-            "multiplexer": getattr(cfg, "runtime", None) if cfg else None,
-            "started_at": "-",
-            "host": "local",
-            "host_display": _host_display_for("local", display_host),
-            "path": str(spec_path),
-            "a2a_port": port_claims.get(name),
-            "account": "" if deferred else _safe_account_for(cfg),
-        }
-        row.update(dict(_MOVEMENT_DEFAULTS) if deferred else _movement_fields(name))
-        if errors:
-            row["validation_errors"] = errors
-        if labels:
-            row["labels"] = labels
-        results.append(row)
+    # Merge in the agents DEFINED on disk but absent from the registry. Their
+    # discovery + row-build live together in the sibling ``_agent_list_discover``
+    # (512-line cap split); this stays the orchestrator that merges the two
+    # sources. They are never live, so they carry the never-checked auth shape.
+    results.extend(
+        defined_agent_rows(
+            registered={r["name"] for r in results},
+            port_claims=port_claims,
+            display_host=display_host,
+            capability=capability,
+            machine=machine,
+            tags=tags,
+            running_only=running_only,
+        )
+    )
     return results
 
 
-# Defined-on-disk discovery lives in the sibling ``_agent_list_discover``
-# module (512-line cap split). Re-imported so the bare-name call site
-# ``_discover_defined_agents()`` above and the test seams
+# Defined-on-disk discovery + row-build live in the sibling
+# ``_agent_list_discover`` module (512-line cap split). Re-imported so the
+# bare-name call sites above and the test seams
 # ``_al._discover_defined_agents`` / ``_al._is_self_peer_marker`` resolve.
 from ._agent_list_discover import (  # noqa: E402,F401
     _discover_defined_agents,
     _is_self_peer_marker,
+    defined_agent_rows,
 )
 
 

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_auth.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_auth.py
@@ -1,0 +1,129 @@
+"""Agent-list AUTH status — "green" vs "green AND actually able to call the API".
+
+THE PROBLEM THIS SOLVES
+    ``sac agents list`` derived its Status from a LIVENESS probe: does the tmux
+    session exist, and is its pane process alive? For a wedged agent the answer
+    is YES — so it renders ``running``, in green, forever. Meanwhile every API
+    call it makes is rejected, it sits under an auth banner, and it does nothing
+    at all. Claude Code never re-reads the credentials file, so only a restart
+    recovers it; none of that is visible from liveness. The operator could not
+    tell working-green from dead-green, and on a fleet of ~30 agents sharing one
+    OAuth account that ambiguity has cost him real time.
+
+    So: **tmux-up is not operational**, and Status must say which.
+
+WHY ``auth-failed`` AND NOT "login required"
+    Claude Code prints ``Login expired · Please run /login`` for every 401, and
+    on this fleet that text is usually FALSE. The real mechanism (proven
+    2026-07-13, four agents lost at once): a sibling agent ran its own OAuth
+    refresh, consumed the single-use ``refresh_token``, rotated the access token,
+    and thereby REVOKED the token every other process was holding. Nothing
+    expired, and no login is required — a restart is.
+
+    So the status asserts only the part we can verify: this agent's auth is
+    failing / it cannot call the API. The CAUSE is carried separately, as a
+    diagnosis (``auth_reason``: revoked / expired / unknown) with the remedy it
+    implies (``auth_remedy``: restart / login) — see
+    ``_account.auth_failure_reason``. Trusting that banner is why this bug
+    survived so long; the list must not repeat its mistake.
+
+CACHE-READ ONLY — NEVER PROBE HERE
+    The auth check is expensive and cannot live on this path. Deciding whether a
+    banner is REAL (a wedged agent) or PROSE (an agent merely discussing the
+    incident) requires capturing the agent's pane TWICE, seconds apart, and
+    confirming the banner is frozen — see ``cli_pkg._auth_status`` /
+    ``_runners._tmux.auth_status``. Doing that per row would make ``sac agents
+    list`` take MINUTES and would undo PR #635's perf work (the list was
+    ~296ms/row).
+
+    Instead the WATCHDOG probes and PERSISTS its verdict to state.db, and this
+    module only READS THAT CACHE — one bulk query for the whole fleet
+    (:func:`all_auth_states`), then a dict lookup per row. The honesty rules
+    (stale evidence, superseded-by-restart) live in ``_state.auth_state`` as
+    pure functions; we apply them and hand the renderer plain fields.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "LIVE_STATUSES",
+    "STATUS_AUTH_FAILED",
+    "all_auth_states",
+    "is_live_status",
+    "resolve_auth",
+]
+
+# The status of an agent that is UP but NOT OPERATIONAL. Kept DISTINCT from
+# ``running`` because telling those two apart at a glance is the entire point.
+STATUS_AUTH_FAILED = "auth-failed"
+
+# Statuses meaning "this agent's process is UP". ``auth-failed`` MUST be a
+# member, and every consumer must go through :func:`is_live_status` rather than
+# comparing against ``"running"`` itself, because two call sites break otherwise:
+#
+#   * ``_agent_list_render`` — the DEFAULT view shows only live rows. An
+#     auth-failed row filtered out as "not running" would HIDE the one status the
+#     operator asked to be shown: an absurd own-goal.
+#   * ``lifecycle._selection._enumerate_running`` — the live set swept by BOTH
+#     ``restart --all-running`` and ``stop --all-running``. A restart is the cure
+#     for the common (revoked) failure, so dropping auth-failed rows would skip
+#     exactly the agents that most need restarting.
+#
+# One definition, imported by both, so those rules cannot drift apart.
+LIVE_STATUSES: tuple[str, ...] = ("running", STATUS_AUTH_FAILED)
+
+
+def is_live_status(status: str | None) -> bool:
+    """True when ``status`` means the agent's process is up (see LIVE_STATUSES)."""
+    return (status or "") in LIVE_STATUSES
+
+
+def all_auth_states() -> dict[str, dict]:
+    """``{agent_name: cached_verdict}`` for the whole fleet, in ONE db read.
+
+    Shaped exactly like ``_agent_list._all_port_claims``: a single bulk query,
+    looked up per row from the returned dict — never a per-row db hit.
+
+    Tolerant by design. A state.db that does not exist, an ``agent_auth_state``
+    table no watchdog has ever written, or any sqlite hiccup all map to ``{}`` —
+    "nobody has been checked yet" — which every row then renders honestly as
+    UNKNOWN rather than as verified-green. An auth-cache miss must never crash
+    ``sac agents list``, and must never slow it down.
+    """
+    # stx-allow: fallback (reason: the auth cache is an ENRICHMENT of the list;
+    # a missing/locked/schema-less db means "not checked yet", never a failure.)
+    try:
+        from ..._state.auth_state import list_auth_states
+
+        return list_auth_states()
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return {}
+
+
+def resolve_auth(
+    name: str,
+    states: dict[str, dict],
+    started_at: str | None,
+    status: str,
+) -> tuple[dict, str]:
+    """``(auth_fields, status)`` for one row — the status may be UPGRADED.
+
+    Returns the seven always-present auth keys (see
+    ``_state.auth_state.verdict_for``) plus the status they imply: a LIVE agent
+    carrying a current ``auth_failed`` verdict becomes :data:`STATUS_AUTH_FAILED`
+    instead of ``running``. Any other status is returned untouched.
+
+    A NON-live agent gets the no-verdict shape rather than its cached row. The
+    verdict describes a LIVE process, so reporting ``auth_failed`` for a STOPPED
+    agent would be a claim about a process that is not even there — and would
+    light up the fleet view with alarms about agents nobody is running. Keys stay
+    present-but-empty so the ``--json`` row shape is uniform.
+    """
+    from ..._state.auth_state import verdict_for
+
+    if not is_live_status(status):
+        return verdict_for(None), status
+    auth = verdict_for(states.get(name), started_at=started_at)
+    if auth["auth_failed"]:
+        return auth, STATUS_AUTH_FAILED
+    return auth, status

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
@@ -1,4 +1,4 @@
-"""Defined-on-disk agent discovery for ``sac agents list``.
+"""Defined-on-disk agents for ``sac agents list`` — discovery AND their rows.
 
 Split out of ``_agent_list.py`` (512-line cap) so the filesystem-walk concern
 lives beside its siblings ``_agent_list_account`` / ``_agent_list_render`` /
@@ -6,6 +6,12 @@ lives beside its siblings ``_agent_list_account`` / ``_agent_list_render`` /
 call site ``_discover_defined_agents()`` in ``get_agent_list_data`` and the
 test seams ``_al._discover_defined_agents`` / ``_al._is_self_peer_marker``
 keep resolving unchanged.
+
+:func:`defined_agent_rows` (moved here when the auth-status column pushed
+``_agent_list`` over the cap) turns those discovered ``(name, spec)`` pairs into
+list rows — the same concern, one module: DISCOVER the on-disk agents, then
+BUILD their rows. ``get_agent_list_data`` stays the orchestrator that merges
+them with the registry's rows.
 """
 
 from __future__ import annotations
@@ -81,3 +87,109 @@ def _discover_defined_agents() -> list[tuple[str, Path]]:
             pairs.append((child.name, spec))
             seen.add(child.name)
     return pairs
+
+
+def defined_agent_rows(
+    *,
+    registered: set[str],
+    port_claims: dict[str, int],
+    display_host: str,
+    capability: str | None = None,
+    machine: str | None = None,
+    tags: str | None = None,
+    running_only: bool = False,
+) -> list[dict]:
+    """Rows for agents DEFINED on disk but absent from the registry.
+
+    The filesystem is the canonical "defined" surface; the registry is only a
+    runtime cache of started/stopped state. An agent that was deleted from the
+    registry (or has never been started) must still appear, or the operator
+    cannot see it exists.
+
+    While walking, each spec is yaml-validated: a broken one surfaces as
+    ``status="invalid"`` rather than hiding, so the operator learns it will not
+    start BEFORE they hit a confusing ``sac agents start`` traceback.
+
+    These agents are never LIVE, so they carry the never-checked auth shape —
+    a cached "auth failed" verdict describes a *running process*, and replaying
+    it for an agent nobody is running would fill the fleet view with alarms
+    about agents that do not exist. Keys stay present-but-empty so the
+    ``--json`` row shape is uniform across every row.
+
+    Helpers are resolved through the ``_agent_list`` module namespace at call
+    time (rather than imported by value) so the real-attribute test seams —
+    ``_al._safe_account_for`` / ``_al._movement_fields`` / etc., which the suite
+    rebinds instead of mocking — keep working after this move. The
+    function-level import also avoids a cycle: ``_agent_list`` imports THIS
+    module at module scope.
+    """
+    from ..._state.auth_state import verdict_for
+    from ...config import load_config
+    from ...config._validation import validate_config
+    from . import _agent_list as _al
+
+    discover = getattr(_al, "_discover_defined_agents", _discover_defined_agents)
+    rows: list[dict] = []
+    for name, spec_path in discover():
+        if name in registered:
+            continue
+        labels: dict[str, str] = {}
+        cfg = None
+        # stx-allow: fallback (defined-row labels are best-effort; a
+        # broken yaml still surfaces with status=invalid + empty labels)
+        try:
+            cfg = load_config(str(spec_path))
+            labels = cfg.labels
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            pass
+        if machine and labels.get("machine") != machine:
+            continue
+        if capability:
+            caps = [
+                c.strip()
+                for c in labels.get("capabilities", "").split(",")
+                if c.strip()
+            ]
+            if capability not in caps:
+                continue
+        if tags and not _al._label_list_contains(labels, "tags", tags):
+            continue
+        # FIX (no double-parse): a spec that ``load_config`` accepted is
+        # valid ⇒ "defined". Only RE-VALIDATE the ones that FAILED to load,
+        # to split "invalid" from "defined" and recover their error list.
+        errors: list[str] = []
+        if cfg is None:
+            # stx-allow: fallback (validator may raise on unparseable yaml;
+            # treat as "invalid" with the exception text as the only error)
+            try:
+                errors = validate_config(str(spec_path))
+            except Exception as exc:  # stx-allow: fallback (reason: see comment)
+                errors = [str(exc)]
+        status = "invalid" if errors else "defined"
+        # PERF: defined agents are never live — in the running-only default
+        # view they are all hidden, so skip their account + movement
+        # enrichment (status is enough for the footer count).
+        deferred = running_only
+        row: dict = {
+            "name": name,
+            "status": status,
+            "screen": "-",
+            "multiplexer": getattr(cfg, "runtime", None) if cfg else None,
+            "started_at": "-",
+            "host": "local",
+            "host_display": _al._host_display_for("local", display_host),
+            "path": str(spec_path),
+            "a2a_port": port_claims.get(name),
+            "account": "" if deferred else _al._safe_account_for(cfg),
+        }
+        movement = (
+            dict(_al._MOVEMENT_DEFAULTS) if deferred else _al._movement_fields(name)
+        )
+        row.update(movement)
+        row.update(verdict_for(None))
+        if errors:
+            row["validation_errors"] = errors
+        if labels:
+            row["labels"] = labels
+        rows.append(row)
+    return rows

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
@@ -16,6 +16,7 @@ from rich.table import Table
 
 from ..._state.registry import Registry
 from .._account_list_format import format_dt_display_tz
+from ._agent_list_auth import STATUS_AUTH_FAILED, is_live_status
 from ._console import console
 
 __all__ = [
@@ -24,6 +25,128 @@ __all__ = [
     "_is_ghost_row",
     "_extract_damaged_fields",
 ]
+
+# Status → colour. ``auth-failed`` is deliberately the loudest thing in the
+# table: it is a LIVE agent that is accomplishing nothing, which is strictly
+# worse than a stopped one (a stopped agent at least looks stopped).
+_CMAP = {
+    "running": "green",
+    "auth-failed": "bold red",
+    "stopped": "red",
+    "defined": "yellow",
+    "invalid": "bold red",
+    "unknown": "dim",
+}
+
+
+def _fmt_age(seconds: int | None) -> str:
+    """Compact age — ``45s`` / ``12m`` / ``6h`` / ``3d``. Empty when unknown."""
+    if seconds is None:
+        return ""
+    if seconds < 60:
+        return f"{int(seconds)}s"
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m"
+    if seconds < 86400:
+        return f"{int(seconds // 3600)}h"
+    return f"{int(seconds // 86400)}d"
+
+
+def _status_cell(row: dict) -> str:
+    """The Status cell — auth-aware, and honest about how old its evidence is.
+
+    An ``auth-failed`` row is the entire point of the auth cache: that agent is
+    tmux-GREEN and doing NOTHING, because every API call it makes is rejected. It
+    must not look like ``running``, and it must carry the AGE of the evidence —
+    a verdict from 6 hours ago is a weaker claim than one from 60 seconds ago and
+    may not be dressed up as the same thing::
+
+        auth failed (2m ago)     bold red — a fresh check; act on it
+        auth failed? (6h ago)    yellow, "?" — STALE cache; re-check before acting
+
+    Every other status renders exactly as it always did.
+    """
+    status = row.get("status") or "unknown"
+    if status != STATUS_AUTH_FAILED:
+        col = _CMAP.get(status, "white")
+        return f"[{col}]{status}[/{col}]"
+    age = _fmt_age(row.get("auth_check_age_s")) or "age unknown"
+    if row.get("auth_check_stale"):
+        return f"[yellow]auth failed? ({age} ago)[/yellow]"
+    return f"[bold red]auth failed ({age} ago)[/bold red]"
+
+
+def _auth_cell(row: dict) -> str:
+    """The verbose-only Auth cell: the raw cached verdict + its age.
+
+    Shown for EVERY row, not just failing ones, because "when was this agent last
+    checked at all?" is its own question. A column of ``never`` — or of ``6h`` —
+    means the watchdog is not running, and therefore that every green row above
+    is unverified rather than healthy. That is worth being able to see.
+    """
+    if not row.get("auth_checked_at"):
+        return "[dim]never[/dim]"
+    age = _fmt_age(row.get("auth_check_age_s"))
+    stale = row.get("auth_check_stale")
+    if row.get("auth_failed"):
+        reason = row.get("auth_reason") or "unknown"
+        remedy = row.get("auth_remedy") or "restart"
+        body = f"failed {age} ({reason} → {remedy})"
+        return f"[yellow]{body}?[/yellow]" if stale else f"[bold red]{body}[/bold red]"
+    return f"[yellow]ok? {age}[/yellow]" if stale else f"[green]ok {age}[/green]"
+
+
+def _print_auth_footer(data: list[dict]) -> None:
+    """One line telling the operator what his green is actually worth.
+
+    ``sac agents list`` reads a CACHE. If nothing has refreshed that cache, every
+    ``running`` above means only "tmux is up" — the very ambiguity this feature
+    exists to remove — so the absence of evidence has to be stated out loud
+    rather than passed off silently as good news. Three cases:
+
+    * never checked → the watchdog has never run here; green is unverified.
+    * checked, but the freshest verdict is STALE → the watchdog has stopped;
+      green is no longer verified.
+    * fresh → say when, quietly, and name anyone who cannot authenticate.
+    """
+    from ..._state.auth_state import STALE_AFTER_S
+
+    live = [r for r in data if is_live_status(r.get("status"))]
+    if not live:
+        return
+    ages = [
+        r["auth_check_age_s"]
+        for r in live
+        if r.get("auth_checked_at") and r.get("auth_check_age_s") is not None
+    ]
+    failed = [r for r in live if r.get("auth_failed")]
+    hint = "run `sac agents auth-status` (or put it on a timer)"
+    if not ages:
+        console.print(
+            f"[yellow]auth: never checked — a green agent is NOT verified "
+            f"working, only tmux-alive; {hint}[/yellow]"
+        )
+        return
+    freshest = min(ages)
+    if freshest > STALE_AFTER_S:
+        console.print(
+            f"[yellow]auth: last checked {_fmt_age(freshest)} ago (STALE) — "
+            f"green is no longer verified; {hint}[/yellow]"
+        )
+    else:
+        unchecked = len(live) - len(ages)
+        extra = f", {unchecked} unchecked" if unchecked else ""
+        console.print(f"[dim]auth: checked {_fmt_age(freshest)} ago{extra}[/dim]")
+    if failed:
+        detail = ", ".join(
+            f"{r['name']} ({r.get('auth_reason') or 'unknown'} → "
+            f"{r.get('auth_remedy') or 'restart'})"
+            for r in failed
+        )
+        console.print(
+            f"[bold red]{len(failed)} agent(s) cannot authenticate: {detail}"
+            "[/bold red]"
+        )
 
 
 def print_agent_list_json(
@@ -152,17 +275,21 @@ def print_agent_list(
         hidden_ghosts = len(data) - len(kept)
         data = kept
 
-    # DEFAULT view shows ONLY running agents; `-v`/`--all` show the full
-    # roster. Tally the hidden non-running rows by status for the footer.
+    # DEFAULT view shows ONLY LIVE agents; `-v`/`--all` show the full roster.
+    # Tally the hidden non-live rows by status for the footer.
+    #
+    # ``is_live_status`` — NOT ``== "running"``. An ``auth-failed`` agent IS
+    # live (tmux up, pane process alive); it is simply not working. Filtering it
+    # out as "not running" would hide the one row the operator most needs to see.
     show_full = verbose or show_all
     status_hidden: dict[str, int] = {}
     if not show_full:
-        running = [r for r in data if r.get("status") == "running"]
+        live = [r for r in data if is_live_status(r.get("status"))]
         for r in data:
             st = r.get("status") or "unknown"
-            if st != "running":
+            if not is_live_status(st):
                 status_hidden[st] = status_hidden.get(st, 0) + 1
-        data = running
+        data = live
 
     if not data:
         if show_full:
@@ -189,20 +316,19 @@ def print_agent_list(
         table.add_column("Account", overflow="fold")
     else:
         table.add_column("Account", no_wrap=True, overflow="ellipsis")
+    # ``Auth`` (the cached verdict + its age, for EVERY row) answers "is this
+    # green verified, or merely tmux-alive?" — but one extra column on the
+    # default view is a cost the compact view should not pay, so it lives behind
+    # `-v`. The default view still shows a FAILING agent loudly (Status) and
+    # summarises the cache's freshness in the footer.
+    if verbose:
+        table.add_column("Auth")
     # ``Path`` (full spec.yaml path) folds every row to 10+ lines, so it is
     # verbose-only (operator 2026-06-17).
     if verbose:
         table.add_column("Path", overflow="fold")
     table.add_column("Started")
-    cmap = {
-        "running": "green",
-        "stopped": "red",
-        "defined": "yellow",
-        "invalid": "bold red",
-        "unknown": "dim",
-    }
     for row in data:
-        col = cmap.get(row["status"], "white")
         # Host column: show the RESOLVED machine hostname (e.g. ``ywata-note-win``)
         # from ``host_display`` (set by get_agent_list_data), not the raw
         # ``"local"`` sentinel. Fall back to the raw host, then the sentinel.
@@ -230,17 +356,23 @@ def print_agent_list(
             account_cell = account_cell.split(" (", 1)[0]
         cells = [
             row["name"],
-            f"[{col}]{row['status']}[/{col}]",
+            _status_cell(row),
             yaml_cell,
             host_cell,
             account_cell,
         ]
+        if verbose:
+            cells.append(_auth_cell(row))
         if verbose:
             cells.append(row.get("path") or "—")
         cells.append(started)
         table.add_row(*cells)
 
     console.print(table)
+
+    # How much is the green above actually worth? Say it out loud — an unrefreshed
+    # cache means every ``running`` here proves only that tmux is up.
+    _print_auth_footer(data)
 
     # Footer. DEFAULT view: summarise every hidden non-running row + ghosts.
     # FULL view (`-v`/`--all`): only note hidden ghosts when `-v` alone.

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -71,7 +71,7 @@ COMMAND_CATEGORIES = [
     ),
     ("Registry & Events", ["db", "registry", "event"]),
     ("Build & Install", ["image", "installation"]),
-    ("Diagnostics", ["doctor", "provenance"]),
+    ("Diagnostics", ["doctor", "ports", "provenance"]),
     ("Remote testing", ["pytest"]),
     ("Introspection", ["mcp", "list-python-apis", "skills", "versions"]),
     ("Developer", ["dev"]),
@@ -106,6 +106,9 @@ class _MainGroup(LazyGroup):
         "fleet": f"{_PKG}.fleet_group:fleet_group",
         "listen": f"{_PKG}.listen_cmds:listen",
         "doctor": f"{_PKG}.doctor_cmds:doctor",
+        # Read-only port-hygiene inventory: listen 7878 + a2a claims +
+        # the scitex/sac port-assignment reference map.
+        "ports": f"{_PKG}.ports_cmds:ports",
         # Which code is ACTUALLY loaded — the heavy half of `--version`
         # (tree hash, duplicate/fossil .dist-info, shadowed imports).
         "provenance": f"{_PKG}.provenance_cmds:provenance",
@@ -291,6 +294,7 @@ class _MainGroup(LazyGroup):
         "doctor": "Diagnose agent-spec source drift (local, or --fleet across hosts).",
         "provenance": "Prove which code is actually loaded (commit, origin, fossil installs).",
         "listen": "Boot the sac listen HTTP/JSON control-plane server.",
+        "ports": "List the ports sac/scitex uses, with live status.",
         "pytest": "Run pytest on remote pools (Spartan SLURM, ...).",
         "install-shell-completion": "Wire up `<TAB>` completion in the user's shell rc.",
         "print-shell-completion": "Print the shell-completion eval line (no install).",

--- a/src/scitex_agent_container/cli_pkg/_send.py
+++ b/src/scitex_agent_container/cli_pkg/_send.py
@@ -150,20 +150,71 @@ def send_to_agent(
 
     from .._network.peer import PeerError
     from .._state.state_db import _resolve_host
+    from ._send_broker import (
+        PeerLookupUnavailable,
+        resolve_send_endpoint_via_host,
+        should_broker_peer_lookup,
+    )
     from ._send_resolve import resolve_send_endpoint
 
     current_host = _resolve_host(None)
-    # Resolve the LIVE endpoint the same way ``a2a_send`` / the listen
-    # forwarder do: active ``instances`` row port first, then the durable
-    # ``port_allocator`` claim that survives a health-monitor restart.
-    # Gating ONLY on the instances row (the old behaviour) caused the
-    # "registry split-brain": a locally-running agent whose row went stale
-    # (supervisor restart via ``runtime.start``, stale-lease clear) showed
-    # ``a2a_port=null`` here even while ``a2a_send`` reached it on the bus.
-    # See :mod:`._send_resolve` for the full root-cause writeup.
-    endpoint = resolve_send_endpoint(name, current_host=current_host)
+
+    # --- Resolve WHERE the peer is ----------------------------------------
+    # IN A CONTAINER the local state.db is a private, effectively empty
+    # per-agent bridge DB that holds no row for ANY other agent, so the local
+    # resolver below reports every peer as "not running" — measured
+    # 2026-07-14: ``scitex-scholar`` came back ``stopped / pid=null /
+    # a2a_port=null`` while the host's registry held ``pid=1777985
+    # a2a_port=19037 ended_at=NULL`` for it and the agent had messaged us 90
+    # seconds earlier. Broker the lookup to the host's ``sac listen`` — the
+    # SAME door ``agent_status`` already goes through — so we read the real
+    # fleet registry. See :mod:`._send_broker`.
+    #
+    # On a BARE HOST this is inert: ``should_broker_peer_lookup()`` is False
+    # and the local resolver runs exactly as before.
+    brokered = None
+    if should_broker_peer_lookup():
+        try:
+            endpoint, brokered = resolve_send_endpoint_via_host(
+                name, current_host=current_host
+            )
+        except PeerLookupUnavailable as exc:
+            # We could not ASK the host. That is UNKNOWN — not dead. We refuse
+            # to fall back to the blind local read, because its empty result
+            # would masquerade as death, which is the bug we are fixing.
+            return _unknown_lookup_payload(name, exc, current_host=current_host)
+    else:
+        # Resolve the LIVE endpoint the same way ``a2a_send`` / the listen
+        # forwarder do: active ``instances`` row port first, then the durable
+        # ``port_allocator`` claim that survives a health-monitor restart.
+        # Gating ONLY on the instances row (the old behaviour) caused the
+        # "registry split-brain": a locally-running agent whose row went stale
+        # (supervisor restart via ``runtime.start``, stale-lease clear) showed
+        # ``a2a_port=null`` here even while ``a2a_send`` reached it on the bus.
+        # See :mod:`._send_resolve` for the full root-cause writeup.
+        endpoint = resolve_send_endpoint(name, current_host=current_host)
+
     a2a_port = endpoint.a2a_port
     peer_host = endpoint.host if endpoint.host != current_host else ""
+
+    if endpoint.source == "host_broker_unknown_agent":
+        # The HOST — which can see the whole fleet — has no agent by this
+        # name. This is the one definitive negative in the brokered path.
+        return {
+            "status": "error",
+            "error": (
+                f"agent {name!r} is not in the host fleet registry "
+                f"(the host's `sac listen` returned 404 for it) — check the "
+                f"name, or the agent was never registered on this host"
+            ),
+            "diagnosis": diagnose_send_failure(
+                name,
+                a2a_port=None,
+                peer_host=current_host,
+                current_host=current_host,
+                brokered=brokered,
+            ),
+        }
     if endpoint.row is None and endpoint.source == "none":
         # No active instances row AND no durable allocator claim → the
         # agent is genuinely not running anywhere this host can see.
@@ -175,24 +226,38 @@ def send_to_agent(
                 a2a_port=None,
                 peer_host=current_host,
                 current_host=current_host,
+                brokered=brokered,
             ),
         }
     if a2a_port is None:
-        # A row exists but neither it nor the allocator carries a usable
-        # port (sidecar-disabled spec, or a row written before the port
-        # was resolved). Loud — there is no /v1/turn to reach.
-        return {
-            "status": "error",
-            "error": (
+        # No usable port. Loud — there is no /v1/turn to reach. The message
+        # names the SOURCE of the verdict, so a reader never has to guess
+        # whether it came from the real fleet registry or a blind local read.
+        if endpoint.source == "host_broker_no_port":
+            error = (
+                f"agent {name!r} is registered on the host, but the host fleet "
+                f"registry holds no a2a port claim for it (a claim is released "
+                f"only at `sac agents stop` / --force); there is no /v1/turn "
+                f"to reach"
+            )
+        else:
+            # A row exists but neither it nor the allocator carries a usable
+            # port (sidecar-disabled spec, or a row written before the port
+            # was resolved).
+            error = (
                 f"agent {name!r} has no a2a_port recorded "
                 f"(no active instances-row port and no port_allocator "
                 f"claim); cannot reach /v1/turn"
-            ),
+            )
+        return {
+            "status": "error",
+            "error": error,
             "diagnosis": diagnose_send_failure(
                 name,
                 a2a_port=None,
                 peer_host=peer_host or current_host,
                 current_host=current_host,
+                brokered=brokered,
             ),
         }
     if peer_host and peer_host != current_host:
@@ -246,6 +311,7 @@ def send_to_agent(
             current_host=current_host,
             url=url,
             metadata_extras=metadata_extras,
+            brokered=brokered,
         )
 
     try:
@@ -266,6 +332,7 @@ def send_to_agent(
             a2a_port=a2a_port,
             peer_host=peer_host,
             current_host=current_host,
+            brokered=brokered,
         )
         if "timeout" in msg.lower():
             return {
@@ -293,6 +360,30 @@ def send_to_agent(
     }
 
 
+def _unknown_lookup_payload(
+    name: str,
+    exc: Exception,
+    *,
+    current_host: str,
+) -> dict[str, Any]:
+    """Payload for "the host broker could not be asked" — UNKNOWN, not dead.
+
+    The one thing this must never do is render an unperformed lookup as a
+    stopped agent. ``registry_status`` comes back ``"unknown: …"``,
+    ``pid_alive`` and ``boot_complete`` stay ``None``, and the message names
+    the broker as the thing that failed — not the agent.
+    """
+    from ._send_diagnosis_brokered import unknown_lookup_diagnosis
+
+    return {
+        "status": "error",
+        "error": str(exc),
+        "diagnosis": unknown_lookup_diagnosis(
+            name, current_host=current_host, reason=str(exc)
+        ),
+    }
+
+
 def _dispatch_nonblocking(
     name: str,
     prompt: str,
@@ -302,6 +393,7 @@ def _dispatch_nonblocking(
     current_host: str,
     url: str,
     metadata_extras: dict[str, Any],
+    brokered: Any = None,
 ) -> dict[str, Any]:
     """Validate reachability, then return a non-blocking dispatch payload.
 
@@ -331,11 +423,20 @@ def _dispatch_nonblocking(
         a2a_port=a2a_port,
         peer_host=peer_host,
         current_host=current_host,
+        brokered=brokered,
     )
 
     # Fail loud on demonstrable unreachability (local probes only — a
     # cross-host port we cannot probe stays None and is NOT treated as
     # unreachable, which would be a false-positive failure).
+    #
+    # Both gates fire ONLY on an explicit ``False`` — never on ``None``.
+    # That is the whole discipline: a probe we could not run leaves ``None``
+    # and must not be read as a failed probe. On the brokered (in-container)
+    # path ``pid_alive`` is deliberately always ``None`` — the host status
+    # route exposes no pid, and importing a STALE one would make
+    # ``os.kill(pid, 0)`` report a healthy, restarted agent as dead. See
+    # :mod:`._send_diagnosis_brokered`.
     if diagnosis.get("pid_alive") is False:
         return {
             "status": "error",
@@ -346,11 +447,24 @@ def _dispatch_nonblocking(
             "diagnosis": diagnosis,
         }
     if diagnosis.get("port_reachable") is False:
+        # An unbound /v1/turn port means THIS TRANSPORT cannot carry the turn.
+        # It does NOT mean the agent is dead, and the old wording here ("it is
+        # not booted or the sidecar crashed") asserted exactly that. Measured
+        # on the live fleet 2026-07-14: only 5 of 47 registered agents had
+        # /v1/turn bound at all — the other 41 held a port claim with nothing
+        # listening, and several of them answered a2a messages that same
+        # minute. Saying "crashed" here would hand the caller a death verdict
+        # whose remedy (`--force --fresh`) destroys a healthy, working agent.
         return {
             "status": "error",
             "error": (
-                f"agent {name!r} sidecar is not listening on port {a2a_port}; "
-                "it is not booted or the sidecar crashed — cannot dispatch"
+                f"agent {name!r}: nothing is listening on a2a port {a2a_port}, "
+                f"so the /v1/turn transport cannot deliver this turn. This is "
+                f"NOT a death verdict — most agents in this fleet never bind "
+                f"/v1/turn and are reached over the a2a subscriber channel "
+                f"instead. Deliver with `sac a2a send {name} ...` (or the "
+                f"a2a_send tool), which does not require this port. Do NOT "
+                f"force-restart the agent on this signal"
             ),
             "diagnosis": diagnosis,
         }

--- a/src/scitex_agent_container/cli_pkg/_send_broker.py
+++ b/src/scitex_agent_container/cli_pkg/_send_broker.py
@@ -1,0 +1,339 @@
+"""Host-brokered peer lookup for the send read path (in-container blindness fix).
+
+The bug
+-------
+Inside an apptainer SIF, ``$HOME`` is ``/home/agent`` (not the operator's
+home) and ``SCITEX_AGENT_CONTAINER_STATE_DB`` points at a PER-AGENT bridge
+DB (e.g. ``/state/<name>/state.db``). So ``open_db(None)`` resolves to a
+private, effectively empty store that holds NO rows for any other agent.
+
+Every local-DB read in the send path therefore comes back empty, and the
+caller renders that emptiness as *death*. Measured 2026-07-14 from inside
+the ``scitex-agent-container`` SIF::
+
+    resolve_send_endpoint("scitex-scholar")
+        -> a2a_port=None, source="none", row=None
+    send_to_agent("scitex-scholar")
+        -> {"status": "error", "error": "agent 'scitex-scholar' not running",
+            "diagnosis": {"registry_status": "stopped", "pid": null,
+                          "a2a_port": null, "boot_complete": false}}
+
+…while the HOST's shared registry, at the same moment, held a live row for
+that agent (``pid=1777985  a2a_port=19037  ended_at=NULL``) and the agent
+had messaged the caller 90 seconds earlier. The lookup was never performed
+against the real fleet registry — and "I could not check" was rendered as
+"the agent is stopped".
+
+The fix
+-------
+Reuse the EXISTING in-SIF broker seam. :func:`agent_status` already solves
+this correctly: when it detects a SIF it proxies ``GET /agents/<name>/status``
+to the host's ``sac listen`` via
+:func:`_lifecycle._in_sif_http_client.host_listen_call` (see
+``cli_pkg/status_cmds.py::_status_via_host_listen``), which reads the real
+fleet registry on the bare host. This module routes the SEND path's peer
+lookup through that same door — same client, same URL, same bearer, same
+server-side auth gate. No second mechanism, no reimplemented client.
+
+Fail-loud / never-fabricate-death invariants
+--------------------------------------------
+These are the whole point of the module; they are not decoration.
+
+* **Broker unreachable → UNKNOWN, never DEAD.** A transport failure raises
+  :class:`PeerLookupUnavailable`. We do NOT fall back to the blind local
+  read, because that read is precisely what reports a live agent as
+  "stopped". Reporting a live agent dead because we could not ask IS the
+  bug.
+* **A refusal is not a death certificate.** A 403 (ACL) / 5xx / unparseable
+  body means we were prevented from learning the answer — also
+  :class:`PeerLookupUnavailable` (UNKNOWN).
+* **Only the HOST may pronounce an agent absent.** A 404 from the host is
+  the one definitive negative: the fleet registry has no such agent.
+* **Hints are not verdicts.** The host's ``status`` field (e.g.
+  ``"startup_failed"``) is carried through as a HINT ONLY. Those markers go
+  stale and are never reconciled — measured 2026-07-14, ``scitex-writer``
+  reported ``startup_failed`` from a marker ~2 days old while its host row
+  held ``pid=1772715 / ended_at=NULL`` and it answered an a2a message that
+  same turn. A stale marker MUST NOT render a live agent unreachable.
+
+Why the caution is asymmetric: the remedy for a "dead" verdict is
+DESTRUCTIVE (``--force --fresh``). A false red kills a healthy, working
+agent; a false green merely wastes a round-trip. When the evidence does not
+support a conclusion, refuse to conclude.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, NamedTuple
+
+from ._send_resolve import ResolvedEndpoint
+
+__all__ = [
+    "BrokeredPeer",
+    "PeerLookupUnavailable",
+    "lookup_peer_via_host",
+    "resolve_send_endpoint_via_host",
+    "should_broker_peer_lookup",
+]
+
+# The peer lookup is a single small GET against a loopback server; it must
+# never be the thing that makes a send feel slow. Deliberately far below the
+# 30s default of the shared client.
+_DEFAULT_TIMEOUT_S = 10.0
+
+
+class PeerLookupUnavailable(RuntimeError):
+    """The peer's state could NOT BE READ — the verdict is UNKNOWN, not DEAD.
+
+    Raised when the host broker could not be asked, or answered in a way that
+    withholds the fact we needed (transport failure, ACL refusal, 5xx,
+    unparseable body).
+
+    This is emphatically **not** "the agent is stopped". The caller MUST
+    surface it as unknown-state and MUST NOT fall back to the blind local
+    read, whose empty result would masquerade as death.
+
+    Attributes:
+        url: The URL that was attempted (``None`` when the failure happened
+            before a URL could be built).
+        http_status: The host's HTTP status, when one was received.
+        kind: The host's structured failure tag (e.g. ``"acl_deny"``), when
+            the body carried one.
+        body: The parsed response body, verbatim, when one was received.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        url: str | None = None,
+        http_status: int | None = None,
+        kind: str | None = None,
+        body: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.url = url
+        self.http_status = http_status
+        self.kind = kind
+        self.body = body
+
+
+class BrokeredPeer(NamedTuple):
+    """What the HOST fleet registry knows about a peer.
+
+    ``known`` is ``False`` only for the host's definitive 404 — the fleet
+    registry has no agent by that name. Every other "we don't know" case
+    raises :class:`PeerLookupUnavailable` instead of landing here, so a
+    ``BrokeredPeer`` always represents an ANSWER, never a shrug.
+
+    ``a2a_port`` is the durable port claim the host holds for the agent
+    (released only at ``agent_stop`` / ``--force``), so a non-``None`` value
+    is real evidence the agent is up.
+
+    ``host_status`` is the host's ``status`` field (e.g. ``"startup_failed"``)
+    — a HINT for the operator, NEVER a liveness verdict. See the module
+    docstring: these markers go stale and nothing reconciles them.
+    """
+
+    known: bool
+    a2a_port: int | None
+    host: str | None
+    host_status: str | None
+    body: dict
+
+
+def should_broker_peer_lookup() -> bool:
+    """True iff the peer lookup must be brokered to the host ``sac listen``.
+
+    Mirrors the decision ``agent_spawn`` and ``agent_status`` already make:
+    in a SIF *and* the apptainer runtime injected a listen URL to broker to.
+
+    The ``SAC_LISTEN_BASE_URL`` half of the predicate is not belt-and-braces
+    — it is load-bearing. ``sac-from-sac`` / bare-host shells can carry a
+    stale ``SINGULARITY_CONTAINER`` with no host listen to talk to, and
+    brokering there would turn a working local read into a stillborn one.
+    ``status_cmds.py`` learned this the hard way (PR#316); we reuse the same
+    guard rather than re-discover it.
+
+    Resolved through :func:`_env.getenv` — the SAME resolver
+    :func:`_in_sif_http_client.host_listen_call` uses — so the guard and the
+    client can never disagree about whether a base URL exists.
+    """
+    from .._env import getenv
+    from .._lifecycle._in_sif_broker import is_in_sif
+
+    if not is_in_sif():
+        return False
+    return bool((getenv("LISTEN_BASE_URL", "") or "").strip())
+
+
+def _host_from_turn_url(turn_url: Any) -> str | None:
+    """Extract the hostname from the host's ``turn_url``, else ``None``.
+
+    ``GET /agents/<name>/status`` carries the agent's endpoint as a derived
+    ``turn_url`` (``http://<host>:<port>/v1/turn``) rather than a bare host
+    field, so that is where the peer's host comes from.
+    """
+    if not isinstance(turn_url, str) or not turn_url:
+        return None
+    from urllib.parse import urlsplit
+
+    try:
+        return urlsplit(turn_url).hostname or None
+    except ValueError:
+        # stx-allow: fallback (reason: a malformed turn_url costs us only the
+        # host field — the caller falls back to the local canonical host. It
+        # must never escalate into a fabricated "agent is dead".)
+        return None
+
+
+def _coerce_port(value: Any) -> int | None:
+    """Return a positive int port, else ``None`` (``bool`` rejected explicitly)."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
+
+
+def lookup_peer_via_host(
+    name: str,
+    *,
+    base_url: str | None = None,
+    bearer: str | None = None,
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    opener: Callable | None = None,
+) -> BrokeredPeer:
+    """Ask the host ``sac listen`` what it knows about ``name``.
+
+    Routes ``GET /agents/<name>/status`` through
+    :func:`_lifecycle._in_sif_http_client.host_listen_call` — the same client,
+    URL and bearer ``agent_status`` uses. The host's ``BearerAuthMiddleware``
+    and lineage ACL remain the authority; nothing here weakens or bypasses
+    them, and a refusal is surfaced (as UNKNOWN), never worked around.
+
+    Returns:
+        :class:`BrokeredPeer` — an ANSWER from the host. ``known=False`` only
+        for the host's definitive 404.
+
+    Raises:
+        PeerLookupUnavailable: When the answer could not be obtained
+            (transport failure, ACL refusal, 5xx, non-dict body). The verdict
+            is UNKNOWN — the caller must not render it as "stopped".
+    """
+    from .._lifecycle._in_sif_http_client import (
+        HostListenTransportError,
+        host_listen_call,
+    )
+
+    try:
+        http_status, body = host_listen_call(
+            "GET",
+            f"/agents/{name}/status",
+            base_url=base_url,
+            bearer=bearer,
+            timeout_s=timeout_s,
+            opener=opener,
+        )
+    except HostListenTransportError as exc:
+        raise PeerLookupUnavailable(
+            f"cannot determine whether agent {name!r} is running: the host "
+            f"listen broker is unreachable ({exc}). Verdict: UNKNOWN — this "
+            f"is NOT evidence the agent is stopped, and it must not be acted "
+            f"on as though it were. Refusing to fall back to the "
+            f"container-local registry, which cannot see any peer and would "
+            f"report every one of them dead.",
+            url=exc.url,
+        ) from exc
+
+    if http_status == 404:
+        # The one definitive negative: the HOST — which can see the whole
+        # fleet — has no agent by this name.
+        return BrokeredPeer(
+            known=False,
+            a2a_port=None,
+            host=None,
+            host_status=None,
+            body=body if isinstance(body, dict) else {},
+        )
+
+    if not (200 <= http_status < 300) or not isinstance(body, dict):
+        kind = body.get("kind") if isinstance(body, dict) else None
+        raise PeerLookupUnavailable(
+            f"cannot determine whether agent {name!r} is running: the host "
+            f"listen answered GET /agents/{name}/status with HTTP "
+            f"{http_status} (kind={kind!r}). Verdict: UNKNOWN — we were "
+            f"prevented from learning the agent's state, which is NOT the "
+            f"same as learning that it is stopped.",
+            http_status=http_status,
+            kind=kind if isinstance(kind, str) else None,
+            body=body,
+        )
+
+    raw_status = body.get("status")
+    return BrokeredPeer(
+        known=True,
+        a2a_port=_coerce_port(body.get("a2a_port")),
+        host=_host_from_turn_url(body.get("turn_url")),
+        host_status=raw_status if isinstance(raw_status, str) else None,
+        body=body,
+    )
+
+
+def resolve_send_endpoint_via_host(
+    name: str,
+    *,
+    current_host: str,
+    base_url: str | None = None,
+    bearer: str | None = None,
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    opener: Callable | None = None,
+) -> tuple[ResolvedEndpoint, BrokeredPeer]:
+    """Brokered twin of :func:`_send_resolve.resolve_send_endpoint`.
+
+    Returns the SAME :class:`ResolvedEndpoint` shape the local resolver
+    returns, so the caller's downstream logic is identical on both paths;
+    only ``source`` differs, which is deliberate — provenance must be visible
+    in the payload, so nobody has to guess whether a verdict came from the
+    blind container DB or the real fleet registry.
+
+    ``source`` values:
+      * ``"host_broker"`` — the host holds a live port claim for the agent.
+      * ``"host_broker_no_port"`` — the host knows the agent but holds no
+        port claim for it.
+      * ``"host_broker_unknown_agent"`` — the host's 404: no such agent.
+
+    The :class:`BrokeredPeer` is returned alongside so the caller can thread
+    the host's facts into the diagnosis WITHOUT a second HTTP round-trip.
+
+    Raises:
+        PeerLookupUnavailable: propagated from :func:`lookup_peer_via_host`.
+            The caller must render this as UNKNOWN, never as "not running".
+    """
+    peer = lookup_peer_via_host(
+        name,
+        base_url=base_url,
+        bearer=bearer,
+        timeout_s=timeout_s,
+        opener=opener,
+    )
+    if not peer.known:
+        return (
+            ResolvedEndpoint(
+                a2a_port=None,
+                host=current_host,
+                source="host_broker_unknown_agent",
+                row=None,
+            ),
+            peer,
+        )
+    source = "host_broker" if peer.a2a_port is not None else "host_broker_no_port"
+    return (
+        ResolvedEndpoint(
+            a2a_port=peer.a2a_port,
+            host=peer.host or current_host,
+            source=source,
+            row=None,
+        ),
+        peer,
+    )

--- a/src/scitex_agent_container/cli_pkg/_send_diagnosis.py
+++ b/src/scitex_agent_container/cli_pkg/_send_diagnosis.py
@@ -118,6 +118,7 @@ def diagnose_send_failure(
     peer_host: str,
     current_host: str,
     now: float | None = None,
+    brokered: Any = None,
 ) -> dict[str, Any]:
     """Gather state-of-the-agent at the moment a send failed.
 
@@ -125,6 +126,17 @@ def diagnose_send_failure(
     ``error`` payload. Every field is explicit — an un-gatherable value
     becomes ``"unreadable: <reason>"`` / ``"unknown"`` / ``None``, never
     a silent healthy-looking default.
+
+    Inside a container the local ``state.db`` is a private, effectively
+    empty per-agent bridge DB, so EVERY field gathered below would be a
+    fabrication about a peer ("stopped", ``pid: null``, ``boot_complete:
+    false``). On that path the facts are sourced from the HOST fleet
+    registry instead, via the same broker door ``agent_status`` uses — see
+    :mod:`._send_broker` / :mod:`._send_diagnosis_brokered`. ``brokered``
+    lets the caller pass an already-fetched
+    :class:`._send_broker.BrokeredPeer` so one send costs one lookup, not
+    two. On a bare host none of this engages and the local gathering below
+    runs exactly as it always has.
 
     Fields
     ------
@@ -154,7 +166,42 @@ def diagnose_send_failure(
     peer_host: ``row["host"]`` — the host the turn was POSTed to.
     current_host: lead-side resolved host.
     now: wall-clock override for deterministic tests.
+    brokered: a pre-fetched :class:`._send_broker.BrokeredPeer`. When
+        ``None`` and we are in a container, the host is asked here.
     """
+    # --- in-container: source the facts from the HOST fleet registry -------
+    # The local reads below cannot see a single peer from inside a SIF, and
+    # their emptiness renders as death. Ask the host instead.
+    from ._send_broker import PeerLookupUnavailable, should_broker_peer_lookup
+
+    if brokered is None and should_broker_peer_lookup():
+        from ._send_broker import lookup_peer_via_host
+
+        try:
+            brokered = lookup_peer_via_host(name)
+        except PeerLookupUnavailable as exc:
+            # Could not ask → UNKNOWN. Explicitly NOT "stopped": falling back
+            # to the blind local read here would recreate the exact bug.
+            from ._send_diagnosis_brokered import unknown_lookup_diagnosis
+
+            return unknown_lookup_diagnosis(
+                name,
+                current_host=current_host,
+                reason=str(exc),
+                a2a_port=a2a_port,
+            )
+    if brokered is not None:
+        from ._send_diagnosis_brokered import brokered_diagnosis
+
+        return brokered_diagnosis(
+            name,
+            a2a_port=a2a_port,
+            peer_host=peer_host,
+            current_host=current_host,
+            peer=brokered,
+        )
+
+    # --- bare host: unchanged local gathering ------------------------------
     now = time.time() if now is None else now
     is_local = (not peer_host) or peer_host == current_host
 

--- a/src/scitex_agent_container/cli_pkg/_send_diagnosis_brokered.py
+++ b/src/scitex_agent_container/cli_pkg/_send_diagnosis_brokered.py
@@ -1,0 +1,219 @@
+"""Diagnosis built from the HOST fleet registry, for the in-container send path.
+
+Companion to :mod:`._send_diagnosis`. That module gathers its facts from the
+LOCAL ``state.db``; inside an apptainer SIF that database is a private,
+effectively empty per-agent bridge DB, so every field it produces about a
+PEER is a fabrication:
+
+    registry_status: "stopped"   <- no row (because we cannot see any row)
+    pid:             null
+    boot_complete:   false       <- no heartbeat (because we cannot see one)
+
+This module produces the same ``diagnosis`` dict from the answer the HOST's
+``sac listen`` gave us (:mod:`._send_broker`), and — where the host does not
+expose a fact — says ``unknown`` instead of inventing a healthy-looking or
+dead-looking default.
+
+The one rule that governs every choice here
+-------------------------------------------
+**Absence of evidence is not death.** A field we could not measure is
+``None`` / ``"unknown: …"``, never ``False`` and never ``"stopped"``. The
+remedy an operator (or an agent) reaches for on a "dead" verdict is
+DESTRUCTIVE — ``--force --fresh`` — so a false red kills a healthy, working
+agent while a false green merely costs a round-trip. The asymmetry is
+deliberate.
+
+Two facts, both measured on the live fleet 2026-07-14, are why this module
+refuses to promote hints into verdicts:
+
+* **The pid is deliberately NOT fetched.** ``GET /agents/<name>/status`` does
+  not carry one, and sourcing it from the registry list would import a
+  *stale* pid: a health-monitor restart gives the agent a new pid without
+  refreshing the recorded row, so ``os.kill(stale_pid, 0)`` returns False for
+  an agent that is running perfectly. That would trip the caller's
+  ``pid_alive is False`` gate and declare a live agent dead. ``pid_alive``
+  therefore stays ``None`` (UNKNOWN) on this path — a refusal, not an
+  oversight.
+
+* **An unbound /v1/turn port is NOT death.** Of the 47 agents the host knew,
+  only 5 had their ``/v1/turn`` port bound; the other 41 — including agents
+  that answered a2a messages that same minute — held a port claim with
+  nothing listening on it. Most of this fleet is reached over the a2a
+  subscriber channel, which does not require that port. So an unreachable
+  port means "this transport cannot carry the turn", never "the agent is
+  gone".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["brokered_diagnosis", "unknown_lookup_diagnosis"]
+
+# The host status route exposes no heartbeat; be explicit about the gap
+# rather than emitting a ``None`` the caller could read as "idle".
+_NO_HEARTBEAT = "unknown: not exposed by host listen GET /agents/<name>/status"
+
+_HOST_STATUS_NOTE = (
+    "HINT ONLY — never a liveness verdict. The host's STARTUP_FAILED marker "
+    "is written once and never reconciled, so it goes stale: measured "
+    "2026-07-14, scitex-writer reported 'startup_failed' from a ~2-day-old "
+    "marker while its host row held a live pid and it answered an a2a message "
+    "that same turn. Do not conclude death from this field."
+)
+
+
+def unknown_lookup_diagnosis(
+    name: str,
+    *,
+    current_host: str,
+    reason: str,
+    a2a_port: int | None = None,
+) -> dict[str, Any]:
+    """The diagnosis for "we could not ask the host" — UNKNOWN, not dead.
+
+    Every liveness field is explicitly unknown. Note what is NOT here:
+    ``registry_status`` is *not* ``"stopped"``, ``pid_alive`` is *not*
+    ``False``, ``boot_complete`` is *not* ``False``. Rendering "I could not
+    check" as "the agent is stopped" is the precise bug this whole change
+    exists to kill; reproducing it in the failure path would be absurd.
+    """
+    return {
+        "agent": name,
+        "host": current_host,
+        "is_local": None,
+        "a2a_port": a2a_port,
+        "lookup_source": "host_broker",
+        "lookup_error": reason,
+        "registry_status": f"unknown: {reason}",
+        "pid": None,
+        "pid_alive": None,
+        "last_activity": None,
+        "heartbeat_state": None,
+        "heartbeat_age_seconds": None,
+        "boot_complete": None,
+        "port_reachable": None,
+        "likely_causes": (
+            "the host listen broker could not be asked, so this agent's state "
+            "is UNKNOWN — it may well be alive and working. Absence of "
+            "evidence is NOT death: do not stop, force-restart or reap the "
+            "agent on the strength of this result. Restore the broker on the "
+            "host (`sac listen restart`) and retry the lookup."
+        ),
+    }
+
+
+def brokered_diagnosis(
+    name: str,
+    *,
+    a2a_port: int | None,
+    peer_host: str,
+    current_host: str,
+    peer: Any,
+    port_probe: Any = None,
+) -> dict[str, Any]:
+    """Build the ``diagnosis`` dict from the HOST's answer about ``name``.
+
+    Args:
+        peer: The :class:`._send_broker.BrokeredPeer` the host returned.
+        port_probe: The TCP-reachability probe to use for the agent's
+            ``/v1/turn`` port — injected so tests drive this without opening
+            a socket. Defaults to :func:`._send_diagnosis._port_reachable`.
+            Its result is recorded as a HINT about the *transport*, and is
+            never allowed to become a verdict about the *agent*.
+    """
+    if port_probe is None:
+        from ._send_diagnosis import _port_reachable as port_probe
+
+    is_local = (not peer_host) or peer_host == current_host
+    diagnosis: dict[str, Any] = {
+        "agent": name,
+        "host": peer_host or current_host,
+        "is_local": is_local,
+        "a2a_port": a2a_port,
+        # Provenance is part of the answer: a reader must never have to guess
+        # whether a verdict came from the blind container-local DB or from the
+        # real fleet registry on the host.
+        "lookup_source": "host_broker",
+        "registry_source": "host listen GET /agents/<name>/status",
+    }
+
+    if not peer.known:
+        diagnosis["registry_status"] = "not_found"
+    elif peer.a2a_port is not None:
+        # The host holds a durable a2a-port claim. Claims are released only at
+        # ``agent stop`` / ``--force``, so this is real evidence of life.
+        diagnosis["registry_status"] = "running"
+    else:
+        diagnosis["registry_status"] = "stopped"
+
+    # pid: withheld on purpose — see the module docstring. UNKNOWN, not False.
+    diagnosis["pid"] = None
+    diagnosis["pid_alive"] = None
+    diagnosis["last_activity"] = None
+    diagnosis["heartbeat_state"] = _NO_HEARTBEAT
+    diagnosis["heartbeat_age_seconds"] = None
+    # boot_complete: the host route carries no heartbeat, so we cannot know.
+    # ``False`` here would be a lie that reads as "never booted".
+    diagnosis["boot_complete"] = None
+
+    session_id = peer.body.get("session_id") if isinstance(peer.body, dict) else None
+    if session_id is not None:
+        diagnosis["session_id"] = session_id
+    if peer.host_status:
+        diagnosis["host_status"] = peer.host_status
+        diagnosis["host_status_note"] = _HOST_STATUS_NOTE
+
+    if not isinstance(a2a_port, int) or a2a_port <= 0 or not is_local:
+        diagnosis["port_reachable"] = None
+    else:
+        diagnosis["port_reachable"] = port_probe(a2a_port)
+
+    diagnosis["likely_causes"] = _interpret_brokered(diagnosis)
+    return diagnosis
+
+
+def _interpret_brokered(diagnosis: dict[str, Any]) -> str:
+    """Plain-language reading of the host's answer. Never concludes death
+    from a hint."""
+    registry = diagnosis.get("registry_status")
+    port = diagnosis.get("a2a_port")
+    reachable = diagnosis.get("port_reachable")
+    name = diagnosis.get("agent")
+
+    if registry == "not_found":
+        return (
+            "the host fleet registry has no agent by this name — check the "
+            "spelling, or the agent was never registered on this host"
+        )
+    if registry == "stopped":
+        return (
+            "the host fleet registry holds no a2a-port claim for this agent, "
+            "and a claim is released only at `sac agents stop` / --force — so "
+            "it is very likely stopped. This is the HOST's answer about the "
+            "real fleet, not a container-local guess"
+        )
+
+    # registry == "running": the host holds a live port claim.
+    if reachable is False:
+        return (
+            f"the agent IS live in the host fleet registry (it holds a2a port "
+            f"{port}), but nothing is listening on that port, so the /v1/turn "
+            f"transport cannot carry this turn. This is NOT a death verdict "
+            f"and must not be acted on as one: most agents in this fleet never "
+            f"bind /v1/turn (measured 2026-07-14: only 5 of 47 had it bound) "
+            f"and are reached over the a2a subscriber channel instead. Deliver "
+            f"with `sac a2a send {name} ...` (or the a2a_send tool), which does "
+            f"not require this port. Do NOT force-restart the agent on this "
+            f"signal — that would kill a healthy, working agent"
+        )
+    if reachable is True:
+        return (
+            "agent is live in the host fleet registry and its /v1/turn sidecar "
+            "is accepting connections; if the turn still fails, the agent is "
+            "alive and the failure is downstream of delivery"
+        )
+    return (
+        "agent is live in the host fleet registry; its /v1/turn port was not "
+        "probed from here, so reachability of that transport is UNKNOWN"
+    )

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_selection.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_selection.py
@@ -62,25 +62,29 @@ def _enumerate_fleet() -> list[str]:
 
 
 def _enumerate_running() -> list[str]:
-    """Return only the agents that are currently RUNNING (the ``--all-running`` set).
+    """Return the agents that are currently LIVE (the ``--all-running`` set).
 
     Reuses the SAME data function — and therefore the SAME liveness — the
     ``list`` / ``status`` commands use
-    (:func:`cli_pkg._helpers.get_agent_list_data`), keeping only rows whose
-    ``status`` probe read ``"running"`` (identity-based liveness: the
-    session exists AND its pane process is alive — see
-    ``_agent_list._probe_local``). Rows that are ``stopped`` / ``unknown`` /
-    ``defined`` / ``invalid`` are excluded, so a plain ``--all-running``
-    never touches an agent the operator had deliberately stopped. No separate
-    liveness rule is invented here. Order-preserving de-dup by name.
+    (:func:`cli_pkg._helpers.get_agent_list_data`). Rows that are ``stopped`` /
+    ``unknown`` / ``defined`` / ``invalid`` are excluded, so a plain
+    ``--all-running`` never touches an agent the operator had deliberately
+    stopped. No separate liveness rule is invented here. Order-preserving
+    de-dup by name.
+
+    LIVE is :func:`cli_pkg._helpers.is_live_status`, NOT ``== "running"``: an
+    ``auth-failed`` agent IS up (its session exists and its pane process is
+    alive) — it simply cannot call the API. Matching ``"running"`` alone would
+    silently skip exactly the agents that most need acting on, and a RESTART
+    cures the common cause (a token revoked by a sibling's OAuth refresh).
     """
     from ..._state.registry import Registry
-    from .._helpers import get_agent_list_data
+    from .._helpers import get_agent_list_data, is_live_status
 
     seen: set[str] = set()
     names: list[str] = []
     for row in get_agent_list_data(Registry()):
-        if row.get("status") != "running":
+        if not is_live_status(row.get("status")):
             continue
         name = row.get("name")
         if name and name not in seen:

--- a/src/scitex_agent_container/cli_pkg/ports_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/ports_cmds.py
@@ -1,0 +1,330 @@
+"""``sac ports`` — read-only inventory of the ports sac / scitex uses.
+
+Port hygiene surface (operator request): a single command that shows
+every port sac cares about, with live status, so the operator can SEE
+the assignment scheme rather than reverse-engineer it from configs.
+
+What it reports:
+
+  1. The **sac listen** control-plane port (default ``7878`` —
+     :data:`_listen._config.DEFAULT_LISTEN_PORT`), its liveness (a
+     bounded TCP-connect probe) and the on-disk pidfile
+     (``~/.scitex/agent-container/runtime/listen-<port>.pid``).
+  2. Every **a2a sidecar** port CLAIM. Read in ONE query via
+     :func:`_state.port_allocator.list_claims` (the same one-shot API
+     ``sac agents list`` uses to enrich its rows), each probed for
+     liveness with a short, bounded socket timeout so the command can
+     never hang.
+  3. A **reference map** of the scitex / sac port-assignment scheme
+     for context (see :func:`_reference_map`).
+  4. **CONFLICT** (two owners on one port) and **ORPHAN** (a claim
+     with nothing listening) flags — both computed cheaply from the
+     data already gathered.
+
+Everything here is READ-ONLY: no claim is created, released, or
+mutated. The probes are outbound TCP connects that touch nothing.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Callable
+
+import click
+
+
+def _reference_map() -> list[dict]:
+    """The scitex / sac port-assignment scheme, as a list of ``{range,
+    purpose, owner}`` rows.
+
+    This is a **sac-side** reference for operator context — there is no
+    cross-ecosystem port-registry SSOT in the codebase yet, so the
+    ``3129X`` GUI/dashboard block (owned by scitex-dev / tools) is
+    listed here by convention. The ecosystem-wide view is being routed
+    to scitex-dev separately; when that SSOT lands, this literal should
+    be replaced with a read of it rather than forked into a second copy.
+
+    The two sac-owned entries (listen port, a2a range) are read from
+    their real sources — :data:`DEFAULT_LISTEN_PORT` and the *effective*
+    allocator range (config override honoured) — so the reference never
+    drifts from what sac actually uses.
+    """
+    from .._listen._config import DEFAULT_LISTEN_PORT
+    from .._state import port_allocator
+
+    # Effective a2a range: honours ``a2a.port_range`` in config.yaml,
+    # falling back to the built-in default. Tolerant — a broken private
+    # resolver must not sink a read-only inventory.
+    try:  # stx-allow: fallback (reason: reference row must render even if config read hiccups)
+        lo, hi = port_allocator._resolve_range(None)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        lo, hi = port_allocator.DEFAULT_RANGE
+
+    return [
+        {
+            "range": str(DEFAULT_LISTEN_PORT),
+            "purpose": "sac listen — control-plane HTTP/JSON (single host port)",
+            "owner": "sac",
+        },
+        {
+            "range": f"{lo}-{hi}",
+            "purpose": "sac a2a sidecar — per-agent IPC auto-allocation range",
+            "owner": "sac (port_allocator)",
+        },
+        {
+            "range": "31290-31299",
+            "purpose": "scitex GUI / dashboard block (scitex-dev / tools)",
+            "owner": "scitex-dev (ecosystem)",
+        },
+    ]
+
+
+def _safe_probe(probe: Callable[[str, int], bool], host: str, port: int) -> bool:
+    """Run ``probe(host, port)`` and swallow any error as ``False``.
+
+    A live-probe hiccup (socket exhaustion, odd address) must degrade to
+    "not live" rather than crash the whole inventory.
+    """
+    # stx-allow: fallback (reason: a single probe failure maps to
+    # not-live; the inventory must never crash on a socket hiccup.)
+    try:
+        return bool(probe(host, port))
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return False
+
+
+def collect_ports_data(
+    *,
+    db_path: Path | None = None,
+    listen_host: str | None = None,
+    listen_port: int | None = None,
+    probe: Callable[[str, int], bool] | None = None,
+    probe_timeout: float = 0.3,
+    lock_dir: Path | None = None,
+) -> dict:
+    """Assemble the port inventory as a plain dict (JSON-ready).
+
+    Args:
+        db_path: Override the state.db location (tests). ``None`` uses
+            the default ``~/.scitex/agent-container/runtime/state.db``.
+        listen_host / listen_port: Override the resolved listen bind
+            (tests). ``None`` reads ``_listen._config`` (config.yaml >
+            built-in ``127.0.0.1:7878``).
+        probe: Liveness probe ``(host, port) -> bool``. ``None`` uses a
+            bounded :func:`_listen._port_holder.port_is_bound` with
+            ``probe_timeout``. Injected as a seam; the default is a real
+            outbound TCP connect.
+        probe_timeout: Per-port socket timeout (seconds) for the default
+            probe. Short so the command stays fast and never hangs.
+        lock_dir: Override the pidfile lock dir (tests).
+
+    Returns:
+        ``{"listen": {...}, "a2a_claims": [...], "conflicts": [...],
+        "orphans": [...], "reference": [...]}``.
+    """
+    from .._listen import _config
+    from .._listen._port_holder import port_is_bound
+    from .._listen._restart import pid_alive, pidfile_path, read_pid_from_file
+    from .._listen._single_instance import default_lock_dir
+    from .._state import port_allocator
+
+    host = listen_host if listen_host is not None else _config.listen_host()
+    lport = listen_port if listen_port is not None else _config.listen_port()
+    ldir = lock_dir if lock_dir is not None else default_lock_dir()
+
+    if probe is None:
+
+        def probe(h: str, p: int) -> bool:  # noqa: A001 — local shadow is intentional
+            return port_is_bound(h, p, timeout=probe_timeout)
+
+    # a2a claims — ONE db read (same API ``sac agents list`` uses).
+    claims = port_allocator.list_claims(db_path=db_path)
+
+    # Bounded liveness probes for listen + every claim, run concurrently
+    # so N dead claims cost ~one timeout, not N. Each probe is already
+    # timeout-bounded, so the pool only parallelises the waiting.
+    targets: list[tuple[str, int]] = [(host, lport)]
+    targets += [("127.0.0.1", c["port"]) for c in claims]
+    workers = min(8, max(1, len(targets)))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        live_flags = list(pool.map(lambda t: _safe_probe(probe, t[0], t[1]), targets))
+
+    listen_live = live_flags[0]
+    a2a_live = live_flags[1:]
+
+    pid_file = pidfile_path(lport, ldir)
+    pid = read_pid_from_file(pid_file)
+    listen_row = {
+        "kind": "listen",
+        "port": lport,
+        "host": host,
+        "purpose": "sac listen (control-plane)",
+        "owner": "sac-listen",
+        "live": bool(listen_live),
+        "pidfile": str(pid_file),
+        "pid": pid,
+        "pid_alive": bool(pid is not None and pid_alive(pid)),
+    }
+
+    a2a_rows: list[dict] = []
+    for claim, live in zip(claims, a2a_live):
+        a2a_rows.append(
+            {
+                "kind": "a2a",
+                "port": claim["port"],
+                "host": "127.0.0.1",
+                "purpose": "a2a sidecar",
+                "owner": claim["name"],
+                "live": bool(live),
+                "claimed_at": claim.get("claimed_at"),
+                "orphan": not bool(live),
+            }
+        )
+
+    # CONFLICT: >1 owner on a single port. list_claims enforces UNIQUE
+    # (port) among a2a claims, so the only way this fires is an a2a
+    # claim colliding with the listen port — but compute it generally.
+    owners_by_port: dict[int, list[str]] = defaultdict(list)
+    owners_by_port[lport].append("sac-listen")
+    for claim in claims:
+        owners_by_port[claim["port"]].append(claim["name"])
+    conflicts = [
+        {"port": port, "owners": sorted(owners)}
+        for port, owners in sorted(owners_by_port.items())
+        if len(owners) > 1
+    ]
+
+    # ORPHAN: an a2a claim with nothing listening on its port.
+    orphans = [
+        {"agent": row["owner"], "port": row["port"]} for row in a2a_rows if row["orphan"]
+    ]
+
+    return {
+        "listen": listen_row,
+        "a2a_claims": a2a_rows,
+        "conflicts": conflicts,
+        "orphans": orphans,
+        "reference": _reference_map(),
+    }
+
+
+def _live_cell(live: bool) -> str:
+    """Rich-markup Live cell — green ``● yes`` / red ``○ no``."""
+    return "[green]● yes[/green]" if live else "[red]○ no[/red]"
+
+
+def _render_table(data: dict) -> None:
+    """Print the inventory as two rich tables + a summary footer."""
+    from rich.table import Table
+
+    from ._helpers._console import console
+
+    conflict_ports = {c["port"] for c in data["conflicts"]}
+
+    inv = Table(title="Ports — sac live inventory")
+    inv.add_column("Port", justify="right", style="bold", no_wrap=True)
+    inv.add_column("Purpose")
+    inv.add_column("Owner / Agent", no_wrap=True)
+    inv.add_column("Live", justify="center")
+    inv.add_column("Flag")
+
+    for row in [data["listen"], *data["a2a_claims"]]:
+        flags: list[str] = []
+        if row["port"] in conflict_ports:
+            flags.append("[bold red]CONFLICT[/bold red]")
+        if row.get("orphan"):
+            flags.append("[yellow]ORPHAN[/yellow]")
+        inv.add_row(
+            str(row["port"]),
+            row["purpose"],
+            row["owner"],
+            _live_cell(bool(row["live"])),
+            " ".join(flags) or "—",
+        )
+    console.print(inv)
+
+    listen = data["listen"]
+    if listen.get("pid") is not None:
+        alive = "alive" if listen.get("pid_alive") else "[red]stale[/red]"
+        console.print(
+            f"[dim]listen pidfile {listen['pidfile']} → pid {listen['pid']} "
+            f"({alive})[/dim]"
+        )
+
+    ref = Table(title="Reference — scitex / sac port-assignment scheme")
+    ref.add_column("Range", justify="right", style="bold", no_wrap=True)
+    ref.add_column("Purpose")
+    ref.add_column("Owner", no_wrap=True)
+    for row in data["reference"]:
+        ref.add_row(row["range"], row["purpose"], row["owner"])
+    console.print(ref)
+    console.print(
+        "[dim]Reference is a sac-side map; the ecosystem-wide port SSOT "
+        "(incl. the 3129X GUI block) is being routed to scitex-dev.[/dim]"
+    )
+
+    live_a2a = sum(1 for r in data["a2a_claims"] if r["live"])
+    console.print(
+        f"[dim]{len(data['a2a_claims'])} a2a claim(s), {live_a2a} live; "
+        f"listen {'up' if listen['live'] else 'down'}.[/dim]"
+    )
+    if data["conflicts"]:
+        console.print(
+            f"[bold red]⚠ {len(data['conflicts'])} port conflict(s)[/bold red] "
+            "— two owners on one port."
+        )
+    if data["orphans"]:
+        console.print(
+            f"[yellow]⚠ {len(data['orphans'])} orphan claim(s)[/yellow] "
+            "— a2a port claimed, nothing listening."
+        )
+
+
+@click.command(name="ports")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a machine-readable JSON envelope.",
+)
+@click.option(
+    "--timeout",
+    "probe_timeout",
+    type=float,
+    default=0.3,
+    show_default=True,
+    help="Per-port live-probe socket timeout (seconds).",
+)
+@click.pass_context
+def ports(ctx: click.Context, as_json: bool, probe_timeout: float) -> None:
+    """List the ports sac / scitex uses, with live status.
+
+    Read-only port-hygiene inventory:
+
+    \b
+      * the sac listen control-plane port (default 7878) + liveness
+      * every a2a sidecar port CLAIM (per-agent IPC) + liveness
+      * a reference map of the scitex / sac port-assignment scheme
+      * CONFLICT (two owners on one port) and ORPHAN (claim with
+        nothing listening) flags
+
+    \b
+    Example:
+        sac ports                 # rich table
+        sac ports --json          # JSON envelope for scripts
+        sac ports --timeout 1.0   # slower / looser live probes
+    """
+    from ._helpers._json_flag import _json_flag
+
+    data = collect_ports_data(probe_timeout=probe_timeout)
+    if _json_flag(ctx, as_json):
+        click.echo(_json.dumps(data, indent=2, default=str))
+        return
+    _render_table(data)
+
+
+__all__ = ["ports", "collect_ports_data"]

--- a/tests/scitex_agent_container/_account/test_auth_failure_reason.py
+++ b/tests/scitex_agent_container/_account/test_auth_failure_reason.py
@@ -1,0 +1,219 @@
+"""Tests for the auth-failure CAUSE diagnosis — REVOKED vs genuinely EXPIRED.
+
+Claude Code renders every 401 as ``Login expired · Please run /login``. On this
+fleet that text is usually FALSE: a sibling agent's OAuth refresh consumes the
+single-use ``refresh_token``, rotates the access token, and REVOKES the one this
+agent still holds in memory. Nothing expired — and the cure is a restart, not a
+login. (Proven 2026-07-13: accounts were valid for another +4h56m..+7h28m and
+quota sat at 14% at the exact moment agents were dying.)
+
+The discriminator is ``claudeAiOauth.expiresAt`` on the agent's own credential:
+
+* still in the FUTURE ⇒ that file would authenticate a fresh process right now,
+  so a 401 can only mean the in-memory token was taken away ⇒ ``revoked``;
+* already in the PAST ⇒ a real ``expired``.
+
+No mocks and no monkeypatch: every test writes a REAL ``.credentials.json`` into
+``tmp_path`` and passes that ``tmp_path`` in as the ``home`` collaborator, so the
+production resolver runs its REAL logic (including ``account_store._store_path``)
+against real bytes on a real filesystem.
+
+TQ: AAA marker triple (TQ002), one asserted fact per test (TQ007).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._account import auth_failure_reason as afr
+
+# ---------------------------------------------------------------------------
+# Real collaborators — a config object and a credential file on disk
+# ---------------------------------------------------------------------------
+
+
+class _Claude:
+    """The ``spec.claude`` block, reduced to the one field the resolver reads."""
+
+    def __init__(self, account: str) -> None:
+        self.account = account
+
+
+class _Config:
+    """A hand-rolled stand-in for AgentConfig: only ``.claude.account`` is read."""
+
+    def __init__(self, account: str = "") -> None:
+        self.claude = _Claude(account)
+
+
+@pytest.fixture
+def now() -> float:
+    """A fixed reference instant so expiry comparisons are deterministic."""
+    return 1_784_000_000.0
+
+
+@pytest.fixture
+def snapshot(tmp_path: Path) -> Path:
+    """Where a pinned agent's credential lives under a ``home`` of ``tmp_path``.
+
+    Mirrors ``account_store._store_path``'s real layout; the tests write actual
+    bytes here and let production resolve its way to them.
+    """
+    return (
+        tmp_path
+        / ".scitex"
+        / "agent-container"
+        / "accounts"
+        / "acct"
+        / ".credentials.json"
+    )
+
+
+def _write_creds(path: Path, expires_at_s: float) -> None:
+    """Write a REAL credentials.json in claude-code's on-disk format.
+
+    claude-code stores ``expiresAt`` as a unix-MILLISECOND timestamp.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"claudeAiOauth": {"expiresAt": int(expires_at_s * 1000)}})
+    )
+
+
+# ---------------------------------------------------------------------------
+# credential_path_for — which file does this agent authenticate with?
+# ---------------------------------------------------------------------------
+
+
+def test_unpinned_agent_authenticates_with_the_host_live_credential(
+    tmp_path: Path,
+) -> None:
+    # Arrange — no spec.claude.account ⇒ the shared host file.
+    config = _Config(account="")
+    # Act
+    path = afr.credential_path_for(config, home=tmp_path)
+    # Assert
+    assert path == tmp_path / ".claude" / ".credentials.json"
+
+
+def test_pinned_agent_authenticates_with_its_account_snapshot(
+    tmp_path: Path, snapshot: Path
+) -> None:
+    # Arrange
+    config = _Config(account="acct")
+    # Act
+    path = afr.credential_path_for(config, home=tmp_path)
+    # Assert
+    assert path == snapshot
+
+
+# ---------------------------------------------------------------------------
+# diagnose_reason — the decisive comparison
+# ---------------------------------------------------------------------------
+
+
+def test_valid_credential_means_the_token_was_revoked_not_expired(
+    tmp_path: Path, snapshot: Path, now: float
+) -> None:
+    # Arrange — the on-disk credential is still good for another 7 hours, yet the
+    # watchdog caught this agent 401-ing. A fresh process would authenticate fine
+    # with this very file, so the token it holds in memory was rotated away. This
+    # is the 2026-07-13 incident, and the banner's "Login expired" is a lie.
+    _write_creds(snapshot, now + 7 * 3600)
+    config = _Config(account="acct")
+    # Act
+    reason = afr.diagnose_reason(config, now=now, home=tmp_path)
+    # Assert
+    assert reason == afr.REASON_REVOKED
+
+
+def test_past_expiry_means_the_token_genuinely_expired(
+    tmp_path: Path, snapshot: Path, now: float
+) -> None:
+    # Arrange — nothing on disk can authenticate; this one really did expire.
+    _write_creds(snapshot, now - 60)
+    config = _Config(account="acct")
+    # Act
+    reason = afr.diagnose_reason(config, now=now, home=tmp_path)
+    # Assert
+    assert reason == afr.REASON_EXPIRED
+
+
+def test_missing_credential_yields_unknown_rather_than_a_guess(
+    tmp_path: Path, now: float
+) -> None:
+    # Arrange — no snapshot written at all. A confidently-wrong cause is exactly
+    # what got us here, so the honest answer is "I could not tell".
+    config = _Config(account="acct")
+    # Act
+    reason = afr.diagnose_reason(config, now=now, home=tmp_path)
+    # Assert
+    assert reason == afr.REASON_UNKNOWN
+
+
+def test_credential_without_a_numeric_expiry_yields_unknown(
+    tmp_path: Path, snapshot: Path, now: float
+) -> None:
+    # Arrange — a real file, but no usable claudeAiOauth.expiresAt.
+    snapshot.parent.mkdir(parents=True, exist_ok=True)
+    snapshot.write_text(json.dumps({"claudeAiOauth": {}}))
+    config = _Config(account="acct")
+    # Act
+    reason = afr.diagnose_reason(config, now=now, home=tmp_path)
+    # Assert
+    assert reason == afr.REASON_UNKNOWN
+
+
+def test_absent_config_degrades_to_unknown_without_raising(tmp_path: Path, now: float) -> None:
+    # Arrange — the watchdog must still annotate a failure when the spec is gone
+    # (it then falls back to the host live file, absent under this tmp home); a
+    # diagnosis hiccup may never take down the whole fleet view.
+    # Act
+    reason = afr.diagnose_reason(None, now=now, home=tmp_path)
+    # Assert
+    assert reason == afr.REASON_UNKNOWN
+
+
+def test_diagnosis_defaults_now_to_the_wall_clock(tmp_path: Path, snapshot: Path) -> None:
+    # Arrange — an expiry 7h in the future must read as revoked with NO injected
+    # clock, proving the default `now` path is wired to real time.
+    _write_creds(snapshot, time.time() + 7 * 3600)
+    config = _Config(account="acct")
+    # Act
+    reason = afr.diagnose_reason(config, home=tmp_path)
+    # Assert
+    assert reason == afr.REASON_REVOKED
+
+
+# ---------------------------------------------------------------------------
+# remedy_for — the actionable payoff
+# ---------------------------------------------------------------------------
+
+
+def test_revoked_token_is_cured_by_a_restart() -> None:
+    # Arrange — the credential file is already valid; only the process is stale,
+    # and Claude Code never re-reads the file. No human needed.
+    # Act
+    remedy = afr.remedy_for(afr.REASON_REVOKED)
+    # Assert
+    assert remedy == "restart"
+
+
+def test_expired_token_needs_an_actual_login() -> None:
+    # Arrange — nothing on disk can authenticate; new credentials must be minted.
+    # Act
+    remedy = afr.remedy_for(afr.REASON_EXPIRED)
+    # Assert
+    assert remedy == "login"
+
+
+def test_unknown_cause_recommends_the_cheap_safe_move_first() -> None:
+    # Arrange — a restart is harmless and cures the common (revoked) case.
+    # Act
+    remedy = afr.remedy_for(afr.REASON_UNKNOWN)
+    # Assert
+    assert remedy == "restart"

--- a/tests/scitex_agent_container/_lifecycle/test__listen_probe.py
+++ b/tests/scitex_agent_container/_lifecycle/test__listen_probe.py
@@ -1,0 +1,251 @@
+"""Tests for the honest listen diagnosis — no mocks.
+
+The production module exposes an injectable ``opener`` callable that
+defaults to ``urllib.request.urlopen``; tests pass hand-rolled openers
+returning real ``urllib``-shaped response objects (the same no-mocks
+pattern as ``test__restart_client`` / ``test__spawn_client``).
+
+What is being pinned here is a HONESTY contract, and it is worth stating
+plainly. The old message asserted "the host listen broker is unreachable;
+it may be flapping" on ANY transport failure. The reporter measured the
+opposite: ``GET /health`` answered HTTP 401 in 0.18s (twice) while the
+authenticated POST hung for 25s. The daemon was UP. So:
+
+  * ANY HTTP response — including a 401 — proves the daemon is serving.
+  * Only the ABSENCE of an HTTP exchange is evidence of "unreachable".
+  * "flapping" is never asserted, because nothing here can observe a
+    crash loop.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import io
+from urllib import error as urlerror
+
+from scitex_agent_container._lifecycle._listen_probe import (
+    HealthProbe,
+    probe_listen_health,
+    transport_failure_message,
+)
+
+_BASE = "http://127.0.0.1:7878"
+
+
+class _FakeResp:
+    """A real callable response object matching the urllib contract."""
+
+    def __init__(self, body: bytes = b"{}", status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _opener_returning(status: int = 200):
+    """Build (opener, captured) — the opener records the request it saw."""
+    captured: dict = {}
+
+    def opener(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = {k.lower(): v for k, v in dict(req.headers).items()}
+        captured["timeout"] = timeout
+        return _FakeResp(status=status)
+
+    return opener, captured
+
+
+def _opener_raising(exc: Exception):
+    def opener(req, timeout=None):
+        raise exc
+
+    return opener
+
+
+def _http_error(status: int) -> urlerror.HTTPError:
+    return urlerror.HTTPError(
+        f"{_BASE}/v1/health", status, "nope", {}, io.BytesIO(b"")
+    )
+
+
+# ---------------------------------------------------------------------------
+# probe_listen_health — what did the daemon ACTUALLY do?
+# ---------------------------------------------------------------------------
+
+
+def test_probe_reads_http_200_as_serving() -> None:
+    # Arrange
+    opener, _ = _opener_returning(status=200)
+    # Act
+    probe = probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert probe.serving is True
+
+
+def test_probe_reads_http_401_as_serving() -> None:
+    # Arrange — the reporter's exact evidence: an unauthenticated GET got a
+    # 401 in 0.18s. A 401 is a RESPONSE: the daemon is up and serving.
+    opener = _opener_raising(_http_error(401))
+    # Act
+    probe = probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert probe.serving is True
+
+
+def test_probe_keeps_the_http_status_it_saw() -> None:
+    # Arrange
+    opener = _opener_raising(_http_error(401))
+    # Act
+    probe = probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert probe.status == 401
+
+
+def test_probe_reads_connection_refused_as_not_serving() -> None:
+    # Arrange — no HTTP exchange at all. THIS, and only this, is
+    # "unreachable".
+    opener = _opener_raising(urlerror.URLError("connection refused"))
+    # Act
+    probe = probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert probe.serving is False
+
+
+def test_probe_hits_the_public_health_path() -> None:
+    # Arrange — /v1/health is the ONE path BearerAuthMiddleware exempts.
+    opener, captured = _opener_returning()
+    # Act
+    probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert captured["url"] == f"{_BASE}/v1/health"
+
+
+def test_probe_sends_no_authorization_header() -> None:
+    # Arrange — the probe must exercise the path that CANNOT be wedged by a
+    # starved worker pool. Sending the bearer would route it through the very
+    # code it is trying to rule out, and it would hang with it.
+    opener, captured = _opener_returning()
+    # Act
+    probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert "authorization" not in captured["headers"]
+
+
+def test_probe_uses_a_short_timeout() -> None:
+    # Arrange — the probe runs INSIDE a failure path that already burned its
+    # own timeout; it must not add another 60s wait.
+    opener, captured = _opener_returning()
+    # Act
+    probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert captured["timeout"] <= 5.0
+
+
+def test_probe_never_raises_on_unexpected_error() -> None:
+    # Arrange — a probe that exists to improve an error message must never
+    # replace it with a crash of its own.
+    opener = _opener_raising(RuntimeError("something exotic"))
+    # Act
+    probe = probe_listen_health(_BASE, opener=opener)
+    # Assert
+    assert probe.serving is False
+
+
+# ---------------------------------------------------------------------------
+# transport_failure_message — say what was measured, and nothing more
+# ---------------------------------------------------------------------------
+
+
+def _message(probe: HealthProbe) -> str:
+    return transport_failure_message(
+        verb="restart",
+        name="neurovista",
+        base=_BASE,
+        route="POST /agents/neurovista/restart",
+        exc=TimeoutError("timed out"),
+        timeout_s=60.0,
+        probe=probe,
+    )
+
+
+_SERVING = HealthProbe(
+    serving=True,
+    status=401,
+    elapsed_s=0.18,
+    error=None,
+    url=f"{_BASE}/v1/health",
+)
+_DEAD = HealthProbe(
+    serving=False,
+    status=None,
+    elapsed_s=0.01,
+    error="connection refused",
+    url=f"{_BASE}/v1/health",
+)
+
+
+def test_message_says_daemon_is_up_when_it_answered() -> None:
+    # Arrange — daemon answered the cheap path; the authed route hung.
+    # Act
+    message = _message(_SERVING)
+    # Assert
+    assert "the listen daemon is UP and serving" in message
+
+
+def test_message_blames_the_authenticated_route_not_the_daemon() -> None:
+    # Arrange
+    # Act
+    message = _message(_SERVING)
+    # Assert
+    assert "it is the AUTHENTICATED route that did not answer" in message.replace(
+        "\n", " "
+    )
+
+
+def test_message_quotes_the_measurement_it_made() -> None:
+    # Arrange
+    # Act
+    message = _message(_SERVING)
+    # Assert — the evidence is IN the message, so the operator can check it.
+    assert "answered HTTP 401 in 0.18s" in message
+
+
+def test_message_never_claims_flapping_when_daemon_answers() -> None:
+    # Arrange — the word asserts a crash loop. Nothing here observed one.
+    # Act
+    message = _message(_SERVING)
+    # Assert
+    assert "flapping" not in message
+
+
+def test_message_never_claims_flapping_when_daemon_is_down() -> None:
+    # Arrange — even a genuinely dead daemon is not evidence of FLAPPING.
+    # Act
+    message = _message(_DEAD)
+    # Assert
+    assert "flapping" not in message
+
+
+def test_message_says_cannot_reach_when_nothing_answered() -> None:
+    # Arrange — no HTTP exchange on either route: genuinely unreachable.
+    # Act
+    message = _message(_DEAD)
+    # Assert
+    assert "cannot reach listen" in message
+
+
+def test_message_keeps_the_listen_restart_remedy_when_down() -> None:
+    # Arrange
+    # Act
+    message = _message(_DEAD)
+    # Assert
+    assert "sac listen restart" in message

--- a/tests/scitex_agent_container/_lifecycle/test__off_loop.py
+++ b/tests/scitex_agent_container/_lifecycle/test__off_loop.py
@@ -1,0 +1,198 @@
+"""``_off_loop`` — bounded off-loop dispatch, and the starvation regression.
+
+The regression these pin (CI hang, 2026-07-13, runs 29274230213 /
+29273968878): ``run_blocking`` used to dispatch through
+``loop.run_in_executor(None, ...)`` — the event loop's SHARED default
+``ThreadPoolExecutor``. A ``concurrent.futures`` future that is already
+running cannot be cancelled, so when ``wait_for`` timed out the worker
+thread kept running the wedged call forever and permanently held its slot
+in that shared pool. The pool is only ``min(32, os.cpu_count() + 4)``
+threads (6-8 on a 2-4 core CI runner), and six listen background loops
+abandon a thread every time a tick overruns. Once the pool was drained,
+every OTHER user of the default executor starved — including the
+*unbounded* ``asyncio.to_thread`` calls in the ``/agents`` spawn handler,
+``_host_exec``, ``_agent_exec_send`` and ``_forward``, which have no
+``wait_for`` to rescue them and so hung FOREVER. That is what killed the
+pytest suite (a test would print its name and never finish) and, in
+production, would wedge brokered spawns while the listen daemon silently
+degraded every probe to its fallback.
+
+NO MOCKS — a real ``threading.Event`` that is never set makes a real call
+block in a real thread; the assertions are on real dispatch behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+
+import pytest
+
+from scitex_agent_container._lifecycle._off_loop import (
+    abandoned_call_count,
+    run_blocking,
+    run_blocking_or,
+)
+
+
+def _default_pool_size() -> int:
+    """Size of the event loop's default ThreadPoolExecutor."""
+    return min(32, (os.cpu_count() or 1) + 4)
+
+
+async def _abandon_a_pools_worth(wedge) -> None:
+    """Time out enough wedged calls to drain the default executor.
+
+    Uses ``run_blocking_or`` (degrades, never raises) so the arrange phase
+    of a test carries no assertion of its own.
+    """
+    for _ in range(_default_pool_size() + 4):
+        await run_blocking_or(wedge, default=None, op="wedged probe", timeout_s=0.05)
+
+
+@pytest.fixture
+def wedge():
+    """A callable that blocks until the test releases it. Always released."""
+    released = threading.Event()
+
+    def blocker() -> str:
+        released.wait()
+        return "unblocked"
+
+    try:
+        yield blocker
+    finally:
+        # Let every abandoned daemon thread exit instead of leaking into
+        # the rest of the session.
+        released.set()
+
+
+# ---------------------------------------------------------------------------
+# Baseline contract.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_returns_the_value():
+    # Arrange
+    def seven() -> int:
+        return 7
+
+    # Act
+    got = await run_blocking(seven)
+    # Assert
+    assert got == 7
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_propagates_the_exception_unchanged():
+    # Arrange
+    def boom() -> None:
+        raise ValueError("kaboom")
+
+    # Act
+    call = run_blocking(boom)
+    # Assert
+    with pytest.raises(ValueError, match="kaboom"):
+        await call
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_times_out_on_a_wedged_call(wedge):
+    # Arrange
+    timeout_s = 0.2
+    # Act
+    call = run_blocking(wedge, timeout_s=timeout_s)
+    # Assert
+    with pytest.raises(asyncio.TimeoutError):
+        await call
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_or_degrades_to_default_on_timeout(wedge):
+    # Arrange
+    sentinel = "fallback"
+    # Act
+    got = await run_blocking_or(wedge, default=sentinel, op="probe", timeout_s=0.2)
+    # Assert
+    assert got == sentinel
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_leaves_the_event_loop_free_to_run(wedge):
+    """The loop must keep ticking while a blocking call is in flight."""
+    # Arrange
+    task = asyncio.create_task(
+        run_blocking_or(wedge, default=None, op="probe", timeout_s=1.0)
+    )
+    ticks = 0
+    # Act
+    while not task.done():
+        await asyncio.sleep(0.01)
+        ticks += 1
+    # Assert
+    assert ticks > 5
+
+
+# ---------------------------------------------------------------------------
+# THE REGRESSION — an abandoned call must starve nothing.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_abandoned_calls_do_not_starve_asyncio_to_thread(wedge):
+    """Abandon more calls than the default pool holds; ``to_thread`` must live.
+
+    This is the exact shape of the CI hang: the ``/agents`` handler awaits an
+    UNBOUNDED ``asyncio.to_thread`` for its brokered launch. Before the fix,
+    the abandoned ``run_blocking`` threads owned every slot of the shared
+    default executor and this ``to_thread`` never ran — the request never
+    returned and the test hung forever.
+    """
+    # Arrange
+    await _abandon_a_pools_worth(wedge)
+
+    def healthy() -> str:
+        return "ok"
+
+    # Act
+    try:
+        got = await asyncio.wait_for(asyncio.to_thread(healthy), timeout=10.0)
+    except asyncio.TimeoutError:
+        got = "STARVED: to_thread never ran — queued behind abandoned threads"
+    # Assert
+    assert got == "ok"
+
+
+@pytest.mark.asyncio
+async def test_abandoned_calls_do_not_starve_later_run_blocking(wedge):
+    """A healthy probe must still run after a pool's worth of wedged ones.
+
+    Otherwise every listen background loop degrades to its fallback forever:
+    heartbeats stop, the liveness tick goes blind, and nothing says why.
+    """
+    # Arrange
+    await _abandon_a_pools_worth(wedge)
+
+    def healthy() -> str:
+        return "healthy"
+
+    # Act
+    got = await run_blocking_or(
+        healthy, default="STARVED: healthy probe never ran", op="probe", timeout_s=10.0
+    )
+    # Assert
+    assert got == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_abandoned_call_count_reports_the_wedged_calls(wedge):
+    """The fail-loud gauge counts calls whose thread is still stuck."""
+    # Arrange
+    before = abandoned_call_count()
+    # Act
+    for _ in range(3):
+        await run_blocking_or(wedge, default=None, op="wedged probe", timeout_s=0.05)
+    # Assert
+    assert abandoned_call_count() == before + 3

--- a/tests/scitex_agent_container/_lifecycle/test__restart_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__restart_client.py
@@ -339,7 +339,8 @@ def test_transport_error_keeps_status_none(listen_env) -> None:
 
 
 def test_transport_error_message_carries_broker_hint(listen_env) -> None:
-    # Arrange — listen unreachable (connection refused etc.).
+    # Arrange — listen unreachable (connection refused etc.): the health
+    # probe gets nothing either, so "cannot reach" is the MEASURED verdict.
     listen_env("LISTEN_BASE_URL", "http://host:9100")
     opener = _opener_raising(urlerror.URLError("connection refused"))
     message = ""
@@ -352,6 +353,73 @@ def test_transport_error_message_carries_broker_hint(listen_env) -> None:
     # detail AND appends the cause+fix hint naming `sac listen restart`, so a
     # broker-down restart is a dead-end no longer.
     assert "cannot reach listen" in message and "sac listen restart" in message
+
+
+# ---------------------------------------------------------------------------
+# The authenticated route is wedged while the daemon is UP (2026-07-14).
+#
+# The reporter measured:
+#   GET  /health             (unauthenticated) -> HTTP 401 in 0.18s, twice
+#   POST /agents/<n>/restart (with bearer)     -> no response in 25s
+#
+# The old message asserted "the host listen broker is unreachable; it may be
+# flapping" — a diagnosis nobody had measured, and the wrong one. A timeout on
+# ONE route licenses a claim about THAT ROUTE and nothing more.
+# ---------------------------------------------------------------------------
+
+
+def _opener_wedged_authed_route():
+    """Real opener: the authenticated POST hangs; GET /v1/health answers fast.
+
+    This is the production split — authed routes dispatch through listen's
+    shared worker pool, the public health path is served on the event loop.
+    """
+
+    def opener(req, timeout=None):
+        if req.get_method() == "GET" and req.full_url.endswith("/v1/health"):
+            return _FakeResp(b'{"ok": true}', 200)
+        raise urlerror.URLError(TimeoutError("timed out"))
+
+    return opener
+
+
+def test_wedged_authed_route_reports_daemon_up(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    message = ""
+    # Act
+    try:
+        request_restart("peer", opener=_opener_wedged_authed_route())
+    except RestartRequestError as exc:
+        message = str(exc)
+    # Assert — the daemon answered the cheap path; say so.
+    assert "the listen daemon is UP and serving" in message
+
+
+def test_wedged_authed_route_never_claims_flapping(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    message = ""
+    # Act
+    try:
+        request_restart("peer", opener=_opener_wedged_authed_route())
+    except RestartRequestError as exc:
+        message = str(exc)
+    # Assert — nothing here observed a crash loop, so nothing may assert one.
+    assert "flapping" not in message
+
+
+def test_wedged_authed_route_never_claims_unreachable(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    message = ""
+    # Act
+    try:
+        request_restart("peer", opener=_opener_wedged_authed_route())
+    except RestartRequestError as exc:
+        message = str(exc)
+    # Assert — it was reached; it just did not answer THIS route.
+    assert "cannot reach listen" not in message
 
 
 def test_non_dict_2xx_body_raises_restart_request_error(listen_env) -> None:

--- a/tests/scitex_agent_container/_lifecycle/test__restart_preflight_integration.py
+++ b/tests/scitex_agent_container/_lifecycle/test__restart_preflight_integration.py
@@ -53,7 +53,21 @@ def registry(tmp_path: Path) -> Registry:
 
 
 class _FakeRuntime:
-    """Recording runtime double (is_running / start / stop)."""
+    """Recording runtime double (is_running / start / stop).
+
+    ``stop`` really stops it — i.e. ``is_running`` reads False afterwards.
+    That is not a convenience: a runtime whose ``is_running`` stays True
+    after a stop and a full SIGTERM grace is a runtime whose stop FAILED,
+    and ``agent_restart``'s teardown gate now (correctly) refuses to start
+    a replacement over such a survivor — it escalates to SIGKILL and, when
+    it still cannot confirm the agent is down, raises (see
+    ``_lifecycle/_stop_escalate.py``; the operator's 2026-07-14
+    "Agent 'neurovista' restarted" over a DOWN agent is what that closes).
+    The cases in this module are about the CREDENTIAL PRE-FLIGHT, so their
+    runtime must model a HEALTHY teardown; a stop that silently does
+    nothing would have them exercising the wedged-teardown path by
+    accident.
+    """
 
     def __init__(self, *, running: bool = False, start_result: bool = True) -> None:
         self.running = running
@@ -66,10 +80,12 @@ class _FakeRuntime:
 
     def start(self, config: Any, **_kw: Any) -> bool:
         self.start_calls.append(config)
+        self.running = True
         return self.start_result
 
     def stop(self, config: Any) -> None:
         self.stop_calls.append(config)
+        self.running = False
 
     def logs(self, config: Any, lines: int) -> str:
         return ""

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
@@ -467,6 +467,67 @@ def test_transport_error_message_carries_broker_hint(listen_env) -> None:
     assert "cannot reach listen" in message and "sac listen restart" in message
 
 
+# ---------------------------------------------------------------------------
+# The authenticated route is wedged while the daemon is UP (2026-07-14).
+#
+# Measured on the live host: an unauthenticated GET answered HTTP 401 in
+# 0.18s (twice) while the authenticated POST hung. The old message asserted
+# "the host listen broker is unreachable; it may be flapping" — unmeasured,
+# and wrong. Authed routes dispatch through listen's shared worker pool; the
+# public /v1/health path is served on the event loop and never touches it.
+# ---------------------------------------------------------------------------
+
+
+def _opener_wedged_authed_route():
+    """Real opener: the authenticated POST hangs; GET /v1/health answers fast."""
+
+    def opener(req, timeout=None):
+        if req.get_method() == "GET" and req.full_url.endswith("/v1/health"):
+            return _FakeResp(b'{"ok": true}', 200)
+        raise urlerror.URLError(TimeoutError("timed out"))
+
+    return opener
+
+
+def test_wedged_authed_route_reports_daemon_up(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    message = ""
+    # Act
+    try:
+        request_spawn("c", opener=_opener_wedged_authed_route())
+    except SpawnRequestError as exc:
+        message = str(exc)
+    # Assert
+    assert "the listen daemon is UP and serving" in message
+
+
+def test_wedged_authed_route_never_claims_flapping(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    message = ""
+    # Act
+    try:
+        request_spawn("c", opener=_opener_wedged_authed_route())
+    except SpawnRequestError as exc:
+        message = str(exc)
+    # Assert — nothing here observed a crash loop, so nothing may assert one.
+    assert "flapping" not in message
+
+
+def test_wedged_authed_route_never_claims_unreachable(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    message = ""
+    # Act
+    try:
+        request_spawn("c", opener=_opener_wedged_authed_route())
+    except SpawnRequestError as exc:
+        message = str(exc)
+    # Assert
+    assert "cannot reach listen" not in message
+
+
 def test_non_dict_2xx_body_raises_spawn_request_error(listen_env) -> None:
     # Arrange — server returns a JSON array instead of an object; must
     # fail loud rather than silently corrupt the caller's downstream use.

--- a/tests/scitex_agent_container/_lifecycle/test__stop_escalate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__stop_escalate.py
@@ -1,0 +1,625 @@
+"""Tests for the restart's stop-leg escalation — no mocks, real processes.
+
+The agent that survives SIGTERM is a REAL OS child process that REALLY
+installs ``signal.SIG_IGN`` for SIGTERM, so the operator's bug shape
+("previous runtime still running after 15.00s — SIGTERM ignored") is
+REPRODUCED rather than simulated. The escalation then sends a REAL
+SIGKILL through the REAL ``os.kill``, and the test asserts on the REAL
+child's exit status (``-signal.SIGKILL``). Nothing about the kill path is
+faked — a fake here would prove nothing, since the entire question is
+whether sac kills the right process for real.
+
+The runtimes are hand-rolled real classes implementing the production
+``RuntimeBase`` surface (the pidless one subclasses ``RuntimeBase`` so its
+``agent_pid`` IS the production default, not a test re-implementation).
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from scitex_agent_container._lifecycle._stop_escalate import (
+    StopEscalationError,
+    ensure_previous_runtime_down,
+    escalate_to_sigkill,
+    long_lived_pid,
+)
+from scitex_agent_container.config import AgentConfig, load_config
+from scitex_agent_container.runtimes.base import RuntimeBase
+
+# A child that IGNORES SIGTERM — the exact behaviour that made the stop leg
+# give up. It announces readiness on stdout so the test never races the
+# handler installation (a SIGTERM delivered before ``SIG_IGN`` is armed
+# would kill it and silently invalidate the whole test).
+_SIGTERM_DEAF = (
+    "import signal, sys, time\n"
+    "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+    "sys.stdout.write('armed\\n')\n"
+    "sys.stdout.flush()\n"
+    "time.sleep(300)\n"
+)
+
+
+def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+def _write_spec(tmp_path: Path, *, name: str = "alpha", runtime: str = "tui") -> Path:
+    """A real, validator-passing v3 spec at ``<tmp>/<name>/spec.yaml``.
+
+    ``load_config`` derives the agent name from the parent directory
+    (dir-as-SSoT), so the file must live at ``<name>/spec.yaml``.
+    """
+    agent_dir = tmp_path / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        f"  runtime: {runtime}\n"
+        "  host: ${HOSTNAME}\n"
+        f"  workdir: {tmp_path / 'work'}\n"
+        "  apptainer:\n"
+        "    image: /x.sif\n"
+        "    binds: []\n"
+        "  claude:\n"
+        "    model: sonnet\n"
+        "  health:\n"
+        "    enabled: true\n"
+        "    interval: 60\n"
+        "  restart:\n"
+        "    policy: on-failure\n"
+        "    max_retries: 3\n"
+        "  hooks:\n"
+        "    pre_start: []\n"
+        "    post_start: []\n"
+        "    pre_stop: []\n"
+        "    post_stop: []\n"
+    )
+    return spec
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path: Path) -> Iterator[None]:
+    """Redirect HOME so nothing here can read or write the LIVE fleet state.
+
+    Production code resolves ``~/.scitex/agent-container/...`` via
+    ``Path.home()``. Without this, the suite would read the developer's real
+    registry — passing locally and failing in CI, where no fleet exists.
+    """
+    prev = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = prev
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> AgentConfig:
+    return load_config(str(_write_spec(tmp_path)))
+
+
+@pytest.fixture
+def deaf_proc() -> Iterator[subprocess.Popen]:
+    """A REAL child process that ignores SIGTERM. Always reaped."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _SIGTERM_DEAF],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    if proc.stdout is not None:
+        proc.stdout.readline()  # blocks until SIG_IGN is armed
+    try:
+        yield proc
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait(timeout=10)
+        if proc.stdout is not None:
+            proc.stdout.close()
+
+
+class _RealProcessRuntime(RuntimeBase):
+    """A runtime whose agent IS a real OS process.
+
+    ``stop`` sends a REAL SIGTERM (which the deaf child ignores),
+    ``is_running`` reads the REAL process state, and ``agent_pid`` reports
+    the REAL long-lived pid — the seam the escalation aims SIGKILL at.
+    """
+
+    def __init__(self, proc: subprocess.Popen) -> None:
+        self._proc = proc
+        self.stop_calls = 0
+        self.start_calls = 0
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        self.start_calls += 1
+        return True
+
+    def stop(self, config: AgentConfig) -> bool:
+        self.stop_calls += 1
+        self._proc.terminate()  # a REAL SIGTERM
+        return True
+
+    def is_running(self, config: AgentConfig) -> bool:
+        return self._proc.poll() is None
+
+    def logs(self, config: AgentConfig, lines: int = 50) -> str:
+        return ""
+
+    def agent_pid(self, config: AgentConfig) -> int | None:
+        return self._proc.pid
+
+
+class _PidlessRuntime(RuntimeBase):
+    """Alive, and cannot name a local pid — the docker / SSHRemote shape.
+
+    ``agent_pid`` is NOT overridden: this exercises the REAL
+    ``RuntimeBase.agent_pid`` default (``None`` = honestly unknown), which
+    is precisely the case where escalation is impossible.
+    """
+
+    def __init__(self) -> None:
+        self.start_calls = 0
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        self.start_calls += 1
+        return True
+
+    def stop(self, config: AgentConfig) -> bool:
+        return False
+
+    def is_running(self, config: AgentConfig) -> bool:
+        return True
+
+    def logs(self, config: AgentConfig, lines: int = 50) -> str:
+        return ""
+
+
+class _UnkillableRuntime(RuntimeBase):
+    """Names a pid, but nothing makes it stop (SIGKILL wedged in D-state).
+
+    ``kill_fn`` is injected by the caller as a real recording callable, so
+    no real process is signalled and the "SIGKILL landed but the process is
+    STILL there" branch is reachable deterministically.
+    """
+
+    def __init__(self, pid: int) -> None:
+        self._pid = pid
+        self.signals: list[int] = []
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        return True
+
+    def stop(self, config: AgentConfig) -> bool:
+        return False
+
+    def is_running(self, config: AgentConfig) -> bool:
+        return True
+
+    def logs(self, config: AgentConfig, lines: int = 50) -> str:
+        return ""
+
+    def agent_pid(self, config: AgentConfig) -> int | None:
+        return self._pid
+
+
+class _StoppedRuntime(RuntimeBase):
+    """Already down — the healthy teardown."""
+
+    def __init__(self) -> None:
+        self.pid_reads = 0
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        return True
+
+    def stop(self, config: AgentConfig) -> bool:
+        return True
+
+    def is_running(self, config: AgentConfig) -> bool:
+        return False
+
+    def logs(self, config: AgentConfig, lines: int = 50) -> str:
+        return ""
+
+    def agent_pid(self, config: AgentConfig) -> int | None:
+        self.pid_reads += 1
+        return 1234
+
+
+# ---------------------------------------------------------------------------
+# long_lived_pid — the seam that decides WHAT gets SIGKILLed
+# ---------------------------------------------------------------------------
+
+
+def test_long_lived_pid_reports_the_real_process_pid(
+    config: AgentConfig, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange
+    runtime = _RealProcessRuntime(deaf_proc)
+    # Act
+    pid = long_lived_pid(runtime, config)
+    # Assert
+    assert pid == deaf_proc.pid
+
+
+def test_long_lived_pid_is_none_without_the_seam(config: AgentConfig) -> None:
+    # Arrange — the production RuntimeBase default (docker / SSHRemote).
+    runtime = _PidlessRuntime()
+    # Act
+    pid = long_lived_pid(runtime, config)
+    # Assert — honestly unknown, never a guess.
+    assert pid is None
+
+
+def test_long_lived_pid_refuses_pid_zero(config: AgentConfig) -> None:
+    # Arrange — os.kill(0, SIGKILL) would signal sac's ENTIRE process group;
+    # a runtime bug returning 0 must never become a fleet-wide massacre.
+    runtime = _UnkillableRuntime(pid=0)
+    # Act
+    pid = long_lived_pid(runtime, config)
+    # Assert
+    assert pid is None
+
+
+def test_long_lived_pid_refuses_negative_pid(config: AgentConfig) -> None:
+    # Arrange — os.kill(-1, ...) signals every process this user owns.
+    runtime = _UnkillableRuntime(pid=-1)
+    # Act
+    pid = long_lived_pid(runtime, config)
+    # Assert
+    assert pid is None
+
+
+def test_long_lived_pid_refuses_our_own_pid(config: AgentConfig) -> None:
+    # Arrange — sac must not SIGKILL itself mid-restart.
+    runtime = _UnkillableRuntime(pid=os.getpid())
+    # Act
+    pid = long_lived_pid(runtime, config)
+    # Assert
+    assert pid is None
+
+
+# ---------------------------------------------------------------------------
+# escalate_to_sigkill — a REAL SIGKILL against a REAL SIGTERM-deaf process
+# ---------------------------------------------------------------------------
+
+
+def test_escalation_really_kills_the_sigterm_deaf_process(
+    config: AgentConfig, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange — the real bug shape: SIGTERM is sent and IGNORED.
+    runtime = _RealProcessRuntime(deaf_proc)
+    runtime.stop(config)
+    # Act — real os.kill, no injected kill_fn.
+    escalate_to_sigkill(config.name, config, runtime, sleep_fn=_no_sleep)
+    # Assert — the REAL child died of a REAL SIGKILL.
+    assert deaf_proc.wait(timeout=10) == -signal.SIGKILL
+
+
+def test_escalation_reports_stopped_after_the_kill(
+    config: AgentConfig, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange
+    runtime = _RealProcessRuntime(deaf_proc)
+    runtime.stop(config)
+    # Act
+    stopped, _pid = escalate_to_sigkill(
+        config.name, config, runtime, sleep_fn=_no_sleep
+    )
+    # Assert — the verdict is the runtime's OWN is_running, post-kill.
+    assert stopped is True
+
+
+def test_escalation_reports_the_pid_it_killed(
+    config: AgentConfig, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange
+    runtime = _RealProcessRuntime(deaf_proc)
+    # Act
+    _stopped, pid = escalate_to_sigkill(
+        config.name, config, runtime, sleep_fn=_no_sleep
+    )
+    # Assert
+    assert pid == deaf_proc.pid
+
+
+def test_escalation_cannot_kill_without_a_pid(config: AgentConfig) -> None:
+    # Arrange — a runtime that is UP and cannot name a pid.
+    runtime = _PidlessRuntime()
+    # Act
+    stopped, _pid = escalate_to_sigkill(
+        config.name, config, runtime, sleep_fn=_no_sleep
+    )
+    # Assert — no signal was sent and the agent is still up: NOT stopped.
+    assert stopped is False
+
+
+def test_escalation_sends_sigkill_not_sigterm(config: AgentConfig) -> None:
+    # Arrange — a real recording kill callable (injection seam, not a mock).
+    runtime = _UnkillableRuntime(pid=999_000)
+    # Act
+    escalate_to_sigkill(
+        config.name,
+        config,
+        runtime,
+        sleep_fn=_no_sleep,
+        settle_s=0.01,
+        kill_fn=lambda pid, sig: runtime.signals.append(sig),
+    )
+    # Assert — the escalation is a KILL; the TERM already failed.
+    assert runtime.signals == [signal.SIGKILL]
+
+
+def test_escalation_reports_not_stopped_when_kill_does_not_land(
+    config: AgentConfig,
+) -> None:
+    # Arrange — SIGKILL "delivered" but the process is still there
+    # (uninterruptible D-state I/O).
+    runtime = _UnkillableRuntime(pid=999_000)
+    # Act
+    stopped, _pid = escalate_to_sigkill(
+        config.name,
+        config,
+        runtime,
+        sleep_fn=_no_sleep,
+        settle_s=0.01,
+        kill_fn=lambda pid, sig: runtime.signals.append(sig),
+    )
+    # Assert — we sent the signal, but we do NOT claim it worked.
+    assert stopped is False
+
+
+# ---------------------------------------------------------------------------
+# ensure_previous_runtime_down — the gate: escalate, else RAISE (never proceed)
+# ---------------------------------------------------------------------------
+
+
+def _gate(
+    tmp_path: Path,
+    runtime: Any,
+    *,
+    timeout_s: float = 0.05,
+    settle_s: float = 5.0,
+    kill_fn: Any = os.kill,
+    name: str = "alpha",
+) -> None:
+    """Act helper: run the REAL gate against ``runtime``.
+
+    ``timeout_s`` (the SIGTERM grace) is tiny so the test is fast. ``settle_s``
+    keeps the PRODUCTION default: SIGKILLing a REAL process and seeing it reaped
+    is not instantaneous, and a sub-100ms settle here would flake on a loaded
+    host — which would be the test lying about a kill that did in fact work.
+    Tests that assert the RAISE path pass a small ``settle_s`` explicitly,
+    because in those the process is deliberately never going to die.
+    """
+    ensure_previous_runtime_down(
+        name,
+        str(tmp_path / name / "spec.yaml"),
+        runtime_factory=lambda _c: runtime,
+        sleep_fn=_no_sleep,
+        timeout_s=timeout_s,
+        settle_s=settle_s,
+        kill_fn=kill_fn,
+    )
+
+
+def test_gate_returns_silently_when_runtime_already_stopped(tmp_path: Path) -> None:
+    # Arrange
+    _write_spec(tmp_path)
+    runtime = _StoppedRuntime()
+    # Act
+    _gate(tmp_path, runtime)
+    # Assert — a healthy teardown never reaches the kill path.
+    assert runtime.pid_reads == 0
+
+
+def test_gate_escalates_and_kills_the_deaf_runtime(
+    tmp_path: Path, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange — SIGTERM sent and ignored; the grace will expire.
+    _write_spec(tmp_path)
+    runtime = _RealProcessRuntime(deaf_proc)
+    runtime.stop(load_config(str(tmp_path / "alpha" / "spec.yaml")))
+    # Act
+    _gate(tmp_path, runtime)
+    # Assert — the survivor is REALLY dead, so the start leg cannot collide.
+    assert deaf_proc.wait(timeout=10) == -signal.SIGKILL
+
+
+def test_gate_raises_when_runtime_cannot_be_stopped(tmp_path: Path) -> None:
+    # Arrange — up, and impossible to kill (no nameable pid).
+    _write_spec(tmp_path)
+    # Act
+    call = lambda: _gate(tmp_path, _PidlessRuntime())  # noqa: E731
+    # Assert — the gate REFUSES to fall through into a guaranteed collision.
+    with pytest.raises(StopEscalationError):
+        call()
+
+
+def test_gate_error_says_the_agent_was_not_restarted(tmp_path: Path) -> None:
+    # Arrange
+    _write_spec(tmp_path)
+    message = ""
+    # Act
+    try:
+        _gate(tmp_path, _PidlessRuntime())
+    except StopEscalationError as exc:
+        message = str(exc)
+    # Assert — the old code printed "restarted" here; the message must say
+    # the opposite, in the operator's own terms.
+    assert "was NOT restarted" in message
+
+
+def test_gate_error_names_the_still_running_agent(tmp_path: Path) -> None:
+    # Arrange
+    _write_spec(tmp_path, name="neurovista")
+    message = ""
+    # Act
+    try:
+        _gate(tmp_path, _PidlessRuntime(), name="neurovista")
+    except StopEscalationError as exc:
+        message = str(exc)
+    # Assert
+    assert "neurovista" in message
+
+
+def test_gate_error_carries_a_remedy_that_works(tmp_path: Path) -> None:
+    # Arrange — a TUI agent (the neurovista shape).
+    _write_spec(tmp_path, name="neurovista", runtime="tui")
+    message = ""
+    # Act
+    try:
+        _gate(tmp_path, _PidlessRuntime(), name="neurovista")
+    except StopEscalationError as exc:
+        message = str(exc)
+    # Assert — NOT `sac agents restart` (the command that just failed).
+    assert "tmux kill-session -t tui-neurovista" in message
+
+
+def test_gate_error_carries_the_pid_it_could_not_kill(tmp_path: Path) -> None:
+    # Arrange
+    _write_spec(tmp_path)
+    runtime = _UnkillableRuntime(pid=999_000)
+    captured: object = None
+    # Act
+    try:
+        _gate(
+            tmp_path,
+            runtime,
+            settle_s=0.05,
+            kill_fn=lambda pid, sig: runtime.signals.append(sig),
+        )
+    except StopEscalationError as exc:
+        captured = exc.pid
+    # Assert — structured, so a caller need not re-parse the message.
+    assert captured == 999_000
+
+
+def test_gate_bypasses_entirely_on_zero_timeout(tmp_path: Path) -> None:
+    # Arrange — the legacy fixed-sleep bypass, retained for callers that
+    # deliberately skip the gate. A running runtime must NOT raise here.
+    _write_spec(tmp_path)
+    runtime = _PidlessRuntime()
+    # Act
+    _gate(tmp_path, runtime, timeout_s=0.0)
+    # Assert — reaching this line at all is the contract (no raise).
+    assert runtime.is_running(load_config(str(tmp_path / "alpha" / "spec.yaml")))
+
+
+# ---------------------------------------------------------------------------
+# agent_restart — the whole chain, end to end.
+#
+# The operator's terminal, 2026-07-14:
+#
+#   WARN: previous runtime still running after 15.00s (SIGTERM ignored...);
+#         proceeding to start anyway.
+#   FAIL: duplicate session 'tui-neurovista' — agent already running.
+#   Agent 'neurovista' restarted        <-- IT WAS NOT
+#
+# Two contracts, one per failure mode of the stop leg:
+#   * the survivor CAN be killed  -> kill it, then really restart;
+#   * the survivor CANNOT be killed -> RAISE. Never start (the start would
+#     collide with it), never report success.
+# ---------------------------------------------------------------------------
+
+
+class _FakeHandover:
+    """Real collaborator matching the handover module surface."""
+
+    def ensure_instance_uuid(self, config: AgentConfig) -> str:
+        return "fake-uuid"
+
+    def hydrate_from_hub(self, config: AgentConfig) -> bool:
+        return True
+
+    def push_pre_stop_snapshot(
+        self, config: AgentConfig, payload: dict | None = None
+    ) -> bool:
+        return True
+
+    def start_failback_poller(self, config: AgentConfig) -> None:
+        return None
+
+
+def _restart(tmp_path: Path, runtime: Any, *, name: str = "alpha") -> bool:
+    """Act helper: drive the REAL ``agent_restart`` against ``runtime``."""
+    from scitex_agent_container._lifecycle import lifecycle as lc
+    from scitex_agent_container._state.registry import Registry
+
+    registry = Registry(registry_dir=tmp_path / "reg")
+    registry.add(name, str(tmp_path / name / "spec.yaml"), f"cld-{name}")
+    return lc.agent_restart(
+        name,
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        sleep_fn=_no_sleep,
+        handover_mod=_FakeHandover(),
+        # The credential pre-flight is a separate production seam with its own
+        # suite; injecting a real no-op callable keeps THIS test about the stop
+        # leg (and off the network).
+        successor_auth_check=lambda _path: None,
+        wait_for_stop_timeout_s=0.05,
+    )
+
+
+def test_restart_kills_the_runtime_that_ignored_sigterm(
+    tmp_path: Path, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange — the neurovista shape: a REAL process that ignores SIGTERM.
+    _write_spec(tmp_path)
+    # Act
+    _restart(tmp_path, _RealProcessRuntime(deaf_proc))
+    # Assert — the previous runtime is REALLY gone, so the new one cannot
+    # collide with it ("duplicate session") on the way up.
+    assert deaf_proc.wait(timeout=10) == -signal.SIGKILL
+
+
+def test_restart_starts_the_replacement_after_escalating(
+    tmp_path: Path, deaf_proc: subprocess.Popen
+) -> None:
+    # Arrange
+    _write_spec(tmp_path)
+    runtime = _RealProcessRuntime(deaf_proc)
+    # Act
+    _restart(tmp_path, runtime)
+    # Assert — escalation is not an abort: the restart still restarts.
+    assert runtime.start_calls == 1
+
+
+def test_restart_raises_when_the_survivor_cannot_be_killed(tmp_path: Path) -> None:
+    # Arrange — up, and unkillable (no nameable pid).
+    _write_spec(tmp_path)
+    # Act
+    call = lambda: _restart(tmp_path, _PidlessRuntime())  # noqa: E731
+    # Assert — the old code returned True here and the CLI printed
+    # "Agent 'neurovista' restarted" over an agent that was left DOWN.
+    with pytest.raises(StopEscalationError):
+        call()
+
+
+def test_restart_never_starts_over_a_surviving_runtime(tmp_path: Path) -> None:
+    # Arrange
+    _write_spec(tmp_path)
+    runtime = _PidlessRuntime()
+    # Act
+    try:
+        _restart(tmp_path, runtime)
+    except StopEscalationError:
+        pass
+    # Assert — the gate must not walk into the collision it just predicted.
+    assert runtime.start_calls == 0

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -1680,18 +1680,38 @@ def test_agent_restart_polls_is_running_until_false(
 # ---------------------------------------------------------------------------
 
 
+# A previous runtime that will NOT die: ``is_running`` stays True forever and
+# ``FakeRuntime`` never overrides ``agent_pid``, so the escalation has nothing
+# to SIGKILL. This is the shape that produced the operator's 2026-07-14
+# terminal:
+#
+#   WARN: previous runtime still running after 15.00s (SIGTERM ignored...);
+#         proceeding to start anyway.
+#   FAIL: duplicate session 'tui-neurovista' — agent already running.
+#   Agent 'neurovista' restarted        <-- IT WAS NOT
+#
+# The gate PREDICTED the collision, proceeded into it, and the restart then
+# reported success over an agent that was left DOWN. These cases used to
+# assert exactly that behaviour ("returns True", "starts anyway"); they now
+# assert its opposite. A stop that could not stop the thing must not report
+# success and must not start a replacement that is guaranteed to collide.
+
+
 def _build_unkillable_setup(
     tmp_path: Path, registry: Registry, caplog: Any
 ) -> _StaggeredRuntime:
     """Arrange helper: previous runtime whose ``is_running`` stays True
-    forever; caplog routed to the stop module so WARN records are
-    captured for the warning-content assertion.
+    forever and which cannot name a pid to kill; caplog routed to the
+    escalation module so its WARN records are captured.
     """
     import logging as _logging
 
     spec = _write_spec(tmp_path)
     registry.add("alpha", str(spec), "cld-alpha")
-    caplog.set_level(_logging.WARNING, logger="scitex_agent_container._lifecycle._stop")
+    caplog.set_level(
+        _logging.WARNING,
+        logger="scitex_agent_container._lifecycle._stop_escalate",
+    )
     return _StaggeredRuntime(stages=[True])
 
 
@@ -1711,39 +1731,52 @@ def _restart_alpha_with_short_wait(
     )
 
 
-def test_agent_restart_returns_true_when_previous_runtime_will_not_exit(
+def test_agent_restart_raises_when_previous_runtime_will_not_exit(
     tmp_path: Path, registry: Registry, caplog: Any
 ) -> None:
     # Arrange
+    from scitex_agent_container._lifecycle._stop_escalate import StopEscalationError
+
     runtime = _build_unkillable_setup(tmp_path, registry, caplog)
     # Act
-    ok = _restart_alpha_with_short_wait(runtime, registry)
-    # Assert
-    assert ok is True
+    call = lambda: _restart_alpha_with_short_wait(runtime, registry)  # noqa: E731
+    # Assert — it used to return True here, and the CLI printed "restarted".
+    with pytest.raises(StopEscalationError):
+        call()
 
 
-def test_agent_restart_starts_new_runtime_when_previous_runtime_will_not_exit(
+def test_agent_restart_does_not_start_when_previous_runtime_will_not_exit(
     tmp_path: Path, registry: Registry, caplog: Any
 ) -> None:
     # Arrange
+    from scitex_agent_container._lifecycle._stop_escalate import StopEscalationError
+
     runtime = _build_unkillable_setup(tmp_path, registry, caplog)
     # Act
-    _restart_alpha_with_short_wait(runtime, registry)
-    # Assert
-    assert len(runtime.start_calls) == 1
+    try:
+        _restart_alpha_with_short_wait(runtime, registry)
+    except StopEscalationError:
+        pass
+    # Assert — starting here is what caused the duplicate-session collision.
+    assert len(runtime.start_calls) == 0
 
 
 def test_agent_restart_warns_about_still_running_previous_runtime(
     tmp_path: Path, registry: Registry, caplog: Any
 ) -> None:
     # Arrange
+    from scitex_agent_container._lifecycle._stop_escalate import StopEscalationError
+
     runtime = _build_unkillable_setup(tmp_path, registry, caplog)
     # Act
-    _restart_alpha_with_short_wait(runtime, registry)
+    try:
+        _restart_alpha_with_short_wait(runtime, registry)
+    except StopEscalationError:
+        pass
     messages = " ".join(rec.getMessage() for rec in caplog.records)
-    # Assert — a WARN log mentions the race so a future "telegrammer
-    # dropped after restart" recurrence is self-diagnosing from stdout.log.
-    assert "still running" in messages or "SIGTERM" in messages
+    # Assert — a WARN log still names the SIGTERM-deaf runtime, so a
+    # recurrence stays self-diagnosing from stdout.log.
+    assert "SIGTERM" in messages
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_state/test_auth_state.py
+++ b/tests/scitex_agent_container/_state/test_auth_state.py
@@ -1,0 +1,319 @@
+"""Tests for the cached per-agent auth verdict (``agent_auth_state``).
+
+The table that lets ``sac agents list`` say "this agent is tmux-GREEN but cannot
+call the API" without probing auth inline. Two halves are covered:
+
+* the STORE — a real state.db in ``tmp_path``, real rows, real sqlite (no mocks,
+  no monkeypatch): write via the watchdog's ``record_auth_checks``, read back via
+  the list's ``list_auth_states``;
+* the HONESTY RULES in :func:`verdict_for` — pure, so they are exercised with
+  plain dicts and an injected ``now``: a verdict has an AGE (stale evidence is
+  flagged, never asserted as fresh) and a SCOPE (a verdict older than the agent's
+  current ``started_at`` describes a dead incarnation and is discarded).
+
+TQ: AAA marker triple (TQ002), one asserted fact per test (TQ007),
+behaviour-naming (TQ003).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state import auth_state as aus
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Path:
+    """A per-test state.db path; the writer creates the schema on demand."""
+    return tmp_path / "state.db"
+
+
+@pytest.fixture
+def now() -> datetime:
+    """A fixed reference instant, so age/staleness assertions are deterministic."""
+    return datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _stamp(moment: datetime) -> str:
+    """``moment`` in the exact ISO-8601 UTC 'Z' shape the store writes."""
+    return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# record_auth_checks / list_auth_states — the store round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_recorded_failing_agent_reads_back_as_auth_failed(db: Path) -> None:
+    # Arrange
+    aus.record_auth_check("figrecipe", True, banner="Login expired", db_path=db)
+    # Act
+    state = aus.list_auth_states(db_path=db)["figrecipe"]
+    # Assert
+    assert state["auth_failed"] is True
+
+
+def test_recorded_healthy_agent_reads_back_as_not_failed(db: Path) -> None:
+    # Arrange
+    aus.record_auth_check("worker", False, db_path=db)
+    # Act
+    state = aus.list_auth_states(db_path=db)["worker"]
+    # Assert
+    assert state["auth_failed"] is False
+
+
+def test_recorded_check_carries_the_diagnosed_reason(db: Path) -> None:
+    # Arrange
+    aus.record_auth_check("figrecipe", True, reason="revoked", db_path=db)
+    # Act
+    state = aus.list_auth_states(db_path=db)["figrecipe"]
+    # Assert
+    assert state["reason"] == "revoked"
+
+
+def test_recorded_check_stamps_checked_at(db: Path) -> None:
+    # Arrange
+    aus.record_auth_check("worker", False, checked_at="2026-07-13T11:59:00Z", db_path=db)
+    # Act
+    state = aus.list_auth_states(db_path=db)["worker"]
+    # Assert
+    assert state["checked_at"] == "2026-07-13T11:59:00Z"
+
+
+def test_re_recording_an_agent_overwrites_rather_than_duplicating(db: Path) -> None:
+    # Arrange — the watchdog re-runs and the agent has recovered.
+    aus.record_auth_check("figrecipe", True, db_path=db)
+    aus.record_auth_check("figrecipe", False, db_path=db)
+    # Act
+    state = aus.list_auth_states(db_path=db)["figrecipe"]
+    # Assert
+    assert state["auth_failed"] is False
+
+
+def test_batch_write_records_every_named_agent(db: Path) -> None:
+    # Arrange
+    checks = [
+        {"name": "a", "auth_failed": False},
+        {"name": "b", "auth_failed": True},
+    ]
+    aus.record_auth_checks(checks, db_path=db)
+    # Act
+    names = sorted(aus.list_auth_states(db_path=db))
+    # Assert
+    assert names == ["a", "b"]
+
+
+def test_clear_auth_state_removes_the_agents_verdict(db: Path) -> None:
+    # Arrange
+    aus.record_auth_check("figrecipe", True, db_path=db)
+    aus.clear_auth_state("figrecipe", db_path=db)
+    # Act
+    states = aus.list_auth_states(db_path=db)
+    # Assert
+    assert "figrecipe" not in states
+
+
+# ---------------------------------------------------------------------------
+# list_auth_states — the CHEAP read: never create, never crash
+# ---------------------------------------------------------------------------
+
+
+def test_read_of_absent_db_returns_no_verdicts(tmp_path: Path) -> None:
+    # Arrange — a host where no watchdog has ever run.
+    missing = tmp_path / "never-created.db"
+    # Act
+    states = aus.list_auth_states(db_path=missing)
+    # Assert
+    assert states == {}
+
+
+def test_read_of_absent_db_does_not_create_it(tmp_path: Path) -> None:
+    # Arrange — the READ path must not materialise a state.db (nor take a
+    # write lock) just because an operator typed `sac agents list`.
+    missing = tmp_path / "never-created.db"
+    # Act
+    aus.list_auth_states(db_path=missing)
+    # Assert
+    assert missing.exists() is False
+
+
+def test_read_of_db_without_the_table_returns_no_verdicts(tmp_path: Path) -> None:
+    # Arrange — a real, pre-existing state.db that no watchdog has written to,
+    # so `agent_auth_state` does not exist yet.
+    from scitex_agent_container._state.state_db import init_schema
+
+    db_path = tmp_path / "state.db"
+    init_schema(db_path)
+    # Act
+    states = aus.list_auth_states(db_path=db_path)
+    # Assert
+    assert states == {}
+
+
+# ---------------------------------------------------------------------------
+# Staleness — a cache is not truth, it has an age
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_verdict_is_not_stale(now: datetime) -> None:
+    # Arrange — checked 60 seconds ago.
+    checked = _stamp(now - timedelta(seconds=60))
+    # Act
+    stale = aus.is_stale(checked, now=now)
+    # Assert
+    assert stale is False
+
+
+def test_six_hour_old_verdict_is_stale(now: datetime) -> None:
+    # Arrange — the evidence the operator must not be shown as fresh truth.
+    checked = _stamp(now - timedelta(hours=6))
+    # Act
+    stale = aus.is_stale(checked, now=now)
+    # Assert
+    assert stale is True
+
+
+def test_never_checked_is_not_reported_as_stale(now: datetime) -> None:
+    # Arrange — no stamp at all is NO EVIDENCE, a different state from old
+    # evidence; readers discriminate on the empty checked_at, not on this flag.
+    # Act
+    stale = aus.is_stale("", now=now)
+    # Assert
+    assert stale is False
+
+
+def test_age_of_a_future_stamp_clamps_to_zero(now: datetime) -> None:
+    # Arrange — clock skew between the watchdog host and the reader.
+    checked = _stamp(now + timedelta(minutes=5))
+    # Act
+    age = aus.age_seconds(checked, now=now)
+    # Assert
+    assert age == 0.0
+
+
+# ---------------------------------------------------------------------------
+# verdict_for — the pure read-side rule
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_for_reports_a_current_failure(now: datetime) -> None:
+    # Arrange
+    state = {"auth_failed": True, "checked_at": _stamp(now), "reason": "revoked"}
+    # Act
+    fields = aus.verdict_for(state, started_at=_stamp(now - timedelta(hours=1)), now=now)
+    # Assert
+    assert fields["auth_failed"] is True
+
+
+def test_verdict_for_exposes_the_age_of_the_evidence(now: datetime) -> None:
+    # Arrange
+    state = {"auth_failed": True, "checked_at": _stamp(now - timedelta(minutes=2))}
+    # Act
+    fields = aus.verdict_for(state, now=now)
+    # Assert
+    assert fields["auth_check_age_s"] == 120
+
+
+def test_verdict_for_flags_an_old_failure_as_stale(now: datetime) -> None:
+    # Arrange — still shown (nothing self-heals) but marked as weak evidence.
+    state = {"auth_failed": True, "checked_at": _stamp(now - timedelta(hours=6))}
+    # Act
+    fields = aus.verdict_for(state, now=now)
+    # Assert
+    assert fields["auth_check_stale"] is True
+
+
+def test_verdict_for_derives_the_remedy_from_the_reason(now: datetime) -> None:
+    # Arrange — a REVOKED token is cured by a restart, not by logging in.
+    state = {"auth_failed": True, "checked_at": _stamp(now), "reason": "revoked"}
+    # Act
+    fields = aus.verdict_for(state, now=now)
+    # Assert
+    assert fields["auth_remedy"] == "restart"
+
+
+def test_verdict_for_prescribes_login_for_a_genuinely_expired_token(
+    now: datetime,
+) -> None:
+    # Arrange
+    state = {"auth_failed": True, "checked_at": _stamp(now), "reason": "expired"}
+    # Act
+    fields = aus.verdict_for(state, now=now)
+    # Assert
+    assert fields["auth_remedy"] == "login"
+
+
+def test_verdict_predating_the_current_start_is_discarded(now: datetime) -> None:
+    # Arrange — the operator restarted the wedged agent 1 minute ago; the
+    # watchdog's older FAILING verdict describes the incarnation that is gone.
+    # Replaying it would call the agent broken at the exact moment it was fixed.
+    state = {"auth_failed": True, "checked_at": _stamp(now - timedelta(hours=2))}
+    started_at = _stamp(now - timedelta(minutes=1))
+    # Act
+    fields = aus.verdict_for(state, started_at=started_at, now=now)
+    # Assert
+    assert fields["auth_failed"] is False
+
+
+def test_verdict_predating_the_current_start_reports_no_evidence(
+    now: datetime,
+) -> None:
+    # Arrange — and it must read as NEVER-CHECKED (no evidence), not as a
+    # healthy check, so the reader says "unverified" rather than "fine".
+    state = {"auth_failed": True, "checked_at": _stamp(now - timedelta(hours=2))}
+    started_at = _stamp(now - timedelta(minutes=1))
+    # Act
+    fields = aus.verdict_for(state, started_at=started_at, now=now)
+    # Assert
+    assert fields["auth_checked_at"] == ""
+
+
+def test_verdict_taken_after_the_current_start_is_kept(now: datetime) -> None:
+    # Arrange — checked AFTER this incarnation booted ⇒ it describes this
+    # process, and a still-wedged agent must keep reading as failing.
+    state = {"auth_failed": True, "checked_at": _stamp(now - timedelta(minutes=1))}
+    started_at = _stamp(now - timedelta(hours=2))
+    # Act
+    fields = aus.verdict_for(state, started_at=started_at, now=now)
+    # Assert
+    assert fields["auth_failed"] is True
+
+
+def test_verdict_for_never_checked_agent_makes_no_claim() -> None:
+    # Arrange — no cached row at all.
+    # Act
+    fields = aus.verdict_for(None)
+    # Assert
+    assert fields["auth_checked_at"] == ""
+
+
+def test_verdict_for_never_checked_agent_is_not_called_failing() -> None:
+    # Arrange — absence of evidence is not evidence of failure.
+    # Act
+    fields = aus.verdict_for(None)
+    # Assert
+    assert fields["auth_failed"] is False
+
+
+def test_stored_verdict_survives_the_full_write_read_verdict_path(
+    db: Path, now: datetime
+) -> None:
+    # Arrange — the real end-to-end shape: watchdog writes, list reads, rule
+    # applies. No mocks anywhere: a real sqlite file, a real row.
+    aus.record_auth_checks(
+        [{"name": "figrecipe", "auth_failed": True, "reason": "revoked"}],
+        checked_at=_stamp(now - timedelta(minutes=3)),
+        db_path=db,
+    )
+    states = aus.list_auth_states(db_path=db)
+    # Act
+    fields = aus.verdict_for(states.get("figrecipe"), now=now)
+    # Assert
+    assert (fields["auth_failed"], fields["auth_remedy"]) == (True, "restart")

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_auth.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_auth.py
@@ -1,0 +1,217 @@
+"""Tests for the agent-list AUTH status — green vs green-AND-actually-working.
+
+The operator's complaint, verbatim: an agent can be green ``running`` because
+tmux is up, while it is not actually operational. These tests pin the behaviour
+that fixes it, and — just as importantly — the two ways that fix could
+accidentally make things WORSE:
+
+* an ``auth-failed`` row must stay in the LIVE set, or the default view would
+  HIDE the one status the operator asked to see;
+* it must stay in the LIVE set for ``restart --all-running`` too, or the sweep
+  would skip exactly the agents a restart would cure.
+
+No mocks: pure functions over real dicts, plus a real state.db in ``tmp_path``
+for the end-to-end read.
+
+TQ: AAA marker triple (TQ002), one asserted fact per test (TQ007).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.cli_pkg._helpers import _agent_list_auth as ala
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def now() -> datetime:
+    """A fixed reference instant so age/staleness assertions are deterministic."""
+    return datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _stamp(moment: datetime) -> str:
+    """``moment`` in the exact ISO-8601 UTC 'Z' shape the store writes."""
+    return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@pytest.fixture
+def failing(now: datetime) -> dict:
+    """A cached verdict: this agent's auth is failing, checked 2 minutes ago."""
+    return {
+        "figrecipe": {
+            "auth_failed": True,
+            "checked_at": _stamp(now - timedelta(minutes=2)),
+            "banner": "Login expired",
+            "reason": "revoked",
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# is_live_status — the predicate both the view and the restart sweep depend on
+# ---------------------------------------------------------------------------
+
+
+def test_running_agent_is_live() -> None:
+    # Arrange
+    status = "running"
+    # Act
+    live = ala.is_live_status(status)
+    # Assert
+    assert live is True
+
+
+def test_auth_failed_agent_is_still_live() -> None:
+    # Arrange — tmux is up and the pane process is alive; the agent simply cannot
+    # call the API. If this read False the default view would hide it (and
+    # `restart --all-running` would skip it) — the two ways to make this worse.
+    status = ala.STATUS_AUTH_FAILED
+    # Act
+    live = ala.is_live_status(status)
+    # Assert
+    assert live is True
+
+
+def test_stopped_agent_is_not_live() -> None:
+    # Arrange
+    status = "stopped"
+    # Act
+    live = ala.is_live_status(status)
+    # Assert
+    assert live is False
+
+
+def test_unknown_status_is_not_live() -> None:
+    # Arrange
+    status = None
+    # Act
+    live = ala.is_live_status(status)
+    # Assert
+    assert live is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_auth — the status upgrade
+# ---------------------------------------------------------------------------
+
+
+def test_running_agent_with_a_failing_verdict_is_no_longer_reported_running(
+    failing: dict, now: datetime
+) -> None:
+    # Arrange — the whole point: liveness says "running", the auth cache says the
+    # agent cannot authenticate. Green would be a lie.
+    # Act
+    _fields, status = ala.resolve_auth("figrecipe", failing, None, "running")
+    # Assert
+    assert status == ala.STATUS_AUTH_FAILED
+
+
+def test_running_agent_with_a_healthy_verdict_stays_running(now: datetime) -> None:
+    # Arrange
+    states = {"worker": {"auth_failed": False, "checked_at": _stamp(now)}}
+    # Act
+    _fields, status = ala.resolve_auth("worker", states, None, "running")
+    # Assert
+    assert status == "running"
+
+
+def test_never_checked_agent_stays_running(now: datetime) -> None:
+    # Arrange — no evidence is not evidence of failure; we must not invent an
+    # alarm for an agent the watchdog has never looked at.
+    # Act
+    _fields, status = ala.resolve_auth("worker", {}, None, "running")
+    # Assert
+    assert status == "running"
+
+
+def test_stopped_agent_is_never_relabelled_auth_failed(failing: dict) -> None:
+    # Arrange — a stale failing verdict for an agent that is no longer running
+    # would be a claim about a process that is not there. `figrecipe` has a
+    # cached failure, but it is stopped.
+    # Act
+    _fields, status = ala.resolve_auth("figrecipe", failing, None, "stopped")
+    # Assert
+    assert status == "stopped"
+
+
+def test_stopped_agent_carries_no_auth_claim(failing: dict) -> None:
+    # Arrange — and its row must report no evidence at all, not a stale failure.
+    # Act
+    fields, _status = ala.resolve_auth("figrecipe", failing, None, "stopped")
+    # Assert
+    assert fields["auth_failed"] is False
+
+
+def test_resolved_row_carries_the_age_of_its_evidence(
+    failing: dict, now: datetime
+) -> None:
+    # Arrange — a 6h-old verdict is weaker evidence than a 60s-old one, so the
+    # age of the check must reach the renderer. It is measured against the real
+    # clock, so the field's presence is what we pin, not an exact second count.
+    # Act
+    fields, _status = ala.resolve_auth("figrecipe", failing, None, "running")
+    # Assert
+    assert fields["auth_check_age_s"] is not None
+
+
+def test_resolved_row_carries_the_remedy_for_a_revoked_token(failing: dict) -> None:
+    # Arrange — "revoked" means the on-disk credential is fine and only the
+    # process is stale: restart, do NOT drag the operator into a re-login.
+    # Act
+    fields, _status = ala.resolve_auth("figrecipe", failing, None, "running")
+    # Assert
+    assert fields["auth_remedy"] == "restart"
+
+
+def test_verdict_from_before_the_current_start_does_not_relabel_the_row(
+    now: datetime,
+) -> None:
+    # Arrange — the operator already restarted this agent, which is the cure. A
+    # verdict older than the current incarnation must not keep calling it broken.
+    states = {
+        "figrecipe": {
+            "auth_failed": True,
+            "checked_at": _stamp(now - timedelta(hours=2)),
+        }
+    }
+    started_at = _stamp(now - timedelta(minutes=1))
+    # Act
+    _fields, status = ala.resolve_auth("figrecipe", states, started_at, "running")
+    # Assert
+    assert status == "running"
+
+
+# ---------------------------------------------------------------------------
+# all_auth_states — the ONE-query cache read, end to end against a real db
+# ---------------------------------------------------------------------------
+
+
+def test_cache_read_survives_a_host_with_no_state_db(tmp_path: Path) -> None:
+    # Arrange — `sac agents list` must never crash (or stall) on an auth-cache
+    # miss; a fresh host simply has nobody checked yet.
+    from scitex_agent_container._state import auth_state as aus
+
+    # Act
+    states = aus.list_auth_states(db_path=tmp_path / "absent.db")
+    # Assert
+    assert states == {}
+
+
+def test_watchdog_write_is_visible_to_the_list_read(tmp_path: Path) -> None:
+    # Arrange — the real contract between the two halves of this feature: the
+    # watchdog persists, the list reads. Real sqlite file, real row, no mocks.
+    from scitex_agent_container._state import auth_state as aus
+
+    db_path = tmp_path / "state.db"
+    aus.record_auth_check("figrecipe", True, reason="revoked", db_path=db_path)
+    # Act
+    states = aus.list_auth_states(db_path=db_path)
+    # Assert
+    assert states["figrecipe"]["auth_failed"] is True

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__selection.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__selection.py
@@ -1,0 +1,158 @@
+"""Tests for cli_pkg.lifecycle._selection — the SHARED bulk-selection surface.
+
+PA-306: no ``unittest.mock``. The one collaborator these enumerators have
+(``get_agent_list_data``) is swapped at the ``_helpers`` module namespace via a
+small ``_swap`` context manager — the same seam ``test__restart`` / ``test__stop``
+use for theirs.
+
+Those two files swap ``_enumerate_running`` itself, so they cover the *plumbing*
+(which flag reaches which seam) and never the enumeration's own filter. This file
+covers that filter — in particular the rule that ``auth-failed`` is LIVE.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+import pytest
+
+import scitex_agent_container.cli_pkg._helpers as helpers_mod
+from scitex_agent_container.cli_pkg.lifecycle._selection import (
+    _enumerate_fleet,
+    _enumerate_running,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path):
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+@contextmanager
+def _swap(name: str, fn: Callable) -> Iterator[None]:
+    """Swap an attribute on the ``_helpers`` namespace both enumerators read.
+
+    Both functions resolve ``get_agent_list_data`` from ``.._helpers`` at CALL
+    time, so a module-namespace swap is the real seam (``_helpers`` caches its
+    PEP-562 lazy attrs into module globals, which this shadows).
+    """
+    saved = getattr(helpers_mod, name)
+    setattr(helpers_mod, name, fn)
+    try:
+        yield
+    finally:
+        setattr(helpers_mod, name, saved)
+
+
+def _rows(*pairs: tuple[str, str]) -> Callable:
+    """A ``get_agent_list_data`` stand-in returning ``(name, status)`` rows."""
+    data = [{"name": n, "status": s} for n, s in pairs]
+    return lambda _registry: data
+
+
+def test_all_running_includes_an_auth_failed_agent():
+    # Arrange — the whole point of the feature: a tmux-green agent whose Claude
+    # is auth-dead is UP, so it belongs to the live set. Were it filtered out as
+    # "not running", `restart --all-running` would skip precisely the agent a
+    # restart cures.
+    rows = _rows(("green", "running"), ("wedged", "auth-failed"))
+    # Act
+    with _swap("get_agent_list_data", rows):
+        names = _enumerate_running()
+    # Assert
+    assert names == ["green", "wedged"]
+
+
+def test_all_running_still_excludes_the_non_live_statuses():
+    # Arrange — an agent the operator deliberately stopped must stay stopped.
+    rows = _rows(
+        ("live", "running"),
+        ("halted", "stopped"),
+        ("ghost", "unknown"),
+        ("on-disk", "defined"),
+        ("broken", "invalid"),
+    )
+    # Act
+    with _swap("get_agent_list_data", rows):
+        names = _enumerate_running()
+    # Assert
+    assert names == ["live"]
+
+
+def test_all_running_dedups_preserving_first_seen_order():
+    # Arrange — the same agent can surface from more than one source row.
+    rows = _rows(
+        ("b", "auth-failed"),
+        ("a", "running"),
+        ("b", "running"),
+    )
+    # Act
+    with _swap("get_agent_list_data", rows):
+        names = _enumerate_running()
+    # Assert
+    assert names == ["b", "a"]
+
+
+def test_all_registry_returns_every_agent_including_stopped_ones():
+    # Arrange — --all-registry is "everything `sac agents list` shows".
+    rows = _rows(("live", "running"), ("wedged", "auth-failed"), ("halted", "stopped"))
+    # Act
+    with _swap("get_agent_list_data", rows):
+        names = _enumerate_fleet()
+    # Assert
+    assert names == ["live", "wedged", "halted"]
+
+
+# #648's invariant: the two destructive verbs import the SAME selection surface
+# so they cannot drift. Identity, not equality — a copy would let one verb's
+# liveness rule (and so its auth-failed handling) diverge from the other's.
+
+
+def test_restart_shares_the_selection_running_enumerator():
+    # Arrange
+    from scitex_agent_container.cli_pkg.lifecycle import _restart
+
+    # Act
+    used = _restart._enumerate_running
+    # Assert
+    assert used is _enumerate_running
+
+
+def test_stop_shares_the_selection_running_enumerator():
+    # Arrange
+    from scitex_agent_container.cli_pkg.lifecycle import _stop
+
+    # Act
+    used = _stop._enumerate_running
+    # Assert
+    assert used is _enumerate_running
+
+
+def test_restart_shares_the_selection_fleet_enumerator():
+    # Arrange
+    from scitex_agent_container.cli_pkg.lifecycle import _restart
+
+    # Act
+    used = _restart._enumerate_fleet
+    # Assert
+    assert used is _enumerate_fleet
+
+
+def test_stop_shares_the_selection_fleet_enumerator():
+    # Arrange
+    from scitex_agent_container.cli_pkg.lifecycle import _stop
+
+    # Act
+    used = _stop._enumerate_fleet
+    # Assert
+    assert used is _enumerate_fleet

--- a/tests/scitex_agent_container/cli_pkg/test__auth_status.py
+++ b/tests/scitex_agent_container/cli_pkg/test__auth_status.py
@@ -1,19 +1,23 @@
-"""`sac agents auth-status` command core — the pure `evaluate_agents` mapper
-plus command registration/help.
+"""`sac agents auth-status` — the pure `evaluate_agents` mapper, the PERSIST
+step, plus command registration/help.
 
-`evaluate_agents` turns each agent's two captured panes into an OK /
-LOGIN-REQUIRED verdict via the near-prompt + distance-frozen matcher. These
-tests use compact captured-pane fixtures (the matcher itself is exercised in
-depth in ``_runners/_tmux/test_auth_status.py``); here we confirm the
-command-level real-vs-prose separation and the wiring. No mocks: pure calls +
-a real Click invocation.
+`evaluate_agents` turns each agent's two captured panes into an OK / AUTH-FAILED
+verdict via the near-prompt + distance-frozen matcher (the matcher itself is
+exercised in depth in ``_runners/_tmux/test_auth_status.py``); here we confirm
+the command-level real-vs-prose separation, and the half that makes the whole
+feature work: this command is the WRITER, so its verdicts must actually land in
+state.db for ``sac agents list`` to read back.
+
+No mocks: pure calls, a real Click invocation, and a real state.db in ``tmp_path``.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from click.testing import CliRunner
 
-from scitex_agent_container.cli_pkg._auth_status import evaluate_agents
+from scitex_agent_container.cli_pkg._auth_status import evaluate_agents, persist_verdicts
 from scitex_agent_container.cli_pkg.agent_group import agent_group
 
 # Wedged: banner directly above the prompt, identical on both reads → frozen.
@@ -22,13 +26,13 @@ _STUCK = "● Login expired · Please run /login\n────────\n❯\
 _OK = "  continuing the task now\n────────\n❯\n────────\n  ctx:1%\n"
 
 
-def test_evaluate_agents_flags_frozen_banner_as_login_required():
+def test_evaluate_agents_flags_frozen_banner_as_auth_failed():
     # Arrange
     captures = {"scitex-hpc": (_STUCK, _STUCK)}
     # Act
     row = evaluate_agents(captures)[0]
     # Assert
-    assert row["verdict"] == "login_required"
+    assert row["verdict"] == "auth_failed"
 
 
 def test_evaluate_agents_marks_clean_pane_ok():
@@ -74,3 +78,61 @@ def test_auth_status_help_renders_interval_option():
     result = runner.invoke(agent_group, ["auth-status", "--help"])
     # Assert
     assert result.exit_code == 0 and "--interval" in result.output
+
+
+# ---------------------------------------------------------------------------
+# persist_verdicts — the WRITE half: what `sac agents list` reads back
+# ---------------------------------------------------------------------------
+
+
+def test_persisted_failing_verdict_is_readable_by_the_list(tmp_path: Path):
+    # Arrange — the contract that makes the feature work: the watchdog writes,
+    # the list reads. A real sqlite file, a real row, no mocks.
+    from scitex_agent_container._state.auth_state import list_auth_states
+
+    db_path = tmp_path / "state.db"
+    rows = evaluate_agents({"scitex-hpc": (_STUCK, _STUCK)})
+    # Act
+    persist_verdicts(rows, db_path=db_path)
+    # Assert
+    assert list_auth_states(db_path=db_path)["scitex-hpc"]["auth_failed"] is True
+
+
+def test_persisted_healthy_verdict_is_readable_by_the_list(tmp_path: Path):
+    # Arrange
+    from scitex_agent_container._state.auth_state import list_auth_states
+
+    db_path = tmp_path / "state.db"
+    rows = evaluate_agents({"figrecipe": (_OK, _OK)})
+    # Act
+    persist_verdicts(rows, db_path=db_path)
+    # Assert
+    assert list_auth_states(db_path=db_path)["figrecipe"]["auth_failed"] is False
+
+
+def test_uncapturable_agent_is_not_recorded_as_healthy(tmp_path: Path):
+    # Arrange — an agent we could not READ produced NO evidence. Writing
+    # "auth is fine" for it would manufacture exactly the false green this
+    # feature exists to abolish, so it must not be written at all.
+    from scitex_agent_container._state.auth_state import list_auth_states
+
+    db_path = tmp_path / "state.db"
+    rows = evaluate_agents({"gone": (None, None)})
+    # Act
+    persist_verdicts(rows, db_path=db_path)
+    # Assert
+    assert list_auth_states(db_path=db_path) == {}
+
+
+def test_persist_stamps_checked_at_so_staleness_can_be_judged(tmp_path: Path):
+    # Arrange — a verdict with no timestamp could never be aged, and a cache that
+    # cannot be aged gets presented as fresh truth forever.
+    from scitex_agent_container._state.auth_state import list_auth_states
+
+    db_path = tmp_path / "state.db"
+    rows = evaluate_agents({"scitex-hpc": (_STUCK, _STUCK)})
+    persist_verdicts(rows, db_path=db_path)
+    # Act
+    checked_at = list_auth_states(db_path=db_path)["scitex-hpc"]["checked_at"]
+    # Assert
+    assert checked_at.endswith("Z")

--- a/tests/scitex_agent_container/cli_pkg/test__send_broker.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send_broker.py
@@ -1,0 +1,517 @@
+"""Tests for the host-brokered peer lookup on the send read path.
+
+The bug being pinned
+--------------------
+Inside a container ``$HOME`` is ``/home/agent`` and
+``SCITEX_AGENT_CONTAINER_STATE_DB`` points at a private per-agent bridge DB,
+so ``open_db(None)`` resolves to a store with no rows for any other agent.
+``send_to_agent`` read that empty store and reported EVERY peer as dead.
+Measured 2026-07-14 from inside the SIF::
+
+    send_to_agent("scitex-scholar")
+      -> error "agent 'scitex-scholar' not running"
+         registry_status="stopped", pid=null, a2a_port=null, boot_complete=false
+
+while the host's registry held ``pid=1777985  a2a_port=19037  ended_at=NULL``
+for that same agent, at that same moment.
+
+What these tests hold down
+--------------------------
+1. In a container the lookup is brokered to the host and a LIVE peer is
+   reachable again (the regression that started this).
+2. "I could not check" is NEVER rendered as "the agent is stopped" — an
+   unreachable broker, an ACL refusal and a 5xx all yield UNKNOWN.
+3. Hints are never promoted to death verdicts: a stale ``startup_failed``
+   marker does not hide a live port, and an UNBOUND ``/v1/turn`` port does
+   not make ``pid_alive`` / ``boot_complete`` false. (Measured 2026-07-14:
+   only 5 of 47 live fleet agents had ``/v1/turn`` bound at all — a
+   port-bind death gate would have condemned 41 healthy agents, whose
+   "remedy" ``--force --fresh`` is destructive.)
+4. On a BARE HOST nothing is brokered — the local read path is untouched.
+
+PA-306 / STX-NM002: no mocks, no monkeypatch. A REAL in-process HTTP server
+stands in for the host ``sac listen`` (same shape as
+``test__send_in_sif_auto_fallback.py``), reached over the REAL urllib stack,
+and the REAL ``send_to_agent`` is driven end to end. State.db is redirected
+to a tmp sandbox so no test ever reads the live fleet registry.
+STX-TQ007: one fact per test. STX-TQ002: AAA.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import socket
+import socketserver
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.cli_pkg._send import send_to_agent
+from scitex_agent_container.cli_pkg._send_broker import (
+    PeerLookupUnavailable,
+    lookup_peer_via_host,
+    resolve_send_endpoint_via_host,
+    should_broker_peer_lookup,
+)
+
+_LOCAL_HOST = "test-host"
+
+
+def _closed_port() -> int:
+    """Return a port number that nothing is listening on."""
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _status_body(**over) -> bytes:
+    """A ``GET /agents/<name>/status`` body in the host's real shape."""
+    body = {
+        "name": "peer",
+        "spec_path": "/specs/peer.yaml",
+        "workdir": "/work",
+        "session_id": None,
+        "state_dir": "/state/peer",
+        "a2a_port": None,
+        "turn_url": None,
+        "role": "worker",
+    }
+    body.update(over)
+    return json.dumps(body).encode()
+
+
+@pytest.fixture
+def fake_host_listen(env_save_restore, tmp_path):
+    """A REAL HTTP server standing in for the host ``sac listen``.
+
+    Also puts the process in the in-container state the fix keys off
+    (``APPTAINER_CONTAINER`` + ``SAC_LISTEN_BASE_URL``) and redirects
+    state.db to a tmp sandbox, so the blind local read the bug came from is
+    empty here too — exactly as it is inside a real SIF.
+    """
+    responses: list[tuple[int, bytes]] = []
+    captured: list[str] = []
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            captured.append(self.path)
+            status, body = (
+                responses.pop(0) if responses else (200, _status_body())
+            )
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args, **kw):  # noqa: ARG002
+            return
+
+    server = socketserver.TCPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    env_save_restore.set("SAC_LISTEN_BASE_URL", f"http://127.0.0.1:{port}")
+    env_save_restore.set("SAC_LISTEN_BEARER", "test-bearer")
+    env_save_restore.set("APPTAINER_CONTAINER", "/path/to/test.sif")
+    env_save_restore.set("SAC_HOST", _LOCAL_HOST)
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
+    )
+
+    class _Ctl:
+        # The server's own port is guaranteed BOUND — hand it out as a live
+        # agent's a2a port so the reachability probe measures a real socket.
+        live_port = port
+
+        @property
+        def captured(self) -> list[str]:
+            return captured
+
+        def enqueue(self, status: int, body: bytes) -> None:
+            responses.append((status, body))
+
+    try:
+        yield _Ctl()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+
+@pytest.fixture
+def fresh_lead_creds_path(tmp_path) -> Path:
+    """Fresh OAuth creds so ``preflight_send_creds`` passes deterministically."""
+    creds = tmp_path / ".credentials.json"
+    creds.write_text(
+        json.dumps(
+            {"claudeAiOauth": {"expiresAt": int((time.time() + 3600) * 1000)}}
+        )
+    )
+    return creds
+
+
+# ---------------------------------------------------------------------------
+# should_broker_peer_lookup — the bare-host path must stay untouched
+# ---------------------------------------------------------------------------
+
+
+def test_bare_host_does_not_broker(env_save_restore):
+    # Arrange — no SIF markers: an ordinary host shell.
+    env_save_restore.delete("APPTAINER_CONTAINER")
+    env_save_restore.delete("SINGULARITY_CONTAINER")
+    env_save_restore.set("SAC_LISTEN_BASE_URL", "http://127.0.0.1:7878")
+    # Act
+    brokering = should_broker_peer_lookup()
+    # Assert — bare host keeps the local read path.
+    assert brokering is False
+
+
+def test_in_sif_without_listen_url_does_not_broker(env_save_restore):
+    # Arrange — a stale SINGULARITY_CONTAINER with no host listen to talk to
+    # (the sac-from-sac / bare-host footgun status_cmds hit in PR#316).
+    env_save_restore.set("APPTAINER_CONTAINER", "/path/to/test.sif")
+    env_save_restore.delete("SAC_LISTEN_BASE_URL")
+    # Act
+    brokering = should_broker_peer_lookup()
+    # Assert — no URL to broker to → do not broker.
+    assert brokering is False
+
+
+def test_in_sif_with_listen_url_brokers(fake_host_listen):
+    # Arrange — fixture puts us in the real in-container state.
+    # Act
+    brokering = should_broker_peer_lookup()
+    # Assert
+    assert brokering is True
+
+
+# ---------------------------------------------------------------------------
+# lookup_peer_via_host — the host's answer
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_returns_the_port_the_host_reports(fake_host_listen):
+    # Arrange — the host knows this agent holds port 19037 (scholar's real one).
+    fake_host_listen.enqueue(
+        200,
+        _status_body(
+            a2a_port=19037, turn_url="http://ywata-note-win:19037/v1/turn"
+        ),
+    )
+    # Act
+    peer = lookup_peer_via_host("scitex-scholar")
+    # Assert — the port the blind local read could never see.
+    assert peer.a2a_port == 19037
+
+
+def test_lookup_uses_the_agent_status_door(fake_host_listen):
+    # Arrange
+    fake_host_listen.enqueue(200, _status_body(a2a_port=1))
+    # Act
+    lookup_peer_via_host("scitex-scholar")
+    # Assert — the SAME door agent_status uses; no second mechanism.
+    assert fake_host_listen.captured == ["/agents/scitex-scholar/status"]
+
+
+def test_lookup_reports_host_404_as_not_known(fake_host_listen):
+    # Arrange — the host, which sees the whole fleet, has no such agent.
+    fake_host_listen.enqueue(404, b'{"error":"no such agent"}')
+    # Act
+    peer = lookup_peer_via_host("ghost")
+    # Assert — the one definitive negative.
+    assert peer.known is False
+
+
+def test_stale_startup_failed_marker_does_not_hide_the_live_port(fake_host_listen):
+    # Arrange — scitex-writer, measured 2026-07-14: a ~2-day-old
+    # startup_failed marker while the agent was alive and answering a2a.
+    fake_host_listen.enqueue(
+        200,
+        _status_body(
+            status="startup_failed",
+            a2a_port=19014,
+            turn_url="http://ywata-note-win:19014/v1/turn",
+        ),
+    )
+    # Act
+    peer = lookup_peer_via_host("scitex-writer")
+    # Assert — the marker is a HINT; it must not suppress the live endpoint.
+    assert peer.a2a_port == 19014
+
+
+def test_startup_failed_is_carried_as_a_hint_only(fake_host_listen):
+    # Arrange
+    fake_host_listen.enqueue(200, _status_body(status="startup_failed", a2a_port=1))
+    # Act
+    peer = lookup_peer_via_host("scitex-writer")
+    # Assert — surfaced for the operator, but it is not the verdict field.
+    assert peer.host_status == "startup_failed"
+
+
+# ---------------------------------------------------------------------------
+# Could-not-ask → UNKNOWN. Never "stopped".
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_broker_raises_rather_than_reporting_stopped(
+    env_save_restore, tmp_path
+):
+    # Arrange — in a SIF, but the host listen is down.
+    env_save_restore.set("APPTAINER_CONTAINER", "/path/to/test.sif")
+    env_save_restore.set(
+        "SAC_LISTEN_BASE_URL", f"http://127.0.0.1:{_closed_port()}"
+    )
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
+    )
+
+    # Act
+    def _lookup():
+        lookup_peer_via_host("scitex-scholar")
+
+    # Assert — refuses to answer rather than guessing "dead".
+    with pytest.raises(PeerLookupUnavailable):
+        _lookup()
+
+
+def test_acl_deny_raises_rather_than_reporting_stopped(fake_host_listen):
+    # Arrange — the host refuses to tell us (403). We were prevented from
+    # learning the state; that is not the same as learning it is stopped.
+    fake_host_listen.enqueue(
+        403, b'{"error":"ACL deny","kind":"acl_deny","reason":"cross-lineage"}'
+    )
+
+    # Act
+    def _lookup():
+        lookup_peer_via_host("scitex-scholar")
+
+    # Assert
+    with pytest.raises(PeerLookupUnavailable):
+        _lookup()
+
+
+def test_acl_deny_preserves_the_hosts_kind(fake_host_listen):
+    # Arrange
+    fake_host_listen.enqueue(
+        403, b'{"error":"ACL deny","kind":"acl_deny","reason":"cross-lineage"}'
+    )
+    captured: Exception | None = None
+    # Act
+    try:
+        lookup_peer_via_host("scitex-scholar")
+    except PeerLookupUnavailable as exc:
+        captured = exc
+    # Assert — the gate's refusal is surfaced verbatim, never worked around.
+    assert getattr(captured, "kind", None) == "acl_deny"
+
+
+# ---------------------------------------------------------------------------
+# resolve_send_endpoint_via_host — provenance is visible in the result
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_endpoint_is_tagged_host_broker(fake_host_listen):
+    # Arrange
+    fake_host_listen.enqueue(
+        200, _status_body(a2a_port=19037, turn_url="http://peer-host:19037/v1/turn")
+    )
+    # Act
+    endpoint, _peer = resolve_send_endpoint_via_host(
+        "scitex-scholar", current_host=_LOCAL_HOST
+    )
+    # Assert — a reader can always tell the fleet registry from a blind read.
+    assert endpoint.source == "host_broker"
+
+
+def test_resolved_endpoint_carries_the_peers_host(fake_host_listen):
+    # Arrange
+    fake_host_listen.enqueue(
+        200, _status_body(a2a_port=19037, turn_url="http://peer-host:19037/v1/turn")
+    )
+    # Act
+    endpoint, _peer = resolve_send_endpoint_via_host(
+        "scitex-scholar", current_host=_LOCAL_HOST
+    )
+    # Assert
+    assert endpoint.host == "peer-host"
+
+
+# ---------------------------------------------------------------------------
+# send_to_agent — the regression, driven end to end through the real function
+# ---------------------------------------------------------------------------
+
+
+def test_live_peer_is_reachable_from_inside_a_container(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange — the host reports a live agent on a port that IS bound.
+    # Before the fix this returned: error "agent 'peer' not running".
+    port = fake_host_listen.live_port
+    fake_host_listen.enqueue(
+        200,
+        _status_body(a2a_port=port, turn_url=f"http://{_LOCAL_HOST}:{port}/v1/turn"),
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — the fleet can talk to itself again.
+    assert result["status"] == "dispatched"
+
+
+def test_dispatch_targets_the_port_the_host_reported(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange
+    port = fake_host_listen.live_port
+    fake_host_listen.enqueue(
+        200,
+        _status_body(a2a_port=port, turn_url=f"http://{_LOCAL_HOST}:{port}/v1/turn"),
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — the endpoint came from the fleet registry, not the empty local DB.
+    assert result["a2a_port"] == port
+
+
+def test_unreachable_broker_never_reports_the_peer_stopped(
+    env_save_restore, tmp_path, fresh_lead_creds_path
+):
+    # Arrange — in a SIF; the host listen is down, so we cannot check.
+    env_save_restore.set("APPTAINER_CONTAINER", "/path/to/test.sif")
+    env_save_restore.set("SAC_HOST", _LOCAL_HOST)
+    env_save_restore.set(
+        "SAC_LISTEN_BASE_URL", f"http://127.0.0.1:{_closed_port()}"
+    )
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — UNKNOWN, not dead. "I could not check" must never render as
+    # "the agent is stopped" — that is the bug, and its remedy is destructive.
+    assert result["diagnosis"]["registry_status"].startswith("unknown")
+
+
+def test_unreachable_broker_names_the_broker_as_the_failure(
+    env_save_restore, tmp_path, fresh_lead_creds_path
+):
+    # Arrange
+    env_save_restore.set("APPTAINER_CONTAINER", "/path/to/test.sif")
+    env_save_restore.set("SAC_HOST", _LOCAL_HOST)
+    env_save_restore.set(
+        "SAC_LISTEN_BASE_URL", f"http://127.0.0.1:{_closed_port()}"
+    )
+    env_save_restore.set(
+        "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — fail honestly: the BROKER is what is unreachable, not the agent.
+    assert "broker is unreachable" in result["error"]
+
+
+def test_unbound_turn_port_still_reports_the_agent_running(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange — the live-fleet norm: the host holds a port claim but nothing
+    # listens on it (41 of 47 agents, measured 2026-07-14). Those agents are
+    # alive and answer over the a2a subscriber channel.
+    fake_host_listen.enqueue(
+        200,
+        _status_body(
+            a2a_port=_closed_port(),
+            turn_url=f"http://{_LOCAL_HOST}:1/v1/turn",
+        ),
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — an unbound port is a TRANSPORT fact, not a death certificate.
+    assert result["diagnosis"]["registry_status"] == "running"
+
+
+def test_unbound_turn_port_does_not_fabricate_a_dead_pid(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange
+    fake_host_listen.enqueue(
+        200,
+        _status_body(
+            a2a_port=_closed_port(),
+            turn_url=f"http://{_LOCAL_HOST}:1/v1/turn",
+        ),
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — UNKNOWN (None), never False. A False here trips the caller's
+    # pid_alive death gate and condemns a healthy agent.
+    assert result["diagnosis"]["pid_alive"] is None
+
+
+def test_unbound_turn_port_does_not_fabricate_a_failed_boot(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange
+    fake_host_listen.enqueue(
+        200,
+        _status_body(
+            a2a_port=_closed_port(),
+            turn_url=f"http://{_LOCAL_HOST}:1/v1/turn",
+        ),
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — the host route carries no heartbeat, so boot state is UNKNOWN.
+    assert result["diagnosis"]["boot_complete"] is None
+
+
+def test_unbound_turn_port_error_does_not_claim_the_agent_crashed(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange
+    fake_host_listen.enqueue(
+        200,
+        _status_body(
+            a2a_port=_closed_port(),
+            turn_url=f"http://{_LOCAL_HOST}:1/v1/turn",
+        ),
+    )
+    # Act
+    result = send_to_agent(
+        "peer", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert — the old wording ("it is not booted or the sidecar crashed") was
+    # a death verdict whose remedy destroys a working agent.
+    assert "crashed" not in result["error"]
+
+
+def test_host_404_is_reported_as_not_found_not_stopped(
+    fake_host_listen, fresh_lead_creds_path
+):
+    # Arrange — the host genuinely has no agent by this name.
+    fake_host_listen.enqueue(404, b'{"error":"no such agent"}')
+    # Act
+    result = send_to_agent(
+        "ghost", "hello", wait=False, lead_creds_path=fresh_lead_creds_path
+    )
+    # Assert
+    assert result["diagnosis"]["registry_status"] == "not_found"

--- a/tests/scitex_agent_container/cli_pkg/test_ports_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_ports_cmds.py
@@ -1,0 +1,301 @@
+"""Tests for ``cli_pkg.ports_cmds`` — the ``sac ports`` inventory.
+
+PA-306 no-mocks: every collaborator is real.
+
+* ``CliRunner`` invokes the real Click command.
+* A real ``state.db`` under ``tmp_path`` carries real a2a claims made
+  through :mod:`_state.port_allocator` — the same allocator production
+  uses.
+* Liveness is exercised against REAL sockets: a bound-and-listening
+  socket (live) and a bound-then-closed free port (dead / orphan). No
+  probe is monkeypatched.
+* A yield-based ``isolated_state`` fixture redirects BOTH state
+  read-paths — ``$HOME`` and the import-time
+  ``state_db.DEFAULT_DB_PATH`` constant — at an isolated ``tmp_path``,
+  so the CLI smoke tests never read or write the live fleet registry
+  (no monkeypatch; these are the codebase's own seams).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._state import port_allocator as pa
+from scitex_agent_container._state import state_db
+from scitex_agent_container.cli_pkg._main import main
+from scitex_agent_container.cli_pkg.ports_cmds import (
+    _reference_map,
+    collect_ports_data,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures (real collaborators, no monkeypatch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Path:
+    """A per-test state.db path; the allocator creates schema on demand."""
+    return tmp_path / "state.db"
+
+
+@pytest.fixture
+def listening_port():
+    """A real listening TCP socket on loopback; yields its port.
+
+    ``port_is_bound`` connects to it, so it must actually ``listen()``.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    try:
+        yield sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+@pytest.fixture
+def free_port():
+    """A port that was bound then released — almost certainly nothing
+    listens on it, so a probe reports it dead (orphan).
+
+    The socket is acquired inside a ``with`` block, so the fd is closed
+    even if ``bind()`` raises, and the fixture ``yield``s (rather than
+    ``return``s) per STX-TQ005: a fixture that acquires an external
+    resource owns its teardown.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    # Closed on block exit — the point of the fixture is a port number
+    # with nothing listening behind it.
+    yield port
+
+
+@pytest.fixture
+def isolated_state(tmp_path):
+    """Isolate EVERY read-path the bare CLI consults for state.
+
+    ``sac ports`` takes no ``--db``: it resolves state.db from
+    :data:`state_db.DEFAULT_DB_PATH`, a **module-level constant computed
+    at import time**. So overriding ``$HOME`` alone does NOT redirect it
+    — by the time a fixture runs, the constant already points at the
+    developer's real ``~/.scitex/agent-container/runtime/state.db``, and
+    a CLI test would *read* (and ``claim_port`` would *WRITE*) the live
+    fleet registry. In CI that silently invents a registry; on a real
+    host it pollutes one.
+
+    So touch both read-paths — the env var AND the constant — exactly as
+    ``tests/smoke/conftest.py::comms_env`` does. These are the seams the
+    codebase itself exposes for this: no monkeypatch, no mock.
+    """
+    db = tmp_path / "state.db"
+    prior = {
+        k: os.environ.get(k)
+        for k in ("HOME", "USERPROFILE", "SCITEX_AGENT_CONTAINER_STATE_DB")
+    }
+    prior_db_path = state_db.DEFAULT_DB_PATH
+
+    os.environ["HOME"] = str(tmp_path)
+    os.environ["USERPROFILE"] = str(tmp_path)
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    try:
+        yield tmp_path
+    finally:
+        state_db.DEFAULT_DB_PATH = prior_db_path
+        for k, v in prior.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+# ---------------------------------------------------------------------------
+# collect_ports_data — listen row
+# ---------------------------------------------------------------------------
+
+
+def test_collect_reports_listen_port_at_given_bind(db: Path) -> None:
+    # Arrange
+    data = collect_ports_data(db_path=db, listen_host="127.0.0.1", listen_port=7878)
+    # Act
+    listen_port = data["listen"]["port"]
+    # Assert
+    assert listen_port == 7878
+
+
+def test_collect_listen_row_carries_pidfile_path(db: Path, tmp_path: Path) -> None:
+    # Arrange
+    data = collect_ports_data(db_path=db, listen_port=7878, lock_dir=tmp_path)
+    # Act
+    pidfile = data["listen"]["pidfile"]
+    # Assert
+    assert pidfile.endswith("listen-7878.pid")
+
+
+# ---------------------------------------------------------------------------
+# collect_ports_data — a2a claims
+# ---------------------------------------------------------------------------
+
+
+def test_collect_lists_a2a_claim_owner(db: Path, free_port: int) -> None:
+    # Arrange
+    pa.claim_port("alpha", explicit=free_port, db_path=db)
+    data = collect_ports_data(db_path=db, listen_port=7878)
+    # Act
+    owners = {row["owner"] for row in data["a2a_claims"]}
+    # Assert
+    assert "alpha" in owners
+
+
+def test_collect_marks_live_listening_port_as_live(
+    db: Path, listening_port: int
+) -> None:
+    # Arrange — claim the very port a real socket is listening on.
+    pa.claim_port("beta", explicit=listening_port, db_path=db)
+    data = collect_ports_data(db_path=db, listen_port=7878, probe_timeout=1.0)
+    # Act
+    row = next(r for r in data["a2a_claims"] if r["owner"] == "beta")
+    # Assert
+    assert row["live"] is True
+
+
+def test_collect_marks_dead_claim_as_orphan(db: Path, free_port: int) -> None:
+    # Arrange — claim a released port; nothing listens on it.
+    pa.claim_port("gamma", explicit=free_port, db_path=db)
+    data = collect_ports_data(db_path=db, listen_port=7878, probe_timeout=0.2)
+    # Act
+    row = next(r for r in data["a2a_claims"] if r["owner"] == "gamma")
+    # Assert
+    assert row["orphan"] is True
+
+
+def test_collect_lists_dead_claim_in_orphans_section(db: Path, free_port: int) -> None:
+    # Arrange
+    pa.claim_port("gamma", explicit=free_port, db_path=db)
+    data = collect_ports_data(db_path=db, listen_port=7878, probe_timeout=0.2)
+    # Act
+    orphan_agents = {o["agent"] for o in data["orphans"]}
+    # Assert
+    assert "gamma" in orphan_agents
+
+
+# ---------------------------------------------------------------------------
+# collect_ports_data — conflict detection
+# ---------------------------------------------------------------------------
+
+
+def test_collect_flags_conflict_when_agent_claims_listen_port(
+    db: Path, free_port: int
+) -> None:
+    # Arrange — an agent claims the same port sac listen is told to use.
+    pa.claim_port("clash", explicit=free_port, db_path=db)
+    data = collect_ports_data(db_path=db, listen_port=free_port, probe_timeout=0.2)
+    # Act
+    conflict_ports = {c["port"] for c in data["conflicts"]}
+    # Assert
+    assert free_port in conflict_ports
+
+
+def test_collect_no_conflict_for_disjoint_ports(db: Path, free_port: int) -> None:
+    # Arrange — claim differs from the listen port.
+    pa.claim_port("solo", explicit=free_port, db_path=db)
+    data = collect_ports_data(db_path=db, listen_port=7878, probe_timeout=0.2)
+    # Act
+    conflicts = data["conflicts"]
+    # Assert
+    assert conflicts == []
+
+
+# ---------------------------------------------------------------------------
+# reference map
+# ---------------------------------------------------------------------------
+
+
+def test_reference_map_includes_listen_7878() -> None:
+    # Arrange
+    ranges = {row["range"] for row in _reference_map()}
+    # Act
+    has_listen = "7878" in ranges
+    # Assert
+    assert has_listen
+
+
+def test_reference_map_includes_gui_dashboard_block() -> None:
+    # Arrange
+    ranges = [row["range"] for row in _reference_map()]
+    # Act
+    has_gui_block = any("3129" in r for r in ranges)
+    # Assert
+    assert has_gui_block
+
+
+def test_reference_map_includes_a2a_range() -> None:
+    # Arrange
+    purposes = " ".join(row["purpose"] for row in _reference_map())
+    # Act
+    has_a2a = "a2a" in purposes
+    # Assert
+    assert has_a2a
+
+
+# ---------------------------------------------------------------------------
+# CLI surface (real Click command via CliRunner)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_json_output_has_listen_key(isolated_state) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(main, ["ports", "--json", "--timeout", "0.1"])
+    payload = json.loads(result.output)
+    # Assert
+    assert "listen" in payload
+
+
+def test_cli_json_output_has_reference_section(isolated_state) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(main, ["ports", "--json", "--timeout", "0.1"])
+    payload = json.loads(result.output)
+    # Assert
+    assert isinstance(payload["reference"], list) and payload["reference"]
+
+
+def test_cli_human_render_exits_zero(isolated_state) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(main, ["ports", "--timeout", "0.1"])
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_cli_json_includes_seeded_a2a_claim(isolated_state) -> None:
+    # Arrange — seed a claim in the HOME-isolated default state.db, then
+    # invoke the real CLI (which reads that same default db).
+    pa.claim_port("cli-agent", range_=(20000, 20050))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(main, ["ports", "--json", "--timeout", "0.1"])
+    owners = {row["owner"] for row in json.loads(result.output)["a2a_claims"]}
+    # Assert
+    assert "cli-agent" in owners
+
+
+def test_main_help_lists_ports_command() -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(main, ["--help"])
+    # Assert
+    assert "ports" in result.output


### PR DESCRIPTION
Ships v0.21.15 to `main`.

## Headline (#658)

`_off_loop.run_blocking` dispatched into the event loop's **shared default ThreadPoolExecutor**. A `concurrent.futures` future that is *already running* **cannot be cancelled** — so every timed-out call orphaned its worker thread while it kept holding a pool slot. Six background loops did this on every overrunning tick.

The pool is `min(32, cpu_count+4)` — **6–8 threads** — and `asyncio.to_thread` draws from **that same pool**. Once the slots were gone, *a task that needs a thread simply never runs*.

One defect, all of these symptoms:
- `sac listen` answered `/health` in 0.18s while **every authenticated route hung** (the fast path never touches the executor) — reported independently by two agents;
- brokered spawns stalled;
- on **Python 3.11 — what the fleet runs** — `sac listen` **could not shut down at all** (non-daemon pool workers; `shutdown_default_executor()` gained a timeout only in 3.12, so loop close joined an orphaned thread forever);
- the CI hang misread for weeks as "flaky CI", which **ghosted the v0.21.14 release** (tag pushed, PyPI got nothing);
- `uvicorn loopback did not start in 5s` — not a separate bug: a server that "did not start" is a task that never got a thread.

**The codebase already knew.** `_tui_heartbeat_loop.py` named the mechanism, named the consequence (*"which is how a slow heartbeat degraded into a fleet-wide comms outage"*), called the leak *"deliberate"* — and fixed **one of six** call sites. `_off_loop.py` had **zero tests**.

Fix: a dedicated **daemon** thread per call. Leaks at most one thread per abandoned call (unkillable in Python), **starves nothing**, never joined at shutdown. Adds `abandoned_call_count()`.

**Verified:** py3.11 green in 10 min on both develop and this release branch — the exact leg that ghosted v0.21.14.

## Also shipping

- **#657** `agent_send` called every live peer "stopped" (container $HOME resolved a private empty DB). Now brokers to the host; an unperformed check yields **UNKNOWN, never "stopped"**.
- **#656** `restart` reported restarts that never happened; `listen` claimed "it may be flapping" without measuring. Both now report only what they observed.
- **#646** a tmux-green agent could hide a dead token — `sac agents list` surfaces auth-failed.
- **#641** `sac ports`; plus tests that were reading *and writing* the live fleet registry through a fixture that only looked like isolation.
- **#655** the pytest matrix had no ceiling. Adding one didn't fix the hang — it **produced the evidence** that found it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)