### PR TITLE
feat(maintenance): sac worktree gc — permanent worktree-sprawl GC + cap alarm + daily timer

### DIFF
--- a/docs/worktree-gc.md
+++ b/docs/worktree-gc.md
@@ -1,0 +1,187 @@
+# `sac worktree gc` — worktree-sprawl GC + cap alarm
+
+Agent-tool isolation worktrees auto-clean **only when nothing edited
+them**. Anything an agent actually TOUCHED persisted forever, and until
+now no periodic GC, no cap, and no alarm existed anywhere: one repo
+reached **105 worktrees** and helped trigger a host load-spike
+(`incident-worktree-sprawl-permanent-gc-20260710`, operator-declared P1).
+
+Sprawl is not a tidiness problem — it is a standing liability. This is
+the permanent countermeasure.
+
+> Documented as a standalone page rather than a section in
+> `scripts/systemd/README.md` (where `sac.accounts-refresh` and
+> `sac.host-sync-check` are written up): that file already sits exactly at
+> the repo's 512-line cap, so adding to it demands an unrelated refactor.
+
+## The safety predicate — the whole point
+
+A worktree is removed **iff ALL FOUR** legs pass:
+
+| leg | passes when | on doubt |
+|---|---|---|
+| **CLEAN** | `git status --porcelain` is empty — **untracked counts as DIRTY** | KEEP |
+| **MERGED** | ancestor of `develop`/`main`, **OR** a merged PR exists for the branch | KEEP |
+| **OLD** | the HEAD commit is older than `--min-age-hours` (default 24) | KEEP |
+| **IDLE** | no running process has its cwd inside it (best-effort `/proc` scan) | KEEP |
+
+Every leg is **three-state**, never boolean: a check that could not RUN
+returns UNKNOWN and the worktree is KEPT with a reason naming the
+unknown. "I could not look" must never collapse into "I looked and it was
+fine" — that collapse is exactly how a predicate destroys work.
+
+The asymmetry is deliberate and permanent:
+
+- a false **KEEP** leaves a stale directory on disk — annoying, and the
+  cap alarm shouts about it;
+- a false **REMOVE** destroys work that exists nowhere else.
+
+We pick annoying, every time.
+
+Two details that are load-bearing rather than incidental:
+
+- **Untracked files count as DIRTY.** An untracked file is work saved
+  nowhere else, which makes it the most expensive thing in the tree, not
+  the cheapest.
+- **The MERGED leg needs both styles.** A squash-merged branch is *not*
+  an ancestor of its base, so the ancestor check alone would call every
+  squash-merged branch "unmerged" forever and a squash-merging repo would
+  never be GC'd at all. The merged-PR lookup (`gh pr list --head <branch>
+  --state merged`) covers that case, and it answers `None` (→ KEEP) on
+  any doubt: gh missing, unauthenticated, offline, or rate-limited.
+
+## What it never touches
+
+- **`--force` is never passed.** Removal is plain `git worktree remove`,
+  so git's own refusal to remove a dirty worktree is a second,
+  independent implementation of the CLEAN leg — the only check in this
+  system we did not write ourselves. Passing `--force` would disable it.
+  A test pins the absence.
+- **The main worktree and bare repos.** They are not sprawl; they are the
+  repo.
+- **Locked worktrees.** A lock is a human saying "leave this alone".
+- **Repos no agent declares.** See `--all`'s source below.
+
+`git worktree prune` runs alongside as the separate, always-safe half: it
+only drops administrative refs whose directory is **already gone**, so it
+destroys no files by construction and needs no predicate. On a dry run it
+is invoked as `prune --dry-run` — a report, so `--dry-run` is a pure read
+across the *whole* pass, not just the remove half.
+
+## Usage
+
+`--dry-run` is the **default**. A GC whose default is destructive gets run
+destructively by accident exactly once.
+
+```bash
+# Report (read-only — removes nothing)
+sac worktree gc --repo ~/proj/scitex-todo
+sac worktree gc --all
+sac worktree gc --all --json          # machine-readable, for cron
+
+# Act
+sac worktree gc --apply --all
+```
+
+| flag | default | meaning |
+|---|---|---|
+| `--dry-run` | **on** | read-only report (explicit form, for scripts) |
+| `--apply` | off | remove what the predicate proved safe |
+| `--repo PATH` | — | sweep this repo (repeatable) |
+| `--all` | — | sweep every declared repo (see below) |
+| `--min-age-hours N` | 24 | keep any worktree whose HEAD commit is younger |
+| `--cap N` | 20 | alarm when a repo *still* has more than N after the pass |
+| `--alarm/--no-alarm` | on with `--apply` | route cap verdicts to a board card |
+| `--json` | off | structured output |
+
+**Exit codes**: `0` every repo under cap · `1` a repo is still over cap
+after the pass · `2` a repo could not be READ (unknown outranks
+known-bad, because it is a known-bad you cannot see).
+
+### What `--all` sweeps
+
+Every local **git-repo toplevel** declared as some agent's
+`spec.workdir`. sac's own spec tree is the source, so `--all` cannot
+drift from a second registry that would need its own maintenance. Two
+filters keep that source clean:
+
+- **Must exist locally** — specs describe agents on Spartan and inside
+  containers too; this GC only ever touches the machine it runs on.
+- **Must be a repo toplevel** — a workdir merely *inside* a repo does not
+  drag the enclosing repo in, and the default per-agent runtime workspace
+  is not a repo at all.
+
+A repo that no agent spec declares is **never** swept by `--all` — name
+it with `--repo`. That gap is honest and narrow: worktree sprawl comes
+from agent tools, and agent tools run in agent workdirs.
+
+## The cap alarm
+
+The reaping is the easy half. The half that prevents the incident is
+**shouting about what the predicate refused to touch**, because those are
+the worktrees that accumulate forever.
+
+After a pass, a repo still over `--cap` upserts an idempotent scitex-todo
+card on the board's BLOCKING-YOU view:
+
+- **id** `worktree-sprawl-<repo-basename>` (stable → a nightly re-run
+  updates in place instead of tiling the board)
+- **status** `blocked` / **blocker** `operator-decision`
+- **body** names the repo, the count, and the **kept-reasons breakdown**
+  (`9 dirty, 6 unmerged, 2 in-use`). That breakdown is the card's whole
+  value: "17 kept" is a number, "9 dirty" is an instruction.
+
+Three-state, like the predicate: **over cap** → card; **unreadable repo**
+→ card labelled UNKNOWN (never rendered clean); **back under cap** →
+card resolved, so a fixed repo stops shouting. A repo that sprawls, gets
+cleaned, then sprawls again alarms again.
+
+Delivery is a **side rail**: a board-write failure prints loudly to
+stderr and never crashes the GC that feeds it.
+
+## The daily timer
+
+`sac.worktree-gc` is a federated `scitex_dev.jobs` JobSpec
+(`_jobs_plugin.py`), `kind="timer"`, running `sac worktree gc --apply
+--all` daily. This is what makes the countermeasure *periodic* — a GC
+nobody schedules is a script, not a countermeasure, which is precisely
+how the sprawl accumulated.
+
+Sprawl accumulates over days and the age gate is 24h, so a faster cadence
+could not remove anything a daily pass would miss.
+
+Install (operator-side). Use the **scitex-dev** verb directly — sac's own
+`sac dev systemd install` wrapper is currently broken (it queries a dead
+kind; carded separately):
+
+```bash
+scitex-dev ecosystem systemd install --name sac.worktree-gc --yes
+systemctl --user daemon-reload
+systemctl --user enable --now sac.worktree-gc.timer
+
+# Verify
+systemctl --user list-timers sac.worktree-gc.timer
+journalctl --user -u sac.worktree-gc.service -n 50
+```
+
+Before enabling it, look at what it *would* do — the default is read-only:
+
+```bash
+sac worktree gc --all
+```
+
+## Where the code lives
+
+| file | concern |
+|---|---|
+| `_maintenance/_worktree_gc_model.py` | dataclasses, keep-reason vocabulary, exit codes |
+| `_maintenance/_worktree_gc_probe.py` | observation: git, `/proc`, `gh` (the injectable seams) |
+| `_maintenance/_worktree_gc_predicate.py` | **the four legs** |
+| `_maintenance/_worktree_gc.py` | the engine (dry-run/apply, remove, prune) |
+| `_maintenance/_worktree_gc_alarm.py` | the idempotent cap card |
+| `_maintenance/_worktree_gc_repos.py` | `--all`'s repo discovery |
+| `cli_pkg/_worktree_gc.py` | the `sac worktree gc` verb |
+
+Tests drive **real** temp git repos with **real** `git worktree add` (and
+a real child process for the in-use leg) — no mocks. Only the merged-PR
+lookup and the `/proc` scan are injected, so the suite needs no network.

--- a/src/scitex_agent_container/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs_plugin.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 def provide_jobs() -> "list[JobSpec]":
     """Return sac's federated scheduled jobs.
 
-    Two jobs today:
+    Three jobs today:
 
     * ``sac.accounts-refresh`` (``kind="timer"``) — a headless OAuth
       access-token refresh for EVERY stored Claude account, including the
@@ -38,6 +38,20 @@ def provide_jobs() -> "list[JobSpec]":
       remedy (that is Stage 1). ``--alarm`` is gated to require
       ``--check`` in the CLI, so this scheduled command is read-only by
       construction.
+
+    * ``sac.worktree-gc`` (``kind="timer"``) — the DAILY worktree GC,
+      ``sac worktree gc --apply --all``. Agent-tool worktrees auto-clean
+      only when nothing edited them, so anything an agent TOUCHED
+      persisted forever with no GC, no cap and no alarm anywhere: one repo
+      reached 105 worktrees and helped trigger a host load-spike
+      (``incident-worktree-sprawl-permanent-gc-20260710``). This is the
+      only thing that makes the countermeasure PERIODIC — a GC nobody
+      schedules is a script, not a countermeasure, which is exactly how
+      the sprawl accumulated in the first place. It removes ONLY what it
+      can prove is safe (clean AND merged AND aged AND idle, never
+      ``--force``) and cards any repo still over its cap. ``--all`` is
+      well-defined here: it sweeps the local git repos declared as agents'
+      ``spec.workdir``, so the command is correct as written.
 
     ``sac listen`` is DELIBERATELY NOT declared here, and adding it back
     would take the fleet's control plane down. scitex-dev derives a unit
@@ -133,6 +147,33 @@ def provide_jobs() -> "list[JobSpec]":
             # connect-timeout). 600s comfortably covers a handful of peers
             # including a slow/unreachable one without ever hanging forever.
             timeout_sec=600,
+        ),
+        JobSpec(
+            name="sac.worktree-gc",
+            schedule="30 4 * * *",  # daily 04:30 (cron form; timer cadence below)
+            command="sac worktree gc --apply --all",
+            description=(
+                "Daily git-worktree GC: removes only worktrees PROVEN safe "
+                "(clean AND merged AND older than 24h AND not in use — never "
+                "--force), prunes admin refs whose directory is already gone, "
+                "and upserts an idempotent scitex-todo card for any repo still "
+                "over its worktree cap (resolved when it drops back under). "
+                "The permanent countermeasure to worktree sprawl."
+            ),
+            kind="timer",
+            # Sprawl accumulates over days, not minutes, and the age gate is
+            # 24h — so a daily pass is the natural cadence and a faster one
+            # could not remove anything a daily one would miss. 20min after
+            # boot keeps it clear of the login/auth settling window.
+            on_boot_sec="20min",
+            on_unit_active_sec="1d",
+            # A pass is a handful of local `git` calls per worktree plus one
+            # `gh pr list` per unmerged branch (the squash-merge leg). A repo
+            # deep in sprawl with a slow/rate-limited gh is the worst case;
+            # 900s covers the whole fleet's repos without ever hanging
+            # forever. Every gh failure already degrades to KEEP, so a
+            # timeout costs a skipped reap, never a wrong one.
+            timeout_sec=900,
         ),
     ]
 

--- a/src/scitex_agent_container/_maintenance/__init__.py
+++ b/src/scitex_agent_container/_maintenance/__init__.py
@@ -1,0 +1,61 @@
+"""Host-hygiene maintenance rails that run on a schedule, not on a whim.
+
+Today one concern lives here: **git worktree sprawl**
+(:mod:`._worktree_gc`), the standing liability behind the incident card
+``incident-worktree-sprawl-permanent-gc-20260710`` — one repo reached 105
+worktrees and helped trigger a host load-spike.
+
+The shape every rail in this package follows, learned from
+``_hostsync``:
+
+* **Three-state honest.** A check that could not run reports UNKNOWN and
+  the caller KEEPS. "I could not look" must never read as "I looked and
+  it was fine".
+* **Report by default, mutate only on request.** ``--dry-run`` is the
+  default surface; ``--apply`` is the deliberate act.
+* **The board is a side rail.** A card-delivery failure prints loudly and
+  never crashes the maintenance pass that feeds it.
+"""
+
+from ._worktree_gc import (
+    DEFAULT_CAP,
+    DEFAULT_MIN_AGE_HOURS,
+    GcOutcome,
+    RepoGcResult,
+    WorktreeInfo,
+    WorktreeVerdict,
+    exit_code_for,
+    gc_repo,
+    gc_repos,
+    gh_pr_merged,
+    list_worktrees,
+    running_cwds,
+)
+from ._worktree_gc_alarm import (
+    CARD_ID_PREFIX,
+    AlarmOutcome,
+    card_id_for,
+    route_gc_to_cards,
+)
+from ._worktree_gc_repos import discover_repos, spec_workdirs
+
+__all__ = [
+    "CARD_ID_PREFIX",
+    "DEFAULT_CAP",
+    "DEFAULT_MIN_AGE_HOURS",
+    "AlarmOutcome",
+    "GcOutcome",
+    "RepoGcResult",
+    "WorktreeInfo",
+    "WorktreeVerdict",
+    "card_id_for",
+    "discover_repos",
+    "exit_code_for",
+    "gc_repo",
+    "gc_repos",
+    "gh_pr_merged",
+    "list_worktrees",
+    "route_gc_to_cards",
+    "running_cwds",
+    "spec_workdirs",
+]

--- a/src/scitex_agent_container/_maintenance/_worktree_gc.py
+++ b/src/scitex_agent_container/_maintenance/_worktree_gc.py
@@ -1,0 +1,185 @@
+"""Reap SAFE, STALE git worktrees — the permanent answer to sprawl.
+
+Agent-tool isolation worktrees auto-clean only when they were never
+edited. Anything an agent actually TOUCHED persists forever, and until
+now no periodic GC, no cap, and no alarm existed anywhere. One repo
+reached **105 worktrees** and helped trigger a host load-spike (card
+``incident-worktree-sprawl-permanent-gc-20260710``, operator-declared
+P1). Sprawl is not a tidiness problem; it is a standing liability.
+
+This module is the engine. It owns three decisions and delegates the
+rest:
+
+* **Report by default.** ``apply=False`` (what ``--dry-run`` gives, and
+  the default of this function) removes NOTHING: every worktree is judged
+  and reported, and the prune pass runs as ``prune --dry-run``. A GC whose
+  default is destructive gets run destructively by accident exactly once.
+* **Removal is ``git worktree remove`` WITHOUT ``--force``.** That is not
+  belt-and-braces, it is the backstop: git's own refusal to remove a
+  dirty worktree is a second, independent implementation of the clean leg
+  written by people better at this than we are. ``--force`` would disable
+  the only check we did not write ourselves. It is never passed, and a
+  test pins the absence.
+* **``git worktree prune`` is separate and unconditional-safe.** It only
+  drops administrative refs whose directory is ALREADY GONE, so it
+  destroys no files by construction and needs no predicate.
+
+The predicate itself lives in :mod:`._worktree_gc_predicate` (four legs,
+each three-state, KEEP on any doubt) and the observation in
+:mod:`._worktree_gc_probe`. ``pr_merged`` and ``cwd_scan`` are injectable
+seams so the whole thing is testable against real temp repos with no
+network and no ambient processes.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from ._worktree_gc_model import (
+    DEFAULT_CAP,
+    DEFAULT_MIN_AGE_HOURS,
+    KEEP_REMOVE_FAILED,
+    GcOutcome,
+    RepoGcResult,
+    WorktreeInfo,
+    WorktreeVerdict,
+    exit_code_for,
+)
+from ._worktree_gc_predicate import verdict_for
+from ._worktree_gc_probe import (
+    CwdScan,
+    PrLookup,
+    gh_pr_merged,
+    list_worktrees,
+    run_git,
+    running_cwds,
+)
+
+__all__ = [
+    "DEFAULT_CAP",
+    "DEFAULT_MIN_AGE_HOURS",
+    "GcOutcome",
+    "RepoGcResult",
+    "WorktreeInfo",
+    "WorktreeVerdict",
+    "exit_code_for",
+    "gc_repo",
+    "gc_repos",
+    "gh_pr_merged",
+    "list_worktrees",
+    "running_cwds",
+]
+
+
+def gc_repo(
+    repo: str | Path,
+    *,
+    apply: bool = False,
+    min_age_hours: float = DEFAULT_MIN_AGE_HOURS,
+    cap: int = DEFAULT_CAP,
+    now: float | None = None,
+    pr_merged: PrLookup = gh_pr_merged,
+    cwd_scan: CwdScan = running_cwds,
+) -> RepoGcResult:
+    """GC one repo's worktrees. Reports by default; mutates only on ``apply``.
+
+    The main worktree (the repo checkout itself) and bare repos are never
+    candidates — they are not sprawl, they are the repo.
+
+    An unreadable repo returns a result carrying ``error`` (UNKNOWN), never
+    an empty verdict list: "I could not read this repo" must not render as
+    "this repo has no worktrees".
+    """
+    now = time.time() if now is None else now
+    ok, infos, err = list_worktrees(repo)
+    if not ok:
+        return RepoGcResult(repo=str(repo), applied=apply, cap=cap, error=err)
+
+    cwds = cwd_scan()
+    verdicts: list[WorktreeVerdict] = []
+    for info in infos:
+        if info.is_main or info.is_bare:
+            continue  # the repo checkout itself is not a GC candidate
+        verdict = verdict_for(
+            repo,
+            info,
+            min_age_hours=min_age_hours,
+            now=now,
+            pr_merged=pr_merged,
+            cwds=cwds,
+        )
+        if verdict.removable and apply:
+            verdict = _remove(repo, verdict)
+        verdicts.append(verdict)
+
+    # Always safe: prune only drops admin refs whose directory is gone.
+    # On a dry run it reports instead of acting, so --dry-run stays a pure
+    # read across the WHOLE pass, not just the remove half.
+    #
+    # --verbose is not decoration: WITHOUT it `prune` (and `prune
+    # --dry-run`) print NOTHING AT ALL, so the pass would silently claim to
+    # have pruned — or to have planned to — with no evidence either way.
+    # That is the exact "green line nobody can check" shape this whole GC
+    # exists to kill, so the prune half reports by name like everything else.
+    #
+    # merge_stderr because git writes that verbose report to STDERR even on
+    # success (measured on git 2.43, not assumed): a stdout-only read comes
+    # back empty and the report silently disappears — which is how the first
+    # cut of this function "reported" a prune it could not evidence.
+    prune_args = ["worktree", "prune", "--verbose"] + ([] if apply else ["--dry-run"])
+    prune_ok, prune_out = run_git(repo, *prune_args, merge_stderr=True)
+    prune_detail = prune_out if prune_ok else f"prune failed: {prune_out}"
+
+    return RepoGcResult(
+        repo=str(repo),
+        applied=apply,
+        cap=cap,
+        verdicts=tuple(verdicts),
+        prune_detail=prune_detail,
+    )
+
+
+def _remove(repo: str | Path, verdict: WorktreeVerdict) -> WorktreeVerdict:
+    """``git worktree remove <path>`` — no ``--force``, ever.
+
+    A refusal is not an error to route around: it means git disagreed with
+    our clean leg, and git wins. The worktree stays, and the disagreement
+    is reported as a keep reason rather than swallowed.
+    """
+    removed_ok, detail = run_git(repo, "worktree", "remove", verdict.path)
+    return WorktreeVerdict(
+        path=verdict.path,
+        branch=verdict.branch,
+        head=verdict.head,
+        keep_reasons=() if removed_ok else (KEEP_REMOVE_FAILED,),
+        removed=removed_ok,
+        remove_error="" if removed_ok else detail,
+    )
+
+
+def gc_repos(
+    repos: list[str] | list[Path],
+    *,
+    apply: bool = False,
+    min_age_hours: float = DEFAULT_MIN_AGE_HOURS,
+    cap: int = DEFAULT_CAP,
+    now: float | None = None,
+    pr_merged: PrLookup = gh_pr_merged,
+    cwd_scan: CwdScan = running_cwds,
+) -> GcOutcome:
+    """Run :func:`gc_repo` over every repo; one bad repo never stops the rest."""
+    return GcOutcome(
+        results=tuple(
+            gc_repo(
+                repo,
+                apply=apply,
+                min_age_hours=min_age_hours,
+                cap=cap,
+                now=now,
+                pr_merged=pr_merged,
+                cwd_scan=cwd_scan,
+            )
+            for repo in repos
+        )
+    )

--- a/src/scitex_agent_container/_maintenance/_worktree_gc_alarm.py
+++ b/src/scitex_agent_container/_maintenance/_worktree_gc_alarm.py
@@ -1,0 +1,290 @@
+"""Route worktree-sprawl over-cap verdicts to a SEEN surface.
+
+A GC that quietly reaps what it can and says nothing about what it could
+NOT reap is how a repo reaches 105 worktrees while a green cron line
+scrolls past every night. The reaping is the easy half; the half that
+prevents the incident is SHOUTING about the worktrees the predicate
+refused to touch, because those are the ones that accumulate forever.
+
+So: after a pass, a repo still over its cap upserts an IDEMPOTENT
+scitex-todo card on the board's BLOCKING-YOU view (``status=blocked``,
+``blocker=operator-decision`` — the surface the operator already
+watches), and the card is RESOLVED the moment the repo drops back under
+so a fixed repo stops shouting. Card id is stable per repo
+(``worktree-sprawl-<repo-basename>``), so a nightly re-run updates in
+place instead of tiling the board with duplicates.
+
+Three-state honest, like every rail here:
+
+* **OVER CAP** → a card naming the repo, the count, and the kept-reasons
+  breakdown (``9 dirty, 6 unmerged, 2 in-use``). The breakdown IS the
+  card's value: "17 worktrees" is a number, "9 dirty" is an instruction.
+* **UNREADABLE** (not a git repo, git missing, unreadable path) → a card
+  too, labelled UNKNOWN. "I could not look" must never read as "I looked
+  and it was fine".
+* **UNDER CAP** → resolve the repo's card.
+
+Delivery is a SIDE RAIL. A board-write failure prints loudly to stderr
+and is recorded in :attr:`AlarmOutcome.failed`; it never crashes the GC
+that feeds it, and one unreachable board never suppresses the rest of the
+fleet's alarms. Mirrors ``_hostsync._alarm`` (the drift rail) deliberately
+— same conventions, same public ``scitex_todo`` writer, no shared import.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ._worktree_gc_model import RepoGcResult
+
+__all__ = ["AlarmOutcome", "CARD_ID_PREFIX", "card_id_for", "route_gc_to_cards"]
+
+#: Stable per-repo card id prefix, so a re-run updates in place instead of
+#: duplicating (idempotency is by id).
+CARD_ID_PREFIX = "worktree-sprawl-"
+
+#: The card's owner + author. A pseudo-agent, not a human: the card is a
+#: standing "this repo is over its worktree cap" fact that the operator
+#: resolves. Mirrors the host-sync drift rail's convention.
+_AGENT = "sac.worktree-gc"
+
+#: An over-cap card and an unreadable-repo card BOTH land on the board's
+#: BLOCKING-YOU view (``status=blocked`` AND ``blocker=operator-decision``)
+#: — the seen surface. The card TEXT distinguishes sprawl from unknown.
+_STATUS = "blocked"
+_BLOCKER = "operator-decision"
+
+
+def card_id_for(repo: str | Path) -> str:
+    """The stable card id for ``repo``'s sprawl alarm.
+
+    Keyed on the repo's BASENAME so the id stays readable on the board.
+    Two checkouts of the same repo under different parents collide by
+    design: the card is about "the repo called scitex-agent-container",
+    which is how the operator thinks about it, and the note carries the
+    full path either way.
+    """
+    name = Path(str(repo)).name or "repo"
+    return f"{CARD_ID_PREFIX}{name}"
+
+
+@dataclass(frozen=True)
+class AlarmOutcome:
+    """What the routing did this run — so the caller is never silent.
+
+    Every repo lands in exactly one bucket (``failed`` is orthogonal: a
+    repo whose card write raised is recorded there instead of its verdict
+    bucket).
+    """
+
+    exceeded: tuple[str, ...] = ()
+    unreadable: tuple[str, ...] = ()
+    cleared: tuple[str, ...] = ()
+    failed: tuple[str, ...] = ()
+
+    def summary_line(self) -> str:
+        """One human line naming what happened to the board this run."""
+        parts = [
+            f"{len(self.exceeded)} over-cap card(s)",
+            f"{len(self.unreadable)} unknown card(s)",
+            f"{len(self.cleared)} cleared",
+        ]
+        if self.failed:
+            parts.append(f"{len(self.failed)} DELIVERY-FAILED")
+        return "scitex-todo alarm: " + ", ".join(parts)
+
+
+def _now_iso(now: datetime | None) -> str:
+    return (now or datetime.now(timezone.utc)).isoformat()
+
+
+def _breakdown(result: RepoGcResult) -> str:
+    counts = result.keep_reason_breakdown
+    if not counts:
+        return "(no kept worktrees)"
+    return ", ".join(f"{n} {reason}" for reason, n in counts.items())
+
+
+def _over_cap_card(result: RepoGcResult) -> tuple[str, str]:
+    """Title + note for a repo STILL over its cap after the pass.
+
+    The note names the concrete breakdown and the exact next commands, so
+    the operator reading only the card knows what to do.
+    """
+    title = (
+        f"[worktree-gc] {Path(result.repo).name} OVER CAP — "
+        f"{result.count_after} worktrees (cap {result.cap})"
+    )
+    note = (
+        f"repo: {result.repo}\n"
+        f"worktrees: {result.count_after} (cap {result.cap})\n"
+        f"removed this pass: {len(result.removed)}\n"
+        f"kept: {len(result.kept)} — {_breakdown(result)}\n\n"
+        "The GC removed everything it could PROVE was safe (clean AND "
+        "merged AND older than the age gate AND not in use). The kept "
+        "worktrees each failed at least one of those legs — the breakdown "
+        "above says which. They will never be auto-removed; a human decides.\n\n"
+        "Inspect (read-only, removes nothing):\n"
+        f"    sac worktree gc --repo {result.repo}\n"
+        "Then, per worktree: land or drop the branch, or clean the tree.\n"
+        "Dirty worktrees hold work that exists NOWHERE else — commit or "
+        "push before removing anything by hand."
+    )
+    return title, note
+
+
+def _unknown_card(result: RepoGcResult) -> tuple[str, str]:
+    """Title + note for a repo we COULD NOT READ.
+
+    Deliberately worded UNKNOWN, never clean. An unreadable repo is not a
+    repo without sprawl — it is a repo whose sprawl we failed to observe.
+    """
+    title = f"[worktree-gc] {Path(result.repo).name} UNKNOWN — could not read repo"
+    note = (
+        f"repo: {result.repo}\n"
+        f"error: {result.error}\n\n"
+        "UNKNOWN is NOT clean — sac could not enumerate this repo's "
+        "worktrees, so its sprawl is unobserved, not absent. Nothing was "
+        "removed. Check the path still exists and is a git repo, then "
+        "re-run:\n"
+        f"    sac worktree gc --repo {result.repo}"
+    )
+    return title, note
+
+
+def _card_exists(store: str | None, card_id: str) -> bool:
+    """True when ``card_id`` is already on the board.
+
+    A MISSING store file (nothing carded yet) and a missing id BOTH mean
+    "no such card" — the first run against a fresh board raises
+    ``FileNotFoundError`` from the loader, later runs raise
+    ``TaskNotFoundError``; neither is an error here.
+    """
+    from scitex_todo import TaskNotFoundError, get_task
+
+    # stx-allow: fallback (reason: "does this card exist yet?" — a missing store file or missing id is a normal False, not an error; any other load failure propagates to the caller's per-repo guard which reports it loudly)
+    try:
+        get_task(store, card_id)
+        return True
+    except (TaskNotFoundError, FileNotFoundError):
+        return False
+
+
+def _upsert(
+    store: str | None,
+    card_id: str,
+    title: str,
+    note: str,
+    now: datetime | None,
+) -> None:
+    """Create the card, or update it in place — never duplicate.
+
+    Always (re)asserts ``status=blocked`` / ``blocker=operator-decision``,
+    which also REOPENS a card a previous under-cap run had resolved: a
+    repo that sprawls, gets cleaned (card resolved), then sprawls again
+    must alarm again.
+    """
+    from scitex_todo import add_task, update_task
+
+    if _card_exists(store, card_id):
+        update_task(
+            store,
+            card_id,
+            title=title,
+            note=note,
+            status=_STATUS,
+            blocker=_BLOCKER,
+            last_activity=_now_iso(now),
+        )
+    else:
+        add_task(
+            store,
+            id=card_id,
+            title=title,
+            status=_STATUS,
+            blocker=_BLOCKER,
+            note=note,
+            scope=f"agent:{_AGENT}",
+            assignee=_AGENT,
+            created_by=_AGENT,
+        )
+
+
+def _clear(store: str | None, card_id: str) -> bool:
+    """Resolve the repo's card if present + still open. Returns did-clear.
+
+    Idempotent: no card, or an already-resolved card, is a quiet no-op — a
+    healthy repo that was never over cap must not create then resolve a
+    phantom card.
+    """
+    from scitex_todo import get_task, resolve_task
+
+    if not _card_exists(store, card_id):
+        return False
+    existing = get_task(store, card_id)
+    if existing.get("status") == "done":
+        return False
+    resolve_task(store, card_id, actor=_AGENT)
+    return True
+
+
+def route_gc_to_cards(
+    results: list[RepoGcResult],
+    *,
+    store: str | None = None,
+    now: datetime | None = None,
+    err_stream: Any = None,
+) -> AlarmOutcome:
+    """Upsert / resolve one scitex-todo card per repo from ``results``.
+
+    Never raises: a per-repo card-write failure is printed loudly to
+    ``err_stream`` and the repo is recorded in :attr:`AlarmOutcome.failed`,
+    so a broken board never takes down the GC pass that feeds it.
+
+    Parameters
+    ----------
+    store
+        scitex-todo store path. ``None`` = the resolved canonical store
+        (``~/.scitex/todo/tasks.yaml``). Tests pass a real temp path — no
+        mocks.
+    now, err_stream
+        Test seams: a fixed clock and a replacement stderr.
+    """
+    stream = err_stream if err_stream is not None else sys.stderr
+    exceeded: list[str] = []
+    unreadable: list[str] = []
+    cleared: list[str] = []
+    failed: list[str] = []
+
+    for result in results:
+        repo = result.repo
+        card_id = card_id_for(repo)
+        # stx-allow: fallback (reason: card delivery is a SIDE rail — one repo's board-write failure must never crash the GC pass that feeds it; it is reported loudly on stderr and recorded in AlarmOutcome.failed)
+        try:
+            if result.unreadable:
+                _upsert(store, card_id, *_unknown_card(result), now=now)
+                unreadable.append(repo)
+            elif result.exceeds_cap:
+                _upsert(store, card_id, *_over_cap_card(result), now=now)
+                exceeded.append(repo)
+            elif _clear(store, card_id):
+                cleared.append(repo)
+        except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+            failed.append(repo)
+            print(
+                f"[worktree-gc-alarm] {repo}: scitex-todo card delivery FAILED "
+                f"— {exc} (the GC pass itself is unaffected; its exit code "
+                "still reflects the cap verdict)",
+                file=stream,
+            )
+
+    return AlarmOutcome(
+        exceeded=tuple(exceeded),
+        unreadable=tuple(unreadable),
+        cleared=tuple(cleared),
+        failed=tuple(failed),
+    )

--- a/src/scitex_agent_container/_maintenance/_worktree_gc_model.py
+++ b/src/scitex_agent_container/_maintenance/_worktree_gc_model.py
@@ -1,0 +1,217 @@
+"""Data + vocabulary for the worktree GC. No subprocess, no I/O.
+
+The types every other ``_worktree_gc*`` module speaks in, kept apart from
+the code that observes the world (:mod:`._worktree_gc_probe`), the code
+that decides (:mod:`._worktree_gc_predicate`), and the engine that
+orchestrates them (:mod:`._worktree_gc`).
+
+The keep-reason strings below are API, not debug text: they land in
+``sac worktree gc --json``, in the console report, and in the cap card's
+breakdown that tells the operator WHY 17 worktrees survived.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "DEFAULT_CAP",
+    "DEFAULT_MIN_AGE_HOURS",
+    "KEEP_AGE_UNKNOWN",
+    "KEEP_DIRTY",
+    "KEEP_IN_USE",
+    "KEEP_IN_USE_UNKNOWN",
+    "KEEP_LOCKED",
+    "KEEP_MERGE_UNKNOWN",
+    "KEEP_MISSING",
+    "KEEP_REMOVE_FAILED",
+    "KEEP_TOO_YOUNG",
+    "KEEP_UNMERGED",
+    "MERGE_BASES",
+    "GcOutcome",
+    "RepoGcResult",
+    "WorktreeInfo",
+    "WorktreeVerdict",
+    "exit_code_for",
+]
+
+#: A worktree younger than this is presumed IN FLIGHT and never touched.
+#: 24h mirrors the SessionStart auto-reaper's threshold and the operator's
+#: original card wording.
+DEFAULT_MIN_AGE_HOURS = 24.0
+
+#: Linked worktrees above this count make a repo shout on the board. It is
+#: NOT a limit the GC enforces by deleting harder — the predicate is never
+#: relaxed to hit a number. It is the threshold at which the worktrees the
+#: predicate refused to touch become the operator's problem to look at.
+DEFAULT_CAP = 20
+
+#: Bases a branch may be merged into, checked in order. A base that does
+#: not exist in the repo is skipped, not treated as a failure.
+MERGE_BASES = ("develop", "main")
+
+KEEP_DIRTY = "dirty"
+KEEP_UNMERGED = "unmerged"
+KEEP_MERGE_UNKNOWN = "merge-unknown"
+KEEP_TOO_YOUNG = "too-young"
+KEEP_AGE_UNKNOWN = "age-unknown"
+KEEP_IN_USE = "in-use"
+KEEP_IN_USE_UNKNOWN = "in-use-unknown"
+KEEP_LOCKED = "locked"
+KEEP_MISSING = "missing"
+KEEP_REMOVE_FAILED = "remove-failed"
+
+
+@dataclass(frozen=True)
+class WorktreeInfo:
+    """One entry from ``git worktree list --porcelain``, as reported."""
+
+    path: str
+    head: str = ""
+    branch: str = ""  # short name ("feat/x"); empty when detached
+    is_main: bool = False
+    is_bare: bool = False
+    is_locked: bool = False
+    is_prunable: bool = False
+
+
+@dataclass(frozen=True)
+class WorktreeVerdict:
+    """What we decided about ONE worktree, and why — never just a bool."""
+
+    path: str
+    branch: str = ""
+    head: str = ""
+    keep_reasons: tuple[str, ...] = ()
+    removed: bool = False
+    remove_error: str = ""
+
+    @property
+    def removable(self) -> bool:
+        """True iff EVERY leg passed. One reason is enough to keep."""
+        return not self.keep_reasons
+
+    def to_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "branch": self.branch,
+            "head": self.head[:12],
+            "removable": self.removable,
+            "keep_reasons": list(self.keep_reasons),
+            "removed": self.removed,
+            "remove_error": self.remove_error,
+        }
+
+
+@dataclass(frozen=True)
+class RepoGcResult:
+    """One repo's pass: every verdict, what was removed, what still hurts."""
+
+    repo: str
+    applied: bool = False
+    cap: int = DEFAULT_CAP
+    verdicts: tuple[WorktreeVerdict, ...] = ()
+    prune_detail: str = ""
+    error: str = ""
+
+    @property
+    def unreadable(self) -> bool:
+        """True when the repo could not be read at all — UNKNOWN, not clean."""
+        return bool(self.error)
+
+    @property
+    def removed(self) -> tuple[WorktreeVerdict, ...]:
+        return tuple(v for v in self.verdicts if v.removed)
+
+    @property
+    def kept(self) -> tuple[WorktreeVerdict, ...]:
+        return tuple(v for v in self.verdicts if not v.removed)
+
+    @property
+    def count_before(self) -> int:
+        """LINKED worktrees before the pass (the main checkout is excluded)."""
+        return len(self.verdicts)
+
+    @property
+    def count_after(self) -> int:
+        return self.count_before - len(self.removed)
+
+    @property
+    def exceeds_cap(self) -> bool:
+        return self.count_after > self.cap
+
+    @property
+    def keep_reason_breakdown(self) -> dict[str, int]:
+        """``{"dirty": 9, "unmerged": 6}`` — WHY the survivors survived.
+
+        The cap card needs this: "17 kept" tells the operator nothing,
+        "9 dirty, 6 unmerged, 2 in-use" tells them what to do.
+        """
+        counts: dict[str, int] = {}
+        for verdict in self.kept:
+            for reason in verdict.keep_reasons:
+                counts[reason] = counts.get(reason, 0) + 1
+        return dict(sorted(counts.items()))
+
+    def to_dict(self) -> dict:
+        return {
+            "repo": self.repo,
+            "applied": self.applied,
+            "cap": self.cap,
+            "error": self.error,
+            "count_before": self.count_before,
+            "count_after": self.count_after,
+            "exceeds_cap": self.exceeds_cap,
+            "removed": [v.path for v in self.removed],
+            "keep_reasons": self.keep_reason_breakdown,
+            "prune": self.prune_detail,
+            "worktrees": [v.to_dict() for v in self.verdicts],
+        }
+
+
+@dataclass(frozen=True)
+class GcOutcome:
+    """The whole pass across every repo — so ``--all`` is never silent."""
+
+    results: tuple[RepoGcResult, ...] = ()
+
+    @property
+    def removed_count(self) -> int:
+        return sum(len(r.removed) for r in self.results)
+
+    @property
+    def kept_count(self) -> int:
+        return sum(len(r.kept) for r in self.results)
+
+    @property
+    def over_cap(self) -> tuple[RepoGcResult, ...]:
+        return tuple(r for r in self.results if r.exceeds_cap)
+
+    @property
+    def unreadable(self) -> tuple[RepoGcResult, ...]:
+        return tuple(r for r in self.results if r.unreadable)
+
+    def summary_line(self) -> str:
+        parts = [
+            f"{len(self.results)} repo(s)",
+            f"{self.removed_count} removed",
+            f"{self.kept_count} kept",
+        ]
+        if self.over_cap:
+            parts.append(f"{len(self.over_cap)} OVER CAP")
+        if self.unreadable:
+            parts.append(f"{len(self.unreadable)} UNREADABLE")
+        return ", ".join(parts)
+
+
+def exit_code_for(outcome: GcOutcome) -> int:
+    """Worst verdict wins — ``--all`` never hides one bad repo behind good ones.
+
+    0 = every repo read, none over cap. 1 = at least one repo is still
+    over its cap after the pass (a real, actionable problem). 2 = at least
+    one repo could not be READ, which OUTRANKS 1: an unknown is worse than
+    a known-bad, because it is a known-bad you cannot see.
+    """
+    if outcome.unreadable:
+        return 2
+    return 1 if outcome.over_cap else 0

--- a/src/scitex_agent_container/_maintenance/_worktree_gc_predicate.py
+++ b/src/scitex_agent_container/_maintenance/_worktree_gc_predicate.py
@@ -1,0 +1,198 @@
+"""THE SAFETY PREDICATE — the whole point of the worktree GC.
+
+A worktree is removable **iff ALL FOUR** legs pass:
+
+1. **CLEAN** — ``git status --porcelain`` is empty. Untracked files count
+   as DIRTY: an untracked file is work saved nowhere else, which makes it
+   the most expensive thing in the tree, not the cheapest.
+2. **MERGED** — the ancestor check (``rev-list --count <base>..<head>``
+   is 0 against ``develop`` or ``main``) OR a MERGED PR exists for the
+   branch. BOTH styles are required: a squash-merged branch is not an
+   ancestor of its base, so the ancestor check alone calls every
+   squash-merged branch "unmerged" forever and a squash-merging repo
+   would never be GC'd at all.
+3. **OLD** — the HEAD commit is older than ``min_age_hours``. A young
+   worktree is presumed in flight.
+4. **IDLE** — no running process has its cwd inside it.
+
+Every leg returns ``True`` / ``False`` / ``None``, and ``None`` (could
+not look) is treated exactly like ``False`` (looked, it failed): both
+KEEP. That is the one rule this module exists to enforce. A boolean leg
+would have to fold "I could not read the tree" into either "clean" or
+"dirty", and whichever pole it picked would eventually be wrong in the
+direction that destroys work.
+
+The asymmetry is permanent and deliberate: a false KEEP leaves a stale
+directory on disk — annoying, and the cap alarm shouts about it. A false
+REMOVE destroys work that exists nowhere else. We pick annoying.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ._worktree_gc_model import (
+    KEEP_AGE_UNKNOWN,
+    KEEP_DIRTY,
+    KEEP_IN_USE,
+    KEEP_IN_USE_UNKNOWN,
+    KEEP_LOCKED,
+    KEEP_MERGE_UNKNOWN,
+    KEEP_MISSING,
+    KEEP_TOO_YOUNG,
+    KEEP_UNMERGED,
+    MERGE_BASES,
+    WorktreeInfo,
+    WorktreeVerdict,
+)
+from ._worktree_gc_probe import PrLookup, run_git
+
+__all__ = ["is_clean", "is_idle", "is_merged", "is_old_enough", "verdict_for"]
+
+
+def is_clean(path: str) -> tuple[bool | None, str]:
+    """Leg 1 — clean tree. Untracked files count as DIRTY.
+
+    An unreadable tree returns ``None`` with the ``dirty`` reason: we
+    could not prove it clean, so it is kept. ``--porcelain`` lists
+    untracked files by default (no ``-uno``), and that default is the
+    behaviour we want, not an accident.
+    """
+    ok, out = run_git(path, "status", "--porcelain")
+    if not ok:
+        return None, KEEP_DIRTY
+    return (True, "") if not out.strip() else (False, KEEP_DIRTY)
+
+
+def is_merged(
+    repo: str | Path, info: WorktreeInfo, pr_merged: PrLookup
+) -> tuple[bool | None, str]:
+    """Leg 2 — merged by ANCESTOR or by MERGED PR (squash-safe).
+
+    Order matters. The ancestor check is local, free, and cannot lie, so
+    it runs first against each base that exists. Only if no base swallows
+    the branch do we ask GitHub, because that is exactly the shape a
+    squash-merge leaves behind.
+
+    A definite UNMERGED requires TWO sources to agree: not an ancestor of
+    a base we actually read, AND GitHub answering that no merged PR
+    exists. One source alone is not corroboration — if we could not read
+    a single base ref, a bare "gh says no PR" leaves us with an UNKNOWN,
+    not a verdict.
+    """
+    ref = info.branch or info.head
+    if not ref:
+        return None, KEEP_MERGE_UNKNOWN
+    evaluated = False
+    for base in MERGE_BASES:
+        base_ok, _ = run_git(repo, "rev-parse", "--verify", "--quiet", base)
+        if not base_ok:
+            continue
+        count_ok, count_out = run_git(repo, "rev-list", "--count", f"{base}..{ref}")
+        if not count_ok:
+            continue
+        evaluated = True
+        if count_out.strip() == "0":
+            return True, ""
+    # Not an ancestor of any base we could read. A squash-merged branch
+    # looks EXACTLY like this, so ask GitHub before concluding anything.
+    # stx-allow: fallback (reason: an injected or real PR seam raising must read as UNKNOWN -> KEEP, never crash the pass)
+    try:
+        pr = pr_merged(Path(str(repo)), info.branch)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        pr = None
+    if pr is True:
+        return True, ""
+    if pr is False and evaluated:
+        return False, KEEP_UNMERGED
+    return None, KEEP_MERGE_UNKNOWN
+
+
+def is_old_enough(
+    repo: str | Path, info: WorktreeInfo, min_age_hours: float, now: float
+) -> tuple[bool | None, str]:
+    """Leg 3 — the HEAD commit is older than ``min_age_hours``.
+
+    Commit time, not directory mtime: an mtime moves when anything writes
+    into the tree (a build, a linter, a stray editor swap file), so it
+    answers "was this touched?" rather than "is this in flight?". A branch
+    whose last commit is a day old is a branch nobody is committing to.
+    """
+    if not info.head:
+        return None, KEEP_AGE_UNKNOWN
+    ok, out = run_git(repo, "log", "-1", "--format=%ct", info.head)
+    if not ok or not out.strip():
+        return None, KEEP_AGE_UNKNOWN
+    # stx-allow: fallback (reason: an unparseable commit timestamp is an UNKNOWN age -> KEEP, never a crash)
+    try:
+        committed = float(out.strip().splitlines()[0])
+    except ValueError:
+        return None, KEEP_AGE_UNKNOWN
+    age_hours = (now - committed) / 3600.0
+    return (True, "") if age_hours > min_age_hours else (False, KEEP_TOO_YOUNG)
+
+
+def is_idle(path: str, cwds: set[Path] | None) -> tuple[bool | None, str]:
+    """Leg 4 — no running process has its cwd inside the worktree.
+
+    ``cwds is None`` means the signal was UNAVAILABLE (see
+    :func:`._worktree_gc_probe.running_cwds`) and returns UNKNOWN -> KEEP.
+    It never reads as "nothing is running": that collapse is what would
+    let the GC delete the tree an agent is working in right now.
+    """
+    if cwds is None:
+        return None, KEEP_IN_USE_UNKNOWN
+    # stx-allow: fallback (reason: an unresolvable worktree path is an UNKNOWN, and unknown means KEEP)
+    try:
+        resolved = Path(path).resolve()
+    except (OSError, RuntimeError):
+        return None, KEEP_IN_USE_UNKNOWN
+    for cwd in cwds:
+        if cwd == resolved or resolved in cwd.parents:
+            return False, KEEP_IN_USE
+    return True, ""
+
+
+def verdict_for(
+    repo: str | Path,
+    info: WorktreeInfo,
+    *,
+    min_age_hours: float,
+    now: float,
+    pr_merged: PrLookup,
+    cwds: set[Path] | None,
+) -> WorktreeVerdict:
+    """Run all four legs and collect EVERY keep reason, not just the first.
+
+    Reporting every reason is what makes the cap card actionable: "17
+    kept: 9 dirty, 6 unmerged, 2 in-use" tells the operator what to do,
+    where "17 kept" tells them nothing. So no leg short-circuits.
+    """
+    reasons: list[str] = []
+    if info.is_locked:
+        reasons.append(KEEP_LOCKED)
+    if info.is_prunable or not Path(info.path).is_dir():
+        # The directory is already gone: `worktree remove` would error and
+        # there is nothing to destroy. `worktree prune` is the correct —
+        # and unconditionally safe — tool for the leftover admin ref.
+        return WorktreeVerdict(
+            path=info.path,
+            branch=info.branch,
+            head=info.head,
+            keep_reasons=tuple(reasons + [KEEP_MISSING]),
+        )
+    legs = (
+        is_clean(info.path),
+        is_merged(repo, info, pr_merged),
+        is_old_enough(repo, info, min_age_hours, now),
+        is_idle(info.path, cwds),
+    )
+    for ok, reason in legs:
+        if ok is not True and reason:
+            reasons.append(reason)
+    return WorktreeVerdict(
+        path=info.path,
+        branch=info.branch,
+        head=info.head,
+        keep_reasons=tuple(reasons),
+    )

--- a/src/scitex_agent_container/_maintenance/_worktree_gc_probe.py
+++ b/src/scitex_agent_container/_maintenance/_worktree_gc_probe.py
@@ -1,0 +1,224 @@
+"""OBSERVATION for the worktree GC — everything that touches the world.
+
+Isolated from the decision logic (:mod:`._worktree_gc_predicate`) on
+purpose: every function here can fail for reasons that have nothing to do
+with the worktree (git missing, gh unauthenticated, ``/proc`` unreadable),
+and each one converts that failure into an honest UNKNOWN rather than a
+convenient boolean. The predicate then only has to know how to keep on an
+unknown — it never has to guess whether an answer is real.
+
+The two seams the GC injects in tests live here as the DEFAULTS:
+:func:`gh_pr_merged` (the merged-PR lookup — no network in tests) and
+:func:`running_cwds` (the ``/proc`` scan — no ambient processes in tests).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+from ._worktree_gc_model import WorktreeInfo
+
+__all__ = [
+    "CwdScan",
+    "PrLookup",
+    "gh_pr_merged",
+    "list_worktrees",
+    "run_git",
+    "running_cwds",
+]
+
+#: (repo, branch) -> True merged / False not merged / None unknown.
+PrLookup = Callable[[Path, str], "bool | None"]
+#: () -> set of cwds of running processes, or None when unobservable.
+CwdScan = Callable[[], "set[Path] | None"]
+
+
+def run_git(
+    cwd: str | Path, *args: str, timeout: int = 60, merge_stderr: bool = False
+) -> tuple[bool, str]:
+    """``git -C <cwd> <args>`` -> (ok, stdout-or-stderr). Never raises.
+
+    Env drift (no git binary, an unreadable cwd, a hung git) degrades to
+    ``(False, "<reason>")`` so every caller can route it to an UNKNOWN
+    verdict instead of an exception — an unreadable repo must be a KEEP,
+    not a crash in a scheduled pass.
+
+    ``merge_stderr`` folds stderr into the SUCCESS output. Needed because
+    some git subcommands report on stderr even when they succeed:
+    ``worktree prune --verbose`` writes "Removing worktrees/x: ..." there,
+    so a stdout-only read silently returns "" and the pass claims a prune
+    it cannot evidence. (Measured, not assumed — git 2.43.)
+    """
+    # stx-allow: fallback (reason: a missing/hung git must degrade to an UNKNOWN leg -> KEEP, never a traceback out of a scheduled maintenance pass)
+    try:
+        res = subprocess.run(
+            ["git", "-C", str(cwd), *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError) as exc:
+        return False, f"git invocation failed ({type(exc).__name__}): {exc}"
+    if res.returncode == 0:
+        if merge_stderr:
+            return True, "\n".join(
+                part for part in (res.stdout.strip(), res.stderr.strip()) if part
+            )
+        return True, res.stdout.strip()
+    return False, (res.stderr or res.stdout).strip()
+
+
+def list_worktrees(repo: str | Path) -> tuple[bool, list[WorktreeInfo], str]:
+    """Enumerate ``repo``'s worktrees -> (ok, infos, error).
+
+    Reads ``git worktree list --porcelain``, which is authoritative: it
+    reports every worktree registered to the repo wherever it lives on
+    disk, so the GC never has to guess at directory layouts
+    (``.worktrees/`` vs ``.claude/worktrees/`` vs wherever an agent put
+    one). Directory-scanning would miss exactly the worktrees nobody
+    expected — which are the ones that sprawl.
+
+    The FIRST record is git's main worktree — the repo checkout itself.
+    It is flagged :attr:`WorktreeInfo.is_main` and is never a GC
+    candidate. ``ok=False`` means the path is not a readable git repo;
+    the caller reports UNKNOWN rather than assuming "no worktrees".
+    """
+    ok, out = run_git(repo, "worktree", "list", "--porcelain")
+    if not ok:
+        return False, [], out
+    infos: list[WorktreeInfo] = []
+    fields: dict = {}
+
+    def _flush() -> None:
+        if not fields.get("path"):
+            return
+        infos.append(
+            WorktreeInfo(
+                path=fields["path"],
+                head=fields.get("head", ""),
+                branch=fields.get("branch", ""),
+                is_main=not infos,  # the first record is the main worktree
+                is_bare=fields.get("bare", False),
+                is_locked=fields.get("locked", False),
+                is_prunable=fields.get("prunable", False),
+            )
+        )
+        fields.clear()
+
+    for raw in out.splitlines():
+        line = raw.rstrip()
+        if not line:
+            _flush()
+            continue
+        key, _, value = line.partition(" ")
+        if key == "worktree":
+            _flush()
+            fields["path"] = value
+        elif key == "HEAD":
+            fields["head"] = value
+        elif key == "branch":
+            fields["branch"] = value.replace("refs/heads/", "", 1)
+        elif key in ("bare", "detached", "locked", "prunable"):
+            fields[key] = True
+    _flush()
+    return True, infos, ""
+
+
+def running_cwds() -> set[Path] | None:
+    """Cwds of every readable running process, or ``None`` if unknowable.
+
+    BEST-EFFORT, and honestly so. This reads ``/proc/<pid>/cwd``, which
+    means it can UNDER-report:
+
+    * a process whose cwd we cannot read (another user's, or a race with
+      its exit) is simply absent from the set;
+    * only this PID namespace is visible — a container that bind-mounts
+      the worktree and chdirs into it from its OWN namespace is invisible;
+    * a process holding an open FILE in the worktree without chdir'ing
+      there is invisible too.
+
+    Because it can under-report, it is ONE leg of four rather than the
+    whole predicate. A worktree that passes the other three and merely
+    looks idle is by construction clean, merged, and a day old — removing
+    it costs a re-checkout, not work.
+
+    ``None`` (no ``/proc``, or nothing readable at all) means the signal
+    is UNAVAILABLE, and every caller turns that into a KEEP. It never
+    silently reads as "nothing is running".
+    """
+    proc = Path("/proc")
+    if not proc.is_dir():
+        return None
+    # stx-allow: fallback (reason: /proc iteration racing process exit must degrade to an honest None, never crash a scheduled pass)
+    try:
+        entries = list(proc.iterdir())
+    except OSError:
+        return None
+    found: set[Path] = set()
+    readable = False
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        try:
+            target = (entry / "cwd").resolve()
+        except (OSError, RuntimeError):
+            # Unreadable (not ours) or vanished mid-scan. Skip it — a scan
+            # that reads SOMETHING is still a usable signal.
+            continue
+        readable = True
+        found.add(target)
+    return found if readable else None
+
+
+def gh_pr_merged(repo: Path, branch: str) -> bool | None:
+    """Does ``branch`` have a MERGED PR? True / False / None (unknown).
+
+    The squash-merge half of the merged leg. A squash-merged branch is not
+    an ancestor of its base, so ``rev-list`` calls it unmerged forever;
+    GitHub still knows the truth, and this asks it. Without this, a repo
+    that squash-merges would never have a single worktree GC'd.
+
+    Returns ``None`` — never ``False`` — on ANY doubt: gh missing, not
+    authenticated, offline, not a GitHub remote, rate-limited, or any
+    other non-zero exit. That distinction is the point: ``False`` means
+    "GitHub answered: no merged PR exists" and lets the GC conclude
+    UNMERGED (paired with the ancestor check); ``None`` means "nobody
+    answered", which keeps the worktree.
+    """
+    if not branch:
+        return None  # detached HEAD — there is no branch to ask about
+    # stx-allow: fallback (reason: gh absent/unauthenticated/offline must read as UNKNOWN -> KEEP; it must never crash the GC nor masquerade as "no merged PR")
+    try:
+        res = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--state",
+                "merged",
+                "--json",
+                "number",
+                "--limit",
+                "1",
+            ],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return None
+    if res.returncode != 0:
+        return None
+    try:
+        payload = json.loads(res.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, list):
+        return None
+    return bool(payload)

--- a/src/scitex_agent_container/_maintenance/_worktree_gc_repos.py
+++ b/src/scitex_agent_container/_maintenance/_worktree_gc_repos.py
@@ -1,0 +1,149 @@
+"""Which repos does ``sac worktree gc --all`` sweep? The fleet's own specs.
+
+sac already knows every repo it cares about, and it has known all along:
+each agent's ``spec.yaml`` carries a ``spec.workdir``, and for the
+maintainer agents that is literally the repo they work in
+(``/home/<user>/proj/scitex-todo``, ...). Those workdirs ARE the repos
+that grow worktrees, because they are the repos agents run tools in. So
+``--all`` reads the spec tree rather than inventing a second registry
+that would immediately drift from it.
+
+Two filters make that source clean rather than merely convenient:
+
+* **Must exist locally.** Specs describe agents on other hosts too
+  (Spartan paths, in-container paths like ``/workdir``). A workdir that
+  is not a directory HERE is silently skipped — this GC only ever touches
+  the machine it runs on.
+* **Must be a git repo TOPLEVEL.** ``git rev-parse --show-toplevel`` must
+  succeed AND equal the workdir itself. A workdir that merely sits inside
+  some repo (or is the default per-agent runtime workspace, which is not
+  a repo at all) is not swept: sweeping the enclosing repo because an
+  agent happened to chdir into a subdirectory of it would silently widen
+  the blast radius past what the spec author declared.
+
+The result is de-duplicated (many specs, one repo) and sorted, so a pass
+is deterministic and reads the same twice.
+
+Deliberately NOT discovered: repos with no agent spec pointing at them.
+If a repo grows worktrees and no agent declares it, ``--all`` will not
+see it — pass ``--repo <path>`` explicitly. That gap is honest and
+narrow: worktree sprawl comes from agent tools, and agent tools run in
+agent workdirs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ._worktree_gc_probe import run_git
+
+__all__ = ["discover_repos", "spec_workdirs"]
+
+
+def _spec_roots() -> list[Path]:
+    """The agent-spec trees to read, project-scope first then user-scope.
+
+    Mirrors ``cli_pkg._helpers._agent_list_discover._discover_defined_agents``
+    — the same two roots the rest of sac treats as the canonical "agents
+    defined on disk" surface.
+    """
+    roots: list[Path] = []
+    # stx-allow: fallback (reason: project-scope is optional; absent -> skip, exactly as the agent-list discovery does)
+    try:
+        from scitex_config._ecosystem import local_state as _ls
+
+        project = _ls.find_project_scope("agent-container")
+        if project is not None:
+            roots.append(project / "agents")
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        pass
+    roots.append(Path.home() / ".scitex" / "agent-container" / "agents")
+    return roots
+
+
+def spec_workdirs(roots: list[Path] | None = None) -> list[str]:
+    """Every ``spec.workdir`` declared by an agent on disk, in spec order.
+
+    A tolerant raw-YAML read, NOT the full config loader: this must not
+    fail because one unrelated spec is malformed, and it needs exactly one
+    string. Unreadable / unparseable / workdir-less specs are skipped
+    silently — a broken spec is the agent-list's problem to surface, not
+    the GC's to crash on.
+
+    ``roots`` is the test seam (real temp spec trees; no mocks).
+    """
+    out: list[str] = []
+    for root in roots if roots is not None else _spec_roots():
+        if not root.is_dir():
+            continue
+        # stx-allow: fallback (reason: an unreadable spec root must not crash a scheduled GC pass; skip it)
+        try:
+            children = sorted(root.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            spec = child / "spec.yaml"
+            if not spec.is_file():
+                continue
+            workdir = _workdir_of(spec)
+            if workdir:
+                out.append(workdir)
+    return out
+
+
+def _workdir_of(spec_path: Path) -> str:
+    """``spec.workdir`` from one spec.yaml, or "" — never raises."""
+    # stx-allow: fallback (reason: one malformed spec must not break discovery of the other 99; skip it silently)
+    try:
+        import yaml
+
+        blob = yaml.safe_load(spec_path.read_text())
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return ""
+    if not isinstance(blob, dict):
+        return ""
+    spec = blob.get("spec")
+    if not isinstance(spec, dict):
+        return ""
+    workdir = spec.get("workdir")
+    return workdir.strip() if isinstance(workdir, str) else ""
+
+
+def _is_repo_toplevel(path: Path) -> bool:
+    """True iff ``path`` is itself the toplevel of a git repo.
+
+    Not "is inside a repo": a workdir nested in a repo must NOT drag the
+    enclosing repo into the sweep. Compares resolved paths so a symlinked
+    workdir (common on this fleet) still matches its own toplevel.
+    """
+    ok, out = run_git(path, "rev-parse", "--show-toplevel")
+    if not ok or not out.strip():
+        return False
+    # stx-allow: fallback (reason: an unresolvable path is simply not a sweepable repo)
+    try:
+        return Path(out.strip()).resolve() == path.resolve()
+    except (OSError, RuntimeError):
+        return False
+
+
+def discover_repos(roots: list[Path] | None = None) -> list[str]:
+    """Local git-repo toplevels declared as some agent's ``spec.workdir``.
+
+    De-duplicated (many agents can share a repo) and sorted, so ``--all``
+    is deterministic. Returns ``[]`` when no spec declares a local repo —
+    the CLI turns that into a loud "nothing to sweep, name a --repo",
+    never a silent success.
+    """
+    seen: set[str] = set()
+    for raw in spec_workdirs(roots):
+        # stx-allow: fallback (reason: a malformed workdir string is not a sweepable repo; skip it)
+        try:
+            path = Path(raw).expanduser()
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if not path.is_dir():
+            continue  # another host's path, or an in-container path
+        if not _is_repo_toplevel(path):
+            continue  # not a repo, or only nested inside one
+        seen.add(str(path))
+    return sorted(seen)

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -71,6 +71,7 @@ COMMAND_CATEGORIES = [
     ),
     ("Registry & Events", ["db", "registry", "event"]),
     ("Build & Install", ["image", "installation"]),
+    ("Host hygiene", ["worktree"]),
     ("Diagnostics", ["doctor", "ports", "provenance", "ci"]),
     ("Remote testing", ["pytest"]),
     ("Introspection", ["whoami", "mcp", "list-python-apis", "skills", "versions"]),
@@ -96,6 +97,12 @@ class _MainGroup(LazyGroup):
         "event": f"{_PKG}.event_group:event_group",
         "image": f"{_PKG}.image_group:image_group",
         "skills": f"{_PKG}.skills_group:skills_group",
+        # Git-worktree hygiene (repo-scoped, not agent-scoped): report +
+        # reap PROVABLY-safe stale worktrees, alarm on a repo still over
+        # its cap. The permanent countermeasure to worktree sprawl
+        # (incident-worktree-sprawl-permanent-gc-20260710 — one repo hit
+        # 105 worktrees and helped trigger a host load-spike).
+        "worktree": f"{_PKG}.worktree_group:worktree_group",
         # `accounts` is a top-level noun — the credential store is fleet-wide,
         # not agent-scoped. Reuses the underlying `account` click group;
         # `accounts` is just the plural surface name.
@@ -307,6 +314,7 @@ class _MainGroup(LazyGroup):
         "listen": "Host HTTP/JSON control plane: start/stop/restart/status.",
         "ports": "List the ports sac/scitex uses, with live status.",
         "pytest": "Run pytest on remote pools (Spartan SLURM, ...).",
+        "worktree": "Git-worktree hygiene: report and reap safe, stale worktrees.",
         "install-shell-completion": "Wire up `<TAB>` completion in the user's shell rc.",
         "print-shell-completion": "Print the shell-completion eval line (no install).",
     }

--- a/src/scitex_agent_container/cli_pkg/_worktree_gc.py
+++ b/src/scitex_agent_container/cli_pkg/_worktree_gc.py
@@ -1,0 +1,289 @@
+"""``sac worktree gc`` — reap safe, stale worktrees; shout about the rest.
+
+Registered onto the ``worktree`` group by :func:`register`, exactly as
+:mod:`._host_sync` does onto ``host``.
+
+Rendering rule for this whole file, inherited from the host-sync verb:
+**there is no quiet success path.** A pass that removes nothing still
+prints what it judged and why it kept each one, because a GC that reaps
+what it can and stays silent about what it cannot is how a repo reaches
+105 worktrees behind a green cron line. The kept-reasons breakdown is the
+product; the removals are the easy half.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from .._maintenance import (
+    DEFAULT_CAP,
+    DEFAULT_MIN_AGE_HOURS,
+    GcOutcome,
+    RepoGcResult,
+    discover_repos,
+    exit_code_for,
+    gc_repos,
+    route_gc_to_cards,
+)
+from ._helpers import _json_flag, console
+
+
+def _evidence(text: str) -> None:
+    """Print one evidence line WITHOUT rich's word-wrap.
+
+    A wrapped absolute path is a path you cannot grep out of a cron log,
+    and every line here exists to be read back later.
+    """
+    console.print(text, soft_wrap=True)
+
+
+def _print_repo(result: RepoGcResult) -> None:
+    """Everything that happened to one repo. All of it gets printed."""
+    if result.unreadable:
+        _evidence(f"[magenta]UNKNOWN[/magenta]   {result.repo}")
+        _evidence(f"    [red]could not read repo: {result.error}[/red]")
+        console.print("")
+        return
+
+    colour = "yellow" if result.exceeds_cap else "green"
+    label = "OVER CAP" if result.exceeds_cap else "ok"
+    _evidence(
+        f"[{colour}]{label:<9}[/{colour}] {result.repo}  "
+        f"[dim]{result.count_after} worktree(s), cap {result.cap}[/dim]"
+    )
+    for verdict in result.removed:
+        _evidence(f"    [green]removed[/green]    {verdict.path}")
+    for verdict in result.kept:
+        if verdict.removable:
+            # Dry-run: proven safe, deliberately untouched.
+            _evidence(f"    [cyan]would remove[/cyan] {verdict.path}")
+            continue
+        reasons = ", ".join(verdict.keep_reasons)
+        _evidence(f"    [dim]kept[/dim]       {verdict.path}  [dim]({reasons})[/dim]")
+        if verdict.remove_error:
+            _evidence(f"      [red]git refused: {verdict.remove_error}[/red]")
+    breakdown = result.keep_reason_breakdown
+    if breakdown:
+        summary = ", ".join(f"{n} {reason}" for reason, n in breakdown.items())
+        _evidence(f"    [dim]kept-reasons: {summary}[/dim]")
+    if result.prune_detail:
+        for line in result.prune_detail.splitlines():
+            _evidence(f"    [dim]prune: {line}[/dim]")
+    console.print("")
+
+
+def _print_report(outcome: GcOutcome, *, apply: bool) -> None:
+    mode = "apply" if apply else "dry-run (read-only)"
+    console.print(
+        f"[bold]sac worktree gc[/bold]  {mode} — {len(outcome.results)} repo(s)\n"
+    )
+    for result in outcome.results:
+        _print_repo(result)
+
+    # Never silent: say what the verdict MEANS, not just what it was.
+    if outcome.over_cap:
+        names = ", ".join(r.repo for r in outcome.over_cap)
+        console.print(
+            f"[yellow]{len(outcome.over_cap)} repo(s) still over cap:[/yellow] {names}\n"
+            "  Every kept worktree failed at least one safety leg (see the\n"
+            "  kept-reasons above). The GC will NEVER auto-remove those — a\n"
+            "  human decides. Dirty worktrees hold work that exists nowhere else."
+        )
+    elif outcome.unreadable:
+        console.print(
+            f"[magenta]{len(outcome.unreadable)} repo(s) UNREADABLE[/magenta] "
+            "[dim]— unknown is not clean; their sprawl is unobserved, not absent.[/dim]"
+        )
+    else:
+        console.print(
+            "[green]every repo under its worktree cap[/green] "
+            "[dim](removals are proven-safe only: clean AND merged AND aged "
+            "AND idle)[/dim]"
+        )
+    if not apply:
+        console.print(
+            "[dim]dry-run: nothing was removed. Re-run with --apply to act.[/dim]"
+        )
+
+
+@click.command("gc")
+@click.option(
+    "--repo",
+    "repos",
+    multiple=True,
+    type=click.Path(),
+    help="Repo to sweep (repeatable). Mutually exclusive with --all.",
+)
+@click.option(
+    "--all",
+    "all_repos",
+    is_flag=True,
+    default=False,
+    help=(
+        "Every local git repo declared as an agent's spec.workdir "
+        "(sac's own spec tree is the source — see `sac worktree gc --help`)."
+    ),
+)
+@click.option(
+    "--apply",
+    "apply",
+    is_flag=True,
+    default=False,
+    help="ACT: remove the worktrees the predicate proved safe. Default is --dry-run.",
+)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="READ-ONLY report (the DEFAULT). Removes nothing; explicit for scripts.",
+)
+@click.option(
+    "--min-age-hours",
+    type=float,
+    default=DEFAULT_MIN_AGE_HOURS,
+    show_default=True,
+    help="Keep any worktree whose HEAD commit is younger than this.",
+)
+@click.option(
+    "--cap",
+    type=int,
+    default=DEFAULT_CAP,
+    show_default=True,
+    help="Alarm when a repo still has more than this many worktrees after the pass.",
+)
+@click.option(
+    "--alarm/--no-alarm",
+    "alarm",
+    default=None,
+    help=(
+        "Route each repo's cap verdict to an idempotent scitex-todo card "
+        "(upsert over cap / unknown, resolve back under). Default: on with "
+        "--apply, off on a dry run (a report must not write to the board)."
+    ),
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON (for cron).")
+@click.pass_context
+def worktree_gc(
+    ctx: click.Context,
+    repos: tuple[str, ...],
+    all_repos: bool,
+    apply: bool,
+    dry_run: bool,
+    min_age_hours: float,
+    cap: int,
+    alarm: bool | None,
+    as_json: bool,
+) -> None:
+    """Remove worktrees that are PROVABLY safe to remove. Keep everything else.
+
+    Agent-tool worktrees auto-clean only when nothing edited them; anything
+    an agent touched persists forever. One repo reached 105 worktrees and
+    helped trigger a host load-spike. This is the permanent countermeasure.
+
+    \b
+    Report (read-only — the DEFAULT):
+      $ sac worktree gc --repo ~/proj/scitex-todo
+      $ sac worktree gc --all --json
+    \b
+    Act:
+      $ sac worktree gc --apply --all
+
+    A worktree is removed ONLY if ALL FOUR legs pass:
+
+    \b
+      CLEAN     `git status --porcelain` is empty. Untracked counts as
+                DIRTY — it is work saved nowhere else.
+      MERGED    an ancestor of develop/main, OR it has a MERGED PR (the
+                squash-merge case, which the ancestor check alone calls
+                unmerged forever).
+      OLD       its HEAD commit is older than --min-age-hours.
+      IDLE      no running process has its cwd inside it (best-effort
+                /proc scan; if the signal is unavailable -> KEEP).
+
+    Every leg is three-state: a check that could not RUN keeps the
+    worktree, exactly like a check that failed. Removal is `git worktree
+    remove` with NO --force, so git's own dirty-refusal is a second,
+    independent backstop. `git worktree prune` (admin refs whose directory
+    is already gone — destroys no files) runs alongside, as --dry-run on a
+    dry run.
+
+    \b
+    --all's repo source is sac's OWN spec tree: every agent spec.yaml's
+    `spec.workdir` that (a) exists on THIS host and (b) is a git repo
+    toplevel. A repo no agent declares is never swept by --all — name it
+    with --repo.
+
+    \b
+    Exit codes:  0 = all repos under cap.  1 = a repo is still over cap
+    after the pass.  2 = a repo could not be READ (unknown outranks
+    known-bad: it is a known-bad you cannot see).
+    """
+    if bool(repos) == all_repos:
+        raise click.UsageError(
+            "give exactly one of --repo PATH (repeatable) or --all  "
+            "(e.g. `sac worktree gc --repo ~/proj/scitex-todo` or "
+            "`sac worktree gc --apply --all`)"
+        )
+    if apply and dry_run:
+        raise click.UsageError(
+            "--apply and --dry-run are opposites; --dry-run is already the default"
+        )
+
+    targets = list(discover_repos()) if all_repos else list(repos)
+    if not targets:
+        raise click.UsageError(
+            "no local git repo is declared as any agent's spec.workdir, so "
+            "--all has nothing to sweep. Name one explicitly:  "
+            "sac worktree gc --repo <path>"
+        )
+
+    outcome = gc_repos(
+        targets,
+        apply=apply,
+        min_age_hours=min_age_hours,
+        cap=cap,
+    )
+    code = exit_code_for(outcome)
+
+    # Make the shout SEEN: route each cap verdict to an idempotent board
+    # card. Defaults to riding --apply only — a dry run is a report and
+    # must not mutate the board.
+    do_alarm = apply if alarm is None else alarm
+    alarm_outcome = route_gc_to_cards(list(outcome.results)) if do_alarm else None
+
+    if _json_flag(ctx, as_json):
+        payload: dict = {
+            "mode": "apply" if apply else "dry-run",
+            "exit_code": code,
+            "cap": cap,
+            "min_age_hours": min_age_hours,
+            "removed": outcome.removed_count,
+            "kept": outcome.kept_count,
+            "repos": [r.to_dict() for r in outcome.results],
+        }
+        if alarm_outcome is not None:
+            payload["alarm"] = {
+                "exceeded": list(alarm_outcome.exceeded),
+                "unreadable": list(alarm_outcome.unreadable),
+                "cleared": list(alarm_outcome.cleared),
+                "failed": list(alarm_outcome.failed),
+            }
+        click.echo(json.dumps(payload, indent=2))
+        raise SystemExit(code)
+
+    _print_report(outcome, apply=apply)
+    console.print(f"[dim]{outcome.summary_line()}[/dim]")
+    if alarm_outcome is not None:
+        console.print(f"[dim]{alarm_outcome.summary_line()}[/dim]")
+    raise SystemExit(code)
+
+
+def register(worktree_group) -> None:
+    """Attach ``gc`` to the parent ``worktree`` Click group."""
+    worktree_group.add_command(worktree_gc)
+
+
+__all__ = ["register", "worktree_gc"]

--- a/src/scitex_agent_container/cli_pkg/worktree_group.py
+++ b/src/scitex_agent_container/cli_pkg/worktree_group.py
@@ -1,0 +1,38 @@
+"""``sac worktree`` noun group — git-worktree hygiene on this host.
+
+A new top-level noun rather than a fold-in, because worktree sprawl is
+REPO-scoped, not agent-scoped. The closest existing homes are all the
+wrong shape: ``sac agents`` verbs take an agent name and act on that
+agent's runtime; ``sac db clean`` is the state DB; ``sac host`` is peer
+identity/routing. A repo's worktrees belong to none of them — they
+outlive the agent that made them, which is precisely why they sprawl.
+
+Verbs are attached by their own modules' ``register()`` (see
+:mod:`._worktree_gc`), mirroring how ``host_group`` collects ``_host_sync``
+and ``_host_crud``.
+"""
+
+from __future__ import annotations
+
+import click
+
+from . import _worktree_gc
+
+
+@click.group(
+    "worktree",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+def worktree_group() -> None:
+    """Git-worktree hygiene: report and reap safe, stale worktrees.
+
+    \b
+    Examples:
+      $ sac worktree gc --repo ~/proj/scitex-todo    # read-only report
+      $ sac worktree gc --apply --all                # act
+    """
+
+
+_worktree_gc.register(worktree_group)
+
+__all__ = ["worktree_group"]

--- a/tests/scitex_agent_container/_maintenance/conftest.py
+++ b/tests/scitex_agent_container/_maintenance/conftest.py
@@ -1,0 +1,131 @@
+"""Real git repos for the worktree-GC suite — no mocks, no fakes.
+
+Every fixture builds an ACTUAL repository with ACTUAL ``git worktree
+add``, because the thing under test is a predicate whose whole job is to
+read git correctly before deleting a directory. A faked ``git status``
+would test our idea of git, which is exactly the idea that would be
+wrong.
+
+Two seams keep the suite hermetic without faking anything that matters:
+
+* ``pr_*`` — the merged-PR lookup. Injected so no test touches the
+  network; a real ``gh`` call from a temp repo would be slow, flaky, and
+  answer about somebody else's repo.
+* ``no_cwds`` / ``unknown_cwds`` — the ``/proc`` scan, injected so a test
+  is not at the mercy of whatever else is running on the box. The in-use
+  test deliberately does NOT inject: it spawns a real process and uses
+  the real scanner.
+
+Worktrees are created under ``tmp_path/worktrees/`` rather than the
+production ``<repo>/.worktrees/`` on purpose — the GC enumerates via
+``git worktree list``, and this proves it does not secretly depend on a
+directory layout.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+#: Enough of a clock lie to clear the 24h age gate without backdating any
+#: commit: the GC takes ``now`` as a seam, so a fresh commit read from 100
+#: simulated hours in the future is genuinely "old" to every leg.
+HOURS_100 = 100 * 3600
+
+
+def git(repo: Path | str, *args: str) -> str:
+    """A real ``git -C <repo> ...``. Raises on failure — a broken fixture
+    must fail loudly at build time, not silently produce a repo whose
+    shape nobody checked.
+    """
+    res = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return res.stdout.strip()
+
+
+def commit(tree: Path, filename: str, text: str, message: str) -> None:
+    """Write a file and really commit it in ``tree``."""
+    (tree / filename).write_text(text)
+    git(tree, "add", filename)
+    git(tree, "commit", "-qm", message)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A real git repo on ``develop`` with one commit and an identity.
+
+    Identity is set repo-locally (never ``--global``): the suite must not
+    touch the machine's git config.
+    """
+    root = tmp_path / "repo"
+    root.mkdir()
+    git(root, "init", "-q", "-b", "develop")
+    git(root, "config", "user.email", "worktree-gc-test@example.invalid")
+    git(root, "config", "user.name", "Worktree GC Test")
+    commit(root, "README.md", "seed\n", "seed")
+    return root
+
+
+@pytest.fixture
+def add_worktree(repo: Path, tmp_path: Path):
+    """Factory: a REAL ``git worktree add`` on a fresh branch.
+
+    ``ahead`` adds a commit that exists only on the branch, which is what
+    makes it a non-ancestor of ``develop`` — i.e. what an unmerged branch
+    and a squash-merged branch look like from git's side (they are
+    identical locally; only GitHub can tell them apart, which is why the
+    merged leg needs both checks).
+    """
+
+    def _add(name: str, *, ahead: bool = False) -> Path:
+        path = tmp_path / "worktrees" / name
+        branch = f"feat/{name}"
+        git(repo, "worktree", "add", "-q", "-b", branch, str(path), "develop")
+        if ahead:
+            commit(path, f"{name}.txt", f"{name} work\n", f"{name}: work")
+        return path
+
+    return _add
+
+
+@pytest.fixture
+def old_now() -> float:
+    """A clock 100h ahead — every fresh commit reads as older than the gate."""
+    return time.time() + HOURS_100
+
+
+@pytest.fixture
+def pr_yes():
+    """Merged-PR seam answering YES — the squash-merged branch's truth."""
+    return lambda repo, branch: True
+
+
+@pytest.fixture
+def pr_no():
+    """Merged-PR seam answering NO — GitHub knows of no merged PR."""
+    return lambda repo, branch: False
+
+
+@pytest.fixture
+def pr_unknown():
+    """Merged-PR seam that could not answer (gh missing / offline / rate-limited)."""
+    return lambda repo, branch: None
+
+
+@pytest.fixture
+def no_cwds():
+    """/proc scan seam: readable, and nothing is running in any worktree."""
+    return lambda: set()
+
+
+@pytest.fixture
+def unknown_cwds():
+    """/proc scan seam: the signal is UNAVAILABLE (never 'nothing runs')."""
+    return lambda: None

--- a/tests/scitex_agent_container/_maintenance/test__worktree_gc.py
+++ b/tests/scitex_agent_container/_maintenance/test__worktree_gc.py
@@ -1,0 +1,503 @@
+"""Tests for ``_maintenance._worktree_gc`` — the GC engine + its predicate.
+
+PA-306: no ``unittest.mock``. REAL temp git repos, REAL ``git worktree
+add``, and for the in-use leg a REAL child process with its cwd inside a
+worktree. Only the two documented seams are injected (the merged-PR
+lookup and the ``/proc`` scan); everything else is git doing what git
+does.
+
+The behaviours that matter — one per leg of the safety predicate, because
+every one of them is a way to destroy work:
+
+* clean + merged-by-ancestor + old + idle -> REMOVED under ``apply``,
+* the same worktree under a dry run -> LISTED and STILL THERE,
+* clean + SQUASH-merged (a merged PR, not an ancestor) -> REMOVED,
+* DIRTY -> KEPT, untracked-only -> KEPT (untracked IS dirty),
+* clean but UNMERGED -> KEPT, too YOUNG -> KEPT, IN USE -> KEPT,
+* an UNKNOWN on any leg -> KEPT (never silently "fine"),
+* ``--force`` is never passed — git's refusal is the backstop.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+from scitex_agent_container._maintenance._worktree_gc import gc_repo, gc_repos
+from scitex_agent_container._maintenance._worktree_gc_model import (
+    KEEP_DIRTY,
+    KEEP_IN_USE,
+    KEEP_IN_USE_UNKNOWN,
+    KEEP_MERGE_UNKNOWN,
+    KEEP_TOO_YOUNG,
+    KEEP_UNMERGED,
+)
+
+
+def _verdict(result, path: Path):
+    (match,) = [v for v in result.verdicts if v.path == str(path)]
+    return match
+
+
+# ---------------------------------------------------------------------------
+# Leg-by-leg: the four ways a worktree earns its life
+# ---------------------------------------------------------------------------
+
+
+def test_clean_merged_old_worktree_is_removed(
+    repo, add_worktree, old_now, pr_no, no_cwds
+):
+    # Arrange — a worktree whose branch is an ancestor of develop, clean,
+    # and (via the clock seam) older than the age gate.
+    path = add_worktree("reapable")
+    # Act
+    result = gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert — the one case where deleting is right.
+    assert [v.path for v in result.removed] == [str(path)]
+
+
+def test_removed_worktree_directory_is_really_gone(
+    repo, add_worktree, old_now, pr_no, no_cwds
+):
+    # Arrange — the verdict is a claim; the filesystem is the fact.
+    path = add_worktree("reapable")
+    # Act
+    gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert not path.exists()
+
+
+def test_squash_merged_worktree_is_removed(
+    repo, add_worktree, old_now, pr_yes, no_cwds
+):
+    # Arrange — a branch AHEAD of develop (so the ancestor check says
+    # "unmerged") whose PR was squash-merged. Without the PR leg, a
+    # squash-merging repo would never have a single worktree collected.
+    path = add_worktree("squashed", ahead=True)
+    # Act
+    result = gc_repo(repo, apply=True, now=old_now, pr_merged=pr_yes, cwd_scan=no_cwds)
+    # Assert
+    assert [v.path for v in result.removed] == [str(path)]
+
+
+def test_dirty_worktree_is_kept(repo, add_worktree, old_now, pr_no, no_cwds):
+    # Arrange — merged + old + idle, but a tracked file is modified.
+    path = add_worktree("dirty")
+    (path / "README.md").write_text("uncommitted edit\n")
+    # Act
+    result = gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert KEEP_DIRTY in _verdict(result, path).keep_reasons
+
+
+def test_untracked_only_worktree_is_kept(repo, add_worktree, old_now, pr_no, no_cwds):
+    # Arrange — the file is untracked, which is the WORST case, not the
+    # mildest: it exists nowhere but this directory. `status --porcelain`
+    # lists it, and we never pass -uno.
+    path = add_worktree("untracked")
+    (path / "scratch.txt").write_text("work saved nowhere else\n")
+    # Act
+    result = gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert KEEP_DIRTY in _verdict(result, path).keep_reasons
+
+
+def test_untracked_only_worktree_survives_on_disk(
+    repo, add_worktree, old_now, pr_no, no_cwds
+):
+    # Arrange — the verdict is a claim; the surviving directory is the fact.
+    path = add_worktree("untracked")
+    (path / "scratch.txt").write_text("work saved nowhere else\n")
+    # Act
+    gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert (path / "scratch.txt").exists()
+
+
+def test_clean_unmerged_worktree_is_kept(repo, add_worktree, old_now, pr_no, no_cwds):
+    # Arrange — ahead of develop AND GitHub says no merged PR. Two
+    # independent sources agree, which is what a definite UNMERGED needs.
+    path = add_worktree("unmerged", ahead=True)
+    # Act
+    result = gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert KEEP_UNMERGED in _verdict(result, path).keep_reasons
+
+
+def test_too_young_worktree_is_kept(repo, add_worktree, pr_no, no_cwds):
+    # Arrange — merged + clean + idle, but committed seconds ago. NOTE the
+    # real clock here (no old_now): a young worktree is presumed in flight.
+    path = add_worktree("young")
+    # Act
+    result = gc_repo(
+        repo, apply=True, now=time.time(), pr_merged=pr_no, cwd_scan=no_cwds
+    )
+    # Assert
+    assert KEEP_TOO_YOUNG in _verdict(result, path).keep_reasons
+
+
+def test_in_use_worktree_is_kept(repo, add_worktree, old_now, pr_no):
+    # Arrange — clean + merged + old, but a REAL process is sitting in it.
+    # No cwd seam: this drives the real /proc scanner against a real child.
+    path = add_worktree("in-use")
+    proc = subprocess.Popen(["sleep", "30"], cwd=str(path))
+    try:
+        # Act
+        result = gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no)
+        # Assert
+        assert KEEP_IN_USE in _verdict(result, path).keep_reasons
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+def test_in_use_worktree_survives_on_disk(repo, add_worktree, old_now, pr_no):
+    # Arrange — the leg that protects an agent working RIGHT NOW.
+    path = add_worktree("in-use")
+    proc = subprocess.Popen(["sleep", "30"], cwd=str(path))
+    try:
+        # Act
+        gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no)
+        # Assert
+        assert path.is_dir()
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# Unknown is not clean — a leg that could not run KEEPS
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_cwd_signal_keeps_the_worktree(
+    repo, add_worktree, old_now, pr_no, unknown_cwds
+):
+    # Arrange — clean + merged + old, but the /proc signal is UNAVAILABLE.
+    # "I could not look" must never read as "nothing is running".
+    path = add_worktree("blind")
+    # Act
+    result = gc_repo(
+        repo, apply=True, now=old_now, pr_merged=pr_no, cwd_scan=unknown_cwds
+    )
+    # Assert
+    assert KEEP_IN_USE_UNKNOWN in _verdict(result, path).keep_reasons
+
+
+def test_unknown_merge_state_keeps_the_worktree(
+    repo, add_worktree, old_now, pr_unknown, no_cwds
+):
+    # Arrange — ahead of develop, and gh could not answer (missing /
+    # offline / rate-limited). A squash-merge and an unmerged branch are
+    # indistinguishable here, so the only safe answer is KEEP.
+    path = add_worktree("unknowable", ahead=True)
+    # Act
+    result = gc_repo(
+        repo, apply=True, now=old_now, pr_merged=pr_unknown, cwd_scan=no_cwds
+    )
+    # Assert
+    assert KEEP_MERGE_UNKNOWN in _verdict(result, path).keep_reasons
+
+
+def test_raising_pr_seam_keeps_the_worktree(repo, add_worktree, old_now, no_cwds):
+    # Arrange — a PR lookup that BLOWS UP must degrade to UNKNOWN -> KEEP,
+    # never crash a scheduled pass and never read as merged.
+    def _boom(repo_path, branch):
+        raise RuntimeError("gh exploded")
+
+    path = add_worktree("exploding", ahead=True)
+    # Act
+    result = gc_repo(repo, apply=True, now=old_now, pr_merged=_boom, cwd_scan=no_cwds)
+    # Assert
+    assert KEEP_MERGE_UNKNOWN in _verdict(result, path).keep_reasons
+
+
+def test_unreadable_repo_reports_unknown_not_empty(tmp_path, pr_no, no_cwds):
+    # Arrange — a directory that is not a git repo at all.
+    not_a_repo = tmp_path / "plain"
+    not_a_repo.mkdir()
+    # Act
+    result = gc_repo(not_a_repo, apply=True, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert — "I could not read it" is not "it has no worktrees".
+    assert result.unreadable
+
+
+# ---------------------------------------------------------------------------
+# Dry-run is the default, and it removes NOTHING
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_lists_the_reapable_worktree(
+    repo, add_worktree, old_now, pr_no, no_cwds
+):
+    # Arrange — a worktree that passes every leg.
+    path = add_worktree("reapable")
+    # Act
+    result = gc_repo(repo, apply=False, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert — it is reported as removable...
+    assert [v.path for v in result.verdicts if v.removable] == [str(path)]
+
+
+def test_dry_run_removes_nothing_from_disk(repo, add_worktree, old_now, pr_no, no_cwds):
+    # Arrange — ...but the directory is still there afterwards.
+    path = add_worktree("reapable")
+    # Act
+    gc_repo(repo, apply=False, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert path.is_dir()
+
+
+def test_dry_run_records_no_removals(repo, add_worktree, old_now, pr_no, no_cwds):
+    # Arrange — and it does not CLAIM to have removed anything either.
+    add_worktree("reapable")
+    # Act
+    result = gc_repo(repo, apply=False, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert result.removed == ()
+
+
+def test_dry_run_is_the_default_mode(repo, add_worktree, old_now, pr_no, no_cwds):
+    # Arrange — `apply` not passed at all. A GC whose default is
+    # destructive gets run destructively by accident exactly once.
+    path = add_worktree("reapable")
+    # Act
+    gc_repo(repo, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert path.is_dir()
+
+
+def test_dry_run_keeps_the_worktree_registered(
+    repo, add_worktree, old_now, pr_no, no_cwds
+):
+    # Arrange — git's own view must be untouched too, not just the disk.
+    path = add_worktree("reapable")
+    # Act
+    gc_repo(repo, apply=False, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    listed = subprocess.run(
+        ["git", "-C", str(repo), "worktree", "list"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert str(path) in listed
+
+
+# ---------------------------------------------------------------------------
+# What the GC deliberately never touches
+# ---------------------------------------------------------------------------
+
+
+def test_main_worktree_is_never_a_candidate(repo, old_now, pr_no, no_cwds):
+    # Arrange — the repo checkout itself is not sprawl, it is the repo.
+    # (Its branch IS develop, so every leg would otherwise pass.)
+    # Act
+    result = gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert result.verdicts == ()
+
+
+def test_locked_worktree_is_kept(repo, add_worktree, old_now, pr_no, no_cwds):
+    # Arrange — a lock is a human saying "leave this alone"; the GC obeys.
+    path = add_worktree("locked")
+    subprocess.run(
+        ["git", "-C", str(repo), "worktree", "lock", str(path)],
+        capture_output=True,
+        check=True,
+    )
+    # Act
+    result = gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert path.is_dir()
+
+
+def test_remove_never_passes_force(repo, add_worktree, old_now, pr_no, no_cwds):
+    # Arrange — THE pin. `--force` would disable git's own dirty-refusal,
+    # the one check in this system we did not write ourselves. A worktree
+    # that is dirty must survive `apply` even though we asked to remove
+    # everything reapable — proving the remove path cannot be forced.
+    path = add_worktree("dirty")
+    (path / "README.md").write_text("uncommitted edit\n")
+    # Act
+    gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert (path / "README.md").read_text() == "uncommitted edit\n"
+
+
+# ---------------------------------------------------------------------------
+# Prune: the always-safe half
+# ---------------------------------------------------------------------------
+
+
+def test_prune_clears_the_ref_of_a_deleted_directory(
+    repo, add_worktree, old_now, pr_no, no_cwds
+):
+    # Arrange — a worktree whose directory someone `rm -rf`'d by hand,
+    # leaving a dangling admin ref. Nothing is destroyed by pruning it.
+    path = add_worktree("vanished")
+    subprocess.run(["rm", "-rf", str(path)], check=True)
+    # Act
+    gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    listed = subprocess.run(
+        ["git", "-C", str(repo), "worktree", "list"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert str(path) not in listed
+
+
+def test_missing_worktree_is_not_removed_by_predicate(
+    repo, add_worktree, old_now, pr_no, no_cwds
+):
+    # Arrange — a vanished directory is prune's job, not remove's:
+    # `worktree remove` would just error on it.
+    path = add_worktree("vanished")
+    subprocess.run(["rm", "-rf", str(path)], check=True)
+    # Act
+    result = gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert result.removed == ()
+
+
+def test_prune_names_what_it_pruned(repo, add_worktree, old_now, pr_no, no_cwds):
+    # Arrange — WITHOUT --verbose, `git worktree prune` prints nothing at
+    # all, so the pass would claim a prune with no evidence either way —
+    # the exact "green line nobody can check" shape this GC exists to kill.
+    path = add_worktree("vanished")
+    subprocess.run(["rm", "-rf", str(path)], check=True)
+    # Act
+    result = gc_repo(repo, apply=True, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert "vanished" in result.prune_detail
+
+
+def test_dry_run_prune_reports_what_it_would_prune(
+    repo, add_worktree, old_now, pr_no, no_cwds
+):
+    # Arrange — a dry run must SAY what it would prune, not go quiet.
+    path = add_worktree("vanished")
+    subprocess.run(["rm", "-rf", str(path)], check=True)
+    # Act
+    result = gc_repo(repo, apply=False, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    assert "vanished" in result.prune_detail
+
+
+def test_dry_run_prune_leaves_the_dangling_ref(
+    repo, add_worktree, old_now, pr_no, no_cwds
+):
+    # Arrange — even prune, which destroys no files, only REPORTS on a dry
+    # run. --dry-run means the whole pass is a read, not most of it.
+    path = add_worktree("vanished")
+    subprocess.run(["rm", "-rf", str(path)], check=True)
+    # Act
+    gc_repo(repo, apply=False, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds)
+    # Assert
+    listed = subprocess.run(
+        ["git", "-C", str(repo), "worktree", "list"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert str(path) in listed
+
+
+# ---------------------------------------------------------------------------
+# Cap + multi-repo
+# ---------------------------------------------------------------------------
+
+
+def test_repo_over_cap_is_flagged(repo, add_worktree, old_now, pr_no, no_cwds):
+    # Arrange — two DIRTY worktrees (so the GC cannot reap them) and a cap
+    # of 1. The cap is about what SURVIVES, which is the whole point: the
+    # predicate is never relaxed to hit a number.
+    for name in ("a", "b"):
+        path = add_worktree(name)
+        (path / "README.md").write_text("edit\n")
+    # Act
+    result = gc_repo(
+        repo, apply=True, cap=1, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds
+    )
+    # Assert
+    assert result.exceeds_cap
+
+
+def test_repo_under_cap_is_not_flagged(repo, add_worktree, old_now, pr_no, no_cwds):
+    # Arrange — one dirty worktree, cap 20.
+    path = add_worktree("a")
+    (path / "README.md").write_text("edit\n")
+    # Act
+    result = gc_repo(
+        repo, apply=True, cap=20, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds
+    )
+    # Assert
+    assert not result.exceeds_cap
+
+
+def test_cap_counts_survivors_not_candidates(
+    repo, add_worktree, old_now, pr_no, no_cwds
+):
+    # Arrange — two worktrees, one reapable and one dirty, cap 1. After
+    # the pass ONE survives, so the repo is at cap, not over it.
+    add_worktree("reapable")
+    dirty = add_worktree("dirty")
+    (dirty / "README.md").write_text("edit\n")
+    # Act
+    result = gc_repo(
+        repo, apply=True, cap=1, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds
+    )
+    # Assert
+    assert not result.exceeds_cap
+
+
+def test_keep_reason_breakdown_counts_each_reason(
+    repo, add_worktree, old_now, pr_no, no_cwds
+):
+    # Arrange — the breakdown IS the cap card's value: "2 dirty" is an
+    # instruction where "2 kept" is a number.
+    for name in ("a", "b"):
+        path = add_worktree(name)
+        (path / "README.md").write_text("edit\n")
+    # Act
+    result = gc_repo(
+        repo, apply=True, cap=1, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds
+    )
+    # Assert
+    assert result.keep_reason_breakdown[KEEP_DIRTY] == 2
+
+
+def test_gc_repos_sweeps_every_repo(
+    repo, add_worktree, old_now, pr_no, no_cwds, tmp_path
+):
+    # Arrange — a second real repo alongside the first.
+    other = tmp_path / "other"
+    other.mkdir()
+    subprocess.run(["git", "-C", str(other), "init", "-q", "-b", "develop"], check=True)
+    add_worktree("reapable")
+    # Act
+    outcome = gc_repos(
+        [repo, other], apply=False, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds
+    )
+    # Assert
+    assert len(outcome.results) == 2
+
+
+def test_one_unreadable_repo_does_not_stop_the_rest(
+    repo, add_worktree, old_now, pr_no, no_cwds, tmp_path
+):
+    # Arrange — a bad path first; the good repo behind it must still be
+    # swept. One broken repo never suppresses the whole fleet's pass.
+    missing = tmp_path / "not-a-repo"
+    missing.mkdir()
+    path = add_worktree("reapable")
+    # Act
+    outcome = gc_repos(
+        [missing, repo], apply=False, now=old_now, pr_merged=pr_no, cwd_scan=no_cwds
+    )
+    # Assert
+    assert [v.path for v in outcome.results[1].verdicts if v.removable] == [str(path)]

--- a/tests/scitex_agent_container/_maintenance/test__worktree_gc_alarm.py
+++ b/tests/scitex_agent_container/_maintenance/test__worktree_gc_alarm.py
@@ -1,0 +1,227 @@
+"""Tests for ``_maintenance._worktree_gc_alarm`` — over-cap → SEEN card.
+
+PA-306: no ``unittest.mock``. Real :class:`RepoGcResult` values and a REAL
+temporary scitex-todo store (``tmp_path/tasks.yaml``); the routing calls
+the real ``scitex_todo`` writer and each test reads the card back through
+the real reader.
+
+The behaviours that matter:
+
+* over cap → an upserted BLOCKING-YOU card naming the repo and count,
+* the card carries the kept-reasons BREAKDOWN (the actionable part),
+* a second over-cap run UPDATES in place (never duplicates),
+* back under cap → the card is RESOLVED (a fixed repo stops shouting),
+* UNREADABLE is carded too but labelled UNKNOWN — never rendered clean,
+* re-sprawl after a clear REOPENS the card,
+* a board-write failure NEVER crashes the GC (delivery is a side rail).
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._maintenance._worktree_gc_alarm import (
+    card_id_for,
+    route_gc_to_cards,
+)
+from scitex_agent_container._maintenance._worktree_gc_model import (
+    KEEP_DIRTY,
+    KEEP_UNMERGED,
+    RepoGcResult,
+    WorktreeVerdict,
+)
+
+scitex_todo = pytest.importorskip("scitex_todo")
+
+
+def _kept(path: str, *reasons: str) -> WorktreeVerdict:
+    return WorktreeVerdict(path=path, branch="feat/x", keep_reasons=tuple(reasons))
+
+
+def _over_cap(repo: str = "/proj/sprawly", cap: int = 1) -> RepoGcResult:
+    """A real result: two survivors against a cap of one."""
+    return RepoGcResult(
+        repo=repo,
+        applied=True,
+        cap=cap,
+        verdicts=(
+            _kept("/wt/a", KEEP_DIRTY),
+            _kept("/wt/b", KEEP_UNMERGED),
+        ),
+    )
+
+
+def _under_cap(repo: str = "/proj/sprawly", cap: int = 20) -> RepoGcResult:
+    return RepoGcResult(
+        repo=repo, applied=True, cap=cap, verdicts=(_kept("/wt/a", KEEP_DIRTY),)
+    )
+
+
+def _unreadable(repo: str = "/proj/broken") -> RepoGcResult:
+    return RepoGcResult(repo=repo, applied=True, error="not a git repository")
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> str:
+    """A real (initially absent) scitex-todo store path — no mocks."""
+    return str(tmp_path / "tasks.yaml")
+
+
+def test_over_cap_upserts_a_blocking_you_card(store):
+    # Arrange — a repo with more survivors than its cap allows.
+    # Act
+    route_gc_to_cards([_over_cap()], store=store)
+    # Assert — it lands on the board's BLOCKING-YOU seen surface.
+    blocking = scitex_todo.list_tasks(store, blocking_me=True)
+    assert [t["id"] for t in blocking] == [card_id_for("/proj/sprawly")]
+
+
+def test_over_cap_card_names_the_repo(store):
+    # Arrange
+    # Act
+    route_gc_to_cards([_over_cap()], store=store)
+    # Assert — never silent: the operator must see WHICH repo.
+    card = scitex_todo.get_task(store, card_id_for("/proj/sprawly"))
+    assert "sprawly" in card["title"]
+
+
+def test_over_cap_card_names_the_count(store):
+    # Arrange — two survivors against a cap of one.
+    # Act
+    route_gc_to_cards([_over_cap()], store=store)
+    # Assert
+    card = scitex_todo.get_task(store, card_id_for("/proj/sprawly"))
+    assert "2 worktrees" in card["title"]
+
+
+def test_over_cap_card_carries_the_reason_breakdown(store):
+    # Arrange — "2 kept" is a number; "1 dirty, 1 unmerged" is an
+    # instruction. The breakdown is the card's entire value.
+    # Act
+    route_gc_to_cards([_over_cap()], store=store)
+    # Assert
+    card = scitex_todo.get_task(store, card_id_for("/proj/sprawly"))
+    assert "1 dirty" in card["note"] and "1 unmerged" in card["note"]
+
+
+def test_second_over_cap_run_updates_not_duplicates(store):
+    # Arrange — first run creates the card.
+    route_gc_to_cards([_over_cap()], store=store)
+    # Act — a nightly timer must UPDATE in place, not tile the board.
+    route_gc_to_cards([_over_cap()], store=store)
+    # Assert
+    assert len(scitex_todo.list_tasks(store)) == 1
+
+
+def test_back_under_cap_resolves_the_card(store):
+    # Arrange — the repo sprawled, so a card exists.
+    route_gc_to_cards([_over_cap()], store=store)
+    # Act — the operator cleaned it up.
+    route_gc_to_cards([_under_cap()], store=store)
+    # Assert — a fixed repo stops shouting (off the BLOCKING-YOU view).
+    assert scitex_todo.list_tasks(store, blocking_me=True) == []
+
+
+def test_back_under_cap_marks_the_card_done(store):
+    # Arrange
+    route_gc_to_cards([_over_cap()], store=store)
+    # Act
+    route_gc_to_cards([_under_cap()], store=store)
+    # Assert
+    card = scitex_todo.get_task(store, card_id_for("/proj/sprawly"))
+    assert card["status"] == "done"
+
+
+def test_healthy_repo_without_prior_card_is_a_noop(store):
+    # Arrange — a repo that was never over cap.
+    # Act
+    route_gc_to_cards([_under_cap()], store=store)
+    # Assert — no phantom card is created just to resolve it.
+    assert not Path(store).exists() or scitex_todo.list_tasks(store) == []
+
+
+def test_unreadable_repo_gets_a_card(store):
+    # Arrange — UNKNOWN must be surfaced, not swallowed.
+    # Act
+    route_gc_to_cards([_unreadable()], store=store)
+    # Assert
+    card_id = card_id_for("/proj/broken")
+    assert scitex_todo.get_task(store, card_id)["id"] == card_id
+
+
+def test_unreadable_card_is_labelled_unknown(store):
+    # Arrange — "I could not look" must never read as "I looked, it's fine".
+    # Act
+    route_gc_to_cards([_unreadable()], store=store)
+    # Assert
+    card = scitex_todo.get_task(store, card_id_for("/proj/broken"))
+    assert "UNKNOWN" in card["title"]
+
+
+def test_route_buckets_over_cap_and_unknown_separately(store):
+    # Arrange — a sprawling repo AND an unreadable one in one run.
+    # Act
+    outcome = route_gc_to_cards([_over_cap(), _unreadable()], store=store)
+    # Assert — three-state honest: distinct buckets, never merged.
+    assert (outcome.exceeded, outcome.unreadable) == (
+        ("/proj/sprawly",),
+        ("/proj/broken",),
+    )
+
+
+def test_route_reports_the_cleared_repo(store):
+    # Arrange — sprawl first so there is a card to clear.
+    route_gc_to_cards([_over_cap()], store=store)
+    # Act
+    outcome = route_gc_to_cards([_under_cap()], store=store)
+    # Assert
+    assert outcome.cleared == ("/proj/sprawly",)
+
+
+def test_resprawl_after_clear_reopens_the_card(store):
+    # Arrange — over cap, then cleaned (card resolved).
+    route_gc_to_cards([_over_cap()], store=store)
+    route_gc_to_cards([_under_cap()], store=store)
+    # Act — it sprawls AGAIN; the alarm must re-fire, not stay silent.
+    route_gc_to_cards([_over_cap()], store=store)
+    # Assert
+    assert len(scitex_todo.list_tasks(store, blocking_me=True)) == 1
+
+
+def test_board_write_failure_does_not_raise(tmp_path):
+    # Arrange — an unwritable store path (a directory where the YAML file
+    # should be). Card delivery is a SIDE rail: it must never crash the GC
+    # pass that feeds it.
+    unwritable = tmp_path / "tasks.yaml"
+    unwritable.mkdir()
+    # Act
+    outcome = route_gc_to_cards(
+        [_over_cap()], store=str(unwritable), err_stream=io.StringIO()
+    )
+    # Assert — recorded as failed, not raised.
+    assert outcome.failed == ("/proj/sprawly",)
+
+
+def test_board_write_failure_is_printed_loudly(tmp_path):
+    # Arrange — a failure nobody hears is the anti-pattern this whole rail
+    # exists to fix, so the side rail still SHOUTS on stderr.
+    unwritable = tmp_path / "tasks.yaml"
+    unwritable.mkdir()
+    stream = io.StringIO()
+    # Act
+    route_gc_to_cards([_over_cap()], store=str(unwritable), err_stream=stream)
+    # Assert
+    assert "FAILED" in stream.getvalue()
+
+
+def test_card_id_is_stable_for_a_repo_path():
+    # Arrange — idempotency is BY ID: an unstable id tiles the board.
+    # Act
+    card_id = card_id_for("/home/user/proj/scitex-todo")
+    # Assert
+    assert card_id == "worktree-sprawl-scitex-todo"

--- a/tests/scitex_agent_container/_maintenance/test__worktree_gc_repos.py
+++ b/tests/scitex_agent_container/_maintenance/test__worktree_gc_repos.py
@@ -1,0 +1,166 @@
+"""Tests for ``_maintenance._worktree_gc_repos`` — what ``--all`` sweeps.
+
+PA-306: no ``unittest.mock``. Real temp spec trees (real ``spec.yaml``
+files) and real git repos; ``roots`` is the injected seam so the suite
+never reads the operator's actual agent tree.
+
+The behaviours that matter — every one of them is a way ``--all`` could
+sweep something it should not:
+
+* a spec's ``spec.workdir`` that IS a local git repo toplevel -> swept,
+* a workdir on another host / in a container -> skipped (not a dir here),
+* a workdir that is not a repo -> skipped,
+* a workdir merely INSIDE a repo -> skipped (never drag the parent in),
+* two specs sharing a repo -> swept once,
+* a malformed spec -> skipped, and the other specs still discovered.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._maintenance._worktree_gc_repos import (
+    discover_repos,
+    spec_workdirs,
+)
+
+
+def _write_spec(root: Path, name: str, workdir: str | None) -> None:
+    """A real spec.yaml in the real on-disk shape sac uses."""
+    agent = root / name
+    agent.mkdir(parents=True)
+    body = [
+        "apiVersion: scitex-agent-container/v3",
+        "kind: Agent",
+        f"metadata:\n  labels:\n    project: {name}",
+        "spec:",
+        "  runtime: tui",
+    ]
+    if workdir is not None:
+        body.append(f"  workdir: {workdir}")
+    (agent / "spec.yaml").write_text("\n".join(body) + "\n")
+
+
+@pytest.fixture
+def spec_root(tmp_path: Path) -> Path:
+    root = tmp_path / "agents"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def real_repo(tmp_path: Path) -> Path:
+    """A real git repo — `git init` for real, no fixture theatre."""
+    repo = tmp_path / "a-real-repo"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q", "-b", "develop"], check=True)
+    return repo
+
+
+def test_spec_workdir_pointing_at_a_repo_is_discovered(spec_root, real_repo):
+    # Arrange — the canonical case: a maintainer agent whose workdir IS
+    # the repo it maintains.
+    _write_spec(spec_root, "maintainer", str(real_repo))
+    # Act
+    found = discover_repos([spec_root])
+    # Assert
+    assert found == [str(real_repo)]
+
+
+def test_workdir_on_another_host_is_skipped(spec_root):
+    # Arrange — specs describe agents on Spartan and inside containers
+    # too. This GC only ever touches the machine it runs on.
+    _write_spec(spec_root, "remote", "/data/gpfs/projects/punim0264/nope")
+    # Act
+    found = discover_repos([spec_root])
+    # Assert
+    assert found == []
+
+
+def test_workdir_that_is_not_a_repo_is_skipped(spec_root, tmp_path):
+    # Arrange — the DEFAULT per-agent workdir is a runtime workspace, not
+    # a repo. It has no worktrees and must never be swept.
+    plain = tmp_path / "plain-workspace"
+    plain.mkdir()
+    _write_spec(spec_root, "plain", str(plain))
+    # Act
+    found = discover_repos([spec_root])
+    # Assert
+    assert found == []
+
+
+def test_workdir_nested_inside_a_repo_is_skipped(spec_root, real_repo):
+    # Arrange — an agent working in a SUBDIRECTORY of a repo must not drag
+    # the whole enclosing repo into the sweep: that would silently widen
+    # the blast radius past what the spec author declared.
+    nested = real_repo / "subproject"
+    nested.mkdir()
+    _write_spec(spec_root, "nested", str(nested))
+    # Act
+    found = discover_repos([spec_root])
+    # Assert
+    assert found == []
+
+
+def test_two_specs_sharing_a_repo_yield_one(spec_root, real_repo):
+    # Arrange — many agents can point at one repo; sweeping it twice would
+    # double every removal attempt.
+    _write_spec(spec_root, "agent-one", str(real_repo))
+    _write_spec(spec_root, "agent-two", str(real_repo))
+    # Act
+    found = discover_repos([spec_root])
+    # Assert
+    assert found == [str(real_repo)]
+
+
+def test_malformed_spec_does_not_break_discovery(spec_root, real_repo):
+    # Arrange — one broken spec must not hide the other 99. A broken spec
+    # is the agent-list's problem to surface, not the GC's to crash on.
+    _write_spec(spec_root, "good", str(real_repo))
+    bad = spec_root / "broken"
+    bad.mkdir()
+    (bad / "spec.yaml").write_text("{[ this is not: valid yaml ::::\n")
+    # Act
+    found = discover_repos([spec_root])
+    # Assert
+    assert found == [str(real_repo)]
+
+
+def test_spec_without_a_workdir_is_skipped(spec_root):
+    # Arrange — a spec that declares no workdir declares no repo.
+    _write_spec(spec_root, "workdirless", None)
+    # Act
+    found = spec_workdirs([spec_root])
+    # Assert
+    assert found == []
+
+
+def test_missing_spec_root_yields_nothing(tmp_path):
+    # Arrange — a fresh install has no agent tree at all.
+    # Act
+    found = discover_repos([tmp_path / "does-not-exist"])
+    # Assert
+    assert found == []
+
+
+def test_discovery_is_sorted_and_deterministic(spec_root, tmp_path):
+    # Arrange — two real repos declared in reverse-alphabetical spec order;
+    # a pass must read the same twice.
+    repos = []
+    for name in ("zeta-repo", "alpha-repo"):
+        repo = tmp_path / name
+        repo.mkdir()
+        subprocess.run(
+            ["git", "-C", str(repo), "init", "-q", "-b", "develop"], check=True
+        )
+        _write_spec(spec_root, f"agent-{name}", str(repo))
+        repos.append(str(repo))
+    # Act
+    found = discover_repos([spec_root])
+    # Assert
+    assert found == sorted(repos)

--- a/tests/scitex_agent_container/cli_pkg/test__worktree_gc.py
+++ b/tests/scitex_agent_container/cli_pkg/test__worktree_gc.py
@@ -1,0 +1,326 @@
+"""CLI tests for ``sac worktree gc``.
+
+PA-306: no ``unittest.mock``. A real ``CliRunner`` driving the real verb
+against REAL temp git repos with REAL worktrees.
+
+Two deliberate choices keep this hermetic without faking anything:
+
+* Every worktree here sits on a branch that IS an ancestor of ``develop``,
+  so the merged leg is satisfied locally and ``gh`` is never invoked — no
+  network, no flake, and the CLI is exercised with its REAL default seams
+  rather than injected ones.
+* ``SCITEX_TODO_TASKS_YAML_SHARED`` is redirected to a temp store for the
+  WHOLE module (verified to be honoured at call time). The alarm defaults
+  ON under ``--apply``, so without this a test would card the operator's
+  real board. Belt and braces: tests whose subject is not the alarm pass
+  ``--no-alarm`` anyway.
+
+The assertions that matter are the EXIT CODES and the DISK: ``--dry-run``
+is the default and must leave every directory exactly where it was, and a
+repo over its cap must exit non-zero — a cap alarm that exits 0 is a
+report nobody reads, which is how a repo reached 105 worktrees.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._worktree_gc import worktree_gc
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], capture_output=True, check=True)
+
+
+@pytest.fixture
+def todo_store(tmp_path: Path, env_save_restore) -> Path:
+    """Redirect scitex-todo to a temp store for this whole module.
+
+    The alarm rides --apply by default; a test must never write to the
+    operator's real board. Env redirect (not a mock) — the same mechanism
+    the fleet uses, and it resolves at call time.
+    """
+    store = tmp_path / "tasks.yaml"
+    env_save_restore.set("SCITEX_TODO_TASKS_YAML_SHARED", str(store))
+    return store
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A real git repo on develop with one commit."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "develop")
+    _git(root, "config", "user.email", "gc-cli-test@example.invalid")
+    _git(root, "config", "user.name", "GC CLI Test")
+    (root / "README.md").write_text("seed\n")
+    _git(root, "add", "README.md")
+    _git(root, "commit", "-qm", "seed")
+    return root
+
+
+@pytest.fixture
+def worktree(repo: Path, tmp_path: Path):
+    """Factory: a real worktree on an ancestor-merged branch (no gh needed)."""
+
+    def _add(name: str) -> Path:
+        path = tmp_path / "worktrees" / name
+        _git(repo, "worktree", "add", "-q", "-b", f"feat/{name}", str(path), "develop")
+        return path
+
+    return _add
+
+
+# ---------------------------------------------------------------------------
+# Dry-run is the default and removes NOTHING
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_reports_the_reapable_worktree(repo, worktree, todo_store):
+    # Arrange — a clean, merged worktree; --min-age-hours 0 clears the age gate.
+    path = worktree("reapable")
+    # Act
+    result = CliRunner().invoke(
+        worktree_gc, ["--repo", str(repo), "--min-age-hours", "0", "--no-alarm"]
+    )
+    # Assert
+    assert "would remove" in result.output
+
+
+def test_dry_run_leaves_the_worktree_on_disk(repo, worktree, todo_store):
+    # Arrange — the report is a claim; the directory is the fact.
+    path = worktree("reapable")
+    # Act
+    CliRunner().invoke(
+        worktree_gc, ["--repo", str(repo), "--min-age-hours", "0", "--no-alarm"]
+    )
+    # Assert
+    assert path.is_dir()
+
+
+def test_dry_run_says_it_removed_nothing(repo, worktree, todo_store):
+    # Arrange — never silent: a dry run must SAY it was a dry run.
+    worktree("reapable")
+    # Act
+    result = CliRunner().invoke(
+        worktree_gc, ["--repo", str(repo), "--min-age-hours", "0", "--no-alarm"]
+    )
+    # Assert
+    assert "nothing was removed" in result.output
+
+
+def test_dry_run_exits_zero_when_under_cap(repo, worktree, todo_store):
+    # Arrange
+    worktree("reapable")
+    # Act
+    result = CliRunner().invoke(
+        worktree_gc, ["--repo", str(repo), "--min-age-hours", "0", "--no-alarm"]
+    )
+    # Assert
+    assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# --apply acts
+# ---------------------------------------------------------------------------
+
+
+def test_apply_removes_the_reapable_worktree(repo, worktree, todo_store):
+    # Arrange — the one case where deleting is right.
+    path = worktree("reapable")
+    # Act
+    CliRunner().invoke(
+        worktree_gc,
+        ["--repo", str(repo), "--apply", "--min-age-hours", "0", "--no-alarm"],
+    )
+    # Assert
+    assert not path.exists()
+
+
+def test_apply_keeps_the_dirty_worktree(repo, worktree, todo_store):
+    # Arrange — merged + old, but dirty. --apply must not touch it.
+    path = worktree("dirty")
+    (path / "README.md").write_text("uncommitted\n")
+    # Act
+    CliRunner().invoke(
+        worktree_gc,
+        ["--repo", str(repo), "--apply", "--min-age-hours", "0", "--no-alarm"],
+    )
+    # Assert
+    assert (path / "README.md").read_text() == "uncommitted\n"
+
+
+def test_apply_names_the_keep_reason(repo, worktree, todo_store):
+    # Arrange — "kept" alone is useless; WHY is the product.
+    path = worktree("dirty")
+    (path / "README.md").write_text("uncommitted\n")
+    # Act
+    result = CliRunner().invoke(
+        worktree_gc,
+        ["--repo", str(repo), "--apply", "--min-age-hours", "0", "--no-alarm"],
+    )
+    # Assert
+    assert "dirty" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Exit codes — the cron-facing contract
+# ---------------------------------------------------------------------------
+
+
+def test_over_cap_exits_non_zero(repo, worktree, todo_store):
+    # Arrange — one dirty survivor against a cap of 0. An alarm that exits
+    # 0 on sprawl is a report nobody reads.
+    path = worktree("dirty")
+    (path / "README.md").write_text("uncommitted\n")
+    # Act
+    result = CliRunner().invoke(
+        worktree_gc,
+        ["--repo", str(repo), "--cap", "0", "--min-age-hours", "0", "--no-alarm"],
+    )
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_unreadable_repo_exits_two(tmp_path, todo_store):
+    # Arrange — unknown OUTRANKS over-cap: it is a known-bad you cannot see.
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    # Act
+    result = CliRunner().invoke(worktree_gc, ["--repo", str(plain), "--no-alarm"])
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_unreadable_repo_is_labelled_unknown(tmp_path, todo_store):
+    # Arrange — "could not read" must never render as "clean".
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    # Act
+    result = CliRunner().invoke(worktree_gc, ["--repo", str(plain), "--no-alarm"])
+    # Assert
+    assert "UNKNOWN" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Usage guards
+# ---------------------------------------------------------------------------
+
+
+def test_repo_and_all_together_is_a_usage_error(repo, todo_store):
+    # Arrange
+    # Act
+    result = CliRunner().invoke(worktree_gc, ["--repo", str(repo), "--all"])
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_neither_repo_nor_all_is_a_usage_error(todo_store):
+    # Arrange
+    # Act
+    result = CliRunner().invoke(worktree_gc, [])
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_apply_with_dry_run_is_a_usage_error(repo, todo_store):
+    # Arrange — opposites. Silently preferring one would be a coin flip on
+    # whether the run destroys anything.
+    # Act
+    result = CliRunner().invoke(
+        worktree_gc, ["--repo", str(repo), "--apply", "--dry-run"]
+    )
+    # Assert
+    assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# --json
+# ---------------------------------------------------------------------------
+
+
+def test_json_output_carries_the_exit_code(repo, worktree, todo_store):
+    # Arrange — cron reads the JSON; it must agree with the exit code.
+    path = worktree("dirty")
+    (path / "README.md").write_text("uncommitted\n")
+    # Act
+    result = CliRunner().invoke(
+        worktree_gc,
+        [
+            "--repo",
+            str(repo),
+            "--cap",
+            "0",
+            "--min-age-hours",
+            "0",
+            "--no-alarm",
+            "--json",
+        ],
+    )
+    # Assert
+    assert json.loads(result.output)["exit_code"] == 1
+
+
+def test_json_output_reports_the_keep_reasons(repo, worktree, todo_store):
+    # Arrange
+    path = worktree("dirty")
+    (path / "README.md").write_text("uncommitted\n")
+    # Act
+    result = CliRunner().invoke(
+        worktree_gc,
+        ["--repo", str(repo), "--min-age-hours", "0", "--no-alarm", "--json"],
+    )
+    # Assert
+    assert json.loads(result.output)["repos"][0]["keep_reasons"] == {"dirty": 1}
+
+
+def test_json_dry_run_reports_zero_removed(repo, worktree, todo_store):
+    # Arrange
+    worktree("reapable")
+    # Act
+    result = CliRunner().invoke(
+        worktree_gc,
+        ["--repo", str(repo), "--min-age-hours", "0", "--no-alarm", "--json"],
+    )
+    # Assert
+    assert json.loads(result.output)["removed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# The alarm rail's CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_writes_no_card_by_default(repo, worktree, todo_store):
+    # Arrange — a dry run is a REPORT; it must not mutate the board. Note
+    # no --no-alarm here: this pins the DEFAULT.
+    path = worktree("dirty")
+    (path / "README.md").write_text("uncommitted\n")
+    # Act
+    CliRunner().invoke(
+        worktree_gc, ["--repo", str(repo), "--cap", "0", "--min-age-hours", "0"]
+    )
+    # Assert
+    assert not todo_store.exists()
+
+
+def test_apply_over_cap_writes_a_card(repo, worktree, todo_store):
+    # Arrange — the scheduled path: --apply alarms by default, so the
+    # sprawl the GC could NOT fix reaches a surface the operator watches.
+    path = worktree("dirty")
+    (path / "README.md").write_text("uncommitted\n")
+    # Act
+    CliRunner().invoke(
+        worktree_gc,
+        ["--repo", str(repo), "--apply", "--cap", "0", "--min-age-hours", "0"],
+    )
+    # Assert
+    scitex_todo = pytest.importorskip("scitex_todo")
+    assert len(scitex_todo.list_tasks(str(todo_store), blocking_me=True)) == 1

--- a/tests/scitex_agent_container/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/test__jobs_plugin.py
@@ -37,14 +37,15 @@ def _job(name: str):
     return match
 
 
-def test_provider_returns_two_jobs() -> None:
-    # Arrange — call the registered provider. Two: accounts-refresh and the
-    # host-sync-check drift alarm. `sac listen` is still NOT federated (see
-    # the module docstring and the absence-pin below).
+def test_provider_returns_three_jobs() -> None:
+    # Arrange — call the registered provider. Three: accounts-refresh, the
+    # host-sync-check drift alarm, and the daily worktree GC. `sac listen`
+    # is still NOT federated (see the module docstring and the absence-pin
+    # below).
     # Act
     jobs = provide_jobs()
     # Assert
-    assert len(jobs) == 2
+    assert len(jobs) == 3
 
 
 def test_provider_jobs_are_real_jobspecs() -> None:
@@ -195,3 +196,52 @@ def test_host_sync_check_cadence_is_hourly() -> None:
     job = _job("sac.host-sync-check")
     # Assert
     assert job.on_unit_active_sec == "1h"
+
+
+def test_worktree_gc_job_name_is_package_prefixed() -> None:
+    # Arrange — the daily GC that makes the worktree-sprawl countermeasure
+    # PERIODIC. A GC nobody schedules is a script, not a countermeasure —
+    # which is exactly how one repo reached 105 worktrees.
+    # Act
+    job = _job("sac.worktree-gc")
+    # Assert
+    assert job.name == "sac.worktree-gc"
+
+
+def test_worktree_gc_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer (daily), so kind="timer".
+    # A bad kind makes `ecosystem up` silently drop sac's WHOLE provider.
+    # Act
+    job = _job("sac.worktree-gc")
+    # Assert
+    assert job.kind == "timer"
+
+
+def test_worktree_gc_command_is_the_apply_form() -> None:
+    # Arrange — the scheduled job must ACT, not just report: a timer that
+    # only dry-runs would print a nightly report nobody reads while the
+    # sprawl kept growing. The safety lives in the predicate, not in
+    # withholding --apply.
+    # Act
+    job = _job("sac.worktree-gc")
+    # Assert
+    assert job.command == "sac worktree gc --apply --all"
+
+
+def test_worktree_gc_command_sweeps_every_declared_repo() -> None:
+    # Arrange — --all is only correct because it HAS a clean source (every
+    # agent spec.workdir that is a local git repo toplevel). If that source
+    # ever disappears, this command silently sweeps nothing.
+    # Act
+    job = _job("sac.worktree-gc")
+    # Assert
+    assert "--all" in job.command
+
+
+def test_worktree_gc_cadence_is_daily() -> None:
+    # Arrange — sprawl accumulates over days and the age gate is 24h, so a
+    # faster pass could not remove anything a daily one would miss.
+    # Act
+    job = _job("sac.worktree-gc")
+    # Assert
+    assert job.on_unit_active_sec == "1d"


### PR DESCRIPTION
Closes the P1 on card `incident-worktree-sprawl-permanent-gc-20260710`.

Agent-tool isolation worktrees auto-clean **only when nothing edited them**. Anything an agent actually TOUCHED persisted forever: no periodic GC, no cap, no alarm existed anywhere. One repo reached **105 worktrees** and helped trigger a host load-spike. This is the permanent countermeasure.

> **I have NOT run this against any real repo.** Every test builds throwaway temp repos; the dry-run sample below is a purpose-built fixture. The first live run is yours.

## The safety predicate — the whole point

A worktree is removed **iff ALL FOUR** hold:

| leg | passes when | on doubt |
|---|---|---|
| **CLEAN** | `git status --porcelain` empty — **untracked counts as DIRTY** | KEEP |
| **MERGED** | ancestor of `develop`/`main`, **OR** a merged PR exists for the branch | KEEP |
| **OLD** | HEAD commit older than `--min-age-hours` (default 24) | KEEP |
| **IDLE** | no running process has its cwd inside (best-effort `/proc` scan) | KEEP |

Every leg is **three-state**: a check that could not RUN keeps the worktree, exactly like a check that failed. "I could not look" never collapses into "I looked and it was fine". A false KEEP leaves a stale directory (annoying — and the cap alarm shouts about it); a false REMOVE destroys work saved nowhere else. We pick annoying.

Two details that are load-bearing, not incidental:

- **Untracked = DIRTY.** Untracked work exists nowhere else; it is the most expensive thing in the tree, not the cheapest.
- **MERGED needs both styles.** A squash-merged branch is *not* an ancestor of its base — the ancestor check alone would call every squash-merged branch "unmerged" forever, and a squash-merging repo would never be GC'd at all. The `gh pr list --head <branch> --state merged` lookup covers it, behind an injectable seam (tests need no network), and answers `None` → KEEP on any doubt.

**Removal is `git worktree remove` with NO `--force`** — git's own dirty-refusal is a second, independent implementation of the CLEAN leg, the only check here we did not write ourselves. A test pins the absence. `git worktree prune` is the separate always-safe half (admin refs whose directory is already gone — destroys no files by construction) and only *reports* on a dry run.

**`--dry-run` is the DEFAULT.** A GC whose default is destructive gets run destructively by accident exactly once.

## Cap + alarm

After a pass, a repo still over `--cap` (default 20) upserts an idempotent scitex-todo card (`worktree-sprawl-<repo>`, `blocked`/`operator-decision`) naming the repo, the count, and the **kept-reasons breakdown** — resolved when it drops back under; UNREADABLE repos get an UNKNOWN card, never a clean one. The reaping is the easy half; *shouting about what the predicate refused to touch* is what prevents the incident. Delivery is a side rail: a board-write failure prints loudly and never crashes the GC.

## Timer (enable is operator-side)

JobSpec `sac.worktree-gc`, `kind="timer"`, daily, command **`sac worktree gc --apply --all`**. `--all` is correct as written: it sweeps every local git-repo toplevel declared as an agent's `spec.workdir` (sac's own spec tree is the source, so it cannot drift from a second registry).

```bash
scitex-dev ecosystem systemd install --name sac.worktree-gc --yes
systemctl --user daemon-reload
systemctl --user enable --now sac.worktree-gc.timer
```

(The **scitex-dev** verb, not sac's own `sac dev systemd install` wrapper — that queries a dead kind and is broken; carded separately.)

Look before enabling — the default removes nothing:
```bash
sac worktree gc --all
```

## Dry-run sample (throwaway fixture repo, cap deliberately set to 2)

```
sac worktree gc  dry-run (read-only) — 1 repo(s)

OVER CAP  /tmp/…/demo-repo  4 worktree(s), cap 2
    kept       /tmp/…/wt/dirty  (dirty)
    would remove /tmp/…/wt/reapable
    kept       /tmp/…/wt/untracked  (dirty)
    kept       /tmp/…/wt/vanished  (missing)
    kept-reasons: 2 dirty, 1 missing
    prune: Removing worktrees/vanished: gitdir file points to non-existent location

1 repo(s) still over cap: /tmp/…/demo-repo
  Every kept worktree failed at least one safety leg (see the
  kept-reasons above). The GC will NEVER auto-remove those — a
  human decides. Dirty worktrees hold work that exists nowhere else.
dry-run: nothing was removed. Re-run with --apply to act.
1 repo(s), 0 removed, 4 kept, 1 OVER CAP
exit=1
```
All three surviving directories were still on disk afterwards (asserted, not eyeballed).

## Two bugs found by measuring instead of assuming

- `git worktree prune --verbose` writes its report to **stderr** even on success → the stdout-only read returned `""` and the pass "reported" a prune it could not evidence. Fixed via `run_git(merge_stderr=True)`.
- Without `--verbose`, prune prints **nothing at all** — the silent green line this GC exists to kill. Both are now pinned by tests.

## Tests — 96 passing, no mocks

Real temp git repos, real `git worktree add`, and a **real child process** (`sleep` with cwd inside) for the in-use leg. Only the merged-PR lookup and the `/proc` scan are injected, so the suite needs no network.

**Each safety leg was mutation-tested** — break the leg, confirm its guarding test goes red — because a test that cannot fail is decoration, not evidence:

| mutation | result |
|---|---|
| CLEAN leg disabled | `test_dirty_worktree_is_kept`, `test_untracked_only_worktree_is_kept` FAILED |
| IDLE leg disabled | `test_in_use_worktree_survives_on_disk`, `test_unavailable_cwd_signal_keeps_the_worktree` FAILED |
| MERGED leg always-true | `test_unknown_merge_state_keeps_the_worktree`, `test_raising_pr_seam_keeps_the_worktree` FAILED |
| AGE leg disabled | `test_too_young_worktree_is_kept` FAILED |
| restored | 31 passed |

## Honest gaps

- **The `/proc` scan can under-report** (documented, not hidden): another user's process, another PID namespace (a container that bind-mounts the worktree), or a process holding an open *file* without chdir'ing are all invisible. That is why it is one leg of four — a worktree that survives the other three and merely looks idle is by construction clean, merged, and a day old, so removing it costs a re-checkout, not work. Signal unavailable → KEEP.
- **`--all` never sees a repo no agent spec declares.** Narrow and honest: sprawl comes from agent tools, and agent tools run in agent workdirs. Use `--repo` for anything else.
- **Never touched**: the main worktree, bare repos, locked worktrees, and any repo not declared/named.
- **Card-id collision by design**: keyed on repo *basename*, so two checkouts of the same repo share one card (the note carries the full path).
- **Docs are a standalone page** (`docs/worktree-gc.md`) rather than a section in `scripts/systemd/README.md` where the sibling timers live: that file already sits exactly at the repo's 512-line cap, so adding to it would force an unrelated refactor into this PR.
- **Pre-existing, not mine**: `tests/scitex_agent_container/cli_pkg/test__main.py` has 5 failing `install-shell-completion` tests. Verified against pristine develop with my work stashed — the same 5 fail. Untouched here.
- `_jobs_plugin.py` diff is **additive** (one JobSpec + its docstring bullet; the "Two jobs"→"Three jobs" count word is the only edited line) so the sibling PR merges trivially. `cli_pkg/_host_push_config.py` and `_hostsync/*` were **not touched**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
