### PR TITLE
feat(listen): give the `listen` NOUN explicit verbs — add `start` + `stop` (bare boot deprecated, NOT removed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`sac listen start` and `sac listen stop` — `listen` is a NOUN, so give it
+  verbs.** `listen` is a command group like `agents` / `db` / `host`, but bare
+  `sac listen` *booted a daemon*. Every other noun group in this CLI prints help
+  when invoked bare; this one silently became a server on 7878 — so a typo or a
+  stray tab-complete started one. That is the anti-pattern the scitex CLI
+  convention names outright (§1: *"trailing noun, no action: **never**"*).
+
+  The group already had `restart` and `status` (the latter easy to miss — it was
+  absent from the help's example block). It now has the coherent set:
+
+  ```bash
+  sac listen start      # boot the daemon (the explicit form of bare `sac listen`)
+  sac listen stop       # NEW — idempotent, like `systemctl stop`
+  sac listen restart    # unchanged
+  sac listen status     # unchanged, now discoverable in `-h`
+  ```
+
+  `start`, not `serve`: the §1d catalog reserves `start`/`stop`/`restart` for
+  *daemonized* lifecycle (a background process with a pid) and gives `serve` to
+  foreground, browser-facing surfaces under a `gui` group. This daemon writes a
+  flock-backed pidfile that `stop`/`restart`/`status` all address by pid, and a
+  systemd unit supervises it. `start` also keeps SSOT with `sac agents start`.
+
+  Options work on the verb (`sac listen start --bind …`) or on the group
+  (`sac listen --bind … start`); the verb wins.
+
+  `stop` is `restart`'s stop half on its own — both now call one implementation
+  (`_listen._stop.stop_listen`), so the two verbs cannot drift. It inherits the
+  full self-heal: SIGTERM → grace → SIGKILL, verify-dead *before* clearing the
+  pidfile, then force-kill a wedged remnant the pidfile never named (the "curl
+  hangs forever" case). `--json` emits a machine-readable envelope.
+
+### Deprecated
+
+- **Bare `sac listen` (boot-by-default) — removal in v0.23.0.** It **still
+  boots**, and deliberately so: it is the launch command of the systemd unit,
+  of `sac listen restart`'s respawn, and of the systemd JobSpec in #543. `sac
+  listen` *is* the host control plane on 127.0.0.1:7878 — flipping the bare form
+  to show-help would take the whole fleet's host access down with it. So this is
+  phase W of the deprecation ladder: **warn and forward**, never break.
+
+  Bare boot now prints a stderr warning naming `sac listen start` and the
+  removal version. Before v0.23.0, every launcher above must move to
+  `sac listen start`.
+
 ## [0.21.16] — 2026-07-14
 
 **⚠️ 0.21.15 WAS NEVER PUBLISHED — it is tagged, but nothing reached PyPI, and

--- a/src/scitex_agent_container/_listen/_restart.py
+++ b/src/scitex_agent_container/_listen/_restart.py
@@ -345,14 +345,26 @@ def restart_listen(
     ``host``/``port`` mirror ``sac listen``'s bind resolution per (a);
     ``lock_dir`` matches ``_single_instance.default_lock_dir()``. Never
     raises — every failure populates ``RestartResult.error``.
-    """
-    pid_file = pidfile_path(port, lock_dir)
-    prior_pid = read_pid_from_file(pid_file)
-    had_prior_pidfile = pid_file.is_file()
-    prior_alive = prior_pid is not None and pid_alive(prior_pid)
 
-    escalated = False
-    port_holders_killed: tuple[int, ...] = ()
+    The STOP half (steps 1-5 above) is SSOT in ``._stop.stop_listen`` —
+    the exact sequence ``sac listen stop`` runs — so the two verbs can
+    never drift. Imported lazily because ``_stop`` imports THIS module
+    (it reaches the ``_kill`` / ``_sleep`` test seams through the module
+    object), and a top-level import here would close that cycle.
+    """
+    from ._stop import stop_listen
+
+    stopped = stop_listen(
+        host=host,
+        port=port,
+        lock_dir=lock_dir,
+        grace_secs=grace_secs,
+        force=force,
+    )
+    escalated = stopped.escalated_to_sigkill
+    had_prior_pidfile = stopped.had_prior_pidfile
+    prior_alive = stopped.prior_pid_alive
+    port_holders_killed = stopped.port_holders_killed
 
     def _fail(*, error: str, took_systemd_path: bool = False) -> RestartResult:
         """Failure result capturing pre-state + self-heal progress so
@@ -368,44 +380,10 @@ def restart_listen(
             port_holders_killed=port_holders_killed,
         )
 
-    if prior_pid is not None and prior_alive:
-        escalated = _terminate_then_kill(
-            prior_pid, grace_secs=grace_secs, force_kill=force
-        )
-        # Defence-in-depth: confirm the PID is actually dead before
-        # touching the pidfile. If still alive after SIGKILL, bail
-        # rather than clear the lock + let a second daemon start beside.
-        _sleep(_POLL_INTERVAL_SECS)
-        if pid_alive(prior_pid):
-            return _fail(
-                error=(
-                    f"PID {prior_pid} survived SIGKILL — refusing to "
-                    f"clear pidfile or relaunch. Inspect manually "
-                    f"(zombie/uninterruptible state)."
-                )
-            )
-
-    try:
-        pid_file.unlink(missing_ok=True)
-    except OSError as exc:
-        return _fail(error=f"failed to clear stale pidfile {pid_file}: {exc!r}")
-
-    # Self-heal a WEDGED port holder the pidfile never named (the
-    # "curl hangs forever" remnant) before relaunch so the new daemon
-    # doesn't hit EADDRINUSE. terminate/sleep are passed in so the
-    # escalation seams stay owned here (and avoid a circular import).
-    heal = clear_wedged_port_holders(
-        host=host,
-        port=port,
-        grace_secs=grace_secs,
-        force=force,
-        terminate_fn=_terminate_then_kill,
-        sleep_fn=_sleep,
-        poll_interval=_POLL_INTERVAL_SECS,
-    )
-    port_holders_killed = heal.killed
-    if heal.error:
-        return _fail(error=heal.error)
+    # A failed stop must NEVER relaunch — that would race a surviving
+    # daemon or bind into an EADDRINUSE on a still-wedged port.
+    if not stopped.ok:
+        return _fail(error=stopped.error)
 
     use_systemd = systemd_unit_is_active(systemd_unit_path)
     if use_systemd:

--- a/src/scitex_agent_container/_listen/_stop.py
+++ b/src/scitex_agent_container/_listen/_stop.py
@@ -1,0 +1,155 @@
+"""Stop sequence for the ``sac listen`` daemon — the half ``restart`` shares.
+
+``sac listen stop`` and ``sac listen restart`` must never drift: a restart
+IS a stop, followed by a relaunch and a health-probe. This module owns the
+stop half as ONE implementation so the two verbs cannot diverge (SSOT).
+``restart_listen`` used to run this sequence inline; it now calls
+:func:`stop_listen`, and the behaviour is unchanged.
+
+The sequence:
+
+1. Read the PID from the flock-backed pidfile at
+   ``<lock_dir>/listen-<port>.pid``.
+2. SIGTERM it and poll for exit up to ``grace_secs``, escalating to
+   SIGKILL on timeout (``force=True`` skips straight to SIGKILL).
+3. **Verify the PID is really dead BEFORE clearing the pidfile** — never
+   release a lock whose owner still lives, or a second daemon starts
+   beside it.
+4. Self-heal a WEDGED port holder the pidfile never named — the half-dead
+   uvicorn that ``curl`` hangs on, whose pidfile may already be ``rm``-ed
+   (incident 2026-06-26; see :mod:`._port_holder`).
+
+**Idempotent**: stopping an already-stopped daemon is SUCCESS
+(``ok=True``, ``was_running=False``) — the same contract as
+``systemctl stop``. Only a daemon we could not kill is a failure.
+
+**Seams.** Every primitive is reached through the ``_restart`` MODULE
+OBJECT (``_restart._sleep``, ``_restart._terminate_then_kill``, …) and
+resolved at CALL time — never bound via ``from ._restart import _sleep``
+at import. Tests swap those module attributes to drive the sequence
+without real signals; a from-import would capture the ORIGINAL callable
+and silently defeat the swap, so the tests would pass while testing
+nothing.
+
+Pure-logic module — no click. Never raises: every failure lands in
+:attr:`StopResult.error`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import _restart
+
+
+@dataclass(frozen=True)
+class StopResult:
+    """Outcome of a :func:`stop_listen` invocation.
+
+    ``ok`` is ``True`` for an idempotent no-op (nothing was running) —
+    stopping a down daemon is success, not failure. :attr:`was_running`
+    is what distinguishes the two for the CLI's report.
+
+    ``port_holders_killed`` records any UNtracked PID(s) the self-heal
+    force-killed off the port — empty when only the pidfile-tracked
+    daemon was stopped.
+    """
+
+    ok: bool
+    escalated_to_sigkill: bool
+    had_prior_pidfile: bool
+    prior_pid_alive: bool
+    prior_pid: int | None = None
+    port_holders_killed: tuple[int, ...] = ()
+    error: str = ""
+
+    @property
+    def was_running(self) -> bool:
+        """``True`` iff we actually stopped something.
+
+        Either the pidfile named a live daemon, or an untracked remnant
+        was still holding the port.
+        """
+        return self.prior_pid_alive or bool(self.port_holders_killed)
+
+
+def stop_listen(
+    *,
+    host: str,
+    port: int,
+    lock_dir: Path,
+    grace_secs: float = _restart.DEFAULT_GRACE_SECS,
+    force: bool = False,
+) -> StopResult:
+    """Stop the ``sac listen`` daemon bound at ``host:port``.
+
+    ``host``/``port`` mirror ``sac listen``'s own bind resolution;
+    ``lock_dir`` matches ``_single_instance.default_lock_dir()``. Never
+    raises — every failure populates :attr:`StopResult.error`.
+    """
+    pid_file = _restart.pidfile_path(port, lock_dir)
+    prior_pid = _restart.read_pid_from_file(pid_file)
+    had_prior_pidfile = pid_file.is_file()
+    prior_alive = prior_pid is not None and _restart.pid_alive(prior_pid)
+
+    escalated = False
+
+    def _fail(error: str, *, killed: tuple[int, ...] = ()) -> StopResult:
+        """Failure result capturing pre-state + self-heal progress so far."""
+        return StopResult(
+            ok=False,
+            escalated_to_sigkill=escalated,
+            had_prior_pidfile=had_prior_pidfile,
+            prior_pid_alive=prior_alive,
+            prior_pid=prior_pid,
+            port_holders_killed=killed,
+            error=error,
+        )
+
+    if prior_pid is not None and prior_alive:
+        escalated = _restart._terminate_then_kill(
+            prior_pid, grace_secs=grace_secs, force_kill=force
+        )
+        # Defence-in-depth: confirm the PID is actually dead before
+        # touching the pidfile. If it survived SIGKILL, bail rather than
+        # clear the lock and let a second daemon start beside it.
+        _restart._sleep(_restart._POLL_INTERVAL_SECS)
+        if _restart.pid_alive(prior_pid):
+            return _fail(
+                f"PID {prior_pid} survived SIGKILL — refusing to "
+                f"clear pidfile or relaunch. Inspect manually "
+                f"(zombie/uninterruptible state)."
+            )
+
+    try:
+        pid_file.unlink(missing_ok=True)
+    except OSError as exc:
+        return _fail(f"failed to clear stale pidfile {pid_file}: {exc!r}")
+
+    # Free the port from an UNtracked wedged remnant the pidfile never
+    # named. The terminate/sleep seams are passed in so escalation stays
+    # owned by ``_restart`` (and to avoid a circular import).
+    heal = _restart.clear_wedged_port_holders(
+        host=host,
+        port=port,
+        grace_secs=grace_secs,
+        force=force,
+        terminate_fn=_restart._terminate_then_kill,
+        sleep_fn=_restart._sleep,
+        poll_interval=_restart._POLL_INTERVAL_SECS,
+    )
+    if heal.error:
+        return _fail(heal.error, killed=heal.killed)
+
+    return StopResult(
+        ok=True,
+        escalated_to_sigkill=escalated,
+        had_prior_pidfile=had_prior_pidfile,
+        prior_pid_alive=prior_alive,
+        prior_pid=prior_pid,
+        port_holders_killed=heal.killed,
+    )
+
+
+__all__ = ["StopResult", "stop_listen"]

--- a/src/scitex_agent_container/_skills/scitex-agent-container/10_cli.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/10_cli.md
@@ -49,17 +49,33 @@ Reads `session_id` from the per-agent state dir and shells out to `claude --resu
 
 ## sac listen (HTTP/JSON control plane)
 
+`listen` is a **noun** — a command group like `agents` / `db` / `host`. Its
+four verbs are the whole lifecycle:
+
 ```bash
-sac listen                                # Boot the local control-plane server (loopback only by default)
-sac listen --bind 127.0.0.1:7878          # Custom bind
-sac listen --print-token                  # Echo the bearer token & exit
+sac listen start                          # Boot the control-plane daemon (loopback only by default)
+sac listen start --bind 127.0.0.1:7979    # Custom bind
+sac listen start --print-token            # Echo the bearer token & exit (does not boot)
 sac listen status                         # One-shot health report (UP/WEDGED/DOWN); exit 1 if not serving
 sac listen status --json                  # Machine-readable status envelope
+sac listen stop                           # Stop the daemon (idempotent — exit 0 if already down)
+sac listen stop --force                   # SIGKILL the daemon + any wedged port holder immediately
+sac listen stop --json                    # Machine-readable result envelope
 sac listen restart                        # Self-healing stop-clean-relaunch (clears stale pidfile, force-kills wedged port holder)
 sac listen restart --force                # SIGKILL the daemon + any wedged port holder immediately
 ```
 
-`restart` is the deterministic incident-recovery verb: it clears a stale pidfile, force-kills an untracked remnant still holding the port (the "curl hangs forever" case), then relaunches and health-probes — failing loud (non-zero, `ERROR:` naming the real cause) if the daemon can't be brought up. `status` is the one-command diagnosis.
+Options may be given on the verb (`sac listen start --bind …`) or on the
+group (`sac listen --bind … start`); the verb wins.
+
+`restart` is the deterministic incident-recovery verb: it clears a stale pidfile, force-kills an untracked remnant still holding the port (the "curl hangs forever" case), then relaunches and health-probes — failing loud (non-zero, `ERROR:` naming the real cause) if the daemon can't be brought up. `status` is the one-command diagnosis. `stop` is `restart`'s stop half on its own — they share one implementation (`_listen._stop.stop_listen`), so they cannot drift.
+
+> **DEPRECATED — bare `sac listen`.** It still BOOTS the daemon (the systemd
+> unit, `sac listen restart`'s respawn, and the systemd JobSpec all still
+> invoke it bare), but it now prints a deprecation warning to stderr. Use
+> **`sac listen start`**. The bare form is removed in **v0.23.0**; every
+> launcher must move to `sac listen start` before then. Booting a daemon off a
+> bare noun is a footgun — a typo or a stray tab-complete starts a server.
 
 When running, exposes (bearer-token authenticated, except the public health route):
 

--- a/src/scitex_agent_container/cli_pkg/_listen_verbs.py
+++ b/src/scitex_agent_container/cli_pkg/_listen_verbs.py
@@ -1,0 +1,249 @@
+"""``sac listen start`` / ``sac listen stop`` — the explicit lifecycle verbs.
+
+``listen`` is a NOUN — a command group, exactly like ``agents`` / ``db`` /
+``host``. Booting a daemon off the bare noun (what ``sac listen`` does, and
+still does for one more release) is the anti-pattern the scitex CLI
+convention names outright — §1 "trailing noun, no action: **never**" — and
+it is a live footgun: a typo or a stray tab-complete starts a server on
+7878. Every other noun group in this CLI shows help when invoked bare; this
+one silently becomes a daemon.
+
+These two verbs make the lifecycle explicit and complete the set the group
+already had (``restart`` / ``status``), so ``listen`` finally reads like
+every other group: **start / stop / restart / status**.
+
+Why ``start`` and not ``serve``
+-------------------------------
+The §1d verb catalog reserves ``start`` / ``stop`` / ``restart`` for
+"daemonized-service lifecycle (background process with a pid)" and gives
+``serve`` to *foreground* serving. This daemon is squarely the former: it
+writes a flock-backed pidfile, ``restart`` / ``status`` / ``stop`` all
+address it BY that pid, ``restart`` re-spawns it with ``setsid``, and a
+systemd unit supervises it. (The catalog's ``serve`` is scoped to §12's
+``gui`` group — foreground, browser-facing surfaces. ``sac listen`` is a
+headless JSON control plane.) ``serve`` would also leave an incoherent
+``serve`` / ``stop`` / ``restart`` triad. ``start`` additionally keeps SSOT
+with the CLI's own existing lifecycle verb, ``sac agents start``.
+
+Layout
+------
+These live here rather than in ``listen_cmds`` purely to keep that module
+under the 512-line cap — the same extraction ``_listen_registry_hooks``
+made. ``listen_cmds`` imports THIS module to attach the commands, so the
+boot primitives are imported LAZILY inside the command bodies: a top-level
+``from .listen_cmds import ...`` would close an import cycle. Lazy
+in-function imports are house style here anyway (see ``21_cli-startup-
+budget.md``) — this module's import cost is click alone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+#: Mirrors the ``listen`` group's own ``--bind`` default. Used only when a
+#: verb runs with no group context at all (e.g. ``CliRunner`` invoking the
+#: command object directly); the group normally stashes the resolved value.
+DEFAULT_BIND = "127.0.0.1:7878"
+
+
+@click.command(name="start")
+@click.option(
+    "--bind",
+    default=None,
+    help=f"HOST:PORT to bind. Loopback-only per §4.4.  [default: {DEFAULT_BIND}]",
+)
+@click.option(
+    "--token-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Bearer-token file. Auto-generated at "
+        "~/.scitex/agent-container/tokens/listen-<host>.token if missing."
+    ),
+)
+@click.option(
+    "--allow-non-loopback",
+    is_flag=True,
+    default=False,
+    help=(
+        "Permit binding to non-loopback addresses. Required for "
+        "tailscale/tunnel binds; orochi-side mesh is the supported transport."
+    ),
+)
+@click.option(
+    "--print-token",
+    is_flag=True,
+    default=False,
+    help="Print the bearer token to stdout and exit (does not boot).",
+)
+@click.pass_context
+def listen_start(
+    ctx: click.Context,
+    bind: str | None,
+    token_file: Path | None,
+    allow_non_loopback: bool,
+    print_token: bool,
+) -> None:
+    """Boot the sac listen HTTP/JSON control-plane daemon.
+
+    The explicit form of what bare `sac listen` still does today. Binds
+    loopback-only unless --allow-non-loopback is passed, and writes a
+    flock-backed pidfile that `stop` / `restart` / `status` address.
+
+    Runs in the FOREGROUND (systemd's Type=simple supervises it; `sac listen
+    restart` re-spawns it under setsid). If another instance already holds
+    the port, this one does NOT crash — it stands by as a warm spare and
+    fails over the moment the holder dies.
+
+    Options may be given on the verb (`sac listen start --bind ...`) or on
+    the group (`sac listen --bind ... start`); the verb wins.
+
+    \b
+    Example:
+        sac listen start                                  # 127.0.0.1:7878
+        sac listen start --bind 127.0.0.1:7979            # custom port
+        sac listen start --bind 100.64.1.2:7878 --allow-non-loopback
+        sac listen start --print-token                    # echo token, exit
+
+    \b
+    Exit codes:
+        0  clean shutdown (SIGTERM / Ctrl-C), or --print-token printed
+        1  uvicorn/starlette missing, or the bind failed
+        2  non-loopback --bind without --allow-non-loopback
+    """
+    from .listen_cmds import _do_start_listen
+
+    obj = ctx.obj or {}
+    _do_start_listen(
+        bind=bind or obj.get("bind") or DEFAULT_BIND,
+        token_file=token_file or obj.get("token_file"),
+        allow_non_loopback=allow_non_loopback or bool(obj.get("allow_non_loopback")),
+        print_token=print_token or bool(obj.get("print_token")),
+    )
+
+
+@click.command(name="stop")
+@click.option(
+    "--grace-secs",
+    type=float,
+    default=10.0,
+    show_default=True,
+    help="SIGTERM-to-SIGKILL escalation deadline (seconds).",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Skip SIGTERM and go straight to SIGKILL.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a machine-readable JSON result envelope on stdout.",
+)
+@click.pass_context
+def listen_stop(
+    ctx: click.Context,
+    grace_secs: float,
+    force: bool,
+    as_json: bool,
+) -> None:
+    """Stop the running sac listen daemon.
+
+    The stop half of `restart`, on its own: SIGTERM the pidfile's PID, poll
+    to --grace-secs, escalate to SIGKILL, verify it is REALLY dead before
+    clearing the pidfile, then force-kill any wedged remnant still holding
+    the port that the pidfile never named (the "curl hangs forever" case).
+    Shares ONE implementation with `restart`, so the two cannot drift.
+
+    IDEMPOTENT: stopping an already-stopped daemon exits 0 and reports "not
+    running" — the same contract as `systemctl stop`.
+
+    Mirrors `sac listen`'s own bind resolution: `sac listen stop` stops the
+    daemon `sac listen start` would have started.
+
+    \b
+    Example:
+        sac listen stop                  # SIGTERM, 10s grace, then SIGKILL
+        sac listen stop --force          # SIGKILL daemon + wedged port holder
+        sac listen stop --json           # machine-readable envelope
+
+    \b
+    Exit codes:
+        0  stopped, or already down (idempotent)
+        1  could not stop (PID survived SIGKILL / port still wedged)
+    """
+    import json as _json
+
+    from .._listen._restart import format_escalation_warning
+    from .._listen._single_instance import default_lock_dir
+    from .._listen._stop import stop_listen
+    from .listen_cmds import _split_bind
+
+    host, port = _split_bind((ctx.obj or {}).get("bind") or DEFAULT_BIND)
+
+    lock_dir = default_lock_dir()
+    lock_dir.mkdir(parents=True, exist_ok=True)
+
+    result = stop_listen(
+        host=host,
+        port=port,
+        lock_dir=lock_dir,
+        grace_secs=grace_secs,
+        force=force,
+    )
+
+    # LOUD WARN on SIGKILL escalation, silent on a clean TERM exit — the
+    # same design call (c) ``restart`` follows, using the same formatter.
+    if result.escalated_to_sigkill:
+        click.echo(format_escalation_warning(grace_secs), err=True)
+
+    # Paper trail for the codified pkill (the wedged, untracked remnant).
+    if result.port_holders_killed:
+        pids = ", ".join(str(p) for p in result.port_holders_killed)
+        click.echo(
+            f"# self-heal: force-killed wedged port holder(s) PID {pids} "
+            f"off {host}:{port}",
+            err=True,
+        )
+
+    # §8: data on stdout, logs/warnings on stderr — `… --json | jq` must be
+    # uncontaminated even on the failure path below.
+    if as_json:
+        click.echo(
+            _json.dumps(
+                {
+                    "ok": result.ok,
+                    "host": host,
+                    "port": port,
+                    "was_running": result.was_running,
+                    "prior_pid": result.prior_pid,
+                    "escalated_to_sigkill": result.escalated_to_sigkill,
+                    "port_holders_killed": list(result.port_holders_killed),
+                    "error": result.error,
+                }
+            )
+        )
+
+    # FAIL LOUD: the error names the REAL cause (``PID X survived SIGKILL`` /
+    # ``port still held``), never a generic "did not stop".
+    if not result.ok:
+        raise click.ClickException(
+            result.error or "ERROR: sac listen stop failed (unknown reason)"
+        )
+
+    if result.was_running:
+        pid_note = f" (PID {result.prior_pid})" if result.prior_pid else ""
+        click.echo(f"# sac listen stopped → {host}:{port}{pid_note}", err=True)
+    else:
+        click.echo(
+            f"# sac listen was not running → {host}:{port} (nothing to stop)",
+            err=True,
+        )
+
+
+__all__ = ["DEFAULT_BIND", "listen_start", "listen_stop"]

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -293,7 +293,7 @@ class _MainGroup(LazyGroup):
         "fleet": "Peer-aware multi-agent orchestration across hosts.",
         "doctor": "Diagnose agent-spec source drift (local, or --fleet across hosts).",
         "provenance": "Prove which code is actually loaded (commit, origin, fossil installs).",
-        "listen": "Boot the sac listen HTTP/JSON control-plane server.",
+        "listen": "Host HTTP/JSON control plane: start/stop/restart/status.",
         "ports": "List the ports sac/scitex uses, with live status.",
         "pytest": "Run pytest on remote pools (Spartan SLURM, ...).",
         "install-shell-completion": "Wire up `<TAB>` completion in the user's shell rc.",
@@ -368,6 +368,7 @@ class _MainGroup(LazyGroup):
         "  $ sac agents status\n"
         "  $ sac agents start orchestrator                                      # by name\n"
         "  $ sac agents start ~/.scitex/agent-container/agents/orchestrator/spec.yaml   # by path\n"
+        "  $ sac listen status                                                  # host control-plane health\n"
     ),
 )
 @click.option(

--- a/src/scitex_agent_container/cli_pkg/listen_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/listen_cmds.py
@@ -51,6 +51,49 @@ from ._listen_registry_hooks import (  # noqa: E402
     _register_self_comms_node,
 )
 
+# ---------------------------------------------------------------------------
+# Bare-boot deprecation — scitex CLI convention §5, phase W (warn + forward)
+# ---------------------------------------------------------------------------
+
+#: The release that REMOVES boot-on-bare-``sac listen``. Every warning names
+#: it, so callers always know the deadline (§5: "each phase names the removal
+#: version").
+BARE_BOOT_REMOVAL_VERSION = "v0.23.0"
+
+
+def _warn_bare_boot_deprecated() -> None:
+    """Warn that bare ``sac listen`` booted a daemon, and name the verb.
+
+    Phase W: the bare form still FORWARDS to the boot, so every caller keeps
+    working — and three still invoke it bare TODAY (the systemd unit's
+    ``ExecStart``, ``_listen._restart``'s direct-spawn argv, and the systemd
+    JobSpec in PR #543). ``sac listen`` IS the host control plane; flipping
+    the bare form to show-help would take the fleet's host access down with
+    it. Removing the bare boot is a FOLLOW-UP, only after all three migrate.
+
+    DELIBERATE DEVIATION from §5a's once-per-shell suppression: §5a keys its
+    marker on ``$PPID`` to give one warning per interactive shell, but this
+    daemon's principal caller is a **systemd unit**, whose PPID is the
+    (constant) user manager — a once-per-PPID marker would warn on the first
+    boot then stay silent forever, muting exactly the caller that must
+    migrate. §5a's rationale ("cron jobs and loops would drown in it") also
+    does not apply: a daemon boots once per lifetime, so this is at most one
+    journal line per start. stderr only, and no marker-file write — the
+    control plane's boot path must not be able to fail on a write it does
+    not need.
+    """
+    click.echo(
+        "WARN: bare `sac listen` is DEPRECATED — use `sac listen start` "
+        f"(removed in {BARE_BOOT_REMOVAL_VERSION}).",
+        err=True,
+    )
+    click.echo(
+        "      `listen` is a command GROUP, not a verb: booting a daemon off "
+        "the bare noun means a typo or a stray tab-complete starts a server. "
+        "Verbs: start / stop / restart / status  (see `sac listen -h`).",
+        err=True,
+    )
+
 
 @click.group(name="listen", invoke_without_command=True)
 @click.option(
@@ -91,17 +134,29 @@ def listen(
     allow_non_loopback: bool,
     print_token: bool,
 ) -> None:
-    """Boot the sac listen HTTP server (default) or invoke a subverb.
+    """The host HTTP/JSON control plane (command group).
+
+    The plane every sac agent reaches the host through — 127.0.0.1:7878 by
+    default, bearer-token authenticated, loopback-only unless you opt out.
+    `listen` is a NOUN; the verbs below are its whole lifecycle.
 
     \b
     Example:
-        sac listen                          # 127.0.0.1:7878 (start)
-        sac listen --bind 100.64.1.2:7878 --allow-non-loopback
-        sac listen --print-token            # echo token then exit
+        sac listen start                    # boot the daemon (loopback only)
+        sac listen status                   # health report; exit 1 if down
+        sac listen status --json            # machine-readable envelope
+        sac listen stop                     # stop it (idempotent)
         sac listen restart                  # atomic stop-clean-relaunch
+        sac listen start --print-token      # echo the bearer token, then exit
+
+    \b
+    DEPRECATED: bare `sac listen` still BOOTS the daemon, so the systemd unit
+    and every existing launcher keep working — but it now warns. Use
+    `sac listen start`. The bare form is removed in v0.23.0.
     """
-    # Stash group-level options so subcommands (``restart``) can
-    # mirror ``sac listen``'s own bind resolution per design call (a).
+    # Stash group-level options so subcommands (``start`` / ``stop`` /
+    # ``restart`` / ``status``) can mirror ``sac listen``'s own bind
+    # resolution per design call (a).
     ctx.ensure_object(dict)
     ctx.obj["bind"] = bind
     ctx.obj["token_file"] = token_file
@@ -111,6 +166,13 @@ def listen(
     if ctx.invoked_subcommand is not None:
         # Subcommand will run next; group callback just stashed options.
         return
+
+    # Bare ``sac listen`` — the deprecated boot-by-default path (phase W:
+    # warn + FORWARD). ``--print-token`` short-circuits inside
+    # ``_do_start_listen`` before anything binds, so it is NOT a boot and
+    # must not draw a boot-deprecation warning.
+    if not print_token:
+        _warn_bare_boot_deprecated()
 
     _do_start_listen(
         bind=bind,
@@ -427,3 +489,18 @@ def listen_status(ctx: click.Context, as_json: bool) -> None:
 
     if not payload["running"]:
         ctx.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# ``sac listen start`` / ``sac listen stop`` — the explicit lifecycle verbs.
+#
+# Defined in a sibling module to keep THIS file under the 512-line cap (the
+# same extraction ``_listen_registry_hooks`` made) and attached here so they
+# resolve on the group. ``_listen_verbs`` imports its boot primitives lazily,
+# inside the command bodies, so importing it here is not a cycle.
+# ---------------------------------------------------------------------------
+
+from ._listen_verbs import listen_start, listen_stop  # noqa: E402
+
+listen.add_command(listen_start)
+listen.add_command(listen_stop)

--- a/tests/scitex_agent_container/_listen/test__stop.py
+++ b/tests/scitex_agent_container/_listen/test__stop.py
@@ -1,0 +1,488 @@
+"""Tests for ``_listen/_stop.py`` — the stop half ``stop`` and ``restart`` share.
+
+``sac listen stop`` and ``sac listen restart`` must never drift: a restart
+IS a stop plus a relaunch plus a health-probe. ``stop_listen`` is that
+stop half as ONE implementation, so the two verbs cannot diverge. These
+tests pin the sequence (SIGTERM → grace → SIGKILL escalation; verify-dead
+BEFORE clearing the pidfile; wedged-port self-heal; idempotent no-op on a
+dead daemon) AND that ``restart_listen`` still routes through it.
+
+PA-306 + STX-NM001-003: no MagicMock / no monkeypatch. The seams
+(``_kill``, ``_sleep``) are swapped on ``_restart`` via a hand-rolled
+save/restore context manager, exactly as ``test__restart.py`` does —
+``_stop`` reaches every primitive through the ``_restart`` MODULE OBJECT
+at call time, so one swap drives both modules. A ``from ._restart import
+_sleep`` in the production code would capture the ORIGINAL callable and
+silently defeat these swaps; that is why it does not do that.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import signal
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._listen import _port_holder as ph_mod
+from scitex_agent_container._listen import _restart as restart_mod
+from scitex_agent_container._listen import _stop as stop_mod
+from scitex_agent_container._listen._stop import StopResult, stop_listen
+
+# A port that is NOT the live control plane (7878). Belt-and-braces with
+# the autouse seam fixture below: nothing here may ever reach the real
+# fleet daemon.
+TEST_PORT = 7999
+
+
+# ---------------------------------------------------------------------------
+# Module-level swap helpers — production callables → recording fakes.
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _swap(name: str, value) -> Iterator[None]:
+    """Replace ``restart_mod.<name>`` for the duration of the block."""
+    saved = getattr(restart_mod, name)
+    setattr(restart_mod, name, value)
+    try:
+        yield
+    finally:
+        setattr(restart_mod, name, saved)
+
+
+@contextmanager
+def _swap_ph(name: str, value) -> Iterator[None]:
+    """Replace a ``_port_holder.<name>`` seam for the block.
+
+    The discovery seams (``_probe_bound`` / ``_resolve_pids``) live on
+    ``_port_holder``, not ``_restart``.
+    """
+    saved = getattr(ph_mod, name)
+    setattr(ph_mod, name, value)
+    try:
+        yield
+    finally:
+        setattr(ph_mod, name, saved)
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_port_seams() -> Iterator[None]:
+    """Make the wedged-port-holder self-heal a hard no-op by default.
+
+    SAFETY: the real ``port_is_bound`` does a live socket connect, and on a
+    dev host the central ``sac listen`` is actually bound on 7878. Without
+    this guard a ``stop_listen`` test could probe a real port, find it held,
+    and FORCE-KILL the live fleet control plane as a test side effect.
+    Defaulting the probe to "not bound" keeps every test hermetic; the
+    dedicated self-heal test overrides these two seams inside its own block.
+    """
+    saved_bound = ph_mod._probe_bound
+    saved_holders = ph_mod._resolve_pids
+    ph_mod._probe_bound = lambda _host, _port: False
+    ph_mod._resolve_pids = lambda _port: []
+    try:
+        yield
+    finally:
+        ph_mod._probe_bound = saved_bound
+        ph_mod._resolve_pids = saved_holders
+
+
+def _no_sleep(_secs: float) -> None:
+    """Recorded fake: no-op sleep, makes the grace loop instant."""
+
+
+class _KillRecorder:
+    """Hand-rolled fake for ``os.kill`` — records every (pid, signal) call
+    and lets the test program a script of liveness responses.
+
+    ``alive_script`` is consumed in order on each ``kill(pid, 0)`` probe:
+    True/False decides whether the probe sees the pid alive. After the
+    script is exhausted, the last value sticks.
+    """
+
+    def __init__(self, *, alive_script: list[bool]) -> None:
+        self.calls: list[tuple[int, int]] = []
+        self._script = list(alive_script)
+        self._last_alive = alive_script[-1] if alive_script else False
+
+    def __call__(self, pid: int, sig: int) -> None:
+        self.calls.append((pid, sig))
+        if sig == 0:
+            if self._script:
+                alive = self._script.pop(0)
+                self._last_alive = alive
+            else:
+                alive = self._last_alive
+            if not alive:
+                raise ProcessLookupError(pid)
+
+    @property
+    def signals(self) -> list[int]:
+        """Every non-probe signal actually delivered."""
+        return [sig for _pid, sig in self.calls if sig != 0]
+
+
+def _write_pidfile(lock_dir: Path, pid: int, port: int = TEST_PORT) -> Path:
+    """Create ``<lock_dir>/listen-<port>.pid`` holding ``pid``."""
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    pid_file = restart_mod.pidfile_path(port, lock_dir)
+    pid_file.write_text(f"{pid}\n", encoding="utf-8")
+    return pid_file
+
+
+# ---------------------------------------------------------------------------
+# stop_listen — the TERM → KILL ladder
+# ---------------------------------------------------------------------------
+
+
+def test_stop_listen_sends_sigterm_to_the_pidfile_pid(tmp_path: Path) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    # alive for the pre-check, then dead on the first grace poll.
+    kills = _KillRecorder(alive_script=[True, False, False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert signal.SIGTERM in kills.signals
+
+
+def test_stop_listen_force_skips_term_and_sends_sigkill(tmp_path: Path) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True, False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        stop_listen(
+            host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path, force=True
+        )
+    # Assert
+    assert kills.signals == [signal.SIGKILL]
+
+
+def test_stop_listen_clean_term_exit_does_not_escalate(tmp_path: Path) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True, False, False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.escalated_to_sigkill is False
+
+
+def test_stop_listen_escalates_to_sigkill_after_grace(tmp_path: Path) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    # Alive through every grace poll, then dead once SIGKILL lands.
+    kills = _KillRecorder(alive_script=[True] * 60 + [False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(
+            host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path, grace_secs=1.0
+        )
+    # Assert
+    assert result.escalated_to_sigkill is True
+
+
+# ---------------------------------------------------------------------------
+# stop_listen — pidfile hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_stop_listen_clears_the_pidfile_after_stopping(tmp_path: Path) -> None:
+    # Arrange
+    pid_file = _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True, False, False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert pid_file.exists() is False
+
+
+def test_stop_listen_clears_a_stale_pidfile_naming_a_dead_pid(
+    tmp_path: Path,
+) -> None:
+    """A pidfile left behind by a crashed daemon must not wedge `stop`."""
+    # Arrange
+    pid_file = _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert pid_file.exists() is False
+
+
+def test_stop_listen_keeps_pidfile_when_pid_survives_sigkill(
+    tmp_path: Path,
+) -> None:
+    """Defence-in-depth: never clear a lock whose owner is still alive."""
+    # Arrange
+    pid_file = _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True])  # never dies
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        stop_listen(
+            host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path, force=True
+        )
+    # Assert
+    assert pid_file.exists() is True
+
+
+def test_stop_listen_fails_when_pid_survives_sigkill(tmp_path: Path) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True])  # never dies
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(
+            host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path, force=True
+        )
+    # Assert
+    assert result.ok is False
+
+
+def test_stop_listen_surviving_pid_error_names_the_pid(tmp_path: Path) -> None:
+    """FAIL LOUD: the error names the REAL cause, not a generic failure."""
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True])  # never dies
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(
+            host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path, force=True
+        )
+    # Assert
+    assert "4242" in result.error
+
+
+# ---------------------------------------------------------------------------
+# stop_listen — idempotence (the `systemctl stop` contract)
+# ---------------------------------------------------------------------------
+
+
+def test_stop_listen_with_no_pidfile_reports_ok(tmp_path: Path) -> None:
+    """Stopping an already-stopped daemon is SUCCESS, not failure."""
+    # Arrange
+    kills = _KillRecorder(alive_script=[False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.ok is True
+
+
+def test_stop_listen_with_no_pidfile_reports_not_running(tmp_path: Path) -> None:
+    # Arrange
+    kills = _KillRecorder(alive_script=[False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.was_running is False
+
+
+def test_stop_listen_with_no_pidfile_sends_no_signals(tmp_path: Path) -> None:
+    # Arrange
+    kills = _KillRecorder(alive_script=[False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert kills.signals == []
+
+
+def test_stop_listen_reports_was_running_for_a_live_daemon(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True, False, False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.was_running is True
+
+
+def test_stop_listen_reports_the_pid_it_stopped(tmp_path: Path) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True, False, False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.prior_pid == 4242
+
+
+# ---------------------------------------------------------------------------
+# stop_listen — wedged-port self-heal (the "curl hangs forever" remnant)
+# ---------------------------------------------------------------------------
+
+
+def test_stop_listen_force_kills_an_untracked_wedged_port_holder(
+    tmp_path: Path,
+) -> None:
+    """The remnant the pidfile never named must still be cleared."""
+    # Arrange — no pidfile at all; the port is held by an unknown PID.
+    kills = _KillRecorder(alive_script=[True, False, False])
+    bound = [True]  # bound on the first probe, freed after the kill
+
+    def _probe(_host: str, _port: int) -> bool:
+        return bound.pop(0) if bound else False
+
+    # Act
+    with (
+        _swap("_kill", kills),
+        _swap("_sleep", _no_sleep),
+        _swap_ph("_probe_bound", _probe),
+        _swap_ph("_resolve_pids", lambda _port: [9191]),
+    ):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.port_holders_killed == (9191,)
+
+
+def test_stop_listen_reports_was_running_for_a_wedged_port_holder(
+    tmp_path: Path,
+) -> None:
+    """A wedged remnant with no pidfile still counts as 'was running'."""
+    # Arrange
+    kills = _KillRecorder(alive_script=[True, False, False])
+    bound = [True]
+
+    def _probe(_host: str, _port: int) -> bool:
+        return bound.pop(0) if bound else False
+
+    # Act
+    with (
+        _swap("_kill", kills),
+        _swap("_sleep", _no_sleep),
+        _swap_ph("_probe_bound", _probe),
+        _swap_ph("_resolve_pids", lambda _port: [9191]),
+    ):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.was_running is True
+
+
+# ---------------------------------------------------------------------------
+# SSOT — restart MUST NOT re-implement the stop sequence.
+# ---------------------------------------------------------------------------
+
+
+def test_restart_listen_delegates_its_stop_half_to_stop_listen(
+    tmp_path: Path,
+) -> None:
+    """The anti-drift guard: one stop sequence, two verbs."""
+    # Arrange
+    calls: list[dict] = []
+
+    def _recording_stop(**kwargs) -> StopResult:
+        calls.append(kwargs)
+        return StopResult(
+            ok=True,
+            escalated_to_sigkill=False,
+            had_prior_pidfile=False,
+            prior_pid_alive=False,
+        )
+
+    saved = stop_mod.stop_listen
+    stop_mod.stop_listen = _recording_stop
+    # Act
+    try:
+        with (
+            _swap("_sleep", _no_sleep),
+            _swap("_run_subprocess", lambda *_a, **_kw: None),
+            _swap("_http_get", lambda _url, timeout: 200),
+        ):
+            restart_mod.restart_listen(
+                host="127.0.0.1",
+                port=TEST_PORT,
+                lock_dir=tmp_path,
+                systemd_unit_path=tmp_path / "absent.service",
+                sac_listen_argv=["/bin/true"],
+            )
+    finally:
+        stop_mod.stop_listen = saved
+    # Assert
+    assert len(calls) == 1
+
+
+def test_restart_listen_forwards_force_to_the_stop_half(tmp_path: Path) -> None:
+    # Arrange
+    calls: list[dict] = []
+
+    def _recording_stop(**kwargs) -> StopResult:
+        calls.append(kwargs)
+        return StopResult(
+            ok=True,
+            escalated_to_sigkill=False,
+            had_prior_pidfile=False,
+            prior_pid_alive=False,
+        )
+
+    saved = stop_mod.stop_listen
+    stop_mod.stop_listen = _recording_stop
+    # Act
+    try:
+        with (
+            _swap("_sleep", _no_sleep),
+            _swap("_run_subprocess", lambda *_a, **_kw: None),
+            _swap("_http_get", lambda _url, timeout: 200),
+        ):
+            restart_mod.restart_listen(
+                host="127.0.0.1",
+                port=TEST_PORT,
+                lock_dir=tmp_path,
+                force=True,
+                systemd_unit_path=tmp_path / "absent.service",
+                sac_listen_argv=["/bin/true"],
+            )
+    finally:
+        stop_mod.stop_listen = saved
+    # Assert
+    assert calls[0]["force"] is True
+
+
+def test_restart_listen_aborts_when_the_stop_half_fails(tmp_path: Path) -> None:
+    """A failed stop must never relaunch into a still-held port."""
+    # Arrange
+    def _failing_stop(**_kwargs) -> StopResult:
+        return StopResult(
+            ok=False,
+            escalated_to_sigkill=True,
+            had_prior_pidfile=True,
+            prior_pid_alive=True,
+            prior_pid=4242,
+            error="PID 4242 survived SIGKILL",
+        )
+
+    saved = stop_mod.stop_listen
+    stop_mod.stop_listen = _failing_stop
+    spawns: list[list[str]] = []
+    # Act
+    try:
+        with (
+            _swap("_sleep", _no_sleep),
+            _swap("_run_subprocess", lambda *a, **_kw: spawns.append(list(a[0]))),
+            _swap("_http_get", lambda _url, timeout: 200),
+        ):
+            restart_mod.restart_listen(
+                host="127.0.0.1",
+                port=TEST_PORT,
+                lock_dir=tmp_path,
+                systemd_unit_path=tmp_path / "absent.service",
+                sac_listen_argv=["/bin/true"],
+            )
+    finally:
+        stop_mod.stop_listen = saved
+    # Assert
+    assert spawns == []

--- a/tests/scitex_agent_container/cli_pkg/test__listen_verbs.py
+++ b/tests/scitex_agent_container/cli_pkg/test__listen_verbs.py
@@ -1,0 +1,450 @@
+"""Tests for ``cli_pkg/_listen_verbs.py`` — ``sac listen start`` / ``stop``.
+
+``listen`` is a NOUN (a command group), exactly like ``agents`` / ``db``
+/ ``host``. Booting a daemon off the bare noun is the anti-pattern the
+scitex CLI convention names outright ("trailing noun, no action:
+never") — a typo or a stray tab-complete would start a server on 7878.
+These tests pin the explicit verbs that fix it, and the coherence of the
+full set (``start`` / ``stop`` / ``restart`` / ``status``).
+
+Bind resolution is tested from BOTH sides — on the verb
+(``sac listen start --bind …``) and on the group
+(``sac listen --bind … start``) — because ``restart``/``status`` read
+the group's stash while an operator's fingers reach for the verb.
+
+No-mocks discipline (PA-306): ``_swap_attr`` / ``_swap_module`` are
+hand-rolled save-and-restore context managers — no ``unittest.mock``, no
+``MagicMock``, no ``monkeypatch``. ``uvicorn`` is replaced with a real
+callable-bearing object so the production call site executes real
+attribute lookups.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import json as _json
+import sys as _sys
+import types as _types
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.listen_cmds import listen
+
+# ---------------------------------------------------------------------------
+# Hand-rolled save/restore seams (PA-306 — no monkeypatch, no mock).
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _swap_attr(obj, name: str, value) -> Iterator[None]:
+    """Replace ``obj.<name>`` with ``value`` for the block; restore after."""
+    saved = getattr(obj, name)
+    setattr(obj, name, value)
+    try:
+        yield
+    finally:
+        setattr(obj, name, saved)
+
+
+@contextmanager
+def _swap_module(name: str, fake) -> Iterator[None]:
+    """Inject ``fake`` at ``sys.modules[name]``; restore the prior entry."""
+    saved = _sys.modules.get(name)
+    _sys.modules[name] = fake
+    try:
+        yield
+    finally:
+        if saved is None:
+            _sys.modules.pop(name, None)
+        else:
+            _sys.modules[name] = saved
+
+
+class _FakeUvicorn:
+    """Real callable-bearing stand-in for the ``uvicorn`` module.
+
+    Records the ``host``/``port`` the production code binds to. Mirrors
+    the explicit ``Config`` + ``Server`` + ``server.run()`` shape the
+    production boot path uses.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        _calls = self.calls
+
+        class Config:
+            def __init__(self, app, host, port, **_kw) -> None:
+                self.app = app
+                self.host = host
+                self.port = port
+
+        class Server:
+            def __init__(self, config) -> None:
+                self.config = config
+                self.should_exit = False
+                self.started = False
+
+            def run(self) -> None:
+                _calls.append({"host": self.config.host, "port": self.config.port})
+
+        self.Config = Config
+        self.Server = Server
+
+
+def _fake_app():
+    """Stand-in for the Starlette app ``create_app`` returns."""
+    return _types.SimpleNamespace(state=_types.SimpleNamespace())
+
+
+@contextmanager
+def _boot_harness(tmp_path) -> Iterator[_FakeUvicorn]:
+    """Hermetic ``start``-path harness: no real flock, port, or bind.
+
+    ``_do_start_listen`` routes the lock through ``_standby.resolve_startup``
+    (hot-standby + failover), whose real path takes the flock at the
+    operator's ``default_lock_dir()`` AND socket-probes the real port — so a
+    CLI start test on a host with a live ``sac listen`` would otherwise stand
+    by forever or probe the LIVE 7878 control plane. Swapping it out keeps
+    these tests hermetic, fast, and incapable of touching the real daemon.
+    """
+    from pathlib import Path as _Path
+
+    from scitex_agent_container._listen import _single_instance, _standby
+    from scitex_agent_container._listen import server as _server
+    from scitex_agent_container._listen import tokens as _tokens
+    from scitex_agent_container._listen._single_instance import LockHandle
+
+    fake_handle = LockHandle(fd=-1, pid_file=_Path("/nonexistent/listen-7878.pid"))
+    fake_uvicorn = _FakeUvicorn()
+
+    @contextmanager
+    def _noop_guard() -> Iterator[None]:
+        yield
+
+    with (
+        _swap_attr(_standby, "resolve_startup", lambda **_kw: fake_handle),
+        _swap_attr(_standby, "standby_signal_guard", _noop_guard),
+        # The throwaway fd=-1 handle must never reach the real releaser
+        # (fcntl rejects a negative fd with ValueError).
+        _swap_attr(_single_instance, "release_listen_lock", lambda _h: None),
+        _swap_attr(_tokens, "ensure_token", lambda _p: "tok"),
+        _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        yield fake_uvicorn
+
+
+class _StopRecorder:
+    """Hand-rolled stand-in for ``_stop.stop_listen``.
+
+    Records the kwargs the CLI passes and returns a REAL ``StopResult``
+    so the production render path executes real attribute lookups.
+    """
+
+    def __init__(self, **result_fields) -> None:
+        from scitex_agent_container._listen._stop import StopResult
+
+        self.calls: list[dict] = []
+        defaults = {
+            "ok": True,
+            "escalated_to_sigkill": False,
+            "had_prior_pidfile": True,
+            "prior_pid_alive": True,
+            "prior_pid": 4242,
+        }
+        defaults.update(result_fields)
+        self._result = StopResult(**defaults)
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._result
+
+
+@contextmanager
+def _stop_harness(tmp_path, recorder: _StopRecorder) -> Iterator[None]:
+    """Point ``sac listen stop`` at ``recorder`` and a throwaway lock dir."""
+    from scitex_agent_container._listen import _single_instance, _stop
+
+    with (
+        _swap_attr(_stop, "stop_listen", recorder),
+        _swap_attr(_single_instance, "default_lock_dir", lambda: tmp_path / "locks"),
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# The verb set — `listen` is a noun; these four are its whole lifecycle.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "verb",
+    [
+        pytest.param("start", id="start-boots-the-daemon"),
+        pytest.param("stop", id="stop-halts-the-daemon"),
+        pytest.param("restart", id="restart-stop-clean-relaunch"),
+        pytest.param("status", id="status-health-report"),
+    ],
+)
+def test_listen_group_exposes_lifecycle_verb(verb: str) -> None:
+    # Arrange — verb provided by parametrize.
+    group = listen
+    # Act
+    registered = group.commands
+    # Assert
+    assert verb in registered
+
+
+# ---------------------------------------------------------------------------
+# `sac listen start` — the explicit boot verb.
+# ---------------------------------------------------------------------------
+
+
+def test_listen_start_verb_boots_uvicorn_on_default_bind(tmp_path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path) as fake_uvicorn:
+        runner.invoke(listen, ["start"])
+    # Assert
+    assert fake_uvicorn.calls == [{"host": "127.0.0.1", "port": 7878}]
+
+
+def test_listen_start_verb_exits_zero_on_clean_shutdown(tmp_path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path):
+        result = runner.invoke(listen, ["start"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_listen_start_accepts_bind_option_on_the_verb(tmp_path) -> None:
+    """`sac listen start --bind …` — where an operator's fingers go."""
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path) as fake_uvicorn:
+        runner.invoke(listen, ["start", "--bind", "127.0.0.1:7999"])
+    # Assert
+    assert fake_uvicorn.calls == [{"host": "127.0.0.1", "port": 7999}]
+
+
+def test_listen_start_accepts_bind_option_on_the_group(tmp_path) -> None:
+    """`sac listen --bind … start` — the form `restart`/`status` already use."""
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path) as fake_uvicorn:
+        runner.invoke(listen, ["--bind", "127.0.0.1:7999", "start"])
+    # Assert
+    assert fake_uvicorn.calls == [{"host": "127.0.0.1", "port": 7999}]
+
+
+def test_listen_start_verb_emits_no_deprecation_warning(tmp_path) -> None:
+    """The whole point of the verb: it is the NON-deprecated form."""
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path):
+        result = runner.invoke(listen, ["start"])
+    # Assert
+    assert "DEPRECATED" not in result.output.upper()
+
+
+def test_listen_start_print_token_writes_token_to_stdout(tmp_path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path):
+        result = runner.invoke(listen, ["start", "--print-token"])
+    # Assert
+    assert "tok" in result.output
+
+
+def test_listen_start_print_token_does_not_boot_uvicorn(tmp_path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path) as fake_uvicorn:
+        runner.invoke(listen, ["start", "--print-token"])
+    # Assert
+    assert fake_uvicorn.calls == []
+
+
+def test_listen_start_non_loopback_bind_without_flag_exits_non_zero(
+    tmp_path,
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path):
+        result = runner.invoke(listen, ["start", "--bind", "8.8.8.8:7878"])
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_listen_start_non_loopback_bind_with_flag_passes_host_to_uvicorn(
+    tmp_path,
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path) as fake_uvicorn:
+        runner.invoke(
+            listen, ["start", "--bind", "8.8.8.8:7878", "--allow-non-loopback"]
+        )
+    # Assert
+    assert fake_uvicorn.calls == [{"host": "8.8.8.8", "port": 7878}]
+
+
+# ---------------------------------------------------------------------------
+# `sac listen stop` — the verb that did not exist.
+# ---------------------------------------------------------------------------
+
+
+def test_listen_stop_verb_exits_zero_after_stopping_daemon(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder()
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_listen_stop_verb_reports_the_stopped_pid(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder(prior_pid=4242)
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert "4242" in result.output
+
+
+def test_listen_stop_on_dead_daemon_exits_zero_idempotently(tmp_path) -> None:
+    """`systemctl stop` contract: stopping a down daemon is SUCCESS."""
+    # Arrange
+    recorder = _StopRecorder(
+        had_prior_pidfile=False, prior_pid_alive=False, prior_pid=None
+    )
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_listen_stop_on_dead_daemon_says_it_was_not_running(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder(
+        had_prior_pidfile=False, prior_pid_alive=False, prior_pid=None
+    )
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert "not running" in result.output.lower()
+
+
+def test_listen_stop_exits_non_zero_when_stop_fails(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder(ok=False, error="ERROR: PID 4242 survived SIGKILL")
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_listen_stop_failure_surfaces_the_real_cause(tmp_path) -> None:
+    """FAIL LOUD: the error names the REAL cause, not 'did not respond'."""
+    # Arrange
+    recorder = _StopRecorder(ok=False, error="ERROR: PID 4242 survived SIGKILL")
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert "survived SIGKILL" in result.output
+
+
+def test_listen_stop_forwards_force_flag_to_stop_listen(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder()
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        CliRunner().invoke(listen, ["stop", "--force"])
+    # Assert
+    assert recorder.calls[0]["force"] is True
+
+
+def test_listen_stop_forwards_grace_secs_to_stop_listen(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder()
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        CliRunner().invoke(listen, ["stop", "--grace-secs", "30"])
+    # Assert
+    assert recorder.calls[0]["grace_secs"] == 30.0
+
+
+def test_listen_stop_resolves_port_from_the_group_bind(tmp_path) -> None:
+    """`sac listen stop` stops the daemon `sac listen start` would start."""
+    # Arrange
+    recorder = _StopRecorder()
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        CliRunner().invoke(listen, ["--bind", "127.0.0.1:7999", "stop"])
+    # Assert
+    assert recorder.calls[0]["port"] == 7999
+
+
+def test_listen_stop_json_emits_parseable_envelope_on_stdout(tmp_path) -> None:
+    """§8: `cmd --json | jq` must work with zero log contamination."""
+    # Arrange
+    recorder = _StopRecorder(prior_pid=4242)
+    runner = CliRunner()
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = runner.invoke(listen, ["stop", "--json"])
+    # Assert
+    assert _json.loads(result.stdout)["prior_pid"] == 4242
+
+
+def test_listen_stop_json_envelope_reports_ok_flag(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder()
+    runner = CliRunner()
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = runner.invoke(listen, ["stop", "--json"])
+    # Assert
+    assert _json.loads(result.stdout)["ok"] is True
+
+
+def test_listen_stop_warns_loudly_on_sigkill_escalation(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder(escalated_to_sigkill=True)
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert "SIGKILL" in result.output
+
+
+def test_listen_stop_surfaces_force_killed_wedged_port_holder(tmp_path) -> None:
+    """Paper trail for the codified pkill (the 'curl hangs forever' case)."""
+    # Arrange
+    recorder = _StopRecorder(port_holders_killed=(9191,))
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert "9191" in result.output

--- a/tests/scitex_agent_container/cli_pkg/test_listen_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_listen_cmds.py
@@ -349,3 +349,143 @@ def test_listen_non_loopback_bind_with_allow_flag_passes_host_to_uvicorn(tmp_pat
         CliRunner().invoke(listen, ["--bind", "8.8.8.8:7878", "--allow-non-loopback"])
     # Assert
     assert fake_uvicorn.calls == [{"host": "8.8.8.8", "port": 7878}]
+
+
+# ---------------------------------------------------------------------------
+# Bare-boot deprecation (phase W: warn + FORWARD).
+#
+# `listen` is a NOUN, so booting a daemon off the bare noun is a footgun —
+# but the bare form MUST keep working until every launcher has migrated to
+# `sac listen start`. Three of them still invoke it bare TODAY:
+#
+#   1. scripts/systemd/sac-listen.service  -> ExecStart=/usr/bin/env sac listen
+#   2. _listen/_restart.py                 -> [sac_binary(), "listen"] respawn
+#   3. PR #543's systemd JobSpec           -> command="sac listen"
+#
+# `sac listen` IS the host control plane on 127.0.0.1:7878; the whole fleet
+# loses host access when it is down. Flipping the bare form to show-help
+# would take it offline. So: warn, never break. The first test below is the
+# regression guard that keeps it that way.
+# ---------------------------------------------------------------------------
+
+
+def test_bare_listen_still_boots_the_daemon_for_launcher_compat(tmp_path):
+    """HARD COUPLING: the systemd unit + `_restart` respawn invoke this bare."""
+    # Arrange
+    from scitex_agent_container._listen import server as _server
+    from scitex_agent_container._listen import tokens as _tokens
+
+    fake_uvicorn = _FakeUvicorn()
+    # Act
+    with (
+        _swap_standby_serves(),
+        _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
+        _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        CliRunner().invoke(listen, [])
+    # Assert
+    assert fake_uvicorn.calls == [{"host": "127.0.0.1", "port": 7878}]
+
+
+def test_bare_listen_boot_warns_that_it_is_deprecated(tmp_path):
+    # Arrange
+    from scitex_agent_container._listen import server as _server
+    from scitex_agent_container._listen import tokens as _tokens
+
+    fake_uvicorn = _FakeUvicorn()
+    # Act
+    with (
+        _swap_standby_serves(),
+        _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
+        _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        result = CliRunner().invoke(listen, [])
+    # Assert
+    assert "DEPRECATED" in result.output.upper()
+
+
+def test_bare_listen_boot_warning_names_the_start_verb(tmp_path):
+    """A deprecation that doesn't name the replacement is just noise."""
+    # Arrange
+    from scitex_agent_container._listen import server as _server
+    from scitex_agent_container._listen import tokens as _tokens
+
+    fake_uvicorn = _FakeUvicorn()
+    # Act
+    with (
+        _swap_standby_serves(),
+        _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
+        _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        result = CliRunner().invoke(listen, [])
+    # Assert
+    assert "sac listen start" in result.output
+
+
+def test_bare_listen_boot_warning_names_the_removal_version(tmp_path):
+    """CLI convention §5: every phase names the removal version."""
+    # Arrange
+    from scitex_agent_container._listen import server as _server
+    from scitex_agent_container._listen import tokens as _tokens
+    from scitex_agent_container.cli_pkg.listen_cmds import (
+        BARE_BOOT_REMOVAL_VERSION,
+    )
+
+    fake_uvicorn = _FakeUvicorn()
+    # Act
+    with (
+        _swap_standby_serves(),
+        _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
+        _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        result = CliRunner().invoke(listen, [])
+    # Assert
+    assert BARE_BOOT_REMOVAL_VERSION in result.output
+
+
+def test_bare_listen_boot_warning_goes_to_stderr_not_stdout(tmp_path):
+    """§8: warnings are stderr. `sac listen --print-token` must stay pipeable."""
+    # Arrange
+    from scitex_agent_container._listen import server as _server
+    from scitex_agent_container._listen import tokens as _tokens
+
+    fake_uvicorn = _FakeUvicorn()
+    runner = CliRunner()
+    # Act
+    with (
+        _swap_standby_serves(),
+        _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
+        _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        result = runner.invoke(listen, [])
+    # Assert
+    assert "DEPRECATED" not in result.stdout.upper()
+
+
+def test_listen_print_token_emits_no_boot_deprecation_warning(tmp_path):
+    """`--print-token` never boots, so the boot-deprecation must not fire."""
+    # Arrange
+    from scitex_agent_container._listen import tokens as _tokens
+
+    tok = tmp_path / "tok.txt"
+    fake_uvicorn = _FakeUvicorn()
+    # Act
+    with (
+        _swap_attr(_tokens, "ensure_token", lambda p: "secret-token-abc"),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        result = CliRunner().invoke(
+            listen, ["--print-token", "--token-file", str(tok)]
+        )
+    # Assert
+    assert "DEPRECATED" not in result.output.upper()


### PR DESCRIPTION
## The point (the operator's, and he is right)

> 「個人的にはリッスンというのは Listen サーバーのことで、名詞、カテゴリだと理解してるんですけど」
> — *"I understand `listen` to mean the Listen server: a **noun**, a **category**."*

He is. `listen` is a command group exactly like `agents` / `db` / `host` — but bare
`sac listen` **booted a daemon**. Every other noun group in this CLI prints help when
invoked bare; this one silently became a server on 7878. **A typo or a stray
tab-complete started one.**

That is not a matter of taste — it is the anti-pattern our own CLI convention names
outright (§1 `02_subcommand-structure-noun-verb.md`):

| Chain | Validity | Why |
|---|---|---|
| `<cli> job` | ✗ | trailing noun, no action — **never** |

…with `<cli> dashboard` (use `start-dashboard`) as its worked example, and *"often
aliased so bare `<cli> <noun>` shows help"* as the stated rationale.

He also asked whether there should be more commands under it, "like a health check".
There already was one — **`sac listen status`** — he just never saw it, because the
help's example block only ever showed the boot form. That is a discoverability bug,
and it is fixed here too.

## What this does

```
sac listen start      # NEW — the explicit form of bare `sac listen`
sac listen stop       # NEW — did not exist (only restart + status did)
sac listen restart    # unchanged
sac listen status     # unchanged — now actually discoverable
```

### `start`, not `serve`

I recommended `start` and I'm keeping it, but the call is closer than it looks and it
is worth stating why. The §1d verb catalog says:

> \| `start` / `stop` / `restart` \| Daemonized-service lifecycle **ONLY** (background
> process with a pid). Foreground serving is `serve`.

`sac listen` runs uvicorn in the foreground, so `serve` has a real claim. It loses on
four counts:

1. **It is pid-managed, which is the catalog's own criterion.** It writes a
   flock-backed pidfile (`listen-<port>.pid`); `stop` / `restart` / `status` all address
   it *by that pid*; `restart` respawns it under `setsid`; a systemd unit supervises it.
2. **§12 scopes `serve` to the `gui` group** — foreground, *browser-facing* surfaces
   ("must expose a browsable HTTP root"). `sac listen` is a headless JSON control plane.
3. **`restart` already exists.** `serve` / `stop` / `restart` is an incoherent triad —
   restart of *what*?
4. **SSOT with `sac agents start`**, the CLI's own existing lifecycle verb.

### `stop` shares one implementation with `restart`

`stop` is `restart`'s stop half. Rather than fork the sequence, `restart_listen` now
**delegates** to a new `_listen._stop.stop_listen`, so the two verbs cannot drift.
`stop` therefore inherits the whole self-heal for free: SIGTERM → grace → SIGKILL,
verify-dead *before* clearing the pidfile, then force-kill a wedged remnant the pidfile
never named (the "curl hangs forever" case). It is **idempotent** (`systemctl stop`
contract: stopping a down daemon exits 0) and has `--json`.

A test pins the delegation, so a future edit can't quietly re-fork it.

---

## ⚠️ Bare `sac listen` STILL BOOTS. That is deliberate and load-bearing.

**Do not "finish the job" by making bare `sac listen` show help.** It would take the
fleet's control plane offline.

`sac listen` is the host control plane on 127.0.0.1:7878 — it **went down today**, and
every agent loses host access when it does. Three launchers still invoke it **bare**:

| # | Launcher | Bare form |
|---|---|---|
| 1 | `scripts/systemd/sac-listen.service` | `ExecStart=/usr/bin/env sac listen` |
| 2 | `_listen/_restart.py` | `argv = sac_listen_argv or [sac_binary(), "listen"]` (the respawn) |
| 3 | `_jobs_plugin.py:90` — the `sac.listen` JobSpec from **#543** | `command="sac listen"` |

(#2 was not in the original brief — I found it while tracing the callers.)

**#543 merged into `develop` while this PR was open** (`c1c391a1`), so I rebased onto it
and re-ran the suite: **117 green** with its JobSpec in the tree. Its `command="sac
listen"` keeps working, unchanged, because bare boot still boots. That is the whole point
of the ordering below.

So this is **phase W** of the deprecation ladder (§5): **warn and forward, never break.**
Bare boot still boots, and now prints to stderr:

```
WARN: bare `sac listen` is DEPRECATED — use `sac listen start` (removed in v0.23.0).
      `listen` is a command GROUP, not a verb: booting a daemon off the bare noun means
      a typo or a stray tab-complete starts a server. Verbs: start / stop / restart /
      status  (see `sac listen -h`).
```

### 🔜 REQUIRED FOLLOW-UP — before the bare form is removed in v0.23.0

**All three launchers above must move to `sac listen start`** — including **#543's
JobSpec (`_jobs_plugin.py:90`)**, which must go from `command="sac listen"` to
`command="sac listen start"`.

**Deliberately NOT in this PR**, and the ordering is not negotiable:

> **A launcher may only be switched to `sac listen start` once a `sac` binary that *has*
> the `start` verb is actually DEPLOYED on that host — not merely merged.**

This fleet has real deploy staleness (host checkout / SIF / daemon all lag `origin`
independently). If a JobSpec or a respawn argv started calling `sac listen start` while
the `sac` on `PATH` predates this PR, it would die on *"No such command 'start'"* — and
**the control plane would never come back up.** That is the exact failure this PR exists
to avoid, so it must not be the failure this PR causes.

Same reasoning for `_restart.py`'s respawn argv (#2): the code doing the respawn and the
binary it shells out to are not guaranteed to be the same version. The bare form is the
safe respawn until every deployed `sac` carries `start`.

### One deliberate deviation from §5a (once-per-shell suppression)

The warning fires on **every** bare boot, not once per shell. §5a keys its marker on
`$PPID` to give one warning per interactive shell — but this daemon's principal caller
is a **systemd unit, whose PPID is the constant user manager**. A once-per-PPID marker
would warn on the first boot and then stay silent forever, muting *exactly the caller
that has to migrate*. §5a's rationale ("cron jobs and loops would drown in it") also
doesn't apply: a daemon boots once per lifetime — at most one journal line per start.
stderr only, and no marker-file write: the control plane's boot path must not be able to
fail on a filesystem write it doesn't need.

---

## Real `sac listen -h` (actually run, not described)

Loaded from this branch's source (`PYTHONPATH=<worktree>/src`, verified via
`cli_pkg/listen_cmds.__file__`):

```
Usage: sac listen [OPTIONS] [COMMAND] [ARGS]...

  The host HTTP/JSON control plane (command group).

  The plane every sac agent reaches the host through — 127.0.0.1:7878 by
  default, bearer-token authenticated, loopback-only unless you opt out.
  `listen` is a NOUN; the verbs below are its whole lifecycle.

  Example:
      sac listen start                    # boot the daemon (loopback only)
      sac listen status                   # health report; exit 1 if down
      sac listen status --json            # machine-readable envelope
      sac listen stop                     # stop it (idempotent)
      sac listen restart                  # atomic stop-clean-relaunch
      sac listen start --print-token      # echo the bearer token, then exit

  DEPRECATED: bare `sac listen` still BOOTS the daemon, so the systemd unit
  and every existing launcher keep working — but it now warns. Use
  `sac listen start`. The bare form is removed in v0.23.0.

Options:
  --bind TEXT           HOST:PORT to bind. Defaults to loopback per §4.4.
                        [default: 127.0.0.1:7878]
  --token-file FILE     Bearer-token file. Auto-generated at ~/.scitex/agent-
                        container/tokens/listen-<host>.token if missing.
  --allow-non-loopback  Permit binding to non-loopback addresses. Required for
                        tailscale/tunnel binds; orochi-side mesh is the
                        supported transport.
  --print-token         Print the bearer token to stdout and exit.
  -h, --help            Show this message and exit.

Commands:
  restart  Atomically stop, self-heal, and relaunch the sac listen daemon.
  start    Boot the sac listen HTTP/JSON control-plane daemon.
  status   Report the sac listen daemon's health in one command.
  stop     Stop the running sac listen daemon.
```

**Before**, for contrast — `Commands:` listed only `restart` and `status`, and the
example block showed only the bare boot form:

```
  Example:
      sac listen                          # 127.0.0.1:7878 (start)
      sac listen --bind 100.64.1.2:7878 --allow-non-loopback
      sac listen --print-token            # echo token then exit
      sac listen restart                  # atomic stop-clean-relaunch

Commands:
  restart  Atomically stop, self-heal, and relaunch the sac listen daemon.
  status   Report the sac listen daemon's health in one command.
```

## Verified LIVE (throwaway port 7999 — 7878 never touched)

Run under a **fake `$HOME`**, because booting calls `_register_self_comms_node(port=...)`,
which writes `comms_nodes` with `a2a_port=<bind port>` — on 7999 that would have
**overwritten the lead's row and misdirected cross-host peers away from the real 7878**.
Under the fake HOME there is no `lead:` block, so it logged "self-register skipped" and
wrote nothing.

```
1. sac listen start --bind 127.0.0.1:7999   ->  7999 health = HTTP 200
2. sac listen --bind ... status             ->  UP (serving), pidfile PID 294082 (alive),
                                                health probe -> HTTP 200, exit=0
3. sac listen --bind ... stop               ->  # sac listen stopped → 127.0.0.1:7999 (PID 294082)
                                                exit=0; port DOWN (connection refused)
4. sac listen --bind ... stop  (again)      ->  # sac listen was not running → ... (nothing to stop)
                                                exit=0   [IDEMPOTENT]
5. BARE sac listen --bind 127.0.0.1:7999    ->  WARN: bare `sac listen` is DEPRECATED ...
                                                SERVING after 8s: HTTP 200
                                                {"ok":true,"service":"sac-listen","v":1}
                                                ps: 302716 ... cli_entry_point()  listen --bind 127.0.0.1:7999
                                                (no subcommand — this IS the bare form)
6. sac listen --bind ... stop               ->  # sac listen stopped → 127.0.0.1:7999 (PID 302716)

7878 health = HTTP 200  — before, during, and after. Never touched.
```

**Bare `sac listen` still boots and still serves.** Proven by polling `/v1/health` to a
200 with a real payload, and by `ps` showing the serving pid is the no-subcommand
invocation — not by reading the code and hoping.

## Tests

**A test failed first**: the new suites went red before the code existed (`ImportError:
cannot import name '_stop'`, then 23 failed / 22 passed once `_stop` landed but the
verbs did not).

**131 focused tests green**, including *every pre-existing* `_restart`, `_port_holder`
and `listen_cmds` test — so the `restart` → `stop_listen` delegation is behaviour-
preserving.

New tests worth calling out:
- `test_bare_listen_still_boots_the_daemon_for_launcher_compat` — **the regression guard
  for the hard coupling above.** If someone later flips the bare form to show-help, this
  goes red and names why.
- `test_restart_listen_delegates_its_stop_half_to_stop_listen` — the anti-drift guard.
- `test_stop_listen_keeps_pidfile_when_pid_survives_sigkill` — never release a lock whose
  owner is still alive.
- `test_listen_stop_on_dead_daemon_exits_zero_idempotently` — the `systemctl stop` contract.

No mocks (PA-306 hand-rolled save/restore seams). The `_stop` tests carry an autouse
fixture that neutralises the port-probe seams, so **no test can socket-probe or kill the
live 7878 daemon** as a side effect.

## Notes for the reviewer

- **`stop` did not exist** before this PR — only `restart` and `status`. Confirmed
  against the real `-h`.
- New modules (`_listen/_stop.py`, `cli_pkg/_listen_verbs.py`) exist partly because
  `listen_cmds.py` and `_restart.py` were at **429** and **exactly 512** lines against a
  hook-enforced **512-line cap** — `_restart.py` had zero headroom, so the stop half had
  to move out. It now sits at 490; `listen_cmds.py` at 506.
- Pre-existing, unrelated: running the whole `tests/.../cli_pkg/` **directory** stalls on
  this dev host (it stalls inside `cli_pkg/lifecycle/`, which this PR does not touch —
  and another agent's unrelated branch hangs identically). Almost certainly tests that
  touch the real fleet (registry / live sockets), which don't exist in CI. Flagging it,
  not fixing it here.
