### PR TITLE
fix(tests): 3 CI legs share ONE tmux socket — this is what failed the v0.21.16 release

### DIFF
--- a/tests/scitex_agent_container/_runners/_tmux/test__tmux_probe_batch.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test__tmux_probe_batch.py
@@ -21,8 +21,11 @@ STX-TQ002 AAA-markers each on its own line + STX-TQ007 one-assert.
 
 from __future__ import annotations
 
+import contextlib
+import os
 import shutil
 import subprocess
+import uuid
 
 import pytest
 
@@ -32,23 +35,52 @@ pytestmark = pytest.mark.skipif(
     shutil.which("tmux") is None, reason="tmux is not installed on this host"
 )
 
-# Private socket so the tests can never touch the operator's real tmux
-# server (which carries the live fleet's `tui-<agent>` sessions).
-SOCKET = "sac-probe-tests"
+# A tmux socket is keyed by (user, socket-NAME), never by process — so a LITERAL
+# name is a HOST-GLOBAL namespace shared with everything else running as us. Two
+# things live there. The obvious one is the operator's real fleet (the live
+# `tui-<agent>` sessions), which is why this socket is separate at all. The one
+# that bit us is our own sibling CI legs: the three matrix legs run CONCURRENTLY
+# as one user on ONE Spartan node (runners -01/-02/-03 are three registrations
+# of the same machine — the v0.21.16 release started all three at 23:24:23 and
+# overlapped them for seven minutes). A literal name put all three on a SINGLE
+# tmux server where they killed each other's sessions, and the two tests below
+# that assert an EXACT count ({} and len == 30) lost that race and failed the
+# release. The four that assert membership could not see it.
+#
+# This is the same dead invariant `.github/ci/exec-in-sif.sh` already documents:
+# "runs here are serialised (one job at a time)" stopped being true the day -02
+# and -03 were registered. That file removed its own dependence on it; nobody
+# grepped for the others, and this was one.
+#
+# Unique per PROCESS, so concurrent legs (and xdist workers) cannot meet. Orphan
+# servers self-reap: every session below runs `sleep`, and tmux exits with its
+# last session.
+SOCKET = f"sac-probe-tests-{os.getpid()}-{uuid.uuid4().hex[:8]}"
 
 
 def _tmux(*args: str) -> subprocess.CompletedProcess:
+    # 30s, not 10s. Three CI legs now share one node, so a `tmux` spawn competes
+    # for a loaded box's CPU; a deadline tight enough to blow under that load is
+    # a race, and blowing it here raises inside the FIXTURE — which reports as a
+    # broken test rather than a busy host. Observed once locally at load ~65.
     return subprocess.run(
-        ["tmux", "-L", SOCKET, *args], capture_output=True, text=True, timeout=10
+        ["tmux", "-L", SOCKET, *args], capture_output=True, text=True, timeout=30
     )
 
 
 @pytest.fixture()
 def tmux_server():
-    """A real, isolated tmux server; killed on teardown."""
+    """A real tmux server on a socket only this process can name."""
+    # SOCKET is per-process, so the tests in one process share a server: this
+    # kill is what isolates each test from the last one's sessions. It is NOT
+    # vestigial — dropping it lets test N inherit test N-1's fleet.
     _tmux("kill-server")
     yield _tmux
-    _tmux("kill-server")
+    # Teardown. A reap that cannot finish is not a test failure: the socket name
+    # is unique, so nothing else can collide with a leftover, and it self-reaps
+    # anyway (every session here runs `sleep`; tmux exits with its last one).
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        _tmux("kill-server")
 
 
 def _probe_on_socket(*, timeout_s: float = 5.0):


### PR DESCRIPTION
## What failed

The v0.21.16 release run: `test (3.11)` ✅ `test (3.12)` ✅ **`test (3.13)` ❌** → `build`/`publish`/`release` all SKIPPED → **PyPI is still on 0.21.14**. Third ghost tag.

```
FAILED test__tmux_probe_batch.py::test_no_tmux_server_is_a_confirmed_empty_fleet_not_unknown
FAILED test__tmux_probe_batch.py::test_one_probe_returns_every_live_session
2 failed, 9942 passed
```

## Root cause — the same dead invariant as #662

`SOCKET = "sac-probe-tests"` was a **literal**. A tmux socket is keyed by `(user, socket-NAME)`, **never by process** — so a literal name is a **host-global namespace**. Proven, not assumed: a wholly separate process sees all 3 sessions another process created on that socket.

The comment above it said the socket was *"private"*. It was — private from the **operator's** fleet. Not from **our own sibling CI legs**:

```
test (3.12)  runner=scitex-agent-container-03             23:24:23 -> 23:31:16  [success]
test (3.11)  runner=scitex-agent-container-02             23:24:23 -> 23:31:10  [success]
test (3.13)  runner=spartan-cpu-scitex-agent-container-01 23:24:23 -> 23:31:25  [failure]
```

All three started at **the same second** and overlapped for **seven minutes**. `-01/-02/-03` are three runner *registrations of one physical node*, same user. So all three legs drove **a single tmux server** and killed each other's sessions.

**Note which two tests failed:** the only two that assert an **exact global count** (`== {}` and `len == 30`). The four that assert *membership* structurally cannot see a collision. That asymmetry is the fingerprint.

`.github/ci/exec-in-sif.sh` **already documents this dead invariant**, in #662's own words:

> *"This block used to justify itself with: 'runs here are serialised (one job at a time)'. That WAS true when there was ONE runner. Then -02 and -03 were registered — and nobody re-checked the invariant this destructive action rests on."*

#662 removed **its own** dependence on it and nobody grepped for the others. This was one of the others.

## Fix

- **Socket name unique per process** (`pid` + `uuid`) — concurrent legs and xdist workers cannot meet. Orphans self-reap: every session is a `sleep`, and tmux exits with its last one.
- **Subprocess deadline 10s → 30s.** A fixed deadline tight enough to blow on a three-legs-at-once box is a race, and it raises inside the **fixture** — reporting as a broken test rather than a busy host. Observed once locally at load ~65.
- **A teardown reap that cannot finish is no longer a test error.**
- The fixture's *setup* `kill-server` is **kept** — the socket is per-process, so it is what isolates test N from test N-1's sessions. Not vestigial.

## Verification — measured, not asserted

| | old (literal socket) | new (unique socket) |
|---|---|---|
| 2 concurrent legs | **FAILED** — a sibling's `kill-server` destroyed the session under test | 6 passed, 6 passed |
| 3 concurrent legs (as Spartan runs them) | — | **6 passed, 6 passed, 6 passed** |
| serial | 6 passed | 6 passed |

## Swept for the same class

No other test names a host-global resource. The hardcoded ports (`7878`/`7901`) construct config objects and **never bind**; the `/tmp/...` paths are asserted-on strings, **never created**.