### PR TITLE
fix(jobs): DON'T federate sac.listen — it installs a SECOND supervisor and the fleet loses

### DIFF
--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -23,11 +23,22 @@ broker, lead inbox. Before this unit landed, the listen was
 operator-started ad-hoc and could be found DOWN with nothing
 restarting it.
 
-> **Also federated as `sac.listen`** (2026-07-05, clew incident
-> `clew-incident-sac-host-listen-down`): sac's `provide_jobs()`
-> (`src/scitex_agent_container/_jobs_plugin.py`) registers a
-> `kind="service"` JobSpec for the same daemon, supervised via
-> **`scitex-dev service ensure sac.listen`**.
+> **THE HOST HAS ALREADY PICKED: this hand-maintained unit.** It was
+> installed 2026-07-05 14:38 (`Restart=always`) and has supervised the
+> daemon ever since — `NRestarts=0`. **Do NOT run
+> `scitex-dev service ensure sac.listen`.** It does not adopt this unit:
+> scitex-dev derives the unit name from the job name VERBATIM, so it
+> installs a SECOND unit, `sac.listen.service` (a DOT), beside the
+> `sac-listen.service` (a HYPHEN) already running. systemd treats them as
+> unrelated, and you get exactly the double-unit fight this file warns
+> about below — with every lost round destroying the in-memory Broker and
+> deafening every agent's inbox.
+>
+> The `sac.listen` JobSpec was therefore REMOVED from `provide_jobs()`
+> (a test now pins its absence). PR #543 added it on the premise that
+> listen "had NO SUPERVISOR" — false: this unit was created the same day
+> that PR was opened, and the PR then sat 9 days and merged unre-checked.
+> Read the rest of this section before re-federating anything.
 >
 > That verb resolves the name from the `scitex_dev.jobs` federation and
 > then — in ONE idempotent step — writes the `.service` unit,

--- a/src/scitex_agent_container/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs_plugin.py
@@ -21,15 +21,38 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 def provide_jobs() -> "list[JobSpec]":
     """Return sac's federated scheduled jobs.
 
-    Two jobs today:
+    One job today:
 
     * ``sac.accounts-refresh`` (``kind="timer"``) — a headless OAuth
       access-token refresh for EVERY stored Claude account, including the
       active one (``--include-active``), mirroring the rotated token back
       into the live ``~/.claude`` login (``--sync-active-login``).
-    * ``sac.listen`` (``kind="service"``) — the host-level HTTP/JSON
-      control plane (``127.0.0.1:7878``: push hub, spawn broker, lead
-      inbox).
+
+    ``sac listen`` is DELIBERATELY NOT declared here, and adding it back
+    would take the fleet's control plane down. scitex-dev derives a unit
+    name from the job name VERBATIM (``scitex-todo.dashboard`` ->
+    ``scitex-todo.dashboard.service``), so a ``sac.listen`` JobSpec
+    materialises ``sac.listen.service`` — while the listen that actually
+    runs on the host is ``sac-listen.service`` (a HYPHEN), hand-written
+    2026-07-05 14:38, ``Restart=always``, with ``10-venv-path`` and
+    ``20-hardening`` drop-ins. The two names differ by one character and
+    systemd treats them as unrelated units, so ``scitex-dev service ensure
+    sac.listen`` does not adopt the running supervisor — it installs a
+    SECOND one. Two units, both ``Restart=always``, both running
+    ``sac listen``, both binding 127.0.0.1:7878: they fight for the port
+    forever, and every lost round destroys the in-memory Broker, which
+    deafens EVERY agent's inbox at once.
+
+    PR #543 declared it on the premise that ``sac listen`` "had NO
+    SUPERVISOR". That premise was false by the time it merged — the
+    hand-written unit was created the SAME DAY the PR was opened, and had
+    been supervising listen for nine days (``NRestarts=0``). The PR was
+    obsolete on arrival and nobody re-checked before merging it.
+
+    If this is ever federated, it must be named ``sac-listen`` (hyphen) so
+    the derived unit is the one that already exists — and even then,
+    ``ensure`` must be shown to ADOPT the running unit rather than
+    overwrite its drop-ins. Do not re-add it without measuring that.
 
     Why ``sac.accounts-refresh`` is not ``--skip-active``: under the
     pre-2026-07-08 two-refresher model both the host timer and the
@@ -43,15 +66,12 @@ def provide_jobs() -> "list[JobSpec]":
     ``--sync-active-login`` keeps the operator's live session valid across
     the single-use refresh_token rotation.
 
-    Why ``sac.listen`` is federated here: it had NO SUPERVISOR. Declaring
-    it as a ``kind="service"`` JobSpec hands it to scitex-dev's supervisor
-    (``scitex-dev service ensure sac.listen`` — systemd ``--user`` with
-    ``Restart=`` where a user manager is reachable, else a respawn-loop
-    keep-alive), so it auto-starts on boot and comes back on ANY exit.
-    This replaces the fragile cron-based watchdog (``sac-listen-watch.sh``,
-    ``*/2`` cron) that died twice on 2026-07-05 (clew incident
-    ``clew-incident-sac-host-listen-down``) and left the whole fleet cut
-    off from the host after a CLEAN shutdown that nothing restarted.
+    The clew incident (``clew-incident-sac-host-listen-down``, 2026-07-05)
+    that motivated federating listen was ALREADY fixed on the day it
+    happened, by the hand-written ``sac-listen.service`` above — not by a
+    JobSpec. The fragile ``sac-listen-watch.sh`` ``*/2`` cron it replaced
+    is gone. Re-federating it does not fix that incident again; it only
+    adds a second supervisor to fight the first.
     """
     from scitex_dev.jobs import JobSpec
 
@@ -82,40 +102,6 @@ def provide_jobs() -> "list[JobSpec]":
             on_boot_sec="15min",
             on_unit_active_sec="2h",
             timeout_sec=120,
-        ),
-        JobSpec(
-            name="sac.listen",
-            kind="service",
-            schedule="",
-            command="sac listen",
-            description=(
-                "Host-level HTTP/JSON control plane for sac agents "
-                "(loopback 127.0.0.1:7878) — push hub, spawn broker, lead "
-                "inbox. No env vars required: SAC_LISTEN_BEARER "
-                "self-resolves from the on-disk token file "
-                "(~/.scitex/agent-container/tokens/listen-<host>.token) "
-                "when unset (PR #470)."
-            ),
-            # restart_policy="always", NOT "on-failure": Incident
-            # 2026-06-26 (scripts/systemd/sac-listen.service) found that
-            # a clean 0-exit (e.g. an unexpected SIGTERM that uvicorn
-            # turns into a graceful shutdown) is NOT covered by
-            # Restart=on-failure, and that is exactly how the fleet lost
-            # a2a comms silently with nothing restarting the listen.
-            # "always" covers every non-`systemctl stop` exit; JobSpec's
-            # ALLOWED_RESTART_POLICIES includes "always" for kind=
-            # "service" specifically for this reason.
-            restart_policy="always",
-            timeout_sec=30,
-            # No watchdog_sec: sac listen is a plain Type=simple daemon
-            # that does not call sd_notify(WATCHDOG=1), so requesting a
-            # watchdog here would just cause systemd to kill-and-restart
-            # it every interval (see JobSpec.watchdog_sec docstring).
-            # Wedge (hang, not crash) detection is instead covered by the
-            # hand-maintained companion
-            # scripts/systemd/sac-listen-health.{service,timer} probe,
-            # which this JobSpec does NOT replace — see
-            # scripts/systemd/README.md for the coexistence note.
         ),
     ]
 

--- a/tests/scitex_agent_container/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/test__jobs_plugin.py
@@ -6,11 +6,14 @@ entry-point group match the federated contract:
 * ``sac.accounts-refresh`` — a periodic systemd timer job that runs
   ``--all --include-active --sync-active-login`` every 2h (the SOLE
   refresher; see the ``--skip-active`` note below).
-* ``sac.listen`` — a long-running systemd service job (the host
-  control-plane daemon), auto-started on boot and auto-restarted on
-  ANY exit (``restart_policy="always"``), registered so the host no
-  longer needs a cron-based watchdog
-  (clew incident ``clew-incident-sac-host-listen-down``, 2026-07-05).
+
+``sac listen`` is deliberately NOT federated, and one test below PINS its
+absence: scitex-dev derives the unit name verbatim, so a ``sac.listen``
+JobSpec installs ``sac.listen.service`` ALONGSIDE the ``sac-listen.service``
+(hyphen) that already supervises the daemon — two units, both
+``Restart=always``, both binding 127.0.0.1:7878, fighting for the port and
+destroying the in-memory Broker (which deafens every agent's inbox) on each
+lost round. See ``_jobs_plugin.provide_jobs`` for the full reasoning.
 
 Skipped cleanly if the installed scitex-dev predates ``scitex_dev.jobs``
 (PyPI lag) — the entry-point registration is install-time metadata and
@@ -34,12 +37,13 @@ def _job(name: str):
     return match
 
 
-def test_provider_returns_two_jobs() -> None:
-    # Arrange — call the registered provider.
+def test_provider_returns_one_job() -> None:
+    # Arrange — call the registered provider. One, not two: `sac listen` is
+    # NOT federated (see the module docstring and the absence-pin below).
     # Act
     jobs = provide_jobs()
     # Assert
-    assert len(jobs) == 2
+    assert len(jobs) == 1
 
 
 def test_provider_jobs_are_real_jobspecs() -> None:
@@ -116,49 +120,25 @@ def test_provider_job_cadence_is_two_hours() -> None:
     assert job.on_unit_active_sec == "2h"
 
 
-def test_provider_listen_job_is_a_service() -> None:
-    # Arrange — call the registered provider.
+def test_provider_does_not_federate_listen_it_would_duplicate_the_supervisor() -> None:
+    # Arrange — `sac listen` must NOT be declared as a JobSpec, and this
+    # test exists to keep it that way.
+    #
+    # scitex-dev derives the unit name from the job name VERBATIM
+    # (`scitex-todo.dashboard` -> `scitex-todo.dashboard.service`), so a
+    # `sac.listen` JobSpec materialises `sac.listen.service`. The listen
+    # that actually runs is `sac-listen.service` — a HYPHEN — hand-written
+    # 2026-07-05, Restart=always, NRestarts=0. systemd treats the two names
+    # as unrelated units, so `scitex-dev service ensure sac.listen` does not
+    # adopt the running supervisor: it installs a SECOND one. Two units,
+    # both Restart=always, both running `sac listen`, both binding
+    # 127.0.0.1:7878 — they fight for the port forever, and every lost round
+    # destroys the in-memory Broker, deafening EVERY agent's inbox at once.
+    #
+    # PR #543 declared it because listen "had NO SUPERVISOR". That premise
+    # was already false when it merged: the hand-written unit was created
+    # the same day the PR was opened and had supervised listen for 9 days.
     # Act
-    job = _job("sac.listen")
-    # Assert — long-running control-plane daemon, not scheduled.
-    assert job.kind == "service"
-
-
-def test_provider_listen_job_has_no_schedule() -> None:
-    # Arrange — call the registered provider. kind="service" requires
-    # schedule=="" (services aren't scheduled — they run continuously).
-    # Act
-    job = _job("sac.listen")
+    names = [spec.name for spec in provide_jobs()]
     # Assert
-    assert job.schedule == ""
-
-
-def test_provider_listen_job_command() -> None:
-    # Arrange — call the registered provider. Confirmed (task brief,
-    # 2026-07-05): SAC_LISTEN_BEARER self-resolves from the on-disk
-    # token file when unset (PR #470), so a bare command suffices.
-    # Act
-    job = _job("sac.listen")
-    # Assert
-    assert job.command == "sac listen"
-
-
-def test_provider_listen_job_restarts_always() -> None:
-    # Arrange — call the registered provider. "always" (not
-    # "on-failure") matches the incident-hardened hand-maintained unit
-    # (scripts/systemd/sac-listen.service, incident 2026-06-26): a
-    # clean 0-exit must still trigger a restart.
-    # Act
-    job = _job("sac.listen")
-    # Assert
-    assert job.restart_policy == "always"
-
-
-def test_provider_listen_job_has_no_watchdog() -> None:
-    # Arrange — call the registered provider. sac listen never calls
-    # sd_notify(WATCHDOG=1), so requesting a watchdog would cause
-    # systemd to kill-and-restart it every interval.
-    # Act
-    job = _job("sac.listen")
-    # Assert
-    assert job.watchdog_sec is None
+    assert "sac.listen" not in names


### PR DESCRIPTION
## PR #543's premise was false, and I repeated it without checking

It declared `sac listen` as a `kind="service"` JobSpec because listen **"had NO SUPERVISOR."** Measured on the host:

```
sac-listen.service   created 2026-07-05 14:38   Restart=always   NRestarts=0
                     MainPID == the process actually holding 127.0.0.1:7878
```

A hand-written unit has supervised listen for **nine days**, created **the same day PR #543 was opened**. The PR was obsolete on arrival, sat 9 days, and merged with nobody re-checking.

## It is not redundant — it is destructive

scitex-dev derives the unit name from the job name **verbatim** (`scitex-todo.dashboard` → `scitex-todo.dashboard.service`). So:

| declared | unit installed | |
|---|---|---|
| `sac.listen` (a **dot**) | `sac.listen.service` | ← what #543 adds |
| — | `sac-listen.service` (a **hyphen**) | ← what actually runs listen today |

systemd treats them as **unrelated units**. `scitex-dev service ensure sac.listen` does **not** adopt the running supervisor — it installs a second one. Two units, both `Restart=always`, both running `sac listen`, both binding `127.0.0.1:7878`, fighting for the port forever. And **every listen restart destroys the in-memory Broker, which deafens every agent's inbox at once** (measured independently while chasing "registered but deaf").

**The merged PR body instructs the reader to run that exact command.** I nearly ran it against the operator's control plane — minutes after he called it a life-or-death dependency.

## The README already warned about this

> *"the two are NOT meant to run simultaneously (both would try to bind `127.0.0.1:7878` … a double **unit** still fights over restarts). **Pick ONE**"*

The host picked nine days ago. It merged anyway. That is the **third** time today a change landed against a warning the codebase had already written down — #662's dead-invariant comment, the shared-executor comment that named its own outage, and now this.

## Changes

- Remove the `sac.listen` JobSpec from `provide_jobs()`.
- **Pin its absence with a test**, carrying the reason, so it cannot return by accident.
- README: state which unit the host picked, and stop handing the reader the command that arms the collision.

If listen is ever federated it must be named `sac-listen` (hyphen) so the derived unit **is** the existing one — and even then `ensure` must be *shown* to adopt the running unit rather than overwrite its `10-venv-path` / `20-hardening` drop-ins.
