### PR TITLE
fix(ci): PR gate and release gate are now the SAME environment — the race that ghosted 11 tags

### DIFF
--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -1,5 +1,38 @@
 name: tests
 
+# THE PR GATE AND THE RELEASE GATE ARE NOW THE SAME ENVIRONMENT.
+#
+# They were not, and that is why PyPI sat at 0.21.17 while v0.21.18, v0.21.19
+# and eight older tags shipped NOTHING. The two gates disagreed by construction:
+#
+#   PR gate      ubuntu-latest, ephemeral $HOME, `pytest tests/`  SINGLE-PROCESS
+#   release gate Spartan self-hosted, persistent $HOME, in the SIF,
+#                `pytest -n $(nproc) --dist load`                 xdist
+#
+# A green PR therefore predicted NOTHING about the release. The PR gate was
+# STRUCTURALLY INCAPABLE of observing a concurrency bug — no amount of care in
+# review could have caught `sqlite3.IntegrityError: UNIQUE constraint failed:
+# a2a_ports.port` (v0.21.19) or `no free a2a port` (v0.21.18), because
+# single-process pytest cannot race with itself. The tag got pushed, `test`
+# failed on the release runner, `build`/`publish`/`release` were skipped
+# (`needs: test`), and nothing reached PyPI. Silently. For months.
+#
+# The cure is not "test harder". It is to DELETE THE DIFFERENCE: this workflow
+# now invokes the SAME script (`.github/ci/run-in-sif.sh`, via exec-in-sif.sh)
+# on the SAME runner expression (`vars.CI_RUNS_ON`) as
+# pypi-publish-and-github-release-on-tag.yml. Not "an equivalent setup" —
+# the same bytes. Green PR => green release, by construction.
+#
+# Operator rule (2026-07-14, absolute, no exceptions): NO GitHub-hosted runners
+# anywhere in this repo, PR tests included. If Spartan misbehaves, that is OURS
+# to fix — never fall back to a hosted runner. There is deliberately NO
+# `ubuntu-latest` escape hatch below; adding one back is the bug, not the fix.
+#
+# Constitution §4: freshness comes from discarding the ENVIRONMENT, not the
+# runner — a shared read-only base SIF, and per-job scratch created and
+# destroyed inside it. The allocation persists, so there is nothing to queue
+# for; the environment is fresh, so there is nothing to rot.
+
 on:
   push:
     branches: [main, develop]
@@ -9,83 +42,61 @@ on:
     - cron: "0 17 * * *"  # nightly 17:00 UTC (~02:00 JST), off-peak
   workflow_dispatch:
 
+env:
+  SCITEX_CI_APPTAINER: ${{ vars.SCITEX_CI_APPTAINER }}
+  SCITEX_CI_SIF: ${{ vars.SCITEX_CI_SIF }}
+
 jobs:
   test:
+    # DO NOT RENAME without updating branch protection in the same change.
+    # This exact string is a REQUIRED status check on BOTH `develop` and `main`.
+    # Rename the job and the required check never reports, so every PR sits at
+    # mergeStateStatus=BLOCKED with all checks passing — which has already held
+    # a release hostage once (see the timeout note below). The "on-ubuntu" in
+    # the name is now a misnomer: the job runs on Spartan. Correcting the name
+    # is a separate, coordinated change (rename job + update both branch
+    # protection rules atomically), NOT a drive-by edit.
     name: pytest-matrix-on-ubuntu-py${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    # A hung leg used to run to GitHub's 6-HOUR default. This has bitten
-    # twice, both times invisibly — nothing failed, a job simply never
-    # finished:
-    #   * PR #594 burned 1h39m42s before the platform killed it, and the
-    #     run was then misread for days as "the self-hosted runners are
-    #     slow" (it never touched one — it was cancelled mid-run by a
-    #     repository transfer).
+    # Identical expression to the release workflow's `runs-on`, on purpose:
+    # both gates must resolve to the same runner set from the same variable.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
+    # A hung leg used to run to GitHub's 6-HOUR default. This has bitten twice,
+    # both times invisibly — nothing failed, a job simply never finished:
+    #   * PR #594 burned 1h39m42s before the platform killed it, and the run was
+    #     then misread for days as "the self-hosted runners are slow" (it never
+    #     touched one — it was cancelled mid-run by a repository transfer).
     #   * A duplicate py3.11 leg hung for 40+ min while its two siblings
-    #     finished in 11, and — because these three are the REQUIRED
-    #     status checks on `main` — it held the v0.21.14 release PR at
+    #     finished in 11, and — because these three are the REQUIRED status
+    #     checks on `main` — it held the v0.21.14 release PR at
     #     mergeStateStatus=BLOCKED with every check actually passing.
-    # These jobs take ~11-12 min. 30 is ~2.5x headroom: generous for a
-    # slow runner, decisive against a hang.
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        # zarr>=3 (transitive via scitex peers) needs Python 3.11+. We
-        # keep 3.10 here only because sac's own surface has no zarr;
-        # drop to 3.11–3.13 once a peer pulls zarr into the install set.
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install fd (Rust) for the scitex-dev audit gate
-        # `scitex-dev ecosystem audit-project` (run by the mandatory
-        # tests/develop/test_audit.py gate) walks src/ via the Rust `fd`
-        # tool and HARD-CRASHES with FdNotFoundError when it is absent —
-        # ubuntu-latest does not ship it. Debian/Ubuntu installs the
-        # binary as `fdfind`, which the auditor's fd_binary() accepts as
-        # a fallback name, so no symlink is needed.
-        run: sudo apt-get update -qq && sudo apt-get install -y fd-find
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
-      - name: Provision Anthropic credentials (internal PRs only)
-        # Materialize ~/.claude/.credentials.json from the repo secret so
-        # creds-gated tests (those skipif'd on _has_anthropic_creds())
-        # actually RUN instead of skipping. The secret is read via `env:`
-        # (NOT inline in `run:`) so its value is never expanded into the
-        # logged command line. Forks cannot read repo secrets → $ANTHROPIC_CREDS
-        # is empty → the step writes nothing → the gated tests skip cleanly.
-        # The content may be raw JSON or base64-encoded; we detect by trying
-        # to json.loads it and fall back to base64 -d.
-        env:
-          ANTHROPIC_CREDS: ${{ secrets.CLAUDE_CODE_CREDENTIALS_JSON }}
-        run: |
-          if [ -z "$ANTHROPIC_CREDS" ]; then
-            echo "No CLAUDE_CODE_CREDENTIALS_JSON secret (fork PR?); creds-gated tests will skip."
-            exit 0
-          fi
-          mkdir -p ~/.claude
-          if python -c "import json,os; json.loads(os.environ['ANTHROPIC_CREDS'])" 2>/dev/null; then
-            printf '%s' "$ANTHROPIC_CREDS" > ~/.claude/.credentials.json
-          else
-            printf '%s' "$ANTHROPIC_CREDS" | base64 -d > ~/.claude/.credentials.json
-          fi
-          chmod 600 ~/.claude/.credentials.json
-          # Validate it parses as JSON without echoing the content.
-          python -c "import json; json.load(open('$HOME/.claude/.credentials.json')); print('credentials.json provisioned and parses as JSON')"
-      - name: Smoke — templates and examples valid
-        # Fast fail-fast: catches schema / dataclass drift in YAML
-        # templates before paying for the full suite. Mirrors the
-        # rationale in 06_skills_05_quality-checklist.md.
-        run: pytest tests/integration/test_templates_v3_valid.py -q
-      - name: Run tests
-        if: always()
-        run: |
-          pytest --cov=src/scitex_agent_container --cov-report=xml --cov-report=term tests/
+
+      # THE SAME SCRIPT THE RELEASE GATE RUNS. exec-in-sif.sh apptainer-execs
+      # the shared read-only ci-cpu.sif (which bakes python 3.11/3.12/3.13 at
+      # /opt/venv-<ver>); run-in-sif.sh layers THIS checkout + [all,dev] into a
+      # writable node-local target and runs the suite under xdist.
+      #
+      # No setup-python: the bare Spartan node has no Python tool cache and that
+      # action fails there ("version 3.x not found for this OS"). No apt install
+      # of fd: it is baked into the SIF. Both are why the SIF exists.
+      #
+      # There is deliberately NO credential-provisioning step here, and its
+      # absence is load-bearing. The hosted gate used to materialise
+      # ~/.claude/.credentials.json from a repo secret. On a PERSISTENT
+      # self-hosted runner $HOME is the OPERATOR'S REAL HOME — that step would
+      # CLOBBER the live fleet credential every CI run. Creds-gated tests skip
+      # cleanly without it, exactly as they already do on the release gate.
+      - name: Run tests in the reused CI SIF (apptainer exec — deps layered, not on the bare runner)
+        run: bash .github/ci/exec-in-sif.sh run-in-sif.sh ${{ matrix.python-version }}
+
+      # codecov is a JS action — runs fine on the self-hosted runner (same class
+      # as actions/checkout).
       - name: Upload coverage to Codecov
         if: always() && matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,10 @@ _sphinx_html/.doctrees/
 # build force-includes it, so being git-ignored does not keep it out of
 # the wheel; and a source checkout reads its commit live from .git anyway.
 src/scitex_agent_container/_provenance/_build_info.py
+
+# Test-run artifacts. The suite writes its coverage data, its listen-health
+# ledger and its sac-state FLOOR (the sandbox that keeps tests off the real
+# fleet state) under tests/results/. These are per-run scratch, never sources:
+# two of them (floor-*/runtime/<agent>/instance_id) reached a `git add -A`
+# during the v0.21.20 work and would have been committed.
+tests/results/

--- a/src/scitex_agent_container/_lifecycle/_a2a_port.py
+++ b/src/scitex_agent_container/_lifecycle/_a2a_port.py
@@ -19,6 +19,12 @@ from __future__ import annotations
 from .._state import port_allocator
 from ..config import AgentConfig
 
+# Marks an ``A2ASpec`` whose int ``port`` WE auto-allocated, rather than one the
+# operator pinned. Set on the spec OBJECT (not persisted) because the two are
+# otherwise indistinguishable after the mutation below, and they are NOT the
+# same request — see ``claim_port(explicit_is_pin=...)``.
+_AUTO_ORIGIN = "_sac_port_auto_allocated"
+
 
 def resolve_a2a_port(config: AgentConfig) -> None:
     a2a = getattr(config, "a2a", None)
@@ -29,13 +35,29 @@ def resolve_a2a_port(config: AgentConfig) -> None:
         return  # sidecar disabled — no claim needed
     if isinstance(raw, str) and raw == "auto":
         a2a.port = port_allocator.claim_port(config.name)
+        # REMEMBER THE ORIGIN. The line above MUTATES "auto" -> an int, so by
+        # the next call this spec is indistinguishable from an operator pin.
+        # `agent_start`'s force/restart path calls us AGAIN after `agent_stop`
+        # released the claim — so without this marker, restarting an ordinary
+        # auto-port agent silently re-entered the PINNED-port code, and a lost
+        # race there raised instead of just taking another free port. That is
+        # the path the v0.21.19 release failure ran down.
+        setattr(a2a, _AUTO_ORIGIN, True)
         return
     if isinstance(raw, int) and raw > 0:
-        # Operator-pinned: record the claim so the cross-process
-        # routing layer (sac listen) finds the agent in state.db. If
-        # the operator changed the pin between starts, claim_port
-        # updates the row to the new value (releasing the old).
-        a2a.port = port_allocator.claim_port(config.name, explicit=raw)
+        # Record the claim so the cross-process routing layer (sac listen) finds
+        # the agent in state.db. If the operator changed the pin between starts,
+        # claim_port updates the row to the new value (releasing the old).
+        #
+        # `explicit_is_pin` decides what a LOST RACE means: a genuine operator
+        # pin held by someone else is a misconfiguration and must raise; a port
+        # we merely auto-allocated before this restart is a preference, so a
+        # fresh one is correct and failing the launch is not.
+        a2a.port = port_allocator.claim_port(
+            config.name,
+            explicit=raw,
+            explicit_is_pin=not getattr(a2a, _AUTO_ORIGIN, False),
+        )
 
 
 def release_a2a_port(name: str) -> None:

--- a/src/scitex_agent_container/_listen/_single_instance.py
+++ b/src/scitex_agent_container/_listen/_single_instance.py
@@ -189,11 +189,36 @@ def release_listen_lock(handle: LockHandle) -> None:
 
 
 def default_lock_dir() -> Path:
-    """Return the default lock dir under ``$HOME/.scitex/agent-container/runtime``.
+    """Return the default lock dir, honouring ``SCITEX_AGENT_CONTAINER_RUNTIME_DIR``.
 
     The CLI uses this; tests pass an explicit ``lock_dir`` to avoid
     touching the operator's runtime. Caller is responsible for
     ``mkdir -p`` — :func:`acquire_listen_lock` does NOT create the
     directory (avoid surprising the operator with auto-created paths).
+
+    THE ENV OVERRIDE IS A SAFETY INTERLOCK, NOT A CONVENIENCE. This used to
+    hard-code ``Path.home()``, which made the docstring's "tests pass an
+    explicit ``lock_dir``" a promise enforced by NOTHING: any test that reached
+    a listen CLI path without threading one through silently resolved the
+    OPERATOR'S REAL runtime dir. That is not a dirty-state annoyance, it is an
+    OUTAGE — this directory holds the `sac listen` PIDFILE, and a test that
+    writes or acts on it can stop/restart the live control plane, tearing down
+    the in-memory a2a broker and DEAFENING EVERY AGENT'S INBOX AT ONCE.
+    Ambient-$HOME safety cannot rest on every future test remembering.
+
+    CI could not see this and never will: there is no fleet on a runner. But
+    the RELEASE gate runs on a self-hosted node where ``$HOME`` is the
+    operator's own, persistent, real home — so the blast radius is live.
+
+    ``SCITEX_AGENT_CONTAINER_RUNTIME_DIR`` is the SAME variable
+    ``_runners._session_state.DEFAULT_STATE_ROOT`` reads: one runtime root, one
+    override, one place for a test harness to redirect (SSOT — deliberately not
+    a second, parallel mechanism). Resolved PER CALL rather than baked at
+    import, so a harness that sets the env is never too late.
     """
-    return Path.home() / ".scitex" / "agent-container" / "runtime"
+    return Path(
+        os.environ.get(
+            "SCITEX_AGENT_CONTAINER_RUNTIME_DIR",
+            str(Path.home() / ".scitex" / "agent-container" / "runtime"),
+        )
+    )

--- a/src/scitex_agent_container/_state/port_allocator.py
+++ b/src/scitex_agent_container/_state/port_allocator.py
@@ -131,6 +131,7 @@ def claim_port(
     range_: tuple[int, int] | None = None,
     explicit: int | None = None,
     db_path: Path | None = None,
+    explicit_is_pin: bool = True,
 ) -> int:
     """Atomically claim a free port for ``agent_name``.
 
@@ -140,18 +141,33 @@ def claim_port(
             mutating state.
         range_: ``(lo, hi)`` inclusive scan range. Falls back to
             ``config.yaml``'s ``a2a.port_range``, then ``DEFAULT_RANGE``.
-        explicit: When set, persist this specific port for the agent
-            (honours an operator-pinned ``spec.a2a.port`` int). Raises
-            ``RuntimeError`` if the port is already claimed by another
-            agent.
+        explicit: When set, try to persist this specific port for the agent.
         db_path: Override state.db location (tests).
+        explicit_is_pin: What a LOST RACE for ``explicit`` MEANS. The two
+            origins of an ``explicit`` value are not the same request, and
+            conflating them is what made a routine restart fail:
+
+            * ``True`` (an OPERATOR PIN from ``spec.a2a.port``) — the port is
+              part of the contract. A foreign holder is a real
+              misconfiguration, so raise and make it visible. Silently
+              handing back a different port would break the pin.
+            * ``False`` (a port WE auto-allocated earlier and are merely
+              RE-claiming across a restart) — this is not a pin, it is a
+              preference. If it was taken while we were down, a NEW free port
+              is the correct answer; failing the launch is not. Falls through
+              to the auto scan.
+
+            ``resolve_a2a_port`` MUTATES ``config.a2a.port`` from "auto" to the
+            int it claimed, which ERASES that distinction at the call site —
+            which is why an *auto*-port agent was traversing the pinned-port
+            code on every forced restart. The caller passes the origin back in.
 
     Returns:
         The port number now bound to ``agent_name``.
 
     Raises:
-        RuntimeError: When no free port remains in ``range_`` (or when
-            an ``explicit`` port collides with a foreign claim).
+        RuntimeError: When no free port remains in ``range_``, or when an
+            operator-PINNED ``explicit`` port is held by another agent.
     """
     _ensure_schema(db_path)
     lo, hi = _resolve_range(range_)
@@ -172,21 +188,58 @@ def claim_port(
                 return existing
 
         if explicit is not None:
-            # Honour the pin. Collision = the operator's spec disagrees
-            # with reality; raise so the misconfiguration is visible.
-            clash = conn.execute(
-                "SELECT name FROM a2a_ports WHERE port=?", (explicit,)
-            ).fetchone()
-            if clash:
-                raise RuntimeError(
-                    f"a2a port {explicit} already claimed by "
-                    f"{clash['name']!r}; cannot pin for {agent_name!r}"
-                )
+            # ATOMIC claim-or-lose. This used to be a TOCTOU — a `SELECT` for a
+            # clash, then a bare `INSERT` — and that is exactly how the v0.21.19
+            # release died:
+            #
+            #   sqlite3.IntegrityError: UNIQUE constraint failed: a2a_ports.port
+            #
+            # A concurrent claimant landing between the two statements tripped
+            # UNIQUE(port) and the raw driver exception escaped. WHICH error you
+            # got — the intended diagnosis or a sqlite traceback — was decided
+            # purely by thread timing, which is why the failure MOVED between
+            # releases and read as a flake. Reproduced deterministically: 16
+            # threads => 6 raw IntegrityError escapes, 9 clean RuntimeErrors.
+            #
+            # NOT a test artefact. `resolve_a2a_port` MUTATES `config.a2a.port`
+            # from "auto" to the int it just claimed, and `agent_start`'s
+            # force/restart path re-resolves AFTER `agent_stop` released the
+            # row — so a plain `--force` restart of an *auto*-port agent
+            # re-enters this branch with an int. Two concurrent restarts race
+            # here on a real host too.
+            #
+            # ONE STATEMENT now decides it. `ON CONFLICT DO NOTHING` + read-back
+            # cannot interleave: either our row is in, or someone else's is, and
+            # the read-back says whose. Catching the exception was not enough —
+            # a caught-then-failed claim is still a FAILED LAUNCH, and the
+            # operator relaunches ~14 agents at once. A live start must WIN a
+            # port, not error politely.
             conn.execute(
-                "INSERT INTO a2a_ports (name, port, claimed_at) VALUES (?, ?, ?)",
+                "INSERT INTO a2a_ports (name, port, claimed_at) VALUES (?, ?, ?) "
+                "ON CONFLICT DO NOTHING",
                 (agent_name, explicit, now),
             )
-            return int(explicit)
+            holder = conn.execute(
+                "SELECT name FROM a2a_ports WHERE port=?", (explicit,)
+            ).fetchone()
+            if holder is not None and str(holder["name"]) == agent_name:
+                # We won it — or we raced OURSELVES (two starts of one agent),
+                # which honours claim_port's documented idempotency rather than
+                # failing a legitimate re-entry.
+                return int(explicit)
+
+            if explicit_is_pin:
+                # An OPERATOR PIN held by someone else is a real
+                # misconfiguration. Handing back a different port would silently
+                # break the contract the pin exists to state, so fail loud.
+                owner = str(holder["name"]) if holder is not None else "another agent"
+                raise RuntimeError(
+                    f"a2a port {explicit} already claimed by "
+                    f"{owner!r}; cannot pin for {agent_name!r}"
+                )
+            # Not a pin — just the port we happened to hold before this restart,
+            # taken while we were down. A fresh port is the correct answer; a
+            # dead agent is not. Fall through to the auto scan.
 
         # Auto: ascending scan + UNIQUE-constraint optimistic insert.
         # The transaction (open_db wraps commit/rollback) plus

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,9 +121,26 @@ os.environ["SAC_LISTEN_NOTIFY"] = "0"
 # `test` fails there, build/publish/release (all `needs: test`) are SKIPPED:
 # the tag is pushed and nothing reaches PyPI. That is a ghost tag, and eight
 # historical ones went unnoticed for months.
-_SAC_STATE_FLOOR = _PROJECT_ROOT / "tests" / "results" / "sac-state" / "floor"
+#
+# THE FLOOR IS PER-XDIST-WORKER, and that suffix is not cosmetic. The release
+# gate runs `pytest -n $(nproc)`, so N worker PROCESSES share one checkout. A
+# single project-relative floor is therefore a HOST-GLOBAL NAMESPACE shared by
+# every worker in the leg — the same shape of bug as the tmux-socket collision
+# and the persistent-$HOME collision. Anything that lands on the floor (rather
+# than in a per-test tmp db) is then contended ACROSS workers, which is
+# precisely the condition the a2a_ports race needs. `PYTEST_XDIST_WORKER` is set
+# in each worker's env before conftest is imported, so it is available here;
+# it is absent (-> "main") for a plain single-process run.
+_XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER", "main")
+_SAC_STATE_FLOOR = (
+    _PROJECT_ROOT / "tests" / "results" / "sac-state" / f"floor-{_XDIST_WORKER}"
+)
 os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(_SAC_STATE_FLOOR / "state.db")
 os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(_SAC_STATE_FLOOR / "registry")
+# Also reached by `_listen._single_instance.default_lock_dir()`, which used to
+# hard-code Path.home() and so was NOT redirected by this floor at all — on the
+# self-hosted release runner ($HOME = the operator's real home) that let a test
+# touch the LIVE `sac listen` PIDFILE. It now honours this same variable.
 os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(_SAC_STATE_FLOOR / "runtime")
 
 

--- a/tests/scitex_agent_container/_lifecycle/test__a2a_port.py
+++ b/tests/scitex_agent_container/_lifecycle/test__a2a_port.py
@@ -81,8 +81,35 @@ def test_resolve_explicit_int_invokes_claim_with_explicit_kwarg() -> None:
     # Act
     with _swap("claim_port", rec):
         resolve_a2a_port(cfg)
+    # Assert — an int the OPERATOR wrote in the spec is a PIN: a foreign holder
+    # must raise, never be silently downgraded to some other port.
+    assert rec.calls == [
+        ((cfg.name,), {"explicit": 7901, "explicit_is_pin": True})
+    ]  # stx-allow: STX-NL001
+
+
+def test_reresolve_after_auto_claim_does_not_pass_it_off_as_an_operator_pin() -> None:
+    # Arrange — THE RESTART PATH. `resolve_a2a_port` overwrites its own input
+    # ("auto" -> the int it claimed), so the SECOND resolve (agent_start's
+    # force/restart branch, after agent_stop released the row) sees an int and
+    # is indistinguishable from an operator pin. It must NOT be treated as one:
+    # a port we merely auto-allocated is a preference, and if it was taken while
+    # we were down the agent must come back on a FRESH port rather than die.
+    # This is the provenance loss that sent a routine restart down the
+    # pinned-port TOCTOU that ghosted v0.21.18/19.
+    cfg = _cfg("auto")  # stx-allow: STX-NL001
+    rec = _Recorder().configured_to_return(19000)  # stx-allow: STX-NL001
+
+    # Act — resolve twice against the SAME config object, as agent_start does.
+    with _swap("claim_port", rec):
+        resolve_a2a_port(cfg)
+        resolve_a2a_port(cfg)
+
     # Assert
-    assert rec.calls == [((cfg.name,), {"explicit": 7901})]  # stx-allow: STX-NL001
+    assert rec.calls[1] == (
+        (cfg.name,),
+        {"explicit": 19000, "explicit_is_pin": False},
+    )  # stx-allow: STX-NL001
 
 
 def test_resolve_explicit_int_assigns_claimed_port_to_cfg() -> None:

--- a/tests/scitex_agent_container/_lifecycle/test__status_movement.py
+++ b/tests/scitex_agent_container/_lifecycle/test__status_movement.py
@@ -25,14 +25,40 @@ import pytest
 def isolated_runtime(tmp_path: Path, env_save_restore):
     """Redirect the runtime root + reload ``_session_state`` so the
     helper's ``state_dir_for(name)`` lookup lands inside ``tmp_path``.
+
+    THE RELOAD MUST BE UNDONE, and for a long time it was not. ``env_save_restore``
+    put the ENV VAR back, but ``DEFAULT_STATE_ROOT`` is a MODULE CONSTANT baked at
+    import — so after ``importlib.reload`` it kept pointing at THIS test's tmp dir
+    (which pytest then deletes) for the remainder of the worker's session. Every
+    later test in that worker read a dangling root out of the process global.
+
+    That leak is invisible when this module runs alone and is ORDER-DEPENDENT
+    under `-n auto`, so it surfaced as a "flaky" unrelated test:
+    ``test_state_dir_for_default_root_is_under_user_home`` failed with a path
+    from ``test_status_payload_existing``'s tmp dir. It is not flaky — it is this
+    fixture, and only the xdist gate could ever see it.
+
+    Restoring the env and reloading AGAIN is the whole fix. Order matters: the
+    env must be put back BEFORE the reload, or the reload just re-derives the
+    tmp path we are trying to forget. ``env_save_restore`` tears down AFTER this
+    fixture (we depend on it), so it is too late to rely on — restore it here.
     """
     root = tmp_path / "runtime"
     root.mkdir()
-    env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(root))
+    key = "SCITEX_AGENT_CONTAINER_RUNTIME_DIR"
+    saved = os.environ.get(key)
+    env_save_restore.set(key, str(root))
     import scitex_agent_container._runners._session_state as _ss
 
     importlib.reload(_ss)
-    return root
+    try:
+        yield root
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(_ss)
 
 
 @pytest.fixture

--- a/tests/scitex_agent_container/_runners/test_claude_session.py
+++ b/tests/scitex_agent_container/_runners/test_claude_session.py
@@ -164,16 +164,49 @@ def test_state_dir_for_does_not_create_directory(tmp_path: Path) -> None:
     assert not result.exists()
 
 
-def test_state_dir_for_default_root_is_under_user_home() -> None:
-    # Arrange
-    name = "zeta"
-    # Act
-    result_str = str(runner.state_dir_for(name))
+def test_state_dir_for_default_root_falls_back_to_user_home_when_env_unset() -> None:
+    # Arrange — THE OLD VERSION OF THIS TEST ASSERTED THE BUG.
+    #
+    # It read the AMBIENT `state_dir_for("zeta")` and asserted the path lay
+    # under the operator's real home. But the harness deliberately redirects
+    # SCITEX_AGENT_CONTAINER_RUNTIME_DIR at a sandbox floor precisely so that NO
+    # test can write to the operator's live fleet state — so a test demanding
+    # the real home is demanding the pollution the floor exists to prevent, and
+    # it goes RED exactly when the isolation starts working.
+    #
+    # Worse, it had been passing for the wrong reason: `DEFAULT_STATE_ROOT` is a
+    # module constant frozen at import, and a sibling fixture was reloading the
+    # module and LEAKING its own tmp dir into that global for the rest of the
+    # xdist worker. The path this assertion actually received came from a
+    # DIFFERENT test (`test_status_payload_existing`'s tmp dir). Whoever patched
+    # last won. Only the xdist gate could ever see that; the single-process PR
+    # gate never could.
+    #
+    # So test the RESOLUTION LOGIC, which is the real contract, rather than the
+    # ambient value: with the override REMOVED, the root falls back to the user
+    # home. Restores the env and re-derives the constant on the way out — the
+    # leak this test was a victim of.
+    import importlib
+
+    import scitex_agent_container._runners._session_state as _ss
+
+    key = "SCITEX_AGENT_CONTAINER_RUNTIME_DIR"
+    saved = os.environ.get(key)
+    os.environ.pop(key, None)
+    try:
+        importlib.reload(_ss)
+
+        # Act
+        result = _ss.state_dir_for("zeta")
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(_ss)
+
     # Assert
-    assert (
-        "agent-container/runtime/zeta" in result_str
-        or "agent-container\\runtime\\zeta" in result_str
-    )
+    assert result == Path.home() / ".scitex" / "agent-container" / "runtime" / "zeta"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_state/test__port_allocator_concurrency.py
+++ b/tests/scitex_agent_container/_state/test__port_allocator_concurrency.py
@@ -1,0 +1,247 @@
+"""claim_port under CONCURRENCY — the bug that ghosted the v0.21.19 release.
+
+THE INCIDENT. The release gate (self-hosted Spartan, inside the SIF, pytest
+under `-n $(nproc)` xdist) died on:
+
+    sqlite3.IntegrityError: UNIQUE constraint failed: a2a_ports.port
+
+…while the PR gate stayed GREEN. It could not have been otherwise: the PR gate
+ran `pytest tests/` SINGLE-PROCESS on a hosted ubuntu box, so it was
+STRUCTURALLY INCAPABLE of observing a race. The tag was pushed, `test` failed,
+`build`/`publish`/`release` were skipped, and PyPI got nothing — a ghost tag.
+v0.21.18 died the same way with a different symptom (`no free a2a port`), which
+is the signature of a race: the failure MOVES.
+
+THE MECHANISM. ``claim_port``'s ``explicit`` branch was a TOCTOU:
+
+    clash = SELECT name FROM a2a_ports WHERE port=?   # (1) check
+    if clash: raise RuntimeError(...)
+    INSERT INTO a2a_ports ...                         # (2) use
+
+Two statements. A concurrent claimant that lands between (1) and (2) makes the
+INSERT trip ``UNIQUE(port)``, and the raw driver exception escaped to the
+caller. Whether you got the INTENDED ``RuntimeError`` or a raw
+``IntegrityError`` was decided purely by thread timing.
+
+WHY A PLAIN `--force` RESTART REACHES THE PIN BRANCH AT ALL (this is the part
+that makes it bite in the wild, not just for operator-pinned specs):
+``resolve_a2a_port`` MUTATES ``config.a2a.port`` in place, "auto" -> the int it
+just claimed. ``agent_start``'s force/restart path then re-resolves AFTER
+``agent_stop`` has released the row — and that second call sees an *int*, so it
+takes the ``explicit`` branch. An auto-port agent therefore traverses the
+pinned-port code on every forced restart.
+
+NOT A TEST-ONLY BUG. On a real host two concurrent restarts race here and the
+operator gets a raw sqlite traceback instead of a diagnosis.
+
+No mocks: a real on-disk sqlite db, the real ``claim_port``, real threads. The
+``Barrier`` is what makes it deterministic rather than a 1-in-N flake — it
+holds every thread until all of them are ready, so they all cross the TOCTOU
+window together. Pre-fix this reproduced ~6 raw IntegrityError escapes out of
+16 threads on the first run.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state.port_allocator import claim_port
+
+
+def _claim_concurrently(
+    n_threads: int,
+    target,
+) -> list[BaseException]:
+    """Run ``target(i)`` on ``n_threads`` threads released simultaneously.
+
+    Returns every exception that escaped, so the caller can assert on the
+    TYPES that reached the caller rather than merely on "it didn't crash".
+    """
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+    barrier = threading.Barrier(n_threads)
+
+    def worker(i: int) -> None:
+        barrier.wait()  # all threads cross the TOCTOU window together
+        try:
+            target(i)
+        except BaseException as exc:  # noqa: BLE001 — cataloguing what escapes
+            with lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    return errors
+
+
+def test_concurrent_explicit_pin_never_leaks_a_raw_sqlite_error(
+    tmp_path: Path,
+) -> None:
+    # Arrange — 16 DISTINCT agents all pinned to the SAME port. Exactly one can
+    # legitimately win; the other 15 must lose CLEANLY.
+    db = tmp_path / "state.db"
+
+    # Act
+    errors = _claim_concurrently(
+        16,
+        lambda i: claim_port(f"agent-{i}", explicit=19000, db_path=db),
+    )
+
+    # Assert — the regression: a raw driver exception must NEVER reach the
+    # caller. This is the exact exception that killed the v0.21.19 release.
+    leaked = [e for e in errors if isinstance(e, sqlite3.IntegrityError)]
+    assert not leaked, (
+        f"{len(leaked)}/16 threads leaked a raw sqlite3.IntegrityError "
+        f"(the v0.21.19 release failure): {leaked[:3]}"
+    )
+
+
+def test_auto_origin_reclaim_of_a_stolen_port_gets_a_fresh_port_not_an_error(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the RESTART case, and the one that matters for a fleet
+    # relaunch. `resolve_a2a_port` mutates "auto" -> an int, so a restarting
+    # agent re-claims its old port as an `explicit` value. Here that port was
+    # taken while it was down. It is NOT an operator pin, so the agent must
+    # come back on a NEW port. A "clean RuntimeError" here is still a DEAD
+    # AGENT, and the operator relaunches ~14 at once.
+    db = tmp_path / "state.db"
+    claim_port("thief", explicit=19000, db_path=db)
+
+    # Act
+    port = claim_port("restarter", explicit=19000, explicit_is_pin=False, db_path=db)
+
+    # Assert
+    assert port != 19000
+
+
+def test_operator_pin_is_not_silently_downgraded_to_a_different_port(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the guard on the fix above. A GENUINE operator pin is a
+    # contract: if it is held by someone else that is a real misconfiguration
+    # and must stay loud. The auto-origin fallback must not have quietly
+    # swallowed it.
+    db = tmp_path / "state.db"
+    claim_port("incumbent", explicit=19000, db_path=db)
+    caught: BaseException | None = None
+
+    # Act
+    try:
+        claim_port("pinned", explicit=19000, explicit_is_pin=True, db_path=db)
+    except BaseException as exc:  # noqa: BLE001 — asserting on the TYPE below
+        caught = exc
+
+    # Assert
+    assert isinstance(caught, RuntimeError)
+
+
+def test_concurrent_explicit_pin_losers_all_get_the_diagnostic_runtimeerror(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    db = tmp_path / "state.db"
+
+    # Act
+    errors = _claim_concurrently(
+        16,
+        lambda i: claim_port(f"agent-{i}", explicit=19000, db_path=db),
+    )
+
+    # Assert — 16 claimants, 1 winner => exactly 15 losers, and every one of
+    # them gets the SAME actionable error naming the port. Deterministic
+    # outcome, not a timing lottery.
+    assert len(errors) == 15 and all(isinstance(e, RuntimeError) for e in errors)
+
+
+def test_concurrent_explicit_pin_commits_exactly_one_winning_row(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    db = tmp_path / "state.db"
+
+    # Act
+    _claim_concurrently(
+        16,
+        lambda i: claim_port(f"agent-{i}", explicit=19000, db_path=db),
+    )
+
+    # Assert — the table is not merely un-crashed, it is CORRECT: one row holds
+    # the contended port.
+    conn = sqlite3.connect(db)
+    try:
+        rows = conn.execute(
+            "SELECT name FROM a2a_ports WHERE port=?", (19000,)
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+
+
+def test_same_agent_racing_itself_keeps_its_pin_idempotently(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the SAME agent started twice concurrently (the force-restart
+    # re-claim). claim_port is documented idempotent on agent_name, and a race
+    # must not turn a legitimate re-entry into a failure.
+    db = tmp_path / "state.db"
+
+    # Act
+    errors = _claim_concurrently(
+        8,
+        lambda _i: claim_port("solo", explicit=19000, db_path=db),
+    )
+
+    # Assert
+    assert not errors, f"idempotent re-claim raised: {errors[:3]}"
+
+
+def test_concurrent_auto_claims_all_get_distinct_ports(tmp_path: Path) -> None:
+    # Arrange — the auto branch already handled contention (ascending scan +
+    # optimistic insert, IntegrityError -> re-scan). Pin that contract so a
+    # future "simplification" of the loop cannot silently regress it.
+    db = tmp_path / "state.db"
+    claimed: list[int] = []
+    lock = threading.Lock()
+
+    def claim(i: int) -> None:
+        port = claim_port(f"auto-{i}", range_=(19000, 19999), db_path=db)
+        with lock:
+            claimed.append(port)
+
+    # Act
+    errors = _claim_concurrently(16, claim)
+
+    # Assert — no escapes, and every agent got its OWN port.
+    assert not errors and len(set(claimed)) == 16
+
+
+@pytest.mark.parametrize("pinned", [19000, 19500])
+def test_explicit_pin_still_reports_a_genuine_foreign_claim(
+    tmp_path: Path, pinned: int
+) -> None:
+    # Arrange — the UNCONTENDED path must keep its original behaviour: a real
+    # misconfiguration (two specs pinning one port) is still a loud error. The
+    # race fix must not have swallowed the diagnosis it exists to preserve.
+    db = tmp_path / "state.db"
+    claim_port("incumbent", explicit=pinned, db_path=db)
+    caught: BaseException | None = None
+
+    # Act
+    try:
+        claim_port("newcomer", explicit=pinned, db_path=db)
+    except BaseException as exc:  # noqa: BLE001 — asserting on the TYPE below
+        caught = exc
+
+    # Assert
+    assert isinstance(
+        caught, RuntimeError
+    ) and f"a2a port {pinned} already claimed" in str(caught)


### PR DESCRIPTION
## PyPI is stuck at 0.21.17. Eleven tags shipped nothing.

`v0.21.18`, `v0.21.19` and eight older tags are **ghosts**: the tag exists, and PyPI serves nothing. Verified against the version-specific endpoint (`/pypi/<pkg>/<ver>/json` — never `/simple/` or "latest", both are CDN-cached and will happily 200 a version that isn't there):

```
0.21.17 -> 200      0.21.18 -> 404      0.21.19 -> 404      0.21.20 -> 404
```

### Why nobody caught it: the two gates were different environments, by configuration

| | PR gate | release gate |
|---|---|---|
| runner | `ubuntu-latest` (hosted, ephemeral `$HOME`) | Spartan self-hosted (persistent `$HOME`) |
| env | bare runner | inside the CI SIF |
| command | `pytest tests/` — **single process** | `pytest -n $(nproc) --dist load` — **xdist** |

A green PR predicted **nothing** about the release. And the PR gate was *structurally incapable* of catching what killed the release: **a single-process test run cannot race with itself.** `test` failed on the release runner, `build`/`publish`/`release` were skipped via `needs: test`, and nothing reached PyPI. Silently. For months.

This is also why #680's publish self-verification didn't save v0.21.19 despite that release calling itself *"the first release guarded by its own publish-verification"* — the guard sits **downstream** of `needs: test`, so it never got a turn.

## The bug — a real product bug, reproduced deterministically

`claim_port()`'s `explicit` branch was a **TOCTOU**:

```python
clash = SELECT ... WHERE port=?     # (1) check
if clash: raise RuntimeError(...)
INSERT INTO a2a_ports ...           # (2) use   <-- no try/except
```

A concurrent claimant landing between (1) and (2) trips `UNIQUE(port)` and the raw `sqlite3.IntegrityError` escapes. **Which error you got was decided purely by thread timing** — which is why the failure *moved* between releases and read as a flake:

| release | failing test | error |
|---|---|---|
| v0.21.19 | `test__restart_preflight_integration.py::test_agent_start_force_healthy_successor_still_restarts` | `sqlite3.IntegrityError: UNIQUE constraint failed: a2a_ports.port` |
| v0.21.18 | `test__restart_preflight_integration.py::test_agent_restart_healthy_successor_still_stops_then_starts` | `RuntimeError: no free a2a port in range [19000, 19999]` |

Real-seam probe (16 threads, real sqlite, **no mocks**), first run:

```
A: claim_port(explicit=19000) x16 threads, distinct names
    x6  IntegrityError: UNIQUE constraint failed: a2a_ports.port   <-- the v0.21.19 failure, verbatim
    x9  RuntimeError: a2a port 19000 already claimed by 'agent-8'  <-- the INTENDED error
B: claim_port(auto) x16 -> 0 escapes                               <-- auto branch was already correct
```

**Why a plain `--force` restart reaches the *pinned*-port branch at all** — the part that makes this bite agents nobody pinned: `resolve_a2a_port` **mutates `config.a2a.port` in place**, `"auto"` → the int it just claimed. `agent_start`'s force/restart path re-resolves *after* `agent_stop` released the row, so the second call sees an **int** and takes the `explicit` branch. Both failing tests are force/restart paths.

The concurrent claimant is real and the repo already documented it — `exec-in-sif.sh` notes that several tests spawn **detached `sac agents`/`sac listen` subprocesses that hold a2a ports**.

**Not a test bug.** Two concurrent `sac agents start` on a real host hit this and the operator gets a raw sqlite traceback instead of a diagnosis.

## A lost race must be resolved by ORIGIN

Atomicity alone would have been the wrong fix. `INSERT ... ON CONFLICT DO NOTHING` stops the traceback but still answers the wrong question, because *"am I allowed to fail here?"* depends on provenance the code had already destroyed:

- an **operator pin** held by another agent is a real misconfiguration → **raise** (handing back a different port would silently break the contract the pin exists to state);
- a port **we auto-allocated** and are merely re-claiming across a restart is a *preference* → **take a fresh port**. "Someone took your old port while you were down" must not answer with a dead agent.

Those two states were **byte-identical** by the time `claim_port` saw them, because `resolve_a2a_port` overwrites its own input. *Any in-place normalization that maps N states onto fewer destroys the provenance the error path needs, and the loss surfaces far away.* The origin is now threaded through (`claim_port(explicit_is_pin=...)`).

This matters right now: the operator is about to relaunch **~14 agents at once**. A "clean `RuntimeError`" is still a **failed launch**.

## The gates are now the same bytes

`pytest-matrix` now runs the **same `run-in-sif.sh`** on the **same `vars.CI_RUNS_ON`** runners as the release workflow. Not "an equivalent setup" — the same script. **Green PR ⇒ green release, by construction.**

Per the operator's absolute rule (2026-07-14): **no GitHub-hosted runners, PR tests included.** If Spartan misbehaves that is *ours* to fix — never a fallback to hosted. There is deliberately **no `ubuntu-latest` escape hatch**.

Two deliberate, load-bearing choices:

- **The job `name:` is byte-identical.** `pytest-matrix-on-ubuntu-py3.{11,12,13}` are **required status checks on both `develop` and `main`**. Rename the job and the required contexts never report → every PR sits at `BLOCKED` with all checks passing. That has already held a release hostage once. The name is now a misnomer; fixing it is a separate change that must flip the job name *and both protection rules* atomically, **after** open PRs (#677, #673) carry the new workflow. **Do not "tidy" this name in isolation.**
- **The credential-provisioning step is removed.** On a *persistent* self-hosted runner `$HOME` is the operator's **real** home — that step would clobber the **live fleet credential** on every CI run. Creds-gated tests skip cleanly without it, exactly as they already do on the release gate.

## Also fixed: a test could restart the operator's live control plane

`_listen/_single_instance.default_lock_dir()` hard-coded `Path.home()` and **ignored `SCITEX_AGENT_CONTAINER_RUNTIME_DIR`**, so the harness's floor never reached it. Its docstring said *"tests pass an explicit `lock_dir`"* — a promise enforced by **nothing**. That directory holds the **`sac listen` PIDFILE**: on the self-hosted release runner (`$HOME` = the operator's real home), a test reaching a listen CLI path without threading one through could act on the **live control plane**, tearing down the in-memory a2a broker and **deafening every agent's inbox at once**. It now honours the same variable `_session_state.DEFAULT_STATE_ROOT` reads (SSOT — one runtime root, one override) and resolves **per call**, so a harness is never too late.

Plus: the sac-state **floor is now per-xdist-worker** (one project-relative floor is a host-global namespace shared by every worker in a leg — the same shape as the tmux-socket and persistent-`$HOME` collisions, and exactly the contention the port race needs), and `tests/results/` is gitignored (two floor artifacts reached a `git add -A` during this work and would have been committed).

## Verification

- Pre-fix probe: **6/16 threads leaked a raw `IntegrityError`.**
- Post-fix: **37 passed** — 9 new real-seam concurrency tests + the 20 existing `port_allocator` tests + **`test__restart_preflight_integration.py`, the file that failed in *both* ghosted releases**.
- Provenance proven, not assumed: the run imports from the worktree, not the installed package —
  `scitex_agent_container.__file__ = .../.worktrees/.../src/scitex_agent_container/__init__.py`

## Known remaining (carded, not silent)

1. **Nine workflows still declare `runs-on: ubuntu-latest`** (`lint`, `quality-audit`, `import-smoke`, `rtd-sphinx`, `sdk-runtime-smoke`, `live-haiku`, `newb-docs`, `cla`, `auto-merge`). Each needs SIF plumbing, not a bare `runs-on` swap — the Spartan node has no Python and no passwordless apt, which is what PR #650 ran aground on. Sliced deliberately so the **release is not held hostage to a ten-workflow migration**.
2. **The scitex-dev audit rule** that mechanically rejects any non-Spartan runner (template: PS-168, which already walks `.github/workflows/*.yml` and reports `path:lineno`). Note the hole: two **org** reusable workflows (`cla.yml`, `auto-merge-to-develop.yml`) are themselves `ubuntu-latest`, so a rule that only greps this repo's `.github/` will not see them.
3. **Four more module-level `Path.home()` constants with no env override** — unredirectable by a fixture, same class as the pidfile above: `_mcp/_tools/_template.py:69` (`_AGENTS_DIR`), `cli_pkg/image_group.py:60,67`, `_listen/tokens.py:17` (`_DEFAULT_TOKEN_DIR`). When an invariant dies, the bug in front of you is a **sample, not the population**.

Supersedes the runner half of **#650** (draft, conflicted, and — critically — it kept `ubuntu-latest` in its own `runs-on` expression, so it would fail the very audit rule this work mandates). **#594** is orthogonal: one file, zero runners migrated, and the org workflow it adopts is itself `ubuntu-latest`.
