### PR TITLE
chore(containers): pin scitex-todo==0.13.5 in base + scitex defs

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -361,20 +361,28 @@ From: ubuntu:24.04
     # pyyaml, ruamel-yaml) are already SAC-transitive via the runner
     # plumbing, so the [mcp] extra adds just fastmcp.
     #
-    # scitex-todo floor >=0.9.4 (was >=0.3.0) — incident-fleet-drift-
-    # stale-scitex-todo (2026-07-12). THIS layer is the one that matters:
-    # most agent specs boot sac-base.sif directly, and the :scitex layer
-    # INHERITS this venv, so whatever scitex-todo lands here is what the
-    # whole fleet runs. The ancient >=0.3.0 floor did not FORCE anything
-    # — it just took whatever was newest on the bake day (0.7.50 on
-    # 2026-07-10) and then froze it into every downstream layer. The
-    # floor now names the capability the fleet actually depends on: the
-    # WIP-gate fix (scitex-todo #356, first released in 0.8.0 — the gate
-    # counts `in_progress` ONLY). Below it, every agent's WIP gate counts
-    # DEFERRED + CANCELLED cards as open and refuses legitimate card
-    # creation. Keep this floor at-or-above the version whose symbol the
-    # section-6c gate below asserts; the gate is what makes a violation
-    # LOUD instead of silent.
+    # scitex-todo PINNED ==0.13.5 (was a >=0.9.4 floor). Two incidents
+    # settle this on an EXACT pin, not a floor. THIS layer is the one that
+    # matters: most agent specs boot sac-base.sif directly, and the :scitex
+    # layer INHERITS this venv, so whatever scitex-todo lands here is what
+    # the whole fleet runs.
+    #  - A floor (>=) never FORCES a version: it takes whatever is newest-
+    #    satisfying on bake day and freezes it downstream. That silently
+    #    shipped 0.7.50 for days (incident-fleet-drift-stale-scitex-todo,
+    #    2026-07-12) — and a bake once 0.13.4 was latest would have auto-
+    #    pulled a version whose per-write store rewrite costs ~171s vs
+    #    ~4.5s on 0.13.5, making the board unusable the moment it landed.
+    #  - The exact pin makes the baked version DETERMINISTIC and bumps
+    #    DELIBERATE (measure, then raise the pin), not automatic-and-hopeful
+    #    — the reproducible-pinned-PyPI rule, applied to the one package the
+    #    whole fleet's task board runs on.
+    #  - 0.13.5 is the MEASURED-good version (scitex-todo owner, 2026-07-15:
+    #    0.9.4=46s / 0.13.4=171s / 0.13.5=4.5s per card write, store
+    #    preserved). It still carries the #356 WIP-gate fix (>=0.8.0); the
+    #    section-6c gate below asserts that capability BY SYMBOL, so a pin
+    #    to a version that dropped it dies LOUD at bake, not silent. To bump:
+    #    raise this pin AND apptainer-scitex.def's, rebake, time one card
+    #    write, confirm it is fast, THEN ship.
     # sac's [openai] extra (openai-agents — the `spec.provider: openai`
     # agent-SDK family, openai-compat-3) is baked UNCONDITIONALLY: one
     # image serves EVERY agent, so a per-spec conditional install is
@@ -386,7 +394,7 @@ From: ubuntu:24.04
     # path resolves it through the bundled tree's own metadata.
     uv pip install --python /opt/venv-sac/bin/python \
         "claude-agent-sdk" \
-        "scitex-todo[mcp]>=0.9.4" \
+        "scitex-todo[mcp]==0.13.5" \
         "/opt/scitex-agent-container-src[openai]"
 
     # ---- 6c. FAIL-LOUD staleness gate — assert BY SYMBOL --------------

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -163,41 +163,37 @@ From: ./sac-base.sif
         #   scitex-audio >=0.3.0  — ffmpeg/portaudio provider
         #   scitex-cv    >=0.2.0  — opencv-python-headless; provider declares []
         #
-        # scitex-todo — ``--upgrade-package`` (-P), NOT a bare floor. THIS IS
-        # THE FLEET-DRIFT FIX (incident-fleet-drift-stale-scitex-todo,
-        # 2026-07-12), and the flag is load-bearing:
+        # scitex-todo — PINNED ==0.13.5 (was ``-P scitex-todo`` + a >=0.9.4
+        # floor). Base pins the SAME exact version, and this layer inherits
+        # base's /opt/venv-sac, so an exact ``==`` that base already satisfies
+        # is a correct no-op — there is nothing to re-resolve and no drift to
+        # fix, which is why the ``--upgrade-package scitex-todo`` flag that
+        # used to force re-resolution is GONE.
         #
-        #   scitex-todo is installed at the :base layer, and this layer
-        #   INHERITS base's /opt/venv-sac. A ``>=`` floor that the inherited
-        #   version ALREADY SATISFIES is a NO-OP — uv audits it and moves on.
-        #   So the :scitex layer could NEVER carry a newer scitex-todo than
-        #   :base, no matter how often it was rebuilt. Proof: sac-scitex.sif
-        #   was baked 2026-07-11 21:14, four hours AFTER scitex-todo 0.8.4
-        #   published (20:27), and still shipped the 0.7.50 it inherited from
-        #   a 2026-07-10 sac-base.sif. The floor was satisfied; nothing
-        #   upgraded; nothing complained. Six busy agents then ran a WIP gate
-        #   that counted DEFERRED + CANCELLED cards as open.
+        #   Why a pin, not the old ``-P latest``: ``-P`` re-resolved
+        #   scitex-todo to the NEWEST published on every :scitex rebuild.
+        #   That fixed the 2026-07-12 fleet-drift — a ``>=`` floor the
+        #   inherited version already satisfied is a NO-OP, so the layer
+        #   could freeze on whatever :base baked (it shipped 0.7.50 for days).
+        #   But ``-P latest`` is a MOVING ref: a rebuild once 0.13.4 was
+        #   latest would have baked its ~171s-per-write store-rewrite
+        #   regression into the fleet image (vs ~4.5s on 0.13.5) — the board
+        #   dies the moment the image lands. An exact pin trades auto-
+        #   currency for reproducibility + safety: the baked version is
+        #   deterministic and bumps are DELIBERATE (measure a timed write,
+        #   then raise the pin in BOTH layers). 0.13.5 = the measured-good
+        #   version (scitex-todo owner, 2026-07-15).
         #
-        #   ``-P scitex-todo`` re-resolves that ONE package against PyPI even
-        #   when the inherited version satisfies the floor, so a :scitex
-        #   rebuild picks up the newest scitex-todo instead of freezing on
-        #   whatever :base happened to bake. Scoped to the single package
-        #   (not a blanket ``-U``) so it cannot perturb scitex[all]'s
-        #   resolution or the local-source sac force-reinstalled in step 2.
-        #   The floor stays as the CAPABILITY statement (>=0.9.4 = the #356
-        #   WIP-gate fix, first released in 0.8.0); section 2b then asserts
-        #   the capability BY SYMBOL so a stale bake dies loudly.
-        #
-        #   ``[mcp]`` extra is carried here too (base installs it): a plain
-        #   ``scitex-todo`` upgrade would leave fastmcp pinned to whatever the
-        #   OLD version's extra resolved, so the extra rides the upgrade.
+        #   ``[mcp]`` extra stays: it pulls fastmcp for the in-container
+        #   ``scitex-todo mcp start`` path. Section 2b re-asserts the WIP-gate
+        #   symbol BY SYMBOL, so a pin to a version that dropped it dies at
+        #   bake rather than shipping silently.
         uv pip install --python /opt/venv-sac/bin/python \
-            --upgrade-package scitex-todo \
             "scitex-dev>=0.29.0" \
             "scitex-writer>=2.29.0" \
             "scitex-audio>=0.3.0" \
             "scitex-cv>=0.2.0" \
-            "scitex-todo[mcp]>=0.9.4"
+            "scitex-todo[mcp]==0.13.5"
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             pip setuptools wheel
@@ -225,18 +221,16 @@ From: ./sac-base.sif
             "scitex-writer>=2.29.0" \
             "scitex-audio>=0.3.0" \
             "scitex-cv>=0.2.0"
-        # scitex-todo gets its OWN invocation with ``--upgrade`` — pip's
-        # equivalent of the uv branch's ``-P scitex-todo``, and load-bearing
-        # for the same reason: this layer INHERITS base's venv, so a bare
-        # ``>=`` floor the inherited scitex-todo already satisfies is a no-op
-        # and the layer freezes on base's version forever (the 2026-07-12
-        # fleet-drift incident — see the uv branch above for the full
-        # autopsy). ``--upgrade`` re-resolves it against PyPI. Kept as a
-        # SEPARATE command so the flag applies to scitex-todo alone (pip's
-        # default only-if-needed strategy would otherwise let it reach into
-        # the providers' resolution too).
-        /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
-            "scitex-todo[mcp]>=0.9.4"
+        # scitex-todo — PINNED ==0.13.5 in its OWN invocation (pip's
+        # equivalent of the uv branch above). Was ``--upgrade`` + a >=0.9.4
+        # floor to force re-resolution over base's inherited venv; with an
+        # exact pin that base ALSO carries there is nothing to re-resolve, so
+        # ``--upgrade`` is dropped. Kept as a SEPARATE command anyway so the
+        # exact scitex-todo pin cannot reach into the providers' resolution
+        # above. See the uv branch for why a pin replaced ``-P latest`` (the
+        # 0.13.x ~171s-per-write regression a moving ref would have baked).
+        /opt/venv-sac/bin/pip install --no-cache-dir \
+            "scitex-todo[mcp]==0.13.5"
     fi
 
     # ---- 2b. FAIL-LOUD staleness gate — assert BY SYMBOL ----------------


### PR DESCRIPTION
## What

Pin `scitex-todo[mcp]==0.13.5` in the base layer (`apptainer-base.def`) and both
`:scitex` install branches (uv + pip fallback in `apptainer-scitex.def`),
replacing the `-P scitex-todo` / `--upgrade` "resolve to latest" mechanism. The
obsolete upgrade flags are removed and their rationale comments rewritten so the
def does not contradict its own pin.

## Why

`-P latest` was the 2026-07-12 fleet-drift fix — a `>=` floor the inherited base
venv already satisfies is a no-op, so the `:scitex` layer would freeze on
whatever base baked. But `-P latest` is a **moving ref**: a rebuild once
scitex-todo 0.13.4 was latest would have auto-baked its **~171s-per-card-write**
store-rewrite regression into the fleet image — the board becomes unusable the
moment the image lands. That is exactly what a pre-bake gate on this repo caught
before the build ran.

An exact pin makes the baked version **deterministic + reproducible** and bumps
**deliberate** (measure a timed write, then raise the pin in both layers) instead
of automatic-and-hopeful. This is the reproducible-pinned-PyPI rule applied to
the one package the whole fleet's task board runs on.

### Why 0.13.5

The scitex-todo owner measured it on the **published** wheel (2026-07-15), one
card write against a copy of the live store:

| version | per-card-write |
|---|---|
| 0.9.4 (currently deployed) | 46,042 ms |
| 0.13.4 | 171,000 ms |
| **0.13.5** | **4,517 ms** |

Store contents preserved (1640 == 1640). 0.13.5 is a ~10x win over the deployed
0.9.4 — a fix, not a regression. (The slow path was in 0.9.4 too; 0.13.4 made it
worse; 0.13.5 fixes it via a libyaml C loader on the store round-trip.)

## Safety

- With base and `:scitex` pinning the **same** exact version, an `==` the
  inherited venv already satisfies is a correct no-op — so `--upgrade-package` /
  `--upgrade` are unnecessary and removed.
- The section-6c / 2b **symbol gate** still asserts
  `scitex_todo._throughput.WIP_STATUSES` BY SYMBOL at bake, so a pin to any
  version that dropped the WIP-gate capability fails the build **loud**, not
  silent.
- The capability-floor contract test
  (`tests/integration/test_apptainer_base_def_scitex_todo.py`) stays green:
  `==0.13.5` parses to `(0,13,5) >= (0,8,0)` (the WIP-gate floor) — **13 passed**.

## NOT in this PR / follow-up

- **Do not bake from this PR.** After merge, a **supervised** bake runs the
  acceptance gate (one timed card write inside the image, expect ~4.5s) before
  flipping the SIF symlink — one measured write, not a reasoned all-clear.
- Confirming with the scitex-todo owner that `_throughput.WIP_STATUSES` survived
  the 0.9 → 0.13 refactors. If it was relocated, the gate is updated in a
  follow-up; the bake self-protects either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
