### PR TITLE
feat(config): append guarded direnv-allow to every agent's default startup_commands

### DIFF
--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from ._host import (
@@ -31,7 +32,56 @@ from ._parsers import (
     parse_startup_commands,
     parse_watchdog,
 )
-from ._types import AgentConfig, HostsSpec
+from ._types import AgentConfig, HostsSpec, StartupCommand
+
+# Guarded default startup command APPENDED to EVERY agent's ``startup_commands``
+# (operator directive, Telegram 2862 / card
+# ``sac-auto-direnv-allow-at-agent-start-guarded-20260717``). It whitelists a
+# project's ``.envrc`` with direnv so the project's NON-SECRET environment
+# surfaces inside the container — WITHOUT any per-spec hand-editing, and VISIBLE
+# in the materialized spec (``AgentConfig.startup_commands``), not buried in the
+# launch code the operator explicitly did not want.
+#
+# GUARDED + FAIL-SOFT + IDEMPOTENT:
+#   * ``command -v direnv`` — no-op when direnv is not installed;
+#   * ``[ -f "$PWD/.envrc" ]`` — no-op when the workdir has no ``.envrc``;
+#   * trailing ``|| true`` — a failed allow NEVER breaks the boot.
+#
+# ``$PWD`` is the agent workdir AT RUN TIME: the inner ``bash -lc`` wrapper that
+# runs ``startup_commands`` inherits apptainer's ``--pwd
+# str(Path(config.workdir).expanduser())`` (runtimes/_apptainer_build_argv.py)
+# and sac emits NO ``cd`` before the commands, so ``$PWD`` == the workdir. If a
+# workdir is not bound in-container ``$PWD`` falls back to ``$HOME``/``/`` where
+# the ``-f "$PWD/.envrc"`` guard simply finds no ``.envrc`` and skips — still
+# fail-soft. This surfaces ONLY the project's ``.envrc``; sac SECRETS and
+# IDENTITY (SCITEX_TODO_AGENT_ID, cct token pool, listen bearer) stay
+# sac-DIRECT-injected and are never routed through direnv.
+DEFAULT_DIRENV_ALLOW_COMMAND = (
+    'command -v direnv >/dev/null 2>&1 && [ -f "$PWD/.envrc" ] '
+    '&& direnv allow "$PWD" || true'
+)
+
+# Recognises an already-authored ``direnv allow`` in a startup command so the
+# default is not duplicated (idempotency; tolerates extra whitespace).
+_DIRENV_ALLOW_RE = re.compile(r"\bdirenv\s+allow\b")
+
+
+def _with_default_direnv_allow(
+    commands: list[StartupCommand],
+) -> list[StartupCommand]:
+    """Append the guarded direnv-allow default unless one is already present.
+
+    Idempotent: a spec whose ``startup_commands`` ALREADY run ``direnv allow``
+    (authored explicitly) is returned unchanged — no duplicate. Otherwise the
+    guarded, fail-soft :data:`DEFAULT_DIRENV_ALLOW_COMMAND` is APPENDED so it
+    runs last, just before the claude runner ``exec``s. Appended (not
+    prepended) so an authored ``startup_commands[0]`` keeps its position.
+    """
+    for cmd in commands:
+        if _DIRENV_ALLOW_RE.search(cmd.command or ""):
+            return commands
+    return [*commands, StartupCommand(command=DEFAULT_DIRENV_ALLOW_COMMAND)]
+
 
 # Generic boot-kick used when a spec omits ``startup_prompts``. Role/ID live in
 # the auto-generated $HOME/.claude/CLAUDE.md and the task lives on the agent's
@@ -226,9 +276,7 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
     singleton_placement_token = not is_multi and contains_hostname_placeholder(
         hosts_spec.host
     )
-    hostname = (
-        resolve_hostname() if (is_multi or singleton_placement_token) else ""
-    )
+    hostname = resolve_hostname() if (is_multi or singleton_placement_token) else ""
     if is_multi:
         raw = substitute_hostnames(raw, hostname)
         spec = raw.get("spec", {}) or {}
@@ -394,7 +442,7 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
         apptainer=apptainer_spec,
         hooks=hooks,
         skills=parse_skills(spec),
-        startup_commands=parse_startup_commands(spec),
+        startup_commands=_with_default_direnv_allow(parse_startup_commands(spec)),
         startup_prompts=startup_prompts,
         exclude_hooks=exclude_hooks,
         exclude_skills=exclude_skills,

--- a/tests/scitex_agent_container/config/test__loaders.py
+++ b/tests/scitex_agent_container/config/test__loaders.py
@@ -21,13 +21,15 @@ import yaml
 
 from scitex_agent_container.config import load_config
 from scitex_agent_container.config._loaders import (
+    DEFAULT_DIRENV_ALLOW_COMMAND,
     DEFAULT_STARTUP_PROMPT,
     _parse_env_files,
     _resolve_python_venv,
     _resolve_venv,
+    _with_default_direnv_allow,
     compose_effective_name,
 )
-from scitex_agent_container.config._types import HostsSpec
+from scitex_agent_container.config._types import HostsSpec, StartupCommand
 
 
 @pytest.fixture(autouse=True)
@@ -799,3 +801,98 @@ def test_load_config_rejects_banned_local_host_at_load_time(
     # Assert
     with pytest.raises(ValueError, match="BANNED"):
         _do()
+
+
+# ---------------------------------------------------------------------------
+# Default direnv-allow startup command (operator directive, Telegram 2862 /
+# card sac-auto-direnv-allow-at-agent-start-guarded-20260717). sac appends a
+# GUARDED + FAIL-SOFT + IDEMPOTENT `direnv allow` to EVERY agent's
+# startup_commands so a project's non-secret .envrc surfaces in-container,
+# fleet-wide and VISIBLE in the materialized spec. Secrets/identity stay
+# sac-direct-injected (never routed through direnv).
+# ---------------------------------------------------------------------------
+
+
+def test_default_direnv_allow_command_has_guarded_fail_soft_shape() -> None:
+    # Arrange — the exact guarded, fail-soft form (guard on direnv + .envrc,
+    # trailing `|| true` so a failed allow never breaks boot; $PWD is the
+    # agent workdir the inner bash -lc inherits from apptainer --pwd).
+    expected = (
+        'command -v direnv >/dev/null 2>&1 && [ -f "$PWD/.envrc" ] '
+        '&& direnv allow "$PWD" || true'
+    )
+    # Act
+    actual = DEFAULT_DIRENV_ALLOW_COMMAND
+    # Assert
+    assert actual == expected
+
+
+def test_with_default_direnv_allow_appends_to_empty_list() -> None:
+    # Arrange — a spec authoring no startup_commands.
+    incoming: list[StartupCommand] = []
+    # Act
+    out = _with_default_direnv_allow(incoming)
+    # Assert
+    assert [c.command for c in out] == [DEFAULT_DIRENV_ALLOW_COMMAND]
+
+
+def test_with_default_direnv_allow_appends_after_authored_commands() -> None:
+    # Arrange — an authored bootstrap command must keep position 0.
+    incoming = [StartupCommand(command="echo hi")]
+    # Act
+    out = _with_default_direnv_allow(incoming)
+    # Assert
+    assert [c.command for c in out] == ["echo hi", DEFAULT_DIRENV_ALLOW_COMMAND]
+
+
+def test_with_default_direnv_allow_is_idempotent_when_already_present() -> None:
+    # Arrange — a spec that already runs `direnv allow` must not be doubled.
+    incoming = [StartupCommand(command='direnv allow "$PWD"')]
+    # Act
+    out = _with_default_direnv_allow(incoming)
+    # Assert
+    assert out == incoming
+
+
+def test_load_config_appends_direnv_allow_when_no_startup_commands(
+    tmp_path: Path,
+) -> None:
+    # Arrange — a bare spec (no startup_commands) loaded through the real API.
+    p = _v3_yaml(tmp_path, "direnv-bare", {})
+    # Act
+    cfg = load_config(p)
+    # Assert
+    assert [c.command for c in cfg.startup_commands] == [DEFAULT_DIRENV_ALLOW_COMMAND]
+
+
+def test_load_config_keeps_authored_startup_command_and_appends_direnv_allow(
+    tmp_path: Path,
+) -> None:
+    # Arrange — an authored startup command stays first; direnv-allow is last.
+    p = _v3_yaml(
+        tmp_path,
+        "direnv-authored",
+        {"startup_commands": [{"command": "echo hello"}]},
+    )
+    # Act
+    cfg = load_config(p)
+    # Assert
+    assert [c.command for c in cfg.startup_commands] == [
+        "echo hello",
+        DEFAULT_DIRENV_ALLOW_COMMAND,
+    ]
+
+
+def test_load_config_does_not_duplicate_authored_direnv_allow(
+    tmp_path: Path,
+) -> None:
+    # Arrange — a spec whose author already wrote a `direnv allow` command.
+    p = _v3_yaml(
+        tmp_path,
+        "direnv-idempotent",
+        {"startup_commands": [{"command": 'direnv allow "$PWD"'}]},
+    )
+    # Act
+    cfg = load_config(p)
+    # Assert — exactly one direnv-allow, no sac-appended duplicate.
+    assert sum("direnv allow" in c.command for c in cfg.startup_commands) == 1


### PR DESCRIPTION
## What

sac now **appends a guarded, fail-soft, idempotent `direnv allow`** to every agent's materialized `startup_commands`, so a project's non-secret `.envrc` surfaces inside the container fleet-wide — **without** hand-editing each spec, and **visible in the materialized spec** (`AgentConfig.startup_commands`), not buried in launch code.

Operator directive (Telegram 2862) / card `sac-auto-direnv-allow-at-agent-start-guarded-20260717`.

The injected command (exact guarded form):

```sh
command -v direnv >/dev/null 2>&1 && [ -f "$PWD/.envrc" ] && direnv allow "$PWD" || true
```

## Injection point

`config/_loaders.py` → `load_v3`, the single `load_config` chokepoint every agent passes through:

```python
startup_commands=_with_default_direnv_allow(parse_startup_commands(spec)),
```

- New module constant `DEFAULT_DIRENV_ALLOW_COMMAND` + helper `_with_default_direnv_allow()`.
- **Appended** (not prepended) so an authored `startup_commands[0]` keeps its position.
- **Idempotent**: a spec already running `direnv allow` (matched by `\bdirenv\s+allow\b`) is returned unchanged — no duplicate.

## `$PWD` == workdir at run time (verified, not assumed)

`startup_commands` run inside the inner `bash -lc "…; exec <runner>"` wrapper, which inherits apptainer's `--pwd str(Path(config.workdir).expanduser())` (`runtimes/_apptainer_build_argv.py:196-197`); sac emits **no `cd`** before the commands (`runtimes/_apptainer_inner_argv.py`). So `$PWD` is the agent workdir. If a workdir is not bound in-container, `$PWD` falls back to `$HOME`/`/`, where the `-f "$PWD/.envrc"` guard simply finds no `.envrc` and skips — still fail-soft.

## Boundary preserved

Secrets/identity stay **sac-direct-injected** (`SCITEX_TODO_AGENT_ID`, cct token pool, listen bearer) — never routed through direnv. This only surfaces the rest of a project's `.envrc`.

## Note

The sac base image already sets `DIRENV_CONFIG=/etc/direnv` with a permissive whitelist (`prefix=["/"]`), so this is partly belt-and-suspenders — but guarded + fail-soft (harmless) and satisfies the operator's explicit "visible in the spec" requirement.

## Tests (TDD, real assembled startup_commands, no mocks)

- **RED (before):** `ImportError: cannot import name 'DEFAULT_DIRENV_ALLOW_COMMAND'` — feature absent.
- **GREEN (after):** 7 new direnv tests pass (4 unit on the helper/constant, 3 integration via real `load_config`): default appended on a bare spec; guard shape exact; authored `[0]` preserved; idempotent when `direnv allow` already present.
- **No regressions:** 177 tests pass across emission (`test__apptainer_inner_argv`), parser (`test__startup`), validation (`test__startup_command_validation`), inline-spec lint, template, and create paths.

Run:
```
PYTHONPATH=<worktree>/src python -m pytest tests/scitex_agent_container/config/test__loaders.py tests/integration/test_v3_spec_structure.py -q
# 97 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqhsrw29CM4siBLcEK2CwV