### PR TITLE
feat(bake): the SIF ships scitex-cards 0.16.0 — pins flipped, gate asserts the shim

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -394,7 +394,7 @@ From: ubuntu:24.04
     # path resolves it through the bundled tree's own metadata.
     uv pip install --python /opt/venv-sac/bin/python \
         "claude-agent-sdk" \
-        "scitex-todo[mcp]==0.13.5" \
+        "scitex-cards[mcp]==0.16.0" \
         "/opt/scitex-agent-container-src[openai]"
 
     # ---- 6c. FAIL-LOUD staleness gate — assert BY SYMBOL --------------

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -193,7 +193,7 @@ From: ./sac-base.sif
             "scitex-writer>=2.29.0" \
             "scitex-audio>=0.3.0" \
             "scitex-cv>=0.2.0" \
-            "scitex-todo[mcp]==0.13.5"
+            "scitex-cards[mcp]==0.16.0"
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             pip setuptools wheel
@@ -230,7 +230,7 @@ From: ./sac-base.sif
         # above. See the uv branch for why a pin replaced ``-P latest`` (the
         # 0.13.x ~171s-per-write regression a moving ref would have baked).
         /opt/venv-sac/bin/pip install --no-cache-dir \
-            "scitex-todo[mcp]==0.13.5"
+            "scitex-cards[mcp]==0.16.0"
     fi
 
     # ---- 2b. FAIL-LOUD staleness gate — assert BY SYMBOL ----------------
@@ -285,7 +285,19 @@ import sys
 # `in_progress` ONLY. Below it, every agent's WIP gate counts DEFERRED +
 # CANCELLED cards as open and refuses legitimate card creation — the
 # 2026-07-12 fleet-drift incident this gate exists to end.
-from scitex_todo._throughput import WIP_STATUSES
+#
+# Package renamed scitex-cards (2026-07-16): the canonical module is
+# scitex_cards; the wheel ALSO ships a scitex_todo shim that must alias
+# to the SAME module objects — un-cutover fleet code imports the old
+# name, so the shim working is itself a ship-gate for this image.
+from scitex_cards._throughput import WIP_STATUSES
+
+import scitex_cards
+import scitex_todo  # the transition shim — its absence breaks the fleet
+
+if scitex_todo is not scitex_cards:
+    print("FATAL: scitex_todo shim is not scitex_cards — two module trees baked")
+    sys.exit(1)
 
 # sac #633: auto-provisions a new agent's container overlay root; without
 # it every newly-created agent is stillborn on a raw apptainer FATAL.
@@ -296,8 +308,8 @@ from scitex_todo._throughput import WIP_STATUSES
 from scitex_agent_container.runtimes._apptainer_overlay import ensure_overlay_dirs
 
 # Printed for the BUILD LOG only — these numbers are NOT the gate.
-print("scitex-todo reported version :", md.version("scitex-todo"))
-print("scitex-todo WIP_STATUSES     :", sorted(WIP_STATUSES))
+print("scitex-cards reported version:", md.version("scitex-cards"))
+print("scitex-cards WIP_STATUSES    :", sorted(WIP_STATUSES))
 print("sac reported version         :", md.version("scitex-agent-container"))
 print(
     "sac overlay auto-provision   :",

--- a/tests/integration/test_apptainer_base_def_scitex_todo.py
+++ b/tests/integration/test_apptainer_base_def_scitex_todo.py
@@ -1,4 +1,10 @@
-"""Static contract: ``apptainer-base.def`` must install scitex-todo[mcp].
+"""Static contract: ``apptainer-base.def`` must install scitex-cards[mcp].
+
+Package renamed scitex-todo -> scitex-cards (2026-07-16, migration S1-S3).
+The wheel ships BOTH console scripts (``scitex-todo`` and ``scitex-cards``)
+and the ``scitex_todo`` import shim, so the runtime claims below — the
+``.mcp.json`` entry invoking ``scitex-todo mcp start`` — stay true with the
+new dist installed. What this file pins is the DIST the .def installs.
 
 P3a-1.5 (operator directive ``feedback_scitex_todo_single_shared_store``,
 lead a2a ``5c0c1fe32a9a43888e01151d6fc0fb9e``): every sac-launched
@@ -57,8 +63,9 @@ _BASE_DEF = (
 # cannot express "or stricter" is not a guard; it is a ratchet welded shut.
 _WIP_GATE_MIN_VERSION = (0, 8, 0)
 
-# The quoted requirement token naming scitex-todo, e.g. "scitex-todo[mcp]>=0.9.4".
-_SCITEX_TODO_REQ_RE = re.compile(r'"(?P<req>[^"]*\bscitex-todo\b[^"]*)"')
+# The quoted requirement token naming the board package (renamed
+# scitex-cards 2026-07-16), e.g. "scitex-cards[mcp]==0.16.0".
+_SCITEX_TODO_REQ_RE = re.compile(r'"(?P<req>[^"]*\bscitex-cards\b[^"]*)"')
 # That requirement's lower bound (the first of >=, == or ~=).
 _FLOOR_RE = re.compile(r"(?:>=|==|~=)\s*(?P<version>\d+(?:\.\d+)*)")
 
@@ -112,10 +119,10 @@ def test_uv_pip_install_block_mentions_scitex_todo(base_def_text: str) -> None:
     # Arrange
     block = _uv_pip_install_block(base_def_text)
     # Act
-    present = "scitex-todo" in block
+    present = "scitex-cards" in block
     # Assert
     assert present, (
-        f"scitex-todo missing from uv pip install in apptainer-base.def:\n{block}"
+        f"scitex-cards missing from uv pip install in apptainer-base.def:\n{block}"
     )
 
 
@@ -123,10 +130,10 @@ def test_uv_pip_install_block_carries_mcp_extra(base_def_text: str) -> None:
     # Arrange
     block = _uv_pip_install_block(base_def_text)
     # Act
-    present = "scitex-todo[mcp]" in block
+    present = "scitex-cards[mcp]" in block
     # Assert
     assert present, (
-        "scitex-todo install must carry the [mcp] extra (pulls fastmcp>=2.0)"
+        "scitex-cards install must carry the [mcp] extra (pulls fastmcp>=2.0)"
         f" in apptainer-base.def:\n{block}"
     )
 
@@ -147,7 +154,7 @@ def test_uv_pip_install_block_pins_scitex_todo_minimum_version(
     floor = _requirement_floor(requirement)
     # Assert
     assert floor is not None, (
-        "scitex-todo install must carry a version specifier (>=, == or ~=)"
+        "scitex-cards install must carry a version specifier (>=, == or ~=)"
         f" in apptainer-base.def; got {requirement!r} in:\n{block}"
     )
 
@@ -178,12 +185,12 @@ def test_scitex_todo_floor_is_at_least_the_wip_gate_capability(
 @pytest.mark.parametrize(
     "requirement",
     [
-        "scitex-todo[mcp]>=0.8.0",  # exactly the capability floor
-        "scitex-todo[mcp]>=0.8",  # the same floor, written short
-        "scitex-todo[mcp]>=0.9.4",  # today's floor
-        "scitex-todo[mcp]>=0.9.4,<1.0",  # a floor with an upper bound
-        "scitex-todo[mcp]==0.9.8",  # an exact pin
-        "scitex-todo[mcp]>=1.0",  # a future major
+        "scitex-cards[mcp]>=0.8.0",  # exactly the capability floor
+        "scitex-cards[mcp]>=0.8",  # the same floor, written short
+        "scitex-cards[mcp]>=0.9.4",  # today's floor
+        "scitex-cards[mcp]>=0.9.4,<1.0",  # a floor with an upper bound
+        "scitex-cards[mcp]==0.9.8",  # an exact pin
+        "scitex-cards[mcp]>=1.0",  # a future major
     ],
 )
 def test_requirement_floor_accepts_the_capability_floor_or_stricter(
@@ -200,9 +207,9 @@ def test_requirement_floor_accepts_the_capability_floor_or_stricter(
 @pytest.mark.parametrize(
     "requirement",
     [
-        "scitex-todo[mcp]",  # unpinned — the drift that started this
-        "scitex-todo[mcp]>=0.3.0",  # the stale floor the old guard froze
-        "scitex-todo[mcp]>=0.7.50",  # the version the live SIFs shipped
+        "scitex-cards[mcp]",  # unpinned — the drift that started this
+        "scitex-cards[mcp]>=0.3.0",  # the stale floor the old guard froze
+        "scitex-cards[mcp]>=0.7.50",  # the version the live SIFs shipped
     ],
 )
 def test_requirement_floor_rejects_unpinned_or_pre_wip_gate(requirement: str) -> None:


### PR DESCRIPTION
Written by scitex-cards on sac's acceptance (DM 2026-07-17): the pin change that makes the next bake produce a fleet image carrying the renamed board package.

- **Pins**: `scitex-todo[mcp]==0.13.5` → `scitex-cards[mcp]==0.16.0` in BOTH layers (base + scitex). One line replaced, none added — the scitex-cards wheel ships both import names and both CLIs; installing the scitex-todo stub too would just add a second dist-info to confuse future probes. **Note**: your DM said `>=0.16.0`; I used `==0.16.0` because the .def's own in-file policy argues for exact pins (the `-P latest` incident: deliberate bumps, reproducible bakes). Flip to a floor in review if you prefer — one word.
- **Build gate** (kept, per your manifest-assertion doctrine): imports `WIP_STATUSES` from `scitex_cards` (canonical), asserts `scitex_todo is scitex_cards` (the shim aliasing to the SAME module objects is itself a ship-gate — un-cutover fleet code imports the old name), version print follows the installed dist.
- **Static-contract test** (`test_apptainer_base_def_scitex_todo.py`) updated to the new dist token; capability-floor design untouched (0.16.0 ≥ 0.8.0). 13/13 pass.

**On the dependency chain**: the claim that `sac image build` is still dead on #652 contradicts your own 01:23Z manifest report — that bake COMPLETED (rc=0 both layers, fresh 6.7GB image, symlinks swapped; contents stale because of exactly these pins). The build machinery is proven alive by its own artifact; after this PR merges, a re-bake should produce the right image, gated by your manifest assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)