### PR TITLE
fix(cli): accounts list usage bars — one block per account, reset time before the bar

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
@@ -12,10 +12,11 @@ percentages; the table holds only what the bars cannot express"):
    credentials; untouched by the 2026-07-11 redesign).
 2. The Stored-accounts table — exactly ``Account | Status | Last
    Update`` (:func:`._account_list_render.render_stored_table`).
-3. The usage-bars block — per-account 5h/7d bars, each percentage
-   carrying its compact relative reset hint (``29% (in 4h05m)`` /
-   ``66% (in 2d 3h)``), plus the rolling-window legend when a row has
-   no cached reset timestamps
+3. The usage-bars block — one 3-line block per account (operator
+   mockup 2026-07-17): the account name, then one line per window with
+   the relative reset hint BEFORE the bar (``5h (in 4h05m) [..] (29%)``),
+   a blank line between accounts; plus the rolling-window legend when a
+   row has no cached reset timestamps
    (:mod:`._account_usage_bars` / :func:`._account_list_render.rolling_legend_line`).
 4. The one-line fleet 7-day capacity-used figure.
 
@@ -57,10 +58,10 @@ def account_list(as_json: bool, refresh: bool) -> None:
     (operator directive 2026-07-11): the Stored-accounts table is
     exactly Account | Status | Last Update — the status cell carries
     the live token TTL (``VALID +2h26m``) — while the monospace
-    usage-bars block below it owns the 5h/7d percentages, each with
-    its compact relative reset hint (``29% (in 4h05m)`` /
-    ``66% (in 2d 3h)``), followed by a single fleet 7-day
-    capacity-used line.
+    usage-bars block below it owns the 5h/7d percentages, one 3-line
+    block per account with the relative reset hint before each bar
+    (``5h (in 4h05m) [..] (29%)``; operator mockup 2026-07-17),
+    followed by a single fleet 7-day capacity-used line.
 
     \b
     Fleet 7d capacity used

--- a/src/scitex_agent_container/cli_pkg/_account_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_render.py
@@ -183,7 +183,8 @@ def rolling_legend_line() -> str:
     """
     return (
         "Legend: 5h = rolling 5-hour window; 7d = rolling 7-day window. "
-        "(in Xh Ym / in Xd Yh next to the % is the time until the next reset.)"
+        "(in XhYYm / in XdYYh after the window label is the time until "
+        "the next reset.)"
     )
 
 

--- a/src/scitex_agent_container/cli_pkg/_account_usage_bars.py
+++ b/src/scitex_agent_container/cli_pkg/_account_usage_bars.py
@@ -6,24 +6,34 @@ scan across accounts. This module adds two purely-additive, purely-pure
 (no I/O, no clock beyond an injectable ``now``) surfaces the CLI prints
 BELOW the existing table:
 
-1. A monospace **usage-bars block** — one fixed-width horizontal bar per
-   window (5h short window + 7d window) per account, so utilisation is
-   visible at a glance and the bars line up vertically across accounts.
-   Since the 2026-07-11 dedupe directive ("the bars own the
-   percentages; the table holds only what the bars cannot express")
-   each percentage also carries a compact per-window reset hint. The
-   operator (2026-07-13) wants that hint to read as the time REMAINING
-   until the window resets — relative, not an absolute wall-clock —
-   ``(in 4h05m)`` for the 5h window, ``(in 2d 3h)`` for the 7d window::
+1. A monospace **usage-bars block** — one 3-line BLOCK per account
+   (operator mockup 2026-07-17, verbatim spec: 「usage bars のところ
+   ちゃんとスペース取って書いてみたらどうでしょうか？」): the account
+   name, then ONE line per window (5h, then 7d), a blank line between
+   accounts. The one-line-per-account layout it replaces crammed both
+   windows' bars + percentages + reset hints into ~120 chars and
+   wrapped on a normal terminal. Since the 2026-07-11 dedupe directive
+   the bars own the percentages; the per-window reset hint reads as the
+   time REMAINING until the window resets (operator 2026-07-13 —
+   relative, not a wall clock) and sits BEFORE the bar, right after the
+   window label — deliberate (operator 2026-07-17): it foregrounds the
+   time-to-reset the credential picker reasons about::
 
-       wyusuuke-gmail-com   5h [██████░░░░░░░░░░░░░░]  29% (in 4h05m)   7d [█████████████░░░░░░░]  66% (in 2d 3h)
-       ywatanabe-scitex-ai  5h [███░░░░░░░░░░░░░░░░░]  14%              7d [███░░░░░░░░░░░░░░░░░]  15% (in 5d 0h)
+       Usage bars (5h / 7d out of 100%):
+       - wyusuuke-gmail-com
+         5h (in 4h05m) [██████░░░░░░░░░░░░░░] (29%)
+         7d (in 2d03h) [█████████████░░░░░░░] (66%)
+
+       - ywatanabe-scitex-ai
+         5h            [███░░░░░░░░░░░░░░░░░] (14%)
+         7d (in 5d00h) [███░░░░░░░░░░░░░░░░░] (15%)
 
    A bar for an account with no cached usage renders a same-width
    ``[      no data       ]`` placeholder rather than crashing; a
-   window with no cached ``reset_at`` renders no hint (the missing
-   5h hint is space-padded so the 7d bars stay vertically aligned).
-   The relative hints are rendered by the shared
+   window with no cached ``reset_at`` renders no hint, space-padded to
+   the block-wide hint column so every bar (both windows, every
+   account) starts at the same column and scans vertically. The
+   relative hints are rendered by the shared
    :func:`~._timefmt.format_relative_until` (SSOT with the JST wall-clock
    helper used by the ``Since`` line).
 
@@ -111,11 +121,11 @@ def render_usage_bar(pct: float | None, *, width: int = _DEFAULT_BAR_WIDTH) -> s
     return "[" + _BAR_FILL * filled + _BAR_EMPTY * (width - filled) + "]"
 
 
-def _pct_label(pct: float | None) -> str:
-    """Right-justified 4-char percentage label: ``100%`` / ``  0%`` / ``   ?``."""
+def _pct_paren(pct: float | None) -> str:
+    """Trailing percentage label: ``(29%)`` for a number, ``(?)`` for unknown."""
     if pct is None:
-        return "   ?"
-    return f"{int(round(max(0.0, min(100.0, float(pct)))))}%".rjust(4)
+        return "(?)"
+    return f"({int(round(max(0.0, min(100.0, float(pct)))))}%)"
 
 
 def _wrap_hint(hint: str) -> str:
@@ -123,38 +133,58 @@ def _wrap_hint(hint: str) -> str:
     return f"({hint})" if hint else ""
 
 
-def render_usage_bar_line(
-    label: str,
-    pct_5h: float | None,
-    pct_7d: float | None,
+def render_window_line(
+    window: str,
+    pct: float | None,
     *,
-    label_width: int,
+    hint: str,
+    hint_width: int,
     width: int = _DEFAULT_BAR_WIDTH,
-    hint_5h: str = "",
-    hint_7d: str = "",
-    hint_5h_width: int = 0,
 ) -> str:
-    """One aligned account line, operator-example shape:
+    """One per-window line of an account block, operator-mockup shape:
 
-    ``<label>  5h [..]  29% (in 4h05m)   7d [..]  66% (in 2d 3h)``
+    ``  5h (in 4h05m) [██████░░░░░░░░░░░░░░] (29%)``
 
-    ``hint_5h`` / ``hint_7d`` are pre-wrapped display strings (e.g.
-    ``(in 4h05m)``) or ``""`` when the window has no cached reset.
-    ``hint_5h_width`` is the block-level max width of the 5h hints; a
-    row whose own hint is shorter (or missing) pads with spaces so the
-    ``7d`` bars stay vertically aligned across accounts. The trailing
-    7d hint needs no padding — nothing follows it.
+    The reset hint comes BEFORE the bar, right after the window label —
+    deliberate (operator 2026-07-17): it foregrounds the time-to-reset
+    the credential picker reasons about. ``hint`` is the pre-wrapped
+    display string (``(in 4h05m)``) or ``""`` when the window has no
+    cached reset; ``hint_width`` is the block-level max hint width and
+    every line pads its hint to it, so the bars of BOTH windows of
+    EVERY account start at the same column. ``hint_width == 0`` (no row
+    in the block has any cached reset) omits the hint column entirely.
     """
-    bar5 = render_usage_bar(pct_5h, width=width)
-    bar7 = render_usage_bar(pct_7d, width=width)
-    seg_5h = f"5h {bar5} {_pct_label(pct_5h)}"
-    pad_5h = max(hint_5h_width, len(hint_5h))
-    if pad_5h:
-        seg_5h += f" {hint_5h.ljust(pad_5h)}"
-    seg_7d = f"7d {bar7} {_pct_label(pct_7d)}"
-    if hint_7d:
-        seg_7d += f" {hint_7d}"
-    return f"  {label.ljust(label_width)}  {seg_5h}   {seg_7d}"
+    parts = [f"  {window}"]
+    if hint_width > 0:
+        parts.append(hint.ljust(max(hint_width, len(hint))))
+    parts.append(render_usage_bar(pct, width=width))
+    parts.append(_pct_paren(pct))
+    return " ".join(parts)
+
+
+def render_account_block(
+    row: "AccountRow",
+    *,
+    hint_5h: str,
+    hint_7d: str,
+    hint_width: int,
+    width: int = _DEFAULT_BAR_WIDTH,
+) -> list[str]:
+    """The 3-line block for one account (operator mockup 2026-07-17):
+
+    ``- <name>`` then one :func:`render_window_line` per window
+    (5h first, then 7d). The caller inserts the blank line BETWEEN
+    accounts and supplies the block-level ``hint_width``.
+    """
+    return [
+        f"- {row.name}",
+        render_window_line(
+            "5h", row.used_pct_5h, hint=hint_5h, hint_width=hint_width, width=width
+        ),
+        render_window_line(
+            "7d", row.used_pct_7d, hint=hint_7d, hint_width=hint_width, width=width
+        ),
+    ]
 
 
 def render_usage_bars_block(
@@ -163,15 +193,17 @@ def render_usage_bars_block(
     width: int = _DEFAULT_BAR_WIDTH,
     now: datetime | None = None,
 ) -> str:
-    """Render the full usage-bars block (header + one line per account).
+    """Render the full usage-bars block (header + one 3-line block per account).
 
-    Each line carries the compact per-window reset hints as the time
-    REMAINING until the window resets (``(in 4h05m)`` for 5h,
-    ``(in 2d 3h)`` for 7d), computed from the row's ``reset_at_5h`` /
-    ``reset_at_7d`` via the shared :func:`~._timefmt.format_relative_until`
-    (operator 2026-07-13: relative time-until-reset, not an absolute
-    wall-clock). The 5h hints are padded to one block-level width so
-    mixed hint/no-hint rows keep the 7d bars vertically aligned.
+    Operator mockup 2026-07-17 — one account per block, one line per
+    window, a blank line between accounts (the single ~120-char line it
+    replaces wrapped on a normal terminal). Each window line carries its
+    compact reset hint (``(in 4h05m)`` / ``(in 2d03h)``) BEFORE the bar,
+    computed from the row's ``reset_at_5h`` / ``reset_at_7d`` via the
+    shared :func:`~._timefmt.format_relative_until` (operator
+    2026-07-13: relative time-until-reset, not an absolute wall-clock).
+    All hints share one block-level column width so every bar starts at
+    the same column and the bars scan vertically.
 
     ``now`` is an injection seam for the current instant (tests pass a
     fixed value); it defaults to real wall-clock time.
@@ -182,26 +214,24 @@ def render_usage_bars_block(
     row_list = list(rows)
     if not row_list:
         return ""
-    label_width = max(len(r.name) for r in row_list)
     hints_5h = [
         _wrap_hint(format_relative_until(r.reset_at_5h, now=now)) for r in row_list
     ]
     hints_7d = [
         _wrap_hint(format_relative_until(r.reset_at_7d, now=now)) for r in row_list
     ]
-    hint_5h_width = max(len(h) for h in hints_5h)
+    hint_width = max(len(h) for h in (*hints_5h, *hints_7d))
     lines = ["Usage bars (5h / 7d out of 100%):"]
-    for r, hint_5h, hint_7d in zip(row_list, hints_5h, hints_7d):
-        lines.append(
-            render_usage_bar_line(
-                r.name,
-                r.used_pct_5h,
-                r.used_pct_7d,
-                label_width=label_width,
-                width=width,
+    for index, (r, hint_5h, hint_7d) in enumerate(zip(row_list, hints_5h, hints_7d)):
+        if index:
+            lines.append("")
+        lines.extend(
+            render_account_block(
+                r,
                 hint_5h=hint_5h,
                 hint_7d=hint_7d,
-                hint_5h_width=hint_5h_width,
+                hint_width=hint_width,
+                width=width,
             )
         )
     return "\n".join(lines)
@@ -250,7 +280,8 @@ def fleet_capacity_used_line(rows: Iterable["AccountRow"]) -> str:
 __all__ = [
     "fleet_7d_capacity_used",
     "fleet_capacity_used_line",
+    "render_account_block",
     "render_usage_bar",
-    "render_usage_bar_line",
     "render_usage_bars_block",
+    "render_window_line",
 ]

--- a/src/scitex_agent_container/cli_pkg/_timefmt.py
+++ b/src/scitex_agent_container/cli_pkg/_timefmt.py
@@ -16,7 +16,7 @@ hand-rolling a private copy:
    hard-coded, so it stays self-consistent if the zone is ever changed.
 
 2. :func:`format_relative_until` — render the time REMAINING until a
-   future timestamp as ``in 4h05m`` / ``in 2d 3h`` / ``now``. Used by
+   future timestamp as ``in 4h05m`` / ``in 2d08h`` / ``now``. Used by
    the usage-bars block of ``sac accounts list`` for the per-window
    reset hints: the operator wants "how long until the window resets"
    (relative), not the absolute wall clock of the reset instant.
@@ -53,7 +53,9 @@ def _jst_tzinfo() -> tzinfo:
         from zoneinfo import ZoneInfo
 
         return ZoneInfo(_JST_IANA)
-    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment)
+    except (
+        Exception
+    ):  # stx-allow: fallback (reason: catch-all safety net — see inline comment)
         return timezone(timedelta(hours=9), "JST")
 
 
@@ -107,12 +109,14 @@ def format_jst(value: str | datetime | None, *, empty: str = "-") -> str:
 
 
 def _humanize_until(seconds: int) -> str:
-    """Render a positive second delta as ``in 2d 3h`` / ``in 4h05m`` / ``in 7m``.
+    """Render a positive second delta as ``in 2d08h`` / ``in 4h05m`` / ``in 7m``.
 
     Picks the two most-significant units so the hint stays compact:
-    days+hours beyond a day, hours+minutes within a day (zero-padded
-    minutes so ``4h05m`` stays fixed-width), bare minutes under the hour.
-    A non-positive delta (reset already due) renders ``now``.
+    days+hours beyond a day, hours+minutes within a day — the lesser
+    unit zero-padded (``2d08h`` / ``4h05m``, operator mockup 2026-07-17)
+    so the hints stay fixed-width and the usage bars they precede align
+    in a column — bare minutes under the hour. A non-positive delta
+    (reset already due) renders ``now``.
     """
     if seconds <= 0:
         return "now"
@@ -120,7 +124,7 @@ def _humanize_until(seconds: int) -> str:
     hours, rem = divmod(rem, 3600)
     minutes = rem // 60
     if days:
-        return f"in {days}d {hours}h"
+        return f"in {days}d{hours:02d}h"
     if hours:
         return f"in {hours}h{minutes:02d}m"
     if minutes:
@@ -134,7 +138,7 @@ def format_relative_until(
     now: datetime | None = None,
     empty: str = "",
 ) -> str:
-    """Render the time remaining until ``value`` as ``in 4h05m`` / ``in 2d 3h``.
+    """Render the time remaining until ``value`` as ``in 4h05m`` / ``in 2d08h``.
 
     Args:
         value: A FUTURE ISO-8601 string / datetime (e.g. a rolling-window
@@ -145,7 +149,7 @@ def format_relative_until(
         empty: What to return for ``None`` / empty / unparseable input.
 
     Returns:
-        ``"in 4h05m"`` (< 1 day), ``"in 2d 3h"`` (>= 1 day), ``"in 7m"``
+        ``"in 4h05m"`` (< 1 day), ``"in 2d08h"`` (>= 1 day), ``"in 7m"``
         (< 1 hour), ``"now"`` (already due), else ``empty``.
     """
     dt = _coerce_dt(value)

--- a/tests/scitex_agent_container/cli_pkg/test__account_usage_bars.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_usage_bars.py
@@ -15,9 +15,10 @@ from scitex_agent_container.cli_pkg._account_list_render import AccountRow
 from scitex_agent_container.cli_pkg._account_usage_bars import (
     fleet_7d_capacity_used,
     fleet_capacity_used_line,
+    render_account_block,
     render_usage_bar,
-    render_usage_bar_line,
     render_usage_bars_block,
+    render_window_line,
 )
 
 # ---------------------------------------------------------------------------
@@ -107,91 +108,91 @@ def test_render_usage_bar_clamps_over_100():
 
 
 # ---------------------------------------------------------------------------
-# render_usage_bar_line / block — alignment across accounts
+# render_window_line / render_account_block — operator mockup 2026-07-17:
+#   - <account>
+#     5h (in 1h07m) [....................] (NN%)
+#     7d (in 2d08h) [....................] (NN%)
+# Reset hint BEFORE the bar (right after the window label); percent after
+# the bar; hints padded to one block-level column so the bars align.
 # ---------------------------------------------------------------------------
 
 
-def test_render_usage_bar_line_shows_5h_window():
+def test_render_window_line_hint_before_bar():
     # Arrange
-    label = "acct"
+    hint = "(in 4h05m)"
     # Act
-    line = render_usage_bar_line(label, 14.0, 99.0, label_width=10, width=20)
+    line = render_window_line("5h", 29.0, hint=hint, hint_width=10, width=20)
+    # Assert — operator mockup: label, then hint, THEN the bar.
+    assert line.startswith("  5h (in 4h05m) [")
+
+
+def test_render_window_line_percent_after_bar():
+    # Arrange
+    hint = "(in 4h05m)"
+    # Act
+    line = render_window_line("5h", 29.0, hint=hint, hint_width=10, width=20)
+    # Assert — operator mockup: the percent trails the bar, parenthesised.
+    assert line.endswith("] (29%)")
+
+
+def test_render_window_line_pads_missing_hint_to_column():
+    # Arrange — a sibling row in the block has a 10-char hint.
+    with_hint = render_window_line(
+        "5h", 29.0, hint="(in 4h05m)", hint_width=10, width=20
+    )
+    # Act
+    without_hint = render_window_line("5h", 14.0, hint="", hint_width=10, width=20)
+    # Assert — the bar starts at the same column in both lines.
+    assert with_hint.index("[") == without_hint.index("[")
+
+
+def test_render_window_line_omits_hint_column_when_block_hintless():
+    # Arrange — hint_width == 0: no row in the block has any cached reset.
+    # Act
+    line = render_window_line("5h", 14.0, hint="", hint_width=0, width=20)
+    # Assert — no fabricated hint column; the bar follows the label.
+    assert line.startswith("  5h [")
+
+
+def test_render_window_line_unknown_pct_renders_question_mark():
+    # Arrange
+    pct = None
+    # Act
+    line = render_window_line("7d", pct, hint="", hint_width=0, width=20)
     # Assert
-    assert "5h [" in line and "14%" in line
+    assert line.endswith("] (?)")
 
 
-def test_render_usage_bar_line_shows_7d_window():
+def test_render_account_block_first_line_is_dashed_name():
     # Arrange
-    label = "acct"
+    row = AccountRow(
+        name="acct",
+        freshness_state="VALID",
+        freshness_hours=2.0,
+        used_pct_5h=14.0,
+        used_pct_7d=99.0,
+        snapshot_as_of=None,
+    )
     # Act
-    line = render_usage_bar_line(label, 14.0, 99.0, label_width=10, width=20)
+    block = render_account_block(row, hint_5h="", hint_7d="", hint_width=0, width=20)
     # Assert
-    assert "7d [" in line and "99%" in line
+    assert block[0] == "- acct"
 
 
-# ---------------------------------------------------------------------------
-# 2026-07-11 dedupe directive — the bars own the reset hints (moved off the
-# Stored-accounts table). Operator's verbatim example shape:
-#   ... 5h [..]  29% (in 4h05m)   7d [..]  66% (in 2d 3h)
-# ---------------------------------------------------------------------------
-
-
-def test_render_usage_bar_line_appends_5h_reset_hint():
-    # Arrange — pre-wrapped hints as the block passes them.
-    label = "acct"
-    # Act
-    line = render_usage_bar_line(
-        label,
-        29.0,
-        66.0,
-        label_width=10,
-        width=20,
-        hint_5h="(in 4h05m)",
-        hint_7d="(in 2d 3h)",
-    )
-    # Assert — operator's verbatim 5h shape.
-    assert "29% (in 4h05m)" in line
-
-
-def test_render_usage_bar_line_appends_7d_reset_hint():
+def test_render_account_block_is_5h_then_7d():
     # Arrange
-    label = "acct"
-    # Act
-    line = render_usage_bar_line(
-        label,
-        29.0,
-        66.0,
-        label_width=10,
-        width=20,
-        hint_5h="(in 4h05m)",
-        hint_7d="(in 2d 3h)",
-    )
-    # Assert — operator's verbatim 7d shape.
-    assert "66% (in 2d 3h)" in line
-
-
-def test_render_usage_bar_line_without_hints_has_no_parens():
-    """No cached reset → no fabricated hint; the line stays hint-free."""
-    # Arrange
-    label = "acct"
-    # Act
-    line = render_usage_bar_line(label, 14.0, 99.0, label_width=10, width=20)
-    # Assert
-    assert "(" not in line
-
-
-def test_render_usage_bar_line_pads_missing_5h_hint_to_block_width():
-    """A hint-less row pads the 5h slot so the 7d bars stay aligned."""
-    # Arrange — a sibling row in the block has a 10-char 5h hint.
-    with_hint = render_usage_bar_line(
-        "aa", 29.0, 66.0, label_width=4, width=20, hint_5h="(in 4h05m)", hint_5h_width=10
+    row = AccountRow(
+        name="acct",
+        freshness_state="VALID",
+        freshness_hours=2.0,
+        used_pct_5h=14.0,
+        used_pct_7d=99.0,
+        snapshot_as_of=None,
     )
     # Act
-    without_hint = render_usage_bar_line(
-        "bbbb", 14.0, 15.0, label_width=4, width=20, hint_5h="", hint_5h_width=10
-    )
-    # Assert — "7d [" starts at the same column in both lines.
-    assert with_hint.index("7d [") == without_hint.index("7d [")
+    block = render_account_block(row, hint_5h="", hint_7d="", hint_width=0, width=20)
+    # Assert — one line per window, 5h first (operator mockup order).
+    assert block[1].startswith("  5h ") and block[2].startswith("  7d ")
 
 
 def test_render_usage_bars_block_empty_rows_is_empty_string():
@@ -225,14 +226,33 @@ def _two_bar_rows() -> list[AccountRow]:
     ]
 
 
-def test_render_usage_bars_block_lines_are_length_aligned():
+def test_render_usage_bars_block_marks_each_account_with_dash():
     # Arrange
     rows = _two_bar_rows()
     # Act
     block = render_usage_bars_block(rows, width=20)
-    data_lines = [ln for ln in block.splitlines() if "5h [" in ln]
-    # Assert — every data line has identical width (monospace aligned).
-    assert len({len(ln) for ln in data_lines}) == 1
+    markers = [ln for ln in block.splitlines() if ln.startswith("- ")]
+    # Assert — one "- <name>" marker per account (operator mockup).
+    assert markers == ["- wyusuuke-gmail-com", "- ywata1989-gmail-com"]
+
+
+def test_render_usage_bars_block_blank_line_between_accounts():
+    # Arrange
+    rows = _two_bar_rows()
+    # Act
+    block = render_usage_bars_block(rows, width=20)
+    # Assert — exactly one separator between the two account blocks.
+    assert block.splitlines().count("") == 1
+
+
+def test_render_usage_bars_block_hintless_rows_share_bar_column():
+    # Arrange — no row has a cached reset → no hint column at all.
+    rows = _two_bar_rows()
+    # Act
+    block = render_usage_bars_block(rows, width=20)
+    starts = {ln.index("[") for ln in block.splitlines() if "[" in ln}
+    # Assert — every bar starts at the same column (scans vertically).
+    assert len(starts) == 1, f"bars misaligned: {starts}\n{block}"
 
 
 def test_render_usage_bars_block_no_data_row_renders_placeholder():
@@ -268,7 +288,7 @@ def _hinted_bar_rows() -> list[AccountRow]:
             used_pct_5h=29.0,
             used_pct_7d=66.0,
             snapshot_as_of=None,
-            # From _HINT_NOW: +4h05m → "in 4h05m"; +2d3h → "in 2d 3h".
+            # From _HINT_NOW: +4h05m → "in 4h05m"; +2d3h → "in 2d03h".
             reset_at_5h="2026-07-12T04:05:00+00:00",
             reset_at_7d="2026-07-14T03:00:00+00:00",
         ),
@@ -283,35 +303,57 @@ def _hinted_bar_rows() -> list[AccountRow]:
     ]
 
 
-def test_render_usage_bars_block_carries_5h_reset_hint():
-    """Block-level: ``reset_at_5h`` renders the operator's ``29% (in 4h05m)``."""
+def test_render_usage_bars_block_5h_hint_precedes_bar():
+    """Block-level: ``reset_at_5h`` renders ``5h (in 4h05m) [`` (hint first)."""
     # Arrange
     rows = _hinted_bar_rows()
     # Act
     block = render_usage_bars_block(rows, width=20, now=_HINT_NOW)
     # Assert
-    assert "29% (in 4h05m)" in block
+    assert "5h (in 4h05m) [" in block
 
 
-def test_render_usage_bars_block_carries_7d_reset_hint():
-    """Block-level: ``reset_at_7d`` renders the operator's ``66% (in 2d 3h)``."""
+def test_render_usage_bars_block_7d_hint_precedes_bar():
+    """Block-level: ``reset_at_7d`` renders ``7d (in 2d03h) [`` (hint first)."""
     # Arrange
     rows = _hinted_bar_rows()
     # Act
     block = render_usage_bars_block(rows, width=20, now=_HINT_NOW)
     # Assert
-    assert "66% (in 2d 3h)" in block
+    assert "7d (in 2d03h) [" in block
 
 
-def test_render_usage_bars_block_aligns_7d_bars_across_mixed_hints():
-    """A hint-less row pads its 5h slot — 7d bars align across the block."""
+def test_render_usage_bars_block_aligns_bars_across_mixed_hints():
+    """A hint-less row pads its hint slot — every bar starts at one column."""
     # Arrange
     rows = _hinted_bar_rows()
     # Act
     block = render_usage_bars_block(rows, width=20, now=_HINT_NOW)
-    starts = {ln.index("7d [") for ln in block.splitlines() if "7d [" in ln}
-    # Assert — one distinct start column means the 7d bars line up.
-    assert len(starts) == 1, f"7d bars misaligned across rows: {starts}\n{block}"
+    starts = {ln.index("[") for ln in block.splitlines() if "[" in ln}
+    # Assert — one distinct start column means the bars line up.
+    assert len(starts) == 1, f"bars misaligned across rows: {starts}\n{block}"
+
+
+def test_render_usage_bars_block_matches_operator_mockup_exactly():
+    """The whole block, verbatim — the operator's 2026-07-17 layout spec."""
+    # Arrange
+    rows = _hinted_bar_rows()
+    # Act
+    block = render_usage_bars_block(rows, width=12, now=_HINT_NOW)
+    # Assert — one account per block, hint before bar, percent after,
+    # blank line between accounts, bars in one column.
+    assert block == "\n".join(
+        [
+            "Usage bars (5h / 7d out of 100%):",
+            "- wyusuuke-gmail-com",
+            "  5h (in 4h05m) [███░░░░░░░░░] (29%)",
+            "  7d (in 2d03h) [████████░░░░] (66%)",
+            "",
+            "- ywata1989-gmail-com",
+            "  5h            [██░░░░░░░░░░] (14%)",
+            "  7d            [██░░░░░░░░░░] (15%)",
+        ]
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/cli_pkg/test__timefmt.py
+++ b/tests/scitex_agent_container/cli_pkg/test__timefmt.py
@@ -119,12 +119,13 @@ def test_relative_hours_minutes_shape():
 
 
 def test_relative_days_hours_shape():
-    # Arrange — +2d3h from now (the operator's 7d example).
+    # Arrange — +2d3h from now (the operator's 7d example; zero-padded
+    # hours per his 2026-07-17 mockup "in 2d08h" so hints stay fixed-width).
     value = "2026-07-14T03:00:00+00:00"
     # Act
     rendered = format_relative_until(value, now=_NOW)
     # Assert
-    assert rendered == "in 2d 3h"
+    assert rendered == "in 2d03h"
 
 
 def test_relative_minutes_only_under_one_hour():


### PR DESCRIPTION
## What

`sac accounts list` crammed one ~120-char line per account (5h bar + % + reset + 7d bar + % + reset) — it wrapped on a normal terminal. This implements the operator's 2026-07-17 mockup verbatim:

```
Usage bars (5h / 7d out of 100%):
- wyusuuke-gmail-com
  5h (in 39m)   [█████████████░░░░░░░] (64%)
  7d (in 2d03h) [█████░░░░░░░░░░░░░░░] (26%)

- ywata1989-gmail-com
  5h (in 49m)   [███░░░░░░░░░░░░░░░░░] (17%)
  7d (in 3d22h) [██░░░░░░░░░░░░░░░░░░] (9%)

- ywatanabe-scitex-ai
  5h (in 39m)   [████░░░░░░░░░░░░░░░░] (21%)
  7d (in 3d13h) [██████░░░░░░░░░░░░░░] (32%)

Fleet 7d capacity used: 22% (3 accounts)
```

(rendered from the REAL account usage caches, today 09:00Z snapshot)

- One 3-line block per account, blank line between accounts.
- **Reset time BEFORE the bar** (right after the window label) — deliberate: it foregrounds the time-to-reset the credential picker should reason about (companion correctness PR follows separately).
- Percent after the bar, parenthesised.
- All hints pad to one block-level column so every bar starts at the same column and scans vertically.
- Day-form hints zero-pad hours (`in 2d08h`, per mockup) — keeps hints fixed-width.
- `Fleet 7d capacity used` summary line kept.

## Surfaces (掟)

CLI-only: verified no MCP tool or skill doc reproduces the bars format (`--json` schema untouched).

## Tests

- Exact-shape test `test_render_usage_bars_block_matches_operator_mockup_exactly` asserts the whole block verbatim (can go RED on any layout drift).
- 114 renderer/timefmt/list-render tests + 70 account-group CLI tests green against the worktree source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)