### PR TITLE
fix(to_home): deploy replaces a leftover symlink dst, never writes through it

### DIFF
--- a/src/scitex_agent_container/runtimes/_to_home_deployers.py
+++ b/src/scitex_agent_container/runtimes/_to_home_deployers.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 def _clear_readonly_dst(dst: Path) -> None:
-    """Make an existing ``dst`` overwritable before a copy/write.
+    """Make ``dst`` a clean, writable slot before a copy/write.
 
     Hooks deployed under ``to_home/`` are commonly mode 0755/read-only
     (e.g. ``hook_switch_helper.sh``). ``shutil.copy2`` / ``Path.write_text``
@@ -50,13 +50,30 @@ def _clear_readonly_dst(dst: Path) -> None:
     ``PermissionError: [Errno 13]`` — the deploy from #142 hit exactly
     this. We add the owner-write bit so the in-place overwrite succeeds.
 
-    No-op when ``dst`` doesn't exist or is already writable. Symlinks are
-    left untouched (the symlink path unlinks them instead). Genuinely
+    A SYMLINK at ``dst`` is UNLINKED (not followed). A to_home deploy must
+    land a real, hermetic file at ``dst`` and must NEVER write THROUGH a
+    leftover link into whatever it points at. This generalises the
+    same-file guard :func:`_dst_resolves_to_source` (INCIDENT 2026-07-02 —
+    a symlink back to the SOURCE) to a symlink pointing at a DIFFERENT
+    target: e.g. a prior host-merge link ``$HOME/.claude/hooks/x ->
+    ~/.claude/hooks/x`` still in place when ``x`` later moves into the agent
+    baseline. Without unlinking, ``shutil.copy2`` / ``Path.write_text``
+    follow the link and CORRUPT the operator's real host file while leaving
+    a non-hermetic symlink in the container ``$HOME`` (and a DANGLING link
+    makes ``copy2`` raise ``FileNotFoundError`` outright). ``_deploy_plain_file``
+    still short-circuits a symlink-back-to-SOURCE via
+    :func:`_dst_resolves_to_source` BEFORE reaching here, so that legitimate
+    "linked host file, skip cleanly" case never hits the unlink.
+
+    No-op when ``dst`` doesn't exist or is already writable. Genuinely
     unexpected ``OSError`` (e.g. EROFS, EPERM on a foreign-owned file) is
     re-raised so the deploy still crashes loud rather than masking a real
     permissions problem.
     """
-    if dst.is_symlink() or not dst.exists():
+    if dst.is_symlink():
+        dst.unlink()
+        return
+    if not dst.exists():
         return
     mode = dst.stat().st_mode
     if not mode & stat.S_IWUSR:

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -731,6 +731,91 @@ class TestDeployToHomeFromConfig:
 
 
 # ---------------------------------------------------------------------------
+# Restart re-delivery: a deploy into a dest that ALREADY holds a stale copy
+# of a to_home file must land the CURRENT content — whether the stale copy is
+# a plain OLD file (the common case) or a leftover host-merge SYMLINK pointing
+# at the operator's real host file (which must be REPLACED, never written
+# through). Mirrors the fleet-restart to_home-staleness class.
+# ---------------------------------------------------------------------------
+
+_HOOK_REL = ".claude/hooks/pre-tool-use/deny_edit_on_main_branch.sh"
+_HOST_ENV = "SAC_HOST_CLAUDE_DIR"
+_USER_BASELINE_ENV = "SAC_USER_TO_HOME_BASELINE"
+
+
+class TestDeployRedeliversChangedFilesOnRestart:
+    def test_deploy_overwrites_old_real_file_in_dest(self, tmp_path):
+        # Arrange — dest already holds an OLD real copy of a baseline hook.
+        cfg, root = _build_cfg(tmp_path)
+        src = root / _HOOK_REL
+        src.parent.mkdir(parents=True)
+        src.write_text("NEW-v2\n")
+        os.chmod(src, 0o755)
+        home = tmp_path / "home"
+        old = home / _HOOK_REL
+        old.parent.mkdir(parents=True)
+        old.write_text("OLD-v1\n")
+        os.chmod(old, 0o755)
+        # Act — the restart-path materialization.
+        deploy_to_home(cfg, str(home))
+        # Assert — the stale content is replaced with the current source.
+        assert (home / _HOOK_REL).read_text() == "NEW-v2\n"
+
+    def test_deploy_replaces_leftover_hostmerge_symlink_with_real_file(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — developer agent; a prior host-merge left a SYMLINK at the
+        # dest pointing at the operator's real host hook, and the hook has
+        # since moved into the agent baseline (a real source file now exists).
+        env_save_restore.set(_USER_BASELINE_ENV, str(tmp_path / "no-user-baseline"))
+        host_root = tmp_path / "host_claude"
+        host_hook = host_root / "hooks" / "pre-tool-use" / "deny_edit_on_main_branch.sh"
+        host_hook.parent.mkdir(parents=True)
+        host_hook.write_text("HOST-ORIGINAL\n")
+        env_save_restore.set(_HOST_ENV, str(host_root))
+        cfg, root = _build_cfg(tmp_path, labels={"role": "project-maintainer"})
+        src = root / _HOOK_REL
+        src.parent.mkdir(parents=True)
+        src.write_text("NEW-baseline\n")
+        os.chmod(src, 0o755)
+        home = tmp_path / "home"
+        stale = home / _HOOK_REL
+        stale.parent.mkdir(parents=True)
+        stale.symlink_to(host_hook)
+        # Act
+        deploy_to_home(cfg, str(home))
+        # Assert — dest is a REAL file carrying the current baseline content.
+        assert (
+            not (home / _HOOK_REL).is_symlink()
+            and (home / _HOOK_REL).read_text() == "NEW-baseline\n"
+        )
+
+    def test_deploy_over_leftover_symlink_does_not_corrupt_host_file(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — same as above; the danger is writing THROUGH the link.
+        env_save_restore.set(_USER_BASELINE_ENV, str(tmp_path / "no-user-baseline"))
+        host_root = tmp_path / "host_claude"
+        host_hook = host_root / "hooks" / "pre-tool-use" / "deny_edit_on_main_branch.sh"
+        host_hook.parent.mkdir(parents=True)
+        host_hook.write_text("HOST-ORIGINAL\n")
+        env_save_restore.set(_HOST_ENV, str(host_root))
+        cfg, root = _build_cfg(tmp_path, labels={"role": "project-maintainer"})
+        src = root / _HOOK_REL
+        src.parent.mkdir(parents=True)
+        src.write_text("NEW-baseline\n")
+        os.chmod(src, 0o755)
+        home = tmp_path / "home"
+        stale = home / _HOOK_REL
+        stale.parent.mkdir(parents=True)
+        stale.symlink_to(host_hook)
+        # Act
+        deploy_to_home(cfg, str(home))
+        # Assert — the operator's real host file is byte-for-byte untouched.
+        assert host_hook.read_text() == "HOST-ORIGINAL\n"
+
+
+# ---------------------------------------------------------------------------
 # Baseline layer — shared/common to_home overlaid by per-agent to_home.
 #
 # Layout under tmp_path:

--- a/tests/scitex_agent_container/runtimes/test__to_home_deployers.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_deployers.py
@@ -71,3 +71,62 @@ class TestDeployPlainFileSameFileGuard:
         _deploy_plain_file(src, dst, config=None, rel=Path("commands/x.md"))
         # Assert
         assert dst.read_text() == "NEW"
+
+
+class TestDeployPlainFileSymlinkToOtherTarget:
+    """A leftover ``dst`` symlink pointing at a DIFFERENT file than ``src``
+    (e.g. a prior host-merge link ``$HOME/.claude/hooks/x -> ~/.claude/hooks/x``
+    left in place after ``x`` moves into the agent baseline) must be REPLACED
+    with a real hermetic file — NEVER written through.
+
+    Writing through the link would (a) CORRUPT the operator's real host file
+    the link points at, and (b) leave a non-hermetic symlink in the container
+    ``$HOME``. The existing same-source guard (:func:`_dst_resolves_to_source`)
+    only covers a symlink back to ``src`` itself (INCIDENT 2026-07-02); this is
+    its unguarded sibling — a symlink to a DIFFERENT target.
+    """
+
+    def _arrange(self, tmp_path: Path) -> tuple[Path, Path, Path]:
+        src = tmp_path / "baseline" / "deny_edit.sh"
+        src.parent.mkdir(parents=True)
+        src.write_text("NEW-baseline")
+        host = tmp_path / "host" / "deny_edit.sh"
+        host.parent.mkdir(parents=True)
+        host.write_text("HOST-ORIGINAL")
+        dst = tmp_path / "home" / "deny_edit.sh"
+        dst.parent.mkdir(parents=True)
+        dst.symlink_to(host)
+        return src, host, dst
+
+    def test_dst_becomes_a_real_file_with_src_content(self, tmp_path) -> None:
+        # Arrange
+        src, _host, dst = self._arrange(tmp_path)
+        # Act
+        _deploy_plain_file(
+            src, dst, config=None, rel=Path("hooks/pre-tool-use/deny_edit.sh")
+        )
+        # Assert — a real file (not a symlink) carrying the current src content.
+        assert not dst.is_symlink() and dst.read_text() == "NEW-baseline"
+
+    def test_pointed_at_host_file_is_not_corrupted(self, tmp_path) -> None:
+        # Arrange
+        src, host, dst = self._arrange(tmp_path)
+        # Act
+        _deploy_plain_file(
+            src, dst, config=None, rel=Path("hooks/pre-tool-use/deny_edit.sh")
+        )
+        # Assert — the host file the stale link pointed at is byte-for-byte intact.
+        assert host.read_text() == "HOST-ORIGINAL"
+
+    def test_broken_symlink_dst_is_replaced_with_real_file(self, tmp_path) -> None:
+        # Arrange — dst is a DANGLING symlink (host target already removed).
+        src = tmp_path / "baseline" / "x.sh"
+        src.parent.mkdir(parents=True)
+        src.write_text("NEW")
+        dst = tmp_path / "home" / "x.sh"
+        dst.parent.mkdir(parents=True)
+        dst.symlink_to(tmp_path / "gone" / "x.sh")
+        # Act
+        _deploy_plain_file(src, dst, config=None, rel=Path("hooks/stop/x.sh"))
+        # Assert
+        assert not dst.is_symlink() and dst.read_text() == "NEW"


### PR DESCRIPTION
## Summary

A `to_home` file deploy must land a **real, hermetic file** at the destination.
For a **symlink** destination, `_clear_readonly_dst` previously left the link in
place, and the subsequent `shutil.copy2` / `Path.write_text` **followed** it:

- A leftover host-merge link (`$HOME/.claude/hooks/x -> ~/.claude/hooks/x`, left
  behind when `x` later moves into the agent `to_home` baseline) is written
  **through**, **corrupting the operator's real host file** with
  agent-interpolated content — and the container `$HOME` keeps a non-hermetic
  symlink instead of a real file.
- A **dangling** link makes `copy2` raise `FileNotFoundError`, aborting the deploy.

This is the unguarded sibling of the same-file guard added for INCIDENT
2026-07-02 (`_dst_resolves_to_source` — a symlink back to the **source**): that
guard only covers a link pointing at `src` itself; a link pointing at a
**different** target fell through and corrupted it.

## Fix

`_clear_readonly_dst` now **unlinks** a symlink `dst` before returning, so every
per-file deployer that clears the slot before writing (`_deploy_plain_file`,
`_deploy_tight_perm_file`, `_deploy_verbatim_secret`, and `_deploy_mcp_merge`'s
pre-read clear) lands a real file and never writes through the link.
`_deploy_plain_file` still short-circuits the legitimate
symlink-back-to-source case via `_dst_resolves_to_source` **before** reaching
here, so "linked host file, skip cleanly" is unaffected.

## Root-cause note on the triggering symptom

The fleet-restart report (scitex-storage came up on a `deny_edit_on_main_branch.sh`
with mtime = its Jul-3 create time) was investigated end to end. On-host evidence
shows scitex-storage's live `$HOME` is the relaxed **overlay upper**
(`--home /home/agent --overlay <dir>`, space-separated), and its last
materialization (`scitex-overlay-versions.json`, Jul 18 03:30) **predated** the
dotfiles `to_home` source fix (Jul 18 05:34). Two co-located baseline hooks whose
overlay-upper mtimes exactly match their source prove the walk **does** overwrite
changed baseline files on every start. So the stale hook is a **timing artifact**
— a restart re-delivers it — **not** a re-delivery code bug. The empirical
reproduction (real files) confirmed: an OLD real file in the dest is overwritten
correctly; only the **symlink** dest was mishandled. That real, adjacent
host-corruption bug in the same overwrite path is what this PR fixes, and it is
the permanent "overwrite-first" hardening requested.

Immediate fleet unblock (independent of this PR): **restart** any agent whose
last materialization predated its `to_home` source fix.

## Tests (real files, no mocks; RED → GREEN)

- **unit** (`test__to_home_deployers.py`): `_deploy_plain_file` with a
  symlink-to-other-target dst → dst becomes a real file with `src` content, the
  pointed-at host file is intact, and a dangling link is replaced (no
  `FileNotFoundError`). These **failed before** the change (dst stayed a symlink;
  host file read `NEW-baseline`; dangling link raised) and pass after.
- **integration** (`test__to_home.py`): `deploy_to_home` with a developer config
  and the `SAC_HOST_CLAUDE_DIR` seam replaces a leftover host-merge symlink
  without corrupting the host file, and overwrites a plain OLD real file in the
  dest (the invariant).

Full `_to_home` / `_to_home_deployers` / `_host_merge` / `_to_home_overlay`
suites: **129 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqhsrw29CM4siBLcEK2CwV
