### PR TITLE
fix(tests): regenerate the cross-package import gate — scitex_dev.hosts (develop is RED, and it is holding the release)

### DIFF
--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -25,6 +25,7 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_container",
     "scitex_dev",
     "scitex_dev._cli._completion",
+    "scitex_dev.hosts",
     "scitex_dev.jobs",
     "scitex_dev.linter._rules._base",
     "scitex_dev.linter._rules._lookup",


### PR DESCRIPTION
**develop is RED and this is the one-line cause.** It is also blocking the v0.21.20 release PR, which runs the same audit.

PR #686 adopted `scitex_dev.hosts` as the host-registry SSOT — three files in `src/`:
```
src/scitex_agent_container/_state/host_registry.py
src/scitex_agent_container/cli_pkg/host_group.py
src/scitex_agent_container/cli_pkg/lifecycle/_dispatch_paths.py
```
…but the **auto-generated** `CROSS_PACKAGE_IMPORTS` gate was not regenerated with it.

`PS-140` (severity **E**) compares the gate against an AST scan of `src/`. The moment #686 merged, `test_audit_all_clean` started failing on develop — and took the release with it.

## Verified, not assumed

Computed with **scitex-dev's own collector** (`_collect_cross_package_imports`) against develop @ `4d6b7c08`:
```
before ->  MISSING from gate: ['scitex_dev.hosts']   STALE: []
after  ->  MISSING: []   STALE: []      => PS-140 SATISFIED
```
And the module actually resolves: `import scitex_dev.hosts` -> OK. (The gate is an `importorskip` test, so it stays correct whether or not the peer is installed.)

## One line

```diff
     "scitex_dev._cli._completion",
+    "scitex_dev.hosts",
     "scitex_dev.jobs",
```