### PR TITLE
docs(inbox-probe): name the confound AT THE SIGNAL — 0 subscribers cannot tell DEAD from DEAF

### DIFF
--- a/src/scitex_agent_container/_lifecycle/inbox_probe.py
+++ b/src/scitex_agent_container/_lifecycle/inbox_probe.py
@@ -12,6 +12,32 @@ the one component that actually knows: the broker inside ``sac listen``
 (via ``GET /agents/<name>/status``, which carries ``inbox_subscribers`` —
 see ``_listen/_reachability.py``).
 
+⚠️ ``inbox_subscribers == 0`` IS CONFOUNDED. READ THIS BEFORE YOU USE IT.
+------------------------------------------------------------------------
+A zero has **at least two** causes, and this probe **cannot tell them apart**:
+
+    (a) the agent is ALIVE but its inbox adapter is DETACHED   (deaf), and
+    (b) the agent IS NOT RUNNING AT ALL                        (dead).
+
+A registry row **outlives the process**, so a stopped agent still appears in
+the listing, still shows a pid and a port — and reports ``0`` exactly like a
+deaf one. **A zero therefore tells you NOTHING about which of (a) or (b) holds.**
+
+This is not hypothetical. On 2026-07-14 **three agents independently** read a
+fleet-wide wall of zeros and each concluded "the fleet has gone deaf". All of
+them were reading *this signal*. Every agent in their lists was simply
+**stopped**. It cost an escalation to the operator and a P0 that did not exist.
+Note the shape: three agreeing reports were **one instrument read three times**.
+
+**To distinguish (a) from (b) you MUST corroborate with an instrument that does
+not derive from ``sac listen``'s own bookkeeping.** Note that the ``instances``
+row, ``runtime/<name>/heartbeat.json`` and this subscriber count *all* reflect
+listen's BELIEF, not the agent's LIFE — they are far less independent than they
+look. Genuinely independent: the **host tmux session** (the only signal that was
+right that day), and **delivery** itself. NOT independent, and NOT a sensor at
+all from inside a container: ``/proc/<pid>`` — the pid namespace differs, so it
+reports ABSENT for demonstrably alive host processes.
+
 Two rules this module will not break
 ------------------------------------
 1. **It never invents a verdict.** Every failure to observe — no listen
@@ -22,8 +48,9 @@ Two rules this module will not break
 2. **It never feeds a restart.** The subscriber count is reported, and
    that is ALL it does. ``healthy`` (which gates ``sac agents health``'s
    exit code, and any automation keyed on it) is deliberately NOT derived
-   from it: 0 subscribers means an inbox adapter is detached, NOT that the
-   agent is dead, and auto-restarting on it would destroy a healthy session.
+   from it: 0 subscribers means an inbox adapter is detached **or that the
+   agent is not running** — never that a *living* agent is beyond saving —
+   and auto-restarting on it would destroy a healthy session.
 """
 
 from __future__ import annotations
@@ -74,7 +101,12 @@ def probe_inbox_reachability(
     try:
         with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310
             body = json.loads(resp.read().decode("utf-8"))
-    except (urllib.error.URLError, TimeoutError, ValueError, OSError):  # stx-allow: fallback (reason: an unobservable listen must yield UNKNOWN — never a false 'unreachable' verdict against a healthy agent)
+    except (
+        urllib.error.URLError,
+        TimeoutError,
+        ValueError,
+        OSError,
+    ):  # stx-allow: fallback (reason: an unobservable listen must yield UNKNOWN — never a false 'unreachable' verdict against a healthy agent)
         return None, UNKNOWN
 
     if not isinstance(body, dict):


### PR DESCRIPTION
## The docstring named one cause of a zero, and was silent on the other

```
0 subscribers means an inbox adapter is detached, NOT that the agent is dead
```

True — and **incomplete**. A registry row **outlives the process**, so a **stopped** agent reports `0` *exactly like* a deaf one. The signal has (at least) two causes and cannot distinguish them:

| | |
|---|---|
| (a) | agent ALIVE, inbox adapter DETACHED → **deaf** |
| (b) | agent **NOT RUNNING AT ALL** → **dead** |

Because the docstring named only (a), **a reader who sees a zero infers (a)** — in good faith. That is not a hypothetical failure mode.

## It already cost us

On 2026-07-14, **three agents independently** read a fleet-wide wall of zeros and each concluded *"the fleet has gone deaf."* All three were reading **this signal**. **Every agent in their lists was simply stopped.** It produced an escalation to the operator and a P0 that did not exist.

Note the shape: **three agreeing reports were one instrument read three times.** Corroboration only counts when the corroborators could have disagreed.

## Why the fix is *here*, and not in a card

I had already refuted this exact story once that morning — and then rebuilt it six hours later on the same confounded signal. **Killing a bad conclusion does not disinfect the evidence that produced it.** If a signal cannot distinguish two states, that fact has to live **next to the signal**, or the next reader honestly re-derives the same story. A retraction in a card protects nobody who never reads the card.

## Also names which corroborators are real

The subtle part, and the reason "just check another source" is not enough:

```
instances row      ╲
heartbeat.json      ├─ ALL reflect sac listen's BELIEF, not the agent's LIFE.
inbox_subscribers  ╱  Far less independent than they look.

/proc/<pid>           NOT A SENSOR from inside a container — different pid
                      namespace. Reports ABSENT for provably-alive processes.

host tmux             genuinely independent — the only signal that was right.
delivery              genuinely independent (already barred from yielding DEAD).
```

Docs only. No behaviour change.