### PR TITLE
fix(auth): a NBSP INSIDE the phrase hides a wedged agent — normalise Unicode whitespace (tail-window half REFUTED)

### DIFF
--- a/src/scitex_agent_container/_runners/_tmux/auth_status.py
+++ b/src/scitex_agent_container/_runners/_tmux/auth_status.py
@@ -45,7 +45,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-from .prompts import prompt_line_index
+from .prompts import normalize_tui_whitespace, prompt_line_index
 
 __all__ = [
     "AuthProbe",
@@ -135,10 +135,17 @@ def banner_kind(line: str) -> str | None:
     volatile ``request_id`` / timestamp / 401 JSON body embedded in the banner
     does not defeat the cross-run frozen comparison (a wedged ``/loop`` agent
     re-renders the SAME banner with a NEW request id every wakeup).
+
+    Unicode whitespace is normalised BEFORE the marker strip (see
+    :func:`prompts.normalize_tui_whitespace`). Order matters: ``_MARKERS``
+    strips a leading NBSP but NOT the other Unicode spaces, so normalising
+    first is what lets an exotic space in the LEFT DECORATION be stripped at
+    all. Normalising the phrase side too keeps the comparison symmetric, so a
+    stray NBSP pasted into ``_AUTH_STARTS`` cannot silently stop matching.
     """
-    s = _strip_markers(line)
+    s = _strip_markers(normalize_tui_whitespace(line))
     for phrase in _AUTH_STARTS:
-        if s.startswith(phrase):
+        if s.startswith(normalize_tui_whitespace(phrase)):
             return phrase
     if _API_AUTH_RE.match(s):
         return "API Error: 4xx"

--- a/src/scitex_agent_container/_runners/_tmux/prompts.py
+++ b/src/scitex_agent_container/_runners/_tmux/prompts.py
@@ -12,10 +12,32 @@ Add new handlers by appending to PROMPT_HANDLERS or calling register_prompt().
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Callable
 
 logger = logging.getLogger(__name__)
+
+
+# Unicode whitespace Claude's Ink TUI renders where an ASCII space is expected.
+# The NBSP part is CAPTURED behaviour, not a guess: every REAL captured pane in
+# ``fixtures/pane_states`` shows the ``❯`` prompt gap as U+00A0, and the head-mba
+# capture renders the gap after the ``⎿`` result marker as U+00A0 too. The wider
+# set is defensive — those variants have NOT been observed from this TUI, they
+# are carried over from the proven emacs-claude-code matcher
+# (``--ecc-state-detection--normalize-text``) so a future Ink release that
+# substitutes one cannot silently blind the watchdog.
+_TUI_UNICODE_SPACE_RE = re.compile("[\u00a0\u2000-\u200b\u202f\u205f\u3000]")
+
+
+def normalize_tui_whitespace(text: str) -> str:
+    """Map the Unicode spaces the Ink TUI emits onto ASCII spaces.
+
+    The substitution is 1:1 and LENGTH-PRESERVING — it never collapses runs of
+    whitespace — so a caller's ``lstrip`` / ``startswith`` offsets keep meaning
+    the same thing they did on the raw line.
+    """
+    return _TUI_UNICODE_SPACE_RE.sub(" ", text)
 
 
 @dataclass
@@ -215,8 +237,6 @@ def _detect_compose_pending_unsent(content: str) -> bool:
     Excluded: lines that are just the decorative separator below an empty
     prompt — those contain only whitespace after ``❯``.
     """
-    import re
-
     # NBSP (U+00A0) included: Claude's Ink TUI renders the prompt gap as
     # ``❯\xa0[Pasted text …]`` (NBSP, not ASCII space); ``❯[ \t]+`` missed it
     # so a pasted-but-unsent buffer went undetected (proj-scitex-dev 2026-06-23).

--- a/tests/scitex_agent_container/_runners/_tmux/test_auth_status.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test_auth_status.py
@@ -13,7 +13,14 @@ real cases from the 2026-07-12 live verification:
     moving → OK.
 
 Plus the real captured pane fixture (``auth_error_head-mba_v2.1.114.txt``) so
-the matcher is proven against Anthropic's actual rendering, not a guess.
+the matcher is proven against Anthropic's actual rendering, not a guess, and
+``auth_wedged_grant_20260718.txt`` — a second real capture, of an agent still
+wedged 6 minutes after a restart — as a WEDGED-agent regression guard.
+
+The Unicode-whitespace section guards a false NEGATIVE rather than a false
+positive: the TUI substitutes U+00A0 for ASCII spaces (visible in the ``❯``
+prompt gap of every captured fixture here), and a substitution INSIDE an auth
+phrase defeats the start-anchored literal match, hiding a wedged agent.
 
 No mocks: every case is a pure function call on captured pane text.
 """
@@ -38,6 +45,24 @@ _REAL_PANE = (
     / "pane_states"
     / "auth_error_head-mba_v2.1.114.txt"
 )
+
+# Real captured pane of the wedged ``grant`` agent (2026-07-18 22:26:19), taken
+# ~6 minutes after its 22:20:14 restart. The operator poked it twice and got the
+# banner both times; the banner is the non-chrome line DIRECTLY above the prompt
+# and only the 0s-turn spinner follows it. Telegram chat id / attachment file_id
+# are redacted — the auth-relevant structure is verbatim, including the real
+# NBSP the TUI renders as the ``❯`` prompt gap.
+_WEDGED_PANE = (
+    Path(__file__).parents[2]
+    / "fixtures"
+    / "pane_states"
+    / "auth_wedged_grant_20260718.txt"
+)
+
+# U+00A0 NON-BREAKING SPACE — the variant Claude's Ink TUI is CAPTURED emitting
+# where an ASCII space is expected (the ``❯`` prompt gap in every fixture here,
+# and the gap after the ``⎿`` result marker in the head-mba pane).
+NBSP = " "
 
 # --------------------------------------------------------------------------
 # Fixtures — captured-pane shapes (verbatim TUI rendering).
@@ -223,6 +248,74 @@ def test_banner_kind_ignores_rate_limit_429():
 
 
 # --------------------------------------------------------------------------
+# banner_kind — Unicode-whitespace normalisation (ported from
+# ``--ecc-state-detection--normalize-text`` in emacs-claude-code).
+#
+# ``_MARKERS`` already strips a LEADING NBSP, so a NBSP in the left decoration
+# has always worked. A NBSP INSIDE the phrase does not: ``startswith`` compares
+# against ASCII-spaced literals, so "Login<NBSP>expired" matched nothing and a
+# wedged agent would be invisible to the watchdog.
+# --------------------------------------------------------------------------
+
+
+def test_banner_kind_matches_nbsp_inside_login_expired():
+    # Arrange
+    line = "● Login" + NBSP + "expired · Please run /login"
+    # Act
+    kind = banner_kind(line)
+    # Assert
+    assert kind == "Login expired"
+
+
+def test_banner_kind_matches_nbsp_inside_please_run_login():
+    # Arrange
+    line = "  ⎿  Please" + NBSP + "run /login"
+    # Act
+    kind = banner_kind(line)
+    # Assert
+    assert kind == "Please run /login"
+
+
+def test_banner_kind_matches_nbsp_inside_api_error_401():
+    # Arrange
+    line = "  API" + NBSP + 'Error: 401 {"type":"error"}'
+    # Act
+    kind = banner_kind(line)
+    # Assert
+    assert kind == "API Error: 4xx"
+
+
+def test_banner_kind_matches_ideographic_space_in_left_decoration():
+    # Arrange — U+3000 is NOT in ``_MARKERS``, so stripping alone leaves it
+    # leading and the start-anchored match fails; normalisation must run FIRST.
+    line = "⎿　Please run /login"
+    # Act
+    kind = banner_kind(line)
+    # Assert
+    assert kind == "Please run /login"
+
+
+def test_banner_kind_normalisation_does_not_widen_into_prose():
+    # Arrange — CONTROL: proves the fix was not "achieved" by loosening the
+    # start-anchored match into a substring search.
+    line = '● figrecipe died in a "Login expired" loop'
+    # Act
+    kind = banner_kind(line)
+    # Assert
+    assert kind is None
+
+
+def test_banner_kind_normalisation_still_ignores_nbsp_rate_limit_429():
+    # Arrange — CONTROL: normalising the API-error branch must not widen it
+    # onto 429, which a restart does not fix.
+    line = "  API" + NBSP + "Error: 429 rate_limit"
+    # Act
+    kind = banner_kind(line)
+    # Assert
+    assert kind is None
+
+
+# --------------------------------------------------------------------------
 # probe_pane — near-prompt tail membership + distance.
 # --------------------------------------------------------------------------
 
@@ -279,6 +372,26 @@ def test_probe_real_captured_fixture_banner_within_tail():
     probe = probe_pane(pane)
     # Assert
     assert probe.distance is not None and probe.distance <= TAIL_LINES
+
+
+def test_probe_wedged_grant_pane_flags_banner_at_distance_zero():
+    # Arrange — regression guard for a WEDGED agent, not a healthy one: in this
+    # capture the banner is the last non-chrome line before the prompt.
+    pane = _WEDGED_PANE.read_text(encoding="utf-8")
+    # Act
+    probe = probe_pane(pane)
+    # Assert
+    assert (probe.present, probe.distance, probe.banner) == (True, 0, "Login expired")
+
+
+def test_probe_wedged_grant_pane_prompt_gap_is_a_real_nbsp():
+    # Arrange — documents WHY normalisation is needed: the production TUI emits
+    # U+00A0 where an ASCII space is expected.
+    lines = _WEDGED_PANE.read_text(encoding="utf-8").splitlines()
+    # Act
+    prompt_line = lines[P.prompt_line_index("\n".join(lines))]
+    # Assert
+    assert prompt_line == "❯" + NBSP
 
 
 # --------------------------------------------------------------------------

--- a/tests/scitex_agent_container/fixtures/pane_states/auth_wedged_grant_20260718.txt
+++ b/tests/scitex_agent_container/fixtures/pane_states/auth_wedged_grant_20260718.txt
@@ -1,0 +1,24 @@
+
+← cct · REDACTED: あれ？
+
+● Login expired · Please run /login
+
+✻ Crunched for 1s
+
+← cct · REDACTED: (photo) まだ変わってない [attachment kind=photo file_id=REDACTED…
+
+● Login expired · Please run /login
+
+✻ Cooked for 0s
+
+────────────────────────────────────────────────────────────────────────────────
+❯ 
+  Start or continue. Scan your scitex-todo card slice, resume any in-flight or
+  assigned work (hold idle if none), then report readiness. Follow CLAUDE.md
+  + your skills; don't restate, don't invent scope.Read and follow
+  /home/ywatanabe/.claude/commands/constitution.md.
+────────────────────────────────────────────────────────────────────────────────
+  [Opus 4.8 (1M context) | Max] │ grant git:(develop*)
+  Context █████████░ 86% (in: 2, cache: 857k) │ Usage █░░░░░░░░░ 12% (2h 59m /…
+  ⏵⏵ bypass permissions on (shift+tab to cycle)
+                                                                            /rc


### PR DESCRIPTION
## What this is

Half of the "port two techniques from `ecc-state-detection.el`" lane. **Technique 1 (tail window) was refuted and is NOT ported.** Technique 2 (Unicode whitespace normalisation) is real and is shipped here, at one site.

## Refutation — why Technique 1 is not in this PR

The lane asked for a 2048-char tail window, justified by a specimen (`grant`, 2026-07-18 22:26:19) described as a healthy agent wrongly flagged. Two premises were false.

**1. The tail window is a provable no-op.** The specimen's pane section is **913 characters**. A 2048-char tail truncates nothing:

```
PANE CHAR LEN = 913
TAIL-2048 WOULD TRUNCATE: False
probe FULL      : AuthProbe(prompt_found=True, present=True, distance=0, banner='Login expired')
probe LAST 2048 : AuthProbe(prompt_found=True, present=True, distance=0, banner='Login expired')
IDENTICAL: True
```

sac already implements a *stronger* form of the same idea. Emacs uses a character count as a recency proxy because a vterm buffer has no structure to anchor on; sac anchors **positionally** — `prompt_line_index()` finds the input prompt, then only the last `TAIL_LINES=6` non-chrome lines above it count. A character-count truncation layered on top can only cut lines the positional layer already ignores.

**2. The specimen is a true positive, not a healthy agent.** The banner is the non-chrome line *directly above* the prompt (distance=0). The only thing rendered after it is `✻ Cooked for 0s` — which this module's own `_VOLATILE_RE` documents as the 0s-turn spinner of a wedged `/loop` agent. The operator poked it twice and got the banner both times. The pid started 22:20:14 and the capture is 22:26:19: still wedged 6 minutes after a restart.

So the fixture is checked in asserting what it **actually shows** (`present=True, distance=0`) as a wedged-agent regression guard — not as an ALIVE case, which would have encoded the assumption as a test.

## The real defect (Technique 2)

`_MARKERS` already contains U+00A0, so a NBSP in the *leading decoration* has always stripped fine. The gap is a NBSP **inside the phrase**: `banner_kind()` does `str.startswith` against ASCII-spaced literals, so `Login<NBSP>expired` matched nothing — a wedged agent invisible to the watchdog, which is the sole safety net for the 2026-07-11 auth-death class.

Ordering is load-bearing, which is why normalisation runs *before* the marker strip: `_MARKERS` strips a leading NBSP but **not** U+3000 and friends, so normalising first is what lets an exotic space in the left decoration be stripped at all.

The helper lives in `prompts.py`, not `auth_status.py` — `auth_status` already imports from `prompts`, so putting it the other way round would be a circular import. One helper, one definition.

## Scope-honest caveat: latent, not observed

I grepped every real captured pane available (2 repo fixtures + 2 runtime specimens). NBSP appears **only** in positions that already work — the `❯` prompt gap and the post-`⎿` gap:

```
auth_error_head-mba_v2.1.114.txt:10 '❯\xa0'
auth_error_head-mba_v2.1.114.txt:25 '  ⎿ \xa0Please run /login · API Error: 401 …'
grant-20260718-222619.log:39        '❯\xa0'
```

**No captured pane shows a NBSP interior to an auth phrase.** This is therefore hardening against an unobserved-but-plausible rendering, not a fix for an observed production false negative — the code comment says so explicitly. It is cheap, 1:1, length-preserving, and the control tests prove it does not widen matching.

## Mutation proof

Written test-first. RED before the fix:

```
FAILED test_banner_kind_matches_nbsp_inside_login_expired            - assert None == 'Login expired'
FAILED test_banner_kind_matches_nbsp_inside_please_run_login         - assert None == 'Please run /login'
FAILED test_banner_kind_matches_nbsp_inside_api_error_401            - assert None == 'API Error: 4xx'
FAILED test_banner_kind_matches_ideographic_space_in_left_decoration - assert None == 'Please run /login'
4 failed, 30 passed
```

Both failure modes were then mutation-proved against the *fixed* tree:

- **Mutation A** — "fix it by widening `startswith` into a substring search": `test_banner_kind_normalisation_does_not_widen_into_prose` goes RED, along with 2 pre-existing prose tests. The control has teeth.
- **Mutation B** — drop the normalisation: the 4 new tests go RED again.

Green after: **131 passed** across `_runners/_tmux/`, `cli_pkg/test__auth_status.py`, `_state/_meta/test_pane.py`.

## Open question for the orchestrator

Someone classified `grant` as a healthy agent wrongly flagged; the captured pane does not support that. If `grant` was in fact working at 22:26 on 2026-07-18, then the bug is somewhere I have not looked and the pane capture is misleading. That needs an answer from whoever observed it live — it determines whether a real false-positive defect exists at all. I could not resolve it from the file.

Unrelated pre-existing: `develop`'s `quality` job was already failing before this branch (run 29647797920, 2026-07-18). Not touched here.
