### PR TITLE
fix(verdict): may_destroy must count INSTRUMENTS, not reporters — its two witnesses were the same syscall

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_start_failure_diag.py
+++ b/src/scitex_agent_container/_lifecycle/_start_failure_diag.py
@@ -11,9 +11,13 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
-__all__ = ["_format_boot_stderr_section", "raise_start_failure"]
+__all__ = [
+    "_format_boot_stderr_section",
+    "capture_pane_diag",
+    "raise_start_failure",
+]
 
 
 def _format_boot_stderr_section(log: Path) -> str:
@@ -33,7 +37,14 @@ def _format_boot_stderr_section(log: Path) -> str:
     return f"  inner stderr ({log}):\n{body}\n"
 
 
-def raise_start_failure(config: Any) -> None:
+_NO_PANE = " (no pane diagnostics available)"
+
+
+def raise_start_failure(
+    config: Any,
+    *,
+    capture_fn: Callable[[Any], str] | None = None,
+) -> None:
     """Always raises. Capture WHY the start failed, persist it, then fail loud.
 
     A bare ``False`` from ``runtime.start()`` must not become a cause-less
@@ -49,27 +60,82 @@ def raise_start_failure(config: Any) -> None:
     is written to disk now. ``boot.stderr.log`` already survives pane death;
     the pane tail did not until this. See
     ``sac-agent-start-false-negative-tui-registry-row``.
-    """
-    diag = ""
-    try:
-        from .._runners._tmux.tmux import TmuxManager
-        from ..runtimes.tui_session import session_name_for, state_dir_for_config
 
-        _sess = session_name_for(config)
-        _pane = TmuxManager.capture_logs(_sess, lines=60).rstrip()
-        _boot_log = state_dir_for_config(config) / "boot.stderr.log"
-        diag = (
-            f" (tmux session_exists={TmuxManager.exists(_sess)})\n"
-            f"{_format_boot_stderr_section(_boot_log)}"
-            f"  pane tail:\n{_pane or '<empty>'}"
-        )
-        _diag_log = state_dir_for_config(config) / "start_failure_diag.log"
-        _diag_log.write_text(
-            f"{datetime.now(timezone.utc).isoformat()} start failed for "
-            f"{config.name!r}: runtime.start() returned False.{diag}\n"
-        )
+    ``capture_fn`` is the injection seam for the BEST-EFFORT half (a real
+    callable taking ``config`` and returning the message suffix; production uses
+    :func:`capture_pane_diag`). It exists so the suite can drive a genuinely
+    exploding tmux layer and still assert the record survives.
+    """
+    # STEP 1 — BEST-EFFORT: the pane capture. It is allowed to fail (no tmux, a
+    # wedged server, an apptainer agent that has no pane at all). A failure here
+    # must degrade the MESSAGE, never the PERSISTED RECORD.
+    try:
+        diag = (capture_fn or capture_pane_diag)(config)
     except Exception:  # stx-allow: fallback (reason: diagnostics must never mask the real start failure — degrade to no pane)
-        diag = " (no pane diagnostics available)"
+        diag = _NO_PANE
+
+    # STEP 2 — MANDATORY: persist the record. This is the whole point of the
+    # function, and it MUST NOT ride on step 1 succeeding.
+    #
+    # It used to. The write was the LAST statement inside step 1's try, under a
+    # bare ``except Exception``, so ANY earlier hiccup threw, got swallowed, and
+    # the diagnostic was silently discarded. The commonest hiccup is the
+    # plainest: THE STATE DIR DOES NOT EXIST, because a start that failed early
+    # never created it — so precisely when this record matters most, it was
+    # thrown away. The caller was then handed "(no pane diagnostics available)":
+    # a message blaming the PANE CAPTURE for a failure it never observed (it was
+    # a missing directory). That is the same disease the liveness verdict next
+    # door exists to kill — an error asserting a cause it did not see.
+    _persist_diag(config, diag)
+
     raise RuntimeError(
         f"Failed to start agent '{config.name}': runtime.start() returned False.{diag}"
     )
+
+
+def _state_dir(config: Any) -> Path:
+    """The agent's state dir. Resolved in one place so both steps agree."""
+    from ..runtimes.tui_session import state_dir_for_config
+
+    return state_dir_for_config(config)
+
+
+def capture_pane_diag(config: Any) -> str:
+    """BEST-EFFORT: the tmux pane tail + inner stderr, as a message suffix.
+
+    The injectable collaborator of :func:`raise_start_failure`. Separated so the
+    MANDATORY persist below cannot be taken down by a tmux hiccup, and so the
+    suite can drive a genuinely exploding capture without patching internals.
+    """
+    from .._runners._tmux.tmux import TmuxManager
+    from ..runtimes.tui_session import session_name_for
+
+    sess = session_name_for(config)
+    pane = TmuxManager.capture_logs(sess, lines=60).rstrip()
+    boot_log = _state_dir(config) / "boot.stderr.log"
+    return (
+        f" (tmux session_exists={TmuxManager.exists(sess)})\n"
+        f"{_format_boot_stderr_section(boot_log)}"
+        f"  pane tail:\n{pane or '<empty>'}"
+    )
+
+
+def _persist_diag(config: Any, diag: str) -> None:
+    """Write ``<state>/start_failure_diag.log``, CREATING the state dir if needed.
+
+    ``mkdir(parents=True, exist_ok=True)`` is load-bearing, not defensive
+    boilerplate: the agents this runs for are exactly the ones whose start
+    FAILED, and a start that failed early enough never created its own state
+    dir. ``write_text`` into a directory that does not exist raises
+    ``FileNotFoundError`` — which is how the only durable evidence of a boot
+    failure was being silently discarded.
+    """
+    try:
+        log = _state_dir(config) / "start_failure_diag.log"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text(
+            f"{datetime.now(timezone.utc).isoformat()} start failed for "
+            f"{config.name!r}: runtime.start() returned False.{diag}\n"
+        )
+    except Exception:  # stx-allow: fallback (reason: an unwritable state dir must not mask the real start failure — the RuntimeError still carries the cause)
+        pass

--- a/src/scitex_agent_container/_lifecycle/_start_verdict.py
+++ b/src/scitex_agent_container/_lifecycle/_start_verdict.py
@@ -62,7 +62,15 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from ._verdict import ALIVE, UNKNOWN, LivenessVerdict, Signal, decide
+from ._verdict import (
+    ALIVE,
+    INSTRUMENT_PID_NAMESPACE,
+    SOURCE_REGISTRY,
+    UNKNOWN,
+    LivenessVerdict,
+    Signal,
+    decide,
+)
 
 __all__ = ["resolve_start_verdict"]
 
@@ -111,9 +119,22 @@ def resolve_start_verdict(
             "runtime.is_running) did not vouch for this agent — no positive "
             "evidence of life, which is not the same as evidence of death"
         )
+        # INSTRUMENT: this legacy signal is a CONJUNCTION spanning the registry
+        # row, ``runtime.is_running`` and the injected verifier — all of them
+        # pid/row-shaped. It can only ever emit ALIVE or UNKNOWN (a bool cannot
+        # express death), so it can never convict; and per the AMBIGUITY RULE we
+        # label the instrument that COLLAPSES with an existing one rather than
+        # inventing an independent witness.
         return decide(
             config.name,
-            [Signal("registry", ALIVE if legacy_alive else UNKNOWN, detail)],
+            [
+                Signal(
+                    SOURCE_REGISTRY,
+                    ALIVE if legacy_alive else UNKNOWN,
+                    detail,
+                    INSTRUMENT_PID_NAMESPACE,
+                )
+            ],
         )
 
     if resolver is None:

--- a/src/scitex_agent_container/_lifecycle/_status.py
+++ b/src/scitex_agent_container/_lifecycle/_status.py
@@ -103,7 +103,13 @@ def _liveness_block(
     verdict with the reason attached — never to a fabricated DEAD, and never to
     an exception that takes the whole status command down with it.
     """
-    from ._verdict import UNKNOWN, LivenessVerdict, Signal
+    from ._verdict import (
+        INSTRUMENT_NO_OBSERVATION,
+        SOURCE_RESOLVER,
+        UNKNOWN,
+        LivenessVerdict,
+        Signal,
+    )
     from ._verdict_resolve import resolve_verdict
 
     try:
@@ -118,9 +124,10 @@ def _liveness_block(
             verdict=UNKNOWN,
             signals=(
                 Signal(
-                    "resolver",
+                    SOURCE_RESOLVER,
                     UNKNOWN,
                     f"could not gather liveness evidence ({type(exc).__name__}: {exc})",
+                    INSTRUMENT_NO_OBSERVATION,
                 ),
             ),
         ).to_dict()

--- a/src/scitex_agent_container/_lifecycle/_verdict.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict.py
@@ -22,8 +22,13 @@ probe FAILED, liveness UNKNOWN — *"callers must NOT read this as 'every agent
 is dead'"*). This module generalises that discipline to liveness at large
 rather than inventing a competing abstraction.
 
-Three rules, and they are the whole module
-------------------------------------------
+The evidence VOCABULARY — the three states, the SOURCE_* reporters, the
+INSTRUMENT_* sensors and :class:`Signal` — lives in
+:mod:`._verdict_instruments` and is re-exported here, so every existing
+``from ._verdict import ...`` keeps working. This module is the RULE.
+
+Four rules, and they are the whole module
+-----------------------------------------
 1. **A verdict is never a bool.** ``pid <= 0``, an absent heartbeat, a probe
    that timed out, a peer on a host we cannot see → :data:`UNKNOWN`, named,
    with the reason attached. Not ``False``.
@@ -43,6 +48,14 @@ Three rules, and they are the whole module
    (starting a process is not destroying one), but it may never tear anything
    down. When in doubt we report and stop.
 
+4. **Corroboration is counted in INSTRUMENTS, not in reports.** Two signals
+   from one sensor are ONE witness. Until 2026-07-14 this gate counted source
+   STRINGS, so ``process`` + ``registry`` — which are the same
+   ``os.kill(pid, 0)`` on the same pid, *by explicit design in both runtimes* —
+   satisfied "2 independent sources" between them. A single syscall in the
+   wrong pid namespace could therefore authorise killing a healthy agent. See
+   :mod:`._verdict_instruments`.
+
 What each signal is worth
 -------------------------
 ``delivery``
@@ -51,17 +64,17 @@ What each signal is worth
     fact that predicts whether a message will wake it. Observed subscribers
     ⇒ :data:`ALIVE`, and nothing outranks it.
 
-    A delivery observation NEVER yields :data:`DEAD`. Zero subscribers means a
-    detached inbox adapter, not a corpse — the doctrine :mod:`.._listen.
-    _reachability` was written to enforce ("``UNREACHABLE`` must NEVER be wired
-    to anything destructive") — so it degrades to :data:`UNKNOWN` here.
+    A delivery observation NEVER yields :data:`DEAD` — that is now ENFORCED by
+    its :class:`._verdict_instruments.InstrumentSpec`, not merely asked for in
+    prose. Zero subscribers means a detached inbox adapter, not a corpse.
 
 ``process`` / ``heartbeat`` / ``registry``
     HINTS. They corroborate; they may promote a verdict to :data:`UNKNOWN`;
     a *positive* one (a live pane pid, a fresh beat) is real evidence of life
     and does yield :data:`ALIVE`. But a NEGATIVE one on its own is never
     enough to destroy anything, because each is a shadow of the agent rather
-    than the agent itself.
+    than the agent itself — and because two of them are frequently THE SAME
+    SHADOW.
 
 ``registry`` in particular is a DECLARATION, not an observation — a row in a
 table someone wrote once. It can vouch for a corpse, and it can be missing for
@@ -75,6 +88,27 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Iterable, Sequence
 
+from ._verdict_instruments import (
+    ALIVE,
+    CONVICTING_INSTRUMENTS,
+    DEAD,
+    INSTRUMENT_AGENT_SELF,
+    INSTRUMENT_HOST_TMUX,
+    INSTRUMENT_INDEPENDENCE,
+    INSTRUMENT_LISTEN_BROKER,
+    INSTRUMENT_NO_OBSERVATION,
+    INSTRUMENT_PID_NAMESPACE,
+    INSTRUMENTS,
+    SOURCE_DELIVERY,
+    SOURCE_HEARTBEAT,
+    SOURCE_PROCESS,
+    SOURCE_REGISTRY,
+    SOURCE_RESOLVER,
+    UNKNOWN,
+    InstrumentSpec,
+    Signal,
+)
+
 __all__ = [
     "ALIVE",
     "DEAD",
@@ -83,61 +117,29 @@ __all__ = [
     "SOURCE_HEARTBEAT",
     "SOURCE_PROCESS",
     "SOURCE_REGISTRY",
+    "SOURCE_RESOLVER",
+    "INSTRUMENT_AGENT_SELF",
+    "INSTRUMENT_HOST_TMUX",
+    "INSTRUMENT_LISTEN_BROKER",
+    "INSTRUMENT_NO_OBSERVATION",
+    "INSTRUMENT_PID_NAMESPACE",
+    "INSTRUMENTS",
+    "CONVICTING_INSTRUMENTS",
+    "INSTRUMENT_INDEPENDENCE",
+    "InstrumentSpec",
     "LivenessVerdict",
     "Signal",
     "decide",
 ]
 
-# The three states. There is no fourth, and there is deliberately no bool.
-ALIVE = "alive"
-DEAD = "dead"
-UNKNOWN = "unknown"
-
-# Signal sources, in descending evidential strength.
-SOURCE_DELIVERY = "delivery"  # the broker OBSERVED the agent's inbox. Authoritative.
-SOURCE_PROCESS = "process"  # a process/session probe (pane pid, apptainer pid).
-SOURCE_HEARTBEAT = "heartbeat"  # the agent's own writer refreshed its beat file.
-SOURCE_REGISTRY = "registry"  # a row in a table. A declaration, not an observation.
-
-# How many INDEPENDENT sources must agree on DEAD before a caller is allowed
-# to destroy anything. Two, because every single signal in this system has
-# been observed lying at least once, and the cost of being wrong is the
-# destruction of a healthy agent. One dissenting ALIVE vetoes regardless.
+# How many INDEPENDENT INSTRUMENTS must agree on DEAD before a caller is allowed
+# to destroy anything. Two, because every single signal in this system has been
+# observed lying at least once, and the cost of being wrong is the destruction
+# of a healthy agent. One dissenting ALIVE vetoes regardless.
+#
+# NOTE WHAT THIS COUNTS: instruments. Not signals, not sources. Four reports
+# from one sensor are ONE witness.
 _CORROBORATION_REQUIRED = 2
-
-
-@dataclass(frozen=True)
-class Signal:
-    """One observation about one agent.
-
-    ``verdict`` is ternary — :data:`ALIVE`, :data:`DEAD` or :data:`UNKNOWN`.
-    A probe that could not run MUST report :data:`UNKNOWN` with the reason in
-    ``detail``; it must never report :data:`DEAD`, because "I did not see it"
-    and "I saw that it is not there" are different facts and only the second
-    one may be acted on.
-
-    ``detail`` is operator-facing and is expected to be specific: not
-    "unhealthy" but ``pid=0 in heartbeat.json — no verdict possible`` or
-    ``no tmux session 'tui-grant' (probe succeeded)``. A row that reads
-    ``running | pid=None`` teaches an operator nothing; that is the UX bug
-    this field exists to fix.
-    """
-
-    source: str
-    verdict: str
-    detail: str
-
-    def __post_init__(self) -> None:
-        if self.verdict not in (ALIVE, DEAD, UNKNOWN):
-            raise ValueError(
-                f"Signal.verdict must be one of {ALIVE!r} / {DEAD!r} / "
-                f"{UNKNOWN!r}, got {self.verdict!r}. A liveness signal is "
-                f"never a bool — 'I could not tell' is a first-class answer "
-                f"and must be spelled {UNKNOWN!r}, never collapsed into a pole."
-            )
-
-    def to_dict(self) -> dict:
-        return {"source": self.source, "verdict": self.verdict, "detail": self.detail}
 
 
 @dataclass(frozen=True)
@@ -166,7 +168,12 @@ class LivenessVerdict:
 
     @property
     def dead_sources(self) -> tuple[str, ...]:
-        """The DISTINCT sources that independently observed death."""
+        """The DISTINCT sources that REPORTED death.
+
+        Reporters, not sensors — two of these can be one instrument, so this
+        feeds the operator-facing text only. :attr:`may_destroy` counts
+        :attr:`dead_instruments`.
+        """
         seen: list[str] = []
         for sig in self.signals:
             if sig.verdict == DEAD and sig.source not in seen:
@@ -175,11 +182,35 @@ class LivenessVerdict:
 
     @property
     def alive_sources(self) -> tuple[str, ...]:
-        """The DISTINCT sources that independently observed life."""
+        """The DISTINCT sources that reported life."""
         seen: list[str] = []
         for sig in self.signals:
             if sig.verdict == ALIVE and sig.source not in seen:
                 seen.append(sig.source)
+        return tuple(seen)
+
+    @property
+    def dead_instruments(self) -> tuple[str, ...]:
+        """The DISTINCT SENSORS that independently observed death.
+
+        THIS is what corroboration means. ``process`` and ``registry`` are two
+        reporters but ONE instrument (the same ``os.kill(pid, 0)`` on the same
+        pid, by explicit design in both runtimes), so they are ONE witness here.
+        That is the entire point of the field.
+        """
+        seen: list[str] = []
+        for sig in self.signals:
+            if sig.verdict == DEAD and sig.instrument not in seen:
+                seen.append(sig.instrument)
+        return tuple(seen)
+
+    @property
+    def alive_instruments(self) -> tuple[str, ...]:
+        """The DISTINCT SENSORS that observed life."""
+        seen: list[str] = []
+        for sig in self.signals:
+            if sig.verdict == ALIVE and sig.instrument not in seen:
+                seen.append(sig.instrument)
         return tuple(seen)
 
     @property
@@ -190,9 +221,12 @@ class LivenessVerdict:
 
         * the verdict is :data:`DEAD` — never :data:`UNKNOWN`, and obviously
           never :data:`ALIVE`;
-        * at least :data:`_CORROBORATION_REQUIRED` INDEPENDENT sources observed
-          it dead — one signal is never enough, because each of them has been
-          caught lying;
+        * at least :data:`_CORROBORATION_REQUIRED` INDEPENDENT INSTRUMENTS
+          observed it dead. **Instruments, not signals and not sources.** Two
+          reports from one sensor are one witness — and until 2026-07-14 this
+          gate counted them as two, which meant a single ``os.kill(pid, 0)``
+          evaluated in the wrong pid namespace could authorise killing a
+          perfectly healthy agent;
         * NOT ONE signal observed it alive. A single dissenting ALIVE vetoes
           destruction outright, even against a pile of DEADs. That asymmetry is
           deliberate: the cost of a false DEAD is a destroyed healthy agent,
@@ -207,7 +241,7 @@ class LivenessVerdict:
             return False
         if self.alive_sources:
             return False
-        return len(self.dead_sources) >= _CORROBORATION_REQUIRED
+        return len(self.dead_instruments) >= _CORROBORATION_REQUIRED
 
     @property
     def destroy_veto_reason(self) -> str:
@@ -236,11 +270,25 @@ class LivenessVerdict:
                 f"{', '.join(self.alive_sources)} observed it ALIVE — a single "
                 f"live signal vetoes destruction"
             )
+        if len(self.dead_sources) >= _CORROBORATION_REQUIRED:
+            # The hole this gate shipped with: enough REPORTS, but they all came
+            # off ONE sensor. Name it explicitly — an operator who sees "process
+            # and registry both say dead" deserves to be told those are the same
+            # os.kill(pid, 0) on the same pid, not two witnesses.
+            return (
+                f"{self.agent} reads DEAD on {len(self.dead_sources)} sources "
+                f"({', '.join(self.dead_sources)}), but they share only "
+                f"{len(self.dead_instruments)} INSTRUMENT "
+                f"({', '.join(self.dead_instruments) or 'none'}) — that is one "
+                f"sensor reported twice, not corroboration. "
+                f"{_CORROBORATION_REQUIRED} INDEPENDENT instruments are required "
+                f"before anything destructive is authorised"
+            )
         return (
-            f"{self.agent} reads DEAD on only {len(self.dead_sources)} source "
-            f"({', '.join(self.dead_sources) or 'none'}); "
-            f"{_CORROBORATION_REQUIRED} independent sources are required before "
-            f"anything destructive is authorised"
+            f"{self.agent} reads DEAD on only {len(self.dead_instruments)} "
+            f"instrument ({', '.join(self.dead_instruments) or 'none'}); "
+            f"{_CORROBORATION_REQUIRED} independent instruments are required "
+            f"before anything destructive is authorised"
         )
 
     def render(self) -> str:
@@ -274,13 +322,15 @@ class LivenessVerdict:
 
         ``evidence`` is always present, even when empty: a consumer must never
         have to guess whether the absence of evidence means "clean" or "we did
-        not look".
+        not look". ``dead_instruments`` is present so a consumer can see WHY a
+        pile of DEAD reports did (or did not) authorise anything.
         """
         return {
             "verdict": self.verdict,
             "summary": self.render(),
             "may_destroy": self.may_destroy,
             "destroy_veto_reason": self.destroy_veto_reason,
+            "dead_instruments": list(self.dead_instruments),
             "evidence": [s.to_dict() for s in self.signals],
         }
 
@@ -300,6 +350,10 @@ def decide(agent: str, signals: Iterable[Signal] | Sequence[Signal]) -> Liveness
 
     Note what is absent: there is no path from "we gathered nothing" to
     :data:`DEAD`. That path is the bug.
+
+    Note also what this does NOT decide: whether the DEAD may be ACTED on. A
+    DEAD verdict is a report; :attr:`LivenessVerdict.may_destroy` is the gate,
+    and it counts INSTRUMENTS.
     """
     sigs = tuple(signals)
     for sig in sigs:

--- a/src/scitex_agent_container/_lifecycle/_verdict_instruments.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict_instruments.py
@@ -1,0 +1,267 @@
+"""The evidence vocabulary: the three states, the reporters, and the SENSORS.
+
+Split out of :mod:`._verdict` (512-line cap) along the natural dependency edge:
+this module is WHAT AN OBSERVATION IS, :mod:`._verdict` is WHAT OBSERVATIONS
+MEAN. :class:`Signal` validates itself against the taxonomy declared here, so
+the taxonomy has to be the lower layer.
+
+A SOURCE IS A REPORTER. AN INSTRUMENT IS A SENSOR.
+-------------------------------------------------
+Conflating those two shipped a destruction gate that a single sensor could
+satisfy by being asked twice.
+
+``may_destroy`` demanded "2 independent sources" and counted SOURCE STRINGS. But
+``process`` and ``registry`` are not two sensors — for BOTH runtimes they are the
+SAME ``os.kill(pid, 0)`` on the SAME pid, and the codebase says so itself:
+
+  ``runtimes/_tui_liveness.pane_pid_of``
+    *"This is the value ``instances.pid`` records for a TUI agent, and it is the
+    SAME signal ``pane_process_alive`` (hence ``is_running``) already keys
+    liveness on — so the registry and ``is_running`` can never disagree about
+    which process represents this agent."*
+
+  ``runtimes/_apptainer_runtime.agent_pid``
+    *"This is EXACTLY the pid ``is_running`` above probes with
+    ``os.kill(pid, 0)`` ... reusing ``_read_pid`` here means the registry and
+    ``is_running`` can never disagree."*
+
+The two witnesses the gate demanded were ENGINEERED to agree. Corroboration from
+one sensor asked twice is not corroboration — it is one observation wearing two
+hats. That is precisely the failure that already burned this fleet: three agents
+"independently corroborated" that the fleet was deaf, all by reading one
+confounded ``inbox_subscribers == 0``.
+
+So a :class:`Signal` must declare WHAT PHYSICALLY OBSERVED IT, and the gate
+deduplicates by that BEFORE counting.
+
+THE AMBIGUITY RULE (load-bearing)
+---------------------------------
+When a signal's instrument cannot be pinned down, label it with the instrument
+that COLLAPSES (shares identity with an existing signal), never the one that ADDS
+an independent witness. Under-counting witnesses refuses a destruction;
+over-counting performs one. Only the second is unrecoverable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "ALIVE",
+    "DEAD",
+    "UNKNOWN",
+    "SOURCE_DELIVERY",
+    "SOURCE_HEARTBEAT",
+    "SOURCE_PROCESS",
+    "SOURCE_REGISTRY",
+    "SOURCE_RESOLVER",
+    "INSTRUMENT_AGENT_SELF",
+    "INSTRUMENT_HOST_TMUX",
+    "INSTRUMENT_LISTEN_BROKER",
+    "INSTRUMENT_NO_OBSERVATION",
+    "INSTRUMENT_PID_NAMESPACE",
+    "INSTRUMENTS",
+    "CONVICTING_INSTRUMENTS",
+    "INSTRUMENT_INDEPENDENCE",
+    "InstrumentSpec",
+    "Signal",
+]
+
+# The three states. There is no fourth, and there is deliberately no bool.
+ALIVE = "alive"
+DEAD = "dead"
+UNKNOWN = "unknown"
+
+# Signal SOURCES — the reporter that carried the news. Descending evidential
+# strength. NOTE: a source is NOT a sensor; see the module docstring.
+SOURCE_DELIVERY = "delivery"  # the broker OBSERVED the agent's inbox. Authoritative.
+SOURCE_PROCESS = "process"  # a process/session probe (pane pid, apptainer pid).
+SOURCE_HEARTBEAT = "heartbeat"  # a beat file someone refreshed.
+SOURCE_REGISTRY = "registry"  # a row in a table. A declaration, not an observation.
+SOURCE_RESOLVER = "resolver"  # the gatherer itself failed. Observes nothing, ever.
+
+# Signal INSTRUMENTS — what PHYSICALLY made the observation.
+INSTRUMENT_LISTEN_BROKER = "listen_broker"
+INSTRUMENT_HOST_TMUX = "host_tmux"
+INSTRUMENT_PID_NAMESPACE = "pid_namespace"
+INSTRUMENT_AGENT_SELF = "agent_self"
+INSTRUMENT_NO_OBSERVATION = "no_observation"
+
+
+@dataclass(frozen=True)
+class InstrumentSpec:
+    """What one sensor physically reads, and what it is permitted to conclude.
+
+    ``verdicts`` is the CLOSED set of verdicts this instrument may emit, and it
+    is ENFORCED at :class:`Signal` construction. That turns two doctrines which
+    were previously only prose into mechanism:
+
+    * a delivery observation may never yield :data:`DEAD` (zero subscribers is a
+      DETACHED adapter, not a corpse — the exact inference that convicted a live
+      fleet);
+    * a heartbeat may never yield :data:`DEAD` (its writer is shared, so a stale
+      beat looks identical whether the AGENT died or the WRITER did).
+
+    Write ``Signal(SOURCE_DELIVERY, DEAD, ...)`` today and it raises, instead of
+    silently arming the destruction gate.
+    """
+
+    reads: str
+    verdicts: frozenset[str]
+    blind_when: str
+
+    @property
+    def may_convict(self) -> bool:
+        """May a :data:`DEAD` from this instrument count toward destruction?"""
+        return DEAD in self.verdicts
+
+
+# EVERY instrument MUST have an entry here. This is not documentation: the suite
+# FAILS if an instrument is added without being classified, and
+# :meth:`Signal.__post_init__` refuses any instrument that is not a key. An
+# enumeration nobody is forced to update is a promise of completeness that
+# quietly stops being true.
+INSTRUMENT_INDEPENDENCE: dict[str, InstrumentSpec] = {
+    INSTRUMENT_LISTEN_BROKER: InstrumentSpec(
+        reads=(
+            "the sac listen broker's inbox-subscriber table — whether a message "
+            "would actually WAKE this agent. The one signal that asks the agent "
+            "instead of inspecting its shadow."
+        ),
+        # Never DEAD: zero subscribers is a DETACHED adapter, and agents with a
+        # detached adapter have been measured answering peer messages the same
+        # minute. UNREACHABLE must never be wired to anything destructive.
+        verdicts=frozenset({ALIVE, UNKNOWN}),
+        blind_when=(
+            "there is no local listen to ask, or the agent lives on another host"
+        ),
+    ),
+    INSTRUMENT_HOST_TMUX: InstrumentSpec(
+        reads=(
+            "the host tmux server's own session bookkeeping "
+            "(``tmux list-sessions``) — whether a ``tui-<name>`` session exists."
+        ),
+        verdicts=frozenset({ALIVE, DEAD, UNKNOWN}),
+        blind_when=(
+            "tmux is wedged, or we are inside a container and the host's tmux "
+            "socket is in another mount namespace (an EMPTY snapshot from in "
+            "there is namespace blindness, not an empty fleet)"
+        ),
+    ),
+    INSTRUMENT_PID_NAMESPACE: InstrumentSpec(
+        reads=(
+            "``os.kill(pid, 0)`` in THIS process's pid namespace — whether the "
+            "recorded pid is reaped. Both ``runtime.is_running`` (for pid-based "
+            "runtimes) and the ``instances`` row's pid check bottom out HERE, on "
+            "the SAME pid, by explicit design. They are ONE instrument."
+        ),
+        verdicts=frozenset({ALIVE, DEAD, UNKNOWN}),
+        blind_when=(
+            "we are inside a container (a host pid is not in our pid namespace, "
+            "so os.kill answers about a DIFFERENT process, or none at all), or "
+            "the row belongs to another host. A pid read across a namespace "
+            "boundary is not a weak sensor — it is NOT A SENSOR."
+        ),
+    ),
+    INSTRUMENT_AGENT_SELF: InstrumentSpec(
+        reads=(
+            "a file the agent's OWN in-process loop refreshed (the SDK heartbeat "
+            "writer). A fresh beat is the agent saying 'I am here'."
+        ),
+        # Never DEAD: a stale beat has two indistinguishable causes — the agent
+        # went away, or its writer did. It convicts nobody.
+        verdicts=frozenset({ALIVE, UNKNOWN}),
+        blind_when="the beat file is unreadable from here (e.g. a container $HOME)",
+    ),
+    INSTRUMENT_NO_OBSERVATION: InstrumentSpec(
+        reads=(
+            "nothing at all. The gatherer itself failed, so no sensor ever ran. "
+            "Exists so that 'we did not look' is a first-class, TYPED answer "
+            "rather than an absence that a counter can mistake for evidence."
+        ),
+        verdicts=frozenset({UNKNOWN}),
+        blind_when="always — by definition it observed nothing",
+    ),
+}
+
+INSTRUMENTS = frozenset(INSTRUMENT_INDEPENDENCE)
+
+# The instruments whose DEAD may count toward a destruction. Exactly two, and
+# they are genuinely independent: NO SINGLE SENSOR MALFUNCTION CAN PRODUCE BOTH.
+# A wedged or namespace-blind tmux yields UNKNOWN (not DEAD); a cross-namespace
+# pid read yields UNKNOWN (not DEAD). So a corroborated DEAD means: the tmux
+# server positively has no session for this agent, AND the kernel positively
+# says the recorded pid is reaped. Two different bookkeepers, two different
+# failure modes.
+CONVICTING_INSTRUMENTS = frozenset(
+    name for name, spec in INSTRUMENT_INDEPENDENCE.items() if spec.may_convict
+)
+
+
+@dataclass(frozen=True)
+class Signal:
+    """One observation about one agent.
+
+    ``verdict`` is ternary — :data:`ALIVE`, :data:`DEAD` or :data:`UNKNOWN`.
+    A probe that could not run MUST report :data:`UNKNOWN` with the reason in
+    ``detail``; it must never report :data:`DEAD`, because "I did not see it"
+    and "I saw that it is not there" are different facts and only the second
+    one may be acted on.
+
+    ``detail`` is operator-facing and is expected to be specific: not
+    "unhealthy" but ``pid=0 in heartbeat.json — no verdict possible`` or
+    ``no tmux session 'tui-grant' (probe succeeded)``. A row that reads
+    ``running | pid=None`` teaches an operator nothing; that is the UX bug
+    this field exists to fix.
+
+    ``instrument`` is WHAT PHYSICALLY OBSERVED THIS — the sensor, as opposed to
+    ``source``, which is merely the reporter that carried the news. It is
+    REQUIRED, and it must be one of the classified :data:`INSTRUMENTS`, because
+    the destruction gate counts DISTINCT INSTRUMENTS and a free string would let
+    one sensor masquerade as two witnesses. That is not hypothetical — it is the
+    bug this field was added to kill.
+    """
+
+    source: str
+    verdict: str
+    detail: str
+    instrument: str
+
+    def __post_init__(self) -> None:
+        if self.verdict not in (ALIVE, DEAD, UNKNOWN):
+            raise ValueError(
+                f"Signal.verdict must be one of {ALIVE!r} / {DEAD!r} / "
+                f"{UNKNOWN!r}, got {self.verdict!r}. A liveness signal is "
+                f"never a bool — 'I could not tell' is a first-class answer "
+                f"and must be spelled {UNKNOWN!r}, never collapsed into a pole."
+            )
+        spec = INSTRUMENT_INDEPENDENCE.get(self.instrument)
+        if spec is None:
+            raise ValueError(
+                f"Signal.instrument must be one of {sorted(INSTRUMENTS)!r}, got "
+                f"{self.instrument!r}. An instrument is the SENSOR that made the "
+                f"observation, and the destruction gate counts DISTINCT "
+                f"instruments — so an unclassified one could pose as an "
+                f"independent second witness and authorise killing a healthy "
+                f"agent. Declare it in INSTRUMENT_INDEPENDENCE (say what it "
+                f"physically reads, which verdicts it may emit, and when it is "
+                f"blind) rather than inventing a string here."
+            )
+        if self.verdict not in spec.verdicts:
+            raise ValueError(
+                f"instrument {self.instrument!r} may not emit {self.verdict!r} — "
+                f"it is declared to emit only {sorted(spec.verdicts)!r}. It "
+                f"reads: {spec.reads} If you believe it can now observe "
+                f"{self.verdict!r}, change its InstrumentSpec and defend it "
+                f"there; do not smuggle the claim in at a call site. (A DEAD "
+                f"from an instrument that cannot see death is how a detached "
+                f"inbox adapter got read as a corpse.)"
+            )
+
+    def to_dict(self) -> dict:
+        return {
+            "source": self.source,
+            "verdict": self.verdict,
+            "detail": self.detail,
+            "instrument": self.instrument,
+        }

--- a/src/scitex_agent_container/_lifecycle/_verdict_resolve.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict_resolve.py
@@ -1,41 +1,63 @@
 """Gather the real liveness signals and fold them into a :mod:`._verdict`.
 
-This is ALL of the verdict's IO and nothing else — the pure decision rule
-lives next door in :mod:`._verdict`, so the rule is testable without a
-process, a socket or a tmux server, and this module is testable against real
-ones. (Same split as ``_liveness_tick`` / ``_liveness_tick_detect`` /
-``_liveness_tick_resolve``.)
+This is the verdict's IO and nothing else — the pure decision rule lives next
+door in :mod:`._verdict`, so the rule is testable without a process, a socket or
+a tmux server, and this module is testable against real ones. Its neighbours:
 
-Every resolver here obeys one contract: **a probe that could not run returns
-UNKNOWN, never DEAD.** ``False`` and "I could not look" are different facts,
-and only one of them may be acted on.
+* :mod:`._verdict_instruments` — the evidence vocabulary (states, reporters,
+  SENSORS) and the independence declaration the destruction gate turns on.
+* :mod:`._verdict_tmux` — "can we even SEE the host's tmux / pid namespace from
+  where we are?" Blindness must come back as "I could not look", never as
+  "nothing is there".
+* :mod:`._verdict_state` — the signals read from a state ARTEFACT somebody else
+  wrote (the heartbeat file, the ``instances`` row). Re-exported below, because
+  callers and the suite have always imported them from here.
+
+Every resolver obeys two contracts:
+
+1. **A probe that could not run returns UNKNOWN, never DEAD.** ``False`` and
+   "I could not look" are different facts, and only one of them may be acted on.
+
+2. **A resolver declares the INSTRUMENT it actually touched** — the sensor, not
+   the reporter. ``process`` and ``registry`` are two reporters, but when the
+   runtime is pid-based they are ONE sensor: the same ``os.kill(pid, 0)`` on the
+   same pid, guaranteed identical by both runtimes' own docstrings. The
+   destruction gate deduplicates on the instrument, so getting this label right
+   is what stops one syscall from posing as two witnesses.
 
 Timeouts are deliberately GENEROUS. The host this fleet runs on idles at load
 60-70; a 2s probe against it is a coin toss, and a coin-toss timeout that
-renders as DEAD is a random agent-killer. Every deadline below is sized to be
-boring on a loaded box, because the cost of waiting an extra second is nothing
-and the cost of a false DEAD is a destroyed agent.
+renders as DEAD is a random agent-killer. Every deadline is sized to be boring
+on a loaded box, because the cost of waiting an extra second is nothing and the
+cost of a false DEAD is a destroyed agent.
 """
 
 from __future__ import annotations
 
-import os
-import time
-from pathlib import Path
 from typing import Any, Callable
 
 from ._verdict import (
     ALIVE,
     DEAD,
+    INSTRUMENT_HOST_TMUX,
+    INSTRUMENT_LISTEN_BROKER,
+    INSTRUMENT_NO_OBSERVATION,
+    INSTRUMENT_PID_NAMESPACE,
     SOURCE_DELIVERY,
-    SOURCE_HEARTBEAT,
     SOURCE_PROCESS,
-    SOURCE_REGISTRY,
     UNKNOWN,
     LivenessVerdict,
     Signal,
     decide,
 )
+from ._verdict_state import HEARTBEAT_STALE_S, heartbeat_signal, registry_signal
+from ._verdict_tmux import in_sif as _in_sif  # noqa: F401  (kept as a seam alias)
+from ._verdict_tmux import (
+    pid_namespace_is_observable,
+    session_name_for_config,
+    tmux_session_observation,
+)
+from ._verdict_tmux import tmux_probe_ran as _tmux_probe_ran  # noqa: F401
 
 __all__ = [
     "HEARTBEAT_STALE_S",
@@ -45,40 +67,6 @@ __all__ = [
     "registry_signal",
     "resolve_verdict",
 ]
-
-# A heartbeat older than this is no longer evidence of life. Ten minutes:
-# the writers beat about every 30s, so this is ~20 missed beats — long enough
-# that a loaded box, a slow FS or a stop-the-world GC cannot manufacture it,
-# short enough to be useful. It is NOT, on its own, evidence of DEATH; see
-# :func:`heartbeat_signal`.
-HEARTBEAT_STALE_S = 600.0
-
-_HEARTBEAT_FILENAME = "heartbeat.json"
-
-
-def _runtime_root() -> Path:
-    """The per-agent runtime state root (``~/.scitex/agent-container/runtime``).
-
-    Resolved at CALL time, never captured into a module-level constant. A
-    ``Path.home()``-derived constant computed at IMPORT cannot be redirected by
-    a fixture that sets ``$HOME`` — that exact bug had a suite in this repo
-    reading and WRITING the real fleet registry, and it is invisible in CI (no
-    fleet there, so it passes).
-
-    KNOWN BLIND SPOT, and it is deliberately left blind rather than guessed at:
-    inside a container ``$HOME`` is ``/home/agent``, not the operator's home, so
-    this resolves to a directory that does not exist and the heartbeat signal
-    comes back UNKNOWN. That is the CORRECT degradation — "I cannot see this
-    agent's heartbeat from here" — and UNKNOWN authorises nothing. The tempting
-    fix (guess at the operator's home and read a path we were not given) trades
-    an honest UNKNOWN for a confident answer about a file we are not sure is the
-    right one, which is how this class of bug is born in the first place.
-    """
-    return Path(os.path.expanduser("~")) / ".scitex" / "agent-container" / "runtime"
-
-
-def _heartbeat_path(name: str) -> Path:
-    return _runtime_root() / name / _HEARTBEAT_FILENAME
 
 
 # --------------------------------------------------------------------------
@@ -98,11 +86,11 @@ def delivery_signal(
     is attached, which is the only fact that predicts whether a message will
     actually wake it.
 
-    Deliberately CANNOT return :data:`DEAD`. Zero subscribers means a detached
-    inbox adapter, not a corpse — :mod:`.._listen._reachability` says so in as
-    many words ("``UNREACHABLE`` must NEVER be wired to anything destructive"),
-    and an agent with a detached adapter is routinely alive and working. It
-    degrades to :data:`UNKNOWN`, which authorises nothing.
+    Deliberately CANNOT return :data:`DEAD` — and that is now MECHANICAL, not a
+    convention: :data:`INSTRUMENT_LISTEN_BROKER` is declared to emit only
+    ALIVE/UNKNOWN, so a ``DEAD`` here raises at construction. Zero subscribers
+    means a detached inbox adapter, not a corpse; an agent with a detached
+    adapter is routinely alive and working.
 
     ``probe`` is the injection seam (a real callable returning the same
     ``(subscribers, reachable)`` tuple); production uses the real
@@ -121,6 +109,7 @@ def delivery_signal(
             UNKNOWN,
             f"could not ask the listen broker ({type(exc).__name__}) — "
             f"unobserved, NOT unreachable",
+            INSTRUMENT_LISTEN_BROKER,
         )
 
     if reachable == REACHABLE:
@@ -128,6 +117,7 @@ def delivery_signal(
             SOURCE_DELIVERY,
             ALIVE,
             f"{subscribers} live inbox subscriber(s) — the broker can wake it",
+            INSTRUMENT_LISTEN_BROKER,
         )
     if reachable == UNREACHABLE:
         # Observed ZERO subscribers on a bus we CAN see. That is evidence the
@@ -140,99 +130,20 @@ def delivery_signal(
             UNKNOWN,
             "0 inbox subscribers — the inbox adapter is DETACHED, which is "
             "not death; the agent may still be alive and working",
+            INSTRUMENT_LISTEN_BROKER,
         )
     return Signal(
         SOURCE_DELIVERY,
         UNKNOWN,
         "the broker cannot observe this agent (no local listen, or it lives "
         "on another host) — unobserved, NOT unreachable",
+        INSTRUMENT_LISTEN_BROKER,
     )
 
 
 # --------------------------------------------------------------------------
-# process — a session/pid probe. Ternary: the probe can FAIL.
+# process — a session/pid probe. Ternary, AND instrument-attributed.
 # --------------------------------------------------------------------------
-
-
-def _in_sif() -> bool:
-    """Are we running INSIDE an apptainer SIF (so the host's tmux is invisible)?
-
-    Reuses the canonical predicate the spawn/status brokers already key off
-    (:func:`.._lifecycle._in_sif_broker.is_in_sif`) rather than sniffing for
-    apptainer markers a second time — one definition of "am I in a container",
-    so the probe and the brokers can never disagree.
-    """
-    try:
-        from ._in_sif_broker import is_in_sif
-
-        return bool(is_in_sif())
-    except Exception:  # stx-allow: fallback (if we cannot even tell where we are, assume the cautious answer: we might be blind)
-        return True
-
-
-def _tmux_probe_ran(
-    socket_name: str | None = None,
-    *,
-    snapshot_fn: Callable[..., dict | None] | None = None,
-    in_sif_fn: Callable[[], bool] | None = None,
-) -> bool | None:
-    """Did a tmux probe run that could actually SEE this fleet's sessions?
-
-    ``True`` = yes, so a "no session" answer is a real observation of absence.
-    ``None`` = no, so a "no session" answer means "I could not look".
-
-    Two distinct ways the probe fails to see the fleet, and BOTH must map to
-    ``None`` — one of them bit this very module during development:
-
-    1. **The probe errored / tmux is wedged.**
-       :func:`.._runners._tmux._tmux_probe.list_sessions_activity` returns
-       ``None`` for this, exactly as its contract says.
-
-    2. **We are inside a container, and the host's tmux is in another mount
-       namespace.** This one is a TRAP, because the probe does not error — it
-       SUCCEEDS and reports an EMPTY fleet. From inside a SIF, ``tmux ls``
-       prints ``no server running on /tmp/tmux-1000/default`` (true! for the
-       CONTAINER's own /tmp), which is one of ``_tmux_probe``'s
-       "no server ⇒ confirmed-empty" markers, so ``list_sessions_activity()``
-       returns ``{}`` — "the probe succeeded and the fleet is genuinely empty".
-
-       MEASURED (2026-07-14): from inside this container that path made
-       ``process_signal`` return DEAD for ``grant`` — an agent holding a live
-       tmux session, a fresh heartbeat and a live inbox subscriber on the host.
-       A confident, well-evidenced, completely false death verdict. Only the
-       corroboration gate stopped it authorising anything.
-
-       So an empty snapshot taken from inside a SIF is NOT evidence of absence.
-       It is the same fact ``_listen._reachability`` already encodes for
-       cross-host peers: *a thing you are not in a position to observe must be
-       UNKNOWN, and never accused.*
-
-    ``snapshot_fn`` / ``in_sif_fn`` are injection seams taking REAL callables
-    (production resolves the real probe + the real in-SIF predicate).
-    """
-    snapshot_fn = snapshot_fn or _real_tmux_snapshot
-    in_sif_fn = in_sif_fn or _in_sif
-
-    try:
-        snapshot = snapshot_fn(socket_name=socket_name)
-    except Exception:  # stx-allow: fallback (cannot even ask tmux → we do not know whether a probe would have run)
-        return None
-
-    if snapshot is None:
-        return None  # the probe FAILED — its own contract already says so.
-    if not snapshot and in_sif_fn():
-        # An "empty fleet" seen from inside a container is namespace blindness,
-        # not an empty fleet. Refuse to treat a non-observation as one.
-        return None
-    return True
-
-
-def _real_tmux_snapshot(*, socket_name: str | None = None) -> dict | None:
-    """The real batched tmux probe. Kept behind a seam so tests drive the RULE
-    above without needing a live tmux server in a specific namespace."""
-    from .._runners._tmux._tmux_probe import list_sessions_activity
-
-    return list_sessions_activity(socket_name=socket_name)
 
 
 def process_signal(
@@ -240,23 +151,46 @@ def process_signal(
     runtime: Any,
     *,
     tmux_probe_ran: Callable[[], bool | None] | None = None,
+    session_observation: Callable[[str], tuple[bool | None, bool | None]] | None = None,
+    in_sif_fn: Callable[[], bool] | None = None,
 ) -> Signal:
-    """Is a process/session for this agent observably up?
+    """Is a process/session for this agent observably up, and WHO SAW IT?
 
-    ``runtime.is_running`` is a BOOL, and its ``False`` conflates two very
-    different facts: "I probed and there is nothing there" and "I could not
-    probe". This wraps it back into a ternary:
+    ``runtime.is_running`` is a BOOL, and its ``False`` conflates two entirely
+    different facts — "I probed and there is nothing there" versus "I could not
+    probe" — AND, for the TUI runtime, two different INSTRUMENTS. This unpacks
+    both.
 
-    * raises                       → :data:`UNKNOWN` (the probe blew up)
-    * ``True``                     → :data:`ALIVE`
-    * ``False`` + probe DID run    → :data:`DEAD` (positive: nothing is there)
-    * ``False`` + probe did NOT run→ :data:`UNKNOWN` (a wedged/invisible tmux)
+    The ternary:
 
-    The last case is the one that matters. ``TuiSessionRuntime.is_running``
-    bottoms out in ``TmuxManager.exists``, which returns ``False`` both for
-    "no such session" and for "I cannot talk to tmux at all" — and TUI is this
-    fleet's DEFAULT runtime, so collapsing those two would mark every agent
-    dead the moment the tmux server hiccups.
+    * raises                        → :data:`UNKNOWN` (the probe blew up)
+    * ``True``                      → :data:`ALIVE`
+    * ``False`` + probe DID run     → :data:`DEAD` (positive: nothing is there)
+    * ``False`` + probe did NOT run → :data:`UNKNOWN` (a wedged/invisible tmux)
+
+    THE INSTRUMENT ATTRIBUTION — the part that keeps the destruction gate honest.
+    ``TuiSessionRuntime.is_running`` is a CONJUNCTION: ``tmux session exists``
+    AND ``os.kill(pane_pid, 0)``. So a ``False`` has two possible authors, and
+    only one of them is independent of the registry:
+
+    * the tmux server has no such session → :data:`INSTRUMENT_HOST_TMUX`. A real,
+      independent bookkeeper.
+    * the session exists but the pane pid is reaped →
+      :data:`INSTRUMENT_PID_NAMESPACE`. This is THE SAME ``os.kill(pane_pid, 0)``
+      that :func:`._verdict_state.registry_signal` runs, on THE SAME pid
+      (``pane_pid_of`` is what feeds ``instances.pid``). Counting it as a second
+      witness next to the registry is one syscall wearing two hats — and it is
+      how a destruction got authorised on a single reading.
+
+    For a pid-based runtime (apptainer / claude-session) there is no tmux at all:
+    ``is_running`` IS ``os.kill(apptainer_pid, 0)``, so it is
+    :data:`INSTRUMENT_PID_NAMESPACE` outright — the same instrument the registry
+    reads, which means those two can NEVER corroborate each other. That is not a
+    regression; it is the truth, finally counted.
+
+    And a pid check from INSIDE a container is not a weak sensor, it is NOT A
+    SENSOR (different pid namespace), so it degrades to :data:`UNKNOWN` in BOTH
+    directions rather than confidently convicting a healthy host agent.
     """
     runtime_kind = str(getattr(config, "runtime", "") or "")
     is_tui = runtime_kind == "tui"
@@ -269,210 +203,87 @@ def process_signal(
             UNKNOWN,
             f"liveness probe raised {type(exc).__name__}: {exc} — the probe "
             f"did not run, which is not evidence of death",
+            INSTRUMENT_NO_OBSERVATION,
+        )
+
+    if not is_tui:
+        # A pid-based runtime. The ONLY thing is_running consults is
+        # os.kill(pid, 0) — the very instrument the registry row check uses.
+        observable, why_not = pid_namespace_is_observable(in_sif_fn=in_sif_fn)
+        if not observable:
+            return Signal(
+                SOURCE_PROCESS,
+                UNKNOWN,
+                f"{runtime_kind or 'runtime'} liveness is a pid check, and {why_not}",
+                INSTRUMENT_PID_NAMESPACE,
+            )
+        if running:
+            return Signal(
+                SOURCE_PROCESS,
+                ALIVE,
+                f"{runtime_kind or 'runtime'} probe: the recorded pid is alive",
+                INSTRUMENT_PID_NAMESPACE,
+            )
+        return Signal(
+            SOURCE_PROCESS,
+            DEAD,
+            f"{runtime_kind or 'runtime'} probe succeeded and the recorded pid "
+            f"is REAPED — positive evidence of absence. NOTE: this is the same "
+            f"os.kill(pid, 0) the registry runs, on the same pid, so the two "
+            f"CANNOT corroborate each other",
+            INSTRUMENT_PID_NAMESPACE,
         )
 
     if running:
         return Signal(
             SOURCE_PROCESS,
             ALIVE,
-            f"{runtime_kind or 'runtime'} probe: process/session is up",
+            "tui probe: the tmux session exists and its pane process is alive",
+            INSTRUMENT_HOST_TMUX,
         )
 
-    if is_tui:
-        ran_fn = tmux_probe_ran or _tmux_probe_ran
-        ran = ran_fn()
-        if ran is not True:
-            return Signal(
-                SOURCE_PROCESS,
-                UNKNOWN,
-                "the tmux probe itself FAILED (wedged tmux, or this process "
-                "cannot see the tmux socket) — 'no session' here means 'I "
-                "could not look', not 'the agent is gone'",
-            )
+    # TUI + not running. WHICH instrument observed the absence?
+    if tmux_probe_ran is not None:
+        # The legacy seam answers "did a probe run", not "what did it see".
+        ran: bool | None = tmux_probe_ran()
+        seen: bool | None = None
+    else:
+        observe = session_observation or (
+            lambda s: tmux_session_observation(s, in_sif_fn=in_sif_fn)
+        )
+        ran, seen = observe(session_name_for_config(config))
+
+    if ran is not True:
+        return Signal(
+            SOURCE_PROCESS,
+            UNKNOWN,
+            "the tmux probe itself FAILED (wedged tmux, or this process "
+            "cannot see the tmux socket) — 'no session' here means 'I "
+            "could not look', not 'the agent is gone'",
+            INSTRUMENT_HOST_TMUX,
+        )
+
+    if seen is False:
         return Signal(
             SOURCE_PROCESS,
             DEAD,
-            "tmux probe SUCCEEDED and this agent has no live session/pane "
-            "process — positive evidence of absence",
+            "tmux probe SUCCEEDED and the tmux server has NO session for this "
+            "agent — positive evidence of absence, from tmux's own bookkeeping",
+            INSTRUMENT_HOST_TMUX,
         )
 
+    # The session EXISTS (or, through the legacy seam, we could not tell WHICH
+    # half of the conjunction said no). Either way the only thing that can have
+    # failed is the pane-pid check — os.kill(pane_pid, 0) — which is the
+    # registry's instrument, not an independent one. THE AMBIGUITY RULE: label
+    # the instrument that COLLAPSES, never the one that invents a witness.
     return Signal(
         SOURCE_PROCESS,
         DEAD,
-        f"{runtime_kind or 'runtime'} probe succeeded and reports no running "
-        f"process — positive evidence of absence",
-    )
-
-
-# --------------------------------------------------------------------------
-# heartbeat — the agent's OWN writer. Fresh beat ⇒ alive.
-# --------------------------------------------------------------------------
-
-
-def heartbeat_signal(
-    name: str,
-    *,
-    now: float | None = None,
-    stale_s: float = HEARTBEAT_STALE_S,
-    path: Path | None = None,
-) -> Signal:
-    """Has this agent's heartbeat been refreshed recently?
-
-    WHO WRITES IT (this is not what the file's name suggests, and the
-    difference is the whole reason ``pid: 0`` misled everyone):
-    ``heartbeat.json`` for a TUI agent is written by a CENTRALIZED loop inside
-    ``sac listen`` (:func:`._tui_heartbeat_loop.tui_heartbeat_loop`), not by
-    the agent. That loop takes ONE batched ``tmux list-sessions`` snapshot and
-    beats only for agents whose ``tui-<name>`` session is actually IN it — and
-    a FAILED probe returns ``None`` and skips the whole tick, so a false beat
-    is never written. So:
-
-    * a FRESH mtime is sound evidence of life: ``sac listen`` observed this
-      agent's session in a probe that SUCCEEDED, seconds ago.
-    * the record's ``pid`` field is a **hardcoded literal 0**
-      (``write_fn(state_dir, pid=0, ...)``) — the central writer does not know
-      the pane pid and never did. It is not a signal, it never was one, and
-      nothing may decide anything on it. We surface it only so the next person
-      to read ``pid: 0`` is told, in words, that it means nothing.
-
-    NEVER RETURNS :data:`DEAD`, on purpose. A stale beat has two
-    indistinguishable causes — the agent went away, or the shared writer inside
-    ``sac listen`` stopped (a loop known to blow its budget and get abandoned,
-    which freezes EVERY agent's beat at once). Worse, for a TUI agent this
-    signal is DERIVED FROM THE SAME tmux probe as :func:`process_signal`, so
-    convicting on it would not be independent corroboration — it would be the
-    same observation, counted twice. :func:`process_signal` already carries the
-    DEAD case, honestly and once.
-    """
-    now = time.time() if now is None else now
-    hb = path if path is not None else _heartbeat_path(name)
-
-    try:
-        mtime = hb.stat().st_mtime
-    except OSError:  # stx-allow: fallback (no heartbeat file at all → no channel that could have shown life → UNKNOWN, never DEAD)
-        return Signal(
-            SOURCE_HEARTBEAT,
-            UNKNOWN,
-            f"no heartbeat file at {hb} — no channel that could have shown "
-            f"life, so nothing is proven either way",
-        )
-
-    age = now - mtime
-    # Surface the record's pid purely as a DE-MYSTIFIER. See the docstring:
-    # for a TUI agent it is a hardcoded 0 written by sac listen.
-    pid_note = ""
-    try:
-        import json as _json
-
-        record = _json.loads(hb.read_text(encoding="utf-8", errors="replace"))
-        if isinstance(record, dict):
-            pid = record.get("pid")
-            if isinstance(pid, int) and not isinstance(pid, bool) and pid <= 0:
-                pid_note = (
-                    f"; record pid={pid} is a HARDCODED literal from the "
-                    f"central listen-side writer, not a fact about the agent "
-                    f"— it decides nothing"
-                )
-            elif isinstance(pid, int) and not isinstance(pid, bool):
-                pid_note = f"; record pid={pid}"
-    except (
-        OSError,
-        ValueError,
-    ):  # stx-allow: fallback (a torn heartbeat write still has a usable mtime; the pid note is a nicety)
-        pass
-
-    if age < stale_s:
-        return Signal(
-            SOURCE_HEARTBEAT,
-            ALIVE,
-            f"beaten {age:.0f}s ago (< {stale_s:.0f}s) — sac listen observed "
-            f"this agent's session in a SUCCESSFUL probe that recently{pid_note}",
-        )
-
-    return Signal(
-        SOURCE_HEARTBEAT,
-        UNKNOWN,
-        f"beat is {age:.0f}s stale — but the writer is a shared loop inside "
-        f"sac listen, so this looks identical whether the agent went away or "
-        f"the writer did. It convicts nobody{pid_note}",
-    )
-
-
-# --------------------------------------------------------------------------
-# registry — a DECLARATION. Asymmetric: a reaped pid is proof, a live one is not.
-# --------------------------------------------------------------------------
-
-
-def registry_signal(
-    name: str,
-    *,
-    rows: list[dict] | None = None,
-    pid_alive: Callable[[int], bool] | None = None,
-) -> Signal:
-    """What does the ``instances`` table DECLARE, and can we corroborate it?
-
-    A registry row is a declaration someone wrote once, not an observation. It
-    can vouch for a corpse, and on this fleet it is routinely missing (or
-    carries ``pid = NULL``) for perfectly healthy agents. So:
-
-    * no row / unreadable table / ``pid`` NULL → :data:`UNKNOWN`. Absence of a
-      row is NOT evidence of death; that inference is what alarmed ~100 false
-      criticals per sweep against agents serving HTTP in the same log.
-    * recorded pid CONFIRMED REAPED → :data:`DEAD`. This is genuinely positive:
-      ``os.kill(pid, 0)`` raising ESRCH means *that* process does not exist.
-    * recorded pid alive → :data:`UNKNOWN`, deliberately NOT ALIVE. Pids are
-      RECYCLED, so a live pid may belong to an unrelated process that has
-      merely inherited the number, and it would then vouch for a dead agent.
-      The evidence is asymmetric and we grade it that way.
-    """
-    if pid_alive is None:
-        from .._listen._agent_exec_liveness import (
-            _pid_alive as pid_alive,  # type: ignore
-        )
-
-    if rows is None:
-        try:
-            from .._state.state_db import list_active_instances
-
-            rows = list_active_instances(host=None)
-        except Exception as exc:  # stx-allow: fallback (an unreadable registry is UNKNOWN — reading it as "every agent is dead" is the documented flood)
-            return Signal(
-                SOURCE_REGISTRY,
-                UNKNOWN,
-                f"instances table unreadable ({type(exc).__name__}) — a "
-                f"registry failure is not agent death",
-            )
-
-    mine = [r for r in (rows or ()) if r.get("name") == name]
-    if not mine:
-        return Signal(
-            SOURCE_REGISTRY,
-            UNKNOWN,
-            "no active instances row — a declaration is missing, which is not "
-            "evidence of death (healthy agents routinely have no row here)",
-        )
-
-    pid = mine[0].get("pid")
-    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
-        return Signal(
-            SOURCE_REGISTRY,
-            UNKNOWN,
-            f"active row declares this agent running, but records pid={pid!r} "
-            f"— nothing to corroborate against, so no verdict",
-        )
-
-    if pid_alive(pid):
-        return Signal(
-            SOURCE_REGISTRY,
-            UNKNOWN,
-            f"active row, recorded pid={pid} is alive — corroborating, but "
-            f"pids are RECYCLED so this alone does not prove it is OUR process",
-        )
-    return Signal(
-        SOURCE_REGISTRY,
-        DEAD,
-        f"active row records pid={pid}, and that pid is REAPED — the process "
-        f"the registry points at does not exist",
+        "tmux probe SUCCEEDED; the session is present but its pane process is "
+        "gone — os.kill(pane_pid, 0) says REAPED. That is the SAME syscall on "
+        "the SAME pid the registry checks, so it is NOT independent of it",
+        INSTRUMENT_PID_NAMESPACE,
     )
 
 
@@ -502,13 +313,21 @@ def resolve_verdict(
     these).
     """
     signals: list[Signal] = []
+    kind = str(getattr(config, "runtime", "") or "") if config is not None else ""
 
     signals.append((delivery or delivery_signal)(name))
 
     if config is not None and runtime is not None:
         signals.append((process or process_signal)(config, runtime))
 
-    signals.append((heartbeat or heartbeat_signal)(name))
+    if heartbeat is None:
+        # runtime_kind decides WHOSE writer produced the beat, hence which
+        # instrument it is. For a TUI agent it is a re-report of the same tmux
+        # snapshot process_signal reads — not a second sensor.
+        signals.append(heartbeat_signal(name, runtime_kind=kind))
+    else:
+        signals.append(heartbeat(name))
+
     signals.append((registry or registry_signal)(name))
 
     return decide(name, signals)

--- a/src/scitex_agent_container/_lifecycle/_verdict_state.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict_state.py
@@ -1,0 +1,290 @@
+"""Liveness signals read from a STATE ARTEFACT that somebody else wrote.
+
+Split out of :mod:`._verdict_resolve` (512-line cap) along a real seam.
+:mod:`._verdict_resolve` PROBES — it asks the broker, it asks the runtime. This
+module READS THINGS OTHER PROCESSES LEFT BEHIND: a heartbeat file and a row in
+the ``instances`` table.
+
+That difference is the whole reason both resolvers here are so cautious. An
+artefact is a claim made by a writer who is not the agent and is not us:
+
+* it can be STALE because its WRITER died, not because the agent did (the TUI
+  heartbeat is written by a shared loop inside ``sac listen``, so when that loop
+  is abandoned EVERY agent's beat freezes at once — a fact about the writer,
+  reported as if it were a fact about twenty agents);
+* it can OUTLIVE the thing it describes (a registry row survives the process, so
+  a stopped agent's row still declares it running);
+* and the only thing in here that actually OBSERVES anything is
+  ``os.kill(pid, 0)`` — which is not a sensor at all unless we are in the pid
+  namespace that minted the pid.
+
+So: :func:`heartbeat_signal` NEVER convicts, and :func:`registry_signal` convicts
+only on a pid it was genuinely in a position to read.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Callable
+
+from ._verdict import (
+    ALIVE,
+    DEAD,
+    INSTRUMENT_AGENT_SELF,
+    INSTRUMENT_HOST_TMUX,
+    INSTRUMENT_NO_OBSERVATION,
+    INSTRUMENT_PID_NAMESPACE,
+    SOURCE_HEARTBEAT,
+    SOURCE_REGISTRY,
+    UNKNOWN,
+    Signal,
+)
+from ._verdict_tmux import pid_namespace_is_observable
+
+__all__ = [
+    "HEARTBEAT_STALE_S",
+    "heartbeat_signal",
+    "registry_signal",
+]
+
+# A heartbeat older than this is no longer evidence of life. Ten minutes:
+# the writers beat about every 30s, so this is ~20 missed beats — long enough
+# that a loaded box, a slow FS or a stop-the-world GC cannot manufacture it,
+# short enough to be useful. It is NOT, on its own, evidence of DEATH; see
+# :func:`heartbeat_signal`.
+HEARTBEAT_STALE_S = 600.0
+
+_HEARTBEAT_FILENAME = "heartbeat.json"
+
+
+def _runtime_root() -> Path:
+    """The per-agent runtime state root (``~/.scitex/agent-container/runtime``).
+
+    Resolved at CALL time, never captured into a module-level constant. A
+    ``Path.home()``-derived constant computed at IMPORT cannot be redirected by
+    a fixture that sets ``$HOME`` — that exact bug had a suite in this repo
+    reading and WRITING the real fleet registry, and it is invisible in CI (no
+    fleet there, so it passes).
+
+    KNOWN BLIND SPOT, and it is deliberately left blind rather than guessed at:
+    inside a container ``$HOME`` is ``/home/agent``, not the operator's home, so
+    this resolves to a directory that does not exist and the heartbeat signal
+    comes back UNKNOWN. That is the CORRECT degradation — "I cannot see this
+    agent's heartbeat from here" — and UNKNOWN authorises nothing. The tempting
+    fix (guess at the operator's home and read a path we were not given) trades
+    an honest UNKNOWN for a confident answer about a file we are not sure is the
+    right one, which is how this class of bug is born in the first place.
+    """
+    return Path(os.path.expanduser("~")) / ".scitex" / "agent-container" / "runtime"
+
+
+def _heartbeat_path(name: str) -> Path:
+    return _runtime_root() / name / _HEARTBEAT_FILENAME
+
+
+def heartbeat_signal(
+    name: str,
+    *,
+    now: float | None = None,
+    stale_s: float = HEARTBEAT_STALE_S,
+    path: Path | None = None,
+    runtime_kind: str = "",
+) -> Signal:
+    """Has this agent's heartbeat been refreshed recently?
+
+    WHO WRITES IT (this is not what the file's name suggests, and the
+    difference is the whole reason ``pid: 0`` misled everyone):
+    ``heartbeat.json`` for a TUI agent is written by a CENTRALIZED loop inside
+    ``sac listen`` (:func:`._tui_heartbeat_loop.tui_heartbeat_loop`), not by
+    the agent. That loop takes ONE batched ``tmux list-sessions`` snapshot and
+    beats only for agents whose ``tui-<name>`` session is actually IN it — and
+    a FAILED probe returns ``None`` and skips the whole tick, so a false beat
+    is never written. So:
+
+    * a FRESH mtime is sound evidence of life: ``sac listen`` observed this
+      agent's session in a probe that SUCCEEDED, seconds ago.
+    * the record's ``pid`` field is a **hardcoded literal 0**
+      (``write_fn(state_dir, pid=0, ...)``) — the central writer does not know
+      the pane pid and never did. It is not a signal, it never was one, and
+      nothing may decide anything on it. We surface it only so the next person
+      to read ``pid: 0`` is told, in words, that it means nothing.
+
+    WHICH INSTRUMENT THIS IS depends on WHO WROTE THE FILE, which is why
+    ``runtime_kind`` is threaded in:
+
+    * ``tui`` → :data:`INSTRUMENT_HOST_TMUX`. The beat is a RE-REPORT of the very
+      same ``tmux list-sessions`` snapshot :func:`._verdict_resolve.process_signal`
+      reads. It is not a second sensor, and labelling it as one would let ``sac
+      listen``'s belief vote twice.
+    * anything else → :data:`INSTRUMENT_AGENT_SELF`: the SDK loop runs INSIDE the
+      agent, so a fresh beat really is the agent saying "I am here".
+
+    NEVER RETURNS :data:`DEAD`, on purpose — and that is now ENFORCED by both
+    instruments' specs rather than merely intended. A stale beat has two
+    indistinguishable causes: the agent went away, or the shared writer inside
+    ``sac listen`` stopped (a loop known to blow its budget and get abandoned,
+    which freezes EVERY agent's beat at once).
+    """
+    now = time.time() if now is None else now
+    hb = path if path is not None else _heartbeat_path(name)
+    instrument = (
+        INSTRUMENT_HOST_TMUX if runtime_kind == "tui" else INSTRUMENT_AGENT_SELF
+    )
+
+    try:
+        mtime = hb.stat().st_mtime
+    except OSError:  # stx-allow: fallback (no heartbeat file at all → no channel that could have shown life → UNKNOWN, never DEAD)
+        return Signal(
+            SOURCE_HEARTBEAT,
+            UNKNOWN,
+            f"no heartbeat file at {hb} — no channel that could have shown "
+            f"life, so nothing is proven either way",
+            instrument,
+        )
+
+    age = now - mtime
+    # Surface the record's pid purely as a DE-MYSTIFIER. See the docstring:
+    # for a TUI agent it is a hardcoded 0 written by sac listen.
+    pid_note = ""
+    try:
+        import json as _json
+
+        record = _json.loads(hb.read_text(encoding="utf-8", errors="replace"))
+        if isinstance(record, dict):
+            pid = record.get("pid")
+            if isinstance(pid, int) and not isinstance(pid, bool) and pid <= 0:
+                pid_note = (
+                    f"; record pid={pid} is a HARDCODED literal from the "
+                    f"central listen-side writer, not a fact about the agent "
+                    f"— it decides nothing"
+                )
+            elif isinstance(pid, int) and not isinstance(pid, bool):
+                pid_note = f"; record pid={pid}"
+    except (
+        OSError,
+        ValueError,
+    ):  # stx-allow: fallback (a torn heartbeat write still has a usable mtime; the pid note is a nicety)
+        pass
+
+    if age < stale_s:
+        return Signal(
+            SOURCE_HEARTBEAT,
+            ALIVE,
+            f"beaten {age:.0f}s ago (< {stale_s:.0f}s) — sac listen observed "
+            f"this agent's session in a SUCCESSFUL probe that recently{pid_note}",
+            instrument,
+        )
+
+    return Signal(
+        SOURCE_HEARTBEAT,
+        UNKNOWN,
+        f"beat is {age:.0f}s stale — but the writer is a shared loop inside "
+        f"sac listen, so this looks identical whether the agent went away or "
+        f"the writer did. It convicts nobody{pid_note}",
+        instrument,
+    )
+
+
+def registry_signal(
+    name: str,
+    *,
+    rows: list[dict] | None = None,
+    pid_alive: Callable[[int], bool] | None = None,
+    in_sif_fn: Callable[[], bool] | None = None,
+) -> Signal:
+    """What does the ``instances`` table DECLARE, and can we corroborate it?
+
+    A registry row is a declaration someone wrote once, not an observation. It
+    can vouch for a corpse, and on this fleet it is routinely missing (or
+    carries ``pid = NULL``) for perfectly healthy agents. The only thing here
+    that ever OBSERVES anything is the pid check, so:
+
+    * no row / unreadable table / ``pid`` NULL → :data:`UNKNOWN`, on
+      :data:`INSTRUMENT_NO_OBSERVATION` — the sensor never ran. Absence of a row
+      is NOT evidence of death; that inference is what alarmed ~100 false
+      criticals per sweep against agents serving HTTP in the same log.
+    * we cannot READ this pid namespace (we are in a container, or the row was
+      written on another host) → :data:`UNKNOWN`. A pid across a namespace
+      boundary is not a weak sensor; it is not a sensor.
+    * recorded pid CONFIRMED REAPED → :data:`DEAD`. Genuinely positive:
+      ``os.kill(pid, 0)`` raising ESRCH means *that* process does not exist.
+    * recorded pid alive → :data:`UNKNOWN`, deliberately NOT ALIVE. Pids are
+      RECYCLED, so a live pid may belong to an unrelated process that has
+      merely inherited the number, and it would then vouch for a dead agent.
+
+    THE INSTRUMENT: every verdict this function can actually OBSERVE comes out of
+    ``os.kill(pid, 0)`` — :data:`INSTRUMENT_PID_NAMESPACE`. That is the same
+    instrument :func:`._verdict_resolve.process_signal` uses for a pid-based
+    runtime, and the same one it falls back to for a TUI agent whose session
+    exists but whose pane pid is gone. Both runtimes deliberately record the pid
+    that ``is_running`` probes ("the registry and ``is_running`` can never
+    disagree"), so the "two" witnesses are one. The gate now knows that.
+    """
+    if pid_alive is None:
+        from .._listen._agent_exec_liveness import (
+            _pid_alive as pid_alive,  # type: ignore
+        )
+
+    if rows is None:
+        try:
+            from .._state.state_db import list_active_instances
+
+            rows = list_active_instances(host=None)
+        except Exception as exc:  # stx-allow: fallback (an unreadable registry is UNKNOWN — reading it as "every agent is dead" is the documented flood)
+            return Signal(
+                SOURCE_REGISTRY,
+                UNKNOWN,
+                f"instances table unreadable ({type(exc).__name__}) — a "
+                f"registry failure is not agent death",
+                INSTRUMENT_NO_OBSERVATION,
+            )
+
+    mine = [r for r in (rows or ()) if r.get("name") == name]
+    if not mine:
+        return Signal(
+            SOURCE_REGISTRY,
+            UNKNOWN,
+            "no active instances row — a declaration is missing, which is not "
+            "evidence of death (healthy agents routinely have no row here)",
+            INSTRUMENT_NO_OBSERVATION,
+        )
+
+    row = mine[0]
+    pid = row.get("pid")
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return Signal(
+            SOURCE_REGISTRY,
+            UNKNOWN,
+            f"active row declares this agent running, but records pid={pid!r} "
+            f"— nothing to corroborate against, so no verdict",
+            INSTRUMENT_NO_OBSERVATION,
+        )
+
+    observable, why_not = pid_namespace_is_observable(
+        row_host=row.get("host"), in_sif_fn=in_sif_fn
+    )
+    if not observable:
+        return Signal(
+            SOURCE_REGISTRY,
+            UNKNOWN,
+            f"active row records pid={pid}, but {why_not}",
+            INSTRUMENT_PID_NAMESPACE,
+        )
+
+    if pid_alive(pid):
+        return Signal(
+            SOURCE_REGISTRY,
+            UNKNOWN,
+            f"active row, recorded pid={pid} is alive — corroborating, but "
+            f"pids are RECYCLED so this alone does not prove it is OUR process",
+            INSTRUMENT_PID_NAMESPACE,
+        )
+    return Signal(
+        SOURCE_REGISTRY,
+        DEAD,
+        f"active row records pid={pid}, and that pid is REAPED — the process "
+        f"the registry points at does not exist",
+        INSTRUMENT_PID_NAMESPACE,
+    )

--- a/src/scitex_agent_container/_lifecycle/_verdict_tmux.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict_tmux.py
@@ -1,0 +1,204 @@
+"""Can we SEE the host's tmux and the host's pid namespace from where we are?
+
+Split out of :mod:`._verdict_resolve` (512-line cap). Every function here answers
+one question: **is this instrument a sensor from HERE, or are we blind?** — and
+blindness must always come back as "I could not look", never as "nothing is
+there".
+
+That distinction is not academic. Both of the sensors this module fronts are
+namespace-scoped, and a container sits in a DIFFERENT namespace:
+
+* **tmux** — from inside a SIF, ``tmux ls`` prints *"no server running on
+  /tmp/tmux-1000/default"*. True! of the CONTAINER's own ``/tmp``. That is one of
+  ``_tmux_probe``'s "no server ⇒ confirmed-empty" markers, so the probe does not
+  fail — it SUCCEEDS and reports an EMPTY fleet.
+* **pids** — from inside a SIF, ``os.kill(host_pid, 0)`` raises ESRCH because
+  that pid does not exist in OUR pid namespace. Worse, the number may be reused
+  by an unrelated container process, in which case it lies in the other
+  direction.
+
+MEASURED 2026-07-14: run from inside this container, the tmux path made
+``process_signal`` return DEAD for ``grant`` — an agent holding a live tmux
+session, a fresh heartbeat and a live inbox subscriber on the host. A confident,
+well-evidenced, completely false death verdict.
+
+A pid or a session read across a namespace boundary is not a WEAK sensor. It is
+NOT A SENSOR. It must return UNKNOWN, in both directions.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+__all__ = [
+    "in_sif",
+    "pid_namespace_is_observable",
+    "session_name_for_config",
+    "tmux_probe_ran",
+    "tmux_session_observation",
+]
+
+
+def in_sif() -> bool:
+    """Are we running INSIDE an apptainer SIF (so the host's tmux/pids are gone)?
+
+    Reuses the canonical predicate the spawn/status brokers already key off
+    (:func:`.._lifecycle._in_sif_broker.is_in_sif`) rather than sniffing for
+    apptainer markers a second time — one definition of "am I in a container",
+    so the probe and the brokers can never disagree.
+
+    Fails CAUTIOUS: if we cannot even tell where we are, assume we might be
+    blind. That direction costs us a refused destruction; the other direction
+    costs us a destroyed agent.
+    """
+    try:
+        from ._in_sif_broker import is_in_sif
+
+        return bool(is_in_sif())
+    except Exception:  # stx-allow: fallback (if we cannot even tell where we are, assume the cautious answer: we might be blind)
+        return True
+
+
+def pid_namespace_is_observable(
+    *,
+    row_host: str | None = None,
+    in_sif_fn: Callable[[], bool] | None = None,
+    local_host_fn: Callable[[], str] | None = None,
+) -> tuple[bool, str]:
+    """Is ``os.kill(pid, 0)`` a SENSOR from here? ``(observable, why_not)``.
+
+    Two ways a recorded pid is not ours to read, and both must degrade to
+    UNKNOWN rather than to a confident DEAD:
+
+    1. **We are in a container.** A host pid is not in our pid namespace, so
+       ``os.kill`` answers about a different process — or none.
+    2. **The row belongs to another host.** Its pid was minted on a machine we
+       cannot see; the same integer here is an unrelated local process.
+
+    ``row_host=None`` skips check 2 (the caller has no host to compare).
+    """
+    if (in_sif_fn or in_sif)():
+        return False, (
+            "we are INSIDE a container, so the recorded pid lives in the HOST's "
+            "pid namespace and os.kill here cannot see it — a pid read across a "
+            "namespace boundary is not a weak sensor, it is NOT A SENSOR"
+        )
+    if row_host:
+        local = (local_host_fn or _local_host)()
+        if local and row_host != local:
+            return False, (
+                f"the row was written on host {row_host!r} but we are on "
+                f"{local!r} — that pid was minted in another machine's namespace, "
+                f"so os.kill here would be asking about an unrelated local process"
+            )
+    return True, ""
+
+
+def _local_host() -> str:
+    """This machine's name, as the ``instances`` table records it."""
+    import socket
+
+    try:
+        return socket.gethostname()
+    except Exception:  # stx-allow: fallback (an unknowable hostname must not manufacture a cross-host mismatch — return "" so the caller skips the check)
+        return ""
+
+
+def _real_tmux_snapshot(*, socket_name: str | None = None) -> dict | None:
+    """The real batched tmux probe, behind a seam so tests drive the RULE."""
+    from .._runners._tmux._tmux_probe import list_sessions_activity
+
+    return list_sessions_activity(socket_name=socket_name)
+
+
+def _observed_snapshot(
+    socket_name: str | None,
+    snapshot_fn: Callable[..., dict | None] | None,
+    in_sif_fn: Callable[[], bool] | None,
+) -> dict | None:
+    """The tmux snapshot IF we were actually in a position to take one.
+
+    ``None`` means "I could not look" — which covers BOTH ways the probe fails
+    to see the fleet, and both must map here:
+
+    1. the probe errored / tmux is wedged (``list_sessions_activity`` already
+       returns ``None`` for this, exactly as its contract says);
+    2. we are inside a container and the host's tmux is in another mount
+       namespace — the TRAP, because the probe does not error, it SUCCEEDS and
+       reports an EMPTY fleet.
+    """
+    snapshot_fn = snapshot_fn or _real_tmux_snapshot
+    in_sif_fn = in_sif_fn or in_sif
+
+    try:
+        snapshot = snapshot_fn(socket_name=socket_name)
+    except Exception:  # stx-allow: fallback (cannot even ask tmux → we do not know whether a probe would have run)
+        return None
+
+    if snapshot is None:
+        return None  # the probe FAILED — its own contract already says so.
+    if not snapshot and in_sif_fn():
+        # An "empty fleet" seen from inside a container is namespace blindness,
+        # not an empty fleet. Refuse to treat a non-observation as one.
+        return None
+    return snapshot
+
+
+def tmux_probe_ran(
+    socket_name: str | None = None,
+    *,
+    snapshot_fn: Callable[..., dict | None] | None = None,
+    in_sif_fn: Callable[[], bool] | None = None,
+) -> bool | None:
+    """Did a tmux probe run that could actually SEE this fleet's sessions?
+
+    ``True`` = yes, so a "no session" answer is a real observation of absence.
+    ``None`` = no, so a "no session" answer means "I could not look".
+    """
+    snapshot = _observed_snapshot(socket_name, snapshot_fn, in_sif_fn)
+    return True if snapshot is not None else None
+
+
+def tmux_session_observation(
+    session_name: str,
+    *,
+    socket_name: str | None = None,
+    snapshot_fn: Callable[..., dict | None] | None = None,
+    in_sif_fn: Callable[[], bool] | None = None,
+) -> tuple[bool | None, bool | None]:
+    """``(probe_ran, session_present)`` — and WHICH instrument may speak.
+
+    This exists because ``TuiSessionRuntime.is_running`` is a CONJUNCTION —
+    ``tmux session exists`` AND ``os.kill(pane_pid, 0)`` — collapsed into one
+    bool. Its ``False`` therefore has two very different authors, and they are
+    two DIFFERENT INSTRUMENTS:
+
+    * the tmux server says there is no such session  → ``host_tmux`` observed it;
+    * the session EXISTS but its pane pid is reaped  → ``pid_namespace`` observed
+      it, which is THE SAME ``os.kill(pane_pid, 0)`` that the ``instances`` row
+      check runs, on THE SAME pid (``pane_pid_of`` feeds ``instances.pid``).
+
+    Counting the second case as an independent witness alongside the registry is
+    exactly the bug: one syscall, two hats, and a destruction authorised on it.
+    So the caller needs to know WHICH of the two spoke, and this is what tells it.
+
+    ``(None, None)`` — we could not look at all.
+    """
+    snapshot = _observed_snapshot(socket_name, snapshot_fn, in_sif_fn)
+    if snapshot is None:
+        return None, None
+    return True, session_name in snapshot
+
+
+def session_name_for_config(config: Any) -> str:
+    """The tmux session name sac owns for this agent (``tui-<name>``).
+
+    Goes through the runtime's own canonical helper so the probe and the runtime
+    can never drift apart about which session belongs to whom.
+    """
+    try:
+        from ..runtimes.tui_session import session_name_for
+
+        return str(session_name_for(config))
+    except Exception:  # stx-allow: fallback (an unresolvable session name must not crash a liveness read; the caller degrades to the ambiguous-instrument branch, which COLLAPSES rather than inventing a witness)
+        return f"tui-{getattr(config, 'name', '')}"

--- a/src/scitex_agent_container/cli_pkg/_health_liveness.py
+++ b/src/scitex_agent_container/cli_pkg/_health_liveness.py
@@ -39,7 +39,13 @@ def liveness_payload(name: str, config: Any) -> dict:
     destructive), and never to an exception that takes the health command down.
     """
     from .._lifecycle._runtime_select import _get_runtime
-    from .._lifecycle._verdict import UNKNOWN, LivenessVerdict, Signal
+    from .._lifecycle._verdict import (
+        INSTRUMENT_NO_OBSERVATION,
+        SOURCE_RESOLVER,
+        UNKNOWN,
+        LivenessVerdict,
+        Signal,
+    )
     from .._lifecycle._verdict_resolve import resolve_verdict
 
     try:
@@ -50,9 +56,10 @@ def liveness_payload(name: str, config: Any) -> dict:
             verdict=UNKNOWN,
             signals=(
                 Signal(
-                    "resolver",
+                    SOURCE_RESOLVER,
                     UNKNOWN,
                     f"could not gather liveness evidence ({type(exc).__name__}: {exc})",
+                    INSTRUMENT_NO_OBSERVATION,
                 ),
             ),
         ).to_dict()

--- a/tests/scitex_agent_container/_lifecycle/test__start_failure_diag_persists.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_failure_diag_persists.py
@@ -19,10 +19,12 @@ blaming the PANE CAPTURE for a failure it never observed. Exactly the disease th
 liveness verdict next door exists to kill: an error asserting a cause it did not
 see.
 
-Found because it turned CI red: two ``test_lifecycle`` tests assert this file
-exists, and they only ever passed when some OTHER test in the same xdist worker
-happened to create ``<floor>/runtime/alpha/`` first. Reordering the suite (two
-new test files) exposed a latent order-dependency AND the real hole under it.
+EVERY TEST HERE OWNS A UNIQUE AGENT NAME, and that is not cosmetic. The bug
+surfaced because two ``test_lifecycle`` tests assert this file for an agent
+called ``alpha``, and they only ever passed when some OTHER test in the same
+xdist worker happened to create ``<floor>/runtime/alpha/`` first. A suite that
+depends on a sibling's leftovers is testing the schedule, not the code — so these
+tests refuse to share a name with anyone.
 
 NO MOCKS (repo doctrine): the exploding tmux layer below is a REAL callable
 passed through the production seam, not a patched internal.
@@ -30,21 +32,19 @@ passed through the production seam, not a patched internal.
 
 from __future__ import annotations
 
-import os
+import uuid
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
 import pytest
 
 from scitex_agent_container._lifecycle._start_failure_diag import raise_start_failure
 
-_RUNTIME_DIR_ENV = "SCITEX_AGENT_CONTAINER_RUNTIME_DIR"
-
 
 class _Cfg:
     """A real minimal config — the attributes the diag path resolution reads."""
 
-    def __init__(self, name: str = "alpha", runtime: str = "apptainer") -> None:
+    def __init__(self, name: str, runtime: str = "apptainer") -> None:
         self.name = name
         self.runtime = runtime
 
@@ -55,106 +55,99 @@ def _wedged_tmux(_config: Any) -> str:
 
 
 @pytest.fixture
-def state_root(tmp_path: Path) -> Iterator[Path]:
-    """Point sac's runtime root at a dir the agent has NEVER written to.
+def config() -> _Cfg:
+    """An agent NOBODY else has ever started, so its state dir cannot exist.
 
-    The real production shape: an agent whose start failed early has no state
-    dir, because nothing ever got far enough to create one.
+    That is the real production shape: a start that failed early never created
+    its state dir. Sharing a name with another test would silently hand us a
+    directory somebody else made, and the regression below would stop being
+    reproducible — which is exactly how the bug survived.
     """
-    root = tmp_path / "runtime"
-    previous = os.environ.get(_RUNTIME_DIR_ENV)
-    os.environ[_RUNTIME_DIR_ENV] = str(root)
-    yield root
-    if previous is None:
-        os.environ.pop(_RUNTIME_DIR_ENV, None)
-    else:
-        os.environ[_RUNTIME_DIR_ENV] = previous
+    return _Cfg(name=f"diagfail-{uuid.uuid4().hex[:12]}")
+
+
+def _state_dir(config: _Cfg) -> Path:
+    from scitex_agent_container.runtimes.tui_session import state_dir_for_config
+
+    return state_dir_for_config(config)
 
 
 def _diag_log(config: _Cfg) -> Path:
-    from scitex_agent_container.runtimes.tui_session import state_dir_for_config
-
-    return state_dir_for_config(config) / "start_failure_diag.log"
+    return _state_dir(config) / "start_failure_diag.log"
 
 
 def _raise_and_swallow(config: _Cfg, **kwargs: Any) -> None:
-    """Drive the real failure path. It ALWAYS raises; the record is the subject."""
+    """Drive the real failure path. It ALWAYS raises; the RECORD is the subject."""
     try:
         raise_start_failure(config, **kwargs)
     except RuntimeError:
         pass
 
 
-def test_the_state_dir_really_is_absent(state_root: Path):
+def test_the_state_dir_really_is_absent(config: _Cfg):
     """Guard the guard: if the dir already existed, every test below proves nothing."""
     # Arrange
-    from scitex_agent_container.runtimes.tui_session import state_dir_for_config
-
-    config = _Cfg()
+    state_dir = _state_dir(config)
     # Act
-    exists = state_dir_for_config(config).exists()
+    exists = state_dir.exists()
     # Assert
     assert exists is False
 
 
-def test_the_diag_is_persisted_even_when_the_state_dir_does_not_exist(
-    state_root: Path,
-):
+def test_the_diag_is_persisted_even_when_the_state_dir_does_not_exist(config: _Cfg):
     """THE REGRESSION. Before the fix this record was silently discarded.
 
     The agents this runs for are exactly the ones whose start FAILED — and a
     start that failed early never created its state dir.
     """
     # Arrange
-    config = _Cfg()
+    log = _diag_log(config)
     # Act
     _raise_and_swallow(config)
     # Assert
-    assert _diag_log(config).is_file()
+    assert log.is_file()
 
 
-def test_the_persisted_diag_names_the_real_reason(state_root: Path):
+def test_the_persisted_diag_names_the_real_reason(config: _Cfg):
     """The record must state WHY, not merely exist."""
     # Arrange
-    config = _Cfg()
+    log = _diag_log(config)
     # Act
     _raise_and_swallow(config)
     # Assert
-    assert "runtime.start() returned False" in _diag_log(config).read_text()
+    assert "runtime.start() returned False" in log.read_text()
 
 
-def test_a_wedged_tmux_does_not_destroy_the_persisted_record(state_root: Path):
+def test_a_wedged_tmux_does_not_destroy_the_persisted_record(config: _Cfg):
     """The BEST-EFFORT half must never be able to kill the MANDATORY half.
 
     An apptainer agent has no tmux pane at all, and a wedged server throws.
     Neither is a reason to lose the only durable evidence of the failure.
     """
     # Arrange
-    config = _Cfg()
+    log = _diag_log(config)
     # Act
     _raise_and_swallow(config, capture_fn=_wedged_tmux)
     # Assert
-    assert _diag_log(config).is_file()
+    assert log.is_file()
 
 
-def test_a_wedged_tmux_still_leaves_the_reason_in_the_record(state_root: Path):
+def test_a_wedged_tmux_still_leaves_the_reason_in_the_record(config: _Cfg):
     """Losing the pane tail is acceptable. Losing the CAUSE is not."""
     # Arrange
-    config = _Cfg()
+    log = _diag_log(config)
     # Act
     _raise_and_swallow(config, capture_fn=_wedged_tmux)
     # Assert
-    assert "runtime.start() returned False" in _diag_log(config).read_text()
+    assert "runtime.start() returned False" in log.read_text()
 
 
-def test_the_raised_error_still_carries_the_cause_when_the_capture_fails(
-    state_root: Path,
-):
+def test_the_raised_error_still_carries_the_cause_when_the_capture_fails(config: _Cfg):
     """The loud failure stays loud even when diagnostics degrade."""
     # Arrange
-    config = _Cfg()
+    capture = _wedged_tmux
     # Act
     # (the raise IS the act under test — it must still name the cause.)
     # Assert
     with pytest.raises(RuntimeError, match=r"runtime\.start\(\) returned False"):
-        raise_start_failure(config, capture_fn=_wedged_tmux)
+        raise_start_failure(config, capture_fn=capture)

--- a/tests/scitex_agent_container/_lifecycle/test__start_failure_diag_persists.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_failure_diag_persists.py
@@ -1,0 +1,160 @@
+"""The start-failure diagnostic must SURVIVE — that is the entire job.
+
+WHY THIS FILE EXISTS (2026-07-14). ``raise_start_failure`` persists
+``<state>/start_failure_diag.log`` because a false-negative start leaves NO
+REGISTRY ROW, so killing the tmux session by hand is often the only way to stop
+the agent — and that destroys the live pane capture forever. This file was the
+copy that was supposed to survive.
+
+It did not survive. The MANDATORY write was the last statement inside the
+BEST-EFFORT pane-capture ``try``, under a bare ``except Exception``. So any
+earlier hiccup threw, got swallowed, and the record was silently discarded. The
+commonest hiccup is the plainest one: **the state dir does not exist yet**,
+because a start that failed early never created it — ``write_text`` into a
+missing directory raises ``FileNotFoundError``. Precisely when the diagnostic
+mattered most, it was thrown away.
+
+The caller was then handed ``(no pane diagnostics available)`` — a message
+blaming the PANE CAPTURE for a failure it never observed. Exactly the disease the
+liveness verdict next door exists to kill: an error asserting a cause it did not
+see.
+
+Found because it turned CI red: two ``test_lifecycle`` tests assert this file
+exists, and they only ever passed when some OTHER test in the same xdist worker
+happened to create ``<floor>/runtime/alpha/`` first. Reordering the suite (two
+new test files) exposed a latent order-dependency AND the real hole under it.
+
+NO MOCKS (repo doctrine): the exploding tmux layer below is a REAL callable
+passed through the production seam, not a patched internal.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from scitex_agent_container._lifecycle._start_failure_diag import raise_start_failure
+
+_RUNTIME_DIR_ENV = "SCITEX_AGENT_CONTAINER_RUNTIME_DIR"
+
+
+class _Cfg:
+    """A real minimal config — the attributes the diag path resolution reads."""
+
+    def __init__(self, name: str = "alpha", runtime: str = "apptainer") -> None:
+        self.name = name
+        self.runtime = runtime
+
+
+def _wedged_tmux(_config: Any) -> str:
+    """A REAL capture collaborator that fails the way a wedged tmux server does."""
+    raise OSError("tmux server is wedged; cannot capture pane")
+
+
+@pytest.fixture
+def state_root(tmp_path: Path) -> Iterator[Path]:
+    """Point sac's runtime root at a dir the agent has NEVER written to.
+
+    The real production shape: an agent whose start failed early has no state
+    dir, because nothing ever got far enough to create one.
+    """
+    root = tmp_path / "runtime"
+    previous = os.environ.get(_RUNTIME_DIR_ENV)
+    os.environ[_RUNTIME_DIR_ENV] = str(root)
+    yield root
+    if previous is None:
+        os.environ.pop(_RUNTIME_DIR_ENV, None)
+    else:
+        os.environ[_RUNTIME_DIR_ENV] = previous
+
+
+def _diag_log(config: _Cfg) -> Path:
+    from scitex_agent_container.runtimes.tui_session import state_dir_for_config
+
+    return state_dir_for_config(config) / "start_failure_diag.log"
+
+
+def _raise_and_swallow(config: _Cfg, **kwargs: Any) -> None:
+    """Drive the real failure path. It ALWAYS raises; the record is the subject."""
+    try:
+        raise_start_failure(config, **kwargs)
+    except RuntimeError:
+        pass
+
+
+def test_the_state_dir_really_is_absent(state_root: Path):
+    """Guard the guard: if the dir already existed, every test below proves nothing."""
+    # Arrange
+    from scitex_agent_container.runtimes.tui_session import state_dir_for_config
+
+    config = _Cfg()
+    # Act
+    exists = state_dir_for_config(config).exists()
+    # Assert
+    assert exists is False
+
+
+def test_the_diag_is_persisted_even_when_the_state_dir_does_not_exist(
+    state_root: Path,
+):
+    """THE REGRESSION. Before the fix this record was silently discarded.
+
+    The agents this runs for are exactly the ones whose start FAILED — and a
+    start that failed early never created its state dir.
+    """
+    # Arrange
+    config = _Cfg()
+    # Act
+    _raise_and_swallow(config)
+    # Assert
+    assert _diag_log(config).is_file()
+
+
+def test_the_persisted_diag_names_the_real_reason(state_root: Path):
+    """The record must state WHY, not merely exist."""
+    # Arrange
+    config = _Cfg()
+    # Act
+    _raise_and_swallow(config)
+    # Assert
+    assert "runtime.start() returned False" in _diag_log(config).read_text()
+
+
+def test_a_wedged_tmux_does_not_destroy_the_persisted_record(state_root: Path):
+    """The BEST-EFFORT half must never be able to kill the MANDATORY half.
+
+    An apptainer agent has no tmux pane at all, and a wedged server throws.
+    Neither is a reason to lose the only durable evidence of the failure.
+    """
+    # Arrange
+    config = _Cfg()
+    # Act
+    _raise_and_swallow(config, capture_fn=_wedged_tmux)
+    # Assert
+    assert _diag_log(config).is_file()
+
+
+def test_a_wedged_tmux_still_leaves_the_reason_in_the_record(state_root: Path):
+    """Losing the pane tail is acceptable. Losing the CAUSE is not."""
+    # Arrange
+    config = _Cfg()
+    # Act
+    _raise_and_swallow(config, capture_fn=_wedged_tmux)
+    # Assert
+    assert "runtime.start() returned False" in _diag_log(config).read_text()
+
+
+def test_the_raised_error_still_carries_the_cause_when_the_capture_fails(
+    state_root: Path,
+):
+    """The loud failure stays loud even when diagnostics degrade."""
+    # Arrange
+    config = _Cfg()
+    # Act
+    # (the raise IS the act under test — it must still name the cause.)
+    # Assert
+    with pytest.raises(RuntimeError, match=r"runtime\.start\(\) returned False"):
+        raise_start_failure(config, capture_fn=_wedged_tmux)

--- a/tests/scitex_agent_container/_lifecycle/test__start_verdict.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_verdict.py
@@ -35,6 +35,8 @@ import pytest
 from scitex_agent_container._lifecycle import lifecycle as lc
 from scitex_agent_container._lifecycle._start_verdict import resolve_start_verdict
 from scitex_agent_container._lifecycle._verdict import (
+    INSTRUMENT_HOST_TMUX,
+    INSTRUMENT_LISTEN_BROKER,
     ALIVE,
     DEAD,
     SOURCE_DELIVERY,
@@ -205,7 +207,7 @@ def test_an_unknown_agent_is_started_rather_than_no_opped(tmp_path, registry):
     spec = _write_spec(tmp_path)
     registry.add("alpha", str(spec), "cld-alpha")
     runtime = _Runtime(running=True, start_result=True)
-    unknown = decide("alpha", [Signal(SOURCE_PROCESS, UNKNOWN, "tmux probe FAILED")])
+    unknown = decide("alpha", [Signal(SOURCE_PROCESS, UNKNOWN, "tmux probe FAILED", INSTRUMENT_HOST_TMUX)])
     # Act
     lc.agent_start(
         str(spec),
@@ -225,7 +227,7 @@ def test_an_unknown_agent_is_started_without_force(tmp_path, registry):
     spec = _write_spec(tmp_path)
     registry.add("alpha", str(spec), "cld-alpha")
     runtime = _Runtime(running=True, start_result=True)
-    unknown = decide("alpha", [Signal(SOURCE_PROCESS, UNKNOWN, "tmux probe FAILED")])
+    unknown = decide("alpha", [Signal(SOURCE_PROCESS, UNKNOWN, "tmux probe FAILED", INSTRUMENT_HOST_TMUX)])
     # Act
     lc.agent_start(
         str(spec),
@@ -244,7 +246,7 @@ def test_a_dead_agent_is_started(tmp_path, registry):
     spec = _write_spec(tmp_path)
     registry.add("alpha", str(spec), "cld-alpha")
     runtime = _Runtime(running=False, start_result=True)
-    dead = decide("alpha", [Signal(SOURCE_PROCESS, DEAD, "no session")])
+    dead = decide("alpha", [Signal(SOURCE_PROCESS, DEAD, "no session", INSTRUMENT_HOST_TMUX)])
     # Act
     lc.agent_start(
         str(spec),
@@ -269,7 +271,9 @@ def test_an_alive_agent_still_no_ops(tmp_path, registry):
     spec = _write_spec(tmp_path)
     registry.add("alpha", str(spec), "cld-alpha")
     runtime = _Runtime(running=True, start_result=True)
-    alive = decide("alpha", [Signal(SOURCE_DELIVERY, ALIVE, "1 live inbox subscriber")])
+    alive = decide("alpha", [Signal(
+            SOURCE_DELIVERY, ALIVE, "1 live inbox subscriber", INSTRUMENT_LISTEN_BROKER
+        )])
     # Act
     lc.agent_start(
         str(spec),
@@ -288,7 +292,9 @@ def test_an_alive_agent_no_op_returns_success(tmp_path, registry):
     spec = _write_spec(tmp_path)
     registry.add("alpha", str(spec), "cld-alpha")
     runtime = _Runtime(running=True, start_result=True)
-    alive = decide("alpha", [Signal(SOURCE_DELIVERY, ALIVE, "1 live inbox subscriber")])
+    alive = decide("alpha", [Signal(
+            SOURCE_DELIVERY, ALIVE, "1 live inbox subscriber", INSTRUMENT_LISTEN_BROKER
+        )])
     # Act
     ok = lc.agent_start(
         str(spec),

--- a/tests/scitex_agent_container/_lifecycle/test__verdict.py
+++ b/tests/scitex_agent_container/_lifecycle/test__verdict.py
@@ -4,6 +4,10 @@ NO MOCKS (repo doctrine). :mod:`._verdict` is a pure decision rule, so these
 drive it with real ``Signal`` values — the exact objects the real resolvers
 emit. The resolvers' own IO is covered in ``test__verdict_resolve.py`` against
 real files, real processes and a real tmux socket.
+
+The instrument taxonomy — and the "one sensor cannot corroborate itself" rule
+that the destruction gate now turns on — gets its own suite in
+``test__verdict_instruments.py``.
 """
 
 from __future__ import annotations
@@ -13,6 +17,11 @@ import pytest
 from scitex_agent_container._lifecycle._verdict import (
     ALIVE,
     DEAD,
+    INSTRUMENT_AGENT_SELF,
+    INSTRUMENT_HOST_TMUX,
+    INSTRUMENT_LISTEN_BROKER,
+    INSTRUMENT_NO_OBSERVATION,
+    INSTRUMENT_PID_NAMESPACE,
     SOURCE_DELIVERY,
     SOURCE_HEARTBEAT,
     SOURCE_PROCESS,
@@ -33,10 +42,14 @@ def writer_signals():
     a PROXY; the one that observed the agent itself said alive.
     """
     return [
-        Signal(SOURCE_DELIVERY, ALIVE, "1 live inbox subscriber"),
-        Signal(SOURCE_PROCESS, DEAD, "no apptainer pid"),
-        Signal(SOURCE_REGISTRY, DEAD, "recorded pid is reaped"),
-        Signal(SOURCE_HEARTBEAT, UNKNOWN, "beat is stale"),
+        Signal(
+            SOURCE_DELIVERY, ALIVE, "1 live inbox subscriber", INSTRUMENT_LISTEN_BROKER
+        ),
+        Signal(SOURCE_PROCESS, DEAD, "no apptainer pid", INSTRUMENT_PID_NAMESPACE),
+        Signal(
+            SOURCE_REGISTRY, DEAD, "recorded pid is reaped", INSTRUMENT_PID_NAMESPACE
+        ),
+        Signal(SOURCE_HEARTBEAT, UNKNOWN, "beat is stale", INSTRUMENT_AGENT_SELF),
     ]
 
 
@@ -44,20 +57,50 @@ def writer_signals():
 def all_unknown_signals():
     """Four "I could not look"s. The ``grant`` shape, as measured 2026-07-14."""
     return [
-        Signal(SOURCE_DELIVERY, UNKNOWN, "could not ask the broker"),
-        Signal(SOURCE_PROCESS, UNKNOWN, "tmux probe FAILED"),
-        Signal(SOURCE_HEARTBEAT, UNKNOWN, "beat is 5086s stale"),
-        Signal(SOURCE_REGISTRY, UNKNOWN, "active row records pid=0"),
+        Signal(
+            SOURCE_DELIVERY,
+            UNKNOWN,
+            "could not ask the broker",
+            INSTRUMENT_LISTEN_BROKER,
+        ),
+        Signal(SOURCE_PROCESS, UNKNOWN, "tmux probe FAILED", INSTRUMENT_HOST_TMUX),
+        Signal(SOURCE_HEARTBEAT, UNKNOWN, "beat is 5086s stale", INSTRUMENT_HOST_TMUX),
+        Signal(
+            SOURCE_REGISTRY,
+            UNKNOWN,
+            "active row records pid=0",
+            INSTRUMENT_NO_OBSERVATION,
+        ),
     ]
 
 
 @pytest.fixture
 def corroborated_dead_signals():
-    """Two INDEPENDENT sources that each positively observed absence."""
+    """Two GENUINELY INDEPENDENT INSTRUMENTS that each positively observed absence.
+
+    tmux's own session bookkeeping says there is no session, AND the kernel says
+    the recorded pid is reaped. Two different bookkeepers, two different failure
+    modes — no single sensor malfunction can produce both. THIS is corroboration.
+    """
     return [
-        Signal(SOURCE_PROCESS, DEAD, "tmux probe succeeded; no session"),
-        Signal(SOURCE_REGISTRY, DEAD, "recorded pid=1234 is REAPED"),
-        Signal(SOURCE_DELIVERY, UNKNOWN, "0 subscribers — adapter detached"),
+        Signal(
+            SOURCE_PROCESS,
+            DEAD,
+            "tmux probe succeeded; no session",
+            INSTRUMENT_HOST_TMUX,
+        ),
+        Signal(
+            SOURCE_REGISTRY,
+            DEAD,
+            "recorded pid=1234 is REAPED",
+            INSTRUMENT_PID_NAMESPACE,
+        ),
+        Signal(
+            SOURCE_DELIVERY,
+            UNKNOWN,
+            "0 subscribers — adapter detached",
+            INSTRUMENT_LISTEN_BROKER,
+        ),
     ]
 
 
@@ -74,7 +117,7 @@ def test_signal_rejects_a_non_ternary_verdict():
     # (constructing the Signal IS the act under test — it must refuse.)
     # Assert
     with pytest.raises(ValueError, match="never a bool"):
-        Signal(SOURCE_PROCESS, bogus, "not a ternary verdict")
+        Signal(SOURCE_PROCESS, bogus, "not a ternary verdict", INSTRUMENT_HOST_TMUX)
 
 
 def test_no_signals_at_all_is_unknown():
@@ -132,7 +175,14 @@ def test_destroy_veto_names_the_agent_as_alive(writer_signals):
 
 def test_alive_verdict_names_the_signal_that_observed_life():
     # Arrange
-    signals = [Signal(SOURCE_DELIVERY, ALIVE, "1 live inbox subscriber(s)")]
+    signals = [
+        Signal(
+            SOURCE_DELIVERY,
+            ALIVE,
+            "1 live inbox subscriber(s)",
+            INSTRUMENT_LISTEN_BROKER,
+        )
+    ]
     # Act
     verdict = decide("grant", signals)
     # Assert
@@ -177,8 +227,13 @@ def test_unknown_veto_says_a_failed_probe_is_not_evidence_of_death(
 def test_a_single_dead_signal_still_yields_a_dead_verdict():
     # Arrange
     signals = [
-        Signal(SOURCE_PROCESS, DEAD, "tmux probe succeeded; no session"),
-        Signal(SOURCE_DELIVERY, UNKNOWN, "no listen to ask"),
+        Signal(
+            SOURCE_PROCESS,
+            DEAD,
+            "tmux probe succeeded; no session",
+            INSTRUMENT_HOST_TMUX,
+        ),
+        Signal(SOURCE_DELIVERY, UNKNOWN, "no listen to ask", INSTRUMENT_LISTEN_BROKER),
     ]
     # Act
     verdict = decide("scitex-dev", signals)
@@ -190,8 +245,13 @@ def test_a_single_dead_witness_does_not_authorise_destruction():
     """DEAD is a report. On one witness it is not a licence to destroy."""
     # Arrange
     signals = [
-        Signal(SOURCE_PROCESS, DEAD, "tmux probe succeeded; no session"),
-        Signal(SOURCE_DELIVERY, UNKNOWN, "no listen to ask"),
+        Signal(
+            SOURCE_PROCESS,
+            DEAD,
+            "tmux probe succeeded; no session",
+            INSTRUMENT_HOST_TMUX,
+        ),
+        Signal(SOURCE_DELIVERY, UNKNOWN, "no listen to ask", INSTRUMENT_LISTEN_BROKER),
     ]
     # Act
     verdict = decide("scitex-dev", signals)
@@ -200,11 +260,12 @@ def test_a_single_dead_witness_does_not_authorise_destruction():
 
 
 # --------------------------------------------------------------------------
-# Rule 3: only a CORROBORATED dead may authorise a destructive remedy.
+# Rule 3: only a CORROBORATED dead may authorise a destructive remedy —
+# and corroboration is counted in INSTRUMENTS, not in reports.
 # --------------------------------------------------------------------------
 
 
-def test_two_independent_dead_sources_authorise_destruction(
+def test_two_independent_dead_instruments_authorise_destruction(
     corroborated_dead_signals,
 ):
     # Arrange
@@ -225,11 +286,11 @@ def test_an_authorised_destruction_has_no_veto_reason(corroborated_dead_signals)
 
 
 def test_the_same_source_twice_is_not_corroboration():
-    """Corroboration means INDEPENDENT sources, not one signal counted twice."""
+    """Corroboration means INDEPENDENT sensors, not one signal counted twice."""
     # Arrange
     signals = [
-        Signal(SOURCE_PROCESS, DEAD, "no session"),
-        Signal(SOURCE_PROCESS, DEAD, "no pane pid either"),
+        Signal(SOURCE_PROCESS, DEAD, "no session", INSTRUMENT_HOST_TMUX),
+        Signal(SOURCE_PROCESS, DEAD, "no pane pid either", INSTRUMENT_HOST_TMUX),
     ]
     # Act
     verdict = decide("x", signals)
@@ -241,9 +302,11 @@ def test_one_dissenting_alive_vetoes_destruction_outright():
     """The asymmetry is the point: a false DEAD destroys, a false ALIVE reports."""
     # Arrange
     signals = [
-        Signal(SOURCE_PROCESS, DEAD, "no session"),
-        Signal(SOURCE_REGISTRY, DEAD, "pid reaped"),
-        Signal(SOURCE_DELIVERY, ALIVE, "1 live inbox subscriber"),
+        Signal(SOURCE_PROCESS, DEAD, "no session", INSTRUMENT_HOST_TMUX),
+        Signal(SOURCE_REGISTRY, DEAD, "pid reaped", INSTRUMENT_PID_NAMESPACE),
+        Signal(
+            SOURCE_DELIVERY, ALIVE, "1 live inbox subscriber", INSTRUMENT_LISTEN_BROKER
+        ),
     ]
     # Act
     verdict = decide("x", signals)
@@ -260,8 +323,13 @@ def test_render_carries_the_reason_not_just_the_verdict():
     """``running | pid=None`` teaches an operator nothing. This must teach them."""
     # Arrange
     signals = [
-        Signal(SOURCE_HEARTBEAT, UNKNOWN, "beat is 5086s stale"),
-        Signal(SOURCE_REGISTRY, UNKNOWN, "active row records pid=0"),
+        Signal(SOURCE_HEARTBEAT, UNKNOWN, "beat is 5086s stale", INSTRUMENT_HOST_TMUX),
+        Signal(
+            SOURCE_REGISTRY,
+            UNKNOWN,
+            "active row records pid=0",
+            INSTRUMENT_NO_OBSERVATION,
+        ),
     ]
     # Act
     rendered = decide("grant", signals).render()
@@ -271,7 +339,14 @@ def test_render_carries_the_reason_not_just_the_verdict():
 
 def test_render_surfaces_the_unfalsifiable_pid_zero_as_evidence():
     # Arrange
-    signals = [Signal(SOURCE_REGISTRY, UNKNOWN, "active row records pid=0")]
+    signals = [
+        Signal(
+            SOURCE_REGISTRY,
+            UNKNOWN,
+            "active row records pid=0",
+            INSTRUMENT_NO_OBSERVATION,
+        )
+    ]
     # Act
     rendered = decide("grant", signals).render()
     # Assert
@@ -281,8 +356,10 @@ def test_render_surfaces_the_unfalsifiable_pid_zero_as_evidence():
 def test_render_shows_dissenting_signals_rather_than_hiding_them():
     # Arrange
     signals = [
-        Signal(SOURCE_DELIVERY, ALIVE, "1 live inbox subscriber"),
-        Signal(SOURCE_PROCESS, DEAD, "no session"),
+        Signal(
+            SOURCE_DELIVERY, ALIVE, "1 live inbox subscriber", INSTRUMENT_LISTEN_BROKER
+        ),
+        Signal(SOURCE_PROCESS, DEAD, "no session", INSTRUMENT_HOST_TMUX),
     ]
     # Act
     rendered = decide("grant", signals).render()
@@ -298,3 +375,13 @@ def test_to_dict_always_carries_an_evidence_key():
     payload = decide("x", signals).to_dict()
     # Assert
     assert payload["evidence"] == []
+
+
+def test_to_dict_evidence_names_the_instrument_behind_each_signal():
+    """A ``--json`` consumer must be able to see that two DEADs were one sensor."""
+    # Arrange
+    signals = [Signal(SOURCE_REGISTRY, DEAD, "pid reaped", INSTRUMENT_PID_NAMESPACE)]
+    # Act
+    payload = decide("x", signals).to_dict()
+    # Assert
+    assert payload["evidence"][0]["instrument"] == INSTRUMENT_PID_NAMESPACE

--- a/tests/scitex_agent_container/_lifecycle/test__verdict_instrument_collapse.py
+++ b/tests/scitex_agent_container/_lifecycle/test__verdict_instrument_collapse.py
@@ -1,0 +1,351 @@
+"""A destruction may be authorised only by TWO SENSORS — not by one, asked twice.
+
+WHY THIS FILE EXISTS (2026-07-14). ``may_destroy`` required "2 independent
+sources" and counted SOURCE STRINGS. But ``process`` and ``registry`` are not two
+sensors — for BOTH runtimes they are the SAME ``os.kill(pid, 0)`` on the SAME
+pid, and the codebase engineered that identity ON PURPOSE:
+
+    runtimes/_tui_liveness.pane_pid_of:
+      "This is the value ``instances.pid`` records for a TUI agent, and it is the
+       SAME signal ``pane_process_alive`` (hence ``is_running``) already keys
+       liveness on — so the registry and ``is_running`` can never disagree about
+       which process represents this agent."
+
+    runtimes/_apptainer_runtime.agent_pid:
+      "This is EXACTLY the pid ``is_running`` above probes with
+       ``os.kill(pid, 0)`` ... reusing ``_read_pid`` here means the registry and
+       ``is_running`` can never disagree."
+
+So the two witnesses the gate demanded were GUARANTEED to agree. One syscall,
+two hats, and ``may_destroy`` came back True — whose remedy is ``--force
+--fresh``, which KILLS THE AGENT. From inside a container, where a host pid is
+not even in our pid namespace, that syscall reads "reaped" for every healthy
+agent on the box.
+
+MEASURED against the code as shipped in v0.21.20, on a real reaped pid:
+``dead_sources = ('process', 'registry')`` → ``may_destroy = True``.
+
+NO MOCKS (repo doctrine): these drive a REAL reaped pid through the REAL
+resolvers. The taxonomy's own guards live in ``test__verdict_instruments.py``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from scitex_agent_container._lifecycle._verdict import (
+    DEAD,
+    INSTRUMENT_HOST_TMUX,
+    INSTRUMENT_PID_NAMESPACE,
+    SOURCE_PROCESS,
+    SOURCE_REGISTRY,
+    UNKNOWN,
+    Signal,
+    decide,
+)
+from scitex_agent_container._lifecycle._verdict_resolve import (
+    process_signal,
+    registry_signal,
+)
+
+
+class _Cfg:
+    """A real minimal config object — the two attributes the resolvers read."""
+
+    def __init__(self, name: str, runtime: str) -> None:
+        self.name = name
+        self.runtime = runtime
+
+
+class _RuntimeSaysDown:
+    """A real runtime whose probe SUCCEEDS and finds nothing there."""
+
+    def is_running(self, config) -> bool:
+        return False
+
+
+def _on_the_host() -> bool:
+    """The destruction gate runs on the HOST, where a pid check IS a sensor."""
+    return False
+
+
+def _in_a_container() -> bool:
+    return True
+
+
+def _session_absent(_session: str) -> tuple[bool | None, bool | None]:
+    """The tmux probe RAN, and tmux has no session for this agent."""
+    return True, False
+
+
+def _session_present(_session: str) -> tuple[bool | None, bool | None]:
+    """The tmux probe RAN, and the session is THERE (so the pane pid is what died)."""
+    return True, True
+
+
+@pytest.fixture
+def reaped_pid():
+    """A REAL pid that has genuinely exited and been reaped."""
+    proc = subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", ""],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    proc.wait(timeout=30)
+    return proc.pid
+
+
+@pytest.fixture
+def pid_collapse_verdict(reaped_pid):
+    """THE P0 SHAPE: an apptainer agent, and a registry row for THE SAME pid.
+
+    ``runtime.is_running`` is ``os.kill(pid, 0)``; ``agent_pid`` (which feeds
+    ``instances.pid``) returns the very pid it probes. So both resolvers run the
+    same syscall on the same integer, and both come back DEAD.
+    """
+    config = _Cfg("agent-a", "apptainer")
+    rows = [{"name": "agent-a", "pid": reaped_pid, "host": None}]
+    return decide(
+        "agent-a",
+        [
+            process_signal(config, _RuntimeSaysDown(), in_sif_fn=_on_the_host),
+            registry_signal("agent-a", rows=rows, in_sif_fn=_on_the_host),
+        ],
+    )
+
+
+# --------------------------------------------------------------------------
+# THE BUG — these fail on the code as it shipped in v0.21.20.
+# --------------------------------------------------------------------------
+
+
+def test_one_syscall_reported_twice_does_not_authorise_a_destruction(
+    pid_collapse_verdict,
+):
+    """BEFORE: dead_sources == ("process", "registry") → 2 → may_destroy True.
+
+    A healthy agent destroyed on the strength of ONE reading. AFTER: both
+    resolvers declare ``pid_namespace``, so there is one witness — and one
+    witness never authorises a kill.
+    """
+    # Arrange
+    verdict = pid_collapse_verdict
+    # Act
+    authorised = verdict.may_destroy
+    # Assert
+    assert authorised is False
+
+
+def test_the_two_dead_reports_are_still_counted_as_two_reporters(
+    pid_collapse_verdict,
+):
+    """The inputs are unchanged — it is the COUNTING that was wrong."""
+    # Arrange
+    verdict = pid_collapse_verdict
+    # Act
+    reporters = verdict.dead_sources
+    # Assert
+    assert reporters == ("process", "registry")
+
+
+def test_the_two_dead_reports_collapse_to_one_instrument(pid_collapse_verdict):
+    """Two reporters, one sensor. This is the whole fix, in one assertion."""
+    # Arrange
+    verdict = pid_collapse_verdict
+    # Act
+    sensors = verdict.dead_instruments
+    # Assert
+    assert sensors == (INSTRUMENT_PID_NAMESPACE,)
+
+
+def test_the_collapse_still_reports_the_agent_as_dead(pid_collapse_verdict):
+    """We do not pretend the pid is alive — we refuse to ACT on one sensor.
+
+    Refusing to destroy is not the same as claiming life. The verdict stays
+    honest; only the authorisation is withheld.
+    """
+    # Arrange
+    verdict = pid_collapse_verdict
+    # Act
+    reported = verdict.verdict
+    # Assert
+    assert reported == DEAD
+
+
+def test_the_veto_tells_the_operator_the_two_deads_were_one_sensor(
+    pid_collapse_verdict,
+):
+    """A refusal must teach, not merely refuse."""
+    # Arrange
+    verdict = pid_collapse_verdict
+    # Act
+    reason = verdict.destroy_veto_reason
+    # Assert
+    assert "one sensor reported twice" in reason
+
+
+def test_two_reporters_on_one_instrument_are_one_witness():
+    """The rule, stated purely: DIFFERENT sources, SAME sensor ⇒ no destruction."""
+    # Arrange — the exact shape the old gate accepted as "2 independent sources".
+    signals = [
+        Signal(SOURCE_PROCESS, DEAD, "pid reaped", INSTRUMENT_PID_NAMESPACE),
+        Signal(SOURCE_REGISTRY, DEAD, "same pid, reaped", INSTRUMENT_PID_NAMESPACE),
+    ]
+    # Act
+    verdict = decide("x", signals)
+    # Assert
+    assert verdict.may_destroy is False
+
+
+# --------------------------------------------------------------------------
+# The RESOLVERS must agree with the taxonomy — a declared independence the code
+# does not honour is just a comment.
+# --------------------------------------------------------------------------
+
+
+def test_a_pid_based_runtime_declares_the_pid_namespace_instrument():
+    """``ApptainerRuntime.is_running`` IS ``os.kill(pid, 0)``. Nothing else."""
+    # Arrange
+    config = _Cfg("agent-a", "apptainer")
+    # Act
+    signal = process_signal(config, _RuntimeSaysDown(), in_sif_fn=_on_the_host)
+    # Assert
+    assert signal.instrument == INSTRUMENT_PID_NAMESPACE
+
+
+def test_the_registry_declares_the_same_instrument_as_a_pid_based_runtime(reaped_pid):
+    """Pin the collapse. If these ever diverge, the gate is armed on one syscall."""
+    # Arrange
+    rows = [{"name": "agent-a", "pid": reaped_pid, "host": None}]
+    # Act
+    signal = registry_signal("agent-a", rows=rows, in_sif_fn=_on_the_host)
+    # Assert
+    assert signal.instrument == INSTRUMENT_PID_NAMESPACE
+
+
+def test_a_tui_agent_whose_session_is_gone_is_convicted_by_tmux():
+    """The one case where ``process`` IS independent of the registry.
+
+    tmux's own bookkeeping positively has no session. That is a different
+    bookkeeper from the kernel's pid table, so it MAY corroborate the registry —
+    which is why the fleet's default runtime keeps a real destruction path.
+    """
+    # Arrange
+    config = _Cfg("grant", "tui")
+    # Act
+    signal = process_signal(
+        config, _RuntimeSaysDown(), session_observation=_session_absent
+    )
+    # Assert
+    assert signal.instrument == INSTRUMENT_HOST_TMUX
+
+
+def test_a_tui_agent_whose_session_is_gone_is_dead():
+    """Positive evidence of absence, from a probe that actually ran."""
+    # Arrange
+    config = _Cfg("grant", "tui")
+    # Act
+    signal = process_signal(
+        config, _RuntimeSaysDown(), session_observation=_session_absent
+    )
+    # Assert
+    assert signal.verdict == DEAD
+
+
+def test_a_tui_agent_whose_session_survives_is_convicted_only_by_the_pid_check():
+    """The trap: the session is THERE, so ``is_running``'s False came from
+    ``os.kill(pane_pid, 0)`` — the registry's instrument, not tmux's.
+
+    ``pane_pid_of`` feeds ``instances.pid``, so this is literally the same syscall
+    on the same integer the registry runs. It must not corroborate the registry.
+    """
+    # Arrange
+    config = _Cfg("grant", "tui")
+    # Act
+    signal = process_signal(
+        config, _RuntimeSaysDown(), session_observation=_session_present
+    )
+    # Assert
+    assert signal.instrument == INSTRUMENT_PID_NAMESPACE
+
+
+def test_a_surviving_tui_session_cannot_corroborate_the_registry(reaped_pid):
+    """The two halves, folded: same sensor ⇒ still no destruction."""
+    # Arrange
+    config = _Cfg("grant", "tui")
+    rows = [{"name": "grant", "pid": reaped_pid, "host": None}]
+    # Act
+    verdict = decide(
+        "grant",
+        [
+            process_signal(
+                config, _RuntimeSaysDown(), session_observation=_session_present
+            ),
+            registry_signal("grant", rows=rows, in_sif_fn=_on_the_host),
+        ],
+    )
+    # Assert
+    assert verdict.may_destroy is False
+
+
+# --------------------------------------------------------------------------
+# A pid read across a namespace boundary is NOT A SENSOR.
+# --------------------------------------------------------------------------
+
+
+def test_a_reaped_pid_seen_from_inside_a_container_convicts_nobody(reaped_pid):
+    """From inside a SIF, a HOST pid is not in our namespace.
+
+    ``os.kill`` there answers about a different process — or none — so it reads
+    "reaped" for agents that are perfectly healthy on the host. That is not a
+    weak sensor. It is not a sensor.
+    """
+    # Arrange
+    rows = [{"name": "grant", "pid": reaped_pid, "host": None}]
+    # Act
+    signal = registry_signal("grant", rows=rows, in_sif_fn=_in_a_container)
+    # Assert
+    assert signal.verdict == UNKNOWN
+
+
+def test_the_container_pid_read_says_in_words_that_it_is_not_a_sensor(reaped_pid):
+    """The evidence line has to teach the next reader why it abstained."""
+    # Arrange
+    rows = [{"name": "grant", "pid": reaped_pid, "host": None}]
+    # Act
+    signal = registry_signal("grant", rows=rows, in_sif_fn=_in_a_container)
+    # Assert
+    assert "NOT A SENSOR" in signal.detail
+
+
+def test_a_pid_runtime_probed_from_inside_a_container_convicts_nobody():
+    """Same blindness, reached through ``runtime.is_running`` — the same syscall."""
+    # Arrange
+    config = _Cfg("agent-a", "apptainer")
+    # Act
+    signal = process_signal(config, _RuntimeSaysDown(), in_sif_fn=_in_a_container)
+    # Assert
+    assert signal.verdict == UNKNOWN
+
+
+def test_a_row_written_on_another_host_convicts_nobody(reaped_pid):
+    """That pid was minted in another machine's namespace. The integer is not ours."""
+    # Arrange
+    rows = [{"name": "grant", "pid": reaped_pid, "host": "some-other-box"}]
+    # Act
+    signal = registry_signal("grant", rows=rows, in_sif_fn=_on_the_host)
+    # Assert
+    assert signal.verdict == UNKNOWN
+
+
+def test_a_cross_host_row_explains_the_namespace_mismatch(reaped_pid):
+    """Name the host we are on and the host the row came from."""
+    # Arrange
+    rows = [{"name": "grant", "pid": reaped_pid, "host": "some-other-box"}]
+    # Act
+    signal = registry_signal("grant", rows=rows, in_sif_fn=_on_the_host)
+    # Assert
+    assert "another machine's namespace" in signal.detail

--- a/tests/scitex_agent_container/_lifecycle/test__verdict_instruments.py
+++ b/tests/scitex_agent_container/_lifecycle/test__verdict_instruments.py
@@ -1,0 +1,376 @@
+"""The INSTRUMENT taxonomy, and the meta-tests that stop it going decorative.
+
+An enumeration nobody is forced to update is a promise of completeness that
+quietly stops being true. ``may_destroy`` demanded "2 independent sources" and
+counted SOURCE STRINGS — and ``process`` and ``registry`` are the SAME
+``os.kill(pid, 0)`` on the SAME pid, by explicit design in both runtimes. So the
+two witnesses the destruction gate required were GUARANTEED to agree, and a
+single syscall could authorise ``--force --fresh`` on a healthy agent.
+
+The collapse itself is exercised end-to-end, against a REAL reaped pid, in
+``test__verdict_instrument_collapse.py``. THIS file guards the classification
+that makes the collapse detectable at all:
+
+* every instrument must be CLASSIFIED (what it reads, what it may conclude,
+  when it is blind);
+* every ``Signal(...)`` anywhere in src must name a DECLARED instrument —
+  provably, statically, through variables and conditionals;
+* every convicting instrument must be unable to corroborate ITSELF;
+* every non-convicting instrument must be unable to report a death at all.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import scitex_agent_container
+from scitex_agent_container._lifecycle import _verdict_instruments
+from scitex_agent_container._lifecycle._verdict import (
+    ALIVE,
+    CONVICTING_INSTRUMENTS,
+    DEAD,
+    INSTRUMENT_HOST_TMUX,
+    INSTRUMENT_INDEPENDENCE,
+    INSTRUMENT_LISTEN_BROKER,
+    INSTRUMENT_NO_OBSERVATION,
+    INSTRUMENT_PID_NAMESPACE,
+    INSTRUMENTS,
+    SOURCE_DELIVERY,
+    SOURCE_PROCESS,
+    SOURCE_REGISTRY,
+    Signal,
+    decide,
+)
+
+
+def _declared_instrument_constants() -> dict[str, str]:
+    """``{CONSTANT_NAME: value}`` for every ``INSTRUMENT_*`` string constant."""
+    return {
+        name: value
+        for name, value in vars(_verdict_instruments).items()
+        if name.startswith("INSTRUMENT_") and isinstance(value, str)
+    }
+
+
+# --------------------------------------------------------------------------
+# Every instrument must be CLASSIFIED.
+# --------------------------------------------------------------------------
+
+
+def test_every_instrument_constant_is_classified_for_independence():
+    """Add an INSTRUMENT_* constant without classifying it, and this FAILS.
+
+    The original bug was an enumeration that silently claimed to be complete.
+    This makes it load-bearing: a sensor with no INSTRUMENT_INDEPENDENCE entry
+    has not been reasoned about, and an unreasoned sensor is exactly the thing
+    that poses as an independent second witness.
+    """
+    # Arrange
+    constants = _declared_instrument_constants()
+    # Act
+    unclassified = sorted(
+        name
+        for name, value in constants.items()
+        if value not in INSTRUMENT_INDEPENDENCE
+    )
+    # Assert
+    assert not unclassified, (
+        f"instrument constants with no INSTRUMENT_INDEPENDENCE entry: "
+        f"{unclassified}. Declare what the sensor physically READS, which "
+        f"VERDICTS it may emit, and WHEN IT IS BLIND — the destruction gate "
+        f"counts distinct instruments, so an unclassified one can corroborate a "
+        f"kill it never observed."
+    )
+
+
+def test_every_instrument_spec_says_what_it_physically_reads():
+    """A classification that says nothing is a classification in name only."""
+    # Arrange
+    specs = INSTRUMENT_INDEPENDENCE
+    # Act
+    silent = sorted(name for name, spec in specs.items() if not spec.reads.strip())
+    # Assert
+    assert not silent, f"instruments that do not say what they read: {silent}"
+
+
+def test_every_instrument_spec_says_when_it_is_blind():
+    """Blindness is the whole failure mode — an unstated blind spot is a trap."""
+    # Arrange
+    specs = INSTRUMENT_INDEPENDENCE
+    # Act
+    silent = sorted(name for name, spec in specs.items() if not spec.blind_when.strip())
+    # Assert
+    assert not silent, f"instruments that do not say when they are blind: {silent}"
+
+
+def test_every_instrument_spec_declares_the_verdicts_it_may_emit():
+    """An instrument with no declared verdicts could smuggle a DEAD through."""
+    # Arrange
+    specs = INSTRUMENT_INDEPENDENCE
+    # Act
+    silent = sorted(name for name, spec in specs.items() if not spec.verdicts)
+    # Assert
+    assert not silent, f"instruments declaring no verdicts: {silent}"
+
+
+# --------------------------------------------------------------------------
+# Every Signal in src must name a DECLARED instrument — provably.
+# --------------------------------------------------------------------------
+
+
+def _resolves_to_declared(
+    expr: ast.expr | None, scope: ast.AST, declared: set[str]
+) -> bool:
+    """Does ``expr`` PROVABLY evaluate to declared instrument constants?
+
+    Static proof, deliberately narrow. We accept exactly three shapes:
+
+    * ``INSTRUMENT_FOO``                        — a declared constant;
+    * ``A if cond else B``                      — both branches declared;
+    * a local variable assigned ONLY from the above, inside the same function
+      (``heartbeat_signal`` legitimately picks its instrument from the runtime,
+      because for a TUI agent the beat is a re-report of the SAME tmux snapshot
+      ``process_signal`` reads, while an SDK agent beats for itself).
+
+    Everything else — a literal, an f-string, a call, a parameter we cannot see
+    through — is REFUSED. That refusal is the point: the destruction gate counts
+    instruments, so an instrument the suite cannot verify is an instrument that
+    could pose as a second witness.
+    """
+    if expr is None:
+        return False
+    if isinstance(expr, ast.IfExp):
+        return _resolves_to_declared(
+            expr.body, scope, declared
+        ) and _resolves_to_declared(expr.orelse, scope, declared)
+    if not isinstance(expr, ast.Name):
+        return False
+    if expr.id in declared:
+        return True
+
+    # A local variable: every assignment to it in this scope must itself resolve.
+    assignments = [
+        node.value
+        for node in ast.walk(scope)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name) and target.id == expr.id
+    ]
+    if not assignments:
+        return False
+    return all(_resolves_to_declared(value, scope, declared) for value in assignments)
+
+
+def _signal_instrument_offenders(src_root: Path, declared: set[str]) -> list[str]:
+    """Every ``Signal(...)`` in ``src_root`` whose instrument is not provable."""
+    offenders: list[str] = []
+    for py in sorted(src_root.rglob("*.py")):
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        scopes: list[ast.AST] = [tree]
+        scopes += [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        seen: set[int] = set()
+        for scope in scopes:
+            for node in ast.walk(scope):
+                if not isinstance(node, ast.Call) or id(node) in seen:
+                    continue
+                called = getattr(node.func, "id", None) or getattr(
+                    node.func, "attr", None
+                )
+                if called != "Signal":
+                    continue
+                seen.add(id(node))
+
+                instrument: ast.expr | None = None
+                for kw in node.keywords:
+                    if kw.arg == "instrument":
+                        instrument = kw.value
+                if instrument is None and len(node.args) >= 4:
+                    instrument = node.args[3]
+
+                if not _resolves_to_declared(instrument, scope, declared):
+                    offenders.append(
+                        f"{py.relative_to(src_root)}:{node.lineno} — instrument "
+                        f"does not provably resolve to a declared INSTRUMENT_* "
+                        f"constant"
+                    )
+    return offenders
+
+
+def test_every_signal_construction_site_in_src_names_a_declared_instrument():
+    """Introduce a signal with an unverifiable sensor anywhere in src, and this FAILS.
+
+    THE guard against the enumeration going decorative again. ``source`` was a
+    free string and it had ALREADY drifted — ``_status`` and ``_health_liveness``
+    were emitting ``Signal("resolver", ...)``, a source that appeared in no
+    enumeration anywhere. A free-string INSTRUMENT would be far worse: the
+    destruction gate COUNTS instruments, so an unrecognised one is a fresh
+    witness for free.
+    """
+    # Arrange
+    src_root = Path(scitex_agent_container.__file__).parent
+    declared = set(_declared_instrument_constants())
+    # Act
+    offenders = _signal_instrument_offenders(src_root, declared)
+    # Assert
+    assert not offenders, (
+        "every Signal must name a CLASSIFIED instrument constant — the gate "
+        "deduplicates on it, so an unverifiable instrument could pose as an "
+        "independent witness and authorise killing a healthy agent:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_the_signal_scan_actually_finds_the_construction_sites():
+    """Guard the guard: a scan that silently matches NOTHING proves nothing.
+
+    A rglob that quietly stopped finding files, or a Signal call shape the walker
+    no longer recognises, would make the test above pass vacuously forever — the
+    same "green because we did not look" failure the whole verdict module exists
+    to prevent.
+    """
+    # Arrange
+    src_root = Path(scitex_agent_container.__file__).parent
+    # Act
+    sites = sum(
+        1
+        for py in src_root.rglob("*.py")
+        for node in ast.walk(ast.parse(py.read_text(encoding="utf-8")))
+        if isinstance(node, ast.Call)
+        and (getattr(node.func, "id", None) or getattr(node.func, "attr", None))
+        == "Signal"
+    )
+    # Assert
+    assert sites >= 10, f"only {sites} Signal() sites found in src — the scan is blind"
+
+
+# --------------------------------------------------------------------------
+# No instrument may corroborate ITSELF.
+# --------------------------------------------------------------------------
+
+
+def test_each_convicting_instrument_alone_is_never_enough_to_destroy():
+    """Every convicting sensor, on its own, is refused — with NO exceptions.
+
+    Iterating the enumeration is the point (cf. scitex-todo's
+    ``test_every_closure_marker_is_actually_checked``): a future instrument
+    marked convicting inherits this rule automatically, instead of quietly
+    becoming a one-witness kill.
+    """
+    # Arrange
+    instruments = sorted(CONVICTING_INSTRUMENTS)
+    # Act
+    self_corroborating = [
+        instrument
+        for instrument in instruments
+        if decide(
+            "x",
+            [
+                Signal(SOURCE_PROCESS, DEAD, "first look", instrument),
+                Signal(SOURCE_REGISTRY, DEAD, "second look", instrument),
+            ],
+        ).may_destroy
+    ]
+    # Assert
+    assert not self_corroborating, (
+        f"{self_corroborating} corroborated ITSELF into a destruction — two "
+        f"reports from one sensor are one witness"
+    )
+
+
+def test_two_distinct_convicting_instruments_do_authorise_destruction():
+    """The gate must keep its teeth.
+
+    Guards the OPPOSITE failure: a "fix" that merely makes ``may_destroy``
+    unreachable is not a fix, it is a disabled feature wearing a safety badge.
+    """
+    # Arrange
+    signals = [
+        Signal(SOURCE_PROCESS, DEAD, "tmux has no such session", INSTRUMENT_HOST_TMUX),
+        Signal(SOURCE_REGISTRY, DEAD, "recorded pid reaped", INSTRUMENT_PID_NAMESPACE),
+    ]
+    # Act
+    verdict = decide("x", signals)
+    # Assert
+    assert verdict.may_destroy is True
+
+
+def test_the_convicting_set_is_exactly_host_tmux_and_the_pid_namespace():
+    """Pin WHICH sensors may kill. Widening this set must be a deliberate act."""
+    # Arrange
+    expected = {INSTRUMENT_HOST_TMUX, INSTRUMENT_PID_NAMESPACE}
+    # Act
+    actual = set(CONVICTING_INSTRUMENTS)
+    # Assert
+    assert actual == expected
+
+
+# --------------------------------------------------------------------------
+# A sensor that cannot see death may not report one.
+# --------------------------------------------------------------------------
+
+
+def _accepts_a_death(instrument: str) -> bool:
+    """Can a DEAD Signal be constructed on this instrument at all?"""
+    try:
+        Signal(SOURCE_PROCESS, DEAD, "a corpse, allegedly", instrument)
+    except ValueError:
+        return False
+    return True
+
+
+def test_no_non_convicting_instrument_can_report_a_death():
+    """The delivery/heartbeat doctrine, made MECHANICAL rather than aspirational.
+
+    "0 subscribers means DEAD" is the inference that convicted a live fleet, and
+    it was previously prevented only by a resolver remembering not to write it.
+    Now the type refuses — for every non-convicting sensor, by enumeration.
+    """
+    # Arrange
+    non_convicting = sorted(INSTRUMENTS - CONVICTING_INSTRUMENTS)
+    # Act
+    leaky = [i for i in non_convicting if _accepts_a_death(i)]
+    # Assert
+    assert not leaky, (
+        f"{leaky} are declared unable to observe death, yet a DEAD Signal was "
+        f"constructible on them — the declaration is decorative"
+    )
+
+
+def test_an_unclassified_instrument_is_refused_at_construction():
+    """A free string cannot sneak in as a second witness."""
+    # Arrange
+    undeclared = "some_new_sensor"
+    # Act
+    # (constructing the Signal IS the act under test — it must refuse.)
+    # Assert
+    with pytest.raises(ValueError, match="must be one of"):
+        Signal(SOURCE_PROCESS, DEAD, "no session", undeclared)
+
+
+def test_an_instrument_that_observed_nothing_may_not_claim_life():
+    """NO_OBSERVATION exists so "we did not look" is TYPED, not inferred."""
+    # Arrange
+    instrument = INSTRUMENT_NO_OBSERVATION
+    # Act
+    # (constructing the Signal IS the act under test — it must refuse.)
+    # Assert
+    with pytest.raises(ValueError, match="may not emit"):
+        Signal(SOURCE_PROCESS, ALIVE, "vibes", instrument)
+
+
+def test_the_listen_broker_may_not_report_a_death():
+    """The confounded signal that started all of this stays incapable of killing."""
+    # Arrange
+    instrument = INSTRUMENT_LISTEN_BROKER
+    # Act
+    # (constructing the Signal IS the act under test — it must refuse.)
+    # Assert
+    with pytest.raises(ValueError, match="may not emit"):
+        Signal(SOURCE_DELIVERY, DEAD, "0 subscribers", instrument)

--- a/tests/scitex_agent_container/_lifecycle/test__verdict_resolve.py
+++ b/tests/scitex_agent_container/_lifecycle/test__verdict_resolve.py
@@ -64,6 +64,18 @@ class _RuntimeProbeExplodes:
         raise OSError("tmux server is wedged; cannot probe")
 
 
+def _on_the_host() -> bool:
+    """We are NOT in a container, so a pid check is a real sensor.
+
+    Pinned explicitly wherever a resolver bottoms out in ``os.kill(pid, 0)``. A
+    pid only means anything in the namespace that minted it, so these tests would
+    otherwise return DEAD on a CI runner and UNKNOWN inside a container —
+    the same code, two answers, depending on where pytest happened to run. The
+    instrument-independence suite covers the in-container half explicitly.
+    """
+    return False
+
+
 @pytest.fixture
 def live_pid():
     """A REAL live OS process. Reaped at teardown."""
@@ -149,11 +161,20 @@ def test_a_probe_that_raises_is_unknown_not_dead():
 
 
 def test_a_non_tui_runtime_that_reports_down_is_dead():
-    """The apptainer pidfile read is local and reliable — its False IS a probe."""
+    """The apptainer pidfile read is a real probe — ON THE HOST.
+
+    ``in_sif_fn`` is pinned rather than left to the ambient environment, and that
+    is not a formality: ``ApptainerRuntime.is_running`` is ``os.kill(pid, 0)``,
+    which is only a sensor in the pid namespace that MINTED the pid. Run from
+    inside a container it reads "reaped" for every healthy agent on the host. So
+    "is this a probe at all" depends on where the test runs — and a test whose
+    verdict flips between CI and a container is testing the environment, not the
+    code.
+    """
     # Arrange
     config = _Cfg("agent-a", "apptainer")
     # Act
-    signal = process_signal(config, _RuntimeSaysDown())
+    signal = process_signal(config, _RuntimeSaysDown(), in_sif_fn=_on_the_host)
     # Assert
     assert signal.verdict == DEAD
 
@@ -301,11 +322,15 @@ def test_heartbeat_signal_is_sourced_as_heartbeat(tmp_path):
 
 
 def test_a_reaped_recorded_pid_is_positive_evidence_of_death(reaped_pid):
-    """``os.kill(pid, 0)`` raising ESRCH means THAT process does not exist."""
+    """``os.kill(pid, 0)`` raising ESRCH means THAT process does not exist.
+
+    True only in the namespace that minted the pid — hence the pinned
+    ``in_sif_fn``; see :func:`_on_the_host`.
+    """
     # Arrange
     rows = [{"name": "scitex-dev", "pid": reaped_pid}]
     # Act
-    signal = registry_signal("scitex-dev", rows=rows)
+    signal = registry_signal("scitex-dev", rows=rows, in_sif_fn=_on_the_host)
     # Assert
     assert signal.verdict == DEAD
 
@@ -315,7 +340,7 @@ def test_a_live_recorded_pid_is_only_unknown_because_pids_are_recycled(live_pid)
     # Arrange
     rows = [{"name": "grant", "pid": live_pid}]
     # Act
-    signal = registry_signal("grant", rows=rows)
+    signal = registry_signal("grant", rows=rows, in_sif_fn=_on_the_host)
     # Assert
     assert signal.verdict == UNKNOWN
 


### PR DESCRIPTION
## The bug: the destruction gate counted REPORTERS, and its two witnesses were engineered to agree

`may_destroy` (shipped v0.21.20) is the gate every destructive remedy is meant to sit behind. It required:

> verdict DEAD **+ ≥ 2 independent dead sources +** zero alive sources

It counted **source strings**. But `process` and `registry` — **the only two sources that can emit DEAD** — are not two sensors. For **both** runtimes they are the *same* `os.kill(pid, 0)` on the *same* pid. The codebase engineered that identity deliberately, and says so in its own docstrings:

> `runtimes/_tui_liveness.pane_pid_of`: *"This is the value `instances.pid` records for a TUI agent, and it is the SAME signal `pane_process_alive` (hence `is_running`) already keys liveness on — **so the registry and `is_running` can never disagree** about which process represents this agent."*

> `runtimes/_apptainer_runtime.agent_pid`: *"This is EXACTLY the pid `is_running` above probes with `os.kill(pid, 0)` ... reusing `_read_pid` here means **the registry and `is_running` can never disagree**."*

The two witnesses the gate demanded were **guaranteed to agree**. Corroboration from one sensor asked twice is not corroboration — it is one observation wearing two hats. And the remedy for a DEAD verdict is `--force --fresh`, which **kills the agent**.

The syscall is not merely a weak sensor either — **from inside a container it is not a sensor at all**: a host pid lives in another pid namespace, so `os.kill` reads "reaped" for every healthy agent on the box.

### Measured — real reaped pid, real resolvers

| | `dead_sources` | `dead_instruments` | `may_destroy` |
|---|---|---|---|
| **v0.21.20 (as shipped)** | `('process','registry')` | *(no such concept)* | **`True`** ← kill authorised |
| **this branch** | `('process','registry')` | `('pid_namespace',)` | **`False`** |

Same inputs. The *counting* was wrong.

## The fix: count SENSORS, not reports

1. **`Signal` carries a required, closed-set `instrument`** — the sensor, as opposed to `source`, the reporter that carried the news. A free string is refused at construction. (`source` was already drifting: `_status` and `_health_liveness` emitted `Signal("resolver", …)`, a source that appears in no enumeration anywhere.)
2. **`may_destroy` deduplicates by instrument** before counting.
3. **Every instrument is declared** — what it physically reads, which verdicts it may emit, and when it is blind (`INSTRUMENT_INDEPENDENCE`):

| instrument | reads | may convict? |
|---|---|---|
| `listen_broker` | the broker's inbox-subscriber table | **no** |
| `host_tmux` | the tmux server's session bookkeeping | yes |
| `pid_namespace` | `os.kill(pid, 0)` in *this* namespace | yes |
| `agent_self` | the SDK loop's own beat file | **no** |
| `no_observation` | nothing — the gatherer itself failed | **no** |

   The collapses: `registry`, pid-runtime `is_running`, and the TUI pane-pid check are **one** instrument (`pid_namespace`). The TUI heartbeat is a re-report of the **same tmux snapshot** `process_signal` reads, so it is `host_tmux` — `sac listen`'s belief no longer votes twice.

4. **A sensor that cannot see death may not report one** — now mechanical, not aspirational. `Signal(SOURCE_DELIVERY, DEAD, …)` **raises**. The "0 subscribers ⇒ dead" inference that convicted a live fleet is no longer expressible.
5. **A pid read across a namespace boundary returns UNKNOWN** (in-container, or a row minted on another host), in both directions.
6. **The ambiguity rule**, stated and applied: when an instrument cannot be pinned down, label the one that **collapses**, never the one that adds a witness. Under-counting witnesses refuses a destruction; over-counting performs one. Only the second is unrecoverable.

## Can `may_destroy` still fire? Partly — and the shrink is the correct outcome

- **TUI (the fleet default): YES.** `host_tmux` positively has no session for the agent **and** `pid_namespace` says the recorded pid is reaped — two genuinely different bookkeepers with two different failure modes. No single sensor malfunction can produce both.
- **apptainer / claude-session: NO — it can no longer fire at all.** Their only convicting sensor is `pid_namespace`, asked twice. **This is correct, not a regression.** If we cannot corroborate death from two truly independent instruments, the verdict is UNKNOWN and we must not destroy. Restoring a destroy path for those runtimes needs a genuinely independent second instrument, not a re-read of the first.
- **A TUI agent whose session survives but whose pane pid is reaped: NO.** That is one `os.kill`, and the registry runs the same one.

## The meta-tests — so the enumeration cannot go decorative

Copying the discipline from scitex-todo's `test_every_closure_marker_is_actually_checked` (their guard knew about one closure marker and had never been told about the other, and returned ok on 5 corrupt cards):

- **every** `INSTRUMENT_*` constant must be classified in `INSTRUMENT_INDEPENDENCE` — add one without classifying it and the suite **fails**;
- **every `Signal(...)` in src** must name a declared instrument, *provably*: an AST scan resolves through variables and conditionals, and refuses literals, f-strings and calls. **This caught a real hole in my own patch** — `heartbeat_signal` was passing an unresolvable local;
- **a guard on the guard**: the scan must actually *find* construction sites, so it can never pass vacuously ("green because we did not look" is the very failure this module exists to prevent);
- **each convicting instrument, by enumeration, must be unable to corroborate itself** — a future convicting sensor inherits the rule automatically;
- **each non-convicting instrument, by enumeration, must be unable to report a death.**

Plus the test that **fails on today's code**: two DEAD signals from one instrument must not satisfy `may_destroy` — verified empirically against the installed v0.21.x, where it returns `True`.

## Scope / blast radius

`may_destroy` currently has **no production consumer that destroys anything** — it is computed, serialized into `--json`, and its veto reason printed. Nothing is gated on it yet, which is precisely why this is the moment: the gate is about to be pointed at a ~20-agent relaunch.

Two previously environment-dependent tests are now pinned: they silently returned DEAD on a CI runner and UNKNOWN inside a container — testing the environment, not the code.

Also fixes a pre-existing cap violation: `_verdict_resolve.py` was 514 lines (cap 512). The split leaves every touched file ≤ 388.

## Verification

- **81 passed** across the five verdict suites, run with `PYTHONPATH` pinned to the worktree **and the import path asserted** — not the installed package.
- Empirical before/after against installed v0.21.x on a real reaped pid (table above).

Card: `sac-may-destroy-counts-reporters-not-instruments-20260714`

---

## Second commit: the start-failure diagnostic was riding on a best-effort tmux capture

Found because this branch turned CI red. It is **not** a consequence of the verdict change — it is a latent production bug the reordered test schedule exposed, and it is the same disease.

`raise_start_failure` exists to **persist** `<state>/start_failure_diag.log`, because a false-negative start leaves **no registry row**, so killing the session by hand is often the only way to stop the agent — and that destroys the live pane capture forever. This file was the copy meant to survive that.

It didn't. The **mandatory write** was the last statement inside the **best-effort** pane-capture `try`, under a bare `except Exception`:

```python
try:
    _pane = TmuxManager.capture_logs(...).rstrip()   # best-effort
    ...
    _diag_log.write_text(...)                        # MANDATORY — last, same try
except Exception:
    diag = " (no pane diagnostics available)"
```

Any earlier hiccup threw, was swallowed, and the record vanished. The commonest hiccup is the plainest: **the state dir does not exist**, because a start that failed early never created it — `write_text` raises `FileNotFoundError`. So exactly when the diagnostic mattered most, it was thrown away.

And the caller was handed **"(no pane diagnostics available)"** — a message blaming the *pane capture* for a failure it never observed (a missing directory). **An error asserting a cause it did not see** — the identical defect the verdict engine exists to kill.

Measured (real config, real absent state dir): `diag file written? False`.

**Fix:** split best-effort (step 1, degrades the *message*) from mandatory (step 2, `_persist_diag`, always runs) + `mkdir(parents=True, exist_ok=True)`. `capture_pane_diag` becomes a real injection seam so the suite drives a genuinely exploding tmux layer without patching internals.

**Watched failing first** (repo rule): against develop's `_start_failure_diag.py` the new suite fails 5/6 — the two core ones for the right behavioural reason (the file is simply not written). On the fix: **89 passed**.

### Why the verdict engine was never implicated
The captured CI stderr from the failing job reads:

```
[sac:liveness] alpha: DEAD (process: apptainer probe succeeded and the recorded pid is REAPED ...)
```

`agent_start` branches **only** on `verdict.is_alive` (`_start.py:286`). Measured bit-identical on bare-metal py3.11, develop vs this branch: `verdict=dead, is_alive=False`. The instrument change can only turn DEAD→UNKNOWN, never →ALIVE, and both take the same non-no-op path.

Every failing CI job named `floor-gw1`: the two `test_lifecycle` diag tests only ever passed when some *other* test in the same xdist worker happened to create `<floor>/runtime/alpha/` first. The two new test files here changed `--dist load` distribution — exposing a latent order-dependency **and** the real hole under it.
