### PR TITLE
feat(host-sync): schedule the drift detector + route drift to a SEEN scitex-todo card

### DIFF
--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -495,3 +495,16 @@ mutation is atomic write-back of the refreshed access_token to the
 per-account credentials file. The unit exits non-zero only when EVERY
 targeted account's refresh failed — that's the operator's signal that a
 real `claude /login` is finally needed.
+
+# sac.host-sync-check — federated timer (peer drift alarm)
+
+A SECOND federated `scitex_dev.jobs` job (same mechanism as above;
+`_jobs_plugin.py`). Runs `sac host sync --check --all --alarm` hourly:
+the **read-only** one-way-sync drift detector (mutates no peer), with
+`--alarm` routing each verdict to an idempotent scitex-todo card
+(`host-sync-drift-<peer>`, `status=blocked`/`blocker=operator-decision`)
+— upsert on drift/unknown, resolve on clean. This makes the Stage-0
+detector (PR #690), previously scheduled nowhere, actually RUN and be
+SEEN on the board instead of in a log nobody reads. Install with
+`sac dev systemd install --yes`, then
+`systemctl --user enable --now sac.host-sync-check.timer`.

--- a/src/scitex_agent_container/_hostsync/__init__.py
+++ b/src/scitex_agent_container/_hostsync/__init__.py
@@ -30,6 +30,7 @@ The invariants, each one paid for:
   what it verified.
 """
 
+from ._alarm import AlarmOutcome, card_id_for, route_reports_to_cards
 from ._apply import FastForwardResult, apply_fast_forward
 from ._ci_guard import DEFAULT_REPO, CiState, CiVerdict, check_ci_idle
 from ._model import GraphState, PeerSyncReport, SyncDecision, sync_decision
@@ -45,6 +46,7 @@ from ._sync import (
 
 __all__ = [
     "DEFAULT_REPO",
+    "AlarmOutcome",
     "CiState",
     "CiVerdict",
     "FastForwardResult",
@@ -54,10 +56,12 @@ __all__ = [
     "SyncDecision",
     "SyncResult",
     "apply_fast_forward",
+    "card_id_for",
     "check_ci_idle",
     "check_peer",
     "exit_code_for",
     "probe_peer",
+    "route_reports_to_cards",
     "sync_decision",
     "sync_peer",
     "syncable_peers",

--- a/src/scitex_agent_container/_hostsync/_alarm.py
+++ b/src/scitex_agent_container/_hostsync/_alarm.py
@@ -1,0 +1,286 @@
+"""Route ``sac host sync --check`` drift verdicts to a SEEN surface.
+
+Stage-0 of the one-way central-sync plan (card
+``sac-one-way-central-sync-staged-plan-20260714``) shipped
+``sac host sync --check`` — a read-only drift detector that mutates
+nothing and exits non-zero on drift. But a detector that only sets an
+exit code is an ALARM WITH NO ONE LISTENING: its shout lands in a
+journald line nobody reads, which is exactly the anti-pattern the plan
+warns against — "an emit is a notification, not a mechanism". That is
+how a five-release-stale checkout stayed invisible until someone looked
+by hand.
+
+This module makes the shout SEEN. For each peer's read-only
+:class:`~._sync.SyncResult` it upserts an IDEMPOTENT scitex-todo card on
+the board's BLOCKING-YOU view (``status=blocked``,
+``blocker=operator-decision`` — the surface the operator already
+monitors), and RESOLVES that card the moment the peer goes clean again so
+a fixed drift stops shouting.
+
+It is a REPORT, never an enforcer. It mutates nothing on any peer and
+never triggers a sync — that (Stage 1) is deliberately out of scope. The
+only writes it makes are to the shared task board.
+
+Three-state honest (the rule sac has paid for, twice):
+
+* **DRIFTED** (behind / ahead / diverged / dirty) → a card NAMING the
+  drift (which peer, and how it differs).
+* **UNDETERMINED** (unreachable / no-module / not-a-checkout) → a card
+  too, but clearly labelled UNKNOWN, never rendered as clean. "I could
+  not look" must never read as "I looked and it was fine".
+* **CURRENT / SYNCED** (clean) → resolve the peer's card.
+
+It reuses the existing scitex-todo integration — the same public writer
+sac's account-refresh alarm rail uses (:mod:`.._account.refresh_alarm`) —
+rather than hand-rolling a todo client. Like that rail, delivery is a
+SIDE rail: a per-card failure is printed loudly to stderr and never
+crashes the check that feeds it. And, like a missing scitex-todo install,
+the whole thing degrades to "printed loudly, nothing recorded" rather
+than taking the check down.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from ._model import PeerSyncReport
+from ._sync import SyncResult
+
+__all__ = ["AlarmOutcome", "CARD_ID_PREFIX", "card_id_for", "route_reports_to_cards"]
+
+#: Stable per-peer card id, so a re-run updates in place instead of
+#: duplicating (idempotency is by id).
+CARD_ID_PREFIX = "host-sync-drift-"
+
+#: The card's owner + author. A pseudo-agent, not a human: the card is a
+#: standing "this peer is not running the centre's code" fact that the
+#: operator resolves, mirroring the accounts-refresh alarm's convention.
+_AGENT = "sac.host-sync-check"
+
+#: A determined-but-drifted card and an undetermined card BOTH land on the
+#: board's BLOCKING-YOU view (``status=blocked`` AND
+#: ``blocker=operator-decision``) — the seen surface the operator already
+#: watches. The card TEXT is what distinguishes drift from unknown.
+_STATUS = "blocked"
+_BLOCKER = "operator-decision"
+
+
+def card_id_for(peer: str) -> str:
+    """The stable card id for ``peer``'s drift alarm."""
+    return f"{CARD_ID_PREFIX}{peer}"
+
+
+@dataclass(frozen=True)
+class AlarmOutcome:
+    """What the routing did this run — so the caller is never silent.
+
+    Every peer lands in exactly one bucket (``failed`` is orthogonal: a
+    peer whose card write raised is recorded there instead of its verdict
+    bucket).
+    """
+
+    drifted: tuple[str, ...] = ()
+    undetermined: tuple[str, ...] = ()
+    cleared: tuple[str, ...] = ()
+    failed: tuple[str, ...] = ()
+
+    def summary_line(self) -> str:
+        """One human line naming what happened to the board this run."""
+        parts = [
+            f"{len(self.drifted)} drift card(s)",
+            f"{len(self.undetermined)} unknown card(s)",
+            f"{len(self.cleared)} cleared",
+        ]
+        if self.failed:
+            parts.append(f"{len(self.failed)} DELIVERY-FAILED")
+        return "scitex-todo alarm: " + ", ".join(parts)
+
+
+def _now_iso(now: datetime | None) -> str:
+    return (now or datetime.now(timezone.utc)).isoformat()
+
+
+def _drift_card(peer: str, report: PeerSyncReport) -> tuple[str, str]:
+    """Title + note for a peer that DIFFERS from the centre.
+
+    The note names the concrete drift (``report.summary()`` already spells
+    out behind/ahead/diverged/dirty) and the exact next command, so the
+    operator reading only the card knows what to do.
+    """
+    title = f"[host-sync] {peer} DRIFTED from centre — {report.summary()}"
+    note = (
+        f"peer: {peer}\n"
+        f"verdict: {report.summary()}\n"
+        f"state: {report.state.value}\n"
+        f"target: {report.target or '?'}\n"
+        f"module: {report.module or '?'}\n\n"
+        "This peer is NOT running the centre's code. It is a REPORT, not an "
+        "auto-sync — reconcile it deliberately (fast-forward only; sac never "
+        "discards remote work):\n"
+        f"    sac host sync {peer}\n"
+        "Inspect first:\n"
+        f"    sac host sync --check {peer}"
+    )
+    return title, note
+
+
+def _unknown_card(peer: str, report: PeerSyncReport) -> tuple[str, str]:
+    """Title + note for a peer we COULD NOT READ.
+
+    Deliberately worded UNKNOWN, never clean. An undetermined peer is not a
+    peer with no drift — it is a peer whose drift we failed to observe, and
+    conflating the two is the exact false-clean that has bitten sac before.
+    """
+    title = f"[host-sync] {peer} UNKNOWN — could not verify ({report.state.value})"
+    note = (
+        f"peer: {peer}\n"
+        f"verdict: {report.summary()}\n"
+        f"state: {report.state.value}\n\n"
+        "UNKNOWN is NOT clean — sac could not read this peer's code, so its "
+        "drift is unobserved, not absent. Nothing was mutated. Restore "
+        "reachability, then re-check:\n"
+        f"    sac host probe {peer}\n"
+        f"    sac host sync --check {peer}"
+    )
+    return title, note
+
+
+def _card_exists(store: str | None, card_id: str) -> bool:
+    """True when ``card_id`` is already on the board.
+
+    A MISSING store file (nothing carded yet) and a missing id BOTH mean
+    "no such card" — the first run against a fresh board raises
+    ``FileNotFoundError`` from the loader, the later runs raise
+    ``TaskNotFoundError``; neither is an error here.
+    """
+    from scitex_todo import TaskNotFoundError, get_task
+
+    # stx-allow: fallback (reason: "does this card exist yet?" — a missing store file or missing id is a normal False, not an error; any other load failure propagates to the caller's per-peer guard which reports it loudly)
+    try:
+        get_task(store, card_id)
+        return True
+    except (TaskNotFoundError, FileNotFoundError):
+        return False
+
+
+def _upsert(
+    store: str | None,
+    card_id: str,
+    title: str,
+    note: str,
+    now: datetime | None,
+) -> None:
+    """Create the card, or update it in place — never duplicate.
+
+    Always (re)asserts ``status=blocked`` / ``blocker=operator-decision``,
+    which also REOPENS a card that a previous clean run had resolved: a
+    peer that drifts, gets fixed (card resolved), then drifts again must
+    alarm again.
+    """
+    from scitex_todo import add_task, update_task
+
+    if _card_exists(store, card_id):
+        update_task(
+            store,
+            card_id,
+            title=title,
+            note=note,
+            status=_STATUS,
+            blocker=_BLOCKER,
+            last_activity=_now_iso(now),
+        )
+    else:
+        add_task(
+            store,
+            id=card_id,
+            title=title,
+            status=_STATUS,
+            blocker=_BLOCKER,
+            note=note,
+            scope=f"agent:{_AGENT}",
+            assignee=_AGENT,
+            created_by=_AGENT,
+        )
+
+
+def _clear(store: str | None, card_id: str) -> bool:
+    """Resolve the peer's card if present + still open. Returns did-clear.
+
+    Idempotent: no card, or an already-resolved card, is a quiet no-op
+    (a clean peer that was never drifted must not create then resolve a
+    phantom card).
+    """
+    from scitex_todo import get_task, resolve_task
+
+    if not _card_exists(store, card_id):
+        return False
+    existing = get_task(store, card_id)
+    if existing.get("status") == "done":
+        return False
+    resolve_task(store, card_id, actor=_AGENT)
+    return True
+
+
+def route_reports_to_cards(
+    results: list[SyncResult],
+    *,
+    store: str | None = None,
+    now: datetime | None = None,
+    err_stream: Any = None,
+) -> AlarmOutcome:
+    """Upsert / resolve one scitex-todo card per peer from ``results``.
+
+    ``results`` are the read-only verdicts ``sac host sync --check``
+    produces. For each peer this upserts a drift or unknown card, or
+    resolves the peer's existing card when it is clean. Never raises: a
+    per-peer card-write failure is printed loudly to ``err_stream`` and the
+    peer is recorded in :attr:`AlarmOutcome.failed`, so one unreachable
+    board never suppresses the rest of the fleet's alarms.
+
+    Parameters
+    ----------
+    store
+        scitex-todo store path. ``None`` = the resolved canonical store
+        (``~/.scitex/todo/tasks.yaml`` on the centre). Tests pass a real
+        temp path — no mocks.
+    now, err_stream
+        Test seams: a fixed clock and a replacement stderr.
+    """
+    stream = err_stream if err_stream is not None else sys.stderr
+    drifted: list[str] = []
+    undetermined: list[str] = []
+    cleared: list[str] = []
+    failed: list[str] = []
+
+    for result in results:
+        peer = result.peer
+        report = result.before
+        card_id = card_id_for(peer)
+        # stx-allow: fallback (reason: card delivery is a SIDE rail — one peer's board-write failure must never crash the drift check that feeds it; it is reported loudly on stderr and recorded in AlarmOutcome.failed)
+        try:
+            if report.is_undetermined:
+                _upsert(store, card_id, *_unknown_card(peer, report), now=now)
+                undetermined.append(peer)
+            elif report.is_drifted:
+                _upsert(store, card_id, *_drift_card(peer, report), now=now)
+                drifted.append(peer)
+            elif _clear(store, card_id):
+                cleared.append(peer)
+        except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+            failed.append(peer)
+            print(
+                f"[host-sync-alarm] {peer}: scitex-todo card delivery FAILED "
+                f"— {exc} (drift verdict unchanged; the --check exit code "
+                "still reflects it)",
+                file=stream,
+            )
+
+    return AlarmOutcome(
+        drifted=tuple(drifted),
+        undetermined=tuple(undetermined),
+        cleared=tuple(cleared),
+        failed=tuple(failed),
+    )

--- a/src/scitex_agent_container/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs_plugin.py
@@ -21,12 +21,23 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 def provide_jobs() -> "list[JobSpec]":
     """Return sac's federated scheduled jobs.
 
-    One job today:
+    Two jobs today:
 
     * ``sac.accounts-refresh`` (``kind="timer"``) — a headless OAuth
       access-token refresh for EVERY stored Claude account, including the
       active one (``--include-active``), mirroring the rotated token back
       into the live ``~/.claude`` login (``--sync-active-login``).
+
+    * ``sac.host-sync-check`` (``kind="timer"``) — the READ-ONLY peer
+      drift detector ``sac host sync --check --all``, run hourly with
+      ``--alarm`` so each peer's verdict is routed to an idempotent
+      scitex-todo card (upsert on drift/unknown, resolve on clean). This
+      is what makes the Stage-0 detector (PR #690) actually RUN and be
+      SEEN: shipped but scheduled nowhere, it was an inert alarm. The job
+      mutates NOTHING on any peer — it never calls the fast-forward
+      remedy (that is Stage 1). ``--alarm`` is gated to require
+      ``--check`` in the CLI, so this scheduled command is read-only by
+      construction.
 
     ``sac listen`` is DELIBERATELY NOT declared here, and adding it back
     would take the fleet's control plane down. scitex-dev derives a unit
@@ -79,10 +90,7 @@ def provide_jobs() -> "list[JobSpec]":
         JobSpec(
             name="sac.accounts-refresh",
             schedule="0 */2 * * *",  # every 2h
-            command=(
-                "sac accounts refresh --all --include-active "
-                "--sync-active-login"
-            ),
+            command=("sac accounts refresh --all --include-active --sync-active-login"),
             description=(
                 "Headless OAuth access-token refresh for all stored Claude "
                 "accounts including the active one (sole-refresher model), "
@@ -102,6 +110,29 @@ def provide_jobs() -> "list[JobSpec]":
             on_boot_sec="15min",
             on_unit_active_sec="2h",
             timeout_sec=120,
+        ),
+        JobSpec(
+            name="sac.host-sync-check",
+            schedule="0 * * * *",  # hourly (cron form; timer cadence below)
+            command="sac host sync --check --all --alarm",
+            description=(
+                "Read-only drift check of every peer's sac checkout vs the "
+                "centre; routes each verdict to an idempotent scitex-todo "
+                "card (upsert on drift/unknown, resolve on clean) so the "
+                "shout is SEEN on the board. Mutates nothing on any peer — "
+                "never runs the fast-forward remedy (Stage 1)."
+            ),
+            kind="timer",
+            # First check 10min after boot/login (peers reachable, listen
+            # settled), then hourly. Drift is slow-moving relative to the
+            # 2h token refresh, so hourly is ample and gentle on ssh.
+            on_boot_sec="10min",
+            on_unit_active_sec="1h",
+            # Sequential per-ssh probe over every peer, each capped at the
+            # verb's 120s default (an unreachable peer waits its ssh
+            # connect-timeout). 600s comfortably covers a handful of peers
+            # including a slow/unreachable one without ever hanging forever.
+            timeout_sec=600,
         ),
     ]
 

--- a/src/scitex_agent_container/cli_pkg/_host_sync.py
+++ b/src/scitex_agent_container/cli_pkg/_host_sync.py
@@ -25,6 +25,7 @@ from .._hostsync import (
     SyncResult,
     check_peer,
     exit_code_for,
+    route_reports_to_cards,
     sync_peer,
     syncable_peers,
 )
@@ -128,6 +129,17 @@ def _print_result(result: SyncResult) -> None:
 @click.option("--repo", default=DEFAULT_REPO, help="owner/name for the CI guard.")
 @click.option("--timeout", type=int, default=120, help="Per-ssh wall-clock cap (s).")
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON (for cron).")
+@click.option(
+    "--alarm",
+    is_flag=True,
+    default=False,
+    help=(
+        "READ-ONLY (requires --check): route each peer's verdict to an "
+        "idempotent scitex-todo card — upsert on drift/unknown, resolve on "
+        "clean — so the shout is SEEN on the board, not just in a log. "
+        "Mutates no peer."
+    ),
+)
 @click.pass_context
 def host_sync(
     ctx: click.Context,
@@ -139,6 +151,7 @@ def host_sync(
     repo: str,
     timeout: int,
     as_json: bool,
+    alarm: bool,
 ) -> None:
     """Reconcile a peer's sac checkout to the centre's code. One-way.
 
@@ -182,6 +195,14 @@ def host_sync(
             "give exactly one of PEER or --all  "
             "(e.g. `sac host sync --check spartan` or `sac host sync --check --all`)"
         )
+    if alarm and not check_only:
+        # Structural safety: the alarm rides ONLY the read-only detector. It
+        # must never be reachable from a mutating sync run — a scheduled
+        # alarm that could fast-forward a peer is Stage 1, not this.
+        raise click.UsageError(
+            "--alarm only rides the read-only --check form (never a mutating "
+            "sync).  Use:  sac host sync --check --all --alarm"
+        )
 
     cfg = _load_cfg()
     targets = syncable_peers(cfg) if all_peers else [peer or ""]
@@ -208,17 +229,25 @@ def host_sync(
 
     code = exit_code_for([r.outcome for r in results])
 
+    # Make the shout SEEN: route each verdict to an idempotent board card
+    # (upsert on drift/unknown, resolve on clean). This runs in BOTH output
+    # modes — the card is the delivery, independent of the console report.
+    alarm_outcome = route_reports_to_cards(results) if alarm else None
+
     if _json_flag(ctx, as_json):
-        click.echo(
-            json.dumps(
-                {
-                    "mode": "check" if check_only else "sync",
-                    "exit_code": code,
-                    "peers": [r.to_dict() for r in results],
-                },
-                indent=2,
-            )
-        )
+        payload: dict = {
+            "mode": "check" if check_only else "sync",
+            "exit_code": code,
+            "peers": [r.to_dict() for r in results],
+        }
+        if alarm_outcome is not None:
+            payload["alarm"] = {
+                "drifted": list(alarm_outcome.drifted),
+                "undetermined": list(alarm_outcome.undetermined),
+                "cleared": list(alarm_outcome.cleared),
+                "failed": list(alarm_outcome.failed),
+            }
+        click.echo(json.dumps(payload, indent=2))
         raise SystemExit(code)
 
     mode = "check (read-only)" if check_only else "sync"
@@ -240,6 +269,8 @@ def host_sync(
             "[green]all peers match the centre[/green] "
             "[dim](verified by loaded-module path + symbol, not by version string)[/dim]"
         )
+    if alarm_outcome is not None:
+        console.print(f"[dim]{alarm_outcome.summary_line()}[/dim]")
     raise SystemExit(code)
 
 

--- a/tests/scitex_agent_container/_hostsync/test__alarm.py
+++ b/tests/scitex_agent_container/_hostsync/test__alarm.py
@@ -1,0 +1,184 @@
+"""Tests for ``_hostsync._alarm`` — drift verdict → SEEN scitex-todo card.
+
+PA-306: no ``unittest.mock``. Real :class:`SyncResult` / :class:`PeerSyncReport`
+objects and a REAL temporary scitex-todo store (``tmp_path/tasks.yaml``);
+the routing calls the real ``scitex_todo`` writer and each test reads the
+card back through the real ``scitex_todo`` reader.
+
+The behaviours that matter:
+
+* drift → an upserted BLOCKING-YOU card (``status=blocked`` /
+  ``blocker=operator-decision``) NAMING the peer,
+* a second drift run UPDATES in place (never duplicates),
+* a clean run RESOLVES the peer's card (a fixed drift stops shouting),
+* UNKNOWN is carded too but labelled UNKNOWN — never rendered as clean,
+* re-drift after a clear REOPENS the card.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._hostsync import route_reports_to_cards
+from scitex_agent_container._hostsync._alarm import card_id_for
+from scitex_agent_container._hostsync._model import GraphState, PeerSyncReport
+from scitex_agent_container._hostsync._sync import Outcome, SyncResult
+
+scitex_todo = pytest.importorskip("scitex_todo")
+
+
+def _behind(peer: str = "spartan", behind: int = 4) -> SyncResult:
+    report = PeerSyncReport(
+        peer=peer,
+        state=GraphState.BEHIND,
+        head="aaa111",
+        target="origin/develop",
+        target_sha="bbb222",
+        behind=behind,
+        repo="/checkout",
+        module="/checkout/src/scitex_agent_container/__init__.py",
+        symbol="['agent_name']",
+    )
+    return SyncResult(peer=peer, outcome=Outcome.DRIFTED, before=report)
+
+
+def _current(peer: str = "spartan") -> SyncResult:
+    report = PeerSyncReport(
+        peer=peer,
+        state=GraphState.CURRENT,
+        head="aaa111",
+        target="origin/develop",
+        target_sha="aaa111",
+        repo="/checkout",
+        module="/checkout/src/scitex_agent_container/__init__.py",
+        symbol="['agent_name']",
+    )
+    return SyncResult(peer=peer, outcome=Outcome.CURRENT, before=report)
+
+
+def _unreachable(peer: str = "nas") -> SyncResult:
+    report = PeerSyncReport(
+        peer=peer,
+        state=GraphState.UNREACHABLE,
+        detail="ssh: connect: refused",
+    )
+    return SyncResult(peer=peer, outcome=Outcome.UNDETERMINED, before=report)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> str:
+    """A real (initially absent) scitex-todo store path — no mocks."""
+    return str(tmp_path / "tasks.yaml")
+
+
+def test_drift_upserts_a_blocking_you_card(store):
+    # Arrange — one peer 4 commits behind the centre.
+    # Act
+    route_reports_to_cards([_behind("spartan")], store=store)
+    # Assert — it lands on the board's BLOCKING-YOU seen surface.
+    blocking = scitex_todo.list_tasks(store, blocking_me=True)
+    assert [t["id"] for t in blocking] == [card_id_for("spartan")]
+
+
+def test_drift_card_names_the_peer(store):
+    # Arrange
+    # Act
+    route_reports_to_cards([_behind("spartan")], store=store)
+    # Assert — never silent: the operator must see WHICH peer.
+    card = scitex_todo.get_task(store, card_id_for("spartan"))
+    assert "spartan" in card["title"]
+
+
+def test_drift_card_names_the_concrete_drift(store):
+    # Arrange — behind is the concrete drift class; the card must say so.
+    # Act
+    route_reports_to_cards([_behind("spartan", behind=4)], store=store)
+    # Assert
+    card = scitex_todo.get_task(store, card_id_for("spartan"))
+    assert "behind" in card["note"].lower()
+
+
+def test_second_drift_run_updates_not_duplicates(store):
+    # Arrange — first run creates the card.
+    route_reports_to_cards([_behind("spartan")], store=store)
+    # Act — a second drift run must UPDATE in place, not add a twin.
+    route_reports_to_cards([_behind("spartan")], store=store)
+    # Assert — exactly one card exists for the peer.
+    assert len(scitex_todo.list_tasks(store)) == 1
+
+
+def test_clean_run_resolves_the_drift_card(store):
+    # Arrange — the peer drifted, so a card exists.
+    route_reports_to_cards([_behind("spartan")], store=store)
+    # Act — the peer is now current with the centre.
+    route_reports_to_cards([_current("spartan")], store=store)
+    # Assert — a fixed drift stops shouting (off the BLOCKING-YOU view).
+    assert scitex_todo.list_tasks(store, blocking_me=True) == []
+
+
+def test_clean_run_marks_the_card_done(store):
+    # Arrange
+    route_reports_to_cards([_behind("spartan")], store=store)
+    # Act
+    route_reports_to_cards([_current("spartan")], store=store)
+    # Assert
+    card = scitex_todo.get_task(store, card_id_for("spartan"))
+    assert card["status"] == "done"
+
+
+def test_clean_peer_without_prior_card_is_a_noop(store):
+    # Arrange — a peer that is current and was NEVER drifted.
+    # Act
+    route_reports_to_cards([_current("spartan")], store=store)
+    # Assert — no phantom card is created just to resolve it.
+    assert not Path(store).exists() or scitex_todo.list_tasks(store) == []
+
+
+def test_undetermined_peer_gets_a_card(store):
+    # Arrange — an unreachable peer. UNKNOWN must be surfaced, not swallowed.
+    # Act
+    route_reports_to_cards([_unreachable("nas")], store=store)
+    # Assert
+    assert scitex_todo.get_task(store, card_id_for("nas"))["id"] == card_id_for("nas")
+
+
+def test_undetermined_card_is_labelled_unknown(store):
+    # Arrange — "I could not look" must never read as "I looked, it's fine".
+    # Act
+    route_reports_to_cards([_unreachable("nas")], store=store)
+    # Assert
+    card = scitex_todo.get_task(store, card_id_for("nas"))
+    assert "UNKNOWN" in card["title"]
+
+
+def test_route_buckets_drift_and_unknown_separately(store):
+    # Arrange — a drifted peer AND an unreachable peer in one run.
+    # Act
+    outcome = route_reports_to_cards(
+        [_behind("spartan"), _unreachable("nas")], store=store
+    )
+    # Assert — drift and unknown are distinct buckets (three-state honest).
+    assert (outcome.drifted, outcome.undetermined) == (("spartan",), ("nas",))
+
+
+def test_route_reports_the_cleared_peer(store):
+    # Arrange — drift first so there is a card to clear.
+    route_reports_to_cards([_behind("spartan")], store=store)
+    # Act
+    outcome = route_reports_to_cards([_current("spartan")], store=store)
+    # Assert
+    assert outcome.cleared == ("spartan",)
+
+
+def test_redrift_after_clear_reopens_the_card(store):
+    # Arrange — drift, then fixed (card resolved).
+    route_reports_to_cards([_behind("spartan")], store=store)
+    route_reports_to_cards([_current("spartan")], store=store)
+    # Act — the peer drifts AGAIN; the alarm must re-fire, not stay silent.
+    route_reports_to_cards([_behind("spartan")], store=store)
+    # Assert — the card is back on the BLOCKING-YOU view.
+    assert len(scitex_todo.list_tasks(store, blocking_me=True)) == 1

--- a/tests/scitex_agent_container/cli_pkg/test__host_sync.py
+++ b/tests/scitex_agent_container/cli_pkg/test__host_sync.py
@@ -138,3 +138,47 @@ def test_neither_peer_nor_all_is_a_usage_error(cfg_path):
     result = CliRunner().invoke(host_sync, ["--check"])
     # Assert
     assert result.exit_code == 2
+
+
+def test_alarm_without_check_is_a_usage_error(cfg_path):
+    # Arrange — the alarm must ride ONLY the read-only --check form; a
+    # scheduled alarm that could fast-forward a peer is Stage 1.
+    # Act
+    result = CliRunner().invoke(host_sync, ["--alarm", "--all"])
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_alarm_writes_a_card_for_a_stale_peer(
+    cfg_path, subprocess_shim, env_save_restore, tmp_path
+):
+    # Arrange — a real temp board, redirected via the documented env var,
+    # and a peer 4 commits behind the centre.
+    scitex_todo = pytest.importorskip("scitex_todo")
+    store = str(tmp_path / "board.yaml")
+    env_save_restore.set("SCITEX_TODO_TASKS_YAML_SHARED", store)
+    subprocess_shim.install(
+        "ssh", stdout=_marker_block(head="aaa111", target_sha="bbb222", behind=4)
+    )
+    # Act — the exact read-only check+alarm form the timer runs.
+    CliRunner().invoke(host_sync, ["--check", "spartan", "--alarm"])
+    # Assert — the shout is SEEN: a card for spartan is on the board.
+    ids = [t["id"] for t in scitex_todo.list_tasks(store, blocking_me=True)]
+    assert ids == ["host-sync-drift-spartan"]
+
+
+def test_alarm_is_read_only_and_runs_no_merge(
+    cfg_path, subprocess_shim, env_save_restore, tmp_path
+):
+    # Arrange — a drifted peer plus a redirected board so nothing touches
+    # the real store.
+    pytest.importorskip("scitex_todo")
+    env_save_restore.set("SCITEX_TODO_TASKS_YAML_SHARED", str(tmp_path / "board.yaml"))
+    subprocess_shim.install(
+        "ssh", stdout=_marker_block(head="aaa111", target_sha="bbb222", behind=4)
+    )
+    # Act
+    CliRunner().invoke(host_sync, ["--check", "spartan", "--alarm"])
+    calls = subprocess_shim.invocations("ssh")
+    # Assert — --alarm rides the read-only detector; it never mutates a peer.
+    assert not any("merge --ff-only" in " ".join(argv) for argv in calls)

--- a/tests/scitex_agent_container/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/test__jobs_plugin.py
@@ -37,13 +37,14 @@ def _job(name: str):
     return match
 
 
-def test_provider_returns_one_job() -> None:
-    # Arrange — call the registered provider. One, not two: `sac listen` is
-    # NOT federated (see the module docstring and the absence-pin below).
+def test_provider_returns_two_jobs() -> None:
+    # Arrange — call the registered provider. Two: accounts-refresh and the
+    # host-sync-check drift alarm. `sac listen` is still NOT federated (see
+    # the module docstring and the absence-pin below).
     # Act
     jobs = provide_jobs()
     # Assert
-    assert len(jobs) == 1
+    assert len(jobs) == 2
 
 
 def test_provider_jobs_are_real_jobspecs() -> None:
@@ -142,3 +143,55 @@ def test_provider_does_not_federate_listen_it_would_duplicate_the_supervisor() -
     names = [spec.name for spec in provide_jobs()]
     # Assert
     assert "sac.listen" not in names
+
+
+def test_host_sync_check_job_name_is_package_prefixed() -> None:
+    # Arrange — the drift-alarm timer that makes the Stage-0 detector run.
+    # Act
+    job = _job("sac.host-sync-check")
+    # Assert
+    assert job.name == "sac.host-sync-check"
+
+
+def test_host_sync_check_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer (hourly), so kind="timer".
+    # Act
+    job = _job("sac.host-sync-check")
+    # Assert
+    assert job.kind == "timer"
+
+
+def test_host_sync_check_command_is_the_readonly_check() -> None:
+    # Arrange — the scheduled command MUST carry --check. A timer that could
+    # fast-forward a peer unattended is Stage 1, explicitly out of scope.
+    # Act
+    job = _job("sac.host-sync-check")
+    # Assert
+    assert "--check" in job.command
+
+
+def test_host_sync_check_command_routes_to_a_seen_card() -> None:
+    # Arrange — --alarm is what turns the exit code into a SEEN board card
+    # instead of a journald line nobody reads.
+    # Act
+    job = _job("sac.host-sync-check")
+    # Assert
+    assert "--alarm" in job.command
+
+
+def test_host_sync_check_command_never_runs_the_mutating_remedy() -> None:
+    # Arrange — belt-and-braces: the exact mutating form `sac host sync
+    # <peer>` (no --check) must never be what this timer runs. The command
+    # is the read-only detector, full stop.
+    # Act
+    job = _job("sac.host-sync-check")
+    # Assert — the command is precisely the read-only check+alarm form.
+    assert job.command == "sac host sync --check --all --alarm"
+
+
+def test_host_sync_check_cadence_is_hourly() -> None:
+    # Arrange — drift is slow-moving; hourly is ample and gentle on ssh.
+    # Act
+    job = _job("sac.host-sync-check")
+    # Assert
+    assert job.on_unit_active_sec == "1h"


### PR DESCRIPTION
## The gap (measured, not hypothesised)

The Stage-0 one-way-sync drift detector `sac host sync --check` (PR #690)
mutates nothing and exits non-zero on drift, so it is a cron-able alarm.
But it was scheduled **NOWHERE** on the centre (ywata-note-win) — no
crontab line, no systemd timer (only `sac-listen-health.timer` and
`sac.accounts-refresh.timer` exist). So the detector was **inert**: it
exists and had never run on a schedule. Per the plan card's own thesis,
"an emit is a notification, not a mechanism" and "an alarm with no
enforcer behind it is a hope with a siren on it."

This PR makes the detector actually **RUN** and makes its shout actually
be **SEEN** — routed to a surface the operator already monitors, not a
journald line nobody reads.

## What changed

- **`_jobs_plugin.py`** — a second federated `JobSpec`
  `sac.host-sync-check` (`kind="timer"`, hourly) running
  `sac host sync --check --all --alarm`. Installed via the **same**
  scitex-dev `ecosystem` aggregator as `sac.accounts-refresh` (extends
  the existing federated-jobs installer; does not fork a parallel one).
  Read-only: it never runs the fast-forward remedy (Stage 1, out of
  scope).
- **`cli_pkg/_host_sync.py`** — new `--alarm` flag on `sac host sync`,
  **gated to require `--check`** (a scheduled alarm must never be able to
  mutate a peer — enforced with a `UsageError`).
- **`_hostsync/_alarm.py`** (new, 286 lines) — routes each read-only
  verdict to an **idempotent** scitex-todo card `host-sync-drift-<peer>`
  on the board's BLOCKING-YOU view (`status=blocked` /
  `blocker=operator-decision`): upsert on drift/unknown, **resolve on
  clean** so a fixed drift stops shouting. **Three-state honest** —
  UNKNOWN (unreachable / no-module / not-a-checkout) gets its own card
  clearly labelled UNKNOWN, never rendered as clean, and nothing is
  auto-synced or destroyed (it is a REPORT). Reuses the public
  `scitex_todo` writer — the same integration the accounts-refresh alarm
  rail uses. Delivery is a side rail: a per-card failure is printed
  loudly and never crashes the check.
- **`scripts/systemd/README.md`** — a short section documenting the new
  federated timer + its enable command.

## Tests (no mocks — real temp scitex-todo store, real CliRunner)

`drift→card`, idempotent re-run (**no duplicate**), `clean→resolve`,
`redrift→reopen`, `unknown-not-clean`, the drift/unknown bucket split,
plus CLI `--alarm` end-to-end (writes a real card) and the `--check`-gate
usage error. Also pins the JobSpec command is the read-only check+alarm
form and never the mutating remedy.

```
39 passed in 14.06s
```
(the `_hostsync/` + `cli_pkg/test__host_sync.py` + `test__jobs_plugin.py`
slice; full `_hostsync/` suite 103 passed with no regression.)

## Operator-only step to ENABLE on the host (after merge + deploy)

Installing/enabling a host systemd `--user` timer is operator-only:

```bash
# 1. Generate + install the unit files (idempotent; also re-emits
#    sac.accounts-refresh unchanged):
sac dev systemd install --yes
systemctl --user daemon-reload

# 2. Enable + start ONLY the new drift-check timer:
systemctl --user enable --now sac.host-sync-check.timer

# 3. Verify:
systemctl --user list-timers sac.host-sync-check.timer
journalctl --user -u sac.host-sync-check.service -n 50
```

Drift then surfaces on the scitex-todo board as `host-sync-drift-<peer>`
cards, not in the journal. **Please review — do not merge on my behalf.**
