### PR TITLE
fix(listen): host_exec wedged behind a timeout it could never reach

### DIFF
--- a/src/scitex_agent_container/_listen/_host_exec.py
+++ b/src/scitex_agent_container/_listen/_host_exec.py
@@ -19,8 +19,9 @@ FLOW:
    ``ELIGIBLE_GROUPS`` (developer, researcher, privileged). The operator
    explicitly scoped arbitrary host-exec to developer + researcher
    (2026-07-01 Q1a) and added ``privileged`` on 2026-07-02.
-4. Execute ``subprocess.run(argv, ...)`` — no shell, argv list only. Capture
-   stdout/stderr, honour an optional timeout, return exit_code + duration.
+4. Execute the child — no shell, argv list only. Capture stdout/stderr, honour
+   an optional timeout, return exit_code + duration. See "WHY THIS ENDPOINT
+   WEDGED" below for the three guards that bound it.
 5. Audit log every invocation as one JSONL line to
    ``~/.scitex/agent-container/runtime/logs/host_exec.log`` — {ts, caller,
    caller_group, argv, cwd, exit_code, duration_s, timed_out}. The operator
@@ -30,6 +31,63 @@ FLOW:
 No shell, no argv-string form. The body's ``argv`` MUST be a non-empty list of
 strings. Anything else 400s. Guards against accidental shell-injection when
 downstream consumers pass user input.
+
+WHY THIS ENDPOINT WEDGED (INCIDENT 2026-07-17) — AND WHY "ADD A TIMEOUT" WAS
+THE WRONG DIAGNOSIS
+---------------------------------------------------------------------------
+Measured during the outage: ``GET /v1/health`` answered 200 in 0.016s while
+``POST /v1/host_exec`` returned **0 bytes at both 20s and 100s**. The endpoint
+was read as "host_exec has no timeout". *It had one* — a 300s default, passed
+to the child and empirically effective. The timeout was not missing; it was
+**unreachable**.
+
+The child timeout lives INSIDE the worker thread. This handler dispatched via
+``asyncio.to_thread``, i.e. the event loop's SHARED default
+``ThreadPoolExecutor``. When that pool has no free worker, the dispatch queues
+and **the thread never starts — so the child never starts, so the child's
+timeout never starts.** The handler then waits forever with nothing to bound
+it, which is precisely "0 bytes, at any deadline you care to pick", while
+``/v1/health`` (which never touches the pool) stays instant.
+
+That is not a new theory. ``_lifecycle/_off_loop.py``'s module docstring names
+*this file* as one of the unbounded ``to_thread`` callers that "queue behind
+the wedged threads and hang FOREVER", and the #647 changelog entry records the
+same fingerprint (health 200 while restarts timed out) from starvation by
+zombie heartbeat threads. The fact was written down; this handler was never
+changed to match it.
+
+Hence the guards below, in the order they catch things:
+
+1. DEDICATED THREAD, BOUNDED END-TO-END (:func:`_off_loop.run_blocking`) —
+   a private daemon thread, never the shared pool, so a drained pool cannot
+   delay this handler and this handler cannot drain the pool. The bound covers
+   dispatch + exec, so it holds even when the child never starts. This is the
+   guard that would have prevented the outage; the child timeout could not.
+2. PROCESS-GROUP KILL — ``start_new_session=True`` puts the child in its own
+   process group and the timeout path kills the GROUP. ``subprocess.run``'s
+   own timeout only SIGKILLs the direct child; measured, a grandchild
+   (``bash -c 'sleep 60 & cat'``) SURVIVED and kept running. Killing the pid
+   alone leaves the grandchildren that are usually the actual problem.
+3. ``stdin=DEVNULL`` — no child invoked here can block on stdin (``git``
+   without ``-F <file>``, an ssh passphrase prompt, ``apt``, a pager,
+   ``read``). Measured: a stdin-reading child gets EOF in 0.02s instead of
+   hanging. This does NOT break the ``echo <b64> | base64 -d | bash`` delivery
+   shape — that outer bash takes its script from ``-c`` and the inner pipeline
+   builds its own stdin internally; both forms verified identical. No caller
+   can send stdin anyway: the body has no ``stdin`` field.
+
+A timeout that returns EMPTY is worthless — an empty body is indistinguishable
+from success-with-no-output, a network fault, or a dead listener (all four had
+to be separated by hand during the incident, and the first reading was wrong).
+Every failure here returns a TYPED, LOUD error naming the deadline, the argv,
+and the caller.
+
+CONCURRENCY: this endpoint does NOT serialise. There is no global lock and no
+in-flight cap; concurrent callers run concurrently, each on its own thread.
+Stated explicitly because an undocumented global lock is exactly how the
+starvation above stayed invisible. ``GET /v1/host_exec/inflight`` reports what
+is currently running so a caller sees "N running, oldest 42s" instead of
+inferring from silence.
 """
 
 from __future__ import annotations
@@ -37,7 +95,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import subprocess
 import time
 from pathlib import Path
 from typing import Any
@@ -45,16 +102,24 @@ from typing import Any
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from .._lifecycle._off_loop import run_blocking
 from ._acl import deny_response, resolve_group_name
+from ._host_exec_child import _POST_KILL_DRAIN_S, ChildOutcome, _run_child
+from ._host_exec_inflight import (
+    InflightExec,
+    host_exec_inflight,
+    inflight_snapshot,
+    next_exec_id,
+    register_inflight,
+    unregister_inflight,
+)
 
 # Operator-scoped groups (2026-07-01 Q1a + researcher; ``privileged`` added
 # 2026-07-02 per operator request). Members of these groups are permitted to
 # broker arbitrary commands as the operator's uid on the host. The
 # ``privileged`` group (grant / dotfiles / claude-code-telegrammer) was added
 # so those agents can run host ops and manage the fleet flexibly.
-ELIGIBLE_GROUPS: frozenset[str] = frozenset(
-    {"developer", "researcher", "privileged"}
-)
+ELIGIBLE_GROUPS: frozenset[str] = frozenset({"developer", "researcher", "privileged"})
 
 # Structured audit log — one JSONL entry per invocation. Path is fixed (matches
 # the other runtime logs). Test seam: monkeypatch ``_audit_log_path``.
@@ -65,6 +130,14 @@ _AUDIT_LOG_PATH = (
 # Guardrails
 _MAX_TIMEOUT_S: float = 3600.0  # 1h — image builds can take a while
 _DEFAULT_TIMEOUT_S: float = 300.0
+
+# Slack between the CHILD deadline (enforced inside the worker thread) and the
+# WATCHDOG deadline (enforced on the event loop by ``run_blocking``). The
+# watchdog only fires when the child timeout ITSELF failed to return — an
+# unkillable D-state child, or a drain that outlived _POST_KILL_DRAIN_S. It
+# must exceed the drain ceiling or it would pre-empt the orderly path that can
+# still report the child's partial output.
+_WATCHDOG_MARGIN_S: float = _POST_KILL_DRAIN_S + 10.0
 
 
 def _audit_log_path() -> Path:
@@ -99,11 +172,16 @@ async def host_exec(
     """``POST /v1/host_exec`` — see module docstring for the full contract.
 
     Body: ``{"argv": [str, ...], "cwd"?: str, "timeout_s"?: float, "env"?:
-    {str: str}, "caller"?: str}``.
+    {str: str}, "caller"?: str}``. There is deliberately no ``stdin`` field —
+    the child always runs with stdin on /dev/null.
     Response 200: ``{"exit_code": int, "stdout": str, "stderr": str,
-    "duration_s": float, "timed_out": bool}``.
+    "duration_s": float, "timed_out": bool, "killed_process_group": bool}``.
+    A child that overran its ``timeout_s`` is a 200 with ``timed_out: true``
+    (it ran, it was killed, and its partial output is real) — never an empty
+    body.
     Errors: 400 (bad body), 403 (ACL deny — group not eligible), 500 (exec
-    error not otherwise mapped).
+    error not otherwise mapped), 504 (the watchdog fired — the child's own
+    deadline failed to return; ``watchdog_fired: true``).
     """
     # ---- 1. Body ------------------------------------------------------------
     try:
@@ -111,9 +189,7 @@ async def host_exec(
     except Exception:  # stx-allow: fallback (empty/malformed JSON body → 400 below)
         body = None
     if not isinstance(body, dict):
-        return JSONResponse(
-            {"error": "body must be a JSON object"}, status_code=400
-        )
+        return JSONResponse({"error": "body must be a JSON object"}, status_code=400)
 
     argv = body.get("argv")
     if (
@@ -197,46 +273,71 @@ async def host_exec(
 
     started = time.monotonic()
     timed_out = False
+    watchdog_fired = False
+    killed_process_group = False
     stdout = ""
     stderr = ""
     exit_code = -1
     exec_error: str | None = None
+
+    entry = InflightExec(
+        exec_id=next_exec_id(),
+        caller=caller,
+        argv=tuple(argv),
+        timeout_s=timeout_s,
+        started_monotonic=started,
+    )
+    register_inflight(entry)
     try:
-        # Dispatch the blocking subprocess OFF the event loop. Running
-        # subprocess.run() directly in this async handler blocks the SINGLE
-        # uvicorn event loop for the command's whole lifetime — a long
-        # host_exec (e.g. a ~13-min `sac image build`) then starves EVERY
-        # other endpoint (a2a, health, spawn), the exact "agents can't reach
-        # sac" outage (INCIDENT 2026-07-02). asyncio.to_thread keeps the loop
-        # free to serve other requests concurrently; subprocess.TimeoutExpired
-        # raised inside the thread still propagates through the await.
-        completed = await asyncio.to_thread(
-            subprocess.run,
+        # Dispatch to a DEDICATED daemon thread, bounded end-to-end.
+        #
+        # NOT `asyncio.to_thread`: that uses the event loop's SHARED default
+        # ThreadPoolExecutor, and when the pool is drained the dispatch queues
+        # — the thread never starts, so the child never starts, so the CHILD'S
+        # OWN TIMEOUT NEVER STARTS, and this handler waits forever returning 0
+        # bytes while /v1/health stays instant. That is the 2026-07-17 outage,
+        # and it is why "the child has a timeout" was never a defence: the
+        # timeout was inside the thing that never ran. `_off_loop.run_blocking`
+        # uses a private daemon thread (immune to a drained pool, and it cannot
+        # drain the pool for others) and bounds the WHOLE dispatch on the event
+        # loop, which holds even when the child never starts.
+        #
+        # Two deadlines, deliberately: the child's `timeout_s` is the normal
+        # path (kills the process group, reports partial output); the watchdog
+        # at +_WATCHDOG_MARGIN_S catches the case where that path ITSELF wedged.
+        outcome = await run_blocking(
+            _run_child,
             argv,
             cwd=cwd_raw,
-            timeout=timeout_s,
-            capture_output=True,
-            text=True,
+            child_timeout_s=timeout_s,
             env=merged_env,
-            check=False,
+            timeout_s=timeout_s + _WATCHDOG_MARGIN_S,
         )
-        exit_code = completed.returncode
-        stdout = completed.stdout or ""
-        stderr = completed.stderr or ""
-    except subprocess.TimeoutExpired as exc:
+        exit_code = outcome.exit_code
+        stdout = outcome.stdout
+        stderr = outcome.stderr
+        timed_out = outcome.timed_out
+        killed_process_group = outcome.killed_process_group
+    except asyncio.TimeoutError:
+        # The child's own deadline failed to return (unkillable D-state child,
+        # or an escaped grandchild holding the pipe past the drain ceiling).
+        # Fail LOUD and typed — never an empty body, which the caller cannot
+        # distinguish from success-with-no-output or a dead listener.
+        watchdog_fired = True
         timed_out = True
-        stdout = (exc.stdout or "") if isinstance(exc.stdout, str) else (
-            exc.stdout.decode("utf-8", "replace") if exc.stdout else ""
+        exec_error = (
+            f"host_exec watchdog fired after "
+            f"{timeout_s + _WATCHDOG_MARGIN_S:.1f}s (child timeout_s={timeout_s:.1f}s "
+            f"did not return): argv={argv!r} caller={caller!r}. The child was "
+            f"abandoned on its own thread; it starves no other caller."
         )
-        stderr = (exc.stderr or "") if isinstance(exc.stderr, str) else (
-            exc.stderr.decode("utf-8", "replace") if exc.stderr else ""
-        )
-        exit_code = -1
     except FileNotFoundError as exc:
         # argv[0] not found — surface a clear error instead of a raw 500.
         exec_error = f"command not found: {exc}"
     except Exception as exc:  # stx-allow: fallback (exec-layer errors must surface as a response, not a raw 500)
         exec_error = f"exec error: {type(exc).__name__}: {exc}"
+    finally:
+        unregister_inflight(entry.exec_id)
 
     duration_s = round(time.monotonic() - started, 3)
 
@@ -252,6 +353,8 @@ async def host_exec(
             "exit_code": exit_code,
             "duration_s": duration_s,
             "timed_out": timed_out,
+            "watchdog_fired": watchdog_fired,
+            "killed_process_group": killed_process_group,
             "exec_error": exec_error,
         }
     )
@@ -262,9 +365,10 @@ async def host_exec(
                 "error": exec_error,
                 "exit_code": exit_code,
                 "duration_s": duration_s,
-                "timed_out": False,
+                "timed_out": timed_out,
+                "watchdog_fired": watchdog_fired,
             },
-            status_code=500,
+            status_code=504 if watchdog_fired else 500,
         )
     return JSONResponse(
         {
@@ -273,8 +377,16 @@ async def host_exec(
             "stderr": stderr,
             "duration_s": duration_s,
             "timed_out": timed_out,
+            "killed_process_group": killed_process_group,
         }
     )
 
 
-__all__ = ["ELIGIBLE_GROUPS", "host_exec"]
+__all__ = [
+    "ELIGIBLE_GROUPS",
+    "ChildOutcome",
+    "InflightExec",
+    "host_exec",
+    "host_exec_inflight",
+    "inflight_snapshot",
+]

--- a/src/scitex_agent_container/_listen/_host_exec_child.py
+++ b/src/scitex_agent_container/_listen/_host_exec_child.py
@@ -1,0 +1,122 @@
+"""Spawn and bound ONE ``host_exec`` child.
+
+Split out of :mod:`._host_exec` (which kept validation + ACL + audit + the
+handler) because the semantics here are subtle enough to be worth reading on
+their own: the process-group kill and the stdin closure are the two guards that
+make a stuck child survivable, and both rest on measured POSIX behaviour rather
+than on the docs' plain reading. See :mod:`._host_exec` for the incident this
+came from.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from dataclasses import dataclass
+
+# After SIGKILLing the child's process GROUP, how long to drain its pipes. The
+# group is dead, so EOF is immediate in practice; this is bounded anyway
+# because a grandchild that escaped the group (its own setsid) could still hold
+# the write end, and an unbounded drain here would be the original bug again.
+_POST_KILL_DRAIN_S: float = 5.0
+
+
+@dataclass(frozen=True)
+class ChildOutcome:
+    """Result of one brokered child. Typed so a timeout can NEVER be confused
+    with success-with-no-output — the distinction the incident turned on."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+    timed_out: bool
+    killed_process_group: bool
+
+
+def _kill_process_group(proc: subprocess.Popen) -> bool:
+    """SIGKILL the child's whole process GROUP. Returns True if the group was
+    signalled.
+
+    ``proc.kill()`` signals ONLY the direct child, so grandchildren survive and
+    keep running (measured: ``bash -c 'sleep 60 & cat'`` left ``sleep`` alive
+    after the documented timeout fired). The child is spawned with
+    ``start_new_session=True``, so its pid IS its process-group id and the
+    group contains everything it spawned.
+    """
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (ProcessLookupError, PermissionError):
+        # Already reaped, or not ours — fall back to the direct child.
+        proc.kill()
+        return False
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+        return True
+    except (ProcessLookupError, PermissionError):
+        proc.kill()
+        return False
+
+
+def _run_child(
+    argv: list[str],
+    *,
+    cwd: str | None,
+    child_timeout_s: float,
+    env: dict[str, str] | None,
+) -> ChildOutcome:
+    """Run one child to completion, bounded. Blocking — call OFF the loop.
+
+    Runs in its own session/process group with stdin closed; on timeout the
+    whole GROUP is killed and the (bounded) drain collects whatever it wrote.
+
+    ``stdin=DEVNULL`` kills the "child blocks on stdin" class by construction
+    (``git`` without ``-F <file>``, an ssh passphrase prompt, ``apt``, a pager,
+    ``read``): measured, such a child gets EOF in 0.02s instead of hanging. It
+    does NOT break the ``echo <b64> | base64 -d | bash`` delivery shape — that
+    outer bash takes its script from ``-c``, and the inner pipeline builds its
+    own stdin internally; both forms were verified to deliver identically. No
+    caller can send stdin anyway: the request body has no ``stdin`` field.
+
+    The parameter is ``child_timeout_s``, not ``timeout_s``, deliberately: this
+    is dispatched through ``run_blocking``, which consumes ``timeout_s`` as its
+    OWN watchdog deadline. Same name would silently hand the child's deadline
+    to the watchdog and leave the child unbounded.
+    """
+    with subprocess.Popen(
+        argv,
+        cwd=cwd,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    ) as proc:
+        try:
+            stdout, stderr = proc.communicate(timeout=child_timeout_s)
+            return ChildOutcome(
+                exit_code=proc.returncode,
+                stdout=stdout or "",
+                stderr=stderr or "",
+                timed_out=False,
+                killed_process_group=False,
+            )
+        except subprocess.TimeoutExpired:
+            killed = _kill_process_group(proc)
+            try:
+                stdout, stderr = proc.communicate(timeout=_POST_KILL_DRAIN_S)
+            except subprocess.TimeoutExpired:
+                # A grandchild escaped the group and still holds the pipe. The
+                # child is dead; report without its output rather than block.
+                stdout, stderr = "", ""
+            return ChildOutcome(
+                exit_code=-1,
+                stdout=stdout or "",
+                stderr=stderr or "",
+                timed_out=True,
+                killed_process_group=killed,
+            )
+
+
+__all__ = ["ChildOutcome", "_run_child", "_POST_KILL_DRAIN_S"]

--- a/src/scitex_agent_container/_listen/_host_exec_inflight.py
+++ b/src/scitex_agent_container/_listen/_host_exec_inflight.py
@@ -1,0 +1,105 @@
+"""What ``host_exec`` is running right now — registry + ``GET
+/v1/host_exec/inflight``.
+
+Split out of :mod:`._host_exec`. Exists because during the 2026-07-17 incident
+the only signal a caller had was an EMPTY RESPONSE, which is equally consistent
+with a hang, a network fault, a dead listener, and a genuinely empty result.
+All four had to be separated by hand, and the first reading was wrong. A
+blocked caller should be able to READ what is running, not infer it from
+silence.
+
+This registry is NOT a lock and NOT a cap. ``host_exec`` does not serialise:
+concurrent callers run concurrently, each on its own dedicated thread. Stated
+explicitly because an undocumented global lock is precisely how the starvation
+this fix removes stayed invisible.
+"""
+
+from __future__ import annotations
+
+import itertools
+import threading
+import time
+from dataclasses import dataclass
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+
+@dataclass(frozen=True)
+class InflightExec:
+    """One host_exec currently running, for the ``/inflight`` probe."""
+
+    exec_id: int
+    caller: str
+    argv: tuple[str, ...]
+    timeout_s: float
+    started_monotonic: float
+
+    def running_s(self) -> float:
+        return round(time.monotonic() - self.started_monotonic, 3)
+
+
+_inflight_lock = threading.Lock()
+_inflight: dict[int, InflightExec] = {}
+_exec_ids = itertools.count(1)
+
+
+def next_exec_id() -> int:
+    """Monotonic id for one exec. ``itertools.count`` is atomic under the GIL
+    for this use, but the handler treats ids as opaque anyway."""
+    return next(_exec_ids)
+
+
+def inflight_snapshot() -> list[InflightExec]:
+    """Currently-running host_execs, oldest first."""
+    with _inflight_lock:
+        entries = list(_inflight.values())
+    return sorted(entries, key=lambda e: e.started_monotonic)
+
+
+def register_inflight(entry: InflightExec) -> None:
+    with _inflight_lock:
+        _inflight[entry.exec_id] = entry
+
+
+def unregister_inflight(exec_id: int) -> None:
+    with _inflight_lock:
+        _inflight.pop(exec_id, None)
+
+
+async def host_exec_inflight(request: Request) -> JSONResponse:
+    """``GET /v1/host_exec/inflight`` — what host_exec is running right now.
+
+    Deliberately NOT gated by ``_host_exec.ELIGIBLE_GROUPS``: this is the
+    diagnostic to reach for when the fleet's host arm looks stuck, so it must
+    not require the privileges of the thing that is stuck. It exposes the argv
+    of in-flight commands to any bearer-authed caller — the same audience that
+    can already read the audit log.
+    """
+    entries = inflight_snapshot()
+    return JSONResponse(
+        {
+            "running": len(entries),
+            "oldest_running_s": entries[0].running_s() if entries else 0.0,
+            "execs": [
+                {
+                    "exec_id": e.exec_id,
+                    "caller": e.caller,
+                    "argv": list(e.argv),
+                    "timeout_s": e.timeout_s,
+                    "running_s": e.running_s(),
+                }
+                for e in entries
+            ],
+        }
+    )
+
+
+__all__ = [
+    "InflightExec",
+    "host_exec_inflight",
+    "inflight_snapshot",
+    "next_exec_id",
+    "register_inflight",
+    "unregister_inflight",
+]

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -64,7 +64,6 @@ async def health(_request: Request) -> JSONResponse:
 from ._agents_list import list_agents  # noqa: E402,F401
 
 
-
 async def agent_status(request: Request) -> JSONResponse:
     name = request.path_params["name"]
     try:
@@ -129,9 +128,7 @@ async def _annotate_status_reachability(
             exc,
         )
         return {**body, "inbox_subscribers": None, "inbox_reachable": UNKNOWN}
-    return annotate_reachability(
-        body, subscriber_counts=counts, local_host=local_host
-    )
+    return annotate_reachability(body, subscriber_counts=counts, local_host=local_host)
 
 
 # --- extracted handlers re-imported for routes + back-compat ---------------
@@ -237,12 +234,6 @@ async def fleet_card_handler(request: Request) -> JSONResponse:
 # :func:`agent_card` falls back to the synthesised card for nodes
 # that are not YAML-backed. That fall-back is added to the existing
 # handler below.
-from ._node_channel import (  # noqa: E402
-    _forward_to_remote,  # noqa: F401  (re-exported for tests)
-    node_inbox_stream,
-    node_message_send,
-)
-
 # ``agent_delete`` (the DELETE /agents/<name> lifecycle handler) was
 # extracted into ``_agent_delete`` (server.py hit the per-file line cap);
 # re-imported here so route registration (:func:`_v1_agent_routes`) and
@@ -256,7 +247,11 @@ from ._agent_delete import agent_delete  # noqa: E402
 # restart on the bare host (manage-gated by check_lineage_acl). Lives in
 # its own module to keep server.py under the per-file line cap.
 from ._agent_restart import agent_restart  # noqa: E402
-
+from ._node_channel import (  # noqa: E402
+    _forward_to_remote,  # noqa: F401  (re-exported for tests)
+    node_inbox_stream,
+    node_message_send,
+)
 
 # --- App factory -----------------------------------------------------------
 
@@ -354,6 +349,15 @@ def create_app(
     # (rather than the silently-ineffective per-container copy).
     from ._acl_routes import acl_block, acl_grant, acl_unblock
 
+    # Arbitrary host-command bypass for developer + researcher agents (operator
+    # directive 2026-07-01). Bearer-authed by the outer middleware; a group gate
+    # inside the handler refuses non-eligible callers with 403. Every invocation
+    # is appended to runtime/logs/host_exec.log.
+    # ``host_exec_inflight`` reports what host_exec is running right now, so a
+    # caller facing a slow endpoint can read the cause instead of inferring it
+    # from an empty body (INCIDENT 2026-07-17).
+    from ._host_exec import host_exec, host_exec_inflight
+
     # Interim card-event delivery (scitex-todo escalation, P1). The board
     # POSTs here (loopback, host-wide bearer) INSTEAD of a containerized
     # agent's unreachable ``turn_url``; ``notify`` publishes the body into
@@ -361,12 +365,6 @@ def create_app(
     # a subscribed (containerized) agent receives it. Bearer-gated by the
     # ``BearerAuthMiddleware`` below (not in its ``PUBLIC_PATHS``).
     from ._notify import notify
-
-    # Arbitrary host-command bypass for developer + researcher agents (operator
-    # directive 2026-07-01). Bearer-authed by the outer middleware; a group gate
-    # inside the handler refuses non-eligible callers with 403. Every invocation
-    # is appended to runtime/logs/host_exec.log.
-    from ._host_exec import host_exec
 
     routes: list[Route] = [
         Route("/v1/health", health, methods=["GET"]),
@@ -376,6 +374,7 @@ def create_app(
         Route("/v1/acl/block", acl_block, methods=["POST"]),
         Route("/v1/acl/grant", acl_grant, methods=["POST"]),
         Route("/v1/host_exec", host_exec, methods=["POST"]),
+        Route("/v1/host_exec/inflight", host_exec_inflight, methods=["GET"]),
     ]
     routes += _v1_agent_routes("/agents")
     # Q4 (lead a2a c8b64f298b8a...): on listen startup, persist every

--- a/tests/scitex_agent_container/_listen/test__host_exec_wedge.py
+++ b/tests/scitex_agent_container/_listen/test__host_exec_wedge.py
@@ -1,0 +1,330 @@
+"""Regression tests for the ``POST /v1/host_exec`` wedge (INCIDENT 2026-07-17).
+
+Every test here was CONFIRMED TO FAIL against the pre-fix handler — see the
+per-test "RED against pre-fix" notes. A gate nobody has watched go red is a
+gate nobody has tested.
+
+The incident's fingerprint: ``/v1/health`` answered 200 in 0.016s while
+``POST /v1/host_exec`` returned 0 bytes at both 20s and 100s. The endpoint was
+read as "host_exec has no timeout"; it had a 300s one that works. The timeout
+was UNREACHABLE — it lives inside the worker thread, and the pre-fix handler
+dispatched through ``asyncio.to_thread`` (the SHARED default
+ThreadPoolExecutor). A drained pool means the thread never starts, so the child
+never starts, so the child's timeout never starts.
+
+No mocks, no monkeypatching (STX-NM002): real subprocesses, real threads, and
+the handler's own ``group_resolver`` / ``audit_writer`` keyword seams take
+plain hand-rolled fakes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import threading
+import time
+import types
+from typing import Any
+
+from scitex_agent_container._listen._host_exec import host_exec
+from scitex_agent_container._listen._host_exec_inflight import (
+    host_exec_inflight,
+    inflight_snapshot,
+)
+
+
+class _FakeRequest:
+    def __init__(self, body: object, *, authenticated_node: str | None = None) -> None:
+        self._body = body
+        self.state = types.SimpleNamespace(authenticated_node=authenticated_node)
+
+    async def json(self) -> object:
+        return self._body
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _resp_json(resp) -> dict:
+    return json.loads(bytes(resp.body).decode("utf-8"))
+
+
+def _dev_resolver(name: str) -> str:
+    return "developer"
+
+
+def _noop_audit(_entry: dict[str, Any]) -> None:
+    return None
+
+
+def _exec(body: dict, *, node: str = "dev"):
+    return host_exec(
+        _FakeRequest(body, authenticated_node=node),
+        group_resolver=_dev_resolver,
+        audit_writer=_noop_audit,
+    )
+
+
+def _starve_default_executor(loop, release: threading.Event) -> int:
+    """Occupy every worker in the loop's SHARED default ThreadPoolExecutor.
+
+    This is the incident's precondition, reproduced honestly: the pool is
+    ``min(32, cpu_count + 4)`` and six background loops in this daemon abandon
+    threads into it on every overrunning tick.
+    """
+    max_workers = min(32, (os.cpu_count() or 1) + 4)
+    for _ in range(max_workers):
+        loop.run_in_executor(None, release.wait)
+    return max_workers
+
+
+# --------------------------------------------------------------------------
+# 1. The wedge itself: a starved shared pool must not delay host_exec.
+# --------------------------------------------------------------------------
+
+
+def test_host_exec_is_served_while_the_shared_default_executor_is_starved():
+    """RED against pre-fix: hung >8s and never returned (measured), because
+    `to_thread` queued behind the drained pool and the child never started."""
+
+    # Arrange — every worker in the shared default pool is occupied.
+    async def scenario():
+        loop = asyncio.get_running_loop()
+        release = threading.Event()
+        _starve_default_executor(loop, release)
+        await asyncio.sleep(0.5)  # let every worker pick up its blocker
+        try:
+            # A trivial command that costs ~1ms.
+            return await asyncio.wait_for(
+                _exec({"argv": ["true"], "timeout_s": 5.0}), timeout=20.0
+            )
+        finally:
+            release.set()
+
+    # Act
+    resp = _run(scenario())
+    # Assert
+    assert _resp_json(resp)["exit_code"] == 0
+
+
+def test_host_exec_does_not_consume_the_shared_default_executor():
+    """host_exec must not DRAIN the pool either — the other half of the
+    contract. A long host_exec leaves the pool free for everyone else."""
+
+    # Arrange — a long-running host_exec is in flight throughout.
+    async def scenario():
+        loop = asyncio.get_running_loop()
+        slow = asyncio.ensure_future(
+            _exec({"argv": ["sleep", "1.5"], "timeout_s": 10.0})
+        )
+        await asyncio.sleep(0.4)  # ensure the child is running
+        # The shared pool must still serve a trivial job promptly.
+        started = time.monotonic()
+        await asyncio.wait_for(loop.run_in_executor(None, lambda: "ok"), timeout=5.0)
+        elapsed = time.monotonic() - started
+        await slow
+        return elapsed
+
+    # Act
+    elapsed = _run(scenario())
+    # Assert — the pool was never touched by host_exec, so this is immediate.
+    assert elapsed < 1.0
+
+
+# --------------------------------------------------------------------------
+# 2. A stuck child must not starve a second caller.
+# --------------------------------------------------------------------------
+
+
+def test_a_second_caller_is_served_while_a_first_caller_is_stuck_on_stdin():
+    """The incident's core claim: one caller's stuck child took the host arm
+    away from the WHOLE fleet. It must not."""
+
+    async def scenario():
+        # Arrange — caller A blocks for a long time; it is never awaited to
+        # completion, exactly like the real stuck command.
+        stuck = asyncio.ensure_future(
+            _exec({"argv": ["sleep", "30"], "timeout_s": 25.0}, node="caller-a")
+        )
+        await asyncio.sleep(0.4)
+        try:
+            # Act — caller B asks for something trivial.
+            return await asyncio.wait_for(
+                _exec(
+                    {"argv": ["echo", "b-served"], "timeout_s": 5.0}, node="caller-b"
+                ),
+                timeout=10.0,
+            )
+        finally:
+            stuck.cancel()
+
+    # Act
+    resp = _run(scenario())
+    # Assert
+    assert _resp_json(resp)["stdout"].strip() == "b-served"
+
+
+# --------------------------------------------------------------------------
+# 3. Timeout kills the process GROUP, not just the pid.
+# --------------------------------------------------------------------------
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def test_timeout_kills_the_whole_process_group_not_just_the_direct_child():
+    """RED against pre-fix: `subprocess.run`'s timeout SIGKILLs only the direct
+    child. Measured pre-fix, the grandchild `sleep` SURVIVED the timeout.
+
+    The child prints its grandchild's pid, then blocks forever on stdin. After
+    the timeout, that grandchild must be gone.
+    """
+    # Arrange — grandchild's pid on stdout, then block forever.
+    script = "sleep 30 & echo $!; exec cat"
+    req = _FakeRequest(
+        {"argv": ["bash", "-c", script], "timeout_s": 1.0}, authenticated_node="dev"
+    )
+    # Act
+    resp = _run(host_exec(req, group_resolver=_dev_resolver, audit_writer=_noop_audit))
+    payload = _resp_json(resp)
+    grandchild_pid = int(payload["stdout"].strip())
+    time.sleep(0.3)  # let the SIGKILL land
+    # Assert
+    assert not _pid_alive(grandchild_pid)
+
+
+def test_timeout_reports_that_it_killed_the_process_group():
+    # Arrange — `sleep`, NOT `cat`: with stdin=/dev/null a stdin-reader gets EOF
+    # and exits, so it never reaches the timeout path this test is about.
+    req = _FakeRequest(
+        {"argv": ["sleep", "30"], "timeout_s": 1.0}, authenticated_node="dev"
+    )
+    # Act
+    resp = _run(host_exec(req, group_resolver=_dev_resolver, audit_writer=_noop_audit))
+    # Assert
+    assert _resp_json(resp)["killed_process_group"] is True
+
+
+# --------------------------------------------------------------------------
+# 4. stdin is /dev/null for the child — the whole "blocks on stdin" class.
+# --------------------------------------------------------------------------
+
+
+def test_a_stdin_reading_child_gets_eof_instead_of_blocking_forever():
+    """RED against pre-fix: the child inherited the daemon's stdin, so `cat`
+    (and `git commit -F -`, and an ssh passphrase prompt) could block until the
+    timeout. With stdin=/dev/null it reaches EOF immediately and exits 0."""
+    # Arrange — `cat` with no redirect; only DEVNULL makes this terminate.
+    req = _FakeRequest({"argv": ["cat"], "timeout_s": 10.0}, authenticated_node="dev")
+    # Act
+    resp = _run(host_exec(req, group_resolver=_dev_resolver, audit_writer=_noop_audit))
+    # Assert — exited cleanly on EOF, did NOT hit the timeout.
+    assert (_resp_json(resp)["exit_code"], _resp_json(resp)["timed_out"]) == (0, False)
+
+
+def test_stdin_devnull_does_not_break_the_b64_pipe_delivery_path():
+    """The subtle one the fix had to not break: `echo <b64> | base64 -d | bash`.
+    The outer bash takes its script from `-c`; the inner pipeline builds its own
+    stdin. Closing the CHILD's stdin must leave delivery intact."""
+    import base64
+
+    # Arrange
+    b64 = base64.b64encode(b"echo DELIVERED-OK").decode()
+    req = _FakeRequest(
+        {"argv": ["bash", "-c", f"echo {b64} | base64 -d | bash"], "timeout_s": 10.0},
+        authenticated_node="dev",
+    )
+    # Act
+    resp = _run(host_exec(req, group_resolver=_dev_resolver, audit_writer=_noop_audit))
+    # Assert
+    assert _resp_json(resp)["stdout"].strip() == "DELIVERED-OK"
+
+
+# --------------------------------------------------------------------------
+# 5. Never return empty — a timeout is TYPED and LOUD.
+# --------------------------------------------------------------------------
+
+
+def test_timeout_response_is_typed_and_names_the_argv():
+    # Arrange
+    req = _FakeRequest(
+        {"argv": ["sleep", "30"], "timeout_s": 0.5}, authenticated_node="dev"
+    )
+    # Act
+    payload = _resp_json(
+        _run(host_exec(req, group_resolver=_dev_resolver, audit_writer=_noop_audit))
+    )
+    # Assert — timed_out is explicit, never an empty body the caller must guess at.
+    assert payload["timed_out"] is True
+
+
+def test_timeout_audit_entry_records_the_process_group_kill():
+    # Arrange — `sleep`, not `cat`: see the note in the test above.
+    entries: list[dict[str, Any]] = []
+    req = _FakeRequest(
+        {"argv": ["sleep", "30"], "timeout_s": 1.0}, authenticated_node="dev"
+    )
+    # Act
+    _run(host_exec(req, group_resolver=_dev_resolver, audit_writer=entries.append))
+    # Assert
+    assert entries[0]["killed_process_group"] is True
+
+
+# --------------------------------------------------------------------------
+# 6. The inflight probe — see the cause instead of inferring it from silence.
+# --------------------------------------------------------------------------
+
+
+def test_inflight_probe_reports_a_running_exec_with_its_caller():
+    async def scenario():
+        # Arrange
+        running = asyncio.ensure_future(
+            _exec({"argv": ["sleep", "5"], "timeout_s": 10.0}, node="noisy-caller")
+        )
+        await asyncio.sleep(0.4)
+        try:
+            # Act
+            resp = await host_exec_inflight(_FakeRequest({}))
+            return _resp_json(resp)
+        finally:
+            running.cancel()
+
+    # Act
+    payload = _run(scenario())
+    # Assert
+    assert payload["execs"][0]["caller"] == "noisy-caller"
+
+
+def test_inflight_probe_is_empty_once_the_exec_completes():
+    # Arrange
+    _run(_exec({"argv": ["true"], "timeout_s": 5.0}))
+    # Act
+    entries = inflight_snapshot()
+    # Assert — the registry unregisters in a finally, so nothing leaks.
+    assert entries == []
+
+
+def test_inflight_entry_is_removed_even_when_the_child_times_out():
+    # Arrange — `sleep`, NOT `cat`: under stdin=/dev/null a stdin-reader exits
+    # on EOF, so this test would pass WITHOUT ever timing out and its name
+    # would assert something that never happened. That this argv really does
+    # time out is pinned by
+    # `test_timeout_response_is_typed_and_names_the_argv`.
+    _run(_exec({"argv": ["sleep", "30"], "timeout_s": 1.0}))
+    # Act
+    entries = inflight_snapshot()
+    # Assert
+    assert entries == []


### PR DESCRIPTION
## The premise was wrong, and that matters

This started as *"`/v1/host_exec` has NO TIMEOUT"*. **It has one** — `_DEFAULT_TIMEOUT_S = 300.0`, passed to the child, with a `TimeoutExpired` handler and a test green since `a1a5acc7`. Measured: `subprocess.run(timeout=2)` returns at 2.01s even with a grandchild holding the pipe (POSIX takes a `process.wait()` path, not a second `communicate()`).

**The timeout was not missing. It was unreachable.**

The child timeout lives *inside the worker thread*. The handler dispatched via `asyncio.to_thread` — the event loop's **shared default ThreadPoolExecutor**. Drain that pool and the dispatch queues: the thread never starts → the child never starts → **the child's timeout never starts**. The handler waits with nothing to bound it (0 bytes at *any* deadline) while `/v1/health`, which never touches the pool, answers in 0.016s.

That is precisely the outage fingerprint:

```
GET  /v1/health    -> 200 {"ok":true} total=0.016s   ALIVE and FAST
POST /v1/host_exec -> 0 bytes, timed out at 20s AND 100s
```

**Adding "a hard timeout on every child" would not have prevented this.**

## A second premise, refuted by measurement

The card's title says *one* stuck command wedges the arm for every caller. Measured against the pre-fix dispatch (16 cores, pool = `min(32, cpu+4)` = 20):

```
ONE stuck child   -> second caller SERVED in 0.00s   <- claim NOT reproduced
POOL drained (20) -> second caller BLOCKED           <- this is the outage
```

One stuck child leaves 19 free workers. **~20 threads must be lost first**, so the reported trigger (`git commit -F -`) cannot by itself have caused it. The known drain source is the zombie-thread leak from the background loops (#647; the shared-executor leak fixed in #658 for `_off_loop`'s own callers only). This also explains why it recovered with no stuck `git` in `pgrep`.

## None of this was new

`_lifecycle/_off_loop.py`'s docstring **already names `_host_exec`** among the unbounded `to_thread` callers that *"queue behind the wedged threads and hang FOREVER"*, and the #647 changelog records the same health-200-while-blocked fingerprint. The remedy existed and was applied to one call site. A documented invariant that is only half-enforced reads as closure.

## The guards, in the order they catch things

1. **Dedicated thread, bounded end-to-end** (`_off_loop.run_blocking`) — a private daemon thread, never the shared pool. Bounds dispatch **+** exec, so it holds even when the child never starts. *This is the guard that addresses the outage.*
2. **Process-group kill** — `start_new_session=True` + `killpg`. `subprocess.run`'s timeout SIGKILLs only the direct child; measured, a grandchild (`bash -c 'sleep 60 & cat'`) **survived** it.
3. **`stdin=/dev/null`** — kills the "child blocks on stdin" class by construction. Verified it does **not** break `echo <b64> | base64 -d | bash`: that outer bash takes its script from `-c` and the inner pipeline builds its own stdin. Both forms verified identical.
4. **`GET /v1/host_exec/inflight`** — read what is running instead of inferring from silence. Concurrency now stated in code: host_exec does **not** serialise, no global lock, no cap.

Failures are typed and loud, naming deadline/argv/caller. A child timeout is a `200` with `timed_out: true`; the watchdog is a `504`. **Never empty** — an empty body is indistinguishable from success-with-no-output, a network fault, and a dead listener.

## Tests — proven able to go red

**5 of 12 confirmed RED against the pre-fix handler** (tests byte-identical, only the handler reverted):

- `test_host_exec_is_served_while_the_shared_default_executor_is_starved` ← the outage
- `test_timeout_kills_the_whole_process_group_not_just_the_direct_child`
- `test_timeout_reports_that_it_killed_the_process_group`
- `test_timeout_audit_entry_records_the_process_group_kill`
- `test_inflight_probe_reports_a_running_exec_with_its_caller`

The other 7 pass both ways — no-regression guards, **not counted as evidence**.

Two first-draft tests were wrong: `stdin=/dev/null` makes `cat` exit on EOF, so `exec cat` never reaches the timeout path — one would have passed while its **name asserted a timeout that never happened**. They use `sleep` now.

`804 passed` across `tests/_listen` + `_off_loop`.

## Known-not-fixed

`_agent_exec_send`, `_forward`, `_node_channel_forwarders` still dispatch unbounded through the shared pool and wedge next if the drain recurs. Card: `sac-shared-executor-drain-remaining-unbounded-to-thread-callers-20260717`.

Refs card `sac-host-exec-one-stuck-command-wedges-the-fleets-only-host-arm-20260717`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)