### PR TITLE
feat(jobs): declare auth-heal as a JobSpec systemd timer (off the swept crontab)

### DIFF
--- a/src/scitex_agent_container/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs_plugin.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 def provide_jobs() -> "list[JobSpec]":
     """Return sac's federated scheduled jobs.
 
-    Five jobs today:
+    Six jobs today:
 
     * ``sac.fleet-reconcile`` (``kind="timer"``) — the only enforcer of
       "should be running ⇒ is running". Restarts agents whose tmux session
@@ -48,6 +48,25 @@ def provide_jobs() -> "list[JobSpec]":
       duplication described below, one costume over. The crontab is host state a
       PR cannot edit, so the cron retirement is an operator/dotfiles step that
       must land WITH the enable.
+
+    * ``sac.heal-agent-auth`` (``kind="timer"``) — the INCUMBENT auth healer
+      (``~/.scitex/agent-container/bin/auth-heal.py``, every 10min), declared
+      here so it stops living as a hand-written crontab line that a sweep
+      deletes. ``~/.dotfiles/src/.cron/copy_crontab`` installs the tracked
+      manifest WHOLESALE (``git show HEAD:.crontab_list | crontab -``), so
+      anything absent from ``.crontab_list`` is erased on its next run — and
+      auth-heal has NO line in that manifest, which is why the wrapper that
+      exports ``SAC_SECRETS_ENVRC`` kept reverting. A hand-added crontab line
+      is temporary BY CONSTRUCTION; a JobSpec is not. scitex-cards and
+      dotfiles moved their own schedules to systemd ``--user`` timers for the
+      same reason, and scitex-dev's ruling makes the JobSpec plugin the SSoT.
+
+      MUTUALLY EXCLUSIVE WITH ``sac.restart-login-expired-agents`` — enable
+      exactly ONE. This job's ``scan_tui`` is precisely what that timer
+      reimplements natively, so the deploy gate documented below is not
+      lifted by declaring this one; it is made explicit. Declaring both is
+      safe (a JobSpec is inert until ``ecosystem up`` installs it); ENABLING
+      both puts two restarters with INDEPENDENT debounce state on one fleet.
 
     * ``sac.accounts-refresh`` (``kind="timer"``) — a headless OAuth
       access-token refresh for EVERY stored Claude account, including the
@@ -269,6 +288,58 @@ def provide_jobs() -> "list[JobSpec]":
             # restarts, each a stop+settle+start) plus the ~4s capture interval.
             # A pass killed here is SAFE — history is persisted per restart, so
             # the next tick still honours the debounce for anything bounced.
+            timeout_sec=300,
+        ),
+        JobSpec(
+            name="sac.heal-agent-auth",
+            schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)
+            # ABSOLUTE by design, both tokens. `resolve_execstart` passes a
+            # command whose head starts with "/" through VERBATIM, so this is
+            # the only form that depends on neither the ambient PATH nor which
+            # interpreter ran `ecosystem up`. A systemd --user unit gets a
+            # MINIMAL PATH, so the venv python must be named outright: the
+            # script's own `#!/usr/bin/env python3` would resolve to the SYSTEM
+            # python under systemd, not the 3.11 venv the fleet runs on.
+            command=(
+                "/home/ywatanabe/.env-3.11/bin/python "
+                "/home/ywatanabe/.scitex/agent-container/bin/auth-heal.py"
+            ),
+            description=(
+                "Auth auto-heal for the fleet: scans each agent's session.jsonl "
+                "TAIL for a CURRENT 401/authentication_error and restarts the "
+                "agent so a fresh credential is re-mounted, plus the sibling "
+                "TUI-pane scan (2-run-corroborated) for tmux agents whose "
+                "transcript lives in the container overlay and is invisible to "
+                "the session.jsonl glob. Rate-limited (per-agent debounce, boot "
+                "grace, global cap/hour) and phones the operator instead of "
+                "looping when a restart provably did not fix it. Declared as a "
+                "JobSpec because its crontab line was swept by copy_crontab's "
+                "full-manifest install. MUTUALLY EXCLUSIVE with "
+                "sac.restart-login-expired-agents — enable exactly one."
+            ),
+            kind="timer",
+            # Same taxonomy note as the jobs above: kind must be one of
+            # {"service","timer","cron"} (scitex-dev #153); a wrong kind raises
+            # at construction and `ecosystem up` then silently drops sac's WHOLE
+            # provider.
+            #
+            # 10min preserves the incumbent cadence EXACTLY — not a guess: the
+            # live `runtime/auth-heal.log` ticks 15:20 → 15:30 → 15:40 → 15:50
+            # → 16:00 (2026-07-18), matching the `*/10` cron line. Migrating a
+            # schedule is the wrong moment to also retune it; a cadence change
+            # belongs in its own PR with its own argument.
+            on_boot_sec="5min",
+            on_unit_active_sec="10min",
+            # `Persistent=true` is emitted by scitex-dev's timer renderer for
+            # every kind="timer", so a window missed while the host was asleep
+            # fires on resume — the property a crontab line does NOT have and a
+            # laptop fleet needs most.
+            #
+            # 300s matches the siblings and comfortably outlives a real pass:
+            # a no-op tick takes ~2-8s, and the worst observed pass (a TUI
+            # restart at 15:30:04 settling by 15:32:08) ~2min. A pass killed
+            # here is SAFE — state is persisted per restart, so the next tick
+            # still honours the debounce for anything already bounced.
             timeout_sec=300,
         ),
     ]

--- a/tests/scitex_agent_container/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/test__jobs_plugin.py
@@ -46,16 +46,17 @@ def _job(name: str):
     return match
 
 
-def test_provider_returns_five_jobs() -> None:
-    # Arrange — call the registered provider. Five: accounts-refresh, the
+def test_provider_returns_six_jobs() -> None:
+    # Arrange — call the registered provider. Six: accounts-refresh, the
     # host-sync-check drift alarm, the daily worktree GC, the fleet-reconcile
-    # enforcer (dead/no-session corpses), and the restart-login-expired-agents
-    # timer (live-session-but-auth-dead agents). `sac listen` is still NOT
-    # federated (see the module docstring and the absence-pin below).
+    # enforcer (dead/no-session corpses), the restart-login-expired-agents
+    # timer (live-session-but-auth-dead agents), and heal-agent-auth (the
+    # incumbent auth-heal.py, migrated off the swept crontab). `sac listen` is
+    # still NOT federated (see the module docstring and the absence-pin below).
     # Act
     jobs = provide_jobs()
     # Assert
-    assert len(jobs) == 5
+    assert len(jobs) == 6
 
 
 def test_provider_jobs_are_real_jobspecs() -> None:
@@ -365,3 +366,139 @@ def test_restart_login_expired_constructs_as_a_real_jobspec() -> None:
     job = _job("sac.restart-login-expired-agents")
     # Assert
     assert isinstance(job, jobs_mod.JobSpec)
+
+
+# ---------------------------------------------------------------------------
+# sac.heal-agent-auth — the INCUMBENT auth healer, migrated off the crontab.
+#
+# The migration is the point. `~/.dotfiles/src/.cron/copy_crontab` installs the
+# tracked manifest WHOLESALE (`git show HEAD:.crontab_list | crontab -`), so a
+# line absent from `.crontab_list` is erased on its next run — and auth-heal has
+# no line in that manifest at all. That is why the wrapper exporting
+# SAC_SECRETS_ENVRC kept reverting: a hand-added crontab line is temporary BY
+# CONSTRUCTION. These tests pin the properties a crontab line could not give it
+# (Persistent=true via kind="timer") and the ones a systemd --user unit would
+# otherwise lose (an absolute, PATH-independent ExecStart).
+#
+# Named verb+object (`heal` + `agent-auth`) like its sibling above, so the
+# derived units read `sac.heal-agent-auth.timer` / `.service` — no "timer" in
+# the name, since systemd's suffix already conveys periodicity.
+# ---------------------------------------------------------------------------
+
+
+def test_heal_agent_auth_job_name_is_package_prefixed() -> None:
+    # Arrange — the incumbent auth healer, now declared rather than hand-cronned.
+    # Act
+    job = _job("sac.heal-agent-auth")
+    # Assert
+    assert job.name == "sac.heal-agent-auth"
+
+
+def test_heal_agent_auth_job_kind_is_timer() -> None:
+    # Arrange — kind="timer" is what buys `Persistent=true` from scitex-dev's
+    # renderer (a missed window fires on resume — the property the swept crontab
+    # line never had). kind="cron" would materialise the very crontab line this
+    # job exists to escape, and a kind outside {"service","timer","cron"} raises
+    # at construction, silently dropping sac's WHOLE provider.
+    # Act
+    job = _job("sac.heal-agent-auth")
+    # Assert
+    assert job.kind == "timer"
+
+
+def test_heal_agent_auth_cadence_preserves_the_incumbent_ten_minutes() -> None:
+    # Arrange — 10min is the LIVE cadence, not a new choice: runtime/auth-heal.log
+    # ticks 15:20 → 15:30 → 15:40 → 15:50 → 16:00, matching the `*/10` cron line.
+    # Migrating a schedule is the wrong moment to also retune it.
+    # Act
+    job = _job("sac.heal-agent-auth")
+    # Assert
+    assert job.on_unit_active_sec == "10min"
+
+
+def test_heal_agent_auth_schedule_mirrors_the_retired_cron_expression() -> None:
+    # Arrange — the cron form is kept alongside the timer cadence (as every
+    # sibling does) so the expression the crontab line used stays legible in the
+    # spec, and so `ecosystem cron` could still derive an equivalent line.
+    # Act
+    job = _job("sac.heal-agent-auth")
+    # Assert
+    assert job.schedule == "*/10 * * * *"
+
+
+def test_heal_agent_auth_interpreter_token_is_absolute() -> None:
+    # Arrange — scitex-dev's `resolve_execstart` passes a head starting with "/"
+    # through VERBATIM. An absolute head is therefore the only form that depends
+    # on neither the ambient PATH nor which interpreter ran `ecosystem up`.
+    # Act
+    job = _job("sac.heal-agent-auth")
+    # Assert
+    assert job.command.split()[0].startswith("/")
+
+
+def test_heal_agent_auth_script_token_is_absolute() -> None:
+    # Arrange — a systemd --user unit gets a MINIMAL PATH and no meaningful cwd,
+    # so the script argument must be absolute too; a relative path would exec
+    # fine under cron's $HOME cwd and fail as status=127 under systemd.
+    # Act
+    job = _job("sac.heal-agent-auth")
+    # Assert
+    assert job.command.split()[1].startswith("/")
+
+
+def test_heal_agent_auth_runs_the_venv_python_not_the_system_one() -> None:
+    # Arrange — the script's own `#!/usr/bin/env python3` would resolve to the
+    # SYSTEM python under systemd's minimal PATH, not the 3.11 venv the fleet
+    # runs on. Naming the venv interpreter outright is what carries the "PATH
+    # prefixed with .env-3.11/bin" requirement into a unit that has no PATH.
+    # Act
+    job = _job("sac.heal-agent-auth")
+    # Assert
+    assert job.command.startswith("/home/ywatanabe/.env-3.11/bin/python ")
+
+
+def test_heal_agent_auth_targets_the_real_auth_heal_entrypoint() -> None:
+    # Arrange — the entrypoint the cron line actually invokes, per the tracked
+    # `~/.scitex/agent-container/bin/README.md` ("run from cron; cron lines live
+    # in ~/.dotfiles/.crontab_list") and corroborated by the live state/log files
+    # that script writes. It takes no arguments — its `main()` has no argparse,
+    # only a `--selftest` branch — so the bare script path is the whole command.
+    # Act
+    job = _job("sac.heal-agent-auth")
+    # Assert
+    assert job.command.endswith(
+        "/home/ywatanabe/.scitex/agent-container/bin/auth-heal.py"
+    )
+
+
+def test_heal_agent_auth_timeout_outlives_a_restarting_pass() -> None:
+    # Arrange — a no-op tick takes ~2-8s; the worst observed pass (a TUI restart
+    # at 15:30:04 settling by 15:32:08) ~2min. A pass killed here is SAFE (state
+    # is persisted per restart), but the timeout must still outlive a real one.
+    # Act
+    job = _job("sac.heal-agent-auth")
+    # Assert
+    assert job.timeout_sec == 300
+
+
+def test_heal_agent_auth_constructs_as_a_real_jobspec() -> None:
+    # Arrange — construction must not raise (a bad field would drop the whole
+    # provider). Assert it is the canonical contract type, not a look-alike.
+    # Act
+    job = _job("sac.heal-agent-auth")
+    # Assert
+    assert isinstance(job, jobs_mod.JobSpec)
+
+
+def test_heal_agent_auth_and_restart_login_expired_are_both_declared() -> None:
+    # Arrange — declaring both is SAFE and deliberate: a JobSpec is inert until
+    # `ecosystem up` installs it, so version-controlling the incumbent does not
+    # enable it. What must never happen is both being ENABLED — they are the two
+    # implementations of the same TUI heal, with INDEPENDENT debounce state, and
+    # two restarters on one fleet is the documented double-supervisor hazard.
+    # This pins that the choice stays an operator deploy decision rather than
+    # being silently foreclosed by deleting one of them.
+    # Act
+    names = {job.name for job in provide_jobs()}
+    # Assert
+    assert {"sac.heal-agent-auth", "sac.restart-login-expired-agents"} <= names


### PR DESCRIPTION
Declares the incumbent auth healer as a `kind="timer"` JobSpec so it stops living as a hand-written crontab line that a sweep deletes.

## Why: the crontab line was temporary by construction

`~/.dotfiles/src/.cron/copy_crontab` is a **full-manifest install**, not a merge:

```sh
desired=$(git -C "$REPO" show HEAD:.crontab_list 2>/dev/null) || exit 0
[ "$(printf '%s\n' "$desired" | grep -c .)" -ge 10 ] || exit 0
current=$(crontab -l 2>/dev/null || true)
[ "$desired" = "$current" ] && exit 0
printf '%s\n' "$desired" | crontab -
```

It runs on the `* 0 * * *` schedule and installs the tracked manifest wholesale, so **anything absent from `.crontab_list` is erased on its next run**. Checking that manifest: it contains only `clean_zombies` and `copy_crontab` — **auth-heal has no line in it at all**. That is the whole explanation for the reverting wrapper: the `SAC_SECRETS_ENVRC` export was added to live crontab state that the next sweep overwrote. No amount of re-adding it fixes that; a hand-added crontab line is temporary by construction.

scitex-cards and dotfiles each moved their own schedules to systemd `--user` timers for exactly this reason. scitex-dev's ruling makes the JobSpec plugin the SSoT for scheduled work, with `kind='timer'` materializing a systemd `--user` timer carrying `Persistent=true` (missed windows fire on resume — the property a crontab line never had, and the one a laptop fleet needs most).

Out of scope, as instructed: this PR does not touch the host crontab or the dotfiles repo. Once this lands and is installed, **the cron line becomes removable by its owner** (dotfiles). Until then the timer is declared but not enabled, so nothing changes on the host.

## Which entrypoint, and how it was verified

`ExecStart` is the venv python plus the script, both tokens absolute:

```
/home/ywatanabe/.env-3.11/bin/python /home/ywatanabe/.scitex/agent-container/bin/auth-heal.py
```

I could not read the live crontab directly — there is no `crontab` binary in the container, and the dotfiles manifest has no auth-heal line to read. So the entrypoint was established from converging evidence rather than asserted:

1. **Documented.** The tracked `~/.scitex/agent-container/bin/README.md` names `auth-heal.py` as the script that restarts 401-stuck agents, states these scripts are "run from cron (cron lines live in `~/.dotfiles/.crontab_list`)", and lists its state/logs as `auth-heal-state.json`, `auth-heal.log`, `auth-heal.cron.log`.
2. **Running right now.** `runtime/auth-heal.log` and `auth-heal-state.json` were both written at `16:00:05` against a wall clock of `16:03` — a live job, not a fossil.
3. **At the documented cadence.** The log ticks `14:30 → 14:40 → 14:50 → 15:00 → 15:10 → 15:20 → 15:30 → 15:40 → 15:50 → 16:00`, i.e. exactly `*/10`, and shows real work (`TUI-STUCK scitex-scholar (auth banner + frozen 2 runs) -> auto-restart`).
4. **No arguments.** `main()` has no argparse — the only argv branch is `--selftest` — so the bare script path is the entire command.
5. **Not repo-tracked.** `git ls-files` has no match for it; it is host-deployed under the sac runtime dir. The JobSpec is therefore host-pinned, but no more so than the script itself, which already hardcodes `/home/ywatanabe` in `RUNTIME_GLOB`, `SAC_BIN` and `NOTIFY_BIN`.

One caveat I did not paper over: `auth-heal.cron.log` last changed at `11:01` while `auth-heal.log` stayed fresh to `16:00`. Something about the invocation changed around 11:01 today. The job is unambiguously still running on the `*/10` beat, so this does not affect the cadence or entrypoint above, but the owner may want to know the cron-log leg went quiet.

## Env requirements: the plugin cannot carry them, and no longer needs to

**`JobSpec` cannot express env — this is a real gap, reported rather than worked around.** Its fields are `name, kind, schedule, command, description, on_boot_sec, on_unit_active_sec, timeout_sec, restart_policy, watchdog_sec, venv`. There is no `environment` or `environment_file`. Confirmed against a *rendered* unit on disk, not just the dataclass — `~/.config/systemd/user/sac.host-sync-check.service` has no `Environment=` and no `EnvironmentFile=` line. The only env any JobSpec can emit is the single `Environment=VIRTUAL_ENV=<venv>` that the `venv` field triggers.

That gap turns out not to block this job, because sac already fixed the underlying problem caller-independently:

- **`SAC_SECRETS_ENVRC`** is resolved at *run* time by `runtimes/_envrc.py::resolve_secret_files`, whose docstring names this exact caller: *"It is baked into `sac-listen.service` but NOT into a cron line, a raw `ssh` restart, or a federated `scitex_dev.jobs` timer (JobSpec cannot inject an environment)."* An explicit non-empty value wins verbatim; when unset it falls back to `$HOME/.bash.d/secrets/010_scitex/*.src` (sorted, existing only) — the same default `install-sac-listen.sh` computes. The CCT pool resolver uses it, so the `sac` process `auth-heal.py` shells out to re-resolves the token pool itself. This satisfies the "resolve the glob, don't hardcode a stale file list" requirement *better* than an `EnvironmentFile` would: the glob is evaluated per run, not frozen at unit-render time.
- **PATH / venv python** are handled by making both `ExecStart` tokens absolute. `resolve_execstart` passes a head starting with `/` through verbatim, so the unit depends on neither the ambient PATH nor which interpreter ran `ecosystem up`. This matters concretely: a systemd `--user` unit gets a minimal PATH, and the script's own `#!/usr/bin/env python3` would resolve to the **system** python rather than the 3.11 venv the fleet runs on. Naming the interpreter outright is strictly stronger than prefixing PATH.

So nothing here needs an `EnvironmentFile`. But if scitex-dev wants leaves to be able to declare env generally, the field genuinely does not exist today.

## The artifact this actually produces

Rendered through scitex-dev's own unit builder rather than inferred from the spec fields:

```ini
# sac.heal-agent-auth.service
[Service]
Type=oneshot
ExecStart=/home/ywatanabe/.env-3.11/bin/python /home/ywatanabe/.scitex/agent-container/bin/auth-heal.py
StandardOutput=journal
StandardError=journal
RemainAfterExit=no
TimeoutStartSec=300s

# sac.heal-agent-auth.timer
[Timer]
OnBootSec=5min
OnUnitActiveSec=10min
Persistent=true
Unit=sac.heal-agent-auth.service

[Install]
WantedBy=timers.target
```

`Persistent=true` is there, the ExecStart passed through verbatim, and the unit name reads as verb+object in `systemctl --user list-timers`. Note also what is *absent*: no `Environment=`, no `EnvironmentFile=` — the gap described above, confirmed on this job's own rendered output.

## Naming: `sac.heal-agent-auth`

Verb + object, because scitex-dev derives the unit name **verbatim** — this materializes `sac.heal-agent-auth.timer` / `.service`, which is legible in `systemctl --user list-timers` output. It reads as an action on a thing, unlike the vague `fleet-reconcile` style that was objected to. It sits naturally beside the existing `sac.restart-login-expired-agents` (verb `restart` + object `login-expired-agents`), and follows that job's convention of keeping "timer" **out** of the name, since systemd's suffix already conveys periodicity and embedding it would double to `.timer.timer`.

## One thing the reviewer must decide: this job and `sac.restart-login-expired-agents` overlap

`auth-heal.py`'s `scan_tui` is precisely what `sac agents restart-login-expired` reimplements natively, and the existing plugin already carries a deploy gate saying that timer *must not* be enabled until this host's `auth-heal.py scan_tui` cron is retired — two restarters on one fleet with independent debounce state.

Declaring both is safe and deliberate: **a JobSpec is inert until `ecosystem up` installs it**, so version-controlling the incumbent does not enable it. What must never happen is both being *enabled*. I documented the mutual exclusion on both specs and pinned it with a test, so the choice stays an explicit operator deploy decision rather than being silently foreclosed by deleting one of them. Note the two are not equivalent: `auth-heal.py` also scans `runtime/*/session.jsonl` for SDK-runner agents, which has no sac-native replacement yet — so retiring it wholesale in favour of the native timer would drop that half.

## Tests

`tests/scitex_agent_container/test__jobs_plugin.py` — 11 new tests, plus `test_provider_returns_five_jobs` renamed to `test_provider_returns_six_jobs` and its count updated (the exact-count test the brief warned about):

- `test_heal_agent_auth_job_name_is_package_prefixed`
- `test_heal_agent_auth_job_kind_is_timer`
- `test_heal_agent_auth_cadence_preserves_the_incumbent_ten_minutes`
- `test_heal_agent_auth_schedule_mirrors_the_retired_cron_expression`
- `test_heal_agent_auth_interpreter_token_is_absolute`
- `test_heal_agent_auth_script_token_is_absolute`
- `test_heal_agent_auth_runs_the_venv_python_not_the_system_one`
- `test_heal_agent_auth_targets_the_real_auth_heal_entrypoint`
- `test_heal_agent_auth_timeout_outlives_a_restarting_pass`
- `test_heal_agent_auth_constructs_as_a_real_jobspec`
- `test_heal_agent_auth_and_restart_login_expired_are_both_declared`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqhsrw29CM4siBLcEK2CwV
