### PR TITLE
feat(verdict): WEDGED state — a screen instrument so an auth-dead agent never reads ALIVE

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_verdict.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict.py
@@ -33,14 +33,23 @@ Four rules, and they are the whole module
    that timed out, a peer on a host we cannot see → :data:`UNKNOWN`, named,
    with the reason attached. Not ``False``.
 
-2. **Positive evidence of life is never overruled.** If ANY signal observed
-   the agent alive, the verdict is :data:`ALIVE` — whatever the other signals
-   say. This is not a heuristic, it is a lesson: an earlier
+2. **Positive evidence of life is never overruled — but PRESENCE is not life.**
+   If a signal observed the agent ALIVE, the verdict is :data:`ALIVE` — whatever
+   the other signals say. This is not a heuristic, it is a lesson: an earlier
    ``pid AND port AND session_id`` predicate was refuted by ``scitex-writer``,
    which carried a stale ``startup_failed`` status, an unbound port and a null
    session_id — and was answering messages. Every one of those "dead" signals
    was a PROXY. The one that observed the agent itself said alive. Proxies
    lose.
+
+   The refinement WEDGED adds: a ``process`` / ``heartbeat`` / ``registry``
+   ALIVE observes only that the pid EXISTS — the session is up, the pane pid is
+   alive — NOT that the agent is WORKING. So those PRESENCE-ALIVEs are overruled
+   by a :data:`._verdict_instruments.WEDGED` from the screen instrument, which
+   read the pane's CONTENT and found a frozen auth banner (the ``scitex-clew``
+   auth-death that sat GREEN for two days). The one ALIVE that is real life, not
+   mere presence — a ``delivery`` ALIVE, the broker seeing the inbox reachable —
+   still wins outright. Presence loses to WEDGED; life does not.
 
 3. **Only a CORROBORATED DEAD may authorise destruction.** See
    :attr:`LivenessVerdict.may_destroy`. :data:`UNKNOWN` authorises NOTHING
@@ -98,13 +107,16 @@ from ._verdict_instruments import (
     INSTRUMENT_LISTEN_BROKER,
     INSTRUMENT_NO_OBSERVATION,
     INSTRUMENT_PID_NAMESPACE,
+    INSTRUMENT_TUI_SCREEN,
     INSTRUMENTS,
     SOURCE_DELIVERY,
     SOURCE_HEARTBEAT,
     SOURCE_PROCESS,
     SOURCE_REGISTRY,
     SOURCE_RESOLVER,
+    SOURCE_SCREEN,
     UNKNOWN,
+    WEDGED,
     InstrumentSpec,
     Signal,
 )
@@ -113,16 +125,19 @@ __all__ = [
     "ALIVE",
     "DEAD",
     "UNKNOWN",
+    "WEDGED",
     "SOURCE_DELIVERY",
     "SOURCE_HEARTBEAT",
     "SOURCE_PROCESS",
     "SOURCE_REGISTRY",
     "SOURCE_RESOLVER",
+    "SOURCE_SCREEN",
     "INSTRUMENT_AGENT_SELF",
     "INSTRUMENT_HOST_TMUX",
     "INSTRUMENT_LISTEN_BROKER",
     "INSTRUMENT_NO_OBSERVATION",
     "INSTRUMENT_PID_NAMESPACE",
+    "INSTRUMENT_TUI_SCREEN",
     "INSTRUMENTS",
     "CONVICTING_INSTRUMENTS",
     "INSTRUMENT_INDEPENDENCE",
@@ -174,6 +189,10 @@ class LivenessVerdict:
 
     @property
     def is_alive(self) -> bool:
+        # UNCHANGED, and load-bearing: is_alive is ``verdict == ALIVE``, so a
+        # WEDGED verdict reads is_alive False BY CONSTRUCTION. That is the whole
+        # point — an auth-dead agent that a pid/session proxy calls ALIVE now
+        # resolves to WEDGED, and WEDGED is not ALIVE.
         return self.verdict == ALIVE
 
     @property
@@ -183,6 +202,17 @@ class LivenessVerdict:
     @property
     def is_unknown(self) -> bool:
         return self.verdict == UNKNOWN
+
+    @property
+    def is_wedged(self) -> bool:
+        """PRESENT but not WORKING — a frozen auth banner, not a corpse.
+
+        Distinct from every pole: is_alive / is_dead / is_unknown are all False
+        for a wedged agent. It is not ALIVE (it is not working), not DEAD (the
+        process is present, so destruction is not authorised), and not UNKNOWN
+        (we DID observe it — we observed that it is stuck).
+        """
+        return self.verdict == WEDGED
 
     @property
     def dead_sources(self) -> tuple[str, ...]:
@@ -276,6 +306,13 @@ class LivenessVerdict:
                 f"{self.agent} is ALIVE ({', '.join(self.alive_sources)}) — "
                 f"refusing to destroy a live agent"
             )
+        if self.verdict == WEDGED:
+            return (
+                f"{self.agent} is WEDGED — present but not working (a frozen "
+                f"auth banner sits above its prompt). A restart clears a "
+                f"rotated/stale token; destruction is NOT authorised, because "
+                f"the process is alive and a wedged agent is not a corpse"
+            )
         if self.verdict == UNKNOWN:
             return (
                 f"{self.agent} liveness is UNKNOWN — no signal observed it "
@@ -360,19 +397,37 @@ class LivenessVerdict:
 def decide(agent: str, signals: Iterable[Signal] | Sequence[Signal]) -> LivenessVerdict:
     """Fold observations into a verdict. Pure — no IO, no clock, no guessing.
 
-    The rules, in order:
+    The rules, in strict order:
 
-    1. **Any LIVE ALIVE ⇒ ALIVE.** Positive evidence of life is never overruled
-       by the ABSENCE of other evidence. An agent that fails four proxy checks
-       and answers one real one is a running agent. The lone exception is a
-       heartbeat ALIVE contradicted by a LIVE probe of the SAME instrument: a
-       TUI beat merely re-reports the tmux snapshot ``process_signal`` reads
-       live, so a live "no such session" (DEAD) ages that beat out. That is the
-       instruments-not-sources rule across time, not a crack in the veto — a
-       delivery/process ALIVE is a live observation and is never suppressed.
-    2. **Else any DEAD ⇒ DEAD.** Death needs POSITIVE evidence — a probe that
+    1. **A ``delivery`` ALIVE is authoritative ⇒ ALIVE.** The broker OBSERVED the
+       agent's inbox adapter attached — the one signal that watched a message be
+       able to WAKE the agent, not a shadow of it. A broker-reachable agent is
+       working, full stop, so it is never flagged. This is FIRST so it beats even
+       WEDGED — see rule 2's rationale.
+    2. **Any WEDGED ⇒ WEDGED.** The screen instrument read the pane's rendered
+       CONTENT and found a FROZEN auth banner above the prompt: the agent is
+       PRESENT but NOT WORKING. This OVERRULES a ``process`` / ``heartbeat`` /
+       ``registry`` ALIVE, because every one of those observes only that the pid
+       EXISTS (the tmux session is up, the pane pid is alive) — none of them
+       looks at whether the agent can actually do anything. That gap is the
+       false-green this whole change exists to close: ``scitex-clew`` sat
+       auth-dead for two days behind a pid-shaped ALIVE. Why a delivery-ALIVE
+       (rule 1) still beats WEDGED: a broker-reachable agent is demonstrably
+       working, the false-red cost of flagging it would be high, and the founding
+       incident had delivery != ALIVE (the wedged agent's inbox was NOT
+       observed reachable), so ordering delivery above WEDGED costs the fix
+       nothing while keeping a live, answering agent from ever reading wedged.
+    3. **Else any LIVE ALIVE ⇒ ALIVE** (the #705 stale-heartbeat carve-out is
+       preserved here verbatim). Positive evidence of life is never overruled by
+       the ABSENCE of other evidence: an agent that fails four proxy checks and
+       answers one real one is running. The lone exception is a heartbeat ALIVE
+       contradicted by a LIVE probe of the SAME instrument — a TUI beat merely
+       re-reports the tmux snapshot ``process_signal`` reads live, so a live "no
+       such session" (DEAD) ages that beat out. (A delivery ALIVE already
+       returned in rule 1 and is never reached here.)
+    4. **Else any DEAD ⇒ DEAD.** Death needs POSITIVE evidence — a probe that
        actually ran and actually found nothing.
-    3. **Else UNKNOWN.** No observation either way. This is a real answer, and
+    5. **Else UNKNOWN.** No observation either way. This is a real answer, and
        the ONE thing a caller may not do with it is destroy something.
 
     Note what is absent: there is no path from "we gathered nothing" to
@@ -380,21 +435,37 @@ def decide(agent: str, signals: Iterable[Signal] | Sequence[Signal]) -> Liveness
 
     Note also what this does NOT decide: whether the DEAD may be ACTED on. A
     DEAD verdict is a report; :attr:`LivenessVerdict.may_destroy` is the gate,
-    and it counts INSTRUMENTS.
+    and it counts INSTRUMENTS. A WEDGED verdict authorises nothing destructive
+    either — ``may_destroy`` gates on DEAD, and WEDGED is not DEAD.
     """
     sigs = tuple(signals)
-    # A heartbeat is a STALE ARTEFACT: a value some other loop wrote to a file
-    # at a past beat, re-reporting an instrument it sampled THEN. For a TUI agent
-    # it re-reports the very tmux snapshot process_signal probes LIVE — so when a
-    # live probe of the SAME instrument now returns DEAD (the tmux server
-    # positively has no such session), the older beat is out of date and must
-    # not vouch for life: "now" supersedes "up to 600s ago" ON ONE INSTRUMENT.
-    # This is the count-instruments-not-sources rule in the time dimension — one
-    # sensor cannot be alive and dead at once, and its LIVE reading beats its own
-    # stale echo. (A reboot left a <600s beat behind a vanished session; the fold
-    # read ALIVE and sac-start refused to relaunch a genuinely dead agent until
-    # the beat finally aged past 600s.) A delivery/process ALIVE is a LIVE
-    # observation, not an artefact, so it is never suppressed here.
+    # (1) A delivery ALIVE is a LIVE observation of the one thing that matters —
+    # can a message reach this agent — and it is supreme, ABOVE even a WEDGED. It
+    # is pulled out of the general positive-life step (rule 3) purely so it sits
+    # ahead of rule 2.
+    for sig in sigs:
+        if sig.verdict == ALIVE and sig.source == SOURCE_DELIVERY:
+            return LivenessVerdict(agent=agent, verdict=ALIVE, signals=sigs)
+    # (2) Any WEDGED wins over a pid/session ALIVE. Those proxies see only that
+    # the process EXISTS; the screen instrument saw that it is not WORKING. A
+    # WEDGED that reaches here is already fresh + this-incarnation — all the
+    # staleness / SUPERSEDED gating lives in ``screen_signal`` — so it is trusted
+    # at face value.
+    for sig in sigs:
+        if sig.verdict == WEDGED:
+            return LivenessVerdict(agent=agent, verdict=WEDGED, signals=sigs)
+    # (3) The general positive-life step, WITH the #705 stale-heartbeat carve-out
+    # intact. A heartbeat is a STALE ARTEFACT: a value some other loop wrote to a
+    # file at a past beat, re-reporting an instrument it sampled THEN. For a TUI
+    # agent it re-reports the very tmux snapshot process_signal probes LIVE — so
+    # when a live probe of the SAME instrument now returns DEAD (the tmux server
+    # positively has no such session), the older beat is out of date and must not
+    # vouch for life: "now" supersedes "up to 600s ago" ON ONE INSTRUMENT. This
+    # is the count-instruments-not-sources rule in the time dimension — one sensor
+    # cannot be alive and dead at once, and its LIVE reading beats its own stale
+    # echo. (A reboot left a <600s beat behind a vanished session; the fold read
+    # ALIVE and sac-start refused to relaunch a genuinely dead agent until the
+    # beat finally aged past 600s.)
     dead_instruments = {s.instrument for s in sigs if s.verdict == DEAD}
     for sig in sigs:
         if sig.verdict != ALIVE:
@@ -402,7 +473,9 @@ def decide(agent: str, signals: Iterable[Signal] | Sequence[Signal]) -> Liveness
         if sig.source == SOURCE_HEARTBEAT and sig.instrument in dead_instruments:
             continue  # stale echo of an instrument a live probe just found DEAD
         return LivenessVerdict(agent=agent, verdict=ALIVE, signals=sigs)
+    # (4) any DEAD ⇒ DEAD.
     for sig in sigs:
         if sig.verdict == DEAD:
             return LivenessVerdict(agent=agent, verdict=DEAD, signals=sigs)
+    # (5) else UNKNOWN.
     return LivenessVerdict(agent=agent, verdict=UNKNOWN, signals=sigs)

--- a/src/scitex_agent_container/_lifecycle/_verdict_instruments.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict_instruments.py
@@ -50,16 +50,19 @@ __all__ = [
     "ALIVE",
     "DEAD",
     "UNKNOWN",
+    "WEDGED",
     "SOURCE_DELIVERY",
     "SOURCE_HEARTBEAT",
     "SOURCE_PROCESS",
     "SOURCE_REGISTRY",
     "SOURCE_RESOLVER",
+    "SOURCE_SCREEN",
     "INSTRUMENT_AGENT_SELF",
     "INSTRUMENT_HOST_TMUX",
     "INSTRUMENT_LISTEN_BROKER",
     "INSTRUMENT_NO_OBSERVATION",
     "INSTRUMENT_PID_NAMESPACE",
+    "INSTRUMENT_TUI_SCREEN",
     "INSTRUMENTS",
     "CONVICTING_INSTRUMENTS",
     "INSTRUMENT_INDEPENDENCE",
@@ -67,10 +70,29 @@ __all__ = [
     "Signal",
 ]
 
-# The three states. There is no fourth, and there is deliberately no bool.
+# The three CORE states — ALIVE / DEAD / UNKNOWN — and WEDGED, a fourth that is
+# deliberately NOT a pole. There is still no bool.
+#
+# ALIVE / DEAD / UNKNOWN are the ternary every PROXY sensor speaks: observed
+# alive, a corroborated absence, or "I could not tell". WEDGED is different in
+# KIND — it is the answer of the one instrument that reads whether the agent is
+# WORKING rather than merely PRESENT. The process exists and its tmux session is
+# up (so every pid/session proxy reads ALIVE), yet a frozen auth-rejection banner
+# sits on its pane and it is doing nothing. WEDGED is NOT a pole:
+#
+#   * a wedged agent is PRESENT, so DEAD — "positive evidence of absence" — would
+#     be a lie, and destruction is NEVER authorised on it (``may_destroy`` gates
+#     on DEAD, so a WEDGED verdict can arm nothing); yet
+#   * it is not WORKING, so ALIVE would be exactly the false-green this state
+#     exists to kill (``is_alive`` stays ``verdict == ALIVE``, so WEDGED reads
+#     is_alive False by construction — the hard requirement).
+#
+# See :func:`.._verdict.decide` for where WEDGED sits in the precedence (below a
+# delivery-ALIVE, above the pid/session positive-life step).
 ALIVE = "alive"
 DEAD = "dead"
 UNKNOWN = "unknown"
+WEDGED = "wedged"
 
 # Signal SOURCES — the reporter that carried the news. Descending evidential
 # strength. NOTE: a source is NOT a sensor; see the module docstring.
@@ -79,6 +101,9 @@ SOURCE_PROCESS = "process"  # a process/session probe (pane pid, apptainer pid).
 SOURCE_HEARTBEAT = "heartbeat"  # a beat file someone refreshed.
 SOURCE_REGISTRY = "registry"  # a row in a table. A declaration, not an observation.
 SOURCE_RESOLVER = "resolver"  # the gatherer itself failed. Observes nothing, ever.
+SOURCE_SCREEN = (
+    "screen"  # the rendered CONTENT of the tui pane. Reads WORKING, not presence.
+)
 
 # Signal INSTRUMENTS — what PHYSICALLY made the observation.
 INSTRUMENT_LISTEN_BROKER = "listen_broker"
@@ -86,6 +111,7 @@ INSTRUMENT_HOST_TMUX = "host_tmux"
 INSTRUMENT_PID_NAMESPACE = "pid_namespace"
 INSTRUMENT_AGENT_SELF = "agent_self"
 INSTRUMENT_NO_OBSERVATION = "no_observation"
+INSTRUMENT_TUI_SCREEN = "tui_screen"
 
 
 @dataclass(frozen=True)
@@ -182,6 +208,32 @@ INSTRUMENT_INDEPENDENCE: dict[str, InstrumentSpec] = {
         verdicts=frozenset({UNKNOWN}),
         blind_when="always — by definition it observed nothing",
     ),
+    INSTRUMENT_TUI_SCREEN: InstrumentSpec(
+        reads=(
+            "the rendered CONTENT of the tui-<name> pane — whether a FROZEN auth "
+            "banner sits directly above the input prompt (read from the cached "
+            "``sac agents auth-status`` verdict, itself produced by the "
+            "2-run-frozen matcher). It observes whether the agent is WORKING, as "
+            "opposed to every pid/session sensor which observes only that the "
+            "process is PRESENT. A tmux-GREEN agent stuck under an auth-rejection "
+            "banner — pid alive, session up, doing nothing — is the exact "
+            "false-green this instrument exists to catch."
+        ),
+        # Never ALIVE (a clean pane is not proof of life — the agent may be busy,
+        # idle, or wedged in a way this banner match does not recognise) and
+        # never DEAD (the pane, and the process behind it, are PRESENT — a wedged
+        # agent is not a corpse, and DEAD would arm a destruction against a living
+        # process). It emits exactly WEDGED (a frozen banner) or UNKNOWN. Because
+        # DEAD ∉ verdicts, ``may_convict`` is False and it is absent from
+        # CONVICTING_INSTRUMENTS — it can NEVER arm a destroy.
+        verdicts=frozenset({WEDGED, UNKNOWN}),
+        blind_when=(
+            "the pane is uncapturable, there is no tui-<name> session on this "
+            "host, we are inside a container (the host's tmux is in another mount "
+            "namespace), or the auth-status cache is stale or absent — all of "
+            "which degrade to UNKNOWN, never a false WEDGE"
+        ),
+    ),
 }
 
 INSTRUMENTS = frozenset(INSTRUMENT_INDEPENDENCE)
@@ -228,12 +280,17 @@ class Signal:
     instrument: str
 
     def __post_init__(self) -> None:
-        if self.verdict not in (ALIVE, DEAD, UNKNOWN):
+        if self.verdict not in (ALIVE, DEAD, UNKNOWN, WEDGED):
             raise ValueError(
                 f"Signal.verdict must be one of {ALIVE!r} / {DEAD!r} / "
-                f"{UNKNOWN!r}, got {self.verdict!r}. A liveness signal is "
-                f"never a bool — 'I could not tell' is a first-class answer "
-                f"and must be spelled {UNKNOWN!r}, never collapsed into a pole."
+                f"{UNKNOWN!r} / {WEDGED!r}, got {self.verdict!r}. A liveness "
+                f"signal is never a bool — 'I could not tell' is a first-class "
+                f"answer and must be spelled {UNKNOWN!r}, never collapsed into a "
+                f"pole. {WEDGED!r} (present but not working) is the one non-pole "
+                f"state, and the InstrumentSpec still decides WHICH instrument "
+                f"may emit it (only the screen sensor), so a "
+                f"Signal(..., {WEDGED!r}, ...) on any other instrument still "
+                f"raises below."
             )
         spec = INSTRUMENT_INDEPENDENCE.get(self.instrument)
         if spec is None:

--- a/src/scitex_agent_container/_lifecycle/_verdict_remote.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict_remote.py
@@ -1,0 +1,190 @@
+"""Cross-host REMOTE liveness — is the agent's tmux session up ON ITS PEER?
+
+Split out of :mod:`._verdict_resolve` (512-line cap) along a real seam: this is
+the ONE resolver that reaches ANOTHER HOST. An agent whose ``spec.host`` is a
+remote peer keeps its TUI session on that peer, so the LOCAL tmux is blind to it
+and the ordinary :func:`._verdict_resolve.process_signal` would read a false
+"no local session" DEAD. This module ssh-probes the peer's own tmux bookkeeping
+instead (the control-plane cross-host liveness added by #708-#710).
+
+Re-exported from :mod:`._verdict_resolve` so ``from ._verdict_resolve import
+remote_process_signal`` and the resolver's own use of it keep working unchanged.
+Same doctrine as every resolver here: a probe that could not run is
+:data:`._verdict.UNKNOWN`, never :data:`._verdict.DEAD` — a wedged ssh, a broken
+ProxyJump, a bare login PATH or an auth failure must not slander a live remote
+agent into a destroyable corpse.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from ._verdict import (
+    ALIVE,
+    DEAD,
+    INSTRUMENT_HOST_TMUX,
+    SOURCE_PROCESS,
+    UNKNOWN,
+    Signal,
+)
+from ._verdict_tmux import session_name_for_config
+
+__all__ = [
+    "remote_process_signal",
+]
+
+
+def _remote_peer_for_config(config: Any) -> str | None:
+    """Return the peer name if the agent's ``spec.host`` is a remote peer.
+
+    Uses the SAME ``classify_dispatch_host`` resolver ``sac agents start`` and
+    ``sac agents attach`` route through, so "remote" means one thing across
+    the whole control plane. Best-effort — any resolution failure returns
+    ``None`` and the caller falls back to the ordinary (local) process probe.
+    Imports are LAZY to avoid a ``cli_pkg`` -> ``_lifecycle`` import cycle.
+    """
+    try:
+        from ..cli_pkg.lifecycle._common import (
+            _local_host_names,
+            classify_dispatch_host,
+        )
+        from ..config._host import resolve_hostname
+
+        spec = config.hosts_spec
+        host = spec.host
+        target = host if isinstance(host, str) else (host[0] if host else None)
+        if not target:
+            return None
+        from .._state.host_config import load as _load_host_config
+
+        current = resolve_hostname()
+        peers = _load_host_config().peers
+        kind, peer = classify_dispatch_host(
+            target, current, peers, local_names=_local_host_names(current)
+        )
+        return peer if kind == "remote" else None
+    except Exception:  # stx-allow: fallback (unresolvable host -> treat as local; the local probe still runs)
+        return None
+
+
+def _run_ssh_rc(argv: list[str]) -> int:
+    """Run ``argv`` and return its exit code (default remote-probe runner).
+
+    A generous 10s timeout keeps a wedged peer from hanging a listing; on
+    timeout or a missing ssh binary we return 255 (ssh's own connection-failed
+    code) so :func:`remote_process_signal` maps it to UNKNOWN. Injection seam —
+    tests pass their own runner and never shell out.
+    """
+    import subprocess
+
+    try:
+        return subprocess.run(argv, capture_output=True, timeout=10).returncode
+    except (
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ):  # stx-allow: fallback (ssh could not run -> 255 -> UNKNOWN upstream)
+        return 255
+
+
+def remote_process_signal(
+    config: Any,
+    peer: str,
+    *,
+    run_ssh: Callable[[list[str]], int] | None = None,
+) -> Signal:
+    """Is the agent's tmux session up ON ITS REMOTE HOST (ssh probe)?
+
+    An agent whose ``spec.host`` is a remote peer has its TUI session on that
+    peer, not here — the LOCAL tmux is blind to it, so the ordinary
+    :func:`._verdict_resolve.process_signal` reads DEAD ("no local session") and
+    the agent vanishes from cross-host ``sac agents list``. This ssh-probes the
+    peer's own tmux bookkeeping for the agent's session instead.
+
+    The argv is rendered by :func:`.._state.host_config.build_ssh_argv` — sac's
+    ONE canonical dispatch primitive — never a hand-rolled ssh line. That is
+    what makes a two-tier HPC target work: ``build_ssh_argv`` applies the peer's
+    ``via:`` ProxyJump chain (``-J``), glob-matches ``spartan-bm043`` onto a
+    ``spartan*`` pattern peer, and wraps the command in that peer's
+    ``env_preamble`` via ``bash -c`` (NOT ``-lc``: a login shell trips the
+    profile's interactive-tmux and false-DEADs a live agent — #709). Hand-rolling
+    it skipped the hop, so every ``spartan-bmNNN`` agent probed UNKNOWN and
+    rendered stale. The ``preamble && tmux has-session`` chain keeps rc 1 for
+    "no session" (a real DEAD); a preamble/hop failure is some other non-0/1 rc,
+    read below as UNKNOWN.
+
+    Verdicts (:data:`INSTRUMENT_HOST_TMUX` — the peer's tmux, a real
+    independent bookkeeper, exactly as in the local case):
+
+    * ssh connected + session present (rc 0) -> :data:`ALIVE`.
+    * ssh connected + no session (rc 1)      -> :data:`DEAD` (positive remote
+      absence, from the peer's own ``tmux has-session``).
+    * ssh could not run / any other rc, OR the peer is not resolvable (no
+      config / unknown peer / glob-miss, so ``build_ssh_argv`` raises)
+      -> :data:`UNKNOWN`. A probe that could not run is NEVER DEAD (this
+      module's core doctrine); a wedged ssh, a broken ProxyJump, a bare login
+      PATH, or an auth failure must not slander a live remote agent into a
+      destroyable corpse.
+
+    ``run_ssh`` is the injection seam (a real callable returning the exit
+    code); production uses :func:`_run_ssh_rc`.
+    """
+    session = session_name_for_config(config)
+
+    # Render the probe argv through sac's canonical dispatch primitive so the
+    # peer's ProxyJump chain + env_preamble apply (see docstring). A load/build
+    # failure (no config, unknown / glob-missed peer) is "I could not look" ->
+    # UNKNOWN, never a false DEAD. ``-n`` so ssh never eats our stdin.
+    try:
+        from .._state.host_config import build_ssh_argv
+        from .._state.host_config import load as _load_host_config
+
+        peers = _load_host_config().peers
+        argv = build_ssh_argv(
+            peer, ["tmux", "has-session", "-t", session], peers, extra_opts=["-n"]
+        )
+    except (
+        Exception
+    ) as exc:  # stx-allow: fallback (unresolvable peer -> UNKNOWN, never DEAD)
+        return Signal(
+            SOURCE_PROCESS,
+            UNKNOWN,
+            f"could not build an ssh probe for peer {peer!r} "
+            f"({type(exc).__name__}) — unresolvable peer is UNKNOWN, never DEAD",
+            INSTRUMENT_HOST_TMUX,
+        )
+
+    try:
+        rc = (run_ssh or _run_ssh_rc)(argv)
+    except (
+        Exception
+    ) as exc:  # stx-allow: fallback (probe shell-out blew up -> UNKNOWN, never DEAD)
+        return Signal(
+            SOURCE_PROCESS,
+            UNKNOWN,
+            f"could not ssh remote host {peer!r} to probe tmux "
+            f"({type(exc).__name__}) — remote liveness UNKNOWN, never DEAD",
+            INSTRUMENT_HOST_TMUX,
+        )
+    if rc == 0:
+        return Signal(
+            SOURCE_PROCESS,
+            ALIVE,
+            f"tmux session {session!r} is up on remote host {peer!r} (ssh probe)",
+            INSTRUMENT_HOST_TMUX,
+        )
+    if rc == 1:
+        return Signal(
+            SOURCE_PROCESS,
+            DEAD,
+            f"ssh to {peer!r} succeeded and its tmux has NO session {session!r} "
+            f"— positive remote absence, from the peer's own bookkeeping",
+            INSTRUMENT_HOST_TMUX,
+        )
+    return Signal(
+        SOURCE_PROCESS,
+        UNKNOWN,
+        f"ssh probe of {peer!r} returned rc={rc} (not 0/1: wedged ssh, a "
+        f"failed ProxyJump/env_preamble, bare PATH, or auth) — remote liveness "
+        f"UNKNOWN, never DEAD",
+        INSTRUMENT_HOST_TMUX,
+    )

--- a/src/scitex_agent_container/_lifecycle/_verdict_resolve.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict_resolve.py
@@ -50,6 +50,8 @@ from ._verdict import (
     Signal,
     decide,
 )
+from ._verdict_remote import _remote_peer_for_config, remote_process_signal
+from ._verdict_screen import screen_signal, started_at_for
 from ._verdict_state import HEARTBEAT_STALE_S, heartbeat_signal, registry_signal
 from ._verdict_tmux import in_sif as _in_sif  # noqa: F401  (kept as a seam alias)
 from ._verdict_tmux import (
@@ -67,6 +69,7 @@ __all__ = [
     "registry_signal",
     "remote_process_signal",
     "resolve_verdict",
+    "screen_signal",
 ]
 
 
@@ -289,167 +292,6 @@ def process_signal(
 
 
 # --------------------------------------------------------------------------
-# remote process — the control-plane cross-host liveness probe. Ternary.
-# --------------------------------------------------------------------------
-
-
-def _remote_peer_for_config(config: Any) -> str | None:
-    """Return the peer name if the agent's ``spec.host`` is a remote peer.
-
-    Uses the SAME ``classify_dispatch_host`` resolver ``sac agents start`` and
-    ``sac agents attach`` route through, so "remote" means one thing across
-    the whole control plane. Best-effort — any resolution failure returns
-    ``None`` and the caller falls back to the ordinary (local) process probe.
-    Imports are LAZY to avoid a ``cli_pkg`` -> ``_lifecycle`` import cycle.
-    """
-    try:
-        from ..cli_pkg.lifecycle._common import (
-            _local_host_names,
-            classify_dispatch_host,
-        )
-        from ..config._host import resolve_hostname
-
-        spec = config.hosts_spec
-        host = spec.host
-        target = host if isinstance(host, str) else (host[0] if host else None)
-        if not target:
-            return None
-        from .._state.host_config import load as _load_host_config
-
-        current = resolve_hostname()
-        peers = _load_host_config().peers
-        kind, peer = classify_dispatch_host(
-            target, current, peers, local_names=_local_host_names(current)
-        )
-        return peer if kind == "remote" else None
-    except Exception:  # stx-allow: fallback (unresolvable host -> treat as local; the local probe still runs)
-        return None
-
-
-def _run_ssh_rc(argv: list[str]) -> int:
-    """Run ``argv`` and return its exit code (default remote-probe runner).
-
-    A generous 10s timeout keeps a wedged peer from hanging a listing; on
-    timeout or a missing ssh binary we return 255 (ssh's own connection-failed
-    code) so :func:`remote_process_signal` maps it to UNKNOWN. Injection seam —
-    tests pass their own runner and never shell out.
-    """
-    import subprocess
-
-    try:
-        return subprocess.run(argv, capture_output=True, timeout=10).returncode
-    except (
-        subprocess.TimeoutExpired,
-        FileNotFoundError,
-    ):  # stx-allow: fallback (ssh could not run -> 255 -> UNKNOWN upstream)
-        return 255
-
-
-def remote_process_signal(
-    config: Any,
-    peer: str,
-    *,
-    run_ssh: Callable[[list[str]], int] | None = None,
-) -> Signal:
-    """Is the agent's tmux session up ON ITS REMOTE HOST (ssh probe)?
-
-    An agent whose ``spec.host`` is a remote peer has its TUI session on that
-    peer, not here — the LOCAL tmux is blind to it, so the ordinary
-    :func:`process_signal` reads DEAD ("no local session") and the agent
-    vanishes from cross-host ``sac agents list``. This ssh-probes the peer's
-    own tmux bookkeeping for the agent's session instead.
-
-    The argv is rendered by :func:`.._state.host_config.build_ssh_argv` — sac's
-    ONE canonical dispatch primitive — never a hand-rolled ssh line. That is
-    what makes a two-tier HPC target work: ``build_ssh_argv`` applies the peer's
-    ``via:`` ProxyJump chain (``-J``), glob-matches ``spartan-bm043`` onto a
-    ``spartan*`` pattern peer, and wraps the command in that peer's
-    ``env_preamble`` via ``bash -c`` (NOT ``-lc``: a login shell trips the
-    profile's interactive-tmux and false-DEADs a live agent — #709). Hand-rolling
-    it skipped the hop, so every ``spartan-bmNNN`` agent probed UNKNOWN and
-    rendered stale. The ``preamble && tmux has-session`` chain keeps rc 1 for
-    "no session" (a real DEAD); a preamble/hop failure is some other non-0/1 rc,
-    read below as UNKNOWN.
-
-    Verdicts (:data:`INSTRUMENT_HOST_TMUX` — the peer's tmux, a real
-    independent bookkeeper, exactly as in the local case):
-
-    * ssh connected + session present (rc 0) -> :data:`ALIVE`.
-    * ssh connected + no session (rc 1)      -> :data:`DEAD` (positive remote
-      absence, from the peer's own ``tmux has-session``).
-    * ssh could not run / any other rc, OR the peer is not resolvable (no
-      config / unknown peer / glob-miss, so ``build_ssh_argv`` raises)
-      -> :data:`UNKNOWN`. A probe that could not run is NEVER DEAD (this
-      module's core doctrine); a wedged ssh, a broken ProxyJump, a bare login
-      PATH, or an auth failure must not slander a live remote agent into a
-      destroyable corpse.
-
-    ``run_ssh`` is the injection seam (a real callable returning the exit
-    code); production uses :func:`_run_ssh_rc`.
-    """
-    session = session_name_for_config(config)
-
-    # Render the probe argv through sac's canonical dispatch primitive so the
-    # peer's ProxyJump chain + env_preamble apply (see docstring). A load/build
-    # failure (no config, unknown / glob-missed peer) is "I could not look" ->
-    # UNKNOWN, never a false DEAD. ``-n`` so ssh never eats our stdin.
-    try:
-        from .._state.host_config import build_ssh_argv
-        from .._state.host_config import load as _load_host_config
-
-        peers = _load_host_config().peers
-        argv = build_ssh_argv(
-            peer, ["tmux", "has-session", "-t", session], peers, extra_opts=["-n"]
-        )
-    except (
-        Exception
-    ) as exc:  # stx-allow: fallback (unresolvable peer -> UNKNOWN, never DEAD)
-        return Signal(
-            SOURCE_PROCESS,
-            UNKNOWN,
-            f"could not build an ssh probe for peer {peer!r} "
-            f"({type(exc).__name__}) — unresolvable peer is UNKNOWN, never DEAD",
-            INSTRUMENT_HOST_TMUX,
-        )
-
-    try:
-        rc = (run_ssh or _run_ssh_rc)(argv)
-    except (
-        Exception
-    ) as exc:  # stx-allow: fallback (probe shell-out blew up -> UNKNOWN, never DEAD)
-        return Signal(
-            SOURCE_PROCESS,
-            UNKNOWN,
-            f"could not ssh remote host {peer!r} to probe tmux "
-            f"({type(exc).__name__}) — remote liveness UNKNOWN, never DEAD",
-            INSTRUMENT_HOST_TMUX,
-        )
-    if rc == 0:
-        return Signal(
-            SOURCE_PROCESS,
-            ALIVE,
-            f"tmux session {session!r} is up on remote host {peer!r} (ssh probe)",
-            INSTRUMENT_HOST_TMUX,
-        )
-    if rc == 1:
-        return Signal(
-            SOURCE_PROCESS,
-            DEAD,
-            f"ssh to {peer!r} succeeded and its tmux has NO session {session!r} "
-            f"— positive remote absence, from the peer's own bookkeeping",
-            INSTRUMENT_HOST_TMUX,
-        )
-    return Signal(
-        SOURCE_PROCESS,
-        UNKNOWN,
-        f"ssh probe of {peer!r} returned rc={rc} (not 0/1: wedged ssh, a "
-        f"failed ProxyJump/env_preamble, bare PATH, or auth) — remote liveness "
-        f"UNKNOWN, never DEAD",
-        INSTRUMENT_HOST_TMUX,
-    )
-
-
-# --------------------------------------------------------------------------
 # the fold
 # --------------------------------------------------------------------------
 
@@ -463,6 +305,7 @@ def resolve_verdict(
     process: Callable[[Any, Any], Signal] | None = None,
     heartbeat: Callable[[str], Signal] | None = None,
     registry: Callable[[str], Signal] | None = None,
+    screen: Callable[[str], Signal] | None = None,
 ) -> LivenessVerdict:
     """Gather every signal we can, then fold them with :func:`._verdict.decide`.
 
@@ -472,7 +315,8 @@ def resolve_verdict(
 
     Every collaborator is an injection seam taking REAL callables (no mocks —
     the suite drives real tmux sockets, real processes, real files through
-    these).
+    these). ``screen`` (the WORKING sensor) folds in for a TUI agent only — see
+    :func:`._verdict_screen.screen_signal`.
     """
     signals: list[Signal] = []
     kind = str(getattr(config, "runtime", "") or "") if config is not None else ""
@@ -500,5 +344,18 @@ def resolve_verdict(
         signals.append(heartbeat(name))
 
     signals.append((registry or registry_signal)(name))
+
+    # SCREEN — the WORKING sensor. A wedged TUI agent's tmux session exists and
+    # its pane pid is alive, so process/heartbeat/registry all read PRESENCE-ALIVE
+    # while it does nothing. The screen signal reads the pane's rendered CONTENT
+    # (a frozen auth banner) and reports WEDGED, which decide() ranks ABOVE those
+    # presence-ALIVEs. TUI only — a pid-based runtime has no tui pane to read. An
+    # injected ``screen`` always wins (the test seam); otherwise we read the auth
+    # cache, passing this incarnation's started_at so a pre-restart (SUPERSEDED)
+    # verdict is discarded rather than read as wedged.
+    if screen is not None:
+        signals.append(screen(name))
+    elif kind == "tui":
+        signals.append(screen_signal(name, started_at=started_at_for(name)))
 
     return decide(name, signals)

--- a/src/scitex_agent_container/_lifecycle/_verdict_screen.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict_screen.py
@@ -1,0 +1,157 @@
+"""The SCREEN signal — does the agent's tui pane show a FROZEN auth banner?
+
+Split out of :mod:`._verdict_resolve` (512-line cap) along the SAME seam
+:mod:`._verdict_state` follows: this reads a state ARTEFACT somebody else wrote
+— here the ``sac agents auth-status`` cache — and turns it into a
+:class:`._verdict.Signal`. :mod:`._verdict_resolve` PROBES live things (the
+broker, the runtime); this READS a cache. That difference is why it is so
+careful, and why every non-fresh / superseded / clean read degrades to
+:data:`._verdict.UNKNOWN`, never a false WEDGE.
+
+THE INSTRUMENT THIS EMBODIES
+    Every other liveness sensor answers "IS IT PRESENT?" — a pid, a session, a
+    row. None of them answers "IS IT WORKING?". A tmux-GREEN agent whose Claude
+    sits under an auth-rejection banner has a live session and a live pane pid,
+    so ``process`` / ``heartbeat`` / ``registry`` all read ALIVE while it does
+    nothing (``scitex-clew`` sat that way for two days). This is the one sensor
+    that reads the pane's rendered CONTENT — :data:`._verdict.INSTRUMENT_TUI_SCREEN`
+    — so a wedged agent resolves to :data:`._verdict.WEDGED` instead of that
+    false-green.
+
+WHY IT READS A CACHE, NOT THE LIVE PANE
+    The prompt-anchored, volatile-stripped, 2-run-frozen banner matcher lives in
+    :mod:`.._runners._tmux.auth_status` and is run by the ``sac agents
+    auth-status`` watchdog, which records its verdict via
+    :func:`.._state.auth_state.record_auth_checks`. This module reads THAT
+    through :func:`.._state.auth_state.verdict_for`, so all the freshness / scope
+    honesty — SUPERSEDED (a verdict predating this incarnation is discarded) and
+    STALE (older than 900s is weak, never asserted) — lives in one tested place.
+    A WEDGED that reaches :func:`._verdict.decide` is therefore already fresh AND
+    this-incarnation, and decide trusts it at face value.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Callable
+
+from ._verdict import (
+    INSTRUMENT_TUI_SCREEN,
+    SOURCE_SCREEN,
+    UNKNOWN,
+    WEDGED,
+    Signal,
+)
+
+__all__ = [
+    "screen_signal",
+    "started_at_for",
+]
+
+
+def started_at_for(name: str) -> str | None:
+    """This incarnation's ``started_at`` stamp, for the screen SUPERSEDED check.
+
+    Read from the SAME ``instances`` table :func:`._verdict_state.registry_signal`
+    reads, so the stamp is directly comparable to the auth cache's ``checked_at``
+    (both are ``state_db.now_iso`` UTC-'Z' stamps). ``list_active_instances``
+    orders started_at DESC, so the newest row is this incarnation.
+
+    Best-effort: any failure returns ``None`` — no started_at means no SUPERSEDED
+    suppression, which is safe, because :func:`.._state.auth_state.verdict_for`
+    still gates on staleness and on a missing row.
+    """
+    try:
+        from .._state.state_db import list_active_instances
+
+        rows = [r for r in list_active_instances(host=None) if r.get("name") == name]
+    except Exception:  # stx-allow: fallback (an unreadable registry ⇒ no started_at ⇒ no SUPERSEDED suppression, never a crash)
+        return None
+    if not rows:
+        return None
+    return str(rows[0].get("started_at") or "") or None
+
+
+def screen_signal(
+    name: str,
+    *,
+    started_at: str | None = None,
+    read_state: Callable[[str], dict | None] | None = None,
+    now: datetime | None = None,
+    stale_after_s: float | None = None,
+) -> Signal:
+    """Does the agent's rendered ``tui-<name>`` pane show a FROZEN auth banner?
+
+    Reads the CACHED verdict, NOT the live pane (see the module docstring): the
+    ``sac agents auth-status`` watchdog runs the banner matcher and records it,
+    and this reads that cache through :func:`.._state.auth_state.verdict_for`.
+    ALL freshness / scope gating lives in ``verdict_for`` (SUPERSEDED — a verdict
+    stamped before ``started_at`` describes a previous incarnation and is
+    discarded — and STALE > 900s), so a WEDGED that reaches
+    :func:`._verdict.decide` is already fresh AND this-incarnation.
+
+    Verdicts (:data:`._verdict.INSTRUMENT_TUI_SCREEN`, declared WEDGED/UNKNOWN
+    only — never ALIVE, because a clean pane is not proof of life; never DEAD,
+    because the pane and the process behind it are PRESENT):
+
+    * no ``auth_checked_at`` (never swept, OR a SUPERSEDED row ``verdict_for``
+      discarded) → :data:`._verdict.UNKNOWN`. The screen was not read; not
+      evidence of life.
+    * ``auth_check_stale`` (the watchdog has not swept recently) →
+      :data:`._verdict.UNKNOWN`. A stale cache is never a stale WEDGE — an old
+      banner may already be cleared.
+    * ``auth_failed`` (a fresh frozen banner) → :data:`._verdict.WEDGED`, message
+      carrying the banner + the remedy (a restart clears a rotated/stale token).
+    * a fresh CLEAN pane → :data:`._verdict.UNKNOWN`. A clean pane is not proof
+      of life, only the absence of a KNOWN wedge (the agent may be busy, idle, or
+      stuck in a way this banner match does not recognise).
+
+    ``read_state`` is the injection seam (default
+    :func:`.._state.auth_state.get_auth_state`); tests pass a real callable
+    returning a real cached-row dict. NO live tmux, NO clock of its own.
+    """
+    from .._state import auth_state as _auth_state
+
+    reader = read_state or _auth_state.get_auth_state
+    fields = _auth_state.verdict_for(
+        reader(name),
+        started_at=started_at,
+        now=now,
+        stale_after_s=stale_after_s or _auth_state.STALE_AFTER_S,
+    )
+
+    if not fields.get("auth_checked_at"):
+        return Signal(
+            SOURCE_SCREEN,
+            UNKNOWN,
+            f"no fresh auth-status check for {name!r} (never swept, or the cached "
+            f"check predates this incarnation) — the screen was not read, which "
+            f"is not evidence of life",
+            INSTRUMENT_TUI_SCREEN,
+        )
+    if fields.get("auth_check_stale"):
+        return Signal(
+            SOURCE_SCREEN,
+            UNKNOWN,
+            "the cached auth-status check is STALE (the watchdog has not swept "
+            "recently) — a stale cache is never a stale WEDGE, because the banner "
+            "may already be cleared; report UNKNOWN, never a stale wedge",
+            INSTRUMENT_TUI_SCREEN,
+        )
+    if fields.get("auth_failed"):
+        banner = fields.get("auth_banner") or "an auth-rejection banner"
+        remedy = fields.get("auth_remedy") or "restart"
+        return Signal(
+            SOURCE_SCREEN,
+            WEDGED,
+            f"a frozen auth banner sits above the prompt ({banner!r}) — the "
+            f"tui-{name} pane is PRESENT but NOT WORKING; remedy: {remedy}",
+            INSTRUMENT_TUI_SCREEN,
+        )
+    return Signal(
+        SOURCE_SCREEN,
+        UNKNOWN,
+        "the auth-status check is fresh and CLEAN (no frozen banner) — but a "
+        "clean pane is not proof of life, only the absence of a known wedge",
+        INSTRUMENT_TUI_SCREEN,
+    )

--- a/src/scitex_agent_container/cli_pkg/_health_liveness.py
+++ b/src/scitex_agent_container/cli_pkg/_health_liveness.py
@@ -28,7 +28,15 @@ from typing import Any
 
 __all__ = ["liveness_payload", "print_liveness"]
 
-_VERDICT_COLOUR = {"alive": "green", "dead": "red", "unknown": "yellow"}
+# wedged = present but NOT working — magenta, distinct from unknown's yellow so
+# a "known-stuck, needs a restart" reads apart from a "we could not tell". It is
+# NOT red: red is DEAD (destroyable), and a wedged agent must never be destroyed.
+_VERDICT_COLOUR = {
+    "alive": "green",
+    "dead": "red",
+    "unknown": "yellow",
+    "wedged": "magenta",
+}
 
 
 def liveness_payload(name: str, config: Any) -> dict:

--- a/tests/scitex_agent_container/_lifecycle/test__verdict.py
+++ b/tests/scitex_agent_container/_lifecycle/test__verdict.py
@@ -22,11 +22,14 @@ from scitex_agent_container._lifecycle._verdict import (
     INSTRUMENT_LISTEN_BROKER,
     INSTRUMENT_NO_OBSERVATION,
     INSTRUMENT_PID_NAMESPACE,
+    INSTRUMENT_TUI_SCREEN,
     SOURCE_DELIVERY,
     SOURCE_HEARTBEAT,
     SOURCE_PROCESS,
     SOURCE_REGISTRY,
+    SOURCE_SCREEN,
     UNKNOWN,
+    WEDGED,
     Signal,
     decide,
 )
@@ -550,3 +553,158 @@ def test_render_omits_a_dissenters_verbose_prose(dissenting_heartbeat_signals):
     rendered = decide("alpha", dissenting_heartbeat_signals).render()
     # Assert — the operator's "splurge" (the dissenter's prose) is gone.
     assert "sac listen observed this session" not in rendered
+
+
+# --------------------------------------------------------------------------
+# WEDGED — present but NOT working. The P0: a tmux-GREEN agent stuck under a
+# frozen auth banner read ALIVE (false-green; clew sat dead two days). The
+# screen instrument observes WORKING, not mere presence, so a wedged agent now
+# resolves to WEDGED — above the pid/session ALIVE, below a delivery ALIVE.
+# --------------------------------------------------------------------------
+
+
+def test_a_wedged_screen_overrides_a_pid_shaped_process_alive():
+    """THE core regression, and the P0 stated as a test.
+
+    A wedged agent's tmux session exists and its pane pid is alive, so
+    ``process`` reads ALIVE — PRESENCE, not WORK. Under the OLD decide (any ALIVE
+    ⇒ ALIVE) this exact fold returned ALIVE: the false-green that let ``clew`` sit
+    auth-dead for two days behind a green row. The NEW decide ranks the screen
+    instrument's WEDGED above a pid/session ALIVE, so it must read WEDGED.
+    """
+    # Arrange — the false-green shape: a live-pid process ALIVE + a frozen banner.
+    signals = [
+        Signal(
+            SOURCE_PROCESS,
+            ALIVE,
+            "tmux session up, pane pid alive",
+            INSTRUMENT_HOST_TMUX,
+        ),
+        Signal(
+            SOURCE_SCREEN,
+            WEDGED,
+            "frozen 'Login expired' banner",
+            INSTRUMENT_TUI_SCREEN,
+        ),
+    ]
+    # Act
+    verdict = decide("clew", signals)
+    # Assert — NEW behaviour: WEDGED (the OLD fold would have said ALIVE here).
+    assert verdict.verdict == WEDGED
+
+
+def test_a_wedged_agent_is_never_alive():
+    """The hard requirement, by construction: is_alive is ``verdict == ALIVE``."""
+    # Arrange
+    signals = [
+        Signal(SOURCE_PROCESS, ALIVE, "tmux up", INSTRUMENT_HOST_TMUX),
+        Signal(SOURCE_SCREEN, WEDGED, "frozen banner", INSTRUMENT_TUI_SCREEN),
+    ]
+    # Act
+    verdict = decide("clew", signals)
+    # Assert
+    assert verdict.is_alive is False
+
+
+def test_a_delivery_alive_still_beats_a_wedged_screen():
+    """A broker-reachable agent is demonstrably WORKING, so it is never flagged.
+
+    The founding incident had delivery != ALIVE (the wedged agent's inbox was not
+    observed reachable), so ordering delivery above WEDGED keeps a live, answering
+    agent from ever reading wedged while costing the fix nothing.
+    """
+    # Arrange
+    signals = [
+        Signal(
+            SOURCE_DELIVERY, ALIVE, "1 live inbox subscriber", INSTRUMENT_LISTEN_BROKER
+        ),
+        Signal(SOURCE_SCREEN, WEDGED, "frozen banner", INSTRUMENT_TUI_SCREEN),
+    ]
+    # Act
+    verdict = decide("x", signals)
+    # Assert
+    assert verdict.verdict == ALIVE
+
+
+def test_a_lone_wedged_signal_yields_wedged():
+    # Arrange
+    signals = [Signal(SOURCE_SCREEN, WEDGED, "frozen banner", INSTRUMENT_TUI_SCREEN)]
+    # Act
+    verdict = decide("clew", signals)
+    # Assert
+    assert verdict.verdict == WEDGED
+
+
+def test_a_wedged_verdict_authorises_nothing_destructive():
+    """WEDGED is present-but-stuck, not a corpse — a restart cures it, not a kill."""
+    # Arrange
+    signals = [Signal(SOURCE_SCREEN, WEDGED, "frozen banner", INSTRUMENT_TUI_SCREEN)]
+    # Act
+    verdict = decide("clew", signals)
+    # Assert
+    assert verdict.may_destroy is False
+
+
+def test_a_wedged_veto_reason_points_at_a_restart_not_destruction():
+    # Arrange
+    signals = [Signal(SOURCE_SCREEN, WEDGED, "frozen banner", INSTRUMENT_TUI_SCREEN)]
+    # Act
+    verdict = decide("clew", signals)
+    # Assert
+    assert "restart" in verdict.destroy_veto_reason
+
+
+def test_a_wedged_verdict_reports_is_wedged():
+    # Arrange
+    signals = [Signal(SOURCE_SCREEN, WEDGED, "frozen banner", INSTRUMENT_TUI_SCREEN)]
+    # Act
+    verdict = decide("clew", signals)
+    # Assert
+    assert verdict.is_wedged is True
+
+
+def test_a_screen_unknown_does_not_suppress_a_real_process_alive():
+    """A CLEAN pane is UNKNOWN (not proof of life), and UNKNOWN suppresses
+    nothing — a genuine process ALIVE still wins."""
+    # Arrange
+    signals = [
+        Signal(SOURCE_SCREEN, UNKNOWN, "fresh clean pane", INSTRUMENT_TUI_SCREEN),
+        Signal(SOURCE_PROCESS, ALIVE, "tmux up", INSTRUMENT_HOST_TMUX),
+    ]
+    # Act
+    verdict = decide("x", signals)
+    # Assert
+    assert verdict.verdict == ALIVE
+
+
+def test_a_wedged_beats_a_dead_because_wedged_is_never_destroyable():
+    """Precedence: WEDGED (rule 2) sits ABOVE any DEAD (rule 4).
+
+    A fresh WEDGE + a contradictory DEAD (a rare race) resolves to the SAFE,
+    non-destructive WEDGED rather than a DEAD that could arm a kill.
+    """
+    # Arrange
+    signals = [
+        Signal(SOURCE_SCREEN, WEDGED, "frozen banner", INSTRUMENT_TUI_SCREEN),
+        Signal(SOURCE_PROCESS, DEAD, "tmux has no session", INSTRUMENT_HOST_TMUX),
+    ]
+    # Act
+    verdict = decide("x", signals)
+    # Assert
+    assert verdict.verdict == WEDGED
+
+
+def test_the_screen_instrument_may_never_report_a_death():
+    """WEDGED is the one non-pole state, but the screen sensor still cannot DEAD.
+
+    A ``Signal(SOURCE_SCREEN, DEAD, ...)`` must raise: the pane, and the process
+    behind it, are PRESENT — DEAD would arm a destruction against a living
+    process. The InstrumentSpec (verdicts = WEDGED/UNKNOWN) forbids it.
+    """
+    # Arrange
+    instrument = INSTRUMENT_TUI_SCREEN
+    # Act
+    # (constructing the Signal IS the act under test — it must refuse.)
+    # Assert
+    with pytest.raises(ValueError, match="may not emit"):
+        Signal(SOURCE_SCREEN, DEAD, "a corpse, allegedly", instrument)

--- a/tests/scitex_agent_container/_lifecycle/test__verdict_instruments.py
+++ b/tests/scitex_agent_container/_lifecycle/test__verdict_instruments.py
@@ -37,10 +37,14 @@ from scitex_agent_container._lifecycle._verdict import (
     INSTRUMENT_LISTEN_BROKER,
     INSTRUMENT_NO_OBSERVATION,
     INSTRUMENT_PID_NAMESPACE,
+    INSTRUMENT_TUI_SCREEN,
     INSTRUMENTS,
     SOURCE_DELIVERY,
     SOURCE_PROCESS,
     SOURCE_REGISTRY,
+    SOURCE_SCREEN,
+    UNKNOWN,
+    WEDGED,
     Signal,
     decide,
 )
@@ -374,3 +378,54 @@ def test_the_listen_broker_may_not_report_a_death():
     # Assert
     with pytest.raises(ValueError, match="may not emit"):
         Signal(SOURCE_DELIVERY, DEAD, "0 subscribers", instrument)
+
+
+# --------------------------------------------------------------------------
+# The SCREEN instrument — the WORKING sensor. It reads whether the agent is
+# working, not merely present, so it emits WEDGED / UNKNOWN and NEVER convicts.
+# --------------------------------------------------------------------------
+
+
+def test_the_screen_instrument_is_classified_for_independence():
+    """A new sensor with no INSTRUMENT_INDEPENDENCE entry has not been reasoned
+    about — and the meta-test above would already fail. This pins it explicitly."""
+    # Arrange
+    instrument = INSTRUMENT_TUI_SCREEN
+    # Act
+    classified = instrument in INSTRUMENT_INDEPENDENCE
+    # Assert
+    assert classified is True
+
+
+def test_the_screen_instrument_emits_exactly_wedged_and_unknown():
+    """Never ALIVE (a clean pane is not proof of life), never DEAD (the pane and
+    the process behind it are PRESENT — DEAD would arm a kill on a live process)."""
+    # Arrange
+    spec = INSTRUMENT_INDEPENDENCE[INSTRUMENT_TUI_SCREEN]
+    # Act
+    verdicts = spec.verdicts
+    # Assert
+    assert verdicts == frozenset({WEDGED, UNKNOWN})
+
+
+def test_the_screen_instrument_is_not_a_convicting_instrument():
+    """DEAD ∉ its verdicts ⇒ ``may_convict`` False ⇒ absent from the convicting
+    set ⇒ it can NEVER arm a destruction. This is the load-bearing guarantee."""
+    # Arrange
+    instrument = INSTRUMENT_TUI_SCREEN
+    # Act
+    convicting = instrument in CONVICTING_INSTRUMENTS
+    # Assert
+    assert convicting is False
+
+
+def test_the_screen_instrument_may_not_report_a_death():
+    """Made MECHANICAL: a ``Signal(SOURCE_SCREEN, DEAD, ...)`` raises at
+    construction, because a wedged agent is present, not a corpse."""
+    # Arrange
+    instrument = INSTRUMENT_TUI_SCREEN
+    # Act
+    # (constructing the Signal IS the act under test — it must refuse.)
+    # Assert
+    with pytest.raises(ValueError, match="may not emit"):
+        Signal(SOURCE_SCREEN, DEAD, "a corpse, allegedly", instrument)

--- a/tests/scitex_agent_container/_lifecycle/test__verdict_resolve.py
+++ b/tests/scitex_agent_container/_lifecycle/test__verdict_resolve.py
@@ -16,6 +16,7 @@ import os
 import subprocess
 import sys
 import time
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -25,7 +26,9 @@ from scitex_agent_container._lifecycle._verdict import (
     SOURCE_HEARTBEAT,
     SOURCE_PROCESS,
     SOURCE_REGISTRY,
+    SOURCE_SCREEN,
     UNKNOWN,
+    WEDGED,
 )
 from scitex_agent_container._lifecycle._verdict_resolve import (
     _tmux_probe_ran,
@@ -33,6 +36,7 @@ from scitex_agent_container._lifecycle._verdict_resolve import (
     process_signal,
     registry_signal,
     remote_process_signal,
+    screen_signal,
 )
 
 
@@ -631,3 +635,163 @@ def test_remote_process_signal_multihop_argv_wraps_cmd_in_bash_c(spartan_config)
         el.startswith("bash -c ") and "tmux has-session -t tui-proj-x" in el
         for el in argv
     )
+
+
+# --------------------------------------------------------------------------
+# screen_signal — the WORKING sensor, driven through the REAL
+# ``auth_state.verdict_for`` with REAL cached-row dicts and a REAL clock (no
+# mocks: ``read_state`` is an injection seam returning a real dict). All the
+# freshness / SUPERSEDED honesty lives in ``verdict_for``, so these pin that a
+# WEDGED reaches decide() ONLY when the cache is fresh AND this-incarnation —
+# every other read (stale, superseded, clean, never-checked) degrades to
+# UNKNOWN, never a false WEDGE.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def screen_now() -> datetime:
+    """A fixed reference instant, so freshness/scope assertions are deterministic."""
+    return datetime(2026, 7, 13, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _screen_stamp(moment: datetime) -> str:
+    """``moment`` in the exact ISO-8601 UTC 'Z' shape the auth store writes."""
+    return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_a_fresh_auth_failed_row_reads_wedged(screen_now):
+    """The P0 at the resolver level: a fresh frozen banner ⇒ WEDGED."""
+    # Arrange — checked 60s ago, this incarnation started an hour ago.
+    row = {
+        "auth_failed": True,
+        "checked_at": _screen_stamp(screen_now - timedelta(seconds=60)),
+        "banner": "Login expired",
+        "reason": "revoked",
+    }
+    # Act
+    signal = screen_signal(
+        "clew",
+        started_at=_screen_stamp(screen_now - timedelta(hours=1)),
+        read_state=lambda _n: row,
+        now=screen_now,
+    )
+    # Assert
+    assert signal.verdict == WEDGED
+
+
+def test_a_wedged_screen_signal_carries_the_banner_and_remedy(screen_now):
+    """The evidence must be specific — the operator learns WHAT and WHAT TO DO."""
+    # Arrange
+    row = {
+        "auth_failed": True,
+        "checked_at": _screen_stamp(screen_now - timedelta(seconds=60)),
+        "banner": "Login expired",
+        "reason": "revoked",
+    }
+    # Act
+    signal = screen_signal(
+        "clew",
+        started_at=_screen_stamp(screen_now - timedelta(hours=1)),
+        read_state=lambda _n: row,
+        now=screen_now,
+    )
+    # Assert — a revoked token's remedy is a restart, and it says so.
+    assert "restart" in signal.detail
+
+
+def test_a_fresh_clean_row_reads_unknown_not_alive(screen_now):
+    """A clean pane is NOT proof of life — only the absence of a known wedge."""
+    # Arrange — fresh, auth_failed False.
+    row = {
+        "auth_failed": False,
+        "checked_at": _screen_stamp(screen_now - timedelta(seconds=60)),
+    }
+    # Act
+    signal = screen_signal(
+        "worker",
+        started_at=_screen_stamp(screen_now - timedelta(hours=1)),
+        read_state=lambda _n: row,
+        now=screen_now,
+    )
+    # Assert
+    assert signal.verdict == UNKNOWN
+
+
+def test_a_stale_auth_failed_row_reads_unknown_never_a_stale_wedge(screen_now):
+    """A verdict older than 900s is weak evidence — the banner may be cleared.
+
+    A stale cache must never be rendered as a current WEDGE, so it degrades to
+    UNKNOWN rather than asserting a wedge that may no longer be true.
+    """
+    # Arrange — checked 6 hours ago (>> 900s STALE_AFTER_S).
+    row = {
+        "auth_failed": True,
+        "checked_at": _screen_stamp(screen_now - timedelta(hours=6)),
+        "banner": "Login expired",
+    }
+    # Act
+    signal = screen_signal(
+        "clew",
+        started_at=_screen_stamp(screen_now - timedelta(hours=12)),
+        read_state=lambda _n: row,
+        now=screen_now,
+    )
+    # Assert
+    assert signal.verdict == UNKNOWN
+
+
+def test_a_superseded_auth_failed_row_reads_unknown(screen_now):
+    """A verdict stamped BEFORE this incarnation's start describes a PREVIOUS
+    life — a restarted agent must never still read wedged.
+
+    verdict_for discards a ``checked_at`` older than ``started_at`` (reports it as
+    never-checked), so screen_signal sees no ``auth_checked_at`` and reports
+    UNKNOWN.
+    """
+    # Arrange — checked 2h ago, but this incarnation started only 1h ago.
+    row = {
+        "auth_failed": True,
+        "checked_at": _screen_stamp(screen_now - timedelta(hours=2)),
+        "banner": "Login expired",
+    }
+    # Act
+    signal = screen_signal(
+        "clew",
+        started_at=_screen_stamp(screen_now - timedelta(hours=1)),
+        read_state=lambda _n: row,
+        now=screen_now,
+    )
+    # Assert
+    assert signal.verdict == UNKNOWN
+
+
+def test_a_never_checked_agent_reads_unknown(screen_now):
+    """No cached row at all ⇒ the screen was not read ⇒ UNKNOWN, never a wedge."""
+    # Arrange — the auth cache has no row for this agent.
+    # Act
+    signal = screen_signal(
+        "ghost",
+        started_at=_screen_stamp(screen_now),
+        read_state=lambda _n: None,
+        now=screen_now,
+    )
+    # Assert
+    assert signal.verdict == UNKNOWN
+
+
+def test_screen_signal_is_sourced_as_screen(screen_now):
+    # Arrange
+    row = {
+        "auth_failed": True,
+        "checked_at": _screen_stamp(screen_now - timedelta(seconds=60)),
+        "banner": "Login expired",
+    }
+    # Act
+    signal = screen_signal(
+        "clew",
+        started_at=_screen_stamp(screen_now - timedelta(hours=1)),
+        read_state=lambda _n: row,
+        now=screen_now,
+    )
+    # Assert
+    assert signal.source == SOURCE_SCREEN


### PR DESCRIPTION
## The P0 (operator-found)

`tmux session EXISTS + pid ALIVE + Claude inside auth-dead/wedged` → the liveness
verdict read **ALIVE** (false-green; `scitex-clew` sat dead two days behind a
green row). Every convicting instrument answers *"IS IT PRESENT?"*, never *"IS IT
WORKING?"*. This adds a **screen-content instrument** so a wedged agent NEVER
reads ALIVE — **without authorising its destruction**.

## What this adds — a fourth state, WEDGED

WEDGED = **present but not working**. It is deliberately NOT a pole:

- not ALIVE (it is not working) — `is_alive` stays `verdict == ALIVE`, so a
  wedged agent reads `is_alive` **False by construction**;
- not DEAD (the process is present) — `may_destroy` is **UNCHANGED** (gates on
  DEAD), so WEDGED can arm **nothing**;
- not UNKNOWN (we DID observe it — we observed that it is stuck).

The screen instrument's `verdicts={WEDGED, UNKNOWN}` (never ALIVE/DEAD) ⇒
`may_convict` is False ⇒ it is **absent from `CONVICTING_INSTRUMENTS`**.

## `decide()` precedence (exact, new)

1. a `delivery` **ALIVE** is authoritative → **ALIVE** (a broker-reachable agent
   is working; low false-red; the incident had delivery ≠ ALIVE);
2. any **WEDGED** → **WEDGED** (overrides process/heartbeat/registry ALIVE, which
   only observe that the pid EXISTS);
3. the existing positive-life step **including the #705 stale-heartbeat
   carve-out** → ALIVE;
4. any **DEAD** → DEAD;
5. else **UNKNOWN**.

Delivery-ALIVE is ranked above WEDGED on purpose: presence loses to WEDGED, but
real life (the broker seeing the inbox reachable) does not.

## Reuse (no new matcher, no forking)

The screen signal reads the **cached** `sac agents auth-status` verdict — NOT the
live pane — through `_state/auth_state.verdict_for(...)`, which already enforces
**SUPERSEDED** (a verdict predating this incarnation's `started_at` is discarded,
so a restarted agent never reads wedged) and **STALE** (>900s degrades to
UNKNOWN). The prompt-anchored, 2-run-frozen banner matcher in
`_runners/_tmux/auth_status.py` is untouched. So all freshness/scope honesty lives
in one tested place, and a WEDGED that reaches `decide()` is already fresh AND
this-incarnation.

## Files

- `_lifecycle/_verdict_instruments.py` — `WEDGED` / `SOURCE_SCREEN` /
  `INSTRUMENT_TUI_SCREEN` + its `InstrumentSpec(verdicts={WEDGED, UNKNOWN})`;
  `Signal.__post_init__` allows WEDGED but a `Signal(SOURCE_SCREEN, DEAD, …)`
  still **raises**.
- `_lifecycle/_verdict.py` — re-exports; `is_wedged`; WEDGED branch in
  `destroy_veto_reason`; the new `decide()` precedence. `may_destroy` and
  `is_alive` **UNCHANGED**.
- `_lifecycle/_verdict_screen.py` **(new)** — `screen_signal` + `started_at_for`.
- `_lifecycle/_verdict_remote.py` **(new)** — `remote_process_signal` extracted
  here (the fold-in pushed `_verdict_resolve.py` past the 512-line cap; this is
  the cohesive cross-host unit, re-exported so all imports are unchanged).
- `_lifecycle/_verdict_resolve.py` — `screen` injection seam + TUI-only fold
  (passes `started_at` so SUPERSEDED fires).
- `cli_pkg/_health_liveness.py` — `wedged` → magenta (distinct "needs a restart",
  not red/destroyable).

## Consumers (all 8 verified)

`_start_verdict`/`_start` treat WEDGED as not-alive → `sac start` relaunches a
wedged agent (**desirable**). `_status`/`_health_liveness` render it via
`to_dict()` (`may_destroy=False`, veto = "restart clears a rotated/stale token").
`_agent_exec_liveness` uses `process_signal` directly (never WEDGED; UNKNOWN→None,
safe). `_hosted_runner_guard` (CI-runner ternary) and `snapshot/_sidecars`
(`Thread.is_alive()`) are unrelated — no change.

## ⚠️ Prerequisite to flag for the parent

**The fix is INERT unless the `sac agents auth-status` sweep runs on a timer** —
it is what writes the cache this instrument reads. Please confirm that watchdog
is scheduled. The capability is correct regardless: with a stale or absent cache
it degrades to **UNKNOWN, never a false WEDGE**, so nothing regresses if the
sweep is not yet wired.

## Tests (no mocks — real Signals, real dict rows, real clock)

- **Core regression** (`test__verdict.py`):
  `test_a_wedged_screen_overrides_a_pid_shaped_process_alive` — the OLD `decide`
  returned ALIVE for `[process/ALIVE, screen/WEDGED]` (the false-green); the NEW
  one yields **WEDGED**. Plus: delivery/ALIVE beats WEDGED; lone WEDGED →
  `may_destroy` False; screen/UNKNOWN doesn't suppress a real process ALIVE;
  `Signal(SOURCE_SCREEN, DEAD, …)` raises.
- **Resolver** (`test__verdict_resolve.py`): real `agent_auth_state` row dicts +
  a real `now`, through the real `verdict_for` — fresh auth_failed→WEDGED, fresh
  clean→UNKNOWN, >900s→UNKNOWN, checked_at<started_at→UNKNOWN, None row→UNKNOWN.
- **Classification** (`test__verdict_instruments.py`): `INSTRUMENT_TUI_SCREEN` is
  classified, `verdicts=={WEDGED,UNKNOWN}`, **absent from
  `CONVICTING_INSTRUMENTS`**.

Full `_lifecycle` suite green (result line in the PR thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
