### PR TITLE
feat(agents): `sac agents rename <old> <new>` — atomic rename, incl. the 158 task cards a hand rename orphans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`sac agents rename <old> <new>` — the rename you cannot do safely by hand.**
+  An agent writes its own name into six places on disk *plus* the shared task
+  board, and the one a human misses is silent. The worst is the board identity:
+  `SCITEX_TODO_AGENT_ID` is how scitex-todo knows the agent, so changing it
+  without migrating the cards **orphans every card that agent owns** — it can no
+  longer see its own work, and nothing tells you. Measured on the live board
+  before this verb existed: `scitex-todo` owned **158 cards** (84 of them scoped
+  `agent:scitex-todo`); a hand rename would have stranded all of them.
+
+  `rename` moves all seven together, or none:
+
+  1. spec dir `agents/<name>/`
+  2. the spec's own self-references — `metadata.labels.project` / `.purpose`,
+     `spec.workdir`, the `--overlay` path, `SCITEX_AGENT_CONTAINER_STATE_DB`,
+     `SCITEX_TODO_AGENT_ID`, and any identity-bearing bind
+  3. overlay dir `containers/overlays/<name>/`
+  4. runtime + state dir `runtime/<name>/` (bound at `/state/<name>`)
+  5. registry entry `runtime/registry/<name>.json`
+  6. `state.db` — 16 name columns + 2 path columns, in one transaction
+  7. **task cards**, via scitex-todo's own `reassign_task`
+
+  Properties: **preflight refuses a running agent** (physical evidence — a live
+  pid, not a row that merely claims to be open — so a stale row cannot wedge a
+  legitimate rename, and a wedged-but-alive agent cannot be renamed out from
+  under itself); **atomic** — every step records its inverse and any failure,
+  including a *partial* card migration, rolls the whole rename back; a
+  postcondition step then proves nothing is left under the old name.
+  `--dry-run` prints every location exactly and touches nothing.
+
+  The spec is edited by **loading it and changing the known fields** (ruamel
+  round-trip, so operator comments and key order survive), never by a regex over
+  the YAML — and the rewrite re-parses its own output and refuses to write a spec
+  whose semantic diff is anything other than the changes it planned.
+
+  sac **calls** scitex-todo's `reassign_task`; it does not reimplement it. The
+  board belongs to scitex-todo, and a forked copy of another package's store
+  logic drifts into a worse version of it.
+
+- `SCITEX_AGENT_CONTAINER_ROOT` — override the sac install root that the rename's
+  seven locations all derive from. Resolved at call time.
+
 ## [0.21.16] — 2026-07-14
 
 **⚠️ 0.21.15 WAS NEVER PUBLISHED — it is tagged, but nothing reached PyPI, and

--- a/src/scitex_agent_container/_lifecycle/_rename.py
+++ b/src/scitex_agent_container/_lifecycle/_rename.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``agent_rename`` — rename an agent everywhere, atomically, or not at all.
+
+An agent's name is written into SIX places on disk plus the shared task
+board. Renaming by hand means editing all of them consistently, and the
+one a human misses is silent — see ``_rename_cards`` for the card
+orphaning that motivated this verb.
+
+The places (:class:`._rename_plan.Layout` owns the paths):
+
+  1. spec dir          ``<root>/agents/<name>/``
+  2. spec self-refs    labels / workdir / overlay / state-db / board identity
+                       (``_rename_spec.SPEC_TOUCHPOINTS``)
+  3. overlay dir       ``<root>/containers/overlays/<name>/``
+  4. runtime/state dir ``<root>/runtime/<name>/``  (bound at ``/state/<name>``)
+  5. registry json     ``<root>/runtime/registry/<name>.json``
+  6. state.db rows     16 name columns + 2 path columns (``_rename_db``)
+  7. task cards        scitex-todo's ``reassign_task`` (``_rename_cards``)
+
+ATOMICITY
+---------
+Each step pushes its INVERSE onto an undo stack before the next runs. Any
+failure unwinds the stack in reverse, leaving the agent exactly as it was.
+A half-renamed agent is worse than an un-renamed one: it starts under one
+name while writing to another's overlay and board slice.
+
+The steps are ordered so the cheap, local, likely-to-fail work happens
+FIRST and the board — the only step that is slow, external, and visible to
+other agents — happens LAST. A rename that is going to fail therefore
+fails before it touches anything shared.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Callable
+
+from ._rename_cards import CardMigration, CardMigrationError, find_owned_cards
+from ._rename_cards import migrate_cards, undo_migrate_cards
+from ._rename_db import DbUndo, count_rows, rename_rows, undo_rename_rows
+from ._rename_plan import (
+    Layout,
+    Move,
+    RenameError,
+    RenamePlan,
+    build_plan,
+    preflight,
+    probe_running,
+)
+from ._rename_spec import rewrite_spec
+
+# Step labels — stable strings. The CLI prints them; the rollback test
+# injects a failure at each in turn.
+STEP_SPEC_DIR = "spec-dir"
+STEP_SPEC_FILE = "spec-file"
+STEP_OVERLAY_DIR = "overlay-dir"
+STEP_RUNTIME_DIR = "runtime-dir"
+STEP_REGISTRY = "registry"
+STEP_STATE_DB = "state-db"
+STEP_CARDS = "cards"
+STEP_VERIFY = "verify"
+
+STEPS: tuple[str, ...] = (
+    STEP_SPEC_DIR,
+    STEP_SPEC_FILE,
+    STEP_OVERLAY_DIR,
+    STEP_RUNTIME_DIR,
+    STEP_REGISTRY,
+    STEP_STATE_DB,
+    STEP_CARDS,
+    STEP_VERIFY,
+)
+
+
+def apply_plan(
+    plan: RenamePlan,
+    *,
+    store: str | Path | None = None,
+    by: str | None = None,
+    on_step: Callable[[str], None] | None = None,
+) -> None:
+    """Execute ``plan``, rolling everything back on any failure.
+
+    ``on_step`` is called with each step's label immediately BEFORE that
+    step runs. The CLI passes a progress printer; the rollback test passes
+    a callback that raises on a chosen step, which aborts the rename
+    mid-flight with a real exception and exercises the real unwind.
+
+    Raises:
+        RenameError: The rename failed. Everything already done has been
+            undone; the message names the original cause and reports any
+            part of the rollback that could not itself complete.
+    """
+    layout = plan.layout
+    old, new = plan.old, plan.new
+    undo: list[tuple[str, Callable[[], None]]] = []
+
+    def _step(label: str) -> None:
+        if on_step is not None:
+            on_step(label)
+
+    try:
+        # 1. Spec dir. Every step below addresses the spec at its NEW path.
+        _step(STEP_SPEC_DIR)
+        _move(plan.spec_move)
+        undo.append((STEP_SPEC_DIR, _undo_move(plan.spec_move)))
+
+        # 2. The spec's self-references.
+        _step(STEP_SPEC_FILE)
+        _rewrite_spec_file(layout.spec_file(new), old, new, undo)
+
+        # 3/4. Overlay + runtime/state dirs.
+        for label, move in (
+            (STEP_OVERLAY_DIR, plan.overlay_move),
+            (STEP_RUNTIME_DIR, plan.runtime_move),
+        ):
+            _step(label)
+            if move is None:
+                continue
+            _move(move)
+            undo.append((label, _undo_move(move)))
+
+        # 5. Registry JSON — its `name` + `config` fields name the agent.
+        _step(STEP_REGISTRY)
+        if plan.registry_move is not None:
+            before = plan.registry_move.src.read_text(encoding="utf-8")
+            _move(plan.registry_move)
+            _rewrite_registry_json(plan.registry_move.dst, old, new, layout)
+            undo.append((STEP_REGISTRY, _undo_registry(plan.registry_move, before)))
+
+        # 6. state.db rows — one transaction, rowid-scoped undo.
+        _step(STEP_STATE_DB)
+        db_undo: DbUndo = rename_rows(layout.state_db, old, new)
+        undo.append((STEP_STATE_DB, lambda: undo_rename_rows(db_undo)))
+
+        # 7. The board. LAST — see the module docstring.
+        _step(STEP_CARDS)
+        if plan.cards_enabled:
+            _migrate_cards_step(old, new, store, by, undo)
+
+        # 8. Postcondition. "I ran the steps" is not the same claim as "the
+        # world is now correct", and this verb exists because the second one
+        # is what an operator actually needs. Anything still standing under
+        # the old name means a step silently did not take — roll back rather
+        # than hand back a half-rename.
+        _step(STEP_VERIFY)
+        _verify_nothing_left_behind(plan, store=store)
+
+    except BaseException as exc:
+        failures = _unwind(undo)
+        raise RenameError(_rollback_message(old, new, exc, failures)) from exc
+
+
+def _migrate_cards_step(
+    old: str,
+    new: str,
+    store: str | Path | None,
+    by: str | None,
+    undo: list[tuple[str, Callable[[], None]]],
+) -> None:
+    """Migrate the cards, registering the undo even on a PARTIAL failure.
+
+    ``migrate_cards`` can fail on card 81 of 158, having already moved 80.
+    Those 80 are real, committed writes on the shared board: if we let the
+    exception past without registering their inverse, the unwind would
+    restore the filesystem and leave 80 cards pointing at an agent that no
+    longer exists. The partial migration rides on the exception for exactly
+    this reason.
+    """
+    try:
+        migration = migrate_cards(old, new, store=store, by=by)
+    except CardMigrationError as exc:
+        partial = getattr(exc, "migration", None)
+        if partial is not None and partial.moved:
+            undo.append((STEP_CARDS, _undo_cards(partial)))
+        raise
+    undo.append((STEP_CARDS, _undo_cards(migration)))
+
+
+def _verify_nothing_left_behind(
+    plan: RenamePlan, *, store: str | Path | None
+) -> None:
+    """Assert the old name owns nothing any more. Raises if it does."""
+    layout = plan.layout
+    old = plan.old
+    leftovers: list[str] = []
+
+    for label, path in (
+        ("spec dir", layout.spec_dir(old)),
+        ("overlay dir", layout.overlay_dir(old)),
+        ("runtime dir", layout.runtime_dir(old)),
+        ("registry entry", layout.registry_json(old)),
+    ):
+        if path.exists():
+            leftovers.append(f"{label} still at {path}")
+
+    rows = count_rows(layout.state_db, old)
+    if rows:
+        leftovers.append(f"state.db still has rows for {old!r}: {rows}")
+
+    if plan.cards_enabled:
+        orphans = find_owned_cards(old, store=store)
+        if orphans:
+            leftovers.append(
+                f"{len(orphans)} card(s) still owned by {old!r}: "
+                f"{', '.join(orphans[:5])}"
+            )
+
+    if leftovers:
+        raise RenameError(
+            "post-rename check failed — these still belong to the OLD name:\n"
+            + "\n".join(f"      - {item}" for item in leftovers)
+        )
+
+
+def agent_rename(
+    old: str,
+    new: str,
+    *,
+    layout: Layout | None = None,
+    store: str | Path | None = None,
+    cards: bool = True,
+    by: str | None = None,
+    on_step: Callable[[str], None] | None = None,
+) -> RenamePlan:
+    """Rename ``old`` to ``new`` everywhere. Returns the plan that was applied."""
+    plan = build_plan(old, new, layout=layout, store=store, cards=cards)
+    apply_plan(plan, store=store, by=by, on_step=on_step)
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# Steps + their inverses
+# ---------------------------------------------------------------------------
+
+
+def _move(move: Move) -> None:
+    move.dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(move.src), str(move.dst))
+
+
+def _undo_move(move: Move) -> Callable[[], None]:
+    return lambda: _move(Move(move.dst, move.src))
+
+
+def _rewrite_spec_file(
+    spec_path: Path,
+    old: str,
+    new: str,
+    undo: list[tuple[str, Callable[[], None]]],
+) -> None:
+    """Rewrite the spec in place, then prove it still validates.
+
+    The undo is pushed BEFORE the validation runs, so a spec that the
+    rewrite broke is restored by the unwind rather than left on disk.
+    """
+    original = spec_path.read_text(encoding="utf-8")
+    rewritten, _changes = rewrite_spec(original, old, new)
+    if rewritten == original:
+        return
+    spec_path.write_text(rewritten, encoding="utf-8")
+    undo.append(
+        (STEP_SPEC_FILE, lambda: spec_path.write_text(original, encoding="utf-8"))
+    )
+
+    from ..config import validate_config
+
+    errors = validate_config(str(spec_path))
+    if errors:
+        raise RenameError(
+            f"the rewritten spec at {spec_path} no longer validates:\n"
+            + "\n".join(f"      - {e}" for e in errors)
+        )
+
+
+def _rewrite_registry_json(path: Path, old: str, new: str, layout: Layout) -> None:
+    """Point the moved registry entry's ``name`` + ``config`` at the new agent."""
+    try:
+        entry = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RenameError(f"registry entry {path} is unreadable: {exc}") from exc
+    if entry.get("name") == old:
+        entry["name"] = new
+    if entry.get("config", "") == str(layout.spec_file(old)):
+        entry["config"] = str(layout.spec_file(new))
+    path.write_text(json.dumps(entry, indent=2), encoding="utf-8")
+
+
+def _undo_registry(move: Move, before: str) -> Callable[[], None]:
+    def _undo() -> None:
+        _move(Move(move.dst, move.src))
+        move.src.write_text(before, encoding="utf-8")
+
+    return _undo
+
+
+def _undo_cards(migration: CardMigration) -> Callable[[], None]:
+    def _undo() -> None:
+        failed = undo_migrate_cards(migration)
+        if failed:
+            raise CardMigrationError(
+                f"could not hand these cards back to {migration.old!r}: "
+                f"{', '.join(failed)}"
+            )
+
+    return _undo
+
+
+# ---------------------------------------------------------------------------
+# Rollback
+# ---------------------------------------------------------------------------
+
+
+def _unwind(undo: list[tuple[str, Callable[[], None]]]) -> list[str]:
+    """Run every recorded inverse, newest first. Never raises."""
+    failures: list[str] = []
+    for label, revert in reversed(undo):
+        try:
+            revert()
+        except Exception as exc:  # noqa: BLE001 - collect; never mask the cause
+            failures.append(f"{label}: {exc}")
+    return failures
+
+
+def _rollback_message(
+    old: str, new: str, exc: BaseException, failures: list[str]
+) -> str:
+    head = f"rename {old!r} -> {new!r} FAILED at: {exc}"
+    if not failures:
+        return f"{head}\n    Rolled back — {old!r} is exactly as it was."
+    listed = "\n".join(f"      - {f}" for f in failures)
+    return (
+        f"{head}\n"
+        f"    ROLLBACK INCOMPLETE. These could not be undone:\n{listed}\n"
+        f"    {old!r} is in a PARTIAL state — fix the above by hand before "
+        "starting either name."
+    )
+
+
+__all__ = [
+    "STEPS",
+    "STEP_CARDS",
+    "STEP_OVERLAY_DIR",
+    "STEP_REGISTRY",
+    "STEP_RUNTIME_DIR",
+    "STEP_SPEC_DIR",
+    "STEP_SPEC_FILE",
+    "STEP_STATE_DB",
+    "STEP_VERIFY",
+    "Layout",
+    "Move",
+    "RenameError",
+    "RenamePlan",
+    "agent_rename",
+    "apply_plan",
+    "build_plan",
+    "preflight",
+    "probe_running",
+]

--- a/src/scitex_agent_container/_lifecycle/_rename_cards.py
+++ b/src/scitex_agent_container/_lifecycle/_rename_cards.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Migrate an agent's task cards when it is renamed — via scitex-todo's port.
+
+THE ORPHANING BUG THIS EXISTS TO PREVENT
+----------------------------------------
+An agent's identity on the board is ``SCITEX_TODO_AGENT_ID``. Change it
+(as any rename must) without moving the cards, and every card the agent
+owns still says ``agent: <old>`` / ``scope: agent:<old>``. The agent under
+its new name can no longer see its own work — and NOTHING tells you.
+Measured on the live board before this verb existed: the ``scitex-todo``
+agent owned 158 cards, 84 of them scoped ``agent:scitex-todo``. A hand
+rename orphans all 158, silently.
+
+PORTS AND ADAPTERS — WHY THERE IS NO REASSIGN LOGIC IN THIS FILE
+----------------------------------------------------------------
+The board belongs to scitex-todo. It already owns the primitive:
+``scitex_todo._store.reassign_task(store, task_id, new_owner, by=...)``,
+which in ONE locked write sets ``agent = assignee = new_owner`` AND
+``scope = "agent:<new_owner>"``, appends an audit comment, and emits the
+canonical ``reassigned`` card-event. sac CALLS that. It does not reproduce
+it. A forked copy of another package's store logic drifts into a worse
+version of it.
+
+The lazy import mirrors the existing precedent
+(``_account/refresh_alarm`` imports ``scitex_todo._help_wait.help_wait``)
+and is covered by the cross-package import gate,
+``tests/integration/test_cross_package_imports.py``.
+
+THE MISSING PRIMITIVE (and why the loop below is a placeholder, not a fork)
+--------------------------------------------------------------------------
+scitex-todo exposes no BULK verb: there is no ``reassign_all(old, new)``.
+So this adapter loops ``reassign_task`` once per card. Profiling ONE warm
+card write against a ONE-card store::
+
+    3.24s total
+      2.18s  _emit_card_event -> dispatch_event -> _iter_entry_points
+               -> importlib.metadata.entry_points()   # ~126 files, UNCACHED
+      0.89s  _save_doc_unlocked -> _git_autocommit_store  # 2 subprocess forks
+
+That is FIXED overhead — it does not scale with the store, it is paid in
+full on every single call. Migrating the 158 cards that motivated this
+verb therefore costs ~158 x 3.2 s ~= 8.5 MINUTES, for what is semantically
+ONE operation. A bulk verb on scitex-todo's side would be one lock, one
+store write, one git commit, one coherent event: seconds.
+
+That cost is the signature of a primitive living on the WRONG SIDE of the
+port. ``reassign_all`` belongs in scitex-todo, NOT here. sac must not "fix"
+it locally by reaching into the store's YAML — that IS the fork, and a
+forked store writer drifts into a worse one. When scitex-todo ships the
+bulk verb, :func:`migrate_cards` collapses to a single call.
+
+(The uncached ``entry_points()`` rescan is a separate, standalone
+scitex-todo bug — a one-line ``functools.cache`` would make EVERY card
+write in the fleet ~2.2 s faster, not just this verb's.)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+class CardMigrationError(RuntimeError):
+    """The board could not be read or migrated."""
+
+
+@dataclass
+class CardMigration:
+    """What :func:`migrate_cards` actually moved — the undo record."""
+
+    old: str
+    new: str
+    store: str | Path | None
+    moved: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.moved)
+
+
+def _store_module() -> Any:
+    """Import scitex-todo's store, or fail LOUD.
+
+    Silently degrading to "no cards migrated" is the exact bug this verb
+    exists to prevent, so a missing board package is an error the operator
+    must acknowledge (``--no-cards``), never a shrug.
+    """
+    try:
+        from scitex_todo import _store
+    except ImportError as exc:
+        raise CardMigrationError(
+            "scitex-todo is not installed, so this rename cannot see the "
+            "board — and a rename that changes SCITEX_TODO_AGENT_ID without "
+            "migrating cards ORPHANS every card the agent owns. Install "
+            "scitex-todo, or re-run with --no-cards to accept that risk "
+            "explicitly."
+        ) from exc
+    return _store
+
+
+def _query(store: str | Path | None, **filters) -> list[dict]:
+    """One ``list_tasks`` call, with the store failure surfaced loudly."""
+    todo = _store_module()
+    try:
+        return todo.list_tasks(store, **filters)
+    except Exception as exc:  # noqa: BLE001 - surface any store failure
+        raise CardMigrationError(f"could not read the board ({filters}): {exc}") from exc
+
+
+def find_owned_cards(old: str, *, store: str | Path | None = None) -> list[str]:
+    """Return the ids of every card ``old`` OWNS — the ones a rename orphans.
+
+    Ownership is the ``agent`` field, or the legacy ``assignee`` for a card
+    written before the two were kept in lock-step. Both are queried and
+    unioned. ``scope`` is DERIVED from the owner (``reassign_task`` sets
+    ``scope = "agent:<owner>"``), so it is not an ownership signal and is
+    deliberately not queried here — see :func:`find_foreign_scoped_cards`
+    for why treating it as one would let a rename STEAL another agent's card.
+
+    ``scope=""`` is LOAD-BEARING, not noise. ``list_tasks(scope=None)`` does
+    not mean "no scope filter" — it means "fall back to
+    ``$SCITEX_TODO_SCOPE``", which a sac-launched agent may well have set.
+    Leaving it None would silently AND every owner query with the CALLER's
+    own scope, so a rename run from inside one agent's container would find
+    only the cards that happen to share its slice and orphan the rest —
+    precisely the bug this module exists to prevent.
+
+    Read-only. This is what ``--dry-run`` counts.
+    """
+    ids: dict[str, None] = {}  # ordered set
+    for filters in ({"agent": old}, {"assignee": old}):
+        for row in _query(store, scope="", **filters):
+            task_id = row.get("id")
+            if task_id:
+                ids[str(task_id)] = None
+    return list(ids)
+
+
+def find_foreign_scoped_cards(
+    old: str, *, store: str | Path | None = None
+) -> list[str]:
+    """Cards scoped ``agent:<old>`` that ``old`` does NOT own.
+
+    Inconsistent data — ``scope`` is supposed to track the owner — but it
+    exists in the wild, and it is a trap. The naive reading of "migrate
+    everything scoped to the old agent" would hand these cards to the NEW
+    name, taking them from whoever actually owns them. sac will not steal a
+    card. It reports them instead, so the operator can see that the scope
+    string ``agent:<old>`` will be left dangling on someone else's work.
+
+    Read-only; surfaced as a plan warning.
+    """
+    owned = set(find_owned_cards(old, store=store))
+    scoped = _query(store, scope=f"agent:{old}")
+    return [
+        str(row["id"])
+        for row in scoped
+        if row.get("id") and str(row["id"]) not in owned
+    ]
+
+
+def migrate_cards(
+    old: str,
+    new: str,
+    *,
+    store: str | Path | None = None,
+    by: str | None = None,
+) -> CardMigration:
+    """Reassign every card owned by ``old`` to ``new``.
+
+    Delegates each card to ``scitex_todo._store.reassign_task`` — see the
+    module docstring for why sac does not do this itself.
+
+    Raises:
+        CardMigrationError: Any card failed to move. The migration record
+            of the cards that DID move is attached as ``.migration`` so the
+            caller can roll them back.
+    """
+    todo = _store_module()
+    migration = CardMigration(old=old, new=new, store=store)
+    for task_id in find_owned_cards(old, store=store):
+        try:
+            result = todo.reassign_task(
+                store, task_id=task_id, new_owner=new, by=by
+            )
+        except Exception as exc:  # noqa: BLE001 - any store failure aborts
+            err = CardMigrationError(
+                f"card {task_id!r} could not be reassigned to {new!r}: {exc}"
+            )
+            err.migration = migration  # type: ignore[attr-defined]
+            raise err from exc
+        # ``changed=False`` is reassign_task's idempotent no-op (the card
+        # already had this owner). Recording it as MOVED would make the
+        # undo hand it back to an owner it never had.
+        if result.get("changed"):
+            migration.moved.append(task_id)
+        else:
+            migration.skipped.append(task_id)
+    return migration
+
+
+def undo_migrate_cards(migration: CardMigration) -> list[str]:
+    """Hand every card :func:`migrate_cards` moved back to the old owner.
+
+    Best-effort by design: this runs on the rollback path, where raising
+    would hide the ORIGINAL failure. Returns the ids it could NOT restore
+    so the caller can print them — an operator who sees the list can
+    finish the job with ``scitex-todo`` directly.
+    """
+    todo = _store_module()
+    failed: list[str] = []
+    for task_id in migration.moved:
+        try:
+            todo.reassign_task(
+                migration.store,
+                task_id=task_id,
+                new_owner=migration.old,
+                by=None,
+            )
+        except Exception:  # noqa: BLE001 - collect, never mask the root cause
+            failed.append(task_id)
+    return failed
+
+
+__all__ = [
+    "CardMigration",
+    "CardMigrationError",
+    "find_foreign_scoped_cards",
+    "find_owned_cards",
+    "migrate_cards",
+    "undo_migrate_cards",
+]

--- a/src/scitex_agent_container/_lifecycle/_rename_db.py
+++ b/src/scitex_agent_container/_lifecycle/_rename_db.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Rename an agent's rows in ``state.db`` — reversibly.
+
+The agent name is a foreign key by convention in a dozen tables (there
+are no real FKs on it). A rename that moves the spec dir but leaves
+``comms_nodes.name`` / ``node_comms_policy.name`` / ``lineage`` pointing
+at the old name produces an agent that starts but cannot be addressed:
+the A2A directory still advertises the dead name, and the ACL gate has no
+policy row for the live one.
+
+So: rename EVERY row that keys on the name, including the history
+(``turns`` / ``errors`` / ``heartbeats`` / ``attempts``). A renamed agent
+is the SAME agent — ``sac agents recall <new>`` must still find its past.
+This is the ``git mv`` position: the name changed, history follows.
+
+Reversibility: we capture the ``rowid`` of every row we are about to
+touch, BEFORE touching it. The undo is then a rowid-scoped UPDATE back to
+the old value — exact, and immune to the trap a naive
+``UPDATE … WHERE name = new`` would hit (it would also clobber rows that
+already held ``new``, e.g. the history of a previously-deleted agent that
+happened to have that name).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ._rename_spec import sub_path
+
+# (table, column) pairs holding an agent NAME verbatim.
+NAME_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("definitions", "name"),
+    ("instances", "name"),
+    ("instances", "spawned_by"),
+    ("attempts", "agent"),
+    ("turns", "name"),
+    ("errors", "name"),
+    ("heartbeats", "name"),
+    ("channel_events", "target"),
+    ("channel_events", "source"),
+    ("node_tokens", "name"),
+    ("lineage", "child_name"),
+    ("lineage", "parent_name"),
+    ("comms_grants", "sender_name"),
+    ("comms_grants", "target_name"),
+    ("comms_nodes", "name"),
+    ("node_comms_policy", "name"),
+)
+
+# (table, column) pairs holding a PATH that embeds the agent name as a
+# component (``…/agents/<name>/spec.yaml``, ``…/proj/<name>``).
+PATH_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("definitions", "yaml_path"),
+    ("instances", "workdir"),
+)
+
+
+class DbRenameError(RuntimeError):
+    """A state.db row rename failed. Nothing was committed."""
+
+
+@dataclass
+class DbUndo:
+    """Rowid-scoped inverse of a completed :func:`rename_rows`."""
+
+    db_path: Path
+    old: str
+    new: str
+    # (table, column) -> rowids we updated
+    name_rows: dict[tuple[str, str], list[int]] = field(default_factory=dict)
+    path_rows: dict[tuple[str, str], list[tuple[int, str]]] = field(
+        default_factory=dict
+    )
+
+    @property
+    def total(self) -> int:
+        return sum(len(v) for v in self.name_rows.values()) + sum(
+            len(v) for v in self.path_rows.values()
+        )
+
+
+def _existing_tables(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table'"
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def count_rows(db_path: Path, old: str) -> dict[str, int]:
+    """Return ``{"table.column": n}`` for every row a rename would touch.
+
+    Read-only — this is what ``--dry-run`` prints. A missing DB file or a
+    table that does not exist yet contributes nothing.
+    """
+    if not Path(db_path).is_file():
+        return {}
+    counts: dict[str, int] = {}
+    conn = sqlite3.connect(str(db_path))
+    try:
+        tables = _existing_tables(conn)
+        for table, column in NAME_COLUMNS:
+            if table not in tables:
+                continue
+            n = conn.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE {column} = ?", (old,)  # noqa: S608
+            ).fetchone()[0]
+            if n:
+                counts[f"{table}.{column}"] = n
+        for table, column in PATH_COLUMNS:
+            if table not in tables:
+                continue
+            n = sum(
+                1
+                for (value,) in conn.execute(
+                    f"SELECT {column} FROM {table} WHERE {column} LIKE ?",  # noqa: S608
+                    (f"%{old}%",),
+                )
+                if _has_component(value, old)
+            )
+            if n:
+                counts[f"{table}.{column}"] = n
+    finally:
+        conn.close()
+    return counts
+
+
+def _has_component(value: object, old: str) -> bool:
+    """True when ``value`` is a path with ``old`` as a whole component."""
+    return isinstance(value, str) and old in value.split("/")
+
+
+def rename_rows(db_path: Path, old: str, new: str) -> DbUndo:
+    """Point every ``old`` row at ``new``, in ONE transaction.
+
+    Returns a :class:`DbUndo` the caller stashes on its rollback stack.
+    A missing DB file is a no-op (an empty undo) — a fleet that has never
+    started an agent has no state.db, and that must not block a rename.
+
+    Raises:
+        DbRenameError: A UNIQUE constraint rejected the new name (a row
+            for ``new`` already exists — typically the leftovers of a
+            previously deleted agent by that name). Nothing is committed.
+    """
+    undo = DbUndo(db_path=Path(db_path), old=old, new=new)
+    if not Path(db_path).is_file():
+        return undo
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        tables = _existing_tables(conn)
+
+        for table, column in NAME_COLUMNS:
+            if table not in tables:
+                continue
+            rowids = [
+                r[0]
+                for r in conn.execute(
+                    f"SELECT rowid FROM {table} WHERE {column} = ?",  # noqa: S608
+                    (old,),
+                )
+            ]
+            if not rowids:
+                continue
+            _update_rowids(conn, table, column, rowids, new)
+            undo.name_rows[(table, column)] = rowids
+
+        for table, column in PATH_COLUMNS:
+            if table not in tables:
+                continue
+            rewritten = [
+                (rowid, value, sub_path(value, old, new))
+                for rowid, value in conn.execute(
+                    f"SELECT rowid, {column} FROM {table} WHERE {column} LIKE ?",  # noqa: S608
+                    (f"%{old}%",),
+                )
+                if isinstance(value, str)
+            ]
+            touched = [(r, b, a) for r, b, a in rewritten if a != b]
+            if not touched:
+                continue
+            for rowid, _before, after in touched:
+                _update_rowids(conn, table, column, [rowid], after)
+            undo.path_rows[(table, column)] = [(r, b) for r, b, _a in touched]
+
+        conn.commit()
+    except sqlite3.IntegrityError as exc:
+        conn.rollback()
+        raise DbRenameError(
+            f"state.db already holds rows for {new!r} — a previously deleted "
+            f"agent by that name likely left them behind ({exc}). Nothing was "
+            f"changed. Inspect with: sac db query --agent {new}"
+        ) from exc
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+    return undo
+
+
+def undo_rename_rows(undo: DbUndo) -> None:
+    """Restore every row :func:`rename_rows` touched, by rowid."""
+    if undo.total == 0 or not undo.db_path.is_file():
+        return
+    conn = sqlite3.connect(str(undo.db_path))
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        for (table, column), rowids in undo.name_rows.items():
+            _update_rowids(conn, table, column, rowids, undo.old)
+        for (table, column), pairs in undo.path_rows.items():
+            for rowid, before in pairs:
+                _update_rowids(conn, table, column, [rowid], before)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _update_rowids(
+    conn: sqlite3.Connection,
+    table: str,
+    column: str,
+    rowids: list[int],
+    value: str,
+) -> None:
+    """``UPDATE <table> SET <column> = ? WHERE rowid IN (…)``.
+
+    ``table`` / ``column`` come from the module-level constants above —
+    never from user input — so interpolating them is safe; the VALUES are
+    always bound.
+    """
+    placeholders = ",".join("?" for _ in rowids)
+    conn.execute(
+        f"UPDATE {table} SET {column} = ? WHERE rowid IN ({placeholders})",  # noqa: S608
+        (value, *rowids),
+    )
+
+
+__all__ = [
+    "NAME_COLUMNS",
+    "PATH_COLUMNS",
+    "DbRenameError",
+    "DbUndo",
+    "count_rows",
+    "rename_rows",
+    "undo_rename_rows",
+]

--- a/src/scitex_agent_container/_lifecycle/_rename_plan.py
+++ b/src/scitex_agent_container/_lifecycle/_rename_plan.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""What a rename WOULD touch — the layout, the preflight, and the plan.
+
+Read-only half of ``sac agents rename``. Nothing in this module mutates
+anything, which is what makes ``--dry-run`` trustworthy: the dry run and
+the real run compute the SAME plan from the SAME code, then one of them
+stops.
+
+:mod:`._rename` owns the other half — executing a plan, reversibly.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ._rename_cards import find_foreign_scoped_cards, find_owned_cards
+from ._rename_db import count_rows
+from ._rename_spec import SpecChange, plan_spec_changes
+
+# Same rule ``sac agents create`` enforces: the name is a directory name.
+_VALID_NAME_CHARS = set("abcdefghijklmnopqrstuvwxyz0123456789-_")
+
+# Operator/test port: point the whole rename at a different sac root.
+# Read at CALL time (see Layout.default) — never captured at import.
+ROOT_ENV = "SCITEX_AGENT_CONTAINER_ROOT"
+
+
+class RenameError(RuntimeError):
+    """The rename was refused, or failed and was rolled back."""
+
+
+@dataclass(frozen=True)
+class Layout:
+    """Where sac keeps an agent's things, rooted at an injectable base.
+
+    Every path derives from ``root``, so a caller — a test, or an operator
+    with a non-standard install — can point the whole rename somewhere
+    else. Deliberately NOT read from the module-level constants elsewhere
+    in sac (``Registry.REGISTRY_DIR``, ``_session_state.DEFAULT_STATE_ROOT``,
+    ``state_db.DEFAULT_DB_PATH``): those are computed from ``$HOME`` at
+    IMPORT time, so a fixture that sets ``$HOME`` afterwards CANNOT redirect
+    them. A test that trusted that would look isolated while reading — and
+    writing — the live fleet.
+    """
+
+    root: Path
+
+    @classmethod
+    def default(cls) -> "Layout":
+        """The production root, or ``$SCITEX_AGENT_CONTAINER_ROOT`` if set.
+
+        Resolved on every call, so the override actually takes effect (an
+        import-time constant would not).
+        """
+        override = os.environ.get(ROOT_ENV, "").strip()
+        if override:
+            return cls(root=Path(override).expanduser())
+        return cls(root=Path.home() / ".scitex" / "agent-container")
+
+    @property
+    def state_db(self) -> Path:
+        return self.root / "runtime" / "state.db"
+
+    def spec_dir(self, name: str) -> Path:
+        return self.root / "agents" / name
+
+    def spec_file(self, name: str) -> Path:
+        return self.spec_dir(name) / "spec.yaml"
+
+    def overlay_dir(self, name: str) -> Path:
+        return self.root / "containers" / "overlays" / name
+
+    def runtime_dir(self, name: str) -> Path:
+        return self.root / "runtime" / name
+
+    def registry_json(self, name: str) -> Path:
+        return self.root / "runtime" / "registry" / f"{name}.json"
+
+
+@dataclass(frozen=True)
+class Move:
+    """A directory or file the rename would move."""
+
+    src: Path
+    dst: Path
+
+
+@dataclass
+class RenamePlan:
+    """Everything the rename would touch. Built without mutating anything."""
+
+    old: str
+    new: str
+    layout: Layout
+    spec_move: Move
+    spec_changes: list[SpecChange] = field(default_factory=list)
+    overlay_move: Move | None = None
+    runtime_move: Move | None = None
+    registry_move: Move | None = None
+    db_counts: dict[str, int] = field(default_factory=dict)
+    card_ids: list[str] = field(default_factory=list)
+    cards_enabled: bool = True
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def db_total(self) -> int:
+        return sum(self.db_counts.values())
+
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+
+def _pid_alive(pid: int) -> bool:
+    """True when a process with ``pid`` currently exists."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # It exists; we merely may not signal it.
+        return True
+    return True
+
+
+def _open_instance_pid(db_path: Path, name: str) -> int | None:
+    """Return the pid of an open ``instances`` row for ``name``, if any."""
+    if not db_path.is_file():
+        return None
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT pid FROM instances "
+            "WHERE name = ? AND ended_at IS NULL AND pid IS NOT NULL "
+            "ORDER BY started_at DESC LIMIT 1",
+            (name,),
+        ).fetchone()
+    except sqlite3.Error:  # stx-allow: fallback (reason: a fresh DB has no instances table — absence of the table is absence of evidence, not evidence of running)
+        return None
+    finally:
+        conn.close()
+    return int(row[0]) if row else None
+
+
+def probe_running(name: str, layout: Layout) -> tuple[str, str]:
+    """Return ``(verdict, reason)`` — ``running`` / ``stopped`` / ``unknown``.
+
+    Renaming a LIVE agent's workdir, overlay and state dir out from under
+    it is unsafe, so only a definitive ``stopped`` may proceed; ``unknown``
+    refuses too.
+
+    The evidence is PHYSICAL — a live PID, never a row that merely CLAIMS
+    to be open. That matters in both directions:
+
+      * a stale ``instances`` row (the reaper closes rows lazily) must not
+        block a legitimate rename forever, so an open row whose pid is DEAD
+        is not evidence of running;
+      * a wedged-but-alive agent still holds its overlay open, so a live
+        pid IS evidence of running even when the agent makes no progress.
+    """
+    pid_file = layout.runtime_dir(name) / "pid"
+    if pid_file.is_file():
+        raw = pid_file.read_text(encoding="utf-8").strip()
+        try:
+            pid = int(raw)
+        except ValueError:
+            return (
+                "unknown",
+                f"{pid_file} exists but holds no pid ({raw!r}); cannot prove "
+                "the agent is stopped",
+            )
+        if _pid_alive(pid):
+            return "running", f"pid {pid} (from {pid_file}) is alive"
+
+    open_pid = _open_instance_pid(layout.state_db, name)
+    if open_pid is not None and _pid_alive(open_pid):
+        return (
+            "running",
+            f"state.db has an open instances row for {name!r} whose pid "
+            f"{open_pid} is alive",
+        )
+
+    return "stopped", ""
+
+
+def preflight(old: str, new: str, layout: Layout) -> None:
+    """Refuse the rename, loudly, if any precondition is unmet."""
+    if not new or not all(ch in _VALID_NAME_CHARS for ch in new):
+        raise RenameError(
+            f"invalid agent name {new!r}: use lowercase letters, digits, '-' "
+            "and '_' only (the name is a directory name)"
+        )
+    if old == new:
+        raise RenameError(f"{old!r} and {new!r} are the same name — nothing to do")
+
+    if not layout.spec_dir(old).is_dir():
+        raise RenameError(
+            f"agent {old!r} not found: {layout.spec_dir(old)} does not exist"
+        )
+    if not layout.spec_file(old).is_file():
+        raise RenameError(
+            f"agent {old!r} has no spec at {layout.spec_file(old)} — refusing "
+            "to rename a directory sac cannot load"
+        )
+
+    for label, path in (
+        ("spec dir", layout.spec_dir(new)),
+        ("overlay dir", layout.overlay_dir(new)),
+        ("runtime dir", layout.runtime_dir(new)),
+        ("registry entry", layout.registry_json(new)),
+    ):
+        if path.exists():
+            raise RenameError(
+                f"{new!r} already exists ({label}: {path}). Pick another name, "
+                f"or remove it first:  sac agents delete {new}"
+            )
+
+    verdict, reason = probe_running(old, layout)
+    if verdict != "stopped":
+        raise RenameError(
+            f"agent {old!r} is {verdict} ({reason}). Renaming a live agent's "
+            "workdir/overlay/state dir out from under it is unsafe.\n"
+            f"    Stop it first:  sac agents stop {old}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plan
+# ---------------------------------------------------------------------------
+
+
+def build_plan(
+    old: str,
+    new: str,
+    *,
+    layout: Layout | None = None,
+    store: str | Path | None = None,
+    cards: bool = True,
+) -> RenamePlan:
+    """Compute everything the rename would touch. Mutates NOTHING.
+
+    Runs :func:`preflight` first: ``--dry-run`` must tell the operator the
+    rename would be REFUSED before they commit to it, not after.
+    """
+    layout = layout or Layout.default()
+    preflight(old, new, layout)
+
+    plan = RenamePlan(
+        old=old,
+        new=new,
+        layout=layout,
+        spec_move=Move(layout.spec_dir(old), layout.spec_dir(new)),
+        cards_enabled=cards,
+    )
+
+    spec_text = layout.spec_file(old).read_text(encoding="utf-8")
+    plan.spec_changes = plan_spec_changes(spec_text, old, new)
+    if not plan.spec_changes:
+        plan.warnings.append(
+            f"the spec never names {old!r} — nothing to rewrite inside it "
+            "(only the directory moves)"
+        )
+
+    for label, src, dst, slot in (
+        ("overlay", layout.overlay_dir(old), layout.overlay_dir(new), "overlay_move"),
+        ("runtime", layout.runtime_dir(old), layout.runtime_dir(new), "runtime_move"),
+        (
+            "registry",
+            layout.registry_json(old),
+            layout.registry_json(new),
+            "registry_move",
+        ),
+    ):
+        if src.exists():
+            setattr(plan, slot, Move(src, dst))
+        else:
+            plan.warnings.append(f"no {label} at {src} — skipping that step")
+
+    plan.db_counts = count_rows(layout.state_db, old)
+
+    if cards:
+        plan.card_ids = find_owned_cards(old, store=store)
+        _warn_about_foreign_scoped_cards(plan, store=store)
+    else:
+        plan.warnings.append(
+            "--no-cards: the board will NOT be migrated. Every card owned by "
+            f"{old!r} is ORPHANED — the agent under its new name cannot see "
+            "its own work, and nothing will tell you."
+        )
+
+    _warn_about_workdir(plan)
+    return plan
+
+
+def _warn_about_foreign_scoped_cards(
+    plan: RenamePlan, *, store: str | Path | None
+) -> None:
+    """Report cards scoped ``agent:<old>`` that ``old`` does not own.
+
+    sac will NOT reassign these: their owner is someone else, and taking a
+    card from a working agent to tidy up a scope string is not a trade this
+    verb gets to make. Say what is being left behind instead of silently
+    picking one of the two wrong answers.
+    """
+    foreign = find_foreign_scoped_cards(plan.old, store=store)
+    if not foreign:
+        return
+    plan.warnings.append(
+        f"{len(foreign)} card(s) are scoped 'agent:{plan.old}' but OWNED BY "
+        f"SOMEONE ELSE ({', '.join(foreign[:5])}). sac will not take another "
+        f"agent's card, so their scope will still say 'agent:{plan.old}' "
+        "afterwards. Fix them on the board if that is wrong."
+    )
+
+
+def _warn_about_workdir(plan: RenamePlan) -> None:
+    """Flag a rewritten workdir whose new target is not on disk.
+
+    sac renames the AGENT, not the repo. When the spec's workdir carried
+    the agent's name (the fleet's project-maintainer convention,
+    ``~/proj/<name>``) the rewrite follows it — but if the repo has not
+    been renamed too, the agent would start with a workdir that is not
+    there. Say so now, not at the next start.
+    """
+    for change in plan.spec_changes:
+        if change.path != "spec.workdir":
+            continue
+        target = Path(os.path.expanduser(change.after))
+        if not target.exists():
+            plan.warnings.append(
+                f"spec.workdir will point at {change.after}, which does not "
+                "exist yet. sac renames the AGENT, not the repo — rename the "
+                "repo too, or edit spec.workdir afterwards."
+            )
+
+
+__all__ = [
+    "ROOT_ENV",
+    "Layout",
+    "Move",
+    "RenameError",
+    "RenamePlan",
+    "build_plan",
+    "preflight",
+    "probe_running",
+]

--- a/src/scitex_agent_container/_lifecycle/_rename_spec.py
+++ b/src/scitex_agent_container/_lifecycle/_rename_spec.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Rewrite an agent spec's SELF-REFERENCES when the agent is renamed.
+
+A spec names itself in more places than the directory it lives in. Miss
+one and the agent starts under the new name but keeps writing to the old
+agent's overlay / state DB / board identity. This module owns the
+EXHAUSTIVE list of those places and rewrites them by LOADING the document
+and changing the known fields — never by running a regex over the file.
+
+Touchpoints (the SSOT — :data:`SPEC_TOUCHPOINTS` documents them for
+``--dry-run``):
+
+  1. ``metadata.labels.project``            token
+  2. ``metadata.labels.purpose``            token (``<name>-maintainer``)
+  3. ``spec.workdir``                       path component
+  4. ``spec.apptainer.overlay``             path component
+  5. ``spec.apptainer.binds[i]``            path component (src + dst)
+  6. ``spec.apptainer.raw_args`` ``--overlay <path>`` / ``--overlay=<path>``
+  7. ``spec.apptainer.raw_args`` ``--env K=V`` for K in :data:`ENV_RULES`
+  8. ``spec.apptainer.env.<K>`` for K in :data:`ENV_RULES`
+
+``ENV_RULES`` is where the DAMAGING one lives: ``SCITEX_TODO_AGENT_ID``
+is the agent's identity ON THE BOARD. Change it without migrating the
+cards and every card the agent owns is orphaned — see ``_rename_cards``.
+
+Why ruamel round-trip and not PyYAML load+dump: specs carry load-bearing
+operator commentary (the live ``scitex-todo`` spec is ~40% comments
+explaining WHY each flag is set). ``ruamel.yaml>=0.18`` is already a hard
+dependency of sac for exactly this reason — see ``pyproject.toml``:
+"operator-authored comments + key order in config.yaml survive a sac-side
+edit". The same rule holds, harder, for a spec.
+
+Why that is still not enough, and what guards it: a round-trip dump can
+in principle reformat content we never meant to touch. So
+:func:`rewrite_spec` re-parses its own output and asserts that the
+SEMANTIC diff against the input is exactly the set of changes it planned
+(:func:`_assert_only_planned_changes`). A rewrite that moved anything
+else raises rather than returning a subtly-corrupted spec.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterator
+
+# Env vars whose VALUE identifies the agent, and how to rewrite each.
+#
+#   "identity" — the whole value IS the agent name.
+#   "path"     — the value is a path with the agent name as a component
+#                (e.g. SCITEX_AGENT_CONTAINER_STATE_DB=/state/<name>/state.db).
+#   "scope"    — the value is the board scope string ``agent:<name>``.
+#
+# SCITEX_TODO_AGENT_ID is the board identity: the shared ``.mcp.json``
+# expands ``${SCITEX_TODO_AGENT_ID}`` and every card the agent writes is
+# attributed to it. SCITEX_TODO_AGENT is its deprecated alias
+# (scitex_todo._store.ENV_AGENT_DEPRECATED) — still honoured, so still
+# renamed.
+ENV_RULES: dict[str, str] = {
+    "SCITEX_TODO_AGENT_ID": "identity",
+    "SCITEX_TODO_AGENT": "identity",
+    "SAC_NAME": "identity",
+    "SCITEX_AGENT_CONTAINER_NAME": "identity",
+    "SCITEX_AGENT_CONTAINER_AGENT": "identity",
+    "SAC_AGENT": "identity",
+    "SCITEX_AGENT_CONTAINER_STATE_DB": "path",
+    "SCITEX_TODO_SCOPE": "scope",
+}
+
+# Human-readable touchpoint list, surfaced by ``sac agents rename --help``
+# and the --dry-run header so the operator can see WHAT is in scope
+# without reading this module.
+SPEC_TOUCHPOINTS: tuple[str, ...] = (
+    "metadata.labels.project",
+    "metadata.labels.purpose",
+    "spec.workdir",
+    "spec.apptainer.overlay",
+    "spec.apptainer.binds[]",
+    "spec.apptainer.raw_args[] --overlay <path>",
+    f"spec.apptainer.raw_args[] --env <K>= for K in {sorted(ENV_RULES)}",
+    "spec.apptainer.env.<K> for the same K",
+)
+
+_OVERLAY_FLAG = "--overlay"
+_ENV_FLAG = "--env"
+
+
+class SpecRewriteError(RuntimeError):
+    """The spec could not be rewritten safely — nothing was written."""
+
+
+@dataclass(frozen=True)
+class SpecChange:
+    """One field the rename touches, with its before/after values."""
+
+    path: str
+    before: str
+    after: str
+
+    def render(self) -> str:
+        return f"{self.path}: {self.before} -> {self.after}"
+
+
+# ---------------------------------------------------------------------------
+# Value-level rewrite rules (precise, boundary-aware — NOT substring sed)
+# ---------------------------------------------------------------------------
+
+
+def sub_token(value: str, old: str, new: str) -> str:
+    """Replace ``old`` with ``new`` at alphanumeric token boundaries.
+
+    ``scitex-todo-maintainer`` -> ``scitex-cards-maintainer`` (the ``-``
+    after the match is a boundary), while ``xscitex-todo`` is left alone
+    (the ``x`` before the match is not). Used for free-form label values.
+    """
+    pattern = re.compile(rf"(?<![A-Za-z0-9]){re.escape(old)}(?![A-Za-z0-9])")
+    return pattern.sub(new, value)
+
+
+def sub_path(value: str, old: str, new: str) -> str:
+    """Replace whole PATH COMPONENTS equal to ``old``.
+
+    ``/home/u/proj/scitex-todo`` -> ``/home/u/proj/scitex-cards``, and
+    ``/state/scitex-todo/state.db`` -> ``/state/scitex-cards/state.db``.
+    A component that merely CONTAINS ``old`` is never touched — this is
+    what keeps the rewrite from mangling ``…/scitex-todo-archive/…``.
+    """
+    return "/".join(new if part == old else part for part in value.split("/"))
+
+
+def sub_bind(value: str, old: str, new: str) -> str:
+    """Rewrite an apptainer bind ``src[:dst[:opts]]`` path-component-wise.
+
+    Only the path fields are touched; a trailing ``:ro`` / ``:rw`` option
+    is passed through untouched (it can never be a path).
+    """
+    parts = value.split(":")
+    opts = ""
+    if len(parts) == 3:
+        parts, opts = parts[:2], f":{parts[2]}"
+    return ":".join(sub_path(p, old, new) for p in parts) + opts
+
+
+def sub_env_value(key: str, value: str, old: str, new: str) -> str:
+    """Rewrite an identity-bearing env VALUE per :data:`ENV_RULES`."""
+    rule = ENV_RULES.get(key)
+    if rule == "identity":
+        return new if value == old else value
+    if rule == "path":
+        return sub_path(value, old, new)
+    if rule == "scope":
+        return f"agent:{new}" if value == f"agent:{old}" else value
+    return value
+
+
+def _split_env_arg(arg: str) -> tuple[str, str] | None:
+    """Split a ``KEY=VALUE`` raw_args env payload, or None if not one."""
+    if "=" not in arg:
+        return None
+    key, value = arg.split("=", 1)
+    return key, value
+
+
+# ---------------------------------------------------------------------------
+# Document-level rewrite
+# ---------------------------------------------------------------------------
+
+
+def _round_trip_yaml():
+    """ruamel YAML configured for comment/order-preserving round-trip.
+
+    Mirrors ``cli_pkg/_host_crud._round_trip_yaml`` — one shape for every
+    sac-side YAML write.
+    """
+    from ruamel.yaml import YAML
+
+    yaml_rt = YAML()
+    yaml_rt.preserve_quotes = True
+    yaml_rt.indent(mapping=2, sequence=4, offset=2)
+    yaml_rt.width = 4096  # never re-wrap a long operator comment or value
+    return yaml_rt
+
+
+def _get(node: Any, *keys: str) -> Any:
+    """Walk a nested mapping, returning None at the first missing key."""
+    for key in keys:
+        if not isinstance(node, dict):
+            return None
+        node = node.get(key)
+    return node
+
+
+def _rewrite_labels(doc: Any, old: str, new: str) -> Iterator[SpecChange]:
+    labels = _get(doc, "metadata", "labels")
+    if not isinstance(labels, dict):
+        return
+    for key in ("project", "purpose"):
+        before = labels.get(key)
+        if not isinstance(before, str):
+            continue
+        after = sub_token(before, old, new)
+        if after != before:
+            labels[key] = after
+            yield SpecChange(f"metadata.labels.{key}", before, after)
+
+
+def _rewrite_workdir(doc: Any, old: str, new: str) -> Iterator[SpecChange]:
+    spec = _get(doc, "spec")
+    if not isinstance(spec, dict):
+        return
+    before = spec.get("workdir")
+    if not isinstance(before, str):
+        return
+    after = sub_path(before, old, new)
+    if after != before:
+        spec["workdir"] = after
+        yield SpecChange("spec.workdir", before, after)
+
+
+def _rewrite_overlay_field(doc: Any, old: str, new: str) -> Iterator[SpecChange]:
+    ap = _get(doc, "spec", "apptainer")
+    if not isinstance(ap, dict):
+        return
+    before = ap.get("overlay")
+    if not isinstance(before, str):
+        return
+    after = sub_path(before, old, new)
+    if after != before:
+        ap["overlay"] = after
+        yield SpecChange("spec.apptainer.overlay", before, after)
+
+
+def _rewrite_binds(doc: Any, old: str, new: str) -> Iterator[SpecChange]:
+    ap = _get(doc, "spec", "apptainer")
+    if not isinstance(ap, dict):
+        return
+    binds = ap.get("binds")
+    if not isinstance(binds, list):
+        return
+    for idx, before in enumerate(binds):
+        if not isinstance(before, str):
+            continue
+        after = sub_bind(before, old, new)
+        if after != before:
+            binds[idx] = after
+            yield SpecChange(f"spec.apptainer.binds[{idx}]", before, after)
+
+
+def _rewrite_env_map(doc: Any, old: str, new: str) -> Iterator[SpecChange]:
+    env = _get(doc, "spec", "apptainer", "env")
+    if not isinstance(env, dict):
+        return
+    for key in list(env):
+        if key not in ENV_RULES:
+            continue
+        before = env[key]
+        if not isinstance(before, str):
+            continue
+        after = sub_env_value(key, before, old, new)
+        if after != before:
+            env[key] = after
+            yield SpecChange(f"spec.apptainer.env.{key}", before, after)
+
+
+def _rewrite_raw_args(doc: Any, old: str, new: str) -> Iterator[SpecChange]:
+    """Rewrite ``--overlay`` paths and identity ``--env`` payloads.
+
+    ``raw_args`` is a FLAT list of argv tokens, so a value is identified
+    by the flag that precedes it (``["--env", "K=V"]``) or by the
+    ``=``-joined spelling (``["--overlay=/path"]``). Both spellings are
+    live in the fleet — see ``runtimes/_apptainer_overlay``.
+    """
+    ap = _get(doc, "spec", "apptainer")
+    if not isinstance(ap, dict):
+        return
+    args = ap.get("raw_args")
+    if not isinstance(args, list):
+        return
+
+    for idx, token in enumerate(args):
+        if not isinstance(token, str):
+            continue
+        prev = args[idx - 1] if idx > 0 else ""
+
+        # `--overlay <path>` (space-separated) — this token is the value.
+        if prev == _OVERLAY_FLAG:
+            after = sub_path(token, old, new)
+            if after != token:
+                args[idx] = after
+                yield SpecChange(
+                    f"spec.apptainer.raw_args[{idx}] (--overlay)", token, after
+                )
+            continue
+
+        # `--overlay=<path>` (=-joined) — flag and value in one token.
+        if token.startswith(f"{_OVERLAY_FLAG}="):
+            value = token.split("=", 1)[1]
+            after_value = sub_path(value, old, new)
+            if after_value != value:
+                after = f"{_OVERLAY_FLAG}={after_value}"
+                args[idx] = after
+                yield SpecChange(
+                    f"spec.apptainer.raw_args[{idx}] (--overlay=)", token, after
+                )
+            continue
+
+        # `--env K=V` — this token is the payload.
+        if prev == _ENV_FLAG:
+            split = _split_env_arg(token)
+            if split is None:
+                continue
+            key, value = split
+            after_value = sub_env_value(key, value, old, new)
+            if after_value != value:
+                after = f"{key}={after_value}"
+                args[idx] = after
+                yield SpecChange(
+                    f"spec.apptainer.raw_args[{idx}] (--env {key})", token, after
+                )
+
+
+_REWRITERS = (
+    _rewrite_labels,
+    _rewrite_workdir,
+    _rewrite_overlay_field,
+    _rewrite_binds,
+    _rewrite_env_map,
+    _rewrite_raw_args,
+)
+
+
+def plan_spec_changes(text: str, old: str, new: str) -> list[SpecChange]:
+    """Return the changes :func:`rewrite_spec` WOULD make. Mutates nothing.
+
+    Drives ``--dry-run``: it loads a throwaway copy of the document, runs
+    the same rewriters, and reports what they touched.
+    """
+    return rewrite_spec(text, old, new)[1]
+
+
+def rewrite_spec(text: str, old: str, new: str) -> tuple[str, list[SpecChange]]:
+    """Rewrite ``text``'s self-references from ``old`` to ``new``.
+
+    Returns ``(new_text, changes)``. ``changes`` is empty (and
+    ``new_text is text``) when the spec names itself nowhere — a valid,
+    if unusual, outcome that the caller surfaces rather than treats as a
+    failure.
+
+    Raises:
+        SpecRewriteError: The document does not parse, or the round-trip
+            moved something we did not plan to move. Nothing is written.
+    """
+    yaml_rt = _round_trip_yaml()
+    try:
+        doc = yaml_rt.load(text)
+    except Exception as exc:  # noqa: BLE001 - any ruamel parse failure
+        raise SpecRewriteError(f"spec does not parse as YAML: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise SpecRewriteError("spec is not a YAML mapping")
+
+    changes: list[SpecChange] = []
+    for rewriter in _REWRITERS:
+        changes.extend(rewriter(doc, old, new))
+
+    if not changes:
+        return text, []
+
+    import io
+
+    buf = io.StringIO()
+    yaml_rt.dump(doc, buf)
+    new_text = buf.getvalue()
+
+    _assert_only_planned_changes(text, new_text, changes)
+    return new_text, changes
+
+
+# ---------------------------------------------------------------------------
+# The guard: prove the round-trip moved ONLY what we planned to move
+# ---------------------------------------------------------------------------
+
+
+def _flatten(node: Any, prefix: str = "") -> dict[str, Any]:
+    """Flatten a parsed YAML doc to ``{dotted.path: scalar}``."""
+    flat: dict[str, Any] = {}
+    if isinstance(node, dict):
+        for key, value in node.items():
+            flat.update(_flatten(value, f"{prefix}.{key}" if prefix else str(key)))
+    elif isinstance(node, list):
+        for idx, value in enumerate(node):
+            flat.update(_flatten(value, f"{prefix}[{idx}]"))
+    else:
+        flat[prefix] = node
+    return flat
+
+
+def _assert_only_planned_changes(
+    before_text: str, after_text: str, changes: list[SpecChange]
+) -> None:
+    """Fail loud if the rewrite changed any value we did not plan to change.
+
+    This is the safety net that makes a full load+dump round-trip
+    acceptable on a comment-heavy, operator-authored spec. We compare the
+    two documents SEMANTICALLY (flattened scalar maps, so comments and
+    formatting are out of scope by construction) and require that the set
+    of differing leaves is exactly the set of leaves our rewriters
+    reported touching.
+
+    A key that appears or disappears is also a failure — a rewrite must
+    never add or drop a field.
+    """
+    import yaml as _pyyaml
+
+    try:
+        before = _flatten(_pyyaml.safe_load(before_text))
+        after = _flatten(_pyyaml.safe_load(after_text))
+    except _pyyaml.YAMLError as exc:
+        raise SpecRewriteError(
+            f"rewritten spec no longer parses: {exc}"
+        ) from exc
+
+    added = set(after) - set(before)
+    dropped = set(before) - set(after)
+    if added or dropped:
+        raise SpecRewriteError(
+            "rewrite changed the spec's SHAPE (this is a bug, not your spec) — "
+            f"added={sorted(added)} dropped={sorted(dropped)}"
+        )
+
+    differing = {k for k in before if before[k] != after[k]}
+    # The rewriters report ruamel paths (`spec.apptainer.raw_args[3]
+    # (--env FOO)`); reduce to the leaf address to compare with _flatten.
+    planned_values = {(c.before, c.after) for c in changes}
+    for key in sorted(differing):
+        if (before[key], after[key]) not in planned_values:
+            raise SpecRewriteError(
+                "rewrite changed a value it did not plan to change "
+                f"(this is a bug, not your spec) — {key}: "
+                f"{before[key]!r} -> {after[key]!r}"
+            )
+    if len(differing) != len(changes):
+        raise SpecRewriteError(
+            f"rewrite planned {len(changes)} change(s) but the document "
+            f"shows {len(differing)} — refusing to write a spec we cannot "
+            "fully account for"
+        )
+
+
+__all__ = [
+    "ENV_RULES",
+    "SPEC_TOUCHPOINTS",
+    "SpecChange",
+    "SpecRewriteError",
+    "plan_spec_changes",
+    "rewrite_spec",
+    "sub_bind",
+    "sub_env_value",
+    "sub_path",
+    "sub_token",
+]

--- a/src/scitex_agent_container/_skills/scitex-agent-container/10_cli.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/10_cli.md
@@ -16,9 +16,39 @@ sac agents start <name|yaml>            # Launch one (or more) agents (dir-as-SS
 sac agents start <name> --foreground    # Stream stdio + block until the turn finishes
 sac agents stop <name|yaml>             # Stop a running agent (graceful SIGTERM → SIGKILL after 5 s)
 sac agents restart <name>               # Stop then start, preserving session_id resume
+sac agents rename <old> <new> --dry-run # Show every location a rename would touch (exact; changes nothing)
+sac agents rename <old> <new> -y        # Rename EVERYWHERE, atomically (rolls back on any failure)
 sac agents delete <name> -y             # Stop, deregister, and remove the agent's dir
 sac db clean                            # Sweep dead instances from state.db (replaces legacy registry clean)
 ```
+
+### `rename` — why it is a verb and not a `mv`
+
+An agent writes its own name into six places on disk plus the shared task
+board. `rename` moves all of them together, or none:
+
+| # | Location |
+|---|---|
+| 1 | spec dir — `~/.scitex/agent-container/agents/<name>/` |
+| 2 | the spec's self-references — `metadata.labels.project` / `.purpose`, `spec.workdir`, the `--overlay` path, `SCITEX_AGENT_CONTAINER_STATE_DB`, and `SCITEX_TODO_AGENT_ID` |
+| 3 | overlay dir — `.../containers/overlays/<name>/` |
+| 4 | runtime + state dir — `.../runtime/<name>/` (bound into the container at `/state/<name>`) |
+| 5 | registry entry — `.../runtime/registry/<name>.json` |
+| 6 | `state.db` — every table that keys on the agent name (identity **and** history) |
+| 7 | **task cards** — reassigned via scitex-todo's own `reassign_task` |
+
+Step 7 is the reason the verb exists. The board knows an agent by
+`SCITEX_TODO_AGENT_ID`. Change it without migrating the cards and every card
+that agent owns is **orphaned** — it can no longer see its own work, and
+nothing tells you.
+
+The agent must be **stopped** (renaming a live agent's workdir and overlay out
+from under it is unsafe); `rename` refuses otherwise and prints the `stop`
+command. Every step records its inverse, so any failure — including a partial
+card migration — rolls the whole rename back.
+
+`$SCITEX_AGENT_CONTAINER_ROOT` overrides the root all seven locations derive
+from.
 
 ## Inspection
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/20_env-vars.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/20_env-vars.md
@@ -61,6 +61,7 @@ resolver walks per-host `<host>/agents/`, then `shared/agents/`, then
 | `SCITEX_AGENT_CONTAINER_REGISTRY_DIR` | Directory where the container registers its presence. | `~/.scitex/agent-container/runtime/registry` | path |
 | `SCITEX_AGENT_CONTAINER_RUNTIME_DIR` | Per-agent runtime state root for the claude-session runner (pid / heartbeat.json / session.jsonl / quota.json / session_id). | `~/.scitex/agent-container/runtime` | path |
 | `SCITEX_AGENT_CONTAINER_SLURM_STATE_DIR` | Directory for SLURM-job state handoff. | `~/.scitex/agent-container/slurm` | path |
+| `SCITEX_AGENT_CONTAINER_ROOT` | sac's install root, as a single base. Read by `sac agents rename` (`_lifecycle._rename_plan.Layout.default`) to derive the spec / overlay / runtime / registry / state.db paths together. Resolved at CALL time, so it actually takes effect. | `~/.scitex/agent-container` | path |
 | `SAC_CACHE_DIR` | Agent-local cache directory. | `~/.cache/scitex-agent` | path |
 
 ## Credentials

--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -23,6 +23,7 @@ from .info_cmds import tail_session as _tail_impl
 from .lifecycle import attach as _attach_impl
 from .lifecycle import delete as _delete_impl
 from .lifecycle import forget as _forget_impl
+from .lifecycle import rename as _rename_impl
 from .lifecycle import restart as _restart_impl
 from .lifecycle import start as _start_impl
 from .lifecycle import stop as _stop_impl
@@ -51,7 +52,17 @@ class _AgentsGroup(HelpRecursiveGroup):
     COMMAND_CATEGORIES = [
         (
             "Lifecycle",
-            ["create", "start", "twin", "stop", "restart", "delete", "forget", "spawn-from-here"],
+            [
+                "create",
+                "start",
+                "twin",
+                "stop",
+                "restart",
+                "rename",
+                "delete",
+                "forget",
+                "spawn-from-here",
+            ],
         ),
         ("Interact", ["send", "attach"]),
         ("Inspect", ["list", "status", "health", "auth-status", "tail", "recall"]),
@@ -89,6 +100,14 @@ agent_group.add_command(_rebind(_start_impl, "start"))
 agent_group.add_command(_rebind(_twin_impl, "twin"))
 agent_group.add_command(_rebind(_stop_impl, "stop"))
 agent_group.add_command(_rebind(_restart_impl, "restart"))
+# `rename` — the ONE verb that moves an agent's name in every place it is
+# written: the spec dir, the spec's own self-references (labels, workdir,
+# overlay path, state-db path, and the SCITEX_TODO_AGENT_ID board
+# identity), the overlay/runtime dirs, the registry entry, the state.db
+# rows, AND the agent's task cards. Renaming by hand orphans the cards —
+# the board still knows the agent by its old id and nothing says so.
+# Atomic: every step records its inverse, any failure rolls the lot back.
+agent_group.add_command(_rebind(_rename_impl, "rename"))
 agent_group.add_command(_rebind(_delete_impl, "delete"))
 agent_group.add_command(_rebind(_forget_impl, "forget"))
 # PR-3 — in-SIF-native spawn verb with wire-stable outcome JSON +

--- a/src/scitex_agent_container/cli_pkg/lifecycle/__init__.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/__init__.py
@@ -15,6 +15,7 @@ from ._attach import attach
 from ._cleanup import cleanup
 from ._delete import delete
 from ._forget import forget
+from ._rename import rename
 from ._restart import restart
 from ._start import start
 from ._stop import stop
@@ -29,4 +30,5 @@ __all__ = [
     "cleanup",
     "attach",
     "twin",
+    "rename",
 ]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_rename.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_rename.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``sac agents rename <old> <new>`` — rename an agent everywhere, atomically.
+
+An agent's name lives in six places on disk plus the shared task board.
+Renaming by hand means editing all of them consistently, and the one you
+miss is silent — most damagingly the board identity
+(``SCITEX_TODO_AGENT_ID``): change it without migrating the cards and
+every card the agent owns is orphaned, with nothing to tell you.
+
+The engine is :mod:`..._lifecycle._rename`; this module is its CLI face —
+argument parsing, the ``--dry-run`` report, and the confirmation gate.
+
+Output goes through ``click.echo``, not the shared rich ``console``: the
+report is full of literal ``[spec-dir]``-style labels and bracketed
+``raw_args[3]`` paths, and rich would parse every one of those as a markup
+tag and blow up on the unknown style. Colour comes from ``click.style``,
+which leaves square brackets alone.
+"""
+
+from __future__ import annotations
+
+import json as _json
+
+import click
+
+from ..._lifecycle._rename import STEPS, agent_rename
+from ..._lifecycle._rename_plan import Layout, RenameError, RenamePlan, build_plan
+from ..._lifecycle._rename_spec import SpecChange
+from .._helpers import agent_name_complete
+
+__all__ = ["rename"]
+
+# The env var whose value IS the agent's identity on the board. Called out
+# explicitly in the report because it is the one whose silent breakage
+# costs real work.
+_BOARD_IDENTITY_ENV = "SCITEX_TODO_AGENT_ID"
+
+_MAX_LISTED_CARDS = 8
+
+
+def _mark(change: SpecChange) -> str:
+    """Annotate the spec change that carries the board identity."""
+    if _BOARD_IDENTITY_ENV not in change.path:
+        return ""
+    return "   " + click.style("<-- BOARD IDENTITY", fg="yellow", bold=True)
+
+
+def _render_plan(plan: RenamePlan, *, dry_run: bool) -> None:
+    """Print the full plan. Identical for --dry-run and the real run."""
+    if dry_run:
+        click.echo(click.style("DRY RUN — nothing will be changed.", bold=True))
+        click.echo("")
+    click.echo(
+        f"rename  {click.style(plan.old, bold=True)}"
+        f"  ->  {click.style(plan.new, bold=True)}\n"
+    )
+
+    click.echo("  [spec-dir]")
+    click.echo(f"      {plan.spec_move.src}")
+    click.echo(f"   -> {plan.spec_move.dst}\n")
+
+    click.echo(f"  [spec-file]    {len(plan.spec_changes)} self-reference(s)")
+    for change in plan.spec_changes:
+        click.echo(f"      {change.render()}{_mark(change)}")
+    click.echo("")
+
+    for label, move in (
+        ("overlay-dir", plan.overlay_move),
+        ("runtime-dir", plan.runtime_move),
+        ("registry", plan.registry_move),
+    ):
+        if move is None:
+            click.echo(f"  [{label}]     (none — skipped)")
+            continue
+        click.echo(f"  [{label}]")
+        click.echo(f"      {move.src}")
+        click.echo(f"   -> {move.dst}")
+    click.echo("")
+
+    click.echo(
+        f"  [state-db]     {plan.db_total} row(s) across "
+        f"{len(plan.db_counts)} column(s)"
+    )
+    for column, count in sorted(plan.db_counts.items()):
+        click.echo(f"      {column:<34} {count}")
+    click.echo("")
+
+    _render_cards(plan)
+    _render_warnings(plan)
+
+
+def _render_cards(plan: RenamePlan) -> None:
+    if not plan.cards_enabled:
+        click.echo("  [cards]        SKIPPED (--no-cards)\n")
+        return
+    n = len(plan.card_ids)
+    click.echo(f"  [cards]        {n} card(s) -> owner '{plan.new}'")
+    shown = plan.card_ids[:_MAX_LISTED_CARDS]
+    if shown:
+        click.echo(f"      {', '.join(shown)}")
+        if n > len(shown):
+            click.echo(f"      ... (+{n - len(shown)} more)")
+    click.echo(
+        "      via scitex_todo._store.reassign_task — sac calls the board's own\n"
+        "      primitive; it never edits the store itself.\n"
+    )
+
+
+def _render_warnings(plan: RenamePlan) -> None:
+    if not plan.warnings:
+        return
+    click.echo(click.style("WARNINGS", fg="yellow", bold=True))
+    for warning in plan.warnings:
+        click.echo(f"  {click.style('!', fg='yellow')} {warning}")
+    click.echo("")
+
+
+def _plan_json(plan: RenamePlan, *, dry_run: bool, applied: bool) -> str:
+    return _json.dumps(
+        {
+            "old": plan.old,
+            "new": plan.new,
+            "dry_run": dry_run,
+            "applied": applied,
+            "spec_dir": {
+                "src": str(plan.spec_move.src),
+                "dst": str(plan.spec_move.dst),
+            },
+            "spec_changes": [
+                {"path": c.path, "before": c.before, "after": c.after}
+                for c in plan.spec_changes
+            ],
+            "moves": {
+                label: (
+                    None
+                    if move is None
+                    else {"src": str(move.src), "dst": str(move.dst)}
+                )
+                for label, move in (
+                    ("overlay", plan.overlay_move),
+                    ("runtime", plan.runtime_move),
+                    ("registry", plan.registry_move),
+                )
+            },
+            "state_db_rows": plan.db_counts,
+            "cards": {
+                "enabled": plan.cards_enabled,
+                "ids": plan.card_ids,
+                "count": len(plan.card_ids),
+            },
+            "warnings": plan.warnings,
+            "steps": list(STEPS),
+        },
+        ensure_ascii=False,
+    )
+
+
+@click.command(name="rename")
+@click.argument("old", type=str, shell_complete=agent_name_complete)
+@click.argument("new", type=str)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="Print every location the rename would touch. Changes nothing.",
+)
+@click.option(
+    "-y",
+    "--yes",
+    "yes",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation gate.",
+)
+@click.option(
+    "--no-cards",
+    "no_cards",
+    is_flag=True,
+    default=False,
+    help=(
+        "Do NOT migrate the agent's task cards. Every card it owns is then "
+        "ORPHANED (the agent under its new name cannot see its own work). "
+        "Only for a fleet with no board."
+    ),
+)
+@click.option(
+    "--store",
+    "store",
+    type=str,
+    default=None,
+    help="Explicit scitex-todo store path. Default: the resolved shared store.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit the plan as a JSON envelope on stdout.",
+)
+def rename(
+    old: str,
+    new: str,
+    dry_run: bool,
+    yes: bool,
+    no_cards: bool,
+    store: str | None,
+    as_json: bool,
+) -> None:
+    """Rename an agent everywhere — spec, dirs, state.db, and its task cards.
+
+    An agent names itself in six places on disk plus the shared board.
+    This verb changes all of them together, or none of them: every step
+    records its inverse, and any failure rolls the whole rename back.
+
+    \b
+    What it touches:
+      1. spec dir          ~/.scitex/agent-container/agents/<name>/
+      2. spec self-refs    labels.project / labels.purpose / workdir /
+                           overlay path / state-db path / board identity
+      3. overlay dir       .../containers/overlays/<name>/
+      4. runtime+state dir .../runtime/<name>/   (bound at /state/<name>)
+      5. registry entry    .../runtime/registry/<name>.json
+      6. state.db rows     every table that keys on the agent name
+      7. TASK CARDS        reassigned via scitex-todo's own reassign_task
+
+    \b
+    Step 7 is the point of the verb. The board knows the agent by
+    SCITEX_TODO_AGENT_ID; rename without migrating and every card the
+    agent owns is orphaned — silently.
+
+    \b
+    The agent must be STOPPED (renaming a live agent's workdir and overlay
+    out from under it is unsafe). Run --dry-run first; it is exact.
+
+    \b
+    Example:
+      $ sac agents rename scitex-todo scitex-cards --dry-run
+      $ sac agents rename scitex-todo scitex-cards -y
+    """
+    try:
+        plan = build_plan(
+            old,
+            new,
+            layout=Layout.default(),
+            store=store,
+            cards=not no_cards,
+        )
+    except RenameError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if as_json and dry_run:
+        click.echo(_plan_json(plan, dry_run=True, applied=False))
+        return
+
+    if not as_json:
+        _render_plan(plan, dry_run=dry_run)
+
+    if dry_run:
+        click.echo(
+            "Re-run without --dry-run to apply "
+            f"({old!r} is stopped, so the rename is allowed)."
+        )
+        return
+
+    if not yes and not as_json:
+        card_note = (
+            f" and reassign {len(plan.card_ids)} card(s)"
+            if plan.cards_enabled and plan.card_ids
+            else ""
+        )
+        click.confirm(
+            f"Rename {old!r} -> {new!r}{card_note}?",
+            abort=True,
+        )
+    elif not yes and as_json:
+        raise click.ClickException(
+            "--json is non-interactive: pass -y/--yes to confirm the rename, "
+            "or --dry-run to inspect it."
+        )
+
+    def _progress(step: str) -> None:
+        if not as_json:
+            click.echo(f"  .. {step}")
+
+    try:
+        # Re-plans (and so re-preflights) immediately before applying, which
+        # closes the window between the report above and the mutation below:
+        # an agent that STARTED in between is caught here, not half-renamed.
+        applied = agent_rename(
+            old,
+            new,
+            layout=plan.layout,
+            store=store,
+            cards=not no_cards,
+            on_step=_progress,
+        )
+    except RenameError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if as_json:
+        click.echo(_plan_json(applied, dry_run=False, applied=True))
+        return
+
+    click.echo(f"\n{click.style('renamed', fg='green', bold=True)} {old} -> {new}")
+    if applied.cards_enabled and applied.card_ids:
+        click.echo(f"  {len(applied.card_ids)} card(s) now owned by {new!r}")
+    click.echo(f"  Start it with:  sac agents start {new}")

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -31,6 +31,7 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_dev.linter.checker",
     "scitex_logging",
     "scitex_notification",
+    "scitex_todo",
     "scitex_todo._help_wait",
 ]
 # ===== END AUTO-GENERATED =====

--- a/tests/scitex_agent_container/_helpers/fleet_root.py
+++ b/tests/scitex_agent_container/_helpers/fleet_root.py
@@ -1,0 +1,303 @@
+"""An ISOLATED fleet root + board, for the ``sac agents rename`` tests.
+
+A rename test that reached the real fleet would move a live agent's spec
+dir, overlay and state dir, and REASSIGN ITS CARDS. So isolation is not a
+tidiness concern here — it is the first requirement, and it is asserted,
+not assumed (``tests/.../test__rename_isolation.py``).
+
+Two escape routes exist and both are closed:
+
+1. **Paths.** ``Layout`` derives every path from an injectable ``root``.
+   That is deliberate: sac's own module-level defaults
+   (``Registry.REGISTRY_DIR``, ``_session_state.DEFAULT_STATE_ROOT``,
+   ``state_db.DEFAULT_DB_PATH``) are computed from ``$HOME`` at IMPORT
+   time, so a fixture that only sets ``$HOME`` CANNOT redirect them — it
+   would read and write the live fleet while looking isolated.
+
+2. **The board.** Every scitex-todo call takes an explicit ``store=``.
+   Belt and braces, :func:`isolated_board` ALSO points
+   ``$SCITEX_TODO_TASKS_YAML_SHARED`` at the tmp store, so even a call
+   that forgot to pass ``store=`` lands in the tmp file rather than on the
+   real 1,400-card board.
+
+No mocks: the store is a real YAML file that real ``scitex_todo`` reads
+and writes, and the state.db is a real SQLite file with the real schema.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+from scitex_agent_container._lifecycle._rename_plan import Layout
+
+# A spec that names itself in every place the rename must find. Modelled
+# on the live project-maintainer shape (relaxed apptainer + directory
+# overlay + raw_args env block), with the comments kept so the tests also
+# prove comment preservation.
+SPEC_TEMPLATE = """\
+# {name} — per-package maintainer agent.
+#
+# This comment block is LOAD-BEARING: it is the operator's record of why
+# each flag below is set, and a rename must not destroy it.
+
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  labels:
+    project: {name}
+    purpose: {name}-maintainer
+    role: project-maintainer
+    groups: [developer, infra]
+
+spec:
+  runtime: tui
+  host: test-host
+  # The --pwd the agent opens at.
+  workdir: {home}/proj/{name}
+
+  apptainer:
+    image: {home}/.scitex/agent-container/containers/sac-base.sif
+    relaxed: true
+    binds:
+      - {home}:{home}:rw
+      - {home}/.ssh:/home/agent/.ssh:ro
+    raw_args:
+      - --userns
+      - --containall
+      - --home
+      - /home/agent
+      - --overlay
+      - {home}/.scitex/agent-container/containers/overlays/{name}/
+      - --env
+      - SCITEX_AGENT_CONTAINER_STATE_DB=/state/{name}/state.db
+      # The board identity. Change this without migrating the cards and
+      # every card the agent owns is orphaned.
+      - --env
+      - SCITEX_TODO_AGENT_ID={name}
+      - --env
+      - GIT_AUTHOR_NAME=Yusuke Watanabe
+
+  claude:
+    model: opus[1m]
+    flags:
+      - --dangerously-skip-permissions
+
+  health:
+    enabled: true
+    interval: 60
+
+  restart:
+    policy: on-failure
+    max_retries: 3
+
+# EOF
+"""
+
+
+def make_spec(name: str, home: str = "/home/tester") -> str:
+    """Render a self-referencing spec for ``name``."""
+    return SPEC_TEMPLATE.format(name=name, home=home)
+
+
+def make_fleet(
+    root: Path,
+    name: str,
+    *,
+    spec: str | None = None,
+    overlay: bool = True,
+    runtime: bool = True,
+    registry: bool = True,
+) -> Layout:
+    """Materialise a complete, isolated fleet root holding one agent.
+
+    Creates the spec dir + spec.yaml, and (by default) the overlay dir,
+    the runtime/state dir, and the JSON registry entry — the same five
+    on-disk locations the real fleet has.
+    """
+    layout = Layout(root=root)
+
+    spec_dir = layout.spec_dir(name)
+    spec_dir.mkdir(parents=True)
+    (spec_dir / "to_home").mkdir()
+    layout.spec_file(name).write_text(spec if spec is not None else make_spec(name))
+
+    if overlay:
+        overlay_dir = layout.overlay_dir(name)
+        (overlay_dir / "upper" / "home" / "agent").mkdir(parents=True)
+        (overlay_dir / "work").mkdir(parents=True)
+        (overlay_dir / "upper" / "home" / "agent" / "marker").write_text(name)
+
+    if runtime:
+        runtime_dir = layout.runtime_dir(name)
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / "session.jsonl").write_text('{"marker": "%s"}\n' % name)
+
+    if registry:
+        registry_dir = layout.registry_json(name).parent
+        registry_dir.mkdir(parents=True, exist_ok=True)
+        layout.registry_json(name).write_text(
+            '{\n  "name": "%s",\n  "config": "%s",\n  "screen": "sac-%s"\n}\n'
+            % (name, layout.spec_file(name), name)
+        )
+
+    return layout
+
+
+def make_state_db(layout: Layout) -> Path:
+    """Create a REAL state.db with the REAL schema under ``layout.root``.
+
+    Uses sac's own ``init_schema`` so the tables (and therefore the
+    columns the rename walks) are exactly the production ones — a
+    hand-rolled fixture schema would drift and the tests would stop
+    proving anything.
+    """
+    from scitex_agent_container._state.state_db import init_schema
+
+    db_path = layout.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    init_schema(db_path)
+    return db_path
+
+
+def _env_overrides(pairs: dict[str, str | None]) -> Iterator[None]:
+    """Set (or clear) env vars for the duration, then restore them.
+
+    Real ``os.environ`` mutation with a real teardown — the ecosystem bans
+    ``monkeypatch``, and rightly: a fixture that rewrites production
+    internals proves nothing about production.
+    """
+    previous = {key: os.environ.get(key) for key in pairs}
+    for key, value in pairs.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    try:
+        yield
+    finally:
+        for key, before in previous.items():
+            if before is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = before
+
+
+def isolated_board(tmp_path: Path) -> Iterator[Path]:
+    """Yield a tmp scitex-todo store, fully cut off from the live fleet.
+
+    THREE things must be isolated, not one. Each is a real production
+    opt-out, not a mock — the code paths stay exactly as they ship; the
+    test simply does not ride them.
+
+    * **the store** — ``$SCITEX_TODO_TASKS_YAML_SHARED`` points at a tmp
+      YAML file, so even a call that forgot ``store=`` lands in tmp rather
+      than on the live 1,400-card board.
+
+    * **the notification rail** — sac registers a ``scitex_todo.hooks``
+      consumer (``_listen._card_event_delivery``), so every real
+      ``reassign_task`` emits a ``reassigned`` event which that consumer
+      turns into an HTTP POST to the LOCAL ``sac listen`` daemon on
+      127.0.0.1:7878, which publishes it onto a live agent's a2a bus. A
+      test that reassigns 5 cards would ping five REAL agents — and block
+      5 s per POST when the daemon is absent. ``SAC_CARD_EVENT_DELIVERY_-
+      DISABLED`` is sac's own shipped kill-switch for exactly this.
+
+    * **the git autocommit** — ``scitex_todo._store_write`` git-commits the
+      store after every write (two ``subprocess.run`` forks). Against a tmp
+      store that is pure cost, and inside a repo it would be a real commit.
+      ``SCITEX_TODO_STORE_GIT_AUTOCOMMIT=0`` is scitex-todo's documented
+      opt-out.
+
+    Generator — call from a fixture with ``yield from``.
+    """
+    store = tmp_path / "board" / "tasks.yaml"
+    store.parent.mkdir(parents=True, exist_ok=True)
+    store.write_text("tasks: []\n")
+
+    yield from _yield_value(
+        store,
+        _env_overrides(
+            {
+                "SCITEX_TODO_TASKS_YAML_SHARED": str(store),
+                "SAC_CARD_EVENT_DELIVERY_DISABLED": "1",
+                "SCITEX_TODO_STORE_GIT_AUTOCOMMIT": "0",
+                # `list_tasks(scope=None)` falls back to this. A stray value
+                # would silently AND every owner query with the caller's own
+                # slice — the exact orphaning the rename exists to prevent.
+                "SCITEX_TODO_SCOPE": None,
+            }
+        ),
+    )
+
+
+def _yield_value(value, guard: Iterator[None]) -> Iterator:
+    """Run ``guard`` (a setup/teardown generator) while yielding ``value``."""
+    for _ in guard:
+        yield value
+
+
+def isolated_root(tmp_path: Path) -> Iterator[Path]:
+    """Yield a tmp sac root, with ``$SCITEX_AGENT_CONTAINER_ROOT`` set to it.
+
+    This is what lets a CliRunner test drive the REAL ``sac agents rename``
+    command — which resolves its own ``Layout.default()`` — without the
+    command reaching the live fleet.
+    """
+    from scitex_agent_container._lifecycle._rename_plan import ROOT_ENV
+
+    root = tmp_path / "fleet"
+    root.mkdir(parents=True, exist_ok=True)
+    yield from _yield_value(root, _env_overrides({ROOT_ENV: str(root)}))
+
+
+def no_root_override(tmp_path: Path) -> Iterator[None]:
+    """Yield with ``$SCITEX_AGENT_CONTAINER_ROOT`` cleared."""
+    from scitex_agent_container._lifecycle._rename_plan import ROOT_ENV
+
+    yield from _env_overrides({ROOT_ENV: None})
+
+
+def add_card(
+    store: Path,
+    task_id: str,
+    *,
+    owner: str,
+    scope: str | None = None,
+) -> str:
+    """Write ONE real card through ``scitex_todo._store.add_task``.
+
+    ``entry_points=[]`` is scitex-todo's documented in-process injection
+    seam. It is used HERE — on the test's own seeding writes, never on the
+    code under test — because the real plugin dispatch re-runs
+    ``importlib.metadata.entry_points()`` on EVERY card write (uncached: it
+    re-reads ~126 ``entry_points.txt`` files, measured at 2.2 s a call in
+    this container). Seeding a fixture is not the behaviour under test, and
+    paying that toll on every seed makes the suite unrunnable. The rename's
+    OWN ``reassign_task`` calls keep real discovery — the code under test is
+    never short-circuited.
+
+    ``scitex-todo`` rejects an owner-less card outright ("creator+assignee
+    are mandatory ... no silent fallback"), so ``owner`` is required.
+    """
+    from scitex_todo import _store
+
+    _store.add_task(
+        store,
+        id=task_id,
+        title=f"card {task_id}",
+        status="in_progress",
+        agent=owner,
+        assignee=owner,
+        scope=scope if scope is not None else f"agent:{owner}",
+        entry_points=[],
+    )
+    return task_id
+
+
+def seed_cards(store: Path, owner: str, count: int) -> list[str]:
+    """Add ``count`` real cards owned by ``owner`` to the tmp store."""
+    return [
+        add_card(store, f"{owner}-card-{i}", owner=owner) for i in range(count)
+    ]

--- a/tests/scitex_agent_container/_helpers/fleet_root.py
+++ b/tests/scitex_agent_container/_helpers/fleet_root.py
@@ -161,6 +161,55 @@ def make_state_db(layout: Layout) -> Path:
     return db_path
 
 
+def seed_db_rows(db_path: Path, statements: list[tuple[str, tuple]]) -> Path:
+    """Execute seeding INSERTs against a real state.db, committing once.
+
+    Lives HERE rather than inline in a fixture on purpose. STX-TQ005 (the
+    ecosystem test-quality rule) forbids a fixture that opens an external
+    resource — ``sqlite3.connect(...)`` — and hands it back with ``return``
+    instead of ``yield``, because a returned connection is never closed.
+    These fixtures never hand the connection back at all; they open it,
+    write, and close it. Extracting that into a plain helper keeps the
+    fixture bodies resource-free and the rule satisfied for the right
+    reason rather than by suppression.
+    """
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        with conn:
+            for sql, args in statements:
+                conn.execute(sql, args)
+    finally:
+        conn.close()
+    return db_path
+
+
+COMMS_NODE_SQL = (
+    "INSERT INTO comms_nodes (name, host, a2a_port, registered_at, updated_at) "
+    "VALUES (?, ?, ?, ?, ?)"
+)
+TURN_SQL = (
+    "INSERT INTO turns (turn_id, name, host, status, ts) VALUES (?, ?, ?, ?, ?)"
+)
+
+
+def seed_identity_and_history(layout: Layout, name: str) -> Path:
+    """Give ``name`` one identity row (comms_nodes) and one history row (turns).
+
+    The two halves the rename must both carry: the live A2A directory entry,
+    and the agent's past.
+    """
+    db_path = make_state_db(layout)
+    return seed_db_rows(
+        db_path,
+        [
+            (COMMS_NODE_SQL, (name, "h", 9001, 1.0, 1.0)),
+            (TURN_SQL, ("t1", name, "h", "ok", 1.0)),
+        ],
+    )
+
+
 def _env_overrides(pairs: dict[str, str | None]) -> Iterator[None]:
     """Set (or clear) env vars for the duration, then restore them.
 

--- a/tests/scitex_agent_container/_lifecycle/test__rename.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename.py
@@ -1,0 +1,583 @@
+"""The rename engine: preflight, plan, apply — and the rollback, at EVERY step.
+
+A rollback that has never been exercised does not work. So the rollback
+here is not one happy test: a failure is injected at each of the eight
+steps in turn (the ``rolled_back`` fixture is parametrised over all of
+them), and every one must leave the agent EXACTLY as it was — spec text,
+directory contents, state.db rows, and card ownership. One organic failure
+(a read-only overlays dir, no injection at all) covers the case where the
+world, not a callback, says no.
+
+Fully isolated: an injected ``Layout`` root and an explicit tmp board.
+Nothing here can see the live fleet — ``test__rename_isolation.py`` proves
+that separately, and proves it rather than assuming it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._lifecycle._rename import (
+    STEPS,
+    agent_rename,
+    apply_plan,
+)
+from scitex_agent_container._lifecycle._rename_cards import find_owned_cards
+from scitex_agent_container._lifecycle._rename_plan import (
+    Layout,
+    RenameError,
+    build_plan,
+    probe_running,
+)
+
+from .._helpers.fleet_root import (
+    isolated_board,
+    make_fleet,
+    make_spec,
+    make_state_db,
+    seed_cards,
+)
+
+OLD = "scitex-todo"
+NEW = "scitex-cards"
+
+# A pid that is essentially never allocated — stands in for a crashed
+# agent's stale pid file.
+DEAD_PID = "2147483646"
+
+
+class Boom(RuntimeError):
+    """An injected mid-rename failure."""
+
+
+@dataclass
+class World:
+    """The whole isolated world a rename touches, plus a way to photograph it."""
+
+    layout: Layout
+    board: Path
+    cards: list[str]
+    before: dict = field(default_factory=dict)
+    error: str = ""
+
+    def snapshot(self) -> dict:
+        """Everything that must be identical after a rolled-back rename."""
+        return {
+            "spec_text": _read(self.layout.spec_file(OLD)),
+            "overlay_marker": _read(
+                self.layout.overlay_dir(OLD) / "upper" / "home" / "agent" / "marker"
+            ),
+            "runtime_marker": _read(self.layout.runtime_dir(OLD) / "session.jsonl"),
+            "registry_text": _read(self.layout.registry_json(OLD)),
+            "new_side_exists": any(
+                p.exists()
+                for p in (
+                    self.layout.spec_dir(NEW),
+                    self.layout.overlay_dir(NEW),
+                    self.layout.runtime_dir(NEW),
+                    self.layout.registry_json(NEW),
+                )
+            ),
+            "db_names": _db_names(self.layout.state_db),
+            "cards_owned_by_old": sorted(find_owned_cards(OLD, store=self.board)),
+            "cards_owned_by_new": sorted(find_owned_cards(NEW, store=self.board)),
+        }
+
+
+def _read(path: Path) -> str | None:
+    return path.read_text() if path.is_file() else None
+
+
+def _db_names(db_path: Path) -> list[str]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        nodes = conn.execute("SELECT name FROM comms_nodes").fetchall()
+        turns = conn.execute("SELECT name FROM turns").fetchall()
+    finally:
+        conn.close()
+    return sorted([r[0] for r in nodes] + [t[0] for t in turns])
+
+
+def _raise_at(step_to_fail: str):
+    """An ``on_step`` callback that aborts the rename at one step.
+
+    Not a mock: ``on_step`` is the REAL progress hook the CLI passes on
+    every run. A test uses that same seam to simulate the interruption
+    (crash, Ctrl-C, ENOSPC) the rollback exists for.
+    """
+
+    def _on_step(step: str) -> None:
+        if step == step_to_fail:
+            raise Boom(f"injected failure at {step}")
+
+    return _on_step
+
+
+def _refusal(world: World, old: str = OLD, new: str = NEW) -> str:
+    """Run a plan that must be refused; return the refusal message."""
+    try:
+        build_plan(old, new, layout=world.layout, store=world.board)
+    except RenameError as exc:
+        return str(exc)
+    raise AssertionError(f"build_plan({old!r} -> {new!r}) was NOT refused")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def board(tmp_path: Path):
+    yield from isolated_board(tmp_path)
+
+
+@pytest.fixture
+def world(tmp_path: Path, board: Path) -> World:
+    """A complete isolated fleet: agent on disk, rows in state.db, cards on the board."""
+    layout = make_fleet(tmp_path / "fleet", OLD)
+    db = make_state_db(layout)
+    conn = sqlite3.connect(str(db))
+    with conn:
+        conn.execute(
+            "INSERT INTO comms_nodes (name, host, a2a_port, registered_at, "
+            "updated_at) VALUES (?, ?, ?, ?, ?)",
+            (OLD, "h", 9001, 1.0, 1.0),
+        )
+        conn.execute(
+            "INSERT INTO turns (turn_id, name, host, status, ts) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("t1", OLD, "h", "ok", 1.0),
+        )
+    conn.close()
+    # Two cards, not twenty: every card write goes through the REAL
+    # scitex-todo store, whose per-write cost is ~2.2 s of uncached
+    # importlib entry-point rescanning (see _helpers.fleet_root.add_card).
+    # Two is enough to prove "every card follows"; the card behaviour itself
+    # is covered exhaustively in test__rename_cards.py.
+    cards = seed_cards(board, OLD, 2)
+    built = World(layout=layout, board=board, cards=cards)
+    built.before = built.snapshot()
+    return built
+
+
+@pytest.fixture
+def renamed(world: World) -> World:
+    """The happy path, already applied."""
+    agent_rename(OLD, NEW, layout=world.layout, store=world.board)
+    return world
+
+
+@pytest.fixture(params=STEPS, ids=list(STEPS))
+def rolled_back(world: World, request) -> World:
+    """A rename that FAILED at ``request.param`` and rolled itself back.
+
+    Parametrised over every step, so each assertion below is checked at
+    eight distinct points of failure.
+    """
+    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
+    try:
+        apply_plan(plan, store=world.board, on_step=_raise_at(request.param))
+    except RenameError as exc:
+        world.error = str(exc)
+        return world
+    raise AssertionError(f"apply_plan did not fail at step {request.param!r}")
+
+
+@pytest.fixture
+def organic_failure(world: World) -> World:
+    """A rename that failed because the WORLD said no — no injected callback.
+
+    The overlays parent is read-only, so ``shutil.move`` genuinely cannot
+    place the overlay. Steps 1-2 have already run and must be undone.
+    """
+    overlays = world.layout.overlay_dir(OLD).parent
+    overlays.chmod(0o555)
+    try:
+        plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
+        try:
+            apply_plan(plan, store=world.board)
+        except RenameError as exc:
+            world.error = str(exc)
+            return world
+        raise AssertionError("the read-only overlays dir did NOT fail the rename")
+    finally:
+        overlays.chmod(0o755)
+
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_refuses_an_unknown_agent(world: World):
+    # Arrange
+    unknown = "no-such-agent"
+    # Act
+    message = _refusal(world, old=unknown)
+    # Assert
+    assert "not found" in message
+
+
+def test_preflight_refuses_a_name_that_already_exists(world: World):
+    # Arrange
+    make_fleet(world.layout.root, NEW)
+    # Act
+    message = _refusal(world)
+    # Assert
+    assert "already exists" in message
+
+
+def test_preflight_refuses_an_invalid_new_name(world: World):
+    # Arrange
+    bad = "Has/Slash"
+    # Act
+    message = _refusal(world, new=bad)
+    # Assert
+    assert "invalid agent name" in message
+
+
+def test_preflight_refuses_a_running_agent(world: World):
+    """The pid file names a LIVE process — this very one."""
+    # Arrange
+    (world.layout.runtime_dir(OLD) / "pid").write_text(f"{os.getpid()}\n")
+    # Act
+    message = _refusal(world)
+    # Assert
+    assert "is running" in message
+
+
+def test_the_running_refusal_names_the_command_to_stop_it(world: World):
+    """A refusal without a remedy is just an obstacle."""
+    # Arrange
+    (world.layout.runtime_dir(OLD) / "pid").write_text(f"{os.getpid()}\n")
+    # Act
+    message = _refusal(world)
+    # Assert
+    assert f"sac agents stop {OLD}" in message
+
+
+def test_preflight_refuses_when_liveness_is_unknown(world: World):
+    """A corrupt pid file proves nothing, and 'unknown' must never proceed."""
+    # Arrange
+    (world.layout.runtime_dir(OLD) / "pid").write_text("not-a-pid\n")
+    # Act
+    message = _refusal(world)
+    # Assert
+    assert "is unknown" in message
+
+
+def test_a_stale_pid_file_does_not_block_the_rename(world: World):
+    """A DEAD pid is not evidence of running — else one crash wedges the agent."""
+    # Arrange
+    (world.layout.runtime_dir(OLD) / "pid").write_text(f"{DEAD_PID}\n")
+    # Act
+    verdict, _reason = probe_running(OLD, world.layout)
+    # Assert
+    assert verdict == "stopped"
+
+
+# ---------------------------------------------------------------------------
+# Plan — what --dry-run shows, and that it mutates NOTHING
+# ---------------------------------------------------------------------------
+
+
+def test_the_plan_counts_every_card_that_would_be_reassigned(world: World):
+    # Arrange
+    expected = set(world.cards)
+    # Act
+    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
+    # Assert
+    assert set(plan.card_ids) == expected
+
+
+def test_the_plan_lists_the_board_identity_among_the_spec_changes(world: World):
+    # Arrange
+    needle = "SCITEX_TODO_AGENT_ID"
+    # Act
+    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
+    # Assert
+    assert any(needle in c.path for c in plan.spec_changes)
+
+
+def test_the_plan_counts_the_state_db_rows(world: World):
+    # Arrange
+    key = "comms_nodes.name"
+    # Act
+    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
+    # Assert
+    assert plan.db_counts[key] == 1
+
+
+def test_building_a_plan_changes_nothing(world: World):
+    """--dry-run must be exactly that."""
+    # Arrange
+    before = world.before
+    # Act
+    build_plan(OLD, NEW, layout=world.layout, store=world.board)
+    # Assert
+    assert world.snapshot() == before
+
+
+def test_the_plan_warns_when_the_workdir_target_does_not_exist(world: World):
+    """sac renames the AGENT, not the repo — say so before the next start fails."""
+    # Arrange
+    needle = "sac renames the AGENT, not the repo"
+    # Act
+    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
+    # Assert
+    assert any(needle in w for w in plan.warnings)
+
+
+def test_no_cards_mode_warns_that_the_cards_will_be_orphaned(world: World):
+    # Arrange
+    needle = "ORPHANED"
+    # Act
+    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board, cards=False)
+    # Assert
+    assert any(needle in w for w in plan.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Apply — the happy path
+# ---------------------------------------------------------------------------
+
+
+def test_rename_moves_the_spec_dir(renamed: World):
+    # Arrange
+    spec = renamed.layout.spec_file(NEW)
+    # Act
+    exists = spec.is_file()
+    # Assert
+    assert exists
+
+
+def test_rename_removes_the_old_spec_dir(renamed: World):
+    # Arrange
+    old_dir = renamed.layout.spec_dir(OLD)
+    # Act
+    exists = old_dir.exists()
+    # Assert
+    assert not exists
+
+
+def test_rename_rewrites_the_board_identity_in_the_spec(renamed: World):
+    # Arrange
+    expected = f"SCITEX_TODO_AGENT_ID={NEW}"
+    # Act
+    text = renamed.layout.spec_file(NEW).read_text()
+    # Assert
+    assert expected in text
+
+
+def test_rename_rewrites_the_state_db_path_in_the_spec(renamed: World):
+    # Arrange
+    expected = f"SCITEX_AGENT_CONTAINER_STATE_DB=/state/{NEW}/state.db"
+    # Act
+    text = renamed.layout.spec_file(NEW).read_text()
+    # Assert
+    assert expected in text
+
+
+def test_rename_moves_the_overlay_dir_with_its_contents(renamed: World):
+    # Arrange
+    marker = renamed.layout.overlay_dir(NEW) / "upper" / "home" / "agent" / "marker"
+    # Act
+    content = marker.read_text()
+    # Assert
+    assert content == OLD  # the file MOVED; its bytes are untouched
+
+
+def test_rename_moves_the_runtime_dir(renamed: World):
+    # Arrange
+    session = renamed.layout.runtime_dir(NEW) / "session.jsonl"
+    # Act
+    exists = session.is_file()
+    # Assert
+    assert exists
+
+
+def test_rename_repoints_the_registry_entry_name(renamed: World):
+    # Arrange
+    path = renamed.layout.registry_json(NEW)
+    # Act
+    entry = json.loads(path.read_text())
+    # Assert
+    assert entry["name"] == NEW
+
+
+def test_rename_repoints_the_registry_config_path(renamed: World):
+    # Arrange
+    expected = str(renamed.layout.spec_file(NEW))
+    # Act
+    entry = json.loads(renamed.layout.registry_json(NEW).read_text())
+    # Assert
+    assert entry["config"] == expected
+
+
+def test_rename_moves_the_state_db_rows(renamed: World):
+    # Arrange
+    expected = [NEW, NEW]
+    # Act
+    names = _db_names(renamed.layout.state_db)
+    # Assert
+    assert names == expected
+
+
+def test_rename_leaves_no_card_orphaned(renamed: World):
+    """THE point of the verb."""
+    # Arrange
+    store = renamed.board
+    # Act
+    orphans = find_owned_cards(OLD, store=store)
+    # Assert
+    assert orphans == []
+
+
+def test_rename_gives_every_card_to_the_new_owner(renamed: World):
+    # Arrange
+    expected = set(renamed.cards)
+    # Act
+    owned = set(find_owned_cards(NEW, store=renamed.board))
+    # Assert
+    assert owned == expected
+
+
+def test_rename_keeps_the_operators_spec_comments(renamed: World):
+    # Arrange
+    marker = "# This comment block is LOAD-BEARING"
+    # Act
+    text = renamed.layout.spec_file(NEW).read_text()
+    # Assert
+    assert marker in text
+
+
+def test_a_renamed_agent_can_be_renamed_back(world: World):
+    """The rename is not a one-way door."""
+    # Arrange
+    agent_rename(OLD, NEW, layout=world.layout, store=world.board)
+    # Act
+    agent_rename(NEW, OLD, layout=world.layout, store=world.board)
+    # Assert
+    assert world.layout.spec_file(OLD).read_text() == make_spec(OLD)
+
+
+# ---------------------------------------------------------------------------
+# ROLLBACK — injected at EVERY step (the fixture is parametrised over STEPS)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("failing_step", STEPS)
+def test_a_failure_at_any_step_raises_rename_error(world: World, failing_step: str):
+    # Arrange
+    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
+    # Act
+    # Assert
+    with pytest.raises(RenameError):
+        apply_plan(plan, store=world.board, on_step=_raise_at(failing_step))
+
+
+def test_rollback_leaves_the_world_exactly_as_it_was(rolled_back: World):
+    """The only assertion that really matters: NOTHING moved."""
+    # Arrange
+    world = rolled_back
+    # Act
+    after = world.snapshot()
+    # Assert
+    assert after == world.before
+
+
+def test_rollback_leaves_nothing_under_the_new_name(rolled_back: World):
+    # Arrange
+    new_spec_dir = rolled_back.layout.spec_dir(NEW)
+    # Act
+    exists = new_spec_dir.exists()
+    # Assert
+    assert not exists
+
+
+def test_rollback_hands_every_card_back(rolled_back: World):
+    """A `verify`-step failure happens AFTER the cards moved — they must return."""
+    # Arrange
+    expected = set(rolled_back.cards)
+    # Act
+    owned = set(find_owned_cards(OLD, store=rolled_back.board))
+    # Assert
+    assert owned == expected
+
+
+def test_rollback_leaves_the_new_owner_holding_no_cards(rolled_back: World):
+    # Arrange
+    store = rolled_back.board
+    # Act
+    owned = find_owned_cards(NEW, store=store)
+    # Assert
+    assert owned == []
+
+
+def test_rollback_restores_the_state_db_rows(rolled_back: World):
+    # Arrange
+    expected = [OLD, OLD]
+    # Act
+    names = _db_names(rolled_back.layout.state_db)
+    # Assert
+    assert names == expected
+
+
+def test_rollback_restores_the_original_spec_text(rolled_back: World):
+    # Arrange
+    expected = make_spec(OLD)
+    # Act
+    text = rolled_back.layout.spec_file(OLD).read_text()
+    # Assert
+    assert text == expected
+
+
+def test_rollback_restores_the_overlay_dir(rolled_back: World):
+    # Arrange
+    marker = (
+        rolled_back.layout.overlay_dir(OLD) / "upper" / "home" / "agent" / "marker"
+    )
+    # Act
+    exists = marker.is_file()
+    # Assert
+    assert exists
+
+
+def test_the_rollback_message_says_it_rolled_back(rolled_back: World):
+    # Arrange
+    needle = "Rolled back"
+    # Act
+    message = rolled_back.error
+    # Assert
+    assert needle in message
+
+
+# ---------------------------------------------------------------------------
+# ROLLBACK from an ORGANIC failure (no injected callback at all)
+# ---------------------------------------------------------------------------
+
+
+def test_an_organic_move_failure_rolls_the_rename_back(organic_failure: World):
+    """The world said no: the overlays dir is read-only. Everything must revert."""
+    # Arrange
+    world = organic_failure
+    # Act
+    after = world.snapshot()
+    # Assert
+    assert after == world.before
+
+
+def test_an_organic_move_failure_restores_the_spec_dir(organic_failure: World):
+    # Arrange
+    spec = organic_failure.layout.spec_file(OLD)
+    # Act
+    exists = spec.is_file()
+    # Assert
+    assert exists

--- a/tests/scitex_agent_container/_lifecycle/test__rename.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename.py
@@ -4,13 +4,21 @@ A rollback that has never been exercised does not work. So the rollback
 here is not one happy test: a failure is injected at each of the eight
 steps in turn (the ``rolled_back`` fixture is parametrised over all of
 them), and every one must leave the agent EXACTLY as it was — spec text,
-directory contents, state.db rows, and card ownership. One organic failure
-(a read-only overlays dir, no injection at all) covers the case where the
-world, not a callback, says no.
+directory contents, and state.db rows. One organic failure (a read-only
+overlays dir, no injection at all) covers the case where the world, not a
+callback, says no.
 
-Fully isolated: an injected ``Layout`` root and an explicit tmp board.
-Nothing here can see the live fleet — ``test__rename_isolation.py`` proves
-that separately, and proves it rather than assuming it.
+BOARD-FREE ON PURPOSE (``cards=False`` throughout). ``scitex-todo`` is an
+OPTIONAL peer — it is not a declared dependency of sac and is absent from
+sac's own CI — so a board-coupled engine test would ERROR there rather than
+run, and the rollback matrix (the part most worth protecting) would never
+execute in CI at all. The card half of the engine lives in the sibling
+``test__rename_board.py``, which skips when the peer is missing. Splitting
+them keeps the atomicity guarantee under test EVERYWHERE.
+
+Fully isolated: an injected ``Layout`` root. Nothing here can see the live
+fleet — ``test__rename_isolation.py`` proves that separately, and proves it
+rather than assuming it.
 """
 
 from __future__ import annotations
@@ -28,7 +36,6 @@ from scitex_agent_container._lifecycle._rename import (
     agent_rename,
     apply_plan,
 )
-from scitex_agent_container._lifecycle._rename_cards import find_owned_cards
 from scitex_agent_container._lifecycle._rename_plan import (
     Layout,
     RenameError,
@@ -36,13 +43,7 @@ from scitex_agent_container._lifecycle._rename_plan import (
     probe_running,
 )
 
-from .._helpers.fleet_root import (
-    isolated_board,
-    make_fleet,
-    make_spec,
-    make_state_db,
-    seed_cards,
-)
+from .._helpers.fleet_root import make_fleet, make_spec, seed_identity_and_history
 
 OLD = "scitex-todo"
 NEW = "scitex-cards"
@@ -61,8 +62,6 @@ class World:
     """The whole isolated world a rename touches, plus a way to photograph it."""
 
     layout: Layout
-    board: Path
-    cards: list[str]
     before: dict = field(default_factory=dict)
     error: str = ""
 
@@ -85,8 +84,6 @@ class World:
                 )
             ),
             "db_names": _db_names(self.layout.state_db),
-            "cards_owned_by_old": sorted(find_owned_cards(OLD, store=self.board)),
-            "cards_owned_by_new": sorted(find_owned_cards(NEW, store=self.board)),
         }
 
 
@@ -122,10 +119,14 @@ def _raise_at(step_to_fail: str):
 def _refusal(world: World, old: str = OLD, new: str = NEW) -> str:
     """Run a plan that must be refused; return the refusal message."""
     try:
-        build_plan(old, new, layout=world.layout, store=world.board)
+        build_plan(old, new, layout=world.layout, cards=False)
     except RenameError as exc:
         return str(exc)
     raise AssertionError(f"build_plan({old!r} -> {new!r}) was NOT refused")
+
+
+def _plan(world: World) -> object:
+    return build_plan(OLD, NEW, layout=world.layout, cards=False)
 
 
 # ---------------------------------------------------------------------------
@@ -134,35 +135,12 @@ def _refusal(world: World, old: str = OLD, new: str = NEW) -> str:
 
 
 @pytest.fixture
-def board(tmp_path: Path):
-    yield from isolated_board(tmp_path)
-
-
-@pytest.fixture
-def world(tmp_path: Path, board: Path) -> World:
-    """A complete isolated fleet: agent on disk, rows in state.db, cards on the board."""
+def world(tmp_path: Path) -> World:
+    """An isolated fleet: agent on disk, rows in state.db. No board — see the
+    module docstring."""
     layout = make_fleet(tmp_path / "fleet", OLD)
-    db = make_state_db(layout)
-    conn = sqlite3.connect(str(db))
-    with conn:
-        conn.execute(
-            "INSERT INTO comms_nodes (name, host, a2a_port, registered_at, "
-            "updated_at) VALUES (?, ?, ?, ?, ?)",
-            (OLD, "h", 9001, 1.0, 1.0),
-        )
-        conn.execute(
-            "INSERT INTO turns (turn_id, name, host, status, ts) "
-            "VALUES (?, ?, ?, ?, ?)",
-            ("t1", OLD, "h", "ok", 1.0),
-        )
-    conn.close()
-    # Two cards, not twenty: every card write goes through the REAL
-    # scitex-todo store, whose per-write cost is ~2.2 s of uncached
-    # importlib entry-point rescanning (see _helpers.fleet_root.add_card).
-    # Two is enough to prove "every card follows"; the card behaviour itself
-    # is covered exhaustively in test__rename_cards.py.
-    cards = seed_cards(board, OLD, 2)
-    built = World(layout=layout, board=board, cards=cards)
+    seed_identity_and_history(layout, OLD)
+    built = World(layout=layout)
     built.before = built.snapshot()
     return built
 
@@ -170,7 +148,7 @@ def world(tmp_path: Path, board: Path) -> World:
 @pytest.fixture
 def renamed(world: World) -> World:
     """The happy path, already applied."""
-    agent_rename(OLD, NEW, layout=world.layout, store=world.board)
+    agent_rename(OLD, NEW, layout=world.layout, cards=False)
     return world
 
 
@@ -181,9 +159,9 @@ def rolled_back(world: World, request) -> World:
     Parametrised over every step, so each assertion below is checked at
     eight distinct points of failure.
     """
-    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
+    plan = _plan(world)
     try:
-        apply_plan(plan, store=world.board, on_step=_raise_at(request.param))
+        apply_plan(plan, on_step=_raise_at(request.param))
     except RenameError as exc:
         world.error = str(exc)
         return world
@@ -200,9 +178,9 @@ def organic_failure(world: World) -> World:
     overlays = world.layout.overlay_dir(OLD).parent
     overlays.chmod(0o555)
     try:
-        plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
+        plan = _plan(world)
         try:
-            apply_plan(plan, store=world.board)
+            apply_plan(plan)
         except RenameError as exc:
             world.error = str(exc)
             return world
@@ -288,20 +266,12 @@ def test_a_stale_pid_file_does_not_block_the_rename(world: World):
 # ---------------------------------------------------------------------------
 
 
-def test_the_plan_counts_every_card_that_would_be_reassigned(world: World):
-    # Arrange
-    expected = set(world.cards)
-    # Act
-    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
-    # Assert
-    assert set(plan.card_ids) == expected
-
-
 def test_the_plan_lists_the_board_identity_among_the_spec_changes(world: World):
+    """The spec-side half of the board identity, provable without a board."""
     # Arrange
     needle = "SCITEX_TODO_AGENT_ID"
     # Act
-    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
+    plan = _plan(world)
     # Assert
     assert any(needle in c.path for c in plan.spec_changes)
 
@@ -310,7 +280,7 @@ def test_the_plan_counts_the_state_db_rows(world: World):
     # Arrange
     key = "comms_nodes.name"
     # Act
-    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
+    plan = _plan(world)
     # Assert
     assert plan.db_counts[key] == 1
 
@@ -320,7 +290,7 @@ def test_building_a_plan_changes_nothing(world: World):
     # Arrange
     before = world.before
     # Act
-    build_plan(OLD, NEW, layout=world.layout, store=world.board)
+    _plan(world)
     # Assert
     assert world.snapshot() == before
 
@@ -330,16 +300,17 @@ def test_the_plan_warns_when_the_workdir_target_does_not_exist(world: World):
     # Arrange
     needle = "sac renames the AGENT, not the repo"
     # Act
-    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
+    plan = _plan(world)
     # Assert
     assert any(needle in w for w in plan.warnings)
 
 
 def test_no_cards_mode_warns_that_the_cards_will_be_orphaned(world: World):
+    """The `--no-cards` escape hatch must say what it costs."""
     # Arrange
     needle = "ORPHANED"
     # Act
-    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board, cards=False)
+    plan = _plan(world)
     # Assert
     assert any(needle in w for w in plan.warnings)
 
@@ -430,25 +401,6 @@ def test_rename_moves_the_state_db_rows(renamed: World):
     assert names == expected
 
 
-def test_rename_leaves_no_card_orphaned(renamed: World):
-    """THE point of the verb."""
-    # Arrange
-    store = renamed.board
-    # Act
-    orphans = find_owned_cards(OLD, store=store)
-    # Assert
-    assert orphans == []
-
-
-def test_rename_gives_every_card_to_the_new_owner(renamed: World):
-    # Arrange
-    expected = set(renamed.cards)
-    # Act
-    owned = set(find_owned_cards(NEW, store=renamed.board))
-    # Assert
-    assert owned == expected
-
-
 def test_rename_keeps_the_operators_spec_comments(renamed: World):
     # Arrange
     marker = "# This comment block is LOAD-BEARING"
@@ -461,9 +413,9 @@ def test_rename_keeps_the_operators_spec_comments(renamed: World):
 def test_a_renamed_agent_can_be_renamed_back(world: World):
     """The rename is not a one-way door."""
     # Arrange
-    agent_rename(OLD, NEW, layout=world.layout, store=world.board)
+    agent_rename(OLD, NEW, layout=world.layout, cards=False)
     # Act
-    agent_rename(NEW, OLD, layout=world.layout, store=world.board)
+    agent_rename(NEW, OLD, layout=world.layout, cards=False)
     # Assert
     assert world.layout.spec_file(OLD).read_text() == make_spec(OLD)
 
@@ -476,11 +428,11 @@ def test_a_renamed_agent_can_be_renamed_back(world: World):
 @pytest.mark.parametrize("failing_step", STEPS)
 def test_a_failure_at_any_step_raises_rename_error(world: World, failing_step: str):
     # Arrange
-    plan = build_plan(OLD, NEW, layout=world.layout, store=world.board)
+    plan = _plan(world)
     # Act
     # Assert
     with pytest.raises(RenameError):
-        apply_plan(plan, store=world.board, on_step=_raise_at(failing_step))
+        apply_plan(plan, on_step=_raise_at(failing_step))
 
 
 def test_rollback_leaves_the_world_exactly_as_it_was(rolled_back: World):
@@ -500,25 +452,6 @@ def test_rollback_leaves_nothing_under_the_new_name(rolled_back: World):
     exists = new_spec_dir.exists()
     # Assert
     assert not exists
-
-
-def test_rollback_hands_every_card_back(rolled_back: World):
-    """A `verify`-step failure happens AFTER the cards moved — they must return."""
-    # Arrange
-    expected = set(rolled_back.cards)
-    # Act
-    owned = set(find_owned_cards(OLD, store=rolled_back.board))
-    # Assert
-    assert owned == expected
-
-
-def test_rollback_leaves_the_new_owner_holding_no_cards(rolled_back: World):
-    # Arrange
-    store = rolled_back.board
-    # Act
-    owned = find_owned_cards(NEW, store=store)
-    # Assert
-    assert owned == []
 
 
 def test_rollback_restores_the_state_db_rows(rolled_back: World):

--- a/tests/scitex_agent_container/_lifecycle/test__rename_board.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_board.py
@@ -1,0 +1,198 @@
+"""The rename engine WITH the board attached — the cards must follow, or come back.
+
+The half of the engine that needs a live ``scitex-todo``. Split out of
+``test__rename.py`` because scitex-todo is an OPTIONAL peer: it is not a
+declared dependency of sac and is absent from sac's own CI, so a
+board-coupled test would ERROR there rather than run. Skipping is the
+repo's established contract for a missing peer (see
+``tests/integration/test_cross_package_imports.py``) — but only the
+board-coupled tests may skip. The atomicity/rollback matrix in the sibling
+module stays board-free precisely so it runs EVERYWHERE.
+
+These tests still carry the point of the whole verb: rename with cards
+present, and every card follows — or, when the rename fails, every card
+comes back.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("scitex_todo")
+
+from scitex_agent_container._lifecycle._rename import (  # noqa: E402
+    STEPS,
+    agent_rename,
+    apply_plan,
+)
+from scitex_agent_container._lifecycle._rename_cards import (  # noqa: E402
+    find_owned_cards,
+)
+from scitex_agent_container._lifecycle._rename_plan import (  # noqa: E402
+    Layout,
+    RenameError,
+    build_plan,
+)
+
+from .._helpers.fleet_root import (  # noqa: E402
+    isolated_board,
+    make_fleet,
+    seed_cards,
+    seed_identity_and_history,
+)
+
+OLD = "scitex-todo"
+NEW = "scitex-cards"
+
+
+class Boom(RuntimeError):
+    """An injected mid-rename failure."""
+
+
+def _raise_at(step_to_fail: str):
+    """An ``on_step`` callback that aborts the rename at one step.
+
+    Not a mock: ``on_step`` is the REAL progress hook the CLI passes on
+    every run.
+    """
+
+    def _on_step(step: str) -> None:
+        if step == step_to_fail:
+            raise Boom(f"injected failure at {step}")
+
+    return _on_step
+
+
+@pytest.fixture
+def board(tmp_path: Path):
+    yield from isolated_board(tmp_path)
+
+
+@pytest.fixture
+def layout(tmp_path: Path) -> Layout:
+    built = make_fleet(tmp_path / "fleet", OLD)
+    seed_identity_and_history(built, OLD)
+    return built
+
+
+@pytest.fixture
+def cards(board: Path) -> list[str]:
+    """Two cards, not twenty.
+
+    Every card write goes through the REAL scitex-todo store, whose
+    per-write cost is ~3.2 s of fixed overhead (see
+    ``_helpers.fleet_root.add_card``). Two proves "every card follows"; the
+    card behaviour itself is covered exhaustively in ``test__rename_cards``.
+    """
+    return seed_cards(board, OLD, 2)
+
+
+@pytest.fixture
+def renamed(layout: Layout, board: Path, cards: list[str]) -> Layout:
+    agent_rename(OLD, NEW, layout=layout, store=board)
+    return layout
+
+
+@pytest.fixture(params=STEPS, ids=list(STEPS))
+def rolled_back(layout: Layout, board: Path, cards: list[str], request) -> Layout:
+    """A rename that FAILED at ``request.param`` and rolled itself back."""
+    plan = build_plan(OLD, NEW, layout=layout, store=board)
+    try:
+        apply_plan(plan, store=board, on_step=_raise_at(request.param))
+    except RenameError:
+        return layout
+    raise AssertionError(f"apply_plan did not fail at step {request.param!r}")
+
+
+# ---------------------------------------------------------------------------
+# The plan sees the cards
+# ---------------------------------------------------------------------------
+
+
+def test_the_plan_counts_every_card_that_would_be_reassigned(
+    layout: Layout, board: Path, cards: list[str]
+):
+    # Arrange
+    expected = set(cards)
+    # Act
+    plan = build_plan(OLD, NEW, layout=layout, store=board)
+    # Assert
+    assert set(plan.card_ids) == expected
+
+
+def test_building_a_plan_moves_no_card(
+    layout: Layout, board: Path, cards: list[str]
+):
+    """--dry-run must be exactly that, on the board too."""
+    # Arrange
+    expected = set(cards)
+    # Act
+    build_plan(OLD, NEW, layout=layout, store=board)
+    # Assert
+    assert set(find_owned_cards(OLD, store=board)) == expected
+
+
+# ---------------------------------------------------------------------------
+# The rename moves them — THE point of the verb
+# ---------------------------------------------------------------------------
+
+
+def test_rename_leaves_no_card_orphaned(renamed: Layout, board: Path):
+    """Rename with cards present: NOT ONE is left behind."""
+    # Arrange
+    store = board
+    # Act
+    orphans = find_owned_cards(OLD, store=store)
+    # Assert
+    assert orphans == []
+
+
+def test_rename_gives_every_card_to_the_new_owner(
+    renamed: Layout, board: Path, cards: list[str]
+):
+    # Arrange
+    expected = set(cards)
+    # Act
+    owned = set(find_owned_cards(NEW, store=board))
+    # Assert
+    assert owned == expected
+
+
+def test_rename_still_rewrites_the_board_identity_in_the_spec(renamed: Layout):
+    """The card owner and the spec's SCITEX_TODO_AGENT_ID must agree."""
+    # Arrange
+    expected = f"SCITEX_TODO_AGENT_ID={NEW}"
+    # Act
+    text = renamed.spec_file(NEW).read_text()
+    # Assert
+    assert expected in text
+
+
+# ---------------------------------------------------------------------------
+# ...or the rollback brings them back — at EVERY step
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_hands_every_card_back(
+    rolled_back: Layout, board: Path, cards: list[str]
+):
+    """A `verify`-step failure lands AFTER the cards moved. They must return."""
+    # Arrange
+    expected = set(cards)
+    # Act
+    owned = set(find_owned_cards(OLD, store=board))
+    # Assert
+    assert owned == expected
+
+
+def test_rollback_leaves_the_new_owner_holding_no_cards(
+    rolled_back: Layout, board: Path
+):
+    # Arrange
+    store = board
+    # Act
+    owned = find_owned_cards(NEW, store=store)
+    # Assert
+    assert owned == []

--- a/tests/scitex_agent_container/_lifecycle/test__rename_cards.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_cards.py
@@ -1,0 +1,263 @@
+"""The cards must follow the agent — this is the whole point of the verb.
+
+Real scitex-todo, real store (a tmp YAML file), real ``reassign_task``.
+sac does not touch the board itself, so these tests exercise the PORT: we
+put real cards in a real store, run the migration, and read the store back
+through scitex-todo's own reader.
+
+The orphaning case is the headline: change the board identity without
+migrating and the agent under its new name cannot see its own work, and
+nothing says so.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._lifecycle._rename_cards import (
+    find_foreign_scoped_cards,
+    find_owned_cards,
+    migrate_cards,
+    undo_migrate_cards,
+)
+
+from .._helpers.fleet_root import add_card, isolated_board, seed_cards
+
+OLD = "scitex-todo"
+NEW = "scitex-cards"
+
+
+@pytest.fixture
+def board(tmp_path: Path):
+    yield from isolated_board(tmp_path)
+
+
+@pytest.fixture
+def owned(board: Path) -> list[str]:
+    """Cards owned by OLD, plus one owned by a bystander agent."""
+    ids = seed_cards(board, OLD, 3)
+    seed_cards(board, "other-agent", 2)
+    return ids
+
+
+@pytest.fixture
+def foreign_scoped(board: Path) -> str:
+    """A card SCOPED to OLD but OWNED by someone else — inconsistent, and real.
+
+    ``scope`` is supposed to track the owner, but drift happens. Reading
+    scope as ownership is the trap: it would make the rename hand this card
+    to the new name, taking it from the agent who actually owns it.
+    """
+    return add_card(
+        board, "drifted", owner="other-agent", scope=f"agent:{OLD}"
+    )
+
+
+def _owner_of(store: Path, task_id: str) -> str | None:
+    from scitex_todo import _store
+
+    return _store.get_task(store, task_id).get("agent")
+
+
+def _scope_of(store: Path, task_id: str) -> str | None:
+    from scitex_todo import _store
+
+    return _store.get_task(store, task_id).get("scope")
+
+
+def _assignee_of(store: Path, task_id: str) -> str | None:
+    from scitex_todo import _store
+
+    return _store.get_task(store, task_id).get("assignee")
+
+
+# ---------------------------------------------------------------------------
+# find_owned_cards — what --dry-run counts
+# ---------------------------------------------------------------------------
+
+
+def test_find_owned_cards_finds_every_card_the_agent_owns(board: Path, owned: list):
+    # Arrange
+    expected = set(owned)
+    # Act
+    found = find_owned_cards(OLD, store=board)
+    # Assert
+    assert set(found) == expected
+
+
+def test_find_owned_cards_ignores_another_agents_cards(board: Path, owned: list):
+    # Arrange
+    stranger_ids = {"other-agent-card-0", "other-agent-card-1"}
+    # Act
+    found = set(find_owned_cards(OLD, store=board))
+    # Assert
+    assert not (found & stranger_ids)
+
+
+def test_find_owned_cards_does_not_claim_a_card_merely_scoped_to_the_agent(
+    board: Path, foreign_scoped: str
+):
+    """SCOPE IS NOT OWNERSHIP — and reading it as ownership steals a card.
+
+    ``reassign_task`` sets ``agent = assignee = scope-owner`` together, so a
+    card whose scope says ``agent:<old>`` while its owner says someone else
+    is drifted data. Migrating it would take a working agent's card away to
+    tidy a string.
+    """
+    # Arrange
+    stolen = foreign_scoped
+    # Act
+    found = find_owned_cards(OLD, store=board)
+    # Assert
+    assert stolen not in found
+
+
+def test_a_foreign_scoped_card_is_reported_rather_than_silently_ignored(
+    board: Path, foreign_scoped: str
+):
+    """Not stealing it is right; saying nothing about it is not."""
+    # Arrange
+    expected = [foreign_scoped]
+    # Act
+    reported = find_foreign_scoped_cards(OLD, store=board)
+    # Assert
+    assert reported == expected
+
+
+def test_a_card_the_agent_owns_is_never_reported_as_foreign(
+    board: Path, owned: list
+):
+    # Arrange
+    store = board
+    # Act
+    reported = find_foreign_scoped_cards(OLD, store=store)
+    # Assert
+    assert reported == []
+
+
+def test_find_owned_cards_returns_empty_for_an_agent_with_no_cards(board: Path):
+    # Arrange
+    nobody = "agent-with-nothing"
+    # Act
+    found = find_owned_cards(nobody, store=board)
+    # Assert
+    assert found == []
+
+
+# ---------------------------------------------------------------------------
+# migrate_cards — THE orphaning case
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_moves_every_card_to_the_new_owner(board: Path, owned: list):
+    """Rename with cards present: every card must follow."""
+    # Arrange
+    migrate_cards(OLD, NEW, store=board)
+    # Act
+    owners = {_owner_of(board, task_id) for task_id in owned}
+    # Assert
+    assert owners == {NEW}
+
+
+def test_migrate_rescopes_every_card_to_the_new_agent(board: Path, owned: list):
+    """``scope`` is the slice the agent lists its work by — it must move too."""
+    # Arrange
+    migrate_cards(OLD, NEW, store=board)
+    # Act
+    scopes = {_scope_of(board, task_id) for task_id in owned}
+    # Assert
+    assert scopes == {f"agent:{NEW}"}
+
+
+def test_migrate_moves_the_legacy_assignee_field_in_lockstep(
+    board: Path, owned: list
+):
+    # Arrange
+    migrate_cards(OLD, NEW, store=board)
+    # Act
+    assignees = {_assignee_of(board, task_id) for task_id in owned}
+    # Assert
+    assert assignees == {NEW}
+
+
+def test_migrate_leaves_no_card_owned_by_the_old_name(board: Path, owned: list):
+    """The orphan check: after the rename, OLD must own nothing."""
+    # Arrange
+    migrate_cards(OLD, NEW, store=board)
+    # Act
+    orphans = find_owned_cards(OLD, store=board)
+    # Assert
+    assert orphans == []
+
+
+def test_migrate_does_not_touch_another_agents_cards(board: Path, owned: list):
+    # Arrange
+    migrate_cards(OLD, NEW, store=board)
+    # Act
+    stranger_owner = _owner_of(board, "other-agent-card-0")
+    # Assert
+    assert stranger_owner == "other-agent"
+
+
+def test_migrate_does_not_steal_a_foreign_scoped_card(
+    board: Path, foreign_scoped: str
+):
+    """The card is scoped to OLD but owned by another agent. It stays theirs."""
+    # Arrange
+    migrate_cards(OLD, NEW, store=board)
+    # Act
+    owner = _owner_of(board, foreign_scoped)
+    # Assert
+    assert owner == "other-agent"
+
+
+def test_migrate_reports_the_cards_it_moved(board: Path, owned: list):
+    # Arrange
+    expected = set(owned)
+    # Act
+    migration = migrate_cards(OLD, NEW, store=board)
+    # Assert
+    assert set(migration.moved) == expected
+
+
+def test_migrate_on_an_agent_with_no_cards_moves_nothing(board: Path):
+    # Arrange
+    nobody = "agent-with-nothing"
+    # Act
+    migration = migrate_cards(nobody, NEW, store=board)
+    # Assert
+    assert migration.total == 0
+
+
+# ---------------------------------------------------------------------------
+# undo
+# ---------------------------------------------------------------------------
+
+
+def test_undo_hands_every_card_back_to_the_old_owner(board: Path, owned: list):
+    # Arrange
+    migration = migrate_cards(OLD, NEW, store=board)
+    # Act
+    undo_migrate_cards(migration)
+    # Assert
+    assert set(find_owned_cards(OLD, store=board)) == set(owned)
+
+
+def test_undo_restores_the_original_scope(board: Path, owned: list):
+    # Arrange
+    migration = migrate_cards(OLD, NEW, store=board)
+    # Act
+    undo_migrate_cards(migration)
+    # Assert
+    assert _scope_of(board, owned[0]) == f"agent:{OLD}"
+
+
+def test_undo_reports_no_failures_on_a_healthy_store(board: Path, owned: list):
+    # Arrange
+    migration = migrate_cards(OLD, NEW, store=board)
+    # Act
+    failed = undo_migrate_cards(migration)
+    # Assert
+    assert failed == []

--- a/tests/scitex_agent_container/_lifecycle/test__rename_cards.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_cards.py
@@ -16,14 +16,25 @@ from pathlib import Path
 
 import pytest
 
-from scitex_agent_container._lifecycle._rename_cards import (
+# scitex-todo is an OPTIONAL peer: not a declared dependency of sac, and
+# absent from sac's own CI. The repo's contract for a missing peer is to
+# SKIP (see tests/integration/test_cross_package_imports.py), and these
+# tests are meaningless without a real board — a faked one would prove
+# nothing about the primitive we are consuming.
+pytest.importorskip("scitex_todo")
+
+from scitex_agent_container._lifecycle._rename_cards import (  # noqa: E402
     find_foreign_scoped_cards,
     find_owned_cards,
     migrate_cards,
     undo_migrate_cards,
 )
 
-from .._helpers.fleet_root import add_card, isolated_board, seed_cards
+from .._helpers.fleet_root import (  # noqa: E402
+    add_card,
+    isolated_board,
+    seed_cards,
+)
 
 OLD = "scitex-todo"
 NEW = "scitex-cards"

--- a/tests/scitex_agent_container/_lifecycle/test__rename_db.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_db.py
@@ -1,0 +1,251 @@
+"""state.db rows follow the agent — and the undo puts them back exactly.
+
+Real SQLite, real schema (``init_schema``), tmp file. The undo is
+rowid-scoped, which is the whole point: a naive
+``UPDATE … SET name = old WHERE name = new`` would also clobber rows that
+ALREADY held the new name — e.g. the history of a previously deleted agent
+that happened to be called that. The last test here is that trap.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._lifecycle._rename_db import (
+    count_rows,
+    rename_rows,
+    undo_rename_rows,
+)
+from scitex_agent_container._lifecycle._rename_plan import Layout
+
+from .._helpers.fleet_root import make_state_db
+
+OLD = "scitex-todo"
+NEW = "scitex-cards"
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Path:
+    layout = Layout(root=tmp_path / "fleet")
+    return make_state_db(layout)
+
+
+@pytest.fixture
+def seeded(db: Path) -> Path:
+    """A DB holding rows for OLD across the identity + history tables."""
+    conn = sqlite3.connect(str(db))
+    with conn:
+        conn.execute(
+            "INSERT INTO definitions (id, name, yaml_path, yaml_sha256, scope, "
+            "first_seen_at) VALUES (?, ?, ?, ?, ?, ?)",
+            ("d1", OLD, f"/root/agents/{OLD}/spec.yaml", "sha", "user", "t0"),
+        )
+        conn.execute(
+            "INSERT INTO instances (id, name, host, scope, started_at, workdir, "
+            "ended_at, spawned_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("i1", OLD, "h", "user", "t0", f"/home/u/proj/{OLD}", "t1", "cli"),
+        )
+        conn.execute(
+            "INSERT INTO comms_nodes (name, host, a2a_port, registered_at, "
+            "updated_at) VALUES (?, ?, ?, ?, ?)",
+            (OLD, "h", 9001, 1.0, 1.0),
+        )
+        conn.execute(
+            "INSERT INTO node_comms_policy (name, updated_at) VALUES (?, ?)",
+            (OLD, 1.0),
+        )
+        conn.execute(
+            "INSERT INTO lineage (child_name, parent_name, created_at) "
+            "VALUES (?, ?, ?)",
+            ("child-a", OLD, 1.0),
+        )
+        conn.execute(
+            "INSERT INTO turns (turn_id, name, host, status, ts) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("t1", OLD, "h", "ok", 1.0),
+        )
+    conn.close()
+    return db
+
+
+def _one(db: Path, sql: str, *args):
+    conn = sqlite3.connect(str(db))
+    try:
+        row = conn.execute(sql, args).fetchone()
+    finally:
+        conn.close()
+    return row[0] if row else None
+
+
+# ---------------------------------------------------------------------------
+# count_rows — what --dry-run prints
+# ---------------------------------------------------------------------------
+
+
+def test_count_rows_counts_the_identity_row(seeded: Path):
+    # Arrange
+    key = "comms_nodes.name"
+    # Act
+    counts = count_rows(seeded, OLD)
+    # Assert
+    assert counts[key] == 1
+
+
+def test_count_rows_counts_the_history_row(seeded: Path):
+    """History follows the agent: a renamed agent is the SAME agent."""
+    # Arrange
+    key = "turns.name"
+    # Act
+    counts = count_rows(seeded, OLD)
+    # Assert
+    assert counts[key] == 1
+
+
+def test_count_rows_counts_the_spec_path_column(seeded: Path):
+    # Arrange
+    key = "definitions.yaml_path"
+    # Act
+    counts = count_rows(seeded, OLD)
+    # Assert
+    assert counts[key] == 1
+
+
+def test_count_rows_is_empty_when_the_db_does_not_exist(tmp_path: Path):
+    """A fleet that never started an agent has no state.db. Not an error."""
+    # Arrange
+    missing = tmp_path / "nope" / "state.db"
+    # Act
+    counts = count_rows(missing, OLD)
+    # Assert
+    assert counts == {}
+
+
+# ---------------------------------------------------------------------------
+# rename_rows
+# ---------------------------------------------------------------------------
+
+
+def test_rename_moves_the_comms_node_row(seeded: Path):
+    """Miss this and the A2A directory still advertises the dead name."""
+    # Arrange
+    sql = "SELECT COUNT(*) FROM comms_nodes WHERE name = ?"
+    # Act
+    rename_rows(seeded, OLD, NEW)
+    # Assert
+    assert _one(seeded, sql, NEW) == 1
+
+
+def test_rename_moves_the_acl_policy_row(seeded: Path):
+    """Miss this and the ACL gate has no policy for the live name."""
+    # Arrange
+    sql = "SELECT COUNT(*) FROM node_comms_policy WHERE name = ?"
+    # Act
+    rename_rows(seeded, OLD, NEW)
+    # Assert
+    assert _one(seeded, sql, NEW) == 1
+
+
+def test_rename_moves_the_lineage_parent_edge(seeded: Path):
+    # Arrange
+    sql = "SELECT parent_name FROM lineage WHERE child_name = 'child-a'"
+    # Act
+    rename_rows(seeded, OLD, NEW)
+    # Assert
+    assert _one(seeded, sql) == NEW
+
+
+def test_rename_moves_the_history_rows(seeded: Path):
+    # Arrange
+    sql = "SELECT COUNT(*) FROM turns WHERE name = ?"
+    # Act
+    rename_rows(seeded, OLD, NEW)
+    # Assert
+    assert _one(seeded, sql, NEW) == 1
+
+
+def test_rename_rewrites_the_spec_path_component(seeded: Path):
+    # Arrange
+    sql = "SELECT yaml_path FROM definitions WHERE id = 'd1'"
+    # Act
+    rename_rows(seeded, OLD, NEW)
+    # Assert
+    assert _one(seeded, sql) == f"/root/agents/{NEW}/spec.yaml"
+
+
+def test_rename_rewrites_the_instance_workdir_component(seeded: Path):
+    # Arrange
+    sql = "SELECT workdir FROM instances WHERE id = 'i1'"
+    # Act
+    rename_rows(seeded, OLD, NEW)
+    # Assert
+    assert _one(seeded, sql) == f"/home/u/proj/{NEW}"
+
+
+def test_rename_leaves_no_row_behind_under_the_old_name(seeded: Path):
+    # Arrange
+    sql = "SELECT COUNT(*) FROM comms_nodes WHERE name = ?"
+    # Act
+    rename_rows(seeded, OLD, NEW)
+    # Assert
+    assert _one(seeded, sql, OLD) == 0
+
+
+def test_rename_is_a_no_op_on_a_missing_db(tmp_path: Path):
+    # Arrange
+    missing = tmp_path / "nope" / "state.db"
+    # Act
+    undo = rename_rows(missing, OLD, NEW)
+    # Assert
+    assert undo.total == 0
+
+
+# ---------------------------------------------------------------------------
+# undo — rowid-scoped, so it cannot clobber a pre-existing `new`
+# ---------------------------------------------------------------------------
+
+
+def test_undo_restores_the_identity_row(seeded: Path):
+    # Arrange
+    undo = rename_rows(seeded, OLD, NEW)
+    sql = "SELECT COUNT(*) FROM comms_nodes WHERE name = ?"
+    # Act
+    undo_rename_rows(undo)
+    # Assert
+    assert _one(seeded, sql, OLD) == 1
+
+
+def test_undo_restores_the_rewritten_path(seeded: Path):
+    # Arrange
+    undo = rename_rows(seeded, OLD, NEW)
+    sql = "SELECT yaml_path FROM definitions WHERE id = 'd1'"
+    # Act
+    undo_rename_rows(undo)
+    # Assert
+    assert _one(seeded, sql) == f"/root/agents/{OLD}/spec.yaml"
+
+
+def test_undo_does_not_clobber_a_row_that_already_held_the_new_name(seeded: Path):
+    """The trap a `WHERE name = new` undo would fall into.
+
+    A previously deleted agent called ``scitex-cards`` can have left
+    history behind. Renaming ``scitex-todo`` -> ``scitex-cards`` and then
+    rolling back must NOT drag that stranger's row along.
+    """
+    # Arrange
+    conn = sqlite3.connect(str(seeded))
+    with conn:
+        conn.execute(
+            "INSERT INTO turns (turn_id, name, host, status, ts) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("t-stranger", NEW, "h", "ok", 0.5),
+        )
+    conn.close()
+    undo = rename_rows(seeded, OLD, NEW)
+    sql = "SELECT name FROM turns WHERE turn_id = 't-stranger'"
+    # Act
+    undo_rename_rows(undo)
+    # Assert
+    assert _one(seeded, sql) == NEW

--- a/tests/scitex_agent_container/_lifecycle/test__rename_db.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_db.py
@@ -21,10 +21,44 @@ from scitex_agent_container._lifecycle._rename_db import (
 )
 from scitex_agent_container._lifecycle._rename_plan import Layout
 
-from .._helpers.fleet_root import make_state_db
+from .._helpers.fleet_root import make_state_db, seed_db_rows
 
 OLD = "scitex-todo"
 NEW = "scitex-cards"
+
+
+# The rows a real agent leaves across the identity AND history tables.
+_SEED = [
+    (
+        "INSERT INTO definitions (id, name, yaml_path, yaml_sha256, scope, "
+        "first_seen_at) VALUES (?, ?, ?, ?, ?, ?)",
+        ("d1", OLD, f"/root/agents/{OLD}/spec.yaml", "sha", "user", "t0"),
+    ),
+    (
+        "INSERT INTO instances (id, name, host, scope, started_at, workdir, "
+        "ended_at, spawned_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ("i1", OLD, "h", "user", "t0", f"/home/u/proj/{OLD}", "t1", "cli"),
+    ),
+    (
+        "INSERT INTO comms_nodes (name, host, a2a_port, registered_at, "
+        "updated_at) VALUES (?, ?, ?, ?, ?)",
+        (OLD, "h", 9001, 1.0, 1.0),
+    ),
+    (
+        "INSERT INTO node_comms_policy (name, updated_at) VALUES (?, ?)",
+        (OLD, 1.0),
+    ),
+    (
+        "INSERT INTO lineage (child_name, parent_name, created_at) "
+        "VALUES (?, ?, ?)",
+        ("child-a", OLD, 1.0),
+    ),
+    (
+        "INSERT INTO turns (turn_id, name, host, status, ts) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("t1", OLD, "h", "ok", 1.0),
+    ),
+]
 
 
 @pytest.fixture
@@ -36,39 +70,7 @@ def db(tmp_path: Path) -> Path:
 @pytest.fixture
 def seeded(db: Path) -> Path:
     """A DB holding rows for OLD across the identity + history tables."""
-    conn = sqlite3.connect(str(db))
-    with conn:
-        conn.execute(
-            "INSERT INTO definitions (id, name, yaml_path, yaml_sha256, scope, "
-            "first_seen_at) VALUES (?, ?, ?, ?, ?, ?)",
-            ("d1", OLD, f"/root/agents/{OLD}/spec.yaml", "sha", "user", "t0"),
-        )
-        conn.execute(
-            "INSERT INTO instances (id, name, host, scope, started_at, workdir, "
-            "ended_at, spawned_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            ("i1", OLD, "h", "user", "t0", f"/home/u/proj/{OLD}", "t1", "cli"),
-        )
-        conn.execute(
-            "INSERT INTO comms_nodes (name, host, a2a_port, registered_at, "
-            "updated_at) VALUES (?, ?, ?, ?, ?)",
-            (OLD, "h", 9001, 1.0, 1.0),
-        )
-        conn.execute(
-            "INSERT INTO node_comms_policy (name, updated_at) VALUES (?, ?)",
-            (OLD, 1.0),
-        )
-        conn.execute(
-            "INSERT INTO lineage (child_name, parent_name, created_at) "
-            "VALUES (?, ?, ?)",
-            ("child-a", OLD, 1.0),
-        )
-        conn.execute(
-            "INSERT INTO turns (turn_id, name, host, status, ts) "
-            "VALUES (?, ?, ?, ?, ?)",
-            ("t1", OLD, "h", "ok", 1.0),
-        )
-    conn.close()
-    return db
+    return seed_db_rows(db, _SEED)
 
 
 def _one(db: Path, sql: str, *args):

--- a/tests/scitex_agent_container/_lifecycle/test__rename_isolation.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_isolation.py
@@ -1,0 +1,144 @@
+"""PROVE the rename tests cannot reach the live fleet or the live board.
+
+This file exists because the failure mode it guards against is a
+catastrophe, not a flake: a rename test that escaped its tmp root would
+move a LIVE agent's spec dir, overlay and state dir, and REASSIGN ITS
+CARDS on the real board. "The fixture sets $HOME, so we're isolated" is
+exactly the assumption that has already burned this codebase once — sac's
+own module-level path constants are computed at IMPORT time, so an env var
+set afterwards cannot redirect them.
+
+So: assert the isolation, do not assume it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._lifecycle._rename_plan import Layout
+
+from .._helpers.fleet_root import (
+    isolated_board,
+    isolated_root,
+    make_fleet,
+    no_root_override,
+)
+
+
+@pytest.fixture
+def board(tmp_path: Path):
+    yield from isolated_board(tmp_path)
+
+
+@pytest.fixture
+def sac_root(tmp_path: Path):
+    yield from isolated_root(tmp_path)
+
+
+@pytest.fixture
+def bare_env(tmp_path: Path):
+    yield from no_root_override(tmp_path)
+
+
+def test_every_layout_path_stays_inside_the_injected_root(tmp_path: Path):
+    """No Layout path may escape the root a test injected."""
+    # Arrange
+    layout = Layout(root=tmp_path / "fleet")
+    # Act
+    paths = [
+        layout.state_db,
+        layout.spec_dir("a"),
+        layout.spec_file("a"),
+        layout.overlay_dir("a"),
+        layout.runtime_dir("a"),
+        layout.registry_json("a"),
+    ]
+    # Assert
+    assert all(p.is_relative_to(tmp_path) for p in paths)
+
+
+@pytest.mark.usefixtures("bare_env")
+def test_layout_default_resolves_to_the_real_fleet_root():
+    """Document WHY every test injects a Layout instead of using the default.
+
+    With no override, ``Layout.default()`` IS the production root. Asserting
+    that here makes the danger explicit rather than tribal knowledge: any
+    test that calls it unguarded is touching the live fleet.
+    """
+    # Arrange
+    expected = Path.home() / ".scitex" / "agent-container"
+    # Act
+    default_root = Layout.default().root
+    # Assert
+    assert default_root == expected
+
+
+def test_the_root_env_port_redirects_layout_default(sac_root: Path):
+    """The seam that lets the CLI test run without touching the live fleet.
+
+    The CLI resolves its own ``Layout.default()`` — there is no ``--root``
+    flag to pass. So the port MUST be honoured at CALL time; an import-time
+    constant would leave the CliRunner test renaming a real agent.
+    """
+    # Arrange
+    expected = sac_root
+    # Act
+    default_root = Layout.default().root
+    # Assert
+    assert default_root == expected
+
+
+def test_isolated_board_redirects_scitex_todos_default_store(board: Path):
+    """Even a call that FORGOT ``store=`` must land in tmp, not on the board.
+
+    ``store=None`` makes scitex-todo resolve its default store. If that
+    still resolved to the live 1,400-card board, one missing keyword in the
+    rename code would reassign real cards. The fixture points
+    ``$SCITEX_TODO_TASKS_YAML_SHARED`` at the tmp store, and scitex-todo
+    reads that env var at CALL time — so this holds.
+    """
+    # Arrange
+    from scitex_todo import _store
+
+    # Act
+    resolved = _store.resolve_tasks_path()
+    # Assert
+    assert resolved == board
+
+
+def test_make_fleet_creates_the_spec_file(tmp_path: Path):
+    # Arrange
+    root = tmp_path / "fleet"
+    # Act
+    layout = make_fleet(root, "demo")
+    # Assert
+    assert layout.spec_file("demo").is_file()
+
+
+def test_make_fleet_creates_the_overlay_dir(tmp_path: Path):
+    # Arrange
+    root = tmp_path / "fleet"
+    # Act
+    layout = make_fleet(root, "demo")
+    # Assert
+    assert layout.overlay_dir("demo").is_dir()
+
+
+def test_make_fleet_creates_the_runtime_dir(tmp_path: Path):
+    # Arrange
+    root = tmp_path / "fleet"
+    # Act
+    layout = make_fleet(root, "demo")
+    # Assert
+    assert layout.runtime_dir("demo").is_dir()
+
+
+def test_make_fleet_creates_the_registry_entry(tmp_path: Path):
+    # Arrange
+    root = tmp_path / "fleet"
+    # Act
+    layout = make_fleet(root, "demo")
+    # Assert
+    assert layout.registry_json("demo").is_file()

--- a/tests/scitex_agent_container/_lifecycle/test__rename_isolation.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_isolation.py
@@ -98,10 +98,12 @@ def test_isolated_board_redirects_scitex_todos_default_store(board: Path):
     rename code would reassign real cards. The fixture points
     ``$SCITEX_TODO_TASKS_YAML_SHARED`` at the tmp store, and scitex-todo
     reads that env var at CALL time — so this holds.
+
+    Skips when the optional peer is absent (sac's own CI); there is no
+    default store to redirect then, and faking one would prove nothing.
     """
     # Arrange
-    from scitex_todo import _store
-
+    _store = pytest.importorskip("scitex_todo._store")
     # Act
     resolved = _store.resolve_tasks_path()
     # Assert

--- a/tests/scitex_agent_container/_lifecycle/test__rename_spec.py
+++ b/tests/scitex_agent_container/_lifecycle/test__rename_spec.py
@@ -1,0 +1,326 @@
+"""The spec rewriter must find every self-reference and corrupt nothing.
+
+Pure functions over YAML text — no filesystem, no fleet. The fixture spec
+is the live project-maintainer shape (relaxed apptainer + directory
+overlay + raw_args env block), comments and all, so "did the rename find
+the overlay path buried in a flat raw_args list?" is a real question here
+and not a toy one.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from scitex_agent_container._lifecycle._rename_spec import (
+    SpecRewriteError,
+    rewrite_spec,
+    sub_bind,
+    sub_env_value,
+    sub_path,
+    sub_token,
+)
+
+from .._helpers.fleet_root import make_spec
+
+OLD = "scitex-todo"
+NEW = "scitex-cards"
+
+
+@pytest.fixture
+def rewritten() -> str:
+    text, _changes = rewrite_spec(make_spec(OLD), OLD, NEW)
+    return text
+
+
+@pytest.fixture
+def doc(rewritten: str) -> dict:
+    return yaml.safe_load(rewritten)
+
+
+@pytest.fixture
+def raw_args(doc: dict) -> list[str]:
+    return doc["spec"]["apptainer"]["raw_args"]
+
+
+# ---------------------------------------------------------------------------
+# Value-level rules
+# ---------------------------------------------------------------------------
+
+
+def test_sub_token_rewrites_a_prefix_before_a_hyphen():
+    """``<old>-maintainer`` is the fleet's purpose-label convention."""
+    # Arrange
+    value = "scitex-todo-maintainer"
+    # Act
+    result = sub_token(value, OLD, NEW)
+    # Assert
+    assert result == "scitex-cards-maintainer"
+
+
+def test_sub_token_leaves_a_name_embedded_in_a_longer_word_alone():
+    """A boundary rule, not a substring sed — this is the anti-corruption bit."""
+    # Arrange
+    value = "xscitex-todoy"
+    # Act
+    result = sub_token(value, OLD, NEW)
+    # Assert
+    assert result == "xscitex-todoy"
+
+
+def test_sub_path_rewrites_a_whole_path_component():
+    # Arrange
+    value = "/home/u/proj/scitex-todo"
+    # Act
+    result = sub_path(value, OLD, NEW)
+    # Assert
+    assert result == "/home/u/proj/scitex-cards"
+
+
+def test_sub_path_leaves_a_component_that_merely_contains_the_name():
+    """``scitex-todo-archive`` is a DIFFERENT directory. Do not touch it."""
+    # Arrange
+    value = "/home/u/proj/scitex-todo-archive/x"
+    # Act
+    result = sub_path(value, OLD, NEW)
+    # Assert
+    assert result == "/home/u/proj/scitex-todo-archive/x"
+
+
+def test_sub_bind_preserves_the_mount_option():
+    # Arrange
+    value = "/home/u/proj/scitex-todo:/home/u/proj/scitex-todo:ro"
+    # Act
+    result = sub_bind(value, OLD, NEW)
+    # Assert
+    assert result == "/home/u/proj/scitex-cards:/home/u/proj/scitex-cards:ro"
+
+
+def test_sub_env_value_rewrites_the_board_identity():
+    # Arrange
+    key = "SCITEX_TODO_AGENT_ID"
+    # Act
+    result = sub_env_value(key, OLD, OLD, NEW)
+    # Assert
+    assert result == NEW
+
+
+def test_sub_env_value_rewrites_the_state_db_path_component():
+    # Arrange
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    # Act
+    result = sub_env_value(key, f"/state/{OLD}/state.db", OLD, NEW)
+    # Assert
+    assert result == f"/state/{NEW}/state.db"
+
+
+def test_sub_env_value_ignores_an_env_var_that_is_not_an_identity():
+    """``GIT_AUTHOR_NAME=scitex-todo`` would be a coincidence, not an identity."""
+    # Arrange
+    key = "GIT_AUTHOR_NAME"
+    # Act
+    result = sub_env_value(key, OLD, OLD, NEW)
+    # Assert
+    assert result == OLD
+
+
+# ---------------------------------------------------------------------------
+# Document-level rewrite — every touchpoint
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_updates_the_project_label(doc: dict):
+    # Arrange
+    labels = doc["metadata"]["labels"]
+    # Act
+    project = labels["project"]
+    # Assert
+    assert project == NEW
+
+
+def test_rewrite_updates_the_purpose_label(doc: dict):
+    # Arrange
+    labels = doc["metadata"]["labels"]
+    # Act
+    purpose = labels["purpose"]
+    # Assert
+    assert purpose == f"{NEW}-maintainer"
+
+
+def test_rewrite_updates_the_workdir(doc: dict):
+    # Arrange
+    spec = doc["spec"]
+    # Act
+    workdir = spec["workdir"]
+    # Assert
+    assert workdir == f"/home/tester/proj/{NEW}"
+
+
+def test_rewrite_updates_the_overlay_path_inside_flat_raw_args(raw_args: list):
+    """The overlay path is a bare list item AFTER ``--overlay``, not a key."""
+    # Arrange
+    idx = raw_args.index("--overlay") + 1
+    # Act
+    overlay = raw_args[idx]
+    # Assert
+    assert overlay == f"/home/tester/.scitex/agent-container/containers/overlays/{NEW}/"
+
+
+def test_rewrite_updates_the_state_db_env(raw_args: list):
+    # Arrange
+    prefix = "SCITEX_AGENT_CONTAINER_STATE_DB="
+    # Act
+    entry = next(a for a in raw_args if a.startswith(prefix))
+    # Assert
+    assert entry == f"{prefix}/state/{NEW}/state.db"
+
+
+def test_rewrite_updates_the_board_identity_env(raw_args: list):
+    """THE one that orphans 158 cards if it moves without them."""
+    # Arrange
+    prefix = "SCITEX_TODO_AGENT_ID="
+    # Act
+    entry = next(a for a in raw_args if a.startswith(prefix))
+    # Assert
+    assert entry == f"{prefix}{NEW}"
+
+
+def test_rewrite_leaves_an_unrelated_env_var_untouched(raw_args: list):
+    # Arrange
+    prefix = "GIT_AUTHOR_NAME="
+    # Act
+    entry = next(a for a in raw_args if a.startswith(prefix))
+    # Assert
+    assert entry == f"{prefix}Yusuke Watanabe"
+
+
+def test_rewrite_updates_a_bind_that_carries_the_name():
+    # Arrange
+    spec = make_spec(OLD).replace(
+        "      - /home/tester/.ssh:/home/agent/.ssh:ro",
+        "      - /home/tester/proj/scitex-todo:/work:rw",
+    )
+    # Act
+    text, _changes = rewrite_spec(spec, OLD, NEW)
+    # Assert
+    assert "/home/tester/proj/scitex-cards:/work:rw" in text
+
+
+def test_rewrite_updates_the_equals_joined_overlay_spelling():
+    """Both ``--overlay <p>`` and ``--overlay=<p>`` are live in the fleet."""
+    # Arrange
+    spec = make_spec(OLD).replace(
+        "      - --overlay\n"
+        "      - /home/tester/.scitex/agent-container/containers/overlays/"
+        "scitex-todo/",
+        "      - --overlay=/home/tester/.scitex/agent-container/containers/"
+        "overlays/scitex-todo/",
+    )
+    # Act
+    text, _changes = rewrite_spec(spec, OLD, NEW)
+    # Assert
+    assert (
+        "--overlay=/home/tester/.scitex/agent-container/containers/overlays/"
+        "scitex-cards/" in text
+    )
+
+
+# ---------------------------------------------------------------------------
+# Corruption guards
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_preserves_the_operators_comments(rewritten: str):
+    """Specs are ~40% load-bearing operator commentary. Destroying it is damage."""
+    # Arrange
+    marker = "# This comment block is LOAD-BEARING"
+    # Act
+    survived = marker in rewritten
+    # Assert
+    assert survived
+
+
+def test_rewrite_preserves_the_comment_that_warns_about_the_board_identity(
+    rewritten: str,
+):
+    # Arrange
+    marker = "# every card the agent owns is orphaned."
+    # Act
+    survived = marker in rewritten
+    # Assert
+    assert survived
+
+
+def test_rewrite_changes_no_key_it_did_not_plan_to_change(rewritten: str):
+    """Every leaf that moved must be accounted for by a reported change."""
+    # Arrange
+    before = yaml.safe_load(make_spec(OLD))
+    after = yaml.safe_load(rewritten)
+    _text, changes = rewrite_spec(make_spec(OLD), OLD, NEW)
+    # Act
+    moved = _leaves(before) ^ _leaves(after)
+    # Assert
+    assert len(moved) == 2 * len(changes)
+
+
+def test_rewrite_keeps_the_document_valid_yaml(rewritten: str):
+    # Arrange
+    expected_kind = "Agent"
+    # Act
+    doc = yaml.safe_load(rewritten)
+    # Assert
+    assert doc["kind"] == expected_kind
+
+
+def test_rewrite_reports_every_change_it_made():
+    # Arrange
+    expected_paths = {
+        "metadata.labels.project",
+        "metadata.labels.purpose",
+        "spec.workdir",
+    }
+    # Act
+    _text, changes = rewrite_spec(make_spec(OLD), OLD, NEW)
+    # Assert
+    assert expected_paths <= {c.path for c in changes}
+
+
+def test_rewrite_is_a_no_op_when_the_spec_never_names_the_agent():
+    # Arrange
+    spec = make_spec("someone-else")
+    # Act
+    text, changes = rewrite_spec(spec, OLD, NEW)
+    # Assert
+    assert (text, changes) == (spec, [])
+
+
+def test_rewrite_refuses_a_spec_that_is_not_yaml():
+    # Arrange
+    text = "{{{ not yaml"
+    # Act
+    # Assert
+    with pytest.raises(SpecRewriteError):
+        rewrite_spec(text, OLD, NEW)
+
+
+def test_rewrite_refuses_a_spec_that_is_not_a_mapping():
+    # Arrange
+    text = "- a\n- b\n"
+    # Act
+    # Assert
+    with pytest.raises(SpecRewriteError):
+        rewrite_spec(text, OLD, NEW)
+
+
+def _leaves(node, prefix: str = "") -> set:
+    """Flatten a doc to a set of ``(path, value)`` pairs."""
+    out = set()
+    if isinstance(node, dict):
+        for key, value in node.items():
+            out |= _leaves(value, f"{prefix}.{key}" if prefix else str(key))
+    elif isinstance(node, list):
+        for idx, value in enumerate(node):
+            out |= _leaves(value, f"{prefix}[{idx}]")
+    else:
+        out.add((prefix, node))
+    return out

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
@@ -1,21 +1,26 @@
 """``sac agents rename`` through the real CLI.
 
 NO MOCKS: a real ``CliRunner`` drives the real click command against a real
-on-disk fleet and a real scitex-todo store. The command resolves its OWN
-``Layout.default()`` — there is no ``--root`` flag — so isolation comes
-from the ``$SCITEX_AGENT_CONTAINER_ROOT`` port, which is read at call time.
-Without that, this file would rename a live agent.
+on-disk fleet. The command resolves its OWN ``Layout.default()`` — there is
+no ``--root`` flag — so isolation comes from the
+``$SCITEX_AGENT_CONTAINER_ROOT`` port, which is read at call time. Without
+that, this file would rename a live agent.
+
+Most tests here drive ``--no-cards``, so they exercise the CLI everywhere
+including sac's own CI, where the optional ``scitex-todo`` peer is absent.
+The card-bearing tests ``importorskip`` it individually rather than taking
+the whole file down with them — the CLI's refusals, its plan rendering and
+its confirmation gate are worth CI coverage on their own.
 """
 
 from __future__ import annotations
 
-import sqlite3
+import json
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
 
-from scitex_agent_container._lifecycle._rename_cards import find_owned_cards
 from scitex_agent_container._lifecycle._rename_plan import Layout
 from scitex_agent_container.cli_pkg.lifecycle._rename import rename
 
@@ -23,17 +28,11 @@ from ..._helpers.fleet_root import (
     isolated_board,
     isolated_root,
     make_fleet,
-    make_state_db,
-    seed_cards,
+    seed_identity_and_history,
 )
 
 OLD = "scitex-todo"
 NEW = "scitex-cards"
-
-
-@pytest.fixture
-def board(tmp_path: Path):
-    yield from isolated_board(tmp_path)
 
 
 @pytest.fixture
@@ -42,19 +41,15 @@ def sac_root(tmp_path: Path):
 
 
 @pytest.fixture
-def fleet(sac_root: Path, board: Path) -> Layout:
-    """A real agent on disk, with rows in state.db and cards on the board."""
+def board(tmp_path: Path):
+    yield from isolated_board(tmp_path)
+
+
+@pytest.fixture
+def fleet(sac_root: Path) -> Layout:
+    """A real agent on disk, with rows in state.db. No board."""
     layout = make_fleet(sac_root, OLD)
-    db = make_state_db(layout)
-    conn = sqlite3.connect(str(db))
-    with conn:
-        conn.execute(
-            "INSERT INTO comms_nodes (name, host, a2a_port, registered_at, "
-            "updated_at) VALUES (?, ?, ?, ?, ?)",
-            (OLD, "h", 9001, 1.0, 1.0),
-        )
-    conn.close()
-    seed_cards(board, OLD, 3)
+    seed_identity_and_history(layout, OLD)
     return layout
 
 
@@ -64,12 +59,12 @@ def _run(*argv: str):
 
 @pytest.fixture
 def dry_run(fleet: Layout):
-    return _run(OLD, NEW, "--dry-run")
+    return _run(OLD, NEW, "--dry-run", "--no-cards")
 
 
 @pytest.fixture
 def applied(fleet: Layout):
-    return _run(OLD, NEW, "-y")
+    return _run(OLD, NEW, "-y", "--no-cards")
 
 
 # ---------------------------------------------------------------------------
@@ -96,18 +91,9 @@ def test_dry_run_says_it_is_a_dry_run(dry_run):
 
 
 def test_dry_run_reports_the_board_identity_change(dry_run):
-    """The change that orphans the cards must be impossible to miss."""
+    """The spec change that orphans the cards must be impossible to miss."""
     # Arrange
     needle = "BOARD IDENTITY"
-    # Act
-    output = dry_run.output
-    # Assert
-    assert needle in output
-
-
-def test_dry_run_reports_the_card_count(dry_run):
-    # Arrange
-    needle = "3 card(s)"
     # Act
     output = dry_run.output
     # Assert
@@ -123,10 +109,19 @@ def test_dry_run_reports_the_state_db_rows(dry_run):
     assert needle in output
 
 
-def test_dry_run_names_the_port_it_migrates_cards_through(dry_run):
-    """Ports and adapters, stated in the UI: sac calls the board's primitive."""
+def test_dry_run_reports_the_overlay_move(dry_run):
     # Arrange
-    needle = "reassign_task"
+    needle = "overlay-dir"
+    # Act
+    output = dry_run.output
+    # Assert
+    assert needle in output
+
+
+def test_dry_run_warns_that_no_cards_orphans_the_board(dry_run):
+    """The escape hatch has to say what it costs."""
+    # Arrange
+    needle = "ORPHANED"
     # Act
     output = dry_run.output
     # Assert
@@ -140,15 +135,6 @@ def test_dry_run_leaves_the_spec_dir_where_it_was(dry_run, fleet: Layout):
     exists = old_dir.is_dir()
     # Assert
     assert exists
-
-
-def test_dry_run_moves_no_cards(dry_run, fleet: Layout, board: Path):
-    # Arrange
-    expected = 3
-    # Act
-    still_owned = find_owned_cards(OLD, store=board)
-    # Assert
-    assert len(still_owned) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -174,15 +160,6 @@ def test_rename_moves_the_spec_dir(applied, fleet: Layout):
     assert exists
 
 
-def test_rename_migrates_every_card(applied, fleet: Layout, board: Path):
-    # Arrange
-    store = board
-    # Act
-    orphans = find_owned_cards(OLD, store=store)
-    # Assert
-    assert orphans == []
-
-
 def test_rename_tells_the_operator_how_to_start_the_agent(applied):
     # Arrange
     needle = f"sac agents start {NEW}"
@@ -201,7 +178,7 @@ def test_rename_refuses_an_unknown_agent(fleet: Layout):
     # Arrange
     unknown = "no-such-agent"
     # Act
-    result = _run(unknown, NEW, "-y")
+    result = _run(unknown, NEW, "-y", "--no-cards")
     # Assert
     assert result.exit_code != 0
 
@@ -210,7 +187,7 @@ def test_the_unknown_agent_refusal_says_not_found(fleet: Layout):
     # Arrange
     unknown = "no-such-agent"
     # Act
-    result = _run(unknown, NEW, "-y")
+    result = _run(unknown, NEW, "-y", "--no-cards")
     # Assert
     assert "not found" in result.output
 
@@ -219,7 +196,7 @@ def test_rename_refuses_when_the_target_name_is_taken(fleet: Layout):
     # Arrange
     make_fleet(fleet.root, NEW)
     # Act
-    result = _run(OLD, NEW, "-y")
+    result = _run(OLD, NEW, "-y", "--no-cards")
     # Assert
     assert "already exists" in result.output
 
@@ -229,26 +206,89 @@ def test_json_mode_refuses_to_run_unconfirmed(fleet: Layout):
     # Arrange
     expected = "non-interactive"
     # Act
-    result = _run(OLD, NEW, "--json")
+    result = _run(OLD, NEW, "--json", "--no-cards")
     # Assert
     assert expected in result.output
 
 
-def test_json_dry_run_emits_the_plan(fleet: Layout):
-    # Arrange
-    import json
-
-    # Act
-    result = _run(OLD, NEW, "--dry-run", "--json")
-    # Assert
-    assert json.loads(result.output)["cards"]["count"] == 3
+# ---------------------------------------------------------------------------
+# --json
+# ---------------------------------------------------------------------------
 
 
 def test_json_dry_run_reports_the_new_name(fleet: Layout):
     # Arrange
-    import json
-
+    expected = NEW
     # Act
-    result = _run(OLD, NEW, "--dry-run", "--json")
+    result = _run(OLD, NEW, "--dry-run", "--json", "--no-cards")
     # Assert
-    assert json.loads(result.output)["new"] == NEW
+    assert json.loads(result.output)["new"] == expected
+
+
+def test_json_dry_run_lists_the_spec_changes(fleet: Layout):
+    # Arrange
+    needle = "SCITEX_TODO_AGENT_ID"
+    # Act
+    result = _run(OLD, NEW, "--dry-run", "--json", "--no-cards")
+    # Assert
+    assert any(
+        needle in c["path"] for c in json.loads(result.output)["spec_changes"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# With a real board (skipped when the optional peer is absent)
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_reports_the_card_count(fleet: Layout, board: Path):
+    # Arrange
+    _seed(board, 3)
+    # Act
+    result = _run(OLD, NEW, "--dry-run")
+    # Assert
+    assert "3 card(s)" in result.output
+
+
+def test_dry_run_names_the_port_it_migrates_cards_through(
+    fleet: Layout, board: Path
+):
+    """Ports and adapters, stated in the UI: sac calls the board's primitive."""
+    # Arrange
+    _seed(board, 1)
+    # Act
+    result = _run(OLD, NEW, "--dry-run")
+    # Assert
+    assert "reassign_task" in result.output
+
+
+def test_dry_run_moves_no_card(fleet: Layout, board: Path):
+    # Arrange
+    _seed(board, 3)
+    # Act
+    _run(OLD, NEW, "--dry-run")
+    # Assert
+    assert len(_owned(OLD, board)) == 3
+
+
+def test_rename_migrates_every_card(fleet: Layout, board: Path):
+    # Arrange
+    _seed(board, 3)
+    # Act
+    _run(OLD, NEW, "-y")
+    # Assert
+    assert _owned(OLD, board) == []
+
+
+def _seed(board: Path, count: int) -> list[str]:
+    """Seed real cards, skipping the test when the optional peer is absent."""
+    pytest.importorskip("scitex_todo")
+    from ..._helpers.fleet_root import seed_cards
+
+    return seed_cards(board, OLD, count)
+
+
+def _owned(name: str, board: Path) -> list[str]:
+    from scitex_agent_container._lifecycle._rename_cards import find_owned_cards
+
+    return find_owned_cards(name, store=board)

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__rename.py
@@ -1,0 +1,254 @@
+"""``sac agents rename`` through the real CLI.
+
+NO MOCKS: a real ``CliRunner`` drives the real click command against a real
+on-disk fleet and a real scitex-todo store. The command resolves its OWN
+``Layout.default()`` — there is no ``--root`` flag — so isolation comes
+from the ``$SCITEX_AGENT_CONTAINER_ROOT`` port, which is read at call time.
+Without that, this file would rename a live agent.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._lifecycle._rename_cards import find_owned_cards
+from scitex_agent_container._lifecycle._rename_plan import Layout
+from scitex_agent_container.cli_pkg.lifecycle._rename import rename
+
+from ..._helpers.fleet_root import (
+    isolated_board,
+    isolated_root,
+    make_fleet,
+    make_state_db,
+    seed_cards,
+)
+
+OLD = "scitex-todo"
+NEW = "scitex-cards"
+
+
+@pytest.fixture
+def board(tmp_path: Path):
+    yield from isolated_board(tmp_path)
+
+
+@pytest.fixture
+def sac_root(tmp_path: Path):
+    yield from isolated_root(tmp_path)
+
+
+@pytest.fixture
+def fleet(sac_root: Path, board: Path) -> Layout:
+    """A real agent on disk, with rows in state.db and cards on the board."""
+    layout = make_fleet(sac_root, OLD)
+    db = make_state_db(layout)
+    conn = sqlite3.connect(str(db))
+    with conn:
+        conn.execute(
+            "INSERT INTO comms_nodes (name, host, a2a_port, registered_at, "
+            "updated_at) VALUES (?, ?, ?, ?, ?)",
+            (OLD, "h", 9001, 1.0, 1.0),
+        )
+    conn.close()
+    seed_cards(board, OLD, 3)
+    return layout
+
+
+def _run(*argv: str):
+    return CliRunner().invoke(rename, list(argv))
+
+
+@pytest.fixture
+def dry_run(fleet: Layout):
+    return _run(OLD, NEW, "--dry-run")
+
+
+@pytest.fixture
+def applied(fleet: Layout):
+    return _run(OLD, NEW, "-y")
+
+
+# ---------------------------------------------------------------------------
+# --dry-run: exact, and touches nothing
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_exits_clean(dry_run):
+    # Arrange
+    expected = 0
+    # Act
+    code = dry_run.exit_code
+    # Assert
+    assert code == expected, dry_run.output
+
+
+def test_dry_run_says_it_is_a_dry_run(dry_run):
+    # Arrange
+    needle = "DRY RUN"
+    # Act
+    output = dry_run.output
+    # Assert
+    assert needle in output
+
+
+def test_dry_run_reports_the_board_identity_change(dry_run):
+    """The change that orphans the cards must be impossible to miss."""
+    # Arrange
+    needle = "BOARD IDENTITY"
+    # Act
+    output = dry_run.output
+    # Assert
+    assert needle in output
+
+
+def test_dry_run_reports_the_card_count(dry_run):
+    # Arrange
+    needle = "3 card(s)"
+    # Act
+    output = dry_run.output
+    # Assert
+    assert needle in output
+
+
+def test_dry_run_reports_the_state_db_rows(dry_run):
+    # Arrange
+    needle = "comms_nodes.name"
+    # Act
+    output = dry_run.output
+    # Assert
+    assert needle in output
+
+
+def test_dry_run_names_the_port_it_migrates_cards_through(dry_run):
+    """Ports and adapters, stated in the UI: sac calls the board's primitive."""
+    # Arrange
+    needle = "reassign_task"
+    # Act
+    output = dry_run.output
+    # Assert
+    assert needle in output
+
+
+def test_dry_run_leaves_the_spec_dir_where_it_was(dry_run, fleet: Layout):
+    # Arrange
+    old_dir = fleet.spec_dir(OLD)
+    # Act
+    exists = old_dir.is_dir()
+    # Assert
+    assert exists
+
+
+def test_dry_run_moves_no_cards(dry_run, fleet: Layout, board: Path):
+    # Arrange
+    expected = 3
+    # Act
+    still_owned = find_owned_cards(OLD, store=board)
+    # Assert
+    assert len(still_owned) == expected
+
+
+# ---------------------------------------------------------------------------
+# The real run
+# ---------------------------------------------------------------------------
+
+
+def test_rename_exits_clean(applied):
+    # Arrange
+    expected = 0
+    # Act
+    code = applied.exit_code
+    # Assert
+    assert code == expected, applied.output
+
+
+def test_rename_moves_the_spec_dir(applied, fleet: Layout):
+    # Arrange
+    new_spec = fleet.spec_file(NEW)
+    # Act
+    exists = new_spec.is_file()
+    # Assert
+    assert exists
+
+
+def test_rename_migrates_every_card(applied, fleet: Layout, board: Path):
+    # Arrange
+    store = board
+    # Act
+    orphans = find_owned_cards(OLD, store=store)
+    # Assert
+    assert orphans == []
+
+
+def test_rename_tells_the_operator_how_to_start_the_agent(applied):
+    # Arrange
+    needle = f"sac agents start {NEW}"
+    # Act
+    output = applied.output
+    # Assert
+    assert needle in output
+
+
+# ---------------------------------------------------------------------------
+# Refusals
+# ---------------------------------------------------------------------------
+
+
+def test_rename_refuses_an_unknown_agent(fleet: Layout):
+    # Arrange
+    unknown = "no-such-agent"
+    # Act
+    result = _run(unknown, NEW, "-y")
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_the_unknown_agent_refusal_says_not_found(fleet: Layout):
+    # Arrange
+    unknown = "no-such-agent"
+    # Act
+    result = _run(unknown, NEW, "-y")
+    # Assert
+    assert "not found" in result.output
+
+
+def test_rename_refuses_when_the_target_name_is_taken(fleet: Layout):
+    # Arrange
+    make_fleet(fleet.root, NEW)
+    # Act
+    result = _run(OLD, NEW, "-y")
+    # Assert
+    assert "already exists" in result.output
+
+
+def test_json_mode_refuses_to_run_unconfirmed(fleet: Layout):
+    """--json is non-interactive; a silent unconfirmed rename would be a trap."""
+    # Arrange
+    expected = "non-interactive"
+    # Act
+    result = _run(OLD, NEW, "--json")
+    # Assert
+    assert expected in result.output
+
+
+def test_json_dry_run_emits_the_plan(fleet: Layout):
+    # Arrange
+    import json
+
+    # Act
+    result = _run(OLD, NEW, "--dry-run", "--json")
+    # Assert
+    assert json.loads(result.output)["cards"]["count"] == 3
+
+
+def test_json_dry_run_reports_the_new_name(fleet: Layout):
+    # Arrange
+    import json
+
+    # Act
+    result = _run(OLD, NEW, "--dry-run", "--json")
+    # Assert
+    assert json.loads(result.output)["new"] == NEW


### PR DESCRIPTION
# `sac agents rename <old> <new>` — the rename you cannot do safely by hand

An agent writes its own name into **six places on disk plus the shared task
board**. Renaming by hand means editing all of them consistently, and the one a
human misses is *silent*.

The worst one is the board identity. `SCITEX_TODO_AGENT_ID` is how scitex-todo
knows the agent. Change it without migrating the cards and **every card that
agent owns is orphaned** — it can no longer see its own work, and nothing tells
you. Measured on the live board before this verb existed: the `scitex-todo`
agent owns **158 cards** (84 of them scoped `agent:scitex-todo`). A hand rename
strands all 158.

## Every location the verb touches

| # | Location | Owner |
|---|---|---|
| 1 | spec dir — `<root>/agents/<name>/` | `_rename.apply_plan` |
| 2 | **the spec's own self-references** — `metadata.labels.project`, `.purpose`, `spec.workdir`, `spec.apptainer.overlay`, `binds[]`, `raw_args[] --overlay`, and `--env K=V` for the identity keys | `_rename_spec` |
| 3 | overlay dir — `<root>/containers/overlays/<name>/` | `_rename.apply_plan` |
| 4 | runtime **and** state dir — `<root>/runtime/<name>/` (these are one dir; it is bind-mounted into the container at `/state/<name>`) | `_rename.apply_plan` |
| 5 | registry entry — `<root>/runtime/registry/<name>.json` (its `name` + `config` fields) | `_rename.apply_plan` |
| 6 | `state.db` — **16 name columns + 2 path columns**, in one transaction | `_rename_db` |
| 7 | **task cards** — `agent` + `assignee` + `scope`, via scitex-todo | `_rename_cards` |

Identity env keys in (2): `SCITEX_TODO_AGENT_ID`, `SCITEX_TODO_AGENT`,
`SAC_NAME`, `SCITEX_AGENT_CONTAINER_NAME`, `SCITEX_AGENT_CONTAINER_AGENT`,
`SAC_AGENT`, `SCITEX_AGENT_CONTAINER_STATE_DB` (path-valued), `SCITEX_TODO_SCOPE`.

state.db tables in (6): `definitions`, `instances`, `attempts`, `turns`,
`errors`, `heartbeats`, `channel_events`, `node_tokens`, `lineage`,
`comms_grants`, `comms_nodes`, `node_comms_policy`. Identity **and** history — a
renamed agent is the same agent, so `sac agents recall <new>` still finds its
past. `git mv` doesn't fork history either.

## Properties

**Preflight refuses a running agent**, on *physical* evidence (a live PID), never
on a row that merely *claims* to be open. That cuts both ways deliberately: a
stale `instances` row (the reaper closes rows lazily) must not wedge a legitimate
rename forever, and a wedged-but-alive agent still holds its overlay open so it
must not be renamed out from under itself. Verdicts are three-valued —
`running` / `stopped` / `unknown` — and only `stopped` proceeds. The refusal
prints `sac agents stop <old>`.

**Atomic.** Every step pushes its inverse onto an undo stack before the next
runs; any failure unwinds in reverse. That includes a *partial* card migration:
`migrate_cards` can fail on card 81 of 158 having already committed 80 real
writes to the shared board, so the partial migration rides on the exception and
its inverse is registered before the raise propagates. A half-renamed agent is
worse than an un-renamed one — it starts under one name while writing to
another's overlay and board slice.

**Postcondition, not just steps.** A final `verify` step asserts nothing is left
under the old name (no dirs, no `state.db` rows, no cards). "I ran the steps" is
not the same claim as "the world is now correct", and the second is the one an
operator actually needs.

**The spec is loaded and edited, never sed'd.** `ruamel.yaml` round-trip — already
a hard dep of sac, added precisely so "operator-authored comments + key order
survive a sac-side edit". Specs are ~40% load-bearing operator commentary and
destroying it is damage. And because a round-trip *could* still reformat
something we never meant to touch, `rewrite_spec` **re-parses its own output**
and refuses to write a spec whose semantic diff is anything other than the change
set it planned (`_assert_only_planned_changes`).

## The real `--dry-run` output (fixture agent, 3 cards)

```
DRY RUN — nothing will be changed.

rename  scitex-todo  ->  scitex-cards

  [spec-dir]
      /tmp/fleet/agents/scitex-todo
   -> /tmp/fleet/agents/scitex-cards

  [spec-file]    6 self-reference(s)
      metadata.labels.project: scitex-todo -> scitex-cards
      metadata.labels.purpose: scitex-todo-maintainer -> scitex-cards-maintainer
      spec.workdir: /home/tester/proj/scitex-todo -> /home/tester/proj/scitex-cards
      spec.apptainer.raw_args[5] (--overlay): .../containers/overlays/scitex-todo/ -> .../containers/overlays/scitex-cards/
      spec.apptainer.raw_args[7] (--env SCITEX_AGENT_CONTAINER_STATE_DB): SCITEX_AGENT_CONTAINER_STATE_DB=/state/scitex-todo/state.db -> SCITEX_AGENT_CONTAINER_STATE_DB=/state/scitex-cards/state.db
      spec.apptainer.raw_args[9] (--env SCITEX_TODO_AGENT_ID): SCITEX_TODO_AGENT_ID=scitex-todo -> SCITEX_TODO_AGENT_ID=scitex-cards   <-- BOARD IDENTITY

  [overlay-dir]
      /tmp/fleet/containers/overlays/scitex-todo
   -> /tmp/fleet/containers/overlays/scitex-cards
  [runtime-dir]
      /tmp/fleet/runtime/scitex-todo
   -> /tmp/fleet/runtime/scitex-cards
  [registry]
      /tmp/fleet/runtime/registry/scitex-todo.json
   -> /tmp/fleet/runtime/registry/scitex-cards.json

  [state-db]     1 row(s) across 1 column(s)
      comms_nodes.name                   1

  [cards]        3 card(s) -> owner 'scitex-cards'
      scitex-todo-card-0, scitex-todo-card-1, scitex-todo-card-2
      via scitex_todo._store.reassign_task — sac calls the board's own
      primitive; it never edits the store itself.

WARNINGS
  ! spec.workdir will point at /home/tester/proj/scitex-cards, which does not
    exist yet. sac renames the AGENT, not the repo — rename the repo too, or
    edit spec.workdir afterwards.

Re-run with -y to apply ('scitex-todo' is stopped, so it is allowed).
```

`-y`/`--yes` is **required** to apply, and the verb **never prompts** — it refuses
with exit 2 and names the flag. That's the ecosystem CLI convention (§2), and it's
the right rule: an interactive confirm hangs forever under cron, CI, or an agent's
non-tty shell, on a verb that has already been asked to move a live agent's
directories. Same shape as `sac agents delete`.

## Ports and adapters: sac does **not** reimplement the card migration

`_rename_cards` calls `scitex_todo._store.reassign_task(store, task_id,
new_owner, by=…)`, which in one locked write sets `agent = assignee = new_owner`
**and** `scope = "agent:<new_owner>"`, appends an audit comment, and emits the
canonical `reassigned` event. sac calls it. sac does not clone it. The lazy
import mirrors the existing precedent (`_account/refresh_alarm` imports
`scitex_todo._help_wait.help_wait`) and rides the existing cross-package import
gate.

If scitex-todo is not installed the rename **refuses** rather than silently
skipping the board — silently skipping *is* the bug this verb exists to prevent.
`--no-cards` is the explicit, loud opt-out.

### The bulk primitive belongs in scitex-todo, not here — and I measured why

scitex-todo exposes **no** `reassign_all(old, new)`, so this adapter loops
`reassign_task` once per card. I profiled one **warm** `add_task` against a
**1-card** tmp store:

```
WARM add_task on a 1-card store: 3.24s
  2.18s  _emit_card_event -> dispatch_event -> _iter_entry_points
           -> importlib.metadata.entry_points()      # 126 entry_points.txt reads
  0.89s  _save_doc_unlocked -> _git_autocommit_store # 2 subprocess forks
```

That cost is **fixed per write** — it is not O(cards). Two independent causes,
both inside scitex-todo's write path:

1. `_hooks/_plugins._iter_entry_points()` calls `importlib.metadata.entry_points()`
   **uncached, on every card event**, re-reading ~126 `entry_points.txt` files off
   disk each time.
2. `_store_write._git_autocommit_store()` forks two `git` subprocesses per write.

So migrating 158 cards through the per-card verb costs **158 × ~3.2 s ≈ 8.5
minutes** of pure fixed overhead for what is semantically **one** operation. A
bulk `reassign_all(old, new)` on their side would be one lock, one store write,
one git commit, one coherent event — seconds, not minutes.

**That is a primitive living on the wrong side of the port, and sac must not "fix"
it locally by reaching into the store's YAML — that would BE the fork.** Two
concrete asks for scitex-todo, in priority order:

- **`reassign_all(old, new)`** — the bulk verb. `migrate_cards` then collapses to
  a single call.
- **Memoize `_iter_entry_points()`** — a one-line `functools.cache`. A standalone
  win that makes *every* card write ~2.2 s faster fleet-wide, not just this verb.

Happy to hand both over rather than fork either.

### Scope is not ownership (a trap worth naming)

The naive reading of "migrate everything scoped to the old agent" would also sweep
up cards whose `scope` says `agent:<old>` but whose **owner is somebody else** —
drifted data that exists in the wild — and hand them to the new name, *taking a
working agent's card away to tidy a string*. So sac keys migration on **ownership**
(`agent`, or the legacy `assignee`) only, and *reports* foreign-scoped cards as a
warning rather than silently picking one of the two wrong answers.

Relatedly, `find_owned_cards` passes `scope=""` explicitly. `list_tasks(scope=None)`
does not mean "no scope filter" — it means "fall back to `$SCITEX_TODO_SCOPE`", so
leaving it None would AND every owner query with the *caller's* slice and orphan
the rest. That is this very bug, reintroduced through the back door.

## Tests

**Isolation was built first, and it is asserted, not assumed**
(`test__rename_isolation.py`). A rename test that escaped its tmp root would move
a live agent's dirs and reassign its real cards. Three escape routes, all closed:

- **paths** — `Layout` derives every path from an injected `root`. Deliberately
  *not* from sac's module-level constants (`Registry.REGISTRY_DIR`,
  `_session_state.DEFAULT_STATE_ROOT`, `state_db.DEFAULT_DB_PATH`), which are
  computed from `$HOME` at **import** time — so a fixture that sets `$HOME`
  afterwards cannot redirect them, and a test trusting that would look isolated
  while reading *and writing* the live fleet.
- **the board** — every call takes an explicit `store=`, and
  `$SCITEX_TODO_TASKS_YAML_SHARED` is *also* pointed at the tmp store so even a
  forgotten keyword lands in tmp.
- **the notify rail** — sac registers a `scitex_todo.hooks` consumer, so a real
  `reassign_task` POSTs to the local `sac listen` daemon and publishes onto a live
  agent's a2a bus. Five reassigns would ping five real agents. Flipped off with
  sac's own shipped `SAC_CARD_EVENT_DELIVERY_DISABLED` kill-switch — the production
  path stays real, the test just does not ride it.

**The rollback is exercised at every step, and it was made to fail first.** The
`rolled_back` fixture is parametrised over all 8 steps, and each invariant is
asserted at every one of them. Plus one **organic** failure with no injected
callback at all — a read-only `overlays/` dir, so the *world* says no rather than
a test hook.

To prove the tests are not theatre I neutered `_unwind` to a no-op (`return []`,
undoing nothing) in a copy of the source and re-ran the same test:

```
A: REAL rollback        ........   8 passed
B: rollback NEUTERED    .FFFFFFF   1 passed, 7 FAILED
                         ^
                         only [spec-dir] still passes — correct: that failure
                         fires BEFORE the first step runs, so there is nothing
                         to undo. Every other step's rollback is load-bearing.
```

**The suite is split by coupling, so the atomicity guarantee runs in CI.**
scitex-todo is an *optional* peer — not a declared dependency of sac, and absent
from sac's own CI. `importorskip`-ing the whole rename suite would have taken the
rollback matrix out of CI entirely, which is exactly the part worth protecting.
So `test__rename.py` is board-free (`cards=False`) and runs everywhere — preflight,
plan, spec rewrite, dir/registry/state.db moves, the 8-step rollback matrix, the
organic failure. `test__rename_board.py` holds the card-coupled half (cards
migrate; cards come back on rollback at every step) and skips when the peer is
missing, per the repo's established contract. The CLI tests drive `--no-cards` so
the refusals, the plan rendering and the `-y` gate keep CI coverage too.

No mocks anywhere: real YAML specs, a real SQLite `state.db` built by sac's own
`init_schema`, a real scitex-todo store, a real `CliRunner`. No `monkeypatch`.

**187 passed** locally against this worktree (import path verified:
`/home/ywatanabe/proj/scitex-agent-container/.worktrees/agent-a34afbb2332bf125a/src/scitex_agent_container/__init__.py`,
*not* the baked `/opt/venv-sac` copy).

## Also

- New env port `SCITEX_AGENT_CONTAINER_ROOT` (resolved at **call** time, so it
  actually takes effect) — the single base all seven locations derive from.
  Documented in `20_env-vars.md`. It is also what lets the CliRunner test drive
  the real command, which resolves its own `Layout.default()`.
- `10_cli.md` + `CHANGELOG.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
