### PR TITLE
fix(listen-watchdog): the 5s fuse was RESTARTING a healthy control plane and deafening the whole fleet

### DIFF
--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -134,28 +134,186 @@ companion watchdog closes the gap:
   ~30s (`OnBootSec=30s`, `OnUnitActiveSec=30s`).
 * `sac-listen-health.service` (oneshot) runs
   `sac-listen-health-probe.sh`, which HTTP-probes
-  `http://127.0.0.1:7878/v1/health`. "Up" == *any* HTTP response
-  (incl. a 401/403 under bearer auth); only a transport failure
-  (connection refused / timeout) counts as "down" — the same
-  auth-change-proof liveness contract as
-  `_listen/_restart.py::wait_for_health`.
-* On a down probe the script:
-  1. logs a **LOUD ERROR** to the journal (`journalctl --user -u
-     sac-listen-health`) so the restart is VISIBLE, not silent;
-  2. best-effort emits the anomaly on the operator alarm path
-     (`sac fleet notify blocker`) — this may fail (the listen is the
-     transport for that notify), but is tried so a peer/lead listen or
-     a recovered inbox still surfaces it;
-  3. runs `systemctl --user reset-failed && restart sac-listen.service`
-     (the `reset-failed` clears a tripped `StartLimitBurst` so a
-     transient burst self-heals while a genuine hard-down stays
-     visible).
+  `http://127.0.0.1:7878/v1/health`.
 * The watchdog is itself decoupled — it does NOT `Requires=`/`After=`
   the listen (it must run and alarm precisely when the listen is
   down), and the timer is enabled independently.
-* Tunables via env on the probe: `SAC_LISTEN_HEALTH_URL`,
-  `SAC_LISTEN_UNIT`, `SAC_LISTEN_PROBE_TIMEOUT`, `SAC_LISTEN_NOTIFY`.
-  `--check-only` probes without any side effects (used by tests).
+
+## The health watchdog: how it decides
+
+**Incident 2026-07-14 — the watchdog WAS the outage.** The probe used to
+restart `sac-listen.service` after **ONE** failed `curl` with a **5-second**
+deadline. On a box that idles at **load 60-70** that is not a health check,
+it is a coin flip. Measured against a REAL server that answered `HTTP 200`
+in 8s (healthy, merely *busy*):
+
+```
+probe #1 -> "sac-listen DOWN ... (transport failure)" -> RESTART
+probe #2 -> "sac-listen DOWN ... (transport failure)" -> RESTART
+probe #3 -> "sac-listen DOWN ... (transport failure)" -> RESTART
+TOTAL RESTARTS of a HEALTHY daemon: 3 / 3
+```
+
+The daemon **answered every time**. The probe called it a "transport
+failure" every time, because it could not tell SLOW from DOWN.
+
+And the remedy is catastrophic: **every `sac listen` restart tears down the
+in-memory a2a `Broker`, which deafens EVERY agent's inbox at once.** So a
+slow probe did not merely mis-report — **it manufactured the outage it
+claimed to detect**, then re-probed *during its own restart*, saw a
+genuinely-down daemon, and restarted again. Live journal, 26s apart:
+
+```
+10:57:26  health-probe: ERROR ... incident-class=sac-listen-watchdog
+10:57:26  systemd: Stopping sac listen            <- restart #1 (of a HEALTHY daemon)
+10:57:45  Started sac listen
+10:57:52  health-probe: ERROR: sac-listen DOWN    <- probed DURING its own restart
+10:57:52  watchdog is RESTARTING                  <- restart #2, 26s later
+```
+
+**A probe that mutates is not a probe.** That single 5-second fuse plausibly
+explains the listen churn (3 pids in 7 min), the "registered but deaf"
+agents, the duplicate standby loops, and the auth pool appearing to
+"re-wedge within a minute of a drain" (it was not a wedge — it was a restart
+severing in-flight requests).
+
+Both directions are bugs: never acting hides an outage, over-acting
+**creates** one. The false-RED is the worse of the two, because its remedy
+destroys a healthy thing. So **only a corroborated verdict may restart.**
+
+### 1. Three states, never a bool
+
+Two states cannot express *"I asked and got nothing"* — which is precisely
+what a loaded box produces.
+
+| Verdict | Meaning | Weight |
+|---|---|---|
+| **UP** | It **answered** — any HTTP status `< 500` (see §2) | — |
+| **DOWN** | Connection **REFUSED** — the kernel sent RST: *nothing is listening* | **2** (hard) |
+| **DOWN** | **HTTP 5xx** — it answered, but its health route is erroring. Bound and speaking HTTP, yet not healthy | 1 (soft) |
+| **UNKNOWN** | We asked and got **nothing** (timeout / DNS / reset). Under load this is what a HEALTHY-but-busy daemon looks like | 1 |
+
+**Absence of evidence is not evidence of death.** A timeout is UNKNOWN, and
+`curl`'s `%{time_connect}` is used to say *why*: if the TCP handshake
+completed, the port **is** bound and the daemon has not exited — so the
+evidence line reads "no HTTP answer within 20s (but TCP connected — the port
+IS bound)". That is the difference between *busy* and *gone*.
+
+### 2. Any HTTP status < 500 is "UP" (deliberate — keep it)
+
+A `401`/`403` **proves** the daemon is up: bound, speaking HTTP, and
+auth-gating. Card `sac-listen-restart-healthcheck-bearer` (PR #463) exists
+because gating liveness on `status == 200` re-classified a live,
+401-answering daemon as "down" — a false-RED that killed a **healthy**
+process. Only a *server error* (5xx) or *no answer at all* counts against
+the daemon. Matches `_listen/_holder_health.py`.
+
+### 3. Corroboration — and a failure is a FACT
+
+Accumulated failure weight must reach `SAC_LISTEN_FAIL_THRESHOLD` (3):
+
+* **2 consecutive REFUSALS** (2+2) → act fast. **Crash coverage** — a
+  genuinely dead listen still comes back (incident 2026-06-26).
+* **3 consecutive UNKNOWNs** (1+1+1) → act. **Wedge coverage** — a daemon
+  that cannot answer a trivial route within a 20s deadline, three times
+  running, is not "busy". Corroboration is what **promotes** a repeated
+  UNKNOWN into a DOWN verdict.
+
+**A single success does not wipe the ledger.** That bug — `consecutive = 0`
+reset by any one lucky reply — is this class's *other half*, and a peer just
+fixed it in `sac listen`'s own holder check (PR #673,
+`_listen/_standby_ledger.py`), where a flapping holder oscillated
+`1/2` → "healthy" → `1/2` forever and was **never acted on**. Here a success
+builds a **serving streak**, and the ledger clears only after
+`SAC_LISTEN_RECOVERY_STREAK` (2) consecutive UPs — logged **LOUD**, because
+"the thing I said was broken now looks fine" is exactly the transition an
+operator must never have hidden from them.
+
+Blip once and you are not destroyed; keep failing and you are always
+eventually healed.
+
+### 4. Never restart something that is already restarting
+
+Two **independent** guards, so losing one cannot resurrect the 26s
+double-restart:
+
+* **(a) Post-restart backoff** — after issuing a restart the probe does not
+  probe **at all** for `SAC_LISTEN_RESTART_BACKOFF` (90s). Restart #2 above
+  happened *because* it probed during its own restart. You cannot draw a
+  conclusion about a daemon you are in the middle of restarting.
+* **(b) Unit-state guard** — if systemd reports the unit `activating`, it is
+  already coming back (someone else restarted it, or it crashed and
+  `Restart=always` caught it) → stand down. This holds **even if the state
+  file is lost or corrupt.**
+
+### 5. Rate-limit the remedy
+
+At most `SAC_LISTEN_MAX_RESTARTS` (2) per `SAC_LISTEN_RESTART_WINDOW`
+(600s). Beyond that the watchdog **ALARMS LOUDLY and STOPS restarting**
+(`incident-class=sac-listen-watchdog-giving-up`, exit 1). If 2 restarts did
+not fix it, the 3rd will not either — and an unbounded restarter on a bad
+signal is how you take a fleet down at 3am. A human is needed, and it says
+so instead of thrashing.
+
+### On a corroborated down, the script still
+
+1. logs a **LOUD ERROR** to the journal (`journalctl --user -u
+   sac-listen-health`) so the restart is VISIBLE, not silent;
+2. best-effort emits the anomaly on the **one** operator alarm path
+   (`sac fleet notify blocker`) — this may fail (the listen is the transport
+   for that notify), but is tried so a peer/lead listen or a recovered inbox
+   still surfaces it;
+3. runs `systemctl --user reset-failed && restart sac-listen.service` (the
+   `reset-failed` clears a tripped `StartLimitBurst` so a transient burst
+   self-heals while a genuine hard-down stays visible).
+
+### The ledger
+
+The script is invoked **fresh** every ~30s, so an in-memory counter would
+always read zero and "N consecutive failures" could never be observed. State
+persists at
+`~/.scitex/agent-container/runtime/listen-health.state` (override:
+`SAC_LISTEN_HEALTH_STATE`) as plain `key=value`. It is **never `source`d** —
+a corrupt or hostile state file must not become code, and any value that is
+not a plain integer resets that field to `0` (**fail-safe: no history == do
+not restart**).
+
+```bash
+# What is the watchdog thinking right now?
+~/.config/systemd/user/sac-listen-health-probe.sh --status
+# state_file:      /home/you/.scitex/agent-container/runtime/listen-health.state
+# unit:            sac-listen.service (ActiveState=active)
+# probe_timeout:   20s (connect 5s)
+# failure_weight:  0 / 3  (weight required to restart)
+# serving_streak:  0 / 2  (consecutive UPs that clear the ledger)
+# restarts_in_600s: 0 / 2
+# last_restart:    never
+```
+
+### Tunables (env on the probe)
+
+| Var | Default | Meaning |
+|---|---|---|
+| `SAC_LISTEN_HEALTH_URL` | `http://127.0.0.1:7878/v1/health` | what to probe |
+| `SAC_LISTEN_UNIT` | `sac-listen.service` | what to restart |
+| `SAC_LISTEN_PROBE_TIMEOUT` | `20` | total curl deadline, s. **Was 5** — the fuse that caused the incident. The live daemon answers in **~30 ms**, so 20s is ~600× the median and still catches a wedge. |
+| `SAC_LISTEN_CONNECT_TIMEOUT` | `5` | TCP-connect deadline, s |
+| `SAC_LISTEN_FAIL_THRESHOLD` | `3` | failure weight required to act |
+| `SAC_LISTEN_RECOVERY_STREAK` | `2` | consecutive UPs that clear the ledger |
+| `SAC_LISTEN_RESTART_BACKOFF` | `90` | no-probe window after a restart, s |
+| `SAC_LISTEN_MAX_RESTARTS` | `2` | restarts allowed per window |
+| `SAC_LISTEN_RESTART_WINDOW` | `600` | rate-limit window, s |
+| `SAC_LISTEN_NOTIFY` | `1` | `0` skips `sac fleet notify` (tests / non-lead hosts) |
+| `SAC_LISTEN_HEALTH_STATE` | `~/.scitex/agent-container/runtime/listen-health.state` | ledger path |
+
+Modes: `--check-only` (pure observation — **zero** side effects, writes no
+state), `--status` (dump the ledger), `--reset` (clear it).
+
+Behaviour is pinned by
+`tests/integration/test_sac_listen_health_watchdog_decision.py`, which drives
+the **real** script against **real** HTTP servers on real ephemeral sockets
+(slow / refusing / 5xx-ing / 401-ing / dying) and asserts the decision each
+time. No mocks; nothing there ever touches port 7878.
 * The companion `_listen/_single_instance.py` flock guard (task
   #26 sub (1)) ensures `Restart=on-failure` can't double-bind the
   port. The kernel releases the flock on every dirty exit, so the

--- a/scripts/systemd/sac-listen-health-probe.sh
+++ b/scripts/systemd/sac-listen-health-probe.sh
@@ -1,137 +1,463 @@
 #!/usr/bin/env bash
-# sac-listen-health-probe.sh — fleet-infrastructure watchdog for the
-# central `sac listen` (a2a + registry control plane, default
-# 127.0.0.1:7878).
+# sac-listen-health-probe.sh — fleet-infrastructure watchdog for the central
+# `sac listen` (a2a + registry control plane, default 127.0.0.1:7878).
 #
-# Incident 2026-06-26: the listen died mid-session with NO auto-restart
-# and NO alarm, so the whole fleet lost agent-to-agent comms SILENTLY.
-# systemd's own Restart=always covers a *process exit*, but a listen
-# that is wedged (process alive, port bound, but the HTTP server no
-# longer answering /v1/health) is invisible to systemd. This probe
-# closes that gap: it HTTP-probes the health endpoint and, on failure,
-#   1. logs a LOUD ERROR (journal, via stderr — the timer unit routes
-#      both streams to `journalctl --user -u sac-listen-health`),
-#   2. restarts `sac-listen.service` (clearing any `failed` state first
-#      so a tripped StartLimit self-heals),
-#   3. best-effort emits the anomaly on the operator alarm path
-#      (`sac fleet notify blocker`) so the restart is VISIBLE, not
-#      silent.
+# Full rationale + both incidents: scripts/systemd/README.md ("The health
+# watchdog: how it decides"). The short version:
 #
-# Run by `sac-listen-health.timer` every ~30s. Also runnable by hand:
+# WHY IT EXISTS (incident 2026-06-26). `sac listen` died mid-session with no
+# restart and no alarm, and the fleet lost a2a comms SILENTLY. systemd's
+# `Restart=always` covers a process EXIT, but a WEDGED listen (alive, port
+# bound, HTTP not answering) is invisible to it. This probe closes that gap.
+# That coverage is load-bearing and is PRESERVED.
 #
-#   scripts/systemd/sac-listen-health-probe.sh            # probe+heal
-#   scripts/systemd/sac-listen-health-probe.sh --check-only   # probe, no side effects
+# WHY IT WAS REWRITTEN (incident 2026-07-14). The probe used to restart after
+# ONE failed curl with a 5-SECOND deadline. On a box that idles at load 60-70
+# that is not a health check, it is a coin flip — and the remedy is
+# catastrophic: every `sac listen` restart tears down the in-memory a2a
+# Broker, DEAFENING EVERY AGENT'S INBOX AT ONCE. So a slow probe did not
+# merely mis-report, it MANUFACTURED the outage it claimed to detect — then
+# re-probed DURING its own restart, saw a genuinely-down daemon, and
+# restarted AGAIN (measured: 2 restarts in 26s of a HEALTHY daemon; 3/3
+# against a real server that answered HTTP 200 in 8s).
+# A PROBE THAT MUTATES IS NOT A PROBE.
 #
-# Exit codes:
-#   0  healthy (or, in heal mode, a restart was issued successfully)
-#   1  unhealthy (in --check-only) / restart attempt failed (heal mode)
-#   2  usage error
+# THE DECISION MODEL. Both directions are bugs: never acting hides an outage,
+# over-acting CREATES one. The false-RED is the worse of the two, because its
+# remedy destroys a healthy thing — so only a CORROBORATED verdict restarts.
+#
+#   1. THREE STATES, never a bool (two cannot express "I asked and got
+#      nothing", which is exactly what a loaded box produces):
+#        UP       it ANSWERED — any HTTP status < 500 (see 2)
+#        DOWN     a POSITIVE observation of not-serving:
+#                   connection REFUSED (kernel sent RST: nothing is
+#                     listening) ................................ weight 2
+#                   HTTP 5xx (answered, but its health route errors —
+#                     bound and speaking HTTP, yet not healthy) .. weight 1
+#        UNKNOWN  we asked and got NOTHING (timeout/DNS/reset). Under load
+#                 this is what a HEALTHY-but-busy daemon looks like. Not
+#                 health — but NOT evidence of death either ...... weight 1
+#      Absence of evidence is not evidence of death.
+#
+#   2. ANY HTTP STATUS < 500 IS "UP" (deliberate — keep it). A 401/403 PROVES
+#      the daemon is up: bound, speaking HTTP, auth-gating. Card
+#      `sac-listen-restart-healthcheck-bearer` (PR #463) exists because gating
+#      liveness on `status == 200` re-classified a live, 401-answering daemon
+#      as "down" — a false-RED that killed a HEALTHY process. Only a *server
+#      error* (5xx) or *no answer at all* counts against it. Matches
+#      `_listen/_holder_health.py`.
+#
+#   3. CORROBORATION, and a failure is a FACT. Weight must reach
+#      SAC_LISTEN_FAIL_THRESHOLD before we act: 2 consecutive REFUSALS act
+#      fast (crash coverage); 3 consecutive UNKNOWNs act (wedge coverage —
+#      corroboration is what PROMOTES a repeated UNKNOWN into a DOWN).
+#      A SINGLE SUCCESS DOES NOT WIPE THE LEDGER: that bug (`consecutive = 0`
+#      reset by one lucky reply) is this class's other half, just fixed in
+#      `sac listen`'s own holder check (PR #673, `_listen/_standby_ledger.py`),
+#      where a flapping holder oscillated 1/2 -> "healthy" forever and was
+#      NEVER acted on. Here a success builds a SERVING STREAK and the ledger
+#      clears only after SAC_LISTEN_RECOVERY_STREAK consecutive UPs — logged
+#      LOUD. Blip once and you are not destroyed; keep failing and you are
+#      always eventually healed.
+#
+#   4. NEVER RESTART SOMETHING THAT IS ALREADY RESTARTING. Two INDEPENDENT
+#      guards, so losing one cannot resurrect the 26s double-restart:
+#        (a) POST-RESTART BACKOFF — after issuing a restart we do not probe
+#            AT ALL for SAC_LISTEN_RESTART_BACKOFF seconds.
+#        (b) UNIT-STATE GUARD — if systemd reports the unit `activating` it
+#            is already coming back (someone else restarted it, or it
+#            crashed and `Restart=always` caught it): stand down. Holds even
+#            if the state file is lost or corrupt.
+#
+#   5. RATE-LIMIT THE REMEDY. At most SAC_LISTEN_MAX_RESTARTS per
+#      SAC_LISTEN_RESTART_WINDOW. Beyond that: ALARM LOUDLY and STOP. If N
+#      restarts did not fix it the (N+1)th will not either, and an unbounded
+#      restarter on a bad signal is how a fleet goes down at 3am.
+#
+# USAGE
+#   sac-listen-health-probe.sh              # probe + heal (the timer path)
+#   sac-listen-health-probe.sh --check-only # probe, ZERO side effects
+#   sac-listen-health-probe.sh --status     # dump the ledger, exit 0
+#   sac-listen-health-probe.sh --reset      # clear the ledger, exit 0
+#
+# Exit: 0 UP (or heal: restart issued / deliberately stood down)
+#       1 not UP (--check-only) / restart attempt FAILED (heal)
+#       2 usage error
 #
 # Env overrides (all optional):
-#   SAC_LISTEN_HEALTH_URL   default http://127.0.0.1:7878/v1/health
-#   SAC_LISTEN_UNIT         default sac-listen.service
-#   SAC_LISTEN_PROBE_TIMEOUT  curl --max-time seconds, default 5
-#   SAC_LISTEN_NOTIFY       1 (default) to attempt `sac fleet notify`,
-#                           0 to skip (used by tests / non-lead hosts)
+#   SAC_LISTEN_HEALTH_URL      default http://127.0.0.1:7878/v1/health
+#   SAC_LISTEN_UNIT            default sac-listen.service
+#   SAC_LISTEN_PROBE_TIMEOUT   total curl deadline, s        default 20
+#                              (was 5 — the fuse that caused the incident.
+#                              The live daemon answers in ~30ms, so 20s is
+#                              ~600x the median and still catches a wedge.)
+#   SAC_LISTEN_CONNECT_TIMEOUT TCP-connect deadline, s       default 5
+#   SAC_LISTEN_FAIL_THRESHOLD  failure weight to act         default 3
+#   SAC_LISTEN_RECOVERY_STREAK consecutive UPs that clear it default 2
+#   SAC_LISTEN_RESTART_BACKOFF no-probe window post-restart  default 90
+#   SAC_LISTEN_MAX_RESTARTS    restarts per window           default 2
+#   SAC_LISTEN_RESTART_WINDOW  rate-limit window, s          default 600
+#   SAC_LISTEN_HEALTH_STATE    ledger path; default
+#                    $HOME/.scitex/agent-container/runtime/listen-health.state
+#   SAC_LISTEN_NOTIFY          1 (default) to attempt `sac fleet notify`,
+#                              0 to skip (tests / non-lead hosts)
 #
-# No mocks (STX-NM002): the probe talks to a REAL HTTP endpoint over a
-# REAL socket; tests stand up a real local HTTP server and assert the
-# real curl-based classification.
+# No mocks (STX-NM002): the probe talks to a REAL endpoint over a REAL
+# socket; tests stand up a real local HTTP server — slow, refusing, 5xx-ing,
+# dying — and assert the REAL decision. Tests NEVER touch port 7878.
 set -uo pipefail
 
 HEALTH_URL="${SAC_LISTEN_HEALTH_URL:-http://127.0.0.1:7878/v1/health}"
 LISTEN_UNIT="${SAC_LISTEN_UNIT:-sac-listen.service}"
-PROBE_TIMEOUT="${SAC_LISTEN_PROBE_TIMEOUT:-5}"
+PROBE_TIMEOUT="${SAC_LISTEN_PROBE_TIMEOUT:-20}"
+CONNECT_TIMEOUT="${SAC_LISTEN_CONNECT_TIMEOUT:-5}"
+FAIL_THRESHOLD="${SAC_LISTEN_FAIL_THRESHOLD:-3}"
+RECOVERY_STREAK="${SAC_LISTEN_RECOVERY_STREAK:-2}"
+RESTART_BACKOFF="${SAC_LISTEN_RESTART_BACKOFF:-90}"
+MAX_RESTARTS="${SAC_LISTEN_MAX_RESTARTS:-2}"
+RESTART_WINDOW="${SAC_LISTEN_RESTART_WINDOW:-600}"
 NOTIFY_ENABLED="${SAC_LISTEN_NOTIFY:-1}"
+STATE_FILE="${SAC_LISTEN_HEALTH_STATE:-${HOME}/.scitex/agent-container/runtime/listen-health.state}"
 
-CHECK_ONLY=0
+# A REFUSAL is a hard, positive observation ("nothing is listening"); a
+# timeout is the ABSENCE of an observation. Refusal counts harder, and so
+# reaches the threshold faster.
+WEIGHT_HARD=2
+WEIGHT_SOFT=1
+
+MODE="heal"
 case "${1:-}" in
-  --check-only) CHECK_ONLY=1 ;;
-  "" ) ;;
-  -h|--help)
-    sed -n '2,40p' "$0"
-    exit 0
-    ;;
+  --check-only) MODE="check" ;;
+  --status)     MODE="status" ;;
+  --reset)      MODE="reset" ;;
+  "")           ;;
+  -h|--help)    sed -n '2,110p' "$0"; exit 0 ;;
   *)
-    echo "usage: $0 [--check-only]" >&2
+    echo "usage: $0 [--check-only|--status|--reset]" >&2
     exit 2
     ;;
 esac
 
-# probe_health URL TIMEOUT -> 0 if the daemon answered with ANY HTTP
-# status (incl. 401/403 under bearer auth — the daemon is up and
-# auth-gating), 1 if the transport failed (connection refused / DNS /
-# timeout). This mirrors the liveness contract in
-# `_listen/_restart.py::wait_for_health`: "got an HTTP response" == up,
-# only a transport failure == down. That is auth-change-proof: a future
-# decision to bearer-gate /v1/health must NOT make the watchdog SIGKILL
-# a live, 401-answering daemon.
-probe_health() {
-  local url="$1" timeout="$2" code
-  # -s silent, -o /dev/null discard body, -w '%{http_code}' print the
-  # numeric status, --max-time bound the whole request. curl exits
-  # non-zero on a transport failure and prints "000" as the code.
-  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time "$timeout" "$url" 2>/dev/null)"
-  local rc=$?
-  if [ "$rc" -ne 0 ]; then
-    return 1
-  fi
-  # "000" == curl reached no HTTP layer (e.g. connection refused that
-  # still returned rc 0 on some curl builds). Treat as down.
-  if [ -z "$code" ] || [ "$code" = "000" ]; then
-    return 1
-  fi
+now() { date +%s; }
+iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# --- ledger ---------------------------------------------------------------
+# Persisted across timer firings: the script is invoked FRESH every ~30s, so
+# an in-memory counter would always read zero and "N consecutive failures"
+# could never be observed. Plain key=value, NEVER `source`d — a corrupt or
+# hostile state file must not become code. A value that is not a plain
+# integer resets that field to 0 (fail-safe: no history == do not restart).
+
+FAILURES=0        # accumulated, un-cleared failure WEIGHT
+SERVING_STREAK=0  # consecutive UPs since the last failure
+LAST_RESTART=0    # epoch of the last restart WE issued
+LAST_ALARM=0      # epoch of the last operator alarm (alarm-spam guard)
+RESTARTS=""       # comma-separated epochs of restarts we issued
+
+_int() { case "$1" in ''|*[!0-9]*) echo 0 ;; *) echo "$1" ;; esac; }
+
+read_state() {
+  [ -r "$STATE_FILE" ] || return 0
+  local key val
+  while IFS='=' read -r key val; do
+    case "$key" in
+      failures)       FAILURES="$(_int "$val")" ;;
+      serving_streak) SERVING_STREAK="$(_int "$val")" ;;
+      last_restart)   LAST_RESTART="$(_int "$val")" ;;
+      last_alarm)     LAST_ALARM="$(_int "$val")" ;;
+      restarts)
+        case "$val" in
+          ''|*[!0-9,]*) RESTARTS="" ;;
+          *)            RESTARTS="$val" ;;
+        esac
+        ;;
+    esac
+  done < "$STATE_FILE"
   return 0
 }
 
-if probe_health "$HEALTH_URL" "$PROBE_TIMEOUT"; then
-  # Quiet on the happy path — a healthy 30s probe should NOT spam the
-  # journal. Operators tail for the LOUD line below.
-  exit 0
-fi
+write_state() {
+  mkdir -p "$(dirname "$STATE_FILE")" 2>/dev/null || true
+  local tmp="${STATE_FILE}.$$"
+  {
+    echo "failures=${FAILURES}"
+    echo "serving_streak=${SERVING_STREAK}"
+    echo "last_restart=${LAST_RESTART}"
+    echo "last_alarm=${LAST_ALARM}"
+    echo "restarts=${RESTARTS}"
+  } > "$tmp" 2>/dev/null || return 1
+  # Atomic swap: a probe killed mid-write must never leave a torn ledger.
+  mv -f "$tmp" "$STATE_FILE" 2>/dev/null || { rm -f "$tmp" 2>/dev/null; return 1; }
+  return 0
+}
 
-# --- UNHEALTHY ------------------------------------------------------------
+# Drop restart timestamps that have aged out of the rate-limit window.
+prune_restarts() {
+  local cutoff="$1" kept="" ts
+  local IFS=','
+  for ts in $RESTARTS; do
+    [ -z "$ts" ] && continue
+    if [ "$ts" -gt "$cutoff" ] 2>/dev/null; then
+      kept="${kept:+${kept},}${ts}"
+    fi
+  done
+  RESTARTS="$kept"
+}
 
-ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+count_restarts() {
+  local n=0 ts
+  local IFS=','
+  for ts in $RESTARTS; do
+    [ -n "$ts" ] && n=$((n + 1))
+  done
+  echo "$n"
+}
 
-if [ "$CHECK_ONLY" -eq 1 ]; then
-  echo "sac-listen-health: UNHEALTHY ${HEALTH_URL} (no HTTP response) at ${ts}" >&2
-  exit 1
-fi
+# --- probe ----------------------------------------------------------------
+# Classify ONE observation as UP / DOWN / UNKNOWN. curl hands us BOTH halves
+# of the discrimination in a single call: the exit code separates "refused"
+# (7) from "timed out" (28), and %{time_connect} says whether the TCP
+# handshake COMPLETED — i.e. whether anything is bound at all — even when no
+# HTTP ever arrived.
+#
+# Echoes: "<verdict> <weight> <evidence...>"
+probe_once() {
+  local out code connect rc
+  out="$(curl -s -o /dev/null \
+              -w '%{http_code} %{time_connect}' \
+              --connect-timeout "$CONNECT_TIMEOUT" \
+              --max-time "$PROBE_TIMEOUT" \
+              "$HEALTH_URL" 2>/dev/null)"
+  rc=$?
+  code="${out%% *}"
+  connect="${out##* }"
+  [ -z "$code" ] && code=000
 
-# LOUD ERROR — this is the line that makes a restart VISIBLE in the
-# journal. Prefixed ERROR + the incident reference so a `journalctl`
-# grep finds it.
-echo "ERROR: sac-listen DOWN — ${HEALTH_URL} did not answer (transport failure)." >&2
-echo "ERROR: sac-listen watchdog is RESTARTING ${LISTEN_UNIT} at ${ts}." >&2
-echo "ERROR: incident-class=sac-listen-watchdog-autorestart-alarm; fleet a2a comms were interrupted." >&2
+  if [ "$rc" -eq 0 ] && [ "$code" != "000" ]; then
+    if [ "$code" -ge 500 ] 2>/dev/null; then
+      # It ANSWERED — bound, speaking HTTP — but its health route is
+      # erroring. An answer, but not health. SOFT: it is demonstrably alive,
+      # so destroying it demands the full corroboration.
+      echo "DOWN ${WEIGHT_SOFT} HTTP ${code} (server error from the health route)"
+    else
+      # Any status < 500 — including 401/403/404 — PROVES it is serving.
+      echo "UP 0 HTTP ${code}"
+    fi
+    return
+  fi
 
-# Best-effort operator alarm. The listen is the transport for
-# `sac fleet notify`, so this MAY fail (the listen is down). We still
-# try: (a) if only the HTTP layer wedged but the inbox path recovers,
-# or (b) if a peer/lead listen on another host receives it. Failure is
-# logged but does NOT change the restart outcome.
-if [ "$NOTIFY_ENABLED" = "1" ] && command -v sac >/dev/null 2>&1; then
+  case "$rc" in
+    7)
+      # Connection REFUSED: the kernel sent RST. NOTHING is listening. A
+      # positive observation of absence, not a failure to observe.
+      echo "DOWN ${WEIGHT_HARD} connection refused (nothing is listening on the port)"
+      ;;
+    28)
+      # Timed out. Did the TCP handshake at least COMPLETE? If so the socket
+      # is BOUND — the daemon has not exited — and this is the genuinely
+      # ambiguous case: busy (healthy) or wedged. UNKNOWN, never DOWN.
+      if [ -n "$connect" ] && [ "$connect" != "0.000000" ] && [ "$connect" != "0" ]; then
+        echo "UNKNOWN ${WEIGHT_SOFT} no HTTP answer within ${PROBE_TIMEOUT}s (but TCP connected in ${connect}s — the port IS bound)"
+      else
+        echo "UNKNOWN ${WEIGHT_SOFT} could not connect within ${CONNECT_TIMEOUT}s (no RST — blackholed, or the accept backlog is full)"
+      fi
+      ;;
+    6)
+      echo "UNKNOWN ${WEIGHT_SOFT} DNS resolution failed (our resolver — not necessarily the daemon)"
+      ;;
+    *)
+      # Reset mid-reply, empty reply, etc: the TCP was answered but the
+      # exchange broke. Ambiguous under load. UNKNOWN.
+      echo "UNKNOWN ${WEIGHT_SOFT} no usable answer (curl rc=${rc})"
+      ;;
+  esac
+}
+
+unit_active_state() {
+  command -v systemctl >/dev/null 2>&1 || { echo "unknown"; return; }
+  local st
+  st="$(systemctl --user show -p ActiveState --value "$LISTEN_UNIT" 2>/dev/null)"
+  echo "${st:-unknown}"
+}
+
+# The ONE operator alarm rail (`sac fleet notify`). Not forked, not replaced.
+alarm() {
+  local summary="$1" detail="$2"
+  [ "$NOTIFY_ENABLED" = "1" ] || return 0
+  command -v sac >/dev/null 2>&1 || return 0
   if sac fleet notify blocker \
       --from-agent "sac-listen-watchdog" \
-      --summary "sac listen DOWN — watchdog restarting ${LISTEN_UNIT}" \
-      --detail "health probe to ${HEALTH_URL} failed at ${ts}; fleet a2a comms interrupted. Auto-restart in progress." \
+      --summary "$summary" \
+      --detail "$detail" \
       >/dev/null 2>&1; then
     echo "sac-listen-health: alarm pushed via 'sac fleet notify blocker'." >&2
   else
     echo "WARN: sac-listen-health: 'sac fleet notify blocker' failed (expected if the listen itself is the down transport)." >&2
   fi
+}
+
+# ==========================================================================
+# MAIN
+# ==========================================================================
+
+read_state
+NOW="$(now)"
+TS="$(iso)"
+
+if [ "$MODE" = "reset" ]; then
+  FAILURES=0
+  SERVING_STREAK=0
+  LAST_RESTART=0
+  LAST_ALARM=0
+  RESTARTS=""
+  write_state
+  echo "sac-listen-health: ledger reset (${STATE_FILE})."
+  exit 0
 fi
 
-# Restart. `reset-failed` first so a tripped StartLimitBurst (the unit
-# entered `failed` after 5 restarts/60s) is cleared and `restart` can
-# proceed — otherwise systemd refuses with "start request repeated too
-# quickly".
+if [ "$MODE" = "status" ]; then
+  prune_restarts "$((NOW - RESTART_WINDOW))"
+  echo "state_file:      ${STATE_FILE}"
+  echo "health_url:      ${HEALTH_URL}"
+  echo "unit:            ${LISTEN_UNIT} (ActiveState=$(unit_active_state))"
+  echo "probe_timeout:   ${PROBE_TIMEOUT}s (connect ${CONNECT_TIMEOUT}s)"
+  echo "failure_weight:  ${FAILURES} / ${FAIL_THRESHOLD}  (weight required to restart)"
+  echo "serving_streak:  ${SERVING_STREAK} / ${RECOVERY_STREAK}  (consecutive UPs that clear the ledger)"
+  echo "restarts_in_${RESTART_WINDOW}s: $(count_restarts) / ${MAX_RESTARTS}"
+  if [ "$LAST_RESTART" -gt 0 ]; then
+    echo "last_restart:    $((NOW - LAST_RESTART))s ago (no-probe backoff ${RESTART_BACKOFF}s)"
+  else
+    echo "last_restart:    never"
+  fi
+  exit 0
+fi
+
+# --- GUARD (a): POST-RESTART BACKOFF --------------------------------------
+# We do not probe AT ALL inside the cooling-off window. The original
+# watchdog's SECOND restart happened *because* it probed during its own
+# restart, saw a genuinely-down daemon, and fired again. You cannot draw a
+# conclusion about a daemon you are in the middle of restarting.
+if [ "$MODE" = "heal" ] && [ "$LAST_RESTART" -gt 0 ]; then
+  age=$((NOW - LAST_RESTART))
+  if [ "$age" -lt "$RESTART_BACKOFF" ]; then
+    echo "sac-listen-health: within post-restart backoff (${age}s < ${RESTART_BACKOFF}s) — NOT probing. A daemon that is still coming up cannot be judged." >&2
+    exit 0
+  fi
+fi
+
+# --- OBSERVE --------------------------------------------------------------
+read -r VERDICT WEIGHT EVIDENCE <<< "$(probe_once)"
+
+# --- check-only: pure observation, ZERO side effects ----------------------
+if [ "$MODE" = "check" ]; then
+  if [ "$VERDICT" = "UP" ]; then
+    exit 0
+  fi
+  echo "sac-listen-health: ${VERDICT} ${HEALTH_URL} — ${EVIDENCE} at ${TS}" >&2
+  exit 1
+fi
+
+# --- RECORD ---------------------------------------------------------------
+# A failure is a FACT: one later success does not un-happen it. A success
+# builds a SERVING STREAK; the ledger clears only on a SUSTAINED recovery,
+# and that clearing is LOUD. (Consistent with _listen/_standby_ledger.py,
+# PR #673 — the same bug class, in the other direction.)
+if [ "$VERDICT" = "UP" ]; then
+  if [ "$FAILURES" -eq 0 ]; then
+    # A clean daemon on the quiet path. Stay QUIET — a healthy 30s probe
+    # must not spam the journal.
+    SERVING_STREAK=0
+    write_state
+    exit 0
+  fi
+  SERVING_STREAK=$((SERVING_STREAK + 1))
+  if [ "$SERVING_STREAK" -ge "$RECOVERY_STREAK" ]; then
+    echo "sac-listen-health: RECOVERED — ${HEALTH_URL} answered ${SERVING_STREAK}x in a row (${EVIDENCE}); clearing a failure ledger that stood at ${FAILURES}/${FAIL_THRESHOLD}. No restart was needed." >&2
+    FAILURES=0
+    SERVING_STREAK=0
+  else
+    echo "sac-listen-health: ${HEALTH_URL} answered (${EVIDENCE}), but a failure ledger of ${FAILURES}/${FAIL_THRESHOLD} still stands — it needs ${RECOVERY_STREAK} consecutive answers to clear (${SERVING_STREAK}/${RECOVERY_STREAK}). One lucky reply does not un-happen a failed check." >&2
+  fi
+  write_state
+  exit 0
+fi
+
+# Not UP. Accrue.
+SERVING_STREAK=0
+FAILURES=$((FAILURES + WEIGHT))
+
+if [ "$FAILURES" -lt "$FAIL_THRESHOLD" ]; then
+  # UNCORROBORATED. This is the whole fix: ONE failed probe on a loaded box
+  # means nothing, and the remedy (a restart) would deafen every agent's
+  # inbox. We say exactly what we saw, and we WAIT.
+  echo "WARN: sac-listen-health: ${VERDICT} — ${EVIDENCE} at ${TS}. Failure weight ${FAILURES}/${FAIL_THRESHOLD} — NOT restarting: an uncorroborated verdict is not grounds to destroy a control plane the whole fleet depends on." >&2
+  write_state
+  exit 0
+fi
+
+# ==========================================================================
+# CORROBORATED — it has failed enough, consecutively, to act.
+# ==========================================================================
+
+# --- GUARD (b): is it ALREADY coming back? --------------------------------
+# Independent of our own backoff (which a lost or corrupt state file would
+# forfeit): if systemd says the unit is `activating`, something is already
+# restarting it. Restarting a restart is exactly the 26-second double-restart
+# we are here to kill.
+ACTIVE_STATE="$(unit_active_state)"
+if [ "$ACTIVE_STATE" = "activating" ] || [ "$ACTIVE_STATE" = "deactivating" ]; then
+  echo "sac-listen-health: ${LISTEN_UNIT} is already '${ACTIVE_STATE}' — standing down. It is coming back on its own, and restarting a restart is what produced the 2026-07-14 double-restart." >&2
+  write_state
+  exit 0
+fi
+
+# --- RATE LIMIT -----------------------------------------------------------
+prune_restarts "$((NOW - RESTART_WINDOW))"
+RECENT="$(count_restarts)"
+
+if [ "$RECENT" -ge "$MAX_RESTARTS" ]; then
+  echo "ERROR: sac-listen DOWN — ${HEALTH_URL}: ${EVIDENCE}." >&2
+  echo "ERROR: sac-listen watchdog is GIVING UP: ${RECENT} restart(s) already issued in the last ${RESTART_WINDOW}s (cap ${MAX_RESTARTS}) and ${LISTEN_UNIT} is STILL failing its health check." >&2
+  echo "ERROR: NOT restarting again — if ${RECENT} restarts did not fix it, another will not either, and an unbounded restarter is how a fleet goes down at 3am. A HUMAN IS NEEDED." >&2
+  echo "ERROR: incident-class=sac-listen-watchdog-giving-up; fleet a2a comms are DOWN and auto-heal is exhausted." >&2
+  echo "ERROR: inspect with:  systemctl --user status ${LISTEN_UNIT}  &&  journalctl --user -u sac-listen -n 100" >&2
+  # Alarm at most once per window: the journal must scream every cycle (this
+  # IS an ongoing outage), but the operator's pager must not.
+  if [ $((NOW - LAST_ALARM)) -ge "$RESTART_WINDOW" ]; then
+    alarm "sac listen STILL DOWN after ${RECENT} restarts — watchdog GIVING UP, human needed" \
+          "health probe to ${HEALTH_URL} failed: ${EVIDENCE} at ${TS}. ${RECENT} restart(s) in the last ${RESTART_WINDOW}s did not fix it (cap ${MAX_RESTARTS}). The watchdog has STOPPED restarting to avoid a restart storm. Fleet a2a comms are down. Inspect: systemctl --user status ${LISTEN_UNIT}"
+    LAST_ALARM="$NOW"
+  fi
+  write_state
+  exit 1
+fi
+
+# --- RESTART --------------------------------------------------------------
+echo "ERROR: sac-listen DOWN — ${HEALTH_URL}: ${EVIDENCE}." >&2
+echo "ERROR: verdict CORROBORATED (failure weight ${FAILURES}/${FAIL_THRESHOLD}; unit ActiveState=${ACTIVE_STATE}). This is not one slow probe." >&2
+echo "ERROR: sac-listen watchdog is RESTARTING ${LISTEN_UNIT} at ${TS}." >&2
+echo "ERROR: incident-class=sac-listen-watchdog-autorestart-alarm; fleet a2a comms were interrupted." >&2
+
+alarm "sac listen DOWN — watchdog restarting ${LISTEN_UNIT}" \
+      "health probe to ${HEALTH_URL} failed ${FAILURES}/${FAIL_THRESHOLD} (weighted, consecutive): ${EVIDENCE} at ${TS}. Fleet a2a comms interrupted. Auto-restart in progress (restart $((RECENT + 1))/${MAX_RESTARTS} within the last ${RESTART_WINDOW}s)."
+
+# Record the attempt BEFORE issuing it: if the restart wedges, or this
+# process is killed mid-flight, the backoff and the rate limit must STILL
+# hold. An unrecorded restart is an unbounded restarter.
+LAST_RESTART="$NOW"
+RESTARTS="${RESTARTS:+${RESTARTS},}${NOW}"
+FAILURES=0
+SERVING_STREAK=0
+write_state
+
 restart_rc=0
 if command -v systemctl >/dev/null 2>&1; then
+  # `reset-failed` first so a tripped StartLimitBurst (the unit entered
+  # `failed` after 5 restarts/60s) is cleared and `restart` can proceed —
+  # otherwise systemd refuses with "start request repeated too quickly".
   systemctl --user reset-failed "$LISTEN_UNIT" >/dev/null 2>&1 || true
   if systemctl --user restart "$LISTEN_UNIT"; then
-    echo "sac-listen-health: issued 'systemctl --user restart ${LISTEN_UNIT}'." >&2
+    echo "sac-listen-health: issued 'systemctl --user restart ${LISTEN_UNIT}'. Not probing again for ${RESTART_BACKOFF}s." >&2
   else
     restart_rc=$?
     echo "ERROR: sac-listen-health: 'systemctl --user restart ${LISTEN_UNIT}' FAILED (rc=${restart_rc})." >&2

--- a/scripts/systemd/sac-listen-health.service
+++ b/scripts/systemd/sac-listen-health.service
@@ -25,6 +25,9 @@ ExecStart=%h/.config/systemd/user/sac-listen-health-probe.sh
 # probe land in `journalctl --user -u sac-listen-health`.
 StandardOutput=journal
 StandardError=journal
-# A wedged-restart cycle should never itself hang the timer; bound the
-# whole probe (curl --max-time is 5s, restart is fast).
-TimeoutStartSec=60s
+# A wedged-restart cycle should never itself hang the timer; bound the whole
+# probe. The curl deadline is SAC_LISTEN_PROBE_TIMEOUT (20s by default — a
+# 5s fuse on a box at load 60-70 restarted a HEALTHY listen, incident
+# 2026-07-14) plus the restart itself, so 90s leaves generous headroom while
+# still guaranteeing the oneshot can never hang the timer forever.
+TimeoutStartSec=90s

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,30 @@ os.environ["COVERAGE_FILE"] = str(_COVERAGE_DIR / ".coverage")
 # tests/scitex_agent_container/test__build_priority.py.
 os.environ.setdefault("SAC_BUILD_NO_NICE", "1")
 
+# --- NEVER let a test drive the LIVE listen watchdog ----------------------
+# `scripts/systemd/sac-listen-health-probe.sh` persists a FAILURE LEDGER at
+#   $HOME/.scitex/agent-container/runtime/listen-health.state
+# because systemd invokes it FRESH every ~30s, so counting CONSECUTIVE
+# failures is only possible across a file.
+#
+# A test that shells the probe without redirecting that path writes to the
+# REAL ledger. On the host that is not a dirty-state annoyance, it is an
+# OUTAGE: a test leaving `failures=2` behind means the next real timer tick
+# can reach the threshold and RESTART the real `sac listen` — which tears
+# down the in-memory a2a Broker and DEAFENS EVERY AGENT'S INBOX AT ONCE. The
+# test suite would cause the exact incident the watchdog exists to prevent
+# (2026-07-14). CI cannot see this — there is no fleet on a runner — which
+# is precisely why the floor belongs here and not in a single test file.
+#
+# Force-set (not setdefault): a hard floor that holds even for code paths
+# that bypass fixtures. Individual probe suites additionally give each test
+# its own ledger so they cannot bleed a failure count into one another.
+_LISTEN_HEALTH_DIR = _PROJECT_ROOT / "tests" / "results" / "listen-health"
+_LISTEN_HEALTH_DIR.mkdir(parents=True, exist_ok=True)
+os.environ["SAC_LISTEN_HEALTH_STATE"] = str(_LISTEN_HEALTH_DIR / "session.state")
+# And a probe run by a test must never page the operator.
+os.environ["SAC_LISTEN_NOTIFY"] = "0"
+
 
 def _ensure_subprocess_coverage_shim() -> None:
     """Drop an idempotent ``.pth`` shim in site-packages so every child

--- a/tests/integration/test_sac_listen_health_probe.py
+++ b/tests/integration/test_sac_listen_health_probe.py
@@ -88,6 +88,38 @@ def _free_port() -> int:
     return port
 
 
+@pytest.fixture(autouse=True)
+def isolated_ledger(tmp_path):
+    """Give every test in this module its OWN watchdog failure ledger.
+
+    The probe counts CONSECUTIVE failures across a state file (systemd
+    invokes it FRESH every ~30s, so a file is the only way to count). Two
+    hazards follow, and this closes both:
+
+    * Without redirection these tests write the REAL ledger under ``$HOME``.
+      On the host that could push the LIVE ``sac listen`` into a restart —
+      the test suite causing the very outage the watchdog exists to prevent.
+      ``tests/conftest.py`` sets a session-wide floor; this makes it per-test.
+    * Sharing one ledger makes the heal-mode tests ORDER-DEPENDENT: one
+      test's leftover failure weight silently satisfies the next test's
+      corroboration threshold. That is a green test proving nothing — and it
+      is exactly how ``test_heal_mode_logs_restart_intent`` passed in CI
+      while asserting a restart it had not actually earned.
+
+    Real env, real file, restored on teardown (no monkeypatch — STX-NM002).
+    """
+    key = "SAC_LISTEN_HEALTH_STATE"
+    prior = os.environ.get(key)
+    os.environ[key] = str(tmp_path / "listen-health.state")
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = prior
+
+
 def _run_probe(*args: str, env_extra: dict[str, str] | None = None):
     env = os.environ.copy()
     # Never let a test accidentally fire the operator alarm.
@@ -132,13 +164,17 @@ def test_check_only_fails_against_dead_port():
     assert result.returncode == 1
 
 
-def test_check_only_down_logs_unhealthy_line():
+def test_check_only_down_names_the_verdict():
     # Arrange
     env = _down_env()
     # Act
     result = _run_probe("--check-only", env_extra=env)
-    # Assert
-    assert "UNHEALTHY" in result.stderr
+    # Assert — the probe now reports a THREE-STATE verdict. "UNHEALTHY" was a
+    # two-state word, and two states cannot distinguish "connection refused"
+    # (nothing is listening) from "I asked and got nothing" (a loaded box).
+    # Collapsing those is what restarted a HEALTHY control plane on
+    # 2026-07-14, so the vocabulary changed with the decision model.
+    assert "DOWN" in result.stderr
 
 
 def test_check_only_healthy_is_quiet(live_health_server):
@@ -153,10 +189,35 @@ def test_check_only_healthy_is_quiet(live_health_server):
 # --- probe: heal-mode loudness (no real systemctl needed) -----------------
 
 
-def test_heal_mode_down_emits_loud_error():
-    # Arrange
+def _corroborated_down_env() -> dict[str, str]:
+    """A dead port, probed ONCE already — the next probe corroborates.
+
+    A SINGLE failed probe is no longer grounds to restart: that was the
+    2026-07-14 false-RED, where one 5s timeout on a box at load 60-70
+    restarted a HEALTHY listen and deafened every agent's inbox. These two
+    tests used to assert the loud line after ONE probe — i.e. they ENCODED
+    the bug. They now earn the verdict first (a refusal is weight 2, the
+    threshold is 3, so a second one crosses it).
+    """
     env = _down_env()
     env["SAC_LISTEN_UNIT"] = "sac-listen-nonexistent-test.service"
+    _run_probe(env_extra=env)
+    return env
+
+
+def test_uncorroborated_down_does_not_restart():
+    # Arrange — the regression that made this whole rewrite necessary.
+    env = _down_env()
+    env["SAC_LISTEN_UNIT"] = "sac-listen-nonexistent-test.service"
+    # Act
+    result = _run_probe(env_extra=env)
+    # Assert — one failed probe must NOT destroy the control plane.
+    assert "RESTARTING" not in result.stderr
+
+
+def test_heal_mode_corroborated_down_emits_loud_error():
+    # Arrange
+    env = _corroborated_down_env()
     # Act
     result = _run_probe(env_extra=env)
     # Assert
@@ -165,11 +226,10 @@ def test_heal_mode_down_emits_loud_error():
 
 def test_heal_mode_logs_restart_intent():
     # Arrange
-    env = _down_env()
-    env["SAC_LISTEN_UNIT"] = "sac-listen-nonexistent-test.service"
+    env = _corroborated_down_env()
     # Act
     result = _run_probe(env_extra=env)
-    # Assert
+    # Assert — a genuinely dead listen still comes back (incident 2026-06-26).
     assert "RESTARTING" in result.stderr
 
 

--- a/tests/integration/test_sac_listen_health_watchdog_decision.py
+++ b/tests/integration/test_sac_listen_health_watchdog_decision.py
@@ -1,0 +1,673 @@
+"""The watchdog's DECISION model — does it restart, and on what evidence?
+
+Incident 2026-07-14: the watchdog RESTARTED A HEALTHY CONTROL PLANE. It
+probed ``/v1/health`` with a 5-SECOND curl deadline on a box that idles at
+load 60-70, and restarted ``sac-listen.service`` after ONE failure. Every
+``sac listen`` restart tears down the in-memory a2a Broker, which DEAFENS
+EVERY AGENT'S INBOX AT ONCE — so a slow probe did not merely mis-report, it
+MANUFACTURED the outage it claimed to detect, then re-probed during its own
+restart and restarted AGAIN (2 restarts in 26s, live journal).
+
+Measured against the UNFIXED probe, with a REAL server answering HTTP 200 in
+8s (healthy, merely busy): **3 restarts out of 3 probes.**
+
+Both directions are bugs. These tests pin BOTH:
+
+* it must NOT restart on a slow-but-alive daemon, a single failure, an
+  uncorroborated verdict, during its own restart, or past the restart cap;
+* it MUST still restart a genuinely dead or wedged one (incident 2026-06-26:
+  listen died with nothing restarting it and the fleet was cut off silently).
+
+No mocks (STX-NM002). Every case drives the REAL probe script against a REAL
+HTTP server on a REAL ephemeral loopback socket — slow, refusing, 5xx-ing,
+401-ing, dying. The "refused" case points at a genuinely closed port. Nothing
+here ever touches port 7878: that is the live control plane the whole fleet
+depends on, and a test that restarts it would repeat the incident.
+
+AAA markers (TQ002); 3+-word test names.
+"""
+
+from __future__ import annotations
+
+import http.server
+import os
+import shutil
+import socket
+import subprocess
+import threading
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PROBE = _REPO_ROOT / "scripts" / "systemd" / "sac-listen-health-probe.sh"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("curl") is None,
+    reason="sac-listen-health-probe.sh requires curl",
+)
+
+# A unit that does not exist. We assert the DECISION (the loud ERROR lines),
+# never a real systemctl effect — the probe must never restart anything real
+# from a test.
+_FAKE_UNIT = "sac-listen-watchdog-pytest-nonexistent.service"
+
+
+# --- real servers ---------------------------------------------------------
+
+
+def _handler(status: int, delay: float):
+    """A REAL handler answering `status` after `delay` seconds."""
+
+    class _H(http.server.BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self):  # noqa: N802 (http.server API)
+            if delay:
+                # A HEALTHY daemon that is merely BUSY: it does answer.
+                threading.Event().wait(delay)
+            body = b'{"ok": true, "service": "sac-listen"}'
+            self.send_response(status)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_a):
+            return
+
+    return _H
+
+
+class _Server:
+    """A real HTTP server on a real ephemeral loopback port (never 7878)."""
+
+    def __init__(self, status: int = 200, delay: float = 0.0):
+        self._srv = http.server.ThreadingHTTPServer(
+            ("127.0.0.1", 0), _handler(status, delay)
+        )
+        self.port = self._srv.server_address[1]
+        self._t = threading.Thread(target=self._srv.serve_forever, daemon=True)
+        self._t.start()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/v1/health"
+
+    def kill(self) -> None:
+        """Really stop serving — the port goes to connection-refused."""
+        self._srv.shutdown()
+        self._srv.server_close()
+
+
+def _closed_port() -> int:
+    """Bind then release a port, so nothing is listening on it."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+# --- driving the real probe -----------------------------------------------
+
+
+class _Probe:
+    """Runs the REAL shipped probe against `url`, with a private ledger."""
+
+    def __init__(self, tmp_path: Path, url: str, **env):
+        self.state = tmp_path / "listen-health.state"
+        self.url = url
+        self.env = {
+            "SAC_LISTEN_HEALTH_URL": url,
+            "SAC_LISTEN_HEALTH_STATE": str(self.state),
+            "SAC_LISTEN_UNIT": _FAKE_UNIT,
+            "SAC_LISTEN_NOTIFY": "0",  # never fire the operator alarm
+            "SAC_LISTEN_PROBE_TIMEOUT": "3",  # keep the suite fast
+            "SAC_LISTEN_CONNECT_TIMEOUT": "2",
+            **{k: str(v) for k, v in env.items()},
+        }
+
+    def run(self, *args: str) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        env.update(self.env)
+        return subprocess.run(
+            ["bash", str(_PROBE), *args],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+    def restarted(self, *args: str) -> bool:
+        """True iff this invocation DECIDED to restart the listen."""
+        return "RESTARTING" in self.run(*args).stderr
+
+
+# ==========================================================================
+# THE HEADLINE BUG: a slow-but-ALIVE daemon must never be restarted
+# ==========================================================================
+
+
+@pytest.fixture()
+def loaded_box(tmp_path):
+    """The incident, exactly: a HEALTHY daemon answering HTTP 200 in 8s.
+
+    Deliberately driven at the probe's SHIPPED DEFAULT deadline — no
+    override. That is the whole point: the old default (5s) restarted this
+    server 3 times out of 3; the new default (20s) sees it for what it is.
+    A test that overrode the deadline would pass on the BROKEN script too,
+    and prove nothing.
+    """
+    srv = _Server(status=200, delay=8.0)
+    probe = _Probe(tmp_path, srv.url)
+    del probe.env["SAC_LISTEN_PROBE_TIMEOUT"]
+    del probe.env["SAC_LISTEN_CONNECT_TIMEOUT"]
+    try:
+        yield probe
+    finally:
+        srv.kill()
+
+
+def test_slow_but_alive_is_never_restarted(loaded_box):
+    # Arrange
+    probe = loaded_box
+    # Act — three consecutive probes, as the timer would fire them.
+    decisions = [probe.restarted() for _ in range(3)]
+    # Assert — the daemon ANSWERED every time. It must not be destroyed.
+    assert decisions == [False, False, False]
+
+
+def test_slow_but_alive_probe_stays_quiet(loaded_box):
+    # Arrange
+    probe = loaded_box
+    # Act
+    result = probe.run()
+    # Assert — a healthy 30s probe must not spam the journal.
+    assert result.returncode == 0 and result.stderr.strip() == ""
+
+
+# ==========================================================================
+# THREE STATES: a timeout is UNKNOWN, not DOWN
+# ==========================================================================
+
+
+def test_timeout_is_unknown_not_down(tmp_path):
+    # Arrange — answers, but SLOWER than the deadline: we get nothing back.
+    srv = _Server(status=200, delay=5.0)
+    probe = _Probe(tmp_path, srv.url, SAC_LISTEN_PROBE_TIMEOUT=1)
+    try:
+        # Act
+        result = probe.run("--check-only")
+    finally:
+        srv.kill()
+    # Assert — "I asked and got nothing" is UNKNOWN. Never reported as DOWN.
+    assert "UNKNOWN" in result.stderr and "DOWN" not in result.stderr
+
+
+def test_timeout_reports_tcp_did_connect(tmp_path):
+    # Arrange — the port IS bound; only the HTTP answer is missing.
+    srv = _Server(status=200, delay=5.0)
+    probe = _Probe(tmp_path, srv.url, SAC_LISTEN_PROBE_TIMEOUT=1)
+    try:
+        # Act
+        result = probe.run("--check-only")
+    finally:
+        srv.kill()
+    # Assert — the evidence must say the socket was reachable, which is what
+    # distinguishes "busy" from "gone".
+    assert "the port IS bound" in result.stderr
+
+
+def test_refused_is_reported_as_down(tmp_path):
+    # Arrange — a genuinely closed port: the kernel sends RST.
+    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    # Act
+    result = probe.run("--check-only")
+    # Assert
+    assert "DOWN" in result.stderr and "connection refused" in result.stderr
+
+
+def test_single_timeout_does_not_restart(tmp_path):
+    # Arrange
+    srv = _Server(status=200, delay=5.0)
+    probe = _Probe(tmp_path, srv.url, SAC_LISTEN_PROBE_TIMEOUT=1)
+    try:
+        # Act — ONE failed probe. On a loaded box this means nothing.
+        decided = probe.restarted()
+    finally:
+        srv.kill()
+    # Assert
+    assert decided is False
+
+
+# ==========================================================================
+# ANY HTTP STATUS < 500 IS "UP" — the bearer-auth lesson (PR #463)
+# ==========================================================================
+
+
+@pytest.mark.parametrize("status", [200, 204, 301, 401, 403, 404])
+def test_any_non_server_error_status_is_up(tmp_path, status):
+    # Arrange — a 401 PROVES the daemon is up: bound, speaking HTTP,
+    # auth-gating. Gating liveness on 200 once SIGKILLed a healthy daemon.
+    srv = _Server(status=status)
+    probe = _Probe(tmp_path, srv.url)
+    try:
+        # Act
+        result = probe.run("--check-only")
+    finally:
+        srv.kill()
+    # Assert
+    assert result.returncode == 0
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_auth_gated_daemon_is_never_restarted(tmp_path, status):
+    # Arrange
+    srv = _Server(status=status)
+    probe = _Probe(tmp_path, srv.url)
+    try:
+        # Act — probe repeatedly; a 401 must never accrue a failure.
+        decisions = [probe.restarted() for _ in range(4)]
+    finally:
+        srv.kill()
+    # Assert
+    assert not any(decisions)
+
+
+def test_server_error_is_a_failure_not_up(tmp_path):
+    # Arrange — it ANSWERED, with a 500. Bound and speaking HTTP, but its
+    # health route is erroring: an answer, but not health.
+    srv = _Server(status=500)
+    probe = _Probe(tmp_path, srv.url)
+    try:
+        # Act
+        result = probe.run("--check-only")
+    finally:
+        srv.kill()
+    # Assert
+    assert result.returncode == 1
+
+
+def test_single_server_error_does_not_restart(tmp_path):
+    # Arrange — a 5xx is a SOFT failure: the daemon is demonstrably alive, so
+    # destroying it demands full corroboration.
+    srv = _Server(status=500)
+    probe = _Probe(tmp_path, srv.url)
+    try:
+        # Act
+        decided = probe.restarted()
+    finally:
+        srv.kill()
+    # Assert
+    assert decided is False
+
+
+# ==========================================================================
+# CORROBORATION — N consecutive failures before the remedy
+# ==========================================================================
+
+
+def test_first_refusal_does_not_restart(tmp_path):
+    # Arrange
+    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    # Act
+    decided = probe.restarted()
+    # Assert — even a HARD down (weight 2) is below the threshold (3) alone.
+    assert decided is False
+
+
+def test_second_refusal_restarts_dead_listen(tmp_path):
+    # Arrange — a genuinely dead listen MUST still come back
+    # (incident 2026-06-26). Crash coverage is not weakened.
+    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    # Act
+    first = probe.restarted()
+    second = probe.restarted()
+    # Assert — refusal counts HARDER than a timeout, so 2 probes suffice.
+    assert (first, second) == (False, True)
+
+
+def test_three_timeouts_restart_wedged_listen(tmp_path):
+    # Arrange — a WEDGED daemon: bound, accepting TCP, never answering. This
+    # is the case systemd's Restart=always CANNOT see, and the reason the
+    # watchdog exists. It must still be healed.
+    srv = _Server(status=200, delay=30.0)
+    probe = _Probe(tmp_path, srv.url, SAC_LISTEN_PROBE_TIMEOUT=1)
+    try:
+        # Act
+        decisions = [probe.restarted() for _ in range(3)]
+    finally:
+        srv.kill()
+    # Assert — 3 consecutive UNKNOWNs corroborate into a DOWN verdict.
+    assert decisions == [False, False, True]
+
+
+def test_two_timeouts_do_not_yet_restart(tmp_path):
+    # Arrange
+    srv = _Server(status=200, delay=30.0)
+    probe = _Probe(tmp_path, srv.url, SAC_LISTEN_PROBE_TIMEOUT=1)
+    try:
+        # Act
+        decisions = [probe.restarted() for _ in range(2)]
+    finally:
+        srv.kill()
+    # Assert — below threshold: the fleet is not sacrificed to a maybe.
+    assert decisions == [False, False]
+
+
+def test_uncorroborated_failure_says_not_restarting(tmp_path):
+    # Arrange
+    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    # Act
+    result = probe.run()
+    # Assert — it must SAY it saw a failure and chose not to act.
+    assert "NOT restarting" in result.stderr and "2/3" in result.stderr
+
+
+# ==========================================================================
+# A FAILURE IS A FACT — one lucky reply must not wipe the ledger
+# (consistent with _listen/_standby_ledger.py, PR #673)
+# ==========================================================================
+
+
+def test_one_success_does_not_wipe_failure_streak(tmp_path):
+    # Arrange — the bug PR #673 fixed in sac listen's own holder check: a
+    # single reply reset `consecutive_unhealthy = 0`, so a FLAPPING daemon
+    # oscillated 1/2 -> "healthy" -> 1/2 forever and was NEVER acted on.
+    dead = f"http://127.0.0.1:{_closed_port()}/v1/health"
+    srv = _Server(status=200)
+    live = srv.url
+    probe = _Probe(tmp_path, dead)
+    try:
+        # Act — fail (weight 2), then one lucky success, then fail again.
+        first = probe.restarted()
+        probe.env["SAC_LISTEN_HEALTH_URL"] = live
+        probe.run()  # a single UP: must NOT clear the standing failure
+        probe.env["SAC_LISTEN_HEALTH_URL"] = dead
+        third = probe.restarted()
+    finally:
+        srv.kill()
+    # Assert — the ledger survived the blip, so the flapper is acted on.
+    assert (first, third) == (False, True)
+
+
+def test_single_success_keeps_ledger_standing(tmp_path):
+    # Arrange
+    dead = f"http://127.0.0.1:{_closed_port()}/v1/health"
+    srv = _Server(status=200)
+    probe = _Probe(tmp_path, dead)
+    try:
+        probe.run()  # accrue a failure
+        probe.env["SAC_LISTEN_HEALTH_URL"] = srv.url
+        # Act
+        result = probe.run()
+    finally:
+        srv.kill()
+    # Assert — it must SAY the ledger still stands, loudly.
+    assert "still stands" in result.stderr
+
+
+def test_sustained_recovery_clears_the_ledger(tmp_path):
+    # Arrange — a daemon that blips once and then genuinely recovers must NOT
+    # be destroyed. Two consecutive answers clear it.
+    dead = f"http://127.0.0.1:{_closed_port()}/v1/health"
+    srv = _Server(status=200)
+    probe = _Probe(tmp_path, dead)
+    try:
+        probe.run()  # failure weight 2
+        probe.env["SAC_LISTEN_HEALTH_URL"] = srv.url
+        probe.run()  # UP 1/2 — not yet cleared
+        # Act
+        result = probe.run()  # UP 2/2 — cleared
+    finally:
+        srv.kill()
+    # Assert — and the clearing is LOUD: "the thing I said was broken now
+    # looks fine" is exactly what an operator must never have hidden.
+    assert "RECOVERED" in result.stderr
+
+
+def test_recovered_daemon_survives_a_later_blip(tmp_path):
+    # Arrange — after a genuine recovery the ledger is clean, so a single
+    # later failure is once again just a blip, not a death sentence.
+    dead = f"http://127.0.0.1:{_closed_port()}/v1/health"
+    srv = _Server(status=200)
+    probe = _Probe(tmp_path, dead)
+    try:
+        probe.run()  # fail (2)
+        probe.env["SAC_LISTEN_HEALTH_URL"] = srv.url
+        probe.run()  # UP 1/2
+        probe.run()  # UP 2/2 -> cleared
+        probe.env["SAC_LISTEN_HEALTH_URL"] = dead
+        # Act
+        decided = probe.restarted()  # fail (2) — from a CLEAN ledger
+    finally:
+        srv.kill()
+    # Assert
+    assert decided is False
+
+
+# ==========================================================================
+# THE DOUBLE-RESTART: never probe during your own restart
+# ==========================================================================
+
+
+def _drive_to_restart(probe: _Probe) -> None:
+    """Two refusals — enough to corroborate and issue restart #1.
+
+    That this REALLY restarts is pinned by
+    ``test_second_refusal_restarts_dead_listen``, so the tests below are not
+    vacuous when they assert no FURTHER restart follows.
+    """
+    probe.run()
+    probe.run()
+
+
+def test_backoff_blocks_the_second_restart(tmp_path):
+    # Arrange — THE incident. The old probe restarted, then re-probed 26s
+    # later DURING its own restart, saw a genuinely-down daemon, and
+    # restarted AGAIN. Drive it to a real restart, then keep probing a
+    # still-dead port.
+    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    _drive_to_restart(probe)
+    # Act — the timer keeps firing while the daemon is coming back up.
+    followups = [probe.restarted() for _ in range(3)]
+    # Assert — NOT ONE further restart inside the cooling-off window.
+    assert followups == [False, False, False]
+
+
+def test_backoff_refuses_to_even_probe(tmp_path):
+    # Arrange
+    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe.run()
+    probe.run()  # restart issued
+    # Act
+    result = probe.run()
+    # Assert — you cannot judge a daemon you are in the middle of restarting.
+    assert "post-restart backoff" in result.stderr and "NOT probing" in result.stderr
+
+
+def test_backoff_expiry_allows_healing_again(tmp_path):
+    # Arrange — the backoff must not be a permanent gag: once it lapses, a
+    # still-dead listen is healed again.
+    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe.run()
+    probe.run()  # restart #1
+    # Act — a 0s backoff is the expiry, exactly as the timer would see it.
+    probe.env["SAC_LISTEN_RESTART_BACKOFF"] = "0"
+    probe.run()  # failure 2/3 again
+    decided = probe.restarted()
+    # Assert
+    assert decided is True
+
+
+# ==========================================================================
+# RATE LIMIT — an unbounded restarter is how a fleet goes down at 3am
+# ==========================================================================
+
+
+def test_restarts_are_capped_per_window(tmp_path):
+    # Arrange — a listen that never comes back. Backoff off so we can reach
+    # the cap; the cap is the thing under test.
+    probe = _Probe(
+        tmp_path,
+        f"http://127.0.0.1:{_closed_port()}/v1/health",
+        SAC_LISTEN_RESTART_BACKOFF=0,
+    )
+    # Act — six probes; each pair corroborates into one restart attempt.
+    decisions = [probe.restarted() for _ in range(6)]
+    # Assert — exactly MAX_RESTARTS (2), then it stops. Not six.
+    assert sum(decisions) == 2
+
+
+@pytest.fixture()
+def exhausted_probe(tmp_path):
+    """A watchdog that has spent its restart budget on a listen still dead."""
+    probe = _Probe(
+        tmp_path,
+        f"http://127.0.0.1:{_closed_port()}/v1/health",
+        SAC_LISTEN_RESTART_BACKOFF=0,
+    )
+    for _ in range(5):  # 2 restarts issued; the cap (2) is now reached
+        probe.run()
+    return probe
+
+
+def test_exhausted_watchdog_gives_up_loudly(exhausted_probe):
+    # Arrange — the restart budget is spent and the listen is still dead.
+    probe = exhausted_probe
+    # Act
+    result = probe.run()
+    # Assert
+    assert "GIVING UP" in result.stderr
+
+
+def test_exhausted_watchdog_calls_for_a_human(exhausted_probe):
+    # Arrange
+    probe = exhausted_probe
+    # Act
+    result = probe.run()
+    # Assert — if 2 restarts did not fix it, a 3rd will not either.
+    assert "HUMAN IS NEEDED" in result.stderr
+
+
+def test_exhausted_watchdog_emits_incident_class(exhausted_probe):
+    # Arrange
+    probe = exhausted_probe
+    # Act
+    result = probe.run()
+    # Assert — greppable in the journal, like the autorestart alarm.
+    assert "incident-class=sac-listen-watchdog-giving-up" in result.stderr
+
+
+def test_giving_up_still_exits_nonzero(exhausted_probe):
+    # Arrange — refusing to restart must NOT read as success: the outage is
+    # ongoing and the exit code has to say so.
+    probe = exhausted_probe
+    # Act
+    result = probe.run()
+    # Assert
+    assert result.returncode == 1
+
+
+# ==========================================================================
+# --check-only is a PROBE: it must not mutate anything
+# ==========================================================================
+
+
+def test_check_only_writes_no_state(tmp_path):
+    # Arrange — a probe that mutates is not a probe.
+    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    # Act
+    for _ in range(5):
+        probe.run("--check-only")
+    # Assert — five failed check-only probes leave NO ledger and NO restart.
+    assert not probe.state.exists()
+
+
+def test_check_only_never_restarts(tmp_path):
+    # Arrange
+    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    # Act
+    outs = [probe.run("--check-only").stderr for _ in range(5)]
+    # Assert
+    assert not any("RESTARTING" in o for o in outs)
+
+
+# ==========================================================================
+# The ledger is DATA, not code — and a corrupt one must fail SAFE
+# ==========================================================================
+
+
+def test_corrupt_ledger_does_not_restart(tmp_path):
+    # Arrange — garbage (and a shell injection attempt) in the state file.
+    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe.state.write_text(
+        "failures=$(touch /tmp/sac-pwned)\n"
+        "serving_streak=../../etc\n"
+        "last_restart=NaN\n"
+        "restarts=x;rm -rf /\n"
+    )
+    # Act
+    decided = probe.restarted()
+    # Assert — unparseable == no history == do NOT restart. Fail safe.
+    assert decided is False
+
+
+def test_corrupt_ledger_is_not_executed(tmp_path):
+    # Arrange — the state file must never be `source`d.
+    canary = tmp_path / "pwned"
+    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe.state.write_text(f"failures=9\nrestarts=$(touch {canary})\n")
+    # Act
+    probe.run()
+    # Assert
+    assert not canary.exists()
+
+
+def test_status_reports_the_ledger(tmp_path):
+    # Arrange
+    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe.run()  # accrue a real failure
+    # Act
+    result = probe.run("--status")
+    # Assert — an operator must be able to see WHY it is or is not acting.
+    assert "failure_weight:  2 / 3" in result.stdout
+
+
+def test_reset_clears_the_ledger(tmp_path):
+    # Arrange
+    probe = _Probe(tmp_path, f"http://127.0.0.1:{_closed_port()}/v1/health")
+    probe.run()
+    # Act
+    probe.run("--reset")
+    decided = probe.restarted()
+    # Assert — after a reset, one failure is once again just one failure.
+    assert decided is False
+
+
+# ==========================================================================
+# A daemon that DIES mid-life is still healed
+# ==========================================================================
+
+
+def test_daemon_that_dies_is_restarted(tmp_path):
+    # Arrange — healthy, then genuinely gone. The 2026-06-26 shape.
+    srv = _Server(status=200)
+    probe = _Probe(tmp_path, srv.url)
+    healthy = probe.restarted()
+    # Act
+    srv.kill()  # the port now really refuses
+    first_after_death = probe.restarted()
+    second_after_death = probe.restarted()
+    # Assert — it stays quiet while healthy, and heals once death is
+    # corroborated. Crash coverage is intact.
+    assert (healthy, first_after_death, second_after_death) == (False, False, True)
+
+
+def test_probe_script_has_valid_bash_syntax():
+    # Arrange
+    cmd = ["bash", "-n", str(_PROBE)]
+    # Act
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    # Assert
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
The `sac listen` health watchdog was **restarting a healthy control plane**, and every restart **deafens every agent's inbox at once**. 「このインフラがぶれると死活問題」

## The bug: a probe that manufactured the outage it claimed to detect

`sac-listen-health-probe.sh` restarted `sac-listen.service` after **ONE** failed `curl` with a **5-second** deadline. On this box — which **idles at load 60-70** — five seconds is not a health check, it is a coin flip.

Measured, against a **REAL** server that answers `HTTP 200` in 8s (healthy, merely *busy*):

```
probe #1  ERROR: sac-listen DOWN — ... did not answer (transport failure).  -> RESTART
probe #2  ERROR: sac-listen DOWN — ... did not answer (transport failure).  -> RESTART
probe #3  ERROR: sac-listen DOWN — ... did not answer (transport failure).  -> RESTART

TOTAL RESTARTS of a HEALTHY (slow) daemon: 3 / 3 probes
```

**The daemon answered every single time.** The probe called it a "transport failure" every single time, because it could not tell **SLOW** from **DOWN**.

And the remedy is catastrophic: **every `sac listen` restart tears down the in-memory a2a `Broker`, which deafens EVERY agent's inbox at once.** So a slow probe did not merely mis-report — **it manufactured the outage it claimed to detect**, then re-probed *during its own restart*, saw a genuinely-down daemon, and restarted **again**. Live journal, 26 seconds apart:

```
10:57:26  health-probe: ERROR ... incident-class=sac-listen-watchdog
10:57:26  systemd: Stopping sac listen            <- restart #1 (of a HEALTHY daemon)
10:57:45  Started sac listen
10:57:52  health-probe: ERROR: sac-listen DOWN    <- probed DURING its own restart
10:57:52  watchdog is RESTARTING                  <- restart #2
```

**A probe that mutates is not a probe.** This single 5-second fuse plausibly explains the listen churn (3 pids in 7 min), the "registered but deaf" agents, the duplicate standby loops, and a peer's report that the auth pool "re-wedged within a minute of a drain" — that was not a wedge, it was a restart severing in-flight requests.

*(The listen running on the box right now was born at `10:57:52` — it **is** the daemon created by that second, false restart.)*

---

## The fix

Both directions are bugs. **Never acting** hides an outage; **over-acting CREATES one.** The false-RED is the worse of the two, because its remedy destroys a healthy thing — so only a **corroborated** verdict may restart.

### 1. Three states, never a bool

Two states cannot express *"I asked and got nothing"* — which is exactly what a loaded box produces.

| Verdict | Meaning | Weight |
|---|---|---|
| **UP** | It **answered** — any HTTP status `< 500` | — |
| **DOWN** | Connection **REFUSED** — kernel sent RST: *nothing is listening* | **2** (hard) |
| **DOWN** | **HTTP 5xx** — answered, but its health route errors | 1 (soft) |
| **UNKNOWN** | We asked and got **nothing** (timeout/DNS/reset) | 1 |

**Absence of evidence is not evidence of death.** `curl`'s `%{time_connect}` is used to say *why*: if the TCP handshake completed, the port **is** bound and the daemon has not exited, so the evidence line reads *"no HTTP answer within 20s (but TCP connected — the port IS bound)"*. That is the measurable difference between **busy** and **gone**.

### 2. Any HTTP status < 500 stays "UP" — preserved verbatim

A `401`/`403` **proves** the daemon is up: bound, speaking HTTP, auth-gating. Card `sac-listen-restart-healthcheck-bearer` (PR #463) exists because gating liveness on `status == 200` re-classified a live, 401-answering daemon as "down" — a false-RED that killed a **healthy** process. That lesson is load-bearing and is kept. Matches `_listen/_holder_health.py`.

### 3. Corroboration — and a failure is a FACT

Failure weight must reach `SAC_LISTEN_FAIL_THRESHOLD` (3):

* **2 consecutive REFUSALS** (2+2) → act fast. **Crash coverage is not weakened** — a genuinely dead listen still comes back (incident 2026-06-26, which is why this watchdog exists).
* **3 consecutive UNKNOWNs** (1+1+1) → act. **Wedge coverage kept** — a daemon that cannot answer a trivial route within 20s, three times running, is not "busy". Corroboration is what **promotes** a repeated UNKNOWN into a DOWN verdict.

**A single success does not wipe the ledger.** That bug — `consecutive = 0` reset by any one lucky reply — is this class's *other half*, and @-the-peer just fixed it in `sac listen`'s own holder check (**PR #673**, `_listen/_standby_ledger.py`), where a flapping holder oscillated `1/2` → "healthy" → `1/2` forever and was **never acted on**. This is consistent with that: a success builds a **serving streak**, and the ledger clears only after 2 consecutive UPs — logged **LOUD**, because "the thing I said was broken now looks fine" is exactly the transition an operator must never have hidden.

Blip once and you are not destroyed; keep failing and you are always eventually healed.

### 4. Never restart something that is already restarting

Two **independent** guards, so losing one cannot resurrect the 26s double-restart:

* **(a) Post-restart backoff** — after issuing a restart, the probe does not probe **at all** for 90s. Restart #2 above happened *because* it probed during its own restart.
* **(b) Unit-state guard** — if systemd reports the unit `activating`, it is already coming back (someone else restarted it, or it crashed and `Restart=always` caught it) → stand down. **Holds even if the ledger is lost or corrupt.**

### 5. Rate-limit the remedy

At most **2 restarts per 10 minutes**. Beyond that: **ALARM LOUDLY and STOP restarting** (`incident-class=sac-listen-watchdog-giving-up`, exit 1). If 2 restarts did not fix it, the 3rd will not either — and an unbounded restarter on a bad signal is how you take a fleet down at 3am. A human is needed, and it says so instead of thrashing.

### The ledger

The script is invoked **fresh** every ~30s, so an in-memory counter would always read zero and "N consecutive failures" could never be observed. State persists at `~/.scitex/agent-container/runtime/listen-health.state`. It is **never `source`d** — a corrupt or hostile state file must not become code — and any non-integer value resets that field to `0` (**fail-safe: no history == do not restart**). There is a test that writes `restarts=$(touch /tmp/pwned)` into the ledger and asserts the canary never appears.

**Deadline 5s → 20s.** The live daemon answers `/v1/health` in **~30 ms**, so 20s is ~600× the median and still catches a wedge. The alarm rail (`sac fleet notify blocker`) is unchanged and **not forked**; a second alarm case (giving-up) rides the same rail, capped at one page per window.

New: `--status` (what is the watchdog thinking?) and `--reset`.

---

## Tests — no mocks, and made to fail first

**41 new tests.** Every case drives the **real** script against a **real** HTTP server on a **real** ephemeral loopback socket — slow, refusing, 5xx-ing, 401-ing, dying. Nothing ever touches **port 7878**: that is the live control plane the whole fleet depends on, and a test that restarted it would repeat the incident.

Run against the **unfixed** script, the same 41 tests: **26 FAIL.** Against this one: **41 pass.**

The headline test is deliberately driven at the probe's **shipped default deadline** — no override. That is the whole point: the old default (5s) restarted an 8s-answering server 3 times out of 3, and a test that overrode the deadline would have passed on the broken script too and proved nothing.

Both directions are pinned: it must **not** restart on a slow-but-alive daemon / a single failure / an uncorroborated verdict / during its own restart / past the cap — and it **must** still restart a genuinely dead (`test_second_refusal_restarts_dead_listen`) or wedged (`test_three_timeouts_restart_wedged_listen`) one.

---

## Deployed + demonstrated live

A merged PR is not a fix. This is deployed to the host and the operator's stop-gap drop-in (`30-loaded-box-fuse.conf`, `SAC_LISTEN_PROBE_TIMEOUT=30`) is **removed** — its value is folded in, and superseded: a fixed deadline on a loaded box is still a race, whereas corroboration + backoff + rate-limit are not.

Deployment order was load-bearing: the new script went in **first**, because removing the drop-in while the old 5s-fuse script was still deployed would have brought the fuse straight back live.

```
deployed probe sha == repo sha   (byte-identical)
DropInPaths=                     (stop-gap gone)
Environment=                     (no override; the script's own 20s default applies)
sac-listen: UNTOUCHED by the deploy (same PID, same start timestamp)
```

### Live evidence

**1. The real listen, made to miss its deadline — OLD vs NEW, side by side.**

I did **not** hammer the shared control plane until it degraded: endangering the whole fleet to prove a point is the same mistake as the bug. "The daemon takes longer than the deadline" is a *relation*, and it can be produced from either side — so both watchdogs were pointed at the **REAL live listen** with a deadline it genuinely cannot meet (5 ms, vs its real 14 ms). Identical physics, zero risk. `SAC_LISTEN_UNIT` pointed at a nonexistent unit, so no real restart was ever issued; the **decision** is what was wrong, and the decision is what is measured.

```
--- OLD watchdog (develop) ---
  probe #1..#6: *** RESTART *** x6
  => 6 restarts of the HEALTHY live listen in 6 probes

--- NEW watchdog (this PR, as deployed) ---
  probe #1: no restart | UNKNOWN — no HTTP answer within 0.005s (but TCP connected in 0.00097s — the port IS bound)
  probe #2: no restart | answered (HTTP 200), but a failure ledger of 1/3 still stands
  probe #3: no restart | UNKNOWN — no HTTP answer within 0.005s (but TCP connected — the port IS bound)
  probe #4: RESTART                     <- corroborated: 3 misses out of 4
  probe #5: no restart | within post-restart backoff (0s < 90s) — NOT probing
  probe #6: no restart | within post-restart backoff (0s < 90s) — NOT probing
  => 1 restart in 6 probes
```

Note the new one **does** restart at probe #4 — and that is correct, not a leak. A daemon that misses its deadline 3 times out of 4 is exactly what the ledger is for, and note probe #2's answer did **not** erase the record (the PR #673 rule). What is gone is the 6× thrash and, decisively, **the double-restart**: the backoff refuses to even *probe* while the daemon is coming back. The safety in production comes from the deadline being ~600× the median, not from the ledger declining to act.

**2. The real listen under the operator's own load, with the real systemd timer.** 12 concurrent authenticated requests, 45s:

```
p50 0.029s   p90 0.185s   p99 0.473s   MAX 0.524s
samples over  5s (the OLD fuse -> instant restart): 0 / 1068
samples over 20s (the NEW deadline):                0 / 1068
watchdog restart decisions during the load: 0 / 5 probes
listen PID unchanged: 2350357.  Fleet stayed audible.
```

(Honest caveat: at 12 concurrent the live listen never actually got slow — max 0.52s — so this run alone does **not** exercise the slow path. That is what demo 1 is for.)

**3. Guard (b), against REAL systemd.** The `activating` stand-down is the one thing a container cannot unit-test, so it was exercised on the host with a real throwaway unit deliberately parked in `activating`:

```
guard-test unit ActiveState = activating
  probe #1: UNKNOWN — could not connect within 5s
  probe #2: UNKNOWN — could not connect within 5s
  probe #3: sac-wdog-guardtest.service is already 'activating' — standing down.
            It is coming back on its own, and restarting a restart is what
            produced the 2026-07-14 double-restart.
```

Corroborated at probe #3 — and instead of restarting, it stood down. The real `sac-listen` was never pointed at.

**4. The real deployed watchdog, now.** Timer firing every 30s, every probe quiet:

```
journalctl --user -u sac-listen-health: ... Finished. Finished. Finished.  (no ERROR lines)
journalctl --user -u sac-listen:        (no Stopping / Started since the deploy)

$ sac-listen-health-probe.sh --status
unit:             sac-listen.service (ActiveState=active)
probe_timeout:    20s (connect 5s)
failure_weight:   0 / 3
serving_streak:   0 / 2
restarts_in_600s: 0 / 2
last_restart:     never

sac-listen NRestarts=0, PID 2350357 (born 10:57:52 — the false restart's child, still serving)
```
