### PR TITLE
fix(jobs): a JobSpec must not declare a bare `sac` — and ship the detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,47 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Fixed
 
+- **A JobSpec declared a bare `sac`, and only an unmanaged drop-in made it
+  safe.** `sac.accounts-refresh` declared `command="sac accounts refresh …"`.
+  The generated unit read `ExecStart=/usr/bin/env sac accounts refresh …` —
+  `resolve_execstart`'s rule-3 LAST RESORT, reached only when the interpreter's
+  sibling bin and the ambient PATH both miss — which a systemd `--user` unit's
+  minimal PATH fails at `status=127`. It has worked since 2026-07-10 only
+  because a hand-added `override.conf` pinned the absolute path.
+
+  That is the defect: the safety lived in host state no PR can see, so deleting
+  the drop-in or regenerating the unit silently restored the hazard. The command
+  now declares `/home/ywatanabe/.env-3.11/bin/sac` outright, the same rule
+  `sac.heal-agent-auth` already followed — `resolve_execstart` passes an
+  absolute head through verbatim, so the declaration depends on neither the
+  ambient PATH nor on which interpreter ran `ecosystem up`. That second
+  dependency is not hypothetical: this host carries SEVEN `sac` installs at FIVE
+  versions, and rule 1 resolves against `sys.executable`'s sibling bin.
+
+### Added
+
+- **`sac dev audit-execstart` — the detector for deployed-vs-declared drift.**
+  Both instances of the `ExecStart` hazard were found by hand, comparing
+  `systemctl --user show -p ExecStart --value <unit>` against the JobSpec
+  source. Nothing ran that comparison, so both were found by luck; a hand repair
+  restores the state and leaves the system able to re-enter it.
+
+  The new `_execstart_audit` package asks systemd what each sac unit actually
+  runs and compares it to what the generator intends (obtained by calling
+  `resolve_execstart`, never by re-implementing it). A divergence means an
+  unmanaged local override or a generator bug — both worth knowing. It REPORTS
+  and never repairs: the `override.conf` above is a live example of a hand-patch
+  that was correct, and an auto-repair would have reverted it.
+
+  Five verdicts, because the failure modes are not binary: `MATCH`, `DIVERGED`,
+  `NOT_INSTALLED` (declared behind a deliberate deploy gate — not a divergence),
+  `UNVERIFIABLE` (the declared head is not absolute, so the intent is not
+  reproducible in the checking interpreter — the check refuses to compare rather
+  than emit a meaningless verdict), and `UNKNOWN` (systemd could not be asked at
+  all, e.g. inside a container). `UNKNOWN` is never folded into `MATCH`: a check
+  that cannot distinguish "matches" from "could not ask" is not a check. stderr
+  is captured and reported, never discarded.
+
 - **The version lie, caught by a test instead of by an incident.** `pyproject.toml`
   is bumped to `0.23.0`, and a guard now fails CI whenever the CHANGELOG lists
   pending work under `[Unreleased]` while the declared version is one the

--- a/src/scitex_agent_container/_execstart_audit/__init__.py
+++ b/src/scitex_agent_container/_execstart_audit/__init__.py
@@ -1,0 +1,195 @@
+"""Deployed-vs-declared detector: does the unit RUN what the source INTENDS?
+
+The axis :mod:`scitex_agent_container._jobs_audit` deliberately leaves
+out. That module answers "is this declaration reachable at all?" from the
+repo tree; this one answers the question underneath the two ``ExecStart``
+incidents we found BY HAND, both by running the same comparison in a
+terminal and eyeballing it::
+
+    systemctl --user show -p ExecStart --value <unit>   # what ACTUALLY runs
+    vs. what the JobSpec source intends
+
+Nothing ran that comparison on a schedule, so both instances were found
+by luck. A hand repair restores the STATE and leaves the SYSTEM able to
+re-enter it; for anything recurring, the deliverable is the DETECTOR.
+
+The two measured instances
+==========================
+1. ``sac.accounts-refresh`` — the generated unit read
+   ``ExecStart=/usr/bin/env sac accounts refresh ...``, which is
+   ``resolve_execstart``'s rule-3 LAST RESORT (interpreter sibling-bin
+   AND ambient PATH both missed). A systemd ``--user`` unit gets a
+   minimal PATH, so that form fails at ``status=127``. It kept working
+   only because a hand-added ``override.conf`` drop-in pinned the
+   absolute path — safety living in unmanaged host state, which a
+   regeneration silently discards.
+2. The same shape upstream in scitex-todo
+   (``scitex-todo.wake-watcher.service``, ``/usr/bin/env scitex-todo``,
+   crash-looping at 127 for ~12h) — the bug that motivated
+   ``resolve_execstart`` in the first place.
+
+Why a divergence is worth a shout in BOTH directions
+====================================================
+Resolved != intended means exactly one of two things, and both are worth
+knowing:
+
+* an UNMANAGED LOCAL OVERRIDE — someone hand-patched the live unit. It
+  may well be a correct patch (instance 1 was!), but it is invisible to
+  every reader of the source and dies at the next regeneration.
+* a GENERATOR BUG — ``ecosystem up`` wrote something other than what the
+  JobSpec asked for.
+
+Three states, never two
+=======================
+Same doctrine as :mod:`scitex_agent_container._jobs_audit`, and the
+reason this lives as a runnable check rather than a CI test: CI cannot
+see the fleet host's ``systemctl --user`` at all, so a check that ran
+there could only ever report "could not ask". :class:`ExecVerdict`
+therefore carries UNKNOWN as a first-class outcome — a check that cannot
+distinguish "matches" from "could not ask" is not a check, it is a green
+light with no bulb behind it. UNKNOWN is never folded into MATCH.
+
+``NOT_INSTALLED`` is likewise its own verdict, not a divergence: several
+sac JobSpecs are declared-but-deliberately-not-deployed (the
+``restart-login-expired-agents`` / ``heal-agent-auth`` deploy gate), and
+calling those a divergence would train the reader to ignore the report.
+
+Reproducibility of the INTENT is itself a finding
+=================================================
+The expected ExecStart comes from asking the GENERATOR
+(``resolve_execstart``), never from re-implementing it — a checker that
+states its own opinion of what the generator ought to emit is a
+declaration with no live counterpart, i.e. the disease
+:mod:`scitex_agent_container._jobs_audit` exists to detect.
+
+But ``resolve_execstart`` is only DETERMINISTIC for an absolute head,
+which it passes through verbatim. For a BARE head it resolves against
+``sys.executable``'s sibling bin and then the ambient PATH — so it can
+legitimately return a different answer in the checking interpreter than
+it did in the generating one, and a mismatch would prove nothing. Those
+jobs get :data:`ExecVerdict.UNVERIFIABLE`, which names the absolute-head
+fix rather than pretending to a verdict. On the host this was written
+for, a bare ``sac`` is genuinely ambiguous: seven installs, five
+versions.
+
+No ``2>/dev/null``
+==================
+stderr is captured and REPORTED, never discarded — see
+:func:`~._probe.query_unit`. Discarding it discards the only channel that
+reports the failure you did not anticipate; that exact pattern hid a dead
+cron job on this host for 49 days.
+
+Reports, never repairs
+======================
+There is no write path in this package. Silently rewriting host state
+someone else may own is worse than naming the divergence — the
+``override.conf`` in instance 1 is a live example of a hand-patch that
+was RIGHT, and an auto-repair would have reverted it.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+from ._model import ExecFinding, ExecStartReport, ExecVerdict, UnitState
+from ._probe import (
+    QUERY_TIMEOUT_SEC,
+    commands_equal,
+    parse_show_output,
+    query_unit,
+    unit_name_for,
+)
+from ._verdict import audit_job
+
+#: sac owns every job whose name is prefixed ``sac.``.
+SAC_PREFIX = "sac."
+
+#: JobSpec kinds that materialise a systemd unit with an ``ExecStart``.
+#: ``cron`` jobs become crontab lines and have no unit to interrogate.
+SYSTEMD_KINDS = frozenset({"timer", "service"})
+
+
+def _resolve_execstart_fn():
+    """Locate scitex-dev's REAL ``resolve_execstart``, or return None.
+
+    Public path first. As of scitex-dev 0.31.1 the function is not
+    re-exported from ``scitex_dev.jobs``, only defined in
+    ``scitex_dev.jobs._systemd`` — the module that also renders the unit,
+    so it IS the generator whose intent we want. We fall back to it rather
+    than re-implement the resolution rules here: a checker that states its
+    own opinion of what the generator ought to emit would stay green while
+    production drifted underneath it.
+
+    A private import is a real coupling, so it is contained to this one
+    function and BOTH failures degrade to None -> UNKNOWN, never to a
+    divergence. The clean fix belongs upstream (export it publicly); until
+    then this is the only way to ask the generator instead of guessing.
+    """
+    try:
+        from scitex_dev.jobs import resolve_execstart
+
+        return resolve_execstart
+    except ImportError:  # stx-allow: fallback (reason: not re-exported publicly as of scitex-dev 0.31.1 — try the defining module)
+        pass
+    try:
+        from scitex_dev.jobs._systemd import resolve_execstart
+
+        return resolve_execstart
+    except ImportError:  # stx-allow: fallback (reason: old scitex-dev has no jobs contract — UNKNOWN, not a divergence)
+        return None
+
+
+def _intended_execstart(job) -> str | None:
+    """Ask the GENERATOR what it intends. Never re-implement it."""
+    fn = _resolve_execstart_fn()
+    if fn is None:
+        return None
+    return fn(job.command, venv=getattr(job, "venv", None))
+
+
+def _declared_systemd_jobs(prefix: str) -> list:
+    from scitex_agent_container._jobs_plugin import provide_jobs
+
+    return [
+        j
+        for j in provide_jobs()
+        if j.name.startswith(prefix) and j.kind in SYSTEMD_KINDS
+    ]
+
+
+def audit_execstart(
+    *, prefix: str = SAC_PREFIX, runner=subprocess.run, which=shutil.which
+) -> ExecStartReport:
+    """Compare every sac-declared unit's RESOLVED ExecStart to its intent.
+
+    ``runner`` / ``which`` are seams for tests that drive a real
+    subprocess against a fixture ``systemctl`` on disk — a fake systemctl
+    that is a real executable file, not a mock.
+    """
+    findings = [
+        audit_job(
+            job,
+            state=query_unit(unit_name_for(job), runner=runner, which=which),
+            intended=_intended_execstart(job),
+        )
+        for job in _declared_systemd_jobs(prefix)
+    ]
+    return ExecStartReport(findings=tuple(findings))
+
+
+__all__ = [
+    "QUERY_TIMEOUT_SEC",
+    "SAC_PREFIX",
+    "SYSTEMD_KINDS",
+    "ExecFinding",
+    "ExecStartReport",
+    "ExecVerdict",
+    "UnitState",
+    "audit_execstart",
+    "audit_job",
+    "commands_equal",
+    "parse_show_output",
+    "query_unit",
+    "unit_name_for",
+]

--- a/src/scitex_agent_container/_execstart_audit/_model.py
+++ b/src/scitex_agent_container/_execstart_audit/_model.py
@@ -1,0 +1,150 @@
+"""Verdict vocabulary and report types for the ExecStart audit.
+
+Split out of the package ``__init__`` purely for size; the doctrine these
+types encode is documented there.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ExecVerdict(str, Enum):
+    """Five states. UNKNOWN and UNVERIFIABLE are refusals to guess.
+
+    * ``MATCH`` — the unit runs exactly what the JobSpec declares.
+    * ``DIVERGED`` — it does not. An unmanaged override, or a generator bug.
+    * ``NOT_INSTALLED`` — nothing is deployed for this declaration. Not a
+      divergence: several sac jobs are declared behind a deliberate
+      deploy gate.
+    * ``UNVERIFIABLE`` — the declared command's head is not absolute, so
+      the intended value is not reproducible in this interpreter. The
+      check refuses to compare rather than emit a meaningless verdict.
+    * ``UNKNOWN`` — systemd could not be asked at all.
+    """
+
+    MATCH = "match"
+    DIVERGED = "diverged"
+    NOT_INSTALLED = "not-installed"
+    UNVERIFIABLE = "unverifiable"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class UnitState:
+    """What systemd said about one unit.
+
+    ``load_state=None`` together with a non-empty ``error`` is the UNKNOWN
+    carrier: systemd could not be asked, and ``error`` says why.
+    """
+
+    load_state: str | None
+    execstart: str | None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class ExecFinding:
+    """One job, what its unit runs, and what the source intended."""
+
+    job: str
+    unit: str
+    verdict: ExecVerdict
+    detail: str
+    intended: str | None = None
+    resolved: str | None = None
+
+    def __post_init__(self) -> None:
+        # Validate at construction so a malformed finding crashes HERE and
+        # not inside a report someone acts on. Same doctrine as JobSpec.
+        if not isinstance(self.verdict, ExecVerdict):
+            raise ValueError(
+                f"ExecFinding.verdict must be an ExecVerdict, got {self.verdict!r}"
+            )
+        if not self.job:
+            raise ValueError("ExecFinding.job must be non-empty")
+        if not self.detail:
+            # A verdict with no stated evidence is a postmortem in a
+            # comment, which is what this module exists to replace.
+            raise ValueError(
+                f"ExecFinding({self.job!r}).detail must state the evidence"
+            )
+        if self.verdict is ExecVerdict.DIVERGED and not (
+            self.intended and self.resolved
+        ):
+            # A divergence that does not carry BOTH sides is unactionable —
+            # the reader cannot tell which side to change.
+            raise ValueError(
+                f"ExecFinding({self.job!r}): a DIVERGED finding must carry "
+                f"both intended and resolved"
+            )
+
+
+@dataclass(frozen=True)
+class ExecStartReport:
+    """The audit result. Fails LOUD via :meth:`render`, never silently."""
+
+    findings: tuple[ExecFinding, ...]
+
+    def __post_init__(self) -> None:
+        if not all(isinstance(f, ExecFinding) for f in self.findings):
+            raise ValueError("ExecStartReport.findings must all be ExecFinding")
+
+    def of(self, verdict: ExecVerdict) -> tuple[ExecFinding, ...]:
+        return tuple(f for f in self.findings if f.verdict is verdict)
+
+    @property
+    def diverged(self) -> tuple[ExecFinding, ...]:
+        return self.of(ExecVerdict.DIVERGED)
+
+    @property
+    def unknown(self) -> tuple[ExecFinding, ...]:
+        return self.of(ExecVerdict.UNKNOWN)
+
+    @property
+    def unverifiable(self) -> tuple[ExecFinding, ...]:
+        return self.of(ExecVerdict.UNVERIFIABLE)
+
+    @property
+    def ok(self) -> bool:
+        """True only when nothing DIVERGED.
+
+        UNKNOWN deliberately does NOT make this False: "I could not ask"
+        is not "I found a problem", and conflating them would make the
+        check permanently red anywhere systemd is absent (every
+        container, all of CI) — which is how a check gets muted. The
+        UNKNOWNs are still rendered, loudly, so the reader always knows
+        how much was actually checked.
+        """
+        return not self.diverged
+
+    def render(self) -> str:
+        """A report that names each divergence and BOTH sides of it."""
+        lines: list[str] = []
+        if self.diverged:
+            lines.append(
+                f"{len(self.diverged)} UNIT(S) DO NOT RUN WHAT THE SOURCE "
+                f"DECLARES — an unmanaged local override, or a generator bug:"
+            )
+            for f in self.diverged:
+                lines.append(f"  {f.job}  ({f.unit})")
+                lines.append(f"      intended: {f.intended}")
+                lines.append(f"      resolved: {f.resolved}")
+                lines.append(f"      {f.detail}")
+        else:
+            lines.append("no ExecStart divergence found")
+
+        for f in self.unverifiable:
+            lines.append(f"  [unverifiable] {f.job}: {f.detail}")
+        if self.unknown:
+            lines.append(
+                f"  ({len(self.unknown)} UNKNOWN — could not ask systemd; "
+                f"this is NOT a pass, and nothing here was checked)"
+            )
+            for f in self.unknown:
+                lines.append(f"      {f.job}: {f.detail}")
+        return "\n".join(lines)
+
+
+__all__ = ["ExecFinding", "ExecStartReport", "ExecVerdict", "UnitState"]

--- a/src/scitex_agent_container/_execstart_audit/_probe.py
+++ b/src/scitex_agent_container/_execstart_audit/_probe.py
@@ -1,0 +1,184 @@
+"""Asking systemd what a unit ACTUALLY runs, and parsing what it says.
+
+The read half of the audit. Every failure mode here becomes an explicit
+UNKNOWN carrier (``UnitState.error``), never a silent empty result — and
+stderr is CAPTURED AND CARRIED, never discarded. Discarding stderr
+discards the only channel that reports the failure you did not
+anticipate; that exact pattern (``2>/dev/null``) hid a dead cron job on
+this host for 49 days.
+"""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+import subprocess
+
+from ._model import UnitState
+
+#: How long to let a single ``systemctl show`` call take. It is a local
+#: read against the user bus; anything slower is a sick bus, which is an
+#: UNKNOWN worth surfacing rather than a hang worth waiting on.
+QUERY_TIMEOUT_SEC = 10
+
+
+def unit_name_for(job) -> str:
+    """The unit scitex-dev derives for ``job``.
+
+    The job name is taken VERBATIM — ``sac.accounts-refresh`` becomes
+    ``sac.accounts-refresh.service``. That verbatim derivation is exactly
+    why ``sac listen`` must never be federated (a ``sac.listen`` JobSpec
+    would materialise ``sac.listen.service``, which does NOT adopt the
+    hand-written ``sac-listen.service``); see ``_jobs_plugin.provide_jobs``.
+    """
+    return f"{job.name}.service"
+
+
+def _argv_from_execstart(value: str) -> str | None:
+    """Pull the ``argv[]=...`` field out of one ExecStart record."""
+    marker = "argv[]="
+    start = value.find(marker)
+    if start == -1:
+        return None
+    rest = value[start + len(marker) :]
+    # Fields are ``;``-separated inside the ``{ ... }`` record.
+    end = rest.find(" ; ")
+    argv = rest[:end] if end != -1 else rest.rstrip(" }")
+    return argv.strip() or None
+
+
+def parse_show_output(text: str) -> UnitState:
+    """Parse ``systemctl show -p LoadState -p ExecStart`` key=value output.
+
+    ``show`` exits 0 even for a unit that does not exist, printing only
+    ``LoadState=not-found`` and omitting ``ExecStart`` entirely — so the
+    EXIT CODE IS USELESS as a discriminator and ``LoadState`` is the crisp
+    one. (Measured against systemd 249 on the fleet host: a nonexistent
+    unit gives rc=0, empty stdout for ``--value``, and empty stderr.)
+
+    The ``ExecStart`` value is a structured record::
+
+        { path=/x/bin/sac ; argv[]=/x/bin/sac accounts refresh --all ; ... }
+
+    ``argv[]`` is the actual exec vector and the only part worth
+    comparing; ``path``, ``pid``, ``status`` and the timestamps are
+    runtime noise that differs between two identical runs.
+    """
+    load_state: str | None = None
+    execstart: str | None = None
+    for line in text.splitlines():
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        if key == "LoadState":
+            load_state = value.strip()
+        elif key == "ExecStart" and value.strip():
+            execstart = _argv_from_execstart(value)
+    return UnitState(load_state=load_state, execstart=execstart)
+
+
+def query_unit(unit: str, *, runner=subprocess.run, which=shutil.which) -> UnitState:
+    """Ask systemd what ``unit`` actually runs.
+
+    Failure modes, each an explicit UNKNOWN carrier:
+
+    * ``systemctl`` not on PATH — the container case, and the common one:
+      this package's own agents run in an Apptainer image with no systemd.
+    * a non-zero exit / no user bus — a session without a user manager.
+    * a timeout — a wedged bus.
+    * rc=0 but an unparseable shape — reported verbatim rather than
+      guessed at.
+
+    ``runner`` and ``which`` are test seams (fake-callables), the same
+    convention scitex-dev's own ``resolve_execstart`` uses for exactly
+    this reason. They let the suite point at a REAL fixture ``systemctl``
+    script on disk — a real program, not a mock — so the parsing and the
+    verdicts are exercised against genuine subprocess behaviour on a
+    machine that may have no systemd at all.
+    """
+    exe = which("systemctl")
+    if exe is None:
+        return UnitState(
+            load_state=None,
+            execstart=None,
+            error=(
+                "`systemctl` is not on PATH — there is no systemd to ask "
+                "(the normal case inside a container; run this on the host)"
+            ),
+        )
+    try:
+        proc = runner(
+            [exe, "--user", "show", "-p", "LoadState", "-p", "ExecStart", unit],
+            capture_output=True,
+            text=True,
+            timeout=QUERY_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        return UnitState(
+            load_state=None,
+            execstart=None,
+            error=(
+                f"`systemctl --user show {unit}` did not return within "
+                f"{QUERY_TIMEOUT_SEC}s — the user bus is not answering"
+            ),
+        )
+    except OSError as exc:
+        return UnitState(
+            load_state=None,
+            execstart=None,
+            error=f"could not exec systemctl: {exc}",
+        )
+
+    stderr = (proc.stderr or "").strip()
+    if proc.returncode != 0:
+        return UnitState(
+            load_state=None,
+            execstart=None,
+            error=(
+                f"`systemctl --user show {unit}` exited {proc.returncode}"
+                + (f": {stderr}" if stderr else " with no stderr")
+            ),
+        )
+
+    state = parse_show_output(proc.stdout or "")
+    if state.load_state is None:
+        # rc=0 but no LoadState at all: not a shape we know how to read.
+        # Report it rather than deriving a verdict from it.
+        return UnitState(
+            load_state=None,
+            execstart=None,
+            error=(
+                f"`systemctl --user show {unit}` returned no LoadState; "
+                f"stdout={proc.stdout!r}" + (f" stderr={stderr!r}" if stderr else "")
+            ),
+        )
+    # A rc=0 call that STILL wrote to stderr is worth carrying forward.
+    return UnitState(
+        load_state=state.load_state,
+        execstart=state.execstart,
+        error=stderr or None,
+    )
+
+
+def commands_equal(intended: str, resolved: str) -> bool:
+    """Compare two ExecStart command strings by their token vectors.
+
+    ``shlex`` both sides so quoting differences that do not change the
+    exec vector are not reported as a divergence. Only a real difference
+    in what gets executed counts.
+    """
+    try:
+        return shlex.split(intended) == shlex.split(resolved)
+    except ValueError:
+        # Unbalanced quotes on either side — cannot tokenize, so fall back
+        # to an exact comparison rather than claiming equality.
+        return intended == resolved
+
+
+__all__ = [
+    "QUERY_TIMEOUT_SEC",
+    "commands_equal",
+    "parse_show_output",
+    "query_unit",
+    "unit_name_for",
+]

--- a/src/scitex_agent_container/_execstart_audit/_verdict.py
+++ b/src/scitex_agent_container/_execstart_audit/_verdict.py
@@ -1,0 +1,114 @@
+"""Deciding one job's verdict from what systemd said vs what we intend.
+
+The judgement half of the audit. The ORDER of the branches below is the
+safety property: every "I could not tell" case is decided BEFORE the
+comparison, so a missing input can never fall through into MATCH.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+from ._model import ExecFinding, ExecVerdict, UnitState
+from ._probe import commands_equal, unit_name_for
+
+
+def audit_job(job, *, state: UnitState, intended: str | None) -> ExecFinding:
+    """Decide one job's verdict.
+
+    ``intended=None`` means the generator could not be asked what it
+    intends (an old scitex-dev with no jobs contract) — UNKNOWN, never a
+    divergence.
+    """
+    unit = unit_name_for(job)
+    head = (shlex.split(job.command) or [""])[0]
+
+    # --- the "could not tell" branches, all before any comparison -------
+    if state.error and state.load_state is None:
+        return ExecFinding(
+            job=job.name,
+            unit=unit,
+            verdict=ExecVerdict.UNKNOWN,
+            detail=f"could not ask systemd: {state.error}",
+        )
+    if intended is None:
+        return ExecFinding(
+            job=job.name,
+            unit=unit,
+            verdict=ExecVerdict.UNKNOWN,
+            detail=(
+                "cannot compute the intended ExecStart — scitex_dev.jobs "
+                "resolve_execstart is unavailable (old scitex-dev)"
+            ),
+        )
+    if state.load_state == "not-found":
+        return ExecFinding(
+            job=job.name,
+            unit=unit,
+            verdict=ExecVerdict.NOT_INSTALLED,
+            detail=(
+                "declared but no unit is installed — expected for a job "
+                "behind a deliberate deploy gate, a finding otherwise"
+            ),
+            intended=intended,
+        )
+    if state.execstart is None:
+        return ExecFinding(
+            job=job.name,
+            unit=unit,
+            verdict=ExecVerdict.UNKNOWN,
+            detail=(
+                f"unit LoadState={state.load_state!r} but systemd reported "
+                f"no ExecStart to compare"
+                + (f"; stderr: {state.error}" if state.error else "")
+            ),
+            intended=intended,
+        )
+    if not head.startswith("/"):
+        # The INTENT is not reproducible here: resolve_execstart resolves a
+        # bare head against THIS interpreter's sibling bin and PATH, which
+        # need not be the ones that generated the unit. Refuse to compare
+        # rather than emit a divergence that proves nothing.
+        return ExecFinding(
+            job=job.name,
+            unit=unit,
+            verdict=ExecVerdict.UNVERIFIABLE,
+            detail=(
+                f"declared command head {head!r} is not absolute, so the "
+                f"intended ExecStart depends on which interpreter ran "
+                f"`ecosystem up` and cannot be reproduced here. The unit "
+                f"runs: {state.execstart!r}. Declare an absolute path to "
+                f"make this job checkable — resolve_execstart passes an "
+                f"absolute head through verbatim."
+            ),
+            intended=intended,
+            resolved=state.execstart,
+        )
+
+    # --- the actual comparison ------------------------------------------
+    if commands_equal(intended, state.execstart):
+        return ExecFinding(
+            job=job.name,
+            unit=unit,
+            verdict=ExecVerdict.MATCH,
+            detail="unit runs exactly what the JobSpec declares",
+            intended=intended,
+            resolved=state.execstart,
+        )
+    return ExecFinding(
+        job=job.name,
+        unit=unit,
+        verdict=ExecVerdict.DIVERGED,
+        detail=(
+            "the running unit does not match the declaration — either a "
+            "drop-in is patching it (check "
+            f"~/.config/systemd/user/{unit}.d/), or `ecosystem up` emitted "
+            "something other than what the JobSpec asked for. REPORTED, "
+            "NOT REPAIRED: the override may well be the correct side."
+        ),
+        intended=intended,
+        resolved=state.execstart,
+    )
+
+
+__all__ = ["audit_job"]

--- a/src/scitex_agent_container/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs_plugin.py
@@ -168,7 +168,39 @@ def provide_jobs() -> "list[JobSpec]":
         JobSpec(
             name="sac.accounts-refresh",
             schedule="0 */2 * * *",  # every 2h
-            command=("sac accounts refresh --all --include-active --sync-active-login"),
+            # ABSOLUTE by design, same rule as ``sac.heal-agent-auth`` below:
+            # ``resolve_execstart`` passes a head starting with "/" through
+            # VERBATIM, so this is the only form that depends on neither the
+            # ambient PATH nor which interpreter ran ``ecosystem up``.
+            #
+            # Not theoretical. The unit generated for this job on 2026-07-10
+            # read ``ExecStart=/usr/bin/env sac accounts refresh ...`` — that is
+            # ``resolve_execstart``'s rule-3 LAST RESORT, reached only when the
+            # interpreter's sibling bin AND the ambient PATH both missed, and a
+            # systemd --user unit's minimal PATH would then have failed it at
+            # status=127. It has been safe since only because a hand-added
+            # ``override.conf`` drop-in pins the absolute path. THAT is the
+            # defect: the safety lives in host state no PR can see, so deleting
+            # the drop-in or regenerating the unit silently restores the hazard.
+            #
+            # Which binary a bare ``sac`` selects is a live question here, not a
+            # hypothetical: this host carries SEVEN sac installs at FIVE
+            # versions (0.22.1 wheel in .env-3.11; three 0.22.0 editable venvs;
+            # 0.21.2; and two 0.21.11 — one of them ``~/.local/bin/sac`` on
+            # python3.10). ``resolve_execstart`` rule 1 resolves against
+            # ``sys.executable``'s sibling bin, so with a bare head the version
+            # baked into the unit is decided by whichever interpreter happened
+            # to run ``ecosystem up``.
+            #
+            # ``/home/ywatanabe/.env-3.11/bin/sac`` is the MEASURED production
+            # install: it is what the live override already pins, what every
+            # other installed ``sac.*`` unit resolved to, the only NON-editable
+            # (wheel) install — so it cannot silently run a dirty working
+            # checkout — and the 3.11 venv the rest of the fleet runs on.
+            command=(
+                "/home/ywatanabe/.env-3.11/bin/sac accounts refresh "
+                "--all --include-active --sync-active-login"
+            ),
             description=(
                 "Headless OAuth access-token refresh for all stored Claude "
                 "accounts including the active one (sole-refresher model), "

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs.py
@@ -240,10 +240,69 @@ def _make_installable_group(group: str):
     return _grp
 
 
+def _add_audit_execstart_command(dev_group: click.Group) -> None:
+    """Attach ``sac dev audit-execstart`` — the deployed-vs-declared check.
+
+    This verb is the whole reason ``_execstart_audit`` is not a CI test:
+    the comparison can only be made where the units live, and CI runs in a
+    SIF with no access to the fleet host's ``systemctl --user``. A checker
+    nobody can run is the inert-feature shape it exists to detect.
+    """
+
+    @dev_group.command(name="audit-execstart")
+    @click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+    def _audit_execstart(as_json):
+        """Check each sac unit RUNS what its JobSpec declares.
+
+        Reports; never repairs. A divergence means an unmanaged local
+        override or a generator bug — both worth knowing, neither safe to
+        rewrite automatically.
+        """
+        import json as _json
+
+        from scitex_agent_container._execstart_audit import audit_execstart
+
+        try:
+            report = audit_execstart()
+        except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — print upgrade hint, not a stack trace)
+            click.echo(_degrade_msg(), err=True)
+            raise SystemExit(3)
+
+        if as_json:
+            click.echo(
+                _json.dumps(
+                    {
+                        "ok": report.ok,
+                        "findings": [
+                            {
+                                "job": f.job,
+                                "unit": f.unit,
+                                "verdict": f.verdict.value,
+                                "detail": f.detail,
+                                "intended": f.intended,
+                                "resolved": f.resolved,
+                            }
+                            for f in report.findings
+                        ],
+                    }
+                )
+            )
+        else:
+            click.echo(report.render())
+
+        # 0 = nothing diverged, 1 = at least one unit does not run what the
+        # source declares. UNKNOWN deliberately does NOT set a failing code:
+        # "could not ask" is not "found a problem", and making it red would
+        # mute the check everywhere systemd is absent. The verdicts are all
+        # in the output — nothing here should be inferred from the exit code.
+        raise SystemExit(0 if report.ok else 1)
+
+
 def register_dev_jobs_commands(dev_group: click.Group) -> None:
     """Attach a job group onto ``sac dev`` for every entry in GROUP_KINDS."""
     for group in sorted(GROUP_KINDS):
         dev_group.add_command(_make_installable_group(group))
+    _add_audit_execstart_command(dev_group)
 
 
 __all__ = ["GROUP_KINDS", "register_dev_jobs_commands"]

--- a/tests/scitex_agent_container/test__execstart_audit.py
+++ b/tests/scitex_agent_container/test__execstart_audit.py
@@ -1,0 +1,605 @@
+"""Tests for the deployed-vs-declared ExecStart detector.
+
+No mocks and no monkeypatch anywhere. Where a systemd is needed the suite
+writes a REAL executable ``systemctl`` script into a real ``tmp_path`` and
+runs it through the real :func:`subprocess.run`, injected through the same
+``which`` / ``runner`` fake-callable seams scitex-dev's own
+``resolve_execstart`` documents. A fixture that is a real program on disk
+exercises real exec, real pipes and real exit codes; a mock would only
+exercise the test's own opinion.
+
+The canned outputs below are VERBATIM captures from the fleet host
+(systemd 249), not invented shapes — including the two facts that decide
+the parser's design:
+
+* ``show`` exits 0 for a unit that does not exist, printing only
+  ``LoadState=not-found``, so the exit code cannot discriminate;
+* the ``ExecStart`` record carries runtime noise (``pid``, ``status``,
+  timestamps) around the one field worth comparing, ``argv[]``.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
+
+from scitex_agent_container._execstart_audit import (  # noqa: E402
+    ExecFinding,
+    ExecStartReport,
+    ExecVerdict,
+    UnitState,
+    audit_execstart,
+    audit_job,
+    commands_equal,
+    parse_show_output,
+    query_unit,
+    unit_name_for,
+)
+from scitex_agent_container._jobs_plugin import provide_jobs  # noqa: E402
+
+# --- verbatim captures from the fleet host (systemd 249) -------------------
+
+REAL_LOADED = (
+    "ExecStart={ path=/home/ywatanabe/.env-3.11/bin/sac ; "
+    "argv[]=/home/ywatanabe/.env-3.11/bin/sac accounts refresh --all "
+    "--include-active --sync-active-login ; ignore_errors=no ; "
+    "start_time=[Mon 2026-07-20 12:11:25 JST] ; "
+    "stop_time=[Mon 2026-07-20 12:11:25 JST] ; pid=1206453 ; "
+    "code=exited ; status=1 }\n"
+    "LoadState=loaded\n"
+)
+
+REAL_NOT_FOUND = "LoadState=not-found\n"
+
+#: The historical hazard: resolve_execstart's rule-3 last resort, which is
+#: what the 2026-07-10 unit actually carried before the drop-in masked it.
+REAL_BARE_ENV = (
+    "ExecStart={ path=/usr/bin/env ; "
+    "argv[]=/usr/bin/env sac accounts refresh --all --include-active "
+    "--sync-active-login ; ignore_errors=no ; pid=0 ; "
+    "code=(null) ; status=0/0 }\n"
+    "LoadState=loaded\n"
+)
+
+
+def _job(name: str):
+    (match,) = [j for j in provide_jobs() if j.name == name]
+    return match
+
+
+def _fake_systemctl(tmp_path: Path, *, stdout: str, stderr: str = "", rc: int = 0):
+    """Write a REAL executable systemctl onto disk and return a ``which``.
+
+    Not a mock: the returned path is a program the OS execs, whose output
+    the real subprocess machinery pipes back. ``stdout``/``stderr`` are
+    written via a heredoc so the canned systemd text survives verbatim.
+    """
+    script = tmp_path / "systemctl"
+    script.write_text(
+        "#!/bin/sh\n"
+        "cat <<'SAC_EOF_OUT'\n" + stdout + "SAC_EOF_OUT\n"
+        "cat >&2 <<'SAC_EOF_ERR'\n" + stderr + "SAC_EOF_ERR\n"
+        f"exit {rc}\n"
+    )
+    script.chmod(0o755)
+    return lambda _name: str(script)
+
+
+def _fake_systemctl_per_unit(tmp_path: Path, by_unit: dict[str, str]):
+    """A REAL systemctl that answers PER UNIT, like the real one does.
+
+    The uniform helper above replies with the same record whatever unit it
+    is asked about, which is fine for probing one unit but wrong for a
+    fleet-wide audit: it makes every OTHER job look divergent. This writes
+    one response file per unit and dispatches on the unit argument,
+    defaulting to the measured ``LoadState=not-found`` shape.
+    """
+    responses = tmp_path / "responses"
+    responses.mkdir()
+    for unit, text in by_unit.items():
+        (responses / unit).write_text(text)
+    script = tmp_path / "systemctl"
+    script.write_text(
+        "#!/bin/sh\n"
+        'for a in "$@"; do last="$a"; done\n'
+        f'if [ -f "{responses}/$last" ]; then cat "{responses}/$last"; '
+        "else echo 'LoadState=not-found'; fi\n"
+    )
+    script.chmod(0o755)
+    return lambda _name: str(script)
+
+
+def _loaded_record(argv: str) -> str:
+    """A ``LoadState=loaded`` response whose argv[] is ``argv``."""
+    return (
+        f"ExecStart={{ path={argv.split()[0]} ; argv[]={argv} ; "
+        "ignore_errors=no ; pid=0 ; code=(null) ; status=0/0 }\n"
+        "LoadState=loaded\n"
+    )
+
+
+def _all_units_agreeing() -> dict[str, str]:
+    """Every declared systemd job reporting exactly what it declares."""
+    from scitex_agent_container._execstart_audit import (
+        SYSTEMD_KINDS,
+        unit_name_for,
+    )
+
+    return {
+        unit_name_for(j): _loaded_record(j.command)
+        for j in provide_jobs()
+        if j.kind in SYSTEMD_KINDS
+    }
+
+
+# ---------------------------------------------------------------------------
+# parse_show_output — against the verbatim captures
+# ---------------------------------------------------------------------------
+
+
+def test_parse_extracts_argv_and_discards_runtime_noise() -> None:
+    # Arrange — the real record wraps argv[] in path/pid/status/timestamps,
+    # every one of which differs between two identical runs. Comparing the
+    # whole record would report a divergence on every restart.
+    # Act
+    state = parse_show_output(REAL_LOADED)
+    # Assert
+    assert state.execstart == (
+        "/home/ywatanabe/.env-3.11/bin/sac accounts refresh --all "
+        "--include-active --sync-active-login"
+    )
+
+
+def test_parse_reads_load_state() -> None:
+    # Arrange — LoadState is the crisp discriminator; the exit code is not.
+    # Act
+    state = parse_show_output(REAL_LOADED)
+    # Assert
+    assert state.load_state == "loaded"
+
+
+def test_parse_absent_unit_is_not_found_with_no_execstart() -> None:
+    # Arrange — a nonexistent unit: systemd omits the ExecStart key entirely
+    # and still exits 0. Measured on the fleet host.
+    # Act
+    state = parse_show_output(REAL_NOT_FOUND)
+    # Assert
+    assert (state.load_state, state.execstart) == ("not-found", None)
+
+
+# ---------------------------------------------------------------------------
+# query_unit — real exec against a real fixture program
+# ---------------------------------------------------------------------------
+
+
+def test_query_unit_reads_a_real_subprocess(tmp_path: Path) -> None:
+    # Arrange — a real executable emitting the real captured shape.
+    which = _fake_systemctl(tmp_path, stdout=REAL_LOADED)
+    # Act
+    state = query_unit(
+        "sac.accounts-refresh.service", runner=subprocess.run, which=which
+    )
+    # Assert
+    assert state.load_state == "loaded"
+
+
+def test_query_unit_without_systemctl_is_unknown_never_a_pass() -> None:
+    # Arrange — the container case. This is THE case the brief singles out:
+    # a check that cannot distinguish "matches" from "could not ask" is not
+    # a check. `which` finding nothing must surface as an error carrier.
+    # Act
+    state = query_unit("sac.accounts-refresh.service", which=lambda _n: None)
+    # Assert — load_state None + a stated reason == the UNKNOWN carrier.
+    assert state.load_state is None and state.error
+
+
+def test_query_unit_carries_stderr_on_failure_never_discards_it(tmp_path: Path) -> None:
+    # Arrange — a systemctl that fails the way a session with no user bus
+    # does. The stderr text is the ONLY report of a failure we did not
+    # anticipate; `2>/dev/null` here is what hid a dead cron job for 49 days.
+    which = _fake_systemctl(
+        tmp_path,
+        stdout="",
+        stderr="Failed to connect to bus: No such file or directory",
+        rc=1,
+    )
+    # Act
+    state = query_unit("sac.accounts-refresh.service", which=which)
+    # Assert
+    assert "Failed to connect to bus" in (state.error or "")
+
+
+def test_query_unit_rc_zero_but_unparseable_is_unknown(tmp_path: Path) -> None:
+    # Arrange — rc=0 with a shape carrying no LoadState. Reporting it beats
+    # deriving a verdict from output we do not understand.
+    which = _fake_systemctl(tmp_path, stdout="something entirely unexpected\n")
+    # Act
+    state = query_unit("sac.accounts-refresh.service", which=which)
+    # Assert
+    assert state.load_state is None and "no LoadState" in (state.error or "")
+
+
+# ---------------------------------------------------------------------------
+# audit_job — the verdict table
+# ---------------------------------------------------------------------------
+
+
+def test_matching_execstart_is_a_match() -> None:
+    # Arrange — the post-fix steady state: the declared absolute command and
+    # the unit's argv[] are the same exec vector.
+    job = _job("sac.accounts-refresh")
+    state = parse_show_output(REAL_LOADED)
+    # Act
+    finding = audit_job(job, state=state, intended=job.command)
+    # Assert
+    assert finding.verdict is ExecVerdict.MATCH
+
+
+def test_divergent_execstart_is_diverged() -> None:
+    # Arrange — THE detector's reason to exist, replayed against the real
+    # historical hazard: the unit runs `/usr/bin/env sac ...` while the
+    # source declares the absolute path.
+    job = _job("sac.accounts-refresh")
+    state = parse_show_output(REAL_BARE_ENV)
+    # Act
+    finding = audit_job(job, state=state, intended=job.command)
+    # Assert
+    assert finding.verdict is ExecVerdict.DIVERGED
+
+
+def test_divergence_reports_both_sides_so_it_is_actionable() -> None:
+    # Arrange — a divergence naming only one side cannot be acted on: the
+    # reader cannot tell which side is wrong.
+    job = _job("sac.accounts-refresh")
+    state = parse_show_output(REAL_BARE_ENV)
+    # Act
+    finding = audit_job(job, state=state, intended=job.command)
+    # Assert
+    assert finding.intended == job.command and "/usr/bin/env" in finding.resolved
+
+
+def test_absent_unit_is_not_installed_not_a_divergence() -> None:
+    # Arrange — several sac jobs are declared behind a DELIBERATE deploy gate
+    # (heal-agent-auth / restart-login-expired-agents). Calling those a
+    # divergence would train the reader to ignore the whole report.
+    job = _job("sac.accounts-refresh")
+    state = parse_show_output(REAL_NOT_FOUND)
+    # Act
+    finding = audit_job(job, state=state, intended=job.command)
+    # Assert
+    assert finding.verdict is ExecVerdict.NOT_INSTALLED
+
+
+def test_unreachable_systemd_is_unknown_never_match() -> None:
+    # Arrange — the container case reaching the verdict layer. It must NOT
+    # fall through into MATCH; ordering of the branches is the safety
+    # property being pinned here.
+    job = _job("sac.accounts-refresh")
+    state = UnitState(load_state=None, execstart=None, error="no systemd here")
+    # Act
+    finding = audit_job(job, state=state, intended=job.command)
+    # Assert
+    assert finding.verdict is ExecVerdict.UNKNOWN
+
+
+def test_missing_generator_intent_is_unknown_never_match() -> None:
+    # Arrange — an old scitex-dev cannot tell us what it intends. Absence of
+    # an expectation is not evidence that the unit is correct.
+    job = _job("sac.accounts-refresh")
+    state = parse_show_output(REAL_LOADED)
+    # Act
+    finding = audit_job(job, state=state, intended=None)
+    # Assert
+    assert finding.verdict is ExecVerdict.UNKNOWN
+
+
+def test_bare_head_job_is_unverifiable_not_falsely_diverged() -> None:
+    # Arrange — a bare head makes the INTENT interpreter-dependent:
+    # resolve_execstart resolves it against sys.executable's sibling bin and
+    # then PATH, which need not be the ones that generated the unit. A
+    # mismatch would prove nothing, so the check must refuse to compare.
+    # sac.fleet-reconcile still declares a bare `sac` today.
+    job = _job("sac.fleet-reconcile")
+    state = parse_show_output(REAL_LOADED)
+    # Act
+    finding = audit_job(
+        job, state=state, intended="/somewhere/else/sac agents reconcile"
+    )
+    # Assert
+    assert finding.verdict is ExecVerdict.UNVERIFIABLE
+
+
+def test_unverifiable_finding_names_the_absolute_head_fix() -> None:
+    # Arrange — a refusal that does not say how to make the job checkable
+    # leaves the reader stuck. The remedy belongs in the finding.
+    job = _job("sac.fleet-reconcile")
+    state = parse_show_output(REAL_LOADED)
+    # Act
+    finding = audit_job(
+        job, state=state, intended="/somewhere/else/sac agents reconcile"
+    )
+    # Assert
+    assert "absolute" in finding.detail
+
+
+# ---------------------------------------------------------------------------
+# commands_equal / unit_name_for
+# ---------------------------------------------------------------------------
+
+
+def test_quoting_that_does_not_change_the_exec_vector_is_not_a_divergence() -> None:
+    # Arrange — only a real difference in what gets EXECUTED counts.
+    quoted, bare = '/bin/x --flag "a"', "/bin/x --flag a"
+    # Act
+    equal = commands_equal(quoted, bare)
+    # Assert
+    assert equal
+
+
+def test_a_different_binary_is_a_divergence() -> None:
+    # Arrange — the case that matters on a host with seven sac installs at
+    # five versions: same args, different binary.
+    left, right = "/a/bin/sac x", "/b/bin/sac x"
+    # Act
+    equal = commands_equal(left, right)
+    # Assert
+    assert not equal
+
+
+def test_unit_name_is_derived_verbatim_from_the_job_name() -> None:
+    # Arrange — scitex-dev derives the unit name VERBATIM, which is exactly
+    # why `sac listen` must never be federated (sac.listen.service would not
+    # adopt the hand-written sac-listen.service). The detector must model
+    # the same derivation or it would interrogate the wrong unit.
+    job = _job("sac.accounts-refresh")
+    # Act
+    unit = unit_name_for(job)
+    # Assert
+    assert unit == "sac.accounts-refresh.service"
+
+
+# ---------------------------------------------------------------------------
+# report shape
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_alone_does_not_fail_the_report() -> None:
+    # Arrange — "could not ask" is not "found a problem". Making UNKNOWN red
+    # would leave the check permanently failing anywhere systemd is absent
+    # (every container, all of CI), which is how a check gets muted.
+    report = ExecStartReport(
+        findings=(
+            ExecFinding(
+                job="sac.x",
+                unit="sac.x.service",
+                verdict=ExecVerdict.UNKNOWN,
+                detail="no systemd",
+            ),
+        )
+    )
+    # Act
+    ok = report.ok
+    # Assert
+    assert ok
+
+
+def test_unknown_is_still_rendered_loudly_so_it_is_never_a_silent_pass() -> None:
+    # Arrange — ok=True must not mean "everything was checked". The reader
+    # has to be told how much the run could not see.
+    report = ExecStartReport(
+        findings=(
+            ExecFinding(
+                job="sac.x",
+                unit="sac.x.service",
+                verdict=ExecVerdict.UNKNOWN,
+                detail="no systemd",
+            ),
+        )
+    )
+    # Act
+    rendered = report.render()
+    # Assert
+    assert "UNKNOWN" in rendered and "NOT a pass" in rendered
+
+
+def test_a_divergence_fails_the_report() -> None:
+    # Arrange — the one condition that must go red.
+    report = ExecStartReport(
+        findings=(
+            ExecFinding(
+                job="sac.x",
+                unit="sac.x.service",
+                verdict=ExecVerdict.DIVERGED,
+                detail="d",
+                intended="/a x",
+                resolved="/b x",
+            ),
+        )
+    )
+    # Act
+    ok = report.ok
+    # Assert
+    assert not ok
+
+
+def test_a_diverged_finding_without_both_sides_refuses_to_construct() -> None:
+    # Arrange — an unactionable divergence must crash HERE, not inside a
+    # report someone acts on.
+    kwargs = dict(
+        job="sac.x",
+        unit="sac.x.service",
+        verdict=ExecVerdict.DIVERGED,
+        detail="d",
+        intended="/a x",
+    )
+    # Act
+    construct = lambda: ExecFinding(**kwargs)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        construct()
+
+
+def test_a_finding_must_state_its_evidence() -> None:
+    # Arrange — a verdict with no stated evidence is the postmortem-in-a-
+    # comment this whole module exists to replace.
+    kwargs = dict(
+        job="sac.x", unit="sac.x.service", verdict=ExecVerdict.MATCH, detail=""
+    )
+    # Act
+    construct = lambda: ExecFinding(**kwargs)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        construct()
+
+
+# ---------------------------------------------------------------------------
+# end-to-end — the mutation proof, pinned permanently
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_goes_red_against_the_historical_hazard(tmp_path: Path) -> None:
+    # Arrange — THE mutation proof, kept in the suite rather than performed
+    # once by hand: a real systemctl reporting the pre-fix
+    # `/usr/bin/env sac ...` for every unit. accounts-refresh now declares an
+    # absolute head, so its intent IS reproducible and the divergence is real.
+    which = _fake_systemctl(tmp_path, stdout=REAL_BARE_ENV)
+    # Act
+    report = audit_execstart(which=which)
+    # Assert
+    assert not report.ok
+
+
+def test_end_to_end_names_the_diverging_job(tmp_path: Path) -> None:
+    # Arrange — going red is not enough: the report must name WHICH job, or
+    # the operator cannot act on it.
+    which = _fake_systemctl(tmp_path, stdout=REAL_BARE_ENV)
+    # Act
+    diverged = audit_execstart(which=which).diverged
+    # Assert
+    assert any(f.job == "sac.accounts-refresh" for f in diverged)
+
+
+def test_end_to_end_is_green_when_every_unit_matches(tmp_path: Path) -> None:
+    # Arrange — the other half of the mutation proof: same code path, same
+    # fixture mechanism, every unit now agreeing with its declaration.
+    which = _fake_systemctl_per_unit(tmp_path, _all_units_agreeing())
+    # Act
+    report = audit_execstart(which=which)
+    # Assert
+    assert report.ok
+
+
+def test_end_to_end_match_is_a_positive_verdict_not_merely_absence_of_red(
+    tmp_path: Path,
+) -> None:
+    # Arrange — ok=True could also mean "nothing was checked". Pin that
+    # accounts-refresh reached a POSITIVE MATCH, so the green is evidence
+    # the comparison actually RAN rather than evidence it was skipped.
+    which = _fake_systemctl_per_unit(tmp_path, _all_units_agreeing())
+    # Act
+    findings = audit_execstart(which=which).findings
+    # Assert
+    assert any(
+        f.job == "sac.accounts-refresh" and f.verdict is ExecVerdict.MATCH
+        for f in findings
+    )
+
+
+def test_a_unit_absent_from_systemd_is_not_installed_end_to_end(
+    tmp_path: Path,
+) -> None:
+    # Arrange — an empty response set: every unit answers not-found, the
+    # measured shape for a job declared but never installed.
+    which = _fake_systemctl_per_unit(tmp_path, {})
+    # Act
+    report = audit_execstart(which=which)
+    # Assert — not-installed is not a divergence, so the report stays ok.
+    assert report.ok and report.of(ExecVerdict.NOT_INSTALLED)
+
+
+def test_end_to_end_without_systemd_is_all_unknown_and_not_a_pass_claim(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the container case, end to end. Every job must land in
+    # UNKNOWN; none may be silently reported as MATCH.
+    # Act
+    report = audit_execstart(which=lambda _n: None)
+    # Assert
+    assert report.unknown and not report.of(ExecVerdict.MATCH)
+
+
+# ---------------------------------------------------------------------------
+# the detector's own hygiene — file-only, so it cannot flake
+# ---------------------------------------------------------------------------
+
+
+def _code_without_docstrings(path: Path) -> str:
+    """Return ``path``'s source with module/class/function docstrings removed.
+
+    Docstrings are stripped because this module's own PROSE discusses the
+    forbidden patterns by name; a naive substring scan flags the warning
+    text rather than the behaviour. Ordinary string literals are KEPT, so
+    a genuine ``subprocess.run("... 2>/dev/null")`` is still caught.
+    """
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        body = getattr(node, "body", [])
+        if (
+            body
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            body.pop(0)
+    return ast.unparse(tree)
+
+
+def test_the_detector_never_discards_stderr() -> None:
+    # Arrange — a file-only assertion (no subprocess, no systemd, so it
+    # cannot flake). Discarding stderr discards the only channel that
+    # reports the failure you did not anticipate; that exact pattern hid a
+    # dead cron job on this host for 49 days, so it must never appear in
+    # the detector's own CODE.
+    pkg = Path(__file__).resolve().parents[2] / (
+        "src/scitex_agent_container/_execstart_audit"
+    )
+    sources = sorted(pkg.glob("*.py"))
+    discards = ("2>/dev/null", "DEVNULL")
+    # Act
+    offenders = [
+        p.name
+        for p in sources
+        if any(tok in _code_without_docstrings(p) for tok in discards)
+    ]
+    # Assert — and prove the glob actually found the package.
+    assert sources and not offenders
+
+
+def test_the_detector_has_no_write_path_to_host_state() -> None:
+    # Arrange — "report, do not auto-repair" as an enforced property rather
+    # than a promise in a docstring. Silently rewriting host state someone
+    # else may own is worse than naming the divergence.
+    pkg = Path(__file__).resolve().parents[2] / (
+        "src/scitex_agent_container/_execstart_audit"
+    )
+    mutating = ("systemctl --user set-property", "daemon-reload", "write_text")
+    # Act
+    offenders = [
+        p.name
+        for p in sorted(pkg.glob("*.py"))
+        if any(token in p.read_text() for token in mutating)
+    ]
+    # Assert
+    assert not offenders

--- a/tests/scitex_agent_container/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/test__jobs_plugin.py
@@ -105,8 +105,38 @@ def test_provider_job_command_includes_active_account() -> None:
     job = _job("sac.accounts-refresh")
     # Assert
     assert job.command == (
-        "sac accounts refresh --all --include-active --sync-active-login"
+        "/home/ywatanabe/.env-3.11/bin/sac accounts refresh "
+        "--all --include-active --sync-active-login"
     )
+
+
+def test_accounts_refresh_head_is_absolute_not_a_bare_sac() -> None:
+    # Arrange — the same rule the heal-agent-auth pins below enforce, and for
+    # the same reason: `resolve_execstart` passes a head starting with "/"
+    # through VERBATIM, so an absolute head is the ONLY form independent of
+    # both the ambient PATH and which interpreter ran `ecosystem up`.
+    #
+    # A bare `sac` is not merely untidy here. The unit generated 2026-07-10
+    # read `ExecStart=/usr/bin/env sac accounts refresh ...` — resolve_execstart's
+    # rule-3 LAST RESORT — and only a hand-added override.conf drop-in has kept
+    # it working since. Safety that lives in an unmanaged drop-in evaporates the
+    # moment the unit is regenerated.
+    # Act
+    job = _job("sac.accounts-refresh")
+    # Assert
+    assert job.command.split()[0].startswith("/")
+
+
+def test_accounts_refresh_runs_the_measured_production_sac() -> None:
+    # Arrange — WHICH absolute sac matters: this host carries seven sac installs
+    # at five versions. `.env-3.11/bin/sac` is the measured production one — what
+    # the live override already pins, what every other installed sac.* unit
+    # resolved to, and the only NON-editable (wheel) install, so it cannot
+    # silently execute a dirty working checkout the way the editable venvs would.
+    # Act
+    job = _job("sac.accounts-refresh")
+    # Assert
+    assert job.command.startswith("/home/ywatanabe/.env-3.11/bin/sac ")
 
 
 def test_provider_job_command_never_skips_active() -> None:


### PR DESCRIPTION
## Part 1 — the fix

`sac.accounts-refresh` declared `command="sac accounts refresh …"`. A bare head.

**What the live host actually showed** (measured, not assumed):

```
unit file : ExecStart=/usr/bin/env sac accounts refresh --all --include-active --sync-active-login
override  : ExecStart=/home/ywatanabe/.env-3.11/bin/sac accounts refresh …   (override.conf, 2026-07-10)
resolved  : /home/ywatanabe/.env-3.11/bin/sac accounts refresh …
```

The brief said the renderer resolves a bare head "through PATH". It is slightly
worse than that. `resolve_execstart` *tries* to absolutise, in order: a `venv`
pin, then **`sys.executable`'s sibling bin**, then PATH, then `/usr/bin/env` as
a rule-3 last resort with a loud warning. So `/usr/bin/env sac` in the unit file
is not the normal path — it is the resolution having **missed entirely**, and a
systemd `--user` unit's minimal PATH fails that at `status=127`. The job has
worked since only because the hand-added `override.conf` pins the absolute path.

That is the defect the brief identified, and it holds: the safety lives in host
state no PR can see. Delete the drop-in or regenerate the unit and the hazard
silently returns.

It also means the hazard has a second axis. Because rule 1 resolves against
whichever interpreter ran `ecosystem up`, the version baked into a unit is
decided by invocation form — and this host carries **seven `sac` installs at
five versions**:

| path | version | kind |
|---|---|---|
| `/home/ywatanabe/.env-3.11/bin/sac` | 0.22.1 | wheel |
| `proj/scitex-cards/.venv/bin/sac` | 0.22.0 | editable |
| `proj/scitex-dev/.venv/bin/sac` | 0.22.0 | editable |
| `proj/scitex-agent-container/.venv/bin/sac` | 0.22.0 | editable |
| `proj/scitex-python/.venv/bin/sac` | 0.21.2 | editable |
| `proj/scitex-mnist-demo/.venv/bin/sac` | 0.21.11 | editable |
| `~/.local/bin/sac` | 0.21.11 | editable, `#!/usr/bin/python3.10` |

### The measured path, and why it is the right one

`/home/ywatanabe/.env-3.11/bin/sac`, because:

1. it is what the live `override.conf` already pins — so this PR makes the
   source agree with reality rather than changing behaviour;
2. it is what **every other installed `sac.*` unit** resolved to;
3. it is the **only non-editable (wheel) install** — the editable ones execute
   whatever is in a working checkout at the time the timer fires;
4. its shebang is the 3.11 venv the rest of the fleet runs on.

Only the string we declare changed. Nothing is asked of the JobSpec/rendering
contract. This is the same rule `sac.heal-agent-auth` already followed:
`resolve_execstart` passes an absolute head through **verbatim**, so the
declaration depends on neither the ambient PATH nor the generating interpreter.

**`sac listen` is untouched** — still deliberately not federated.

## Part 2 — the detector

`sac dev audit-execstart`, backed by `_execstart_audit`. It asks systemd what
each sac unit actually runs and compares it to what the generator intends —
obtained by **calling `resolve_execstart`**, never by re-implementing it (a
checker that states its own opinion of the generator drifts silently, which is
the disease `_jobs_audit` exists to detect).

### Contract

| verdict | meaning |
|---|---|
| `MATCH` | the unit runs exactly what the JobSpec declares |
| `DIVERGED` | it does not — an unmanaged override, or a generator bug. Carries **both** sides (construction fails otherwise: a one-sided divergence is unactionable) |
| `NOT_INSTALLED` | declared, nothing deployed. **Not** a divergence — several sac jobs sit behind a deliberate deploy gate, and flagging those would train the reader to ignore the report |
| `UNVERIFIABLE` | the declared head is not absolute, so the intent is **not reproducible** in the checking interpreter. The check refuses to compare rather than emit a verdict that proves nothing — and names the absolute-head fix |
| `UNKNOWN` | systemd could not be asked at all |

**The UNKNOWN case.** `systemctl` missing (every container), a non-zero exit, no
user bus, a timeout, or an rc=0 shape we cannot parse — each becomes an explicit
UNKNOWN carrying the reason. UNKNOWN is never folded into MATCH, and every
"could not tell" branch is evaluated **before** the comparison so a missing
input cannot fall through into a pass. UNKNOWN does *not* set a failing exit
code — "could not ask" is not "found a problem", and making it red would mute
the check everywhere systemd is absent — but it is always rendered loudly, so
`ok=True` never silently means "nothing was checked".

Two design notes worth flagging:

- **`LoadState`, not the exit code.** `systemctl --user show` exits **0 for a
  unit that does not exist**, printing only `LoadState=not-found` with empty
  stdout and empty stderr. The exit code cannot discriminate; `LoadState` can.
- **Only `argv[]` is compared.** The `ExecStart` record wraps it in `path`,
  `pid`, `status` and timestamps, all of which differ between two identical
  runs. Comparing the record would report a divergence on every restart.

**No `2>/dev/null`.** stderr is captured and carried, including on rc=0. A
file-only test asserts the pattern (and `DEVNULL`) stays out of the detector's
own code; it parses with `ast` and strips docstrings, so it flags *code* rather
than the prose that discusses the hazard. Another file-only test asserts the
package has no write path — it **reports, never repairs**, because the
`override.conf` above is a live example of a hand-patch that was *correct*, and
an auto-repair would have reverted it.

It is a CLI verb rather than a CI test on purpose: CI has no access to the fleet
host's `systemctl --user`, so a checker wired there could only ever report
"could not ask". `_jobs_audit`'s docstring already scopes this axis out for
exactly that reason; this is its sibling, not a replacement.

## Mutation proof

**Live, against real systemd on the fleet host** (temporarily appending
`--MUTATION-PROBE` to the declared command — my source only, never host state):

```
RED   ok = False
      1 UNIT(S) DO NOT RUN WHAT THE SOURCE DECLARES
        sac.accounts-refresh  (sac.accounts-refresh.service)
            intended: …/bin/sac accounts refresh --all --include-active --sync-active-login --MUTATION-PROBE
            resolved: …/bin/sac accounts refresh --all --include-active --sync-active-login
GREEN ok = True     accounts-refresh verdict: ['match']   (probe removed)
```

**Suite mutations** (proving the tests are not vacuous):

- `commands_equal` forced to `return True` (detector blinded) → **4 tests red**,
  incl. both end-to-end divergence tests. Restored → green.
- the no-`systemctl` branch made to return a silent pass instead of the UNKNOWN
  carrier → **1 test red**
  (`test_query_unit_without_systemctl_is_unknown_never_a_pass`). The end-to-end
  UNKNOWN test stayed green because a second guard also catches it — defence in
  depth, not a gap. Restored → green.

No mutation residue remains (`rg MUTATION-PROBE src/` is empty).

Both halves are pinned permanently in the suite, so the proof is a test rather
than a one-off I performed by hand.

## Fixtures are real

No mocks, no monkeypatch. Where systemd is needed the suite writes a **real
executable `systemctl` script** into a real `tmp_path` and runs it through the
real `subprocess.run`, injected via the `which`/`runner` fake-callable seams
(the same convention scitex-dev's own `resolve_execstart` documents). The canned
outputs are **verbatim captures from the fleet host** (systemd 249), not
invented shapes.

One fixture flaw worth recording, because it was a real near-miss: the first
version answered with the same record for *every* unit, which made
`sac.heal-agent-auth` look divergent. Rather than weaken the assertion I made
the fake systemctl **unit-aware** — it now dispatches per unit like the real one.

## Live result on the fleet host

```
match           sac.accounts-refresh
unverifiable    sac.host-sync-check
not-installed   sac.worktree-gc
unverifiable    sac.spartan-sif-bake
not-installed   sac.freshness-refresh
unverifiable    sac.fleet-reconcile
not-installed   sac.restart-login-expired-agents
not-installed   sac.heal-agent-auth
```

`accounts-refresh` is now `MATCH`: the source states what the unit runs, and the
`override.conf` becomes redundant rather than load-bearing. **I have not touched
it** — report, don't repair. It can be removed once this ships, but that is host
state and an operator call.

## What I did not do, and could not verify

- **Five other jobs still declare a bare `sac`** (`host-sync-check`,
  `worktree-gc`, `spartan-sif-bake`, `freshness-refresh`, `fleet-reconcile`).
  The detector surfaces three of them as `UNVERIFIABLE` above — I deliberately
  left them: their units currently carry the right absolute path with no
  override masking anything, so they are latent rather than live, and
  hardcoding an operator-specific path into five more shipped declarations
  would trade today's *warned* failure for a silent `203/EXEC` on any other
  host. Worth a follow-up decision, not a silent widening of this PR.
- **`resolve_execstart` is not publicly exported** from `scitex_dev.jobs` as of
  scitex-dev 0.31.1 — only defined in `scitex_dev.jobs._systemd`. I try the
  public path first and fall back to the defining module, contained to one
  function, with both failures degrading to UNKNOWN. A public export upstream is
  the clean fix; that is scitex-dev's call, not this PR's.
- **The full local test suite did not finish in-session** (>11 min; another
  agent was running pytest on the same host). The full surface touched by this
  change is green: **108 passed** across `test__execstart_audit`,
  `test__jobs_plugin`, `test__jobs_audit`, `test__dev_jobs`. CI runs the rest.
- **`26_credentials-rotation-host.md:109`** describes the timer as firing
  `sac accounts refresh …`. Still true of the CLI verb, now imprecise about the
  declared form. Left alone for scope; flagging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqhsrw29CM4siBLcEK2CwV
