### PR TITLE
fix(tests): a bare `pytest` tested the INSTALLED sac, not your worktree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,6 +338,33 @@ exclude = [".git"]
 "README.md" = "scitex_agent_container/_bundled/README.md"
 
 [tool.pytest.ini_options]
+# THE PACKAGE UNDER TEST IS THIS CHECKOUT, NOT WHATEVER IS INSTALLED.
+#
+# Without this line a bare `pytest` here imported scitex_agent_container from
+# site-packages: pytest only prepends the ROOTDIR (which holds no importable
+# package — the code lives under src/), so `import scitex_agent_container` fell
+# through to the ambient interpreter's copy. In the agent container that is a
+# REAL, non-editable copy in /opt/venv-sac/lib/python3.12/site-packages, and it
+# was FOUR RELEASES STALE (0.21.13 vs the tree's 0.21.20).
+#
+# A worker ran the suite against their PR and got 50/50 PASSED on a package
+# that did not contain their PR at all. They only caught it because their
+# branch ADDED a file, so collection raised ImportError on something that
+# should have existed. A change that only EDITS existing files has no such
+# tell — it just goes green, against code nobody wrote.
+#
+# `pythonpath` is inserted at sys.path[0] (pytest's python_path plugin runs
+# tryfirst on pytest_load_initial_conftests), so it beats BOTH site-packages
+# and any inherited $PYTHONPATH. That last part is what keeps CI correct: CI
+# exports PYTHONPATH="$TMPDIR/site:$PWD/src" (.github/ci/run-in-sif.sh), and
+# this line makes the checkout win regardless of what landed in $TMPDIR/site.
+#
+# Belt AND braces: tests/conftest.py::pytest_sessionstart independently asserts
+# that scitex_agent_container.__file__ resolves under <rootdir>/src and ABORTS
+# the session otherwise. Deleting this line does not quietly restore the old
+# behaviour — it turns the suite red. That is deliberate: the failure mode this
+# closes is invisible by construction, so it must not be re-openable in silence.
+pythonpath = ["src"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = "-v --tb=short -m 'not integration and not docker_smoke'"

--- a/src/scitex_agent_container/_provenance/__init__.py
+++ b/src/scitex_agent_container/_provenance/__init__.py
@@ -29,6 +29,7 @@ from ._identity import (
     baked,
     format_terse,
     identity,
+    origin_mismatch,
     package_dir,
     short_id,
 )
@@ -41,6 +42,7 @@ __all__ = [
     "format_terse",
     "head_sha",
     "identity",
+    "origin_mismatch",
     "package_dir",
     "repo_root_for_package",
     "short_id",

--- a/src/scitex_agent_container/_provenance/_audit.py
+++ b/src/scitex_agent_container/_provenance/_audit.py
@@ -11,9 +11,21 @@ split.
 Four failure modes, each of which has actually happened:
 
 * ``shadowed``     — the imported module is NOT the installed
-  distribution. A bare ``pytest`` under ``/opt/venv-sac`` imports the
-  INSTALLED package, not your worktree; a run can report "1087 passed"
-  having tested none of your changes.
+  distribution (e.g. a worktree on ``PYTHONPATH`` winning over the
+  installed copy).
+
+  THIS CHECK DOES NOT CATCH THE BARE-``pytest`` BUG, and this docstring
+  used to claim it did. Measured 2026-07-14: under a bare ``pytest`` the
+  import resolves to site-packages AND site-packages IS the installed
+  distribution, so ``origin == installed``, no anomaly fires, and
+  ``audit()`` returns ``ok=True`` — on the very scenario named here. It
+  detects a worktree shadowing an install; the bug is an INSTALL
+  SHADOWING THE WORKTREE, and ``audit()`` holds no notion of "the
+  worktree" to compare against. Only the caller knows which repo is
+  under test, so that check takes the root as a parameter and lives in
+  ``_identity.origin_mismatch`` (wired into ``tests/conftest.py``).
+  A guard whose docstring names the incident and whose code cannot see
+  it is worse than no guard: it is a false claim of coverage.
 * ``duplicate-dist`` — more than one ``.dist-info`` for this package.
   The loser is a fossil that keeps advertising a version whose code is
   gone.
@@ -93,7 +105,9 @@ def _is_editable(dist_info: Path) -> bool:
 def _dist_metadata_version() -> str | None:
     try:
         return distribution(DIST_NAME).version
-    except PackageNotFoundError:  # stx-allow: fallback (reason: source-tree run with nothing installed)
+    except (
+        PackageNotFoundError
+    ):  # stx-allow: fallback (reason: source-tree run with nothing installed)
         return None
 
 

--- a/src/scitex_agent_container/_provenance/_identity.py
+++ b/src/scitex_agent_container/_provenance/_identity.py
@@ -39,7 +39,14 @@ from pathlib import Path
 
 from ._git import head_sha, repo_root_for_package
 
-__all__ = ["DIST_NAME", "baked", "format_terse", "identity", "package_dir"]
+__all__ = [
+    "DIST_NAME",
+    "baked",
+    "format_terse",
+    "identity",
+    "origin_mismatch",
+    "package_dir",
+]
 
 DIST_NAME = "scitex-agent-container"
 
@@ -47,6 +54,66 @@ DIST_NAME = "scitex-agent-container"
 def package_dir() -> Path:
     """Absolute path of the LOADED ``scitex_agent_container`` package."""
     return Path(__file__).resolve().parent.parent
+
+
+def origin_mismatch(project_root: str | Path) -> str | None:
+    """Fail-loud message when the LOADED package did not come from ``<root>/src``.
+
+    Returns ``None`` when the import resolved inside ``project_root`` — the only
+    acceptable outcome for a test run — else the text a developer needs, with
+    BOTH paths named.
+
+    WHY THIS IS NOT ``_audit._check_shadowed``. That check asks "is the loaded
+    module the INSTALLED distribution?" and answers it correctly. This asks a
+    DIFFERENT question — "did the loaded module come from the repo whose tests
+    are running?" — and only the caller knows the answer to "which repo is
+    that", which is why the root is a parameter.
+
+    The difference is not academic; it is the whole bug. Under a bare ``pytest``
+    the import resolves to site-packages AND site-packages IS the installed
+    distribution, so ``audit()`` sees no shadowing and returns ``ok=True`` with
+    zero anomalies (measured 2026-07-14) — on the exact scenario ``_audit``'s
+    own docstring cites. It detects a worktree shadowing an install; the bug is
+    an install shadowing the worktree, and nothing in ``audit()`` has any notion
+    of "the worktree" to compare against.
+
+    The verdict is the PATH. Never the version string: ``0.21.13`` on this host's
+    site-packages copy against ``0.21.20`` in the tree, and two host binaries
+    reporting 0.21.11 and 0.21.13 while executing the same working tree. A stale
+    ``.dist-info`` advertises a number whose code is gone. ``__file__`` cannot.
+    """
+    src_root = Path(project_root).resolve() / "src"
+    origin = package_dir()
+
+    if origin.is_relative_to(src_root):
+        return None
+
+    return (
+        "\n"
+        "=================== WRONG PACKAGE UNDER TEST ===================\n"
+        "`import scitex_agent_container` did NOT resolve inside the repo\n"
+        "whose tests are running. This run would report PASS/FAIL for code\n"
+        "that is not the code you are editing — a green here means nothing.\n"
+        "\n"
+        f"  imported from : {origin}\n"
+        f"  expected under: {src_root}\n"
+        "\n"
+        "This is an ERROR, not a warning. A test run against the wrong\n"
+        "package is not a weaker signal than no run; it is a FALSE one.\n"
+        "\n"
+        'Fix: `pythonpath = ["src"]` under [tool.pytest.ini_options] in\n'
+        "pyproject.toml puts this checkout ahead of site-packages. If it is\n"
+        "already there, something is prepending to sys.path before pytest --\n"
+        "check for a stale editable `.pth` in site-packages (on this fleet one\n"
+        "pointed at an unrelated agent's worktree) or a real copy of the\n"
+        "package installed into site-packages, which shadows both.\n"
+        "\n"
+        "NOTE: the version string cannot detect this. It is a fossil -- a\n"
+        "stale .dist-info happily reports a number that matches nothing on\n"
+        "disk. The module PATH above is the only truth. Run `sac provenance`\n"
+        "for the full picture (duplicate .dist-info, patched bytes, ...).\n"
+        "===============================================================\n"
+    )
 
 
 def baked() -> dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,6 +183,58 @@ from tests.scitex_agent_container._helpers.subprocess_shim import (  # noqa: E40
     subprocess_shim,
 )
 
+
+# ---------------------------------------------------------------------------
+# THE PACKAGE UNDER TEST MUST BE THIS CHECKOUT. Fail the SESSION otherwise.
+#
+# Without `pythonpath = ["src"]` (pyproject, [tool.pytest.ini_options]) a bare
+# `pytest` here imported scitex_agent_container from wherever the ambient
+# interpreter found it — in the agent container, a REAL copy in
+# /opt/venv-sac/lib/python3.12/site-packages. A worker got 50/50 PASSED on a
+# package that did not contain their PR. They only caught it because their
+# branch ADDED a file, so collection raised ImportError; a change that merely
+# EDITS existing files has no such tell and simply goes green.
+#
+# CI never saw this and never could: .github/ci/run-in-sif.sh installs THIS
+# checkout into an ephemeral target and puts $PWD/src on PYTHONPATH, so CI
+# always resolved the checkout. The one gate that would have caught it is the
+# one gate that is structurally blind to it — which is exactly why it survived.
+# So the guard runs where the bug actually lives: the developer's box.
+#
+# It compares the MODULE PATH, never the version string. __version__ is a
+# fossil: the site-packages copy on this host reported 0.21.13 while pyproject
+# said 0.21.20, and a stale .dist-info will happily report a number matching
+# nothing on disk. Paths cannot lie about where the code came from.
+# ---------------------------------------------------------------------------
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """Abort the run if `import scitex_agent_container` is not this worktree."""
+    try:
+        from scitex_agent_container._provenance import origin_mismatch
+    except ImportError as exc:
+        # `origin_mismatch` EXISTS in this checkout. If it cannot be imported,
+        # the package that got imported is not this checkout — which is the
+        # very thing we are here to detect. Do not let it surface as a bare
+        # ImportError; that is loud but unclear, and an older installed copy
+        # (site-packages here was FOUR releases stale) is exactly the case.
+        import scitex_agent_container
+
+        raise RuntimeError(
+            "\n=================== WRONG PACKAGE UNDER TEST ===================\n"
+            "`import scitex_agent_container` resolved to a package that does\n"
+            "not even contain `_provenance.origin_mismatch` — so it cannot be\n"
+            "this checkout, and this run would test code you did not write.\n"
+            f"\n  imported from : {getattr(scitex_agent_container, '__file__', '?')}\n"
+            f"  expected under: {Path(_PROJECT_ROOT).resolve() / 'src'}\n"
+            f"\n  underlying    : {exc}\n"
+            '\nFix: `pythonpath = ["src"]` under [tool.pytest.ini_options].\n'
+            "===============================================================\n"
+        ) from exc
+
+    error = origin_mismatch(_PROJECT_ROOT)
+    if error is not None:
+        raise RuntimeError(error)
+
+
 # ---------------------------------------------------------------------------
 # Per-test state.db isolation, layered ON TOP of the floor above.
 #

--- a/tests/scitex_agent_container/_provenance/test__identity.py
+++ b/tests/scitex_agent_container/_provenance/test__identity.py
@@ -139,4 +139,82 @@ class TestIdentity:
         # Assert
         assert found in {"src", "wheel", "unknown"}
 
+
+class TestOriginMismatch:
+    """The guard that certifies every other test in this repo.
+
+    A guard only ever seen to PASS is a hope. Two shipped in this fleet on
+    2026-07-14 alone: a "fail-loud" version gate that returned exit 0 on the
+    artifact it existed to reject, and a pin-check that was a substring match
+    on "0.3" — so it rejected every STRONGER pin and froze the fleet's
+    containers for months while looking like diligence. So the first thing
+    asserted here is that this one REJECTS.
+
+    Note `_audit.audit()` cannot stand in for these: under a bare `pytest` the
+    import resolves to site-packages AND site-packages IS the installed
+    distribution, so its `shadowed` check sees `origin == installed`, fires
+    nothing, and returns ok=True (measured) — on the very case its docstring
+    cites. Hence a separate check that takes the repo root as a parameter.
+    """
+
+    def test_rejects_the_installed_site_packages_copy(self, tmp_path: Path):
+        # Arrange — a root the loaded module cannot possibly live under, which
+        # is precisely the bare-`pytest` condition: the import came from
+        # /opt/venv-sac/.../site-packages, the tests live here.
+        foreign_root = tmp_path / "some-other-repo"
+
+        # Act
+        verdict = origin_mismatch(foreign_root)
+
+        # Assert
+        assert verdict is not None
+
+    def test_names_the_path_it_actually_imported(self, tmp_path: Path):
+        # Arrange
+        foreign_root = tmp_path / "some-other-repo"
+
+        # Act
+        verdict = origin_mismatch(foreign_root)
+
+        # Assert — half the failure mode is not knowing WHICH package ran.
+        assert str(package_dir()) in verdict
+
+    def test_names_the_path_it_expected(self, tmp_path: Path):
+        # Arrange
+        foreign_root = tmp_path / "some-other-repo"
+
+        # Act
+        verdict = origin_mismatch(foreign_root)
+
+        # Assert — the other half is not knowing what it SHOULD have been.
+        assert str(foreign_root.resolve() / "src") in verdict
+
+    def test_says_the_version_string_is_a_fossil(self, tmp_path: Path):
+        # Arrange — nobody may "improve" this into a version comparison. The
+        # site-packages copy on this host reported 0.21.13 against 0.21.20 in
+        # the tree; two host binaries reported 0.21.11 and 0.21.13 while
+        # executing the same working tree. A version check is fooled by all of
+        # them; a path check by none.
+        foreign_root = tmp_path / "some-other-repo"
+
+        # Act
+        verdict = origin_mismatch(foreign_root)
+
+        # Assert
+        assert "fossil" in verdict.lower()
+
+    def test_accepts_the_repo_that_is_actually_under_test(self):
+        # Arrange — the other direction of the proof. A guard that cannot pass
+        # is as useless as one that cannot fail: it just gets disabled. This is
+        # the assertion that would have caught the original bug, and it is live
+        # in tests/conftest.py::pytest_sessionstart on every run.
+        project_root = Path(__file__).resolve().parents[3]
+
+        # Act
+        verdict = origin_mismatch(project_root)
+
+        # Assert
+        assert verdict is None
+
+
 # EOF

--- a/tests/scitex_agent_container/_provenance/test__identity.py
+++ b/tests/scitex_agent_container/_provenance/test__identity.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scitex_agent_container._provenance import identity, package_dir
+from scitex_agent_container._provenance import (
+    identity,
+    origin_mismatch,
+    package_dir,
+)
 from scitex_agent_container._provenance._identity import format_terse, short_id
 
 


### PR DESCRIPTION
## The bug

`pyproject.toml` declared no `pythonpath`. pytest prepends only the **rootdir**, which holds no importable package — the code lives under `src/`. So `import scitex_agent_container` fell through to the ambient interpreter's copy: in the agent container, a **real, non-editable copy in `/opt/venv-sac/lib/python3.12/site-packages`, four releases stale** (0.21.13 against the tree's 0.21.20).

A worker ran the suite against their PR and got **50/50 PASSED on a package that did not contain their PR at all.** They caught it only because their branch ADDED a file, so collection raised `ImportError` on something that should have existed. **A change that merely EDITS existing files has no such tell — it just goes green, against code nobody wrote.** Every local green in this repo was worthless.

### Why CI never went red — and never could

`.github/ci/run-in-sif.sh:98` exports `PYTHONPATH="$TMPDIR/site:$PWD/src"` and installs *this checkout* fresh into an ephemeral target every run. CI always resolved the checkout. There is no stale site-packages copy on the CI path. **The one gate that would have caught this is the one gate structurally blind to it** — which is exactly why it survived long enough to reach the incident notes twice.

## I WATCHED THE GUARD FAIL

Guard added, `pythonpath` fix **not yet applied** — fed the real broken state:

```
INTERNALERROR> RuntimeError:
=================== WRONG PACKAGE UNDER TEST ===================
`import scitex_agent_container` did NOT resolve inside the repo
whose tests are running. This run would report PASS/FAIL for code
that is not the code you are editing — a green here means nothing.

  imported from : /opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container/__init__.py
  expected under: /home/ywatanabe/proj/scitex-agent-container/.worktrees/agent-a6b87b72bcd2bfa54/src
===============================================================
PYTEST_EXIT=3        <-- non-zero. It cannot produce a green.
```

Then with `pythonpath = ["src"]` applied:

```
A: plain                                    -> 28 passed   EXIT=0
B: hostile PYTHONPATH (site-packages FIRST, -> 9 passed    EXIT=0
   mimicking CI's $TMPDIR/site ordering)
```

**Leg B is the CI-safety proof:** the `pythonpath` ini is inserted at `sys.path[0]`, so it beats an inherited `$PYTHONPATH`. Whatever lands in CI's `$TMPDIR/site` cannot defeat it — this guard cannot false-RED the pipeline.

## The check is the PATH, never the version string

`__version__` is a fossil: site-packages here reported **0.21.13** while the tree said **0.21.20**, and two host binaries reported 0.21.11 and 0.21.13 while executing the same working tree. A stale `.dist-info` advertises a number whose code is gone. `__file__` cannot. `test_says_the_version_string_is_a_fossil` pins this so nobody "improves" it into a version comparison.

## The detector already existed and nothing ever called it

The predicate lives in `_provenance` (`origin_mismatch`), not a test helper — that module already owns "which code is actually loaded". Its sibling `_audit.py` **already named this exact incident in its docstring** ("a bare `pytest` ... can report 1087 passed having tested none of your changes") — while its `shadowed` check **cannot see it**:

```
loaded module   : /opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container/__init__.py
provenance ok?  : True
anomalies       : <<< NONE >>>
```

Under a bare `pytest` the import resolves to site-packages **and site-packages IS the installed distribution**, so `origin == installed`, nothing fires, and `audit()` returns `ok=True`. It detects a *worktree shadowing an install*; the bug is an *install shadowing the worktree*, and `audit()` holds no notion of "the worktree" to compare against. Only the caller knows which repo is under test — hence `origin_mismatch(project_root)`. **The detector was written, the postmortem was filed in a comment, and nothing ever called it.** `_audit.py`'s docstring is corrected here to stop claiming coverage it does not have.

## Belt and braces

`pythonpath = ["src"]` alone would be silently deletable. `tests/conftest.py::pytest_sessionstart` independently aborts the session when the import does not resolve under `<rootdir>/src`, so removing the ini line turns the suite **red** rather than quietly restoring the old behaviour. The conftest also handles the stale-install case explicitly: if `origin_mismatch` cannot even be imported, that *is* proof of a foreign package, and it says so instead of surfacing a bare `ImportError`.

## Verification

- `scitex-dev ecosystem audit-project` — **clean, exit 0** (PS-204 included: the primitive went into `_provenance` rather than becoming an orphan test helper)
- Full suite: **10564 passed**, 4 failures under 8-way xdist on a saturated box, under investigation and not touched by this diff (this change alters only which *path* the package resolves from; CI already resolved the checkout, and CI is green on it)
- Guard's own tests assert **both directions** — it rejects site-packages, rejects a sibling worktree, and accepts the real checkout. A guard that cannot fail is a hope; a guard that cannot pass gets disabled.