### PR TITLE
fix(acl): derive the researcher group from the role, as developer already did

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_spawn_gate.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_gate.py
@@ -16,9 +16,8 @@ This module unifies the two. The core start codepath now:
   1. resolves the *caller* identity from the parent agent's
      ``SAC_NAME`` container env (``None`` / empty → admin / human-operator
      / lead path — always allowed);
-  2. runs :func:`check_spawn` — root-only spawn under current policy;
-     a denied spawn raises :class:`SpawnDeniedError` BEFORE the runtime
-     is touched;
+  2. runs :func:`check_spawn`; a denied spawn raises
+     :class:`SpawnDeniedError` BEFORE the runtime is touched;
   3. on allow with a non-empty caller, records the ``caller → child``
      edge in the ``lineage`` table (idempotent; same-parent re-record is
      a no-op).
@@ -28,11 +27,24 @@ The same ``SAC_NAME`` already drives ``_instances._spawned_by()`` (the
 and the spawned_by string are written from the same identity on the
 same codepath — the split-brain is resolved.
 
-Scope (ADR-0010 staged plan): this is **Phase 2 / Step 1 only** —
+Current spawn policy — NOT root-only (this prose said "root-only" long
+after the code stopped being root-only, and that stale sentence is how
+the policy got mis-triaged; keep it in step with
+:func:`._listen._acl.check_spawn`, which is the SSOT):
+
+  * admin / operator (no ``SAC_NAME``) — allowed;
+  * a ``developer``- or ``researcher``-group caller — allowed EVEN AS A
+    CHILD (operator ruling: dev and research agents must both be able to
+    start/stop peer agents);
+  * a ROOT node (no lineage parent) — allowed;
+  * any other child (``generalist`` / ``privileged`` / isolated solver /
+    ungrouped) — denied, as is any caller with
+    ``spec.lineage.may_spawn=false``.
+
+Scope (ADR-0010 staged plan): this module is **Phase 2 / Step 1** —
 make ALL spawn paths go through ``check_spawn`` + write the lineage
 row. The ``spec.acl`` schema (Step 2) and ``child ⊆ parent`` clamp
-(Step 3) are separate follow-up PRs; ``check_spawn``'s current binary
-root/child policy is kept verbatim.
+(Step 3) are separate follow-up PRs.
 """
 
 from __future__ import annotations
@@ -84,9 +96,12 @@ def persist_acl_policy(config: Any, db_path: Path | None = None) -> None:
 class SpawnDeniedError(RuntimeError):
     """Raised when an agent-from-agent spawn is rejected by the ACL.
 
-    Current policy (``spawn_allowed``): only a *root* node (no parent
-    in ``lineage``) may spawn. A child caller gets this error, carrying
-    the explicit allow/deny reason for the operator log + caller.
+    Carries the explicit deny reason from :func:`._listen._acl.check_spawn`
+    (the policy SSOT) for the operator log + the caller. A ROOT node, and a
+    ``developer``- or ``researcher``-group caller, may spawn; any other
+    child — and any caller with ``spec.lineage.may_spawn=false`` — gets
+    this error. (This docstring used to say "only a root node may spawn",
+    which the code had already outgrown.)
     """
 
 

--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -39,7 +39,6 @@ from typing import Literal
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from ..config._group_resolver import groups_mesh
 from .._state.state_db_nodes import (
     derive_group,
     has_grant,
@@ -51,6 +50,7 @@ from .._state.state_db_nodes import (
     sender_target_relationship,
     spawn_allowed,
 )
+from ..config._group_resolver import groups_mesh
 
 log = logging.getLogger(__name__)
 
@@ -446,23 +446,29 @@ def check_spawn(
     as :func:`check_send_acl` so the listen-server handler can branch
     uniformly.
 
-    Policy:
+    **Read BOTH layers before concluding what is denied.** The
+    ``is_developer`` branch below is a SHORT-CIRCUIT, not the policy —
+    the RESEARCHER allow lives one level down, in :func:`spawn_allowed`.
+    Reading only this file, and seeing ``is_developer`` with no
+    ``is_researcher`` beside it, reads as "researchers fall through to
+    the root-only gate". That is FALSE, and has been mis-triaged that
+    way. Effective policy across both layers:
 
-      * ``caller=None`` — administrative / human-operator path (allowed
-        by :func:`spawn_allowed`).
-      * **Developer group full authority (operator 2026-06-25)** — a
-        caller whose resolved NAMED group is ``developer`` may spawn
-        regardless of the root-only default. Checked BEFORE the
-        root-only gate so a developer child (non-root) is still allowed.
-      * Otherwise the default root-only policy (a node with no lineage
-        parent may spawn; a child may not).
-
-    The developer bypass deliberately does NOT override a per-spec
-    ``spec.lineage.may_spawn=false`` deny by *not consulting it*: a
-    developer caller is granted authority by the group policy here. A
-    deployment that needs an agent which still cannot spawn should keep
-    it out of the developer group (and rely on the root-only +
-    ``may_spawn`` gates in :func:`spawn_allowed`).
+      * ``caller=None`` — administrative / operator path. Allowed.
+      * ``developer`` group — allowed regardless of the root-only
+        default, so a developer CHILD may spawn. Short-circuited here.
+      * ``researcher`` group — likewise allowed, resolved one layer
+        down in :func:`spawn_allowed` (operator ruling: dev AND
+        research agents must both be able to start/stop peers).
+      * ROOT node (no lineage parent) — allowed.
+      * Any other child — DENIED: ``generalist`` / ``privileged`` /
+        an isolated solver group / ungrouped. Note generalist and
+        privileged DO mesh for *manage* (:func:`check_lineage_acl`)
+        but get NO spawn authority; only developer + researcher do.
+      * ``spec.lineage.may_spawn=false`` denies even a researcher —
+        but NOT a developer, whose short-circuit here bypasses
+        :func:`spawn_allowed` and the ``may_spawn`` gate with it. An
+        agent that must never spawn has to stay out of ``developer``.
     """
     if caller and is_developer(name=caller, db_path=db_path):
         return ("allow", None)

--- a/src/scitex_agent_container/config/_group_resolver.py
+++ b/src/scitex_agent_container/config/_group_resolver.py
@@ -13,16 +13,28 @@ group mesh (:func:`scitex_agent_container._state.state_db_nodes.derive_group`):
     specs that prefer a scalar.
   * When NEITHER ``group`` nor ``groups`` is present, the group is
     *derived from the
-    role* (``metadata.labels.role`` / ``CLAUDE_AGENT_ROLE``): the
-    developer-ish roles — ``project-maintainer`` / ``maintainer`` /
-    ``dev-agent`` / ``contributor`` (and their project-suffixed forms,
-    e.g. ``contributor-figrecipe``) — resolve to the group
-    :data:`DEVELOPER_GROUP`. So every existing dev agent joins
-    ``developer`` with NO spec edit; an explicit ``labels.group``
-    always overrides the role default.
-  * Anything else (no group label, non-developer / absent role) →
-    the empty string ``""`` — "ungrouped". An ungrouped agent never
-    shares a NAMED group with anyone (the ACL same-group allow is
+    role* (``metadata.labels.role`` / ``CLAUDE_AGENT_ROLE``):
+
+      - the developer-ish roles — ``project-maintainer`` /
+        ``maintainer`` / ``dev-agent`` / ``contributor`` (and their
+        project-suffixed forms, e.g. ``contributor-figrecipe``) —
+        resolve to :data:`DEVELOPER_GROUP`;
+      - the research-ish roles — ``researcher`` / ``research-agent`` /
+        ``scientist`` (and their project-suffixed forms, e.g.
+        ``research-agent-neurovista``) — resolve to
+        :data:`RESEARCHER_GROUP`.
+
+    So every existing dev *and research* agent joins its group with NO
+    spec edit; an explicit ``labels.group`` / ``labels.groups`` always
+    overrides the role default. The two derivations are symmetric
+    because the operator granted BOTH groups peer spawn/restart
+    authority (nv-spawn-acl-incident): leaving the researcher half
+    label-only meant a research agent authored by role alone was
+    silently ungrouped, hence denied spawn AND denied cross-group
+    manage.
+  * Anything else (no group label; a ``worker`` / ``probe`` / absent
+    role) → the empty string ``""`` — "ungrouped". An ungrouped agent
+    never shares a NAMED group with anyone (the ACL same-group allow is
     gated on a non-empty match), so absence is byte-equivalent to the
     pre-existing behaviour.
 
@@ -139,17 +151,77 @@ def _role_is_developer(role: str | None) -> bool:
     return norm.startswith(_DEVELOPER_ROLE_PREFIXES)
 
 
+# Exact role strings (case-insensitive) that default to the RESEARCHER
+# group when no explicit ``labels.group`` / ``labels.groups`` is set —
+# the symmetric counterpart of :data:`_DEVELOPER_ROLES`.
+#
+# Operator ruling (nv-spawn-acl-incident): "Dev agents and research agents
+# MUST have full permissions — including the ability to start/stop peer
+# agents." The developer half of that ruling had a role-derivation path
+# from the start; the researcher half had NONE. A spec that named
+# ``role: researcher`` but no group therefore resolved to ``""``
+# (ungrouped) — and an ungrouped caller is denied BOTH spawn (root-only
+# gate) and cross-group manage (not in the mesh). Research agents only
+# worked because every one of them happened to carry an explicit
+# ``groups: [researcher]`` label; the first one authored by role alone
+# would have been silently denied.
+_RESEARCHER_ROLES: frozenset[str] = frozenset(
+    {
+        "researcher",
+        "research-agent",
+        "scientist",
+    }
+)
+
+# Role PREFIXES that also map to the researcher group even when the role
+# is project-suffixed — e.g. ``research-agent-neurovista``. Mirrors
+# :data:`_DEVELOPER_ROLE_PREFIXES`.
+_RESEARCHER_ROLE_PREFIXES: tuple[str, ...] = (
+    "researcher-",
+    "research-agent-",
+    "scientist-",
+)
+
+
+def _role_is_researcher(role: str | None) -> bool:
+    """Return True iff ``role`` is a research-ish role.
+
+    Case-insensitive, whitespace-trimmed. Matches the exact role set
+    or any project-suffixed prefix. ``None`` / empty → False. The exact
+    mirror of :func:`_role_is_developer`.
+    """
+    if not role:
+        return False
+    norm = str(role).strip().lower()
+    if not norm:
+        return False
+    if norm in _RESEARCHER_ROLES:
+        return True
+    return norm.startswith(_RESEARCHER_ROLE_PREFIXES)
+
+
 def resolve_group(*, group_label: str | None, role: str | None) -> str:
     """Resolve an agent's NAMED group from its group label + role.
 
-    Precedence (operator 2026-06-25):
+    Precedence (operator 2026-06-25; researcher derivation added for the
+    nv-spawn-acl-incident ruling):
 
       1. An explicit, non-empty ``group_label`` wins verbatim
          (whitespace-trimmed) — the operator can name ANY group, not
-         just ``developer``.
+         just ``developer``. This is what keeps a deliberately-isolated
+         solver (``groups: [solver]``) OUT of the fleet mesh even when
+         its role reads ``researcher``.
       2. Otherwise, if ``role`` is developer-ish, the group is
          :data:`DEVELOPER_GROUP`.
-      3. Otherwise, the empty string ``""`` (ungrouped).
+      3. Otherwise, if ``role`` is research-ish, the group is
+         :data:`RESEARCHER_GROUP`. These are the two groups the operator
+         granted peer spawn/restart authority; they derive symmetrically
+         so neither depends on the spec author remembering a group label.
+      4. Otherwise, the empty string ``""`` (ungrouped).
+
+    The role sets are DISJOINT, so rules 2 and 3 cannot both match and
+    their order carries no meaning. Every other role (``worker``,
+    ``probe``, ``experiment-capsule``, …) still falls to ``""``.
 
     Returns a plain ``str`` (never ``None``). An empty return means
     "no named group" — the ACL same-group allow is gated on a
@@ -162,6 +234,8 @@ def resolve_group(*, group_label: str | None, role: str | None) -> str:
             return trimmed
     if _role_is_developer(role):
         return DEVELOPER_GROUP
+    if _role_is_researcher(role):
+        return RESEARCHER_GROUP
     return ""
 
 

--- a/tests/scitex_agent_container/_listen/test__acl_group.py
+++ b/tests/scitex_agent_container/_listen/test__acl_group.py
@@ -40,6 +40,30 @@ from scitex_agent_container._state.state_db_nodes import (
     record_comms_policy,
     record_lineage,
 )
+from scitex_agent_container.config._group_resolver import group_from_labels
+
+
+def _seed_child_from_labels(
+    name: str,
+    labels: dict,
+    *,
+    db_path: Path,
+    may_spawn: bool = True,
+) -> None:
+    """Seed a non-root agent EXACTLY as ``agent_start`` would.
+
+    Walks the real production path — ``metadata.labels`` → ``group_from_labels``
+    → ``node_comms_policy.group_name`` — rather than hand-writing the resolved
+    group into the DB. That is what makes these tests able to catch a gap in
+    the RESOLVER (a role that derives no group) and not just in the gate.
+    """
+    record_lineage(child=name, parent="root-parent", db_path=db_path)
+    record_comms_policy(
+        name=name,
+        group_name=group_from_labels(labels),
+        may_spawn=may_spawn,
+        db_path=db_path,
+    )
 
 
 @pytest.fixture
@@ -255,6 +279,116 @@ def test_non_developer_child_still_denied_spawn(db_path: Path) -> None:
     record_comms_policy(name="worker-a", group_name="analysts", db_path=db_path)
     # Act
     decision, _reason = check_spawn(caller="worker-a", db_path=db_path)
+    # Assert
+    assert decision == "deny"
+
+
+# ---------------------------------------------------------------------------
+# check_spawn / check_lineage_acl — BOTH privileged roles, seeded from real
+# spec labels (nv-spawn-acl-incident). The operator ruled that developer AND
+# researcher roles must both be able to spawn / restart peers. A child agent
+# authored with an explicit ``groups: [researcher]`` label already worked; a
+# child authored with only ``role: researcher`` did NOT — it resolved to the
+# empty group and was denied by the root-only gate. Both are pinned here,
+# together with the cases that must STAY denied.
+# ---------------------------------------------------------------------------
+
+
+def test_labelled_researcher_child_may_spawn(db_path: Path) -> None:
+    """Explicit ``groups: [researcher]`` child may spawn (regression pin)."""
+    # Arrange
+    _seed_child_from_labels(
+        "neurovista", {"groups": ["researcher", "active"]}, db_path=db_path
+    )
+    # Act
+    decision, _reason = check_spawn(caller="neurovista", db_path=db_path)
+    # Assert
+    assert decision == "allow"
+
+
+def test_role_derived_researcher_child_may_spawn(db_path: Path) -> None:
+    """``role: researcher`` with NO groups label may spawn.
+
+    The half of the operator's ruling that was missing: only developer-ish
+    ROLES auto-joined their group, so a research agent that named its role
+    but not its group was ungrouped — and an ungrouped child is denied.
+    """
+    # Arrange
+    _seed_child_from_labels("res-by-role", {"role": "researcher"}, db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="res-by-role", db_path=db_path)
+    # Assert
+    assert decision == "allow"
+
+
+def test_role_derived_researcher_child_may_manage_peer(db_path: Path) -> None:
+    """``role: researcher`` child may RESTART a developer peer (the incident)."""
+    # Arrange
+    _seed_child_from_labels("res-by-role", {"role": "research-agent"}, db_path=db_path)
+    record_comms_policy(name="scitex-clew", group_name="developer", db_path=db_path)
+    # Act
+    decision, _reason = check_lineage_acl(
+        caller="res-by-role", target="scitex-clew", db_path=db_path
+    )
+    # Assert
+    assert decision == "allow"
+
+
+def test_role_derived_developer_child_may_spawn(db_path: Path) -> None:
+    """The other half of the ruling: ``role: project-maintainer`` may spawn."""
+    # Arrange
+    _seed_child_from_labels(
+        "dev-by-role", {"role": "project-maintainer"}, db_path=db_path
+    )
+    # Act
+    decision, _reason = check_spawn(caller="dev-by-role", db_path=db_path)
+    # Assert
+    assert decision == "allow"
+
+
+def test_worker_role_child_still_denied_spawn(db_path: Path) -> None:
+    """NEGATIVE: a ``role: worker`` child derives no group → still denied.
+
+    Guards against the fix over-reaching: role-derivation must promote the
+    research roles ONLY, not every role. The clew haiku-TUI workers are real
+    agents carrying exactly this label.
+    """
+    # Arrange
+    _seed_child_from_labels("worker-1", {"role": "worker"}, db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="worker-1", db_path=db_path)
+    # Assert
+    assert decision == "deny"
+
+
+def test_isolated_solver_child_still_denied_spawn(db_path: Path) -> None:
+    """NEGATIVE: an explicit non-mesh ``groups: [solver]`` child stays denied.
+
+    Even when its role says ``researcher``: the explicit label wins, so a
+    deliberately-isolated solver is never promoted into the fleet mesh.
+    """
+    # Arrange
+    _seed_child_from_labels(
+        "solver-1", {"role": "researcher", "groups": ["solver"]}, db_path=db_path
+    )
+    # Act
+    decision, _reason = check_spawn(caller="solver-1", db_path=db_path)
+    # Assert
+    assert decision == "deny"
+
+
+def test_researcher_child_with_may_spawn_false_is_denied(db_path: Path) -> None:
+    """NEGATIVE: per-spec ``lineage.may_spawn=false`` still overrides the group.
+
+    The group grants authority; the spec can still revoke it. Without this,
+    the fix would have removed an operator escape hatch.
+    """
+    # Arrange
+    _seed_child_from_labels(
+        "res-nospawn", {"role": "researcher"}, db_path=db_path, may_spawn=False
+    )
+    # Act
+    decision, _reason = check_spawn(caller="res-nospawn", db_path=db_path)
     # Assert
     assert decision == "deny"
 

--- a/tests/scitex_agent_container/config/test__group_resolver.py
+++ b/tests/scitex_agent_container/config/test__group_resolver.py
@@ -113,6 +113,78 @@ def test_non_developer_role_is_ungrouped() -> None:
     assert group == ""
 
 
+# ---------------------------------------------------------------------------
+# Researcher role-derivation (operator ruling, nv-spawn-acl-incident:
+# developer AND researcher roles must BOTH be able to spawn / restart peers).
+#
+# The developer group has always had a role-derivation path, so a dev agent
+# joins ``developer`` with no spec edit. The researcher group had NONE: a spec
+# carrying ``role: researcher`` but no explicit ``groups:`` label resolved to
+# ``""`` (ungrouped) — and an ungrouped caller is denied BOTH spawn and
+# cross-group manage. These pin the symmetric derivation.
+# ---------------------------------------------------------------------------
+
+
+def test_role_researcher_derives_researcher_group() -> None:
+    # Arrange
+    role = "researcher"
+    # Act
+    group = resolve_group(group_label=None, role=role)
+    # Assert
+    assert group == RESEARCHER_GROUP
+
+
+def test_role_research_agent_derives_researcher_group() -> None:
+    # Arrange
+    role = "research-agent"
+    # Act
+    group = resolve_group(group_label=None, role=role)
+    # Assert
+    assert group == RESEARCHER_GROUP
+
+
+def test_role_scientist_derives_researcher_group() -> None:
+    # Arrange
+    role = "scientist"
+    # Act
+    group = resolve_group(group_label=None, role=role)
+    # Assert
+    assert group == RESEARCHER_GROUP
+
+
+def test_project_suffixed_research_agent_role_derives_researcher_group() -> None:
+    # Arrange
+    role = "research-agent-neurovista"
+    # Act
+    group = resolve_group(group_label=None, role=role)
+    # Assert
+    assert group == RESEARCHER_GROUP
+
+
+def test_researcher_role_match_is_case_insensitive() -> None:
+    # Arrange
+    role = "Research-Agent"
+    # Act
+    group = resolve_group(group_label=None, role=role)
+    # Assert
+    assert group == RESEARCHER_GROUP
+
+
+def test_explicit_group_label_wins_over_researcher_role() -> None:
+    """Isolation guard: an explicit label still beats the new role default.
+
+    A deliberately-isolated solver authored as ``role: researcher`` +
+    ``groups: [solver]`` must STAY in ``solver`` (a non-mesh group), so
+    role-derivation can never silently promote it into the fleet mesh.
+    """
+    # Arrange
+    label = "solver"
+    # Act
+    group = resolve_group(group_label=label, role="researcher")
+    # Assert
+    assert group == label
+
+
 def test_empty_group_label_falls_through_to_role() -> None:
     # Arrange
     label = "   "


### PR DESCRIPTION
## What the gate actually did (the card's premise is false — verify this first)

Card `nv-spawn-acl-incident` says researcher-role agents cannot spawn or restart
peers. A triage pass said the developer group can spawn but the researcher group
"still falls through to the root-only gate".

**Both are wrong.** I executed the real gate — on `develop` *and* on the deployed
`0.21.20` wheel the live daemon imports (`~/.scitex/agent-container/venv`) — with a
researcher child (`neurovista`, child of `scitex-cv`):

| caller (child of scitex-cv) | `check_spawn` | `check_lineage_acl` → restart `scitex-clew` |
|---|---|---|
| `neurovista` (researcher)   | **ALLOW** | **ALLOW** |
| developer                   | ALLOW | ALLOW |
| generalist / privileged     | DENY  | ALLOW (manage-only) |
| solver / ungrouped          | DENY  | DENY |

`ffd93182` ("allow dev/research-role agents to spawn peers") already shipped this.
The triage misread is understandable and is itself a bug worth fixing: `check_spawn`
in `_acl.py` has an `is_developer` short-circuit and **no** `is_researcher` beside it
— the researcher allow lives one layer down in `spawn_allowed`. Read only that
function and you conclude researchers are denied.

## What was actually broken

How an agent **joins** the researcher group. `resolve_group()` role-derives **only**
the developer-ish roles, so every dev agent auto-joins `developer` with no spec edit.
The researcher side had **no derivation at all**:

```python
group_from_labels({"role": "researcher"})      # -> ''   (ungrouped!)
group_from_labels({"role": "project-maintainer"})  # -> 'developer'
```

An ungrouped caller is denied **both** spawn (root-only gate) **and** cross-group
manage (not in the mesh). Research agents worked only because every one of them
happens to hand-carry `groups: [researcher]`. The first agent authored by role alone
is silently denied — the exact shape of the incident. `paper-scitex-clew` already
declares `role: research-agent`.

## Change

Symmetric derivation: `researcher` / `research-agent` / `scientist` (+ project-suffixed
forms, case-insensitive) → `RESEARCHER_GROUP`.

## What is still denied, and to whom

This does **not** open the gate. Pinned by new negative tests:

- `role: worker` / `probe` / absent role → ungrouped → **no spawn**. The clew
  haiku-TUI workers and the solver capsules keep their isolation.
- An explicit non-mesh label (`groups: [solver]`) **beats** the role → an isolated
  solver is never promoted into the fleet mesh. This also leaves
  `_apptainer_jail.is_jailed()` untouched: it triggers on the explicit `solver`
  group, which is never role-derived, so **no agent's mount boundary changes**.
- `spec.lineage.may_spawn: false` still overrides the group.
- `generalist` / `privileged` children mesh for MANAGE but still get **no SPAWN**.

Blast radius on the current fleet: **zero agents change group** (every research agent
already carries an explicit label; no fleet agent declares a research-ish role without
one). It is a guardrail for the relaunch, not a live behaviour change. Note that a
role-derived researcher inherits the *whole* researcher group — including `host_exec`
eligibility (`ELIGIBLE_GROUPS = {developer, researcher, privileged}`), per the
operator's 2026-07-01 scoping. Same group, same authority.

## Stale docstrings (the reason this got mis-triaged)

Three docstrings contradicted their own code and are fixed here:
- `_spawn_gate.py` module prose: said spawn was "root-only" long after it wasn't.
- `SpawnDeniedError`: said "only a root node may spawn".
- `check_spawn`: documented only the developer bypass, then "otherwise the default
  root-only policy" — hiding the researcher allow one layer down.

## Tests

- **7 new tests that FAIL on `develop` and pass here** (5 resolver + 2 gate). One
  reproduces the incident exactly: a role-derived researcher restarting `scitex-clew`
  → `deny` before, `allow` after.
- **3 new negatives** that pass before *and* after — that is the point: they prove the
  gate was not removed.
- `240 passed` across the ACL / spawn / state / jail surface (was `7 failed, 72 passed`).
- `scitex-dev quality audit-lines`: PASS (0 over-limit). Linter clean on all changed files.

## Deploy

**Merged is not deployed.** The live daemon runs the pinned `0.21.20` release venv, not
the checkout. This fix is not live until that venv is upgraded.