### PR TITLE
fix(list/attach): remote tmux probe must not use a login shell (false DEAD)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_verdict_resolve.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict_resolve.py
@@ -34,7 +34,6 @@ cost of a false DEAD is a destroyed agent.
 
 from __future__ import annotations
 
-import shlex
 from typing import Any, Callable
 
 from ._verdict import (
@@ -387,16 +386,21 @@ def remote_process_signal(
     ):  # stx-allow: fallback (peer without an ssh alias -> use the peer name verbatim)
         pass
 
+    # tmux is on the peer's non-login PATH; a login shell (bash -lc) triggers the
+    # profile's interactive-tmux and fails with "open terminal failed: not a
+    # terminal" -> false DEAD. -n so ssh never consumes our stdin.
     argv = [
         "ssh",
+        "-n",
         "-o",
         "BatchMode=yes",
         "-o",
         "ConnectTimeout=6",
         ssh_target,
-        "bash",
-        "-lc",
-        f"tmux has-session -t {shlex.quote(session)}",
+        "tmux",
+        "has-session",
+        "-t",
+        session,
     ]
     try:
         rc = (run_ssh or _run_ssh_rc)(argv)

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_attach.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_attach.py
@@ -24,7 +24,6 @@ drop into an empty tmux.
 from __future__ import annotations
 
 import os
-import shlex
 import subprocess
 
 import click
@@ -83,13 +82,15 @@ def _classify_agent_host(name: str) -> tuple[str, str | None]:
 
 
 def _remote_attach_argv(session: str, peer: str) -> list[str]:
-    """Build the ``ssh -t <target> … tmux attach`` argv for a remote agent.
+    """Build the ``ssh -t <target> tmux attach -t <session>`` argv for a remote agent.
 
     The ssh alias comes from ``host_config.peers[peer].ssh`` (the same
     source ``sac agents start`` dispatches through); it falls back to the
-    peer name when no explicit ``ssh:`` is set. ``bash -lc`` gives the login
-    PATH so ``tmux`` resolves on hosts (e.g. Spartan) whose non-interactive
-    ssh PATH is bare, and ``-t`` forces a PTY so tmux gets a terminal.
+    peer name when no explicit ``ssh:`` is set. ``tmux`` is invoked DIRECTLY on
+    the peer's non-login PATH: a login shell (``bash -lc``) triggers the
+    profile's interactive-tmux and fails with "open terminal failed: not a
+    terminal", so attach must not wrap the command. ``-t`` still forces a PTY so
+    tmux gets a terminal.
     """
     ssh_target = peer
     try:
@@ -102,16 +103,16 @@ def _remote_attach_argv(session: str, peer: str) -> list[str]:
         Exception
     ):  # stx-allow: fallback (peer without an ssh alias → use the peer name)
         pass
-    remote = f"tmux attach -t {shlex.quote(session)}"
     return [
         "ssh",
         "-t",
         "-o",
         "StrictHostKeyChecking=accept-new",
         ssh_target,
-        "bash",
-        "-lc",
-        remote,
+        "tmux",
+        "attach",
+        "-t",
+        session,
     ]
 
 

--- a/tests/scitex_agent_container/_lifecycle/test__verdict_resolve.py
+++ b/tests/scitex_agent_container/_lifecycle/test__verdict_resolve.py
@@ -434,3 +434,65 @@ def test_remote_process_signal_run_ssh_raising_is_unknown_never_dead():
     signal = remote_process_signal(cfg, "spartan", run_ssh=_boom)
     # Assert
     assert signal.verdict == UNKNOWN
+
+
+# --------------------------------------------------------------------------
+# The argv the remote probe hands to ssh — captured via the injected run_ssh
+# (a real recording callable, no mock). A login shell (`bash -lc`) is the bug:
+# on Spartan it triggers the profile's interactive-tmux, which prints
+# "open terminal failed: not a terminal" and exits rc 1 — a LIVE remote agent
+# misread as DEAD. tmux is on the peer's non-login PATH, so we call it directly.
+# --------------------------------------------------------------------------
+
+
+def _captured_remote_probe_argv(
+    peer: str = "spartan", name: str = "spartan-dev"
+) -> list[str]:
+    """Return the argv ``remote_process_signal`` hands to ssh.
+
+    The ``run_ssh`` seam is a real callable; here it merely records the argv it
+    is given and reports rc 0. No mock — this is the injection point the signal
+    is designed around.
+    """
+    captured: list[list[str]] = []
+
+    def _run_ssh(argv: list[str]) -> int:
+        captured.append(argv)
+        return 0
+
+    remote_process_signal(_Cfg(name, "tui"), peer, run_ssh=_run_ssh)
+    return captured[0]
+
+
+def test_remote_process_signal_argv_uses_no_login_shell():
+    """Regression (2026-07-16): the probe must NOT wrap tmux in a login shell.
+
+    ``ssh <peer> bash -lc 'tmux has-session ...'`` runs the peer's login profile,
+    whose interactive-tmux stanza fails with "open terminal failed: not a
+    terminal" (rc 1) — mapping a live remote agent to DEAD in ``sac agents list``.
+    """
+    # Arrange
+    login_shell_tokens = {"bash", "-lc"}
+    # Act
+    argv = _captured_remote_probe_argv()
+    # Assert — no login shell: neither `bash` nor `-lc` in the built argv.
+    assert not (login_shell_tokens & set(argv))
+
+
+def test_remote_process_signal_argv_probes_tmux_has_session_directly():
+    # Arrange
+    expected_tail = ["tmux", "has-session", "-t", "tui-spartan-dev"]
+    # Act
+    argv = _captured_remote_probe_argv()
+    # Assert — ssh runs `tmux has-session -t <session>` directly on the peer.
+    assert argv[-4:] == expected_tail
+
+
+def test_remote_process_signal_argv_passes_ssh_dash_n():
+    """``-n`` so ssh never consumes our stdin during a bulk `sac agents list`."""
+    # Arrange
+    required_flag = "-n"
+    # Act
+    argv = _captured_remote_probe_argv()
+    # Assert
+    assert required_flag in argv

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__attach.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__attach.py
@@ -56,8 +56,25 @@ def test_remote_attach_argv_runs_tmux_attach_on_the_named_session() -> None:
 
     # Act
     argv = _remote_attach_argv("tui-spartan-dev", "zzz-unknown-peer-zzz")
-    # Assert
-    assert argv[-1] == "tmux attach -t tui-spartan-dev"
+    # Assert — tmux attach runs DIRECTLY on the peer (no `bash -lc` wrapper).
+    assert argv[-4:] == ["tmux", "attach", "-t", "tui-spartan-dev"]
+
+
+def test_remote_attach_argv_uses_no_login_shell() -> None:
+    """Regression (2026-07-16): attach must not wrap tmux in a login shell.
+
+    A login shell (``bash -lc``) runs the peer's profile, whose interactive-tmux
+    stanza fails with "open terminal failed: not a terminal"; tmux is on the
+    peer's non-login PATH, so attach invokes it directly.
+    """
+    # Arrange
+    from scitex_agent_container.cli_pkg.lifecycle._attach import _remote_attach_argv
+
+    login_shell_tokens = {"bash", "-lc"}
+    # Act
+    argv = _remote_attach_argv("tui-spartan-dev", "zzz-unknown-peer-zzz")
+    # Assert — no login shell: neither `bash` nor `-lc` in the built argv.
+    assert not (login_shell_tokens & set(argv))
 
 
 def test_remote_attach_argv_falls_back_to_peer_name_when_no_ssh_alias() -> None:


### PR DESCRIPTION
## The bug

Two cross-host control-plane helpers ssh to a peer and run tmux through a
**login shell** (`bash -lc "tmux …"`):

- `remote_process_signal` in `_lifecycle/_verdict_resolve.py` — the cross-host
  liveness probe behind `sac agents list`.
- `_remote_attach_argv` in `cli_pkg/lifecycle/_attach.py` — the cross-host
  `sac agents attach`.

On Spartan, the login profile's interactive-tmux stanza runs under `bash -lc`
and tmux emits `open terminal failed: not a terminal`, exiting **rc 1**. The
liveness ternary maps rc 1 to **DEAD**, so a **live** remote agent is misread as
dead in `sac agents list`, and `sac agents attach <remote-agent>` fails the same
way.

## Empirical proof

Spy on the exact failing call:

```
ARGV = ['ssh','-o','BatchMode=yes','-o','ConnectTimeout=6','spartan',
        'bash','-lc','tmux has-session -t tui-spartan-dev']
  -> RC=1, STDERR='open terminal failed: not a terminal'
```

The **direct** form (no login shell) works, verified 5× consistently:

```
ssh -n spartan tmux has-session -t tui-spartan-dev   -> rc 0  (session FOUND)
```

tmux is on the peer's **non-login PATH** on Spartan, so no login shell is
needed — the `bash -lc` wrapper is pure harm.

## The fix

Call tmux **directly** over ssh in both helpers; no `bash -lc` wrapper.

- probe: `ssh -n -o BatchMode=yes -o ConnectTimeout=6 <peer> tmux has-session -t <session>`
  (`-n` so ssh never consumes our stdin during a bulk `sac agents list`).
- attach: `ssh -t -o StrictHostKeyChecking=accept-new <peer> tmux attach -t <session>`
  (`-t` kept — attach needs a PTY).

The liveness ternary (rc0→ALIVE, rc1→DEAD, other/raise→UNKNOWN) is unchanged;
only the argv changes. The now-unused `import shlex` is removed from both files.

## Tests (no mocks — real injected seams)

- `test__verdict_resolve.py`: capture the built argv via the injected `run_ssh`
  seam and assert it contains **no** `bash`/`-lc` (regression guard for exactly
  this bug), runs `tmux has-session -t <session>` directly, and passes `-n`. The
  rc0/rc1/rc255/raise verdict tests are unchanged.
- `test__attach.py`: the session assertion now expects the direct
  `["tmux","attach","-t",<session>]` tail, plus a regression test that the argv
  contains no `bash`/`-lc`.
