### PR TITLE
fix(listen): sac listen span forever behind a holder it never really checked, and published a turn_url that could not connect

### DIFF
--- a/scripts/systemd/sac-listen.service
+++ b/scripts/systemd/sac-listen.service
@@ -57,6 +57,28 @@ StandardError=journal
 # restart can't double-bind the port; the kernel releases the flock
 # on every dirty exit, so the next start cleanly takes it.
 Restart=always
+#
+# INTERACTION WITH THE "already serving" 0-EXIT (read before changing this).
+# `sac listen` now EXITS 0 immediately when ANOTHER instance is already
+# VERIFIED SERVING on the port ("already serving: PID N ... nothing to do")
+# instead of standing by in a poll loop forever. Restart=always restarts
+# even on a 0-exit — deliberately, see above — so under this unit that
+# 0-exit IS retried. The churn is BOUNDED and self-limiting, by design:
+#   * RestartSec=5s + StartLimitBurst=5 / StartLimitIntervalSec=60s ⇒ at
+#     most 5 restarts (~25s) and then the unit parks in `failed`, which is
+#     VISIBLE (`systemctl --user status sac-listen`). It is NOT a hot loop.
+#   * The companion sac-listen-health.timer does NOT resurrect that loop:
+#     its probe is PORT-based (`curl http://127.0.0.1:7878/v1/health`), so
+#     while the foreign instance is serving, the probe is GREEN and the
+#     timer neither alarms nor restarts. Fleet comms stay up throughout.
+# In other words: a duplicate `sac listen` is a configuration problem, and
+# the unit surfaces it as `failed` while the port keeps being served. The
+# fix is to stop the foreign instance, not to make this unit spin.
+# If that `failed` state ever becomes a nuisance, the CLEAN remedy is a
+# dedicated exit code for "already serving" plus `RestartPreventExitStatus=`
+# — NOT reverting to Restart=on-failure (which would reopen the silent
+# 0-exit outage of 2026-06-26).
+#
 # Brief debounce: avoid hot-looping a launch that always fails (e.g.
 # uvicorn import error after a bad pip upgrade). 5s is the same
 # value scitex-orochi's persistent-services use.

--- a/src/scitex_agent_container/_listen/_graceful_stop.py
+++ b/src/scitex_agent_container/_listen/_graceful_stop.py
@@ -1,0 +1,79 @@
+"""SIGTERM-only stop primitive — the automatic path may ASK, never destroy.
+
+Why this exists alongside ``_restart._terminate_then_kill``
+==========================================================
+``_terminate_then_kill`` escalates SIGTERM → SIGKILL after a grace
+window. That is correct for ``sac listen restart``: an operator typed
+the command, so escalating is *sanctioned destruction*.
+
+The hot-standby loop (:mod:`._standby`) is a different animal. It acts
+on a **probe-based inference** that the holder is wedged — and a probe
+can be wrong. A 2-second health timeout under load, a momentary stall,
+a GC pause: any of these can read as "not answering". The remedy for a
+wrong verdict there is to SIGKILL a perfectly healthy control plane and
+cut the entire fleet off from the host.
+
+    A false-RED is strictly worse than a false-green: the false-green
+    merely fails to act, while the false-RED actively destroys the
+    working thing it misdiagnosed.
+
+So the automatic take-over may only ever ASK the holder to leave. If the
+holder ignores SIGTERM, the standby loop FAILS LOUD and names the one
+destructive command a HUMAN can authorise (``sac listen restart
+--force``). No SIGKILL is ever sent on the strength of a probe.
+
+Seams (``_kill`` / ``_sleep`` / ``_alive``) are module-level swappable
+callables per PA-306 / STX-NM001-003 — no MagicMock.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import time
+from typing import Callable
+
+from ._restart import pid_alive
+
+__all__ = ["DEFAULT_POLL_INTERVAL_SECS", "terminate_gracefully"]
+
+DEFAULT_POLL_INTERVAL_SECS: float = 0.2
+
+_kill: Callable[[int, int], None] = os.kill
+_sleep: Callable[[float], None] = time.sleep
+_alive: Callable[[int], bool] = pid_alive
+
+
+def terminate_gracefully(
+    pid: int,
+    *,
+    grace_secs: float,
+    poll_interval: float = DEFAULT_POLL_INTERVAL_SECS,
+) -> bool:
+    """SIGTERM ``pid``, poll for its exit, and **NEVER escalate**.
+
+    Returns ``True`` iff the process is GONE by the time we stop waiting
+    (including the case where it was already gone — that is the goal
+    state, not a failure). Returns ``False`` when it ignored SIGTERM and
+    is still alive; the caller must then surface a loud, actionable
+    failure rather than reach for SIGKILL.
+
+    Bounded by ``grace_secs`` — this must never become an unbounded wait.
+    """
+    try:
+        _kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return True  # already gone — the goal state
+    except PermissionError:
+        # Someone else's process. We cannot stop it and we must not
+        # pretend we did; the caller fails loud with the pid.
+        return False
+
+    remaining = grace_secs
+    step = poll_interval if poll_interval > 0 else DEFAULT_POLL_INTERVAL_SECS
+    while remaining > 0:
+        _sleep(step)
+        remaining -= step
+        if not _alive(pid):
+            return True
+    return not _alive(pid)

--- a/src/scitex_agent_container/_listen/_holder_health.py
+++ b/src/scitex_agent_container/_listen/_holder_health.py
@@ -1,0 +1,154 @@
+"""Three-state health verdict for the ``sac listen`` flock holder.
+
+Why three states (the false-green this closes)
+==============================================
+The standby loop used to ask ``_probe_health() -> bool``. A two-state
+predicate cannot distinguish the two things an operator MUST be able to
+tell apart:
+
+* "the holder ANSWERED ``/v1/health``"  — an OBSERVATION, and
+* "I asked and got NOTHING back"        — the ABSENCE of an observation.
+
+Collapsed into one ``False``, the second becomes indistinguishable from
+a merely-slow probe, and the loop's ``consecutive_unhealthy = 0`` reset
+then let a single lucky reply erase the record of a failed check. The
+holder was declared a ``healthy holder`` on the strength of nothing at
+all, and ``sac listen`` stood by behind it forever while the fleet was
+cut off from the host (operator incident 2026-07-14, PID 738982 on
+127.0.0.1:7878).
+
+Absence of evidence is NOT evidence of health. So the verdict is a
+THREE-state enum, and the caller must branch on the state it actually
+observed:
+
+* :attr:`HolderHealth.SERVING` — the holder answered ``/v1/health``.
+* :attr:`HolderHealth.NOT_SERVING` — the holder answered, with a 5xx.
+  It is bound and speaking HTTP but its health route is erroring. An
+  answer, but NOT health.
+* :attr:`HolderHealth.UNREACHABLE` — we asked and got nothing back
+  (connection refused / timed out / DNS). This is the "I have no
+  observation" state. It is NOT healthy, and it must never be logged
+  as one.
+
+Why 4xx still counts as SERVING
+===============================
+A 401/403 PROVES the daemon is up: it is bound, speaking HTTP, and
+auth-gating (:class:`~_listen.auth.BearerAuthMiddleware`). Card
+``sac-listen-restart-healthcheck-bearer`` (PR #463) was written because
+gating liveness on ``status == 200`` re-classified a live, 401-answering
+daemon as "down" — a false-RED that SIGKILLed a HEALTHY process. That
+lesson is load-bearing and is preserved here: a false-RED (destroying a
+working daemon) is strictly worse than a false-green, so every response
+below 500 — including a 404 from a daemon whose route table differs —
+is SERVING. Only a *server error* (5xx) or *no answer at all* counts
+against the holder.
+
+Pure + dependency-light: stdlib ``urllib`` via ``_restart``'s
+``_default_http_get``, which already returns ``-1`` for a transport
+failure and the real status for any HTTP response.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable
+
+from ._restart import HEALTH_PATH
+from ._restart import _default_http_get as _default_http_get_impl
+
+__all__ = [
+    "HEALTH_PATH",
+    "HolderHealth",
+    "HolderProbe",
+    "classify_status",
+    "probe_holder_health",
+]
+
+# The status at/above which an HTTP answer stops counting as "serving".
+# Below it (2xx/3xx/4xx) the daemon is bound and answering — see the
+# module docstring on why 401/403/404 must stay SERVING.
+_SERVER_ERROR_FLOOR = 500
+
+
+class HolderHealth(Enum):
+    """What the flock holder ACTUALLY did when asked ``/v1/health``.
+
+    Three states because two cannot express "I asked and got nothing".
+    Only :attr:`SERVING` is health; the other two are NOT, and neither
+    may ever be rendered to the operator as a "healthy holder".
+    """
+
+    SERVING = "serving"
+    NOT_SERVING = "not-serving"
+    UNREACHABLE = "unreachable"
+
+
+@dataclass(frozen=True)
+class HolderProbe:
+    """One health observation: the verdict PLUS the evidence for it.
+
+    ``status`` is the raw HTTP status the holder answered with, or
+    ``-1`` when the probe got no answer at all. It is carried so every
+    log line can state what was OBSERVED rather than assert a
+    conclusion — the whole point of this module.
+    """
+
+    health: HolderHealth
+    status: int
+
+    @property
+    def serving(self) -> bool:
+        """True ONLY when the holder answered ``/v1/health``."""
+        return self.health is HolderHealth.SERVING
+
+    def describe(self) -> str:
+        """Human-readable evidence for this verdict (for the log line)."""
+        if self.health is HolderHealth.SERVING:
+            return f"{HEALTH_PATH} answered HTTP {self.status}"
+        if self.health is HolderHealth.NOT_SERVING:
+            return (
+                f"{HEALTH_PATH} answered HTTP {self.status} "
+                f"— a server error, NOT health"
+            )
+        return (
+            f"{HEALTH_PATH} did not answer AT ALL "
+            f"(connection refused / timed out) — no evidence of health"
+        )
+
+
+def classify_status(status: int) -> HolderHealth:
+    """Map an ``_default_http_get`` status onto the three-state verdict.
+
+    ``status < 0`` is ``_default_http_get``'s transport-failure sentinel
+    (refused / timeout / DNS): we asked and got nothing ⇒ UNREACHABLE.
+    ``>= 500`` ⇒ answered-but-erroring ⇒ NOT_SERVING. Everything else
+    ⇒ SERVING (see the module docstring on 401/403/404).
+    """
+    if status < 0:
+        return HolderHealth.UNREACHABLE
+    if status >= _SERVER_ERROR_FLOOR:
+        return HolderHealth.NOT_SERVING
+    return HolderHealth.SERVING
+
+
+def probe_holder_health(
+    host: str,
+    port: int,
+    *,
+    timeout: float,
+    http_get: Callable[[str, float], int] | None = None,
+) -> HolderProbe:
+    """Ask ``http://<host>:<port>/v1/health`` and return what came back.
+
+    BOUNDED by ``timeout`` so a hung holder cannot stall the probe —
+    a probe that never returns is itself an unbounded wait, and this
+    module exists to make waiting bounded and observable.
+
+    ``http_get`` is injectable so callers/tests can drive the classifier
+    without a socket; the default is the real stdlib-``urllib`` GET.
+    """
+    url = f"http://{host}:{port}{HEALTH_PATH}"
+    get = http_get or _default_http_get_impl
+    status = int(get(url, timeout))
+    return HolderProbe(health=classify_status(status), status=status)

--- a/src/scitex_agent_container/_listen/_local_host.py
+++ b/src/scitex_agent_container/_listen/_local_host.py
@@ -1,0 +1,138 @@
+"""Resolve "does this hostname mean THIS machine?" — and if so, use loopback.
+
+The bug this closes (deterministic, 100% reproducible)
+======================================================
+:func:`~._registry_endpoints.derive_turn_url` built an agent's
+``turn_url`` as ``http://<canonical-hostname>:<port>/v1/turn``. On this
+box — and on every stock Debian / Ubuntu / WSL install — the machine's
+own hostname does NOT resolve to the loopback address that the a2a
+sidecar binds::
+
+    $ getent hosts ywata-note-win
+    127.0.1.1   ywata-note-win.localdomain ywata-note-win     <-- .1.1
+
+    a2a/_server.py:  host: str = "127.0.0.1"                  <-- .0.1
+
+    127.0.0.1:19017        -> OPEN
+    ywata-note-win:19017   -> CONNECTION REFUSED
+
+``127.0.1.1`` is a loopback address, but it is a DIFFERENT loopback
+address from the one the sidecar listens on, so every connection to the
+derived URL is refused. Not flaky — deterministic, for every local
+consumer, on every box that follows the Debian self-host convention
+(``/etc/hosts``: ``127.0.1.1  <fqdn> <hostname>``).
+
+The fix, and why NOT ``0.0.0.0``
+================================
+Two options existed: (a) derive ``127.0.0.1`` for local callers, or
+(b) rebind every agent's a2a sidecar to ``0.0.0.0``. We chose (a).
+
+Binding the sidecar to ``0.0.0.0`` would expose EVERY agent's
+``/v1/turn`` — an endpoint that injects a prompt into a live Claude
+session — on every interface of the host. sac's whole transport doctrine
+is loopback-only, with orochi's tunnel/VPN mesh as the sanctioned
+external path (SAC_OROCHI_SCOPES.md §4.4); ``sac listen`` itself refuses
+a non-loopback bind without an explicit ``--allow-non-loopback``. Fixing
+an address-derivation bug by widening a listener's exposure would trade
+a connectivity bug for a security regression. Deriving the address the
+sidecar actually binds costs nothing and changes no listener.
+
+So: a host that NAMES THIS MACHINE is normalised to ``127.0.0.1``. A
+genuinely REMOTE host keeps its name (a cross-host peer must still be
+addressed by hostname, and its URL is consumed over the tunnel mesh).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+
+__all__ = [
+    "LOOPBACK_HOST",
+    "is_local_host",
+    "local_host_aliases",
+]
+
+# The address every local a2a sidecar (a2a/_server.py) actually binds,
+# and the ONLY loopback address a derived local URL may use. NOT
+# ``localhost`` (which can resolve to ::1 first) and emphatically NOT
+# the machine's own hostname (→ 127.0.1.1 on Debian/Ubuntu/WSL).
+LOOPBACK_HOST = "127.0.0.1"
+
+# Names that mean "this machine" regardless of what the box is called.
+# A wildcard bind (``0.0.0.0`` / ``::``) is reachable ON loopback, so it
+# is normalised too.
+_ALWAYS_LOCAL = frozenset(
+    {
+        "",
+        "localhost",
+        "localhost.localdomain",
+        "0.0.0.0",
+        "::",
+    }
+)
+
+
+def local_host_aliases() -> frozenset[str]:
+    """Every name (lower-cased) that denotes THIS machine.
+
+    Sources: the always-local literals above, this host's ``gethostname``
+    (both the FQDN-ish form and its short label), and sac's own canonical
+    host from ``_state.host_config`` — the SAME name every ``state.db``
+    write stamps as self-identity, which is exactly the name that ends up
+    in an ``instances`` row's ``host`` column and therefore the name
+    ``resolve_a2a_host`` hands to ``derive_turn_url``.
+
+    Deliberately does NOT call :func:`socket.getfqdn` — that can trigger
+    a blocking reverse-DNS lookup, and nothing on the registry-response
+    path may block.
+    """
+    names: set[str] = set(_ALWAYS_LOCAL)
+
+    try:
+        hostname = socket.gethostname()
+    except OSError:  # stx-allow: fallback (reason: an unresolvable own-hostname must not break URL derivation — we simply learn no extra alias)
+        hostname = ""
+    if hostname:
+        names.add(hostname)
+        names.add(hostname.split(".", 1)[0])
+
+    try:
+        from .._state.host_config import load as load_host_config
+
+        canonical = load_host_config().canonical_host()
+    except Exception:  # stx-allow: fallback (reason: best-effort — a host_config failure must never block the /agents response; we just lose one alias)
+        canonical = ""
+    if canonical:
+        names.add(canonical)
+        names.add(canonical.split(".", 1)[0])
+
+    return frozenset(name.lower() for name in names if name is not None)
+
+
+def is_local_host(host: str | None, *, aliases: frozenset[str] | None = None) -> bool:
+    """Return ``True`` iff ``host`` names THIS machine.
+
+    True for: the always-local literals, this box's own hostname (short or
+    long), sac's canonical host — and for ANY loopback IP literal.
+
+    That last clause is the crux of the bug: ``127.0.1.1`` IS a loopback
+    address, so a naive ``host == "127.0.0.1"`` check would miss it and
+    happily emit an unreachable URL. Every address in ``127.0.0.0/8`` (and
+    ``::1``) is only reachable from this machine, so all of them are
+    "local" — and all of them must be normalised to the ONE loopback
+    address the sidecar is actually bound to.
+
+    ``aliases`` is injectable so the predicate can be exercised without
+    depending on the test runner's real hostname.
+    """
+    if host is None:
+        return False
+    candidate = host.strip().lower()
+    if candidate in (aliases if aliases is not None else local_host_aliases()):
+        return True
+    try:
+        return ipaddress.ip_address(candidate).is_loopback
+    except ValueError:
+        # Not an IP literal — it was already checked against the aliases.
+        return False

--- a/src/scitex_agent_container/_listen/_registry_endpoints.py
+++ b/src/scitex_agent_container/_listen/_registry_endpoints.py
@@ -24,6 +24,14 @@ For the host:
 2. ``host_config.load().canonical_host()`` (local fallback — what every
    other ``state.db`` write uses for self-identity).
 
+…and then, crucially, a host that names THIS MACHINE is normalised to
+``127.0.0.1`` by :func:`derive_turn_url`. Do NOT "simplify" that away:
+the canonical hostname resolves to ``127.0.1.1`` on stock Debian /
+Ubuntu / WSL while the a2a sidecar binds ``127.0.0.1``, so the
+un-normalised URL was refused for EVERY local consumer, deterministically.
+See :mod:`._local_host` for the evidence and for why we normalise the
+address rather than widen the sidecar's bind to ``0.0.0.0``.
+
 This module is pure-logic on purpose: everything that touches state.db
 is wrapped in ``try/except Exception → None`` so an unreadable registry
 NEVER blocks the ``/agents`` response. The whole point of these fields
@@ -32,6 +40,8 @@ turn_url: null`` and the caller branches accordingly.
 """
 
 from __future__ import annotations
+
+from ._local_host import LOOPBACK_HOST, is_local_host
 
 
 def _instance_endpoint(agent_name: str) -> tuple[int | None, str | None]:
@@ -115,17 +125,50 @@ def resolve_a2a_host(agent_name: str) -> str | None:
         return None
 
 
-def derive_turn_url(host: str | None, port: int | None) -> str | None:
-    """Return ``http://<host>:<port>/v1/turn`` iff both inputs are valid.
+def derive_turn_url(
+    host: str | None,
+    port: int | None,
+    *,
+    local_aliases: frozenset[str] | None = None,
+) -> str | None:
+    """Return a REACHABLE ``http://<host>:<port>/v1/turn``, or ``None``.
 
-    Pure — no I/O. ``None`` for any missing / empty input (the
-    receiving caller branches on ``turn_url is None`` to skip
-    dispatch).
+    A LOCAL host is normalised to ``127.0.0.1`` — the address the a2a
+    sidecar actually binds (``a2a/_server.py``: ``host: str =
+    "127.0.0.1"``). This is the fix for a deterministic outage: the
+    derived URL used to name the machine's own canonical hostname, which
+    on stock Debian / Ubuntu / WSL resolves to ``127.0.1.1``::
+
+        $ getent hosts ywata-note-win
+        127.0.1.1   ywata-note-win.localdomain ywata-note-win
+
+        127.0.0.1:19017        -> OPEN
+        ywata-note-win:19017   -> CONNECTION REFUSED
+
+    ``127.0.1.1`` is a loopback address, but it is a DIFFERENT loopback
+    address from the one the sidecar listens on, so EVERY connection to
+    the derived URL was refused — 100% of the time, for every local
+    consumer. See :mod:`._local_host` for why we normalise the address
+    rather than rebind the sidecar to ``0.0.0.0``.
+
+    A genuinely REMOTE host keeps its name: a cross-host peer is not on
+    our loopback, and rewriting its URL would point every cross-host
+    dispatch back at ourselves.
+
+    ``None`` for any missing / empty input (the receiving caller branches
+    on ``turn_url is None`` to skip dispatch). An unresolvable host is
+    NEVER silently promoted to loopback — that would advertise OUR
+    sidecar as somebody else's endpoint.
+
+    ``local_aliases`` is injectable so the derivation can be exercised
+    without depending on the runner's real hostname.
     """
     if not host:
         return None
     if port is None:
         return None
+    if is_local_host(host, aliases=local_aliases):
+        host = LOOPBACK_HOST
     return f"http://{host}:{port}/v1/turn"
 
 

--- a/src/scitex_agent_container/_listen/_standby.py
+++ b/src/scitex_agent_container/_listen/_standby.py
@@ -1,78 +1,97 @@
-"""Hot-standby + failover startup for ``sac listen`` (no more crash-loop).
+"""Startup decision for ``sac listen``: bind, stand down, or fail loud.
 
-Root cause this fixes (observed: ``sac-listen.service`` NRestarts
-11→34+, ~4s CPU/cycle, wedged the systemd user manager): a SECOND
-``sac listen`` launched while one already holds port 7878 used to raise
-:class:`~._single_instance.ListenAlreadyRunningError`, which
-``cli_pkg/listen_cmds.py`` turned into a ``click.ClickException`` →
-**exit 1**. Under the unit's ``Restart=always`` that relaunched → failed
-→ relaunched … an INFINITE CRASH-LOOP. The exit-1-on-contention was the
-root cause.
+``sac listen`` starting while another instance already holds port 7878 has
+exactly THREE possible answers, and this module picks one in BOUNDED time:
 
-The fix turns the second instance into a HOT STANDBY that FAILS OVER
-instead of crash-looping. On startup :func:`resolve_startup` runs a
-loop:
+1. **Nobody is holding it** (or the holder died — the kernel releases its
+   flock on death) → take the flock, heal any untracked port remnant,
+   BIND and serve.
+2. **Another instance is ALREADY SERVING** (it answers ``/v1/health``) →
+   the goal state is already true. Say so and **EXIT 0. Nothing to do.**
+3. **The holder is NOT serving** and cannot be freed → **FAIL LOUD**
+   (non-zero, naming the PID and the exact command to run).
 
-1. **Port free** (or the prior holder died — the kernel releases its
-   flock on death) → :func:`~._single_instance.acquire_listen_lock`
-   succeeds → return the handle → the caller binds + serves.
-2. **Port held** (``acquire_listen_lock`` raises because a LIVE process
-   holds the flock) → probe the holder's ``/v1/health`` (bounded):
-   a. **Healthy** → do NOT exit; STAND BY: sleep a short interval, then
-      re-check. When the holder later dies/wedges, take over → instant
-      failover. This is the redundancy: the systemd instance stays a
-      warm standby.
-   b. **Unhealthy** (bounded GET fails/times out) for
-      ``unhealthy_takeover_threshold`` consecutive cycles → the holder
-      is wedged (alive, holds the flock+port, not serving) → TAKE OVER:
-      kill the wedged holder (releases its flock) + clear any untracked
-      port remnant, then loop → re-acquire.
+There is no fourth answer. In particular there is **no "spin" answer.**
 
-**Race freedom.** The flock (``LOCK_EX | LOCK_NB``) is the ONLY gate
-before binding and is atomic: at most one process can hold it, so two
-instances can NEVER both bind. Take-over is therefore race-free —
-every path funnels back through ``acquire_listen_lock``. If several
-standbys wake on the same dead holder, each kills the (already-dead)
-PID idempotently and re-acquires; the flock hands the lock to exactly
-ONE winner, and every loser simply re-observes a healthy holder and
-returns to standby.
+Why (operator incidents, 2026-07-14)
+====================================
+This module used to run an UNBOUNDED standby loop, and it hurt twice.
 
-**Startup-window safety.** A holder that just won the flock has a brief
-window before it binds the port, during which a health probe would read
-"not serving". The consecutive-cycle ``unhealthy_takeover_threshold``
-(default 2) corroborates the wedged verdict across a standby interval
-before killing, so a legitimately-starting daemon is never taken over.
+**(a) A healthy holder made ``sac listen`` hang forever.** ::
 
-**SIGTERM stays clean.** During standby the loop is interruptible:
-:func:`standby_signal_guard` installs SIGTERM/SIGINT handlers that flip
-a flag the loop polls (``_should_stop``), so ``systemctl stop`` during
-standby returns a prompt clean exit — the wait never blocks the signal.
-The guard restores the prior handlers on exit, so once the loop wins the
-lock and returns, uvicorn installs its own graceful-shutdown handlers
-unchanged.
+    $ sac listen
+    # sac listen: standing by behind healthy holder PID 745734 on 127.0.0.1:7878
+    # sac listen: standing by behind healthy holder PID 745734 on 127.0.0.1:7878
+       ... (forever) ...
+    ^C
+    $ kill 745734          <-- the operator had to do this BY HAND
 
-No-mocks (PA-306 / STX-NM001-003): every external effect is a
-module-level seam swapped via save/restore in tests; the health probe
-runs against a real loopback socket and the lock against a real flock.
+"Someone else is already serving" is a SUCCESS, not a reason to poll every
+4 seconds until the human gives up. The spinner was the only way out, so he
+Ctrl-C'd and killed the holder manually — and every abandoned spinner left
+junk behind (two orphaned ``sac-listen`` screen sessions were found this
+way). Waiting bought nothing: a standby holds no lock and serves no request.
+And taking over a HEALTHY holder is not merely useless but harmful — a
+listen restart tears down the in-process a2a Broker and deafens EVERY
+agent's inbox at once. So: verified serving ⇒ stand down, exit 0.
+
+**(b) A DEAD holder was announced as "healthy".** ::
+
+    # sac listen: holder PID 738982 ... not answering health (1/2) — re-checking
+    # sac listen: standing by behind healthy holder PID 738982 on 127.0.0.1:7878
+    # sac listen: standing by behind healthy holder PID 738982 on 127.0.0.1:7878
+
+…while PID 738982 answered nothing and the fleet was cut off from the host.
+It SAW the failed check, then went back to calling the holder healthy. Two
+causes, both fixed:
+
+* ``consecutive_unhealthy = 0`` was wiped by ANY single lucky reply, so a
+  FLAPPING holder (the measured behaviour of the live 7878 daemon: HTTP 200
+  one minute, ``Connection refused`` the next) never accumulated the
+  CONSECUTIVE failures the threshold demanded. Now
+  :class:`~._standby_ledger.HolderLedger` keeps the record: a failure is a
+  fact, and one later success does not un-happen it.
+* The probe was ``_http_get(…) > 0``, so any HTTP status — even a 5xx —
+  read as health. Now the verdict is the three-state
+  :class:`~._holder_health.HolderHealth`; "I asked and got nothing" is a
+  state the code can express, and it is NOT health.
+
+Never destroy on a negative signal
+==================================
+A take-over ASKS (SIGTERM, via :func:`._graceful_stop.terminate_gracefully`)
+and never escalates. A probe-based "wedged" verdict can be wrong, and the
+remedy for a wrong one is to SIGKILL a healthy control plane — a false-RED
+is strictly worse than a false-green. A holder that ignores SIGTERM is
+handed to the operator with the one destructive command they can authorise
+(``sac listen restart --force``). The take-over also never unlinks a LIVE
+holder's pidfile: a racing standby holding an flock on the old inode plus a
+fresh acquirer creating a new one would BOTH think they held the lock.
+
+The flock (``LOCK_EX | LOCK_NB``) remains the atomic bind arbiter, so two
+instances can never both bind, no matter how many start at once.
+
+No-mocks (PA-306 / STX-NM001-003): every external effect is a module-level
+seam swapped via save/restore in tests; the health probe runs against a real
+loopback socket and the lock against a real flock.
 """
 
 from __future__ import annotations
 
-import signal
 import sys
 import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Callable, Iterator
 
+from ._graceful_stop import terminate_gracefully as _terminate_graceful_impl
+from ._holder_health import HEALTH_PATH, HolderProbe
+from ._holder_health import probe_holder_health as _probe_health_impl
 from ._port_holder import clear_wedged_port_holders
 from ._restart import (
-    HEALTH_PATH,
     pid_alive,
     pidfile_path,
     read_pid_from_file,
 )
-from ._restart import _default_http_get as _http_get_impl
 from ._restart import _terminate_then_kill as _terminate_impl
 from ._single_instance import (
     ListenAlreadyRunningError,
@@ -80,12 +99,21 @@ from ._single_instance import (
     acquire_listen_lock,
     release_listen_lock,
 )
+from ._standby_ledger import (
+    HolderLedger,
+    ListenTakeoverFailed,
+    takeover_failure_message,
+)
+from ._standby_signal import stop_flag_guard
 
 __all__ = [
     "DEFAULT_HEALTH_TIMEOUT_SECS",
-    "DEFAULT_STANDBY_INTERVAL_SECS",
+    "DEFAULT_MAX_TAKEOVER_ATTEMPTS",
+    "DEFAULT_RECHECK_INTERVAL_SECS",
     "DEFAULT_TAKEOVER_GRACE_SECS",
     "DEFAULT_UNHEALTHY_TAKEOVER_THRESHOLD",
+    "HEALTH_PATH",
+    "ListenTakeoverFailed",
     "resolve_startup",
     "standby_signal_guard",
 ]
@@ -94,23 +122,31 @@ __all__ = [
 # Tunables
 # ---------------------------------------------------------------------------
 
-# Standby re-check cadence. ~4s (operator brief: ~3-5s) keeps failover
-# latency low without a hot poll loop.
-DEFAULT_STANDBY_INTERVAL_SECS: float = 4.0
-# SIGTERM window granted to a wedged holder before SIGKILL during a
-# take-over. Short — the holder is already not serving.
+# Pause between the re-checks that CORROBORATE a failed health check. This
+# is NOT a standby cadence — a serving holder is never re-checked, we exit
+# at once. It only spaces out the (bounded) probes of a SUSPECT holder.
+DEFAULT_RECHECK_INTERVAL_SECS: float = 4.0
+# Back-compat alias: the old name for the same knob.
+DEFAULT_STANDBY_INTERVAL_SECS: float = DEFAULT_RECHECK_INTERVAL_SECS
+# SIGTERM window granted to a wedged holder during a take-over. We never
+# escalate past it — see the module docstring.
 DEFAULT_TAKEOVER_GRACE_SECS: float = 5.0
-# Per-probe health timeout. BOUNDED so a hung/zombie holder is detected
-# unhealthy → failover, never an infinite wait.
+# Per-probe health timeout. BOUNDED so a hung holder is detected, never an
+# infinite wait.
 DEFAULT_HEALTH_TIMEOUT_SECS: float = 2.0
-# Consecutive unhealthy cycles required before a take-over kills the
-# holder. Corroborates the verdict across a standby interval so a
-# daemon that merely hasn't finished binding yet is not killed.
+# Failed health checks required before the wedged verdict is corroborated
+# and acted on. Corroboration protects a daemon that merely has not
+# finished binding yet from being taken over on one unlucky probe.
 DEFAULT_UNHEALTHY_TAKEOVER_THRESHOLD: int = 2
+# How many times we may ASK a non-serving holder to leave before we stop
+# and FAIL LOUD. A holder that will not exit is a human's problem.
+DEFAULT_MAX_TAKEOVER_ATTEMPTS: int = 3
+# Hard ceiling on decision iterations. Belt-and-braces: NO input may make
+# this loop run forever, because an unbounded loop is the bug.
+_MAX_DECISION_CYCLES: int = 32
 
-# Sub-slice the standby sleep so a SIGTERM flag is noticed within
-# ~250ms even though the sleep seam itself is not signal-aware.
-_STANDBY_POLL_SLICE_SECS: float = 0.25
+# Sub-slice the re-check pause so a SIGTERM is noticed within ~250ms.
+_POLL_SLICE_SECS: float = 0.25
 # Poll granularity handed to the port-holder self-heal.
 _POLL_INTERVAL_SECS: float = 0.2
 
@@ -120,16 +156,14 @@ _POLL_INTERVAL_SECS: float = 0.2
 # ---------------------------------------------------------------------------
 
 
-def _default_probe_health(host: str, port: int, *, timeout: float) -> bool:
-    """True iff the holder answered ``/v1/health`` with ANY HTTP status.
+def _default_probe_health(host: str, port: int, *, timeout: float) -> HolderProbe:
+    """Ask the holder ``/v1/health`` and report WHAT IT ACTUALLY DID.
 
-    Mirrors ``_restart.wait_for_health``'s liveness contract: a 200 —
-    but ALSO a 401/403 under bearer auth — proves the daemon is up and
-    serving; only a transport failure (refused / timeout) is "down".
-    Bounded by ``timeout`` so a wedged holder cannot hang the probe.
+    Returns a three-state :class:`~._holder_health.HolderProbe`, never a
+    bool: "I asked and got nothing" must be expressible and must not be
+    silently equal to "it said no". Bounded by ``timeout``.
     """
-    url = f"http://{host}:{port}{HEALTH_PATH}"
-    return _http_get_impl(url, timeout) > 0
+    return _probe_health_impl(host, port, timeout=timeout)
 
 
 def _default_take_over(
@@ -140,43 +174,43 @@ def _default_take_over(
     holder_pid: int | None,
     grace_secs: float,
 ) -> str:
-    """Free the port from a wedged holder so a re-acquire can serve.
+    """ASK the wedged holder to exit so a re-acquire can serve. Never SIGKILL.
 
-    Kills the tracked flock holder named by the pidfile (releasing its
-    flock even if it never bound the port), THEN clears any untracked
-    remnant still holding the port, THEN drops the now-stale pidfile.
-    Returns ``""`` on success or a LOUD error string when the port
-    could not be freed (an unkillable holder). Never raises.
+    Returns ``""`` when the holder is gone (the kernel releases its flock,
+    so the next ``acquire_listen_lock`` wins the port), or a LOUD error
+    string when it refused to leave. Never raises.
+
+    Deliberately does NOT unlink the pidfile: the flock — not the file's
+    existence — is the bind arbiter, and the next acquirer truncates and
+    rewrites the body anyway. Unlinking a LIVE holder's pidfile would let a
+    racing standby (flocking the OLD inode) and a fresh acquirer (creating
+    a NEW inode) BOTH believe they hold the lock, and both bind.
     """
-    if holder_pid is not None and pid_alive(holder_pid):
-        _terminate(holder_pid, grace_secs=grace_secs, force_kill=False)
+    if holder_pid is None:
+        # Nothing tracked to stop. Any remnant on the PORT is handled by
+        # the serve path's heal once we hold the flock.
+        return ""
+    if not pid_alive(holder_pid):
+        return ""  # already gone — the kernel released its flock
 
-    heal = _clear_port(
-        host=host,
-        port=port,
-        grace_secs=grace_secs,
-        force=False,
-        terminate_fn=_terminate,
-        sleep_fn=_sleep,
-        poll_interval=_POLL_INTERVAL_SECS,
+    if _terminate_graceful(holder_pid, grace_secs=grace_secs):
+        return ""
+
+    return (
+        f"holder PID {holder_pid} ignored SIGTERM after {grace_secs}s and "
+        f"still holds the {host}:{port} lock. Refusing to SIGKILL it "
+        f"automatically — a probe-based 'wedged' verdict can be wrong, and "
+        f"force-killing a healthy control plane would cut the whole fleet "
+        f"off from this host. Run `sac listen restart --force` to force it."
     )
-
-    try:
-        pidfile_path(port, lock_dir).unlink()
-    except FileNotFoundError:  # stx-allow: fallback (reason: already gone — the goal state)
-        pass
-    except OSError:  # stx-allow: fallback (reason: best-effort — a leftover pidfile is a stale diagnostic the next acquire overwrites)
-        pass
-    return heal.error
 
 
 def _default_heal_untracked_port(*, host: str, port: int, grace_secs: float) -> str:
     """Clear an UNtracked remnant still on the port after we won the flock.
 
-    We hold the flock, so no TRACKED ``sac listen`` holds the port; a
-    bound port here is a wedged remnant that would EADDRINUSE our bind.
-    No-op when the port is free. Returns ``""`` or a LOUD error when the
-    remnant is unkillable.
+    We hold the flock, so no TRACKED ``sac listen`` holds the port; a bound
+    port here is a wedged remnant that would EADDRINUSE our bind. No-op
+    when the port is free. Returns ``""`` or a LOUD error when unkillable.
     """
     return _clear_port(
         host=host,
@@ -198,8 +232,9 @@ _acquire: Callable[..., LockHandle] = acquire_listen_lock
 _release: Callable[[LockHandle], None] = release_listen_lock
 _read_pid: Callable[[Path], "int | None"] = read_pid_from_file
 _terminate: Callable[..., bool] = _terminate_impl
+_terminate_graceful: Callable[..., bool] = _terminate_graceful_impl
 _clear_port = clear_wedged_port_holders
-_probe_health: Callable[..., bool] = _default_probe_health
+_probe_health: Callable[..., HolderProbe] = _default_probe_health
 _take_over: Callable[..., str] = _default_take_over
 _heal_untracked_port: Callable[..., str] = _default_heal_untracked_port
 _sleep: Callable[[float], None] = time.sleep
@@ -207,21 +242,15 @@ _should_stop: Callable[[], bool] = lambda: False  # noqa: E731 (seam; swapped by
 _log: Callable[[str], None] = _default_log
 
 
-# ---------------------------------------------------------------------------
-# Interruptible standby wait
-# ---------------------------------------------------------------------------
-
-
 def _sleep_unless_stopped(interval: float) -> None:
     """Sleep ``interval`` seconds but bail the instant a stop is flagged.
 
-    Polls ``_should_stop`` on ``_STANDBY_POLL_SLICE_SECS`` boundaries so
-    a SIGTERM during standby is honoured within ~250ms — the wait never
-    blocks the signal.
+    Polls ``_should_stop`` on ``_POLL_SLICE_SECS`` boundaries so a SIGTERM
+    during a re-check pause is honoured within ~250ms.
     """
     if interval <= 0:
         return
-    step = min(_STANDBY_POLL_SLICE_SECS, interval)
+    step = min(_POLL_SLICE_SECS, interval)
     slept = 0.0
     while slept < interval:
         if _should_stop():
@@ -244,67 +273,94 @@ def resolve_startup(
     host: str,
     port: int,
     lock_dir: Path,
-    standby_interval: float = DEFAULT_STANDBY_INTERVAL_SECS,
+    standby_interval: float = DEFAULT_RECHECK_INTERVAL_SECS,
     takeover_grace_secs: float = DEFAULT_TAKEOVER_GRACE_SECS,
     health_timeout: float = DEFAULT_HEALTH_TIMEOUT_SECS,
     unhealthy_takeover_threshold: int = DEFAULT_UNHEALTHY_TAKEOVER_THRESHOLD,
+    max_takeover_attempts: int = DEFAULT_MAX_TAKEOVER_ATTEMPTS,
 ) -> LockHandle | None:
-    """Acquire the listen lock, standing by / failing over as needed.
+    """Decide, in BOUNDED time, what this ``sac listen`` should do.
 
-    Returns a held :class:`LockHandle` the caller must keep for the
-    lifetime of the daemon (release on exit), or ``None`` when a stop
-    signal arrived while standing by (the caller should exit cleanly
-    WITHOUT binding). Never raises on contention — that is the whole
-    point; a duplicate launch stands by instead of crash-looping.
+    Returns:
+        * a held :class:`LockHandle` — we own the port; the caller BINDS.
+        * ``None`` — do NOT bind; exit 0. Either another instance is
+          already serving (nothing to do) or a stop signal arrived. The
+          reason has already been logged.
 
-    The flock remains the atomic bind arbiter, so this never lets two
-    instances bind at once regardless of how many stand by.
+    Raises:
+        ListenTakeoverFailed: the holder is NOT serving and the port could
+            not be freed. The CLI maps this to a non-zero exit carrying the
+            PID and the exact remedy.
+
+    There is deliberately NO "spin" outcome: this function always reaches a
+    decision, and it never polls a healthy holder.
     """
     pidfile = pidfile_path(port, lock_dir)
-    threshold = unhealthy_takeover_threshold if unhealthy_takeover_threshold > 0 else 1
-    consecutive_unhealthy = 0
+    ledger = HolderLedger(threshold=unhealthy_takeover_threshold)
+    takeover_attempts = 0
+    heal_attempts = 0
+    max_attempts = max(1, max_takeover_attempts)
 
-    while True:
+    for _cycle in range(_MAX_DECISION_CYCLES):
         if _should_stop():
-            _log(
-                "# sac listen: shutdown signal received while standing by "
-                "— exiting without binding"
-            )
+            _log("# sac listen: shutdown signal received — exiting without binding")
             return None
 
         try:
             handle = _acquire(port=port, lock_dir=lock_dir)
         except ListenAlreadyRunningError:
-            # A LIVE process holds the flock (the kernel releases the
-            # flock on death, so a held flock == a live holder).
+            # A LIVE process holds the flock (the kernel releases it on
+            # death, so a held flock == a live holder). But a live PID is
+            # NOT health — ask the PORT what it is actually doing.
             holder_pid = _read_pid(pidfile)
+            probe = _probe_health(host, port, timeout=health_timeout)
+            ledger.record(probe)
 
-            if _probe_health(host, port, timeout=health_timeout):
-                consecutive_unhealthy = 0
+            if not ledger.suspect:
+                # ANOTHER INSTANCE IS ALREADY SERVING → the goal state is
+                # already true. EXIT 0. Do NOT stand by, and do NOT take
+                # over: a listen restart tears down the in-process a2a
+                # Broker and deafens every agent's inbox at once, so
+                # displacing a working holder is pure damage.
                 _log(
-                    f"# sac listen: standing by behind healthy holder "
-                    f"PID {_pid_str(holder_pid)} on {host}:{port}"
+                    f"# sac listen: already serving: PID {_pid_str(holder_pid)} "
+                    f"on {host}:{port} ({probe.describe()}) — nothing to do"
                 )
+                return None
+
+            if not ledger.corroborated:
+                # Corroborate across a short pause before acting — a holder
+                # that just won the flock may not have bound the port yet.
+                #
+                # Unlike the counter this replaces, a failure is NOT erased
+                # by the next lucky reply: THAT reset is what let a flapping
+                # holder be announced "healthy" forever. So say plainly what
+                # is on the books, whichever way this particular probe went.
+                if probe.serving:
+                    _log(
+                        f"# sac listen: holder PID {_pid_str(holder_pid)} on "
+                        f"{host}:{port} answered this time ({probe.describe()}) "
+                        f"but still carries {ledger.failures}/{ledger.threshold} "
+                        f"failed health check(s) — NOT standing down on one "
+                        f"lucky reply; re-checking in {standby_interval}s"
+                    )
+                else:
+                    _log(
+                        f"# sac listen: holder PID {_pid_str(holder_pid)} on "
+                        f"{host}:{port} FAILED its health check "
+                        f"({ledger.failures}/{ledger.threshold}) — "
+                        f"{probe.describe()} — re-checking in {standby_interval}s"
+                    )
                 _sleep_unless_stopped(standby_interval)
                 continue
 
-            consecutive_unhealthy += 1
-            if consecutive_unhealthy < threshold:
-                # Corroborate across a standby interval before killing —
-                # a holder that just won the flock may not have bound
-                # the port yet. Do not take over on a single miss.
-                _log(
-                    f"# sac listen: holder PID {_pid_str(holder_pid)} on "
-                    f"{host}:{port} not answering health "
-                    f"({consecutive_unhealthy}/{threshold}) — re-checking "
-                    f"in {standby_interval}s before taking over"
-                )
-                _sleep_unless_stopped(standby_interval)
-                continue
-
+            takeover_attempts += 1
             _log(
                 f"# sac listen: holder PID {_pid_str(holder_pid)} on "
-                f"{host}:{port} is wedged (not serving) — taking over"
+                f"{host}:{port} is NOT SERVING — {probe.describe()} — "
+                f"corroborated over {ledger.failures} failed checks. Asking "
+                f"it to exit (SIGTERM, attempt {takeover_attempts}/"
+                f"{max_attempts}); it will NOT be SIGKILLed automatically."
             )
             error = _take_over(
                 host=host,
@@ -313,14 +369,29 @@ def resolve_startup(
                 holder_pid=holder_pid,
                 grace_secs=takeover_grace_secs,
             )
-            consecutive_unhealthy = 0
-            if error:
-                _log(
-                    f"# sac listen: take-over incomplete — {error} — "
-                    f"standing by, will retry"
+            if not error:
+                # It left (or was already gone). Re-acquire; the flock
+                # arbitrates any race between several starters.
+                ledger.reset()
+                continue
+
+            if takeover_attempts >= max_attempts:
+                raise ListenTakeoverFailed(
+                    takeover_failure_message(
+                        host=host,
+                        port=port,
+                        holder_pid=holder_pid,
+                        probe=probe,
+                        failures=ledger.failures,
+                        attempts=takeover_attempts,
+                        error=error,
+                    )
                 )
-                _sleep_unless_stopped(standby_interval)
-            # Loop: re-acquire. The flock arbitrates any standby race.
+            _log(
+                f"# sac listen: take-over attempt {takeover_attempts}/"
+                f"{max_attempts} did not free {host}:{port} — {error}"
+            )
+            _sleep_unless_stopped(standby_interval)
             continue
 
         # We hold the flock: the sole authorized binder. An UNtracked
@@ -330,72 +401,56 @@ def resolve_startup(
             host=host, port=port, grace_secs=takeover_grace_secs
         )
         if heal_error:
-            # Cannot free the port. Releasing the flock + standing by is
-            # strictly better than crash-looping into EADDRINUSE.
+            heal_attempts += 1
+            _release(handle)
+            if heal_attempts >= max_attempts:
+                raise ListenTakeoverFailed(
+                    f"ERROR: sac listen cannot bind {host}:{port} — the port "
+                    f"is held by an unkillable remnant after {heal_attempts} "
+                    f"attempts: {heal_error}\n"
+                    f"  Refusing to spin silently behind it. To force the "
+                    f"take-over, run:  sac listen restart --force"
+                )
             _log(
                 f"# sac listen: port {port} held by an unkillable remnant "
-                f"— {heal_error} — releasing lock, standing by"
+                f"({heal_attempts}/{max_attempts}) — {heal_error} — "
+                f"released lock, retrying"
             )
-            _release(handle)
             _sleep_unless_stopped(standby_interval)
             continue
 
         _log(f"# sac listen: acquired {host}:{port} — serving")
         return handle
 
+    # Belt-and-braces: no input may make this loop run forever.
+    raise ListenTakeoverFailed(
+        f"ERROR: sac listen could not reach a decision about {host}:{port} "
+        f"after {_MAX_DECISION_CYCLES} cycles (the flock keeps changing "
+        f"hands). Refusing to spin. Inspect with `sac listen status`, then "
+        f"`sac listen restart --force`."
+    )
+
 
 # ---------------------------------------------------------------------------
-# Signal guard — clean, prompt exit on SIGTERM/SIGINT during standby
+# Signal guard — clean, prompt exit on SIGTERM/SIGINT mid-decision
 # ---------------------------------------------------------------------------
-
-
-class _StopFlag:
-    """A one-way stop flag flipped by a signal handler, polled by the loop."""
-
-    __slots__ = ("_tripped",)
-
-    def __init__(self) -> None:
-        self._tripped = False
-
-    def trip(self, *_args: object) -> None:
-        """Signal-handler entrypoint — minimal work: flip the flag."""
-        self._tripped = True
-
-    def is_set(self) -> bool:
-        return self._tripped
 
 
 @contextmanager
 def standby_signal_guard() -> Iterator[None]:
-    """Make the standby loop exit cleanly + promptly on SIGTERM/SIGINT.
+    """Make the startup decision exit cleanly + promptly on SIGTERM/SIGINT.
 
-    Installs handlers that flip a flag the loop polls (via the
-    ``_should_stop`` seam) instead of letting SIGTERM's default
-    disposition abruptly terminate the process or SIGINT raise
-    ``KeyboardInterrupt`` mid-standby. Restores the prior handlers on
-    exit so uvicorn (started only once the loop owns the lock) installs
-    its own graceful-shutdown handlers unchanged.
-
-    Handlers can only be installed from the main thread; the ``sac
-    listen`` CLI runs there. Off the main thread this degrades to a
-    no-op guard (keeps the prior never-stop behaviour) rather than
-    crashing the boot.
+    Wires :func:`._standby_signal.stop_flag_guard`'s flag into the
+    ``_should_stop`` seam the decision loop polls, and restores the prior
+    ``_should_stop`` (and the prior OS handlers) on exit — so uvicorn,
+    started only once the loop owns the lock, installs its own
+    graceful-shutdown handlers unchanged.
     """
     global _should_stop
-    flag = _StopFlag()
-    try:
-        prev_term = signal.signal(signal.SIGTERM, flag.trip)
-        prev_int = signal.signal(signal.SIGINT, flag.trip)
-    except ValueError:
-        # Not the main thread — cannot install signal handlers.
-        yield
-        return
-
-    saved_should_stop = _should_stop
-    _should_stop = flag.is_set
-    try:
-        yield
-    finally:
-        _should_stop = saved_should_stop
-        signal.signal(signal.SIGTERM, prev_term)
-        signal.signal(signal.SIGINT, prev_int)
+    with stop_flag_guard() as flag:
+        saved_should_stop = _should_stop
+        _should_stop = flag.is_set
+        try:
+            yield
+        finally:
+            _should_stop = saved_should_stop

--- a/src/scitex_agent_container/_listen/_standby_ledger.py
+++ b/src/scitex_agent_container/_listen/_standby_ledger.py
@@ -1,0 +1,160 @@
+"""The holder's health LEDGER — a failed check is never erased by a lucky reply.
+
+The defect this closes (operator incident 2026-07-14)
+=====================================================
+The standby loop counted ``consecutive_unhealthy`` and reset it to ``0``
+on ANY single successful probe::
+
+    if _probe_health(...):
+        consecutive_unhealthy = 0          # <-- the whole record, gone
+        _log("standing by behind healthy holder PID …")
+
+A holder that FLAPS — answers one probe, misses the next — therefore
+never accumulated the CONSECUTIVE failures the take-over threshold
+demands. It oscillated ``1/2`` → "healthy" → ``1/2`` → "healthy" and
+``sac listen`` stood by behind it FOREVER::
+
+    # sac listen: holder PID 738982 on 127.0.0.1:7878 not answering
+      health (1/2) — re-checking in 4.0s before taking over
+    # sac listen: standing by behind healthy holder PID 738982 …
+    # sac listen: standing by behind healthy holder PID 738982 …
+    ... (forever)
+
+That is not a hypothetical: the live 7878 daemon on this box was
+measured answering ``HTTP 200`` one minute and ``Connection refused``
+the next. Flapping is the ACTUAL field behaviour, and the reset made it
+invisible.
+
+The rule
+========
+**A failure is a fact. One later success does not un-happen it.**
+
+* Any non-SERVING observation adds to ``failures``.
+* A SERVING observation does NOT wipe ``failures``. It only builds a
+  ``serving_streak``; the suspicion is cleared only once the holder has
+  answered ``recovery_streak`` times IN A ROW — and that clearing is
+  logged LOUD, because "the thing I said was broken now looks fine" is
+  exactly the transition an operator must never have hidden from them.
+* ``failures >= threshold`` ⇒ the verdict is corroborated ⇒ act.
+
+A genuinely healthy holder that blips once is therefore NOT destroyed
+(it answers twice more and is cleared), while a holder that keeps
+failing is ALWAYS eventually acted on — which is precisely the
+distinction the old counter could not draw.
+"""
+
+from __future__ import annotations
+
+from ._holder_health import HolderHealth, HolderProbe
+
+__all__ = [
+    "HolderLedger",
+    "ListenTakeoverFailed",
+    "takeover_failure_message",
+]
+
+
+class ListenTakeoverFailed(RuntimeError):
+    """The holder failed its health checks and the port could NOT be freed.
+
+    Deliberately NOT a subclass of ``ListenAlreadyRunningError``: plain
+    contention is NORMAL (stand by behind a serving primary), whereas an
+    unfreeable non-serving holder is an OUTAGE that no amount of further
+    waiting can fix. The CLI maps this to a non-zero exit carrying the
+    operator-actionable message built by :func:`takeover_failure_message`.
+    """
+
+
+class HolderLedger:
+    """Corroboration ledger for one holder's health observations.
+
+    ``threshold`` consecutive-equivalent failures are required before the
+    holder is declared wedged (so a daemon that merely has not finished
+    binding yet is never taken over), but — unlike the counter it
+    replaces — a single lucky reply does NOT erase the record.
+    """
+
+    __slots__ = ("_threshold", "_recovery_streak", "failures", "serving_streak")
+
+    def __init__(self, *, threshold: int, recovery_streak: int | None = None) -> None:
+        self._threshold = max(1, threshold)
+        self._recovery_streak = max(1, recovery_streak or self._threshold)
+        self.failures = 0
+        self.serving_streak = 0
+
+    @property
+    def threshold(self) -> int:
+        return self._threshold
+
+    def record(self, probe: HolderProbe) -> bool:
+        """Record one observation. Returns ``True`` iff it CLEARED a suspicion.
+
+        A ``True`` return is the "holder recovered" transition and must be
+        logged loudly — it is the moment we stop distrusting a holder we
+        previously reported as failing.
+        """
+        if probe.health is HolderHealth.SERVING:
+            if self.failures == 0:
+                return False  # a clean holder; nothing to clear
+            self.serving_streak += 1
+            if self.serving_streak >= self._recovery_streak:
+                self.failures = 0
+                self.serving_streak = 0
+                return True
+            return False
+        # NOT_SERVING or UNREACHABLE — both are failures. A holder that
+        # answers nothing is NOT healthy; absence of evidence is not
+        # evidence of health.
+        self.serving_streak = 0
+        self.failures += 1
+        return False
+
+    @property
+    def suspect(self) -> bool:
+        """True while at least one failed check stands un-cleared."""
+        return self.failures > 0
+
+    @property
+    def corroborated(self) -> bool:
+        """True once enough failures have accrued to act on the verdict."""
+        return self.failures >= self._threshold
+
+    def reset(self) -> None:
+        """Forget the history (used after a take-over changes the world)."""
+        self.failures = 0
+        self.serving_streak = 0
+
+
+def takeover_failure_message(
+    *,
+    host: str,
+    port: int,
+    holder_pid: int | None,
+    probe: HolderProbe,
+    failures: int,
+    attempts: int,
+    error: str,
+) -> str:
+    """Build the LOUD, actionable message for an unfreeable wedged holder.
+
+    Names (a) what was OBSERVED, (b) which PID, (c) why we did not force
+    it, and (d) the exact command a human can run. Never a bare "did not
+    respond" — the operator sat watching an unbounded loop precisely
+    because the daemon never told him anything he could act on.
+    """
+    pid_str = str(holder_pid) if holder_pid is not None else "<unknown>"
+    return (
+        f"ERROR: sac listen cannot take over {host}:{port}.\n"
+        f"  The flock holder PID {pid_str} FAILED its health check "
+        f"{failures}x ({probe.describe()}), so it is NOT serving — but it "
+        f"also did not exit on SIGTERM after {attempts} take-over "
+        f"attempt(s): {error}\n"
+        f"  Refusing to SIGKILL it automatically: a probe-based 'wedged' "
+        f"verdict can be wrong, and force-killing a healthy control plane "
+        f"would cut the whole fleet off from this host.\n"
+        f"  Refusing to stand by behind it either: it is not serving, so "
+        f"waiting silently would hide the outage indefinitely.\n"
+        f"  To force the take-over, run:  sac listen restart --force\n"
+        f"  To inspect the holder first:  sac listen status  /  "
+        f"lsof -nP -iTCP:{port} -sTCP:LISTEN"
+    )

--- a/src/scitex_agent_container/_listen/_standby_signal.py
+++ b/src/scitex_agent_container/_listen/_standby_signal.py
@@ -1,0 +1,63 @@
+"""SIGTERM/SIGINT guard for ``sac listen``'s bounded startup decision.
+
+``resolve_startup`` may spend a few seconds re-checking a holder that
+failed its health check. A ``systemctl stop`` (or a Ctrl-C) landing in
+that window must produce a PROMPT, CLEAN exit — not a ``KeyboardInterrupt``
+traceback, and not a process that ignores the signal until its next poll.
+
+The handler does the minimum a signal handler may safely do: flip a flag.
+The decision loop polls that flag on ~250ms boundaries, so the wait never
+blocks the signal. Prior handlers are restored on exit, so uvicorn (which
+only starts once the loop owns the lock) installs its own graceful-shutdown
+handlers unchanged.
+"""
+
+from __future__ import annotations
+
+import signal
+from contextlib import contextmanager
+from typing import Iterator
+
+__all__ = ["StopFlag", "stop_flag_guard"]
+
+
+class StopFlag:
+    """A one-way stop flag flipped by a signal handler, polled by the loop."""
+
+    __slots__ = ("_tripped",)
+
+    def __init__(self) -> None:
+        self._tripped = False
+
+    def trip(self, *_args: object) -> None:
+        """Signal-handler entrypoint — minimal work: flip the flag."""
+        self._tripped = True
+
+    def is_set(self) -> bool:
+        return self._tripped
+
+
+@contextmanager
+def stop_flag_guard() -> Iterator[StopFlag]:
+    """Install SIGTERM/SIGINT handlers that trip a :class:`StopFlag`.
+
+    Yields the flag. Restores the previous handlers on exit.
+
+    Handlers can only be installed from the main thread; the ``sac
+    listen`` CLI runs there. Off the main thread this degrades to a no-op
+    guard (yielding a flag nothing will ever trip) rather than crashing
+    the boot.
+    """
+    flag = StopFlag()
+    try:
+        prev_term = signal.signal(signal.SIGTERM, flag.trip)
+        prev_int = signal.signal(signal.SIGINT, flag.trip)
+    except ValueError:
+        # Not the main thread — cannot install signal handlers.
+        yield flag
+        return
+    try:
+        yield flag
+    finally:
+        signal.signal(signal.SIGTERM, prev_term)
+        signal.signal(signal.SIGINT, prev_int)

--- a/src/scitex_agent_container/cli_pkg/_send.py
+++ b/src/scitex_agent_container/cli_pkg/_send.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import shlex
 from typing import Any
 
+from .._listen._local_host import is_local_host
 from ._send_diagnosis import diagnose_send_failure
 from ._send_preflight import SshRunner, preflight_send_creds
 
@@ -195,7 +196,19 @@ def send_to_agent(
         endpoint = resolve_send_endpoint(name, current_host=current_host)
 
     a2a_port = endpoint.a2a_port
-    peer_host = endpoint.host if endpoint.host != current_host else ""
+    # "" means LOCAL (dispatch over loopback); anything else is a genuinely
+    # cross-host peer and goes over ssh below.
+    #
+    # This must be a LOOPBACK-AWARE test, not a string compare against
+    # ``current_host``. The brokered path derives this host by parsing the
+    # registry's ``turn_url`` (``_send_broker._host_from_turn_url``), and that
+    # URL now correctly names ``127.0.0.1`` for a local agent — the address the
+    # a2a sidecar actually binds — instead of the canonical hostname, which on
+    # Debian/Ubuntu/WSL resolves to 127.0.1.1 and is refused. A bare
+    # ``!= current_host`` would read that loopback literal as a REMOTE host and
+    # try to ssh to ``ssh://127.0.0.1:<port>`` — turning a URL fix into a
+    # comms outage. Any name that means THIS machine dispatches locally.
+    peer_host = "" if is_local_host(endpoint.host) else endpoint.host
 
     if endpoint.source == "host_broker_unknown_agent":
         # The HOST — which can see the whole fleet — has no agent by this

--- a/src/scitex_agent_container/cli_pkg/listen_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/listen_cmds.py
@@ -181,21 +181,37 @@ def _do_start_listen(
         default_lock_dir,
         release_listen_lock,
     )
-    from .._listen._standby import resolve_startup, standby_signal_guard
+    from .._listen._standby import (
+        ListenTakeoverFailed,
+        resolve_startup,
+        standby_signal_guard,
+    )
 
     lock_dir = default_lock_dir()
     lock_dir.mkdir(parents=True, exist_ok=True)
-    with standby_signal_guard():
-        lock_handle = resolve_startup(host=host, port=port, lock_dir=lock_dir)
+    try:
+        with standby_signal_guard():
+            lock_handle = resolve_startup(host=host, port=port, lock_dir=lock_dir)
+    except ListenTakeoverFailed as exc:
+        # The holder FAILED its health check and could not be freed. The
+        # old code stood by against it forever, printing "standing by
+        # behind healthy holder" while the fleet was cut off from the host
+        # (incident 2026-07-14). An unbounded standby loop hides an outage;
+        # exiting non-zero with the PID and the exact remedy surfaces it.
+        # This is NOT the #640 crash-loop: ordinary contention behind a
+        # SERVING holder still stands by and never reaches here.
+        raise click.ClickException(str(exc)) from exc
     if lock_handle is None:
-        # A stop signal (``systemctl stop`` / Ctrl-C) arrived while
-        # standing by. We never acquired the lock — nothing to release;
-        # exit cleanly without binding.
-        click.echo(
-            "# sac listen: received shutdown signal while standing by "
-            "— exiting without binding",
-            err=True,
-        )
+        # Do NOT bind; exit 0. Either another instance is ALREADY SERVING
+        # (nothing to do — the goal state is already true) or a stop signal
+        # arrived. ``resolve_startup`` has already logged which, naming the
+        # holding PID and the health evidence.
+        #
+        # This used to be an unbounded standby loop that polled a healthy
+        # holder every 4s forever, so an interactive `sac listen` never
+        # returned and the operator had to Ctrl-C and `kill` the holder by
+        # hand to escape it. Standing by bought nothing: a standby holds no
+        # lock and serves no request.
         return
 
     click.echo(f"# sac listen v1 → {host}:{port}", err=True)

--- a/tests/scitex_agent_container/_listen/test__graceful_stop.py
+++ b/tests/scitex_agent_container/_listen/test__graceful_stop.py
@@ -1,0 +1,174 @@
+"""Tests for ``_listen/_graceful_stop.py`` — the take-over may ASK, never destroy.
+
+The contract these pin: the standby loop's automatic take-over acts on a
+PROBE-BASED inference. A probe can be wrong, and the remedy for a wrong
+"wedged" verdict is to SIGKILL a healthy control plane and cut the whole
+fleet off from the host. So the automatic path sends SIGTERM and NOTHING
+ELSE — a survivor is reported to the caller, never escalated.
+
+No-mocks (PA-306 / STX-NM001-003): these drive REAL child processes with
+REAL signals. The "ignores SIGTERM" case installs ``SIG_IGN`` in a real
+child, so a stray SIGKILL anywhere in the implementation would show up
+as a dead process — which is exactly what the assertion checks.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from typing import Iterator
+
+from scitex_agent_container._listen._graceful_stop import terminate_gracefully
+
+# Each child announces "ready" on stdout and the harness BLOCKS on that
+# line before signalling it. Do NOT replace this with a sleep: under `-n 8`
+# an interpreter can take longer than any guessed delay to install its
+# handler, and a SIGTERM landing before ``SIG_IGN`` is in place kills the
+# "stubborn" child — which would make the never-SIGKILL test pass or fail
+# on a race rather than on the behaviour it claims to check.
+
+# A child that sleeps until signalled — SIGTERM's default disposition kills
+# it, so it models a well-behaved holder.
+_OBEDIENT = (
+    "import sys, time; sys.stdout.write('ready\\n'); sys.stdout.flush(); "
+    "time.sleep(30)"
+)
+# A child that IGNORES SIGTERM outright — it models the wedged holder we
+# must refuse to destroy. Only a SIGKILL could take it down, so if it is
+# dead after terminate_gracefully, the implementation escalated.
+_STUBBORN = (
+    "import signal, sys, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+    "sys.stdout.write('ready\\n'); sys.stdout.flush(); "
+    "time.sleep(30)"
+)
+
+
+@contextmanager
+def _child(code: str) -> Iterator[subprocess.Popen]:
+    """Spawn a REAL child process running ``code``; always reap it.
+
+    A background reaper is essential, not incidental: a dead-but-unreaped
+    child lingers as a ZOMBIE, and ``os.kill(pid, 0)`` — the liveness probe
+    ``terminate_gracefully`` polls — SUCCEEDS on a zombie. Without a reaper
+    the harness would report a process that has already exited as still
+    alive, and the test would "fail" on a liveness artefact of its own
+    making. (Production never hits this: the flock holder is an independent
+    daemon, never a child of ``sac listen``.)
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-c", code], stdout=subprocess.PIPE, text=True
+    )
+    # BLOCK until the child says it is ready — its signal handler is
+    # installed by then. A guessed sleep is not enough under parallel load.
+    assert proc.stdout is not None
+    ready = proc.stdout.readline()
+    assert ready.strip() == "ready", f"child never became ready: {ready!r}"
+
+    reaper = threading.Thread(target=proc.wait, daemon=True)
+    reaper.start()
+    try:
+        yield proc
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        reaper.join(timeout=5)
+        proc.stdout.close()
+
+
+def _is_alive(pid: int) -> bool:
+    """True iff the PID is still a running (non-reaped) process."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# The ordinary failover — a well-behaved holder exits on SIGTERM
+# ---------------------------------------------------------------------------
+
+
+def test_obedient_holder_is_stopped() -> None:
+    # Arrange — a real child that dies on SIGTERM's default disposition.
+    with _child(_OBEDIENT) as proc:
+        # Act
+        stopped = terminate_gracefully(proc.pid, grace_secs=5.0, poll_interval=0.1)
+    # Assert
+    assert stopped is True
+
+
+def test_already_dead_holder_reports_stopped() -> None:
+    # Arrange — the holder is already gone. That IS the goal state, so it
+    # must not read as a failure (its flock is already kernel-released).
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait(timeout=5)
+    # Act
+    stopped = terminate_gracefully(proc.pid, grace_secs=0.5, poll_interval=0.1)
+    # Assert
+    assert stopped is True
+
+
+# ---------------------------------------------------------------------------
+# Never destroy on a negative signal
+# ---------------------------------------------------------------------------
+
+
+def test_stubborn_holder_reports_not_stopped() -> None:
+    # Arrange — a real child that IGNORES SIGTERM (the wedged holder).
+    with _child(_STUBBORN) as proc:
+        # Act
+        stopped = terminate_gracefully(proc.pid, grace_secs=1.0, poll_interval=0.1)
+    # Assert — we report the truth rather than pretend we stopped it.
+    assert stopped is False
+
+
+def test_stubborn_holder_is_never_killed() -> None:
+    # Arrange — THE load-bearing test. The child ignores SIGTERM, so the
+    # ONLY way it can end up dead is a SIGKILL. A probe-based verdict must
+    # never be able to destroy a process: the false-RED (killing a healthy
+    # control plane) is strictly worse than the false-green.
+    with _child(_STUBBORN) as proc:
+        terminate_gracefully(proc.pid, grace_secs=1.0, poll_interval=0.1)
+        # Act
+        survived = _is_alive(proc.pid)
+    # Assert
+    assert survived, "terminate_gracefully escalated to SIGKILL — it must not"
+
+
+def test_stubborn_holder_is_bounded_by_grace() -> None:
+    # Arrange — the wait must be BOUNDED. An unbounded wait on a wedged
+    # holder is just the unbounded standby loop wearing a different hat.
+    with _child(_STUBBORN) as proc:
+        started = time.monotonic()
+        # Act
+        terminate_gracefully(proc.pid, grace_secs=1.0, poll_interval=0.1)
+        elapsed = time.monotonic() - started
+    # Assert — returned promptly after the grace window, not "eventually".
+    assert elapsed < 5.0
+
+
+def test_sigterm_is_the_only_signal_sent() -> None:
+    # Arrange — pin the exact signal at the syscall seam, so a future edit
+    # cannot quietly slip a SIGKILL back in.
+    sent: list[int] = []
+    from scitex_agent_container._listen import _graceful_stop as gs
+
+    saved_kill, saved_sleep, saved_alive = gs._kill, gs._sleep, gs._alive
+    gs._kill = lambda _pid, sig: sent.append(sig)
+    gs._sleep = lambda _s: None
+    gs._alive = lambda _p: False  # exits promptly after the TERM
+    # Act
+    try:
+        terminate_gracefully(4242, grace_secs=1.0, poll_interval=0.1)
+    finally:
+        gs._kill, gs._sleep, gs._alive = saved_kill, saved_sleep, saved_alive
+    # Assert
+    assert sent == [signal.SIGTERM]

--- a/tests/scitex_agent_container/_listen/test__holder_health.py
+++ b/tests/scitex_agent_container/_listen/test__holder_health.py
@@ -1,0 +1,168 @@
+"""Tests for ``_listen/_holder_health.py`` — the three-state health verdict.
+
+Two states could not express "I asked and got nothing", so the standby
+loop collapsed that into the same ``False`` as "it said no" and a later
+lucky reply erased it. These pin the three-state contract, including the
+load-bearing asymmetry: a 401 (auth-gated but ALIVE) must never be read
+as dead, because destroying a healthy control plane on a wrong verdict is
+worse than failing to act on a right one.
+
+No-mocks (PA-306 / STX-NM001-003): the probe runs against a REAL loopback
+``http.server`` on an ephemeral port and a REAL closed port.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import http.server
+import threading
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._listen._holder_health import (
+    HolderHealth,
+    classify_status,
+    probe_holder_health,
+)
+
+
+@contextmanager
+def _server(status: int) -> Iterator[int]:
+    """A REAL HTTP server answering every GET with ``status``."""
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 (stdlib handler contract)
+            self.send_response(status)
+            self.end_headers()
+
+        def log_message(self, *_a) -> None:
+            return
+
+    srv = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield srv.server_address[1]
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        thread.join(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# classify_status — the three states
+# ---------------------------------------------------------------------------
+
+
+def test_transport_failure_is_unreachable() -> None:
+    # Arrange — ``-1`` is _default_http_get's transport-failure sentinel:
+    # we asked and got NOTHING. That is its own state, not a "no".
+    # Act
+    verdict = classify_status(-1)
+    # Assert
+    assert verdict is HolderHealth.UNREACHABLE
+
+
+def test_server_error_is_not_serving() -> None:
+    # Arrange — a 503 IS an answer, but it is not health. The old probe
+    # (``status > 0``) called it a healthy holder.
+    # Act
+    verdict = classify_status(503)
+    # Assert
+    assert verdict is HolderHealth.NOT_SERVING
+
+
+def test_ok_status_is_serving() -> None:
+    # Arrange — the plain healthy case.
+    # Act
+    verdict = classify_status(200)
+    # Assert
+    assert verdict is HolderHealth.SERVING
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_auth_gated_status_is_serving(status: int) -> None:
+    # Arrange — load-bearing (card sac-listen-restart-healthcheck-bearer,
+    # PR #463): a 401/403 PROVES the daemon is bound and auth-gating.
+    # Reading it as dead once SIGKILLed a healthy daemon.
+    # Act
+    verdict = classify_status(status)
+    # Assert
+    assert verdict is HolderHealth.SERVING
+
+
+def test_not_found_status_is_serving() -> None:
+    # Arrange — a 404 still proves the process is bound and speaking HTTP.
+    # We refuse to destroy on a route-shape difference.
+    # Act
+    verdict = classify_status(404)
+    # Assert
+    assert verdict is HolderHealth.SERVING
+
+
+# ---------------------------------------------------------------------------
+# probe_holder_health — REAL sockets
+# ---------------------------------------------------------------------------
+
+
+def test_live_server_probes_as_serving() -> None:
+    # Arrange
+    with _server(200) as port:
+        # Act
+        probe = probe_holder_health("127.0.0.1", port, timeout=2.0)
+    # Assert
+    assert probe.health is HolderHealth.SERVING
+
+
+def test_erroring_server_probes_as_not_serving() -> None:
+    # Arrange — bound, speaking HTTP, but its health route is broken.
+    with _server(503) as port:
+        # Act
+        probe = probe_holder_health("127.0.0.1", port, timeout=2.0)
+    # Assert
+    assert probe.health is HolderHealth.NOT_SERVING
+
+
+def test_closed_port_probes_as_unreachable() -> None:
+    # Arrange — nothing is listening on port 1.
+    # Act
+    probe = probe_holder_health("127.0.0.1", 1, timeout=0.5)
+    # Assert
+    assert probe.health is HolderHealth.UNREACHABLE
+
+
+def test_unreachable_probe_is_not_serving() -> None:
+    # Arrange — the predicate the standby loop branches on. Absence of
+    # evidence must never read as evidence of health.
+    # Act
+    probe = probe_holder_health("127.0.0.1", 1, timeout=0.5)
+    # Assert
+    assert probe.serving is False
+
+
+# ---------------------------------------------------------------------------
+# describe() — the log line must state the EVIDENCE, not a conclusion
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_describe_says_no_answer() -> None:
+    # Arrange — the operator must be able to read the log and see that
+    # nothing answered, rather than be told a verdict.
+    probe = probe_holder_health("127.0.0.1", 1, timeout=0.5)
+    # Act
+    text = probe.describe()
+    # Assert
+    assert "did not answer" in text
+
+
+def test_serving_describe_names_the_status() -> None:
+    # Arrange
+    with _server(200) as port:
+        probe = probe_holder_health("127.0.0.1", port, timeout=2.0)
+    # Act
+    text = probe.describe()
+    # Assert
+    assert "HTTP 200" in text

--- a/tests/scitex_agent_container/_listen/test__local_host.py
+++ b/tests/scitex_agent_container/_listen/test__local_host.py
@@ -1,0 +1,171 @@
+"""Tests for ``_listen/_local_host.py`` — "does this hostname mean THIS box?"
+
+The predicate that fixes a deterministic outage. ``derive_turn_url``
+named the machine's own canonical hostname, which on stock Debian /
+Ubuntu / WSL resolves to ``127.0.1.1``::
+
+    $ getent hosts ywata-note-win
+    127.0.1.1   ywata-note-win.localdomain ywata-note-win
+
+…while the a2a sidecar binds ``127.0.0.1``. Both are loopback, but they
+are DIFFERENT loopback addresses, so every connection to the derived URL
+was refused — 100% of the time.
+
+The trap this pins: a naive ``host == "127.0.0.1"`` check MISSES
+``127.0.1.1`` and happily emits the dead URL. "Local" has to mean *any*
+loopback address, all of which normalise to the one the sidecar binds.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from scitex_agent_container._listen._local_host import (
+    LOOPBACK_HOST,
+    is_local_host,
+    local_host_aliases,
+)
+
+
+# ---------------------------------------------------------------------------
+# The reported trap — 127.0.1.1 is loopback, and is NOT 127.0.0.1
+# ---------------------------------------------------------------------------
+
+
+def test_debian_self_host_ip_is_local() -> None:
+    # Arrange — the crux of the bug. 127.0.1.1 is a loopback address, so a
+    # naive equality check against 127.0.0.1 would miss it and emit a URL
+    # that is refused on every single connection.
+    # Act
+    local = is_local_host("127.0.1.1")
+    # Assert
+    assert local
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "127.0.0.2", "127.1.2.3", "::1"])
+def test_loopback_addresses_are_local(host: str) -> None:
+    # Arrange — everything in 127.0.0.0/8 (and ::1) is reachable only from
+    # this machine, so all of it is "local" and all of it must normalise.
+    # Act
+    local = is_local_host(host)
+    # Assert
+    assert local
+
+
+# ---------------------------------------------------------------------------
+# This machine's own names
+# ---------------------------------------------------------------------------
+
+
+def test_own_hostname_is_local() -> None:
+    # Arrange — this is the name ``resolve_a2a_host`` hands to
+    # ``derive_turn_url`` for a LOCAL agent.
+    # Act
+    local = is_local_host(socket.gethostname())
+    # Assert
+    assert local
+
+
+def test_short_hostname_is_local() -> None:
+    # Arrange — an ``instances`` row may carry the short label rather than
+    # the FQDN; both denote this machine.
+    short = socket.gethostname().split(".", 1)[0]
+    # Act
+    local = is_local_host(short)
+    # Assert
+    assert local
+
+
+def test_hostname_match_is_case_insensitive() -> None:
+    # Arrange — DNS names are case-insensitive; a row carrying an
+    # upper-cased hostname must not slip through as "remote".
+    # Act
+    local = is_local_host(socket.gethostname().upper())
+    # Assert
+    assert local
+
+
+@pytest.mark.parametrize("host", ["localhost", "0.0.0.0", "::", ""])
+def test_always_local_literals_are_local(host: str) -> None:
+    # Arrange — a wildcard listener IS reachable on loopback, and
+    # "localhost" can resolve to ::1 first, so both are normalised.
+    # Act
+    local = is_local_host(host)
+    # Assert
+    assert local
+
+
+# ---------------------------------------------------------------------------
+# Remote peers must NOT be normalised (that would point every cross-host
+# dispatch back at ourselves)
+# ---------------------------------------------------------------------------
+
+
+def test_remote_hostname_is_not_local() -> None:
+    # Arrange
+    # Act
+    local = is_local_host("spartan-cpu.example.org")
+    # Assert
+    assert not local
+
+
+def test_routable_ip_is_not_local() -> None:
+    # Arrange — a tailscale / VPN address belongs to another box.
+    # Act
+    local = is_local_host("100.64.1.2")
+    # Assert
+    assert not local
+
+
+def test_none_host_is_not_local() -> None:
+    # Arrange — a missing host is not a claim that it is ours. Promoting
+    # it to loopback would advertise OUR sidecar as somebody else's.
+    # Act
+    local = is_local_host(None)
+    # Assert
+    assert not local
+
+
+# ---------------------------------------------------------------------------
+# local_host_aliases + the loopback constant
+# ---------------------------------------------------------------------------
+
+
+def test_aliases_include_the_short_hostname() -> None:
+    # Arrange
+    short = socket.gethostname().split(".", 1)[0].lower()
+    # Act
+    aliases = local_host_aliases()
+    # Assert
+    assert short in aliases
+
+
+def test_aliases_are_lower_cased() -> None:
+    # Arrange — the predicate lower-cases its input, so the alias set must
+    # be lower-cased too or the comparison silently never matches.
+    # Act
+    aliases = local_host_aliases()
+    # Assert
+    assert all(alias == alias.lower() for alias in aliases)
+
+
+def test_loopback_host_is_the_sidecar_bind_address() -> None:
+    # Arrange — a2a/_server.py binds ``host: str = "127.0.0.1"``. If these
+    # two ever drift, every derived local turn_url dies again.
+    # Act
+    address = LOOPBACK_HOST
+    # Assert
+    assert address == "127.0.0.1"
+
+
+def test_injected_aliases_override_the_real_hostname() -> None:
+    # Arrange — the predicate is injectable so derivation can be tested
+    # without depending on the runner's /etc/hosts.
+    # Act
+    local = is_local_host("some-box", aliases=frozenset({"some-box"}))
+    # Assert
+    assert local

--- a/tests/scitex_agent_container/_listen/test__registry_endpoints.py
+++ b/tests/scitex_agent_container/_listen/test__registry_endpoints.py
@@ -212,13 +212,19 @@ def test_derive_turn_url_returns_none_when_host_is_empty_string() -> None:
 def test_enrich_row_with_endpoint_adds_both_fields_when_sources_present(
     isolated_host_env: Path,
 ) -> None:
-    # Arrange
+    # Arrange — ``epsilon`` holds a LOCAL port claim, and the fixture's
+    # canonical host (``test-host``) IS this machine's identity. The derived
+    # turn_url must therefore name the address the a2a sidecar actually binds
+    # (127.0.0.1), NOT the canonical hostname: a hostname resolves to
+    # 127.0.1.1 on stock Debian/Ubuntu/WSL and every connection to it is
+    # refused. The old expectation here (``http://test-host:21000/…``) encoded
+    # exactly that unreachable URL. See ``_listen/_local_host.py``.
     _pa.claim_port("epsilon", range_=(21000, 21001), db_path=isolated_host_env)
     row = {"name": "epsilon"}
     # Act
     enriched = _re.enrich_row_with_endpoint(row)
     # Assert
-    assert enriched["turn_url"] == "http://test-host:21000/v1/turn"
+    assert enriched["turn_url"] == "http://127.0.0.1:21000/v1/turn"
 
 
 def test_enrich_row_with_endpoint_carries_resolved_a2a_port(

--- a/tests/scitex_agent_container/_listen/test__standby.py
+++ b/tests/scitex_agent_container/_listen/test__standby.py
@@ -6,6 +6,11 @@ port used to exit 1, which under systemd ``Restart=always`` was an
 infinite CRASH-LOOP. ``resolve_startup`` turns the second instance into
 a warm STANDBY that fails over instead of crashing.
 
+The health verdict is now THREE-state (``HolderProbe``) rather than a
+bool — see ``test__standby_false_green.py`` for the false-green
+regression suite and ``_holder_health.py`` for why two states could not
+express "I asked and got nothing".
+
 No-mocks (PA-306 / STX-NM001-003): every external effect is a
 module-level seam swapped via a hand-rolled save/restore context
 manager. The health probe runs against a REAL loopback ``http.server``
@@ -24,11 +29,14 @@ from pathlib import Path
 from typing import Iterator
 
 from scitex_agent_container._listen import _standby as std
-from scitex_agent_container._listen._port_holder import PortHealResult
+from scitex_agent_container._listen._holder_health import HolderHealth, HolderProbe
 from scitex_agent_container._listen._single_instance import (
     ListenAlreadyRunningError,
     LockHandle,
 )
+
+SERVING = HolderProbe(health=HolderHealth.SERVING, status=200)
+UNREACHABLE = HolderProbe(health=HolderHealth.UNREACHABLE, status=-1)
 
 
 @contextmanager
@@ -80,15 +88,16 @@ class _StopAfter:
         return self.calls > self._false_calls
 
 
-class _TermRecorder:
-    """Records (pid, force_kill) for each terminate call."""
+class _GracefulRecorder:
+    """Records each graceful-stop call; reports the holder as exited."""
 
-    def __init__(self) -> None:
-        self.calls: list[tuple[int, bool]] = []
+    def __init__(self, *, died: bool = True) -> None:
+        self.calls: list[int] = []
+        self._died = died
 
-    def __call__(self, pid: int, *, grace_secs: float, force_kill: bool) -> bool:
-        self.calls.append((pid, force_kill))
-        return force_kill
+    def __call__(self, pid: int, *, grace_secs: float) -> bool:
+        self.calls.append(pid)
+        return self._died
 
 
 # ---------------------------------------------------------------------------
@@ -116,23 +125,24 @@ def test_port_free_acquires_and_serves() -> None:
 
 
 # ---------------------------------------------------------------------------
-# resolve_startup — healthy holder → STAND BY, then serve when freed
+# resolve_startup — serving holder → STAND DOWN (exit 0). Never spin.
 # ---------------------------------------------------------------------------
 
 
-def test_healthy_holder_stands_by_then_serves_when_freed() -> None:
-    # Arrange — contended once behind a HEALTHY holder, then it frees.
-    sentinel = _sentinel_handle()
-    acquire = _FakeAcquire(raises=1, handle=sentinel)
-    logs: list[str] = []
+def test_serving_holder_stands_down_immediately() -> None:
+    # Arrange — another instance is already serving. That is a SUCCESS: the
+    # goal state ("a listen is serving on this port") is already true, so
+    # there is nothing to do. Returning None tells the caller to exit 0
+    # WITHOUT binding. It must NOT poll the holder forever — that spinner is
+    # what forced the operator to Ctrl-C and `kill` the holder by hand.
+    acquire = _FakeAcquire(raises=999, handle=_sentinel_handle())
     # Act
     with (
         _swap("_acquire", acquire),
-        _swap("_probe_health", lambda *_a, **_k: True),
-        _swap("_heal_untracked_port", lambda **_k: ""),
-        _swap("_read_pid", lambda _p: 4242),
+        _swap("_probe_health", lambda *_a, **_k: SERVING),
+        _swap("_read_pid", lambda _p: 745734),
         _swap("_sleep", _no_sleep),
-        _swap("_log", logs.append),
+        _swap("_log", lambda _m: None),
     ):
         result = std.resolve_startup(
             host="127.0.0.1",
@@ -140,12 +150,110 @@ def test_healthy_holder_stands_by_then_serves_when_freed() -> None:
             lock_dir=Path("/tmp"),
             standby_interval=0.01,
         )
-    # Assert — served after standing by behind the healthy holder.
-    assert result is sentinel and any("standing by behind healthy" in m for m in logs)
+    # Assert — stood down rather than binding or spinning.
+    assert result is None
 
 
-def test_healthy_holder_never_takes_over() -> None:
-    # Arrange — a healthy holder must NEVER be killed. Contended once,
+def test_serving_holder_probed_exactly_once() -> None:
+    # Arrange — THE anti-spin assertion. The old loop re-probed a healthy
+    # holder every 4s, without end. One probe is enough to decide.
+    acquire = _FakeAcquire(raises=999, handle=_sentinel_handle())
+    probes: list[int] = []
+
+    def _probe(*_a, **_k):
+        probes.append(1)
+        return SERVING
+
+    # Act
+    with (
+        _swap("_acquire", acquire),
+        _swap("_probe_health", _probe),
+        _swap("_read_pid", lambda _p: 745734),
+        _swap("_sleep", _no_sleep),
+        _swap("_log", lambda _m: None),
+    ):
+        std.resolve_startup(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=Path("/tmp"),
+            standby_interval=0.01,
+        )
+    # Assert
+    assert len(probes) == 1
+
+
+def test_serving_holder_never_sleeps() -> None:
+    # Arrange — an interactive `sac listen` behind a healthy holder must
+    # RETURN, not wait. Any sleep at all on this path is a spin.
+    acquire = _FakeAcquire(raises=999, handle=_sentinel_handle())
+    sleeps: list[float] = []
+    # Act
+    with (
+        _swap("_acquire", acquire),
+        _swap("_probe_health", lambda *_a, **_k: SERVING),
+        _swap("_read_pid", lambda _p: 745734),
+        _swap("_sleep", sleeps.append),
+        _swap("_log", lambda _m: None),
+    ):
+        std.resolve_startup(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=Path("/tmp"),
+            standby_interval=4.0,
+        )
+    # Assert
+    assert sleeps == []
+
+
+def test_already_serving_log_names_the_pid() -> None:
+    # Arrange — the operator must be told WHO is serving, so he can decide
+    # whether he wanted that process running at all.
+    acquire = _FakeAcquire(raises=999, handle=_sentinel_handle())
+    logs: list[str] = []
+    # Act
+    with (
+        _swap("_acquire", acquire),
+        _swap("_probe_health", lambda *_a, **_k: SERVING),
+        _swap("_read_pid", lambda _p: 745734),
+        _swap("_sleep", _no_sleep),
+        _swap("_log", logs.append),
+    ):
+        std.resolve_startup(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=Path("/tmp"),
+            standby_interval=0.01,
+        )
+    # Assert
+    assert any("already serving: PID 745734" in line for line in logs)
+
+
+def test_already_serving_log_states_the_evidence() -> None:
+    # Arrange — the line must report what the holder ACTUALLY did, rather
+    # than claim a bare "healthy holder" conclusion. That wording is the
+    # false-green the operator watched scroll (incident 2026-07-14).
+    acquire = _FakeAcquire(raises=999, handle=_sentinel_handle())
+    logs: list[str] = []
+    # Act
+    with (
+        _swap("_acquire", acquire),
+        _swap("_probe_health", lambda *_a, **_k: SERVING),
+        _swap("_read_pid", lambda _p: 745734),
+        _swap("_sleep", _no_sleep),
+        _swap("_log", logs.append),
+    ):
+        std.resolve_startup(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=Path("/tmp"),
+            standby_interval=0.01,
+        )
+    # Assert
+    assert any("HTTP 200" in line for line in logs)
+
+
+def test_serving_holder_never_takes_over() -> None:
+    # Arrange — a serving holder must NEVER be killed. Contended once,
     # then frees; the take-over seam must remain untouched.
     sentinel = _sentinel_handle()
     acquire = _FakeAcquire(raises=1, handle=sentinel)
@@ -153,7 +261,7 @@ def test_healthy_holder_never_takes_over() -> None:
     # Act
     with (
         _swap("_acquire", acquire),
-        _swap("_probe_health", lambda *_a, **_k: True),
+        _swap("_probe_health", lambda *_a, **_k: SERVING),
         _swap("_take_over", lambda **kw: takeovers.append(kw) or ""),
         _swap("_heal_untracked_port", lambda **_k: ""),
         _swap("_read_pid", lambda _p: 4242),
@@ -168,7 +276,7 @@ def test_healthy_holder_never_takes_over() -> None:
 
 
 # ---------------------------------------------------------------------------
-# resolve_startup — wedged (unhealthy) holder → TAKE OVER after corroboration
+# resolve_startup — wedged holder → TAKE OVER after corroboration
 # ---------------------------------------------------------------------------
 
 
@@ -182,7 +290,7 @@ def test_wedged_holder_takes_over_then_serves() -> None:
     # Act
     with (
         _swap("_acquire", acquire),
-        _swap("_probe_health", lambda *_a, **_k: False),
+        _swap("_probe_health", lambda *_a, **_k: UNREACHABLE),
         _swap("_take_over", lambda **kw: takeovers.append(kw) or ""),
         _swap("_heal_untracked_port", lambda **_k: ""),
         _swap("_read_pid", lambda _p: 4242),
@@ -206,12 +314,12 @@ def test_single_unhealthy_miss_does_not_take_over() -> None:
     # flock may not have finished binding). Threshold is 2.
     sentinel = _sentinel_handle()
     acquire = _FakeAcquire(raises=2, handle=sentinel)
-    health = iter([False, True])
+    health = iter([UNREACHABLE, SERVING])
     takeovers: list[dict] = []
     # Act
     with (
         _swap("_acquire", acquire),
-        _swap("_probe_health", lambda *_a, **_k: next(health, True)),
+        _swap("_probe_health", lambda *_a, **_k: next(health, SERVING)),
         _swap("_take_over", lambda **kw: takeovers.append(kw) or ""),
         _swap("_heal_untracked_port", lambda **_k: ""),
         _swap("_read_pid", lambda _p: 4242),
@@ -234,15 +342,18 @@ def test_single_unhealthy_miss_does_not_take_over() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_stop_signal_during_standby_exits_without_binding() -> None:
-    # Arrange — perpetually contended behind a healthy holder; a stop is
-    # flagged on the first standby wait. resolve_startup must return None
-    # (the caller then exits WITHOUT binding) rather than loop forever.
+def test_stop_signal_during_recheck_exits_without_binding() -> None:
+    # Arrange — a SUSPECT holder (so we are inside the bounded re-check
+    # window, the only place that waits at all); a stop is flagged on the
+    # first re-check pause. ``systemctl stop`` / Ctrl-C must be a prompt
+    # clean exit that never binds and never takes over.
     acquire = _FakeAcquire(raises=999, handle=_sentinel_handle())
+    takeovers: list[dict] = []
     # Act
     with (
         _swap("_acquire", acquire),
-        _swap("_probe_health", lambda *_a, **_k: True),
+        _swap("_probe_health", lambda *_a, **_k: UNREACHABLE),
+        _swap("_take_over", lambda **kw: takeovers.append(kw) or ""),
         _swap("_read_pid", lambda _p: 4242),
         _swap("_sleep", _no_sleep),
         _swap("_should_stop", _StopAfter(1)),
@@ -254,19 +365,19 @@ def test_stop_signal_during_standby_exits_without_binding() -> None:
             lock_dir=Path("/tmp"),
             standby_interval=0.01,
         )
-    # Assert — clean standby exit signalled by None.
+    # Assert — clean exit signalled by None.
     assert result is None
 
 
 # ---------------------------------------------------------------------------
-# resolve_startup — unkillable port remnant on the serve path → stand by
+# resolve_startup — unkillable port remnant on the serve path
 # ---------------------------------------------------------------------------
 
 
-def test_unkillable_port_remnant_releases_lock_and_stands_by() -> None:
+def test_unkillable_port_remnant_releases_lock_and_retries() -> None:
     # Arrange — the flock acquires but an untracked remnant holds the port
     # and cannot be freed. Rather than crash-loop into EADDRINUSE, the
-    # loop must RELEASE the flock and stand by (here we then stop).
+    # loop must RELEASE the flock and retry (here we then stop).
     sentinel = _sentinel_handle()
     acquire = _FakeAcquire(raises=0, handle=sentinel)
     releases: list[LockHandle] = []
@@ -343,20 +454,19 @@ def test_signal_guard_restores_prior_sigterm_handler() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _default_take_over — kill holder + clear port + drop stale pidfile
+# _default_take_over — ASK the holder to leave; never destroy it
 # ---------------------------------------------------------------------------
 
 
-def test_take_over_terminates_the_tracked_holder_pid(tmp_path: Path) -> None:
+def test_take_over_gracefully_stops_the_tracked_holder(tmp_path: Path) -> None:
     # Arrange — a live tracked holder named by the pidfile.
     port = 7878
     (tmp_path / f"listen-{port}.pid").write_text("4242\n")
-    term = _TermRecorder()
+    graceful = _GracefulRecorder()
     # Act
     with (
         _swap("pid_alive", lambda _p: True),
-        _swap("_terminate", term),
-        _swap("_clear_port", lambda **_k: PortHealResult()),
+        _swap("_terminate_graceful", graceful),
         _swap("_sleep", _no_sleep),
     ):
         std._default_take_over(
@@ -366,20 +476,22 @@ def test_take_over_terminates_the_tracked_holder_pid(tmp_path: Path) -> None:
             holder_pid=4242,
             grace_secs=1.0,
         )
-    # Assert — SIGTERM-first escalation against the holder PID.
-    assert term.calls == [(4242, False)]
+    # Assert — a graceful SIGTERM against the holder PID.
+    assert graceful.calls == [4242]
 
 
-def test_take_over_removes_the_stale_pidfile(tmp_path: Path) -> None:
-    # Arrange — pidfile present; take-over must drop it.
+def test_take_over_keeps_the_pidfile_intact(tmp_path: Path) -> None:
+    # Arrange — the take-over must NOT unlink the pidfile. The flock (not
+    # the file's existence) is the bind arbiter, and unlinking it lets a
+    # racing standby flock the OLD inode while a fresh acquirer creates a
+    # NEW one — both would then "hold the lock" and both would bind.
     port = 7878
     pidfile = tmp_path / f"listen-{port}.pid"
     pidfile.write_text("4242\n")
     # Act
     with (
-        _swap("pid_alive", lambda _p: False),
-        _swap("_terminate", _TermRecorder()),
-        _swap("_clear_port", lambda **_k: PortHealResult()),
+        _swap("pid_alive", lambda _p: True),
+        _swap("_terminate_graceful", _GracefulRecorder()),
         _swap("_sleep", _no_sleep),
     ):
         std._default_take_over(
@@ -390,18 +502,19 @@ def test_take_over_removes_the_stale_pidfile(tmp_path: Path) -> None:
             grace_secs=1.0,
         )
     # Assert
-    assert not pidfile.exists()
+    assert pidfile.exists()
 
 
-def test_take_over_surfaces_unkillable_port_error(tmp_path: Path) -> None:
-    # Arrange — the port stays held after the kill (unkillable remnant).
+def test_take_over_of_dead_holder_is_a_noop(tmp_path: Path) -> None:
+    # Arrange — the holder is already gone; the kernel released its flock,
+    # so there is nothing to stop and no error to report.
     port = 7878
     (tmp_path / f"listen-{port}.pid").write_text("4242\n")
+    graceful = _GracefulRecorder()
     # Act
     with (
         _swap("pid_alive", lambda _p: False),
-        _swap("_terminate", _TermRecorder()),
-        _swap("_clear_port", lambda **_k: PortHealResult(error="still held by PID 9")),
+        _swap("_terminate_graceful", graceful),
         _swap("_sleep", _no_sleep),
     ):
         error = std._default_take_over(
@@ -411,16 +524,38 @@ def test_take_over_surfaces_unkillable_port_error(tmp_path: Path) -> None:
             holder_pid=4242,
             grace_secs=1.0,
         )
-    # Assert — the loud port error is surfaced to the caller.
-    assert "still held by PID 9" in error
+    # Assert — no signal sent, no error.
+    assert error == "" and graceful.calls == []
+
+
+def test_take_over_surfaces_sigterm_refusal(tmp_path: Path) -> None:
+    # Arrange — the holder ignores SIGTERM. We do NOT escalate; we report
+    # a loud, actionable failure and let the human decide.
+    port = 7878
+    (tmp_path / f"listen-{port}.pid").write_text("4242\n")
+    # Act
+    with (
+        _swap("pid_alive", lambda _p: True),
+        _swap("_terminate_graceful", _GracefulRecorder(died=False)),
+        _swap("_sleep", _no_sleep),
+    ):
+        error = std._default_take_over(
+            host="127.0.0.1",
+            port=port,
+            lock_dir=tmp_path,
+            holder_pid=4242,
+            grace_secs=1.0,
+        )
+    # Assert
+    assert "sac listen restart --force" in error
 
 
 # ---------------------------------------------------------------------------
-# _default_probe_health — REAL loopback socket, bounded
+# _default_probe_health — REAL loopback socket, bounded, three-state
 # ---------------------------------------------------------------------------
 
 
-def test_probe_health_true_for_live_loopback_server() -> None:
+def test_probe_health_serving_for_live_loopback_server() -> None:
     # Arrange — a real HTTP server answering any GET (proves "up").
     import http.server
 
@@ -438,17 +573,26 @@ def test_probe_health_true_for_live_loopback_server() -> None:
     thread.start()
     # Act
     try:
-        healthy = std._default_probe_health("127.0.0.1", port, timeout=1.0)
+        probe = std._default_probe_health("127.0.0.1", port, timeout=1.0)
     finally:
         server.shutdown()
         thread.join(timeout=2.0)
     # Assert
-    assert healthy is True
+    assert probe.health is HolderHealth.SERVING
 
 
-def test_probe_health_false_for_closed_port() -> None:
-    # Arrange — port 1 on loopback refuses (transport failure == down).
+def test_probe_health_unreachable_for_closed_port() -> None:
+    # Arrange — port 1 on loopback refuses. "I asked and got nothing" is
+    # its own state; it is emphatically NOT health.
     # Act
-    healthy = std._default_probe_health("127.0.0.1", 1, timeout=0.2)
+    probe = std._default_probe_health("127.0.0.1", 1, timeout=0.2)
     # Assert
-    assert healthy is False
+    assert probe.health is HolderHealth.UNREACHABLE
+
+
+def test_probe_health_closed_port_is_not_serving() -> None:
+    # Arrange — the ``serving`` predicate is what the loop branches on.
+    # Act
+    probe = std._default_probe_health("127.0.0.1", 1, timeout=0.2)
+    # Assert
+    assert probe.serving is False

--- a/tests/scitex_agent_container/_listen/test__standby_false_green.py
+++ b/tests/scitex_agent_container/_listen/test__standby_false_green.py
@@ -1,0 +1,562 @@
+"""Regression tests: the standby loop must never call a DEAD holder healthy.
+
+Operator incident 2026-07-14 — ``sac listen`` printed this, forever::
+
+    # sac listen: holder PID 738982 on 127.0.0.1:7878 not answering health
+      (1/2) — re-checking in 4.0s before taking over
+    # sac listen: standing by behind healthy holder PID 738982 on 127.0.0.1:7878
+    # sac listen: standing by behind healthy holder PID 738982 on 127.0.0.1:7878
+    ... (forever)
+
+…while PID 738982 answered nothing and the whole fleet was cut off from
+the host. Note the shape: it SAW the failed check, then went back to
+calling the same holder "healthy". Two defects produced that:
+
+1. ``consecutive_unhealthy = 0`` was reset by ANY single lucky reply, so
+   a FLAPPING holder — one that answers one probe in N, which is exactly
+   what the live 7878 daemon does (HTTP 200 one minute, ``Connection
+   refused`` the next; measured on this box) — could never accumulate the
+   CONSECUTIVE failures the take-over threshold demands. The record of
+   the failed check was erased by the next lucky reply.
+2. ``_default_probe_health`` was ``_http_get(...) > 0``, so ANY HTTP
+   status — including a 5xx from a daemon whose health route is erroring
+   — read as a "healthy holder".
+
+Both are one class of bug: a DECLARED state trusted as an OBSERVED one.
+And an unbounded standby loop hides it forever instead of failing loud.
+
+No-mocks (PA-306 / STX-NM001-003): every holder here is a REAL HTTP
+server on a REAL loopback socket, always on an ephemeral kernel-assigned
+port — these tests NEVER touch the live 7878 control plane.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import http.server
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._listen import _standby as std
+from scitex_agent_container._listen._single_instance import (
+    ListenAlreadyRunningError,
+    LockHandle,
+)
+
+HOLDER_PID = 738982  # the operator's actual wedged holder
+
+
+@contextmanager
+def _swap(name: str, value) -> Iterator[None]:
+    saved = getattr(std, name)
+    setattr(std, name, value)
+    try:
+        yield
+    finally:
+        setattr(std, name, saved)
+
+
+def _no_sleep(_secs: float) -> None:
+    """No-op sleep seam — keeps the loop's cadence out of wall-clock."""
+
+
+class _AlwaysContended:
+    """``_acquire`` seam that NEVER hands over the lock.
+
+    Models the holder keeping its flock: the loop can only escape by
+    taking over or failing loud, never by the port quietly freeing itself.
+    """
+
+    def __call__(self, *, port: int, lock_dir: Path) -> LockHandle:
+        raise ListenAlreadyRunningError("held")
+
+
+class _StopAfter:
+    """``_should_stop`` seam: False for ``false_calls`` polls, then True.
+
+    A GUARD-RAIL, not part of the contract under test — it bounds a loop
+    that (on the buggy code) would otherwise spin forever and hang CI.
+    Reaching it means the loop never reached a decision on its own.
+    """
+
+    def __init__(self, false_calls: int) -> None:
+        self._false_calls = false_calls
+        self.calls = 0
+
+    def __call__(self) -> bool:
+        self.calls += 1
+        return self.calls > self._false_calls
+
+
+@contextmanager
+def _real_holder(status_sequence: list[int]) -> Iterator[int]:
+    """Run a REAL HTTP server on an ephemeral loopback port.
+
+    ``status_sequence`` is cycled: each ``/v1/health`` GET is answered
+    with the next status. A ``0`` entry means "answer NOTHING" — the
+    handler slams the connection shut without a response, which is what a
+    wedged holder looks like on the wire. Yields the bound port.
+    """
+    seq = list(status_sequence)
+    counter = {"i": 0}
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.0"
+
+        def do_GET(self) -> None:  # noqa: N802 (stdlib handler contract)
+            status = seq[counter["i"] % len(seq)]
+            counter["i"] += 1
+            if status == 0:
+                self.close_connection = True
+                return
+            self.send_response(status)
+            self.end_headers()
+
+        def log_message(self, *_args) -> None:
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+
+
+def _takeovers_against(port: int, *, stop_after: int = 12) -> list[dict]:
+    """Drive ``resolve_startup`` against the REAL holder on ``port``.
+
+    The health probe is NOT swapped — the real one runs against the real
+    socket. Returns the take-over calls the loop made; empty means it
+    stood by behind the holder instead of ever acting on it.
+    """
+    takeovers: list[dict] = []
+    with (
+        _swap("_acquire", _AlwaysContended()),
+        _swap("_take_over", lambda **kw: takeovers.append(kw) or ""),
+        _swap("_heal_untracked_port", lambda **_k: ""),
+        _swap("_read_pid", lambda _p: HOLDER_PID),
+        _swap("_sleep", _no_sleep),
+        _swap("_should_stop", _StopAfter(stop_after)),
+        _swap("_log", lambda _m: None),
+    ):
+        std.resolve_startup(
+            host="127.0.0.1",
+            port=port,
+            lock_dir=Path("/nonexistent"),
+            standby_interval=0.01,
+            health_timeout=0.5,
+            unhealthy_takeover_threshold=2,
+        )
+    return takeovers
+
+
+def _failure_message(port: int, *, take_over_error: str) -> str:
+    """Return the ``ListenTakeoverFailed`` message, or ``""`` if none was raised.
+
+    The ``_should_stop`` guard-rail bounds the OLD (unbounded) loop so a
+    non-failing implementation returns ``""`` instead of hanging CI.
+    """
+    with (
+        _swap("_acquire", _AlwaysContended()),
+        _swap("_take_over", lambda **_kw: take_over_error),
+        _swap("_heal_untracked_port", lambda **_k: ""),
+        _swap("_read_pid", lambda _p: HOLDER_PID),
+        _swap("_sleep", _no_sleep),
+        _swap("_should_stop", _StopAfter(40)),
+        _swap("_log", lambda _m: None),
+    ):
+        try:
+            std.resolve_startup(
+                host="127.0.0.1",
+                port=port,
+                lock_dir=Path("/nonexistent"),
+                standby_interval=0.01,
+                health_timeout=0.5,
+                unhealthy_takeover_threshold=2,
+            )
+        except std.ListenTakeoverFailed as exc:
+            return str(exc)
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 — a FLAPPING holder must not have its failure record erased
+# ---------------------------------------------------------------------------
+
+
+def test_flapping_holder_is_eventually_taken_over() -> None:
+    # Arrange — the operator's exact holder: it misses a health check, then
+    # answers, then misses… The old loop wiped ``consecutive_unhealthy`` on
+    # every lucky 200, so the corroboration threshold was NEVER reached and
+    # it stood by behind a dead holder forever.
+    with _real_holder([0, 200, 0, 200, 0, 200, 0, 200]) as port:
+        # Act
+        takeovers = _takeovers_against(port)
+    # Assert
+    assert takeovers, (
+        "the standby loop never took over a holder that repeatedly failed "
+        "/v1/health — one lucky reply erased the record of the failure"
+    )
+
+
+def test_flapping_holder_never_logged_as_healthy() -> None:
+    # Arrange — a holder that has FAILED a check must never afterwards be
+    # rendered to the operator as a "healthy holder". That log line is the
+    # false-green he sat and watched scroll while the fleet was cut off.
+    logs: list[str] = []
+    with _real_holder([0, 200, 0, 200, 0, 200]) as port:
+        # Act
+        with (
+            _swap("_acquire", _AlwaysContended()),
+            _swap("_take_over", lambda **_kw: ""),
+            _swap("_heal_untracked_port", lambda **_k: ""),
+            _swap("_read_pid", lambda _p: HOLDER_PID),
+            _swap("_sleep", _no_sleep),
+            _swap("_should_stop", _StopAfter(8)),
+            _swap("_log", logs.append),
+        ):
+            std.resolve_startup(
+                host="127.0.0.1",
+                port=port,
+                lock_dir=Path("/nonexistent"),
+                standby_interval=0.01,
+                health_timeout=0.5,
+                unhealthy_takeover_threshold=2,
+            )
+    # Assert
+    assert not any("healthy holder" in line for line in logs), (
+        f"a holder that failed its health check was still announced as a "
+        f"'healthy holder': {logs!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defect 2 — an answering-but-erroring holder is NOT healthy
+# ---------------------------------------------------------------------------
+
+
+def test_server_error_holder_is_taken_over() -> None:
+    # Arrange — the holder answers every /v1/health with 503: bound and
+    # speaking HTTP, but NOT serving. The old probe was ``_http_get() > 0``,
+    # so a 503 read as a healthy holder — forever.
+    with _real_holder([503]) as port:
+        # Act
+        takeovers = _takeovers_against(port, stop_after=10)
+    # Assert
+    assert takeovers, (
+        "a holder answering /v1/health with 503 was treated as healthy — any "
+        "HTTP status counted as health, so a broken daemon was never taken over"
+    )
+
+
+def test_auth_gated_holder_is_never_taken_over() -> None:
+    # Arrange — the load-bearing counterpart (card
+    # sac-listen-restart-healthcheck-bearer / PR #463): a 401 PROVES the
+    # daemon is up and auth-gating. A false-RED here would destroy a
+    # perfectly healthy control plane — strictly worse than the false-green
+    # this PR fixes. It must NEVER be taken over.
+    with _real_holder([401]) as port:
+        # Act
+        takeovers = _takeovers_against(port, stop_after=10)
+    # Assert
+    assert takeovers == []
+
+
+def test_serving_holder_is_never_taken_over() -> None:
+    # Arrange — the warm-standby path must survive the fix: a holder that
+    # answers 200 every time is a working primary. Standing by behind it is
+    # the FEATURE (#640); killing it would BE the outage.
+    with _real_holder([200]) as port:
+        # Act
+        takeovers = _takeovers_against(port, stop_after=10)
+    # Assert
+    assert takeovers == []
+
+
+# ---------------------------------------------------------------------------
+# Defect 3 — the loop must be BOUNDED: take over, or FAIL LOUD
+# ---------------------------------------------------------------------------
+
+
+def test_unfreeable_holder_fails_loud_instead_of_spinning() -> None:
+    # Arrange — the holder never answers AND the take-over can never free
+    # the port. The old loop logged "standing by, will retry" and span
+    # forever, silently, while the operator watched.
+    with _real_holder([0]) as port:
+        # Act
+        message = _failure_message(port, take_over_error="port still held")
+    # Assert — it terminated with a loud error instead of hiding the outage.
+    assert message, "the standby loop span forever instead of failing loud"
+
+
+def test_takeover_failure_names_the_holder_pid() -> None:
+    # Arrange — the message must name the PID a human has to act on.
+    with _real_holder([0]) as port:
+        # Act
+        message = _failure_message(port, take_over_error="port still held")
+    # Assert
+    assert str(HOLDER_PID) in message
+
+
+def test_takeover_failure_names_the_exact_remedy() -> None:
+    # Arrange — "a message a human can act on": the exact command to run.
+    with _real_holder([0]) as port:
+        # Act
+        message = _failure_message(port, take_over_error="port still held")
+    # Assert
+    assert "sac listen restart --force" in message
+
+
+def test_takeover_failure_names_the_health_evidence() -> None:
+    # Arrange — the message must state what was OBSERVED (the holder did
+    # not answer /v1/health), never merely assert a conclusion.
+    with _real_holder([0]) as port:
+        # Act
+        message = _failure_message(port, take_over_error="port still held")
+    # Assert
+    assert "/v1/health" in message
+
+
+# ---------------------------------------------------------------------------
+# Never destroy on a negative signal
+# ---------------------------------------------------------------------------
+
+
+def test_takeover_never_uses_the_sigkill_escalator(tmp_path: Path) -> None:
+    # Arrange — a probe-based "wedged" verdict must never SIGKILL: the
+    # false-RED is worse than the false-green. The holder gets a graceful
+    # SIGTERM and nothing more; if it ignores that, the human decides.
+    escalations: list[int] = []
+    (tmp_path / "listen-7999.pid").write_text(f"{HOLDER_PID}\n")
+    # Act
+    with (
+        _swap("_terminate", lambda pid, **_kw: escalations.append(pid) or False),
+        _swap("_terminate_graceful", lambda _pid, **_kw: True),
+        _swap("pid_alive", lambda _p: True),
+        _swap("_sleep", _no_sleep),
+    ):
+        std._default_take_over(
+            host="127.0.0.1",
+            port=7999,
+            lock_dir=tmp_path,
+            holder_pid=HOLDER_PID,
+            grace_secs=0.05,
+        )
+    # Assert — the TERM→SIGKILL escalator was never reached.
+    assert escalations == []
+
+
+def test_surviving_holder_keeps_its_pidfile(tmp_path: Path) -> None:
+    # Arrange — the old take-over unlinked the pidfile even when the holder
+    # was still ALIVE. That (a) let a second daemon start beside a live one
+    # and (b) broke the flock's atomic-bind invariant: a racing standby
+    # holding an flock on the OLD inode and a new acquirer creating a FRESH
+    # inode would BOTH believe they held "the lock".
+    pidfile = tmp_path / "listen-7999.pid"
+    pidfile.write_text(f"{HOLDER_PID}\n")
+    # Act — the holder ignores SIGTERM and stays alive.
+    with (
+        _swap("_terminate_graceful", lambda _pid, **_kw: False),
+        _swap("pid_alive", lambda _p: True),
+        _swap("_sleep", _no_sleep),
+    ):
+        std._default_take_over(
+            host="127.0.0.1",
+            port=7999,
+            lock_dir=tmp_path,
+            holder_pid=HOLDER_PID,
+            grace_secs=0.05,
+        )
+    # Assert — a LIVE holder's pidfile is left exactly where it was.
+    assert pidfile.exists()
+
+
+def test_surviving_holder_surfaces_loud_error(tmp_path: Path) -> None:
+    # Arrange — a holder that ignores SIGTERM is NOT escalated; the
+    # take-over reports a loud, actionable failure to the caller instead.
+    pidfile = tmp_path / "listen-7999.pid"
+    pidfile.write_text(f"{HOLDER_PID}\n")
+    # Act
+    with (
+        _swap("_terminate_graceful", lambda _pid, **_kw: False),
+        _swap("pid_alive", lambda _p: True),
+        _swap("_sleep", _no_sleep),
+    ):
+        error = std._default_take_over(
+            host="127.0.0.1",
+            port=7999,
+            lock_dir=tmp_path,
+            holder_pid=HOLDER_PID,
+            grace_secs=0.05,
+        )
+    # Assert
+    assert "sac listen restart --force" in error
+
+
+def test_dead_holder_takeover_reports_success(tmp_path: Path) -> None:
+    # Arrange — the ordinary failover: the holder exits on SIGTERM, the
+    # kernel releases its flock, and the loop re-acquires. No error.
+    (tmp_path / "listen-7999.pid").write_text(f"{HOLDER_PID}\n")
+    # Act
+    with (
+        _swap("_terminate_graceful", lambda _pid, **_kw: True),
+        _swap("pid_alive", lambda _p: True),
+        _swap("_sleep", _no_sleep),
+    ):
+        error = std._default_take_over(
+            host="127.0.0.1",
+            port=7999,
+            lock_dir=tmp_path,
+            holder_pid=HOLDER_PID,
+            grace_secs=0.05,
+        )
+    # Assert
+    assert error == ""
+
+
+# ---------------------------------------------------------------------------
+# The stop signal still wins (systemctl stop during standby stays clean)
+# ---------------------------------------------------------------------------
+
+
+def test_stop_signal_still_exits_without_binding() -> None:
+    # Arrange — a SIGTERM landing inside the bounded re-check window (the
+    # only place that waits at all) must be a prompt clean exit: no bind,
+    # no take-over, no exception.
+    with _real_holder([0]) as port:
+        # Act
+        with (
+            _swap("_acquire", _AlwaysContended()),
+            _swap("_take_over", lambda **_kw: ""),
+            _swap("_read_pid", lambda _p: HOLDER_PID),
+            _swap("_sleep", _no_sleep),
+            _swap("_should_stop", _StopAfter(1)),
+            _swap("_log", lambda _m: None),
+        ):
+            result = std.resolve_startup(
+                host="127.0.0.1",
+                port=port,
+                lock_dir=Path("/nonexistent"),
+                standby_interval=0.01,
+                health_timeout=0.5,
+            )
+    # Assert
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Defect 0 — a HEALTHY holder must make `sac listen` STAND DOWN, not spin
+# ---------------------------------------------------------------------------
+
+
+def test_serving_holder_stands_down_immediately() -> None:
+    # Arrange — the operator's second incident. `sac listen` behind a
+    # perfectly healthy holder printed "standing by behind healthy holder"
+    # every 4s FOREVER; the only escape was Ctrl-C, and then he had to
+    # `kill` the holder BY HAND. "Someone else is already serving" is a
+    # SUCCESS: return, so the human gets his shell back.
+    with _real_holder([200]) as port:
+        # Act
+        with (
+            _swap("_acquire", _AlwaysContended()),
+            _swap("_read_pid", lambda _p: 745734),
+            _swap("_sleep", _no_sleep),
+            _swap("_log", lambda _m: None),
+        ):
+            result = std.resolve_startup(
+                host="127.0.0.1",
+                port=port,
+                lock_dir=Path("/nonexistent"),
+                standby_interval=0.01,
+                health_timeout=0.5,
+            )
+    # Assert — decided, and returned. No spin, no bind.
+    assert result is None
+
+
+def test_serving_holder_never_polls_again() -> None:
+    # Arrange — THE anti-spin assertion, against a REAL healthy holder: it
+    # must be probed once and decided on. Every extra poll was another
+    # "standing by behind healthy holder" line scrolling past the operator.
+    sleeps: list[float] = []
+    with _real_holder([200]) as port:
+        # Act
+        with (
+            _swap("_acquire", _AlwaysContended()),
+            _swap("_read_pid", lambda _p: 745734),
+            _swap("_sleep", sleeps.append),
+            _swap("_log", lambda _m: None),
+        ):
+            std.resolve_startup(
+                host="127.0.0.1",
+                port=port,
+                lock_dir=Path("/nonexistent"),
+                standby_interval=4.0,
+                health_timeout=0.5,
+            )
+    # Assert — it never waited, so it cannot have looped.
+    assert sleeps == []
+
+
+def test_serving_holder_reports_nothing_to_do() -> None:
+    # Arrange — the operator asked why he had to kill by hand. The answer
+    # has to be on screen: who is serving, and that there is nothing to do.
+    logs: list[str] = []
+    with _real_holder([200]) as port:
+        # Act
+        with (
+            _swap("_acquire", _AlwaysContended()),
+            _swap("_read_pid", lambda _p: 745734),
+            _swap("_sleep", _no_sleep),
+            _swap("_log", logs.append),
+        ):
+            std.resolve_startup(
+                host="127.0.0.1",
+                port=port,
+                lock_dir=Path("/nonexistent"),
+                standby_interval=0.01,
+                health_timeout=0.5,
+            )
+    # Assert
+    assert any("already serving: PID 745734" in line for line in logs)
+
+
+def test_takeover_failed_is_a_runtime_error() -> None:
+    # Arrange — ListenTakeoverFailed must be a distinct, catchable type so
+    # the CLI can map it to a non-zero exit carrying the operator's message.
+    failure_type = std.ListenTakeoverFailed
+    # Act
+    is_runtime_error = issubclass(failure_type, RuntimeError)
+    # Assert
+    assert is_runtime_error
+
+
+def test_takeover_failed_is_not_already_running() -> None:
+    # Arrange — the two must not be conflated: contention is NORMAL (stand
+    # by), an unfreeable wedged holder is an OUTAGE (fail loud).
+    failure_type = std.ListenTakeoverFailed
+    # Act
+    conflated = issubclass(failure_type, ListenAlreadyRunningError)
+    # Assert
+    assert not conflated
+
+
+@pytest.mark.parametrize("status", [200, 204, 401, 403, 404])
+def test_answering_holder_is_not_taken_over(status: int) -> None:
+    # Arrange — every sub-500 answer PROVES the daemon is bound and
+    # speaking HTTP. None of them may trigger a destroy.
+    with _real_holder([status]) as port:
+        # Act
+        takeovers = _takeovers_against(port, stop_after=8)
+    # Assert
+    assert takeovers == []

--- a/tests/scitex_agent_container/_listen/test__standby_ledger.py
+++ b/tests/scitex_agent_container/_listen/test__standby_ledger.py
@@ -1,0 +1,237 @@
+"""Tests for ``_listen/_standby_ledger.py`` — a failed check is never erased.
+
+The rule under test: **a failure is a fact; one later success does not
+un-happen it.** The counter this ledger replaces did ``consecutive_
+unhealthy = 0`` on ANY single lucky reply, so a FLAPPING holder — which
+is exactly what the live 7878 daemon does (HTTP 200 one minute,
+``Connection refused`` the next) — never accumulated the consecutive
+failures the take-over threshold demanded, and ``sac listen`` stood by
+behind a dead holder forever.
+
+The counter-invariant matters just as much: a genuinely healthy holder
+that blips ONCE must not be destroyed. It clears its suspicion by
+answering again, repeatedly.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._listen._holder_health import HolderHealth, HolderProbe
+from scitex_agent_container._listen._standby_ledger import (
+    HolderLedger,
+    ListenTakeoverFailed,
+    takeover_failure_message,
+)
+
+SERVING = HolderProbe(health=HolderHealth.SERVING, status=200)
+UNREACHABLE = HolderProbe(health=HolderHealth.UNREACHABLE, status=-1)
+NOT_SERVING = HolderProbe(health=HolderHealth.NOT_SERVING, status=503)
+
+
+def _feed(ledger: HolderLedger, probes: list[HolderProbe]) -> None:
+    for probe in probes:
+        ledger.record(probe)
+
+
+# ---------------------------------------------------------------------------
+# The defect: a lucky reply must not erase a failure
+# ---------------------------------------------------------------------------
+
+
+def test_lucky_reply_does_not_erase_failure() -> None:
+    # Arrange — THE regression. Old behaviour: the 200 reset the counter
+    # to zero and the holder was announced "healthy" again.
+    ledger = HolderLedger(threshold=2)
+    # Act
+    _feed(ledger, [UNREACHABLE, SERVING])
+    # Assert — the failure still stands on the books.
+    assert ledger.failures == 1
+
+
+def test_flapping_holder_eventually_corroborates() -> None:
+    # Arrange — miss, answer, miss: the operator's actual holder. With the
+    # old counter this could never reach the threshold.
+    ledger = HolderLedger(threshold=2)
+    # Act
+    _feed(ledger, [UNREACHABLE, SERVING, UNREACHABLE])
+    # Assert — the wedged verdict is now corroborated and can be acted on.
+    assert ledger.corroborated
+
+
+def test_flapping_holder_stays_suspect_after_reply() -> None:
+    # Arrange — while a failure stands un-cleared the holder is SUSPECT,
+    # so the loop must not print "standing by behind healthy holder".
+    ledger = HolderLedger(threshold=2)
+    # Act
+    _feed(ledger, [UNREACHABLE, SERVING])
+    # Assert
+    assert ledger.suspect
+
+
+# ---------------------------------------------------------------------------
+# The counter-invariant: a single blip must not destroy a healthy holder
+# ---------------------------------------------------------------------------
+
+
+def test_sustained_recovery_clears_the_suspicion() -> None:
+    # Arrange — one blip, then the holder answers consistently. It is
+    # healthy; killing it would BE the outage.
+    ledger = HolderLedger(threshold=2)
+    # Act
+    _feed(ledger, [UNREACHABLE, SERVING, SERVING])
+    # Assert
+    assert ledger.failures == 0
+
+
+def test_recovery_transition_is_reported() -> None:
+    # Arrange — "the thing I said was broken now looks fine" is a
+    # transition the operator must never have hidden from them, so the
+    # ledger reports it for a LOUD log line.
+    ledger = HolderLedger(threshold=2)
+    _feed(ledger, [UNREACHABLE, SERVING])
+    # Act
+    recovered = ledger.record(SERVING)
+    # Assert
+    assert recovered is True
+
+
+def test_recovered_holder_is_no_longer_suspect() -> None:
+    # Arrange
+    ledger = HolderLedger(threshold=2)
+    # Act
+    _feed(ledger, [UNREACHABLE, SERVING, SERVING])
+    # Assert
+    assert not ledger.suspect
+
+
+def test_clean_holder_is_never_suspect() -> None:
+    # Arrange — a holder that has never missed must stand by silently.
+    ledger = HolderLedger(threshold=2)
+    # Act
+    _feed(ledger, [SERVING, SERVING, SERVING])
+    # Assert
+    assert not ledger.suspect
+
+
+def test_clean_holder_reports_no_recovery() -> None:
+    # Arrange — nothing to recover FROM, so no loud line is emitted.
+    ledger = HolderLedger(threshold=2)
+    # Act
+    recovered = ledger.record(SERVING)
+    # Assert
+    assert recovered is False
+
+
+# ---------------------------------------------------------------------------
+# Both failure kinds count
+# ---------------------------------------------------------------------------
+
+
+def test_server_error_counts_as_failure() -> None:
+    # Arrange — a 503 is an ANSWER but not health. It must accrue.
+    ledger = HolderLedger(threshold=2)
+    # Act
+    _feed(ledger, [NOT_SERVING, NOT_SERVING])
+    # Assert
+    assert ledger.corroborated
+
+
+def test_single_miss_is_not_corroborated() -> None:
+    # Arrange — corroboration protects a daemon that merely has not
+    # finished binding yet. One miss is never enough to act.
+    ledger = HolderLedger(threshold=2)
+    # Act
+    ledger.record(UNREACHABLE)
+    # Assert
+    assert not ledger.corroborated
+
+
+def test_reset_forgets_the_history() -> None:
+    # Arrange — after a take-over the world changed; the old observations
+    # no longer describe the process now holding the flock.
+    ledger = HolderLedger(threshold=2)
+    _feed(ledger, [UNREACHABLE, UNREACHABLE])
+    # Act
+    ledger.reset()
+    # Assert
+    assert ledger.failures == 0
+
+
+# ---------------------------------------------------------------------------
+# takeover_failure_message — loud + actionable
+# ---------------------------------------------------------------------------
+
+
+def test_failure_message_names_the_holder_pid() -> None:
+    # Arrange
+    # Act
+    message = takeover_failure_message(
+        host="127.0.0.1",
+        port=7878,
+        holder_pid=738982,
+        probe=UNREACHABLE,
+        failures=2,
+        attempts=3,
+        error="ignored SIGTERM",
+    )
+    # Assert
+    assert "738982" in message
+
+
+def test_failure_message_names_the_remedy() -> None:
+    # Arrange
+    # Act
+    message = takeover_failure_message(
+        host="127.0.0.1",
+        port=7878,
+        holder_pid=738982,
+        probe=UNREACHABLE,
+        failures=2,
+        attempts=3,
+        error="ignored SIGTERM",
+    )
+    # Assert
+    assert "sac listen restart --force" in message
+
+
+def test_failure_message_explains_the_refusal() -> None:
+    # Arrange — the operator must understand WHY we did not force it, or
+    # the next person will just add the SIGKILL back.
+    # Act
+    message = takeover_failure_message(
+        host="127.0.0.1",
+        port=7878,
+        holder_pid=738982,
+        probe=UNREACHABLE,
+        failures=2,
+        attempts=3,
+        error="ignored SIGTERM",
+    )
+    # Assert
+    assert "Refusing to SIGKILL" in message
+
+
+def test_failure_message_states_the_evidence() -> None:
+    # Arrange — what was OBSERVED, not merely what was concluded.
+    # Act
+    message = takeover_failure_message(
+        host="127.0.0.1",
+        port=7878,
+        holder_pid=738982,
+        probe=UNREACHABLE,
+        failures=2,
+        attempts=3,
+        error="ignored SIGTERM",
+    )
+    # Assert
+    assert "/v1/health" in message
+
+
+def test_takeover_failed_is_a_runtime_error() -> None:
+    # Arrange
+    failure_type = ListenTakeoverFailed
+    # Act
+    is_runtime = issubclass(failure_type, RuntimeError)
+    # Assert
+    assert is_runtime

--- a/tests/scitex_agent_container/_listen/test__standby_signal.py
+++ b/tests/scitex_agent_container/_listen/test__standby_signal.py
@@ -1,0 +1,110 @@
+"""Tests for ``_listen/_standby_signal.py`` — a prompt, clean stop mid-decision.
+
+``resolve_startup`` may spend a few seconds re-checking a holder that failed
+its health check. A ``systemctl stop`` (or Ctrl-C) landing in that window must
+produce a prompt clean exit — not a ``KeyboardInterrupt`` traceback, and not a
+process that ignores the signal.
+
+No-mocks (PA-306 / STX-NM001-003): the handler the guard installed is invoked
+exactly as the kernel would — the REAL registered callable — and handler
+restoration is asserted against the REAL ``signal.getsignal``.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import signal
+
+from scitex_agent_container._listen._standby_signal import StopFlag, stop_flag_guard
+
+
+# ---------------------------------------------------------------------------
+# StopFlag — a one-way latch
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_flag_is_not_set() -> None:
+    # Arrange
+    flag = StopFlag()
+    # Act
+    tripped = flag.is_set()
+    # Assert
+    assert tripped is False
+
+
+def test_tripped_flag_reports_set() -> None:
+    # Arrange
+    flag = StopFlag()
+    # Act
+    flag.trip(signal.SIGTERM, None)
+    # Assert
+    assert flag.is_set() is True
+
+
+def test_flag_stays_set_once_tripped() -> None:
+    # Arrange — a one-way latch: the loop polls it, so a stop must not be
+    # able to "un-happen" between polls.
+    flag = StopFlag()
+    flag.trip()
+    # Act
+    still_set = flag.is_set()
+    # Assert
+    assert still_set is True
+
+
+# ---------------------------------------------------------------------------
+# stop_flag_guard — real signal wiring + handler restoration
+# ---------------------------------------------------------------------------
+
+
+def test_guard_handler_trips_the_flag() -> None:
+    # Arrange / Act — invoke the REAL handler the guard registered, exactly
+    # as the kernel would.
+    with stop_flag_guard() as flag:
+        handler = signal.getsignal(signal.SIGTERM)
+        handler(signal.SIGTERM, None)
+        # Act
+        tripped = flag.is_set()
+    # Assert
+    assert tripped is True
+
+
+def test_guard_restores_prior_sigterm_handler() -> None:
+    # Arrange
+    prior = signal.getsignal(signal.SIGTERM)
+    # Act
+    with stop_flag_guard():
+        pass
+    # Assert
+    assert signal.getsignal(signal.SIGTERM) is prior
+
+
+def test_guard_restores_prior_sigint_handler() -> None:
+    # Arrange — SIGINT too: an interactive Ctrl-C must not leave the process
+    # with the guard's handler after the decision is made.
+    prior = signal.getsignal(signal.SIGINT)
+    # Act
+    with stop_flag_guard():
+        pass
+    # Assert
+    assert signal.getsignal(signal.SIGINT) is prior
+
+
+def test_guard_installs_its_own_sigterm_handler() -> None:
+    # Arrange — inside the guard the handler must be the flag's trip method,
+    # not the default disposition (which would kill the process outright).
+    # Act
+    with stop_flag_guard() as flag:
+        installed = signal.getsignal(signal.SIGTERM)
+    # Assert
+    assert installed == flag.trip
+
+
+def test_untripped_flag_survives_the_guard() -> None:
+    # Arrange — no signal arrives; the loop must keep running.
+    # Act
+    with stop_flag_guard() as flag:
+        pass
+    # Assert
+    assert flag.is_set() is False

--- a/tests/scitex_agent_container/_listen/test__turn_url_reachability.py
+++ b/tests/scitex_agent_container/_listen/test__turn_url_reachability.py
@@ -1,0 +1,181 @@
+"""Regression tests: a derived local ``turn_url`` must actually CONNECT.
+
+The bug (deterministic, 100% reproducible — reported by
+``claude-code-telegrammer``, independently re-measured on this box)::
+
+    _listen/_registry_endpoints.py::derive_turn_url()
+        builds  http://<canonical-hostname>:<port>/v1/turn
+
+    $ getent hosts ywata-note-win
+    127.0.1.1   ywata-note-win.localdomain ywata-note-win   <-- .1.1, not .0.1
+
+    127.0.0.1:19017        -> OPEN
+    ywata-note-win:19017   -> CONNECTION REFUSED
+
+The a2a sidecar binds ``127.0.0.1`` (``a2a/_server.py``: ``host: str =
+"127.0.0.1"``), but the machine's own hostname resolves to ``127.0.1.1``
+— the stock Debian / Ubuntu / WSL self-host convention. A different
+loopback address means REFUSED, every time, for every local consumer of
+the derived URL. Not flaky: deterministic.
+
+These tests bind a REAL socket on ``127.0.0.1`` exactly as the sidecar
+does, then assert the URL ``derive_turn_url`` hands out actually connects
+to it. A URL that "looks right" but refuses is precisely the failure mode
+being closed, so the only honest assertion is a real ``connect()`` — a
+string-shape assertion would have passed happily throughout the outage.
+
+The predicate underneath is covered in ``test__local_host.py``.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import socket
+from contextlib import contextmanager
+from typing import Iterator
+from urllib.parse import urlsplit
+
+from scitex_agent_container._listen import _registry_endpoints as re_mod
+from scitex_agent_container._listen._local_host import LOOPBACK_HOST
+
+
+@contextmanager
+def _sidecar() -> Iterator[int]:
+    """Bind a REAL listening socket on 127.0.0.1, exactly like a2a/_server.
+
+    Yields the ephemeral port. This is the thing a ``turn_url`` is
+    supposed to reach; if the derived URL cannot connect to it, the URL
+    is wrong.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((LOOPBACK_HOST, 0))
+    sock.listen(8)
+    try:
+        yield sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+def _connects(url: str) -> bool:
+    """True iff the URL's host:port accepts a TCP connection RIGHT NOW."""
+    parts = urlsplit(url)
+    try:
+        with socket.create_connection((parts.hostname, parts.port), timeout=2.0):
+            return True
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# The reported bug — the derived URL must be reachable
+# ---------------------------------------------------------------------------
+
+
+def test_debian_self_host_address_derives_reachable_url() -> None:
+    # Arrange — 127.0.1.1 is what a Debian/Ubuntu/WSL box's own hostname
+    # resolves to. It IS a loopback address, but NOT the one the sidecar
+    # binds, so a URL naming it is refused on every single connection.
+    with _sidecar() as port:
+        # Act
+        url = re_mod.derive_turn_url("127.0.1.1", port)
+        reachable = _connects(url)
+    # Assert
+    assert reachable, (
+        "derive_turn_url handed out a URL that cannot connect to the sidecar "
+        "— 127.0.1.1 is a DIFFERENT loopback address from the 127.0.0.1 the "
+        "a2a sidecar binds"
+    )
+
+
+def test_own_hostname_derives_reachable_url() -> None:
+    # Arrange — the actual field path: resolve_a2a_host() returns this
+    # machine's canonical hostname for a LOCAL agent and derive_turn_url
+    # used it verbatim. On any box following the Debian self-host
+    # convention that URL is refused 100% of the time.
+    with _sidecar() as port:
+        # Act
+        url = re_mod.derive_turn_url(socket.gethostname(), port)
+        reachable = _connects(url)
+    # Assert
+    assert reachable, (
+        f"the turn_url derived for a LOCAL agent from this machine's own "
+        f"hostname ({socket.gethostname()!r}) does not connect to the sidecar "
+        f"bound on {LOOPBACK_HOST}"
+    )
+
+
+def test_localhost_derives_reachable_url() -> None:
+    # Arrange — "localhost" can resolve to ::1 first; the sidecar is IPv4
+    # loopback only, so it must be normalised too.
+    with _sidecar() as port:
+        # Act
+        url = re_mod.derive_turn_url("localhost", port)
+        reachable = _connects(url)
+    # Assert
+    assert reachable
+
+
+def test_local_host_normalises_to_loopback_literal() -> None:
+    # Arrange — the derived URL for a local agent must name the exact
+    # address the sidecar binds, not a name that merely resolves nearby.
+    hostname = socket.gethostname()
+    # Act
+    url = re_mod.derive_turn_url(hostname, 19017)
+    # Assert
+    assert url == f"http://{LOOPBACK_HOST}:19017/v1/turn"
+
+
+# ---------------------------------------------------------------------------
+# Cross-host callers must keep the hostname form
+# ---------------------------------------------------------------------------
+
+
+def test_remote_host_keeps_its_hostname() -> None:
+    # Arrange — a genuinely REMOTE peer is not on our loopback. Rewriting
+    # its URL to 127.0.0.1 would point every cross-host dispatch at
+    # ourselves — a far worse bug than the one being fixed.
+    # Act
+    url = re_mod.derive_turn_url("spartan-cpu.example.org", 19017)
+    # Assert
+    assert url == "http://spartan-cpu.example.org:19017/v1/turn"
+
+
+def test_remote_ip_keeps_its_address() -> None:
+    # Arrange — a routable (non-loopback) IP is a remote peer.
+    # Act
+    url = re_mod.derive_turn_url("100.64.1.2", 7878)
+    # Assert
+    assert url == "http://100.64.1.2:7878/v1/turn"
+
+
+# ---------------------------------------------------------------------------
+# Pre-existing contract must not regress
+# ---------------------------------------------------------------------------
+
+
+def test_missing_port_still_returns_none() -> None:
+    # Arrange — the caller branches on ``turn_url is None`` to skip dispatch.
+    host = socket.gethostname()
+    # Act
+    url = re_mod.derive_turn_url(host, None)
+    # Assert
+    assert url is None
+
+
+def test_missing_host_still_returns_none() -> None:
+    # Arrange — an unresolvable host must NOT silently become loopback:
+    # that would advertise OUR sidecar as some other agent's endpoint.
+    # Act
+    url = re_mod.derive_turn_url(None, 19017)
+    # Assert
+    assert url is None
+
+
+def test_empty_host_still_returns_none() -> None:
+    # Arrange — same reasoning for the empty-string case.
+    # Act
+    url = re_mod.derive_turn_url("", 19017)
+    # Assert
+    assert url is None

--- a/tests/scitex_agent_container/cli_pkg/test__send_loopback_dispatch.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send_loopback_dispatch.py
@@ -1,0 +1,219 @@
+"""Blast-radius guard: a LOOPBACK peer host must dispatch locally, not over ssh.
+
+Why this file exists
+====================
+``derive_turn_url`` now names ``127.0.0.1`` for a LOCAL agent instead of
+the machine's canonical hostname (which on Debian / Ubuntu / WSL resolves
+to ``127.0.1.1`` and is refused by the sidecar bound on ``127.0.0.1``).
+
+``_send`` consumes that URL: the BROKERED lookup an in-container agent
+uses parses the registry's ``turn_url`` back into a host
+(``_send_broker._host_from_turn_url``) and hands it to ``send_to_agent``
+as ``endpoint.host``. The dispatch branch then read::
+
+    peer_host = endpoint.host if endpoint.host != current_host else ""
+    ...
+    if peer_host and peer_host != current_host:
+        url = f"ssh://{peer_host}:{a2a_port}/v1/turn"
+
+A bare string-compare against ``current_host`` would classify the new
+``127.0.0.1`` literal as a REMOTE peer and try to **ssh to
+``ssh://127.0.0.1:<port>``** — turning a URL fix into a comms outage.
+The classification is therefore loopback-aware (``is_local_host``), and
+these tests pin that, in both directions: a loopback host stays LOCAL, a
+genuinely remote host still routes over ssh.
+
+PA-306 / STX-NM002: no ``unittest.mock``, no ``monkeypatch`` — the
+collaborator is swapped at the module namespace via a real save/restore
+context manager.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import subprocess
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+import scitex_agent_container.cli_pkg._send as _send_mod
+from scitex_agent_container.cli_pkg._send import send_to_agent
+
+
+@contextmanager
+def _swap_post_turn(fn) -> Iterator[None]:
+    """Replace ``_send._post_turn`` with ``fn`` for the duration of the test."""
+    saved = _send_mod._post_turn
+    _send_mod._post_turn = fn  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _send_mod._post_turn = saved  # type: ignore[assignment]
+
+
+@pytest.fixture
+def fresh_lead_creds_path(tmp_path) -> Path:
+    """A fresh, non-expired OAuth credentials JSON so the preflight passes."""
+    creds = tmp_path / ".credentials.json"
+    creds.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat-fake",
+                    "refreshToken": "sk-ant-ort-fake",
+                    "expiresAt": int((time.time() + 3600) * 1000),
+                    "scopes": ["user:inference"],
+                    "subscriptionType": "max",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return creds
+
+
+@pytest.fixture
+def state_db_env(tmp_path):
+    """Redirect state.db + SAC_HOST so the test NEVER touches the live registry."""
+    saved_db = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_host = os.environ.get("SAC_HOST")
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(tmp_path / "state.db")
+    os.environ["SAC_HOST"] = "lead-host"
+    import scitex_agent_container._state.state_db as _state_db_mod
+
+    importlib.reload(_state_db_mod)
+    try:
+        yield tmp_path
+    finally:
+        if saved_db is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_db
+        if saved_host is None:
+            os.environ.pop("SAC_HOST", None)
+        else:
+            os.environ["SAC_HOST"] = saved_host
+        importlib.reload(_state_db_mod)
+
+
+def _seed(name: str, host: str, a2a_port: int) -> None:
+    """Record an active instance row for ``name`` on ``host``."""
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(name=name, host=host, a2a_port=a2a_port)
+
+
+def _ok_ssh_runner(peer_host, remote_creds_path):
+    """Stub ssh probe — rc=0 so the cross-host preflight cannot hang on real ssh."""
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+# ---------------------------------------------------------------------------
+# A loopback peer host is LOCAL — never ssh
+# ---------------------------------------------------------------------------
+
+
+def test_loopback_host_dispatches_over_loopback(state_db_env, fresh_lead_creds_path):
+    # Arrange — the endpoint host is the loopback literal the fixed
+    # derive_turn_url now yields for a local agent.
+    _seed("gamma", host="127.0.0.1", a2a_port=19017)
+    captured: dict = {}
+
+    def fake_post(url, text, *, timeout_s):
+        captured["url"] = url
+        return ("ok", {})
+
+    # Act
+    with _swap_post_turn(fake_post):
+        send_to_agent(
+            "gamma",
+            "hi",
+            wait=True,
+            lead_creds_path=fresh_lead_creds_path,
+            ssh_runner=_ok_ssh_runner,
+        )
+    # Assert
+    assert captured["url"] == "http://127.0.0.1:19017/v1/turn"
+
+
+def test_loopback_host_never_routes_through_ssh(state_db_env, fresh_lead_creds_path):
+    # Arrange — the failure this guards: ssh://127.0.0.1:19017/v1/turn.
+    _seed("gamma", host="127.0.0.1", a2a_port=19017)
+    captured: dict = {}
+
+    def fake_post(url, text, *, timeout_s):
+        captured["url"] = url
+        return ("ok", {})
+
+    # Act
+    with _swap_post_turn(fake_post):
+        send_to_agent(
+            "gamma",
+            "hi",
+            wait=True,
+            lead_creds_path=fresh_lead_creds_path,
+            ssh_runner=_ok_ssh_runner,
+        )
+    # Assert
+    assert not captured["url"].startswith("ssh://")
+
+
+def test_debian_self_host_ip_dispatches_over_loopback(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange — 127.0.1.1 is loopback too. Even if a stale row still carries
+    # it, it must never be treated as a remote peer to ssh into.
+    _seed("delta", host="127.0.1.1", a2a_port=19018)
+    captured: dict = {}
+
+    def fake_post(url, text, *, timeout_s):
+        captured["url"] = url
+        return ("ok", {})
+
+    # Act
+    with _swap_post_turn(fake_post):
+        send_to_agent(
+            "delta",
+            "hi",
+            wait=True,
+            lead_creds_path=fresh_lead_creds_path,
+            ssh_runner=_ok_ssh_runner,
+        )
+    # Assert
+    assert captured["url"] == "http://127.0.0.1:19018/v1/turn"
+
+
+# ---------------------------------------------------------------------------
+# A genuinely remote peer STILL routes over ssh (no over-correction)
+# ---------------------------------------------------------------------------
+
+
+def test_remote_host_still_routes_through_ssh(state_db_env, fresh_lead_creds_path):
+    # Arrange — the loopback-awareness must not swallow real cross-host
+    # dispatch: rewriting a remote peer to loopback would point every
+    # cross-host send back at ourselves.
+    _seed("beta", host="peer-x", a2a_port=18888)
+    captured: dict = {}
+
+    def fake_post(url, text, *, timeout_s):
+        captured["url"] = url
+        return ("ok", {})
+
+    # Act
+    with _swap_post_turn(fake_post):
+        send_to_agent(
+            "beta",
+            "hi",
+            wait=True,
+            lead_creds_path=fresh_lead_creds_path,
+            ssh_runner=_ok_ssh_runner,
+        )
+    # Assert
+    assert captured["url"] == "ssh://peer-x:18888/v1/turn"


### PR DESCRIPTION
Two real bugs in `sac listen`, the host control plane. Both were hurting the operator right now. 「このインフラがぶれると死活問題」

---

## Bug 1 — `sac listen` never returned, and it called a dead holder "healthy"

### 1a. A HEALTHY holder made `sac listen` spin forever (operator, verbatim)

```
$ sac listen
# sac listen: standing by behind healthy holder PID 745734 on 127.0.0.1:7878
# sac listen: standing by behind healthy holder PID 745734 on 127.0.0.1:7878
   ... (forever) ...
^C# sac listen: shutdown signal received while standing by — exiting without binding
$ kill 745734                      <-- HE HAD TO DO THIS BY HAND
$ sac listen
# sac listen: holder PID 823966 not answering health (1/2) — re-checking in 4.0s before taking over
# sac listen: holder PID 823966 is wedged (not serving) — taking over
# sac listen: acquired 127.0.0.1:7878 — serving
```

> 「なぜ私がいちいち手でキルしないといけないんでしたっけ そこは自動化できてないんですか」

**"Someone else is already serving" is a SUCCESS, not a reason to poll every 4s until the human gives up.** Standing by bought nothing — a standby holds no lock and serves no request — and the spinner was the only way out, so he Ctrl-C'd and killed the holder by hand. Every abandoned spinner left junk behind (two orphaned `sac-listen` screen sessions were found this way; the flock guard held, only one ever bound — the *spinner* was the junk).

Taking over a healthy holder would be worse than useless: a listen restart tears down the in-process a2a `Broker` and **deafens every agent's inbox at once**.

### 1b. A DEAD holder was announced as "healthy" — forever

```
# sac listen: holder PID 738982 on 127.0.0.1:7878 not answering health (1/2) — re-checking in 4.0s before taking over
# sac listen: standing by behind healthy holder PID 738982 on 127.0.0.1:7878
# sac listen: standing by behind healthy holder PID 738982 on 127.0.0.1:7878
... (forever)
```

…while PID 738982 answered nothing and the fleet was cut off from the host. Note the shape: it **SAW** the failed check, then went back to calling the same holder healthy.

**Root cause, reproduced verbatim in a test:**

```python
if _probe_health(...):
    consecutive_unhealthy = 0          # <-- the whole record, gone
    _log("standing by behind healthy holder PID …")
```

A single lucky reply erased the record of the failed check, so a **flapping** holder could never accumulate the *consecutive* failures the take-over threshold demanded. It oscillated `1/2` → "healthy" → `1/2` → "healthy" forever.

Flapping is not hypothetical — I measured the live 7878 daemon on this box answering `HTTP 200` one minute and `Connection refused` five minutes later.

Second cause: the probe was `_http_get(...) > 0`, so **any** HTTP status — including a 5xx from a daemon whose health route is erroring — read as a healthy holder.

### What a failed health check does now

The startup path is a **bounded decision** with exactly three outcomes and no "spin":

| Holder state | Action |
|---|---|
| **Nobody holding** (or holder died) | take the flock, heal any untracked port remnant, **BIND** |
| **Verified SERVING** (answers `/v1/health`) | `# sac listen: already serving: PID N on 127.0.0.1:7878 (/v1/health answered HTTP 200) — nothing to do` → **EXIT 0 immediately.** One probe. No sleep. No loop. |
| **NOT SERVING**, corroborated | **SIGTERM only** → holder exits → re-acquire → bind |
| **NOT SERVING** and won't leave | **FAIL LOUD**, exit non-zero, naming the PID + the exact command |

Health is now a three-state verdict (`_holder_health.py`), never a bool:

- `SERVING` — it answered `/v1/health`.
- `NOT_SERVING` — it answered, with a 5xx. An answer, but not health.
- `UNREACHABLE` — **"I asked and got nothing."** This is the state two states could not express. It is NOT health, and it is never logged as one.

**A failure is a fact; one later success does not un-happen it** (`_standby_ledger.py`). A failed check is cleared only by a *sustained* serving streak, and that recovery is logged loudly. A holder that blips once is not destroyed; a holder that keeps failing is always eventually acted on.

**Never destroy on a negative signal.** The automatic take-over sends **SIGTERM and nothing else** — it never escalates. A probe-based "wedged" verdict can be wrong, and the remedy for a wrong one is to SIGKILL a healthy control plane. The false-RED is strictly worse than the false-green. A holder that ignores SIGTERM is handed to the human:

```
ERROR: sac listen cannot take over 127.0.0.1:7878.
  The flock holder PID 738982 FAILED its health check 2x (/v1/health did not answer
  AT ALL (connection refused / timed out) — no evidence of health), so it is NOT
  serving — but it also did not exit on SIGTERM after 3 take-over attempt(s): …
  Refusing to SIGKILL it automatically: a probe-based 'wedged' verdict can be wrong,
  and force-killing a healthy control plane would cut the whole fleet off from this host.
  Refusing to stand by behind it either: it is not serving, so waiting silently would
  hide the outage indefinitely.
  To force the take-over, run:  sac listen restart --force
  To inspect the holder first:  sac listen status  /  lsof -nP -iTCP:7878 -sTCP:LISTEN
```

Also fixed: the take-over **no longer unlinks a live holder's pidfile**. That broke the flock's own atomic-bind invariant — a racing standby flocking the OLD inode plus a fresh acquirer creating a NEW one would *both* believe they held the lock.

### systemd interaction (`Restart=always`) — checked, as asked

`scripts/systemd/sac-listen.service` has `Restart=always`, `RestartSec=5s`, `StartLimitIntervalSec=60s`, `StartLimitBurst=5`. Its comment says `Restart=always` was chosen **deliberately** over `on-failure` because "a listen that exits 0 for ANY reason … must STILL come back. `Restart=on-failure` does NOT cover a 0-exit, which is exactly how the fleet lost a2a comms silently."

**So yes: `Restart=always` restarts even on exit 0.** The new "already serving" 0-exit *is* retried under the unit. But the churn is **bounded and self-limiting**, and it does not produce a new spin loop:

- `RestartSec=5s` + `StartLimitBurst=5`/`60s` ⇒ at most **5 restarts (~25s)**, then the unit parks in `failed` — visible in `systemctl --user status sac-listen`. Not a hot loop.
- The companion `sac-listen-health.timer` does **not** resurrect it: its probe is **port-based** (`curl http://127.0.0.1:7878/v1/health`), so while the foreign instance is serving, the probe is **green** and the timer neither alarms nor restarts. **Fleet comms stay up throughout.**

A duplicate `sac listen` is a configuration problem; the unit now surfaces it as `failed` while the port keeps being served. Documented in the unit file. If that `failed` state ever becomes a nuisance, the clean remedy is a dedicated exit code + `RestartPreventExitStatus=` — **not** reverting to `Restart=on-failure`, which would reopen the silent-0-exit outage of 2026-06-26. I did not change the restart policy: it was a deliberate, incident-driven choice and is out of scope here.

---

## Bug 2 — the derived `turn_url` was unreachable, 100% of the time

Reported by `claude-code-telegrammer`, independently re-measured on this box:

```
$ getent hosts ywata-note-win
127.0.1.1   ywata-note-win.localdomain ywata-note-win      <-- .1.1, not .0.1

127.0.0.1:19017        -> OPEN
ywata-note-win:19017   -> CONNECTION REFUSED
```

My own measurement (same network namespace, live 7878):

```
resolve ywata-note-win -> ['127.0.1.1']
TCP 127.0.0.1:7878      OPEN
TCP ywata-note-win:7878 ConnectionRefusedError: [Errno 111] Connection refused
GET http://127.0.0.1:7878/v1/health      -> status 200
GET http://ywata-note-win:7878/v1/health -> URLError: [Errno 111] Connection refused
```

`derive_turn_url()` built `http://<canonical-hostname>:<port>/v1/turn`. The a2a sidecar binds `127.0.0.1` (`a2a/_server.py:555`: `host: str = "127.0.0.1"`). The machine's own hostname resolves to `127.0.1.1` — the stock Debian/Ubuntu/WSL self-host convention. **Different loopback address ⇒ refused, deterministically, for every local consumer.**

### Chosen fix: derive `127.0.0.1`, do NOT rebind the sidecar to `0.0.0.0`

Binding every agent's sidecar to `0.0.0.0` would expose `/v1/turn` — an endpoint that **injects a prompt into a live Claude session** — on every interface of the host. sac's transport doctrine is loopback-only with orochi's tunnel mesh as the sanctioned external path (`SAC_OROCHI_SCOPES.md §4.4`); `sac listen` itself refuses a non-loopback bind without `--allow-non-loopback`. Fixing an address-derivation bug by widening a listener's exposure trades a connectivity bug for a security regression. Deriving the address the sidecar *actually binds* costs nothing and changes no listener.

A host that names **this machine** normalises to `127.0.0.1`. A genuinely **remote** host keeps its name. The predicate (`_local_host.py`) treats **any** loopback address as local — a naive `host == "127.0.0.1"` check would miss `127.0.1.1` and happily emit the dead URL again.

### Every consumer of `derive_turn_url`, as asked

| Consumer | Affected? |
|---|---|
| `_listen/server.py:161` → `GET /agents` (`enrich_row`) | **YES** — published the dead URL |
| `_listen/server.py:229` → `GET /agents/<name>/status` | **YES** — same |
| `cli_pkg/_send_broker.py:277` `_host_from_turn_url()` → **`sac agents send`** | **YES, load-bearing** — see below |
| `cli_pkg/a2a_group.py:557` → `sac a2a peers` table | display only |
| scitex-todo's board (external) — POSTs directly to `turn_url` | **YES** — this is the `Connection refused [Errno 111]` that `_listen/_notify.py`'s docstring blames on *container isolation* |
| `_mcp/channel.py` wake-on-push (cct's suspect) | **NO** — see below |

**Were card-event wakes affected? NO.** `_mcp/channel.py`'s `turn_url` does not come from `derive_turn_url` at all — it arrives via `sac mcp channel --turn-url`, which `runtimes/_sdk_channels.py:241` builds as a **hardcoded** `f"http://127.0.0.1:{a2a_port}/v1/turn"`. Likewise `_listen/_card_event_delivery.py` POSTs to `SAC_LISTEN_BASE_URL` (`http://127.0.0.1:7878`) `/v1/notify`, also loopback. cct's suspicion is not borne out — sac's own card-event rail was never on this URL.

**Worth flagging (not fixed here):** `_listen/_notify.py`'s docstring attributes the board's `Connection refused` to "the agent's a2a port is NOT reachable inbound from the board's host context" (container isolation). That diagnosis looks wrong: `127.0.0.1:<a2a_port>` **is** open from the host (cct measured `127.0.0.1:19017 -> OPEN`; I reached the host's 7878 from inside a container). The refusal matches the `127.0.1.1` derivation, not container isolation. The `/v1/notify` rail works and is unchanged — but the "interim workaround" may have been built on a misdiagnosis. Follow-up.

### Blast radius caught: `sac agents send` would have regressed onto ssh

`cli_pkg/_send.py:198` classified local-vs-remote by **string-comparing the host**:

```python
peer_host = endpoint.host if endpoint.host != current_host else ""
...
if peer_host and peer_host != current_host:
    url = f"ssh://{peer_host}:{a2a_port}/v1/turn"
```

The brokered lookup an in-container agent uses parses the registry's `turn_url` back into a host (`_send_broker._host_from_turn_url`). Once that URL correctly says `127.0.0.1`, a bare `!= current_host` would have classified the loopback literal as a **remote peer and tried to `ssh://127.0.0.1:<port>`** — turning a URL fix into a comms outage. The classification is now loopback-aware, with tests in both directions (loopback stays local; a real remote still routes over ssh).

---

## Tests — made to fail first

Both suites were run against the **unfixed** code first: **16 failed**. The flapping-holder test reproduced the operator's log verbatim:

```
'# sac listen: holder PID 738982 ... not answering health (1/2) — re-checking ...'
'# sac listen: standing by behind healthy holder PID 738982 on 127.0.0.1:40982'
'# sac listen: holder PID 738982 ... not answering health (1/2) — re-checking ...'
'# sac listen: standing by behind healthy holder PID 738982 on 127.0.0.1:40982'
```

and the turn_url tests failed with:

```
AssertionError: the turn_url derived for a LOCAL agent from this machine's own
hostname ('ywata-note-win') does not connect to the sidecar bound on 127.0.0.1
```

**No mocks.** Every holder is a REAL HTTP server on a REAL ephemeral loopback socket (never 7878). The "never SIGKILL" guarantee is proved against a REAL child process that installs `SIG_IGN` for SIGTERM — the only way it could end up dead is a SIGKILL, so the assertion that it survives *is* the proof. `derive_turn_url`'s output is asserted by actually `connect()`-ing to a real socket bound exactly like the sidecar; a string-shape assertion would have passed happily throughout the outage.

New: `test__standby_false_green.py`, `test__standby_ledger.py`, `test__standby_signal.py`, `test__holder_health.py`, `test__local_host.py`, `test__graceful_stop.py`, `test__turn_url_reachability.py`, `test__send_loopback_dispatch.py`.

One pre-existing expectation was updated — `test_enrich_row_with_endpoint_adds_both_fields_when_sources_present` asserted `http://test-host:21000/v1/turn`, where `test-host` is the fixture's *own canonical host*. That expectation encoded the bug.

The live 7878 control plane was never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
