### PR TITLE
fix(auth-status): an unread pane is UNKNOWN, not OK — the false green at the last inch

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_auth_status.py
+++ b/src/scitex_agent_container/cli_pkg/_auth_status.py
@@ -46,6 +46,24 @@ from ._helpers import _json_flag, console
 # server the live fleet actually runs on.
 _TUI_PREFIX = "tui-"
 
+# THREE verdicts, never two. A pane we could not READ has produced no evidence,
+# and "no evidence" is not "ok" — it is UNKNOWN. Collapsing it into OK is the
+# same false-green this command exists to abolish, just moved to the last inch:
+# an instrument reporting good news about a thing it never observed. The WRITE
+# path already refuses to record an unread pane (see :func:`persist_verdicts`);
+# these constants make the DISPLAY tell the same truth.
+VERDICT_OK = "ok"
+VERDICT_AUTH_FAILED = "auth_failed"
+VERDICT_UNKNOWN = "unknown"
+
+#: How each verdict renders. UNKNOWN is YELLOW — an unread pane is a warning to
+#: look closer, never a green light.
+_VERDICT_STYLE: dict[str, tuple[str, str]] = {
+    VERDICT_OK: ("OK", "green"),
+    VERDICT_AUTH_FAILED: ("AUTH-FAILED", "red"),
+    VERDICT_UNKNOWN: ("UNKNOWN", "yellow"),
+}
+
 
 def _list_tui_sessions() -> list[str]:
     """Live ``tui-<agent>`` tmux sessions on the default server (sorted)."""
@@ -101,6 +119,17 @@ def evaluate_agents(
     ``auth_failed``; a banner that moved — or none at all — is ``ok``. Kept free
     of tmux so it is unit-testable against captured panes (no mocks). Rows are
     sorted by agent name for stable output.
+
+    THREE verdicts. A pane that could not be READ on the decisive (second)
+    capture yields :data:`VERDICT_UNKNOWN` — never ``ok``. The session can vanish
+    between list and capture, tmux can be pointed at the wrong server, a pane can
+    be unreadable for any number of reasons, and in every one of them we learned
+    NOTHING about that agent's auth. Reporting OK there would be an instrument
+    announcing good news about a thing it never observed — the precise failure
+    this command exists to end, and the reason a wedged agent could read ALIVE.
+    ``persist_verdicts`` already refuses to record these rows; the verdict now
+    says so out loud instead of leaving the operator to infer it from an empty
+    ``captured`` field he cannot see in the table.
     """
     rows: list[dict] = []
     for name in sorted(captures):
@@ -108,11 +137,19 @@ def evaluate_agents(
         probe1, _ = evaluate(pane1, None)
         probe2, stuck = evaluate(pane2, probe_to_state(probe1))
         present = probe2.present or probe1.present
-        verdict = "auth_failed" if stuck else "ok"
+        captured = pane2 is not None
+        if not captured:
+            verdict = VERDICT_UNKNOWN
+        elif stuck:
+            verdict = VERDICT_AUTH_FAILED
+        else:
+            verdict = VERDICT_OK
         note = ""
-        if verdict == "ok" and present:
+        if not captured:
+            note = "pane could not be read — NO evidence, which is not health"
+        elif verdict == VERDICT_OK and present:
             note = "banner seen but moving (working/quoting)"
-        elif not probe2.prompt_found and pane2 is not None:
+        elif not probe2.prompt_found:
             note = "no prompt line found"
         rows.append(
             {
@@ -206,7 +243,7 @@ def persist_verdicts(rows: list[dict], *, db_path=None) -> int:
             [
                 {
                     "name": r["agent"],
-                    "auth_failed": r.get("verdict") == "auth_failed",
+                    "auth_failed": r.get("verdict") == VERDICT_AUTH_FAILED,
                     "banner": r.get("banner"),
                     "reason": r.get("reason") or "",
                     "note": r.get("note") or "",
@@ -233,12 +270,12 @@ def _render_table(rows: list[dict]) -> None:
     table.add_column("banner")
     table.add_column("note", overflow="fold")
     for r in rows:
-        failed = r["verdict"] == "auth_failed"
-        status = "AUTH-FAILED" if failed else "OK"
-        style = "red" if failed else "green"
+        # UNKNOWN is yellow, not green: it is the absence of a reading, and it
+        # must never look like a clean bill of health at a glance.
+        label, style = _VERDICT_STYLE.get(r["verdict"], ("UNKNOWN", "yellow"))
         table.add_row(
             r["agent"],
-            f"[{style}]{status}[/{style}]",
+            f"[{style}]{label}[/{style}]",
             r.get("reason") or "-",
             r.get("remedy") or "-",
             r["banner"] or "-",
@@ -297,11 +334,30 @@ def auth_status(ctx: click.Context, as_json: bool, interval: float) -> None:
     captures = {name: (run1.get(name), run2.get(name)) for name in run1}
     rows = diagnose_agents(evaluate_agents(captures))
     persist_verdicts(rows)
-    stuck = [r for r in rows if r["verdict"] == "auth_failed"]
+    stuck = [r for r in rows if r["verdict"] == VERDICT_AUTH_FAILED]
+    unread = [r for r in rows if r["verdict"] == VERDICT_UNKNOWN]
     if use_json:
-        click.echo(json_mod.dumps({"agents": rows, "auth_failed": len(stuck)}, indent=2))
+        click.echo(
+            json_mod.dumps(
+                {
+                    "agents": rows,
+                    "auth_failed": len(stuck),
+                    "unknown": len(unread),
+                },
+                indent=2,
+            )
+        )
     else:
         _render_table(rows)
+        # Say the unreadable ones OUT LOUD. Their rows are yellow above, but a
+        # count is what stops "no red on screen" from being read as "fleet fine"
+        # — we did not check these agents, and silence would imply we had.
+        if unread:
+            console.print(
+                f"[yellow]{len(unread)} agent(s) could NOT be read "
+                f"({', '.join(r['agent'] for r in unread)}) — UNKNOWN, not OK: "
+                f"nothing was observed about their auth[/yellow]"
+            )
         if stuck:
             console.print(
                 f"[red]{len(stuck)} agent(s) cannot authenticate: "

--- a/tests/scitex_agent_container/cli_pkg/test__auth_status.py
+++ b/tests/scitex_agent_container/cli_pkg/test__auth_status.py
@@ -17,7 +17,10 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from scitex_agent_container.cli_pkg._auth_status import evaluate_agents, persist_verdicts
+from scitex_agent_container.cli_pkg._auth_status import (
+    evaluate_agents,
+    persist_verdicts,
+)
 from scitex_agent_container.cli_pkg.agent_group import agent_group
 
 # Wedged: banner directly above the prompt, identical on both reads → frozen.
@@ -44,13 +47,46 @@ def test_evaluate_agents_marks_clean_pane_ok():
     assert row["verdict"] == "ok"
 
 
-def test_evaluate_agents_uncapturable_agent_is_ok_and_uncaptured():
+def test_evaluate_agents_uncapturable_agent_is_UNKNOWN_never_ok():
+    """A pane we could not READ is UNKNOWN — absence of evidence, not health.
+
+    This test previously asserted ``("ok", False)`` — it encoded the bug as the
+    expected behaviour and stayed green while `sac agents auth-status` printed OK
+    for agents it had never observed. An instrument reporting good news about a
+    thing it did not look at is the same false-green that let a wedged agent read
+    ALIVE; the verdict must be the third state.
+    """
     # Arrange
     captures = {"gone": (None, None)}
     # Act
     row = evaluate_agents(captures)[0]
     # Assert
-    assert (row["verdict"], row["captured"]) == ("ok", False)
+    assert (row["verdict"], row["captured"]) == ("unknown", False)
+
+
+def test_evaluate_agents_unreadable_second_pane_is_UNKNOWN():
+    """Corroboration needs the DECISIVE read: run 1 alone cannot yield a verdict.
+
+    A session that vanishes between the two captures produced one pane and then
+    nothing. Without the second read there is no frozen/moving judgement to make,
+    so the honest answer is UNKNOWN rather than a verdict invented from run 1.
+    """
+    # Arrange
+    captures = {"vanished": (_OK, None)}
+    # Act
+    row = evaluate_agents(captures)[0]
+    # Assert
+    assert (row["verdict"], row["captured"]) == ("unknown", False)
+
+
+def test_unknown_row_note_says_no_evidence_not_health():
+    """The row must carry WHY it is unknown, not just that it is."""
+    # Arrange
+    captures = {"gone": (None, None)}
+    # Act
+    note = evaluate_agents(captures)[0]["note"]
+    # Assert
+    assert "could not be read" in note
 
 
 def test_evaluate_agents_sorts_rows_by_agent_name():


### PR DESCRIPTION
## The bug

`sac agents auth-status` printed **OK for agents it never observed**.

When a pane could not be captured, `evaluate_agents` fell through to:

```python
verdict = "auth_failed" if stuck else "ok"
```

`stuck` is `False` for an unread pane — so an agent nobody could look at rendered a **green OK with every detail column empty**. Absence of evidence, printed as evidence of health. It is the same false-green that let a wedged agent read ALIVE, surviving at the last inch of the command built to abolish it.

Demonstrated on the pure mapper (no mocks):

```
healthy captured twice : verdict=ok           captured=True
frozen banner          : verdict=auth_failed  captured=True
UNCAPTURABLE pane      : verdict=ok           captured=False   <-- the bug
```

**The write path already knew better.** `persist_verdicts` refuses to record an uncaptured row precisely because it "would manufacture exactly the false green this feature exists to abolish". The display contradicted the writer. That asymmetry is the proof this was an oversight, not a design.

## The fix — three verdicts, never two

| verdict | meaning |
|---|---|
| `ok` | captured, no frozen banner |
| `auth_failed` | captured, banner frozen across both reads |
| `unknown` | **NOT captured — nothing was observed** |

- UNKNOWN renders **yellow, never green**, and carries its reason in the note: `pane could not be read — NO evidence, which is not health`.
- The summary **counts unread agents out loud**, so "no red on screen" can never be mistaken for "fleet fine" when we simply failed to look.
- `--json` gains an `unknown` count alongside `auth_failed`.
- Exit-code contract is unchanged (1 iff any agent is auth-failed) — deliberately not widened in this PR.

## The test that encoded the bug

```python
def test_evaluate_agents_uncapturable_agent_is_ok_and_uncaptured():
    assert (row["verdict"], row["captured"]) == ("ok", False)
```

It **pinned the defect as expected behaviour** and stayed green while the command lied — the same shape as #729, where green tests guarded a feature that never worked. Replaced with `..._is_UNKNOWN_never_ok`, plus a vanished-second-capture case and one asserting the note explains itself.

**Verified they can go RED** (a test that cannot fail is worse than none) — reverted to the shipped two-state logic:

```
FAILED test_evaluate_agents_uncapturable_agent_is_UNKNOWN_never_ok
FAILED test_evaluate_agents_unreadable_second_pane_is_UNKNOWN
E   AssertionError: assert ('ok', False) == ('unknown', False)
2 failed, 10 passed
```

With the fix: **193 passed** across the auth-status, auth_state, agent-list-auth, tmux-matcher and verdict suites.

## Scope note — what this is NOT

This was reported as "a missing cache row renders as OK". That mechanism does not exist:

- **`auth-status` never reads `agent_auth_state`.** It captures live panes and renders that. Its OK/AUTH-FAILED owe nothing to the cache.
- **`sac agents list` — the surface that DOES read the cache — is already honest.** A missing row renders `[dim]never[/dim]`, a stale one `ok?` in yellow, and `_print_auth_footer` states the three cases out loud so "the absence of evidence has to be stated out loud rather than passed off silently as good news".

The reported symptom (`│ grant │ OK │ - │ - │ - │`, all detail columns empty) is what a **healthy** agent looks like by design: `diagnose_agents` deliberately leaves reason/remedy empty for healthy rows ("diagnosing a working agent would confidently report `revoked` about nothing at all"), and `_render_table` maps empty to `-`. An independent sweep of those same agents at the same time found them captured, unfrozen and banner-free — the OKs were true.

The principle behind the report was right, and it found a real bug — just one inch away from where it was thought to be.

Companion: dotfiles PR #152 supplies the missing cache WRITER (the `agent_auth_state` cache had 3 rows, all 2 days stale, so the WEDGED verdict was inert).