### PR TITLE
feat(creds): 7d spend policy — burn-to-zero opt-in + auditable pick log

### DIFF
--- a/src/scitex_agent_container/_creds/__init__.py
+++ b/src/scitex_agent_container/_creds/__init__.py
@@ -12,14 +12,25 @@ Freshness (a non-expired snapshot) is the hard gate — see
 :func:`._pick_healthy.pick_healthy_account`. On top of it the pick is
 quota-CONDITIONAL, read cache-only from the bound ``quota-cache.json``
 (:mod:`._quota_rank`): avoid accounts at ≥ ~95% of their 5h window
-(blocked-now — they 429 immediately) and ≥ ~90% of their 7d window
-(near-capped), and load-balance the remaining healthy tier across the
-fleet via per-agent weighted rendezvous hashing. Quota state is a
-preference, never a gate — in-turn 429s still surface from claude.
+(blocked-now — they 429 immediately) and, under the default
+``POLICY_SPREAD``, ≥ ~90% of their 7d window (near-capped), and
+load-balance the remaining healthy tier across the fleet via per-agent
+weighted rendezvous hashing. The opt-in ``POLICY_BURN``
+(:mod:`._spend_policy`; activation gated on the fleet reconciler)
+inverts the 7d rule: prefer the FULLEST weekly bucket and drain it to
+zero, because unspent 7d quota is destroyed at the boundary. Quota
+state is a preference, never a gate — in-turn 429s still surface from
+claude. Every pool pick logs its full ranking inputs
+(:mod:`._pick_audit`) so a pick is auditable after the fact.
 """
 
 from __future__ import annotations
 
+from ._pick_audit import (
+    CandidateAudit,
+    audit_candidates,
+    format_pick_audit,
+)
 from ._pick_healthy import (
     AccountHealth,
     NoHealthyAccountError,
@@ -28,12 +39,27 @@ from ._pick_healthy import (
     account_health,
     pick_healthy_account,
 )
+from ._quota_rank import account_7d_reset_at
+from ._spend_policy import (
+    POLICY_BURN,
+    POLICY_SPREAD,
+    VALID_7D_POLICIES,
+    resolve_7d_policy,
+)
 
 __all__ = [
     "AccountHealth",
+    "CandidateAudit",
     "NoHealthyAccountError",
+    "POLICY_BURN",
+    "POLICY_SPREAD",
+    "VALID_7D_POLICIES",
     "account_5h_usage",
+    "account_7d_reset_at",
     "account_7d_usage",
     "account_health",
+    "audit_candidates",
+    "format_pick_audit",
     "pick_healthy_account",
+    "resolve_7d_policy",
 ]

--- a/src/scitex_agent_container/_creds/_pick_audit.py
+++ b/src/scitex_agent_container/_creds/_pick_audit.py
@@ -1,0 +1,148 @@
+"""Auditable ranking-input record for the account pick.
+
+Operator finding 2026-07-17: the ``[sac:creds] ... selected
+credentials_files pool entry`` notice named its CRITERIA (token-fresh,
+5h-blocked avoided, 7d-near-capped avoided, load-balanced) but not its
+INPUTS — so when the pick happened to match what reset-time-awareness
+would have chosen, nobody could tell a REASONED pick from a LUCKY one
+(and it was lucky: both 7d resets were days out, far beyond the 2h
+expiring horizon, so time-to-reset had zero effect and the
+headroom-weighted rendezvous hash decided).
+
+This module renders every candidate's full ranking inputs — 5h %, 7d %,
+time-to-7d-reset, and the derived tier flags — into one log-safe line so
+every pick is auditable after the fact.
+
+Token safety: the audit reads ONLY utilisation percentages and reset
+stamps (the same quota-cache / usage-cache values ``sac accounts list``
+shows). No credential file is opened, no token value can appear in the
+output — this is the pool behind the 2026-07-09 load/401 incident, and
+a probe here must not mutate (or even read) a token.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Mapping
+
+from ._quota_rank import (
+    BLOCKED_5H_PCT,
+    EXPIRING_7D_HORIZON_S,
+    NEAR_CAP_7D_PCT,
+    is_expiring_7d,
+)
+from ._spend_policy import coerce_epoch
+
+
+@dataclass(frozen=True)
+class CandidateAudit:
+    """One candidate's full ranking inputs at pick time.
+
+    Attributes
+    ----------
+    name
+        The stored-account slug.
+    pct_5h, pct_7d
+        Cached window utilisation % (``None`` = unknown / no cache).
+    reset_7d_in_s
+        Seconds until the 7d window resets (negative = already past),
+        or ``None`` when no reset stamp is cached.
+    blocked_5h
+        ``pct_5h`` at/above the blocked-now threshold (cannot serve a
+        request immediately).
+    near_capped_7d
+        ``pct_7d`` at/above the near-cap threshold AND not expiring —
+        the spread policy's avoid flag (burn inverts it into a reason
+        to pick).
+    expiring_7d
+        The remaining 7d quota is use-it-or-lose-it right now
+        (:func:`._quota_rank.is_expiring_7d`).
+    """
+
+    name: str
+    pct_5h: float | None
+    pct_7d: float | None
+    reset_7d_in_s: float | None
+    blocked_5h: bool
+    near_capped_7d: bool
+    expiring_7d: bool
+
+
+def audit_candidates(
+    names: list[str],
+    usage_5h: Mapping[str, float | None],
+    usage_7d: Mapping[str, float | None],
+    *,
+    reset_7d: Mapping[str, object] | None = None,
+    now: float | None = None,
+    near_cap_pct: float = NEAR_CAP_7D_PCT,
+    blocked_5h_pct: float = BLOCKED_5H_PCT,
+    expiring_horizon_s: float = EXPIRING_7D_HORIZON_S,
+) -> list[CandidateAudit]:
+    """Build one :class:`CandidateAudit` per candidate, in input order.
+
+    Pure over its inputs (injectable ``now``); mirrors EXACTLY the
+    derivations :func:`._quota_rank.pick_ranked` applies, so the audit
+    line shows the same flags the ranking acted on.
+    """
+    _now = now if now is not None else time.time()
+    _resets: Mapping[str, object] = reset_7d if reset_7d is not None else {}
+    records: list[CandidateAudit] = []
+    for name in names:
+        h5 = usage_5h.get(name)
+        d7 = usage_7d.get(name)
+        reset_at = coerce_epoch(_resets.get(name))
+        expiring = is_expiring_7d(d7, reset_at, _now, horizon_s=expiring_horizon_s)
+        records.append(
+            CandidateAudit(
+                name=name,
+                pct_5h=h5,
+                pct_7d=d7,
+                reset_7d_in_s=(reset_at - _now) if reset_at is not None else None,
+                blocked_5h=h5 is not None and h5 >= blocked_5h_pct,
+                near_capped_7d=(d7 is not None and d7 >= near_cap_pct and not expiring),
+                expiring_7d=expiring,
+            )
+        )
+    return records
+
+
+def _fmt_pct(value: float | None) -> str:
+    return "?" if value is None else f"{value:.0f}%"
+
+
+def _fmt_reset(seconds: float | None) -> str:
+    """Hours-to-reset with sign: ``+56.1h`` / ``-0.2h`` / ``?``."""
+    return "?" if seconds is None else f"{seconds / 3600.0:+.1f}h"
+
+
+def format_pick_audit(records: list[CandidateAudit]) -> str:
+    """One log-safe line naming EVERY ranking input for every candidate.
+
+    ``ranking inputs: a(5h=9% 7d=10% 7d_reset=+56.4h), b(...)`` — the
+    flags (``5h-blocked`` / ``7d-near-cap`` / ``7d-expiring``) appear
+    only when set. Contains percentages, relative hours, and account
+    slugs ONLY — never a token value or credential path.
+    """
+    parts: list[str] = []
+    for r in records:
+        flags = "".join(
+            (
+                " 5h-blocked" if r.blocked_5h else "",
+                " 7d-near-cap" if r.near_capped_7d else "",
+                " 7d-expiring" if r.expiring_7d else "",
+            )
+        )
+        parts.append(
+            f"{r.name}(5h={_fmt_pct(r.pct_5h)} 7d={_fmt_pct(r.pct_7d)} "
+            f"7d_reset={_fmt_reset(r.reset_7d_in_s)}{flags})"
+        )
+    return "ranking inputs: " + ", ".join(parts)
+
+
+__all__ = [
+    "CandidateAudit",
+    "audit_candidates",
+    "format_pick_audit",
+]

--- a/src/scitex_agent_container/_creds/_pick_healthy.py
+++ b/src/scitex_agent_container/_creds/_pick_healthy.py
@@ -84,6 +84,11 @@ from ._quota_rank import (
     is_expiring_7d,
     pick_ranked,
 )
+from ._spend_policy import (
+    POLICY_BURN,
+    POLICY_SPREAD,
+    validate_7d_policy,
+)
 
 # Health states for one account's snapshot. Mirrors
 # :class:`_account.creds_sync.Freshness` but anchored on a *name* so the
@@ -271,6 +276,7 @@ def pick_healthy_account(
     blocked_5h_pct: float = _BLOCKED_5H_PCT,
     expiring_horizon_s: float = EXPIRING_7D_HORIZON_S,
     spread_key: str | None = None,
+    policy: str = POLICY_SPREAD,
 ) -> str:
     """Return the stored-account name an agent should run on right now.
 
@@ -351,6 +357,13 @@ def pick_healthy_account(
         "best" one. ``None`` / empty keeps the legacy single-winner
         ordering. The same key always maps to the same account while
         quota tiers are unchanged (no churn across restarts).
+    policy
+        The 7d spend policy (:mod:`._spend_policy`). ``POLICY_SPREAD``
+        (default) is the behaviour above, unchanged. ``POLICY_BURN``
+        (opt-in; activation gated on the fleet reconciler) prefers the
+        HIGHEST 7d usage among 5h-unblocked fresh accounts, tie-break
+        soonest 7d reset — and a near-capped 7d ``preferred`` is a
+        reason to STAY (drain it), never to rotate off.
 
     Returns
     -------
@@ -366,6 +379,7 @@ def pick_healthy_account(
         blocked/near-capped (quota is a preference, freshness is the
         gate).
     """
+    validate_7d_policy(policy)
     _home = home if home is not None else Path.home()
 
     if candidates is None:
@@ -461,6 +475,10 @@ def pick_healthy_account(
                     horizon_s=expiring_horizon_s,
                 )
             )
+            # POLICY_BURN inverts the 7d rule: a near-capped pin is a
+            # reason to STAY and drain it, never to rotate off.
+            if policy == POLICY_BURN:
+                near_capped = False
             if not blocked_now and not near_capped:
                 return pref
 
@@ -480,6 +498,7 @@ def pick_healthy_account(
         near_cap_pct=near_cap_pct,
         blocked_5h_pct=blocked_5h_pct,
         expiring_horizon_s=expiring_horizon_s,
+        policy=policy,
     )
 
 

--- a/src/scitex_agent_container/_creds/_quota_rank.py
+++ b/src/scitex_agent_container/_creds/_quota_rank.py
@@ -73,11 +73,20 @@ from __future__ import annotations
 import hashlib
 import math
 import time
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Mapping
 
 from .._account.quota_cache import read_quota_entry
+from ._spend_policy import (
+    ENV_7D_POLICY_SUFFIX,
+    POLICY_BURN,
+    POLICY_SPREAD,
+    VALID_7D_POLICIES,
+    coerce_epoch,
+    pick_burn,
+    resolve_7d_policy,
+    validate_7d_policy,
+)
 
 # 7d-utilisation threshold above which an account is "near-capped —
 # avoid unless no better fresh alternative". See _pick_healthy's module
@@ -126,6 +135,12 @@ EXPIRING_MIN_HEADROOM_PCT = 2.0
 # docstring). Weight ∝ headroom keeps each account's share bounded by
 # the capacity it actually has.
 EXPIRING_WEIGHT_BOOST = 4.0
+
+# The 7d SPEND POLICY layer (POLICY_SPREAD / POLICY_BURN, the env
+# resolver, and the burn ordering) lives in :mod:`._spend_policy`
+# (512-line module limit) and is re-exported here — see that module's
+# docstring for the operator's 2026-07-17 ruling and the reconciler
+# gate on flipping the default to burn.
 
 
 def _coerce_pct(value: object) -> float | None:
@@ -192,30 +207,8 @@ def account_7d_usage(
     )
 
 
-def _coerce_epoch(value: object) -> float | None:
-    """Return *value* as epoch seconds, or ``None`` if unparseable.
-
-    Tolerant on purpose — the quota cache stores the reset stamp as the
-    upstream ISO-8601 string (``reset_at_7d``), but tests and callers
-    find raw epoch floats easier to reason about, so both are accepted.
-    A naive (tz-less) ISO stamp is read as UTC, matching
-    :func:`cli_pkg._account_list_format._coerce_dt`.
-    """
-    if isinstance(value, bool) or value is None:
-        return None
-    if isinstance(value, (int, float)):
-        return float(value)
-    if not isinstance(value, str) or not value.strip():
-        return None
-    # stx-allow: fallback (reason: a malformed cache timestamp must degrade to
-    # "reset unknown" — i.e. the pre-existing behaviour — never crash a boot.)
-    try:
-        dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.timestamp()
+# Epoch coercion for the reset stamps lives in ._spend_policy
+# (coerce_epoch, imported above) — shared with the burn ordering.
 
 
 def account_7d_reset_at(
@@ -233,11 +226,11 @@ def account_7d_reset_at(
     rather than assume "unknown reset" means "resets now".
     """
     if reset_7d is not None:
-        return _coerce_epoch(reset_7d.get(name))
+        return coerce_epoch(reset_7d.get(name))
     entry = read_quota_entry(account=name, cache_path=quota_cache_path)
     if entry is None:
         return None
-    return _coerce_epoch(entry.get("reset_at_7d"))
+    return coerce_epoch(entry.get("reset_at_7d"))
 
 
 def is_expiring_7d(
@@ -308,6 +301,7 @@ def pick_ranked(
     near_cap_pct: float = NEAR_CAP_7D_PCT,
     blocked_5h_pct: float = BLOCKED_5H_PCT,
     expiring_horizon_s: float = EXPIRING_7D_HORIZON_S,
+    policy: str = POLICY_SPREAD,
 ) -> str:
     """Return the best account among *names* (all token-fresh, non-empty).
 
@@ -315,10 +309,25 @@ def pick_ranked(
     % or ``None`` (unknown). ``reset_7d`` maps each name to its 7d-window
     reset stamp (ISO string or epoch seconds; ``None``/absent = unknown).
     See the module docstring for the tier rules; this never raises on
-    quota state (fail-loud for "nothing fresh" lives in the caller).
+    quota state (fail-loud for "nothing fresh" lives in the caller —
+    only an invalid ``policy`` raises here).
 
-    Expiring capacity (see :func:`is_expiring_7d`) enters the ranking in
-    exactly two places, and NOWHERE else:
+    ``policy`` selects the 7d spend rule (operator ruling 2026-07-17 —
+    see the policy block above the constants):
+
+    * :data:`POLICY_SPREAD` (default) — the historical behaviour,
+      unchanged: demote near-capped 7d accounts, spread by headroom.
+    * :data:`POLICY_BURN` — tier only on ``(blocked_now, d7 unknown)``
+      (near-cap is a reason to PICK, not to avoid), then prefer the
+      HIGHEST 7d usage, tie-break by SOONEST 7d reset, then candidate
+      order. Deterministic on purpose: ``spread_key`` is IGNORED —
+      burn-to-zero deliberately concentrates the fleet on the
+      perishable bucket until it blocks, which is the opposite of
+      spreading.
+
+    Under :data:`POLICY_SPREAD`, expiring capacity (see
+    :func:`is_expiring_7d`) enters the ranking in exactly two places,
+    and NOWHERE else:
 
     1. it SUPPRESSES the ``near_capped`` demotion — quota that is about
        to be deleted is expiring, not scarce, so the account competes on
@@ -327,21 +336,32 @@ def pick_ranked(
        no-spread order) — we spend what is about to vanish before we
        spend a reserve that persists.
 
-    ``blocked_now`` (the 5h window) is untouched and still dominates
-    both: an account that cannot serve a request *now* is never picked
-    over one that can, however soon its weekly budget refreshes.
+    ``blocked_now`` (the 5h window) dominates under BOTH policies: an
+    account that cannot serve a request *now* is never picked over one
+    that can, however soon its weekly budget refreshes.
 
     With no ``reset_7d`` data (a cache predating the field) every
     account reads "reset unknown" → ``is_expiring_7d`` is ``False``
-    everywhere → this function behaves EXACTLY as it did before.
+    everywhere → the spread policy behaves EXACTLY as it did before
+    (and burn falls back to pure highest-7d-usage ordering).
     """
+    validate_7d_policy(policy)
     _now = now if now is not None else time.time()
     _resets: Mapping[str, object] = reset_7d if reset_7d is not None else {}
+
+    if policy == POLICY_BURN:
+        return pick_burn(
+            names,
+            usage_5h,
+            usage_7d,
+            _resets,
+            blocked_5h_pct=blocked_5h_pct,
+        )
 
     def expiring(name: str) -> bool:
         return is_expiring_7d(
             usage_7d.get(name),
-            _coerce_epoch(_resets.get(name)),
+            coerce_epoch(_resets.get(name)),
             _now,
             horizon_s=expiring_horizon_s,
         )
@@ -394,13 +414,18 @@ def pick_ranked(
 
 __all__ = [
     "BLOCKED_5H_PCT",
+    "ENV_7D_POLICY_SUFFIX",
     "EXPIRING_7D_HORIZON_S",
     "EXPIRING_MIN_HEADROOM_PCT",
     "EXPIRING_WEIGHT_BOOST",
     "NEAR_CAP_7D_PCT",
+    "POLICY_BURN",
+    "POLICY_SPREAD",
+    "VALID_7D_POLICIES",
     "account_5h_usage",
     "account_7d_reset_at",
     "account_7d_usage",
     "is_expiring_7d",
     "pick_ranked",
+    "resolve_7d_policy",
 ]

--- a/src/scitex_agent_container/_creds/_spend_policy.py
+++ b/src/scitex_agent_container/_creds/_spend_policy.py
@@ -1,0 +1,180 @@
+"""7d spend policy for the account picker (operator ruling 2026-07-17).
+
+Split out of :mod:`._quota_rank` (512-line module limit). This module
+owns the POLICY layer of the quota-conditional pick — which rule the
+ranking applies to the 7-day window — while ``_quota_rank`` keeps the
+tiering/spread machinery and ``_pick_healthy`` the freshness gate.
+
+Why two policies (operator, 2026-07-17)
+---------------------------------------
+The 5h and 7d windows are DIFFERENT KINDS of resource and must not
+share a rule:
+
+* **5h window — ROLLING.** Hitting the cap costs a short wait and the
+  capacity returns on its own. Avoiding a blocked-now account is
+  reasonable; you lose little by waiting.
+* **7d window — WEEKLY, USE-IT-OR-LOSE-IT.** Unspent 7d quota is
+  DESTROYED at the boundary. It does not roll over. "Avoid the
+  near-capped 7d account" therefore PRESERVES nothing — it throws the
+  remainder away.
+
+:data:`POLICY_SPREAD` (default) — the historical ranking: demote
+7d-near-capped accounts (unless expiring within the
+``EXPIRING_7D_HORIZON_S`` window) and spread the fleet by 7d headroom
+via weighted rendezvous hashing.
+
+:data:`POLICY_BURN` (opt-in) — the operator's corrected rule: 「7d 上限
+が近ければむしろ積極的に使って使い切る；落ちたら再起動」. Among
+token-fresh, 5h-unblocked accounts prefer the HIGHEST 7d usage (spend
+the perishable weekly bucket to zero), tie-break by SOONEST 7d reset;
+when the account blocks, the next boot fails over.
+
+*** ACTIVATION IS GATED — DO NOT FLIP THE DEFAULT. *** Burn-to-zero
+deliberately manufactures agent deaths (「落ちたら再起動」), which is
+only safe when restart is AUTOMATIC. The fleet reconciler (card
+``sac-fleet-reconciler-restart-dead-agents-20260716``) is not live —
+``restart.policy`` is dead code in all 93 specs — so the default stays
+:data:`POLICY_SPREAD` until it is. Opt in per host via
+``SAC_CREDS_7D_POLICY=burn`` once the reconciler restarts quota-dead
+agents on its own.
+
+Read-only, like everything in ``_creds``: this module never touches a
+token (the pool behind the 2026-07-09 load/401 incident — a probe here
+must not mutate).
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Mapping
+
+# The two 7d spend policies — see the module docstring.
+POLICY_SPREAD = "spread"
+POLICY_BURN = "burn"
+VALID_7D_POLICIES = (POLICY_SPREAD, POLICY_BURN)
+
+# Env suffix read by resolve_7d_policy() — SAC_CREDS_7D_POLICY /
+# SCITEX_AGENT_CONTAINER_CREDS_7D_POLICY (see scitex_agent_container._env).
+ENV_7D_POLICY_SUFFIX = "CREDS_7D_POLICY"
+
+
+def resolve_7d_policy(raw: str | None = None) -> str:
+    """Resolve the effective 7d spend policy (arg wins, else env, else spread).
+
+    ``raw=None`` reads ``SAC_CREDS_7D_POLICY`` (either sac prefix) via
+    :func:`scitex_agent_container._env.getenv`. Empty/unset resolves to
+    :data:`POLICY_SPREAD` — the burn-to-zero default is GATED on the
+    fleet reconciler (see the module docstring). Any other value must
+    be a member of :data:`VALID_7D_POLICIES` (case-insensitive,
+    whitespace-tolerant); an unknown value raises ``ValueError`` — an
+    operator who asked for a policy must never silently get another.
+    """
+    if raw is None:
+        from .._env import getenv
+
+        raw = getenv(ENV_7D_POLICY_SUFFIX, "") or ""
+    value = raw.strip().lower()
+    if not value:
+        return POLICY_SPREAD
+    if value not in VALID_7D_POLICIES:
+        raise ValueError(
+            f"invalid 7d spend policy {raw!r} (SAC_{ENV_7D_POLICY_SUFFIX}): "
+            f"valid values are {', '.join(VALID_7D_POLICIES)}"
+        )
+    return value
+
+
+def validate_7d_policy(policy: str) -> None:
+    """Fail loud on a policy string outside :data:`VALID_7D_POLICIES`."""
+    if policy not in VALID_7D_POLICIES:
+        raise ValueError(
+            f"invalid 7d spend policy {policy!r}: valid values are "
+            f"{', '.join(VALID_7D_POLICIES)}"
+        )
+
+
+def coerce_epoch(value: object) -> float | None:
+    """Return *value* as epoch seconds, or ``None`` if unparseable.
+
+    Tolerant on purpose — the quota cache stores the reset stamp as the
+    upstream ISO-8601 string (``reset_at_7d``), but tests and callers
+    find raw epoch floats easier to reason about, so both are accepted.
+    A naive (tz-less) ISO stamp is read as UTC, matching
+    :func:`cli_pkg._account_list_format._coerce_dt`.
+    """
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    # stx-allow: fallback (reason: a malformed cache timestamp must degrade to
+    # "reset unknown" — i.e. the pre-existing behaviour — never crash a boot.)
+    try:
+        dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def pick_burn(
+    names: list[str],
+    usage_5h: Mapping[str, float | None],
+    usage_7d: Mapping[str, float | None],
+    resets: Mapping[str, object],
+    *,
+    blocked_5h_pct: float,
+) -> str:
+    """The :data:`POLICY_BURN` ordering (operator ruling 2026-07-17).
+
+    1. Tier out 5h-blocked accounts (cannot serve NOW; still a
+       preference, not a gate — an all-blocked fleet boots on the
+       least-bad tier) and unknown-7d accounts (known usage beats a
+       guess).
+    2. Within the best tier, HIGHEST 7d usage first — spend the
+       perishable weekly bucket to zero; unspent 7d quota is destroyed
+       at the boundary.
+    3. Tie-break by SOONEST 7d reset (an unknown reset sorts last),
+       then candidate order.
+
+    Deterministic — no spread key. Concentrating agents on the near-cap
+    account until it blocks is the POINT (「落ちたら再起動」); fail-over
+    happens on the next boot, once the reconciler owns the restart.
+    """
+
+    def tier(name: str) -> tuple[bool, bool]:
+        h5 = usage_5h.get(name)
+        return (
+            h5 is not None and h5 >= blocked_5h_pct,
+            usage_7d.get(name) is None,
+        )
+
+    best = min(tier(n) for n in names)
+    group = [n for n in names if tier(n) == best]
+
+    def sort_key(item: tuple[int, str]) -> tuple[float, float, int]:
+        idx, name = item
+        d7 = usage_7d.get(name)
+        reset_at = coerce_epoch(resets.get(name))
+        return (
+            -(d7 if d7 is not None else -math.inf),
+            reset_at if reset_at is not None else math.inf,
+            idx,
+        )
+
+    return min(enumerate(group), key=sort_key)[1]
+
+
+__all__ = [
+    "ENV_7D_POLICY_SUFFIX",
+    "POLICY_BURN",
+    "POLICY_SPREAD",
+    "VALID_7D_POLICIES",
+    "coerce_epoch",
+    "pick_burn",
+    "resolve_7d_policy",
+    "validate_7d_policy",
+]

--- a/src/scitex_agent_container/_lifecycle/_start_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_start_preflight.py
@@ -147,7 +147,11 @@ def _rotate_among_credentials_files(
     Back-compat: a 1-element pool whose one snapshot is healthy resolves
     to that exact file (no-op — ``credentials_file`` unchanged, no log).
     """
-    from .._creds import pick_healthy_account
+    from .._creds import (
+        POLICY_BURN,
+        pick_healthy_account,
+        resolve_7d_policy,
+    )
 
     entries: list[tuple[str, Path]] = []
     grandparents: set[str] = set()
@@ -165,17 +169,26 @@ def _rotate_among_credentials_files(
         entries[0][1].parent.parent if len(grandparents) == 1 else None
     )
 
+    # The 7d spend policy (env: SAC_CREDS_7D_POLICY). Fail-loud on an
+    # invalid value — an operator who asked for a policy must never
+    # silently get another. Default stays "spread": burn-to-zero is
+    # GATED on the fleet reconciler (see _creds._spend_policy).
+    policy = resolve_7d_policy()
+
     claude = config.claude
     # Preferred = a GENUINE pin only: the spec's named account when it is
     # one of the listed slugs, else the currently-effective
     # credentials_file's slug when it is listed. NOT the first listed
-    # entry — see the docstring (fleet-stacking incident).
+    # entry — see the docstring (fleet-stacking incident). Under
+    # POLICY_BURN the prior-slug churn-minimisation is dropped too:
+    # keeping the previously-bound file would freeze the pool and defeat
+    # draining the near-cap bucket (a named spec pin still holds).
     account = str(getattr(claude, "account", "") or "").strip()
     prior = str(getattr(claude, "credentials_file", "") or "").strip()
     prior_slug = _slug_of_credentials_file(Path(prior)) if prior else ""
     if account in slugs:
         preferred: str | None = account
-    elif prior_slug in slugs:
+    elif prior_slug in slugs and policy != POLICY_BURN:
         preferred = prior_slug
     else:
         preferred = None
@@ -189,6 +202,7 @@ def _rotate_among_credentials_files(
         usage_7d=usage_7d,
         quota_cache_path=quota_cache_path,
         spread_key=config.name,
+        policy=policy,
     )
 
     picked_path = next(p for slug, p in entries if slug == picked)
@@ -197,21 +211,47 @@ def _rotate_among_credentials_files(
     if str(picked_path) == prior:
         return  # 1-element / already-selected pool — no change, no log.
 
-    from .._creds import account_5h_usage, account_7d_usage
+    from .._creds import (
+        account_5h_usage,
+        account_7d_reset_at,
+        account_7d_usage,
+        audit_candidates,
+        format_pick_audit,
+    )
 
-    h5 = account_5h_usage(picked, usage_5h=usage_5h, quota_cache_path=quota_cache_path)
-    d7 = account_7d_usage(picked, usage_7d=usage_7d, quota_cache_path=quota_cache_path)
+    # EVERY ranking input, per candidate — the pick must be auditable
+    # (operator 2026-07-17: the notice named criteria but not inputs, so
+    # a reasoned pick was indistinguishable from a lucky one). Reads the
+    # same caches the pick read; never a token.
+    u5 = {
+        s: account_5h_usage(s, usage_5h=usage_5h, quota_cache_path=quota_cache_path)
+        for s in slugs
+    }
+    u7 = {
+        s: account_7d_usage(s, usage_7d=usage_7d, quota_cache_path=quota_cache_path)
+        for s in slugs
+    }
+    r7 = {s: account_7d_reset_at(s, quota_cache_path=quota_cache_path) for s in slugs}
+    audit = format_pick_audit(audit_candidates(slugs, u5, u7, reset_7d=r7, now=now))
 
     def fmt(v: float | None) -> str:
         return "?" if v is None else f"{v:.0f}%"
 
+    rationale = (
+        "token-fresh gate, 5h-blocked excluded, then HIGHEST 7d usage — "
+        "burn the perishable weekly bucket to zero — tie-break soonest "
+        "7d reset"
+        if policy == POLICY_BURN
+        else "token-fresh gate, avoids 5h-blocked and 7d-near-capped "
+        "accounts, load-balanced per agent by 7d headroom; time-to-reset "
+        "counts only within the 2h expiring horizon"
+    )
     stream = log_stream if log_stream is not None else sys.stderr
     print(
         f"[sac:creds] agent '{config.name}' selected credentials_files pool "
         f"entry: account {picked!r} ({picked_path}) among {len(slugs)} listed "
-        f"credentials_files (quota-conditional pick — token-fresh, avoids "
-        f"5h-blocked and 7d-near-capped accounts, load-balanced per agent; "
-        f"picked usage 5h={fmt(h5)} 7d={fmt(d7)})",
+        f"credentials_files (policy={policy} — {rationale}; picked usage "
+        f"5h={fmt(u5.get(picked))} 7d={fmt(u7.get(picked))}; {audit})",
         file=stream,
     )
 
@@ -280,8 +320,9 @@ def _rotate_to_healthy_account(
     if not pinned:
         return  # unpinned agent — host live OAuth, untouched.
 
-    from .._creds import pick_healthy_account
+    from .._creds import pick_healthy_account, resolve_7d_policy
 
+    policy = resolve_7d_policy()
     picked = pick_healthy_account(
         pinned,
         now=now,
@@ -289,6 +330,7 @@ def _rotate_to_healthy_account(
         usage_7d=usage_7d,
         quota_cache_path=quota_cache_path,
         spread_key=config.name,
+        policy=policy,
     )
     if picked == pinned:
         return  # pinned is healthy — no rotation, no log line.
@@ -297,9 +339,9 @@ def _rotate_to_healthy_account(
     stream = log_stream if log_stream is not None else sys.stderr
     print(
         f"[sac:creds] agent '{config.name}' rotated account: "
-        f"{pinned!r} -> {picked!r} (pinned account stale, 5h-blocked, or "
-        f"near its weekly cap; rotated to a fresh account with headroom, "
-        f"load-balanced per agent)",
+        f"{pinned!r} -> {picked!r} (policy={policy}; pinned account stale, "
+        f"5h-blocked, or otherwise outranked; rotated to the "
+        f"policy-preferred fresh account)",
         file=stream,
     )
 

--- a/tests/scitex_agent_container/_creds/test__spend_policy.py
+++ b/tests/scitex_agent_container/_creds/test__spend_policy.py
@@ -1,0 +1,388 @@
+"""Tests for the 7d spend-policy layer (operator ruling 2026-07-17).
+
+PA-306 no-mocks: every case drives the real functions with injected
+quota maps / an injected ``now`` (the documented seams) — no real quota
+cache, no network, and NEVER a token. Covers:
+
+* policy resolution (default spread; burn opt-in; fail-loud on unknown);
+* the POLICY_BURN ordering — highest 7d usage first (spend the
+  perishable weekly bucket), soonest-reset tie-break, 5h-blocked tier
+  still supreme, deterministic (spread_key ignored);
+* the preferred-pin inversion — under burn a near-capped pin is a
+  reason to STAY, not to rotate off;
+* the auditable ranking-input record (the fix for "the notice named
+  criteria but not inputs, so a reasoned pick was indistinguishable
+  from a lucky one").
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._creds._pick_audit import (
+    audit_candidates,
+    format_pick_audit,
+)
+from scitex_agent_container._creds._pick_healthy import pick_healthy_account
+from scitex_agent_container._creds._quota_rank import pick_ranked
+from scitex_agent_container._creds._spend_policy import (
+    POLICY_BURN,
+    POLICY_SPREAD,
+    resolve_7d_policy,
+    validate_7d_policy,
+)
+
+_NOW = 1_752_700_000.0  # fixed instant for reset arithmetic
+
+
+# ---------------------------------------------------------------------------
+# resolve_7d_policy — default, opt-in, fail-loud
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_policy_empty_defaults_to_spread():
+    # Arrange — burn-to-zero stays GATED on the fleet reconciler.
+    raw = ""
+    # Act
+    policy = resolve_7d_policy(raw)
+    # Assert
+    assert policy == POLICY_SPREAD
+
+
+def test_resolve_policy_accepts_burn():
+    # Arrange
+    raw = "burn"
+    # Act
+    policy = resolve_7d_policy(raw)
+    # Assert
+    assert policy == POLICY_BURN
+
+
+def test_resolve_policy_normalises_case_and_whitespace():
+    # Arrange
+    raw = "  BURN "
+    # Act
+    policy = resolve_7d_policy(raw)
+    # Assert
+    assert policy == POLICY_BURN
+
+
+def test_resolve_policy_rejects_unknown_value():
+    # Arrange — an operator who asked for a policy must never silently
+    # get another (no silent fallback).
+    raw = "hoard"
+    # Act
+    ctx = pytest.raises(ValueError, match="hoard")
+    # Assert
+    with ctx:
+        resolve_7d_policy(raw)
+
+
+@pytest.fixture
+def _burn_env() -> "Iterator[None]":
+    """Set the REAL SAC_CREDS_7D_POLICY env var; restore on teardown."""
+    saved = os.environ.get("SAC_CREDS_7D_POLICY")
+    saved_long = os.environ.pop("SCITEX_AGENT_CONTAINER_CREDS_7D_POLICY", None)
+    os.environ["SAC_CREDS_7D_POLICY"] = "burn"
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_CREDS_7D_POLICY", None)
+        else:
+            os.environ["SAC_CREDS_7D_POLICY"] = saved
+        if saved_long is not None:
+            os.environ["SCITEX_AGENT_CONTAINER_CREDS_7D_POLICY"] = saved_long
+
+
+def test_resolve_policy_reads_sac_env(_burn_env: None):
+    # Arrange — the real env rail (SAC_ prefix; long form unset) is set
+    # by the fixture.
+    # Act
+    policy = resolve_7d_policy()
+    # Assert
+    assert policy == POLICY_BURN
+
+
+def test_validate_policy_rejects_unknown_value():
+    # Arrange
+    policy = "greedy"
+    # Act
+    ctx = pytest.raises(ValueError, match="greedy")
+    # Assert
+    with ctx:
+        validate_7d_policy(policy)
+
+
+def test_pick_ranked_rejects_unknown_policy():
+    # Arrange
+    names = ["a"]
+    # Act
+    ctx = pytest.raises(ValueError, match="bogus")
+    # Assert
+    with ctx:
+        pick_ranked(names, {"a": 1.0}, {"a": 1.0}, policy="bogus")
+
+
+# ---------------------------------------------------------------------------
+# POLICY_BURN ordering — spend the perishable weekly bucket first
+# ---------------------------------------------------------------------------
+
+
+def test_burn_prefers_highest_7d_usage():
+    # Arrange — nobody blocked; b holds the fullest (most perishable) bucket.
+    names = ["a", "b", "c"]
+    u5 = {"a": 10.0, "b": 10.0, "c": 10.0}
+    u7 = {"a": 10.0, "b": 50.0, "c": 30.0}
+    # Act
+    picked = pick_ranked(names, u5, u7, now=_NOW, policy=POLICY_BURN)
+    # Assert — highest 7d usage wins (spread would prefer a).
+    assert picked == "b"
+
+
+def test_burn_never_picks_a_5h_blocked_account_over_an_unblocked_one():
+    # Arrange — a holds the fullest 7d bucket but cannot serve NOW.
+    names = ["a", "b"]
+    u5 = {"a": 100.0, "b": 10.0}
+    u7 = {"a": 90.0, "b": 50.0}
+    # Act
+    picked = pick_ranked(names, u5, u7, now=_NOW, policy=POLICY_BURN)
+    # Assert — the 5h gate stays supreme under burn.
+    assert picked == "b"
+
+
+def test_burn_tie_breaks_by_soonest_7d_reset():
+    # Arrange — equal 7d usage; b's window resets sooner (its remainder
+    # is destroyed sooner — the operator's original insight).
+    names = ["a", "b"]
+    u5 = {"a": 10.0, "b": 10.0}
+    u7 = {"a": 50.0, "b": 50.0}
+    resets = {"a": _NOW + 4 * 86_400.0, "b": _NOW + 2 * 86_400.0}
+    # Act
+    picked = pick_ranked(names, u5, u7, reset_7d=resets, now=_NOW, policy=POLICY_BURN)
+    # Assert
+    assert picked == "b"
+
+
+def test_burn_is_deterministic_across_spread_keys():
+    # Arrange — burn deliberately concentrates: spread_key must not
+    # change the winner (「落ちたら再起動」 — draining is the point).
+    names = ["a", "b", "c"]
+    u5 = {n: 10.0 for n in names}
+    u7 = {"a": 20.0, "b": 60.0, "c": 40.0}
+    # Act
+    picks = {
+        pick_ranked(names, u5, u7, now=_NOW, spread_key=key, policy=POLICY_BURN)
+        for key in (None, "agent-one", "agent-two")
+    }
+    # Assert — one winner regardless of the key.
+    assert picks == {"b"}
+
+
+def test_burn_known_7d_usage_beats_unknown():
+    # Arrange — a's 7d usage is unknown; known usage beats a guess.
+    names = ["a", "b"]
+    u5 = {"a": 10.0, "b": 10.0}
+    u7 = {"a": None, "b": 5.0}
+    # Act
+    picked = pick_ranked(names, u5, u7, now=_NOW, policy=POLICY_BURN)
+    # Assert
+    assert picked == "b"
+
+
+def test_burn_all_blocked_still_boots_on_highest_7d_usage():
+    # Arrange — quota is a preference, never a gate: an all-blocked
+    # fleet still boots, on the fullest perishable bucket.
+    names = ["a", "b"]
+    u5 = {"a": 100.0, "b": 96.0}
+    u7 = {"a": 80.0, "b": 10.0}
+    # Act
+    picked = pick_ranked(names, u5, u7, now=_NOW, policy=POLICY_BURN)
+    # Assert
+    assert picked == "a"
+
+
+def test_burn_near_cap_is_a_reason_to_pick_not_to_avoid():
+    # Arrange — a sits at 96% of its 7d window (spread demotes it to the
+    # near-capped tier; burn inverts: unspent quota is destroyed at the
+    # boundary, so drain it to zero).
+    names = ["a", "b"]
+    u5 = {"a": 10.0, "b": 10.0}
+    u7 = {"a": 96.0, "b": 50.0}
+    # Act
+    picked = pick_ranked(names, u5, u7, now=_NOW, policy=POLICY_BURN)
+    # Assert
+    assert picked == "a"
+
+
+def test_default_policy_matches_explicit_spread():
+    # Arrange — omitting ``policy`` must be EXACTLY the historical pick.
+    names = ["a", "b", "c"]
+    u5 = {n: 10.0 for n in names}
+    u7 = {"a": 20.0, "b": 60.0, "c": 40.0}
+    # Act
+    default_pick = pick_ranked(names, u5, u7, now=_NOW, spread_key="alpha")
+    explicit_pick = pick_ranked(
+        names, u5, u7, now=_NOW, spread_key="alpha", policy=POLICY_SPREAD
+    )
+    # Assert
+    assert default_pick == explicit_pick
+
+
+def test_burn_on_the_observed_20260717_pool_state():
+    # Arrange — the exact pool state from the operator's report
+    # (5h 10/3/25, 7d 11/3/25, resets +2d8h/+4d3h/+3d18h). Under the
+    # corrected rule usage DOMINATES and reset only tie-breaks, so the
+    # winner is the FULLEST 7d bucket — ywatanabe-scitex-ai at 25% —
+    # not the soonest-resetting wyusuuke (that was the pre-correction
+    # ordering).
+    names = ["wyusuuke-gmail-com", "ywata1989-gmail-com", "ywatanabe-scitex-ai"]
+    u5 = {names[0]: 10.0, names[1]: 3.0, names[2]: 25.0}
+    u7 = {names[0]: 11.0, names[1]: 3.0, names[2]: 25.0}
+    resets = {
+        names[0]: _NOW + (2 * 24 + 8) * 3_600.0,
+        names[1]: _NOW + (4 * 24 + 3) * 3_600.0,
+        names[2]: _NOW + (3 * 24 + 18) * 3_600.0,
+    }
+    # Act
+    picked = pick_ranked(names, u5, u7, reset_7d=resets, now=_NOW, policy=POLICY_BURN)
+    # Assert
+    assert picked == "ywatanabe-scitex-ai"
+
+
+# ---------------------------------------------------------------------------
+# pick_healthy_account — the preferred-pin inversion under burn
+# ---------------------------------------------------------------------------
+
+
+def _write_snapshot(home: Path, name: str, expires_at_ms: int) -> Path:
+    path = (
+        home / ".scitex" / "agent-container" / "accounts" / name / ".credentials.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"claudeAiOauth": {"expiresAt": expires_at_ms}}))
+    return path
+
+
+def _fresh_ms() -> int:
+    return int((time.time() + 7_200.0) * 1_000)
+
+
+def test_spread_rotates_off_a_near_capped_pin(tmp_path: Path):
+    # Arrange — the pinned account is near-capped (95%, not expiring).
+    _write_snapshot(tmp_path, "pin", _fresh_ms())
+    _write_snapshot(tmp_path, "alt", _fresh_ms())
+    quota = {"pin": 95.0, "alt": 10.0}
+    # Act
+    picked = pick_healthy_account(
+        "pin",
+        candidates=["pin", "alt"],
+        home=tmp_path,
+        usage_5h={},
+        usage_7d=quota,
+        reset_7d={},
+        policy=POLICY_SPREAD,
+    )
+    # Assert — the historical avoidance: rotate off the near-capped pin.
+    assert picked == "alt"
+
+
+def test_burn_keeps_a_near_capped_pin_and_drains_it(tmp_path: Path):
+    # Arrange — same state; burn inverts: near-cap is a reason to STAY.
+    _write_snapshot(tmp_path, "pin", _fresh_ms())
+    _write_snapshot(tmp_path, "alt", _fresh_ms())
+    quota = {"pin": 95.0, "alt": 10.0}
+    # Act
+    picked = pick_healthy_account(
+        "pin",
+        candidates=["pin", "alt"],
+        home=tmp_path,
+        usage_5h={},
+        usage_7d=quota,
+        reset_7d={},
+        policy=POLICY_BURN,
+    )
+    # Assert
+    assert picked == "pin"
+
+
+def test_burn_still_rotates_off_a_5h_blocked_pin(tmp_path: Path):
+    # Arrange — burn never overrides the 5h gate: a blocked-now pin
+    # cannot serve a request no matter how full its weekly bucket is.
+    _write_snapshot(tmp_path, "pin", _fresh_ms())
+    _write_snapshot(tmp_path, "alt", _fresh_ms())
+    # Act
+    picked = pick_healthy_account(
+        "pin",
+        candidates=["pin", "alt"],
+        home=tmp_path,
+        usage_5h={"pin": 100.0, "alt": 5.0},
+        usage_7d={"pin": 95.0, "alt": 10.0},
+        reset_7d={},
+        policy=POLICY_BURN,
+    )
+    # Assert
+    assert picked == "alt"
+
+
+# ---------------------------------------------------------------------------
+# The auditable ranking-input record
+# ---------------------------------------------------------------------------
+
+
+def test_audit_records_seconds_to_7d_reset():
+    # Arrange
+    names = ["a"]
+    resets = {"a": _NOW + 3_600.0}
+    # Act
+    records = audit_candidates(names, {"a": 5.0}, {"a": 7.0}, reset_7d=resets, now=_NOW)
+    # Assert — time-to-reset is IN the record (the missing input).
+    assert records[0].reset_7d_in_s == 3_600.0
+
+
+def test_audit_line_names_every_candidate():
+    # Arrange
+    names = ["a", "b"]
+    u = {"a": 5.0, "b": 7.0}
+    # Act
+    line = format_pick_audit(audit_candidates(names, u, u, now=_NOW))
+    # Assert
+    assert "a(" in line and "b(" in line
+
+
+def test_audit_line_carries_reset_hours():
+    # Arrange
+    names = ["a"]
+    resets = {"a": _NOW + 3_600.0}
+    # Act
+    line = format_pick_audit(
+        audit_candidates(names, {"a": 5.0}, {"a": 7.0}, reset_7d=resets, now=_NOW)
+    )
+    # Assert
+    assert "7d_reset=+1.0h" in line
+
+
+def test_audit_line_flags_a_5h_blocked_candidate():
+    # Arrange
+    names = ["a"]
+    # Act
+    line = format_pick_audit(
+        audit_candidates(names, {"a": 100.0}, {"a": 7.0}, now=_NOW)
+    )
+    # Assert
+    assert "5h-blocked" in line
+
+
+def test_audit_line_renders_unknowns_as_question_marks():
+    # Arrange — no cached usage / reset at all.
+    names = ["a"]
+    # Act
+    line = format_pick_audit(audit_candidates(names, {}, {}, now=_NOW))
+    # Assert
+    assert "5h=? 7d=? 7d_reset=?" in line

--- a/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
@@ -113,6 +113,77 @@ def test_pool_selection_emits_a_one_line_notice(_isolate_home: Path) -> None:
     assert "alpha" in msg and "acct-b" in msg
 
 
+def test_pool_notice_names_the_active_policy(_isolate_home: Path) -> None:
+    # Arrange — the notice must say WHICH 7d spend policy ranked the pick.
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _future_ms())
+    p_b = _write_snapshot(home, "acct-b", _future_ms())
+    cfg = _make_pool_config("alpha", [p_a, p_b])
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(
+        cfg, log_stream=log, usage_7d={"acct-a": 95.0, "acct-b": 5.0}
+    )
+    # Assert
+    assert "policy=spread" in log.getvalue()
+
+
+def test_pool_notice_carries_per_candidate_ranking_inputs(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — operator 2026-07-17: the notice named its CRITERIA but
+    # not its INPUTS, so a reasoned pick was indistinguishable from a
+    # lucky one. Every candidate's 5h/7d/reset must appear.
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _future_ms())
+    p_b = _write_snapshot(home, "acct-b", _future_ms())
+    cfg = _make_pool_config("alpha", [p_a, p_b])
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(
+        cfg, log_stream=log, usage_7d={"acct-a": 95.0, "acct-b": 5.0}
+    )
+    # Assert — the losing candidate's inputs are logged too.
+    assert "ranking inputs:" in log.getvalue() and "acct-a(5h=" in log.getvalue()
+
+
+@pytest.fixture
+def _burn_policy_env() -> Iterator[None]:
+    """Set the REAL SAC_CREDS_7D_POLICY=burn env var; restore on teardown."""
+    saved = os.environ.get("SAC_CREDS_7D_POLICY")
+    saved_long = os.environ.pop("SCITEX_AGENT_CONTAINER_CREDS_7D_POLICY", None)
+    os.environ["SAC_CREDS_7D_POLICY"] = "burn"
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_CREDS_7D_POLICY", None)
+        else:
+            os.environ["SAC_CREDS_7D_POLICY"] = saved
+        if saved_long is not None:
+            os.environ["SCITEX_AGENT_CONTAINER_CREDS_7D_POLICY"] = saved_long
+
+
+def test_pool_under_burn_env_prefers_the_near_capped_entry(
+    _isolate_home: Path, _burn_policy_env: None
+) -> None:
+    # Arrange — SAC_CREDS_7D_POLICY=burn (fixture). Under the corrected
+    # 7d rule the near-capped entry is a reason to PICK: its unspent
+    # quota is destroyed at the weekly boundary.
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _future_ms())
+    p_b = _write_snapshot(home, "acct-b", _future_ms())
+    cfg = _make_pool_config("alpha", [p_a, p_b])
+    # Act
+    _rotate_to_healthy_account(
+        cfg,
+        log_stream=io.StringIO(),
+        usage_7d={"acct-a": 95.0, "acct-b": 5.0},
+    )
+    # Assert — spread avoids acct-a; burn drains it to zero.
+    assert cfg.claude.credentials_file == str(p_a)
+
+
 # ---------------------------------------------------------------------------
 # Only one entry is token-fresh — it is returned even when near-capped.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The question: was tonight's pick REASONED or LUCKY?

**LUCKY — with evidence.** The picker DOES read `reset_at_7d`, but only as a binary *is-expiring-within-2h* flag (`EXPIRING_7D_HORIZON_S = 2h` in `_creds/_quota_rank.py`). Outside that horizon time-to-reset has ZERO effect. Tonight both 7d resets were 2d+ away → the flag was False everywhere → the pick fell to the 7d-headroom-weighted rendezvous hash, whose weight (`100 - d7`) actually favours the account with the MOST headroom — ywata1989 at 97 vs wyusuuke at 90. The hash landing scitex-hub on wyusuuke was coincidence. Worse: *most headroom first* is the exact inverse of the operator's corrected rule.

## The corrected rule (operator, 2026-07-17)

The 5h and 7d windows are different kinds of resource: 5h is ROLLING (a cap costs a short wait), 7d is WEEKLY USE-IT-OR-LOSE-IT (unspent quota is destroyed at the boundary). So: (1) exclude 5h-hard-blocked / token-stale; (2) among survivors prefer HIGHEST 7d usage — burn the perishable bucket to zero (「7d 上限が近ければむしろ積極的に使って使い切る；落ちたら再起動」); (3) tie-break soonest 7d reset; on block, fail over.

## What ships

- `_creds/_spend_policy.py` — `POLICY_SPREAD` (default; historical behaviour byte-identical) / `POLICY_BURN` (the corrected rule; deterministic, spread_key deliberately ignored — concentration is the point); `resolve_7d_policy()` from `SAC_CREDS_7D_POLICY` with a fail-loud validator (unknown value raises — no silent fallback).
- `pick_healthy_account` / `pick_ranked` take `policy=`; under burn a near-capped pin is a reason to STAY; the pool path drops the prior-slug churn preference (a named spec pin still holds); 5h-blocked stays supreme under both policies.
- `_creds/_pick_audit.py` — every pool pick now logs EVERY ranking input + the active policy, e.g. on the real pool right now (read-only; percentages and hours only, never a token):

```
ranking inputs: wyusuuke-gmail-com(5h=64% 7d=26% 7d_reset=+51.1h), ywata1989-gmail-com(5h=23% 7d=10% 7d_reset=+94.1h), ywatanabe-scitex-ai(5h=29% 7d=34% 7d_reset=+85.1h)

policy=spread agent=scitex-hub    -> wyusuuke-gmail-com
policy=spread agent=scitex-writer -> ywata1989-gmail-com
policy=burn   agent=scitex-hub    -> ywatanabe-scitex-ai   (highest 7d usage, deterministic)
```

## *** ACTIVATION IS GATED — default stays spread ***

Burn-to-zero deliberately manufactures agent deaths (「落ちたら再起動」). That is only safe when restart is AUTOMATIC, and today it is not: `restart.policy` is dead code in all 93 specs and the reconciler timer is not installed (card `sac-fleet-reconciler-restart-dead-agents-20260716`). This PR ships the logic and the audit rail; flipping the default (or setting `SAC_CREDS_7D_POLICY=burn` fleet-wide) waits for the reconciler to be live.

## Safety

Read-only throughout — no token is read, refreshed, or validated (this is the pool behind the 2026-07-09 load/401 incident; a probe must not mutate).

## Tests

24 new tests (policy resolution incl. real-env fixture, burn ordering incl. tonight's observed pool state, pin inversion, audit record/line, pool-notice policy + ranking-inputs assertions); 121 total picker/pool/rotate/preflight tests green against worktree source.

Companion display PR: #737 (accounts list layout — reset time before the bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)