### PR TITLE
fix(off_loop): honour cancellation — on 3.11 `sac listen`'s loops could IGNORE it and never stop

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_off_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_off_loop.py
@@ -130,14 +130,15 @@ async def run_blocking(
     The call is dispatched to a DEDICATED daemon thread — never the event
     loop's shared default executor — so it neither occupies the loop
     thread nor competes for the pool that ``asyncio.to_thread`` callers
-    depend on. It is bounded by ``timeout_s`` via :func:`asyncio.wait_for`
-    and raises :class:`asyncio.TimeoutError` if the call does not finish
-    in time. The underlying thread is left to finish/abandon — we do NOT
-    join it, so a wedged child can never block the loop; because the
-    thread is private to this call, abandoning it starves nothing (see the
-    module docstring: doing this on the shared executor is what made a
-    wedged probe hang the whole process). Any exception ``fn`` raises
-    propagates unchanged.
+    depend on. It is bounded by ``timeout_s`` (a plain deadline timer, NOT
+    ``asyncio.wait_for`` — see the comment on the await below) and raises
+    :class:`asyncio.TimeoutError` if the call does not finish in time. The
+    underlying thread is left to finish/abandon — we do NOT join it, so a
+    wedged child can never block the loop; because the thread is private to
+    this call, abandoning it starves nothing (see the module docstring:
+    doing this on the shared executor is what made a wedged probe hang the
+    whole process). Any exception ``fn`` raises propagates unchanged, and
+    CANCELLATION IS ALWAYS HONOURED — a cancelled caller never keeps running.
     """
     loop = asyncio.get_running_loop()
     future: asyncio.Future[T] = loop.create_future()
@@ -149,14 +150,19 @@ async def run_blocking(
     abandoned = False
 
     def _deliver(result: Any, exc: BaseException | None) -> None:
-        # On the loop thread. If wait_for already timed out it cancelled the
-        # future and moved on — there is no awaiter left to deliver to.
+        # On the loop thread. If the deadline already fired (or the awaiter was
+        # cancelled) the future is done — there is nobody left to deliver to.
         if future.done():
             return
         if exc is not None:
             future.set_exception(exc)
         else:
             future.set_result(result)
+
+    def _on_deadline() -> None:
+        # On the loop thread, timeout_s after dispatch.
+        if not future.done():
+            future.set_exception(asyncio.TimeoutError())
 
     def _runner() -> None:
         nonlocal finished
@@ -181,16 +187,39 @@ async def run_blocking(
     threading.Thread(
         target=_runner, name=f"sac-off-loop-{op}", daemon=True
     ).start()
+    # A BARE `await future` + a plain deadline timer, NOT `asyncio.wait_for`.
+    # On Python <= 3.11 wait_for SWALLOWS an outer cancellation that lands in
+    # the same instant the inner future resolves:
+    #
+    #     except CancelledError:
+    #         if fut.done():
+    #             return fut.result()   # <- the cancellation is dropped
+    #
+    # A background loop cancelled at that instant therefore keeps ticking, and
+    # `await task` never returns — an infinite, 3.11-only hang (it is what wedged
+    # `test_loop_honours_cancellation_cleanly` and the sdk/tui heartbeat loop
+    # tests in CI). 3.12 rebuilt wait_for on `asyncio.timeouts` and has no such
+    # branch. Measured, 120 cancellations of a 20Hz poll loop:
+    #     3.11.15  wait_for -> 13 swallowed   asyncio.timeout/bare await -> 0
+    #     3.12.3   wait_for ->  0 swallowed   asyncio.timeout/bare await -> 0
+    # `asyncio.timeout()` would fix it too but is 3.11+, and this package still
+    # declares `requires-python = ">=3.10"`. A bare await has no swallow branch
+    # on ANY version: cancellation always propagates.
+    deadline = loop.call_later(timeout_s, _on_deadline)
     try:
-        return await asyncio.wait_for(future, timeout=timeout_s)
+        return await future
     except asyncio.TimeoutError:
         with state_lock:
+            # `finished` disambiguates OUR deadline from an `fn` that itself
+            # raised TimeoutError (that one is a real result, not an abandon).
             newly_abandoned = not finished
             if newly_abandoned:
                 abandoned = True
         if newly_abandoned:
             _mark_abandoned(op)
         raise
+    finally:
+        deadline.cancel()
 
 
 async def run_blocking_or(

--- a/tests/scitex_agent_container/_lifecycle/test__off_loop.py
+++ b/tests/scitex_agent_container/_lifecycle/test__off_loop.py
@@ -196,3 +196,56 @@ async def test_abandoned_call_count_reports_the_wedged_calls(wedge):
         await run_blocking_or(wedge, default=None, op="wedged probe", timeout_s=0.05)
     # Assert
     assert abandoned_call_count() == before + 3
+
+
+# ---------------------------------------------------------------------------
+# CANCELLATION MUST NEVER BE SWALLOWED (3.11-only infinite hang).
+#
+# `run_blocking` used to await via `asyncio.wait_for`. On Python <= 3.11 that
+# SWALLOWS an outer cancellation which lands in the same instant the inner
+# future resolves:
+#
+#     except CancelledError:
+#         if fut.done():
+#             return fut.result()      # <- cancellation dropped on the floor
+#
+# A background loop (github-CI poll, sdk/tui heartbeat, liveness tick — every
+# one of them is `while True: await run_blocking_or(...)`) then IGNORES
+# `task.cancel()` and keeps ticking forever, so `await task` never returns.
+# That is an infinite hang, and it is 3.11-only: 3.12 rebuilt wait_for on
+# `asyncio.timeouts` and has no such branch. Measured over 120 cancellations of
+# a 20Hz loop: 3.11.15 dropped 13, 3.12.3 dropped 0.
+#
+# It is also a PRODUCTION defect on the fleet's 3.11: a `sac listen` whose
+# loops ignore cancellation cannot shut down cleanly.
+#
+# The loop below cancels repeatedly to make the race bite: a single attempt hits
+# the window only ~10% of the time.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancellation_is_never_swallowed_by_the_deadline_wait():
+    """A cancelled `run_blocking` caller must STOP — not keep looping."""
+    # Arrange — a poll loop shaped exactly like the real background loops:
+    # a fast off-loop call, then a short sleep, forever.
+    async def poll_loop() -> None:
+        while True:
+            await run_blocking(lambda: None, timeout_s=5.0)
+            await asyncio.sleep(0.05)
+
+    survived_cancellation = 0
+    # Act — cancel it many times; each cancel MUST be honoured.
+    for _ in range(40):
+        task = asyncio.create_task(poll_loop())
+        await asyncio.sleep(0.06)
+        task.cancel()
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+        except asyncio.CancelledError:
+            pass  # correct — the loop stopped
+        except asyncio.TimeoutError:
+            survived_cancellation += 1  # the loop IGNORED cancel → would hang
+            task.cancel()
+    # Assert
+    assert survived_cancellation == 0


### PR DESCRIPTION
## The production defect (this is the headline; CI is only how we noticed)

On **Python 3.11 — what the whole fleet runs** — every `sac listen` background loop could **silently ignore cancellation and keep ticking forever.**

Each loop is `while True: await run_blocking_or(...)`. A dropped cancel means the loop never stops:

- the daemon **does not shut down cleanly on SIGTERM**,
- `agents stop` / `agents restart` leave it ticking,
- a task that was "cancelled" is still probing.

The cancel is requested, never happens, and reports nothing. **This is the long-standing "the listen daemon will not die properly" complaint.**

## Root cause

`run_blocking` awaited via `asyncio.wait_for`. CPython **≤ 3.11**:

```python
except exceptions.CancelledError:
    if fut.done():
        return fut.result()      # <-- the cancellation is DROPPED ON THE FLOOR
```

If the outer task is cancelled in the **same instant** the inner future resolves, `wait_for` returns the value and **swallows** the `CancelledError`. Python 3.12 rebuilt `wait_for` on `asyncio.timeouts` and has no such branch — so this is **3.11-only**.

## Measured, not asserted

120 cancellations of a 20 Hz poll loop:

| | 3.11.15 | 3.12.3 |
|---|---|---|
| `asyncio.wait_for` (what `run_blocking` used) | **13 of 120 SWALLOWED** | 0 of 120 |
| bare `await` (this fix) | **0 of 120** | 0 of 120 |

The bare-await control column is what makes this a fact rather than a story.

## #658 widened this race — the record should state it plainly

The swallow branch **predates #658**: the old `run_blocking` also used `asyncio.wait_for`. But #658 moved dispatch to a dedicated thread that resolves the future **promptly** via `call_soon_threadsafe`, which enormously widened the window in which `fut.done()` is true exactly as the cancel lands.

**#658 turned a dormant defect into a live one. That is a regression even though the bug was not introduced there, and v0.21.15 ships with the hole.** This needs a release behind it.

## The CI symptom

A third py3.11-only infinite hang, distinct from the two already fixed (#658 executor-orphan, #661 server deadlines): `test_loop_honours_cancellation_cleanly` starts, the poll loop absorbs `task.cancel()`, `await task` never returns, and the job runs to the 30-minute cap. It wedged the sdk/tui heartbeat-loop tests the same way.

## The fix

A bare `await future` plus a plain `loop.call_later` deadline timer. No `wait_for`, therefore **no swallow branch on any version** — cancellation always propagates.

`asyncio.timeout()` would fix it too, but it is 3.11+ and this package declares `requires-python = ">=3.10"` — hence the timer, on the constraint rather than on taste. The `finished` flag disambiguates our own deadline from an `fn` that itself raised `TimeoutError`.

## Verification (py3.11.15, import path inside the worktree)

- New `test_cancellation_is_never_swallowed_by_the_deadline_wait` cancels a 20 Hz loop 40 times and requires **every** cancel to be honoured. It **FAILS against the old dispatch** (`assert 1 == 0`) and passes with the fix — a test that has never failed proves nothing.
- `test__github_ci_poll_loop.py`: **hung** on develop → now **5 passed × 6 consecutive runs**, 0.5–0.9 s each.
- `_lifecycle/` dir: **killed mid-run (hang)** on develop → **719 passed** with the fix.
- `ruff --select F401,F811` clean.