### PR TITLE
fix(lifecycle): pre-stop rescue never pushes — local save only

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_pre_stop_rescue.py
+++ b/src/scitex_agent_container/_lifecycle/_pre_stop_rescue.py
@@ -1,4 +1,4 @@
-"""Fleet-default pre-stop rescue — commit + push dirty worktrees before stop.
+"""Fleet-default pre-stop rescue — commit dirty worktrees LOCALLY before stop.
 
 Operator priority (lead a2a ``efa48850daf248ed9fe3ae5232677b2b``): make
 restart cheap. Before this module, ``sac agents stop`` would happily
@@ -8,23 +8,46 @@ Operator-declared ``pre_stop`` hooks could rescue it, but no fleet
 default shipped, so every agent had to opt in by spec edit (the
 band-aid the operator explicitly dislikes).
 
-This module is the SAC-side auto-rescue. It runs once per
-``agent_stop`` call, BEFORE the operator's ``pre_stop`` hooks fire,
-walks every git worktree under the agent's work roots, and for each
-DIRTY worktree:
+*** THE RESCUE NEVER PUBLISHES. ***
+
+Operator ruling, 2026-07-17 (「プッシュはなしじゃない？」, after
+「やりかけで落ちてしまったなら仕方ないじゃん…潔くやり直すのも良い」):
+this module saves work LOCALLY and stops there. It does not push, and
+there is no push primitive in ``_pre_stop_rescue_git`` to reach for.
+
+Why the push had to go — it published on the agent's behalf, at the one
+moment the agent could not review the result:
+
+* It ran NO tests. ``git add -A`` → commit → push, with no concept of
+  whether the code so much as imports. That is how red code reached
+  origin (operator: 「テストが赤いまま公開？どうやって？」).
+* It used ``--force-with-lease``, which every agent is hook-banned from
+  running by hand. A stop hook is not an exemption.
+* It protected BRANCHES, not TREES, and the walk has no ownership
+  model: a foreign worktree parked on a topic branch (another agent's
+  in-flight work, in a checkout this agent merely shares) got committed
+  and force-pushed with no guard anywhere in its path. Observed
+  2026-07-17: a stopping agent force-pushed a peer's ``feat/`` branch.
+
+Nothing is lost by dropping it. ``workdir`` is a host bind mount, so a
+LOCAL commit already survives the restart that motivated this module —
+the push was never what made the work durable.
+
+It runs once per ``agent_stop`` call, BEFORE the operator's
+``pre_stop`` hooks fire, walks every git worktree under the agent's
+work roots, and for each DIRTY worktree:
 
 * On a NON-protected topic branch: commits the dirty changes locally
-  with a stable rescue message and pushes the branch to its tracking
-  remote.
+  with a stable rescue message.
 * On a PROTECTED branch (``develop`` / ``main`` / ``master`` /
   ``release/*``): carries the dirty tree onto a dedicated
-  ``rescue/<agent>-<utc>`` side-branch, commits + pushes it THERE, and
+  ``rescue/<agent>-<utc>`` side-branch, commits it THERE, and
   returns the checkout to the protected branch with a clean tree — so
   the protected branch NEVER gains a local-only commit that would
   diverge it from origin and break ``git pull --ff-only`` + the
   deploy-freshness cron (the root cause this module was hardened to
   prevent, fleet-wide 2026-07).
-* On push failure (offline / no remote): writes a diff-tarball under
+* On COMMIT failure: writes a diff-tarball under
   ``<state_dir>/rescue/<branch>-<utc>.tar.gz`` so the next start can
   re-apply. The dirty work is never dropped.
 
@@ -60,7 +83,6 @@ from ._pre_stop_rescue_git import (
     is_dirty,
     is_git_worktree,
     move_dirty_to_side_branch,
-    push_branch,
     write_diff_tarball,
 )
 
@@ -118,26 +140,29 @@ def rescue_worktree(
     rescue_root: Path,
     timeout: float,
 ) -> dict[str, object]:
-    """Run the rescue sequence on a single git worktree.
+    """Run the rescue sequence on a single git worktree. Never pushes.
 
     Returns a dict with: ``path``, ``branch``, ``committed``,
-    ``pushed``, ``tarball`` (Path or None), ``protected``,
-    ``rescue_branch`` (str; the ``rescue/`` side-branch used on a
-    protected branch, else ``""``), ``error``. NEVER raises.
+    ``tarball`` (Path or None), ``protected``, ``rescue_branch`` (str;
+    the ``rescue/`` side-branch used on a protected branch, else
+    ``""``), ``error``. NEVER raises.
 
-    On a NON-protected topic branch the dirty tree is committed in place
-    and pushed (existing behavior). On a PROTECTED branch (``develop`` /
-    ``main`` / ``master`` / ``release/*``) the dirty tree is instead
-    carried onto a fresh ``rescue/<agent>-<ts>`` side-branch, committed +
-    pushed there, and the checkout is returned to the protected branch
-    with a clean tree — so the protected branch NEVER gains a local-only
-    commit and stays ``git pull --ff-only`` friendly.
+    On a NON-protected topic branch the dirty tree is committed in
+    place. On a PROTECTED branch (``develop`` / ``main`` / ``master`` /
+    ``release/*``) the dirty tree is instead carried onto a fresh
+    ``rescue/<agent>-<ts>`` side-branch, committed there, and the
+    checkout is returned to the protected branch with a clean tree — so
+    the protected branch NEVER gains a local-only commit and stays
+    ``git pull --ff-only`` friendly.
+
+    The result deliberately has NO ``pushed`` key: the rescue does not
+    publish (see the module docstring). A permanently-``False`` field
+    would read as a capability that merely happens to be off.
     """
     result: dict[str, object] = {
         "path": path,
         "branch": "",
         "committed": False,
-        "pushed": False,
         "tarball": None,
         "protected": False,
         "rescue_branch": "",
@@ -162,7 +187,7 @@ def rescue_worktree(
             rescue_root=rescue_root,
             timeout=timeout,
         )
-    # --- non-protected topic branch: commit in place + push -----------
+    # --- non-protected topic branch: commit in place, LOCAL ONLY ------
     ok_commit, commit_msg = commit_dirty(
         path, agent_name=agent_name, timestamp=timestamp, timeout=timeout
     )
@@ -170,19 +195,6 @@ def rescue_worktree(
     if not ok_commit:
         result["error"] = commit_msg
         # Even when commit fails, write a tarball so work survives.
-        result["tarball"] = write_diff_tarball(
-            path,
-            rescue_root=rescue_root,
-            branch=branch,
-            agent_name=agent_name,
-            timestamp=timestamp,
-            timeout=timeout,
-        )
-        return result
-    ok_push, push_err = push_branch(path, branch, timeout=timeout)
-    result["pushed"] = ok_push
-    if not ok_push:
-        result["error"] = push_err
         result["tarball"] = write_diff_tarball(
             path,
             rescue_root=rescue_root,
@@ -206,12 +218,13 @@ def _rescue_protected(
 ) -> dict[str, object]:
     """Rescue a dirty tree that sits on a PROTECTED branch, without polluting it.
 
-    Carries the tree onto a ``rescue/<agent>-<ts>`` side-branch, commits
-    + pushes it there, then returns the checkout to ``branch`` so the
-    protected ref is unchanged from origin (``ff-only`` pull still
-    works). Falls back to the diff-tarball if the side-branch can't be
-    created / committed / pushed — the dirty work is never dropped. The
-    protected branch is restored on EVERY path.
+    Carries the tree onto a ``rescue/<agent>-<ts>`` side-branch and
+    commits it there — LOCALLY; the side-branch is never pushed — then
+    returns the checkout to ``branch`` so the protected ref is unchanged
+    from origin (``ff-only`` pull still works). Falls back to the
+    diff-tarball if the side-branch can't be created or committed — the
+    dirty work is never dropped. The protected branch is restored on
+    EVERY path.
     """
     ok_side, rescue_branch, side_err = move_dirty_to_side_branch(
         path, agent_name=agent_name, timestamp=timestamp, timeout=timeout
@@ -233,22 +246,8 @@ def _rescue_protected(
         checkout_branch(path, branch, timeout=timeout)
         return result
     # Work is committed on the rescue side-branch; protected HEAD untouched.
+    # The side-branch stays LOCAL — it is a save, not a publication.
     result["committed"] = True
-    ok_push, push_err = push_branch(path, rescue_branch, timeout=timeout)
-    result["pushed"] = ok_push
-    if not ok_push:
-        # Offline / no remote: keep the local rescue branch AND drop a
-        # tarball so the work survives even if that branch is pruned.
-        # HEAD is still the rescue commit here, so the tarball captures it.
-        result["error"] = push_err
-        result["tarball"] = write_diff_tarball(
-            path,
-            rescue_root=rescue_root,
-            branch=rescue_branch,
-            agent_name=agent_name,
-            timestamp=timestamp,
-            timeout=timeout,
-        )
     # ALWAYS return to the protected branch so its ref equals origin's and
     # ``git pull --ff-only`` keeps working.
     ok_back, back_err = checkout_branch(path, branch, timeout=timeout)
@@ -316,7 +315,6 @@ def rescue_worktrees_for_agent(
                     "path": candidate,
                     "branch": "",
                     "committed": False,
-                    "pushed": False,
                     "tarball": None,
                     "protected": False,
                     "rescue_branch": "",
@@ -374,14 +372,13 @@ def run_pre_stop_rescue(config) -> None:
         log.warning("pre-stop rescue: unexpected failure (%r); skipping", exc)
         return
     committed = sum(1 for r in results if r.get("committed"))
-    pushed = sum(1 for r in results if r.get("pushed"))
     tarballed = sum(1 for r in results if r.get("tarball"))
     skipped = sum(1 for r in results if r.get("error"))
     log.info(
-        "pre-stop rescue: agent=%s committed=%d pushed=%d tarballed=%d skipped=%d",
+        "pre-stop rescue: agent=%s committed=%d tarballed=%d skipped=%d "
+        "(local only — the rescue never pushes)",
         getattr(config, "name", "?"),
         committed,
-        pushed,
         tarballed,
         skipped,
     )

--- a/src/scitex_agent_container/_lifecycle/_pre_stop_rescue_git.py
+++ b/src/scitex_agent_container/_lifecycle/_pre_stop_rescue_git.py
@@ -3,8 +3,14 @@
 Extracted from the orchestrator to keep both files under the per-file
 line cap. The orchestrator
 (:mod:`_lifecycle._pre_stop_rescue`) owns the policy (which roots to
-walk, when to skip, when to push vs tarball); this module owns the
-how (subprocess wrappers, branch detection, diff-tarball writing).
+walk, when to skip, when to tarball); this module owns the how
+(subprocess wrappers, branch detection, diff-tarball writing).
+
+There is deliberately NO push primitive here. The rescue is a LOCAL
+save and nothing more — see the "never publishes" contract in
+:mod:`_lifecycle._pre_stop_rescue`. A push helper in this module would
+be a loaded gun: the orchestrator is one call away from it, and the
+whole point is that no code path can publish on the agent's behalf.
 
 No mocks. Real subprocesses against real git worktrees.
 """
@@ -25,7 +31,6 @@ __all__ = [
     "is_dirty",
     "is_git_worktree",
     "move_dirty_to_side_branch",
-    "push_branch",
     "rescue_branch_name",
     "write_diff_tarball",
 ]
@@ -132,8 +137,8 @@ def move_dirty_to_side_branch(
     the dirty tree THERE with the stable rescue message.
 
     On success the caller is left standing ON the rescue branch (HEAD =
-    the rescue commit) so a subsequent ``push_branch`` / diff-tarball
-    captures the right commit; the caller MUST call ``checkout_branch``
+    the rescue commit) so a subsequent diff-tarball captures the right
+    commit; the caller MUST call ``checkout_branch``
     to return to the protected branch — which then reverts to a clean,
     ff-able tree since all the work is now committed on the side branch.
 
@@ -155,18 +160,6 @@ def move_dirty_to_side_branch(
     return (True, rescue_branch, "")
 
 
-def push_branch(path: Path, branch: str, *, timeout: float) -> tuple[bool, str]:
-    """Push ``branch`` to ``origin`` with ``--force-with-lease -u``."""
-    rc, _, err = _run(
-        ["git", "push", "--force-with-lease", "-u", "origin", branch],
-        cwd=path,
-        timeout=timeout,
-    )
-    if rc != 0:
-        return (False, err.strip() or "push failed")
-    return (True, "")
-
-
 def write_diff_tarball(
     path: Path,
     *,
@@ -179,9 +172,12 @@ def write_diff_tarball(
     """Write a ``.tar.gz`` bundling the worktree's last-commit patch + manifest.
 
     Lands under ``<rescue_root>/<safe-branch>-<timestamp>.tar.gz``.
-    Used as the fallback when ``push_branch`` couldn't ship the work
-    upstream. Returns the written path on success, ``None`` on
-    failure (logged once, never raised).
+    Used as the fallback when the rescue COMMIT could not land — then
+    the tarball is the only copy of the dirty tree. (It is no longer a
+    push fallback: the rescue does not push, and a commit that landed
+    is already durable on the bind-mounted host disk.) Returns the
+    written path on success, ``None`` on failure (logged once, never
+    raised).
     """
     rescue_root.mkdir(parents=True, exist_ok=True)
     safe_branch = branch.replace("/", "-") or "_detached"

--- a/src/scitex_agent_container/_state/worktree_safety.py
+++ b/src/scitex_agent_container/_state/worktree_safety.py
@@ -12,10 +12,9 @@ tree, that is silent loss of work.
 
 PR #369 (``feat(lifecycle): fleet-default pre-stop rescue for dirty
 worktrees``) closes the destruction window on the *write* side by
-auto-committing + pushing dirty worktrees on capsule stop. Once a
-worktree is rescued + pushed, its branch is durable on the remote and
-the on-disk worktree IS safe to reap. This module is the *read* side
-of that pair: a small, mock-free predicate that the dotfiles janitor
+auto-committing dirty worktrees on capsule stop. This module is the
+*read* side of that pair: a small, mock-free predicate that the
+dotfiles janitor
 and the future ``sac janitor`` CLI call before invoking
 ``git worktree prune`` (or ``git worktree remove``), so the prune-bug
 window from lead-learnings/19 cannot re-open.
@@ -61,11 +60,13 @@ def is_safe_to_reap(path: Path) -> bool:
       potential loss-of-work and disqualifies the worktree.
     * ``git -C <path> rev-list develop..HEAD`` is empty — ``HEAD``
       is not ahead of ``develop``. A worktree that IS ahead has
-      commits not yet on ``develop`` and must not be reaped
-      (it pairs with the PR #369 pre-stop rescue: rescued +
-      pushed branches typically land via PR onto ``develop``, at
-      which point ``develop..HEAD`` becomes empty and reaping is
-      safe).
+      commits not yet on ``develop`` and must not be reaped. This
+      is what pairs the predicate with the PR #369 pre-stop rescue,
+      and it carries MORE weight since the rescue stopped pushing
+      (2026-07-17): a rescue commit now exists ONLY on local disk,
+      so ``develop..HEAD`` being non-empty is the sole thing
+      standing between it and a janitor. Reaping stays blocked
+      until the work lands on ``develop`` via PR.
 
     Any error — subprocess failure, missing ``git``, unreadable
     path, ``develop`` not present, etc. — returns ``False``. The

--- a/tests/scitex_agent_container/_lifecycle/test__pre_stop_rescue.py
+++ b/tests/scitex_agent_container/_lifecycle/test__pre_stop_rescue.py
@@ -1,10 +1,17 @@
 """Tests for ``_lifecycle/_pre_stop_rescue`` — fleet-default rescue pass.
 
 Operator priority (lead a2a ``efa48850daf248ed9fe3ae5232677b2b``): make
-restart cheap. Walks the agent's worktrees, commits dirty changes,
-pushes to non-protected branches, falls back to diff-tarballs when
-push isn't possible — all bounded by a 60s grace timeout so the
-rescue can never wedge a restart.
+restart cheap. Walks the agent's worktrees and commits dirty changes
+LOCALLY — on a topic branch in place, on a protected branch onto a
+``rescue/`` side-branch — falling back to a diff-tarball only when the
+commit itself fails, all bounded by a 60s grace timeout so the rescue
+can never wedge a restart.
+
+*** The rescue NEVER pushes *** (operator ruling 2026-07-17,
+「プッシュはなしじゃない？」). ``test_rescue_never_pushes_*`` below are
+the regression guards: they exercise the rescue against a REAL origin
+and assert nothing ever lands on it. If someone re-introduces a push,
+those go RED — which is the whole point of writing them.
 
 STX-TQ002 AAA + STX-TQ007 one-assert. No mocks — real ``tmp_path``
 git repos exercised through real ``git`` invocations.
@@ -199,12 +206,40 @@ def test_rescue_worktree_commits_dirty_changes(
     assert result["committed"] is True
 
 
-def test_rescue_worktree_writes_tarball_when_no_remote(
+def test_rescue_worktree_no_remote_still_commits_locally(
     git_env_save_restore, tmp_path: Path
 ) -> None:
-    # Arrange — the repo has no ``origin`` remote configured, so push
-    # MUST fail and the diff-tarball fallback MUST land.
+    # Arrange — no ``origin`` remote at all. Before 2026-07-17 this
+    # forced the push to fail and a diff-tarball to land. The rescue no
+    # longer pushes, so a missing remote is not a failure mode: the
+    # LOCAL commit is the save, and it is durable on the host bind.
     repo = _init_repo(tmp_path / "repo")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    result = rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260613T000000Z",
+        rescue_root=rescue_root,
+        timeout=10.0,
+    )
+    # Assert
+    assert result["committed"] is True and result["tarball"] is None
+
+
+def test_rescue_worktree_writes_tarball_when_commit_fails(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — a real pre-commit hook that refuses. ``commit_dirty``
+    # does not pass ``--no-verify``, so ``git commit`` genuinely exits
+    # non-zero and the dirty tree is left UNCOMMITTED. That is the one
+    # case where the tarball is the only copy of the work, and it must
+    # land. (No mock: the hook is a real file git really executes.)
+    repo = _init_repo(tmp_path / "repo")
+    hook = repo / ".git" / "hooks" / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 1\n")
+    hook.chmod(0o755)
     _make_dirty(repo)
     rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
     # Act
@@ -219,10 +254,10 @@ def test_rescue_worktree_writes_tarball_when_no_remote(
     assert isinstance(result.get("tarball"), Path) and Path(result["tarball"]).is_file()
 
 
-def test_rescue_worktree_protected_branch_skips_push(
+def test_rescue_worktree_protected_branch_is_flagged_protected(
     git_env_save_restore, tmp_path: Path
 ) -> None:
-    # Arrange — branch=main is denylisted; commit lands but push doesn't.
+    # Arrange — branch=main is denylisted.
     repo = _init_repo(tmp_path / "repo", branch="main")
     _make_dirty(repo)
     rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
@@ -235,7 +270,7 @@ def test_rescue_worktree_protected_branch_skips_push(
         timeout=10.0,
     )
     # Assert
-    assert result["pushed"] is False and result["protected"] is True
+    assert result["protected"] is True
 
 
 def test_rescue_worktree_protected_branch_still_commits(
@@ -272,11 +307,7 @@ def test_rescue_worktree_clean_worktree_no_op(
         timeout=10.0,
     )
     # Assert
-    assert (
-        result["committed"] is False
-        and result["pushed"] is False
-        and result["tarball"] is None
-    )
+    assert result["committed"] is False and result["tarball"] is None
 
 
 def test_rescue_worktree_non_repo_returns_error(tmp_path: Path) -> None:
@@ -383,9 +414,15 @@ def test_rescue_for_agent_respects_grace_budget(
 def test_rescue_for_agent_rescue_dir_named_correctly(
     git_env_save_restore, tmp_path: Path
 ) -> None:
-    # Arrange — make sure the rescue dir lands under ``state_dir/rescue/``
-    # (the documented operator path so they can find the diff-tarballs).
+    # Arrange — the rescue dir must land under ``state_dir/rescue/`` (the
+    # documented operator path for diff-tarballs). Since the rescue no
+    # longer pushes, a tarball is written ONLY when the commit itself
+    # fails — so force that with a real pre-commit hook exiting non-zero,
+    # which is exactly the case the operator needs to find on disk.
     workdir = _init_repo(tmp_path / "wd")
+    hook = workdir / ".git" / "hooks" / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 1\n")
+    hook.chmod(0o755)
     _make_dirty(workdir)
     state_dir = tmp_path / "state"
     # Act
@@ -500,9 +537,7 @@ def test_rescue_protected_develop_work_preserved_on_rescue_branch(
         timeout=15.0,
     )
     # Assert — the rescue branch's tip carries the dirty content.
-    content = _git_out(
-        ["show", f"{result['rescue_branch']}:README.md"], cwd=repo
-    )
+    content = _git_out(["show", f"{result['rescue_branch']}:README.md"], cwd=repo)
     assert "rescue-target" in content
 
 
@@ -525,10 +560,13 @@ def test_rescue_protected_develop_rescue_branch_named_by_convention(
     assert result["rescue_branch"] == "rescue/agent-x-20260709T000000Z"
 
 
-def test_rescue_protected_develop_pushes_rescue_branch_to_origin(
+def test_rescue_never_pushes_protected_rescue_branch_to_origin(
     git_env_save_restore, tmp_path: Path
 ) -> None:
-    # Arrange
+    # Arrange — a REAL origin is present and reachable, so a push WOULD
+    # succeed if the code attempted one. This is the regression guard for
+    # the operator's no-push ruling: the rescue side-branch must exist
+    # locally but must NOT appear on origin.
     repo = _init_repo_with_origin(tmp_path / "repo", tmp_path / "remote.git")
     _make_dirty(repo)
     rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
@@ -540,19 +578,46 @@ def test_rescue_protected_develop_pushes_rescue_branch_to_origin(
         rescue_root=rescue_root,
         timeout=15.0,
     )
-    # Assert — the rescue branch actually landed on origin.
+    # Assert — origin does NOT carry the rescue branch (nothing pushed).
     remote_heads = _git_out(
         ["ls-remote", "--heads", "origin", str(result["rescue_branch"])],
         cwd=repo,
     )
-    assert remote_heads.strip() != ""
+    assert remote_heads.strip() == ""
 
 
-def test_rescue_protected_develop_no_remote_writes_tarball(
+def test_rescue_never_pushes_topic_branch_to_origin(
     git_env_save_restore, tmp_path: Path
 ) -> None:
-    # Arrange — develop but NO origin: push MUST fail, tarball MUST land,
-    # develop MUST stay pristine (no local-only commit vs its init tip).
+    # Arrange — a topic branch with a REAL reachable origin. A foreign
+    # worktree parked on a topic branch is exactly the case that got a
+    # peer's work force-pushed (observed 2026-07-17). The rescue commit
+    # lands locally; origin's topic branch must stay at its init tip.
+    repo = _init_repo_with_origin(
+        tmp_path / "repo", tmp_path / "remote.git", branch="feature/topic"
+    )
+    tip_before = _git_out(["ls-remote", "origin", "feature/topic"], cwd=repo).split()[0]
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260709T000000Z",
+        rescue_root=rescue_root,
+        timeout=15.0,
+    )
+    # Assert — origin's topic branch is unmoved (the local commit never shipped).
+    tip_after = _git_out(["ls-remote", "origin", "feature/topic"], cwd=repo).split()[0]
+    assert tip_after == tip_before
+
+
+def test_rescue_protected_develop_no_remote_commits_to_side_branch(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — develop, NO origin. Since the rescue no longer pushes, a
+    # missing remote is not a failure: the side-branch commit is the save
+    # and no tarball is needed (the commit succeeded).
     repo = _init_repo(tmp_path / "repo", branch="develop")
     _make_dirty(repo)
     rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
@@ -564,8 +629,8 @@ def test_rescue_protected_develop_no_remote_writes_tarball(
         rescue_root=rescue_root,
         timeout=15.0,
     )
-    # Assert — work still captured on disk despite no remote.
-    assert isinstance(result.get("tarball"), Path) and Path(result["tarball"]).is_file()
+    # Assert — committed on the side-branch, no tarball fallback triggered.
+    assert result["committed"] is True and result["tarball"] is None
 
 
 def test_rescue_protected_develop_no_remote_keeps_develop_clean(
@@ -605,9 +670,7 @@ def test_rescue_protected_develop_no_remote_preserves_on_rescue_branch(
         timeout=15.0,
     )
     # Assert — the local rescue branch still carries the dirty content.
-    content = _git_out(
-        ["show", f"{result['rescue_branch']}:README.md"], cwd=repo
-    )
+    content = _git_out(["show", f"{result['rescue_branch']}:README.md"], cwd=repo)
     assert "rescue-target" in content
 
 


### PR DESCRIPTION
## What

The pre-stop autosave force-pushed worktrees it did not own, under the stopping agent's identity, with no test gate. This removes the push entirely: the rescue saves work **locally** and stops there.

Fixes P1 card `fleet-autosave-commits-and-pushes-foreign-worktrees-20260717`.

## Why

Operator ruling 2026-07-17 (「プッシュはなしじゃない？」, after 「やりかけで落ちてしまったなら仕方ないじゃん…潔くやり直すのも良い」). The push carried every irreversible property and none of the durability:

- **Foreign publication** — observed 2026-07-17, a stopping agent force-pushed a peer's `feat/matrix-view` branch to the shared remote, under an identity that never saw the diff.
- **Force-push** (`--force-with-lease`), which every agent is hook-banned from running by hand.
- **No test gate** — `git add -A` → commit → push, with no concept of whether the code so much as imports. This is how test-failing code reached origin.
- Nothing is lost: `workdir` is a host **bind mount**, so a local commit already survives the restart this module exists to make cheap. The push was never what made the work durable.

## Changes

1. **`push_branch()` DELETED** from `_pre_stop_rescue_git` — function + both call sites. Deleting the function (not just the calls) makes the ban structural: no path is one edit from publishing again.
2. `rescue_worktree()` commits locally — in place on a topic branch, onto a `rescue/<agent>-<ts>` side-branch on a protected branch — and never pushes. The result dict drops its `pushed` key rather than carry a permanently-`False` field.
3. The diff-tarball is now a **commit-failure** fallback only (a landed commit is already durable), not a push fallback.
4. `worktree_safety.py`: fixed the now-stale docstring claiming rescued branches are "durable on the remote". `is_safe_to_reap()` never checked pushed-ness — it gates on `rev-list develop..HEAD`, so with no push a rescue branch stays *ahead* of develop and the reap gate gets **more** conservative, not less.

## Regression guards

`test_rescue_never_pushes_{protected_rescue_branch,topic_branch}_to_origin` exercise the rescue against a **real reachable origin** and assert nothing lands on it — they go RED if the push is ever reintroduced.

Suite: **32/32 green** (`test__pre_stop_rescue.py`).

## Out of scope — deliberately

This does **not** resolve why two `rescue: pre-stop autosave` commits reached `origin/develop` on 2026-07-13. That root cause stays **open** on the card:
- drift (pre-#578 install) refuted by a `rescue/scitex-agent-container-20260712T…` branch artifact — one day before, same agent;
- guard-broken refuted by the protected-branch guard firing correctly on 2026-07-17.

Removing the push removes every irreversible property **regardless** of that answer, which is why it does not wait on it.