### PR TITLE
release: v0.21.16 — `sac listen` could ignore cancellation and never stop

### DIFF
--- a/.github/ci/exec-in-sif.sh
+++ b/.github/ci/exec-in-sif.sh
@@ -50,12 +50,45 @@ mkdir -p "$APPTAINER_TMPDIR"
 # (`python -m scitex_agent_container ...`); a failed/killed run leaves them
 # running and holding a2a ports [19000-19999], so claims accumulate until the
 # allocator can't find a free port (test__start_force_clears_session went red on
-# the release node after repeated retries). Runs here are serialised (one job at
-# a time) and the operator's LIVE agents run on a DIFFERENT host, so killing
-# leftover CI sac/ci-cpu processes before this run starts is safe + makes the
-# node self-healing instead of needing a manual clean.
-pkill -f 'python.* -m scitex_agent_container' 2>/dev/null || true
-pkill -f 'apptainer.*ci-cpu' 2>/dev/null || true
+# the release node after repeated retries). So the reap itself is legitimate.
+#
+# *** BUT AN UNSCOPED pkill HERE IS A LOADED GUN AIMED AT OUR OWN SIBLING JOBS. ***
+#
+# This block used to justify itself with: "runs here are serialised (one job at a
+# time)". That WAS true when there was ONE runner. Then -02 and -03 were
+# registered — and nobody re-checked the invariant this destructive action rests
+# on. It is now FALSE: all three matrix legs start at the SAME INSTANT, they run
+# the SAME ci-cpu SIF, `pkill -f` is MACHINE-scoped, and the runners share one
+# node (spartan-bm155). Nothing but timing has been stopping a leg from SIGTERMing
+# its siblings mid-run.
+#
+# HONESTY, because the wrong story is worse than no story: this pkill is NOT known
+# to have caused the v0.21.14 / v0.21.15 release ghost-tags. I believed it had, and
+# said so. The real cause was found by scitex-hpc, by inspecting live processes:
+# DUPLICATE Runner.Listener processes under one registered runner identity, with
+# GitHub reconciling the conflict by killing the other session's in-flight job
+# (SIGTERM → 143). That explains a MID-RUN kill; this pkill only fires at startup
+# and could not have. Fixed on their side.
+#
+# So this change is HAZARD REMOVAL, not a root-cause fix. It stays because the
+# hazard is real and the justifying assumption is provably dead.
+#
+# THE AGE GUARD IS THE FIX: it puts the word this comment always used — LEFTOVER —
+# into the MECHANISM instead of into an assumption the world can quietly
+# invalidate underneath it. A leftover from a prior run is minutes-to-hours old; a
+# concurrent sibling is seconds old. `--older` separates them no matter how many
+# runners share the node, which is exactly the property "serialised" did not have.
+_REAP_MIN_AGE_S=600
+if pkill --help 2>&1 | grep -q -- '--older'; then
+    pkill --older "$_REAP_MIN_AGE_S" -f 'python.* -m scitex_agent_container' 2>/dev/null || true
+    pkill --older "$_REAP_MIN_AGE_S" -f 'apptainer.*ci-cpu'                   2>/dev/null || true
+else
+    # procps too old for --older. Reaping leftovers is a nice-to-have; killing the
+    # sibling matrix legs is not. Skip LOUDLY rather than shoot blind — a silently
+    # skipped cleanup costs a stale port, an unscoped pkill costs a release.
+    echo "::warning::pkill --older unsupported here; skipping the leftover reap." \
+         "An unscoped pkill would SIGTERM the sibling matrix legs (see run 29284554656)."
+fi
 
 # --bind punim0264: $HOME/.scitex is a symlink into punim0264; bind it so the
 # symlink resolves inside the container. --pwd "$PWD" keeps the checkout as cwd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,72 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.21.15] — 2026-07-14
+## [0.21.16] — 2026-07-14
+
+**⚠️ 0.21.15 WAS NEVER PUBLISHED — it is tagged, but nothing reached PyPI, and
+that is deliberate.** It shipped #658 (the shared-executor fix) *with a hole*:
+#658 did not introduce the cancellation race below, but it **widened the window
+enormously**, so 0.21.15 would have traded a thread leak for a `sac listen` that
+cannot be stopped. It was held back rather than published. **Install 0.21.16.**
+
+### Fixed
+
+- **`sac listen` could ignore `stop` and `restart` entirely, and never shut down
+  (#663).** On **Python 3.11 — the version the fleet runs** — `asyncio.wait_for`
+  **silently swallows a cancellation** when the inner future resolves in the same
+  instant:
+
+  ```python
+  except exceptions.CancelledError:
+      if fut.done():
+          return fut.result()      # the cancellation is dropped on the floor
+  ```
+
+  Every background loop is `while True: await run_blocking_or(...)`, so one
+  swallowed cancel and **the loop ticks forever**: `task.cancel()` returns,
+  `await task` never does, and the daemon does not die on SIGTERM. `agents stop`
+  and `agents restart` leave it running; a "cancelled" task is still probing.
+  3.12 rebuilt `wait_for` on `asyncio.timeouts` and has no such branch.
+
+  Measured over 120 cancellations of a 20 Hz loop:
+
+  | dispatch | 3.11.15 | 3.12.3 |
+  |---|---|---|
+  | `asyncio.wait_for` | **13 swallowed** | 0 |
+  | bare `await` (the fix) | 0 | 0 |
+
+  Fix: bare `await future` + a `loop.call_later` deadline. No `wait_for`, no
+  swallow branch, on any version. (`asyncio.timeout()` would also work but is
+  3.11+, and `requires-python` is `>=3.10`.) The regression test was confirmed to
+  **fail against the old dispatch** — a test that has never failed proves nothing.
+
+- **A live agent's registry row was buried 64 seconds after it started (#644).**
+  A freshly booted agent has not written a heartbeat yet, and the reaper read
+  *no heartbeat* as *dead* and ended its row — after which `agent_send` refused to
+  deliver to a demonstrably live agent. Measured: `paper-scitex-clew` started
+  18:21:20, row ended 18:22:24, agent alive with a real pid and a real port.
+  **Absence of evidence is not evidence of death.** Liveness now yields UNKNOWN
+  where it cannot measure, and only an *observed* absence may end a row.
+
+- **Tests raced real servers against arbitrary 5-second deadlines (#661).** The
+  loopback server wasn't dead — it was **slow** (`server.started` measured at
+  7.49s, because the listen lifespan does a filesystem walk plus SQLite upserts
+  before reporting ready). The old wait also **swallowed the server's startup
+  exception**, burned its ceiling, and then blamed a timeout — so a *crashed*
+  server and a *slow* one produced the identical error. The idiom was copy-pasted
+  into **eight** places. Replaced with a shared helper that polls the real ready
+  state and distinguishes slow from dead. Verified under 14-way CPU
+  oversubscription: 6 failed → 10 passed.
+
+- **The CI leftover-reap could SIGTERM its own sibling matrix legs (#662).** The
+  reap is legitimate (leaked `sac` processes hold a2a ports until the allocator
+  starves), but it justified itself with *"runs here are serialised (one job at a
+  time)"* — true when there was **one** runner, and silently false once `-02` and
+  `-03` were registered onto the same node. Now scoped by **age**, so the word the
+  comment always used — *leftover* — lives in the mechanism instead of in an
+  assumption the world can quietly invalidate.
+
+## [0.21.15] — 2026-07-14 *(tagged, never published — see 0.21.16)*
 
 Honesty release. Every fix here is the same bug wearing a different face:
 **something reported a state it had not observed.** The headline (#658) is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.15"
+version = "0.21.16"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/_lifecycle/_off_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_off_loop.py
@@ -130,14 +130,15 @@ async def run_blocking(
     The call is dispatched to a DEDICATED daemon thread — never the event
     loop's shared default executor — so it neither occupies the loop
     thread nor competes for the pool that ``asyncio.to_thread`` callers
-    depend on. It is bounded by ``timeout_s`` via :func:`asyncio.wait_for`
-    and raises :class:`asyncio.TimeoutError` if the call does not finish
-    in time. The underlying thread is left to finish/abandon — we do NOT
-    join it, so a wedged child can never block the loop; because the
-    thread is private to this call, abandoning it starves nothing (see the
-    module docstring: doing this on the shared executor is what made a
-    wedged probe hang the whole process). Any exception ``fn`` raises
-    propagates unchanged.
+    depend on. It is bounded by ``timeout_s`` (a plain deadline timer, NOT
+    ``asyncio.wait_for`` — see the comment on the await below) and raises
+    :class:`asyncio.TimeoutError` if the call does not finish in time. The
+    underlying thread is left to finish/abandon — we do NOT join it, so a
+    wedged child can never block the loop; because the thread is private to
+    this call, abandoning it starves nothing (see the module docstring:
+    doing this on the shared executor is what made a wedged probe hang the
+    whole process). Any exception ``fn`` raises propagates unchanged, and
+    CANCELLATION IS ALWAYS HONOURED — a cancelled caller never keeps running.
     """
     loop = asyncio.get_running_loop()
     future: asyncio.Future[T] = loop.create_future()
@@ -149,14 +150,19 @@ async def run_blocking(
     abandoned = False
 
     def _deliver(result: Any, exc: BaseException | None) -> None:
-        # On the loop thread. If wait_for already timed out it cancelled the
-        # future and moved on — there is no awaiter left to deliver to.
+        # On the loop thread. If the deadline already fired (or the awaiter was
+        # cancelled) the future is done — there is nobody left to deliver to.
         if future.done():
             return
         if exc is not None:
             future.set_exception(exc)
         else:
             future.set_result(result)
+
+    def _on_deadline() -> None:
+        # On the loop thread, timeout_s after dispatch.
+        if not future.done():
+            future.set_exception(asyncio.TimeoutError())
 
     def _runner() -> None:
         nonlocal finished
@@ -181,16 +187,39 @@ async def run_blocking(
     threading.Thread(
         target=_runner, name=f"sac-off-loop-{op}", daemon=True
     ).start()
+    # A BARE `await future` + a plain deadline timer, NOT `asyncio.wait_for`.
+    # On Python <= 3.11 wait_for SWALLOWS an outer cancellation that lands in
+    # the same instant the inner future resolves:
+    #
+    #     except CancelledError:
+    #         if fut.done():
+    #             return fut.result()   # <- the cancellation is dropped
+    #
+    # A background loop cancelled at that instant therefore keeps ticking, and
+    # `await task` never returns — an infinite, 3.11-only hang (it is what wedged
+    # `test_loop_honours_cancellation_cleanly` and the sdk/tui heartbeat loop
+    # tests in CI). 3.12 rebuilt wait_for on `asyncio.timeouts` and has no such
+    # branch. Measured, 120 cancellations of a 20Hz poll loop:
+    #     3.11.15  wait_for -> 13 swallowed   asyncio.timeout/bare await -> 0
+    #     3.12.3   wait_for ->  0 swallowed   asyncio.timeout/bare await -> 0
+    # `asyncio.timeout()` would fix it too but is 3.11+, and this package still
+    # declares `requires-python = ">=3.10"`. A bare await has no swallow branch
+    # on ANY version: cancellation always propagates.
+    deadline = loop.call_later(timeout_s, _on_deadline)
     try:
-        return await asyncio.wait_for(future, timeout=timeout_s)
+        return await future
     except asyncio.TimeoutError:
         with state_lock:
+            # `finished` disambiguates OUR deadline from an `fn` that itself
+            # raised TimeoutError (that one is a real result, not an abandon).
             newly_abandoned = not finished
             if newly_abandoned:
                 abandoned = True
         if newly_abandoned:
             _mark_abandoned(op)
         raise
+    finally:
+        deadline.cancel()
 
 
 async def run_blocking_or(

--- a/src/scitex_agent_container/_listen/_liveness_tick.py
+++ b/src/scitex_agent_container/_listen/_liveness_tick.py
@@ -15,12 +15,15 @@ record + operator push. Nothing here writes ``tasks.yaml``.
 
 Bind-safety (cards ``sac-listen-self-peer-persist-blocks-bind`` /
 ``sac-listen-watchdog-autorestart-alarm``): the only blocking IO — reading
-``tasks.yaml`` + each owner's ``session.jsonl`` + the active-instances
-registry — runs through :func:`_off_loop.run_blocking_or`, so a
-slow/locked read can NEVER starve uvicorn's bind or the running server.
+``tasks.yaml`` + each owner's ``session.jsonl`` / ``heartbeat.json`` + the
+active-instances registry — runs through :func:`_off_loop.run_blocking_or`,
+so a slow/locked read can NEVER starve uvicorn's bind or the running server.
 
-This module is the IO + emit + loop glue; the pure reconcile rule lives
-in :mod:`_liveness_tick_detect` and is re-exported here.
+This module is the LOOP + EMIT glue. The other two thirds live beside it
+and are re-exported here:
+
+* :mod:`_liveness_tick_detect`  — the PURE reconcile rule (no IO).
+* :mod:`_liveness_tick_resolve` — the SIGNAL RESOLVERS (all the blocking IO).
 
 Event shape (locked proposal)::
 
@@ -28,16 +31,17 @@ Event shape (locked proposal)::
      "severity": str, "ts": float}
 
 ``reason`` ∈ {"owner-not-live", "owner-idle"}; ``severity`` scales with
-staleness ("warning" → "critical").
+staleness ("warning" → "critical"). An owner whose liveness could NOT be
+determined emits NOTHING — see :mod:`_liveness_tick_detect` on why guessing
+"dead" for an unresolvable owner is what flooded this log with false
+criticals in the first place.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import time
-from datetime import timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
@@ -46,6 +50,11 @@ from ._liveness_tick_detect import (  # re-exported public surface
     StuckCard,
     find_stuck_cards,
     open_card_owners,
+)
+from ._liveness_tick_resolve import (  # the blocking IO resolvers
+    _default_tasks_path,
+    _resolve_doc_and_liveness,
+    resolve_liveness,  # re-exported (public surface, see __all__)
 )
 
 logger = logging.getLogger(__name__)
@@ -65,124 +74,6 @@ DEFAULT_RENOTIFY_S = 3600.0
 # producer — until a consumer is registered the emit degrades to a logged
 # line.
 HOOKS_ENTRY_POINT_GROUP = "scitex_todo.hooks"
-
-
-# --- IO resolvers (run OFF the event loop via run_blocking_or) --------------
-
-
-def _default_tasks_path() -> Path:
-    """Resolve the scitex-todo card-store path this reconciler reads.
-
-    This is the load-bearing scitex-todo handoff (the liveness-tick reads
-    OPEN cards as truth); scitex-todo owns this path, so the legacy
-    ``SCITEX_TODO_TASKS_YAML_SHARED`` env var and the on-disk default live
-    HERE (not in ``_ci_owner``, whose CI-owner lookup is now sac-local).
-    Removed once scitex-todo takes over the stuck-card reconciliation."""
-    env = os.environ.get("SCITEX_TODO_TASKS_YAML_SHARED")
-    if env:
-        return Path(env).expanduser()
-    return Path.home() / ".scitex" / "todo" / "tasks.yaml"
-
-
-def _load_tasks_doc(tasks_path: Path) -> dict:
-    """Read + parse ``tasks.yaml``. Fail-soft: unreadable ⇒ ``{}``."""
-    if not tasks_path.is_file():
-        return {}
-    import yaml
-
-    try:
-        doc = yaml.safe_load(tasks_path.read_text()) or {}
-    except Exception:  # stx-allow: fallback (unreadable tasks store → no cards this tick)
-        return {}
-    return doc if isinstance(doc, dict) else {}
-
-
-def _session_last_active_ts(name: str) -> float | None:
-    """Epoch seconds of ``name``'s session.jsonl last-record, or ``None``.
-
-    Reads the last non-empty JSONL line carrying a ``ts``/``timestamp``
-    via the same parser the SSE tail uses. Fail-soft: a missing /
-    unreadable / tsless session yields ``None`` (unknown)."""
-    from ._tail import _record_ts, _runtime_session_jsonl
-
-    path = _runtime_session_jsonl(name)
-    if not path.is_file():
-        return None
-    import json as _json
-
-    last_ts: float | None = None
-    try:
-        with path.open("r", encoding="utf-8") as fh:
-            for line in fh:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    record = _json.loads(line)
-                except _json.JSONDecodeError:
-                    continue
-                if not isinstance(record, dict):
-                    continue
-                dt = _record_ts(record)
-                if dt is not None:
-                    if dt.tzinfo is None:
-                        dt = dt.replace(tzinfo=timezone.utc)
-                    last_ts = dt.timestamp()
-    except OSError:  # stx-allow: fallback (unreadable session → unknown activity)
-        return None
-    return last_ts
-
-
-def _live_agent_pids() -> dict[str, int]:
-    """Map active-agent name → recorded pid, from the instances registry.
-
-    Reuses the existing ``list_active_instances`` reader (``ended_at IS
-    NULL`` rows) rather than reinventing a liveness store. Fail-soft: any
-    registry hiccup ⇒ ``{}`` (nobody-live this tick — the SAFE direction:
-    a card resolves to ``owner-not-live`` only once it is ALSO stale, so a
-    transient registry blip cannot spam)."""
-    try:
-        from .._state.state_db import list_active_instances
-
-        rows = list_active_instances()
-    except Exception:  # stx-allow: fallback (registry transient → nobody resolved this tick)
-        return {}
-    out: dict[str, int] = {}
-    for row in rows or []:
-        try:
-            name = str(row.get("name", "")).strip()
-            pid = row.get("pid")
-            if name and isinstance(pid, int):
-                out.setdefault(name, pid)  # newest row wins (DESC order)
-        except Exception:  # stx-allow: fallback (one bad row contributes nothing)
-            continue
-    return out
-
-
-def resolve_liveness(owners: Iterable[str]) -> dict[str, AgentLiveness]:
-    """Resolve each owner agent → :class:`AgentLiveness` (BLOCKING — run
-    off-loop). ``is_live`` is "active registry row AND pid alive"; the
-    session timestamp comes from ``session.jsonl``'s last record."""
-    from ._agent_exec_liveness import _pid_alive
-
-    pids = _live_agent_pids()
-    out: dict[str, AgentLiveness] = {}
-    for owner in owners:
-        pid = pids.get(owner)
-        is_live = bool(pid is not None and _pid_alive(pid))
-        last_active = _session_last_active_ts(owner) if is_live else None
-        out[owner] = AgentLiveness(is_live=is_live, last_active_ts=last_active)
-    return out
-
-
-def _resolve_doc_and_liveness(tasks_path: Path) -> tuple[dict, dict[str, AgentLiveness]]:
-    """One blocking unit: load the doc, then resolve liveness for exactly
-    the owners of its OPEN, unblocked cards. Bundled so the loop makes a
-    SINGLE off-loop call per tick."""
-    doc = _load_tasks_doc(tasks_path)
-    owners = open_card_owners(doc)
-    liveness = resolve_liveness(owners) if owners else {}
-    return doc, liveness
 
 
 # --- bus emit (degrade gracefully) ------------------------------------------
@@ -299,29 +190,48 @@ async def liveness_tick_reconciler_loop(
     last_emit_at: dict[tuple[str, str], float] = {}
     try:
         while True:
+            # WARM-UP: sleep BEFORE the first tick, not after it.
+            #
+            # The heartbeat records this rule reads as proof-of-life are
+            # written by SIBLING loops in THIS process (the tui/sdk heartbeat
+            # writers, ~30s cadence). The instant `sac listen` starts — above
+            # all after downtime — not one beat has landed yet, so EVERY
+            # agent's heartbeat looks stale and a work-first loop would
+            # declare the whole fleet dead on tick #1: the same false flood,
+            # re-armed on every restart. One interval of warm-up lets the
+            # beats land first, and costs nothing — a card must already be
+            # stale by `stale_s` to alarm at all.
+            await asyncio.sleep(interval_s)
             try:
+                fleet_beat: float | None = None
                 if tasks_doc_source is not None or liveness_source is not None:
                     doc = tasks_doc_source if tasks_doc_source is not None else {}
                     liveness = liveness_source if liveness_source is not None else {}
                 else:
                     # DEFENSE IN DEPTH (cards sac-listen-self-peer-persist-
                     # blocks-bind / sac-listen-watchdog-autorestart-alarm):
-                    # the doc read + session.jsonl reads + registry read are
-                    # blocking FS/SQLite. Run them OFF the event loop with a
-                    # hard timeout so a slow/locked read can never starve
+                    # the doc read + session/heartbeat reads + registry read
+                    # are blocking FS/SQLite. Run them OFF the event loop with
+                    # a hard timeout so a slow/locked read can never starve
                     # uvicorn's bind or the running listen server.
                     from .._lifecycle._off_loop import run_blocking_or
 
-                    doc, liveness = await run_blocking_or(
+                    doc, liveness, fleet_beat = await run_blocking_or(
                         _resolve_doc_and_liveness,
                         tasks_path,
-                        default=({}, {}),
+                        default=({}, {}, None),
                         op="liveness_tick resolve (tasks.yaml + session/registry FS)",
                         timeout_s=max(interval_s, 15.0),
                     )
 
                 now = now_fn()
-                stuck = find_stuck_cards(doc, liveness, now=now, stale_s=stale_s)
+                stuck = find_stuck_cards(
+                    doc,
+                    liveness,
+                    now=now,
+                    stale_s=stale_s,
+                    fleet_last_beat_ts=fleet_beat,
+                )
 
                 if consumers_source is not None:
                     consumers = list(consumers_source)
@@ -349,7 +259,6 @@ async def liveness_tick_reconciler_loop(
                 raise
             except Exception as exc:  # stx-allow: fallback (loop must not die on a transient FS/registry error)
                 logger.warning("liveness_tick: tick failed (%s); sleeping + retry", exc)
-            await asyncio.sleep(interval_s)
     except asyncio.CancelledError:
         logger.info("liveness_tick: cancelled cleanly")
         raise
@@ -369,5 +278,6 @@ __all__ = [
     "emit_anomaly",
     "find_stuck_cards",
     "liveness_tick_reconciler_loop",
+    "open_card_owners",
     "resolve_liveness",
 ]

--- a/src/scitex_agent_container/_listen/_liveness_tick_detect.py
+++ b/src/scitex_agent_container/_listen/_liveness_tick_detect.py
@@ -8,10 +8,32 @@ mirroring how ``_periodic_drive`` (pure core) is separate from
 
 The rule keeps false positives low: a card fires an anomaly ONLY when it
 is OPEN, has an assignee, declares NO blocker, and its ``last_activity``
-is older than ``stale_s`` — and then ``owner-not-live`` if the owner
-agent is not live, else ``owner-idle`` if the owner is live but its
-session.jsonl last-record is also older than ``stale_s``; otherwise the
-owner is progressing and nothing fires.
+is older than ``stale_s`` — and even then, only when the owner's OWN
+records corroborate that it is not progressing.
+
+ABSENCE OF EVIDENCE IS NOT EVIDENCE OF DEATH
+--------------------------------------------
+The rule used to gate liveness entirely on the instances registry: an
+owner with no live registry pid was declared ``owner-not-live``. The
+registry turned out to be an unreliable gate — on the live fleet EVERY
+active instances row carries ``pid = NULL``, so no owner could ever
+resolve live, and so EVERY stale card alarmed ``owner-not-live`` /
+``critical`` against agents that were provably alive (serving HTTP in the
+same log). ~100 false criticals per sweep, every sweep.
+
+So the rule is now built on POSITIVE evidence in both directions, and it
+distinguishes THREE states, not two:
+
+* **progressing** — a fresh ACTIVITY record (``last_active_ts``). Nothing
+  fires. This outranks the registry entirely: an agent that is writing
+  session/heartbeat records right now is alive, whatever the registry says.
+* **alive but not progressing** — a fresh PROCESS record (``last_beat_ts``,
+  or a live registry pid) with a stale activity record ⇒ ``owner-idle``.
+* **dead** — a channel that WOULD have shown life (a recorded pid, or a
+  heartbeat file) shows none ⇒ ``owner-not-live``. Positive evidence.
+* **UNKNOWN** (``known=False``) — no channel that could have shown life at
+  all. Emits NOTHING, and never a ``critical``. We do not know, and
+  guessing "dead" is exactly what produced the flood.
 """
 
 from __future__ import annotations
@@ -61,12 +83,48 @@ class StuckCard:
 class AgentLiveness:
     """Resolved liveness for one owner agent — the input the rule reads.
 
-    ``is_live`` — owner process is alive (registry row + ``_pid_alive``).
-    ``last_active_ts`` — epoch seconds of the owner's session.jsonl
-    last-record, or ``None`` when unknown (no session yet)."""
+    FOUR fields, because "alive", "dead" and "we cannot tell" are three
+    different answers and the old two-field shape could only express two
+    of them. Collapsing UNKNOWN into "dead" is what flooded the daemon log
+    with false criticals (see the module docstring).
+
+    ``is_live``
+        POSITIVE registry evidence — an active instances row whose recorded
+        pid is alive. ``False`` means "the registry did not prove it live",
+        NOT "it is dead": on the live fleet the registry records
+        ``pid = NULL`` on every row, so this signal is routinely absent for
+        a perfectly healthy agent. Corroborating only — never a gate.
+    ``last_active_ts``
+        Epoch seconds of the owner's newest ACTIVITY record (its
+        session.jsonl last record, or its heartbeat's ``ts`` field —
+        whichever is newer), or ``None`` when it has no such record. A
+        fresh one is PROOF OF PROGRESS and outranks every other signal.
+    ``known``
+        Whether we had ANY channel that would have shown life had the owner
+        been alive (a recorded pid, or a heartbeat file). ``False`` ⇒
+        UNKNOWN: the rule stays SILENT rather than guess "dead".
+    ``last_beat_ts``
+        Epoch seconds of the owner's newest PROCESS record — when its
+        heartbeat writer last beat. A fresh beat proves the process is
+        alive even while it makes no progress, which is exactly the
+        ``owner-idle`` case.
+
+    The two defaults keep every existing 2-arg construction meaning what it
+    always meant: ``AgentLiveness(is_live=False, last_active_ts=None)`` is
+    still a KNOWN-dead owner.
+    """
 
     is_live: bool
     last_active_ts: float | None
+    known: bool = True
+    last_beat_ts: float | None = None
+
+
+# The verdict for an owner the resolver never produced an entry for. NOT
+# "dead" — we simply never looked, or the lookup could not be made.
+UNKNOWN_LIVENESS = AgentLiveness(
+    is_live=False, last_active_ts=None, known=False, last_beat_ts=None
+)
 
 
 def _parse_iso_ts(value: Any) -> float | None:
@@ -110,6 +168,11 @@ def _severity_for(stale_for_s: float, stale_s: float) -> str:
     return "warning"
 
 
+def _idle_for(ts: float | None, now: float) -> float:
+    """Seconds since ``ts``; ``inf`` when there is no such record at all."""
+    return (now - ts) if ts is not None else float("inf")
+
+
 def open_card_owners(tasks_doc: dict) -> set[str]:
     """Owner agent names of OPEN, unblocked cards — the set whose liveness
     the loop needs to resolve. Pure over ``tasks_doc``."""
@@ -130,6 +193,8 @@ def find_stuck_cards(
     liveness: dict[str, AgentLiveness],
     now: float,
     stale_s: float,
+    *,
+    fleet_last_beat_ts: float | None = None,
 ) -> list[StuckCard]:
     """Pure reconcile rule — NO IO. Return the OPEN cards that are stuck.
 
@@ -138,16 +203,53 @@ def find_stuck_cards(
     :class:`AgentLiveness`. ``now`` is epoch seconds; ``stale_s`` is the
     staleness threshold.
 
-    A card contributes an anomaly ONLY when ALL hold:
+    A card is a CANDIDATE only when ALL hold:
       * its ``status`` is OPEN (not terminal, not a parked state);
       * it has an ``assignee``/``agent`` owner;
       * it declares NO ``blocker``;
       * its ``last_activity`` is older than ``stale_s`` (or absent).
-    Then the reason is ``"owner-not-live"`` if the owner is not live, else
-    ``"owner-idle"`` if the owner is live but its session.jsonl
-    last-record is older than ``stale_s``; otherwise the owner is making
-    progress and no anomaly is emitted.
+
+    A candidate then resolves against the owner's OWN records, in strict
+    order of evidential strength — positive evidence first, silence when
+    there is none:
+
+      1. **Fresh activity record** ⇒ the owner is demonstrably alive AND
+         progressing ⇒ NOTHING fires. This deliberately outranks the
+         registry: the strongest positive signal must never be overruled
+         by a missing or stale registry row.
+      2. **Fresh heartbeat, or a live registry pid** ⇒ the process is alive
+         but is not progressing ⇒ ``owner-idle``.
+      3. **UNKNOWN** (``known=False``, or no entry at all) ⇒ we had no
+         channel that could have shown life ⇒ NOTHING fires. Never a
+         critical on an owner we were unable to resolve.
+      4. Otherwise the owner is dead on POSITIVE evidence — a channel that
+         would have shown life shows none ⇒ ``owner-not-live``.
     """
+    # Is the heartbeat WRITER itself working this tick?
+    #
+    # The beats we read as proof-of-life come from ONE shared writer (sibling
+    # loops inside ``sac listen``), which is known to blow its budget and get
+    # abandoned. When it stops, EVERY agent's beat freezes at once — for the
+    # same reason. That is a fact about the WRITER, not about any agent, so a
+    # frozen beat only convicts a PARTICULAR owner if the writer is still
+    # demonstrably beating for somebody.
+    #
+    # Without this, the fix would merely swap one fleet-wide false-death flood
+    # (a registry that records no pids) for another (a writer that records no
+    # beats) — the same inversion down a different channel.
+    #
+    # ``fleet_last_beat_ts`` is the newest beat ANYWHERE in the fleet, not just
+    # among these owners. That distinction is load-bearing: the owners of stale
+    # cards are a biased sample (skewed toward dead agents), so inferring
+    # "the writer is down" from THEIR silence would let a lone dead owner
+    # suppress its own alarm. ``None`` means "no fleet reading was supplied" —
+    # then we trust the beats rather than invent a suppression.
+    beats_trustworthy = (
+        True
+        if fleet_last_beat_ts is None
+        else _idle_for(fleet_last_beat_ts, now) < stale_s
+    )
+
     out: list[StuckCard] = []
     for task in tasks_doc.get("tasks", []) or []:
         if not isinstance(task, dict):
@@ -162,7 +264,7 @@ def find_stuck_cards(
             continue
 
         card_last = _parse_iso_ts(task.get("last_activity"))
-        card_stale_for = (now - card_last) if card_last is not None else float("inf")
+        card_stale_for = _idle_for(card_last, now)
         if card_stale_for < stale_s:
             continue  # card itself moved recently → progressing
 
@@ -170,33 +272,60 @@ def find_stuck_cards(
         if not card_id:
             continue
 
-        live = liveness.get(owner)
-        if live is None or not live.is_live:
-            out.append(
-                StuckCard(
-                    agent=owner,
-                    card_id=card_id,
-                    reason="owner-not-live",
-                    severity=_severity_for(card_stale_for, stale_s),
-                    stale_for_s=card_stale_for,
-                )
-            )
+        # No resolved entry ⇒ we never determined this owner's liveness.
+        # That is UNKNOWN, not dead.
+        live = liveness.get(owner, UNKNOWN_LIVENESS)
+
+        # (1) PROGRESS outranks everything. An owner writing activity
+        #     records right now is alive and working — whatever the
+        #     registry claims, and whether or not it claims anything at all.
+        activity_idle_for = _idle_for(live.last_active_ts, now)
+        if activity_idle_for < stale_s:
             continue
 
-        # Owner IS live — anomaly only if its session is ALSO idle past
-        # the threshold (hung). A recent session record ⇒ progressing.
-        sess_last = live.last_active_ts
-        sess_idle_for = (now - sess_last) if sess_last is not None else float("inf")
-        if sess_idle_for >= stale_s:
+        # (2) The process is demonstrably alive (its heartbeat writer is
+        #     still beating, or the registry recorded a pid that is alive)
+        #     but nothing is moving on the card.
+        beat_idle_for = _idle_for(live.last_beat_ts, now)
+        if live.is_live or beat_idle_for < stale_s:
             out.append(
                 StuckCard(
                     agent=owner,
                     card_id=card_id,
                     reason="owner-idle",
-                    severity=_severity_for(min(card_stale_for, sess_idle_for), stale_s),
+                    severity=_severity_for(
+                        min(card_stale_for, activity_idle_for), stale_s
+                    ),
                     stale_for_s=card_stale_for,
                 )
             )
+            continue
+
+        # (3) UNKNOWN — nothing could have told us either way, so say
+        #     nothing. Guessing "dead" here is precisely the inversion that
+        #     flooded the log with false criticals.
+        if not live.known:
+            continue
+
+        # (3b) UNKNOWN, second kind: this owner HAS a beat record, but it is
+        #      frozen at a moment when NOBODY in the fleet is beating. The
+        #      writer stopped — we cannot tell whether this agent did too.
+        #      Withhold the verdict rather than indict every agent at once.
+        if live.last_beat_ts is not None and not beats_trustworthy:
+            continue
+
+        # (4) POSITIVE evidence of death: a channel that would have shown
+        #     life (a recorded pid / a heartbeat the writer is still able to
+        #     refresh) shows none, and there is no fresh activity either.
+        out.append(
+            StuckCard(
+                agent=owner,
+                card_id=card_id,
+                reason="owner-not-live",
+                severity=_severity_for(card_stale_for, stale_s),
+                stale_for_s=card_stale_for,
+            )
+        )
     return out
 
 
@@ -205,6 +334,7 @@ __all__ = [
     "PARKED_STATUSES",
     "StuckCard",
     "TERMINAL_STATUSES",
+    "UNKNOWN_LIVENESS",
     "find_stuck_cards",
     "open_card_owners",
 ]

--- a/src/scitex_agent_container/_listen/_liveness_tick_resolve.py
+++ b/src/scitex_agent_container/_listen/_liveness_tick_resolve.py
@@ -1,0 +1,362 @@
+"""Liveness SIGNAL RESOLVERS for the liveness-tick reconciler (blocking IO).
+
+Card ``sac-card-anchored-stop-reconciler``. Split out of ``_liveness_tick``
+(the loop/emit glue) alongside ``_liveness_tick_detect`` (the pure rule), so
+the three concerns are separately testable: this module is ALL of the
+reconciler's blocking IO and nothing else.
+
+Everything here is called from inside ``run_blocking_or`` — never on the
+event loop — and every reader is fail-soft: a signal we cannot read yields
+"no record", which the rule reads as UNKNOWN, never as death.
+
+WHY THREE SIGNALS
+-----------------
+The reconciler used to gate liveness on ONE signal, the instances registry:
+no live registry pid ⇒ ``owner-not-live``. On the live fleet EVERY active
+registry row carries ``pid = NULL``, so no owner could ever resolve live and
+every stale card alarmed ``critical`` against agents that were provably
+alive. The registry is corroborating evidence, not a gate, and the agents'
+OWN records outrank it:
+
+* ``session.jsonl`` last-record ts — PROGRESS (SDK runtimes).
+* ``heartbeat.json`` ``ts`` field  — PROGRESS (the TUI runtimes that make up
+  the fleet write no session.jsonl at all, so without this there is no
+  progress signal for them whatsoever).
+* ``heartbeat.json`` MTIME         — PROCESS ALIVE. The heartbeat writer runs
+  inside the live agent, so a fresh beat proves the process exists even when
+  the registry has no pid for it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import timezone
+from pathlib import Path
+from typing import Iterable
+
+from ._liveness_tick_detect import AgentLiveness, open_card_owners
+
+logger = logging.getLogger(__name__)
+
+# Tail window for the session.jsonl read. The last record lives at the end of
+# the file, so an O(1) tail beats an O(file) scan — and this now runs for
+# EVERY open-card owner on EVERY tick.
+_SESSION_TAIL_BYTES = 1 << 20  # 1 MiB
+
+_HEARTBEAT_FILENAME = "heartbeat.json"
+
+
+def _default_tasks_path() -> Path:
+    """Resolve the scitex-todo card-store path this reconciler reads.
+
+    This is the load-bearing scitex-todo handoff (the liveness-tick reads
+    OPEN cards as truth); scitex-todo owns this path, so the legacy
+    ``SCITEX_TODO_TASKS_YAML_SHARED`` env var and the on-disk default live
+    HERE (not in ``_ci_owner``, whose CI-owner lookup is now sac-local).
+    Removed once scitex-todo takes over the stuck-card reconciliation."""
+    env = os.environ.get("SCITEX_TODO_TASKS_YAML_SHARED")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".scitex" / "todo" / "tasks.yaml"
+
+
+def _load_tasks_doc(tasks_path: Path) -> dict:
+    """Read + parse ``tasks.yaml``. Fail-soft: unreadable ⇒ ``{}``."""
+    if not tasks_path.is_file():
+        return {}
+    import yaml
+
+    try:
+        doc = yaml.safe_load(tasks_path.read_text()) or {}
+    except Exception:  # stx-allow: fallback (unreadable tasks store → no cards this tick)
+        return {}
+    return doc if isinstance(doc, dict) else {}
+
+
+def _line_ts(line: str) -> float | None:
+    """Epoch seconds of one JSONL record's ``ts``/``timestamp``, else ``None``.
+
+    Delegates to the same ``_record_ts`` parser the SSE tail uses, so "what
+    counts as a record timestamp" has exactly one definition in this package."""
+    from ._tail import _record_ts
+
+    line = line.strip()
+    if not line:
+        return None
+    import json as _json
+
+    try:
+        record = _json.loads(line)
+    except ValueError:  # stx-allow: fallback (a torn/partial line is not a record)
+        return None
+    if not isinstance(record, dict):
+        return None
+    dt = _record_ts(record)
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def _full_scan_last_ts(path: Path) -> float | None:
+    """Forward-stream the WHOLE file, keeping the last parseable record ts.
+
+    O(file), so this is the RARE fallback only (see
+    :func:`_session_last_active_ts`). Streams line-by-line — never
+    ``readlines()`` — so an enormous session cannot blow up the daemon's RSS."""
+    last_ts: float | None = None
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                ts = _line_ts(line)
+                if ts is not None:
+                    last_ts = ts
+    except OSError:  # stx-allow: fallback (unreadable session → unknown activity)
+        return None
+    return last_ts
+
+
+def _session_last_active_ts(name: str) -> float | None:
+    """Epoch seconds of ``name``'s session.jsonl last-record, or ``None``.
+
+    A POSITIVE PROOF OF PROGRESS: an agent appending session records right
+    now is alive and working. :func:`resolve_liveness` reads this
+    UNCONDITIONALLY. It used to be read only once the registry had ALREADY
+    said "live", so the strongest positive signal was never consulted for
+    exactly the agents the registry missed — which is the entire population
+    that flooded the log.
+
+    Reads only the last ``_SESSION_TAIL_BYTES`` and scans BACKWARDS for the
+    newest record carrying a ``ts``/``timestamp``, so the cost is O(1) in the
+    session size rather than O(file). That matters now that this runs for
+    EVERY open-card owner on EVERY tick: session.jsonl grows without bound,
+    and a full re-scan per owner per tick would burn CPU on the very daemon
+    this reconciler exists to keep responsive. The full scan survives only as
+    the fallback for a session whose final record is larger than the window.
+
+    Fail-soft: a missing / unreadable / ts-less session yields ``None`` — no
+    activity record, which is UNKNOWN activity and NOT evidence of death."""
+    from ._tail import _runtime_session_jsonl
+
+    path = _runtime_session_jsonl(name)
+    if not path.is_file():
+        return None
+    try:
+        with path.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            start = max(0, size - _SESSION_TAIL_BYTES)
+            fh.seek(start)
+            blob = fh.read()
+    except OSError:  # stx-allow: fallback (unreadable session → unknown activity)
+        return None
+
+    lines = blob.decode("utf-8", errors="replace").splitlines()
+    if start > 0 and lines:
+        lines = lines[1:]  # the window cut this line mid-record — drop it
+    for line in reversed(lines):
+        ts = _line_ts(line)
+        if ts is not None:
+            return ts
+    if start == 0:
+        return None  # the whole file was scanned: there is genuinely no ts
+    # The final record is larger than the tail window. Pay for the full scan
+    # rather than mis-report an ACTIVE agent as having no activity record.
+    return _full_scan_last_ts(path)
+
+
+def _heartbeat_signals(name: str) -> tuple[float | None, float | None]:
+    """``(beat_ts, activity_ts)`` read from ``name``'s ``heartbeat.json``.
+
+    The heartbeat is the ONE record every runtime writes — the TUI agents
+    that make up the fleet write no session.jsonl at all — so without it the
+    rule has no positive signal to weigh the registry against.
+
+    * ``beat_ts`` — the file's MTIME: when the agent's heartbeat writer last
+      beat. The writer runs inside the live agent, so a fresh beat is PROOF
+      THE PROCESS IS ALIVE. It deliberately does NOT prove progress: a wedged
+      agent keeps beating, and that is precisely the ``owner-idle`` case.
+    * ``activity_ts`` — the record's ``ts`` field: the agent's last real
+      activity (the TUI heartbeat writer stores the tmux pane-activity epoch
+      here). A PROGRESS signal, folded into ``last_active_ts``.
+
+    Fail-soft: missing / unreadable / unparseable ⇒ ``(None, None)`` — no
+    record at all, which is UNKNOWN and never "dead"."""
+    from ._tail import _runtime_session_jsonl
+
+    path = _runtime_session_jsonl(name).parent / _HEARTBEAT_FILENAME
+    try:
+        beat_ts = path.stat().st_mtime
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:  # stx-allow: fallback (no/unreadable heartbeat → no record)
+        return None, None
+    import json as _json
+
+    try:
+        record = _json.loads(raw)
+    except ValueError:  # stx-allow: fallback (torn heartbeat write → beat only)
+        return beat_ts, None
+    if not isinstance(record, dict):
+        return beat_ts, None
+    ts = record.get("ts")
+    if isinstance(ts, (int, float)) and not isinstance(ts, bool) and ts > 0:
+        return beat_ts, float(ts)
+    return beat_ts, None
+
+
+def _live_agent_pids(db_path: Path | None = None) -> dict[str, int] | None:
+    """Map active-agent name → recorded pid — or ``None`` if the registry
+    could not be READ AT ALL.
+
+    Reuses the existing ``list_active_instances`` reader (``ended_at IS NULL``
+    rows) rather than reinventing a liveness store.
+
+    The ``None`` return is load-bearing and must NOT be collapsed back into
+    ``{}``:
+
+    * ``{}``   — the registry WAS read, and lists nobody with a live pid.
+    * ``None`` — the registry could not be read. We know NOTHING.
+
+    The previous version returned ``{}`` for both and called it "the SAFE
+    direction". It is the exact opposite: a registry that cannot be read makes
+    EVERY owner resolve not-live, so EVERY stale card alarms
+    ``owner-not-live`` — absence of evidence rendered as evidence of death.
+
+    ``{}`` is ALSO not proof of death, for the same reason: this fleet's
+    registry records ``pid = NULL`` on every active row, so a perfectly
+    healthy agent contributes no entry here. Callers must corroborate a
+    missing pid against the owner's heartbeat before concluding anything —
+    :func:`resolve_liveness` does."""
+    try:
+        from .._state.state_db import list_active_instances
+
+        rows = list_active_instances(db_path=db_path)
+    except Exception as exc:  # stx-allow: fallback (registry unreadable → UNKNOWN, never "dead")
+        logger.warning(
+            "liveness_tick: instances registry unavailable (%s) — owner "
+            "liveness is UNKNOWN this tick; owner-not-live detection is "
+            "SUSPENDED (a registry failure must never read as agent death)",
+            exc,
+        )
+        return None
+    out: dict[str, int] = {}
+    for row in rows or []:
+        try:
+            name = str(row.get("name", "")).strip()
+            pid = row.get("pid")
+            if name and isinstance(pid, int) and not isinstance(pid, bool):
+                out.setdefault(name, pid)  # newest row wins (DESC order)
+        except Exception:  # stx-allow: fallback (one bad row contributes nothing)
+            continue
+    return out
+
+
+def resolve_liveness(
+    owners: Iterable[str],
+    *,
+    db_path: Path | None = None,
+) -> dict[str, AgentLiveness]:
+    """Resolve each owner agent → :class:`AgentLiveness` (BLOCKING — run
+    off-loop).
+
+    Reads three independent signals per owner and — the whole point — reads
+    the POSITIVE ones UNCONDITIONALLY, never gated on the registry's verdict:
+
+    * ``last_active_ts`` — newest ACTIVITY record: the owner's session.jsonl
+      last record, or its heartbeat's ``ts``, whichever is newer. PROGRESS.
+    * ``last_beat_ts``   — the owner's heartbeat MTIME. PROCESS ALIVE.
+    * ``is_live``        — the registry's verdict (active row + live pid).
+      Corroborating evidence only, no longer a gate: every row on the live
+      fleet carries ``pid = NULL``, so this reads ``False`` for healthy agents
+      exactly as often as for dead ones.
+
+    ``known`` is the honest "could we have seen life, had there been any?"
+    flag: true iff the registry was readable AND the owner has at least one
+    channel a live agent would have refreshed (a recorded pid, or a heartbeat
+    file). When it is false the owner is UNKNOWN and the rule stays silent —
+    it never guesses "dead".
+
+    ``db_path`` overrides the registry location (tests point it at a real temp
+    SQLite file; production leaves it ``None``)."""
+    from ._agent_exec_liveness import _pid_alive
+
+    pids = _live_agent_pids(db_path)
+    registry_ok = pids is not None
+    pids = pids or {}
+
+    out: dict[str, AgentLiveness] = {}
+    for owner in owners:
+        beat_ts, beat_activity_ts = _heartbeat_signals(owner)
+        session_ts = _session_last_active_ts(owner)
+        seen = [t for t in (session_ts, beat_activity_ts) if t is not None]
+        last_active = max(seen) if seen else None
+
+        pid = pids.get(owner)
+        is_live = bool(pid is not None and _pid_alive(pid))
+        known = registry_ok and (pid is not None or beat_ts is not None)
+
+        out[owner] = AgentLiveness(
+            is_live=is_live,
+            last_active_ts=last_active,
+            known=known,
+            last_beat_ts=beat_ts,
+        )
+    return out
+
+
+def fleet_last_beat_ts() -> float | None:
+    """Newest heartbeat MTIME across the WHOLE fleet, or ``None`` if there is
+    no heartbeat anywhere.
+
+    This answers ONE question the per-owner signals cannot: **is the heartbeat
+    writer itself still working?** The writer is a single shared loop inside
+    ``sac listen`` that is known to blow its budget and get abandoned; when it
+    stops, every agent's beat freezes at once. The rule needs to tell that
+    apart from "the agents died", and it can: if ANY agent in the fleet is
+    still being beaten for, the writer works, and a frozen beat then really
+    does convict the agent it belongs to.
+
+    Deliberately scans the whole runtime root and NOT just the card owners:
+    owners of stale cards are a biased sample (skewed toward dead agents), so
+    inferring writer health from their silence would let a lone dead owner
+    suppress its own alarm.
+
+    Cost is one ``scandir`` + one ``stat`` per agent dir — no file is opened —
+    so it stays O(agents) and cheap enough for every tick."""
+    root = Path(os.path.expanduser("~")) / ".scitex" / "agent-container" / "runtime"
+    newest: float | None = None
+    try:
+        entries = list(os.scandir(root))
+    except OSError:  # stx-allow: fallback (no runtime root → no fleet reading)
+        return None
+    for entry in entries:
+        try:
+            if not entry.is_dir():
+                continue
+            mtime = (Path(entry.path) / _HEARTBEAT_FILENAME).stat().st_mtime
+        except OSError:  # stx-allow: fallback (no heartbeat for this agent)
+            continue
+        if newest is None or mtime > newest:
+            newest = mtime
+    return newest
+
+
+def _resolve_doc_and_liveness(
+    tasks_path: Path,
+) -> tuple[dict, dict[str, AgentLiveness], float | None]:
+    """One blocking unit: load the doc, resolve liveness for exactly the owners
+    of its OPEN, unblocked cards, and take one fleet-wide reading of the
+    heartbeat writer's health. Bundled so the loop makes a SINGLE off-loop call
+    per tick."""
+    doc = _load_tasks_doc(tasks_path)
+    owners = open_card_owners(doc)
+    liveness = resolve_liveness(owners) if owners else {}
+    return doc, liveness, fleet_last_beat_ts()
+
+
+__all__ = [
+    "fleet_last_beat_ts",
+    "resolve_liveness",
+]

--- a/tests/integration/test_listen_notify_delivery.py
+++ b/tests/integration/test_listen_notify_delivery.py
@@ -39,8 +39,6 @@ import contextlib
 import json
 import os
 import socket
-import threading
-import time
 from pathlib import Path
 
 import httpx
@@ -51,6 +49,10 @@ from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
 from scitex_agent_container._state import state_db
+from tests.scitex_agent_container._helpers.loopback_server import (
+    serve_in_thread,
+    wait_until_serving,
+)
 
 HOST_TOKEN = "integration-notify-host-token"
 AGENT = "containerized-worker"
@@ -140,13 +142,11 @@ def live_listen(listen_state_db):
         app, host="127.0.0.1", port=port, log_level="warning", ws="none"
     )
     server = uvicorn.Server(config)
-    thread = threading.Thread(target=server.run, daemon=True)
-    thread.start()
-    deadline = time.monotonic() + 5.0
-    while not server.started:
-        if time.monotonic() > deadline:
-            raise RuntimeError("uvicorn loopback did not start in 5s")
-        time.sleep(0.05)
+    # Shared startup wait: the hand-rolled 5s ceiling that used to live here
+    # raced the listen lifespan (measured 7.49s under load) and turned the
+    # py3.11 leg red. See tests/.../_helpers/loopback_server.py.
+    thread, crash = serve_in_thread(server, port)
+    wait_until_serving(server, thread, port=port, crash=crash)
     try:
         yield f"http://127.0.0.1:{port}"
     finally:

--- a/tests/integration/test_listen_sigterm_sse_shutdown.py
+++ b/tests/integration/test_listen_sigterm_sse_shutdown.py
@@ -34,6 +34,10 @@ import uvicorn
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
+from tests.scitex_agent_container._helpers.loopback_server import (
+    serve_in_thread,
+    wait_until_serving,
+)
 
 TOKEN = "test-token-shutdown-sse"
 
@@ -174,13 +178,12 @@ def test_sac_listen_graceful_shutdown_cancels_inflight_sse(shutdown_env) -> None
     # Mirror the boot path (listen_cmds._do_start_listen) so the lifespan
     # shutdown bridge is wired to this server's ``should_exit``.
     app.state.uvicorn_server = server
-    thread = threading.Thread(target=server.run, daemon=True)
-    thread.start()
-    deadline = time.monotonic() + 5.0
-    while not server.started:
-        if time.monotonic() > deadline:
-            raise RuntimeError("uvicorn loopback did not start in 5s")
-        time.sleep(0.02)
+    # Shared startup wait: the hand-rolled 5s ceiling that used to live here
+    # raced the listen lifespan (measured 7.49s under load). This test keeps
+    # its own server object because it drives `should_exit` as the thing under
+    # test. See tests/.../_helpers/loopback_server.py.
+    thread, crash = serve_in_thread(server, port)
+    wait_until_serving(server, thread, port=port, crash=crash)
 
     # Act
     try:

--- a/tests/scitex_agent_container/_helpers/loopback_server.py
+++ b/tests/scitex_agent_container/_helpers/loopback_server.py
@@ -1,0 +1,197 @@
+"""Wait for a REAL uvicorn loopback server to come up — generously, and loudly.
+
+Why this exists (CI failure 2026-07-13, develop ``b92f38c3``, py3.11 leg:
+``1 failed, 9890 passed`` — ``test_cross_host_send_with_explicit_grant_...``):
+six test modules had each hand-rolled the same startup wait —
+
+    deadline = time.monotonic() + 5.0
+    while not server.started:
+        if time.monotonic() > deadline:
+            raise RuntimeError("uvicorn loopback did not start in 5s")
+        time.sleep(0.05)
+
+— and that 5-second ceiling is a RACE BY CONSTRUCTION. uvicorn sets
+``server.started`` only AFTER the ASGI **lifespan startup** completes, and the
+listen app's lifespan awaits ``persist_self_peers_on_listen_startup()`` (a
+filesystem walk over the config/fleet search dirs plus SQLite upserts) before
+spawning its six background loops. Measured on a loaded box: the server came
+up in **7.49s** — against the 5.0s ceiling. On a 2-core CI runner under load
+that is a coin flip, and it is why the leg went red without hanging.
+
+Two things are fixed here, once, for every call site:
+
+* **Poll, with a GENEROUS ceiling.** The wait already polled the real ready
+  state, so the fast path returns the instant the server binds — a generous
+  ceiling therefore costs *nothing* when the server is healthy and only bounds
+  the pathological case. Raising a tight deadline is not "moving the flake"
+  when the thing you are waiting on is a polled predicate rather than a fixed
+  sleep. Same reasoning as ``_settle`` in ``test__tui_heartbeat_loop.py``:
+  "poll for the expected end-state instead of guessing a duration".
+
+* **Fail loud, and say WHICH failure it was.** The old wait could not tell a
+  SLOW server from a DEAD one. If ``server.run()`` raised (port collision, bad
+  config), the thread exited, ``started`` stayed False, the wait burned its
+  whole ceiling and then blamed a *timeout* — while the real exception was
+  swallowed and never printed. Here the server thread's exception is captured
+  and re-raised as the ``__cause__``, so a genuine startup failure names itself
+  instead of masquerading as slowness.
+
+NO MOCKS — a real ``uvicorn.Server`` on a real loopback port.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import threading
+import time
+from typing import Any, Iterator
+
+import uvicorn
+
+# Generous on purpose: the happy path returns as soon as the port is serving,
+# so this only ever bounds a genuinely broken server. Overridable for a very
+# slow runner via SAC_TEST_LOOPBACK_STARTUP_TIMEOUT_S.
+DEFAULT_STARTUP_TIMEOUT_S = 30.0
+_POLL_INTERVAL_S = 0.02
+_SHUTDOWN_JOIN_TIMEOUT_S = 10.0
+
+__all__ = [
+    "DEFAULT_STARTUP_TIMEOUT_S",
+    "await_until_serving",
+    "run_loopback",
+    "serve_in_thread",
+    "wait_until_serving",
+]
+
+
+def _startup_timeout_s(explicit: float | None = None) -> float:
+    if explicit is not None:
+        return explicit
+    raw = os.environ.get("SAC_TEST_LOOPBACK_STARTUP_TIMEOUT_S", "").strip()
+    if not raw:
+        return DEFAULT_STARTUP_TIMEOUT_S
+    try:
+        return float(raw)
+    except ValueError:
+        return DEFAULT_STARTUP_TIMEOUT_S
+
+
+def serve_in_thread(server: uvicorn.Server, port: int) -> tuple[threading.Thread, list]:
+    """Run ``server`` in a daemon thread; return ``(thread, crash_box)``.
+
+    ``crash_box`` receives the exception if ``server.run()`` raises, so the
+    waiter can re-raise it on the test thread instead of losing it.
+    """
+    crash: list[BaseException] = []
+
+    def _serve() -> None:
+        try:
+            server.run()
+        except BaseException as exc:  # stx-allow: fallback (reason: relayed to the test thread by wait_until_serving; swallowing it here is exactly the old bug)
+            crash.append(exc)
+
+    thread = threading.Thread(
+        target=_serve, name=f"uvicorn-loopback-{port}", daemon=True
+    )
+    thread.start()
+    return thread, crash
+
+
+def _check_dead(
+    server: uvicorn.Server,
+    thread: threading.Thread,
+    crash: list,
+    port: int,
+    elapsed: float,
+) -> None:
+    """Raise (naming the real cause) if the server thread died before serving."""
+    if crash:
+        raise RuntimeError(
+            f"uvicorn loopback on port {port} CRASHED during startup after "
+            f"{elapsed:.2f}s — see the chained exception for the real cause"
+        ) from crash[0]
+    if not thread.is_alive() and not server.started:
+        raise RuntimeError(
+            f"uvicorn loopback on port {port} exited during startup after "
+            f"{elapsed:.2f}s without ever serving, and raised nothing"
+        )
+
+
+def _timed_out(port: int, elapsed: float, ceiling: float, alive: bool) -> RuntimeError:
+    return RuntimeError(
+        f"uvicorn loopback on port {port} never became ready: server.started "
+        f"stayed False for {elapsed:.1f}s (ceiling {ceiling:.1f}s; server thread "
+        f"alive={alive}). uvicorn only flips `started` once the ASGI LIFESPAN "
+        f"startup has completed, so the lifespan is what never finished."
+    )
+
+
+def wait_until_serving(
+    server: uvicorn.Server,
+    thread: threading.Thread,
+    *,
+    port: int,
+    crash: list | None = None,
+    timeout_s: float | None = None,
+) -> None:
+    """Block until ``server`` is serving. Fail loud on death or timeout."""
+    ceiling = _startup_timeout_s(timeout_s)
+    started_at = time.monotonic()
+    crash = crash if crash is not None else []
+    while not server.started:
+        elapsed = time.monotonic() - started_at
+        _check_dead(server, thread, crash, port, elapsed)
+        if elapsed > ceiling:
+            raise _timed_out(port, elapsed, ceiling, thread.is_alive())
+        time.sleep(_POLL_INTERVAL_S)
+
+
+async def await_until_serving(
+    server: uvicorn.Server,
+    thread: threading.Thread,
+    *,
+    port: int,
+    crash: list | None = None,
+    timeout_s: float | None = None,
+) -> None:
+    """``wait_until_serving`` for an async test — yields to the loop while waiting."""
+    ceiling = _startup_timeout_s(timeout_s)
+    started_at = time.monotonic()
+    crash = crash if crash is not None else []
+    while not server.started:
+        elapsed = time.monotonic() - started_at
+        _check_dead(server, thread, crash, port, elapsed)
+        if elapsed > ceiling:
+            raise _timed_out(port, elapsed, ceiling, thread.is_alive())
+        await asyncio.sleep(_POLL_INTERVAL_S)
+
+
+@contextlib.contextmanager
+def run_loopback(
+    app: Any, port: int, *, timeout_s: float | None = None, **config_kwargs: Any
+) -> Iterator[int]:
+    """Serve ``app`` on ``127.0.0.1:port`` for the duration of the block.
+
+    Teardown flips ``should_exit`` and joins, so the ``finally`` fires even on
+    test failure and a hung client never strands the server.
+    """
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        ws="none",
+        **config_kwargs,
+    )
+    server = uvicorn.Server(config)
+    thread, crash = serve_in_thread(server, port)
+    wait_until_serving(
+        server, thread, port=port, crash=crash, timeout_s=timeout_s
+    )
+    try:
+        yield port
+    finally:
+        server.should_exit = True
+        thread.join(timeout=_SHUTDOWN_JOIN_TIMEOUT_S)

--- a/tests/scitex_agent_container/_lifecycle/test__off_loop.py
+++ b/tests/scitex_agent_container/_lifecycle/test__off_loop.py
@@ -196,3 +196,56 @@ async def test_abandoned_call_count_reports_the_wedged_calls(wedge):
         await run_blocking_or(wedge, default=None, op="wedged probe", timeout_s=0.05)
     # Assert
     assert abandoned_call_count() == before + 3
+
+
+# ---------------------------------------------------------------------------
+# CANCELLATION MUST NEVER BE SWALLOWED (3.11-only infinite hang).
+#
+# `run_blocking` used to await via `asyncio.wait_for`. On Python <= 3.11 that
+# SWALLOWS an outer cancellation which lands in the same instant the inner
+# future resolves:
+#
+#     except CancelledError:
+#         if fut.done():
+#             return fut.result()      # <- cancellation dropped on the floor
+#
+# A background loop (github-CI poll, sdk/tui heartbeat, liveness tick — every
+# one of them is `while True: await run_blocking_or(...)`) then IGNORES
+# `task.cancel()` and keeps ticking forever, so `await task` never returns.
+# That is an infinite hang, and it is 3.11-only: 3.12 rebuilt wait_for on
+# `asyncio.timeouts` and has no such branch. Measured over 120 cancellations of
+# a 20Hz loop: 3.11.15 dropped 13, 3.12.3 dropped 0.
+#
+# It is also a PRODUCTION defect on the fleet's 3.11: a `sac listen` whose
+# loops ignore cancellation cannot shut down cleanly.
+#
+# The loop below cancels repeatedly to make the race bite: a single attempt hits
+# the window only ~10% of the time.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancellation_is_never_swallowed_by_the_deadline_wait():
+    """A cancelled `run_blocking` caller must STOP — not keep looping."""
+    # Arrange — a poll loop shaped exactly like the real background loops:
+    # a fast off-loop call, then a short sleep, forever.
+    async def poll_loop() -> None:
+        while True:
+            await run_blocking(lambda: None, timeout_s=5.0)
+            await asyncio.sleep(0.05)
+
+    survived_cancellation = 0
+    # Act — cancel it many times; each cancel MUST be honoured.
+    for _ in range(40):
+        task = asyncio.create_task(poll_loop())
+        await asyncio.sleep(0.06)
+        task.cancel()
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+        except asyncio.CancelledError:
+            pass  # correct — the loop stopped
+        except asyncio.TimeoutError:
+            survived_cancellation += 1  # the loop IGNORED cancel → would hang
+            task.cancel()
+    # Assert
+    assert survived_cancellation == 0

--- a/tests/scitex_agent_container/_listen/test__liveness_tick.py
+++ b/tests/scitex_agent_container/_listen/test__liveness_tick.py
@@ -18,9 +18,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from datetime import datetime, timezone
 
 import pytest
+
+from scitex_agent_container._state.state_db_instances import record_instance_start
 
 from scitex_agent_container._listen._liveness_tick import (
     DEFAULT_INTERVAL_S,
@@ -31,7 +34,10 @@ from scitex_agent_container._listen._liveness_tick import (
     emit_anomaly,
     liveness_tick_reconciler_loop,
 )
-from scitex_agent_container._listen import _liveness_tick as mod
+
+# The blocking IO resolvers live beside the loop glue (``_liveness_tick`` is
+# the loop + bus emit; ``_liveness_tick_resolve`` is every FS/registry read).
+from scitex_agent_container._listen import _liveness_tick_resolve as mod
 
 NOW = 2_000_000.0
 STALE_S = 900.0
@@ -173,8 +179,6 @@ def home_at_tmp(tmp_path):
     """Point ``$HOME`` (which the production session-path resolver expands)
     at a real ``tmp_path`` and restore it on teardown — a real env swap,
     NOT a monkeypatch of any production internal."""
-    import os
-
     saved = os.environ.get("HOME")
     os.environ["HOME"] = str(tmp_path)
     try:
@@ -216,6 +220,240 @@ class TestSessionLastActiveTs:
         ts = mod._session_last_active_ts(target)
         # Assert
         assert ts is None
+
+    def test_final_record_larger_than_the_tail_window_is_still_found(
+        self, home_at_tmp
+    ) -> None:
+        # Arrange — the read is a bounded O(1) TAIL (it now runs for every
+        # owner every tick). A final record bigger than that window must fall
+        # back to the full scan rather than report "no activity" — reporting
+        # none for a busy agent is exactly the false-death this fix removes.
+        run_dir = (
+            home_at_tmp / ".scitex" / "agent-container" / "runtime" / "agent-x"
+        )
+        run_dir.mkdir(parents=True)
+        late = _iso(NOW - 5.0)
+        huge = json.dumps({"ts": late, "payload": "x" * (2 * mod._SESSION_TAIL_BYTES)})
+        (run_dir / "session.jsonl").write_text(
+            json.dumps({"ts": _iso(NOW - 900.0)}) + "\n" + huge + "\n"
+        )
+        # Act
+        ts = mod._session_last_active_ts("agent-x")
+        # Assert
+        assert ts == pytest.approx(
+            datetime.fromisoformat(late.replace("Z", "+00:00")).timestamp()
+        )
+
+
+class TestHeartbeatSignals:
+    def test_reads_the_beat_and_the_activity_ts_from_a_real_heartbeat(
+        self, home_at_tmp
+    ) -> None:
+        # Arrange — a real heartbeat.json. The TUI runtimes that make up the
+        # fleet write NO session.jsonl at all, so this is their only record.
+        run_dir = (
+            home_at_tmp / ".scitex" / "agent-container" / "runtime" / "agent-x"
+        )
+        run_dir.mkdir(parents=True)
+        (run_dir / "heartbeat.json").write_text(
+            json.dumps({"ts": NOW - 300.0, "pid": 0, "state": "running"})
+        )
+        # Act
+        _beat_ts, activity_ts = mod._heartbeat_signals("agent-x")
+        # Assert — the record's own ``ts`` is the PROGRESS signal.
+        assert activity_ts == pytest.approx(NOW - 300.0)
+
+    def test_beat_ts_tracks_the_file_mtime(self, home_at_tmp) -> None:
+        # Arrange — the MTIME is the PROCESS-ALIVE signal: the heartbeat writer
+        # runs inside the live agent, so a fresh beat proves it exists even
+        # when the registry has no pid for it.
+        run_dir = (
+            home_at_tmp / ".scitex" / "agent-container" / "runtime" / "agent-x"
+        )
+        run_dir.mkdir(parents=True)
+        hb = run_dir / "heartbeat.json"
+        hb.write_text(json.dumps({"ts": NOW - 300.0}))
+        # Act
+        beat_ts, _activity_ts = mod._heartbeat_signals("agent-x")
+        # Assert
+        assert beat_ts == pytest.approx(hb.stat().st_mtime)
+
+    def test_missing_heartbeat_is_no_record_at_all(self, home_at_tmp) -> None:
+        # Arrange — no heartbeat file ⇒ (None, None) ⇒ UNKNOWN, not "dead".
+        # Act
+        signals = mod._heartbeat_signals("ghost-agent")
+        # Assert
+        assert signals == (None, None)
+
+
+class TestFleetLastBeatTs:
+    def test_returns_the_newest_beat_across_the_whole_fleet(
+        self, home_at_tmp
+    ) -> None:
+        # Arrange — REAL runtime dirs. The fleet reading must see the agent
+        # that is STILL being beaten for, even though it owns no card: that is
+        # how the rule tells "the writer died" from "the agents died".
+        runtime = home_at_tmp / ".scitex" / "agent-container" / "runtime"
+        for name in ("stale-agent", "beating-agent"):
+            (runtime / name).mkdir(parents=True)
+            (runtime / name / "heartbeat.json").write_text(json.dumps({"ts": 1.0}))
+        fresh = runtime / "beating-agent" / "heartbeat.json"
+        os.utime(fresh, (NOW, NOW))
+        os.utime(runtime / "stale-agent" / "heartbeat.json", (NOW - 99_999, NOW - 99_999))
+        # Act
+        newest = mod.fleet_last_beat_ts()
+        # Assert
+        assert newest == pytest.approx(NOW)
+
+    def test_no_heartbeat_anywhere_is_no_reading(self, home_at_tmp) -> None:
+        # Arrange — an empty runtime root ⇒ no fleet reading available.
+        (home_at_tmp / ".scitex" / "agent-container" / "runtime").mkdir(parents=True)
+        # Act
+        newest = mod.fleet_last_beat_ts()
+        # Assert
+        assert newest is None
+
+
+# ===========================================================================
+# registry availability — UNREADABLE (None) must not look like EMPTY ({})
+# ===========================================================================
+
+
+class TestRegistryAvailability:
+    def test_readable_but_empty_registry_is_an_empty_dict(self, tmp_path) -> None:
+        # Arrange — a REAL sqlite state.db, created empty by the real schema
+        # init. The read SUCCEEDS and lists nobody.
+        # Act
+        pids = mod._live_agent_pids(db_path=tmp_path / "state.db")
+        # Assert
+        assert pids == {}
+
+    def test_unreadable_registry_is_none(self, tmp_path) -> None:
+        # Arrange — a REAL failure, no mock: the db's parent path is a regular
+        # FILE, so the OS refuses to create the directory sqlite needs.
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("i am a file, not a directory")
+        # Act
+        pids = mod._live_agent_pids(db_path=blocker / "state.db")
+        # Assert — distinctly "we could not read it", NOT "nobody is alive".
+        assert pids is None
+
+    def test_pidless_rows_contribute_no_pid(self, tmp_path) -> None:
+        # Arrange — EXACTLY what the live fleet writes: an active instances row
+        # with pid=NULL. The read succeeds; it simply proves nothing.
+        db = tmp_path / "state.db"
+        record_instance_start("agent-x", db_path=db)
+        # Act
+        pids = mod._live_agent_pids(db_path=db)
+        # Assert
+        assert pids == {}
+
+    def test_a_recorded_live_pid_is_returned(self, tmp_path) -> None:
+        # Arrange — a row carrying a REAL, alive pid (this test process).
+        db = tmp_path / "state.db"
+        record_instance_start("agent-x", pid=os.getpid(), db_path=db)
+        # Act
+        pids = mod._live_agent_pids(db_path=db)
+        # Assert
+        assert pids["agent-x"] == os.getpid()
+
+
+# ===========================================================================
+# resolve_liveness — the POSITIVE signals are read UNCONDITIONALLY
+#
+# The flood's IO-level cause: the session timestamp used to be read ONLY when
+# the registry had already voted "live" (``... if is_live else None``). Since
+# the fleet's registry records pid=NULL on every row, it never voted live, so
+# the strongest positive signal was never consulted for ANY agent.
+# ===========================================================================
+
+
+class TestResolveLiveness:
+    def test_activity_is_read_even_when_the_registry_proves_nothing(
+        self, home_at_tmp
+    ) -> None:
+        # Arrange — a REAL empty registry (nobody vouched for) + a REAL session
+        # record written 10s ago. The owner is plainly alive and working.
+        run_dir = (
+            home_at_tmp / ".scitex" / "agent-container" / "runtime" / "agent-x"
+        )
+        run_dir.mkdir(parents=True)
+        late = _iso(NOW - 10.0)
+        (run_dir / "session.jsonl").write_text(json.dumps({"ts": late}) + "\n")
+        # Act
+        out = mod.resolve_liveness(["agent-x"], db_path=home_at_tmp / "state.db")
+        # Assert — THE regression: this used to be None (never even read).
+        assert out["agent-x"].last_active_ts == pytest.approx(
+            datetime.fromisoformat(late.replace("Z", "+00:00")).timestamp()
+        )
+
+    def test_heartbeat_beat_is_read_for_an_owner_with_no_registry_pid(
+        self, home_at_tmp
+    ) -> None:
+        # Arrange — the fleet's real shape: a pid-less active row + a fresh
+        # heartbeat. The heartbeat is the proof of life the registry lost.
+        db = home_at_tmp / "state.db"
+        record_instance_start("agent-x", db_path=db)
+        run_dir = (
+            home_at_tmp / ".scitex" / "agent-container" / "runtime" / "agent-x"
+        )
+        run_dir.mkdir(parents=True)
+        (run_dir / "heartbeat.json").write_text(json.dumps({"ts": NOW - 300.0}))
+        # Act
+        out = mod.resolve_liveness(["agent-x"], db_path=db)
+        # Assert
+        assert out["agent-x"].last_beat_ts is not None
+
+    def test_a_live_registry_pid_still_resolves_live(self, home_at_tmp) -> None:
+        # Arrange — the registry CAN still vouch for an agent; when it does,
+        # that remains corroborating positive evidence.
+        db = home_at_tmp / "state.db"
+        record_instance_start("agent-x", pid=os.getpid(), db_path=db)
+        # Act
+        out = mod.resolve_liveness(["agent-x"], db_path=db)
+        # Assert
+        assert out["agent-x"].is_live is True
+
+    def test_unreadable_registry_makes_the_owner_unknown(self, home_at_tmp) -> None:
+        # Arrange — a REAL unreadable registry (parent path is a file).
+        blocker = home_at_tmp / "not-a-dir"
+        blocker.write_text("i am a file, not a directory")
+        # Act
+        out = mod.resolve_liveness(["agent-x"], db_path=blocker / "state.db")
+        # Assert — UNKNOWN, so the rule stays silent instead of guessing dead.
+        assert out["agent-x"].known is False
+
+    def test_owner_with_no_pid_and_no_heartbeat_is_unknown(
+        self, home_at_tmp
+    ) -> None:
+        # Arrange — registry readable, but this owner has NO channel that would
+        # have shown life (no recorded pid, no heartbeat file). E.g. the
+        # pseudo-owners on the real board ("operator", "lead"), which are not
+        # sac-managed processes at all and must never be called dead.
+        db = home_at_tmp / "state.db"
+        record_instance_start("someone-else", db_path=db)
+        # Act
+        out = mod.resolve_liveness(["operator"], db_path=db)
+        # Assert
+        assert out["operator"].known is False
+
+    def test_a_dead_agent_that_left_a_heartbeat_behind_stays_known(
+        self, home_at_tmp
+    ) -> None:
+        # Arrange — a crashed agent's heartbeat.json PERSISTS with a frozen
+        # mtime. That is a channel that would have shown life and does not, so
+        # the owner stays KNOWN and real death is still detectable.
+        db = home_at_tmp / "state.db"
+        record_instance_start("agent-x", db_path=db)
+        run_dir = (
+            home_at_tmp / ".scitex" / "agent-container" / "runtime" / "agent-x"
+        )
+        run_dir.mkdir(parents=True)
+        (run_dir / "heartbeat.json").write_text(json.dumps({"ts": NOW - 99_999.0}))
+        # Act
+        out = mod.resolve_liveness(["agent-x"], db_path=db)
+        # Assert
+        assert out["agent-x"].known is True
 
 
 # ===========================================================================
@@ -281,6 +519,39 @@ class TestLoopEmits:
         # Arrange — owner live + session moved 1s ago ⇒ no anomaly.
         events: list[dict] = []
         liveness = {"agent-x": AgentLiveness(is_live=True, last_active_ts=NOW - 1.0)}
+        # Act
+        await _run_one_tick(
+            consumers=[events.append], doc=_stuck_doc(), liveness=liveness
+        )
+        # Assert
+        assert events == []
+
+    async def test_live_owner_the_registry_missed_emits_nothing(self) -> None:
+        # Arrange — THE FLOOD, end to end through the loop: the registry
+        # vouches for nobody (pid=NULL rows), but the owner wrote an activity
+        # record 5s ago. Every one of the ~100 false criticals looked like this.
+        events: list[dict] = []
+        liveness = {
+            "agent-x": AgentLiveness(
+                is_live=False, last_active_ts=NOW - 5.0, known=True
+            )
+        }
+        # Act
+        await _run_one_tick(
+            consumers=[events.append], doc=_stuck_doc(), liveness=liveness
+        )
+        # Assert — the bus stays silent.
+        assert events == []
+
+    async def test_unknown_owner_emits_nothing(self) -> None:
+        # Arrange — liveness could not be determined at all (registry
+        # unavailable, no heartbeat) ⇒ never guess "dead".
+        events: list[dict] = []
+        liveness = {
+            "agent-x": AgentLiveness(
+                is_live=False, last_active_ts=None, known=False
+            )
+        }
         # Act
         await _run_one_tick(
             consumers=[events.append], doc=_stuck_doc(), liveness=liveness

--- a/tests/scitex_agent_container/_listen/test__liveness_tick_detect.py
+++ b/tests/scitex_agent_container/_listen/test__liveness_tick_detect.py
@@ -61,13 +61,23 @@ class TestOwnerNotLive:
         # Assert
         assert [s.reason for s in stuck] == ["owner-not-live"]
 
-    def test_owner_absent_from_liveness_map_is_not_live(self) -> None:
-        # Arrange — no entry at all for the owner ⇒ treated as not live.
+    def test_dead_owner_with_a_stale_heartbeat_still_fires(self) -> None:
+        # Arrange — POSITIVE evidence of death: the registry was readable
+        # (``known``), the owner has no live pid, its heartbeat writer stopped
+        # beating long ago and its activity record is stale too.
         doc = {"tasks": [_card()]}
+        liveness = {
+            "agent-x": AgentLiveness(
+                is_live=False,
+                last_active_ts=NOW - STALE_S * 10,
+                known=True,
+                last_beat_ts=NOW - STALE_S * 10,
+            )
+        }
         # Act
-        stuck = find_stuck_cards(doc, {}, now=NOW, stale_s=STALE_S)
-        # Assert
-        assert stuck and stuck[0].reason == "owner-not-live"
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert — real detection must NOT be regressed by the UNKNOWN work.
+        assert [s.reason for s in stuck] == ["owner-not-live"]
 
     def test_anomaly_carries_the_card_id(self) -> None:
         # Arrange
@@ -106,6 +116,160 @@ class TestOwnerIdle:
         stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
         # Assert
         assert stuck and stuck[0].reason == "owner-idle"
+
+
+# ---------------------------------------------------------------------------
+# THE FLOOD REGRESSION — a LIVE owner the registry failed to vouch for
+#
+# Observed on the live fleet: every active ``instances`` row carries
+# ``pid = NULL``, so the registry proves NOBODY live. The old rule read that
+# as "everybody is dead" and fired ``owner-not-live`` / ``critical`` at ~100
+# cards per sweep, against agents that were serving HTTP in the same log.
+# The owner's OWN records must outrank the registry's silence.
+# ---------------------------------------------------------------------------
+
+
+class TestLiveOwnerRegistryMissed:
+    def test_recent_activity_record_outranks_a_registry_that_says_dead(
+        self,
+    ) -> None:
+        # Arrange — registry readable but proves nothing (pid-less rows), while
+        # the owner wrote an activity record 5s ago. It is demonstrably ALIVE
+        # and PROGRESSING.
+        doc = {"tasks": [_card()]}
+        liveness = {
+            "agent-x": AgentLiveness(
+                is_live=False, last_active_ts=NOW - 5.0, known=True
+            )
+        }
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert — THE regression: this used to emit owner-not-live/critical.
+        assert stuck == []
+
+    def test_fresh_heartbeat_downgrades_a_stalled_owner_to_idle(self) -> None:
+        # Arrange — no live registry pid and no activity for a while, but the
+        # heartbeat writer beat 30s ago ⇒ the PROCESS is provably alive.
+        doc = {"tasks": [_card()]}
+        liveness = {
+            "agent-x": AgentLiveness(
+                is_live=False,
+                last_active_ts=None,
+                known=True,
+                last_beat_ts=NOW - 30.0,
+            )
+        }
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert — idle (true), never not-live (a lie about a beating agent).
+        assert [s.reason for s in stuck] == ["owner-idle"]
+
+
+# ---------------------------------------------------------------------------
+# UNKNOWN ≠ DEAD — no evidence either way ⇒ say nothing, never a critical
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownIsNotDead:
+    def test_unresolvable_owner_emits_nothing(self) -> None:
+        # Arrange — the registry read FAILED and the owner has no heartbeat, so
+        # nothing could have shown life had there been any.
+        doc = {"tasks": [_card()]}
+        liveness = {
+            "agent-x": AgentLiveness(
+                is_live=False, last_active_ts=None, known=False
+            )
+        }
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck == []
+
+    def test_unknown_owner_never_escalates_to_critical(self) -> None:
+        # Arrange — a card stale by 5× the threshold would be CRITICAL if the
+        # owner were known-dead. Unknown must never reach that severity.
+        doc = {"tasks": [_card(last_activity=_iso(NOW - STALE_S * 5))]}
+        liveness = {
+            "agent-x": AgentLiveness(
+                is_live=False, last_active_ts=None, known=False
+            )
+        }
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert not any(s.severity == "critical" for s in stuck)
+
+    def test_owner_absent_from_liveness_map_is_unknown_not_dead(self) -> None:
+        # Arrange — no entry at all for the owner. We never resolved it; that
+        # is absence of evidence, not evidence of death.
+        doc = {"tasks": [_card()]}
+        # Act
+        stuck = find_stuck_cards(doc, {}, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck == []
+
+
+# ---------------------------------------------------------------------------
+# The heartbeat WRITER can die too
+#
+# The beats this rule reads as proof-of-life come from ONE shared writer
+# (sibling loops inside ``sac listen``) which is known to blow its budget and
+# get abandoned. When it stops, every beat freezes AT ONCE. Reading that as
+# "the whole fleet died" would just swap the registry flood for a heartbeat
+# flood — the same inversion down a different channel.
+# ---------------------------------------------------------------------------
+
+
+class TestAbandonedHeartbeatWriter:
+    def test_a_dead_writer_indicts_nobody(self) -> None:
+        # Arrange — the owner's beat is frozen AND the newest beat anywhere in
+        # the fleet is frozen too ⇒ the WRITER stopped. Its silence is a fact
+        # about the writer, not about this agent.
+        doc = {"tasks": [_card()]}
+        liveness = {
+            "agent-x": AgentLiveness(
+                is_live=False,
+                last_active_ts=None,
+                known=True,
+                last_beat_ts=NOW - STALE_S * 3,
+            )
+        }
+        # Act
+        stuck = find_stuck_cards(
+            doc,
+            liveness,
+            now=NOW,
+            stale_s=STALE_S,
+            fleet_last_beat_ts=NOW - STALE_S * 3,  # nobody, anywhere, is beating
+        )
+        # Assert — no flood: an abandoned writer must not read as mass death.
+        assert stuck == []
+
+    def test_a_frozen_owner_still_dies_while_the_writer_beats_for_others(
+        self,
+    ) -> None:
+        # Arrange — the fleet reading is FRESH (some other agent, not
+        # necessarily a card owner, is still being beaten for), so the writer
+        # demonstrably WORKS. This owner's silence is therefore its own.
+        doc = {"tasks": [_card()]}
+        liveness = {
+            "agent-x": AgentLiveness(
+                is_live=False,
+                last_active_ts=None,
+                known=True,
+                last_beat_ts=NOW - STALE_S * 3,
+            )
+        }
+        # Act
+        stuck = find_stuck_cards(
+            doc,
+            liveness,
+            now=NOW,
+            stale_s=STALE_S,
+            fleet_last_beat_ts=NOW - 30.0,  # the writer is alive and beating
+        )
+        # Assert — real death is still detected (no gap for a lone dead owner).
+        assert [s.reason for s in stuck] == ["owner-not-live"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_listen/test__nodes.py
+++ b/tests/scitex_agent_container/_listen/test__nodes.py
@@ -47,6 +47,10 @@ from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
 from scitex_agent_container._state import state_db as _state_db
 from scitex_agent_container._state.state_db_nodes import record_lineage
+from tests.scitex_agent_container._helpers.loopback_server import (
+    await_until_serving,
+    serve_in_thread,
+)
 
 TOKEN = "test-token-wi3"
 
@@ -201,7 +205,6 @@ async def _sse_roundtrip(
     """
     import contextlib as _contextlib
     import socket
-    import threading
 
     import uvicorn
 
@@ -217,14 +220,11 @@ async def _sse_roundtrip(
     )
     server = uvicorn.Server(config)
 
-    server_thread = threading.Thread(target=server.run, daemon=True)
-    server_thread.start()
-    # Wait for the server to come up.
-    deadline = asyncio.get_event_loop().time() + 5.0
-    while not server.started:
-        if asyncio.get_event_loop().time() > deadline:
-            raise AssertionError("uvicorn did not start in 5s")
-        await asyncio.sleep(0.05)
+    # Shared startup wait: the hand-rolled 5s ceiling that used to live here
+    # raced the listen lifespan (measured 7.49s under load) and turned the
+    # py3.11 leg red. See tests/.../_helpers/loopback_server.py.
+    server_thread, crash = serve_in_thread(server, port)
+    await await_until_serving(server, server_thread, port=port, crash=crash)
 
     headers = {"authorization": f"Bearer {TOKEN}"}
     ready = asyncio.Event()

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -24,12 +24,10 @@ import contextlib
 import json
 import os
 import socket
-import threading
 from pathlib import Path
 
 import httpx
 import pytest
-import uvicorn
 import yaml
 from starlette.testclient import TestClient
 
@@ -40,6 +38,7 @@ from scitex_agent_container._state import registry as _reg
 from scitex_agent_container._state import state_db
 from scitex_agent_container._state import state_db_nodes as state_db_nodes_grant
 from scitex_agent_container._state.state_db_nodes import record_lineage
+from tests.scitex_agent_container._helpers.loopback_server import run_loopback
 
 TOKEN = "test-token-abc123"
 
@@ -828,30 +827,33 @@ def _free_port() -> int:
         return s.getsockname()[1]
 
 
+# Ceiling for the REAL cross-host I/O below (loopback HTTP + the SSE roundtrip
+# between two live uvicorn servers). Generous ON PURPOSE, and not a magic number:
+# every wait it bounds is event-driven — the httpx read returns the instant the
+# forwarded event lands, the `wait_for`s the instant their event fires — so a
+# large ceiling costs NOTHING on the happy path and only bounds a genuinely
+# broken run. The 5.0s literals that used to be sprinkled here were the second
+# half of the py3.11 CI flake: once the `uvicorn loopback did not start in 5s`
+# ceiling was fixed, a loaded runner simply failed one layer down instead, with
+# `httpx.ReadTimeout` (reproduced: 6 cross-host tests fail under CPU
+# oversubscription purely on these 5s bounds). Bounding real I/O by an arbitrary
+# tight deadline is a race by construction; the fix is to make the bound
+# generous, not to guess a better number.
+LOOPBACK_IO_TIMEOUT_S = 30.0
+
+
 @contextlib.contextmanager
 def _run_loopback(app, port: int):
     """Spin up uvicorn on a loopback port. The app's
     ``local_host`` identity is configured at ``create_app`` time
     (see :func:`scitex_agent_container._listen.server.create_app`).
-    """
-    config = uvicorn.Config(
-        app, host="127.0.0.1", port=port, log_level="warning", ws="none"
-    )
-    server = uvicorn.Server(config)
-    t = threading.Thread(target=server.run, daemon=True)
-    t.start()
-    import time as _time
 
-    deadline = _time.monotonic() + 5.0
-    while not server.started:
-        if _time.monotonic() > deadline:
-            raise RuntimeError("uvicorn loopback did not start in 5s")
-        _time.sleep(0.05)
-    try:
-        yield port
-    finally:
-        server.should_exit = True
-        t.join(timeout=5.0)
+    Startup wait lives in the shared helper — the hand-rolled 5s ceiling this
+    used to carry raced the listen lifespan (measured 7.49s under load) and
+    turned the py3.11 leg red. See ``_helpers/loopback_server.py``.
+    """
+    with run_loopback(app, port) as p:
+        yield p
 
 
 def _send_payload(text: str, *, from_agent: str) -> dict:
@@ -904,7 +906,7 @@ def test_cross_host_send_forwards_to_target_host(cross_host_env) -> None:
             captured: dict = {}
 
             async def consume():
-                async with httpx.AsyncClient(timeout=5.0) as ac:
+                async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                     async with ac.stream(
                         "GET",
                         f"http://127.0.0.1:{host_a_port}/agents/alice/inbox/stream",
@@ -922,11 +924,11 @@ def test_cross_host_send_forwards_to_target_host(cross_host_env) -> None:
 
             sub = asyncio.create_task(consume())
             try:
-                await asyncio.wait_for(ready.wait(), timeout=5.0)
+                await asyncio.wait_for(ready.wait(), timeout=LOOPBACK_IO_TIMEOUT_S)
                 # Now stand up host B and post to it. WI-4 forwarder
                 # on host B should resolve alice→host-a and forward.
                 with _run_loopback(app_b, host_b_port):
-                    async with httpx.AsyncClient(timeout=5.0) as ac:
+                    async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                         resp = await ac.post(
                             f"http://127.0.0.1:{host_b_port}/agents/alice/message:send",
                             json=_send_payload(
@@ -938,7 +940,7 @@ def test_cross_host_send_forwards_to_target_host(cross_host_env) -> None:
                     raise RuntimeError(
                         f"forward returned {resp.status_code}: {resp.text!r}"
                     )
-                await asyncio.wait_for(sub, timeout=5.0)
+                await asyncio.wait_for(sub, timeout=LOOPBACK_IO_TIMEOUT_S)
             finally:
                 if not sub.done():
                     sub.cancel()
@@ -978,7 +980,7 @@ def test_cross_host_forward_preserves_from_agent_metadata(cross_host_env) -> Non
             captured: dict = {}
 
             async def consume():
-                async with httpx.AsyncClient(timeout=5.0) as ac:
+                async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                     async with ac.stream(
                         "GET",
                         f"http://127.0.0.1:{host_a_port}/agents/alice/inbox/stream",
@@ -996,15 +998,15 @@ def test_cross_host_forward_preserves_from_agent_metadata(cross_host_env) -> Non
 
             sub = asyncio.create_task(consume())
             try:
-                await asyncio.wait_for(ready.wait(), timeout=5.0)
+                await asyncio.wait_for(ready.wait(), timeout=LOOPBACK_IO_TIMEOUT_S)
                 with _run_loopback(app_b, host_b_port):
-                    async with httpx.AsyncClient(timeout=5.0) as ac:
+                    async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                         await ac.post(
                             f"http://127.0.0.1:{host_b_port}/agents/alice/message:send",
                             json=_send_payload("x", from_agent="permitted-peer"),
                             headers={"authorization": f"Bearer {SHARED_TOKEN}"},
                         )
-                await asyncio.wait_for(sub, timeout=5.0)
+                await asyncio.wait_for(sub, timeout=LOOPBACK_IO_TIMEOUT_S)
             finally:
                 if not sub.done():
                     sub.cancel()
@@ -1220,7 +1222,7 @@ def _drive_ssh_cross_host_send(
             captured: dict = {}
 
             async def consume():
-                async with httpx.AsyncClient(timeout=5.0) as ac:
+                async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                     async with ac.stream(
                         "GET",
                         f"http://127.0.0.1:{host_a_port}/agents/alice/inbox/stream",
@@ -1238,9 +1240,9 @@ def _drive_ssh_cross_host_send(
 
             sub = asyncio.create_task(consume())
             try:
-                await asyncio.wait_for(ready.wait(), timeout=5.0)
+                await asyncio.wait_for(ready.wait(), timeout=LOOPBACK_IO_TIMEOUT_S)
                 with _run_loopback(app_b, host_b_port):
-                    async with httpx.AsyncClient(timeout=10.0) as ac:
+                    async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                         resp = await ac.post(
                             f"http://127.0.0.1:{host_b_port}/agents/alice/message:send",
                             json=_send_payload(text, from_agent=sender),
@@ -1250,7 +1252,7 @@ def _drive_ssh_cross_host_send(
                     raise RuntimeError(
                         f"ssh forward returned {resp.status_code}: {resp.text!r}"
                     )
-                await asyncio.wait_for(sub, timeout=5.0)
+                await asyncio.wait_for(sub, timeout=LOOPBACK_IO_TIMEOUT_S)
             finally:
                 if not sub.done():
                     sub.cancel()
@@ -1351,7 +1353,7 @@ def test_cross_host_send_without_grant_returns_403_from_target_listen(
 
     async def driver() -> int:
         with _run_loopback(app_a, host_a_port), _run_loopback(app_b, host_b_port):
-            async with httpx.AsyncClient(timeout=10.0) as ac:
+            async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                 resp = await ac.post(
                     f"http://127.0.0.1:{host_b_port}/agents/alice/message:send",
                     json=_send_payload("denied", from_agent="outsider"),
@@ -1429,7 +1431,7 @@ def _roundtrip_local_send(cross_host_env, *, metadata: dict) -> dict:
             captured: dict = {}
 
             async def consume():
-                async with httpx.AsyncClient(timeout=5.0) as ac:
+                async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                     async with ac.stream(
                         "GET",
                         f"http://127.0.0.1:{port}/agents/alice/inbox/stream",
@@ -1447,14 +1449,14 @@ def _roundtrip_local_send(cross_host_env, *, metadata: dict) -> dict:
 
             sub = asyncio.create_task(consume())
             try:
-                await asyncio.wait_for(ready.wait(), timeout=5.0)
-                async with httpx.AsyncClient(timeout=5.0) as ac:
+                await asyncio.wait_for(ready.wait(), timeout=LOOPBACK_IO_TIMEOUT_S)
+                async with httpx.AsyncClient(timeout=LOOPBACK_IO_TIMEOUT_S) as ac:
                     await ac.post(
                         f"http://127.0.0.1:{port}/agents/alice/message:send",
                         json=_send_payload_with_meta("ping", metadata=metadata),
                         headers={"authorization": f"Bearer {SHARED_TOKEN}"},
                     )
-                await asyncio.wait_for(sub, timeout=5.0)
+                await asyncio.wait_for(sub, timeout=LOOPBACK_IO_TIMEOUT_S)
             finally:
                 if not sub.done():
                     sub.cancel()

--- a/tests/scitex_agent_container/_runners/test_a2a_proxy.py
+++ b/tests/scitex_agent_container/_runners/test_a2a_proxy.py
@@ -18,6 +18,10 @@ from starlette.routing import Route
 from starlette.testclient import TestClient
 
 from scitex_agent_container._runners.a2a_proxy import build_app, splice_card
+from tests.scitex_agent_container._helpers.loopback_server import (
+    serve_in_thread,
+    wait_until_serving,
+)
 
 # ---------------------------------------------------------------------------
 # Upstream stubs (in-process ASGI app, accessed via httpx.AsyncClient)
@@ -907,8 +911,6 @@ def real_upstream_server() -> Any:
     Yields ``("http://127.0.0.1:<port>", recorder)`` where recorder is
     a dict the upstream mutates so tests can observe traffic.
     """
-    import threading
-    import time
 
     import uvicorn
 
@@ -935,17 +937,15 @@ def real_upstream_server() -> Any:
     )
     server = uvicorn.Server(config)
 
-    thread = threading.Thread(target=server.run, daemon=True)
-    thread.start()
-
-    # Wait until the server reports it's actually listening.
-    deadline = time.time() + 5.0
-    while time.time() < deadline and not server.started:
-        time.sleep(0.02)
-    if not server.started:
+    # Shared startup wait — a hand-rolled 5s ceiling on a real server start is
+    # a race by construction (see tests/.../_helpers/loopback_server.py).
+    thread, crash = serve_in_thread(server, port)
+    try:
+        wait_until_serving(server, thread, port=port, crash=crash)
+    except Exception:
         server.should_exit = True
         thread.join(timeout=2.0)
-        raise RuntimeError("upstream uvicorn server failed to start")
+        raise
 
     try:
         yield (f"http://127.0.0.1:{port}", recorder)
@@ -957,8 +957,6 @@ def real_upstream_server() -> Any:
 @pytest.fixture
 def failing_upstream_server() -> Any:
     """Real uvicorn server whose card endpoint returns 500."""
-    import threading
-    import time
 
     import uvicorn
 
@@ -974,16 +972,14 @@ def failing_upstream_server() -> Any:
         app, host="127.0.0.1", port=port, log_level="warning", lifespan="off"
     )
     server = uvicorn.Server(config)
-    thread = threading.Thread(target=server.run, daemon=True)
-    thread.start()
-
-    deadline = time.time() + 5.0
-    while time.time() < deadline and not server.started:
-        time.sleep(0.02)
-    if not server.started:
+    # Shared startup wait — see tests/.../_helpers/loopback_server.py.
+    thread, crash = serve_in_thread(server, port)
+    try:
+        wait_until_serving(server, thread, port=port, crash=crash)
+    except Exception:
         server.should_exit = True
         thread.join(timeout=2.0)
-        raise RuntimeError("upstream uvicorn server failed to start")
+        raise
 
     try:
         yield f"http://127.0.0.1:{port}"

--- a/tests/scitex_agent_container/a2a/test__server.py
+++ b/tests/scitex_agent_container/a2a/test__server.py
@@ -658,12 +658,13 @@ def test_sdk_round_trip_get_task_envelope_carries_result(_round_trip):
 import asyncio as _asyncio
 import contextlib as _contextlib
 import socket as _socket
-import threading as _threading
 
 import httpx as _httpx
-import uvicorn as _uvicorn
 
 from scitex_agent_container._state import state_db as _state_db
+from tests.scitex_agent_container._helpers.loopback_server import (
+    run_loopback as _run_loopback_shared,
+)
 
 
 @pytest.fixture
@@ -709,27 +710,14 @@ def _send_payload(text: str, *, from_agent: str = "alice") -> dict:
 
 @_contextlib.contextmanager
 def _run_loopback(app, port: int):
-    """Spin up uvicorn on a loopback port for a single test block."""
-    # Arrange — boot the uvicorn server on a background thread.
-    config = _uvicorn.Config(
-        app, host="127.0.0.1", port=port, log_level="warning", ws="none"
-    )
-    server = _uvicorn.Server(config)
-    t = _threading.Thread(target=server.run, daemon=True)
-    t.start()
-    # Wait for "started"; raise loudly if it doesn't come up.
-    import time as _time
+    """Spin up uvicorn on a loopback port for a single test block.
 
-    deadline = _time.monotonic() + 5.0
-    while not server.started:
-        if _time.monotonic() > deadline:
-            raise RuntimeError("uvicorn loopback did not start in 5s")
-        _time.sleep(0.05)
-    try:
-        yield port
-    finally:
-        server.should_exit = True
-        t.join(timeout=5.0)
+    Startup wait lives in the shared helper — the hand-rolled 5s ceiling this
+    used to carry raced the app's lifespan startup (measured 7.49s under load)
+    and turned the py3.11 leg red. See ``_helpers/loopback_server.py``.
+    """
+    with _run_loopback_shared(app, port) as p:
+        yield p
 
 
 def _free_port() -> int:

--- a/tests/smoke/_node_comms.py
+++ b/tests/smoke/_node_comms.py
@@ -24,18 +24,16 @@ import asyncio
 import contextlib
 import json
 import socket
-import threading
-import time
 from pathlib import Path
 
 import httpx
-import uvicorn
 import yaml
 
 from scitex_agent_container._state.state_db_nodes import (
     mint_node_token,
     record_lineage,
 )
+from tests.scitex_agent_container._helpers.loopback_server import run_loopback
 
 # ---------------------------------------------------------------------------
 # uvicorn loopback helpers (mirrors tests/.../_listen/test_server.py).
@@ -55,23 +53,13 @@ def _run_loopback(app, port: int):
 
     Teardown sets ``should_exit`` + joins; the ``finally`` fires even
     on test failure so a hung subscriber never strands the server.
+
+    The startup wait lives in the shared helper — the hand-rolled 5s ceiling
+    this used to carry raced the listen lifespan (measured 7.49s under load).
+    See ``_helpers/loopback_server.py``.
     """
-    config = uvicorn.Config(
-        app, host="127.0.0.1", port=port, log_level="warning", ws="none"
-    )
-    server = uvicorn.Server(config)
-    t = threading.Thread(target=server.run, daemon=True)
-    t.start()
-    deadline = time.monotonic() + 5.0
-    while not server.started:
-        if time.monotonic() > deadline:
-            raise RuntimeError("uvicorn loopback did not start in 5s")
-        time.sleep(0.05)
-    try:
-        yield port
-    finally:
-        server.should_exit = True
-        t.join(timeout=5.0)
+    with run_loopback(app, port) as p:
+        yield p
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Ships v0.21.16 to `main`. **0.21.15 was tagged but never published — deliberately** (it carried #658 *with* the cancellation hole below). Install 0.21.16.

## Headline (#663) — a production defect on the fleet's own Python

On **Python 3.11** — what the fleet runs — `asyncio.wait_for` **silently swallows a cancellation** when the inner future resolves in the same instant:

```python
except exceptions.CancelledError:
    if fut.done():
        return fut.result()      # the cancellation is dropped on the floor
```

Every background loop is `while True: await run_blocking_or(...)`, so **one swallowed cancel and the loop ticks forever**: `task.cancel()` returns, `await task` never does, **and the daemon does not die on SIGTERM.** `agents stop` / `agents restart` leave it running.

Measured over 120 cancellations of a 20 Hz loop: `wait_for` swallowed **13/120 on 3.11.15**, **0/120 on 3.12.3**; a bare `await` swallowed **0/120 on both**. That control column is what makes it a fact rather than a story.

## Also shipping

- **#644** — a live agent's registry row was buried **64 seconds** after it started (no heartbeat yet ⇒ read as dead), after which `agent_send` refused to deliver to it. **Absence of evidence is not evidence of death.**
- **#661** — tests raced real servers against arbitrary 5s deadlines; the server was **slow, not dead** (7.49s), and the old wait swallowed its startup exception before blaming a timeout.
- **#662** — the CI leftover-reap could SIGTERM its own sibling matrix legs; its safety rested on *"runs are serialised"*, an invariant that quietly died when a second runner was registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)