### PR TITLE
fix(acl): privileged group may spawn (operator ruling — the strongest group was absent from the allowlist)

### DIFF
--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -120,7 +120,9 @@ def record_lineage(
                 return  # idempotent no-op
             _logger.warning(
                 "record_lineage: child %r keeps parent %r (ignored re-parent to %r)",
-                child, existing["parent_name"], parent,
+                child,
+                existing["parent_name"],
+                parent,
             )
             return
         conn.execute(
@@ -301,7 +303,11 @@ def spawn_allowed(
     ``developer`` or ``researcher`` (:func:`is_developer` /
     :func:`is_researcher`) — the operator's exact words: "Dev agents
     and research agents MUST have full permissions — including the
-    ability to start/stop peer agents." Any other child is denied.
+    ability to start/stop peer agents." The ``privileged`` group is
+    allowed on the same footing (operator ruling 2026-07-16: denying
+    a privileged-group agent — dotfiles — "is a sac bug"; checked in
+    the group fallthrough below, which every named path also reaches).
+    Any other child is denied.
     ``caller=None`` means the administrative / human-operator path
     (e.g., a shell invocation from outside any sac-managed agent) —
     allowed.
@@ -337,19 +343,28 @@ def spawn_allowed(
     # must be able to self-heal a DOWN peer like scitex-clew without waiting
     # on the operator). The per-spec may_spawn gate still layers on top,
     # exactly like the root path above.
-    from ..config._group_resolver import is_developer_group, is_research_group
+    from ..config._group_resolver import (
+        is_developer_group,
+        is_privileged_group,
+        is_research_group,
+    )
 
     group = resolve_group_name(name=caller, db_path=db_path)
-    if is_developer_group(group) or is_research_group(group):
+    if (
+        is_developer_group(group)
+        or is_research_group(group)
+        or is_privileged_group(group)
+    ):
         return apply_may_spawn_gate(caller=caller, base=(True, None), db_path=db_path)
     return (
         False,
         (
             f"spawn denied: caller {caller!r} is a child of "
-            f"{parent_row['parent_name']!r} and is in neither the developer "
-            "nor research group. Current policy: only root nodes, or "
-            "developer/research group members, may spawn (handoff §4 "
-            "'lift-able policy' — a single edit to spawn_allowed())."
+            f"{parent_row['parent_name']!r} and is in none of the developer, "
+            "research, or privileged groups. Current policy: only root "
+            "nodes, or developer/research/privileged group members, may "
+            "spawn (handoff §4 'lift-able policy' — a single edit to "
+            "spawn_allowed())."
         ),
     )
 
@@ -367,7 +382,6 @@ from .state_db_grants import (  # noqa: E402, F401
     list_comms_grants,
     revoke_send,
 )
-
 
 # ---------------------------------------------------------------------------
 # WI-4 — name → host resolver primitives. Kept here (rather than

--- a/src/scitex_agent_container/config/_group_resolver.py
+++ b/src/scitex_agent_container/config/_group_resolver.py
@@ -66,6 +66,7 @@ __all__ = [
     "group_from_labels",
     "groups_mesh",
     "is_developer_group",
+    "is_privileged_group",
     "is_mesh_group",
     "is_research_group",
     "resolve_group",
@@ -320,6 +321,22 @@ def is_research_group(group: str | None) -> bool:
     if not group:
         return False
     return str(group).strip().lower() == RESEARCHER_GROUP
+
+
+def is_privileged_group(group: str | None) -> bool:
+    """Return True iff ``group`` is the privileged group.
+
+    Case-insensitive on the resolved group name. ``None`` / empty →
+    False. Mirrors :func:`is_developer_group` on the same group-name
+    source of truth (:data:`PRIVILEGED_GROUP`). Used by the spawn ACL
+    gate (operator ruling 2026-07-16: the spawn denial for a
+    privileged-group agent — dotfiles, groups [privileged, infra] —
+    "is a sac bug"; the nominally strongest group could not spawn
+    while developer/researcher could).
+    """
+    if not group:
+        return False
+    return str(group).strip().lower() == PRIVILEGED_GROUP
 
 
 def is_mesh_group(group: str | None) -> bool:

--- a/tests/scitex_agent_container/_listen/test__acl.py
+++ b/tests/scitex_agent_container/_listen/test__acl.py
@@ -30,8 +30,8 @@ from starlette.testclient import TestClient
 from scitex_agent_container._listen._acl import check_send_acl, check_spawn
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
-from scitex_agent_container._state import state_db
 from scitex_agent_container._state import registry as _reg
+from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_blocks import block_send
 from scitex_agent_container._state.state_db_channel import list_undelivered
 from scitex_agent_container._state.state_db_nodes import (
@@ -286,7 +286,10 @@ def test_spawn_deny_reason_explains_root_only_policy(db_path: Path) -> None:
     # Act
     _decision, reason = check_spawn(caller="worker-a", db_path=db_path)
     # Assert
-    assert reason is not None and "neither the developer nor research group" in reason
+    assert (
+        reason is not None
+        and "none of the developer, research, or privileged groups" in reason
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -529,7 +532,9 @@ def test_http_agents_start_403_carries_role_policy_text(
         )
     body_json = r.json()
     # Assert
-    assert "neither the developer nor research group" in body_json.get("reason", "")
+    assert "none of the developer, research, or privileged groups" in body_json.get(
+        "reason", ""
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -552,9 +557,7 @@ def _denied_attempt_rows(target: str, db_path: Path) -> list[dict]:
     receiver coming online sees after the denial.
     """
     rows = list_undelivered(target=target, db_path=db_path)
-    return [
-        r for r in rows if (r["event"] or {}).get("kind") == "denied_attempt"
-    ]
+    return [r for r in rows if (r["event"] or {}).get("kind") == "denied_attempt"]
 
 
 # Scenarios are computed once per test function via fixtures; each
@@ -737,9 +740,7 @@ def fanout_scope_scenario(isolated_listen_env, db_path: Path) -> dict:
     return {
         "resp": resp,
         "target_notifs": _denied_attempt_rows(target="child-2", db_path=db_path),
-        "bystander_notifs": _denied_attempt_rows(
-            target="bystander", db_path=db_path
-        ),
+        "bystander_notifs": _denied_attempt_rows(target="bystander", db_path=db_path),
         "empty_notifs": _denied_attempt_rows(target="", db_path=db_path),
     }
 

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -442,7 +442,8 @@ def test_spawn_allowed_deny_reason_names_group_policy(db_path: Path) -> None:
     _allowed, reason = spawn_allowed(caller="worker-gen", db_path=db_path)
     # Assert
     assert (
-        reason is not None and "developer/research group members, may spawn" in reason
+        reason is not None
+        and "developer/research/privileged group members, may" in reason
     )
 
 

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -70,24 +70,20 @@ def test_comms_grants_table_exists(db_path: Path) -> None:
     # Act
     with conn_ctx as conn:
         rows = conn.execute(
-            "SELECT name FROM sqlite_master "
-            "WHERE type='table' AND name='comms_grants'"
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='comms_grants'"
         ).fetchall()
     # Assert
     assert len(rows) == 1
 
 
-@pytest.mark.parametrize(
-    "column", ["sender_name", "target_name", "created_at", "note"]
-)
+@pytest.mark.parametrize("column", ["sender_name", "target_name", "created_at", "note"])
 def test_comms_grants_has_column(db_path: Path, column: str) -> None:
     # Arrange
     conn_ctx = state_db.open_db(db_path)
     # Act
     with conn_ctx as conn:
         cols = {
-            r[1]
-            for r in conn.execute("PRAGMA table_info(comms_grants)").fetchall()
+            r[1] for r in conn.execute("PRAGMA table_info(comms_grants)").fetchall()
         }
     # Assert
     assert column in cols
@@ -246,7 +242,10 @@ def test_spawn_allowed_deny_reason_explains_role_policy(
     # Act
     _allowed, reason = spawn_allowed(caller="worker-a", db_path=db_path)
     # Assert
-    assert reason is not None and "neither the developer nor research group" in reason
+    assert (
+        reason is not None
+        and "none of the developer, research, or privileged groups" in reason
+    )
 
 
 def test_spawn_allowed_returns_true_for_developer_group_child(
@@ -275,6 +274,24 @@ def test_spawn_allowed_returns_true_for_researcher_group_child(
     assert allowed is True
 
 
+def test_spawn_allowed_returns_true_for_privileged_group_child(
+    db_path: Path,
+) -> None:
+    """A privileged-group child may spawn (operator ruling 2026-07-16).
+
+    Watch-it-fail: on the pre-fix code this is the exact 403 the
+    dotfiles agent (groups [privileged, infra]) hit — the nominally
+    strongest group was absent from the spawn allowlist.
+    """
+    # Arrange
+    record_lineage(child="dotfiles", parent="root", db_path=db_path)
+    record_comms_policy(name="dotfiles", group_name="privileged", db_path=db_path)
+    # Act
+    allowed, _reason = spawn_allowed(caller="dotfiles", db_path=db_path)
+    # Assert
+    assert allowed is True
+
+
 def test_spawn_allowed_returns_false_for_non_dev_research_group_child(
     db_path: Path,
 ) -> None:
@@ -298,7 +315,10 @@ def test_spawn_allowed_deny_reason_for_non_dev_research_group_child(
     # Act
     _allowed, reason = spawn_allowed(caller="worker-a", db_path=db_path)
     # Assert
-    assert reason is not None and "neither the developer nor research group" in reason
+    assert (
+        reason is not None
+        and "none of the developer, research, or privileged groups" in reason
+    )
 
 
 def test_spawn_allowed_may_spawn_false_still_denies_developer_child(
@@ -421,7 +441,9 @@ def test_spawn_allowed_deny_reason_names_group_policy(db_path: Path) -> None:
     # Act
     _allowed, reason = spawn_allowed(caller="worker-gen", db_path=db_path)
     # Assert
-    assert reason is not None and "developer/research group members, may spawn" in reason
+    assert (
+        reason is not None and "developer/research group members, may spawn" in reason
+    )
 
 
 def test_spawn_allowed_developer_group_child_still_respects_may_spawn(
@@ -561,7 +583,9 @@ def test_list_comms_grants_returns_each_grant_pair(db_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _insert_grant_at(db_path: Path, sender: str, target: str, created_at: float) -> None:
+def _insert_grant_at(
+    db_path: Path, sender: str, target: str, created_at: float
+) -> None:
     """Write one ``comms_grants`` row with an EXPLICIT ``created_at``.
 
     ``grant_send`` stamps ``time.time()`` internally, so a tie / skew can't
@@ -615,8 +639,7 @@ def test_node_tokens_table_exists(db_path: Path) -> None:
     # Act
     with conn_ctx as conn:
         rows = conn.execute(
-            "SELECT name FROM sqlite_master "
-            "WHERE type='table' AND name='node_tokens'"
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='node_tokens'"
         ).fetchall()
     # Assert
     assert len(rows) == 1


### PR DESCRIPTION
Operator (2026-07-16): the spawn 403 for the dotfiles agent (groups [privileged, infra]) is a sac bug. spawn_allowed() allowlisted root/developer/researcher but never privileged. Adds is_privileged_group (mirroring the dev/research helpers), wires it into the group fallthrough every path reaches, and corrects the 403 text. infra is deliberately NOT granted wholesale — privileged is the operator-named gap. Watch-it-fail: the new privileged-child test reproduces the exact production denial on pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)