### PR TITLE
fix(recipes): a floor alone does not upgrade — add -U/--upgrade so the routine bake installs LATEST

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -423,7 +423,18 @@ From: ubuntu:24.04
     # starting with ``uv pip install`` — the base-def contract tests locate
     # this block with startswith("uv pip install"), so an env-var prefix
     # (UV_NO_CACHE=1 ...) makes the block invisible to them.
-    uv pip install --no-cache --python /opt/venv-sac/bin/python \
+    #
+    # ``-U`` — a FLOOR ALONE DOES NOT UPGRADE. This layer bootstraps from
+    # ubuntu:24.04, so its venv is normally fresh and ``-U`` is a no-op
+    # here; it is load-bearing for the ``--sandbox`` mutate-and-re-bake
+    # flow documented at the top of this file, where the venv already
+    # exists and an already-satisfied floor would leave the OLD build in
+    # place while exiting 0. It also keeps this line honest against its
+    # counterpart in apptainer-scitex.def, where the inherited-venv case
+    # is the NORM and ``-U`` is the whole mechanism. ``-U`` does not
+    # weaken ``--reinstall-package``: that stays the stronger lever for
+    # sac's own rebuild-from-staged-source.
+    uv pip install --no-cache --python /opt/venv-sac/bin/python -U \
         --reinstall-package scitex-agent-container \
         "claude-agent-sdk" \
         "scitex-cards[mcp]>=0.16.0" \

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -161,7 +161,17 @@ From: ./sac-base.sif
     fi
 
     if command -v uv >/dev/null; then
-        uv pip install --python /opt/venv-sac/bin/python \
+        # ``-U`` — A FLOOR ALONE DOES NOT UPGRADE. This layer bakes ONTO a
+        # base image and INHERITS its venv, so every requirement below is
+        # already SATISFIED at whatever version base baked. uv/pip leave a
+        # satisfied requirement alone and exit 0, so without ``-U`` a
+        # rebake silently reships yesterday's ``scitex[all]`` while
+        # reporting success. Unpinning was only half the job: the floor
+        # states the capability requirement, ``-U`` is what actually
+        # re-resolves to the newest published version. A FRESH-base bake
+        # happens to work either way, which is precisely why this went
+        # unnoticed — and why the timer-driven routine bake needs it.
+        uv pip install --python /opt/venv-sac/bin/python -U \
             black flake8 \
             ipython ipdb \
             pytest pytest-cov \
@@ -233,7 +243,10 @@ From: ./sac-base.sif
         #   section 2b still asserts the shim BY SYMBOL, so a release that
         #   drops it dies at bake instead of shipping — which is the honest
         #   protection: verify the artifact, do not freeze the input.
-        uv pip install --python /opt/venv-sac/bin/python \
+        # ``-U`` for the same reason as scitex-cards below: these floors are
+        # ALREADY satisfied by the inherited base venv, so without it the
+        # providers freeze at base's build and a routine rebake is a no-op.
+        uv pip install --python /opt/venv-sac/bin/python -U \
             "scitex-dev>=0.29.0" \
             "scitex-writer>=2.29.0" \
             "scitex-audio>=0.3.0" \
@@ -266,8 +279,10 @@ From: ./sac-base.sif
         # the older transitive pins scitex[all] pulls, so the federated
         # install in section 3 can discover every leaf's
         # ``scitex_dev.system_deps`` entry-point. Floors mirror the uv branch
-        # above. Matches this branch's plain ``pip install`` style.
-        /opt/venv-sac/bin/pip install --no-cache-dir \
+        # above, ``--upgrade`` included: a floor the inherited base venv
+        # already satisfies never re-resolves, so without it these providers
+        # freeze at base's build and the routine rebake ships stale.
+        /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             "scitex-dev>=0.29.0" \
             "scitex-writer>=2.29.0" \
             "scitex-audio>=0.3.0" \


### PR DESCRIPTION
## Why

Unpinning was only **half** of "a routine bake must pick up new code".

The pins are already gone — every requirement in both recipes is a FLOOR
(`scitex-cards[mcp]>=0.16.0`, `scitex-dev>=0.29.0`, `scitex-writer>=2.29.0`,
`scitex-audio>=0.3.0`, `scitex-cv>=0.2.0`, `openai-agents>=0.17.4`; the `==`
strings grep still finds are all inside comments describing the old pins).

But **a floor that is already satisfied is a no-op.** uv/pip leave the
installed build in place and exit 0. And "already satisfied" is the *steady
state* for the `:scitex` layer, because it bootstraps

```
Bootstrap: localimage
From: ./sac-base.sif
```

— it INHERITS base's venv with every scitex package already present at base's
version. So without `-U`, a rebake re-resolves nothing, reships yesterday's
packages, and reports success. A FRESH-base bake happens to work either way,
which is exactly why this went unnoticed while `-U` sat on only one of the
install lines.

Operator ruling (2026-07-17): 「pin 止めしてたら routine 焼きする意味ないですからね」.
The bake now runs on a timer, so the silent no-op is live, not theoretical.

## What changed

Ecosystem install lines that were missing the flag:

| file | line | packages | added |
|---|---|---|---|
| `apptainer-scitex.def` | uv branch | `scitex[all]`, `openai-agents`, `claude-agent-sdk` | `-U` |
| `apptainer-scitex.def` | uv branch | `scitex-dev` / `-writer` / `-audio` / `-cv` | `-U` |
| `apptainer-scitex.def` | pip branch | `scitex-dev` / `-writer` / `-audio` / `-cv` | `--upgrade` |
| `apptainer-base.def` | uv branch | `scitex-cards[mcp]`, `claude-agent-sdk` | `-U` |

## Deliberately unchanged

- **Both sac local-source installs** — `--reinstall-package scitex-agent-container`
  (uv) and `--force-reinstall --no-deps` (pip). Those are the stronger,
  content-correct levers already; `-U` adds nothing over them.
- **base's `-U` is insurance, not mechanism.** base bootstraps from
  `ubuntu:24.04`, so its venv is normally fresh. It matters for the
  `--sandbox` mutate-and-re-bake flow documented at the top of that file
  (venv already exists ⇒ satisfied floor ⇒ old build stays, exit 0), and it
  keeps the two recipes honest against each other.

## Both constraints verified

1. **The base-def block still literally starts with `uv pip install`.** The four
   contract tests locate it via `stripped.startswith("uv pip install")`
   (`tests/integration/test_apptainer_base_def_scitex_todo.py:86`); a flag placed
   *after* `install` keeps the block visible to them. **37 passed.**

2. **The embedded freshness-gate heredoc is byte-identical between the two
   `.def` files, unchanged by this PR.** Measured before *and* after the edit —
   both copies: **6865 bytes, sha256 `4bf6611df331…`**. (My extraction spans the
   heredoc body between the `cat > /tmp/sac-assert-image-fresh.py <<'EOF'` line
   and its closing `EOF`, which is why the byte count differs slightly from the
   6881 figure quoted in the brief — the important part is that the two files
   agree with each other and neither moved.)

## Tests

Targeted only (CI runners are saturated on this host):

- `test_apptainer_base_def_scitex_todo.py`, `test_apptainer_def_openai_agents.py`,
  `test_apptainer_base_def_playwright_libs.py` — **37 passed**
- `test_image_group.py`, `test__image_remote_bake.py`, `test__image_source_build.py`,
  `config/_parsers/test__apptainer.py`, `examples/test_01_image_build_and_inspect.py`
  — **158 passed**
