### PR TITLE
feat(auth-events): one collected fleet auth log — attempt and outcome as SEPARATE records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **A single collected fleet AUTH-EVENT log (`sac auth-events`)**. Operator,
+  2026-07-18: 「サーバーが落とすんだから、ログを取ればいいんじゃないですか？」 — the
+  server is what drops us, so log it. New `_authevents` package: an append-only
+  JSONL rail at `<runtime>/auth-events.jsonl` (beside `auth-heal.log`), one line
+  per auth event, with UTC ISO timestamp, agent, event type, HTTP status,
+  account and free-text detail. It **OBSERVES ONLY** — no detector, no
+  restarter, no remediation; `auth-heal.py` keeps owning that.
+
+  **Attempt and outcome are SEPARATE records, joined by `attempt_id`.** This is
+  the point, not a detail: `auth-heal.log` carried 169 `-> auto-restart` lines
+  over seven days whose `age=` field never reset (one reached 262200s = three
+  days). Each stated an INTENT in the grammar of an EFFECT, and nothing existed
+  that could contradict one. `unresolved_attempts()` now answers "which restarts
+  were attempted and never shown to work" — covering both an outcome that says
+  `succeeded: false` and an outcome that never arrived. The suite
+  mutation-proves the separation: collapsing the two emissions into one combined
+  "restarted" event turns four tests red.
+
+  **The rotation event was never missing — it was unjoined.**
+  `_account._rotation_audit` has recorded every credential rotation to
+  `<accounts-store>/rotation-audit.jsonl` for weeks. Checked against the
+  2026-07-18 incident, the last record before six agents died at ~19:30 JST
+  reads `10:31:28 UTC` — the deaths, to the minute. So this PR adds **no second
+  rotation writer**; `_authevents._timeline` PROJECTS that existing audit at
+  read time, leaving `rotation-audit.jsonl` the single source of truth (and its
+  fingerprint-only security contract intact) while putting rotations and their
+  consequences in one ordered reading.
+
+  Fail-open throughout: every write is best-effort and returns a bool, so an
+  unwritable log can never abort the restart or refresh it observes. Fields are
+  tri-state — an undeterminable account is written as `null`, never guessed and
+  never omitted, since an absent key and an unknown value are different facts.
+  No `http_status` is synthesised from a "Login expired" banner: Claude Code
+  renders ANY 401 that way, sometimes when nothing expired, so a banner is
+  recorded as a banner.
+
 ## [0.21.26] - 2026-07-18
 
 ### Added

--- a/src/scitex_agent_container/_authevents/__init__.py
+++ b/src/scitex_agent_container/_authevents/__init__.py
@@ -1,0 +1,66 @@
+"""The fleet AUTH-EVENT log: one collected, machine-parseable auth timeline.
+
+Operator, 2026-07-18: 「サーバーが落とすんだから、ログを取ればいいんじゃないですか？
+普通にバグのためにも開発のためにもログは必要なんじゃないですか？」 — the server is
+what drops us, so log it; logs are needed for debugging and for development.
+
+This package OBSERVES ONLY. It contains no detector, no restarter and no
+remediation of any kind: ``auth-heal.py`` and :mod:`.._authheal` own that, and
+a second actor on this rail would be the double-supervisor class in a new
+costume. :mod:`._log` is the append-only writer/reader; :mod:`._timeline` joins
+those events with the credential rotations :mod:`.._account._rotation_audit`
+already records, so the causal event and its consequences finally read as one
+ordered story. Surfaced as ``sac auth-events``.
+"""
+
+from __future__ import annotations
+
+from ._account_label import resolve_account_for_agent
+from ._log import (
+    AUTH_EVENT_FILENAME,
+    AUTH_EVENT_LOG_ENV,
+    AUTH_FAILURE_OBSERVED,
+    KNOWN_EVENTS,
+    RESTART_ATTEMPTED,
+    RESTART_OUTCOME,
+    TOKEN_ROTATED,
+    AuthEvent,
+    auth_event_log_path,
+    log_auth_event,
+    log_auth_failure_observed,
+    log_restart_attempted,
+    log_restart_outcome,
+    log_token_rotated,
+    read_auth_events,
+    unresolved_attempts,
+)
+from ._timeline import (
+    ROTATION_AUDIT_FILENAME,
+    rotation_audit_path,
+    rotation_events,
+    unified_timeline,
+)
+
+__all__ = [
+    "AUTH_EVENT_FILENAME",
+    "AUTH_EVENT_LOG_ENV",
+    "AUTH_FAILURE_OBSERVED",
+    "KNOWN_EVENTS",
+    "RESTART_ATTEMPTED",
+    "RESTART_OUTCOME",
+    "ROTATION_AUDIT_FILENAME",
+    "TOKEN_ROTATED",
+    "AuthEvent",
+    "auth_event_log_path",
+    "log_auth_event",
+    "log_auth_failure_observed",
+    "log_restart_attempted",
+    "log_restart_outcome",
+    "log_token_rotated",
+    "read_auth_events",
+    "resolve_account_for_agent",
+    "rotation_audit_path",
+    "rotation_events",
+    "unified_timeline",
+    "unresolved_attempts",
+]

--- a/src/scitex_agent_container/_authevents/_account_label.py
+++ b/src/scitex_agent_container/_authevents/_account_label.py
@@ -1,0 +1,64 @@
+"""Best-effort: WHICH account was an agent using when this happened?
+
+The account is the field that makes the log answer the question the operator
+actually asks — "six died at once, whose token rotated?" Correlating deaths
+against rotations is only possible if each death record names an account.
+
+IT MUST BE ALLOWED TO SAY "I DON'T KNOW"
+    So this resolver returns ``None`` on every failure path, and ``None`` is
+    written to the log as JSON ``null`` — present, and explicitly unknown.
+    The alternative (guessing the host's current account, or reusing the
+    literal ``"unknown"`` string the label resolver returns) would put a
+    plausible value into the exact field investigators join on. A field that
+    can only ever say "yes" cannot corroborate anything; an account that is
+    wrong is worse than an account that is missing, because it will be
+    believed and it will send someone to the wrong rotation.
+
+    Note also what this resolves: the account an agent is CONFIGURED to use,
+    read from its spec. That is a strong hint, not proof of the credential the
+    wedged process is actually holding in memory — an agent started before a
+    reassignment holds the OLD one. Treat it as a hint and say so in the log.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["resolve_account_for_agent"]
+
+
+def resolve_account_for_agent(
+    name: str, *, specs_dir: Path | None = None
+) -> str | None:
+    """The account label for ``name``, or ``None`` if undeterminable.
+
+    Never raises, never blocks and never guesses. Every failure — no registry,
+    no spec, an unparseable spec, a resolver hiccup — collapses to ``None``,
+    which the writer records as ``null``.
+    """
+    # stx-allow: fallback (reason: this fills ONE optional field on an
+    # observability record. Any failure must render as UNKNOWN (None) and can
+    # never be allowed to raise into the restart path being observed.)
+    try:
+        from .._reconcile._pass import fleet_agents_dir
+
+        root = specs_dir if specs_dir is not None else fleet_agents_dir()
+        spec = Path(root) / name / "spec.yaml"
+        if not spec.is_file():
+            return None
+
+        from .._account.agent_account import resolve_agent_account_label
+        from ..config import load_config
+
+        config = load_config(spec)
+        env = getattr(config, "env", None)
+        assigned = getattr(getattr(config, "claude", None), "account", "") or None
+        label = resolve_agent_account_label(env, assigned_account=assigned)
+        # The label resolver answers the literal "unknown" when it has no
+        # credentials file and no override. That is a non-answer, so it must
+        # not travel as though it were one.
+        if not label or str(label).strip().lower() == "unknown":
+            return None
+        return str(label)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None

--- a/src/scitex_agent_container/_authevents/_log.py
+++ b/src/scitex_agent_container/_authevents/_log.py
@@ -1,0 +1,427 @@
+"""The append-only fleet AUTH-EVENT log — one JSONL line per auth event.
+
+WHY THIS EXISTS (operator, 2026-07-18)
+    「サーバーが落とすんだから、ログを取ればいいんじゃないですか？」 — the server
+    is what drops us, so log it. On 2026-07-18 ~19:30 JST six parallel workers
+    died at once behind "Login expired". The facts needed to explain that —
+    WHICH account rotated, WHEN, and whether the restarts that followed did
+    anything — existed in three unjoined places: ``auth-heal.log`` (prose,
+    intent-only), ``accounts/rotation-audit.jsonl`` (the causal rotation), and
+    each agent's private session transcript. No single timeline held them, so a
+    one-query answer took hours. This module is that timeline.
+
+WHAT IT IS AND IS NOT
+    It OBSERVES. It never detects, restarts, refreshes or remediates anything —
+    ``auth-heal.py`` / :mod:`.._authheal` own remediation and keep owning it. A
+    second actor on this rail would be the double-supervisor class; a recorder
+    is not an actor.
+
+ATTEMPT AND OUTCOME ARE SEPARATE RECORDS — THE WHOLE POINT
+    ``auth-heal.log`` recorded 169 ``-> auto-restart`` lines over seven days
+    whose ``age=`` field never reset (one reached 262200s = three days). Every
+    one of those lines is a statement of INTENT that reads exactly like a
+    statement of EFFECT, and nothing existed to disagree with it. So a restart
+    here writes TWO records — :data:`RESTART_ATTEMPTED` before the act,
+    :data:`RESTART_OUTCOME` after it — joined by an ``attempt_id``. An attempt
+    whose outcome never lands, or lands with ``succeeded: false``, is then a
+    QUERY (:func:`unresolved_attempts`), not an inference from screens. Merging
+    them back into one "restarted" event would restore the exact blindness that
+    let 169 ineffective restarts look like remediation.
+
+FAIL-OPEN, ALWAYS
+    This is an observability rail bolted to the side of the auth path. Every
+    write is best-effort and returns a bool; a full disk, a read-only mount or a
+    serialisation failure must NEVER abort a restart or a refresh. The thing
+    observed always outranks the observing of it.
+
+TRI-STATE FIELDS
+    ``account`` and ``http_status`` are ALWAYS present and are ``null`` when not
+    determinable. An absent field and an unknown value are different facts: the
+    first says nobody thought to record it, the second says we looked and could
+    not tell. Never guess an account onto a record — a wrong account is worse
+    than a null one, because it will be believed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+__all__ = [
+    "AUTH_EVENT_FILENAME",
+    "AUTH_EVENT_LOG_ENV",
+    "AUTH_FAILURE_OBSERVED",
+    "KNOWN_EVENTS",
+    "RESTART_ATTEMPTED",
+    "RESTART_OUTCOME",
+    "TOKEN_ROTATED",
+    "AuthEvent",
+    "auth_event_log_path",
+    "log_auth_event",
+    "log_auth_failure_observed",
+    "log_restart_attempted",
+    "log_restart_outcome",
+    "log_token_rotated",
+    "read_auth_events",
+    "unresolved_attempts",
+]
+
+#: Filename of the append-only event log, relative to the runtime dir. Sits
+#: alongside ``auth-heal.log`` deliberately — the convention is the runtime
+#: dir, and an observability file that needs explaining where it lives is one
+#: nobody will open at 3am.
+AUTH_EVENT_FILENAME = "auth-events.jsonl"
+
+#: An auth failure was OBSERVED (an HTTP 401 seen, or a login banner on a pane).
+#: Note the name: what is recorded is that we SAW it, not that a token expired.
+#: Claude Code renders ANY 401 as "Login expired · Please run /login" while
+#: nothing has necessarily expired, so the string is not the fact — the status
+#: code, the account and the timing are.
+AUTH_FAILURE_OBSERVED = "auth-failure-observed"
+
+#: A credential ROTATION was performed. THE causal event: the refresh_token is
+#: single-use, so one rotation invalidates every co-tenant's in-memory token at
+#: once. Six agents dying together is one of these, not six coincidences.
+TOKEN_ROTATED = "token-rotated"
+
+#: A restart was ATTEMPTED. Written BEFORE the act, so an attempt that never
+#: returns still leaves a record. Intent — never read this as effect.
+RESTART_ATTEMPTED = "restart-attempted"
+
+#: What the attempt ACTUALLY did, carrying ``attempt_id`` + ``succeeded``.
+#: This is the record that can REFUTE the one above.
+RESTART_OUTCOME = "restart-outcome"
+
+#: The closed set. Unknown values are still written (forward-compat: a record
+#: we do not recognise is evidence too) but flagged with ``event_known: false``
+#: so a reader can tell a new event type from a typo.
+KNOWN_EVENTS = frozenset(
+    {AUTH_FAILURE_OBSERVED, TOKEN_ROTATED, RESTART_ATTEMPTED, RESTART_OUTCOME}
+)
+
+#: Env override for the log location. Lets a test drive a REAL file in a temp
+#: dir (no mocks) and lets an operator relocate the rail without a code change.
+AUTH_EVENT_LOG_ENV = "SAC_AUTH_EVENT_LOG"
+
+
+def auth_event_log_path() -> Path:
+    """Where the auth-event log lives. Resolved PER CALL, never cached.
+
+    Per-call resolution matters: a module-level constant computed at import
+    cannot be redirected by an env var a test sets afterwards, which is how a
+    suite ends up writing into the REAL fleet runtime dir while believing it is
+    hermetic.
+    """
+    override = os.environ.get(AUTH_EVENT_LOG_ENV)
+    if override:
+        return Path(override).expanduser()
+    from .._state.state_paths import runtime_root
+
+    return runtime_root() / AUTH_EVENT_FILENAME
+
+
+def _resolve_host() -> str:
+    """Best-effort canonical host label. Never raises."""
+    # stx-allow: fallback (reason: the host is a cosmetic label on an
+    # observability record; a resolver failure must degrade to a short
+    # hostname and then to "unknown", never break the write.)
+    try:
+        from .._state.state_db_hostname import resolve_host
+
+        return resolve_host(None)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        try:
+            return socket.gethostname()
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            return "unknown"
+
+
+def _normalise_account(account: str | None) -> str | None:
+    """Map a non-answer to ``None`` so the record says UNKNOWN, not a guess.
+
+    ``resolve_agent_account_label`` answers the literal string ``"unknown"``
+    when it has no credentials file and no env override. Writing that through
+    verbatim would put a plausible-looking value in a field readers join on.
+    An unknown account must read as ``null`` — the tri-state — so nobody
+    correlates a rotation against the string "unknown" and believes it.
+    """
+    if account is None:
+        return None
+    text = str(account).strip()
+    if not text or text.lower() == "unknown":
+        return None
+    return text
+
+
+def log_auth_event(
+    *,
+    event: str,
+    agent: str | None,
+    detail: str,
+    account: str | None = None,
+    http_status: int | None = None,
+    path: Path | None = None,
+    now: float | None = None,
+    extra: dict[str, Any] | None = None,
+) -> bool:
+    """Append ONE auth event. Returns success; NEVER raises.
+
+    Parameters
+    ----------
+    event
+        One of :data:`KNOWN_EVENTS`. Unknown values are recorded anyway and
+        marked ``event_known: false``.
+    agent
+        The agent this concerns, or ``None`` when it is fleet-wide (a rotation
+        hits every co-tenant, so it belongs to no single agent).
+    account
+        The account in play. ``None``, or an undeterminable label, is written
+        as JSON ``null`` — present-and-unknown, never absent, never guessed.
+    http_status
+        The HTTP status when one was actually observed, else ``None``. Do not
+        synthesise a 401 from a banner string: a banner is a rendering, a
+        status code is a fact, and this field is for facts.
+    """
+    now_ts = now if now is not None else datetime.now(tz=timezone.utc).timestamp()
+    record: dict[str, Any] = {
+        "timestamp_utc": datetime.fromtimestamp(now_ts, tz=timezone.utc).isoformat(),
+        "event": event,
+        "agent": agent,
+        # Tri-state, always present: null == "we looked and could not tell".
+        "account": _normalise_account(account),
+        "http_status": http_status,
+        "detail": detail,
+        "host": _resolve_host(),
+        "pid": os.getpid(),
+    }
+    if event not in KNOWN_EVENTS:
+        record["event_known"] = False
+    if extra:
+        for key, val in extra.items():
+            record.setdefault(key, val)
+
+    target = path if path is not None else auth_event_log_path()
+    # stx-allow: fallback (reason: FAIL-OPEN is this rail's contract. A failure
+    # to record an auth event must never abort the restart or refresh being
+    # observed — losing a log line is bad, losing the recovery is worse.)
+    try:
+        target = Path(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+        return True
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return False
+
+
+def log_auth_failure_observed(
+    *,
+    agent: str | None,
+    detail: str,
+    account: str | None = None,
+    http_status: int | None = None,
+    path: Path | None = None,
+    now: float | None = None,
+    extra: dict[str, Any] | None = None,
+) -> bool:
+    """Record that an auth failure was SEEN. Returns success; never raises."""
+    return log_auth_event(
+        event=AUTH_FAILURE_OBSERVED,
+        agent=agent,
+        detail=detail,
+        account=account,
+        http_status=http_status,
+        path=path,
+        now=now,
+        extra=extra,
+    )
+
+
+def log_token_rotated(
+    *,
+    account: str | None,
+    detail: str,
+    agent: str | None = None,
+    path: Path | None = None,
+    now: float | None = None,
+    extra: dict[str, Any] | None = None,
+) -> bool:
+    """Record a credential rotation — the causal event. Never raises."""
+    return log_auth_event(
+        event=TOKEN_ROTATED,
+        agent=agent,
+        detail=detail,
+        account=account,
+        path=path,
+        now=now,
+        extra=extra,
+    )
+
+
+def log_restart_attempted(
+    *,
+    agent: str,
+    detail: str,
+    account: str | None = None,
+    attempt_id: str | None = None,
+    path: Path | None = None,
+    now: float | None = None,
+    extra: dict[str, Any] | None = None,
+) -> str:
+    """Record that a restart is ABOUT to be attempted; return its ``attempt_id``.
+
+    Written BEFORE the restart runs, so a restart that hangs, crashes the
+    process, or is killed by a timer still leaves its intent on the record.
+    The returned id is what :func:`log_restart_outcome` joins on.
+
+    Returns the ``attempt_id`` even if the write FAILED — the caller must be
+    able to carry on and still label its outcome. This function's job is to
+    observe the restart, never to gate it.
+    """
+    ident = attempt_id or uuid.uuid4().hex[:12]
+    payload: dict[str, Any] = {"attempt_id": ident}
+    if extra:
+        payload.update(extra)
+    log_auth_event(
+        event=RESTART_ATTEMPTED,
+        agent=agent,
+        detail=detail,
+        account=account,
+        path=path,
+        now=now,
+        extra=payload,
+    )
+    return ident
+
+
+def log_restart_outcome(
+    *,
+    agent: str,
+    attempt_id: str,
+    succeeded: bool,
+    detail: str,
+    account: str | None = None,
+    path: Path | None = None,
+    now: float | None = None,
+    extra: dict[str, Any] | None = None,
+) -> bool:
+    """Record what the attempt ACTUALLY did. Never raises.
+
+    ``succeeded=False`` is the record that REFUTES the attempt above it. It is
+    a first-class outcome, not an error path: a restart that ran and left the
+    agent wedged is exactly the event the 169-line ``auto-restart`` history
+    could not express.
+    """
+    payload: dict[str, Any] = {"attempt_id": attempt_id, "succeeded": bool(succeeded)}
+    if extra:
+        payload.update(extra)
+    return log_auth_event(
+        event=RESTART_OUTCOME,
+        agent=agent,
+        detail=detail,
+        account=account,
+        path=path,
+        now=now,
+        extra=payload,
+    )
+
+
+@dataclass(frozen=True)
+class AuthEvent:
+    """One parsed record. ``raw`` keeps every field, including unknown ones."""
+
+    timestamp_utc: str | None
+    event: str | None
+    agent: str | None
+    account: str | None
+    http_status: int | None
+    detail: str | None
+    raw: dict[str, Any]
+
+    @property
+    def attempt_id(self) -> str | None:
+        value = self.raw.get("attempt_id")
+        return str(value) if value is not None else None
+
+    @property
+    def succeeded(self) -> bool | None:
+        """Tri-state: True / False / ``None`` when the record does not say."""
+        value = self.raw.get("succeeded")
+        return bool(value) if isinstance(value, bool) else None
+
+
+def _parse(line: str) -> AuthEvent | None:
+    # stx-allow: fallback (reason: a half-written or corrupt line must not
+    # blind a reader to the thousands of good ones around it — an append-only
+    # log read during an incident has to degrade, not refuse.)
+    try:
+        obj = json.loads(line)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+    if not isinstance(obj, dict):
+        return None
+    status = obj.get("http_status")
+    return AuthEvent(
+        timestamp_utc=obj.get("timestamp_utc"),
+        event=obj.get("event"),
+        agent=obj.get("agent"),
+        account=obj.get("account"),
+        http_status=status if isinstance(status, int) else None,
+        detail=obj.get("detail"),
+        raw=obj,
+    )
+
+
+def read_auth_events(path: Path | None = None) -> list[AuthEvent]:
+    """Read the log, skipping unparseable lines. Returns ``[]`` if absent.
+
+    A missing log is an empty reading, not an error — but note it is also NOT
+    evidence that no auth event happened. Absence of the rail is absence of
+    evidence, and this function cannot tell those apart for you.
+    """
+    target = Path(path) if path is not None else auth_event_log_path()
+    # stx-allow: fallback (reason: reading is diagnostic; an unreadable log
+    # must degrade to an empty reading rather than raise into an incident.)
+    try:
+        with target.open("r", encoding="utf-8") as handle:
+            return [event for event in (_parse(ln) for ln in handle) if event]
+    except FileNotFoundError:
+        return []
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return []
+
+
+def unresolved_attempts(events: Iterable[AuthEvent]) -> list[AuthEvent]:
+    """Attempts with NO successful outcome — the refutation query.
+
+    Returns every :data:`RESTART_ATTEMPTED` whose ``attempt_id`` has no
+    :data:`RESTART_OUTCOME` recording ``succeeded: true``. That covers both
+    ways a restart fails to be remediation:
+
+    * an outcome landed saying ``succeeded: false`` — it ran and did not work;
+    * no outcome landed at all — it never came back to tell us.
+
+    Both are "we tried and cannot show it worked", which is precisely what 169
+    ``-> auto-restart`` lines were silently asserting the opposite of. An
+    attempt leaves this list only by being contradicted by a real success.
+    """
+    collected = list(events)
+    succeeded_ids = {
+        event.attempt_id
+        for event in collected
+        if event.event == RESTART_OUTCOME
+        and event.succeeded is True
+        and event.attempt_id
+    }
+    return [
+        event
+        for event in collected
+        if event.event == RESTART_ATTEMPTED
+        and (event.attempt_id is None or event.attempt_id not in succeeded_ids)
+    ]

--- a/src/scitex_agent_container/_authevents/_timeline.py
+++ b/src/scitex_agent_container/_authevents/_timeline.py
@@ -1,0 +1,159 @@
+"""ONE timeline: auth events joined with the rotations that caused them.
+
+THE ROTATION EVENT WAS NEVER MISSING — IT WAS UNJOINED
+    The obvious design here is a new "token rotated" emitter. It would be
+    wrong. :mod:`.._account._rotation_audit` has been recording every
+    credential rotation to ``<accounts-store>/rotation-audit.jsonl`` for weeks,
+    with the account, the reason, the host, the pid and opaque FROM→TO token
+    fingerprints. Checked against the 2026-07-18 incident, the last record
+    before six agents died reads::
+
+        {"timestamp_utc": "2026-07-18T10:31:28.316535+00:00",
+         "event": "refresh", "from_account": "ywata1989-gmail-com", ...
+         "reason": "single-use refresh_token rotated (headless access-token
+                    refresh)", "pid": 830472}
+
+    10:31:28 UTC is 19:31:28 JST — the deaths, to the minute. The causal fact
+    was on disk the whole time. What did not exist was anything that put it in
+    the same timeline as the restarts that followed, so nobody looked.
+
+    Adding a second rotation writer would therefore fix nothing and cost
+    something real: two files claiming to record the same event, drifting, with
+    no rule for which is authoritative. Instead this module PROJECTS the
+    existing audit into the shared shape at READ time. ``rotation-audit.jsonl``
+    stays the single source of truth for rotations and keeps its security
+    contract (fingerprints only, never token material); the timeline borrows
+    from it and owns nothing.
+
+WHAT A MERGED TIMELINE LETS YOU ASK
+    "Six agents died at 19:30 — what rotated just before?" becomes one ordered
+    read instead of an inference from screens and stuck-durations. That is the
+    entire ask, and it needs no new detector, restarter or daemon.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ._log import TOKEN_ROTATED, AuthEvent, read_auth_events
+
+__all__ = [
+    "ROTATION_AUDIT_FILENAME",
+    "rotation_audit_path",
+    "rotation_events",
+    "unified_timeline",
+]
+
+#: Mirrors ``_account._rotation_audit.AUDIT_FILENAME``. Imported lazily in
+#: :func:`rotation_audit_path` so a reader never drags the account stack in.
+ROTATION_AUDIT_FILENAME = "rotation-audit.jsonl"
+
+
+def rotation_audit_path() -> Path:
+    """Where the rotation audit lives. Resolved per call; never raises."""
+    # stx-allow: fallback (reason: this is a diagnostic reader. If the account
+    # store cascade cannot be resolved we still want a usable default rather
+    # than an exception thrown into an incident investigation.)
+    try:
+        from .._state.account_store import _store_path
+
+        return _store_path(None, Path.home()) / ROTATION_AUDIT_FILENAME
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return (
+            Path.home()
+            / ".scitex"
+            / "agent-container"
+            / "accounts"
+            / ROTATION_AUDIT_FILENAME
+        )
+
+
+def _project(record: dict[str, Any]) -> AuthEvent:
+    """Turn ONE rotation-audit record into a :class:`AuthEvent`.
+
+    The audit's ``to_account`` is the account that ends up holding the new
+    token, so it is the account the event is ABOUT. Its ``event`` value
+    (``refresh`` / ``switch`` / ``auto-rotate`` / …) is preserved verbatim
+    under ``rotation_event`` — flattening those distinct triggers into one
+    word would discard exactly the detail that says whether a rotation was a
+    scheduled refresh or somebody reacting to a 429.
+    """
+    detail = record.get("reason") or "credential rotation"
+    from_account = record.get("from_account")
+    to_account = record.get("to_account")
+    if from_account and to_account and from_account != to_account:
+        detail = f"{detail} ({from_account} -> {to_account})"
+    raw = dict(record)
+    raw.update(
+        {
+            "event": TOKEN_ROTATED,
+            "agent": None,  # a rotation hits every co-tenant, not one agent
+            "account": to_account or from_account,
+            "http_status": None,
+            "detail": detail,
+            "rotation_event": record.get("event"),
+            "source": ROTATION_AUDIT_FILENAME,
+        }
+    )
+    return AuthEvent(
+        timestamp_utc=record.get("timestamp_utc"),
+        event=TOKEN_ROTATED,
+        agent=None,
+        account=to_account or from_account,
+        http_status=None,
+        detail=detail,
+        raw=raw,
+    )
+
+
+def rotation_events(path: Path | None = None) -> list[AuthEvent]:
+    """Read the rotation audit, projected into auth-event shape.
+
+    Returns ``[]`` when the audit is missing or unreadable. That empty answer
+    means "we have no rotation record here", NOT "no rotation happened" — the
+    two are different, and only the caller knows whether the rail was even
+    installed for the window being investigated.
+    """
+    import json
+
+    target = Path(path) if path is not None else rotation_audit_path()
+    # stx-allow: fallback (reason: diagnostic read — a missing or unreadable
+    # audit must degrade to an empty projection, never raise.)
+    try:
+        with target.open("r", encoding="utf-8") as handle:
+            out: list[AuthEvent] = []
+            for line in handle:
+                try:
+                    obj = json.loads(line)
+                except Exception:  # stx-allow: fallback (reason: see above)
+                    continue
+                if isinstance(obj, dict):
+                    out.append(_project(obj))
+            return out
+    except FileNotFoundError:
+        return []
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return []
+
+
+def unified_timeline(
+    *,
+    events_path: Path | None = None,
+    audit_path: Path | None = None,
+    include_rotations: bool = True,
+) -> list[AuthEvent]:
+    """Auth events + projected rotations, ordered oldest-first.
+
+    Sorted by ``timestamp_utc`` as a STRING, which is correct here only
+    because every writer emits timezone-aware ISO-8601 in UTC — same offset,
+    same field widths, so lexical order is chronological order. A record with
+    no timestamp sorts last rather than being dropped: a malformed record is
+    still evidence that something wrote one.
+    """
+    events = list(read_auth_events(events_path))
+    if include_rotations:
+        events.extend(rotation_events(audit_path))
+    return sorted(
+        events, key=lambda e: (e.timestamp_utc is None, e.timestamp_utc or "")
+    )

--- a/src/scitex_agent_container/_authheal/_observe.py
+++ b/src/scitex_agent_container/_authheal/_observe.py
@@ -1,0 +1,73 @@
+"""Record WHAT THE PASS SAW, separately from what it then did about it.
+
+The restarter's own reports say what it DECIDED. This module writes the prior,
+weaker, more durable fact — that at time T a wedge was observed on agent A —
+into the shared auth-event log (:mod:`.._authevents`), where it can be read
+alongside the credential rotations that caused it.
+
+WHY THE OBSERVATION IS WORTH A RECORD OF ITS OWN
+    ``auth-heal.log`` carried the wedge age inside its restart lines, so the
+    only way to learn how long an agent had been stuck was to read lines about
+    restarts. When those restarts stopped working the ``age=`` field just kept
+    climbing (one reached 262200s — three days) inside messages that each
+    announced a remedy. Recording the OBSERVATION on its own — every pass,
+    ``--check`` runs included — means the duration of a wedge is established by
+    repeated sightings that owe nothing to the restarter's claims about itself.
+
+This module emits. It never decides anything and never restarts anything.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .._authevents import log_auth_failure_observed, resolve_account_for_agent
+
+__all__ = ["observe_wedge"]
+
+#: Written onto every record so a reader can tell which emitter produced it —
+#: this restarter, or (one day) another one on the same rail.
+SOURCE = "sac.restart-login-expired"
+
+
+def observe_wedge(
+    name: str,
+    *,
+    specs_dir: Path | None = None,
+    event_log: Path | None = None,
+    now: float | None = None,
+) -> str | None:
+    """Record one observed wedge; return the account HINT for reuse.
+
+    The account is resolved from the agent's spec and is a hint, not proof of
+    the credential the wedged process is holding in memory — an agent started
+    before a reassignment holds the old one. ``None`` when undeterminable, and
+    ``None`` is written as ``null``: present and explicitly unknown.
+
+    Returns the hint so the caller can label its restart records with the SAME
+    value, rather than resolving twice and risking two records that disagree
+    about one agent at one instant.
+
+    Fail-open: the write is best-effort and its failure is not reported here,
+    because nothing upstream may act on it. Losing this line must never cost
+    the recovery it describes.
+    """
+    account = resolve_account_for_agent(name, specs_dir=specs_dir)
+    log_auth_failure_observed(
+        agent=name,
+        account=account,
+        # NO http_status. A frozen pane banner is a RENDERING, not a status
+        # code read off a response — and Claude Code prints "Login expired"
+        # for ANY 401, sometimes when nothing expired at all. Synthesising a
+        # 401 here would fabricate the single field this log exists to make
+        # trustworthy. Null means: we saw a wedge, we did not see a status.
+        http_status=None,
+        detail=(
+            "system auth banner frozen above the prompt across two captures "
+            "(corroborated login-expired wedge)"
+        ),
+        path=event_log,
+        now=now,
+        extra={"source": SOURCE, "detector": "tui-pane"},
+    )
+    return account

--- a/src/scitex_agent_container/_authheal/_pass.py
+++ b/src/scitex_agent_container/_authheal/_pass.py
@@ -59,6 +59,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+from .._authevents import log_restart_attempted, log_restart_outcome
 from .._reconcile._budget import (
     DEFAULT_PASS_CAP,
     Budget,
@@ -73,6 +74,7 @@ from ._detect import (
     detect_login_expired,
     registered_agents,
 )
+from ._observe import observe_wedge
 
 __all__ = [
     "DEFAULT_INTERVAL",
@@ -204,8 +206,19 @@ def _perform(
     now: float,
     restart_fn: Callable[[str], bool],
     budget_detail: str,
+    account: str | None = None,
+    event_log: Path | None = None,
 ) -> AgentReport:
-    """Turn a corroborated login-expired agent into what we actually did."""
+    """Turn a corroborated login-expired agent into what we actually did.
+
+    Emits the ATTEMPT and the OUTCOME to the auth-event log as two SEPARATE
+    records (see :mod:`.._authevents`). They are deliberately not merged: this
+    function is the exact place where intent and effect diverge — ``restart_fn``
+    can raise, or return False, or return True over an agent that is still
+    wedged — and a single "restarted" line cannot express that divergence. The
+    emission is fail-open on both sides; a log that cannot be written must not
+    cost us the restart.
+    """
     base = f"{name} is login-expired (corroborated: a system auth banner frozen above its prompt across two captures)"
     if budget is None:
         # We could not read our OWN restart memory, so the debounce and the
@@ -233,15 +246,53 @@ def _perform(
             f"{base} — would restart (dry-run/--check: nothing was done; re-run "
             f"with --apply to actually restart)",
         )
+    # The ATTEMPT is recorded BEFORE the act, so a restart that hangs, or that
+    # takes this process down with it, still leaves its intent on the record.
+    attempt_id = log_restart_attempted(
+        agent=name,
+        account=account,
+        detail=f"{base} — restarting to re-mount a live credential",
+        path=event_log,
+        now=now,
+        extra={"source": "sac.restart-login-expired"},
+    )
     # stx-allow: fallback (reason: one agent's restart raising must never abort the sweep — the rest of the wedged fleet still needs recovering; the failure is carded and reported)
     try:
         ok = restart_fn(name)
     except Exception as exc:
         budget.record(name, now)  # a restart we ATTEMPTED still spends budget
+        log_restart_outcome(
+            agent=name,
+            attempt_id=attempt_id,
+            succeeded=False,
+            account=account,
+            detail=f"restart RAISED and the agent was not recovered: {exc}",
+            path=event_log,
+            now=now,
+        )
         return AgentReport(
             name, Verdict.FAILED, "restart-raised", f"{base}; restart FAILED: {exc}"
         )
     budget.record(name, now)
+    # The OUTCOME is a separate record carrying the same attempt_id. Note what
+    # ``succeeded`` claims and what it does not: the restart CALL reported
+    # success. Whether the agent is actually authenticating again is decided by
+    # the NEXT pass's reading, not by this line — which is why the attempt is
+    # never retro-edited and the two records always both stand.
+    log_restart_outcome(
+        agent=name,
+        attempt_id=attempt_id,
+        succeeded=bool(ok),
+        account=account,
+        detail=(
+            "restart call reported success (re-observation by a later pass is "
+            "what confirms the wedge actually cleared)"
+            if ok
+            else "restart ran but reported FAILURE — the agent is still wedged"
+        ),
+        path=event_log,
+        now=now,
+    )
     if ok:
         return AgentReport(
             name,
@@ -319,12 +370,15 @@ def auth_heal_pass(
     capture_fn: Callable[[], dict] | None = None,
     interval: float = DEFAULT_INTERVAL,
     err_stream: Any = None,
+    event_log: Path | None = None,
 ) -> PassOutcome:
     """Run ONE login-expired auto-restart pass over the live TUI fleet.
 
     ``apply=False`` (the default, selected by ``--check``) is a REPORT: it
     detects and decides but restarts nothing. The only board write a dry-run
-    makes is this restarter's own heartbeat.
+    makes is this restarter's own heartbeat — and, since 2026-07-18, the
+    auth-event records of what it OBSERVED. Observing is not acting: a dry run
+    that saw a wedge really did see it, and that sighting is worth keeping.
 
     Parameters
     ----------
@@ -332,6 +386,12 @@ def auth_heal_pass(
         The fleet registry to read the roster from — the population every
         report is checked against. Real state, redirectable for tests, exactly
         as ``reconcile_pass`` takes it.
+    event_log
+        Override for the shared auth-event log (:mod:`.._authevents`). ``None``
+        resolves the real runtime-dir path per call. This pass EMITS to that
+        log and never reads it back: the log is a record for humans and later
+        queries, never an input to this pass's decisions. Wiring it as an input
+        would make the restarter's own history its evidence about itself.
     """
     now = now if now is not None else time.time()
     now_dt = datetime.fromtimestamp(now, tz=timezone.utc)
@@ -361,6 +421,12 @@ def auth_heal_pass(
     reports: list[AgentReport] = []
 
     for name in detection.auth_failed:
+        # WHAT WE SAW, recorded before anything we do about it and regardless
+        # of whether we are allowed to act — a wedge observed under --check, or
+        # while cooling down, is the same fact as one observed before a
+        # restart, and only the unbroken series of sightings can show that a
+        # wedge outlived its remedy.
+        account = observe_wedge(name, specs_dir=specs_dir, event_log=event_log, now=now)
         report = _perform(
             name,
             budget=budget,
@@ -368,6 +434,8 @@ def auth_heal_pass(
             now=now,
             restart_fn=restart_fn,
             budget_detail=read.detail,
+            account=account,
+            event_log=event_log,
         )
         reports.append(report)
         # PERSIST THE MOMENT WE SPEND BUDGET, never only at the end: a pass

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -72,7 +72,7 @@ COMMAND_CATEGORIES = [
     ("Registry & Events", ["db", "registry", "event"]),
     ("Build & Install", ["image", "installation"]),
     ("Host hygiene", ["worktree"]),
-    ("Diagnostics", ["doctor", "ports", "provenance", "ci"]),
+    ("Diagnostics", ["doctor", "ports", "provenance", "auth-events", "ci"]),
     ("Remote testing", ["pytest"]),
     ("Introspection", ["whoami", "mcp", "list-python-apis", "skills", "versions"]),
     ("Developer", ["dev"]),
@@ -120,6 +120,10 @@ class _MainGroup(LazyGroup):
         # Read-only port-hygiene inventory: listen 7878 + a2a claims +
         # the scitex/sac port-assignment reference map.
         "ports": f"{_PKG}.ports_cmds:ports",
+        # READ-ONLY auth timeline: this host's auth-event log joined with the
+        # credential rotations the accounts store already audits. Observes
+        # only — auth-heal owns remediation.
+        "auth-events": f"{_PKG}.auth_events_cmds:auth_events",
         # Which code is ACTUALLY loaded — the heavy half of `--version`
         # (tree hash, duplicate/fossil .dist-info, shadowed imports).
         "provenance": f"{_PKG}.provenance_cmds:provenance",
@@ -318,6 +322,7 @@ class _MainGroup(LazyGroup):
         "ci": "Read WHY CI is red as cheaply as its status (extract the real failure).",
         "listen": "Host HTTP/JSON control plane: start/stop/restart/status.",
         "ports": "List the ports sac/scitex uses, with live status.",
+        "auth-events": "Read the fleet auth timeline: 401s, rotations, restarts.",
         "pytest": "Run pytest on remote pools (Spartan SLURM, ...).",
         "worktree": "Git-worktree hygiene: report and reap safe, stale worktrees.",
         "install-shell-completion": "Wire up `<TAB>` completion in the user's shell rc.",

--- a/src/scitex_agent_container/cli_pkg/auth_events_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/auth_events_cmds.py
@@ -1,0 +1,102 @@
+"""``sac auth-events`` — read the fleet auth timeline. READ-ONLY.
+
+The log is JSONL precisely so it can be answered with ``jq``; this command
+exists for the two questions nobody should have to write a query for at 3am:
+
+* ``--since`` … what happened around the time everything died?
+* ``--unresolved`` … which restarts were attempted and never shown to work?
+
+The second is the one the old rail could not answer at all. A restart log that
+only records successes has no reading under which the restarter looks wrong, so
+169 ineffective restarts read exactly like 169 recoveries.
+
+This command NEVER writes, restarts, or remediates. It prints.
+"""
+
+from __future__ import annotations
+
+import click
+
+__all__ = ["auth_events"]
+
+#: Verdict shown for an attempt with no successful outcome. Deliberately not
+#: "FAILED": we know we cannot SHOW it worked, which is a weaker and more
+#: honest claim than knowing it did not.
+_UNRESOLVED = "UNPROVEN"
+
+
+def _fmt(event) -> str:
+    account = event.account if event.account is not None else "account:unknown"
+    agent = event.agent or "-"
+    status = f" http={event.http_status}" if event.http_status is not None else ""
+    return (
+        f"{event.timestamp_utc}  {event.event:<24} {agent:<28} "
+        f"{account:<34}{status}  {event.detail or ''}"
+    )
+
+
+@click.command(name="auth-events")
+@click.option(
+    "--since",
+    default=None,
+    help="Only events at/after this ISO-8601 UTC prefix (e.g. 2026-07-18T10).",
+)
+@click.option(
+    "--agent", "agent_filter", default=None, help="Only events for this agent."
+)
+@click.option(
+    "--unresolved",
+    is_flag=True,
+    help="Only restarts ATTEMPTED with no successful outcome recorded.",
+)
+@click.option(
+    "--no-rotations",
+    is_flag=True,
+    help="Omit credential rotations (they are read from the accounts audit).",
+)
+@click.option("--limit", default=200, show_default=True, help="Max rows to print.")
+def auth_events(
+    since: str | None,
+    agent_filter: str | None,
+    unresolved: bool,
+    no_rotations: bool,
+    limit: int,
+) -> None:
+    """Show the collected fleet auth-event timeline.
+
+    Joins this host's auth-event log with the credential rotations already
+    recorded by the accounts store, so a rotation and the agents it knocked
+    over appear in one ordered reading.
+    """
+    from .._authevents import unified_timeline, unresolved_attempts
+
+    events = unified_timeline(include_rotations=not no_rotations)
+    if unresolved:
+        events = unresolved_attempts(events)
+    if since:
+        events = [e for e in events if (e.timestamp_utc or "") >= since]
+    if agent_filter:
+        events = [e for e in events if e.agent == agent_filter]
+
+    if not events:
+        # Say which of the two empties this is. "Nothing matched" and "nothing
+        # was ever recorded" look identical on a silent terminal, and only the
+        # first one is evidence about the fleet.
+        click.echo(
+            "no matching auth events. NOTE: an empty reading is not evidence "
+            "that nothing happened — it is evidence that nothing was recorded "
+            "here (the rail may not have been running for that window)."
+        )
+        return
+
+    shown = events[-limit:]
+    for event in shown:
+        click.echo(_fmt(event))
+    if unresolved:
+        click.echo(
+            f"\n{len(events)} restart attempt(s) {_UNRESOLVED}: attempted with no "
+            f"successful outcome recorded. That is 'we cannot show it worked', "
+            f"not 'it definitely failed' — re-observation is what settles it."
+        )
+    if len(events) > len(shown):
+        click.echo(f"\n({len(events) - len(shown)} older event(s) not shown)")

--- a/tests/scitex_agent_container/_authevents/_helpers.py
+++ b/tests/scitex_agent_container/_authevents/_helpers.py
@@ -1,0 +1,18 @@
+"""Shared constants for the auth-event-log suites — no mocks.
+
+Mirrors ``tests/scitex_agent_container/_authheal/_helpers.py`` so the two
+packages share one clock: an event written by a pass suite and an event written
+by a log suite carry the same timestamp, which keeps a cross-suite comparison
+honest instead of accidentally time-dependent.
+"""
+
+from __future__ import annotations
+
+#: A fixed clock. Every suite injects it, so no test can be flaky on time.
+NOW = 1_800_000_000.0
+
+#: What :data:`NOW` renders as on a record. Written out literally rather than
+#: recomputed from :data:`NOW` with the same call the production code makes —
+#: a test that derives its expectation the way the code derives its answer
+#: agrees with the code by construction and can never catch it being wrong.
+NOW_ISO = "2027-01-15T08:00:00+00:00"

--- a/tests/scitex_agent_container/_authevents/conftest.py
+++ b/tests/scitex_agent_container/_authevents/conftest.py
@@ -1,0 +1,39 @@
+"""Real temp state for the auth-event-log suites — no mocks.
+
+Every fixture is a real path on ``tmp_path`` that the production writer really
+appends to and the test really reads back. The one "failure injection" is a
+genuinely read-only directory: the operating system refuses the write, so the
+fail-open contract is proved against a real refusal rather than a patched one
+that could only ever agree with us.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+#: A fixed clock, matching the ``_authheal`` suites, so no test is time-flaky.
+NOW = 1_800_000_000.0
+
+
+@pytest.fixture
+def event_log(tmp_path: Path) -> Path:
+    """The auth-event log path. Absent = nothing has ever been recorded."""
+    return tmp_path / "auth-events.jsonl"
+
+
+@pytest.fixture
+def denied_log(tmp_path: Path):
+    """A log path the REAL writer genuinely cannot create. No mocks.
+
+    The parent dir is read-only, so the append fails the way it would on a
+    full disk or a revoked mount — the world says no; nothing is injected.
+    """
+    readonly = tmp_path / "readonly"
+    readonly.mkdir()
+    readonly.chmod(0o555)
+    try:
+        yield readonly / "auth-events.jsonl"
+    finally:
+        readonly.chmod(0o755)

--- a/tests/scitex_agent_container/_authevents/test__log.py
+++ b/tests/scitex_agent_container/_authevents/test__log.py
@@ -1,0 +1,437 @@
+"""The auth-event log records facts, and can record a fact that REFUTES us.
+
+The suite's centre of gravity is :func:`unresolved_attempts`. A restart log
+that can only say "restarted" is not evidence, because there is no reading of
+it under which the restarter looks wrong — and the fleet spent seven days with
+exactly that log while 169 restarts failed to clear anything. So the tests
+below insist an ATTEMPT and an OUTCOME are two records, and that the outcome is
+free to contradict the attempt.
+
+No mocks: every test drives the production writer against a real file on
+``tmp_path`` and reads the real bytes back.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from scitex_agent_container._authevents import (
+    AUTH_FAILURE_OBSERVED,
+    RESTART_ATTEMPTED,
+    RESTART_OUTCOME,
+    auth_event_log_path,
+    log_auth_event,
+    log_auth_failure_observed,
+    log_restart_attempted,
+    log_restart_outcome,
+    read_auth_events,
+    unresolved_attempts,
+)
+
+from ._helpers import NOW, NOW_ISO
+
+
+def test_attempt_and_outcome_are_two_distinct_records(event_log: Path) -> None:
+    """THE contract: one restart leaves an attempt AND an outcome, not one line.
+
+    If the code ever collapses these into a single "restarted" event this test
+    goes red — which is the point. The two-record shape is what lets a later
+    reader ASK whether the restart worked, instead of being TOLD that it did.
+    """
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    attempt_id = log_restart_attempted(
+        agent=agent, detail="wedged", path=event_log, now=NOW
+    )
+    log_restart_outcome(
+        agent=agent,
+        attempt_id=attempt_id,
+        succeeded=True,
+        detail="restart call reported success",
+        path=event_log,
+        now=NOW + 1,
+    )
+
+    # Assert
+    events = read_auth_events(event_log)
+    assert [e.event for e in events] == [RESTART_ATTEMPTED, RESTART_OUTCOME]
+
+
+def test_attempt_and_outcome_are_joined_by_attempt_id(event_log: Path) -> None:
+    """The join key makes two records one story rather than two rumours."""
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    attempt_id = log_restart_attempted(
+        agent=agent, detail="wedged", path=event_log, now=NOW
+    )
+    log_restart_outcome(
+        agent=agent,
+        attempt_id=attempt_id,
+        succeeded=True,
+        detail="ok",
+        path=event_log,
+        now=NOW + 1,
+    )
+
+    # Assert
+    attempt, outcome = read_auth_events(event_log)
+    assert attempt.attempt_id == outcome.attempt_id == attempt_id
+
+
+def test_a_failed_restart_is_recorded_as_attempt_without_success(
+    event_log: Path,
+) -> None:
+    """REFUTATION: a restart that ran and did not work must be readable as such.
+
+    This is the case the old ``-> auto-restart`` line could not express: the
+    outcome exists, and it disagrees with the attempt.
+    """
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    attempt_id = log_restart_attempted(
+        agent=agent, detail="wedged", path=event_log, now=NOW
+    )
+    log_restart_outcome(
+        agent=agent,
+        attempt_id=attempt_id,
+        succeeded=False,
+        detail="restart ran but reported FAILURE",
+        path=event_log,
+        now=NOW + 1,
+    )
+
+    # Assert
+    unresolved = unresolved_attempts(read_auth_events(event_log))
+    assert [e.attempt_id for e in unresolved] == [attempt_id]
+
+
+def test_an_attempt_with_no_outcome_at_all_is_unresolved(event_log: Path) -> None:
+    """Silence is not success. A restart that never reported back stays open.
+
+    The process could have hung or been killed by its timer. Reading a missing
+    outcome as a successful one is the assumption that lets a wedge sit for
+    three days while every log line announces a remedy.
+    """
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    attempt_id = log_restart_attempted(
+        agent=agent, detail="wedged", path=event_log, now=NOW
+    )
+
+    # Assert
+    unresolved = unresolved_attempts(read_auth_events(event_log))
+    assert [e.attempt_id for e in unresolved] == [attempt_id]
+
+
+def test_a_successful_outcome_clears_its_attempt(event_log: Path) -> None:
+    """The query must also be able to say NOTHING is outstanding.
+
+    A refutation test that can never come back clean is not measuring anything.
+    """
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    attempt_id = log_restart_attempted(
+        agent=agent, detail="wedged", path=event_log, now=NOW
+    )
+    log_restart_outcome(
+        agent=agent,
+        attempt_id=attempt_id,
+        succeeded=True,
+        detail="ok",
+        path=event_log,
+        now=NOW + 1,
+    )
+
+    # Assert
+    assert unresolved_attempts(read_auth_events(event_log)) == []
+
+
+def test_one_agents_success_does_not_clear_another_agents_attempt(
+    event_log: Path,
+) -> None:
+    """Attempts are cleared by THEIR own outcome, never by a neighbour's.
+
+    Six agents wedged at once is the shape that matters here; a rail that let
+    any success clear the batch would have reported 2026-07-18 as handled.
+    """
+    # Arrange
+    healed = log_restart_attempted(
+        agent="figrecipe", detail="wedged", path=event_log, now=NOW
+    )
+    still_wedged = log_restart_attempted(
+        agent="crossref-local", detail="wedged", path=event_log, now=NOW
+    )
+
+    # Act
+    log_restart_outcome(
+        agent="figrecipe",
+        attempt_id=healed,
+        succeeded=True,
+        detail="ok",
+        path=event_log,
+        now=NOW + 1,
+    )
+
+    # Assert
+    unresolved = unresolved_attempts(read_auth_events(event_log))
+    assert [e.attempt_id for e in unresolved] == [still_wedged]
+
+
+def test_unknown_account_is_written_as_null_not_omitted(event_log: Path) -> None:
+    """Tri-state: the field is PRESENT and null. Absent and unknown differ.
+
+    An absent key says nobody thought to record it; a null says we looked and
+    could not tell. Only the second one is a finding.
+    """
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    log_auth_failure_observed(
+        agent=agent, detail="banner", account=None, path=event_log, now=NOW
+    )
+
+    # Assert
+    record = json.loads(event_log.read_text().strip())
+    assert "account" in record and record["account"] is None
+
+
+def test_the_literal_unknown_label_is_normalised_to_null(event_log: Path) -> None:
+    """A non-answer must not travel as though it were an answer.
+
+    ``resolve_agent_account_label`` says the string ``"unknown"`` when it has
+    nothing to go on. Writing that verbatim would put a joinable-looking value
+    into the field investigators correlate rotations against.
+    """
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    log_auth_failure_observed(
+        agent=agent, detail="banner", account="unknown", path=event_log, now=NOW
+    )
+
+    # Assert
+    record = json.loads(event_log.read_text().strip())
+    assert record["account"] is None
+
+
+def test_a_known_account_is_recorded_verbatim(event_log: Path) -> None:
+    """The normaliser must not eat real answers along with the non-answers."""
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    log_auth_failure_observed(
+        agent=agent,
+        detail="banner",
+        account="ywata1989-gmail-com",
+        path=event_log,
+        now=NOW,
+    )
+
+    # Assert
+    assert read_auth_events(event_log)[0].account == "ywata1989-gmail-com"
+
+
+def test_http_status_is_null_when_none_was_observed(event_log: Path) -> None:
+    """A banner is a rendering; a status code is a fact. Never synthesise one.
+
+    Claude Code prints "Login expired · Please run /login" for ANY 401 — and
+    sometimes when nothing expired. Inventing a 401 from that string would
+    corrupt the one field this log exists to make trustworthy.
+    """
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    log_auth_failure_observed(agent=agent, detail="banner", path=event_log, now=NOW)
+
+    # Assert
+    record = json.loads(event_log.read_text().strip())
+    assert "http_status" in record and record["http_status"] is None
+
+
+def test_an_observed_status_code_is_recorded(event_log: Path) -> None:
+    """When a real status IS observed it must survive to the record."""
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    log_auth_failure_observed(
+        agent=agent,
+        detail="401 from the API",
+        http_status=401,
+        path=event_log,
+        now=NOW,
+    )
+
+    # Assert
+    assert read_auth_events(event_log)[0].http_status == 401
+
+
+def test_the_write_fails_open_when_the_log_cannot_be_written(
+    denied_log: Path,
+) -> None:
+    """FAIL-OPEN: an unwritable log returns False and never raises.
+
+    Driven against a really read-only directory. This rail is bolted to the
+    side of the auth path; if it could raise, an observability bug would become
+    an outage — and the thing observed always outranks the observing of it.
+    """
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    written = log_auth_failure_observed(
+        agent=agent, detail="banner", path=denied_log, now=NOW
+    )
+
+    # Assert
+    assert written is False
+
+
+def test_an_attempt_id_is_returned_even_when_the_write_failed(
+    denied_log: Path,
+) -> None:
+    """The caller must still be able to label its outcome after a failed write.
+
+    Returning nothing here would let the recorder's own failure change the
+    shape of the restart path around it — which is what fail-open forbids.
+    """
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    attempt_id = log_restart_attempted(
+        agent=agent, detail="wedged", path=denied_log, now=NOW
+    )
+
+    # Assert
+    assert attempt_id
+
+
+def test_reading_a_log_that_does_not_exist_yields_no_events(tmp_path: Path) -> None:
+    """A missing log reads as empty, never as an exception."""
+    # Arrange
+    absent = tmp_path / "never-written.jsonl"
+
+    # Act
+    events = read_auth_events(absent)
+
+    # Assert
+    assert events == []
+
+
+def test_a_corrupt_line_does_not_hide_the_good_records_around_it(
+    event_log: Path,
+) -> None:
+    """A half-written line must cost one record, not the whole investigation."""
+    # Arrange
+    log_auth_failure_observed(
+        agent="figrecipe", detail="banner", path=event_log, now=NOW
+    )
+    with event_log.open("a", encoding="utf-8") as handle:
+        handle.write("{not json at all\n")
+
+    # Act
+    log_auth_failure_observed(
+        agent="crossref-local", detail="banner", path=event_log, now=NOW
+    )
+
+    # Assert
+    events = read_auth_events(event_log)
+    assert [e.agent for e in events] == ["figrecipe", "crossref-local"]
+
+
+def test_records_are_appended_never_overwritten(event_log: Path) -> None:
+    """Append-only: a later write must not cost us an earlier one."""
+    # Arrange
+    agents = ("a", "b", "c")
+
+    # Act
+    for agent in agents:
+        log_auth_failure_observed(agent=agent, detail="banner", path=event_log, now=NOW)
+
+    # Assert
+    assert [e.agent for e in read_auth_events(event_log)] == list(agents)
+
+
+def test_the_timestamp_is_utc_and_iso_8601(event_log: Path) -> None:
+    """Cross-host correlation needs one clock, spelled one way."""
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    log_auth_failure_observed(agent=agent, detail="banner", path=event_log, now=NOW)
+
+    # Assert
+    assert read_auth_events(event_log)[0].timestamp_utc == NOW_ISO
+
+
+def test_an_unrecognised_event_type_is_recorded_and_flagged(event_log: Path) -> None:
+    """Forward-compat: a record we do not recognise is still evidence.
+
+    Dropping it would let a newer writer's events vanish silently; keeping it
+    unmarked would hide a typo. So it is kept AND flagged.
+    """
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    log_auth_event(
+        event="something-new", agent=agent, detail="?", path=event_log, now=NOW
+    )
+
+    # Assert
+    assert read_auth_events(event_log)[0].raw["event_known"] is False
+
+
+def test_the_log_path_honours_its_env_override(tmp_path: Path) -> None:
+    """Resolved per call, so a relocation (or a test) takes effect immediately.
+
+    A module-level constant computed at import cannot be redirected afterwards
+    — the shape that once had a suite reading and writing the REAL fleet store
+    while believing it was hermetic.
+    """
+    # Arrange
+    target = tmp_path / "relocated" / "auth-events.jsonl"
+    saved = os.environ.get("SAC_AUTH_EVENT_LOG")
+    os.environ["SAC_AUTH_EVENT_LOG"] = str(target)
+
+    # Act
+    try:
+        resolved = auth_event_log_path()
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_AUTH_EVENT_LOG", None)
+        else:
+            os.environ["SAC_AUTH_EVENT_LOG"] = saved
+
+    # Assert
+    assert resolved == target
+
+
+def test_an_observation_records_which_agent_it_is_about(event_log: Path) -> None:
+    """Sanity: the observation event carries its own type and its subject."""
+    # Arrange
+    agent = "figrecipe"
+
+    # Act
+    log_auth_failure_observed(agent=agent, detail="banner", path=event_log, now=NOW)
+
+    # Assert
+    event = read_auth_events(event_log)[0]
+    assert (event.event, event.agent) == (AUTH_FAILURE_OBSERVED, agent)

--- a/tests/scitex_agent_container/_authevents/test__timeline.py
+++ b/tests/scitex_agent_container/_authevents/test__timeline.py
@@ -1,0 +1,210 @@
+"""Rotations and their consequences must read as ONE ordered story.
+
+THE FIXTURE IS THE REAL WRITER
+    Every rotation record in this suite is produced by the PRODUCTION
+    :func:`scitex_agent_container._account._rotation_audit.log_rotation_event`,
+    never hand-built. A hand-built fixture would only prove that my parser
+    agrees with my idea of the format — and a test whose input I shaped to
+    match my parser cannot disagree with me. Driving the real writer is what
+    makes a schema drift between the two modules show up here as a failure
+    instead of showing up during the next incident.
+
+WHAT THIS BUYS
+    The 2026-07-18 deaths clustered at 10:31 UTC. The rotation that caused them
+    was already on disk at 10:31:28 UTC — in a different file, so nobody put
+    the two side by side. Ordering them into one timeline is the whole fix; it
+    needs no new emitter, because the emitter already existed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._account import _rotation_audit as ra
+from scitex_agent_container._authevents import (
+    AUTH_FAILURE_OBSERVED,
+    TOKEN_ROTATED,
+    log_auth_failure_observed,
+    rotation_events,
+    unified_timeline,
+)
+
+from ._helpers import NOW
+
+
+def _rotate(store: Path, *, reason: str, now: float, to: str = "ywata1989") -> None:
+    """Write ONE rotation record with the real production writer."""
+    ra.log_rotation_event(
+        store=store,
+        event="refresh",
+        from_account=to,
+        to_account=to,
+        reason=reason,
+        now=now,
+    )
+
+
+def test_a_real_rotation_record_projects_into_the_shared_event_shape(
+    tmp_path: Path,
+) -> None:
+    """The projection must read what the production writer actually writes."""
+    # Arrange
+    store = tmp_path / "accounts"
+
+    # Act
+    _rotate(store, reason="single-use refresh_token rotated", now=NOW)
+
+    # Assert
+    events = rotation_events(store / ra.AUDIT_FILENAME)
+    assert [e.event for e in events] == [TOKEN_ROTATED]
+
+
+def test_the_rotated_account_survives_the_projection(tmp_path: Path) -> None:
+    """The account is the field the whole correlation hangs on.
+
+    "Six died at once — whose token rotated?" is unanswerable if the projected
+    record forgets which account it was about.
+    """
+    # Arrange
+    store = tmp_path / "accounts"
+
+    # Act
+    _rotate(store, reason="headless access-token refresh", now=NOW, to="ywata1989")
+
+    # Assert
+    assert rotation_events(store / ra.AUDIT_FILENAME)[0].account == "ywata1989"
+
+
+def test_the_rotation_reason_survives_the_projection(tmp_path: Path) -> None:
+    """WHY it rotated distinguishes a scheduled refresh from a reaction."""
+    # Arrange
+    store = tmp_path / "accounts"
+    reason = "single-use refresh_token rotated (headless access-token refresh)"
+
+    # Act
+    _rotate(store, reason=reason, now=NOW)
+
+    # Assert
+    assert rotation_events(store / ra.AUDIT_FILENAME)[0].detail == reason
+
+
+def test_a_rotation_belongs_to_no_single_agent(tmp_path: Path) -> None:
+    """A rotation hits every co-tenant at once, so its ``agent`` is null.
+
+    Attributing it to one agent would suggest the others were separate
+    incidents — which is exactly the misreading that cost hours.
+    """
+    # Arrange
+    store = tmp_path / "accounts"
+
+    # Act
+    _rotate(store, reason="refresh", now=NOW)
+
+    # Assert
+    assert rotation_events(store / ra.AUDIT_FILENAME)[0].agent is None
+
+
+def test_the_timeline_orders_a_rotation_before_the_failures_it_caused(
+    tmp_path: Path,
+) -> None:
+    """The causal shape of the incident, reconstructed from two files.
+
+    Rotation first, then the agents noticing. That ordering IS the answer the
+    operator could not get on the night, and it comes from a single read.
+    """
+    # Arrange
+    store = tmp_path / "accounts"
+    event_log = tmp_path / "auth-events.jsonl"
+    _rotate(store, reason="single-use refresh_token rotated", now=NOW)
+
+    # Act
+    for agent in ("figrecipe", "crossref-local"):
+        log_auth_failure_observed(
+            agent=agent, detail="banner", path=event_log, now=NOW + 60
+        )
+
+    # Assert
+    timeline = unified_timeline(
+        events_path=event_log, audit_path=store / ra.AUDIT_FILENAME
+    )
+    assert [e.event for e in timeline] == [
+        TOKEN_ROTATED,
+        AUTH_FAILURE_OBSERVED,
+        AUTH_FAILURE_OBSERVED,
+    ]
+
+
+def test_the_timeline_can_be_read_without_rotations(tmp_path: Path) -> None:
+    """The join is opt-out, so the auth events can be read on their own."""
+    # Arrange
+    store = tmp_path / "accounts"
+    event_log = tmp_path / "auth-events.jsonl"
+    _rotate(store, reason="refresh", now=NOW)
+
+    # Act
+    log_auth_failure_observed(
+        agent="figrecipe", detail="banner", path=event_log, now=NOW + 60
+    )
+
+    # Assert
+    timeline = unified_timeline(
+        events_path=event_log,
+        audit_path=store / ra.AUDIT_FILENAME,
+        include_rotations=False,
+    )
+    assert [e.event for e in timeline] == [AUTH_FAILURE_OBSERVED]
+
+
+def test_a_missing_rotation_audit_yields_no_rotations(tmp_path: Path) -> None:
+    """An absent audit reads as empty, never as an exception.
+
+    Note what the empty answer does NOT mean: it is not evidence that no
+    rotation happened, only that we have no record of one here.
+    """
+    # Arrange
+    absent = tmp_path / "accounts" / ra.AUDIT_FILENAME
+
+    # Act
+    events = rotation_events(absent)
+
+    # Assert
+    assert events == []
+
+
+def test_the_timeline_survives_a_corrupt_rotation_line(tmp_path: Path) -> None:
+    """One bad line must not cost the whole rotation history."""
+    # Arrange
+    store = tmp_path / "accounts"
+    _rotate(store, reason="first", now=NOW)
+    with (store / ra.AUDIT_FILENAME).open("a", encoding="utf-8") as handle:
+        handle.write("{truncated mid-write\n")
+
+    # Act
+    _rotate(store, reason="second", now=NOW + 1)
+
+    # Assert
+    details = [e.detail for e in rotation_events(store / ra.AUDIT_FILENAME)]
+    assert details == ["first", "second"]
+
+
+def test_a_record_with_no_timestamp_sorts_last_instead_of_vanishing(
+    tmp_path: Path,
+) -> None:
+    """A malformed record is still evidence that something wrote one.
+
+    Dropping it would make the timeline quietly shorter than the truth, which
+    is the failure mode an investigator has no way to notice.
+    """
+    # Arrange
+    event_log = tmp_path / "auth-events.jsonl"
+    log_auth_failure_observed(
+        agent="figrecipe", detail="banner", path=event_log, now=NOW
+    )
+    with event_log.open("a", encoding="utf-8") as handle:
+        handle.write('{"event": "auth-failure-observed", "agent": "nostamp"}\n')
+
+    # Act
+    timeline = unified_timeline(events_path=event_log, include_rotations=False)
+
+    # Assert
+    assert [e.agent for e in timeline] == ["figrecipe", "nostamp"]

--- a/tests/scitex_agent_container/_authheal/test__pass_auth_events.py
+++ b/tests/scitex_agent_container/_authheal/test__pass_auth_events.py
@@ -1,0 +1,397 @@
+"""A real pass leaves an auth-event trail that can DISAGREE with the pass.
+
+This is the suite the whole PR exists for. It drives the production
+:func:`auth_heal_pass` over real captured panes, a real temp history file and a
+real temp registry — the only injected seam is the restart itself, a
+:class:`Recorder` with the production ``(name) -> bool`` signature — and then
+reads the real JSONL bytes back off disk.
+
+WHAT IT PROVES, AND WHY THAT WAS NOT PROVABLE BEFORE
+    ``auth-heal.log`` recorded 169 ``-> auto-restart`` lines over seven days
+    whose ``age=`` field never reset. Every line stated an INTENT in the
+    grammar of an EFFECT, and no record existed that could contradict one. The
+    decisive test here is
+    :func:`test_a_restart_that_does_not_take_effect_is_visible_as_unresolved`:
+    a restart is attempted, it does NOT take, and the log must be readable as
+    attempt-without-successful-outcome.
+
+MUTATION-PROOF
+    Collapse the two emissions in ``_pass._perform`` into one combined
+    "restarted" event and these tests go red — the attempt/outcome pair
+    disappears and ``unresolved_attempts`` can no longer see the failure. That
+    is the intended failure mode: the test is pinned to the SEPARATION, not to
+    the fact that something was written.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._authevents import (
+    AUTH_FAILURE_OBSERVED,
+    RESTART_ATTEMPTED,
+    RESTART_OUTCOME,
+    read_auth_events,
+    unresolved_attempts,
+)
+from scitex_agent_container._authheal._pass import auth_heal_pass
+
+from ._helpers import NOW, Recorder, stuck
+
+
+def _events(path: Path, kind: str) -> list:
+    return [e for e in read_auth_events(path) if e.event == kind]
+
+
+def test_a_restart_that_does_not_take_effect_is_visible_as_unresolved(
+    tmp_path: Path, history: Path, store: str
+) -> None:
+    """THE test: a restart that ran and did not work must be refutable.
+
+    The recorder returns False — the production signature's way of saying the
+    restart reported failure — so the pass really does attempt a restart that
+    really does not take. The log must show the attempt AND an outcome that
+    contradicts it, and the refutation query must surface it.
+    """
+    # Arrange
+    event_log = tmp_path / "auth-events.jsonl"
+    recorder = Recorder(ok=False)
+
+    # Act
+    auth_heal_pass(
+        apply=True,
+        now=NOW,
+        history_file=history,
+        store=store,
+        alarm=False,
+        restart_fn=recorder,
+        capture_fn=lambda: stuck("figrecipe"),
+        event_log=event_log,
+    )
+
+    # Assert
+    unresolved = unresolved_attempts(read_auth_events(event_log))
+    assert [e.agent for e in unresolved] == ["figrecipe"]
+
+
+def test_the_attempt_and_the_outcome_are_two_separate_records(
+    tmp_path: Path, history: Path, store: str
+) -> None:
+    """Conflating them is the exact defect this rail exists to prevent.
+
+    One restart, two records. If ``_perform`` ever writes a single combined
+    event this assertion is the one that catches it.
+    """
+    # Arrange
+    event_log = tmp_path / "auth-events.jsonl"
+    recorder = Recorder(ok=False)
+
+    # Act
+    auth_heal_pass(
+        apply=True,
+        now=NOW,
+        history_file=history,
+        store=store,
+        alarm=False,
+        restart_fn=recorder,
+        capture_fn=lambda: stuck("figrecipe"),
+        event_log=event_log,
+    )
+
+    # Assert
+    attempts = _events(event_log, RESTART_ATTEMPTED)
+    outcomes = _events(event_log, RESTART_OUTCOME)
+    assert (len(attempts), len(outcomes)) == (1, 1)
+
+
+def test_the_failed_outcome_records_that_it_did_not_succeed(
+    tmp_path: Path, history: Path, store: str
+) -> None:
+    """The outcome must carry the refutation explicitly, not by omission."""
+    # Arrange
+    event_log = tmp_path / "auth-events.jsonl"
+    recorder = Recorder(ok=False)
+
+    # Act
+    auth_heal_pass(
+        apply=True,
+        now=NOW,
+        history_file=history,
+        store=store,
+        alarm=False,
+        restart_fn=recorder,
+        capture_fn=lambda: stuck("figrecipe"),
+        event_log=event_log,
+    )
+
+    # Assert
+    assert _events(event_log, RESTART_OUTCOME)[0].succeeded is False
+
+
+def test_a_successful_restart_leaves_nothing_unresolved(
+    tmp_path: Path, history: Path, store: str
+) -> None:
+    """The refutation query must be able to come back clean.
+
+    Without this, the failing test above would pass under a rail that reports
+    EVERY restart as unresolved — which would measure nothing at all.
+    """
+    # Arrange
+    event_log = tmp_path / "auth-events.jsonl"
+    recorder = Recorder(ok=True)
+
+    # Act
+    auth_heal_pass(
+        apply=True,
+        now=NOW,
+        history_file=history,
+        store=store,
+        alarm=False,
+        restart_fn=recorder,
+        capture_fn=lambda: stuck("figrecipe"),
+        event_log=event_log,
+    )
+
+    # Assert
+    assert unresolved_attempts(read_auth_events(event_log)) == []
+
+
+def test_the_attempt_is_recorded_before_the_outcome(
+    tmp_path: Path, history: Path, store: str
+) -> None:
+    """Order is load-bearing: intent is written BEFORE the act it describes.
+
+    A restart that hangs or takes the process down with it must still leave its
+    intent behind — otherwise the most interesting failures are the ones that
+    write nothing.
+    """
+    # Arrange
+    event_log = tmp_path / "auth-events.jsonl"
+    recorder = Recorder(ok=True)
+
+    # Act
+    auth_heal_pass(
+        apply=True,
+        now=NOW,
+        history_file=history,
+        store=store,
+        alarm=False,
+        restart_fn=recorder,
+        capture_fn=lambda: stuck("figrecipe"),
+        event_log=event_log,
+    )
+
+    # Assert
+    restart_events = [
+        e.event
+        for e in read_auth_events(event_log)
+        if e.event in (RESTART_ATTEMPTED, RESTART_OUTCOME)
+    ]
+    assert restart_events == [RESTART_ATTEMPTED, RESTART_OUTCOME]
+
+
+def test_a_raising_restart_still_leaves_an_attempt_and_a_failed_outcome(
+    tmp_path: Path, history: Path, store: str
+) -> None:
+    """An exception is an outcome too, and a failed one.
+
+    The recorder raises for real; nothing is patched. A restart that blew up
+    must not read as a restart that never happened.
+    """
+    # Arrange
+    event_log = tmp_path / "auth-events.jsonl"
+    recorder = Recorder(boom=RuntimeError("tmux is gone"))
+
+    # Act
+    auth_heal_pass(
+        apply=True,
+        now=NOW,
+        history_file=history,
+        store=store,
+        alarm=False,
+        restart_fn=recorder,
+        capture_fn=lambda: stuck("figrecipe"),
+        event_log=event_log,
+    )
+
+    # Assert
+    assert _events(event_log, RESTART_OUTCOME)[0].succeeded is False
+
+
+def test_the_wedge_is_observed_before_any_restart_decision(
+    tmp_path: Path, history: Path, store: str
+) -> None:
+    """What we SAW is recorded first, and separately from what we DID.
+
+    The sighting owes nothing to the restarter's claims about itself, which is
+    what lets a series of sightings establish that a wedge outlived its remedy.
+    """
+    # Arrange
+    event_log = tmp_path / "auth-events.jsonl"
+    recorder = Recorder(ok=True)
+
+    # Act
+    auth_heal_pass(
+        apply=True,
+        now=NOW,
+        history_file=history,
+        store=store,
+        alarm=False,
+        restart_fn=recorder,
+        capture_fn=lambda: stuck("figrecipe"),
+        event_log=event_log,
+    )
+
+    # Assert
+    assert read_auth_events(event_log)[0].event == AUTH_FAILURE_OBSERVED
+
+
+def test_a_check_run_observes_the_wedge_but_attempts_no_restart(
+    tmp_path: Path, history: Path, store: str
+) -> None:
+    """Observing is not acting. A dry run that saw a wedge really did see it.
+
+    It must therefore record the sighting — and must NOT record an attempt,
+    because it did not make one. Writing an attempt here would put phantom
+    restarts in the log of a run whose entire promise is that it changed
+    nothing.
+    """
+    # Arrange
+    event_log = tmp_path / "auth-events.jsonl"
+    recorder = Recorder(ok=True)
+
+    # Act
+    auth_heal_pass(
+        apply=False,
+        now=NOW,
+        history_file=history,
+        store=store,
+        alarm=False,
+        restart_fn=recorder,
+        capture_fn=lambda: stuck("figrecipe"),
+        event_log=event_log,
+    )
+
+    # Assert
+    kinds = [e.event for e in read_auth_events(event_log)]
+    assert kinds == [AUTH_FAILURE_OBSERVED]
+
+
+def test_each_wedged_agent_gets_its_own_attempt_id(
+    tmp_path: Path, history: Path, store: str
+) -> None:
+    """Six agents dying together must be six traceable stories, not one blur.
+
+    Shared ids would let one agent's recovery appear to account for another's,
+    which is the failure the 2026-07-18 incident would have been misread as.
+    """
+    # Arrange
+    event_log = tmp_path / "auth-events.jsonl"
+    recorder = Recorder(ok=False)
+
+    # Act
+    auth_heal_pass(
+        apply=True,
+        now=NOW,
+        history_file=history,
+        store=store,
+        alarm=False,
+        restart_fn=recorder,
+        capture_fn=lambda: stuck("figrecipe", "crossref-local"),
+        event_log=event_log,
+    )
+
+    # Assert
+    ids = [e.attempt_id for e in _events(event_log, RESTART_ATTEMPTED)]
+    assert len(set(ids)) == 2
+
+
+def test_an_unresolvable_account_is_recorded_as_null_not_guessed(
+    tmp_path: Path, history: Path, store: str
+) -> None:
+    """The registry here is empty, so the account is genuinely undeterminable.
+
+    It must read as ``null``. Guessing the host's current account would put a
+    plausible value into the field an investigator joins rotations against —
+    and a wrong account is worse than a missing one, because it is believed.
+    """
+    # Arrange
+    event_log = tmp_path / "auth-events.jsonl"
+    recorder = Recorder(ok=True)
+
+    # Act
+    auth_heal_pass(
+        apply=True,
+        now=NOW,
+        history_file=history,
+        store=store,
+        alarm=False,
+        restart_fn=recorder,
+        capture_fn=lambda: stuck("figrecipe"),
+        event_log=event_log,
+    )
+
+    # Assert
+    observed = _events(event_log, AUTH_FAILURE_OBSERVED)[0]
+    assert "account" in observed.raw and observed.account is None
+
+
+def test_an_unwritable_event_log_does_not_stop_the_restart(
+    tmp_path: Path, history: Path, store: str
+) -> None:
+    """FAIL-OPEN, proved end to end against a really read-only directory.
+
+    The observability rail must never cost us the recovery it observes. The
+    evidence is the recorder: the restart still happened.
+    """
+    # Arrange
+    readonly = tmp_path / "readonly"
+    readonly.mkdir()
+    readonly.chmod(0o555)
+    recorder = Recorder(ok=True)
+
+    # Act
+    try:
+        auth_heal_pass(
+            apply=True,
+            now=NOW,
+            history_file=history,
+            store=store,
+            alarm=False,
+            restart_fn=recorder,
+            capture_fn=lambda: stuck("figrecipe"),
+            event_log=readonly / "auth-events.jsonl",
+        )
+    finally:
+        readonly.chmod(0o755)
+
+    # Assert
+    assert recorder.names == ["figrecipe"]
+
+
+def test_a_healthy_fleet_writes_no_auth_events(
+    tmp_path: Path, history: Path, store: str
+) -> None:
+    """Silence means nothing was seen — the log must not invent activity.
+
+    A rail that writes on every tick regardless would drown the one line that
+    matters, and would make "the log is quiet" meaningless.
+    """
+    # Arrange
+    event_log = tmp_path / "auth-events.jsonl"
+    recorder = Recorder(ok=True)
+
+    # Act
+    auth_heal_pass(
+        apply=True,
+        now=NOW,
+        history_file=history,
+        store=store,
+        alarm=False,
+        restart_fn=recorder,
+        capture_fn=dict,
+        event_log=event_log,
+    )
+
+    # Assert
+    assert read_auth_events(event_log) == []

--- a/tests/scitex_agent_container/cli_pkg/test_auth_events_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_auth_events_cmds.py
@@ -1,0 +1,135 @@
+"""``sac auth-events`` reads the timeline and never writes to it.
+
+Drives the real click command with ``CliRunner`` against a real log file on
+``tmp_path``, redirected via the production env knob — no mocks, no patching.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._authevents import (
+    log_restart_attempted,
+    log_restart_outcome,
+)
+from scitex_agent_container.cli_pkg._main import _MainGroup
+from scitex_agent_container.cli_pkg.auth_events_cmds import auth_events
+
+_LOG_ENV = "SAC_AUTH_EVENT_LOG"
+
+
+@pytest.fixture
+def event_log(tmp_path: Path):
+    """A real, redirected auth-event log — the production env knob, no mocks."""
+    target = tmp_path / "auth-events.jsonl"
+    saved = os.environ.get(_LOG_ENV)
+    os.environ[_LOG_ENV] = str(target)
+    try:
+        yield target
+    finally:
+        if saved is None:
+            os.environ.pop(_LOG_ENV, None)
+        else:
+            os.environ[_LOG_ENV] = saved
+
+
+def test_the_command_is_registered_on_the_main_group() -> None:
+    """A command absent from the registry is a command nobody can run."""
+    # Arrange
+    group = _MainGroup
+
+    # Act
+    spec = group.LAZY_COMMANDS.get("auth-events")
+
+    # Assert
+    assert spec == "scitex_agent_container.cli_pkg.auth_events_cmds:auth_events"
+
+
+def test_the_command_has_a_short_help_so_help_stays_lazy() -> None:
+    """``--help`` must render without importing every command module."""
+    # Arrange
+    group = _MainGroup
+
+    # Act
+    short_help = group.LAZY_SHORT_HELPS.get("auth-events")
+
+    # Assert
+    assert short_help
+
+
+def test_an_empty_log_says_so_rather_than_printing_nothing(
+    event_log: Path,
+) -> None:
+    """ "Nothing matched" and "nothing was recorded" must not look identical.
+
+    A silent terminal invites the reader to conclude the fleet is fine. Only
+    one of those two empties is evidence about the fleet, and the command has
+    to say which it is holding.
+    """
+    # Arrange
+    runner = CliRunner()
+
+    # Act
+    result = runner.invoke(auth_events, ["--no-rotations"])
+
+    # Assert
+    assert "not evidence" in result.output
+
+
+def test_unresolved_lists_a_restart_that_was_never_shown_to_work(
+    event_log: Path,
+) -> None:
+    """The question the old rail could not answer, answered from the CLI."""
+    # Arrange
+    log_restart_attempted(agent="figrecipe", detail="wedged", path=event_log)
+
+    # Act
+    result = runner_output(["--unresolved", "--no-rotations"])
+
+    # Assert
+    assert "figrecipe" in result
+
+
+def test_unresolved_omits_a_restart_that_was_shown_to_work(
+    event_log: Path,
+) -> None:
+    """The filter must be able to come back empty, or it measures nothing."""
+    # Arrange
+    attempt_id = log_restart_attempted(
+        agent="figrecipe", detail="wedged", path=event_log
+    )
+    log_restart_outcome(
+        agent="figrecipe",
+        attempt_id=attempt_id,
+        succeeded=True,
+        detail="ok",
+        path=event_log,
+    )
+
+    # Act
+    result = runner_output(["--unresolved", "--no-rotations"])
+
+    # Assert
+    assert "figrecipe" not in result
+
+
+def test_reading_the_log_does_not_modify_it(event_log: Path) -> None:
+    """READ-ONLY: an observability rail whose reader mutates is not one."""
+    # Arrange
+    log_restart_attempted(agent="figrecipe", detail="wedged", path=event_log)
+    before = event_log.read_bytes()
+
+    # Act
+    runner_output(["--no-rotations"])
+
+    # Assert
+    assert event_log.read_bytes() == before
+
+
+def runner_output(args: list[str]) -> str:
+    """Invoke the real command and return its output."""
+    return CliRunner().invoke(auth_events, args).output


### PR DESCRIPTION
## Why

Operator, 2026-07-18: 「サーバーが落とすんだから、ログを取ればいいんじゃないですか？普通にバグのためにも開発のためにもログは必要なんじゃないですか？」 — the server is what drops us, so log it; logs are needed for debugging and for development.

Tonight proved the gap. At ~19:30 JST six parallel workers died together behind "Login expired". The facts needed to explain that lived in three unjoined places — `auth-heal.log` (prose, intent-only), `accounts/rotation-audit.jsonl` (the causal rotation), and each agent's private session transcript. Nothing held them in one timeline, so a one-query answer took hours.

## What this adds

A single append-only JSONL rail at `<runtime>/auth-events.jsonl`, beside `auth-heal.log`. One line per auth event: UTC ISO timestamp, agent, event type, HTTP status, account, free-text detail, plus host/pid.

It **OBSERVES ONLY** — no detector, no restarter, no remediation of any kind. `auth-heal.py` owns remediation and keeps owning it; a second actor on this rail would be the double-supervisor class in a new costume.

## Attempt and outcome are SEPARATE records

This is the point, not a detail. `auth-heal.log` carried **169 `-> auto-restart` lines over seven days whose `age=` field never reset** — one reached 262200s, three days. Every line stated an INTENT in the grammar of an EFFECT, and no record existed that could contradict one.

So a restart writes `restart-attempted` **before** the act and `restart-outcome` after it, joined by `attempt_id`. `unresolved_attempts()` answers "which restarts were attempted and never shown to work", covering both ways that happens:

- an outcome landed saying `succeeded: false` — it ran and did not work;
- no outcome landed at all — it never came back to tell us.

**Mutation-proven.** I collapsed the two emissions in `_pass._perform` into one combined event, ran the suite, and observed **4 tests go RED** — including the decisive `test_a_restart_that_does_not_take_effect_is_visible_as_unresolved` — then reverted. The tests are pinned to the SEPARATION, not to the fact that something was written.

## The rotation event was never missing — it was unjoined

The obvious design was a new "token rotated" emitter. It would have been wrong. `_account._rotation_audit` has recorded every rotation to `<accounts-store>/rotation-audit.jsonl` for weeks. Checked against tonight's incident, the last record before the six deaths reads:

```
"timestamp_utc": "2026-07-18T10:31:28.316535+00:00", "event": "refresh",
"from_account": "ywata1989-gmail-com",
"reason": "single-use refresh_token rotated (headless access-token refresh)"
```

10:31:28 UTC is **19:31:28 JST** — the deaths, to the minute. The causal fact was on disk the whole time; nothing put it beside the restarts that followed.

So this PR adds **no second rotation writer**. `_authevents._timeline` PROJECTS the existing audit at read time, leaving `rotation-audit.jsonl` the single source of truth with its fingerprint-only security contract intact. Verified against the live file: **94 real rotations project correctly.**

## Which of the four event types are actually wired

| Event | Wired | Where from |
|---|---|---|
| `auth-failure-observed` | Yes — banner only | `_authheal/_observe.py`, from the corroborated frozen-pane detection |
| `token-rotated` | Yes — projected | `_authevents/_timeline.py`, from the existing rotation audit |
| `restart-attempted` | Yes | `_authheal/_pass.py::_perform`, before the act |
| `restart-outcome` | Yes | `_authheal/_pass.py::_perform`, after it |

**The raw HTTP 401 is NOT observable from sac's position.** It exists inside each agent's own Claude Code session transcript, which sac does not read. Rather than invent a collector that cannot see it, `http_status` stays `null` for banner-derived observations and the field is reserved for a status actually read off a response. Claude Code renders ANY 401 as "Login expired" — sometimes when nothing expired — so a banner is recorded as a banner.

## Contracts

- **Fail-open.** Every write is best-effort and returns a bool; an unwritable log can never abort the restart or refresh it observes. Proved end-to-end against a genuinely read-only directory.
- **Tri-state.** An undeterminable account is written as `null` — present and explicitly unknown, never guessed and never omitted. An absent key and an unknown value are different facts, and a wrong account is worse than a missing one because it will be believed.
- **Read-only surface.** `sac auth-events` (`--since`, `--agent`, `--unresolved`, `--no-rotations`). An empty reading says so explicitly, because "nothing matched" and "nothing was ever recorded" must not look identical on a silent terminal.

## Tests

85 green: 20 log-contract, 9 timeline, 12 pass-integration, 6 CLI, plus all 21 pre-existing `_authheal` tests unchanged. No mocks — every test drives the production writer against a real temp file, and the timeline suite drives the **real** `log_rotation_event` rather than a hand-built fixture, so a schema drift between the two modules fails here instead of during the next incident.

Pre-existing unrelated failures in `test__main.py` (shell-completion install, container `$HOME`) were confirmed to fail identically on clean `develop`.

## Not in scope

The deployed `auth-heal.py` cron lives **outside this repo** (`~/.scitex/agent-container/bin/`, unversioned here), so its emitters are not wired by this PR — that needs a separate operator decision. The in-repo `_authheal` restarter is wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqhsrw29CM4siBLcEK2CwV
