### PR TITLE
fix(never-stop): exit 2 is not a verdict — gate it on a parseable payload

### DIFF
--- a/src/scitex_agent_container/_never_stop_when_task_remains/_detector.py
+++ b/src/scitex_agent_container/_never_stop_when_task_remains/_detector.py
@@ -21,13 +21,26 @@ same knot tied the other way round.
 What this module DOES read is the **Claude Code hook protocol**, which is
 owned by Claude Code and is the shared standard both sides already target:
 
-* stdout that parses as a JSON object → **passed through verbatim**.
-* exit 0 with nothing usable → allow the stop.
-* exit 2 with nothing usable → block, with the executable's **raw stderr**
-  as an opaque reason string. We do not interpret that text, only forward
-  it. (This is the transitional path: today only ``scitex-cards may-stop``
-  exists, which signals via exit codes rather than emitting hook JSON.)
+* stdout carrying a hook-protocol object (it has ``decision``) → **passed
+  through verbatim**.
+* exit 0 → allow the stop.
+* exit 2 **plus** a parseable verdict on stdout (it has ``runnable``) →
+  block, with a reason composed from THAT PAYLOAD.
+* exit 2 with nothing parseable on stdout → ``UNKNOWN``.
 * anything else → ``UNKNOWN``.
+
+A RESULT IS ONLY ADMISSIBLE IF WE CAN PARSE IT
+----------------------------------------------
+An exit code on its own is not an answer. Exit 2 is both "work remains" and
+the universal CLI usage-error code, so a host whose scitex-cards predates
+``may-stop`` exits 2 with click's ``No such command`` on stderr. Treating
+that as an affirmative block turned "I could not determine whether you may
+stop" into "you may NOT stop" — UNKNOWN collapsed into the blocking pole,
+the one direction this gate must never fail in — and then handed the usage
+text back to the agent as its next instruction.
+
+So: only a payload we can actually read counts as a verdict, and only the
+detector's own words may become a ``reason``. Raw stderr never does.
 
 THREE STATES, NEVER TWO
 -----------------------
@@ -40,7 +53,9 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
+import shutil
 import subprocess
 from dataclasses import dataclass
 
@@ -60,8 +75,34 @@ UNKNOWN = "unknown"
 _DEFAULT_CMD = "scitex-cards may-stop"
 _CMD_ENV = "SAC_MAY_STOP_CMD"
 
+#: THE COMPATIBILITY FLOOR — the scitex-cards version that first provides
+#: :data:`_DEFAULT_CMD`'s verb. Declared here so the skew is STATED rather
+#: than discovered at runtime by an agent that cannot stop.
+#:
+#: Treat this as a signpost, not an oracle, and prefer the OBSERVED version
+#: that :func:`_provenance` reports. It is contested: scitex-cards report the
+#: verb shipped in 0.17.0, yet a clean non-editable install reporting 0.16.2
+#: answers `may-stop` correctly — so at least one version STRING in this
+#: ecosystem does not match the code behind it. That is exactly why the
+#: failure log below prints what the binary ACTUALLY reports instead of
+#: trusting this constant.
+MIN_CARDS_VERSION = "0.17.0"
+
 #: Seconds before we give up on the executable and fail open.
 _TIMEOUT_S = 15.0
+
+#: The key that marks stdout as a CLAUDE CODE hook-protocol payload.
+_DECISION_KEY = "decision"
+
+#: The key that marks stdout as the detector's own verdict — THE SHAPE WE
+#: EXPECT. ``may-stop`` answers with one JSON line carrying ``runnable`` and,
+#: when work remains, ``items[]``.
+_RUNNABLE_KEY = "runnable"
+
+#: Bounds on the composed reason, so a runaway board cannot produce a
+#: megabyte-long instruction.
+_MAX_REASON_ITEMS = 20
+_MAX_ITEM_CHARS = 200
 
 
 @dataclass(frozen=True)
@@ -160,8 +201,154 @@ def _invoke(argv: list[str]) -> _Run:
     )
 
 
+#: Bound on the version probe. It runs only on a FAILURE path, never on the
+#: hot path.
+#:
+#: MEASURED, not guessed: ``scitex-cards --version`` takes 3.3-4.1s cold on a
+#: loaded host, because the CLI does import-time work before click's eager
+#: ``--version`` short-circuits. An earlier 5s budget looked generous and
+#: silently timed out under load, reporting ``version: unknown`` for a binary
+#: that answers perfectly well — a diagnostic that lies about the one fact it
+#: exists to establish is worse than no diagnostic at all.
+_VERSION_TIMEOUT_S = 10.0
+
+#: A version-shaped token, e.g. the ``0.16.2`` in "scitex-cards, version
+#: 0.16.2". We extract ONLY this rather than quoting the banner, so a CLI that
+#: answers ``--version`` with a usage error cannot smuggle its prose into a
+#: message that reaches the agent.
+_VERSION_RE = re.compile(r"\d+\.\d+(?:\.\d+)?[0-9A-Za-z.+-]*")
+
+
+def _reported_version(exe: str) -> str:
+    """What ``exe`` claims its version is, or ``"unknown"``. Never raises."""
+    try:
+        proc = subprocess.run(
+            [exe, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=_VERSION_TIMEOUT_S,
+            check=False,
+        )
+    except (
+        OSError,
+        subprocess.SubprocessError,
+    ):  # stx-allow: fallback (reason: a diagnostic must never become a second failure)
+        return "unknown"
+    match = _VERSION_RE.search(f"{proc.stdout or ''}\n{proc.stderr or ''}")
+    return match.group(0) if match else "unknown"
+
+
+def _provenance(argv: list[str]) -> str:
+    """Name WHICH BINARY answered, where it lives, and what version it claims.
+
+    ``Error: No such command 'may-stop'`` says a verb is missing but NOT WHICH
+    SIDE is stale — the caller naming a verb that never existed, or a callee
+    too old to have it. Three agents investigated that one string on the night
+    this was written, and one concluded the caller was wrong and filed a card
+    proposing we change our default command; the truth was the opposite. The
+    error names the verb but never the version that lacks it.
+
+    So whenever we cannot get an answer, we say exactly who we asked. That
+    turns a multi-agent investigation into one line of log.
+    """
+    exe = argv[0] if argv else ""
+    resolved = shutil.which(exe) if exe else None
+    return (
+        f"asked: {shlex.join(argv)}; resolved: {resolved or 'NOT FOUND on PATH'}; "
+        f"reports version: {_reported_version(exe) if exe else 'unknown'}; "
+        f"this command needs scitex-cards >= {MIN_CARDS_VERSION}"
+    )
+
+
+#: Why an exit 2 carrying no parseable verdict is UNKNOWN. Names the
+#: overwhelmingly likely cause, because it is the fleet's STEADY STATE rather
+#: than an edge case: a host whose scitex-cards predates the verb answers with
+#: click's usage error — which also exits 2.
+#:
+#: The child's own output is deliberately NOT quoted here. This text reaches
+#: the agent and the operator, and CLI error text read back as an instruction
+#: is precisely the defect this guard exists to prevent. The provenance line
+#: appended by :func:`_provenance` is more actionable than the bytes anyway:
+#: it names WHICH binary answered and WHAT version it claims to be.
+_UNREADABLE_EXIT_TWO = (
+    "hook executable exited 2 but printed no verdict we could parse on "
+    "stdout, so we could not tell whether work remains. The usual cause is "
+    "that this host's scitex-cards predates the `may-stop` verb, whose usage "
+    "error also exits 2."
+)
+
+
+def _compose_reason(payload: dict, agent: str) -> str:
+    """Build the agent's next instruction from the DETECTOR-AUTHORED verdict.
+
+    Sourced strictly from the parsed stdout payload — never from stderr. The
+    ``reason`` is handed back to Claude as its next instruction, so anything
+    that reaches it must be something the detector deliberately said. stderr
+    is an unstructured channel that carries deprecation notices, library
+    warnings, and (the bug this replaced) CLI usage errors; forwarding it
+    verbatim is how "No such command" became an agent's marching orders.
+
+    Deliberately omits volatile fields such as ``idle_seconds``: the loop
+    guard digests this text to detect "no progress", so a value that moves
+    every turn would mean the guard could never trip.
+    """
+    lines: list[str] = []
+    items = payload.get("items")
+    if isinstance(items, list):
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            parts = [
+                str(item[key]).strip()
+                for key in ("card_id", "reason", "next_action")
+                if isinstance(item.get(key), (str, int, float))
+                and str(item[key]).strip()
+            ]
+            if parts:
+                lines.append(" — ".join(parts)[:_MAX_ITEM_CHARS])
+            if len(lines) >= _MAX_REASON_ITEMS:
+                break
+
+    who = agent or "this agent"
+    if not lines:
+        return (
+            f"The runnable-work check reports that work remains on {who}'s "
+            "board, but listed no items. Do not stop — inspect your board and "
+            "take the next item."
+        )
+    numbered = "\n".join(f"{n}. {text}" for n, text in enumerate(lines, 1))
+    return (
+        f"{len(lines)} runnable item(s) on {who}'s board — an agent does not "
+        f"stop while the board holds work:\n{numbered}"
+    )
+
+
 def probe(agent: str) -> Verdict:
-    """Run the hook executable for ``agent`` and classify. Never raises."""
+    """Run the hook executable for ``agent`` and classify. Never raises.
+
+    EXIT 2 IS A BORROWED SIGNAL — GATE IT ON THE PAYLOAD
+    ----------------------------------------------------
+    The detector signals "work remains" with exit 2, which is also the
+    UNIVERSAL usage-error code (click, argparse, most CLIs). So any missing,
+    renamed, or not-yet-shipped verb IMPERSONATES A POSITIVE RESULT: the
+    process exits 2 and we would read a failure to answer as an affirmative
+    "you may not stop". We therefore keep accepting 2 for compatibility but
+    require a parseable verdict on stdout alongside it.
+
+    If the protocol ever gains a distinct code, a value outside the
+    conventional range (e.g. 10) would remove the ambiguity at the source and
+    is the recommended direction — but the exit codes are scitex-cards' to
+    choose, so this side does not change them unilaterally.
+
+    THE GENERAL RULE: a hook that calls a NEW verb needs a guarded fallback,
+    because THE FLEET ALWAYS RUNS OLDER THAN THE PUBLISHED VERSION. ``may-stop``
+    was published and correct; the deployed SIF simply predated it, which made
+    the missing-verb path the steady state rather than an edge case. The verb
+    is not the lesson — the skew is, and it recurs on every rename and every
+    new verb. Note the shape of the trap: the caller was RIGHT, and the error
+    text still read as if it were wrong, which is why :func:`_provenance`
+    reports who was actually asked.
+    """
     if not agent:
         return Verdict(
             state=UNKNOWN,
@@ -172,42 +359,55 @@ def probe(agent: str) -> Verdict:
             ),
         )
 
-    run = _invoke(detector_argv(agent))
+    argv = detector_argv(agent)
+    run = _invoke(argv)
 
     if run.failure:
-        return Verdict(state=UNKNOWN, detail=run.failure, returncode=run.returncode)
+        return Verdict(
+            state=UNKNOWN,
+            detail=f"{run.failure}. {_provenance(argv)}",
+            returncode=run.returncode,
+        )
 
     payload = _hook_json(run.stdout)
-    if payload is not None:
-        # The executable spoke the hook protocol. Forward it untouched — the
-        # decision is entirely theirs to make and ours to deliver.
-        state = BLOCK if payload.get("decision") == "block" else ALLOW
+
+    # (1) The executable spoke the CLAUDE CODE hook protocol outright. Forward
+    # it untouched — the decision is theirs to make and ours to deliver.
+    if payload is not None and _DECISION_KEY in payload:
+        state = BLOCK if payload.get(_DECISION_KEY) == "block" else ALLOW
         return Verdict(state=state, payload=payload, returncode=run.returncode)
 
+    # (2) exit 0 — a definite "nothing runnable".
     if run.returncode == 0:
         return Verdict(state=ALLOW, returncode=0)
 
+    # (3) exit 2 — "work remains", but ONLY when a verdict we can PARSE came
+    # with it. An exit code alone is not an answer: click exits 2 for a usage
+    # error too, so on any host whose scitex-cards predates `may-stop`,
+    # "work remains" and "No such command" are literally the same number.
     if run.returncode == 2:
-        # Transitional exit-code signalling. stderr is forwarded as opaque
-        # text — we never interpret it, so its format stays theirs.
-        reason = (run.stderr or "").strip()
+        if payload is None or _RUNNABLE_KEY not in payload:
+            return Verdict(
+                state=UNKNOWN,
+                detail=f"{_UNREADABLE_EXIT_TWO} {_provenance(argv)}",
+                returncode=2,
+            )
+        if not payload.get(_RUNNABLE_KEY):
+            # They answered, and the answer was "nothing runnable".
+            return Verdict(state=ALLOW, returncode=2)
         return Verdict(
             state=BLOCK,
-            reason=reason
-            or (
-                "The runnable-work check reported that work remains, but said "
-                "nothing further. Do not stop — inspect your board and take "
-                "the next item."
-            ),
+            payload={"decision": "block", "reason": _compose_reason(payload, agent)},
             returncode=2,
         )
 
-    tail = (run.stderr or run.stdout or "").strip().splitlines()
+    # (4) Any other exit code is UNKNOWN by contract. Their output is not
+    # quoted here either, for the reason given at _UNREADABLE_EXIT_TWO.
     return Verdict(
         state=UNKNOWN,
         detail=(
-            f"hook executable exited {run.returncode} (expected 0 or 2)"
-            + (f": {tail[-1][:300]}" if tail else "")
+            f"hook executable exited {run.returncode} (expected 0 or 2) and "
+            f"printed no verdict we could parse. {_provenance(argv)}"
         ),
         returncode=run.returncode,
     )

--- a/tests/scitex_agent_container/_never_stop_when_task_remains/_fake_detector.py
+++ b/tests/scitex_agent_container/_never_stop_when_task_remains/_fake_detector.py
@@ -6,18 +6,38 @@ stdout/stderr, and exits with a real code — the same interface the
 scitex-cards executable presents. ``$SAC_MAY_STOP_CMD`` (a documented
 production knob, not a test-only hatch) points sac at the script.
 
-Note what is NOT here any more: there is no fixture reproducing
-scitex-cards' payload schema or its numbered hint lines. sac no longer
-parses either, so a fixture encoding their format would be testing a
-coupling we deliberately removed — and would quietly re-establish it, since
-a fixture is a claim about someone else's output.
+A fixture is a CLAIM ABOUT SOMEONE ELSE'S OUTPUT, so the two below are not
+invented — both were captured from real runs on this host:
+
+* :data:`CLICK_USAGE_ERROR` is what ``scitex-cards`` really prints (and the
+  code it really exits with) for a verb it does not have.
+* :func:`runnable_verdict` mirrors a real ``may-stop --agent ...`` answer.
+
+An earlier revision deliberately shipped NO fixture of the detector's
+payload, to avoid coupling sac to scitex-cards' schema. That purity is what
+let the live defect through: with only hook-protocol JSON in the suite,
+nothing ever exercised the shape the detector ACTUALLY emits, and the
+never-stop gate was tested exclusively against output it never receives. We
+now assert the minimum needed to tell an ANSWER from a FAILURE TO ANSWER —
+the ``runnable`` flag — and nothing more.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import stat
 from pathlib import Path
+
+#: Exactly what a host whose scitex-cards predates ``may-stop`` emits: the
+#: usage text on STDERR, an EMPTY stdout, and exit 2 — the same code the
+#: protocol uses for "work remains". Captured from a real run.
+CLICK_USAGE_ERROR = (
+    "Usage: scitex-cards [OPTIONS] [COMMAND] [ARGS]...\n"
+    "Try 'scitex-cards --help' for help.\n"
+    "\n"
+    "Error: No such command 'may-stop'."
+)
 
 
 def write_detector(
@@ -39,6 +59,43 @@ def write_detector(
     )
     script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
     return script
+
+
+def stale_cards_detector(tmp_path: Path, *, name="stale-cards") -> Path:
+    """A detector from BEFORE ``may-stop`` existed — the fleet's steady state.
+
+    Exits 2 (which the protocol reads as "work remains") while stdout is
+    empty and stderr holds click's usage error.
+    """
+    return write_detector(
+        tmp_path, returncode=2, stdout="", stderr=CLICK_USAGE_ERROR, name=name
+    )
+
+
+def runnable_verdict(
+    *, agent: str = "a", items: "list[dict] | None" = None, idle_seconds: int = 1084
+) -> str:
+    """One line of JSON shaped like a real ``may-stop`` "work remains" answer.
+
+    Note it carries NO ``decision`` key — the detector answers in its own
+    verdict schema, not in Claude Code's hook protocol.
+    """
+    if items is None:
+        items = [
+            {
+                "card_id": "card-1",
+                "reason": "in_progress card",
+                "next_action": "work it, update it, or close it",
+            }
+        ]
+    return json.dumps(
+        {
+            "agent": agent,
+            "runnable": True,
+            "items": items,
+            "idle_seconds": idle_seconds,
+        }
+    )
 
 
 def isolate_runtime(env_save_restore, tmp_path: Path) -> Path:

--- a/tests/scitex_agent_container/_never_stop_when_task_remains/test__detector.py
+++ b/tests/scitex_agent_container/_never_stop_when_task_remains/test__detector.py
@@ -19,12 +19,19 @@ from pathlib import Path
 from scitex_agent_container._never_stop_when_task_remains._detector import (
     ALLOW,
     BLOCK,
+    MIN_CARDS_VERSION,
     UNKNOWN,
     detector_argv,
     probe,
 )
 
-from ._fake_detector import detector_env, missing_detector, write_detector
+from ._fake_detector import (
+    detector_env,
+    missing_detector,
+    runnable_verdict,
+    stale_cards_detector,
+    write_detector,
+)
 
 #: A hook-protocol payload as the executable would emit it. The nested field
 #: names here belong to the CLAUDE CODE Stop-hook contract, not to
@@ -128,7 +135,10 @@ def test_hook_json_found_below_a_noisy_stdout_line(env_save_restore, tmp_path: P
 
 
 # ---------------------------------------------------------------------------
-# transitional exit-code path — stderr forwarded as OPAQUE text
+# exit 2 — admissible ONLY with a parseable verdict alongside it
+#
+# Exit 2 means "work remains" AND is the universal CLI usage-error code, so
+# an exit code on its own cannot be read as an affirmative answer.
 # ---------------------------------------------------------------------------
 
 
@@ -141,11 +151,12 @@ def test_exit_zero_is_allow(env_save_restore, tmp_path: Path):
     assert verdict.state == ALLOW
 
 
-def test_exit_two_is_block(env_save_restore, tmp_path: Path):
+def test_exit_two_with_a_runnable_verdict_blocks(env_save_restore, tmp_path: Path):
+    """THE CONTROL. Without it, "never block" would pass as a fix."""
     # Arrange
     detector_env(
         env_save_restore,
-        write_detector(tmp_path, returncode=2, stderr="work remains, do X"),
+        write_detector(tmp_path, returncode=2, stdout=runnable_verdict()),
     )
     # Act
     verdict = probe("a")
@@ -153,38 +164,144 @@ def test_exit_two_is_block(env_save_restore, tmp_path: Path):
     assert verdict.state == BLOCK
 
 
-def test_exit_two_forwards_stderr_verbatim(env_save_restore, tmp_path: Path):
-    """Their text is forwarded, not interpreted. sac must not reformat it,
-    strip lines from it, or extract fields out of it."""
+def test_block_reason_is_composed_from_the_detectors_payload(
+    env_save_restore, tmp_path: Path
+):
+    """The instruction handed back must be the DETECTOR'S words."""
     # Arrange
-    text = "1. card-a — reason — do the thing\n2. card-b — reason — do the other"
-    detector_env(env_save_restore, write_detector(tmp_path, returncode=2, stderr=text))
+    detector_env(
+        env_save_restore,
+        write_detector(
+            tmp_path,
+            returncode=2,
+            stdout=runnable_verdict(
+                items=[{"card_id": "card-7", "next_action": "ship the fix"}]
+            ),
+        ),
+    )
     # Act
     verdict = probe("a")
     # Assert
-    assert verdict.reason == text
+    assert "card-7" in verdict.payload["reason"]
 
 
-def test_exit_two_with_silent_stderr_still_blocks(env_save_restore, tmp_path: Path):
-    """Exit 2 already proved work remains; having nothing to quote does not
-    downgrade that to 'nothing to do'."""
+def test_block_reason_omits_volatile_fields(env_save_restore, tmp_path: Path):
+    """``idle_seconds`` moves every turn; if it reached the reason, the loop
+    guard's signature would change every turn and the guard could never
+    trip."""
     # Arrange
-    detector_env(env_save_restore, write_detector(tmp_path, returncode=2))
+    detector_env(
+        env_save_restore,
+        write_detector(
+            tmp_path, returncode=2, stdout=runnable_verdict(idle_seconds=4_242)
+        ),
+    )
     # Act
     verdict = probe("a")
     # Assert
-    assert verdict.state == BLOCK
+    assert "4242" not in verdict.payload["reason"]
 
 
-def test_exit_two_with_silent_stderr_supplies_a_reason(
+def test_exit_two_saying_not_runnable_is_allow(env_save_restore, tmp_path: Path):
+    # Arrange — a parseable answer, and the answer is "nothing runnable".
+    detector_env(
+        env_save_restore,
+        write_detector(
+            tmp_path, returncode=2, stdout=json.dumps({"runnable": False, "items": []})
+        ),
+    )
+    # Act
+    verdict = probe("a")
+    # Assert
+    assert verdict.state == ALLOW
+
+
+# ---------------------------------------------------------------------------
+# THE LIVE DEFECT — a scitex-cards older than `may-stop`
+#
+# `may-stop` shipped in scitex-cards 0.16.2 and the SIF baked 0.16.1, so this
+# is the fleet's STEADY STATE, not an edge case. Every one of these went the
+# other way before the fix: rc=2 was consumed as an affirmative BLOCK and the
+# usage text became the agent's next instruction.
+# ---------------------------------------------------------------------------
+
+
+def test_missing_verb_usage_error_is_unknown_not_block(
     env_save_restore, tmp_path: Path
 ):
     # Arrange
+    detector_env(env_save_restore, stale_cards_detector(tmp_path))
+    # Act
+    verdict = probe("a")
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_missing_verb_usage_error_never_becomes_a_reason(
+    env_save_restore, tmp_path: Path
+):
+    """A usage error must never be handed to the agent as an instruction."""
+    # Arrange
+    detector_env(env_save_restore, stale_cards_detector(tmp_path))
+    # Act
+    verdict = probe("a")
+    # Assert
+    assert "No such command" not in verdict.reason
+
+
+def test_missing_verb_produces_no_block_payload(env_save_restore, tmp_path: Path):
+    # Arrange
+    detector_env(env_save_restore, stale_cards_detector(tmp_path))
+    # Act
+    verdict = probe("a")
+    # Assert
+    assert verdict.payload is None
+
+
+def test_missing_verb_detail_names_the_version_cause(env_save_restore, tmp_path: Path):
+    """The loud log must say WHY we could not be consulted."""
+    # Arrange
+    detector_env(env_save_restore, stale_cards_detector(tmp_path))
+    # Act
+    verdict = probe("a")
+    # Assert
+    assert "predates the `may-stop` verb" in verdict.detail
+
+
+def test_exit_two_with_unparseable_stdout_is_unknown(env_save_restore, tmp_path: Path):
+    # Arrange — output arrived, but it is not a verdict we can read.
+    detector_env(
+        env_save_restore,
+        write_detector(tmp_path, returncode=2, stdout="not json at all"),
+    )
+    # Act
+    verdict = probe("a")
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_exit_two_with_json_lacking_the_verdict_key_is_unknown(
+    env_save_restore, tmp_path: Path
+):
+    # Arrange — valid JSON, but it answers a different question.
+    detector_env(
+        env_save_restore,
+        write_detector(tmp_path, returncode=2, stdout=json.dumps({"hello": "world"})),
+    )
+    # Act
+    verdict = probe("a")
+    # Assert
+    assert verdict.state == UNKNOWN
+
+
+def test_exit_two_with_silent_streams_is_unknown(env_save_restore, tmp_path: Path):
+    """Nothing on either stream is not an answer, it is a failure to answer."""
+    # Arrange
     detector_env(env_save_restore, write_detector(tmp_path, returncode=2))
     # Act
     verdict = probe("a")
     # Assert
-    assert "Do not stop" in verdict.reason
+    assert verdict.state == UNKNOWN
 
 
 # ---------------------------------------------------------------------------
@@ -232,6 +349,89 @@ def test_unexpected_exit_code_detail_reports_the_code(env_save_restore, tmp_path
     assert "exited 9" in verdict.detail
 
 
+# ---------------------------------------------------------------------------
+# WHICH SIDE IS STALE? — provenance on every failure path
+#
+# "No such command 'may-stop'" names the verb but never the VERSION that
+# lacks it, so it reads identically whether the caller invented a verb or the
+# callee is too old to have it. Three agents investigated that one string
+# before anyone established which side was stale — and the one who guessed,
+# guessed wrong and proposed changing the (correct) caller. These assertions
+# make the log answer that question by itself.
+# ---------------------------------------------------------------------------
+
+
+def test_failure_detail_names_the_resolved_binary(env_save_restore, tmp_path: Path):
+    # Arrange
+    script = stale_cards_detector(tmp_path)
+    detector_env(env_save_restore, script)
+    # Act
+    verdict = probe("a")
+    # Assert
+    assert str(script) in verdict.detail
+
+
+def test_failure_detail_names_the_argv_actually_executed(
+    env_save_restore, tmp_path: Path
+):
+    # Arrange
+    detector_env(env_save_restore, stale_cards_detector(tmp_path))
+    # Act
+    verdict = probe("a")
+    # Assert
+    assert "--agent a" in verdict.detail
+
+
+def test_failure_detail_reports_the_version_the_binary_claims(
+    env_save_restore, tmp_path: Path
+):
+    # Arrange — a CLI that answers `--version` the ordinary way.
+    detector_env(
+        env_save_restore,
+        write_detector(tmp_path, returncode=2, stdout="scitex-cards, version 0.16.2"),
+    )
+    # Act
+    verdict = probe("a")
+    # Assert
+    assert "reports version: 0.16.2" in verdict.detail
+
+
+def test_version_probe_never_leaks_cli_prose(env_save_restore, tmp_path: Path):
+    """A CLI too old to answer ``--version`` cleanly must not smuggle its
+    usage text into a message that reaches the agent. Only a version-SHAPED
+    token is ever extracted."""
+    # Arrange
+    detector_env(env_save_restore, stale_cards_detector(tmp_path))
+    # Act
+    verdict = probe("a")
+    # Assert
+    assert "reports version: unknown" in verdict.detail
+
+
+def test_missing_executable_detail_says_it_resolved_nowhere(
+    env_save_restore, tmp_path: Path
+):
+    # Arrange
+    missing_detector(env_save_restore, tmp_path)
+    # Act
+    verdict = probe("a")
+    # Assert
+    assert "NOT FOUND on PATH" in verdict.detail
+
+
+def test_failure_detail_states_the_compatibility_floor(
+    env_save_restore, tmp_path: Path
+):
+    """The skew should be STATED, not discovered by an agent that cannot
+    stop."""
+    # Arrange
+    detector_env(env_save_restore, stale_cards_detector(tmp_path))
+    # Act
+    verdict = probe("a")
+    # Assert
+    assert MIN_CARDS_VERSION in verdict.detail
+
+
 def test_empty_agent_is_unknown_not_allow(env_save_restore, tmp_path: Path):
     """No identity means we cannot ask the question — not that the answer is
     'nothing to do'."""
@@ -263,17 +463,54 @@ def test_signature_source_differs_when_their_text_changes(
     # Arrange
     detector_env(
         env_save_restore,
-        write_detector(tmp_path, returncode=2, stderr="first", name="d1"),
+        write_detector(
+            tmp_path,
+            returncode=2,
+            stdout=runnable_verdict(items=[{"card_id": "card-a"}]),
+            name="d1",
+        ),
     )
     first = probe("a").block_signature_source()
     detector_env(
         env_save_restore,
-        write_detector(tmp_path, returncode=2, stderr="second", name="d2"),
+        write_detector(
+            tmp_path,
+            returncode=2,
+            stdout=runnable_verdict(items=[{"card_id": "card-b"}]),
+            name="d2",
+        ),
     )
     # Act
     second = probe("a").block_signature_source()
     # Assert
     assert first != second
+
+
+def test_signature_source_is_stable_while_only_idle_seconds_moves(
+    env_save_restore, tmp_path: Path
+):
+    """Same work, later turn — the guard must still see a repeat."""
+    # Arrange
+    detector_env(
+        env_save_restore,
+        write_detector(
+            tmp_path, returncode=2, stdout=runnable_verdict(idle_seconds=10), name="e1"
+        ),
+    )
+    first = probe("a").block_signature_source()
+    detector_env(
+        env_save_restore,
+        write_detector(
+            tmp_path,
+            returncode=2,
+            stdout=runnable_verdict(idle_seconds=9_999),
+            name="e2",
+        ),
+    )
+    # Act
+    second = probe("a").block_signature_source()
+    # Assert
+    assert first == second
 
 
 def test_signature_source_is_stable_for_identical_output(

--- a/tests/scitex_agent_container/cli_pkg/test_never_stop_when_task_remains_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_never_stop_when_task_remains_cmds.py
@@ -31,6 +31,8 @@ from .._never_stop_when_task_remains._fake_detector import (
     detector_env,
     isolate_runtime,
     missing_detector,
+    runnable_verdict,
+    stale_cards_detector,
     write_detector,
 )
 
@@ -149,30 +151,130 @@ def test_unknown_payload_fields_reach_claude_code(env_save_restore, tmp_path: Pa
     assert _decision(out).get("someFutureField") == [1, 2]
 
 
-def test_transitional_exit_two_blocks_with_their_stderr(
-    env_save_restore, tmp_path: Path
-):
-    """Today's path: an executable that signals by exit code. Its stderr is
-    forwarded as the reason, opaque and unedited."""
+def test_a_real_runnable_verdict_blocks_the_stop(env_save_restore, tmp_path: Path):
+    """THE CONTROL for the fix below.
+
+    Uses the shape ``may-stop`` ACTUALLY emits — its own verdict schema,
+    carrying ``runnable``/``items`` and no ``decision`` key. The suite
+    previously exercised only hook-protocol JSON, which the detector never
+    sends, so this path was entirely untested in the direction that matters.
+    Without this test, "never block at all" would pass as a fix.
+    """
     # Arrange
     isolate_runtime(env_save_restore, tmp_path)
-    text = "1. card-a — in_progress — finish the failing test"
-    detector_env(env_save_restore, write_detector(tmp_path, returncode=2, stderr=text))
+    detector_env(
+        env_save_restore,
+        write_detector(tmp_path, returncode=2, stdout=runnable_verdict()),
+    )
     # Act
     _, out = _run("agent-x")
     # Assert
-    assert _decision(out).get("reason") == text
+    assert _decision(out).get("decision") == "block"
+
+
+def test_block_reason_is_composed_from_their_verdict(env_save_restore, tmp_path: Path):
+    """Refusing the stop is NOT enough — a refused stop leaves the agent
+    idle. The instruction must name the work, in the detector's own words."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(
+        env_save_restore,
+        write_detector(
+            tmp_path,
+            returncode=2,
+            stdout=runnable_verdict(
+                items=[{"card_id": "card-42", "next_action": "land the fix"}]
+            ),
+        ),
+    )
+    # Act
+    _, out = _run("agent-x")
+    # Assert
+    assert "card-42" in _decision(out)["reason"]
 
 
 def test_block_reason_is_never_empty(env_save_restore, tmp_path: Path):
     """The docs require ``reason`` whenever ``decision`` is ``block``."""
     # Arrange
     isolate_runtime(env_save_restore, tmp_path)
-    detector_env(env_save_restore, write_detector(tmp_path, returncode=2))
+    detector_env(
+        env_save_restore,
+        write_detector(tmp_path, returncode=2, stdout=runnable_verdict(items=[])),
+    )
     # Act
     _, out = _run("agent-x")
     # Assert
     assert _decision(out).get("reason", "").strip()
+
+
+# ---------------------------------------------------------------------------
+# THE LIVE DEFECT — a host whose scitex-cards predates `may-stop`
+#
+# `may-stop` shipped in scitex-cards 0.16.2; the fleet's SIF baked 0.16.1, so
+# this is the STEADY STATE, not an edge case. Click exits 2 for a usage
+# error, which is the same code the protocol uses for "work remains", so a
+# failure to answer was being read as an affirmative "you may NOT stop" — and
+# the usage text was handed to the agent as its next instruction.
+# ---------------------------------------------------------------------------
+
+
+def test_stale_cards_usage_error_allows_the_stop(env_save_restore, tmp_path: Path):
+    """ "I could not tell" must never be served as "you may NOT stop"."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(env_save_restore, stale_cards_detector(tmp_path))
+    # Act
+    _, out = _run("dotfiles")
+    # Assert
+    assert _decision(out).get("decision") is None
+
+
+def test_stale_cards_usage_error_emits_no_reason(env_save_restore, tmp_path: Path):
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(env_save_restore, stale_cards_detector(tmp_path))
+    # Act
+    _, out = _run("dotfiles")
+    # Assert
+    assert "reason" not in _decision(out)
+
+
+def test_stale_cards_usage_text_never_reaches_the_agent(
+    env_save_restore, tmp_path: Path
+):
+    """The exact strings from the reported artifact, asserted on the exact
+    bytes the hook writes — the only thing Claude Code actually reads."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(env_save_restore, stale_cards_detector(tmp_path))
+    # Act
+    _, out = _run("dotfiles")
+    # Assert
+    assert "No such command" not in out and "Usage:" not in out
+
+
+def test_stale_cards_fail_open_is_loud(env_save_restore, tmp_path: Path):
+    """A silent allow is indistinguishable from a clean board — which is
+    exactly where a fleet-wide breakage would hide."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(env_save_restore, stale_cards_detector(tmp_path))
+    # Act
+    _, out = _run("dotfiles")
+    # Assert
+    assert "FAIL-OPEN" in _decision(out).get("systemMessage", "")
+
+
+def test_stale_cards_message_names_the_actionable_cause(
+    env_save_restore, tmp_path: Path
+):
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(env_save_restore, stale_cards_detector(tmp_path))
+    # Act
+    _, out = _run("dotfiles")
+    # Assert
+    assert "predates the `may-stop` verb" in _decision(out).get("systemMessage", "")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The live defect

`never-stop-when-task-remains` shells out to `scitex-cards may-stop` and read **exit 2** as "work remains". Exit 2 is also the **universal CLI usage-error code**, so on any host whose scitex-cards predates the verb, click's usage error exits 2 and was consumed as an affirmative BLOCK — with the usage text forwarded as `reason`, which Claude Code hands back to the agent as its next instruction:

```json
{"decision": "block", "reason": "Usage: scitex-cards … Error: No such command 'may-stop'."}
```

**"I could not determine whether you may stop" was rendered as "you may NOT stop."** The fail-open path was never reached — the subprocess did not fail, it answered with a number that means two different things.

Reproduced empirically before fixing: `scitex-cards no-such-verb` → rc=2, usage text on stderr, empty stdout.

## The fix

- **rc=2 blocks only with a parseable verdict on stdout** (a `runnable` key). rc=2 with empty/unparseable stdout → UNKNOWN → allow, logged loudly. Any other rc stays UNKNOWN as before.
- **`reason` is composed strictly from the parsed payload.** Raw stderr never reaches it — it carries deprecation notices, library warnings and usage errors, and it becomes an instruction.
- **Volatile fields (`idle_seconds`) excluded from the reason**, so the loop-guard signature is stable and the guard can actually trip. It could not before: the reason moved every turn.
- `_DEFAULT_CMD` **deliberately unchanged** — the verb is published and the caller was right; the deployment was old.

## Second defect, found while fixing — the opposite direction

`may-stop` answers in its **own** schema (`{agent, runnable, items, idle_seconds}`) with **no `decision` key**, so `payload.get("decision") == "block"` was false and the gate **ALLOWED every stop on hosts where the detector works correctly**. The feature was inert wherever it was not harmful.

The suite hid this by only ever feeding it hook-protocol JSON, which the detector never emits. A fixture is a claim about someone else's output, and this claim was wrong. Fixtures are now captured from real runs.

## Diagnostics: which side is stale?

Every failure path now reports the argv executed, the resolved absolute binary, and the version it claims:

```
… asked: /opt/venv-sac/bin/scitex-cards no-such-verb --agent dotfiles;
  resolved: /opt/venv-sac/bin/scitex-cards; reports version: 0.16.2;
  this command needs scitex-cards >= 0.17.0
```

`No such command` names the verb but never the version that lacks it, so it reads identically whether the caller invented a verb or the callee is too old. Three agents investigated that one string tonight; the one who guessed proposed changing the *correct* caller. Only a version-**shaped** token is extracted, so a CLI that answers `--version` with a usage error cannot smuggle prose into a message that reaches the agent.

The probe budget is **measured, not guessed**: `scitex-cards --version` takes 3.3–4.1s cold, and an earlier 5s budget silently timed out under load, reporting `version: unknown` for a binary that answers fine.

## Compatibility floor — needs a decision, not expanded here

`MIN_CARDS_VERSION` declares the floor so the skew is *stated* rather than discovered by an agent that cannot stop. **It is contested and I did not resolve it:** scitex-cards report the verb shipped in **0.17.0**, yet on this host a clean, non-editable install reporting **0.16.2** answers `may-stop` correctly (`--version` → `scitex-cards, version 0.16.2`, no `direct_url.json`). So at least one version string in this ecosystem does not match the code behind it.

I deliberately did **not** encode that as fact. The runtime log prints the **observed** version, so the diagnostic is right regardless of which number is correct. Enforcing the floor (refusing to call a too-old CLI) is left as a follow-up — it needs the version question settled first.

## Mutation proof, both directions

All new tests confirmed **RED against the pre-fix detector** (18 failed / 37 passed), including the exact reported artifact:

```
assert 'reason' not in {'decision': 'block', 'reason': "Usage: scitex-cards [OPTIONS] [COMMAND] [ARGS]...
Try 'scitex-cards --help' for help.\n\nError: No such command 'may-stop'."}
```

The **control** was red too, confirming the second defect:
```
test_a_real_runnable_verdict_blocks_the_stop: assert None == 'block'
```

After the fix: **84 passed**. Verified end-to-end against the real scitex-cards on this host — a genuine runnable board still blocks with a clean composed reason; a missing verb allows the stop.

Unblocks retiring the `SAC_MAY_STOP_CMD=true` stopgap.
