### PR TITLE
feat(list): master shows remote-dispatched agents as running-on-peer (live-probed)

### DIFF
--- a/src/scitex_agent_container/_state/state_db_gc.py
+++ b/src/scitex_agent_container/_state/state_db_gc.py
@@ -52,8 +52,12 @@ def gc_dead_instances(
        is older than ``heartbeat_stale_seconds``, mark
        ``exit_reason='gc-stale'``.
 
-    Cross-host instances are NOT swept (we have no liveness signal
-    for them; F-CS12 will add ssh-based probing).
+    Cross-host (``remote=1``) instances are NEVER swept, by construction
+    in all three branches: reboot + pid are ``host=<self>``-scoped (a
+    peer's row has a different host), and the heartbeat sweep carries an
+    explicit ``AND remote=0``. We have no local liveness signal for a
+    remote agent — ``sac agents list`` ssh-probes the peer live instead of
+    tombstoning it here.
 
     ``dry_run=True`` runs all three checks but emits zero UPDATE
     statements — counters reflect what *would* be swept.
@@ -116,9 +120,16 @@ def gc_dead_instances(
                     )
                 counters["crashed"] += 1
 
+        # ``AND remote=0`` — the heartbeat sweep is the ONE branch without a
+        # host filter, so without this a cross-host (``remote=1``) row could be
+        # reaped from the master the instant a stale ``last_heartbeat_at`` were
+        # ever written to it. A master remote row is safe TODAY only because its
+        # heartbeat is NULL; this makes "cross-host instances are never swept"
+        # true BY CONSTRUCTION across all three branches (reboot + pid are
+        # already ``host=<self>``-scoped), not merely true by accident.
         cur = conn.execute(
             "SELECT id, last_heartbeat_at FROM instances "
-            "WHERE ended_at IS NULL AND last_heartbeat_at IS NOT NULL"
+            "WHERE ended_at IS NULL AND last_heartbeat_at IS NOT NULL AND remote=0"
         ).fetchall()
         for row in cur:
             try:

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -160,6 +160,8 @@ def get_agent_list_data(
     remote_probe_timeout_s: float = 2.0,
     max_parallel_probes: int = 8,
     running_only: bool = False,
+    remote_status_probe=None,
+    remote_run_ssh=None,
 ) -> list[dict]:
     """Get agent list as plain dicts for JSON or table output.
 
@@ -193,6 +195,15 @@ def get_agent_list_data(
         max_parallel_probes: How many remote probes to run concurrently.
             Kept small to stay under the macOS ``kern.maxproc`` wall
             that today's SSH fan-out regression exposed.
+        remote_status_probe: Injection seam for the cross-host status probe
+            (``(name, host) -> status``). ``None`` uses the default ssh probe
+            (peer tmux ``has-session`` via ``remote_process_signal``). Tests
+            pass a real callable so they never shell out.
+        remote_run_ssh: Injection seam ONE LEVEL DOWN — the ``(argv) -> rc``
+            ssh runner threaded into the default status probe's
+            ``remote_process_signal``. Lets a test drive the real
+            verdict-mapping (rc 0/1/other -> running/stopped/running) without
+            an ssh binary. Ignored when ``remote_status_probe`` is given.
 
     Rows with a remote probe that timed out have ``status="unknown"``
     and ``liveness_unknown=True`` so JSON consumers can surface a
@@ -417,13 +428,35 @@ def get_agent_list_data(
             row["labels"] = labels
         results.append(row)
 
-    # Merge in the agents DEFINED on disk but absent from the registry. Their
+    # Merge in agents recorded as running on a REMOTE peer (master-authoritative
+    # cross-host visibility). The master already wrote an ``instances`` row on
+    # dispatch (``host=<peer>``, ``remote=1``); this is the READ side that was
+    # missing. Precedence: a LOCAL registry row wins (its name is in
+    # ``reg_names`` so the remote merge skips it); the remote row in turn
+    # suppresses the defined-on-disk row (``covered`` feeds ``defined_agent_rows``
+    # so a remote agent is not ALSO emitted as a defined/local row).
+    reg_names = {r["name"] for r in results}
+    remote_rows = remote_instance_rows(
+        registered=reg_names,
+        display_host=display_host,
+        port_claims=port_claims,
+        running_only=running_only,
+        capability=capability,
+        machine=machine,
+        tags=tags,
+        status_probe=remote_status_probe,
+        run_ssh=remote_run_ssh,
+    )
+    results.extend(remote_rows)
+    covered = reg_names | {r["name"] for r in remote_rows}
+
+    # Then the agents DEFINED on disk but absent from BOTH registries. Their
     # discovery + row-build live together in the sibling ``_agent_list_discover``
-    # (512-line cap split); this stays the orchestrator that merges the two
-    # sources. They are never live, so they carry the never-checked auth shape.
+    # (512-line cap split); this stays the orchestrator that merges the sources.
+    # They are never live, so they carry the never-checked auth shape.
     results.extend(
         defined_agent_rows(
-            registered={r["name"] for r in results},
+            registered=covered,
             port_claims=port_claims,
             display_host=display_host,
             capability=capability,
@@ -443,8 +476,8 @@ from ._agent_list_discover import (  # noqa: E402,F401
     _discover_defined_agents,
     _is_self_peer_marker,
     defined_agent_rows,
+    remote_instance_rows,
 )
-
 
 # Presentation layer lives in the sibling ``_agent_list_render`` module
 # (512-line cap split). Re-exported here so ``from ._agent_list import
@@ -455,4 +488,3 @@ from ._agent_list_render import (  # noqa: E402,F401
     print_agent_list,
     print_agent_list_json,
 )
-

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
@@ -17,6 +17,7 @@ them with the registry's rows.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, Callable
 
 
 def _is_self_peer_marker(spec_path: Path) -> bool:
@@ -191,5 +192,250 @@ def defined_agent_rows(
             row["validation_errors"] = errors
         if labels:
             row["labels"] = labels
+        rows.append(row)
+    return rows
+
+
+def _load_or_synthesize_config(spec_path: Path | None, name: str) -> Any:
+    """Load ``name``'s spec, or synthesize a bare ``AgentConfig(name=name)``.
+
+    The remote probe only needs a config to derive the agent's tmux session
+    name (:func:`_verdict_tmux.session_name_for_config` → ``tui-<name>``). A
+    remote agent's spec DOES live on the master's disk (that is how the master
+    ssh-dispatched it), so ``load_config`` normally succeeds; the synthesize
+    fallback keeps the probe working — never silently skipped — even if the
+    spec is momentarily unreadable. Returns ``None`` only if even a bare
+    config cannot be built (so the caller degrades to "never hide").
+    """
+    from ...config import load_config
+
+    if spec_path:
+        # stx-allow: fallback (a transiently-unreadable spec must not disable the
+        # live probe; fall through to a synthesized name-only config)
+        try:
+            return load_config(str(spec_path))
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            pass
+    # stx-allow: fallback (a bare AgentConfig should always build; if it cannot,
+    # the caller maps None -> "running" so a live peer is never hidden)
+    try:
+        from ...config._types import AgentConfig
+
+        return AgentConfig(name=name)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+
+
+def _default_remote_status_probe(
+    specs: dict[str, Path],
+    run_ssh: Callable[[list[str]], int] | None,
+) -> Callable[[str, str], str]:
+    """The production status probe: ssh the peer's tmux, map the verdict.
+
+    Returns a ``(name, host) -> status`` callable. It routes through the
+    ALREADY-deployed :func:`_lifecycle._verdict_resolve.remote_process_signal`
+    (ssh ``tmux has-session`` on the peer) and maps its TERNARY verdict:
+
+        ALIVE -> "running", DEAD -> "stopped", UNKNOWN -> "running".
+
+    UNKNOWN maps to "running" on purpose: a wedged ssh / bare-PATH / auth
+    hiccup must NEVER hide a live remote peer — that module's core doctrine.
+    Only a POSITIVE remote absence (the peer's own ``tmux has-session`` rc=1)
+    reads "stopped". ``run_ssh`` is threaded straight into
+    ``remote_process_signal`` so tests inject a real rc-returning callable and
+    never shell out.
+    """
+
+    def _probe(name: str, host: str) -> str:
+        from ..._lifecycle._verdict import ALIVE, DEAD
+        from ..._lifecycle._verdict_resolve import remote_process_signal
+
+        config = _load_or_synthesize_config(specs.get(name), name)
+        if config is None:
+            return "running"
+        # stx-allow: fallback (a probe that blew up observed NOTHING — never
+        # render that as a death that would hide a live peer)
+        try:
+            signal = remote_process_signal(config, host, run_ssh=run_ssh)
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            return "running"
+        return {ALIVE: "running", DEAD: "stopped"}.get(signal.verdict, "running")
+
+    return _probe
+
+
+def _probe_remote_statuses(
+    candidates: list[dict],
+    probe: Callable[[str, str], str],
+    max_parallel_probes: int,
+    probe_timeout_s: float,
+) -> dict[str, str]:
+    """``{name: status}`` from ``probe`` over a bounded pool with a hard timeout.
+
+    Mirrors the local liveness pass in :func:`_agent_list.get_agent_list_data`:
+    a dedicated ``ThreadPoolExecutor`` with a per-future timeout and
+    ``shutdown(wait=False)`` so one wedged peer cannot serialize (or hang) the
+    whole ``sac agents list``. A timed-out / raised probe maps to "running" —
+    the never-hide default, since a probe that could not run is not evidence a
+    remote agent died.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+    from concurrent.futures import TimeoutError as _FuturesTimeout
+
+    statuses: dict[str, str] = {}
+    if not candidates:
+        return statuses
+    workers = max(1, min(max_parallel_probes, len(candidates)))
+    pool = ThreadPoolExecutor(max_workers=workers)
+    try:
+        future_to_name = {
+            pool.submit(probe, c["name"], c["host"]): c["name"] for c in candidates
+        }
+        for future in list(future_to_name):
+            name = future_to_name[future]
+            # stx-allow: fallback (a per-probe timeout/exception is "unknown",
+            # which for a remote row means keep it visible as running)
+            try:
+                statuses[name] = future.result(timeout=probe_timeout_s)
+            except _FuturesTimeout:  # stx-allow: fallback (reason: see inline comment)
+                statuses[name] = "running"
+                future.cancel()
+            except Exception:  # stx-allow: fallback (reason: see inline comment)
+                statuses[name] = "running"
+    finally:
+        pool.shutdown(wait=False)
+    return statuses
+
+
+def remote_instance_rows(
+    *,
+    registered: set[str],
+    display_host: str,
+    port_claims: dict[str, int],
+    running_only: bool = False,
+    capability: str | None = None,
+    machine: str | None = None,
+    tags: str | None = None,
+    instances_oracle: Callable[[], list[dict]] | None = None,
+    status_probe: Callable[[str, str], str] | None = None,
+    run_ssh: Callable[[list[str]], int] | None = None,
+    max_parallel_probes: int = 8,
+    probe_timeout_s: float = 12.0,
+) -> list[dict]:
+    """Rows for agents recorded as running on a REMOTE peer (master-authoritative).
+
+    THE READ-SIDE the fleet view was missing. On dispatch, the master already
+    records an ``instances`` row (``host=<peer>``, ``remote=1``, ``pid=NULL``;
+    see ``_dispatch.try_dispatch_remote``) and tombstones it on stop — but
+    :func:`get_agent_list_data` only ever read the JSON ``Registry`` (local,
+    hostless) and the on-disk spec walk, so a spartan-dispatched agent fell
+    through to a misleading ``defined`` / ``local`` row. This reads the active
+    ``remote=1`` rows and emits a proper ``host=<peer>`` row per remote agent.
+
+    Precedence: a LOCAL ``Registry`` row wins (its name is in ``registered``,
+    so it is skipped here) and this in turn suppresses the defined-on-disk row
+    (the caller feeds the union of covered names into
+    :func:`defined_agent_rows`). Keyed on the authoritative ``remote`` flag, NOT
+    a hostname compare, so a same-host-named local start is never mistaken for a
+    cross-host one.
+
+    STATUS IS LIVE, never a trusted stale row: each remote row's status comes
+    from an ssh probe of the peer's own tmux (see
+    :func:`_default_remote_status_probe`), so an agent that died on a
+    login-node reboot reads ``stopped`` rather than a comforting ``running``.
+    Probes run through a bounded pool (:func:`_probe_remote_statuses`) to keep
+    list latency bounded. Both the ``status_probe`` and the underlying
+    ``run_ssh`` are injection seams so tests never shell out.
+
+    These agents are never locally LIVE, so — exactly like
+    :func:`defined_agent_rows` — they carry the never-checked auth shape
+    (``verdict_for(None)``) and the empty movement trio, keeping the ``--json``
+    row shape uniform. Helpers resolve through the ``_agent_list`` module
+    namespace so the suite's real-attribute seams keep working.
+    """
+    from ..._state.auth_state import verdict_for
+    from ..._state.state_db import list_active_instances
+    from ...config import load_config
+    from . import _agent_list as _al
+
+    del running_only  # accepted for signature-parity; remote status is always
+    # probed (a remote row's whole value is its live status), and the render
+    # layer — not this builder — hides non-running rows in the default view.
+
+    oracle = instances_oracle or (lambda: list_active_instances(host=None))
+    discover = getattr(_al, "_discover_defined_agents", _discover_defined_agents)
+    specs: dict[str, Path] = {name: path for name, path in discover()}
+
+    # First pass: keep only the active REMOTE rows, apply the label filters
+    # (loading the agent's on-disk spec for its labels), collect candidates.
+    candidates: list[dict] = []
+    for entry in oracle():
+        name = entry.get("name")
+        if not name or name in registered:  # a local Registry row wins
+            continue
+        if not entry.get("remote"):  # key on the authoritative flag
+            continue
+        spec_path = specs.get(name)
+        labels: dict[str, str] = {}
+        # stx-allow: fallback (label filtering is best-effort; an unreadable
+        # spec yields empty labels, never a crash of the list)
+        try:
+            if spec_path is not None:
+                labels = load_config(str(spec_path)).labels
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            labels = {}
+        if machine and labels.get("machine") != machine:
+            continue
+        if capability:
+            caps = [
+                c.strip()
+                for c in labels.get("capabilities", "").split(",")
+                if c.strip()
+            ]
+            if capability not in caps:
+                continue
+        if tags and not _al._label_list_contains(labels, "tags", tags):
+            continue
+        candidates.append(
+            {
+                "name": name,
+                "host": entry.get("host") or "",
+                "started_at": entry.get("started_at") or "-",
+                "a2a_port": entry.get("a2a_port")
+                or entry.get("bound_port")
+                or port_claims.get(name),
+                "spec_path": spec_path,
+                "labels": labels,
+            }
+        )
+
+    # Second pass: LIVE status via the injected (or default ssh) probe.
+    probe = status_probe or _default_remote_status_probe(specs, run_ssh)
+    statuses = _probe_remote_statuses(
+        candidates, probe, max_parallel_probes, probe_timeout_s
+    )
+
+    # Third pass: build the rows (mirrors ``defined_agent_rows``' shape).
+    rows: list[dict] = []
+    for cand in candidates:
+        name = cand["name"]
+        host = cand["host"]
+        row: dict = {
+            "name": name,
+            "status": statuses.get(name, "running"),
+            "screen": "-",
+            "multiplexer": None,
+            "started_at": cand["started_at"],
+            "host": host,
+            "host_display": _al._host_display_for(host, display_host),
+            "path": str(cand["spec_path"] or ""),
+            "a2a_port": cand["a2a_port"],
+            "account": "",
+            "remote": True,
+        }
+        row.update(dict(_al._MOVEMENT_DEFAULTS))
+        row.update(verdict_for(None))
+        if cand["labels"]:
+            row["labels"] = cand["labels"]
         rows.append(row)
     return rows

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_remote.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_remote.py
@@ -1,0 +1,403 @@
+"""Tests for the REMOTE-instance read side of ``sac agents list``.
+
+The master ssh-dispatches an agent (spec ``host: spartan``) and already records
+an ``instances`` row (``host=<peer>``, ``remote=1``, ``pid=NULL``) on dispatch,
+tombstoning it on stop. This suite pins the newly-added READ side:
+``get_agent_list_data`` / ``remote_instance_rows`` surface that row as
+**running on host <peer>** — with a LIVE ssh probe deciding the status — and the
+gc reaper's ``remote=0`` guard never tombstones it locally.
+
+No-mocks, per the repo's STX-TQ rules:
+
+* real on-disk ``state.db`` via the ``isolated_state_db`` fixture (env override +
+  module reload — the exact pattern the ``_stale_lease`` / lifecycle suites use),
+* all ``instances`` state through the real ``record_instance_start`` /
+  ``record_instance_stop`` / ``gc_dead_instances``,
+* a real empty ``Registry(tmp_path)``,
+* the cross-host probe driven by an injected ``run_ssh`` / ``status_probe``
+  (real rc-returning / status-returning callables — never a shell-out, never a
+  ``MagicMock``),
+* real ``spec.yaml`` files exercised by the real ``load_config`` for labels.
+
+One logical assertion per test (STX-TQ007); AAA markers throughout.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+import pytest
+
+import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+from scitex_agent_container._state.registry import Registry
+from scitex_agent_container.cli_pkg._helpers._agent_list import (
+    get_agent_list_data,
+    remote_instance_rows,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures + seams (copied from the sibling suites — real callables, no mocks).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_state_db(tmp_path: Path) -> Iterator[Path]:
+    """Per-test on-disk state.db, exported via env (explicit save/restore).
+
+    ``state_db`` reads ``SCITEX_AGENT_CONTAINER_STATE_DB`` at import into a
+    module-level ``DEFAULT_DB_PATH``; reload it after setting the env so the
+    ``instances`` writes land in the temp DB, not the developer's real
+    ``~/.scitex`` tree. Mirrors ``_lifecycle/test__stale_lease.py``.
+    """
+    p = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(p)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield p
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+@contextmanager
+def _swap_discover(
+    impl: Callable[[], list[tuple[str, Path]]],
+) -> Iterator[None]:
+    """Swap ``_al._discover_defined_agents`` for a real callable."""
+    saved = _al._discover_defined_agents
+    _al._discover_defined_agents = impl  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _al._discover_defined_agents = saved  # type: ignore[assignment]
+
+
+@contextmanager
+def _swap_probe(impl: Callable[[Any], bool | None]) -> Iterator[None]:
+    """Swap the LOCAL liveness probe (both module + parent-package re-export)."""
+    import scitex_agent_container.cli_pkg._helpers as _pkg
+
+    saved_al = _al._probe_local
+    saved_pkg = getattr(_pkg, "_probe_local", None)
+    _al._probe_local = impl  # type: ignore[assignment]
+    _pkg._probe_local = impl  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _al._probe_local = saved_al  # type: ignore[assignment]
+        if saved_pkg is None:
+            delattr(_pkg, "_probe_local")
+        else:
+            _pkg._probe_local = saved_pkg  # type: ignore[assignment]
+
+
+def _no_discover() -> list[tuple[str, Path]]:
+    """Return [] — no on-disk agents interfere with the instances-row merge."""
+    return []
+
+
+def _write_valid_spec(dir_: Path, *, machine: str | None = None) -> Path:
+    """Write a minimal real v3 spec.yaml (optionally with a machine label)."""
+    dir_.mkdir(parents=True, exist_ok=True)
+    spec = dir_ / "spec.yaml"
+    lines = ["apiVersion: scitex-agent-container/v3", "kind: Agent"]
+    if machine is not None:
+        lines += ["metadata:", "  labels:", f'    machine: "{machine}"']
+    else:
+        lines.append("metadata: {}")
+    lines += [
+        "spec:",
+        "  runtime: apptainer",
+        "  host: ${HOSTNAME}",
+        "  workdir: /home/agent/work",
+        "  apptainer:",
+        "    image: /x.sif",
+        "    binds: []",
+        "  claude:",
+        "    model: sonnet",
+        "  health:",
+        "    enabled: true",
+        "    interval: 60",
+        "  restart:",
+        "    policy: on-failure",
+        "    max_retries: 3",
+    ]
+    spec.write_text("\n".join(lines) + "\n")
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# Drive helpers — real record_instance_start + the two entry points.
+# ---------------------------------------------------------------------------
+
+
+def _record_remote(
+    name: str = "spartan-dev", host: str = "spartan", a2a: int = 8123
+) -> str:
+    """Record a cross-host (remote=1) active instances row; return its id."""
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    return record_instance_start(name=name, host=host, a2a_port=a2a, remote=True)
+
+
+def _list_rows(
+    tmp_path: Path,
+    *,
+    run_ssh: Callable[[list[str]], int] = lambda argv: 0,
+    discover: Callable[[], list[tuple[str, Path]]] = _no_discover,
+    registry: Registry | None = None,
+    **kw: Any,
+) -> list[dict]:
+    """Drive ``get_agent_list_data`` with an injected (never-shell-out) ssh
+    probe. ``run_ssh`` default returns rc 0 (ALIVE -> running)."""
+    reg = registry or Registry(registry_dir=tmp_path / "reg")
+    with _swap_discover(discover):
+        return get_agent_list_data(reg, remote_run_ssh=run_ssh, **kw)
+
+
+def _remote_rows_direct(
+    *,
+    run_ssh: Callable[[list[str]], int],
+    discover: Callable[[], list[tuple[str, Path]]] = _no_discover,
+) -> list[dict]:
+    """Drive ``remote_instance_rows`` straight (real instances oracle)."""
+    with _swap_discover(discover):
+        return remote_instance_rows(
+            registered=set(),
+            display_host="master-host",
+            port_claims={},
+            run_ssh=run_ssh,
+        )
+
+
+def _spartan_row(rows: list[dict]) -> dict:
+    return next(r for r in rows if r["name"] == "spartan-dev")
+
+
+# ---------------------------------------------------------------------------
+# 1. A remote-dispatched agent surfaces as running-on-peer (probe ALIVE).
+# ---------------------------------------------------------------------------
+
+
+def test_remote_dispatched_agent_surfaces_exactly_once(isolated_state_db, tmp_path):
+    # Arrange
+    _record_remote()
+    # Act
+    rows = _list_rows(tmp_path)
+    # Assert — surfaces AND is not duplicated as a defined/local row.
+    assert [r["name"] for r in rows].count("spartan-dev") == 1
+
+
+def test_remote_row_status_is_running_when_probe_alive(isolated_state_db, tmp_path):
+    # Arrange
+    _record_remote()
+    # Act — rc 0 == tmux session up on the peer == ALIVE.
+    rows = _list_rows(tmp_path, run_ssh=lambda argv: 0)
+    # Assert
+    assert _spartan_row(rows)["status"] == "running"
+
+
+def test_remote_row_reports_the_peer_host(isolated_state_db, tmp_path):
+    # Arrange
+    _record_remote()
+    # Act
+    rows = _list_rows(tmp_path)
+    # Assert
+    assert _spartan_row(rows)["host"] == "spartan"
+
+
+def test_remote_row_host_display_is_the_peer(isolated_state_db, tmp_path):
+    # Arrange
+    _record_remote()
+    # Act
+    rows = _list_rows(tmp_path)
+    # Assert — a concrete peer host passes through the display mapping unchanged.
+    assert _spartan_row(rows)["host_display"] == "spartan"
+
+
+def test_remote_row_carries_the_bound_a2a_port(isolated_state_db, tmp_path):
+    # Arrange
+    _record_remote(a2a=8123)
+    # Act
+    rows = _list_rows(tmp_path)
+    # Assert
+    assert _spartan_row(rows)["a2a_port"] == 8123
+
+
+def test_remote_row_is_flagged_remote(isolated_state_db, tmp_path):
+    # Arrange
+    _record_remote()
+    # Act
+    rows = _list_rows(tmp_path)
+    # Assert
+    assert _spartan_row(rows)["remote"] is True
+
+
+def test_remote_row_is_not_emitted_as_defined_local(isolated_state_db, tmp_path):
+    # Arrange
+    _record_remote()
+    # Act
+    rows = _list_rows(tmp_path)
+    # Assert — the only row for the name is the remote one (host != "local").
+    matching = [r for r in rows if r["name"] == "spartan-dev"]
+    assert len(matching) == 1 and matching[0]["host"] == "spartan"
+
+
+# ---------------------------------------------------------------------------
+# 2. LIVE probe verdict -> status (via remote_process_signal + injected run_ssh).
+# ---------------------------------------------------------------------------
+
+
+def test_remote_probe_dead_maps_to_stopped(isolated_state_db):
+    # Arrange — rc 1 == ssh connected, peer tmux has NO session == DEAD.
+    _record_remote()
+    # Act
+    rows = _remote_rows_direct(run_ssh=lambda argv: 1)
+    # Assert
+    assert _spartan_row(rows)["status"] == "stopped"
+
+
+def test_remote_probe_unknown_maps_to_running(isolated_state_db):
+    # Arrange — rc 255 == wedged/auth/bare-PATH ssh == UNKNOWN (never hide).
+    _record_remote()
+    # Act
+    rows = _remote_rows_direct(run_ssh=lambda argv: 255)
+    # Assert
+    assert _spartan_row(rows)["status"] == "running"
+
+
+# ---------------------------------------------------------------------------
+# 3. Precedence: a LOCAL registry row wins over the remote instances row.
+# ---------------------------------------------------------------------------
+
+
+def test_local_registry_row_wins_over_remote_instance(isolated_state_db, tmp_path):
+    # Arrange — same name registered locally AND active as a remote instance.
+    spec = _write_valid_spec(tmp_path / "spartan-dev")
+    registry = Registry(registry_dir=tmp_path / "reg")
+    registry.add("spartan-dev", str(spec), "tui-spartan-dev")
+    _record_remote()
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        rows = get_agent_list_data(registry, remote_run_ssh=lambda argv: 0)
+    # Assert — one row, and it is the local one.
+    matching = [r for r in rows if r["name"] == "spartan-dev"]
+    assert len(matching) == 1 and matching[0]["host"] == "local"
+
+
+# ---------------------------------------------------------------------------
+# 4. A tombstoned (stopped) remote row disappears from the list.
+# ---------------------------------------------------------------------------
+
+
+def test_tombstoned_remote_row_disappears(isolated_state_db, tmp_path):
+    # Arrange
+    from scitex_agent_container._state.state_db import record_instance_stop
+
+    instance_id = _record_remote()
+    record_instance_stop(instance_id)
+    # Act
+    rows = _list_rows(tmp_path)
+    # Assert
+    assert [r for r in rows if r["name"] == "spartan-dev"] == []
+
+
+# ---------------------------------------------------------------------------
+# 5. The gc reaper never tombstones a remote row (the remote=0 guard).
+# ---------------------------------------------------------------------------
+
+
+def test_reaper_leaves_remote_row_active(isolated_state_db):
+    # Arrange
+    from scitex_agent_container._state.state_db import (
+        gc_dead_instances,
+        list_active_instances,
+    )
+
+    _record_remote()
+    # Act — a full sweep must not touch the cross-host row.
+    gc_dead_instances(dry_run=False)
+    # Assert
+    active = [r for r in list_active_instances(host=None) if r["name"] == "spartan-dev"]
+    assert len(active) == 1
+
+
+def test_reaper_remote_guard_keeps_row_with_forced_stale_heartbeat(isolated_state_db):
+    # Arrange — force a long-stale last_heartbeat_at onto the remote row; only
+    # the ``AND remote=0`` guard keeps the heartbeat sweep from reaping it.
+    from scitex_agent_container._state.state_db import (
+        gc_dead_instances,
+        list_active_instances,
+        open_db,
+    )
+
+    instance_id = _record_remote()
+    with open_db() as conn:
+        conn.execute(
+            "UPDATE instances SET last_heartbeat_at=? WHERE id=?",
+            ("2000-01-01T00:00:00Z", instance_id),
+        )
+    # Act — a 1s staleness cutoff would trip the sweep but for the guard.
+    gc_dead_instances(dry_run=False, heartbeat_stale_seconds=1)
+    # Assert
+    active = [r for r in list_active_instances(host=None) if r["name"] == "spartan-dev"]
+    assert len(active) == 1
+
+
+# ---------------------------------------------------------------------------
+# 6. The default RUNNING-ONLY view retains a running remote row.
+# ---------------------------------------------------------------------------
+
+
+def test_running_only_view_retains_running_remote_row(isolated_state_db, tmp_path):
+    # Arrange
+    _record_remote()
+    # Act
+    rows = _list_rows(tmp_path, running_only=True, run_ssh=lambda argv: 0)
+    # Assert
+    matching = [r for r in rows if r["name"] == "spartan-dev"]
+    assert len(matching) == 1 and matching[0]["status"] == "running"
+
+
+# ---------------------------------------------------------------------------
+# 7. Label filters (machine) include / exclude the remote row correctly.
+# ---------------------------------------------------------------------------
+
+
+def test_machine_label_includes_matching_remote_row(isolated_state_db, tmp_path):
+    # Arrange — spec on disk carries machine="spartan"; the instances row is remote.
+    spec = _write_valid_spec(tmp_path / "spartan-dev", machine="spartan")
+    _record_remote()
+
+    def _disc() -> list[tuple[str, Path]]:
+        return [("spartan-dev", spec)]
+
+    # Act
+    rows = _list_rows(tmp_path, machine="spartan", discover=_disc)
+    # Assert
+    assert any(r["name"] == "spartan-dev" and r.get("remote") for r in rows)
+
+
+def test_machine_label_excludes_non_matching_remote_row(isolated_state_db, tmp_path):
+    # Arrange
+    spec = _write_valid_spec(tmp_path / "spartan-dev", machine="spartan")
+    _record_remote()
+
+    def _disc() -> list[tuple[str, Path]]:
+        return [("spartan-dev", spec)]
+
+    # Act
+    rows = _list_rows(tmp_path, machine="nuc", discover=_disc)
+    # Assert
+    assert [r for r in rows if r["name"] == "spartan-dev"] == []


### PR DESCRIPTION
## Problem

On the master (ywata-note-win), a remote-dispatched agent (spec `host: spartan`,
e.g. `spartan-dev`) showed up in `sac agents list` as **`defined` / `local`** —
not as running on its peer. The master **already records** the truth on dispatch
(`_dispatch.try_dispatch_remote` writes an `instances` row `host=<peer>`,
`remote=1`, `pid=NULL`) and **already tombstones** it on stop (`_stop` →
`record_instance_stop`). The only missing half was the **READ side**:
`get_agent_list_data` read the JSON `Registry` (local-only, no host field) and the
on-disk spec walk, but **never the `instances` table** — so the recorded remote
placement was invisible.

## Change (master-authoritative — operator decision A; peer registries untouched)

- **A. `remote_instance_rows` builder** (`_agent_list_discover.py`) — reads active
  `remote=1` instances rows (keyed on the authoritative `remote` flag, not a
  hostname compare) and emits one `host=<peer>` row per remote agent. Mirrors
  `defined_agent_rows` shape (never-checked auth via `verdict_for(None)`, empty
  movement trio) so the `--json` row shape stays uniform.
- **B. LIVE status (not a trusted stale row)** — each remote row's status comes
  from an ssh probe of the peer's own tmux via the already-deployed
  `_verdict_resolve.remote_process_signal`, mapped **ALIVE→running, DEAD→stopped,
  UNKNOWN→running** (never hide a live peer on an ssh hiccup — this module's
  doctrine). So an agent that died on a login-node reboot reads `stopped`, not a
  comforting `running`. Probes run through a bounded `ThreadPoolExecutor` with a
  per-future timeout (self-contained — the local probe pass keys on a different
  probe signature/row source, so a shared pass didn't integrate cleanly). Both
  `status_probe=` and the underlying `run_ssh=` are injection seams so tests never
  shell out.
- **C. Wired into `get_agent_list_data`** after the Registry rows, before the
  defined-on-disk merge. Precedence: **local Registry row > remote instance row >
  defined-on-disk row** (the union of covered names is fed into
  `defined_agent_rows` so a remote agent is not also emitted as a defined/local
  row). Two forwarding seam params (`remote_status_probe` / `remote_run_ssh`),
  default `None` → production ssh probe.
- **D. Reaper defense-in-depth** (`state_db_gc.py`) — the gc heartbeat sweep was
  the ONE branch not host-filtered. Added `AND remote=0` to its predicate, so
  "cross-host instances are never swept" holds **by construction** across all
  three branches (reboot + pid are already `host=<self>`-scoped). A master remote
  row was safe today only because its `last_heartbeat_at` is NULL; this closes the
  latent hazard the instant a heartbeat is ever written.

**Not touched** (already correct): the dispatch write, the stop tombstone, the
singleton-skip logic, and the JSON `Registry` (remote agents are read-merged from
`instances` only — never written into the `Registry`, whose `cleanup_stale`
probes LOCAL tmux and would delete them).

## Tests (no mocks — real state.db, real seams)

16 new tests in `test__agent_list_remote.py` (real `isolated_state_db` fixture +
`record_instance_start`/`record_instance_stop` + `gc_dead_instances`, real empty
`Registry(tmp_path)`, injected `run_ssh`/`status_probe`; AAA markers, one logical
assert each) covering all 7 scenarios: remote row surfaces on-peer, DEAD→stopped /
UNKNOWN→running probe mapping, local precedence, tombstone disappears, reaper
leaves the row (plus a variant with a forced stale heartbeat proving the
`remote=0` guard), running-only default view, and machine-label include/exclude.

```
215 passed in 28.79s   # new file + test__agent_list.py + state_db + state_db_instances + instances_pid gc
 47 passed in  3.89s   # test__agent_list_{perf,movement,host_display,auth}
```

The `remote=0` guard was empirically confirmed non-vacuous: on a real temp db, the
OLD heartbeat-sweep predicate selects the stale-heartbeat remote row (would sweep
it) while the NEW `AND remote=0` predicate selects 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
