### PR TITLE
fix(tests): a sandbox floor that cannot detect its own breach — assert it after every test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,52 @@ os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(_SAC_STATE_FLOOR / "regi
 # touch the LIVE `sac listen` PIDFILE. It now honours this same variable.
 os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(_SAC_STATE_FLOOR / "runtime")
 
+# --- NEVER let a test touch the REAL card board ---------------------------
+# INCIDENT 2026-07-20: the fleet's live board went from ~2777 cards to SIX.
+# Five of the six survivors were OUR fixtures — `other-agent-card-0/1` and
+# `scitex-todo-card-0/1/2`, i.e. exactly the `seed_cards()` calls in
+# tests/scitex_agent_container/_lifecycle/test__rename_cards.py.
+#
+# This was NOT a floor that broke. It is a floor that was never laid, and the
+# reason it was missed is that the tests LOOKED isolated. `_helpers/fleet_root.
+# isolated_board()` carefully redirects `$SCITEX_TODO_TASKS_YAML_SHARED` at a
+# tmp YAML and passes an explicit `store=` to every scitex-todo call. All of
+# that is correct — and all of it protects only the YAML.
+#
+# The board is no longer just YAML. scitex-cards mirrors every write into a
+# SQLite shadow, and the mirror resolves its OWN path independently of the
+# store you wrote to:
+#
+#   _dual_write.mirror_after_save(doc, store_path)   # store_path = our tmp yaml
+#     -> mirror_doc_incremental(doc, resolve_db_path(), store_path=store_path)
+#                                    ^^^^^^^^^^^^^^^^^ no explicit arg
+#
+# `resolve_db_path()` (scitex_cards/_db.py:95) with no argument falls through
+# `$SCITEX_CARDS_DB` -> `$SCITEX_TODO_DB` -> `~/.scitex/cards/cards.db`. None of
+# those were set, so the doc went to tmp and the MIRROR went to the live board.
+#
+# And the mirror is a RECONCILE, not an append (scitex_cards/_db_mirror.py:208):
+#
+#   removed = [i for i in prior if i not in now_hashes]
+#   for tid in removed: _delete_task(conn, tid)
+#
+# So mirroring a 5-card tmp doc onto the real DB DELETED the other 2,772 cards.
+# The test never touched the real board's YAML and still destroyed the board.
+#
+# Force-set, same rationale as the sac paths above: a hard floor that does not
+# depend on any fixture remembering to opt in. Redirecting the PATH (rather
+# than switching the mirror off) is deliberate — the production dual-write path
+# keeps running and stays under test; it just runs into the sandbox.
+#
+# BOTH names are set. `$SCITEX_CARDS_DB` is the current one and wins;
+# `$SCITEX_TODO_DB` is the pre-rename name (package renamed 2026-07-16) that
+# `resolve_db_path` still honours for direct callers in a process that never
+# imported the scitex_cards root, and this is the variable whose absence cost
+# 2,777 cards — it is not the place to bet on a transition window.
+_SAC_CARDS_DB = _SAC_STATE_FLOOR / "cards" / "cards.db"
+os.environ["SCITEX_CARDS_DB"] = str(_SAC_CARDS_DB)
+os.environ["SCITEX_TODO_DB"] = str(_SAC_CARDS_DB)
+
 
 def _ensure_subprocess_coverage_shim() -> None:
     """Drop an idempotent ``.pth`` shim in site-packages so every child
@@ -263,14 +309,137 @@ _STATE_DB_KEY = "SCITEX_AGENT_CONTAINER_STATE_DB"
 _state_db_seq = itertools.count()
 
 
+# ---------------------------------------------------------------------------
+# THE FLOOR MUST BE ABLE TO DETECT ITS OWN BREACH.
+#
+# Everything above sets the env EARLY so the three import-time constants are
+# born inside the sandbox. Nothing above notices when a test MOVES one back
+# out — and a test can, trivially: `importlib.reload()` re-derives the constant
+# from whatever the env says AT THAT MOMENT, so any teardown that drops the env
+# var and only THEN reloads re-pins the constant at the operator's real
+# ``$HOME/.scitex/agent-container/runtime`` for the REST of that xdist worker's
+# session. Every later test in that worker keeps passing while writing outside
+# the floor, because passing was never conditional on where the bytes landed.
+#
+# That is not hypothetical. Measured on PR #784, all three matrix legs died on
+# a Spartan runner with
+#
+#   OSError: [Errno 122] Disk quota exceeded:
+#     '/home/ywatanabe/.scitex/agent-container/runtime/alpha/instance_id.tmp'
+#
+# and the same escape had produced a FileNotFoundError on that path earlier.
+# Worse than CI: a live fleet agent really is named `alpha`, so the suite was
+# contending with a running agent for its own state files.
+#
+# So the floor gets an alarm. After EVERY test, re-read all three constants and
+# fail loudly — naming the test — if any of them no longer resolves inside
+# ``_SAC_STATE_FLOOR``. The modules are imported LAZILY here, inside the
+# finalizer, on purpose: binding them at collection time would capture a stale
+# reference and we would be asserting about a copy of the value rather than the
+# value the next test is about to use.
+#
+# ``sys.modules.get`` (not ``import_module``) so this fixture never IMPORTS a
+# module the run had not already loaded — a check that changes what it measures
+# is not a check.
+#
+# ORDERING IS LOAD-BEARING: ``_isolate_state_db`` below legitimately points
+# ``DEFAULT_DB_PATH`` at a per-test tmp db and restores it on teardown, so this
+# assertion has to run AFTER that restore. Fixture finalization is LIFO, so
+# this fixture must be SET UP FIRST — which is why ``_isolate_state_db``
+# requests it by name rather than relying on declaration order.
+# ---------------------------------------------------------------------------
+
+_STATE_FLOOR_CONSTANTS = (
+    ("scitex_agent_container._state.state_db", "DEFAULT_DB_PATH"),
+    ("scitex_agent_container._state.registry", "REGISTRY_DIR"),
+    ("scitex_agent_container._runners._session_state", "DEFAULT_STATE_ROOT"),
+)
+
+
+@pytest.fixture(autouse=True, scope="function")
+def _assert_state_floor_intact(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Fail the test that moves an import-time state constant off the floor."""
+    yield
+
+    import sys
+
+    floor = _SAC_STATE_FLOOR.resolve()
+    breaches: list[str] = []
+    for module_path, attr in _STATE_FLOOR_CONSTANTS:
+        module = sys.modules.get(module_path)
+        if module is None:
+            continue
+        value = getattr(module, attr, None)
+        if value is None:
+            continue
+        resolved = Path(value).resolve()
+        if resolved != floor and floor not in resolved.parents:
+            breaches.append(f"  {module_path}.{attr}\n      -> {resolved}")
+
+    # The card board is checked by ASKING THE RESOLVER, not by reading a
+    # constant: `scitex_cards._db.resolve_db_path()` is a function evaluated at
+    # every write, so the only honest question is the one the dual-write mirror
+    # itself asks -- "where would a card write land RIGHT NOW". Reading an env
+    # var here would re-implement its precedence chain and could agree with
+    # itself while disagreeing with production.
+    #
+    # scitex-cards is an OPTIONAL peer (see test__rename_cards.py's
+    # importorskip), so its absence is not a breach -- but it must be a real
+    # ImportError, never a silently swallowed one.
+    try:
+        from scitex_cards._db import resolve_db_path
+    except ImportError:
+        resolve_db_path = None
+    if resolve_db_path is not None:
+        card_db = Path(resolve_db_path()).resolve()
+        if card_db != floor and floor not in card_db.parents:
+            breaches.append(f"  scitex_cards._db.resolve_db_path()\n      -> {card_db}")
+
+    if breaches:
+        raise AssertionError(
+            "\n=============== SAC STATE FLOOR BREACHED ===============\n"
+            f"After `{request.node.nodeid}` these state locations no longer\n"
+            "resolve under the per-worker sandbox floor:\n\n"
+            + "\n".join(breaches)
+            + f"\n\n  floor: {floor}\n\n"
+            "Everything from here on in this xdist worker will keep PASSING\n"
+            "while writing to the operator's REAL state -- that is precisely\n"
+            "how this went unseen: nothing was asserting on where the bytes\n"
+            "landed. It has cost three CI legs (Errno 122 on a live agent's\n"
+            "runtime dir) and ~2,772 cards off the live board.\n\n"
+            "If a MODULE CONSTANT moved: the teardown re-derived it from an\n"
+            "env var it had ALREADY dropped. RESTORE the env var BEFORE the\n"
+            "final `importlib.reload(...)`, not after. Working examples:\n"
+            "  tests/scitex_agent_container/_listen/test__agent_delete.py\n"
+            "  tests/scitex_agent_container/_runners/test_claude_session.py\n"
+            "Or register the module with the `env_save_restore` fixture:\n"
+            "  env_save_restore.reload_after_restore(module)\n\n"
+            "If the CARD BOARD moved: something cleared or overrode\n"
+            "$SCITEX_CARDS_DB. Note the dual-write mirror resolves that path\n"
+            "ITSELF at every write and RECONCILES (deletes cards absent from\n"
+            "the doc), so a tmp store plus a real DB path does not merely\n"
+            "pollute the board -- it DESTROYS it.\n"
+            "=======================================================\n"
+        )
+
+
 # scope="function" is SPELLED OUT (it is also pytest's default) because the
 # whole fix depends on it, and a future "let's not rebuild the DB 4900 times"
 # optimisation to scope="session"/"module" would silently REINTRODUCE the bug:
 # `claim_port` never releases, so any db shared across tests re-accumulates
 # rows until [19000, 19999] is exhausted mid-run. Per-TEST or it does not work.
 @pytest.fixture(autouse=True, scope="function")
-def _isolate_state_db(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
-    """Point this test's state.db at a private tmp file. Restores on teardown."""
+def _isolate_state_db(
+    tmp_path_factory: pytest.TempPathFactory,
+    _assert_state_floor_intact: None,
+) -> Iterator[Path]:
+    """Point this test's state.db at a private tmp file. Restores on teardown.
+
+    Requests ``_assert_state_floor_intact`` purely for ORDERING: that makes the
+    floor assertion set up FIRST and therefore (LIFO) finalize LAST, so it
+    observes ``DEFAULT_DB_PATH`` after the restore below rather than while this
+    fixture still has it pointed at a tmp db.
+    """
     from scitex_agent_container._state import state_db
 
     # Computed but deliberately NOT created: `state_db._connect` mkdirs the

--- a/tests/scitex_agent_container/_helpers/fleet_root.py
+++ b/tests/scitex_agent_container/_helpers/fleet_root.py
@@ -189,9 +189,7 @@ COMMS_NODE_SQL = (
     "INSERT INTO comms_nodes (name, host, a2a_port, registered_at, updated_at) "
     "VALUES (?, ?, ?, ?, ?)"
 )
-TURN_SQL = (
-    "INSERT INTO turns (turn_id, name, host, status, ts) VALUES (?, ?, ?, ?, ?)"
-)
+TURN_SQL = "INSERT INTO turns (turn_id, name, host, status, ts) VALUES (?, ?, ?, ?, ?)"
 
 
 def seed_identity_and_history(layout: Layout, name: str) -> Path:
@@ -236,13 +234,20 @@ def _env_overrides(pairs: dict[str, str | None]) -> Iterator[None]:
 def isolated_board(tmp_path: Path) -> Iterator[Path]:
     """Yield a tmp scitex-todo store, fully cut off from the live fleet.
 
-    THREE things must be isolated, not one. Each is a real production
+    FOUR things must be isolated, not one. Each is a real production
     opt-out, not a mock — the code paths stay exactly as they ship; the
     test simply does not ride them.
 
     * **the store** — ``$SCITEX_TODO_TASKS_YAML_SHARED`` points at a tmp
       YAML file, so even a call that forgot ``store=`` lands in tmp rather
       than on the live 1,400-card board.
+
+    * **the SQLite shadow** — ``$SCITEX_CARDS_DB`` (+ its pre-rename alias
+      ``$SCITEX_TODO_DB``) points at a tmp DB. This one is not belt-and-
+      braces, it is load-bearing, and its absence destroyed the live board
+      on 2026-07-20: the dual-write mirror resolves its own path and
+      RECONCILES, so isolating only the YAML meant a five-card tmp doc
+      deleted 2,772 real cards. See the inline note below.
 
     * **the notification rail** — sac registers a ``scitex_todo.hooks``
       consumer (``_listen._card_event_delivery``), so every real
@@ -264,12 +269,42 @@ def isolated_board(tmp_path: Path) -> Iterator[Path]:
     store = tmp_path / "board" / "tasks.yaml"
     store.parent.mkdir(parents=True, exist_ok=True)
     store.write_text("tasks: []\n")
+    cards_db = tmp_path / "board" / "cards.db"
 
     yield from _yield_value(
         store,
         _env_overrides(
             {
                 "SCITEX_TODO_TASKS_YAML_SHARED": str(store),
+                # *** THE SQLITE SHADOW — isolating the YAML IS NOT ENOUGH. ***
+                #
+                # Redirecting the store above protects the YAML and nothing
+                # else. scitex-cards mirrors every write into a SQLite shadow
+                # whose path it resolves ITSELF, ignoring the store you wrote
+                # to: `_dual_write.mirror_after_save` calls
+                # `mirror_doc_incremental(doc, resolve_db_path(), ...)` with NO
+                # explicit path, so it lands on `$SCITEX_CARDS_DB` or, failing
+                # that, the live `~/.scitex/cards/cards.db`.
+                #
+                # And the mirror RECONCILES rather than appends
+                # (`_db_mirror.py:208`): every card in the DB that is absent
+                # from the doc is DELETED. So a tmp store of five seeded cards
+                # does not pollute the real board, it REPLACES it. On
+                # 2026-07-20 that took the fleet board from ~2,777 cards to
+                # six, five of which were this module's own fixtures.
+                #
+                # tests/conftest.py force-sets the same variable as a floor
+                # under the whole suite. This is the belt to that braces: a
+                # test using this helper is isolated even if the floor is not
+                # there (a bare `pytest` from another rootdir, a subprocess
+                # with a scrubbed env, a future refactor of conftest).
+                "SCITEX_CARDS_DB": str(cards_db),
+                # Pre-rename name of the same knob, still honoured by
+                # `resolve_db_path` for direct callers that never imported the
+                # scitex_cards root. Set both — this is the variable whose
+                # absence destroyed the board; do not bet on a transition
+                # window closing cleanly.
+                "SCITEX_TODO_DB": str(cards_db),
                 "SAC_CARD_EVENT_DELIVERY_DISABLED": "1",
                 "SCITEX_TODO_STORE_GIT_AUTOCOMMIT": "0",
                 # `list_tasks(scope=None)` falls back to this. A stray value
@@ -347,6 +382,4 @@ def add_card(
 
 def seed_cards(store: Path, owner: str, count: int) -> list[str]:
     """Add ``count`` real cards owned by ``owner`` to the tmp store."""
-    return [
-        add_card(store, f"{owner}-card-{i}", owner=owner) for i in range(count)
-    ]
+    return [add_card(store, f"{owner}-card-{i}", owner=owner) for i in range(count)]

--- a/tests/scitex_agent_container/_helpers/subprocess_shim.py
+++ b/tests/scitex_agent_container/_helpers/subprocess_shim.py
@@ -19,9 +19,11 @@ Usage::
 from __future__ import annotations
 
 import base64
+import importlib
 import json
 import os
 from pathlib import Path
+from types import ModuleType
 from typing import Callable
 
 import pytest
@@ -167,8 +169,34 @@ def subprocess_shim(tmp_path: Path):
 
 @pytest.fixture
 def env_save_restore():
-    """Generic env save/restore — track keys you mutate, auto-revert."""
+    """Generic env save/restore — track keys you mutate, auto-revert.
+
+    ``reload_after_restore(module)`` additionally re-imports ``module`` AFTER
+    the env has been reverted. Use it for any module whose constants are
+    computed at IMPORT time from an env var this fixture is mutating —
+    ``_state.state_db``, ``_state.registry``, ``_runners._session_state``.
+
+    That ordering is the entire point, and getting it wrong is a REAL bug this
+    package shipped. ``importlib.reload`` re-derives such a constant from
+    whatever the env says at that instant, so a teardown that drops the env var
+    and only THEN reloads pins the constant at the operator's real
+    ``$HOME/.scitex/agent-container/runtime`` for the rest of the xdist
+    worker's session — every later test then passes while writing outside the
+    tests/results sandbox floor set in tests/conftest.py. It cost three green
+    matrix legs on PR #784 (``[Errno 122] Disk quota exceeded`` on a live fleet
+    agent's state path) and went unseen for months because nothing was
+    asserting on where the bytes landed.
+
+    Fixtures previously hand-rolled this and hand-rolled it WRONG, because
+    pytest finalizes inner-first: a fixture's own teardown runs BEFORE this
+    fixture reverts the env, so reloading there sees the still-mutated env.
+    The workaround was to ``os.environ.pop()`` the keys first — which reloads
+    against NO env var at all, i.e. straight back to the real ``$HOME``. Hence
+    this hook: register the module and let the reload happen on the correct
+    side of the restore.
+    """
     saved: dict[str, str | None] = {}
+    reload_targets: list[ModuleType] = []
 
     def _set(key: str, value: str) -> None:
         if key not in saved:
@@ -180,9 +208,16 @@ def env_save_restore():
             saved[key] = os.environ.get(key)
         os.environ.pop(key, None)
 
+    def _reload_after_restore(module: ModuleType) -> None:
+        if module not in reload_targets:
+            reload_targets.append(module)
+
     class _Env:
         set: Callable[[str, str], None] = staticmethod(_set)
         delete: Callable[[str], None] = staticmethod(_delete)
+        reload_after_restore: Callable[[ModuleType], None] = staticmethod(
+            _reload_after_restore
+        )
 
     try:
         yield _Env
@@ -192,3 +227,7 @@ def env_save_restore():
                 os.environ.pop(k, None)
             else:
                 os.environ[k] = v
+        # Only NOW, with the env back to its pre-test values, is a reload
+        # guaranteed to re-derive the constants the rest of the session needs.
+        for module in reload_targets:
+            importlib.reload(module)

--- a/tests/scitex_agent_container/_lifecycle/test__prune_runtime.py
+++ b/tests/scitex_agent_container/_lifecycle/test__prune_runtime.py
@@ -65,17 +65,19 @@ def test_prune_removes_runtime_dir(env_save_restore, tmp_path):
     ss = importlib.reload(
         importlib.import_module("scitex_agent_container._runners._session_state")
     )
-    try:
-        state_dir = ss.state_dir_for("cap")
-        state_dir.mkdir(parents=True)
-        (state_dir / "heartbeat.json").write_text("{}")
-        # Act
-        pr.prune_agent_runtime(_cfg(name="cap", policy="never", prune_on_stop=True))
-        # Assert
-        assert not state_dir.exists()
-    finally:
-        env_save_restore.delete(_RT_ENV)
-        importlib.reload(ss)
+    # Reload on the FAR side of the env restore. Deleting the env var and THEN
+    # reloading (the old shape here) re-derived DEFAULT_STATE_ROOT with no
+    # override at all, pinning it at the real $HOME for the rest of this xdist
+    # worker — this test was the FIRST breach the conftest floor assertion
+    # caught across the whole suite.
+    env_save_restore.reload_after_restore(ss)
+    state_dir = ss.state_dir_for("cap")
+    state_dir.mkdir(parents=True)
+    (state_dir / "heartbeat.json").write_text("{}")
+    # Act
+    pr.prune_agent_runtime(_cfg(name="cap", policy="never", prune_on_stop=True))
+    # Assert
+    assert not state_dir.exists()
 
 
 def test_prune_removes_overlay_dir(tmp_path):

--- a/tests/scitex_agent_container/_lifecycle/test__session_movement.py
+++ b/tests/scitex_agent_container/_lifecycle/test__session_movement.py
@@ -276,6 +276,11 @@ def isolated_runtime_root(tmp_path: Path, env_save_restore):
     import scitex_agent_container._runners._session_state as _ss
 
     importlib.reload(_ss)
+    # This fixture had NO teardown at all: it reloaded the module against the
+    # redirected env and returned, leaving DEFAULT_STATE_ROOT pinned at a
+    # tmp_path that pytest later deletes. Register the reload so it happens
+    # after env_save_restore puts the env back.
+    env_save_restore.reload_after_restore(_ss)
     return runtime_root
 
 

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -1139,6 +1139,11 @@ def _stop_with_prune(
     ss = importlib.reload(
         importlib.import_module("scitex_agent_container._runners._session_state")
     )
+    # Registered HERE, in the shared helper, so both callers are covered by
+    # construction. Their old per-test `finally` blocks dropped the env var and
+    # THEN reloaded, which re-derived DEFAULT_STATE_ROOT from the real $HOME
+    # and left it there for every later test in the worker.
+    env_save_restore.reload_after_restore(ss)
     spec = _write_spec(tmp_path, name=name, restart_block=restart_block)
     registry.add(name, str(spec), f"cld-{name}")
     state_dir = ss.state_dir_for(name)
@@ -1161,22 +1166,16 @@ def test_agent_stop_prune_removes_ephemeral_runtime_dir(
     restart_block = (
         "  restart:\n    policy: never\n    max_retries: 3\n    prune_on_stop: true\n"
     )
-    try:
-        # Act — never-policy agent that opted in via prune_on_stop.
-        state_dir = _stop_with_prune(
-            tmp_path,
-            registry,
-            env_save_restore,
-            name="cap",
-            restart_block=restart_block,
-        )
-        # Assert
-        assert not state_dir.exists()
-    finally:
-        env_save_restore.delete("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
-        importlib.reload(
-            importlib.import_module("scitex_agent_container._runners._session_state")
-        )
+    # Act — never-policy agent that opted in via prune_on_stop.
+    state_dir = _stop_with_prune(
+        tmp_path,
+        registry,
+        env_save_restore,
+        name="cap",
+        restart_block=restart_block,
+    )
+    # Assert
+    assert not state_dir.exists()
 
 
 def test_agent_stop_prune_keeps_persistent_runtime_dir(
@@ -1187,22 +1186,16 @@ def test_agent_stop_prune_keeps_persistent_runtime_dir(
     restart_block = (
         "  restart:\n    policy: always\n    max_retries: 3\n    prune_on_stop: true\n"
     )
-    try:
-        # Act
-        state_dir = _stop_with_prune(
-            tmp_path,
-            registry,
-            env_save_restore,
-            name="coord",
-            restart_block=restart_block,
-        )
-        # Assert
-        assert state_dir.exists()
-    finally:
-        env_save_restore.delete("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
-        importlib.reload(
-            importlib.import_module("scitex_agent_container._runners._session_state")
-        )
+    # Act
+    state_dir = _stop_with_prune(
+        tmp_path,
+        registry,
+        env_save_restore,
+        name="coord",
+        restart_block=restart_block,
+    )
+    # Assert
+    assert state_dir.exists()
 
 
 def test_agent_stop_yaml_gone_with_force_succeeds(

--- a/tests/scitex_agent_container/_listen/test_server_inline_spec_bind_translate.py
+++ b/tests/scitex_agent_container/_listen/test_server_inline_spec_bind_translate.py
@@ -61,11 +61,11 @@ def isolated_env(tmp_path: Path, env_save_restore):
     import scitex_agent_container._runners._session_state as ss
 
     importlib.reload(ss)
+    # Reload on the FAR side of the env restore — see
+    # test_server_startup_failed.py for why popping-then-reloading here
+    # silently re-pinned this constant at the operator's real $HOME.
+    env_save_restore.reload_after_restore(ss)
     yield tmp_path
-    os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
-    os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
-    os.environ.pop("HOME", None)
-    importlib.reload(ss)
 
 
 @pytest.fixture

--- a/tests/scitex_agent_container/_listen/test_server_inline_spec_failloud.py
+++ b/tests/scitex_agent_container/_listen/test_server_inline_spec_failloud.py
@@ -49,19 +49,15 @@ def isolated_env(tmp_path: Path, env_save_restore):
     env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(runtime))
     env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", str(yaml_dir))
     import importlib
-    import os as _os
 
     import scitex_agent_container._runners._session_state as ss
 
     importlib.reload(ss)
+    # See test_server_startup_failed.py's same-named fixture: picking up "the
+    # OPERATOR's HOME" was the BUG, not the goal. Reload on the far side of the
+    # env restore so the constant lands back on the conftest sandbox floor.
+    env_save_restore.reload_after_restore(ss)
     yield tmp_path
-    # See test_server_startup_failed.py's same-named fixture for the
-    # LIFO-finalizer rationale: pop the env keys ourselves so the
-    # reload picks up the OPERATOR's HOME, not our tmp_path.
-    _os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
-    _os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
-    _os.environ.pop("HOME", None)
-    importlib.reload(ss)
 
 
 @pytest.fixture

--- a/tests/scitex_agent_container/_listen/test_server_lineage_acl.py
+++ b/tests/scitex_agent_container/_listen/test_server_lineage_acl.py
@@ -19,7 +19,6 @@ path the listen server reads at request time).
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -52,12 +51,11 @@ def isolated_env(tmp_path: Path, env_save_restore):
     import scitex_agent_container._runners._session_state as ss
 
     importlib.reload(ss)
+    # Reload on the FAR side of the env restore — see
+    # test_server_startup_failed.py for why popping-then-reloading here
+    # silently re-pinned this constant at the operator's real $HOME.
+    env_save_restore.reload_after_restore(ss)
     yield tmp_path
-    os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
-    os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
-    os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
-    os.environ.pop("HOME", None)
-    importlib.reload(ss)
 
 
 @pytest.fixture

--- a/tests/scitex_agent_container/_listen/test_server_restart_route.py
+++ b/tests/scitex_agent_container/_listen/test_server_restart_route.py
@@ -57,12 +57,11 @@ def isolated_env(tmp_path: Path, env_save_restore):
     import scitex_agent_container._runners._session_state as ss
 
     importlib.reload(ss)
+    # Reload on the FAR side of the env restore — see
+    # test_server_startup_failed.py for why popping-then-reloading here
+    # silently re-pinned this constant at the operator's real $HOME.
+    env_save_restore.reload_after_restore(ss)
     yield tmp_path
-    os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
-    os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
-    os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
-    os.environ.pop("HOME", None)
-    importlib.reload(ss)
 
 
 @pytest.fixture

--- a/tests/scitex_agent_container/_listen/test_server_startup_failed.py
+++ b/tests/scitex_agent_container/_listen/test_server_startup_failed.py
@@ -62,18 +62,24 @@ def isolated_env(tmp_path: Path, env_save_restore):
     import scitex_agent_container._runners._session_state as ss
 
     importlib.reload(ss)
+    # Pytest finalizes inner-first (LIFO): this fixture's teardown runs BEFORE
+    # ``env_save_restore`` restores the env, so a reload HERE would re-bind
+    # ``DEFAULT_STATE_ROOT`` to our tmp_path again.
+    #
+    # This used to be worked around by popping the env keys first and then
+    # reloading. That reasoning came from a pre-floor world and is now WRONG:
+    # with the keys popped there is no ``SCITEX_AGENT_CONTAINER_RUNTIME_DIR``
+    # at all, so the reload re-derives ``DEFAULT_STATE_ROOT`` from the
+    # operator's REAL $HOME rather than from the sandbox floor
+    # tests/conftest.py installs. The module was left "cached with the right
+    # defaults" only in the sense that they were the defaults of a machine, not
+    # of this test run — every later test in the worker then wrote to
+    # ~/.scitex/agent-container/runtime while still passing.
+    #
+    # Correct ordering is to reload on the FAR side of the env restore, which
+    # is exactly what ``reload_after_restore`` exists to do.
+    env_save_restore.reload_after_restore(ss)
     yield tmp_path
-    # Pytest finalizes inner-first (LIFO): this fixture's teardown runs
-    # BEFORE ``env_save_restore`` restores the env. So we have to pop
-    # the env keys ourselves before reloading — otherwise the reload
-    # re-binds ``DEFAULT_STATE_ROOT`` to our tmp_path again. After we
-    # reload, ``env_save_restore`` will set the env back to its
-    # original (pre-test) values, but the module is already cached
-    # with the right defaults.
-    os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
-    os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
-    os.environ.pop("HOME", None)
-    importlib.reload(ss)
 
 
 @pytest.fixture

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_movement.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_movement.py
@@ -25,6 +25,17 @@ def isolated_runtime(tmp_path: Path, env_save_restore):
     """Redirect the runtime root + reload ``_session_state`` so
     ``DEFAULT_STATE_ROOT`` picks up the redirected value. Real reload,
     no monkeypatch.
+
+    THE RELOAD MUST BE UNDONE. ``env_save_restore`` puts the ENV VAR back, but
+    ``DEFAULT_STATE_ROOT`` is a MODULE CONSTANT baked at import — so without the
+    second reload it stays pinned at THIS test's tmp dir (which pytest then
+    deletes) for the remainder of the xdist worker's session, and every later
+    test in that worker reads a dangling root out of the process global.
+
+    ``reload_after_restore`` puts that reload on the correct side of the env
+    restore (``env_save_restore`` tears down AFTER this fixture, since we depend
+    on it, so reloading in our own ``finally`` would re-derive the tmp path we
+    are trying to forget).
     """
     root = tmp_path / "runtime"
     root.mkdir()
@@ -32,6 +43,7 @@ def isolated_runtime(tmp_path: Path, env_save_restore):
     import scitex_agent_container._runners._session_state as _ss
 
     importlib.reload(_ss)
+    env_save_restore.reload_after_restore(_ss)
     return root
 
 

--- a/tests/scitex_agent_container/cli_pkg/test_info_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_info_cmds.py
@@ -72,6 +72,10 @@ def tmp_registry(tmp_path, env_save_restore):
     Reloads ``_state.registry`` so its module-level ``REGISTRY_DIR``
     picks up the env var. ``info_cmds`` imports ``Registry`` lazily,
     so the reload is honoured automatically.
+
+    ``reload_after_restore`` undoes that reload once the env is back: without
+    it ``REGISTRY_DIR`` stays pinned at this test's (soon-deleted) tmp dir for
+    the rest of the xdist worker's session.
     """
     reg = tmp_path / "registry"
     reg.mkdir()
@@ -79,6 +83,7 @@ def tmp_registry(tmp_path, env_save_restore):
     import scitex_agent_container._state.registry as _reg
 
     importlib.reload(_reg)
+    env_save_restore.reload_after_restore(_reg)
     yield reg
 
 

--- a/tests/scitex_agent_container/cli_pkg/test_priority_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_priority_cmds.py
@@ -125,6 +125,9 @@ def tmp_registry(tmp_path, env_save_restore) -> Path:
     import scitex_agent_container._state.registry as _reg
 
     importlib.reload(_reg)
+    # Undo the reload once the env is back — otherwise ``REGISTRY_DIR`` stays
+    # pinned at this test's (soon-deleted) tmp dir for the rest of the worker.
+    env_save_restore.reload_after_restore(_reg)
     saved_registry_cls = pc.Registry
     pc.Registry = _reg.Registry  # type: ignore[assignment]
     try:

--- a/tests/scitex_agent_container/cli_pkg/test_status_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_status_cmds.py
@@ -62,6 +62,9 @@ def tmp_registry(tmp_path, env_save_restore):
     import scitex_agent_container._state.registry as _reg
 
     importlib.reload(_reg)
+    # Undo the reload once the env is back — otherwise ``REGISTRY_DIR`` stays
+    # pinned at this test's (soon-deleted) tmp dir for the rest of the worker.
+    env_save_restore.reload_after_restore(_reg)
     saved = status_cmds.Registry
     status_cmds.Registry = _reg.Registry  # type: ignore[assignment]
     try:
@@ -507,7 +510,7 @@ def test_status_per_agent_table_survives_non_ascii_extensions_on_ascii_stdout(
             "    policy: on-failure\n"
             "    max_retries: 3\n"
             "  extensions:\n"
-            "    note: \"❯ ready\"\n"
+            '    note: "❯ ready"\n'
         ),
     )
     _register(tmp_registry, "unicode-agent", spec)

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -70,13 +70,18 @@ def home_redirect(tmp_path: Path, env_save_restore) -> Path:
 def state_root(tmp_path: Path, env_save_restore, home_redirect: Path) -> Path:
     """Sandbox the per-agent state-dir root. Sets the env var that
     ``_session_state.DEFAULT_STATE_ROOT`` caches at import time, then
-    reloads the module so the next ``state_dir_for`` call sees it."""
+    reloads the module so the next ``state_dir_for`` call sees it.
+
+    ``reload_after_restore`` undoes the reload once ``env_save_restore`` has put
+    the env back — without it ``DEFAULT_STATE_ROOT`` stays pinned at this test's
+    (soon-deleted) tmp dir for the rest of the xdist worker's session."""
     root = tmp_path / "runtime"
     root.mkdir()
     env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(root))
     import scitex_agent_container._runners._session_state as ss
 
     importlib.reload(ss)
+    env_save_restore.reload_after_restore(ss)
     return root
 
 
@@ -1638,8 +1643,7 @@ def test_build_run_argv_still_carries_the_real_secret_for_the_subprocess(
     # Assert — the SDK in the container still authenticates: the secret is
     # delivered via the 0600 --env-file, not world-readable --env argv.
     assert (
-        _env_pairs(argv).get("SAC_ANTHROPIC_API_KEY")
-        == "sk-ant-oat01-supersecrettoken"
+        _env_pairs(argv).get("SAC_ANTHROPIC_API_KEY") == "sk-ant-oat01-supersecrettoken"
     )
 
 
@@ -2534,8 +2538,7 @@ def test_listen_env_flags_unions_spec_dirs_value_with_default(
     flags = listen_env_flags(cfg)
     # Assert — the host value rides first, host default appended.
     assert (
-        "SCITEX_AGENT_CONTAINER_YAML_DIRS=/host/agents:"
-        f"{_host_default_agents_dir()}"
+        f"SCITEX_AGENT_CONTAINER_YAML_DIRS=/host/agents:{_host_default_agents_dir()}"
     ) in flags
 
 
@@ -2551,8 +2554,7 @@ def test_listen_env_flags_spec_dirs_pair_is_contiguous(env_save_restore) -> None
     # Act
     flags = listen_env_flags(cfg)
     value = (
-        "SCITEX_AGENT_CONTAINER_YAML_DIRS=/host/agents:"
-        f"{_host_default_agents_dir()}"
+        f"SCITEX_AGENT_CONTAINER_YAML_DIRS=/host/agents:{_host_default_agents_dir()}"
     )
     # Assert
     assert flags[flags.index(value) - 1] == "--env"
@@ -2571,9 +2573,7 @@ def test_listen_env_flags_injects_default_spec_dir_when_unset(
     # Act
     flags = listen_env_flags(cfg)
     # Assert — the host default is injected even with nothing set.
-    assert (
-        f"SCITEX_AGENT_CONTAINER_YAML_DIRS={_host_default_agents_dir()}" in flags
-    )
+    assert f"SCITEX_AGENT_CONTAINER_YAML_DIRS={_host_default_agents_dir()}" in flags
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/test__runtime_paths.py
+++ b/tests/scitex_agent_container/test__runtime_paths.py
@@ -68,23 +68,27 @@ def test_empty_env_falls_back_to_default(env_save_restore):
         ("scitex_agent_container._runners._session_state", "DEFAULT_STATE_ROOT", ""),
     ],
 )
-def test_env_relocates_module_constant(env_save_restore, tmp_path, module_path, attr, subpath):
+def test_env_relocates_module_constant(
+    env_save_restore, tmp_path, module_path, attr, subpath
+):
     # Arrange — clear the per-file override envs so the RUNTIME_DIR fallback
     # is what's exercised; reload so the module-level constant recomputes.
+    #
+    # The final reload is delegated to ``env_save_restore`` rather than done in
+    # a ``finally`` here, and that is the whole fix: reloading before the env is
+    # restored re-derives the constant from an env var this test has just
+    # dropped, which pins it at the operator's real $HOME for every remaining
+    # test in this xdist worker. See the fixture's docstring.
     env_save_restore.delete("SCITEX_AGENT_CONTAINER_STATE_DB")
     env_save_restore.delete("SCITEX_AGENT_CONTAINER_REGISTRY_DIR")
     env_save_restore.set(RUNTIME_DIR_ENV, str(tmp_path / "rt"))
     mod = importlib.reload(importlib.import_module(module_path))
+    env_save_restore.reload_after_restore(mod)
     expected = tmp_path / "rt" / subpath if subpath else tmp_path / "rt"
-    try:
-        # Act
-        got = getattr(mod, attr)
-        # Assert
-        assert Path(got) == expected
-    finally:
-        # Restore the module to the ambient-env state for other tests.
-        env_save_restore.delete(RUNTIME_DIR_ENV)
-        importlib.reload(mod)
+    # Act
+    got = getattr(mod, attr)
+    # Assert
+    assert Path(got) == expected
 
 
 def test_per_file_state_db_override_still_wins(env_save_restore, tmp_path):
@@ -96,12 +100,8 @@ def test_per_file_state_db_override_still_wins(env_save_restore, tmp_path):
     mod = importlib.reload(
         importlib.import_module("scitex_agent_container._state.state_db")
     )
-    try:
-        # Act
-        got = mod.DEFAULT_DB_PATH
-        # Assert
-        assert Path(got) == tmp_path / "explicit" / "s.db"
-    finally:
-        env_save_restore.delete(RUNTIME_DIR_ENV)
-        env_save_restore.delete("SCITEX_AGENT_CONTAINER_STATE_DB")
-        importlib.reload(mod)
+    env_save_restore.reload_after_restore(mod)
+    # Act
+    got = mod.DEFAULT_DB_PATH
+    # Assert
+    assert Path(got) == tmp_path / "explicit" / "s.db"


### PR DESCRIPTION
Two escapes, one class: the suite passed **green while writing outside its sandbox**, because nothing ever asserted on where the bytes landed.

## 1. The card board (the urgent arm)

Tonight the live board went **~2777 cards → 6**. Five of the six survivors were this suite's own fixtures (`other-agent-card-0/1`, `scitex-todo-card-0/1/2`) — the `seed_cards()` calls in `_lifecycle/test__rename_cards.py`.

The tests *looked* isolated. `_helpers/fleet_root.isolated_board()` redirects `$SCITEX_TODO_TASKS_YAML_SHARED` at a tmp YAML and passes explicit `store=` everywhere. All correct — and all of it protects only the YAML.

The board is no longer just YAML. scitex-cards mirrors every write into a SQLite shadow that resolves its **own** path, ignoring the store you wrote to:

```
_dual_write.mirror_after_save(doc, store_path)      # store_path = our tmp yaml
  -> mirror_doc_incremental(doc, resolve_db_path(), store_path=store_path)
                                 ^^^^^^^^^^^^^^^^^ no explicit arg
```

`resolve_db_path()` (`scitex_cards/_db.py:95`) falls through `$SCITEX_CARDS_DB` → `$SCITEX_TODO_DB` → `~/.scitex/cards/cards.db`. **None were set anywhere in the test tree.** And the mirror *reconciles* rather than appends (`_db_mirror.py:208`):

```python
removed = [i for i in prior if i not in now_hashes]
for tid in removed: _delete_task(conn, tid)
```

So mirroring a five-card tmp doc onto the real DB **deleted the other 2,772**. The test never touched the real board's YAML and still destroyed the board.

**Fix:** `$SCITEX_CARDS_DB` (+ legacy `$SCITEX_TODO_DB`) added to the conftest module-body floor, and pinned again per-test in `isolated_board()`. Redirecting the path rather than switching the mirror off is deliberate — the production dual-write path keeps running and stays under test, it just runs into the sandbox.

> **This arm is a STOP-GAP.** Per the operator's ruling that sac must not depend on the card package at all, the ~20 production imports are scheduled for deletion and alarms move to sac's own event log. This becomes redundant once that decoupling lands — but the board is unprotected until then, and that will take longer than tonight.

## 2. The sac state floor

`tests/conftest.py` force-sets three env vars in the module body so import-time constants are born in a per-xdist-worker sandbox. A teardown that **drops the env var and only then calls `importlib.reload()`** re-derives the constant from the real `$HOME`, pinning it there for the rest of the worker's session.

Measured, with the control that makes it evidence:

| run | result |
|---|---|
| `test__runtime_paths.py` **then** `test_lifecycle.py` | 93 passed **and** 3 files created under `$HOME/.scitex/agent-container/runtime/alpha/` |
| `test_lifecycle.py` alone | 85 passed, nothing under `$HOME/.scitex` |

Cost three matrix legs on #784 (`OSError: [Errno 122] Disk quota exceeded` on `.../runtime/alpha/instance_id.tmp`). A live fleet agent really is named `alpha`.

## The class fix

An autouse function-scoped finalizer that, after **every** test, re-reads all three constants and **asks scitex-cards' own resolver** where a card write would land — failing loudly by test name if any escapes the floor.

- Modules are read lazily via `sys.modules.get` inside the finalizer, so it reads the *current* value and never imports something the run had not already loaded.
- The card path is **resolved, not inferred** from an env var — re-implementing that precedence chain would let the check agree with itself while disagreeing with production.
- Ordering is load-bearing: `_isolate_state_db` requests the finalizer by name so it sets up first and therefore finalizes *last*, after the per-test DB restore.

`env_save_restore` also gains `reload_after_restore(module)`, which reloads on the **far side** of the env restore. **I chose this over fixing each site in place**, because the LIFO trap (a fixture's teardown runs *before* `env_save_restore` reverts) is exactly what made five `_listen` fixtures hand-roll the wrong shape and write a comment arguing *for* it. Making the correct thing the easy thing removes the reason the bad shape kept being reinvented. The finalizer is what closes the class; this just stops it being reintroduced.

## Mutation proof (before/after counts)

A seeded scratch board plays the live board's role. **Not** a sandboxed-`$HOME`-only check — with `$HOME` sandboxed the real path is unreachable *by construction*, so that check could never have disagreed.

| leg | tests | board rows | sha256 | breaches |
|---|---|---|---|---|
| floor present | 38 passed | 7 → 7 | **identical** | 0 |
| **card floor line removed** | 38 passed, **38 errors** | **7 → 2** | changed | 76 |

The mutant leg **still reported "38 passed" while destroying the board** — which is the entire point. Restored after.

Third-site check (`_hostsync`, `_maintenance`, `_reconcile` alarms — none of them the originally-implicated tests), proving the guard is not fitted to two known sites:

| leg | result |
|---|---|
| mutant | 52 passed, **52 errors**, 104 breach reports |
| fixed | 52 passed, **0** breaches, sha256 identical |

## Sites fixed

Six known, plus **three the finalizer found that were not on the list** — a full `_lifecycle/` run reported 1,061 errors (one root breach plus its cascade), and tracing the first named `test__prune_runtime.py`. `test__session_movement.py`'s fixture had **no teardown at all**.

## Acceptance (run, not reasoned about)

- `test__runtime_paths.py` then `test_lifecycle.py`, sandboxed `$HOME`: **93 passed, 0 files** under `$HOME/.scitex` (was 93 + 3).
- Full `_lifecycle/` against a seeded scratch board: **1040 passed, 0 breaches, board sha256 identical, 0 files** under `$HOME/.scitex/agent-container`.

The single failure in that run (`test__sdk_heartbeat_loop.py::test_heartbeat_ts_is_fresh_wall_clock`) is a wall-clock flake under machine load — 11/11 in isolation on this branch **and** on `origin/develop`.

## Out of scope

The fixed-literal tmp-name race (`instance_id.tmp`, ~30 sites) remains open on its own card; mixing them makes both unreviewable.
