### PR TITLE
feat(attach): sac agents attach reaches a remote agent over ssh

### DIFF
--- a/src/scitex_agent_container/cli_pkg/lifecycle/_attach.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_attach.py
@@ -6,6 +6,16 @@ DETACHED tmux session named by :func:`session_name_for` (currently
 ``tmux attach`` (via ``execvp``) so you can watch and drive the live agent;
 detach again with the usual tmux keys (``Ctrl-b d``).
 
+**Cross-host (control-plane) attach.** The operator drives the whole fleet
+from the master, regardless of where an agent actually runs. So when the
+agent's ``spec.host`` classifies as a *remote* peer (the same
+``classify_dispatch_host`` resolution ``sac agents start`` dispatches
+through), attach does not look at the LOCAL tmux — it ``ssh -t``'s to that
+peer and runs ``tmux attach`` there. The remote agent's session lives on the
+peer's default tmux server and persists across attach/detach, so the
+operator gets the live remote agent from their local terminal; ``Ctrl-b d``
+detaches and drops back to the peer shell, ``Ctrl-d`` returns to the master.
+
 Fail-loud: if the agent has no running session, print a red notice with the
 next step (``sac agents start <name>``) and exit non-zero — never silently
 drop into an empty tmux.
@@ -14,6 +24,7 @@ drop into an empty tmux.
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 
 import click
@@ -40,16 +51,99 @@ def _session_for(name: str) -> tuple[str, str]:
         return name, f"tui-{name}"
 
 
+def _classify_agent_host(name: str) -> tuple[str, str | None]:
+    """Return ``(kind, peer)`` for the agent's ``spec.host``.
+
+    ``kind`` is ``"local"`` / ``"remote"`` / ``"unknown"`` per
+    :func:`._common.classify_dispatch_host` — the SAME resolver
+    ``sac agents start`` uses, so attach and start agree on where an agent
+    lives. Best-effort: an unresolvable spec (moved / deleted) degrades to
+    ``("local", None)`` so attach still tries the local tmux, preserving the
+    historic single-host behaviour.
+    """
+    try:
+        from ..._state.host_config import load as _load_host_config
+        from ...config import load_config
+        from ...config._host import resolve_hostname
+        from ...config._resolve import resolve_with_prefix
+        from ._common import _local_host_names, classify_dispatch_host
+
+        config = load_config(resolve_with_prefix(name))
+        bound = config.hosts_spec.host
+        target = bound if isinstance(bound, str) else (bound[0] if bound else None)
+        if not target:
+            return ("local", None)
+        current = resolve_hostname()
+        peers = _load_host_config().peers
+        return classify_dispatch_host(
+            target, current, peers, local_names=_local_host_names(current)
+        )
+    except Exception:  # stx-allow: fallback (unresolved spec/config → local attach)
+        return ("local", None)
+
+
+def _remote_attach_argv(session: str, peer: str) -> list[str]:
+    """Build the ``ssh -t <target> … tmux attach`` argv for a remote agent.
+
+    The ssh alias comes from ``host_config.peers[peer].ssh`` (the same
+    source ``sac agents start`` dispatches through); it falls back to the
+    peer name when no explicit ``ssh:`` is set. ``bash -lc`` gives the login
+    PATH so ``tmux`` resolves on hosts (e.g. Spartan) whose non-interactive
+    ssh PATH is bare, and ``-t`` forces a PTY so tmux gets a terminal.
+    """
+    ssh_target = peer
+    try:
+        from ..._state.host_config import load as _load_host_config
+
+        spec = _load_host_config().peers.get(peer)
+        if spec is not None and getattr(spec, "ssh", None):
+            ssh_target = spec.ssh
+    except (
+        Exception
+    ):  # stx-allow: fallback (peer without an ssh alias → use the peer name)
+        pass
+    remote = f"tmux attach -t {shlex.quote(session)}"
+    return [
+        "ssh",
+        "-t",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        ssh_target,
+        "bash",
+        "-lc",
+        remote,
+    ]
+
+
 @click.command()
 @click.argument("name", shell_complete=agent_name_complete)
 def attach(name: str) -> None:
     """Attach your terminal to a running agent's TUI (tmux) session.
 
+    Works whether the agent runs locally or on a remote peer host — a
+    remote agent is attached over ssh, so you drive the whole fleet from
+    the master.
+
     \b
     Example:
-      $ sac agents attach neurovista     # Ctrl-b d to detach
+      $ sac agents attach neurovista     # local; Ctrl-b d to detach
+      $ sac agents attach spartan-dev    # remote (Spartan) over ssh
     """
     agent, session = _session_for(name)
+    kind, peer = _classify_agent_host(name)
+
+    if kind == "remote" and peer is not None:
+        # Control-plane attach: the session lives on the peer, not here.
+        system_msg(
+            f"'{agent}' runs on remote host '{peer}'; attaching over ssh. "
+            f"Ctrl-b d detaches (back to {peer}'s shell); Ctrl-d returns here.",
+            style="cyan",
+        )
+        # Hand the terminal to ssh (replaces this process). A missing remote
+        # session surfaces as tmux's own "can't find session" over the PTY —
+        # loud, not silent.
+        os.execvp("ssh", _remote_attach_argv(session, peer))
+        return  # unreachable (execvp replaced the process)
 
     try:
         exists = (

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__attach.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__attach.py
@@ -33,3 +33,48 @@ def test_session_for_falls_back_to_tui_prefix_for_unknown_name() -> None:
     _, session = _session_for("zzz-not-a-real-spec-zzz")
     # Assert
     assert session == "tui-zzz-not-a-real-spec-zzz"
+
+
+# --------------------------------------------------------------------------
+# Cross-host attach: a remote agent is attached over ssh, not the local tmux.
+# --------------------------------------------------------------------------
+
+
+def test_remote_attach_argv_forces_a_pty_with_ssh_dash_t() -> None:
+    # Arrange
+    from scitex_agent_container.cli_pkg.lifecycle._attach import _remote_attach_argv
+
+    # Act
+    argv = _remote_attach_argv("tui-spartan-dev", "zzz-unknown-peer-zzz")
+    # Assert
+    assert argv[:2] == ["ssh", "-t"]
+
+
+def test_remote_attach_argv_runs_tmux_attach_on_the_named_session() -> None:
+    # Arrange
+    from scitex_agent_container.cli_pkg.lifecycle._attach import _remote_attach_argv
+
+    # Act
+    argv = _remote_attach_argv("tui-spartan-dev", "zzz-unknown-peer-zzz")
+    # Assert
+    assert argv[-1] == "tmux attach -t tui-spartan-dev"
+
+
+def test_remote_attach_argv_falls_back_to_peer_name_when_no_ssh_alias() -> None:
+    # Arrange — a peer absent from host_config has no ssh alias.
+    from scitex_agent_container.cli_pkg.lifecycle._attach import _remote_attach_argv
+
+    # Act
+    argv = _remote_attach_argv("tui-x", "zzz-unknown-peer-zzz")
+    # Assert
+    assert "zzz-unknown-peer-zzz" in argv
+
+
+def test_classify_agent_host_unresolvable_spec_is_local() -> None:
+    # Arrange
+    from scitex_agent_container.cli_pkg.lifecycle._attach import _classify_agent_host
+
+    # Act
+    kind, _peer = _classify_agent_host("zzz-not-a-real-spec-zzz")
+    # Assert
+    assert kind == "local"


### PR DESCRIPTION
## `sac agents attach` — cross-host (control-plane) attach

The operator drives the whole fleet from the master. But `sac agents attach`
only ever checked the **local** tmux server, so attaching a remote agent
(`spartan-dev` on Spartan) failed with *"no running session"* even though the
agent was live on its own host — the operator hit this directly.

### Fix

`attach` now classifies the agent's `spec.host` with the **same**
`classify_dispatch_host` resolver `sac agents start` dispatches through:

- **local** → the existing `tmux attach` (byte-identical to before).
- **remote** → `ssh -t <peer> bash -lc "tmux attach -t <session>"`, where the
  ssh alias comes from `host_config.peers[peer].ssh`. The `-t` forces a PTY;
  the login shell puts `tmux` on PATH even where the non-interactive ssh PATH
  is bare (Spartan). The remote session lives on the peer's default tmux
  server and persists across attach/detach — Ctrl-b d detaches (back to the
  peer shell), Ctrl-d returns to the master.

### Tests

4 new (argv builder + host classification, no mocks); full attach suite green
(6 passed).

### Companion (tracked separately)

This is half of "master = single control plane". The other half is
`sac agents list` cross-host federation — a remote agent's liveness currently
reads local-only, so it shows stopped/hidden even when live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
