### PR TITLE
ci: pin uv — all 6 setup-uv call sites installed unpinned `latest` (random red)

### DIFF
--- a/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
+++ b/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
@@ -54,6 +54,9 @@ jobs:
 
       - uses: astral-sh/setup-uv@v3
         with:
+          # PINNED: unpinned `latest` made CI a function of wall-clock
+          # time and runner cache state. See sac-ci-pin-uv-version-*.
+          version: "0.11.29"
           cache-dependency-glob: pyproject.toml
 
       - name: Install from source (no extras)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,6 +57,9 @@ jobs:
 
       - uses: astral-sh/setup-uv@v3
         with:
+          # PINNED: unpinned `latest` made CI a function of wall-clock
+          # time and runner cache state. See sac-ci-pin-uv-version-*.
+          version: "0.11.29"
           cache-dependency-glob: pyproject.toml
 
       - name: Ruff check

--- a/.github/workflows/newb-docs-quality-on-ubuntu-latest.yml
+++ b/.github/workflows/newb-docs-quality-on-ubuntu-latest.yml
@@ -78,6 +78,9 @@ jobs:
       - uses: astral-sh/setup-uv@v3
         if: steps.guard.outputs.enabled == 'true'
         with:
+          # PINNED: unpinned `latest` made CI a function of wall-clock
+          # time and runner cache state. See sac-ci-pin-uv-version-*.
+          version: "0.11.29"
           cache-dependency-glob: pyproject.toml
 
       - name: Put the Spartan apptainer shim on PATH

--- a/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
+++ b/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
@@ -47,6 +47,9 @@ jobs:
       # the only thing that works there. The guard needs nothing but PyYAML.
       - uses: astral-sh/setup-uv@v3
         with:
+          # PINNED: unpinned `latest` made CI a function of wall-clock
+          # time and runner cache state. See sac-ci-pin-uv-version-*.
+          version: "0.11.29"
           cache-dependency-glob: pyproject.toml
 
       - name: Guard — no GitHub-hosted runners

--- a/.github/workflows/quality-audit-on-ubuntu-latest.yml
+++ b/.github/workflows/quality-audit-on-ubuntu-latest.yml
@@ -51,6 +51,9 @@ jobs:
 
       - uses: astral-sh/setup-uv@v3
         with:
+          # PINNED: unpinned `latest` made CI a function of wall-clock
+          # time and runner cache state. See sac-ci-pin-uv-version-*.
+          version: "0.11.29"
           cache-dependency-glob: pyproject.toml
 
       - name: Install package + scitex-dev audit extras

--- a/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
+++ b/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
@@ -46,6 +46,9 @@ jobs:
 
       - uses: astral-sh/setup-uv@v3
         with:
+          # PINNED: unpinned `latest` made CI a function of wall-clock
+          # time and runner cache state. See sac-ci-pin-uv-version-*.
+          version: "0.11.29"
           cache-dependency-glob: pyproject.toml
 
       - name: Install package + docs deps


### PR DESCRIPTION
ci: pin uv (all 6 setup-uv call sites installed unpinned `latest`)

develop went red on `lint` + `import-smoke` at 44e362a1 while tests / quality /
docs / no-hosted-runners passed the SAME commit, and a re-run of identical code
went green. It was never a code failure. The failing step is
`Run astral-sh/setup-uv@v3`, which executes BEFORE any repo code:

    Downloading uv from ".../releases/latest/download/uv-x86_64-unknown-linux-gnu.tar.gz"
    tar xz -C .../_work/_temp/<uuid> -f .../_work/_temp/<uuid>
    ##[error]ENOENT: copyfile '.../_temp/<uuid>/uv-x86_64-unknown-linux-gnu/uv'
                            -> '/home/ywatanabe/.runner-toolcache/uv/0.11.29/x86_64/uv'

None of the 6 call sites passed `version:`, so every one installed uv **latest**.
That makes CI a function of wall-clock time and runner cache state: a job's
outcome depends on which uv is current and whether that runner's toolcache is
warm. Same disease as depending on git@develop instead of a pinned release.

Pinned to 0.11.29 — the version CI already resolves — so this changes nothing
except making it deterministic.

Ruled OUT, with evidence, so nobody re-litigates it: this is NOT the punim0264
revocation, despite the runner paths sitting inside that project.
  * The copy DESTINATION (~/.runner-toolcache) is punim2354-owned and readable
    by fresh processes (verified by scitex-hpc).
  * ENOENT is a missing SOURCE. A permission wall gives EACCES.
  * The failing runner demonstrably tar'd INTO _work/_temp under punim0264, so
    it was not walled off.

Also ruled out: a per-fleet or per-runner property. Correlating runner_name
across attempts kills that story outright —

    lint          A1 FAILURE :: spartan-cpu-org-01        A2 SUCCESS :: spartan-cpu-org-02
    import-smoke  A1 FAILURE :: scitex-agent-container-02 A2 SUCCESS :: spartan-cpu-org-01

spartan-cpu-org-01 both FAILED and PASSED, and red hit BOTH the org pool and a
repo-level runner. So it is transient, not configuration.

The pin is sufficient on its own to stop this class of red. A remaining
hypothesis (NOT established, and not fixed here): the toolcache path is on
SHARED storage, so concurrent jobs may race to populate the same
`uv/<version>/x86_64/` directory. If the pooled fleet does not export a
node-local RUNNER_TOOL_CACHE, that race is possible. That half is Spartan-side
and belongs to scitex-hpc; raised with them.

Deliberately NOT bundled: bumping setup-uv@v3 -> v5 (would also clear the
Node20-deprecation warning in the same log). That is a behaviour change and
does not belong in a red-CI fix.

Verified by PARSING, not grepping: all 9 workflows yaml.safe_load clean, and
every setup-uv step resolves version='0.11.29' through the parser — so the key
is provably inside the right `with:` block, not merely present in the text.
