### PR TITLE
ci: forbid GitHub-hosted runners — the guard PR #694 never built

### DIFF
--- a/.github/hosted-runner-allowlist.yaml
+++ b/.github/hosted-runner-allowlist.yaml
@@ -1,0 +1,59 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# GitHub-HOSTED runner allowlist — the ONLY sanctioned exceptions.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Operator directive, 2026-07-14: GitHub-hosted runners are FORBIDDEN.
+# Every job runs on the self-hosted Spartan pool. Mandatory, no exceptions.
+# If the pool is broken, that is OUR problem to fix — escaping back to a
+# hosted runner is not an option.
+#
+# Enforced by `src/scitex_agent_container/_hosted_runner_guard.py`, which runs
+#   - as a CI job on the SELF-HOSTED pool
+#     (.github/workflows/no-hosted-runners-guard-on-self-hosted.yml),
+#   - as a `pre-commit` hook,
+#   - as a pytest test against this very repo.
+#
+# WHY THIS FILE EXISTS AT ALL
+# ===========================
+# An operator-approved exception that lives only in a chat message and a
+# merged PR body is a fact written in one place and believed in another.
+# The next agent greps for `ubuntu-latest`, finds cla.yml, reads it as an
+# oversight, "fixes" it — and reopens a security hole with the best of
+# intentions. So the exception lives HERE, in the mechanism, with its
+# argument attached, where the person about to remove it must first read
+# why it is there.
+#
+# THE `reason:` FIELD IS MANDATORY AND MACHINE-ENFORCED.
+# The guard FAILS (SAC-CI003) on any entry whose `reason:` is missing or
+# shorter than 40 characters. You cannot add an exception without arguing
+# for it. The guard also FAILS (SAC-CI004) on a STALE entry — one whose
+# workflow is gone, or which no longer has a hosted job — because a dead
+# exception is a live loophole: it silently pre-approves whatever that
+# file does next.
+#
+# Adding an entry is a deliberate, reviewable act. Argue for it in the PR.
+# ─────────────────────────────────────────────────────────────────────────────
+
+allow:
+  - workflow: cla.yml
+    jobs:
+      - CLAssistant
+    approved_by: operator
+    approved_on: 2026-07-14
+    # Operator ruled explicitly on this (案1 / "option 1") after being shown
+    # the argument below. This is NOT "we forgot to migrate it".
+    reason: >-
+      Migrating this one to the self-hosted pool would be STRICTLY WORSE than
+      the hole it appears to be. cla.yml is triggered by `issue_comment` and
+      `pull_request_target` — both UNAUTHENTICATED triggers that ANY stranger
+      can fire simply by commenting on an issue. Neither is covered by the
+      fork-PR approval gate (`pull_request_target` is the documented way
+      AROUND that gate), and the job runs a THIRD-PARTY action. On the Spartan
+      self-hosted runner, $HOME is the operator's REAL home directory, holding
+      the fleet's LIVE CREDENTIALS. Migrating cla.yml would therefore let an
+      unauthenticated stranger execute third-party code on the crown-jewel node
+      by commenting on an issue. It stays on GitHub's disposable hardware,
+      where a compromise costs us a throwaway VM instead of the fleet. The
+      third-party action is SHA-pinned (not tag-pinned) as the compensating
+      control. DO NOT "FIX" THIS BY MIGRATING IT — that is the exact bug this
+      allowlist exists to prevent.

--- a/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
+++ b/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
@@ -1,0 +1,62 @@
+name: no-hosted-runners
+
+# THE GUARD FOR THE RULE THAT HAS NO OTHER GUARD.
+#
+# Operator directive 2026-07-14 (absolute, no exceptions): NO GitHub-hosted
+# runners anywhere in this repo. Every job runs on the self-hosted Spartan
+# pool. If Spartan misbehaves, that is OURS to fix — never fall back to a
+# hosted runner.
+#
+# PR #694 migrated the 11 jobs. It did NOT build the guard. So until this
+# workflow existed, nothing stopped the next PR from quietly landing on
+# `ubuntu-latest` again, and we would not have noticed until it had.
+#
+# WHAT IT CHECKS
+#   Parses every .github/workflows/*.y*ml, reads each job's `runs-on:`, and
+#   fails on any job that (a) lands on a GitHub-hosted image family
+#   (ubuntu-* / macos-* / windows-*, not just the `-latest` literals), or
+#   (b) whose runner target cannot be PROVEN self-hosted. It does not grep:
+#   our filenames and job `name:` fields still contain "ubuntu-latest", and
+#   a grep would red-flag the very jobs we just migrated.
+#
+# THE ONE EXCEPTION lives in .github/hosted-runner-allowlist.yaml, WITH the
+# security argument attached and machine-enforced (an entry without a real
+# `reason:` fails the guard). cla.yml stays hosted on purpose — read the
+# allowlist before you "fix" it.
+#
+# AND OBVIOUSLY: this job runs on the SELF-HOSTED pool. A no-hosted-runners
+# guard running on a hosted runner would be its own punchline.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+jobs:
+  no-hosted-runners:
+    name: no-hosted-runners-guard-on-self-hosted
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      # Same pattern as lint.yml: the bare Spartan node has no Python and is
+      # PEP-668 externally-managed, so setup-uv + uv's own managed CPython is
+      # the only thing that works there. The guard needs nothing but PyYAML.
+      - uses: astral-sh/setup-uv@v3
+        with:
+          cache-dependency-glob: pyproject.toml
+
+      - name: Guard — no GitHub-hosted runners
+        run: |
+          set -euo pipefail
+          uv venv --python 3.12 .venv
+          uv pip install --python .venv/bin/python pyyaml
+          # 2>&1 on purpose: the guard prints its FAILURE report to stderr.
+          # Without the merge, the one thing a reader needs would be missing
+          # from the step summary. pipefail keeps the non-zero exit intact.
+          PYTHONPATH=src .venv/bin/python \
+            -m scitex_agent_container._hosted_runner_guard . 2>&1 \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,14 @@ repos:
     hooks:
       - id: no-hosted-runners
         name: "no GitHub-hosted runners in .github/workflows/"
-        entry: python -m scitex_agent_container._hosted_runner_guard
-        language: system
+        # Invoked BY PATH, not `-m`: the module is self-contained (stdlib +
+        # pyyaml, no intra-package imports), so the hook works in a bare
+        # checkout without sac installed. `language: system` + `-m` would
+        # false-RED for any contributor whose PATH python cannot import
+        # scitex_agent_container — and a guard that cries wolf gets disabled.
+        entry: python src/scitex_agent_container/_hosted_runner_guard.py
+        language: python
+        additional_dependencies: [pyyaml]
         pass_filenames: false
         files: ^\.github/(workflows/.*\.ya?ml|hosted-runner-allowlist\.yaml)$
         description: >

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,18 @@
 repos:
   - repo: local
     hooks:
+      - id: no-hosted-runners
+        name: "no GitHub-hosted runners in .github/workflows/"
+        entry: python -m scitex_agent_container._hosted_runner_guard
+        language: system
+        pass_filenames: false
+        files: ^\.github/(workflows/.*\.ya?ml|hosted-runner-allowlist\.yaml)$
+        description: >
+          Operator directive 2026-07-14 (mandatory, no exceptions): every job
+          runs on the self-hosted pool. The ONE approved exception (cla.yml)
+          lives in .github/hosted-runner-allowlist.yaml WITH its security
+          argument — an entry without a real `reason:` fails the guard.
+
       - id: stx-allow-fallback
         name: "stx-allow: fallback lint (no-silent-fallback)"
         entry: python scripts/check_stx_allow.py

--- a/src/scitex_agent_container/_hosted_runner_guard.py
+++ b/src/scitex_agent_container/_hosted_runner_guard.py
@@ -1,0 +1,483 @@
+"""Guard: no GitHub-HOSTED runner may appear in ``.github/workflows/``.
+
+Operator directive, 2026-07-14 (condensed):
+
+    Never use GitHub-hosted runners. MAKE IT AN ERROR via linter/hook.
+    Mandatory, no exceptions. If Spartan (the self-hosted pool) breaks,
+    that is OUR problem — never escape back to a hosted runner.
+
+PR #694 migrated sac's 11 jobs onto the self-hosted Spartan pool, but the
+GUARD was never built: nothing stopped the next workflow from quietly
+landing on ``ubuntu-latest`` again, and we would not have noticed until
+it had. This module is that guard.
+
+Why this is not a ``grep ubuntu-latest``
+========================================
+Three ways the naive grep is wrong, all of them live in this repo today:
+
+1. It MISSES ``ubuntu-24.04`` / ``macos-14`` / ``windows-2022``. We match
+   the runner-image FAMILY (``ubuntu-`` / ``macos-`` / ``windows-``), not
+   one literal.
+2. It FALSE-FLAGS our own migrated files. Both the workflow FILENAMES
+   (``quality-audit-on-ubuntu-latest.yml``) and the job ``name:`` fields
+   (``ruff-on-ubuntu-latest``) still carry the legacy string. Only a job's
+   ``runs-on:`` decides where it executes, so we parse YAML and read
+   ``runs-on`` — nothing else.
+3. It cannot resolve ``runs-on: ${{ fromJSON(vars.CI_RUNS_ON ||
+   '["self-hosted","Linux","X64","scitex-ci"]') }}`` — the expression our
+   11 migrated jobs actually use.
+
+Three verdicts, never two
+=========================
+A boolean here would collapse "I cannot tell" into one of the poles, and
+whichever pole it picks is a bug: assume-hosted false-REDs a healthy job,
+assume-self-hosted opens a silent bypass (``runs-on: ${{ vars.ANYTHING }}``
+proves nothing). So :func:`classify_runs_on` returns one of:
+
+* ``SELF_HOSTED``   — we can PROVE it lands on our hardware.
+* ``HOSTED``        — we can PROVE it lands on GitHub's.
+* ``UNRESOLVABLE``  — we can prove NEITHER.
+
+``UNRESOLVABLE`` fails the guard, on purpose: a guard that cannot see
+cannot guard, and an unreadable ``runs-on`` is exactly the shape a bypass
+would take. It is reported under its own code so the message stays honest
+— it says "cannot prove", not "is hosted".
+
+Known limitation (stated, not hidden)
+=====================================
+``vars.CI_RUNS_ON`` is a GitHub repo/org Variable resolved at run time. A
+static reader cannot see its value; we check the INLINE DEFAULT that ships
+in the repo. If someone re-points that Variable at a hosted image, this
+guard cannot see it — that is a GitHub-settings change, not a code change,
+and belongs to org/branch protection.
+
+Entry points
+============
+* ``python -m scitex_agent_container._hosted_runner_guard [REPO_ROOT]``
+  — exit 0 clean, exit 1 on any violation. Wired as (a) a CI job on the
+  SELF-HOSTED pool and (b) a ``pre-commit`` hook.
+* :func:`check_repo` — pure function; returns violations, raises nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+# Runner-image families GitHub hosts. Prefix match, so `ubuntu-latest`,
+# `ubuntu-24.04`, `ubuntu-22.04-arm`, `macos-13-xlarge`, `windows-2022`
+# and the larger-runner variants (`ubuntu-latest-4-cores`) all match.
+_HOSTED_PREFIXES = ("ubuntu-", "macos-", "windows-")
+
+# The label GitHub puts on every self-hosted runner. Its presence is
+# positive proof the job lands on our hardware.
+_SELF_HOSTED_LABEL = "self-hosted"
+
+# An allowlist entry must ARGUE its case. A stub ("legacy", "needed") is
+# not an argument; this floor makes the reason a sentence, not a shrug.
+_MIN_REASON_CHARS = 40
+
+_ALLOWLIST_RELPATH = Path(".github") / "hosted-runner-allowlist.yaml"
+_WORKFLOWS_RELDIR = Path(".github") / "workflows"
+
+# Verdicts.
+SELF_HOSTED = "SELF_HOSTED"
+HOSTED = "HOSTED"
+UNRESOLVABLE = "UNRESOLVABLE"
+
+# Violation codes.
+CODE_HOSTED = "SAC-CI001"  # hosted runner, not allowlisted
+CODE_UNRESOLVABLE = "SAC-CI002"  # runs-on cannot be proven either way
+CODE_ALLOWLIST_NO_REASON = "SAC-CI003"  # allowlist entry without an argument
+CODE_ALLOWLIST_STALE = "SAC-CI004"  # allowlist entry that no longer applies
+
+_EXPR_RE = re.compile(r"\$\{\{(.+?)\}\}", re.DOTALL)
+_QUOTED_RE = re.compile(r"'([^']*)'|\"([^\"]*)\"")
+_MATRIX_REF_RE = re.compile(r"matrix\.([A-Za-z0-9_-]+)")
+
+_CANONICAL_RUNS_ON = (
+    "runs-on: ${{ fromJSON(vars.CI_RUNS_ON || "
+    '\'["self-hosted","Linux","X64","scitex-ci"]\') }}'
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One reason the guard failed. ``where`` is repo-relative."""
+
+    code: str
+    where: str
+    message: str
+
+    def render(self) -> str:
+        return f"  {self.code}  {self.where}\n      {self.message}"
+
+
+def _flatten(value: Any) -> list[str]:
+    """Collapse a scalar / list / nested list into a flat list of strings."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple)):
+        out: list[str] = []
+        for item in value:
+            out.extend(_flatten(item))
+        return out
+    return [str(value)]
+
+
+def _matrix_values(job: dict, key: str) -> list[str]:
+    """Every value ``matrix.<key>`` can take, incl. ``include:`` entries."""
+    strategy = job.get("strategy")
+    if not isinstance(strategy, dict):
+        return []
+    matrix = strategy.get("matrix")
+    if not isinstance(matrix, dict):
+        return []
+    out = _flatten(matrix.get(key))
+    include = matrix.get("include")
+    if isinstance(include, list):
+        for entry in include:
+            if isinstance(entry, dict) and key in entry:
+                out.extend(_flatten(entry[key]))
+    return out
+
+
+def _labels_from_expression(expr: str, job: dict) -> list[str]:
+    """Best-effort static resolution of a ``${{ ... }}`` runs-on expression.
+
+    Two sources, both static:
+
+    * quoted literals — a bare ``'self-hosted'`` or an embedded JSON array
+      such as ``'["self-hosted","Linux","X64","scitex-ci"]'`` (the inline
+      default of our canonical ``fromJSON(vars.CI_RUNS_ON || ...)`` form);
+    * ``matrix.<key>`` references — resolved against the job's own
+      ``strategy.matrix`` (so a matrix fanning out over ``[ubuntu-latest,
+      macos-latest]`` is caught, not waved through).
+    """
+    labels: list[str] = []
+    for match in _QUOTED_RE.finditer(expr):
+        literal = match.group(1) if match.group(1) is not None else match.group(2)
+        stripped = literal.strip()
+        if stripped.startswith("["):
+            try:
+                labels.extend(_flatten(json.loads(stripped)))
+                continue
+            except ValueError:
+                pass  # not JSON after all — fall through and take it whole
+        if stripped:
+            labels.append(stripped)
+    for match in _MATRIX_REF_RE.finditer(expr):
+        labels.extend(_matrix_values(job, match.group(1)))
+    return labels
+
+
+def _runner_labels(job: dict) -> tuple[list[str], bool]:
+    """Return ``(labels, saw_unresolvable_expression)`` for one job.
+
+    ``runs-on`` may be a scalar, a list of labels, or the runner-group
+    mapping (``{group: ..., labels: [...]}``). Any of those may itself be
+    — or contain — a ``${{ }}`` expression.
+    """
+    runs_on = job.get("runs-on")
+    raw: list[str] = []
+    if isinstance(runs_on, dict):
+        raw.extend(_flatten(runs_on.get("labels")))
+        raw.extend(_flatten(runs_on.get("group")))
+    else:
+        raw.extend(_flatten(runs_on))
+
+    labels: list[str] = []
+    unresolvable = False
+    for token in raw:
+        expressions = _EXPR_RE.findall(token)
+        if not expressions:
+            labels.append(token)
+            continue
+        for expr in expressions:
+            resolved = _labels_from_expression(expr, job)
+            if resolved:
+                labels.extend(resolved)
+            else:
+                unresolvable = True
+    return labels, unresolvable
+
+
+def classify_runs_on(job: dict) -> str:
+    """Return ``SELF_HOSTED`` / ``HOSTED`` / ``UNRESOLVABLE`` for one job.
+
+    Positive proof wins: a label set carrying ``self-hosted`` runs on our
+    hardware even if a sibling label happens to name an OS image.
+    """
+    labels, unresolvable = _runner_labels(job)
+    lowered = [label.strip().lower() for label in labels if label and label.strip()]
+
+    if any(label == _SELF_HOSTED_LABEL for label in lowered):
+        return SELF_HOSTED
+    if any(label.startswith(_HOSTED_PREFIXES) for label in lowered):
+        return HOSTED
+    if unresolvable or not lowered:
+        return UNRESOLVABLE
+    # Bare labels naming neither a hosted image nor `self-hosted`
+    # (e.g. `[Linux, X64, scitex-ci]`) target our own pool by label.
+    return SELF_HOSTED
+
+
+def _iter_jobs(doc: Any) -> Iterable[tuple[str, dict]]:
+    jobs = doc.get("jobs") if isinstance(doc, dict) else None
+    if not isinstance(jobs, dict):
+        return
+    for job_id, job in jobs.items():
+        if isinstance(job, dict):
+            yield str(job_id), job
+
+
+def _allowed_jobs(entry: dict) -> set[str] | None:
+    """Job ids this entry covers; ``None`` means every job in the file."""
+    jobs = entry.get("jobs")
+    if jobs is None:
+        return None
+    return {str(job) for job in _flatten(jobs)}
+
+
+def load_allowlist(repo: Path) -> tuple[dict[str, dict], list[Violation]]:
+    """Parse the allowlist; enforce that every entry ARGUES its case.
+
+    Returns ``({workflow_filename: entry}, violations)``. The mandatory
+    ``reason`` is enforced HERE, in the mechanism — an entry without a real
+    argument fails the guard exactly like an un-allowlisted hosted runner
+    would. That is the whole point: an operator-approved exception that
+    lives only in a chat message is a fact written in one place and
+    believed in another; the next agent greps, finds the exception, reads
+    it as an oversight, and "fixes" it — reopening the hole with the best
+    of intentions.
+    """
+    path = repo / _ALLOWLIST_RELPATH
+    if not path.is_file():
+        return {}, []
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        return {}, [
+            Violation(
+                CODE_ALLOWLIST_NO_REASON,
+                str(_ALLOWLIST_RELPATH),
+                f"allowlist is unreadable / not valid YAML: {exc}",
+            )
+        ]
+
+    entries = doc.get("allow") if isinstance(doc, dict) else None
+    allow: dict[str, dict] = {}
+    violations: list[Violation] = []
+    if not isinstance(entries, list):
+        return {}, violations
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            violations.append(
+                Violation(
+                    CODE_ALLOWLIST_NO_REASON,
+                    str(_ALLOWLIST_RELPATH),
+                    f"allowlist entry is not a mapping: {entry!r}",
+                )
+            )
+            continue
+        workflow = str(entry.get("workflow") or "").strip()
+        if not workflow:
+            violations.append(
+                Violation(
+                    CODE_ALLOWLIST_NO_REASON,
+                    str(_ALLOWLIST_RELPATH),
+                    f"allowlist entry has no `workflow:` key: {entry!r}",
+                )
+            )
+            continue
+        reason = str(entry.get("reason") or "").strip()
+        if len(reason) < _MIN_REASON_CHARS:
+            violations.append(
+                Violation(
+                    CODE_ALLOWLIST_NO_REASON,
+                    f"{_ALLOWLIST_RELPATH} -> {workflow}",
+                    (
+                        "allowlist entry needs a `reason:` of at least "
+                        f"{_MIN_REASON_CHARS} characters explaining WHY this "
+                        "workflow may run on GitHub's hardware. An exception "
+                        "without its argument attached is precisely the bug "
+                        f"this guard exists to prevent (got {len(reason)} chars)."
+                    ),
+                )
+            )
+            continue
+        allow[workflow] = entry
+    return allow, violations
+
+
+def _hosted_violation(rel: str, job_id: str, labels: list[str]) -> Violation:
+    return Violation(
+        CODE_HOSTED,
+        f"{rel} -> job `{job_id}`",
+        (
+            f"runs on a GitHub-HOSTED runner ({', '.join(labels)}). "
+            "Move it to the self-hosted pool:\n"
+            f"        {_CANONICAL_RUNS_ON}\n"
+            "      Hosted runners are FORBIDDEN in this repo (operator, "
+            "2026-07-14: mandatory, no exceptions). If the self-hosted pool "
+            "is broken, fix the pool — do not escape to a hosted runner. A "
+            f"genuine security exception goes in {_ALLOWLIST_RELPATH}, WITH "
+            "its argument attached."
+        ),
+    )
+
+
+def _unresolvable_violation(rel: str, job_id: str) -> Violation:
+    return Violation(
+        CODE_UNRESOLVABLE,
+        f"{rel} -> job `{job_id}`",
+        (
+            "`runs-on` cannot be proven to target the self-hosted pool. The "
+            "guard reads only what ships in the repo, so an unreadable runner "
+            "target is indistinguishable from a deliberate bypass. Use a "
+            "literal label list, or the canonical form whose inline default "
+            f"names `self-hosted`:\n        {_CANONICAL_RUNS_ON}"
+        ),
+    )
+
+
+def _stale_violations(
+    repo: Path, allow: dict[str, dict], used: set[tuple[str, str]]
+) -> list[Violation]:
+    """A dead exception is a live loophole — it silently pre-approves
+    whatever that workflow does next. Every entry must still be EARNING
+    its place."""
+    out: list[Violation] = []
+    wf_dir = repo / _WORKFLOWS_RELDIR
+    for workflow in allow:
+        if not (wf_dir / workflow).is_file():
+            out.append(
+                Violation(
+                    CODE_ALLOWLIST_STALE,
+                    f"{_ALLOWLIST_RELPATH} -> {workflow}",
+                    (
+                        "allowlisted workflow does not exist — delete the stale "
+                        "entry. A dead exception is a standing pre-approval for "
+                        "whatever takes that filename next."
+                    ),
+                )
+            )
+            continue
+        if not any(name == workflow for name, _ in used):
+            out.append(
+                Violation(
+                    CODE_ALLOWLIST_STALE,
+                    f"{_ALLOWLIST_RELPATH} -> {workflow}",
+                    (
+                        "allowlisted workflow no longer needs the exception (no "
+                        "hosted job left in it) — delete the entry. Keeping it "
+                        "leaves a standing exception nobody needs, which the "
+                        "next hosted job added to that file would inherit for "
+                        "free."
+                    ),
+                )
+            )
+    return out
+
+
+def check_repo(repo: Path) -> list[Violation]:
+    """Scan ``<repo>/.github/workflows/``. Pure; never raises."""
+    violations: list[Violation] = []
+    allow, allow_violations = load_allowlist(repo)
+    violations.extend(allow_violations)
+
+    wf_dir = repo / _WORKFLOWS_RELDIR
+    if not wf_dir.is_dir():
+        return violations
+
+    used: set[tuple[str, str]] = set()
+
+    for path in sorted(wf_dir.iterdir()):
+        if not path.is_file() or path.suffix not in {".yml", ".yaml"}:
+            continue
+        rel = str(path.relative_to(repo))
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            violations.append(
+                Violation(CODE_UNRESOLVABLE, rel, f"cannot parse workflow: {exc}")
+            )
+            continue
+
+        entry = allow.get(path.name)
+        exempt_jobs = _allowed_jobs(entry) if entry is not None else set()
+
+        for job_id, job in _iter_jobs(doc):
+            # A `uses:` job calls a reusable workflow and declares no runner
+            # of its own — there is no runs-on decision to police here.
+            if "runs-on" not in job and job.get("uses"):
+                continue
+
+            verdict = classify_runs_on(job)
+            if verdict == SELF_HOSTED:
+                continue
+
+            if entry is not None and (exempt_jobs is None or job_id in exempt_jobs):
+                used.add((path.name, job_id))
+                continue
+
+            if verdict == HOSTED:
+                labels, _ = _runner_labels(job)
+                violations.append(_hosted_violation(rel, job_id, labels))
+            else:
+                violations.append(_unresolvable_violation(rel, job_id))
+
+    violations.extend(_stale_violations(repo, allow, used))
+    return violations
+
+
+def format_report(repo: Path, violations: list[Violation]) -> str:
+    if not violations:
+        return (
+            f"no-hosted-runners: OK — every job in {_WORKFLOWS_RELDIR} targets "
+            "the self-hosted pool (or is allowlisted WITH a stated reason)."
+        )
+    lines = [
+        "",
+        "=" * 72,
+        "NO-HOSTED-RUNNERS GUARD FAILED",
+        "=" * 72,
+        "",
+        f"{len(violations)} violation(s) in {repo}:",
+        "",
+    ]
+    lines.extend(violation.render() for violation in violations)
+    lines.extend(
+        [
+            "",
+            "GitHub-hosted runners are forbidden in this repo (operator "
+            "directive, 2026-07-14: mandatory, no exceptions).",
+            "If the self-hosted pool is broken, that is OUR problem to fix — "
+            "escaping back to a hosted runner is not an option.",
+            "=" * 72,
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    repo = Path(args[0]).resolve() if args else Path.cwd()
+    violations = check_repo(repo)
+    stream = sys.stderr if violations else sys.stdout
+    print(format_report(repo, violations), file=stream)
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI shim
+    raise SystemExit(main())

--- a/tests/scitex_agent_container/test__hosted_runner_guard.py
+++ b/tests/scitex_agent_container/test__hosted_runner_guard.py
@@ -1,0 +1,468 @@
+"""Tests for the no-GitHub-hosted-runner guard.
+
+A GUARD YOU HAVE ONLY EVER SEEN PASS IS A HOPE. We merged a "fail-loud"
+version gate earlier this week that returned exit 0 on the exact broken
+artifact it existed to reject — because it was calibrated to the last
+incident and nobody ever ran it against a bad input.
+
+So this file proves BOTH directions:
+
+* the guard FAILS (non-zero, with the right code) on a workflow that lands
+  on a hosted runner — one test per evasion we could think of;
+* the guard PASSES on the real ``.github/workflows/`` of this repo — the
+  11 migrated self-hosted jobs plus the one allowlisted exception.
+
+``test_this_repo_is_clean`` is also the false-positive alarm: if the guard
+ever red-flags the migrated jobs, or stops honouring the cla.yml
+exception, this file goes red.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scitex_agent_container._hosted_runner_guard import (
+    CODE_ALLOWLIST_NO_REASON,
+    CODE_ALLOWLIST_STALE,
+    CODE_HOSTED,
+    CODE_UNRESOLVABLE,
+    HOSTED,
+    SELF_HOSTED,
+    UNRESOLVABLE,
+    check_repo,
+    classify_runs_on,
+    load_allowlist,
+    main,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The canonical self-hosted target our 11 migrated jobs actually use.
+CANONICAL = (
+    '${{ fromJSON(vars.CI_RUNS_ON || \'["self-hosted","Linux","X64","scitex-ci"]\') }}'
+)
+
+GOOD_REASON = (
+    "This job may run on GitHub's hardware because its triggers are "
+    "unauthenticated and it runs a third-party action, which on the "
+    "self-hosted node would reach the operator's live credentials."
+)
+
+MATRIX_FANOUT = (
+    "name: demo\n"
+    "on: [push]\n"
+    "jobs:\n"
+    "  test:\n"
+    "    strategy:\n"
+    "      matrix:\n"
+    "        os: [ubuntu-latest, macos-latest]\n"
+    "    runs-on: ${{ matrix.os }}\n"
+    "    steps:\n"
+    "      - run: echo hi\n"
+)
+
+TWO_HOSTED_JOBS = (
+    "name: cla\n"
+    "on: [push]\n"
+    "jobs:\n"
+    "  CLAssistant:\n"
+    "    runs-on: ubuntu-latest\n"
+    "    steps:\n"
+    "      - run: echo hi\n"
+    "  sneaky:\n"
+    "    runs-on: ubuntu-latest\n"
+    "    steps:\n"
+    "      - run: echo hi\n"
+)
+
+REUSABLE_CALLER = (
+    "name: demo\non: [push]\njobs:\n  call:\n    uses: ./.github/workflows/other.yml\n"
+)
+
+LEGACY_NAMED = (
+    "name: quality\n"
+    "on: [push]\n"
+    "jobs:\n"
+    "  audit:\n"
+    "    name: scitex-dev-quality-audit-on-ubuntu-latest\n"
+    f"    runs-on: {CANONICAL}\n"
+    "    steps:\n"
+    "      - run: echo hi\n"
+)
+
+
+def _workflow(runs_on: str, job_id: str = "build") -> str:
+    return (
+        "name: demo\n"
+        "on: [push]\n"
+        "jobs:\n"
+        f"  {job_id}:\n"
+        f"    runs-on: {runs_on}\n"
+        "    steps:\n"
+        "      - run: echo hi\n"
+    )
+
+
+def _write_repo(
+    root: Path,
+    workflows: dict[str, str],
+    allowlist: str | None = None,
+) -> Path:
+    """Materialise a throwaway repo with real files on disk (no mocks)."""
+    wf_dir = root / ".github" / "workflows"
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    for name, body in workflows.items():
+        (wf_dir / name).write_text(body, encoding="utf-8")
+    if allowlist is not None:
+        (root / ".github" / "hosted-runner-allowlist.yaml").write_text(
+            allowlist, encoding="utf-8"
+        )
+    return root
+
+
+def _allowlist(workflow: str, jobs: str = "", reason: str = GOOD_REASON) -> str:
+    jobs_line = f"    jobs: [{jobs}]\n" if jobs else ""
+    return (
+        f"allow:\n  - workflow: {workflow}\n{jobs_line}    reason: >-\n      {reason}\n"
+    )
+
+
+def _codes(root: Path) -> list[str]:
+    return [violation.code for violation in check_repo(root)]
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# FAIL DIRECTION — the guard must actually fire.
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "ubuntu-latest",  # the literal everyone greps for
+        "ubuntu-24.04",  # ...and the one they write next week
+        "ubuntu-22.04",
+        "ubuntu-latest-4-cores",  # larger runners
+        "macos-latest",
+        "macos-14",
+        "windows-latest",
+        "windows-2022",
+    ],
+)
+def test_every_hosted_image_family_is_flagged(tmp_path: Path, label: str) -> None:
+    # Arrange
+    _write_repo(tmp_path, {"ci.yml": _workflow(label)})
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert codes == [CODE_HOSTED]
+
+
+def test_hosted_runner_exits_non_zero(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(tmp_path, {"ci.yml": _workflow("ubuntu-latest")})
+    # Act
+    exit_code = main([str(tmp_path)])
+    # Assert
+    assert exit_code == 1
+
+
+def test_hosted_runner_message_names_the_offence(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(tmp_path, {"ci.yml": _workflow("ubuntu-latest")})
+    # Act
+    violations = check_repo(tmp_path)
+    # Assert
+    assert "GitHub-HOSTED runner" in violations[0].message
+
+
+def test_hosted_runner_in_list_form_is_flagged(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(tmp_path, {"ci.yml": _workflow("[ubuntu-latest]")})
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert codes == [CODE_HOSTED]
+
+
+def test_hosted_matrix_fanout_is_flagged(tmp_path: Path) -> None:
+    # Arrange: `runs-on: ${{ matrix.os }}` resolved against the matrix values
+    _write_repo(tmp_path, {"ci.yml": MATRIX_FANOUT})
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert codes == [CODE_HOSTED]
+
+
+def test_hosted_default_smuggled_into_fromjson_is_flagged(tmp_path: Path) -> None:
+    # Arrange
+    runs_on = "${{ fromJSON(vars.CI_RUNS_ON || '[\"ubuntu-latest\"]') }}"
+    _write_repo(tmp_path, {"ci.yml": _workflow(runs_on)})
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert codes == [CODE_HOSTED]
+
+
+def test_unresolvable_runs_on_is_refused(tmp_path: Path) -> None:
+    # Arrange: we cannot PROVE `${{ vars.WHATEVER }}` is ours. Absence of
+    # evidence is not evidence of self-hosting, and an unreadable runner
+    # target is exactly the shape a deliberate bypass would take.
+    _write_repo(tmp_path, {"ci.yml": _workflow("${{ vars.WHATEVER }}")})
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert codes == [CODE_UNRESOLVABLE]
+
+
+def test_allowlist_entry_without_reason_is_rejected(tmp_path: Path) -> None:
+    # Arrange: the mandatory `reason:` is enforced by the MECHANISM
+    _write_repo(
+        tmp_path,
+        {"cla.yml": _workflow("ubuntu-latest", job_id="CLAssistant")},
+        allowlist="allow:\n  - workflow: cla.yml\n",
+    )
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert CODE_ALLOWLIST_NO_REASON in codes
+
+
+def test_allowlist_entry_without_reason_does_not_exempt_the_job(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    _write_repo(
+        tmp_path,
+        {"cla.yml": _workflow("ubuntu-latest", job_id="CLAssistant")},
+        allowlist="allow:\n  - workflow: cla.yml\n",
+    )
+    # Act: a rejected entry must not smuggle the job through
+    codes = _codes(tmp_path)
+    # Assert
+    assert CODE_HOSTED in codes
+
+
+def test_allowlist_entry_with_stub_reason_is_rejected(tmp_path: Path) -> None:
+    # Arrange: a shrug ("legacy") is not an argument
+    _write_repo(
+        tmp_path,
+        {"cla.yml": _workflow("ubuntu-latest", job_id="CLAssistant")},
+        allowlist='allow:\n  - workflow: cla.yml\n    reason: "legacy"\n',
+    )
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert CODE_ALLOWLIST_NO_REASON in codes
+
+
+def test_stale_allowlist_entry_is_flagged(tmp_path: Path) -> None:
+    # Arrange: ci.yml is self-hosted, so it needs no exception. A dead
+    # exception is a live loophole — it pre-approves the next hosted job.
+    _write_repo(
+        tmp_path,
+        {"ci.yml": _workflow(CANONICAL)},
+        allowlist=_allowlist("ci.yml"),
+    )
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert codes == [CODE_ALLOWLIST_STALE]
+
+
+def test_allowlist_entry_for_missing_workflow_is_flagged(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(
+        tmp_path,
+        {"ci.yml": _workflow(CANONICAL)},
+        allowlist=_allowlist("gone.yml"),
+    )
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert codes == [CODE_ALLOWLIST_STALE]
+
+
+def test_job_scoped_allowlist_does_not_cover_a_new_job(tmp_path: Path) -> None:
+    # Arrange: entry covers CLAssistant only; `sneaky` must not ride along
+    _write_repo(
+        tmp_path,
+        {"cla.yml": TWO_HOSTED_JOBS},
+        allowlist=_allowlist("cla.yml", jobs="CLAssistant"),
+    )
+    # Act
+    codes = _codes(tmp_path)
+    # Assert
+    assert codes == [CODE_HOSTED]
+
+
+def test_job_scoped_allowlist_names_the_uncovered_job(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(
+        tmp_path,
+        {"cla.yml": TWO_HOSTED_JOBS},
+        allowlist=_allowlist("cla.yml", jobs="CLAssistant"),
+    )
+    # Act
+    violations = check_repo(tmp_path)
+    # Assert
+    assert "sneaky" in violations[0].where
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# PASS DIRECTION — the guard must not cry wolf.
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def test_canonical_self_hosted_expression_passes(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(tmp_path, {"ci.yml": _workflow(CANONICAL)})
+    # Act
+    violations = check_repo(tmp_path)
+    # Assert
+    assert violations == []
+
+
+def test_canonical_self_hosted_expression_exits_zero(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(tmp_path, {"ci.yml": _workflow(CANONICAL)})
+    # Act
+    exit_code = main([str(tmp_path)])
+    # Assert
+    assert exit_code == 0
+
+
+def test_plain_self_hosted_label_list_passes(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(tmp_path, {"ci.yml": _workflow("[self-hosted, Linux, X64]")})
+    # Act
+    violations = check_repo(tmp_path)
+    # Assert
+    assert violations == []
+
+
+def test_legacy_ubuntu_filenames_and_job_names_are_not_flagged(
+    tmp_path: Path,
+) -> None:
+    # Arrange: the naive-grep trap. Both the FILENAME and the job `name:`
+    # still say ubuntu-latest, but only `runs-on:` decides where it runs.
+    _write_repo(tmp_path, {"quality-audit-on-ubuntu-latest.yml": LEGACY_NAMED})
+    # Act
+    violations = check_repo(tmp_path)
+    # Assert
+    assert violations == []
+
+
+def test_reusable_workflow_call_is_not_flagged(tmp_path: Path) -> None:
+    # Arrange: a `uses:` job declares no runner of its own
+    _write_repo(
+        tmp_path,
+        {
+            "caller.yml": REUSABLE_CALLER,
+            "other.yml": _workflow(CANONICAL, job_id="inner"),
+        },
+    )
+    # Act
+    violations = check_repo(tmp_path)
+    # Assert
+    assert violations == []
+
+
+def test_allowlisted_hosted_job_passes(tmp_path: Path) -> None:
+    # Arrange: the approved exception, with its argument attached
+    _write_repo(
+        tmp_path,
+        {"cla.yml": _workflow("ubuntu-latest", job_id="CLAssistant")},
+        allowlist=_allowlist("cla.yml", jobs="CLAssistant"),
+    )
+    # Act
+    violations = check_repo(tmp_path)
+    # Assert
+    assert violations == []
+
+
+def test_allowlisted_hosted_job_exits_zero(tmp_path: Path) -> None:
+    # Arrange
+    _write_repo(
+        tmp_path,
+        {"cla.yml": _workflow("ubuntu-latest", job_id="CLAssistant")},
+        allowlist=_allowlist("cla.yml", jobs="CLAssistant"),
+    )
+    # Act
+    exit_code = main([str(tmp_path)])
+    # Assert
+    assert exit_code == 0
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# The verdict is a TERNARY, never a boolean.
+# ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "runs_on,expected",
+    [
+        ("ubuntu-latest", HOSTED),
+        ("self-hosted", SELF_HOSTED),
+        (["self-hosted", "Linux"], SELF_HOSTED),
+        # `self-hosted` is positive proof — it is OUR box even if a sibling
+        # label happens to name an OS image.
+        (["self-hosted", "ubuntu-latest"], SELF_HOSTED),
+        ("${{ vars.MYSTERY }}", UNRESOLVABLE),
+        (None, UNRESOLVABLE),
+    ],
+)
+def test_classify_runs_on_returns_the_right_verdict(runs_on, expected: str) -> None:
+    # Arrange
+    job = {"runs-on": runs_on}
+    # Act
+    verdict = classify_runs_on(job)
+    # Assert
+    assert verdict == expected
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# THE REAL REPO — the trap the brief warned about.
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def test_this_repo_is_clean() -> None:
+    # Arrange: sac's own workflows — 11 migrated jobs + 1 allowlisted
+    repo = REPO_ROOT
+    # Act
+    violations = check_repo(repo)
+    # Assert
+    assert violations == [], "\n".join(v.render() for v in violations)
+
+
+def test_the_cla_allowlist_entry_is_present() -> None:
+    # Arrange
+    repo = REPO_ROOT
+    # Act
+    allow, _ = load_allowlist(repo)
+    # Assert
+    assert "cla.yml" in allow, "the operator-approved cla.yml exception vanished"
+
+
+def test_the_cla_allowlist_entry_carries_a_real_reason() -> None:
+    # Arrange
+    repo = REPO_ROOT
+    # Act
+    _, allow_violations = load_allowlist(repo)
+    # Assert
+    assert allow_violations == []
+
+
+def test_the_cla_job_really_is_still_hosted() -> None:
+    # Arrange: the exception must be LOAD-BEARING, not decorative. If
+    # cla.yml ever stops being hosted, the entry is stale (SAC-CI004) and
+    # must be deleted rather than left lying around as a standing loophole.
+    cla = REPO_ROOT / ".github" / "workflows" / "cla.yml"
+    doc = yaml.safe_load(cla.read_text(encoding="utf-8"))
+    # Act
+    verdict = classify_runs_on(doc["jobs"]["CLAssistant"])
+    # Assert
+    assert verdict == HOSTED


### PR DESCRIPTION
## The gap

Operator directive (2026-07-14): **never use GitHub-hosted runners; make it an ERROR via linter/hook; mandatory, no exceptions.** If Spartan breaks, that is OUR problem — never escape back to a hosted runner.

PR #694 did the migration: 11 jobs onto the self-hosted pool, one left on `ubuntu-latest`. **It never built the guard.** So nothing stopped the next workflow from quietly landing on a hosted runner again, and we would not have noticed until it had.

## What the guard checks

`src/scitex_agent_container/_hosted_runner_guard.py` parses every `.github/workflows/*.y*ml` and reads each job's `runs-on:`. It is deliberately **not** a grep — all three failure modes are live in this repo today:

| | naive `grep ubuntu-latest` | this guard |
|---|---|---|
| `ubuntu-24.04` next week | misses it | caught (matches the image **family**: `ubuntu-*` / `macos-*` / `windows-*`) |
| our filenames + job `name:` fields still *say* `on-ubuntu-latest` | red-flags the 11 jobs we just migrated | ignores them — only `runs-on:` decides where a job runs |
| `${{ fromJSON(vars.CI_RUNS_ON \|\| '["self-hosted",...]') }}` | cannot read it | resolves it (and `${{ matrix.os }}` against the job's own matrix) |

The verdict is a **ternary — `SELF_HOSTED` / `HOSTED` / `UNRESOLVABLE`** — never a boolean. A boolean would have to collapse "I cannot tell" into a pole, and either choice is a bug: assume-hosted false-REDs a healthy job; assume-self-hosted turns `runs-on: ${{ vars.ANYTHING }}` into a silent bypass. `UNRESOLVABLE` fails under its own code, saying *"cannot prove"* rather than *"is hosted"*.

## The one exception — encoded, not remembered

`.github/hosted-runner-allowlist.yaml`, one entry: **cla.yml**.

The `reason:` field is **mandatory and machine-enforced**. An entry without a real argument fails the guard exactly like an un-allowlisted hosted runner (`SAC-CI003`). A **stale** entry fails too (`SAC-CI004`) — a dead exception is a live loophole that pre-approves whatever that file does next.

cla.yml stays hosted **on purpose**, and the argument now lives next to it: `issue_comment` + `pull_request_target` are **unauthenticated** triggers that any stranger fires by commenting on an issue; neither is covered by the fork-PR approval gate (`pull_request_target` is the documented way *around* it); the job runs a **third-party action**; and on Spartan `$HOME` is the operator's real home holding the fleet's **live credentials**. Migrating it would hand an unauthenticated stranger third-party code execution on the crown-jewel node — **strictly worse than the hole we closed**. (The action is SHA-pinned.)

That exception previously existed only in a chat message and a merged PR body. The next agent greps `ubuntu-latest`, finds cla.yml, reads it as an oversight, and "fixes" it. Now the mechanism carries the reason, so removing it is a deliberate act someone has to argue for.

**`cla.yml` is not modified by this PR.**

## Where it runs

- **CI job on the SELF-HOSTED pool** (`no-hosted-runners-guard-on-self-hosted.yml`) — a no-hosted-runners guard running on a hosted runner would be its own punchline;
- a **pre-commit hook**;
- **pytest**, including a test asserting *this* repo is clean.

## Tests — 38, proving BOTH directions

A guard you have only ever seen pass is a hope. We merged a "fail-loud" version gate this week that returned exit 0 on the exact broken artifact it existed to reject, because nobody ever ran it against a bad input. So this one is watched failing:

```
$ python -m scitex_agent_container._hosted_runner_guard .   # + a nightly job on ubuntu-24.04
========================================================================
NO-HOSTED-RUNNERS GUARD FAILED
========================================================================
1 violation(s):
  SAC-CI001  .github/workflows/nightly-bench-on-ubuntu.yml -> job `bench`
      runs on a GitHub-HOSTED runner (ubuntu-24.04). Move it to the self-hosted pool:
        runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
>>> EXIT=1
```

Strip the `reason:` from the allowlist and it fails too — **and the entry stops exempting cla.yml**:

```
  SAC-CI003  .github/hosted-runner-allowlist.yaml -> cla.yml
      allowlist entry needs a `reason:` of at least 40 characters ... (got 0 chars).
  SAC-CI001  .github/workflows/cla.yml -> job `CLAssistant`
>>> EXIT=1
```

Fail direction: every hosted image family, matrix fan-out to `ubuntu-latest`, a hosted default smuggled into `fromJSON`, an unresolvable `runs-on`, a reason-less/stub/stale allowlist entry, and a job-scoped entry that must not cover a *new* job.
Pass direction: the canonical self-hosted expression, `uses:`-only reusable calls, legacy `on-ubuntu-latest` filenames/job-names, and **the real repo** (11 migrated jobs + the one allowlisted exception).

## SSOT: why the rule is not in scitex-dev (yet)

The ecosystem home for a `.github/workflows` rule is scitex-dev's **project auditor** (it already parses workflows for PS-164/165/168) — *not* the linter SPI, which is Python-AST-only and cannot see YAML. Deferred out of this PR **on measured evidence**, not preference:

1. **Blast radius** — ~40 ecosystem repos are still *fully* hosted (`hosted == total`); sac is the only migrated one. An E-severity rule turns them all red at once.
2. **No opt-in** — sac installs `scitex-dev[cli-audit]` **unpinned**, so a published E rule lands on every consumer's next CI run with no version gate.
3. **It would not even fire in sac** — sac's CI runs only `scitex-dev quality audit-*`; it never invokes the PS-1xx auditor.

Carded as `scitex-dev-ps-rule-no-hosted-runners`: port at severity **W** (the established warn-first rollout, as PS-148/164/214 did), migrate the ecosystem, then promote to **E**.