### PR TITLE
feat(ci): `sac ci why` — extract the real CI failure cheaply (invert the price)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_ci_why.py
+++ b/src/scitex_agent_container/cli_pkg/_ci_why.py
@@ -1,0 +1,509 @@
+"""Extract the REAL reason a CI run is red — as cheaply as its status.
+
+Reading CI *status* is one word (``failure``); reading *why* has been
+tens of thousands of lines, so a bounded-context agent is steered to the
+cheap word and the word replaces the reason instead of summarising it.
+This module inverts that price: it fetches a failing run's log ONCE and
+parses it to a few hundred bytes — failing test IDs, assertion lines, or
+a setup failure's ``##[error]``. Everything except the injectable
+:func:`run_gh` gh-seam is pure/string-based (unit-tested, no network).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+__all__ = [
+    "CIWhyError",
+    "GhRunner",
+    "JobFailure",
+    "RunFailures",
+    "run_gh",
+    "clean_log_line",
+    "parse_job_context",
+    "split_log_by_job",
+    "parse_failed_log",
+    "resolve_run_ids",
+    "explain_run",
+    "explain",
+    "render_text",
+]
+
+# --log-failed can be a few MB; give the fetch room but stay bounded.
+_GH_TIMEOUT_S = 90
+
+# A PR number is small; a run id is a 10+ digit database id. Anything at
+# or above this magnitude is treated as a run id, below it as a PR number.
+_RUN_ID_MIN = 10_000_000
+
+GhRunner = Callable[[list[str]], str]
+
+
+class CIWhyError(RuntimeError):
+    """gh is missing/unauthenticated/errored, or the target won't resolve.
+
+    Raised, never swallowed into a reassuring "no failures": not knowing
+    WHY a run is red is UNKNOWN, and UNKNOWN must not read as green. The
+    click layer turns this into a loud stderr error + non-zero exit.
+    """
+
+
+def run_gh(args: list[str], *, _run=subprocess.run) -> str:
+    """Default ``gh`` seam: run ``gh <args>`` and return stdout text.
+
+    The one place the network is touched. Returns stdout even on a
+    non-zero exit *when stdout is non-empty* — ``gh pr checks`` exits
+    non-zero precisely when checks fail, yet still prints the JSON we
+    want. A non-zero exit with no output (bad run id, auth failure, gh
+    missing) raises :class:`CIWhyError`.
+    """
+    try:
+        proc = _run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=_GH_TIMEOUT_S,
+            check=False,
+        )
+    except FileNotFoundError as exc:  # stx-allow: fallback (reason: gh not installed → loud CIWhyError, never a silent green)
+        raise CIWhyError(
+            "gh CLI not found on PATH — install GitHub CLI: https://cli.github.com"
+        ) from exc
+    except (
+        OSError,
+        subprocess.SubprocessError,
+    ) as exc:  # stx-allow: fallback (reason: spawn error / timeout → loud CIWhyError, never a silent green)
+        raise CIWhyError(f"gh {' '.join(args)} failed to run: {exc}") from exc
+    out = proc.stdout or ""
+    if proc.returncode != 0 and not out.strip():
+        err = (proc.stderr or "").strip() or f"exited {proc.returncode}"
+        raise CIWhyError(f"gh {' '.join(args)}: {err}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Log cleaning — strip GitHub-Actions scaffolding.
+# ---------------------------------------------------------------------------
+
+# The ISO-8601 runner timestamp that prefixes every raw actions log line
+# (after gh's optional "<job>\t<step>\t" prefix). Everything up to and
+# including it is scaffolding.
+_TS_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z ?")
+_BOM = "﻿"
+_ERROR_ANNOT = "##[error]"
+
+
+def clean_log_line(raw: str) -> Optional[str]:
+    r"""Strip GitHub-Actions scaffolding from one raw log line.
+
+    Removes the optional ``<job>\t<step>\t`` prefix that
+    ``gh run view --log-failed`` prepends, the ISO-8601 runner timestamp,
+    and the UTF-8 BOM. ``##[group]`` / ``##[endgroup]`` fold markers are
+    dropped entirely (return ``None``). Everything else — including
+    ``##[error]`` — is returned as bare content.
+    """
+    line = raw.rstrip("\n").replace(_BOM, "")
+    m = _TS_RE.search(line)
+    content = line[m.end() :] if m else line
+    stripped = content.strip()
+    if stripped.startswith("##[group]") or stripped.startswith("##[endgroup]"):
+        return None
+    return content
+
+
+def split_log_by_job(log_text: str) -> "OrderedDict[str, str]":
+    r"""Group ``gh run view --log-failed`` lines by job name (first column).
+
+    ``--log-failed`` prefixes each line ``<job>\t<step>\t<ts> <content>``.
+    Lines with no such prefix (a plain single-job log, as in a fixture)
+    group under the empty-string key.
+    """
+    groups: "OrderedDict[str, list[str]]" = OrderedDict()
+    for raw in log_text.splitlines():
+        line = raw.replace(_BOM, "")
+        parts = line.split("\t", 2)
+        if len(parts) == 3 and _TS_RE.match(parts[2]):
+            job = parts[0]
+        else:
+            job = ""
+        groups.setdefault(job, []).append(raw)
+    return OrderedDict((job, "\n".join(lines)) for job, lines in groups.items())
+
+
+# ---------------------------------------------------------------------------
+# Job-name context — python version + runner OS from the job name.
+# ---------------------------------------------------------------------------
+
+_PY_RE = re.compile(r"(?:py[ -]?)?3[.\-](\d{1,2})\b", re.IGNORECASE)
+_OS_RE = re.compile(
+    r"(ubuntu-latest|ubuntu-\d[\w.]*|ubuntu|macos-[\w.]+|macos|"
+    r"windows-[\w.]+|windows|self-hosted)",
+    re.IGNORECASE,
+)
+
+
+def parse_job_context(job_name: str) -> tuple[Optional[str], Optional[str]]:
+    """Best-effort ``(python_version, runner_os)`` from a job name.
+
+    Matrix legs encode context in the name, e.g.
+    ``pytest-matrix-on-ubuntu-py3.11``  -> ('3.11', 'ubuntu'),
+    ``import-smoke-on-ubuntu-py3-12``   -> ('3.12', 'ubuntu'),
+    ``...guard-on-self-hosted``         -> (None, 'self-hosted').
+    """
+    py = None
+    m = _PY_RE.search(job_name)
+    if m:
+        py = f"3.{m.group(1)}"
+    os_ = None
+    mo = _OS_RE.search(job_name)
+    if mo:
+        os_ = mo.group(1).lower()
+    return py, os_
+
+
+# ---------------------------------------------------------------------------
+# The parser — the testable core.
+# ---------------------------------------------------------------------------
+
+_SUMMARY_RE = re.compile(r"={3,}\s*short test summary info\s*={3,}", re.IGNORECASE)
+_FAILURES_HDR_RE = re.compile(r"={3,}\s*(FAILURES|ERRORS)\s*={3,}")
+_SUMMARY_END_RE = re.compile(
+    r"={3,}.*\b(passed|failed|error|errors|skipped|deselected|"
+    r"xfailed|xpassed|warning|warnings|no tests ran)\b.*={3,}",
+    re.IGNORECASE,
+)
+_FAILED_LINE_RE = re.compile(r"^(FAILED|ERROR)\s+\S")
+_E_LINE_RE = re.compile(r"^E(?:\s|$)")
+
+
+@dataclass
+class JobFailure:
+    """The distilled failure of ONE job — a few lines, not a whole log."""
+
+    job: str
+    py: Optional[str] = None
+    os: Optional[str] = None
+    failed_tests: list[str] = field(default_factory=list)
+    assertions: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)  # ##[error] annotations
+    tail: list[str] = field(default_factory=list)
+    url: str = ""
+
+    @property
+    def signal(self) -> str:
+        """Which tier produced the primary evidence (priority order)."""
+        if self.failed_tests:
+            return "pytest-summary"
+        if self.assertions:
+            return "pytest-assertion"
+        if self.errors:
+            return "annotation"
+        if self.tail:
+            return "tail"
+        return "none"
+
+    def context(self) -> str:
+        """`` (py3.11, ubuntu)`` — the matrix context, or empty."""
+        bits = [b for b in (self.py and f"py{self.py}", self.os) if b]
+        return f" ({', '.join(bits)})" if bits else ""
+
+    def primary_lines(
+        self, *, max_assertions: int = 8, max_errors: int = 5, max_tests: int = 20
+    ) -> list[str]:
+        """The compact evidence to show under this job's header."""
+        lines: list[str] = []
+        if self.failed_tests:
+            lines.extend(self.failed_tests[:max_tests])
+            extra = len(self.failed_tests) - max_tests
+            if extra > 0:
+                lines.append(f"... and {extra} more failing test(s)")
+        if self.assertions:
+            lines.extend(self.assertions[:max_assertions])
+        if not self.failed_tests and not self.assertions:
+            if self.errors:
+                lines.extend(f"##[error] {e}" for e in self.errors[:max_errors])
+            elif self.tail:
+                lines.append("(no pytest/annotation signal — last log lines:)")
+                lines.extend(self.tail)
+            else:
+                lines.append("(failed, but gh returned no log content)")
+        return lines
+
+    def to_dict(self) -> dict:
+        return {
+            "job": self.job,
+            "python": self.py,
+            "os": self.os,
+            "signal": self.signal,
+            "failed_tests": self.failed_tests,
+            "assertions": self.assertions,
+            "errors": self.errors,
+            "tail": self.tail,
+            "url": self.url,
+        }
+
+
+def parse_failed_log(
+    log_text: str,
+    *,
+    job_name: str = "",
+    url: str = "",
+    tail_lines: int = 8,
+) -> JobFailure:
+    """Parse ONE job's ``--log-failed`` text into a :class:`JobFailure`.
+
+    Priority of signals: (1) the ``short test summary info`` ``FAILED``
+    lines; (2) the ``FAILURES`` block ``E`` assertion lines; (3)
+    ``##[error]`` annotations (setup/infra failures); (4) fallback to the
+    last ``tail_lines`` non-blank cleaned lines.
+    """
+    py, os_ = parse_job_context(job_name)
+    fail = JobFailure(job=job_name, py=py, os=os_, url=url)
+
+    clean: list[str] = []
+    for raw in log_text.splitlines():
+        c = clean_log_line(raw)
+        if c is None:
+            continue
+        clean.append(c)
+        if c.lstrip().startswith(_ERROR_ANNOT):
+            annot = c.lstrip()[len(_ERROR_ANNOT) :].strip()
+            if annot:
+                fail.errors.append(annot)
+
+    # (1) pytest short test summary — the cheapest, richest signal.
+    in_summary = False
+    for c in clean:
+        s = c.strip()
+        if _SUMMARY_RE.search(s):
+            in_summary = True
+            continue
+        if in_summary:
+            if _SUMMARY_END_RE.search(s):
+                break
+            if _FAILED_LINE_RE.match(s):
+                fail.failed_tests.append(s)
+
+    # (2) assertion detail from the FAILURES / ERRORS block.
+    in_failures = False
+    for c in clean:
+        st = c.strip()
+        if _FAILURES_HDR_RE.search(st):
+            in_failures = True
+            continue
+        if in_failures:
+            if _SUMMARY_RE.search(st):
+                break
+            if _E_LINE_RE.match(c):
+                fail.assertions.append(st)
+
+    # (4) fallback tail when nothing structured was found.
+    if not (fail.failed_tests or fail.assertions or fail.errors):
+        nonblank = [c for c in clean if c.strip()]
+        fail.tail = nonblank[-tail_lines:]
+    return fail
+
+
+# ---------------------------------------------------------------------------
+# Run-level orchestration (uses the run_gh seam).
+# ---------------------------------------------------------------------------
+
+_FAILED_JOB_CONCLUSIONS = {"failure", "cancelled", "timed_out", "startup_failure"}
+_RUN_ID_IN_LINK = re.compile(r"/actions/runs/(\d+)")
+
+
+@dataclass
+class RunFailures:
+    """Every distilled job failure for ONE run."""
+
+    run_id: str
+    workflow: str = ""
+    title: str = ""
+    branch: str = ""
+    url: str = ""
+    failures: list[JobFailure] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "run_id": self.run_id,
+            "workflow": self.workflow,
+            "title": self.title,
+            "branch": self.branch,
+            "url": self.url,
+            "failures": [f.to_dict() for f in self.failures],
+        }
+
+
+def _repo_args(repo: Optional[str]) -> list[str]:
+    return ["-R", repo] if repo else []
+
+
+def _current_branch(_run=subprocess.run) -> str:
+    try:
+        proc = _run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (
+        OSError
+    ) as exc:  # stx-allow: fallback (reason: git missing → loud CIWhyError)
+        raise CIWhyError(f"could not determine current branch: {exc}") from exc
+    branch = (proc.stdout or "").strip()
+    if proc.returncode != 0 or not branch:
+        raise CIWhyError(
+            "not in a git checkout (or detached HEAD) — pass a PR number, "
+            "run id, or branch explicitly"
+        )
+    return branch
+
+
+def _pr_failing_run_ids(pr: str, *, run_gh: GhRunner, repo: Optional[str]) -> list[str]:
+    raw = run_gh(
+        ["pr", "checks", pr, *_repo_args(repo), "--json", "name,state,link,bucket"]
+    )
+    try:
+        checks = json.loads(raw or "[]")
+    except ValueError as exc:
+        raise CIWhyError(f"could not parse gh pr checks JSON for PR {pr}") from exc
+    run_ids: list[str] = []
+    for c in checks or []:
+        failed = c.get("bucket") == "fail" or str(c.get("state", "")).upper() in {
+            "FAILURE",
+            "ERROR",
+            "CANCELLED",
+            "TIMED_OUT",
+        }
+        if not failed:
+            continue
+        m = _RUN_ID_IN_LINK.search(str(c.get("link", "")))
+        if m and m.group(1) not in run_ids:
+            run_ids.append(m.group(1))
+    return run_ids
+
+
+def _branch_latest_run_id(
+    branch: str, *, run_gh: GhRunner, repo: Optional[str]
+) -> list[str]:
+    raw = run_gh(
+        [
+            "run",
+            "list",
+            *_repo_args(repo),
+            "-b",
+            branch,
+            "-L",
+            "1",
+            "--json",
+            "databaseId",
+        ]
+    )
+    try:
+        runs = json.loads(raw or "[]")
+    except ValueError as exc:
+        raise CIWhyError(
+            f"could not parse gh run list JSON for branch {branch}"
+        ) from exc
+    if not runs:
+        raise CIWhyError(f"no workflow runs found for branch '{branch}'")
+    return [str(runs[0]["databaseId"])]
+
+
+def resolve_run_ids(
+    target: Optional[str], *, run_gh: GhRunner = run_gh, repo: Optional[str] = None
+) -> list[str]:
+    """Resolve a PR number / run id / branch / nothing to failing run id(s).
+
+    * empty  -> the latest run for the current git branch;
+    * a run id (>= 8 digits) -> itself;
+    * a PR number -> the run id(s) behind its failing checks;
+    * anything else -> the latest run for that branch name.
+    """
+    target = (target or "").strip()
+    if not target:
+        return _branch_latest_run_id(_current_branch(), run_gh=run_gh, repo=repo)
+    if target.isdigit():
+        if int(target) >= _RUN_ID_MIN:
+            return [target]
+        return _pr_failing_run_ids(target, run_gh=run_gh, repo=repo)
+    return _branch_latest_run_id(target, run_gh=run_gh, repo=repo)
+
+
+def explain_run(
+    run_id: str, *, run_gh: GhRunner = run_gh, repo: Optional[str] = None
+) -> RunFailures:
+    """Fetch + distil every failing job of a single run."""
+    meta_raw = run_gh(
+        [
+            "run",
+            "view",
+            str(run_id),
+            *_repo_args(repo),
+            "--json",
+            "jobs,displayTitle,headBranch,conclusion,url,workflowName",
+        ]
+    )
+    try:
+        meta = json.loads(meta_raw or "{}")
+    except ValueError as exc:
+        raise CIWhyError(f"could not parse gh run view JSON for run {run_id}") from exc
+    run = RunFailures(
+        run_id=str(run_id),
+        workflow=meta.get("workflowName", ""),
+        title=meta.get("displayTitle", ""),
+        branch=meta.get("headBranch", ""),
+        url=meta.get("url", ""),
+    )
+    failing = [
+        j
+        for j in (meta.get("jobs") or [])
+        if str(j.get("conclusion", "")).lower() in _FAILED_JOB_CONCLUSIONS
+    ]
+    if not failing:
+        return run
+
+    by_job = split_log_by_job(
+        run_gh(["run", "view", str(run_id), *_repo_args(repo), "--log-failed"])
+    )
+    for j in failing:
+        name = j.get("name", "")
+        jf = parse_failed_log(by_job.get(name, ""), job_name=name, url=j.get("url", ""))
+        if jf.signal == "none":
+            steps = [
+                s.get("name", "?")
+                for s in (j.get("steps") or [])
+                if str(s.get("conclusion", "")).lower() == "failure"
+            ]
+            if steps:
+                jf.errors.append("failed step: " + ", ".join(steps))
+        run.failures.append(jf)
+    return run
+
+
+def explain(
+    target: Optional[str], *, run_gh: GhRunner = run_gh, repo: Optional[str] = None
+) -> list[RunFailures]:
+    """Resolve ``target`` and distil the failing run(s) behind it."""
+    return [
+        explain_run(rid, run_gh=run_gh, repo=repo)
+        for rid in resolve_run_ids(target, run_gh=run_gh, repo=repo)
+    ]
+
+
+def render_text(run: RunFailures) -> str:
+    """Render one run's failures as compact human text (per-job blocks)."""
+    if not run.failures:
+        return "no failures"
+    out: list[str] = []
+    for jf in run.failures:
+        out.append(f"{jf.job}{jf.context()}")
+        out.extend(f"  {line}" for line in jf.primary_lines())
+        if jf.url:
+            out.append(f"  -> {jf.url}")
+    return "\n".join(out)

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -71,7 +71,7 @@ COMMAND_CATEGORIES = [
     ),
     ("Registry & Events", ["db", "registry", "event"]),
     ("Build & Install", ["image", "installation"]),
-    ("Diagnostics", ["doctor", "ports", "provenance"]),
+    ("Diagnostics", ["doctor", "ports", "provenance", "ci"]),
     ("Remote testing", ["pytest"]),
     ("Introspection", ["mcp", "list-python-apis", "skills", "versions"]),
     ("Developer", ["dev"]),
@@ -106,6 +106,10 @@ class _MainGroup(LazyGroup):
         "fleet": f"{_PKG}.fleet_group:fleet_group",
         "listen": f"{_PKG}.listen_cmds:listen",
         "doctor": f"{_PKG}.doctor_cmds:doctor",
+        # Read WHY a CI run is red as cheaply as its status word — fetch
+        # the failing run's log once, print only the failing test IDs +
+        # assertion lines (or the ##[error] setup annotation).
+        "ci": f"{_PKG}.ci_group:ci_group",
         # Read-only port-hygiene inventory: listen 7878 + a2a claims +
         # the scitex/sac port-assignment reference map.
         "ports": f"{_PKG}.ports_cmds:ports",
@@ -293,6 +297,7 @@ class _MainGroup(LazyGroup):
         "fleet": "Peer-aware multi-agent orchestration across hosts.",
         "doctor": "Diagnose agent-spec source drift (local, or --fleet across hosts).",
         "provenance": "Prove which code is actually loaded (commit, origin, fossil installs).",
+        "ci": "Read WHY CI is red as cheaply as its status (extract the real failure).",
         "listen": "Host HTTP/JSON control plane: start/stop/restart/status.",
         "ports": "List the ports sac/scitex uses, with live status.",
         "pytest": "Run pytest on remote pools (Spartan SLURM, ...).",

--- a/src/scitex_agent_container/cli_pkg/ci_group.py
+++ b/src/scitex_agent_container/cli_pkg/ci_group.py
@@ -1,0 +1,80 @@
+"""``sac ci`` — read a CI failure as cheaply as reading its status.
+
+``sac ci why <pr|run|branch>`` fetches the failing run's log ONCE and
+prints only the essential — failing test IDs + assertion lines, or the
+``##[error]`` annotation for a setup failure — a few hundred bytes, not
+the whole log. The real reason is now as cheap to read as the status
+word, so there is no economic reason to skip it. See ``_ci_why`` for the
+parser and the rationale.
+"""
+
+from __future__ import annotations
+
+import json as _json
+
+import click
+
+from ._ci_why import CIWhyError, explain, render_text
+from ._helpers import _json_flag
+
+
+@click.group("ci", context_settings={"help_option_names": ["-h", "--help"]})
+def ci_group() -> None:
+    """Read WHY CI is red as cheaply as reading THAT it's red."""
+
+
+def _run_header(run) -> str:
+    bits = [f"run {run.run_id}"]
+    if run.workflow:
+        bits.append(run.workflow)
+    if run.branch:
+        bits.append(f"@ {run.branch}")
+    head = "  ".join(bits)
+    return f"{head}\n{run.url}" if run.url else head
+
+
+@ci_group.command("why")
+@click.argument("target", required=False, default="")
+@click.option(
+    "--repo",
+    default=None,
+    help="owner/name; defaults to the repo gh detects from the cwd.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit structured JSON.")
+@click.pass_context
+def why(ctx: click.Context, target: str, repo: str, as_json: bool) -> None:
+    """Extract the real failure(s) from a red CI run — compactly.
+
+    \b
+    TARGET may be:
+      * a PR number   -> the run(s) behind its failing checks
+      * a run id       -> that run
+      * a branch name  -> the latest run for that branch
+      * omitted        -> the latest run for the current branch
+
+    \b
+    Examples:
+      $ sac ci why 712              # a PR
+      $ sac ci why 29446283736      # a run id
+      $ sac ci why fix/foo          # a branch
+      $ sac ci why                  # current branch's latest run
+      $ sac ci why 712 --json       # machine-readable
+    """
+    try:
+        runs = explain(target, repo=repo)
+    except CIWhyError as exc:
+        # UNKNOWN is not green: fail loud rather than print "no failures".
+        raise click.ClickException(str(exc)) from exc
+
+    if _json_flag(ctx, as_json):
+        click.echo(_json.dumps([r.to_dict() for r in runs], indent=2))
+        return
+
+    blocks = [f"{_run_header(r)}\n{render_text(r)}" for r in runs if r.failures]
+    if not blocks:
+        click.echo("no failures")
+        return
+    click.echo("\n\n".join(blocks))
+
+
+__all__ = ["ci_group"]

--- a/tests/scitex_agent_container/cli_pkg/test__ci_why.py
+++ b/tests/scitex_agent_container/cli_pkg/test__ci_why.py
@@ -1,0 +1,419 @@
+"""Tests for the ``sac ci why`` failure-extraction core (``_ci_why``).
+
+No mocks. The parser is exercised on real-shaped GitHub-Actions log
+STRINGS (timestamp prefixes, ``##[group]`` noise, a ``FAILURES`` block,
+a ``short test summary info`` block, and a setup ``##[error]`` log). The
+run-level resolver is exercised through the injectable ``run_gh`` seam —
+a plain callable returning canned output — so nothing here touches the
+network. AAA, one logical assertion per test.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+from scitex_agent_container.cli_pkg._ci_why import (
+    CIWhyError,
+    RunFailures,
+    clean_log_line,
+    explain_run,
+    parse_failed_log,
+    parse_job_context,
+    render_text,
+    resolve_run_ids,
+    run_gh,
+    split_log_by_job,
+)
+
+# ---------------------------------------------------------------------------
+# Real-shaped fixtures: gh --log-failed prefixes each line
+# "<job>\t<step>\t<ISO-timestamp>Z <content>".
+# ---------------------------------------------------------------------------
+
+_PJ = "pytest-matrix-on-ubuntu-py3.11"
+_PS = "Run pytest"
+
+
+def _line(job: str, step: str, ts: str, content: str) -> str:
+    return f"{job}\t{step}\t{ts}Z {content}"
+
+
+PYTEST_LOG = "\n".join(
+    _line(_PJ, _PS, ts, content)
+    for ts, content in [
+        ("2026-07-15T10:00:00.1000000", "##[group]Run python -m pytest"),
+        ("2026-07-15T10:00:00.2000000", "python -m pytest -v"),
+        ("2026-07-15T10:00:00.3000000", "##[endgroup]"),
+        ("2026-07-15T10:00:01.0000000", "=============== FAILURES ==============="),
+        ("2026-07-15T10:00:01.1000000", "_______________ test_math _______________"),
+        ("2026-07-15T10:00:01.3000000", "    def test_math():"),
+        ("2026-07-15T10:00:01.4000000", ">       assert 3 == 4"),
+        ("2026-07-15T10:00:01.5000000", "E       assert 3 == 4"),
+        ("2026-07-15T10:00:01.7000000", "tests/test_math.py:5: AssertionError"),
+        (
+            "2026-07-15T10:00:02.0000000",
+            "=========== short test summary info ===========",
+        ),
+        (
+            "2026-07-15T10:00:02.1000000",
+            "FAILED tests/test_math.py::test_math - AssertionError: assert 3 == 4",
+        ),
+        (
+            "2026-07-15T10:00:02.2000000",
+            "=========== 1 failed, 4 passed in 0.12s ===========",
+        ),
+        ("2026-07-15T10:00:02.3000000", "##[error]Process completed with exit code 1."),
+    ]
+)
+
+_SJ = "no-hosted-runners-guard-on-self-hosted"
+_SS = "Run astral-sh/setup-uv@v3"
+
+SETUP_LOG = "\n".join(
+    _line(_SJ, _SS, ts, content)
+    for ts, content in [
+        ("2026-07-15T15:59:17.6765113", "##[group]Run astral-sh/setup-uv@v3"),
+        ("2026-07-15T15:59:17.6769300", "##[endgroup]"),
+        (
+            "2026-07-15T15:59:17.7931495",
+            'Downloading uv from "https://x/uv.tar.gz" ...',
+        ),
+        (
+            "2026-07-15T15:59:18.4499226",
+            "ENOENT: no such file or directory, open '/data/_temp/99eb7246'",
+        ),
+        (
+            "2026-07-15T15:59:48.7185987",
+            "##[error]ENOENT: no such file or directory, open '/data/_temp/99eb7246'",
+        ),
+    ]
+)
+
+TAIL_LOG = "\n".join(
+    _line("some-job-on-ubuntu-latest", "Build", ts, content)
+    for ts, content in [
+        ("2026-07-15T10:00:00.1000000", "##[group]Build"),
+        ("2026-07-15T10:00:00.2000000", "compiling module foo"),
+        ("2026-07-15T10:00:00.3000000", "##[endgroup]"),
+        ("2026-07-15T10:00:00.4000000", "linker: undefined reference to bar"),
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# clean_log_line — strips scaffolding.
+# ---------------------------------------------------------------------------
+
+
+def test_clean_log_line_strips_job_prefix_and_timestamp():
+    # Arrange
+    raw = _line(_PJ, _PS, "2026-07-15T10:00:02.1000000", "FAILED tests/t.py::t - X")
+    # Act
+    cleaned = clean_log_line(raw)
+    # Assert
+    assert cleaned == "FAILED tests/t.py::t - X"
+
+
+def test_clean_log_line_drops_group_markers():
+    # Arrange
+    raw = _line(_PJ, _PS, "2026-07-15T10:00:00.1000000", "##[group]Run x")
+    # Act
+    cleaned = clean_log_line(raw)
+    # Assert
+    assert cleaned is None
+
+
+def test_clean_log_line_keeps_error_annotation():
+    # Arrange
+    raw = _line(_SJ, _SS, "2026-07-15T15:59:48.7185987", "##[error]ENOENT: boom")
+    # Act
+    cleaned = clean_log_line(raw)
+    # Assert
+    assert cleaned == "##[error]ENOENT: boom"
+
+
+# ---------------------------------------------------------------------------
+# split_log_by_job — groups by first tab column.
+# ---------------------------------------------------------------------------
+
+
+def test_split_log_by_job_separates_two_jobs():
+    # Arrange
+    text = "\n".join(
+        [
+            _line("job-a", "s", "2026-07-15T10:00:00.1000000", "a1"),
+            _line("job-b", "s", "2026-07-15T10:00:00.2000000", "b1"),
+            _line("job-a", "s", "2026-07-15T10:00:00.3000000", "a2"),
+        ]
+    )
+    # Act
+    groups = split_log_by_job(text)
+    # Assert
+    assert list(groups) == ["job-a", "job-b"]
+
+
+# ---------------------------------------------------------------------------
+# parse_job_context — python version + OS from the job name.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_job_context_dotted_pyversion_and_os():
+    # Arrange
+    name = "pytest-matrix-on-ubuntu-py3.11"
+    # Act
+    py, os_ = parse_job_context(name)
+    # Assert
+    assert (py, os_) == ("3.11", "ubuntu")
+
+
+def test_parse_job_context_dashed_pyversion():
+    # Arrange
+    name = "import-smoke-on-ubuntu-py3-12"
+    # Act
+    py, _os = parse_job_context(name)
+    # Assert
+    assert py == "3.12"
+
+
+def test_parse_job_context_self_hosted_has_no_python():
+    # Arrange
+    name = "no-hosted-runners-guard-on-self-hosted"
+    # Act
+    py, os_ = parse_job_context(name)
+    # Assert
+    assert (py, os_) == (None, "self-hosted")
+
+
+# ---------------------------------------------------------------------------
+# parse_failed_log — the testable core.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_failed_log_extracts_failing_test_id():
+    # Arrange
+    log = PYTEST_LOG
+    # Act
+    fail = parse_failed_log(log, job_name=_PJ)
+    # Assert
+    assert fail.failed_tests == [
+        "FAILED tests/test_math.py::test_math - AssertionError: assert 3 == 4"
+    ]
+
+
+def test_parse_failed_log_extracts_assertion_line():
+    # Arrange
+    log = PYTEST_LOG
+    # Act
+    fail = parse_failed_log(log, job_name=_PJ)
+    # Assert
+    assert any("assert 3 == 4" in a for a in fail.assertions)
+
+
+def test_parse_failed_log_strips_timestamp_and_group_noise():
+    # Arrange
+    log = PYTEST_LOG
+    # Act
+    fail = parse_failed_log(log, job_name=_PJ)
+    # Assert — no scaffolding leaks into the extracted signal.
+    leaked = [
+        line
+        for line in fail.failed_tests + fail.assertions
+        if "2026-" in line or "##[group]" in line
+    ]
+    assert leaked == []
+
+
+def test_parse_failed_log_carries_matrix_context():
+    # Arrange
+    log = PYTEST_LOG
+    # Act
+    fail = parse_failed_log(log, job_name=_PJ)
+    # Assert
+    assert (fail.py, fail.os) == ("3.11", "ubuntu")
+
+
+def test_parse_failed_log_setup_failure_signal_is_annotation():
+    # Arrange
+    log = SETUP_LOG
+    # Act
+    fail = parse_failed_log(log, job_name=_SJ)
+    # Assert
+    assert fail.signal == "annotation"
+
+
+def test_parse_failed_log_setup_failure_surfaces_enoent():
+    # Arrange
+    log = SETUP_LOG
+    # Act
+    fail = parse_failed_log(log, job_name=_SJ)
+    # Assert
+    assert any("ENOENT" in e for e in fail.errors)
+
+
+def test_parse_failed_log_falls_back_to_tail_when_no_signal():
+    # Arrange
+    log = TAIL_LOG
+    # Act
+    fail = parse_failed_log(log, job_name="some-job-on-ubuntu-latest")
+    # Assert
+    assert "linker: undefined reference to bar" in fail.tail
+
+
+# ---------------------------------------------------------------------------
+# render_text — compact human output.
+# ---------------------------------------------------------------------------
+
+
+def test_render_text_says_no_failures_when_empty():
+    # Arrange
+    run = RunFailures(run_id="1")
+    # Act
+    rendered = render_text(run)
+    # Assert
+    assert rendered == "no failures"
+
+
+def test_render_text_is_far_smaller_than_the_raw_log():
+    # Arrange — the whole point: the reason costs a fraction of the log.
+    jf = parse_failed_log(PYTEST_LOG, job_name=_PJ)
+    run = RunFailures(run_id="1", failures=[jf])
+    # Act
+    rendered = render_text(run)
+    # Assert
+    assert len(rendered) < len(PYTEST_LOG) // 2
+
+
+def test_render_text_includes_the_failing_test_id():
+    # Arrange
+    jf = parse_failed_log(PYTEST_LOG, job_name=_PJ)
+    run = RunFailures(run_id="1", failures=[jf])
+    # Act
+    rendered = render_text(run)
+    # Assert
+    assert "tests/test_math.py::test_math" in rendered
+
+
+# ---------------------------------------------------------------------------
+# run_gh seam — honest failure, and gh-pr-checks non-zero semantics.
+# ---------------------------------------------------------------------------
+
+
+def test_run_gh_raises_when_gh_missing():
+    # Arrange
+    def _no_gh(*_a, **_kw):
+        raise FileNotFoundError("gh")
+
+    captured = None
+    # Act
+    try:
+        run_gh(["run", "list"], _run=_no_gh)
+    except CIWhyError as exc:
+        captured = exc
+    # Assert
+    assert captured is not None
+
+
+def test_run_gh_returns_stdout_on_nonzero_with_output():
+    # Arrange — gh pr checks exits non-zero when checks fail, yet prints JSON.
+    def _fake(argv, **_kw):
+        return subprocess.CompletedProcess(argv, 1, stdout='[{"a":1}]', stderr="")
+
+    # Act
+    out = run_gh(["pr", "checks", "712"], _run=_fake)
+    # Assert
+    assert out == '[{"a":1}]'
+
+
+def test_run_gh_raises_on_nonzero_with_empty_output():
+    # Arrange — a bad run id: non-zero AND nothing on stdout is a real error.
+    def _fake(argv, **_kw):
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="not found")
+
+    captured = None
+    # Act
+    try:
+        run_gh(["run", "view", "0"], _run=_fake)
+    except CIWhyError as exc:
+        captured = exc
+    # Assert
+    assert captured is not None
+
+
+# ---------------------------------------------------------------------------
+# Resolver + explain_run — through the injected run_gh seam (no network).
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_run_ids_treats_large_number_as_run_id_without_calling_gh():
+    # Arrange — a run id must not cost a gh round-trip.
+    def _boom(_args):
+        raise RuntimeError("gh should not be called for a bare run id")
+
+    # Act
+    ids = resolve_run_ids("29446283736", run_gh=_boom)
+    # Assert
+    assert ids == ["29446283736"]
+
+
+def test_resolve_run_ids_pr_number_extracts_failing_run_id():
+    # Arrange — one failing check, its link carries the run id.
+    checks = [
+        {"bucket": "pass", "state": "SUCCESS", "link": ".../actions/runs/111/job/1"},
+        {
+            "bucket": "fail",
+            "state": "FAILURE",
+            "link": "https://github.com/o/r/actions/runs/29446283736/job/9",
+        },
+    ]
+
+    def _fake(_args):
+        return json.dumps(checks)
+
+    # Act
+    ids = resolve_run_ids("712", run_gh=_fake)
+    # Assert
+    assert ids == ["29446283736"]
+
+
+def _gh_router(jobs: list[dict], log_text: str):
+    """A canned run_gh: run-view JSON on --json, the log on --log-failed."""
+
+    def _router(args: list[str]) -> str:
+        if "--log-failed" in args:
+            return log_text
+        if "--json" in args:
+            return json.dumps(
+                {
+                    "workflowName": "tests",
+                    "displayTitle": "t",
+                    "headBranch": "b",
+                    "jobs": jobs,
+                }
+            )
+        raise RuntimeError(f"unexpected gh args: {args}")
+
+    return _router
+
+
+def test_explain_run_green_has_no_failures():
+    # Arrange
+    router = _gh_router([{"name": "x", "conclusion": "success"}], "")
+    # Act
+    run = explain_run("10000001", run_gh=router)
+    # Assert
+    assert run.failures == []
+
+
+def test_explain_run_parses_the_failing_job():
+    # Arrange
+    jobs = [{"name": _PJ, "conclusion": "failure"}]
+    router = _gh_router(jobs, PYTEST_LOG)
+    # Act
+    run = explain_run("10000002", run_gh=router)
+    # Assert
+    assert (
+        run.failures[0]
+        .failed_tests[0]
+        .startswith("FAILED tests/test_math.py::test_math")
+    )

--- a/tests/scitex_agent_container/cli_pkg/test_ci_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_ci_group.py
@@ -1,0 +1,149 @@
+"""CLI wiring tests for ``sac ci why``.
+
+No mocks: a real fake ``gh`` executable is installed on ``PATH`` (a tiny
+Python script that prints canned run-view JSON and ``--log-failed``
+output). The command therefore drives the true ``run_gh`` subprocess
+path end-to-end. A bare run id resolves without a gh round-trip, so
+these exercise ``explain_run`` + rendering + the click surface. PATH is
+set through the repo's ``env_save_restore`` fixture (save/restore on
+teardown — no ``monkeypatch``). AAA, one assertion per test.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from scitex_agent_container.cli import main
+
+# A 10+ digit id → treated as a run id, so resolution needs no gh call.
+_RUN_ID = "29446283736"
+_PJ = "pytest-matrix-on-ubuntu-py3.11"
+
+
+def _log_line(content: str, ts: str = "2026-07-15T10:00:02.1000000") -> str:
+    return f"{_PJ}\tRun pytest\t{ts}Z {content}"
+
+
+# A realistically noisy pytest failure log (tab/timestamp/group scaffolding).
+PYTEST_LOG = "\n".join(
+    [
+        _log_line("##[group]Run python -m pytest", "2026-07-15T10:00:00.1000000"),
+        _log_line("python -m pytest -v tests/", "2026-07-15T10:00:00.2000000"),
+        _log_line("##[endgroup]", "2026-07-15T10:00:00.3000000"),
+        _log_line(
+            "=============== FAILURES ===============", "2026-07-15T10:00:01.0000000"
+        ),
+        _log_line("E       assert 3 == 4", "2026-07-15T10:00:01.5000000"),
+        _log_line("=========== short test summary info ==========="),
+        _log_line(
+            "FAILED tests/test_math.py::test_math - AssertionError: assert 3 == 4"
+        ),
+        _log_line("=========== 1 failed, 4 passed in 0.12s ==========="),
+        _log_line("##[error]Process completed with exit code 1."),
+    ]
+)
+
+# Hand-written JSON strings (no json module → no provenance-audit noise).
+META_FAIL = (
+    '{"workflowName":"quality","displayTitle":"t","headBranch":"b",'
+    '"conclusion":"failure","jobs":['
+    '{"name":"pytest-matrix-on-ubuntu-py3.11","conclusion":"failure"}]}'
+)
+META_GREEN = (
+    '{"workflowName":"tests","displayTitle":"t","headBranch":"b",'
+    '"conclusion":"success","jobs":[{"name":"x","conclusion":"success"}]}'
+)
+
+_FAKE_GH = """#!/usr/bin/env python3
+import sys
+args = sys.argv[1:]
+if "--log-failed" in args:
+    sys.stdout.write(open({log!r}).read())
+elif "--json" in args:
+    sys.stdout.write(open({meta!r}).read())
+else:
+    sys.stderr.write("fake gh: unhandled %r\\n" % (args,))
+    sys.exit(9)
+"""
+
+_BROKEN_GH = """#!/usr/bin/env python3
+import sys
+sys.stderr.write("could not find any workflows named 0\\n")
+sys.exit(1)
+"""
+
+
+def _install_gh(tmp_path: Path, env, script: str) -> None:
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    gh = bindir / "gh"
+    gh.write_text(script)
+    gh.chmod(gh.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    env.set("PATH", str(bindir) + os.pathsep + os.environ["PATH"])
+
+
+def _install_fake_gh(tmp_path: Path, env, meta: str, log_text: str) -> None:
+    (tmp_path / "log.txt").write_text(log_text)
+    (tmp_path / "meta.json").write_text(meta)
+    script = _FAKE_GH.format(
+        log=str(tmp_path / "log.txt"), meta=str(tmp_path / "meta.json")
+    )
+    _install_gh(tmp_path, env, script)
+
+
+def test_why_renders_the_failing_test_id(tmp_path: Path, env_save_restore):
+    # Arrange
+    _install_fake_gh(tmp_path, env_save_restore, META_FAIL, PYTEST_LOG)
+    # Act
+    result = CliRunner().invoke(main, ["ci", "why", _RUN_ID])
+    # Assert
+    assert "tests/test_math.py::test_math" in result.output
+
+
+def test_why_output_is_smaller_than_the_raw_log(tmp_path: Path, env_save_restore):
+    # Arrange — the inversion: the reason costs a fraction of the log.
+    _install_fake_gh(tmp_path, env_save_restore, META_FAIL, PYTEST_LOG)
+    # Act
+    result = CliRunner().invoke(main, ["ci", "why", _RUN_ID])
+    # Assert
+    assert len(result.output) < len(PYTEST_LOG)
+
+
+def test_why_strips_group_noise_from_output(tmp_path: Path, env_save_restore):
+    # Arrange
+    _install_fake_gh(tmp_path, env_save_restore, META_FAIL, PYTEST_LOG)
+    # Act
+    result = CliRunner().invoke(main, ["ci", "why", _RUN_ID])
+    # Assert
+    assert "##[group]" not in result.output
+
+
+def test_why_green_run_says_no_failures(tmp_path: Path, env_save_restore):
+    # Arrange
+    _install_fake_gh(tmp_path, env_save_restore, META_GREEN, "")
+    # Act
+    result = CliRunner().invoke(main, ["ci", "why", _RUN_ID])
+    # Assert
+    assert result.output.strip() == "no failures"
+
+
+def test_why_json_flag_emits_structured_output(tmp_path: Path, env_save_restore):
+    # Arrange
+    _install_fake_gh(tmp_path, env_save_restore, META_FAIL, PYTEST_LOG)
+    # Act
+    result = CliRunner().invoke(main, ["ci", "why", _RUN_ID, "--json"])
+    # Assert
+    assert '"failed_tests"' in result.output
+
+
+def test_why_reports_gh_failure_loudly(tmp_path: Path, env_save_restore):
+    # Arrange — gh errors: UNKNOWN must fail loud, never print "no failures".
+    _install_gh(tmp_path, env_save_restore, _BROKEN_GH)
+    # Act
+    result = CliRunner().invoke(main, ["ci", "why", _RUN_ID])
+    # Assert
+    assert result.exit_code != 0


### PR DESCRIPTION
## Why

Reading CI **status** is one cheap word — `gh pr checks` says `failure`. Reading **why** has been tens of thousands of lines — `gh run view --log-failed` dumps every failed step in full. An agent with a bounded context window is economically steered to the cheap call, and the status word then becomes a **replacement** for the reason instead of a summary of it. That is how the day's two worst incidents (11 ghost releases; frozen containers) slipped through — nobody read WHY. A written "I'll always read the log" promise is a notification, not an enforcement. This **inverts the price**: make reading the real failure as cheap as reading the status word, and there is no economic reason to skip it.

Card: `sac-make-reading-a-ci-failure-as-cheap-as-reading-its-status-20260715` (P0, operator-asked).

## What

`sac ci why <pr#|run-id|branch>` (new `ci` group, registered under Diagnostics):

- **Resolve** the target: a PR number → its failing check-run(s) (via `gh pr checks`, run id parsed from each failing check's link); a run id → that run; a branch or nothing → the latest run for that branch.
- **Fetch once, parse down.** For each failing job it fetches `--log-failed` a single time and distils it to a few hundred bytes, in priority order:
  1. `=== short test summary info ===` `FAILED …` test IDs (cheapest signal);
  2. the `E   …` assertion lines from the `=== FAILURES ===` block;
  3. the `##[error] …` annotation for a setup/infra failure that never reached pytest (e.g. a `setup-uv` ENOENT / copyfile error);
  4. fallback: the last N non-blank lines.
- GitHub-Actions scaffolding (the gh `job\tstep\t` prefix, the ISO-8601 timestamp, `##[group]`/`##[endgroup]`) is stripped first.
- `--json` for machine reading; a green run prints `no failures`.
- A gh error (missing / unauthenticated / bad id) is **UNKNOWN, not green**: it fails loud with a non-zero exit, never a reassuring `no failures`.

## Design

- **`cli_pkg/_ci_why.py`** — the pure, network-free parser core (`clean_log_line`, `split_log_by_job`, `parse_job_context`, `parse_failed_log`) plus the run-level resolver. `gh` is reached only through the injectable **`run_gh`** seam.
- **`cli_pkg/ci_group.py`** — the thin click group + `why` verb.

## Tests (no mocks)

- `test__ci_why.py` — the parser exercised off real-shaped GitHub-Actions log **strings** (timestamp prefixes, `##[group]` noise, a `FAILURES` block, a `short test summary` block, and a setup `##[error]` log); the resolver exercised through an injected `run_gh` callable — no network.
- `test_ci_group.py` — the CLI driven end-to-end against a **real fake `gh`** installed on `PATH` (a tiny script), so it exercises the true `run_gh` subprocess path. PATH is set via the repo's `env_save_restore` fixture (no `monkeypatch`).
- 30/30 pass under `/opt/venv-sac/bin/python` with `PYTHONPATH=src`.

## Watch it fail (real run)

Ran the new command against the real failing run `29446283736` (the `quality` job on PR #712) — a 37,546-byte / 257-line log:

```
$ sac ci why 29446283736
run 29446283736  quality  @ docs/product-readme
https://github.com/scitex-ai/scitex-agent-container/actions/runs/29446283736
scitex-dev-quality-audit-on-ubuntu-latest (ubuntu-latest)
  ##[error] error: could not lock config file …/.gitconfig: File exists
  ##[error] fatal: no submodule mapping found in .gitmodules for path '.tmp-audit/scitex-browser'
  ##[error] Unknown system error -116: … copyfile '…/uv-x86_64-unknown-linux-gnu/uv' -> '…/.runner-toolcache/uv/0.11.29/x86_64/uv'
  -> https://github.com/scitex-ai/scitex-agent-container/actions/runs/29446283736/job/87457438439
```

`sac ci why 712` (the PR) resolves to the same run and prints identically. This is exactly the `setup-uv` failure class the card names.

## Not merging

PR to `develop`; do **not** merge — for review.
