### PR TITLE
fix(tests): no test may touch the real sac state — the a2a_ports leak was ghosting every release

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,13 @@ dir by the time this conftest is loaded — force-set is required. See
 
 from __future__ import annotations
 
+import itertools
 import os
 import sysconfig
 from pathlib import Path
+from typing import Iterator
+
+import pytest
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
@@ -62,6 +66,66 @@ os.environ["SAC_LISTEN_HEALTH_STATE"] = str(_LISTEN_HEALTH_DIR / "session.state"
 # And a probe run by a test must never page the operator.
 os.environ["SAC_LISTEN_NOTIFY"] = "0"
 
+# --- NEVER let a test touch the REAL sac state root -----------------------
+# Same class as the watchdog ledger above, same reason it belongs HERE.
+#
+# sac resolves its state root under $HOME. Three of those paths are
+# module-level constants computed at IMPORT time from an env var:
+#
+#   SCITEX_AGENT_CONTAINER_STATE_DB      -> _state.state_db.DEFAULT_DB_PATH
+#   SCITEX_AGENT_CONTAINER_REGISTRY_DIR  -> _state.registry.REGISTRY_DIR
+#   SCITEX_AGENT_CONTAINER_RUNTIME_DIR   -> _runners._session_state.DEFAULT_STATE_ROOT
+#
+# Because they are computed at import, a *fixture* that only sets the env var
+# is too late — the value is already baked. Setting the env HERE, in the
+# conftest module body, is early enough: pytest imports this before it imports
+# any test module (and therefore before `scitex_agent_container` is first
+# imported), so the constants are born pointing at the sandbox.
+#
+# Force-set, not setdefault: a hard floor that holds even for code paths that
+# bypass fixtures (module-level imports, session fixtures, subprocesses a test
+# spawns with an inherited env).
+#
+# The bug this closes — ghost tag v0.21.18 (2026-07-14). Tests opted into
+# state.db isolation one file at a time and several that reach `agent_start`
+# never did, so their writes landed in whatever the process called "default":
+#
+#   grant_send -> comms_grants rows     (fixed at the seam in #675)
+#   claim_port -> a2a_ports rows        <-- the release killer
+#
+# The killer mechanism is INTRA-RUN EXHAUSTION, and it is worth being precise
+# because the obvious story is wrong. `claim_port` (port_allocator.py:196)
+# consults ONLY the database — it never checks whether a port is actually
+# bound — and `a2a_ports.name` is the PRIMARY KEY. So every DISTINCT agent
+# name that reaches `agent_start` inserts ANOTHER row and burns ANOTHER port
+# out of the fixed range [19000, 19999]. Nothing gives them back inside a
+# run: `release_port` is only ever called from `agent_stop`, which an
+# `agent_start`-only test never reaches.
+#
+# So the rows pile up WITHIN a single pytest session, against the one
+# unisolated database all of those tests share. Once ~1000 distinct names
+# have been through, the range is gone and every subsequent `agent_start`
+# dies with:
+#
+#   RuntimeError: no free a2a port in range [19000, 19999] (all claimed)
+#
+# It is NOT an accumulation across runs. (The release runner's on-disk db was
+# checked afterwards and held FOUR rows, not a thousand — the exhausted db is
+# the job's own, and it dies with the job.) It is also not a flake: it is a
+# deterministic function of how many distinct agent names one session drives.
+#
+# CI's PR gate cannot see it and never will: `pytest-matrix` shards nothing
+# and each `ubuntu-latest` job is ephemeral, but more importantly the count
+# only has to cross 1000 — which it does on the release job, where three
+# python legs run concurrently on the SELF-HOSTED `scitex-ci` node. When
+# `test` fails there, build/publish/release (all `needs: test`) are SKIPPED:
+# the tag is pushed and nothing reaches PyPI. That is a ghost tag, and eight
+# historical ones went unnoticed for months.
+_SAC_STATE_FLOOR = _PROJECT_ROOT / "tests" / "results" / "sac-state" / "floor"
+os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(_SAC_STATE_FLOOR / "state.db")
+os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(_SAC_STATE_FLOOR / "registry")
+os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(_SAC_STATE_FLOOR / "runtime")
+
 
 def _ensure_subprocess_coverage_shim() -> None:
     """Drop an idempotent ``.pth`` shim in site-packages so every child
@@ -101,3 +165,60 @@ from tests.scitex_agent_container._helpers.subprocess_shim import (  # noqa: E40
     env_save_restore,
     subprocess_shim,
 )
+
+# ---------------------------------------------------------------------------
+# Per-test state.db isolation, layered ON TOP of the floor above.
+#
+# The floor keeps every write off the operator's real state.db. This fixture
+# additionally gives each test its OWN database, and that second layer is not
+# cosmetic — it is what stops the port ratchet from re-forming INSIDE a single
+# run. `claim_port` never releases, so ~4900 tests sharing one floor database
+# would march through [19000, 19999] and exhaust it from the inside, failing
+# late tests for the same reason the release was failing. A fresh DB per test
+# means the allocator always starts from an empty `a2a_ports` table and always
+# finds 19000 free, so isolation alone cures the exhaustion and no test has to
+# learn to call `release_port`.
+#
+# BOTH handles are redirected. The env var alone is not enough once
+# `state_db` has been imported (DEFAULT_DB_PATH is already baked), and the
+# constant alone is not enough for a subprocess (which reads the env). Tests
+# that additionally `importlib.reload(state_db)` re-derive the constant from
+# the env we set here, so they keep working; tests with their own isolation
+# fixture just override both again — this only moves the DEFAULT.
+# ---------------------------------------------------------------------------
+
+_STATE_DB_KEY = "SCITEX_AGENT_CONTAINER_STATE_DB"
+_state_db_seq = itertools.count()
+
+
+# scope="function" is SPELLED OUT (it is also pytest's default) because the
+# whole fix depends on it, and a future "let's not rebuild the DB 4900 times"
+# optimisation to scope="session"/"module" would silently REINTRODUCE the bug:
+# `claim_port` never releases, so any db shared across tests re-accumulates
+# rows until [19000, 19999] is exhausted mid-run. Per-TEST or it does not work.
+@pytest.fixture(autouse=True, scope="function")
+def _isolate_state_db(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    """Point this test's state.db at a private tmp file. Restores on teardown."""
+    from scitex_agent_container._state import state_db
+
+    # Computed but deliberately NOT created: `state_db._connect` mkdirs the
+    # parent on first real use, so a test that never opens the DB pays no
+    # mkdir and leaves no empty dir behind (this runs ~4900 times).
+    db = (
+        tmp_path_factory.getbasetemp()
+        / "state-db"
+        / f"t{next(_state_db_seq)}"
+        / "state.db"
+    )
+    saved_env = os.environ.get(_STATE_DB_KEY)
+    saved_const = state_db.DEFAULT_DB_PATH
+    os.environ[_STATE_DB_KEY] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_const
+        if saved_env is None:
+            os.environ.pop(_STATE_DB_KEY, None)
+        else:
+            os.environ[_STATE_DB_KEY] = saved_env

--- a/tests/scitex_agent_container/_state/test_state_db_test_isolation.py
+++ b/tests/scitex_agent_container/_state/test_state_db_test_isolation.py
@@ -1,0 +1,82 @@
+"""The test suite must never touch the operator's real sac state.
+
+These pin the contract of the ``_isolate_state_db`` guard in
+``tests/conftest.py``. They are cheap, and they fail LOUDLY if someone
+removes the guard or widens its scope — which is worth a file of its own,
+because the last time this contract broke it cost a release (ghost tag
+v0.21.18) and, in a neighbouring namespace, nearly restarted the live
+control plane.
+
+Why ``claim_port`` is the canary. ``a2a_ports.name`` is the PRIMARY KEY and
+:func:`port_allocator.claim_port` consults ONLY the database — it never checks
+whether a port is really bound. So every distinct agent name that reaches
+``agent_start`` burns another port out of the fixed range [19000, 19999], and
+nothing hands one back inside a run (``release_port`` is only ever called from
+``agent_stop``). Share one database across a ~4900-test session and the range
+is gone long before the session is; every later ``agent_start`` then dies with
+``RuntimeError: no free a2a port in range [19000, 19999] (all claimed)``.
+
+That is exactly what killed the v0.21.18 release run, and it is why the guard
+must be FUNCTION-scoped. A session- or module-scoped "optimisation" would
+reintroduce the bug silently — so ``test_claim_port_starts_at_the_range_floor_
+in_a_second_test`` below exists to make that impossible: it can only pass if
+this test got a database of its own.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.port_allocator import claim_port
+
+_REAL_DB = Path("~/.scitex/agent-container/runtime/state.db").expanduser()
+
+
+def test_default_db_path_is_not_the_real_state_db() -> None:
+    """The resolved default must never be the operator's live fleet database."""
+    # Arrange
+    real = _REAL_DB
+    # Act
+    resolved = Path(state_db.DEFAULT_DB_PATH)
+    # Assert
+    assert resolved != real
+
+
+def test_state_db_env_var_is_not_the_real_state_db() -> None:
+    """Subprocesses inherit the env, so the env var must be redirected too."""
+    # Arrange
+    real = str(_REAL_DB)
+    # Act
+    env_value = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB", "")
+    # Assert
+    assert env_value != real
+
+
+def test_claim_port_starts_at_the_range_floor() -> None:
+    """A fresh state.db has an empty ``a2a_ports``, so the scan hands out 19000."""
+    # Arrange
+    name = "isolation-probe-a"
+    # Act
+    port = claim_port(name)
+    # Assert
+    assert port == 19000
+
+
+def test_claim_port_starts_at_the_range_floor_in_a_second_test() -> None:
+    """FUNCTION-scope canary — the whole release fix rests on this.
+
+    A DIFFERENT agent name in a DIFFERENT test still gets 19000. That can only
+    be true if this test received its own database: were the guard session- or
+    module-scoped, the previous test's ``isolation-probe-a`` row would still be
+    there and the allocator would hand out 19001 instead. Widen the scope and
+    this test goes red immediately, rather than the next release going silently
+    missing from PyPI.
+    """
+    # Arrange
+    name = "isolation-probe-b"
+    # Act
+    port = claim_port(name)
+    # Assert
+    assert port == 19000


### PR DESCRIPTION
Ships the guard I pulled from #675. My reason for pulling it was good then and is not good now: the residual I flagged has materialised as the release blocker (ghost tag v0.21.18).

## The real mechanism (the obvious story is wrong)

`claim_port` (`_state/port_allocator.py:196`) **consults only the database — it never checks whether a port is actually bound** — and `a2a_ports.name` is the PRIMARY KEY. So every *distinct* agent name that reaches `agent_start` inserts another row and burns another port out of the fixed range `[19000, 19999]`. Nothing gives one back inside a run: `release_port` is only ever called from `agent_stop`, which an `agent_start`-only test never reaches.

Tests opted into state.db isolation one file at a time, and several that reach `agent_start` never did. Those all shared **one** unisolated database, so claims piled up **within a single test session** until the range was gone and every later `agent_start` died with:

```
RuntimeError: no free a2a port in range [19000, 19999] (all claimed)
```

`test` fails, so `build`/`publish`/`release` (all `needs: test`) are **skipped**: tag pushed, nothing on PyPI. A ghost tag. Eight historical ones went unnoticed for months.

**It is INTRA-run exhaustion, not accumulation across runs.** The release runner's on-disk db was checked afterwards and held **four** rows, not a thousand — the exhausted database is the job's own, and it dies with the job.

## Why CI could never catch it

The PR gate (`pytest-matrix`) runs on ephemeral `ubuntu-latest`, so its state.db starts empty and the distinct-name count never crossed 1000. The `release` workflow's `test` job runs on the self-hosted `scitex-ci` node with three python legs concurrently. The bug is **structurally invisible on PRs and only kills releases** — which is exactly why it survived.

## Fix — two layers, alongside the watchdog-ledger floor (#679), which is the same class

1. **Module-level force-set floor** for `SCITEX_AGENT_CONTAINER_{STATE_DB,REGISTRY_DIR,RUNTIME_DIR}`. It runs in the conftest module body, which the test runner imports *before* any test module — and therefore before `scitex_agent_container` is first imported — so the import-time constants (`state_db.DEFAULT_DB_PATH`, `registry.REGISTRY_DIR`, `_session_state.DEFAULT_STATE_ROOT`) are **born pointing at a sandbox**. A fixture that only sets the env var is too late: the constant is already baked. Force-set, not `setdefault`, so it holds for code that bypasses fixtures.

2. **FUNCTION-scoped autouse fixture** giving each test its own state.db, redirecting **both** the env var (for subprocesses) and the module constant (for in-process callers).

**The scope is load-bearing, not an implementation detail.** The floor alone would still be *one* database shared by ~10k tests, which would re-accumulate claims and exhaust the range from the inside. A fresh db per test means the allocator always starts from an empty `a2a_ports` and always finds 19000 free — so **isolation alone cures the exhaustion and no test needs to call `release_port`**. `scope="function"` is spelled out explicitly, and a canary test fails loudly if anyone widens it to session/module.

## Fail-first proof (verified RED against the unfixed tree)

**1. The exact release failure, reproduced.** With the real db exhausted (1000 claims), on the exact test that killed v0.21.18:

```
E   RuntimeError: no free a2a port in range [19000, 19999] (all claimed)
FAILED ...test__restart_preflight_integration.py::test_agent_restart_healthy_successor_still_stops_then_starts
FAILED ...test__restart_preflight_integration.py::test_agent_start_force_healthy_successor_still_restarts   <-- a second one
2 failed
```

With the guard: **2 passed.**

**2. The one-number version of the whole bug.** The canary test, unguarded:

```
assert 19007 == 19000
```

**19007** — because the real fleet db in that container already held **7** `a2a_ports` rows, so the ascending scan walked straight past them. The allocator's next port is a pure function of accumulated rows. With the guard, every test gets 19000.

## Real pollution this also stops

Tests had been writing port claims into the operator's **live fleet db**: `~/.scitex/agent-container/runtime/state.db` held **65** `a2a_ports` rows, among them the fixture names `mini`, `alpha`, `smoke-neutral` — the same way they wrote the grant rows fixed in #675.

## Scope — what this does NOT cover (stated, not silently omitted)

The guard redirects the three state roots that have an env-var contract. It does **not** redirect `$HOME` itself, and the paths below are hard-coded to `Path.home()` with **no env override**, so they stay exposed to a test that drives them without passing an explicit path:

| path | module |
|---|---|
| `~/.scitex/agent-container/agents` | `_mcp/_tools/_template.py:69` (`_AGENTS_DIR`), `_lifecycle/_ci_owner.py:37` |
| `~/.scitex/agent-container/runtime` (listen pidfile / single-instance lock) | `_listen/_single_instance.py:199` |
| `~/.scitex/agent-container/runtime/agents/<name>` | `_lifecycle/_runtime_select.py:105` |
| `~/.scitex/agent-container/runtime/logs/host_exec.log` | `_listen/_host_exec.py:62` |
| `~/.scitex/agent-container/containers`, `~/.scitex` | `cli_pkg/image_group.py:60,67` |

I deliberately did **not** blanket-redirect `$HOME`: real credentials (`~/.claude/.credentials.json`), `gh` config and Claude session state live there, many tests legitimately read them, and a sweeping unvalidatable change is precisely what has been ghosting releases. The durable fix for the table above is to give those paths the same env-override contract the three state roots already have — a follow-up, not something to bolt onto the release blocker.

## Verification

Isolation is **observed, not assumed**: with the guard, a real-db stand-in is **never even created** — zero writes escape, for `a2a_ports` *and* `comms_grants`. The full 10,339-test suite is running locally with the operator's real state.db hashed before/after; CI's 3-version matrix is the regression gate.
