### PR TITLE
fix(auth-heal): UNOBSERVED survives — a login-expired pass cannot report a fleet it never read

### DIFF
--- a/src/scitex_agent_container/_authheal/__init__.py
+++ b/src/scitex_agent_container/_authheal/__init__.py
@@ -15,7 +15,14 @@ double-supervisor class.
 
 from __future__ import annotations
 
-from ._detect import DEFAULT_INTERVAL, capture_live_panes, detect_login_expired
+from ._detect import (
+    DEFAULT_INTERVAL,
+    DetectionOutcome,
+    Roster,
+    capture_live_panes,
+    detect_login_expired,
+    registered_agents,
+)
 from ._pass import (
     DEFAULT_PASS_CAP,
     AgentReport,
@@ -28,9 +35,12 @@ __all__ = [
     "DEFAULT_INTERVAL",
     "DEFAULT_PASS_CAP",
     "AgentReport",
+    "DetectionOutcome",
     "PassOutcome",
+    "Roster",
     "auth_heal_pass",
     "capture_live_panes",
     "detect_login_expired",
     "history_path",
+    "registered_agents",
 ]

--- a/src/scitex_agent_container/_authheal/_alarm.py
+++ b/src/scitex_agent_container/_authheal/_alarm.py
@@ -240,6 +240,12 @@ def route_reports_to_cards(
 
     # Recovered-on-their-own: an agent with an open card that is NOT in this
     # pass's reports is no longer login-expired → resolve its stale card.
+    #
+    # An UNOBSERVED agent IS in the reports, so its card survives this sweep.
+    # That is the point: resolving an escalation card on a reading we never
+    # took would be a false all-clear in its most durable form — the board
+    # would say a human had nothing left to look at, on the strength of the
+    # pass having failed to look.
     for name in _carded_agents(store):
         if name in active:
             continue

--- a/src/scitex_agent_container/_authheal/_detect.py
+++ b/src/scitex_agent_container/_authheal/_detect.py
@@ -7,6 +7,25 @@ frozen across two captures ``--interval`` apart. A banner that moved — the age
 is producing output, working or merely QUOTING the incident — is never flagged,
 so a false positive can never bounce a working agent and destroy its context.
 
+ALL THREE VERDICTS LEAVE THIS MODULE
+    The matcher answers ok / auth_failed / unknown, and :class:`DetectionOutcome`
+    carries all three out. Only ``auth_failed`` authorises a restart — absence of
+    evidence is not evidence of a wedge — but ``unknown`` is a FINDING, not a
+    value to drop: an agent nobody could read is exactly the agent nobody is
+    watching. A detector that returned the wedged names alone left "we observed
+    nothing at all" and "we observed everything and it was fine" spelling the
+    same empty answer, and nothing downstream could tell them apart.
+
+THE POPULATION IS THE ROSTER, NOT THE ENUMERATION
+    :func:`capture_live_panes` can only key on tmux sessions it can SEE, so an
+    agent whose session is gone never becomes a key and could not be reported as
+    anything at all. :func:`registered_agents` supplies the independent
+    population — the same fleet registry ``sac.fleet-reconcile`` sweeps — that
+    the reading is checked against, so an agent missing from the reading becomes
+    a VALUE rather than a silence. That also makes a BLIND read self-announcing:
+    an enumeration that comes back empty because tmux itself failed now leaves
+    the whole roster unaccounted for, instead of looking like a quiet fleet.
+
 Detection performs NO token-rotating probe and writes nothing: it captures panes
 and classifies them, full stop (the ``sac agents auth-status`` writer owns the
 state.db cache; this consumer must not fight its cadence). The ONLY mutation in
@@ -20,29 +39,131 @@ time, and so there is no import-time coupling to the CLI package.
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass
+from pathlib import Path
 
-__all__ = ["DEFAULT_INTERVAL", "capture_live_panes", "detect_login_expired"]
+__all__ = [
+    "DEFAULT_INTERVAL",
+    "DetectionOutcome",
+    "Roster",
+    "capture_live_panes",
+    "detect_login_expired",
+    "registered_agents",
+]
 
 #: Seconds between the two pane captures whose agreement defines "frozen".
 #: Same default as ``sac agents auth-status --interval``.
 DEFAULT_INTERVAL = 4.0
 
 
+@dataclass(frozen=True)
+class DetectionOutcome:
+    """Every agent we looked at, in the THREE buckets the matcher produces.
+
+    The buckets PARTITION the input: every key of ``captures`` lands in exactly
+    one of them, so a caller can distinguish "clean" from "never read" without
+    re-deriving it from row fields. Each is sorted by agent name, inherited from
+    the rows they are built out of.
+
+    ``auth_failed`` is the only bucket that may lead to a restart. ``unknown`` is
+    the bucket this type exists for: it must never be restarted, and it must
+    never be discarded either — an instrument silent about the agents it failed
+    to measure is reporting good news about things it never saw.
+    """
+
+    auth_failed: tuple[str, ...] = ()
+    ok: tuple[str, ...] = ()
+    unknown: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Roster:
+    """The REGISTERED agent population — or an honest refusal to claim one.
+
+    ``readable=False`` means the fleet registry could not be enumerated, and it
+    is deliberately NOT the same value as an empty registry. "No agents are
+    registered" and "we cannot tell which agents are registered" lead to
+    opposite conclusions about a thin pane reading: the first says nothing is
+    missing, the second says we have no idea what is missing. Collapsing them
+    would let the roster check certify a fleet it never managed to look up.
+
+    Mirrors :class:`.._reconcile._budget.HistoryRead`, which draws exactly this
+    distinction for the restart history.
+    """
+
+    names: tuple[str, ...] = ()
+    readable: bool = True
+    detail: str = ""
+
+
 def detect_login_expired(
     captures: "dict[str, tuple[str | None, str | None]]",
-) -> list[str]:
-    """Corroborated login-expired agent NAMES (sorted), from two-capture panes.
+) -> DetectionOutcome:
+    """Classify two-capture panes into OK / AUTH-FAILED / UNKNOWN.
 
     ``captures`` maps ``agent -> (pane_run1, pane_run2)``. Delegates to the real
-    ``evaluate_agents`` corroboration and keeps ONLY the ``auth_failed`` verdict
-    — never ``ok`` (banner moved / clean) and never ``unknown`` (pane could not
-    be read: absence of evidence is not evidence of a wedge). Pure: no tmux, no
-    I/O, so it is unit-testable against captured panes without mocks.
+    ``evaluate_agents`` corroboration and keeps ALL THREE of its verdicts:
+    ``auth_failed`` (a system auth banner frozen above the prompt across both
+    reads), ``ok`` (the banner moved, or there was none), and ``unknown`` (the
+    pane could not be read). Pure: no tmux, no I/O, so it is unit-testable
+    against captured panes without mocks.
+
+    Only ``auth_failed`` authorises a restart. ``unknown`` never does — absence
+    of evidence is not evidence of a wedge, and bouncing an agent on a reading
+    we failed to take would destroy the context of something that was working
+    fine — but it is returned rather than dropped, so the pass can report it.
     """
-    from ..cli_pkg._auth_status import VERDICT_AUTH_FAILED, evaluate_agents
+    from ..cli_pkg._auth_status import (
+        VERDICT_AUTH_FAILED,
+        VERDICT_UNKNOWN,
+        evaluate_agents,
+    )
 
     rows = evaluate_agents(captures)  # sorts by agent name
-    return [r["agent"] for r in rows if r["verdict"] == VERDICT_AUTH_FAILED]
+    return DetectionOutcome(
+        auth_failed=tuple(
+            r["agent"] for r in rows if r["verdict"] == VERDICT_AUTH_FAILED
+        ),
+        ok=tuple(
+            r["agent"]
+            for r in rows
+            if r["verdict"] not in (VERDICT_AUTH_FAILED, VERDICT_UNKNOWN)
+        ),
+        unknown=tuple(r["agent"] for r in rows if r["verdict"] == VERDICT_UNKNOWN),
+    )
+
+
+def registered_agents(specs_dir: "Path | None" = None) -> Roster:
+    """The fleet registry's agent names — the population a pass must account for.
+
+    Reuses ``sac.fleet-reconcile``'s enumeration
+    (:func:`.._reconcile._pass.fleet_spec_paths`) instead of inventing a second
+    roster, so the two sweeps can never disagree about which agents exist and
+    the one ``SCITEX_AGENT_CONTAINER_AGENTS_DIR`` override redirects both.
+
+    A registry we cannot enumerate yields ``readable=False``, never an empty
+    roster. An empty roster would quietly assert that no agent is missing, which
+    is the strongest claim available and the last one earned by having seen
+    nothing.
+    """
+    from .._reconcile._pass import fleet_agents_dir, fleet_spec_paths
+
+    root = specs_dir if specs_dir is not None else fleet_agents_dir()
+    if not root.is_dir():
+        return Roster(
+            readable=False,
+            detail=f"the fleet registry {root} is not a readable directory, so "
+            f"we cannot know which agents SHOULD have a live session",
+        )
+    # stx-allow: fallback (reason: a revoked/unreadable registry must render as UNKNOWN, never as an empty roster that would silently certify "nobody is missing"; the OS's own message is carried into the report)
+    try:
+        names = tuple(spec.parent.name for spec in fleet_spec_paths(root))
+    except OSError as exc:
+        return Roster(
+            readable=False,
+            detail=f"could not enumerate the fleet registry {root}: {exc}",
+        )
+    return Roster(names=names, detail=f"{len(names)} agent(s) registered in {root}")
 
 
 def capture_live_panes(
@@ -55,6 +176,12 @@ def capture_live_panes(
     the two commands see the same fleet on the same tmux server. An uncapturable
     pane is ``None`` (the honest "could not read"), which the matcher maps to
     UNKNOWN — never a false AUTH-FAILED.
+
+    The KEYS here are the live sessions and nothing else, which makes this a
+    reading of the fleet rather than the fleet itself: an agent whose session is
+    gone cannot appear, however wrong its absence is. Squaring this reading
+    against the :func:`registered_agents` roster is the pass's job, and that is
+    what turns such an absence into a reportable value.
     """
     from ..cli_pkg._auth_status import _agent_of, _capture, _list_tui_sessions
 

--- a/src/scitex_agent_container/_authheal/_pass.py
+++ b/src/scitex_agent_container/_authheal/_pass.py
@@ -34,6 +34,15 @@ DEPLOY GATE — READ BEFORE ENABLING THE TIMER
     host's ``auth-heal.py`` ``scan_tui`` is retired. See :mod:`.._jobs_plugin`
     and the ``sac agents restart-login-expired`` command help.
 
+WHAT A CLEAN PASS IS ALLOWED TO MEAN
+    A pass reports on the REGISTERED roster, not on whatever its pane reading
+    happened to contain. Every registered agent must leave this pass in exactly
+    one of three states — wedged, observed-and-fine, or UNOBSERVED — and only
+    the wedged ones are ever restarted. That third state is what makes exit 0 a
+    real claim: "we accounted for the whole roster and none of it is wedged",
+    rather than the far weaker "we produced no reports", which is also what a
+    pass that read nothing at all produces.
+
 Every collaborator is an injectable seam with a REAL default, so tests drive the
 whole pass against real panes, a real temp history file and a real scitex-todo
 store — with the one irreversible act (the restart) swapped for a recorder. No
@@ -58,7 +67,12 @@ from .._reconcile._budget import (
 )
 from .._reconcile._rule import Verdict
 from ._alarm import route_reports_to_cards, upsert_heartbeat
-from ._detect import DEFAULT_INTERVAL, capture_live_panes, detect_login_expired
+from ._detect import (
+    DEFAULT_INTERVAL,
+    capture_live_panes,
+    detect_login_expired,
+    registered_agents,
+)
 
 __all__ = [
     "DEFAULT_INTERVAL",
@@ -86,6 +100,11 @@ _BUDGET_VERDICTS = {
 #: Verdicts that mean we ATTEMPTED a restart, so the history must be persisted
 #: before the next agent (a killed pass must not forget what it already bounced).
 _SPENT = (Verdict.RESTARTED, Verdict.FAILED)
+
+#: The report subject used when the ROSTER ITSELF could not be read. Not an
+#: agent — it is the population we failed to establish — and named so that a
+#: cron log says WHICH reading failed instead of showing an unexplained exit 2.
+_ROSTER_SUBJECT = "<fleet-roster>"
 
 
 def history_path() -> Path:
@@ -149,8 +168,22 @@ class PassOutcome:
         return {k: v for k, v in out.items() if v}
 
     def exit_code(self) -> int:
-        """0 clean · 1 something is wedged · 2 we cannot read our own memory."""
-        if self.of(Verdict.BUDGET_UNKNOWN):
+        """0 confirmed-clean · 1 something is wedged · 2 could-not-determine.
+
+        0 is the STRONGEST claim this pass can make, so it is reserved for
+        earning it: EVERY agent in the registered roster was actually observed,
+        and none of them is wedged. It is never the answer to "we produced no
+        reports", because a pass that observed nothing at all produces no
+        reports either — and while those two spelled the same 0, a wedged agent
+        could sit for hours while the timer recorded a healthy tick for each
+        pass that had failed to look at it.
+
+        Anything UNOBSERVED therefore outranks the clean answer and joins
+        BUDGET_UNKNOWN at 2. They are one statement in two costumes — we could
+        not determine the thing this pass exists to determine — and 2 is the
+        code that lets a cron tell that apart from a fleet genuinely healthy.
+        """
+        if self.of(Verdict.BUDGET_UNKNOWN, Verdict.UNOBSERVED):
             return 2
         if self.of(
             Verdict.FAILED,
@@ -224,10 +257,60 @@ def _perform(
     )
 
 
+def _unobserved(name: str, *, live: bool) -> AgentReport:
+    """An agent we took NO reading of — reported, never restarted.
+
+    There are two ways to be unobserved and the detail must say which, because
+    they send the operator to different places: a LIVE session whose pane would
+    not capture (tmux is there, the read failed), versus a registered agent with
+    no session at all (the reading could not even have had a row for it — the
+    shape that let an agent go missing rather than red). Neither is evidence of
+    a wedge, so neither is restarted; neither is evidence of health either, so
+    neither is silently dropped.
+    """
+    if live:
+        return AgentReport(
+            name,
+            Verdict.UNOBSERVED,
+            "pane-unreadable",
+            f"{name} has a live tui- session but its pane could NOT be captured, "
+            f"so nothing was learned about its auth. NOT restarted (absence of "
+            f"evidence is not evidence of a wedge) and NOT counted healthy",
+        )
+    return AgentReport(
+        name,
+        Verdict.UNOBSERVED,
+        "no-session",
+        f"{name} is REGISTERED but has no live tui- session, so this pass could "
+        f"not read it at all. NOT restarted — a missing session is "
+        f"fleet-reconcile's half of the fleet, not ours — but its absence from "
+        f"the reading is not evidence that {name} is healthy",
+    )
+
+
+def _roster_unreadable(detail: str) -> AgentReport:
+    """The ROSTER is the thing we could not read, so no pass can be clean.
+
+    Without it we do not know which agents SHOULD have been observed, so we
+    cannot claim to have observed them all however many panes we did read. The
+    finding is carried as a report of its own rather than a bare exit code, so
+    the reason travels with the verdict to whoever reads the log.
+    """
+    return AgentReport(
+        _ROSTER_SUBJECT,
+        Verdict.UNOBSERVED,
+        "roster-unreadable",
+        f"could not establish which agents SHOULD be running: {detail}. Agents "
+        f"missing from this pass's reading cannot be told apart from agents that "
+        f"do not exist, so this pass cannot report a clean fleet",
+    )
+
+
 def auth_heal_pass(
     *,
     apply: bool = False,
     limit: int = DEFAULT_PASS_CAP,
+    specs_dir: Path | None = None,
     history_file: Path | None = None,
     store: str | None = None,
     alarm: bool = True,
@@ -242,6 +325,13 @@ def auth_heal_pass(
     ``apply=False`` (the default, selected by ``--check``) is a REPORT: it
     detects and decides but restarts nothing. The only board write a dry-run
     makes is this restarter's own heartbeat.
+
+    Parameters
+    ----------
+    specs_dir
+        The fleet registry to read the roster from — the population every
+        report is checked against. Real state, redirectable for tests, exactly
+        as ``reconcile_pass`` takes it.
     """
     now = now if now is not None else time.time()
     now_dt = datetime.fromtimestamp(now, tz=timezone.utc)
@@ -252,7 +342,17 @@ def auth_heal_pass(
     history_file = history_file if history_file is not None else history_path()
     stream = err_stream if err_stream is not None else sys.stderr
 
-    names = detect_login_expired(capture_fn())
+    captures = capture_fn()
+    roster = registered_agents(specs_dir)
+
+    # A REGISTERED agent absent from the capture is missing from our READING of
+    # the fleet, not from the fleet. Seeding it as an explicit (None, None)
+    # turns that absence into a value the matcher classifies as UNKNOWN, rather
+    # than a key that never exists and so can never be reported as anything.
+    observed = dict(captures)
+    for agent in roster.names:
+        observed.setdefault(agent, (None, None))
+    detection = detect_login_expired(observed)
 
     # PROVE we can read (and create) our own memory before acting on it — a
     # budget we cannot read is not a budget (see _reconcile._budget).
@@ -260,7 +360,7 @@ def auth_heal_pass(
     budget = Budget(read.history, pass_cap=limit) if read.enforceable else None
     reports: list[AgentReport] = []
 
-    for name in names:
+    for name in detection.auth_failed:
         report = _perform(
             name,
             budget=budget,
@@ -298,6 +398,15 @@ def auth_heal_pass(
             f"agent(s): {read.detail}",
             file=stream,
         )
+
+    # Now say what we did NOT manage to look at. These reports carry no action
+    # — they are added after every restart decision precisely so they cannot
+    # influence one — and they exist so that an agent this pass never read
+    # leaves a line behind instead of leaving nothing behind.
+    live = set(captures)
+    if not roster.readable:
+        reports.append(_roster_unreadable(roster.detail))
+    reports.extend(_unobserved(name, live=name in live) for name in detection.unknown)
 
     outcome = PassOutcome(reports=tuple(reports), applied=apply)
     alarm_outcome = None

--- a/src/scitex_agent_container/_reconcile/_pass.py
+++ b/src/scitex_agent_container/_reconcile/_pass.py
@@ -34,6 +34,7 @@ from ._rule import MANAGED_POLICIES, Verdict, decide
 __all__ = [
     "AgentReport",
     "PassOutcome",
+    "fleet_agents_dir",
     "fleet_spec_paths",
     "reconcile_pass",
 ]
@@ -103,7 +104,7 @@ class PassOutcome:
         return 0
 
 
-def _fleet_agents_dir() -> Path:
+def fleet_agents_dir() -> Path:
     """The user-scope fleet registry dir (``…/agents``).
 
     Globbed DIRECTLY rather than through :func:`config._resolve.resolve_config`
@@ -112,6 +113,11 @@ def _fleet_agents_dir() -> Path:
     resolve the same fleet whatever directory systemd happens to start it in,
     so it takes the deterministic path, exactly as ``sac agents refresh-acl``
     already does for the same reason.
+
+    Public because :mod:`.._authheal._detect` resolves the SAME roster to find
+    the agents its pane reading failed to account for. Two sweeps of one fleet
+    must never disagree about which agents exist, so they share this accessor
+    rather than each growing their own.
     """
     override = os.environ.get(_AGENTS_DIR_ENV)
     if override:
@@ -127,7 +133,7 @@ def fleet_spec_paths(specs_dir: Path | None = None) -> list[Path]:
     Skips ``_``-prefixed dirs (``_shared``, ``_template_*``, ``_archive``) —
     scaffolding, not fleet agents.
     """
-    root = specs_dir if specs_dir is not None else _fleet_agents_dir()
+    root = specs_dir if specs_dir is not None else fleet_agents_dir()
     if not root.is_dir():
         return []
     return [

--- a/src/scitex_agent_container/_reconcile/_rule.py
+++ b/src/scitex_agent_container/_reconcile/_rule.py
@@ -73,8 +73,9 @@ class Verdict(str, Enum):
     """What we concluded about ONE agent. Every leg is printed, never silent.
 
     The RULE in this module only ever returns the first five. The remaining
-    verdicts describe what the PASS then DID with a :attr:`RESTART`, and are
-    reachable only from :mod:`._pass`.
+    verdicts are reachable only from a PASS: most describe what it then DID
+    with a :attr:`RESTART`, while :attr:`UNOBSERVED` records the agents it
+    never managed to take a reading of at all.
     """
 
     # --- reachable by the pure rule ---------------------------------------
@@ -92,6 +93,17 @@ class Verdict(str, Enum):
     COOLING_DOWN = "COOLING-DOWN"  # inside the debounce → wait, do not card
     CAPPED = "CAPPED"  # this pass's global cap spent; next pass retries
     BUDGET_UNKNOWN = "BUDGET-UNKNOWN"  # we cannot read our OWN memory → refuse
+
+    # Not a thing a pass DID — a thing it could not do. An agent whose pane
+    # would not capture, or that is registered with no live session at all,
+    # produced no evidence, and no evidence is neither OK nor AUTH-FAILED. It
+    # is therefore never restarted and never counted clean; it is REPORTED, so
+    # that the one agent nobody could read is the one agent nobody can miss.
+    #
+    # Distinct from :attr:`UNKNOWN` above, which is the pure rule's fleet-wide
+    # "the tmux probe was not a sensor from where we stand". This one is
+    # per-agent and per-reading: the probe worked, this agent did not answer.
+    UNOBSERVED = "UNOBSERVED"
 
 
 @dataclass(frozen=True)

--- a/src/scitex_agent_container/cli_pkg/_agents_restart_login_expired.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_restart_login_expired.py
@@ -37,6 +37,10 @@ _STYLE = {
     Verdict.OVER_BUDGET: ("red", "OVER-BUDGET"),
     Verdict.FAILED: ("red", "FAILED"),
     Verdict.BUDGET_UNKNOWN: ("magenta", "BUDGET-UNKNOWN"),
+    # Magenta groups with BUDGET-UNKNOWN rather than with the yellow "wedged"
+    # verdicts, because it says the same thing they do: we could not determine
+    # this, and it is the one colour that must never read as a clean line.
+    Verdict.UNOBSERVED: ("magenta", "UNOBSERVED"),
 }
 
 
@@ -117,7 +121,10 @@ def restart_login_expired(
       two restarters bouncing one fleet is the double-supervisor class. Running
       THIS COMMAND by hand is always safe.
 
-    Exits 0 clean, 1 if something is wedged, 2 if it cannot read its own memory.
+    Exits 0 ONLY when every registered agent was actually observed and none is
+    wedged, 1 if something is wedged, and 2 if anything could not be determined
+    — an unreadable pane, a registered agent with no live session, an
+    unreadable fleet roster, or an unreadable restart history.
     """
     if apply and check:
         raise click.UsageError(
@@ -144,9 +151,14 @@ def restart_login_expired(
         raise SystemExit(code)
 
     mode = "apply" if apply else "check (read-only)"
+    # Count the two populations SEPARATELY. A single total would fold the
+    # agents we could not read into the agents we found wedged, which is the
+    # collapse this command's exit code exists to keep apart.
+    unseen = outcome.of(Verdict.UNOBSERVED)
     console.print(
         f"[bold]sac agents restart-login-expired[/bold]  {mode} — "
-        f"{len(outcome.reports)} corroborated login-expired agent(s)\n"
+        f"{len(outcome.reports) - len(unseen)} corroborated login-expired "
+        f"agent(s), {len(unseen)} NOT observed\n"
     )
     for report in outcome.reports:
         _print_report(report)
@@ -173,6 +185,16 @@ def restart_login_expired(
             f"them:[/red] {', '.join(r.name for r in down)}\n"
             "  Each has a board card. A human needs to look — restarting is not "
             "fixing these (usually a real account problem)."
+        )
+    if unseen:
+        console.print(
+            f"\n[magenta]{len(unseen)} agent(s) were NOT observed:[/magenta] "
+            f"{', '.join(r.name for r in unseen)}\n"
+            "  Nothing was learned about these — they are neither healthy nor "
+            "wedged, and this pass therefore CANNOT report a clean fleet.\n"
+            "  Look at them by hand:\n"
+            "    sac agents auth-status\n"
+            "    sac agents list"
         )
     if outcome.of(Verdict.BUDGET_UNKNOWN):
         console.print(

--- a/tests/scitex_agent_container/_authheal/_helpers.py
+++ b/tests/scitex_agent_container/_authheal/_helpers.py
@@ -10,6 +10,8 @@ signature, never a mock of the thing under test. The corroboration logic
 
 from __future__ import annotations
 
+from pathlib import Path
+
 #: A fixed clock. Every suite injects it, so no test can be flaky on time.
 NOW = 1_800_000_000.0
 
@@ -35,6 +37,20 @@ def transient(*names: str) -> dict:
     agent must NOT be restarted.
     """
     return {n: (STUCK, OK) for n in names}
+
+
+def register_agents(root: Path, *names: str) -> None:
+    """Register each name in a REAL fleet registry dir, as a real spec file.
+
+    The roster enumeration GLOBS ``*/spec.yaml`` and never loads it, so an empty
+    file is a genuine registration rather than a stand-in for one: this is the
+    on-disk shape ``sac agents new`` leaves behind, reduced to the part the
+    roster actually reads. A registered agent with no live pane is what makes
+    absence a value instead of a silence.
+    """
+    for name in names:
+        (root / name).mkdir(parents=True, exist_ok=True)
+        (root / name / "spec.yaml").write_text("")
 
 
 class Recorder:

--- a/tests/scitex_agent_container/_authheal/conftest.py
+++ b/tests/scitex_agent_container/_authheal/conftest.py
@@ -1,16 +1,52 @@
 """Real temp state for the login-expired auto-restart suites — no mocks.
 
 Every fixture hands the pass REAL state it can write to and a test can read
-back: an on-disk restart-history file and an on-disk scitex-todo store.
-Detection is capture-driven (injected panes), so — unlike the reconcile
-suite — no state.db or fleet registry is needed here.
+back: an on-disk restart-history file, an on-disk scitex-todo store and an
+on-disk fleet registry. Detection is capture-driven (injected panes), so no
+state.db is needed here — but the ROSTER is real, because the pass now checks
+its pane reading against the registry to find the agents that reading failed
+to account for.
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
+
+#: The registry override ``sac.fleet-reconcile`` and ``sac agents refresh-acl``
+#: already honour — the roster reader reuses it, so redirecting it here points
+#: every roster lookup in this package at temp state.
+_AGENTS_DIR_ENV = "SCITEX_AGENT_CONTAINER_AGENTS_DIR"
+
+
+@pytest.fixture(autouse=True)
+def roster(tmp_path: Path):
+    """A REAL, EMPTY fleet registry — the population every pass is checked against.
+
+    AUTOUSE, so no test in this package can reach the live fleet registry. The
+    pass enumerates the roster to find the agents its pane reading failed to
+    account for, and a suite pointed at the real one would report on production
+    agents and flake on whatever happens to be deployed.
+
+    Empty means READABLE and nobody registered — the neutral roster that leaves
+    the injected captures as the whole population, so a test about the restart
+    logic stays a test about the restart logic. Tests that need a registered
+    agent create its spec dir with :func:`_helpers.register_agents`; a test that
+    needs an UNREADABLE roster passes ``specs_dir`` at a path that is not there.
+    """
+    root = tmp_path / "agents"
+    root.mkdir()
+    saved = os.environ.get(_AGENTS_DIR_ENV)
+    os.environ[_AGENTS_DIR_ENV] = str(root)
+    try:
+        yield root
+    finally:
+        if saved is None:
+            os.environ.pop(_AGENTS_DIR_ENV, None)
+        else:
+            os.environ[_AGENTS_DIR_ENV] = saved
 
 
 @pytest.fixture

--- a/tests/scitex_agent_container/_authheal/test__detect.py
+++ b/tests/scitex_agent_container/_authheal/test__detect.py
@@ -6,22 +6,33 @@ the two captures (the real ``evaluate_agents`` matcher runs here, unmocked),
 and it must reject a banner that moved, a clean pane, and an unreadable pane.
 A false positive here is a needless restart that destroys a working agent's
 context, so these are the tests that keep the auto-restarter safe.
+
+Rejecting is not the same as forgetting, and the second half of this suite
+pins that difference: an unreadable pane must stay OUT of ``auth_failed`` and
+must still turn up in ``unknown``, because the agent nobody could read is the
+one nobody is watching. The roster tests do the same for the population — a
+registry we cannot enumerate must not read as a registry with nobody in it.
 """
 
 from __future__ import annotations
 
-from scitex_agent_container._authheal._detect import detect_login_expired
+from pathlib import Path
 
-from ._helpers import OK, stuck, transient
+from scitex_agent_container._authheal._detect import (
+    detect_login_expired,
+    registered_agents,
+)
+
+from ._helpers import OK, register_agents, stuck, transient
 
 
 def test_frozen_banner_is_corroborated_login_expired():
     # Arrange — a banner identical on both reads = frozen = the real thing.
     captures = stuck("scitex-hpc")
     # Act
-    names = detect_login_expired(captures)
+    outcome = detect_login_expired(captures)
     # Assert
-    assert names == ["scitex-hpc"]
+    assert outcome.auth_failed == ("scitex-hpc",)
 
 
 def test_single_run_transient_banner_is_not_flagged():
@@ -30,18 +41,18 @@ def test_single_run_transient_banner_is_not_flagged():
     # it is NOT wedged and must never be restarted.
     captures = transient("figrecipe")
     # Act
-    names = detect_login_expired(captures)
+    outcome = detect_login_expired(captures)
     # Assert
-    assert names == []
+    assert outcome.auth_failed == ()
 
 
 def test_clean_pane_is_not_flagged():
     # Arrange — no banner at all on either read.
     captures = {"writer": (OK, OK)}
     # Act
-    names = detect_login_expired(captures)
+    outcome = detect_login_expired(captures)
     # Assert
-    assert names == []
+    assert outcome.auth_failed == ()
 
 
 def test_uncapturable_pane_is_not_flagged():
@@ -50,9 +61,9 @@ def test_uncapturable_pane_is_not_flagged():
     # is not evidence of a wedge).
     captures = {"gone": (None, None)}
     # Act
-    names = detect_login_expired(captures)
+    outcome = detect_login_expired(captures)
     # Assert
-    assert names == []
+    assert outcome.auth_failed == ()
 
 
 def test_only_the_frozen_agents_are_returned_and_sorted():
@@ -63,6 +74,99 @@ def test_only_the_frozen_agents_are_returned_and_sorted():
         "clean": (OK, OK),
     }
     # Act
-    names = detect_login_expired(captures)
+    outcome = detect_login_expired(captures)
     # Assert — sorted, and ONLY the corroborated ones.
-    assert names == ["alpha", "zeta"]
+    assert outcome.auth_failed == ("alpha", "zeta")
+
+
+# --- the third verdict SURVIVES: rejected is not the same as forgotten -----
+
+
+def test_uncapturable_pane_is_reported_as_unknown():
+    # Arrange — the same unread pane the test above proves is never restarted.
+    # It must still come OUT of the detector, or the one agent we failed to
+    # measure becomes the one agent nobody hears about.
+    captures = {"gone": (None, None)}
+    # Act
+    outcome = detect_login_expired(captures)
+    # Assert
+    assert outcome.unknown == ("gone",)
+
+
+def test_clean_pane_is_reported_as_ok():
+    # Arrange — positive evidence is a finding too: this is what lets a caller
+    # say "we observed it and it was fine" instead of merely staying quiet.
+    captures = {"writer": (OK, OK)}
+    # Act
+    outcome = detect_login_expired(captures)
+    # Assert
+    assert outcome.ok == ("writer",)
+
+
+def test_moving_banner_is_reported_as_ok_not_unknown():
+    # Arrange — a banner that MOVED is a working agent, which we did observe.
+    # It belongs in ok, not in the bucket reserved for what we never read.
+    captures = transient("figrecipe")
+    # Act
+    outcome = detect_login_expired(captures)
+    # Assert
+    assert outcome.ok == ("figrecipe",)
+
+
+def test_every_agent_lands_in_exactly_one_bucket():
+    # Arrange — the partition property: nothing handed to the detector may
+    # vanish between the input and the three buckets, which is precisely how
+    # an unread agent used to disappear.
+    captures = {
+        **stuck("zeta"),
+        **transient("mid"),
+        "clean": (OK, OK),
+        "gone": (None, None),
+    }
+    # Act
+    outcome = detect_login_expired(captures)
+    # Assert
+    buckets = outcome.auth_failed + outcome.ok + outcome.unknown
+    assert sorted(buckets) == sorted(captures)
+
+
+# --- the roster: an unreadable registry is not an empty one ----------------
+
+
+def test_registry_lists_its_registered_agents(roster: Path):
+    # Arrange — a REAL registry dir with real spec files, the same shape the
+    # fleet-reconcile sweep enumerates.
+    register_agents(roster, "scitex-hub", "writer")
+    # Act
+    outcome = registered_agents(roster)
+    # Assert
+    assert sorted(outcome.names) == ["scitex-hub", "writer"]
+
+
+def test_empty_registry_is_readable_with_nobody_in_it(roster: Path):
+    # Arrange — a registry that genuinely holds no agents. That is a real
+    # answer, and it must stay distinguishable from having failed to ask.
+    # Act
+    outcome = registered_agents(roster)
+    # Assert
+    assert (outcome.readable, outcome.names) == (True, ())
+
+
+def test_absent_registry_is_unreadable_not_empty(tmp_path: Path):
+    # Arrange — the registry is not there, so we cannot know which agents
+    # SHOULD have a live session. Reporting an empty roster here would assert
+    # that nobody is missing, which is the strongest claim available and the
+    # last one earned by having seen nothing.
+    # Act
+    outcome = registered_agents(tmp_path / "not-there")
+    # Assert
+    assert outcome.readable is False
+
+
+def test_unreadable_registry_says_why(tmp_path: Path):
+    # Arrange — the refusal has to travel with its reason, or a downstream exit
+    # code is all that is left and nobody can act on it.
+    # Act
+    outcome = registered_agents(tmp_path / "not-there")
+    # Assert
+    assert "not-there" in outcome.detail

--- a/tests/scitex_agent_container/_authheal/test__pass.py
+++ b/tests/scitex_agent_container/_authheal/test__pass.py
@@ -8,6 +8,13 @@ test.
 The load-bearing safety property is that a persistently-failing agent is
 CARDED, never bounced forever: these tests pin the debounce, the hourly cap,
 and the escalation card that replaces an infinite restart loop.
+
+The second load-bearing property is that a pass cannot report a clean fleet it
+did not look at. An agent whose pane will not capture, and a registered agent
+with no session at all, must both leave a VISIBLE report and drive the exit
+code to could-not-determine — while still never being restarted, because an
+unread pane is no evidence of a wedge. Exit 0 is reserved for a roster fully
+accounted for.
 """
 
 from __future__ import annotations
@@ -25,7 +32,7 @@ from scitex_agent_container._reconcile._budget import (
 )
 from scitex_agent_container._reconcile._rule import Verdict
 
-from ._helpers import NOW, Recorder, stuck, transient
+from ._helpers import NOW, OK, Recorder, register_agents, stuck, transient
 
 
 def _seed_history(path: Path, mapping: dict) -> None:
@@ -195,3 +202,124 @@ def test_unreadable_budget_reports_budget_unknown(denied_history, store):
     outcome = _run(stuck("hpc"), denied_history, store, rec)
     # Assert
     assert _verdict(outcome, "hpc") == Verdict.BUDGET_UNKNOWN
+
+
+# --- an agent we did NOT read is REPORTED, never silently dropped ----------
+#
+# The pane of a live agent will not capture, so the pass learns nothing at all
+# about its auth. Producing no report for it made "we checked and it is fine"
+# and "we never looked" the same answer — which is how a wedged agent sat for
+# hours while every pass logged a success.
+
+
+def test_uncapturable_pane_is_reported(history, store):
+    # Arrange — a live session whose pane cannot be read.
+    rec = Recorder()
+    # Act
+    outcome = _run({"scitex-hub": (None, None)}, history, store, rec)
+    # Assert
+    assert _verdict(outcome, "scitex-hub") == Verdict.UNOBSERVED
+
+
+def test_uncapturable_pane_makes_the_pass_could_not_determine(history, store):
+    # Arrange — THE gate. 0 must mean "we accounted for the roster and nothing
+    # is wedged", never "we produced no reports": the second is also what a
+    # pass that observed nothing produces, and while both spelled 0 the timer
+    # recorded ExecMainStatus=0 for every pass that had failed to look.
+    rec = Recorder()
+    # Act
+    outcome = _run({"scitex-hub": (None, None)}, history, store, rec)
+    # Assert
+    assert outcome.exit_code() == 2
+
+
+def test_uncapturable_pane_is_never_restarted(history, store):
+    # Arrange — visible is not the same as actionable. An unread pane is no
+    # evidence of a wedge, so making it loud must not make it restartable.
+    rec = Recorder()
+    # Act
+    _run({"scitex-hub": (None, None)}, history, store, rec)
+    # Assert
+    assert rec.names == []
+
+
+# --- absence is a value: the ROSTER is the population, not the reading -----
+#
+# An agent whose tmux session is GONE can never become a key in a reading built
+# by enumerating live sessions, so it could not be reported as anything at all.
+# The registry is the independent population that makes it visible.
+
+
+def test_registered_agent_with_no_session_is_reported(roster, history, store):
+    # Arrange — scitex-hub is registered; the reading contains only some other,
+    # healthy agent, so nothing in it mentions scitex-hub.
+    register_agents(roster, "scitex-hub")
+    rec = Recorder()
+    # Act
+    outcome = _run({"writer": (OK, OK)}, history, store, rec)
+    # Assert
+    assert _verdict(outcome, "scitex-hub") == Verdict.UNOBSERVED
+
+
+def test_registered_agent_with_no_session_could_not_be_determined(
+    roster, history, store
+):
+    # Arrange
+    register_agents(roster, "scitex-hub")
+    rec = Recorder()
+    # Act
+    outcome = _run({"writer": (OK, OK)}, history, store, rec)
+    # Assert
+    assert outcome.exit_code() == 2
+
+
+def test_registered_agent_with_no_session_is_never_restarted(roster, history, store):
+    # Arrange — a missing session is fleet-reconcile's half of the fleet. This
+    # pass makes it visible; it must not also act on it.
+    register_agents(roster, "scitex-hub")
+    rec = Recorder()
+    # Act
+    _run({"writer": (OK, OK)}, history, store, rec)
+    # Assert
+    assert rec.names == []
+
+
+def test_fully_observed_healthy_roster_exits_clean(roster, history, store):
+    # Arrange — the other half of the gate: 0 must stay REACHABLE, or the exit
+    # code carries no information. Every registered agent has a live pane that
+    # read clean, so this pass genuinely accounted for the whole roster.
+    register_agents(roster, "writer")
+    rec = Recorder()
+    # Act
+    outcome = _run({"writer": (OK, OK)}, history, store, rec)
+    # Assert
+    assert outcome.exit_code() == 0
+
+
+# --- the roster itself is unreadable → still not a clean fleet -------------
+
+
+def test_unreadable_roster_is_reported(history, store, tmp_path):
+    # Arrange — the registry cannot be enumerated, so we do not know which
+    # agents SHOULD have been observed. An empty roster here would silently
+    # certify that nobody is missing.
+    rec = Recorder()
+    # Act
+    outcome = _run(
+        {"writer": (OK, OK)}, history, store, rec, specs_dir=tmp_path / "not-there"
+    )
+    # Assert
+    assert [r.reason for r in outcome.reports] == ["roster-unreadable"]
+
+
+def test_unreadable_roster_makes_the_pass_could_not_determine(history, store, tmp_path):
+    # Arrange — every pane we did read came back clean, which is exactly the
+    # shape that must NOT be allowed to look like a healthy fleet: we cannot
+    # say we observed everyone without knowing who everyone is.
+    rec = Recorder()
+    # Act
+    outcome = _run(
+        {"writer": (OK, OK)}, history, store, rec, specs_dir=tmp_path / "not-there"
+    )
+    # Assert
+    assert outcome.exit_code() == 2


### PR DESCRIPTION
## The bug

The login-expired detector computed a correct three-state verdict and then threw
two of the states away.

- `_authheal/_detect.py` — `detect_login_expired(captures) -> list[str]` called
  `evaluate_agents`, which yields ok / auth_failed / unknown, and kept only
  `auth_failed`. Refusing to restart an `unknown` is correct and unchanged; the
  bug is that `unknown` was silently DISCARDED rather than REPORTED. `list[str]`
  had nowhere to put it.
- `_authheal/_pass.py` — reports were built only from those names, so an agent
  whose pane could not be read produced no report at all.
- `PassOutcome.exit_code()` ended in a bare `return 0`. Empty reports therefore
  meant BOTH "we checked everything and all is well" AND "we observed nothing at
  all". systemd recorded `Result=success ExecMainStatus=0` on every one of these
  passes.
- `capture_live_panes()` built its population from live tmux sessions, so an
  agent whose session was GONE never became a key and could not be reported as
  anything. The enumeration WAS the population, so absence was invisible by
  construction.

This is why scitex-hub sat "Login expired" for hours while the timer reported
success every 10 minutes, and produced no row anywhere.

## The change

| | |
|---|---|
| `DetectionOutcome` | frozen dataclass carrying `auth_failed` / `ok` / `unknown` out of the detector. The buckets PARTITION the input, so nothing handed in can vanish. Only `auth_failed` still authorises a restart. |
| `Verdict.UNOBSERVED` | for agents no reading covered. Reported, never restarted, never counted clean. Distinct from the pure rule's fleet-wide `UNKNOWN`: that one is "the tmux probe was not a sensor from where we stand", this one is per-agent and per-reading. |
| `Roster` + `registered_agents()` | the independent population, reusing fleet-reconcile's own registry enumeration (`_fleet_agents_dir` → public `fleet_agents_dir`) rather than a second source of truth. A registry we cannot enumerate is `readable=False`, **never** an empty roster — an empty roster would silently certify that nobody is missing. |
| the pass | seeds each registered-but-unread agent as an explicit `(None, None)` so the existing matcher classifies the absence as UNKNOWN. Absence becomes a value instead of a silence. This also makes a BLIND read self-announcing: a tmux enumeration that returns empty because tmux itself failed now leaves the whole roster unaccounted for, instead of looking like a quiet fleet. |
| `exit_code()` | 0 is reserved for "every agent in the roster was observed and none is wedged". UNOBSERVED joins BUDGET_UNKNOWN at 2 (could-not-determine). |
| `_alarm` | no longer resolves an escalation card for an UNOBSERVED agent — clearing a card on a reading we never took is a false all-clear in its most durable form. |

Restart behaviour is unchanged: an unread pane is still never bounced, and that
refusal is re-pinned by test.

## Mutation proof — verified RED before green

The gates were run against the **pre-fix source** (source stashed, new tests
kept) before being made green:

```
FAILED test_uncapturable_pane_is_reported
FAILED test_uncapturable_pane_makes_the_pass_could_not_determine
FAILED test_registered_agent_with_no_session_is_reported
FAILED test_registered_agent_with_no_session_could_not_be_determined
FAILED test_unreadable_roster_is_reported
FAILED test_unreadable_roster_makes_the_pass_could_not_determine
6 failed, 15 passed
```

with the decisive assertion failing exactly as diagnosed:

```
assert outcome.exit_code() == 2
E   assert 0 == 2
E    +  where 0 = PassOutcome(reports=(), alarm=None, heartbeat_ok=False, applied=True).exit_code()
```

Two **controls** passed both before and after, which is what keeps the gate from
being trivially red: `test_uncapturable_pane_is_never_restarted` (the refusal was
always correct) and `test_fully_observed_healthy_roster_exits_clean` (0 must stay
reachable, or the exit code carries no information).

## Tests

No mocks. Real temp fleet registry (real `spec.yaml` files), real temp history
file, real scitex-todo store; only the restart is a recorder. A new **autouse**
`roster` fixture points `SCITEX_AGENT_CONTAINER_AGENTS_DIR` at temp state so no
test in the package can read the live fleet registry.

`_authheal` 38/38 · `_reconcile` + `test__agents_reconcile` +
`test__agents_restart_login_expired` + `test__auth_status` +
`_runners/_tmux/test_auth_status` all green (215 passed alongside). The
auth-status command shares the matcher and does not regress.

## Out of scope — the same collapse elsewhere

Surveyed for this defect class; the strongest hit is the direct sibling:

1. **`_reconcile/_pass.py:86` `PassOutcome.exit_code()`** — identical shape.
   `fleet_spec_paths` returns `[]` when the registry dir is missing or
   permission-revoked, so zero specs → zero reports → bare `return 0`, and the
   scheduled `sac agents reconcile` logs a healthy tick while the whole fleet
   went unexamined. The `Roster`/`readable=False` treatment added here applies
   verbatim. **Recommend a follow-up.**
2. `cli_pkg/spartan_pytest/_summary.py:78` — `all_passed` never consults
   `passed`, so an empty or **stale** `summary.json` reads as green; the SLURM
   `final_state` (FAILED/CANCELLED/TIMEOUT) is echoed but never reaches the exit
   code.
3. `_runners/_session_candidates.py:264` — `except OSError: return []`
   contradicts its own docstring promise that `[]` means "genuinely nothing to
   resume"; an unreadable projects dir silently becomes a fresh session.
4. `_maintenance/_worktree_gc_model.py:207` and `_hostsync/_sync.py:78` — empty
   outcome list → 0. Both currently guarded at their CLI call sites, but
   `exit_code_for` is public API in each.
5. `_lifecycle/_github_ci.py:68` — an expired `gh` token renders as "this PR has
   no CI" rather than "I cannot check". Documented as deliberate fail-soft, but
   it is a silent-forever mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqhsrw29CM4siBLcEK2CwV
