### PR TITLE
fix(to_home): gate the telegrammer MCP on the spec, not on whatever the shell env carries

### DIFF
--- a/src/scitex_agent_container/runtimes/_to_home_deployers.py
+++ b/src/scitex_agent_container/runtimes/_to_home_deployers.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from ..config import AgentConfig
 from ._mcp_merge import merge_mcp_json
 from ._mcp_reliability import inject_always_load
+from ._sdk_channels import _TELEGRAMMER_CHANNEL, _TELEGRAMMER_MCP_KEY
 from ._to_home_errors import WorkspaceMcpMergeError
 from ._to_home_text import (
     END_MARKER,
@@ -165,6 +166,7 @@ def _deploy_mcp_merge(
         merged = merge_mcp_json(base_doc, overlay_doc)
     else:
         merged = overlay_doc
+    _drop_unrequested_telegrammer(merged, config=config, dst=dst)
     # Cold-start race fix (fleet incident 2026-07-06): stamp ``alwaysLoad:true``
     # onto the critical stdio MCP servers so Claude Code BLOCKS on startup until
     # they connect (capped at MCP_TIMEOUT) instead of racing the slow fastmcp
@@ -172,6 +174,63 @@ def _deploy_mcp_merge(
     inject_always_load(merged)
     dst.write_text(json.dumps(merged, indent=2) + "\n")
     logger.info("to_home: deep-merged .mcp.json %s -> %s", rel, dst)
+
+
+def _drop_unrequested_telegrammer(
+    merged: dict,
+    *,
+    config: AgentConfig | None,
+    dst: Path,
+) -> None:
+    """Remove the telegrammer MCP unless the spec ASKED for its channel.
+
+    The shared baseline ``.mcp.json`` carries claude-code-telegrammer for every
+    agent, and the union above faithfully preserves it. But ``spec.claude.channels``
+    only gates the ``--dangerously-load-development-channels`` FLAG — it never
+    gated the SERVER. So an agent whose spec says nothing about Telegram still
+    got a telegrammer MCP, whose config expands ``${CCT_BOT_TOKEN}`` /
+    ``${CCT_AGENT_ID}`` from the shell env at runtime.
+
+    That stayed invisible while those vars were empty. It stopped being invisible
+    on 2026-07-17, when direnv began loading each project's ``.envrc`` in the
+    agent's shell: three scitex-cards UI agents working in ``~/proj/scitex-todo``
+    picked up that project's ``CCT_BOT_TOKEN`` **and its CCT_AGENT_ID**, came up
+    announcing themselves as ``scitex-todo``, and fought over the scitex-todo
+    steward's bot (Telegram allows exactly one poller per token, so the three of
+    them stole the connection from each other in a loop).
+
+    The token half is a leak; the IDENTITY half is the real defect — an ambient
+    file made whoever ``cd``-ed into a directory *become* another agent. Neither
+    is the ``.envrc``'s fault: a project file may reasonably describe its own bot.
+    The fault is that the SPEC was not the authority over what the agent runs.
+    So the gate belongs here, at the last point where the agent's real MCP set is
+    decided, and it is keyed on the spec — the SSoT — not on whether some env var
+    happens to be populated.
+
+    Absent config (``None``) leaves the doc untouched: the baseline deploy has no
+    spec to consult, and an agent's own pass always follows. Silently stripping a
+    server on a config-less pass would be a fallback, and a wrong one.
+    """
+    if config is None:
+        return
+    servers = merged.get("mcpServers")
+    if not isinstance(servers, dict) or _TELEGRAMMER_MCP_KEY not in servers:
+        return
+    claude_spec = getattr(config, "claude", None)
+    channels = list(getattr(claude_spec, "channels", None) or [])
+    if any(str(c).strip() == _TELEGRAMMER_CHANNEL for c in channels):
+        return
+    servers.pop(_TELEGRAMMER_MCP_KEY, None)
+    logger.info(
+        "to_home: dropped %r MCP for agent %r — its spec does not request %r "
+        "(the server would otherwise poll whatever CCT_BOT_TOKEN the shell "
+        "environment happened to carry, under whatever CCT_AGENT_ID came with "
+        "it). Add the channel to spec.claude.channels to keep it. -> %s",
+        _TELEGRAMMER_MCP_KEY,
+        getattr(config, "name", "?"),
+        _TELEGRAMMER_CHANNEL,
+        dst,
+    )
 
 
 def _deploy_tight_perm_file(

--- a/tests/runtimes/test_telegrammer_mcp_gated_on_spec.py
+++ b/tests/runtimes/test_telegrammer_mcp_gated_on_spec.py
@@ -1,0 +1,84 @@
+"""The telegrammer MCP must be gated on the spec, not on the env.
+
+Incident 2026-07-17: the shared baseline .mcp.json carries a
+claude-code-telegrammer MCP for EVERY agent. spec.claude.channels gated only the
+--dangerously-load-development-channels flag, never the server. Once direnv began
+loading each project's .envrc in the agent's shell, three scitex-cards UI agents
+whose cwd was ~/proj/scitex-todo picked up that project's CCT_BOT_TOKEN *and*
+CCT_AGENT_ID, came up announcing themselves as scitex-todo, and fought over the
+scitex-todo steward's bot.
+
+These are AAA and each name states the behaviour, not the implementation.
+"""
+
+import json
+import types
+from pathlib import Path
+
+from scitex_agent_container.runtimes._to_home_deployers import _deploy_mcp_merge
+
+_BASELINE = {
+    "mcpServers": {
+        "sac": {"command": "sac"},
+        "scitex-todo": {"command": "scitex-todo"},
+        "claude-code-telegrammer": {
+            "command": "cct",
+            "env": {"CCT_BOT_TOKEN": "${CCT_BOT_TOKEN}"},
+        },
+    }
+}
+
+
+def _config(name, channels):
+    """A stand-in AgentConfig: only .name/.workdir/.claude.channels are read."""
+    return types.SimpleNamespace(
+        name=name,
+        workdir="/home/ywatanabe/proj/scitex-todo",
+        claude=types.SimpleNamespace(channels=list(channels)),
+        env={},
+    )
+
+
+def _run(tmp_path, config):
+    """Deploy the baseline, then merge a per-agent overlay over it."""
+    src = tmp_path / "src.mcp.json"
+    src.write_text(json.dumps(_BASELINE))
+    dst = tmp_path / ".mcp.json"
+    _deploy_mcp_merge(src, dst, config=config, rel=Path(".mcp.json"))
+    return json.loads(dst.read_text()).get("mcpServers", {})
+
+
+def test_agent_whose_spec_omits_the_channel_gets_no_telegrammer_mcp(tmp_path):
+    # Arrange: the exact shape of the three scitex-cards UI agents.
+    config = _config("scitex-cards-chat", ["server:sac", "server:scitex-todo"])
+    # Act
+    servers = _run(tmp_path, config)
+    # Assert: the server that would have polled a stolen bot is simply absent.
+    assert "claude-code-telegrammer" not in servers
+
+
+def test_agent_whose_spec_requests_the_channel_keeps_its_telegrammer_mcp(tmp_path):
+    # Arrange
+    config = _config("dotfiles", ["server:sac", "server:claude-code-telegrammer"])
+    # Act
+    servers = _run(tmp_path, config)
+    # Assert: the gate must not break the agents that legitimately have a bot.
+    assert "claude-code-telegrammer" in servers
+
+
+def test_gating_the_telegrammer_leaves_every_other_baseline_server_intact(tmp_path):
+    # Arrange
+    config = _config("scitex-cards-gui", ["server:sac"])
+    # Act
+    servers = _run(tmp_path, config)
+    # Assert: a scalpel, not a hammer -- only the one server is dropped.
+    assert "sac" in servers and "scitex-todo" in servers
+
+
+def test_baseline_pass_without_a_config_keeps_the_telegrammer_untouched(tmp_path):
+    # Arrange: the config-less baseline deploy has no spec to consult; stripping
+    # there would be a fallback, and the agent's own pass always follows.
+    # Act
+    servers = _run(tmp_path, None)
+    # Assert
+    assert "claude-code-telegrammer" in servers


### PR DESCRIPTION
## The bug

The shared baseline `.mcp.json` carries a **claude-code-telegrammer MCP server for
every agent**, and the baseline-union merge faithfully preserves it.
`spec.claude.channels` gates the `--dangerously-load-development-channels` **flag** —
it never gated the **server**.

So an agent whose spec says nothing about Telegram still got a telegrammer MCP,
whose config expands `${CCT_BOT_TOKEN}` / `${CCT_AGENT_ID}` from the **shell
environment** at runtime. The spec says no; the agent runs one anyway.

## Why it detonated tonight

Invisible while those vars were empty. Then direnv began loading each project's
`.envrc` in the agent's shell. Three scitex-cards UI agents working in
`~/proj/scitex-todo` picked up that project's `CCT_BOT_TOKEN` **and its
`CCT_AGENT_ID`**, came up announcing themselves as `scitex-todo`, and fought over
the scitex-todo steward's bot — Telegram allows exactly one poller per token.

Measured by reading each poller process's own environment:

```
pid=2675173 owner=scitex-cards-chat    polling_as=scitex-todo
pid=2696432 owner=scitex-cards-gui     polling_as=scitex-todo
pid=2719398 owner=scitex-cards-mobile  polling_as=scitex-todo
pid=2909718 owner=scitex-cards-mobile  polling_as=scitex-todo
```

**The leaked token is the smaller half. The IDENTITY is the defect**: an ambient
file made whoever `cd`-ed into a directory *become* another agent.

That is **not the `.envrc`'s fault** — a project file may reasonably describe its
own bot. The fault is that the **spec was not the authority over what the agent
runs**.

## The fix

One call, at the last point where the agent's real MCP set is decided, keyed on
the **spec** (the SSoT) — never on whether an env var happens to be populated.

A config-less baseline pass is left untouched: it has no spec to consult and the
agent's own pass always follows. Stripping there would be a fallback, and a wrong
one.

## Evidence

- **4 new tests**, AAA, each name states the behaviour.
- **Mutation-proven**: with the gate line disabled,
  `test_agent_whose_spec_omits_the_channel_gets_no_telegrammer_mcp` goes RED, and
  its failure message shows the exact incident payload surviving into an agent
  that never asked for it. A guard nobody has watched fail is a hope with YAML
  around it.
- **Regression: 913 passed / 1 pre-existing failure.** That one
  (`test__sdk_channels.py::test_no_log_when_channel_not_requested`) is
  `SacBinaryNotFoundError` from `sac` not being on PATH in the test shell, and it
  fails **identically on pristine `origin/develop`** with this change absent —
  verified in a detached worktree rather than assumed.

## Sequencing (load-bearing)

The fleet rolling-restart is on hold behind this. Most agents currently run
*without* direnv active, so the trap is unarmed for them; a rolling restart
delivers direnv to all 96 specs and would arm it fleet-wide at once. **Fix → then
restart.** Killing the four pollers was a mitigation with a lifetime of "until the
next restart."
