### PR TITLE
fix(sif-bake): one build, one filesystem — move the apptainer cache off GPFS

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -256,8 +256,28 @@ From: ./sac-base.sif
         # 2026-07-12 fleet-drift: a floor the inherited version already
         # satisfied never re-resolved, and the layer froze on base's build
         # for days). ``-U`` forces the upgrade this layer exists to deliver.
+        # TEMPORARY SHA PIN (2026-07-19) — NOT the steady state. Remove and
+        # restore the floor the moment scitex-cards >=0.17.2 is ON PyPI.
+        #
+        # WHY: PyPI's latest is 0.17.0, and 0.17.0 DESTROYS CARD DATABASES.
+        # Its store resolution accepts an explicit YAML path that does not
+        # exist and a bundled-example fallback; a YAML->sqlite sync then wrote
+        # the example's single card over 2142 real ones (2026-07-19, recovered
+        # from backup). Baking the PyPI floor pins that version into every
+        # agent image, so every agent restarting onto it reproduces the loss.
+        #
+        # WHY NOT JUST BUMP THE FLOOR: 0.17.1 DOES NOT EXIST AS AN ARTIFACT.
+        # Its tag points at a commit predating the fix, so every publish run
+        # since 2026-07-18T14:02 failed. Tag, version bump and release notes
+        # all exist; nothing was ever uploaded. A floor of >=0.17.1 would
+        # therefore resolve to nothing installable — the record exists, the
+        # thing does not.
+        #
+        # The fix IS on develop and verified there by scitex-cards (the
+        # example runs clean with no $SCITEX_CARDS_DB). Operator chose the SHA
+        # pin over waiting a CI cycle (2026-07-19, "a").
         uv pip install --python /opt/venv-sac/bin/python -U \
-            "scitex-cards[mcp]>=0.16.0"
+            "scitex-cards[mcp] @ git+https://github.com/scitex-ai/scitex-cards@dcb3d5b086f752cf85ffcc48b2a3e1894ec8b82a"
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             pip setuptools wheel
@@ -295,8 +315,12 @@ From: ./sac-base.sif
         # actually moves it past whatever version base baked — without it a
         # satisfied requirement is a no-op and the layer silently freezes on
         # base's build (the 2026-07-12 fleet-drift).
+        # TEMPORARY SHA PIN — mirrors the uv branch above; see it for the full
+        # reason. Short version: PyPI's 0.17.0 destroys card databases and
+        # 0.17.1 was never actually published, so the floor cannot express
+        # "the fixed version". Restore the floor once >=0.17.2 is on PyPI.
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
-            "scitex-cards[mcp]>=0.16.0"
+            "scitex-cards[mcp] @ git+https://github.com/scitex-ai/scitex-cards@dcb3d5b086f752cf85ffcc48b2a3e1894ec8b82a"
     fi
 
     # ---- 2b. FAIL-LOUD staleness gate — assert BY SYMBOL ----------------

--- a/src/scitex_agent_container/containers/spartan-sif-bake.sh
+++ b/src/scitex_agent_container/containers/spartan-sif-bake.sh
@@ -237,11 +237,31 @@ echo "build: layer=$LAYER ts=$TS cpus=$CPUS (log: $BUILD_LOG)"
 # than redirected: a redirect leaves the channel silent for ~20 minutes, and
 # the master's journal gets the full bake log as a bonus. pipefail makes the
 # captured rc srun's, not tee's.
+#
+# ONE FILESYSTEM RULE — TMPDIR *AND* CACHEDIR ARE BOTH NODE-LOCAL.
+# CACHEDIR used to point at "$WORKDIR/apptainer-cache", i.e. GPFS, while
+# TMPDIR was node-local: ONE build straddling TWO filesystems with different
+# consistency semantics. GPFS on this cluster has a documented read-after-
+# write consistency race — the same root cause as the CI-runner _work/_temp
+# incident, which produced "Missing file at path ..." and "Unknown system
+# error -116" (ESTALE) with no clean error and no exit signal.
+#
+# 2026-07-19: two bakes died at DIFFERENT points (one after "Build complete",
+# one mid-apt), each with no error, no signal and no SAC_BAKE_RESULT line.
+# A deterministic control-flow bug dies in the SAME place every run; a
+# filesystem race dies wherever it happens to be. Disk space was NOT the
+# cause and is refuted with numbers: GPFS had 2.0T / 2.8M inodes free, node
+# /tmp 3.3T of 3.5T free, /dev/shm 1008G free.
+#
+# THE TRADE, stated so nobody "optimises" it back: a node-local cache does
+# NOT persist across nodes or lease re-allocations, so some bakes re-pull
+# base layers. A cache miss costs minutes. A consistency race costs a
+# silently unpublished image and a whole debugging session. Take the miss.
 "$SRUN" --input=none --jobid="$JID" --overlap --ntasks=1 --cpus-per-task="$CPUS" \
     --job-name="sac-sif-bake-$LAYER" \
     --chdir="$CTX" \
-    --export=ALL,APPTAINER_TMPDIR="/tmp/sac-sif-bake-$USER",APPTAINER_CACHEDIR="$WORKDIR/apptainer-cache" \
-    bash -c "mkdir -p /tmp/sac-sif-bake-$USER && exec \"$APPTAINER\" build --force \"$PARTIAL_SIF\" \"$CTX/apptainer-$LAYER.def\"" \
+    --export=ALL,APPTAINER_TMPDIR="/tmp/sac-sif-bake-$USER",APPTAINER_CACHEDIR="/tmp/sac-sif-bake-$USER/cache" \
+    bash -c "mkdir -p /tmp/sac-sif-bake-$USER/cache && exec \"$APPTAINER\" build --force \"$PARTIAL_SIF\" \"$CTX/apptainer-$LAYER.def\"" \
     < /dev/null 2>&1 | tee "$BUILD_LOG"
 BUILD_RC=$?
 [ "$BUILD_RC" -eq 0 ] || fail "apptainer-build" "rc=$BUILD_RC (log: $BUILD_LOG)"

--- a/src/scitex_agent_container/containers/spartan-sif-bake.sh
+++ b/src/scitex_agent_container/containers/spartan-sif-bake.sh
@@ -257,11 +257,17 @@ echo "build: layer=$LAYER ts=$TS cpus=$CPUS (log: $BUILD_LOG)"
 # NOT persist across nodes or lease re-allocations, so some bakes re-pull
 # base layers. A cache miss costs minutes. A consistency race costs a
 # silently unpublished image and a whole debugging session. Take the miss.
+#
+# ONE VARIABLE, so the invariant is greppable rather than implied: both
+# APPTAINER_TMPDIR and APPTAINER_CACHEDIR derive from BUILD_SCRATCH, so they
+# cannot drift onto different filesystems by an edit to one of them. A test
+# asserts they share this parent AND that the parent is under /tmp.
+BUILD_SCRATCH="/tmp/sac-sif-bake-$USER"
 "$SRUN" --input=none --jobid="$JID" --overlap --ntasks=1 --cpus-per-task="$CPUS" \
     --job-name="sac-sif-bake-$LAYER" \
     --chdir="$CTX" \
-    --export=ALL,APPTAINER_TMPDIR="/tmp/sac-sif-bake-$USER",APPTAINER_CACHEDIR="/tmp/sac-sif-bake-$USER/cache" \
-    bash -c "mkdir -p /tmp/sac-sif-bake-$USER/cache && exec \"$APPTAINER\" build --force \"$PARTIAL_SIF\" \"$CTX/apptainer-$LAYER.def\"" \
+    --export=ALL,APPTAINER_TMPDIR="$BUILD_SCRATCH/tmp",APPTAINER_CACHEDIR="$BUILD_SCRATCH/cache" \
+    bash -c "mkdir -p \"$BUILD_SCRATCH/tmp\" \"$BUILD_SCRATCH/cache\" && exec \"$APPTAINER\" build --force \"$PARTIAL_SIF\" \"$CTX/apptainer-$LAYER.def\"" \
     < /dev/null 2>&1 | tee "$BUILD_LOG"
 BUILD_RC=$?
 [ "$BUILD_RC" -eq 0 ] || fail "apptainer-build" "rc=$BUILD_RC (log: $BUILD_LOG)"

--- a/src/scitex_agent_container/containers/spartan-sif-bake.sh
+++ b/src/scitex_agent_container/containers/spartan-sif-bake.sh
@@ -258,16 +258,21 @@ echo "build: layer=$LAYER ts=$TS cpus=$CPUS (log: $BUILD_LOG)"
 # base layers. A cache miss costs minutes. A consistency race costs a
 # silently unpublished image and a whole debugging session. Take the miss.
 #
-# ONE VARIABLE, so the invariant is greppable rather than implied: both
-# APPTAINER_TMPDIR and APPTAINER_CACHEDIR derive from BUILD_SCRATCH, so they
-# cannot drift onto different filesystems by an edit to one of them. A test
-# asserts they share this parent AND that the parent is under /tmp.
-BUILD_SCRATCH="/tmp/sac-sif-bake-$USER"
+# BOTH PATHS SPELLED OUT IN FULL, sharing one parent — deliberately NOT a
+# shell variable. A variable assigned on the line above would live OUTSIDE
+# this block, and the stdin-guard harness extracts each srun invocation IN
+# ISOLATION to prove it does not swallow the script tail. An unset variable
+# there makes the block fail early for the wrong reason, so the control test
+# can no longer tell a guarded block from an unguarded one.
+# Keep every path this block needs INSIDE the block.
+#
+# The invariant a test pins: both paths share the SAME parent, and that
+# parent is under node-local /tmp. Editing one without the other breaks it.
 "$SRUN" --input=none --jobid="$JID" --overlap --ntasks=1 --cpus-per-task="$CPUS" \
     --job-name="sac-sif-bake-$LAYER" \
     --chdir="$CTX" \
-    --export=ALL,APPTAINER_TMPDIR="$BUILD_SCRATCH/tmp",APPTAINER_CACHEDIR="$BUILD_SCRATCH/cache" \
-    bash -c "mkdir -p \"$BUILD_SCRATCH/tmp\" \"$BUILD_SCRATCH/cache\" && exec \"$APPTAINER\" build --force \"$PARTIAL_SIF\" \"$CTX/apptainer-$LAYER.def\"" \
+    --export=ALL,APPTAINER_TMPDIR="/tmp/sac-sif-bake-$USER/tmp",APPTAINER_CACHEDIR="/tmp/sac-sif-bake-$USER/cache" \
+    bash -c "mkdir -p /tmp/sac-sif-bake-$USER/tmp /tmp/sac-sif-bake-$USER/cache && exec \"$APPTAINER\" build --force \"$PARTIAL_SIF\" \"$CTX/apptainer-$LAYER.def\"" \
     < /dev/null 2>&1 | tee "$BUILD_LOG"
 BUILD_RC=$?
 [ "$BUILD_RC" -eq 0 ] || fail "apptainer-build" "rc=$BUILD_RC (log: $BUILD_LOG)"

--- a/tests/integration/test_spartan_sif_bake_scratch_filesystem.py
+++ b/tests/integration/test_spartan_sif_bake_scratch_filesystem.py
@@ -35,8 +35,8 @@ BAKE_SCRIPT = (
 
 # The pre-fix export line, verbatim, for the mutation controls.
 _FIXED_EXPORT = (
-    '--export=ALL,APPTAINER_TMPDIR="$BUILD_SCRATCH/tmp"'
-    ',APPTAINER_CACHEDIR="$BUILD_SCRATCH/cache"'
+    '--export=ALL,APPTAINER_TMPDIR="/tmp/sac-sif-bake-$USER/tmp"'
+    ',APPTAINER_CACHEDIR="/tmp/sac-sif-bake-$USER/cache"'
 )
 _SPLIT_EXPORT = (
     '--export=ALL,APPTAINER_TMPDIR="/tmp/sac-sif-bake-$USER"'

--- a/tests/integration/test_spartan_sif_bake_scratch_filesystem.py
+++ b/tests/integration/test_spartan_sif_bake_scratch_filesystem.py
@@ -1,0 +1,160 @@
+"""The bake's scratch must live on ONE filesystem — node-local, not GPFS.
+
+MEASURED (2026-07-19). The build ``srun`` in ``containers/spartan-sif-bake.sh``
+exported ``APPTAINER_TMPDIR`` onto node-local ext4 and ``APPTAINER_CACHEDIR``
+onto ``$WORKDIR/apptainer-cache`` on GPFS, so a single apptainer build ran
+across two filesystems with different consistency semantics. Two live bakes
+died at DIFFERENT points — one after writing a complete 1.4GB ``.partial``,
+one mid-build during apt — with no error, no signal and no ``SAC_BAKE_RESULT``
+line. A deterministic control-flow bug dies in the same place every run; the
+divergence is what a filesystem consistency race looks like. Spartan's GPFS
+has a documented read-after-write race (the CI-runner ``_temp`` incident:
+ESTALE / "Unknown system error -116", re-confirmed live 2026-07-18) and the
+remedy there was the same one: move the scratch off GPFS.
+
+This is a leading hypothesis, not a proven cure — an intermittent fault is not
+disproved by one green bake. What these tests DO pin is the invariant the fix
+asserts, so nobody silently re-splits the scratch across two filesystems while
+chasing a cache hit. The control tests mutate the shipped script back to its
+pre-fix shape: a checker that cannot go red proves nothing about the green.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from pathlib import Path
+
+import scitex_agent_container
+
+BAKE_SCRIPT = (
+    Path(scitex_agent_container.__file__).resolve().parent
+    / "containers"
+    / "spartan-sif-bake.sh"
+)
+
+# The pre-fix export line, verbatim, for the mutation controls.
+_FIXED_EXPORT = (
+    '--export=ALL,APPTAINER_TMPDIR="$BUILD_SCRATCH/tmp"'
+    ',APPTAINER_CACHEDIR="$BUILD_SCRATCH/cache"'
+)
+_SPLIT_EXPORT = (
+    '--export=ALL,APPTAINER_TMPDIR="/tmp/sac-sif-bake-$USER"'
+    ',APPTAINER_CACHEDIR="$WORKDIR/apptainer-cache"'
+)
+
+_ASSIGNMENT = re.compile(r'(APPTAINER_(?:TMPDIR|CACHEDIR))="([^"]*)"')
+_TOP_LEVEL_ASSIGNMENT = re.compile(r'^([A-Z_][A-Z0-9_]*)="([^"]*)"', re.MULTILINE)
+_VAR_REF = re.compile(r"\$([A-Z_][A-Z0-9_]*)")
+
+
+def _script_source() -> str:
+    return BAKE_SCRIPT.read_text(encoding="utf-8")
+
+
+def _export_line(source: str) -> str:
+    """The build srun's ``--export=`` line. Exactly one, or the parse is a lie."""
+    lines = [ln for ln in source.splitlines() if "--export=ALL," in ln]
+    if len(lines) != 1:
+        raise AssertionError(f"expected 1 build --export= line, found {len(lines)}")
+    return lines[0]
+
+
+def _scratch_dirs(source: str) -> dict[str, str]:
+    """Map ``APPTAINER_TMPDIR``/``APPTAINER_CACHEDIR`` to their exported paths."""
+    found = dict(_ASSIGNMENT.findall(_export_line(source)))
+    missing = {"APPTAINER_TMPDIR", "APPTAINER_CACHEDIR"} - set(found)
+    if missing:
+        raise AssertionError(f"build srun exports neither of: {sorted(missing)}")
+    return found
+
+
+def _mkdir_command(source: str) -> str:
+    """The ``mkdir -p`` the build srun runs ON THE NODE, and only that.
+
+    Scoped to the ``bash -c`` payload on purpose. Searching the whole file
+    would match the ``--export=`` line itself, so the check would pass on a
+    script that creates nothing — a test the mutation cannot move.
+    """
+    lines = [ln for ln in source.splitlines() if "bash -c" in ln and "mkdir -p" in ln]
+    if len(lines) != 1:
+        raise AssertionError(f"expected 1 build `bash -c` mkdir, found {len(lines)}")
+    return lines[0]
+
+
+def _expand(path: str, source: str) -> str:
+    """Substitute the script's own top-level ``NAME="literal"`` assignments.
+
+    Comparing the raw text would call two spellings of one directory different
+    and one variable used twice the same — neither is what "same filesystem"
+    means. ``$USER`` has no assignment and stays literal; it is identical on
+    both sides, so it cannot hide a split.
+    """
+    literals = dict(_TOP_LEVEL_ASSIGNMENT.findall(source))
+    return _VAR_REF.sub(
+        lambda m: literals.get(m.group(1), m.group(0)),
+        path,
+    )
+
+
+def _scratch_parents(source: str) -> tuple[str, str]:
+    """The parent dir of each scratch path — equal iff they share a root."""
+    dirs = _scratch_dirs(source)
+    return (
+        posixpath.dirname(_expand(dirs["APPTAINER_TMPDIR"], source)),
+        posixpath.dirname(_expand(dirs["APPTAINER_CACHEDIR"], source)),
+    )
+
+
+def test_build_scratch_tmpdir_and_cachedir_share_a_parent() -> None:
+    # Arrange — the whole point: one apptainer build, one filesystem.
+    tmp_parent, cache_parent = _scratch_parents(_script_source())
+    # Act
+    same_root = tmp_parent == cache_parent
+    # Assert
+    assert same_root, f"scratch split across {tmp_parent!r} and {cache_parent!r}"
+
+
+def test_build_scratch_parent_is_node_local_tmp() -> None:
+    # Arrange — sharing a root is not enough; the shared root must be the
+    # node-local one. Both paths under $WORKDIR would pass the check above
+    # and put the entire build back on GPFS.
+    tmp_parent, _ = _scratch_parents(_script_source())
+    # Act
+    node_local = tmp_parent.startswith("/tmp/")
+    # Assert
+    assert node_local, f"build scratch parent {tmp_parent!r} is not under /tmp/"
+
+
+def test_build_srun_creates_both_scratch_directories() -> None:
+    # Arrange — apptainer does not create a missing CACHEDIR tree for us, and
+    # the node-local scratch is empty on every fresh node by construction.
+    source = _script_source()
+    dirs = _scratch_dirs(source)
+    mkdir = _mkdir_command(source)
+    # Act
+    created = [path for path in dirs.values() if path in mkdir]
+    # Assert
+    assert sorted(created) == sorted(dirs.values()), f"not mkdir'd: {dirs}"
+
+
+def test_control_the_split_scratch_fails_the_shared_parent_check() -> None:
+    # Arrange — MUTATION PROOF. Put the pre-2026-07-19 export line back on the
+    # real shipped script. If the check still reports one filesystem, the
+    # green above is measuring nothing and this file is decoration.
+    mutated = _script_source().replace(_FIXED_EXPORT, _SPLIT_EXPORT)
+    # Act
+    tmp_parent, cache_parent = _scratch_parents(mutated)
+    # Assert
+    assert tmp_parent != cache_parent
+
+
+def test_control_the_mutation_actually_edits_the_script() -> None:
+    # Arrange — a replace() that matched nothing would make the control above
+    # pass against unmutated text, which is the same failure it exists to
+    # catch. Pin that the fixed export line is really the one we ship.
+    source = _script_source()
+    # Act
+    mutated = source.replace(_FIXED_EXPORT, _SPLIT_EXPORT)
+    # Assert
+    assert mutated != source


### PR DESCRIPTION
## The defect

The build's scratch straddled **two filesystems**:

```
APPTAINER_TMPDIR=/tmp/sac-sif-bake-$USER          <- node-local ext4
APPTAINER_CACHEDIR=$WORKDIR/apptainer-cache       <- GPFS
```

One apptainer build, two storage systems with different consistency semantics.

## What was observed

Two live bakes on the standing lease, 2026-07-19:

| run | outcome |
|---|---|
| 1 | build **completed** — 1.4 GB `.partial`, 186,724-byte log — then died before gate/publish, no `SAC_BAKE_RESULT` |
| 2 | died **earlier**, mid-build during apt, 38,957-byte log, no artifact |

Both silent: no error, no signal, no result line.

**Different death points is the discriminating evidence.** A deterministic control-flow bug dies in the same place every run. A filesystem consistency race dies wherever it happens to be.

## Hypotheses refuted with numbers before landing this

- `set -e` aborting before `RC=$?` — the script sets only `set -uo pipefail` (line 62). No `-e`, no trap.
- Project GPFS full — 2.0 T and 2,812,839 inodes free.
- Node scratch full — `/tmp` 3.3 T of 3.5 T free; `/dev/shm` 1008 G, zero used.

Disk space was never the constraint. The split was.

## Prior art on this cluster

GPFS here has a documented read-after-write consistency race — the root cause of the CI-runner `_work/_temp` incident, which produced `Missing file at path ...` and `Unknown system error -116` (ESTALE) with no clean error. scitex-ssh re-confirmed it still live on 2026-07-18. The remedy there was the same: move scratch off GPFS onto node-local storage.

## Result — first complete publish

```
bake: BAKED  .../sac-base-2026-0719-182642.sif
publish: SWAPPED — flipped both live symlinks; pruned 3 older SIFs
bake-remote: all layers ok
```

Gate ran, symbol probe ran, publish and atomic swap completed.

## This is NOT a proven cure

An intermittent fault is not disproved by one green bake. Validation needs **≥3 consecutive successful publishes**, or a captured ESTALE under `bash -x`. The test module docstring says the same, so the caveat lives with the code rather than only here.

## The trade, stated in the code

A node-local cache does not persist across nodes or lease re-allocations, so some bakes re-pull base layers. **A cache miss costs minutes; a consistency race costs a silently unpublished image and an entire debugging session.** The comment says so explicitly so nobody optimises it back onto shared storage.

## Known residual, deliberately not fixed here

The node-local cache has no prune step and will accumulate on a long-lived compute node. `/tmp` has 3.3 T free so it is not urgent, but it is a new unmanaged consumer and wants its own card.