### PR TITLE
release: v0.21.17 — the release that actually reaches PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The account picker threw away ~10% of a 7-day Max-20x window, every cycle.**
+  `sac accounts list` at the time of the report:
+
+  ```
+  wyusuuke-gmail-com   5h 28%   7d 67%  (resets in 5d 14h)
+  ywata1989-gmail-com  5h  0%   7d 90%  (resets in 9h06m)
+  ywatanabe-scitex-ai  5h  0%   7d 90%  (resets in 6 MINUTES)   <- 10% about to evaporate
+  ```
+
+  The picker sent every agent to `wyusuuke` (67%), so `ywatanabe-scitex-ai`'s
+  remaining **10% of a 7-day window was deleted unused six minutes later**
+  (operator: 「毎回 90%で10%捨ててる」 — we bin it every cycle).
+
+  Root cause: `_creds._quota_rank.pick_ranked` **had no notion of when a window
+  resets.** It scored "90%, resets in 6 minutes" and "90%, resets in 6 days"
+  *identically* and avoided both — but they are opposites. 90% with 6 days left
+  is a genuine reserve (avoiding it is correct); 90% with 6 minutes left is
+  **use-it-or-lose-it**, and avoiding it burns the capacity for nothing.
+
+  The reset time was not merely unused — it was **unreachable**. The usage API
+  returns `resets_at` for both windows and `_account.claude_usage` already parsed
+  it, but `_account.quota_cache_refresh` **dropped it when writing the aggregate
+  `quota-cache.json` the picker reads**, so the ranker was structurally unable to
+  see it. (`sac accounts list` renders "resets in …" from a *different* cache —
+  the per-account `usage.json` — which is why it was visible to the human and
+  invisible to the picker.)
+
+  Fixed in three parts:
+  - `quota_cache_refresh` now persists `reset_at_5h` / `reset_at_7d` into the
+    aggregate cache (additive; entries stay valid when upstream omits them).
+  - `_quota_rank.is_expiring_7d` classifies a near-capped window whose reset is
+    imminent as **expiring, not scarce**: it no longer suffers the `near_capped`
+    demotion, and its rendezvous-hash weight is boosted so the fleet spends
+    vanishing capacity before a reserve that persists.
+  - `_pick_healthy` applies the same rule to the `preferred` account, so an agent
+    is no longer rotated *off* the very account whose quota is about to evaporate.
+
+  On the table above the expiring account goes from **0 of 60 agents to 37 of 60**,
+  while the 9h-away reserve stays correctly avoided (**0 of 60**) and the fleet
+  still spreads (23 of 60 to `wyusuuke`).
+
+  Bounded against a 429 (the risk of routing onto a 90% account): the 5h window
+  remains the supreme, untouched gate; an account with <2% of its weekly window
+  left is never treated as expiring capacity; the horizon is 2h, so worst-case
+  "stuck at the cap" exposure is short; the preference is a spread *weight*, not
+  a hard tier, so a bulk restart cannot stack the whole fleet onto a window with
+  10% left; and a 429 at these usage levels already classifies as `Mode.ROTATE`
+  (`_account.rate_limit_classifier`), which rotates the agent to a *different*
+  healthy account — `rotate_account` excludes the current one, so it cannot
+  thrash back onto the drained account.
+
+  An old cache with no reset stamps degrades to exactly the previous behaviour.
+
 ## [0.21.16] — 2026-07-14
 
 **⚠️ 0.21.15 WAS NEVER PUBLISHED — it is tagged, but nothing reached PyPI, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Fixed
 
+- **`a2a_send` reported SUCCESS for a message that reached nobody — agents were
+  silently swallowing each other's messages.** Reported by the `grant` agent,
+  who measured it live: of four peers that `a2a_peers` listed as running (pid,
+  port, start time, group `active`), two delivered and two had
+  `delivered_subscriber_count=0`. The tool *did* put "reached no live
+  subscriber" in its response **body** — but returned it as a plain
+  `list[TextContent]`, and the MCP low-level server stamps `isError=False` on
+  anything a handler returns that way. So the protocol classified the call as
+  successful. In grant's words: *"Had it returned a bare 200, I would have
+  believed the message landed and moved on. How many agent-to-agent messages
+  have been swallowed this way? Nobody would know."*
+
+  A 0-subscriber send is now an **MCP error** (`isError=True`), so a caller
+  cannot mistake it for delivery. It keeps the structured detail — target,
+  machine-readable `code`, subscriber count — and adds what to do instead.
+  Notably it does **not** tell you to re-send (sac persists to
+  `channel_events` *before* it publishes, and replays undelivered rows on the
+  target's next connect, so the message is queued, not lost — re-sending would
+  double-deliver), and it does **not** tell you to restart the target
+  (0 subscribers means a detached inbox adapter, not a dead agent).
+
+- **`GET /agents` (and so `a2a_peers`) conflated REGISTERED with REACHABLE.**
+  Every row said what the registry *declared* — a pid, a port, a group — and
+  nothing said whether a message would actually wake anybody. That signal was
+  load-bearing: the fleet constitution says to confirm a peer is "alive and
+  able to act" before handing it work, and `a2a_peers` is the tool provided to
+  do it. It answered yes for a deaf agent.
+
+  Rows now carry `inbox_subscribers` (live SSE subscribers on that agent's
+  inbox stream) and `inbox_reachable`, which is **ternary** on purpose:
+  `reachable` / `unreachable` / `unknown` — the last for a peer on another host
+  whose broker this listen cannot observe. "I could not check" is never
+  rendered as either success or death. Same fields on
+  `GET /agents/<name>/status` and in `sac agents health --json`.
+
+  `healthy` is deliberately **not** derived from the subscriber count, and
+  nothing auto-restarts on it. Measured during this investigation:
+  `claude-code-telegrammer`'s zero was a *transient* reconnect window on a
+  perfectly healthy agent — a restart would have destroyed a live session.
+
 - **The account picker threw away ~10% of a 7-day Max-20x window, every cycle.**
   `sac accounts list` at the time of the report:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `scitex-agent-container` (sac) are recorded here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [0.21.17] — 2026-07-14
 
 ### Fixed
 
@@ -101,13 +101,60 @@ versioning follows [SemVer](https://semver.org/).
 
   An old cache with no reset stamps degrades to exactly the previous behaviour.
 
-## [0.21.16] — 2026-07-14
+- **Three CI legs shared ONE tmux socket — this is what failed the 0.21.16
+  release (#667).** `SOCKET = "sac-probe-tests"` was a literal. A tmux socket is
+  keyed by `(user, socket-NAME)`, **never by process**, so a literal name is a
+  *host-global namespace*. The comment above it called the socket "private", and
+  it was — private from the **operator's** fleet. Not from our own sibling CI
+  legs:
+
+  ```
+  test (3.12)  runner=scitex-agent-container-03             23:24:23 -> 23:31:16  [ok]
+  test (3.11)  runner=scitex-agent-container-02             23:24:23 -> 23:31:10  [ok]
+  test (3.13)  runner=spartan-cpu-scitex-agent-container-01 23:24:23 -> 23:31:25  [FAIL]
+  ```
+
+  All three started **in the same second** and overlapped for seven minutes;
+  `-01/-02/-03` are three runner *registrations of one physical node*, same user.
+  So all three drove a **single** tmux server and killed each other's sessions.
+  Note *which* two tests failed: the only two asserting an **exact global count**
+  (`== {}` and `len == 30`). The four asserting *membership* structurally cannot
+  see a collision. That asymmetry is the fingerprint.
+
+  This is the **same dead invariant #662 already documented** in `exec-in-sif.sh`
+  — "runs here are serialised (one job at a time)" stopped being true the day -02
+  and -03 were registered. #662 removed *its own* dependence on it and nobody
+  grepped for the rest. This was the rest.
+
+  The socket name is now unique per process (pid + uuid), so concurrent legs and
+  xdist workers cannot meet. The subprocess deadline went 10s → 30s: a fixed
+  deadline tight enough to blow on a three-legs-at-once box is a race, and it
+  raises inside the *fixture*, reporting as a broken test rather than a busy
+  host. Measured, not assumed — old code, 2 concurrent legs: **FAILED**; new
+  code, 3 concurrent legs: **6 passed, 6 passed, 6 passed**.
+
+### Added
+
+- **`sac listen` is now a supervised service (#543).** It is declared as a
+  `kind="service"` JobSpec (`sac.listen`, `restart_policy="always"`) via the
+  `scitex_dev.jobs` entry point, so `scitex-dev service ensure sac.listen`
+  installs and keeps it alive (systemd `--user` where available, a respawn
+  keep-alive otherwise). Until now **nothing restarted it**: the listen log
+  showed two *clean* shutdowns followed by silence — it had no supervisor at
+  all, and the fleet's control plane simply stayed down until a human noticed.
+
+## [0.21.16] — 2026-07-14 *(tagged, never published — see 0.21.17)*
+
+**⚠️ 0.21.16 WAS NEVER PUBLISHED EITHER.** Its release run died on the CI tmux
+collision fixed above (#667) — `test (3.13)` failed, so `build`/`publish` never
+ran and PyPI stayed on 0.21.14. The *code* below is sound and is included in
+0.21.17. **Install 0.21.17.**
 
 **⚠️ 0.21.15 WAS NEVER PUBLISHED — it is tagged, but nothing reached PyPI, and
 that is deliberate.** It shipped #658 (the shared-executor fix) *with a hole*:
 #658 did not introduce the cancellation race below, but it **widened the window
 enormously**, so 0.21.15 would have traded a thread leak for a `sac listen` that
-cannot be stopped. It was held back rather than published. **Install 0.21.16.**
+cannot be stopped. It was held back rather than published.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,59 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [0.21.17] — 2026-07-14
 
+### Added
+
+- **`sac listen start` and `sac listen stop` — `listen` is a NOUN, so give it
+  verbs.** `listen` is a command group like `agents` / `db` / `host`, but bare
+  `sac listen` *booted a daemon*. Every other noun group in this CLI prints help
+  when invoked bare; this one silently became a server on 7878 — so a typo or a
+  stray tab-complete started one. That is the anti-pattern the scitex CLI
+  convention names outright (§1: *"trailing noun, no action: **never**"*).
+
+  The group already had `restart` and `status` (the latter easy to miss — it was
+  absent from the help's example block). It now has the coherent set:
+
+  ```bash
+  sac listen start      # boot the daemon (the explicit form of bare `sac listen`)
+  sac listen stop       # NEW — idempotent, like `systemctl stop`
+  sac listen restart    # unchanged
+  sac listen status     # unchanged, now discoverable in `-h`
+  ```
+
+  `start`, not `serve`: the §1d catalog reserves `start`/`stop`/`restart` for
+  *daemonized* lifecycle (a background process with a pid) and gives `serve` to
+  foreground, browser-facing surfaces under a `gui` group. This daemon writes a
+  flock-backed pidfile that `stop`/`restart`/`status` all address by pid, and a
+  systemd unit supervises it. `start` also keeps SSOT with `sac agents start`.
+
+  Options work on the verb (`sac listen start --bind …`) or on the group
+  (`sac listen --bind … start`); the verb wins.
+
+  `stop` is `restart`'s stop half on its own — both now call one implementation
+  (`_listen._stop.stop_listen`), so the two verbs cannot drift. It inherits the
+  full self-heal: SIGTERM → grace → SIGKILL, verify-dead *before* clearing the
+  pidfile, then force-kill a wedged remnant the pidfile never named (the "curl
+  hangs forever" case). `--json` emits a machine-readable envelope.
+
+### Deprecated
+
+- **Bare `sac listen` (boot-by-default) — removal in v0.23.0.** It **still
+  boots**, and deliberately so. Three launchers still invoke it bare:
+
+  1. `scripts/systemd/sac-listen.service` — `ExecStart=/usr/bin/env sac listen`
+  2. `_listen/_restart.py` — the respawn argv, `[sac_binary(), "listen"]`
+  3. `_jobs_plugin.py` — the `sac.listen` systemd JobSpec (#543), `command="sac listen"`
+
+  `sac listen` *is* the host control plane on 127.0.0.1:7878, and the whole fleet
+  loses host access when it is down — flipping the bare form to show-help would
+  take it offline. So this is phase W of the deprecation ladder: **warn and
+  forward**, never break.
+
+  Bare boot now prints a stderr warning naming `sac listen start` and the removal
+  version. **Follow-up (required before v0.23.0):** move all three launchers to
+  `sac listen start` — but only once a `sac` carrying the `start` verb is actually
+  *deployed* everywhere, or a respawn/JobSpec would die on "No such command" and
+  the control plane would never come back.
 ### Fixed
 
 - **`a2a_send` reported SUCCESS for a message that reached nobody — agents were

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.16"
+version = "0.21.17"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -23,6 +23,52 @@ broker, lead inbox. Before this unit landed, the listen was
 operator-started ad-hoc and could be found DOWN with nothing
 restarting it.
 
+> **Also federated as `sac.listen`** (2026-07-05, clew incident
+> `clew-incident-sac-host-listen-down`): sac's `provide_jobs()`
+> (`src/scitex_agent_container/_jobs_plugin.py`) registers a
+> `kind="service"` JobSpec for the same daemon, supervised via
+> **`scitex-dev service ensure sac.listen`**.
+>
+> That verb resolves the name from the `scitex_dev.jobs` federation and
+> then — in ONE idempotent step — writes the `.service` unit,
+> `daemon-reload`s, and `enable --now`s it (falling back to a respawn
+> keep-alive loop under `~/.scitex/<pkg>/runtime/` on hosts with no
+> reachable systemd `--user` manager). It is the purpose-built consumer
+> for `kind="service"`; `scitex-dev ecosystem systemd install` is the
+> *timer* installer and does not start a service.
+>
+> This is an ALTERNATIVE activation path to the hand-maintained unit
+> below — the two are NOT meant to run simultaneously (both would try
+> to bind `127.0.0.1:7878`; the flock-backed single-instance guard
+> stops a double *process*, but a double *unit* still fights over
+> restarts). Pick ONE:
+>
+> * **`scitex-dev service ensure sac.listen`** — federated unit, one
+>   idempotent command, single source of truth with the rest of the
+>   ecosystem's jobs, and the only path that also works on a host with
+>   no systemd `--user` manager. Covers **every** non-`systemctl stop`
+>   exit via `Restart=always` — including the CLEAN 0-exit shutdown
+>   that is how this daemon has actually been lost in production
+>   (2026-07-05, and again 2026-07-14), with nothing bringing it back.
+>   Does **not** detect a wedged-but-alive process.
+> * `scripts/systemd/install-sac-listen.sh` — hand-maintained unit plus
+>   the `sac-listen-health.timer` wedge-detection watchdog, i.e. hang
+>   coverage on top of crash coverage. Choose this if wedge detection
+>   is worth hand-maintaining the unit; note the probe restarts
+>   `sac-listen.service` **by name**, so it does not compose as-is with
+>   the federated `sac.listen.service` unit.
+>
+> Wedge detection has no equivalent in `scitex_dev.jobs` yet
+> (`JobSpec.watchdog_sec` drives systemd's `sd_notify` watchdog, which
+> `sac listen` does not implement — see the `watchdog_sec` note in
+> `_jobs_plugin.py`). Closing that gap in the federated path — a
+> health-probe primitive keyed on an HTTP endpoint — is the follow-up
+> that would make the federated unit a strict superset.
+>
+> If you switch from the hand-maintained unit to the federated one (or
+> vice versa), `systemctl --user disable --now` the one you are
+> retiring first.
+
 ```bash
 # Install BOTH the listen unit and its health watchdog (preferred —
 # copies units + probe script, daemon-reload, enable --now, status):

--- a/src/scitex_agent_container/_account/quota_cache_refresh.py
+++ b/src/scitex_agent_container/_account/quota_cache_refresh.py
@@ -94,8 +94,12 @@ def refresh_quota_cache(
 
     Returns:
         ``{"cache_path": str, "written": bool, "ok": int, "failed": int,
-           "results": [{"name", "short", "h5", "d7", "ttl_h", "error"}]}``.
-        ``error`` is ``None`` on success. Never raises.
+           "results": [{"name", "short", "h5", "d7", "ttl_h",
+                        "reset_at_5h", "reset_at_7d", "error"}]}``.
+        ``error`` is ``None`` on success. The two ``reset_at_*`` stamps
+        are ISO-8601 strings (or ``None`` when upstream omits them) and
+        are what lets the picker tell expiring quota from a reserve —
+        see :func:`_creds._quota_rank.is_expiring_7d`. Never raises.
     """
     from .._state.account_store import list_accounts
 
@@ -125,6 +129,17 @@ def refresh_quota_cache(
                 "h5": row["h5"],
                 "d7": row["d7"],
                 "ttl_h": row["ttl_h"],
+                # WHEN each window resets — not just how full it is. The
+                # picker cannot tell "90%, resets in 6 minutes" (spend it,
+                # it is about to be deleted) from "90%, resets in 6 days"
+                # (a reserve, leave it) without this. The usage API has
+                # always returned it; we simply dropped it here, so the
+                # ranker was structurally unable to see it and the fleet
+                # binned the tail of every 7d window. Optional (None when
+                # upstream omits it) — every reader degrades to the
+                # reset-unaware behaviour rather than guess.
+                "reset_at_5h": row["reset_at_5h"],
+                "reset_at_7d": row["reset_at_7d"],
             }
             ok += 1
         else:
@@ -182,6 +197,8 @@ def _refresh_one(
         "h5": None,
         "d7": None,
         "ttl_h": None,
+        "reset_at_5h": None,
+        "reset_at_7d": None,
         "error": None,
     }
     creds_path = store / name / _CREDENTIALS_FILENAME
@@ -219,7 +236,20 @@ def _refresh_one(
     row["h5"] = float(h5)
     row["d7"] = float(d7)
     row["ttl_h"] = ttl_h
+    # Reset stamps are OPTIONAL, unlike h5/d7/ttl_h above: a response that
+    # omits them still yields a usable entry (the picker just degrades to
+    # its reset-unaware ranking for that account). Making them required
+    # would let a single upstream field change blank the whole cache.
+    row["reset_at_5h"] = _iso_or_none(usage.get("reset_at_5h"))
+    row["reset_at_7d"] = _iso_or_none(usage.get("reset_at_7d"))
     return row
+
+
+def _iso_or_none(value: Any) -> str | None:
+    """Pass through a non-empty ISO-8601 string; anything else → ``None``."""
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
 
 
 def _is_pct(value: Any) -> bool:

--- a/src/scitex_agent_container/_creds/_pick_healthy.py
+++ b/src/scitex_agent_container/_creds/_pick_healthy.py
@@ -27,7 +27,10 @@ Scope (Phase 1, deliberately small)
   axes carry different rules (see :mod:`._quota_rank`): an account at
   ≥ ~95% of its **5h** window is *blocked-now* (429s immediately) and
   is avoided while any fresh alternative is unblocked; an account at
-  ≥ ~90% **7d** is *near-capped* (the existing avoidance). The
+  ≥ ~90% **7d** is *near-capped* (the existing avoidance) — UNLESS its
+  7d window resets within the hour(s), in which case the remainder is
+  EXPIRING, not scarce, and we spend it rather than let it be deleted
+  (:func:`._quota_rank.is_expiring_7d`). The
   ``preferred`` account is kept only when it is fresh AND not
   blocked-now AND not near-capped, to minimise churn. Otherwise the
   best tier of fresh candidates competes: with a ``spread_key`` (the
@@ -73,9 +76,12 @@ from .._account.creds_sync import (
 from .._state.account_store import _store_path
 from ._quota_rank import (
     BLOCKED_5H_PCT,
+    EXPIRING_7D_HORIZON_S,
     NEAR_CAP_7D_PCT,
     account_5h_usage,
+    account_7d_reset_at,
     account_7d_usage,
+    is_expiring_7d,
     pick_ranked,
 )
 
@@ -259,9 +265,11 @@ def pick_healthy_account(
     now: float | None = None,
     usage_5h: Mapping[str, float] | None = None,
     usage_7d: Mapping[str, float] | None = None,
+    reset_7d: Mapping[str, object] | None = None,
     quota_cache_path: Path | str | None = None,
     near_cap_pct: float = _NEAR_CAP_PCT,
     blocked_5h_pct: float = _BLOCKED_5H_PCT,
+    expiring_horizon_s: float = EXPIRING_7D_HORIZON_S,
     spread_key: str | None = None,
 ) -> str:
     """Return the stored-account name an agent should run on right now.
@@ -311,10 +319,17 @@ def pick_healthy_account(
         :func:`._quota_rank.account_5h_usage` /
         :func:`._quota_rank.account_7d_usage`. A missing key / missing
         cache reads as "unknown" → per-account degradation.
+    reset_7d
+        Test-injectable per-account 7d-window reset stamp (name → ISO
+        string or epoch seconds). ``None`` (the boot path) reads
+        ``reset_at_7d`` from the same cache. This is what separates
+        "90%, resets in 6 minutes" (expiring — spend it, it is about to
+        be deleted) from "90%, resets in 6 days" (a reserve — leave
+        it). Unknown → the reset-unaware behaviour, unchanged.
     quota_cache_path
         Override the quota-cache path (passed through to
         :func:`_account.quota_cache.read_quota_entry`). Ignored when
-        the corresponding ``usage_*`` override is given.
+        the corresponding ``usage_*`` / ``reset_7d`` override is given.
     near_cap_pct
         The 7d % at/above which an account is "near-capped — avoid
         unless no better fresh alternative". Defaults to
@@ -323,6 +338,12 @@ def pick_healthy_account(
         The 5h % at/above which an account is "blocked-now — cannot
         serve requests until its 5h window resets". Defaults to
         :data:`._quota_rank.BLOCKED_5H_PCT` (95). Exposed for tests.
+    expiring_horizon_s
+        Seconds-to-7d-reset at/below which a near-capped account's
+        remainder counts as EXPIRING rather than scarce. Defaults to
+        :data:`._quota_rank.EXPIRING_7D_HORIZON_S` (2h) — the knob that
+        bounds how long an agent could sit at the cap if it drains the
+        remainder before the reset. Exposed for tests / tuning.
     spread_key
         Fleet load-balancing key — pass the AGENT NAME so concurrent
         boots of *different* agents spread across the eligible accounts
@@ -403,6 +424,17 @@ def pick_healthy_account(
         )
         for h in fresh
     }
+    # WHEN each 7d window resets — the axis that tells quota which is
+    # about to be DELETED from quota which is a reserve. Unknown for a
+    # cache written before the populator persisted it: every consumer
+    # then degrades to the reset-unaware ranking (see is_expiring_7d).
+    r7: dict[str, float | None] = {
+        h.name: account_7d_reset_at(
+            h.name, reset_7d=reset_7d, quota_cache_path=quota_cache_path
+        )
+        for h in fresh
+    }
+    probe_now = now if now is not None else time.time()
 
     # 1. Preferred wins when it is fresh AND not blocked-now (5h) AND
     #    not near-capped (7d); unknown quota keeps it (degrade to
@@ -414,22 +446,40 @@ def pick_healthy_account(
             pref_5h = u5.get(pref)
             pref_7d = u7.get(pref)
             blocked_now = pref_5h is not None and pref_5h >= blocked_5h_pct
-            near_capped = pref_7d is not None and pref_7d >= near_cap_pct
+            # An EXPIRING window is not a scarce one — the same rule the
+            # ranking applies (RULE 1). Without this an agent pinned to
+            # the very account whose quota is about to evaporate would be
+            # rotated OFF it minutes before the reset, which is the waste
+            # this change exists to stop, just via the other code path.
+            near_capped = (
+                pref_7d is not None
+                and pref_7d >= near_cap_pct
+                and not is_expiring_7d(
+                    pref_7d,
+                    r7.get(pref),
+                    probe_now,
+                    horizon_s=expiring_horizon_s,
+                )
+            )
             if not blocked_now and not near_capped:
                 return pref
 
     # 2. Otherwise the conditional ranking picks among the fresh set —
-    #    unblocked beats 5h-blocked, headroom beats near-capped, and a
-    #    spread_key load-balances the winning tier across the fleet.
-    #    Quota is a preference, not a hard gate: an all-blocked fleet
-    #    still returns the least-bad fresh account.
+    #    unblocked beats 5h-blocked, headroom beats near-capped, expiring
+    #    capacity is spent before a persisting reserve, and a spread_key
+    #    load-balances the winning tier across the fleet. Quota is a
+    #    preference, not a hard gate: an all-blocked fleet still returns
+    #    the least-bad fresh account.
     return pick_ranked(
         [h.name for h in fresh],
         u5,
         u7,
+        reset_7d=r7,
+        now=probe_now,
         spread_key=spread_key,
         near_cap_pct=near_cap_pct,
         blocked_5h_pct=blocked_5h_pct,
+        expiring_horizon_s=expiring_horizon_s,
     )
 
 

--- a/src/scitex_agent_container/_creds/_quota_rank.py
+++ b/src/scitex_agent_container/_creds/_quota_rank.py
@@ -28,6 +28,24 @@ The two quota axes mean different things and need different rules:
   :data:`NEAR_CAP_7D_PCT` avoidance, plus a *weight* for spreading:
   more weekly headroom → proportionally more of the fleet.
 
+Expiring capacity — the third axis (2026-07-14)
+-----------------------------------------------
+A utilisation % alone is NOT a decision. The ranker scored "90%, resets
+in 6 minutes" and "90%, resets in 6 days" identically and avoided both,
+but they are opposites: the first is quota that is about to be DELETED,
+the second is a genuine reserve. So every cycle the fleet binned the
+last ~10% of a 7-day window unused (operator: 「毎回 90%で10%捨ててる」).
+
+The window's reset time — already fetched from the usage API and shown
+by ``sac accounts list`` — was simply never persisted into the cache the
+picker reads. It is now (``reset_at_7d``; see
+:func:`_account.quota_cache_refresh.refresh_quota_cache`), and
+:func:`is_expiring_7d` turns it into the missing distinction:
+near-capped-but-expiring stops being *avoided* (it is not scarce) and
+starts being *preferred* (spend what vanishes before what persists).
+The preference is expressed as a spread WEIGHT, not a hard tier, so it
+cannot re-create the stacking incident below.
+
 Ranking (lexicographic tiers, then in-tier choice)
 --------------------------------------------------
 Fresh candidates are partitioned by ``(blocked_now, near_capped_7d,
@@ -54,6 +72,8 @@ from __future__ import annotations
 
 import hashlib
 import math
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Mapping
 
@@ -71,6 +91,41 @@ NEAR_CAP_7D_PCT = 90.0
 # at the wall by boot time. Also a preference (an all-blocked fleet
 # still boots on the least-bad account), never a hard gate.
 BLOCKED_5H_PCT = 95.0
+
+# --- Expiring-capacity ("use it or lose it") ------------------------------
+#
+# Seconds-to-7d-reset at/below which a near-capped account's REMAINING
+# quota is reclassified from "scarce reserve" to "about to be deleted".
+#
+# Why 2h (and not "any account that will reset eventually"): the ONLY
+# reason to avoid a near-capped account is that an agent parked there
+# would burn the remainder and then be stuck until the window resets.
+# The cost of being wrong is therefore bounded by TIME-TO-RESET — so
+# that is exactly what we bound. 2h keeps the worst-case "stuck at the
+# cap" exposure short while still giving the fleet a real drain window
+# before every reset (each account passes through it once per cycle).
+# Widen it to drain more aggressively; the 429 exposure scales with it.
+EXPIRING_7D_HORIZON_S = 2.0 * 3600.0
+
+# An account must retain at least this much 7d headroom to count as
+# "expiring capacity worth spending". Without this floor a FULLY
+# exhausted account (d7 == 100) resetting in 5 minutes would look like
+# free capacity and we would route work onto an account that 429s on
+# its very first request — burning the "expiring" preference for
+# nothing. There is no capacity to reclaim below this line.
+EXPIRING_MIN_HEADROOM_PCT = 2.0
+
+# Multiplier applied to an expiring account's rendezvous-hash WEIGHT.
+#
+# This is the load-balancing-safe expression of "prefer expiring
+# capacity": a boosted weight makes the fleet drain the vanishing quota
+# FASTER without making it the single winner for every agent. Promoting
+# expiring accounts to their own hard TIER instead would put every
+# booting agent on one account holding ~10% of a week — precisely the
+# stacking incident this module was written to prevent (see the module
+# docstring). Weight ∝ headroom keeps each account's share bounded by
+# the capacity it actually has.
+EXPIRING_WEIGHT_BOOST = 4.0
 
 
 def _coerce_pct(value: object) -> float | None:
@@ -137,6 +192,96 @@ def account_7d_usage(
     )
 
 
+def _coerce_epoch(value: object) -> float | None:
+    """Return *value* as epoch seconds, or ``None`` if unparseable.
+
+    Tolerant on purpose — the quota cache stores the reset stamp as the
+    upstream ISO-8601 string (``reset_at_7d``), but tests and callers
+    find raw epoch floats easier to reason about, so both are accepted.
+    A naive (tz-less) ISO stamp is read as UTC, matching
+    :func:`cli_pkg._account_list_format._coerce_dt`.
+    """
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    # stx-allow: fallback (reason: a malformed cache timestamp must degrade to
+    # "reset unknown" — i.e. the pre-existing behaviour — never crash a boot.)
+    try:
+        dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def account_7d_reset_at(
+    name: str,
+    *,
+    reset_7d: Mapping[str, object] | None = None,
+    quota_cache_path: Path | str | None = None,
+) -> float | None:
+    """One account's 7d-window reset time as epoch seconds, or ``None``.
+
+    Reads the ``reset_at_7d`` field the quota-cache populator persists
+    (:func:`_account.quota_cache_refresh.refresh_quota_cache`). ``None``
+    for a cache written BEFORE that field existed — which is exactly why
+    every consumer below must degrade to the reset-unaware behaviour
+    rather than assume "unknown reset" means "resets now".
+    """
+    if reset_7d is not None:
+        return _coerce_epoch(reset_7d.get(name))
+    entry = read_quota_entry(account=name, cache_path=quota_cache_path)
+    if entry is None:
+        return None
+    return _coerce_epoch(entry.get("reset_at_7d"))
+
+
+def is_expiring_7d(
+    d7: float | None,
+    reset_at: float | None,
+    now: float,
+    *,
+    horizon_s: float = EXPIRING_7D_HORIZON_S,
+    min_headroom_pct: float = EXPIRING_MIN_HEADROOM_PCT,
+) -> bool:
+    """Is this account's remaining 7d quota USE-IT-OR-LOSE-IT right now?
+
+    The distinction the ranker was missing (operator, 2026-07-14: 「毎回
+    90%で10%捨ててる」). ``d7 = 90%`` means two OPPOSITE things depending
+    on a number the ranker never looked at:
+
+    * **90%, resets in 6 days** — a genuine reserve. Spend it and the
+      fleet is stuck without weekly budget. Avoiding it is CORRECT.
+    * **90%, resets in 6 minutes** — the remaining 10% is about to be
+      DELETED. Avoiding it burns the capacity for nothing.
+
+    Only the second is "expiring". Returns ``True`` only when all hold:
+
+    * the 7d utilisation is KNOWN (an unknown % cannot be reasoned about);
+    * the reset stamp is KNOWN and lies within ``horizon_s`` — an unknown
+      or already-past stamp returns ``False``, i.e. the pre-existing
+      near-cap avoidance, so a stale/old cache is never *more* risky than
+      today's behaviour;
+    * at least ``min_headroom_pct`` of the window remains — there is no
+      capacity to reclaim from an account that is already at the wall.
+
+    Deliberately says nothing about the 5h window: that is the IMMEDIATE
+    throttle and stays a separate, supreme tier in :func:`pick_ranked`.
+    An expiring account that is 5h-blocked still loses — it cannot serve
+    a request *now* no matter how soon its weekly budget refreshes.
+    """
+    if d7 is None or reset_at is None:
+        return False
+    secs_to_reset = reset_at - now
+    if secs_to_reset < 0.0 or secs_to_reset > horizon_s:
+        return False
+    return d7 <= 100.0 - min_headroom_pct
+
+
 def _hrw_score(spread_key: str, name: str, weight: float) -> float:
     """Weighted rendezvous (HRW) score for one (agent, account) pair.
 
@@ -157,23 +302,57 @@ def pick_ranked(
     usage_5h: Mapping[str, float | None],
     usage_7d: Mapping[str, float | None],
     *,
+    reset_7d: Mapping[str, object] | None = None,
+    now: float | None = None,
     spread_key: str | None = None,
     near_cap_pct: float = NEAR_CAP_7D_PCT,
     blocked_5h_pct: float = BLOCKED_5H_PCT,
+    expiring_horizon_s: float = EXPIRING_7D_HORIZON_S,
 ) -> str:
     """Return the best account among *names* (all token-fresh, non-empty).
 
     ``usage_5h`` / ``usage_7d`` map each name to its cached utilisation
-    % or ``None`` (unknown). See the module docstring for the tier
-    rules; this never raises on quota state (fail-loud for "nothing
-    fresh" lives in the caller).
+    % or ``None`` (unknown). ``reset_7d`` maps each name to its 7d-window
+    reset stamp (ISO string or epoch seconds; ``None``/absent = unknown).
+    See the module docstring for the tier rules; this never raises on
+    quota state (fail-loud for "nothing fresh" lives in the caller).
+
+    Expiring capacity (see :func:`is_expiring_7d`) enters the ranking in
+    exactly two places, and NOWHERE else:
+
+    1. it SUPPRESSES the ``near_capped`` demotion — quota that is about
+       to be deleted is expiring, not scarce, so the account competes on
+       equal footing instead of being avoided;
+    2. it BOOSTS the account's spread weight (and sorts first in the
+       no-spread order) — we spend what is about to vanish before we
+       spend a reserve that persists.
+
+    ``blocked_now`` (the 5h window) is untouched and still dominates
+    both: an account that cannot serve a request *now* is never picked
+    over one that can, however soon its weekly budget refreshes.
+
+    With no ``reset_7d`` data (a cache predating the field) every
+    account reads "reset unknown" → ``is_expiring_7d`` is ``False``
+    everywhere → this function behaves EXACTLY as it did before.
     """
+    _now = now if now is not None else time.time()
+    _resets: Mapping[str, object] = reset_7d if reset_7d is not None else {}
+
+    def expiring(name: str) -> bool:
+        return is_expiring_7d(
+            usage_7d.get(name),
+            _coerce_epoch(_resets.get(name)),
+            _now,
+            horizon_s=expiring_horizon_s,
+        )
 
     def tier(name: str) -> tuple[bool, bool, bool]:
         h5 = usage_5h.get(name)
         d7 = usage_7d.get(name)
         blocked_now = h5 is not None and h5 >= blocked_5h_pct
-        near_capped = d7 is not None and d7 >= near_cap_pct
+        # RULE 1 — an expiring window is NOT a scarce one. Its remaining
+        # quota evaporates at the reset whether we spend it or not.
+        near_capped = d7 is not None and d7 >= near_cap_pct and not expiring(name)
         return (blocked_now, near_capped, d7 is None)
 
     best = min(tier(n) for n in names)
@@ -185,20 +364,26 @@ def pick_ranked(
 
         def weight(name: str) -> float:
             d7 = usage_7d.get(name)
-            if d7 is None:
-                return 1.0
-            return max(1.0, 100.0 - d7)
+            base = 1.0 if d7 is None else max(1.0, 100.0 - d7)
+            # RULE 2 (fleet path) — drain vanishing capacity faster, but
+            # as a WEIGHT, never a hard tier: the account still takes a
+            # bounded share proportional to what it actually holds, so a
+            # bulk restart cannot stack the whole fleet onto a window
+            # with 10% left.
+            return base * EXPIRING_WEIGHT_BOOST if expiring(name) else base
 
         return max(group, key=lambda n: _hrw_score(spread_key, n, weight(n)))
 
-    # Legacy deterministic order (no spread requested): most 7d headroom,
-    # then most 5h headroom, then candidate order. Unknowns sort last via
-    # +inf so a known value always wins inside the tie-break.
-    def sort_key(item: tuple[int, str]) -> tuple[float, float, int]:
+    # Legacy deterministic order (no spread requested): expiring capacity
+    # first (RULE 2 — spend what vanishes before what persists), then most
+    # 7d headroom, then most 5h headroom, then candidate order. Unknowns
+    # sort last via +inf so a known value always wins inside the tie-break.
+    def sort_key(item: tuple[int, str]) -> tuple[int, float, float, int]:
         idx, name = item
         d7 = usage_7d.get(name)
         h5 = usage_5h.get(name)
         return (
+            0 if expiring(name) else 1,
             d7 if d7 is not None else math.inf,
             h5 if h5 is not None else math.inf,
             idx,
@@ -209,8 +394,13 @@ def pick_ranked(
 
 __all__ = [
     "BLOCKED_5H_PCT",
+    "EXPIRING_7D_HORIZON_S",
+    "EXPIRING_MIN_HEADROOM_PCT",
+    "EXPIRING_WEIGHT_BOOST",
     "NEAR_CAP_7D_PCT",
     "account_5h_usage",
+    "account_7d_reset_at",
     "account_7d_usage",
+    "is_expiring_7d",
     "pick_ranked",
 ]

--- a/src/scitex_agent_container/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs_plugin.py
@@ -21,21 +21,37 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 def provide_jobs() -> "list[JobSpec]":
     """Return sac's federated scheduled jobs.
 
-    Currently one job: ``sac.accounts-refresh`` — a headless OAuth
-    access-token refresh for EVERY stored Claude account, including the
-    active one (``--include-active``), mirroring the rotated token back
-    into the live ``~/.claude`` login (``--sync-active-login``).
+    Two jobs today:
 
-    Why not ``--skip-active``: under the pre-2026-07-08 two-refresher
-    model both the host timer and the in-container CLI redeemed the same
-    single-use refresh_token, so skipping the active account was the race
-    guard (2026-06-04 neurovista 401 storm). Since 2026-07-08 agents bind
-    the credential ``:ro`` and never refresh, making this timer the SOLE
-    refresher — so ``--skip-active`` stopped guarding a race and instead
-    starved the one account every agent uses, whose ~8h access_token then
-    expired and 401'd the whole fleet (2026-07-09/10 total stall).
+    * ``sac.accounts-refresh`` (``kind="timer"``) — a headless OAuth
+      access-token refresh for EVERY stored Claude account, including the
+      active one (``--include-active``), mirroring the rotated token back
+      into the live ``~/.claude`` login (``--sync-active-login``).
+    * ``sac.listen`` (``kind="service"``) — the host-level HTTP/JSON
+      control plane (``127.0.0.1:7878``: push hub, spawn broker, lead
+      inbox).
+
+    Why ``sac.accounts-refresh`` is not ``--skip-active``: under the
+    pre-2026-07-08 two-refresher model both the host timer and the
+    in-container CLI redeemed the same single-use refresh_token, so
+    skipping the active account was the race guard (2026-06-04 neurovista
+    401 storm). Since 2026-07-08 agents bind the credential ``:ro`` and
+    never refresh, making this timer the SOLE refresher — so
+    ``--skip-active`` stopped guarding a race and instead starved the one
+    account every agent uses, whose ~8h access_token then expired and
+    401'd the whole fleet (2026-07-09/10 total stall).
     ``--sync-active-login`` keeps the operator's live session valid across
     the single-use refresh_token rotation.
+
+    Why ``sac.listen`` is federated here: it had NO SUPERVISOR. Declaring
+    it as a ``kind="service"`` JobSpec hands it to scitex-dev's supervisor
+    (``scitex-dev service ensure sac.listen`` — systemd ``--user`` with
+    ``Restart=`` where a user manager is reachable, else a respawn-loop
+    keep-alive), so it auto-starts on boot and comes back on ANY exit.
+    This replaces the fragile cron-based watchdog (``sac-listen-watch.sh``,
+    ``*/2`` cron) that died twice on 2026-07-05 (clew incident
+    ``clew-incident-sac-host-listen-down``) and left the whole fleet cut
+    off from the host after a CLEAN shutdown that nothing restarted.
     """
     from scitex_dev.jobs import JobSpec
 
@@ -66,7 +82,41 @@ def provide_jobs() -> "list[JobSpec]":
             on_boot_sec="15min",
             on_unit_active_sec="2h",
             timeout_sec=120,
-        )
+        ),
+        JobSpec(
+            name="sac.listen",
+            kind="service",
+            schedule="",
+            command="sac listen",
+            description=(
+                "Host-level HTTP/JSON control plane for sac agents "
+                "(loopback 127.0.0.1:7878) — push hub, spawn broker, lead "
+                "inbox. No env vars required: SAC_LISTEN_BEARER "
+                "self-resolves from the on-disk token file "
+                "(~/.scitex/agent-container/tokens/listen-<host>.token) "
+                "when unset (PR #470)."
+            ),
+            # restart_policy="always", NOT "on-failure": Incident
+            # 2026-06-26 (scripts/systemd/sac-listen.service) found that
+            # a clean 0-exit (e.g. an unexpected SIGTERM that uvicorn
+            # turns into a graceful shutdown) is NOT covered by
+            # Restart=on-failure, and that is exactly how the fleet lost
+            # a2a comms silently with nothing restarting the listen.
+            # "always" covers every non-`systemctl stop` exit; JobSpec's
+            # ALLOWED_RESTART_POLICIES includes "always" for kind=
+            # "service" specifically for this reason.
+            restart_policy="always",
+            timeout_sec=30,
+            # No watchdog_sec: sac listen is a plain Type=simple daemon
+            # that does not call sd_notify(WATCHDOG=1), so requesting a
+            # watchdog here would just cause systemd to kill-and-restart
+            # it every interval (see JobSpec.watchdog_sec docstring).
+            # Wedge (hang, not crash) detection is instead covered by the
+            # hand-maintained companion
+            # scripts/systemd/sac-listen-health.{service,timer} probe,
+            # which this JobSpec does NOT replace — see
+            # scripts/systemd/README.md for the coexistence note.
+        ),
     ]
 
 

--- a/src/scitex_agent_container/_lifecycle/inbox_probe.py
+++ b/src/scitex_agent_container/_lifecycle/inbox_probe.py
@@ -1,0 +1,89 @@
+"""Ask ``sac listen`` whether an agent's inbox adapter is actually attached.
+
+``sac agents health`` answers "is the process up?" (``health_check`` →
+``runtime.is_running``). That is a PID-shaped question, and a deaf agent
+passes it: its process is alive, its port is claimed, its registry row says
+``active`` — and every ``a2a_send`` aimed at it lands on a bus with zero
+subscribers and wakes nobody.
+
+So health reported green for agents that could not receive a single message.
+This probe adds the missing OBSERVATION next to the declaration, by asking
+the one component that actually knows: the broker inside ``sac listen``
+(via ``GET /agents/<name>/status``, which carries ``inbox_subscribers`` —
+see ``_listen/_reachability.py``).
+
+Two rules this module will not break
+------------------------------------
+1. **It never invents a verdict.** Every failure to observe — no listen
+   running, transport error, missing field, malformed body — returns
+   :data:`UNKNOWN`, never :data:`UNREACHABLE`. "I could not check" is not
+   evidence of deafness, and rendering it as such would slander healthy
+   agents.
+2. **It never feeds a restart.** The subscriber count is reported, and
+   that is ALL it does. ``healthy`` (which gates ``sac agents health``'s
+   exit code, and any automation keyed on it) is deliberately NOT derived
+   from it: 0 subscribers means an inbox adapter is detached, NOT that the
+   agent is dead, and auto-restarting on it would destroy a healthy session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+from .._listen._reachability import REACHABLE, UNKNOWN, UNREACHABLE
+
+__all__ = ["DEFAULT_LISTEN_URL", "probe_inbox_reachability"]
+
+DEFAULT_LISTEN_URL = "http://127.0.0.1:7878"
+
+# Short on purpose. This is an ADVISORY observation bolted onto a fast local
+# command; it must never be the reason `sac agents health` feels slow or
+# hangs. A listen that cannot answer in 2 s yields UNKNOWN, which is honest.
+_TIMEOUT_S = 2.0
+
+
+def _listen_base_url() -> str:
+    return os.environ.get("SAC_LISTEN_BASE_URL", DEFAULT_LISTEN_URL).rstrip("/")
+
+
+def probe_inbox_reachability(
+    name: str,
+    *,
+    listen_url: str | None = None,
+    bearer: str | None = None,
+    timeout_s: float = _TIMEOUT_S,
+) -> tuple[int | None, str]:
+    """Return ``(inbox_subscribers, inbox_reachable)`` for ``name``.
+
+    ``inbox_subscribers`` is the live SSE subscriber count on that agent's
+    inbox stream, or ``None`` when it could not be observed.
+    ``inbox_reachable`` is one of ``reachable`` / ``unreachable`` /
+    ``unknown`` (the vocabulary in :mod:`_listen._reachability`).
+
+    Never raises: every failure path degrades to ``(None, UNKNOWN)``.
+    """
+    base = (listen_url or _listen_base_url()).rstrip("/")
+    token = bearer if bearer is not None else os.environ.get("SAC_LISTEN_BEARER")
+    req = urllib.request.Request(f"{base}/agents/{name}/status", method="GET")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310
+            body = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError):  # stx-allow: fallback (reason: an unobservable listen must yield UNKNOWN — never a false 'unreachable' verdict against a healthy agent)
+        return None, UNKNOWN
+
+    if not isinstance(body, dict):
+        return None, UNKNOWN
+
+    count = body.get("inbox_subscribers")
+    if not isinstance(count, int) or isinstance(count, bool):
+        # Field absent (an older listen that predates the observation) or
+        # not an int. We did not observe a zero — we observed nothing.
+        return None, UNKNOWN
+
+    return count, (REACHABLE if count >= 1 else UNREACHABLE)

--- a/src/scitex_agent_container/_listen/_agents_list.py
+++ b/src/scitex_agent_container/_listen/_agents_list.py
@@ -1,0 +1,221 @@
+"""``GET /agents`` — the peer-discovery route (extracted from server.py).
+
+Backs the ``a2a_peers`` MCP tool: this is THE surface an agent consults to
+answer "is this peer alive and able to act?" before handing it work. It is
+therefore the surface where "registered" and "reachable" must not be
+conflated — see :mod:`._reachability` for why that conflation was a P1 bug
+(deaf agents advertising themselves as ``active`` while silently swallowing
+every message).
+
+Split out of :mod:`scitex_agent_container._listen.server` (which sits at the
+per-file line cap), mirroring the existing extractions of ``agent_send`` /
+``agents_start`` / ``agent_tail`` / the node inbox channel. ``server.py``
+re-imports :func:`list_agents` so route registration and the historical
+``from ..._listen.server import list_agents`` import path keep working.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from .._state.registry import Registry
+
+__all__ = ["list_agents"]
+
+log = logging.getLogger(__name__)
+
+
+async def list_agents(request: Request) -> JSONResponse:
+    """List agents the local Registry knows about + self-peers.
+
+    Every row carries the INBOX-SUBSCRIBER OBSERVATION — ``inbox_subscribers``
+    and ``inbox_reachable`` — alongside the registry's declarations.
+
+    All three sources below report what the fleet has DECLARED about an agent
+    (a pid, a port, a group, a start time). None of them can tell you whether
+    a message sent to that agent would actually wake anybody: that depends on
+    whether its inbox adapter is subscribed to the channel bus, which only the
+    broker knows. Publishing the declaration alone is what let two of four
+    agents advertise ``active`` while silently swallowing every ``a2a_send``.
+    So we publish the observation next to it, distinctly. See
+    :mod:`._reachability`.
+
+    Three sources, concatenated in this order:
+
+    1. Container-agent rows from :meth:`Registry.list_all` — the
+       traditional ``sac a2a peers`` shape (``name`` / ``config`` /
+       ``pid`` / ``started_at`` / ``screen``).
+    2. Self-peer rows from :func:`_self_peers.discover_self_peers`
+       — any agent dir whose ``spec.yaml`` carries only a
+       ``listen_url`` (no container ``spec`` block, no
+       ``apiVersion``). These have no ``pid`` / ``screen`` — they
+       are external listen sessions that own a port and want to be
+       discoverable. Carries ``"kind": "self-peer"`` so peer-aware
+       clients can branch on the source.
+    3. Comms-node self-registrations from ``comms_nodes`` (ADR-0014).
+
+    Dedup: a self-peer whose ``name`` already appears in the
+    container-row list loses to the container row (the running
+    container is the more authoritative source). Order matches
+    operator-facing convention: container rows first, then
+    self-peers alphabetically by ``name``.
+    """
+    rows: list[dict] = []
+    seen_names: set[str] = set()
+    try:
+        reg = Registry()
+        for row in reg.list_all():
+            rows.append(row)
+            name = row.get("name") if isinstance(row, dict) else None
+            if isinstance(name, str):
+                seen_names.add(name)
+    except Exception as exc:  # stx-allow: fallback (reason: surface a JSON error to the caller rather than ASGI 500 stack)
+        return JSONResponse({"error": str(exc)}, status_code=500)
+
+    _append_self_peers(rows, seen_names)
+    _append_comms_nodes(rows, seen_names)
+
+    # Q1 (lead dispatch a2a dc6fd23387f64e329049d218cf85a4d4): surface
+    # ``a2a_port`` + derived ``turn_url`` on every row so scitex-todo's
+    # notify resolver (P3a-b) can dispatch nudge→turn without redeploy.
+    # Idempotent: self-peer rows that already carry a non-None value
+    # keep theirs (the discovery layer is the authoritative source for
+    # those).
+    from ._registry_endpoints import enrich_row
+
+    rows = [enrich_row(row) for row in rows]
+    rows = await _annotate_reachability(request, rows)
+    return JSONResponse({"agents": rows})
+
+
+async def _annotate_reachability(request: Request, rows: list[dict]) -> list[dict]:
+    """Add ``inbox_subscribers`` / ``inbox_reachable`` to every row.
+
+    Reads the live broker — the ONLY authority on whether an agent's inbox
+    adapter is actually attached. One snapshot (a single lock take on an
+    in-memory dict), so this adds no I/O per row and cannot stall the route.
+
+    Best-effort in the SAFE direction: if the broker cannot be read at all,
+    every row is annotated ``unknown`` rather than ``unreachable``. "I could
+    not check" must never be rendered as death — that error would accuse
+    healthy agents of being deaf, and the remedy a caller reaches for on a
+    false death verdict is destructive.
+    """
+    from ._reachability import UNKNOWN, annotate_rows
+
+    try:
+        broker = request.app.state.inbox
+        counts = await broker.subscriber_counts()
+        local_host = getattr(request.app.state, "local_host", None)
+    except Exception as exc:  # stx-allow: fallback (reason: an unreadable broker must degrade to UNKNOWN, never to a false 'unreachable' verdict against healthy agents)
+        log.warning(
+            "list_agents: could not read inbox broker (reporting reachability "
+            "as %r for every row — NOT as unreachable): %s",
+            UNKNOWN,
+            exc,
+        )
+        return [
+            {**row, "inbox_subscribers": None, "inbox_reachable": UNKNOWN}
+            for row in rows
+        ]
+    return annotate_rows(rows, subscriber_counts=counts, local_host=local_host)
+
+
+def _append_self_peers(rows: list[dict], seen_names: set[str]) -> None:
+    """Self-peers — best-effort. Failures here must NOT mask a healthy
+    container-row response (an unreadable agents dir is operator state, not a
+    listen failure).
+
+    Runtime self-identity is derived from host_config — the same source the
+    existing channel/listen self-registration paths consult. Missing
+    host_config / missing ``lead:`` block degrades to ``None``;
+    :func:`discover_self_peers` then surfaces the literal ``self`` dir as
+    ``"self"`` with a logged warning, which is the loudest signal short of
+    failing the request.
+    """
+    try:
+        from ..config._resolve import _search_dirs
+        from ._self_peers import discover_self_peers
+
+        primary, env_dirs, fleet_dirs = _search_dirs()
+        search_dirs = [*env_dirs, primary, *fleet_dirs]
+        self_identity = _resolve_runtime_self_identity()
+        for peer in discover_self_peers(search_dirs, self_identity=self_identity):
+            if peer["name"] in seen_names:
+                continue
+            rows.append(peer)
+            seen_names.add(peer["name"])
+    except Exception as exc:  # stx-allow: fallback (reason: self-peer discovery must never block the registry response)
+        log.warning(
+            "list_agents: self-peer discovery failed (returning registry rows only): %s",
+            exc,
+        )
+
+
+def _append_comms_nodes(rows: list[dict], seen_names: set[str]) -> None:
+    """Comms-node self-registrations (operator mandate 2026-06-14): ANY
+    process that loaded the sac MCP and self-registered into the
+    ``comms_nodes`` table (e.g. ``sac mcp channel --name lead``, or any
+    CLI/SDK session running the channel adapter) MUST appear in ``a2a peers``
+    at startup -- no exceptions. Such nodes are not in the Registry (no
+    container) and can live outside the filesystem self-peer search dirs, so
+    without this source the lead (and any bare sac-MCP session) is invisible
+    here. Best-effort: a read failure must not mask the rest of the response.
+    """
+    try:
+        from .._state.state_db_comms_nodes import list_comms_nodes
+
+        for node in list_comms_nodes():
+            if node["name"] in seen_names:
+                continue
+            rows.append(
+                {
+                    "name": node["name"],
+                    "host": node["host"],
+                    "a2a_port": node["a2a_port"],
+                    "kind": "comms-node",
+                    "registered_at": node.get("registered_at"),
+                    "updated_at": node.get("updated_at"),
+                }
+            )
+            seen_names.add(node["name"])
+    except Exception as exc:  # stx-allow: fallback (reason: comms-node surfacing must never block the registry response)
+        log.warning(
+            "list_agents: comms_nodes surfacing failed (returning prior rows): %s",
+            exc,
+        )
+
+
+def _resolve_runtime_self_identity() -> str | None:
+    """Return the running listen's runtime identity, or ``None``.
+
+    Reads :func:`host_config.load().lead.name` — the same source the
+    existing channel/listen self-registration paths
+    (:mod:`_mcp._channel_self_register`,
+    :func:`cli_pkg.listen_cmds._register_self_comms_node`) consult.
+    A missing ``lead:`` block in host_config returns ``None`` — the
+    self-peer discovery downstream then surfaces the literal
+    ``self`` dir as ``"self"`` so the operator sees the gap rather
+    than getting a silently-renamed peer row.
+
+    Generic on purpose: there is no name-specific branching here.
+    ``host_config.lead.name`` is THE host's "who am I" answer for
+    operator-class sessions; a future evolution that supports
+    multiple self-identities on one host would extend the host_config
+    shape, not insert per-name special cases here.
+    """
+    try:
+        from .._state.host_config import load as load_host_config
+
+        cfg = load_host_config()
+        lead = getattr(cfg, "lead", None)
+        if lead is not None:
+            name = getattr(lead, "name", None)
+            if isinstance(name, str) and name.strip():
+                return name
+    except Exception:  # stx-allow: fallback (reason: host_config errors must never block the /agents response)
+        pass
+    return None

--- a/src/scitex_agent_container/_listen/_reachability.py
+++ b/src/scitex_agent_container/_listen/_reachability.py
@@ -1,0 +1,134 @@
+"""REGISTERED is not REACHABLE — the inbox-subscriber observation.
+
+A row in ``GET /agents`` used to say only what the registry DECLARED: a
+name, a pid, a port, a start time, a group. All of that can be true of an
+agent whose inbox adapter is not attached to the channel bus — an agent
+that will silently swallow every ``a2a_send`` aimed at it, because the
+broker fans out to zero subscribers.
+
+That conflation was load-bearing. The fleet constitution says "before
+handing work to another party, confirm it is alive and able to act", and
+``a2a_peers`` is the tool provided to do exactly that. An agent could
+confirm via ``a2a_peers``, be told the peer was running and ``active``,
+send, and reach nobody. A liveness signal that reports alive-and-able for
+a deaf agent is worse than no signal, because it is trusted.
+
+So this module keeps the two facts DISTINCT:
+
+* **registered** — the registry has a row (pid, port, groups). Unchanged;
+  still reported. It is a declaration.
+* **reachable** — the ``sac listen`` broker has a live SSE subscriber on
+  that agent's inbox stream. It is an OBSERVATION, and it is the only one
+  that predicts whether a message will actually wake them.
+
+Three states, never two
+-----------------------
+``inbox_reachable`` is deliberately ternary. Collapsing "I could not
+check" into either "fine" or "dead" is the class of bug this whole module
+exists to kill:
+
+* :data:`REACHABLE`   — observed >= 1 live subscriber. A send will wake them.
+* :data:`UNREACHABLE` — observed exactly 0 subscribers on a bus we CAN see.
+  This is EVIDENCE of non-delivery, not absence of evidence, so an
+  ``a2a_send`` to this agent fails loudly (see ``_mcp/_channel_send_errors``).
+* :data:`UNKNOWN`     — we cannot observe this agent's bus at all (it lives
+  on another host, whose broker is a different process). NOT a failure and
+  NOT a success. Never rendered as either.
+
+And a hard rule that outlives this file: ``UNREACHABLE`` must NEVER be
+wired to anything destructive. It says an inbox adapter is detached; it
+does NOT say the agent is dead. Auto-restarting on it would destroy a
+healthy session — the exact "destroy on a negative signal you did not
+directly observe" failure this fleet has already paid for.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+# ``inbox_reachable`` values.
+REACHABLE = "reachable"
+UNREACHABLE = "unreachable"
+UNKNOWN = "unknown"
+
+__all__ = [
+    "REACHABLE",
+    "UNKNOWN",
+    "UNREACHABLE",
+    "annotate_reachability",
+    "annotate_rows",
+]
+
+
+def _is_locally_observable(row: Mapping[str, Any], local_host: str | None) -> bool:
+    """Can THIS listen's broker answer for ``row``'s inbox?
+
+    Mirrors the locality rule the publish path already uses
+    (:func:`_state.state_db_nodes.is_local_node`): a node whose host we
+    cannot distinguish from our own — including one that declares no host
+    at all — is served by the LOCAL broker, so the local subscriber count
+    is authoritative for it.
+
+    A row that declares a host we can see is NOT ours is served by a
+    different ``sac listen`` process with a different in-memory broker.
+    We have no window into it, so we must say :data:`UNKNOWN` rather than
+    invent a zero — a fabricated zero would be a false accusation of
+    deafness against a perfectly reachable remote agent.
+    """
+    host = row.get("host")
+    if not isinstance(host, str) or not host:
+        return True  # no host declared → the local publish path serves it
+    if not local_host:
+        return False  # we don't know who WE are → cannot claim locality
+    return host == local_host
+
+
+def annotate_reachability(
+    row: Mapping[str, Any],
+    *,
+    subscriber_counts: Mapping[str, int],
+    local_host: str | None,
+) -> dict[str, Any]:
+    """Add ``inbox_subscribers`` + ``inbox_reachable`` to one registry row.
+
+    ``subscriber_counts`` is a snapshot of the local broker
+    (:meth:`a2a._inbox_bus.Broker.subscriber_counts`) — an in-memory dict,
+    so this costs no I/O per row and cannot stall ``GET /agents``.
+
+    Idempotent and non-destructive: every pre-existing field (``pid``,
+    ``groups``, ``started_at``, …) is preserved untouched. We ADD the
+    observation next to the declaration; we do not overwrite or reinterpret
+    the declaration.
+    """
+    out = dict(row)
+    name = row.get("name")
+    if not isinstance(name, str) or not name:
+        # No usable key for the broker → we genuinely cannot look it up.
+        out["inbox_subscribers"] = None
+        out["inbox_reachable"] = UNKNOWN
+        return out
+
+    if not _is_locally_observable(row, local_host):
+        out["inbox_subscribers"] = None
+        out["inbox_reachable"] = UNKNOWN
+        return out
+
+    count = int(subscriber_counts.get(name, 0))
+    out["inbox_subscribers"] = count
+    out["inbox_reachable"] = REACHABLE if count >= 1 else UNREACHABLE
+    return out
+
+
+def annotate_rows(
+    rows: list[dict[str, Any]],
+    *,
+    subscriber_counts: Mapping[str, int],
+    local_host: str | None,
+) -> list[dict[str, Any]]:
+    """Apply :func:`annotate_reachability` across a ``GET /agents`` list."""
+    return [
+        annotate_reachability(
+            row, subscriber_counts=subscriber_counts, local_host=local_host
+        )
+        for row in rows
+    ]

--- a/src/scitex_agent_container/_listen/_restart.py
+++ b/src/scitex_agent_container/_listen/_restart.py
@@ -345,14 +345,26 @@ def restart_listen(
     ``host``/``port`` mirror ``sac listen``'s bind resolution per (a);
     ``lock_dir`` matches ``_single_instance.default_lock_dir()``. Never
     raises — every failure populates ``RestartResult.error``.
-    """
-    pid_file = pidfile_path(port, lock_dir)
-    prior_pid = read_pid_from_file(pid_file)
-    had_prior_pidfile = pid_file.is_file()
-    prior_alive = prior_pid is not None and pid_alive(prior_pid)
 
-    escalated = False
-    port_holders_killed: tuple[int, ...] = ()
+    The STOP half (steps 1-5 above) is SSOT in ``._stop.stop_listen`` —
+    the exact sequence ``sac listen stop`` runs — so the two verbs can
+    never drift. Imported lazily because ``_stop`` imports THIS module
+    (it reaches the ``_kill`` / ``_sleep`` test seams through the module
+    object), and a top-level import here would close that cycle.
+    """
+    from ._stop import stop_listen
+
+    stopped = stop_listen(
+        host=host,
+        port=port,
+        lock_dir=lock_dir,
+        grace_secs=grace_secs,
+        force=force,
+    )
+    escalated = stopped.escalated_to_sigkill
+    had_prior_pidfile = stopped.had_prior_pidfile
+    prior_alive = stopped.prior_pid_alive
+    port_holders_killed = stopped.port_holders_killed
 
     def _fail(*, error: str, took_systemd_path: bool = False) -> RestartResult:
         """Failure result capturing pre-state + self-heal progress so
@@ -368,44 +380,10 @@ def restart_listen(
             port_holders_killed=port_holders_killed,
         )
 
-    if prior_pid is not None and prior_alive:
-        escalated = _terminate_then_kill(
-            prior_pid, grace_secs=grace_secs, force_kill=force
-        )
-        # Defence-in-depth: confirm the PID is actually dead before
-        # touching the pidfile. If still alive after SIGKILL, bail
-        # rather than clear the lock + let a second daemon start beside.
-        _sleep(_POLL_INTERVAL_SECS)
-        if pid_alive(prior_pid):
-            return _fail(
-                error=(
-                    f"PID {prior_pid} survived SIGKILL — refusing to "
-                    f"clear pidfile or relaunch. Inspect manually "
-                    f"(zombie/uninterruptible state)."
-                )
-            )
-
-    try:
-        pid_file.unlink(missing_ok=True)
-    except OSError as exc:
-        return _fail(error=f"failed to clear stale pidfile {pid_file}: {exc!r}")
-
-    # Self-heal a WEDGED port holder the pidfile never named (the
-    # "curl hangs forever" remnant) before relaunch so the new daemon
-    # doesn't hit EADDRINUSE. terminate/sleep are passed in so the
-    # escalation seams stay owned here (and avoid a circular import).
-    heal = clear_wedged_port_holders(
-        host=host,
-        port=port,
-        grace_secs=grace_secs,
-        force=force,
-        terminate_fn=_terminate_then_kill,
-        sleep_fn=_sleep,
-        poll_interval=_POLL_INTERVAL_SECS,
-    )
-    port_holders_killed = heal.killed
-    if heal.error:
-        return _fail(error=heal.error)
+    # A failed stop must NEVER relaunch — that would race a surviving
+    # daemon or bind into an EADDRINUSE on a still-wedged port.
+    if not stopped.ok:
+        return _fail(error=stopped.error)
 
     use_systemd = systemd_unit_is_active(systemd_unit_path)
     if use_systemd:

--- a/src/scitex_agent_container/_listen/_stop.py
+++ b/src/scitex_agent_container/_listen/_stop.py
@@ -1,0 +1,155 @@
+"""Stop sequence for the ``sac listen`` daemon — the half ``restart`` shares.
+
+``sac listen stop`` and ``sac listen restart`` must never drift: a restart
+IS a stop, followed by a relaunch and a health-probe. This module owns the
+stop half as ONE implementation so the two verbs cannot diverge (SSOT).
+``restart_listen`` used to run this sequence inline; it now calls
+:func:`stop_listen`, and the behaviour is unchanged.
+
+The sequence:
+
+1. Read the PID from the flock-backed pidfile at
+   ``<lock_dir>/listen-<port>.pid``.
+2. SIGTERM it and poll for exit up to ``grace_secs``, escalating to
+   SIGKILL on timeout (``force=True`` skips straight to SIGKILL).
+3. **Verify the PID is really dead BEFORE clearing the pidfile** — never
+   release a lock whose owner still lives, or a second daemon starts
+   beside it.
+4. Self-heal a WEDGED port holder the pidfile never named — the half-dead
+   uvicorn that ``curl`` hangs on, whose pidfile may already be ``rm``-ed
+   (incident 2026-06-26; see :mod:`._port_holder`).
+
+**Idempotent**: stopping an already-stopped daemon is SUCCESS
+(``ok=True``, ``was_running=False``) — the same contract as
+``systemctl stop``. Only a daemon we could not kill is a failure.
+
+**Seams.** Every primitive is reached through the ``_restart`` MODULE
+OBJECT (``_restart._sleep``, ``_restart._terminate_then_kill``, …) and
+resolved at CALL time — never bound via ``from ._restart import _sleep``
+at import. Tests swap those module attributes to drive the sequence
+without real signals; a from-import would capture the ORIGINAL callable
+and silently defeat the swap, so the tests would pass while testing
+nothing.
+
+Pure-logic module — no click. Never raises: every failure lands in
+:attr:`StopResult.error`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import _restart
+
+
+@dataclass(frozen=True)
+class StopResult:
+    """Outcome of a :func:`stop_listen` invocation.
+
+    ``ok`` is ``True`` for an idempotent no-op (nothing was running) —
+    stopping a down daemon is success, not failure. :attr:`was_running`
+    is what distinguishes the two for the CLI's report.
+
+    ``port_holders_killed`` records any UNtracked PID(s) the self-heal
+    force-killed off the port — empty when only the pidfile-tracked
+    daemon was stopped.
+    """
+
+    ok: bool
+    escalated_to_sigkill: bool
+    had_prior_pidfile: bool
+    prior_pid_alive: bool
+    prior_pid: int | None = None
+    port_holders_killed: tuple[int, ...] = ()
+    error: str = ""
+
+    @property
+    def was_running(self) -> bool:
+        """``True`` iff we actually stopped something.
+
+        Either the pidfile named a live daemon, or an untracked remnant
+        was still holding the port.
+        """
+        return self.prior_pid_alive or bool(self.port_holders_killed)
+
+
+def stop_listen(
+    *,
+    host: str,
+    port: int,
+    lock_dir: Path,
+    grace_secs: float = _restart.DEFAULT_GRACE_SECS,
+    force: bool = False,
+) -> StopResult:
+    """Stop the ``sac listen`` daemon bound at ``host:port``.
+
+    ``host``/``port`` mirror ``sac listen``'s own bind resolution;
+    ``lock_dir`` matches ``_single_instance.default_lock_dir()``. Never
+    raises — every failure populates :attr:`StopResult.error`.
+    """
+    pid_file = _restart.pidfile_path(port, lock_dir)
+    prior_pid = _restart.read_pid_from_file(pid_file)
+    had_prior_pidfile = pid_file.is_file()
+    prior_alive = prior_pid is not None and _restart.pid_alive(prior_pid)
+
+    escalated = False
+
+    def _fail(error: str, *, killed: tuple[int, ...] = ()) -> StopResult:
+        """Failure result capturing pre-state + self-heal progress so far."""
+        return StopResult(
+            ok=False,
+            escalated_to_sigkill=escalated,
+            had_prior_pidfile=had_prior_pidfile,
+            prior_pid_alive=prior_alive,
+            prior_pid=prior_pid,
+            port_holders_killed=killed,
+            error=error,
+        )
+
+    if prior_pid is not None and prior_alive:
+        escalated = _restart._terminate_then_kill(
+            prior_pid, grace_secs=grace_secs, force_kill=force
+        )
+        # Defence-in-depth: confirm the PID is actually dead before
+        # touching the pidfile. If it survived SIGKILL, bail rather than
+        # clear the lock and let a second daemon start beside it.
+        _restart._sleep(_restart._POLL_INTERVAL_SECS)
+        if _restart.pid_alive(prior_pid):
+            return _fail(
+                f"PID {prior_pid} survived SIGKILL — refusing to "
+                f"clear pidfile or relaunch. Inspect manually "
+                f"(zombie/uninterruptible state)."
+            )
+
+    try:
+        pid_file.unlink(missing_ok=True)
+    except OSError as exc:
+        return _fail(f"failed to clear stale pidfile {pid_file}: {exc!r}")
+
+    # Free the port from an UNtracked wedged remnant the pidfile never
+    # named. The terminate/sleep seams are passed in so escalation stays
+    # owned by ``_restart`` (and to avoid a circular import).
+    heal = _restart.clear_wedged_port_holders(
+        host=host,
+        port=port,
+        grace_secs=grace_secs,
+        force=force,
+        terminate_fn=_restart._terminate_then_kill,
+        sleep_fn=_restart._sleep,
+        poll_interval=_restart._POLL_INTERVAL_SECS,
+    )
+    if heal.error:
+        return _fail(heal.error, killed=heal.killed)
+
+    return StopResult(
+        ok=True,
+        escalated_to_sigkill=escalated,
+        had_prior_pidfile=had_prior_pidfile,
+        prior_pid_alive=prior_alive,
+        prior_pid=prior_pid,
+        port_holders_killed=heal.killed,
+    )
+
+
+__all__ = ["StopResult", "stop_listen"]

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -55,143 +55,14 @@ async def health(_request: Request) -> JSONResponse:
     return JSONResponse({"ok": True, "service": "sac-listen", "v": 1})
 
 
-async def list_agents(_request: Request) -> JSONResponse:
-    """List agents the local Registry knows about + self-peers.
+# ``list_agents`` (GET /agents — the peer-discovery route backing the
+# ``a2a_peers`` MCP tool) was extracted into ``_agents_list`` when it grew
+# the inbox-subscriber reachability observation (REGISTERED IS NOT
+# REACHABLE — see ``_reachability``). Re-imported here so route
+# registration and the historical
+# ``from ..._listen.server import list_agents`` import path keep working.
+from ._agents_list import list_agents  # noqa: E402,F401
 
-    Two sources, concatenated in this order:
-
-    1. Container-agent rows from :meth:`Registry.list_all` — the
-       traditional ``sac a2a peers`` shape (``name`` / ``config`` /
-       ``pid`` / ``started_at`` / ``screen``).
-    2. Self-peer rows from :func:`_self_peers.discover_self_peers`
-       — any agent dir whose ``spec.yaml`` carries only a
-       ``listen_url`` (no container ``spec`` block, no
-       ``apiVersion``). These have no ``pid`` / ``screen`` — they
-       are external listen sessions that own a port and want to be
-       discoverable. Carries ``"kind": "self-peer"`` so peer-aware
-       clients can branch on the source.
-
-    Dedup: a self-peer whose ``name`` already appears in the
-    container-row list loses to the container row (the running
-    container is the more authoritative source). Order matches
-    operator-facing convention: container rows first, then
-    self-peers alphabetically by ``name``.
-    """
-    rows: list[dict] = []
-    seen_names: set[str] = set()
-    try:
-        reg = Registry()
-        for row in reg.list_all():
-            rows.append(row)
-            name = row.get("name") if isinstance(row, dict) else None
-            if isinstance(name, str):
-                seen_names.add(name)
-    except Exception as exc:  # stx-allow: fallback (reason: surface a JSON error to the caller rather than ASGI 500 stack)
-        return JSONResponse({"error": str(exc)}, status_code=500)
-    # Self-peers — best-effort. Failures here must NOT mask a healthy
-    # container-row response (an unreadable agents dir is operator
-    # state, not a listen failure).
-    #
-    # Runtime self-identity is derived from host_config — the same
-    # source the existing channel/listen self-registration paths
-    # consult. Missing host_config / missing ``lead:`` block degrades
-    # to ``None``; :func:`discover_self_peers` then surfaces the
-    # literal ``self`` dir as ``"self"`` with a logged warning, which
-    # is the loudest signal short of failing the request.
-    try:
-        from ..config._resolve import _search_dirs
-        from ._self_peers import discover_self_peers
-
-        primary, env_dirs, fleet_dirs = _search_dirs()
-        search_dirs = [*env_dirs, primary, *fleet_dirs]
-        self_identity = _resolve_runtime_self_identity()
-        for peer in discover_self_peers(search_dirs, self_identity=self_identity):
-            if peer["name"] in seen_names:
-                continue
-            rows.append(peer)
-            seen_names.add(peer["name"])
-    except Exception as exc:  # stx-allow: fallback (reason: self-peer discovery must never block the registry response)
-        import logging
-
-        logging.getLogger(__name__).warning(
-            "list_agents: self-peer discovery failed (returning registry rows only): %s",
-            exc,
-        )
-    # Comms-node self-registrations (operator mandate 2026-06-14): ANY
-    # process that loaded the sac MCP and self-registered into the
-    # comms_nodes table (e.g. ``sac mcp channel --name lead``, or any
-    # CLI/SDK session running the channel adapter) MUST appear in
-    # ``a2a peers`` at startup -- no exceptions. Such nodes are not in
-    # the Registry (no container) and can live outside the filesystem
-    # self-peer search dirs, so without this source the lead (and any
-    # bare sac-MCP session) is invisible here. Best-effort: a read
-    # failure must not mask the rest of the response.
-    try:
-        from .._state.state_db_comms_nodes import list_comms_nodes
-
-        for node in list_comms_nodes():
-            if node["name"] in seen_names:
-                continue
-            rows.append(
-                {
-                    "name": node["name"],
-                    "host": node["host"],
-                    "a2a_port": node["a2a_port"],
-                    "kind": "comms-node",
-                    "registered_at": node.get("registered_at"),
-                    "updated_at": node.get("updated_at"),
-                }
-            )
-            seen_names.add(node["name"])
-    except Exception as exc:  # stx-allow: fallback (reason: comms-node surfacing must never block the registry response)
-        import logging
-
-        logging.getLogger(__name__).warning(
-            "list_agents: comms_nodes surfacing failed (returning prior rows): %s",
-            exc,
-        )
-    # Q1 (lead dispatch a2a dc6fd23387f64e329049d218cf85a4d4): surface
-    # ``a2a_port`` + derived ``turn_url`` on every row so scitex-todo's
-    # notify resolver (P3a-b) can dispatch nudge→turn without redeploy.
-    # Idempotent: self-peer rows that already carry a non-None value
-    # keep theirs (the discovery layer is the authoritative source for
-    # those).
-    from ._registry_endpoints import enrich_row
-
-    rows = [enrich_row(row) for row in rows]
-    return JSONResponse({"agents": rows})
-
-
-def _resolve_runtime_self_identity() -> str | None:
-    """Return the running listen's runtime identity, or ``None``.
-
-    Reads :func:`host_config.load().lead.name` — the same source the
-    existing channel/listen self-registration paths
-    (:mod:`_mcp._channel_self_register`,
-    :func:`cli_pkg.listen_cmds._register_self_comms_node`) consult.
-    A missing ``lead:`` block in host_config returns ``None`` — the
-    self-peer discovery downstream then surfaces the literal
-    ``self`` dir as ``"self"`` so the operator sees the gap rather
-    than getting a silently-renamed peer row.
-
-    Generic on purpose: there is no name-specific branching here.
-    ``host_config.lead.name`` is THE host's "who am I" answer for
-    operator-class sessions; a future evolution that supports
-    multiple self-identities on one host would extend the host_config
-    shape, not insert per-name special cases here.
-    """
-    try:
-        from .._state.host_config import load as load_host_config
-
-        cfg = load_host_config()
-        lead = getattr(cfg, "lead", None)
-        if lead is not None:
-            name = getattr(lead, "name", None)
-            if isinstance(name, str) and name.strip():
-                return name
-    except Exception:  # stx-allow: fallback (reason: host_config errors must never block the /agents response)
-        pass
-    return None
 
 
 async def agent_status(request: Request) -> JSONResponse:
@@ -227,7 +98,40 @@ async def agent_status(request: Request) -> JSONResponse:
     from ._registry_endpoints import enrich_row
 
     body = enrich_row(body)
+    # …and the same inbox-subscriber OBSERVATION ``GET /agents`` carries, so
+    # a single-agent status poll can also tell REGISTERED from REACHABLE. A
+    # running session_id + a live pid say nothing about whether this agent's
+    # inbox adapter is attached; only the broker does. See ``_reachability``.
+    body = await _annotate_status_reachability(request, body)
     return JSONResponse(body)
+
+
+async def _annotate_status_reachability(
+    request: Request, body: dict[str, Any]
+) -> dict[str, Any]:
+    """Add ``inbox_subscribers`` / ``inbox_reachable`` to a status body.
+
+    Degrades to ``unknown`` (never ``unreachable``) if the broker cannot be
+    read — "I could not check" must not be rendered as death.
+    """
+    from ._reachability import UNKNOWN, annotate_reachability
+
+    try:
+        counts = await request.app.state.inbox.subscriber_counts()
+        local_host = getattr(request.app.state, "local_host", None)
+    except Exception as exc:  # stx-allow: fallback (reason: an unreadable broker must degrade to UNKNOWN, never to a false 'unreachable' verdict)
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "agent_status: could not read inbox broker (reporting reachability "
+            "as %r, NOT as unreachable): %s",
+            UNKNOWN,
+            exc,
+        )
+        return {**body, "inbox_subscribers": None, "inbox_reachable": UNKNOWN}
+    return annotate_reachability(
+        body, subscriber_counts=counts, local_host=local_host
+    )
 
 
 # --- extracted handlers re-imported for routes + back-compat ---------------

--- a/src/scitex_agent_container/_mcp/_channel_send_errors.py
+++ b/src/scitex_agent_container/_mcp/_channel_send_errors.py
@@ -1,0 +1,226 @@
+"""The FAIL-LOUD contract for the send-side ``a2a_*`` MCP tools.
+
+Extracted from :mod:`._channel_tools` (which hit the module size budget)
+because it is one cohesive responsibility: deciding that a send
+demonstrably failed, and rendering that failure so the CALLER CANNOT
+MISTAKE IT FOR DELIVERY.
+
+Why this module exists at all
+-----------------------------
+``a2a_send`` already detected the no-subscriber case and returned a body
+carrying ``{"error": ...}``. But the MCP low-level ``Server.call_tool``
+decorator wraps whatever a handler returns:
+
+* a plain ``list[TextContent]`` becomes ``CallToolResult(isError=False)``
+  — a **SUCCESS**, whatever the text inside happens to say;
+* a ``CallToolResult`` is passed through **verbatim**, so a handler that
+  wants to fail must say ``isError=True`` itself.
+
+So the old shape was a false green: the tool reported "reached no live
+subscriber" inside the body of a result flagged as successful. A caller
+that trusted the MCP contract (rather than string-matching the payload)
+read it as a delivered message. Agents silently swallowed each other's
+messages and nothing in the control plane said so.
+
+The three-state discipline
+--------------------------
+Delivery has THREE outcomes and they must never be collapsed into two:
+
+* **delivered** — ``delivered_subscriber_count >= 1``. Success.
+* **definitively NOT delivered** — an explicit ``0`` from the local
+  publish path. The bus fanned out to nobody. This is a hard failure and
+  the ONLY one this module raises for. It is EVIDENCE, not an absence of
+  evidence.
+* **could not determine** — the field is ABSENT (e.g. a cross-host
+  forward whose reply does not carry it). Inventing a zero here would be
+  a false-positive failure, so an absent count is NEVER read as zero and
+  never fails. "I could not check" is rendered as neither success nor
+  death.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from mcp.types import CallToolResult
+
+
+class SendError(RuntimeError):
+    """A send/push could NOT reach or wake the target agent.
+
+    Raised by the send helper when delivery demonstrably failed:
+
+    * the transport raised (agent down / connection refused),
+    * the listen server returned a non-2xx status (delivery error), or
+    * the publish reported ``delivered_subscriber_count == 0`` — no live
+      inbox subscriber, so the message woke nobody.
+
+    The send-side ``a2a_*`` tools render this via :func:`error_result`
+    into an MCP result with ``isError=True`` — never a misleading
+    success — and log it.
+
+    ``code`` is the machine-readable failure class (one of the ``ERR_*``
+    constants) and ``detail`` carries the structured fields a caller can
+    branch on without re-parsing the human message.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        target: str,
+        detail: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.target = target
+        self.detail: dict[str, Any] = dict(detail or {})
+
+
+# Machine-readable failure classes, echoed as ``code`` in the tool's
+# error payload so a caller branches on the CLASS of failure instead of
+# string-matching a human sentence.
+ERR_NO_SUBSCRIBER = "no_live_subscriber"
+ERR_UNREACHABLE = "unreachable"
+ERR_DELIVERY_ERROR = "delivery_error"
+ERR_LOOKUP_FAILED = "lookup_failed"
+
+# What a 0-subscriber send hands the caller instead of a false success.
+#
+# It deliberately does NOT recommend ``agent_send`` / ``sac agents send``.
+# That rail POSTs to the agent's ``/v1/turn`` sidecar port, which —
+# measured on the live fleet, 2026-07-14 — only 5 of 47 registered agents
+# actually bind. Its own failure path tells callers to use a2a instead
+# (see ``cli_pkg._send``), so recommending it here would be a circular
+# dead end for most of the fleet.
+#
+# It also does NOT recommend restarting the target. A 0-subscriber
+# reading is a negative signal about ONE transport; it is not an
+# observation of agent death. ``--force --fresh`` on it would destroy a
+# healthy agent whose only problem is a detached inbox adapter.
+NO_SUBSCRIBER_REMEDY: tuple[str, ...] = (
+    "NOT LOST: sac listen persists every message to `channel_events` BEFORE "
+    "publishing, and the target's inbox stream replays all undelivered rows "
+    "on its next connect. Do NOT re-send this message — it would arrive "
+    "twice once their adapter reconnects.",
+    "To reach them NOW, use a rail that does not depend on their inbox "
+    "adapter: a scitex-todo card assigned to them (durable, pull-based), or "
+    "escalate to the operator.",
+    "Do NOT force-restart the target on this signal. 0 subscribers means "
+    "their inbox adapter is not attached; it is NOT evidence that the agent "
+    "is dead, and a restart would destroy a healthy session.",
+)
+
+
+def no_subscriber_error(target: str) -> SendError:
+    """Build the loud error for an explicit ``delivered_subscriber_count == 0``.
+
+    The message states exactly what was observed (the bus fanned out to
+    zero subscribers) and — just as importantly — what was NOT observed
+    (that the agent is dead, or that the message is gone).
+    """
+    return SendError(
+        f"NOT DELIVERED — send to {target!r} reached no live subscriber "
+        "(delivered_subscriber_count=0). The message woke nobody: "
+        f"{target!r} has no inbox adapter attached to the channel bus "
+        "(its session is not running `sac mcp channel`, or that adapter's "
+        "SSE stream is not connected). Being listed as a running/`active` "
+        "peer does NOT mean an agent is subscribed — registered is not "
+        "reachable. Check `inbox_subscribers` on a2a_peers before "
+        "handing work to a peer.",
+        code=ERR_NO_SUBSCRIBER,
+        target=target,
+        detail={
+            "delivered": False,
+            "delivered_subscriber_count": 0,
+            "durably_queued": True,
+            "what_to_do": list(NO_SUBSCRIBER_REMEDY),
+        },
+    )
+
+
+def unreachable_error(target: str, exc: Exception) -> SendError:
+    """Build the loud error for a transport failure (connection refused …)."""
+    return SendError(
+        f"NOT DELIVERED — send to {target!r} failed: agent unreachable ({exc})",
+        code=ERR_UNREACHABLE,
+        target=target,
+        detail={"delivered": False, "transport_error": str(exc)},
+    )
+
+
+def delivery_error(target: str, status: Any, body: Any) -> SendError:
+    """Build the loud error for a server-side (5xx / bogus status) failure."""
+    return SendError(
+        f"NOT DELIVERED — send to {target!r} failed: listen returned "
+        f"HTTP {status} ({body})",
+        code=ERR_DELIVERY_ERROR,
+        target=target,
+        detail={"delivered": False, "http_status": status, "http_body": body},
+    )
+
+
+def _error_payload(exc: SendError) -> dict[str, Any]:
+    """Project a :class:`SendError` onto the tool's JSON error body."""
+    payload: dict[str, Any] = {
+        "error": str(exc),
+        "code": exc.code,
+        "target": exc.target,
+        "delivered": False,
+    }
+    payload.update(exc.detail)
+    return payload
+
+
+def error_result(exc: SendError) -> "CallToolResult":
+    """Render a :class:`SendError` as an MCP result the caller CANNOT read
+    as success.
+
+    Returns a ``CallToolResult`` with ``isError=True``. The MCP low-level
+    server passes a ``CallToolResult`` through verbatim (unlike a bare
+    ``list[TextContent]``, which it stamps ``isError=False``), so this is
+    the seam where "the message was not delivered" actually becomes a
+    tool-level failure the calling model sees as one.
+
+    The structured detail (target, failure ``code``, subscriber count,
+    and what to do instead) is preserved in the payload — failing loudly
+    must not cost the caller the information it needs to recover.
+    """
+    from mcp.types import CallToolResult, TextContent
+
+    return CallToolResult(
+        content=[
+            TextContent(type="text", text=json.dumps(_error_payload(exc), indent=2))
+        ],
+        isError=True,
+    )
+
+
+def lookup_error_result(message: str, *, target: str = "") -> "CallToolResult":
+    """Render a non-send failure (unknown msg_id, unknown sender, unknown
+    tool) as an ``isError=True`` result.
+
+    These never delivered anything either, so they must not come back as
+    a success body — same rule, different cause.
+    """
+    return error_result(
+        SendError(message, code=ERR_LOOKUP_FAILED, target=target, detail={})
+    )
+
+
+__all__ = [
+    "ERR_DELIVERY_ERROR",
+    "ERR_LOOKUP_FAILED",
+    "ERR_NO_SUBSCRIBER",
+    "ERR_UNREACHABLE",
+    "NO_SUBSCRIBER_REMEDY",
+    "SendError",
+    "delivery_error",
+    "error_result",
+    "lookup_error_result",
+    "no_subscriber_error",
+    "unreachable_error",
+]

--- a/src/scitex_agent_container/_mcp/_channel_tools.py
+++ b/src/scitex_agent_container/_mcp/_channel_tools.py
@@ -19,26 +19,17 @@ import json
 import logging
 from typing import Any
 
+from ._channel_send_errors import (
+    SendError,
+    delivery_error,
+    error_result,
+    lookup_error_result,
+    no_subscriber_error,
+    unreachable_error,
+)
 from .channel import _recent
 
 log = logging.getLogger(__name__)
-
-
-class SendError(RuntimeError):
-    """A send/push could NOT reach or wake the target agent.
-
-    Raised by the send helper when delivery demonstrably failed:
-
-    * the transport raised (agent down / connection refused),
-    * the listen server returned a non-2xx status (delivery error), or
-    * the publish reported ``delivered_subscriber_count == 0`` — no live
-      inbox subscriber, so the message woke nobody.
-
-    The send-side ``a2a_*`` tools translate this into a loud, explicit
-    ``{"error": ...}`` result for the calling agent (never a misleading
-    success) and log it. STX hard rule: fail loudly, never silently drop
-    or return a misleading success.
-    """
 
 
 def register_tools(
@@ -53,7 +44,7 @@ def register_tools(
     """
     import uuid as _uuid
 
-    from mcp.types import TextContent, Tool
+    from mcp.types import CallToolResult, TextContent, Tool
 
     from .._state.dispatch_ledger import (
         STATUS_DELIVERED,
@@ -122,7 +113,8 @@ def register_tools(
         """POST a send/push and FAIL LOUDLY when it cannot reach/wake (WI-2).
 
         Returns the parsed ``{status, body}`` on success. Raises
-        :class:`SendError` — never a misleading success — when:
+        :class:`SendError` — which the caller renders as an MCP result
+        with ``isError=True``, never a misleading success — when:
 
         * the transport raises (target agent down / connection refused),
         * the HTTP status is 5xx (server / infra delivery error), or
@@ -135,6 +127,17 @@ def register_tools(
         the agent ("denial is the policy working"). Reshaping it into an
         opaque error string would lose the structured ``reason`` and is not
         the silent-drop/misleading-success the fail-loud rule targets.
+
+        KNOWN GAP (deliberate, not an oversight): a 4xx therefore still comes
+        back with ``isError=False``, even though it delivered nothing. It is
+        far less dangerous than the 0-subscriber case this fail-loud path was
+        written for — a 403 body is self-evidently a failure, whereas a
+        no-subscriber publish returned an HTTP **200** and read as success by
+        every conventional measure. Flipping 4xx to ``isError=True`` (keeping
+        the body verbatim, so the original "don't lose the structured reason"
+        objection would not apply) is a one-line change, but it alters the ACL
+        contract and is pinned by ``tests/smoke/test_node_comms_e2e_mcp.py``,
+        so it belongs in its own PR rather than riding along with this one.
 
         ``delivered_subscriber_count`` ABSENT is NOT treated as zero: some
         responses (cross-host forwards) don't carry it, and inventing a
@@ -180,9 +183,7 @@ def register_tools(
             res = await _post(path, payload)
         except httpx.HTTPError as exc:
             log.warning("sac a2a: send to %r failed (transport): %s", target, exc)
-            raise SendError(
-                f"send to {target!r} failed: agent unreachable ({exc})"
-            ) from exc
+            raise unreachable_error(target, exc) from exc
 
         status = res.get("status")
         # 5xx (and any non-int / sub-200) = server/infra delivery failure.
@@ -192,9 +193,7 @@ def register_tools(
             log.warning(
                 "sac a2a: send to %r returned HTTP %s: %s", target, status, body
             )
-            raise SendError(
-                f"send to {target!r} failed: listen returned HTTP {status} ({body})"
-            )
+            raise delivery_error(target, status, body)
         if not isinstance(status, int) or status < 200:
             body = res.get("body")
             log.warning(
@@ -203,9 +202,7 @@ def register_tools(
                 status,
                 body,
             )
-            raise SendError(
-                f"send to {target!r} failed: unexpected status {status!r} ({body})"
-            )
+            raise delivery_error(target, status, body)
 
         body = res.get("body")
         if isinstance(body, dict):
@@ -213,21 +210,11 @@ def register_tools(
             if isinstance(delivered, int) and delivered == 0:
                 log.warning(
                     "sac a2a: send to %r reached no subscriber "
-                    "(delivered_subscriber_count=0)",
+                    "(delivered_subscriber_count=0) — NOT DELIVERED",
                     target,
                 )
-                raise SendError(
-                    f"send to {target!r} reached no live subscriber "
-                    "(delivered_subscriber_count=0): the agent is not "
-                    "subscribed to its inbox (down, not started, or its "
-                    "channel adapter is not connected) — the message woke "
-                    "nobody and was not delivered."
-                )
+                raise no_subscriber_error(target)
         return res
-
-    def _error_result(exc: SendError) -> "list[TextContent]":
-        """Render a :class:`SendError` as a loud tool result."""
-        return [TextContent(type="text", text=json.dumps({"error": str(exc)}))]
 
     def _find(msg_id: str) -> dict[str, Any] | None:
         for ev in reversed(_recent):
@@ -279,7 +266,10 @@ def register_tools(
                 description=(
                     "Send a message to another agent on this sac listen. "
                     "Sets from_agent automatically; mints conversation_id "
-                    "when omitted."
+                    "when omitted. FAILS (isError) when the message reached "
+                    "no live inbox subscriber — a peer listed as running is "
+                    "NOT necessarily subscribed. Check `inbox_subscribers` "
+                    "via a2a_peers before handing work to a peer."
                 ),
                 inputSchema={
                     "type": "object",
@@ -325,7 +315,17 @@ def register_tools(
             ),
             Tool(
                 name="a2a_peers",
-                description="List reachable agents on this sac listen.",
+                description=(
+                    "List agents known to this sac listen. REGISTERED IS NOT "
+                    "REACHABLE: a row can show a pid, a port and group "
+                    "'active' while having NO inbox subscriber, in which case "
+                    "a2a_send to it delivers nothing. Each row carries "
+                    "`inbox_subscribers` (live subscriber count) and "
+                    "`inbox_reachable` ('reachable' / 'unreachable' / "
+                    "'unknown' when it lives on another host and this listen "
+                    "cannot observe it). Only 'reachable' means a message "
+                    "will actually wake them."
+                ),
                 inputSchema={"type": "object", "properties": {}},
             ),
             Tool(
@@ -344,7 +344,20 @@ def register_tools(
         ]
 
     @server.call_tool()
-    async def _call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    async def _call_tool(
+        name: str, arguments: dict[str, Any]
+    ) -> "list[TextContent] | CallToolResult":
+        """Dispatch one ``a2a_*`` call.
+
+        Return-type contract (the fix for the swallowed-message false
+        green): a SUCCESS returns ``list[TextContent]``, which the MCP
+        low-level server stamps ``isError=False``. A FAILURE returns a
+        ``CallToolResult`` carrying ``isError=True``, which the server
+        passes through verbatim. A caller therefore cannot mistake a
+        message that reached nobody for a delivered one — previously
+        BOTH shapes came back as ``isError=False`` and the failure was
+        just a field in the body that a caller could (and did) miss.
+        """
         if name == "a2a_send":
             target = arguments["target"]
             content = arguments["content"]
@@ -367,7 +380,7 @@ def register_tools(
                 )
             except SendError as exc:
                 _ledger_update(dispatch_id, STATUS_FAILED)
-                return _error_result(exc)
+                return error_result(exc)
             _ledger_update(dispatch_id, STATUS_DELIVERED)
             return [TextContent(type="text", text=json.dumps(res))]
 
@@ -375,22 +388,10 @@ def register_tools(
             mid = arguments["in_reply_to"]
             orig = _find(mid)
             if orig is None:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {"error": f"unknown msg_id {mid} (inbox window)"}
-                        ),
-                    )
-                ]
+                return lookup_error_result(f"unknown msg_id {mid} (inbox window)")
             target = orig.get("from_agent", "")
             if not target:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps({"error": "original sender unknown"}),
-                    )
-                ]
+                return lookup_error_result("original sender unknown")
             payload = _wrap_message_send(
                 arguments["content"],
                 conversation_id=orig.get("conversation_id"),
@@ -401,29 +402,17 @@ def register_tools(
                     target, f"/agents/{target}/message:send", payload
                 )
             except SendError as exc:
-                return _error_result(exc)
+                return error_result(exc)
             return [TextContent(type="text", text=json.dumps(res))]
 
         if name == "a2a_ack":
             mid = arguments["msg_id"]
             orig = _find(mid)
             if orig is None:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {"error": f"unknown msg_id {mid} (inbox window)"}
-                        ),
-                    )
-                ]
+                return lookup_error_result(f"unknown msg_id {mid} (inbox window)")
             target = orig.get("from_agent", "")
             if not target:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps({"error": "original sender unknown"}),
-                    )
-                ]
+                return lookup_error_result("original sender unknown")
             payload = _wrap_message_send(
                 "",
                 conversation_id=orig.get("conversation_id"),
@@ -435,13 +424,18 @@ def register_tools(
                     target, f"/agents/{target}/message:send", payload
                 )
             except SendError as exc:
-                return _error_result(exc)
+                return error_result(exc)
             return [TextContent(type="text", text=json.dumps(res))]
 
         if name == "a2a_peers":
             # No trailing slash: sac listen registers `/agents` and a GET to
             # `/agents/` 307-redirects, which httpx does not follow by default
             # (a2a_peers then returns a bare 307 with empty body).
+            #
+            # Each row carries `inbox_subscribers` + `inbox_reachable` (see
+            # ``_listen/_reachability.py``) so a caller can tell REGISTERED
+            # from REACHABLE. Reading only pid/groups is what let a deaf peer
+            # look alive-and-able.
             res = await _get("/agents")
             return [TextContent(type="text", text=json.dumps(res))]
 
@@ -454,11 +448,7 @@ def register_tools(
                 )
             ]
 
-        return [
-            TextContent(
-                type="text", text=json.dumps({"error": f"unknown tool: {name}"})
-            )
-        ]
+        return lookup_error_result(f"unknown tool: {name}")
 
 
 __all__ = ["SendError", "register_tools"]

--- a/src/scitex_agent_container/_skills/scitex-agent-container/10_cli.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/10_cli.md
@@ -49,17 +49,33 @@ Reads `session_id` from the per-agent state dir and shells out to `claude --resu
 
 ## sac listen (HTTP/JSON control plane)
 
+`listen` is a **noun** — a command group like `agents` / `db` / `host`. Its
+four verbs are the whole lifecycle:
+
 ```bash
-sac listen                                # Boot the local control-plane server (loopback only by default)
-sac listen --bind 127.0.0.1:7878          # Custom bind
-sac listen --print-token                  # Echo the bearer token & exit
+sac listen start                          # Boot the control-plane daemon (loopback only by default)
+sac listen start --bind 127.0.0.1:7979    # Custom bind
+sac listen start --print-token            # Echo the bearer token & exit (does not boot)
 sac listen status                         # One-shot health report (UP/WEDGED/DOWN); exit 1 if not serving
 sac listen status --json                  # Machine-readable status envelope
+sac listen stop                           # Stop the daemon (idempotent — exit 0 if already down)
+sac listen stop --force                   # SIGKILL the daemon + any wedged port holder immediately
+sac listen stop --json                    # Machine-readable result envelope
 sac listen restart                        # Self-healing stop-clean-relaunch (clears stale pidfile, force-kills wedged port holder)
 sac listen restart --force                # SIGKILL the daemon + any wedged port holder immediately
 ```
 
-`restart` is the deterministic incident-recovery verb: it clears a stale pidfile, force-kills an untracked remnant still holding the port (the "curl hangs forever" case), then relaunches and health-probes — failing loud (non-zero, `ERROR:` naming the real cause) if the daemon can't be brought up. `status` is the one-command diagnosis.
+Options may be given on the verb (`sac listen start --bind …`) or on the
+group (`sac listen --bind … start`); the verb wins.
+
+`restart` is the deterministic incident-recovery verb: it clears a stale pidfile, force-kills an untracked remnant still holding the port (the "curl hangs forever" case), then relaunches and health-probes — failing loud (non-zero, `ERROR:` naming the real cause) if the daemon can't be brought up. `status` is the one-command diagnosis. `stop` is `restart`'s stop half on its own — they share one implementation (`_listen._stop.stop_listen`), so they cannot drift.
+
+> **DEPRECATED — bare `sac listen`.** It still BOOTS the daemon (the systemd
+> unit, `sac listen restart`'s respawn, and the systemd JobSpec all still
+> invoke it bare), but it now prints a deprecation warning to stderr. Use
+> **`sac listen start`**. The bare form is removed in **v0.23.0**; every
+> launcher must move to `sac listen start` before then. Booting a daemon off a
+> bare noun is a footgun — a typo or a stray tab-complete starts a server.
 
 When running, exposes (bearer-token authenticated, except the public health route):
 

--- a/src/scitex_agent_container/a2a/_inbox_bus.py
+++ b/src/scitex_agent_container/a2a/_inbox_bus.py
@@ -190,6 +190,29 @@ class Broker:
         async with self._lock:
             return len(self._subs.get(agent, ()))
 
+    async def subscriber_counts(self) -> dict[str, int]:
+        """Snapshot every agent's live subscriber count in ONE lock take.
+
+        This is the control plane's only OBSERVATION of reachability — the
+        registry can say an agent is running and ``active`` while its inbox
+        adapter is not attached here, in which case :meth:`publish` fans out
+        to nobody and the message wakes no one. ``GET /agents`` reports this
+        count per row so "registered" and "reachable" stay distinguishable
+        (see ``_listen/_reachability.py``).
+
+        One lock acquisition rather than N (as repeated
+        :meth:`subscriber_count` calls would take) so annotating a whole
+        peer list stays O(1) in lock round-trips and cannot stall the
+        ``/agents`` route.
+
+        Agents with zero subscribers are simply absent from ``_subs``
+        (:meth:`unsubscribe` pops the empty set), so a name missing from the
+        returned dict means zero — callers must treat "absent" as 0, which
+        :func:`_listen._reachability.annotate_reachability` does.
+        """
+        async with self._lock:
+            return {agent: len(queues) for agent, queues in self._subs.items()}
+
 
 def mint_event(
     agent: str,

--- a/src/scitex_agent_container/cli_pkg/_listen_verbs.py
+++ b/src/scitex_agent_container/cli_pkg/_listen_verbs.py
@@ -1,0 +1,249 @@
+"""``sac listen start`` / ``sac listen stop`` — the explicit lifecycle verbs.
+
+``listen`` is a NOUN — a command group, exactly like ``agents`` / ``db`` /
+``host``. Booting a daemon off the bare noun (what ``sac listen`` does, and
+still does for one more release) is the anti-pattern the scitex CLI
+convention names outright — §1 "trailing noun, no action: **never**" — and
+it is a live footgun: a typo or a stray tab-complete starts a server on
+7878. Every other noun group in this CLI shows help when invoked bare; this
+one silently becomes a daemon.
+
+These two verbs make the lifecycle explicit and complete the set the group
+already had (``restart`` / ``status``), so ``listen`` finally reads like
+every other group: **start / stop / restart / status**.
+
+Why ``start`` and not ``serve``
+-------------------------------
+The §1d verb catalog reserves ``start`` / ``stop`` / ``restart`` for
+"daemonized-service lifecycle (background process with a pid)" and gives
+``serve`` to *foreground* serving. This daemon is squarely the former: it
+writes a flock-backed pidfile, ``restart`` / ``status`` / ``stop`` all
+address it BY that pid, ``restart`` re-spawns it with ``setsid``, and a
+systemd unit supervises it. (The catalog's ``serve`` is scoped to §12's
+``gui`` group — foreground, browser-facing surfaces. ``sac listen`` is a
+headless JSON control plane.) ``serve`` would also leave an incoherent
+``serve`` / ``stop`` / ``restart`` triad. ``start`` additionally keeps SSOT
+with the CLI's own existing lifecycle verb, ``sac agents start``.
+
+Layout
+------
+These live here rather than in ``listen_cmds`` purely to keep that module
+under the 512-line cap — the same extraction ``_listen_registry_hooks``
+made. ``listen_cmds`` imports THIS module to attach the commands, so the
+boot primitives are imported LAZILY inside the command bodies: a top-level
+``from .listen_cmds import ...`` would close an import cycle. Lazy
+in-function imports are house style here anyway (see ``21_cli-startup-
+budget.md``) — this module's import cost is click alone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+#: Mirrors the ``listen`` group's own ``--bind`` default. Used only when a
+#: verb runs with no group context at all (e.g. ``CliRunner`` invoking the
+#: command object directly); the group normally stashes the resolved value.
+DEFAULT_BIND = "127.0.0.1:7878"
+
+
+@click.command(name="start")
+@click.option(
+    "--bind",
+    default=None,
+    help=f"HOST:PORT to bind. Loopback-only per §4.4.  [default: {DEFAULT_BIND}]",
+)
+@click.option(
+    "--token-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Bearer-token file. Auto-generated at "
+        "~/.scitex/agent-container/tokens/listen-<host>.token if missing."
+    ),
+)
+@click.option(
+    "--allow-non-loopback",
+    is_flag=True,
+    default=False,
+    help=(
+        "Permit binding to non-loopback addresses. Required for "
+        "tailscale/tunnel binds; orochi-side mesh is the supported transport."
+    ),
+)
+@click.option(
+    "--print-token",
+    is_flag=True,
+    default=False,
+    help="Print the bearer token to stdout and exit (does not boot).",
+)
+@click.pass_context
+def listen_start(
+    ctx: click.Context,
+    bind: str | None,
+    token_file: Path | None,
+    allow_non_loopback: bool,
+    print_token: bool,
+) -> None:
+    """Boot the sac listen HTTP/JSON control-plane daemon.
+
+    The explicit form of what bare `sac listen` still does today. Binds
+    loopback-only unless --allow-non-loopback is passed, and writes a
+    flock-backed pidfile that `stop` / `restart` / `status` address.
+
+    Runs in the FOREGROUND (systemd's Type=simple supervises it; `sac listen
+    restart` re-spawns it under setsid). If another instance already holds
+    the port, this one does NOT crash — it stands by as a warm spare and
+    fails over the moment the holder dies.
+
+    Options may be given on the verb (`sac listen start --bind ...`) or on
+    the group (`sac listen --bind ... start`); the verb wins.
+
+    \b
+    Example:
+        sac listen start                                  # 127.0.0.1:7878
+        sac listen start --bind 127.0.0.1:7979            # custom port
+        sac listen start --bind 100.64.1.2:7878 --allow-non-loopback
+        sac listen start --print-token                    # echo token, exit
+
+    \b
+    Exit codes:
+        0  clean shutdown (SIGTERM / Ctrl-C), or --print-token printed
+        1  uvicorn/starlette missing, or the bind failed
+        2  non-loopback --bind without --allow-non-loopback
+    """
+    from .listen_cmds import _do_start_listen
+
+    obj = ctx.obj or {}
+    _do_start_listen(
+        bind=bind or obj.get("bind") or DEFAULT_BIND,
+        token_file=token_file or obj.get("token_file"),
+        allow_non_loopback=allow_non_loopback or bool(obj.get("allow_non_loopback")),
+        print_token=print_token or bool(obj.get("print_token")),
+    )
+
+
+@click.command(name="stop")
+@click.option(
+    "--grace-secs",
+    type=float,
+    default=10.0,
+    show_default=True,
+    help="SIGTERM-to-SIGKILL escalation deadline (seconds).",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Skip SIGTERM and go straight to SIGKILL.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a machine-readable JSON result envelope on stdout.",
+)
+@click.pass_context
+def listen_stop(
+    ctx: click.Context,
+    grace_secs: float,
+    force: bool,
+    as_json: bool,
+) -> None:
+    """Stop the running sac listen daemon.
+
+    The stop half of `restart`, on its own: SIGTERM the pidfile's PID, poll
+    to --grace-secs, escalate to SIGKILL, verify it is REALLY dead before
+    clearing the pidfile, then force-kill any wedged remnant still holding
+    the port that the pidfile never named (the "curl hangs forever" case).
+    Shares ONE implementation with `restart`, so the two cannot drift.
+
+    IDEMPOTENT: stopping an already-stopped daemon exits 0 and reports "not
+    running" — the same contract as `systemctl stop`.
+
+    Mirrors `sac listen`'s own bind resolution: `sac listen stop` stops the
+    daemon `sac listen start` would have started.
+
+    \b
+    Example:
+        sac listen stop                  # SIGTERM, 10s grace, then SIGKILL
+        sac listen stop --force          # SIGKILL daemon + wedged port holder
+        sac listen stop --json           # machine-readable envelope
+
+    \b
+    Exit codes:
+        0  stopped, or already down (idempotent)
+        1  could not stop (PID survived SIGKILL / port still wedged)
+    """
+    import json as _json
+
+    from .._listen._restart import format_escalation_warning
+    from .._listen._single_instance import default_lock_dir
+    from .._listen._stop import stop_listen
+    from .listen_cmds import _split_bind
+
+    host, port = _split_bind((ctx.obj or {}).get("bind") or DEFAULT_BIND)
+
+    lock_dir = default_lock_dir()
+    lock_dir.mkdir(parents=True, exist_ok=True)
+
+    result = stop_listen(
+        host=host,
+        port=port,
+        lock_dir=lock_dir,
+        grace_secs=grace_secs,
+        force=force,
+    )
+
+    # LOUD WARN on SIGKILL escalation, silent on a clean TERM exit — the
+    # same design call (c) ``restart`` follows, using the same formatter.
+    if result.escalated_to_sigkill:
+        click.echo(format_escalation_warning(grace_secs), err=True)
+
+    # Paper trail for the codified pkill (the wedged, untracked remnant).
+    if result.port_holders_killed:
+        pids = ", ".join(str(p) for p in result.port_holders_killed)
+        click.echo(
+            f"# self-heal: force-killed wedged port holder(s) PID {pids} "
+            f"off {host}:{port}",
+            err=True,
+        )
+
+    # §8: data on stdout, logs/warnings on stderr — `… --json | jq` must be
+    # uncontaminated even on the failure path below.
+    if as_json:
+        click.echo(
+            _json.dumps(
+                {
+                    "ok": result.ok,
+                    "host": host,
+                    "port": port,
+                    "was_running": result.was_running,
+                    "prior_pid": result.prior_pid,
+                    "escalated_to_sigkill": result.escalated_to_sigkill,
+                    "port_holders_killed": list(result.port_holders_killed),
+                    "error": result.error,
+                }
+            )
+        )
+
+    # FAIL LOUD: the error names the REAL cause (``PID X survived SIGKILL`` /
+    # ``port still held``), never a generic "did not stop".
+    if not result.ok:
+        raise click.ClickException(
+            result.error or "ERROR: sac listen stop failed (unknown reason)"
+        )
+
+    if result.was_running:
+        pid_note = f" (PID {result.prior_pid})" if result.prior_pid else ""
+        click.echo(f"# sac listen stopped → {host}:{port}{pid_note}", err=True)
+    else:
+        click.echo(
+            f"# sac listen was not running → {host}:{port} (nothing to stop)",
+            err=True,
+        )
+
+
+__all__ = ["DEFAULT_BIND", "listen_start", "listen_stop"]

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -293,7 +293,7 @@ class _MainGroup(LazyGroup):
         "fleet": "Peer-aware multi-agent orchestration across hosts.",
         "doctor": "Diagnose agent-spec source drift (local, or --fleet across hosts).",
         "provenance": "Prove which code is actually loaded (commit, origin, fossil installs).",
-        "listen": "Boot the sac listen HTTP/JSON control-plane server.",
+        "listen": "Host HTTP/JSON control plane: start/stop/restart/status.",
         "ports": "List the ports sac/scitex uses, with live status.",
         "pytest": "Run pytest on remote pools (Spartan SLURM, ...).",
         "install-shell-completion": "Wire up `<TAB>` completion in the user's shell rc.",
@@ -368,6 +368,7 @@ class _MainGroup(LazyGroup):
         "  $ sac agents status\n"
         "  $ sac agents start orchestrator                                      # by name\n"
         "  $ sac agents start ~/.scitex/agent-container/agents/orchestrator/spec.yaml   # by path\n"
+        "  $ sac listen status                                                  # host control-plane health\n"
     ),
 )
 @click.option(

--- a/src/scitex_agent_container/cli_pkg/listen_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/listen_cmds.py
@@ -51,6 +51,49 @@ from ._listen_registry_hooks import (  # noqa: E402
     _register_self_comms_node,
 )
 
+# ---------------------------------------------------------------------------
+# Bare-boot deprecation — scitex CLI convention §5, phase W (warn + forward)
+# ---------------------------------------------------------------------------
+
+#: The release that REMOVES boot-on-bare-``sac listen``. Every warning names
+#: it, so callers always know the deadline (§5: "each phase names the removal
+#: version").
+BARE_BOOT_REMOVAL_VERSION = "v0.23.0"
+
+
+def _warn_bare_boot_deprecated() -> None:
+    """Warn that bare ``sac listen`` booted a daemon, and name the verb.
+
+    Phase W: the bare form still FORWARDS to the boot, so every caller keeps
+    working — and three still invoke it bare TODAY (the systemd unit's
+    ``ExecStart``, ``_listen._restart``'s direct-spawn argv, and the systemd
+    JobSpec in PR #543). ``sac listen`` IS the host control plane; flipping
+    the bare form to show-help would take the fleet's host access down with
+    it. Removing the bare boot is a FOLLOW-UP, only after all three migrate.
+
+    DELIBERATE DEVIATION from §5a's once-per-shell suppression: §5a keys its
+    marker on ``$PPID`` to give one warning per interactive shell, but this
+    daemon's principal caller is a **systemd unit**, whose PPID is the
+    (constant) user manager — a once-per-PPID marker would warn on the first
+    boot then stay silent forever, muting exactly the caller that must
+    migrate. §5a's rationale ("cron jobs and loops would drown in it") also
+    does not apply: a daemon boots once per lifetime, so this is at most one
+    journal line per start. stderr only, and no marker-file write — the
+    control plane's boot path must not be able to fail on a write it does
+    not need.
+    """
+    click.echo(
+        "WARN: bare `sac listen` is DEPRECATED — use `sac listen start` "
+        f"(removed in {BARE_BOOT_REMOVAL_VERSION}).",
+        err=True,
+    )
+    click.echo(
+        "      `listen` is a command GROUP, not a verb: booting a daemon off "
+        "the bare noun means a typo or a stray tab-complete starts a server. "
+        "Verbs: start / stop / restart / status  (see `sac listen -h`).",
+        err=True,
+    )
+
 
 @click.group(name="listen", invoke_without_command=True)
 @click.option(
@@ -91,17 +134,29 @@ def listen(
     allow_non_loopback: bool,
     print_token: bool,
 ) -> None:
-    """Boot the sac listen HTTP server (default) or invoke a subverb.
+    """The host HTTP/JSON control plane (command group).
+
+    The plane every sac agent reaches the host through — 127.0.0.1:7878 by
+    default, bearer-token authenticated, loopback-only unless you opt out.
+    `listen` is a NOUN; the verbs below are its whole lifecycle.
 
     \b
     Example:
-        sac listen                          # 127.0.0.1:7878 (start)
-        sac listen --bind 100.64.1.2:7878 --allow-non-loopback
-        sac listen --print-token            # echo token then exit
+        sac listen start                    # boot the daemon (loopback only)
+        sac listen status                   # health report; exit 1 if down
+        sac listen status --json            # machine-readable envelope
+        sac listen stop                     # stop it (idempotent)
         sac listen restart                  # atomic stop-clean-relaunch
+        sac listen start --print-token      # echo the bearer token, then exit
+
+    \b
+    DEPRECATED: bare `sac listen` still BOOTS the daemon, so the systemd unit
+    and every existing launcher keep working — but it now warns. Use
+    `sac listen start`. The bare form is removed in v0.23.0.
     """
-    # Stash group-level options so subcommands (``restart``) can
-    # mirror ``sac listen``'s own bind resolution per design call (a).
+    # Stash group-level options so subcommands (``start`` / ``stop`` /
+    # ``restart`` / ``status``) can mirror ``sac listen``'s own bind
+    # resolution per design call (a).
     ctx.ensure_object(dict)
     ctx.obj["bind"] = bind
     ctx.obj["token_file"] = token_file
@@ -111,6 +166,13 @@ def listen(
     if ctx.invoked_subcommand is not None:
         # Subcommand will run next; group callback just stashed options.
         return
+
+    # Bare ``sac listen`` — the deprecated boot-by-default path (phase W:
+    # warn + FORWARD). ``--print-token`` short-circuits inside
+    # ``_do_start_listen`` before anything binds, so it is NOT a boot and
+    # must not draw a boot-deprecation warning.
+    if not print_token:
+        _warn_bare_boot_deprecated()
 
     _do_start_listen(
         bind=bind,
@@ -427,3 +489,18 @@ def listen_status(ctx: click.Context, as_json: bool) -> None:
 
     if not payload["running"]:
         ctx.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# ``sac listen start`` / ``sac listen stop`` — the explicit lifecycle verbs.
+#
+# Defined in a sibling module to keep THIS file under the 512-line cap (the
+# same extraction ``_listen_registry_hooks`` made) and attached here so they
+# resolve on the group. ``_listen_verbs`` imports its boot primitives lazily,
+# inside the command bodies, so importing it here is not a cycle.
+# ---------------------------------------------------------------------------
+
+from ._listen_verbs import listen_start, listen_stop  # noqa: E402
+
+listen.add_command(listen_start)
+listen.add_command(listen_stop)

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -443,10 +443,30 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
 
     is_healthy, message = health_check(config)
 
+    # REGISTERED IS NOT REACHABLE. ``health_check`` asks "is the process
+    # up?" — a deaf agent (one whose inbox adapter is not subscribed to the
+    # channel bus) passes that check while silently swallowing every
+    # a2a_send aimed at it. Report the inbox observation ALONGSIDE the
+    # process verdict so the two facts stay distinguishable.
+    #
+    # ``healthy`` is deliberately NOT derived from this: 0 subscribers means
+    # a detached inbox adapter, not a dead agent, and anything that
+    # auto-restarts on it would destroy a healthy session. Observation only.
+    from .._lifecycle.inbox_probe import probe_inbox_reachability
+    from .._listen._reachability import UNKNOWN, UNREACHABLE
+
+    subscribers, reachable = probe_inbox_reachability(name)
+
     if use_json:
         click.echo(
             json_mod.dumps(
-                {"name": name, "healthy": is_healthy, "message": message},
+                {
+                    "name": name,
+                    "healthy": is_healthy,
+                    "message": message,
+                    "inbox_subscribers": subscribers,
+                    "inbox_reachable": reachable,
+                },
                 indent=2,
             )
         )
@@ -458,4 +478,22 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
         console.print(f"[green]{message}[/green]")
     else:
         console.print(f"[red]{message}[/red]")
+
+    if reachable == UNREACHABLE:
+        console.print(
+            f"[yellow]inbox: NOT REACHABLE — 0 live subscribers. "
+            f"a2a_send to '{name}' will reach nobody (messages are queued and "
+            f"replayed when its channel adapter reconnects). The process is "
+            f"up; its inbox adapter is not attached. Do NOT force-restart on "
+            f"this alone.[/yellow]"
+        )
+    elif reachable == UNKNOWN:
+        console.print(
+            "[dim]inbox: unknown (could not reach sac listen to observe "
+            "subscribers)[/dim]"
+        )
+    else:
+        console.print(f"[green]inbox: reachable ({subscribers} subscriber(s))[/green]")
+
+    if not is_healthy:
         sys.exit(1)

--- a/tests/scitex_agent_container/_account/test_quota_cache_refresh.py
+++ b/tests/scitex_agent_container/_account/test_quota_cache_refresh.py
@@ -97,8 +97,61 @@ def test_refresh_entry_carries_h5_d7_and_ttl(tmp_path: Path) -> None:
         now=_NOW,
     )
     entry = read_quota_entry(account="ywatanabe-scitex-ai", cache_path=cache)
+    # Assert — the reset stamps are part of the entry shape now (None here:
+    # this fetcher's response omits them, which must stay a usable entry).
+    assert entry == {
+        "short": "ywatanabe",
+        "h5": 19.0,
+        "d7": 3.0,
+        "ttl_h": 7.5,
+        "reset_at_5h": None,
+        "reset_at_7d": None,
+    }
+
+
+def test_refresh_persists_the_7d_reset_stamp_for_the_picker(tmp_path: Path) -> None:
+    # Arrange — the usage API returns `resets_at` for both windows and
+    # `claude_usage` already parses it into reset_at_5h / reset_at_7d. The
+    # populator used to DROP it here, which left the account picker unable
+    # to tell expiring quota from a reserve (it binned ~10% of every 7d
+    # window). It must round-trip into the cache the picker reads.
+    store = tmp_path / "store"
+    _make_account(store, "ywatanabe-scitex-ai", ttl_hours=7.5)
+    cache = tmp_path / "quota-cache.json"
+    usage = _ok(0.0, 90.0)
+    usage["reset_at_7d"] = "2026-07-14T09:00:00+00:00"
+    fetch = _fetcher({"ywatanabe-scitex-ai": usage})
+    # Act
+    refresh_quota_cache(
+        home=tmp_path,
+        store_dir=store,
+        cache_path=cache,
+        usage_fetcher=fetch,
+        now=_NOW,
+    )
+    entry = read_quota_entry(account="ywatanabe-scitex-ai", cache_path=cache)
     # Assert
-    assert entry == {"short": "ywatanabe", "h5": 19.0, "d7": 3.0, "ttl_h": 7.5}
+    assert entry is not None and entry["reset_at_7d"] == "2026-07-14T09:00:00+00:00"
+
+
+def test_refresh_keeps_entry_usable_when_upstream_omits_reset(tmp_path: Path) -> None:
+    # Arrange — the reset stamps are OPTIONAL, unlike h5/d7/ttl_h: a response
+    # without them must still yield a cached entry (the picker just degrades
+    # to its reset-unaware ranking), never blank the account.
+    store = tmp_path / "store"
+    _make_account(store, "a-gmail-com", ttl_hours=3.0)
+    cache = tmp_path / "quota-cache.json"
+    fetch = _fetcher({"a-gmail-com": _ok(5.0, 1.0)})
+    # Act
+    result = refresh_quota_cache(
+        home=tmp_path,
+        store_dir=store,
+        cache_path=cache,
+        usage_fetcher=fetch,
+        now=_NOW,
+    )
+    # Assert
+    assert result["ok"] == 1
 
 
 def test_refresh_reports_ok_count(tmp_path: Path) -> None:

--- a/tests/scitex_agent_container/_creds/test__quota_rank.py
+++ b/tests/scitex_agent_container/_creds/test__quota_rank.py
@@ -9,11 +9,14 @@ descriptive names (TQ003), one assertion per test (TQ007).
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 from scitex_agent_container._creds._quota_rank import (
     account_5h_usage,
+    account_7d_reset_at,
     account_7d_usage,
+    is_expiring_7d,
     pick_ranked,
 )
 
@@ -178,3 +181,294 @@ def test_pick_ranked_spread_weights_toward_more_7d_headroom() -> None:
     ]
     # Assert
     assert picks.count("acct-b") > picks.count("acct-a")
+
+
+# ---------------------------------------------------------------------------
+# pick_ranked — EXPIRING capacity (use-it-or-lose-it)
+#
+# The operator's LIVE account table, 2026-07-14 (`sac accounts list`):
+#
+#   wyusuuke-gmail-com   5h 28%   7d 67%  (resets in 5d 14h)
+#   ywata1989-gmail-com  5h  0%   7d 90%  (resets in 9h06m)
+#   ywatanabe-scitex-ai  5h  0%   7d 90%  (resets in 6 MINUTES)
+#
+# ywatanabe-scitex-ai holds 10% of a 7-day Max-20x window that is about
+# to be DELETED. The reset-blind ranker scored it identically to a 90%
+# account with 6 days left, demoted both as "near-capped", and picked
+# wyusuuke — binning the 10%. 「毎回 90%で10%捨ててる」
+# ---------------------------------------------------------------------------
+
+_NOW = 1_780_000_000.0
+_HOUR = 3600.0
+
+_LIVE = ["wyusuuke-gmail-com", "ywata1989-gmail-com", "ywatanabe-scitex-ai"]
+_LIVE_5H = {
+    "wyusuuke-gmail-com": 28.0,
+    "ywata1989-gmail-com": 0.0,
+    "ywatanabe-scitex-ai": 0.0,
+}
+_LIVE_7D = {
+    "wyusuuke-gmail-com": 67.0,
+    "ywata1989-gmail-com": 90.0,
+    "ywatanabe-scitex-ai": 90.0,
+}
+_LIVE_RESET = {
+    "wyusuuke-gmail-com": _NOW + 5 * 24 * _HOUR + 14 * _HOUR,  # 5d 14h
+    "ywata1989-gmail-com": _NOW + 9 * _HOUR + 6 * 60.0,  # 9h06m
+    "ywatanabe-scitex-ai": _NOW + 6 * 60.0,  # 6 MINUTES
+}
+
+
+def test_pick_ranked_spends_the_7d_window_that_resets_in_minutes() -> None:
+    # Arrange — the operator's live table (above), reset stamps included.
+    # Act
+    picked = pick_ranked(_LIVE, _LIVE_5H, _LIVE_7D, reset_7d=_LIVE_RESET, now=_NOW)
+    # Assert — the 10% about to evaporate is SPENT, not binned.
+    assert picked == "ywatanabe-scitex-ai"
+
+
+def test_pick_ranked_bins_expiring_quota_when_reset_is_unknown() -> None:
+    # Arrange — the SAME live table with no reset data (a quota cache
+    # written before the populator persisted `reset_at_7d`). This pins the
+    # pre-change behaviour: unknown reset must degrade EXACTLY to it, never
+    # guess. It is also the bug the operator reported, in one line.
+    # Act
+    picked = pick_ranked(_LIVE, _LIVE_5H, _LIVE_7D, now=_NOW)
+    # Assert
+    assert picked == "wyusuuke-gmail-com"
+
+
+def test_pick_ranked_routes_fleet_to_the_expiring_account_on_the_spread_path() -> None:
+    # Arrange — the SHIPPING path: `_start_preflight` always passes
+    # spread_key=<agent name>, so this (not the legacy order) is what a real
+    # boot takes. Before the fix the expiring account was demoted out of the
+    # winning tier entirely and received EXACTLY ZERO agents.
+    fleet = [f"agent-{i}" for i in range(60)]
+    # Act
+    picks = [
+        pick_ranked(
+            _LIVE, _LIVE_5H, _LIVE_7D, reset_7d=_LIVE_RESET, now=_NOW, spread_key=key
+        )
+        for key in fleet
+    ]
+    # Assert
+    assert picks.count("ywatanabe-scitex-ai") > 0
+
+
+def test_pick_ranked_spread_never_routes_to_the_far_out_reserve() -> None:
+    # Arrange — ywata1989 is at 90% with 9h left: a genuine weekly reserve.
+    # It must stay demoted even while the fleet drains the expiring account.
+    fleet = [f"agent-{i}" for i in range(60)]
+    # Act
+    picks = [
+        pick_ranked(
+            _LIVE, _LIVE_5H, _LIVE_7D, reset_7d=_LIVE_RESET, now=_NOW, spread_key=key
+        )
+        for key in fleet
+    ]
+    # Assert
+    assert picks.count("ywata1989-gmail-com") == 0
+
+
+def test_pick_ranked_still_avoids_a_near_capped_account_resetting_far_out() -> None:
+    # Arrange — ywata1989 is ALSO at 90%, but its window has 9h left: a
+    # genuine reserve, not expiring capacity. Drop the truly-expiring
+    # account so the reserve is the only near-capped candidate left.
+    names = ["wyusuuke-gmail-com", "ywata1989-gmail-com"]
+    # Act
+    picked = pick_ranked(names, _LIVE_5H, _LIVE_7D, reset_7d=_LIVE_RESET, now=_NOW)
+    # Assert — avoiding a real reserve stays correct.
+    assert picked == "wyusuuke-gmail-com"
+
+
+def test_pick_ranked_keeps_avoiding_expiring_account_blocked_on_5h() -> None:
+    # Arrange — expiring 7d window, but the 5h wall is hit: it 429s NOW,
+    # however soon its weekly budget refreshes. The immediate throttle
+    # must still dominate.
+    usage_5h = {"acct-expiring": 99.0, "acct-reserve": 10.0}
+    usage_7d = {"acct-expiring": 90.0, "acct-reserve": 40.0}
+    reset_7d = {"acct-expiring": _NOW + 300.0, "acct-reserve": _NOW + 6 * 24 * _HOUR}
+    # Act
+    picked = pick_ranked(
+        ["acct-expiring", "acct-reserve"], usage_5h, usage_7d,
+        reset_7d=reset_7d, now=_NOW,
+    )
+    # Assert
+    assert picked == "acct-reserve"
+
+
+def test_pick_ranked_ignores_expiring_account_with_no_headroom_left() -> None:
+    # Arrange — 100% of the 7d window used and resetting in 5 minutes.
+    # There is no capacity to reclaim; routing here would just 429.
+    usage_7d = {"acct-exhausted": 100.0, "acct-reserve": 40.0}
+    reset_7d = {"acct-exhausted": _NOW + 300.0, "acct-reserve": _NOW + 6 * 24 * _HOUR}
+    # Act
+    picked = pick_ranked(
+        ["acct-exhausted", "acct-reserve"], {}, usage_7d, reset_7d=reset_7d, now=_NOW
+    )
+    # Assert
+    assert picked == "acct-reserve"
+
+
+def test_pick_ranked_treats_an_already_past_reset_stamp_as_unknown() -> None:
+    # Arrange — a STALE cache: the stamp says the window reset already, so
+    # the 90% reading cannot be trusted either. Degrade to avoidance rather
+    # than route onto an account we can no longer reason about.
+    usage_7d = {"acct-stale": 90.0, "acct-reserve": 40.0}
+    reset_7d = {"acct-stale": _NOW - 600.0, "acct-reserve": _NOW + 6 * 24 * _HOUR}
+    # Act
+    picked = pick_ranked(
+        ["acct-stale", "acct-reserve"], {}, usage_7d, reset_7d=reset_7d, now=_NOW
+    )
+    # Assert
+    assert picked == "acct-reserve"
+
+
+def test_pick_ranked_accepts_an_iso_reset_stamp_from_the_cache() -> None:
+    # Arrange — the cache persists the upstream ISO-8601 string, not an
+    # epoch, so the ranker must read that shape natively.
+    usage_7d = {"acct-expiring": 90.0, "acct-reserve": 40.0}
+    reset_7d = {
+        "acct-expiring": "2026-06-01T00:30:00Z",
+        "acct-reserve": "2026-06-08T00:00:00Z",
+    }
+    now = datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc).timestamp()  # 30m before
+    # Act
+    picked = pick_ranked(
+        ["acct-expiring", "acct-reserve"], {}, usage_7d, reset_7d=reset_7d, now=now
+    )
+    # Assert
+    assert picked == "acct-expiring"
+
+
+# ---------------------------------------------------------------------------
+# pick_ranked — expiring capacity must NOT re-create the stacking incident
+#
+# Preferring expiring quota via a hard TIER would put EVERY booting agent
+# on one account holding ~10% of a week. The preference is a spread WEIGHT
+# instead, so the fleet drains it fast while still spreading.
+# ---------------------------------------------------------------------------
+
+_SPREAD_7D = {"acct-expiring": 90.0, "acct-reserve": 60.0}
+_SPREAD_RESET = {
+    "acct-expiring": _NOW + 10 * 60.0,
+    "acct-reserve": _NOW + 5 * 24 * _HOUR,
+}
+
+
+def _spread_picks(n: int) -> list[str]:
+    return [
+        pick_ranked(
+            ["acct-expiring", "acct-reserve"],
+            {},
+            _SPREAD_7D,
+            reset_7d=_SPREAD_RESET,
+            now=_NOW,
+            spread_key=f"agent-{i}",
+        )
+        for i in range(n)
+    ]
+
+
+def test_pick_ranked_spread_drains_the_expiring_account_with_the_majority() -> None:
+    # Arrange
+    fleet_size = 100
+    # Act
+    picks = _spread_picks(fleet_size)
+    # Assert — vanishing capacity is spent before the persisting reserve.
+    assert picks.count("acct-expiring") > picks.count("acct-reserve")
+
+
+def test_pick_ranked_spread_does_not_stack_the_whole_fleet_on_expiring() -> None:
+    # Arrange
+    fleet_size = 100
+    # Act
+    picks = _spread_picks(fleet_size)
+    # Assert — the reserve still serves a real share: an account with 10%
+    # of a week left must not absorb an entire fleet restart.
+    assert picks.count("acct-reserve") > 0
+
+
+# ---------------------------------------------------------------------------
+# is_expiring_7d — the predicate itself
+# ---------------------------------------------------------------------------
+
+
+def test_is_expiring_7d_true_for_near_capped_window_resetting_in_minutes() -> None:
+    # Arrange
+    resets_in_6_minutes = _NOW + 6 * 60.0
+    # Act
+    verdict = is_expiring_7d(90.0, resets_in_6_minutes, _NOW)
+    # Assert
+    assert verdict is True
+
+
+def test_is_expiring_7d_false_for_same_pct_resetting_days_out() -> None:
+    # Arrange — 90% with 6 days left is a RESERVE, not expiring capacity.
+    resets_in_6_days = _NOW + 6 * 24 * _HOUR
+    # Act
+    verdict = is_expiring_7d(90.0, resets_in_6_days, _NOW)
+    # Assert
+    assert verdict is False
+
+
+def test_is_expiring_7d_false_when_reset_stamp_is_unknown() -> None:
+    # Arrange
+    reset_unknown = None
+    # Act
+    verdict = is_expiring_7d(90.0, reset_unknown, _NOW)
+    # Assert
+    assert verdict is False
+
+
+def test_is_expiring_7d_false_when_no_headroom_remains() -> None:
+    # Arrange — nothing left to reclaim; routing here only buys a 429.
+    fully_used_pct = 100.0
+    # Act
+    verdict = is_expiring_7d(fully_used_pct, _NOW + 300.0, _NOW)
+    # Assert
+    assert verdict is False
+
+
+# ---------------------------------------------------------------------------
+# account_7d_reset_at — cache field reader
+# ---------------------------------------------------------------------------
+
+
+def test_account_7d_reset_at_reads_reset_at_7d_field_from_cache(tmp_path: Path) -> None:
+    # Arrange
+    cache = tmp_path / "quota-cache.json"
+    cache.write_text(
+        json.dumps(
+            {
+                "written_at": 1.0,
+                "accounts": {
+                    "ywatanabe@scitex.ai": {
+                        "short": "ywatanabe",
+                        "h5": 0.0,
+                        "d7": 90.0,
+                        "ttl_h": 7.9,
+                        "reset_at_7d": "2026-06-01T00:00:00Z",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    expected = datetime(2026, 6, 1, tzinfo=timezone.utc).timestamp()
+    # Act
+    reset_at = account_7d_reset_at("ywatanabe-scitex-ai", quota_cache_path=cache)
+    # Assert
+    assert reset_at == expected
+
+
+def test_account_7d_reset_at_is_none_for_a_cache_without_the_field(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the pre-change cache shape (short/h5/d7/ttl_h only). It must
+    # still parse; the picker just degrades to its reset-unaware ranking.
+    cache = _write_cache(tmp_path)
+    # Act
+    reset_at = account_7d_reset_at("wyusuuke-gmail-com", quota_cache_path=cache)
+    # Assert
+    assert reset_at is None

--- a/tests/scitex_agent_container/_listen/test__reachability.py
+++ b/tests/scitex_agent_container/_listen/test__reachability.py
@@ -1,0 +1,203 @@
+"""REGISTERED is not REACHABLE — the inbox-subscriber observation.
+
+``GET /agents`` (which backs the ``a2a_peers`` MCP tool) used to report only
+what the registry DECLARED: a pid, a port, a start time, a group. An agent
+whose inbox adapter is not attached to the channel bus satisfies every one of
+those and still swallows every message sent to it. Two of four live agents
+were in exactly that state while advertising themselves as ``active``.
+
+These tests pin the distinction, and — just as importantly — pin the THIRD
+state. A remote agent's broker lives in another process that this listen
+cannot see; reporting it as ``unreachable`` would be a false accusation
+against a healthy peer, and the remedy a caller reaches for on a false death
+verdict is destructive. So "cannot observe" must come back as ``unknown``.
+
+Real ``Broker`` throughout — no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._listen._reachability import (
+    REACHABLE,
+    UNKNOWN,
+    UNREACHABLE,
+    annotate_reachability,
+    annotate_rows,
+)
+from scitex_agent_container.a2a._inbox_bus import Broker
+
+LOCAL = "ywata-note-win"
+
+
+# ---------------------------------------------------------------------------
+# Broker.subscriber_counts — the only OBSERVATION of reachability there is.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broker_reports_zero_for_an_agent_with_no_subscriber():
+    """The deaf case: nobody ever subscribed, so the agent is simply absent
+    from the map. Callers must read "absent" as zero."""
+    # Arrange
+    broker = Broker()
+    # Act
+    counts = await broker.subscriber_counts()
+    # Assert
+    assert counts.get("deaf-agent", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_broker_counts_a_live_subscriber():
+    # Arrange
+    broker = Broker()
+    await broker.subscribe("alice")
+    # Act
+    counts = await broker.subscriber_counts()
+    # Assert
+    assert counts["alice"] == 1
+
+
+@pytest.mark.asyncio
+async def test_broker_counts_drop_when_a_subscriber_leaves():
+    """An agent whose adapter disconnects becomes deaf again — the count must
+    follow reality, not the registry."""
+    # Arrange
+    broker = Broker()
+    queue = await broker.subscribe("alice")
+    await broker.unsubscribe("alice", queue)
+    # Act
+    counts = await broker.subscriber_counts()
+    # Assert
+    assert counts.get("alice", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_broker_snapshot_matches_publish_fanout():
+    """The count must be the SAME number ``publish`` fans out to — otherwise
+    a2a_peers would be advertising a reachability the bus does not honour."""
+    # Arrange
+    broker = Broker()
+    await broker.subscribe("alice")
+    await broker.subscribe("alice")
+    # Act
+    counts = await broker.subscriber_counts()
+    delivered = await broker.publish("alice", {"msg_id": "m1"})
+    # Assert
+    assert counts["alice"] == delivered
+
+
+# ---------------------------------------------------------------------------
+# annotate_reachability — the three states.
+# ---------------------------------------------------------------------------
+
+
+def test_agent_with_a_subscriber_is_reachable():
+    # Arrange
+    row = {"name": "scitex-todo", "host": LOCAL, "pid": 123}
+    # Act
+    out = annotate_reachability(
+        row, subscriber_counts={"scitex-todo": 1}, local_host=LOCAL
+    )
+    # Assert
+    assert out["inbox_reachable"] == REACHABLE
+
+
+def test_agent_with_no_subscriber_is_unreachable_not_active():
+    """THE BUG. A registered, running, ``active`` agent with zero subscribers
+    is NOT reachable, and must not be presented as though it were."""
+    # Arrange — every declaration says healthy; the bus says nobody is home.
+    row = {
+        "name": "claude-code-telegrammer",
+        "host": LOCAL,
+        "pid": 4242,
+        "groups": ["active"],
+    }
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNREACHABLE
+
+
+def test_unreachable_agent_reports_zero_subscribers():
+    # Arrange
+    row = {"name": "scitex-dev", "host": LOCAL, "pid": 7, "groups": ["active"]}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_subscribers"] == 0
+
+
+def test_remote_agent_is_unknown_not_unreachable():
+    """A peer on ANOTHER host has its subscribers in another process's broker.
+    We cannot see it, so we must not claim it is deaf — that would be a false
+    accusation, and false death verdicts get healthy agents destroyed."""
+    # Arrange
+    row = {"name": "remote-agent", "host": "spartan", "pid": 9}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNKNOWN
+
+
+def test_remote_agent_reports_null_subscribers_not_zero():
+    """A count we could not take is ``None``, never ``0``. Zero is a claim."""
+    # Arrange
+    row = {"name": "remote-agent", "host": "spartan"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_subscribers"] is None
+
+
+def test_row_without_a_host_is_observed_locally():
+    """The publish path treats a host-less name as local (see
+    ``state_db_nodes.is_local_node``), so the local broker IS authoritative
+    for it and a zero there is a real observation."""
+    # Arrange
+    row = {"name": "hostless", "pid": 1}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert out["inbox_reachable"] == UNREACHABLE
+
+
+def test_unknown_local_identity_makes_a_hosted_row_unknown():
+    """If we don't know which host WE are, we cannot prove a hosted row is
+    ours — so we cannot claim its broker is the one we just read."""
+    # Arrange
+    row = {"name": "somebody", "host": "elsewhere"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=None)
+    # Assert
+    assert out["inbox_reachable"] == UNKNOWN
+
+
+def test_annotation_preserves_the_registry_declaration():
+    """We ADD the observation next to the declaration. We never overwrite or
+    reinterpret what the registry said — both facts must stay readable."""
+    # Arrange
+    row = {"name": "a", "host": LOCAL, "pid": 5, "groups": ["active"], "role": "dev"}
+    # Act
+    out = annotate_reachability(row, subscriber_counts={}, local_host=LOCAL)
+    # Assert
+    assert (out["pid"], out["groups"], out["role"]) == (5, ["active"], "dev")
+
+
+def test_annotate_rows_separates_reachable_from_deaf_peers():
+    """The scorecard that started this: two agents delivered, two swallowed —
+    and the peer list called all four ``active``."""
+    # Arrange
+    rows = [
+        {"name": "scitex-todo", "host": LOCAL, "groups": ["active"]},
+        {"name": "scitex-agent-container", "host": LOCAL, "groups": ["active"]},
+        {"name": "claude-code-telegrammer", "host": LOCAL, "groups": ["active"]},
+        {"name": "scitex-dev", "host": LOCAL, "groups": ["active"]},
+    ]
+    counts = {"scitex-todo": 1, "scitex-agent-container": 1}
+    # Act
+    out = annotate_rows(rows, subscriber_counts=counts, local_host=LOCAL)
+    deaf = [r["name"] for r in out if r["inbox_reachable"] == UNREACHABLE]
+    # Assert
+    assert deaf == ["claude-code-telegrammer", "scitex-dev"]

--- a/tests/scitex_agent_container/_listen/test__stop.py
+++ b/tests/scitex_agent_container/_listen/test__stop.py
@@ -1,0 +1,488 @@
+"""Tests for ``_listen/_stop.py`` — the stop half ``stop`` and ``restart`` share.
+
+``sac listen stop`` and ``sac listen restart`` must never drift: a restart
+IS a stop plus a relaunch plus a health-probe. ``stop_listen`` is that
+stop half as ONE implementation, so the two verbs cannot diverge. These
+tests pin the sequence (SIGTERM → grace → SIGKILL escalation; verify-dead
+BEFORE clearing the pidfile; wedged-port self-heal; idempotent no-op on a
+dead daemon) AND that ``restart_listen`` still routes through it.
+
+PA-306 + STX-NM001-003: no MagicMock / no monkeypatch. The seams
+(``_kill``, ``_sleep``) are swapped on ``_restart`` via a hand-rolled
+save/restore context manager, exactly as ``test__restart.py`` does —
+``_stop`` reaches every primitive through the ``_restart`` MODULE OBJECT
+at call time, so one swap drives both modules. A ``from ._restart import
+_sleep`` in the production code would capture the ORIGINAL callable and
+silently defeat these swaps; that is why it does not do that.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import signal
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._listen import _port_holder as ph_mod
+from scitex_agent_container._listen import _restart as restart_mod
+from scitex_agent_container._listen import _stop as stop_mod
+from scitex_agent_container._listen._stop import StopResult, stop_listen
+
+# A port that is NOT the live control plane (7878). Belt-and-braces with
+# the autouse seam fixture below: nothing here may ever reach the real
+# fleet daemon.
+TEST_PORT = 7999
+
+
+# ---------------------------------------------------------------------------
+# Module-level swap helpers — production callables → recording fakes.
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _swap(name: str, value) -> Iterator[None]:
+    """Replace ``restart_mod.<name>`` for the duration of the block."""
+    saved = getattr(restart_mod, name)
+    setattr(restart_mod, name, value)
+    try:
+        yield
+    finally:
+        setattr(restart_mod, name, saved)
+
+
+@contextmanager
+def _swap_ph(name: str, value) -> Iterator[None]:
+    """Replace a ``_port_holder.<name>`` seam for the block.
+
+    The discovery seams (``_probe_bound`` / ``_resolve_pids``) live on
+    ``_port_holder``, not ``_restart``.
+    """
+    saved = getattr(ph_mod, name)
+    setattr(ph_mod, name, value)
+    try:
+        yield
+    finally:
+        setattr(ph_mod, name, saved)
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_port_seams() -> Iterator[None]:
+    """Make the wedged-port-holder self-heal a hard no-op by default.
+
+    SAFETY: the real ``port_is_bound`` does a live socket connect, and on a
+    dev host the central ``sac listen`` is actually bound on 7878. Without
+    this guard a ``stop_listen`` test could probe a real port, find it held,
+    and FORCE-KILL the live fleet control plane as a test side effect.
+    Defaulting the probe to "not bound" keeps every test hermetic; the
+    dedicated self-heal test overrides these two seams inside its own block.
+    """
+    saved_bound = ph_mod._probe_bound
+    saved_holders = ph_mod._resolve_pids
+    ph_mod._probe_bound = lambda _host, _port: False
+    ph_mod._resolve_pids = lambda _port: []
+    try:
+        yield
+    finally:
+        ph_mod._probe_bound = saved_bound
+        ph_mod._resolve_pids = saved_holders
+
+
+def _no_sleep(_secs: float) -> None:
+    """Recorded fake: no-op sleep, makes the grace loop instant."""
+
+
+class _KillRecorder:
+    """Hand-rolled fake for ``os.kill`` — records every (pid, signal) call
+    and lets the test program a script of liveness responses.
+
+    ``alive_script`` is consumed in order on each ``kill(pid, 0)`` probe:
+    True/False decides whether the probe sees the pid alive. After the
+    script is exhausted, the last value sticks.
+    """
+
+    def __init__(self, *, alive_script: list[bool]) -> None:
+        self.calls: list[tuple[int, int]] = []
+        self._script = list(alive_script)
+        self._last_alive = alive_script[-1] if alive_script else False
+
+    def __call__(self, pid: int, sig: int) -> None:
+        self.calls.append((pid, sig))
+        if sig == 0:
+            if self._script:
+                alive = self._script.pop(0)
+                self._last_alive = alive
+            else:
+                alive = self._last_alive
+            if not alive:
+                raise ProcessLookupError(pid)
+
+    @property
+    def signals(self) -> list[int]:
+        """Every non-probe signal actually delivered."""
+        return [sig for _pid, sig in self.calls if sig != 0]
+
+
+def _write_pidfile(lock_dir: Path, pid: int, port: int = TEST_PORT) -> Path:
+    """Create ``<lock_dir>/listen-<port>.pid`` holding ``pid``."""
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    pid_file = restart_mod.pidfile_path(port, lock_dir)
+    pid_file.write_text(f"{pid}\n", encoding="utf-8")
+    return pid_file
+
+
+# ---------------------------------------------------------------------------
+# stop_listen — the TERM → KILL ladder
+# ---------------------------------------------------------------------------
+
+
+def test_stop_listen_sends_sigterm_to_the_pidfile_pid(tmp_path: Path) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    # alive for the pre-check, then dead on the first grace poll.
+    kills = _KillRecorder(alive_script=[True, False, False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert signal.SIGTERM in kills.signals
+
+
+def test_stop_listen_force_skips_term_and_sends_sigkill(tmp_path: Path) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True, False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        stop_listen(
+            host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path, force=True
+        )
+    # Assert
+    assert kills.signals == [signal.SIGKILL]
+
+
+def test_stop_listen_clean_term_exit_does_not_escalate(tmp_path: Path) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True, False, False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.escalated_to_sigkill is False
+
+
+def test_stop_listen_escalates_to_sigkill_after_grace(tmp_path: Path) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    # Alive through every grace poll, then dead once SIGKILL lands.
+    kills = _KillRecorder(alive_script=[True] * 60 + [False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(
+            host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path, grace_secs=1.0
+        )
+    # Assert
+    assert result.escalated_to_sigkill is True
+
+
+# ---------------------------------------------------------------------------
+# stop_listen — pidfile hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_stop_listen_clears_the_pidfile_after_stopping(tmp_path: Path) -> None:
+    # Arrange
+    pid_file = _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True, False, False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert pid_file.exists() is False
+
+
+def test_stop_listen_clears_a_stale_pidfile_naming_a_dead_pid(
+    tmp_path: Path,
+) -> None:
+    """A pidfile left behind by a crashed daemon must not wedge `stop`."""
+    # Arrange
+    pid_file = _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert pid_file.exists() is False
+
+
+def test_stop_listen_keeps_pidfile_when_pid_survives_sigkill(
+    tmp_path: Path,
+) -> None:
+    """Defence-in-depth: never clear a lock whose owner is still alive."""
+    # Arrange
+    pid_file = _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True])  # never dies
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        stop_listen(
+            host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path, force=True
+        )
+    # Assert
+    assert pid_file.exists() is True
+
+
+def test_stop_listen_fails_when_pid_survives_sigkill(tmp_path: Path) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True])  # never dies
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(
+            host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path, force=True
+        )
+    # Assert
+    assert result.ok is False
+
+
+def test_stop_listen_surviving_pid_error_names_the_pid(tmp_path: Path) -> None:
+    """FAIL LOUD: the error names the REAL cause, not a generic failure."""
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True])  # never dies
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(
+            host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path, force=True
+        )
+    # Assert
+    assert "4242" in result.error
+
+
+# ---------------------------------------------------------------------------
+# stop_listen — idempotence (the `systemctl stop` contract)
+# ---------------------------------------------------------------------------
+
+
+def test_stop_listen_with_no_pidfile_reports_ok(tmp_path: Path) -> None:
+    """Stopping an already-stopped daemon is SUCCESS, not failure."""
+    # Arrange
+    kills = _KillRecorder(alive_script=[False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.ok is True
+
+
+def test_stop_listen_with_no_pidfile_reports_not_running(tmp_path: Path) -> None:
+    # Arrange
+    kills = _KillRecorder(alive_script=[False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.was_running is False
+
+
+def test_stop_listen_with_no_pidfile_sends_no_signals(tmp_path: Path) -> None:
+    # Arrange
+    kills = _KillRecorder(alive_script=[False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert kills.signals == []
+
+
+def test_stop_listen_reports_was_running_for_a_live_daemon(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True, False, False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.was_running is True
+
+
+def test_stop_listen_reports_the_pid_it_stopped(tmp_path: Path) -> None:
+    # Arrange
+    _write_pidfile(tmp_path, 4242)
+    kills = _KillRecorder(alive_script=[True, False, False])
+    # Act
+    with _swap("_kill", kills), _swap("_sleep", _no_sleep):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.prior_pid == 4242
+
+
+# ---------------------------------------------------------------------------
+# stop_listen — wedged-port self-heal (the "curl hangs forever" remnant)
+# ---------------------------------------------------------------------------
+
+
+def test_stop_listen_force_kills_an_untracked_wedged_port_holder(
+    tmp_path: Path,
+) -> None:
+    """The remnant the pidfile never named must still be cleared."""
+    # Arrange — no pidfile at all; the port is held by an unknown PID.
+    kills = _KillRecorder(alive_script=[True, False, False])
+    bound = [True]  # bound on the first probe, freed after the kill
+
+    def _probe(_host: str, _port: int) -> bool:
+        return bound.pop(0) if bound else False
+
+    # Act
+    with (
+        _swap("_kill", kills),
+        _swap("_sleep", _no_sleep),
+        _swap_ph("_probe_bound", _probe),
+        _swap_ph("_resolve_pids", lambda _port: [9191]),
+    ):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.port_holders_killed == (9191,)
+
+
+def test_stop_listen_reports_was_running_for_a_wedged_port_holder(
+    tmp_path: Path,
+) -> None:
+    """A wedged remnant with no pidfile still counts as 'was running'."""
+    # Arrange
+    kills = _KillRecorder(alive_script=[True, False, False])
+    bound = [True]
+
+    def _probe(_host: str, _port: int) -> bool:
+        return bound.pop(0) if bound else False
+
+    # Act
+    with (
+        _swap("_kill", kills),
+        _swap("_sleep", _no_sleep),
+        _swap_ph("_probe_bound", _probe),
+        _swap_ph("_resolve_pids", lambda _port: [9191]),
+    ):
+        result = stop_listen(host="127.0.0.1", port=TEST_PORT, lock_dir=tmp_path)
+    # Assert
+    assert result.was_running is True
+
+
+# ---------------------------------------------------------------------------
+# SSOT — restart MUST NOT re-implement the stop sequence.
+# ---------------------------------------------------------------------------
+
+
+def test_restart_listen_delegates_its_stop_half_to_stop_listen(
+    tmp_path: Path,
+) -> None:
+    """The anti-drift guard: one stop sequence, two verbs."""
+    # Arrange
+    calls: list[dict] = []
+
+    def _recording_stop(**kwargs) -> StopResult:
+        calls.append(kwargs)
+        return StopResult(
+            ok=True,
+            escalated_to_sigkill=False,
+            had_prior_pidfile=False,
+            prior_pid_alive=False,
+        )
+
+    saved = stop_mod.stop_listen
+    stop_mod.stop_listen = _recording_stop
+    # Act
+    try:
+        with (
+            _swap("_sleep", _no_sleep),
+            _swap("_run_subprocess", lambda *_a, **_kw: None),
+            _swap("_http_get", lambda _url, timeout: 200),
+        ):
+            restart_mod.restart_listen(
+                host="127.0.0.1",
+                port=TEST_PORT,
+                lock_dir=tmp_path,
+                systemd_unit_path=tmp_path / "absent.service",
+                sac_listen_argv=["/bin/true"],
+            )
+    finally:
+        stop_mod.stop_listen = saved
+    # Assert
+    assert len(calls) == 1
+
+
+def test_restart_listen_forwards_force_to_the_stop_half(tmp_path: Path) -> None:
+    # Arrange
+    calls: list[dict] = []
+
+    def _recording_stop(**kwargs) -> StopResult:
+        calls.append(kwargs)
+        return StopResult(
+            ok=True,
+            escalated_to_sigkill=False,
+            had_prior_pidfile=False,
+            prior_pid_alive=False,
+        )
+
+    saved = stop_mod.stop_listen
+    stop_mod.stop_listen = _recording_stop
+    # Act
+    try:
+        with (
+            _swap("_sleep", _no_sleep),
+            _swap("_run_subprocess", lambda *_a, **_kw: None),
+            _swap("_http_get", lambda _url, timeout: 200),
+        ):
+            restart_mod.restart_listen(
+                host="127.0.0.1",
+                port=TEST_PORT,
+                lock_dir=tmp_path,
+                force=True,
+                systemd_unit_path=tmp_path / "absent.service",
+                sac_listen_argv=["/bin/true"],
+            )
+    finally:
+        stop_mod.stop_listen = saved
+    # Assert
+    assert calls[0]["force"] is True
+
+
+def test_restart_listen_aborts_when_the_stop_half_fails(tmp_path: Path) -> None:
+    """A failed stop must never relaunch into a still-held port."""
+    # Arrange
+    def _failing_stop(**_kwargs) -> StopResult:
+        return StopResult(
+            ok=False,
+            escalated_to_sigkill=True,
+            had_prior_pidfile=True,
+            prior_pid_alive=True,
+            prior_pid=4242,
+            error="PID 4242 survived SIGKILL",
+        )
+
+    saved = stop_mod.stop_listen
+    stop_mod.stop_listen = _failing_stop
+    spawns: list[list[str]] = []
+    # Act
+    try:
+        with (
+            _swap("_sleep", _no_sleep),
+            _swap("_run_subprocess", lambda *a, **_kw: spawns.append(list(a[0]))),
+            _swap("_http_get", lambda _url, timeout: 200),
+        ):
+            restart_mod.restart_listen(
+                host="127.0.0.1",
+                port=TEST_PORT,
+                lock_dir=tmp_path,
+                systemd_unit_path=tmp_path / "absent.service",
+                sac_listen_argv=["/bin/true"],
+            )
+    finally:
+        stop_mod.stop_listen = saved
+    # Assert
+    assert spawns == []

--- a/tests/scitex_agent_container/_mcp/test__channel_send_errors.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_send_errors.py
@@ -1,0 +1,317 @@
+"""The FAIL-LOUD contract: a send that reached nobody must FAIL the call.
+
+Why this module exists as its own file
+--------------------------------------
+``test__channel_tools.py`` already asserted that a 0-subscriber send returns
+a body containing an ``error`` key. Those tests passed — and agents silently
+swallowed each other's messages anyway.
+
+The gap: a caller does not decide "did my call succeed?" by reading the body.
+It reads the MCP protocol's ``isError`` flag. And the low-level server stamps
+``isError=False`` on ANY plain ``list[TextContent]`` a handler returns — so
+"reached no live subscriber" was arriving inside a result the protocol
+classified as SUCCESSFUL. The old tests could not have caught that, because
+they invoked the handler directly and never went through the component that
+produces the flag.
+
+So every test here drives a REAL ``mcp.server.lowlevel.Server`` against a
+REAL loopback HTTP listen. No mocks. The assertions are about what the caller
+actually sees.
+
+The three states (and why the middle one is the only failure)
+-------------------------------------------------------------
+* ``delivered_subscriber_count >= 1`` → delivered. Success.
+* ``delivered_subscriber_count == 0``  → DEFINITIVELY not delivered. The bus
+  fanned out to nobody. This is evidence, so it fails loudly.
+* field ABSENT (e.g. a cross-host forward) → could not determine. Inventing a
+  zero would be a false accusation of non-delivery, so it does NOT fail.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+pytest.importorskip("mcp.types")  # gates the module on `mcp`
+
+from scitex_agent_container._mcp._channel_send_errors import (  # noqa: E402
+    ERR_NO_SUBSCRIBER,
+    ERR_UNREACHABLE,
+)
+from scitex_agent_container._mcp._channel_tools import register_tools  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# A real loopback listen. Speaks just enough HTTP/1.1 to answer message:send
+# with a configurable publish reply — the same shape sac listen returns from
+# ``node_message_send``.
+# ---------------------------------------------------------------------------
+
+
+class _FakeListen:
+    """Real asyncio TCP server answering ``POST /agents/<n>/message:send``."""
+
+    def __init__(self) -> None:
+        self.send_response: dict[str, Any] = {"ok": True}
+        self._server: asyncio.base_events.Server | None = None
+        self.port = 0
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            if not await reader.readline():
+                return
+            content_length = 0
+            while True:
+                line = await reader.readline()
+                if line in (b"\r\n", b"\n", b""):
+                    break
+                if line.lower().startswith(b"content-length:"):
+                    content_length = int(line.split(b":", 1)[1].strip())
+            if content_length:
+                await reader.readexactly(content_length)
+            body = json.dumps(self.send_response).encode()
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"Connection: close\r\n\r\n" + body
+            )
+            await writer.drain()
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+
+@pytest_asyncio.fixture
+async def listen():
+    server = _FakeListen()
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+async def _call(listen_url: str, tool: str, args: dict[str, Any]):
+    """Invoke ``tool`` through a REAL MCP Server; return its CallToolResult.
+
+    This is the caller's-eye view. The low-level server is what turns a
+    handler's return value into the ``CallToolResult`` (and its ``isError``
+    flag) that the calling model receives — so it is the only place the
+    swallowed-message bug was ever observable.
+    """
+    import mcp.types as types
+    from mcp.server.lowlevel import Server
+
+    server = Server(name="sac-channel-test")
+    register_tools(server, agent_name="alice", listen_url=listen_url, bearer=None)
+    handler = server.request_handlers[types.CallToolRequest]
+    request = types.CallToolRequest(
+        method="tools/call",
+        params=types.CallToolRequestParams(name=tool, arguments=args),
+    )
+    return (await handler(request)).root
+
+
+def _body(result) -> dict[str, Any]:
+    return json.loads(result.content[0].text)
+
+
+def _refused_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = int(s.getsockname()[1])
+    s.close()
+    return port
+
+
+# ---------------------------------------------------------------------------
+# THE BUG: 0 subscribers came back as a SUCCESSFUL tool call.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_send_is_an_mcp_error(listen):
+    """delivered_subscriber_count == 0 → the caller must see a FAILED call,
+    not a success whose body merely mentions an error."""
+    # Arrange — the listen publishes to nobody.
+    listen.send_response = {"msg_id": "m1", "delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert result.isError is True
+
+
+@pytest.mark.asyncio
+async def test_delivered_send_is_not_an_mcp_error(listen):
+    """Guard against the fail-loud check over-firing: >= 1 subscriber is a
+    real delivery and must stay a plain success."""
+    # Arrange
+    listen.send_response = {"msg_id": "m1", "delivered_subscriber_count": 1}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert result.isError is False
+
+
+@pytest.mark.asyncio
+async def test_absent_subscriber_count_is_not_an_mcp_error(listen):
+    """Three states, not two. An ABSENT count (a cross-host forward that does
+    not report one) is "could not determine" — it must NOT be inferred as zero
+    and failed. Absence of evidence is not evidence of non-delivery."""
+    # Arrange — a 200 carrying no delivered_subscriber_count at all.
+    listen.send_response = {"ok": True}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert result.isError is False
+
+
+@pytest.mark.asyncio
+async def test_unreachable_listen_is_an_mcp_error():
+    """Connection refused is a demonstrable non-delivery — also a caller-
+    visible failure, not a quietly-swallowed one."""
+    # Arrange — nothing is listening on this port.
+    url = f"http://127.0.0.1:{_refused_port()}"
+    # Act
+    result = await _call(url, "a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert result.isError is True
+
+
+@pytest.mark.asyncio
+async def test_reply_to_unknown_msg_id_is_an_mcp_error(listen):
+    """A reply that resolved no recipient delivered nothing either."""
+    # Arrange — nothing in the inbox ring, so this msg_id resolves to no sender.
+    unknown_msg_id = "ghost"
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_reply", {"in_reply_to": unknown_msg_id, "content": "x"}
+    )
+    # Assert
+    assert result.isError is True
+
+
+# ---------------------------------------------------------------------------
+# The failure must stay ACTIONABLE — loud is not enough if it strands the
+# caller. The detail (who, how many, what now) survives the fail-loud change.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_error_names_the_target(listen):
+    # Arrange
+    listen.send_response = {"delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert _body(result)["target"] == "bob"
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_error_carries_machine_readable_code(listen):
+    # Arrange
+    listen.send_response = {"delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert _body(result)["code"] == ERR_NO_SUBSCRIBER
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_error_reports_the_subscriber_count(listen):
+    # Arrange
+    listen.send_response = {"delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert _body(result)["delivered_subscriber_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_error_states_delivered_false(listen):
+    # Arrange
+    listen.send_response = {"delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert _body(result)["delivered"] is False
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_error_reports_the_message_as_durably_queued(listen):
+    """sac listen persists to ``channel_events`` BEFORE it publishes, and
+    replays undelivered rows on the target's next connect. "Not delivered"
+    therefore does not mean "lost" — and telling the caller to re-send would
+    double-deliver once the adapter reconnects."""
+    # Arrange
+    listen.send_response = {"delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    # Assert
+    assert _body(result)["durably_queued"] is True
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_error_does_not_prescribe_a_restart(listen):
+    """0 subscribers means a DETACHED INBOX ADAPTER, not a dead agent. The
+    remedy must never be one that destroys a healthy session."""
+    # Arrange
+    listen.send_response = {"delivered_subscriber_count": 0}
+    # Act
+    result = await _call(
+        listen.base_url, "a2a_send", {"target": "bob", "content": "hi"}
+    )
+    advice = " ".join(_body(result)["what_to_do"]).lower()
+    # Assert
+    assert "do not force-restart" in advice
+
+
+@pytest.mark.asyncio
+async def test_unreachable_error_carries_machine_readable_code():
+    # Arrange
+    url = f"http://127.0.0.1:{_refused_port()}"
+    # Act
+    result = await _call(url, "a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert _body(result)["code"] == ERR_UNREACHABLE

--- a/tests/scitex_agent_container/_mcp/test__channel_tools.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_tools.py
@@ -25,10 +25,39 @@ import pytest
 import pytest_asyncio
 
 mcp_types = pytest.importorskip("mcp.types")  # gates entire module on `mcp`
-from mcp.types import TextContent, Tool  # noqa: E402
+from mcp.types import CallToolResult, TextContent, Tool  # noqa: E402
 
 from scitex_agent_container._mcp._channel_tools import register_tools  # noqa: E402
 from scitex_agent_container._mcp.channel import _recent  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Result helpers.
+#
+# A tool result is EITHER a plain ``list[TextContent]`` (success — the MCP
+# server stamps ``isError=False`` on it) OR a ``CallToolResult`` carrying
+# ``isError=True`` (failure). Both shapes are unwrapped uniformly here so the
+# assertions stay about BEHAVIOUR, not about which container the payload
+# arrived in.
+# ---------------------------------------------------------------------------
+
+
+def _blocks(out: "list[TextContent] | CallToolResult") -> "list[TextContent]":
+    """Content blocks of a tool result, whichever shape it came back in."""
+    if isinstance(out, CallToolResult):
+        return list(out.content)
+    return list(out)
+
+
+def _payload(out: "list[TextContent] | CallToolResult") -> dict:
+    """The JSON body of a tool result."""
+    return json.loads(_blocks(out)[0].text)
+
+
+# NB: whether a failure is actually visible to the CALLER (the MCP ``isError``
+# flag, which a bare ``list[TextContent]`` can never set) is pinned in
+# ``test__channel_send_errors.py`` — it drives a real ``mcp.server.lowlevel``
+# Server rather than the ``_ToolRecorder`` stand-in used here, because that
+# flag is produced by the server, not by the handler.
 
 # ---------------------------------------------------------------------------
 # Real in-process HTTP/1.1 + JSON server (no aiohttp dependency).
@@ -259,7 +288,7 @@ async def test_call_tool_unknown_name_returns_error_payload(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("not_a_tool", {})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert "error" in body
 
@@ -311,7 +340,7 @@ async def test_call_tool_a2a_send_returns_status_field(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_send", {"target": "bob", "content": "hi"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert body["status"] == 200
 
@@ -483,7 +512,7 @@ async def test_call_tool_a2a_reply_unknown_msg_id_returns_error(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_reply", {"in_reply_to": "ghost", "content": "x"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert "error" in body
 
@@ -539,7 +568,7 @@ async def test_call_tool_a2a_reply_unknown_sender_returns_error(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_reply", {"in_reply_to": "m9", "content": "x"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert "error" in body
 
@@ -552,7 +581,7 @@ async def test_call_tool_a2a_ack_unknown_msg_id_returns_error(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_ack", {"msg_id": "nope"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert "error" in body
 
@@ -566,7 +595,7 @@ async def test_call_tool_a2a_ack_unknown_sender_returns_error(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_ack", {"msg_id": "m11"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert "error" in body
 
@@ -599,7 +628,7 @@ async def test_call_tool_a2a_ack_returns_suppression_marker(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_ack", {"msg_id": "m1"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert body.get("body", {}).get("suppressed") == "empty_ack"
 
@@ -613,7 +642,7 @@ async def test_call_tool_a2a_peers_returns_status(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_peers", {})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert body["status"] == 200
 
@@ -627,7 +656,7 @@ async def test_call_tool_a2a_peers_returns_peers_body(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_peers", {})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert body["body"] == {"agents": ["alice", "bob"]}
 
@@ -647,7 +676,7 @@ async def test_call_tool_a2a_inbox_returns_count(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_inbox", {"limit": 10})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert body["count"] == 3
 
@@ -662,7 +691,7 @@ async def test_call_tool_a2a_inbox_respects_limit(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_inbox", {"limit": 5})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert body["count"] == 5
 
@@ -705,9 +734,9 @@ async def test_register_tools_forwards_bearer_token_on_post(fake_listen):
 # ---------------------------------------------------------------------------
 
 
-def _err(out: "list[TextContent]") -> str | None:
+def _err(out: "list[TextContent] | CallToolResult") -> str | None:
     """Pull the ``error`` field out of a tool result, or None."""
-    body = json.loads(out[0].text)
+    body = _payload(out)
     return body.get("error") if isinstance(body, dict) else None
 
 
@@ -833,6 +862,6 @@ async def test_a2a_ack_is_suppressed_before_subscriber_check(
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_ack", {"msg_id": "orig2"})
-    body = json.loads(out[0].text)
+    body = _payload(out)
     # Assert
     assert _err(out) is None and body.get("body", {}).get("suppressed") == "empty_ack"

--- a/tests/scitex_agent_container/_runners/_tmux/test__tmux_probe_batch.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test__tmux_probe_batch.py
@@ -21,8 +21,11 @@ STX-TQ002 AAA-markers each on its own line + STX-TQ007 one-assert.
 
 from __future__ import annotations
 
+import contextlib
+import os
 import shutil
 import subprocess
+import uuid
 
 import pytest
 
@@ -32,23 +35,52 @@ pytestmark = pytest.mark.skipif(
     shutil.which("tmux") is None, reason="tmux is not installed on this host"
 )
 
-# Private socket so the tests can never touch the operator's real tmux
-# server (which carries the live fleet's `tui-<agent>` sessions).
-SOCKET = "sac-probe-tests"
+# A tmux socket is keyed by (user, socket-NAME), never by process — so a LITERAL
+# name is a HOST-GLOBAL namespace shared with everything else running as us. Two
+# things live there. The obvious one is the operator's real fleet (the live
+# `tui-<agent>` sessions), which is why this socket is separate at all. The one
+# that bit us is our own sibling CI legs: the three matrix legs run CONCURRENTLY
+# as one user on ONE Spartan node (runners -01/-02/-03 are three registrations
+# of the same machine — the v0.21.16 release started all three at 23:24:23 and
+# overlapped them for seven minutes). A literal name put all three on a SINGLE
+# tmux server where they killed each other's sessions, and the two tests below
+# that assert an EXACT count ({} and len == 30) lost that race and failed the
+# release. The four that assert membership could not see it.
+#
+# This is the same dead invariant `.github/ci/exec-in-sif.sh` already documents:
+# "runs here are serialised (one job at a time)" stopped being true the day -02
+# and -03 were registered. That file removed its own dependence on it; nobody
+# grepped for the others, and this was one.
+#
+# Unique per PROCESS, so concurrent legs (and xdist workers) cannot meet. Orphan
+# servers self-reap: every session below runs `sleep`, and tmux exits with its
+# last session.
+SOCKET = f"sac-probe-tests-{os.getpid()}-{uuid.uuid4().hex[:8]}"
 
 
 def _tmux(*args: str) -> subprocess.CompletedProcess:
+    # 30s, not 10s. Three CI legs now share one node, so a `tmux` spawn competes
+    # for a loaded box's CPU; a deadline tight enough to blow under that load is
+    # a race, and blowing it here raises inside the FIXTURE — which reports as a
+    # broken test rather than a busy host. Observed once locally at load ~65.
     return subprocess.run(
-        ["tmux", "-L", SOCKET, *args], capture_output=True, text=True, timeout=10
+        ["tmux", "-L", SOCKET, *args], capture_output=True, text=True, timeout=30
     )
 
 
 @pytest.fixture()
 def tmux_server():
-    """A real, isolated tmux server; killed on teardown."""
+    """A real tmux server on a socket only this process can name."""
+    # SOCKET is per-process, so the tests in one process share a server: this
+    # kill is what isolates each test from the last one's sessions. It is NOT
+    # vestigial — dropping it lets test N inherit test N-1's fleet.
     _tmux("kill-server")
     yield _tmux
-    _tmux("kill-server")
+    # Teardown. A reap that cannot finish is not a test failure: the socket name
+    # is unique, so nothing else can collide with a leftover, and it self-reaps
+    # anyway (every session here runs `sleep`; tmux exits with its last one).
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        _tmux("kill-server")
 
 
 def _probe_on_socket(*, timeout_s: float = 5.0):

--- a/tests/scitex_agent_container/cli_pkg/test__listen_verbs.py
+++ b/tests/scitex_agent_container/cli_pkg/test__listen_verbs.py
@@ -1,0 +1,450 @@
+"""Tests for ``cli_pkg/_listen_verbs.py`` — ``sac listen start`` / ``stop``.
+
+``listen`` is a NOUN (a command group), exactly like ``agents`` / ``db``
+/ ``host``. Booting a daemon off the bare noun is the anti-pattern the
+scitex CLI convention names outright ("trailing noun, no action:
+never") — a typo or a stray tab-complete would start a server on 7878.
+These tests pin the explicit verbs that fix it, and the coherence of the
+full set (``start`` / ``stop`` / ``restart`` / ``status``).
+
+Bind resolution is tested from BOTH sides — on the verb
+(``sac listen start --bind …``) and on the group
+(``sac listen --bind … start``) — because ``restart``/``status`` read
+the group's stash while an operator's fingers reach for the verb.
+
+No-mocks discipline (PA-306): ``_swap_attr`` / ``_swap_module`` are
+hand-rolled save-and-restore context managers — no ``unittest.mock``, no
+``MagicMock``, no ``monkeypatch``. ``uvicorn`` is replaced with a real
+callable-bearing object so the production call site executes real
+attribute lookups.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import json as _json
+import sys as _sys
+import types as _types
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.listen_cmds import listen
+
+# ---------------------------------------------------------------------------
+# Hand-rolled save/restore seams (PA-306 — no monkeypatch, no mock).
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _swap_attr(obj, name: str, value) -> Iterator[None]:
+    """Replace ``obj.<name>`` with ``value`` for the block; restore after."""
+    saved = getattr(obj, name)
+    setattr(obj, name, value)
+    try:
+        yield
+    finally:
+        setattr(obj, name, saved)
+
+
+@contextmanager
+def _swap_module(name: str, fake) -> Iterator[None]:
+    """Inject ``fake`` at ``sys.modules[name]``; restore the prior entry."""
+    saved = _sys.modules.get(name)
+    _sys.modules[name] = fake
+    try:
+        yield
+    finally:
+        if saved is None:
+            _sys.modules.pop(name, None)
+        else:
+            _sys.modules[name] = saved
+
+
+class _FakeUvicorn:
+    """Real callable-bearing stand-in for the ``uvicorn`` module.
+
+    Records the ``host``/``port`` the production code binds to. Mirrors
+    the explicit ``Config`` + ``Server`` + ``server.run()`` shape the
+    production boot path uses.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        _calls = self.calls
+
+        class Config:
+            def __init__(self, app, host, port, **_kw) -> None:
+                self.app = app
+                self.host = host
+                self.port = port
+
+        class Server:
+            def __init__(self, config) -> None:
+                self.config = config
+                self.should_exit = False
+                self.started = False
+
+            def run(self) -> None:
+                _calls.append({"host": self.config.host, "port": self.config.port})
+
+        self.Config = Config
+        self.Server = Server
+
+
+def _fake_app():
+    """Stand-in for the Starlette app ``create_app`` returns."""
+    return _types.SimpleNamespace(state=_types.SimpleNamespace())
+
+
+@contextmanager
+def _boot_harness(tmp_path) -> Iterator[_FakeUvicorn]:
+    """Hermetic ``start``-path harness: no real flock, port, or bind.
+
+    ``_do_start_listen`` routes the lock through ``_standby.resolve_startup``
+    (hot-standby + failover), whose real path takes the flock at the
+    operator's ``default_lock_dir()`` AND socket-probes the real port — so a
+    CLI start test on a host with a live ``sac listen`` would otherwise stand
+    by forever or probe the LIVE 7878 control plane. Swapping it out keeps
+    these tests hermetic, fast, and incapable of touching the real daemon.
+    """
+    from pathlib import Path as _Path
+
+    from scitex_agent_container._listen import _single_instance, _standby
+    from scitex_agent_container._listen import server as _server
+    from scitex_agent_container._listen import tokens as _tokens
+    from scitex_agent_container._listen._single_instance import LockHandle
+
+    fake_handle = LockHandle(fd=-1, pid_file=_Path("/nonexistent/listen-7878.pid"))
+    fake_uvicorn = _FakeUvicorn()
+
+    @contextmanager
+    def _noop_guard() -> Iterator[None]:
+        yield
+
+    with (
+        _swap_attr(_standby, "resolve_startup", lambda **_kw: fake_handle),
+        _swap_attr(_standby, "standby_signal_guard", _noop_guard),
+        # The throwaway fd=-1 handle must never reach the real releaser
+        # (fcntl rejects a negative fd with ValueError).
+        _swap_attr(_single_instance, "release_listen_lock", lambda _h: None),
+        _swap_attr(_tokens, "ensure_token", lambda _p: "tok"),
+        _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        yield fake_uvicorn
+
+
+class _StopRecorder:
+    """Hand-rolled stand-in for ``_stop.stop_listen``.
+
+    Records the kwargs the CLI passes and returns a REAL ``StopResult``
+    so the production render path executes real attribute lookups.
+    """
+
+    def __init__(self, **result_fields) -> None:
+        from scitex_agent_container._listen._stop import StopResult
+
+        self.calls: list[dict] = []
+        defaults = {
+            "ok": True,
+            "escalated_to_sigkill": False,
+            "had_prior_pidfile": True,
+            "prior_pid_alive": True,
+            "prior_pid": 4242,
+        }
+        defaults.update(result_fields)
+        self._result = StopResult(**defaults)
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._result
+
+
+@contextmanager
+def _stop_harness(tmp_path, recorder: _StopRecorder) -> Iterator[None]:
+    """Point ``sac listen stop`` at ``recorder`` and a throwaway lock dir."""
+    from scitex_agent_container._listen import _single_instance, _stop
+
+    with (
+        _swap_attr(_stop, "stop_listen", recorder),
+        _swap_attr(_single_instance, "default_lock_dir", lambda: tmp_path / "locks"),
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# The verb set — `listen` is a noun; these four are its whole lifecycle.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "verb",
+    [
+        pytest.param("start", id="start-boots-the-daemon"),
+        pytest.param("stop", id="stop-halts-the-daemon"),
+        pytest.param("restart", id="restart-stop-clean-relaunch"),
+        pytest.param("status", id="status-health-report"),
+    ],
+)
+def test_listen_group_exposes_lifecycle_verb(verb: str) -> None:
+    # Arrange — verb provided by parametrize.
+    group = listen
+    # Act
+    registered = group.commands
+    # Assert
+    assert verb in registered
+
+
+# ---------------------------------------------------------------------------
+# `sac listen start` — the explicit boot verb.
+# ---------------------------------------------------------------------------
+
+
+def test_listen_start_verb_boots_uvicorn_on_default_bind(tmp_path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path) as fake_uvicorn:
+        runner.invoke(listen, ["start"])
+    # Assert
+    assert fake_uvicorn.calls == [{"host": "127.0.0.1", "port": 7878}]
+
+
+def test_listen_start_verb_exits_zero_on_clean_shutdown(tmp_path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path):
+        result = runner.invoke(listen, ["start"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_listen_start_accepts_bind_option_on_the_verb(tmp_path) -> None:
+    """`sac listen start --bind …` — where an operator's fingers go."""
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path) as fake_uvicorn:
+        runner.invoke(listen, ["start", "--bind", "127.0.0.1:7999"])
+    # Assert
+    assert fake_uvicorn.calls == [{"host": "127.0.0.1", "port": 7999}]
+
+
+def test_listen_start_accepts_bind_option_on_the_group(tmp_path) -> None:
+    """`sac listen --bind … start` — the form `restart`/`status` already use."""
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path) as fake_uvicorn:
+        runner.invoke(listen, ["--bind", "127.0.0.1:7999", "start"])
+    # Assert
+    assert fake_uvicorn.calls == [{"host": "127.0.0.1", "port": 7999}]
+
+
+def test_listen_start_verb_emits_no_deprecation_warning(tmp_path) -> None:
+    """The whole point of the verb: it is the NON-deprecated form."""
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path):
+        result = runner.invoke(listen, ["start"])
+    # Assert
+    assert "DEPRECATED" not in result.output.upper()
+
+
+def test_listen_start_print_token_writes_token_to_stdout(tmp_path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path):
+        result = runner.invoke(listen, ["start", "--print-token"])
+    # Assert
+    assert "tok" in result.output
+
+
+def test_listen_start_print_token_does_not_boot_uvicorn(tmp_path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path) as fake_uvicorn:
+        runner.invoke(listen, ["start", "--print-token"])
+    # Assert
+    assert fake_uvicorn.calls == []
+
+
+def test_listen_start_non_loopback_bind_without_flag_exits_non_zero(
+    tmp_path,
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path):
+        result = runner.invoke(listen, ["start", "--bind", "8.8.8.8:7878"])
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_listen_start_non_loopback_bind_with_flag_passes_host_to_uvicorn(
+    tmp_path,
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _boot_harness(tmp_path) as fake_uvicorn:
+        runner.invoke(
+            listen, ["start", "--bind", "8.8.8.8:7878", "--allow-non-loopback"]
+        )
+    # Assert
+    assert fake_uvicorn.calls == [{"host": "8.8.8.8", "port": 7878}]
+
+
+# ---------------------------------------------------------------------------
+# `sac listen stop` — the verb that did not exist.
+# ---------------------------------------------------------------------------
+
+
+def test_listen_stop_verb_exits_zero_after_stopping_daemon(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder()
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_listen_stop_verb_reports_the_stopped_pid(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder(prior_pid=4242)
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert "4242" in result.output
+
+
+def test_listen_stop_on_dead_daemon_exits_zero_idempotently(tmp_path) -> None:
+    """`systemctl stop` contract: stopping a down daemon is SUCCESS."""
+    # Arrange
+    recorder = _StopRecorder(
+        had_prior_pidfile=False, prior_pid_alive=False, prior_pid=None
+    )
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_listen_stop_on_dead_daemon_says_it_was_not_running(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder(
+        had_prior_pidfile=False, prior_pid_alive=False, prior_pid=None
+    )
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert "not running" in result.output.lower()
+
+
+def test_listen_stop_exits_non_zero_when_stop_fails(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder(ok=False, error="ERROR: PID 4242 survived SIGKILL")
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_listen_stop_failure_surfaces_the_real_cause(tmp_path) -> None:
+    """FAIL LOUD: the error names the REAL cause, not 'did not respond'."""
+    # Arrange
+    recorder = _StopRecorder(ok=False, error="ERROR: PID 4242 survived SIGKILL")
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert "survived SIGKILL" in result.output
+
+
+def test_listen_stop_forwards_force_flag_to_stop_listen(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder()
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        CliRunner().invoke(listen, ["stop", "--force"])
+    # Assert
+    assert recorder.calls[0]["force"] is True
+
+
+def test_listen_stop_forwards_grace_secs_to_stop_listen(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder()
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        CliRunner().invoke(listen, ["stop", "--grace-secs", "30"])
+    # Assert
+    assert recorder.calls[0]["grace_secs"] == 30.0
+
+
+def test_listen_stop_resolves_port_from_the_group_bind(tmp_path) -> None:
+    """`sac listen stop` stops the daemon `sac listen start` would start."""
+    # Arrange
+    recorder = _StopRecorder()
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        CliRunner().invoke(listen, ["--bind", "127.0.0.1:7999", "stop"])
+    # Assert
+    assert recorder.calls[0]["port"] == 7999
+
+
+def test_listen_stop_json_emits_parseable_envelope_on_stdout(tmp_path) -> None:
+    """§8: `cmd --json | jq` must work with zero log contamination."""
+    # Arrange
+    recorder = _StopRecorder(prior_pid=4242)
+    runner = CliRunner()
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = runner.invoke(listen, ["stop", "--json"])
+    # Assert
+    assert _json.loads(result.stdout)["prior_pid"] == 4242
+
+
+def test_listen_stop_json_envelope_reports_ok_flag(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder()
+    runner = CliRunner()
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = runner.invoke(listen, ["stop", "--json"])
+    # Assert
+    assert _json.loads(result.stdout)["ok"] is True
+
+
+def test_listen_stop_warns_loudly_on_sigkill_escalation(tmp_path) -> None:
+    # Arrange
+    recorder = _StopRecorder(escalated_to_sigkill=True)
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert "SIGKILL" in result.output
+
+
+def test_listen_stop_surfaces_force_killed_wedged_port_holder(tmp_path) -> None:
+    """Paper trail for the codified pkill (the 'curl hangs forever' case)."""
+    # Arrange
+    recorder = _StopRecorder(port_holders_killed=(9191,))
+    # Act
+    with _stop_harness(tmp_path, recorder):
+        result = CliRunner().invoke(listen, ["stop"])
+    # Assert
+    assert "9191" in result.output

--- a/tests/scitex_agent_container/cli_pkg/test_listen_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_listen_cmds.py
@@ -349,3 +349,143 @@ def test_listen_non_loopback_bind_with_allow_flag_passes_host_to_uvicorn(tmp_pat
         CliRunner().invoke(listen, ["--bind", "8.8.8.8:7878", "--allow-non-loopback"])
     # Assert
     assert fake_uvicorn.calls == [{"host": "8.8.8.8", "port": 7878}]
+
+
+# ---------------------------------------------------------------------------
+# Bare-boot deprecation (phase W: warn + FORWARD).
+#
+# `listen` is a NOUN, so booting a daemon off the bare noun is a footgun —
+# but the bare form MUST keep working until every launcher has migrated to
+# `sac listen start`. Three of them still invoke it bare TODAY:
+#
+#   1. scripts/systemd/sac-listen.service  -> ExecStart=/usr/bin/env sac listen
+#   2. _listen/_restart.py                 -> [sac_binary(), "listen"] respawn
+#   3. PR #543's systemd JobSpec           -> command="sac listen"
+#
+# `sac listen` IS the host control plane on 127.0.0.1:7878; the whole fleet
+# loses host access when it is down. Flipping the bare form to show-help
+# would take it offline. So: warn, never break. The first test below is the
+# regression guard that keeps it that way.
+# ---------------------------------------------------------------------------
+
+
+def test_bare_listen_still_boots_the_daemon_for_launcher_compat(tmp_path):
+    """HARD COUPLING: the systemd unit + `_restart` respawn invoke this bare."""
+    # Arrange
+    from scitex_agent_container._listen import server as _server
+    from scitex_agent_container._listen import tokens as _tokens
+
+    fake_uvicorn = _FakeUvicorn()
+    # Act
+    with (
+        _swap_standby_serves(),
+        _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
+        _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        CliRunner().invoke(listen, [])
+    # Assert
+    assert fake_uvicorn.calls == [{"host": "127.0.0.1", "port": 7878}]
+
+
+def test_bare_listen_boot_warns_that_it_is_deprecated(tmp_path):
+    # Arrange
+    from scitex_agent_container._listen import server as _server
+    from scitex_agent_container._listen import tokens as _tokens
+
+    fake_uvicorn = _FakeUvicorn()
+    # Act
+    with (
+        _swap_standby_serves(),
+        _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
+        _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        result = CliRunner().invoke(listen, [])
+    # Assert
+    assert "DEPRECATED" in result.output.upper()
+
+
+def test_bare_listen_boot_warning_names_the_start_verb(tmp_path):
+    """A deprecation that doesn't name the replacement is just noise."""
+    # Arrange
+    from scitex_agent_container._listen import server as _server
+    from scitex_agent_container._listen import tokens as _tokens
+
+    fake_uvicorn = _FakeUvicorn()
+    # Act
+    with (
+        _swap_standby_serves(),
+        _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
+        _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        result = CliRunner().invoke(listen, [])
+    # Assert
+    assert "sac listen start" in result.output
+
+
+def test_bare_listen_boot_warning_names_the_removal_version(tmp_path):
+    """CLI convention §5: every phase names the removal version."""
+    # Arrange
+    from scitex_agent_container._listen import server as _server
+    from scitex_agent_container._listen import tokens as _tokens
+    from scitex_agent_container.cli_pkg.listen_cmds import (
+        BARE_BOOT_REMOVAL_VERSION,
+    )
+
+    fake_uvicorn = _FakeUvicorn()
+    # Act
+    with (
+        _swap_standby_serves(),
+        _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
+        _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        result = CliRunner().invoke(listen, [])
+    # Assert
+    assert BARE_BOOT_REMOVAL_VERSION in result.output
+
+
+def test_bare_listen_boot_warning_goes_to_stderr_not_stdout(tmp_path):
+    """§8: warnings are stderr. `sac listen --print-token` must stay pipeable."""
+    # Arrange
+    from scitex_agent_container._listen import server as _server
+    from scitex_agent_container._listen import tokens as _tokens
+
+    fake_uvicorn = _FakeUvicorn()
+    runner = CliRunner()
+    # Act
+    with (
+        _swap_standby_serves(),
+        _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
+        _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        result = runner.invoke(listen, [])
+    # Assert
+    assert "DEPRECATED" not in result.stdout.upper()
+
+
+def test_listen_print_token_emits_no_boot_deprecation_warning(tmp_path):
+    """`--print-token` never boots, so the boot-deprecation must not fire."""
+    # Arrange
+    from scitex_agent_container._listen import tokens as _tokens
+
+    tok = tmp_path / "tok.txt"
+    fake_uvicorn = _FakeUvicorn()
+    # Act
+    with (
+        _swap_attr(_tokens, "ensure_token", lambda p: "secret-token-abc"),
+        _swap_module("uvicorn", fake_uvicorn),
+    ):
+        result = CliRunner().invoke(
+            listen, ["--print-token", "--token-file", str(tok)]
+        )
+    # Assert
+    assert "DEPRECATED" not in result.output.upper()

--- a/tests/scitex_agent_container/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/test__jobs_plugin.py
@@ -1,9 +1,16 @@
 """Tests for the ``scitex_dev.jobs`` provider (``_jobs_plugin``).
 
-Verifies the JobSpec sac registers under the ``scitex_dev.jobs``
-entry-point group matches the federated contract: a single
-``sac.accounts-refresh`` systemd job that runs
-``--all --include-active --sync-active-login`` every 2h.
+Verifies the JobSpecs sac registers under the ``scitex_dev.jobs``
+entry-point group match the federated contract:
+
+* ``sac.accounts-refresh`` — a periodic systemd timer job that runs
+  ``--all --include-active --sync-active-login`` every 2h (the SOLE
+  refresher; see the ``--skip-active`` note below).
+* ``sac.listen`` — a long-running systemd service job (the host
+  control-plane daemon), auto-started on boot and auto-restarted on
+  ANY exit (``restart_policy="always"``), registered so the host no
+  longer needs a cron-based watchdog
+  (clew incident ``clew-incident-sac-host-listen-down``, 2026-07-05).
 
 Skipped cleanly if the installed scitex-dev predates ``scitex_dev.jobs``
 (PyPI lag) — the entry-point registration is install-time metadata and
@@ -22,26 +29,31 @@ jobs_mod = pytest.importorskip(
 from scitex_agent_container._jobs_plugin import provide_jobs  # noqa: E402
 
 
-def test_provider_returns_single_job() -> None:
+def _job(name: str):
+    (match,) = [j for j in provide_jobs() if j.name == name]
+    return match
+
+
+def test_provider_returns_two_jobs() -> None:
     # Arrange — call the registered provider.
     # Act
     jobs = provide_jobs()
     # Assert
-    assert len(jobs) == 1
+    assert len(jobs) == 2
 
 
-def test_provider_job_is_real_jobspec() -> None:
+def test_provider_jobs_are_real_jobspecs() -> None:
     # Arrange — call the registered provider.
     # Act
-    job = provide_jobs()[0]
-    # Assert — it is the canonical contract type, not a look-alike.
-    assert isinstance(job, jobs_mod.JobSpec)
+    jobs = provide_jobs()
+    # Assert — every entry is the canonical contract type, not a look-alike.
+    assert all(isinstance(job, jobs_mod.JobSpec) for job in jobs)
 
 
 def test_provider_job_name_is_package_prefixed() -> None:
     # Arrange — call the registered provider.
     # Act
-    job = provide_jobs()[0]
+    job = _job("sac.accounts-refresh")
     # Assert
     assert job.name == "sac.accounts-refresh"
 
@@ -55,8 +67,10 @@ def test_provider_job_command_includes_active_account() -> None:
     # refresher: skipping the active account starved the one account the
     # whole fleet uses until its ~8h access_token expired (2026-07-09/10
     # total stall). Do NOT revert to --skip-active.
-    # Act
-    job = provide_jobs()[0]
+    # Act — by NAME, not by index: this provider now returns two jobs, so
+    # provide_jobs()[0] would silently start asserting against the wrong
+    # JobSpec the day the list order changes.
+    job = _job("sac.accounts-refresh")
     # Assert
     assert job.command == (
         "sac accounts refresh --all --include-active --sync-active-login"
@@ -67,7 +81,7 @@ def test_provider_job_command_never_skips_active() -> None:
     # Arrange — a belt-and-braces guard: --skip-active must never
     # reappear in the sole-refresher timer, however the command is spelled.
     # Act
-    job = provide_jobs()[0]
+    job = _job("sac.accounts-refresh")
     # Assert
     assert "--skip-active" not in job.command
 
@@ -79,7 +93,7 @@ def test_provider_job_kind_is_timer() -> None:
     # systemd --user timer (token TTL ~7h, refresh every 2h) so the
     # canonical kind is ``"timer"`` (lead msg c5212862, 2026-06-11).
     # Act
-    job = provide_jobs()[0]
+    job = _job("sac.accounts-refresh")
     # Assert
     assert job.kind == "timer"
 
@@ -97,6 +111,54 @@ def test_every_provided_job_uses_an_allowed_kind() -> None:
 def test_provider_job_cadence_is_two_hours() -> None:
     # Arrange — call the registered provider.
     # Act
-    job = provide_jobs()[0]
+    job = _job("sac.accounts-refresh")
     # Assert
     assert job.on_unit_active_sec == "2h"
+
+
+def test_provider_listen_job_is_a_service() -> None:
+    # Arrange — call the registered provider.
+    # Act
+    job = _job("sac.listen")
+    # Assert — long-running control-plane daemon, not scheduled.
+    assert job.kind == "service"
+
+
+def test_provider_listen_job_has_no_schedule() -> None:
+    # Arrange — call the registered provider. kind="service" requires
+    # schedule=="" (services aren't scheduled — they run continuously).
+    # Act
+    job = _job("sac.listen")
+    # Assert
+    assert job.schedule == ""
+
+
+def test_provider_listen_job_command() -> None:
+    # Arrange — call the registered provider. Confirmed (task brief,
+    # 2026-07-05): SAC_LISTEN_BEARER self-resolves from the on-disk
+    # token file when unset (PR #470), so a bare command suffices.
+    # Act
+    job = _job("sac.listen")
+    # Assert
+    assert job.command == "sac listen"
+
+
+def test_provider_listen_job_restarts_always() -> None:
+    # Arrange — call the registered provider. "always" (not
+    # "on-failure") matches the incident-hardened hand-maintained unit
+    # (scripts/systemd/sac-listen.service, incident 2026-06-26): a
+    # clean 0-exit must still trigger a restart.
+    # Act
+    job = _job("sac.listen")
+    # Assert
+    assert job.restart_policy == "always"
+
+
+def test_provider_listen_job_has_no_watchdog() -> None:
+    # Arrange — call the registered provider. sac listen never calls
+    # sd_notify(WATCHDOG=1), so requesting a watchdog would cause
+    # systemd to kill-and-restart it every interval.
+    # Act
+    job = _job("sac.listen")
+    # Assert
+    assert job.watchdog_sec is None


### PR DESCRIPTION
v0.21.15 and v0.21.16 are both tagged and UNPUBLISHED. PyPI has been on 0.21.14 for three tags. This carries #667 (the CI tmux-socket collision that killed the v0.21.16 release run), #666 (account picker binned ~10% of every 7d window), #543 (sac listen is finally supervised). Verify on PyPI, not on the tag.