### PR TITLE
feat(config): reject unguarded `rm -rf $VAR` in startup_commands (195-repo landmine guard)

### DIFF
--- a/src/scitex_agent_container/config/_startup_command_validation.py
+++ b/src/scitex_agent_container/config/_startup_command_validation.py
@@ -1,0 +1,213 @@
+"""``spec.startup_commands`` destructive-command guard.
+
+Extracted from ``_validation.py`` to keep that orchestrator under the
+512-line cap (sibling to ``_claude_validation`` / ``_placement_validation``
+/ ``_shape_validation``). Called from ``validate_raw`` via
+``errors.extend(validate_startup_commands(spec))``.
+
+WHY THIS EXISTS — 2026-07-16 P0 (highest-blast-radius incident to date).
+Every one of the fleet's 96 generated agent specs shipped an UNGUARDED::
+
+    rm -rf $HOME/proj 2>/dev/null; ln -sfn <src> $HOME/proj
+
+in ``startup_commands``. ``$HOME/proj`` is normally a SYMLINK, so the
+author's intent was "atomically re-point the symlink". But ``rm -rf`` on a
+*variable* target is a landmine: if ``$HOME/proj`` ever resolved to a real
+directory (a stale checkout, a failed earlier symlink, a race) the
+recursive force-delete would descend into it and wipe the ~195 real repos
+underneath. One bad symlink from deleting the fleet's entire working tree.
+
+The fixed form we shipped is symlink-checked + NON-recursive::
+
+    [ -L "$HOME/proj" ] && rm -f "$HOME/proj"; ln -sfn <src> "$HOME/proj"
+
+``rm -f`` (no ``-r``) CANNOT descend into a directory, so even if the guard
+were wrong the blast radius is a single inode. This validator makes the
+landmine IMPOSSIBLE TO REINTRODUCE: a spec whose ``startup_commands`` carry
+a recursive-force ``rm`` on a variable target is REJECTED at validate time
+(constitution: "prefer hooks to prompts; make the destructive path
+impossible; fail fast and loud").
+
+THE MATCHER (deliberately conservative — optimised for ZERO false
+positives, because over-rejecting a valid spec blocks an agent boot):
+
+  * The command string is split into simple-command SEGMENTS on shell
+    control operators (``;`` ``&&`` ``||`` ``|`` ``&`` newline ``(`` ``)``)
+    so ``rm`` is only inspected when it is in COMMAND POSITION — ``echo rm
+    -rf $X`` (rm is an argument to echo) is NOT flagged.
+  * Within a segment, leading ``KEY=VAL`` env-assignments are stripped and
+    the command word must be ``rm`` (or ``/bin/rm`` / ``/usr/bin/rm``).
+    Wrapper-prefixed forms (``sudo rm``, ``xargs rm``) are intentionally
+    OUT OF SCOPE — they were not the incident and parsing their own option
+    grammar would add false-positive risk; this guard stays narrow.
+  * The rm's flags are parsed: short clusters (``-rf`` / ``-fr`` / ``-Rf``
+    / ``-r`` / ``-f``), separated short flags (``-r -f``), long flags
+    (``--recursive`` / ``--force``), and the ``--`` end-of-options marker.
+    BOTH recursive (``r`` / ``R`` / ``--recursive``) AND force (``f`` /
+    ``--force``) must be present — a plain ``rm -f $VAR`` (the FIXED form)
+    is ALLOWED.
+  * At least one operand (target) must contain a shell variable: a ``$``
+    (``$HOME``, ``${SCRATCH}``, ``$VAR``) or a leading ``~`` (tilde home
+    expansion). A purely literal target (``rm -rf /opt/build``) is the
+    author's explicit choice and is NOT flagged — only a VARIABLE target
+    can silently resolve to the wrong tree.
+
+Known, accepted limitations (documented so review is honest): a shell
+metacharacter INSIDE a quoted operand (``rm -rf "$HOME/a;b"``) may
+mis-segment, and a single-quoted variable (``rm -rf '$HOME/proj'`` —
+literal text in real shell) over-matches because ``shlex`` in posix mode
+discards the quote style. Both are pathological, weighed against the
+incident, and err toward the recurrence guard's purpose rather than
+crashing realistic specs.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+
+# Shell control operators that terminate one simple command and begin the
+# next. Splitting on these puts the command word at segment position 0, so
+# we only inspect ``rm`` when it is actually being invoked (not passed as an
+# argument to ``echo`` / ``printf`` / a subshell). ``||`` and ``&&`` are
+# listed before the single-char class so a two-char operator is one split
+# point rather than two.
+_SEGMENT_SPLIT = re.compile(r"\|\||&&|[;\n\r|&()]")
+
+# Command words that ARE a recursive-capable ``rm`` invocation. Absolute
+# paths are included because ``/bin/rm -rf $X`` is exactly as dangerous as
+# the bare ``rm``.
+_RM_WORDS = frozenset({"rm", "/bin/rm", "/usr/bin/rm"})
+
+
+def _strip_env_assignments(tokens: list[str]) -> list[str]:
+    """Drop leading ``KEY=VAL`` shell env-var assignments.
+
+    ``FOO=bar rm -rf $X`` → ``["rm", "-rf", "$X"]``. Same rule as the helper
+    in ``_listen._inline_spec_startup_lint`` (kept local to avoid importing
+    the _listen layer from config/).
+    """
+    out = list(tokens)
+    while out:
+        head = out[0]
+        eq = head.find("=")
+        if eq <= 0:
+            break
+        ident = head[:eq]
+        if not (ident[0].isalpha() or ident[0] == "_"):
+            break
+        if not all(c.isalnum() or c == "_" for c in ident):
+            break
+        out.pop(0)
+    return out
+
+
+def _is_variable_target(operand: str) -> bool:
+    """True when ``operand`` can expand to a path the author did not spell.
+
+    A ``$`` anywhere (``$HOME``, ``${SCRATCH}/x``, ``a$b``) is a parameter
+    expansion; a leading ``~`` is tilde home-expansion. Either means the
+    real delete target is not its literal text — the landmine condition.
+    """
+    return "$" in operand or operand.startswith("~")
+
+
+def _rm_is_recursive_force_on_variable(tokens: list[str]) -> bool:
+    """True when ``tokens`` (one simple command) is the ``rm -rf $VAR`` landmine.
+
+    Requires: command word is ``rm``; BOTH recursive and force flags are
+    present; and at least one operand is a variable target. See the module
+    docstring for the full flag grammar covered.
+    """
+    tokens = _strip_env_assignments(tokens)
+    if not tokens or tokens[0] not in _RM_WORDS:
+        return False
+    recursive = False
+    force = False
+    has_variable_target = False
+    end_of_options = False
+    for tok in tokens[1:]:
+        if not end_of_options and tok == "--":
+            # POSIX end-of-options: everything after is an operand.
+            end_of_options = True
+            continue
+        if not end_of_options and tok.startswith("--"):
+            name = tok[2:].split("=", 1)[0]
+            if name == "recursive":
+                recursive = True
+            elif name == "force":
+                force = True
+            # Any other long option (``--verbose``, ``--one-file-system``)
+            # is irrelevant to the recursive+force+variable signature.
+            continue
+        if not end_of_options and tok.startswith("-") and len(tok) > 1:
+            # Short flag cluster: ``-rf`` / ``-fr`` / ``-Rf`` / ``-v`` ...
+            letters = tok[1:]
+            if "r" in letters or "R" in letters:
+                recursive = True
+            if "f" in letters:
+                force = True
+            continue
+        # Operand (delete target).
+        if _is_variable_target(tok):
+            has_variable_target = True
+    return recursive and force and has_variable_target
+
+
+def _command_is_unguarded_recursive_var_delete(command: str) -> bool:
+    """True when any simple-command segment of ``command`` is the landmine."""
+    for segment in _SEGMENT_SPLIT.split(command):
+        segment = segment.strip()
+        if not segment:
+            continue
+        try:
+            tokens = shlex.split(segment, comments=False, posix=True)
+        except ValueError:
+            # Un-tokenisable segment (unbalanced quote / stray backslash).
+            # The recursive+force+variable signature cannot be CONFIRMED
+            # here, so we do not reject — shell-syntax errors are owned by
+            # the _listen startup lint. Prefer not to false-positive.
+            continue
+        if _rm_is_recursive_force_on_variable(tokens):
+            return True
+    return False
+
+
+def validate_startup_commands(spec: dict) -> list[str]:
+    """Reject any ``startup_commands`` entry with an unguarded ``rm -rf $VAR``.
+
+    Returns a list of error strings (empty = valid), matching the
+    ``list[str]`` contract of the other ``config._*_validation`` siblings
+    called from ``validate_raw``. Defensive: any unexpected shape collapses
+    to "nothing to check".
+    """
+    errors: list[str] = []
+    if not isinstance(spec, dict):
+        return errors
+    cmds = spec.get("startup_commands")
+    if not isinstance(cmds, list):
+        return errors
+    for index, entry in enumerate(cmds):
+        if not isinstance(entry, dict):
+            continue
+        command = entry.get("command")
+        if not isinstance(command, str) or not command.strip():
+            continue
+        if _command_is_unguarded_recursive_var_delete(command):
+            errors.append(
+                f"spec.startup_commands[{index}].command runs an UNGUARDED "
+                f"recursive delete of a variable path:\n    {command}\n"
+                "`rm -rf $VAR` recurses, and a variable target can resolve to "
+                "a real directory — this is the 2026-07-16 P0 where an "
+                "unguarded `rm -rf $HOME/proj` was one bad symlink from "
+                "deleting ~195 fleet repos. Use a symlink-checked, "
+                "NON-recursive delete instead:\n"
+                '    [ -L "$HOME/proj" ] && rm -f "$HOME/proj"\n'
+                "(-L checks it is a symlink; -f without -r cannot descend "
+                "into a directory). Never `rm -rf $VAR` in startup_commands "
+                "(recursive + variable target = landmine)."
+            )
+    return errors
+
+
+__all__ = ["validate_startup_commands"]

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -28,6 +28,7 @@ from ._placement_validation import validate_placement
 # note in config._provider_types.AgentProvider.
 from ._provider_registry import is_known_agent_provider, list_agent_providers
 from ._shape_validation import validate_autonomous, validate_proxy_coupling
+from ._startup_command_validation import validate_startup_commands
 
 # ``_VALID_MODEL_RE`` (accepted ``spec.claude.model`` shapes) moved to
 # ``_claude_validation`` alongside the rest of the claude-block checks;
@@ -454,6 +455,13 @@ def validate_raw(raw: dict, path: str) -> list[str]:
         # coupling rules — sibling ``_shape_validation`` module.
         errors.extend(validate_autonomous(spec))
         errors.extend(validate_proxy_coupling(spec, kind))
+
+        # spec.startup_commands destructive-command guard — REJECT an
+        # unguarded recursive-force ``rm`` on a variable target (the
+        # 2026-07-16 P0 landmine: ``rm -rf $HOME/proj`` one bad symlink
+        # from wiping ~195 repos). Sibling ``_startup_command_validation``
+        # module; allows the fixed ``rm -f $VAR`` form.
+        errors.extend(validate_startup_commands(spec))
 
         # Phase-3 capsule-isolation: type-check ``spec.comms`` +
         # ``spec.lineage`` shapes. Detailed rules live in the

--- a/tests/scitex_agent_container/config/test__startup_command_validation.py
+++ b/tests/scitex_agent_container/config/test__startup_command_validation.py
@@ -1,0 +1,246 @@
+"""Tests for scitex_agent_container.config._startup_command_validation.
+
+Deterministic recurrence guard for the 2026-07-16 P0: every one of the
+fleet's 96 generated specs shipped an UNGUARDED::
+
+    rm -rf $HOME/proj 2>/dev/null; ln -sfn <src> $HOME/proj
+
+in ``startup_commands`` — one bad symlink from recursively deleting the
+~195 real repos under ``$HOME/proj``. The validator REJECTS a
+recursive-force ``rm`` on a VARIABLE target at spec-validate time; it
+ALLOWS the fixed, NON-recursive form ``[ -L "$VAR" ] && rm -f "$VAR"``.
+
+Real validator, no mocks. AAA + one logical assert per test (PA-307).
+The four task-mandated cases run through the real ``validate_raw`` on a
+complete, otherwise-valid spec (integration); the flag-ordering matrix +
+false-positive allow-list drive the sibling ``validate_startup_commands``
+directly (the same function ``validate_raw`` calls).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.config._startup_command_validation import (
+    validate_startup_commands,
+)
+from scitex_agent_container.config._validation import validate_raw
+
+# ---------------------------------------------------------------------------
+# Spec builders
+# ---------------------------------------------------------------------------
+
+_COMPLETE_SPEC = {
+    "apiVersion": "scitex-agent-container/v3",
+    "kind": "Agent",
+    "spec": {
+        "runtime": "tui",
+        "host": "${HOSTNAME}",
+        "workdir": "/home/agent/work",
+        "apptainer": {"image": "/x.sif", "binds": []},
+        "claude": {"model": "opus"},
+        "health": {"enabled": True, "interval": 60},
+        "restart": {"policy": "on-failure", "max_retries": 3},
+    },
+}
+
+
+def _raw_with_startup(cmds: list) -> dict:
+    """A complete, valid v3 spec whose only variable is ``startup_commands``."""
+    import copy
+
+    raw = copy.deepcopy(_COMPLETE_SPEC)
+    raw["spec"]["startup_commands"] = cmds
+    return raw
+
+
+def _startup_errors_via_validate_raw(cmds: list) -> list[str]:
+    """Errors from the REAL validator, narrowed to startup_commands ones."""
+    errors = validate_raw(_raw_with_startup(cmds), path="<test>")
+    return [e for e in errors if "startup_commands" in e]
+
+
+# ---------------------------------------------------------------------------
+# The four task-mandated cases — through the real validate_raw
+# ---------------------------------------------------------------------------
+
+_LANDMINE = "rm -rf $HOME/proj 2>/dev/null; ln -sfn /src/proj $HOME/proj"
+_GUARDED = '[ -L "$HOME/proj" ] && rm -f "$HOME/proj"; ln -sfn /src/proj "$HOME/proj"'
+
+
+def test_landmine_rm_rf_variable_is_rejected() -> None:
+    # Arrange — the exact unguarded form the 96 specs shipped.
+    cmds = [{"command": _LANDMINE}]
+    # Act
+    startup_errors = _startup_errors_via_validate_raw(cmds)
+    # Assert
+    assert startup_errors, f"landmine {_LANDMINE!r} must be rejected"
+
+
+def test_landmine_rejection_echoes_the_offending_command() -> None:
+    # Arrange
+    cmds = [{"command": _LANDMINE}]
+    # Act
+    startup_errors = _startup_errors_via_validate_raw(cmds)
+    # Assert — the error names the offending command verbatim.
+    assert _LANDMINE in startup_errors[0]
+
+
+def test_landmine_rejection_shows_the_guarded_fix() -> None:
+    # Arrange
+    cmds = [{"command": _LANDMINE}]
+    # Act
+    startup_errors = _startup_errors_via_validate_raw(cmds)
+    # Assert — actionable: the message hands over the symlink-checked fix.
+    assert 'rm -f "$HOME/proj"' in startup_errors[0]
+
+
+def test_guarded_form_passes() -> None:
+    # Arrange — symlink-checked + NON-recursive ``rm -f`` is the fix we
+    # shipped; it must validate clean even though it targets $HOME/proj.
+    cmds = [{"command": _GUARDED}]
+    # Act
+    startup_errors = _startup_errors_via_validate_raw(cmds)
+    # Assert
+    assert startup_errors == []
+
+
+def test_literal_path_rm_rf_passes() -> None:
+    # Arrange — a fixed literal target is the author's explicit choice; no
+    # variable can silently resolve to the wrong tree, so no false positive.
+    cmds = [{"command": "rm -rf /tmp/fixed/dir"}]
+    # Act
+    startup_errors = _startup_errors_via_validate_raw(cmds)
+    # Assert
+    assert startup_errors == []
+
+
+def test_braced_variable_is_rejected() -> None:
+    # Arrange — ${SCRATCH}/build is a braced variable target.
+    cmds = [{"command": "rm -rf ${SCRATCH}/build"}]
+    # Act
+    startup_errors = _startup_errors_via_validate_raw(cmds)
+    # Assert
+    assert startup_errors, "braced ${SCRATCH} target must be rejected"
+
+
+def test_complete_spec_without_startup_commands_has_no_errors() -> None:
+    # Arrange — sanity: the guard adds ZERO errors when the field is absent.
+    raw = _COMPLETE_SPEC
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Flag-ordering matrix — every common recursive-force spelling is caught
+# ---------------------------------------------------------------------------
+
+_REJECTED_COMMANDS = [
+    "rm -rf $HOME/proj",  # canonical
+    "rm -fr $VAR",  # force-then-recursive cluster
+    "rm -Rf $VAR",  # capital -R
+    "rm -r -f $VAR",  # separated short flags
+    "rm -f -r $VAR",  # separated, reversed
+    "rm --recursive --force $VAR",  # long flags
+    "rm -rf ${SCRATCH}/build",  # braced variable
+    "rm -rf ~/proj",  # leading tilde (home expansion)
+    "rm -rf -- $VAR",  # POSIX end-of-options marker
+    "rm -rf /tmp/keep $HOME/proj",  # mixed: one variable target present
+    "/bin/rm -rf $HOME/x",  # absolute-path rm is equally dangerous
+    "FOO=bar rm -rf $HOME/x",  # leading env-assignment stripped
+    "mkdir -p /tmp/x && rm -rf $HOME/proj",  # rm in second segment
+]
+
+
+@pytest.mark.parametrize("command", _REJECTED_COMMANDS)
+def test_recursive_force_variable_is_rejected(command: str) -> None:
+    # Arrange
+    spec = {"startup_commands": [{"command": command}]}
+    # Act
+    errors = validate_startup_commands(spec)
+    # Assert
+    assert errors, f"expected rejection for {command!r}"
+
+
+# ---------------------------------------------------------------------------
+# False-positive allow-list — the matcher must NOT over-reject
+# ---------------------------------------------------------------------------
+
+_ALLOWED_COMMANDS = [
+    'rm -f "$HOME/proj"',  # FIXED form: force but NON-recursive
+    "rm -f $VAR",  # non-recursive, variable target
+    "rm -rf /tmp/fixed/dir",  # recursive-force but LITERAL target
+    "rm -rf /opt/build/cache",  # literal
+    "echo rm -rf $HOME/proj",  # rm is an ARGUMENT to echo, not invoked
+    'printf "rm -rf $X"',  # rm inside a printf argument
+    "rm -r $VAR",  # recursive WITHOUT force (task rule: force required)
+    "ln -sfn /src/proj $HOME/proj",  # the symlink half of the pattern
+    "true",  # trivial no-op
+]
+
+
+@pytest.mark.parametrize("command", _ALLOWED_COMMANDS)
+def test_safe_commands_are_not_flagged(command: str) -> None:
+    # Arrange
+    spec = {"startup_commands": [{"command": command}]}
+    # Act
+    errors = validate_startup_commands(spec)
+    # Assert
+    assert errors == [], f"false positive on {command!r}: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Defensive shapes — collapse to "nothing to check"
+# ---------------------------------------------------------------------------
+
+
+def test_missing_startup_commands_yields_no_error() -> None:
+    # Arrange
+    spec: dict = {}
+    # Act
+    errors = validate_startup_commands(spec)
+    # Assert
+    assert errors == []
+
+
+def test_non_list_startup_commands_yields_no_error() -> None:
+    # Arrange — wrong shape; downstream validators own the type error.
+    spec = {"startup_commands": {"command": "rm -rf $X"}}
+    # Act
+    errors = validate_startup_commands(spec)
+    # Assert
+    assert errors == []
+
+
+def test_non_dict_entry_is_skipped() -> None:
+    # Arrange — a bare-string entry (parser drops it anyway).
+    spec = {"startup_commands": ["rm -rf $X"]}
+    # Act
+    errors = validate_startup_commands(spec)
+    # Assert
+    assert errors == []
+
+
+def test_non_string_command_is_skipped() -> None:
+    # Arrange
+    spec = {"startup_commands": [{"command": 42}]}
+    # Act
+    errors = validate_startup_commands(spec)
+    # Assert
+    assert errors == []
+
+
+def test_error_names_the_entry_index() -> None:
+    # Arrange — first entry OK, second entry is the landmine; index pins 1.
+    spec = {
+        "startup_commands": [
+            {"command": "echo starting"},
+            {"command": "rm -rf $HOME/proj"},
+        ]
+    }
+    # Act
+    errors = validate_startup_commands(spec)
+    # Assert
+    assert "startup_commands[1]" in errors[0]


### PR DESCRIPTION
## What

Adds a **deterministic recurrence-prevention guard** to sac's config
validation: any agent spec whose `startup_commands` contain an **unguarded
recursive-force `rm` on a shell-variable path** is now **REJECTED at
spec-validate time** (the same `validate_raw` surface that already rejects
bad models, relocated fields, missing required fields, etc.).

## Why — the just-fixed P0 (2026-07-16)

Every one of the fleet's **96 generated agent specs** shipped an unguarded

```
rm -rf $HOME/proj 2>/dev/null; ln -sfn <src> $HOME/proj
```

in `startup_commands`. `$HOME/proj` is normally a **symlink**, so the intent
was "atomically re-point the symlink". But `rm -rf` on a **variable** target
is a landmine: if `$HOME/proj` ever resolved to a **real directory** (a stale
checkout, a failed earlier symlink, a race), the recursive force-delete would
descend into it and wipe the **~195 real repos** underneath — one bad symlink
from deleting the fleet's entire working tree.

The 96 outputs + the generator templates were already fixed to the
symlink-checked, non-recursive form. **This PR makes the landmine impossible
to reintroduce** — per the constitution: *"prefer hooks to prompts; make the
destructive path impossible; fail fast and loud."*

## The rule (designed for zero false positives)

REJECT a `command` when a simple-command **segment** is:

- an `rm` in **command position** (`rm`, `/bin/rm`, `/usr/bin/rm`; leading
  `KEY=VAL` env-assignments stripped) —
- with **both** recursive (`-r`/`-R`/`--recursive`) **and** force
  (`-f`/`--force`) flags (covers `-rf`, `-fr`, `-Rf`, `-r -f`,
  `--recursive --force`, and the `--` end-of-options marker) —
- on a **variable** target: a `$` (`$HOME`, `${SCRATCH}`, `$VAR`) or a
  leading `~`.

ALLOWED (not flagged):

- The fixed form `[ -L "$VAR" ] && rm -f "$VAR"` — `rm -f` is **non-recursive**
  and cannot descend into a directory.
- A purely **literal** target (`rm -rf /opt/build`) — the author's explicit
  choice; no variable can silently resolve to the wrong tree.
- `rm` appearing as an **argument** (`echo rm -rf $X`) — the command string is
  split on shell control operators so `rm` is only inspected when actually
  invoked.

The error message names the offending spec entry + command, states the
195-repo blast radius, and hands over the guarded fix.

## Where

- New sibling module `config/_startup_command_validation.py`
  (`validate_startup_commands(spec) -> list[str]`), following the existing
  `_placement_validation` / `_shape_validation` / `_claude_validation`
  pattern.
- Wired into `config/_validation.py::validate_raw` via
  `errors.extend(validate_startup_commands(spec))`.

## Tests

`tests/scitex_agent_container/config/test__startup_command_validation.py` —
34 tests, **no mocks**, AAA + one assert each. The four mandated cases run
through the real `validate_raw` on a complete valid spec; a flag-ordering
matrix + a false-positive allow-list drive the sibling validator directly.

Full config suite green: **718 passed**.

## Deliberate scope note (for review)

The matcher requires **recursive AND force** (matching the incident and the
task's "recursive-force" definition). A recursive-*without*-force `rm -r $VAR`
is therefore **not** flagged, and wrapper-prefixed forms (`sudo rm`,
`xargs rm`) are intentionally out of scope — both were weighed to keep false
positives at zero. Easy to widen later if desired.
