### PR TITLE
fix(tests): stop racing REAL servers with arbitrary 5s deadlines — the second py3.11 CI failure

### DIFF
--- a/tests/integration/test_listen_notify_delivery.py
+++ b/tests/integration/test_listen_notify_delivery.py
@@ -39,8 +39,6 @@ import contextlib
 import json
 import os
 import socket
-import threading
-import time
 from pathlib import Path
 
 import httpx
@@ -51,6 +49,10 @@ from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
 from scitex_agent_container._state import state_db
+from tests.scitex_agent_container._helpers.loopback_server import (
+    serve_in_thread,
+    wait_until_serving,
+)
 
 HOST_TOKEN = "integration-notify-host-token"
 AGENT = "containerized-worker"
@@ -140,13 +142,11 @@ def live_listen(listen_state_db):
         app, host="127.0.0.1", port=port, log_level="warning", ws="none"
     )
     server = uvicorn.Server(config)
-    thread = threading.Thread(target=server.run, daemon=True)
-    thread.start()
-    deadline = time.monotonic() + 5.0
-    while not server.started:
-        if time.monotonic() > deadline:
-            raise RuntimeError("uvicorn loopback did not start in 5s")
-        time.sleep(0.05)
+    # Shared startup wait: the hand-rolled 5s ceiling that used to live here
+    # raced the listen lifespan (measured 7.49s under load) and turned the
+    # py3.11 leg red. See tests/.../_helpers/loopback_server.py.
+    thread, crash = serve_in_thread(server, port)
+    wait_until_serving(server, thread, port=port, crash=crash)
     try:
         yield f"http://127.0.0.1:{port}"
     finally:

--- a/tests/integration/test_listen_sigterm_sse_shutdown.py
+++ b/tests/integration/test_listen_sigterm_sse_shutdown.py
@@ -34,6 +34,10 @@ import uvicorn
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
+from tests.scitex_agent_container._helpers.loopback_server import (
+    serve_in_thread,
+    wait_until_serving,
+)
 
 TOKEN = "test-token-shutdown-sse"
 
@@ -174,13 +178,12 @@ def test_sac_listen_graceful_shutdown_cancels_inflight_sse(shutdown_env) -> None
     # Mirror the boot path (listen_cmds._do_start_listen) so the lifespan
     # shutdown bridge is wired to this server's ``should_exit``.
     app.state.uvicorn_server = server
-    thread = threading.Thread(target=server.run, daemon=True)
-    thread.start()
-    deadline = time.monotonic() + 5.0
-    while not server.started:
-        if time.monotonic() > deadline:
-            raise RuntimeError("uvicorn loopback did not start in 5s")
-        time.sleep(0.02)
+    # Shared startup wait: the hand-rolled 5s ceiling that used to live here
+    # raced the listen lifespan (measured 7.49s under load). This test keeps
+    # its own server object because it drives `should_exit` as the thing under
+    # test. See tests/.../_helpers/loopback_server.py.
+    thread, crash = serve_in_thread(server, port)
+    wait_until_serving(server, thread, port=port, crash=crash)
 
     # Act
     try:

--- a/tests/scitex_agent_container/_helpers/loopback_server.py
+++ b/tests/scitex_agent_container/_helpers/loopback_server.py
@@ -1,0 +1,197 @@
+"""Wait for a REAL uvicorn loopback server to come up — generously, and loudly.
+
+Why this exists (CI failure 2026-07-13, develop ``b92f38c3``, py3.11 leg:
+``1 failed, 9890 passed`` — ``test_cross_host_send_with_explicit_grant_...``):
+six test modules had each hand-rolled the same startup wait —
+
+    deadline = time.monotonic() + 5.0
+    while not server.started:
+        if time.monotonic() > deadline:
+            raise RuntimeError("uvicorn loopback did not start in 5s")
+        time.sleep(0.05)
+
+— and that 5-second ceiling is a RACE BY CONSTRUCTION. uvicorn sets
+``server.started`` only AFTER the ASGI **lifespan startup** completes, and the
+listen app's lifespan awaits ``persist_self_peers_on_listen_startup()`` (a
+filesystem walk over the config/fleet search dirs plus SQLite upserts) before
+spawning its six background loops. Measured on a loaded box: the server came
+up in **7.49s** — against the 5.0s ceiling. On a 2-core CI runner under load
+that is a coin flip, and it is why the leg went red without hanging.
+
+Two things are fixed here, once, for every call site:
+
+* **Poll, with a GENEROUS ceiling.** The wait already polled the real ready
+  state, so the fast path returns the instant the server binds — a generous
+  ceiling therefore costs *nothing* when the server is healthy and only bounds
+  the pathological case. Raising a tight deadline is not "moving the flake"
+  when the thing you are waiting on is a polled predicate rather than a fixed
+  sleep. Same reasoning as ``_settle`` in ``test__tui_heartbeat_loop.py``:
+  "poll for the expected end-state instead of guessing a duration".
+
+* **Fail loud, and say WHICH failure it was.** The old wait could not tell a
+  SLOW server from a DEAD one. If ``server.run()`` raised (port collision, bad
+  config), the thread exited, ``started`` stayed False, the wait burned its
+  whole ceiling and then blamed a *timeout* — while the real exception was
+  swallowed and never printed. Here the server thread's exception is captured
+  and re-raised as the ``__cause__``, so a genuine startup failure names itself
+  instead of masquerading as slowness.
+
+NO MOCKS — a real ``uvicorn.Server`` on a real loopback port.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import threading
+import time
+from typing import Any, Iterator
+
+import uvicorn
+
+# Generous on purpose: the happy path returns as soon as the port is serving,
+# so this only ever bounds a genuinely broken server. Overridable for a very
+# slow runner via SAC_TEST_LOOPBACK_STARTUP_TIMEOUT_S.
+DEFAULT_STARTUP_TIMEOUT_S = 30.0
+_POLL_INTERVAL_S = 0.02
+_SHUTDOWN_JOIN_TIMEOUT_S = 10.0
+
+__all__ = [
+    "DEFAULT_STARTUP_TIMEOUT_S",
+    "await_until_serving",
+    "run_loopback",
+    "serve_in_thread",
+    "wait_until_serving",
+]
+
+
+def _startup_timeout_s(explicit: float | None = None) -> float:
+    if explicit is not None:
+        return explicit
+    raw = os.environ.get("SAC_TEST_LOOPBACK_STARTUP_TIMEOUT_S", "").strip()
+    if not raw:
+        return DEFAULT_STARTUP_TIMEOUT_S
+    try:
+        return float(raw)
+    except ValueError:
+        return DEFAULT_STARTUP_TIMEOUT_S
+
+
+def serve_in_thread(server: uvicorn.Server, port: int) -> tuple[threading.Thread, list]:
+    """Run ``server`` in a daemon thread; return ``(thread, crash_box)``.
+
+    ``crash_box`` receives the exception if ``server.run()`` raises, so the
+    waiter can re-raise it on the test thread instead of losing it.
+    """
+    crash: list[BaseException] = []
+
+    def _serve() -> None:
+        try:
+            server.run()
+        except BaseException as exc:  # stx-allow: fallback (reason: relayed to the test thread by wait_until_serving; swallowing it here is exactly the old bug)
+            crash.append(exc)
+
+    thread = threading.Thread(
+        target=_serve, name=f"uvicorn-loopback-{port}", daemon=True
+    )
+    thread.start()
+    return thread, crash
+
+
+def _check_dead(
+    server: uvicorn.Server,
+    thread: threading.Thread,
+    crash: list,
+    port: int,
+    elapsed: float,
+) -> None:
+    """Raise (naming the real cause) if the server thread died before serving."""
+    if crash:
+        raise RuntimeError(
+            f"uvicorn loopback on port {port} CRASHED during startup after "
+            f"{elapsed:.2f}s — see the chained exception for the real cause"
+        ) from crash[0]
+    if not thread.is_alive() and not server.started:
+        raise RuntimeError(
+            f"uvicorn loopback on port {port} exited during startup after "
+            f"{elapsed:.2f}s without ever serving, and raised nothing"
+        )
+
+
+def _timed_out(port: int, elapsed: float, ceiling: float, alive: bool) -> RuntimeError:
+    return RuntimeError(
+        f"uvicorn loopback on port {port} never became ready: server.started "
+        f"stayed False for {elapsed:.1f}s (ceiling {ceiling:.1f}s; server thread "
+        f"alive={alive}). uvicorn only flips `started` once the ASGI LIFESPAN "
+        f"startup has completed, so the lifespan is what never finished."
+    )
+
+
+def wait_until_serving(
+    server: uvicorn.Server,
+    thread: threading.Thread,
+    *,
+    port: int,
+    crash: list | None = None,
+    timeout_s: float | None = None,
+) -> None:
+    """Block until ``server`` is serving. Fail loud on death or timeout."""
+    ceiling = _startup_timeout_s(timeout_s)
+    started_at = time.monotonic()
+    crash = crash if crash is not None else []
+    while not server.started:
+        elapsed = time.monotonic() - started_at
+        _check_dead(server, thread, crash, port, elapsed)
+        if elapsed > ceiling:
+            raise _timed_out(port, elapsed, ceiling, thread.is_alive())
+        time.sleep(_POLL_INTERVAL_S)
+
+
+async def await_until_serving(
+    server: uvicorn.Server,
+    thread: threading.Thread,
+    *,
+    port: int,
+    crash: list | None = None,
+    timeout_s: float | None = None,
+) -> None:
+    """``wait_until_serving`` for an async test — yields to the loop while waiting."""
+    ceiling = _startup_timeout_s(timeout_s)
+    started_at = time.monotonic()
+    crash = crash if crash is not None else []
+    while not server.started:
+        elapsed = time.monotonic() - started_at
+        _check_dead(server, thread, crash, port, elapsed)
+        if elapsed > ceiling:
+            raise _timed_out(port, elapsed, ceiling, thread.is_alive())
+        await asyncio.sleep(_POLL_INTERVAL_S)
+
+
+@contextlib.contextmanager
+def run_loopback(
+    app: Any, port: int, *, timeout_s: float | None = None, **config_kwargs: Any
+) -> Iterator[int]:
+    """Serve ``app`` on ``127.0.0.1:port`` for the duration of the block.
+
+    Teardown flips ``should_exit`` and joins, so the ``finally`` fires even on
+    test failure and a hung client never strands the server.
+    """
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        ws="none",
+        **config_kwargs,
+    )
+    server = uvicorn.Server(config)
+    thread, crash = serve_in_thread(server, port)
+    wait_until_serving(
+        server, thread, port=port, crash=crash, timeout_s=timeout_s
+    )
+    try:
+        yield port
+    finally:
+        server.should_exit = True
+        thread.join(timeout=_SHUTDOWN_JOIN_TIMEOUT_S)

--- a/tests/scitex_agent_container/_listen/test__nodes.py
+++ b/tests/scitex_agent_container/_listen/test__nodes.py
@@ -47,6 +47,10 @@ from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
 from scitex_agent_container._state import state_db as _state_db
 from scitex_agent_container._state.state_db_nodes import record_lineage
+from tests.scitex_agent_container._helpers.loopback_server import (
+    await_until_serving,
+    serve_in_thread,
+)
 
 TOKEN = "test-token-wi3"
 
@@ -201,7 +205,6 @@ async def _sse_roundtrip(
     """
     import contextlib as _contextlib
     import socket
-    import threading
 
     import uvicorn
 
@@ -217,14 +220,11 @@ async def _sse_roundtrip(
     )
     server = uvicorn.Server(config)
 
-    server_thread = threading.Thread(target=server.run, daemon=True)
-    server_thread.start()
-    # Wait for the server to come up.
-    deadline = asyncio.get_event_loop().time() + 5.0
-    while not server.started:
-        if asyncio.get_event_loop().time() > deadline:
-            raise AssertionError("uvicorn did not start in 5s")
-        await asyncio.sleep(0.05)
+    # Shared startup wait: the hand-rolled 5s ceiling that used to live here
+    # raced the listen lifespan (measured 7.49s under load) and turned the
+    # py3.11 leg red. See tests/.../_helpers/loopback_server.py.
+    server_thread, crash = serve_in_thread(server, port)
+    await await_until_serving(server, server_thread, port=port, crash=crash)
 
     headers = {"authorization": f"Bearer {TOKEN}"}
     ready = asyncio.Event()

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -24,12 +24,10 @@ import contextlib
 import json
 import os
 import socket
-import threading
 from pathlib import Path
 
 import httpx
 import pytest
-import uvicorn
 import yaml
 from starlette.testclient import TestClient
 
@@ -40,6 +38,7 @@ from scitex_agent_container._state import registry as _reg
 from scitex_agent_container._state import state_db
 from scitex_agent_container._state import state_db_nodes as state_db_nodes_grant
 from scitex_agent_container._state.state_db_nodes import record_lineage
+from tests.scitex_agent_container._helpers.loopback_server import run_loopback
 
 TOKEN = "test-token-abc123"
 
@@ -828,30 +827,33 @@ def _free_port() -> int:
         return s.getsockname()[1]
 
 
+# Ceiling for the REAL cross-host I/O below (loopback HTTP + the SSE roundtrip
+# between two live uvicorn servers). Generous ON PURPOSE, and not a magic number:
+# every wait it bounds is event-driven — the httpx read returns the instant the
+# forwarded event lands, the `wait_for`s the instant their event fires — so a
+# large ceiling costs NOTHING on the happy path and only bounds a genuinely
+# broken run. The 5.0s literals that used to be sprinkled here were the second
+# half of the py3.11 CI flake: once the `uvicorn loopback did not start in 5s`
+# ceiling was fixed, a loaded runner simply failed one layer down instead, with
+# `httpx.ReadTimeout` (reproduced: 6 cross-host tests fail under CPU
+# oversubscription purely on these 5s bounds). Bounding real I/O by an arbitrary
+# tight deadline is a race by construction; the fix is to make the bound
+# generous, not to guess a better number.
+LOOPBACK_IO_TIMEOUT_S = 30.0
+
+
 @contextlib.contextmanager
 def _run_loopback(app, port: int):
     """Spin up uvicorn on a loopback port. The app's
     ``local_host`` identity is configured at ``create_app`` time
     (see :func:`scitex_agent_container._listen.server.create_app`).
-    """
-    config = uvicorn.Config(
-        app, host="127.0.0.1", port=port, log_level="warning", ws="none"
-    )
-    server = uvicorn.Server(config)
-    t = threading.Thread(target=server.run, daemon=True)
-    t.start()
-    import time as _time
 
-    deadline = _time.monotonic() + 5.0
-    while not server.started:
-        if _time.monotonic() > deadline:
-            raise RuntimeError("uvicorn loopback did not start in 5s")
-        _time.sleep(0.05)
-    try:
-        yield port
-    finally:
-        server.should_exit = True
-        t.join(timeout=5.0)
+    Startup wait lives in the shared helper — the hand-rolled 5s ceiling this
+    used to carry raced the listen lifespan (measured 7.49s under load) and
+    turned the py3.11 leg red. See ``_helpers/loopback_server.py``.
+    """
+    with run_loopback(app, port) as p:
+        yield p
 
 
 def _send_payload(text: str, *, from_agent: str) -> dict:
@@ -904,7 +906,7 @@ def test_cross_host_send_forwards_to_target_host(cross_host_env) -> None:
             captured: dict = {}
 
             async def consume():
-                async with httpx.AsyncClient(timeout=5.0) as ac:
+                async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                     async with ac.stream(
                         "GET",
                         f"http://127.0.0.1:{host_a_port}/agents/alice/inbox/stream",
@@ -922,11 +924,11 @@ def test_cross_host_send_forwards_to_target_host(cross_host_env) -> None:
 
             sub = asyncio.create_task(consume())
             try:
-                await asyncio.wait_for(ready.wait(), timeout=5.0)
+                await asyncio.wait_for(ready.wait(), timeout=LOOPBACK_IO_TIMEOUT_S)
                 # Now stand up host B and post to it. WI-4 forwarder
                 # on host B should resolve alice→host-a and forward.
                 with _run_loopback(app_b, host_b_port):
-                    async with httpx.AsyncClient(timeout=5.0) as ac:
+                    async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                         resp = await ac.post(
                             f"http://127.0.0.1:{host_b_port}/agents/alice/message:send",
                             json=_send_payload(
@@ -938,7 +940,7 @@ def test_cross_host_send_forwards_to_target_host(cross_host_env) -> None:
                     raise RuntimeError(
                         f"forward returned {resp.status_code}: {resp.text!r}"
                     )
-                await asyncio.wait_for(sub, timeout=5.0)
+                await asyncio.wait_for(sub, timeout=LOOPBACK_IO_TIMEOUT_S)
             finally:
                 if not sub.done():
                     sub.cancel()
@@ -978,7 +980,7 @@ def test_cross_host_forward_preserves_from_agent_metadata(cross_host_env) -> Non
             captured: dict = {}
 
             async def consume():
-                async with httpx.AsyncClient(timeout=5.0) as ac:
+                async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                     async with ac.stream(
                         "GET",
                         f"http://127.0.0.1:{host_a_port}/agents/alice/inbox/stream",
@@ -996,15 +998,15 @@ def test_cross_host_forward_preserves_from_agent_metadata(cross_host_env) -> Non
 
             sub = asyncio.create_task(consume())
             try:
-                await asyncio.wait_for(ready.wait(), timeout=5.0)
+                await asyncio.wait_for(ready.wait(), timeout=LOOPBACK_IO_TIMEOUT_S)
                 with _run_loopback(app_b, host_b_port):
-                    async with httpx.AsyncClient(timeout=5.0) as ac:
+                    async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                         await ac.post(
                             f"http://127.0.0.1:{host_b_port}/agents/alice/message:send",
                             json=_send_payload("x", from_agent="permitted-peer"),
                             headers={"authorization": f"Bearer {SHARED_TOKEN}"},
                         )
-                await asyncio.wait_for(sub, timeout=5.0)
+                await asyncio.wait_for(sub, timeout=LOOPBACK_IO_TIMEOUT_S)
             finally:
                 if not sub.done():
                     sub.cancel()
@@ -1220,7 +1222,7 @@ def _drive_ssh_cross_host_send(
             captured: dict = {}
 
             async def consume():
-                async with httpx.AsyncClient(timeout=5.0) as ac:
+                async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                     async with ac.stream(
                         "GET",
                         f"http://127.0.0.1:{host_a_port}/agents/alice/inbox/stream",
@@ -1238,9 +1240,9 @@ def _drive_ssh_cross_host_send(
 
             sub = asyncio.create_task(consume())
             try:
-                await asyncio.wait_for(ready.wait(), timeout=5.0)
+                await asyncio.wait_for(ready.wait(), timeout=LOOPBACK_IO_TIMEOUT_S)
                 with _run_loopback(app_b, host_b_port):
-                    async with httpx.AsyncClient(timeout=10.0) as ac:
+                    async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                         resp = await ac.post(
                             f"http://127.0.0.1:{host_b_port}/agents/alice/message:send",
                             json=_send_payload(text, from_agent=sender),
@@ -1250,7 +1252,7 @@ def _drive_ssh_cross_host_send(
                     raise RuntimeError(
                         f"ssh forward returned {resp.status_code}: {resp.text!r}"
                     )
-                await asyncio.wait_for(sub, timeout=5.0)
+                await asyncio.wait_for(sub, timeout=LOOPBACK_IO_TIMEOUT_S)
             finally:
                 if not sub.done():
                     sub.cancel()
@@ -1351,7 +1353,7 @@ def test_cross_host_send_without_grant_returns_403_from_target_listen(
 
     async def driver() -> int:
         with _run_loopback(app_a, host_a_port), _run_loopback(app_b, host_b_port):
-            async with httpx.AsyncClient(timeout=10.0) as ac:
+            async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                 resp = await ac.post(
                     f"http://127.0.0.1:{host_b_port}/agents/alice/message:send",
                     json=_send_payload("denied", from_agent="outsider"),
@@ -1429,7 +1431,7 @@ def _roundtrip_local_send(cross_host_env, *, metadata: dict) -> dict:
             captured: dict = {}
 
             async def consume():
-                async with httpx.AsyncClient(timeout=5.0) as ac:
+                async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                     async with ac.stream(
                         "GET",
                         f"http://127.0.0.1:{port}/agents/alice/inbox/stream",
@@ -1447,14 +1449,14 @@ def _roundtrip_local_send(cross_host_env, *, metadata: dict) -> dict:
 
             sub = asyncio.create_task(consume())
             try:
-                await asyncio.wait_for(ready.wait(), timeout=5.0)
-                async with httpx.AsyncClient(timeout=5.0) as ac:
+                await asyncio.wait_for(ready.wait(), timeout=LOOPBACK_IO_TIMEOUT_S)
+                async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                     await ac.post(
                         f"http://127.0.0.1:{port}/agents/alice/message:send",
                         json=_send_payload_with_meta("ping", metadata=metadata),
                         headers={"authorization": f"Bearer {SHARED_TOKEN}"},
                     )
-                await asyncio.wait_for(sub, timeout=5.0)
+                await asyncio.wait_for(sub, timeout=LOOPBACK_IO_TIMEOUT_S)
             finally:
                 if not sub.done():
                     sub.cancel()

--- a/tests/scitex_agent_container/_runners/test_a2a_proxy.py
+++ b/tests/scitex_agent_container/_runners/test_a2a_proxy.py
@@ -18,6 +18,10 @@ from starlette.routing import Route
 from starlette.testclient import TestClient
 
 from scitex_agent_container._runners.a2a_proxy import build_app, splice_card
+from tests.scitex_agent_container._helpers.loopback_server import (
+    serve_in_thread,
+    wait_until_serving,
+)
 
 # ---------------------------------------------------------------------------
 # Upstream stubs (in-process ASGI app, accessed via httpx.AsyncClient)
@@ -907,8 +911,6 @@ def real_upstream_server() -> Any:
     Yields ``("http://127.0.0.1:<port>", recorder)`` where recorder is
     a dict the upstream mutates so tests can observe traffic.
     """
-    import threading
-    import time
 
     import uvicorn
 
@@ -935,17 +937,15 @@ def real_upstream_server() -> Any:
     )
     server = uvicorn.Server(config)
 
-    thread = threading.Thread(target=server.run, daemon=True)
-    thread.start()
-
-    # Wait until the server reports it's actually listening.
-    deadline = time.time() + 5.0
-    while time.time() < deadline and not server.started:
-        time.sleep(0.02)
-    if not server.started:
+    # Shared startup wait — a hand-rolled 5s ceiling on a real server start is
+    # a race by construction (see tests/.../_helpers/loopback_server.py).
+    thread, crash = serve_in_thread(server, port)
+    try:
+        wait_until_serving(server, thread, port=port, crash=crash)
+    except Exception:
         server.should_exit = True
         thread.join(timeout=2.0)
-        raise RuntimeError("upstream uvicorn server failed to start")
+        raise
 
     try:
         yield (f"http://127.0.0.1:{port}", recorder)
@@ -957,8 +957,6 @@ def real_upstream_server() -> Any:
 @pytest.fixture
 def failing_upstream_server() -> Any:
     """Real uvicorn server whose card endpoint returns 500."""
-    import threading
-    import time
 
     import uvicorn
 
@@ -974,16 +972,14 @@ def failing_upstream_server() -> Any:
         app, host="127.0.0.1", port=port, log_level="warning", lifespan="off"
     )
     server = uvicorn.Server(config)
-    thread = threading.Thread(target=server.run, daemon=True)
-    thread.start()
-
-    deadline = time.time() + 5.0
-    while time.time() < deadline and not server.started:
-        time.sleep(0.02)
-    if not server.started:
+    # Shared startup wait — see tests/.../_helpers/loopback_server.py.
+    thread, crash = serve_in_thread(server, port)
+    try:
+        wait_until_serving(server, thread, port=port, crash=crash)
+    except Exception:
         server.should_exit = True
         thread.join(timeout=2.0)
-        raise RuntimeError("upstream uvicorn server failed to start")
+        raise
 
     try:
         yield f"http://127.0.0.1:{port}"

--- a/tests/scitex_agent_container/a2a/test__server.py
+++ b/tests/scitex_agent_container/a2a/test__server.py
@@ -658,12 +658,13 @@ def test_sdk_round_trip_get_task_envelope_carries_result(_round_trip):
 import asyncio as _asyncio
 import contextlib as _contextlib
 import socket as _socket
-import threading as _threading
 
 import httpx as _httpx
-import uvicorn as _uvicorn
 
 from scitex_agent_container._state import state_db as _state_db
+from tests.scitex_agent_container._helpers.loopback_server import (
+    run_loopback as _run_loopback_shared,
+)
 
 
 @pytest.fixture
@@ -709,27 +710,14 @@ def _send_payload(text: str, *, from_agent: str = "alice") -> dict:
 
 @_contextlib.contextmanager
 def _run_loopback(app, port: int):
-    """Spin up uvicorn on a loopback port for a single test block."""
-    # Arrange — boot the uvicorn server on a background thread.
-    config = _uvicorn.Config(
-        app, host="127.0.0.1", port=port, log_level="warning", ws="none"
-    )
-    server = _uvicorn.Server(config)
-    t = _threading.Thread(target=server.run, daemon=True)
-    t.start()
-    # Wait for "started"; raise loudly if it doesn't come up.
-    import time as _time
+    """Spin up uvicorn on a loopback port for a single test block.
 
-    deadline = _time.monotonic() + 5.0
-    while not server.started:
-        if _time.monotonic() > deadline:
-            raise RuntimeError("uvicorn loopback did not start in 5s")
-        _time.sleep(0.05)
-    try:
-        yield port
-    finally:
-        server.should_exit = True
-        t.join(timeout=5.0)
+    Startup wait lives in the shared helper — the hand-rolled 5s ceiling this
+    used to carry raced the app's lifespan startup (measured 7.49s under load)
+    and turned the py3.11 leg red. See ``_helpers/loopback_server.py``.
+    """
+    with _run_loopback_shared(app, port) as p:
+        yield p
 
 
 def _free_port() -> int:

--- a/tests/smoke/_node_comms.py
+++ b/tests/smoke/_node_comms.py
@@ -24,18 +24,16 @@ import asyncio
 import contextlib
 import json
 import socket
-import threading
-import time
 from pathlib import Path
 
 import httpx
-import uvicorn
 import yaml
 
 from scitex_agent_container._state.state_db_nodes import (
     mint_node_token,
     record_lineage,
 )
+from tests.scitex_agent_container._helpers.loopback_server import run_loopback
 
 # ---------------------------------------------------------------------------
 # uvicorn loopback helpers (mirrors tests/.../_listen/test_server.py).
@@ -55,23 +53,13 @@ def _run_loopback(app, port: int):
 
     Teardown sets ``should_exit`` + joins; the ``finally`` fires even
     on test failure so a hung subscriber never strands the server.
+
+    The startup wait lives in the shared helper — the hand-rolled 5s ceiling
+    this used to carry raced the listen lifespan (measured 7.49s under load).
+    See ``_helpers/loopback_server.py``.
     """
-    config = uvicorn.Config(
-        app, host="127.0.0.1", port=port, log_level="warning", ws="none"
-    )
-    server = uvicorn.Server(config)
-    t = threading.Thread(target=server.run, daemon=True)
-    t.start()
-    deadline = time.monotonic() + 5.0
-    while not server.started:
-        if time.monotonic() > deadline:
-            raise RuntimeError("uvicorn loopback did not start in 5s")
-        time.sleep(0.05)
-    try:
-        yield port
-    finally:
-        server.should_exit = True
-        t.join(timeout=5.0)
+    with run_loopback(app, port) as p:
+        yield p
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Second, **independent** py3.11 failure. Not the hang from #658 — this one **fails fast**, and it is **not 3.11-specific**: 3.12/3.13 passed the very same commit on load luck alone.

develop `b92f38c3`, run 29279320144, py3.11: `1 failed, 9890 passed … in 544.48s (9:04)`

```
RuntimeError: uvicorn loopback did not start in 5s
FAILED tests/.../_listen/test_server.py::test_cross_host_send_with_explicit_grant_unblocks_cross_group_push
```

## Root cause

A tight deadline on a **real server** — a race by construction.

uvicorn flips `server.started` only **after the ASGI lifespan startup completes**, and the listen lifespan `await`s `persist_self_peers_on_listen_startup()` (a filesystem walk over the config/fleet search dirs + SQLite upserts) *before* spawning its six background loops.

**Measured** (py3.11, under load): the server came up in **7.49 s** — against the **5.0 s** ceiling. The thread never dies; the server is simply slow. On a 2-core runner nine minutes into the suite, that is a coin flip.

The same hand-rolled wait had been copy-pasted into **eight** call sites.

## Fix — two layers, because fixing only the first just moves the flake

**1. Startup.** One shared helper (`tests/.../_helpers/loopback_server.py`) replaces all eight copies. It still **polls the real ready state**, so the fast path returns the instant the port serves — a generous ceiling costs *nothing* when the server is healthy and only bounds a genuinely broken run. (This is not "bump 5 to 30": the thing being waited on is a polled predicate, not a fixed sleep. Same reasoning as `_settle` in `test__tui_heartbeat_loop.py`.)

It also now **tells a slow server from a dead one**. The old wait swallowed the exception from `server.run()`, burned its whole ceiling, and then blamed a *timeout* — so a port collision or bad config was reported as slowness and the real cause was never printed. The thread's exception is captured and re-raised as `__cause__`.

**2. The next domino.** With the startup ceiling fixed, a loaded runner simply failed **one layer down**: `httpx.ReadTimeout`, from the 5.0 s bounds on the cross-host SSE roundtrip. These are *event-driven* waits (they return the instant the forwarded event lands), so bounding them generously is free on the happy path. The scattered `5.0`/`10.0` literals are now one named `LOOPBACK_IO_TIMEOUT_S` carrying the rationale.

## Verification — py3.11, identical 14-way CPU-oversubscribed load

| | before layer-2 fix | after |
|---|---|---|
| cross-host tests | **6 failed, 4 passed** | **10 passed, 0 failed** |
| `httpx.ReadTimeout` | 6 | **0** |

Unloaded, the named test passes in 7.21 s. `ruff --select F401,F811` clean.

## Scope

**Test-only — no production code is touched.** The defect here is the test harness, not the daemon. That is the opposite of #658, where the bug was in production (`sac listen` could not shut down and brokered spawns hung). Kept as a separate PR for that reason.