### PR TITLE
fix(liveness): stale heartbeat must not outvote a live tmux-DEAD; + terse verdict render()

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_verdict.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict.py
@@ -142,6 +142,24 @@ __all__ = [
 _CORROBORATION_REQUIRED = 2
 
 
+def _first_clause(detail: str) -> str:
+    """The claim at the head of a verbose signal detail, without the lecture.
+
+    Signal details lead with the OBSERVATION and put the (important, long)
+    justification after an em-dash or a semicolon — e.g. ``"tmux probe
+    SUCCEEDED and the server has NO session — positive evidence of absence,
+    from tmux's own bookkeeping"``. A one-line status wants only that head;
+    :meth:`LivenessVerdict.to_dict` keeps the whole thing for ``--json``.
+    Splits on whichever of ``—`` / ``;`` comes first.
+    """
+    cut = len(detail)
+    for sep in ("—", ";"):
+        i = detail.find(sep)
+        if i != -1:
+            cut = min(cut, i)
+    return detail[:cut].strip() or detail.strip()
+
+
 @dataclass(frozen=True)
 class LivenessVerdict:
     """The resolved verdict for one agent, and the evidence that produced it.
@@ -292,29 +310,33 @@ class LivenessVerdict:
         )
 
     def render(self) -> str:
-        """One line: the verdict AND why. Never just the verdict.
+        """One line: the verdict AND why — TERSE. The full prose is in --json.
 
         e.g. ``ALIVE (delivery: 1 live inbox subscriber)``
-             ``UNKNOWN (heartbeat: pid=0 — no verdict possible)``
-             ``DEAD (process: no tmux session 'tui-x'; registry: no active row)``
+             ``UNKNOWN (heartbeat: pid=0 in heartbeat.json)``
+             ``DEAD (process: tmux has no session for this agent) | also: heartbeat[alive], registry[unknown]``
 
-        An operator staring at ``running | pid=None`` learns nothing. This is
-        the line that replaces it.
+        Each signal's ``detail`` is deliberately verbose and educational — the
+        justification an operator can read once and learn from. But a STATUS
+        line must not dump all of it for every signal at once; that is the
+        "prose splurge" an operator rightly calls unreadable. So this shows the
+        FIRST CLAUSE (the claim, before the lecture) of each AGREEING signal and
+        reduces the dissenters to ``source[verdict]`` tags. The complete
+        reasoning for every signal is always one ``--json`` away in
+        :meth:`to_dict` (``evidence[].detail``) — nothing is lost, only folded.
         """
         if not self.signals:
             return f"{self.verdict.upper()} (no signals gathered)"
         # Lead with the signals that AGREE with the verdict — that is the
-        # reasoning; the dissenters follow so they are never hidden.
+        # reasoning; the dissenters follow as tags so they are never hidden.
         agreeing = [s for s in self.signals if s.verdict == self.verdict]
         dissenting = [s for s in self.signals if s.verdict != self.verdict]
-        parts = [f"{s.source}: {s.detail}" for s in agreeing]
+        parts = [f"{s.source}: {_first_clause(s.detail)}" for s in agreeing]
         why = "; ".join(parts) if parts else "no corroborating signal"
         out = f"{self.verdict.upper()} ({why})"
         if dissenting:
-            other = "; ".join(
-                f"{s.source}[{s.verdict}]: {s.detail}" for s in dissenting
-            )
-            out += f" | also: {other}"
+            tags = ", ".join(f"{s.source}[{s.verdict}]" for s in dissenting)
+            out += f" | also: {tags}"
         return out
 
     def to_dict(self) -> dict:
@@ -340,9 +362,14 @@ def decide(agent: str, signals: Iterable[Signal] | Sequence[Signal]) -> Liveness
 
     The rules, in order:
 
-    1. **Any ALIVE ⇒ ALIVE.** Positive evidence of life is never overruled by
-       the absence of other evidence. An agent that fails four proxy checks and
-       answers one real one is a running agent.
+    1. **Any LIVE ALIVE ⇒ ALIVE.** Positive evidence of life is never overruled
+       by the ABSENCE of other evidence. An agent that fails four proxy checks
+       and answers one real one is a running agent. The lone exception is a
+       heartbeat ALIVE contradicted by a LIVE probe of the SAME instrument: a
+       TUI beat merely re-reports the tmux snapshot ``process_signal`` reads
+       live, so a live "no such session" (DEAD) ages that beat out. That is the
+       instruments-not-sources rule across time, not a crack in the veto — a
+       delivery/process ALIVE is a live observation and is never suppressed.
     2. **Else any DEAD ⇒ DEAD.** Death needs POSITIVE evidence — a probe that
        actually ran and actually found nothing.
     3. **Else UNKNOWN.** No observation either way. This is a real answer, and
@@ -356,9 +383,25 @@ def decide(agent: str, signals: Iterable[Signal] | Sequence[Signal]) -> Liveness
     and it counts INSTRUMENTS.
     """
     sigs = tuple(signals)
+    # A heartbeat is a STALE ARTEFACT: a value some other loop wrote to a file
+    # at a past beat, re-reporting an instrument it sampled THEN. For a TUI agent
+    # it re-reports the very tmux snapshot process_signal probes LIVE — so when a
+    # live probe of the SAME instrument now returns DEAD (the tmux server
+    # positively has no such session), the older beat is out of date and must
+    # not vouch for life: "now" supersedes "up to 600s ago" ON ONE INSTRUMENT.
+    # This is the count-instruments-not-sources rule in the time dimension — one
+    # sensor cannot be alive and dead at once, and its LIVE reading beats its own
+    # stale echo. (A reboot left a <600s beat behind a vanished session; the fold
+    # read ALIVE and sac-start refused to relaunch a genuinely dead agent until
+    # the beat finally aged past 600s.) A delivery/process ALIVE is a LIVE
+    # observation, not an artefact, so it is never suppressed here.
+    dead_instruments = {s.instrument for s in sigs if s.verdict == DEAD}
     for sig in sigs:
-        if sig.verdict == ALIVE:
-            return LivenessVerdict(agent=agent, verdict=ALIVE, signals=sigs)
+        if sig.verdict != ALIVE:
+            continue
+        if sig.source == SOURCE_HEARTBEAT and sig.instrument in dead_instruments:
+            continue  # stale echo of an instrument a live probe just found DEAD
+        return LivenessVerdict(agent=agent, verdict=ALIVE, signals=sigs)
     for sig in sigs:
         if sig.verdict == DEAD:
             return LivenessVerdict(agent=agent, verdict=DEAD, signals=sigs)

--- a/tests/scitex_agent_container/_lifecycle/test__verdict.py
+++ b/tests/scitex_agent_container/_lifecycle/test__verdict.py
@@ -385,3 +385,168 @@ def test_to_dict_evidence_names_the_instrument_behind_each_signal():
     payload = decide("x", signals).to_dict()
     # Assert
     assert payload["evidence"][0]["instrument"] == INSTRUMENT_PID_NAMESPACE
+
+
+# --------------------------------------------------------------------------
+# Rule 1, the TIME dimension: a STALE heartbeat artefact does not overrule a
+# LIVE probe of the SAME instrument (the reboot-recovery regression, 2026-07-15).
+# --------------------------------------------------------------------------
+
+
+def test_a_stale_heartbeat_alive_does_not_override_a_live_tmux_dead():
+    """After a reboot the beat is still <600s but the tmux session is GONE.
+
+    heartbeat and process are ONE instrument (host_tmux) for a TUI agent — the
+    beat merely re-reports the snapshot the live probe reads. The live "no
+    session" is newer than the file, so the fold must read DEAD, not ALIVE.
+    (The bug: sac-start read ALIVE and refused to relaunch a dead agent.)
+    """
+    # Arrange — a fresh-looking beat, and a live tmux probe that found nothing.
+    signals = [
+        Signal(
+            SOURCE_HEARTBEAT,
+            ALIVE,
+            "beaten 516s ago (< 600s) — sac listen observed this session",
+            INSTRUMENT_HOST_TMUX,
+        ),
+        Signal(
+            SOURCE_PROCESS,
+            DEAD,
+            "tmux probe SUCCEEDED and the server has NO session — positive absence",
+            INSTRUMENT_HOST_TMUX,
+        ),
+    ]
+    # Act
+    verdict = decide("alpha", signals)
+    # Assert
+    assert verdict.verdict == DEAD
+
+
+def test_the_stale_heartbeat_flip_still_authorises_no_destruction():
+    """DEAD here rests on ONE instrument (host_tmux): it may report, not destroy.
+
+    So the flip unblocks a NON-destructive sac-start, and cannot arm an auto-kill.
+    """
+    # Arrange
+    signals = [
+        Signal(
+            SOURCE_HEARTBEAT, ALIVE, "beaten 516s ago (< 600s)", INSTRUMENT_HOST_TMUX
+        ),
+        Signal(SOURCE_PROCESS, DEAD, "no session", INSTRUMENT_HOST_TMUX),
+    ]
+    # Act
+    verdict = decide("alpha", signals)
+    # Assert
+    assert verdict.may_destroy is False
+
+
+def test_a_delivery_alive_still_overrides_a_live_tmux_dead():
+    """The suppression is NARROW: only a heartbeat echo of the SAME instrument.
+
+    A delivery ALIVE is a LIVE, independent observation (the broker saw the
+    inbox), so it still vetoes — a working agent with a detached tmux is alive.
+    """
+    # Arrange
+    signals = [
+        Signal(
+            SOURCE_DELIVERY,
+            ALIVE,
+            "1 live inbox subscriber",
+            INSTRUMENT_LISTEN_BROKER,
+        ),
+        Signal(SOURCE_PROCESS, DEAD, "no session", INSTRUMENT_HOST_TMUX),
+    ]
+    # Act
+    verdict = decide("alpha", signals)
+    # Assert
+    assert verdict.verdict == ALIVE
+
+
+def test_a_self_heartbeat_is_not_suppressed_by_a_pid_dead():
+    """A NON-tui beat is INSTRUMENT_AGENT_SELF — a real self-report, not a tmux
+    echo — and the pid check is a DIFFERENT instrument, so it is not suppressed.
+    """
+    # Arrange
+    signals = [
+        Signal(
+            SOURCE_HEARTBEAT,
+            ALIVE,
+            "the agent's own loop beat 5s ago",
+            INSTRUMENT_AGENT_SELF,
+        ),
+        Signal(
+            SOURCE_PROCESS,
+            DEAD,
+            "recorded pid is reaped",
+            INSTRUMENT_PID_NAMESPACE,
+        ),
+    ]
+    # Act
+    verdict = decide("alpha", signals)
+    # Assert — a live self-report is real evidence of life; it wins.
+    assert verdict.verdict == ALIVE
+
+
+# --------------------------------------------------------------------------
+# render() is TERSE: the claim, not the lecture; dissenters as tags.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def verbose_dead_signals():
+    """A DEAD verdict's one signal: a claim followed by a long lecture tail."""
+    return [
+        Signal(
+            SOURCE_PROCESS,
+            DEAD,
+            "tmux has no session for this agent — positive evidence of absence, "
+            "from tmux's own bookkeeping",
+            INSTRUMENT_HOST_TMUX,
+        )
+    ]
+
+
+def test_render_shows_the_first_clause_of_a_verbose_detail(verbose_dead_signals):
+    # Arrange — verbose_dead_signals fixture
+    # Act
+    rendered = decide("alpha", verbose_dead_signals).render()
+    # Assert — the claim (before the em-dash) is shown.
+    assert "tmux has no session for this agent" in rendered
+
+
+def test_render_drops_the_lecture_after_the_em_dash(verbose_dead_signals):
+    # Arrange — verbose_dead_signals fixture
+    # Act
+    rendered = decide("alpha", verbose_dead_signals).render()
+    # Assert — the educational tail belongs in --json, not the one-liner.
+    assert "positive evidence of absence" not in rendered
+
+
+@pytest.fixture
+def dissenting_heartbeat_signals():
+    """A DEAD verdict where a suppressed same-instrument heartbeat ALIVE dissents."""
+    return [
+        Signal(SOURCE_PROCESS, DEAD, "tmux has no session", INSTRUMENT_HOST_TMUX),
+        Signal(
+            SOURCE_HEARTBEAT,
+            ALIVE,
+            "beaten 516s ago (< 600s) — sac listen observed this session recently",
+            INSTRUMENT_HOST_TMUX,
+        ),
+    ]
+
+
+def test_render_shows_a_dissenter_as_a_source_verdict_tag(dissenting_heartbeat_signals):
+    # Arrange — dissenting_heartbeat_signals fixture
+    # Act
+    rendered = decide("alpha", dissenting_heartbeat_signals).render()
+    # Assert — the dissenter is a compact tag.
+    assert "heartbeat[alive]" in rendered
+
+
+def test_render_omits_a_dissenters_verbose_prose(dissenting_heartbeat_signals):
+    # Arrange — dissenting_heartbeat_signals fixture
+    # Act
+    rendered = decide("alpha", dissenting_heartbeat_signals).render()
+    # Assert — the operator's "splurge" (the dissenter's prose) is gone.
+    assert "sac listen observed this session" not in rendered


### PR DESCRIPTION
## The bug (operator hit it during a reboot recovery, 2026-07-15)

After restarting the machine, `sac-start <agent>` refused to relaunch a
genuinely-dead agent for up to ~600s, printing *"already running. No-op. Use
--force"*. The heartbeat file — written <600s earlier by the **pre-reboot**
`sac listen` — produced an ALIVE that the verdict fold let win over the LIVE
tmux probe's DEAD ("the server has no session for this agent"). The operator
had to wait for the beat to age past 600s, or reach for `--force` (which
destroys the session), just to restart after a reboot.

## The fix

For a TUI agent the heartbeat IS `INSTRUMENT_HOST_TMUX` — the very instrument
`process_signal` probes live — so a stale heartbeat ALIVE is an **out-of-date
echo of the same sensor**, not independent evidence. `decide()` now suppresses
a heartbeat ALIVE whose instrument also carries a live DEAD: *"now" supersedes
"up to 600s ago" on one sensor.* This is the module's own
count-instruments-not-sources rule, applied in the time dimension.

Safety preserved:
- `may_destroy` still requires **2 independent instruments**, so the flip to
  DEAD unblocks only a **non-destructive** `sac-start` — it never arms an
  auto-kill / watchdog restart.
- A `delivery`/`process` ALIVE is a **live** observation and is never
  suppressed — a working agent with a detached tmux stays ALIVE (the
  `scitex-writer` refutation still holds).

## Also: the "prose splurge" (operator's second complaint)

`render()` dumped every signal's full educational `detail` into the one-line
status. It now shows the **first clause** of each agreeing signal and reduces
dissenters to `source[verdict]` tags; the complete reasoning stays in `--json`
(`to_dict().evidence[].detail`) — nothing lost, only folded.

## Tests

8 new regression tests (the reboot case; the narrowness of the suppression —
delivery-ALIVE and self-heartbeat are NOT suppressed; and the terse render).
Full `_lifecycle` suite green: **1009 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
