### PR TITLE
fix(lifecycle): pre-stop rescue only touches worktrees it owns (ownership marker + default-deny)

### DIFF
--- a/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_create.py
+++ b/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_create.py
@@ -161,9 +161,7 @@ def _try_policy_target(name: str, cwd: str) -> str | None:
     base = _resolve_base(git_root)
 
     if _branch_exists(git_root, branch):
-        ok, _err = _try_git(
-            "worktree", "add", str(target), branch, cwd=git_root
-        )
+        ok, _err = _try_git("worktree", "add", str(target), branch, cwd=git_root)
     else:
         ok, _err = _try_git(
             "worktree", "add", "-b", branch, str(target), base, cwd=git_root
@@ -198,9 +196,7 @@ def _try_sdk_default_fallback(name: str, cwd: str) -> str | None:
         return None
     branch = f"claude/{name}"
     if _branch_exists(git_root, branch):
-        ok, _err = _try_git(
-            "worktree", "add", str(target), branch, cwd=git_root
-        )
+        ok, _err = _try_git("worktree", "add", str(target), branch, cwd=git_root)
     else:
         base = _resolve_base(git_root)
         ok, _err = _try_git(
@@ -209,6 +205,48 @@ def _try_sdk_default_fallback(name: str, cwd: str) -> str | None:
     if not ok or not target.is_dir():
         return None
     return str(target)
+
+
+# Ownership marker filename. MUST match
+# ``scitex_agent_container._lifecycle._pre_stop_rescue_git.OWNER_MARKER_NAME``
+# — this standalone hook cannot import the package, so the constant is
+# duplicated here with a pointer to its authoritative definition.
+_OWNER_MARKER_NAME = "sac-owner"
+
+
+def _stamp_owner(worktree_path: str) -> None:
+    """Stamp the owning agent id into ``<git-dir>/sac-owner`` for this worktree.
+
+    Why OUT of the working tree: the pre-stop rescue runs ``git add -A``
+    on every worktree it commits. An in-tree marker (``.sac-owner``)
+    would be STAGED into that rescue commit — a plausible-but-wrong
+    artifact. The worktree's PRIVATE gitdir (``git rev-parse
+    --absolute-git-dir`` → ``<main>/.git/worktrees/<name>`` for a linked
+    worktree, ``<checkout>/.git`` for a primary checkout) is OUTSIDE the
+    working tree, so git never stages it. The pre-stop rescue reads this
+    stamp and rescues a worktree ONLY when it names the stopping agent
+    (default-deny otherwise) — the shared-checkout mis-attribution fix.
+
+    Owner id = ``$SCITEX_TODO_AGENT_ID`` (the agent's board identity,
+    which equals its ``config.name`` — the value the rescue compares
+    against). Best-effort: a failure here must NEVER break worktree
+    creation, whose SDK contract is to echo the path. An empty/unset
+    agent id is left UNSTAMPED — the rescue then default-denies the
+    worktree, which is the safe outcome.
+    """
+    owner = os.environ.get("SCITEX_TODO_AGENT_ID", "").strip()
+    if not owner:
+        return
+    try:
+        git_dir = _run_git("rev-parse", "--absolute-git-dir", cwd=worktree_path)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return
+    if not git_dir:
+        return
+    try:
+        (Path(git_dir) / _OWNER_MARKER_NAME).write_text(owner + "\n", encoding="utf-8")
+    except OSError:
+        return
 
 
 def main() -> int:
@@ -254,6 +292,7 @@ def main() -> int:
 
     policy_path = _try_policy_target(name, cwd)
     if policy_path is not None:
+        _stamp_owner(policy_path)
         print(policy_path)
         return 0
 
@@ -262,6 +301,7 @@ def main() -> int:
     # the prune cron is the implicit cleanup contract.
     fallback_path = _try_sdk_default_fallback(name, cwd)
     if fallback_path is not None:
+        _stamp_owner(fallback_path)
         print(
             f"WorktreeCreate hook: policy target .worktrees/{name} failed; "
             f"falling back to SDK default {fallback_path} so the Agent "

--- a/src/scitex_agent_container/_lifecycle/_pre_stop_rescue.py
+++ b/src/scitex_agent_container/_lifecycle/_pre_stop_rescue.py
@@ -23,7 +23,7 @@ moment the agent could not review the result:
   origin (operator: 「テストが赤いまま公開？どうやって？」).
 * It used ``--force-with-lease``, which every agent is hook-banned from
   running by hand. A stop hook is not an exemption.
-* It protected BRANCHES, not TREES, and the walk has no ownership
+* It protected BRANCHES, not TREES, and the walk had no ownership
   model: a foreign worktree parked on a topic branch (another agent's
   in-flight work, in a checkout this agent merely shares) got committed
   and force-pushed with no guard anywhere in its path. Observed
@@ -32,6 +32,30 @@ moment the agent could not review the result:
 Nothing is lost by dropping it. ``workdir`` is a host bind mount, so a
 LOCAL commit already survives the restart that motivated this module —
 the push was never what made the work durable.
+
+*** THE RESCUE ONLY TOUCHES WORKTREES IT OWNS. ***
+
+The push is gone (#743), but a residual harm survived it: on a SHARED
+checkout the LOCAL commit still mis-attributed a peer's tree. The
+``scitex-cards`` lane runs four agents (``scitex-cards`` / ``-chat`` /
+``-gui`` / ``-mobile``) over ONE physical checkout — the workdir is a
+symlink farm onto a single ``scitex-todo`` checkout — so its ``.git``,
+``.worktrees/`` and ``git worktree list`` are SHARED. The walk therefore
+saw every peer's worktree and, since worktrees are branch-named with no
+agent id, could not tell them apart. Observed twice 2026-07-17: agent
+``chat``'s rescue committed agent ``gui``'s in-flight worktree under
+``chat``'s identity.
+
+The fix is an OWNERSHIP MARKER + DEFAULT-DENY. Each subagent worktree is
+stamped at creation (the ``WorktreeCreate`` hook) with its creating
+agent's id, stored OUT of the working tree at ``<git-dir>/sac-owner`` so
+the ``git add -A`` this module runs can NEVER stage it. The walk reads
+that stamp (:func:`_pre_stop_rescue_git.worktree_owner`) and rescues a
+``.worktrees`` child ONLY when the stamp names the stopping agent —
+skipping any child whose owner MISMATCHES or is ABSENT
+(:func:`_ownership_allows`). The unstamped-window cost is bounded: the
+commit-before-idle stop hook already forces dirty subagent worktrees to
+commit, so this rescue is the SECOND net, mattering mainly for CRASHES.
 
 It runs once per ``agent_stop`` call, BEFORE the operator's
 ``pre_stop`` hooks fire, walks every git worktree under the agent's
@@ -83,6 +107,7 @@ from ._pre_stop_rescue_git import (
     is_dirty,
     is_git_worktree,
     move_dirty_to_side_branch,
+    worktree_owner,
     write_diff_tarball,
 )
 
@@ -257,25 +282,61 @@ def _rescue_protected(
     return result
 
 
-def _candidate_roots(workdir: Path) -> Iterable[Path]:
-    """Yield the directories the pass walks for rescue candidates.
+def _candidate_roots(workdir: Path) -> Iterable[tuple[Path, bool]]:
+    """Yield ``(path, is_child)`` for every directory the pass walks.
 
     Per lead refinement (a2a efa48850): cover the subagent
     ``.worktrees/*`` and the legacy ``worktrees/*`` — those are
     exactly what restart kills + what the reap-bug
     (lead-learnings/19) silently destroys.
+
+    ``is_child`` is ``True`` for a ``.worktrees/*`` / ``worktrees/*``
+    subagent worktree and ``False`` for the primary ``workdir`` root.
+    The distinction drives the OWNERSHIP gate in
+    ``rescue_worktrees_for_agent``: children are DEFAULT-DENY (rescued
+    only when their ``sac-owner`` stamp names the stopping agent), while
+    the shared-checkout root keeps its existing conservative handling.
     """
-    yield workdir
+    yield workdir, False
     sub = workdir / ".worktrees"
     if sub.is_dir():
         for child in sorted(sub.iterdir()):
             if child.is_dir():
-                yield child
+                yield child, True
     legacy = workdir / "worktrees"
     if legacy.is_dir():
         for child in sorted(legacy.iterdir()):
             if child.is_dir():
-                yield child
+                yield child, True
+
+
+def _ownership_allows(owner: str | None, agent_name: str, *, is_child: bool) -> bool:
+    """Decide whether the stopping ``agent_name`` may rescue this candidate.
+
+    THREE states, never a boolean collapse of "I don't know" into a pole:
+
+    * ``owner == agent_name`` — positively owned → ALLOW (both children
+      and root).
+    * ``owner`` present but ``!= agent_name`` — a DIFFERENT agent owns
+      this worktree → DENY (both). This is the exact mis-attribution the
+      fix exists to stop: a peer's in-flight tree must never be committed
+      under the stopping agent's identity.
+    * ``owner is None`` (marker ABSENT / unknown) — DEFAULT-DENY for a
+      ``.worktrees`` CHILD (an unstamped peer worktree in the shared
+      checkout is indistinguishable from our own, so we refuse it), but
+      ALLOW for the primary ROOT. The root is the agent's own workdir;
+      denying an unstamped root would REGRESS the ordinary
+      single-checkout agent whose root-level work must still be rescued.
+      The shared-checkout root is protected a different way: it sits on
+      ``develop`` (protected), so ``rescue_worktree`` routes it to a
+      local ``rescue/`` side-branch rather than committing peer work onto
+      the shared branch.
+    """
+    if owner == agent_name:
+        return True
+    if owner is None:
+        return not is_child
+    return False
 
 
 def rescue_worktrees_for_agent(
@@ -303,7 +364,7 @@ def rescue_worktrees_for_agent(
     results: list[dict[str, object]] = []
     deadline = time.monotonic() + grace_seconds
     per_candidate_timeout = max(2.0, grace_seconds / 4.0)
-    for candidate in _candidate_roots(workdir):
+    for candidate, is_child in _candidate_roots(workdir):
         if time.monotonic() >= deadline:
             log.warning(
                 "pre-stop rescue: grace budget elapsed before scanning %s; "
@@ -322,13 +383,49 @@ def rescue_worktrees_for_agent(
                 }
             )
             continue
+        remaining = deadline - time.monotonic()
+        candidate_timeout = min(per_candidate_timeout, remaining)
+        # OWNERSHIP GATE (shared-checkout mis-attribution fix). Read the
+        # worktree's ``sac-owner`` stamp and DEFAULT-DENY a child whose
+        # owner is not the stopping agent (mismatch) OR is absent
+        # (unknown) — a stopping agent must never commit a peer's
+        # in-flight worktree under its own identity. The primary root is
+        # handled conservatively inside ``_ownership_allows`` (an
+        # unstamped own-checkout root is still rescued; a shared-checkout
+        # root on ``develop`` is routed to a local side-branch by
+        # ``rescue_worktree``).
+        owner = worktree_owner(candidate, timeout=candidate_timeout)
+        if not _ownership_allows(owner, agent_name, is_child=is_child):
+            log.info(
+                "pre-stop rescue: skipping %s — owner=%r != stopping agent=%r "
+                "(default-deny; not this agent's worktree)",
+                candidate,
+                owner,
+                agent_name,
+            )
+            results.append(
+                {
+                    "path": candidate,
+                    "branch": "",
+                    "committed": False,
+                    "tarball": None,
+                    "protected": False,
+                    "rescue_branch": "",
+                    "error": (
+                        f"skipped: owner={owner!r} != stopping agent="
+                        f"{agent_name!r} (ownership default-deny)"
+                    ),
+                    "owner": owner,
+                }
+            )
+            continue
         results.append(
             rescue_worktree(
                 candidate,
                 agent_name=agent_name,
                 timestamp=timestamp,
                 rescue_root=rescue_root,
-                timeout=min(per_candidate_timeout, deadline - time.monotonic()),
+                timeout=candidate_timeout,
             )
         )
     return results

--- a/src/scitex_agent_container/_lifecycle/_pre_stop_rescue_git.py
+++ b/src/scitex_agent_container/_lifecycle/_pre_stop_rescue_git.py
@@ -25,6 +25,7 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 __all__ = [
+    "OWNER_MARKER_NAME",
     "checkout_branch",
     "commit_dirty",
     "current_branch",
@@ -32,8 +33,16 @@ __all__ = [
     "is_git_worktree",
     "move_dirty_to_side_branch",
     "rescue_branch_name",
+    "worktree_owner",
     "write_diff_tarball",
 ]
+
+# Ownership marker filename. Stored in the worktree's PRIVATE gitdir
+# (``<git-dir>/sac-owner``), NEVER in the working tree — see
+# ``worktree_owner`` for why. The stamp is written at worktree-creation
+# time by the ``WorktreeCreate`` hook (``claude_worktree_hooks``); the
+# rescue reads it here to decide OWNERSHIP.
+OWNER_MARKER_NAME: str = "sac-owner"
 
 
 def _run(cmd: list[str], *, cwd: Path, timeout: float) -> tuple[int, str, str]:
@@ -61,6 +70,49 @@ def is_git_worktree(path: Path) -> bool:
     if not path.is_dir():
         return False
     return (path / ".git").exists()
+
+
+def worktree_owner(path: Path, *, timeout: float) -> str | None:
+    """Return the owning agent id stamped at ``<git-dir>/sac-owner``, or None.
+
+    OWNERSHIP is the fix for the shared-checkout mis-attribution bug: the
+    ``scitex-cards`` lane runs four agents over ONE physical checkout (a
+    symlink farm), so its ``.git`` — and therefore ``.worktrees/`` and
+    ``git worktree list`` — is SHARED. A stopping agent's rescue walk sees
+    every peer's worktree and cannot tell them apart from the branch name.
+
+    So each worktree is stamped with its creating agent's id at creation
+    time (``WorktreeCreate`` hook). The stamp lives in the worktree's
+    PRIVATE gitdir — ``<main>/.git/worktrees/<name>/sac-owner`` for a
+    linked worktree, ``<checkout>/.git/sac-owner`` for a primary checkout
+    — resolved here via ``git rev-parse --absolute-git-dir``. That path is
+    OUTSIDE the working tree, so the ``git add -A`` every rescue runs can
+    NEVER stage it (git does not stage anything under ``.git/``).
+
+    Returns the stamped id (stripped) when the marker is present and
+    non-empty; ``None`` when the marker is ABSENT or unreadable, or when
+    the git-dir cannot be resolved. ``None`` means "unknown owner" — the
+    caller DEFAULT-DENIES an unknown owner on a ``.worktrees`` child.
+    NEVER raises.
+    """
+    rc, out, _ = _run(
+        ["git", "rev-parse", "--absolute-git-dir"], cwd=path, timeout=timeout
+    )
+    if rc != 0:
+        return None
+    git_dir = out.strip()
+    if not git_dir:
+        return None
+    marker = Path(git_dir) / OWNER_MARKER_NAME
+    try:
+        text = marker.read_text(encoding="utf-8")
+    except (
+        OSError,
+        FileNotFoundError,
+    ):  # stx-allow: fallback (reason: an absent/unreadable marker is "unknown owner", not a crash — the caller default-denies.)
+        return None
+    owner = text.strip()
+    return owner or None
 
 
 def current_branch(path: Path, *, timeout: float) -> str:

--- a/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/conftest.py
+++ b/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/conftest.py
@@ -46,12 +46,20 @@ def _git(cwd: Path, *args: str) -> str:
 
 
 def _run_hook(
-    script: Path, payload: dict, cwd: Path | None = None
+    script: Path,
+    payload: dict,
+    cwd: Path | None = None,
+    env: dict | None = None,
 ) -> subprocess.CompletedProcess:
     """Invoke the hook script with the given JSON payload on stdin.
 
     Returns the completed process so individual tests can assert on
     returncode / stdout / stderr without retrying or coupling.
+
+    ``env`` (when given) fully REPLACES the subprocess environment —
+    the owner-stamp tests use it to pin ``SCITEX_TODO_AGENT_ID`` (or to
+    prove its absence) deterministically, independent of the runner's
+    ambient value. When ``None`` the child inherits the parent env.
     """
     return subprocess.run(
         [sys.executable, str(script)],
@@ -59,6 +67,7 @@ def _run_hook(
         capture_output=True,
         text=True,
         cwd=str(cwd) if cwd else None,
+        env=env,
     )
 
 

--- a/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_create.py
+++ b/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_create.py
@@ -13,6 +13,7 @@ a ≥3-word descriptive name, and exactly one assertion.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -246,3 +247,51 @@ class TestWorktreeCreateBaseResolution:
         # the local develop HEAD which has the extra commit).
         new_sha = _git(target, "rev-parse", "HEAD")
         assert new_sha == origin_develop_sha
+
+
+# ---------------------------------------------------------------------------
+# Owner stamp — WRITE half of the shared-checkout mis-attribution fix.
+#
+# The hook stamps the creating agent's id at ``<git-dir>/sac-owner`` (OUT of
+# the working tree) so the pre-stop rescue can rescue ONLY worktrees it owns
+# (default-deny otherwise) on a checkout shared by several agents.
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeCreateOwnerStamp:
+    def test_owner_stamp_written_to_private_gitdir(self, ephemeral_repo: Path) -> None:
+        # Arrange — SCITEX_TODO_AGENT_ID identifies the owning agent; the
+        # hook must stamp it into the worktree's PRIVATE gitdir.
+        payload = _create_payload("stamp-probe", ephemeral_repo)
+        env = {**os.environ, "SCITEX_TODO_AGENT_ID": "stampy-agent"}
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload, env=env)
+        target = Path(result.stdout.strip())
+        git_dir = _git(target, "rev-parse", "--absolute-git-dir")
+        # Assert — the marker holds the agent id, in the private gitdir.
+        assert (Path(git_dir) / "sac-owner").read_text().strip() == "stampy-agent"
+
+    def test_owner_stamp_is_never_inside_the_working_tree(
+        self, ephemeral_repo: Path
+    ) -> None:
+        # Arrange — the marker MUST live outside the working tree so the
+        # rescue's ``git add -A`` can never stage it.
+        payload = _create_payload("stamp-outside-probe", ephemeral_repo)
+        env = {**os.environ, "SCITEX_TODO_AGENT_ID": "stampy-agent"}
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload, env=env)
+        target = Path(result.stdout.strip())
+        # Assert — no sac-owner file in the worktree's working directory.
+        assert not (target / "sac-owner").exists()
+
+    def test_no_owner_stamp_when_agent_id_unset(self, ephemeral_repo: Path) -> None:
+        # Arrange — an unset agent id leaves the worktree UNSTAMPED (the
+        # rescue then default-denies it) rather than stamping an empty id.
+        payload = _create_payload("no-stamp-probe", ephemeral_repo)
+        env = {k: v for k, v in os.environ.items() if k != "SCITEX_TODO_AGENT_ID"}
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload, env=env)
+        target = Path(result.stdout.strip())
+        git_dir = _git(target, "rev-parse", "--absolute-git-dir")
+        # Assert — no marker written.
+        assert not (Path(git_dir) / "sac-owner").exists()

--- a/tests/scitex_agent_container/_lifecycle/test__pre_stop_rescue.py
+++ b/tests/scitex_agent_container/_lifecycle/test__pre_stop_rescue.py
@@ -111,6 +111,45 @@ def _init_repo_with_origin(
     return root
 
 
+def _porcelain(path: Path) -> str:
+    """Return ``git status --porcelain`` output (stripped) for ``path``."""
+    return _git_out(["status", "--porcelain"], cwd=path).strip()
+
+
+def _stamp_owner_marker(worktree: Path, owner: str) -> None:
+    """Stamp ``<git-dir>/sac-owner = owner`` exactly as the WorktreeCreate hook does.
+
+    Written OUT of the working tree — into the worktree's PRIVATE gitdir
+    (``git rev-parse --absolute-git-dir``) — so ``git add -A`` can NEVER
+    stage it. That out-of-tree property is the whole point of the fix.
+    """
+    git_dir = _git_out(["rev-parse", "--absolute-git-dir"], cwd=worktree).strip()
+    (Path(git_dir) / "sac-owner").write_text(owner + "\n")
+
+
+def _init_shared_checkout(root: Path, *, branch: str = "develop") -> Path:
+    """A shared checkout that gitignores ``.worktrees/`` — the real lane topology.
+
+    Mirrors the ``scitex-cards`` lane: ONE physical checkout whose shared
+    ``.git`` hosts every agent's LINKED worktree under ``.worktrees/``.
+    ``.worktrees/`` + ``worktrees/`` are gitignored (verified against
+    sac's own ``.gitignore``) so the root checkout stays clean with
+    respect to the nested worktrees — exactly like production.
+    """
+    _init_repo(root, branch=branch)
+    (root / ".gitignore").write_text(".worktrees/\nworktrees/\n")
+    _git(["add", ".gitignore"], cwd=root)
+    _git(["commit", "-m", "ignore worktrees", "--quiet"], cwd=root)
+    return root
+
+
+def _add_linked_worktree(checkout: Path, rel: str, *, branch: str) -> Path:
+    """``git worktree add`` a real LINKED worktree under ``checkout`` (shares one .git)."""
+    wt = checkout / rel
+    _git(["worktree", "add", "-q", "-b", branch, str(wt), "HEAD"], cwd=checkout)
+    return wt
+
+
 # ---------------------------------------------------------------------------
 # is_protected_branch — denylist policy
 # ---------------------------------------------------------------------------
@@ -336,9 +375,13 @@ def test_rescue_for_agent_finds_dotworktrees_subagent(
     git_env_save_restore, tmp_path: Path
 ) -> None:
     # Arrange — primary workdir is clean; a .worktrees/agent-foo sibling
-    # carries the dirty work that restart would otherwise destroy.
+    # carries the dirty work that restart would otherwise destroy. The
+    # sub is stamped as owned by the stopping agent (``parent``) so the
+    # ownership gate ALLOWS its rescue (default-deny only skips peers /
+    # unstamped worktrees).
     workdir = _init_repo(tmp_path / "wd")
     sub = _init_repo(workdir / ".worktrees" / "agent-foo")
+    _stamp_owner_marker(sub, "parent")
     _make_dirty(sub)
     state_dir = tmp_path / "state"
     # Act
@@ -355,9 +398,12 @@ def test_rescue_for_agent_finds_dotworktrees_subagent(
 def test_rescue_for_agent_finds_legacy_worktrees_dir(
     git_env_save_restore, tmp_path: Path
 ) -> None:
-    # Arrange — legacy worktrees/legacy-feat carries the dirty work.
+    # Arrange — legacy worktrees/legacy-feat carries the dirty work,
+    # stamped as owned by the stopping agent so the ownership gate allows
+    # its rescue.
     workdir = _init_repo(tmp_path / "wd")
     legacy = _init_repo(workdir / "worktrees" / "legacy-feat")
+    _stamp_owner_marker(legacy, "parent")
     _make_dirty(legacy)
     state_dir = tmp_path / "state"
     # Act
@@ -712,3 +758,88 @@ def test_rescue_nonprotected_topic_branch_leaves_commit_on_that_branch(
     # Assert — HEAD's newest commit is the rescue autosave on feature/topic.
     subject = _git_out(["log", "-1", "--pretty=%s"], cwd=repo)
     assert subject.strip() == "rescue: pre-stop autosave agent-x@20260709T000000Z"
+
+
+# ---------------------------------------------------------------------------
+# OWNERSHIP — shared-checkout mis-attribution fix (stamp + default-deny)
+#
+# The ``scitex-cards`` lane runs four agents over ONE physical checkout, so
+# ``.git`` + ``.worktrees/`` are SHARED. Before the fix, a stopping agent's
+# rescue committed EVERY dirty ``.worktrees`` child — including peers' — under
+# its own identity (observed twice 2026-07-17: chat committed gui's tree).
+# Each worktree is now stamped at creation with its owner id at
+# ``<git-dir>/sac-owner`` (OUT of the working tree); the rescue rescues a
+# child ONLY when the stamp names the stopping agent, default-denying a
+# mismatched OR absent owner.
+# ---------------------------------------------------------------------------
+
+
+def test_rescue_skips_peer_and_unstamped_worktrees_in_shared_checkout(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — SPECIMEN REPRO. One shared checkout; three LINKED worktrees
+    # sharing its .git: wt_a stamped ownerA, wt_b stamped ownerB, wt_c
+    # UNSTAMPED. All three dirty. agentA stops.
+    checkout = _init_shared_checkout(tmp_path / "shared")
+    wt_a = _add_linked_worktree(checkout, ".worktrees/wt-a", branch="feature/a")
+    wt_b = _add_linked_worktree(checkout, ".worktrees/wt-b", branch="feature/b")
+    wt_c = _add_linked_worktree(checkout, ".worktrees/wt-c", branch="feature/c")
+    _stamp_owner_marker(wt_a, "agentA")
+    _stamp_owner_marker(wt_b, "agentB")
+    for wt in (wt_a, wt_b, wt_c):
+        _make_dirty(wt)
+    state_dir = tmp_path / "state"
+    # Act — agentA stops.
+    rescue_worktrees_for_agent(
+        agent_name="agentA", workdir=checkout, state_dir=state_dir
+    )
+    # Assert — ONLY agentA's own worktree was committed (clean now); the
+    # peer's (ownerB) and the unstamped one are SKIPPED (still dirty).
+    assert _porcelain(wt_a) == "" and _porcelain(wt_b) != "" and _porcelain(wt_c) != ""
+
+
+def test_rescue_commits_own_stamped_worktree_default_deny_is_not_deny_all(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — TWIN guard: default-deny must NOT collapse into deny-all.
+    # agentA's OWN stamped, dirty worktree in the shared checkout MUST
+    # still be rescued.
+    checkout = _init_shared_checkout(tmp_path / "shared")
+    wt = _add_linked_worktree(checkout, ".worktrees/mine", branch="feature/mine")
+    _stamp_owner_marker(wt, "agentA")
+    _make_dirty(wt)
+    state_dir = tmp_path / "state"
+    # Act
+    results = rescue_worktrees_for_agent(
+        agent_name="agentA", workdir=checkout, state_dir=state_dir
+    )
+    # Assert — the owned worktree's result records a commit.
+    mine = [r for r in results if Path(r["path"]).samefile(wt)]
+    assert mine and mine[0]["committed"] is True
+
+
+def test_rescue_never_stages_owner_marker_into_commit(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — agentA's own stamped, dirty worktree; the rescue commits
+    # it via ``git add -A``. The stamp lives in the private gitdir, so it
+    # must appear in NO committed path and NO working-tree status entry,
+    # yet still exist on disk (never lost, never staged).
+    checkout = _init_shared_checkout(tmp_path / "shared")
+    wt = _add_linked_worktree(checkout, ".worktrees/mine", branch="feature/mine")
+    _stamp_owner_marker(wt, "agentA")
+    _make_dirty(wt)
+    state_dir = tmp_path / "state"
+    # Act
+    rescue_worktrees_for_agent(
+        agent_name="agentA", workdir=checkout, state_dir=state_dir
+    )
+    # Assert — sac-owner is OUT of the tree: absent from the committed tree
+    # AND from porcelain, but present in the private gitdir.
+    committed_paths = _git_out(["ls-tree", "-r", "--name-only", "HEAD"], cwd=wt)
+    git_dir = _git_out(["rev-parse", "--absolute-git-dir"], cwd=wt).strip()
+    assert (
+        "sac-owner" not in committed_paths
+        and "sac-owner" not in _porcelain(wt)
+        and (Path(git_dir) / "sac-owner").is_file()
+    )


### PR DESCRIPTION
## Problem — pre-stop rescue mis-attributes a peer's worktree on a SHARED checkout

Card: `fleet-autosave-commits-and-pushes-foreign-worktrees-20260717`.

The `scitex-cards` lane runs **four** agents (`scitex-cards` / `-chat` / `-gui` /
`-mobile`) over **one physical checkout**: their workdir `…/proj/scitex-cards` is
a symlink onto a single `…/proj/scitex-todo` checkout, with separate `$HOME`
overlays only. One checkout ⇒ **one `.git`** ⇒ **one `.worktrees/`** ⇒ one
`git worktree list`. So `_pre_stop_rescue._candidate_roots` walked the *shared*
`.worktrees/` and swept **every peer's** worktree. Worktrees are branch-named
with no agent id (and pinned under `<checkout>/.worktrees/` by the
`WorktreeCreate` hook), so neither the path nor `git worktree list` can
disambiguate ownership.

Observed twice on 2026-07-17: agent **chat**'s rescue committed agent **gui**'s
in-flight worktree under chat's identity. The push half is already gone (#743),
so the residual harm is a **local commit of a peer's tree under the wrong
identity** — an integrity / mis-attribution violation.

## Fix — ownership marker (out of the working tree) + default-deny

**Marker location.** The owning agent id is stored at **`<git-dir>/sac-owner`**,
resolved via `git rev-parse --absolute-git-dir` (a linked worktree →
`<main>/.git/worktrees/<name>/`, a primary checkout → `<checkout>/.git/`). This
is **outside the working tree**, so the `git add -A` every rescue runs can
**never** stage it. An in-tree marker (e.g. `.sac-owner`) was rejected precisely
because `git add -A` would fold it into the rescue commit — a plausible-but-wrong
artifact. (`OWNER_MARKER_NAME = "sac-owner"`.)

**Stamp (write half).** The `WorktreeCreate` hook
(`_baseline_assets/claude_worktree_hooks/worktree_create.py` — the hook that
already fires on worktree creation and pins the path under `.worktrees/`) now
writes `<git-dir>/sac-owner = $SCITEX_TODO_AGENT_ID` on every successful create /
idempotent resume. `SCITEX_TODO_AGENT_ID` equals the agent's `{name}`
(`cli_pkg/_create.py`), which is exactly the `config.name` the rescue compares
against — so the write identity and the read identity are the same string.
Best-effort: a stamp failure never breaks worktree creation (whose SDK contract
is to echo the path); an empty/unset id is left unstamped (⇒ default-denied,
the safe outcome).

**Read half (rescue).** `_pre_stop_rescue_git.worktree_owner()` reads the stamp;
`_pre_stop_rescue._ownership_allows()` is a **three-state** gate (never a boolean
collapse of "unknown"):

| owner vs stopping agent | `.worktrees/*` child | primary root |
|---|---|---|
| **matches** | rescue | rescue |
| **mismatches** (peer) | **skip** | **skip** |
| **absent** (unstamped/unknown) | **skip (default-deny)** | rescue (unchanged) |

**Shared-root policy (flagged).** Default-deny is applied to `.worktrees/*` /
`worktrees/*` **children** only. The **primary workdir root** keeps its existing
handling, denied only on a *positive* owner mismatch:
- An ordinary single-checkout agent's own root is typically unstamped — denying
  it would regress the legitimate root-level rescue, so an absent stamp on the
  root still proceeds.
- A shared-checkout root sits on `develop` (protected), so `rescue_worktree`
  already routes its dirty tree to a **local `rescue/<agent>-<ts>` side-branch**
  (never a commit on the shared branch). The residual (a peer's *root-level*
  dirty work carried onto the stopping agent's local side-branch) is a lesser,
  local-only harm than the fixed case (a peer's `.worktrees` child committed
  onto their topic branch). See "Uncertainty" below.

## Bounded unstamped-window (rider from the owner)

The lost-autosave cost of default-deny is bounded and **must not be misread as a
regression later**: sac's commit-before-idle stop hook already forces dirty
subagent worktrees to commit, so this rescue is the **second net** — it matters
mainly for **crashes**. The stamp also only becomes effective after the changed
hook is redelivered to running containers (separate fix, card
`sac-to-home-restart-redelivers-changed-files-20260717`) **and** agents create
**new** worktrees; existing worktrees stay unstamped (⇒ default-denied) until
then. That is expected and safe.

## Tests (no mocks — real `tmp_path` git repos, real linked worktrees)

`tests/…/_lifecycle/test__pre_stop_rescue.py` (rescue / read half):
- `test_rescue_skips_peer_and_unstamped_worktrees_in_shared_checkout` — **SPECIMEN
  REPRO**: shared checkout, three linked worktrees (owner A, owner B, unstamped),
  all dirty; rescue as A commits **only** A's worktree, skips B's and the
  unstamped one. Proven **RED before** (old code commits all three) → GREEN after.
- `test_rescue_commits_own_stamped_worktree_default_deny_is_not_deny_all` — TWIN
  guard: default-deny must not become deny-everything (A's own stamped worktree
  is still rescued).
- `test_rescue_never_stages_owner_marker_into_commit` — the stamp appears in no
  committed tree and no `git status`, yet exists in the private gitdir.
- Two pre-existing `.worktrees`/legacy tests updated to stamp their child (they
  encoded the old "rescue any child" behavior that this PR intentionally changes).

`tests/…/claude_worktree_hooks/test_worktree_create.py` (stamp / write half):
- `test_owner_stamp_written_to_private_gitdir` — proven **RED before** → GREEN.
- `test_owner_stamp_is_never_inside_the_working_tree`.
- `test_no_owner_stamp_when_agent_id_unset`.

Full run: **rescue + hook suites green** (see PR checks). RED-before was
demonstrated by reverting only the source files and re-running the new tests.

## Not doing here
- No merge (PR only).
- Redelivery of the changed hook to running containers is the separate
  `sac-to-home-restart-…` card.

## Uncertainty
The shared-checkout **root** case is the one residual: if the shared root's
`develop` is dirty with a *peer's* root-level work when another agent stops, that
work is carried onto the stopping agent's **local** `rescue/` side-branch (never
pushed, never on the shared branch). This is strictly less harmful than the fixed
`.worktrees`-child case; fully resolving it would require stamping the primary
checkout root too, which is out of scope here.
