### PR TITLE
feat(auth-heal): sac agents restart-login-expired timer + caller-independent CCT pool

### DIFF
--- a/src/scitex_agent_container/_authheal/__init__.py
+++ b/src/scitex_agent_container/_authheal/__init__.py
@@ -1,0 +1,36 @@
+"""Auto-restart LIVE agents wedged behind a frozen "Login expired" banner.
+
+The sibling of :mod:`.._reconcile`: fleet-reconcile restarts DEAD (no tmux
+session) agents; this restarts LIVE-session-but-auth-dead ones — the case
+fleet-reconcile explicitly leaves alone. Detection is READ-ONLY and
+2-run-corroborated (:mod:`._detect`); the restart is rate-limited and escalates
+to a board card instead of an infinite bounce (:mod:`._pass`, :mod:`._alarm`).
+
+Surfaced as ``sac agents restart-login-expired`` and the federated
+``sac.restart-login-expired-agents`` timer job. READ THE DEPLOY GATE in
+:mod:`._pass` before enabling that timer — an existing ``auth-heal.py`` cron
+already restarts these agents, and two restarters on one fleet is the
+double-supervisor class.
+"""
+
+from __future__ import annotations
+
+from ._detect import DEFAULT_INTERVAL, capture_live_panes, detect_login_expired
+from ._pass import (
+    DEFAULT_PASS_CAP,
+    AgentReport,
+    PassOutcome,
+    auth_heal_pass,
+    history_path,
+)
+
+__all__ = [
+    "DEFAULT_INTERVAL",
+    "DEFAULT_PASS_CAP",
+    "AgentReport",
+    "PassOutcome",
+    "auth_heal_pass",
+    "capture_live_panes",
+    "detect_login_expired",
+    "history_path",
+]

--- a/src/scitex_agent_container/_authheal/_alarm.py
+++ b/src/scitex_agent_container/_authheal/_alarm.py
@@ -1,0 +1,322 @@
+"""Route login-expired-restart verdicts to a SEEN surface — and prove liveness.
+
+Two idempotent scitex-todo rails, both SIDE rails (a board write that fails
+prints loudly and can NEVER crash or skip the restart pass that feeds it):
+
+1. **Escalation cards** (``fleet-agent-login-expired-<name>``) — one per agent
+   that is STILL login-expired after the hourly restart cap. Restarting is not
+   fixing it, so instead of an infinite bounce the agent is handed to a human.
+   Upsert on OVER-BUDGET/FAILED; resolve the moment the agent is no longer
+   login-expired (restarted, or recovered on its own and gone from the pass).
+
+2. **Heartbeat card** (``fleet-login-expired-restarter-heartbeat``) — the answer
+   to "who watches the watcher": refreshed on EVERY pass, so if this timer stops
+   ticking its card goes stale and scitex-todo's stale-active nudge shouts. One
+   system's silence becomes another's alarm — the same design as
+   :mod:`.._reconcile._alarm`.
+
+Mirrors the reconcile alarm's shape but talks to the scitex-todo PUBLIC API
+directly (``add_task``/``update_task``/``get_task``/``resolve_task``/
+``list_tasks``) so this package stays self-contained and its card wording is
+specific to the login-expired case.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping
+
+from .._reconcile._rule import Verdict
+
+__all__ = [
+    "AlarmOutcome",
+    "CARD_ID_PREFIX",
+    "HEARTBEAT_CARD_ID",
+    "card_id_for",
+    "route_reports_to_cards",
+    "upsert_heartbeat",
+]
+
+#: Stable per-agent card id — idempotency is by id, so a re-run updates in place.
+CARD_ID_PREFIX = "fleet-agent-login-expired-"
+
+#: The restarter's own liveness beacon. ONE card, stable id, forever.
+HEARTBEAT_CARD_ID = "fleet-login-expired-restarter-heartbeat"
+
+#: Owner + author of the escalation cards (a pseudo-agent, not a human).
+_AGENT = "sac.restart-login-expired-agents"
+
+#: The heartbeat is owned by the PACKAGE identity: a human must own noticing
+#: that this restarter went quiet.
+_HEARTBEAT_ASSIGNEE = "scitex-agent-container"
+
+_STATUS = "blocked"
+_BLOCKER = "operator-decision"
+
+#: Verdicts meaning "still login-expired and a restart is NOT fixing it" → card.
+_UNRECOVERED = (Verdict.OVER_BUDGET, Verdict.FAILED)
+
+#: Verdicts meaning "we acted / it is on the mend" → resolve any card it had.
+_CLEARED_BY = (Verdict.RESTARTED,)
+
+
+def card_id_for(name: str) -> str:
+    """The stable escalation-card id for ``name``."""
+    return f"{CARD_ID_PREFIX}{name}"
+
+
+def _now_iso(now: datetime | None) -> str:
+    """A timestamp in scitex-todo's canonical shape (second-res, ``Z`` suffix)."""
+    stamp = now or datetime.now(timezone.utc)
+    return stamp.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class AlarmOutcome:
+    """What the routing did this run — so the caller is never silent."""
+
+    carded: tuple[str, ...] = ()
+    cleared: tuple[str, ...] = ()
+    failed: tuple[str, ...] = ()
+
+
+def _card_exists(store: str | None, card_id: str) -> bool:
+    from scitex_todo import TaskNotFoundError, get_task
+
+    # stx-allow: fallback (reason: "does this card exist yet?" — a missing store file or missing id is a normal False; any other load failure propagates to the caller's per-card guard, which reports it loudly)
+    try:
+        get_task(store, card_id)
+        return True
+    except (TaskNotFoundError, FileNotFoundError):
+        return False
+
+
+def _escalation_card(name: str, verdict: Verdict, detail: str) -> tuple[str, str]:
+    """Title + note for an agent this restarter could not heal."""
+    title = (
+        f"[fleet] {name} is STILL login-expired after auto-restart ({verdict.value})"
+    )
+    note = (
+        f"agent: {name}\n"
+        f"verdict: {verdict.value}\n"
+        f"why: {detail}\n\n"
+        "sac's login-expired restarter found this LIVE agent wedged behind a "
+        "frozen auth banner and auto-restarted it, but it is STILL login-expired "
+        "after the hourly cap. A restart LOOP is worse than a wedged agent, so "
+        "the restarter stops and asks a human instead of bouncing it forever.\n\n"
+        "The usual cause is a genuine account problem (the shared OAuth account "
+        "cannot refresh), which no restart fixes.\n\n"
+        "Investigate:\n"
+        f"    sac agents auth-status | grep {name}\n"
+        f"    sac agents tail {name}\n"
+        "Restart by hand once the account is healthy:\n"
+        f"    sac agents restart {name} --yes"
+    )
+    return title, note
+
+
+def _upsert(
+    store: str | None,
+    card_id: str,
+    title: str,
+    note: str,
+    now: datetime | None,
+    *,
+    status: str = _STATUS,
+    blocker: str | None = _BLOCKER,
+    assignee: str = _AGENT,
+) -> None:
+    """Create the card, or update it in place — never duplicate.
+
+    Re-asserting ``status`` also REOPENS a card a previous clean run resolved:
+    an agent that wedges, is healed (card resolved), then wedges again must
+    alarm again.
+    """
+    from scitex_todo import add_task, update_task
+
+    if _card_exists(store, card_id):
+        kwargs: dict[str, Any] = {
+            "title": title,
+            "note": note,
+            "status": status,
+            "last_activity": _now_iso(now),
+        }
+        if blocker is not None:
+            kwargs["blocker"] = blocker
+        update_task(store, card_id, **kwargs)
+    else:
+        kwargs = {
+            "id": card_id,
+            "title": title,
+            "status": status,
+            "note": note,
+            "scope": f"agent:{assignee}",
+            "assignee": assignee,
+            "created_by": _AGENT,
+        }
+        if blocker is not None:
+            kwargs["blocker"] = blocker
+        add_task(store, **kwargs)
+
+
+def _clear(store: str | None, card_id: str) -> bool:
+    """Resolve the card if present + still open. Returns did-clear (idempotent)."""
+    from scitex_todo import get_task, resolve_task
+
+    if not _card_exists(store, card_id):
+        return False
+    if get_task(store, card_id).get("status") == "done":
+        return False
+    resolve_task(store, card_id, actor=_AGENT)
+    return True
+
+
+def _carded_agents(store: str | None) -> list[str]:
+    """Names of every agent that currently has an OPEN escalation card.
+
+    Lets a pass RESOLVE the card of an agent that recovered on its own — it is
+    simply absent from this pass's reports, so without this it would leave a
+    stale alarm on the board forever.
+    """
+    from scitex_todo import list_tasks
+
+    # stx-allow: fallback (reason: card-clearing is a SIDE rail — a store read failure must never crash the restart pass; an empty list just means "clear nothing this pass")
+    try:
+        rows = list_tasks(store, id_prefix=CARD_ID_PREFIX)
+    except Exception:
+        return []
+    return [
+        str(r["id"])[len(CARD_ID_PREFIX) :]
+        for r in rows
+        if str(r.get("id", "")).startswith(CARD_ID_PREFIX) and r.get("status") != "done"
+    ]
+
+
+def route_reports_to_cards(
+    reports: Iterable[Any],
+    *,
+    store: str | None = None,
+    now: datetime | None = None,
+    err_stream: Any = None,
+) -> AlarmOutcome:
+    """Upsert / resolve one escalation card per agent from this pass's reports.
+
+    Never raises: a per-agent card-write failure is printed loudly and recorded
+    in :attr:`AlarmOutcome.failed`, so one unwritable board never suppresses the
+    rest of the fleet's alarms — nor unwinds a restart that already happened.
+    """
+    stream = err_stream if err_stream is not None else sys.stderr
+    reports = list(reports)
+    active = {r.name for r in reports}
+    carded: list[str] = []
+    cleared: list[str] = []
+    failed: list[str] = []
+
+    for report in reports:
+        name = report.name
+        card_id = card_id_for(name)
+        # stx-allow: fallback (reason: card delivery is a SIDE rail — one agent's board-write failure must never crash the pass that feeds it, nor suppress the other agents' alarms; it is reported loudly and recorded in AlarmOutcome.failed)
+        try:
+            if report.verdict in _UNRECOVERED:
+                _upsert(
+                    store,
+                    card_id,
+                    *_escalation_card(name, report.verdict, report.detail),
+                    now=now,
+                )
+                carded.append(name)
+            elif report.verdict in _CLEARED_BY and _clear(store, card_id):
+                cleared.append(name)
+        except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+            failed.append(name)
+            print(
+                f"[login-expired-restart-alarm] {name}: scitex-todo card "
+                f"delivery FAILED — {exc} (the verdict above is UNCHANGED and any "
+                f"restart it performed still happened)",
+                file=stream,
+            )
+
+    # Recovered-on-their-own: an agent with an open card that is NOT in this
+    # pass's reports is no longer login-expired → resolve its stale card.
+    for name in _carded_agents(store):
+        if name in active:
+            continue
+        # stx-allow: fallback (reason: side rail — a failed clear must never crash the pass)
+        try:
+            if _clear(store, card_id_for(name)):
+                cleared.append(name)
+        except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+            failed.append(name)
+            print(
+                f"[login-expired-restart-alarm] {name}: could not resolve stale "
+                f"card — {exc}",
+                file=stream,
+            )
+
+    return AlarmOutcome(
+        carded=tuple(carded), cleared=tuple(cleared), failed=tuple(failed)
+    )
+
+
+def _heartbeat_note(
+    stats: Mapping[str, int], *, mode: str, host: str, now: datetime | None
+) -> str:
+    counted = "\n".join(f"  {k:<22} {v}" for k, v in stats.items())
+    return (
+        f"last run: {_now_iso(now)}\n"
+        f"mode:     {mode}\n"
+        f"host:     {host}\n\n"
+        f"{counted}\n\n"
+        "This card is sac's login-expired-restarter LIVENESS BEACON, refreshed "
+        "on every pass — including passes that find nothing wrong, which are the "
+        "ticks that prove the mechanism is alive at all.\n\n"
+        "IF THIS CARD IS STALE, THE RESTARTER IS NOT RUNNING, and live agents "
+        "wedged behind an auth banner are once again staying wedged unnoticed.\n\n"
+        "Check the timer:\n"
+        "    systemctl --user list-timers | grep restart-login-expired\n"
+        "Run a pass by hand (read-only):\n"
+        "    sac agents restart-login-expired --check"
+    )
+
+
+def upsert_heartbeat(
+    stats: Mapping[str, int],
+    *,
+    mode: str,
+    host: str = "",
+    store: str | None = None,
+    now: datetime | None = None,
+    err_stream: Any = None,
+) -> bool:
+    """Refresh the restarter's own liveness card. Returns did-write.
+
+    Kept ``in_progress`` (NOT ``done``): only an OPEN card is watched by
+    scitex-todo's stale-active nudge, and that nudge firing IS the alarm for a
+    dead restarter. A SIDE rail — a board-write failure prints loudly and returns
+    ``False``; it never raises into the pass.
+    """
+    stream = err_stream if err_stream is not None else sys.stderr
+    # stx-allow: fallback (reason: the heartbeat is a SIDE rail — telling the board we are alive must never crash the pass that restarts wedged agents; a failure here is printed loudly and reported to the caller)
+    try:
+        _upsert(
+            store,
+            HEARTBEAT_CARD_ID,
+            f"[fleet] sac login-expired-restarter heartbeat — last {mode} pass "
+            f"{_now_iso(now)}",
+            _heartbeat_note(stats, mode=mode, host=host, now=now),
+            now,
+            status="in_progress",
+            blocker=None,
+            assignee=_HEARTBEAT_ASSIGNEE,
+        )
+        return True
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        print(
+            f"[login-expired-restart-alarm] HEARTBEAT card delivery FAILED — "
+            f"{exc}. The pass itself was UNAFFECTED, but the board can no longer "
+            f"tell anyone whether this restarter is alive.",
+            file=stream,
+        )
+        return False

--- a/src/scitex_agent_container/_authheal/_detect.py
+++ b/src/scitex_agent_container/_authheal/_detect.py
@@ -1,0 +1,65 @@
+"""READ-ONLY detection: which live TUI agents are CORROBORATED login-expired.
+
+Reuses the ``sac agents auth-status`` detector as the SINGLE SOURCE OF TRUTH for
+the near-prompt + distance-frozen matcher (2-run corroboration): an agent is
+flagged only when a system auth banner sits directly above its prompt AND stays
+frozen across two captures ``--interval`` apart. A banner that moved — the agent
+is producing output, working or merely QUOTING the incident — is never flagged,
+so a false positive can never bounce a working agent and destroy its context.
+
+Detection performs NO token-rotating probe and writes nothing: it captures panes
+and classifies them, full stop (the ``sac agents auth-status`` writer owns the
+state.db cache; this consumer must not fight its cadence). The ONLY mutation in
+the whole flow is the restart itself, in :mod:`._pass`.
+
+The ``sac agents auth-status`` symbols are imported LAZILY (inside the
+functions) so this module stays importable without pulling ``click`` at import
+time, and so there is no import-time coupling to the CLI package.
+"""
+
+from __future__ import annotations
+
+import time
+
+__all__ = ["DEFAULT_INTERVAL", "capture_live_panes", "detect_login_expired"]
+
+#: Seconds between the two pane captures whose agreement defines "frozen".
+#: Same default as ``sac agents auth-status --interval``.
+DEFAULT_INTERVAL = 4.0
+
+
+def detect_login_expired(
+    captures: "dict[str, tuple[str | None, str | None]]",
+) -> list[str]:
+    """Corroborated login-expired agent NAMES (sorted), from two-capture panes.
+
+    ``captures`` maps ``agent -> (pane_run1, pane_run2)``. Delegates to the real
+    ``evaluate_agents`` corroboration and keeps ONLY the ``auth_failed`` verdict
+    — never ``ok`` (banner moved / clean) and never ``unknown`` (pane could not
+    be read: absence of evidence is not evidence of a wedge). Pure: no tmux, no
+    I/O, so it is unit-testable against captured panes without mocks.
+    """
+    from ..cli_pkg._auth_status import VERDICT_AUTH_FAILED, evaluate_agents
+
+    rows = evaluate_agents(captures)  # sorts by agent name
+    return [r["agent"] for r in rows if r["verdict"] == VERDICT_AUTH_FAILED]
+
+
+def capture_live_panes(
+    interval: float = DEFAULT_INTERVAL,
+) -> "dict[str, tuple[str | None, str | None]]":
+    """Capture every live ``tui-<agent>`` pane TWICE, ``interval`` apart.
+
+    The live default seam for :func:`._pass.auth_heal_pass` — reuses the exact
+    tmux enumeration + capture the ``sac agents auth-status`` command uses, so
+    the two commands see the same fleet on the same tmux server. An uncapturable
+    pane is ``None`` (the honest "could not read"), which the matcher maps to
+    UNKNOWN — never a false AUTH-FAILED.
+    """
+    from ..cli_pkg._auth_status import _agent_of, _capture, _list_tui_sessions
+
+    sessions = _list_tui_sessions()
+    run1 = {_agent_of(s): _capture(s) for s in sessions}
+    time.sleep(max(0.0, interval))
+    run2 = {_agent_of(s): _capture(s) for s in sessions}
+    return {name: (run1.get(name), run2.get(name)) for name in run1}

--- a/src/scitex_agent_container/_authheal/_pass.py
+++ b/src/scitex_agent_container/_authheal/_pass.py
@@ -1,0 +1,327 @@
+"""One login-expired auto-restart pass over the live TUI fleet.
+
+SIBLING OF ``_reconcile``, NOT A REPLACEMENT
+    ``sac.fleet-reconcile`` restarts agents whose tmux session is GONE (a
+    corpse: no session ⇒ no context to lose). It EXPLICITLY leaves alone a LIVE
+    session whose Claude cannot authenticate — a frozen "Login expired" banner —
+    because touching a live session destroys context. THIS pass owns exactly
+    that other half: a live-but-auth-dead agent, which only a restart clears
+    (Claude never re-reads its credentials). The frozen-banner corroboration
+    (:mod:`._detect`) is what proves the session is wedged, not working, so the
+    restart is safe and is the cure.
+
+REUSE, NOT REINVENTION
+    Reuses :mod:`.._reconcile._budget` wholesale — the rate limits proven in
+    production by ``auth-heal.py`` (30-min/agent debounce, <=2/agent/hour,
+    <=N/pass) — and :class:`.._reconcile._rule.Verdict`. It keeps its OWN history
+    file (``SAC_LOGIN_EXPIRED_HISTORY``) so the two restarters' debounces stay
+    independent and their atomic writes never race on one file.
+
+POOL-LOADING RESTART (class fix, 2026-07-18)
+    The restart goes through the normal :func:`.._lifecycle.lifecycle
+    .agent_restart` path — the SAME mechanism ``sac.fleet-reconcile`` uses. With
+    the pool class fix (:func:`..runtimes._envrc.resolve_secret_files`), that
+    path now loads the CCT/Telegram token pool from the canonical ``$HOME``
+    default even when ``SAC_SECRETS_ENVRC`` is unset, so a timer-driven restart
+    can no longer strip an agent's bot token.
+
+DEPLOY GATE — READ BEFORE ENABLING THE TIMER
+    An existing ``auth-heal.py`` cron (its ``scan_tui``) ALREADY restarts these
+    agents on the fleet host. Enabling this timer while that cron still runs =
+    TWO restarters bouncing the same ``tui-<agent>`` sessions with INDEPENDENT
+    debounce state = the double-supervisor class (the ``sac.listen`` catastrophe
+    in another costume). This timer MUST NOT be enabled on a host until that
+    host's ``auth-heal.py`` ``scan_tui`` is retired. See :mod:`.._jobs_plugin`
+    and the ``sac agents restart-login-expired`` command help.
+
+Every collaborator is an injectable seam with a REAL default, so tests drive the
+whole pass against real panes, a real temp history file and a real scitex-todo
+store — with the one irreversible act (the restart) swapped for a recorder. No
+mocks.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from .._reconcile._budget import (
+    DEFAULT_PASS_CAP,
+    Budget,
+    read_history,
+    save_history,
+)
+from .._reconcile._rule import Verdict
+from ._alarm import route_reports_to_cards, upsert_heartbeat
+from ._detect import DEFAULT_INTERVAL, capture_live_panes, detect_login_expired
+
+__all__ = [
+    "DEFAULT_INTERVAL",
+    "DEFAULT_PASS_CAP",
+    "AgentReport",
+    "PassOutcome",
+    "auth_heal_pass",
+    "history_path",
+]
+
+#: Explicit override for WHERE this restarter's history lives — SEPARATE from
+#: ``sac.fleet-reconcile``'s, so the two never race on one file.
+_HISTORY_ENV = "SAC_LOGIN_EXPIRED_HISTORY"
+
+#: Which rate-limit stood in the way, mapped to the verdict it becomes. Same
+#: split as reconcile: only OVER-BUDGET is carded (a human is genuinely needed);
+#: COOLING-DOWN is the NORMAL state of a healthy recovery and CAPPED is our own
+#: throttle, so neither mints a card.
+_BUDGET_VERDICTS = {
+    "debounce": Verdict.COOLING_DOWN,
+    "over-budget": Verdict.OVER_BUDGET,
+    "pass-cap": Verdict.CAPPED,
+}
+
+#: Verdicts that mean we ATTEMPTED a restart, so the history must be persisted
+#: before the next agent (a killed pass must not forget what it already bounced).
+_SPENT = (Verdict.RESTARTED, Verdict.FAILED)
+
+
+def history_path() -> Path:
+    """Where the restart history lives. Resolved PER CALL, never cached."""
+    override = os.environ.get(_HISTORY_ENV)
+    if override:
+        return Path(override).expanduser()
+    from .._state.state_paths import runtime_root
+
+    return runtime_root() / "login-expired-restart-history.json"
+
+
+def _real_restart(name: str) -> bool:
+    """Restart ONE local agent through the pool-loading start path.
+
+    ``agent_restart`` returns True on its own paths but forwards
+    ``runtime.start(...)`` on another, and a runtime returning ``None`` must NOT
+    be read as failure — inventing a false FAILURE is the mirror of the false
+    SUCCESS that once sent the operator hunting a healthy credential store. So
+    ``is not False`` (the same rule ``_reconcile._pass._real_restart`` uses).
+    """
+    from .._lifecycle.lifecycle import agent_restart
+
+    return agent_restart(name) is not False
+
+
+@dataclass(frozen=True)
+class AgentReport:
+    """One agent's line in the report. ``detail`` is ALWAYS printed."""
+
+    name: str
+    verdict: Verdict
+    reason: str
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "verdict": self.verdict.value,
+            "reason": self.reason,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class PassOutcome:
+    """Everything one pass concluded and did."""
+
+    reports: tuple[AgentReport, ...] = ()
+    alarm: Any = None
+    heartbeat_ok: bool = False
+    applied: bool = False
+
+    def of(self, *verdicts: Verdict) -> tuple[AgentReport, ...]:
+        return tuple(r for r in self.reports if r.verdict in verdicts)
+
+    def counts(self) -> dict[str, int]:
+        out = {v.value: 0 for v in Verdict}
+        for report in self.reports:
+            out[report.verdict.value] += 1
+        return {k: v for k, v in out.items() if v}
+
+    def exit_code(self) -> int:
+        """0 clean · 1 something is wedged · 2 we cannot read our own memory."""
+        if self.of(Verdict.BUDGET_UNKNOWN):
+            return 2
+        if self.of(
+            Verdict.FAILED,
+            Verdict.OVER_BUDGET,
+            Verdict.COOLING_DOWN,
+            Verdict.CAPPED,
+            Verdict.WOULD_RESTART,
+        ):
+            return 1
+        return 0
+
+
+def _perform(
+    name: str,
+    *,
+    budget: Budget | None,
+    apply: bool,
+    now: float,
+    restart_fn: Callable[[str], bool],
+    budget_detail: str,
+) -> AgentReport:
+    """Turn a corroborated login-expired agent into what we actually did."""
+    base = f"{name} is login-expired (corroborated: a system auth banner frozen above its prompt across two captures)"
+    if budget is None:
+        # We could not read our OWN restart memory, so the debounce and the
+        # hourly cap cannot be enforced. Restarting anyway would make EVERY
+        # wedged agent restartable on EVERY tick — the loop the limits prevent.
+        return AgentReport(
+            name,
+            Verdict.BUDGET_UNKNOWN,
+            "budget-unreadable",
+            f"{base}; NOT restarted: {budget_detail}",
+        )
+    check = budget.check(name, now)
+    if not check.allowed:
+        return AgentReport(
+            name,
+            _BUDGET_VERDICTS[check.reason],
+            check.reason,
+            f"{base}; NOT restarted: {check.detail}",
+        )
+    if not apply:
+        return AgentReport(
+            name,
+            Verdict.WOULD_RESTART,
+            "login-expired",
+            f"{base} — would restart (dry-run/--check: nothing was done; re-run "
+            f"with --apply to actually restart)",
+        )
+    # stx-allow: fallback (reason: one agent's restart raising must never abort the sweep — the rest of the wedged fleet still needs recovering; the failure is carded and reported)
+    try:
+        ok = restart_fn(name)
+    except Exception as exc:
+        budget.record(name, now)  # a restart we ATTEMPTED still spends budget
+        return AgentReport(
+            name, Verdict.FAILED, "restart-raised", f"{base}; restart FAILED: {exc}"
+        )
+    budget.record(name, now)
+    if ok:
+        return AgentReport(
+            name,
+            Verdict.RESTARTED,
+            "login-expired",
+            f"{base} — restarted to re-mount a live credential",
+        )
+    return AgentReport(
+        name,
+        Verdict.FAILED,
+        "restart-returned-false",
+        f"{base}; restart ran but reported FAILURE — the agent is still wedged",
+    )
+
+
+def auth_heal_pass(
+    *,
+    apply: bool = False,
+    limit: int = DEFAULT_PASS_CAP,
+    history_file: Path | None = None,
+    store: str | None = None,
+    alarm: bool = True,
+    now: float | None = None,
+    restart_fn: Callable[[str], bool] | None = None,
+    capture_fn: Callable[[], dict] | None = None,
+    interval: float = DEFAULT_INTERVAL,
+    err_stream: Any = None,
+) -> PassOutcome:
+    """Run ONE login-expired auto-restart pass over the live TUI fleet.
+
+    ``apply=False`` (the default, selected by ``--check``) is a REPORT: it
+    detects and decides but restarts nothing. The only board write a dry-run
+    makes is this restarter's own heartbeat.
+    """
+    now = now if now is not None else time.time()
+    now_dt = datetime.fromtimestamp(now, tz=timezone.utc)
+    restart_fn = restart_fn if restart_fn is not None else _real_restart
+    capture_fn = (
+        capture_fn if capture_fn is not None else (lambda: capture_live_panes(interval))
+    )
+    history_file = history_file if history_file is not None else history_path()
+    stream = err_stream if err_stream is not None else sys.stderr
+
+    names = detect_login_expired(capture_fn())
+
+    # PROVE we can read (and create) our own memory before acting on it — a
+    # budget we cannot read is not a budget (see _reconcile._budget).
+    read = read_history(history_file)
+    budget = Budget(read.history, pass_cap=limit) if read.enforceable else None
+    reports: list[AgentReport] = []
+
+    for name in names:
+        report = _perform(
+            name,
+            budget=budget,
+            apply=apply,
+            now=now,
+            restart_fn=restart_fn,
+            budget_detail=read.detail,
+        )
+        reports.append(report)
+        # PERSIST THE MOMENT WE SPEND BUDGET, never only at the end: a pass
+        # killed at its systemd timeout with history still in RAM would forget
+        # what it just bounced and re-bounce it next tick, disarming the limits.
+        if apply and budget is not None and report.verdict in _SPENT:
+            # stx-allow: fallback (reason: if we can no longer RECORD restarts we must STOP performing them — an unrecordable restart is unbounded. Spending the pass cap halts further restarts safely; the loud print carries the failure.)
+            try:
+                save_history(history_file, budget.history, now=now)
+            except OSError as exc:
+                budget.spent = budget.pass_cap
+                print(
+                    f"[login-expired-restart] CANNOT RECORD restarts to "
+                    f"{history_file} ({exc}) — halting this pass's restarts.",
+                    file=stream,
+                )
+
+    if apply and budget is not None:
+        # stx-allow: fallback (reason: the end-of-pass write is housekeeping; its failure is already reported per-restart above and must not crash a pass that has done its work)
+        try:
+            save_history(history_file, budget.history, now=now)
+        except OSError:
+            pass
+
+    if budget is None and reports:
+        print(
+            f"[login-expired-restart] REFUSING to restart {len(reports)} wedged "
+            f"agent(s): {read.detail}",
+            file=stream,
+        )
+
+    outcome = PassOutcome(reports=tuple(reports), applied=apply)
+    alarm_outcome = None
+    heartbeat_ok = False
+    if alarm:
+        # Board rails run LAST, after every restart decision is made and carried
+        # out, so nothing they do (or fail to do) can change what happened.
+        alarm_outcome = (
+            route_reports_to_cards(
+                reports, store=store, now=now_dt, err_stream=err_stream
+            )
+            if apply
+            else None
+        )
+        heartbeat_ok = upsert_heartbeat(
+            outcome.counts(),
+            mode="apply" if apply else "check",
+            store=store,
+            now=now_dt,
+            err_stream=err_stream,
+        )
+    return PassOutcome(
+        reports=tuple(reports),
+        alarm=alarm_outcome,
+        heartbeat_ok=heartbeat_ok,
+        applied=apply,
+    )

--- a/src/scitex_agent_container/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs_plugin.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 def provide_jobs() -> "list[JobSpec]":
     """Return sac's federated scheduled jobs.
 
-    Four jobs today:
+    Five jobs today:
 
     * ``sac.fleet-reconcile`` (``kind="timer"``) — the only enforcer of
       "should be running ⇒ is running". Restarts agents whose tmux session
@@ -29,6 +29,25 @@ def provide_jobs() -> "list[JobSpec]":
       a deliberate stop. See its inline comment: the spec field it enforces
       (``restart.policy``) is dead code without it, and 33 agents once
       stayed dead for hours because of that.
+
+    * ``sac.restart-login-expired-agents`` (``kind="timer"``) — the SIBLING of
+      fleet-reconcile and the exact division of labor: fleet-reconcile owns
+      DEAD/no-session corpses; this owns LIVE-session-but-AUTH-DEAD agents (a
+      frozen "Login expired" banner) that fleet-reconcile explicitly leaves
+      alone, because touching a live session destroys context. Detection is
+      READ-ONLY + 2-run-corroborated; the restart runs through the pool-loading
+      start path (so a timer-driven restart cannot strip an agent's CCT/Telegram
+      token) and is rate-limited exactly like fleet-reconcile.
+
+      DEPLOY GATE — declared here so the mechanism is version-controlled and
+      TESTED, but it MUST NOT be enabled on a host until that host's
+      ``auth-heal.py`` ``scan_tui`` cron is RETIRED. That cron already restarts
+      these agents (2-run-corroborated TUI heal, since 2026-06-01); enabling
+      this timer alongside it puts TWO restarters on one fleet with INDEPENDENT
+      debounce state — the same double-supervisor class as the ``sac.listen``
+      duplication described below, one costume over. The crontab is host state a
+      PR cannot edit, so the cron retirement is an operator/dotfiles step that
+      must land WITH the enable.
 
     * ``sac.accounts-refresh`` (``kind="timer"``) — a headless OAuth
       access-token refresh for EVERY stored Claude account, including the
@@ -216,6 +235,40 @@ def provide_jobs() -> "list[JobSpec]":
             # this timeout is SAFE: the restart history is persisted per
             # restart, not at the end, so the next tick still honours the
             # debounce for anything already bounced.
+            timeout_sec=300,
+        ),
+        JobSpec(
+            name="sac.restart-login-expired-agents",
+            schedule="*/5 * * * *",  # every 5min (cron form; timer cadence below)
+            command="sac agents restart-login-expired --apply",
+            description=(
+                "Restarts LIVE agents wedged behind a frozen 'Login expired' "
+                "banner (auth-dead but tmux-alive) — the half fleet-reconcile "
+                "leaves alone. Detection is READ-ONLY + 2-run-corroborated (a "
+                "banner that moved between the two captures = working, never "
+                "restarted); the restart runs through the pool-loading start "
+                "path (cannot strip CCT tokens) and is rate-limited (30min/agent "
+                "debounce, <=2/agent/hour, <=10/pass); an agent still wedged "
+                "after the cap gets a scitex-todo card, not an endless bounce. "
+                "DEPLOY GATE: do NOT enable until the host's auth-heal.py "
+                "scan_tui cron is retired (double-supervisor risk)."
+            ),
+            # Same taxonomy note as the jobs above: kind must be one of
+            # {"service","timer","cron"} (scitex-dev #153); a periodic
+            # systemd --user timer is ``kind="timer"`` with the cadence in
+            # ``on_unit_active_sec``. A wrong kind raises at construction and
+            # ``ecosystem up`` then silently drops sac's WHOLE provider.
+            kind="timer",
+            # 5min matched to fleet-reconcile so the two enforcers sweep on the
+            # same beat rather than harmonising into one; it is the window a
+            # wedged agent stays wedged. A no-op pass is one `tmux list-sessions`
+            # plus two pane captures ~4s apart.
+            on_boot_sec="5min",
+            on_unit_active_sec="5min",
+            # Mirrors fleet-reconcile: bounds the pathological pass (`--limit`
+            # restarts, each a stop+settle+start) plus the ~4s capture interval.
+            # A pass killed here is SAFE — history is persisted per restart, so
+            # the next tick still honours the debounce for anything bounced.
             timeout_sec=300,
         ),
     ]

--- a/src/scitex_agent_container/cli_pkg/_agents_restart_login_expired.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_restart_login_expired.py
@@ -1,0 +1,193 @@
+"""``sac agents restart-login-expired`` — restart LIVE agents wedged on auth.
+
+The operator's window onto :mod:`.._authheal`. Sibling of ``sac agents
+reconcile``: reconcile restarts DEAD (no tmux session) agents; this restarts
+LIVE ones whose Claude cannot authenticate — a frozen "Login expired" banner —
+which reconcile explicitly leaves alone. Detection is READ-ONLY and
+2-run-corroborated; the restart is rate-limited and escalates to a board card
+rather than looping.
+
+Rendering rule (inherited from ``sac agents reconcile``): there is no quiet
+path. Every agent this pass touched gets a line saying what we concluded and
+WHY — a silent skip is indistinguishable from a bug.
+
+DEPLOY GATE: an existing ``auth-heal.py`` cron already restarts these agents.
+Do NOT enable the ``sac.restart-login-expired-agents`` timer on a host until
+that host's ``auth-heal.py`` ``scan_tui`` is retired — two restarters on one
+fleet is the double-supervisor class. Running this command BY HAND is always
+safe.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from .._authheal import DEFAULT_INTERVAL, DEFAULT_PASS_CAP, auth_heal_pass
+from .._reconcile._rule import Verdict
+from ._helpers import _json_flag, console
+
+#: Colour per verdict. Anything that leaves an agent wedged is loud on purpose.
+_STYLE = {
+    Verdict.RESTARTED: ("green", "RESTARTED"),
+    Verdict.WOULD_RESTART: ("yellow", "WOULD-RESTART"),
+    Verdict.COOLING_DOWN: ("yellow", "COOLING-DOWN"),
+    Verdict.CAPPED: ("yellow", "CAPPED"),
+    Verdict.OVER_BUDGET: ("red", "OVER-BUDGET"),
+    Verdict.FAILED: ("red", "FAILED"),
+    Verdict.BUDGET_UNKNOWN: ("magenta", "BUDGET-UNKNOWN"),
+}
+
+
+def _print_report(report) -> None:
+    colour, label = _STYLE.get(report.verdict, ("white", report.verdict.value))
+    # soft_wrap: a wrapped agent name is one you cannot grep out of a cron log.
+    console.print(f"[{colour}]{label:<14}[/{colour}] {report.name}", soft_wrap=True)
+    console.print(f"    [dim]{report.detail}[/dim]", soft_wrap=True)
+
+
+@click.command(name="restart-login-expired")
+@click.option(
+    "--apply",
+    "apply",
+    is_flag=True,
+    default=False,
+    help="ACTUALLY restart the wedged agents. Without this, nothing is restarted.",
+)
+@click.option(
+    "--check",
+    "check",
+    is_flag=True,
+    default=False,
+    help="Report only, mutate nothing (dry-run). This is already the DEFAULT.",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=DEFAULT_PASS_CAP,
+    show_default=True,
+    help="Global cap on restarts in ONE pass — the blast radius of a bad tick.",
+)
+@click.option(
+    "--interval",
+    type=float,
+    default=DEFAULT_INTERVAL,
+    show_default=True,
+    help="Seconds between the two pane captures used for the frozen check.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON (for cron).")
+@click.pass_context
+def restart_login_expired(
+    ctx: click.Context,
+    apply: bool,
+    check: bool,
+    limit: int,
+    interval: float,
+    as_json: bool,
+) -> None:
+    """Restart LIVE agents wedged behind a frozen "Login expired" banner.
+
+    An agent whose API calls are rejected sits at its prompt under an auth
+    banner forever — the tmux session is alive, so ``reconcile`` (which only
+    ever touches a CORPSE) leaves it be, yet it does nothing. Claude never
+    re-reads its credentials, so ONLY a restart clears it. This verb detects
+    that state (a system auth banner frozen directly above the prompt across two
+    captures — so a working agent QUOTING the banner is never mistaken for a
+    wedged one) and restarts it, through the pool-loading start path so the
+    restart cannot strip the agent's CCT/Telegram token.
+
+    \b
+    Detect (read-only — the DEFAULT; exits non-zero if anything is wedged):
+      $ sac agents restart-login-expired
+      $ sac agents restart-login-expired --check --json
+    \b
+    Remedy:
+      $ sac agents restart-login-expired --apply
+
+    Rate-limited exactly like ``reconcile`` (30-min/agent debounce, <=2/agent/
+    hour, --limit per pass): an agent STILL wedged after the cap gets a BOARD
+    CARD rather than an infinite bounce — a restart loop is worse than a wedged
+    agent.
+
+    \b
+    ! DEPLOY GATE — the SCHEDULED form (sac.restart-login-expired-agents timer):
+      An existing auth-heal.py cron ALREADY restarts these agents. Do NOT enable
+      this timer on a host until that host's auth-heal.py scan_tui is retired —
+      two restarters bouncing one fleet is the double-supervisor class. Running
+      THIS COMMAND by hand is always safe.
+
+    Exits 0 clean, 1 if something is wedged, 2 if it cannot read its own memory.
+    """
+    if apply and check:
+        raise click.UsageError(
+            "--apply and --check are contradictory. Dry-run is the DEFAULT: "
+            "drop both flags to preview, pass --apply to restart."
+        )
+
+    outcome = auth_heal_pass(apply=apply, limit=limit, interval=interval)
+    code = outcome.exit_code()
+
+    if _json_flag(ctx, as_json):
+        click.echo(
+            json.dumps(
+                {
+                    "mode": "apply" if apply else "check",
+                    "exit_code": code,
+                    "counts": outcome.counts(),
+                    "heartbeat_carded": outcome.heartbeat_ok,
+                    "agents": [r.to_dict() for r in outcome.reports],
+                },
+                indent=2,
+            )
+        )
+        raise SystemExit(code)
+
+    mode = "apply" if apply else "check (read-only)"
+    console.print(
+        f"[bold]sac agents restart-login-expired[/bold]  {mode} — "
+        f"{len(outcome.reports)} corroborated login-expired agent(s)\n"
+    )
+    for report in outcome.reports:
+        _print_report(report)
+
+    counts = outcome.counts()
+    console.print(
+        "\n[bold]"
+        + ("  ".join(f"{k}={v}" for k, v in counts.items()) or "nothing wedged")
+        + "[/bold]"
+    )
+
+    would = outcome.of(Verdict.WOULD_RESTART)
+    if would:
+        console.print(
+            f"\n[yellow]{len(would)} agent(s) are login-expired and would be "
+            f"restarted:[/yellow] {', '.join(r.name for r in would)}\n"
+            "  Nothing was restarted — this is a dry-run. To act:\n"
+            "    sac agents restart-login-expired --apply"
+        )
+    down = outcome.of(Verdict.FAILED, Verdict.OVER_BUDGET)
+    if down:
+        console.print(
+            f"\n[red]{len(down)} agent(s) are STILL wedged and sac could NOT heal "
+            f"them:[/red] {', '.join(r.name for r in down)}\n"
+            "  Each has a board card. A human needs to look — restarting is not "
+            "fixing these (usually a real account problem)."
+        )
+    if outcome.of(Verdict.BUDGET_UNKNOWN):
+        console.print(
+            "\n[magenta]sac could not read its OWN restart history[/magenta] — so "
+            "the debounce and the hourly cap cannot be enforced. It has REFUSED "
+            "to restart anything rather than risk a loop.\n"
+            "  Pin the state somewhere durable:\n"
+            "    export SAC_LOGIN_EXPIRED_HISTORY=/var/tmp/sac-login-expired.json"
+        )
+    raise SystemExit(code)
+
+
+def register(agent_group) -> None:
+    """Attach ``restart-login-expired`` to the parent ``agents`` Click group."""
+    agent_group.add_command(restart_login_expired)
+
+
+__all__ = ["register", "restart_login_expired"]

--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -59,6 +59,7 @@ class _AgentsGroup(HelpRecursiveGroup):
                 "stop",
                 "restart",
                 "reconcile",
+                "restart-login-expired",
                 "rename",
                 "delete",
                 "forget",
@@ -113,6 +114,19 @@ agent_group.add_command(_rebind(_restart_impl, "restart"))
 from ._agents_reconcile import register as _register_reconcile  # noqa: E402
 
 _register_reconcile(agent_group)
+# `restart-login-expired` — the SIBLING enforcer. `reconcile` restarts DEAD
+# (no tmux session) agents; this restarts LIVE ones wedged behind a frozen
+# "Login expired" banner, which reconcile explicitly leaves alone (touching a
+# live session destroys context). Detection is READ-ONLY + 2-run-corroborated;
+# the restart is rate-limited like reconcile and goes through the pool-loading
+# start path so it cannot strip CCT/Telegram tokens. DEPLOY GATE: the scheduled
+# `sac.restart-login-expired-agents` timer must NOT be enabled on a host until
+# that host's auth-heal.py `scan_tui` cron is retired (double-supervisor risk).
+from ._agents_restart_login_expired import (  # noqa: E402
+    register as _register_restart_login_expired,
+)
+
+_register_restart_login_expired(agent_group)
 # `rename` — the ONE verb that moves an agent's name in every place it is
 # written: the spec dir, the spec's own self-references (labels, workdir,
 # overlay path, state-db path, and the SCITEX_TODO_AGENT_ID board

--- a/src/scitex_agent_container/runtimes/_cct_token_pool.py
+++ b/src/scitex_agent_container/runtimes/_cct_token_pool.py
@@ -186,30 +186,36 @@ def _read_env_file(path: Path) -> dict[str, str]:
 
 def _pool_env() -> dict[str, str]:
     """The pool: ``CCT_BOT_TOKEN_*`` vars from the launching env, overlaid
-    with the ``SAC_SECRETS_ENVRC`` secret files (daemon-start path).
+    with the secret files (daemon-start path).
 
-    Reuses :func:`._envrc._capture_env` + the shared preamble so the pool
-    read has EXACTLY the same semantics as the ``.envrc`` fold's secret
-    resolution. Falls back to the plain process env when no secret file is
-    configured/present, and degrades to the process env (rather than
-    failing the deploy) if a listed secret file cannot be sourced — the
-    caller's missing-token ERROR then names the pool source anyway.
+    Resolves the secret files via :func:`._envrc.resolve_secret_files`, which
+    honours an explicit ``SAC_SECRETS_ENVRC`` AND — the 2026-07-18 class fix —
+    falls back to the canonical ``$HOME`` default pool when the var is unset, so
+    a cron / raw-ssh / federated-timer restart that never had the var exported
+    still finds the bot token instead of folding (and STRIPPING) it. Sourced in
+    a strict bash with the same ``set -a`` semantics as the ``.envrc`` fold.
+    Falls back to the plain process env when no secret file resolves, and
+    degrades to the process env (rather than failing the deploy) if a resolved
+    secret file cannot be sourced — the caller's missing-token WARNING then
+    names the pool source anyway.
     """
-    from ._envrc import EnvrcEvalError, _capture_env, _secrets_preamble_lines
+    import shlex
 
-    preamble = _secrets_preamble_lines()
-    if not preamble:
+    from ._envrc import EnvrcEvalError, _capture_env, resolve_secret_files
+
+    files = resolve_secret_files()
+    if not files:
         return dict(os.environ)
+    preamble = [f". {shlex.quote(str(p))}" for p in files]
     try:
         return _capture_env(
             "\n".join(["set -a", *preamble, "set +a", "env -0"]), Path.cwd()
         )
     except EnvrcEvalError as exc:  # stx-allow: fallback (reason: pool read must not abort deploy; missing token is reported loudly by the caller)
         _logger().warning(
-            "cct pool: failed to source %s=%s (%s); falling back to the "
+            "cct pool: failed to source %s (%s); falling back to the "
             "launching process env only.",
-            _SECRETS_ENVRC_VAR,
-            os.environ.get(_SECRETS_ENVRC_VAR, ""),
+            _pool_source_label(),
             exc,
         )
         return dict(os.environ)
@@ -220,9 +226,19 @@ def _pool_source_label() -> str:
     raw = os.environ.get(_SECRETS_ENVRC_VAR, "")
     if raw:
         return f"{_SECRETS_ENVRC_VAR}={raw}"
+    # Class fix (2026-07-18): an unset var no longer means an empty pool — the
+    # resolver falls back to the canonical ``$HOME`` default. Report THAT so the
+    # missing-token WARN names where sac actually looked, not a pool it stopped
+    # limiting itself to.
+    from ._envrc import resolve_secret_files
+
+    defaults = resolve_secret_files()
+    if defaults:
+        joined = ":".join(str(p) for p in defaults)
+        return f"{_SECRETS_ENVRC_VAR} unset — using the canonical default pool {joined}"
     return (
-        f"{_SECRETS_ENVRC_VAR} is UNSET — pool limited to the launching "
-        "process environment"
+        f"{_SECRETS_ENVRC_VAR} is UNSET and no canonical default pool files were "
+        "found — pool limited to the launching process environment"
     )
 
 

--- a/src/scitex_agent_container/runtimes/_envrc.py
+++ b/src/scitex_agent_container/runtimes/_envrc.py
@@ -25,9 +25,28 @@ BOTH the baseline AND the loaded shells, BEFORE everything else. Because the
 secret files' own vars then appear in BOTH shells they are NOT in the diff →
 NOT folded into the agent ``.env`` (no leak); but the per-agent ``.envrc``'s
 references now resolve to the real values and, being NEW/CHANGED keys, ARE
-folded. Unset/empty ``SAC_SECRETS_ENVRC`` ⇒ behaviour is exactly as before. A
-secret file that exists but fails to source still raises (fail-loud); only a
-NON-EXISTENT path is skipped (matching the per-layer skip-if-missing posture).
+folded. A secret file that exists but fails to source still raises (fail-loud);
+only a NON-EXISTENT path is skipped (matching the per-layer skip-if-missing
+posture).
+
+CANONICAL DEFAULT (class fix, 2026-07-18): ``start``/``restart`` used to TRUST
+the caller's environment for the pool — so ``SAC_SECRETS_ENVRC`` had to be set
+by whoever launched the process. It is baked into ``sac-listen.service`` but
+NOT into a cron line, a raw ``ssh`` restart, or a federated ``scitex_dev.jobs``
+timer (JobSpec cannot inject an environment). Any such caller folded EMPTY
+CCT/Telegram tokens and thereby STRIPPED them on redeploy (confirmed live: an
+``auth-heal.py`` cron restart and a raw-ssh restart both stripped cards+hub).
+:func:`resolve_secret_files` is the caller-independent resolver: an explicit
+``SAC_SECRETS_ENVRC`` wins verbatim, and when it is unset/empty it falls back to
+the operator's standardized secret files (``$HOME/.bash.d/secrets/010_scitex/
+*.src``) — the SAME default ``scripts/systemd/install-sac-listen.sh`` computes.
+The CCT pool resolver (``_cct_token_pool._pool_env``) uses it, so any caller
+re-resolves the bot token from the default pool AFTER the fold — no more
+stripping. The general ``.envrc`` fold preamble (:func:`_secrets_preamble_lines`)
+deliberately stays env-ONLY: it runs in a strict bash and must not couple every
+deploy to host ``$HOME`` state; the CCT re-resolution (fail-open) is what heals
+the reported incident. A host without that directory resolves to nothing (a safe
+no-op, exactly as before).
 """
 
 from __future__ import annotations
@@ -50,21 +69,65 @@ _SHELL_NOISE = frozenset({"_", "SHLVL", "PWD", "OLDPWD"})
 # Env var naming the secrets-preamble files (colon-separated absolute paths).
 _SECRETS_ENVRC_VAR = "SAC_SECRETS_ENVRC"
 
+# Canonical default pool location, resolved relative to ``$HOME`` — the SAME
+# glob ``scripts/systemd/install-sac-listen.sh::secrets_envrc_value`` bakes into
+# the listen unit. Used ONLY when ``SAC_SECRETS_ENVRC`` is unset/empty, so the
+# CCT/Telegram pool is found no matter which caller (cron, raw ssh, a federated
+# timer) launched the restart — not just the one process the operator's shell or
+# the listen unit happened to export the var into. See the module docstring.
+_DEFAULT_SECRETS_GLOB = ".bash.d/secrets/010_scitex/*.src"
+
 
 class EnvrcEvalError(RuntimeError):
     """An agent's ``.envrc`` failed to evaluate (fail-loud; aborts deploy)."""
 
 
-def _secrets_preamble_lines() -> list[str]:
-    """Return ``. <path>`` source lines for the ``SAC_SECRETS_ENVRC`` files.
+def resolve_secret_files(
+    *, environ: "dict[str, str] | None" = None, home: "Path | None" = None
+) -> list[Path]:
+    """The secret files the preamble sources, honouring the canonical default.
 
-    Reads the colon-separated absolute paths from ``SAC_SECRETS_ENVRC``,
-    keeps only the entries that currently exist (a non-existent path is
-    skipped — matching the per-layer skip-if-missing posture), and returns
-    one quoted ``. <path>`` line per surviving file. Empty list when the var
-    is unset/empty — so the baseline and loaded scripts are unchanged from
-    pre-preamble behaviour. The same list is spliced into BOTH the baseline
-    and the loaded shell so the secret files' own vars cancel in the diff.
+    Precedence — and the whole point of the 2026-07-18 class fix:
+
+    1. An explicit non-empty ``SAC_SECRETS_ENVRC`` wins VERBATIM: its
+       colon-separated paths, keeping only the entries that currently exist (a
+       non-existent path is skipped — the per-layer skip-if-missing posture).
+       An operator/inherited value is never overridden.
+    2. Otherwise (unset OR empty) fall back to the operator's standardized
+       secret files ``$HOME/.bash.d/secrets/010_scitex/*.src`` (sorted, existing
+       only) — the SAME default the listen-unit installer computes. This is what
+       makes the pool CALLER-INDEPENDENT: a cron/raw-ssh/federated-timer restart
+       that never had the var exported still loads the pool instead of folding
+       (and thereby STRIPPING) every CCT/Telegram token.
+
+    A host without that directory resolves to an empty list — a safe no-op,
+    exactly the pre-fix behaviour for a caller with no pool. ``environ`` / ``home``
+    are injectable so the resolution is unit-testable without touching the real
+    process environment or ``$HOME``.
+    """
+    env = environ if environ is not None else os.environ
+    raw = (env.get(_SECRETS_ENVRC_VAR) or "").strip()
+    if raw:
+        return [Path(e) for e in raw.split(":") if e and Path(e).is_file()]
+    base = Path(home) if home is not None else Path(env.get("HOME") or Path.home())
+    return sorted(p for p in base.glob(_DEFAULT_SECRETS_GLOB) if p.is_file())
+
+
+def _secrets_preamble_lines() -> list[str]:
+    """Return ``. <path>`` source lines from an EXPLICIT ``SAC_SECRETS_ENVRC``.
+
+    Env-ONLY by design (unset var ⇒ empty preamble, unchanged pre-fix
+    behaviour): the general ``.envrc`` fold sources these in a strict
+    ``--noprofile --norc`` bash, so it must stay a pure function of the
+    explicitly-configured var and never couple a deploy to host ``$HOME``
+    state. The canonical ``$HOME`` default fallback lives in
+    :func:`resolve_secret_files` and is applied only by the CCT pool resolver
+    (``_cct_token_pool._pool_env``) — which is fail-open and re-resolves the
+    bot token AFTER the fold, so an unset var no longer strips it.
+
+    The same list is spliced into BOTH the baseline AND the loaded shell so the
+    secret files' own vars cancel in the diff (no leak) while the per-agent
+    ``.envrc``'s references still resolve.
     """
     raw = os.environ.get(_SECRETS_ENVRC_VAR, "")
     lines: list[str] = []
@@ -126,9 +189,7 @@ def eval_envrc(envrc: Path, *, base_env: Path | None = None) -> dict[str, str]:
     return _folded_env(loaded, baseline)
 
 
-def _folded_env(
-    loaded: dict[str, str], baseline: dict[str, str]
-) -> dict[str, str]:
+def _folded_env(loaded: dict[str, str], baseline: dict[str, str]) -> dict[str, str]:
     """Filter a captured ``loaded`` env down to the net ``.env`` contribution.
 
     Applied identically by :func:`eval_envrc` and :func:`eval_envrc_cascade`.
@@ -266,4 +327,5 @@ __all__ = [
     "eval_envrc_cascade",
     "fold_envrc_into_env",
     "fold_envrc_cascade_into_env",
+    "resolve_secret_files",
 ]

--- a/tests/scitex_agent_container/_authheal/_helpers.py
+++ b/tests/scitex_agent_container/_authheal/_helpers.py
@@ -1,0 +1,57 @@
+"""Shared no-mocks helpers for the login-expired auto-restart suites.
+
+Real captured panes (byte-identical to the ones the ``sac agents
+auth-status`` matcher is tested against) and a real restart callable that
+RECORDS instead of restarting — a plain object with the production
+signature, never a mock of the thing under test. The corroboration logic
+(:func:`_authheal._detect.detect_login_expired` → the real
+``evaluate_agents`` matcher) runs for real against these panes.
+"""
+
+from __future__ import annotations
+
+#: A fixed clock. Every suite injects it, so no test can be flaky on time.
+NOW = 1_800_000_000.0
+
+# Wedged: a system auth banner sits directly above the prompt, IDENTICAL on
+# both reads → frozen → corroborated AUTH-FAILED. Same fixture the
+# auth-status matcher suite uses.
+STUCK = "● Login expired · Please run /login\n────────\n❯\n────────\n  ctx:1%\n"
+
+# Healthy: no banner above the prompt.
+OK = "  continuing the task now\n────────\n❯\n────────\n  ctx:1%\n"
+
+
+def stuck(*names: str) -> dict:
+    """``{name: (STUCK, STUCK)}`` — every named agent frozen-login-expired."""
+    return {n: (STUCK, STUCK) for n in names}
+
+
+def transient(*names: str) -> dict:
+    """``{name: (STUCK, OK)}`` — a banner on run 1 that is GONE on run 2.
+
+    The single-run-transient case: it looked login-expired once, but the
+    second (decisive) read is clean, so the frozen check yields OK and the
+    agent must NOT be restarted.
+    """
+    return {n: (STUCK, OK) for n in names}
+
+
+class Recorder:
+    """A real restart callable that records names instead of restarting.
+
+    Not a mock: a plain object with the production ``(name) -> bool``
+    signature. ``names`` is the evidence a test reads to prove a restart did
+    — or, more importantly, did NOT — happen.
+    """
+
+    def __init__(self, *, ok: bool = True, boom: Exception | None = None) -> None:
+        self.names: list[str] = []
+        self._ok = ok
+        self._boom = boom
+
+    def __call__(self, name: str) -> bool:
+        self.names.append(name)
+        if self._boom is not None:
+            raise self._boom
+        return self._ok

--- a/tests/scitex_agent_container/_authheal/conftest.py
+++ b/tests/scitex_agent_container/_authheal/conftest.py
@@ -1,0 +1,42 @@
+"""Real temp state for the login-expired auto-restart suites — no mocks.
+
+Every fixture hands the pass REAL state it can write to and a test can read
+back: an on-disk restart-history file and an on-disk scitex-todo store.
+Detection is capture-driven (injected panes), so — unlike the reconcile
+suite — no state.db or fleet registry is needed here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> str:
+    """A real (initially absent) scitex-todo store path — no mocks."""
+    return str(tmp_path / "tasks.yaml")
+
+
+@pytest.fixture
+def history(tmp_path: Path) -> Path:
+    """The restart-history file. Absent = the first run ever."""
+    return tmp_path / "login-expired-history.json"
+
+
+@pytest.fixture
+def denied_history(tmp_path: Path):
+    """A history path the REAL writer genuinely cannot create. No mocks.
+
+    The parent dir is read-only, so ``_prove_writable`` fails the way it
+    would on a revoked mount — the world says no; nothing is injected. This
+    is what drives the BUDGET-UNKNOWN refusal.
+    """
+    readonly = tmp_path / "readonly"
+    readonly.mkdir()
+    readonly.chmod(0o555)
+    try:
+        yield readonly / "history.json"
+    finally:
+        readonly.chmod(0o755)

--- a/tests/scitex_agent_container/_authheal/test__alarm.py
+++ b/tests/scitex_agent_container/_authheal/test__alarm.py
@@ -8,12 +8,20 @@ board full of stale alarms. Real scitex-todo store, no mocks.
 
 from __future__ import annotations
 
+import pytest
+
 from scitex_agent_container._authheal._alarm import (
     card_id_for,
     route_reports_to_cards,
 )
 from scitex_agent_container._authheal._pass import AgentReport
 from scitex_agent_container._reconcile._rule import Verdict
+
+# Every assertion here reads a card back through the REAL scitex_todo writer, so
+# the whole module needs the board package. It is a runtime dependency that the
+# CI test SIF does not layer in, so skip cleanly there rather than fail — the
+# same guard the sibling ``_reconcile/test__alarm.py`` uses.
+scitex_todo = pytest.importorskip("scitex_todo")
 
 
 def _report(name: str, verdict: Verdict) -> AgentReport:
@@ -22,37 +30,31 @@ def _report(name: str, verdict: Verdict) -> AgentReport:
 
 def test_over_budget_report_creates_a_card(store):
     # Arrange — an agent the restarter has given up on.
-    from scitex_todo import get_task
-
     reports = [_report("hpc", Verdict.OVER_BUDGET)]
     # Act
     route_reports_to_cards(reports, store=store)
     # Assert — the card exists and is a live BLOCKING-YOU alarm.
-    assert get_task(store, card_id_for("hpc"))["status"] == "blocked"
+    assert scitex_todo.get_task(store, card_id_for("hpc"))["status"] == "blocked"
 
 
 def test_restarted_report_resolves_a_prior_card(store):
     # Arrange — first over budget (carded), then successfully restarted.
-    from scitex_todo import get_task
-
     route_reports_to_cards([_report("hpc", Verdict.OVER_BUDGET)], store=store)
     # Act
     route_reports_to_cards([_report("hpc", Verdict.RESTARTED)], store=store)
     # Assert
-    assert get_task(store, card_id_for("hpc"))["status"] == "done"
+    assert scitex_todo.get_task(store, card_id_for("hpc"))["status"] == "done"
 
 
 def test_recovered_agent_no_longer_in_reports_is_resolved(store):
     # Arrange — carded, then the agent recovers on its own (operator logged
     # in) so it is not login-expired anymore and never appears in a later
     # pass's reports at all.
-    from scitex_todo import get_task
-
     route_reports_to_cards([_report("hpc", Verdict.OVER_BUDGET)], store=store)
     # Act — a subsequent pass finds nothing wrong.
     route_reports_to_cards([], store=store)
     # Assert — the stale card is cleared without a human.
-    assert get_task(store, card_id_for("hpc"))["status"] == "done"
+    assert scitex_todo.get_task(store, card_id_for("hpc"))["status"] == "done"
 
 
 def test_over_budget_card_is_reported_as_carded(store):

--- a/tests/scitex_agent_container/_authheal/test__alarm.py
+++ b/tests/scitex_agent_container/_authheal/test__alarm.py
@@ -1,0 +1,64 @@
+"""The board rail: escalate the unhealable, resolve the recovered.
+
+The card is the alternative to an infinite bounce — it must appear when an
+agent is over the hourly cap, and it must go away on its own the moment the
+agent is no longer login-expired, or the operator learns to scroll past a
+board full of stale alarms. Real scitex-todo store, no mocks.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._authheal._alarm import (
+    card_id_for,
+    route_reports_to_cards,
+)
+from scitex_agent_container._authheal._pass import AgentReport
+from scitex_agent_container._reconcile._rule import Verdict
+
+
+def _report(name: str, verdict: Verdict) -> AgentReport:
+    return AgentReport(name=name, verdict=verdict, reason="t", detail="detail")
+
+
+def test_over_budget_report_creates_a_card(store):
+    # Arrange — an agent the restarter has given up on.
+    from scitex_todo import get_task
+
+    reports = [_report("hpc", Verdict.OVER_BUDGET)]
+    # Act
+    route_reports_to_cards(reports, store=store)
+    # Assert — the card exists and is a live BLOCKING-YOU alarm.
+    assert get_task(store, card_id_for("hpc"))["status"] == "blocked"
+
+
+def test_restarted_report_resolves_a_prior_card(store):
+    # Arrange — first over budget (carded), then successfully restarted.
+    from scitex_todo import get_task
+
+    route_reports_to_cards([_report("hpc", Verdict.OVER_BUDGET)], store=store)
+    # Act
+    route_reports_to_cards([_report("hpc", Verdict.RESTARTED)], store=store)
+    # Assert
+    assert get_task(store, card_id_for("hpc"))["status"] == "done"
+
+
+def test_recovered_agent_no_longer_in_reports_is_resolved(store):
+    # Arrange — carded, then the agent recovers on its own (operator logged
+    # in) so it is not login-expired anymore and never appears in a later
+    # pass's reports at all.
+    from scitex_todo import get_task
+
+    route_reports_to_cards([_report("hpc", Verdict.OVER_BUDGET)], store=store)
+    # Act — a subsequent pass finds nothing wrong.
+    route_reports_to_cards([], store=store)
+    # Assert — the stale card is cleared without a human.
+    assert get_task(store, card_id_for("hpc"))["status"] == "done"
+
+
+def test_over_budget_card_is_reported_as_carded(store):
+    # Arrange
+    reports = [_report("hpc", Verdict.OVER_BUDGET)]
+    # Act
+    outcome = route_reports_to_cards(reports, store=store)
+    # Assert
+    assert outcome.carded == ("hpc",)

--- a/tests/scitex_agent_container/_authheal/test__detect.py
+++ b/tests/scitex_agent_container/_authheal/test__detect.py
@@ -1,0 +1,68 @@
+"""The READ-ONLY detector: which live agents are CORROBORATED login-expired.
+
+``detect_login_expired`` is the gate in front of every restart, so its whole
+job is to be conservative: it fires ONLY on a banner that is frozen across
+the two captures (the real ``evaluate_agents`` matcher runs here, unmocked),
+and it must reject a banner that moved, a clean pane, and an unreadable pane.
+A false positive here is a needless restart that destroys a working agent's
+context, so these are the tests that keep the auto-restarter safe.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._authheal._detect import detect_login_expired
+
+from ._helpers import OK, stuck, transient
+
+
+def test_frozen_banner_is_corroborated_login_expired():
+    # Arrange — a banner identical on both reads = frozen = the real thing.
+    captures = stuck("scitex-hpc")
+    # Act
+    names = detect_login_expired(captures)
+    # Assert
+    assert names == ["scitex-hpc"]
+
+
+def test_single_run_transient_banner_is_not_flagged():
+    # Arrange — a banner on run 1 that is GONE on the decisive run 2. The
+    # agent is producing output (working or merely quoting the incident), so
+    # it is NOT wedged and must never be restarted.
+    captures = transient("figrecipe")
+    # Act
+    names = detect_login_expired(captures)
+    # Assert
+    assert names == []
+
+
+def test_clean_pane_is_not_flagged():
+    # Arrange — no banner at all on either read.
+    captures = {"writer": (OK, OK)}
+    # Act
+    names = detect_login_expired(captures)
+    # Assert
+    assert names == []
+
+
+def test_uncapturable_pane_is_not_flagged():
+    # Arrange — a pane we could not READ produced NO evidence. UNKNOWN is not
+    # AUTH-FAILED, so an unread agent is never restarted (absence of evidence
+    # is not evidence of a wedge).
+    captures = {"gone": (None, None)}
+    # Act
+    names = detect_login_expired(captures)
+    # Assert
+    assert names == []
+
+
+def test_only_the_frozen_agents_are_returned_and_sorted():
+    # Arrange — a mixed fleet: two frozen, one transient, one clean.
+    captures = {
+        **stuck("zeta", "alpha"),
+        **transient("mid"),
+        "clean": (OK, OK),
+    }
+    # Act
+    names = detect_login_expired(captures)
+    # Assert — sorted, and ONLY the corroborated ones.
+    assert names == ["alpha", "zeta"]

--- a/tests/scitex_agent_container/_authheal/test__pass.py
+++ b/tests/scitex_agent_container/_authheal/test__pass.py
@@ -12,14 +12,16 @@ and the escalation card that replaces an infinite restart loop.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
+
+import pytest
 
 from scitex_agent_container._authheal._alarm import CARD_ID_PREFIX, card_id_for
 from scitex_agent_container._authheal._pass import auth_heal_pass
 from scitex_agent_container._reconcile._budget import (
     DEBOUNCE_S,
     MAX_RESTARTS_PER_AGENT_PER_HOUR,
+    save_history,
 )
 from scitex_agent_container._reconcile._rule import Verdict
 
@@ -27,7 +29,9 @@ from ._helpers import NOW, Recorder, stuck, transient
 
 
 def _seed_history(path: Path, mapping: dict) -> None:
-    path.write_text(json.dumps(mapping))
+    # Seed via the PRODUCTION writer so the file is byte-identical to what a real
+    # pass persists (every seed stamp is inside the 1h window, so none prunes).
+    save_history(path, mapping, now=NOW)
 
 
 def _run(capture, history, store, rec, **over):
@@ -134,7 +138,9 @@ def test_agent_over_the_hourly_cap_is_not_restarted(history, store):
     # the rolling hour and the debounce has since passed; it is STILL wedged.
     # Restarting is not fixing it — a loop is worse than a down agent. Two
     # stamps within the hour, the newest older than the debounce.
-    stamps = [NOW - 3400, NOW - int(DEBOUNCE_S) - 100][:MAX_RESTARTS_PER_AGENT_PER_HOUR]
+    stamps = [NOW - 3_400, NOW - int(DEBOUNCE_S) - 100][
+        :MAX_RESTARTS_PER_AGENT_PER_HOUR
+    ]
     _seed_history(history, {"hpc": stamps})
     rec = Recorder()
     # Act
@@ -145,7 +151,7 @@ def test_agent_over_the_hourly_cap_is_not_restarted(history, store):
 
 def test_agent_over_the_hourly_cap_reports_over_budget(history, store):
     # Arrange
-    _seed_history(history, {"hpc": [NOW - 3400, NOW - int(DEBOUNCE_S) - 100]})
+    _seed_history(history, {"hpc": [NOW - 3_400, NOW - int(DEBOUNCE_S) - 100]})
     rec = Recorder()
     # Act
     outcome = _run(stuck("hpc"), history, store, rec)
@@ -156,14 +162,15 @@ def test_agent_over_the_hourly_cap_reports_over_budget(history, store):
 def test_over_budget_agent_is_escalated_to_a_board_card(history, store):
     # Arrange — the whole point of the cap: instead of bouncing forever, the
     # agent that cannot be healed is handed to a human via an idempotent card.
-    from scitex_todo import list_tasks
-
-    _seed_history(history, {"hpc": [NOW - 3400, NOW - int(DEBOUNCE_S) - 100]})
+    # This ONE test needs the real board writer; skip cleanly where the CI test
+    # SIF has not layered scitex_todo in (the rest of this module does not).
+    scitex_todo = pytest.importorskip("scitex_todo")
+    _seed_history(history, {"hpc": [NOW - 3_400, NOW - int(DEBOUNCE_S) - 100]})
     rec = Recorder()
     # Act
     _run(stuck("hpc"), history, store, rec, alarm=True)
     # Assert — exactly one escalation card, for this agent.
-    ids = [c["id"] for c in list_tasks(store, id_prefix=CARD_ID_PREFIX)]
+    ids = [c["id"] for c in scitex_todo.list_tasks(store, id_prefix=CARD_ID_PREFIX)]
     assert ids == [card_id_for("hpc")]
 
 

--- a/tests/scitex_agent_container/_authheal/test__pass.py
+++ b/tests/scitex_agent_container/_authheal/test__pass.py
@@ -1,0 +1,190 @@
+"""One login-expired auto-restart pass, end to end, with real state.
+
+Detection (the real ``evaluate_agents`` corroboration) runs against injected
+panes; the ONE irreversible act (the restart) is a recording callable, and
+the budget/history/cards are real on-disk state. No mocks of anything under
+test.
+
+The load-bearing safety property is that a persistently-failing agent is
+CARDED, never bounced forever: these tests pin the debounce, the hourly cap,
+and the escalation card that replaces an infinite restart loop.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scitex_agent_container._authheal._alarm import CARD_ID_PREFIX, card_id_for
+from scitex_agent_container._authheal._pass import auth_heal_pass
+from scitex_agent_container._reconcile._budget import (
+    DEBOUNCE_S,
+    MAX_RESTARTS_PER_AGENT_PER_HOUR,
+)
+from scitex_agent_container._reconcile._rule import Verdict
+
+from ._helpers import NOW, Recorder, stuck, transient
+
+
+def _seed_history(path: Path, mapping: dict) -> None:
+    path.write_text(json.dumps(mapping))
+
+
+def _run(capture, history, store, rec, **over):
+    kwargs = dict(
+        apply=True,
+        alarm=False,
+        now=NOW,
+        history_file=history,
+        store=store,
+        capture_fn=lambda: capture,
+        restart_fn=rec,
+    )
+    kwargs.update(over)
+    return auth_heal_pass(**kwargs)
+
+
+def _verdict(outcome, name: str) -> Verdict:
+    return next(r.verdict for r in outcome.reports if r.name == name)
+
+
+# --- the happy path: a corroborated wedge is restarted --------------------
+
+
+def test_corroborated_login_expired_agent_is_restarted(history, store):
+    # Arrange — one frozen-banner agent, empty history (first sight).
+    rec = Recorder()
+    # Act
+    _run(stuck("hpc"), history, store, rec)
+    # Assert — the single irreversible act happened, exactly once, for it.
+    assert rec.names == ["hpc"]
+
+
+def test_corroborated_agent_reports_restarted(history, store):
+    # Arrange
+    rec = Recorder()
+    # Act
+    outcome = _run(stuck("hpc"), history, store, rec)
+    # Assert
+    assert _verdict(outcome, "hpc") == Verdict.RESTARTED
+
+
+# --- the safety gate: a transient / single-run flag is NOT restarted ------
+
+
+def test_single_run_transient_agent_is_not_restarted(history, store):
+    # Arrange — a banner on run 1, gone on the decisive run 2: not frozen.
+    rec = Recorder()
+    # Act
+    _run(transient("figrecipe"), history, store, rec)
+    # Assert — no restart, because it was never corroborated.
+    assert rec.names == []
+
+
+# --- dry-run / --check: report, never act ---------------------------------
+
+
+def test_check_mode_does_not_restart(history, store):
+    # Arrange — apply=False is the dry-run the `--check` flag selects.
+    rec = Recorder()
+    # Act
+    _run(stuck("hpc"), history, store, rec, apply=False)
+    # Assert
+    assert rec.names == []
+
+
+def test_check_mode_reports_would_restart(history, store):
+    # Arrange
+    rec = Recorder()
+    # Act
+    outcome = _run(stuck("hpc"), history, store, rec, apply=False)
+    # Assert
+    assert _verdict(outcome, "hpc") == Verdict.WOULD_RESTART
+
+
+# --- the debounce bound: a just-restarted agent is left to boot ------------
+
+
+def test_agent_inside_the_debounce_is_not_restarted_again(history, store):
+    # Arrange — restarted 100s ago; still login-expired, but restarting again
+    # now would kill the recovery in progress.
+    _seed_history(history, {"hpc": [NOW - 100]})
+    rec = Recorder()
+    # Act
+    _run(stuck("hpc"), history, store, rec)
+    # Assert
+    assert rec.names == []
+
+
+def test_agent_inside_the_debounce_reports_cooling_down(history, store):
+    # Arrange
+    _seed_history(history, {"hpc": [NOW - 100]})
+    rec = Recorder()
+    # Act
+    outcome = _run(stuck("hpc"), history, store, rec)
+    # Assert
+    assert _verdict(outcome, "hpc") == Verdict.COOLING_DOWN
+
+
+# --- the hourly cap: persistently failing → card, NOT an infinite bounce ---
+
+
+def test_agent_over_the_hourly_cap_is_not_restarted(history, store):
+    # Arrange — already restarted MAX_RESTARTS_PER_AGENT_PER_HOUR times inside
+    # the rolling hour and the debounce has since passed; it is STILL wedged.
+    # Restarting is not fixing it — a loop is worse than a down agent. Two
+    # stamps within the hour, the newest older than the debounce.
+    stamps = [NOW - 3400, NOW - int(DEBOUNCE_S) - 100][:MAX_RESTARTS_PER_AGENT_PER_HOUR]
+    _seed_history(history, {"hpc": stamps})
+    rec = Recorder()
+    # Act
+    _run(stuck("hpc"), history, store, rec)
+    # Assert — the loop is refused.
+    assert rec.names == []
+
+
+def test_agent_over_the_hourly_cap_reports_over_budget(history, store):
+    # Arrange
+    _seed_history(history, {"hpc": [NOW - 3400, NOW - int(DEBOUNCE_S) - 100]})
+    rec = Recorder()
+    # Act
+    outcome = _run(stuck("hpc"), history, store, rec)
+    # Assert
+    assert _verdict(outcome, "hpc") == Verdict.OVER_BUDGET
+
+
+def test_over_budget_agent_is_escalated_to_a_board_card(history, store):
+    # Arrange — the whole point of the cap: instead of bouncing forever, the
+    # agent that cannot be healed is handed to a human via an idempotent card.
+    from scitex_todo import list_tasks
+
+    _seed_history(history, {"hpc": [NOW - 3400, NOW - int(DEBOUNCE_S) - 100]})
+    rec = Recorder()
+    # Act
+    _run(stuck("hpc"), history, store, rec, alarm=True)
+    # Assert — exactly one escalation card, for this agent.
+    ids = [c["id"] for c in list_tasks(store, id_prefix=CARD_ID_PREFIX)]
+    assert ids == [card_id_for("hpc")]
+
+
+# --- can't read our own memory → refuse, never a blind loop ---------------
+
+
+def test_unreadable_budget_refuses_to_restart(denied_history, store):
+    # Arrange — the restart history cannot be created, so the debounce/cap are
+    # unenforceable. Restarting anyway would make every wedge restartable on
+    # every tick, forever — the exact loop the budget exists to prevent.
+    rec = Recorder()
+    # Act
+    _run(stuck("hpc"), denied_history, store, rec)
+    # Assert
+    assert rec.names == []
+
+
+def test_unreadable_budget_reports_budget_unknown(denied_history, store):
+    # Arrange
+    rec = Recorder()
+    # Act
+    outcome = _run(stuck("hpc"), denied_history, store, rec)
+    # Assert
+    assert _verdict(outcome, "hpc") == Verdict.BUDGET_UNKNOWN

--- a/tests/scitex_agent_container/cli_pkg/test__agents_restart_login_expired.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_restart_login_expired.py
@@ -1,0 +1,72 @@
+"""``sac agents restart-login-expired`` — command wiring, help, arg validation.
+
+The command is a thin shell over :func:`.._authheal.auth_heal_pass` (whose
+behaviour is exercised in depth, with injected panes and a real temp store, in
+``tests/scitex_agent_container/_authheal/``). Here we pin only the CLI surface:
+it is registered, its help documents the two modes AND the deploy gate, and the
+contradictory-flags guard fires BEFORE any pass runs (so these tests never touch
+real tmux or the real board).
+
+No mocks: a real Click invocation against the real ``agents`` group.
+"""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.agent_group import agent_group
+
+
+def test_command_registered_under_agents_group():
+    # Arrange
+    group = agent_group
+    # Act
+    registered = "restart-login-expired" in group.commands
+    # Assert
+    assert registered is True
+
+
+def test_help_renders_apply_option():
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(agent_group, ["restart-login-expired", "--help"])
+    # Assert
+    assert "--apply" in result.output
+
+
+def test_help_renders_check_option():
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(agent_group, ["restart-login-expired", "--help"])
+    # Assert
+    assert "--check" in result.output
+
+
+def test_help_warns_about_the_deploy_gate():
+    # Arrange — the double-supervisor hazard must be impossible to miss.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(agent_group, ["restart-login-expired", "--help"])
+    # Assert
+    assert "DEPLOY GATE" in result.output
+
+
+def test_apply_and_check_are_contradictory():
+    # Arrange — the guard must fire before any pass runs, so this never touches
+    # tmux or the board.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(agent_group, ["restart-login-expired", "--apply", "--check"])
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_apply_and_check_error_explains_why():
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(agent_group, ["restart-login-expired", "--apply", "--check"])
+    # Assert
+    assert "contradictory" in result.output

--- a/tests/scitex_agent_container/runtimes/test__cct_token_pool.py
+++ b/tests/scitex_agent_container/runtimes/test__cct_token_pool.py
@@ -214,6 +214,52 @@ def test_empty_pool_value_is_treated_as_missing(
 
 
 # ---------------------------------------------------------------------------
+# caller-independent pool: the canonical $HOME default (class fix 2026-07-18)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path) -> Iterator[Path]:
+    """Point ``$HOME`` at a real temp dir (save/restore) — no monkeypatch.
+
+    So the canonical-default resolver globs THIS dir, never the operator's real
+    ``~/.bash.d/secrets`` — the test stays deterministic on every host.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(home)
+    try:
+        yield home
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def test_pool_resolves_from_canonical_default_when_var_unset(
+    tmp_path: Path, secrets_envrc: None, isolated_home: Path
+) -> None:
+    # Arrange — SAC_SECRETS_ENVRC UNSET (the cron / raw-ssh / federated-timer
+    # case that stripped tokens tonight), but the operator's standardized default
+    # pool file exists under $HOME. The class fix must resolve the token from
+    # there instead of folding it EMPTY — the whole point of the fix.
+    os.environ.pop(_SECRETS_VAR, None)
+    pooldir = isolated_home / ".bash.d" / "secrets" / "010_scitex"
+    pooldir.mkdir(parents=True)
+    (pooldir / "01_cct.src").write_text(
+        "export CCT_BOT_TOKEN_ZZ_DEFAULT=tok-default\n", encoding="utf-8"
+    )
+    dest = tmp_path / "workspace-home"
+    dest.mkdir()
+    # Act — no SAC_SECRETS_ENVRC set anywhere; only the default location has it.
+    ensure_cct_bot_token(_cfg("zz-default"), dest)
+    # Assert — the token is loaded from the canonical default pool, NOT stripped.
+    assert "CCT_BOT_TOKEN=tok-default" in (dest / ".env").read_text()
+
+
+# ---------------------------------------------------------------------------
 # injected .env contents
 # ---------------------------------------------------------------------------
 

--- a/tests/scitex_agent_container/runtimes/test__envrc.py
+++ b/tests/scitex_agent_container/runtimes/test__envrc.py
@@ -24,9 +24,67 @@ from scitex_agent_container.runtimes._envrc import (
     eval_envrc_cascade,
     fold_envrc_cascade_into_env,
     fold_envrc_into_env,
+    resolve_secret_files,
 )
 
 _SECRETS_VAR = "SAC_SECRETS_ENVRC"
+
+
+def _seed_default_pool(home: Path, *names: str) -> list[Path]:
+    """Create ``$HOME/.bash.d/secrets/010_scitex/<name>`` real files."""
+    d = home / ".bash.d" / "secrets" / "010_scitex"
+    d.mkdir(parents=True)
+    out: list[Path] = []
+    for n in names:
+        f = d / n
+        f.write_text("# secret\n", encoding="utf-8")
+        out.append(f)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# resolve_secret_files — the caller-independent-pool class fix (2026-07-18)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_secret_files_honours_explicit_var(tmp_path: Path) -> None:
+    # Arrange — an explicit SAC_SECRETS_ENVRC wins verbatim over any default.
+    explicit = tmp_path / "explicit.src"
+    explicit.write_text("# s\n", encoding="utf-8")
+    _seed_default_pool(tmp_path, "01_default.src")
+    env = {"SAC_SECRETS_ENVRC": str(explicit)}
+    # Act
+    files = resolve_secret_files(environ=env, home=tmp_path)
+    # Assert
+    assert files == [explicit]
+
+
+def test_resolve_secret_files_falls_back_to_canonical_default(tmp_path: Path) -> None:
+    # Arrange — the var is UNSET (the cron / raw-ssh / timer case), but the
+    # operator's standardized secret files exist under $HOME.
+    seeded = _seed_default_pool(tmp_path, "01_a.src", "02_b.src")
+    # Act — no SAC_SECRETS_ENVRC in the environment at all.
+    files = resolve_secret_files(environ={}, home=tmp_path)
+    # Assert — the canonical default is loaded (sorted), so the pool is found
+    # even though nobody exported the var.
+    assert files == sorted(seeded)
+
+
+def test_resolve_secret_files_empty_var_uses_default(tmp_path: Path) -> None:
+    # Arrange — a stray blank export is not a real value; treat as unset.
+    seeded = _seed_default_pool(tmp_path, "01_a.src")
+    # Act
+    files = resolve_secret_files(environ={"SAC_SECRETS_ENVRC": ""}, home=tmp_path)
+    # Assert
+    assert files == seeded
+
+
+def test_resolve_secret_files_no_pool_is_a_safe_noop(tmp_path: Path) -> None:
+    # Arrange — no var and no default directory: a host with no pool.
+    # Act
+    files = resolve_secret_files(environ={}, home=tmp_path)
+    # Assert — empty, exactly the pre-fix behaviour (never a raise).
+    assert files == []
 
 
 @pytest.fixture

--- a/tests/scitex_agent_container/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/test__jobs_plugin.py
@@ -46,15 +46,16 @@ def _job(name: str):
     return match
 
 
-def test_provider_returns_four_jobs() -> None:
-    # Arrange — call the registered provider. Four: accounts-refresh, the
-    # host-sync-check drift alarm, the daily worktree GC, and the
-    # fleet-reconcile enforcer. `sac listen` is still NOT federated (see the
-    # module docstring and the absence-pin below).
+def test_provider_returns_five_jobs() -> None:
+    # Arrange — call the registered provider. Five: accounts-refresh, the
+    # host-sync-check drift alarm, the daily worktree GC, the fleet-reconcile
+    # enforcer (dead/no-session corpses), and the restart-login-expired-agents
+    # timer (live-session-but-auth-dead agents). `sac listen` is still NOT
+    # federated (see the module docstring and the absence-pin below).
     # Act
     jobs = provide_jobs()
     # Assert
-    assert len(jobs) == 4
+    assert len(jobs) == 5
 
 
 def test_provider_jobs_are_real_jobspecs() -> None:
@@ -306,3 +307,61 @@ def test_fleet_reconcile_timeout_outlives_a_capped_pass() -> None:
     job = _job("sac.fleet-reconcile")
     # Assert
     assert job.timeout_sec == 300
+
+
+# ---------------------------------------------------------------------------
+# sac.restart-login-expired-agents — the SIBLING enforcer. fleet-reconcile
+# owns dead/no-session corpses; this timer owns the OTHER half fleet-reconcile
+# explicitly leaves alone: a LIVE tmux session whose Claude cannot authenticate
+# (a frozen "Login expired" banner), which only a restart clears. Named
+# verb+object so the derived units read `sac.restart-login-expired-agents
+# .timer` / `.service` — no "timer" in the name (systemd's suffix already
+# conveys periodicity; embedding it would double to `.timer.timer`).
+# ---------------------------------------------------------------------------
+
+
+def test_restart_login_expired_job_name_is_package_prefixed() -> None:
+    # Arrange — the auto-restarter for auth-dead-but-live agents.
+    # Act
+    job = _job("sac.restart-login-expired-agents")
+    # Assert
+    assert job.name == "sac.restart-login-expired-agents"
+
+
+def test_restart_login_expired_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer, so kind="timer". A wrong kind
+    # raises at construction and `ecosystem up` then silently DROPS sac's whole
+    # provider (provider-isolated, WARN-only) — taking the OAuth refresh, the
+    # drift check, the worktree GC AND the fleet-reconcile enforcer down too.
+    # Act
+    job = _job("sac.restart-login-expired-agents")
+    # Assert
+    assert job.kind == "timer"
+
+
+def test_restart_login_expired_command_is_the_applying_form() -> None:
+    # Arrange — a scheduled DRY-RUN would detect wedged agents and heal none.
+    # The whole point is `--apply`. Detection stays read-only; the restart is
+    # the only mutation.
+    # Act
+    job = _job("sac.restart-login-expired-agents")
+    # Assert
+    assert job.command == "sac agents restart-login-expired --apply"
+
+
+def test_restart_login_expired_cadence_is_five_minutes() -> None:
+    # Arrange — the cadence IS the window a login-expired agent stays wedged,
+    # matched to fleet-reconcile so the two enforcers sweep on the same beat.
+    # Act
+    job = _job("sac.restart-login-expired-agents")
+    # Assert
+    assert job.on_unit_active_sec == "5min"
+
+
+def test_restart_login_expired_constructs_as_a_real_jobspec() -> None:
+    # Arrange — construction must not raise (a bad field would drop the whole
+    # provider). Assert it is the canonical contract type, not a look-alike.
+    # Act
+    job = _job("sac.restart-login-expired-agents")
+    # Assert
+    assert isinstance(job, jobs_mod.JobSpec)


### PR DESCRIPTION
## What

Per the 2026-07-18 operator directive, two things:

1. **A federated login-expired auto-restarter** for LIVE agents wedged behind a frozen `Login expired` banner — the half `sac.fleet-reconcile` explicitly leaves alone (reconcile only restarts DEAD/no-session corpses; a live session holds context).
2. **A class fix** for the root cause of tonight's CCT/Telegram token stripping: `sac start/restart` trusted the *caller's* environment for the bot-token pool.

## New surface

- **`sac agents restart-login-expired [--apply | --check]`** — READ-ONLY, 2-run-corroborated detection (reuses the `sac agents auth-status` near-prompt + distance-frozen matcher, so a banner that MOVED between the two captures = working/quoting, never restarted). Restart via the pool-loading `agent_restart` path. Reconcile's exact rate-limits (30 min/agent debounce, ≤2/agent/hour, ≤10/pass). An agent still wedged after the cap gets an idempotent scitex-todo escalation card — never an infinite bounce. `--check` (default) reports what it WOULD restart without acting.
- **JobSpec `sac.restart-login-expired-agents`** (`kind="timer"`, 5 min) in `_jobs_plugin.py`, sibling to `sac.fleet-reconcile`. Division of labor documented inline: fleet-reconcile = dead/no-session; this = live-session-but-auth-dead.
- **`_authheal/`** package (`_detect`/`_pass`/`_alarm`) reusing `_reconcile._budget` + `_reconcile._rule.Verdict`; its own history file (`SAC_LOGIN_EXPIRED_HISTORY`) so the two restarters' debounces stay independent and never race on one file.

## Class fix — caller-independent pool

A federated `scitex_dev.jobs` timer cannot inject an env var (JobSpec has no Environment field), and `SAC_SECRETS_ENVRC` is baked only into the hand-written `sac-listen.service` — not into a cron line, a raw `ssh` restart, or a timer. Any such caller folded EMPTY CCT/Telegram tokens and thereby **stripped** them on redeploy.

`runtimes/_envrc.resolve_secret_files` now falls back to the canonical `$HOME/.bash.d/secrets/010_scitex/*.src` default (the SAME default `scripts/systemd/install-sac-listen.sh` computes) when `SAC_SECRETS_ENVRC` is unset; `_cct_token_pool._pool_env` uses it, so **any** caller re-resolves the token after the fold. An explicit `SAC_SECRETS_ENVRC` still wins verbatim; a host without that dir resolves to nothing (safe no-op). This fixes the whole class, not just the new timer.

## ⚠️ DEPLOY GATE — do not enable the timer yet

An existing `auth-heal.py` cron (`scan_tui`, `*/10`) **already** restarts these agents (2-run-corroborated TUI heal, since 2026-06-01). Enabling this timer while that cron runs = **two restarters** bouncing the same `tui-<agent>` sessions with independent debounce state = the `sac.listen` double-supervisor class in another costume.

This JobSpec is declared so the mechanism is version-controlled and tested, but **it MUST NOT be enabled on a host until that host's `auth-heal.py` `scan_tui` is retired.** The crontab is host state a PR cannot edit, so the retirement is an operator/dotfiles step that must land *with* the enable. Documented loudly in `_jobs_plugin`, `_authheal/_pass`, and the CLI help. **PR-only — do not merge/enable until coordinated.**

## Tests (RED → GREEN, real objects, no mocks of the thing under test)

- RED: with `_authheal/` absent, all three test modules fail to collect (`ModuleNotFoundError: No module named 'scitex_agent_container._authheal'`).
- GREEN: 146 passed, 2 skipped (pre-existing). Includes:
  - corroborated login-expired → restart issued; single-run transient → NOT restarted; persistently-failing → escalation card + restart bounded by the debounce/hourly cap (no infinite bounce); budget-unreadable → refuse.
  - class fix: unset `SAC_SECRETS_ENVRC` + default pool file under a temp `$HOME` → token resolved (not stripped); explicit var still wins; no-pool = safe no-op.
  - the new JobSpec is present, `kind=timer` valid, command `sac agents restart-login-expired --apply`, and constructs against the real installed `scitex_dev.jobs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqhsrw29CM4siBLcEK2CwV
