### PR TITLE
fix(image): content assert compares shared .py content, not whole-tree set — kill the false positive

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -518,31 +518,41 @@ print(
 failures = []
 
 # The version string lies (uv's wheel cache is version-keyed and sac's
-# version does not advance per-commit). File content cannot lie: this
-# compares the INSTALLED sac tree to the STAGED source tree — a stale
-# wheel makes them differ. Generic on purpose: it names no feature, so a
-# rename or decoupling never breaks it.
+# version does not advance per-commit). File content cannot lie — but the
+# comparison must be SET-AWARE: compare CONTENT of .py files present in
+# BOTH the installed package and the staged source (shared relative
+# paths); a stale wheel makes a shared file's content differ.
+# Set-differences (wheel excludes data files) are NOT staleness and are
+# ignored — comparing whole-tree hashes false-positives on them. Generic
+# on purpose: it names no feature, so a rename or decoupling never breaks it.
 import hashlib as _hashlib, pathlib as _pathlib
 import scitex_agent_container as _sac
 _installed_root = _pathlib.Path(_sac.__file__).parent
 _staged_root = _pathlib.Path("/opt/scitex-agent-container-src/src/scitex_agent_container")
-def _tree_sha(root):
-    h = _hashlib.sha256()
-    for p in sorted(root.rglob("*.py")):
-        h.update(p.relative_to(root).as_posix().encode())
-        h.update(p.read_bytes())
-    return h.hexdigest()
-_di = _tree_sha(_installed_root)
+def _rel_shas(root):
+    out = {}
+    for p in root.rglob("*.py"):
+        rel = p.relative_to(root).as_posix()
+        out[rel] = _hashlib.sha256(p.read_bytes()).hexdigest()
+    return out
 if _staged_root.is_dir():
-    _ds = _tree_sha(_staged_root)
-    print("installed sac .py tree sha  :", _di[:16])
-    print("staged   sac .py tree sha  :", _ds[:16])
-    if _di != _ds:
+    _inst = _rel_shas(_installed_root)
+    _stg = _rel_shas(_staged_root)
+    _shared = sorted(set(_inst) & set(_stg))
+    print("content-assert shared .py files:", len(_shared))
+    if len(_shared) < 50:
         failures.append(
-            "installed sac (%s) != staged source (%s) — uv served a STALE "
-            "wheel; the fix did NOT ship. Add/verify --no-cache-dir on the "
-            "sac install." % (_di[:12], _ds[:12])
+            "content assert compared only %d shared .py files (expected hundreds) — "
+            "installed/staged package roots may be misaligned; comparison is not meaningful." % len(_shared)
         )
+    else:
+        _mismatch = [rel for rel in _shared if _inst[rel] != _stg[rel]]
+        if _mismatch:
+            failures.append(
+                "installed sac differs from staged source in %d of %d shared .py files "
+                "(e.g. %s) — a STALE wheel shipped; the fix did NOT ship. Verify --no-cache-dir "
+                "on the sac install." % (len(_mismatch), len(_shared), _mismatch[:5])
+            )
 else:
     print("NOTE: staged source not at /opt/scitex-agent-container-src; content assert skipped")
 

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -338,31 +338,41 @@ print(
 failures = []
 
 # The version string lies (uv's wheel cache is version-keyed and sac's
-# version does not advance per-commit). File content cannot lie: this
-# compares the INSTALLED sac tree to the STAGED source tree — a stale
-# wheel makes them differ. Generic on purpose: it names no feature, so a
-# rename or decoupling never breaks it.
+# version does not advance per-commit). File content cannot lie — but the
+# comparison must be SET-AWARE: compare CONTENT of .py files present in
+# BOTH the installed package and the staged source (shared relative
+# paths); a stale wheel makes a shared file's content differ.
+# Set-differences (wheel excludes data files) are NOT staleness and are
+# ignored — comparing whole-tree hashes false-positives on them. Generic
+# on purpose: it names no feature, so a rename or decoupling never breaks it.
 import hashlib as _hashlib, pathlib as _pathlib
 import scitex_agent_container as _sac
 _installed_root = _pathlib.Path(_sac.__file__).parent
 _staged_root = _pathlib.Path("/opt/scitex-agent-container-src/src/scitex_agent_container")
-def _tree_sha(root):
-    h = _hashlib.sha256()
-    for p in sorted(root.rglob("*.py")):
-        h.update(p.relative_to(root).as_posix().encode())
-        h.update(p.read_bytes())
-    return h.hexdigest()
-_di = _tree_sha(_installed_root)
+def _rel_shas(root):
+    out = {}
+    for p in root.rglob("*.py"):
+        rel = p.relative_to(root).as_posix()
+        out[rel] = _hashlib.sha256(p.read_bytes()).hexdigest()
+    return out
 if _staged_root.is_dir():
-    _ds = _tree_sha(_staged_root)
-    print("installed sac .py tree sha  :", _di[:16])
-    print("staged   sac .py tree sha  :", _ds[:16])
-    if _di != _ds:
+    _inst = _rel_shas(_installed_root)
+    _stg = _rel_shas(_staged_root)
+    _shared = sorted(set(_inst) & set(_stg))
+    print("content-assert shared .py files:", len(_shared))
+    if len(_shared) < 50:
         failures.append(
-            "installed sac (%s) != staged source (%s) — uv served a STALE "
-            "wheel; the fix did NOT ship. Add/verify --no-cache-dir on the "
-            "sac install." % (_di[:12], _ds[:12])
+            "content assert compared only %d shared .py files (expected hundreds) — "
+            "installed/staged package roots may be misaligned; comparison is not meaningful." % len(_shared)
         )
+    else:
+        _mismatch = [rel for rel in _shared if _inst[rel] != _stg[rel]]
+        if _mismatch:
+            failures.append(
+                "installed sac differs from staged source in %d of %d shared .py files "
+                "(e.g. %s) — a STALE wheel shipped; the fix did NOT ship. Verify --no-cache-dir "
+                "on the sac install." % (len(_mismatch), len(_shared), _mismatch[:5])
+            )
 else:
     print("NOTE: staged source not at /opt/scitex-agent-container-src; content assert skipped")
 


### PR DESCRIPTION
## The bug: a set-equality assert masquerading as a staleness check

PR #749 added a build-time "content assert" to the image freshness gate in
**both** recipes (`apptainer-base.def` and `apptainer-scitex.def`). It hashed
the **whole** installed `.py` tree and required it to equal the whole staged
`.py` tree-hash:

```python
def _tree_sha(root):
    h = _hashlib.sha256()
    for p in sorted(root.rglob("*.py")):
        h.update(p.relative_to(root).as_posix().encode()); h.update(p.read_bytes())
    return h.hexdigest()
if _tree_sha(_installed_root) != _tree_sha(_staged_root): failures.append("... STALE wheel ...")
```

That is a **whole-tree SET equality**, and it false-positives. The installed
package tree (what the wheel ships into `site-packages`) legitimately differs
**as a set** from the source tree — the wheel excludes/relocates some `.py`
(data scripts, build files, path-prefix normalization). So `_tree_sha` folds
path bytes for files that only exist on one side into the hash, and the two
hashes never match even on a perfectly correct build.

### Empirical proof (independent agent)

A **correct** bake still FAILED this assert:

- uv logged `Building scitex-agent-container @ file:///opt/...src` -> installed
  from the staged source, not a cached wheel.
- Staged tree byte-identical to the repo: **587 == 587** `.py` files.
- `diff -rq` between installed and staged: **zero** non-`__pycache__` diffs.

The bake was correct; the assert lied. In this state it blocks **every** bake.

## The fix: per-file intersection content compare

A real stale wheel = the **installed** `.py` files carry **old content** for
files that **also exist in source**. So compare CONTENT of the files present
in BOTH trees, keyed on relative path within the package, and ignore
files-only-in-one (packaging set-difference, not staleness):

```python
def _rel_shas(root):
    out = {}
    for p in root.rglob("*.py"):
        rel = p.relative_to(root).as_posix()
        out[rel] = _hashlib.sha256(p.read_bytes()).hexdigest()
    return out
_shared = sorted(set(_inst) & set(_stg))
if len(_shared) < 50:      # meaningless comparison -> fail loud
    failures.append("content assert compared only %d shared .py files ...")
else:
    _mismatch = [rel for rel in _shared if _inst[rel] != _stg[rel]]
    if _mismatch:
        failures.append("installed sac differs from staged source in %d of %d shared .py files ...")
```

- **Set-difference** (wheel-excluded data files) is no longer treated as
  staleness -> the false positive is gone.
- **Content drift** in a shared file — a genuinely stale wheel — still trips it.
- A **misalignment guard** fails loudly if fewer than 50 shared files are
  compared (roots misaligned -> the comparison is not meaningful).

Everything else in the gate is preserved: the symbol asserts, the
`scitex_todo`/`scitex_cards` shim-alias check, `WIP_STATUSES`, the
one-distribution-per-name check, and the `_installed_root`/`_staged_root`
resolution + `is_dir()` skip branch. Both gate bodies stay **byte-identical**.

## Verification

- Extracted each gate's embedded python and `python -m py_compile`d both ->
  PASS. Gate bodies confirmed byte-identical (5860 bytes, same sha256).
- Simulation: (a) identical shared content + an extra file on each side ->
  **no failure** (no false positive on set difference); (b) one shared file
  with differing content -> **failure** (real staleness caught); (c) fewer than
  50 shared files -> misalignment guard fires.
- `183 passed` across the recipe/image/parser test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqhsrw29CM4siBLcEK2CwV
