### PR TITLE
feat(delivery): verified a2a delivery — prove the target, confirm arrival, confirm SUBMISSION

### DIFF
--- a/src/scitex_agent_container/_delivery/__init__.py
+++ b/src/scitex_agent_container/_delivery/__init__.py
@@ -1,0 +1,124 @@
+"""VERIFIED agent-to-agent delivery — a send that reports what it actually knows.
+
+Agents talk by pasting into each other's tmux panes and learn NOTHING about
+whether it worked. ``tmux send-keys`` into a session that does not exist prints
+"can't find pane" to a stderr nobody reads and exits 0, so four completely
+different outcomes are indistinguishable from the sender's side:
+
+1. **TARGET DEAD** — the session does not exist. An operator coordinated with
+   ``tui-dotfiles`` for hours; every message vanished and every one was reported
+   as delivered.
+2. **TARGET WEDGED** — the pane exists and nothing ever submits.
+3. **TEXT SITS UNSUBMITTED IN THE COMPOSER** — the message landed (confirmed by
+   reading the pane) and the agent stayed idle; a bare Enter started it working
+   immediately. A send is NOT complete until the newline actually submits.
+4. **THE VERIFICATION ITSELF LIES** — a pane grepped for a prose fragment
+   returned nothing about a message that HAD arrived, because the TUI re-rendered
+   and wrapped it.
+
+This package makes each of those a NAMED, SEPARATELY REPORTED signal, and — the
+part that matters most — keeps "I could not tell" as a first-class answer rather
+than rounding it to one of the poles.
+
+* :mod:`._spec` declares the signals, which are load-bearing, which are decisive
+  (none are, and it says why). Validated at import.
+* :mod:`._state` is the frozen dataclass a send returns, every signal
+  ``bool | None``, with reasons and the RAW captures attached.
+* :mod:`._assess` is THE single pure fold: True / False / None.
+* :mod:`._token` is the arrival matcher — a short injected token against a
+  flattened pane, which is the fix for mode 4.
+* :mod:`._route` proves the target exists before anything is sent (mode 1), and
+  refuses to convict off an enumeration that could not have shown presence.
+* :mod:`._deliver` wires it together: ONE verb, two strategies — the existing
+  ``sac agents send`` resume path when the agent has a recorded session id, and
+  the verified tmux path for TUI agents, which is the population that matters.
+
+The submit-verification (mode 3) is NOT new code: it reuses
+``runtimes._tui_compose.verify_submit_by_advancement``, the idle-gated Enter with
+bounded retry that already fixed this exact drop on the boot path. Composing the
+proven part beats writing a second one that can drift from it.
+"""
+
+from __future__ import annotations
+
+from ._assess import (
+    EXIT_DELIVERED,
+    EXIT_NO_ROUTE,
+    EXIT_REFUTED,
+    EXIT_UNKNOWN,
+    EXIT_UNSUBMITTED,
+    DeliveryAssessment,
+    assess_delivery,
+)
+from ._deliver import (
+    DEFAULT_ARRIVAL_TIMEOUT_S,
+    DEFAULT_IDLE_WAIT_S,
+    DEFAULT_MAX_RESENDS,
+    DEFAULT_POLL_S,
+    deliver,
+)
+from ._route import (
+    STRATEGY_SDK,
+    STRATEGY_TUI,
+    TUI_SESSION_PREFIX,
+    Route,
+    list_tmux_sessions,
+    read_agent_session_id,
+    resolve_route,
+)
+from ._spec import (
+    DELIVERY_LOAD_BEARING,
+    DELIVERY_SIGNAL_NAMES,
+    DELIVERY_SIGNALS,
+    OBSERVATION_DIRECT,
+    OBSERVATION_INFERRED,
+    DeliverySignalSpec,
+    delivery_spec_for,
+    validate_delivery_specs,
+)
+from ._state import DeliveryState
+from ._token import (
+    DELIVERY_TOKEN_BYTES,
+    flatten_pane,
+    format_payload,
+    make_token,
+    pane_contains_token,
+)
+
+__all__ = [
+    "DEFAULT_ARRIVAL_TIMEOUT_S",
+    "DEFAULT_IDLE_WAIT_S",
+    "DEFAULT_MAX_RESENDS",
+    "DEFAULT_POLL_S",
+    "DELIVERY_LOAD_BEARING",
+    "DELIVERY_SIGNALS",
+    "DELIVERY_SIGNAL_NAMES",
+    "DELIVERY_TOKEN_BYTES",
+    "EXIT_DELIVERED",
+    "EXIT_NO_ROUTE",
+    "EXIT_REFUTED",
+    "EXIT_UNKNOWN",
+    "EXIT_UNSUBMITTED",
+    "OBSERVATION_DIRECT",
+    "OBSERVATION_INFERRED",
+    "STRATEGY_SDK",
+    "STRATEGY_TUI",
+    "TUI_SESSION_PREFIX",
+    "DeliveryAssessment",
+    "DeliverySignalSpec",
+    "DeliveryState",
+    "Route",
+    "assess_delivery",
+    "deliver",
+    "delivery_spec_for",
+    "flatten_pane",
+    "format_payload",
+    "list_tmux_sessions",
+    "make_token",
+    "pane_contains_token",
+    "read_agent_session_id",
+    "resolve_route",
+    "validate_delivery_specs",
+]
+
+# EOF

--- a/src/scitex_agent_container/_delivery/_assess.py
+++ b/src/scitex_agent_container/_delivery/_assess.py
@@ -1,0 +1,199 @@
+"""THE ONE PURE FOLD for a delivery. Every send verdict folds here or it is a bug.
+
+Mirrors :func:`.._agentstate._assess.assess` exactly, because the failure it
+prevents is the same one: N call sites each re-deriving "did that send work?" from
+whatever subset of facts they happened to hold, and disagreeing.
+
+THE AGGREGATE
+-------------
+``True``   every load-bearing signal is at its healthy value. The message
+           arrived AND was submitted as a turn.
+``False``  at least one load-bearing signal REFUTES **and no load-bearing signal
+           is None** — a refutation with COMPLETE information.
+``None``   at least one load-bearing signal is None, **and the output NAMES WHICH
+           ONE.** An UNKNOWN that will not say what it could not read is the same
+           shrug that let an operator report hours of messages as delivered.
+
+Order is load-bearing: UNKNOWN outranks a False. A refutation drawn from partial
+information is a guess, and guesses here get acted on — the remedy a caller
+reaches for on a negative delivery verdict is TO SEND AGAIN, and re-sending into
+an agent that did receive the first copy is how a peer gets the same instruction
+twice and does the work twice.
+
+THERE IS NO DECISIVE SHORT-CIRCUIT HERE
+---------------------------------------
+:mod:`._spec` grants decisiveness to nothing, so the branch that exists in the
+sibling module is absent by construction rather than by omission — see that
+module for why no delivery reading is first-hand enough to earn it. The
+consequence is that this fold can never convict while blind, which is the correct
+trade for an operation whose negative verdict triggers a retry.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ._spec import DELIVERY_SIGNALS, DeliverySignalSpec
+from ._state import DeliveryState
+
+__all__ = [
+    "EXIT_DELIVERED",
+    "EXIT_NO_ROUTE",
+    "EXIT_REFUTED",
+    "EXIT_UNKNOWN",
+    "EXIT_UNSUBMITTED",
+    "DeliveryAssessment",
+    "assess_delivery",
+]
+
+#: Exit codes. The verdict is THREE-VALUED and stays three-valued; the two extra
+#: codes below are REFINEMENTS of ``EXIT_REFUTED``, never new verdicts, and each
+#: names an outcome whose remedy is different from a generic failure.
+#:
+#: A WARNING THAT IS PART OF THE CONTRACT: an exit code is the least specific
+#: thing this module produces, and small ints collide. ``click`` itself exits 2
+#: on a USAGE ERROR — the same 2 this module spells COULD-NOT-DETERMINE — so a
+#: caller that must tell those apart MUST read the JSON payload and MUST NOT
+#: branch on the integer alone. That collision has already turned a missing verb
+#: into an impersonated positive detection once. The code is for a cron that only
+#: needs a coarse split; the payload is for anything that needs to be right.
+EXIT_DELIVERED = 0
+EXIT_REFUTED = 1
+EXIT_UNKNOWN = 2
+
+#: No route to the target at all — the session does not exist on a tmux server
+#: that demonstrably CAN see other sessions. Distinct because the remedy is
+#: distinct: do not retry the send, go find out whether the agent is running.
+#: This is the mode that silently ate hours of coordination.
+EXIT_NO_ROUTE = 3
+
+#: The payload ARRIVED but was never submitted as a turn — it is sitting in the
+#: peer's composer right now. Distinct because the remedy is a single Enter into
+#: that pane, and because a caller must NOT resend (the text is already there;
+#: resending stacks a second copy into the same buffer).
+EXIT_UNSUBMITTED = 4
+
+
+@dataclass(frozen=True)
+class DeliveryAssessment:
+    """The folded delivery verdict, plus which signals produced it and why."""
+
+    agent: str
+
+    #: True / False / None. The same ternary as every signal — the aggregate of
+    #: tri-state values is itself tri-state, and collapsing it at the last inch
+    #: would undo the whole exercise.
+    verdict: bool | None
+
+    #: The signals that FORCED this verdict: the refuting ones for False, the
+    #: unresolved ones for None, all load-bearing ones for True.
+    deciding: tuple[str, ...] = ()
+
+    #: Every load-bearing signal that is None. Non-empty exactly when the verdict
+    #: is None.
+    unresolved: tuple[str, ...] = ()
+
+    reason: str = ""
+
+    def exit_code(self) -> int:
+        """0 delivered · 1 refuted · 2 could-not-determine · 3 no-route · 4 unsubmitted.
+
+        The refinements apply ONLY to a False verdict and only when the named
+        signal is the one that refuted, so the mapping stays a function of the
+        signals rather than of the caller's mood.
+        """
+        if self.verdict is True:
+            return EXIT_DELIVERED
+        if self.verdict is None:
+            return EXIT_UNKNOWN
+        if "is_route_resolved" in self.deciding:
+            return EXIT_NO_ROUTE
+        if "is_payload_submitted" in self.deciding:
+            return EXIT_UNSUBMITTED
+        return EXIT_REFUTED
+
+    @property
+    def is_unknown(self) -> bool:
+        return self.verdict is None
+
+    def to_dict(self) -> dict:
+        return {
+            "agent": self.agent,
+            "verdict": self.verdict,
+            "exit_code": self.exit_code(),
+            "deciding": list(self.deciding),
+            "unresolved": list(self.unresolved),
+            "reason": self.reason,
+        }
+
+
+def _refutes(state: DeliveryState, spec: DeliverySignalSpec) -> bool:
+    """Is this signal OBSERVED at its unhealthy pole? ``None`` never refutes."""
+    value = getattr(state, spec.name)
+    return value is not None and value is not spec.healthy
+
+
+def assess_delivery(state: DeliveryState) -> DeliveryAssessment:
+    """Fold one :class:`.DeliveryState` into True / False / None. Pure.
+
+    No IO, no clock, no environment: hand it a state and it returns the same
+    answer forever, which is what makes the aggregation testable at all. Every
+    branch below is reachable from a hand-built state, so the rule can be
+    MUTATION-PROVED rather than trusted.
+    """
+    load_bearing = [s for s in DELIVERY_SIGNALS if s.load_bearing]
+    unresolved = tuple(s.name for s in load_bearing if getattr(state, s.name) is None)
+
+    # (1) UNKNOWN outranks a refutation. Name what could not be read — an UNKNOWN
+    #     that will not say WHICH signal is unread is unactionable, and the
+    #     unactionable warnings are the ones that get ignored into an outage.
+    if unresolved:
+        detail = "; ".join(
+            f"{name}: {state.reason_for(name) or 'no reason recorded'}"
+            for name in unresolved
+        )
+        return DeliveryAssessment(
+            agent=state.agent,
+            verdict=None,
+            deciding=unresolved,
+            unresolved=unresolved,
+            reason=(
+                f"COULD NOT DETERMINE — {len(unresolved)} load-bearing signal(s) "
+                f"unread: {detail}. This is NOT a failed send and NOT a "
+                f"successful one; it is the absence of a reading. Do not resend "
+                f"on this verdict — the message may well have landed, and a "
+                f"blind retry stacks a second copy into the peer's composer"
+            ),
+        )
+
+    # (2) A refutation with COMPLETE information.
+    refuting = tuple(s.name for s in load_bearing if _refutes(state, s))
+    if refuting:
+        detail = "; ".join(
+            f"{name}: {state.reason_for(name) or 'observed at its unhealthy value'}"
+            for name in refuting
+        )
+        return DeliveryAssessment(
+            agent=state.agent,
+            verdict=False,
+            deciding=refuting,
+            reason=(
+                f"REFUTED with complete information — every load-bearing signal "
+                f"was read, and {len(refuting)} of them refute: {detail}"
+            ),
+        )
+
+    # (3) Everything load-bearing was read, and all of it is healthy.
+    names = tuple(s.name for s in load_bearing)
+    return DeliveryAssessment(
+        agent=state.agent,
+        verdict=True,
+        deciding=names,
+        reason=(
+            f"DELIVERED and SUBMITTED — every load-bearing signal was OBSERVED "
+            f"and is healthy ({', '.join(names)})"
+        ),
+    )
+
+
+# EOF

--- a/src/scitex_agent_container/_delivery/_deliver.py
+++ b/src/scitex_agent_container/_delivery/_deliver.py
@@ -1,0 +1,499 @@
+"""The verified send — ONE verb, two strategies, a tri-state answer either way.
+
+This module is WIRING, deliberately. Every hard part already existed somewhere in
+this repo and was simply never composed into a single answerable question:
+
+* :mod:`.._lifecycle.liveness_probe` — the nonce generator and the busy-marker
+  classifier (the fleet's SSOT for "is this pane mid-turn?");
+* :mod:`..runtimes._tui_compose` — ``verify_submit_by_advancement``, the
+  idle-gated Enter with bounded retry that is the ALREADY-DIAGNOSED fix for the
+  unsubmitted-composer mode;
+* :mod:`.._runners._tmux.tmux` — ``send_text_literal``, whose ``-l`` flag is
+  REQUIRED because the containerized Ink/React TUI silently drops non-literal
+  ``send-keys``;
+* :mod:`..cli_pkg._auth_status` — ``_capture``, which returns ``None`` on any
+  error so "uncapturable" stays distinct from "clean pane";
+* :mod:`.._runners._tmux.auth_status` — the near-prompt auth-banner matcher.
+
+WHY THE TRAILING ENTER DID NOT TAKE
+-----------------------------------
+The operator observed a message land in a peer's composer while the agent stayed
+idle, and a bare Enter into that pane started it working immediately. The repo had
+already root-caused this once, on the boot path, under card
+``sac-tui-enter-drop-on-boot``, and the answer is BOTH of the suspected causes at
+once:
+
+1. the Ink TUI drops NON-LITERAL ``send-keys``, so the text must be pasted with
+   ``-l`` and the submit must be a SEPARATE named ``Enter`` (never ``-l``, which
+   would type the five characters "Enter"); and
+2. the Ink TUI eats an ``Enter`` fired while the pane is BUSY (spinner up, MCP
+   reconnecting, a hook running) — and a ``UserPromptSubmit`` hook alone can hold
+   that window for 30 seconds.
+
+A blind ``send-keys text Enter`` loses the submit to (2) whenever the peer happens
+to be working, which is most of the time on a busy fleet. The fix is not a longer
+sleep: it is to WAIT FOR IDLE, send exactly one Enter, VERIFY the compose buffer
+advanced, and retry bounded — which is what ``verify_submit_by_advancement``
+already does. This module reuses it rather than reimplementing it, so the boot
+path and the a2a path can never drift apart on the one behaviour that was hardest
+to get right.
+
+BUDGETS ARE GENEROUS AND CONFIGURABLE
+-------------------------------------
+Every default below is deliberately larger than feels necessary, because the
+recorded failure was a 25-second wait misread as death. Waiting too long costs
+seconds; concluding death too early costs a restart that destroys a working
+agent's context.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import replace
+from typing import Callable, Optional
+
+from ._route import STRATEGY_SDK, STRATEGY_TUI, Route, resolve_route
+from ._state import DeliveryState
+from ._token import format_payload, make_token, pane_contains_token
+
+__all__ = [
+    "DEFAULT_ARRIVAL_TIMEOUT_S",
+    "DEFAULT_IDLE_WAIT_S",
+    "DEFAULT_MAX_RESENDS",
+    "DEFAULT_POLL_S",
+    "OBSERVER",
+    "deliver",
+]
+
+#: How long to watch for the token to RENDER after the paste. The paste is
+#: instant; the render is not, and a multi-line payload takes a beat.
+DEFAULT_ARRIVAL_TIMEOUT_S = 30.0
+
+#: How long to wait for the pane to go idle before each submit attempt. Sized
+#: for a peer that is genuinely working: a UserPromptSubmit hook alone can take
+#: 30s, so anything under a minute manufactures false "wedged" readings.
+DEFAULT_IDLE_WAIT_S = 60.0
+
+#: Bounded submit retries. Each one re-checks idle from scratch, so this is a
+#: budget of ATTEMPTS, not a burst of blind Enters (the burst was the old bug).
+DEFAULT_MAX_RESENDS = 8
+
+#: Poll cadence for every wait loop here.
+DEFAULT_POLL_S = 0.6
+
+OBSERVER = "sac agents deliver"
+
+
+class _CaptureTap:
+    """A real capture callable that counts unreadable captures. Not a mock.
+
+    ``verify_submit_by_advancement`` is typed ``capture_fn(name) -> str`` and has
+    no way to express "the pane could not be read", so this adapter turns a
+    ``None`` into ``""`` for it while REMEMBERING that it happened. Without the
+    memory, a submit failure caused by blindness would be indistinguishable from
+    one caused by a dropped Enter, and only the second of those is a refutation.
+    The tap is what lets the caller downgrade a ``False`` to ``None`` when any
+    part of the observation window was blind.
+    """
+
+    def __init__(self, capture_fn: Callable[[str], Optional[str]]) -> None:
+        self._capture_fn = capture_fn
+        self.unreadable = 0
+        self.readable = 0
+        self.last_readable = ""
+
+    def read(self, target: str) -> Optional[str]:
+        """Capture, recording readability, and preserve the tri-state."""
+        pane = self._capture_fn(target)
+        if pane is None:
+            self.unreadable += 1
+        else:
+            self.readable += 1
+            self.last_readable = pane
+        return pane
+
+    def __call__(self, target: str) -> str:
+        """The ``capture_fn(name) -> str`` shape the submit verifier requires."""
+        return self.read(target) or ""
+
+
+def _default_capture(session: str) -> Optional[str]:
+    """The fleet's correct pane read: default server, ``-J``, ``None`` on error."""
+    from ..cli_pkg._auth_status import _capture
+
+    return _capture(session)
+
+
+def _default_paste(session: str, text: str) -> None:
+    """Literal paste, no submit. ``-l`` is not optional — see the module docstring."""
+    from .._runners._tmux.tmux import TmuxManager
+
+    TmuxManager.send_text_literal(session, text)
+
+
+def _default_send_keys(session: str, key: str) -> None:
+    from .._runners._tmux.tmux import TmuxManager
+
+    TmuxManager.send_keys(session, key)
+
+
+def _default_sdk_send(agent: str, payload: str) -> tuple[Optional[bool], str]:
+    """Deliver through the existing ``sac agents send`` library path.
+
+    ``wait=True`` on purpose. The non-blocking default returns
+    ``status="dispatched"``, which means "the agent looks reachable and here is a
+    command YOU can run to actually send it" — validation, not delivery. Reading
+    that as a delivered message would reintroduce the exact bug this package
+    exists to remove, one layer up.
+    """
+    # stx-allow: fallback (reason: a transport failure must render UNKNOWN, not a
+    # refutation — we cannot tell a refused send from an unobserved one)
+    try:
+        from ..cli_pkg._send import send_to_agent
+
+        result = send_to_agent(agent, payload, wait=True)
+    except Exception as exc:  # stx-allow: fallback (reason: see comment above)
+        return None, (
+            f"send_to_agent raised {type(exc).__name__}: {exc}. A transport "
+            f"failure says nothing about whether the turn reached the agent"
+        )
+    status = str(result.get("status") or "")
+    if status == "ok":
+        return True, "send_to_agent completed the turn (status='ok')"
+    if status in ("error", "creds-expired"):
+        return False, (
+            f"send_to_agent refused the turn (status={status!r}): "
+            f"{result.get('error') or 'no detail'}"
+        )
+    if status == "timeout":
+        return None, (
+            "send_to_agent timed out waiting for the reply. The turn may well be "
+            "RUNNING — a timeout is a statement about our patience, not about "
+            "delivery, and must not be recorded as a failed send"
+        )
+    return None, (
+        f"send_to_agent returned an unrecognised status {status!r}; refusing to "
+        f"guess which pole it means"
+    )
+
+
+def _observe_pane_before(state: DeliveryState, pane: Optional[str]) -> DeliveryState:
+    """Record what the pane looked like BEFORE the send: readable / busy / banner."""
+    from .._lifecycle.liveness_probe import pane_is_busy
+
+    if pane is None:
+        state = state.with_signal(
+            "is_pane_readable",
+            False,
+            "the pre-send capture failed — the session may have vanished between "
+            "the enumeration and the capture",
+        )
+        return state.with_signal(
+            "is_target_busy_before",
+            None,
+            "not read: the pane could not be captured",
+        ).with_signal(
+            "is_login_banner_before",
+            None,
+            "not read: the pane could not be captured",
+        )
+
+    from .._runners._tmux.auth_status import evaluate
+
+    state = state.with_signal(
+        "is_pane_readable", True, "the pre-send pane was captured", pane_before=pane
+    )
+    busy = pane_is_busy(pane)
+    state = state.with_signal(
+        "is_target_busy_before",
+        busy,
+        (
+            "an in-progress marker was on the pane tail — the peer is WORKING, "
+            "which is healthy; the submit step will wait for it to go idle"
+            if busy
+            else "no in-progress marker on the pane tail"
+        ),
+    )
+    probe, _ = evaluate(pane, None)
+    return state.with_signal(
+        "is_login_banner_before",
+        bool(probe.present),
+        (
+            "an auth banner sits near the prompt on this SINGLE capture. "
+            "UNCORROBORATED — run `sac agents auth-status` for the two-capture "
+            "frozen check before acting. If it is real, a submitted turn will "
+            "produce nothing and resending will not help"
+            if probe.present
+            else "no auth banner near the prompt"
+        ),
+    )
+
+
+def _watch_for_arrival(
+    session: str,
+    token: str,
+    *,
+    tap: _CaptureTap,
+    timeout_s: float,
+    poll_s: float,
+    time_fn: Callable[[], float],
+    sleep_fn: Callable[[float], None],
+) -> tuple[Optional[bool], str, str]:
+    """Poll until the token renders. Returns ``(signal, reason, last_pane)``.
+
+    Tri-state: ``True`` on a match, ``False`` when readable captures were taken
+    throughout and none contained it, and ``None`` when NO readable capture was
+    ever taken — because a window in which we never once saw the screen cannot
+    support a claim about what was on it.
+    """
+    deadline = time_fn() + timeout_s
+    last = ""
+    while True:
+        pane = tap.read(session)
+        if pane is not None:
+            last = pane
+        if pane_contains_token(pane, token) is True:
+            return (
+                True,
+                f"token {token} was found on the pane after the paste",
+                last,
+            )
+        if time_fn() >= deadline:
+            break
+        if poll_s > 0:
+            sleep_fn(poll_s)
+    if tap.readable == 0:
+        return (
+            None,
+            f"the pane could not be read even once in {timeout_s:.0f}s, so "
+            f"nothing is known about whether the payload arrived",
+            last,
+        )
+    return (
+        False,
+        f"token {token} did not appear on {tap.readable} readable capture(s) "
+        f"over {timeout_s:.0f}s. NOTE the matcher flattens the pane before "
+        f"searching, so this is not a wrapping artefact",
+        last,
+    )
+
+
+def deliver(
+    agent: str,
+    message: str,
+    *,
+    strategy: str = "auto",
+    arrival_timeout_s: float = DEFAULT_ARRIVAL_TIMEOUT_S,
+    idle_wait_s: float = DEFAULT_IDLE_WAIT_S,
+    max_resends: int = DEFAULT_MAX_RESENDS,
+    poll_s: float = DEFAULT_POLL_S,
+    capture_fn: Callable[[str], Optional[str]] = _default_capture,
+    paste_fn: Callable[[str, str], None] = _default_paste,
+    send_keys_fn: Callable[[str, str], None] = _default_send_keys,
+    sdk_send_fn: Callable[[str, str], tuple[Optional[bool], str]] = _default_sdk_send,
+    list_sessions_fn: Optional[Callable[[], Optional[list[str]]]] = None,
+    session_id_fn: Optional[Callable[[str], Optional[str]]] = None,
+    time_fn: Callable[[], float] = time.monotonic,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    clock_fn: Callable[[], float] = time.time,
+) -> DeliveryState:
+    """Send ``message`` to ``agent`` and RETURN WHAT IS KNOWN ABOUT THE OUTCOME.
+
+    Every collaborator is an injected seam with a REAL production default, so a
+    test drives this function itself — not a rehearsal of it — by passing plain
+    objects with the same signatures.
+
+    The sequence, and what each step buys:
+
+    1. **Resolve and prove the target exists** (:func:`.._route.resolve_route`).
+       A missing session is a distinct, loud outcome, not a silent success.
+    2. **Observe the pane BEFORE sending** — readable, busy, auth banner. This is
+       evidence, never a veto: a busy peer is a healthy peer and delivery to it
+       works fine.
+    3. **Paste literally**, with a short token injected at the front.
+    4. **Confirm arrival by token**, against a FLATTENED pane so a re-render
+       cannot fake a negative.
+    5. **Confirm SUBMISSION** and retry the Enter — the step that was missing,
+       via the already-proven ``verify_submit_by_advancement``.
+    """
+    started = time_fn()
+    token = make_token()
+    payload = format_payload(message, token)
+    state = DeliveryState(
+        agent=agent,
+        token=token,
+        observed_at=clock_fn(),
+        observer=OBSERVER,
+    )
+
+    route_kwargs: dict = {"strategy": strategy}
+    if list_sessions_fn is not None:
+        route_kwargs["list_sessions_fn"] = list_sessions_fn
+    if session_id_fn is not None:
+        route_kwargs["session_id_fn"] = session_id_fn
+    route = resolve_route(agent, **route_kwargs)
+
+    state = state.with_signal(
+        "is_route_resolved",
+        route.resolved,
+        route.reason,
+        tmux_sessions=route.sessions_raw,
+    )
+    state = replace(state, strategy=route.strategy)
+
+    if route.resolved is not True:
+        return _finish(_no_attempt(state, route), started, time_fn)
+    if route.strategy == STRATEGY_SDK:
+        return _finish(
+            _deliver_via_sdk(state, agent, payload, sdk_send_fn), started, time_fn
+        )
+    return _finish(
+        _deliver_via_tui(
+            state,
+            route,
+            payload,
+            token,
+            capture_fn=capture_fn,
+            paste_fn=paste_fn,
+            send_keys_fn=send_keys_fn,
+            arrival_timeout_s=arrival_timeout_s,
+            idle_wait_s=idle_wait_s,
+            max_resends=max_resends,
+            poll_s=poll_s,
+            time_fn=time_fn,
+            sleep_fn=sleep_fn,
+        ),
+        started,
+        time_fn,
+    )
+
+
+def _no_attempt(state: DeliveryState, route: Route) -> DeliveryState:
+    """Nothing was sent. Say so as a KNOWN negative, not as an unread signal.
+
+    Subtle but load-bearing: when the route did not resolve, ``False`` is the
+    honest value for both payload signals, because we know with certainty that
+    nothing was transmitted — this is complete information, not a guess. The
+    verdict then lands on ``False`` and the exit code refines to
+    ``EXIT_NO_ROUTE``. When the route is UNKNOWN (a blind enumeration) the route
+    signal itself is ``None``, so the fold returns UNKNOWN regardless of what
+    these two say — blindness cannot be argued into a conviction.
+    """
+    why = (
+        "nothing was transmitted — the route did not resolve. This is a KNOWN "
+        "negative (we can be certain no bytes were sent), not an unread signal"
+    )
+    return state.with_signal("is_payload_delivered", False, why).with_signal(
+        "is_payload_submitted", False, why
+    )
+
+
+def _deliver_via_sdk(
+    state: DeliveryState,
+    agent: str,
+    payload: str,
+    sdk_send_fn: Callable[[str, str], tuple[Optional[bool], str]],
+) -> DeliveryState:
+    """The existing send path. One call answers both payload signals.
+
+    A completed turn is proof of BOTH arrival and submission — the SDK path has
+    no composer to leave text sitting in, so the mode that motivates this whole
+    package cannot occur here. ``is_pane_readable`` stays ``None``: there is no
+    pane, and "nothing to read" is not "failed to read".
+    """
+    ok, detail = sdk_send_fn(agent, payload)
+    return state.with_signal(
+        "is_payload_delivered", ok, detail, send_detail=detail
+    ).with_signal(
+        "is_payload_submitted",
+        ok,
+        f"{detail} (on the SDK path a completed turn proves submission — there "
+        f"is no composer for text to sit unsent in)",
+    )
+
+
+def _deliver_via_tui(
+    state: DeliveryState,
+    route: Route,
+    payload: str,
+    token: str,
+    *,
+    capture_fn: Callable[[str], Optional[str]],
+    paste_fn: Callable[[str, str], None],
+    send_keys_fn: Callable[[str, str], None],
+    arrival_timeout_s: float,
+    idle_wait_s: float,
+    max_resends: int,
+    poll_s: float,
+    time_fn: Callable[[], float],
+    sleep_fn: Callable[[float], None],
+) -> DeliveryState:
+    """Paste literally, confirm arrival by token, then confirm SUBMISSION."""
+    from ..runtimes._tui_compose import verify_submit_by_advancement
+
+    session = route.session
+    state = _observe_pane_before(state, capture_fn(session))
+
+    paste_fn(session, payload)
+
+    tap = _CaptureTap(capture_fn)
+    arrived, why, pane_after = _watch_for_arrival(
+        session,
+        token,
+        tap=tap,
+        timeout_s=arrival_timeout_s,
+        poll_s=poll_s,
+        time_fn=time_fn,
+        sleep_fn=sleep_fn,
+    )
+    state = state.with_signal(
+        "is_payload_delivered", arrived, why, pane_after_paste=pane_after
+    )
+
+    blind_before = tap.unreadable
+    submitted = verify_submit_by_advancement(
+        session,
+        capture_fn=tap,
+        send_keys_fn=lambda key: send_keys_fn(session, key),
+        max_resends=max_resends,
+        poll_s=poll_s,
+        idle_wait_s=idle_wait_s,
+        sleep_fn=sleep_fn,
+        time_fn=time_fn,
+    )
+    blind_during = tap.unreadable - blind_before
+
+    if submitted:
+        value: Optional[bool] = True
+        reason = (
+            "the live compose box was observed to CLEAR after an idle-gated "
+            "Enter — the turn was submitted"
+        )
+    elif blind_during:
+        value = None
+        reason = (
+            f"the submit could not be confirmed, but {blind_during} capture(s) "
+            f"during the attempt were unreadable. A submit failure observed "
+            f"through a partly blind window is not a refutation"
+        )
+    else:
+        value = False
+        reason = (
+            f"the payload is STILL SITTING UNSENT in the compose box after "
+            f"{max_resends} idle-gated Enter attempts. Do NOT resend — the text "
+            f"is already there and a second copy would stack on it. Attach and "
+            f"press Enter: `tmux attach -t {session}`"
+        )
+    return state.with_signal(
+        "is_payload_submitted", value, reason, pane_after_submit=tap.last_readable
+    )
+
+
+def _finish(
+    state: DeliveryState, started: float, time_fn: Callable[[], float]
+) -> DeliveryState:
+    """Stamp the elapsed time so a budget can be tuned against measurements."""
+    return replace(state, elapsed=time_fn() - started)
+
+
+# EOF

--- a/src/scitex_agent_container/_delivery/_deliver.py
+++ b/src/scitex_agent_container/_delivery/_deliver.py
@@ -1,7 +1,7 @@
-"""The verified send — ONE verb, two strategies, a tri-state answer either way.
+"""ONE verb, TWO strategies — the orchestrator, and nothing else.
 
-This module is WIRING, deliberately. Every hard part already existed somewhere in
-this repo and was simply never composed into a single answerable question:
+This module is WIRING, deliberately. Every hard part already existed in this repo
+and was simply never composed into a single answerable question:
 
 * :mod:`.._lifecycle.liveness_probe` — the nonce generator and the busy-marker
   classifier (the fleet's SSOT for "is this pane mid-turn?");
@@ -13,30 +13,11 @@ this repo and was simply never composed into a single answerable question:
   ``send-keys``;
 * :mod:`..cli_pkg._auth_status` — ``_capture``, which returns ``None`` on any
   error so "uncapturable" stays distinct from "clean pane";
-* :mod:`.._runners._tmux.auth_status` — the near-prompt auth-banner matcher.
+* :mod:`..cli_pkg._send` — the existing send path, preferred whenever it applies.
 
-WHY THE TRAILING ENTER DID NOT TAKE
------------------------------------
-The operator observed a message land in a peer's composer while the agent stayed
-idle, and a bare Enter into that pane started it working immediately. The repo had
-already root-caused this once, on the boot path, under card
-``sac-tui-enter-drop-on-boot``, and the answer is BOTH of the suspected causes at
-once:
-
-1. the Ink TUI drops NON-LITERAL ``send-keys``, so the text must be pasted with
-   ``-l`` and the submit must be a SEPARATE named ``Enter`` (never ``-l``, which
-   would type the five characters "Enter"); and
-2. the Ink TUI eats an ``Enter`` fired while the pane is BUSY (spinner up, MCP
-   reconnecting, a hook running) — and a ``UserPromptSubmit`` hook alone can hold
-   that window for 30 seconds.
-
-A blind ``send-keys text Enter`` loses the submit to (2) whenever the peer happens
-to be working, which is most of the time on a busy fleet. The fix is not a longer
-sleep: it is to WAIT FOR IDLE, send exactly one Enter, VERIFY the compose buffer
-advanced, and retry bounded — which is what ``verify_submit_by_advancement``
-already does. This module reuses it rather than reimplementing it, so the boot
-path and the a2a path can never drift apart on the one behaviour that was hardest
-to get right.
+The per-strategy work lives in :mod:`._sdk_strategy` and :mod:`._tui_strategy`.
+What stays here is the sequence and the one decision that binds them: resolve the
+route FIRST, and let the route pick the strategy.
 
 BUDGETS ARE GENEROUS AND CONFIGURABLE
 -------------------------------------
@@ -52,9 +33,16 @@ import time
 from dataclasses import replace
 from typing import Callable, Optional
 
-from ._route import STRATEGY_SDK, STRATEGY_TUI, Route, resolve_route
+from ._route import STRATEGY_SDK, Route, resolve_route
+from ._sdk_strategy import default_sdk_send, deliver_via_sdk
 from ._state import DeliveryState
-from ._token import format_payload, make_token, pane_contains_token
+from ._token import format_payload, make_token
+from ._tui_strategy import (
+    default_capture,
+    default_paste,
+    default_send_keys,
+    deliver_via_tui,
+)
 
 __all__ = [
     "DEFAULT_ARRIVAL_TIMEOUT_S",
@@ -69,9 +57,9 @@ __all__ = [
 #: instant; the render is not, and a multi-line payload takes a beat.
 DEFAULT_ARRIVAL_TIMEOUT_S = 30.0
 
-#: How long to wait for the pane to go idle before each submit attempt. Sized
-#: for a peer that is genuinely working: a UserPromptSubmit hook alone can take
-#: 30s, so anything under a minute manufactures false "wedged" readings.
+#: How long to wait for the pane to go idle before each submit attempt. Sized for
+#: a peer that is genuinely working: a UserPromptSubmit hook alone can take 30s,
+#: so anything under a minute manufactures false "wedged" readings.
 DEFAULT_IDLE_WAIT_S = 60.0
 
 #: Bounded submit retries. Each one re-checks idle from scratch, so this is a
@@ -84,200 +72,6 @@ DEFAULT_POLL_S = 0.6
 OBSERVER = "sac agents deliver"
 
 
-class _CaptureTap:
-    """A real capture callable that counts unreadable captures. Not a mock.
-
-    ``verify_submit_by_advancement`` is typed ``capture_fn(name) -> str`` and has
-    no way to express "the pane could not be read", so this adapter turns a
-    ``None`` into ``""`` for it while REMEMBERING that it happened. Without the
-    memory, a submit failure caused by blindness would be indistinguishable from
-    one caused by a dropped Enter, and only the second of those is a refutation.
-    The tap is what lets the caller downgrade a ``False`` to ``None`` when any
-    part of the observation window was blind.
-    """
-
-    def __init__(self, capture_fn: Callable[[str], Optional[str]]) -> None:
-        self._capture_fn = capture_fn
-        self.unreadable = 0
-        self.readable = 0
-        self.last_readable = ""
-
-    def read(self, target: str) -> Optional[str]:
-        """Capture, recording readability, and preserve the tri-state."""
-        pane = self._capture_fn(target)
-        if pane is None:
-            self.unreadable += 1
-        else:
-            self.readable += 1
-            self.last_readable = pane
-        return pane
-
-    def __call__(self, target: str) -> str:
-        """The ``capture_fn(name) -> str`` shape the submit verifier requires."""
-        return self.read(target) or ""
-
-
-def _default_capture(session: str) -> Optional[str]:
-    """The fleet's correct pane read: default server, ``-J``, ``None`` on error."""
-    from ..cli_pkg._auth_status import _capture
-
-    return _capture(session)
-
-
-def _default_paste(session: str, text: str) -> None:
-    """Literal paste, no submit. ``-l`` is not optional — see the module docstring."""
-    from .._runners._tmux.tmux import TmuxManager
-
-    TmuxManager.send_text_literal(session, text)
-
-
-def _default_send_keys(session: str, key: str) -> None:
-    from .._runners._tmux.tmux import TmuxManager
-
-    TmuxManager.send_keys(session, key)
-
-
-def _default_sdk_send(agent: str, payload: str) -> tuple[Optional[bool], str]:
-    """Deliver through the existing ``sac agents send`` library path.
-
-    ``wait=True`` on purpose. The non-blocking default returns
-    ``status="dispatched"``, which means "the agent looks reachable and here is a
-    command YOU can run to actually send it" — validation, not delivery. Reading
-    that as a delivered message would reintroduce the exact bug this package
-    exists to remove, one layer up.
-    """
-    # stx-allow: fallback (reason: a transport failure must render UNKNOWN, not a
-    # refutation — we cannot tell a refused send from an unobserved one)
-    try:
-        from ..cli_pkg._send import send_to_agent
-
-        result = send_to_agent(agent, payload, wait=True)
-    except Exception as exc:  # stx-allow: fallback (reason: see comment above)
-        return None, (
-            f"send_to_agent raised {type(exc).__name__}: {exc}. A transport "
-            f"failure says nothing about whether the turn reached the agent"
-        )
-    status = str(result.get("status") or "")
-    if status == "ok":
-        return True, "send_to_agent completed the turn (status='ok')"
-    if status in ("error", "creds-expired"):
-        return False, (
-            f"send_to_agent refused the turn (status={status!r}): "
-            f"{result.get('error') or 'no detail'}"
-        )
-    if status == "timeout":
-        return None, (
-            "send_to_agent timed out waiting for the reply. The turn may well be "
-            "RUNNING — a timeout is a statement about our patience, not about "
-            "delivery, and must not be recorded as a failed send"
-        )
-    return None, (
-        f"send_to_agent returned an unrecognised status {status!r}; refusing to "
-        f"guess which pole it means"
-    )
-
-
-def _observe_pane_before(state: DeliveryState, pane: Optional[str]) -> DeliveryState:
-    """Record what the pane looked like BEFORE the send: readable / busy / banner."""
-    from .._lifecycle.liveness_probe import pane_is_busy
-
-    if pane is None:
-        state = state.with_signal(
-            "is_pane_readable",
-            False,
-            "the pre-send capture failed — the session may have vanished between "
-            "the enumeration and the capture",
-        )
-        return state.with_signal(
-            "is_target_busy_before",
-            None,
-            "not read: the pane could not be captured",
-        ).with_signal(
-            "is_login_banner_before",
-            None,
-            "not read: the pane could not be captured",
-        )
-
-    from .._runners._tmux.auth_status import evaluate
-
-    state = state.with_signal(
-        "is_pane_readable", True, "the pre-send pane was captured", pane_before=pane
-    )
-    busy = pane_is_busy(pane)
-    state = state.with_signal(
-        "is_target_busy_before",
-        busy,
-        (
-            "an in-progress marker was on the pane tail — the peer is WORKING, "
-            "which is healthy; the submit step will wait for it to go idle"
-            if busy
-            else "no in-progress marker on the pane tail"
-        ),
-    )
-    probe, _ = evaluate(pane, None)
-    return state.with_signal(
-        "is_login_banner_before",
-        bool(probe.present),
-        (
-            "an auth banner sits near the prompt on this SINGLE capture. "
-            "UNCORROBORATED — run `sac agents auth-status` for the two-capture "
-            "frozen check before acting. If it is real, a submitted turn will "
-            "produce nothing and resending will not help"
-            if probe.present
-            else "no auth banner near the prompt"
-        ),
-    )
-
-
-def _watch_for_arrival(
-    session: str,
-    token: str,
-    *,
-    tap: _CaptureTap,
-    timeout_s: float,
-    poll_s: float,
-    time_fn: Callable[[], float],
-    sleep_fn: Callable[[float], None],
-) -> tuple[Optional[bool], str, str]:
-    """Poll until the token renders. Returns ``(signal, reason, last_pane)``.
-
-    Tri-state: ``True`` on a match, ``False`` when readable captures were taken
-    throughout and none contained it, and ``None`` when NO readable capture was
-    ever taken — because a window in which we never once saw the screen cannot
-    support a claim about what was on it.
-    """
-    deadline = time_fn() + timeout_s
-    last = ""
-    while True:
-        pane = tap.read(session)
-        if pane is not None:
-            last = pane
-        if pane_contains_token(pane, token) is True:
-            return (
-                True,
-                f"token {token} was found on the pane after the paste",
-                last,
-            )
-        if time_fn() >= deadline:
-            break
-        if poll_s > 0:
-            sleep_fn(poll_s)
-    if tap.readable == 0:
-        return (
-            None,
-            f"the pane could not be read even once in {timeout_s:.0f}s, so "
-            f"nothing is known about whether the payload arrived",
-            last,
-        )
-    return (
-        False,
-        f"token {token} did not appear on {tap.readable} readable capture(s) "
-        f"over {timeout_s:.0f}s. NOTE the matcher flattens the pane before "
-        f"searching, so this is not a wrapping artefact",
-        last,
-    )
-
-
 def deliver(
     agent: str,
     message: str,
@@ -287,10 +81,10 @@ def deliver(
     idle_wait_s: float = DEFAULT_IDLE_WAIT_S,
     max_resends: int = DEFAULT_MAX_RESENDS,
     poll_s: float = DEFAULT_POLL_S,
-    capture_fn: Callable[[str], Optional[str]] = _default_capture,
-    paste_fn: Callable[[str, str], None] = _default_paste,
-    send_keys_fn: Callable[[str, str], None] = _default_send_keys,
-    sdk_send_fn: Callable[[str, str], tuple[Optional[bool], str]] = _default_sdk_send,
+    capture_fn: Callable[[str], Optional[str]] = default_capture,
+    paste_fn: Callable[[str, str], None] = default_paste,
+    send_keys_fn: Callable[[str, str], None] = default_send_keys,
+    sdk_send_fn: Callable[[str, str], tuple[Optional[bool], str]] = default_sdk_send,
     list_sessions_fn: Optional[Callable[[], Optional[list[str]]]] = None,
     session_id_fn: Optional[Callable[[str], Optional[str]]] = None,
     time_fn: Callable[[], float] = time.monotonic,
@@ -301,20 +95,20 @@ def deliver(
 
     Every collaborator is an injected seam with a REAL production default, so a
     test drives this function itself — not a rehearsal of it — by passing plain
-    objects with the same signatures.
+    objects carrying the same signatures.
 
     The sequence, and what each step buys:
 
-    1. **Resolve and prove the target exists** (:func:`.._route.resolve_route`).
-       A missing session is a distinct, loud outcome, not a silent success.
-    2. **Observe the pane BEFORE sending** — readable, busy, auth banner. This is
-       evidence, never a veto: a busy peer is a healthy peer and delivery to it
-       works fine.
+    1. **Resolve and prove the target exists** (:func:`._route.resolve_route`).
+       A missing session becomes a distinct, loud outcome instead of a silent
+       success, and a BLIND enumeration becomes UNKNOWN instead of a death
+       sentence.
+    2. **Observe the pane BEFORE sending** — readable, busy, auth banner. All
+       evidence, never a veto: a busy peer is a healthy peer.
     3. **Paste literally**, with a short token injected at the front.
     4. **Confirm arrival by token**, against a FLATTENED pane so a re-render
        cannot fake a negative.
-    5. **Confirm SUBMISSION** and retry the Enter — the step that was missing,
-       via the already-proven ``verify_submit_by_advancement``.
+    5. **Confirm SUBMISSION** and retry the Enter — the step that was missing.
     """
     started = time_fn()
     token = make_token()
@@ -333,22 +127,24 @@ def deliver(
         route_kwargs["session_id_fn"] = session_id_fn
     route = resolve_route(agent, **route_kwargs)
 
-    state = state.with_signal(
-        "is_route_resolved",
-        route.resolved,
-        route.reason,
-        tmux_sessions=route.sessions_raw,
+    state = replace(
+        state.with_signal(
+            "is_route_resolved",
+            route.resolved,
+            route.reason,
+            tmux_sessions=route.sessions_raw,
+        ),
+        strategy=route.strategy,
     )
-    state = replace(state, strategy=route.strategy)
 
     if route.resolved is not True:
         return _finish(_no_attempt(state, route), started, time_fn)
     if route.strategy == STRATEGY_SDK:
         return _finish(
-            _deliver_via_sdk(state, agent, payload, sdk_send_fn), started, time_fn
+            deliver_via_sdk(state, agent, payload, sdk_send_fn), started, time_fn
         )
     return _finish(
-        _deliver_via_tui(
+        deliver_via_tui(
             state,
             route,
             payload,
@@ -371,14 +167,17 @@ def deliver(
 def _no_attempt(state: DeliveryState, route: Route) -> DeliveryState:
     """Nothing was sent. Say so as a KNOWN negative, not as an unread signal.
 
-    Subtle but load-bearing: when the route did not resolve, ``False`` is the
-    honest value for both payload signals, because we know with certainty that
-    nothing was transmitted — this is complete information, not a guess. The
-    verdict then lands on ``False`` and the exit code refines to
-    ``EXIT_NO_ROUTE``. When the route is UNKNOWN (a blind enumeration) the route
-    signal itself is ``None``, so the fold returns UNKNOWN regardless of what
-    these two say — blindness cannot be argued into a conviction.
+    Subtle but load-bearing. When the route did not resolve, ``False`` is the
+    HONEST value for both payload signals, because we know with certainty that
+    nothing was transmitted — this is complete information, not a guess. The fold
+    then lands on ``False`` and the exit code refines to ``EXIT_NO_ROUTE``.
+
+    When the route is UNKNOWN (a blind enumeration) the route signal itself is
+    ``None``, so the fold returns UNKNOWN regardless of what these two say.
+    Blindness cannot be argued into a conviction, and it is the route signal —
+    not these — that carries that distinction.
     """
+    del route
     why = (
         "nothing was transmitted — the route did not resolve. This is a KNOWN "
         "negative (we can be certain no bytes were sent), not an unread signal"
@@ -388,111 +187,15 @@ def _no_attempt(state: DeliveryState, route: Route) -> DeliveryState:
     )
 
 
-def _deliver_via_sdk(
-    state: DeliveryState,
-    agent: str,
-    payload: str,
-    sdk_send_fn: Callable[[str, str], tuple[Optional[bool], str]],
-) -> DeliveryState:
-    """The existing send path. One call answers both payload signals.
-
-    A completed turn is proof of BOTH arrival and submission — the SDK path has
-    no composer to leave text sitting in, so the mode that motivates this whole
-    package cannot occur here. ``is_pane_readable`` stays ``None``: there is no
-    pane, and "nothing to read" is not "failed to read".
-    """
-    ok, detail = sdk_send_fn(agent, payload)
-    return state.with_signal(
-        "is_payload_delivered", ok, detail, send_detail=detail
-    ).with_signal(
-        "is_payload_submitted",
-        ok,
-        f"{detail} (on the SDK path a completed turn proves submission — there "
-        f"is no composer for text to sit unsent in)",
-    )
-
-
-def _deliver_via_tui(
-    state: DeliveryState,
-    route: Route,
-    payload: str,
-    token: str,
-    *,
-    capture_fn: Callable[[str], Optional[str]],
-    paste_fn: Callable[[str, str], None],
-    send_keys_fn: Callable[[str, str], None],
-    arrival_timeout_s: float,
-    idle_wait_s: float,
-    max_resends: int,
-    poll_s: float,
-    time_fn: Callable[[], float],
-    sleep_fn: Callable[[float], None],
-) -> DeliveryState:
-    """Paste literally, confirm arrival by token, then confirm SUBMISSION."""
-    from ..runtimes._tui_compose import verify_submit_by_advancement
-
-    session = route.session
-    state = _observe_pane_before(state, capture_fn(session))
-
-    paste_fn(session, payload)
-
-    tap = _CaptureTap(capture_fn)
-    arrived, why, pane_after = _watch_for_arrival(
-        session,
-        token,
-        tap=tap,
-        timeout_s=arrival_timeout_s,
-        poll_s=poll_s,
-        time_fn=time_fn,
-        sleep_fn=sleep_fn,
-    )
-    state = state.with_signal(
-        "is_payload_delivered", arrived, why, pane_after_paste=pane_after
-    )
-
-    blind_before = tap.unreadable
-    submitted = verify_submit_by_advancement(
-        session,
-        capture_fn=tap,
-        send_keys_fn=lambda key: send_keys_fn(session, key),
-        max_resends=max_resends,
-        poll_s=poll_s,
-        idle_wait_s=idle_wait_s,
-        sleep_fn=sleep_fn,
-        time_fn=time_fn,
-    )
-    blind_during = tap.unreadable - blind_before
-
-    if submitted:
-        value: Optional[bool] = True
-        reason = (
-            "the live compose box was observed to CLEAR after an idle-gated "
-            "Enter — the turn was submitted"
-        )
-    elif blind_during:
-        value = None
-        reason = (
-            f"the submit could not be confirmed, but {blind_during} capture(s) "
-            f"during the attempt were unreadable. A submit failure observed "
-            f"through a partly blind window is not a refutation"
-        )
-    else:
-        value = False
-        reason = (
-            f"the payload is STILL SITTING UNSENT in the compose box after "
-            f"{max_resends} idle-gated Enter attempts. Do NOT resend — the text "
-            f"is already there and a second copy would stack on it. Attach and "
-            f"press Enter: `tmux attach -t {session}`"
-        )
-    return state.with_signal(
-        "is_payload_submitted", value, reason, pane_after_submit=tap.last_readable
-    )
-
-
 def _finish(
     state: DeliveryState, started: float, time_fn: Callable[[], float]
 ) -> DeliveryState:
-    """Stamp the elapsed time so a budget can be tuned against measurements."""
+    """Stamp the elapsed time so a budget can be tuned against measurements.
+
+    The 25-second window that was misread as death is exactly the number this
+    makes visible — a budget argued from a measurement beats one argued from a
+    memory of how long it felt.
+    """
     return replace(state, elapsed=time_fn() - started)
 
 

--- a/src/scitex_agent_container/_delivery/_route.py
+++ b/src/scitex_agent_container/_delivery/_route.py
@@ -1,0 +1,224 @@
+"""Route resolution — PROVE the target exists before claiming anything reached it.
+
+``tmux send-keys -t tui-dotfiles`` against a session that does not exist prints
+"can't find pane" and the sender, who never looks at stderr, carries on. That is
+not a hypothetical: an operator coordinated with an agent for HOURS on that basis,
+reporting every message as delivered into a session that had never existed.
+
+So resolution happens FIRST, its own signal, before a single keystroke is sent.
+
+THE EMPTY ENUMERATION RULE
+--------------------------
+The subtle half. "``tui-<agent>`` is not in the session list" is only evidence of
+absence if the list was CAPABLE of showing it. A process in a different mount
+namespace — every containerized agent on this fleet — sees the host's tmux as an
+EMPTY session list, and an empty list read as "the agent is dead" is a measured
+false DEAD (2026-07-14). So:
+
+* enumeration failed        → ``None``   (we are blind)
+* enumeration returned []   → ``None``   (we are probably blind; nothing on a
+                                          live host has zero sessions, and this
+                                          is exactly what a namespace boundary
+                                          looks like from the inside)
+* enumeration showed others → ``False``  (a capable instrument looked and this
+                                          session was not there)
+* enumeration showed ours   → ``True``
+
+Only the third case may convict. This is the "absence of evidence is not evidence
+of absence" rule with the one condition under which absence IS evidence spelled
+out: the instrument must have demonstrated, in the same reading, that it can see
+the kind of thing whose absence it is reporting.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+__all__ = [
+    "STRATEGY_SDK",
+    "STRATEGY_TUI",
+    "TUI_SESSION_PREFIX",
+    "Route",
+    "list_tmux_sessions",
+    "read_agent_session_id",
+    "resolve_route",
+]
+
+#: The TUI runtime names its sessions ``tui-<agent>`` on the DEFAULT tmux server
+#: (``runtimes/tui_session.session_name_for``) — NOT the ``-L sac`` server that
+#: ``_runners/_tmux/pane_capture`` targets. Using that other server here would
+#: read a DIFFERENT server's emptiness as this fleet's death.
+TUI_SESSION_PREFIX = "tui-"
+
+#: Resume the agent's recorded Claude session via the existing ``sac agents
+#: send`` machinery. Covers SDK-runner agents.
+STRATEGY_SDK = "sdk"
+
+#: Verified tmux paste + idle-gated submit. The ONLY path that reaches a TUI
+#: agent, which is the population that matters: of the fleet's agents, only a
+#: handful have a recorded ``session_id`` at all.
+STRATEGY_TUI = "tui"
+
+
+@dataclass(frozen=True)
+class Route:
+    """How (and whether) we can reach one agent."""
+
+    #: ``STRATEGY_SDK`` / ``STRATEGY_TUI`` / ``""`` when nothing resolved.
+    strategy: str
+
+    #: The tmux session name for the TUI strategy; ``""`` otherwise.
+    session: str
+
+    #: True / False / None — the ``is_route_resolved`` signal, per the rule in
+    #: the module docstring.
+    resolved: bool | None
+
+    #: WHY, in the operator's terms. Carried rather than reconstructed, because
+    #: "not found" and "could not look" need different sentences and the caller
+    #: cannot regenerate which one applied.
+    reason: str
+
+    #: The raw enumeration, kept verbatim for the journal.
+    sessions_raw: str = ""
+
+
+def list_tmux_sessions() -> Optional[list[str]]:
+    """Every session on the DEFAULT tmux server; ``None`` on any error.
+
+    ``None`` rather than ``[]`` on failure — the whole point of this module is
+    that those two are different findings, and collapsing them at the sensor
+    makes the distinction unrecoverable upstream no matter how careful the
+    caller is.
+    """
+    # stx-allow: fallback (reason: tmux may be absent or have no server; None is
+    # the honest "could not read" sentinel and is handled distinctly upstream)
+    try:
+        out = subprocess.run(
+            ["tmux", "list-sessions", "-F", "#{session_name}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:  # stx-allow: fallback (reason: catch-all — see comment above)
+        return None
+    if out.returncode != 0:
+        return None
+    return sorted(s for s in out.stdout.split() if s)
+
+
+def read_agent_session_id(agent: str) -> Optional[str]:
+    """The agent's recorded Claude session id, or ``None``.
+
+    Its presence is what selects the SDK strategy. Measured on the live host:
+    only a handful of agents have this file at all — the TUI population does
+    not, which is precisely why ``sac agents send`` alone could never reach the
+    agents that matter, and why this module needs a second strategy rather than
+    a better error message on the first.
+    """
+    # stx-allow: fallback (reason: a missing/unreadable state dir simply means no
+    # SDK route; None selects the TUI strategy rather than raising)
+    try:
+        from .._runners._session_state import read_session_id, state_dir_for
+
+        return read_session_id(state_dir_for(agent)) or None
+    except Exception:  # stx-allow: fallback (reason: catch-all — see comment above)
+        return None
+
+
+def resolve_route(
+    agent: str,
+    *,
+    strategy: str = "auto",
+    list_sessions_fn: Callable[[], Optional[list[str]]] = list_tmux_sessions,
+    session_id_fn: Callable[[str], Optional[str]] = read_agent_session_id,
+) -> Route:
+    """Pick a strategy and PROVE the target exists on it. Pure but for the seams.
+
+    ``strategy`` is ``"auto"`` (prefer SDK when a session id exists, else TUI),
+    or one of :data:`STRATEGY_SDK` / :data:`STRATEGY_TUI` to force one. Forcing
+    matters for diagnosis: an operator who suspects the SDK route is stale needs
+    to be able to say "use tmux and tell me what you see".
+    """
+    if strategy in ("auto", STRATEGY_SDK):
+        session_id = session_id_fn(agent)
+        if session_id:
+            return Route(
+                strategy=STRATEGY_SDK,
+                session="",
+                resolved=True,
+                reason=(
+                    f"a recorded session_id was found for {agent!r}, so the "
+                    f"existing verified send path applies"
+                ),
+            )
+        if strategy == STRATEGY_SDK:
+            return Route(
+                strategy=STRATEGY_SDK,
+                session="",
+                resolved=False,
+                reason=(
+                    f"--strategy sdk was forced but {agent!r} has NO recorded "
+                    f"session_id. This is the normal state for a TUI agent: the "
+                    f"SDK path cannot reach it at all. Use --strategy tui (or "
+                    f"auto) instead of reading this as the agent being down"
+                ),
+            )
+
+    sessions = list_sessions_fn()
+    wanted = f"{TUI_SESSION_PREFIX}{agent}"
+    if sessions is None:
+        return Route(
+            strategy=STRATEGY_TUI,
+            session=wanted,
+            resolved=None,
+            reason=(
+                "the tmux session list could NOT be read (tmux absent, no "
+                "server, or the call failed). Nothing is known about whether "
+                f"{wanted!r} exists — this is blindness, not absence"
+            ),
+        )
+    if not sessions:
+        return Route(
+            strategy=STRATEGY_TUI,
+            session=wanted,
+            resolved=None,
+            reason=(
+                "the tmux session list came back EMPTY. An empty list is what a "
+                "process in a different mount namespace sees of the host's tmux, "
+                "so it is a statement about this observer, not about the fleet. "
+                f"Refusing to conclude that {wanted!r} is absent from a reading "
+                "that could not have shown it present"
+            ),
+            sessions_raw="",
+        )
+    raw = "\n".join(sessions)
+    if wanted in sessions:
+        return Route(
+            strategy=STRATEGY_TUI,
+            session=wanted,
+            resolved=True,
+            reason=(
+                f"{wanted!r} is present in a session list that enumerated "
+                f"{len(sessions)} session(s)"
+            ),
+            sessions_raw=raw,
+        )
+    return Route(
+        strategy=STRATEGY_TUI,
+        session=wanted,
+        resolved=False,
+        reason=(
+            f"{wanted!r} is NOT among the {len(sessions)} session(s) this tmux "
+            f"server reports. The enumeration DID show other sessions, so it was "
+            f"capable of showing this one — the absence is real, and every "
+            f"message sent to this target would have gone nowhere while "
+            f"`tmux send-keys` reported success"
+        ),
+        sessions_raw=raw,
+    )
+
+
+# EOF

--- a/src/scitex_agent_container/_delivery/_sdk_strategy.py
+++ b/src/scitex_agent_container/_delivery/_sdk_strategy.py
@@ -1,0 +1,96 @@
+"""Strategy 1 — deliver through the EXISTING ``sac agents send`` machinery.
+
+The preferred path whenever the target has a recorded session id, because it is
+already written, already used, and has no composer for text to sit unsent in. Its
+whole job here is to answer the same two signals the TUI strategy answers, so one
+verb can return one shape regardless of how the message travelled.
+
+Measured on the live host: only a handful of agents have a ``session_id`` file at
+all. That is why this cannot be the only strategy, and why a caller who reads
+"``send`` failed" against a TUI agent is reading the wrong thing — the path was
+never able to reach it.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from ._state import DeliveryState
+
+__all__ = ["default_sdk_send", "deliver_via_sdk"]
+
+
+def default_sdk_send(agent: str, payload: str) -> tuple[Optional[bool], str]:
+    """Deliver through the ``sac agents send`` library sibling.
+
+    ``wait=True`` on purpose. The non-blocking default returns
+    ``status="dispatched"``, which means "the agent looks reachable, and here is a
+    command YOU can run to actually send it" — validation, NOT delivery. Recording
+    that as a delivered message would reintroduce the exact bug this package
+    exists to remove, one layer up: an instrument reporting good news about a
+    thing it never observed.
+    """
+    # stx-allow: fallback (reason: a transport failure must render UNKNOWN, not a
+    # refutation — we cannot tell a refused send from an unobserved one)
+    try:
+        from ..cli_pkg._send import send_to_agent
+
+        result = send_to_agent(agent, payload, wait=True)
+    except Exception as exc:  # stx-allow: fallback (reason: see comment above)
+        return None, (
+            f"send_to_agent raised {type(exc).__name__}: {exc}. A transport "
+            f"failure says nothing about whether the turn reached the agent"
+        )
+    status = str(result.get("status") or "")
+    if status == "ok":
+        return True, "send_to_agent completed the turn (status='ok')"
+    if status in ("error", "creds-expired"):
+        return False, (
+            f"send_to_agent refused the turn (status={status!r}): "
+            f"{result.get('error') or 'no detail'}"
+        )
+    if status == "timeout":
+        return None, (
+            "send_to_agent timed out waiting for the reply. The turn may well be "
+            "RUNNING — a timeout is a statement about OUR PATIENCE, not about "
+            "delivery, and must never be recorded as a failed send"
+        )
+    if status == "dispatched":
+        return None, (
+            "send_to_agent returned status='dispatched', which validates "
+            "reachability WITHOUT delivering. Nothing was actually sent to the "
+            "agent, so no delivery claim can be made from it"
+        )
+    return None, (
+        f"send_to_agent returned an unrecognised status {status!r}; refusing to "
+        f"guess which pole it means"
+    )
+
+
+def deliver_via_sdk(
+    state: DeliveryState,
+    agent: str,
+    payload: str,
+    sdk_send_fn: Callable[[str, str], tuple[Optional[bool], str]],
+) -> DeliveryState:
+    """One call answers BOTH payload signals.
+
+    A completed turn is proof of arrival AND of submission — this path has no
+    compose box for text to sit unsent in, so the mode that motivates the whole
+    package cannot occur here. ``is_pane_readable`` is deliberately left ``None``:
+    there is no pane, and "there was nothing to read" is not "we failed to read
+    it". Spelling it ``False`` would invent a failure out of an inapplicable
+    question.
+    """
+    ok, detail = sdk_send_fn(agent, payload)
+    return state.with_signal(
+        "is_payload_delivered", ok, detail, send_detail=detail
+    ).with_signal(
+        "is_payload_submitted",
+        ok,
+        f"{detail} (on the SDK path a completed turn proves submission — there "
+        f"is no composer for text to sit unsent in)",
+    )
+
+
+# EOF

--- a/src/scitex_agent_container/_delivery/_spec.py
+++ b/src/scitex_agent_container/_delivery/_spec.py
@@ -1,0 +1,278 @@
+"""THE DELIVERY SPEC: which signals a send produces, and which ones may convict.
+
+The sibling of :mod:`.._agentstate._spec`, for the other half of the question.
+``_agentstate`` answers "what state is this peer in?"; this table answers "did the
+thing I sent it actually ARRIVE, and did it actually RUN?" — and those are not the
+same question, because a perfectly healthy agent can sit forever with a message
+pasted into its composer that nobody ever submitted.
+
+WHY EVERY DELIVERY SIGNAL IS NON-DECISIVE
+-----------------------------------------
+``_agentstate`` grants ``is_process_alive`` decisiveness because the process table
+is read first-hand and cannot be wrong about absence. NOTHING here earns that.
+Every delivery reading is taken through a pane capture or a subprocess exit
+status, and each of those has a measured way to lie:
+
+* a pane capture aimed at the wrong tmux server reports an empty pane, and empty
+  reads as clean (``_runners/_tmux/pane_capture`` targets a DEDICATED ``sac``
+  server, NOT the default server the live fleet runs on — reading the wrong
+  server's emptiness as death is the exact shape of the 2026-07-14 false DEAD);
+* a prose match against a re-rendered, soft-wrapped TUI returns 0 for text that
+  DID arrive (measured 2026-07-18: an operator grepped a pane for a sentence
+  fragment, got nothing, and reported "not delivered" about a message sitting on
+  screen);
+* a subprocess exit status is a claim about a process, not an observation of the
+  peer's session.
+
+So no signal below is ``decisive``, and :func:`validate_delivery_specs` enforces
+the same rule the sibling table does — decisiveness requires DIRECT observation —
+so nobody can grant it later without also changing how the signal is read. The
+practical consequence is deliberate: this subsystem can report "I could not tell",
+and it will never authorise a destructive remedy off a reading it did not take.
+
+WHAT EACH FLAG MEANS
+--------------------
+Identical semantics to :mod:`.._agentstate._spec` — ``healthy`` names the good
+pole (it is NOT always ``True``), ``load_bearing`` decides whether the signal
+participates in the verdict, ``decisive`` allows a short-circuit past unknowns,
+and ``evidence`` names the raw captures the signal was read out of.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "DELIVERY_LOAD_BEARING",
+    "DELIVERY_SIGNALS",
+    "DELIVERY_SIGNAL_NAMES",
+    "OBSERVATION_DIRECT",
+    "OBSERVATION_INFERRED",
+    "DeliverySignalSpec",
+    "delivery_spec_for",
+    "validate_delivery_specs",
+]
+
+#: The sensor physically read the thing itself, in this process, just now.
+OBSERVATION_DIRECT = "direct"
+
+#: The value came from an exit status, a cache, a declaration, or a deduction.
+#: Perfectly good evidence; never grounds for a decisive verdict.
+OBSERVATION_INFERRED = "inferred"
+
+
+@dataclass(frozen=True)
+class DeliverySignalSpec:
+    """One delivery criterion, and everything the fold needs to know about it."""
+
+    name: str
+    reads: str
+    healthy: bool
+    load_bearing: bool
+    why: str
+    decisive: bool = False
+    observation: str = OBSERVATION_INFERRED
+    evidence: tuple[str, ...] = ()
+
+
+DELIVERY_SIGNALS: tuple[DeliverySignalSpec, ...] = (
+    DeliverySignalSpec(
+        name="is_route_resolved",
+        reads=(
+            "whether a delivery route to this agent exists — a tui-<agent> "
+            "session on the DEFAULT tmux server the live fleet runs on, or a "
+            "recorded session_id for the SDK send path"
+        ),
+        healthy=True,
+        load_bearing=True,
+        decisive=False,
+        observation=OBSERVATION_DIRECT,
+        evidence=("tmux_sessions", "session_id_path"),
+        why=(
+            "LOAD-BEARING: with no route there is no delivery, and this is the "
+            "mode that cost the most — an operator coordinated with tui-dotfiles "
+            "for HOURS while every `tmux send-keys` returned 'can't find pane' "
+            "and each message was reported as delivered. NOT decisive, and the "
+            "resolver must render None rather than False whenever the "
+            "enumeration itself came back EMPTY: an empty tmux session list is "
+            "exactly what a process in a different mount namespace sees of the "
+            "host's tmux, so emptiness is a statement about the observer, not "
+            "about the fleet. Only an enumeration that DID show other sessions "
+            "is capable of showing this one's absence, and only then may absence "
+            "read False."
+        ),
+    ),
+    DeliverySignalSpec(
+        name="is_payload_delivered",
+        reads=(
+            "whether the payload's unique token was observed at the target — "
+            "found in the FLATTENED pane capture (TUI path), or implied by a "
+            "clean return from the agent's own send endpoint (SDK path)"
+        ),
+        healthy=True,
+        load_bearing=True,
+        decisive=False,
+        observation=OBSERVATION_INFERRED,
+        evidence=("pane_after_paste", "send_detail"),
+        why=(
+            "LOAD-BEARING: text that never landed cannot be acted on. INFERRED "
+            "rather than direct because the SDK strategy reads this off a "
+            "subprocess outcome rather than off the peer's screen, and a signal's "
+            "observation grade must describe its WEAKEST reader — otherwise one "
+            "strategy's inference inherits the other strategy's authority. Never "
+            "decisive: the matcher runs against a live TUI that re-renders and "
+            "soft-wraps, and a negative there has already been wrong in "
+            "production."
+        ),
+    ),
+    DeliverySignalSpec(
+        name="is_payload_submitted",
+        reads=(
+            "whether the payload was actually SUBMITTED as a turn — the live "
+            "compose box observed to advance (empty) after Enter on the TUI "
+            "path, or the turn returned on the SDK path"
+        ),
+        healthy=True,
+        load_bearing=True,
+        decisive=False,
+        observation=OBSERVATION_INFERRED,
+        evidence=("pane_after_submit",),
+        why=(
+            "LOAD-BEARING, and THE signal this whole verb exists to add. Measured "
+            "2026-07-18: a message landed in a peer's composer (confirmed by "
+            "reading the pane) and the agent stayed idle; a bare Enter into that "
+            "pane started it working immediately. A send is therefore NOT "
+            "complete when the text arrives — arrival and submission are two "
+            "different facts and the old path only ever checked the first, which "
+            "is why 'delivered' and 'ignored' were indistinguishable. INFERRED + "
+            "non-decisive for the same reason as is_payload_delivered."
+        ),
+    ),
+    DeliverySignalSpec(
+        name="is_pane_readable",
+        reads="whether the target's pane could be captured at all",
+        healthy=True,
+        load_bearing=False,
+        observation=OBSERVATION_DIRECT,
+        evidence=("pane_before", "pane_after_paste"),
+        why=(
+            "EVIDENCE ONLY — it is the PRECONDITION of the two load-bearing "
+            "readings above, not a competitor to them. When the pane cannot be "
+            "read they are already None and the verdict is already UNKNOWN, so "
+            "promoting this would double-count one failure. It is carried "
+            "because it tells the reader WHICH KIND of unknown they have: 'the "
+            "screen was unreadable' sends an operator somewhere completely "
+            "different from 'the screen was fine and the token never appeared'. "
+            "It is also None, never False, on the SDK path — that path has no "
+            "pane, and 'there was nothing to read' is not 'we failed to read it'."
+        ),
+    ),
+    DeliverySignalSpec(
+        name="is_target_busy_before",
+        reads=(
+            "whether the pane showed an in-progress marker (spinner / 'esc to "
+            "interrupt') on the capture taken BEFORE the send"
+        ),
+        healthy=False,
+        load_bearing=False,
+        observation=OBSERVATION_DIRECT,
+        evidence=("pane_before",),
+        why=(
+            "EVIDENCE ONLY. A busy agent is a WORKING agent — the healthiest "
+            "thing on the fleet — and delivery to it succeeds normally because "
+            "the text queues in the composer and the submit step waits for idle. "
+            "Making this refute would flag exactly the agents that are fine. It "
+            "is carried because it is the single best explanation for a slow "
+            "delivery, and an operator who cannot see it will misread a long "
+            "wait as a wedge (25 seconds was misread as death once already; a "
+            "UserPromptSubmit hook alone can legitimately take 30)."
+        ),
+    ),
+    DeliverySignalSpec(
+        name="is_login_banner_before",
+        reads=(
+            "whether an auth banner ('Login expired') sat above the prompt on "
+            "the single capture taken BEFORE the send"
+        ),
+        healthy=False,
+        load_bearing=False,
+        observation=OBSERVATION_DIRECT,
+        evidence=("pane_before",),
+        why=(
+            "EVIDENCE ONLY, and deliberately so despite being load-bearing in "
+            "the sibling table. There it is trusted because it is corroborated "
+            "across TWO captures taken an interval apart — a banner that MOVED "
+            "means the agent is working or merely quoting the incident. A send "
+            "takes ONE pre-capture, so this reading is UNCORROBORATED, and an "
+            "uncorroborated banner match must never be allowed to refute a "
+            "delivery. Surfaced loudly all the same: it is usually the reason a "
+            "submitted turn produces nothing, and the operator should be told to "
+            "go look at `sac agents auth-status` rather than resend."
+        ),
+    ),
+)
+
+
+def validate_delivery_specs(
+    specs: "tuple[DeliverySignalSpec, ...]" = DELIVERY_SIGNALS,
+) -> None:
+    """Refuse a spec table that would let an INFERENCE convict.
+
+    Called at module scope, so a bad table fails at IMPORT rather than shipping
+    and being discovered by an operator acting on its verdict. Same three
+    invariants as :func:`.._agentstate._spec.validate_specs`, each with a real
+    failure behind it: a duplicate name lets one signal silently shadow another
+    in the lookup; a decisive signal that is not load-bearing would
+    short-circuit a verdict it takes no part in; and a decisive signal read from
+    an exit status is precisely the "confident answer about a thing we never
+    observed" this package exists to end.
+    """
+    seen: set[str] = set()
+    for spec in specs:
+        if spec.name in seen:
+            raise ValueError(
+                f"duplicate delivery signal {spec.name!r} — one entry would "
+                f"silently shadow the other, and half the callers would be "
+                f"reading a criterion nobody knows is there"
+            )
+        seen.add(spec.name)
+        if spec.decisive and not spec.load_bearing:
+            raise ValueError(
+                f"{spec.name!r} is decisive but not load-bearing — a signal that "
+                f"does not participate in the verdict cannot short-circuit it"
+            )
+        if spec.decisive and spec.observation != OBSERVATION_DIRECT:
+            raise ValueError(
+                f"{spec.name!r} is decisive but its observation is "
+                f"{spec.observation!r}. DECISIVE REQUIRES DIRECT OBSERVATION: a "
+                f"decisive signal overrides every other signal's UNKNOWN, so it "
+                f"must be a thing we read ourselves, just now. A subprocess exit "
+                f"status or a cached verdict may be evidence, never a "
+                f"short-circuit."
+            )
+
+
+validate_delivery_specs()
+
+DELIVERY_SIGNAL_NAMES: tuple[str, ...] = tuple(s.name for s in DELIVERY_SIGNALS)
+DELIVERY_LOAD_BEARING: tuple[str, ...] = tuple(
+    s.name for s in DELIVERY_SIGNALS if s.load_bearing
+)
+
+_BY_NAME = {s.name: s for s in DELIVERY_SIGNALS}
+
+
+def delivery_spec_for(name: str) -> DeliverySignalSpec:
+    """The spec for one delivery signal. Raises on an unknown name."""
+    try:
+        return _BY_NAME[name]
+    except KeyError:
+        raise KeyError(
+            f"unknown delivery signal {name!r} — the signal set is declared in "
+            f"{__name__}.DELIVERY_SIGNALS and nowhere else. Add it THERE (with "
+            f"what it reads, its healthy pole, and why it is or is not "
+            f"load-bearing) rather than introducing a criterion at a call site."
+        ) from None
+
+
+# EOF

--- a/src/scitex_agent_container/_delivery/_state.py
+++ b/src/scitex_agent_container/_delivery/_state.py
@@ -1,0 +1,196 @@
+"""``DeliveryState`` — the ONE shape every send returns about its own outcome.
+
+The constitution's §2 rule applied to the act of sending. :mod:`.._agentstate`
+fixed "what state is this peer in?"; a send was still answering "did it work?"
+with nothing at all — ``tmux send-keys`` returns 0 for a pane that does not
+exist, and the caller learned NOTHING.
+
+Every signal is ``bool | None``: **True / False / None, where None means COULD NOT
+DETERMINE.** That third value is the entire point, and delivery is where it bites
+hardest, because all four failure modes are indistinguishable from the sender's
+side unless the shape can hold "I could not tell":
+
+* the target was DEAD (session never existed, every message vanished, all of them
+  reported as delivered);
+* the target was WEDGED (pane exists, nothing ever submits);
+* the text SAT UNSUBMITTED in the composer (it arrived, and the agent stayed idle
+  until a bare Enter started it);
+* the VERIFICATION ITSELF LIED (a prose grep returned 0 for a message that had in
+  fact arrived — the TUI had re-rendered and wrapped it).
+
+The fourth is the reason this type refuses to store only a verdict. ``raw``
+carries what was actually SEEN — the pane before the send, the pane after the
+paste, the pane after the submit — so a disputed outcome can be re-examined
+against the bytes rather than re-argued from a summary. A summary is a claim you
+cannot check later.
+
+NO COMBINING LOGIC LIVES HERE
+    This type HOLDS signals. It never folds them. The single fold is
+    :func:`._assess.assess_delivery`, and there is exactly one of it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from ._spec import DELIVERY_SIGNAL_NAMES, DELIVERY_SIGNALS, delivery_spec_for
+
+__all__ = ["DeliveryState"]
+
+
+@dataclass(frozen=True)
+class DeliveryState:
+    """Every criterion sac has about ONE delivery, each True / False / None.
+
+    Construct it with whatever was actually observed and leave the rest ``None``
+    — a signal that was not read is ``None`` by default, which is the honest
+    value, and it is why the default constructor cannot accidentally claim a
+    successful send. There is deliberately no bare ``bool`` anywhere in this type.
+    """
+
+    agent: str
+
+    #: Which strategy was used: ``"sdk"`` (the existing ``sac agents send``
+    #: resume path) or ``"tui"`` (verified tmux paste + submit). ONE verb, two
+    #: strategies — and the reader must always be able to tell which one ran,
+    #: because the two have different blind spots and an outcome is only
+    #: interpretable against the way it was obtained.
+    strategy: str = ""
+
+    #: The short token injected into the payload and matched back out of the
+    #: pane. Recorded so a human can grep the peer's scrollback for the SAME
+    #: token later and independently confirm — or refute — this row.
+    token: str = ""
+
+    # --- the signals. Order matches the spec table. --------------------------
+    is_route_resolved: bool | None = None
+    is_payload_delivered: bool | None = None
+    is_payload_submitted: bool | None = None
+    is_pane_readable: bool | None = None
+    is_target_busy_before: bool | None = None
+    is_login_banner_before: bool | None = None
+
+    #: Per-signal WHY. A ``None`` that does not say why it is None is a shrug
+    #: wearing a type — the reader still cannot tell "the pane was unreadable"
+    #: from "nobody looked", and those send them to different places.
+    reasons: Mapping[str, str] = field(default_factory=dict)
+
+    #: The RAW observations, keyed by the ``evidence`` names the spec declares
+    #: (``pane_before``, ``pane_after_paste``, ``tmux_sessions``, …). WHOLE
+    #: captures, not tails: the wrapped-prose false negative was only ever
+    #: diagnosable because someone still had the full screen.
+    raw: Mapping[str, str] = field(default_factory=dict)
+
+    #: When the send was attempted (unix seconds). ``None`` when the caller did
+    #: not supply one — never defaulted to "now", which would date an old
+    #: reading to the moment it was rendered.
+    observed_at: float | None = None
+
+    #: Seconds the whole verified send took, so a budget can be tuned against
+    #: measurements instead of guesses. The 25-second window that was misread as
+    #: death is exactly the number this field exists to make visible.
+    elapsed: float | None = None
+
+    #: Who produced this row (``"sac agents deliver"``, …).
+    observer: str = ""
+
+    def __post_init__(self) -> None:
+        for name in DELIVERY_SIGNAL_NAMES:
+            value = getattr(self, name)
+            if value is not None and not isinstance(value, bool):
+                raise TypeError(
+                    f"{name} must be True, False or None — got {value!r} "
+                    f"({type(value).__name__}). A signal is never a truthy "
+                    f"string or an int: 'could not determine' is a first-class "
+                    f"answer here and must be spelled None, and a non-bool would "
+                    f"quietly evaluate as one of the poles."
+                )
+        for key in self.reasons:
+            delivery_spec_for(key)  # raises, with guidance, on a typo
+        object.__setattr__(self, "reasons", MappingProxyType(dict(self.reasons)))
+        object.__setattr__(self, "raw", MappingProxyType(dict(self.raw)))
+
+    # --- construction --------------------------------------------------------
+
+    @classmethod
+    def unknown(cls, agent: str, reason: str, **kwargs: Any) -> "DeliveryState":
+        """A send we could not evaluate AT ALL — every signal ``None``, with WHY.
+
+        The constructor for "we did not even get far enough to try". It assesses
+        to UNKNOWN and exits 2, which is the honest answer and, crucially, NOT
+        the answer the old path gave: ``tmux send-keys`` into a nonexistent pane
+        returned success, so an unattempted delivery and a completed one spelled
+        the same thing.
+        """
+        return cls(
+            agent=agent,
+            reasons={name: reason for name in DELIVERY_SIGNAL_NAMES},
+            **kwargs,
+        )
+
+    def with_signal(
+        self, name: str, value: bool | None, reason: str = "", **evidence: str
+    ) -> "DeliveryState":
+        """A copy with one signal set, its reason recorded and its raw kept.
+
+        The builder the sender uses per step, so a signal and the evidence it was
+        read from can never be stored apart from each other.
+        """
+        delivery_spec_for(name)
+        reasons = dict(self.reasons)
+        if reason:
+            reasons[name] = reason
+        raw = dict(self.raw)
+        raw.update(evidence)
+        return replace(self, reasons=reasons, raw=raw, **{name: value})
+
+    # --- reading -------------------------------------------------------------
+
+    def signals(self) -> dict[str, bool | None]:
+        """Every signal by name, including the ones that are ``None``.
+
+        ALWAYS the full set — never only the ones that were read. A mapping that
+        omits its unknowns cannot distinguish "we checked and it was fine" from
+        "we never looked", which is precisely the pair that must never spell the
+        same thing.
+        """
+        return {name: getattr(self, name) for name in DELIVERY_SIGNAL_NAMES}
+
+    def reason_for(self, name: str) -> str:
+        delivery_spec_for(name)
+        return self.reasons.get(name, "")
+
+    def to_dict(self) -> dict[str, Any]:
+        """The JSON shape. Carries EVERY RAW SIGNAL — the exit code is elsewhere.
+
+        The signals appear exactly as observed, each with its reason and its spec
+        metadata, and the summarising happens strictly at the exit code. A
+        consumer can therefore disagree with our aggregation and recompute its
+        own, which is impossible against a bare status string.
+        """
+        return {
+            "agent": self.agent,
+            "strategy": self.strategy,
+            "token": self.token,
+            "observed_at": self.observed_at,
+            "elapsed": self.elapsed,
+            "observer": self.observer,
+            "signals": {
+                spec.name: {
+                    "value": getattr(self, spec.name),
+                    "reason": self.reasons.get(spec.name, ""),
+                    "healthy": spec.healthy,
+                    "load_bearing": spec.load_bearing,
+                    "decisive": spec.decisive,
+                    "observation": spec.observation,
+                    "reads": spec.reads,
+                }
+                for spec in DELIVERY_SIGNALS
+            },
+            "raw": dict(self.raw),
+        }
+
+
+# EOF

--- a/src/scitex_agent_container/_delivery/_token.py
+++ b/src/scitex_agent_container/_delivery/_token.py
@@ -1,0 +1,116 @@
+"""The arrival matcher — a SHORT INJECTED TOKEN, matched against a FLAT pane.
+
+THE FAILURE THIS EXISTS TO END
+------------------------------
+On 2026-07-18 an operator confirmed a delivery by grepping the peer's pane for a
+fragment of the prose he had sent. He got zero matches and concluded "not
+delivered". The message HAD arrived — the Ink TUI had re-rendered and soft-wrapped
+it, so the fragment he searched for no longer existed as a contiguous string
+anywhere on screen. **The verification itself lied**, and it lied in the confident
+direction: a negative from an instrument that cannot represent the positive.
+
+Two rules follow, and both are implemented here rather than left to callers.
+
+**Match a short INJECTED token, never prose.** The sender chooses the needle, so
+the needle can be made short enough to survive a wrap and unique enough that a
+match means something. Prose is the opposite on both counts.
+
+**Flatten the haystack before matching.** Even a short token can be split by the
+TUI's own box drawing — the composer renders inside a bordered box, so a wrapped
+row arrives as ``…ab12│\\n│cd34…`` where the newline and the border are the TUI's
+layout, not tmux's line wrapping. ``tmux capture-pane -J`` rejoins tmux's OWN
+wraps and is necessary, but it cannot undo the TUI's, so :func:`flatten_pane`
+strips everything that is not alphanumeric and lowercases the rest. A hex token
+contains no stripped characters, so it survives any amount of border, whitespace
+and wrapping the renderer inserts into it.
+
+The collision risk this trades for is negligible and quantified: a 12-hex-char
+token is one of 2**48 ≈ 2.8e14, and a flattened pane offers on the order of 1e4
+starting positions, so a coincidental match runs about 1 in 1e10 per capture. A
+false NEGATIVE from wrapping was a measured, recurring event; a false positive at
+that rate is not.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .._lifecycle.liveness_probe import generate_nonce, pane_has_nonce_echo
+
+__all__ = [
+    "DELIVERY_TOKEN_BYTES",
+    "flatten_pane",
+    "format_payload",
+    "make_token",
+    "pane_contains_token",
+]
+
+#: 6 bytes = 12 hex characters. Long enough that a flattened-pane collision is
+#: ~1e-10 per capture, short enough to stay unobtrusive in a human-read message.
+DELIVERY_TOKEN_BYTES = 6
+
+_NON_ALNUM = re.compile(r"[^0-9a-z]+")
+
+
+def make_token() -> str:
+    """A fresh delivery token. Hex, via the fleet's existing nonce generator.
+
+    Reuses :func:`.._lifecycle.liveness_probe.generate_nonce` rather than
+    introducing a second source of randomness, so there is one answer to "where
+    do sac's probe tokens come from". Hex-only also keeps the token visually
+    unambiguous in a monospace TUI, where 0/O and 1/l/I collisions plague base64.
+    """
+    return generate_nonce(DELIVERY_TOKEN_BYTES)
+
+
+def format_payload(message: str, token: str) -> str:
+    """The wire form: a marked token, then the message.
+
+    The token goes FIRST, on purpose. It is the part that must survive
+    rendering, and the start of the payload is the position least likely to be
+    split across a wrap boundary — the composer has a full row available at that
+    point. (:func:`flatten_pane` makes the matcher wrap-proof anyway; this merely
+    keeps the token legible to a HUMAN reading the pane, who has no flattener.)
+
+    The ``sac-deliver:`` marker makes the token self-describing on the receiving
+    end: an agent that sees it knows the message came through a verified send and
+    that the sender is watching for arrival, rather than wondering what the
+    stray hex is.
+    """
+    return f"[sac-deliver:{token}] {message}"
+
+
+def flatten_pane(pane: str) -> str:
+    """Strip every non-alphanumeric character and lowercase the rest.
+
+    Defeats EVERY renderer artefact at once — soft wraps, box-drawing borders,
+    ANSI-stripped whitespace runs, the lot — without needing to know which one
+    the TUI applied. See the module docstring for why matching the raw capture
+    is not good enough and has already produced a wrong answer in production.
+    """
+    return _NON_ALNUM.sub("", (pane or "").lower())
+
+
+def pane_contains_token(pane: str | None, token: str) -> bool | None:
+    """Did the token arrive on this pane? ``None`` when the pane is unreadable.
+
+    THREE-VALUED on purpose: ``None`` is a capture that could not be taken, and
+    it must never be spelled the same as a capture that was taken and came back
+    clean. "Uncapturable" and "empty" reading alike is precisely how the wrong
+    tmux server's emptiness got read as an agent's death.
+
+    ``min_occurrences=1`` — NOT the default. :func:`pane_has_nonce_echo` defaults
+    to ``2`` because it was written for a ROUND-TRIP ECHO probe ("repeat this
+    nonce back to me"), where the sender's own prompt line contributes the first
+    occurrence and only the agent's reply can contribute a second. Plain message
+    DELIVERY has no round trip: the token is pasted once and appears once, so the
+    echo module's default would report every successful delivery as a failure.
+    The primitive is reused (one matcher, one place to fix) with the count set to
+    what THIS question actually requires.
+    """
+    if pane is None:
+        return None
+    return pane_has_nonce_echo(flatten_pane(pane), token, min_occurrences=1)
+
+
+# EOF

--- a/src/scitex_agent_container/_delivery/_tui_strategy.py
+++ b/src/scitex_agent_container/_delivery/_tui_strategy.py
@@ -1,0 +1,328 @@
+"""Strategy 2 — the VERIFIED tmux path, the only one that reaches a TUI agent.
+
+Paste literally, confirm arrival by token, then confirm SUBMISSION and retry the
+Enter. Each step is an existing, proven primitive; this module is the wiring plus
+the tri-state bookkeeping those primitives cannot express on their own.
+
+WHY THE TRAILING ENTER DID NOT TAKE
+-----------------------------------
+The operator saw a message land in a peer's composer while the agent stayed idle,
+and a bare Enter into that pane started it working immediately. The repo had
+already root-caused this once on the boot path (card ``sac-tui-enter-drop-on-boot``)
+and the answer is BOTH suspected causes at once:
+
+1. the Ink/React TUI silently DROPS non-literal ``send-keys``, so the text must go
+   in with ``-l`` and the submit must be a SEPARATE named ``Enter`` — never ``-l``,
+   which would type the five characters "Enter" into the box; and
+2. the TUI EATS an ``Enter`` fired while the pane is BUSY (spinner up, MCP
+   reconnecting, a hook running), and a ``UserPromptSubmit`` hook alone can hold
+   that window for 30 seconds.
+
+A blind ``send-keys text Enter`` loses the submit to (2) whenever the peer happens
+to be working, which on a busy fleet is most of the time. The fix is not a longer
+sleep — it is to WAIT FOR IDLE, send exactly one Enter, VERIFY the compose buffer
+advanced, and retry bounded. That is precisely
+:func:`..runtimes._tui_compose.verify_submit_by_advancement`, so this module calls
+it rather than growing a second copy that could drift from the boot path on the
+one behaviour that was hardest to get right.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from ._route import Route
+from ._state import DeliveryState
+from ._token import pane_contains_token
+
+__all__ = [
+    "CaptureTap",
+    "default_capture",
+    "default_paste",
+    "default_send_keys",
+    "deliver_via_tui",
+    "observe_pane_before",
+]
+
+
+class CaptureTap:
+    """A real capture callable that REMEMBERS how often it could not read.
+
+    ``verify_submit_by_advancement`` is typed ``capture_fn(name) -> str`` and has
+    no way to express "the pane could not be read", so this adapter substitutes
+    ``""`` for it while recording that a substitution happened. Without that
+    memory, a submit outcome computed against a blind window would be
+    indistinguishable from one computed against a screen we actually saw — and
+    only the second kind may become a verdict.
+    """
+
+    def __init__(self, capture_fn: Callable[[str], Optional[str]]) -> None:
+        self._capture_fn = capture_fn
+        self.unreadable = 0
+        self.readable = 0
+        self.last_readable = ""
+
+    def read(self, target: str) -> Optional[str]:
+        """Capture, recording readability, and PRESERVE the tri-state."""
+        pane = self._capture_fn(target)
+        if pane is None:
+            self.unreadable += 1
+        else:
+            self.readable += 1
+            self.last_readable = pane
+        return pane
+
+    def __call__(self, target: str) -> str:
+        """The ``capture_fn(name) -> str`` shape the submit verifier requires."""
+        return self.read(target) or ""
+
+
+def default_capture(session: str) -> Optional[str]:
+    """The fleet's CORRECT pane read: default server, ``-J``, ``None`` on error.
+
+    Deliberately ``cli_pkg._auth_status._capture`` and not
+    ``_runners._tmux.pane_capture``: the latter targets a DEDICATED tmux server
+    named ``sac``, not the default server the live fleet runs on, so it would
+    report a different server's emptiness as this agent's death. ``-J`` rejoins
+    tmux's own soft wraps, and ``None`` on any error keeps "uncapturable"
+    distinct from "clean pane".
+    """
+    from ..cli_pkg._auth_status import _capture
+
+    return _capture(session)
+
+
+def default_paste(session: str, text: str) -> None:
+    """Literal paste, NO submit. The ``-l`` is not optional — see the docstring."""
+    from .._runners._tmux.tmux import TmuxManager
+
+    TmuxManager.send_text_literal(session, text)
+
+
+def default_send_keys(session: str, key: str) -> None:
+    """A named key (``Enter``), sent separately from the literal text."""
+    from .._runners._tmux.tmux import TmuxManager
+
+    TmuxManager.send_keys(session, key)
+
+
+def observe_pane_before(state: DeliveryState, pane: Optional[str]) -> DeliveryState:
+    """Record what the pane looked like BEFORE the send: readable / busy / banner.
+
+    All three are EVIDENCE, never a veto. A busy peer is a working peer and
+    delivery to it succeeds normally; a banner seen on one capture is
+    uncorroborated. Refusing to send on either would block exactly the agents
+    that are fine.
+    """
+    from .._lifecycle.liveness_probe import pane_is_busy
+
+    if pane is None:
+        return (
+            state.with_signal(
+                "is_pane_readable",
+                False,
+                "the pre-send capture failed — the session may have vanished "
+                "between the enumeration and the capture",
+            )
+            .with_signal(
+                "is_target_busy_before",
+                None,
+                "not read: the pane could not be captured",
+            )
+            .with_signal(
+                "is_login_banner_before",
+                None,
+                "not read: the pane could not be captured",
+            )
+        )
+
+    from .._runners._tmux.auth_status import evaluate
+
+    state = state.with_signal(
+        "is_pane_readable", True, "the pre-send pane was captured", pane_before=pane
+    )
+    busy = pane_is_busy(pane)
+    state = state.with_signal(
+        "is_target_busy_before",
+        busy,
+        (
+            "an in-progress marker was on the pane tail — the peer is WORKING, "
+            "which is healthy; the submit step will wait for it to go idle"
+            if busy
+            else "no in-progress marker on the pane tail"
+        ),
+    )
+    probe, _ = evaluate(pane, None)
+    return state.with_signal(
+        "is_login_banner_before",
+        bool(probe.present),
+        (
+            "an auth banner sits near the prompt on this SINGLE capture. "
+            "UNCORROBORATED — run `sac agents auth-status` for the two-capture "
+            "frozen check before acting. If it is real, a submitted turn will "
+            "produce nothing and resending will not help"
+            if probe.present
+            else "no auth banner near the prompt"
+        ),
+    )
+
+
+def _watch_for_arrival(
+    session: str,
+    token: str,
+    *,
+    tap: CaptureTap,
+    timeout_s: float,
+    poll_s: float,
+    time_fn: Callable[[], float],
+    sleep_fn: Callable[[float], None],
+) -> tuple[Optional[bool], str, str]:
+    """Poll until the token renders. Returns ``(signal, reason, last_pane)``.
+
+    Tri-state: ``True`` on a match, ``False`` when readable captures were taken
+    and none contained it, and ``None`` when NO readable capture was ever taken —
+    a window in which we never once saw the screen cannot support a claim about
+    what was on it.
+    """
+    deadline = time_fn() + timeout_s
+    last = ""
+    while True:
+        pane = tap.read(session)
+        if pane is not None:
+            last = pane
+        if pane_contains_token(pane, token) is True:
+            return True, f"token {token} was found on the pane after the paste", last
+        if time_fn() >= deadline:
+            break
+        if poll_s > 0:
+            sleep_fn(poll_s)
+    if tap.readable == 0:
+        return (
+            None,
+            f"the pane could not be read even once in {timeout_s:.0f}s, so "
+            f"nothing is known about whether the payload arrived",
+            last,
+        )
+    return (
+        False,
+        f"token {token} did not appear on {tap.readable} readable capture(s) "
+        f"over {timeout_s:.0f}s. NOTE the matcher flattens the pane before "
+        f"searching, so this is NOT a wrapping artefact",
+        last,
+    )
+
+
+def _submission_signal(
+    *,
+    submitted: bool,
+    readable_during: int,
+    blind_during: int,
+    max_resends: int,
+    session: str,
+) -> tuple[Optional[bool], str]:
+    """Turn the verifier's bool into a TRI-STATE, guarding its vacuous True.
+
+    THE ORDER OF THESE BRANCHES IS THE POINT, and it was wrong once. A wholly
+    blind window is checked FIRST, before ``submitted`` is consulted at all,
+    because ``verify_submit_by_advancement`` returns ``True`` from its phase 1
+    when the compose box never showed pending text — "there is nothing to force".
+    Against a pane that could not be read, every capture it saw was the empty
+    string :class:`CaptureTap` substitutes for ``None``, so that ``True`` was
+    computed from evidence WITH NO WAY TO DISAGREE WITH IT. Trusting it would
+    report a successful submission to an agent whose screen we never saw. The
+    verifier is not wrong; it was asked a question it could not know it was
+    unable to answer, so the guard belongs here.
+
+    A PARTIALLY blind window is treated asymmetrically on purpose: it may still
+    carry a positive (we watched the buffer clear with our own eyes) but never a
+    negative (a failure seen through gaps is not a refutation).
+    """
+    if readable_during == 0:
+        return None, (
+            f"not one readable capture was taken during the submit attempt "
+            f"({blind_during} unreadable). The submit verifier returned "
+            f"{submitted!r}, but it read only empty strings, so that answer is "
+            f"vacuous and is NOT recorded as a verdict"
+        )
+    if submitted:
+        return True, (
+            "the live compose box was observed to CLEAR after an idle-gated "
+            "Enter — the turn was submitted"
+        )
+    if blind_during:
+        return None, (
+            f"the submit could not be confirmed, but {blind_during} capture(s) "
+            f"during the attempt were unreadable. A submit failure observed "
+            f"through a partly blind window is not a refutation"
+        )
+    return False, (
+        f"the payload is STILL SITTING UNSENT in the compose box after "
+        f"{max_resends} idle-gated Enter attempts. Do NOT resend — the text is "
+        f"already there and a second copy would stack on it. Attach and press "
+        f"Enter: `tmux attach -t {session}`"
+    )
+
+
+def deliver_via_tui(
+    state: DeliveryState,
+    route: Route,
+    payload: str,
+    token: str,
+    *,
+    capture_fn: Callable[[str], Optional[str]],
+    paste_fn: Callable[[str, str], None],
+    send_keys_fn: Callable[[str, str], None],
+    arrival_timeout_s: float,
+    idle_wait_s: float,
+    max_resends: int,
+    poll_s: float,
+    time_fn: Callable[[], float],
+    sleep_fn: Callable[[float], None],
+) -> DeliveryState:
+    """Observe, paste literally, confirm arrival by token, then confirm SUBMISSION."""
+    from ..runtimes._tui_compose import verify_submit_by_advancement
+
+    session = route.session
+    state = observe_pane_before(state, capture_fn(session))
+
+    paste_fn(session, payload)
+
+    tap = CaptureTap(capture_fn)
+    arrived, why, pane_after = _watch_for_arrival(
+        session,
+        token,
+        tap=tap,
+        timeout_s=arrival_timeout_s,
+        poll_s=poll_s,
+        time_fn=time_fn,
+        sleep_fn=sleep_fn,
+    )
+    state = state.with_signal(
+        "is_payload_delivered", arrived, why, pane_after_paste=pane_after
+    )
+
+    blind_before = tap.unreadable
+    readable_before = tap.readable
+    submitted = verify_submit_by_advancement(
+        session,
+        capture_fn=tap,
+        send_keys_fn=lambda key: send_keys_fn(session, key),
+        max_resends=max_resends,
+        poll_s=poll_s,
+        idle_wait_s=idle_wait_s,
+        sleep_fn=sleep_fn,
+        time_fn=time_fn,
+    )
+    value, reason = _submission_signal(
+        submitted=bool(submitted),
+        readable_during=tap.readable - readable_before,
+        blind_during=tap.unreadable - blind_before,
+        max_resends=max_resends,
+        session=session,
+    )
+    return state.with_signal(
+        "is_payload_submitted", value, reason, pane_after_submit=tap.last_readable
+    )
+
+
+# EOF

--- a/src/scitex_agent_container/cli_pkg/_agents_deliver.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_deliver.py
@@ -1,0 +1,164 @@
+"""``sac agents deliver`` — send a message and REPORT whether it actually landed.
+
+The operator-facing half of :mod:`.._delivery`. ``sac agents send`` already exists
+and is the right tool when the target has a recorded session id — but measured on
+the live host, only a handful of agents do. The TUI population, which is most of
+the fleet, has none, so for those agents ``send`` cannot deliver at all and the
+only route is a tmux paste, which until now reported success unconditionally.
+
+This verb is ONE verb with TWO strategies: it prefers the existing ``send`` path
+when a session id exists and falls back to the verified tmux path otherwise. What
+it adds in both cases is an ANSWER — a tri-state verdict with every signal named,
+its reason recorded, and the raw pane captures attached, so a delivery can be
+re-examined later instead of merely believed.
+
+Exit code is ONLY the summary. Every raw signal is in ``--json``, and a caller
+that needs to distinguish an UNKNOWN (2) from click's own usage error (also 2)
+MUST read the JSON rather than branch on the integer.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from .._delivery import (
+    DEFAULT_ARRIVAL_TIMEOUT_S,
+    DEFAULT_IDLE_WAIT_S,
+    DEFAULT_MAX_RESENDS,
+    STRATEGY_SDK,
+    STRATEGY_TUI,
+    assess_delivery,
+    deliver,
+)
+from ._helpers import _json_flag, agent_name_complete, console
+
+#: How a verdict renders. UNKNOWN is MAGENTA — grouped with nothing green, since
+#: the failure being fixed is an unverified send that looked like a delivered one.
+_STYLE = {
+    True: ("green", "DELIVERED"),
+    False: ("red", "NOT DELIVERED"),
+    None: ("magenta", "UNKNOWN"),
+}
+
+
+@click.command(name="deliver")
+@click.argument("name", shell_complete=agent_name_complete)
+@click.argument("message")
+@click.option(
+    "--strategy",
+    type=click.Choice(["auto", STRATEGY_SDK, STRATEGY_TUI]),
+    default="auto",
+    show_default=True,
+    help="Force a delivery strategy. 'auto' prefers the recorded-session send "
+    "path and falls back to the verified tmux path.",
+)
+@click.option(
+    "--arrival-timeout",
+    type=float,
+    default=DEFAULT_ARRIVAL_TIMEOUT_S,
+    show_default=True,
+    help="Seconds to watch for the injected token to render after the paste.",
+)
+@click.option(
+    "--idle-wait",
+    type=float,
+    default=DEFAULT_IDLE_WAIT_S,
+    show_default=True,
+    help="Seconds to wait for the peer to go idle before each submit attempt. "
+    "Keep this generous — a UserPromptSubmit hook alone can take 30s, and a "
+    "short budget manufactures false 'wedged' readings.",
+)
+@click.option(
+    "--max-resends",
+    type=int,
+    default=DEFAULT_MAX_RESENDS,
+    show_default=True,
+    help="Bounded submit retries. Each re-checks idle from scratch.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Every RAW signal, as JSON.")
+@click.pass_context
+def agents_deliver(
+    ctx: click.Context,
+    name: str,
+    message: str,
+    strategy: str,
+    arrival_timeout: float,
+    idle_wait: float,
+    max_resends: int,
+    as_json: bool,
+) -> None:
+    """Deliver MESSAGE to agent NAME and verify it arrived AND was submitted.
+
+    Unlike a bare ``tmux send-keys``, this resolves and PROVES the target exists,
+    observes the pane before sending, confirms arrival by a short injected token
+    matched against a flattened pane (so a re-render cannot fake a negative), and
+    then confirms SUBMISSION — retrying the Enter only when the pane is idle,
+    because the Ink TUI silently eats an Enter fired while it is busy.
+
+    \b
+    Examples:
+      $ sac agents deliver scitex-dev "please rebase onto develop"
+      $ sac agents deliver dotfiles "ping" --json
+      $ sac agents deliver some-agent "hi" --strategy tui --idle-wait 120
+
+    \b
+    Exit codes (the summary only — read --json for the signals):
+      0  delivered AND submitted
+      1  refuted with complete information
+      2  could NOT determine (do not resend on this — the message may have landed)
+      3  no route: the session does not exist on a tmux server that can see others
+      4  arrived but STILL UNSENT in the composer — attach and press Enter
+    """
+    use_json = _json_flag(ctx, as_json)
+
+    state = deliver(
+        name,
+        message,
+        strategy=strategy,
+        arrival_timeout_s=arrival_timeout,
+        idle_wait_s=idle_wait,
+        max_resends=max_resends,
+    )
+    verdict = assess_delivery(state)
+    code = verdict.exit_code()
+
+    if use_json:
+        click.echo(
+            json.dumps(
+                {**state.to_dict(), "assessment": verdict.to_dict()},
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        raise SystemExit(code)
+
+    colour, label = _STYLE[verdict.verdict]
+    console.print(
+        f"[{colour}]{label}[/{colour}] {state.agent} "
+        f"[dim](strategy={state.strategy or 'none'}, token={state.token}, "
+        f"{state.elapsed or 0.0:.1f}s)[/dim]",
+        soft_wrap=True,
+    )
+    for signal, value in state.signals().items():
+        shown = "None" if value is None else str(value)
+        tone = "magenta" if value is None else "dim"
+        console.print(
+            f"    [{tone}]{signal:<24} {shown:<5}[/{tone}] "
+            f"[dim]{state.reason_for(signal)}[/dim]",
+            soft_wrap=True,
+        )
+    console.print(f"    [{colour}]=> {verdict.reason}[/{colour}]", soft_wrap=True)
+    console.print(f"[dim]exit {code}[/dim]", soft_wrap=True)
+    raise SystemExit(code)
+
+
+def register(agent_group) -> None:
+    """Attach ``deliver`` to the parent ``agents`` Click group."""
+    agent_group.add_command(agents_deliver)
+
+
+__all__ = ["agents_deliver", "register"]
+
+# EOF

--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -137,6 +137,20 @@ _register_restart_login_expired(agent_group)
 from ._agents_state import register as _register_agents_state  # noqa: E402
 
 _register_agents_state(agent_group)
+# `deliver` — a send that reports whether it actually landed. `send` (above)
+# resumes a recorded Claude session and is the right tool when the target has
+# one; measured on the live host, only a handful of agents do, so for the TUI
+# population it cannot deliver at all. A bare `tmux send-keys` into a session
+# that does not exist prints "can't find pane" to a stderr nobody reads and
+# exits 0 — which is how hours of coordination went to a session that had never
+# existed, every message reported as delivered. This verb resolves and PROVES
+# the target, confirms arrival by an injected token matched against a FLATTENED
+# pane (a prose grep already returned 0 for a message that had arrived), and
+# confirms SUBMISSION — the step that was missing, since text can sit unsent in
+# the composer forever while the agent looks idle.
+from ._agents_deliver import register as _register_agents_deliver  # noqa: E402
+
+_register_agents_deliver(agent_group)
 # `rename` — the ONE verb that moves an agent's name in every place it is
 # written: the spec dir, the spec's own self-references (labels, workdir,
 # overlay path, state-db path, and the SCITEX_TODO_AGENT_ID board

--- a/tests/scitex_agent_container/_delivery/_helpers.py
+++ b/tests/scitex_agent_container/_delivery/_helpers.py
@@ -1,0 +1,164 @@
+"""Hand-rolled seams for the verified-delivery suites. NO mocks, no monkeypatch.
+
+:class:`ComposerPane` is not a stand-in for the thing under test — it is a small
+REAL implementation of the one behaviour the production code reads: an Ink-style
+compose box that accumulates pasted text and empties it when an ``Enter`` is
+accepted. It renders an actual pane STRING, so every production detector in the
+path (``_compose_pending_live``, ``pane_is_busy``, ``prompts``, the auth-banner
+matcher, ``verify_submit_by_advancement``) runs for real against it. The tests
+therefore exercise the shipping algorithms rather than a rehearsal of them.
+
+It can also reproduce the two behaviours that caused the incident, because a test
+that cannot reproduce the bug cannot prove the fix:
+
+* ``drops_enter`` — the Ink TUI silently EATS an ``Enter`` (this is what happens
+  when one is fired into its busy window), so the retry path can be driven and
+  the "text sits unsubmitted" mode can be produced on demand;
+* ``wrap_at`` — the renderer soft-wraps and draws a border through the middle of
+  the pasted text, which is what made a prose grep return 0 for a message that
+  had in fact arrived.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+__all__ = ["ComposerPane", "KeyRecorder", "PasteRecorder", "TickClock"]
+
+_BUSY_MARKER = "esc to interrupt"
+_BANNER = "● Login expired · Please run /login"
+
+
+class ComposerPane:
+    """A real compose box that renders a pane and answers ``Enter``.
+
+    Parameters mirror the failure modes under test rather than the TUI's full
+    behaviour — this is the smallest thing that makes the production detectors
+    give true answers.
+    """
+
+    def __init__(
+        self,
+        *,
+        readable: bool = True,
+        busy_captures: int = 0,
+        drops_enter: int = 0,
+        banner: bool = False,
+        wrap_at: int = 0,
+    ) -> None:
+        self.buffer = ""
+        self.submitted: list[str] = []
+        self.enters = 0
+        self.captures = 0
+        #: Enters that arrived while this pane was rendering a busy marker. The
+        #: Ink TUI eats those, so the production code must never fire one — this
+        #: counter is how a test proves the idle gate held rather than assuming it.
+        self.enters_while_busy = 0
+        self._readable = readable
+        self._busy_captures = busy_captures
+        self._drops_enter = drops_enter
+        self._banner = banner
+        self._wrap_at = wrap_at
+
+    # --- the production signatures -----------------------------------------
+
+    def capture(self, target: str) -> Optional[str]:
+        """``capture_fn(session) -> str | None`` — ``None`` means UNREADABLE.
+
+        Tri-state on purpose: the whole package turns on "uncapturable" never
+        being spelled the same as "captured and clean".
+        """
+        self.captures += 1
+        if not self._readable:
+            return None
+        busy = self.captures <= self._busy_captures
+        return self._render(busy=busy)
+
+    def paste(self, target: str, text: str) -> None:
+        """``paste_fn(session, text)`` — a literal paste appends, never submits."""
+        self.buffer += text
+
+    def send_key(self, target: str, key: str) -> None:
+        """``send_keys_fn(session, key)`` — only ``Enter`` submits, and it can be eaten."""
+        if key != "Enter":
+            return
+        self.enters += 1
+        if self.captures <= self._busy_captures:
+            self.enters_while_busy += 1
+        if self._drops_enter > 0:
+            self._drops_enter -= 1
+            return
+        self.submitted.append(self.buffer)
+        self.buffer = ""
+
+    # --- rendering ----------------------------------------------------------
+
+    def _compose_text(self) -> str:
+        """The live compose row, optionally wrapped through a drawn border.
+
+        ``wrap_at`` splits the buffer across rows and puts a ``│`` at each seam,
+        which is exactly the artefact that defeats a naive substring search.
+        """
+        if not self.buffer:
+            return "❯"
+        if self._wrap_at <= 0:
+            return f"❯ {self.buffer}"
+        chunks = [
+            self.buffer[i : i + self._wrap_at]
+            for i in range(0, len(self.buffer), self._wrap_at)
+        ]
+        head, *rest = chunks
+        rows = [f"❯ {head} │"] + [f"│ {chunk} │" for chunk in rest]
+        return "\n".join(rows)
+
+    def _render(self, *, busy: bool) -> str:
+        lines: list[str] = []
+        for turn in self.submitted:
+            lines.append(f"  {turn}")
+        if self._banner:
+            lines.append(_BANNER)
+        lines.append("─" * 20)
+        lines.append(self._compose_text())
+        lines.append("─" * 20)
+        lines.append(f"  {_BUSY_MARKER}" if busy else "  ctx:1%")
+        return "\n".join(lines) + "\n"
+
+
+class PasteRecorder:
+    """A real ``paste_fn(session, text)`` that records instead of pasting."""
+
+    def __init__(self) -> None:
+        self.pastes: list[tuple[str, str]] = []
+
+    def __call__(self, session: str, text: str) -> None:
+        self.pastes.append((session, text))
+
+
+class KeyRecorder:
+    """A real ``send_keys_fn(session, key)`` that records instead of sending."""
+
+    def __init__(self) -> None:
+        self.keys: list[tuple[str, str]] = []
+
+    def __call__(self, session: str, key: str) -> None:
+        self.keys.append((session, key))
+
+
+class TickClock:
+    """An injected clock whose ONLY advance is an explicit sleep.
+
+    Reading the time never moves it, so a loop that forgets to sleep hangs in the
+    test instead of passing on wall-clock luck — the bound is proven, not hoped
+    for. Every wait budget in this package is therefore verified in milliseconds.
+    """
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.now_value = start
+        self.slept: list[float] = []
+
+    def now(self) -> float:
+        return self.now_value
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now_value += seconds

--- a/tests/scitex_agent_container/_delivery/test__assess.py
+++ b/tests/scitex_agent_container/_delivery/test__assess.py
@@ -1,0 +1,165 @@
+"""The single fold, and the rule that UNKNOWN outranks a refutation.
+
+Every branch is reached from a hand-built state, so the aggregation is proved
+rather than trusted — including the branch that must NOT fire: a blind reading
+can never be argued into a conviction.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._delivery._assess import (
+    EXIT_DELIVERED,
+    EXIT_NO_ROUTE,
+    EXIT_REFUTED,
+    EXIT_UNKNOWN,
+    EXIT_UNSUBMITTED,
+    assess_delivery,
+)
+from scitex_agent_container._delivery._state import DeliveryState
+
+
+def _state(**signals):
+    state = DeliveryState(agent="peer")
+    for name, value in signals.items():
+        state = state.with_signal(name, value, f"{name}={value}")
+    return state
+
+
+def _all_healthy(**overrides):
+    signals = {
+        "is_route_resolved": True,
+        "is_payload_delivered": True,
+        "is_payload_submitted": True,
+    }
+    signals.update(overrides)
+    return _state(**signals)
+
+
+def test_every_signal_healthy_verdicts_true():
+    # Arrange
+    state = _all_healthy()
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert verdict.verdict is True
+
+
+def test_every_signal_healthy_exits_zero():
+    # Arrange
+    state = _all_healthy()
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert verdict.exit_code() == EXIT_DELIVERED
+
+
+def test_default_state_verdicts_unknown():
+    # Arrange
+    state = DeliveryState(agent="peer")
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert verdict.verdict is None
+
+
+def test_unknown_outranks_a_refutation():
+    # Arrange
+    state = _state(is_route_resolved=True, is_payload_delivered=False)
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert verdict.verdict is None
+
+
+def test_unknown_names_the_unread_signal():
+    # Arrange
+    state = _state(is_route_resolved=True, is_payload_delivered=False)
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert verdict.unresolved == ("is_payload_submitted",)
+
+
+def test_unknown_warns_against_blind_resend():
+    # Arrange
+    state = DeliveryState(agent="peer")
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert "Do not resend" in verdict.reason
+
+
+def test_unknown_exits_could_not_determine():
+    # Arrange
+    state = _state(is_route_resolved=True, is_payload_delivered=True)
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert verdict.exit_code() == EXIT_UNKNOWN
+
+
+def test_missing_route_exits_no_route():
+    # Arrange
+    state = _state(
+        is_route_resolved=False,
+        is_payload_delivered=False,
+        is_payload_submitted=False,
+    )
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert verdict.exit_code() == EXIT_NO_ROUTE
+
+
+def test_arrived_but_unsent_exits_unsubmitted():
+    # Arrange
+    state = _all_healthy(is_payload_submitted=False)
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert verdict.exit_code() == EXIT_UNSUBMITTED
+
+
+def test_arrived_but_unsent_verdicts_false():
+    # Arrange
+    state = _all_healthy(is_payload_submitted=False)
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert verdict.verdict is False
+
+
+def test_undelivered_exits_generic_refuted():
+    # Arrange
+    state = _all_healthy(is_payload_delivered=False)
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert verdict.exit_code() == EXIT_REFUTED
+
+
+def test_evidence_signals_never_change_verdict():
+    # Arrange
+    state = _all_healthy(is_login_banner_before=True, is_target_busy_before=True)
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert verdict.verdict is True
+
+
+def test_unreadable_pane_alone_stays_true():
+    # Arrange
+    state = _all_healthy(is_pane_readable=False)
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert verdict.verdict is True
+
+
+def test_refutation_names_the_deciding_signal():
+    # Arrange
+    state = _all_healthy(is_payload_submitted=False)
+    # Act
+    verdict = assess_delivery(state)
+    # Assert
+    assert verdict.deciding == ("is_payload_submitted",)

--- a/tests/scitex_agent_container/_delivery/test__deliver.py
+++ b/tests/scitex_agent_container/_delivery/test__deliver.py
@@ -1,0 +1,464 @@
+"""The four indistinguishable modes, each driven end-to-end and each SEPARATED.
+
+Every test here runs the REAL production path — the real route resolver, the real
+busy classifier, the real auth-banner matcher, the real
+``verify_submit_by_advancement`` — against a hand-rolled compose box that
+reproduces the TUI behaviours that caused the incident. No mocks, no monkeypatch.
+
+The modes, and the exit code each one now produces:
+
+1. TARGET DEAD              → 3 (was: silent success)
+2. TARGET UNREADABLE/BLIND  → 2 (was: silent success)
+3. TEXT SITS UNSUBMITTED    → 4 (was: silent success)
+4. VERIFICATION LIES        → 0, correctly, where a prose grep said "not
+                                delivered" about a message that had arrived
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._delivery import (
+    EXIT_DELIVERED,
+    EXIT_NO_ROUTE,
+    EXIT_UNKNOWN,
+    EXIT_UNSUBMITTED,
+    assess_delivery,
+    deliver,
+)
+
+from ._helpers import ComposerPane, TickClock
+
+
+class SessionLister:
+    """A real ``list_sessions_fn() -> list[str] | None``."""
+
+    def __init__(self, sessions):
+        self._sessions = sessions
+
+    def __call__(self):
+        return self._sessions
+
+
+class SessionIdReader:
+    """A real ``session_id_fn(agent) -> str | None``."""
+
+    def __init__(self, session_id):
+        self._session_id = session_id
+
+    def __call__(self, agent):
+        return self._session_id
+
+
+class SdkSender:
+    """A real ``sdk_send_fn(agent, payload) -> (bool | None, str)``."""
+
+    def __init__(self, outcome):
+        self._outcome = outcome
+        self.calls = []
+
+    def __call__(self, agent, payload):
+        self.calls.append((agent, payload))
+        return self._outcome
+
+
+def _deliver(pane, *, sessions=("tui-peer",), max_resends=3, **overrides):
+    """Run the production ``deliver`` against ``pane``, on an injected clock."""
+    clock = TickClock()
+    kwargs = dict(
+        strategy="tui",
+        list_sessions_fn=SessionLister(list(sessions)),
+        capture_fn=pane.capture,
+        paste_fn=pane.paste,
+        send_keys_fn=pane.send_key,
+        time_fn=clock.now,
+        sleep_fn=clock.sleep,
+        clock_fn=lambda: 1_800_000_000.0,
+        poll_s=0.1,
+        arrival_timeout_s=2.0,
+        idle_wait_s=2.0,
+        max_resends=max_resends,
+    )
+    kwargs.update(overrides)
+    return deliver("peer", "please rebase onto develop", **kwargs)
+
+
+# --- the happy path ---------------------------------------------------------
+
+
+def test_idle_target_reports_delivered_verdict():
+    # Arrange
+    pane = ComposerPane()
+    # Act
+    verdict = assess_delivery(_deliver(pane))
+    # Assert
+    assert verdict.verdict is True
+
+
+def test_idle_target_exits_delivered_code():
+    # Arrange
+    pane = ComposerPane()
+    # Act
+    verdict = assess_delivery(_deliver(pane))
+    # Assert
+    assert verdict.exit_code() == EXIT_DELIVERED
+
+
+def test_delivered_payload_reaches_the_transcript():
+    # Arrange
+    pane = ComposerPane()
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert state.token in pane.submitted[0]
+
+
+def test_successful_send_needs_one_enter():
+    # Arrange
+    pane = ComposerPane()
+    # Act
+    _deliver(pane)
+    # Assert
+    assert pane.enters == 1
+
+
+# --- mode 1: TARGET DEAD ----------------------------------------------------
+
+
+def test_missing_session_exits_no_route():
+    # Arrange
+    pane = ComposerPane()
+    # Act
+    verdict = assess_delivery(_deliver(pane, sessions=("tui-someone-else",)))
+    # Assert
+    assert verdict.exit_code() == EXIT_NO_ROUTE
+
+
+def test_missing_session_never_pastes_anything():
+    # Arrange
+    pane = ComposerPane()
+    # Act
+    _deliver(pane, sessions=("tui-someone-else",))
+    # Assert
+    assert pane.buffer == ""
+
+
+def test_missing_session_states_a_known_negative():
+    # Arrange
+    pane = ComposerPane()
+    # Act
+    state = _deliver(pane, sessions=("tui-someone-else",))
+    # Assert
+    assert state.is_payload_delivered is False
+
+
+# --- mode 1b: BLIND, which must NOT read as dead ----------------------------
+
+
+def test_empty_enumeration_exits_unknown_not_dead():
+    # Arrange
+    pane = ComposerPane()
+    # Act
+    verdict = assess_delivery(_deliver(pane, sessions=()))
+    # Assert
+    assert verdict.exit_code() == EXIT_UNKNOWN
+
+
+# --- mode 2: UNREADABLE PANE ------------------------------------------------
+
+
+def test_unreadable_pane_exits_could_not_determine():
+    # Arrange
+    pane = ComposerPane(readable=False)
+    # Act
+    verdict = assess_delivery(_deliver(pane))
+    # Assert
+    assert verdict.exit_code() == EXIT_UNKNOWN
+
+
+def test_unreadable_pane_reports_arrival_unknown():
+    # Arrange
+    pane = ComposerPane(readable=False)
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert state.is_payload_delivered is None
+
+
+def test_unreadable_pane_never_claims_submission():
+    # Arrange
+    pane = ComposerPane(readable=False)
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert state.is_payload_submitted is None
+
+
+def test_blind_submit_is_named_vacuous():
+    # Arrange
+    pane = ComposerPane(readable=False)
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert "vacuous" in state.reason_for("is_payload_submitted")
+
+
+def test_unreadable_pane_is_reported_unreadable():
+    # Arrange
+    pane = ComposerPane(readable=False)
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert state.is_pane_readable is False
+
+
+# --- mode 3: TEXT SITS UNSUBMITTED IN THE COMPOSER --------------------------
+
+
+def test_dropped_enters_exit_unsubmitted_code():
+    # Arrange
+    pane = ComposerPane(drops_enter=99)
+    # Act
+    verdict = assess_delivery(_deliver(pane))
+    # Assert
+    assert verdict.exit_code() == EXIT_UNSUBMITTED
+
+
+def test_unsubmitted_still_reports_arrival_true():
+    # Arrange
+    pane = ComposerPane(drops_enter=99)
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert state.is_payload_delivered is True
+
+
+def test_unsubmitted_advises_against_resending():
+    # Arrange
+    pane = ComposerPane(drops_enter=99)
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert "Do NOT resend" in state.reason_for("is_payload_submitted")
+
+
+def test_submit_retry_recovers_a_dropped_enter():
+    # Arrange
+    pane = ComposerPane(drops_enter=1)
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert state.is_payload_submitted is True
+
+
+def test_recovering_retry_sends_a_second_enter():
+    # Arrange
+    pane = ComposerPane(drops_enter=1)
+    # Act
+    _deliver(pane)
+    # Assert
+    assert pane.enters == 2
+
+
+def test_submit_budget_is_bounded_by_resends():
+    # Arrange
+    pane = ComposerPane(drops_enter=99)
+    # Act
+    _deliver(pane, max_resends=2)
+    # Assert
+    assert pane.enters == 2
+
+
+# --- the busy window, which is what EATS the Enter --------------------------
+
+
+def test_busy_target_gets_no_enter_while_busy():
+    # Arrange
+    pane = ComposerPane(busy_captures=4)
+    # Act
+    _deliver(pane)
+    # Assert
+    assert pane.enters_while_busy == 0
+
+
+def test_busy_target_still_delivers_successfully():
+    # Arrange
+    pane = ComposerPane(busy_captures=4)
+    # Act
+    verdict = assess_delivery(_deliver(pane))
+    # Assert
+    assert verdict.verdict is True
+
+
+def test_busy_before_send_is_recorded():
+    # Arrange
+    pane = ComposerPane(busy_captures=4)
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert state.is_target_busy_before is True
+
+
+def test_busy_evidence_does_not_refute_delivery():
+    # Arrange
+    pane = ComposerPane(busy_captures=4)
+    # Act
+    verdict = assess_delivery(_deliver(pane))
+    # Assert
+    assert verdict.exit_code() == EXIT_DELIVERED
+
+
+# --- mode 4: THE VERIFICATION ITSELF LIES -----------------------------------
+
+
+def test_wrapped_render_still_confirms_arrival():
+    # Arrange
+    pane = ComposerPane(wrap_at=8)
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert state.is_payload_delivered is True
+
+
+def test_wrapped_render_exits_delivered_code():
+    # Arrange
+    pane = ComposerPane(wrap_at=8)
+    # Act
+    verdict = assess_delivery(_deliver(pane))
+    # Assert
+    assert verdict.exit_code() == EXIT_DELIVERED
+
+
+def test_wrapped_token_defeats_naive_substring():
+    # Arrange
+    pane = ComposerPane(wrap_at=8)
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert state.token not in state.raw["pane_after_paste"]
+
+
+# --- the auth banner, surfaced but never allowed to refute ------------------
+
+
+def test_login_banner_before_send_is_surfaced():
+    # Arrange
+    pane = ComposerPane(banner=True)
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert state.is_login_banner_before is True
+
+
+def test_login_banner_does_not_refute_delivery():
+    # Arrange
+    pane = ComposerPane(banner=True)
+    # Act
+    verdict = assess_delivery(_deliver(pane))
+    # Assert
+    assert verdict.verdict is True
+
+
+# --- ONE verb, TWO strategies -----------------------------------------------
+
+
+def test_recorded_session_uses_the_sdk_path():
+    # Arrange
+    sender = SdkSender((True, "send_to_agent completed the turn"))
+    # Act
+    _deliver(
+        ComposerPane(),
+        strategy="auto",
+        session_id_fn=SessionIdReader("sid-abc"),
+        sdk_send_fn=sender,
+    )
+    # Assert
+    assert len(sender.calls) == 1
+
+
+def test_sdk_path_never_touches_the_pane():
+    # Arrange
+    pane = ComposerPane()
+    # Act
+    _deliver(
+        pane,
+        strategy="auto",
+        session_id_fn=SessionIdReader("sid-abc"),
+        sdk_send_fn=SdkSender((True, "ok")),
+    )
+    # Assert
+    assert pane.captures == 0
+
+
+def test_sdk_success_verdicts_delivered():
+    # Arrange
+    sender = SdkSender((True, "send_to_agent completed the turn"))
+    # Act
+    verdict = assess_delivery(
+        _deliver(
+            ComposerPane(),
+            strategy="auto",
+            session_id_fn=SessionIdReader("sid-abc"),
+            sdk_send_fn=sender,
+        )
+    )
+    # Assert
+    assert verdict.verdict is True
+
+
+def test_sdk_timeout_verdicts_could_not_determine():
+    # Arrange
+    sender = SdkSender((None, "timed out waiting for the reply"))
+    # Act
+    verdict = assess_delivery(
+        _deliver(
+            ComposerPane(),
+            strategy="auto",
+            session_id_fn=SessionIdReader("sid-abc"),
+            sdk_send_fn=sender,
+        )
+    )
+    # Assert
+    assert verdict.exit_code() == EXIT_UNKNOWN
+
+
+def test_sdk_path_records_its_strategy():
+    # Arrange
+    sender = SdkSender((True, "ok"))
+    # Act
+    state = _deliver(
+        ComposerPane(),
+        strategy="auto",
+        session_id_fn=SessionIdReader("sid-abc"),
+        sdk_send_fn=sender,
+    )
+    # Assert
+    assert state.strategy == "sdk"
+
+
+def test_tui_path_records_its_strategy():
+    # Arrange
+    pane = ComposerPane()
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert state.strategy == "tui"
+
+
+# --- the payload carries a greppable token ----------------------------------
+
+
+def test_pasted_payload_carries_the_token():
+    # Arrange
+    pane = ComposerPane()
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert f"[sac-deliver:{state.token}]" in pane.submitted[0]
+
+
+def test_elapsed_time_is_always_stamped():
+    # Arrange
+    pane = ComposerPane()
+    # Act
+    state = _deliver(pane)
+    # Assert
+    assert state.elapsed is not None

--- a/tests/scitex_agent_container/_delivery/test__route.py
+++ b/tests/scitex_agent_container/_delivery/test__route.py
@@ -1,0 +1,122 @@
+"""Route resolution — and the rule that an empty enumeration may not convict."""
+
+from __future__ import annotations
+
+from scitex_agent_container._delivery._route import (
+    STRATEGY_SDK,
+    STRATEGY_TUI,
+    resolve_route,
+)
+
+
+class SessionLister:
+    """A real ``list_sessions_fn() -> list[str] | None`` returning a fixed answer."""
+
+    def __init__(self, sessions):
+        self._sessions = sessions
+        self.calls = 0
+
+    def __call__(self):
+        self.calls += 1
+        return self._sessions
+
+
+class SessionIdReader:
+    """A real ``session_id_fn(agent) -> str | None`` returning a fixed answer."""
+
+    def __init__(self, session_id):
+        self._session_id = session_id
+
+    def __call__(self, agent):
+        return self._session_id
+
+
+def test_present_session_resolves_the_route():
+    # Arrange
+    lister = SessionLister(["tui-peer", "tui-other"])
+    # Act
+    route = resolve_route("peer", strategy=STRATEGY_TUI, list_sessions_fn=lister)
+    # Assert
+    assert route.resolved is True
+
+
+def test_absent_among_others_refutes_route():
+    # Arrange
+    lister = SessionLister(["tui-other", "tui-third"])
+    # Act
+    route = resolve_route("peer", strategy=STRATEGY_TUI, list_sessions_fn=lister)
+    # Assert
+    assert route.resolved is False
+
+
+def test_empty_enumeration_refuses_to_convict():
+    # Arrange
+    lister = SessionLister([])
+    # Act
+    route = resolve_route("peer", strategy=STRATEGY_TUI, list_sessions_fn=lister)
+    # Assert
+    assert route.resolved is None
+
+
+def test_failed_enumeration_renders_unknown_route():
+    # Arrange
+    lister = SessionLister(None)
+    # Act
+    route = resolve_route("peer", strategy=STRATEGY_TUI, list_sessions_fn=lister)
+    # Assert
+    assert route.resolved is None
+
+
+def test_empty_enumeration_names_the_namespace_reason():
+    # Arrange
+    lister = SessionLister([])
+    # Act
+    route = resolve_route("peer", strategy=STRATEGY_TUI, list_sessions_fn=lister)
+    # Assert
+    assert "mount namespace" in route.reason
+
+
+def test_recorded_session_id_selects_sdk():
+    # Arrange
+    reader = SessionIdReader("sid-abc123")
+    # Act
+    route = resolve_route("peer", strategy="auto", session_id_fn=reader)
+    # Assert
+    assert route.strategy == STRATEGY_SDK
+
+
+def test_missing_session_id_falls_back_tui():
+    # Arrange
+    lister = SessionLister(["tui-peer"])
+    # Act
+    route = resolve_route(
+        "peer",
+        strategy="auto",
+        list_sessions_fn=lister,
+        session_id_fn=SessionIdReader(None),
+    )
+    # Assert
+    assert route.strategy == STRATEGY_TUI
+
+
+def test_auto_never_enumerates_when_sdk_resolves():
+    # Arrange
+    lister = SessionLister(["tui-peer"])
+    # Act
+    resolve_route(
+        "peer",
+        strategy="auto",
+        list_sessions_fn=lister,
+        session_id_fn=SessionIdReader("sid-abc123"),
+    )
+    # Assert
+    assert lister.calls == 0
+
+
+def test_forced_sdk_without_session_refutes():
+    # Arrange
+    reader = SessionIdReader(None)
+    # Act
+    route = resolve_route("peer", strategy=STRATEGY_SDK, session_id_fn=reader)
+    # Assert
+    assert route.resolved is False

--- a/tests/scitex_agent_container/_delivery/test__sdk_strategy.py
+++ b/tests/scitex_agent_container/_delivery/test__sdk_strategy.py
@@ -1,0 +1,101 @@
+"""The SDK strategy — and the statuses that must NOT be read as a delivery.
+
+``dispatched`` is the dangerous one: it means "the agent looks reachable, here is
+a command you can run to actually send it". Reading that as a delivered message
+would rebuild the original bug one layer up, so it is pinned here explicitly.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._delivery._sdk_strategy import deliver_via_sdk
+from scitex_agent_container._delivery._state import DeliveryState
+
+
+class Sender:
+    """A real ``sdk_send_fn(agent, payload) -> (bool | None, str)``."""
+
+    def __init__(self, outcome):
+        self._outcome = outcome
+        self.calls = []
+
+    def __call__(self, agent, payload):
+        self.calls.append((agent, payload))
+        return self._outcome
+
+
+def _sent(outcome):
+    return deliver_via_sdk(
+        DeliveryState(agent="peer"), "peer", "[sac-deliver:abc] hi", Sender(outcome)
+    )
+
+
+def test_completed_turn_reports_delivered_true():
+    # Arrange
+    outcome = (True, "send_to_agent completed the turn (status='ok')")
+    # Act
+    state = _sent(outcome)
+    # Assert
+    assert state.is_payload_delivered is True
+
+
+def test_completed_turn_reports_submitted_true():
+    # Arrange
+    outcome = (True, "send_to_agent completed the turn (status='ok')")
+    # Act
+    state = _sent(outcome)
+    # Assert
+    assert state.is_payload_submitted is True
+
+
+def test_refused_turn_reports_delivered_false():
+    # Arrange
+    outcome = (False, "send_to_agent refused the turn (status='error')")
+    # Act
+    state = _sent(outcome)
+    # Assert
+    assert state.is_payload_delivered is False
+
+
+def test_unknown_outcome_stays_unknown():
+    # Arrange
+    outcome = (None, "send_to_agent timed out waiting for the reply")
+    # Act
+    state = _sent(outcome)
+    # Assert
+    assert state.is_payload_delivered is None
+
+
+def test_sdk_path_leaves_pane_readable_none():
+    # Arrange
+    outcome = (True, "ok")
+    # Act
+    state = _sent(outcome)
+    # Assert
+    assert state.is_pane_readable is None
+
+
+def test_sdk_path_records_the_send_detail():
+    # Arrange
+    outcome = (True, "send_to_agent completed the turn (status='ok')")
+    # Act
+    state = _sent(outcome)
+    # Assert
+    assert state.raw["send_detail"] == "send_to_agent completed the turn (status='ok')"
+
+
+def test_submission_reason_explains_no_composer():
+    # Arrange
+    outcome = (True, "ok")
+    # Act
+    state = _sent(outcome)
+    # Assert
+    assert "no composer" in state.reason_for("is_payload_submitted")
+
+
+def test_sender_receives_the_tokenised_payload():
+    # Arrange
+    sender = Sender((True, "ok"))
+    # Act
+    deliver_via_sdk(DeliveryState(agent="peer"), "peer", "[sac-deliver:abc] hi", sender)
+    # Assert
+    assert sender.calls == [("peer", "[sac-deliver:abc] hi")]

--- a/tests/scitex_agent_container/_delivery/test__spec.py
+++ b/tests/scitex_agent_container/_delivery/test__spec.py
@@ -1,0 +1,106 @@
+"""The spec table's guardrails — MUTATION-PROVED, not merely called.
+
+Each invariant is driven with a table built to VIOLATE it, so these tests would
+go red if the check were deleted. A validator nobody has watched reject anything
+is a hope with a function signature around it.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+
+import pytest
+
+from scitex_agent_container._delivery._spec import (
+    DELIVERY_SIGNALS,
+    OBSERVATION_DIRECT,
+    OBSERVATION_INFERRED,
+    DeliverySignalSpec,
+    delivery_spec_for,
+    validate_delivery_specs,
+)
+
+
+def _spec(name, **kwargs):
+    base = dict(
+        name=name,
+        reads="whatever",
+        healthy=True,
+        load_bearing=True,
+        why="test fixture",
+    )
+    base.update(kwargs)
+    return DeliverySignalSpec(**base)
+
+
+def test_shipped_table_validates_at_import():
+    # Arrange
+    table = DELIVERY_SIGNALS
+    # Act
+    result = validate_delivery_specs(table)
+    # Assert
+    assert result is None
+
+
+def test_no_shipped_signal_is_decisive():
+    # Arrange
+    table = DELIVERY_SIGNALS
+    # Act
+    decisive = [s.name for s in table if s.decisive]
+    # Assert
+    assert decisive == []
+
+
+def test_duplicate_signal_name_is_rejected():
+    # Arrange
+    bad = (_spec("is_route_resolved"), _spec("is_route_resolved"))
+    # Act
+    validating = partial(validate_delivery_specs, bad)
+    # Assert
+    with pytest.raises(ValueError, match="duplicate delivery signal"):
+        validating()
+
+
+def test_decisive_inferred_signal_is_rejected():
+    # Arrange
+    bad = (_spec("x", decisive=True, observation=OBSERVATION_INFERRED),)
+    # Act
+    validating = partial(validate_delivery_specs, bad)
+    # Assert
+    with pytest.raises(ValueError, match="DECISIVE REQUIRES DIRECT OBSERVATION"):
+        validating()
+
+
+def test_decisive_non_load_bearing_is_rejected():
+    # Arrange
+    bad = (
+        _spec("x", decisive=True, load_bearing=False, observation=OBSERVATION_DIRECT),
+    )
+    # Act
+    validating = partial(validate_delivery_specs, bad)
+    # Assert
+    with pytest.raises(ValueError, match="cannot short-circuit"):
+        validating()
+
+
+def test_unknown_signal_name_raises_keyerror():
+    # Arrange
+    name = "is_totally_invented"
+    # Act
+    looking_up = partial(delivery_spec_for, name)
+    # Assert
+    with pytest.raises(KeyError, match="unknown delivery signal"):
+        looking_up()
+
+
+def test_three_signals_are_load_bearing():
+    # Arrange
+    table = DELIVERY_SIGNALS
+    # Act
+    load_bearing = [s.name for s in table if s.load_bearing]
+    # Assert
+    assert load_bearing == [
+        "is_route_resolved",
+        "is_payload_delivered",
+        "is_payload_submitted",
+    ]

--- a/tests/scitex_agent_container/_delivery/test__state.py
+++ b/tests/scitex_agent_container/_delivery/test__state.py
@@ -1,0 +1,117 @@
+"""``DeliveryState`` refuses the shapes that let an UNKNOWN become a pole."""
+
+from __future__ import annotations
+
+from functools import partial
+
+import pytest
+
+from scitex_agent_container._delivery._state import DeliveryState
+
+
+def test_default_signals_are_all_none():
+    # Arrange
+    state = DeliveryState(agent="peer")
+    # Act
+    values = set(state.signals().values())
+    # Assert
+    assert values == {None}
+
+
+def test_unknown_constructor_reasons_every_signal():
+    # Arrange
+    state = DeliveryState.unknown("peer", "nobody looked")
+    # Act
+    reasons = set(state.reasons.values())
+    # Assert
+    assert reasons == {"nobody looked"}
+
+
+def test_non_bool_signal_raises_typeerror():
+    # Arrange
+    building = partial(DeliveryState, agent="peer", is_route_resolved="yes")
+    # Act
+    constructing = building
+    # Assert
+    with pytest.raises(TypeError, match="must be True, False or None"):
+        constructing()
+
+
+def test_integer_signal_raises_typeerror_too():
+    # Arrange
+    building = partial(DeliveryState, agent="peer", is_payload_submitted=1)
+    # Act
+    constructing = building
+    # Assert
+    with pytest.raises(TypeError, match="must be True, False or None"):
+        constructing()
+
+
+def test_unknown_reason_key_is_rejected():
+    # Arrange
+    building = partial(DeliveryState, agent="peer", reasons={"is_not_a_signal": "oops"})
+    # Act
+    constructing = building
+    # Assert
+    with pytest.raises(KeyError, match="unknown delivery signal"):
+        constructing()
+
+
+def test_with_signal_records_its_reason():
+    # Arrange
+    state = DeliveryState(agent="peer")
+    # Act
+    updated = state.with_signal("is_route_resolved", True, "session present")
+    # Assert
+    assert updated.reason_for("is_route_resolved") == "session present"
+
+
+def test_with_signal_keeps_raw_evidence():
+    # Arrange
+    state = DeliveryState(agent="peer")
+    # Act
+    updated = state.with_signal(
+        "is_payload_delivered", True, "token seen", pane_after_paste="❯ hi\n"
+    )
+    # Assert
+    assert updated.raw["pane_after_paste"] == "❯ hi\n"
+
+
+def test_with_signal_leaves_original_untouched():
+    # Arrange
+    state = DeliveryState(agent="peer")
+    # Act
+    state.with_signal("is_route_resolved", True, "session present")
+    # Assert
+    assert state.is_route_resolved is None
+
+
+def test_signals_always_returns_full_set():
+    # Arrange
+    state = DeliveryState(agent="peer").with_signal("is_route_resolved", True)
+    # Act
+    names = sorted(state.signals())
+    # Assert
+    assert len(names) == 6
+
+
+def test_to_dict_carries_the_raw_captures():
+    # Arrange
+    state = DeliveryState(agent="peer").with_signal(
+        "is_payload_delivered", False, "no token", pane_after_paste="❯\n"
+    )
+    # Act
+    payload = state.to_dict()
+    # Assert
+    assert payload["raw"]["pane_after_paste"] == "❯\n"
+
+
+def test_to_dict_reports_a_false_signal():
+    # Arrange
+    state = DeliveryState(agent="peer").with_signal(
+        "is_payload_submitted", False, "still pending"
+    )
+    # Act
+    payload = state.to_dict()
+    # Assert
+    assert payload["signals"]["is_payload_submitted"]["value"] is False

--- a/tests/scitex_agent_container/_delivery/test__token.py
+++ b/tests/scitex_agent_container/_delivery/test__token.py
@@ -1,0 +1,102 @@
+"""The arrival matcher must survive what the TUI does to the token.
+
+The negative these tests pin is the one that already happened: a search that
+returns "not delivered" about a message sitting on the peer's screen.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._delivery._token import (
+    DELIVERY_TOKEN_BYTES,
+    flatten_pane,
+    format_payload,
+    make_token,
+    pane_contains_token,
+)
+
+#: A token split across a soft wrap with the composer's border drawn through the
+#: seam — byte-for-byte the shape that defeated a naive substring search.
+_WRAPPED = (
+    "  earlier turn\n────────\n❯ [sac-deliver:ab12cd │\n│ 34ef56] hello │\n────────\n"
+)
+
+
+def test_token_survives_wrapped_border_split():
+    # Arrange
+    pane = _WRAPPED
+    # Act
+    found = pane_contains_token(pane, "ab12cd34ef56")
+    # Assert
+    assert found is True
+
+
+def test_raw_substring_search_would_have_failed():
+    # Arrange
+    pane = _WRAPPED
+    # Act
+    naive = "ab12cd34ef56" in pane
+    # Assert
+    assert naive is False
+
+
+def test_single_occurrence_counts_as_delivered():
+    # Arrange
+    pane = "❯ [sac-deliver:deadbeef0123] hello\n"
+    # Act
+    found = pane_contains_token(pane, "deadbeef0123")
+    # Assert
+    assert found is True
+
+
+def test_unreadable_pane_renders_none_not_false():
+    # Arrange
+    pane = None
+    # Act
+    found = pane_contains_token(pane, "deadbeef0123")
+    # Assert
+    assert found is None
+
+
+def test_absent_token_renders_false_cleanly():
+    # Arrange
+    pane = "❯ nothing of interest here\n"
+    # Act
+    found = pane_contains_token(pane, "deadbeef0123")
+    # Assert
+    assert found is False
+
+
+def test_flatten_strips_every_border_artefact():
+    # Arrange
+    pane = "│ AB 12 │\n│ cd-34 │\n"
+    # Act
+    flat = flatten_pane(pane)
+    # Assert
+    assert flat == "ab12cd34"
+
+
+def test_payload_places_token_before_message():
+    # Arrange
+    token = "deadbeef0123"
+    # Act
+    payload = format_payload("hello there", token)
+    # Assert
+    assert payload == "[sac-deliver:deadbeef0123] hello there"
+
+
+def test_generated_token_is_twelve_hex():
+    # Arrange
+    expected_length = DELIVERY_TOKEN_BYTES * 2
+    # Act
+    token = make_token()
+    # Assert
+    assert len(token) == expected_length
+
+
+def test_two_tokens_are_not_equal():
+    # Arrange
+    first = make_token()
+    # Act
+    second = make_token()
+    # Assert
+    assert first != second

--- a/tests/scitex_agent_container/_delivery/test__tui_strategy.py
+++ b/tests/scitex_agent_container/_delivery/test__tui_strategy.py
@@ -1,0 +1,223 @@
+"""The TUI strategy's own units — especially the guard that got this wrong once.
+
+``_submission_signal`` is tested directly and exhaustively because its BRANCH
+ORDER is the whole correctness argument: the wholly-blind check must run BEFORE
+``submitted`` is consulted, since the submit verifier returns ``True`` from its
+"nothing pending to force" phase even when every capture it read was the empty
+string substituted for an unreadable pane.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._delivery._state import DeliveryState
+from scitex_agent_container._delivery._tui_strategy import (
+    CaptureTap,
+    _submission_signal,
+    observe_pane_before,
+)
+
+_IDLE = "  earlier turn\n────────\n❯\n────────\n  ctx:1%\n"
+_BUSY = "  earlier turn\n────────\n❯\n────────\n  esc to interrupt\n"
+_BANNER = "● Login expired · Please run /login\n────────\n❯\n────────\n  ctx:1%\n"
+
+
+class ScriptedCapture:
+    """A real ``capture_fn(session) -> str | None`` returning a fixed answer."""
+
+    def __init__(self, pane):
+        self._pane = pane
+
+    def __call__(self, session):
+        return self._pane
+
+
+def _signal(**kwargs):
+    base = dict(
+        submitted=True,
+        readable_during=5,
+        blind_during=0,
+        max_resends=8,
+        session="tui-peer",
+    )
+    base.update(kwargs)
+    return _submission_signal(**base)
+
+
+# --- _submission_signal: the tri-state guard --------------------------------
+
+
+def test_observed_clear_reports_submitted_true():
+    # Arrange
+    kwargs = dict(submitted=True, readable_during=5, blind_during=0)
+    # Act
+    value, _ = _signal(**kwargs)
+    # Assert
+    assert value is True
+
+
+def test_wholly_blind_window_refuses_a_verdict():
+    # Arrange
+    kwargs = dict(submitted=True, readable_during=0, blind_during=40)
+    # Act
+    value, _ = _signal(**kwargs)
+    # Assert
+    assert value is None
+
+
+def test_wholly_blind_window_names_it_vacuous():
+    # Arrange
+    kwargs = dict(submitted=True, readable_during=0, blind_during=40)
+    # Act
+    _, reason = _signal(**kwargs)
+    # Assert
+    assert "vacuous" in reason
+
+
+def test_partly_blind_failure_is_not_refutation():
+    # Arrange
+    kwargs = dict(submitted=False, readable_during=3, blind_during=2)
+    # Act
+    value, _ = _signal(**kwargs)
+    # Assert
+    assert value is None
+
+
+def test_partly_blind_success_is_still_trusted():
+    # Arrange
+    kwargs = dict(submitted=True, readable_during=3, blind_during=2)
+    # Act
+    value, _ = _signal(**kwargs)
+    # Assert
+    assert value is True
+
+
+def test_fully_observed_failure_refutes_cleanly():
+    # Arrange
+    kwargs = dict(submitted=False, readable_during=9, blind_during=0)
+    # Act
+    value, _ = _signal(**kwargs)
+    # Assert
+    assert value is False
+
+
+def test_observed_failure_forbids_a_resend():
+    # Arrange
+    kwargs = dict(submitted=False, readable_during=9, blind_during=0)
+    # Act
+    _, reason = _signal(**kwargs)
+    # Assert
+    assert "Do NOT resend" in reason
+
+
+def test_observed_failure_offers_the_attach_hint():
+    # Arrange
+    kwargs = dict(submitted=False, readable_during=9, blind_during=0)
+    # Act
+    _, reason = _signal(**kwargs)
+    # Assert
+    assert "tmux attach -t tui-peer" in reason
+
+
+# --- CaptureTap: the tri-state that the verifier's type cannot hold ---------
+
+
+def test_tap_counts_an_unreadable_capture():
+    # Arrange
+    tap = CaptureTap(ScriptedCapture(None))
+    # Act
+    tap("tui-peer")
+    # Assert
+    assert tap.unreadable == 1
+
+
+def test_tap_substitutes_empty_for_unreadable():
+    # Arrange
+    tap = CaptureTap(ScriptedCapture(None))
+    # Act
+    seen = tap("tui-peer")
+    # Assert
+    assert seen == ""
+
+
+def test_tap_read_preserves_the_none():
+    # Arrange
+    tap = CaptureTap(ScriptedCapture(None))
+    # Act
+    seen = tap.read("tui-peer")
+    # Assert
+    assert seen is None
+
+
+def test_tap_remembers_the_last_readable():
+    # Arrange
+    tap = CaptureTap(ScriptedCapture(_IDLE))
+    # Act
+    tap("tui-peer")
+    # Assert
+    assert tap.last_readable == _IDLE
+
+
+# --- observe_pane_before: evidence, never a veto ----------------------------
+
+
+def test_busy_pane_is_observed_busy():
+    # Arrange
+    state = DeliveryState(agent="peer")
+    # Act
+    observed = observe_pane_before(state, _BUSY)
+    # Assert
+    assert observed.is_target_busy_before is True
+
+
+def test_idle_pane_is_observed_not_busy():
+    # Arrange
+    state = DeliveryState(agent="peer")
+    # Act
+    observed = observe_pane_before(state, _IDLE)
+    # Assert
+    assert observed.is_target_busy_before is False
+
+
+def test_banner_pane_is_observed_banner():
+    # Arrange
+    state = DeliveryState(agent="peer")
+    # Act
+    observed = observe_pane_before(state, _BANNER)
+    # Assert
+    assert observed.is_login_banner_before is True
+
+
+def test_banner_reason_flags_it_uncorroborated():
+    # Arrange
+    state = DeliveryState(agent="peer")
+    # Act
+    observed = observe_pane_before(state, _BANNER)
+    # Assert
+    assert "UNCORROBORATED" in observed.reason_for("is_login_banner_before")
+
+
+def test_unreadable_pane_leaves_busy_unknown():
+    # Arrange
+    state = DeliveryState(agent="peer")
+    # Act
+    observed = observe_pane_before(state, None)
+    # Assert
+    assert observed.is_target_busy_before is None
+
+
+def test_unreadable_pane_marks_pane_unreadable():
+    # Arrange
+    state = DeliveryState(agent="peer")
+    # Act
+    observed = observe_pane_before(state, None)
+    # Assert
+    assert observed.is_pane_readable is False
+
+
+def test_readable_pane_keeps_the_raw_capture():
+    # Arrange
+    state = DeliveryState(agent="peer")
+    # Act
+    observed = observe_pane_before(state, _IDLE)
+    # Assert
+    assert observed.raw["pane_before"] == _IDLE


### PR DESCRIPTION
## The problem

Agents talk by `tmux send-keys` into a peer's pane and learn **nothing** about whether it worked. `send-keys` into a session that does not exist prints "can't find pane" to a stderr nobody reads and **exits 0**, so four completely different outcomes are indistinguishable from the sender's side:

1. **TARGET DEAD** — the session does not exist. An operator coordinated with `tui-dotfiles` for hours; every message vanished and every one was reported as delivered.
2. **TARGET WEDGED** — the pane exists, nothing ever submits.
3. **TEXT SITS UNSUBMITTED IN THE COMPOSER** — the message landed (confirmed by reading the pane) and the agent stayed idle. A bare `Enter` into that pane started it working immediately.
4. **THE VERIFICATION ITSELF LIES** — a pane grepped for a prose fragment returned 0 about a message that *had* arrived; the TUI had re-rendered and wrapped it.

## What this is

`sac agents deliver <name> <message>` — **one verb, two strategies**, and a tri-state answer either way.

This is deliberately **thin wiring over parts that already existed**. Every hard piece was already in this repo and had simply never been composed into a single answerable question:

| Existing part | What it already solved |
|---|---|
| `_lifecycle/liveness_probe.py` | nonce generation, `pane_is_busy` (the fleet's busy-marker SSOT) |
| `runtimes/_tui_compose.verify_submit_by_advancement` | **mode 3, already root-caused** on the boot path (card `sac-tui-enter-drop-on-boot`) |
| `_runners/_tmux/tmux.send_text_literal` | the `-l` flag the Ink TUI requires |
| `cli_pkg/_auth_status._capture` | default-server capture with `-J`, `None` on error |
| `cli_pkg/_send.send_to_agent` | the existing send path, now *preferred* when it applies |

### Why the trailing Enter did not take

Already answered in this repo, and it is **both** suspected causes at once: the Ink/React TUI silently drops **non-literal** `send-keys` (so the paste must be `-l` and the submit a *separate* named `Enter`), and it **eats an `Enter` fired while the pane is BUSY** — a window a `UserPromptSubmit` hook alone can hold for 30s. A blind `send-keys text Enter` loses the submit whenever the peer happens to be working. The fix is not a longer sleep: wait for idle, send one Enter, verify the buffer advanced, retry bounded. `verify_submit_by_advancement` already does exactly this, so this PR **calls it** rather than growing a second copy that could drift from the boot path.

### Two things that are genuinely new

**The arrival matcher (mode 4).** A short **injected** 12-hex-char token, matched against a **flattened** pane (every non-alphanumeric stripped). `-J` rejoins tmux's own wraps but cannot undo the TUI's box-drawing, so flattening is what makes the match wrap-proof. Collision risk is about 1e-10 per capture; the false *negative* it replaces was measured and recurring.

It reuses `pane_has_nonce_echo` **with `min_occurrences=1`, not the default 2**. That default encodes a ROUND-TRIP ECHO assumption ("repeat this nonce back to me") where the sender's own prompt contributes the first occurrence. Plain delivery has no round trip — the token appears once — so the default would report **every successful delivery as a failure**. Stated in a comment at the call site.

**The empty-enumeration rule (mode 1, the subtle half).** "`tui-<agent>` is not in the session list" is evidence of absence *only if the list was capable of showing it*. A process in a different mount namespace sees the host's tmux as an **empty** list, and empty-read-as-dead is a measured false DEAD. So: enumeration failed then `None`; enumeration returned `[]` then `None`; enumeration showed **others** then `False`; showed ours then `True`. Only the third may convict.

## Return shape

`src/scitex_agent_container/_delivery/` mirrors `_agentstate/` exactly: frozen dataclass, every signal `bool | None`, `__post_init__` that **raises** on a non-bool, a `reasons` map so a `None` says why, raw captures attached, one pure fold, and `validate_delivery_specs()` called at module scope so a bad table fails at import.

**No delivery signal is `decisive`, and the spec says why** — every reading here comes through a pane capture or an exit status, and each has a measured way to lie. `validate_delivery_specs` still enforces "decisive requires DIRECT observation" so nobody can grant it later without also changing how the signal is read.

Exit codes — the verdict stays **three-valued**; 3 and 4 are *refinements* of 1 whose remedies differ:

| Code | Meaning |
|---|---|
| `0` | delivered **and** submitted |
| `1` | refuted with complete information |
| `2` | could not determine — *do not resend*, it may have landed |
| `3` | **no route** — session absent from a server that can see others |
| `4` | **arrived but still unsent** — attach and press Enter; do **not** resend |

Documented in-module: `click` also exits 2 on a usage error, so a caller that must tell that apart from UNKNOWN **must read the JSON**, never branch on the int.

## A false GREEN the suite caught

`verify_submit_by_advancement` returns `True` from its phase 1 ("nothing pending, nothing to force"). Against an **unreadable** pane every capture it saw was the empty string `CaptureTap` substitutes for `None` — so that `True` was computed from evidence **with no way to disagree with it**, and the first version of this PR reported a successful submission to an agent whose screen was never seen. The blind check now runs *before* that bool is consulted. `test_unreadable_pane_never_claims_submission` is the test that caught it.

## Tests — 113, mutation-proved, no mocks and no monkeypatch

`ComposerPane` is a small **real** compose box that renders an actual pane string, so every production detector runs for real against it. It reproduces the two behaviours that caused the incident (`drops_enter`, `wrap_at`) — a test that cannot reproduce the bug cannot prove the fix. `TickClock` only advances on an explicit sleep, so a loop that forgets to sleep hangs the test instead of passing on wall-clock luck.

Each guard was broken and watched go RED:

| Mutation | Result |
|---|---|
| `min_occurrences=2` (the echo default) | **8 failed** |
| flattening removed (match raw pane) | **3 failed** |
| vacuous-`True` guard removed | **2 failed** |
| empty enumeration convicts | **2 failed** |

Restored: **86 passed**. Full run: 113 delivery + 101 `_agentstate` = **214 passed**. `ecosystem audit-project` and `audit-lines` both pass.

## Honest limits — which modes it can and cannot separate

- **Mode 1 (dead) — separated**, but only when the enumeration showed other sessions. A blind read is deliberately `UNKNOWN`/2, never "dead".
- **Mode 3 (unsubmitted) — separated**, its own exit code 4, with retry.
- **Mode 4 (verification lies) — fixed** at the matcher.
- **Mode 2 (wedged) — only partly.** A pane that accepts text and never submits is caught as exit 4. A peer that submits and then does nothing is **not** distinguishable here: this verb confirms the turn was *taken*, not that it was *acted on*. `is_login_banner_before` is surfaced as the usual explanation but is **evidence only** — a send takes one pre-capture, so it is uncorroborated and must not refute. Use `sac agents auth-status` for the two-capture frozen check.
- The SDK path cannot observe a composer at all; its two payload signals are `INFERRED` from the turn outcome, and the spec grades them that way rather than letting one strategy inherit the other's authority. `status="dispatched"` is explicitly mapped to `None` — it validates reachability *without* delivering.

## Not verified live

Every claim above rests on the suites plus reading the source. This was **not** exercised against a live TUI agent from this container — `tmux` here is a different namespace from the host's fleet, which is the very blindness the route resolver refuses to convict on. Recommend one live `sac agents deliver <peer> "ping" --json` on the host before relying on it.
