### PR TITLE
refactor(spec)!: abolish metadata.labels.tags — groups is the only classification field

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -137,18 +137,31 @@ def _probe_local(cfg) -> bool | None:
         return None
 
 
-def _label_list_contains(labels: dict, label_key: str, wanted: str) -> bool:
-    """True iff any comma-separated ``wanted`` token is in ``labels[label_key]``.
+def _label_group_matches(labels: dict, wanted: str) -> bool:
+    """True iff the spec's ``groups`` name ANY comma-separated ``wanted`` value.
 
-    Mirrors the existing ``capabilities`` matching (comma-separated in YAML,
-    ``value in list`` membership), generalised so both ``--capability`` and
-    ``--tags`` share one comparison instead of two near-identical copies.
-    Also OR-matches when the CALLER passes multiple comma-separated wanted
-    values (``--tags active-development,researcher``): true if the agent
-    carries ANY of them.
+    Replaces the pre-2026-07-19 ``tags``-label matcher. ``tags:`` was
+    ABOLISHED (operator decision) because every spec carrying it also
+    carried the same classification inside ``groups:`` — pure duplication.
+    ``groups`` is now the only classification field.
+
+    NOT a rename of the old string matcher: ``tags`` was authored as a
+    CSV STRING (``tags: "active-development"``) while ``groups`` is a YAML
+    LIST (``groups: [developer, active]``), so the old ``.split(",")``
+    read would not work here. Group reading is delegated to
+    :func:`config._group_resolver.all_named_groups` — the SSOT MULTI-value
+    reader that ``sac agents start --group`` already trusts — which
+    honours the plural list, the singular ``group`` string, and a
+    defensively-authored bare string alike.
+
+    Matching is case-insensitive / whitespace-trimmed (mirroring
+    ``_start_group_filter.resolve_group_targets``) and OR-shaped: a caller
+    passing ``--group developer,researcher`` matches an agent in EITHER.
     """
-    have = {c.strip() for c in labels.get(label_key, "").split(",") if c.strip()}
-    want = {w.strip() for w in wanted.split(",") if w.strip()}
+    from ...config._group_resolver import all_named_groups
+
+    have = {g.strip().lower() for g in all_named_groups(labels)}
+    want = {w.strip().lower() for w in wanted.split(",") if w.strip()}
     return bool(have & want)
 
 
@@ -156,7 +169,7 @@ def get_agent_list_data(
     registry: Registry,
     capability: str | None = None,
     machine: str | None = None,
-    tags: str | None = None,
+    group: str | None = None,
     remote_probe_timeout_s: float = 2.0,
     max_parallel_probes: int = 8,
     running_only: bool = False,
@@ -179,13 +192,17 @@ def get_agent_list_data(
         capability: If set, only include agents whose ``capabilities`` label
             contains this value (comma-separated matching).
         machine: If set, only include agents whose ``machine`` label matches.
-        tags: If set, only include agents whose ``tags`` label (comma-
-            separated in YAML, e.g. ``tags: "active-development"``) contains
-            ANY of the given comma-separated values — a free-form, multi-
-            value lifecycle/status marker, deliberately separate from
-            ``groups`` (which is ACL-gated and singular-effective; see
-            ``config._group_resolver``) and from ``capabilities`` (what an
-            agent can do, not its current work status).
+        group: If set, only include agents whose spec names ANY of the
+            given comma-separated groups in ``metadata.labels.groups``
+            (or the singular ``.group``). Replaces the abolished ``tags``
+            filter (operator decision 2026-07-19): ``groups`` is the only
+            classification field, so the lifecycle/status marker that used
+            to live in ``tags`` (e.g. ``active-development``) is now the
+            ``active`` group. Read via the SSOT multi-value reader
+            ``config._group_resolver.all_named_groups``, so an agent in
+            several groups is reachable by ANY of them — the same cut
+            ``sac agents start --group`` uses, NOT the singular-effective
+            ACL resolution.
         remote_probe_timeout_s: Per-agent SSH probe timeout for the
             ``is_running`` check. Short by default (2s) so the list
             command doesn't block indefinitely when the remote host is
@@ -260,7 +277,7 @@ def get_agent_list_data(
             ]
             if capability not in caps:
                 continue
-        if tags and not _label_list_contains(labels, "tags", tags):
+        if group and not _label_group_matches(labels, group):
             continue
 
         prep = {
@@ -443,7 +460,7 @@ def get_agent_list_data(
         running_only=running_only,
         capability=capability,
         machine=machine,
-        tags=tags,
+        group=group,
         status_probe=remote_status_probe,
         run_ssh=remote_run_ssh,
     )
@@ -461,7 +478,7 @@ def get_agent_list_data(
             display_host=display_host,
             capability=capability,
             machine=machine,
-            tags=tags,
+            group=group,
             running_only=running_only,
         )
     )

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
@@ -97,7 +97,7 @@ def defined_agent_rows(
     display_host: str,
     capability: str | None = None,
     machine: str | None = None,
-    tags: str | None = None,
+    group: str | None = None,
     running_only: bool = False,
 ) -> list[dict]:
     """Rows for agents DEFINED on disk but absent from the registry.
@@ -153,7 +153,7 @@ def defined_agent_rows(
             ]
             if capability not in caps:
                 continue
-        if tags and not _al._label_list_contains(labels, "tags", tags):
+        if group and not _al._label_group_matches(labels, group):
             continue
         # FIX (no double-parse): a spec that ``load_config`` accepted is
         # valid ⇒ "defined". Only RE-VALIDATE the ones that FAILED to load,
@@ -324,7 +324,7 @@ def remote_instance_rows(
     running_only: bool = False,
     capability: str | None = None,
     machine: str | None = None,
-    tags: str | None = None,
+    group: str | None = None,
     instances_oracle: Callable[[], list[dict]] | None = None,
     status_probe: Callable[[str, str], str] | None = None,
     run_ssh: Callable[[list[str]], int] | None = None,
@@ -411,7 +411,7 @@ def remote_instance_rows(
             ]
             if capability not in caps:
                 continue
-        if tags and not _al._label_list_contains(labels, "tags", tags):
+        if group and not _al._label_group_matches(labels, group):
             continue
         candidates.append(
             {

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
@@ -153,13 +153,13 @@ def print_agent_list_json(
     registry: Registry,
     capability: str | None = None,
     machine: str | None = None,
-    tags: str | None = None,
+    group: str | None = None,
 ) -> None:
     """Print agent list as JSON."""
     from ._agent_list import get_agent_list_data
 
     data = get_agent_list_data(
-        registry, capability=capability, machine=machine, tags=tags
+        registry, capability=capability, machine=machine, group=group
     )
     click.echo(json_mod.dumps(data, indent=2))
 
@@ -234,7 +234,7 @@ def print_agent_list(
     registry: Registry,
     capability: str | None = None,
     machine: str | None = None,
-    tags: str | None = None,
+    group: str | None = None,
     *,
     verbose: bool = False,
     show_all: bool = False,
@@ -261,7 +261,7 @@ def print_agent_list(
         registry,
         capability=capability,
         machine=machine,
-        tags=tags,
+        group=group,
         running_only=not (verbose or show_all),
     )
     if not data:

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -166,14 +166,16 @@ def _format_claude_account_block(meta: dict) -> list[str]:
     help="Fleet view: filter by machine label.",
 )
 @click.option(
-    "--tags",
-    "-t",
+    "--group",
+    "-g",
     default=None,
-    help="Fleet view: filter by tags label (comma-separated in YAML; "
-    "matches if the agent carries ANY of the given comma-separated "
-    "values). A free-form lifecycle/status marker, e.g. "
-    "'active-development' -- separate from --capability (what an agent "
-    "can do) and from the ACL group label (metadata.labels.groups).",
+    help="Fleet view: filter by group membership (metadata.labels.groups, "
+    "or the singular .group). Matches if the agent's spec names ANY of "
+    "the given comma-separated groups -- e.g. --group active. Replaces "
+    "the removed --tags flag: 'groups' is the only classification field "
+    "(operator decision 2026-07-19), so the 'active-development' tag is "
+    "now the 'active' group. Separate from --capability (what an agent "
+    "can do, not which cohort it is in).",
 )
 @click.option(
     "--verbose",
@@ -229,7 +231,7 @@ def status(
     terse: bool,
     capability: str | None,
     machine: str | None,
-    tags: str | None,
+    group: str | None,
     verbose: bool,
     show_all: bool,
     with_snapshot: bool,
@@ -239,7 +241,7 @@ def status(
     """Show agent status.
 
     Without ``NAME``: fleet view — every registered agent in a table,
-    optionally filtered by ``--capability`` / ``--machine`` / ``--tags``.
+    optionally filtered by ``--capability`` / ``--machine`` / ``--group``.
 
     With ``NAME``: rich per-agent payload (registry entry + config-derived
     fields + resource snapshot).
@@ -250,7 +252,7 @@ def status(
       $ sac agent status orchestrator               # rich per-agent
       $ sac agent status --json                     # fleet view, JSON
       $ sac agent status --capability HPC           # fleet view, filtered
-      $ sac agent status --tags active-development  # fleet view, by tag
+      $ sac agent status --group active            # fleet view, by group
     """
     use_json = _json_flag(ctx, as_json) or terse
     registry = Registry()
@@ -386,7 +388,7 @@ def status(
                             registry,
                             capability=capability,
                             machine=machine,
-                            tags=tags,
+                            group=group,
                         ),
                     },
                     indent=2,
@@ -397,7 +399,7 @@ def status(
                 registry,
                 capability=capability,
                 machine=machine,
-                tags=tags,
+                group=group,
                 verbose=verbose,
                 show_all=show_all,
             )

--- a/src/scitex_agent_container/config/_labels_validation.py
+++ b/src/scitex_agent_container/config/_labels_validation.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``metadata.labels`` validation — the classification-field SSoT gate.
+
+Split out of ``_validation.py`` to match the sibling focused-validator
+convention (``_acl_validation`` / ``_claude_validation`` /
+``_placement_validation`` / ``_shape_validation`` /
+``_startup_command_validation``) and to keep the orchestrator under the
+per-file line cap.
+
+ABOLISHED FIELDS
+----------------
+``metadata.labels.tags`` — removed by operator decision 2026-07-19.
+``groups:`` is the ONLY classification field. The evidence: all 16 fleet
+specs that carried ``tags: "active-development"`` ALSO carried ``active``
+inside their ``groups:`` list, so ``tags`` carried ZERO information that
+``groups`` did not already carry. Pure duplication is the SSoT violation
+constitution §1 forbids.
+
+Rejected LOUDLY, with no silent-accept transition window (constitution §2,
+no silent fallbacks). A silently-ignored field is exactly how dead fields
+survive for months: nothing ever fails, so nobody ever removes them. The
+message names the offending FILE because an operator fixing a fleet of
+specs needs to know which one failed, and points at the replacement so the
+fix is mechanical.
+"""
+
+from __future__ import annotations
+
+# Labels that are no longer accepted, mapped to the actionable remedy.
+# Keyed by label name; the message is formatted with the spec ``path``.
+_ABOLISHED_LABELS: dict[str, str] = {
+    "tags": (
+        "metadata.labels.tags is no longer accepted in {path}; 'groups' is "
+        "the only classification field (operator decision 2026-07-19). "
+        "Remove the 'tags:' line and list the value in 'groups:' instead "
+        "— e.g. groups: [developer, active]. Filter with "
+        "`sac agent status --group NAME` (the --tags flag is gone)."
+    ),
+}
+
+
+def validate_labels(metadata: object, path: str) -> list[str]:
+    """Return error strings for abolished ``metadata.labels`` entries.
+
+    ``metadata`` is the raw ``metadata`` value straight off the parsed
+    YAML — it may legitimately be ``None`` (no metadata block) or a
+    non-mapping (already reported by the caller's shape check), in which
+    case there is nothing here to validate and the result is empty.
+
+    Deliberately checks KEY PRESENCE, not truthiness: ``tags:`` with an
+    empty value is still an authored dead field and must still fail, or
+    the abolition leaks through the one spec that blanked it instead of
+    deleting it.
+    """
+    if not isinstance(metadata, dict):
+        return []
+    labels = metadata.get("labels")
+    if not isinstance(labels, dict):
+        return []
+    return [
+        message.format(path=path)
+        for label, message in _ABOLISHED_LABELS.items()
+        if label in labels
+    ]
+
+
+__all__ = ["validate_labels"]

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -20,6 +20,7 @@ from ._acl_validation import validate_phase3_acl
 # back-compat with any importer of the old ``_validation._VALID_MODEL_RE``.
 from ._claude_validation import _VALID_MODEL_RE as _VALID_MODEL_RE  # noqa: F401
 from ._claude_validation import validate_claude
+from ._labels_validation import validate_labels
 from ._placement_validation import validate_placement
 
 # spec.provider (TOP-LEVEL agent-SDK-family selector; openai-compat-1
@@ -256,6 +257,10 @@ def validate_raw(raw: dict, path: str) -> list[str]:
             "the metadata.name field and ensure the YAML lives at "
             "<name>/<name>.yaml."
         )
+
+    # metadata.labels — abolished classification fields (``tags``, removed
+    # 2026-07-19 in favour of the ``groups`` SSoT). See _labels_validation.
+    errors.extend(validate_labels(metadata, path))
 
     # spec
     spec = raw.get("spec")

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
@@ -110,9 +110,15 @@ def _write_valid_spec(
     *,
     capabilities: str | None = None,
     machine: str | None = None,
-    tags: str | None = None,
+    groups: list[str] | None = None,
 ) -> Path:
-    """Write a minimal real v3 spec.yaml; optionally with labels."""
+    """Write a minimal real v3 spec.yaml; optionally with labels.
+
+    ``groups`` is authored as a YAML FLOW LIST (``groups: [a, b]``) —
+    the real fleet convention, and deliberately NOT the CSV string the
+    abolished ``tags`` label used. A filter that assumed a string would
+    pass a test that faked one, so the fixture writes the real shape.
+    """
     dir_.mkdir(parents=True, exist_ok=True)
     spec = dir_ / "spec.yaml"
     lines = ["apiVersion: scitex-agent-container/v3", "kind: Agent"]
@@ -121,8 +127,8 @@ def _write_valid_spec(
         label_lines.append(f'    capabilities: "{capabilities}"')
     if machine is not None:
         label_lines.append(f'    machine: "{machine}"')
-    if tags is not None:
-        label_lines.append(f'    tags: "{tags}"')
+    if groups is not None:
+        label_lines.append(f"    groups: [{', '.join(groups)}]")
     if label_lines:
         # ``cfg.labels`` is sourced from ``metadata.labels`` by the v3 loader.
         lines.append("metadata:")
@@ -375,65 +381,81 @@ def test_get_data_with_machine_filter_excludes_non_matching_agent(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# tags filter — a free-form, multi-value lifecycle/status label (e.g.
-# "active-development"), deliberately separate from the ACL-gated `groups`
-# label (config._group_resolver) and from `capabilities` (what an agent can
-# do, not its current work status). Mirrors the capability-filter tests.
+# group filter — `metadata.labels.groups`, the ONLY classification field
+# (operator decision 2026-07-19). Replaces the abolished `tags` label, whose
+# every value duplicated a group the same spec already carried. Read through
+# the SSOT multi-value reader `config._group_resolver.all_named_groups`, so a
+# YAML LIST is matched natively — the abolished `tags` matcher read a CSV
+# STRING and would not have worked here.
 # ---------------------------------------------------------------------------
 
 
-def test_get_data_with_tags_filter_includes_matching_agent(tmp_path):
-    # Arrange — real spec with labels.tags="active-development, researcher".
-    spec = _write_valid_spec(tmp_path / "x", tags="active-development, researcher")
+def test_get_data_with_group_filter_includes_matching_agent(tmp_path):
+    # Arrange — real spec with labels.groups: [active, researcher].
+    spec = _write_valid_spec(tmp_path / "x", groups=["active", "researcher"])
     entries = [
         {"name": "x", "screen": "s", "started_at": "ts", "config": str(spec)},
     ]
     registry = _FakeRegistry(entries)
     # Act
     with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
-        out = get_agent_list_data(registry, tags="active-development")
+        out = get_agent_list_data(registry, group="active")
     # Assert
-    assert len(out) == 1 and out[0]["name"] == "x"
+    assert [r["name"] for r in out] == ["x"]
 
 
-def test_get_data_with_tags_filter_excludes_non_matching_agent(tmp_path):
+def test_get_data_with_group_filter_excludes_non_matching_agent(tmp_path):
     # Arrange
-    spec = _write_valid_spec(tmp_path / "x", tags="researcher")
+    spec = _write_valid_spec(tmp_path / "x", groups=["researcher"])
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
     # Act
     with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
-        out = get_agent_list_data(registry, tags="active-development")
+        out = get_agent_list_data(registry, group="active")
     # Assert
     assert out == []
 
 
-def test_get_data_with_tags_filter_matches_any_of_multiple_wanted_values(tmp_path):
-    # Arrange — caller passes two comma-separated wanted tags; agent has one.
-    spec = _write_valid_spec(tmp_path / "x", tags="researcher")
+def test_get_data_with_group_filter_matches_any_of_multiple_wanted_values(tmp_path):
+    # Arrange — caller passes two comma-separated groups; agent is in one.
+    spec = _write_valid_spec(tmp_path / "x", groups=["researcher"])
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
     # Act
     with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
-        out = get_agent_list_data(registry, tags="active-development,researcher")
-    # Assert — OR-match: any overlap between wanted and carried tags is a hit.
-    assert len(out) == 1 and out[0]["name"] == "x"
+        out = get_agent_list_data(registry, group="active,researcher")
+    # Assert — OR-match: any overlap between wanted and carried groups hits.
+    assert [r["name"] for r in out] == ["x"]
 
 
-def test_get_data_with_tags_filter_untagged_agent_is_excluded(tmp_path):
-    # Arrange — agent has no tags label at all.
+def test_get_data_with_group_filter_matches_a_non_first_group(tmp_path):
+    # Arrange — `active` is NOT the first element. The ACL resolver reduces a
+    # spec to its FIRST group; selection must use the MULTI-value read instead,
+    # or every real fleet spec (groups: [developer, active]) would be missed.
+    spec = _write_valid_spec(tmp_path / "x", groups=["developer", "active"])
+    entries = [{"name": "x", "config": str(spec)}]
+    registry = _FakeRegistry(entries)
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        out = get_agent_list_data(registry, group="active")
+    # Assert
+    assert [r["name"] for r in out] == ["x"]
+
+
+def test_get_data_with_group_filter_ungrouped_agent_is_excluded(tmp_path):
+    # Arrange — agent has no groups label at all.
     spec = _write_valid_spec(tmp_path / "x")
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
     # Act
     with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
-        out = get_agent_list_data(registry, tags="active-development")
+        out = get_agent_list_data(registry, group="active")
     # Assert
     assert out == []
 
 
-def test_get_data_without_tags_filter_includes_untagged_agent(tmp_path):
-    # Arrange — no --tags passed at all: the filter must be a pure no-op.
+def test_get_data_without_group_filter_includes_ungrouped_agent(tmp_path):
+    # Arrange — no --group passed at all: the filter must be a pure no-op.
     spec = _write_valid_spec(tmp_path / "x")
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
@@ -441,13 +463,13 @@ def test_get_data_without_tags_filter_includes_untagged_agent(tmp_path):
     with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
         out = get_agent_list_data(registry)
     # Assert
-    assert len(out) == 1 and out[0]["name"] == "x"
+    assert [r["name"] for r in out] == ["x"]
 
 
-def test_get_data_with_tags_filter_includes_matching_defined_agent(tmp_path):
+def test_get_data_with_group_filter_includes_matching_defined_agent(tmp_path):
     # Arrange — defined-on-disk (not registered) agent; the second filter
-    # site (the disk-merge loop) must apply the SAME tags matching.
-    spec = _write_valid_spec(tmp_path / "ondisk", tags="active-development")
+    # site (the disk-merge loop) must apply the SAME group matching.
+    spec = _write_valid_spec(tmp_path / "ondisk", groups=["developer", "active"])
     registry = _FakeRegistry([])
 
     def _discover() -> list[tuple[str, Path]]:
@@ -455,14 +477,40 @@ def test_get_data_with_tags_filter_includes_matching_defined_agent(tmp_path):
 
     # Act
     with _swap_discover(_discover):
-        out = get_agent_list_data(registry, tags="active-development")
+        out = get_agent_list_data(registry, group="active")
     # Assert
     assert any(r["name"] == "ondisk" for r in out)
 
 
-def test_get_data_with_tags_filter_excludes_non_matching_defined_agent(tmp_path):
-    # Arrange — same disk-merge loop, non-matching tag this time.
-    spec = _write_valid_spec(tmp_path / "ondisk", tags="researcher")
+def test_get_data_group_filter_selects_what_the_tags_filter_used_to_select(tmp_path):
+    """MIGRATION EQUIVALENCE — `--group active` == the old `--tags active-development`.
+
+    The abolition rests on the claim that `tags` carried no information
+    `groups` did not: all 16 fleet specs carrying `tags: "active-development"`
+    ALSO carried `active` in `groups:`. This pins the consequence — the
+    replacement filter returns the SAME agents the removed one did — so the
+    migration cannot silently narrow or widen the fleet view.
+    """
+    # Arrange — two agents in the real fleet shape (the tagged one carried
+    # groups: [developer, active]), and one deliberately outside the cohort.
+    tagged = _write_valid_spec(tmp_path / "figrecipe", groups=["developer", "active"])
+    other = _write_valid_spec(tmp_path / "dormant", groups=["developer"])
+    registry = _FakeRegistry(
+        [
+            {"name": "figrecipe", "config": str(tagged)},
+            {"name": "dormant", "config": str(other)},
+        ]
+    )
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        out = get_agent_list_data(registry, group="active")
+    # Assert — exactly the formerly-tagged agent, not the whole developer set.
+    assert [r["name"] for r in out] == ["figrecipe"]
+
+
+def test_get_data_with_group_filter_excludes_non_matching_defined_agent(tmp_path):
+    # Arrange — same disk-merge loop, non-matching group this time.
+    spec = _write_valid_spec(tmp_path / "ondisk", groups=["researcher"])
     registry = _FakeRegistry([])
 
     def _discover() -> list[tuple[str, Path]]:
@@ -470,7 +518,7 @@ def test_get_data_with_tags_filter_excludes_non_matching_defined_agent(tmp_path)
 
     # Act
     with _swap_discover(_discover):
-        out = get_agent_list_data(registry, tags="active-development")
+        out = get_agent_list_data(registry, group="active")
     # Assert
     assert out == []
 
@@ -1234,7 +1282,12 @@ def test_runtime_account_for_reads_per_agent_oauth_email(tmp_path):
     (home / ".claude").mkdir(parents=True)
     (home / ".claude" / ".credentials.json").write_text(
         _json.dumps(
-            {"claudeAiOauth": {"accessToken": "sk-ant-x", "expiresAt": 9_999_999_999_000}}
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-x",
+                    "expiresAt": 9_999_999_999_000,
+                }
+            }
         )
     )
     (home / ".claude.json").write_text(

--- a/tests/scitex_agent_container/config/test__validation.py
+++ b/tests/scitex_agent_container/config/test__validation.py
@@ -1056,3 +1056,60 @@ def test_container_workdir_is_rejected():
     errors = validate_raw(raw, path="<test>")
     # Assert
     assert [e for e in errors if "container_workdir has been REMOVED" in e]
+
+
+# ---------------------------------------------------------------------------
+# metadata.labels.tags — ABOLISHED (operator decision 2026-07-19).
+#
+# `groups:` is the only classification field. Every one of the 16 fleet
+# specs that carried `tags: "active-development"` ALSO carried `active`
+# inside `groups:`, so `tags` carried ZERO information `groups` did not
+# already carry — pure duplication, i.e. the SSoT violation constitution
+# §1 forbids. Rejected LOUDLY (no silent-accept transition window, per
+# constitution §2 no-silent-fallbacks): a silently-ignored field is how
+# dead fields survive for months.
+# ---------------------------------------------------------------------------
+
+
+def _labels_spec(labels: dict) -> dict:
+    """A minimal valid v3 raw spec carrying ``metadata.labels``."""
+    return {**_BASE, "metadata": {"labels": labels}}
+
+
+def test_labels_tags_is_rejected():
+    # Arrange — the abolished classification field.
+    raw = _labels_spec({"tags": "active-development"})
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "metadata.labels.tags" in e]
+
+
+def test_labels_tags_rejection_points_at_groups():
+    # Arrange — the rejection must hand the operator the replacement field.
+    raw = _labels_spec({"tags": "active-development"})
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    bad = [e for e in errors if "metadata.labels.tags" in e]
+    # Assert
+    assert "groups" in bad[0]
+
+
+def test_labels_tags_rejection_names_the_offending_file():
+    # Arrange — an operator fixing 16 specs needs to know WHICH one failed.
+    raw = _labels_spec({"tags": "active-development"})
+    # Act
+    errors = validate_raw(raw, path="/agents/figrecipe/spec.yaml")
+    bad = [e for e in errors if "metadata.labels.tags" in e]
+    # Assert
+    assert "/agents/figrecipe/spec.yaml" in bad[0]
+
+
+def test_labels_groups_only_is_accepted():
+    # Arrange — CONTROL: the surviving field must still validate cleanly,
+    # so the rejection above cannot "pass" by rejecting every spec.
+    raw = _labels_spec({"groups": ["developer", "active"]})
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert not [e for e in errors if "metadata.labels" in e]


### PR DESCRIPTION
Operator decision 2026-07-19: `tags:` in agent `spec.yaml` is **abolished**. `groups:` is the only classification field.

**Evidence:** all 16 fleet specs carrying `tags: "active-development"` ALSO carry `active` inside `groups:`. `tags` carried zero information `groups` did not already carry — pure duplication, the SSoT violation constitution §1 forbids.

## Refutation: `tags` was NOT inert

The brief expected no consumers. There was one, and it was a real user-facing CLI surface:

| Consumer | File |
|---|---|
| `sac agent status --tags` / `-t` | `cli_pkg/status_cmds.py` |
| `get_agent_list_data(tags=…)` + filter site | `cli_pkg/_helpers/_agent_list.py` |
| `print_agent_list(tags=…)` → `get_agent_list_data` | `cli_pkg/_helpers/_agent_list_render.py` |
| `defined_agent_rows` / `remote_instance_rows` (2 filter sites) | `cli_pkg/_helpers/_agent_list_discover.py` |
| `_label_list_contains(labels, "tags", …)` | `cli_pkg/_helpers/_agent_list.py` |
| filter tests | `tests/…/_helpers/test__agent_list.py` |

Everything else matching `tags` in the repo is a **different concept** and is deliberately untouched: the A2A AgentCard `skills[0].tags` (`a2a/_card.py`, `docs/spec-reference.md`), Claude skill-markdown frontmatter (`_skills/*.md`), and a FontAwesome glyph.

No JSON schema exists for the spec; `labels` is a free-form `dict[str, str]` (`config/_types.py`), which is exactly why `tags` was silently accepted for months.

## This is a migration, not a rename

`--tags` → `--group`. The two label shapes genuinely differ:

- `tags` was a **CSV string** — `tags: "active-development"`
- `groups` is a **YAML list** — `groups: [developer, active]`

Verified against a real loaded spec: the old `.split(",")` read raises `AttributeError: 'list' object has no attribute 'split'` on a groups label. So group reading is delegated to the SSOT multi-value reader `config._group_resolver.all_named_groups` — the one `sac agents start --group` already trusts — which matches a group named **anywhere** in the list rather than only the ACL-effective first element. A first-element-only read would have missed every real fleet spec, since they all author `groups: [developer, active]` with `active` second.

**No information is lost:** the `active-development` tag cohort is exactly the `active` group cohort, pinned by a migration-equivalence test.

## Loud rejection, no transition window

New `config/_labels_validation.py` rejects `metadata.labels.tags` with a message naming the offending **file** and pointing at `groups` (constitution §2, no silent fallbacks). I agree with the brief's judgement against a transition window — a silently-ignored field is precisely how dead fields survive for months. It checks key **presence**, not truthiness, so a blanked `tags:` still fails.

Split into its own module rather than growing `_validation.py`, matching the existing focused-validator convention (`_acl_validation`, `_claude_validation`, `_placement_validation`, `_shape_validation`, `_startup_command_validation`) — and because `_validation.py` was already within 9 lines of the 512-line cap.

## Tests — RED confirmed before the fix

```
FAILED test_labels_tags_is_rejected                      - assert []
FAILED test_labels_tags_rejection_points_at_groups       - IndexError: list index out of range
FAILED test_labels_tags_rejection_names_the_offending_file - IndexError: list index out of range
================= 3 failed, 1 passed, 114 deselected =================
```

`assert []` is the proof the pre-fix code **silently accepted** `tags`. The 4th test — the `groups`-only control — passed both before and after, so the gate cannot "pass" by rejecting everything.

Green after: `test__validation.py` 118 passed · `test__agent_list.py` 68 passed · `test__selection.py` + `test__group_resolver.py` + `test__loaders.py` 128 passed.

End-to-end CLI check: `-g, --group` present in `--help`; `--tags active-development` now exits **2** (no such option) rather than being silently ignored.

## HAND-OFF: dotfiles specs (NOT edited here)

These live in the **dotfiles agent's** repository, so this PR does not touch them. Delete exactly these 16 lines — each is `    tags: "active-development"`, and each file already carries `active` in its `groups:`, so nothing else needs adding:

```
~/.dotfiles/src/.scitex/agent-container/agents/
  claude-code-telegrammer/spec.yaml:26
  figrecipe/spec.yaml:13
  grant/spec.yaml:16
  neurovista/spec.yaml:24
  neurovista-paper-writer/spec.yaml:26
  paper-scitex-clew/spec.yaml:29
  scitex-agent-container/spec.yaml:12
  scitex-clew/spec.yaml:11
  scitex-dev/spec.yaml:28
  scitex-hpc/spec.yaml:14
  scitex-python/spec.yaml:25
  scitex-scholar/spec.yaml:13
  scitex-storage/spec.yaml:11
  scitex-ui/spec.yaml:13
  scitex-writer/spec.yaml:26
  spartan-dev/spec.yaml:41
```

**Ordering matters:** once this merges, those 16 specs fail validation until the lines are removed. Merge the dotfiles change first, or accept a window where those agents' specs are invalid.

Anyone whose muscle memory is `sac agent status --tags active-development` should switch to `sac agent status --group active`.

## Pre-existing, not from this PR

CI `quality` was already failing on `develop` before this branch (run 29647797920), and `config/_validation.py` carries a pre-existing `STX-IO010` warning on a `yaml.safe_load` line I did not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqhsrw29CM4siBLcEK2CwV
