### PR TITLE
feat(freshness): sac warns on EVERY invocation when it is not what shipped — ghost tags, stale installs, stale daemons

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,6 +324,10 @@ exclude = [".git"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "src/scitex_agent_container/cron/post-merge-pull.sh" = "scitex_agent_container/cron/post-merge-pull.sh"
+# The deploy-freshness alarm (cron half of `sac freshness`). Must ship in
+# the wheel: it is what writes the cache the every-invocation CLI warning
+# reads, so a host that installs sac from PyPI gets the alarm with it.
+"src/scitex_agent_container/cron/deploy-freshness-alarm.py" = "scitex_agent_container/cron/deploy-freshness-alarm.py"
 # Bundle pyproject.toml + README.md inside the wheel so the
 # source-bundled SIF build (cli_pkg/_image_source_build.py) can
 # reconstruct a pip-installable source tree from the INSTALLED

--- a/src/scitex_agent_container/_freshness/__init__.py
+++ b/src/scitex_agent_container/_freshness/__init__.py
@@ -1,0 +1,100 @@
+"""Deploy freshness: is the code we are running the code that shipped?
+
+Born from the 2026-07-13/14 comms outage. Seven PRs fixed a `sac listen`
+wedge; every one merged; the host ran 0.21.14 the entire time, which
+predates all of them. Agents hand-drained the wedged pool and re-diagnosed
+the same already-fixed bug for a day, because three consecutive tags never
+reached PyPI and NOTHING anywhere said a word.
+
+    "We are not failing to FIX these bugs. We are failing to SHIP them."
+
+The drift is structural, not bad luck. A release is
+``tag -> test -> build -> publish``. The tag is a local action that always
+succeeds; everything downstream is asynchronous and can fail silently. No
+consumer ever compares what it is running against what actually shipped,
+so drift is monotonic — it can only accumulate, never self-correct. (Six
+of the eighteen v0.21.x tags never published. The operator knew about two.)
+
+This package closes the loop: the consumer checks itself, and speaks up.
+
+* :mod:`._checks`  — the four failure modes, which are genuinely different
+  and do not catch each other: ghost tag / host behind PyPI / running !=
+  installed / release run failed.
+* :mod:`._symbols` — probes a fix by the SYMBOL it introduced, never by a
+  version string (which lies in both directions here).
+* :mod:`._warn`    — the every-invocation stderr warning. The operator's
+  primary ask: typing ``sac`` is how you find out.
+* :mod:`._cache`   — cron writes, CLI reads. The CLI never does I/O beyond
+  one small JSON file.
+
+Three states, and the middle one is the reason this works:
+**FRESH / STALE / UNKNOWN.** Only STALE ever speaks. UNKNOWN is silent —
+never "fine", and never a remedy either, because a false RED gets acted on
+and the action destroys a healthy thing.
+
+Imports here are LAZY (PEP 562). ``_sources`` pulls in urllib and
+subprocess, and this package sits in the CLI's import graph — an eager
+import would put ~15 ms of urllib on every ``sac --help``, against a
+~150 ms budget for the entire CLI.
+"""
+
+from __future__ import annotations
+
+from ._model import Finding, Freshness, FreshnessReport
+
+__all__ = [
+    "EXPECTATIONS",
+    "Finding",
+    "Freshness",
+    "FreshnessReport",
+    "LiveSources",
+    "StaticSources",
+    "SymbolExpectation",
+    "build_report",
+    "cache_path",
+    "check_ghost_tags",
+    "check_host_behind_pypi",
+    "check_release_runs",
+    "check_running_vs_installed",
+    "check_symbols",
+    "probe",
+    "read_cache",
+    "warn_if_stale",
+    "write_cache",
+]
+
+# name -> submodule holding it. Resolved on first attribute access so the
+# CLI never pays for urllib/subprocess just by importing the package.
+_LAZY = {
+    "EXPECTATIONS": "._symbols",
+    "SymbolExpectation": "._symbols",
+    "probe": "._symbols",
+    "LiveSources": "._sources",
+    "StaticSources": "._sources",
+    "build_report": "._checks",
+    "check_ghost_tags": "._checks",
+    "check_host_behind_pypi": "._checks",
+    "check_release_runs": "._checks",
+    "check_running_vs_installed": "._checks",
+    "check_symbols": "._checks",
+    "cache_path": "._cache",
+    "read_cache": "._cache",
+    "write_cache": "._cache",
+    "warn_if_stale": "._warn",
+}
+
+
+def __getattr__(name: str):
+    module = _LAZY.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    return getattr(import_module(module, __name__), name)
+
+
+def __dir__():
+    return sorted(__all__)
+
+
+# EOF

--- a/src/scitex_agent_container/_freshness/_cache.py
+++ b/src/scitex_agent_container/_freshness/_cache.py
@@ -1,0 +1,166 @@
+"""The cache: written by the refresher, read by every ``sac`` invocation.
+
+WHY A CACHE AND NOT A LOOKUP
+---------------------------
+The warning has to appear when the operator types ``sac`` — that is the
+whole point; a README nobody opens is not a control. But a PyPI lookup in
+the CLI hot path would be a ~200-2000 ms network round trip on every
+single command, and would HANG the CLI on a flaky link. A version check
+that makes ``sac`` slow, or that wedges it when the network is bad, gets
+switched off within a day, and then there is no check at all.
+
+So the two halves are split by who can afford to wait:
+
+* the **refresher** (cron / ``sac freshness refresh``) pays the network
+  cost, off the interactive path, and writes this file;
+* the **CLI** reads this file and nothing else. No socket, no subprocess.
+
+STALE CACHE IS UNKNOWN, AND UNKNOWN IS SILENT
+---------------------------------------------
+Beyond ``ttl_s`` we do not trust our own file. An old cache means the
+refresher died, and a dead refresher's last answer is not evidence about
+the present — it is a fossil. Returning it would be the same class of
+bug as the one this subsystem exists to kill: a confident statement
+backed by nothing current. So an expired cache reads as ``None``
+(UNKNOWN), and UNKNOWN says nothing at all.
+
+Default TTL is 24 h against an hourly refresher — 24 consecutive misses
+before we fall silent. Deliberately generous: this host runs at load ~60
+and a cron job can simply not get scheduled for a long while. A tight TTL
+here would not make us safer, it would just make us blind and noisy by
+turns.
+
+PATH RESOLUTION
+---------------
+``scitex_config._ecosystem.local_state`` is the ecosystem's canonical
+resolver and would be the natural import — but it costs **1.59 s** to
+import (measured: ``python -X importtime`` => 1,593,638 us cumulative),
+and this module is on a path with a ~150 ms budget for the WHOLE CLI.
+Importing it here would make every ``sac`` command ten times slower,
+which is a guaranteed revert.
+
+So the one-line contract (``$SCITEX_DIR``, default ``~/.scitex``) is
+mirrored in stdlib here, and ``test__cache.py`` asserts our resolution
+equals ``local_state``'s for both the default and the ``$SCITEX_DIR``
+override. If the ecosystem ever changes that contract, the test fails
+loudly instead of the two silently disagreeing about where the file is.
+That is SSOT held by a test rather than by an import we cannot afford.
+
+Everything is resolved AT CALL TIME. Nothing here is a module-level
+``Path.home()`` constant: ``$HOME`` is ``/home/agent`` inside a container
+and ``/home/ywatanabe`` on the host, and an import-time constant cannot
+be redirected by a test fixture (or by a container) that sets the env
+afterwards. That bug has already cost this repo a day.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from ._model import FreshnessReport
+
+__all__ = ["DEFAULT_TTL_S", "cache_path", "read_cache", "write_cache"]
+
+# 24 h against an hourly refresher. See module docstring.
+DEFAULT_TTL_S = 24 * 60 * 60
+
+# Relative fragment only — never joined to a home dir at import time.
+_CACHE_SUBPATH = ("agent-container", "runtime", "deploy-freshness.json")
+
+_ENV_CACHE = "SAC_FRESHNESS_CACHE"
+_ENV_SCITEX_DIR = "SCITEX_DIR"
+_ENV_TTL = "SAC_FRESHNESS_TTL_S"
+
+
+def scitex_dir() -> Path:
+    """``$SCITEX_DIR``, else ``~/.scitex``. Resolved per call.
+
+    Mirrors ``scitex_config._ecosystem.local_state.user_root()``; the
+    equivalence is pinned by a test rather than by an import we cannot
+    afford on the CLI hot path (see module docstring).
+    """
+    env = os.environ.get(_ENV_SCITEX_DIR)
+    return Path(env) if env else Path.home() / ".scitex"
+
+
+def cache_path() -> Path:
+    """Where the freshness cache lives. Resolved per call.
+
+    ``$SAC_FRESHNESS_CACHE`` overrides it outright — that is the seam
+    tests use, and the way a container can be pointed at the host's
+    cache instead of its own empty ``$HOME``.
+    """
+    override = os.environ.get(_ENV_CACHE)
+    if override:
+        return Path(override)
+    return scitex_dir().joinpath(*_CACHE_SUBPATH)
+
+
+def ttl_s() -> int:
+    """Cache lifetime. ``$SAC_FRESHNESS_TTL_S`` overrides the default.
+
+    A garbage value falls back to the default rather than raising — a
+    typo in an env var must not break ``sac``.
+    """
+    raw = os.environ.get(_ENV_TTL)
+    if not raw:
+        return DEFAULT_TTL_S
+    try:
+        value = int(raw)
+    except ValueError:  # stx-allow: fallback (reason: a malformed env var must not break the CLI; the default is the safe answer)
+        return DEFAULT_TTL_S
+    return value if value > 0 else DEFAULT_TTL_S
+
+
+def write_cache(report: FreshnessReport, path: Path | None = None) -> Path:
+    """Atomically publish a report. Returns the path written.
+
+    tmp + ``os.replace`` so a reader never sees a half-written file: the
+    CLI reads this on every invocation, and a torn read would surface as
+    a spurious UNKNOWN at best.
+    """
+    target = path or cache_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(json.dumps(report.to_dict(), indent=2), encoding="utf-8")
+    os.replace(tmp, target)
+    return target
+
+
+def read_cache(
+    path: Path | None = None,
+    *,
+    now: float | None = None,
+    max_age_s: int | None = None,
+) -> FreshnessReport | None:
+    """Load the cached report, or ``None`` when it cannot be trusted.
+
+    ``None`` (=> UNKNOWN => silence) for every one of: no file, an
+    unreadable file, malformed JSON, a report with no timestamp, and a
+    report older than the TTL. Each of those is an absence of current
+    evidence, and this function refuses to dress any of them up as an
+    answer.
+    """
+    target = path or cache_path()
+    try:
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, ValueError):  # stx-allow: fallback (reason: missing/corrupt cache is UNKNOWN by design -- the caller stays silent)
+        return None
+    if not isinstance(raw, dict):
+        return None
+
+    report = FreshnessReport.from_dict(raw)
+    if not report.generated_at:
+        return None
+
+    age = (time.time() if now is None else now) - report.generated_at
+    limit = ttl_s() if max_age_s is None else max_age_s
+    if age > limit:
+        return None
+    return report
+
+
+# EOF

--- a/src/scitex_agent_container/_freshness/_checks.py
+++ b/src/scitex_agent_container/_freshness/_checks.py
@@ -1,0 +1,352 @@
+"""The four conditions, plus the symbol probe. Pure verdicts, no I/O.
+
+Each of the four fails in a DIFFERENT way, which is why each is a
+separate check and none of them subsumes another:
+
+1. ``ghost-tag``           — a tag exists, PyPI has no such release. The
+   release *looks* done (the tag is right there) and is not. This is the
+   one that ran for a full day unnoticed.
+2. ``host-behind-pypi``    — what shipped is newer than what is installed.
+3. ``running-vs-installed``— what is installed is newer than what the live
+   daemon is executing. Installed is NOT running: Python does not reload
+   a module in a live process, so an upgrade changes nothing at all until
+   a restart.
+4. ``release-run``         — the release workflow ended in failure and sat
+   red in a tab nobody opens.
+
+A check for any one of these is blind to the other three. On
+2026-07-13 all four were true at once and the fleet saw none of them.
+"""
+
+from __future__ import annotations
+
+import time
+
+from . import _version
+from ._model import Finding, Freshness, FreshnessReport
+from ._symbols import EXPECTATIONS, probe
+
+__all__ = [
+    "build_report",
+    "check_ghost_tags",
+    "check_host_behind_pypi",
+    "check_release_runs",
+    "check_running_vs_installed",
+    "check_symbols",
+]
+
+# A run that has not finished yet says nothing about whether it will ship.
+_TERMINAL = "completed"
+
+
+def _unknown(check: str, why: str) -> Finding:
+    """UNKNOWN carries its reason. 'I don't know' is only useful with a
+    'because'."""
+    return Finding(check=check, state=Freshness.UNKNOWN, summary=why)
+
+
+def check_host_behind_pypi(installed, latest, *, python=None) -> Finding:
+    """Is the installed package older than the newest PyPI release?"""
+    check = "host-behind-pypi"
+    if not installed:
+        return _unknown(check, "installed version unknown (package not installed?)")
+    if not latest:
+        return _unknown(check, "PyPI unreachable — cannot tell what shipped")
+
+    behind = _version.is_behind(installed, latest)
+    if behind is None:
+        return _unknown(
+            check, f"cannot order versions {installed!r} vs {latest!r}"
+        )
+    if not behind:
+        return Finding(
+            check=check,
+            state=Freshness.FRESH,
+            summary=f"installed {installed} is current with PyPI ({latest})",
+            data={"installed": installed, "pypi_latest": latest},
+        )
+
+    exe = python or "python"
+    return Finding(
+        check=check,
+        state=Freshness.STALE,
+        summary=f"installed {installed} is BEHIND PyPI {latest}",
+        remedy=f"{exe} -m pip install -U '{_DIST}=={latest}'",
+        detail=(
+            "The fixes released between these two versions are NOT running "
+            "on this machine. Upgrading is not enough on its own — any "
+            "long-lived process (sac listen, MCP servers) also has to be "
+            "restarted, because Python does not reload modules in a live "
+            "process."
+        ),
+        data={"installed": installed, "pypi_latest": latest},
+    )
+
+
+def check_ghost_tags(tags, released) -> Finding:
+    """A tag with no PyPI release: ``git tag`` succeeded, shipping did not.
+
+    The verdict keys on the **head** tag — the newest one — and this is
+    the whole design:
+
+    * head tag not on PyPI => STALE. The last thing we tried to ship did
+      not ship. This is the live, actionable failure, and it is exactly
+      the state the repo was in from 23:24 on 2026-07-13 (head v0.21.16,
+      PyPI 0.21.14) until v0.21.17 published a day later.
+    * head tag published, older ghosts behind it => FRESH, but every
+      ghost is still NAMED in the summary and in ``data``. They are real
+      (v0.21.15 and v0.21.16 never shipped), they stay visible in ``sac
+      freshness check`` -- and they raise no alarm, because a superseded
+      ghost has no remedy and an alarm with no remedy is noise that gets
+      the whole check switched off.
+
+    That split is also self-cleaning: a deliberately-abandoned tag stops
+    being the head as soon as a later version ships, and goes quiet on
+    its own. No allowlist to maintain, and no way to abandon the HEAD tag
+    without either shipping something newer or deleting the tag.
+    """
+    check = "ghost-tag"
+    if tags is None:
+        return _unknown(check, "no git checkout — cannot read release tags")
+    if released is None:
+        return _unknown(check, "PyPI unreachable — cannot tell what shipped")
+    if not tags:
+        return _unknown(check, "no release tags found")
+
+    published = {k for k in (_version.parse(v) for v in released) if k is not None}
+    ordered = sorted(
+        ((_version.parse(t), t) for t in tags if _version.parse(t) is not None),
+        key=lambda pair: pair[0],
+    )
+    if not ordered:
+        return _unknown(check, "no parseable release tags")
+
+    ghosts = [tag for key, tag in ordered if key not in published]
+    head_key, head_tag = ordered[-1]
+    head_is_ghost = head_key not in published
+
+    data = {
+        "ghosts": ghosts,
+        "head_tag": head_tag,
+        "head_is_ghost": head_is_ghost,
+        "pypi_latest_published": _version.latest(released),
+    }
+
+    if head_is_ghost:
+        return Finding(
+            check=check,
+            state=Freshness.STALE,
+            summary=(
+                f"GHOST TAG: {head_tag} is tagged but NEVER reached PyPI "
+                f"(newest published: {_version.latest(released) or 'none'})"
+            ),
+            remedy=(
+                "gh run list --workflow pypi-publish-and-github-release-on-tag.yml"
+                "   # then re-run the failed release, or re-tag"
+            ),
+            detail=(
+                "The tag exists, so the release LOOKS done. It is not: "
+                "nothing was published. Anyone who assumes this fix is live "
+                "is wrong, and will re-diagnose an already-fixed bug."
+            ),
+            data=data,
+        )
+
+    if ghosts:
+        return Finding(
+            check=check,
+            state=Freshness.FRESH,
+            summary=(
+                f"head tag {head_tag} published OK; "
+                f"{len(ghosts)} older tag(s) never shipped and were "
+                f"superseded: {' '.join(ghosts)}"
+            ),
+            detail=(
+                "Superseded ghosts: each of these tags exists in git but has "
+                "no PyPI release. A later version did ship, so there is "
+                "nothing to fix and no alarm is raised — but they are why "
+                "the tag list cannot be trusted as a record of what shipped. "
+                "Delete them if you want the history to stop lying."
+            ),
+            data=data,
+        )
+
+    return Finding(
+        check=check,
+        state=Freshness.FRESH,
+        summary=f"every release tag reached PyPI (head: {head_tag})",
+        data=data,
+    )
+
+
+def check_running_vs_installed(daemon_started_at, installed_at, *, unit) -> Finding:
+    """Is a live daemon still executing code from before the last upgrade?
+
+    Installed is not running. ``pip install -U`` rewrites files on disk;
+    it does not — cannot — reach into a running process and swap the
+    modules it imported at boot. Until the daemon restarts, the upgrade
+    has changed precisely nothing about what is executing.
+    """
+    check = "running-vs-installed"
+    if daemon_started_at is None:
+        return _unknown(check, f"{unit} is not running (or not under systemd)")
+    if installed_at is None:
+        return _unknown(check, "cannot determine when the package was installed")
+
+    if installed_at <= daemon_started_at:
+        return Finding(
+            check=check,
+            state=Freshness.FRESH,
+            summary=f"{unit} started after the last install — running current code",
+            data={"daemon_started_at": daemon_started_at, "installed_at": installed_at},
+        )
+
+    lag_h = (installed_at - daemon_started_at) / 3600.0
+    return Finding(
+        check=check,
+        state=Freshness.STALE,
+        summary=(
+            f"{unit} is RUNNING PRE-UPGRADE CODE — it started "
+            f"{lag_h:.1f}h before the package was last installed"
+        ),
+        remedy=f"systemctl --user restart {unit}",
+        detail=(
+            "The package on disk was upgraded while this daemon was already "
+            "running. Python does not reload modules in a live process, so "
+            "the daemon is still executing the OLD code and will keep doing "
+            "so until it is restarted. `sac --version` will report the NEW "
+            "version the whole time, which is why the version string cannot "
+            "be trusted to answer this."
+        ),
+        data={
+            "daemon_started_at": daemon_started_at,
+            "installed_at": installed_at,
+            "lag_hours": lag_h,
+        },
+    )
+
+
+def check_release_runs(runs) -> Finding:
+    """Did the most recent finished release run actually succeed?
+
+    Anything that is not ``success`` — ``failure``, ``cancelled``,
+    ``timed_out`` — shipped nothing. v0.21.16's run FAILED and v0.21.15's
+    was CANCELLED; both left a tag behind and neither published, so
+    treating "not success" as one class is not pedantry, it is the two
+    real cases.
+    """
+    check = "release-run"
+    if runs is None:
+        return _unknown(check, "gh unavailable — cannot read release runs")
+
+    finished = [r for r in runs if (r or {}).get("status") == _TERMINAL]
+    if not finished:
+        return _unknown(check, "no completed release runs found")
+
+    last = finished[0]
+    conclusion = last.get("conclusion")
+    ref = last.get("headBranch") or "?"
+    if conclusion == "success":
+        return Finding(
+            check=check,
+            state=Freshness.FRESH,
+            summary=f"last release run ({ref}) succeeded",
+            data={"conclusion": conclusion, "ref": ref, "url": last.get("url")},
+        )
+
+    return Finding(
+        check=check,
+        state=Freshness.STALE,
+        summary=f"last release run ({ref}) ended in {conclusion!r} — NOTHING SHIPPED",
+        remedy=f"gh run view {last.get('url') or ''}".strip(),
+        detail=(
+            "The release pipeline is test -> build -> publish -> release. A "
+            "non-success conclusion means build/publish never ran, so the tag "
+            "exists with no PyPI release behind it. Red in a tab nobody opens "
+            "is how this went unnoticed for a day."
+        ),
+        data={"conclusion": conclusion, "ref": ref, "url": last.get("url")},
+    )
+
+
+def check_symbols(expectations=EXPECTATIONS, prober=probe) -> Finding:
+    """Are the fixes we KNOW shipped actually present in the loaded code?
+
+    This is the check that cannot be fooled by a number. Each expectation
+    names a symbol that exists only in fixed code; ``hasattr`` is asked of
+    the module object in the running interpreter. See ``_symbols`` for why
+    every version-string-based answer here is worthless.
+    """
+    check = "symbol-probe"
+    if not expectations:
+        return _unknown(check, "no symbol expectations registered")
+
+    missing, present, unknown = [], [], []
+    for exp in expectations:
+        result = prober(exp)
+        if result is True:
+            present.append(exp)
+        elif result is False:
+            missing.append(exp)
+        else:
+            unknown.append(exp)
+
+    if missing:
+        first = missing[0]
+        return Finding(
+            check=check,
+            state=Freshness.STALE,
+            summary=(
+                f"{len(missing)} known fix(es) MISSING from the loaded code: "
+                + ", ".join(e.dotted for e in missing)
+            ),
+            remedy=f"pip install -U {_DIST}   # then restart long-lived processes",
+            detail=(
+                "Probed by symbol, not by version string. "
+                + first.why
+                + f"  (expected since {first.since})"
+            ),
+            data={
+                "missing": [e.dotted for e in missing],
+                "present": [e.dotted for e in present],
+                "unknown": [e.dotted for e in unknown],
+            },
+        )
+
+    if not present:
+        return _unknown(check, "no symbol could be probed")
+
+    return Finding(
+        check=check,
+        state=Freshness.FRESH,
+        summary=f"all {len(present)} probed fix(es) present in the loaded code",
+        data={
+            "present": [e.dotted for e in present],
+            "unknown": [e.dotted for e in unknown],
+        },
+    )
+
+
+_DIST = "scitex-agent-container"
+
+
+def build_report(sources, *, unit: str, python: str | None = None, now=None):
+    """Run every check against ``sources`` and assemble the report."""
+    latest = sources.pypi_latest()
+    released = sources.pypi_versions()
+    findings = (
+        check_host_behind_pypi(sources.installed_version(), latest, python=python),
+        check_ghost_tags(sources.git_tags(), released),
+        check_running_vs_installed(
+            sources.daemon_started_at(), sources.installed_at(), unit=unit
+        ),
+        check_release_runs(sources.release_runs()),
+        check_symbols(),
+    )
+    return FreshnessReport(
+        findings=findings,
+        generated_at=time.time() if now is None else now,
+    )
+
+
+# EOF

--- a/src/scitex_agent_container/_freshness/_model.py
+++ b/src/scitex_agent_container/_freshness/_model.py
@@ -1,0 +1,164 @@
+"""The freshness verdict model — three states, and UNKNOWN is not "fine".
+
+This is the deploy-side sibling of :mod:`.._drift._status`. ``_drift``
+compares a git checkout against its upstream (behind / ahead / diverged);
+``_freshness`` compares what is *deployed* against what actually
+*shipped* (installed vs PyPI, tag vs PyPI, running vs installed).
+
+Different domain, same hard-won doctrine, stated once here:
+
+    A check that cannot reach its evidence reports UNKNOWN. It never
+    reports FRESH.
+
+Both halves of that sentence are load-bearing, and both were paid for:
+
+* Treating "no evidence" as healthy is how a fix sits un-shipped for a
+  day while agents re-diagnose it. Tags v0.21.15 and v0.21.16 never
+  reached PyPI, and nothing anywhere said a word.
+* Treating "no evidence" as *broken* is worse, because a false RED gets
+  a remedy, and the remedy destroys a healthy thing. So only
+  :attr:`Freshness.STALE` — positive evidence of staleness — is ever
+  actionable. UNKNOWN is silent by construction.
+
+``_drift`` reached the same conclusion in its own vocabulary; see
+``DriftStatus.is_drifted``: "NOT_A_REPO / UNREACHABLE are NOT drift --
+drift is *unknown* there, not present."
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+
+__all__ = ["Finding", "Freshness", "FreshnessReport"]
+
+
+class Freshness(enum.Enum):
+    """The verdict for one deploy-freshness check.
+
+    * ``FRESH``   — positive evidence the thing is current.
+    * ``STALE``   — positive evidence the thing is behind. Actionable.
+    * ``UNKNOWN`` — the evidence could not be obtained (offline, no such
+      file, unparseable version, daemon not under systemd, ...). NOT a
+      synonym for FRESH. Never actionable, never raised as an alarm.
+    """
+
+    FRESH = "fresh"
+    STALE = "stale"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """The outcome of a single named check.
+
+    Attributes:
+        check: Stable machine id (``host-behind-pypi``, ``ghost-tag``,
+            ``running-vs-installed``, ``release-run``, ``symbol-probe``).
+        state: The :class:`Freshness` verdict.
+        summary: One human line. Shown to the operator when STALE.
+        remedy: The exact command that fixes it. Empty when the fix is
+            not a command a human can just run (e.g. a failed CI run).
+            An alarm that does not say what to *do* gets ignored.
+        detail: Longer context; shown in ``--json`` and verbose output.
+        data: Machine-readable evidence for this finding.
+    """
+
+    check: str
+    state: Freshness
+    summary: str
+    remedy: str = ""
+    detail: str = ""
+    data: dict = field(default_factory=dict)
+
+    @property
+    def is_stale(self) -> bool:
+        """True only on positive evidence of staleness.
+
+        UNKNOWN is deliberately excluded — see the module docstring.
+        """
+        return self.state is Freshness.STALE
+
+    def to_dict(self) -> dict:
+        return {
+            "check": self.check,
+            "state": self.state.value,
+            "summary": self.summary,
+            "remedy": self.remedy,
+            "detail": self.detail,
+            "data": dict(self.data),
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "Finding":
+        """Rebuild from :meth:`to_dict` (the cache round-trip).
+
+        An unrecognised state string decays to UNKNOWN rather than
+        raising: a cache written by a future version must never break
+        the CLI that reads it.
+        """
+        try:
+            state = Freshness(raw.get("state"))
+        except ValueError:
+            state = Freshness.UNKNOWN
+        return cls(
+            check=str(raw.get("check", "")),
+            state=state,
+            summary=str(raw.get("summary", "")),
+            remedy=str(raw.get("remedy", "")),
+            detail=str(raw.get("detail", "")),
+            data=dict(raw.get("data") or {}),
+        )
+
+
+@dataclass(frozen=True)
+class FreshnessReport:
+    """All findings from one refresh, plus the aggregate verdict."""
+
+    findings: tuple[Finding, ...] = ()
+    generated_at: float = 0.0
+
+    @property
+    def state(self) -> Freshness:
+        """Aggregate verdict. Precedence is STALE > UNKNOWN > FRESH.
+
+        * any STALE -> STALE. Positive evidence of a problem outranks
+          everything; one un-shipped fix still matters when four other
+          checks are clean.
+        * else any UNKNOWN -> UNKNOWN. Partial blindness is never
+          summarised as "fresh".
+        * else FRESH.
+
+        No findings at all is UNKNOWN, not FRESH — an empty report means
+        nothing was checked, which is exactly the state this module
+        exists to stop being read as good news.
+        """
+        if not self.findings:
+            return Freshness.UNKNOWN
+        if any(f.state is Freshness.STALE for f in self.findings):
+            return Freshness.STALE
+        if any(f.state is Freshness.UNKNOWN for f in self.findings):
+            return Freshness.UNKNOWN
+        return Freshness.FRESH
+
+    @property
+    def stale(self) -> tuple[Finding, ...]:
+        """Just the actionable findings — all an alarm may speak about."""
+        return tuple(f for f in self.findings if f.is_stale)
+
+    def to_dict(self) -> dict:
+        return {
+            "state": self.state.value,
+            "generated_at": self.generated_at,
+            "findings": [f.to_dict() for f in self.findings],
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "FreshnessReport":
+        return cls(
+            findings=tuple(Finding.from_dict(f) for f in (raw.get("findings") or [])),
+            generated_at=float(raw.get("generated_at") or 0.0),
+        )
+
+
+# EOF

--- a/src/scitex_agent_container/_freshness/_sources.py
+++ b/src/scitex_agent_container/_freshness/_sources.py
@@ -1,0 +1,329 @@
+"""The evidence seams: where the facts come from.
+
+Every fact the checks reason about arrives through :class:`Sources`. Two
+implementations:
+
+* :class:`LiveSources` — the real thing. PyPI over HTTPS, ``git tag``,
+  ``gh run list``, ``importlib.metadata``, ``systemctl show``.
+* :class:`StaticSources` — the same interface, handed data captured from
+  those real systems. This is what the tests drive: no mocks, no
+  monkeypatching, no network — a real object with a real implementation,
+  fed real recorded evidence (including the actual PyPI release list and
+  the actual GitHub run conclusions from the 2026-07-13 incident).
+
+**Every method returns ``None`` when it cannot get a real answer.** That
+``None`` is the only way UNKNOWN reaches the verdict layer, and it is why
+this alarm cannot become the next false-green: a source that cannot see
+says so, instead of returning an empty list that reads like "nothing
+wrong".
+
+TIMEOUTS
+--------
+The fleet host runs at load ~60. Every timeout here is deliberately
+generous (20-30 s, not 2-5 s), because a tight timeout on a loaded box
+does not "fail fast" — it manufactures an UNKNOWN out of a machine that
+was merely busy, and a check that goes blind under load is useless
+exactly when the fleet is under load. None of this is on an interactive
+path; the refresher runs from cron and nobody is waiting on it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Protocol
+
+__all__ = ["DIST_NAME", "LiveSources", "Sources", "StaticSources"]
+
+DIST_NAME = "scitex-agent-container"
+PYPI_JSON_URL = f"https://pypi.org/pypi/{DIST_NAME}/json"
+RELEASE_WORKFLOW = "pypi-publish-and-github-release-on-tag.yml"
+LISTEN_UNIT = "sac-listen.service"
+
+# See module docstring: generous on purpose, this host sits at load ~60.
+_HTTP_TIMEOUT_S = 30
+_CMD_TIMEOUT_S = 30
+
+
+class Sources(Protocol):
+    """The facts a freshness verdict needs. ``None`` always means UNKNOWN."""
+
+    def pypi_versions(self) -> set[str] | None:
+        """Every version PyPI has ever published. The only truth about
+        what shipped — not the tag, not the GitHub release, not the
+        changelog, all three of which lied during the 2026-07-13
+        incident."""
+
+    def pypi_latest(self) -> str | None:
+        """PyPI's own idea of the newest release."""
+
+    def installed_version(self) -> str | None:
+        """What THIS interpreter has installed."""
+
+    def installed_at(self) -> float | None:
+        """When the installed package was last written (epoch seconds)."""
+
+    def git_tags(self) -> list[str] | None:
+        """Every ``v*`` release tag."""
+
+    def release_runs(self) -> list[dict] | None:
+        """Recent release-workflow runs, newest first."""
+
+    def daemon_started_at(self) -> float | None:
+        """When the long-lived listen daemon began executing."""
+
+
+class LiveSources:
+    """Real evidence, from the real systems."""
+
+    def __init__(self, repo_root: Path | None = None, unit: str = LISTEN_UNIT):
+        self._repo_root = repo_root
+        self._unit = unit
+        self._pypi: dict | None | object = _UNSET
+
+    # -- PyPI ------------------------------------------------------------
+    def _pypi_json(self) -> dict | None:
+        if self._pypi is _UNSET:
+            self._pypi = self._fetch_pypi()
+        return self._pypi  # type: ignore[return-value]
+
+    def _fetch_pypi(self) -> dict | None:
+        # Imported here, not at module scope: this module is reachable
+        # from the CLI's import graph and urllib costs ~15 ms we do not
+        # want to pay on `sac --help`.
+        import urllib.error
+        import urllib.request
+
+        try:
+            with urllib.request.urlopen(
+                PYPI_JSON_URL, timeout=_HTTP_TIMEOUT_S
+            ) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except (urllib.error.URLError, OSError, ValueError):  # stx-allow: fallback (reason: offline/slow/garbled PyPI is UNKNOWN, never "fine")
+            return None
+
+    def pypi_versions(self) -> set[str] | None:
+        data = self._pypi_json()
+        if not data:
+            return None
+        releases = data.get("releases")
+        if not isinstance(releases, dict):
+            return None
+        # A version with an empty file list was yanked/never uploaded; it
+        # is NOT a shipped release, and counting it would let a ghost
+        # masquerade as published.
+        return {v for v, files in releases.items() if files}
+
+    def pypi_latest(self) -> str | None:
+        data = self._pypi_json()
+        if not data:
+            return None
+        return (data.get("info") or {}).get("version")
+
+    # -- this install ----------------------------------------------------
+    def installed_version(self) -> str | None:
+        """The version of the LOADED code, via ``_provenance`` (the SSOT).
+
+        Not re-derived here: ``_provenance.identity()`` already resolves
+        "which code is actually loaded, and what does it declare", and
+        having two answers to that question is how this class of bug
+        starts in the first place.
+        """
+        from .._provenance import identity
+
+        version = identity().get("version") or ""
+        # `_provenance` says "0.0.0+unknown" when nothing is installed;
+        # that is an absence of evidence, not a version.
+        return None if not version or version.startswith("0.0.0+") else version
+
+    def installed_at(self) -> float | None:
+        """mtime of the dist-info dir (when pip wrote it), else the package.
+
+        dist-info is the better signal: pip stamps it at install time,
+        whereas a package ``__init__.py`` can be touched by anything.
+        """
+        from importlib.metadata import PackageNotFoundError, distribution
+
+        try:
+            dist = distribution(DIST_NAME)
+        except PackageNotFoundError:  # stx-allow: fallback (reason: running off a source tree with nothing installed -- no install time exists)
+            dist = None
+        if dist is not None:
+            base = getattr(dist, "_path", None)
+            if isinstance(base, Path) and base.exists():
+                return base.stat().st_mtime
+        from .._provenance import package_dir
+
+        init = package_dir() / "__init__.py"
+        try:
+            return init.stat().st_mtime
+        except OSError:  # stx-allow: fallback (reason: no readable package file -> UNKNOWN)
+            return None
+
+    # -- the repo --------------------------------------------------------
+    def repo_root(self) -> Path | None:
+        if self._repo_root is not None:
+            return self._repo_root
+        from .._provenance import package_dir
+        from .._provenance._git import repo_root_for_package
+
+        return repo_root_for_package(package_dir())
+
+    def git_tags(self) -> list[str] | None:
+        """Release tags from the checkout. ``None`` when there is no repo.
+
+        A wheel-only host has no tags to read, and that is UNKNOWN, not
+        "no ghosts". Run the refresher where a checkout exists (the dev
+        host, CI) to get this check.
+        """
+        root = self.repo_root()
+        if root is None:
+            return None
+        out = _run(["git", "-C", str(root), "tag", "-l", "v*"])
+        if out is None:
+            return None
+        return [line.strip() for line in out.splitlines() if line.strip()]
+
+    def release_runs(self) -> list[dict] | None:
+        """Release-workflow runs via ``gh``. ``None`` when gh is absent."""
+        out = _run(
+            [
+                "gh", "run", "list",
+                "--workflow", RELEASE_WORKFLOW,
+                "--limit", "10",
+                "--json", "conclusion,status,headBranch,createdAt,url",
+            ],
+            cwd=self.repo_root(),
+        )
+        if out is None:
+            return None
+        try:
+            runs = json.loads(out)
+        except ValueError:  # stx-allow: fallback (reason: unparseable gh output is UNKNOWN)
+            return None
+        return runs if isinstance(runs, list) else None
+
+    # -- the running daemon ----------------------------------------------
+    def daemon_started_at(self) -> float | None:
+        """``ExecMainStartTimestamp`` of the listen unit, as epoch seconds.
+
+        systemd reports this in microseconds since the epoch, which is
+        exact and needs no date parsing. ``0`` means the unit exists but
+        has never run -> nothing is running -> UNKNOWN, not stale.
+        """
+        out = _run(
+            [
+                "systemctl", "--user", "show", self._unit,
+                "-p", "ExecMainStartTimestampMonotonic",
+                "-p", "ExecMainStartTimestamp",
+                "--value",
+            ]
+        )
+        if out is None:
+            return None
+        return _parse_systemd_timestamp(out)
+
+
+class StaticSources:
+    """The same interface, fed real recorded evidence. For tests.
+
+    Not a mock: it is a genuine implementation of :class:`Sources` whose
+    backing store happens to be a dict instead of a network. Tests hand
+    it the actual bytes the real systems returned, so the verdict logic
+    is exercised against reality without ever touching reality.
+    """
+
+    def __init__(
+        self,
+        *,
+        pypi_versions=None,
+        pypi_latest=None,
+        installed_version=None,
+        installed_at=None,
+        git_tags=None,
+        release_runs=None,
+        daemon_started_at=None,
+    ):
+        self._pypi_versions = pypi_versions
+        self._pypi_latest = pypi_latest
+        self._installed_version = installed_version
+        self._installed_at = installed_at
+        self._git_tags = git_tags
+        self._release_runs = release_runs
+        self._daemon_started_at = daemon_started_at
+
+    def pypi_versions(self):
+        return set(self._pypi_versions) if self._pypi_versions is not None else None
+
+    def pypi_latest(self):
+        return self._pypi_latest
+
+    def installed_version(self):
+        return self._installed_version
+
+    def installed_at(self):
+        return self._installed_at
+
+    def git_tags(self):
+        return list(self._git_tags) if self._git_tags is not None else None
+
+    def release_runs(self):
+        return list(self._release_runs) if self._release_runs is not None else None
+
+    def daemon_started_at(self):
+        return self._daemon_started_at
+
+
+class _Unset:
+    pass
+
+
+_UNSET = _Unset()
+
+
+def _run(argv: list[str], cwd: Path | None = None) -> str | None:
+    """Run a command; ``None`` on any failure. Never raises, never hangs."""
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=_CMD_TIMEOUT_S,
+            cwd=str(cwd) if cwd else None,
+        )
+    except (OSError, subprocess.SubprocessError):  # stx-allow: fallback (reason: missing binary / timeout is UNKNOWN, never "fine")
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def _parse_systemd_timestamp(raw: str) -> float | None:
+    """First line = monotonic usec, second = human stamp. Prefer neither
+    if the unit never started."""
+    lines = [line.strip() for line in raw.splitlines() if line.strip()]
+    if not lines:
+        return None
+    # `--value` with two -p flags prints them in the order asked:
+    # monotonic first. 0 => never started.
+    try:
+        monotonic_usec = int(lines[0])
+    except ValueError:
+        return None
+    if monotonic_usec <= 0:
+        return None
+    # Convert monotonic -> wall clock via /proc/uptime, which is the only
+    # translation available without pulling in a date parser.
+    try:
+        with open("/proc/uptime", encoding="utf-8") as fh:
+            uptime_s = float(fh.read().split()[0])
+    except (OSError, ValueError, IndexError):  # stx-allow: fallback (reason: no /proc/uptime -> cannot translate -> UNKNOWN)
+        return None
+    import time as _time
+
+    boot_epoch = _time.time() - uptime_s
+    return boot_epoch + (monotonic_usec / 1_000_000.0)
+
+
+# EOF

--- a/src/scitex_agent_container/_freshness/_symbols.py
+++ b/src/scitex_agent_container/_freshness/_symbols.py
@@ -1,0 +1,119 @@
+"""Symbol probes — ask the code what it IS, not what it CLAIMS to be.
+
+A version string lies in both directions in this project, and has:
+
+* **Stale in memory.** A daemon imported its modules at boot. Upgrading
+  the package on disk does not reload them — Python has no such
+  mechanism. ``sac --version`` reports the NEW number while ``sac
+  listen`` is still executing the OLD bytecode.
+* **Stale on disk.** The host sat on 0.21.14 for a full day while three
+  tags came and went. The number was self-consistent and completely
+  wrong about what was fixed.
+* **Fossil metadata.** A leftover ``.dist-info`` makes
+  ``importlib.metadata.version()`` report a release whose code is not
+  the code being imported.
+
+A number cannot see any of this, because a fix that does not bump the
+version does not move the number, and a number that is bumped does not
+prove the code moved with it. **The symbol can.** ``hasattr(mod, name)``
+is evaluated against the module object actually loaded into the running
+interpreter, so it answers the only question anybody ever really asks:
+
+    is the fix *in the code I am running right now*?
+
+Registering an expectation here is how a fix becomes *provable* rather
+than merely *claimed*. When you ship a fix that matters, add the symbol
+it introduced.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["EXPECTATIONS", "SymbolExpectation", "probe", "probe_all"]
+
+
+@dataclass(frozen=True)
+class SymbolExpectation:
+    """A symbol whose PRESENCE proves a specific fix is in the loaded code.
+
+    Attributes:
+        module: Dotted path of the module the fix landed in.
+        symbol: A name that exists ONLY in the fixed code. Pick something
+            the fix genuinely introduced — a counter, a new function, a
+            new class. A symbol that predates the fix proves nothing.
+        since: The release that first carried it. Informational only:
+            it is never used to decide the verdict, because deciding on
+            the number is precisely the failure this module exists to
+            end.
+        why: What breaks when it is missing. This lands in front of a
+            human at 3am; make it mean something.
+    """
+
+    module: str
+    symbol: str
+    since: str
+    why: str
+
+    @property
+    def dotted(self) -> str:
+        return f"{self.module}.{self.symbol}"
+
+
+# The registry. Seeded with the fix at the centre of the 2026-07-13/14
+# comms outage: a shared-executor thread leak that wedged `sac listen`'s
+# authenticated routes while /v1/health cheerfully kept answering 200 --
+# the exact false-green this whole subsystem exists to prevent.
+EXPECTATIONS: tuple[SymbolExpectation, ...] = (
+    SymbolExpectation(
+        module="scitex_agent_container._lifecycle._off_loop",
+        symbol="abandoned_call_count",
+        since="0.21.15",
+        why=(
+            "#658 — a timed-out run_in_executor orphans its thread, which "
+            "holds a slot in the shared pool forever; once the pool is full "
+            "every asyncio.to_thread in the process silently stops running, "
+            "wedging sac listen's authenticated routes while /v1/health "
+            "still answers 200"
+        ),
+    ),
+)
+
+
+def probe(exp: SymbolExpectation) -> bool | None:
+    """Is ``exp.symbol`` present in the loaded ``exp.module``?
+
+    Returns:
+        ``True``  — the symbol is there. The fix is in the running code.
+        ``False`` — the module imported fine and the symbol is absent, OR
+            the module itself does not exist. Both are positive evidence
+            the fix is not here.
+        ``None``  — UNKNOWN. The module exists but could not be imported
+            because something *it* depends on is broken. That tells us
+            nothing about our symbol, so we say nothing.
+
+    The ``exc.name`` check is what separates the last two cases. A bare
+    ``except ImportError: return False`` would report "fix missing" when
+    the truth is "this module's dependency is broken" — a false RED, and
+    a false RED is the dangerous kind, because someone acts on it.
+    """
+    try:
+        mod = __import__(exp.module, fromlist=["_"])
+    except ModuleNotFoundError as exc:
+        # Our module genuinely isn't in this install -> the fix isn't here.
+        # A DIFFERENT module missing (a broken dependency of ours) is not
+        # evidence about our symbol.
+        if getattr(exc, "name", None) == exp.module:
+            return False
+        return None
+    except Exception:  # stx-allow: fallback (reason: any other import failure is evidence about the dependency, not about our symbol; UNKNOWN is the honest answer)
+        return None
+    return hasattr(mod, exp.symbol)
+
+
+def probe_all(expectations=None) -> list[tuple[SymbolExpectation, bool | None]]:
+    """Probe every registered expectation against the LOADED code."""
+    return [(e, probe(e)) for e in (EXPECTATIONS if expectations is None else expectations)]
+
+
+# EOF

--- a/src/scitex_agent_container/_freshness/_version.py
+++ b/src/scitex_agent_container/_freshness/_version.py
@@ -1,0 +1,109 @@
+"""Version ordering — deliberately strict, and honest about giving up.
+
+Zero dependencies on purpose. This code runs on every ``sac`` invocation
+(via the cached-warning path) and inside a cron alarm that must keep
+working on a host whose sac is *too old to fix itself*. A hard import of
+``packaging`` is a way for the staleness alarm to be taken out by the
+very staleness it exists to report.
+
+The contract every function here keeps: **an input it does not fully
+understand returns ``None``, never a guess.** ``None`` propagates to
+:attr:`Freshness.UNKNOWN`, which is silent. A comparator that guesses
+wrong in the "fresh" direction hides a real outage; one that guesses
+wrong in the "stale" direction cries wolf until it is disabled. Both
+end with nobody trusting the alarm, so neither is permitted.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["compare", "is_behind", "latest", "parse"]
+
+# X.Y.Z[.N...] with an optional PEP440 pre-release suffix (a/b/rc).
+# Anything else -- dev builds, local versions, epochs, post-releases,
+# "dev", "0.0.0+unknown" -- is intentionally NOT matched, and therefore
+# reported UNKNOWN rather than mis-ordered.
+_RE = re.compile(r"^v?(\d+(?:\.\d+)*)(?:(a|b|rc)(\d+))?$")
+
+# Final releases sort AFTER every pre-release of the same number:
+# 0.21.17rc1 < 0.21.17. Ranks are compared as the 2nd tuple element.
+_PRE_RANK = {"a": 0, "b": 1, "rc": 2}
+_FINAL_RANK = 3
+
+
+def parse(raw: str | None) -> tuple | None:
+    """Parse a version into a sortable key, or ``None`` if not understood.
+
+    ``None`` is a first-class answer, not a failure to handle: it is how
+    "I cannot order this" reaches the caller as UNKNOWN instead of as a
+    silently wrong comparison.
+
+    >>> parse("0.21.17") < parse("v0.21.17") is False
+    True
+    >>> parse("0.21.9") < parse("0.21.17")   # not string order
+    True
+    >>> parse("0.21.17rc1") < parse("0.21.17")
+    True
+    >>> parse("dev") is None
+    True
+    """
+    if not raw or not isinstance(raw, str):
+        return None
+    m = _RE.match(raw.strip())
+    if m is None:
+        return None
+    release = tuple(int(p) for p in m.group(1).split("."))
+    if m.group(2) is None:
+        return (release, _FINAL_RANK, 0)
+    return (release, _PRE_RANK[m.group(2)], int(m.group(3)))
+
+
+def compare(a: str | None, b: str | None) -> int | None:
+    """``-1`` if a<b, ``0`` if equal, ``1`` if a>b; ``None`` if either is
+    unparseable.
+
+    Note ``0.21.17`` and ``v0.21.17`` compare EQUAL — the ``v`` prefix is
+    a git-tag spelling of the same release, and the whole point of the
+    ghost-tag check is to line tags up against PyPI versions.
+    """
+    pa, pb = parse(a), parse(b)
+    if pa is None or pb is None:
+        return None
+    return (pa > pb) - (pa < pb)
+
+
+def is_behind(installed: str | None, latest_: str | None) -> bool | None:
+    """Is ``installed`` strictly older than ``latest_``?
+
+    ``None`` when either side is unparseable — the caller MUST map that
+    to UNKNOWN and stay quiet. An installed version *newer* than PyPI
+    (a dev build, a worktree, an unreleased bump) is ``False``: ahead is
+    not behind, and warning a developer that their own unpublished build
+    is "stale" is exactly the noise that gets an alarm switched off.
+    """
+    cmp = compare(installed, latest_)
+    if cmp is None:
+        return None
+    return cmp < 0
+
+
+def latest(versions) -> str | None:
+    """The greatest parseable version in ``versions``, or ``None``.
+
+    Unparseable entries are skipped rather than poisoning the result:
+    one weird string on PyPI must not blind the whole check. ``None``
+    only when *nothing* was parseable.
+    """
+    best_key = None
+    best_raw = None
+    for v in versions or ():
+        key = parse(v)
+        if key is None:
+            continue
+        if best_key is None or key > best_key:
+            best_key, best_raw = key, v
+    return best_raw
+
+
+# EOF

--- a/src/scitex_agent_container/_freshness/_warn.py
+++ b/src/scitex_agent_container/_freshness/_warn.py
@@ -1,0 +1,141 @@
+"""The every-invocation warning. This is the whole point of the feature.
+
+Operator, 2026-07-14: "Comments and READMEs are meaningless if nobody
+reads them. If you're not on the latest version, that itself should emit
+a warning. When I type ``sac`` on the host and a newer version is already
+published, a warning should appear. THAT is how I learn I need to
+install."
+
+So the control lives where the attention already is — in front of the
+command the operator types every day — and not in a document, a dashboard
+or a tab.
+
+THREE RULES THIS MODULE CANNOT BREAK
+------------------------------------
+1. **Never slow ``sac`` down.** No network, no subprocess, no heavy
+   import. One small JSON read of a file the cron refresher already
+   wrote. ``$SAC_FRESHNESS_QUIET`` is honoured before we even touch the
+   disk.
+2. **Never break ``sac``.** Every failure path in here ends in silence.
+   A staleness warning that can crash the CLI is infinitely worse than
+   the staleness it reports.
+3. **Never cry wolf.** Only a cached finding that is positively STALE
+   speaks. Missing cache, expired cache, corrupt cache, unparseable
+   version, offline refresher -> UNKNOWN -> **say nothing at all**. A
+   check that nags when it does not know gets silenced within a day, and
+   a silenced check is worth less than no check, because everyone still
+   believes it is watching.
+
+Rules 2 and 3 are why this is a warning and not a hard failure by
+default. ``$SAC_FRESHNESS_SEVERITY=error`` is the single knob that
+tightens it, once the signal has earned that trust.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+__all__ = ["SEVERITY_DEFAULT", "warn_if_stale"]
+
+SEVERITY_DEFAULT = "warn"
+_SEVERITIES = ("silent", "warn", "error")
+
+_ENV_QUIET = "SAC_FRESHNESS_QUIET"
+_ENV_SEVERITY = "SAC_FRESHNESS_SEVERITY"
+_ENV_DEBUG = "SAC_FRESHNESS_DEBUG"
+
+# Exit code used only when severity=error. Distinct from click's 1/2 so a
+# staleness abort is never mistaken for a usage error or a command failure.
+EXIT_STALE = 3
+
+_BAR = "!" * 72
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def severity() -> str:
+    """``silent`` | ``warn`` (default) | ``error``.
+
+    An unrecognised value falls back to the default instead of raising —
+    a typo in an env var must never be able to break the CLI.
+    """
+    raw = (os.environ.get(_ENV_SEVERITY) or "").strip().lower()
+    return raw if raw in _SEVERITIES else SEVERITY_DEFAULT
+
+
+def warning_lines(findings) -> list[str]:
+    """The banner. Mirrors ``_drift.drift_warning_lines``' house style.
+
+    Every stale finding gets its own ``why`` + ``fix`` pair, because an
+    alarm that does not say what to DO is an alarm people learn to skip.
+    """
+    if not findings:
+        return []
+    lines = [_BAR, "sac-freshness WARNING: this sac is not what shipped."]
+    for finding in findings:
+        lines.append(f"  * {finding.summary}")
+        if finding.remedy:
+            lines.append(f"      fix: {finding.remedy}")
+    lines.append(f"  (silence: {_ENV_QUIET}=1   details: sac freshness check)")
+    lines.append(_BAR)
+    return lines
+
+
+def warn_if_stale(stream=None) -> int:
+    """Emit the staleness banner to stderr. Returns an exit code.
+
+    Returns ``0`` in every case except ``severity=error`` with a genuinely
+    STALE cached report, which returns :data:`EXIT_STALE`. The caller
+    decides whether to act on it; this function's own contract is that it
+    NEVER raises, whatever it finds on disk.
+
+    ``stream`` is resolved at call time (default ``sys.stderr``) so tests
+    can capture it — the same seam ``_drift`` uses.
+    """
+    if _truthy(os.environ.get(_ENV_QUIET)):
+        return 0
+    level = severity()
+    if level == "silent":
+        return 0
+
+    debug = _truthy(os.environ.get(_ENV_DEBUG))
+    out = stream if stream is not None else sys.stderr
+
+    try:
+        from ._cache import read_cache
+
+        report = read_cache()
+        if report is None:
+            # No current evidence. This is UNKNOWN, and UNKNOWN is silent.
+            if debug:
+                print(
+                    "sac-freshness: no usable cache (missing/expired/corrupt) "
+                    "-> UNKNOWN -> silent. Refresh: sac freshness refresh",
+                    file=out,
+                )
+            return 0
+
+        stale = report.stale
+        if not stale:
+            if debug:
+                print(
+                    f"sac-freshness: cached state={report.state.value} "
+                    f"({len(report.findings)} checks) -> nothing to warn about",
+                    file=out,
+                )
+            return 0
+
+        for line in warning_lines(stale):
+            print(line, file=out)
+        return EXIT_STALE if level == "error" else 0
+
+    except Exception as exc:  # stx-allow: fallback (reason: rule 2 -- a freshness warning must NEVER be able to break the sac CLI; any failure here degrades to silence)
+        if debug:
+            print(f"sac-freshness: check failed ({exc!r}) -> silent", file=out)
+        return 0
+
+
+# EOF

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -71,7 +71,7 @@ COMMAND_CATEGORIES = [
     ),
     ("Registry & Events", ["db", "registry", "event"]),
     ("Build & Install", ["image", "installation"]),
-    ("Diagnostics", ["doctor", "ports", "provenance"]),
+    ("Diagnostics", ["doctor", "ports", "provenance", "freshness"]),
     ("Remote testing", ["pytest"]),
     ("Introspection", ["mcp", "list-python-apis", "skills", "versions"]),
     ("Developer", ["dev"]),
@@ -112,6 +112,11 @@ class _MainGroup(LazyGroup):
         # Which code is ACTUALLY loaded — the heavy half of `--version`
         # (tree hash, duplicate/fossil .dist-info, shadowed imports).
         "provenance": f"{_PKG}.provenance_cmds:provenance",
+        # Whether the loaded code is what SHIPPED: ghost tags, host behind
+        # PyPI, daemons running pre-upgrade code, failed release runs.
+        # `provenance` answers "which code is loaded"; `freshness` answers
+        # "is that the code that was released".
+        "freshness": f"{_PKG}.freshness_cmds:freshness_group",
         # Spartan pytest runner (operator directive 2026-06-13). Phase 1
         # surface: ``sac pytest spartan run <repo>@<branch>``. The lazy
         # mapping resolves to the ``pytest_group`` click group exported
@@ -293,6 +298,7 @@ class _MainGroup(LazyGroup):
         "fleet": "Peer-aware multi-agent orchestration across hosts.",
         "doctor": "Diagnose agent-spec source drift (local, or --fleet across hosts).",
         "provenance": "Prove which code is actually loaded (commit, origin, fossil installs).",
+        "freshness": "Is the loaded code what shipped? Ghost tags, stale installs, stale daemons.",
         "listen": "Host HTTP/JSON control plane: start/stop/restart/status.",
         "ports": "List the ports sac/scitex uses, with live status.",
         "pytest": "Run pytest on remote pools (Spartan SLURM, ...).",
@@ -423,6 +429,35 @@ def main(ctx: click.Context, help_recursive: bool, as_json: bool) -> None:
         click.echo(ctx.get_help())
 
 
+def _warn_if_stale() -> None:
+    """Tell the operator, on EVERY ``sac``, when this sac is not what shipped.
+
+    Operator directive 2026-07-14, after a day lost to a fix that was
+    merged but never published: "If you're not on the latest version,
+    that itself should emit a warning. When I type ``sac`` on the host
+    and a newer version is already published, a warning should appear.
+    THAT is how I learn I need to install."
+
+    Placed in ``cli_entry_point`` rather than in ``main``'s group callback
+    because that callback is skipped by click's eager flags — so ``sac
+    --version``, the very command someone runs to ask "am I current?",
+    would have been the one invocation that never answered it.
+
+    Cost: one small JSON read (the cron refresher does the network). Never
+    raises — ``warn_if_stale`` swallows everything and degrades to silence,
+    because a staleness warning that can break the CLI is far worse than
+    the staleness it reports. Silenced with ``SAC_FRESHNESS_QUIET=1``;
+    escalated to a hard exit with ``SAC_FRESHNESS_SEVERITY=error``.
+    """
+    from .._freshness._warn import warn_if_stale
+
+    code = warn_if_stale()
+    if code:
+        import sys
+
+        sys.exit(code)
+
+
 def cli_entry_point() -> None:
     """Console-script entry. Honours the global ``--on <peer>`` flag.
 
@@ -435,6 +470,12 @@ def cli_entry_point() -> None:
     otherwise.
     """
     import sys
+
+    # Before anything else: is this sac the sac that shipped? Emitted to
+    # stderr, so it never pollutes the stdout that `--json` consumers
+    # parse (`quota-alarm.py` parses `sac accounts list --json`; a chatty
+    # stdout would break it).
+    _warn_if_stale()
 
     # Cheap pre-scan: don't import the heavy ``host_group`` module
     # unless ``--on`` is actually present on the command line. Importing

--- a/src/scitex_agent_container/cli_pkg/freshness_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/freshness_cmds.py
@@ -1,0 +1,138 @@
+"""``sac freshness`` — is the code we are running the code that shipped?
+
+Two verbs, split by who can afford to wait:
+
+* ``refresh`` — does the network I/O (PyPI, git tags, gh runs), writes the
+  cache. Run from cron. Nobody is waiting on it.
+* ``check``   — reads the cache and reports. No network, no waiting. This
+  is also what the every-invocation CLI warning reads.
+
+Exit codes are chosen so this is safe to put in a pipeline:
+
+* ``0`` — FRESH, **or UNKNOWN**. Not knowing is not a failure. A check
+  that exits non-zero when it cannot see turns every offline laptop and
+  every slow CI runner into a red build, and gets removed.
+* ``3`` — STALE. Positive evidence something did not ship, or is not
+  running. The only actionable state.
+"""
+
+from __future__ import annotations
+
+import json as _json
+
+import click
+
+from .._freshness._cache import cache_path, read_cache, write_cache
+from .._freshness._model import Freshness
+from .._freshness._warn import EXIT_STALE
+
+_STYLE = {
+    Freshness.FRESH: ("green", "FRESH"),
+    Freshness.STALE: ("red", "STALE"),
+    Freshness.UNKNOWN: ("yellow", "UNKNOWN"),
+}
+
+
+@click.group(
+    "freshness",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+def freshness_group() -> None:
+    """Deploy freshness: ghost tags, stale installs, stale daemons.
+
+    \b
+    Examples:
+      $ sac freshness check              # read the cache (no network)
+      $ sac freshness refresh            # re-probe PyPI/git/gh, write cache
+      $ sac freshness check --json
+    """
+
+
+def _render(report, *, verbose: bool) -> None:
+    """Print a report. STALE findings always; the rest under --verbose.
+
+    FRESH findings still carry information worth having on demand — the
+    ghost-tag check names every superseded ghost even when it raises no
+    alarm — so ``check`` prints them and only the every-invocation
+    warning stays terse.
+    """
+    colour, label = _STYLE[report.state]
+    click.secho(f"deploy freshness: {label}", fg=colour, bold=True)
+
+    for finding in report.findings:
+        f_colour, f_label = _STYLE[finding.state]
+        if finding.state is Freshness.STALE or verbose:
+            click.secho(f"  [{f_label:^7}] {finding.check}", fg=f_colour, nl=False)
+            click.echo(f" — {finding.summary}")
+            if finding.remedy:
+                click.echo(f"            fix: {finding.remedy}")
+            if verbose and finding.detail:
+                click.echo(f"            {finding.detail}")
+
+    if report.state is Freshness.UNKNOWN and not verbose:
+        click.echo("  (UNKNOWN is not 'fine' — rerun with -v to see why)")
+
+
+@freshness_group.command("check")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Structured output.")
+@click.option("-v", "--verbose", is_flag=True, default=False, help="Show FRESH/UNKNOWN findings too.")
+def freshness_check(as_json: bool, verbose: bool) -> None:
+    """Report cached freshness. No network — reads what `refresh` wrote."""
+    report = read_cache()
+    if report is None:
+        # UNKNOWN, and we say WHY. Silence is right for the every-command
+        # warning; here the operator asked, so we owe an answer.
+        msg = (
+            f"deploy freshness: UNKNOWN — no usable cache at {cache_path()}\n"
+            "  (missing, corrupt, or older than the TTL)\n"
+            "  fix: sac freshness refresh"
+        )
+        if as_json:
+            click.echo(_json.dumps({"state": "unknown", "reason": "no-cache", "findings": []}, indent=2))
+        else:
+            click.secho(msg, fg="yellow")
+        raise SystemExit(0)
+
+    if as_json:
+        click.echo(_json.dumps(report.to_dict(), indent=2))
+    else:
+        _render(report, verbose=verbose)
+
+    raise SystemExit(EXIT_STALE if report.state is Freshness.STALE else 0)
+
+
+@freshness_group.command("refresh")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Structured output.")
+@click.option("-v", "--verbose", is_flag=True, default=False, help="Show FRESH/UNKNOWN findings too.")
+@click.option(
+    "--unit",
+    default="sac-listen.service",
+    show_default=True,
+    help="systemd unit whose running code is compared against the install.",
+)
+def freshness_refresh(as_json: bool, verbose: bool, unit: str) -> None:
+    """Re-probe PyPI / git tags / gh runs / symbols, then write the cache.
+
+    This is the only surface that touches the network. Run it from cron;
+    everything else reads its output.
+    """
+    import sys
+
+    from .._freshness._checks import build_report
+    from .._freshness._sources import LiveSources
+
+    report = build_report(LiveSources(), unit=unit, python=sys.executable)
+    path = write_cache(report)
+
+    if as_json:
+        payload = report.to_dict()
+        payload["cache"] = str(path)
+        click.echo(_json.dumps(payload, indent=2))
+    else:
+        _render(report, verbose=verbose)
+        click.echo(f"  cache: {path}")
+
+    raise SystemExit(EXIT_STALE if report.state is Freshness.STALE else 0)
+
+
+# EOF

--- a/src/scitex_agent_container/cron/deploy-freshness-alarm.py
+++ b/src/scitex_agent_container/cron/deploy-freshness-alarm.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Deploy-freshness alarm. Cron-side half of ``sac freshness``.
+
+Runs hourly, off any Claude session, and does two jobs:
+
+1. **Refreshes the cache** that every ``sac`` invocation reads. The CLI
+   warning cannot do its own network lookup (it would put a multi-second
+   PyPI round trip in front of every command), so something has to write
+   that file. This is that something.
+2. **Alarms** on the notify rail when the fleet is positively STALE, so
+   the failure reaches the operator even if nobody happens to type
+   ``sac`` today.
+
+Shape deliberately mirrors ``quota-alarm.py`` (the established prior art):
+shell the ``sac`` JSON surface, keep the logic in the package, debounce
+per condition, notify via ``scitex-notification``. No forked logic lives
+here — this file decides *when to speak*, never *what is true*.
+
+THE BOOTSTRAP, AND WHY IT CANNOT FAIL QUIETLY
+---------------------------------------------
+This alarm shells ``sac freshness refresh``, a command that only exists
+in the version that introduces it. On a host whose sac predates it, that
+call fails — and a naive script would treat the failure as "nothing to
+report" and go silently to sleep. That is the *exact* bug class this
+whole subsystem exists to abolish: the alarm for staleness, defeated by
+staleness.
+
+So a missing ``freshness`` subcommand on an sac that IS installed is
+itself treated as positive evidence of STALE (that sac is, by
+construction, older than this feature) and raises the alarm. A missing
+``sac`` binary entirely is UNKNOWN, and stays silent. The distinction is
+the whole tri-state doctrine in one branch.
+
+NOT AN AUTO-REMEDY
+------------------
+This never upgrades and never restarts anything. An automatic remedy on
+a signal this coarse is how you take a fleet down at 3am. It surfaces;
+a human or the owning agent acts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+
+# One alarm per condition per 6h. The conditions here PERSIST until a
+# human acts (a ghost tag stays a ghost), so a short debounce would mean
+# an hourly repeat of the same unactioned line — which trains the
+# operator to ignore it, and then the next real one is ignored too.
+DEBOUNCE_S = 6 * 60 * 60
+
+STATE_PATH = os.path.expanduser(
+    "~/.scitex/agent-container/runtime/deploy-freshness-alarm-state.json"
+)
+NOTIFY_BIN = "/home/ywatanabe/.venv/bin/scitex-notification"
+SAC_BIN = os.environ.get("SAC_BIN", "sac")
+
+# Generous: this host sits at load ~60 and the refresh does a PyPI round
+# trip plus two subprocesses. A tight timeout here would manufacture a
+# false UNKNOWN out of a machine that was merely busy.
+REFRESH_TIMEOUT_S = 180
+
+
+def load_state() -> dict:
+    try:
+        with open(STATE_PATH) as fh:
+            return json.load(fh)
+    except (OSError, ValueError):
+        return {}
+
+
+def save_state(state: dict) -> None:
+    os.makedirs(os.path.dirname(STATE_PATH), exist_ok=True)
+    tmp = STATE_PATH + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(state, fh, indent=2)
+    os.replace(tmp, STATE_PATH)
+
+
+def notify(message: str) -> None:
+    """Warning-level notification on the established rail.
+
+    Warning, not a phone call: the operator ruled that a warning is the
+    right severity here and can be tightened later. Waking someone at 3am
+    for a ghost tag would get the alarm muted, and a muted alarm is worse
+    than none because everyone still believes it is watching.
+    """
+    subprocess.run(
+        [
+            NOTIFY_BIN,
+            "send-notification",
+            "--backend",
+            "audio",
+            "--level",
+            "warning",
+            message,
+        ],
+        check=False,
+    )
+
+
+def refresh() -> tuple[str, list[dict]]:
+    """Run ``sac freshness refresh --json``.
+
+    Returns ``(state, stale_findings)`` where state is
+    ``fresh`` / ``stale`` / ``unknown``. See the module docstring for why
+    a missing ``freshness`` subcommand is STALE while a missing ``sac``
+    is UNKNOWN.
+    """
+    try:
+        proc = subprocess.run(
+            [SAC_BIN, "freshness", "refresh", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=REFRESH_TIMEOUT_S,
+        )
+    except FileNotFoundError:
+        # No sac at all. We cannot conclude anything about a fleet we
+        # cannot see. UNKNOWN -> silent.
+        return "unknown", []
+    except (OSError, subprocess.SubprocessError):
+        return "unknown", []
+
+    try:
+        payload = json.loads(proc.stdout)
+    except ValueError:
+        # sac ran but produced no JSON. The overwhelmingly likely cause
+        # is a sac too old to HAVE this subcommand (click exits 2 with a
+        # usage error on stderr) -- which is itself proof this host is
+        # behind. Say so; do not shrug.
+        if proc.returncode == 2:
+            return "stale", [
+                {
+                    "check": "sac-too-old",
+                    "summary": (
+                        "the installed sac has no `freshness` command — it "
+                        "predates the deploy-freshness alarm entirely"
+                    ),
+                    "remedy": "pip install -U scitex-agent-container",
+                }
+            ]
+        return "unknown", []
+
+    state = payload.get("state", "unknown")
+    stale = [f for f in payload.get("findings", []) if f.get("state") == "stale"]
+    return state, stale
+
+
+def main() -> None:
+    state, stale = refresh()
+
+    # UNKNOWN and FRESH both say nothing. Only positive evidence speaks.
+    if state != "stale" or not stale:
+        return
+
+    now = time.time()
+    saved = load_state()
+    spoke = False
+
+    for finding in stale:
+        check = finding.get("check", "?")
+        last = saved.get(check, {})
+        if now - last.get("alarmed_at", 0) < DEBOUNCE_S:
+            continue
+
+        message = f"Deploy freshness: {finding.get('summary', check)}."
+        remedy = finding.get("remedy")
+        if remedy:
+            message += f" Fix: {remedy}"
+        notify(message)
+        saved[check] = {"alarmed_at": now, "summary": finding.get("summary", "")}
+        spoke = True
+
+    if spoke:
+        save_state(saved)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scitex_agent_container/_freshness/_real_data.py
+++ b/tests/scitex_agent_container/_freshness/_real_data.py
@@ -1,0 +1,139 @@
+"""Real evidence, recorded from the real systems on 2026-07-14.
+
+NOT fixtures invented to make tests pass. Every value here was captured
+from production:
+
+* ``PYPI_RELEASES`` — ``GET https://pypi.org/pypi/scitex-agent-container/json``
+* ``GIT_TAGS``      — ``git tag -l 'v*'`` in the repo
+* ``RELEASE_RUNS``  — ``gh run list --workflow pypi-publish-and-github-release-on-tag.yml --json ...``
+
+Which is why the numbers are ugly: the real 0.21 line is missing SIX of
+its eighteen tags on PyPI (v0.21.6, .8, .10, .12, .15, .16 never
+published). The operator knew about two of them. Tests written against
+tidy invented data would never have shown that, and the check would have
+been tuned against a world that does not exist.
+
+The ``AT_INCIDENT_*`` values are the same systems as they stood at
+2026-07-13 ~23:30 UTC — the moment v0.21.16's release run failed and the
+fleet went a full day believing a merged fix was live. They exist so the
+regression test can ask the only question that matters:
+
+    would this alarm have fired, then, on that data?
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# NOW (2026-07-14): v0.21.17 published, six older ghosts behind it.
+# ---------------------------------------------------------------------------
+
+# Every version PyPI has actually published, in full. Recorded rather
+# than trimmed: an earlier draft of this file carried only the 0.21.x
+# slice, and the ghost-tag check then (correctly) flagged all of v0.17-
+# v0.20 as ghosts. The test failed, the data was wrong, and fixing it
+# surfaced a SEVENTH ghost nobody had noticed — v0.17.1. Trimmed fixtures
+# hide exactly the thing this check exists to find.
+PYPI_RELEASES = {
+    "0.1.0", "0.2.0",
+    "0.3.0", "0.3.1", "0.3.2", "0.3.3",
+    "0.4.0", "0.4.1", "0.4.2",
+    "0.5.0", "0.7.0", "0.7.1", "0.9.0", "0.9.1",
+    "0.10.0", "0.10.1", "0.10.2", "0.10.3", "0.10.4", "0.10.5", "0.10.6", "0.10.7",
+    "0.12.0", "0.13.0", "0.14.0", "0.15.0", "0.16.0",
+    # NOTE: 0.17.1 is absent. Tag v0.17.1 exists. Ghost #7.
+    "0.17.0", "0.17.2", "0.17.3",
+    "0.18.0", "0.19.0", "0.20.0",
+    "0.21.0", "0.21.1", "0.21.2", "0.21.3", "0.21.4", "0.21.5",
+    # 0.21.6 absent — ghost.   0.21.8 absent — ghost.
+    "0.21.7",
+    # 0.21.10 absent — ghost.  0.21.12 absent — ghost.
+    "0.21.9", "0.21.11", "0.21.13", "0.21.14",
+    # 0.21.15 absent — ghost (run CANCELLED).
+    # 0.21.16 absent — ghost (run FAILED). This is the incident.
+    "0.21.17",
+}
+
+PYPI_LATEST = "0.21.17"
+
+# Every tag that never reached PyPI. EIGHT, not the two anyone remembered
+# — confirmed against the live systems on 2026-07-14, and the live `sac
+# freshness refresh` reports exactly this set.
+ALL_GHOSTS = {
+    "v0.6.0",
+    "v0.17.1",
+    "v0.21.6",
+    "v0.21.8",
+    "v0.21.10",
+    "v0.21.12",
+    "v0.21.15",
+    "v0.21.16",
+}
+
+# The COMPLETE tag list — `git tag -l 'v*'`, all 44, nothing trimmed.
+# An earlier draft kept only the tail of this list, which quietly hid two
+# ghosts (v0.6.0 and v0.17.1). A fixture that is a convenient subset of
+# reality is how a check gets tuned against a world that does not exist.
+GIT_TAGS = [
+    "v0.5.0", "v0.6.0", "v0.7.0", "v0.7.1", "v0.9.0", "v0.9.1",
+    "v0.10.0", "v0.10.1", "v0.10.2", "v0.10.3",
+    "v0.10.4", "v0.10.5", "v0.10.6", "v0.10.7",
+    "v0.12.0", "v0.13.0", "v0.14.0", "v0.15.0", "v0.16.0",
+    "v0.17.0", "v0.17.1", "v0.17.2", "v0.17.3",
+    "v0.18.0", "v0.19.0", "v0.20.0",
+    "v0.21.0", "v0.21.1", "v0.21.2", "v0.21.3", "v0.21.4",
+    "v0.21.5", "v0.21.6", "v0.21.7", "v0.21.8", "v0.21.9",
+    "v0.21.10", "v0.21.11", "v0.21.12", "v0.21.13", "v0.21.14",
+    "v0.21.15", "v0.21.16", "v0.21.17",
+]
+
+# The two the operator named. Both real, both never published.
+KNOWN_GHOSTS = ("v0.21.15", "v0.21.16")
+
+RELEASE_RUNS = [
+    {
+        "conclusion": "success",
+        "status": "completed",
+        "headBranch": "v0.21.17",
+        "createdAt": "2026-07-14T01:37:33Z",
+        "url": "https://github.com/scitex-ai/scitex-agent-container/actions/runs/29299020678",
+    },
+    {
+        "conclusion": "failure",
+        "status": "completed",
+        "headBranch": "v0.21.16",
+        "createdAt": "2026-07-13T23:24:19Z",
+        "url": "https://github.com/scitex-ai/scitex-agent-container/actions/runs/29292943090",
+    },
+    {
+        "conclusion": "cancelled",
+        "status": "completed",
+        "headBranch": "v0.21.15",
+        "createdAt": "2026-07-13T20:58:50Z",
+        "url": "https://github.com/scitex-ai/scitex-agent-container/actions/runs/29284554656",
+    },
+    {
+        "conclusion": "success",
+        "status": "completed",
+        "headBranch": "v0.21.14",
+        "createdAt": "2026-07-13T15:18:40Z",
+        "url": "https://github.com/scitex-ai/scitex-agent-container/actions/runs/29261686336",
+    },
+]
+
+# What the host actually had installed while all of the above was true.
+HOST_INSTALLED = "0.21.14"
+
+
+# ---------------------------------------------------------------------------
+# AT THE INCIDENT (2026-07-13 ~23:30 UTC): v0.21.16 tagged, run FAILED,
+# PyPI still on 0.21.14, host on 0.21.14. Nothing alarmed.
+# ---------------------------------------------------------------------------
+
+AT_INCIDENT_PYPI_RELEASES = PYPI_RELEASES - {"0.21.17"}
+AT_INCIDENT_PYPI_LATEST = "0.21.14"
+AT_INCIDENT_GIT_TAGS = [t for t in GIT_TAGS if t != "v0.21.17"]
+AT_INCIDENT_RELEASE_RUNS = [
+    r for r in RELEASE_RUNS if r["headBranch"] != "v0.21.17"
+]
+
+# EOF

--- a/tests/scitex_agent_container/_freshness/conftest.py
+++ b/tests/scitex_agent_container/_freshness/conftest.py
@@ -1,0 +1,38 @@
+"""Real environment manipulation — no monkeypatch (STX-NM002).
+
+``os.environ`` IS the production collaborator here: ``_cache`` and
+``_warn`` read it live, on purpose, so that a container or a test can
+redirect them. So the honest way to test that is to set the real variable
+and put it back afterwards — which is all this fixture does.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def env():
+    """Set/unset real env vars for one test; restore exactly on teardown."""
+    saved: dict[str, str | None] = {}
+
+    def _set(name: str, value: str | None) -> None:
+        if name not in saved:
+            saved[name] = os.environ.get(name)
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+
+    yield _set
+
+    for name, old in saved.items():
+        if old is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = old
+
+
+# EOF

--- a/tests/scitex_agent_container/_freshness/test__cache.py
+++ b/tests/scitex_agent_container/_freshness/test__cache.py
@@ -1,0 +1,198 @@
+"""Cache round-trip, TTL, and the anti-fork guard on path resolution.
+
+``test_cache_path_matches_ecosystem_resolver`` is the important one: the
+CLI hot path cannot afford to import ``scitex_config._ecosystem`` (1.59 s,
+measured), so ``_cache`` mirrors its one-line ``$SCITEX_DIR`` contract in
+stdlib. That mirror is only safe while it is PINNED — this test is what
+turns "a fork waiting to drift" into "SSOT held by a test".
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+from scitex_agent_container._freshness._cache import (
+    DEFAULT_TTL_S,
+    cache_path,
+    read_cache,
+    scitex_dir,
+    write_cache,
+)
+from scitex_agent_container._freshness._model import (
+    Finding,
+    Freshness,
+    FreshnessReport,
+)
+
+
+def _report(state=Freshness.STALE, at=None):
+    return FreshnessReport(
+        findings=(
+            Finding(
+                check="host-behind-pypi",
+                state=state,
+                summary="installed 0.21.14 is BEHIND PyPI 0.21.17",
+                remedy="pip install -U scitex-agent-container==0.21.17",
+            ),
+        ),
+        generated_at=time.time() if at is None else at,
+    )
+
+
+def test_cache_round_trips_the_verdict(tmp_path):
+    # Arrange
+    path = tmp_path / "freshness.json"
+
+    # Act
+    write_cache(_report(), path)
+    loaded = read_cache(path)
+
+    # Assert
+    assert loaded.state is Freshness.STALE
+
+
+def test_cache_round_trips_the_remedy(tmp_path):
+    """The fix command must survive the trip — it is the actionable half."""
+    # Arrange
+    path = tmp_path / "freshness.json"
+
+    # Act
+    write_cache(_report(), path)
+    loaded = read_cache(path)
+
+    # Assert
+    assert loaded.findings[0].remedy == "pip install -U scitex-agent-container==0.21.17"
+
+
+def test_missing_cache_reads_as_unknown(tmp_path):
+    """No file => None => UNKNOWN => the CLI stays silent."""
+    # Arrange
+    path = tmp_path / "nope.json"
+
+    # Act
+    loaded = read_cache(path)
+
+    # Assert
+    assert loaded is None
+
+
+def test_corrupt_cache_reads_as_unknown(tmp_path):
+    """A half-written or garbled file must never be parsed into a verdict."""
+    # Arrange
+    path = tmp_path / "freshness.json"
+    path.write_text("{ this is not json")
+
+    # Act
+    loaded = read_cache(path)
+
+    # Assert
+    assert loaded is None
+
+
+def test_expired_cache_reads_as_unknown(tmp_path):
+    """An old cache means the refresher died. Its last answer is a fossil.
+
+    Serving it would be exactly the bug this subsystem exists to kill: a
+    confident claim backed by nothing current.
+    """
+    # Arrange — written just over the TTL ago.
+    path = tmp_path / "freshness.json"
+    write_cache(_report(at=time.time() - DEFAULT_TTL_S - 60), path)
+
+    # Act
+    loaded = read_cache(path)
+
+    # Assert
+    assert loaded is None
+
+
+def test_fresh_cache_within_ttl_is_served(tmp_path):
+    # Arrange
+    path = tmp_path / "freshness.json"
+    write_cache(_report(at=time.time() - 60), path)
+
+    # Act
+    loaded = read_cache(path)
+
+    # Assert
+    assert loaded is not None
+
+
+def test_undated_cache_reads_as_unknown(tmp_path):
+    """No timestamp means we cannot age it, so we cannot trust it."""
+    # Arrange
+    path = tmp_path / "freshness.json"
+    path.write_text(json.dumps({"state": "stale", "findings": []}))
+
+    # Act
+    loaded = read_cache(path)
+
+    # Assert
+    assert loaded is None
+
+
+def test_cache_write_is_atomic(tmp_path):
+    """No .tmp left behind — a reader must never catch a torn file."""
+    # Arrange
+    path = tmp_path / "freshness.json"
+
+    # Act
+    write_cache(_report(), path)
+
+    # Assert
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_env_override_redirects_the_cache(tmp_path, env):
+    """$SAC_FRESHNESS_CACHE is the seam containers and tests use."""
+    # Arrange
+    target = tmp_path / "elsewhere.json"
+    env("SAC_FRESHNESS_CACHE", str(target))
+
+    # Act
+    resolved = cache_path()
+
+    # Assert
+    assert resolved == target
+
+
+def test_cache_path_follows_scitex_dir(tmp_path, env):
+    """$SCITEX_DIR moves the whole tree — resolved per call, not at import.
+
+    An import-time Path.home() constant could not be redirected by a test
+    that sets the env afterwards; that exact bug had tests reading and
+    writing the REAL fleet registry.
+    """
+    # Arrange
+    env("SAC_FRESHNESS_CACHE", None)
+    env("SCITEX_DIR", str(tmp_path))
+
+    # Act
+    resolved = cache_path()
+
+    # Assert
+    assert resolved.is_relative_to(tmp_path)
+
+
+def test_cache_path_matches_ecosystem_resolver(tmp_path, env):
+    """Our stdlib mirror must agree with the ecosystem's canonical resolver.
+
+    We cannot IMPORT ``local_state`` on the CLI hot path (1.59 s), so we
+    mirror its contract — and pin the mirror here. If the ecosystem ever
+    changes where ``$SCITEX_DIR`` points, this fails loudly instead of the
+    writer and the reader silently disagreeing about where the file is.
+    """
+    # Arrange
+    from scitex_config._ecosystem import local_state
+
+    env("SCITEX_DIR", str(tmp_path))
+
+    # Act
+    ours = scitex_dir()
+
+    # Assert
+    assert ours == local_state.user_root()
+
+
+# EOF

--- a/tests/scitex_agent_container/_freshness/test__checks.py
+++ b/tests/scitex_agent_container/_freshness/test__checks.py
@@ -1,0 +1,387 @@
+"""The four conditions, driven by REAL recorded evidence (PA-306: no mocks).
+
+``StaticSources`` is a genuine implementation of the ``Sources`` protocol
+whose backing store is a dict rather than a network — the checks run their
+real code path against the real bytes PyPI, git and gh actually returned.
+No monkeypatching, no network.
+
+The test that earns this file its place is
+``test_would_have_caught_the_incident``: it replays the fleet exactly as it
+stood at 2026-07-13 23:30 and asserts the alarm fires. Everything else here
+is scaffolding around that one question.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._freshness._checks import (
+    build_report,
+    check_ghost_tags,
+    check_host_behind_pypi,
+    check_release_runs,
+    check_running_vs_installed,
+)
+from scitex_agent_container._freshness._model import Freshness
+from scitex_agent_container._freshness._sources import StaticSources
+
+from ._real_data import (
+    ALL_GHOSTS,
+    AT_INCIDENT_GIT_TAGS,
+    AT_INCIDENT_PYPI_LATEST,
+    AT_INCIDENT_PYPI_RELEASES,
+    AT_INCIDENT_RELEASE_RUNS,
+    GIT_TAGS,
+    HOST_INSTALLED,
+    KNOWN_GHOSTS,
+    PYPI_LATEST,
+    PYPI_RELEASES,
+    RELEASE_RUNS,
+)
+
+UNIT = "sac-listen.service"
+
+
+# ---------------------------------------------------------------------------
+# THE REGRESSION TEST. This is the whole point of the feature.
+# ---------------------------------------------------------------------------
+
+
+def test_would_have_caught_the_incident_as_stale():
+    """Replaying 2026-07-13 23:30, the alarm must fire.
+
+    Tag v0.21.16 exists, its release run FAILED, PyPI is still on 0.21.14
+    and so is the host. The fleet then spent a day re-diagnosing an
+    already-fixed bug because nothing said a word. If this assertion ever
+    goes green-as-FRESH, the alarm is worthless.
+    """
+    # Arrange — the fleet exactly as it stood, from real recorded data.
+    sources = StaticSources(
+        pypi_versions=AT_INCIDENT_PYPI_RELEASES,
+        pypi_latest=AT_INCIDENT_PYPI_LATEST,
+        installed_version=HOST_INSTALLED,
+        git_tags=AT_INCIDENT_GIT_TAGS,
+        release_runs=AT_INCIDENT_RELEASE_RUNS,
+        installed_at=1_000.0,
+        daemon_started_at=900.0,
+    )
+
+    # Act
+    report = build_report(sources, unit=UNIT, now=1.0)
+
+    # Assert
+    assert report.state is Freshness.STALE
+
+
+def test_incident_names_the_ghost_tag():
+    """The alarm must name v0.21.16 — the tag that looked shipped and wasn't."""
+    # Arrange
+    # Act
+    finding = check_ghost_tags(
+        AT_INCIDENT_GIT_TAGS, AT_INCIDENT_PYPI_RELEASES
+    )
+
+    # Assert
+    assert "v0.21.16" in finding.summary
+
+
+def test_incident_head_ghost_is_stale():
+    """A head tag with no PyPI release is positive evidence, not a shrug."""
+    # Arrange
+    # Act
+    finding = check_ghost_tags(AT_INCIDENT_GIT_TAGS, AT_INCIDENT_PYPI_RELEASES)
+
+    # Assert
+    assert finding.state is Freshness.STALE
+
+
+# ---------------------------------------------------------------------------
+# ghost-tag
+# ---------------------------------------------------------------------------
+
+
+def test_ghost_tags_lists_both_known_ghosts():
+    """v0.21.15 and v0.21.16 are ghosts today and must be reported as such."""
+    # Arrange
+    # Act
+    finding = check_ghost_tags(GIT_TAGS, PYPI_RELEASES)
+
+    # Assert
+    assert set(KNOWN_GHOSTS).issubset(set(finding.data["ghosts"]))
+
+
+def test_superseded_ghosts_raise_no_alarm():
+    """Once a later version ships, an old ghost has no remedy — so no alarm.
+
+    It stays visible in the report; it just stops shouting. An alarm with
+    no action attached is noise, and noise is how a check gets muted.
+    """
+    # Arrange
+    # Act
+    finding = check_ghost_tags(GIT_TAGS, PYPI_RELEASES)
+
+    # Assert
+    assert finding.state is Freshness.FRESH
+
+
+def test_ghost_tags_finds_every_real_ghost():
+    """SEVEN tags never shipped, not the two anyone remembered.
+
+    v0.17.1, v0.21.6, v0.21.8, v0.21.10, v0.21.12, v0.21.15, v0.21.16.
+    The drift is systemic, not a one-off — which is the real answer to
+    "how many times is this?"
+    """
+    # Arrange
+    # Act
+    finding = check_ghost_tags(GIT_TAGS, PYPI_RELEASES)
+
+    # Assert
+    assert set(finding.data["ghosts"]) == ALL_GHOSTS
+
+
+def test_ghost_tags_unknown_without_pypi():
+    """No PyPI answer means UNKNOWN — never 'no ghosts'."""
+    # Arrange
+    # Act
+    finding = check_ghost_tags(GIT_TAGS, None)
+
+    # Assert
+    assert finding.state is Freshness.UNKNOWN
+
+
+def test_ghost_tags_unknown_without_checkout():
+    """A wheel-only host cannot read tags. That is UNKNOWN, not clean."""
+    # Arrange
+    # Act
+    finding = check_ghost_tags(None, PYPI_RELEASES)
+
+    # Assert
+    assert finding.state is Freshness.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# host-behind-pypi
+# ---------------------------------------------------------------------------
+
+
+def test_host_behind_pypi_is_stale():
+    """The live case: host on 0.21.14, PyPI on 0.21.17."""
+    # Arrange
+    # Act
+    finding = check_host_behind_pypi(HOST_INSTALLED, PYPI_LATEST)
+
+    # Assert
+    assert finding.state is Freshness.STALE
+
+
+def test_host_behind_pypi_names_the_remedy():
+    """An alarm without a fix command is one people learn to skip."""
+    # Arrange
+    # Act
+    finding = check_host_behind_pypi(HOST_INSTALLED, PYPI_LATEST, python="/v/bin/python")
+
+    # Assert
+    assert finding.remedy == "/v/bin/python -m pip install -U 'scitex-agent-container==0.21.17'"
+
+
+def test_host_current_with_pypi_is_fresh():
+    # Arrange
+    # Act
+    finding = check_host_behind_pypi(PYPI_LATEST, PYPI_LATEST)
+
+    # Assert
+    assert finding.state is Freshness.FRESH
+
+
+def test_host_ahead_of_pypi_is_not_stale():
+    """A dev build ahead of PyPI is not behind it.
+
+    Warning a developer that their own unpublished build is 'stale' is
+    exactly the false positive that gets a version check disabled.
+    """
+    # Arrange
+    # Act
+    finding = check_host_behind_pypi("0.21.18", PYPI_LATEST)
+
+    # Assert
+    assert finding.state is Freshness.FRESH
+
+
+def test_host_behind_unknown_when_offline():
+    """Offline is UNKNOWN. It is emphatically not 'up to date'."""
+    # Arrange
+    # Act
+    finding = check_host_behind_pypi(HOST_INSTALLED, None)
+
+    # Assert
+    assert finding.state is Freshness.UNKNOWN
+
+
+def test_host_behind_unknown_on_unparseable_version():
+    """We refuse to order what we cannot parse."""
+    # Arrange
+    # Act
+    finding = check_host_behind_pypi("dev", PYPI_LATEST)
+
+    # Assert
+    assert finding.state is Freshness.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# running-vs-installed
+# ---------------------------------------------------------------------------
+
+
+def test_daemon_older_than_install_is_stale():
+    """Installed is not running: the upgrade landed after the daemon booted."""
+    # Arrange — daemon up at t=1000, package written at t=5000.
+    # Act
+    finding = check_running_vs_installed(1_000.0, 5_000.0, unit=UNIT)
+
+    # Assert
+    assert finding.state is Freshness.STALE
+
+
+def test_daemon_restart_is_the_remedy():
+    """Upgrading alone changes nothing; only a restart reloads the code."""
+    # Arrange
+    # Act
+    finding = check_running_vs_installed(1_000.0, 5_000.0, unit=UNIT)
+
+    # Assert
+    assert finding.remedy == f"systemctl --user restart {UNIT}"
+
+
+def test_daemon_newer_than_install_is_fresh():
+    # Arrange — package written at t=1000, daemon (re)started at t=5000.
+    # Act
+    finding = check_running_vs_installed(5_000.0, 1_000.0, unit=UNIT)
+
+    # Assert
+    assert finding.state is Freshness.FRESH
+
+
+def test_daemon_not_running_is_unknown():
+    """A daemon that is not running is not running STALE code."""
+    # Arrange
+    # Act
+    finding = check_running_vs_installed(None, 5_000.0, unit=UNIT)
+
+    # Assert
+    assert finding.state is Freshness.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# release-run
+# ---------------------------------------------------------------------------
+
+
+def test_failed_release_run_is_stale():
+    """v0.21.16's run FAILED — build/publish never ran, nothing shipped."""
+    # Arrange
+    # Act
+    finding = check_release_runs(AT_INCIDENT_RELEASE_RUNS)
+
+    # Assert
+    assert finding.state is Freshness.STALE
+
+
+def test_cancelled_release_run_is_stale():
+    """v0.21.15's run was CANCELLED, not failed. It shipped just as little.
+
+    'Not success' is one class precisely because these were the two real
+    cases, and a check that only looked for 'failure' would have missed one.
+    """
+    # Arrange
+    cancelled_only = [
+        r for r in RELEASE_RUNS if r["headBranch"] in ("v0.21.15", "v0.21.14")
+    ]
+
+    # Act
+    finding = check_release_runs(cancelled_only)
+
+    # Assert
+    assert finding.state is Freshness.STALE
+
+
+def test_successful_release_run_is_fresh():
+    # Arrange
+    # Act
+    finding = check_release_runs(RELEASE_RUNS)
+
+    # Assert
+    assert finding.state is Freshness.FRESH
+
+
+def test_release_run_unknown_without_gh():
+    # Arrange
+    # Act
+    finding = check_release_runs(None)
+
+    # Assert
+    assert finding.state is Freshness.UNKNOWN
+
+
+def test_in_flight_run_is_not_judged():
+    """A run still going says nothing yet about whether it will ship."""
+    # Arrange
+    running = [{"status": "in_progress", "conclusion": None, "headBranch": "v9.9.9"}]
+
+    # Act
+    finding = check_release_runs(running)
+
+    # Assert
+    assert finding.state is Freshness.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_blind_report_is_unknown_not_fresh():
+    """Every source dark => UNKNOWN. This is the anti-false-green test.
+
+    A report that can see nothing must never summarise itself as fine.
+    """
+    # Arrange
+    sources = StaticSources()
+
+    # Act
+    report = build_report(sources, unit=UNIT, now=1.0)
+
+    # Assert
+    assert report.state is not Freshness.FRESH
+
+
+def test_one_stale_finding_makes_report_stale():
+    """Positive evidence of a problem outranks any number of clean checks."""
+    # Arrange — everything current except the host, which is behind.
+    sources = StaticSources(
+        pypi_versions=PYPI_RELEASES,
+        pypi_latest=PYPI_LATEST,
+        installed_version=HOST_INSTALLED,
+        git_tags=GIT_TAGS,
+        release_runs=RELEASE_RUNS,
+        installed_at=1_000.0,
+        daemon_started_at=5_000.0,
+    )
+
+    # Act
+    report = build_report(sources, unit=UNIT, now=1.0)
+
+    # Assert
+    assert report.state is Freshness.STALE
+
+
+def test_stale_findings_exclude_unknown():
+    """Only STALE is actionable. UNKNOWN must never reach the alarm."""
+    # Arrange — PyPI dark, so most checks are UNKNOWN.
+    sources = StaticSources(installed_version=HOST_INSTALLED, git_tags=GIT_TAGS)
+
+    # Act
+    report = build_report(sources, unit=UNIT, now=1.0)
+
+    # Assert
+    assert report.stale == ()
+
+
+# EOF

--- a/tests/scitex_agent_container/_freshness/test__symbols.py
+++ b/tests/scitex_agent_container/_freshness/test__symbols.py
@@ -1,0 +1,125 @@
+"""Symbol probes against REAL modules (PA-306: no mocks).
+
+The UNKNOWN case is driven by writing a real module to ``tmp_path`` that
+imports a genuinely-missing dependency, then importing it for real. That
+is the actual failure we must distinguish from "the symbol is absent",
+and the only way to test it honestly is to cause it.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from scitex_agent_container._freshness._symbols import (
+    EXPECTATIONS,
+    SymbolExpectation,
+    probe,
+    probe_all,
+)
+
+OFF_LOOP = "scitex_agent_container._lifecycle._off_loop"
+
+
+def test_registered_fix_is_present_in_loaded_code():
+    """#658's counter really is in this checkout — probed, not assumed.
+
+    This is the canonical example: `abandoned_call_count` exists ONLY in
+    the fixed `_off_loop`, so `hasattr` answers "is the fix in the code I
+    am running" without consulting any version string.
+    """
+    # Arrange
+    expectation = SymbolExpectation(
+        module=OFF_LOOP,
+        symbol="abandoned_call_count",
+        since="0.21.15",
+        why="#658 shared-executor thread leak",
+    )
+
+    # Act
+    result = probe(expectation)
+
+    # Assert
+    assert result is True
+
+
+def test_absent_symbol_probes_false():
+    """A real module, a symbol that is not in it => the fix is not here."""
+    # Arrange
+    expectation = SymbolExpectation(
+        module=OFF_LOOP,
+        symbol="a_symbol_that_was_never_written",
+        since="9.9.9",
+        why="a fix that does not exist",
+    )
+
+    # Act
+    result = probe(expectation)
+
+    # Assert
+    assert result is False
+
+
+def test_absent_module_probes_false():
+    """The module itself missing is still positive evidence the fix is not here."""
+    # Arrange
+    expectation = SymbolExpectation(
+        module="scitex_agent_container._a_module_that_never_shipped",
+        symbol="whatever",
+        since="9.9.9",
+        why="a module that does not exist",
+    )
+
+    # Act
+    result = probe(expectation)
+
+    # Assert
+    assert result is False
+
+
+def test_broken_dependency_probes_unknown(tmp_path):
+    """A module whose OWN dependency is broken tells us nothing about our symbol.
+
+    Returning False here would be a false RED — "the fix is missing!" when
+    the truth is "this module's import chain is broken". A false RED is the
+    dangerous kind, because someone acts on it. So: UNKNOWN.
+    """
+    # Arrange — a real module that really fails to import, for a reason
+    # that has nothing to do with the symbol we are asking about.
+    broken = tmp_path / "sac_freshness_broken_probe.py"
+    broken.write_text("import a_package_that_is_not_installed_anywhere\n")
+    sys.path.insert(0, str(tmp_path))
+    expectation = SymbolExpectation(
+        module="sac_freshness_broken_probe",
+        symbol="anything",
+        since="9.9.9",
+        why="its dependency is missing, which is not evidence about us",
+    )
+
+    # Act
+    try:
+        result = probe(expectation)
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("sac_freshness_broken_probe", None)
+
+    # Assert
+    assert result is None
+
+
+def test_shipped_registry_probes_clean_here():
+    """Every registered expectation holds in this checkout.
+
+    If this fails, either a registered symbol was renamed/removed (fix the
+    registry) or the registry is claiming a fix that never landed (fix the
+    claim). Both are bugs worth failing the build over — a registry that
+    lies is worse than an empty one.
+    """
+    # Arrange
+    # Act
+    results = probe_all(EXPECTATIONS)
+
+    # Assert
+    assert all(present is True for _, present in results)
+
+
+# EOF

--- a/tests/scitex_agent_container/_freshness/test__version.py
+++ b/tests/scitex_agent_container/_freshness/test__version.py
@@ -1,0 +1,136 @@
+"""Version ordering. The contract: what it cannot parse, it refuses to judge."""
+
+from __future__ import annotations
+
+from scitex_agent_container._freshness._version import (
+    compare,
+    is_behind,
+    latest,
+    parse,
+)
+
+
+def test_orders_by_number_not_string():
+    """0.21.9 < 0.21.17. String comparison gets this backwards, and the
+    whole 0.21 line lives exactly where it would bite."""
+    # Arrange
+    # Act
+    result = compare("0.21.9", "0.21.17")
+
+    # Assert
+    assert result == -1
+
+
+def test_tag_and_release_compare_equal():
+    """v0.21.17 (git) and 0.21.17 (PyPI) are the same release.
+
+    The ghost-tag check is precisely the act of lining these two spellings
+    up, so they must compare equal or every tag reads as a ghost.
+    """
+    # Arrange
+    # Act
+    result = compare("v0.21.17", "0.21.17")
+
+    # Assert
+    assert result == 0
+
+
+def test_prerelease_sorts_before_final():
+    # Arrange
+    # Act
+    result = compare("0.21.17rc1", "0.21.17")
+
+    # Assert
+    assert result == -1
+
+
+def test_unparseable_version_returns_none():
+    """'dev' is not a version. Guessing is how a comparator lies."""
+    # Arrange
+    # Act
+    result = parse("dev")
+
+    # Assert
+    assert result is None
+
+
+def test_compare_with_unparseable_is_unknown():
+    # Arrange
+    # Act
+    result = compare("0.0.0+unknown", "0.21.17")
+
+    # Assert
+    assert result is None
+
+
+def test_older_install_is_behind():
+    # Arrange
+    # Act
+    result = is_behind("0.21.14", "0.21.17")
+
+    # Assert
+    assert result is True
+
+
+def test_equal_install_is_not_behind():
+    # Arrange
+    # Act
+    result = is_behind("0.21.17", "0.21.17")
+
+    # Assert
+    assert result is False
+
+
+def test_newer_install_is_not_behind():
+    """Ahead is not behind. A dev build must not be nagged as 'stale'."""
+    # Arrange
+    # Act
+    result = is_behind("0.22.0", "0.21.17")
+
+    # Assert
+    assert result is False
+
+
+def test_behind_is_unknown_when_unparseable():
+    # Arrange
+    # Act
+    result = is_behind("dev", "0.21.17")
+
+    # Assert
+    assert result is None
+
+
+def test_latest_picks_highest_release():
+    """Real PyPI list; 0.21.17 is newest despite 0.21.9 sorting later as text."""
+    # Arrange
+    releases = ["0.21.4", "0.21.9", "0.21.14", "0.21.17", "0.21.11"]
+
+    # Act
+    result = latest(releases)
+
+    # Assert
+    assert result == "0.21.17"
+
+
+def test_latest_skips_unparseable_entries():
+    """One weird string on PyPI must not blind the whole check."""
+    # Arrange
+    releases = ["0.21.14", "not-a-version", "0.21.17"]
+
+    # Act
+    result = latest(releases)
+
+    # Assert
+    assert result == "0.21.17"
+
+
+def test_latest_of_nothing_is_none():
+    # Arrange
+    # Act
+    result = latest([])
+
+    # Assert
+    assert result is None
+
+
+# EOF

--- a/tests/scitex_agent_container/_freshness/test__warn.py
+++ b/tests/scitex_agent_container/_freshness/test__warn.py
@@ -1,0 +1,252 @@
+"""The every-invocation warning: it must speak on STALE and ONLY on STALE.
+
+Driven through the real cache file and the real env vars — the same seams
+production uses. ``warn_if_stale`` writes to an injected stream (the same
+seam ``_drift.warn_if_spec_source_drifted`` uses), so the output is
+captured without touching sys.stderr.
+"""
+
+from __future__ import annotations
+
+import io
+import time
+
+from scitex_agent_container._freshness._cache import write_cache
+from scitex_agent_container._freshness._model import (
+    Finding,
+    Freshness,
+    FreshnessReport,
+)
+from scitex_agent_container._freshness._warn import EXIT_STALE, warn_if_stale
+
+
+def _write(path, state, at=None):
+    report = FreshnessReport(
+        findings=(
+            Finding(
+                check="host-behind-pypi",
+                state=state,
+                summary="installed 0.21.14 is BEHIND PyPI 0.21.17",
+                remedy="pip install -U 'scitex-agent-container==0.21.17'",
+            ),
+        ),
+        generated_at=time.time() if at is None else at,
+    )
+    write_cache(report, path)
+    return path
+
+
+def test_stale_cache_warns_on_stream(tmp_path, env):
+    """The operator's ask: typing sac tells you that you are behind."""
+    # Arrange
+    cache = _write(tmp_path / "f.json", Freshness.STALE)
+    env("SAC_FRESHNESS_CACHE", str(cache))
+    env("SAC_FRESHNESS_QUIET", None)
+    env("SAC_FRESHNESS_SEVERITY", None)
+    out = io.StringIO()
+
+    # Act
+    warn_if_stale(stream=out)
+
+    # Assert
+    assert "BEHIND PyPI 0.21.17" in out.getvalue()
+
+
+def test_warning_names_the_fix_command(tmp_path, env):
+    """An alarm that does not say what to DO is one people learn to skip."""
+    # Arrange
+    cache = _write(tmp_path / "f.json", Freshness.STALE)
+    env("SAC_FRESHNESS_CACHE", str(cache))
+    env("SAC_FRESHNESS_QUIET", None)
+    env("SAC_FRESHNESS_SEVERITY", None)
+    out = io.StringIO()
+
+    # Act
+    warn_if_stale(stream=out)
+
+    # Assert
+    assert "pip install -U 'scitex-agent-container==0.21.17'" in out.getvalue()
+
+
+def test_fresh_cache_says_nothing(tmp_path, env):
+    # Arrange
+    cache = _write(tmp_path / "f.json", Freshness.FRESH)
+    env("SAC_FRESHNESS_CACHE", str(cache))
+    env("SAC_FRESHNESS_QUIET", None)
+    env("SAC_FRESHNESS_SEVERITY", None)
+    out = io.StringIO()
+
+    # Act
+    warn_if_stale(stream=out)
+
+    # Assert
+    assert out.getvalue() == ""
+
+
+def test_unknown_cache_says_nothing(tmp_path, env):
+    """UNKNOWN is SILENT. Not 'fine' — silent.
+
+    A check that nags when it does not know gets muted within a day, and a
+    muted check is worth less than no check, because everyone still
+    believes it is watching.
+    """
+    # Arrange
+    cache = _write(tmp_path / "f.json", Freshness.UNKNOWN)
+    env("SAC_FRESHNESS_CACHE", str(cache))
+    env("SAC_FRESHNESS_QUIET", None)
+    env("SAC_FRESHNESS_SEVERITY", None)
+    out = io.StringIO()
+
+    # Act
+    warn_if_stale(stream=out)
+
+    # Assert
+    assert out.getvalue() == ""
+
+
+def test_missing_cache_says_nothing(tmp_path, env):
+    """No evidence => no noise. This is the anti-cry-wolf guarantee."""
+    # Arrange
+    env("SAC_FRESHNESS_CACHE", str(tmp_path / "absent.json"))
+    env("SAC_FRESHNESS_QUIET", None)
+    env("SAC_FRESHNESS_SEVERITY", None)
+    out = io.StringIO()
+
+    # Act
+    warn_if_stale(stream=out)
+
+    # Assert
+    assert out.getvalue() == ""
+
+
+def test_corrupt_cache_never_breaks_the_cli(tmp_path, env):
+    """Rule 2: this may NEVER break sac. Garbage on disk => silence, exit 0."""
+    # Arrange
+    cache = tmp_path / "f.json"
+    cache.write_text("}{ not json at all")
+    env("SAC_FRESHNESS_CACHE", str(cache))
+    env("SAC_FRESHNESS_QUIET", None)
+    env("SAC_FRESHNESS_SEVERITY", None)
+    out = io.StringIO()
+
+    # Act
+    code = warn_if_stale(stream=out)
+
+    # Assert
+    assert code == 0
+
+
+def test_quiet_env_silences_the_warning(tmp_path, env):
+    """The escape hatch. Precedent: SCITEX_DEV_LINTER_QUIET."""
+    # Arrange
+    cache = _write(tmp_path / "f.json", Freshness.STALE)
+    env("SAC_FRESHNESS_CACHE", str(cache))
+    env("SAC_FRESHNESS_QUIET", "1")
+    out = io.StringIO()
+
+    # Act
+    warn_if_stale(stream=out)
+
+    # Assert
+    assert out.getvalue() == ""
+
+
+def test_warn_severity_exits_zero(tmp_path, env):
+    """Default severity WARNS — it must not break anybody's pipeline."""
+    # Arrange
+    cache = _write(tmp_path / "f.json", Freshness.STALE)
+    env("SAC_FRESHNESS_CACHE", str(cache))
+    env("SAC_FRESHNESS_QUIET", None)
+    env("SAC_FRESHNESS_SEVERITY", None)
+    out = io.StringIO()
+
+    # Act
+    code = warn_if_stale(stream=out)
+
+    # Assert
+    assert code == 0
+
+
+def test_error_severity_returns_stale_exit_code(tmp_path, env):
+    """The single knob that escalates warning -> error, when it has earned it."""
+    # Arrange
+    cache = _write(tmp_path / "f.json", Freshness.STALE)
+    env("SAC_FRESHNESS_CACHE", str(cache))
+    env("SAC_FRESHNESS_QUIET", None)
+    env("SAC_FRESHNESS_SEVERITY", "error")
+    out = io.StringIO()
+
+    # Act
+    code = warn_if_stale(stream=out)
+
+    # Assert
+    assert code == EXIT_STALE
+
+
+def test_error_severity_still_silent_when_unknown(tmp_path, env):
+    """Even escalated, UNKNOWN must not fail a command. Only STALE may.
+
+    Otherwise every offline laptop turns into a hard error and the knob
+    gets reverted, taking the whole feature with it.
+    """
+    # Arrange
+    env("SAC_FRESHNESS_CACHE", str(tmp_path / "absent.json"))
+    env("SAC_FRESHNESS_QUIET", None)
+    env("SAC_FRESHNESS_SEVERITY", "error")
+    out = io.StringIO()
+
+    # Act
+    code = warn_if_stale(stream=out)
+
+    # Assert
+    assert code == 0
+
+
+def test_bad_severity_value_falls_back_to_warn(tmp_path, env):
+    """A typo in an env var must never be able to break sac."""
+    # Arrange
+    cache = _write(tmp_path / "f.json", Freshness.STALE)
+    env("SAC_FRESHNESS_CACHE", str(cache))
+    env("SAC_FRESHNESS_QUIET", None)
+    env("SAC_FRESHNESS_SEVERITY", "erorr")
+    out = io.StringIO()
+
+    # Act
+    code = warn_if_stale(stream=out)
+
+    # Assert
+    assert code == 0
+
+
+def test_silent_severity_suppresses_stale(tmp_path, env):
+    # Arrange
+    cache = _write(tmp_path / "f.json", Freshness.STALE)
+    env("SAC_FRESHNESS_CACHE", str(cache))
+    env("SAC_FRESHNESS_QUIET", None)
+    env("SAC_FRESHNESS_SEVERITY", "silent")
+    out = io.StringIO()
+
+    # Act
+    warn_if_stale(stream=out)
+
+    # Assert
+    assert out.getvalue() == ""
+
+
+def test_expired_cache_says_nothing(tmp_path, env):
+    """A dead refresher's last answer is a fossil, not evidence."""
+    # Arrange — 30 days old, far past any TTL.
+    cache = _write(tmp_path / "f.json", Freshness.STALE, at=time.time() - 30 * 86_400)
+    env("SAC_FRESHNESS_CACHE", str(cache))
+    env("SAC_FRESHNESS_QUIET", None)
+    env("SAC_FRESHNESS_SEVERITY", None)
+    out = io.StringIO()
+
+    # Act
+    warn_if_stale(stream=out)
+
+    # Assert
+    assert out.getvalue() == ""
+
+
+# EOF


### PR DESCRIPTION
## Why

**We are not failing to FIX these bugs. We are failing to SHIP them.**

On 2026-07-13 seven PRs fixed the `sac listen` wedge (#658, #663, #644, #656, #657, #661, #662). All merged. The host ran **0.21.14 the entire time — which predates every one of them.** Agents hand-drained the wedged pool and re-diagnosed the same already-fixed bug for a day, because three consecutive tags never reached PyPI and **nothing anywhere said a word**.

A "ghost tag" is the exact failure mode: `git tag` succeeds, the release workflow dies, and nothing alarms. The tag exists, so it *looks* released.

The drift is **structural, not bad luck.** A release is `tag → test → build → publish`. The tag is a local action that always succeeds; everything downstream is async and can fail silently. **No consumer ever compared what it was RUNNING against what actually SHIPPED**, so drift was monotonic — it could only accumulate, never self-correct.

This closes the loop at the consumer.

## What this does

Every `sac` invocation now warns on **stderr** when the install is behind PyPI, naming the exact fix:

```
$ sac --version
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
sac-freshness WARNING: this sac is not what shipped.
  * installed 0.21.13 is BEHIND PyPI 0.21.17
      fix: /opt/venv-sac/bin/python -m pip install -U 'scitex-agent-container==0.21.17'
  (silence: SAC_FRESHNESS_QUIET=1   details: sac freshness check)
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

Typing `sac` is how you find out. No README required — a doc nobody opens is not a control.

## Four INDEPENDENT detections

Each is blind to the other three. On 2026-07-13 **all four were true at once** and the fleet saw none of them.

| check | detects |
|---|---|
| `ghost-tag` | a tag exists, PyPI has no such release |
| `host-behind-pypi` | the install is older than the newest release |
| `running-vs-installed` | a live daemon still executes **pre-upgrade code** (installed is NOT running — Python never reloads a module in a live process) |
| `release-run` | the release workflow ended in `failure`/`cancelled` |

### It found EIGHT ghost tags, not the two anyone remembered

`v0.6.0`, `v0.17.1`, `v0.21.6`, `v0.21.8`, `v0.21.10`, `v0.21.12`, **`v0.21.15`**, **`v0.21.16`**

A third of the 0.21 line never shipped. That is the real answer to 「これ何回目？」.

## Design constraints

- **SYMBOL-PROBE, NEVER THE VERSION STRING.** The number lies in both directions here (stale in memory / stale on disk / fossil `.dist-info`). `_symbols` asks `hasattr(mod, name)` of the module *actually loaded*, so a fix is **provable** rather than claimed. Seeded with #658's `_off_loop.abandoned_call_count`.
- **PyPI is the only truth** about what shipped. Not the tag, not the GitHub release, not the changelog — all three lied during the incident.
- **Three states: FRESH / STALE / UNKNOWN.** Only STALE ever speaks. UNKNOWN is **silent** — never "fine", and never a remedy either, because a false RED gets acted on and the action destroys a healthy thing.
- **No auto-remedy.** Never upgrades, never restarts. Surfaces only.
- **Never slow, never fatal.** Cron does the network and writes a cache; the CLI reads that cache and nothing else. Any failure degrades to silence — a staleness warning that can break the CLI is worse than the staleness it reports.

## Performance (measured, not asserted)

- `warn_if_stale()`: **1.4 ms** median (p95 4.2 ms) on a load-60 host
- imports added: **~7.5 ms** on a ~150 ms CLI budget
- `_freshness/__init__` is lazy (PEP 562): the hot path pulls in **NO** urllib / subprocess / scitex_config — verified

`scitex_config._ecosystem` (the canonical path resolver) costs **1.59 s** to import — measured — so `_cache` mirrors its one-line `$SCITEX_DIR` contract in stdlib instead. Importing it would make every `sac` call ~10x slower, which is a guaranteed revert. **The equivalence is pinned by a test** (`test_cache_path_matches_ecosystem_resolver`) so the mirror cannot silently fork.

## Hook point

`cli_entry_point`, **not** `main`'s group callback: click's eager flags skip the callback, so `sac --version` — the very command you run to ask "am I current?" — would have been the one invocation that never answered it.

## Knobs

- `SAC_FRESHNESS_QUIET=1` — silence (precedent: `SCITEX_DEV_LINTER_QUIET`)
- `SAC_FRESHNESS_SEVERITY=silent|warn|error` — the single knob to escalate warn → hard exit (exit 3) once the signal has earned that trust

## Tests

67 new, driving **real seams with real recorded evidence** (no mocks): the actual PyPI release list, the actual tag list, the actual `gh run` conclusions.

The centrepiece — `test_would_have_caught_the_incident_as_stale` — replays the fleet exactly as it stood at 2026-07-13 23:30 (head tag `v0.21.16`, its run FAILED, PyPI still 0.21.14) and asserts the alarm fires. **It proves this would have caught the incident.**

152 passed across `test_cli` + `_provenance` + `_freshness` — no regressions.

## Verified live

`sac freshness refresh` run against **real PyPI / real git tags / real gh runs** correctly reports `host-behind-pypi` STALE (0.21.13 → 0.21.17), names all 8 ghost tags, returns `running-vs-installed` as **UNKNOWN** (no systemd in-container — correctly *not* "fine"), and confirms #658's symbol is present in the loaded code.

## Follow-up (not in this PR)

The cron line is host-only (`~/.dotfiles/.crontab_list`, dotfiles-owned). The script is deployed to `~/.scitex/agent-container/bin/deploy-freshness-alarm.py`; it needs one hourly crontab entry to go live. Until then the alarm is inert but the CLI warning works as soon as this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)