### PR TITLE
fix(state-db): pin the store a health monitor writes to — leaked daemon thread polluted other tests' isolated DBs (and production)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_instances.py
+++ b/src/scitex_agent_container/_lifecycle/_instances.py
@@ -20,7 +20,8 @@ without rescanning by name+host.
 
 from __future__ import annotations
 
-from typing import Any
+from pathlib import Path
+from typing import Any, Callable
 
 from ..config import AgentConfig
 
@@ -98,13 +99,37 @@ def _state_dir_for(config: AgentConfig, runtime: Any):
     return _runner.state_dir_for(config.name)
 
 
-def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
+def record_local_instance(
+    config: AgentConfig,
+    runtime: Any,
+    *,
+    db_path: Path | None = None,
+) -> str | None:
     """Insert (or refresh) the local ``instances`` row for ``config``.
 
     Ends any stale active row for the same (name, host) first so the
     unique partial index ``instances(name, host, scope) WHERE ended_at
     IS NULL`` never collides on a restart. Returns the new instance id,
     or ``None`` when the runtime can't report a state dir.
+
+    ``db_path`` PINS the store every write below lands in. ``None``
+    keeps the historical behaviour (resolve ``state_db.DEFAULT_DB_PATH``
+    per write, at call time).
+
+    Why the parameter exists (test-isolation bug, 2026-07-14): this
+    function is also reached from the health-monitor's restart callback
+    (:func:`restart_and_record`), which runs on a BACKGROUND DAEMON
+    THREAD that outlives whatever started it. With ``db_path=None``
+    every write re-resolved the module-level ``DEFAULT_DB_PATH`` — a
+    MUTABLE PROCESS-GLOBAL — at call time, so the monitor wrote into
+    whichever database the process happened to consider "default" at
+    the moment it fired. Under pytest that is a *different test's*
+    isolated tmp DB (the auto-grant below then showed up as a stray
+    ``<name> -> lead`` row in an unrelated suite); on a real host with
+    no test redirecting it, it is the live fleet ``state.db``.
+    :func:`_lifecycle._start.agent_start` now resolves the path ONCE
+    and pins it here and into the restart callback, so a monitor always
+    writes to the store its agent was started against.
     """
     from .._runners._session_state import write_instance_id
     from .._state.port_allocator import get_port
@@ -118,11 +143,13 @@ def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
     host = _resolve_host(None)
     # End stale active rows for this name+host (e.g. a previous crash
     # that never reached agent_stop) so the unique index stays clear.
-    for row in list_active_instances(host=host):
+    for row in list_active_instances(host=host, db_path=db_path):
         if row.get("name") == config.name:
-            record_instance_stop(str(row["id"]), exit_reason="superseded")
+            record_instance_stop(
+                str(row["id"]), exit_reason="superseded", db_path=db_path
+            )
 
-    a2a_port = get_port(config.name)
+    a2a_port = get_port(config.name, db_path=db_path)
     workdir = getattr(config, "expanded_workdir", None) or getattr(
         config, "workdir", None
     )
@@ -152,6 +179,7 @@ def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
         remote=False,
         spawned_by=_spawned_by(),
         workdir=str(workdir) if workdir else None,
+        db_path=db_path,
     )
 
     # ADR-0014 Stage 1 — paired comms_nodes write so cross-host peers
@@ -179,6 +207,7 @@ def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
                 source_path=getattr(config, "config_path", None)
                 or getattr(config, "spec_path", None)
                 or f"<spec:{config.name}>",
+                db_path=db_path,
             )
         except Exception:  # stx-allow: fallback (reason: never block agent start on registry write; PR L1's CommsNodeConflictError surfaces here as a logged collision rather than a silent shadow.)
             pass
@@ -199,6 +228,7 @@ def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
             sender=config.name,
             target="lead",
             note="auto-grant on agent_start (op-2026-06-09)",
+            db_path=db_path,
         )
     except Exception:  # stx-allow: fallback (reason: never block agent start on grant write; missing grant degrades to operator running `sac a2a grant <name> lead` manually until next start)
         pass
@@ -209,7 +239,12 @@ def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
     return instance_id
 
 
-def restart_and_record(config: AgentConfig, runtime_factory: Any) -> bool:
+def restart_and_record(
+    config: AgentConfig,
+    runtime_factory: Any,
+    *,
+    db_path: Path | None = None,
+) -> bool:
     """Restart ``config`` via its runtime AND refresh its ``instances`` row.
 
     The health-monitor's restart callback (wired in :mod:`._start`) used to
@@ -235,12 +270,67 @@ def restart_and_record(config: AgentConfig, runtime_factory: Any) -> bool:
 
     Returns whatever ``runtime.start`` returned; the row is refreshed only
     on a successful start (a failed restart must not fabricate a live row).
+
+    ``db_path`` PINS the store the refreshed row (and the ``<self> ->
+    lead`` auto-grant) is written to. This function is the health
+    monitor's restart callback and therefore runs on a long-lived
+    BACKGROUND DAEMON THREAD; resolving the store from the mutable
+    ``state_db.DEFAULT_DB_PATH`` global at call time meant the thread
+    followed that global wherever it moved. See
+    :func:`record_local_instance` for the full incident note.
     """
     runtime = runtime_factory(config)
     started = runtime.start(config)
     if started:
-        record_local_instance(config, runtime)
+        record_local_instance(config, runtime, db_path=db_path)
     return started
+
+
+def make_restart_callback(
+    runtime_factory: Any,
+    *,
+    db_path: Path | None = None,
+) -> Callable[[AgentConfig], bool]:
+    """Build the health-monitor's restart callback with the state.db PINNED.
+
+    :func:`_lifecycle._start.agent_start` spawns :func:`health.health_monitor`
+    on a DAEMON THREAD and hands it this callback. That thread outlives the
+    call that created it — it keeps ticking (``health.interval``, then a
+    restart backoff) long after ``agent_start`` returned.
+
+    The callback must therefore capture WHICH state.db it writes to, once,
+    up front. Previously it did not: it called
+    :func:`restart_and_record` with no ``db_path``, so each write
+    re-resolved ``state_db.DEFAULT_DB_PATH`` — a MUTABLE PROCESS-GLOBAL —
+    at the moment the monitor fired, and landed wherever that global then
+    pointed:
+
+    * under pytest, into a LATER, UNRELATED test's isolated tmp database
+      (its ``<self> -> lead`` auto-grant surfaced as a stray
+      ``target='lead'`` row in a suite that never started an agent — an
+      intermittent red gated by ``health.interval`` + restart backoff,
+      invisible when that suite ran alone);
+    * on a real host with nothing redirecting the global, into the LIVE
+      FLEET ``state.db`` (test agent names ``alpha`` / ``beta`` / ``zombie``
+      were found granted to ``lead`` in production because of this).
+
+    Resolving ``DEFAULT_DB_PATH`` as a module ATTRIBUTE here (never
+    ``from .state_db import DEFAULT_DB_PATH``, which would capture the
+    value at import and be immune to redirection) pins the store at
+    agent_start time. The monitor then always writes to the database its
+    agent was started against.
+    """
+    if db_path is None:
+        from .._state import state_db as _state_db
+
+        db_path = _state_db.DEFAULT_DB_PATH
+
+    pinned = db_path
+
+    def _restart(config: AgentConfig) -> bool:
+        return restart_and_record(config, runtime_factory, db_path=pinned)
+
+    return _restart
 
 
 def end_local_instance(config: AgentConfig, runtime: Any) -> bool:

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -18,8 +18,8 @@ from ..config import AgentConfig, load_config, resolve_config
 from ._a2a_port import resolve_a2a_port
 from ._handover_loader import _load_handover_module
 from ._hook_runner import _fire_forget_hook, _run_hooks
+from ._instances import make_restart_callback as _make_restart_callback
 from ._instances import record_local_instance as _record_local_instance
-from ._instances import restart_and_record as _restart_and_record
 from ._runtime_select import _get_runtime
 from ._session_reset import _clear_persisted_session_id
 from ._spawn_gate import enforce_spawn_gate, persist_acl_policy
@@ -484,8 +484,8 @@ def agent_start(
     _run_hooks(config.hooks.get("post_start", []), extra_env=hook_env)
     _fire_forget_hook(config.name, "post_start", config.hooks.get("post_start", []))
 
-    # Restart callback re-records the row: a restart = a NEW pid. See
-    # ``_instances.restart_and_record`` for why a stale pid is dangerous.
+    # Restart callback re-records the row (a restart = a NEW pid) AND pins
+    # the state.db it writes to -- see ``_instances.make_restart_callback``.
     if config.health.enabled:
         thread = thread_factory(
             target=health_monitor,
@@ -493,7 +493,7 @@ def agent_start(
                 config.name,
                 config,
                 registry,
-                lambda c: _restart_and_record(c, runtime_factory),
+                _make_restart_callback(runtime_factory),
             ),
             daemon=True,
         )

--- a/src/scitex_agent_container/_state/state_db_grants.py
+++ b/src/scitex_agent_container/_state/state_db_grants.py
@@ -108,10 +108,39 @@ def has_grant(
 def list_comms_grants(
     db_path: Path | None = None,
 ) -> list[dict[str, Any]]:
-    """Return every grant row in insertion order.
+    """Return every grant row in INSERTION order (SQLite ``rowid``).
 
     Observability surface for the host operator. Each row carries the
     audit ``note`` (default: the deferred-identity caveat).
+
+    Ordering contract — the docstring is authoritative, the old
+    ``ORDER BY`` was the bug (fixed 2026-07-14). Both callers want
+    insertion order (``sac a2a grants`` documents "rows are emitted in
+    insertion order"; the tests assert it); NOTHING wants alphabetical.
+    The previous clause ::
+
+        ORDER BY created_at ASC, sender_name ASC, target_name ASC
+
+    only APPROXIMATED that, and lied in two ways:
+
+    * ``created_at`` is a wall-clock ``time.time()`` float, so equal
+      timestamps fall through to the ALPHABETICAL tiebreak. Ties are
+      real, not theoretical: :func:`state_db_export.import_state`
+      bulk-imports peer rows carrying the PEER's ``created_at``
+      verbatim.
+    * Wall clocks skew and step across hosts, so an imported row can
+      carry a SMALLER ``created_at`` than a row inserted locally before
+      it — and then sorts ahead of it. That is not insertion order by
+      any reading.
+
+    The net effect was that a foreign row sorted into a plausible-looking
+    position instead of standing out, which is precisely what let a
+    leaked ``-> lead`` grant hide inside this listing.
+
+    ``comms_grants`` is a plain rowid table (no ``WITHOUT ROWID``), so
+    the implicit ``rowid`` IS the true insertion order: monotonic,
+    tie-free and immune to clock skew. ``created_at`` stays in the
+    payload — it is useful audit data, just not a sort key.
     """
     from .state_db import open_db
 
@@ -119,7 +148,7 @@ def list_comms_grants(
         cur = conn.execute(
             "SELECT sender_name, target_name, created_at, note "
             "FROM comms_grants "
-            "ORDER BY created_at ASC, sender_name ASC, target_name ASC"
+            "ORDER BY rowid ASC"
         )
         return [
             {

--- a/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
@@ -129,3 +129,160 @@ def test_record_local_instance_returns_instance_id_when_grant_write_succeeds(
     # Assert — record_local_instance documents ``str | None``; on the
     # happy path with a writeable state.db it MUST return the id string.
     assert isinstance(instance_id, str)
+
+
+# ---------------------------------------------------------------------------
+# REGRESSION (2026-07-14) — the auto-grant must not escape into a FOREIGN
+# state.db.
+#
+# ``agent_start`` runs ``health_monitor`` on a DAEMON THREAD and hands it a
+# restart callback -> ``restart_and_record`` -> ``record_local_instance`` ->
+# ``grant_send(target="lead")``. That thread OUTLIVES the call that made it
+# (it wakes after ``health.interval`` + a restart backoff, ~90 s with the
+# shipped defaults).
+#
+# The callback used to take no ``db_path``, so each write re-resolved
+# ``state_db.DEFAULT_DB_PATH`` -- a MUTABLE PROCESS-GLOBAL -- at the moment
+# the monitor fired. Whatever the process then called "default" got the row:
+#
+#   * under pytest, a LATER, UNRELATED test's isolated tmp DB. That is the
+#     stray ``target='lead'`` grant that made
+#     cli_pkg/test_a2a_group.py's ``grants`` tests fail intermittently in
+#     full-suite runs while passing when run alone.
+#   * on a bare host with nothing redirecting the global, the LIVE FLEET
+#     state.db (``alpha``/``beta``/``zombie`` -> ``lead`` rows were found in
+#     production, written by this suite).
+#
+# The thread is captured rather than started: waiting ~90 s of real backoff
+# would make the test slow AND flaky, and the point under test is WHICH DB
+# the callback writes to, not that Python can run a thread. ``thread_factory``
+# is a first-class injectable seam on ``agent_start`` (production default:
+# ``threading.Thread``), already used this way by test_lifecycle.py.
+# ---------------------------------------------------------------------------
+
+
+class _CapturingThread:
+    """Honest stand-in for ``threading.Thread``: records target + args and
+    never spawns a real thread, so the monitor's restart callback can be
+    fired deterministically instead of waited on."""
+
+    def __init__(self, *, target=None, args=(), daemon=False, **_kw) -> None:
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+
+class _DeadRuntime:
+    """Runtime that reports the agent as never running, so the health
+    monitor's restart path is the one under test."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+        self.start_calls: list[str] = []
+
+    def is_running(self, config: AgentConfig, **_kw) -> bool:
+        return False
+
+    def start(self, config: AgentConfig, **_kw) -> bool:
+        self.start_calls.append(config.name)
+        return True
+
+    def stop(self, config: AgentConfig, **_kw) -> bool:
+        return True
+
+    def _state_dir(self, config: AgentConfig) -> Path:
+        return self._root / config.name
+
+
+def _write_health_spec(tmp_path: Path, name: str) -> Path:
+    """v3 ``spec.yaml`` with health ENABLED (so agent_start spawns the
+    monitor). Dir-as-SSoT: the agent name comes from the parent dir."""
+    agent_dir = tmp_path / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+        "  host: ${HOSTNAME}\n"
+        f"  workdir: {tmp_path / 'work'}\n"
+        "  apptainer:\n    image: /x.sif\n    binds: []\n"
+        "  health:\n    enabled: true\n    interval: 60\n"
+        "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+        "  claude:\n    model: sonnet\n"
+    )
+    return spec
+
+
+def _fire_monitor_restart_against_foreign_db(
+    db_path: Path, tmp_path: Path, name: str
+) -> Path:
+    """Arrange + Act: start a health-monitored agent against ``db_path``,
+    then move the process-global default to a FOREIGN db and fire the
+    monitor's restart callback (what the leaked daemon thread does on its
+    next tick). Returns the foreign db path for the caller to assert on."""
+    from scitex_agent_container._lifecycle import lifecycle as lc
+    from scitex_agent_container._state import state_db
+    from scitex_agent_container._state.registry import Registry
+
+    created: list[_CapturingThread] = []
+
+    def _thread_factory(**kwargs) -> _CapturingThread:
+        t = _CapturingThread(**kwargs)
+        created.append(t)
+        return t
+
+    lc.agent_start(
+        str(_write_health_spec(tmp_path, name)),
+        registry=Registry(registry_dir=tmp_path / "reg"),
+        runtime_factory=lambda _c: _DeadRuntime(tmp_path),
+        sleep_fn=lambda _s: None,
+        thread_factory=_thread_factory,
+    )
+    assert created and created[0].started, "agent_start did not start a monitor"
+    restart_cb = created[0].args[3]
+    config = created[0].args[1]
+
+    # An unrelated LATER test isolates itself: the process-global moves.
+    foreign = tmp_path / "foreign" / "state.db"
+    state_db.init_schema(foreign)
+    saved = state_db.DEFAULT_DB_PATH
+    state_db.DEFAULT_DB_PATH = foreign
+    try:
+        restart_cb(config)  # the leaked monitor thread fires
+    finally:
+        state_db.DEFAULT_DB_PATH = saved
+    return foreign
+
+
+def test_monitor_restart_does_not_auto_grant_into_a_foreign_state_db(
+    db_path: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    from scitex_agent_container._state.state_db_nodes import list_comms_grants
+
+    name = "pinned-1"
+    # Act — the leaked monitor thread fires while the global points elsewhere.
+    foreign = _fire_monitor_restart_against_foreign_db(db_path, tmp_path, name)
+    # Assert — the unrelated store MUST be untouched. Pre-fix it held
+    # ("pinned-1" -> "lead"): exactly the stray target='lead' row that made
+    # cli_pkg/test_a2a_group.py's grants tests red in full-suite runs.
+    assert list_comms_grants(db_path=foreign) == []
+
+
+def test_monitor_restart_auto_grants_into_the_db_the_agent_started_against(
+    db_path: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    from scitex_agent_container._state.state_db_nodes import has_grant
+
+    name = "pinned-2"
+    # Act — same drive, asserting the other half of the contract.
+    _fire_monitor_restart_against_foreign_db(db_path, tmp_path, name)
+    # Assert — pinning must not LOSE the write, only aim it correctly.
+    assert has_grant(sender=name, target="lead", db_path=db_path) is True

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -541,6 +541,70 @@ def test_list_comms_grants_returns_each_grant_pair(db_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# ORDERING CONTRACT (2026-07-14) — ``list_comms_grants`` documents INSERTION
+# order and both callers rely on it (``sac a2a grants`` says "rows are
+# emitted in insertion order"); nothing wants alphabetical. It used to sort
+# by ``ORDER BY created_at ASC, sender_name ASC, target_name ASC``, which
+# only APPROXIMATES insertion order and lies whenever the wall-clock
+# ``created_at`` ties (-> falls through to the ALPHABETICAL tiebreak) or
+# skews (-> a peer row sorts ahead of a locally-earlier one).
+#
+# Neither case is theoretical: ``import_state`` bulk-imports peer rows
+# carrying the PEER's ``created_at`` verbatim, and peer clocks drift. The
+# rows below are written through the real ``open_db`` connection with
+# explicit timestamps -- exactly the shape ``import_state`` produces. Real
+# SQLite, real rows, no mocks.
+#
+# The pre-existing insertion-order test could not catch this: it inserted
+# "first-sender" then "second-sender", which are in the SAME order
+# alphabetically as by insertion, so it passed under both implementations.
+# ---------------------------------------------------------------------------
+
+
+def _insert_grant_at(db_path: Path, sender: str, target: str, created_at: float) -> None:
+    """Write one ``comms_grants`` row with an EXPLICIT ``created_at``.
+
+    ``grant_send`` stamps ``time.time()`` internally, so a tie / skew can't
+    be expressed through it. This is the same INSERT ``import_state`` uses
+    when it replays a peer's rows.
+    """
+    from scitex_agent_container._state.state_db import open_db
+
+    with open_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO comms_grants "
+            "(sender_name, target_name, created_at, note) VALUES (?, ?, ?, ?)",
+            (sender, target, created_at, None),
+        )
+
+
+def test_list_comms_grants_keeps_insertion_order_when_timestamps_tie(
+    db_path: Path,
+) -> None:
+    # Arrange — same created_at, inserted in NON-alphabetical order. The old
+    # clause fell through to `sender_name ASC` and returned "alpha" first.
+    _insert_grant_at(db_path, "zeta", "lead", 100.0)
+    _insert_grant_at(db_path, "alpha", "lead", 100.0)
+    # Act
+    rows = list_comms_grants(db_path=db_path)
+    # Assert
+    assert [r["sender"] for r in rows] == ["zeta", "alpha"]
+
+
+def test_list_comms_grants_keeps_insertion_order_when_peer_clock_is_behind(
+    db_path: Path,
+) -> None:
+    # Arrange — a peer row imported LATER but stamped EARLIER (clock skew).
+    # The old clause sorted by created_at and put the peer's row first.
+    _insert_grant_at(db_path, "local-first", "lead", 200.0)
+    _insert_grant_at(db_path, "peer-imported-later", "lead", 100.0)
+    # Act
+    rows = list_comms_grants(db_path=db_path)
+    # Assert
+    assert [r["sender"] for r in rows] == ["local-first", "peer-imported-later"]
+
+
+# ---------------------------------------------------------------------------
 # node_tokens — authenticated identity primitive (handoff §4 acceptance)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## The bug

`cli_pkg/test_a2a_group.py`'s **grants** tests are red on `develop`, intermittently, in full-suite runs — and green when the file runs alone. A stray grant row with `target='lead'` appears in their isolated DB.

## True root cause (deterministically reproduced)

`agent_start` runs `health_monitor` on an **un-joined daemon thread**. Its restart callback chain is:

```
health_monitor (daemon thread, outlives the test)
  -> restart_and_record
    -> record_local_instance
      -> grant_send(sender=<name>, target="lead", db_path=None)
```

`db_path=None` re-resolves `state_db.DEFAULT_DB_PATH` — a **mutable process-global** — *at the moment the monitor fires*, which is long after `agent_start` returned (`health.interval`, then a **30 s restart backoff**; ~90 s with the shipped defaults).

So the thread writes to whatever DB the process calls "default" **when it fires**, not the one its agent was started against:

- **Under pytest** → a *later, unrelated* test's isolated tmp DB. That is the stray `target='lead'` row. It is intermittent because it is gated on the backoff timer lining up with whichever test is running ~90 s later, and invisible when the file runs alone because no agent was ever started.
- **On a real host** → the **live fleet `state.db`**. Grants for the test agent names `alpha`, `beta` and `zombie` are sitting in production *right now*, written by this suite (note: `auto-grant on agent_start`). **CI cannot see this** — a runner has no fleet DB — which is why it survived.

The previously-suspected cause (`test__acl_approve_flow.py:371`'s `CliRunner` grant escaping) is **refuted**: that fixture redirects both the env var *and* the module constant, and the file does not reproduce the failure (verified: 32 passed with the grants file in the same process).

## Fix

- `_instances.make_restart_callback()` resolves `DEFAULT_DB_PATH` **once**, as a module *attribute* (never `from ... import DEFAULT_DB_PATH`, which captures at import and is immune to redirection), and pins it into the callback.
- `record_local_instance` / `restart_and_record` gain a `db_path` and thread it into **every** write (`instances`, `comms_nodes`, the auto-grant, the port claim).
- A monitor now always writes where its agent lives. **No production behaviour change** — on a real host the pinned path *is* the default one. `_start.py` is a net-zero-line change (it sits on the 512-line cap).

## Second defect: `list_comms_grants` order/docstring contradiction

The docstring promised *insertion order*; the clause was `ORDER BY created_at ASC, sender_name ASC, target_name ASC`, which only *approximates* it and lies twice:

- equal wall-clock `created_at` values fall through to the **alphabetical** tiebreak — and ties are real, since `import_state` replays a peer's `created_at` verbatim;
- peer **clock skew** can sort an imported row *ahead* of a locally-earlier one.

Both callers want insertion order (`sac a2a grants` documents it; the tests assert it) and **nothing** wants alphabetical — so the **docstring was right and the clause was the bug**. Fixed to `ORDER BY rowid ASC`: `comms_grants` is a plain rowid table, so `rowid` *is* insertion order — monotonic, tie-free, skew-proof. `created_at` stays in the payload as audit data, just not as a sort key.

That alphabetical tiebreak is also what made the leak **silent**: it sorted the foreign row into a plausible-looking position instead of leaving it obviously out of place.

## Fail-first proof

Verified **red against the unfixed source** (`git stash push -- src/`), then green:

```
FAILED test_monitor_restart_does_not_auto_grant_into_a_foreign_state_db
  AssertionError: assert [...] == []
  Left contains one more item:
    {'sender': 'pinned-1', 'target': 'lead',
     'note': 'auto-grant on agent_start (op-2026-06-09)'}   <-- the stray row

FAILED test_list_comms_grants_keeps_insertion_order_when_timestamps_tie
  assert ['alpha', 'zeta'] == ['zeta', 'alpha']              <-- alphabetical, not insertion

FAILED test_list_comms_grants_keeps_insertion_order_when_peer_clock_is_behind
  assert ['peer-imported-later', 'local-first'] == ['local-first', 'peer-imported-later']
```

The monitor's thread is **captured** through the existing `thread_factory` seam (a first-class injectable on `agent_start`, already used this way by `test_lifecycle.py`) rather than slept on — waiting out ~90 s of real backoff would be slow *and* flaky, and the point under test is *which DB* the callback writes to.

The old insertion-order test could catch neither ordering bug: it inserted `first-sender` then `second-sender`, which sort identically alphabetically and by insertion — it passed for the wrong reason.

## Verification

`228 passed` across everything the change touches, including the victim file:

- `_lifecycle/test__instances_auto_grant.py` (+2 new), `test__instances_pid.py`, `test_lifecycle.py`, `test__stale_lease.py`
- `_state/test_state_db_nodes.py` (+2 new)
- **`cli_pkg/test_a2a_group.py`** (all 44 — the victim)
- `_listen/test__acl_approve_flow.py` (the refuted suspect)

## Known residual (deliberately NOT in this PR)

The pinning fix stops a monitor from polluting *another* store. It does **not** help a test that never isolates in the first place — those still write the process-default DB (= production on a real host). **5 test files call `agent_start` with no state.db isolation at all**:

- `_mcp/_tools/test___init__.py`, `_mcp/_tools/test__agent_start.py`
- `_lifecycle/test__start_drift.py`, `_lifecycle/test__restart_preflight_integration.py`
- `cli_pkg/lifecycle/test__start_force_clears_session.py`

(plus a few `test_lifecycle.py` tests that skip its own `isolated_state_db` fixture — that is how `alpha -> lead` reached production).

I wrote the systemic guard for this (an autouse conftest fixture defaulting every test's state.db to a tmp path, redirecting **both** the env var and the import-time constant) and then **pulled it from this PR**: it touches all 4883 tests in the package, and the one file that could plausibly break under it (`test__broker_self.py`, which bootstraps a real `sac listen` subprocess per test) takes ~5 min/test to validate. Given three releases have already ghosted this week, I am not putting an unvalidated broad change in the release-unblocking PR. It gets its own PR with a full-suite run.

Also: the 3 stray rows (`alpha`/`beta`/`zombie` -> `lead`) are still in the production fleet `state.db`. Harmless (they permit sends from agents that do not exist) but they are test garbage — purging them is an operator call, so I have not touched it.