### PR TITLE
fix(hooks): check-merge-conflict was INERT outside a merge — the guard I shipped an hour ago

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,10 +30,27 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-merge-conflict
+        # --assume-in-merge IS LOAD-BEARING. Without it this hook is INERT for
+        # the case anyone actually cares about. Its source (check_merge_conflict.py:37):
+        #
+        #     if not is_in_merge() and not args.assume_in_merge:
+        #         return 0
+        #
+        # i.e. OUTSIDE a merge state it returns 0 without looking at a single
+        # byte. Measured: staged a file containing `<<<<<<< HEAD` / `=======` /
+        # `>>>>>>>` and committed it. The hook ran, printed
+        # "check for merge conflicts....Passed", and THE COMMIT WENT THROUGH.
+        #
+        # A conflict marker pasted into a normal commit — the failure that
+        # actually happens — sails straight past the default config. (The
+        # git-template hook this replaces was equally blind: `git ls-files
+        # --unmerged` only populates during a merge. So this is not a regression
+        # against what we displaced; it is both of them being weaker than they
+        # read.) With the flag, the check runs on every staged file, always.
+        args: ["--assume-in-merge"]
         description: >
-          Conflict markers must never reach a commit. The displaced git-template
-          hook checked exactly this, so keeping it makes the hooksPath flip a
-          strict improvement rather than a trade.
+          Conflict markers must never reach a commit — in a merge OR outside one.
+          Verified by feeding it a marker-laden file and watching it BLOCK.
       - id: check-added-large-files
         args: ["--maxkb=10000"]
         description: >


### PR DESCRIPTION
## I armed the hooks, then attacked one. It failed.

Staged a file containing `<<<<<<< HEAD` / `=======` / `>>>>>>>` and committed it. The hook ran:

```
check for merge conflicts................................................Passed
check for added large files..............................................Passed
detect private key.......................................................Passed
[fix/git-hooks-actually-execute 8d9da382] probe: this commit MUST be blocked
 1 file changed, 6 insertions(+)
```

**Exit 0, and the commit went through** — on the exact input the hook exists to reject.

## Why

Its own source, `check_merge_conflict.py:37`:

```python
if not is_in_merge() and not args.assume_in_merge:
    return 0
```

Outside a merge state it **returns 0 without reading a byte.** A conflict marker pasted into an ordinary commit — the failure that actually happens to people — sails straight past the default config.

## The fix, and the same probe again

`args: ["--assume-in-merge"]` makes it check every staged file, always:

```
- hook id: check-merge-conflict
- exit code: 1

hook_probe.py:2: Merge conflict string '<<<<<<<' found
hook_probe.py:4: Merge conflict string '=======' found
hook_probe.py:6: Merge conflict string '>>>>>>>' found
```

...and **no commit is created.** Same input, same hook: exit 0 before, exit 1 after.

## Not a regression against what it displaced

The git-template hook this replaced was **equally blind** — `git ls-files --unmerged` also only populates during a merge. #699's claim that keeping this hook made the `hooksPath` flip "a strict improvement, not a trade" was *true*, and also beside the point: both were weaker than they read. This makes the check do what its name promises.

## Why this PR exists at all

This is the day's lesson landing on my own commit, one hour after I wrote it into three PR bodies:

> **A GUARD YOU HAVE ONLY EVER SEEN PASS IS A HOPE.**

I only caught it because I armed the hook and then deliberately fed it the bad input. Had I stopped at *"pre-commit ran, all hooks green"* — which is exactly what a reasonable person does — this would have shipped as coverage and enforced nothing, joining the version gate that returns 0 on the artifact it rejects and the pin-check that was a substring match on `"0.3"`.

The hooks are now armed on this box (`core.hooksPath = .githooks`), so this PR's own commit was gated by them.