### PR TITLE
release: v0.21.18 — remove the sac.listen second-supervisor landmine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to `scitex-agent-container` (sac) are recorded here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
+## [0.21.18] — 2026-07-14
+
+### Fixed
+
+- **`sac listen` was declared as a JobSpec that installs a SECOND supervisor (#672).**
+  0.21.17 shipped a `sac.listen` `kind="service"` JobSpec. scitex-dev derives the
+  unit name from the job name VERBATIM, so it materialises `sac.listen.service`
+  (a DOT) beside the `sac-listen.service` (a HYPHEN) that has actually supervised
+  the daemon since 2026-07-05 (`Restart=always`, `NRestarts=0`). systemd treats
+  them as unrelated units, so `scitex-dev service ensure sac.listen` does not adopt
+  the running supervisor — it installs a second one. Two units, both
+  `Restart=always`, both binding 127.0.0.1:7878, fighting for the port forever —
+  and **every listen restart destroys the in-memory Broker, deafening every
+  agent's inbox at once**. The JobSpec is removed and a test now pins its absence.
+  `scripts/systemd/README.md` had already warned that the two must not run
+  together ("Pick ONE"); it merged anyway.
+
 ## [0.21.17] — 2026-07-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.17"
+version = "0.21.18"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -23,11 +23,22 @@ broker, lead inbox. Before this unit landed, the listen was
 operator-started ad-hoc and could be found DOWN with nothing
 restarting it.
 
-> **Also federated as `sac.listen`** (2026-07-05, clew incident
-> `clew-incident-sac-host-listen-down`): sac's `provide_jobs()`
-> (`src/scitex_agent_container/_jobs_plugin.py`) registers a
-> `kind="service"` JobSpec for the same daemon, supervised via
-> **`scitex-dev service ensure sac.listen`**.
+> **THE HOST HAS ALREADY PICKED: this hand-maintained unit.** It was
+> installed 2026-07-05 14:38 (`Restart=always`) and has supervised the
+> daemon ever since — `NRestarts=0`. **Do NOT run
+> `scitex-dev service ensure sac.listen`.** It does not adopt this unit:
+> scitex-dev derives the unit name from the job name VERBATIM, so it
+> installs a SECOND unit, `sac.listen.service` (a DOT), beside the
+> `sac-listen.service` (a HYPHEN) already running. systemd treats them as
+> unrelated, and you get exactly the double-unit fight this file warns
+> about below — with every lost round destroying the in-memory Broker and
+> deafening every agent's inbox.
+>
+> The `sac.listen` JobSpec was therefore REMOVED from `provide_jobs()`
+> (a test now pins its absence). PR #543 added it on the premise that
+> listen "had NO SUPERVISOR" — false: this unit was created the same day
+> that PR was opened, and the PR then sat 9 days and merged unre-checked.
+> Read the rest of this section before re-federating anything.
 >
 > That verb resolves the name from the `scitex_dev.jobs` federation and
 > then — in ONE idempotent step — writes the `.service` unit,

--- a/src/scitex_agent_container/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs_plugin.py
@@ -21,15 +21,38 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 def provide_jobs() -> "list[JobSpec]":
     """Return sac's federated scheduled jobs.
 
-    Two jobs today:
+    One job today:
 
     * ``sac.accounts-refresh`` (``kind="timer"``) — a headless OAuth
       access-token refresh for EVERY stored Claude account, including the
       active one (``--include-active``), mirroring the rotated token back
       into the live ``~/.claude`` login (``--sync-active-login``).
-    * ``sac.listen`` (``kind="service"``) — the host-level HTTP/JSON
-      control plane (``127.0.0.1:7878``: push hub, spawn broker, lead
-      inbox).
+
+    ``sac listen`` is DELIBERATELY NOT declared here, and adding it back
+    would take the fleet's control plane down. scitex-dev derives a unit
+    name from the job name VERBATIM (``scitex-todo.dashboard`` ->
+    ``scitex-todo.dashboard.service``), so a ``sac.listen`` JobSpec
+    materialises ``sac.listen.service`` — while the listen that actually
+    runs on the host is ``sac-listen.service`` (a HYPHEN), hand-written
+    2026-07-05 14:38, ``Restart=always``, with ``10-venv-path`` and
+    ``20-hardening`` drop-ins. The two names differ by one character and
+    systemd treats them as unrelated units, so ``scitex-dev service ensure
+    sac.listen`` does not adopt the running supervisor — it installs a
+    SECOND one. Two units, both ``Restart=always``, both running
+    ``sac listen``, both binding 127.0.0.1:7878: they fight for the port
+    forever, and every lost round destroys the in-memory Broker, which
+    deafens EVERY agent's inbox at once.
+
+    PR #543 declared it on the premise that ``sac listen`` "had NO
+    SUPERVISOR". That premise was false by the time it merged — the
+    hand-written unit was created the SAME DAY the PR was opened, and had
+    been supervising listen for nine days (``NRestarts=0``). The PR was
+    obsolete on arrival and nobody re-checked before merging it.
+
+    If this is ever federated, it must be named ``sac-listen`` (hyphen) so
+    the derived unit is the one that already exists — and even then,
+    ``ensure`` must be shown to ADOPT the running unit rather than
+    overwrite its drop-ins. Do not re-add it without measuring that.
 
     Why ``sac.accounts-refresh`` is not ``--skip-active``: under the
     pre-2026-07-08 two-refresher model both the host timer and the
@@ -43,15 +66,12 @@ def provide_jobs() -> "list[JobSpec]":
     ``--sync-active-login`` keeps the operator's live session valid across
     the single-use refresh_token rotation.
 
-    Why ``sac.listen`` is federated here: it had NO SUPERVISOR. Declaring
-    it as a ``kind="service"`` JobSpec hands it to scitex-dev's supervisor
-    (``scitex-dev service ensure sac.listen`` — systemd ``--user`` with
-    ``Restart=`` where a user manager is reachable, else a respawn-loop
-    keep-alive), so it auto-starts on boot and comes back on ANY exit.
-    This replaces the fragile cron-based watchdog (``sac-listen-watch.sh``,
-    ``*/2`` cron) that died twice on 2026-07-05 (clew incident
-    ``clew-incident-sac-host-listen-down``) and left the whole fleet cut
-    off from the host after a CLEAN shutdown that nothing restarted.
+    The clew incident (``clew-incident-sac-host-listen-down``, 2026-07-05)
+    that motivated federating listen was ALREADY fixed on the day it
+    happened, by the hand-written ``sac-listen.service`` above — not by a
+    JobSpec. The fragile ``sac-listen-watch.sh`` ``*/2`` cron it replaced
+    is gone. Re-federating it does not fix that incident again; it only
+    adds a second supervisor to fight the first.
     """
     from scitex_dev.jobs import JobSpec
 
@@ -82,40 +102,6 @@ def provide_jobs() -> "list[JobSpec]":
             on_boot_sec="15min",
             on_unit_active_sec="2h",
             timeout_sec=120,
-        ),
-        JobSpec(
-            name="sac.listen",
-            kind="service",
-            schedule="",
-            command="sac listen",
-            description=(
-                "Host-level HTTP/JSON control plane for sac agents "
-                "(loopback 127.0.0.1:7878) — push hub, spawn broker, lead "
-                "inbox. No env vars required: SAC_LISTEN_BEARER "
-                "self-resolves from the on-disk token file "
-                "(~/.scitex/agent-container/tokens/listen-<host>.token) "
-                "when unset (PR #470)."
-            ),
-            # restart_policy="always", NOT "on-failure": Incident
-            # 2026-06-26 (scripts/systemd/sac-listen.service) found that
-            # a clean 0-exit (e.g. an unexpected SIGTERM that uvicorn
-            # turns into a graceful shutdown) is NOT covered by
-            # Restart=on-failure, and that is exactly how the fleet lost
-            # a2a comms silently with nothing restarting the listen.
-            # "always" covers every non-`systemctl stop` exit; JobSpec's
-            # ALLOWED_RESTART_POLICIES includes "always" for kind=
-            # "service" specifically for this reason.
-            restart_policy="always",
-            timeout_sec=30,
-            # No watchdog_sec: sac listen is a plain Type=simple daemon
-            # that does not call sd_notify(WATCHDOG=1), so requesting a
-            # watchdog here would just cause systemd to kill-and-restart
-            # it every interval (see JobSpec.watchdog_sec docstring).
-            # Wedge (hang, not crash) detection is instead covered by the
-            # hand-maintained companion
-            # scripts/systemd/sac-listen-health.{service,timer} probe,
-            # which this JobSpec does NOT replace — see
-            # scripts/systemd/README.md for the coexistence note.
         ),
     ]
 

--- a/src/scitex_agent_container/_lifecycle/_instances.py
+++ b/src/scitex_agent_container/_lifecycle/_instances.py
@@ -20,7 +20,8 @@ without rescanning by name+host.
 
 from __future__ import annotations
 
-from typing import Any
+from pathlib import Path
+from typing import Any, Callable
 
 from ..config import AgentConfig
 
@@ -98,13 +99,37 @@ def _state_dir_for(config: AgentConfig, runtime: Any):
     return _runner.state_dir_for(config.name)
 
 
-def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
+def record_local_instance(
+    config: AgentConfig,
+    runtime: Any,
+    *,
+    db_path: Path | None = None,
+) -> str | None:
     """Insert (or refresh) the local ``instances`` row for ``config``.
 
     Ends any stale active row for the same (name, host) first so the
     unique partial index ``instances(name, host, scope) WHERE ended_at
     IS NULL`` never collides on a restart. Returns the new instance id,
     or ``None`` when the runtime can't report a state dir.
+
+    ``db_path`` PINS the store every write below lands in. ``None``
+    keeps the historical behaviour (resolve ``state_db.DEFAULT_DB_PATH``
+    per write, at call time).
+
+    Why the parameter exists (test-isolation bug, 2026-07-14): this
+    function is also reached from the health-monitor's restart callback
+    (:func:`restart_and_record`), which runs on a BACKGROUND DAEMON
+    THREAD that outlives whatever started it. With ``db_path=None``
+    every write re-resolved the module-level ``DEFAULT_DB_PATH`` — a
+    MUTABLE PROCESS-GLOBAL — at call time, so the monitor wrote into
+    whichever database the process happened to consider "default" at
+    the moment it fired. Under pytest that is a *different test's*
+    isolated tmp DB (the auto-grant below then showed up as a stray
+    ``<name> -> lead`` row in an unrelated suite); on a real host with
+    no test redirecting it, it is the live fleet ``state.db``.
+    :func:`_lifecycle._start.agent_start` now resolves the path ONCE
+    and pins it here and into the restart callback, so a monitor always
+    writes to the store its agent was started against.
     """
     from .._runners._session_state import write_instance_id
     from .._state.port_allocator import get_port
@@ -118,11 +143,13 @@ def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
     host = _resolve_host(None)
     # End stale active rows for this name+host (e.g. a previous crash
     # that never reached agent_stop) so the unique index stays clear.
-    for row in list_active_instances(host=host):
+    for row in list_active_instances(host=host, db_path=db_path):
         if row.get("name") == config.name:
-            record_instance_stop(str(row["id"]), exit_reason="superseded")
+            record_instance_stop(
+                str(row["id"]), exit_reason="superseded", db_path=db_path
+            )
 
-    a2a_port = get_port(config.name)
+    a2a_port = get_port(config.name, db_path=db_path)
     workdir = getattr(config, "expanded_workdir", None) or getattr(
         config, "workdir", None
     )
@@ -152,6 +179,7 @@ def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
         remote=False,
         spawned_by=_spawned_by(),
         workdir=str(workdir) if workdir else None,
+        db_path=db_path,
     )
 
     # ADR-0014 Stage 1 — paired comms_nodes write so cross-host peers
@@ -179,6 +207,7 @@ def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
                 source_path=getattr(config, "config_path", None)
                 or getattr(config, "spec_path", None)
                 or f"<spec:{config.name}>",
+                db_path=db_path,
             )
         except Exception:  # stx-allow: fallback (reason: never block agent start on registry write; PR L1's CommsNodeConflictError surfaces here as a logged collision rather than a silent shadow.)
             pass
@@ -199,6 +228,7 @@ def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
             sender=config.name,
             target="lead",
             note="auto-grant on agent_start (op-2026-06-09)",
+            db_path=db_path,
         )
     except Exception:  # stx-allow: fallback (reason: never block agent start on grant write; missing grant degrades to operator running `sac a2a grant <name> lead` manually until next start)
         pass
@@ -209,7 +239,12 @@ def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
     return instance_id
 
 
-def restart_and_record(config: AgentConfig, runtime_factory: Any) -> bool:
+def restart_and_record(
+    config: AgentConfig,
+    runtime_factory: Any,
+    *,
+    db_path: Path | None = None,
+) -> bool:
     """Restart ``config`` via its runtime AND refresh its ``instances`` row.
 
     The health-monitor's restart callback (wired in :mod:`._start`) used to
@@ -235,12 +270,67 @@ def restart_and_record(config: AgentConfig, runtime_factory: Any) -> bool:
 
     Returns whatever ``runtime.start`` returned; the row is refreshed only
     on a successful start (a failed restart must not fabricate a live row).
+
+    ``db_path`` PINS the store the refreshed row (and the ``<self> ->
+    lead`` auto-grant) is written to. This function is the health
+    monitor's restart callback and therefore runs on a long-lived
+    BACKGROUND DAEMON THREAD; resolving the store from the mutable
+    ``state_db.DEFAULT_DB_PATH`` global at call time meant the thread
+    followed that global wherever it moved. See
+    :func:`record_local_instance` for the full incident note.
     """
     runtime = runtime_factory(config)
     started = runtime.start(config)
     if started:
-        record_local_instance(config, runtime)
+        record_local_instance(config, runtime, db_path=db_path)
     return started
+
+
+def make_restart_callback(
+    runtime_factory: Any,
+    *,
+    db_path: Path | None = None,
+) -> Callable[[AgentConfig], bool]:
+    """Build the health-monitor's restart callback with the state.db PINNED.
+
+    :func:`_lifecycle._start.agent_start` spawns :func:`health.health_monitor`
+    on a DAEMON THREAD and hands it this callback. That thread outlives the
+    call that created it — it keeps ticking (``health.interval``, then a
+    restart backoff) long after ``agent_start`` returned.
+
+    The callback must therefore capture WHICH state.db it writes to, once,
+    up front. Previously it did not: it called
+    :func:`restart_and_record` with no ``db_path``, so each write
+    re-resolved ``state_db.DEFAULT_DB_PATH`` — a MUTABLE PROCESS-GLOBAL —
+    at the moment the monitor fired, and landed wherever that global then
+    pointed:
+
+    * under pytest, into a LATER, UNRELATED test's isolated tmp database
+      (its ``<self> -> lead`` auto-grant surfaced as a stray
+      ``target='lead'`` row in a suite that never started an agent — an
+      intermittent red gated by ``health.interval`` + restart backoff,
+      invisible when that suite ran alone);
+    * on a real host with nothing redirecting the global, into the LIVE
+      FLEET ``state.db`` (test agent names ``alpha`` / ``beta`` / ``zombie``
+      were found granted to ``lead`` in production because of this).
+
+    Resolving ``DEFAULT_DB_PATH`` as a module ATTRIBUTE here (never
+    ``from .state_db import DEFAULT_DB_PATH``, which would capture the
+    value at import and be immune to redirection) pins the store at
+    agent_start time. The monitor then always writes to the database its
+    agent was started against.
+    """
+    if db_path is None:
+        from .._state import state_db as _state_db
+
+        db_path = _state_db.DEFAULT_DB_PATH
+
+    pinned = db_path
+
+    def _restart(config: AgentConfig) -> bool:
+        return restart_and_record(config, runtime_factory, db_path=pinned)
+
+    return _restart
 
 
 def end_local_instance(config: AgentConfig, runtime: Any) -> bool:

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -18,8 +18,8 @@ from ..config import AgentConfig, load_config, resolve_config
 from ._a2a_port import resolve_a2a_port
 from ._handover_loader import _load_handover_module
 from ._hook_runner import _fire_forget_hook, _run_hooks
+from ._instances import make_restart_callback as _make_restart_callback
 from ._instances import record_local_instance as _record_local_instance
-from ._instances import restart_and_record as _restart_and_record
 from ._runtime_select import _get_runtime
 from ._session_reset import _clear_persisted_session_id
 from ._spawn_gate import enforce_spawn_gate, persist_acl_policy
@@ -484,8 +484,8 @@ def agent_start(
     _run_hooks(config.hooks.get("post_start", []), extra_env=hook_env)
     _fire_forget_hook(config.name, "post_start", config.hooks.get("post_start", []))
 
-    # Restart callback re-records the row: a restart = a NEW pid. See
-    # ``_instances.restart_and_record`` for why a stale pid is dangerous.
+    # Restart callback re-records the row (a restart = a NEW pid) AND pins
+    # the state.db it writes to -- see ``_instances.make_restart_callback``.
     if config.health.enabled:
         thread = thread_factory(
             target=health_monitor,
@@ -493,7 +493,7 @@ def agent_start(
                 config.name,
                 config,
                 registry,
-                lambda c: _restart_and_record(c, runtime_factory),
+                _make_restart_callback(runtime_factory),
             ),
             daemon=True,
         )

--- a/src/scitex_agent_container/_state/state_db_grants.py
+++ b/src/scitex_agent_container/_state/state_db_grants.py
@@ -108,10 +108,39 @@ def has_grant(
 def list_comms_grants(
     db_path: Path | None = None,
 ) -> list[dict[str, Any]]:
-    """Return every grant row in insertion order.
+    """Return every grant row in INSERTION order (SQLite ``rowid``).
 
     Observability surface for the host operator. Each row carries the
     audit ``note`` (default: the deferred-identity caveat).
+
+    Ordering contract — the docstring is authoritative, the old
+    ``ORDER BY`` was the bug (fixed 2026-07-14). Both callers want
+    insertion order (``sac a2a grants`` documents "rows are emitted in
+    insertion order"; the tests assert it); NOTHING wants alphabetical.
+    The previous clause ::
+
+        ORDER BY created_at ASC, sender_name ASC, target_name ASC
+
+    only APPROXIMATED that, and lied in two ways:
+
+    * ``created_at`` is a wall-clock ``time.time()`` float, so equal
+      timestamps fall through to the ALPHABETICAL tiebreak. Ties are
+      real, not theoretical: :func:`state_db_export.import_state`
+      bulk-imports peer rows carrying the PEER's ``created_at``
+      verbatim.
+    * Wall clocks skew and step across hosts, so an imported row can
+      carry a SMALLER ``created_at`` than a row inserted locally before
+      it — and then sorts ahead of it. That is not insertion order by
+      any reading.
+
+    The net effect was that a foreign row sorted into a plausible-looking
+    position instead of standing out, which is precisely what let a
+    leaked ``-> lead`` grant hide inside this listing.
+
+    ``comms_grants`` is a plain rowid table (no ``WITHOUT ROWID``), so
+    the implicit ``rowid`` IS the true insertion order: monotonic,
+    tie-free and immune to clock skew. ``created_at`` stays in the
+    payload — it is useful audit data, just not a sort key.
     """
     from .state_db import open_db
 
@@ -119,7 +148,7 @@ def list_comms_grants(
         cur = conn.execute(
             "SELECT sender_name, target_name, created_at, note "
             "FROM comms_grants "
-            "ORDER BY created_at ASC, sender_name ASC, target_name ASC"
+            "ORDER BY rowid ASC"
         )
         return [
             {

--- a/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
@@ -129,3 +129,160 @@ def test_record_local_instance_returns_instance_id_when_grant_write_succeeds(
     # Assert — record_local_instance documents ``str | None``; on the
     # happy path with a writeable state.db it MUST return the id string.
     assert isinstance(instance_id, str)
+
+
+# ---------------------------------------------------------------------------
+# REGRESSION (2026-07-14) — the auto-grant must not escape into a FOREIGN
+# state.db.
+#
+# ``agent_start`` runs ``health_monitor`` on a DAEMON THREAD and hands it a
+# restart callback -> ``restart_and_record`` -> ``record_local_instance`` ->
+# ``grant_send(target="lead")``. That thread OUTLIVES the call that made it
+# (it wakes after ``health.interval`` + a restart backoff, ~90 s with the
+# shipped defaults).
+#
+# The callback used to take no ``db_path``, so each write re-resolved
+# ``state_db.DEFAULT_DB_PATH`` -- a MUTABLE PROCESS-GLOBAL -- at the moment
+# the monitor fired. Whatever the process then called "default" got the row:
+#
+#   * under pytest, a LATER, UNRELATED test's isolated tmp DB. That is the
+#     stray ``target='lead'`` grant that made
+#     cli_pkg/test_a2a_group.py's ``grants`` tests fail intermittently in
+#     full-suite runs while passing when run alone.
+#   * on a bare host with nothing redirecting the global, the LIVE FLEET
+#     state.db (``alpha``/``beta``/``zombie`` -> ``lead`` rows were found in
+#     production, written by this suite).
+#
+# The thread is captured rather than started: waiting ~90 s of real backoff
+# would make the test slow AND flaky, and the point under test is WHICH DB
+# the callback writes to, not that Python can run a thread. ``thread_factory``
+# is a first-class injectable seam on ``agent_start`` (production default:
+# ``threading.Thread``), already used this way by test_lifecycle.py.
+# ---------------------------------------------------------------------------
+
+
+class _CapturingThread:
+    """Honest stand-in for ``threading.Thread``: records target + args and
+    never spawns a real thread, so the monitor's restart callback can be
+    fired deterministically instead of waited on."""
+
+    def __init__(self, *, target=None, args=(), daemon=False, **_kw) -> None:
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+
+class _DeadRuntime:
+    """Runtime that reports the agent as never running, so the health
+    monitor's restart path is the one under test."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+        self.start_calls: list[str] = []
+
+    def is_running(self, config: AgentConfig, **_kw) -> bool:
+        return False
+
+    def start(self, config: AgentConfig, **_kw) -> bool:
+        self.start_calls.append(config.name)
+        return True
+
+    def stop(self, config: AgentConfig, **_kw) -> bool:
+        return True
+
+    def _state_dir(self, config: AgentConfig) -> Path:
+        return self._root / config.name
+
+
+def _write_health_spec(tmp_path: Path, name: str) -> Path:
+    """v3 ``spec.yaml`` with health ENABLED (so agent_start spawns the
+    monitor). Dir-as-SSoT: the agent name comes from the parent dir."""
+    agent_dir = tmp_path / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+        "  host: ${HOSTNAME}\n"
+        f"  workdir: {tmp_path / 'work'}\n"
+        "  apptainer:\n    image: /x.sif\n    binds: []\n"
+        "  health:\n    enabled: true\n    interval: 60\n"
+        "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+        "  claude:\n    model: sonnet\n"
+    )
+    return spec
+
+
+def _fire_monitor_restart_against_foreign_db(
+    db_path: Path, tmp_path: Path, name: str
+) -> Path:
+    """Arrange + Act: start a health-monitored agent against ``db_path``,
+    then move the process-global default to a FOREIGN db and fire the
+    monitor's restart callback (what the leaked daemon thread does on its
+    next tick). Returns the foreign db path for the caller to assert on."""
+    from scitex_agent_container._lifecycle import lifecycle as lc
+    from scitex_agent_container._state import state_db
+    from scitex_agent_container._state.registry import Registry
+
+    created: list[_CapturingThread] = []
+
+    def _thread_factory(**kwargs) -> _CapturingThread:
+        t = _CapturingThread(**kwargs)
+        created.append(t)
+        return t
+
+    lc.agent_start(
+        str(_write_health_spec(tmp_path, name)),
+        registry=Registry(registry_dir=tmp_path / "reg"),
+        runtime_factory=lambda _c: _DeadRuntime(tmp_path),
+        sleep_fn=lambda _s: None,
+        thread_factory=_thread_factory,
+    )
+    assert created and created[0].started, "agent_start did not start a monitor"
+    restart_cb = created[0].args[3]
+    config = created[0].args[1]
+
+    # An unrelated LATER test isolates itself: the process-global moves.
+    foreign = tmp_path / "foreign" / "state.db"
+    state_db.init_schema(foreign)
+    saved = state_db.DEFAULT_DB_PATH
+    state_db.DEFAULT_DB_PATH = foreign
+    try:
+        restart_cb(config)  # the leaked monitor thread fires
+    finally:
+        state_db.DEFAULT_DB_PATH = saved
+    return foreign
+
+
+def test_monitor_restart_does_not_auto_grant_into_a_foreign_state_db(
+    db_path: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    from scitex_agent_container._state.state_db_nodes import list_comms_grants
+
+    name = "pinned-1"
+    # Act — the leaked monitor thread fires while the global points elsewhere.
+    foreign = _fire_monitor_restart_against_foreign_db(db_path, tmp_path, name)
+    # Assert — the unrelated store MUST be untouched. Pre-fix it held
+    # ("pinned-1" -> "lead"): exactly the stray target='lead' row that made
+    # cli_pkg/test_a2a_group.py's grants tests red in full-suite runs.
+    assert list_comms_grants(db_path=foreign) == []
+
+
+def test_monitor_restart_auto_grants_into_the_db_the_agent_started_against(
+    db_path: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    from scitex_agent_container._state.state_db_nodes import has_grant
+
+    name = "pinned-2"
+    # Act — same drive, asserting the other half of the contract.
+    _fire_monitor_restart_against_foreign_db(db_path, tmp_path, name)
+    # Assert — pinning must not LOSE the write, only aim it correctly.
+    assert has_grant(sender=name, target="lead", db_path=db_path) is True

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -541,6 +541,70 @@ def test_list_comms_grants_returns_each_grant_pair(db_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# ORDERING CONTRACT (2026-07-14) — ``list_comms_grants`` documents INSERTION
+# order and both callers rely on it (``sac a2a grants`` says "rows are
+# emitted in insertion order"); nothing wants alphabetical. It used to sort
+# by ``ORDER BY created_at ASC, sender_name ASC, target_name ASC``, which
+# only APPROXIMATES insertion order and lies whenever the wall-clock
+# ``created_at`` ties (-> falls through to the ALPHABETICAL tiebreak) or
+# skews (-> a peer row sorts ahead of a locally-earlier one).
+#
+# Neither case is theoretical: ``import_state`` bulk-imports peer rows
+# carrying the PEER's ``created_at`` verbatim, and peer clocks drift. The
+# rows below are written through the real ``open_db`` connection with
+# explicit timestamps -- exactly the shape ``import_state`` produces. Real
+# SQLite, real rows, no mocks.
+#
+# The pre-existing insertion-order test could not catch this: it inserted
+# "first-sender" then "second-sender", which are in the SAME order
+# alphabetically as by insertion, so it passed under both implementations.
+# ---------------------------------------------------------------------------
+
+
+def _insert_grant_at(db_path: Path, sender: str, target: str, created_at: float) -> None:
+    """Write one ``comms_grants`` row with an EXPLICIT ``created_at``.
+
+    ``grant_send`` stamps ``time.time()`` internally, so a tie / skew can't
+    be expressed through it. This is the same INSERT ``import_state`` uses
+    when it replays a peer's rows.
+    """
+    from scitex_agent_container._state.state_db import open_db
+
+    with open_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO comms_grants "
+            "(sender_name, target_name, created_at, note) VALUES (?, ?, ?, ?)",
+            (sender, target, created_at, None),
+        )
+
+
+def test_list_comms_grants_keeps_insertion_order_when_timestamps_tie(
+    db_path: Path,
+) -> None:
+    # Arrange — same created_at, inserted in NON-alphabetical order. The old
+    # clause fell through to `sender_name ASC` and returned "alpha" first.
+    _insert_grant_at(db_path, "zeta", "lead", 100.0)
+    _insert_grant_at(db_path, "alpha", "lead", 100.0)
+    # Act
+    rows = list_comms_grants(db_path=db_path)
+    # Assert
+    assert [r["sender"] for r in rows] == ["zeta", "alpha"]
+
+
+def test_list_comms_grants_keeps_insertion_order_when_peer_clock_is_behind(
+    db_path: Path,
+) -> None:
+    # Arrange — a peer row imported LATER but stamped EARLIER (clock skew).
+    # The old clause sorted by created_at and put the peer's row first.
+    _insert_grant_at(db_path, "local-first", "lead", 200.0)
+    _insert_grant_at(db_path, "peer-imported-later", "lead", 100.0)
+    # Act
+    rows = list_comms_grants(db_path=db_path)
+    # Assert
+    assert [r["sender"] for r in rows] == ["local-first", "peer-imported-later"]
+
+
+# ---------------------------------------------------------------------------
 # node_tokens — authenticated identity primitive (handoff §4 acceptance)
 # ---------------------------------------------------------------------------
 

--- a/tests/scitex_agent_container/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/test__jobs_plugin.py
@@ -6,11 +6,14 @@ entry-point group match the federated contract:
 * ``sac.accounts-refresh`` — a periodic systemd timer job that runs
   ``--all --include-active --sync-active-login`` every 2h (the SOLE
   refresher; see the ``--skip-active`` note below).
-* ``sac.listen`` — a long-running systemd service job (the host
-  control-plane daemon), auto-started on boot and auto-restarted on
-  ANY exit (``restart_policy="always"``), registered so the host no
-  longer needs a cron-based watchdog
-  (clew incident ``clew-incident-sac-host-listen-down``, 2026-07-05).
+
+``sac listen`` is deliberately NOT federated, and one test below PINS its
+absence: scitex-dev derives the unit name verbatim, so a ``sac.listen``
+JobSpec installs ``sac.listen.service`` ALONGSIDE the ``sac-listen.service``
+(hyphen) that already supervises the daemon — two units, both
+``Restart=always``, both binding 127.0.0.1:7878, fighting for the port and
+destroying the in-memory Broker (which deafens every agent's inbox) on each
+lost round. See ``_jobs_plugin.provide_jobs`` for the full reasoning.
 
 Skipped cleanly if the installed scitex-dev predates ``scitex_dev.jobs``
 (PyPI lag) — the entry-point registration is install-time metadata and
@@ -34,12 +37,13 @@ def _job(name: str):
     return match
 
 
-def test_provider_returns_two_jobs() -> None:
-    # Arrange — call the registered provider.
+def test_provider_returns_one_job() -> None:
+    # Arrange — call the registered provider. One, not two: `sac listen` is
+    # NOT federated (see the module docstring and the absence-pin below).
     # Act
     jobs = provide_jobs()
     # Assert
-    assert len(jobs) == 2
+    assert len(jobs) == 1
 
 
 def test_provider_jobs_are_real_jobspecs() -> None:
@@ -116,49 +120,25 @@ def test_provider_job_cadence_is_two_hours() -> None:
     assert job.on_unit_active_sec == "2h"
 
 
-def test_provider_listen_job_is_a_service() -> None:
-    # Arrange — call the registered provider.
+def test_provider_does_not_federate_listen_it_would_duplicate_the_supervisor() -> None:
+    # Arrange — `sac listen` must NOT be declared as a JobSpec, and this
+    # test exists to keep it that way.
+    #
+    # scitex-dev derives the unit name from the job name VERBATIM
+    # (`scitex-todo.dashboard` -> `scitex-todo.dashboard.service`), so a
+    # `sac.listen` JobSpec materialises `sac.listen.service`. The listen
+    # that actually runs is `sac-listen.service` — a HYPHEN — hand-written
+    # 2026-07-05, Restart=always, NRestarts=0. systemd treats the two names
+    # as unrelated units, so `scitex-dev service ensure sac.listen` does not
+    # adopt the running supervisor: it installs a SECOND one. Two units,
+    # both Restart=always, both running `sac listen`, both binding
+    # 127.0.0.1:7878 — they fight for the port forever, and every lost round
+    # destroys the in-memory Broker, deafening EVERY agent's inbox at once.
+    #
+    # PR #543 declared it because listen "had NO SUPERVISOR". That premise
+    # was already false when it merged: the hand-written unit was created
+    # the same day the PR was opened and had supervised listen for 9 days.
     # Act
-    job = _job("sac.listen")
-    # Assert — long-running control-plane daemon, not scheduled.
-    assert job.kind == "service"
-
-
-def test_provider_listen_job_has_no_schedule() -> None:
-    # Arrange — call the registered provider. kind="service" requires
-    # schedule=="" (services aren't scheduled — they run continuously).
-    # Act
-    job = _job("sac.listen")
+    names = [spec.name for spec in provide_jobs()]
     # Assert
-    assert job.schedule == ""
-
-
-def test_provider_listen_job_command() -> None:
-    # Arrange — call the registered provider. Confirmed (task brief,
-    # 2026-07-05): SAC_LISTEN_BEARER self-resolves from the on-disk
-    # token file when unset (PR #470), so a bare command suffices.
-    # Act
-    job = _job("sac.listen")
-    # Assert
-    assert job.command == "sac listen"
-
-
-def test_provider_listen_job_restarts_always() -> None:
-    # Arrange — call the registered provider. "always" (not
-    # "on-failure") matches the incident-hardened hand-maintained unit
-    # (scripts/systemd/sac-listen.service, incident 2026-06-26): a
-    # clean 0-exit must still trigger a restart.
-    # Act
-    job = _job("sac.listen")
-    # Assert
-    assert job.restart_policy == "always"
-
-
-def test_provider_listen_job_has_no_watchdog() -> None:
-    # Arrange — call the registered provider. sac listen never calls
-    # sd_notify(WATCHDOG=1), so requesting a watchdog would cause
-    # systemd to kill-and-restart it every interval.
-    # Act
-    job = _job("sac.listen")
-    # Assert
-    assert job.watchdog_sec is None
+    assert "sac.listen" not in names


### PR DESCRIPTION
Ships #672 (remove the sac.listen JobSpec), plus whatever else landed on develop.