### PR TITLE
fix(picker): stop binning ~10% of every 7-day quota window — the ranker never knew when a window resets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The account picker threw away ~10% of a 7-day Max-20x window, every cycle.**
+  `sac accounts list` at the time of the report:
+
+  ```
+  wyusuuke-gmail-com   5h 28%   7d 67%  (resets in 5d 14h)
+  ywata1989-gmail-com  5h  0%   7d 90%  (resets in 9h06m)
+  ywatanabe-scitex-ai  5h  0%   7d 90%  (resets in 6 MINUTES)   <- 10% about to evaporate
+  ```
+
+  The picker sent every agent to `wyusuuke` (67%), so `ywatanabe-scitex-ai`'s
+  remaining **10% of a 7-day window was deleted unused six minutes later**
+  (operator: 「毎回 90%で10%捨ててる」 — we bin it every cycle).
+
+  Root cause: `_creds._quota_rank.pick_ranked` **had no notion of when a window
+  resets.** It scored "90%, resets in 6 minutes" and "90%, resets in 6 days"
+  *identically* and avoided both — but they are opposites. 90% with 6 days left
+  is a genuine reserve (avoiding it is correct); 90% with 6 minutes left is
+  **use-it-or-lose-it**, and avoiding it burns the capacity for nothing.
+
+  The reset time was not merely unused — it was **unreachable**. The usage API
+  returns `resets_at` for both windows and `_account.claude_usage` already parsed
+  it, but `_account.quota_cache_refresh` **dropped it when writing the aggregate
+  `quota-cache.json` the picker reads**, so the ranker was structurally unable to
+  see it. (`sac accounts list` renders "resets in …" from a *different* cache —
+  the per-account `usage.json` — which is why it was visible to the human and
+  invisible to the picker.)
+
+  Fixed in three parts:
+  - `quota_cache_refresh` now persists `reset_at_5h` / `reset_at_7d` into the
+    aggregate cache (additive; entries stay valid when upstream omits them).
+  - `_quota_rank.is_expiring_7d` classifies a near-capped window whose reset is
+    imminent as **expiring, not scarce**: it no longer suffers the `near_capped`
+    demotion, and its rendezvous-hash weight is boosted so the fleet spends
+    vanishing capacity before a reserve that persists.
+  - `_pick_healthy` applies the same rule to the `preferred` account, so an agent
+    is no longer rotated *off* the very account whose quota is about to evaporate.
+
+  On the table above the expiring account goes from **0 of 60 agents to 37 of 60**,
+  while the 9h-away reserve stays correctly avoided (**0 of 60**) and the fleet
+  still spreads (23 of 60 to `wyusuuke`).
+
+  Bounded against a 429 (the risk of routing onto a 90% account): the 5h window
+  remains the supreme, untouched gate; an account with <2% of its weekly window
+  left is never treated as expiring capacity; the horizon is 2h, so worst-case
+  "stuck at the cap" exposure is short; the preference is a spread *weight*, not
+  a hard tier, so a bulk restart cannot stack the whole fleet onto a window with
+  10% left; and a 429 at these usage levels already classifies as `Mode.ROTATE`
+  (`_account.rate_limit_classifier`), which rotates the agent to a *different*
+  healthy account — `rotate_account` excludes the current one, so it cannot
+  thrash back onto the drained account.
+
+  An old cache with no reset stamps degrades to exactly the previous behaviour.
+
 ## [0.21.16] — 2026-07-14
 
 **⚠️ 0.21.15 WAS NEVER PUBLISHED — it is tagged, but nothing reached PyPI, and

--- a/src/scitex_agent_container/_account/quota_cache_refresh.py
+++ b/src/scitex_agent_container/_account/quota_cache_refresh.py
@@ -94,8 +94,12 @@ def refresh_quota_cache(
 
     Returns:
         ``{"cache_path": str, "written": bool, "ok": int, "failed": int,
-           "results": [{"name", "short", "h5", "d7", "ttl_h", "error"}]}``.
-        ``error`` is ``None`` on success. Never raises.
+           "results": [{"name", "short", "h5", "d7", "ttl_h",
+                        "reset_at_5h", "reset_at_7d", "error"}]}``.
+        ``error`` is ``None`` on success. The two ``reset_at_*`` stamps
+        are ISO-8601 strings (or ``None`` when upstream omits them) and
+        are what lets the picker tell expiring quota from a reserve —
+        see :func:`_creds._quota_rank.is_expiring_7d`. Never raises.
     """
     from .._state.account_store import list_accounts
 
@@ -125,6 +129,17 @@ def refresh_quota_cache(
                 "h5": row["h5"],
                 "d7": row["d7"],
                 "ttl_h": row["ttl_h"],
+                # WHEN each window resets — not just how full it is. The
+                # picker cannot tell "90%, resets in 6 minutes" (spend it,
+                # it is about to be deleted) from "90%, resets in 6 days"
+                # (a reserve, leave it) without this. The usage API has
+                # always returned it; we simply dropped it here, so the
+                # ranker was structurally unable to see it and the fleet
+                # binned the tail of every 7d window. Optional (None when
+                # upstream omits it) — every reader degrades to the
+                # reset-unaware behaviour rather than guess.
+                "reset_at_5h": row["reset_at_5h"],
+                "reset_at_7d": row["reset_at_7d"],
             }
             ok += 1
         else:
@@ -182,6 +197,8 @@ def _refresh_one(
         "h5": None,
         "d7": None,
         "ttl_h": None,
+        "reset_at_5h": None,
+        "reset_at_7d": None,
         "error": None,
     }
     creds_path = store / name / _CREDENTIALS_FILENAME
@@ -219,7 +236,20 @@ def _refresh_one(
     row["h5"] = float(h5)
     row["d7"] = float(d7)
     row["ttl_h"] = ttl_h
+    # Reset stamps are OPTIONAL, unlike h5/d7/ttl_h above: a response that
+    # omits them still yields a usable entry (the picker just degrades to
+    # its reset-unaware ranking for that account). Making them required
+    # would let a single upstream field change blank the whole cache.
+    row["reset_at_5h"] = _iso_or_none(usage.get("reset_at_5h"))
+    row["reset_at_7d"] = _iso_or_none(usage.get("reset_at_7d"))
     return row
+
+
+def _iso_or_none(value: Any) -> str | None:
+    """Pass through a non-empty ISO-8601 string; anything else → ``None``."""
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
 
 
 def _is_pct(value: Any) -> bool:

--- a/src/scitex_agent_container/_creds/_pick_healthy.py
+++ b/src/scitex_agent_container/_creds/_pick_healthy.py
@@ -27,7 +27,10 @@ Scope (Phase 1, deliberately small)
   axes carry different rules (see :mod:`._quota_rank`): an account at
   ≥ ~95% of its **5h** window is *blocked-now* (429s immediately) and
   is avoided while any fresh alternative is unblocked; an account at
-  ≥ ~90% **7d** is *near-capped* (the existing avoidance). The
+  ≥ ~90% **7d** is *near-capped* (the existing avoidance) — UNLESS its
+  7d window resets within the hour(s), in which case the remainder is
+  EXPIRING, not scarce, and we spend it rather than let it be deleted
+  (:func:`._quota_rank.is_expiring_7d`). The
   ``preferred`` account is kept only when it is fresh AND not
   blocked-now AND not near-capped, to minimise churn. Otherwise the
   best tier of fresh candidates competes: with a ``spread_key`` (the
@@ -73,9 +76,12 @@ from .._account.creds_sync import (
 from .._state.account_store import _store_path
 from ._quota_rank import (
     BLOCKED_5H_PCT,
+    EXPIRING_7D_HORIZON_S,
     NEAR_CAP_7D_PCT,
     account_5h_usage,
+    account_7d_reset_at,
     account_7d_usage,
+    is_expiring_7d,
     pick_ranked,
 )
 
@@ -259,9 +265,11 @@ def pick_healthy_account(
     now: float | None = None,
     usage_5h: Mapping[str, float] | None = None,
     usage_7d: Mapping[str, float] | None = None,
+    reset_7d: Mapping[str, object] | None = None,
     quota_cache_path: Path | str | None = None,
     near_cap_pct: float = _NEAR_CAP_PCT,
     blocked_5h_pct: float = _BLOCKED_5H_PCT,
+    expiring_horizon_s: float = EXPIRING_7D_HORIZON_S,
     spread_key: str | None = None,
 ) -> str:
     """Return the stored-account name an agent should run on right now.
@@ -311,10 +319,17 @@ def pick_healthy_account(
         :func:`._quota_rank.account_5h_usage` /
         :func:`._quota_rank.account_7d_usage`. A missing key / missing
         cache reads as "unknown" → per-account degradation.
+    reset_7d
+        Test-injectable per-account 7d-window reset stamp (name → ISO
+        string or epoch seconds). ``None`` (the boot path) reads
+        ``reset_at_7d`` from the same cache. This is what separates
+        "90%, resets in 6 minutes" (expiring — spend it, it is about to
+        be deleted) from "90%, resets in 6 days" (a reserve — leave
+        it). Unknown → the reset-unaware behaviour, unchanged.
     quota_cache_path
         Override the quota-cache path (passed through to
         :func:`_account.quota_cache.read_quota_entry`). Ignored when
-        the corresponding ``usage_*`` override is given.
+        the corresponding ``usage_*`` / ``reset_7d`` override is given.
     near_cap_pct
         The 7d % at/above which an account is "near-capped — avoid
         unless no better fresh alternative". Defaults to
@@ -323,6 +338,12 @@ def pick_healthy_account(
         The 5h % at/above which an account is "blocked-now — cannot
         serve requests until its 5h window resets". Defaults to
         :data:`._quota_rank.BLOCKED_5H_PCT` (95). Exposed for tests.
+    expiring_horizon_s
+        Seconds-to-7d-reset at/below which a near-capped account's
+        remainder counts as EXPIRING rather than scarce. Defaults to
+        :data:`._quota_rank.EXPIRING_7D_HORIZON_S` (2h) — the knob that
+        bounds how long an agent could sit at the cap if it drains the
+        remainder before the reset. Exposed for tests / tuning.
     spread_key
         Fleet load-balancing key — pass the AGENT NAME so concurrent
         boots of *different* agents spread across the eligible accounts
@@ -403,6 +424,17 @@ def pick_healthy_account(
         )
         for h in fresh
     }
+    # WHEN each 7d window resets — the axis that tells quota which is
+    # about to be DELETED from quota which is a reserve. Unknown for a
+    # cache written before the populator persisted it: every consumer
+    # then degrades to the reset-unaware ranking (see is_expiring_7d).
+    r7: dict[str, float | None] = {
+        h.name: account_7d_reset_at(
+            h.name, reset_7d=reset_7d, quota_cache_path=quota_cache_path
+        )
+        for h in fresh
+    }
+    probe_now = now if now is not None else time.time()
 
     # 1. Preferred wins when it is fresh AND not blocked-now (5h) AND
     #    not near-capped (7d); unknown quota keeps it (degrade to
@@ -414,22 +446,40 @@ def pick_healthy_account(
             pref_5h = u5.get(pref)
             pref_7d = u7.get(pref)
             blocked_now = pref_5h is not None and pref_5h >= blocked_5h_pct
-            near_capped = pref_7d is not None and pref_7d >= near_cap_pct
+            # An EXPIRING window is not a scarce one — the same rule the
+            # ranking applies (RULE 1). Without this an agent pinned to
+            # the very account whose quota is about to evaporate would be
+            # rotated OFF it minutes before the reset, which is the waste
+            # this change exists to stop, just via the other code path.
+            near_capped = (
+                pref_7d is not None
+                and pref_7d >= near_cap_pct
+                and not is_expiring_7d(
+                    pref_7d,
+                    r7.get(pref),
+                    probe_now,
+                    horizon_s=expiring_horizon_s,
+                )
+            )
             if not blocked_now and not near_capped:
                 return pref
 
     # 2. Otherwise the conditional ranking picks among the fresh set —
-    #    unblocked beats 5h-blocked, headroom beats near-capped, and a
-    #    spread_key load-balances the winning tier across the fleet.
-    #    Quota is a preference, not a hard gate: an all-blocked fleet
-    #    still returns the least-bad fresh account.
+    #    unblocked beats 5h-blocked, headroom beats near-capped, expiring
+    #    capacity is spent before a persisting reserve, and a spread_key
+    #    load-balances the winning tier across the fleet. Quota is a
+    #    preference, not a hard gate: an all-blocked fleet still returns
+    #    the least-bad fresh account.
     return pick_ranked(
         [h.name for h in fresh],
         u5,
         u7,
+        reset_7d=r7,
+        now=probe_now,
         spread_key=spread_key,
         near_cap_pct=near_cap_pct,
         blocked_5h_pct=blocked_5h_pct,
+        expiring_horizon_s=expiring_horizon_s,
     )
 
 

--- a/src/scitex_agent_container/_creds/_quota_rank.py
+++ b/src/scitex_agent_container/_creds/_quota_rank.py
@@ -28,6 +28,24 @@ The two quota axes mean different things and need different rules:
   :data:`NEAR_CAP_7D_PCT` avoidance, plus a *weight* for spreading:
   more weekly headroom → proportionally more of the fleet.
 
+Expiring capacity — the third axis (2026-07-14)
+-----------------------------------------------
+A utilisation % alone is NOT a decision. The ranker scored "90%, resets
+in 6 minutes" and "90%, resets in 6 days" identically and avoided both,
+but they are opposites: the first is quota that is about to be DELETED,
+the second is a genuine reserve. So every cycle the fleet binned the
+last ~10% of a 7-day window unused (operator: 「毎回 90%で10%捨ててる」).
+
+The window's reset time — already fetched from the usage API and shown
+by ``sac accounts list`` — was simply never persisted into the cache the
+picker reads. It is now (``reset_at_7d``; see
+:func:`_account.quota_cache_refresh.refresh_quota_cache`), and
+:func:`is_expiring_7d` turns it into the missing distinction:
+near-capped-but-expiring stops being *avoided* (it is not scarce) and
+starts being *preferred* (spend what vanishes before what persists).
+The preference is expressed as a spread WEIGHT, not a hard tier, so it
+cannot re-create the stacking incident below.
+
 Ranking (lexicographic tiers, then in-tier choice)
 --------------------------------------------------
 Fresh candidates are partitioned by ``(blocked_now, near_capped_7d,
@@ -54,6 +72,8 @@ from __future__ import annotations
 
 import hashlib
 import math
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Mapping
 
@@ -71,6 +91,41 @@ NEAR_CAP_7D_PCT = 90.0
 # at the wall by boot time. Also a preference (an all-blocked fleet
 # still boots on the least-bad account), never a hard gate.
 BLOCKED_5H_PCT = 95.0
+
+# --- Expiring-capacity ("use it or lose it") ------------------------------
+#
+# Seconds-to-7d-reset at/below which a near-capped account's REMAINING
+# quota is reclassified from "scarce reserve" to "about to be deleted".
+#
+# Why 2h (and not "any account that will reset eventually"): the ONLY
+# reason to avoid a near-capped account is that an agent parked there
+# would burn the remainder and then be stuck until the window resets.
+# The cost of being wrong is therefore bounded by TIME-TO-RESET — so
+# that is exactly what we bound. 2h keeps the worst-case "stuck at the
+# cap" exposure short while still giving the fleet a real drain window
+# before every reset (each account passes through it once per cycle).
+# Widen it to drain more aggressively; the 429 exposure scales with it.
+EXPIRING_7D_HORIZON_S = 2.0 * 3600.0
+
+# An account must retain at least this much 7d headroom to count as
+# "expiring capacity worth spending". Without this floor a FULLY
+# exhausted account (d7 == 100) resetting in 5 minutes would look like
+# free capacity and we would route work onto an account that 429s on
+# its very first request — burning the "expiring" preference for
+# nothing. There is no capacity to reclaim below this line.
+EXPIRING_MIN_HEADROOM_PCT = 2.0
+
+# Multiplier applied to an expiring account's rendezvous-hash WEIGHT.
+#
+# This is the load-balancing-safe expression of "prefer expiring
+# capacity": a boosted weight makes the fleet drain the vanishing quota
+# FASTER without making it the single winner for every agent. Promoting
+# expiring accounts to their own hard TIER instead would put every
+# booting agent on one account holding ~10% of a week — precisely the
+# stacking incident this module was written to prevent (see the module
+# docstring). Weight ∝ headroom keeps each account's share bounded by
+# the capacity it actually has.
+EXPIRING_WEIGHT_BOOST = 4.0
 
 
 def _coerce_pct(value: object) -> float | None:
@@ -137,6 +192,96 @@ def account_7d_usage(
     )
 
 
+def _coerce_epoch(value: object) -> float | None:
+    """Return *value* as epoch seconds, or ``None`` if unparseable.
+
+    Tolerant on purpose — the quota cache stores the reset stamp as the
+    upstream ISO-8601 string (``reset_at_7d``), but tests and callers
+    find raw epoch floats easier to reason about, so both are accepted.
+    A naive (tz-less) ISO stamp is read as UTC, matching
+    :func:`cli_pkg._account_list_format._coerce_dt`.
+    """
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    # stx-allow: fallback (reason: a malformed cache timestamp must degrade to
+    # "reset unknown" — i.e. the pre-existing behaviour — never crash a boot.)
+    try:
+        dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def account_7d_reset_at(
+    name: str,
+    *,
+    reset_7d: Mapping[str, object] | None = None,
+    quota_cache_path: Path | str | None = None,
+) -> float | None:
+    """One account's 7d-window reset time as epoch seconds, or ``None``.
+
+    Reads the ``reset_at_7d`` field the quota-cache populator persists
+    (:func:`_account.quota_cache_refresh.refresh_quota_cache`). ``None``
+    for a cache written BEFORE that field existed — which is exactly why
+    every consumer below must degrade to the reset-unaware behaviour
+    rather than assume "unknown reset" means "resets now".
+    """
+    if reset_7d is not None:
+        return _coerce_epoch(reset_7d.get(name))
+    entry = read_quota_entry(account=name, cache_path=quota_cache_path)
+    if entry is None:
+        return None
+    return _coerce_epoch(entry.get("reset_at_7d"))
+
+
+def is_expiring_7d(
+    d7: float | None,
+    reset_at: float | None,
+    now: float,
+    *,
+    horizon_s: float = EXPIRING_7D_HORIZON_S,
+    min_headroom_pct: float = EXPIRING_MIN_HEADROOM_PCT,
+) -> bool:
+    """Is this account's remaining 7d quota USE-IT-OR-LOSE-IT right now?
+
+    The distinction the ranker was missing (operator, 2026-07-14: 「毎回
+    90%で10%捨ててる」). ``d7 = 90%`` means two OPPOSITE things depending
+    on a number the ranker never looked at:
+
+    * **90%, resets in 6 days** — a genuine reserve. Spend it and the
+      fleet is stuck without weekly budget. Avoiding it is CORRECT.
+    * **90%, resets in 6 minutes** — the remaining 10% is about to be
+      DELETED. Avoiding it burns the capacity for nothing.
+
+    Only the second is "expiring". Returns ``True`` only when all hold:
+
+    * the 7d utilisation is KNOWN (an unknown % cannot be reasoned about);
+    * the reset stamp is KNOWN and lies within ``horizon_s`` — an unknown
+      or already-past stamp returns ``False``, i.e. the pre-existing
+      near-cap avoidance, so a stale/old cache is never *more* risky than
+      today's behaviour;
+    * at least ``min_headroom_pct`` of the window remains — there is no
+      capacity to reclaim from an account that is already at the wall.
+
+    Deliberately says nothing about the 5h window: that is the IMMEDIATE
+    throttle and stays a separate, supreme tier in :func:`pick_ranked`.
+    An expiring account that is 5h-blocked still loses — it cannot serve
+    a request *now* no matter how soon its weekly budget refreshes.
+    """
+    if d7 is None or reset_at is None:
+        return False
+    secs_to_reset = reset_at - now
+    if secs_to_reset < 0.0 or secs_to_reset > horizon_s:
+        return False
+    return d7 <= 100.0 - min_headroom_pct
+
+
 def _hrw_score(spread_key: str, name: str, weight: float) -> float:
     """Weighted rendezvous (HRW) score for one (agent, account) pair.
 
@@ -157,23 +302,57 @@ def pick_ranked(
     usage_5h: Mapping[str, float | None],
     usage_7d: Mapping[str, float | None],
     *,
+    reset_7d: Mapping[str, object] | None = None,
+    now: float | None = None,
     spread_key: str | None = None,
     near_cap_pct: float = NEAR_CAP_7D_PCT,
     blocked_5h_pct: float = BLOCKED_5H_PCT,
+    expiring_horizon_s: float = EXPIRING_7D_HORIZON_S,
 ) -> str:
     """Return the best account among *names* (all token-fresh, non-empty).
 
     ``usage_5h`` / ``usage_7d`` map each name to its cached utilisation
-    % or ``None`` (unknown). See the module docstring for the tier
-    rules; this never raises on quota state (fail-loud for "nothing
-    fresh" lives in the caller).
+    % or ``None`` (unknown). ``reset_7d`` maps each name to its 7d-window
+    reset stamp (ISO string or epoch seconds; ``None``/absent = unknown).
+    See the module docstring for the tier rules; this never raises on
+    quota state (fail-loud for "nothing fresh" lives in the caller).
+
+    Expiring capacity (see :func:`is_expiring_7d`) enters the ranking in
+    exactly two places, and NOWHERE else:
+
+    1. it SUPPRESSES the ``near_capped`` demotion — quota that is about
+       to be deleted is expiring, not scarce, so the account competes on
+       equal footing instead of being avoided;
+    2. it BOOSTS the account's spread weight (and sorts first in the
+       no-spread order) — we spend what is about to vanish before we
+       spend a reserve that persists.
+
+    ``blocked_now`` (the 5h window) is untouched and still dominates
+    both: an account that cannot serve a request *now* is never picked
+    over one that can, however soon its weekly budget refreshes.
+
+    With no ``reset_7d`` data (a cache predating the field) every
+    account reads "reset unknown" → ``is_expiring_7d`` is ``False``
+    everywhere → this function behaves EXACTLY as it did before.
     """
+    _now = now if now is not None else time.time()
+    _resets: Mapping[str, object] = reset_7d if reset_7d is not None else {}
+
+    def expiring(name: str) -> bool:
+        return is_expiring_7d(
+            usage_7d.get(name),
+            _coerce_epoch(_resets.get(name)),
+            _now,
+            horizon_s=expiring_horizon_s,
+        )
 
     def tier(name: str) -> tuple[bool, bool, bool]:
         h5 = usage_5h.get(name)
         d7 = usage_7d.get(name)
         blocked_now = h5 is not None and h5 >= blocked_5h_pct
-        near_capped = d7 is not None and d7 >= near_cap_pct
+        # RULE 1 — an expiring window is NOT a scarce one. Its remaining
+        # quota evaporates at the reset whether we spend it or not.
+        near_capped = d7 is not None and d7 >= near_cap_pct and not expiring(name)
         return (blocked_now, near_capped, d7 is None)
 
     best = min(tier(n) for n in names)
@@ -185,20 +364,26 @@ def pick_ranked(
 
         def weight(name: str) -> float:
             d7 = usage_7d.get(name)
-            if d7 is None:
-                return 1.0
-            return max(1.0, 100.0 - d7)
+            base = 1.0 if d7 is None else max(1.0, 100.0 - d7)
+            # RULE 2 (fleet path) — drain vanishing capacity faster, but
+            # as a WEIGHT, never a hard tier: the account still takes a
+            # bounded share proportional to what it actually holds, so a
+            # bulk restart cannot stack the whole fleet onto a window
+            # with 10% left.
+            return base * EXPIRING_WEIGHT_BOOST if expiring(name) else base
 
         return max(group, key=lambda n: _hrw_score(spread_key, n, weight(n)))
 
-    # Legacy deterministic order (no spread requested): most 7d headroom,
-    # then most 5h headroom, then candidate order. Unknowns sort last via
-    # +inf so a known value always wins inside the tie-break.
-    def sort_key(item: tuple[int, str]) -> tuple[float, float, int]:
+    # Legacy deterministic order (no spread requested): expiring capacity
+    # first (RULE 2 — spend what vanishes before what persists), then most
+    # 7d headroom, then most 5h headroom, then candidate order. Unknowns
+    # sort last via +inf so a known value always wins inside the tie-break.
+    def sort_key(item: tuple[int, str]) -> tuple[int, float, float, int]:
         idx, name = item
         d7 = usage_7d.get(name)
         h5 = usage_5h.get(name)
         return (
+            0 if expiring(name) else 1,
             d7 if d7 is not None else math.inf,
             h5 if h5 is not None else math.inf,
             idx,
@@ -209,8 +394,13 @@ def pick_ranked(
 
 __all__ = [
     "BLOCKED_5H_PCT",
+    "EXPIRING_7D_HORIZON_S",
+    "EXPIRING_MIN_HEADROOM_PCT",
+    "EXPIRING_WEIGHT_BOOST",
     "NEAR_CAP_7D_PCT",
     "account_5h_usage",
+    "account_7d_reset_at",
     "account_7d_usage",
+    "is_expiring_7d",
     "pick_ranked",
 ]

--- a/tests/scitex_agent_container/_account/test_quota_cache_refresh.py
+++ b/tests/scitex_agent_container/_account/test_quota_cache_refresh.py
@@ -97,8 +97,61 @@ def test_refresh_entry_carries_h5_d7_and_ttl(tmp_path: Path) -> None:
         now=_NOW,
     )
     entry = read_quota_entry(account="ywatanabe-scitex-ai", cache_path=cache)
+    # Assert — the reset stamps are part of the entry shape now (None here:
+    # this fetcher's response omits them, which must stay a usable entry).
+    assert entry == {
+        "short": "ywatanabe",
+        "h5": 19.0,
+        "d7": 3.0,
+        "ttl_h": 7.5,
+        "reset_at_5h": None,
+        "reset_at_7d": None,
+    }
+
+
+def test_refresh_persists_the_7d_reset_stamp_for_the_picker(tmp_path: Path) -> None:
+    # Arrange — the usage API returns `resets_at` for both windows and
+    # `claude_usage` already parses it into reset_at_5h / reset_at_7d. The
+    # populator used to DROP it here, which left the account picker unable
+    # to tell expiring quota from a reserve (it binned ~10% of every 7d
+    # window). It must round-trip into the cache the picker reads.
+    store = tmp_path / "store"
+    _make_account(store, "ywatanabe-scitex-ai", ttl_hours=7.5)
+    cache = tmp_path / "quota-cache.json"
+    usage = _ok(0.0, 90.0)
+    usage["reset_at_7d"] = "2026-07-14T09:00:00+00:00"
+    fetch = _fetcher({"ywatanabe-scitex-ai": usage})
+    # Act
+    refresh_quota_cache(
+        home=tmp_path,
+        store_dir=store,
+        cache_path=cache,
+        usage_fetcher=fetch,
+        now=_NOW,
+    )
+    entry = read_quota_entry(account="ywatanabe-scitex-ai", cache_path=cache)
     # Assert
-    assert entry == {"short": "ywatanabe", "h5": 19.0, "d7": 3.0, "ttl_h": 7.5}
+    assert entry is not None and entry["reset_at_7d"] == "2026-07-14T09:00:00+00:00"
+
+
+def test_refresh_keeps_entry_usable_when_upstream_omits_reset(tmp_path: Path) -> None:
+    # Arrange — the reset stamps are OPTIONAL, unlike h5/d7/ttl_h: a response
+    # without them must still yield a cached entry (the picker just degrades
+    # to its reset-unaware ranking), never blank the account.
+    store = tmp_path / "store"
+    _make_account(store, "a-gmail-com", ttl_hours=3.0)
+    cache = tmp_path / "quota-cache.json"
+    fetch = _fetcher({"a-gmail-com": _ok(5.0, 1.0)})
+    # Act
+    result = refresh_quota_cache(
+        home=tmp_path,
+        store_dir=store,
+        cache_path=cache,
+        usage_fetcher=fetch,
+        now=_NOW,
+    )
+    # Assert
+    assert result["ok"] == 1
 
 
 def test_refresh_reports_ok_count(tmp_path: Path) -> None:

--- a/tests/scitex_agent_container/_creds/test__quota_rank.py
+++ b/tests/scitex_agent_container/_creds/test__quota_rank.py
@@ -9,11 +9,14 @@ descriptive names (TQ003), one assertion per test (TQ007).
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 from scitex_agent_container._creds._quota_rank import (
     account_5h_usage,
+    account_7d_reset_at,
     account_7d_usage,
+    is_expiring_7d,
     pick_ranked,
 )
 
@@ -178,3 +181,294 @@ def test_pick_ranked_spread_weights_toward_more_7d_headroom() -> None:
     ]
     # Assert
     assert picks.count("acct-b") > picks.count("acct-a")
+
+
+# ---------------------------------------------------------------------------
+# pick_ranked — EXPIRING capacity (use-it-or-lose-it)
+#
+# The operator's LIVE account table, 2026-07-14 (`sac accounts list`):
+#
+#   wyusuuke-gmail-com   5h 28%   7d 67%  (resets in 5d 14h)
+#   ywata1989-gmail-com  5h  0%   7d 90%  (resets in 9h06m)
+#   ywatanabe-scitex-ai  5h  0%   7d 90%  (resets in 6 MINUTES)
+#
+# ywatanabe-scitex-ai holds 10% of a 7-day Max-20x window that is about
+# to be DELETED. The reset-blind ranker scored it identically to a 90%
+# account with 6 days left, demoted both as "near-capped", and picked
+# wyusuuke — binning the 10%. 「毎回 90%で10%捨ててる」
+# ---------------------------------------------------------------------------
+
+_NOW = 1_780_000_000.0
+_HOUR = 3600.0
+
+_LIVE = ["wyusuuke-gmail-com", "ywata1989-gmail-com", "ywatanabe-scitex-ai"]
+_LIVE_5H = {
+    "wyusuuke-gmail-com": 28.0,
+    "ywata1989-gmail-com": 0.0,
+    "ywatanabe-scitex-ai": 0.0,
+}
+_LIVE_7D = {
+    "wyusuuke-gmail-com": 67.0,
+    "ywata1989-gmail-com": 90.0,
+    "ywatanabe-scitex-ai": 90.0,
+}
+_LIVE_RESET = {
+    "wyusuuke-gmail-com": _NOW + 5 * 24 * _HOUR + 14 * _HOUR,  # 5d 14h
+    "ywata1989-gmail-com": _NOW + 9 * _HOUR + 6 * 60.0,  # 9h06m
+    "ywatanabe-scitex-ai": _NOW + 6 * 60.0,  # 6 MINUTES
+}
+
+
+def test_pick_ranked_spends_the_7d_window_that_resets_in_minutes() -> None:
+    # Arrange — the operator's live table (above), reset stamps included.
+    # Act
+    picked = pick_ranked(_LIVE, _LIVE_5H, _LIVE_7D, reset_7d=_LIVE_RESET, now=_NOW)
+    # Assert — the 10% about to evaporate is SPENT, not binned.
+    assert picked == "ywatanabe-scitex-ai"
+
+
+def test_pick_ranked_bins_expiring_quota_when_reset_is_unknown() -> None:
+    # Arrange — the SAME live table with no reset data (a quota cache
+    # written before the populator persisted `reset_at_7d`). This pins the
+    # pre-change behaviour: unknown reset must degrade EXACTLY to it, never
+    # guess. It is also the bug the operator reported, in one line.
+    # Act
+    picked = pick_ranked(_LIVE, _LIVE_5H, _LIVE_7D, now=_NOW)
+    # Assert
+    assert picked == "wyusuuke-gmail-com"
+
+
+def test_pick_ranked_routes_fleet_to_the_expiring_account_on_the_spread_path() -> None:
+    # Arrange — the SHIPPING path: `_start_preflight` always passes
+    # spread_key=<agent name>, so this (not the legacy order) is what a real
+    # boot takes. Before the fix the expiring account was demoted out of the
+    # winning tier entirely and received EXACTLY ZERO agents.
+    fleet = [f"agent-{i}" for i in range(60)]
+    # Act
+    picks = [
+        pick_ranked(
+            _LIVE, _LIVE_5H, _LIVE_7D, reset_7d=_LIVE_RESET, now=_NOW, spread_key=key
+        )
+        for key in fleet
+    ]
+    # Assert
+    assert picks.count("ywatanabe-scitex-ai") > 0
+
+
+def test_pick_ranked_spread_never_routes_to_the_far_out_reserve() -> None:
+    # Arrange — ywata1989 is at 90% with 9h left: a genuine weekly reserve.
+    # It must stay demoted even while the fleet drains the expiring account.
+    fleet = [f"agent-{i}" for i in range(60)]
+    # Act
+    picks = [
+        pick_ranked(
+            _LIVE, _LIVE_5H, _LIVE_7D, reset_7d=_LIVE_RESET, now=_NOW, spread_key=key
+        )
+        for key in fleet
+    ]
+    # Assert
+    assert picks.count("ywata1989-gmail-com") == 0
+
+
+def test_pick_ranked_still_avoids_a_near_capped_account_resetting_far_out() -> None:
+    # Arrange — ywata1989 is ALSO at 90%, but its window has 9h left: a
+    # genuine reserve, not expiring capacity. Drop the truly-expiring
+    # account so the reserve is the only near-capped candidate left.
+    names = ["wyusuuke-gmail-com", "ywata1989-gmail-com"]
+    # Act
+    picked = pick_ranked(names, _LIVE_5H, _LIVE_7D, reset_7d=_LIVE_RESET, now=_NOW)
+    # Assert — avoiding a real reserve stays correct.
+    assert picked == "wyusuuke-gmail-com"
+
+
+def test_pick_ranked_keeps_avoiding_expiring_account_blocked_on_5h() -> None:
+    # Arrange — expiring 7d window, but the 5h wall is hit: it 429s NOW,
+    # however soon its weekly budget refreshes. The immediate throttle
+    # must still dominate.
+    usage_5h = {"acct-expiring": 99.0, "acct-reserve": 10.0}
+    usage_7d = {"acct-expiring": 90.0, "acct-reserve": 40.0}
+    reset_7d = {"acct-expiring": _NOW + 300.0, "acct-reserve": _NOW + 6 * 24 * _HOUR}
+    # Act
+    picked = pick_ranked(
+        ["acct-expiring", "acct-reserve"], usage_5h, usage_7d,
+        reset_7d=reset_7d, now=_NOW,
+    )
+    # Assert
+    assert picked == "acct-reserve"
+
+
+def test_pick_ranked_ignores_expiring_account_with_no_headroom_left() -> None:
+    # Arrange — 100% of the 7d window used and resetting in 5 minutes.
+    # There is no capacity to reclaim; routing here would just 429.
+    usage_7d = {"acct-exhausted": 100.0, "acct-reserve": 40.0}
+    reset_7d = {"acct-exhausted": _NOW + 300.0, "acct-reserve": _NOW + 6 * 24 * _HOUR}
+    # Act
+    picked = pick_ranked(
+        ["acct-exhausted", "acct-reserve"], {}, usage_7d, reset_7d=reset_7d, now=_NOW
+    )
+    # Assert
+    assert picked == "acct-reserve"
+
+
+def test_pick_ranked_treats_an_already_past_reset_stamp_as_unknown() -> None:
+    # Arrange — a STALE cache: the stamp says the window reset already, so
+    # the 90% reading cannot be trusted either. Degrade to avoidance rather
+    # than route onto an account we can no longer reason about.
+    usage_7d = {"acct-stale": 90.0, "acct-reserve": 40.0}
+    reset_7d = {"acct-stale": _NOW - 600.0, "acct-reserve": _NOW + 6 * 24 * _HOUR}
+    # Act
+    picked = pick_ranked(
+        ["acct-stale", "acct-reserve"], {}, usage_7d, reset_7d=reset_7d, now=_NOW
+    )
+    # Assert
+    assert picked == "acct-reserve"
+
+
+def test_pick_ranked_accepts_an_iso_reset_stamp_from_the_cache() -> None:
+    # Arrange — the cache persists the upstream ISO-8601 string, not an
+    # epoch, so the ranker must read that shape natively.
+    usage_7d = {"acct-expiring": 90.0, "acct-reserve": 40.0}
+    reset_7d = {
+        "acct-expiring": "2026-06-01T00:30:00Z",
+        "acct-reserve": "2026-06-08T00:00:00Z",
+    }
+    now = datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc).timestamp()  # 30m before
+    # Act
+    picked = pick_ranked(
+        ["acct-expiring", "acct-reserve"], {}, usage_7d, reset_7d=reset_7d, now=now
+    )
+    # Assert
+    assert picked == "acct-expiring"
+
+
+# ---------------------------------------------------------------------------
+# pick_ranked — expiring capacity must NOT re-create the stacking incident
+#
+# Preferring expiring quota via a hard TIER would put EVERY booting agent
+# on one account holding ~10% of a week. The preference is a spread WEIGHT
+# instead, so the fleet drains it fast while still spreading.
+# ---------------------------------------------------------------------------
+
+_SPREAD_7D = {"acct-expiring": 90.0, "acct-reserve": 60.0}
+_SPREAD_RESET = {
+    "acct-expiring": _NOW + 10 * 60.0,
+    "acct-reserve": _NOW + 5 * 24 * _HOUR,
+}
+
+
+def _spread_picks(n: int) -> list[str]:
+    return [
+        pick_ranked(
+            ["acct-expiring", "acct-reserve"],
+            {},
+            _SPREAD_7D,
+            reset_7d=_SPREAD_RESET,
+            now=_NOW,
+            spread_key=f"agent-{i}",
+        )
+        for i in range(n)
+    ]
+
+
+def test_pick_ranked_spread_drains_the_expiring_account_with_the_majority() -> None:
+    # Arrange
+    fleet_size = 100
+    # Act
+    picks = _spread_picks(fleet_size)
+    # Assert — vanishing capacity is spent before the persisting reserve.
+    assert picks.count("acct-expiring") > picks.count("acct-reserve")
+
+
+def test_pick_ranked_spread_does_not_stack_the_whole_fleet_on_expiring() -> None:
+    # Arrange
+    fleet_size = 100
+    # Act
+    picks = _spread_picks(fleet_size)
+    # Assert — the reserve still serves a real share: an account with 10%
+    # of a week left must not absorb an entire fleet restart.
+    assert picks.count("acct-reserve") > 0
+
+
+# ---------------------------------------------------------------------------
+# is_expiring_7d — the predicate itself
+# ---------------------------------------------------------------------------
+
+
+def test_is_expiring_7d_true_for_near_capped_window_resetting_in_minutes() -> None:
+    # Arrange
+    resets_in_6_minutes = _NOW + 6 * 60.0
+    # Act
+    verdict = is_expiring_7d(90.0, resets_in_6_minutes, _NOW)
+    # Assert
+    assert verdict is True
+
+
+def test_is_expiring_7d_false_for_same_pct_resetting_days_out() -> None:
+    # Arrange — 90% with 6 days left is a RESERVE, not expiring capacity.
+    resets_in_6_days = _NOW + 6 * 24 * _HOUR
+    # Act
+    verdict = is_expiring_7d(90.0, resets_in_6_days, _NOW)
+    # Assert
+    assert verdict is False
+
+
+def test_is_expiring_7d_false_when_reset_stamp_is_unknown() -> None:
+    # Arrange
+    reset_unknown = None
+    # Act
+    verdict = is_expiring_7d(90.0, reset_unknown, _NOW)
+    # Assert
+    assert verdict is False
+
+
+def test_is_expiring_7d_false_when_no_headroom_remains() -> None:
+    # Arrange — nothing left to reclaim; routing here only buys a 429.
+    fully_used_pct = 100.0
+    # Act
+    verdict = is_expiring_7d(fully_used_pct, _NOW + 300.0, _NOW)
+    # Assert
+    assert verdict is False
+
+
+# ---------------------------------------------------------------------------
+# account_7d_reset_at — cache field reader
+# ---------------------------------------------------------------------------
+
+
+def test_account_7d_reset_at_reads_reset_at_7d_field_from_cache(tmp_path: Path) -> None:
+    # Arrange
+    cache = tmp_path / "quota-cache.json"
+    cache.write_text(
+        json.dumps(
+            {
+                "written_at": 1.0,
+                "accounts": {
+                    "ywatanabe@scitex.ai": {
+                        "short": "ywatanabe",
+                        "h5": 0.0,
+                        "d7": 90.0,
+                        "ttl_h": 7.9,
+                        "reset_at_7d": "2026-06-01T00:00:00Z",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    expected = datetime(2026, 6, 1, tzinfo=timezone.utc).timestamp()
+    # Act
+    reset_at = account_7d_reset_at("ywatanabe-scitex-ai", quota_cache_path=cache)
+    # Assert
+    assert reset_at == expected
+
+
+def test_account_7d_reset_at_is_none_for_a_cache_without_the_field(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the pre-change cache shape (short/h5/d7/ttl_h only). It must
+    # still parse; the picker just degrades to its reset-unaware ranking.
+    cache = _write_cache(tmp_path)
+    # Act
+    reset_at = account_7d_reset_at("wyusuuke-gmail-com", quota_cache_path=cache)
+    # Assert
+    assert reset_at is None


### PR DESCRIPTION
## The operator's live account table

```
wyusuuke-gmail-com   5h 28%   7d 67%  (resets in 5d 14h)
ywata1989-gmail-com  5h  0%   7d 90%  (resets in 9h06m)
ywatanabe-scitex-ai  5h  0%   7d 90%  (resets in 6 MINUTES)   <- 10% about to evaporate
Fleet 7d capacity used: 82%
```

The picker assigned **wyusuuke** (67%). So `ywatanabe-scitex-ai`'s remaining **10% of a
7-day Max-20x window was DELETED unused six minutes later.** Operator:
「毎回 90%で10%捨ててる」 — every cycle we bin it.

## Root cause

`_creds/_quota_rank.py::pick_ranked` **had no notion of when a window resets.** It scored
`90%, resets in 6 minutes` and `90%, resets in 6 days` *identically* and avoided both. But
they are opposites:

- **90% with 6 days left** = a genuine reserve. Avoiding it is CORRECT (you would exhaust it and be stuck).
- **90% with 6 minutes left** = **use-it-or-lose-it.** Avoiding it BURNS THE CAPACITY FOR NOTHING.

**The reset timestamp was not merely ignored — it was _unreachable from the picker_.** This
is worth stating precisely, because it changed the shape of the fix:

- the usage API **does** return `resets_at` for both windows, and `_account/claude_usage.py`
  **already parses** it into `reset_at_5h` / `reset_at_7d`;
- but `_account/quota_cache_refresh.py` **dropped both fields when writing the aggregate
  `quota-cache.json` that the picker reads** (entry shape was `{short, h5, d7, ttl_h}`);
- `sac accounts list` renders "resets in …" from a **different** cache — the per-account
  `usage.json` — which is exactly why the number was visible to the human and invisible to
  the ranker.

So the fix had to *persist* the stamp before it could *rank* on it.

## What changed

1. **`quota_cache_refresh`** now persists `reset_at_5h` / `reset_at_7d` into the aggregate
   cache. Additive and **optional**: an entry stays usable when upstream omits them, so a
   single upstream field change can never blank the cache.
2. **`_quota_rank.is_expiring_7d`** makes time-to-reset a first-class ranking input. An
   imminently-resetting near-capped account is **expiring, not scarce**:
   - **RULE 1** — it no longer suffers the `near_capped` demotion (this alone is what the
     operator asked for as the minimum);
   - **RULE 2** — its rendezvous-hash **weight is boosted**, so the fleet spends vanishing
     capacity *before* a reserve that persists.
3. **`_pick_healthy`** applies the same predicate to the `preferred` account — otherwise an
   agent pinned to the very account whose quota is about to evaporate would be rotated *off*
   it minutes before the reset: the identical waste via the other code path.

An old cache with no reset stamps degrades to **exactly** the previous behaviour — "unknown
reset" is never read as "resets now".

## Effect on the table above

Measured on the live numbers (60-agent fleet, the shipping `spread_key` path):

| account | before | **after** |
|---|---|---|
| `ywatanabe-scitex-ai` — 90%, resets in **6 min** | **0 / 60** (binned) | **37 / 60** (drained) |
| `wyusuuke-gmail-com` — 67%, resets in 5d | 60 / 60 | 23 / 60 (still spread) |
| `ywata1989-gmail-com` — 90%, resets in **9h** | 0 / 60 | **0 / 60** (still avoided) |

The third row is the control: a 90% account that is **not** imminently resetting is still
treated as a reserve. This is not "stop avoiding near-capped accounts" — it is "stop
confusing expiring quota with scarce quota".

## The 429 risk, and how it is bounded

Routing an agent to a 90% account risks a 429 if it drains the last 10% before the reset —
and on this fleet a 429 has historically been rendered to the user as the lie
*"Login expired"*. So the preference is bounded five ways:

1. **The 5h window still dominates.** `blocked_now` is the untouched, supreme tier element.
   An account that cannot serve a request *now* is never preferred, however soon its weekly
   budget refreshes. `is_expiring_7d` deliberately says nothing about the 5h axis.
2. **Headroom floor (`EXPIRING_MIN_HEADROOM_PCT = 2%`).** An account with essentially nothing
   left is *not* expiring capacity — there is nothing to reclaim, and routing there buys a
   429 on the first request for zero gain.
3. **Short horizon (`EXPIRING_7D_HORIZON_S = 2h`).** The *only* reason to avoid a near-capped
   account is that an agent parked there could burn the remainder and be stuck **until the
   reset** — so the cost of being wrong is bounded by *time-to-reset*, and that is exactly
   what we bound. This is the single knob trading drain-rate against 429 exposure; widen it
   to drain more aggressively.
4. **Preference is a WEIGHT, not a tier.** Promoting expiring accounts into their own hard
   tier would put *every* booting agent on one account holding ~10% of a week — precisely the
   2026-07 stacking incident this module was written to prevent. As a weight, the account's
   share stays bounded by the capacity it actually has (23/60 agents still go to the reserve).
5. **sac already rotates on a 429 here — checked in source, not assumed.**
   `_account/rate_limit_classifier.py`: `HTTP_429` with `used_pct_7d >= 85` → `Mode.ROTATE`
   (not `BACKOFF`), and `_runners/_rate_limit_reactive.py` acts on it via
   `_account/rotate_account.py`. Crucially, `rotate_account` selects through
   `quota_watch._select_next_account`, which picks a healthy account **that is not the current
   one** — it does *not* re-enter this ranker — so a drained account **cannot thrash back onto
   itself**. sac rotates on a 429 at these levels; it does not die.

**What I could not determine, and therefore did not build:** the picker has **no signal for
expected work duration** (nothing on the spec, and neither `_start_preflight` call site passes
one), so I did **not** implement "short/bounded work prefers the expiring account while
long-running agents take a reserve". That would have required inventing a duration signal.
The five bounds above are the mitigation instead. If you want the duration split, the seam is
`pick_healthy_account(..., expiring_horizon_s=...)` — a caller that knows its job is short can
already widen the horizon per-boot.

## Tests — made to fail first

`pick_ranked` is exercised through its real seams (`usage_5h` / `usage_7d` / `reset_7d` / `now`);
no mocks, no live registry, tmp-only caches.

The new tests were run against a tree with **the new API but the three behavioural hunks
reverted**, to prove they detect the *ranking change* and not merely the added kwargs:

```
FAILED test_pick_ranked_spends_the_7d_window_that_resets_in_minutes
FAILED test_pick_ranked_accepts_an_iso_reset_stamp_from_the_cache
FAILED test_pick_ranked_spread_drains_the_expiring_account_with_the_majority
  E   AssertionError: assert 0 > 100     <- zero of 100 agents reached the expiring account
3 failed, 24 passed
```

The 24 that passed are the backward-compat and risk-bound cases — they pin behaviour that
must *not* change. Against the fix: **112 passed** (`_creds/`, `quota_cache_refresh`,
`quota_cache`), plus **54 passed** across the picker's consumers (`_start_preflight`,
`_start_creds_rotate`, `lifecycle`).

Note: `_lifecycle/test__broker_self.py` fails on **pristine `origin/develop`** too — verified
by running it against unmodified develop source. Pre-existing, unrelated to this change.
