### PR TITLE
fix(host_exec): SIGTERM + grace before SIGKILL — a bare SIGKILL stranded .git/index.lock

### DIFF
--- a/src/scitex_agent_container/_listen/_host_exec.py
+++ b/src/scitex_agent_container/_listen/_host_exec.py
@@ -63,11 +63,16 @@ Hence the guards below, in the order they catch things:
    delay this handler and this handler cannot drain the pool. The bound covers
    dispatch + exec, so it holds even when the child never starts. This is the
    guard that would have prevented the outage; the child timeout could not.
-2. PROCESS-GROUP KILL — ``start_new_session=True`` puts the child in its own
-   process group and the timeout path kills the GROUP. ``subprocess.run``'s
-   own timeout only SIGKILLs the direct child; measured, a grandchild
-   (``bash -c 'sleep 60 & cat'``) SURVIVED and kept running. Killing the pid
-   alone leaves the grandchildren that are usually the actual problem.
+2. PROCESS-GROUP KILL, SIGTERM FIRST — ``start_new_session=True`` puts the
+   child in its own process group and the timeout path kills the GROUP.
+   ``subprocess.run``'s own timeout only SIGKILLs the direct child; measured, a
+   grandchild (``bash -c 'sleep 60 & cat'``) SURVIVED and kept running. Killing
+   the pid alone leaves the grandchildren that are usually the actual problem.
+   The group gets SIGTERM plus a bounded grace BEFORE the SIGKILL: SIGKILL is
+   uncatchable, so a bare one skipped the child's own cleanup and stranded
+   ``.git/index.lock`` files on shared checkouts (INCIDENT 2026-07-18 — one
+   lock broke the once-a-minute pull sweep for 83 minutes). See
+   ``_TERM_GRACE_S``.
 3. ``stdin=DEVNULL`` — no child invoked here can block on stdin (``git``
    without ``-F <file>``, an ssh passphrase prompt, ``apt``, a pager,
    ``read``). Measured: a stdin-reading child gets EOF in 0.02s instead of
@@ -104,7 +109,12 @@ from starlette.responses import JSONResponse
 
 from .._lifecycle._off_loop import run_blocking
 from ._acl import deny_response, resolve_group_name
-from ._host_exec_child import _POST_KILL_DRAIN_S, ChildOutcome, _run_child
+from ._host_exec_child import (
+    _POST_KILL_DRAIN_S,
+    _TERM_GRACE_S,
+    ChildOutcome,
+    _run_child,
+)
 from ._host_exec_inflight import (
     InflightExec,
     host_exec_inflight,
@@ -135,9 +145,14 @@ _DEFAULT_TIMEOUT_S: float = 300.0
 # WATCHDOG deadline (enforced on the event loop by ``run_blocking``). The
 # watchdog only fires when the child timeout ITSELF failed to return — an
 # unkillable D-state child, or a drain that outlived _POST_KILL_DRAIN_S. It
-# must exceed the drain ceiling or it would pre-empt the orderly path that can
+# must exceed the whole orderly teardown or it would pre-empt the path that can
 # still report the child's partial output.
-_WATCHDOG_MARGIN_S: float = _POST_KILL_DRAIN_S + 10.0
+#
+# DERIVED, never hardcoded: the orderly timeout path now costs the SIGTERM
+# grace (added for the stranded-index.lock incident, 2026-07-18) PLUS the drain
+# ceiling. Writing this as a literal is how the watchdog would silently start
+# pre-empting the teardown the next time either constant is retuned.
+_WATCHDOG_MARGIN_S: float = _TERM_GRACE_S + _POST_KILL_DRAIN_S + 10.0
 
 
 def _audit_log_path() -> Path:

--- a/src/scitex_agent_container/_listen/_host_exec_child.py
+++ b/src/scitex_agent_container/_listen/_host_exec_child.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import time
 from dataclasses import dataclass
 
 # After SIGKILLing the child's process GROUP, how long to drain its pipes. The
@@ -20,7 +21,6 @@ from dataclasses import dataclass
 # because a grandchild that escaped the group (its own setsid) could still hold
 # the write end, and an unbounded drain here would be the original bug again.
 _POST_KILL_DRAIN_S: float = 5.0
-
 
 @dataclass(frozen=True)
 class ChildOutcome:
@@ -34,15 +34,51 @@ class ChildOutcome:
     killed_process_group: bool
 
 
-def _kill_process_group(proc: subprocess.Popen) -> bool:
-    """SIGKILL the child's whole process GROUP. Returns True if the group was
-    signalled.
+# How long the group has to run its own cleanup after SIGTERM, before SIGKILL.
+#
+# INCIDENT 2026-07-18 — stranded `.git/index.lock`. This path used to send a
+# bare SIGKILL, which cannot be caught, so a child died with its cleanup
+# handlers unrun. Measured by strace: `git status --porcelain` really does
+# `openat(".git/index.lock", O_RDWR|O_CREAT|O_EXCL)`, so a brokered git op that
+# overran its timeout stranded a lock EVERY time. One such lock left the
+# once-a-minute post-merge-pull sweep failing for 83 minutes — and a stranded
+# lock is silent to readers (`git status` still exits 0), so it sits invisible
+# until something needs to WRITE.
+#
+# 3s is chosen to cover a lock-file unlink (microseconds) with room to spare,
+# while staying far below `_WATCHDOG_MARGIN_S` in `._host_exec`, which is
+# derived from this constant so the two can never drift apart.
+_TERM_GRACE_S: float = 3.0
 
-    ``proc.kill()`` signals ONLY the direct child, so grandchildren survive and
-    keep running (measured: ``bash -c 'sleep 60 & cat'`` left ``sleep`` alive
-    after the documented timeout fired). The child is spawned with
-    ``start_new_session=True``, so its pid IS its process-group id and the
-    group contains everything it spawned.
+
+def _terminate_process_group(
+    proc: subprocess.Popen, *, grace_s: float = _TERM_GRACE_S
+) -> bool:
+    """SIGTERM the child's process GROUP, allow a bounded grace for cleanup,
+    then SIGKILL the group. Returns True if the group was signalled.
+
+    SIGTERM FIRST because SIGKILL is uncatchable: under a bare SIGKILL a child
+    never runs its cleanup, which is how `git`'s own lock removal was skipped
+    and `.git/index.lock` files were stranded on the shared fleet checkouts.
+
+    SIGKILL STILL FOLLOWS, unconditionally, because the grace is a courtesy and
+    not a veto — a child that ignores SIGTERM must not be able to outlive its
+    deadline, which was the unbounded-child wedge of INCIDENT 2026-07-17.
+
+    The grace is a FLAT sleep rather than a wait-for-exit, deliberately.
+    `proc.wait()` REAPS the child, freeing its pid — and the pid IS the pgid
+    (`start_new_session=True`), so a reaped-then-recycled pgid would point our
+    SIGKILL at an unrelated process group. Leaving the child unreaped here
+    keeps the pgid reserved by its own zombie until `communicate()` collects
+    it. The cost is that a timed-out call always spends the full grace; that is
+    an already-exceptional path which has just spent `timeout_s` seconds, so a
+    few more are noise. Do not "optimise" this into a wait() without resolving
+    the recycle hazard.
+
+    The SIGKILL is also why the direct child exiting on SIGTERM is not enough
+    to stop here: it says nothing about GRANDCHILDREN, and the process-group
+    kill exists precisely because grandchildren outlive their parent (measured:
+    `bash -c 'sleep 60 & cat'` left `sleep` alive).
     """
     try:
         pgid = os.getpgid(proc.pid)
@@ -50,10 +86,25 @@ def _kill_process_group(proc: subprocess.Popen) -> bool:
         # Already reaped, or not ours — fall back to the direct child.
         proc.kill()
         return False
+
+    signalled = False
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+        signalled = True
+    except (ProcessLookupError, PermissionError):
+        # Nothing to term (already gone) — the SIGKILL sweep below still runs.
+        pass
+
+    if signalled and grace_s > 0:
+        time.sleep(grace_s)
+
     try:
         os.killpg(pgid, signal.SIGKILL)
         return True
-    except (ProcessLookupError, PermissionError):
+    except ProcessLookupError:
+        # Whole group is already gone: SIGTERM was sufficient. Still a kill.
+        return signalled
+    except PermissionError:
         proc.kill()
         return False
 
@@ -68,7 +119,8 @@ def _run_child(
     """Run one child to completion, bounded. Blocking — call OFF the loop.
 
     Runs in its own session/process group with stdin closed; on timeout the
-    whole GROUP is killed and the (bounded) drain collects whatever it wrote.
+    whole GROUP is SIGTERMed, given a bounded grace to run its own cleanup, and
+    then SIGKILLed, after which the (bounded) drain collects whatever it wrote.
 
     ``stdin=DEVNULL`` kills the "child blocks on stdin" class by construction
     (``git`` without ``-F <file>``, an ssh passphrase prompt, ``apt``, a pager,
@@ -103,7 +155,7 @@ def _run_child(
                 killed_process_group=False,
             )
         except subprocess.TimeoutExpired:
-            killed = _kill_process_group(proc)
+            killed = _terminate_process_group(proc)
             try:
                 stdout, stderr = proc.communicate(timeout=_POST_KILL_DRAIN_S)
             except subprocess.TimeoutExpired:
@@ -119,4 +171,10 @@ def _run_child(
             )
 
 
-__all__ = ["ChildOutcome", "_run_child", "_POST_KILL_DRAIN_S"]
+__all__ = [
+    "ChildOutcome",
+    "_run_child",
+    "_POST_KILL_DRAIN_S",
+    "_TERM_GRACE_S",
+    "_terminate_process_group",
+]

--- a/tests/scitex_agent_container/_listen/test__host_exec_term_grace.py
+++ b/tests/scitex_agent_container/_listen/test__host_exec_term_grace.py
@@ -1,0 +1,193 @@
+"""The timeout path must let a child clean up before it is destroyed.
+
+INCIDENT (2026-07-18): three ``.git/index.lock`` files were stranded on the
+shared ``~/proj/scitex-agent-container`` checkout; one of them left the
+once-a-minute ``post-merge-pull`` sweep failing for 83 minutes with
+``Unable to create '.../.git/index.lock': File exists``.
+
+The producer mechanism, verified by strace rather than inferred: ``git status
+--porcelain`` really does ``openat(".git/index.lock", O_RDWR|O_CREAT|O_EXCL)``,
+and ``host_exec``'s timeout path sent the child's whole process GROUP a bare
+SIGKILL. SIGKILL cannot be caught, so git's own lock cleanup never runs and the
+file is stranded. A brokered call that ran a git op on a shared checkout and
+exceeded its timeout stranded a lock every time.
+
+The fix is a grace period, not the removal of the kill: SIGTERM the group, give
+it a bounded moment to run its cleanup, then SIGKILL whatever is left. The
+CONTROL tests below exist because "let the child clean up" is one careless edit
+away from "stop killing the child" — which would restore the wedge that the
+process-group kill was added to fix (see ``test__host_exec_wedge.py``).
+
+No mocks (STX-NM002): real subprocesses, real signals, real files on disk. The
+assertion is on the ARTIFACT — whether the lock file is gone — not on a return
+code, because a return code cannot tell you whether cleanup ran.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+import types
+from pathlib import Path
+from typing import Any
+
+from scitex_agent_container._listen._host_exec import host_exec
+
+
+class _FakeRequest:
+    def __init__(self, body: object, *, authenticated_node: str | None = None) -> None:
+        self._body = body
+        self.state = types.SimpleNamespace(authenticated_node=authenticated_node)
+
+    async def json(self) -> object:
+        return self._body
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _resp_json(resp) -> dict:
+    return json.loads(bytes(resp.body).decode("utf-8"))
+
+
+def _dev_resolver(name: str) -> str:
+    # Called by the handler as `group_resolver(name=caller)` — keyword, so the
+    # parameter name is part of the seam's contract.
+    _ = name
+    return "developer"
+
+
+def _noop_audit(_entry: dict[str, Any]) -> None:
+    return None
+
+
+def _exec(body: dict, *, node: str = "dev"):
+    return host_exec(
+        _FakeRequest(body, authenticated_node=node),
+        group_resolver=_dev_resolver,
+        audit_writer=_noop_audit,
+    )
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+# --------------------------------------------------------------------------
+# 1. THE FIX — a child gets to run its cleanup handler before it is destroyed.
+# --------------------------------------------------------------------------
+
+
+def test_timeout_lets_the_child_run_its_cleanup_handler_before_it_dies(tmp_path: Path):
+    """RED against pre-fix: the lock file SURVIVED the timeout, because the
+    group got a bare SIGKILL and the trap never ran. This is the incident's
+    mechanism in miniature — the trap stands in for git's own atexit lock
+    cleanup, which is likewise unreachable under SIGKILL.
+    """
+    # Arrange — a child that strands a lock file unless its TERM trap runs.
+    lock = tmp_path / "index.lock"
+    script = f'trap "rm -f {lock!s}; exit 143" TERM; touch {lock!s}; sleep 30'
+    # Act — the call exceeds its deadline, so the timeout path destroys it.
+    _run(_exec({"argv": ["bash", "-c", script], "timeout_s": 1.0}))
+    # Assert — ask the artifact, not the exit code: the lock is NOT stranded.
+    assert not lock.exists()
+
+
+def test_the_cleanup_grace_does_not_stop_the_timeout_from_being_reported(
+    tmp_path: Path,
+):
+    """A child that exits via its TERM trap still timed out. The grace period
+    must not launder a timeout into an ordinary exit — the caller has to be
+    able to tell a deadline miss from a clean run."""
+    # Arrange
+    lock = tmp_path / "index.lock"
+    script = f'trap "rm -f {lock!s}; exit 143" TERM; touch {lock!s}; sleep 30'
+    # Act
+    payload = _resp_json(
+        _run(_exec({"argv": ["bash", "-c", script], "timeout_s": 1.0}))
+    )
+    # Assert
+    assert payload["timed_out"] is True
+
+
+# --------------------------------------------------------------------------
+# 2. CONTROLS — the kill must still happen. "Fixed it by not killing" fails
+#    every test below.
+# --------------------------------------------------------------------------
+
+
+def test_a_child_that_ignores_sigterm_is_still_killed(tmp_path: Path):
+    """CONTROL. The grace period is a courtesy, not a veto. A child that
+    ignores SIGTERM (bash `trap "" TERM`, inherited as SIG_IGN by its
+    children) must still be destroyed by the SIGKILL that follows.
+
+    Without this, "let the child clean up" degrades into "the child decides
+    whether to die", which is the unbounded-child wedge of INCIDENT 2026-07-17.
+    """
+    # Arrange — the whole group ignores SIGTERM; only SIGKILL can end it.
+    script = 'trap "" TERM; sleep 30 & echo $!; sleep 30'
+    # Act
+    payload = _resp_json(
+        _run(_exec({"argv": ["bash", "-c", script], "timeout_s": 1.0}))
+    )
+    grandchild_pid = int(payload["stdout"].strip())
+    time.sleep(0.3)  # let the SIGKILL land
+    # Assert — the SIGTERM-proof grandchild is gone anyway.
+    assert not _pid_alive(grandchild_pid)
+
+
+def test_a_child_that_ignores_sigterm_still_reports_the_process_group_kill(
+    tmp_path: Path,
+):
+    """CONTROL. The typed outcome must still say the group was killed —
+    a caller reading `killed_process_group` must not be told "no" merely
+    because a SIGTERM was tried first."""
+    # Arrange
+    script = 'trap "" TERM; sleep 30'
+    # Act
+    payload = _resp_json(
+        _run(_exec({"argv": ["bash", "-c", script], "timeout_s": 1.0}))
+    )
+    # Assert
+    assert (payload["timed_out"], payload["killed_process_group"]) == (True, True)
+
+
+def test_the_timeout_path_stays_bounded_even_for_a_sigterm_proof_child():
+    """CONTROL. The grace must be BOUNDED. An unbounded wait-for-cleanup is
+    just the original wedge wearing a politer name: the handler would never
+    return and the whole host arm would be gone again."""
+    # Arrange — ignores SIGTERM, so the full grace elapses before SIGKILL.
+    script = 'trap "" TERM; sleep 30'
+    # Act
+    started = time.monotonic()
+    _run(_exec({"argv": ["bash", "-c", script], "timeout_s": 1.0}))
+    elapsed = time.monotonic() - started
+    # Assert — deadline + grace + drain, with slack; NOT the child's 30s.
+    assert elapsed < 15.0
+
+
+def test_a_prompt_child_is_not_delayed_by_the_grace_period():
+    """CONTROL. The grace belongs to the TIMEOUT path only. A command that
+    finishes normally must not pay for it — a fix that charges every call a
+    few seconds would be a performance regression across the whole fleet."""
+    # Arrange
+    body = {"argv": ["echo", "prompt"], "timeout_s": 10.0}
+    started = time.monotonic()
+    # Act
+    payload = _resp_json(_run(_exec(body)))
+    elapsed = time.monotonic() - started
+    # Assert
+    assert (payload["stdout"].strip(), elapsed < 2.0) == ("prompt", True)


### PR DESCRIPTION
## The peer hypothesis is REFUTED

`post-merge-pull.sh` is **not** the producer — it is the **victim**, and it
already has the overlap guard the hypothesis assumed was missing. Lines 56-61
are exactly that `flock` guard, and it is demonstrably live: 1735
`Another instance is running` hits in the current log. Self-overlap is
impossible, so the proposed mechanism cannot occur.

Correlation, not just code reading: there is exactly **one** index.lock band in
the entire 145 MB log (22:52:01 -> 23:10:01) and **no** killed post-merge-pull
run precedes it. The 53 killed runs that do exist are on 07-15 and 07-19 —
zero temporal overlap.

## The actual producer

Verified by strace rather than inferred — `git status --porcelain` really does:

```
openat(AT_FDCWD, ".../.git/index.lock", O_RDWR|O_CREAT|O_EXCL|O_CLOEXEC, 0666) = 3
```

…and this timeout path sent the child's whole process **group** a bare
SIGKILL. SIGKILL is uncatchable, so git's own lock cleanup never ran and the
file was stranded. `host_exec.log` holds 183 killed calls, 13 of them invoking
version control inside a shared fleet checkout; one matches a stranded lock to
the exact second (`timed_out=true`, `killed_pg=true`).

The debris survives unnoticed because a stranded lock is **silent to readers** —
`git status` still exits 0 — so it sits invisible until something needs to
WRITE. That is the 83-minute outage.

## The fix

On timeout: SIGTERM the group -> bounded 3s grace for its own cleanup -> SIGKILL.

The SIGKILL still follows **unconditionally**. The grace is a courtesy, not a
veto: a child that ignores SIGTERM must not outlive its deadline (the
unbounded-child wedge of INCIDENT 2026-07-17), and the direct child exiting
says nothing about **grandchildren**.

The grace is a flat sleep, not a wait-for-exit — `proc.wait()` reaps the child
and frees its pid, and the pid **is** the pgid, so a recycled pgid would point
the SIGKILL at an unrelated process group. That hazard is documented in the
function so nobody "optimises" it back in.

`_WATCHDOG_MARGIN_S` is now **derived** from the grace, so the watchdog can
never silently start pre-empting the orderly teardown when either constant is
retuned.

## Mutation proof

**RED** before the fix — the artifact, not a return code:

```
tests/.../test__host_exec_term_grace.py:106: in test_timeout_lets_the_child_run_its_cleanup_handler_before_it_dies
    assert not lock.exists()
E   AssertionError: assert not True
E    +  where True = exists()
E    +    where exists = PosixPath('.../index.lock').exists
1 failed, 5 passed in 14.06s
```

**GREEN** after: `18 passed in 49.74s` — 6 new plus all 12 pre-existing
`test__host_exec_wedge.py` tests, so the process-group kill did not regress.

**CONTROLS proved sensitive** (a control that never goes red is worthless).
Deleting the SIGKILL — the "fixed it by disabling the feature" scenario:

```
FAILED ...::test_a_child_that_ignores_sigterm_is_still_killed
FAILED ...::test_a_child_that_ignores_sigterm_still_reports_the_process_group_kill
FAILED ...::test_the_timeout_path_stays_bounded_even_for_a_sigterm_proof_child
3 failed, 15 passed
```

Exactly the 3 controls fail while the primary test still passes.

## Scope — what is deliberately NOT here

This is FIX 1 of 4 from the investigation, and the only one that reduces lock
**births** rather than cleaning up after them.

**FIX 2 (stale-lock breaker in post-merge-pull.sh) is deliberately excluded.**
It is specified around `fuser`, and `fuser` does not exist in the container:

```
$ command -v fuser lsof
timeout: failed to run command 'command': No such file or directory
```

Whether the **host** has it is UNKNOWN — the broker denies this caller:

```
{"error":"ACL deny","reason":"host_exec is restricted to groups
['developer','privileged','researcher']; caller 'sac-fcs1-impl' resolves to group ''"}
```

Shipping a **destructive** lock-deleter whose safety gate I cannot exercise in
the deployed environment would be a gate nobody executed. Worse, `fuser`
returns non-zero for BOTH "no holder" and "fatal error" — an exit-code
collision that would silently turn UNKNOWN into "FREE, delete it". If FIX 2 is
wanted, it needs a probe with a **payload** and a runtime calibration step, and
someone in the `developer` group to confirm what exists on the host.

FIX 3 (alerting + logrotate) and FIX 4 (re-run `sac installation setup-cron`)
are adjacent scope / an ops action, not this diff.

## Still open

- Locks #1 (21:46:58) and #3 (22:00:12) have **no identified producer** — a
  genuine UNKNOWN, not a soft conclusion. FIX 1 provably does not cover them.
  What would settle it: an inotify `IN_CREATE` watch on `.git/index.lock` that
  records the creating process's `/proc/<pid>/cmdline` and ppid chain — the
  only instrument that **observes** the producer instead of inferring it.
- The ~5-minute-cadence kills of post-merge-pull itself (07-15 06:57-09:57,
  07-19 06:43/06:48) are unexplained; they smell like a `timeout 300` wrapper
  or a watchdog I could not see (crontab is ACL-denied to me).
- Unrelated but visible: CI is failing on develop (quality job, run
  29647797920). Not investigated.
