### PR TITLE
fix(image): bake ships the source, not a stale wheel — uv --no-cache-dir + content assert + rename-correct gate

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -407,7 +407,18 @@ From: ubuntu:24.04
     # runtimes/_apptainer_provider.py). The extra's version floor lives
     # in pyproject.toml (SSoT); the bracket syntax on the local source
     # path resolves it through the bundled tree's own metadata.
-    uv pip install --python /opt/venv-sac/bin/python \
+    #
+    # --no-cache-dir forces a REBUILD from the staged source rather than a
+    # reuse of uv's built-wheel cache. That cache is keyed on (name,
+    # version) — NOT on content — and sac's version does NOT advance
+    # per-commit (importlib.metadata reports the last RELEASED version even
+    # for brand-new bundled source). So without this flag uv serves a
+    # byte-identical STALE wheel from a prior bake and the new source never
+    # ships: a green build carrying OLD code. --force-reinstall reinstalls
+    # but REUSES the cached wheel; only --no-cache-dir rebuilds from source.
+    # (Two bakers hit exactly this — the image's _cct_token_pool.py was
+    # byte-identical to the pre-#742 source while the tree was at HEAD.)
+    uv pip install --no-cache-dir --python /opt/venv-sac/bin/python \
         "claude-agent-sdk" \
         "scitex-cards[mcp]>=0.16.0" \
         "/opt/scitex-agent-container-src[openai]"
@@ -473,7 +484,19 @@ import sys
 # `in_progress` ONLY. Below it, every agent's WIP gate counts DEFERRED +
 # CANCELLED cards as open and refuses legitimate card creation — the
 # 2026-07-12 fleet-drift incident this gate exists to end.
-from scitex_todo._throughput import WIP_STATUSES
+#
+# Package renamed scitex-cards (2026-07-16): the canonical module is
+# scitex_cards; the wheel ALSO ships a scitex_todo shim that must alias
+# to the SAME module objects — un-cutover fleet code imports the old
+# name, so the shim working is itself a ship-gate for this image.
+from scitex_cards._throughput import WIP_STATUSES
+
+import scitex_cards
+import scitex_todo  # the transition shim — its absence breaks the fleet
+
+if scitex_todo is not scitex_cards:
+    print("FATAL: scitex_todo shim is not scitex_cards — two module trees baked")
+    sys.exit(1)
 
 # sac #633: auto-provisions a new agent's container overlay root; without
 # it every newly-created agent is stillborn on a raw apptainer FATAL.
@@ -484,8 +507,8 @@ from scitex_todo._throughput import WIP_STATUSES
 from scitex_agent_container.runtimes._apptainer_overlay import ensure_overlay_dirs
 
 # Printed for the BUILD LOG only — these numbers are NOT the gate.
-print("scitex-todo reported version :", md.version("scitex-todo"))
-print("scitex-todo WIP_STATUSES     :", sorted(WIP_STATUSES))
+print("scitex-cards reported version:", md.version("scitex-cards"))
+print("scitex-cards WIP_STATUSES    :", sorted(WIP_STATUSES))
 print("sac reported version         :", md.version("scitex-agent-container"))
 print(
     "sac overlay auto-provision   :",
@@ -493,6 +516,35 @@ print(
 )
 
 failures = []
+
+# The version string lies (uv's wheel cache is version-keyed and sac's
+# version does not advance per-commit). File content cannot lie: this
+# compares the INSTALLED sac tree to the STAGED source tree — a stale
+# wheel makes them differ. Generic on purpose: it names no feature, so a
+# rename or decoupling never breaks it.
+import hashlib as _hashlib, pathlib as _pathlib
+import scitex_agent_container as _sac
+_installed_root = _pathlib.Path(_sac.__file__).parent
+_staged_root = _pathlib.Path("/opt/scitex-agent-container-src/src/scitex_agent_container")
+def _tree_sha(root):
+    h = _hashlib.sha256()
+    for p in sorted(root.rglob("*.py")):
+        h.update(p.relative_to(root).as_posix().encode())
+        h.update(p.read_bytes())
+    return h.hexdigest()
+_di = _tree_sha(_installed_root)
+if _staged_root.is_dir():
+    _ds = _tree_sha(_staged_root)
+    print("installed sac .py tree sha  :", _di[:16])
+    print("staged   sac .py tree sha  :", _ds[:16])
+    if _di != _ds:
+        failures.append(
+            "installed sac (%s) != staged source (%s) — uv served a STALE "
+            "wheel; the fix did NOT ship. Add/verify --no-cache-dir on the "
+            "sac install." % (_di[:12], _ds[:12])
+        )
+else:
+    print("NOTE: staged source not at /opt/scitex-agent-container-src; content assert skipped")
 
 # The WIP gate counts work IN FLIGHT, and only that. Terminal/parked
 # states must never occupy a WIP slot.
@@ -508,7 +560,7 @@ if terminal:
 # Exactly one installed distribution may claim each name. Two (an
 # orphaned .dist-info left by a partial reinstall) is the failure mode
 # that lets the reported version diverge from the code.
-for name in ("scitex-todo", "scitex-agent-container"):
+for name in ("scitex-cards", "scitex-agent-container"):
     dists = [
         dist
         for dist in md.distributions()
@@ -526,7 +578,7 @@ if failures:
         print(f"  - {line}", file=sys.stderr)
     sys.exit(1)
 
-print("OK: scitex-todo WIP-gate + sac overlay symbols present and correct.")
+print("OK: scitex-cards WIP-gate + scitex_todo shim + sac overlay + staged-source content present and correct.")
 EOF
     /opt/venv-sac/bin/python /tmp/sac-assert-image-fresh.py \
         || { echo "FATAL: stale or wrong-tree package baked into this image (see above). Raise the floor / fix the staging; do NOT weaken this gate." >&2; exit 1; }

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -142,7 +142,14 @@ From: ./sac-base.sif
             "openai-agents>=0.17.4" \
             "scitex[all]" \
             xarray
-        uv pip install --python /opt/venv-sac/bin/python \
+        # --no-cache-dir forces a REBUILD from the %files-staged source, not a
+        # reuse of uv's built-wheel cache. That cache is keyed on (name,
+        # version) — NOT on content — and sac's version does NOT advance
+        # per-commit, so without it uv serves a byte-identical STALE wheel from
+        # a prior bake and --force-reinstall merely reinstalls THAT stale wheel
+        # (it reinstalls but does not rebuild). Only --no-cache-dir rebuilds, so
+        # the staged source actually ships. Mirrors the pip-fallback below.
+        uv pip install --no-cache-dir --python /opt/venv-sac/bin/python \
             --force-reinstall --no-deps \
             /opt/scitex-agent-container-src
         # scitex-dev keystone (system-deps aggregator) + the 3 leaf providers,
@@ -330,6 +337,35 @@ print(
 
 failures = []
 
+# The version string lies (uv's wheel cache is version-keyed and sac's
+# version does not advance per-commit). File content cannot lie: this
+# compares the INSTALLED sac tree to the STAGED source tree — a stale
+# wheel makes them differ. Generic on purpose: it names no feature, so a
+# rename or decoupling never breaks it.
+import hashlib as _hashlib, pathlib as _pathlib
+import scitex_agent_container as _sac
+_installed_root = _pathlib.Path(_sac.__file__).parent
+_staged_root = _pathlib.Path("/opt/scitex-agent-container-src/src/scitex_agent_container")
+def _tree_sha(root):
+    h = _hashlib.sha256()
+    for p in sorted(root.rglob("*.py")):
+        h.update(p.relative_to(root).as_posix().encode())
+        h.update(p.read_bytes())
+    return h.hexdigest()
+_di = _tree_sha(_installed_root)
+if _staged_root.is_dir():
+    _ds = _tree_sha(_staged_root)
+    print("installed sac .py tree sha  :", _di[:16])
+    print("staged   sac .py tree sha  :", _ds[:16])
+    if _di != _ds:
+        failures.append(
+            "installed sac (%s) != staged source (%s) — uv served a STALE "
+            "wheel; the fix did NOT ship. Add/verify --no-cache-dir on the "
+            "sac install." % (_di[:12], _ds[:12])
+        )
+else:
+    print("NOTE: staged source not at /opt/scitex-agent-container-src; content assert skipped")
+
 # The WIP gate counts work IN FLIGHT, and only that. Terminal/parked
 # states must never occupy a WIP slot.
 if "in_progress" not in WIP_STATUSES:
@@ -344,7 +380,7 @@ if terminal:
 # Exactly one installed distribution may claim each name. Two (an
 # orphaned .dist-info left by a partial reinstall) is the failure mode
 # that lets the reported version diverge from the code.
-for name in ("scitex-todo", "scitex-agent-container"):
+for name in ("scitex-cards", "scitex-agent-container"):
     dists = [
         dist
         for dist in md.distributions()
@@ -362,7 +398,7 @@ if failures:
         print(f"  - {line}", file=sys.stderr)
     sys.exit(1)
 
-print("OK: scitex-todo WIP-gate + sac overlay symbols present and correct.")
+print("OK: scitex-cards WIP-gate + scitex_todo shim + sac overlay + staged-source content present and correct.")
 EOF
     /opt/venv-sac/bin/python /tmp/sac-assert-image-fresh.py \
         || { echo "FATAL: stale or wrong-tree package baked into this image (see above). Raise the floor / fix the staging; do NOT weaken this gate." >&2; exit 1; }


### PR DESCRIPTION
## The bug

`sac image build` produced a SIF that reported success but installed **pre-#742 sac code** — the `_cct_token_pool.py` inside the image was byte-identical to the pre-#742 source while the staged source tree was at HEAD.

**Root cause — uv's version-keyed built-wheel cache.** uv caches built wheels keyed on `(name, version)`, *not* on content. sac's metadata version does **not** advance per-commit (`importlib.metadata` reports `0.21.21` even for #742/#748 source). So the uv install of the `%files`-staged sac source served a **stale wheel** from a prior build instead of rebuilding from the newly staged tree. `--force-reinstall` reinstalls but *reuses* the cached wheel — it does not force a rebuild. `--no-cache-dir` **does** force a fresh build from source.

**Two independent bakers confirmed it:** the image's `_cct_token_pool.py` == the pre-#742 sha while the source tree == HEAD. A green build, shipping old code, silently.

## The fix (both `apptainer-base.def` and `apptainer-scitex.def`)

**1. Cache-bypass on the uv sac-source installs (the core fix).** Added `--no-cache-dir` to the uv `pip install` of the staged sac source:
- `base.def`: the `uv pip install … "/opt/scitex-agent-container-src[openai]"`.
- `scitex.def` uv branch: the `--force-reinstall --no-deps /opt/scitex-agent-container-src` install (kept `--force-reinstall --no-deps`).

The pip-fallback branches already carried `--no-cache-dir` and are untouched. Each recipe's nearby comment now explains that `--no-cache-dir` forces a rebuild because the wheel cache is version-keyed and sac's version does not advance per-commit — otherwise a stale wheel is served.

**2. Generic installed-vs-staged content assert, folded into the existing freshness gate (both recipes).** The version string lies; **file content cannot**. After `failures = []` and before `if failures:`, each gate now sha256s the *installed* sac `.py` tree and the *staged* source `.py` tree and appends a failure if they differ — which is exactly what a stale wheel produces. It is deliberately **generic**: it names no feature (no CCT coupling), so a rename or decoupling never breaks it. Falls back to a printed NOTE (skip) if the staged source is not present, so it never false-fails outside a source bake.

**3. Rename-correct gate: `scitex-todo` → `scitex-cards`.** The board package was renamed `scitex-todo` → `scitex-cards` (2026-07-16); `scitex-todo` is now a metadata-only shim, so `md.version("scitex-todo")` raises `PackageNotFoundError` — the **fatal a fresh base bake hit**. `scitex.def`'s gate was already mostly migrated; this mirrors that exact pattern into `base.def`'s gate (the `WIP_STATUSES` import, the `import scitex_cards` / `import scitex_todo` shim-alias assert, `md.version("scitex-cards")`, the dist-count loop, and the OK message). It also fixes the **latent twin bug** in `scitex.def`'s dist-count loop, which still named `scitex-todo`.

## Verification

- Extracted each gate's embedded Python (the `cat <<'EOF' … EOF` body) and ran `python -m py_compile` — **both compile cleanly**, including the new content-assert block. The two extracted gate bodies are now **byte-identical** (120 lines each).
- Ran the image / recipe / apptainer-def test suites: `test__image_source_build.py`, `test_image_group.py`, `test_apptainer_def_openai_agents.py`, `test_apptainer_base_def_scitex_todo.py`, `test_apptainer_base_def_playwright_libs.py`, `test__apptainer_build_argv.py` — **187 passed, 2 skipped** (the 2 skips are environment-gated apptainer-binary tests, unrelated). No lockstep test compares the two gate bodies; the openai/scitex-cards contract tests only substring-check lines this PR preserves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqhsrw29CM4siBLcEK2CwV
