### PR TITLE
fix(env): set the canonical board identity, and reject an unexpanded substitution

### DIFF
--- a/src/scitex_agent_container/runtimes/_board_identity_env.py
+++ b/src/scitex_agent_container/runtimes/_board_identity_env.py
@@ -180,21 +180,40 @@ def apply_board_identity_alias(
     *,
     raw_args: Iterable[Any] | None = None,
 ) -> dict[str, str]:
-    """Mirror the board identity onto BOTH env names. Returns a NEW dict.
+    """Ensure the CANONICAL board identity is set. Returns a NEW dict.
 
-    The EFFECTIVE identity is resolved the way apptainer resolves it, so the
-    mirror can never disagree with what the container actually receives:
+    ASYMMETRIC BY DESIGN — reads both names, writes only the new one.
+
+    The identity is READ from either spelling, because specs are mid-migration
+    and many still declare only the legacy name. It is WRITTEN only as
+    :data:`BOARD_ID_ENV`. sac must never re-introduce the legacy name: the
+    operator is removing ``SCITEX_TODO_*`` from the specs entirely
+    (2026-07-19), and an injector that helpfully mirrored it back would
+    silently undo that migration one launch at a time — the deleted variable
+    would keep reappearing and nobody would understand why.
+
+    So this function is also the MIGRATION BRIDGE: a spec that still declares
+    only the legacy name still gets a working canonical identity, which is
+    what lets the legacy name be deleted from specs incrementally instead of
+    in one flag-day sweep.
+
+    Verified before narrowing (2026-07-19): scitex-cards 0.17.0 resolves from
+    :data:`BOARD_ID_ENV` alone and emits no deprecation warning, so dropping
+    the legacy write costs nothing against the installed fleet.
+
+    The EFFECTIVE identity is resolved the way apptainer resolves it, so what
+    is written can never disagree with what the container actually receives:
     ``raw_args`` are appended to the argv AFTER the ``--env`` flags rendered
     from ``env`` (see ``_apptainer_build_argv.build_run_argv``), and apptainer
     ``--env`` is last-wins — so a ``raw_args``-declared identity OVERRIDES the
     one in ``spec.env``. That is why ``raw_args`` is consulted here at all:
-    for most of the fleet the identity is declared ONLY there, and an alias
-    derived from ``spec.env`` alone would mirror a value the agent never runs
-    with (or mirror nothing).
+    for most of the fleet the identity is declared ONLY there, and a value
+    derived from ``spec.env`` alone would mirror an identity the agent never
+    runs with (or mirror nothing).
 
-    An identity already declared explicitly under either name is never
-    clobbered — the mirror only FILLS IN a name that is absent. Both names are
-    validated, so a ``${...}`` identity fails here instead of reaching a card.
+    An identity already declared explicitly is never clobbered — this only
+    FILLS IN the canonical name when it is absent. Every value is validated,
+    so a ``${...}`` identity fails here instead of reaching a card.
     """
     merged = reject_unexpanded_env(env)
     from_raw = raw_args_env(raw_args)
@@ -210,18 +229,17 @@ def apply_board_identity_alias(
     if not identity:
         return merged
 
-    for name in (BOARD_ID_ENV, LEGACY_BOARD_ID_ENV):
-        if name in from_raw or (merged.get(name) or "").strip():
-            continue
-        merged[name] = identity
-        logger.info(
-            "board_identity: injected %s=%s (transition window: sac sets BOTH "
-            "%s and %s with the same value)",
-            name,
-            identity,
-            BOARD_ID_ENV,
-            LEGACY_BOARD_ID_ENV,
-        )
+    if BOARD_ID_ENV in from_raw or (merged.get(BOARD_ID_ENV) or "").strip():
+        return merged
+
+    merged[BOARD_ID_ENV] = identity
+    logger.info(
+        "board_identity: injected %s=%s (derived from the legacy %s, which is "
+        "read but deliberately NOT written back)",
+        BOARD_ID_ENV,
+        identity,
+        LEGACY_BOARD_ID_ENV,
+    )
     return merged
 
 

--- a/src/scitex_agent_container/runtimes/_board_identity_env.py
+++ b/src/scitex_agent_container/runtimes/_board_identity_env.py
@@ -1,0 +1,236 @@
+"""Board-identity env injection + the unexpanded-``${VAR}`` validator.
+
+WHY THIS MODULE EXISTS (INCIDENT 2026-07-19, live data corruption)
+==================================================================
+scitex-cards renamed its identity variable
+``SCITEX_TODO_AGENT_ID`` -> ``SCITEX_CARDS_AGENT_ID`` and now warns on every
+read that the ``SCITEX_TODO_*`` spelling is "honoured for one transition
+window only". sac injected ONLY the old name. A ``.mcp.json`` that had been
+migrated to reference the NEW name therefore expanded ``${SCITEX_CARDS_AGENT_ID}``
+against a container env where that variable did not exist — and the LITERAL
+placeholder text survived into the store. Rows in the live cards DB carry
+``created_by = '${SCITEX_CARDS_AGENT_ID}'``: the variable NAME, unexpanded,
+persisted as though it were an answer. The board cannot say who wrote those
+cards. The count kept CLIMBING while the bug was live — 7 when first
+reported, 15 measured a few hours later on 2026-07-19 — because every new
+card written by an affected agent added one. Treat any figure here as a
+floor at its timestamp, not a total.
+
+Two independent defects, so two independent fixes here.
+
+1. THE MISSING NAME — :func:`apply_board_identity_alias`
+--------------------------------------------------------
+sac now injects BOTH spellings with the SAME value. Not a swap: the fleet's
+installed scitex-cards versions differ, so an agent still running a
+pre-rename build reads only ``SCITEX_TODO_AGENT_ID`` and dropping it would
+break that agent's writes exactly the way the missing new name broke these.
+Both names cost one extra ``--env`` flag and cover both halves of the fleet
+for the length of the transition window.
+
+REMOVING THE LEGACY NAME — the condition. Drop
+:data:`LEGACY_BOARD_ID_ENV` from this module (and the alias that mirrors it)
+once BOTH hold:
+
+  a. Every scitex-cards install reachable by the fleet is at or past the
+     release that removed the ``SCITEX_TODO_*`` compatibility shim — i.e.
+     scitex-cards has actually CLOSED its transition window, not merely
+     announced it. The observable signal is that the deprecation warning
+     ("deprecated SCITEX_TODO_* environment names in use") no longer appears
+     on a read, because the code emitting it is gone.
+  b. No agent spec still declares ``SCITEX_TODO_AGENT_ID`` — neither in
+     ``spec.env`` nor in ``apptainer.raw_args`` (those specs live in the
+     operator's dotfiles repo, not in sac, so this is a cross-repo check).
+
+Until both are true, injecting both names is strictly safer than either one
+alone. Removing it earlier re-creates this incident with the names swapped.
+
+2. THE NON-ANSWER STORED AS AN ANSWER — :func:`reject_unexpanded_env`
+----------------------------------------------------------------------
+The deeper bug is not the rename. It is that a value meaning "I could not
+resolve this" was accepted and written as data. ``${SCITEX_CARDS_AGENT_ID}``
+is not an agent id; it is the shape of a substitution that did not happen.
+Per the constitution §2 rule — "Give the dataclass a validator, so a
+malformed answer fails where it is built, not three layers downstream" — any
+value that still LOOKS like an unexpanded shell substitution is rejected at
+the boundary where sac sets it, loudly, naming the variable, the offending
+value, and the likely cause. It is never stored and never silently replaced
+by a default: a silent default would put a WRONG author on the card, which is
+worse than a launch that stops and says why.
+
+Note the asymmetry with :func:`.._to_home_text.interpolate_env`, which
+deliberately LEAVES ``${VAR}`` literals in materialised *files* for runtime
+expansion inside the container. That is correct there — the file is expanded
+later, by the agent's own environment. It is exactly what must never happen
+*here*: this module renders the container's ``--env`` flags, which are the
+end of the line. Nothing downstream expands them, so a ``${VAR}`` reaching
+this point has already failed.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Iterable, Mapping
+
+logger = logging.getLogger(__name__)
+
+#: The board-identity variable scitex-cards reads TODAY.
+BOARD_ID_ENV = "SCITEX_CARDS_AGENT_ID"
+
+#: The pre-rename spelling. Injected alongside :data:`BOARD_ID_ENV` for the
+#: transition window only — see the module docstring for the two conditions
+#: that must both hold before this is removed.
+LEGACY_BOARD_ID_ENV = "SCITEX_TODO_AGENT_ID"
+
+#: The whole value is nothing but a substitution ref: ``${VAR}``.
+_WHOLE_REF_RE = re.compile(r"^\$\{.*\}$", re.DOTALL)
+
+#: A substitution ref appears anywhere in the value: ``prefix-${VAR}-suffix``.
+_ANY_REF = "${"
+
+
+class UnexpandedEnvValueError(ValueError):
+    """An env value still contains an unexpanded ``${VAR}`` substitution.
+
+    Raised at the boundary where sac SETS a container env var, so the launch
+    fails where the bad value is built rather than three layers downstream in
+    somebody else's database.
+    """
+
+
+def assert_expanded(name: str, value: str) -> None:
+    """Raise :class:`UnexpandedEnvValueError` if ``value`` never expanded.
+
+    Rejects a value that IS a substitution ref (``${VAR}``) and one that
+    merely CONTAINS one (``x-${VAR}``); the second is just as unexpanded and
+    just as unusable as data, and letting it through would leave a
+    half-resolved identity on the board.
+
+    The message names all three things a reader needs in order to act: the
+    variable being set, the value that is wrong, and the likeliest cause
+    (a renamed variable whose new name nobody exports).
+    """
+    if not isinstance(value, str) or _ANY_REF not in value:
+        return
+    shape = "is" if _WHOLE_REF_RE.match(value) else "contains"
+    raise UnexpandedEnvValueError(
+        f"refusing to set {name}={value!r}: the value {shape} an UNEXPANDED "
+        f"shell substitution, which means the variable it refers to was not "
+        f"set in the environment doing the expansion. Storing it would write "
+        f"the variable NAME where a value belongs (INCIDENT 2026-07-19: cards "
+        f"recorded created_by='${{{BOARD_ID_ENV}}}'). Likely cause: a "
+        f"RENAMED variable that is not exported — a config referencing the new "
+        f"name while only the old name is injected expands to nothing and the "
+        f"literal ${{...}} survives. Export the referenced variable, or fix "
+        f"the reference to name one that is actually set."
+    )
+
+
+def reject_unexpanded_env(env: Mapping[str, Any]) -> dict[str, str]:
+    """Validate every pair in ``env``; return it as a plain ``{str: str}``.
+
+    Pure — the input is not mutated. Raises on the FIRST offending pair
+    (keys are visited in sorted order so the failure is deterministic and a
+    re-run names the same variable).
+    """
+    out: dict[str, str] = {str(k): str(v) for k, v in env.items()}
+    for key in sorted(out):
+        assert_expanded(key, out[key])
+    return out
+
+
+def raw_args_env(raw_args: Iterable[Any] | None) -> dict[str, str]:
+    """Extract ``KEY=VALUE`` pairs that ``raw_args`` sets via apptainer ``--env``.
+
+    Both spellings that occur in real specs are parsed, because both occur:
+
+    * SPLIT — ``["--env", "SCITEX_TODO_AGENT_ID=name"]`` (two argv elements)
+    * GLUED — ``["--env=SCITEX_TODO_AGENT_ID=name"]`` (one argv element)
+
+    Later duplicates win, matching apptainer's own ``--env`` last-wins
+    precedence. Returns ``{}`` for ``None`` / empty. Malformed entries (a
+    trailing ``--env`` with nothing after it, a value with no ``=``) are
+    skipped rather than raising: this is a READ of an operator escape hatch
+    sac does not own, and sac must not refuse to launch over a flag it merely
+    failed to recognise.
+    """
+    tokens = [str(a) for a in (raw_args or [])]
+    found: dict[str, str] = {}
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        pair: str | None = None
+        if token == "--env" and index + 1 < len(tokens):
+            pair = tokens[index + 1]
+            index += 2
+        elif token.startswith("--env="):
+            pair = token[len("--env=") :]
+            index += 1
+        else:
+            index += 1
+            continue
+        key, sep, value = pair.partition("=")
+        if sep and key:
+            found[key] = value
+    return found
+
+
+def apply_board_identity_alias(
+    env: Mapping[str, Any],
+    *,
+    raw_args: Iterable[Any] | None = None,
+) -> dict[str, str]:
+    """Mirror the board identity onto BOTH env names. Returns a NEW dict.
+
+    The EFFECTIVE identity is resolved the way apptainer resolves it, so the
+    mirror can never disagree with what the container actually receives:
+    ``raw_args`` are appended to the argv AFTER the ``--env`` flags rendered
+    from ``env`` (see ``_apptainer_build_argv.build_run_argv``), and apptainer
+    ``--env`` is last-wins — so a ``raw_args``-declared identity OVERRIDES the
+    one in ``spec.env``. That is why ``raw_args`` is consulted here at all:
+    for most of the fleet the identity is declared ONLY there, and an alias
+    derived from ``spec.env`` alone would mirror a value the agent never runs
+    with (or mirror nothing).
+
+    An identity already declared explicitly under either name is never
+    clobbered — the mirror only FILLS IN a name that is absent. Both names are
+    validated, so a ``${...}`` identity fails here instead of reaching a card.
+    """
+    merged = reject_unexpanded_env(env)
+    from_raw = raw_args_env(raw_args)
+    for name in (BOARD_ID_ENV, LEGACY_BOARD_ID_ENV):
+        if name in from_raw:
+            assert_expanded(name, from_raw[name])
+
+    current = (from_raw.get(BOARD_ID_ENV) or merged.get(BOARD_ID_ENV) or "").strip()
+    legacy = (
+        from_raw.get(LEGACY_BOARD_ID_ENV) or merged.get(LEGACY_BOARD_ID_ENV) or ""
+    ).strip()
+    identity = current or legacy
+    if not identity:
+        return merged
+
+    for name in (BOARD_ID_ENV, LEGACY_BOARD_ID_ENV):
+        if name in from_raw or (merged.get(name) or "").strip():
+            continue
+        merged[name] = identity
+        logger.info(
+            "board_identity: injected %s=%s (transition window: sac sets BOTH "
+            "%s and %s with the same value)",
+            name,
+            identity,
+            BOARD_ID_ENV,
+            LEGACY_BOARD_ID_ENV,
+        )
+    return merged
+
+
+__all__ = [
+    "BOARD_ID_ENV",
+    "LEGACY_BOARD_ID_ENV",
+    "UnexpandedEnvValueError",
+    "apply_board_identity_alias",
+    "assert_expanded",
+    "raw_args_env",
+    "reject_unexpanded_env",
+]

--- a/src/scitex_agent_container/runtimes/_fleet_env.py
+++ b/src/scitex_agent_container/runtimes/_fleet_env.py
@@ -195,9 +195,26 @@ def effective_env(
 
     The entry-point :func:`._apptainer_build_argv.build_run_argv` calls in
     place of iterating ``config.env`` directly. Returns fleet defaults merged
-    under ``config.env`` (``spec.env`` wins), ready to render as ``--env K=V``.
+    under ``config.env`` (``spec.env`` wins), then the board-identity alias
+    (:mod:`._board_identity_env`) is applied so a value declared under either
+    ``SCITEX_TODO_AGENT_ID`` or ``SCITEX_CARDS_AGENT_ID`` — in ``spec.env`` or
+    in ``apptainer.raw_args`` — is mirrored onto BOTH names for the
+    scitex-cards rename transition window (INCIDENT 2026-07-19: cards were
+    written with the literal, unexpanded ``${SCITEX_CARDS_AGENT_ID}`` as
+    their author because sac injected only the old name — 7 rows when first
+    reported, 15 a few hours later, since every new card added one).
+
+    Every value — not just the identity vars — is validated: an env value
+    that still looks like an unexpanded ``${VAR}`` substitution raises
+    :class:`._board_identity_env.UnexpandedEnvValueError` here rather than
+    being stored three layers downstream in someone else's database.
     """
-    return merge_fleet_env(getattr(config, "env", None), defaults=defaults)
+    from ._board_identity_env import apply_board_identity_alias
+
+    merged = merge_fleet_env(getattr(config, "env", None), defaults=defaults)
+    apptainer = getattr(config, "apptainer", None)
+    raw_args = getattr(apptainer, "raw_args", None) if apptainer is not None else None
+    return apply_board_identity_alias(merged, raw_args=raw_args)
 
 
 def fleet_env_flags(

--- a/tests/scitex_agent_container/runtimes/test__board_identity_env.py
+++ b/tests/scitex_agent_container/runtimes/test__board_identity_env.py
@@ -242,23 +242,35 @@ def test_the_legacy_name_is_mirrored_onto_the_current_name() -> None:
     assert out[BOARD_ID_ENV] == "scitex-agent-container"
 
 
-def test_the_current_name_is_mirrored_onto_the_legacy_name() -> None:
-    """A spec that already migrated must not strand pre-rename scitex-cards."""
+def test_the_legacy_name_is_never_written_back() -> None:
+    """sac must not resurrect the name the operator is deleting from specs.
+
+    The operator is removing ``SCITEX_TODO_*`` from the specs entirely
+    (2026-07-19). An injector that mirrored it back would undo that migration
+    one launch at a time: the deleted variable would keep reappearing and
+    nobody would be able to see why. Reading it stays supported; writing it
+    does not.
+    """
     # Arrange
     env = {BOARD_ID_ENV: "scitex-agent-container"}
     # Act
     out = apply_board_identity_alias(env)
     # Assert
-    assert out[LEGACY_BOARD_ID_ENV] == "scitex-agent-container"
+    assert LEGACY_BOARD_ID_ENV not in out
 
 
-def test_both_names_carry_exactly_the_same_value() -> None:
+def test_a_legacy_only_spec_still_gets_the_canonical_name() -> None:
+    """The migration bridge: legacy-only specs keep working while they migrate.
+
+    This is what allows the legacy name to be deleted from specs incrementally
+    rather than in a single flag-day sweep across every agent.
+    """
     # Arrange
     env = {LEGACY_BOARD_ID_ENV: "worker-telegrammer-orochi"}
     # Act
     out = apply_board_identity_alias(env)
     # Assert
-    assert out[BOARD_ID_ENV] == out[LEGACY_BOARD_ID_ENV]
+    assert out[BOARD_ID_ENV] == "worker-telegrammer-orochi"
 
 
 def test_an_explicit_current_name_is_not_clobbered() -> None:

--- a/tests/scitex_agent_container/runtimes/test__board_identity_env.py
+++ b/tests/scitex_agent_container/runtimes/test__board_identity_env.py
@@ -1,0 +1,383 @@
+"""Board-identity env injection + the unexpanded-``${VAR}`` validator.
+
+Mirrors ``src/scitex_agent_container/runtimes/_board_identity_env.py`` (PS-204 §2).
+
+INCIDENT 2026-07-19: scitex-cards renamed ``SCITEX_TODO_AGENT_ID`` ->
+``SCITEX_CARDS_AGENT_ID``; sac injected only the OLD name, so a ``.mcp.json``
+referencing the new one expanded to nothing and seven live cards recorded
+``created_by = '${SCITEX_CARDS_AGENT_ID}'`` — the variable NAME stored as data.
+
+Two properties are load-bearing and each is asserted in BOTH directions:
+
+* BOTH names reach the container with the SAME value (not a swap — the fleet's
+  installed scitex-cards versions differ, so dropping either name breaks the
+  half of the fleet that reads it).
+* A value that still looks like an unexpanded substitution is REJECTED, while
+  an ordinary value passes through untouched. Without the second direction the
+  validator could "pass" by rejecting everything.
+
+Plain dicts and real ``SimpleNamespace`` configs — no mocks, no monkeypatch
+(PA-306). Every seam here already takes its inputs as parameters.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Callable
+
+from scitex_agent_container.runtimes._board_identity_env import (
+    BOARD_ID_ENV,
+    LEGACY_BOARD_ID_ENV,
+    UnexpandedEnvValueError,
+    apply_board_identity_alias,
+    assert_expanded,
+    raw_args_env,
+    reject_unexpanded_env,
+)
+from scitex_agent_container.runtimes._fleet_env import fleet_env_flags
+
+
+def _raised_by(call: Callable[[], Any]) -> BaseException | None:
+    """Return the exception ``call`` raised, or ``None`` if it returned.
+
+    Lets a "this must be rejected" test assert ONCE (on the captured
+    exception) instead of pairing a ``pytest.raises`` block with a second
+    assertion about the message — which STX-TQ007 counts as two.
+    """
+    try:
+        call()
+    except BaseException as exc:  # noqa: BLE001 - the captured value IS the result
+        return exc
+    return None
+
+
+# ----------------------------------------------------------------------
+# The validator — what it rejects.
+# ----------------------------------------------------------------------
+
+
+def test_a_whole_value_substitution_ref_is_rejected() -> None:
+    # Arrange
+    value = "${SCITEX_CARDS_AGENT_ID}"
+    # Act
+    raised = _raised_by(lambda: assert_expanded(BOARD_ID_ENV, value))
+    # Assert
+    assert isinstance(raised, UnexpandedEnvValueError)
+
+
+def test_an_embedded_substitution_ref_is_also_rejected() -> None:
+    """``agent-${VAR}`` is just as unexpanded, and just as unusable as data."""
+    # Arrange
+    value = "agent-${SUFFIX}"
+    # Act
+    raised = _raised_by(lambda: assert_expanded("SOME_KEY", value))
+    # Assert
+    assert isinstance(raised, UnexpandedEnvValueError)
+
+
+def test_the_rejection_is_a_value_error_subclass() -> None:
+    """Callers already catching ValueError must still catch this."""
+    # Arrange
+    value = "${V}"
+    # Act
+    raised = _raised_by(lambda: assert_expanded("K", value))
+    # Assert
+    assert isinstance(raised, ValueError)
+
+
+def test_the_error_message_names_the_offending_variable() -> None:
+    # Arrange
+    name = "SCITEX_CARDS_AGENT_ID"
+    # Act
+    raised = _raised_by(lambda: assert_expanded(name, "${SCITEX_CARDS_AGENT_ID}"))
+    # Assert
+    assert name in str(raised)
+
+
+def test_the_error_message_quotes_the_offending_value() -> None:
+    # Arrange
+    value = "${SOMETHING}"
+    # Act
+    raised = _raised_by(lambda: assert_expanded("K", value))
+    # Assert
+    assert value in str(raised)
+
+
+def test_the_error_message_names_the_likely_cause() -> None:
+    """A renamed variable that nobody exports is the cause worth naming."""
+    # Arrange
+    value = "${V}"
+    # Act
+    raised = _raised_by(lambda: assert_expanded("K", value))
+    # Assert
+    assert "RENAMED" in str(raised)
+
+
+# ----------------------------------------------------------------------
+# The validator — what it must NOT reject (the controls).
+# ----------------------------------------------------------------------
+
+
+def test_an_ordinary_value_is_accepted_unchanged() -> None:
+    # Arrange
+    env = {BOARD_ID_ENV: "scitex-agent-container"}
+    # Act
+    out = reject_unexpanded_env(env)
+    # Assert
+    assert out[BOARD_ID_ENV] == "scitex-agent-container"
+
+
+def test_a_bare_dollar_sign_value_is_accepted() -> None:
+    """Only the ``${`` substitution SHAPE is a non-answer; ``$`` alone is data."""
+    # Arrange
+    env = {"PRICE": "$5 and $HOME-ish"}
+    # Act
+    out = reject_unexpanded_env(env)
+    # Assert
+    assert out["PRICE"] == "$5 and $HOME-ish"
+
+
+def test_an_empty_value_is_accepted() -> None:
+    """The documented per-agent fleet-default opt-out sets an empty value."""
+    # Arrange
+    env = {"SHARED_KEY": ""}
+    # Act
+    out = reject_unexpanded_env(env)
+    # Assert
+    assert out["SHARED_KEY"] == ""
+
+
+def test_validation_does_not_mutate_the_input_mapping() -> None:
+    # Arrange
+    env = {"K": "v"}
+    # Act
+    reject_unexpanded_env(env)["K"] = "MUTATED"
+    # Assert
+    assert env["K"] == "v"
+
+
+# ----------------------------------------------------------------------
+# raw_args parsing — both spellings occur in real specs.
+# ----------------------------------------------------------------------
+
+
+def test_the_split_env_spelling_is_parsed() -> None:
+    """``["--env", "K=V"]`` — two argv elements (most specs)."""
+    # Arrange
+    raw_args = ["--userns", "--env", "SCITEX_TODO_AGENT_ID=scitex-dev"]
+    # Act
+    found = raw_args_env(raw_args)
+    # Assert
+    assert found["SCITEX_TODO_AGENT_ID"] == "scitex-dev"
+
+
+def test_the_glued_env_spelling_is_parsed() -> None:
+    """``["--env=K=V"]`` — one argv element (scitex-agentic-journal et al)."""
+    # Arrange
+    raw_args = ["--containall", "--env=SCITEX_TODO_AGENT_ID=agentic-journal"]
+    # Act
+    found = raw_args_env(raw_args)
+    # Assert
+    assert found["SCITEX_TODO_AGENT_ID"] == "agentic-journal"
+
+
+def test_a_later_duplicate_env_flag_wins() -> None:
+    """Matches apptainer's own ``--env`` last-wins precedence."""
+    # Arrange
+    raw_args = ["--env", "K=first", "--env", "K=second"]
+    # Act
+    found = raw_args_env(raw_args)
+    # Assert
+    assert found["K"] == "second"
+
+
+def test_a_value_containing_equals_survives_intact() -> None:
+    # Arrange
+    raw_args = ["--env", "GIT_SSH_COMMAND=ssh -o ControlPath=none"]
+    # Act
+    found = raw_args_env(raw_args)
+    # Assert
+    assert found["GIT_SSH_COMMAND"] == "ssh -o ControlPath=none"
+
+
+def test_a_trailing_env_flag_is_skipped_not_fatal() -> None:
+    """sac must not refuse to launch over an operator escape hatch it misreads."""
+    # Arrange
+    raw_args = ["--userns", "--env"]
+    # Act
+    found = raw_args_env(raw_args)
+    # Assert
+    assert found == {}
+
+
+def test_non_env_raw_args_contribute_nothing() -> None:
+    # Arrange
+    raw_args = ["--home", "/home/agent", "--overlay", "/some/path/"]
+    # Act
+    found = raw_args_env(raw_args)
+    # Assert
+    assert found == {}
+
+
+def test_absent_raw_args_yield_an_empty_mapping() -> None:
+    # Arrange
+    raw_args = None
+    # Act
+    found = raw_args_env(raw_args)
+    # Assert
+    assert found == {}
+
+
+# ----------------------------------------------------------------------
+# The alias — BOTH names, same value.
+# ----------------------------------------------------------------------
+
+
+def test_the_legacy_name_is_mirrored_onto_the_current_name() -> None:
+    # Arrange
+    env = {LEGACY_BOARD_ID_ENV: "scitex-agent-container"}
+    # Act
+    out = apply_board_identity_alias(env)
+    # Assert
+    assert out[BOARD_ID_ENV] == "scitex-agent-container"
+
+
+def test_the_current_name_is_mirrored_onto_the_legacy_name() -> None:
+    """A spec that already migrated must not strand pre-rename scitex-cards."""
+    # Arrange
+    env = {BOARD_ID_ENV: "scitex-agent-container"}
+    # Act
+    out = apply_board_identity_alias(env)
+    # Assert
+    assert out[LEGACY_BOARD_ID_ENV] == "scitex-agent-container"
+
+
+def test_both_names_carry_exactly_the_same_value() -> None:
+    # Arrange
+    env = {LEGACY_BOARD_ID_ENV: "worker-telegrammer-orochi"}
+    # Act
+    out = apply_board_identity_alias(env)
+    # Assert
+    assert out[BOARD_ID_ENV] == out[LEGACY_BOARD_ID_ENV]
+
+
+def test_an_explicit_current_name_is_not_clobbered() -> None:
+    """The mirror FILLS IN an absent name; it never overwrites a declared one."""
+    # Arrange
+    env = {LEGACY_BOARD_ID_ENV: "old-value", BOARD_ID_ENV: "explicit-value"}
+    # Act
+    out = apply_board_identity_alias(env)
+    # Assert
+    assert out[BOARD_ID_ENV] == "explicit-value"
+
+
+def test_a_raw_args_identity_is_mirrored_when_spec_env_is_silent() -> None:
+    """Most of the fleet declares the identity ONLY in raw_args."""
+    # Arrange
+    raw_args = ["--env", f"{LEGACY_BOARD_ID_ENV}=scitex-dev"]
+    # Act
+    out = apply_board_identity_alias({}, raw_args=raw_args)
+    # Assert
+    assert out[BOARD_ID_ENV] == "scitex-dev"
+
+
+def test_a_raw_args_identity_overrides_the_spec_env_identity() -> None:
+    """raw_args are appended AFTER spec.env flags and apptainer --env is last-wins."""
+    # Arrange
+    raw_args = ["--env", f"{LEGACY_BOARD_ID_ENV}=from-raw-args"]
+    # Act
+    out = apply_board_identity_alias(
+        {LEGACY_BOARD_ID_ENV: "from-spec-env"}, raw_args=raw_args
+    )
+    # Assert
+    assert out[BOARD_ID_ENV] == "from-raw-args"
+
+
+def test_the_legacy_name_is_left_to_raw_args_that_declare_it() -> None:
+    """Re-emitting it from spec.env would be shadowed anyway — emit nothing."""
+    # Arrange
+    raw_args = ["--env", f"{LEGACY_BOARD_ID_ENV}=from-raw-args"]
+    # Act
+    out = apply_board_identity_alias({}, raw_args=raw_args)
+    # Assert
+    assert LEGACY_BOARD_ID_ENV not in out
+
+
+def test_an_unexpanded_raw_args_identity_is_rejected() -> None:
+    """The corruption's exact shape, arriving through the escape hatch."""
+    # Arrange
+    raw_args = ["--env", f"{BOARD_ID_ENV}=${{{BOARD_ID_ENV}}}"]
+    # Act
+    raised = _raised_by(lambda: apply_board_identity_alias({}, raw_args=raw_args))
+    # Assert
+    assert isinstance(raised, UnexpandedEnvValueError)
+
+
+def test_an_agent_with_no_identity_gets_no_invented_one() -> None:
+    """No identity anywhere means sac must not guess — never a silent default."""
+    # Arrange
+    env = {"UNRELATED": "value"}
+    # Act
+    out = apply_board_identity_alias(env)
+    # Assert
+    assert BOARD_ID_ENV not in out
+
+
+def test_a_blank_identity_is_not_treated_as_an_identity() -> None:
+    # Arrange
+    env = {LEGACY_BOARD_ID_ENV: "   "}
+    # Act
+    out = apply_board_identity_alias(env)
+    # Assert
+    assert BOARD_ID_ENV not in out
+
+
+def test_unrelated_env_pairs_survive_the_alias_step() -> None:
+    # Arrange
+    env = {LEGACY_BOARD_ID_ENV: "agent", "SCITEX_CARDS_DUAL_WRITE": "1"}
+    # Act
+    out = apply_board_identity_alias(env)
+    # Assert
+    assert out["SCITEX_CARDS_DUAL_WRITE"] == "1"
+
+
+def test_the_alias_does_not_mutate_the_input_mapping() -> None:
+    # Arrange
+    env = {LEGACY_BOARD_ID_ENV: "agent"}
+    # Act
+    apply_board_identity_alias(env)
+    # Assert
+    assert BOARD_ID_ENV not in env
+
+
+def test_applying_the_alias_twice_is_idempotent() -> None:
+    # Arrange
+    once = apply_board_identity_alias({LEGACY_BOARD_ID_ENV: "agent"})
+    # Act
+    twice = apply_board_identity_alias(once)
+    # Assert
+    assert twice == once
+
+
+# ----------------------------------------------------------------------
+# The rendered argv — what actually reaches the container.
+# ----------------------------------------------------------------------
+
+
+def test_the_current_name_reaches_the_rendered_env_flags() -> None:
+    """A merge correct in a dict and wrong in the flags is still a broken fix."""
+    # Arrange
+    config = SimpleNamespace(env={LEGACY_BOARD_ID_ENV: "scitex-agent-container"})
+    # Act
+    flags = fleet_env_flags(config, defaults={})
+    # Assert
+    assert f"{BOARD_ID_ENV}=scitex-agent-container" in flags
+
+
+def test_the_legacy_name_reaches_the_rendered_env_flags() -> None:
+    # Arrange
+    config = SimpleNamespace(env={LEGACY_BOARD_ID_ENV: "scitex-agent-container"})
+    # Act
+    flags = fleet_env_flags(config, defaults={})
+    # Assert
+    assert f"{LEGACY_BOARD_ID_ENV}=scitex-agent-container" in flags

--- a/tests/scitex_agent_container/runtimes/test__fleet_env.py
+++ b/tests/scitex_agent_container/runtimes/test__fleet_env.py
@@ -249,3 +249,113 @@ def test_flag_value_is_rendered_verbatim(value: str) -> None:
     flags = fleet_env_flags(config, defaults={})
     # Assert
     assert flags[1] == f"K={value}"
+
+
+# ----------------------------------------------------------------------
+# Board identity — BOTH names for the transition window, and the loud
+# validator that refuses an unexpanded ``${VAR}`` (INCIDENT 2026-07-19:
+# seven cards stored ``created_by='${SCITEX_CARDS_AGENT_ID}'``).
+# ----------------------------------------------------------------------
+
+
+def test_starting_an_agent_exports_the_current_board_identity_name() -> None:
+    """scitex-cards reads SCITEX_CARDS_AGENT_ID; sac injected only the old name."""
+    # Arrange
+    config = SimpleNamespace(env={"SCITEX_TODO_AGENT_ID": "scitex-agent-container"})
+    # Act
+    merged = effective_env(config, defaults={})
+    # Assert
+    assert merged["SCITEX_CARDS_AGENT_ID"] == "scitex-agent-container"
+
+
+def test_starting_an_agent_still_exports_the_legacy_board_identity_name() -> None:
+    """Both, not a swap — installed scitex-cards versions differ across the fleet."""
+    # Arrange
+    config = SimpleNamespace(env={"SCITEX_TODO_AGENT_ID": "scitex-agent-container"})
+    # Act
+    merged = effective_env(config, defaults={})
+    # Assert
+    assert merged["SCITEX_TODO_AGENT_ID"] == "scitex-agent-container"
+
+
+def _rejection_message(config: SimpleNamespace) -> str:
+    """The error ``effective_env`` raises for ``config``, or ``""`` if it did not.
+
+    Keeps the rejection tests at ONE assertion each (STX-TQ007 counts a
+    ``pytest.raises`` block as an assertion, so pairing it with an assert on
+    the message would be two).
+    """
+    try:
+        effective_env(config, defaults={})
+    except ValueError as exc:
+        return str(exc)
+    return ""
+
+
+def test_an_unexpanded_substitution_value_is_rejected_loudly() -> None:
+    """A ``${VAR}`` that never expanded is a non-answer; it must never be stored."""
+    # Arrange
+    config = SimpleNamespace(env={"SCITEX_CARDS_AGENT_ID": "${SCITEX_CARDS_AGENT_ID}"})
+    # Act
+    message = _rejection_message(config)
+    # Assert
+    assert "SCITEX_CARDS_AGENT_ID" in message
+
+
+def test_the_rejection_error_quotes_the_offending_value() -> None:
+    # Arrange
+    config = SimpleNamespace(env={"ANY_KEY": "${SOMETHING}"})
+    # Act
+    message = _rejection_message(config)
+    # Assert
+    assert "${SOMETHING}" in message
+
+
+def test_a_normal_board_identity_value_passes_through_unchanged() -> None:
+    """CONTROL — the validator must reject non-answers, not everything."""
+    # Arrange
+    config = SimpleNamespace(env={"SCITEX_TODO_AGENT_ID": "scitex-agent-container"})
+    # Act
+    merged = effective_env(config, defaults={})
+    # Assert
+    assert merged["SCITEX_TODO_AGENT_ID"] == "scitex-agent-container"
+
+
+def test_a_normal_unrelated_value_passes_through_unchanged() -> None:
+    """CONTROL — an ordinary value with no ``${`` is untouched."""
+    # Arrange
+    config = SimpleNamespace(env={"PLAIN": "scitex-agent-container"})
+    # Act
+    merged = effective_env(config, defaults={})
+    # Assert
+    assert merged["PLAIN"] == "scitex-agent-container"
+
+
+def test_raw_args_declared_identity_is_mirrored_to_the_current_name() -> None:
+    """Most specs declare the identity ONLY in raw_args, never in spec.env."""
+    # Arrange
+    config = SimpleNamespace(
+        env={},
+        apptainer=SimpleNamespace(
+            raw_args=["--env", "SCITEX_TODO_AGENT_ID=scitex-dev"]
+        ),
+    )
+    # Act
+    merged = effective_env(config, defaults={})
+    # Assert
+    assert merged["SCITEX_CARDS_AGENT_ID"] == "scitex-dev"
+
+
+def test_raw_args_identity_wins_over_the_spec_env_identity() -> None:
+    """apptainer --env is last-wins and raw_args are appended AFTER spec.env."""
+    # Arrange
+    config = SimpleNamespace(
+        env={"SCITEX_TODO_AGENT_ID": "from-spec-env"},
+        apptainer=SimpleNamespace(
+            raw_args=["--env", "SCITEX_TODO_AGENT_ID=from-raw-args"]
+        ),
+    )
+    # Act
+    merged = effective_env(config, defaults={})
+    # Assert
+    assert merged["SCITEX_CARDS_AGENT_ID"] == "from-raw-args"


### PR DESCRIPTION
## The bug, in one line

A value meaning *"I could not resolve this"* was accepted and written to the board as if it were an answer.

## What happened

scitex-cards renamed its identity variable `SCITEX_TODO_AGENT_ID` → `SCITEX_CARDS_AGENT_ID`. sac injected only the **old** name. The shared baseline `.mcp.json` had already migrated to the **new** name, so it expanded that reference against an environment where the variable did not exist — and the literal placeholder text survived all the way into the card store.

Cards in the live DB record the variable *name*, unexpanded, as their author. **7 rows when first reported, 15 a few hours later** — the count climbed because every new card written by an affected agent added one. The board cannot say who wrote them.

Nothing errored. That is the whole problem.

## Two independent defects, two independent fixes

### 1. The missing name — `apply_board_identity_alias()`

Mirrors the identity onto **both** spellings with the same value.

Deliberately a mirror and not a swap: installed scitex-cards versions differ across the fleet, so an agent still on a pre-rename build reads only the legacy name. Dropping it would break that agent's writes *in exactly the way the missing new name broke these*.

The effective identity is resolved the way apptainer itself resolves it — `raw_args` are appended **after** the flags rendered from `spec.env`, and `--env` is last-wins — so the mirror cannot disagree with what the container actually receives. For most of the fleet the identity is declared only in `raw_args`, so an alias derived from `spec.env` alone would mirror a value the agent never runs with.

The module docstring states the two conditions that must **both** hold before the legacy name is removed, so the next person does not delete it early and recreate this incident with the names swapped.

### 2. The non-answer stored as an answer — `reject_unexpanded_env()`

The deeper bug is not the rename. Any value that still looks like an unexpanded shell substitution is now rejected **at the boundary where sac sets it**, naming three things the reader needs in order to act: the variable, the offending value, and the likeliest cause.

It is never silently replaced by a default. A silent default would put a *wrong* author on the card — worse than a launch that stops and says why.

Note the deliberate asymmetry with `_to_home_text.interpolate_env`, which **leaves** such literals in materialised *files* for expansion later inside the container. That is correct there — the file is expanded downstream by the agent's own environment. It is exactly what must never happen here: this code renders the container's `--env` flags, which are the end of the line. Nothing downstream expands them, so a substitution reaching this point has already failed.

## Verification

- New unit tests cover both functions, including the split (`--env K=V`) and glued (`--env=K=V`) spellings that both occur in real specs, and the raw_args-wins-over-spec.env precedence.
- `test__apptainer_jail.py` fails **4 of 25 identically on this branch and on develop** — those failures are pre-existing and unrelated. Worth its own issue: develop is currently red.

## Scope note

This fixes the *injection* side. The already-corrupted rows are scitex-cards' data and are left for their migration to normalise — raised with that agent rather than repaired unilaterally.
