### PR TITLE
feat(list): multihop remote probe + honest UNKNOWN + spec-derived account

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_verdict_resolve.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict_resolve.py
@@ -359,49 +359,59 @@ def remote_process_signal(
     vanishes from cross-host ``sac agents list``. This ssh-probes the peer's
     own tmux bookkeeping for the agent's session instead.
 
+    The argv is rendered by :func:`.._state.host_config.build_ssh_argv` — sac's
+    ONE canonical dispatch primitive — never a hand-rolled ssh line. That is
+    what makes a two-tier HPC target work: ``build_ssh_argv`` applies the peer's
+    ``via:`` ProxyJump chain (``-J``), glob-matches ``spartan-bm043`` onto a
+    ``spartan*`` pattern peer, and wraps the command in that peer's
+    ``env_preamble`` via ``bash -c`` (NOT ``-lc``: a login shell trips the
+    profile's interactive-tmux and false-DEADs a live agent — #709). Hand-rolling
+    it skipped the hop, so every ``spartan-bmNNN`` agent probed UNKNOWN and
+    rendered stale. The ``preamble && tmux has-session`` chain keeps rc 1 for
+    "no session" (a real DEAD); a preamble/hop failure is some other non-0/1 rc,
+    read below as UNKNOWN.
+
     Verdicts (:data:`INSTRUMENT_HOST_TMUX` — the peer's tmux, a real
     independent bookkeeper, exactly as in the local case):
 
     * ssh connected + session present (rc 0) -> :data:`ALIVE`.
     * ssh connected + no session (rc 1)      -> :data:`DEAD` (positive remote
       absence, from the peer's own ``tmux has-session``).
-    * ssh could not run / any other rc       -> :data:`UNKNOWN`. A probe that
-      could not run is NEVER DEAD (this module's core doctrine); a wedged ssh,
-      a bare login PATH, or an auth failure must not slander a live remote
-      agent into a destroyable corpse.
+    * ssh could not run / any other rc, OR the peer is not resolvable (no
+      config / unknown peer / glob-miss, so ``build_ssh_argv`` raises)
+      -> :data:`UNKNOWN`. A probe that could not run is NEVER DEAD (this
+      module's core doctrine); a wedged ssh, a broken ProxyJump, a bare login
+      PATH, or an auth failure must not slander a live remote agent into a
+      destroyable corpse.
 
     ``run_ssh`` is the injection seam (a real callable returning the exit
     code); production uses :func:`_run_ssh_rc`.
     """
     session = session_name_for_config(config)
-    ssh_target = peer
+
+    # Render the probe argv through sac's canonical dispatch primitive so the
+    # peer's ProxyJump chain + env_preamble apply (see docstring). A load/build
+    # failure (no config, unknown / glob-missed peer) is "I could not look" ->
+    # UNKNOWN, never a false DEAD. ``-n`` so ssh never eats our stdin.
     try:
+        from .._state.host_config import build_ssh_argv
         from .._state.host_config import load as _load_host_config
 
-        spec = _load_host_config().peers.get(peer)
-        if spec is not None and getattr(spec, "ssh", None):
-            ssh_target = spec.ssh
+        peers = _load_host_config().peers
+        argv = build_ssh_argv(
+            peer, ["tmux", "has-session", "-t", session], peers, extra_opts=["-n"]
+        )
     except (
         Exception
-    ):  # stx-allow: fallback (peer without an ssh alias -> use the peer name verbatim)
-        pass
+    ) as exc:  # stx-allow: fallback (unresolvable peer -> UNKNOWN, never DEAD)
+        return Signal(
+            SOURCE_PROCESS,
+            UNKNOWN,
+            f"could not build an ssh probe for peer {peer!r} "
+            f"({type(exc).__name__}) — unresolvable peer is UNKNOWN, never DEAD",
+            INSTRUMENT_HOST_TMUX,
+        )
 
-    # tmux is on the peer's non-login PATH; a login shell (bash -lc) triggers the
-    # profile's interactive-tmux and fails with "open terminal failed: not a
-    # terminal" -> false DEAD. -n so ssh never consumes our stdin.
-    argv = [
-        "ssh",
-        "-n",
-        "-o",
-        "BatchMode=yes",
-        "-o",
-        "ConnectTimeout=6",
-        ssh_target,
-        "tmux",
-        "has-session",
-        "-t",
-        session,
-    ]
     try:
         rc = (run_ssh or _run_ssh_rc)(argv)
     except (
@@ -432,8 +442,9 @@ def remote_process_signal(
     return Signal(
         SOURCE_PROCESS,
         UNKNOWN,
-        f"ssh probe of {peer!r} returned rc={rc} (not 0/1: wedged ssh, bare "
-        f"PATH, or auth) — remote liveness UNKNOWN, never DEAD",
+        f"ssh probe of {peer!r} returned rc={rc} (not 0/1: wedged ssh, a "
+        f"failed ProxyJump/env_preamble, bare PATH, or auth) — remote liveness "
+        f"UNKNOWN, never DEAD",
         INSTRUMENT_HOST_TMUX,
     )
 

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
@@ -205,7 +205,8 @@ def _load_or_synthesize_config(spec_path: Path | None, name: str) -> Any:
     ssh-dispatched it), so ``load_config`` normally succeeds; the synthesize
     fallback keeps the probe working — never silently skipped — even if the
     spec is momentarily unreadable. Returns ``None`` only if even a bare
-    config cannot be built (so the caller degrades to "never hide").
+    config cannot be built (so the caller degrades to "unknown" — hidden from
+    the default view but counted in the footer, never a false "running").
     """
     from ...config import load_config
 
@@ -217,7 +218,8 @@ def _load_or_synthesize_config(spec_path: Path | None, name: str) -> Any:
         except Exception:  # stx-allow: fallback (reason: see inline comment)
             pass
     # stx-allow: fallback (a bare AgentConfig should always build; if it cannot,
-    # the caller maps None -> "running" so a live peer is never hidden)
+    # the caller maps None -> "unknown" so a probe that could not run is hidden
+    # from the default view + counted in the footer, never a false "running")
     try:
         from ...config._types import AgentConfig
 
@@ -236,11 +238,15 @@ def _default_remote_status_probe(
     ALREADY-deployed :func:`_lifecycle._verdict_resolve.remote_process_signal`
     (ssh ``tmux has-session`` on the peer) and maps its TERNARY verdict:
 
-        ALIVE -> "running", DEAD -> "stopped", UNKNOWN -> "running".
+        ALIVE -> "running", DEAD -> "stopped", UNKNOWN -> "unknown".
 
-    UNKNOWN maps to "running" on purpose: a wedged ssh / bare-PATH / auth
-    hiccup must NEVER hide a live remote peer — that module's core doctrine.
-    Only a POSITIVE remote absence (the peer's own ``tmux has-session`` rc=1)
+    UNKNOWN maps to "unknown" — hidden from the default view but COUNTED in the
+    footer and shown in ``-v`` (the render layer's non-live handling). A wedged
+    ssh / bare-PATH / auth / ProxyJump hiccup did not OBSERVE the peer, so it
+    must not masquerade as "running" — the ~17 stale ``spartan-bmNNN`` rows that
+    rendered as a comforting green were exactly this lie. "Never hide" always
+    meant "do not DELETE a live agent", not "report an un-probed one as up":
+    only a POSITIVE remote absence (the peer's own ``tmux has-session`` rc=1)
     reads "stopped". ``run_ssh`` is threaded straight into
     ``remote_process_signal`` so tests inject a real rc-returning callable and
     never shell out.
@@ -252,14 +258,15 @@ def _default_remote_status_probe(
 
         config = _load_or_synthesize_config(specs.get(name), name)
         if config is None:
-            return "running"
-        # stx-allow: fallback (a probe that blew up observed NOTHING — never
-        # render that as a death that would hide a live peer)
+            return "unknown"
+        # stx-allow: fallback (a probe that blew up observed NOTHING — "unknown"
+        # (hidden + footer-counted), never a false "running" that would slander
+        # an un-probed peer as up)
         try:
             signal = remote_process_signal(config, host, run_ssh=run_ssh)
         except Exception:  # stx-allow: fallback (reason: see inline comment)
-            return "running"
-        return {ALIVE: "running", DEAD: "stopped"}.get(signal.verdict, "running")
+            return "unknown"
+        return {ALIVE: "running", DEAD: "stopped"}.get(signal.verdict, "unknown")
 
     return _probe
 
@@ -275,9 +282,10 @@ def _probe_remote_statuses(
     Mirrors the local liveness pass in :func:`_agent_list.get_agent_list_data`:
     a dedicated ``ThreadPoolExecutor`` with a per-future timeout and
     ``shutdown(wait=False)`` so one wedged peer cannot serialize (or hang) the
-    whole ``sac agents list``. A timed-out / raised probe maps to "running" —
-    the never-hide default, since a probe that could not run is not evidence a
-    remote agent died.
+    whole ``sac agents list``. A timed-out / raised probe maps to "unknown" —
+    hidden from the default view but COUNTED in the footer: a probe that could
+    not run is not evidence a remote agent died, but neither is it evidence it
+    is running, so it must not render as a comforting green.
     """
     from concurrent.futures import ThreadPoolExecutor
     from concurrent.futures import TimeoutError as _FuturesTimeout
@@ -293,15 +301,16 @@ def _probe_remote_statuses(
         }
         for future in list(future_to_name):
             name = future_to_name[future]
-            # stx-allow: fallback (a per-probe timeout/exception is "unknown",
-            # which for a remote row means keep it visible as running)
+            # stx-allow: fallback (a per-probe timeout/exception is "unknown" —
+            # hidden from the default view + counted in the footer; a probe that
+            # could not run must not masquerade as a running remote row)
             try:
                 statuses[name] = future.result(timeout=probe_timeout_s)
             except _FuturesTimeout:  # stx-allow: fallback (reason: see inline comment)
-                statuses[name] = "running"
+                statuses[name] = "unknown"
                 future.cancel()
             except Exception:  # stx-allow: fallback (reason: see inline comment)
-                statuses[name] = "running"
+                statuses[name] = "unknown"
     finally:
         pool.shutdown(wait=False)
     return statuses
@@ -342,10 +351,18 @@ def remote_instance_rows(
     STATUS IS LIVE, never a trusted stale row: each remote row's status comes
     from an ssh probe of the peer's own tmux (see
     :func:`_default_remote_status_probe`), so an agent that died on a
-    login-node reboot reads ``stopped`` rather than a comforting ``running``.
-    Probes run through a bounded pool (:func:`_probe_remote_statuses`) to keep
-    list latency bounded. Both the ``status_probe`` and the underlying
-    ``run_ssh`` are injection seams so tests never shell out.
+    login-node reboot reads ``stopped`` rather than a comforting ``running`` —
+    and a peer the probe could NOT reach (wedged ssh, a broken ProxyJump to a
+    compute node, auth) reads ``unknown`` (hidden from the default view but
+    counted in the footer), NOT a false ``running``. Probes run through a
+    bounded pool (:func:`_probe_remote_statuses`) to keep list latency bounded.
+    Both the ``status_probe`` and the underlying ``run_ssh`` are injection seams
+    so tests never shell out.
+
+    The Account column is derived from the agent's on-disk spec (which lives on
+    the master's disk — that is how it was dispatched) via
+    :func:`_safe_account_for`, exactly like :func:`defined_agent_rows`, so a
+    remote row no longer shows a bare ``—``.
 
     These agents are never locally LIVE, so — exactly like
     :func:`defined_agent_rows` — they carry the never-checked auth shape
@@ -420,17 +437,35 @@ def remote_instance_rows(
     for cand in candidates:
         name = cand["name"]
         host = cand["host"]
+        spec_path = cand["spec_path"]
+        # Account from the on-disk spec — the SAME spec-derived label
+        # ``defined_agent_rows`` uses. The remote agent's spec DOES live on the
+        # master's disk (that is how it was ssh-dispatched), so this kills the
+        # bare "—" the Account column showed for every remote row. (This is the
+        # spec-derived label, NOT the exact runtime pool pick — that accurate
+        # value needs a DB column and is a separate follow-up.) Best-effort: an
+        # unreadable spec yields "" so the list never crashes on it.
+        account = ""
+        if spec_path is not None:
+            # stx-allow: fallback (a broken/unreadable spec must not crash the
+            # list; "" is the honest empty, exactly as before this change)
+            try:
+                account = _al._safe_account_for(load_config(str(spec_path)))
+            except Exception:  # stx-allow: fallback (reason: see inline comment)
+                account = ""
         row: dict = {
             "name": name,
-            "status": statuses.get(name, "running"),
+            # A probe that could not OBSERVE the peer is "unknown" (hidden from
+            # the default view, counted in the footer), never a false "running".
+            "status": statuses.get(name, "unknown"),
             "screen": "-",
             "multiplexer": None,
             "started_at": cand["started_at"],
             "host": host,
             "host_display": _al._host_display_for(host, display_host),
-            "path": str(cand["spec_path"] or ""),
+            "path": str(spec_path or ""),
             "a2a_port": cand["a2a_port"],
-            "account": "",
+            "account": account,
             "remote": True,
         }
         row.update(dict(_al._MOVEMENT_DEFAULTS))

--- a/tests/scitex_agent_container/_lifecycle/test__verdict_resolve.py
+++ b/tests/scitex_agent_container/_lifecycle/test__verdict_resolve.py
@@ -393,11 +393,55 @@ def test_registry_signal_is_sourced_as_registry():
 # remote_process_signal — control-plane cross-host liveness. ssh is INJECTED
 # (a real callable returning rc). Same doctrine: a probe that could not run
 # is UNKNOWN, never DEAD — so a wedged ssh cannot slander a live remote agent.
+#
+# The argv is rendered by the REAL ``build_ssh_argv`` off a REAL ``PeersMap``
+# parsed from a REAL temp config.yaml (``spartan_config`` — no mock), pinned via
+# the documented ``SCITEX_AGENT_CONTAINER_CONFIG`` override. That is what lets a
+# two-tier HPC target (a ``spartan-bmNNN`` compute node reachable ONLY via the
+# ``spartan`` login node) probe at all — the follow-on to #710.
 # --------------------------------------------------------------------------
 
 
-def test_remote_process_signal_rc0_session_present_is_alive():
-    # Arrange
+@pytest.fixture
+def spartan_config(tmp_path):
+    """A REAL temp sac config.yaml the remote probe loads through the real
+    ``host_config.load()`` (glob matching + ``build_ssh_argv`` all real):
+
+      * ``spartan``  — the login-node peer (DIRECT, no ProxyJump).
+      * ``spartan*`` — the compute-node GLOB peer whose ssh target is the queried
+        node name, reachable only ``via: [spartan]`` and gated behind an
+        ``env_preamble`` (Lmod) — the exact two-tier HPC shape.
+
+    Exported via env (explicit save/restore, no ``monkeypatch``): the documented
+    ``SCITEX_AGENT_CONTAINER_CONFIG`` override points ``load()`` at this file,
+    and ``SAC_SSH_CONTROL_MASTER=0`` opts out of ControlMaster so the rendered
+    argv is deterministic (no scratch-dir-dependent ``-o ControlPath`` triple).
+    """
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "peers:\n"
+        "  spartan: { ssh: ywatanabe@spartan-login }\n"
+        '  "spartan*": { via: [spartan], env_preamble: "source /lmod/init'
+        ' && module load apptainer" }\n'
+    )
+    env = {
+        "SCITEX_AGENT_CONTAINER_CONFIG": str(cfg),
+        "SAC_SSH_CONTROL_MASTER": "0",
+    }
+    saved = {k: os.environ.get(k) for k in env}
+    os.environ.update(env)
+    try:
+        yield cfg
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def test_remote_process_signal_rc0_session_present_is_alive(spartan_config):
+    # Arrange — spartan-dev lives on the login node (a DIRECT peer).
     cfg = _Cfg("spartan-dev", "tui")
     # Act
     signal = remote_process_signal(cfg, "spartan", run_ssh=lambda _argv: 0)
@@ -405,7 +449,7 @@ def test_remote_process_signal_rc0_session_present_is_alive():
     assert signal.verdict == ALIVE
 
 
-def test_remote_process_signal_rc1_no_remote_session_is_dead():
+def test_remote_process_signal_rc1_no_remote_session_is_dead(spartan_config):
     # Arrange
     cfg = _Cfg("spartan-dev", "tui")
     # Act
@@ -414,7 +458,9 @@ def test_remote_process_signal_rc1_no_remote_session_is_dead():
     assert signal.verdict == DEAD
 
 
-def test_remote_process_signal_ssh_connect_failure_is_unknown_never_dead():
+def test_remote_process_signal_ssh_connect_failure_is_unknown_never_dead(
+    spartan_config,
+):
     # Arrange — rc 255 is ssh's own connection-failed code.
     cfg = _Cfg("spartan-dev", "tui")
     # Act
@@ -423,7 +469,7 @@ def test_remote_process_signal_ssh_connect_failure_is_unknown_never_dead():
     assert signal.verdict == UNKNOWN
 
 
-def test_remote_process_signal_run_ssh_raising_is_unknown_never_dead():
+def test_remote_process_signal_run_ssh_raising_is_unknown_never_dead(spartan_config):
     # Arrange
     cfg = _Cfg("spartan-dev", "tui")
 
@@ -436,12 +482,59 @@ def test_remote_process_signal_run_ssh_raising_is_unknown_never_dead():
     assert signal.verdict == UNKNOWN
 
 
+def test_remote_process_signal_unknown_peer_is_unknown_never_dead(spartan_config):
+    """A peer that is neither a config entry nor a ``spartan*`` glob match cannot
+    be rendered into an argv (``build_ssh_argv`` raises ``KeyError``); that is
+    "I could not even look" -> UNKNOWN, never a false DEAD. ``run_ssh`` returning
+    0 is irrelevant — it is never reached."""
+    # Arrange
+    cfg = _Cfg("mystery", "tui")
+    # Act — rc 0 would be ALIVE if the argv had built; it does not.
+    signal = remote_process_signal(cfg, "nuc-not-in-config", run_ssh=lambda _argv: 0)
+    # Assert
+    assert signal.verdict == UNKNOWN
+
+
+# --- Part 2: the ProxyJump multihop path (compute node via login node) --------
+
+
+def test_remote_process_signal_multihop_rc0_session_present_is_alive(spartan_config):
+    # Arrange — spartan-bm043 glob-matches spartan*, reached via the login node.
+    cfg = _Cfg("proj-x", "tui")
+    # Act
+    signal = remote_process_signal(cfg, "spartan-bm043", run_ssh=lambda _argv: 0)
+    # Assert
+    assert signal.verdict == ALIVE
+
+
+def test_remote_process_signal_multihop_rc1_no_session_is_dead(spartan_config):
+    """The ``preamble && tmux has-session`` chain preserves tmux's rc 1 through
+    ``bash -c`` for a genuinely-absent session -> DEAD."""
+    # Arrange
+    cfg = _Cfg("proj-x", "tui")
+    # Act
+    signal = remote_process_signal(cfg, "spartan-bm043", run_ssh=lambda _argv: 1)
+    # Assert
+    assert signal.verdict == DEAD
+
+
+def test_remote_process_signal_multihop_rc255_is_unknown_never_dead(spartan_config):
+    # Arrange — a wedged hop / failed ProxyJump is a non-0/1 rc.
+    cfg = _Cfg("proj-x", "tui")
+    # Act
+    signal = remote_process_signal(cfg, "spartan-bm043", run_ssh=lambda _argv: 255)
+    # Assert
+    assert signal.verdict == UNKNOWN
+
+
 # --------------------------------------------------------------------------
 # The argv the remote probe hands to ssh — captured via the injected run_ssh
-# (a real recording callable, no mock). A login shell (`bash -lc`) is the bug:
-# on Spartan it triggers the profile's interactive-tmux, which prints
-# "open terminal failed: not a terminal" and exits rc 1 — a LIVE remote agent
-# misread as DEAD. tmux is on the peer's non-login PATH, so we call it directly.
+# (a real recording callable, no mock), rendered by the REAL ``build_ssh_argv``
+# off the ``spartan_config`` PeersMap. A login shell (`bash -lc`) is the bug: on
+# Spartan it triggers the profile's interactive-tmux, which prints "open
+# terminal failed: not a terminal" and exits rc 1 — a LIVE remote agent misread
+# as DEAD. A DIRECT peer runs tmux without any wrapper; a preamble peer wraps it
+# in ``bash -c`` (deliberately ``-c``, NOT ``-lc``).
 # --------------------------------------------------------------------------
 
 
@@ -452,7 +545,8 @@ def _captured_remote_probe_argv(
 
     The ``run_ssh`` seam is a real callable; here it merely records the argv it
     is given and reports rc 0. No mock — this is the injection point the signal
-    is designed around.
+    is designed around. The caller must hold the ``spartan_config`` fixture so
+    the peer resolves through the real loader.
     """
     captured: list[list[str]] = []
 
@@ -464,7 +558,7 @@ def _captured_remote_probe_argv(
     return captured[0]
 
 
-def test_remote_process_signal_argv_uses_no_login_shell():
+def test_remote_process_signal_argv_uses_no_login_shell(spartan_config):
     """Regression (2026-07-16): the probe must NOT wrap tmux in a login shell.
 
     ``ssh <peer> bash -lc 'tmux has-session ...'`` runs the peer's login profile,
@@ -473,22 +567,22 @@ def test_remote_process_signal_argv_uses_no_login_shell():
     """
     # Arrange
     login_shell_tokens = {"bash", "-lc"}
-    # Act
+    # Act — a DIRECT peer (spartan): no wrapper at all.
     argv = _captured_remote_probe_argv()
     # Assert — no login shell: neither `bash` nor `-lc` in the built argv.
     assert not (login_shell_tokens & set(argv))
 
 
-def test_remote_process_signal_argv_probes_tmux_has_session_directly():
+def test_remote_process_signal_argv_probes_tmux_has_session_directly(spartan_config):
     # Arrange
     expected_tail = ["tmux", "has-session", "-t", "tui-spartan-dev"]
     # Act
     argv = _captured_remote_probe_argv()
-    # Assert — ssh runs `tmux has-session -t <session>` directly on the peer.
+    # Assert — a DIRECT peer runs `tmux has-session -t <session>` directly.
     assert argv[-4:] == expected_tail
 
 
-def test_remote_process_signal_argv_passes_ssh_dash_n():
+def test_remote_process_signal_argv_passes_ssh_dash_n(spartan_config):
     """``-n`` so ssh never consumes our stdin during a bulk `sac agents list`."""
     # Arrange
     required_flag = "-n"
@@ -496,3 +590,44 @@ def test_remote_process_signal_argv_passes_ssh_dash_n():
     argv = _captured_remote_probe_argv()
     # Assert
     assert required_flag in argv
+
+
+# --- Part 2: multihop argv (compute node via login node) + regression guard ---
+
+
+def test_remote_process_signal_direct_peer_argv_has_no_proxyjump(spartan_config):
+    """#710 regression guard: spartan-dev lives on the login node (host=spartan),
+    a DIRECT peer — its probe argv must carry NO ProxyJump (`-J`). Reusing
+    ``build_ssh_argv`` must not start hopping a login-node agent."""
+    # Arrange
+    direct_peer = "spartan"
+    # Act
+    argv = _captured_remote_probe_argv(peer=direct_peer, name="spartan-dev")
+    # Assert
+    assert "-J" not in argv
+
+
+def test_remote_process_signal_multihop_argv_uses_proxyjump_via_login(spartan_config):
+    """A ``spartan-bmNNN`` compute node is reachable ONLY through its login node,
+    so ``build_ssh_argv`` must emit ``-J <login-node ssh target>`` (from the
+    ``spartan*`` glob peer's ``via: [spartan]``)."""
+    # Arrange
+    compute_node = "spartan-bm043"
+    # Act
+    argv = _captured_remote_probe_argv(peer=compute_node, name="proj-x")
+    # Assert — `-J` is immediately followed by the login node's ssh target.
+    assert argv[argv.index("-J") + 1] == "ywatanabe@spartan-login"
+
+
+def test_remote_process_signal_multihop_argv_wraps_cmd_in_bash_c(spartan_config):
+    """The glob peer's ``env_preamble`` forces a single ``bash -c '<preamble> &&
+    tmux has-session ...'`` argv element (``-c``, NOT ``-lc``)."""
+    # Arrange
+    compute_node = "spartan-bm043"
+    # Act
+    argv = _captured_remote_probe_argv(peer=compute_node, name="proj-x")
+    # Assert — one collapsed element carrying the preamble + the tmux probe.
+    assert any(
+        el.startswith("bash -c ") and "tmux has-session -t tui-proj-x" in el
+        for el in argv
+    )

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_remote.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_remote.py
@@ -34,9 +34,13 @@ import pytest
 
 import scitex_agent_container.cli_pkg._helpers._agent_list as _al
 from scitex_agent_container._state.registry import Registry
+from scitex_agent_container.cli_pkg._helpers import is_live_status
 from scitex_agent_container.cli_pkg._helpers._agent_list import (
     get_agent_list_data,
     remote_instance_rows,
+)
+from scitex_agent_container.cli_pkg._helpers._agent_list_discover import (
+    _default_remote_status_probe,
 )
 
 # ---------------------------------------------------------------------------
@@ -68,6 +72,37 @@ def isolated_state_db(tmp_path: Path) -> Iterator[Path]:
         else:
             os.environ[key] = saved
         importlib.reload(mod)
+
+
+@pytest.fixture(autouse=True)
+def _pin_spartan_peer(tmp_path: Path) -> Iterator[None]:
+    """Pin a REAL temp sac config.yaml with a ``spartan`` login-node peer.
+
+    Part 2 routes the remote probe through ``build_ssh_argv``, which raises for
+    an UNKNOWN peer (→ UNKNOWN, never a false DEAD). Every remote row in this
+    suite lives on host ``spartan``; make it a real, resolvable peer via the
+    documented ``SCITEX_AGENT_CONTAINER_CONFIG`` override so the probe's
+    rc→status mapping is actually exercised (not short-circuited to UNKNOWN by
+    an unresolvable peer). Real config file + real loader — no mock; the env is
+    saved/restored explicitly (no ``monkeypatch``). ``SAC_SSH_CONTROL_MASTER=0``
+    keeps the rendered argv deterministic.
+    """
+    cfg = tmp_path / "sac-config.yaml"
+    cfg.write_text("peers:\n  spartan: { ssh: ywatanabe@spartan-login }\n")
+    env = {
+        "SCITEX_AGENT_CONTAINER_CONFIG": str(cfg),
+        "SAC_SSH_CONTROL_MASTER": "0",
+    }
+    saved = {k: os.environ.get(k) for k in env}
+    os.environ.update(env)
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
 
 
 @contextmanager
@@ -107,8 +142,15 @@ def _no_discover() -> list[tuple[str, Path]]:
     return []
 
 
-def _write_valid_spec(dir_: Path, *, machine: str | None = None) -> Path:
-    """Write a minimal real v3 spec.yaml (optionally with a machine label)."""
+def _write_valid_spec(
+    dir_: Path, *, machine: str | None = None, account: str | None = None
+) -> Path:
+    """Write a minimal real v3 spec.yaml.
+
+    ``machine`` adds a ``metadata.labels.machine`` label; ``account`` adds a
+    ``spec.claude.account`` pin (so ``_safe_account_for`` resolves a
+    deterministic, non-empty spec-derived label — Part 3).
+    """
     dir_.mkdir(parents=True, exist_ok=True)
     spec = dir_ / "spec.yaml"
     lines = ["apiVersion: scitex-agent-container/v3", "kind: Agent"]
@@ -126,6 +168,10 @@ def _write_valid_spec(dir_: Path, *, machine: str | None = None) -> Path:
         "    binds: []",
         "  claude:",
         "    model: sonnet",
+    ]
+    if account is not None:
+        lines.append(f"    account: {account}")
+    lines += [
         "  health:",
         "    enabled: true",
         "    interval: 60",
@@ -268,13 +314,14 @@ def test_remote_probe_dead_maps_to_stopped(isolated_state_db):
     assert _spartan_row(rows)["status"] == "stopped"
 
 
-def test_remote_probe_unknown_maps_to_running(isolated_state_db):
-    # Arrange — rc 255 == wedged/auth/bare-PATH ssh == UNKNOWN (never hide).
+def test_remote_probe_unknown_maps_to_unknown(isolated_state_db):
+    # Arrange — rc 255 == wedged/auth/bare-PATH/broken-ProxyJump ssh == UNKNOWN.
     _record_remote()
     # Act
     rows = _remote_rows_direct(run_ssh=lambda argv: 255)
-    # Assert
-    assert _spartan_row(rows)["status"] == "running"
+    # Assert — Part 1: an un-probed peer reads "unknown" (hidden from the default
+    # view but counted in the footer), NOT a comforting false "running".
+    assert _spartan_row(rows)["status"] == "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -401,3 +448,94 @@ def test_machine_label_excludes_non_matching_remote_row(isolated_state_db, tmp_p
     rows = _list_rows(tmp_path, machine="nuc", discover=_disc)
     # Assert
     assert [r for r in rows if r["name"] == "spartan-dev"] == []
+
+
+# ---------------------------------------------------------------------------
+# 8. Part 1 — the default ssh probe maps the ternary verdict to a status word,
+#    with UNKNOWN → "unknown" (NOT a false "running"). Driven straight through
+#    the real ``remote_process_signal`` via an injected rc-returning ``run_ssh``
+#    (the ``_pin_spartan_peer`` autouse fixture makes ``spartan`` resolvable).
+# ---------------------------------------------------------------------------
+
+
+def test_default_remote_status_probe_rc0_is_running():
+    # Arrange — rc 0 == the peer's tmux HAS the session == ALIVE.
+    probe = _default_remote_status_probe({}, run_ssh=lambda argv: 0)
+    # Act
+    status = probe("spartan-dev", "spartan")
+    # Assert
+    assert status == "running"
+
+
+def test_default_remote_status_probe_rc1_is_stopped():
+    # Arrange — rc 1 == ssh connected, peer tmux has NO session == DEAD.
+    probe = _default_remote_status_probe({}, run_ssh=lambda argv: 1)
+    # Act
+    status = probe("spartan-dev", "spartan")
+    # Assert
+    assert status == "stopped"
+
+
+def test_default_remote_status_probe_rc255_is_unknown():
+    # Arrange — rc 255 == wedged/auth ssh == UNKNOWN, NOT a false "running".
+    probe = _default_remote_status_probe({}, run_ssh=lambda argv: 255)
+    # Act
+    status = probe("spartan-dev", "spartan")
+    # Assert
+    assert status == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# 9. Part 1 — get_agent_list_data surfaces an UNKNOWN remote row as status
+#    "unknown": present in the full (-v/--json) data, but excluded by the
+#    render layer's own default-view filter (``is_live_status``).
+# ---------------------------------------------------------------------------
+
+
+def test_get_agent_list_data_remote_unknown_probe_status_is_unknown(
+    isolated_state_db, tmp_path
+):
+    # Arrange — an active remote row whose live probe cannot observe the peer.
+    _record_remote()
+    # Act — full data keeps every row (running_only defers enrichment, not rows).
+    rows = _list_rows(tmp_path, run_ssh=lambda argv: 255)
+    # Assert
+    assert _spartan_row(rows)["status"] == "unknown"
+
+
+def test_get_agent_list_data_remote_unknown_row_hidden_from_default_view(
+    isolated_state_db, tmp_path
+):
+    # Arrange — an active remote row whose live probe cannot observe the peer.
+    _record_remote()
+    # Act — the exact predicate print_agent_list applies for the default view.
+    rows = _list_rows(tmp_path, run_ssh=lambda argv: 255)
+    # Assert — "unknown" is not a live status, so the default view omits it.
+    visible = [r["name"] for r in rows if is_live_status(r.get("status"))]
+    assert "spartan-dev" not in visible
+
+
+# ---------------------------------------------------------------------------
+# 10. Part 3 — the remote row's Account is derived from the on-disk spec (the
+#     SAME spec-derived label ``defined_agent_rows`` uses), killing the bare
+#     "—". The remote agent's spec lives on the master's disk (that is how it
+#     was ssh-dispatched), so the label is available without a DB migration.
+# ---------------------------------------------------------------------------
+
+
+def test_remote_row_account_is_spec_derived(isolated_state_db, tmp_path):
+    # Arrange — a real spec carrying a claude.account pin; discover feeds it.
+    from scitex_agent_container.cli_pkg._helpers._agent_list import _safe_account_for
+    from scitex_agent_container.config import load_config
+
+    spec = _write_valid_spec(tmp_path / "spartan-dev", account="pool-acct-xyz")
+    _record_remote()
+
+    def _disc() -> list[tuple[str, Path]]:
+        return [("spartan-dev", spec)]
+
+    expected = _safe_account_for(load_config(str(spec)))
+    # Act
+    rows = _remote_rows_direct(run_ssh=lambda argv: 0, discover=_disc)
+    # Assert — same spec-derived label, and demonstrably non-empty (not "").
+    assert _spartan_row(rows)["account"] == expected != ""


### PR DESCRIPTION
Follow-on to #710, which read-merged remote `instances` rows into
`sac agents list` and live-probed them. That surfaced ~17 STALE rows
(proj-* on `spartan-bmNNN` compute nodes, May/June) rendering as
**"running"** with Account **"—"**. Three fixes ship here, one PR.

## Part 1 — UNKNOWN -> "unknown" (stop the false "running")
`_agent_list_discover.py`'s probe returned `"running"` for a verdict it
could NOT observe. Every such case now maps to `"unknown"`:
- `_default_remote_status_probe._probe`: verdict-map default, config-None
  degrade, and probe-raised degrade.
- `_probe_remote_statuses`: the `_FuturesTimeout` and generic-`except`
  pool fallbacks.
- `remote_instance_rows`: the row-build status default.

The render layer already **hides** `"unknown"` from the default view,
**counts** it in the footer, and **shows** it in `-v` — so render is
untouched. "Never hide" always meant *don't DELETE a live agent*, never
*report an un-probed one as up*.

## Part 2 — `remote_process_signal` reuses `build_ssh_argv` (ProxyJump multihop)
It hand-rolled its ssh argv and read only `spec.ssh`, so it never applied
a peer's `via:` chain — a compute node reachable only via its login node
failed -> UNKNOWN. It now renders through sac's ONE canonical dispatch
primitive `build_ssh_argv`, which:
- applies `-J` (ProxyJump) from `peer.via`,
- glob-matches `spartan-bm043` onto a `spartan*` pattern peer,
- wraps the command in the peer's `env_preamble` via `bash -c` (**not**
  `-lc` — the #709 login-shell bug),
- sets `StrictHostKeyChecking=accept-new` + `ConnectTimeout=10`.

Called as `build_ssh_argv(peer, ["tmux","has-session","-t",session], peers, extra_opts=["-n"])`.
An unresolvable peer (build raises KeyError / glob-miss) returns an
**UNKNOWN** Signal, never DEAD. The rc->verdict ternary is unchanged
(rc0->ALIVE, rc1->DEAD, else->UNKNOWN); the `preamble && tmux has-session`
chain preserves rc1 for "no session".

## Part 3 — Account via spec-derived label (kills "—", zero migration)
The remote row hardcoded `account=""`. The agent's spec lives on the
master's disk (that is how it was dispatched), so the Account is now
derived from it via `_safe_account_for(load_config(spec_path))` — exactly
like `defined_agent_rows` — best-effort -> `""` on failure. This is the
spec-derived label, **not** the exact runtime pool pick (that needs a DB
column and is a separate carded follow-up).

## Tests (no mocks — real seams/injection; AAA; one logical assert each)
A real `PeersMap` parsed from a temp `config.yaml` (via the documented
`SCITEX_AGENT_CONTAINER_CONFIG` override) drives the real `build_ssh_argv`;
injected rc-returning `run_ssh` callables drive the verdict mapping. New
coverage: multihop `-J`/`bash -c`/rc-mapping, the **spartan-dev
DIRECT-peer regression** (no `-J`, rc0->ALIVE), the unresolvable-peer
guard, the probe's rc->status mapping (incl. UNKNOWN->`"unknown"`),
`get_agent_list_data` hiding an unknown row from the default view, and the
spec-derived account. Existing #710 test `test_remote_probe_unknown_maps_to_running`
renamed/fixed to `..._maps_to_unknown`.

**All affected suites green: 194 passed** (`_agent_list*` helpers +
`test__agent_list_remote.py` + `test__verdict_resolve.py`), Python 3.12.

## Out of scope (separate card)
Reconciling/tombstoning the dead `spartan-bmNNN` `instances` rows (they
now read `unknown` instead of a false `running`) needs SLURM/scitex-hpc
and is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
