### PR TITLE
feat(jobs): inert-feature detector — fail LOUD when a declaration has no live counterpart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,71 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Inert-feature detector (`_jobs_audit`) — a declaration with no live
+  counterpart now fails a REQUIRED gate.** Four features shipped in one night
+  (2026-07-17) with PRs, tests and ADRs, and none of them ever executed:
+  `sac agents twin` (every derived spec unloadable), the auth `screen` verdict
+  (computed, persisted nowhere), `restart.policy` (no enforcer in ~93 specs),
+  and `auto-merge-to-develop` (0 runs since 07-09). `_jobs_plugin.py`'s own
+  docstring had already named the pathology — *"shipped but scheduled nowhere,
+  it was an inert alarm"* — which is the point: we diagnosed it in a comment
+  and kept doing it. A postmortem in a comment is not a countermeasure.
+
+  The detector checks two half-pair forms deterministically and reports three
+  states (`LIVE` / `INERT` / **`UNKNOWN`** — "I cannot tell" is never "inert",
+  because a false INERT that gets a working feature deleted is worse than the
+  disease):
+  - a JobSpec declared but unreachable via the real `discover_jobs()` — which
+    swallows a raising provider with a mere `logging.warning`, so ONE bad spec
+    silently drops all four of sac's timers;
+  - a declared `kind` no consumer can see, or a consumer filtering on a kind
+    outside `ALLOWED_KINDS` (one that can never match anything, ever).
+
+  It runs in `pytest-matrix-on-ubuntu-py{3.11,3.12,3.13}`, a required status
+  check on `develop` and `main` — deliberately NOT in `quality-audit`, whose
+  every step is `continue-on-error: true` and therefore could never go red. A
+  checker nobody runs is just the fifth instance of the disease.
+
+  NOT covered, stated plainly: declared-vs-**deployed** (whether a timer is
+  actually installed and enabled on the fleet host) is unanswerable from CI —
+  the suite runs in a SIF with no access to the host's `systemctl --user`, and
+  answering it from the JobSpec *source* is the exact trap that produced a P0
+  diagnosis off a 4-day-stale schedule. Out of scope beats answered wrongly.
+
+### Fixed
+
+- **Every `sac dev` job verb was inert, and had been for weeks.**
+  `_dev_jobs.py` passed the CLI GROUP NAME straight through as the JobSpec
+  KIND filter, so `sac dev systemd list` asked for `kind="systemd"` — a value
+  `JobSpec.validate()` rejects at construction (`ALLOWED_KINDS` is
+  `{service,timer,cron}` since scitex-dev #153). All four of sac's real timers
+  are `kind="timer"`, so the command printed "No sac systemd-kind jobs." and
+  exited 0, forever. `sac dev daemon` was deader still: it filtered a
+  never-legal kind AND delegated to `scitex-dev ecosystem daemon`, which is
+  not an `ecosystem` subcommand at all. The group is removed; a long-running
+  job is `kind="service"`, installed via the `systemd` group.
+
+  The group→kind mapping is now `GROUP_KINDS`, a module-level SSOT that
+  mirrors scitex-dev's own selection (`_jobs_cron.py` takes `cron`;
+  `_jobs_systemd.py` takes `timer` + `service`), and the audit IMPORTS it
+  rather than restating it — a checker that asserts its own opinion of what
+  production ought to do is itself a dangling declaration.
+  (Card `sac-dev-systemd-group-queries-dead-kind-20260716`, found 2026-07-16
+  by watching it fail in production, deferred with a workaround; `docs/
+  worktree-gc.md` had been telling operators to route around the broken
+  wrapper.)
+
+- **The fixture that hid it.** `test__dev_jobs.py` installed a hand-rolled
+  fake `scitex_dev.jobs` whose `_Job` dataclass defaulted to `kind="systemd"`
+  — a shape no real JobSpec can have — so 13 tests asserted in green that
+  `sac dev systemd list` shows `sac.accounts-refresh` while production showed
+  nothing. Identical in kind to the twin suite's 29 green tests over a
+  `spec.env` shape v3 validation rejects. The tests now drive the REAL
+  `scitex_dev.jobs` with REAL `JobSpec` objects, and skip rather than invent a
+  stand-in when the contract is absent.
+
 ## [0.21.22] - 2026-07-17
 
 **The version number was itself the bug.** develop carried 21 merged PRs

--- a/README.md
+++ b/README.md
@@ -275,9 +275,8 @@ sac mcp list-tools                        # MCP introspection
 sac skills list / get                     # bundled agent-facing skills
 
 # Federated scheduled jobs (delegates to scitex-dev ecosystem)
-sac dev systemd list / install / uninstall    # generate ~/.config/systemd/user/sac.*
-sac dev cron    list / install / uninstall    # crontab entries
-sac dev daemon  list / install / uninstall    # interactive daemons
+sac dev systemd list / install / uninstall    # kind=timer|service -> ~/.config/systemd/user/sac.*
+sac dev cron    list / install / uninstall    # kind=cron -> crontab entries
 
 # State db / registry / events
 sac db query / show / clean / export / import / migrate / tick   # state.db inspection

--- a/docs/worktree-gc.md
+++ b/docs/worktree-gc.md
@@ -150,11 +150,13 @@ how the sprawl accumulated.
 Sprawl accumulates over days and the age gate is 24h, so a faster cadence
 could not remove anything a daily pass would miss.
 
-Install (operator-side). Use the **scitex-dev** verb directly — sac's own
-`sac dev systemd install` wrapper is currently broken (it queries a dead
-kind; carded separately):
+Install (operator-side). sac's own wrapper works again — it used to query
+a dead kind (`jobs_of_kind("systemd")`) and report "No sac systemd-kind
+jobs to install." forever, so this page told you to route around it. Both
+forms below are equivalent; the wrapper just filters `sac.*` for you:
 
 ```bash
+sac dev systemd install --yes                 # or, equivalently:
 scitex-dev ecosystem systemd install --name sac.worktree-gc --yes
 systemctl --user daemon-reload
 systemctl --user enable --now sac.worktree-gc.timer

--- a/src/scitex_agent_container/_jobs_audit.py
+++ b/src/scitex_agent_container/_jobs_audit.py
@@ -1,0 +1,342 @@
+"""Inert-feature detector — a DECLARATION with no LIVE counterpart.
+
+The pathology this module exists to make LOUD, in its own words from
+``_jobs_plugin.provide_jobs``: *"shipped but scheduled nowhere, it was an
+inert alarm."* We diagnosed it once, in a comment, and kept doing it. A
+postmortem in a comment is not a countermeasure — this is.
+
+The shape is always a DANGLING HALF-PAIR: something is declared, and the
+counterpart that would make the declaration DO anything does not exist.
+Four measured instances in one night (2026-07-17), each with a PR, tests,
+and often an ADR — none of which ever ran:
+
+1. ``sac agents twin`` — ``derive_twin_spec`` wrote ``spec.env`` at top
+   level, which v3 validation REJECTS, so no twin ever started. 29 green
+   tests, because the FIXTURE used a spec shape no real spec has and the
+   suite never ran the validator.
+2. ``auth-heal`` computes a ``screen`` verdict and persists it nowhere, so
+   presence-ALIVE always wins and a dead agent reads healthy.
+3. ``restart.policy`` is a spec field with no enforcer in ~93 specs.
+4. ``auto-merge-to-develop`` never FAILED; it was never TRIGGERED.
+
+Why the checker lives in the test suite, not in a new mechanism
+===============================================================
+A checker THAT NOBODY RUNS is the fifth instance of the very disease. So
+this module is consumed by ``tests/scitex_agent_container/
+test__jobs_audit.py``, which runs in ``pytest-matrix-on-ubuntu-py*`` — a
+REQUIRED status check on both ``develop`` and ``main``. It is deliberately
+NOT wired into ``quality-audit-on-ubuntu-latest.yml``: every step there is
+``continue-on-error: true``, so a checker hung off it could never go red,
+which is precisely how you ship instance #5 with a straight face.
+
+Three states, never two
+=======================
+:class:`Verdict` has LIVE / INERT / **UNKNOWN**. "I cannot tell whether a
+counterpart exists" is UNKNOWN — never INERT. A false INERT that gets
+someone to delete a working feature is worse than the disease it claims to
+cure. Only positive evidence of NO counterpart yields INERT.
+
+What this module covers — and what it does NOT
+==============================================
+COVERED, deterministically, from the repo tree alone:
+
+* :data:`Form.DISCOVERY` — a JobSpec sac declares that the REAL
+  ``discover_jobs()`` cannot reach. ``discover_jobs`` swallows a raising
+  provider with only a ``logging.warning``, so one bad JobSpec silently
+  drops sac's ENTIRE provider — all four timers vanish and nothing turns
+  red. That is instance-shaped and invisible today.
+* :data:`Form.CONSUMER` — a ``kind`` sac declares that no ``sac dev``
+  consumer group can ever list, and a consumer group that filters on a
+  ``kind`` outside ``ALLOWED_KINDS`` (i.e. one that can never match
+  anything, ever).
+
+NOT COVERED — stated plainly, because a checker that silently covers less
+than it appears to is the same disease wearing a lab coat:
+
+* **Declared vs DEPLOYED.** Whether ``sac.fleet-reconcile`` is an
+  installed, enabled, running systemd ``--user`` timer on the fleet host
+  is the question behind instances 2 and 3, and it is STRUCTURALLY
+  unanswerable from CI: the suite runs in a SIF on a Spartan node that has
+  no access to the fleet host's ``systemctl --user``. Answering it from
+  the JobSpec SOURCE instead is the exact trap that produced a P0
+  diagnosis off a 4-day-stale schedule (source said ``0 */2 * * *`` while
+  the deployed unit said ``OnUnitActiveSec=10min``). So this module does
+  not guess: the deployed axis is simply out of scope here rather than
+  answered wrongly.
+* **Workflow triggers** (instance 4) and **spec-shape validation**
+  (instance 1) — other owners are live on those files.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Verdict(str, Enum):
+    """Three states. UNKNOWN is not a soft INERT — it is a refusal to guess."""
+
+    LIVE = "live"
+    INERT = "inert"
+    UNKNOWN = "unknown"
+
+
+class Form(str, Enum):
+    """The half-pair shapes this module can check deterministically."""
+
+    DISCOVERY = "declared-job-unreachable-by-discover_jobs"
+    CONSUMER = "declared-kind-has-no-consumer"
+    IMPOSSIBLE_KIND = "consumer-filters-on-an-impossible-kind"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One declared capability and the verdict on its live counterpart."""
+
+    form: Form
+    subject: str
+    verdict: Verdict
+    detail: str
+
+    def __post_init__(self) -> None:
+        # Validate at construction so a malformed finding crashes HERE and
+        # not in a report someone acts on. Same doctrine as JobSpec.
+        if not isinstance(self.form, Form):
+            raise ValueError(f"Finding.form must be a Form, got {self.form!r}")
+        if not isinstance(self.verdict, Verdict):
+            raise ValueError(f"Finding.verdict must be a Verdict, got {self.verdict!r}")
+        if not self.subject:
+            raise ValueError("Finding.subject must be non-empty")
+        if not self.detail:
+            # A verdict with no stated evidence is exactly the
+            # postmortem-in-a-comment this module exists to replace.
+            raise ValueError(
+                f"Finding({self.subject!r}).detail must state the evidence"
+            )
+
+
+@dataclass(frozen=True)
+class InertReport:
+    """The audit result. Fails LOUD via :meth:`render`, never silently."""
+
+    findings: tuple[Finding, ...]
+
+    def __post_init__(self) -> None:
+        if not all(isinstance(f, Finding) for f in self.findings):
+            raise ValueError("InertReport.findings must all be Finding")
+
+    def of(self, verdict: Verdict) -> tuple[Finding, ...]:
+        return tuple(f for f in self.findings if f.verdict is verdict)
+
+    @property
+    def inert(self) -> tuple[Finding, ...]:
+        return self.of(Verdict.INERT)
+
+    @property
+    def unknown(self) -> tuple[Finding, ...]:
+        return self.of(Verdict.UNKNOWN)
+
+    def render(self) -> str:
+        """A report that names each dangling pair and its evidence."""
+        if not self.inert:
+            return "no inert declarations found"
+        lines = [
+            f"{len(self.inert)} DECLARATION(S) WITH NO LIVE COUNTERPART "
+            f"— shipped, but nothing executes them:",
+        ]
+        for f in self.inert:
+            lines.append(f"  [{f.form.value}] {f.subject}")
+            lines.append(f"      {f.detail}")
+        if self.unknown:
+            lines.append(
+                f"  ({len(self.unknown)} UNKNOWN — not enough evidence to "
+                f"call inert; NOT a finding, do not delete anything on it)"
+            )
+        return "\n".join(lines)
+
+
+def audit_discovery(
+    *,
+    declared_names: frozenset[str],
+    discovered_names: frozenset[str] | None,
+) -> tuple[Finding, ...]:
+    """Form DISCOVERY: can the real aggregator reach what we declare?
+
+    ``discovered_names=None`` means discovery could not run at all (an old
+    scitex-dev with no jobs contract, say) — every declaration is then
+    UNKNOWN, because absence of evidence is not evidence of absence.
+    """
+    if discovered_names is None:
+        return tuple(
+            Finding(
+                form=Form.DISCOVERY,
+                subject=name,
+                verdict=Verdict.UNKNOWN,
+                detail=(
+                    "discover_jobs() could not run (no jobs contract "
+                    "installed) — cannot tell if this job is reachable"
+                ),
+            )
+            for name in sorted(declared_names)
+        )
+    return tuple(
+        Finding(
+            form=Form.DISCOVERY,
+            subject=name,
+            verdict=Verdict.LIVE if name in discovered_names else Verdict.INERT,
+            detail=(
+                "reachable via the scitex_dev.jobs entry point"
+                if name in discovered_names
+                else (
+                    "declared by provide_jobs() but ABSENT from "
+                    "discover_jobs() — the entry point is unregistered, or "
+                    "the provider raised and was swallowed by the "
+                    "WARN-only provider isolation, dropping sac's whole "
+                    "provider. Nothing schedules this job."
+                )
+            ),
+        )
+        for name in sorted(declared_names)
+    )
+
+
+def audit_consumers(
+    *,
+    declared_kinds: frozenset[str],
+    group_kinds: dict[str, frozenset[str]],
+    allowed_kinds: frozenset[str],
+) -> tuple[Finding, ...]:
+    """Form CONSUMER / IMPOSSIBLE_KIND: is anything able to read what we declare?
+
+    Two directions, because the pair dangles from either end:
+
+    * a consumer group filtering on a kind outside ``allowed_kinds`` can
+      never match anything — the JobSpec validator rejects that kind at
+      construction, so no such job can exist;
+    * a declared kind no consumer group covers is a job the CLI cannot
+      list, install, or uninstall.
+    """
+    findings: list[Finding] = []
+
+    for group in sorted(group_kinds):
+        impossible = sorted(group_kinds[group] - allowed_kinds)
+        if impossible:
+            findings.append(
+                Finding(
+                    form=Form.IMPOSSIBLE_KIND,
+                    subject=f"sac dev {group}",
+                    verdict=Verdict.INERT,
+                    detail=(
+                        f"filters on kind(s) {impossible} which are not in "
+                        f"ALLOWED_KINDS {sorted(allowed_kinds)} — "
+                        f"JobSpec.validate() rejects them at construction, "
+                        f"so this group can never list a single job"
+                    ),
+                )
+            )
+
+    covered: set[str] = set()
+    for kinds in group_kinds.values():
+        covered |= kinds
+    for kind in sorted(declared_kinds):
+        findings.append(
+            Finding(
+                form=Form.CONSUMER,
+                subject=f"kind={kind}",
+                verdict=Verdict.LIVE if kind in covered else Verdict.INERT,
+                detail=(
+                    "listable by a sac dev group"
+                    if kind in covered
+                    else (
+                        "sac declares job(s) of this kind but no sac dev "
+                        "group filters on it — those jobs cannot be listed, "
+                        "installed or uninstalled through the CLI"
+                    )
+                ),
+            )
+        )
+    return tuple(findings)
+
+
+def _declared_jobs() -> list:
+    from scitex_agent_container._jobs_plugin import provide_jobs
+
+    return list(provide_jobs())
+
+
+def _consumer_group_kinds() -> dict[str, frozenset[str]]:
+    """The kind filter the ``sac dev`` groups ACTUALLY use.
+
+    Imported from the consumer rather than re-declared here, on purpose.
+    A checker that states its own opinion of what the consumer ought to
+    filter on is itself a declaration with no live counterpart — it would
+    stay green while production drifted away underneath it, which is the
+    exact disease this module exists to detect. Read the real thing.
+    """
+    from scitex_agent_container.cli_pkg._dev_jobs import GROUP_KINDS
+
+    return GROUP_KINDS
+
+
+def _discovered_sac_names(prefix: str) -> frozenset[str] | None:
+    try:
+        from scitex_dev.jobs import discover_jobs
+    except ImportError:  # stx-allow: fallback (reason: old scitex-dev has no jobs contract — UNKNOWN, not INERT)
+        return None
+    return frozenset(j.name for j in discover_jobs() if j.name.startswith(prefix))
+
+
+def _allowed_kinds() -> frozenset[str] | None:
+    try:
+        from scitex_dev.jobs import ALLOWED_KINDS
+    except ImportError:  # stx-allow: fallback (reason: old scitex-dev has no jobs contract — UNKNOWN, not INERT)
+        return None
+    return frozenset(ALLOWED_KINDS)
+
+
+def audit_jobs(*, prefix: str = "sac.") -> InertReport:
+    """Run every covered form against the REAL declarations and consumers."""
+    declared = _declared_jobs()
+    declared_names = frozenset(j.name for j in declared)
+    declared_kinds = frozenset(j.kind for j in declared)
+
+    findings: list[Finding] = list(
+        audit_discovery(
+            declared_names=declared_names,
+            discovered_names=_discovered_sac_names(prefix),
+        )
+    )
+
+    allowed = _allowed_kinds()
+    if allowed is None:
+        findings.append(
+            Finding(
+                form=Form.CONSUMER,
+                subject="sac dev job groups",
+                verdict=Verdict.UNKNOWN,
+                detail=(
+                    "ALLOWED_KINDS unavailable (no jobs contract installed) "
+                    "— cannot tell which kinds are legal"
+                ),
+            )
+        )
+    else:
+        findings.extend(
+            audit_consumers(
+                declared_kinds=declared_kinds,
+                group_kinds=_consumer_group_kinds(),
+                allowed_kinds=allowed,
+            )
+        )
+    return InertReport(findings=tuple(findings))
+
+
+__all__ = [
+    "Finding",
+    "Form",
+    "InertReport",
+    "Verdict",
+    "audit_consumers",
+    "audit_discovery",
+    "audit_jobs",
+]

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs.py
@@ -1,25 +1,47 @@
-"""``sac dev {cron,daemon,systemd}`` — sac's federated scheduled jobs.
+"""``sac dev {cron,systemd}`` — sac's federated scheduled jobs.
 
 Surfaces sac's OWN jobs (``sac.*``) by delegating to scitex-dev's
 ecosystem aggregator (``scitex_dev.jobs``).
 
-The verbs per job-kind mirror scitex-dev's canonical ecosystem
-aggregator exactly (``scitex-dev ecosystem <kind> <verb>``):
+The group name is the ``scitex-dev ecosystem <name>`` subcommand we
+delegate to; the KIND is the ``JobSpec.kind`` taxonomy we filter on. They
+are NOT the same axis, and :data:`GROUP_KINDS` is the mapping between
+them. Conflating the two made every job verb here inert for weeks —
+``_load_sac_jobs`` was called with the GROUP NAME, so ``sac dev systemd
+list`` asked for ``kind="systemd"``, a value ``JobSpec.validate()``
+rejects at construction (``ALLOWED_KINDS`` is ``{service,timer,cron}``
+since scitex-dev #153). No job could ever match, so all four of sac's
+timers — the OAuth refresh, the drift check, the worktree GC and the
+fleet reconciler — were invisible to their own CLI, which reported "No
+sac systemd-kind jobs." and exit 0. The tests passed the whole time
+because the fixture hand-rolled a fake ``scitex_dev.jobs`` whose ``_Job``
+defaulted to ``kind="systemd"`` — a spec shape no real spec can have —
+so the suite never ran the real validator. See ``_jobs_audit`` for the
+detector that now makes this shape fail loudly in CI.
+
+:data:`GROUP_KINDS` mirrors scitex-dev's canonical selection exactly
+(verified against ``_cli/ecosystem/_cmds/``): ``_jobs_cron.py`` selects
+``jobs_of_kind("cron")``; ``_jobs_systemd.py`` selects
+``jobs_of_kind("timer") + jobs_of_kind("service")``.
+
+The verbs per group mirror ``scitex-dev ecosystem <group> <verb>``:
 
 * ``cron``    → ``list`` / ``install`` / ``uninstall``
 * ``systemd`` → ``list`` / ``install`` / ``uninstall``
-* ``daemon``  → ``list`` / ``exec``   (a daemon is *run*, not "installed")
+
+There is deliberately NO ``sac dev daemon`` group. It used to exist and
+was dead in BOTH halves: it filtered ``kind="daemon"`` (not a legal kind,
+so always zero jobs) and delegated to ``scitex-dev ecosystem daemon``,
+which is not a subcommand of ``ecosystem`` at all. A long-running job is
+``kind="service"``, installed through the ``systemd`` group above.
 
 ``install`` / ``uninstall`` delegate to
-``scitex-dev ecosystem <kind> {install,uninstall} --name <name>`` so the
-unit/cron generation stays single-sourced in scitex-dev; ``exec``
-delegates to ``scitex-dev ecosystem daemon exec <name>`` (positional
-job-name argument, like scitex-dev's own ``daemon exec``).
+``scitex-dev ecosystem <group> {install,uninstall} --name <name>`` so the
+unit/cron generation stays single-sourced in scitex-dev.
 
 Graceful degradation: a scitex-dev that predates the ``scitex_dev.jobs``
-contract (PyPI lag — the contract is unreleased at the time of writing)
-raises ``ImportError`` on the lazy import; every command catches it and
-prints an upgrade hint instead of a stack trace.
+contract (PyPI lag) raises ``ImportError`` on the lazy import; every
+command catches it and prints an upgrade hint instead of a stack trace.
 
 These commands are attached onto ``dev_group`` at import time via
 :func:`register_dev_jobs_commands` (same pattern as the account group's
@@ -42,6 +64,19 @@ _JOBS_MIN_VERSION = "0.16.0"
 # convention — see scitex_dev.jobs docstring).
 _SAC_PREFIX = "sac."
 
+#: ``sac dev <group>`` -> the ``JobSpec.kind`` values that group lists.
+#:
+#: THE SSOT for this mapping, and the reason it is module-level rather
+#: than inlined: ``_jobs_audit.audit_jobs`` imports THIS dict to check
+#: that every kind sac declares has a consumer able to see it. If the
+#: audit re-declared the mapping instead of importing the one production
+#: uses, the audit would be checking its own opinion — a declaration with
+#: no live counterpart, i.e. the exact disease it exists to detect.
+GROUP_KINDS: dict[str, frozenset[str]] = {
+    "cron": frozenset({"cron"}),
+    "systemd": frozenset({"timer", "service"}),
+}
+
 
 def _degrade_msg() -> str:
     return (
@@ -51,8 +86,11 @@ def _degrade_msg() -> str:
     )
 
 
-def _load_sac_jobs(kind: str) -> list:
-    """Return sac-owned ``JobSpec`` of ``kind``, or raise ImportError.
+def _load_sac_jobs(kinds: frozenset[str]) -> list:
+    """Return sac-owned ``JobSpec`` whose kind is in ``kinds``.
+
+    Takes the KIND SET, never a group name: passing the group name was the
+    bug that made every verb here inert (see the module docstring).
 
     Lazy import of ``scitex_dev.jobs`` so an older installed scitex-dev
     surfaces as a clean ImportError the callers translate into an
@@ -60,18 +98,14 @@ def _load_sac_jobs(kind: str) -> list:
     """
     from scitex_dev.jobs import jobs_of_kind  # may ImportError on old scitex-dev
 
-    return [j for j in jobs_of_kind(kind) if j.name.startswith(_SAC_PREFIX)]
+    jobs: list = []
+    for kind in sorted(kinds):
+        jobs.extend(j for j in jobs_of_kind(kind) if j.name.startswith(_SAC_PREFIX))
+    return jobs
 
 
-def _ecosystem_delegate(kind: str, verb: str, name: str, yes: bool = False) -> int:
-    """Delegate to ``scitex-dev ecosystem <kind> <verb> ... <name>``.
-
-    The job-name is passed the way each canonical verb expects it:
-
-    * ``daemon exec`` takes a *positional* ``NAME`` argument (and no
-      ``--yes``), matching ``scitex-dev ecosystem daemon exec <name>``.
-    * ``cron``/``systemd`` ``install``/``uninstall`` take ``--name
-      <name>`` (and optionally ``--yes``).
+def _ecosystem_delegate(group: str, verb: str, name: str, yes: bool = False) -> int:
+    """Delegate to ``scitex-dev ecosystem <group> <verb> --name <name>``.
 
     Returns the subprocess exit code. ``scitex-dev`` is a hard dependency
     of this package, so the console script is expected on PATH; a missing
@@ -82,26 +116,23 @@ def _ecosystem_delegate(kind: str, verb: str, name: str, yes: bool = False) -> i
         raise click.ClickException(
             "`scitex-dev` console script not found on PATH; " + _degrade_msg()
         )
-    if kind == "daemon" and verb == "exec":
-        # `daemon exec` runs in the foreground via a positional NAME.
-        return subprocess.call([exe, "ecosystem", kind, verb, name])
-    cmd = [exe, "ecosystem", kind, verb, "--name", name]
+    cmd = [exe, "ecosystem", group, verb, "--name", name]
     if yes:
         cmd.append("--yes")
     return subprocess.call(cmd)
 
 
-def _add_list_command(grp, kind: str) -> None:
-    """Attach the shared ``list`` read-verb onto a kind group."""
+def _add_list_command(grp, group: str) -> None:
+    """Attach the shared ``list`` read-verb onto a group."""
 
     @grp.command("list")
     @click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
     def _list(as_json):
-        """List sac's own jobs of this kind."""
+        """List sac's own jobs of this group."""
         import json as _json
 
         try:
-            jobs = _load_sac_jobs(kind)
+            jobs = _load_sac_jobs(GROUP_KINDS[group])
         except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — print upgrade hint, not a stack trace)
             click.echo(_degrade_msg(), err=True)
             raise SystemExit(3)
@@ -111,6 +142,7 @@ def _add_list_command(grp, kind: str) -> None:
                     [
                         {
                             "name": j.name,
+                            "kind": j.kind,
                             "schedule": j.schedule,
                             "command": j.command,
                             "description": j.description,
@@ -122,7 +154,7 @@ def _add_list_command(grp, kind: str) -> None:
             )
             return
         if not jobs:
-            click.echo(f"No sac {kind}-kind jobs.")
+            click.echo(f"No sac {group} jobs.")
             return
         for j in jobs:
             cadence = j.on_unit_active_sec or j.schedule
@@ -131,29 +163,31 @@ def _add_list_command(grp, kind: str) -> None:
             click.echo(f"  {'':24s} {j.description}")
 
 
-def _make_installable_group(kind: str):
-    """Build a ``sac dev <kind>`` group with list/install/uninstall.
+def _make_installable_group(group: str):
+    """Build a ``sac dev <group>`` group with list/install/uninstall.
 
-    Used for the ``cron`` and ``systemd`` job-kinds — both of which are
-    *installed* (materialised into a crontab block / systemd unit files)
-    by scitex-dev. Mirrors ``scitex-dev ecosystem <kind>``.
+    Mirrors ``scitex-dev ecosystem <group>``, which is what the verbs
+    delegate to; the jobs shown are those whose kind is in
+    ``GROUP_KINDS[group]``.
     """
 
-    @click.group(kind, invoke_without_command=True)
+    @click.group(group, invoke_without_command=True)
     @click.pass_context
     def _grp(ctx):
         if ctx.invoked_subcommand is None:
             click.echo(ctx.get_help())
 
+    kinds = ", ".join(sorted(GROUP_KINDS[group]))
     _grp.help = (
-        f"sac's federated {kind} jobs (delegates to scitex-dev ecosystem).\n\n"
+        f"sac's federated {group} jobs (delegates to scitex-dev ecosystem).\n\n"
+        f"\b\nShows JobSpecs of kind: {kinds}\n\n"
         "\b\nVerbs:\n"
-        "  list       — show sac's own jobs of this kind\n"
+        "  list       — show sac's own jobs of this group\n"
         "  install    — generate + install them via scitex-dev\n"
         "  uninstall  — remove them via scitex-dev"
     )
 
-    _add_list_command(_grp, kind)
+    _add_list_command(_grp, group)
 
     @_grp.command("install")
     @click.option(
@@ -164,18 +198,18 @@ def _make_installable_group(kind: str):
         help="Confirm. Forwarded to scitex-dev.",
     )
     def _install(yes):
-        """Install sac's jobs of this kind via scitex-dev."""
+        """Install sac's jobs of this group via scitex-dev."""
         try:
-            jobs = _load_sac_jobs(kind)
+            jobs = _load_sac_jobs(GROUP_KINDS[group])
         except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — print upgrade hint, not a stack trace)
             click.echo(_degrade_msg(), err=True)
             raise SystemExit(3)
         if not jobs:
-            click.echo(f"No sac {kind}-kind jobs to install.")
+            click.echo(f"No sac {group} jobs to install.")
             return
         rc = 0
         for j in jobs:
-            code = _ecosystem_delegate(kind, "install", j.name, yes)
+            code = _ecosystem_delegate(group, "install", j.name, yes)
             rc = rc or code
         raise SystemExit(rc)
 
@@ -188,77 +222,28 @@ def _make_installable_group(kind: str):
         help="Confirm. Forwarded to scitex-dev.",
     )
     def _uninstall(yes):
-        """Uninstall sac's jobs of this kind via scitex-dev."""
+        """Uninstall sac's jobs of this group via scitex-dev."""
         try:
-            jobs = _load_sac_jobs(kind)
+            jobs = _load_sac_jobs(GROUP_KINDS[group])
         except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — print upgrade hint, not a stack trace)
             click.echo(_degrade_msg(), err=True)
             raise SystemExit(3)
         if not jobs:
-            click.echo(f"No sac {kind}-kind jobs to uninstall.")
+            click.echo(f"No sac {group} jobs to uninstall.")
             return
         rc = 0
         for j in jobs:
-            code = _ecosystem_delegate(kind, "uninstall", j.name, yes)
+            code = _ecosystem_delegate(group, "uninstall", j.name, yes)
             rc = rc or code
         raise SystemExit(rc)
 
     return _grp
 
 
-def _make_daemon_group():
-    """Build the ``sac dev daemon`` group with list/exec.
-
-    A daemon is a long-running process that is *run* (not "installed"),
-    so this group exposes ``exec`` (run one job in the foreground) rather
-    than install/uninstall — matching ``scitex-dev ecosystem daemon``.
-    """
-
-    @click.group("daemon", invoke_without_command=True)
-    @click.pass_context
-    def _grp(ctx):
-        if ctx.invoked_subcommand is None:
-            click.echo(ctx.get_help())
-
-    _grp.help = (
-        "sac's federated daemon jobs (delegates to scitex-dev ecosystem).\n\n"
-        "\b\nVerbs:\n"
-        "  list  — show sac's own daemon jobs\n"
-        "  exec  — run one sac daemon job in the foreground via scitex-dev"
-    )
-
-    _add_list_command(_grp, "daemon")
-
-    @_grp.command("exec")
-    @click.argument("name")
-    def _exec(name):
-        """Run the sac daemon job NAME in the foreground via scitex-dev.
-
-        \b
-        Blocks until the process exits; the caller is responsible for
-        backgrounding / supervision. Delegates to
-        `scitex-dev ecosystem daemon exec <name>`.
-        """
-        try:
-            jobs = {j.name: j for j in _load_sac_jobs("daemon")}
-        except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — print upgrade hint, not a stack trace)
-            click.echo(_degrade_msg(), err=True)
-            raise SystemExit(3)
-        if name not in jobs:
-            known = ", ".join(sorted(jobs)) or "(none)"
-            raise click.ClickException(
-                f"unknown sac daemon job: {name!r}. Known jobs: {known}"
-            )
-        raise SystemExit(_ecosystem_delegate("daemon", "exec", name))
-
-    return _grp
-
-
 def register_dev_jobs_commands(dev_group: click.Group) -> None:
-    """Attach the ``cron`` / ``daemon`` / ``systemd`` groups onto ``sac dev``."""
-    for kind in ("cron", "systemd"):
-        dev_group.add_command(_make_installable_group(kind))
-    dev_group.add_command(_make_daemon_group())
+    """Attach a job group onto ``sac dev`` for every entry in GROUP_KINDS."""
+    for group in sorted(GROUP_KINDS):
+        dev_group.add_command(_make_installable_group(group))
 
 
-__all__ = ["register_dev_jobs_commands"]
+__all__ = ["GROUP_KINDS", "register_dev_jobs_commands"]

--- a/src/scitex_agent_container/cli_pkg/dev_group.py
+++ b/src/scitex_agent_container/cli_pkg/dev_group.py
@@ -169,9 +169,10 @@ def dev_group() -> None:
     """Developer / maintainer plumbing (CI secrets, scheduled jobs, etc.)."""
 
 
-# Federated scheduled-job subcommands (`sac dev {cron,daemon,systemd}`)
-# delegate to scitex-dev's ecosystem aggregator. Kept in their own module
-# to hold this file under the per-file line cap; attached at import time.
+# Federated scheduled-job subcommands (`sac dev {cron,systemd}`, derived
+# from `_dev_jobs.GROUP_KINDS`) delegate to scitex-dev's ecosystem
+# aggregator. Kept in their own module to hold this file under the
+# per-file line cap; attached at import time.
 from ._dev_jobs import register_dev_jobs_commands
 
 register_dev_jobs_commands(dev_group)

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
@@ -1,11 +1,28 @@
-"""Tests for ``sac dev {cron,daemon,systemd}`` federated-job commands.
+"""Tests for ``sac dev {cron,systemd}`` federated-job commands.
 
-No-mocks (PA-306): the production seam is the lazy ``from scitex_dev.jobs
-import jobs_of_kind`` inside ``_dev_jobs``. We drive that seam by
-installing a real, hand-rolled ``scitex_dev.jobs`` module into
-``sys.modules`` (present-case) or by forcing its import to fail
-(degrade-case) — exercising the exact code path production hits when the
-installed scitex-dev does / does not ship the jobs contract.
+WHY THIS FILE WAS REWRITTEN — it is the fixture that hid the bug.
+
+It used to install a hand-rolled fake ``scitex_dev.jobs`` module into
+``sys.modules``, whose ``_Job`` dataclass defaulted to ``kind="systemd"``.
+No real JobSpec can have that kind: ``ALLOWED_KINDS`` is
+``{service,timer,cron}`` and ``JobSpec.validate()`` raises on anything
+else at construction. So the suite asserted, in green, that ``sac dev
+systemd list`` shows ``sac.accounts-refresh`` — while in production that
+command printed "No sac systemd-kind jobs." and exited 0, because the
+group name was being passed straight through as the kind filter and all
+four of sac's real timers are ``kind="timer"``.
+
+A fake whose shape no real object can have does not test the production
+path; it tests the fake. That is the same failure as the twin-spawning
+suite (29 green tests over a ``spec.env`` shape v3 validation rejects) and
+it is why these tests now drive the REAL ``scitex_dev.jobs`` with REAL
+``JobSpec`` objects. If the contract is not installed, the file skips —
+it does not invent a stand-in.
+
+No mocks (PA-306). The one seam still injected is ``_ecosystem_delegate``,
+which would otherwise shell out to a real ``scitex-dev`` subprocess and
+mutate the host's crontab/units; the delegation ARGUMENTS are the thing
+under test there, and they are captured, not faked.
 
 AAA marker comments; one assertion per test.
 """
@@ -13,57 +30,19 @@ AAA marker comments; one assertion per test.
 from __future__ import annotations
 
 import sys
-import types
 from contextlib import contextmanager
-from dataclasses import dataclass
 from typing import Iterator
 
+import pytest
 from click.testing import CliRunner
 
-from scitex_agent_container.cli_pkg.dev_group import dev_group
+jobs_mod = pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
 
-
-@dataclass
-class _Job:
-    name: str
-    schedule: str
-    command: str
-    description: str
-    kind: str = "systemd"
-    on_boot_sec: str | None = None
-    on_unit_active_sec: str | None = None
-    timeout_sec: int | None = None
-
-
-def _sac_systemd_job() -> _Job:
-    return _Job(
-        name="sac.accounts-refresh",
-        schedule="0 */2 * * *",
-        command="sac accounts refresh --all --skip-active",
-        description="Headless OAuth refresh.",
-        kind="systemd",
-        on_unit_active_sec="2h",
-    )
-
-
-@contextmanager
-def _jobs_present(jobs: list[_Job]) -> Iterator[None]:
-    """Install a real fake ``scitex_dev.jobs`` exposing ``jobs_of_kind``."""
-    mod = types.ModuleType("scitex_dev.jobs")
-
-    def jobs_of_kind(kind: str) -> list[_Job]:
-        return [j for j in jobs if j.kind == kind]
-
-    mod.jobs_of_kind = jobs_of_kind  # type: ignore[attr-defined]
-    saved = sys.modules.get("scitex_dev.jobs")
-    sys.modules["scitex_dev.jobs"] = mod
-    try:
-        yield
-    finally:
-        if saved is None:
-            del sys.modules["scitex_dev.jobs"]
-        else:
-            sys.modules["scitex_dev.jobs"] = saved
+from scitex_agent_container.cli_pkg._dev_jobs import GROUP_KINDS  # noqa: E402
+from scitex_agent_container.cli_pkg.dev_group import dev_group  # noqa: E402
 
 
 @contextmanager
@@ -81,41 +60,101 @@ def _jobs_absent() -> Iterator[None]:
 
 
 # ---------------------------------------------------------------------------
-# list — present case
+# list — against the REAL provider and the REAL taxonomy
 # ---------------------------------------------------------------------------
 
 
-def test_systemd_list_shows_only_sac_jobs() -> None:
-    # Arrange — one sac systemd job + a foreign systemd job that must NOT show.
-    foreign = _Job("other.thing", "0 * * * *", "do", "x", kind="systemd")
-    with _jobs_present([_sac_systemd_job(), foreign]):
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(dev_group, ["systemd", "list"])
-    # Assert — sac's job is listed, the foreign one filtered out.
-    assert (
-        "sac.accounts-refresh" in result.output and "other.thing" not in result.output
-    )
+def test_systemd_list_shows_sacs_real_timers() -> None:
+    # Arrange — the regression that matters: sac's four jobs are all
+    # kind="timer", and `ecosystem systemd` selects timer+service. This
+    # command listed NOTHING for weeks while the old fake made it green.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["systemd", "list"])
+    # Assert
+    assert "sac.accounts-refresh" in result.output
 
 
-def test_systemd_list_exit_zero_when_present() -> None:
+def test_systemd_list_shows_every_declared_sac_job() -> None:
+    # Arrange — all four, not just the one a pinning test happens to name.
+    from scitex_agent_container._jobs_plugin import provide_jobs
+
+    expected = [j.name for j in provide_jobs() if j.kind in GROUP_KINDS["systemd"]]
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["systemd", "list"])
+    # Assert
+    assert all(name in result.output for name in expected)
+
+
+def test_systemd_list_exit_zero() -> None:
     # Arrange
-    with _jobs_present([_sac_systemd_job()]):
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(dev_group, ["systemd", "list"])
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["systemd", "list"])
     # Assert
     assert result.exit_code == 0
 
 
-def test_cron_list_empty_when_sac_has_no_cron_jobs() -> None:
-    # Arrange — sac only has a systemd job.
-    with _jobs_present([_sac_systemd_job()]):
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(dev_group, ["cron", "list"])
+def test_systemd_list_filters_out_foreign_jobs() -> None:
+    # Arrange — scitex-dev's own built-in jobs are discoverable too; only
+    # sac.* may show here.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["systemd", "list", "--json"])
     # Assert
-    assert "No sac cron-kind jobs." in result.output
+    import json as _json
+
+    assert all(j["name"].startswith("sac.") for j in _json.loads(result.output))
+
+
+def test_systemd_list_json_reports_the_real_kind() -> None:
+    # Arrange — the JSON surfaces `kind` precisely so a future taxonomy
+    # drift is visible rather than silently filtered to nothing.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["systemd", "list", "--json"])
+    # Assert
+    import json as _json
+
+    assert {j["kind"] for j in _json.loads(result.output)} == {"timer"}
+
+
+def test_cron_list_is_empty_because_sac_declares_no_cron_jobs() -> None:
+    # Arrange — a TRUE empty (sac has no kind="cron" job), unlike the
+    # systemd group's old empty, which was a bug wearing the same output.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["cron", "list"])
+    # Assert
+    assert "No sac cron jobs." in result.output
+
+
+# ---------------------------------------------------------------------------
+# the dead group stays dead
+# ---------------------------------------------------------------------------
+
+
+def test_there_is_no_daemon_group() -> None:
+    # Arrange — `sac dev daemon` was dead in BOTH halves: it filtered
+    # kind="daemon" (never legal, so always zero jobs) AND delegated to
+    # `scitex-dev ecosystem daemon`, which is not an ecosystem subcommand
+    # at all. A long-running job is kind="service", via the systemd group.
+    groups = dev_group.commands
+    # Act
+    present = "daemon" in groups
+    # Assert
+    assert present is False
+
+
+def test_job_groups_are_exactly_the_group_kinds_ssot() -> None:
+    # Arrange — the CLI surface is derived from GROUP_KINDS, so a group can
+    # never again exist without a declared kind filter behind it.
+    expected = set(GROUP_KINDS)
+    # Act
+    present = {g for g in expected if g in dev_group.commands}
+    # Assert
+    assert present == expected
 
 
 # ---------------------------------------------------------------------------
@@ -156,111 +195,68 @@ def test_install_degrades_when_jobs_absent() -> None:
 
 
 # ---------------------------------------------------------------------------
-# verb consistency with scitex-dev ecosystem aggregator
-#
-# Canonical verbs per job-kind (scitex-dev ecosystem):
-#   cron    → list / install / uninstall
-#   systemd → list / install / uninstall
-#   daemon  → list / exec   (a daemon is *run*, not "installed")
+# verb consistency with the scitex-dev ecosystem aggregator
 # ---------------------------------------------------------------------------
 
 
-def _verbs_of(kind: str) -> set[str]:
-    """The leaf subcommand names exposed under ``sac dev <kind>``."""
-    grp = dev_group.commands[kind]
+def _verbs_of(group: str) -> set[str]:
+    """The leaf subcommand names exposed under ``sac dev <group>``."""
+    grp = dev_group.commands[group]
     return set(grp.commands)  # type: ignore[attr-defined]
 
 
 def test_cron_verbs_are_list_install_uninstall() -> None:
     # Arrange
-    kind = "cron"
+    group = "cron"
     # Act
-    verbs = _verbs_of(kind)
+    verbs = _verbs_of(group)
     # Assert
     assert verbs == {"list", "install", "uninstall"}
 
 
 def test_systemd_verbs_are_list_install_uninstall() -> None:
     # Arrange
-    kind = "systemd"
+    group = "systemd"
     # Act
-    verbs = _verbs_of(kind)
+    verbs = _verbs_of(group)
     # Assert
     assert verbs == {"list", "install", "uninstall"}
 
 
-def test_daemon_verbs_are_list_exec() -> None:
-    # Arrange — daemon is run, not installed: list + exec, no
-    # install/uninstall (matches scitex-dev ecosystem daemon).
-    kind = "daemon"
-    # Act
-    verbs = _verbs_of(kind)
-    # Assert
-    assert verbs == {"list", "exec"}
-
-
-def test_daemon_has_no_install_verb() -> None:
-    # Arrange
-    kind = "daemon"
-    # Act
-    verbs = _verbs_of(kind)
-    # Assert — explicit: the wrong install/uninstall verbs are gone.
-    assert "install" not in verbs and "uninstall" not in verbs
-
-
-def test_daemon_exec_takes_positional_name_argument() -> None:
-    # Arrange — exec mirrors `scitex-dev ecosystem daemon exec <name>`.
-    exec_cmd = dev_group.commands["daemon"].commands["exec"]  # type: ignore[attr-defined]
-    # Act
-    arg_names = [p.name for p in exec_cmd.params if p.param_type_name == "argument"]
-    # Assert
-    assert arg_names == ["name"]
-
-
-def _sac_daemon_job() -> _Job:
-    return _Job(
-        name="sac.watcher",
-        schedule="-",
-        command="sac listen --forever",
-        description="Long-running sac watcher.",
-        kind="daemon",
-    )
-
-
-def test_daemon_exec_delegates_to_scitex_dev_with_positional_name() -> None:
-    # Arrange — capture the (kind, verb, name) the exec verb delegates with.
+def test_install_delegates_to_the_matching_ecosystem_group() -> None:
+    # Arrange — capture the (group, verb, name) tuples install delegates
+    # with, rather than shelling out to a real scitex-dev that would
+    # rewrite the host's systemd units.
     import scitex_agent_container.cli_pkg._dev_jobs as dj
 
     captured: list[tuple] = []
     original = dj._ecosystem_delegate
-    dj._ecosystem_delegate = lambda *a, **k: (captured.append(a) or 0)  # type: ignore[assignment]
+    dj._ecosystem_delegate = lambda *a, **k: captured.append(a) or 0  # type: ignore[assignment]
     try:
-        with _jobs_present([_sac_daemon_job()]):
-            runner = CliRunner()
-            # Act
-            runner.invoke(dev_group, ["daemon", "exec", "sac.watcher"])
+        runner = CliRunner()
+        # Act
+        runner.invoke(dev_group, ["systemd", "install", "-y"])
     finally:
         dj._ecosystem_delegate = original  # type: ignore[assignment]
-    # Assert — delegated as (kind="daemon", verb="exec", name="sac.watcher").
-    assert captured == [("daemon", "exec", "sac.watcher")]
+    # Assert — every delegation targets `ecosystem systemd install`.
+    assert captured and all(a[:2] == ("systemd", "install") for a in captured)
 
 
-def test_daemon_exec_rejects_unknown_job() -> None:
-    # Arrange — only sac.watcher exists.
-    with _jobs_present([_sac_daemon_job()]):
+def test_install_delegates_once_per_declared_timer() -> None:
+    # Arrange — the count is the point: a group that silently matched zero
+    # jobs delegated zero times and still exited 0.
+    import scitex_agent_container.cli_pkg._dev_jobs as dj
+    from scitex_agent_container._jobs_plugin import provide_jobs
+
+    expected = len([j for j in provide_jobs() if j.kind in GROUP_KINDS["systemd"]])
+    captured: list[tuple] = []
+    original = dj._ecosystem_delegate
+    dj._ecosystem_delegate = lambda *a, **k: captured.append(a) or 0  # type: ignore[assignment]
+    try:
         runner = CliRunner()
         # Act
-        result = runner.invoke(dev_group, ["daemon", "exec", "does.not.exist"])
-    # Assert — clean ClickException, not a delegated run.
-    assert result.exit_code != 0 and "unknown sac daemon job" in result.output
-
-
-def test_daemon_exec_degrades_when_jobs_absent() -> None:
-    # Arrange
-    with _jobs_absent():
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(dev_group, ["daemon", "exec", "sac.watcher"])
+        runner.invoke(dev_group, ["systemd", "install", "-y"])
+    finally:
+        dj._ecosystem_delegate = original  # type: ignore[assignment]
     # Assert
-    text = (result.output or "") + (getattr(result, "stderr", "") or "")
-    assert "requires scitex-dev>=" in text
+    assert len(captured) == expected

--- a/tests/scitex_agent_container/test__jobs_audit.py
+++ b/tests/scitex_agent_container/test__jobs_audit.py
@@ -1,0 +1,242 @@
+"""Tests for the inert-feature detector (``_jobs_audit``).
+
+This file IS the gate. It runs in ``pytest-matrix-on-ubuntu-py{3.11,3.12,
+3.13}``, a REQUIRED status check on both ``develop`` and ``main``, which
+is the whole point: a checker nobody runs is another instance of the
+disease it claims to detect, so the checker had to be hung off something
+that already fails builds. It is deliberately NOT in the quality-audit
+workflow — every step there is ``continue-on-error: true``.
+
+No mocks (PA-306). The two pure functions take plain frozensets/dicts and
+return dataclasses, so the "arrange" is real data, not a patched seam;
+the integration tests drive the REAL ``provide_jobs`` / ``discover_jobs``
+/ Click groups with the REAL ``scitex_dev.jobs`` installed.
+
+AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+jobs_mod = pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
+
+from scitex_agent_container._jobs_audit import (  # noqa: E402
+    Finding,
+    Form,
+    InertReport,
+    Verdict,
+    audit_consumers,
+    audit_discovery,
+    audit_jobs,
+)
+from scitex_agent_container.cli_pkg._dev_jobs import GROUP_KINDS  # noqa: E402
+
+# The mapping the CLI ACTUALLY used before this was fixed: ``_load_sac_jobs``
+# was called with the GROUP NAME, so each group filtered on a kind literally
+# equal to its own name. Reconstructed here as data so the detector can be
+# shown firing on the real historical bug rather than on a hypothetical.
+_PRE_FIX_GROUP_KINDS = {
+    "cron": frozenset({"cron"}),
+    "systemd": frozenset({"systemd"}),
+    "daemon": frozenset({"daemon"}),
+}
+
+
+# ---------------------------------------------------------------------------
+# Form DISCOVERY — declared vs reachable by the real aggregator
+# ---------------------------------------------------------------------------
+
+
+def test_every_declared_job_is_reachable_by_discover_jobs() -> None:
+    # Arrange — the real provider + the real entry-point aggregation.
+    # `discover_jobs` swallows a raising provider with only a warning, so a
+    # single bad JobSpec silently drops ALL of sac's timers and nothing
+    # else in the suite would notice.
+    # Act
+    report = audit_jobs()
+    # Assert
+    assert not [f for f in report.inert if f.form is Form.DISCOVERY], report.render()
+
+
+def test_declared_job_missing_from_discovery_reads_inert() -> None:
+    # Arrange — declared, but the aggregator cannot see it.
+    # Act
+    findings = audit_discovery(
+        declared_names=frozenset({"sac.ghost"}),
+        discovered_names=frozenset({"sac.real"}),
+    )
+    # Assert
+    assert findings[0].verdict is Verdict.INERT
+
+
+def test_discovery_without_the_contract_reads_unknown_not_inert() -> None:
+    # Arrange — discovery could not run at all. Absence of evidence is not
+    # evidence of absence: a false INERT here would invite someone to
+    # delete a working job, which is worse than the disease.
+    # Act
+    findings = audit_discovery(
+        declared_names=frozenset({"sac.accounts-refresh"}),
+        discovered_names=None,
+    )
+    # Assert
+    assert findings[0].verdict is Verdict.UNKNOWN
+
+
+def test_discovery_inert_finding_states_its_evidence() -> None:
+    # Arrange
+    findings = audit_discovery(
+        declared_names=frozenset({"sac.ghost"}),
+        discovered_names=frozenset(),
+    )
+    # Act
+    detail = findings[0].detail
+    # Assert — a verdict with no stated evidence is the postmortem-in-a-
+    # comment this module replaces.
+    assert "discover_jobs()" in detail
+
+
+# ---------------------------------------------------------------------------
+# Form CONSUMER — declared vs anything able to read it
+# ---------------------------------------------------------------------------
+
+
+def test_every_declared_kind_has_a_consumer_that_can_see_it() -> None:
+    # Arrange — the real declarations against the real CLI kind filter.
+    # Act
+    report = audit_jobs()
+    # Assert
+    assert not [f for f in report.inert if f.form is Form.CONSUMER], report.render()
+
+
+def test_no_consumer_group_filters_on_an_impossible_kind() -> None:
+    # Arrange — a group filtering outside ALLOWED_KINDS can never match a
+    # single job, because JobSpec.validate() rejects that kind at
+    # construction.
+    # Act
+    report = audit_jobs()
+    # Assert
+    assert not [f for f in report.inert if f.form is Form.IMPOSSIBLE_KIND], (
+        report.render()
+    )
+
+
+def test_detector_fires_on_the_historical_group_name_as_kind_bug() -> None:
+    # Arrange — THE RED PROOF. This is the exact mapping production used
+    # for weeks: the group name passed straight through as the kind
+    # filter. `sac dev systemd list` asked for kind="systemd", which is not
+    # in ALLOWED_KINDS, so all four sac timers were invisible to their own
+    # CLI while 13 tests stayed green.
+    # Act
+    findings = audit_consumers(
+        declared_kinds=frozenset({"timer"}),
+        group_kinds=_PRE_FIX_GROUP_KINDS,
+        allowed_kinds=frozenset(jobs_mod.ALLOWED_KINDS),
+    )
+    inert = {f.subject for f in findings if f.verdict is Verdict.INERT}
+    # Assert — both dead groups AND the orphaned declared kind are named.
+    assert inert == {"sac dev systemd", "sac dev daemon", "kind=timer"}
+
+
+def test_declared_kind_with_no_consumer_group_reads_inert() -> None:
+    # Arrange — a legal kind that no group covers: the jobs exist and are
+    # discoverable, but the CLI can neither list nor install them.
+    # Act
+    findings = audit_consumers(
+        declared_kinds=frozenset({"service"}),
+        group_kinds={"cron": frozenset({"cron"})},
+        allowed_kinds=frozenset(jobs_mod.ALLOWED_KINDS),
+    )
+    # Assert
+    assert findings[0].verdict is Verdict.INERT
+
+
+def test_consumer_group_kinds_are_all_legal_kinds() -> None:
+    # Arrange — pin the SSOT itself against the canonical taxonomy.
+    groups = GROUP_KINDS
+    # Act
+    covered: set[str] = set()
+    for kinds in groups.values():
+        covered |= kinds
+    # Assert
+    assert covered <= jobs_mod.ALLOWED_KINDS
+
+
+# ---------------------------------------------------------------------------
+# Dataclass contract — validators fire at construction, like JobSpec
+# ---------------------------------------------------------------------------
+
+
+def test_finding_rejects_a_verdict_that_is_not_a_verdict() -> None:
+    # Arrange — a stringly-typed verdict is how "unknown" silently becomes
+    # "inert" three refactors later.
+    kwargs = dict(form=Form.CONSUMER, subject="x", detail="d")
+
+    # Act
+    def _build():
+        return Finding(verdict="inert", **kwargs)  # type: ignore[arg-type]
+
+    # Assert
+    with pytest.raises(ValueError):
+        _build()
+
+
+def test_finding_requires_stated_evidence() -> None:
+    # Arrange
+    kwargs = dict(form=Form.CONSUMER, subject="x", verdict=Verdict.INERT)
+
+    # Act
+    def _build():
+        return Finding(detail="", **kwargs)
+
+    # Assert
+    with pytest.raises(ValueError):
+        _build()
+
+
+def test_report_does_not_count_unknown_as_inert() -> None:
+    # Arrange — the three-state discipline, at the report boundary.
+    report = InertReport(
+        findings=(
+            Finding(
+                form=Form.DISCOVERY,
+                subject="sac.maybe",
+                verdict=Verdict.UNKNOWN,
+                detail="cannot tell",
+            ),
+        )
+    )
+    # Act
+    inert = report.inert
+    # Assert
+    assert inert == ()
+
+
+def test_render_names_each_dangling_pair_and_its_evidence() -> None:
+    # Arrange — the output has to be readable enough to act on.
+    report = InertReport(
+        findings=(
+            Finding(
+                form=Form.CONSUMER,
+                subject="kind=timer",
+                verdict=Verdict.INERT,
+                detail="no group filters on it",
+            ),
+        )
+    )
+    # Act
+    text = report.render()
+    # Assert
+    assert "kind=timer" in text and "no group filters on it" in text
+
+
+def test_render_is_quiet_when_nothing_dangles() -> None:
+    # Arrange
+    report = InertReport(findings=())
+    # Act
+    text = report.render()
+    # Assert
+    assert text == "no inert declarations found"


### PR DESCRIPTION
## The disease

Four features shipped in one night (2026-07-17), each with a PR, tests, and often an ADR. **None of them ever executed. The tests passed the whole time.**

1. `sac agents twin` — `derive_twin_spec` wrote `spec.env` at top level, which v3 validation REJECTS. Every derived spec was unloadable ⇒ no twin ever started. 29 green tests, because the **fixture used a spec shape no real spec has** and the suite never ran the validator.
2. The auth `screen` verdict — computed by `auth-heal.py`, persisted nowhere. `agent_auth_state` holds 3 rows against 101 fleet specs, so `screen` is permanently UNKNOWN and presence-ALIVE wins.
3. `restart.policy` — a spec field with no enforcer, dead code in ~93 specs.
4. `auto-merge-to-develop` — 0 runs since 07-09. It never FAILED; it was never TRIGGERED.

`_jobs_plugin.py`'s **own docstring** already names this pathology: *"shipped but scheduled nowhere, it was an inert alarm."* We diagnosed it once, in a comment, and kept doing it. **A postmortem in a comment is not a countermeasure.**

## The check

The common form is a **dangling half-pair**: a declaration with no live counterpart. `_jobs_audit.py` checks two forms deterministically, in **three states** — `LIVE` / `INERT` / **`UNKNOWN`**. "I cannot tell" is UNKNOWN, never INERT: a false INERT that gets someone to delete a working feature is worse than the disease. Only positive evidence of no counterpart yields INERT.

| Form | Catches |
|---|---|
| `DISCOVERY` | A JobSpec declared but unreachable via the **real** `discover_jobs()` — which swallows a raising provider with a mere `logging.warning`, so **one** bad spec silently drops **all four** sac timers and nothing turns red. |
| `CONSUMER` / `IMPOSSIBLE_KIND` | A declared `kind` no consumer can see, or a consumer filtering on a kind outside `ALLOWED_KINDS` — one that can never match anything, ever. |

Dataclasses in/out (`Finding`, `InertReport`), validators firing at construction like `JobSpec` does (a verdict with no stated evidence raises), fail loud via `render()`, no silent fallback.

## Where it runs — this is the deliverable, not the checker

**A checker that nobody runs is the fifth instance of the very disease.** So it is wired into `pytest-matrix-on-ubuntu-py{3.11,3.12,3.13}` — a **REQUIRED status check on both `develop` and `main`**.

It is **deliberately NOT** in `quality-audit-on-ubuntu-latest.yml`: every step there is `continue-on-error: true`, so a checker hung off it **could never go red**. That would have been instance #5 with a straight face.

## What this does NOT cover — stated plainly

A checker that silently covers less than it appears to is the same disease wearing a lab coat.

- **Declared vs DEPLOYED** — whether `sac.fleet-reconcile` is an installed, enabled, running systemd `--user` timer on the fleet host. This is the question behind instances 2 and 3, and it is **structurally unanswerable from CI**: the suite runs in a SIF on a Spartan node with no access to the fleet host's `systemctl --user`. Answering it from the JobSpec **source** instead is the exact trap that produced a P0 diagnosis off a 4-day-stale schedule (source said `0 */2 * * *`; the deployed unit said `OnUnitActiveSec=10min`). **Out of scope beats answered wrongly.**
- **Workflow triggers** (instance 4) and **spec-shape validation** (instance 1) — other owners are live on those files.

So: this catches instances of the **shape**, not instances 1–4 themselves. It catches a **fifth, live one** (below).

## The live instance it found and fixes

**Every `sac dev` job verb was inert, and had been for weeks.**

`_dev_jobs.py` passed the CLI **group name** straight through as the JobSpec **kind** filter. `sac dev systemd list` asked for `kind="systemd"` — a value `JobSpec.validate()` rejects at construction (`ALLOWED_KINDS` is `{service,timer,cron}` since scitex-dev #153). All four real timers are `kind="timer"`, so the command printed `No sac systemd-kind jobs.` and **exited 0, forever**.

`sac dev daemon` was deader still: it filtered a never-legal kind **and** delegated to `scitex-dev ecosystem daemon`, which **is not an `ecosystem` subcommand at all**. Dead in both halves — removed. A long-running job is `kind="service"`, via the `systemd` group.

The mapping is now `GROUP_KINDS`, a module-level **SSOT** mirroring scitex-dev's own selection (verified by source read: `_jobs_cron.py` → `cron`; `_jobs_systemd.py` → `timer` + `service`). **The audit imports it rather than restating it** — a checker that asserts its own opinion of what production ought to do is itself a dangling declaration.

This was already known: card `sac-dev-systemd-group-queries-dead-kind-20260716`, found 07-16 by watching it fail in production, **deferred with a workaround**, and `docs/worktree-gc.md` had been telling operators to route *around* the broken wrapper. It was found by a human watching production, never by any automated check. That gap is what this PR closes.

## And the fixture that hid it

`test__dev_jobs.py` installed a hand-rolled fake `scitex_dev.jobs` whose `_Job` dataclass **defaulted to `kind="systemd"`** — a shape no real JobSpec can have. 13 tests asserted in green that `sac dev systemd list` shows `sac.accounts-refresh` while production showed nothing. **Identical in kind to instance 1's 29 green tests over a `spec.env` shape v3 rejects.** The tests now drive the REAL contract with REAL `JobSpec` objects, and skip rather than invent a stand-in.

## Verification

**VERIFIED (measured, not inferred):**

- `sac dev systemd list` now lists all four timers end-to-end — was `No sac systemd-kind jobs.`
- `sac dev --help` exposes only `cron` + `systemd`; the dead `daemon` group is gone.
- 54 passed across `test__jobs_audit.py` + `test__dev_jobs.py` + `test__jobs_plugin.py`.
- Blast radius clean: the only other suites touching `dev_group` (`test_dev_group.py`, `test_peer_edges.py`) — 45 passed.
- **Proven RED**: reintroducing the pre-fix mapping fails **7 tests**, including `assert 'sac.accounts-refresh' in 'No sac systemd jobs.'` — the exact production symptom — with the report naming each dangling pair and its evidence:

```
3 DECLARATION(S) WITH NO LIVE COUNTERPART — shipped, but nothing executes them:
  [consumer-filters-on-an-impossible-kind] sac dev systemd
      filters on kind(s) ['systemd'] which are not in ALLOWED_KINDS
      ['cron', 'service', 'timer'] — JobSpec.validate() rejects them at
      construction, so this group can never list a single job
  [declared-kind-has-no-consumer] kind=timer
      sac declares job(s) of this kind but no sac dev group filters on it
```

- The gate is real, confirmed against the protection API rather than the workflow's own comment:
  ```
  $ gh api repos/scitex-ai/scitex-agent-container/branches/develop/protection \
      --jq '.required_status_checks.contexts'
  ["pytest-matrix-on-ubuntu-py3.11","pytest-matrix-on-ubuntu-py3.12","pytest-matrix-on-ubuntu-py3.13"]
  ```

**ASSUMED (not verified here):** nothing material. The `quality-audit` workflow's `continue-on-error: true` was read from the workflow file, not observed failing-open at runtime.

Cards: `sac-inert-feature-detector-20260717`; closes `sac-dev-systemd-group-queries-dead-kind-20260716`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
