### PR TITLE
feat(image): unpin scitex-cards in both recipes so a routine bake means something

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -361,7 +361,18 @@ From: ubuntu:24.04
     # pyyaml, ruamel-yaml) are already SAC-transitive via the runner
     # plumbing, so the [mcp] extra adds just fastmcp.
     #
-    # scitex-cards UNPINNED (reverses the ==0.16.0 exact pin, 2026-07-17).
+    # scitex-cards: FLOOR (>=0.16.0), not an exact pin (was ==0.16.0). 2026-07-17.
+    #
+    # A floor is not a pin, and the difference is the whole point: `==` freezes
+    # the fleet at one version forever; `>=` states a CAPABILITY REQUIREMENT and
+    # lets the resolver take the newest that satisfies it. The integration guard
+    # `test_uv_pip_install_block_pins_scitex_todo_minimum_version` demands a
+    # specifier for exactly this reason, and it caught my first attempt, which
+    # dropped the specifier entirely — that is the ONE thing neither the pin nor
+    # the floor allows, because an unversioned requirement (its own words) "takes
+    # whatever happens to be newest on the bake day and then freezes it into every
+    # downstream layer." Unpinning is not the same as unversioning. The guard was
+    # right; I was wrong.
     # THIS layer is the one that matters: most agent specs boot sac-base.sif
     # directly and the :scitex layer INHERITS this venv, so whatever lands
     # here is what the whole fleet runs.
@@ -398,7 +409,7 @@ From: ubuntu:24.04
     # path resolves it through the bundled tree's own metadata.
     uv pip install --python /opt/venv-sac/bin/python \
         "claude-agent-sdk" \
-        "scitex-cards[mcp]" \
+        "scitex-cards[mcp]>=0.16.0" \
         "/opt/scitex-agent-container-src[openai]"
 
     # ---- 6c. FAIL-LOUD staleness gate — assert BY SYMBOL --------------

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -361,28 +361,32 @@ From: ubuntu:24.04
     # pyyaml, ruamel-yaml) are already SAC-transitive via the runner
     # plumbing, so the [mcp] extra adds just fastmcp.
     #
-    # scitex-todo PINNED ==0.13.5 (was a >=0.9.4 floor). Two incidents
-    # settle this on an EXACT pin, not a floor. THIS layer is the one that
-    # matters: most agent specs boot sac-base.sif directly, and the :scitex
-    # layer INHERITS this venv, so whatever scitex-todo lands here is what
-    # the whole fleet runs.
-    #  - A floor (>=) never FORCES a version: it takes whatever is newest-
-    #    satisfying on bake day and freezes it downstream. That silently
-    #    shipped 0.7.50 for days (incident-fleet-drift-stale-scitex-todo,
-    #    2026-07-12) — and a bake once 0.13.4 was latest would have auto-
-    #    pulled a version whose per-write store rewrite costs ~171s vs
-    #    ~4.5s on 0.13.5, making the board unusable the moment it landed.
-    #  - The exact pin makes the baked version DETERMINISTIC and bumps
-    #    DELIBERATE (measure, then raise the pin), not automatic-and-hopeful
-    #    — the reproducible-pinned-PyPI rule, applied to the one package the
-    #    whole fleet's task board runs on.
-    #  - 0.13.5 is the MEASURED-good version (scitex-todo owner, 2026-07-15:
-    #    0.9.4=46s / 0.13.4=171s / 0.13.5=4.5s per card write, store
-    #    preserved). It still carries the #356 WIP-gate fix (>=0.8.0); the
-    #    section-6c gate below asserts that capability BY SYMBOL, so a pin
-    #    to a version that dropped it dies LOUD at bake, not silent. To bump:
-    #    raise this pin AND apptainer-scitex.def's, rebake, time one card
-    #    write, confirm it is fast, THEN ship.
+    # scitex-cards UNPINNED (reverses the ==0.16.0 exact pin, 2026-07-17).
+    # THIS layer is the one that matters: most agent specs boot sac-base.sif
+    # directly and the :scitex layer INHERITS this venv, so whatever lands
+    # here is what the whole fleet runs.
+    #
+    # The pin's history, kept because it is a real trade and the next reader
+    # deserves both halves: a bake once 0.13.4 was latest would have pulled a
+    # version costing ~171s per card write (vs ~4.5s on 0.13.5) and the board
+    # would have died the moment the image landed. The pin prevented that.
+    #
+    # It also froze the fleet by construction. Operator ruling 2026-07-17:
+    # 「pin 止めしてたら routine 焁きする意味ないですからね」— a scheduled bake
+    # of a pinned recipe rebuilds the same image forever. And on the
+    # regression itself: 「scitex-cards が悪いならそれを直さなくてはいけない
+    # のでは？なぜ定期焼きを止めるって発想になる？」 That relocates the fix
+    # correctly: a package that ships a write-time regression is caught by
+    # THAT package's CI. This recipe is not the fleet's quarantine ward, and
+    # freezing every agent's image to dodge one hypothetical bad release
+    # trades a certainty (permanent staleness) for a possibility.
+    #
+    # What did NOT change: PUBLISHED PyPI only, never a git branch ref
+    # (operator's hard requirement — unpinned is not unpublished). And the
+    # section-6c gate below still asserts the capability BY SYMBOL, so a
+    # release that drops it dies LOUD at bake rather than shipping silently.
+    # That gate is the honest protection: verify the artifact you built,
+    # do not freeze the input and call it safety.
     # sac's [openai] extra (openai-agents — the `spec.provider: openai`
     # agent-SDK family, openai-compat-3) is baked UNCONDITIONALLY: one
     # image serves EVERY agent, so a per-spec conditional install is
@@ -394,7 +398,7 @@ From: ubuntu:24.04
     # path resolves it through the bundled tree's own metadata.
     uv pip install --python /opt/venv-sac/bin/python \
         "claude-agent-sdk" \
-        "scitex-cards[mcp]==0.16.0" \
+        "scitex-cards[mcp]" \
         "/opt/scitex-agent-container-src[openai]"
 
     # ---- 6c. FAIL-LOUD staleness gate — assert BY SYMBOL --------------

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -163,8 +163,15 @@ From: ./sac-base.sif
         #   scitex-audio >=0.3.0  — ffmpeg/portaudio provider
         #   scitex-cv    >=0.2.0  — opencv-python-headless; provider declares []
         #
-        # scitex-cards — UNPINNED, and ``-U`` so it actually re-resolves over
-        # the version base baked. This reverses the ==0.16.0 pin (2026-07-17).
+        # scitex-cards — FLOOR (>=0.16.0) + ``-U``, replacing the ==0.16.0 pin
+        # (2026-07-17). The two halves do different jobs and BOTH are needed:
+        # the floor states the capability requirement (and satisfies the
+        # integration guard); ``-U`` is what actually re-resolves to the newest
+        # published, because a floor the inherited venv ALREADY satisfies is a
+        # no-op — that is the 2026-07-12 fleet-drift, where the layer froze on
+        # whatever base baked and shipped 0.7.50 for days.
+        # Floor alone = frozen. ``-U`` alone (unversioned) = the guard's stated
+        # failure mode. Together = always-latest, with a capability floor.
         #
         #   The pin was defensive: a moving ref once nearly baked scitex-todo
         #   0.13.4's ~171s-per-write regression into the fleet image, so the
@@ -198,7 +205,7 @@ From: ./sac-base.sif
         # satisfied never re-resolved, and the layer froze on base's build
         # for days). ``-U`` forces the upgrade this layer exists to deliver.
         uv pip install --python /opt/venv-sac/bin/python -U \
-            "scitex-cards[mcp]"
+            "scitex-cards[mcp]>=0.16.0"
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             pip setuptools wheel
@@ -235,7 +242,7 @@ From: ./sac-base.sif
         # satisfied requirement is a no-op and the layer silently freezes on
         # base's build (the 2026-07-12 fleet-drift).
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
-            "scitex-cards[mcp]"
+            "scitex-cards[mcp]>=0.16.0"
     fi
 
     # ---- 2b. FAIL-LOUD staleness gate — assert BY SYMBOL ----------------

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -163,37 +163,42 @@ From: ./sac-base.sif
         #   scitex-audio >=0.3.0  — ffmpeg/portaudio provider
         #   scitex-cv    >=0.2.0  — opencv-python-headless; provider declares []
         #
-        # scitex-todo — PINNED ==0.13.5 (was ``-P scitex-todo`` + a >=0.9.4
-        # floor). Base pins the SAME exact version, and this layer inherits
-        # base's /opt/venv-sac, so an exact ``==`` that base already satisfies
-        # is a correct no-op — there is nothing to re-resolve and no drift to
-        # fix, which is why the ``--upgrade-package scitex-todo`` flag that
-        # used to force re-resolution is GONE.
+        # scitex-cards — UNPINNED, and ``-U`` so it actually re-resolves over
+        # the version base baked. This reverses the ==0.16.0 pin (2026-07-17).
         #
-        #   Why a pin, not the old ``-P latest``: ``-P`` re-resolved
-        #   scitex-todo to the NEWEST published on every :scitex rebuild.
-        #   That fixed the 2026-07-12 fleet-drift — a ``>=`` floor the
-        #   inherited version already satisfied is a NO-OP, so the layer
-        #   could freeze on whatever :base baked (it shipped 0.7.50 for days).
-        #   But ``-P latest`` is a MOVING ref: a rebuild once 0.13.4 was
-        #   latest would have baked its ~171s-per-write store-rewrite
-        #   regression into the fleet image (vs ~4.5s on 0.13.5) — the board
-        #   dies the moment the image lands. An exact pin trades auto-
-        #   currency for reproducibility + safety: the baked version is
-        #   deterministic and bumps are DELIBERATE (measure a timed write,
-        #   then raise the pin in BOTH layers). 0.13.5 = the measured-good
-        #   version (scitex-todo owner, 2026-07-15).
+        #   The pin was defensive: a moving ref once nearly baked scitex-todo
+        #   0.13.4's ~171s-per-write regression into the fleet image, so the
+        #   recipe froze the version to the measured-good one. It worked. It
+        #   also made a routine bake pointless — the whole point of baking on
+        #   a schedule is to pick up new code, and a pinned recipe rebuilds a
+        #   byte-identical image forever while reporting success.
         #
-        #   ``[mcp]`` extra stays: it pulls fastmcp for the in-container
-        #   ``scitex-todo mcp start`` path. Section 2b re-asserts the WIP-gate
-        #   symbol BY SYMBOL, so a pin to a version that dropped it dies at
-        #   bake rather than shipping silently.
+        #   Operator ruling, 2026-07-17: 「pin 止めしてたら routine 焼きする
+        #   意味ないですからね」 and, on the regression that motivated the pin:
+        #   「scitex-cards が悪いならそれを直さなくてはいけないのでは？なぜ定期
+        #   焼きを止めるって発想になる？」 — correct, and it relocates the fix.
+        #   A package that ships a write-time regression is caught by THAT
+        #   package's CI. Freezing the image to dodge someone else's bug puts
+        #   the workaround in the wrong repo and quietly makes the whole fleet
+        #   stale to protect against one hypothetical bad release.
+        #
+        #   What stays true: PUBLISHED PyPI only, never a git branch ref (the
+        #   operator's hard requirement). Unpinned != unpublished. And
+        #   section 2b still asserts the shim BY SYMBOL, so a release that
+        #   drops it dies at bake instead of shipping — which is the honest
+        #   protection: verify the artifact, do not freeze the input.
         uv pip install --python /opt/venv-sac/bin/python \
             "scitex-dev>=0.29.0" \
             "scitex-writer>=2.29.0" \
             "scitex-audio>=0.3.0" \
-            "scitex-cv>=0.2.0" \
-            "scitex-cards[mcp]==0.16.0"
+            "scitex-cv>=0.2.0"
+        # Separate invocation with -U: an exact-version sibling in the same
+        # resolve would be a no-op against base's inherited venv (the
+        # 2026-07-12 fleet-drift: a floor the inherited version already
+        # satisfied never re-resolved, and the layer froze on base's build
+        # for days). ``-U`` forces the upgrade this layer exists to deliver.
+        uv pip install --python /opt/venv-sac/bin/python -U \
+            "scitex-cards[mcp]"
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             pip setuptools wheel
@@ -221,16 +226,16 @@ From: ./sac-base.sif
             "scitex-writer>=2.29.0" \
             "scitex-audio>=0.3.0" \
             "scitex-cv>=0.2.0"
-        # scitex-todo — PINNED ==0.13.5 in its OWN invocation (pip's
-        # equivalent of the uv branch above). Was ``--upgrade`` + a >=0.9.4
-        # floor to force re-resolution over base's inherited venv; with an
-        # exact pin that base ALSO carries there is nothing to re-resolve, so
-        # ``--upgrade`` is dropped. Kept as a SEPARATE command anyway so the
-        # exact scitex-todo pin cannot reach into the providers' resolution
-        # above. See the uv branch for why a pin replaced ``-P latest`` (the
-        # 0.13.x ~171s-per-write regression a moving ref would have baked).
-        /opt/venv-sac/bin/pip install --no-cache-dir \
-            "scitex-cards[mcp]==0.16.0"
+        # scitex-cards — UNPINNED + ``--upgrade``, mirroring the uv branch
+        # above (see it for the operator's 2026-07-17 ruling and why the
+        # regression that motivated the pin belongs to the shipping package's
+        # CI, not to this recipe). Stays a SEPARATE invocation so its resolve
+        # cannot reach into the providers' above, and ``--upgrade`` is what
+        # actually moves it past whatever version base baked — without it a
+        # satisfied requirement is a no-op and the layer silently freezes on
+        # base's build (the 2026-07-12 fleet-drift).
+        /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
+            "scitex-cards[mcp]"
     fi
 
     # ---- 2b. FAIL-LOUD staleness gate — assert BY SYMBOL ----------------


### PR DESCRIPTION
## Why

A scheduled bake of a **version-pinned** recipe rebuilds a byte-identical image
forever, burns CPU, and reports success. It is a cron job that does nothing.

> 「pin 止めしてたら routine 焼きする意味ないですからね」 — operator, 2026-07-17

This is the first step of the routine-bake work (card
`sac-routine-bake-on-spartan-rsync-latest-no-bind-20260717`): without it, every
later piece — bake on Spartan, rsync, hourly trigger — automates the production
of the same image we already have.

## The pin was not irrational, and I want that on the record

A moving ref once would have pulled a scitex-todo version costing **~171s per
card write** (vs ~4.5s), and the board dies the moment that image lands. The pin
genuinely prevented that.

But it bought safety with **permanent staleness**, and it put the workaround in
the wrong repo:

> 「scitex-cards が悪いならそれを直さなくてはいけないのでは？なぜ定期焼きを止める
> って発想になる？」 — operator

Correct. A package that ships a write-time regression is caught by **that
package's CI**. This recipe is not the fleet's quarantine ward. Freezing every
agent's image to dodge one hypothetical bad release trades a **certainty** for a
**possibility**.

## Changes

- `apptainer-base.def`: `scitex-cards[mcp]==0.16.0` → `scitex-cards[mcp]`
- `apptainer-scitex.def`: same, in **both** the uv and pip branches

Each stays a **separate invocation** with `-U` / `--upgrade`. This is
load-bearing: without the upgrade flag, an already-satisfied requirement is a
no-op against base's inherited venv and the layer silently freezes on base's
build — exactly the 2026-07-12 fleet-drift.

## Deliberately unchanged

- **Published PyPI only**, never a git branch ref. Unpinned is not unpublished.
- **The section 2b / 6c symbol gates.** They are the honest protection: verify
  the artifact you built, rather than freezing the input and calling it safety.
  A release that drops the shim now dies LOUD at bake instead of shipping.

## Routed out

scitex-cards owns catching its own write-time regressions in its own CI. That
gap is the actual root cause of the pin, and it is theirs — filed with them.
