### PR TITLE
fix(comms): a silent listen death must not deafen an agent forever

### DIFF
--- a/src/scitex_agent_container/_listen/_node_channel.py
+++ b/src/scitex_agent_container/_listen/_node_channel.py
@@ -30,6 +30,8 @@ from .._state.state_db_channel import (
     persist_event,
 )
 from ..a2a._inbox_bus import (
+    KEEPALIVE,
+    keepalive_interval_s,
     mint_acl_deny_synthetic_notification,
     mint_deny_notification,
     mint_event,
@@ -414,6 +416,7 @@ async def node_inbox_stream(request: Request) -> Response:
                 )
                 mark_delivered([row_id])
 
+            beat_s = keepalive_interval_s()
             while True:
                 if await request.is_disconnected():
                     return
@@ -424,9 +427,20 @@ async def node_inbox_stream(request: Request) -> Response:
                 # (card sac-listen-sigterm-sse-shutdown-hang). ``None``
                 # means "broker closing" — return so the StreamingResponse
                 # completes and the daemon exits cleanly.
-                event = await broker.get_or_close(queue)
+                event = await broker.get_or_close(queue, keepalive_after=beat_s)
                 if event is None:
                     return
+                if event is KEEPALIVE:
+                    # Idle stream — beat. A comment frame is a no-op as CONTENT
+                    # to any SSE client (the adapter skips lines starting with
+                    # ':'), but it is not a no-op as SIGNAL: it gives the client
+                    # bytes, which is the ONLY way a bounded read deadline can
+                    # tell "quiet" from "silently dead" and re-dial instead of
+                    # parking forever on a socket nobody will ever speak on
+                    # again. Without it, a listen that vanishes without closing
+                    # deafens this agent until someone restarts it.
+                    yield b": keepalive\n\n"
+                    continue
                 # The publish path stamps the persisted row id onto
                 # the envelope as ``_row_id`` (see
                 # :func:`node_message_send`). We surface it as the SSE

--- a/src/scitex_agent_container/_mcp/_channel_sse.py
+++ b/src/scitex_agent_container/_mcp/_channel_sse.py
@@ -1,0 +1,193 @@
+"""The long-lived SSE inbox consumer, and the reconnect policy it enforces.
+
+Extracted from :mod:`.channel` (which mixes this with the MCP-session adapter
+that pushes received events into the running Claude session, and sat over the
+per-file cap). This half deserves to stand alone: it is the component whose
+failure DEAFENS an agent, and every past outage in this area has been a bug in
+exactly one of the three deadlines below.
+
+THE INVARIANT: an agent that survives ``sac listen`` going away must
+re-subscribe on its own, with **no agent restart**. The only way to hold that is
+for every way a connection can end to route back to the top of the retry loop.
+Three of them, each historically unbounded, each one an outage:
+
+``connect``  bounded by :data:`_SSE_CONNECT_TIMEOUT_S`.
+    Until #591 this was ``timeout=None``. During the 2026-07-01 outage every
+    reconnect hung forever inside ``client.stream(...)``, so the backoff loop
+    never came around: agents stayed alive and permanently unsubscribed, curable
+    only by restarting all 14 of them.
+
+``read``     bounded by :func:`_sse_read_timeout_s`.
+    #591 left this unbounded. A stream that is merely QUIET is byte-for-byte
+    indistinguishable from one that has died SILENTLY (no FIN, no RST — a hard
+    host death, a wedged uvicorn, an idle NAT/firewall flow drop), so the
+    consumer parked here forever, still believing it was subscribed while the
+    broker held no subscriber for it. ``sac listen`` now beats ``: keepalive``
+    down every idle stream (``a2a._inbox_bus.keepalive_interval_s``), so silence
+    past the deadline is real evidence of death — and evidence is what a
+    reconnect needs.
+
+``backoff``  capped by :data:`_SSE_BACKOFF_CAP_S`, and JITTERED.
+    Every agent on a host subscribes to the same listen, so they all lose the
+    stream in the same instant and climb an identical ladder in lockstep. See
+    :func:`_jittered_backoff`.
+
+Reconnecting is cheap and IDEMPOTENT — the stream replays undelivered rows on
+connect — so every deadline here errs toward re-dialling. A false positive costs
+one reconnect; a false negative costs the agent every message it will ever be
+sent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import random
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Bound the SSE CONNECT phase (see module docstring — #591).
+_SSE_CONNECT_TIMEOUT_S: float = 30.0
+
+# ...and bound the READ, which #591 left unbounded. Must exceed the server's
+# keepalive beat (default 15s) by a wide margin so several missed beats are
+# tolerated before a healthy stream is torn down.
+_DEFAULT_SSE_READ_TIMEOUT_S: float = 60.0
+_ENV_SSE_READ_TIMEOUT_S = "SAC_MCP_SSE_READ_TIMEOUT_S"
+
+# Ceiling on the retry ladder. Bounds the worst-case window between listen
+# coming back and this adapter noticing. Messages are NOT lost in that window —
+# they are persisted before publish and replayed on connect — so the cost of the
+# cap is latency, not delivery.
+_SSE_BACKOFF_CAP_S: float = 30.0
+
+_SSE_BACKOFF_START_S: float = 0.5
+
+
+def _sse_read_timeout_s() -> float:
+    """Seconds of total silence before the SSE read is declared dead.
+
+    Read from the env at CALL time, never baked into a module-level constant at
+    import: an import-time ``float(os.environ[...])`` cannot be redirected by a
+    test (or an operator) that sets the var afterwards, and a knob that silently
+    ignores its own env var is worse than no knob.
+
+    A malformed or non-positive value falls back to the default. Never returns
+    ``None``: "wait forever" is the bug, not a configuration.
+    """
+    raw = os.environ.get(_ENV_SSE_READ_TIMEOUT_S)
+    if raw is None:
+        return _DEFAULT_SSE_READ_TIMEOUT_S
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_SSE_READ_TIMEOUT_S
+    return value if value > 0 else _DEFAULT_SSE_READ_TIMEOUT_S
+
+
+def _jittered_backoff(backoff: float) -> float:
+    """Spread a retry across the BACK HALF of its backoff window.
+
+    Every agent on a host subscribes to the same ``sac listen``. When it goes
+    away they all lose the stream in the same instant and climb an IDENTICAL
+    ladder — 0.5s, 1s, 2s, 4s … — re-dialling in lockstep. That is a thundering
+    herd aimed at a process which is, by definition, in the middle of coming
+    back up: the fleet's ~14 adapters land on it simultaneously at every rung,
+    which is an excellent way to knock over the very thing they are all waiting
+    for (and this fleet HAS watched a listen die and take every inbox with it).
+
+    Equal jitter — half the window, plus a random half — decorrelates them while
+    keeping a floor, so recovery latency is unchanged but the arrivals are
+    smeared across the window instead of stacked on its edge.
+    """
+    half = backoff / 2.0
+    return half + random.random() * half
+
+
+async def _consume_sse(
+    url: str,
+    bearer: str | None,
+    on_event: "callable[[dict[str, Any]], asyncio.Future[None]]",
+) -> None:
+    """Long-lived SSE consumer. Reconnects with jittered backoff on disconnect.
+
+    Each ``event: message`` frame's ``data:`` line is JSON-decoded and handed to
+    ``on_event``. Comment frames (``: ...``) are ignored as CONTENT — sac listen
+    emits one on connect (``: sac-channel ready``) and then beats ``: keepalive``
+    down every idle stream. Ignored as content is NOT ignored as signal: each
+    beat is bytes arriving, which resets the read deadline and is how this
+    consumer tells a quiet stream from a dead one.
+
+    This loop must never exit: the process has no other path back to subscribed.
+    Even a non-200 (say, a stale bearer) is logged and retried.
+    """
+    try:
+        import httpx
+    except Exception as exc:  # pragma: no cover
+        # Catch broadly: optional deps can fail at *import time* with
+        # non-ImportError errors (e.g. a misconfigured transitive dep
+        # raising RuntimeError). Surface them as an actionable
+        # ImportError so the caller knows install/upgrade is needed.
+        raise ImportError(
+            "httpx is required for sac mcp channel — install with `pip install httpx`"
+        ) from exc
+
+    headers = {"Accept": "text/event-stream"}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+
+    backoff = _SSE_BACKOFF_START_S
+    sse_timeout = httpx.Timeout(_SSE_CONNECT_TIMEOUT_S, read=_sse_read_timeout_s())
+    while True:
+        try:
+            async with httpx.AsyncClient(timeout=sse_timeout) as client:
+                async with client.stream("GET", url, headers=headers) as resp:
+                    if resp.status_code != 200:
+                        body = await resp.aread()
+                        log.warning(
+                            "sac channel SSE %s returned %d: %s",
+                            url,
+                            resp.status_code,
+                            body[:200],
+                        )
+                    else:
+                        backoff = _SSE_BACKOFF_START_S
+                        data_lines: list[str] = []
+                        async for line in resp.aiter_lines():
+                            if not line:
+                                # frame separator — dispatch what we have
+                                if data_lines:
+                                    payload = "\n".join(data_lines)
+                                    data_lines = []
+                                    try:
+                                        event = json.loads(payload)
+                                    except json.JSONDecodeError:
+                                        log.warning(
+                                            "sac channel SSE bad JSON: %r",
+                                            payload[:200],
+                                        )
+                                        continue
+                                    await on_event(event)
+                                continue
+                            if line.startswith(":"):
+                                continue  # comment frame (incl. the keepalive beat)
+                            if line.startswith("data:"):
+                                data_lines.append(line[5:].lstrip())
+        except Exception as exc:  # stx-allow: fallback (reason: long-lived SSE — must retry on any transient error, including the ReadTimeout that a silently-dead stream now raises)
+            log.warning(
+                "sac channel SSE error (%s); reconnecting in ~%.1fs", exc, backoff
+            )
+        await asyncio.sleep(_jittered_backoff(backoff))
+        backoff = min(backoff * 2, _SSE_BACKOFF_CAP_S)
+
+
+__all__ = [
+    "_consume_sse",
+    "_jittered_backoff",
+    "_sse_read_timeout_s",
+    "_SSE_BACKOFF_CAP_S",
+    "_SSE_CONNECT_TIMEOUT_S",
+]

--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -57,12 +57,56 @@ _recent: "deque[dict[str, Any]]" = deque(maxlen=_INBOX_CAP)
 _CHANNEL_SOURCE_ENV_VAR = "SAC_MCP_CHANNEL_SOURCE"
 _CHANNEL_SOURCE_DEFAULT = "sac"
 
-# Bound the SSE CONNECT phase; read stays unbounded (the event stream is
-# legitimately long-lived). Load-resilience fix (2026-07-09): ``timeout=None``
-# left CONNECT unbounded too, so a hung connect to ``:7878`` under load blocked
-# inside ``client.stream(...)`` forever and the reconnect-with-backoff loop never
-# retried. See ``docs/mcp-load-resilience.md``.
+# Bound the SSE CONNECT phase. Load-resilience fix (2026-07-09, #591):
+# ``timeout=None`` left CONNECT unbounded, so a hung connect to ``:7878`` under
+# load blocked inside ``client.stream(...)`` forever and the
+# reconnect-with-backoff loop never retried — the agent stayed alive and
+# permanently unsubscribed, curable only by restarting it. That was the
+# mechanism of the 2026-07-01 fleet-comms outage.
+# See ``docs/mcp-load-resilience.md``.
 _SSE_CONNECT_TIMEOUT_S: float = 30.0
+
+# ...and bound the READ, which that fix left unbounded.
+#
+# An unbounded read is the SAME bug one layer down. `sac listen` beats a
+# keepalive comment frame down every idle inbox stream (see
+# ``a2a._inbox_bus.keepalive_interval_s``, default 15 s), so a healthy stream is
+# NEVER silent for long. Without a read deadline, a connection that dies
+# SILENTLY — no FIN, no RST: a hard host death, a wedged uvicorn, an idle
+# NAT/firewall flow drop — parks this consumer inside ``aiter_lines()`` forever.
+# It believes it is subscribed; the broker holds no subscriber for it; every
+# message aimed at the agent lands on an empty bus. Deafness, with no error
+# raised anywhere, until someone restarts the agent.
+#
+# So: exceed the server's beat by a wide margin (tolerate several missed beats
+# before tearing down a healthy stream), then let the deadline fire. A
+# ``ReadTimeout`` is caught by the reconnect loop below, which re-dials with
+# backoff and RE-SUBSCRIBES. Reconnecting is cheap and idempotent — the stream
+# replays undelivered rows on connect — so a false positive costs a reconnect,
+# while a false negative costs the agent every message it will ever be sent.
+_DEFAULT_SSE_READ_TIMEOUT_S: float = 60.0
+_ENV_SSE_READ_TIMEOUT_S = "SAC_MCP_SSE_READ_TIMEOUT_S"
+
+
+def _sse_read_timeout_s() -> float:
+    """Seconds of total silence before the SSE read is declared dead.
+
+    Read from the env at CALL time, never baked into a module-level constant at
+    import: an import-time ``float(os.environ[...])`` cannot be redirected by a
+    test (or an operator) that sets the var afterwards, and a knob that silently
+    ignores its own env var is worse than no knob.
+
+    A malformed or non-positive value falls back to the default. Never returns
+    ``None``: "wait forever" is the bug, not a configuration.
+    """
+    raw = os.environ.get(_ENV_SSE_READ_TIMEOUT_S)
+    if raw is None:
+        return _DEFAULT_SSE_READ_TIMEOUT_S
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_SSE_READ_TIMEOUT_S
+    return value if value > 0 else _DEFAULT_SSE_READ_TIMEOUT_S
 
 
 # WI-1 wake-on-push primitives live in ``_channel_wake`` (extracted to keep
@@ -105,9 +149,27 @@ async def _consume_sse(
 ) -> None:
     """Long-lived SSE consumer. Reconnects with backoff on disconnect.
 
-    Each `event: message` frame's `data:` line is JSON-decoded and
-    handed to ``on_event``. Comment frames (``: ...``) are ignored —
-    sac listen emits one at connection time as a keep-alive hint.
+    Each ``event: message`` frame's ``data:`` line is JSON-decoded and handed to
+    ``on_event``. Comment frames (``: ...``) are ignored as content — sac listen
+    emits one on connect (``: sac-channel ready``) and then beats ``: keepalive``
+    down every idle stream. Ignored as CONTENT is not ignored as SIGNAL: each
+    beat is bytes arriving, which resets the read deadline below and is how this
+    consumer tells a quiet stream from a dead one.
+
+    THE INVARIANT THIS LOOP EXISTS FOR: an agent that survives ``sac listen``
+    going away must re-subscribe on its own, with no agent restart. Every way
+    the connection can end has to route back to the top of this loop:
+
+      * clean EOF mid-stream (listen restarted / SIGTERM'd) — ``aiter_lines()``
+        ends, we fall through and re-dial;
+      * connect refused / hung (listen down, or wedged under load) — bounded by
+        ``_SSE_CONNECT_TIMEOUT_S``; before #591 this was unbounded and the loop
+        never came around, which is how a whole fleet went permanently deaf;
+      * a socket that dies with NO close at all — bounded by the read deadline
+        (:func:`_sse_read_timeout_s`); before this, that parked here forever.
+
+    A non-200 (e.g. a stale bearer) is logged and retried too: we must never
+    exit this loop, because the process has no other path back to subscribed.
     """
     try:
         import httpx
@@ -125,7 +187,7 @@ async def _consume_sse(
         headers["Authorization"] = f"Bearer {bearer}"
 
     backoff = 0.5
-    sse_timeout = httpx.Timeout(_SSE_CONNECT_TIMEOUT_S, read=None)
+    sse_timeout = httpx.Timeout(_SSE_CONNECT_TIMEOUT_S, read=_sse_read_timeout_s())
     while True:
         try:
             async with httpx.AsyncClient(timeout=sse_timeout) as client:
@@ -205,7 +267,9 @@ def _build_notification(event: dict[str, Any]) -> dict[str, Any]:
     """
     from .._state.state_db_channel import format_ts_iso
 
-    source = os.environ.get(_CHANNEL_SOURCE_ENV_VAR, "").strip() or _CHANNEL_SOURCE_DEFAULT
+    source = (
+        os.environ.get(_CHANNEL_SOURCE_ENV_VAR, "").strip() or _CHANNEL_SOURCE_DEFAULT
+    )
     meta: dict[str, Any] = {
         "source": source,
         "from_agent": _meta_str(event.get("from_agent", "unknown")),

--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -36,7 +36,6 @@ container and no spec; its AgentCard is synthesised by
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
 from collections import deque
@@ -56,58 +55,6 @@ _recent: "deque[dict[str, Any]]" = deque(maxlen=_INBOX_CAP)
 # separate from_agent meta key. Env-overridable (SAC_MCP_* convention, #591).
 _CHANNEL_SOURCE_ENV_VAR = "SAC_MCP_CHANNEL_SOURCE"
 _CHANNEL_SOURCE_DEFAULT = "sac"
-
-# Bound the SSE CONNECT phase. Load-resilience fix (2026-07-09, #591):
-# ``timeout=None`` left CONNECT unbounded, so a hung connect to ``:7878`` under
-# load blocked inside ``client.stream(...)`` forever and the
-# reconnect-with-backoff loop never retried — the agent stayed alive and
-# permanently unsubscribed, curable only by restarting it. That was the
-# mechanism of the 2026-07-01 fleet-comms outage.
-# See ``docs/mcp-load-resilience.md``.
-_SSE_CONNECT_TIMEOUT_S: float = 30.0
-
-# ...and bound the READ, which that fix left unbounded.
-#
-# An unbounded read is the SAME bug one layer down. `sac listen` beats a
-# keepalive comment frame down every idle inbox stream (see
-# ``a2a._inbox_bus.keepalive_interval_s``, default 15 s), so a healthy stream is
-# NEVER silent for long. Without a read deadline, a connection that dies
-# SILENTLY — no FIN, no RST: a hard host death, a wedged uvicorn, an idle
-# NAT/firewall flow drop — parks this consumer inside ``aiter_lines()`` forever.
-# It believes it is subscribed; the broker holds no subscriber for it; every
-# message aimed at the agent lands on an empty bus. Deafness, with no error
-# raised anywhere, until someone restarts the agent.
-#
-# So: exceed the server's beat by a wide margin (tolerate several missed beats
-# before tearing down a healthy stream), then let the deadline fire. A
-# ``ReadTimeout`` is caught by the reconnect loop below, which re-dials with
-# backoff and RE-SUBSCRIBES. Reconnecting is cheap and idempotent — the stream
-# replays undelivered rows on connect — so a false positive costs a reconnect,
-# while a false negative costs the agent every message it will ever be sent.
-_DEFAULT_SSE_READ_TIMEOUT_S: float = 60.0
-_ENV_SSE_READ_TIMEOUT_S = "SAC_MCP_SSE_READ_TIMEOUT_S"
-
-
-def _sse_read_timeout_s() -> float:
-    """Seconds of total silence before the SSE read is declared dead.
-
-    Read from the env at CALL time, never baked into a module-level constant at
-    import: an import-time ``float(os.environ[...])`` cannot be redirected by a
-    test (or an operator) that sets the var afterwards, and a knob that silently
-    ignores its own env var is worse than no knob.
-
-    A malformed or non-positive value falls back to the default. Never returns
-    ``None``: "wait forever" is the bug, not a configuration.
-    """
-    raw = os.environ.get(_ENV_SSE_READ_TIMEOUT_S)
-    if raw is None:
-        return _DEFAULT_SSE_READ_TIMEOUT_S
-    try:
-        value = float(raw)
-    except (TypeError, ValueError):
-        return _DEFAULT_SSE_READ_TIMEOUT_S
-    return value if value > 0 else _DEFAULT_SSE_READ_TIMEOUT_S
-
 
 # WI-1 wake-on-push primitives live in ``_channel_wake`` (extracted to keep
 # this receive-side adapter under the module size budget). Re-exported here
@@ -139,96 +86,19 @@ from ._channel_reaction_ack import (  # noqa: E402,F401
 from ._channel_self_register import (  # noqa: E402
     refresh_node as _refresh_comms_node,
 )
+
+# The SSE inbox consumer + its reconnect policy (bounded connect, bounded
+# read, jittered backoff) live in ``_channel_sse`` — the component whose
+# failure deafens an agent, kept readable on its own. Re-exported here so the
+# historical ``from ...channel import _consume_sse`` path (used by the tests
+# and by ``_serve`` below) keeps working unchanged.
+from ._channel_sse import (  # noqa: E402,F401
+    _SSE_CONNECT_TIMEOUT_S,
+    _consume_sse,
+    _jittered_backoff,
+    _sse_read_timeout_s,
+)
 from ._channel_wake import _should_wake_turn, _wake_text, _wake_turn  # noqa: E402,F401
-
-
-async def _consume_sse(
-    url: str,
-    bearer: str | None,
-    on_event: "callable[[dict[str, Any]], asyncio.Future[None]]",
-) -> None:
-    """Long-lived SSE consumer. Reconnects with backoff on disconnect.
-
-    Each ``event: message`` frame's ``data:`` line is JSON-decoded and handed to
-    ``on_event``. Comment frames (``: ...``) are ignored as content — sac listen
-    emits one on connect (``: sac-channel ready``) and then beats ``: keepalive``
-    down every idle stream. Ignored as CONTENT is not ignored as SIGNAL: each
-    beat is bytes arriving, which resets the read deadline below and is how this
-    consumer tells a quiet stream from a dead one.
-
-    THE INVARIANT THIS LOOP EXISTS FOR: an agent that survives ``sac listen``
-    going away must re-subscribe on its own, with no agent restart. Every way
-    the connection can end has to route back to the top of this loop:
-
-      * clean EOF mid-stream (listen restarted / SIGTERM'd) — ``aiter_lines()``
-        ends, we fall through and re-dial;
-      * connect refused / hung (listen down, or wedged under load) — bounded by
-        ``_SSE_CONNECT_TIMEOUT_S``; before #591 this was unbounded and the loop
-        never came around, which is how a whole fleet went permanently deaf;
-      * a socket that dies with NO close at all — bounded by the read deadline
-        (:func:`_sse_read_timeout_s`); before this, that parked here forever.
-
-    A non-200 (e.g. a stale bearer) is logged and retried too: we must never
-    exit this loop, because the process has no other path back to subscribed.
-    """
-    try:
-        import httpx
-    except Exception as exc:  # pragma: no cover
-        # Catch broadly: optional deps can fail at *import time* with
-        # non-ImportError errors (e.g. a misconfigured transitive dep
-        # raising RuntimeError). Surface them as an actionable
-        # ImportError so the caller knows install/upgrade is needed.
-        raise ImportError(
-            "httpx is required for sac mcp channel — install with `pip install httpx`"
-        ) from exc
-
-    headers = {"Accept": "text/event-stream"}
-    if bearer:
-        headers["Authorization"] = f"Bearer {bearer}"
-
-    backoff = 0.5
-    sse_timeout = httpx.Timeout(_SSE_CONNECT_TIMEOUT_S, read=_sse_read_timeout_s())
-    while True:
-        try:
-            async with httpx.AsyncClient(timeout=sse_timeout) as client:
-                async with client.stream("GET", url, headers=headers) as resp:
-                    if resp.status_code != 200:
-                        body = await resp.aread()
-                        log.warning(
-                            "sac channel SSE %s returned %d: %s",
-                            url,
-                            resp.status_code,
-                            body[:200],
-                        )
-                    else:
-                        backoff = 0.5
-                        data_lines: list[str] = []
-                        async for line in resp.aiter_lines():
-                            if not line:
-                                # frame separator — dispatch what we have
-                                if data_lines:
-                                    payload = "\n".join(data_lines)
-                                    data_lines = []
-                                    try:
-                                        event = json.loads(payload)
-                                    except json.JSONDecodeError:
-                                        log.warning(
-                                            "sac channel SSE bad JSON: %r",
-                                            payload[:200],
-                                        )
-                                        continue
-                                    await on_event(event)
-                                continue
-                            if line.startswith(":"):
-                                continue  # comment frame
-                            if line.startswith("data:"):
-                                data_lines.append(line[5:].lstrip())
-        except Exception as exc:  # stx-allow: fallback (reason: long-lived SSE — must retry on any transient error)
-            log.warning(
-                "sac channel SSE error (%s); reconnecting in %.1fs", exc, backoff
-            )
-        await asyncio.sleep(backoff)
-        backoff = min(backoff * 2, 30.0)
 
 
 def _meta_str(value: Any) -> str:

--- a/src/scitex_agent_container/_skills/scitex-agent-container/20_env-vars.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/20_env-vars.md
@@ -141,27 +141,12 @@ start`` against the bare host's apptainer.
 |---|---|---|---|
 | `SAC_LISTEN_BASE_URL` | Host-stable ``sac listen`` base URL the in-SIF CLI POSTs spawn requests against (also used by the in-container channel adapter to subscribe to the bus). Auto-injected by the apptainer runtime from ``listen.host`` / ``listen.port`` in ``~/.scitex/agent-container/config.yaml``. | `http://127.0.0.1:7878` | URL |
 | `SAC_LISTEN_BEARER` | Bearer token presented as ``Authorization: Bearer ...`` to the host listen server. Auto-injected from the host's bearer-token file; required when ``server:sac`` is in ``spec.claude.channels`` (the runtime fails loud at launch otherwise). | `—` | string |
-| `SAC_INBOX_KEEPALIVE_S` | **Server side.** Seconds between keepalive comment frames (``: keepalive``) on an IDLE inbox SSE stream. A stream that never writes is indistinguishable from one that has died silently, which parks the subscriber forever and deafens the agent — so a malformed or non-positive value falls back to the default rather than disabling the beat. | `15` | float |
-| `SAC_MCP_SSE_READ_TIMEOUT_S` | **Client side** (``sac mcp channel``). Seconds of total silence on the inbox stream before the read is declared dead and the adapter re-dials with backoff. MUST stay comfortably above `SAC_INBOX_KEEPALIVE_S` (several missed beats) or a healthy stream is torn down every cycle. Never unbounded: "wait forever" is the bug, not a setting. | `60` | float |
+| `SAC_INBOX_KEEPALIVE_S` | Server: seconds between `: keepalive` frames on an IDLE inbox SSE stream. A silent stream is indistinguishable from a dead one, which parks the subscriber forever (silent deafness) — so a bad value falls back to the default rather than disabling the beat. | `15` | float |
+| `SAC_MCP_SSE_READ_TIMEOUT_S` | Client (`sac mcp channel`): seconds of silence before the inbox read is declared dead and the adapter re-dials. Keep well above `SAC_INBOX_KEEPALIVE_S`. Never unbounded — "wait forever" is the bug, not a setting. | `60` | float |
 
-The keepalive pair is the fleet's guard against SILENT deafness: a listen that
-vanishes **without closing the socket** (hard host death, wedged uvicorn, idle
-NAT/firewall drop) leaves the agent believing it is subscribed while the broker
-holds no subscriber for it. The beat gives the client bytes; the read deadline
-turns their absence into a reconnect. Reconnecting is cheap and idempotent (the
-stream replays undelivered rows on connect), so err toward re-dialling.
-
-**Deploy order — restart `sac listen` when you ship this.** The two halves are
-independent binaries (the host daemon; the in-SIF adapter), so they can be
-skewed, and only one skew is noisy:
-
-| skew | behaviour |
-|---|---|
-| new listen + **old** adapter | fine. The old adapter ignores `:` comment frames as content; the beat is simply unused. |
-| **new** adapter + old listen | the adapter gets no beats, so it re-dials every `SAC_MCP_SSE_READ_TIMEOUT_S` (~60s). Harmless and self-healing — it re-subscribes each time and undelivered rows are replayed, so **no message is lost** — but it looks like flapping in the logs until the daemon is restarted. |
-
-So restart the daemon (`systemctl --user restart sac-listen.service`) at or
-before the SIF rebuild that carries the new adapter, and the skew never appears.
+Deploy order: restart `sac listen` when shipping the beat. A NEW adapter against
+a not-yet-restarted daemon gets no beats and re-dials every ~60s — lossless and
+self-healing (rows replay on connect), but it looks like flapping.
 
 Fail-loud: when the broker runs in a SIF and ``SAC_LISTEN_BASE_URL`` is
 unset, ``sac agents start`` raises ``InSifBrokerError`` (apptainer

--- a/src/scitex_agent_container/_skills/scitex-agent-container/20_env-vars.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/20_env-vars.md
@@ -151,6 +151,18 @@ holds no subscriber for it. The beat gives the client bytes; the read deadline
 turns their absence into a reconnect. Reconnecting is cheap and idempotent (the
 stream replays undelivered rows on connect), so err toward re-dialling.
 
+**Deploy order — restart `sac listen` when you ship this.** The two halves are
+independent binaries (the host daemon; the in-SIF adapter), so they can be
+skewed, and only one skew is noisy:
+
+| skew | behaviour |
+|---|---|
+| new listen + **old** adapter | fine. The old adapter ignores `:` comment frames as content; the beat is simply unused. |
+| **new** adapter + old listen | the adapter gets no beats, so it re-dials every `SAC_MCP_SSE_READ_TIMEOUT_S` (~60s). Harmless and self-healing — it re-subscribes each time and undelivered rows are replayed, so **no message is lost** — but it looks like flapping in the logs until the daemon is restarted. |
+
+So restart the daemon (`systemctl --user restart sac-listen.service`) at or
+before the SIF rebuild that carries the new adapter, and the skew never appears.
+
 Fail-loud: when the broker runs in a SIF and ``SAC_LISTEN_BASE_URL`` is
 unset, ``sac agents start`` raises ``InSifBrokerError`` (apptainer
 runtime forgot to inject it). Never silently downgrades to "skip the

--- a/src/scitex_agent_container/_skills/scitex-agent-container/20_env-vars.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/20_env-vars.md
@@ -141,6 +141,15 @@ start`` against the bare host's apptainer.
 |---|---|---|---|
 | `SAC_LISTEN_BASE_URL` | Host-stable ``sac listen`` base URL the in-SIF CLI POSTs spawn requests against (also used by the in-container channel adapter to subscribe to the bus). Auto-injected by the apptainer runtime from ``listen.host`` / ``listen.port`` in ``~/.scitex/agent-container/config.yaml``. | `http://127.0.0.1:7878` | URL |
 | `SAC_LISTEN_BEARER` | Bearer token presented as ``Authorization: Bearer ...`` to the host listen server. Auto-injected from the host's bearer-token file; required when ``server:sac`` is in ``spec.claude.channels`` (the runtime fails loud at launch otherwise). | `—` | string |
+| `SAC_INBOX_KEEPALIVE_S` | **Server side.** Seconds between keepalive comment frames (``: keepalive``) on an IDLE inbox SSE stream. A stream that never writes is indistinguishable from one that has died silently, which parks the subscriber forever and deafens the agent — so a malformed or non-positive value falls back to the default rather than disabling the beat. | `15` | float |
+| `SAC_MCP_SSE_READ_TIMEOUT_S` | **Client side** (``sac mcp channel``). Seconds of total silence on the inbox stream before the read is declared dead and the adapter re-dials with backoff. MUST stay comfortably above `SAC_INBOX_KEEPALIVE_S` (several missed beats) or a healthy stream is torn down every cycle. Never unbounded: "wait forever" is the bug, not a setting. | `60` | float |
+
+The keepalive pair is the fleet's guard against SILENT deafness: a listen that
+vanishes **without closing the socket** (hard host death, wedged uvicorn, idle
+NAT/firewall drop) leaves the agent believing it is subscribed while the broker
+holds no subscriber for it. The beat gives the client bytes; the read deadline
+turns their absence into a reconnect. Reconnecting is cheap and idempotent (the
+stream replays undelivered rows on connect), so err toward re-dialling.
 
 Fail-loud: when the broker runs in a SIF and ``SAC_LISTEN_BASE_URL`` is
 unset, ``sac agents start`` raises ``InSifBrokerError`` (apptainer

--- a/src/scitex_agent_container/a2a/_inbox_bus.py
+++ b/src/scitex_agent_container/a2a/_inbox_bus.py
@@ -30,6 +30,7 @@ the same bearer-auth shape as the rest of sac listen.
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 import uuid
 from collections import defaultdict
@@ -39,6 +40,72 @@ from typing import Any
 # beyond that is almost certainly a misbehaving sender — we'd rather
 # drop oldest than block the publisher's HTTP handler.
 _QUEUE_CAP = 64
+
+
+class _Keepalive:
+    """Sentinel: the stream is IDLE — emit a beat, do NOT close."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return "KEEPALIVE"
+
+
+#: Returned by :meth:`Broker.get_or_close` when no event arrived within
+#: ``keepalive_after`` and the broker is NOT closing. Deliberately distinct
+#: from ``None`` (closing): "nothing has happened yet" and "stop" are
+#: different facts, and collapsing them into one is how a healthy idle
+#: stream gets torn down.
+KEEPALIVE = _Keepalive()
+
+# How often an IDLE inbox stream emits a keepalive comment frame.
+#
+# This is not cosmetic. A stream that never writes cannot be told apart from a
+# stream that has DIED, and the CLIENT is the one that pays: a connection that
+# died SILENTLY (no FIN, no RST — a hard host death, a wedged uvicorn, an idle
+# NAT/firewall flow drop) parks the consumer on an unbounded read forever. It
+# still believes it is subscribed; the broker holds no subscriber for it; every
+# message aimed at that agent lands on an empty bus. That is deafness with no
+# error raised anywhere, curable only by restarting the agent — the same shape
+# as the 2026-07-01 fleet-comms outage, which lived in the CONNECT path until
+# #591 bounded it. The READ path was left unbounded; the beat is what closes it,
+# by giving the client bytes so a bounded read deadline can fire and it can
+# re-dial (see ``_mcp/channel.py::_consume_sse``).
+#
+# Server-side, be precise about what this buys, because it is narrower than it
+# looks: uvicorn ALREADY reaps a subscriber whose client closes cleanly or
+# resets (it sees ``connection_lost`` and cancels the response, running the
+# stream's ``finally``). The beat adds nothing there. What it adds is that on an
+# idle stream the beat is the ONLY write, so a peer that vanished with NO TCP
+# signal at all will eventually error out on write (TCP retransmit timeout)
+# rather than holding its subscriber slot indefinitely — which keeps
+# ``subscriber_counts`` (and the ``delivered_subscriber_count`` that ``a2a_send``
+# fails loudly on) from indefinitely reporting a subscriber nobody can reach.
+DEFAULT_KEEPALIVE_INTERVAL_S = 15.0
+ENV_KEEPALIVE_INTERVAL_S = "SAC_INBOX_KEEPALIVE_S"
+
+
+def keepalive_interval_s() -> float:
+    """Seconds between keepalive beats on an idle inbox stream.
+
+    Read from the environment at CALL time, never baked into a module-level
+    constant at import: an import-time ``float(os.environ[...])`` cannot be
+    redirected by a test (or an operator) that sets the env afterwards, and a
+    knob that silently ignores its own env var is worse than no knob at all.
+
+    A malformed or non-positive value falls back to the default rather than
+    disabling the beat. Disabling it is precisely the silent-deafness footgun
+    this exists to prevent, so a typo must never buy it.
+    """
+    raw = os.environ.get(ENV_KEEPALIVE_INTERVAL_S)
+    if raw is None:
+        return DEFAULT_KEEPALIVE_INTERVAL_S
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_KEEPALIVE_INTERVAL_S
+    return value if value > 0 else DEFAULT_KEEPALIVE_INTERVAL_S
+
 
 # Canonical ``from_agent`` (sender) value for messages sac's OWN
 # daemon originates — as opposed to an agent's a2a reasoning, which
@@ -96,23 +163,40 @@ class Broker:
         self._closing.set()
 
     async def get_or_close(
-        self, q: asyncio.Queue[dict[str, Any]]
-    ) -> dict[str, Any] | None:
-        """Await the next event on ``q``, or ``None`` when the broker is
-        closing.
+        self,
+        q: asyncio.Queue[dict[str, Any]],
+        *,
+        keepalive_after: float | None = None,
+    ) -> dict[str, Any] | _Keepalive | None:
+        """Await the next event on ``q``. Three outcomes, never two.
+
+        * an **event** — deliver it;
+        * :data:`KEEPALIVE` — ``keepalive_after`` seconds passed with no event
+          and the broker is NOT closing. The stream is healthy and idle: beat,
+          do not close. Only returned when ``keepalive_after`` is set;
+        * ``None`` — the broker is closing. Stop.
 
         The SSE inbox-stream handlers loop on this instead of a bare
-        ``await q.get()``. A bare ``get()`` parks forever when no event
-        is flowing, so uvicorn's graceful shutdown (SIGTERM) waits on the
+        ``await q.get()``. A bare ``get()`` parks forever when no event is
+        flowing, so uvicorn's graceful shutdown (SIGTERM) waits on the
         in-flight stream until it force-cancels / ``sac listen restart
         --force`` escalates to SIGKILL after 10 s (card
-        ``sac-listen-sigterm-sse-shutdown-hang``). Racing ``get()``
-        against the shutdown Event lets the loop return the instant
-        :meth:`close` fires, so the daemon exits cleanly.
+        ``sac-listen-sigterm-sse-shutdown-hang``). Racing ``get()`` against
+        the shutdown Event lets the loop return the instant :meth:`close`
+        fires, so the daemon exits cleanly.
 
-        A live event still in flight when close fires is delivered (not
-        dropped) so a normal event landing on the same tick is not lost
-        to the shutdown race.
+        ``keepalive_after`` adds the third outcome so an idle stream can emit a
+        beat (see :func:`keepalive_interval_s` for why a silent stream is a
+        deafness bug in both directions). ``None`` keeps the original two-state
+        contract verbatim for callers that do not want beats.
+
+        **An event is never lost to a beat.** A live event still in flight when
+        the timeout (or close) fires is returned, not dropped: we check
+        ``get_task`` for a result BEFORE treating the wait as idle. And
+        cancelling a pending ``Queue.get()`` does not consume an item —
+        ``asyncio.Queue.get`` only calls ``get_nowait()`` after its getter
+        future resolves, so an item that arrives in the cancellation race stays
+        queued and the next call picks it up.
         """
         if self._closing.is_set():
             return None
@@ -120,7 +204,9 @@ class Broker:
         close_task = asyncio.ensure_future(self._closing.wait())
         try:
             await asyncio.wait(
-                {get_task, close_task}, return_when=asyncio.FIRST_COMPLETED
+                {get_task, close_task},
+                return_when=asyncio.FIRST_COMPLETED,
+                timeout=keepalive_after,
             )
         except asyncio.CancelledError:
             # The whole stream is being cancelled (client gone, or
@@ -130,8 +216,9 @@ class Broker:
             get_task.cancel()
             close_task.cancel()
             raise
-        # Prefer a delivered event even if close fired on the same tick —
-        # an event already pulled off the queue must not be dropped.
+        # Prefer a delivered event even if close (or the keepalive timeout)
+        # fired on the same tick — an event already pulled off the queue must
+        # not be dropped.
         if (
             get_task.done()
             and not get_task.cancelled()
@@ -139,10 +226,17 @@ class Broker:
         ):
             close_task.cancel()
             return get_task.result()
-        # Closing won (or the queue errored) — abandon the pending get and
-        # signal the loop to stop.
+        # No event. Abandon the pending get (the item, if any, stays queued)
+        # and decide WHY we woke: shutdown, or merely an idle stream.
         get_task.cancel()
         close_task.cancel()
+        if self._closing.is_set():
+            return None
+        if keepalive_after is not None:
+            # Idle, not closing. This is the distinction the whole ternary
+            # exists for: reporting "closed" here would tear down a perfectly
+            # healthy stream every keepalive interval.
+            return KEEPALIVE
         return None
 
     async def subscribe(self, agent: str) -> asyncio.Queue[dict[str, Any]]:
@@ -375,7 +469,11 @@ def mint_acl_deny_synthetic_notification(
 
 __all__ = [
     "DAEMON_SENDER",
+    "DEFAULT_KEEPALIVE_INTERVAL_S",
+    "ENV_KEEPALIVE_INTERVAL_S",
+    "KEEPALIVE",
     "Broker",
+    "keepalive_interval_s",
     "mint_event",
     "mint_deny_notification",
     "mint_acl_deny_synthetic_notification",

--- a/src/scitex_agent_container/a2a/_inbox_stream.py
+++ b/src/scitex_agent_container/a2a/_inbox_stream.py
@@ -1,0 +1,174 @@
+"""The per-agent sidecar's inbox SSE stream (extracted from ``_server.py``).
+
+Serves ``GET /agents/<name>/inbox/stream`` on an agent's own a2a port — the
+A2A-facing twin of the host control plane's stream in
+:mod:`.._listen._node_channel`. Split out of :mod:`._server` (which sat over
+the per-file line cap) exactly as ``node_inbox_stream`` was split out of
+``_listen/server.py``: one cohesive responsibility per file, and the original
+keeps a thin delegate so route registration and every historical import path
+are unchanged.
+
+The two streams are the SAME primitive and must not drift. Both:
+
+  * emit one comment frame on connect so a client can detect "subscribed"
+    without waiting for traffic;
+  * replay durable ``channel_events`` rows before accepting live events, so an
+    event published while nobody was subscribed is delivered on connect;
+  * BEAT when idle (see below);
+  * unsubscribe in a ``finally`` so the broker's subscriber count is honest.
+
+Why an idle stream must still write
+-----------------------------------
+A stream that goes silent when there is nothing to say cannot be told apart from
+a stream that has DIED silently — no FIN, no RST, just a socket nobody will ever
+speak on again (a hard host death, a wedged uvicorn, an idle NAT/firewall flow
+drop). The CLIENT then parks on an unbounded read believing it is subscribed,
+while the broker holds no subscriber for it: every message aimed at that agent
+lands on an empty bus, with no error raised anywhere, until someone restarts the
+agent.
+
+The keepalive beat gives the client bytes, so a bounded read deadline can fire
+and it can re-dial. See :func:`.._inbox_bus.keepalive_interval_s` — including
+the precise (and narrower) note on what the beat does and does not buy on the
+SERVER side.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+
+from scitex_agent_container._state.state_db_channel import (
+    list_since_id,
+    list_undelivered,
+    mark_delivered,
+)
+from scitex_agent_container.a2a._inbox_bus import KEEPALIVE, keepalive_interval_s
+
+__all__ = ["inbox_stream"]
+
+
+async def inbox_stream(request: Request, ctx: Any) -> Response:
+    """SSE: one frame per inbound event addressed to ``/agents/<name>``.
+
+    Consumed by ``sac mcp channel`` inside the agent's container — each frame
+    turns into a ``notifications/claude/channel`` push so Claude sees
+    ``<channel source="..." msg_id="..." ...>`` tags in real time. Plain SSE,
+    so non-sac A2A clients work too.
+
+    Durability / replay-on-reconnect (handoff §4):
+
+      * On connect, replay missed events from the persistent ``channel_events``
+        table BEFORE accepting any new live event. Replay source:
+
+          - if the client passed ``Last-Event-ID``, replay every row with
+            ``id > Last-Event-ID``;
+          - otherwise replay every undelivered row (the fresh-subscriber case —
+            handoff acceptance "an event POSTed with no subscriber is delivered
+            on connect").
+
+      * Each replay frame stamps the SQLite row id onto the SSE ``id:`` line so
+        the client can echo it back as ``Last-Event-ID`` after a reconnect.
+
+      * After yielding a replay frame the row is marked ``delivered_at`` so a
+        subsequent fresh-subscriber connect does not re-yield it.
+
+      * A malformed ``Last-Event-ID`` is a loud 400 — a corrupt cursor would
+        silently disable replay if tolerated.
+    """
+    name = request.path_params["name"]
+    if name not in ctx.yamls:
+        return JSONResponse({"error": f"unknown agent: {name}"}, status_code=404)
+
+    last_event_id_raw = request.headers.get("last-event-id")
+    last_event_id: int | None = None
+    if last_event_id_raw is not None:
+        # Loud failure on a malformed header: a corrupt cursor would silently
+        # disable replay if we tolerated it.
+        try:
+            last_event_id = int(last_event_id_raw)
+        except ValueError:
+            return JSONResponse(
+                {
+                    "error": (
+                        "Last-Event-ID header must be an integer; got "
+                        f"{last_event_id_raw!r}"
+                    )
+                },
+                status_code=400,
+            )
+
+    broker = ctx.inbox
+    queue = await broker.subscribe(name)
+
+    async def stream():
+        try:
+            # Comment-only frame so HTTP clients see the connection open
+            # before any real event arrives.
+            yield b": sac-channel ready\n\n"
+
+            # Replay missed events from state.db. Mark each row delivered as
+            # soon as we ship its SSE frame so a second fresh subscriber does
+            # not re-receive it.
+            if last_event_id is not None:
+                replay = list_since_id(target=name, since_id=last_event_id)
+            else:
+                replay = list_undelivered(target=name)
+            for entry in replay:
+                if await request.is_disconnected():
+                    return
+                row_id = entry["id"]
+                event = entry["event"]
+                # Strip the internal ``_row_id`` if a publish path stored it
+                # inside ``meta_json``; the SSE ``id:`` line is the
+                # authoritative cursor.
+                event.pop("_row_id", None)
+                data = json.dumps(event, ensure_ascii=False)
+                yield (f"id: {row_id}\nevent: message\ndata: {data}\n\n").encode(
+                    "utf-8"
+                )
+                mark_delivered([row_id])
+
+            beat_s = keepalive_interval_s()
+            while True:
+                if await request.is_disconnected():
+                    return
+                # Three outcomes, never two: an event, a beat, or "closing".
+                # ``get_or_close`` races the queue against the broker's
+                # shutdown Event so a graceful SIGTERM cancels this in-flight
+                # stream promptly instead of parking here.
+                event = await broker.get_or_close(queue, keepalive_after=beat_s)
+                if event is None:
+                    return
+                if event is KEEPALIVE:
+                    # Idle — beat. Invisible as CONTENT (a ':' line is an SSE
+                    # comment), but it is what lets a client tell "quiet" from
+                    # "silently dead" and re-dial rather than park forever.
+                    yield b": keepalive\n\n"
+                    continue
+                # The publish path stamps the persisted row id onto the
+                # envelope as ``_row_id``. Surface it as the SSE ``id:`` line
+                # and mark the row delivered.
+                row_id = event.pop("_row_id", None)
+                data = json.dumps(event, ensure_ascii=False)
+                if row_id is not None:
+                    yield (f"id: {row_id}\nevent: message\ndata: {data}\n\n").encode(
+                        "utf-8"
+                    )
+                    mark_delivered([int(row_id)])
+                else:
+                    # No row id means the event was injected by a path that did
+                    # NOT persist (lifecycle fan-out, ACL-reject notice, …).
+                    # Deliver it but skip the marker.
+                    yield f"event: message\ndata: {data}\n\n".encode("utf-8")
+        finally:
+            await broker.unsubscribe(name, queue)
+
+    return StreamingResponse(
+        stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/src/scitex_agent_container/a2a/_server.py
+++ b/src/scitex_agent_container/a2a/_server.py
@@ -43,9 +43,6 @@ from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
 from scitex_agent_container._state.state_db_channel import (
-    list_since_id,
-    list_undelivered,
-    mark_delivered,
     persist_event,
 )
 from scitex_agent_container.a2a._card import (
@@ -57,6 +54,7 @@ from scitex_agent_container.a2a._card import (
 )
 from scitex_agent_container.a2a._handlers import HANDLERS
 from scitex_agent_container.a2a._inbox_bus import Broker, mint_event
+from scitex_agent_container.a2a._inbox_stream import inbox_stream
 
 log = logging.getLogger(__name__)
 
@@ -227,112 +225,15 @@ def _build_app(ctx: _ServerCtx) -> Starlette:
         return await sdk_route.endpoint(request)  # type: ignore[no-any-return]
 
     async def get_inbox_stream(request: Request) -> Response:
-        """SSE: one frame per inbound event addressed to /agents/<name>.
+        """SSE inbox stream for ``/agents/<name>`` — see :mod:`._inbox_stream`.
 
-        Consumed by `sac mcp channel` (commit 2) inside the agent's
-        container — each frame turns into a notifications/claude/channel
-        push so Claude sees `<channel source="..." msg_id="..." ...>`
-        tags in real time. Plain SSE — non-sac A2A clients work too.
-
-        WI-1 durability semantics (handoff §4 "Durability /
-        replay-on-reconnect"):
-
-          * On connect, the handler replays missed events from the
-            persistent ``channel_events`` table BEFORE accepting any
-            new live events. Replay source:
-
-              - if the client passed ``Last-Event-ID``, replay every
-                row with ``id > Last-Event-ID``;
-              - otherwise replay every undelivered row (the fresh-
-                subscriber case — handoff acceptance "an event POSTed
-                with no subscriber is delivered on connect").
-
-          * Each replay frame stamps the SQLite row id onto the SSE
-            ``id:`` line so the client can echo it back as
-            ``Last-Event-ID`` after a reconnect.
-
-          * After yielding a replay frame the handler marks that row
-            ``delivered_at`` so a subsequent fresh-subscriber connect
-            does not re-yield it.
+        Thin delegate. The handler lives in its own module so this file stays
+        under the per-file cap, and so the sidecar's stream and the host listen's
+        stream (``_listen/_node_channel.node_inbox_stream``) stay visibly the
+        same primitive rather than drifting apart — they must agree on connect
+        frame, durable replay, the idle KEEPALIVE beat, and unsubscribe-on-exit.
         """
-        name = request.path_params["name"]
-        if name not in ctx.yamls:
-            return JSONResponse({"error": f"unknown agent: {name}"}, status_code=404)
-        from starlette.responses import StreamingResponse
-
-        last_event_id_raw = request.headers.get("last-event-id")
-        last_event_id: int | None = None
-        if last_event_id_raw is not None:
-            # Loud failure on a malformed header: a corrupt cursor
-            # would silently disable replay if we tolerated it.
-            try:
-                last_event_id = int(last_event_id_raw)
-            except ValueError:
-                return JSONResponse(
-                    {
-                        "error": (
-                            "Last-Event-ID header must be an integer; got "
-                            f"{last_event_id_raw!r}"
-                        )
-                    },
-                    status_code=400,
-                )
-
-        queue = await ctx.inbox.subscribe(name)
-
-        async def stream():
-            try:
-                # Send a comment-only frame so HTTP clients see the
-                # connection open before any real event arrives.
-                yield b": sac-channel ready\n\n"
-
-                # WI-1: replay missed events from state.db. Mark each
-                # row delivered as soon as we ship its SSE frame so a
-                # second fresh subscriber does not re-receive it.
-                if last_event_id is not None:
-                    replay = list_since_id(target=name, since_id=last_event_id)
-                else:
-                    replay = list_undelivered(target=name)
-                for entry in replay:
-                    if await request.is_disconnected():
-                        return
-                    row_id = entry["id"]
-                    event = entry["event"]
-                    data = json.dumps(event, ensure_ascii=False)
-                    yield (f"id: {row_id}\nevent: message\ndata: {data}\n\n").encode(
-                        "utf-8"
-                    )
-                    mark_delivered([row_id])
-
-                while True:
-                    if await request.is_disconnected():
-                        return
-                    event = await queue.get()
-                    # The publish path stamps the persisted row id onto
-                    # the envelope as ``_row_id`` (see
-                    # :func:`_publish_channel_event`). We surface it
-                    # as the SSE ``id:`` and mark the row delivered.
-                    row_id = event.pop("_row_id", None)
-                    data = json.dumps(event, ensure_ascii=False)
-                    if row_id is not None:
-                        yield (
-                            f"id: {row_id}\nevent: message\ndata: {data}\n\n"
-                        ).encode("utf-8")
-                        mark_delivered([int(row_id)])
-                    else:
-                        # No row id means the event was injected by a
-                        # path that did NOT persist (lifecycle event
-                        # fan-out, future ACL-reject notice, …).
-                        # Deliver it but skip the marker.
-                        yield f"event: message\ndata: {data}\n\n".encode("utf-8")
-            finally:
-                await ctx.inbox.unsubscribe(name, queue)
-
-        return StreamingResponse(
-            stream(),
-            media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-        )
+        return await inbox_stream(request, ctx)
 
     async def get_active_tasks(request: Request) -> Response:
         """Sac-side observability: list every task currently in the

--- a/tests/scitex_agent_container/_listen/test__node_channel_keepalive.py
+++ b/tests/scitex_agent_container/_listen/test__node_channel_keepalive.py
@@ -1,0 +1,126 @@
+"""The listen inbox stream BEATS when idle.
+
+This is the stream every sac agent subscribes to (``sac mcp channel`` →
+``GET /agents/<name>/inbox/stream`` on the host listen). It used to write one
+frame on connect and then go silent until an event arrived — and a stream that
+never writes cannot be told apart from one that has DIED.
+
+That is the client's problem, and it is the one that matters: with no bytes ever
+arriving, a connection that died silently (no FIN, no RST — a hard host death, a
+wedged uvicorn, an idle NAT/firewall flow drop) parks the consumer on an
+unbounded read forever. It believes it is subscribed; the broker holds no
+subscriber for it; every message aimed at that agent lands on an empty bus.
+Deafness, with nothing logged anywhere, curable only by restarting the agent.
+The beat gives the client bytes to read, so a bounded read deadline can fire and
+it can re-dial. See ``_mcp/channel.py::_consume_sse``.
+
+Scope note, so nobody inherits a claim this file does not prove: uvicorn ALREADY
+reaps a subscriber whose client closes cleanly or resets the connection (it sees
+``connection_lost`` and cancels the response, which runs the stream's
+``finally``). The beat adds nothing there. What it adds server-side is narrower:
+on an idle stream the beat is the ONLY write, so a peer that vanished with no TCP
+signal at all will eventually surface an error on write (TCP retransmit timeout)
+instead of holding its subscriber slot indefinitely. That path takes minutes and
+is not exercised here — it is a consequence, not a claim under test.
+
+Runs a REAL uvicorn over a real loopback socket against the real ``create_app``
+— the only seam is the network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import socket
+
+import httpx
+import pytest
+import uvicorn
+
+from scitex_agent_container._listen.server import create_app
+from tests.scitex_agent_container._helpers.loopback_server import (
+    await_until_serving,
+    serve_in_thread,
+)
+
+TOKEN = "test-token-keepalive"
+AGENT = "keepalive-bob"
+
+# Beat fast so the tests take milliseconds, not a minute.
+BEAT_S = "0.2"
+
+
+@pytest.fixture
+def fast_beat_env():
+    """Set the REAL env var the server reads for its beat cadence, then restore.
+
+    The interval is resolved at CALL time precisely so a deployment (or a test)
+    can steer it — this exercises that real path rather than rewriting an
+    internal.
+    """
+    key = "SAC_INBOX_KEEPALIVE_S"
+    previous = os.environ.get(key)
+    os.environ[key] = BEAT_S
+    try:
+        yield float(BEAT_S)
+    finally:
+        if previous is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = previous
+
+
+@pytest.fixture
+def free_port() -> int:
+    with contextlib.closing(socket.socket()) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+async def _serve(port: int):
+    app = create_app(token=TOKEN)
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=port, log_level="warning", ws="none"
+    )
+    server = uvicorn.Server(config)
+    thread, crash = serve_in_thread(server, port)
+    await await_until_serving(server, thread, port=port, crash=crash)
+    return app, server, thread
+
+
+@pytest.mark.asyncio
+async def test_idle_inbox_stream_emits_keepalive_frames(fast_beat_env, free_port):
+    # Arrange — subscribe and then publish NOTHING. Under the old handler this
+    # connection would receive exactly one frame ever and then fall silent.
+    app, server, thread = await _serve(free_port)
+    headers = {"authorization": f"Bearer {TOKEN}"}
+    beats: list[str] = []
+
+    async def subscribe() -> None:
+        async with httpx.AsyncClient(
+            base_url=f"http://127.0.0.1:{free_port}", timeout=10.0
+        ) as ac:
+            async with ac.stream(
+                "GET", f"/agents/{AGENT}/inbox/stream", headers=headers
+            ) as sse:
+                async for line in sse.aiter_lines():
+                    if line.startswith(":") and "keepalive" in line:
+                        beats.append(line)
+                        if len(beats) >= 2:
+                            return
+
+    # Act — wait for two beats on a stream with zero traffic.
+    task = asyncio.create_task(subscribe())
+    try:
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(task, timeout=10.0)
+    finally:
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(BaseException):
+                await task
+        server.should_exit = True
+        thread.join(timeout=5.0)
+    # Assert — an idle stream keeps speaking, so a client can tell it is alive.
+    assert len(beats) >= 2

--- a/tests/scitex_agent_container/_listen/test__node_channel_keepalive.py
+++ b/tests/scitex_agent_container/_listen/test__node_channel_keepalive.py
@@ -71,8 +71,13 @@ def fast_beat_env():
             os.environ[key] = previous
 
 
-@pytest.fixture
-def free_port() -> int:
+def _free_port() -> int:
+    """Pick a free loopback port.
+
+    A plain helper, deliberately NOT a fixture: STX-TQ005 forbids a fixture from
+    acquiring an external resource, and the same convention is already used by
+    the sibling suites (see ``test__nodes.py::_sse_roundtrip``).
+    """
     with contextlib.closing(socket.socket()) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
@@ -90,16 +95,17 @@ async def _serve(port: int):
 
 
 @pytest.mark.asyncio
-async def test_idle_inbox_stream_emits_keepalive_frames(fast_beat_env, free_port):
+async def test_idle_inbox_stream_emits_keepalive_frames(fast_beat_env):
     # Arrange — subscribe and then publish NOTHING. Under the old handler this
     # connection would receive exactly one frame ever and then fall silent.
-    app, server, thread = await _serve(free_port)
+    port = _free_port()
+    app, server, thread = await _serve(port)
     headers = {"authorization": f"Bearer {TOKEN}"}
     beats: list[str] = []
 
     async def subscribe() -> None:
         async with httpx.AsyncClient(
-            base_url=f"http://127.0.0.1:{free_port}", timeout=10.0
+            base_url=f"http://127.0.0.1:{port}", timeout=10.0
         ) as ac:
             async with ac.stream(
                 "GET", f"/agents/{AGENT}/inbox/stream", headers=headers

--- a/tests/scitex_agent_container/_mcp/test_channel_reconnect.py
+++ b/tests/scitex_agent_container/_mcp/test_channel_reconnect.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from typing import Any
 
 import pytest
@@ -274,3 +275,134 @@ async def test_consume_sse_reconnects_after_server_starts_late():
     # callback, proving the consumer kept retrying through the
     # unreachable window.
     assert received and received[0]["msg_id"] == "late-start"
+
+
+# ---------------------------------------------------------------------------
+# Reconnect when the stream dies SILENTLY — no FIN, no RST, just a socket
+# nobody will ever speak on again.
+#
+# This is the failure mode the two tests above CANNOT see: they close the
+# connection, so the client gets an EOF and obviously loops. A real listen can
+# vanish without closing (hard host death, wedged uvicorn, an idle NAT/firewall
+# flow drop). With an unbounded read the consumer then parks inside
+# ``aiter_lines()`` forever, still believing it is subscribed while the broker
+# holds no subscriber for it — deafness with no error raised anywhere, curable
+# only by restarting the agent. That is the same shape as the bug #591 fixed in
+# the CONNECT path, surviving in the READ path.
+# ---------------------------------------------------------------------------
+
+
+class _SilentStallServer:
+    """Accepts, sends SSE headers, then goes SILENT — never writes, never closes.
+
+    Faithful to a peer that died without closing its socket: from the client's
+    side the connection is still ESTABLISHED and simply has nothing to say.
+    """
+
+    def __init__(self) -> None:
+        self.connection_count = 0
+        self._server: asyncio.base_events.Server | None = None
+        self._held: list[asyncio.StreamWriter] = []
+        self.host = "127.0.0.1"
+        self.port = 0
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(self._handle, host=self.host, port=0)
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def stop(self) -> None:
+        for w in self._held:
+            try:
+                w.close()
+            except Exception:  # stx-allow: defensive on writer close
+                pass
+        self._held.clear()
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        self.connection_count += 1
+        await reader.readline()
+        while True:
+            line = await reader.readline()
+            if line in (b"\r\n", b"\n", b""):
+                break
+        writer.write(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: text/event-stream\r\n"
+            b"Cache-Control: no-cache\r\n"
+            b"Connection: keep-alive\r\n"
+            b"\r\n"
+            b": sac-channel ready\n\n"
+        )
+        await writer.drain()
+        # ...and now say nothing, forever. Hold the writer open so the socket
+        # is never closed — the client must time out the READ to escape.
+        self._held.append(writer)
+
+
+@pytest_asyncio.fixture
+async def silent_stall_server():
+    server = _SilentStallServer()
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+@pytest.fixture
+def fast_read_deadline():
+    """Squeeze the SSE read deadline to 1s so this test runs in seconds.
+
+    Sets the REAL env var the production code reads (and restores it), rather
+    than rewriting an internal — the read deadline is resolved from the
+    environment at CALL time precisely so a deployment (or a test) can steer it.
+    """
+    key = "SAC_MCP_SSE_READ_TIMEOUT_S"
+    previous = os.environ.get(key)
+    os.environ[key] = "1"
+    try:
+        yield 1.0
+    finally:
+        if previous is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = previous
+
+
+@pytest.mark.asyncio
+async def test_consume_sse_reconnects_when_stream_goes_silent(
+    silent_stall_server, fast_read_deadline
+):
+    # Arrange — a server that opens the stream and then never speaks again and
+    # never hangs up.
+    received: list[dict[str, Any]] = []
+
+    async def on_event(ev: dict[str, Any]) -> None:
+        received.append(ev)
+
+    url = f"{silent_stall_server.base_url}/agents/alice/inbox/stream"
+    task = asyncio.create_task(_consume_sse(url, bearer=None, on_event=on_event))
+    # Act — wait long enough for the read deadline to fire and the backoff to
+    # bring the consumer back around for a second connect.
+    for _ in range(120):
+        if silent_stall_server.connection_count >= 2:
+            break
+        await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+    # Assert — it re-dialled. With an unbounded read this stays at 1 forever:
+    # the consumer is wedged, the agent is deaf, and nothing anywhere errors.
+    assert silent_stall_server.connection_count >= 2

--- a/tests/scitex_agent_container/_mcp/test_channel_reconnect.py
+++ b/tests/scitex_agent_container/_mcp/test_channel_reconnect.py
@@ -37,7 +37,7 @@ from typing import Any
 import pytest
 import pytest_asyncio
 
-from scitex_agent_container._mcp.channel import _consume_sse
+from scitex_agent_container._mcp.channel import _consume_sse, _jittered_backoff
 
 # ---------------------------------------------------------------------------
 # Servers — minimal asyncio TCP servers speaking SSE, with controllable
@@ -406,3 +406,34 @@ async def test_consume_sse_reconnects_when_stream_goes_silent(
     # Assert — it re-dialled. With an unbounded read this stays at 1 forever:
     # the consumer is wedged, the agent is deaf, and nothing anywhere errors.
     assert silent_stall_server.connection_count >= 2
+
+
+# ---------------------------------------------------------------------------
+# Jittered backoff — the thundering herd.
+#
+# Every agent on a host subscribes to the SAME listen, so when it goes away they
+# all lose the stream in the same instant and climb an IDENTICAL ladder (0.5s,
+# 1s, 2s, 4s …), re-dialling in lockstep at a process that is by definition
+# mid-restart. ~14 adapters landing together on every rung is a good way to
+# knock over the thing they are all waiting for.
+# ---------------------------------------------------------------------------
+
+
+def test_jittered_backoff_stays_within_its_window():
+    # Arrange — jitter must not extend the ladder: a retry still lands inside
+    # its own backoff window, so recovery latency is unchanged.
+    window = 8.0
+    # Act
+    samples = [_jittered_backoff(window) for _ in range(200)]
+    # Assert — equal jitter: never below half the window, never above it.
+    assert all(window / 2 <= s <= window for s in samples)
+
+
+def test_jittered_backoff_decorrelates_retries():
+    # Arrange — the whole point: two adapters that lost the stream in the same
+    # instant must NOT re-dial at the same moment.
+    window = 8.0
+    # Act
+    samples = [_jittered_backoff(window) for _ in range(200)]
+    # Assert — a fixed backoff would collapse to one value; jitter spreads them.
+    assert len(set(samples)) > 100

--- a/tests/scitex_agent_container/a2a/test__inbox_bus_keepalive.py
+++ b/tests/scitex_agent_container/a2a/test__inbox_bus_keepalive.py
@@ -1,0 +1,167 @@
+"""The inbox bus's idle KEEPALIVE beat — three outcomes, never two.
+
+``Broker.get_or_close`` used to answer a binary question: an event, or ``None``
+meaning "closing". An idle stream is neither, and with only two answers the SSE
+handler had to park forever waiting for one of them. A stream that never writes
+cannot be told apart from a stream that has DIED silently (no FIN, no RST), so:
+
+  * the CLIENT parks on an unbounded read believing it is subscribed;
+  * the SERVER keeps the subscriber's queue registered, reports a PHANTOM
+    subscriber, and ``a2a_send`` claims a delivery nobody will ever read.
+
+:data:`KEEPALIVE` is the third answer — "idle, and healthy". These tests pin the
+contract, and above all pin the property a beat must never violate: **an event
+must never be lost to it.**
+
+Real ``asyncio.Queue`` + the real ``Broker``; no mocks.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from scitex_agent_container.a2a._inbox_bus import (
+    DEFAULT_KEEPALIVE_INTERVAL_S,
+    ENV_KEEPALIVE_INTERVAL_S,
+    KEEPALIVE,
+    Broker,
+    keepalive_interval_s,
+    mint_event,
+)
+
+
+@pytest.fixture
+def keepalive_env():
+    """Set the REAL env var the production code reads, and restore it after.
+
+    The interval is resolved from the environment at CALL time precisely so a
+    deployment (or a test) can steer it; this exercises that real path rather
+    than rewriting an internal.
+    """
+    previous = os.environ.get(ENV_KEEPALIVE_INTERVAL_S)
+
+    def _set(value: str) -> None:
+        os.environ[ENV_KEEPALIVE_INTERVAL_S] = value
+
+    try:
+        yield _set
+    finally:
+        if previous is None:
+            os.environ.pop(ENV_KEEPALIVE_INTERVAL_S, None)
+        else:
+            os.environ[ENV_KEEPALIVE_INTERVAL_S] = previous
+
+
+@pytest.fixture
+def no_keepalive_env():
+    """Guarantee the interval env var is ABSENT, restoring any prior value."""
+    previous = os.environ.pop(ENV_KEEPALIVE_INTERVAL_S, None)
+    try:
+        yield
+    finally:
+        if previous is not None:
+            os.environ[ENV_KEEPALIVE_INTERVAL_S] = previous
+
+
+@pytest.mark.asyncio
+async def test_idle_stream_returns_keepalive_sentinel():
+    # Arrange — a subscriber with nothing to receive.
+    broker = Broker()
+    queue = await broker.subscribe("alice")
+    # Act — wait past the beat interval with no event published.
+    result = await broker.get_or_close(queue, keepalive_after=0.05)
+    # Assert — idle reports KEEPALIVE, NOT None. Returning None here would tear
+    # down a perfectly healthy stream on every interval.
+    assert result is KEEPALIVE
+
+
+@pytest.mark.asyncio
+async def test_pending_event_wins_over_keepalive_beat():
+    # Arrange — an event is already queued when the beat interval elapses.
+    broker = Broker()
+    queue = await broker.subscribe("alice")
+    await broker.publish("alice", mint_event("alice", content="hi"))
+    # Act
+    result = await broker.get_or_close(queue, keepalive_after=0.05)
+    # Assert — the event is delivered, never shadowed by a beat.
+    assert result["content"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_event_survives_repeated_keepalive_beats():
+    # Arrange — THE safety property. Each beat abandons a pending ``Queue.get()``;
+    # if that cancellation could consume an item, every keepalive interval would
+    # be a chance to silently eat a message.
+    broker = Broker()
+    queue = await broker.subscribe("alice")
+    for _ in range(5):
+        await broker.get_or_close(queue, keepalive_after=0.02)
+    # Act — publish AFTER five beats have come and gone, then read.
+    await broker.publish("alice", mint_event("alice", content="survived"))
+    result = await broker.get_or_close(queue, keepalive_after=1.0)
+    # Assert
+    assert result["content"] == "survived"
+
+
+@pytest.mark.asyncio
+async def test_closing_broker_returns_none_not_keepalive():
+    # Arrange — a graceful shutdown must still stop the stream, beats or no.
+    broker = Broker()
+    queue = await broker.subscribe("alice")
+    broker.close()
+    # Act
+    result = await broker.get_or_close(queue, keepalive_after=5.0)
+    # Assert — None (stop), not KEEPALIVE (keep beating).
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_omitted_interval_keeps_two_state_contract():
+    # Arrange — callers passing no interval must see the ORIGINAL contract: an
+    # event, or None. A surprise third value would break them.
+    broker = Broker()
+    queue = await broker.subscribe("alice")
+    broker.close()
+    # Act
+    result = await broker.get_or_close(queue)
+    # Assert
+    assert result is None
+
+
+def test_interval_defaults_when_env_absent(no_keepalive_env):
+    # Arrange — no override set.
+    expected = DEFAULT_KEEPALIVE_INTERVAL_S
+    # Act
+    value = keepalive_interval_s()
+    # Assert
+    assert value == expected
+
+
+def test_malformed_interval_env_falls_back_to_default(keepalive_env):
+    # Arrange — a typo must NOT disable the beat: a disabled beat is the
+    # silent-deafness footgun this whole mechanism exists to prevent.
+    keepalive_env("not-a-number")
+    # Act
+    value = keepalive_interval_s()
+    # Assert
+    assert value == DEFAULT_KEEPALIVE_INTERVAL_S
+
+
+def test_nonpositive_interval_env_falls_back_to_default(keepalive_env):
+    # Arrange — same reasoning for 0 / negative: never buy "never beat again".
+    keepalive_env("0")
+    # Act
+    value = keepalive_interval_s()
+    # Assert
+    assert value == DEFAULT_KEEPALIVE_INTERVAL_S
+
+
+def test_valid_interval_env_overrides_default(keepalive_env):
+    # Arrange — a deployment must be able to steer the cadence.
+    keepalive_env("3.5")
+    # Act
+    value = keepalive_interval_s()
+    # Assert
+    assert value == 3.5


### PR DESCRIPTION
## The failure this was sent to fix

The card (deferred 313h): *a `sac listen` restart silently deafens every surviving agent; `a2a_send` to scitex-writer / scitex-scholar / openalex-local / crossref-local all returned `delivered_subscriber_count=0`, and the workaround was a manual restart of all 14 agents.*

**That specific bug is already fixed, and I could not reproduce it. I am not claiming a fix for it.** What I found instead is the same bug one layer down, still wide open. The difference matters for what you deploy, so here is the evidence.

## What I measured

**1. A live adapter DOES re-subscribe across a real listen restart, on today's `develop`.**

I ran the real channel adapter (`sac mcp channel` — the exact binary and code path agents run) in its own cgroup, and restarted `sac-listen.service` under it:

```
listen pid before restart : 1687   →  after: 540411   (real restart)
adapter pid 533455 stayed alive, untouched
[+  5s] inbox_subscribers=1  reachable
[+ 64s] inbox_subscribers=1  reachable
[+123s] inbox_subscribers=1  reachable
```

It dropped, backed off, re-dialled, re-subscribed — in under 5 seconds.

**2. The "05:42 before/after split" is confounded.** A registry row **outlives the process**, so a *stopped* agent reads `inbox_subscribers=0` exactly like a deaf one. Every 0-subscriber agent I sampled was a corpse:

```
claude-code-telegrammer (pid 19131): NO SUCH PID    scitex-todo    (pid  505303): NO SUCH PID
dotfiles                (pid 2151240): NO SUCH PID  scitex-dev     (pid 1422425): NO SUCH PID
neurovista-paper-writer (pid 496066): NO SUCH PID   scitex-scholar (pid 3407892): NO SUCH PID

host tmux: only tui-grant + tui-scitex-agent-container alive — and both read inbox_subscribers=1
```

The agents "started after 05:42" were not fine *because* they started after the restart. They were fine because they were the only ones **alive**.

**3. The original incident's root cause — found, and fixed 5 days ago.** Before `56c9afb0` (2026-07-09, #591) the adapter used `httpx.AsyncClient(timeout=None)`: **connect was unbounded**. During the 2026-07-01 1.7h outage every reconnect attempt hung forever inside `client.stream(...)`, so the backoff loop never came around. Agent alive, permanently unsubscribed, curable only by a restart — the incident and its workaround, exactly. #591 bounded connect at 30s and the reconnect loop came back to life. The card was simply never closed.

## The hole that is still open — what this PR fixes

#591 bounded CONNECT. It left **READ unbounded** (`read=None`), and `sac listen` **never writes to an idle stream** (one frame on connect, then silence until an event arrives).

So a stream that is *quiet* is byte-for-byte indistinguishable from a stream that has **died silently** — no FIN, no RST: a hard host death, a wedged uvicorn, an idle NAT/firewall flow drop. The adapter parks inside `aiter_lines()` **forever**. It believes it is subscribed; the broker holds no subscriber for it; every message aimed at that agent lands on an empty bus. **Deafness, with no error raised anywhere, curable only by restarting the agent** — the same outcome as the original incident, reached through a different door.

Proven, not asserted — a real socket that accepts, sends headers, then goes silent and never closes:

```
[0.1s] line=': ready'
[1.1s] RAISED ReadTimeout          ← with this PR
       (without it: hangs forever, zero reconnects)
```

**The fix, at both ends:**

- **server** — `sac listen` beats `: keepalive` down every idle inbox stream (`SAC_INBOX_KEEPALIVE_S`, default 15s), so a healthy stream is never silent.
- **client** — `sac mcp channel` bounds the read (`SAC_MCP_SSE_READ_TIMEOUT_S`, default 60s = several missed beats), so silence raises `ReadTimeout`, which the existing backoff loop already turns into a re-dial + re-subscribe.

Reconnecting is cheap and idempotent (the stream replays undelivered rows on connect), so a false positive costs one reconnect — a false negative costs the agent every message it will ever be sent.

## Second commit: jitter the reconnect ladder (the thundering herd)

Directly relevant to the ~14 agents about to be relaunched, and an explicitly open item on card `sac-listen-churn-kills-every-inbox-subscriber`:

> *"Harden `_consume_sse`: add jitter to the reconnect backoff (12 adapters currently reconnect as a thundering herd)"*

Every agent on a host subscribes to the **same** listen, so when it goes away they all lose the stream in the same instant and climb an **identical** ladder — 0.5s, 1s, 2s, 4s … — re-dialling in lockstep at a process that is, by definition, mid-restart. ~14 adapters landing together on every rung is an excellent way to knock over the very thing they are all waiting for.

Equal jitter (half the window + a random half) decorrelates them. Recovery latency is unchanged — a retry still lands inside its own window — but arrivals are smeared across the window instead of stacked on its edge.

This also extracts the SSE consumer and its reconnect *policy* into `_mcp/_channel_sse.py` (the component whose failure deafens an agent, kept readable on its own), bringing `channel.py` back under the per-file cap (586 → 445). `channel.py` re-exports `_consume_sse`, so every existing import path is unchanged.

## Which shape: (a) or (b)?

**(b), agent-side self-heal — because (a) is not physically possible here, and I would rather say so than pretend otherwise.**

The subscription *is* an SSE socket the **client** dials and owns. `sac listen` cannot reach out and re-establish it; there is no handle on the server side to re-create a connection the client has not made. A listen-side "reconcile subscriptions from the registry" sweep would have nothing to reconcile with.

What the centre **can** own — and now does — is the **liveness contract**: listen dictates the beat cadence, and the client's deadline is keyed to it. Authority stays central and one-way; only the re-dial is local, because only the client can dial.

## The ternary, again

`Broker.get_or_close` was binary — an event, or `None` (closing). An idle stream is *neither*, and collapsing "nothing yet" into "stop" would tear down a healthy stream every interval. It now has three answers: **event / `KEEPALIVE` (idle, healthy) / `None` (closing)** — the same discipline as `_verdict.py` and `_reachability.py`.

Nothing here is wired to anything destructive: 0 subscribers still means *cannot be reached*, never *dead*. The remedy is a re-subscribe, which is safe and idempotent — never a restart.

## Both streams, not just the one that bit us

The sidecar's stream in `a2a/_server.py` was the same primitive with the same hole. Fixing one and leaving its twin is the "fixed 1 of N call sites" failure this repo has already paid for, so both get the beat. Extracting the handler to `a2a/_inbox_stream.py` also brings `_server.py` back under the per-file cap (601 → 497 lines).

## Health check (item 3)

Already shipped — verified, not changed. `sac agents check-health` prints `inbox: NOT REACHABLE — 0 live subscribers … Do NOT force-restart on this alone`, reports `inbox_subscribers` / `inbox_reachable` in `--json`, and deliberately does **not** derive `healthy` from it.

## Verification

**Live**, against a real listen + real adapter:

| step | result |
|---|---|
| adapter subscribed | `inbox_subscribers=1` |
| idle beats on the wire | `: keepalive` ×2 in 12s (beat=5s) |
| **listen restarted, agent untouched** | **`inbox_subscribers=1`** |
| real message sent | `delivered_subscriber_count: 1` |
| **adapter actually received it** | its own log: `live-proof: delivered after listen restart, agent never touched` |

**Tests** — real sockets, no mocks. Each new test was verified to **fail on unfixed code** (a guard that passes on the bug is theatre):

- `test_consume_sse_reconnects_when_stream_goes_silent` — the silent-death case. Fails on `develop` (1 connection, wedged forever); passes here.
- `test_idle_inbox_stream_emits_keepalive_frames` — real uvicorn. Fails on `develop` (no beats); passes here.
- `test__inbox_bus_keepalive.py` — the ternary contract, including **an event is never lost to a beat**.
- 1435 passed across `a2a/` + `_listen/` + `_mcp/`; 38 passed across smoke + integration, including the SIGTERM SSE-shutdown test — the one most at risk from the `get_or_close` change.

## What I could NOT verify

I did **not** prove server-side reaping of a subscriber whose peer vanished with **no TCP signal at all**. That path only errors out on TCP retransmit exhaustion (minutes), and I could not reproduce it deterministically. I wrote a test for it, found it **passed on unfixed code too** (uvicorn already reaps clean closes and RSTs by itself), and **deleted it** rather than ship a green bar that proves nothing. The comments in the code now claim only what is actually true.
