### PR TITLE
chore(release): 0.21.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.23] - 2026-07-18
+
 ### Added
 
 - **Inert-feature detector (`_jobs_audit`) — a declaration with no live
@@ -40,6 +42,28 @@ versioning follows [SemVer](https://semver.org/).
   diagnosis off a 4-day-stale schedule. Out of scope beats answered wrongly.
 
 ### Fixed
+
+- **The pre-stop rescue no longer pushes — it saves work LOCALLY and stops
+  there** (`_pre_stop_rescue`, PR #743). The fleet-default autosave that runs
+  on `sac agents stop` force-pushed worktrees it did not own, under the
+  stopping agent's identity, with no test gate. Observed 2026-07-17: a stopping
+  agent force-pushed a peer's `feat/` branch to the shared remote (bytes a peer
+  never reviewed, published under a name that never saw them); separately, two
+  `rescue:` commits reached `origin/develop`. Operator ruling 2026-07-17
+  (「プッシュはなしじゃない？」): the rescue commits locally — in place on a
+  topic branch, onto a `rescue/<agent>-<ts>` side-branch on a protected branch
+  — and never pushes either. `push_branch()` is **deleted** (function + both
+  call sites), so the ban is structural, not conventional: no code path is one
+  edit away from publishing again. `workdir` is a host bind mount, so the local
+  commit already survives the restart this module exists to make cheap — the
+  push was never what made the work durable. Two regression guards
+  (`test_rescue_never_pushes_*`) exercise the rescue against a REAL reachable
+  origin and assert nothing lands on it, so a reintroduced push goes red — the
+  observe-don't-assert acceptance test the earlier #578 lacked. NOT covered:
+  why two rescue commits reached `origin/develop` on 2026-07-13 stays open
+  (narrowed to a drift/propagation question, not a broken guard — the guard
+  fires correctly in current code); removing the push kills the irreversible
+  harm regardless of that answer.
 
 - **Every `sac dev` job verb was inert, and had been for weeks.**
   `_dev_jobs.py` passed the CLI GROUP NAME straight through as the JobSpec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.22"
+version = "0.21.23"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Cut **0.21.23** — ships the 21-commit develop backlog to PyPI + GitHub release, so the running fleet can actually receive it. A published version number can never lie about its contents; an unreleased one silently can (this is exactly what bit us — see the 0.21.22 changelog note).

## Headline in this release

- **Pre-stop rescue never pushes** (#743) — the fleet-default autosave force-pushed worktrees it did not own, under the stopping agent's identity, with no test gate. Now local-commit-only; `push_branch()` deleted so the ban is structural; two regression guards assert nothing lands on a real origin. Operator ruling 2026-07-17 (「プッシュはなしじゃない？」).

Plus the rest of the backlog already documented under `[Unreleased]` → now `[0.21.23]`: the inert-feature detector, the `sac dev` job-verb fixes, and #742/#740/#734 etc.

## Mechanics

- `pyproject.toml`: 0.21.22 → 0.21.23
- `CHANGELOG.md`: `[Unreleased]` → `[0.21.23] - 2026-07-18` (+ fresh empty `[Unreleased]`), with the #743 entry added under Fixed.

On merge, I tag `v0.21.23` on develop → the tag workflow runs test → build → publish to PyPI + GitHub release. Then the hosts get `pip install --force-reinstall`, verified by **symbol probe** (`push_branch` absent from the installed `_pre_stop_rescue_git`), not a version string — because the version string is the liar this release exists to retire.