### PR TITLE
fix(tests): develop RED — join wedged threads so a straggler decrement cannot cross into the next test

### DIFF
--- a/tests/scitex_agent_container/_lifecycle/test__off_loop.py
+++ b/tests/scitex_agent_container/_lifecycle/test__off_loop.py
@@ -55,17 +55,30 @@ async def _abandon_a_pools_worth(wedge) -> None:
 def wedge():
     """A callable that blocks until the test releases it. Always released."""
     released = threading.Event()
+    blocked: list[threading.Thread] = []
 
     def blocker() -> str:
+        blocked.append(threading.current_thread())
         released.wait()
         return "unblocked"
 
     try:
         yield blocker
     finally:
-        # Let every abandoned daemon thread exit instead of leaking into
-        # the rest of the session.
+        # Release AND JOIN every abandoned daemon thread before the next test
+        # observes the gauge. `set()` alone only SIGNALS: an abandoned thread
+        # calls _clear_abandoned() (a DECREMENT) on its way out, whenever it
+        # next gets scheduled. `_abandon_a_pools_worth` leaves a pool's worth
+        # of them, so under CI load those decrements land inside the NEXT
+        # test's measurement window and silently eat one of its marks --
+        # `assert abandoned_call_count() == before + 3` fails as 3 == (1 + 3).
         released.set()
+        for thread in blocked:
+            thread.join(timeout=5)
+            assert not thread.is_alive(), (
+                "a released wedge thread never exited; it would decrement the "
+                "abandoned gauge inside a later test"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -227,6 +240,7 @@ async def test_abandoned_call_count_reports_the_wedged_calls(wedge):
 @pytest.mark.asyncio
 async def test_cancellation_is_never_swallowed_by_the_deadline_wait():
     """A cancelled `run_blocking` caller must STOP — not keep looping."""
+
     # Arrange — a poll loop shaped exactly like the real background loops:
     # a fast off-loop call, then a short sleep, forever.
     async def poll_loop() -> None:


### PR DESCRIPTION
## develop is RED, and this is the fix

`develop` went red at **a6bd10fc** — the #721 merge, which I landed. It was green through the five merges before it:

```
failure   a6bd10fc 11:05   <- #721 merge (mine)
success   78fcabcf 09:40
success   3803cd35 09:29
success   674e6022 09:10
success   54dd6ba0 09:03
success   408d3cb4 03:31
```

#721's own PR CI was all-green. I merged on that and did not check post-merge CI — the PR-green/merge-red gap. Per the constitution a red CI is a drift detector turned off, so this is P1.

## It is not #721's bug

#721 added ~100 tests, which changed xdist's distribution and surfaced a race that **predates it**. The race has always been there; the test only ever passed by luck.

## Root cause

The abandoned gauge is **live, not monotonic**. `_mark_abandoned()` increments, `_clear_abandoned()` **decrements** — and the decrement runs *inside the worker daemon thread* on its way out:

```python
def _runner() -> None:
    result = fn(*args, **kwargs)      # blocks on released.wait()
    ...
    if was_abandoned:
        _clear_abandoned()            # <- decrement, in the thread
```

`wedge`'s teardown did:

```python
finally:
    # Let every abandoned daemon thread exit instead of leaking into
    # the rest of the session.
    released.set()
```

That comment states the right intent, but `set()` only **signals**. It never waits. Each released thread decrements whenever it is next scheduled — and `_abandon_a_pools_worth` leaves a pool's worth (~36) of them. Those decrements drain into whatever test runs **next**.

`test_abandoned_call_count_reports_the_wedged_calls` reads `before = abandoned_call_count()` and asserts `== before + 3`. When the prior test's threads are still draining, `before` captures the undrained remainder, and the stragglers land inside the measurement window and eat its own marks:

```
assert 3 == (1 + 3)      CI      (drain nearly complete when `before` was read)
assert 3 == (36 + 3)     repro   (drain barely started)
```

Both land on `3` — all that survives is the test's own marks. The test passed only when the previous test's threads happened to fully drain first: true for a 9-test local run, false on a loaded CI worker.

## The fix

Release **and join**. This delivers what the fixture's comment already claimed. The join is fail-loud — a thread still alive afterward would decrement inside a later test, which is the bug itself, not a nit.

## Evidence (watch-it-fail, against the real module)

| | result |
|---|---|
| pre-fix (`set()` only) | **8/8 FAILED** — `before=36 got=3 want=39` |
| with fix (`set()` + join) | **0/8 FAILED** — `before=0`, deterministic |

Full `_lifecycle` suite with the fix: **1044 passed**.

`before=0` in 8/8 also rules out the one hole I could see in my own fix — threads are tracked from inside `blocker()`, so a call abandoned before its thread entered would escape the join. Had that happened, `before` would be non-zero sometimes. It never was.

## Method note

My first two diagnoses were both wrong, and worth recording. I grepped the counter with a `= 0` pattern, which **structurally cannot match `-= 1`** — so it hid the decrement and could not have disagreed with me. The docstring ("calls whose thread is **STILL** running") was the tell, and I read past it twice. The arithmetic is what finally broke the theory: a monotonic counter cannot produce a result *lower* than `before + 3`.
