### PR TITLE
fix(sif-bake): the fix never reached the machine — bump the cache key, preflight the piped script, make failures explain themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-07-19
+
+### Fixed
+
+- **The SIF bake ran a script the fix had never reached** (follow-up to PR #771).
+  #771 correctly identified that an unguarded `srun` was eating the bake script
+  off its own stdin, and added `--input=none` to all three `srun` calls. The next
+  real bake failed *identically* — build complete, `.partial` left, no
+  `SAC_BAKE_RESULT`, and `bake-remote FAILED:` with nothing after the colon.
+
+  The script that ran was never the fixed one. `sac image bake-remote` pipes the
+  script off the **installed wheel**, and the installed wheel still held pre-#771
+  bytes: `grep -c -- --input=none` on it returned **0**, with all three `srun`
+  calls unguarded at lines 223, 266 and 279. Its version read `0.22.0` — and so
+  did the checkout, because the version was never bumped when #771 merged. A
+  wheel cache keyed on `(name, version)` had served the stale build straight back
+  through a `--force-reinstall`. **The version string could not tell the two
+  apart; only the bytes could.**
+
+  Three changes, because each half failed on its own:
+
+  - `version` is bumped to `0.22.1`, so the cache key moves with the fix. A
+    merged fix that cannot reach a machine is not deployed.
+  - `run_remote_bake` now **preflights the script it is about to pipe**
+    (`unguarded_srun_invocations`) and refuses to bake when a guard is missing,
+    naming the offending file, the installed version, the exact line numbers and
+    the cache-busting reinstall that fixes it — instead of spending an hour of
+    standing lease producing another orphan `.partial`.
+  - Bake failures now **carry their evidence**. `bake-remote FAILED:` composes a
+    self-contained headline (a bare colon is invisible to the grep an operator
+    actually runs), and the reason carries the remote's exit status, the last
+    line of its stdout and the tail of its stderr. Previously `run_remote_bake`
+    discarded `returncode` and `stderr` entirely, so a failure that knew it had
+    failed could not say why. That is how this bug survived six silent runs.
+
+  Verified against the real artifact: the new preflight, run on the actual stale
+  script still installed on the master, reports all three unguarded calls.
+
 ## [0.22.0] - 2026-07-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.22.0"
+version = "0.22.1"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/cli_pkg/_image_remote_bake.py
+++ b/src/scitex_agent_container/cli_pkg/_image_remote_bake.py
@@ -35,6 +35,8 @@ The chain, per layer (each leg three-state and loud — see
 from __future__ import annotations
 
 import subprocess
+from dataclasses import replace
+from importlib import metadata
 from pathlib import Path
 
 import click
@@ -46,6 +48,22 @@ from ._remote_bake_core import (
     RemoteBakeOutcome,
     parse_bake_result,
 )
+
+
+def _first_line(text: str) -> str:
+    """First non-blank line — the headline summary of a multi-line reason."""
+    for line in (text or "").splitlines():
+        if line.strip():
+            return line.strip()
+    return "(no reason given)"
+
+
+def _installed_version() -> str:
+    """Version of the sac actually imported here (never a hardcoded value)."""
+    try:
+        return metadata.version("scitex-agent-container")
+    except metadata.PackageNotFoundError:  # pragma: no cover - source checkout
+        return "unknown"
 
 
 def run_remote_bake(
@@ -64,6 +82,22 @@ def run_remote_bake(
     script = script_path or core.BAKE_SCRIPT
     if not script.is_file():
         raise click.ClickException(f"bake script missing from wheel: {script}")
+    # PREFLIGHT — the script we are ABOUT TO PIPE is the one that runs, and
+    # it is read off the INSTALLED wheel, not the checkout. PR #771's fix
+    # lived in develop for a full day while every bake still ran the
+    # pre-fix bytes from a cache-hit wheel under an unchanged version
+    # string. Refuse to spend an hour of lease on a script we can already
+    # see is broken, and say exactly which file and which lines.
+    source = script.read_text(encoding="utf-8")
+    offenders = core.unguarded_srun_invocations(source)
+    if offenders:
+        return RemoteBakeOutcome(
+            verdict=BakeVerdict.FAILED,
+            layer=layer,
+            detail=core.stale_bake_script_error(
+                script=script, offenders=offenders, version=_installed_version()
+            ),
+        )
     args = [
         "ssh",
         "-o",
@@ -107,9 +141,31 @@ def run_remote_bake(
             verdict=BakeVerdict.NO_RESULT,
             layer=layer,
             detail=(
-                f"ssh rc={proc.returncode} contradicts verdict {outcome.verdict.value}"
+                f"ssh rc={proc.returncode} contradicts verdict "
+                f"{outcome.verdict.value}\n"
+                + core.describe_remote_failure(
+                    verdict=BakeVerdict.NO_RESULT,
+                    script=script,
+                    ssh_rc=proc.returncode,
+                    stdout=proc.stdout or "",
+                    stderr=proc.stderr or "",
+                )
             ),
         )
+    if outcome.verdict in (BakeVerdict.FAILED, BakeVerdict.NO_RESULT):
+        # Carry the EVIDENCE, not just the label. The remote's exit status
+        # and the tail of its stderr are the whole diagnosis, and both were
+        # being thrown away here — which is how six silent runs went by
+        # with nothing to read but the word FAILED.
+        described = core.describe_remote_failure(
+            verdict=outcome.verdict,
+            script=script,
+            ssh_rc=proc.returncode,
+            stdout=proc.stdout or "",
+            stderr=proc.stderr or "",
+        )
+        remote_reason = outcome.detail or "(remote gave no reason)"
+        return replace(outcome, detail=f"{remote_reason}\n{described}")
     return outcome
 
 
@@ -207,6 +263,11 @@ def image_bake_remote(
         containers_dir = Path.home() / ".scitex" / "agent-container" / "containers"
 
     failures: list[str] = []
+    # One-line-per-failure summaries for the headline. The full reason is
+    # multi-line by design (remote stderr, remedy), and a headline that
+    # ends at the colon is unreadable in a journal: `bake-remote FAILED:`
+    # matched a grep and told the reader NOTHING.
+    failure_heads: list[str] = []
     for layer in layers:
         click.echo(f"=== bake-remote: layer={layer} host={host} ===")
         try:
@@ -221,13 +282,17 @@ def image_bake_remote(
                 timeout=ssh_timeout,
             )
         except subprocess.TimeoutExpired:
-            failures.append(
+            failure_heads.append(
                 f"{layer}: remote bake exceeded --ssh-timeout={ssh_timeout}s"
             )
+            failures.append(failure_heads[-1])
             click.echo(failures[-1], err=True)
             continue
         if outcome.verdict in (BakeVerdict.FAILED, BakeVerdict.NO_RESULT):
-            failures.append(f"{layer}: bake {outcome.verdict.value} ({outcome.detail})")
+            failure_heads.append(
+                f"{layer}: bake {outcome.verdict.value} — {_first_line(outcome.detail)}"
+            )
+            failures.append(f"{layer}: bake {outcome.verdict.value}\n{outcome.detail}")
             click.echo(failures[-1], err=True)
             continue
         click.echo(f"bake: {outcome.verdict.value} {outcome.sif}")
@@ -238,10 +303,16 @@ def image_bake_remote(
         )
         click.echo(f"publish: {pull.verdict.value} — {pull.detail}")
         if pull.verdict is PullVerdict.FAILED:
+            failure_heads.append(
+                f"{layer}: publish FAILED — {_first_line(pull.detail)}"
+            )
             failures.append(f"{layer}: publish FAILED ({pull.detail})")
 
     if failures:
-        click.echo("bake-remote FAILED:", err=True)
+        # The headline itself names what broke. Anything less makes the
+        # whole message invisible to the grep that a tired operator at
+        # 03:00 actually runs.
+        click.echo(f"bake-remote FAILED: {'; '.join(failure_heads)}", err=True)
         for f in failures:
             click.echo(f"  - {f}", err=True)
         raise SystemExit(1)

--- a/src/scitex_agent_container/cli_pkg/_remote_bake_core.py
+++ b/src/scitex_agent_container/cli_pkg/_remote_bake_core.py
@@ -92,6 +92,126 @@ class RemoteBakeOutcome:
                 )
 
 
+def _logical_lines(script_text: str) -> list[tuple[int, str]]:
+    """Split shell source into logical lines, merging ``\\`` continuations.
+
+    An ``srun`` invocation in the bake script spans several physical lines
+    and its guard sits on the first of them, so a per-physical-line check
+    would read every continuation line as an unguarded srun step.
+    """
+    physical = script_text.splitlines()
+    merged: list[tuple[int, str]] = []
+    index = 0
+    while index < len(physical):
+        start = index + 1
+        block = [physical[index]]
+        while block[-1].rstrip().endswith("\\") and index + 1 < len(physical):
+            index += 1
+            block.append(physical[index])
+        merged.append((start, "\n".join(block)))
+        index += 1
+    return merged
+
+
+def unguarded_srun_invocations(script_text: str) -> list[tuple[int, str]]:
+    """``"$SRUN"`` invocations that do not carry slurm's ``--input=none``.
+
+    This is the machine-checkable form of the STDIN RULE documented at the
+    top of ``containers/spartan-sif-bake.sh``. That script is DELIVERED ON
+    STDIN (``bash -l -s --`` over ssh), so bash reads it from a
+    non-seekable pipe; an srun without this guard forwards the unread
+    REMAINDER OF THE SCRIPT to the compute node, bash finds EOF where the
+    next line should be, and exits **0** — build done, nothing published,
+    no verdict line at all. Measured: seven dead bakes, 2026-07-17..19
+    (PR #771).
+
+    Returns ``(line_number, invocation)`` per offender so a caller can NAME
+    them instead of merely reporting that something is wrong.
+    """
+    offenders: list[tuple[int, str]] = []
+    for lineno, command in _logical_lines(script_text):
+        if command.lstrip().startswith("#"):
+            continue
+        if '"$SRUN"' not in command:
+            continue
+        if "--input=none" in command:
+            continue
+        offenders.append((lineno, command.strip()))
+    return offenders
+
+
+def stale_bake_script_error(
+    *, script: Path, offenders: list[tuple[int, str]], version: str
+) -> str:
+    """Explain a pre-#771 bake script found at RUN time, and what to do.
+
+    A merged fix is not a deployed fix. The version string cannot reveal
+    this: a wheel cache keyed on ``(name, version)`` serves the stale build
+    under the SAME version, so only the file's bytes can answer. This is
+    why the fix was verified by re-running the bake and the bake failed the
+    same way — the run never saw the new script.
+    """
+    numbers = ", ".join(str(lineno) for lineno, _ in offenders)
+    return (
+        "REFUSING to bake: the script this sac is about to pipe to the remote "
+        f"is missing srun's `--input=none` stdin guard on line(s) {numbers}.\n"
+        f"    offending file : {script}\n"
+        f"    installed sac  : {version}\n"
+        "An unguarded srun eats the rest of this script off the ssh pipe; bash "
+        "then hits EOF and exits 0, leaving a .partial that nothing renames and "
+        "no SAC_BAKE_RESULT line (seven dead bakes, 2026-07-17..19).\n"
+        "So the INSTALLED wheel predates PR #771 even when the checkout does "
+        "not. Redeploy the wheel, then re-run:\n"
+        "    pip install --force-reinstall --no-deps --no-cache-dir <checkout>\n"
+        "Then confirm the BYTES changed — the version string cannot tell you, "
+        "it is identical across a cache hit:\n"
+        f"    grep -c -- --input=none {script}    # must be > 0"
+    )
+
+
+def _tail(text: str, max_lines: int) -> str:
+    """Last ``max_lines`` non-blank lines of ``text`` (evidence, not noise)."""
+    lines = [line for line in (text or "").splitlines() if line.strip()]
+    return "\n".join(lines[-max_lines:])
+
+
+def describe_remote_failure(
+    *,
+    verdict: BakeVerdict,
+    script: Path,
+    ssh_rc: int,
+    stdout: str,
+    stderr: str,
+    max_lines: int = 8,
+) -> str:
+    """Compose a bake failure reason that can be ACTED on.
+
+    "An error that only states what broke is half-written — say what to do
+    about it, and name the offending file, value, or version." A bare
+    ``bake FAILED`` survived six silent runs precisely because it carried
+    neither the remote's exit status nor one line of its stderr.
+    """
+    parts = [f"remote bake {verdict.value} (ssh rc={ssh_rc}, script={script})"]
+    last_stdout = _tail(stdout, 1)
+    if last_stdout:
+        parts.append(f"  last remote stdout : {last_stdout}")
+    remote_stderr = _tail(stderr, max_lines)
+    if remote_stderr:
+        indented = "\n".join(f"      {line}" for line in remote_stderr.splitlines())
+        parts.append(f"  last remote stderr :\n{indented}")
+    else:
+        parts.append("  last remote stderr : (empty — the remote said nothing)")
+    if verdict is BakeVerdict.NO_RESULT:
+        parts.append(
+            "  meaning            : the script reached no verdict — it DIED "
+            "mid-flight. A remote that logged 'Build complete' and then stopped "
+            "without SAC_BAKE_RESULT is the stdin-eating-srun signature; check "
+            "that the INSTALLED bake script still carries --input=none "
+            "(a merged fix is not a deployed fix)."
+        )
+    return "\n".join(parts)
+
+
 def parse_bake_result(output: str, *, layer: str) -> RemoteBakeOutcome:
     """Parse the LAST ``SAC_BAKE_RESULT={...}`` line of the remote output.
 
@@ -347,8 +467,11 @@ __all__ = [
     "RemoteBakeOutcome",
     "SIF_RE",
     "SYMBOL_PROBE",
+    "describe_remote_failure",
     "parse_bake_result",
     "prune_local",
     "pull_and_publish",
+    "stale_bake_script_error",
     "swap_live_symlinks",
+    "unguarded_srun_invocations",
 ]

--- a/tests/integration/test_spartan_sif_bake_deploy_guard.py
+++ b/tests/integration/test_spartan_sif_bake_deploy_guard.py
@@ -1,0 +1,71 @@
+"""The SHIPPED bake script must satisfy the stdin guard the caller enforces.
+
+MEASURED (2026-07-19). PR #771 put ``--input=none`` on every ``srun`` in
+``containers/spartan-sif-bake.sh``. The next real bake failed identically —
+build complete, ``.partial`` left behind, no ``SAC_BAKE_RESULT`` line, exit 1
+with nothing readable after ``bake-remote FAILED:``. The script that ran was
+not the fixed one: ``sac image bake-remote`` pipes the script off the
+INSTALLED wheel, and the installed wheel still held pre-#771 bytes. Its
+version said ``0.22.0``, and so did the checkout — a wheel cache keyed on
+``(name, version)`` had served the stale build straight back through a
+``--force-reinstall``. The version string could not tell the two apart.
+
+So this file checks the two halves that could each drift on their own:
+
+* the script this repo SHIPS passes the preflight the caller runs, and
+* the preflight still FAILS a script with the guards taken back off —
+  a checker that cannot go red proves nothing about the one that is green.
+
+The stdin mechanism itself (an srun draining the piped script, and the
+controls that stop a "fix" from simply deleting the guarded work) is covered
+behaviourally in ``test_spartan_sif_bake_stdin.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import scitex_agent_container
+from scitex_agent_container.cli_pkg import _remote_bake_core as core
+
+BAKE_SCRIPT = (
+    Path(scitex_agent_container.__file__).resolve().parent
+    / "containers"
+    / "spartan-sif-bake.sh"
+)
+
+
+def _script_source() -> str:
+    return BAKE_SCRIPT.read_text(encoding="utf-8")
+
+
+def test_the_shipped_bake_script_passes_the_stdin_preflight() -> None:
+    # Arrange — the caller refuses to bake when this is non-empty, so a
+    # regression here takes the whole periodic bake offline loudly rather
+    # than silently producing another orphan .partial.
+    source = _script_source()
+    # Act
+    offenders = core.unguarded_srun_invocations(source)
+    # Assert
+    assert offenders == []
+
+
+def test_control_the_preflight_catches_the_script_with_its_guards_removed() -> None:
+    # Arrange — MUTATION PROOF. Strip the guard back off the real shipped
+    # script; if the preflight still reports it clean, the green above is
+    # measuring nothing and this file is decoration.
+    mutated = _script_source().replace("--input=none", "")
+    # Act
+    offenders = core.unguarded_srun_invocations(mutated)
+    # Assert
+    assert len(offenders) == 3
+
+
+def test_control_the_preflight_names_a_line_number_for_every_offender() -> None:
+    # Arrange — the refusal message quotes these numbers; a zero or a None
+    # in here would print an error that names nothing.
+    mutated = _script_source().replace("--input=none", "")
+    # Act
+    numbered = [lineno for lineno, _ in core.unguarded_srun_invocations(mutated)]
+    # Assert
+    assert all(lineno > 0 for lineno in numbered)

--- a/tests/scitex_agent_container/cli_pkg/test__image_remote_bake.py
+++ b/tests/scitex_agent_container/cli_pkg/test__image_remote_bake.py
@@ -180,3 +180,83 @@ def test_missing_wheel_script_is_a_loud_click_error() -> None:
 
     with pytest.raises(click.ClickException):
         _call()
+
+
+# ---------------------------------------------------------------------------
+# The stdin-guard PREFLIGHT — no seam needed, and that is the point: an
+# unguarded script is refused BEFORE any ssh happens, so an hour of standing
+# lease is not spent on a script we can already read as broken.
+# ---------------------------------------------------------------------------
+_UNGUARDED_SCRIPT = (
+    "#!/usr/bin/env bash\n"
+    "set -uo pipefail\n"
+    'SRUN="$(command -v srun)"\n'
+    '"$SRUN" --jobid="$JID" --overlap --ntasks=1 apptainer build a b < /dev/null\n'
+)
+
+
+def _bake_with_script(script: Path):
+    return mod.run_remote_bake(
+        host="spartan",
+        layer="base",
+        lease_name="lease",
+        remote_workdir="/w",
+        branch="develop",
+        retain=3,
+        force=False,
+        timeout=60,
+        script_path=script,
+    )
+
+
+def test_preflight_refuses_a_script_whose_srun_lacks_the_stdin_guard(
+    tmp_path: Path,
+) -> None:
+    # Arrange — this is the exact shape that ran in production on
+    # 2026-07-19 while develop already carried the fix.
+    script = tmp_path / "spartan-sif-bake.sh"
+    script.write_text(_UNGUARDED_SCRIPT, encoding="utf-8")
+    # Act
+    outcome = _bake_with_script(script)
+    # Assert
+    assert outcome.verdict is BakeVerdict.FAILED
+
+
+def test_preflight_refusal_names_the_offending_script(tmp_path: Path) -> None:
+    # Arrange — naming the FILE is what turns "it failed again" into a fix;
+    # the stale bytes live at a path nobody was looking at.
+    script = tmp_path / "spartan-sif-bake.sh"
+    script.write_text(_UNGUARDED_SCRIPT, encoding="utf-8")
+    # Act
+    outcome = _bake_with_script(script)
+    # Assert
+    assert str(script) in outcome.detail
+
+
+def test_preflight_refusal_reports_the_offending_line_number(tmp_path: Path) -> None:
+    # Arrange
+    script = tmp_path / "spartan-sif-bake.sh"
+    script.write_text(_UNGUARDED_SCRIPT, encoding="utf-8")
+    # Act
+    outcome = _bake_with_script(script)
+    # Assert
+    assert "line(s) 4" in outcome.detail
+
+
+def test_first_line_summarises_a_multi_line_reason() -> None:
+    # Arrange — the headline takes the first line so that
+    # `bake-remote FAILED:` can never again print nothing after the colon.
+    reason = "remote bake NO_RESULT (ssh rc=0)\n  last remote stdout : x\n"
+    # Act
+    head = mod._first_line(reason)
+    # Assert
+    assert head == "remote bake NO_RESULT (ssh rc=0)"
+
+
+def test_first_line_of_an_empty_reason_still_says_something() -> None:
+    # Arrange — an absent reason must render as a statement of absence,
+    # never as the empty string that started this whole investigation.
+    # Act
+    head = mod._first_line("")
+    # Assert
+    assert head == "(no reason given)"

--- a/tests/scitex_agent_container/cli_pkg/test__remote_bake_core.py
+++ b/tests/scitex_agent_container/cli_pkg/test__remote_bake_core.py
@@ -334,3 +334,186 @@ def test_bake_script_emits_the_three_state_verdict_contract() -> None:
     )
     # Assert
     assert verdicts_present
+
+
+# ---------------------------------------------------------------------------
+# The stdin-guard PREFLIGHT (measured 2026-07-19)
+#
+# PR #771 added `--input=none` to every srun in the bake script, and the very
+# next bake failed identically: build done, `.partial` left, no
+# SAC_BAKE_RESULT. The script the run PIPED came off the INSTALLED wheel,
+# whose bytes still predated #771 — the wheel cache is keyed on
+# (name, version) and the version had not moved, so a reinstall served the
+# stale build back under the same number. A merged fix is not a deployed fix,
+# and the version string cannot tell the two apart. Only the bytes can, so
+# the caller now reads them before spending an hour of lease.
+# ---------------------------------------------------------------------------
+_GUARDED_SRUN = (
+    '"$SRUN" --input=none --jobid="$JID" --overlap --ntasks=1 \\\n'
+    '    --job-name="sac-sif-bake-$LAYER" \\\n'
+    '    bash -c "build" < /dev/null\n'
+)
+
+_UNGUARDED_SRUN = (
+    '"$SRUN" --jobid="$JID" --overlap --ntasks=1 \\\n'
+    '    --job-name="sac-sif-bake-$LAYER" \\\n'
+    '    bash -c "build" < /dev/null\n'
+)
+
+
+def test_an_srun_without_input_none_is_reported_as_an_offender() -> None:
+    # Arrange
+    script = f"set -uo pipefail\n{_UNGUARDED_SRUN}"
+    # Act
+    offenders = core.unguarded_srun_invocations(script)
+    # Assert
+    assert len(offenders) == 1
+
+
+def test_an_unguarded_srun_is_reported_with_its_line_number() -> None:
+    # Arrange — naming the LINE is the point: "something is wrong" is what
+    # the old failure said, and it cost six silent runs.
+    script = f"set -uo pipefail\n{_UNGUARDED_SRUN}"
+    # Act
+    offenders = core.unguarded_srun_invocations(script)
+    # Assert
+    assert offenders[0][0] == 2
+
+
+def test_a_guarded_srun_is_not_an_offender() -> None:
+    # Arrange
+    script = f"set -uo pipefail\n{_GUARDED_SRUN}"
+    # Act
+    offenders = core.unguarded_srun_invocations(script)
+    # Assert
+    assert offenders == []
+
+
+def test_continuation_lines_of_a_guarded_srun_are_not_separate_offenders() -> None:
+    # Arrange — the guard sits on the FIRST physical line of a multi-line
+    # invocation, so a per-physical-line check would flag the continuations
+    # and cry wolf on a correct script.
+    script = f"set -uo pipefail\n{_GUARDED_SRUN}{_GUARDED_SRUN}"
+    # Act
+    offenders = core.unguarded_srun_invocations(script)
+    # Assert
+    assert offenders == []
+
+
+def test_a_commented_out_srun_is_not_an_offender() -> None:
+    # Arrange — the script's own STDIN RULE header quotes srun invocations
+    # in prose; documentation must not read as a defect.
+    script = '# "$SRUN" --jobid="$JID" would eat this file\n'
+    # Act
+    offenders = core.unguarded_srun_invocations(script)
+    # Assert
+    assert offenders == []
+
+
+def test_stale_bake_script_error_names_the_offending_file() -> None:
+    # Arrange
+    script = Path("/opt/venv/lib/python3.11/site-packages/x/spartan-sif-bake.sh")
+    # Act
+    message = core.stale_bake_script_error(
+        script=script, offenders=[(240, '"$SRUN" --jobid=1')], version="0.22.0"
+    )
+    # Assert
+    assert str(script) in message
+
+
+def test_stale_bake_script_error_names_the_installed_version() -> None:
+    # Arrange — the version is the value that LIED, so it must be quoted
+    # back at the reader rather than trusted.
+    # Act
+    message = core.stale_bake_script_error(
+        script=Path("/x/bake.sh"), offenders=[(240, "srun")], version="0.22.0"
+    )
+    # Assert
+    assert "0.22.0" in message
+
+
+def test_stale_bake_script_error_states_the_remedy() -> None:
+    # Arrange — "say what to do about it": a cache-busting reinstall is the
+    # only thing that moves the bytes when the version has not moved.
+    # Act
+    message = core.stale_bake_script_error(
+        script=Path("/x/bake.sh"), offenders=[(240, "srun")], version="0.22.0"
+    )
+    # Assert
+    assert "--no-cache-dir" in message
+
+
+def test_describe_remote_failure_carries_the_remote_exit_status() -> None:
+    # Arrange
+    # Act
+    message = core.describe_remote_failure(
+        verdict=BakeVerdict.FAILED,
+        script=Path("/x/bake.sh"),
+        ssh_rc=17,
+        stdout="",
+        stderr="",
+    )
+    # Assert
+    assert "ssh rc=17" in message
+
+
+def test_describe_remote_failure_carries_the_tail_of_remote_stderr() -> None:
+    # Arrange — the remote's own words are the diagnosis; throwing them
+    # away is what made `bake-remote FAILED:` unreadable.
+    stderr = "\n".join(f"line-{n}" for n in range(1, 21))
+    # Act
+    message = core.describe_remote_failure(
+        verdict=BakeVerdict.FAILED,
+        script=Path("/x/bake.sh"),
+        ssh_rc=1,
+        stdout="",
+        stderr=stderr,
+    )
+    # Assert
+    assert "line-20" in message
+
+
+def test_describe_remote_failure_reports_the_last_remote_stdout_line() -> None:
+    # Arrange — "Build complete: ...partial" as the LAST word out of the
+    # remote is the whole fingerprint of the stdin-eating srun.
+    stdout = "starting\nINFO: Build complete: /store/sac-base-x.sif.partial\n"
+    # Act
+    message = core.describe_remote_failure(
+        verdict=BakeVerdict.NO_RESULT,
+        script=Path("/x/bake.sh"),
+        ssh_rc=0,
+        stdout=stdout,
+        stderr="",
+    )
+    # Assert
+    assert "Build complete" in message
+
+
+def test_describe_remote_failure_says_so_when_remote_stderr_was_empty() -> None:
+    # Arrange — silence must render as SILENCE, never as an empty string
+    # the reader mistakes for "nothing was wrong".
+    # Act
+    message = core.describe_remote_failure(
+        verdict=BakeVerdict.FAILED,
+        script=Path("/x/bake.sh"),
+        ssh_rc=1,
+        stdout="",
+        stderr="",
+    )
+    # Assert
+    assert "the remote said nothing" in message
+
+
+def test_no_result_failure_says_what_to_check() -> None:
+    # Arrange — NO_RESULT means the script DIED; the reader needs to be
+    # pointed at the installed script, which is where the answer was.
+    # Act
+    message = core.describe_remote_failure(
+        verdict=BakeVerdict.NO_RESULT,
+        script=Path("/x/bake.sh"),
+        ssh_rc=0,
+        stdout="",
+        stderr="",
+    )
+    # Assert
+    assert "--input=none" in message


### PR DESCRIPTION
## The second defect: the fix never reached the machine that runs it

PR #771 diagnosed the mechanism correctly — an unguarded `srun` was eating the
bake script off its own stdin — and added `--input=none` to all three calls.
The next real bake failed **identically**: `Build complete`, a `.partial` left
behind, no `SAC_BAKE_RESULT`, and `bake-remote FAILED:` with nothing readable
after the colon.

There is no third bug between the build and the swap. **The run never executed
the fixed script.**

### Evidence

`sac image bake-remote` pipes the script off the **installed wheel**, not the
checkout. On the master, that file was still pre-#771:

```
$ grep -c -- --input=none .../site-packages/scitex_agent_container/containers/spartan-sif-bake.sh
0
```

All three `srun` calls unguarded, at lines 223, 266 and 279 — and no `STDIN
RULE` header. The wheel reported version `0.22.0`; so did the checkout, because
the version was never bumped when #771 merged. A wheel cache keyed on
`(name, version)` served the stale build straight back through a
`--force-reinstall`. **The version string could not distinguish the two builds;
only the bytes could.**

One inference in the original report does not survive: exit 1 was read as proof
that `--input=none` had changed something. It was not. The `NO_RESULT →
SystemExit(1)` path has existed since #739, so exit 1 is the *expected* outcome
of this failure mode, fixed or not. And the reason was never actually empty —
it was printed on the *following* line (`  - base: bake NO_RESULT (...)`), which
a grep for `bake-remote FAILED:` cannot see. Both halves are addressed below.

### Changes

1. **`version` → `0.22.1`.** The cache key moves with the fix. A merged fix that
   cannot reach a machine is not deployed.

2. **A preflight on the script about to be piped.**
   `unguarded_srun_invocations()` reads the bytes and `run_remote_bake` refuses
   to bake when a guard is missing — naming the offending file, the installed
   version, the exact line numbers and the cache-busting reinstall that fixes
   it, instead of spending an hour of standing lease on another orphan
   `.partial`.

3. **Failures carry their evidence.** The `bake-remote FAILED:` headline is now
   self-contained, and the reason carries the remote's exit status, its last
   stdout line and the tail of its stderr. `run_remote_bake` was discarding
   `returncode` and `stderr` outright — which is how this survived six silent
   runs.

### Verified against the real artifact

The new preflight, run on the actual stale script still installed on the
master, reports exactly the three unguarded calls:

```
OFFENDERS FOUND: 3
  line 223: "$SRUN" --jobid="$JID" --overlap --ntasks=1 --cpus-per-task="$CPUS" \
  line 266: "$SRUN" --jobid="$JID" --overlap --ntasks=1 \
  line 279: SHA256="$("$SRUN" --jobid="$JID" --overlap --ntasks=1 sha256sum ...
```

This is a true-positive specimen from the incident itself, not a synthetic one.
The suite also mutation-proves the checker goes red: strip `--input=none` back
off the shipped script and the preflight reports 3 offenders; a checker that
cannot fail proves nothing about the one that passes.

### The two log-only builds are a DIFFERENT bug

`2026-0717-182108` and `2026-0718-110909` left build logs but no `.partial`
because the **`.def`'s `%post` freshness gate correctly killed the build**:

```
importlib.metadata.PackageNotFoundError: No package metadata was found for scitex-todo
FATAL: stale or wrong-tree package baked into this image
FATAL:   While performing build: while running engine: exit status 1
srun: error: spartan-bm197: task 0: Exited with exit code 255
```

The package had been renamed to `scitex-cards` while the gate still asked for
`scitex-todo` metadata. That is the gate working as designed, loudly, at build
time — the opposite failure mode from this PR's silent one. It has since been
fixed; every build from `0717-185849` onward reaches `Build complete`. No action
needed here.

### Deployment note

Merging this is not enough to make the next bake work — that is the whole point
of the PR. After merge the master must be reinstalled with a cache-bust:

```
pip install --force-reinstall --no-deps --no-cache-dir <checkout>
grep -c -- --input=none <installed>/containers/spartan-sif-bake.sh   # must be > 0
```

If it is skipped, the preflight now fails loudly with those instructions rather
than baking another orphan.

### Pre-existing issue noticed, not fixed here

`tests/integration/test_spartan_sif_bake_stdin.py` (from #771) writes a
`SAC_TEST_SCRIPT_TAIL_REACHED` file into the current working directory when
run. Harmless but it dirties the worktree; left for its author to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqhsrw29CM4siBLcEK2CwV
