### PR TITLE
fix(security): make the creds-watch change key see a same-size token rotation

### DIFF
--- a/src/scitex_agent_container/_account/creds_watch.py
+++ b/src/scitex_agent_container/_account/creds_watch.py
@@ -10,8 +10,9 @@ Two watch backends, picked at runtime:
 
 * **inotify** via the ``inotifywait`` binary when it is on ``$PATH`` —
   event-driven, zero idle CPU.
-* **poll** fallback otherwise — stat the file's ``mtime``/``size`` on a
-  short interval.
+* **poll** fallback otherwise — stat the file on a short interval and
+  compare a ``(mtime_ns, size, ino)`` change key (see
+  :func:`_signature` for why all three terms are load-bearing).
 
 Both call the same engine, so behaviour is identical; only the
 wake-up mechanism differs. Each sync attempt is logged (stderr by
@@ -87,13 +88,47 @@ def run_sync_once(
         _emit(log, f"up-to-date {result.store_name} (email={result.email})")
 
 
-def _signature(path: Path) -> tuple[float, int] | None:
-    """Return ``(mtime, size)`` of ``path``, or ``None`` if absent."""
+def _signature(path: Path) -> tuple[int, int, int] | None:
+    """Return the change-detection key ``(mtime_ns, size, ino)``, or ``None``.
+
+    :func:`watch_poll` compares this tuple for EQUALITY, so any change it
+    cannot represent is a rotation the watcher never reports — and a
+    missed rotation is a missed warning, because a shared-account
+    ``refreshToken`` is single-use: one rotation invalidates every
+    co-tenant's in-memory token.
+
+    Each term covers a different way two consecutive writes can look
+    identical:
+
+    * ``st_mtime_ns`` — the raw integer, NOT the ``st_mtime`` float it
+      replaces. ``st_mtime`` is a lossy conversion: at a 2026 epoch a
+      double's ulp is ~477 ns, so two writes closer together than that
+      collapse to the same value.
+    * ``st_size`` — the only discriminator left on a filesystem with
+      coarse (whole-second) timestamps, where ``st_mtime_ns`` is
+      nanosecond-TYPED but not nanosecond-ACCURATE and its low digits
+      are simply zero.
+    * ``st_ino`` — moves whenever the file is REPLACED rather than
+      rewritten. Both credential writers we control
+      (``active_login_write.sync_active_login`` and
+      ``creds_sync._atomic_copy``) write a tmp file then ``os.replace``
+      it, so the inode moves on exactly the rotation where the other two
+      terms are least helpful: measured on this fleet a rotated token
+      bundle is the SAME LENGTH as its predecessor (1102 bytes across
+      successive rotations), so ``st_size`` alone cannot see a rotation.
+
+    Limitation, stated rather than papered over: inode numbers are
+    RECYCLED — on ext4 a freed inode is handed straight back to the next
+    allocation — so this is a strengthening, not a guarantee. A collision
+    now requires the same timestamp granule AND an identical size AND a
+    recycled inode simultaneously, which is far less reachable than any
+    single term but is not impossible.
+    """
     try:
         st = path.stat()
     except OSError:  # stx-allow: fallback (reason: file may not exist yet — None signals "no live cred", caller treats it as unchanged-absent)
         return None
-    return (st.st_mtime, st.st_size)
+    return (st.st_mtime_ns, st.st_size, st.st_ino)
 
 
 def watch_poll(
@@ -108,8 +143,11 @@ def watch_poll(
     """Poll the live credential and sync on every change.
 
     Runs an initial sync, then watches the file signature
-    (``mtime``+``size``) every ``interval`` seconds, syncing whenever it
-    changes. ``iterations`` caps the number of poll cycles (``None`` =
+    (:func:`_signature` — ``mtime_ns``+``size``+``ino``) every
+    ``interval`` seconds, syncing whenever it changes. A term dropped
+    from that key is a rotation this loop silently misses, so each one
+    is covered by its own mutation test.
+    ``iterations`` caps the number of poll cycles (``None`` =
     forever); the cap makes the loop smoke-testable against a tmp file.
     ``sleep_fn`` is injected so a test can drive the loop without real
     sleeps.

--- a/tests/scitex_agent_container/_account/test_creds_watch.py
+++ b/tests/scitex_agent_container/_account/test_creds_watch.py
@@ -21,10 +21,21 @@ from pathlib import Path
 import pytest
 
 from scitex_agent_container._account.creds_watch import (
+    _signature,
     default_log_path,
     run_sync_once,
     watch_poll,
 )
+
+# A whole-second ns timestamp. Whole-second so the float(st_mtime)
+# conversion is EXACT, which makes the sub-ulp test below deterministic
+# rather than dependent on where the rounding boundary happens to fall.
+_PINNED_NS = 1_784_352_999_000_000_000
+
+# The live credential bundle's real size on this fleet. Successive
+# rotations were measured at exactly this length, which is why st_size
+# alone cannot detect a token rotation.
+_CRED_BYTES = 1_102
 
 
 @pytest.fixture
@@ -186,3 +197,85 @@ def test_watch_poll_no_change_does_not_log_change_detected(
     watch_poll(home=home, log=log, iterations=2, sleep_fn=lambda _s: None)
     # Assert
     assert "change detected" not in log.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# _signature — the change-detection EQUALITY key
+#
+# A term missing from this key is a token rotation the watcher never
+# reports. Each test below pins the OTHER two terms so it fails if and
+# only if its own term is dropped — i.e. each is a mutation test for one
+# element of the tuple.
+#
+# Note on method: timestamps are pinned with os.utime(ns=...) rather than
+# produced by sleeping. A test that merely writes twice in quick
+# succession does NOT discriminate the old key from the new one on a
+# nanosecond-granularity filesystem — both pass — which is exactly how
+# the float-mtime defect survived review. Pinning states the intended
+# collision directly instead of hoping the scheduler produces it.
+# ---------------------------------------------------------------------------
+
+
+def test_signature_is_none_for_absent_file(tmp_path: Path) -> None:
+    # Arrange — no live credential on disk yet.
+    missing = tmp_path / ".credentials.json"
+    # Act
+    sig = _signature(missing)
+    # Assert
+    assert sig is None
+
+
+def test_signature_changes_when_mtime_moves_below_float_precision(
+    tmp_path: Path,
+) -> None:
+    # Arrange — two same-length writes 1 ns apart. At a 2026 epoch a
+    # double's ulp is ~477 ns, so both timestamps convert to the SAME
+    # st_mtime float: the old (st_mtime, st_size) key cannot see this.
+    # Size and inode are held constant (in-place rewrite), so mtime_ns is
+    # the only term that can distinguish them.
+    path = tmp_path / ".credentials.json"
+    path.write_text("a" * _CRED_BYTES)
+    os.utime(path, ns=(_PINNED_NS, _PINNED_NS))
+    before = _signature(path)
+    path.write_text("b" * _CRED_BYTES)
+    os.utime(path, ns=(_PINNED_NS + 1, _PINNED_NS + 1))
+    # Act
+    after = _signature(path)
+    # Assert
+    assert after != before
+
+
+def test_signature_changes_when_only_inode_moves(tmp_path: Path) -> None:
+    # Arrange — an atomic tmp+os.replace rotation, which is how BOTH
+    # credential writers we control update the file. mtime and size are
+    # forced identical across the swap, so the inode is the only term
+    # left that can reveal the rotation.
+    path = tmp_path / ".credentials.json"
+    path.write_text("a" * _CRED_BYTES)
+    os.utime(path, ns=(_PINNED_NS, _PINNED_NS))
+    before = _signature(path)
+    rotated = tmp_path / ".credentials.json.tmp"
+    rotated.write_text("b" * _CRED_BYTES)
+    os.replace(rotated, path)
+    os.utime(path, ns=(_PINNED_NS, _PINNED_NS))
+    # Act
+    after = _signature(path)
+    # Assert
+    assert after != before
+
+
+def test_signature_changes_when_only_size_moves(tmp_path: Path) -> None:
+    # Arrange — models a coarse (whole-second) filesystem by pinning the
+    # timestamp identical across an in-place rewrite that keeps the same
+    # inode. Size is then the only term that can see the change, which is
+    # why it stays in the key even though mtime_ns is finer-grained.
+    path = tmp_path / ".credentials.json"
+    path.write_text("a" * _CRED_BYTES)
+    os.utime(path, ns=(_PINNED_NS, _PINNED_NS))
+    before = _signature(path)
+    path.write_text("a" * (_CRED_BYTES * 2))
+    os.utime(path, ns=(_PINNED_NS, _PINNED_NS))
+    # Act
+    after = _signature(path)
+    # Assert
+    assert after != before


### PR DESCRIPTION
## The bug

`_account/creds_watch.py:96` returned `(st.st_mtime, st.st_size)` — a change-detection **equality** key built from a float-second mtime. Two writes inside one timestamp granule with the same length compare equal, so the watcher concludes nothing changed.

That is not hypothetical for this file. **A rotated token bundle is the same length as its predecessor** — measured on this fleet:

| file | bytes |
|---|---|
| `~/.claude/.credentials.json` | 1102 |
| `.credentials.json.bak` (its immediate predecessor) | 1102 |
| `.credentials.json.bak-expired-20260714-025724` | 1102 |

So `st_size` cannot see a rotation at all, leaving the timestamp as the only real term. A shared-account `refreshToken` is single-use — one rotation invalidates every co-tenant's in-memory token — so a watcher that can miss a rotation is a watcher that cannot warn anyone. `inotifywait` is absent in the container, so `watch_poll` (and this key) is the *active* detection path here, not a fallback corner case.

## The fix

`(st_mtime_ns, st_size, st_ino)`. Each term is load-bearing:

- **`st_mtime_ns`** — `st_mtime` is a lossy conversion. At a 2026 epoch a double's ulp is ~477 ns, so writes closer than that collapse to one value.
- **`st_size`** — the only discriminator left on a coarse-timestamp filesystem, where `st_mtime_ns` is nanosecond-*typed* but not nanosecond-*accurate* and its low digits are zeros.
- **`st_ino`** — `(st_mtime_ns, st_size)` alone was **not** enough. Both credential writers we control (`active_login_write.sync_active_login`, `creds_sync._atomic_copy`) write tmp + `os.replace`, so the inode moves on exactly the atomic rotation where the other two terms are least helpful.

**Residual, documented in the docstring rather than papered over:** inode numbers are recycled — on ext4 a freed inode goes straight back to the next allocation (measured: `os.replace` cycled between two inode numbers). This narrows the hole; it does not close it.

## Mutation evidence

Each term has a test that goes RED when only that term is dropped.

**Against the original shipped key `(st_mtime, st_size)`:**

```
tests/scitex_agent_container/_account/test_creds_watch.py .FF.           [100%]
E   assert (1784352999.0, 1102) != (1784352999.0, 1102)   # mtime test
E   assert (1784352999.0, 1102) != (1784352999.0, 1102)   # inode test
================== 2 failed, 2 passed, 9 deselected in 1.60s ===================
```

**Against `(st_mtime_ns, st_size)` — i.e. the ns fix without the inode:**

```
E   assert (1784352999000000000, 1102) != (1784352999000000000, 1102)
================== 1 failed, 3 passed, 9 deselected in 0.27s ===================
```

**Against `(st_mtime_ns, st_ino)` — i.e. dropping size:**

```
E   assert (1784352999000000000, 14656241) != (1784352999000000000, 14656241)
================== 1 failed, 3 passed, 9 deselected in 0.20s ===================
```

**With the real fix:** `13 passed in 0.69s`.

## On the test method (why the obvious test is not written here)

A test that writes the file twice with a sleep between them **passes under the buggy code**. This filesystem (ext4) reports *true* nanosecond mtimes — four back-to-back same-size writes gave 4/4 distinct `st_mtime_ns` **and** 4/4 distinct `st_mtime` floats — so both the old and new keys distinguish two ordinary writes and the naive test proves nothing. That is how this defect survived.

The tests therefore pin timestamps with `os.utime(ns=...)` and state the intended collision directly: deterministic, no sleep, no flake. The 1 ns delta is provably below the ~238 ns half-ulp, so the float collision is guaranteed rather than hoped for.

## Not persisted

The key is held only in `watch_poll`'s local `last`; nothing serializes it. On restart the loop runs an unconditional `run_sync_once` and then establishes a fresh baseline, so there is no cross-restart comparison and no old-float-vs-new-ns format mismatch to guard against.

## Scope

Only this equality key. The ~20 other bare `st_mtime` uses in sac are sorting (`key=lambda p: p.stat().st_mtime`) and age arithmetic (`_now() - mtime`), where float granularity is harmless — only equality turns granularity into correctness. `_liveness_tick_resolve.py` and `_verdict_state.py` are deliberately untouched.

Found by sweeping sac after scitex-cards hit the identical defect in their board cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqhsrw29CM4siBLcEK2CwV