### PR TITLE
fix(stop): remove the pre-stop rescue autosave — it published what it promised never to publish

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_stop.py
+++ b/src/scitex_agent_container/_lifecycle/_stop.py
@@ -100,15 +100,29 @@ def agent_stop(
     except Exception:
         traceback.print_exc()
 
-    # Fleet-default pre-stop rescue (operator priority, lead a2a
-    # efa48850daf248ed9fe3ae5232677b2b). Commits + pushes every dirty
-    # worktree (or diff-tarballs them on protected/push-failure) before
-    # the agent dies, so restart never silently loses uncommitted work.
-    # NEVER raises — bounded by RESCUE_GRACE_SECONDS; whatever finished
-    # before the budget elapsed is preserved.
-    from ._pre_stop_rescue import run_pre_stop_rescue
-
-    run_pre_stop_rescue(config)
+    # PRE-STOP RESCUE REMOVED — operator ruling 2026-07-19: 「rescue 一切やめましょう」.
+    #
+    # It committed every dirty worktree before an agent died. Its git module
+    # claimed a "never publishes" contract, enforced by shipping no push
+    # primitive. That contract was enforced against the WRONG VERB and was
+    # false in production: the rescue commits onto whatever branch the agent
+    # is currently on, and when that is a feature branch the commit rides a
+    # normal PR merge straight into develop. Measured on 2026-07-19:
+    #
+    #   git log origin/develop --grep='^rescue' | wc -l   ->  7
+    #   5340014c -> fix/restart-preflight-auth-before-stop      (feature branch)
+    #   1042139e -> feat/a2a-default-communicate-and-role-visibility
+    #
+    # One of those (37d83977, ancestor of BOTH develop and main) committed
+    # nine mode-160000 gitlinks under .tmp-audit/ with no .gitmodules, which
+    # broke actions/checkout on every CI run of every workflow until PR #769
+    # removed them. The same pollution sits in seven other repos, because a
+    # broad `git add` of a dirty worktree sweeps up whatever happens to be in
+    # it — audit scratch, nested clones, .worktrees/.
+    #
+    # A dirty worktree now simply STAYS dirty across a stop. That is the
+    # intended behaviour: losing uncommitted scratch is cheaper than silently
+    # publishing it.
 
     # Pre-stop hooks
     # stx-allow: fallback (reason: hook commands may reference paths or env vars absent at stop time; force-stop must continue regardless)


### PR DESCRIPTION
Operator ruling 2026-07-19: 「rescue 一切やめましょう」.

## What it did
Committed every dirty worktree before an agent stopped, so a restart would not lose uncommitted work.

## Why it goes
Its git module asserts a "never publishes" contract, enforced by shipping no push primitive — the docstring calls a push helper "a loaded gun". **The guard was aimed at the wrong verb.** The rescue commits onto whatever branch the agent is currently on; when that is a feature branch, the commit rides an ordinary PR merge into develop. Publication happened through the front door, so a no-push guard could never have caught it.

Measured today:

```
git log origin/develop --grep="^rescue" | wc -l   ->  7

git branch -a --contains:
  8e70ca8b -> rescue/scitex-agent-container-20260718T112001Z   (correct: side branch)
  5340014c -> fix/restart-preflight-auth-before-stop            (a FEATURE branch)
  1042139e -> feat/a2a-default-communicate-and-role-visibility  (a FEATURE branch)
```

Still firing: 50 rescue commits in 2026-07, 8 of them on 2026-07-18.

## The damage
Rescue commit `37d83977` (2026-07-01), an ancestor of **both develop and main**, committed nine `mode 160000` gitlinks under `.tmp-audit/` with no `.gitmodules`. That broke `actions/checkout` on every CI run of every workflow until PR #769 removed them. The same pollution exists in seven other repos — scitex-python (8), scitex-code (8), scitex-io (6), scitex-dataset (5), scitex-ui (3), scitex-audio (1), scitex-cv (1) — because a broad `git add` of a dirty worktree stages whatever happens to be sitting in it.

## Behaviour change
A dirty worktree now stays dirty across a stop. That is intended: losing uncommitted scratch is cheaper than silently publishing it.

## Scope
This PR removes the **call site** only, to stop the bleeding immediately. Full removal of `_pre_stop_rescue.py` / `_pre_stop_rescue_git.py` (archived to `.old/`), their tests, and any docs advertising them is in flight separately.

## Not done here, deliberately
The 7 rescue commits already in develop are ancestors of published branches. Rewriting that history is destructive and is the operator’s call, not mine.