### PR TITLE
fix(whoami): placeholder shape instead of the word UNKNOWN (operator UX ruling)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_whoami.py
+++ b/src/scitex_agent_container/cli_pkg/_whoami.py
@@ -7,7 +7,7 @@ real agent container actually has — the sac-injected environment and
 (when resolvable through the injected spec search path) its own
 ``spec.yaml``. It never assumes the host registry is readable: the
 in-container ``$HOME`` is ``/home/agent`` and shadows the host home, so
-any fact that cannot be derived renders an honest ``UNKNOWN``
+any fact that cannot be derived renders an honest placeholder
 (``null`` under ``--json``) instead of a guess.
 
 Environment facts surveyed (injection sites, for the record):
@@ -43,7 +43,10 @@ from pathlib import Path
 import click
 
 #: Text rendering for a fact we cannot derive in-container. JSON uses null.
-UNKNOWN = "UNKNOWN"
+# Operator UX ruling (2026-07-16, Telegram 2614): the literal word
+# "UNKNOWN" reads like a value and is misleading — render underivable
+# facts as an obviously-non-value placeholder instead. JSON stays null.
+UNKNOWN = "xxxx****xxxx"
 
 #: Mount-point prefixes worth showing (kept to a few lines by design).
 _MOUNT_PREFIXES = ("/home", "/work", "/uvwork", "/state")
@@ -401,7 +404,7 @@ def whoami(ctx: click.Context, as_json: bool) -> None:
 
     Facts come from the sac-injected environment and, when resolvable
     through $SCITEX_AGENT_CONTAINER_YAML_DIRS, the agent's own spec.yaml.
-    Underivable facts render an honest UNKNOWN (null under --json); no
+    Underivable facts render an honest placeholder (null under --json); no
     secret value (e.g. the listen bearer) is ever printed.
     """
     from ._helpers import _json_flag

--- a/tests/scitex_agent_container/cli_pkg/test__whoami.py
+++ b/tests/scitex_agent_container/cli_pkg/test__whoami.py
@@ -140,13 +140,25 @@ def test_whoami_renders_all_section_headers(tmp_path):
     assert {h for h in headers if h in result.output} == headers
 
 
-def test_whoami_blank_env_agent_is_unknown(tmp_path):
+def test_whoami_blank_env_agent_renders_placeholder(tmp_path):
     # Arrange
+    from scitex_agent_container.cli_pkg._whoami import UNKNOWN
+
+    env = _blank_env(tmp_path)
+    # Act
+    result = _invoke(env)
+    # Assert — underivable facts render the placeholder shape.
+    assert UNKNOWN in _line(result.output, "agent:")
+
+
+def test_whoami_blank_env_never_prints_the_word_unknown(tmp_path):
+    # Arrange — the literal word reads like a value and misleads (operator
+    # UX ruling 2026-07-16); the placeholder is an obviously-non-value shape.
     env = _blank_env(tmp_path)
     # Act
     result = _invoke(env)
     # Assert
-    assert "UNKNOWN" in _line(result.output, "agent:")
+    assert "UNKNOWN" not in result.output
 
 
 def test_whoami_blank_env_role_points_to_claude_md(tmp_path):


### PR DESCRIPTION
The literal word UNKNOWN reads like a value (operator, 2026-07-16: "unknown は unknown でミスリーディング。xxxx****xxxx とかの方がよい"). Underivable facts now render `xxxx****xxxx`; reason suffixes stay; `--json` still emits null. Tests updated: placeholder asserted via the constant + a test that the word UNKNOWN never appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)