### PR TITLE
chore(release): v0.21.21 — and unbreak the SIF build, dead since #652

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,62 @@ versioning follows [SemVer](https://semver.org/).
   decided it should use this same guarded one-way channel rather than growing a
   second path to the same hosts.
 
+## [0.21.21] - 2026-07-15
+
+The release exists to carry **#696** to the machines. Everything else here is
+what had to be true for it to actually arrive.
+
+### Fixed
+
+- **`sac image build` has been dead since #652, and the SIF is how sac reaches the
+  fleet.** #652 added a custom hatchling build hook (`[tool.hatch.build.targets.*
+  .hooks.custom] path = "src/hatch_build.py"`). `stage_build_context()` copies
+  pyproject.toml, README.md and the package — but nothing taught it about the new
+  file, and the wheel never bundled it either. hatchling resolves a hook path
+  against *the tree being built*, and in a SIF build that tree is the staged one,
+  so every `sac image build` died ~8 minutes into `%post`, inside apptainer, on a
+  machine nobody was watching:
+
+      OSError: Build script does not exist: src/hatch_build.py
+
+  Staging now copies **every path pyproject NAMES**, and the wheel force-includes
+  the hook into the inert `_bundled/` data dir (no `__init__.py` — bundled is not
+  packaged, so hatch_build.py's own rule that an `import hatchling` module never
+  reaches the runtime path still holds).
+
+  The reason no test caught it is worth more than the fix: every staging test ran
+  against a fixture whose pyproject **declared nothing**. A fixture that declares
+  nothing cannot disagree with a stager that copies nothing — the suite was green
+  and blind at the same time. The new guard stages the **real** package root and
+  asserts the general invariant, derived from the staged pyproject rather than
+  hardcoded: *every path pyproject declares must exist in the staged tree.* It
+  fails for the next forgotten file too, not just this one. A second test pins that
+  the pyproject actually declares a hook, so the guard can never pass vacuously.
+
+### Changed
+
+- `pythonpath = [".", "src"]` — the rootdir joins the test import path, so
+  rootdir-relative imports (`tests.*`) resolve identically from any cwd. #698's
+  `pytest_sessionstart` guard was re-verified in both directions afterwards: it
+  still aborts when `scitex_agent_container` resolves outside `<rootdir>/src`.
+
+### Shipped from develop (already merged, released here)
+
+- **#696 — `may_destroy`'s two witnesses were the same syscall.** Read from inside a
+  container — which is where every fleet agent runs — the shipped v0.21.20 reported
+  every healthy peer as DEAD with `may_destroy=True`. Its two "independent"
+  witnesses were the same `os.kill(pid, 0)` on the same pid, an identity the module
+  documented in its own docstring. `Signal` now carries a closed-set `instrument`,
+  `may_destroy` dedupes by instrument, and a cross-namespace pid read is UNKNOWN,
+  not DEAD. A false-RED is worse than a false-green here: its remedy destroys a
+  healthy agent.
+- **#698** — a bare `pytest` tested the INSTALLED sac, not the worktree.
+- **#699** — the git hooks were advertised and enforced by nothing; they run now.
+- **#700** — `check-merge-conflict` was INERT outside a merge (exit 0 without
+  reading a byte).
+- **#694 / #697** — the last 9 workflows off GitHub-hosted runners, plus the guard
+  that keeps them off.
+
 ## [0.21.20] - 2026-07-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.20"
+version = "0.21.21"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"
@@ -336,6 +336,18 @@ exclude = [".git"]
 # (with a fallback to the editable-install repo root).
 "pyproject.toml" = "scitex_agent_container/_bundled/pyproject.toml"
 "README.md" = "scitex_agent_container/_bundled/README.md"
+# ...and hatch_build.py, for the same reason and no other. The bundled
+# pyproject above DECLARES this file
+# (``[tool.hatch.build.targets.*.hooks.custom] path = "src/hatch_build.py"``)
+# and hatchling resolves that path against the tree being built — which,
+# in a SIF build, is the STAGED tree. Ship the pyproject without the hook
+# it names and every `sac image build` dies in %post before reading a line
+# of source: ``OSError: Build script does not exist: src/hatch_build.py``.
+# It lands in the inert ``_bundled/`` data dir (no ``__init__.py``), so it
+# is still NOT importable as ``scitex_agent_container.*`` — hatch_build.py's
+# own rule (never put an ``import hatchling`` module on the runtime path)
+# holds. Bundled ≠ packaged.
+"src/hatch_build.py" = "scitex_agent_container/_bundled/hatch_build.py"
 
 [tool.pytest.ini_options]
 # THE PACKAGE UNDER TEST IS THIS CHECKOUT, NOT WHATEVER IS INSTALLED.
@@ -364,7 +376,10 @@ exclude = [".git"]
 # the session otherwise. Deleting this line does not quietly restore the old
 # behaviour — it turns the suite red. That is deliberate: the failure mode this
 # closes is invisible by construction, so it must not be re-openable in silence.
-pythonpath = ["src"]
+#
+# "." is the rootdir, so rootdir-relative imports (`tests.*`) resolve the same
+# way from any cwd.
+pythonpath = [".", "src"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = "-v --tb=short -m 'not integration and not docker_smoke'"

--- a/src/scitex_agent_container/cli_pkg/_image_source_build.py
+++ b/src/scitex_agent_container/cli_pkg/_image_source_build.py
@@ -86,7 +86,9 @@ _COPY_IGNORE = shutil.ignore_patterns(
 _STAGED_SRC_NAME = "scitex-agent-container-src"
 
 
-def _locate_bundled_sibling(pkg_root: Path, name: str) -> Path:
+def _locate_bundled_sibling(
+    pkg_root: Path, name: str, *, editable_rel: str | None = None
+) -> Path:
     """Return the path to a wheel-bundled or repo-root file by name.
 
     Resolution order — both supported because sac is installed BOTH
@@ -95,10 +97,16 @@ def _locate_bundled_sibling(pkg_root: Path, name: str) -> Path:
       1. ``pkg_root/_bundled/<name>`` — wheel install. The wheel
          ships the file via ``[tool.hatch.build.targets.wheel.
          force-include]`` in the repo's own pyproject.toml.
-      2. ``pkg_root.parent.parent/<name>`` — editable install
-         (``pip install -e .``). The package is at
+      2. ``pkg_root.parent.parent/<editable_rel or name>`` — editable
+         install (``pip install -e .``). The package is at
          ``<repo>/src/scitex_agent_container/``; ``parent.parent``
          walks up through ``src/`` to the repo root.
+
+    ``editable_rel`` exists because a file's slot in the wheel's FLAT
+    ``_bundled/`` dir need not mirror its path in the repo:
+    ``hatch_build.py`` bundles to ``_bundled/hatch_build.py`` but lives
+    at ``<repo>/src/hatch_build.py``. Defaults to ``name`` (the
+    repo-root case: pyproject.toml, README.md).
 
     Raises
     ------
@@ -110,7 +118,7 @@ def _locate_bundled_sibling(pkg_root: Path, name: str) -> Path:
     bundled = pkg_root / "_bundled" / name
     if bundled.is_file():
         return bundled
-    editable_repo = pkg_root.parent.parent / name
+    editable_repo = pkg_root.parent.parent / (editable_rel or name)
     if editable_repo.is_file():
         return editable_repo
     raise FileNotFoundError(
@@ -140,6 +148,32 @@ def locate_bundled_readme(pkg_root: Path) -> Path:
     return _locate_bundled_sibling(pkg_root, "README.md")
 
 
+def locate_bundled_hatch_build(pkg_root: Path) -> Path:
+    """Return the custom hatchling BUILD HOOK pyproject.toml declares.
+
+    pyproject wires ``[tool.hatch.build.targets.*.hooks.custom] path =
+    "src/hatch_build.py"``, and hatchling resolves that path RELATIVE TO
+    THE TREE BEING BUILT. The staged tree IS that tree (the .def runs
+    ``uv pip install /opt/scitex-agent-container-src``), so the hook must
+    be staged next to pyproject.toml or the backend dies before reading
+    one line of source: ``OSError: Build script does not exist:
+    src/hatch_build.py``. Not hypothetical — that is how EVERY SIF build
+    failed from the moment the hook landed.
+
+    The hook is a BUILD input (same category as pyproject.toml/README.md),
+    not a runtime module, so the wheel carries it in the inert
+    ``_bundled/`` data dir — no ``__init__.py``, never importable as
+    ``scitex_agent_container.*`` — which keeps hatch_build.py's own rule
+    that an ``import hatchling`` module never reaches the runtime path.
+
+    Editable fallback is ``<repo>/src/hatch_build.py``, not the repo
+    root — hence ``editable_rel``. See :func:`_locate_bundled_sibling`.
+    """
+    return _locate_bundled_sibling(
+        pkg_root, "hatch_build.py", editable_rel="src/hatch_build.py"
+    )
+
+
 def stage_build_context(
     pkg_root: Path,
     def_path: Path,
@@ -157,6 +191,7 @@ def stage_build_context(
             scitex-agent-container-src/        # pip-installable source tree
                 pyproject.toml                 # from locate_bundled_pyproject
                 src/
+                    hatch_build.py             # pyproject's hooks.custom path
                     scitex_agent_container/    # copy of pkg_root contents
 
     The ``src/scitex_agent_container/`` layout matches what
@@ -213,11 +248,12 @@ def stage_build_context(
     if not pkg_root.is_dir():
         raise NotADirectoryError(f"package source is not a directory: {pkg_root}")
 
-    # Resolve pyproject.toml + README.md + (when set) bootstrap_sif
-    # BEFORE wiping dest_dir so a missing-file failure doesn't strand
-    # the operator with a half-staged tree.
+    # Resolve pyproject.toml + README.md + hatch_build.py + (when set)
+    # bootstrap_sif BEFORE wiping dest_dir so a missing-file failure
+    # doesn't strand the operator with a half-staged tree.
     pyproject_src = locate_bundled_pyproject(pkg_root)
     readme_src = locate_bundled_readme(pkg_root)
+    hatch_build_src = locate_bundled_hatch_build(pkg_root)
     if bootstrap_sif is not None and not bootstrap_sif.is_file():
         raise FileNotFoundError(
             f"bootstrap SIF not found: {bootstrap_sif} — build the prerequisite "
@@ -248,14 +284,20 @@ def stage_build_context(
 
     # The staged pip-installable source tree:
     #   <staged_src>/pyproject.toml
-    #   <staged_src>/README.md           (referenced by pyproject's readme=)
+    #   <staged_src>/README.md           (pyproject's readme=)
+    #   <staged_src>/src/hatch_build.py  (pyproject's hooks.custom path)
     #   <staged_src>/src/scitex_agent_container/...
+    #
+    # EVERY path pyproject NAMES must be staged, not just the package:
+    # the PEP-517 backend reads pyproject FIRST and resolves its declared
+    # paths against the staged root.
     staged_src = dest_dir / _STAGED_SRC_NAME
     staged_src.mkdir()
     shutil.copy2(pyproject_src, staged_src / "pyproject.toml")
     shutil.copy2(readme_src, staged_src / "README.md")
     pkg_dest = staged_src / "src" / "scitex_agent_container"
     pkg_dest.parent.mkdir(parents=True)
+    shutil.copy2(hatch_build_src, staged_src / "src" / "hatch_build.py")
     shutil.copytree(pkg_root, pkg_dest, ignore=_COPY_IGNORE)
 
     return staged_def
@@ -458,6 +500,7 @@ def resolve_bootstrap_sif(layer: str, output_dir: Path) -> Path | None:
 __all__ = [
     "stage_build_context",
     "build_layer_from_source",
+    "locate_bundled_hatch_build",
     "resolve_bootstrap_sif",
     "BootstrapSifMissing",
     "_default_container_build",

--- a/tests/scitex_agent_container/cli_pkg/test__image_source_build.py
+++ b/tests/scitex_agent_container/cli_pkg/test__image_source_build.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from typing import Iterator
 
 import pytest
+import tomllib
 
 import scitex_agent_container
 from scitex_agent_container.cli_pkg import _image_source_build as isb
@@ -72,8 +73,14 @@ def fake_pkg_root(tmp_path: Path) -> Path:
     bundled.mkdir()
     (bundled / "pyproject.toml").write_text(
         "[project]\nname = 'scitex-agent-container'\nversion = '0.0.0-test'\n"
+        '\n[tool.hatch.build.targets.wheel.hooks.custom]\npath = "src/hatch_build.py"\n'
     )
     (bundled / "README.md").write_text("# fake readme for tests\n")
+    # The wheel force-includes the custom build hook too — pyproject
+    # NAMES it, so a staged tree without it cannot be built at all.
+    # The fixture must mirror the real wheel, or the suite is testing a
+    # layout that does not ship.
+    (bundled / "hatch_build.py").write_text("# fake build hook for tests\n")
     return root
 
 
@@ -204,6 +211,93 @@ def test_locate_bundled_readme_falls_back_to_editable_repo_root(tmp_path):
     found = isb.locate_bundled_readme(pkg)
     # Assert
     assert found == repo_readme
+
+
+def test_locate_bundled_hatch_build_falls_back_to_editable_src_dir(tmp_path):
+    # Arrange — editable layout. hatch_build.py lives at <repo>/src/,
+    # NOT the repo root: it is the one bundled sibling whose repo path
+    # differs from its slot in the wheel's flat _bundled/ dir.
+    repo = tmp_path / "repo"
+    pkg = repo / "src" / "scitex_agent_container"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("\n")
+    hook = repo / "src" / "hatch_build.py"
+    hook.write_text("# editable repo build hook\n")
+    # Act
+    found = isb.locate_bundled_hatch_build(pkg)
+    # Assert
+    assert found == hook
+
+
+def test_locate_bundled_hatch_build_raises_when_neither_location_exists(tmp_path):
+    # Arrange — no _bundled/hatch_build.py and no <repo>/src/hatch_build.py
+    pkg = tmp_path / "orphan-pkg" / "scitex_agent_container"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("\n")
+
+    # Act
+    def _call():
+        return isb.locate_bundled_hatch_build(pkg)
+
+    # Assert
+    with pytest.raises(FileNotFoundError, match=r"could not locate hatch_build\.py"):
+        _call()
+
+
+def test_stage_build_context_stages_hatch_build_hook_under_src(
+    tmp_path, fake_pkg_root, fake_def
+):
+    # Arrange — pyproject declares hooks.custom path = "src/hatch_build.py",
+    # a path hatchling resolves against the STAGED root.
+    dest = tmp_path / "staging"
+    # Act
+    isb.stage_build_context(fake_pkg_root, fake_def, dest)
+    # Assert — the hook is staged at exactly the path pyproject names,
+    # beside (not inside) the package dir.
+    staged_hook = dest / "scitex-agent-container-src" / "src" / "hatch_build.py"
+    bundled = fake_pkg_root / "_bundled" / "hatch_build.py"
+    assert staged_hook.is_file() and staged_hook.read_text() == bundled.read_text()
+
+
+def test_stage_build_context_missing_hatch_build_raises(
+    tmp_path, fake_pkg_root, fake_def
+):
+    # Arrange — a wheel-shaped pkg root whose _bundled/ has pyproject +
+    # README but NOT the build hook. That is precisely the layout every
+    # sac wheel shipped before this fix, and it must now fail LOUD at
+    # staging rather than silently producing a tree the container's
+    # `uv pip install` dies on 8 minutes into %post.
+    (fake_pkg_root / "_bundled" / "hatch_build.py").unlink()
+    dest = tmp_path / "staging"
+
+    # Act
+    def _call():
+        return isb.stage_build_context(fake_pkg_root, fake_def, dest)
+
+    # Assert
+    with pytest.raises(FileNotFoundError, match=r"could not locate hatch_build\.py"):
+        _call()
+
+
+def test_stage_build_context_does_not_wipe_dest_when_hatch_build_missing(
+    tmp_path, fake_pkg_root, fake_def
+):
+    # Arrange — the hook is resolved BEFORE dest_dir is wiped, so a
+    # missing hook must not strand the operator with a half-staged tree.
+    (fake_pkg_root / "_bundled" / "hatch_build.py").unlink()
+    dest = tmp_path / "staging"
+    dest.mkdir()
+    sentinel = dest / "preexisting.txt"
+    sentinel.write_text("must not be wiped\n")
+
+    # Act
+    try:
+        isb.stage_build_context(fake_pkg_root, fake_def, dest)
+    except FileNotFoundError:
+        pass
+
+    # Assert
+    assert sentinel.read_text() == "must not be wiped\n"
 
 
 def test_locate_bundled_pyproject_raises_when_neither_location_exists(tmp_path):
@@ -860,6 +954,95 @@ _skip_no_pip = pytest.mark.skipif(
 )
 
 
+# ---------------------------------------------------------------------------
+# Staged-tree completeness — THE GUARD THAT WAS MISSING.
+#
+# Every staging test above runs against ``fake_pkg_root``, whose fake
+# pyproject.toml declares nothing. So when #652 added a custom hatchling
+# build hook to the REAL pyproject and nobody taught the stager to copy
+# it, the whole suite stayed green while EVERY `sac image build` died in
+# %post — 8 minutes in, on a machine nobody was watching:
+#
+#     OSError: Build script does not exist: src/hatch_build.py
+#
+# A fixture that declares nothing cannot disagree with a stager that
+# copies nothing. So this test stages the REAL package root and asserts
+# the general invariant, derived FROM the staged pyproject rather than
+# hardcoded: every path pyproject NAMES must EXIST in the staged tree.
+# It fails on any future pyproject that names a file staging forgets —
+# not just on hatch_build.py.
+# ---------------------------------------------------------------------------
+
+
+def _declared_hook_paths(pyproject_path: Path) -> list[str]:
+    """Every ``hooks.*.path`` the pyproject declares, across all targets.
+
+    hatchling resolves each of these RELATIVE TO THE TREE BEING BUILT,
+    which for a SIF build is the staged tree — so each one is a file the
+    stager owes the build.
+    """
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    targets = data.get("tool", {}).get("hatch", {}).get("build", {}).get("targets", {})
+    paths: list[str] = []
+    for target in targets.values():
+        for hook in (target.get("hooks") or {}).values():
+            path = (hook or {}).get("path")
+            if path:
+                paths.append(path)
+    return paths
+
+
+@pytest.fixture(scope="module")
+def real_staged_src(tmp_path_factory) -> Path:
+    """Stage the REAL package root + a REAL shipped .def, once.
+
+    Exactly what ``sac image build`` stages before it hands the tree to
+    apptainer — no fakes, so the staged pyproject is the one that ships.
+    """
+    dest = tmp_path_factory.mktemp("real-build-context") / "build-context"
+    isb.stage_build_context(_PKG_PATH.parent, _RECIPES_DIR / "apptainer-base.def", dest)
+    return dest / isb._STAGED_SRC_NAME
+
+
+@_skip_no_repo
+def test_real_staged_pyproject_declares_at_least_one_build_hook(real_staged_src: Path):
+    # Arrange — if the real pyproject declared no hooks, the completeness
+    # test below would pass VACUOUSLY. Pin that it cannot.
+    pyproject = real_staged_src / "pyproject.toml"
+    # Act
+    declared = _declared_hook_paths(pyproject)
+    # Assert
+    assert declared, (
+        "the staged pyproject declares no hatchling build hooks at all, so "
+        "the staged-tree completeness guard would pass vacuously. Either "
+        "staging copied the wrong pyproject, or the hook was removed — in "
+        "which case delete the guard deliberately rather than let it rot "
+        "into a test that can never fail."
+    )
+
+
+@_skip_no_repo
+def test_staged_tree_contains_every_path_the_real_pyproject_declares(
+    real_staged_src: Path,
+):
+    # Arrange — every path the STAGED pyproject names. Derived, not
+    # hardcoded: this fails for any future pyproject that names a file
+    # staging forgets, not just for hatch_build.py.
+    declared = _declared_hook_paths(real_staged_src / "pyproject.toml")
+    # Act — check each against the STAGED tree
+    missing = [p for p in declared if not (real_staged_src / p).is_file()]
+    # Assert
+    assert missing == [], (
+        f"the staged source tree is missing {missing}, which the staged "
+        f"pyproject.toml NAMES as a hatchling build-hook path. hatchling "
+        f"resolves those against the tree being built, so the .def's "
+        f"`uv pip install /opt/scitex-agent-container-src` dies in %post "
+        f"with 'Build script does not exist: {missing[0] if missing else ''}' "
+        f"— minutes into a SIF build nobody is watching. Stage every file "
+        f"pyproject names, not just the package."
+    )
+
+
 def _build_wheel(out_dir: Path) -> Path:
     """Build the wheel + return the .whl path. ``pip wheel --no-deps``.
 
@@ -895,6 +1078,44 @@ def _build_wheel(out_dir: Path) -> Path:
 def built_wheel(tmp_path_factory) -> Path:
     out_dir = tmp_path_factory.mktemp("wheel-out")
     return _build_wheel(out_dir)
+
+
+@_skip_no_repo
+@_skip_no_pip
+def test_wheel_ships_bundled_hatch_build_py(built_wheel: Path):
+    # Arrange — the bundled pyproject NAMES src/hatch_build.py as a build
+    # hook, so the wheel must carry the hook too or a wheel-installed sac
+    # stages a pyproject whose hook it does not have. That is the FLEET
+    # case: agents run sac from a wheel, not a checkout.
+    expected = "scitex_agent_container/_bundled/hatch_build.py"
+    # Act
+    with zipfile.ZipFile(built_wheel) as zf:
+        names = set(zf.namelist())
+    # Assert
+    assert expected in names, (
+        f"wheel must ship hatch_build.py under {expected} (force-include in "
+        "pyproject.toml). Ship the bundled pyproject without the hook it "
+        "declares and every `sac image build` from a wheel-installed sac "
+        "dies in %post: 'Build script does not exist: src/hatch_build.py'."
+    )
+
+
+@_skip_no_repo
+@_skip_no_pip
+def test_wheel_does_not_ship_hatch_build_as_importable_module(built_wheel: Path):
+    # Arrange — hatch_build.py imports hatchling at top level, so it must
+    # never land on the RUNTIME import path. _bundled/ is inert data (no
+    # __init__.py); scitex_agent_container/hatch_build.py would not be.
+    forbidden = "scitex_agent_container/hatch_build.py"
+    # Act
+    with zipfile.ZipFile(built_wheel) as zf:
+        names = set(zf.namelist())
+    # Assert
+    assert forbidden not in names, (
+        f"{forbidden} must not ship: it imports hatchling at module level "
+        "and the build frontend does not exist at runtime. Bundle it as "
+        "inert data under _bundled/ instead. Bundled != packaged."
+    )
 
 
 @_skip_no_repo


### PR DESCRIPTION
## Why

v0.21.21 exists to carry **#696** to the machines.

Read from **inside a container** — which is where every fleet agent runs — the shipped v0.21.20 reports **every healthy peer as DEAD with `may_destroy=True`**, because `may_destroy`'s two "independent" witnesses were the same `os.kill(pid, 0)` on the same pid. The fleet is running that build right now. A false-RED is worse than a false-green: its remedy destroys a healthy agent.

## It could not get there: `sac image build` has been dead since #652

#652 added a custom hatchling build hook:

```toml
[tool.hatch.build.targets.wheel.hooks.custom]
path = "src/hatch_build.py"
```

hatchling resolves that path against **the tree being built**. In a SIF build that tree is the **staged** one — and `stage_build_context()` copies pyproject.toml, README.md and the package, but nothing taught it about the new file. The wheel never bundled it either. So every `sac image build` died ~8 minutes into `%post`, inside apptainer, on a machine nobody was watching:

```
OSError: Build script does not exist: src/hatch_build.py
```

That is what actually killed the 2026-07-14 rebake (card `sac-rebake-scitex-todo-0134`) — not scitex-todo pinning, which is what the log looked like.

**Reproduced without apptainer** — stage the real package root, drive the real PEP-517 backend on the result:

```
 staged pyproject DECLARES hook 'src/hatch_build.py' : True
 staged tree CONTAINS src/hatch_build.py            : False
 OSError: Build script does not exist: src/hatch_build.py
 VERDICT: BUILD FAILED
```

## Fixed

- `stage_build_context()` stages **every path pyproject NAMES**, not just the package.
- The wheel force-includes the hook into the inert `_bundled/` data dir. No `__init__.py` there, so it is still **not** importable as `scitex_agent_container.*` — hatch_build.py's own rule (an `import hatchling` module never reaches the runtime path) still holds. **Bundled is not packaged**, and a test pins that.
- `locate_bundled_hatch_build()` + an `editable_rel` seam: this is the one bundled sibling whose repo path (`<repo>/src/hatch_build.py`) differs from its slot in the wheel's flat `_bundled/` dir.

## Why no test caught it — worth more than the fix

Every staging test ran against a fixture whose pyproject **declared nothing**. A fixture that declares nothing cannot disagree with a stager that copies nothing: the suite was green and blind at the same time.

So the new guard stages the **real** package root and asserts the invariant **derived from the staged pyproject rather than hardcoded** — *every path pyproject declares must exist in the staged tree*. It fails for the next forgotten file too, not just this one. A companion test pins that the pyproject actually declares a hook, so the guard **cannot pass vacuously**.

## Both guards were fed bad input and watched to FAIL before being trusted

| guard | input | result |
|---|---|---|
| new staged-tree guard | pre-fix stager | **FAILED** — `missing ['src/hatch_build.py']` |
| new staged-tree guard | post-fix stager | passed |
| #698 `pytest_sessionstart` | `src` off pythonpath | **ABORTED** — named `/opt/venv-sac/.../site-packages` as the wrong package |
| #698 `pytest_sessionstart` | normal | passed |

`56 passed` on the file after the fix.

## Also

`pythonpath = [".", "src"]` (operator request) so rootdir-relative imports (`tests.*`) resolve identically from any cwd. Measured before adding: the repo root holds **zero** `*.py` files, so nothing shadows the stdlib from `sys.path[0]`; the only root package is `tests/`.

## Separate finding, filed for the record

**PyPI has no 0.21.18 and no 0.21.19** — version-specific endpoints return HTTP 404, while 0.21.17 and 0.21.20 return 200. Two more ghost tags. This PR does not fix that; it is reported so it is not discovered a third time.
