### PR TITLE
chore(release): v0.21.16 — `sac listen` could ignore cancellation and never stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,72 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.21.15] — 2026-07-14
+## [0.21.16] — 2026-07-14
+
+**⚠️ 0.21.15 WAS NEVER PUBLISHED — it is tagged, but nothing reached PyPI, and
+that is deliberate.** It shipped #658 (the shared-executor fix) *with a hole*:
+#658 did not introduce the cancellation race below, but it **widened the window
+enormously**, so 0.21.15 would have traded a thread leak for a `sac listen` that
+cannot be stopped. It was held back rather than published. **Install 0.21.16.**
+
+### Fixed
+
+- **`sac listen` could ignore `stop` and `restart` entirely, and never shut down
+  (#663).** On **Python 3.11 — the version the fleet runs** — `asyncio.wait_for`
+  **silently swallows a cancellation** when the inner future resolves in the same
+  instant:
+
+  ```python
+  except exceptions.CancelledError:
+      if fut.done():
+          return fut.result()      # the cancellation is dropped on the floor
+  ```
+
+  Every background loop is `while True: await run_blocking_or(...)`, so one
+  swallowed cancel and **the loop ticks forever**: `task.cancel()` returns,
+  `await task` never does, and the daemon does not die on SIGTERM. `agents stop`
+  and `agents restart` leave it running; a "cancelled" task is still probing.
+  3.12 rebuilt `wait_for` on `asyncio.timeouts` and has no such branch.
+
+  Measured over 120 cancellations of a 20 Hz loop:
+
+  | dispatch | 3.11.15 | 3.12.3 |
+  |---|---|---|
+  | `asyncio.wait_for` | **13 swallowed** | 0 |
+  | bare `await` (the fix) | 0 | 0 |
+
+  Fix: bare `await future` + a `loop.call_later` deadline. No `wait_for`, no
+  swallow branch, on any version. (`asyncio.timeout()` would also work but is
+  3.11+, and `requires-python` is `>=3.10`.) The regression test was confirmed to
+  **fail against the old dispatch** — a test that has never failed proves nothing.
+
+- **A live agent's registry row was buried 64 seconds after it started (#644).**
+  A freshly booted agent has not written a heartbeat yet, and the reaper read
+  *no heartbeat* as *dead* and ended its row — after which `agent_send` refused to
+  deliver to a demonstrably live agent. Measured: `paper-scitex-clew` started
+  18:21:20, row ended 18:22:24, agent alive with a real pid and a real port.
+  **Absence of evidence is not evidence of death.** Liveness now yields UNKNOWN
+  where it cannot measure, and only an *observed* absence may end a row.
+
+- **Tests raced real servers against arbitrary 5-second deadlines (#661).** The
+  loopback server wasn't dead — it was **slow** (`server.started` measured at
+  7.49s, because the listen lifespan does a filesystem walk plus SQLite upserts
+  before reporting ready). The old wait also **swallowed the server's startup
+  exception**, burned its ceiling, and then blamed a timeout — so a *crashed*
+  server and a *slow* one produced the identical error. The idiom was copy-pasted
+  into **eight** places. Replaced with a shared helper that polls the real ready
+  state and distinguishes slow from dead. Verified under 14-way CPU
+  oversubscription: 6 failed → 10 passed.
+
+- **The CI leftover-reap could SIGTERM its own sibling matrix legs (#662).** The
+  reap is legitimate (leaked `sac` processes hold a2a ports until the allocator
+  starves), but it justified itself with *"runs here are serialised (one job at a
+  time)"* — true when there was **one** runner, and silently false once `-02` and
+  `-03` were registered onto the same node. Now scoped by **age**, so the word the
+  comment always used — *leftover* — lives in the mechanism instead of in an
+  assumption the world can quietly invalidate.
+
+## [0.21.15] — 2026-07-14 *(tagged, never published — see 0.21.16)*
 
 Honesty release. Every fix here is the same bug wearing a different face:
 **something reported a state it had not observed.** The headline (#658) is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.15"
+version = "0.21.16"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
**⚠️ 0.21.15 was TAGGED BUT NEVER PUBLISHED — deliberately.** It shipped #658 (the shared-executor fix) *with a hole*: #658 didn't introduce the cancellation race below, but it **widened the window enormously**, so 0.21.15 would have traded a thread leak for a listen daemon that cannot be stopped. Held back rather than published. **Install 0.21.16.**

## Headline (#663) — a production defect on the fleet's own Python

On **Python 3.11** — what the fleet runs — `asyncio.wait_for` **silently swallows a cancellation** when the inner future resolves in the same instant:

```python
except exceptions.CancelledError:
    if fut.done():
        return fut.result()      # the cancellation is dropped on the floor
```

Every background loop is `while True: await run_blocking_or(...)`, so **one swallowed cancel and the loop ticks forever**: `task.cancel()` returns, `await task` never does, and **the daemon does not die on SIGTERM**. `agents stop` and `agents restart` leave it running; a "cancelled" task is still probing. 3.12 rebuilt `wait_for` on `asyncio.timeouts` and has no such branch.

Measured over 120 cancellations of a 20 Hz loop:

| dispatch | 3.11.15 | 3.12.3 |
|---|---|---|
| `asyncio.wait_for` | **13 swallowed** | 0 |
| bare `await` (the fix) | 0 | 0 |

The bare-`await` control column is what makes this a fact rather than a story. Fix: bare `await future` + a `loop.call_later` deadline — no `wait_for`, no swallow branch on any version. The regression test was confirmed to **fail against the old dispatch**.

## Also shipping

- **#644** — a live agent's registry row was buried **64 seconds** after it started. A freshly booted agent hasn't written a heartbeat yet, and the reaper read *no heartbeat* as *dead*; `agent_send` then refused to deliver to it. Measured: `paper-scitex-clew` started 18:21:20, row ended 18:22:24, agent alive with a real pid and port. **Absence of evidence is not evidence of death.**
- **#661** — tests raced real servers against arbitrary 5s deadlines. The server wasn't dead, it was **slow** (`server.started` at 7.49s). The old wait also **swallowed the server's startup exception** before blaming a timeout, so a crashed server and a slow one produced identical errors. Idiom was copy-pasted into **eight** places.
- **#662** — the CI leftover-reap could SIGTERM its own sibling matrix legs. It justified itself with *"runs here are serialised"* — true with one runner, silently false once `-02`/`-03` were registered onto the same node. Now scoped by **age**.

## Known, and deliberately not blocking this

`test_a2a_group.py::test_grants_json_orders_by_insertion` has an **intermittent test-isolation leak** (a grant bleeds in from another test via a shared `state.db`), compounded by `list_comms_grants` documenting *"insertion order"* while ordering alphabetically — which is what let the leaked row land silently mid-list. **It is a test bug, not a production one**, develop is green across three consecutive runs, and it is being fixed separately. It does not justify withholding two production fixes from the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)