### PR TITLE
fix(a2a): a send that reached NOBODY reported SUCCESS — agents were silently swallowing each other's messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`a2a_send` reported SUCCESS for a message that reached nobody — agents were
+  silently swallowing each other's messages.** Reported by the `grant` agent,
+  who measured it live: of four peers that `a2a_peers` listed as running (pid,
+  port, start time, group `active`), two delivered and two had
+  `delivered_subscriber_count=0`. The tool *did* put "reached no live
+  subscriber" in its response **body** — but returned it as a plain
+  `list[TextContent]`, and the MCP low-level server stamps `isError=False` on
+  anything a handler returns that way. So the protocol classified the call as
+  successful. In grant's words: *"Had it returned a bare 200, I would have
+  believed the message landed and moved on. How many agent-to-agent messages
+  have been swallowed this way? Nobody would know."*
+
+  A 0-subscriber send is now an **MCP error** (`isError=True`), so a caller
+  cannot mistake it for delivery. It keeps the structured detail — target,
+  machine-readable `code`, subscriber count — and adds what to do instead.
+  Notably it does **not** tell you to re-send (sac persists to
+  `channel_events` *before* it publishes, and replays undelivered rows on the
+  target's next connect, so the message is queued, not lost — re-sending would
+  double-deliver), and it does **not** tell you to restart the target
+  (0 subscribers means a detached inbox adapter, not a dead agent).
+
+- **`GET /agents` (and so `a2a_peers`) conflated REGISTERED with REACHABLE.**
+  Every row said what the registry *declared* — a pid, a port, a group — and
+  nothing said whether a message would actually wake anybody. That signal was
+  load-bearing: the fleet constitution says to confirm a peer is "alive and
+  able to act" before handing it work, and `a2a_peers` is the tool provided to
+  do it. It answered yes for a deaf agent.
+
+  Rows now carry `inbox_subscribers` (live SSE subscribers on that agent's
+  inbox stream) and `inbox_reachable`, which is **ternary** on purpose:
+  `reachable` / `unreachable` / `unknown` — the last for a peer on another host
+  whose broker this listen cannot observe. "I could not check" is never
+  rendered as either success or death. Same fields on
+  `GET /agents/<name>/status` and in `sac agents health --json`.
+
+  `healthy` is deliberately **not** derived from the subscriber count, and
+  nothing auto-restarts on it. Measured during this investigation:
+  `claude-code-telegrammer`'s zero was a *transient* reconnect window on a
+  perfectly healthy agent — a restart would have destroyed a live session.
+
 ## [0.21.16] — 2026-07-14
 
 **⚠️ 0.21.15 WAS NEVER PUBLISHED — it is tagged, but nothing reached PyPI, and

--- a/src/scitex_agent_container/_lifecycle/inbox_probe.py
+++ b/src/scitex_agent_container/_lifecycle/inbox_probe.py
@@ -1,0 +1,89 @@
+"""Ask ``sac listen`` whether an agent's inbox adapter is actually attached.
+
+``sac agents health`` answers "is the process up?" (``health_check`` →
+``runtime.is_running``). That is a PID-shaped question, and a deaf agent
+passes it: its process is alive, its port is claimed, its registry row says
+``active`` — and every ``a2a_send`` aimed at it lands on a bus with zero
+subscribers and wakes nobody.
+
+So health reported green for agents that could not receive a single message.
+This probe adds the missing OBSERVATION next to the declaration, by asking
+the one component that actually knows: the broker inside ``sac listen``
+(via ``GET /agents/<name>/status``, which carries ``inbox_subscribers`` —
+see ``_listen/_reachability.py``).
+
+Two rules this module will not break
+------------------------------------
+1. **It never invents a verdict.** Every failure to observe — no listen
+   running, transport error, missing field, malformed body — returns
+   :data:`UNKNOWN`, never :data:`UNREACHABLE`. "I could not check" is not
+   evidence of deafness, and rendering it as such would slander healthy
+   agents.
+2. **It never feeds a restart.** The subscriber count is reported, and
+   that is ALL it does. ``healthy`` (which gates ``sac agents health``'s
+   exit code, and any automation keyed on it) is deliberately NOT derived
+   from it: 0 subscribers means an inbox adapter is detached, NOT that the
+   agent is dead, and auto-restarting on it would destroy a healthy session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+from .._listen._reachability import REACHABLE, UNKNOWN, UNREACHABLE
+
+__all__ = ["DEFAULT_LISTEN_URL", "probe_inbox_reachability"]
+
+DEFAULT_LISTEN_URL = "http://127.0.0.1:7878"
+
+# Short on purpose. This is an ADVISORY observation bolted onto a fast local
+# command; it must never be the reason `sac agents health` feels slow or
+# hangs. A listen that cannot answer in 2 s yields UNKNOWN, which is honest.
+_TIMEOUT_S = 2.0
+
+
+def _listen_base_url() -> str:
+    return os.environ.get("SAC_LISTEN_BASE_URL", DEFAULT_LISTEN_URL).rstrip("/")
+
+
+def probe_inbox_reachability(
+    name: str,
+    *,
+    listen_url: str | None = None,
+    bearer: str | None = None,
+    timeout_s: float = _TIMEOUT_S,
+) -> tuple[int | None, str]:
+    """Return ``(inbox_subscribers, inbox_reachable)`` for ``name``.
+
+    ``inbox_subscribers`` is the live SSE subscriber count on that agent's
+    inbox stream, or ``None`` when it could not be observed.
+    ``inbox_reachable`` is one of ``reachable`` / ``unreachable`` /
+    ``unknown`` (the vocabulary in :mod:`_listen._reachability`).
+
+    Never raises: every failure path degrades to ``(None, UNKNOWN)``.
+    """
+    base = (listen_url or _listen_base_url()).rstrip("/")
+    token = bearer if bearer is not None else os.environ.get("SAC_LISTEN_BEARER")
+    req = urllib.request.Request(f"{base}/agents/{name}/status", method="GET")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310
+            body = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError):  # stx-allow: fallback (reason: an unobservable listen must yield UNKNOWN — never a false 'unreachable' verdict against a healthy agent)
+        return None, UNKNOWN
+
+    if not isinstance(body, dict):
+        return None, UNKNOWN
+
+    count = body.get("inbox_subscribers")
+    if not isinstance(count, int) or isinstance(count, bool):
+        # Field absent (an older listen that predates the observation) or
+        # not an int. We did not observe a zero — we observed nothing.
+        return None, UNKNOWN
+
+    return count, (REACHABLE if count >= 1 else UNREACHABLE)

--- a/src/scitex_agent_container/_listen/_agents_list.py
+++ b/src/scitex_agent_container/_listen/_agents_list.py
@@ -1,0 +1,221 @@
+"""``GET /agents`` — the peer-discovery route (extracted from server.py).
+
+Backs the ``a2a_peers`` MCP tool: this is THE surface an agent consults to
+answer "is this peer alive and able to act?" before handing it work. It is
+therefore the surface where "registered" and "reachable" must not be
+conflated — see :mod:`._reachability` for why that conflation was a P1 bug
+(deaf agents advertising themselves as ``active`` while silently swallowing
+every message).
+
+Split out of :mod:`scitex_agent_container._listen.server` (which sits at the
+per-file line cap), mirroring the existing extractions of ``agent_send`` /
+``agents_start`` / ``agent_tail`` / the node inbox channel. ``server.py``
+re-imports :func:`list_agents` so route registration and the historical
+``from ..._listen.server import list_agents`` import path keep working.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from .._state.registry import Registry
+
+__all__ = ["list_agents"]
+
+log = logging.getLogger(__name__)
+
+
+async def list_agents(request: Request) -> JSONResponse:
+    """List agents the local Registry knows about + self-peers.
+
+    Every row carries the INBOX-SUBSCRIBER OBSERVATION — ``inbox_subscribers``
+    and ``inbox_reachable`` — alongside the registry's declarations.
+
+    All three sources below report what the fleet has DECLARED about an agent
+    (a pid, a port, a group, a start time). None of them can tell you whether
+    a message sent to that agent would actually wake anybody: that depends on
+    whether its inbox adapter is subscribed to the channel bus, which only the
+    broker knows. Publishing the declaration alone is what let two of four
+    agents advertise ``active`` while silently swallowing every ``a2a_send``.
+    So we publish the observation next to it, distinctly. See
+    :mod:`._reachability`.
+
+    Three sources, concatenated in this order:
+
+    1. Container-agent rows from :meth:`Registry.list_all` — the
+       traditional ``sac a2a peers`` shape (``name`` / ``config`` /
+       ``pid`` / ``started_at`` / ``screen``).
+    2. Self-peer rows from :func:`_self_peers.discover_self_peers`
+       — any agent dir whose ``spec.yaml`` carries only a
+       ``listen_url`` (no container ``spec`` block, no
+       ``apiVersion``). These have no ``pid`` / ``screen`` — they
+       are external listen sessions that own a port and want to be
+       discoverable. Carries ``"kind": "self-peer"`` so peer-aware
+       clients can branch on the source.
+    3. Comms-node self-registrations from ``comms_nodes`` (ADR-0014).
+
+    Dedup: a self-peer whose ``name`` already appears in the
+    container-row list loses to the container row (the running
+    container is the more authoritative source). Order matches
+    operator-facing convention: container rows first, then
+    self-peers alphabetically by ``name``.
+    """
+    rows: list[dict] = []
+    seen_names: set[str] = set()
+    try:
+        reg = Registry()
+        for row in reg.list_all():
+            rows.append(row)
+            name = row.get("name") if isinstance(row, dict) else None
+            if isinstance(name, str):
+                seen_names.add(name)
+    except Exception as exc:  # stx-allow: fallback (reason: surface a JSON error to the caller rather than ASGI 500 stack)
+        return JSONResponse({"error": str(exc)}, status_code=500)
+
+    _append_self_peers(rows, seen_names)
+    _append_comms_nodes(rows, seen_names)
+
+    # Q1 (lead dispatch a2a dc6fd23387f64e329049d218cf85a4d4): surface
+    # ``a2a_port`` + derived ``turn_url`` on every row so scitex-todo's
+    # notify resolver (P3a-b) can dispatch nudge→turn without redeploy.
+    # Idempotent: self-peer rows that already carry a non-None value
+    # keep theirs (the discovery layer is the authoritative source for
+    # those).
+    from ._registry_endpoints import enrich_row
+
+    rows = [enrich_row(row) for row in rows]
+    rows = await _annotate_reachability(request, rows)
+    return JSONResponse({"agents": rows})
+
+
+async def _annotate_reachability(request: Request, rows: list[dict]) -> list[dict]:
+    """Add ``inbox_subscribers`` / ``inbox_reachable`` to every row.
+
+    Reads the live broker — the ONLY authority on whether an agent's inbox
+    adapter is actually attached. One snapshot (a single lock take on an
+    in-memory dict), so this adds no I/O per row and cannot stall the route.
+
+    Best-effort in the SAFE direction: if the broker cannot be read at all,
+    every row is annotated ``unknown`` rather than ``unreachable``. "I could
+    not check" must never be rendered as death — that error would accuse
+    healthy agents of being deaf, and the remedy a caller reaches for on a
+    false death verdict is destructive.
+    """
+    from ._reachability import UNKNOWN, annotate_rows
+
+    try:
+        broker = request.app.state.inbox
+        counts = await broker.subscriber_counts()
+        local_host = getattr(request.app.state, "local_host", None)
+    except Exception as exc:  # stx-allow: fallback (reason: an unreadable broker must degrade to UNKNOWN, never to a false 'unreachable' verdict against healthy agents)
+        log.warning(
+            "list_agents: could not read inbox broker (reporting reachability "
+            "as %r for every row — NOT as unreachable): %s",
+            UNKNOWN,
+            exc,
+        )
+        return [
+            {**row, "inbox_subscribers": None, "inbox_reachable": UNKNOWN}
+            for row in rows
+        ]
+    return annotate_rows(rows, subscriber_counts=counts, local_host=local_host)
+
+
+def _append_self_peers(rows: list[dict], seen_names: set[str]) -> None:
+    """Self-peers — best-effort. Failures here must NOT mask a healthy
+    container-row response (an unreadable agents dir is operator state, not a
+    listen failure).
+
+    Runtime self-identity is derived from host_config — the same source the
+    existing channel/listen self-registration paths consult. Missing
+    host_config / missing ``lead:`` block degrades to ``None``;
+    :func:`discover_self_peers` then surfaces the literal ``self`` dir as
+    ``"self"`` with a logged warning, which is the loudest signal short of
+    failing the request.
+    """
+    try:
+        from ..config._resolve import _search_dirs
+        from ._self_peers import discover_self_peers
+
+        primary, env_dirs, fleet_dirs = _search_dirs()
+        search_dirs = [*env_dirs, primary, *fleet_dirs]
+        self_identity = _resolve_runtime_self_identity()
+        for peer in discover_self_peers(search_dirs, self_identity=self_identity):
+            if peer["name"] in seen_names:
+                continue
+            rows.append(peer)
+            seen_names.add(peer["name"])
+    except Exception as exc:  # stx-allow: fallback (reason: self-peer discovery must never block the registry response)
+        log.warning(
+            "list_agents: self-peer discovery failed (returning registry rows only): %s",
+            exc,
+        )
+
+
+def _append_comms_nodes(rows: list[dict], seen_names: set[str]) -> None:
+    """Comms-node self-registrations (operator mandate 2026-06-14): ANY
+    process that loaded the sac MCP and self-registered into the
+    ``comms_nodes`` table (e.g. ``sac mcp channel --name lead``, or any
+    CLI/SDK session running the channel adapter) MUST appear in ``a2a peers``
+    at startup -- no exceptions. Such nodes are not in the Registry (no
+    container) and can live outside the filesystem self-peer search dirs, so
+    without this source the lead (and any bare sac-MCP session) is invisible
+    here. Best-effort: a read failure must not mask the rest of the response.
+    """
+    try:
+        from .._state.state_db_comms_nodes import list_comms_nodes
+
+        for node in list_comms_nodes():
+            if node["name"] in seen_names:
+                continue
+            rows.append(
+                {
+                    "name": node["name"],
+                    "host": node["host"],
+                    "a2a_port": node["a2a_port"],
+                    "kind": "comms-node",
+                    "registered_at": node.get("registered_at"),
+                    "updated_at": node.get("updated_at"),
+                }
+            )
+            seen_names.add(node["name"])
+    except Exception as exc:  # stx-allow: fallback (reason: comms-node surfacing must never block the registry response)
+        log.warning(
+            "list_agents: comms_nodes surfacing failed (returning prior rows): %s",
+            exc,
+        )
+
+
+def _resolve_runtime_self_identity() -> str | None:
+    """Return the running listen's runtime identity, or ``None``.
+
+    Reads :func:`host_config.load().lead.name` — the same source the
+    existing channel/listen self-registration paths
+    (:mod:`_mcp._channel_self_register`,
+    :func:`cli_pkg.listen_cmds._register_self_comms_node`) consult.
+    A missing ``lead:`` block in host_config returns ``None`` — the
+    self-peer discovery downstream then surfaces the literal
+    ``self`` dir as ``"self"`` so the operator sees the gap rather
+    than getting a silently-renamed peer row.
+
+    Generic on purpose: there is no name-specific branching here.
+    ``host_config.lead.name`` is THE host's "who am I" answer for
+    operator-class sessions; a future evolution that supports
+    multiple self-identities on one host would extend the host_config
+    shape, not insert per-name special cases here.
+    """
+    try:
+        from .._state.host_config import load as load_host_config
+
+        cfg = load_host_config()
+        lead = getattr(cfg, "lead", None)
+        if lead is not None:
+            name = getattr(lead, "name", None)
+            if isinstance(name, str) and name.strip():
+                return name
+    except Exception:  # stx-allow: fallback (reason: host_config errors must never block the /agents response)
+        pass
+    return None

--- a/src/scitex_agent_container/_listen/_reachability.py
+++ b/src/scitex_agent_container/_listen/_reachability.py
@@ -1,0 +1,134 @@
+"""REGISTERED is not REACHABLE — the inbox-subscriber observation.
+
+A row in ``GET /agents`` used to say only what the registry DECLARED: a
+name, a pid, a port, a start time, a group. All of that can be true of an
+agent whose inbox adapter is not attached to the channel bus — an agent
+that will silently swallow every ``a2a_send`` aimed at it, because the
+broker fans out to zero subscribers.
+
+That conflation was load-bearing. The fleet constitution says "before
+handing work to another party, confirm it is alive and able to act", and
+``a2a_peers`` is the tool provided to do exactly that. An agent could
+confirm via ``a2a_peers``, be told the peer was running and ``active``,
+send, and reach nobody. A liveness signal that reports alive-and-able for
+a deaf agent is worse than no signal, because it is trusted.
+
+So this module keeps the two facts DISTINCT:
+
+* **registered** — the registry has a row (pid, port, groups). Unchanged;
+  still reported. It is a declaration.
+* **reachable** — the ``sac listen`` broker has a live SSE subscriber on
+  that agent's inbox stream. It is an OBSERVATION, and it is the only one
+  that predicts whether a message will actually wake them.
+
+Three states, never two
+-----------------------
+``inbox_reachable`` is deliberately ternary. Collapsing "I could not
+check" into either "fine" or "dead" is the class of bug this whole module
+exists to kill:
+
+* :data:`REACHABLE`   — observed >= 1 live subscriber. A send will wake them.
+* :data:`UNREACHABLE` — observed exactly 0 subscribers on a bus we CAN see.
+  This is EVIDENCE of non-delivery, not absence of evidence, so an
+  ``a2a_send`` to this agent fails loudly (see ``_mcp/_channel_send_errors``).
+* :data:`UNKNOWN`     — we cannot observe this agent's bus at all (it lives
+  on another host, whose broker is a different process). NOT a failure and
+  NOT a success. Never rendered as either.
+
+And a hard rule that outlives this file: ``UNREACHABLE`` must NEVER be
+wired to anything destructive. It says an inbox adapter is detached; it
+does NOT say the agent is dead. Auto-restarting on it would destroy a
+healthy session — the exact "destroy on a negative signal you did not
+directly observe" failure this fleet has already paid for.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+# ``inbox_reachable`` values.
+REACHABLE = "reachable"
+UNREACHABLE = "unreachable"
+UNKNOWN = "unknown"
+
+__all__ = [
+    "REACHABLE",
+    "UNKNOWN",
+    "UNREACHABLE",
+    "annotate_reachability",
+    "annotate_rows",
+]
+
+
+def _is_locally_observable(row: Mapping[str, Any], local_host: str | None) -> bool:
+    """Can THIS listen's broker answer for ``row``'s inbox?
+
+    Mirrors the locality rule the publish path already uses
+    (:func:`_state.state_db_nodes.is_local_node`): a node whose host we
+    cannot distinguish from our own — including one that declares no host
+    at all — is served by the LOCAL broker, so the local subscriber count
+    is authoritative for it.
+
+    A row that declares a host we can see is NOT ours is served by a
+    different ``sac listen`` process with a different in-memory broker.
+    We have no window into it, so we must say :data:`UNKNOWN` rather than
+    invent a zero — a fabricated zero would be a false accusation of
+    deafness against a perfectly reachable remote agent.
+    """
+    host = row.get("host")
+    if not isinstance(host, str) or not host:
+        return True  # no host declared → the local publish path serves it
+    if not local_host:
+        return False  # we don't know who WE are → cannot claim locality
+    return host == local_host
+
+
+def annotate_reachability(
+    row: Mapping[str, Any],
+    *,
+    subscriber_counts: Mapping[str, int],
+    local_host: str | None,
+) -> dict[str, Any]:
+    """Add ``inbox_subscribers`` + ``inbox_reachable`` to one registry row.
+
+    ``subscriber_counts`` is a snapshot of the local broker
+    (:meth:`a2a._inbox_bus.Broker.subscriber_counts`) — an in-memory dict,
+    so this costs no I/O per row and cannot stall ``GET /agents``.
+
+    Idempotent and non-destructive: every pre-existing field (``pid``,
+    ``groups``, ``started_at``, …) is preserved untouched. We ADD the
+    observation next to the declaration; we do not overwrite or reinterpret
+    the declaration.
+    """
+    out = dict(row)
+    name = row.get("name")
+    if not isinstance(name, str) or not name:
+        # No usable key for the broker → we genuinely cannot look it up.
+        out["inbox_subscribers"] = None
+        out["inbox_reachable"] = UNKNOWN
+        return out
+
+    if not _is_locally_observable(row, local_host):
+        out["inbox_subscribers"] = None
+        out["inbox_reachable"] = UNKNOWN
+        return out
+
+    count = int(subscriber_counts.get(name, 0))
+    out["inbox_subscribers"] = count
+    out["inbox_reachable"] = REACHABLE if count >= 1 else UNREACHABLE
+    return out
+
+
+def annotate_rows(
+    rows: list[dict[str, Any]],
+    *,
+    subscriber_counts: Mapping[str, int],
+    local_host: str | None,
+) -> list[dict[str, Any]]:
+    """Apply :func:`annotate_reachability` across a ``GET /agents`` list."""
+    return [
+        annotate_reachability(
+            row, subscriber_counts=subscriber_counts, local_host=local_host
+        )
+        for row in rows
+    ]

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -55,143 +55,14 @@ async def health(_request: Request) -> JSONResponse:
     return JSONResponse({"ok": True, "service": "sac-listen", "v": 1})
 
 
-async def list_agents(_request: Request) -> JSONResponse:
-    """List agents the local Registry knows about + self-peers.
+# ``list_agents`` (GET /agents — the peer-discovery route backing the
+# ``a2a_peers`` MCP tool) was extracted into ``_agents_list`` when it grew
+# the inbox-subscriber reachability observation (REGISTERED IS NOT
+# REACHABLE — see ``_reachability``). Re-imported here so route
+# registration and the historical
+# ``from ..._listen.server import list_agents`` import path keep working.
+from ._agents_list import list_agents  # noqa: E402,F401
 
-    Two sources, concatenated in this order:
-
-    1. Container-agent rows from :meth:`Registry.list_all` — the
-       traditional ``sac a2a peers`` shape (``name`` / ``config`` /
-       ``pid`` / ``started_at`` / ``screen``).
-    2. Self-peer rows from :func:`_self_peers.discover_self_peers`
-       — any agent dir whose ``spec.yaml`` carries only a
-       ``listen_url`` (no container ``spec`` block, no
-       ``apiVersion``). These have no ``pid`` / ``screen`` — they
-       are external listen sessions that own a port and want to be
-       discoverable. Carries ``"kind": "self-peer"`` so peer-aware
-       clients can branch on the source.
-
-    Dedup: a self-peer whose ``name`` already appears in the
-    container-row list loses to the container row (the running
-    container is the more authoritative source). Order matches
-    operator-facing convention: container rows first, then
-    self-peers alphabetically by ``name``.
-    """
-    rows: list[dict] = []
-    seen_names: set[str] = set()
-    try:
-        reg = Registry()
-        for row in reg.list_all():
-            rows.append(row)
-            name = row.get("name") if isinstance(row, dict) else None
-            if isinstance(name, str):
-                seen_names.add(name)
-    except Exception as exc:  # stx-allow: fallback (reason: surface a JSON error to the caller rather than ASGI 500 stack)
-        return JSONResponse({"error": str(exc)}, status_code=500)
-    # Self-peers — best-effort. Failures here must NOT mask a healthy
-    # container-row response (an unreadable agents dir is operator
-    # state, not a listen failure).
-    #
-    # Runtime self-identity is derived from host_config — the same
-    # source the existing channel/listen self-registration paths
-    # consult. Missing host_config / missing ``lead:`` block degrades
-    # to ``None``; :func:`discover_self_peers` then surfaces the
-    # literal ``self`` dir as ``"self"`` with a logged warning, which
-    # is the loudest signal short of failing the request.
-    try:
-        from ..config._resolve import _search_dirs
-        from ._self_peers import discover_self_peers
-
-        primary, env_dirs, fleet_dirs = _search_dirs()
-        search_dirs = [*env_dirs, primary, *fleet_dirs]
-        self_identity = _resolve_runtime_self_identity()
-        for peer in discover_self_peers(search_dirs, self_identity=self_identity):
-            if peer["name"] in seen_names:
-                continue
-            rows.append(peer)
-            seen_names.add(peer["name"])
-    except Exception as exc:  # stx-allow: fallback (reason: self-peer discovery must never block the registry response)
-        import logging
-
-        logging.getLogger(__name__).warning(
-            "list_agents: self-peer discovery failed (returning registry rows only): %s",
-            exc,
-        )
-    # Comms-node self-registrations (operator mandate 2026-06-14): ANY
-    # process that loaded the sac MCP and self-registered into the
-    # comms_nodes table (e.g. ``sac mcp channel --name lead``, or any
-    # CLI/SDK session running the channel adapter) MUST appear in
-    # ``a2a peers`` at startup -- no exceptions. Such nodes are not in
-    # the Registry (no container) and can live outside the filesystem
-    # self-peer search dirs, so without this source the lead (and any
-    # bare sac-MCP session) is invisible here. Best-effort: a read
-    # failure must not mask the rest of the response.
-    try:
-        from .._state.state_db_comms_nodes import list_comms_nodes
-
-        for node in list_comms_nodes():
-            if node["name"] in seen_names:
-                continue
-            rows.append(
-                {
-                    "name": node["name"],
-                    "host": node["host"],
-                    "a2a_port": node["a2a_port"],
-                    "kind": "comms-node",
-                    "registered_at": node.get("registered_at"),
-                    "updated_at": node.get("updated_at"),
-                }
-            )
-            seen_names.add(node["name"])
-    except Exception as exc:  # stx-allow: fallback (reason: comms-node surfacing must never block the registry response)
-        import logging
-
-        logging.getLogger(__name__).warning(
-            "list_agents: comms_nodes surfacing failed (returning prior rows): %s",
-            exc,
-        )
-    # Q1 (lead dispatch a2a dc6fd23387f64e329049d218cf85a4d4): surface
-    # ``a2a_port`` + derived ``turn_url`` on every row so scitex-todo's
-    # notify resolver (P3a-b) can dispatch nudge→turn without redeploy.
-    # Idempotent: self-peer rows that already carry a non-None value
-    # keep theirs (the discovery layer is the authoritative source for
-    # those).
-    from ._registry_endpoints import enrich_row
-
-    rows = [enrich_row(row) for row in rows]
-    return JSONResponse({"agents": rows})
-
-
-def _resolve_runtime_self_identity() -> str | None:
-    """Return the running listen's runtime identity, or ``None``.
-
-    Reads :func:`host_config.load().lead.name` — the same source the
-    existing channel/listen self-registration paths
-    (:mod:`_mcp._channel_self_register`,
-    :func:`cli_pkg.listen_cmds._register_self_comms_node`) consult.
-    A missing ``lead:`` block in host_config returns ``None`` — the
-    self-peer discovery downstream then surfaces the literal
-    ``self`` dir as ``"self"`` so the operator sees the gap rather
-    than getting a silently-renamed peer row.
-
-    Generic on purpose: there is no name-specific branching here.
-    ``host_config.lead.name`` is THE host's "who am I" answer for
-    operator-class sessions; a future evolution that supports
-    multiple self-identities on one host would extend the host_config
-    shape, not insert per-name special cases here.
-    """
-    try:
-        from .._state.host_config import load as load_host_config
-
-        cfg = load_host_config()
-        lead = getattr(cfg, "lead", None)
-        if lead is not None:
-            name = getattr(lead, "name", None)
-            if isinstance(name, str) and name.strip():
-                return name
-    except Exception:  # stx-allow: fallback (reason: host_config errors must never block the /agents response)
-        pass
-    return None
 
 
 async def agent_status(request: Request) -> JSONResponse:
@@ -227,7 +98,40 @@ async def agent_status(request: Request) -> JSONResponse:
     from ._registry_endpoints import enrich_row
 
     body = enrich_row(body)
+    # …and the same inbox-subscriber OBSERVATION ``GET /agents`` carries, so
+    # a single-agent status poll can also tell REGISTERED from REACHABLE. A
+    # running session_id + a live pid say nothing about whether this agent's
+    # inbox adapter is attached; only the broker does. See ``_reachability``.
+    body = await _annotate_status_reachability(request, body)
     return JSONResponse(body)
+
+
+async def _annotate_status_reachability(
+    request: Request, body: dict[str, Any]
+) -> dict[str, Any]:
+    """Add ``inbox_subscribers`` / ``inbox_reachable`` to a status body.
+
+    Degrades to ``unknown`` (never ``unreachable``) if the broker cannot be
+    read — "I could not check" must not be rendered as death.
+    """
+    from ._reachability import UNKNOWN, annotate_reachability
+
+    try:
+        counts = await request.app.state.inbox.subscriber_counts()
+        local_host = getattr(request.app.state, "local_host", None)
+    except Exception as exc:  # stx-allow: fallback (reason: an unreadable broker must degrade to UNKNOWN, never to a false 'unreachable' verdict)
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "agent_status: could not read inbox broker (reporting reachability "
+            "as %r, NOT as unreachable): %s",
+            UNKNOWN,
+            exc,
+        )
+        return {**body, "inbox_subscribers": None, "inbox_reachable": UNKNOWN}
+    return annotate_reachability(
+        body, subscriber_counts=counts, local_host=local_host
+    )
 
 
 # --- extracted handlers re-imported for routes + back-compat ---------------

--- a/src/scitex_agent_container/_mcp/_channel_send_errors.py
+++ b/src/scitex_agent_container/_mcp/_channel_send_errors.py
@@ -1,0 +1,226 @@
+"""The FAIL-LOUD contract for the send-side ``a2a_*`` MCP tools.
+
+Extracted from :mod:`._channel_tools` (which hit the module size budget)
+because it is one cohesive responsibility: deciding that a send
+demonstrably failed, and rendering that failure so the CALLER CANNOT
+MISTAKE IT FOR DELIVERY.
+
+Why this module exists at all
+-----------------------------
+``a2a_send`` already detected the no-subscriber case and returned a body
+carrying ``{"error": ...}``. But the MCP low-level ``Server.call_tool``
+decorator wraps whatever a handler returns:
+
+* a plain ``list[TextContent]`` becomes ``CallToolResult(isError=False)``
+  — a **SUCCESS**, whatever the text inside happens to say;
+* a ``CallToolResult`` is passed through **verbatim**, so a handler that
+  wants to fail must say ``isError=True`` itself.
+
+So the old shape was a false green: the tool reported "reached no live
+subscriber" inside the body of a result flagged as successful. A caller
+that trusted the MCP contract (rather than string-matching the payload)
+read it as a delivered message. Agents silently swallowed each other's
+messages and nothing in the control plane said so.
+
+The three-state discipline
+--------------------------
+Delivery has THREE outcomes and they must never be collapsed into two:
+
+* **delivered** — ``delivered_subscriber_count >= 1``. Success.
+* **definitively NOT delivered** — an explicit ``0`` from the local
+  publish path. The bus fanned out to nobody. This is a hard failure and
+  the ONLY one this module raises for. It is EVIDENCE, not an absence of
+  evidence.
+* **could not determine** — the field is ABSENT (e.g. a cross-host
+  forward whose reply does not carry it). Inventing a zero here would be
+  a false-positive failure, so an absent count is NEVER read as zero and
+  never fails. "I could not check" is rendered as neither success nor
+  death.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from mcp.types import CallToolResult
+
+
+class SendError(RuntimeError):
+    """A send/push could NOT reach or wake the target agent.
+
+    Raised by the send helper when delivery demonstrably failed:
+
+    * the transport raised (agent down / connection refused),
+    * the listen server returned a non-2xx status (delivery error), or
+    * the publish reported ``delivered_subscriber_count == 0`` — no live
+      inbox subscriber, so the message woke nobody.
+
+    The send-side ``a2a_*`` tools render this via :func:`error_result`
+    into an MCP result with ``isError=True`` — never a misleading
+    success — and log it.
+
+    ``code`` is the machine-readable failure class (one of the ``ERR_*``
+    constants) and ``detail`` carries the structured fields a caller can
+    branch on without re-parsing the human message.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        target: str,
+        detail: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.target = target
+        self.detail: dict[str, Any] = dict(detail or {})
+
+
+# Machine-readable failure classes, echoed as ``code`` in the tool's
+# error payload so a caller branches on the CLASS of failure instead of
+# string-matching a human sentence.
+ERR_NO_SUBSCRIBER = "no_live_subscriber"
+ERR_UNREACHABLE = "unreachable"
+ERR_DELIVERY_ERROR = "delivery_error"
+ERR_LOOKUP_FAILED = "lookup_failed"
+
+# What a 0-subscriber send hands the caller instead of a false success.
+#
+# It deliberately does NOT recommend ``agent_send`` / ``sac agents send``.
+# That rail POSTs to the agent's ``/v1/turn`` sidecar port, which —
+# measured on the live fleet, 2026-07-14 — only 5 of 47 registered agents
+# actually bind. Its own failure path tells callers to use a2a instead
+# (see ``cli_pkg._send``), so recommending it here would be a circular
+# dead end for most of the fleet.
+#
+# It also does NOT recommend restarting the target. A 0-subscriber
+# reading is a negative signal about ONE transport; it is not an
+# observation of agent death. ``--force --fresh`` on it would destroy a
+# healthy agent whose only problem is a detached inbox adapter.
+NO_SUBSCRIBER_REMEDY: tuple[str, ...] = (
+    "NOT LOST: sac listen persists every message to `channel_events` BEFORE "
+    "publishing, and the target's inbox stream replays all undelivered rows "
+    "on its next connect. Do NOT re-send this message — it would arrive "
+    "twice once their adapter reconnects.",
+    "To reach them NOW, use a rail that does not depend on their inbox "
+    "adapter: a scitex-todo card assigned to them (durable, pull-based), or "
+    "escalate to the operator.",
+    "Do NOT force-restart the target on this signal. 0 subscribers means "
+    "their inbox adapter is not attached; it is NOT evidence that the agent "
+    "is dead, and a restart would destroy a healthy session.",
+)
+
+
+def no_subscriber_error(target: str) -> SendError:
+    """Build the loud error for an explicit ``delivered_subscriber_count == 0``.
+
+    The message states exactly what was observed (the bus fanned out to
+    zero subscribers) and — just as importantly — what was NOT observed
+    (that the agent is dead, or that the message is gone).
+    """
+    return SendError(
+        f"NOT DELIVERED — send to {target!r} reached no live subscriber "
+        "(delivered_subscriber_count=0). The message woke nobody: "
+        f"{target!r} has no inbox adapter attached to the channel bus "
+        "(its session is not running `sac mcp channel`, or that adapter's "
+        "SSE stream is not connected). Being listed as a running/`active` "
+        "peer does NOT mean an agent is subscribed — registered is not "
+        "reachable. Check `inbox_subscribers` on a2a_peers before "
+        "handing work to a peer.",
+        code=ERR_NO_SUBSCRIBER,
+        target=target,
+        detail={
+            "delivered": False,
+            "delivered_subscriber_count": 0,
+            "durably_queued": True,
+            "what_to_do": list(NO_SUBSCRIBER_REMEDY),
+        },
+    )
+
+
+def unreachable_error(target: str, exc: Exception) -> SendError:
+    """Build the loud error for a transport failure (connection refused …)."""
+    return SendError(
+        f"NOT DELIVERED — send to {target!r} failed: agent unreachable ({exc})",
+        code=ERR_UNREACHABLE,
+        target=target,
+        detail={"delivered": False, "transport_error": str(exc)},
+    )
+
+
+def delivery_error(target: str, status: Any, body: Any) -> SendError:
+    """Build the loud error for a server-side (5xx / bogus status) failure."""
+    return SendError(
+        f"NOT DELIVERED — send to {target!r} failed: listen returned "
+        f"HTTP {status} ({body})",
+        code=ERR_DELIVERY_ERROR,
+        target=target,
+        detail={"delivered": False, "http_status": status, "http_body": body},
+    )
+
+
+def _error_payload(exc: SendError) -> dict[str, Any]:
+    """Project a :class:`SendError` onto the tool's JSON error body."""
+    payload: dict[str, Any] = {
+        "error": str(exc),
+        "code": exc.code,
+        "target": exc.target,
+        "delivered": False,
+    }
+    payload.update(exc.detail)
+    return payload
+
+
+def error_result(exc: SendError) -> "CallToolResult":
+    """Render a :class:`SendError` as an MCP result the caller CANNOT read
+    as success.
+
+    Returns a ``CallToolResult`` with ``isError=True``. The MCP low-level
+    server passes a ``CallToolResult`` through verbatim (unlike a bare
+    ``list[TextContent]``, which it stamps ``isError=False``), so this is
+    the seam where "the message was not delivered" actually becomes a
+    tool-level failure the calling model sees as one.
+
+    The structured detail (target, failure ``code``, subscriber count,
+    and what to do instead) is preserved in the payload — failing loudly
+    must not cost the caller the information it needs to recover.
+    """
+    from mcp.types import CallToolResult, TextContent
+
+    return CallToolResult(
+        content=[
+            TextContent(type="text", text=json.dumps(_error_payload(exc), indent=2))
+        ],
+        isError=True,
+    )
+
+
+def lookup_error_result(message: str, *, target: str = "") -> "CallToolResult":
+    """Render a non-send failure (unknown msg_id, unknown sender, unknown
+    tool) as an ``isError=True`` result.
+
+    These never delivered anything either, so they must not come back as
+    a success body — same rule, different cause.
+    """
+    return error_result(
+        SendError(message, code=ERR_LOOKUP_FAILED, target=target, detail={})
+    )
+
+
+__all__ = [
+    "ERR_DELIVERY_ERROR",
+    "ERR_LOOKUP_FAILED",
+    "ERR_NO_SUBSCRIBER",
+    "ERR_UNREACHABLE",
+    "NO_SUBSCRIBER_REMEDY",
+    "SendError",
+    "delivery_error",
+    "error_result",
+    "lookup_error_result",
+    "no_subscriber_error",
+    "unreachable_error",
+]

--- a/src/scitex_agent_container/_mcp/_channel_tools.py
+++ b/src/scitex_agent_container/_mcp/_channel_tools.py
@@ -19,26 +19,17 @@ import json
 import logging
 from typing import Any
 
+from ._channel_send_errors import (
+    SendError,
+    delivery_error,
+    error_result,
+    lookup_error_result,
+    no_subscriber_error,
+    unreachable_error,
+)
 from .channel import _recent
 
 log = logging.getLogger(__name__)
-
-
-class SendError(RuntimeError):
-    """A send/push could NOT reach or wake the target agent.
-
-    Raised by the send helper when delivery demonstrably failed:
-
-    * the transport raised (agent down / connection refused),
-    * the listen server returned a non-2xx status (delivery error), or
-    * the publish reported ``delivered_subscriber_count == 0`` — no live
-      inbox subscriber, so the message woke nobody.
-
-    The send-side ``a2a_*`` tools translate this into a loud, explicit
-    ``{"error": ...}`` result for the calling agent (never a misleading
-    success) and log it. STX hard rule: fail loudly, never silently drop
-    or return a misleading success.
-    """
 
 
 def register_tools(
@@ -53,7 +44,7 @@ def register_tools(
     """
     import uuid as _uuid
 
-    from mcp.types import TextContent, Tool
+    from mcp.types import CallToolResult, TextContent, Tool
 
     from .._state.dispatch_ledger import (
         STATUS_DELIVERED,
@@ -122,7 +113,8 @@ def register_tools(
         """POST a send/push and FAIL LOUDLY when it cannot reach/wake (WI-2).
 
         Returns the parsed ``{status, body}`` on success. Raises
-        :class:`SendError` — never a misleading success — when:
+        :class:`SendError` — which the caller renders as an MCP result
+        with ``isError=True``, never a misleading success — when:
 
         * the transport raises (target agent down / connection refused),
         * the HTTP status is 5xx (server / infra delivery error), or
@@ -135,6 +127,17 @@ def register_tools(
         the agent ("denial is the policy working"). Reshaping it into an
         opaque error string would lose the structured ``reason`` and is not
         the silent-drop/misleading-success the fail-loud rule targets.
+
+        KNOWN GAP (deliberate, not an oversight): a 4xx therefore still comes
+        back with ``isError=False``, even though it delivered nothing. It is
+        far less dangerous than the 0-subscriber case this fail-loud path was
+        written for — a 403 body is self-evidently a failure, whereas a
+        no-subscriber publish returned an HTTP **200** and read as success by
+        every conventional measure. Flipping 4xx to ``isError=True`` (keeping
+        the body verbatim, so the original "don't lose the structured reason"
+        objection would not apply) is a one-line change, but it alters the ACL
+        contract and is pinned by ``tests/smoke/test_node_comms_e2e_mcp.py``,
+        so it belongs in its own PR rather than riding along with this one.
 
         ``delivered_subscriber_count`` ABSENT is NOT treated as zero: some
         responses (cross-host forwards) don't carry it, and inventing a
@@ -180,9 +183,7 @@ def register_tools(
             res = await _post(path, payload)
         except httpx.HTTPError as exc:
             log.warning("sac a2a: send to %r failed (transport): %s", target, exc)
-            raise SendError(
-                f"send to {target!r} failed: agent unreachable ({exc})"
-            ) from exc
+            raise unreachable_error(target, exc) from exc
 
         status = res.get("status")
         # 5xx (and any non-int / sub-200) = server/infra delivery failure.
@@ -192,9 +193,7 @@ def register_tools(
             log.warning(
                 "sac a2a: send to %r returned HTTP %s: %s", target, status, body
             )
-            raise SendError(
-                f"send to {target!r} failed: listen returned HTTP {status} ({body})"
-            )
+            raise delivery_error(target, status, body)
         if not isinstance(status, int) or status < 200:
             body = res.get("body")
             log.warning(
@@ -203,9 +202,7 @@ def register_tools(
                 status,
                 body,
             )
-            raise SendError(
-                f"send to {target!r} failed: unexpected status {status!r} ({body})"
-            )
+            raise delivery_error(target, status, body)
 
         body = res.get("body")
         if isinstance(body, dict):
@@ -213,21 +210,11 @@ def register_tools(
             if isinstance(delivered, int) and delivered == 0:
                 log.warning(
                     "sac a2a: send to %r reached no subscriber "
-                    "(delivered_subscriber_count=0)",
+                    "(delivered_subscriber_count=0) — NOT DELIVERED",
                     target,
                 )
-                raise SendError(
-                    f"send to {target!r} reached no live subscriber "
-                    "(delivered_subscriber_count=0): the agent is not "
-                    "subscribed to its inbox (down, not started, or its "
-                    "channel adapter is not connected) — the message woke "
-                    "nobody and was not delivered."
-                )
+                raise no_subscriber_error(target)
         return res
-
-    def _error_result(exc: SendError) -> "list[TextContent]":
-        """Render a :class:`SendError` as a loud tool result."""
-        return [TextContent(type="text", text=json.dumps({"error": str(exc)}))]
 
     def _find(msg_id: str) -> dict[str, Any] | None:
         for ev in reversed(_recent):
@@ -279,7 +266,10 @@ def register_tools(
                 description=(
                     "Send a message to another agent on this sac listen. "
                     "Sets from_agent automatically; mints conversation_id "
-                    "when omitted."
+                    "when omitted. FAILS (isError) when the message reached "
+                    "no live inbox subscriber — a peer listed as running is "
+                    "NOT necessarily subscribed. Check `inbox_subscribers` "
+                    "via a2a_peers before handing work to a peer."
                 ),
                 inputSchema={
                     "type": "object",
@@ -325,7 +315,17 @@ def register_tools(
             ),
             Tool(
                 name="a2a_peers",
-                description="List reachable agents on this sac listen.",
+                description=(
+                    "List agents known to this sac listen. REGISTERED IS NOT "
+                    "REACHABLE: a row can show a pid, a port and group "
+                    "'active' while having NO inbox subscriber, in which case "
+                    "a2a_send to it delivers nothing. Each row carries "
+                    "`inbox_subscribers` (live subscriber count) and "
+                    "`inbox_reachable` ('reachable' / 'unreachable' / "
+                    "'unknown' when it lives on another host and this listen "
+                    "cannot observe it). Only 'reachable' means a message "
+                    "will actually wake them."
+                ),
                 inputSchema={"type": "object", "properties": {}},
             ),
             Tool(
@@ -344,7 +344,20 @@ def register_tools(
         ]
 
     @server.call_tool()
-    async def _call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    async def _call_tool(
+        name: str, arguments: dict[str, Any]
+    ) -> "list[TextContent] | CallToolResult":
+        """Dispatch one ``a2a_*`` call.
+
+        Return-type contract (the fix for the swallowed-message false
+        green): a SUCCESS returns ``list[TextContent]``, which the MCP
+        low-level server stamps ``isError=False``. A FAILURE returns a
+        ``CallToolResult`` carrying ``isError=True``, which the server
+        passes through verbatim. A caller therefore cannot mistake a
+        message that reached nobody for a delivered one — previously
+        BOTH shapes came back as ``isError=False`` and the failure was
+        just a field in the body that a caller could (and did) miss.
+        """
         if name == "a2a_send":
             target = arguments["target"]
             content = arguments["content"]
@@ -367,7 +380,7 @@ def register_tools(
                 )
             except SendError as exc:
                 _ledger_update(dispatch_id, STATUS_FAILED)
-                return _error_result(exc)
+                return error_result(exc)
             _ledger_update(dispatch_id, STATUS_DELIVERED)
             return [TextContent(type="text", text=json.dumps(res))]
 
@@ -375,22 +388,10 @@ def register_tools(
             mid = arguments["in_reply_to"]
             orig = _find(mid)
             if orig is None:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {"error": f"unknown msg_id {mid} (inbox window)"}
-                        ),
-                    )
-                ]
+                return lookup_error_result(f"unknown msg_id {mid} (inbox window)")
             target = orig.get("from_agent", "")
             if not target:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps({"error": "original sender unknown"}),
-                    )
-                ]
+                return lookup_error_result("original sender unknown")
             payload = _wrap_message_send(
                 arguments["content"],
                 conversation_id=orig.get("conversation_id"),
@@ -401,29 +402,17 @@ def register_tools(
                     target, f"/agents/{target}/message:send", payload
                 )
             except SendError as exc:
-                return _error_result(exc)
+                return error_result(exc)
             return [TextContent(type="text", text=json.dumps(res))]
 
         if name == "a2a_ack":
             mid = arguments["msg_id"]
             orig = _find(mid)
             if orig is None:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {"error": f"unknown msg_id {mid} (inbox window)"}
-                        ),
-                    )
-                ]
+                return lookup_error_result(f"unknown msg_id {mid} (inbox window)")
             target = orig.get("from_agent", "")
             if not target:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps({"error": "original sender unknown"}),
-                    )
-                ]
+                return lookup_error_result("original sender unknown")
             payload = _wrap_message_send(
                 "",
                 conversation_id=orig.get("conversation_id"),
@@ -435,13 +424,18 @@ def register_tools(
                     target, f"/agents/{target}/message:send", payload
                 )
             except SendError as exc:
-                return _error_result(exc)
+                return error_result(exc)
             return [TextContent(type="text", text=json.dumps(res))]
 
         if name == "a2a_peers":
             # No trailing slash: sac listen registers `/agents` and a GET to
             # `/agents/` 307-redirects, which httpx does not follow by default
             # (a2a_peers then returns a bare 307 with empty body).
+            #
+            # Each row carries `inbox_subscribers` + `inbox_reachable` (see
+            # ``_listen/_reachability.py``) so a caller can tell REGISTERED
+            # from REACHABLE. Reading only pid/groups is what let a deaf peer
+            # look alive-and-able.
             res = await _get("/agents")
             return [TextContent(type="text", text=json.dumps(res))]
 
@@ -454,11 +448,7 @@ def register_tools(
                 )
             ]
 
-        return [
-            TextContent(
-                type="text", text=json.dumps({"error": f"unknown tool: {name}"})
-            )
-        ]
+        return lookup_error_result(f"unknown tool: {name}")
 
 
 __all__ = ["SendError", "register_tools"]

--- a/src/scitex_agent_container/a2a/_inbox_bus.py
+++ b/src/scitex_agent_container/a2a/_inbox_bus.py
@@ -190,6 +190,29 @@ class Broker:
         async with self._lock:
             return len(self._subs.get(agent, ()))
 
+    async def subscriber_counts(self) -> dict[str, int]:
+        """Snapshot every agent's live subscriber count in ONE lock take.
+
+        This is the control plane's only OBSERVATION of reachability — the
+        registry can say an agent is running and ``active`` while its inbox
+        adapter is not attached here, in which case :meth:`publish` fans out
+        to nobody and the message wakes no one. ``GET /agents`` reports this
+        count per row so "registered" and "reachable" stay distinguishable
+        (see ``_listen/_reachability.py``).
+
+        One lock acquisition rather than N (as repeated
+        :meth:`subscriber_count` calls would take) so annotating a whole
+        peer list stays O(1) in lock round-trips and cannot stall the
+        ``/agents`` route.
+
+        Agents with zero subscribers are simply absent from ``_subs``
+        (:meth:`unsubscribe` pops the empty set), so a name missing from the
+        returned dict means zero — callers must treat "absent" as 0, which
+        :func:`_listen._reachability.annotate_reachability` does.
+        """
+        async with self._lock:
+            return {agent: len(queues) for agent, queues in self._subs.items()}
+
 
 def mint_event(
     agent: str,

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -443,10 +443,30 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
 
     is_healthy, message = health_check(config)
 
+    # REGISTERED IS NOT REACHABLE. ``health_check`` asks "is the process
+    # up?" — a deaf agent (one whose inbox adapter is not subscribed to the
+    # channel bus) passes that check while silently swallowing every
+    # a2a_send aimed at it. Report the inbox observation ALONGSIDE the
+    # process verdict so the two facts stay distinguishable.
+    #
+    # ``healthy`` is deliberately NOT derived from this: 0 subscribers means
+    # a detached inbox adapter, not a dead agent, and anything that
+    # auto-restarts on it would destroy a healthy session. Observation only.
+    from .._lifecycle.inbox_probe import probe_inbox_reachability
+    from .._listen._reachability import UNKNOWN, UNREACHABLE
+
+    subscribers, reachable = probe_inbox_reachability(name)
+
     if use_json:
         click.echo(
             json_mod.dumps(
-                {"name": name, "healthy": is_healthy, "message": message},
+                {
+                    "name": name,
+                    "healthy": is_healthy,
+                    "message": message,
+                    "inbox_subscribers": subscribers,
+                    "inbox_reachable": reachable,
+                },
                 indent=2,
             )
         )
@@ -458,4 +478,22 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
         console.print(f"[green]{message}[/green]")
     else:
         console.print(f"[red]{message}[/red]")
+
+    if reachable == UNREACHABLE:
+        console.print(
+            f"[yellow]inbox: NOT REACHABLE — 0 live subscribers. "
+            f"a2a_send to '{name}' will reach nobody (messages are queued and "
+            f"replayed when its channel adapter reconnects). The process is "
+            f"up; its inbox adapter is not attached. Do NOT force-restart on "
+            f"this alone.[/yellow]"
+        )
+    elif reachable == UNKNOWN:
+        console.print(
+            "[dim]inbox: unknown (could not reach sac listen to observe "
+            "subscribers)[/dim]"
+        )
+    else:
+        console.print(f"[green]inbox: reachable ({subscribers} subscriber(s))[/green]")
+
+    if not is_healthy:
         sys.exit(1)

--- a/tests/scitex_agent_container/_listen/test__reachability.py
+++ b/tests/scitex_agent_container/_listen/test__reachability.py
@@ -1,0 +1,203 @@
+"""REGISTERED is not REACHABLE — the inbox-subscriber observation.
+
+``GET /agents`` (which backs the ``a2a_peers`` MCP tool) used to report only
+what the registry DECLARED: a pid, a port, a start time, a group. An agent
+whose inbox adapter is not attached to the channel bus satisfies every one of
+those and still swallows every message sent to it. Two of four live agents
+were in exactly that state while advertising themselves as ``active``.
+
+These tests pin the distinction, and — just as importantly — pin the THIRD
+state. A remote agent's broker lives in another process that this listen
+cannot see; reporting it as ``unreachable`` would be a false accusation
+against a healthy peer, and the remedy a caller reaches for on a false death
+verdict is destructive. So "cannot observe" must come back as ``unknown``.
+
+Real ``Broker`` throughout — no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._listen._reachability import (
+    REACHABLE,
+    UNKNOWN,
+    UNREACHABLE,
+    annotate_reachability,
+    annotate_rows,
+)
+from scitex_agent_container.a2a._inbox_bus import Broker
+
+LOCAL = "ywata-note-win"
+
+
+# ---------------------------------------------------------------------------
+# Broker.subscriber_counts — the only OBSERVATION of reachability there is.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broker_reports_zero_for_an_agent_with_no_subscriber():
+    """The deaf case: nobody ever subscribed, so the agent is simply absent
+    from the map. Callers must read "absent" as zero."""
+    # Arrange
+    broker = Broker()
+    # Act
+    counts = await broker.subscriber_counts()
+    # Assert
+    assert counts.get("deaf-agent", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_broker_counts_a_live_subscriber():
+    # Arrange
+    broker = Broker()
+    await broker.subscribe("alice")
+    # Act
+    counts = await broker.subscriber_counts()
+    # Assert
+    assert counts["alice"] == 1
+
+
+@pytest.mark.asyncio
+async def test_broker_counts_drop_when_a_subscriber_leaves():
+    """An agent whose adapter disconnects becomes deaf again — the count must
+    follow reality, not the registry."""
+    # Arrange
+    broker = Broker()
+    queue = await broker.subscribe("alice")
+    await broker.unsubscribe("alice", queue)
+    # Act
+    counts = await broker.subscriber_counts()
+    # Assert
+    assert counts.get("alice", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_broker_snapshot_matches_publish_fanout():
+    """The count must be the SAME number ``publish`` fans out to — otherwise
+    a2a_peers would be advertising a reachability the bus does not honour."""
+    # Arrange
+    broker = Broker()
+    await broker.subscribe("alice")
+    await broker.subscribe("alice")
+    # Act
+    counts = await broker.subscriber_counts()
+    delivered = await broker.publish("alice", {"msg_id": "m1"})
+    # Assert
+    assert counts["alice"] == delivered
+
+
+# ---------------------------------------------------------------------------
+# annotate_reachability — the three states.
+# ---------------------------------------------------------------------------
+
+
+def test_agent_with_a_subscriber_is_reachable():
+    # Arrange
+    row = {"name": "scitex-todo", "host": LOCAL, "pid": 123}
+    # Act
+    out = annotate_reachability(
+        row, subscriber_counts={"scitex-todo": 1}, local_host=LOCAL
+    )
+    # Assert
+    assert out["inbox_reachable"] == REACHABLE
+
+
+def test_agent_with_no_subscriber_is_unreachable_not_active():
+    """THE BUG. A registered, running, ``active`` agent with zero subscribers
+    is NOT reachable, and must not be presented as though it were."""
+    # Arrange — every declaration says healthy; the bus says nobody is home.
+    row = {
+        "name": "claude-code-telegrammer",
+        "host": LOCAL,
+        "pid": 4242,
+        "groups": ["active"],
+    }
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNREACHABLE
+
+
+def test_unreachable_agent_reports_zero_subscribers():
+    # Arrange
+    row = {"name": "scitex-dev", "host": LOCAL, "pid": 7, "groups": ["active"]}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_subscribers"] == 0
+
+
+def test_remote_agent_is_unknown_not_unreachable():
+    """A peer on ANOTHER host has its subscribers in another process's broker.
+    We cannot see it, so we must not claim it is deaf — that would be a false
+    accusation, and false death verdicts get healthy agents destroyed."""
+    # Arrange
+    row = {"name": "remote-agent", "host": "spartan", "pid": 9}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNKNOWN
+
+
+def test_remote_agent_reports_null_subscribers_not_zero():
+    """A count we could not take is ``None``, never ``0``. Zero is a claim."""
+    # Arrange
+    row = {"name": "remote-agent", "host": "spartan"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_subscribers"] is None
+
+
+def test_row_without_a_host_is_observed_locally():
+    """The publish path treats a host-less name as local (see
+    ``state_db_nodes.is_local_node``), so the local broker IS authoritative
+    for it and a zero there is a real observation."""
+    # Arrange
+    row = {"name": "hostless", "pid": 1}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNREACHABLE
+
+
+def test_unknown_local_identity_makes_a_hosted_row_unknown():
+    """If we don't know which host WE are, we cannot prove a hosted row is
+    ours — so we cannot claim its broker is the one we just read."""
+    # Arrange
+    row = {"name": "somebody", "host": "elsewhere"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=None)
+    # Assert
+    assert out["inbox_reachable"] == UNKNOWN
+
+
+def test_annotation_preserves_the_registry_declaration():
+    """We ADD the observation next to the declaration. We never overwrite or
+    reinterpret what the registry said — both facts must stay readable."""
+    # Arrange
+    row = {"name": "a", "host": LOCAL, "pid": 5, "groups": ["active"], "role": "dev"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert (out["pid"], out["groups"], out["role"]) == (5, ["active"], "dev")
+
+
+def test_annotate_rows_separates_reachable_from_deaf_peers():
+    """The scorecard that started this: two agents delivered, two swallowed —
+    and the peer list called all four ``active``."""
+    # Arrange
+    rows = [
+        {"name": "scitex-todo", "host": LOCAL, "groups": ["active"]},
+        {"name": "scitex-agent-container", "host": LOCAL, "groups": ["active"]},
+        {"name": "claude-code-telegrammer", "host": LOCAL, "groups": ["active"]},
+        {"name": "scitex-dev", "host": LOCAL, "groups": ["active"]},
+    ]
+    counts = {"scitex-todo": 1, "scitex-agent-container": 1}
+    # Act
+    out = annotate_rows(rows, subscriber_counts=counts, local_host=LOCAL)
+    deaf = [r["name"] for r in out if r["inbox_reachable"] == UNREACHABLE]
+    # Assert
+    assert deaf == ["claude-code-telegrammer", "scitex-dev"]

--- a/tests/scitex_agent_container/_mcp/test__channel_send_errors.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_send_errors.py
@@ -1,0 +1,317 @@
+"""The FAIL-LOUD contract: a send that reached nobody must FAIL the call.
+
+Why this module exists as its own file
+--------------------------------------
+``test__channel_tools.py`` already asserted that a 0-subscriber send returns
+a body containing an ``error`` key. Those tests passed — and agents silently
+swallowed each other's messages anyway.
+
+The gap: a caller does not decide "did my call succeed?" by reading the body.
+It reads the MCP protocol's ``isError`` flag. And the low-level server stamps
+``isError=False`` on ANY plain ``list[TextContent]`` a handler returns — so
+"reached no live subscriber" was arriving inside a result the protocol
+classified as SUCCESSFUL. The old tests could not have caught that, because
+they invoked the handler directly and never went through the component that
+produces the flag.
+
+So every test here drives a REAL ``mcp.server.lowlevel.Server`` against a
+REAL loopback HTTP listen. No mocks. The assertions are about what the caller
+actually sees.
+
+The three states (and why the middle one is the only failure)
+-------------------------------------------------------------
+* ``delivered_subscriber_count >= 1`` → delivered. Success.
+* ``delivered_subscriber_count == 0``  → DEFINITIVELY not delivered. The bus
+  fanned out to nobody. This is evidence, so it fails loudly.
+* field ABSENT (e.g. a cross-host forward) → could not determine. Inventing a
+  zero would be a false accusation of non-delivery, so it does NOT fail.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+pytest.importorskip("mcp.types")  # gates the module on `mcp`
+
+from scitex_agent_container._mcp._channel_send_errors import (  # noqa: E402
+    ERR_NO_SUBSCRIBER,
+    ERR_UNREACHABLE,
+)
+from scitex_agent_container._mcp._channel_tools import register_tools  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# A real loopback listen. Speaks just enough HTTP/1.1 to answer message:send
+# with a configurable publish reply — the same shape sac listen returns from
+# ``node_message_send``.
+# ---------------------------------------------------------------------------
+
+
+class _FakeListen:
+    """Real asyncio TCP server answering ``POST /agents/<n>/message:send``."""
+
+    def __init__(self) -> None:
+        self.send_response: dict[str, Any] = {"ok": True}
+        self._server: asyncio.base_events.Server | None = None
+        self.port = 0
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            if not await reader.readline():
+                return
+            content_length = 0
+            while True:
+                line = await reader.readline()
+                if line in (b"\r\n", b"\n", b""):
+                    break
+                if line.lower().startswith(b"content-length:"):
+                    content_length = int(line.split(b":", 1)[1].strip())
+            if content_length:
+                await reader.readexactly(content_length)
+            body = json.dumps(self.send_response).encode()
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"Connection: close\r\n\r\n" + body
+            )
+            await writer.drain()
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+
+@pytest_asyncio.fixture
+async def listen():
+    server = _FakeListen()
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+async def _call(listen_url: str, tool: str, args: dict[str, Any]):
+    """Invoke ``tool`` through a REAL MCP Server; return its CallToolResult.
+
+    This is the caller's-eye view. The low-level server is what turns a
+    handler's return value into the ``CallToolResult`` (and its ``isError``
+    flag) that the calling model receives — so it is the only place the
+    swallowed-message bug was ever observable.
+    """
+    import mcp.types as types
+    from mcp.server.lowlevel import Server
+
+    server = Server(name="sac-channel-test")
+    register_tools(server, agent_name="alice", listen_url=listen_url, bearer=None)
+    handler = server.request_handlers[types.CallToolRequest]
+    request = types.CallToolRequest(
+        method="tools/call",
+        params=types.CallToolRequestParams(name=tool, arguments=args),
+    )
+    return (await handler(request)).root
+
+
+def _body(result) -> dict[str, Any]:
+    return json.loads(result.content[0].text)
+
+
+def _refused_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = int(s.getsockname()[1])
+    s.close()
+    return port
+
+
+# ---------------------------------------------------------------------------
+# THE BUG: 0 subscribers came back as a SUCCESSFUL tool call.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_send_is_an_mcp_error(listen):
+    """delivered_subscriber_count == 0 → the caller must see a FAILED call,
+    not a success whose body merely mentions an error."""
+    # Arrange — the listen publishes to nobody.
+    listen.send_response = {"msg_id": "m1", "delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert result.isError is True
+
+
+@pytest.mark.asyncio
+async def test_delivered_send_is_not_an_mcp_error(listen):
+    """Guard against the fail-loud check over-firing: >= 1 subscriber is a
+    real delivery and must stay a plain success."""
+    # Arrange
+    listen.send_response = {"msg_id": "m1", "delivered_subscriber_count": 1}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert result.isError is False
+
+
+@pytest.mark.asyncio
+async def test_absent_subscriber_count_is_not_an_mcp_error(listen):
+    """Three states, not two. An ABSENT count (a cross-host forward that does
+    not report one) is "could not determine" — it must NOT be inferred as zero
+    and failed. Absence of evidence is not evidence of non-delivery."""
+    # Arrange — a 200 carrying no delivered_subscriber_count at all.
+    listen.send_response = {"ok": True}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert result.isError is False
+
+
+@pytest.mark.asyncio
+async def test_unreachable_listen_is_an_mcp_error():
+    """Connection refused is a demonstrable non-delivery — also a caller-
+    visible failure, not a quietly-swallowed one."""
+    # Arrange — nothing is listening on this port.
+    url = f"http://127.0.0.1:{_refused_port()}"
+    # Act
+    result = await _call(url, "a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert result.isError is True
+
+
+@pytest.mark.asyncio
+async def test_reply_to_unknown_msg_id_is_an_mcp_error(listen):
+    """A reply that resolved no recipient delivered nothing either."""
+    # Arrange — nothing in the inbox ring, so this msg_id resolves to no sender.
+    unknown_msg_id = "ghost"
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_reply", {"in_reply_to": unknown_msg_id, "content": "x"}
+    )
+    # Assert
+    assert result.isError is True
+
+
+# ---------------------------------------------------------------------------
+# The failure must stay ACTIONABLE — loud is not enough if it strands the
+# caller. The detail (who, how many, what now) survives the fail-loud change.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_error_names_the_target(listen):
+    # Arrange
+    listen.send_response = {"delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert _body(result)["target"] == "bob"
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_error_carries_machine_readable_code(listen):
+    # Arrange
+    listen.send_response = {"delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert _body(result)["code"] == ERR_NO_SUBSCRIBER
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_error_reports_the_subscriber_count(listen):
+    # Arrange
+    listen.send_response = {"delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert _body(result)["delivered_subscriber_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_error_states_delivered_false(listen):
+    # Arrange
+    listen.send_response = {"delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert _body(result)["delivered"] is False
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_error_reports_the_message_as_durably_queued(listen):
+    """sac listen persists to ``channel_events`` BEFORE it publishes, and
+    replays undelivered rows on the target's next connect. "Not delivered"
+    therefore does not mean "lost" — and telling the caller to re-send would
+    double-deliver once the adapter reconnects."""
+    # Arrange
+    listen.send_response = {"delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert _body(result)["durably_queued"] is True
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_error_does_not_prescribe_a_restart(listen):
+    """0 subscribers means a DETACHED INBOX ADAPTER, not a dead agent. The
+    remedy must never be one that destroys a healthy session."""
+    # Arrange
+    listen.send_response = {"delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    advice = " ".join(_body(result)["what_to_do"]).lower()
+    # Assert
+    assert "do not force-restart" in advice
+
+
+@pytest.mark.asyncio
+async def test_unreachable_error_carries_machine_readable_code():
+    # Arrange
+    url = f"http://127.0.0.1:{_refused_port()}"
+    # Act
+    result = await _call(url, "a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert _body(result)["code"] == ERR_UNREACHABLE

--- a/tests/scitex_agent_container/_mcp/test__channel_tools.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_tools.py
@@ -25,10 +25,39 @@ import pytest
 import pytest_asyncio
 
 mcp_types = pytest.importorskip("mcp.types")  # gates entire module on `mcp`
-from mcp.types import TextContent, Tool  # noqa: E402
+from mcp.types import CallToolResult, TextContent, Tool  # noqa: E402
 
 from scitex_agent_container._mcp._channel_tools import register_tools  # noqa: E402
 from scitex_agent_container._mcp.channel import _recent  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Result helpers.
+#
+# A tool result is EITHER a plain ``list[TextContent]`` (success — the MCP
+# server stamps ``isError=False`` on it) OR a ``CallToolResult`` carrying
+# ``isError=True`` (failure). Both shapes are unwrapped uniformly here so the
+# assertions stay about BEHAVIOUR, not about which container the payload
+# arrived in.
+# ---------------------------------------------------------------------------
+
+
+def _blocks(out: "list[TextContent] | CallToolResult") -> "list[TextContent]":
+    """Content blocks of a tool result, whichever shape it came back in."""
+    if isinstance(out, CallToolResult):
+        return list(out.content)
+    return list(out)
+
+
+def _payload(out: "list[TextContent] | CallToolResult") -> dict:
+    """The JSON body of a tool result."""
+    return json.loads(_blocks(out)[0].text)
+
+
+# NB: whether a failure is actually visible to the CALLER (the MCP ``isError``
+# flag, which a bare ``list[TextContent]`` can never set) is pinned in
+# ``test__channel_send_errors.py`` — it drives a real ``mcp.server.lowlevel``
+# Server rather than the ``_ToolRecorder`` stand-in used here, because that
+# flag is produced by the server, not by the handler.
 
 # ---------------------------------------------------------------------------
 # Real in-process HTTP/1.1 + JSON server (no aiohttp dependency).
@@ -259,7 +288,7 @@ async def test_call_tool_unknown_name_returns_error_payload(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("not_a_tool", {})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert "error" in body
 
@@ -311,7 +340,7 @@ async def test_call_tool_a2a_send_returns_status_field(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_send", {"target": "bob", "content": "hi"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert body["status"] == 200
 
@@ -483,7 +512,7 @@ async def test_call_tool_a2a_reply_unknown_msg_id_returns_error(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_reply", {"in_reply_to": "ghost", "content": "x"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert "error" in body
 
@@ -539,7 +568,7 @@ async def test_call_tool_a2a_reply_unknown_sender_returns_error(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_reply", {"in_reply_to": "m9", "content": "x"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert "error" in body
 
@@ -552,7 +581,7 @@ async def test_call_tool_a2a_ack_unknown_msg_id_returns_error(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_ack", {"msg_id": "nope"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert "error" in body
 
@@ -566,7 +595,7 @@ async def test_call_tool_a2a_ack_unknown_sender_returns_error(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_ack", {"msg_id": "m11"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert "error" in body
 
@@ -599,7 +628,7 @@ async def test_call_tool_a2a_ack_returns_suppression_marker(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_ack", {"msg_id": "m1"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert body.get("body", {}).get("suppressed") == "empty_ack"
 
@@ -613,7 +642,7 @@ async def test_call_tool_a2a_peers_returns_status(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_peers", {})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert body["status"] == 200
 
@@ -627,7 +656,7 @@ async def test_call_tool_a2a_peers_returns_peers_body(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_peers", {})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert body["body"] == {"agents": ["alice", "bob"]}
 
@@ -647,7 +676,7 @@ async def test_call_tool_a2a_inbox_returns_count(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_inbox", {"limit": 10})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert body["count"] == 3
 
@@ -662,7 +691,7 @@ async def test_call_tool_a2a_inbox_respects_limit(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_inbox", {"limit": 5})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert body["count"] == 5
 
@@ -705,9 +734,9 @@ async def test_register_tools_forwards_bearer_token_on_post(fake_listen):
 # ---------------------------------------------------------------------------
 
 
-def _err(out: "list[TextContent]") -> str | None:
+def _err(out: "list[TextContent] | CallToolResult") -> str | None:
     """Pull the ``error`` field out of a tool result, or None."""
-    body = json.loads(out[0].text)
+    body = _payload(out)
     return body.get("error") if isinstance(body, dict) else None
 
 
@@ -833,6 +862,6 @@ async def test_a2a_ack_is_suppressed_before_subscriber_check(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_ack", {"msg_id": "orig2"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert _err(out) is None and body.get("body", {}).get("suppressed") == "empty_ack"


### PR DESCRIPTION
## The bug

Reported by the **`grant`** agent, from a live session. Their scorecard — every `a2a_send` they attempted:

```
scitex-todo              -> DELIVERED (delivered_subscriber_count=1)
scitex-agent-container   -> DELIVERED (delivered_subscriber_count=1)
claude-code-telegrammer  -> 0 subscribers   <-- registry says groups include "active"
scitex-dev               -> 0 subscribers   <-- registry says groups include "active"
```

> **"Had it returned a bare 200, I would have believed the message landed and moved on.
> HOW MANY AGENT-TO-AGENT MESSAGES HAVE BEEN SWALLOWED THIS WAY? Nobody would know."**

They are right, and the mechanism is worse than a missing check — **the check was already there and did not matter.**
`a2a_send` *did* detect the 0-subscriber case and *did* put `"reached no live subscriber"` in its response body. But it
returned that body as a plain `list[TextContent]`, and the MCP low-level server (`mcp==1.28.1`) stamps
**`isError=False`** on anything a handler returns that way:

```python
# mcp/server/lowlevel/server.py — call_tool()
results = await func(tool_name, arguments)
...
return types.ServerResult(types.CallToolResult(
    content=list(unstructured_content), ..., isError=False,   # <-- always
))
```

So the protocol classified "the message woke nobody" as a **successful tool call**. A caller that trusts the MCP contract —
rather than string-matching the payload — reads it as delivered. That is a DECLARED state (`active` in the registry)
trusted as an OBSERVED one (an inbox that is actually attached), and it defeats the constitution's own rule: grant *did*
confirm the peers were alive-and-able, via `a2a_peers`, the tool provided for exactly that — and the confirmation was false.

The existing tests could never have caught it. They asserted the *body* contained an `error` key, and passed all along —
they invoked the handler directly, so they never went through the component that produces the flag.

---

## 1. A 0-subscriber send now FAILS to the caller

`a2a_send` / `a2a_reply` / `a2a_ack` return a `CallToolResult` with **`isError=True`** on demonstrable non-delivery (the
MCP server passes a `CallToolResult` through verbatim, unlike a bare `list[TextContent]`). Success is unchanged.

**Callers checked before changing the contract, as asked.** The only *production* consumer of the handler's return value
is the MCP SDK itself → the model. Every other caller of `call_tool_fn` is test code. So the change is contained; those
tests are updated.

The failure stays **actionable** — loud is not enough if it strands the caller:

```json
{
  "error": "NOT DELIVERED — send to 'scitex-dev' reached no live subscriber ...",
  "code": "no_live_subscriber",
  "target": "scitex-dev",
  "delivered": false,
  "delivered_subscriber_count": 0,
  "durably_queued": true,
  "what_to_do": ["...", "...", "..."]
}
```

Two things the remedy deliberately does **not** say — both of which I had wrong on the first pass and corrected against
the source:

- **It does not tell you to re-send.** `node_message_send` calls `persist_event(...)` *before* `broker.publish(...)`, and
  `node_inbox_stream` replays `list_undelivered(target)` on every fresh connect. A 0-subscriber message is **queued, not
  lost** — it is replayed when the target's adapter reconnects. Telling the caller to re-send would double-deliver.
- **It does not recommend `agent_send`, and it does not tell you to restart the target.** `agent_send` POSTs to the agent's
  `/v1/turn` sidecar port which — per the measurement already recorded in `cli_pkg/_send.py` (2026-07-14) — only **5 of 47**
  registered agents actually bind. Its own error path tells callers to use a2a instead, so recommending it here would be a
  circular dead end for most of the fleet.

## 2. Reachability is now OBSERVABLE — registered ≠ reachable

`GET /agents` (which backs `a2a_peers`), `GET /agents/<name>/status`, and `sac agents health --json` now each carry:

- **`inbox_subscribers`** — live SSE subscribers on that agent's inbox stream, read from the one component that actually
  knows: the `Broker` inside `sac listen`.
- **`inbox_reachable`** — **ternary on purpose**: `reachable` / `unreachable` / `unknown`.

`unknown` is not padding. A peer on another host keeps its subscribers in a different process's broker, which this listen
cannot see. Reporting that as `unreachable` would be a false accusation against a healthy agent — and the remedy a caller
reaches for on a false death verdict is destructive. **"I could not check" is never rendered as success or as death**,
including when the broker itself is unreadable (that degrades to `unknown`, never to `unreachable`).

The registry's declarations (`pid`, `groups`, `started_at`) are preserved untouched. The observation is added *next to* the
declaration, never over it.

**`healthy` is deliberately NOT derived from the subscriber count**, and nothing auto-restarts on it. Section 3 shows why
that restraint is load-bearing rather than timid.

---

## 3. Root cause of the deaf subscribe: FOUND — and it is two unrelated bugs, not one

I root-caused it. Stating plainly what is proven and what is not.

**grant's "2 work / 2 deaf" split is a coincidence.** The two deaf agents were deaf for entirely different reasons, sampled
at one instant. All four share identical specs (`server:sac` channel, `runtime: tui`, `a2a.port: auto`); all four registered
their adapter under the correct broker key (`sac-channel-<agent>`, confirmed in their MCP logs); all four resolve the same
listen (`SAC_LISTEN_BASE_URL` is injected unconditionally as `http://127.0.0.1:7878`). Name-mismatch, wrong-listen-URL,
not-configured, and runtime-difference are therefore all **disproven**.

### `scitex-dev` — dead since 2026-07-11, and its registry row is UNFALSIFIABLE. This is the true false-green.

No tmux session, no `sac mcp channel --name scitex-dev` process, a2a port 19013 unbound, and `agent_status` itself says
`startup_failed / post_ack_no_apptainer_pid`. Yet `a2a_peers` lists it running with a pid, a port, a start time, and group
`active`. The engine of the lie:

```json
// runtime/scitex-dev/heartbeat.json  (15.5h stale)
{"pid": 0, "state": "running", "seconds_since_last_beat": 2796}
```

`state=running` with **`pid: 0`**. sac's liveness helpers correctly treat `pid <= 0` as *no verdict*, not *dead*
(`_lifecycle/_instances.py:81`, `cli_pkg/_send_diagnosis.py:58-66` — the rule #644 established). But paired with a writer
that persists `pid: 0`, the row becomes **unfalsifiable by construction**: there is no pid to disprove it, nothing reaps it,
and `state=running` survives forever. It then self-perpetuates — `_start.py:298` sees the stale row, prints *"already
running. No-op."*, and returns **rc=0**.

### `claude-code-telegrammer` — not broken at all.

Its adapter is alive (pid 504300) and holds an ESTABLISHED socket to `127.0.0.1:7878`. Its zero was a **transient reconnect
window**: `sac listen` is churning (pid turnover `738982 → 745734 → 823966` inside ~7 minutes; two `listen` processes
coexisted despite the flock guard). Every listen restart destroys the in-memory `Broker`, so *every* adapter's SSE dies at
once and all 12 climb the `_consume_sse` backoff ladder (0.5s doubling, capped at 30s, **no jitter**).

**This is precisely why nothing here auto-restarts on a 0-subscriber signal.** Had we "fixed" cct by restarting it — the
obvious move, and the one the ticket explicitly warned against — we would have destroyed a healthy, working session to cure
a 30-second backoff window.

Both root causes are **out of scope for this PR** and filed as cards, because both sit in the liveness/start-gating and
daemon-supervision blast radius, where a confident wrong fix destroys healthy agents:

- `sac-stale-heartbeat-pid0-unfalsifiable-row` — the heartbeat writer must never persist `state=running` with `pid=0`, and
  `_start.py`'s "already running" gate must not trust a row with a null/0 pid or a heartbeat stale past threshold.
- `sac-listen-churn-kills-every-inbox-subscriber` — why is `sac listen` respawning, and how did two instances survive the
  flock guard? Plus: jitter the adapter reconnect ladder.

**This PR fixes DETECTION, not either root cause.** That is worth shipping on its own: until now the fleet could not even
tell this was happening.

---

## Verification

- **Import path proven** — an installed-package import would have made a green run meaningless:
  with `PYTHONPATH=<worktree>/src` →
  `/home/ywatanabe/proj/scitex-agent-container/.worktrees/agent-a9287527b09c02610/src/scitex_agent_container/__init__.py`

  ⚠️ **Reviewers:** `pyproject.toml` sets no pytest `pythonpath`, so a bare local `pytest` here imports the **installed**
  `scitex_agent_container` from site-packages, not `src/`. CI installs the package, so CI is unaffected — but a local run
  without `PYTHONPATH` tests the wrong code.

- **The tests fail first.** Against the original `_channel_tools.py` (fix stashed, tests kept): **10 failed, 2 passed** —
  and the 2 that passed are exactly the controls (`delivered → not an error`, `absent count → not an error`), which
  correctly hold on the old code. The suite detects the bug rather than always failing. With the fix, all pass.

- **No mocks.** The fail-loud tests drive a real `mcp.server.lowlevel.Server` against a real `asyncio.start_server`
  loopback listen; the reachability tests use a real `Broker`. No test touches live fleet state.

- **`scripts/check_stx_allow.py`** (no-silent-fallback gate): the 4 new modules are clean, and every touched file has
  **exactly** the same violation count as `origin/develop` — zero new violations.

- `_listen/server.py` was at the 512-line cap, so `list_agents` moved to `_listen/_agents_list.py`, mirroring the repo's
  existing extractions (`agent_send`, `node_message_send`, `agent_tail`). `server.py` re-exports it, so route registration
  and the historical import path are unchanged (asserted: `server.list_agents is _agents_list.list_agents`).

## Known gap — disclosed rather than silently expanded

A **4xx** (notably the 403 ACL deny) also delivers nothing, yet still returns `isError=False`. I left it alone: it is a
deliberate, documented design ("denial is the policy working" — the sender gets a structured 403 carrying the `reason` and
the exact `sac a2a grant` command), and it is pinned by `tests/smoke/test_node_comms_e2e_mcp.py`. It is also materially less
dangerous than the bug fixed here: a 403 body is self-evidently a failure, whereas the 0-subscriber case returned an
**HTTP 200**. Flipping it is a one-line change *if* the owner wants it — but it changes the ACL contract and belongs in its
own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
