### PR TITLE
refactor(events)!: sac records its own operational events instead of writing a third-party store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **sac records its own operational events, and no longer writes into a
+  third-party application's store.** sac's unattended passes — the fleet
+  reconciler, the auth-heal login-expired restarter, the host-sync drift check,
+  the worktree GC, the accounts refresh — decide things about the fleet every
+  few minutes, forever, with nobody watching. Their verdicts went to stderr and
+  into another application's data store. Neither is sac's own record: the stderr
+  line lands in a journal nobody opens (which is how a dead cron job stayed dead
+  for 49 days), and a store sac does not own can be absent, unwritable or
+  renamed — and when it is, sac retains no account of what its own timers
+  decided. An unlogged decision is an undebuggable one.
+
+  New `_events/` package: an append-only JSONL log of what sac observed and
+  decided, in sac's own vocabulary (`pass-completed`, `subject-degraded`,
+  `subject-unknown`, `subject-recovered`, `self-impaired`, `self-recovered`),
+  following the shape `_authevents/_log.py` already set. Default
+  `<runtime>/sac-events.jsonl`, relocatable with `SAC_EVENT_LOG`, resolved per
+  call. Fail-open but never silent — a failed write always prints loudly.
+
+  The four alarm modules each carried a near-identical private copy of the same
+  routing helpers; all four are replaced by one shared implementation
+  (`_events/_verdicts.py`), removing roughly 240 lines of duplication.
+
+  Interface changes: `reconcile_pass()` / `auth_heal_pass()` take `events_path`
+  where they took `store`; the `alarm` block of `sac host sync --json` and
+  `sac worktree gc --json` now uses the uniform keys
+  `degraded` / `unknown` / `recovered` / `failed`.
+
+  `tests/scitex_agent_container/test__card_package_boundary.py` enforces the
+  boundary with an AST scan asserting the importer set EXACTLY equals the two
+  files still permitted, so both a new import and a stale allowance go red.
+
 ### Fixed
 
 - **The version lie, caught by a test instead of by an incident.** `pyproject.toml`

--- a/docs/worktree-gc.md
+++ b/docs/worktree-gc.md
@@ -91,7 +91,7 @@ sac worktree gc --apply --all
 | `--all` | — | sweep every declared repo (see below) |
 | `--min-age-hours N` | 24 | keep any worktree whose HEAD commit is younger |
 | `--cap N` | 20 | alarm when a repo *still* has more than N after the pass |
-| `--alarm/--no-alarm` | on with `--apply` | route cap verdicts to a board card |
+| `--alarm/--no-alarm` | on with `--apply` | record cap verdicts in sac's event log |
 | `--json` | off | structured output |
 
 **Exit codes**: `0` every repo under cap · `1` a repo is still over cap
@@ -121,23 +121,24 @@ The reaping is the easy half. The half that prevents the incident is
 **shouting about what the predicate refused to touch**, because those are
 the worktrees that accumulate forever.
 
-After a pass, a repo still over `--cap` upserts an idempotent scitex-todo
-card on the board's BLOCKING-YOU view:
+After a pass, a repo still over `--cap` is recorded in sac's own
+append-only event log (`sac-events.jsonl`):
 
-- **id** `worktree-sprawl-<repo-basename>` (stable → a nightly re-run
-  updates in place instead of tiling the board)
-- **status** `blocked` / **blocker** `operator-decision`
-- **body** names the repo, the count, and the **kept-reasons breakdown**
-  (`9 dirty, 6 unmerged, 2 in-use`). That breakdown is the card's whole
-  value: "17 kept" is a number, "9 dirty" is an instruction.
+- **event** `subject-degraded`, **subsystem** `worktree-gc`,
+  **subject** the repo basename
+- **fields** carry the count, the cap, how many were removed, and the
+  **kept-reasons breakdown** (`9 dirty, 6 unmerged, 2 in-use`) as
+  structured data. That breakdown is the record's whole value: "17 kept"
+  is a number, "9 dirty" is an instruction.
 
-Three-state, like the predicate: **over cap** → card; **unreadable repo**
-→ card labelled UNKNOWN (never rendered clean); **back under cap** →
-card resolved, so a fixed repo stops shouting. A repo that sprawls, gets
-cleaned, then sprawls again alarms again.
+Three-state, like the predicate: **over cap** → `subject-degraded`;
+**unreadable repo** → `subject-unknown` (never rendered clean); **back
+under cap** → `subject-recovered`, recorded on the transition, so a
+fixed repo stops shouting. A repo that sprawls, gets cleaned, then
+sprawls again is recorded as degraded again.
 
-Delivery is a **side rail**: a board-write failure prints loudly to
-stderr and never crashes the GC that feeds it.
+Recording is a **side rail**: a failed write prints loudly to stderr and
+never crashes the GC that feeds it.
 
 ## The daily timer
 
@@ -180,7 +181,7 @@ sac worktree gc --all
 | `_maintenance/_worktree_gc_probe.py` | observation: git, `/proc`, `gh` (the injectable seams) |
 | `_maintenance/_worktree_gc_predicate.py` | **the four legs** |
 | `_maintenance/_worktree_gc.py` | the engine (dry-run/apply, remove, prune) |
-| `_maintenance/_worktree_gc_alarm.py` | the idempotent cap card |
+| `_maintenance/_worktree_gc_alarm.py` | the cap verdict record |
 | `_maintenance/_worktree_gc_repos.py` | `--all`'s repo discovery |
 | `cli_pkg/_worktree_gc.py` | the `sac worktree gc` verb |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.23.0"
+version = "0.24.0"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -501,10 +501,10 @@ real `claude /login` is finally needed.
 A SECOND federated `scitex_dev.jobs` job (same mechanism as above;
 `_jobs_plugin.py`). Runs `sac host sync --check --all --alarm` hourly:
 the **read-only** one-way-sync drift detector (mutates no peer), with
-`--alarm` routing each verdict to an idempotent scitex-todo card
-(`host-sync-drift-<peer>`, `status=blocked`/`blocker=operator-decision`)
-— upsert on drift/unknown, resolve on clean. This makes the Stage-0
-detector (PR #690), previously scheduled nowhere, actually RUN and be
-SEEN on the board instead of in a log nobody reads. Install with
+`--alarm` recording each verdict in sac's own append-only event log
+(`sac-events.jsonl`, subsystem `host-sync`) as `subject-degraded` /
+`subject-unknown` / `subject-recovered`. This makes the Stage-0 detector
+(PR #690), previously scheduled nowhere, actually RUN and leave a durable
+record instead of a journal line nobody reads. Install with
 `sac dev systemd install --yes`, then
 `systemctl --user enable --now sac.host-sync-check.timer`.

--- a/src/scitex_agent_container/_account/refresh_alarm.py
+++ b/src/scitex_agent_container/_account/refresh_alarm.py
@@ -9,12 +9,17 @@ failures went to the journal each run, nothing pushed at the operator,
 and the first visible symptom was ``sac agents start --group infra``
 failing for every agent with ``NoHealthyAccountError``.
 
-This module turns a failed refresh into an IMMEDIATE push on the
+This module turns a failed refresh into a DURABLE RECORD in sac's own
+event log (:mod:`.._events`), and then into an IMMEDIATE push on the
 fleet's existing agent→lead ``blocker`` rail (ADR-0013,
 :func:`scitex_agent_container._state.lead_inbox.push_to_lead` — the
 same typed event agents already use for "creds expired", persisted
 durably in the lead listen's ``channel_events`` store and relayed to
 the operator by the lead session). No new delivery rail is invented.
+
+The record is what makes the rail trustworthy; the push is what makes
+it timely. They fail independently, and only the record failing leaves
+sac with no account of the outage.
 
 Dedupe contract (operator spec):
 
@@ -27,8 +32,8 @@ Dedupe contract (operator spec):
 * A successful refresh (or a skipped-still-fresh result) CLEARS the
   account's entry — an account that recovers and later dies again
   alerts again.
-* A FAILED alert delivery is NOT recorded, so the next run retries it;
-  the delivery failure itself is printed loudly to stderr.
+* A FAILED record is NOT acknowledged, so the next run retries it; the
+  failure itself is printed loudly to stderr.
 
 :func:`alert_failed_refreshes` never raises — alerting is a side rail
 and must never break the refresh run that feeds it.
@@ -43,7 +48,12 @@ import time
 from pathlib import Path
 from typing import Any, Callable
 
+from .._events import SUBJECT_DEGRADED, log_event
+
 STATE_FILENAME = "refresh-alarm-state.json"
+
+#: The pass this module speaks for — the axis a reader filters the log on.
+SUBSYSTEM = "accounts-refresh"
 
 # One-line recovery recipe included in every alert (operator spec: the
 # canonical fix line must ride with the alert). Only meaningful for the
@@ -101,48 +111,48 @@ def _notify_lead_blocker(summary: str, detail: str) -> None:
     )
 
 
-def _notify_todo_help_card(account: str, summary: str, detail: str) -> None:
-    """Leg 2 — the scitex-todo BLOCKING-YOU card (first-tier nudge rail).
-
-    Upserts the canonical ``help-<agent>-waiting`` card via
-    :func:`scitex_todo._help_wait.help_wait` (idempotent; status
-    ``blocked`` / blocker ``operator-decision``) under the pseudo-agent
-    ``accounts-refresh-<account>``, so a dead account surfaces on the
-    board's BLOCKING-YOU view and rides scitex-todo's own card-event
-    delivery (digest/telegram). Lazy import — raises when scitex-todo
-    is not installed, letting the caller report the rail as down.
-    """
-    from scitex_todo._help_wait import help_wait
-
-    help_wait(
-        agent=f"accounts-refresh-{account}",
-        question=f"{summary}\n\n{detail}",
-    )
-
-
 def _default_notify(account: str, summary: str, detail: str) -> None:
-    """Deliver through the EXISTING rails, most direct first.
+    """RECORD the failure in sac's own log, then push it at the operator.
 
-    Leg 1 is the typed lead ``blocker`` push; a fleet without a
-    ``lead:`` block (this host, 2026-07-11) falls through to leg 2, the
-    scitex-todo help card — the board's standing "waiting on operator"
-    rail. Raises only when EVERY leg failed, so the caller leaves the
-    dedupe unmarked and retries next run.
+    The record comes first and is what makes this rail trustworthy: it is
+    sac's own durable account of a refresh sac could not perform, written
+    to a file sac owns. It does not depend on a lead being configured, on
+    the network, or on any other software being installed.
+
+    The lead ``blocker`` push (ADR-0013) is the notification ON TOP of that
+    record — the thing that gets a human's attention today rather than
+    whenever somebody next reads the log. It is best-effort by design: on a
+    fleet with no ``lead:`` block (this host, 2026-07-11) there is nowhere to
+    push, and that must not turn into a re-page on every one of the timer's
+    ~12 daily runs.
+
+    Raises only when the RECORD failed, because that is the only failure that
+    leaves sac with no account of the outage at all — and only then does the
+    caller leave the dedupe unmarked so the next run tries again.
     """
-    # stx-allow: fallback (reason: multi-rail delivery — leg 1 being unconfigured/down must fall through to leg 2, not lose the alert; both failing raises loudly below)
+    recorded = log_event(
+        event=SUBJECT_DEGRADED,
+        subsystem=SUBSYSTEM,
+        subject=account,
+        subject_kind="account",
+        verdict="refresh_failed",
+        detail=f"{summary}\n\n{detail}",
+    )
+    if not recorded:
+        raise RuntimeError(
+            f"could not record the refresh failure for {account} in sac's "
+            f"event log; leaving it unacknowledged so the next run retries"
+        )
+    # stx-allow: fallback (reason: the durable record above already succeeded, so a lead-push failure loses attention-now, not the fact. It is printed loudly rather than swallowed, and must not re-page the operator every run on a fleet with no lead configured.)
     try:
         _notify_lead_blocker(summary, detail)
-        return
-    except Exception as lead_exc:  # stx-allow: fallback (reason: see inline comment)
-        lead_err = lead_exc
-    try:
-        _notify_todo_help_card(account, summary, detail)
-        return
-    except Exception as todo_exc:  # stx-allow: fallback (reason: re-raised with full context — both rails' failures are surfaced together)
-        raise RuntimeError(
-            f"every alert rail failed — lead blocker rail: {lead_err}; "
-            f"scitex-todo help-card rail: {todo_exc}"
-        ) from todo_exc
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        print(
+            f"[refresh-alarm] {account}: recorded in sac's event log, but the "
+            f"lead blocker push FAILED — {exc}. Nobody has been paged; the "
+            f"failure is durable in the event log only.",
+            file=sys.stderr,
+        )
 
 
 def _build_summary(name: str, error: str) -> str:
@@ -245,8 +255,7 @@ def alert_failed_refreshes(
             _save_state(path, state)
         except OSError as exc:
             print(
-                f"[refresh-alarm] failed to persist dedupe state at {path}: "
-                f"{exc}",
+                f"[refresh-alarm] failed to persist dedupe state at {path}: {exc}",
                 file=stream,
             )
     return alerted

--- a/src/scitex_agent_container/_account/refresh_alarm.py
+++ b/src/scitex_agent_container/_account/refresh_alarm.py
@@ -243,8 +243,9 @@ def alert_failed_refreshes(
         dirty = True
         alerted.append(name)
         print(
-            f"  {name:20s}  RECORDED in sac's event log + pushed at the lead "
-            "blocker rail; deduped until this account refreshes OK again",
+            f"  {name:20s}  ALERTED operator (recorded in sac's event log, "
+            "pushed at the lead blocker rail; deduped until this account "
+            "refreshes OK again)",
             file=stream,
         )
 

--- a/src/scitex_agent_container/_authheal/_alarm.py
+++ b/src/scitex_agent_container/_authheal/_alarm.py
@@ -1,328 +1,139 @@
-"""Route login-expired-restart verdicts to a SEEN surface — and prove liveness.
+"""Record login-expired-restart verdicts in sac's own event log.
 
-Two idempotent scitex-todo rails, both SIDE rails (a board write that fails
-prints loudly and can NEVER crash or skip the restart pass that feeds it):
+Two rails, both writing to :mod:`..._events`, both SIDE rails (a write that
+fails is printed loudly by the log rail itself and can NEVER crash or skip the
+restart pass that feeds it):
 
-1. **Escalation cards** (``fleet-agent-login-expired-<name>``) — one per agent
-   that is STILL login-expired after the hourly restart cap. Restarting is not
-   fixing it, so instead of an infinite bounce the agent is handed to a human.
-   Upsert on OVER-BUDGET/FAILED; resolve the moment the agent is no longer
+1. **Unrecovered records** — one per agent that is STILL login-expired after
+   the hourly restart cap. Restarting is not fixing it, so instead of an
+   infinite bounce sac records that it has stopped trying. Recorded on
+   OVER-BUDGET/FAILED; a recovery is recorded the moment the agent is no longer
    login-expired (restarted, or recovered on its own and gone from the pass).
 
-2. **Heartbeat card** (``fleet-login-expired-restarter-heartbeat``) — the answer
-   to "who watches the watcher": refreshed on EVERY pass, so if this timer stops
-   ticking its card goes stale and scitex-todo's stale-active nudge shouts. One
-   system's silence becomes another's alarm — the same design as
-   :mod:`.._reconcile._alarm`.
+2. **The pass record** (:func:`record_pass_completed`) — written on EVERY pass,
+   so a pass that finds nothing wrong still leaves proof the timer ticked. A
+   rail that only writes when there is trouble cannot distinguish a healthy
+   fleet from a restarter that stopped running months ago.
 
-Mirrors the reconcile alarm's shape but talks to the scitex-todo PUBLIC API
-directly (``add_task``/``update_task``/``get_task``/``resolve_task``/
-``list_tasks``) so this package stays self-contained and its card wording is
-specific to the login-expired case.
+Mirrors :mod:`.._reconcile._alarm` deliberately — same vocabulary, same shared
+routing, wording specific to the login-expired case.
+
+ABSENCE MEANS RECOVERY HERE, AND ONLY HERE
+    This pass reports only the agents currently login-expired, so an agent that
+    was recorded as degraded and is NOT in this pass's reports has recovered on
+    its own. That is why :func:`record_reports` calls
+    :func:`~..._events.recover_absent_subjects`, which a whole-fleet pass such
+    as the reconciler must NOT do.
+
+    An UNOBSERVED agent IS in the reports, so it is not swept: recording a
+    recovery on a reading we never took would be a false all-clear in its most
+    durable form — the log would say there was nothing left to look at, on the
+    strength of the pass having failed to look.
 """
 
 from __future__ import annotations
 
-import sys
-from dataclasses import dataclass
-from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping
 
+from .._events import (
+    EmitOutcome,
+    SubjectState,
+    SubjectVerdict,
+    emit_subject_verdicts,
+    log_pass_completed,
+    recover_absent_subjects,
+)
 from .._reconcile._rule import Verdict
 
-__all__ = [
-    "AlarmOutcome",
-    "CARD_ID_PREFIX",
-    "HEARTBEAT_CARD_ID",
-    "card_id_for",
-    "route_reports_to_cards",
-    "upsert_heartbeat",
-]
+__all__ = ["SUBSYSTEM", "record_pass_completed", "record_reports"]
 
-#: Stable per-agent card id — idempotency is by id, so a re-run updates in place.
-CARD_ID_PREFIX = "fleet-agent-login-expired-"
+#: The pass this module speaks for — the axis a reader filters the log on.
+SUBSYSTEM = "auth-heal"
 
-#: The restarter's own liveness beacon. ONE card, stable id, forever.
-HEARTBEAT_CARD_ID = "fleet-login-expired-restarter-heartbeat"
+_SUBJECT_KIND = "agent"
 
-#: Owner + author of the escalation cards (a pseudo-agent, not a human).
-_AGENT = "sac.restart-login-expired-agents"
+#: Verdicts meaning "still login-expired and a restart is NOT fixing it".
+_DEGRADED = (Verdict.OVER_BUDGET, Verdict.FAILED)
 
-#: The heartbeat is owned by the PACKAGE identity: a human must own noticing
-#: that this restarter went quiet.
-_HEARTBEAT_ASSIGNEE = "scitex-agent-container"
-
-_STATUS = "blocked"
-_BLOCKER = "operator-decision"
-
-#: Verdicts meaning "still login-expired and a restart is NOT fixing it" → card.
-_UNRECOVERED = (Verdict.OVER_BUDGET, Verdict.FAILED)
-
-#: Verdicts meaning "we acted / it is on the mend" → resolve any card it had.
-_CLEARED_BY = (Verdict.RESTARTED,)
+#: Verdicts meaning "we acted / it is on the mend".
+_HEALTHY = (Verdict.RESTARTED,)
 
 
-def card_id_for(name: str) -> str:
-    """The stable escalation-card id for ``name``."""
-    return f"{CARD_ID_PREFIX}{name}"
+def _verdict_for(report: Any) -> SubjectVerdict | None:
+    """Map one agent's report onto sac's states, or ``None`` for no record."""
+    if report.verdict in _DEGRADED:
+        return SubjectVerdict(
+            subject=report.name,
+            state=SubjectState.DEGRADED,
+            verdict=report.verdict.value,
+            detail=(
+                f"{report.name} is STILL login-expired after auto-restart — "
+                f"{report.detail}. sac has stopped restarting it: a restart "
+                f"LOOP is worse than a wedged agent, and the usual cause is an "
+                f"account that cannot refresh, which no restart fixes."
+            ),
+            subject_kind=_SUBJECT_KIND,
+        )
+    if report.verdict in _HEALTHY:
+        return SubjectVerdict(
+            subject=report.name,
+            state=SubjectState.HEALTHY,
+            verdict=report.verdict.value,
+            detail=f"{report.name} was restarted — {report.detail}",
+            subject_kind=_SUBJECT_KIND,
+        )
+    return None
 
 
-def _now_iso(now: datetime | None) -> str:
-    """A timestamp in scitex-todo's canonical shape (second-res, ``Z`` suffix)."""
-    stamp = now or datetime.now(timezone.utc)
-    return stamp.replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
-@dataclass(frozen=True)
-class AlarmOutcome:
-    """What the routing did this run — so the caller is never silent."""
-
-    carded: tuple[str, ...] = ()
-    cleared: tuple[str, ...] = ()
-    failed: tuple[str, ...] = ()
-
-
-def _card_exists(store: str | None, card_id: str) -> bool:
-    from scitex_todo import TaskNotFoundError, get_task
-
-    # stx-allow: fallback (reason: "does this card exist yet?" — a missing store file or missing id is a normal False; any other load failure propagates to the caller's per-card guard, which reports it loudly)
-    try:
-        get_task(store, card_id)
-        return True
-    except (TaskNotFoundError, FileNotFoundError):
-        return False
-
-
-def _escalation_card(name: str, verdict: Verdict, detail: str) -> tuple[str, str]:
-    """Title + note for an agent this restarter could not heal."""
-    title = (
-        f"[fleet] {name} is STILL login-expired after auto-restart ({verdict.value})"
-    )
-    note = (
-        f"agent: {name}\n"
-        f"verdict: {verdict.value}\n"
-        f"why: {detail}\n\n"
-        "sac's login-expired restarter found this LIVE agent wedged behind a "
-        "frozen auth banner and auto-restarted it, but it is STILL login-expired "
-        "after the hourly cap. A restart LOOP is worse than a wedged agent, so "
-        "the restarter stops and asks a human instead of bouncing it forever.\n\n"
-        "The usual cause is a genuine account problem (the shared OAuth account "
-        "cannot refresh), which no restart fixes.\n\n"
-        "Investigate:\n"
-        f"    sac agents auth-status | grep {name}\n"
-        f"    sac agents tail {name}\n"
-        "Restart by hand once the account is healthy:\n"
-        f"    sac agents restart {name} --yes"
-    )
-    return title, note
-
-
-def _upsert(
-    store: str | None,
-    card_id: str,
-    title: str,
-    note: str,
-    now: datetime | None,
-    *,
-    status: str = _STATUS,
-    blocker: str | None = _BLOCKER,
-    assignee: str = _AGENT,
-) -> None:
-    """Create the card, or update it in place — never duplicate.
-
-    Re-asserting ``status`` also REOPENS a card a previous clean run resolved:
-    an agent that wedges, is healed (card resolved), then wedges again must
-    alarm again.
-    """
-    from scitex_todo import add_task, update_task
-
-    if _card_exists(store, card_id):
-        kwargs: dict[str, Any] = {
-            "title": title,
-            "note": note,
-            "status": status,
-            "last_activity": _now_iso(now),
-        }
-        if blocker is not None:
-            kwargs["blocker"] = blocker
-        update_task(store, card_id, **kwargs)
-    else:
-        kwargs = {
-            "id": card_id,
-            "title": title,
-            "status": status,
-            "note": note,
-            "scope": f"agent:{assignee}",
-            "assignee": assignee,
-            "created_by": _AGENT,
-        }
-        if blocker is not None:
-            kwargs["blocker"] = blocker
-        add_task(store, **kwargs)
-
-
-def _clear(store: str | None, card_id: str) -> bool:
-    """Resolve the card if present + still open. Returns did-clear (idempotent)."""
-    from scitex_todo import get_task, resolve_task
-
-    if not _card_exists(store, card_id):
-        return False
-    if get_task(store, card_id).get("status") == "done":
-        return False
-    resolve_task(store, card_id, actor=_AGENT)
-    return True
-
-
-def _carded_agents(store: str | None) -> list[str]:
-    """Names of every agent that currently has an OPEN escalation card.
-
-    Lets a pass RESOLVE the card of an agent that recovered on its own — it is
-    simply absent from this pass's reports, so without this it would leave a
-    stale alarm on the board forever.
-    """
-    from scitex_todo import list_tasks
-
-    # stx-allow: fallback (reason: card-clearing is a SIDE rail — a store read failure must never crash the restart pass; an empty list just means "clear nothing this pass")
-    try:
-        rows = list_tasks(store, id_prefix=CARD_ID_PREFIX)
-    except Exception:
-        return []
-    return [
-        str(r["id"])[len(CARD_ID_PREFIX) :]
-        for r in rows
-        if str(r.get("id", "")).startswith(CARD_ID_PREFIX) and r.get("status") != "done"
-    ]
-
-
-def route_reports_to_cards(
+def record_reports(
     reports: Iterable[Any],
     *,
-    store: str | None = None,
-    now: datetime | None = None,
+    path: Any = None,
+    now: float | None = None,
     err_stream: Any = None,
-) -> AlarmOutcome:
-    """Upsert / resolve one escalation card per agent from this pass's reports.
-
-    Never raises: a per-agent card-write failure is printed loudly and recorded
-    in :attr:`AlarmOutcome.failed`, so one unwritable board never suppresses the
-    rest of the fleet's alarms — nor unwinds a restart that already happened.
-    """
-    stream = err_stream if err_stream is not None else sys.stderr
-    reports = list(reports)
-    active = {r.name for r in reports}
-    carded: list[str] = []
-    cleared: list[str] = []
-    failed: list[str] = []
-
-    for report in reports:
-        name = report.name
-        card_id = card_id_for(name)
-        # stx-allow: fallback (reason: card delivery is a SIDE rail — one agent's board-write failure must never crash the pass that feeds it, nor suppress the other agents' alarms; it is reported loudly and recorded in AlarmOutcome.failed)
-        try:
-            if report.verdict in _UNRECOVERED:
-                _upsert(
-                    store,
-                    card_id,
-                    *_escalation_card(name, report.verdict, report.detail),
-                    now=now,
-                )
-                carded.append(name)
-            elif report.verdict in _CLEARED_BY and _clear(store, card_id):
-                cleared.append(name)
-        except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
-            failed.append(name)
-            print(
-                f"[login-expired-restart-alarm] {name}: scitex-todo card "
-                f"delivery FAILED — {exc} (the verdict above is UNCHANGED and any "
-                f"restart it performed still happened)",
-                file=stream,
-            )
-
-    # Recovered-on-their-own: an agent with an open card that is NOT in this
-    # pass's reports is no longer login-expired → resolve its stale card.
-    #
-    # An UNOBSERVED agent IS in the reports, so its card survives this sweep.
-    # That is the point: resolving an escalation card on a reading we never
-    # took would be a false all-clear in its most durable form — the board
-    # would say a human had nothing left to look at, on the strength of the
-    # pass having failed to look.
-    for name in _carded_agents(store):
-        if name in active:
-            continue
-        # stx-allow: fallback (reason: side rail — a failed clear must never crash the pass)
-        try:
-            if _clear(store, card_id_for(name)):
-                cleared.append(name)
-        except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
-            failed.append(name)
-            print(
-                f"[login-expired-restart-alarm] {name}: could not resolve stale "
-                f"card — {exc}",
-                file=stream,
-            )
-
-    return AlarmOutcome(
-        carded=tuple(carded), cleared=tuple(cleared), failed=tuple(failed)
+) -> EmitOutcome:
+    """Record one event per agent from this pass's ``reports``. Never raises."""
+    collected = list(reports)
+    verdicts = [v for v in (_verdict_for(report) for report in collected) if v]
+    emitted = emit_subject_verdicts(
+        SUBSYSTEM, verdicts, path=path, now=now, err_stream=err_stream
+    )
+    swept = recover_absent_subjects(
+        SUBSYSTEM,
+        [report.name for report in collected],
+        detail=(
+            "no longer login-expired — absent from this pass, which reports "
+            "only the agents currently wedged behind an auth banner"
+        ),
+        subject_kind=_SUBJECT_KIND,
+        path=path,
+        now=now,
+        err_stream=err_stream,
+    )
+    return EmitOutcome(
+        degraded=emitted.degraded,
+        unknown=emitted.unknown,
+        recovered=emitted.recovered + swept.recovered,
+        failed=emitted.failed + swept.failed,
     )
 
 
-def _heartbeat_note(
-    stats: Mapping[str, int], *, mode: str, host: str, now: datetime | None
-) -> str:
-    counted = "\n".join(f"  {k:<22} {v}" for k, v in stats.items())
-    return (
-        f"last run: {_now_iso(now)}\n"
-        f"mode:     {mode}\n"
-        f"host:     {host}\n\n"
-        f"{counted}\n\n"
-        "This card is sac's login-expired-restarter LIVENESS BEACON, refreshed "
-        "on every pass — including passes that find nothing wrong, which are the "
-        "ticks that prove the mechanism is alive at all.\n\n"
-        "IF THIS CARD IS STALE, THE RESTARTER IS NOT RUNNING, and live agents "
-        "wedged behind an auth banner are once again staying wedged unnoticed.\n\n"
-        "Check the timer:\n"
-        "    systemctl --user list-timers | grep restart-login-expired\n"
-        "Run a pass by hand (read-only):\n"
-        "    sac agents restart-login-expired --check"
-    )
-
-
-def upsert_heartbeat(
+def record_pass_completed(
     stats: Mapping[str, int],
     *,
     mode: str,
     host: str = "",
-    store: str | None = None,
-    now: datetime | None = None,
+    path: Any = None,
+    now: float | None = None,
     err_stream: Any = None,
 ) -> bool:
-    """Refresh the restarter's own liveness card. Returns did-write.
-
-    Kept ``in_progress`` (NOT ``done``): only an OPEN card is watched by
-    scitex-todo's stale-active nudge, and that nudge firing IS the alarm for a
-    dead restarter. A SIDE rail — a board-write failure prints loudly and returns
-    ``False``; it never raises into the pass.
-    """
-    stream = err_stream if err_stream is not None else sys.stderr
-    # stx-allow: fallback (reason: the heartbeat is a SIDE rail — telling the board we are alive must never crash the pass that restarts wedged agents; a failure here is printed loudly and reported to the caller)
-    try:
-        _upsert(
-            store,
-            HEARTBEAT_CARD_ID,
-            f"[fleet] sac login-expired-restarter heartbeat — last {mode} pass "
-            f"{_now_iso(now)}",
-            _heartbeat_note(stats, mode=mode, host=host, now=now),
-            now,
-            status="in_progress",
-            blocker=None,
-            assignee=_HEARTBEAT_ASSIGNEE,
-        )
-        return True
-    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
-        print(
-            f"[login-expired-restart-alarm] HEARTBEAT card delivery FAILED — "
-            f"{exc}. The pass itself was UNAFFECTED, but the board can no longer "
-            f"tell anyone whether this restarter is alive.",
-            file=stream,
-        )
-        return False
+    """Record that a login-expired-restart pass RAN. Never raises."""
+    return log_pass_completed(
+        subsystem=SUBSYSTEM,
+        mode=mode,
+        counts=dict(stats),
+        detail=f"auth-heal {mode} pass completed on {host or 'this host'}",
+        path=path,
+        now=now,
+        err_stream=err_stream,
+    )

--- a/src/scitex_agent_container/_authheal/_pass.py
+++ b/src/scitex_agent_container/_authheal/_pass.py
@@ -44,8 +44,8 @@ WHAT A CLEAN PASS IS ALLOWED TO MEAN
     pass that read nothing at all produces.
 
 Every collaborator is an injectable seam with a REAL default, so tests drive the
-whole pass against real panes, a real temp history file and a real scitex-todo
-store — with the one irreversible act (the restart) swapped for a recorder. No
+whole pass against real panes, a real temp history file and a real temp event
+log — with the one irreversible act (the restart) swapped for a recorder. No
 mocks.
 """
 
@@ -55,7 +55,6 @@ import os
 import sys
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -67,7 +66,7 @@ from .._reconcile._budget import (
     save_history,
 )
 from .._reconcile._rule import Verdict
-from ._alarm import route_reports_to_cards, upsert_heartbeat
+from ._alarm import record_pass_completed, record_reports
 from ._detect import (
     DEFAULT_INTERVAL,
     capture_live_panes,
@@ -90,9 +89,9 @@ __all__ = [
 _HISTORY_ENV = "SAC_LOGIN_EXPIRED_HISTORY"
 
 #: Which rate-limit stood in the way, mapped to the verdict it becomes. Same
-#: split as reconcile: only OVER-BUDGET is carded (a human is genuinely needed);
-#: COOLING-DOWN is the NORMAL state of a healthy recovery and CAPPED is our own
-#: throttle, so neither mints a card.
+#: split as reconcile: only OVER-BUDGET gets a per-agent record (sac has stopped
+#: trying); COOLING-DOWN is the NORMAL state of a healthy recovery and CAPPED is
+#: our own throttle, so neither does — both are still counted in the pass record.
 _BUDGET_VERDICTS = {
     "debounce": Verdict.COOLING_DOWN,
     "over-budget": Verdict.OVER_BUDGET,
@@ -363,7 +362,7 @@ def auth_heal_pass(
     limit: int = DEFAULT_PASS_CAP,
     specs_dir: Path | None = None,
     history_file: Path | None = None,
-    store: str | None = None,
+    events_path: Path | None = None,
     alarm: bool = True,
     now: float | None = None,
     restart_fn: Callable[[str], bool] | None = None,
@@ -394,7 +393,6 @@ def auth_heal_pass(
         would make the restarter's own history its evidence about itself.
     """
     now = now if now is not None else time.time()
-    now_dt = datetime.fromtimestamp(now, tz=timezone.utc)
     restart_fn = restart_fn if restart_fn is not None else _real_restart
     capture_fn = (
         capture_fn if capture_fn is not None else (lambda: capture_live_panes(interval))
@@ -480,20 +478,18 @@ def auth_heal_pass(
     alarm_outcome = None
     heartbeat_ok = False
     if alarm:
-        # Board rails run LAST, after every restart decision is made and carried
-        # out, so nothing they do (or fail to do) can change what happened.
+        # Recording runs LAST, after every restart decision is made and carried
+        # out, so nothing it does (or fails to do) can change what happened.
         alarm_outcome = (
-            route_reports_to_cards(
-                reports, store=store, now=now_dt, err_stream=err_stream
-            )
+            record_reports(reports, path=events_path, now=now, err_stream=err_stream)
             if apply
             else None
         )
-        heartbeat_ok = upsert_heartbeat(
+        heartbeat_ok = record_pass_completed(
             outcome.counts(),
             mode="apply" if apply else "check",
-            store=store,
-            now=now_dt,
+            path=events_path,
+            now=now,
             err_stream=err_stream,
         )
     return PassOutcome(

--- a/src/scitex_agent_container/_events/__init__.py
+++ b/src/scitex_agent_container/_events/__init__.py
@@ -32,8 +32,10 @@ from ._verdicts import (
     SubjectState,
     SubjectVerdict,
     degraded_state_path,
+    emit_self_state,
     emit_subject_verdicts,
     recover_absent_subjects,
+    self_state_path,
 )
 
 __all__ = [
@@ -51,10 +53,12 @@ __all__ = [
     "SubjectState",
     "SubjectVerdict",
     "degraded_state_path",
+    "emit_self_state",
     "emit_subject_verdicts",
     "event_log_path",
     "log_event",
     "log_pass_completed",
     "read_events",
     "recover_absent_subjects",
+    "self_state_path",
 ]

--- a/src/scitex_agent_container/_events/__init__.py
+++ b/src/scitex_agent_container/_events/__init__.py
@@ -1,0 +1,60 @@
+"""sac's own operational event log.
+
+sac's unattended passes decide things about the fleet every few minutes,
+forever, with nobody watching. This package is where sac records what it
+observed and what it decided, so that sac's own behaviour is auditable
+afterwards without depending on any software sac does not own.
+
+See :mod:`._log` for the record and the event vocabulary, and
+:mod:`._verdicts` for the shared per-subject routing the scheduled passes use.
+"""
+
+from __future__ import annotations
+
+from ._log import (
+    EVENT_LOG_ENV,
+    EVENT_LOG_FILENAME,
+    KNOWN_EVENTS,
+    PASS_COMPLETED,
+    SELF_IMPAIRED,
+    SELF_RECOVERED,
+    SUBJECT_DEGRADED,
+    SUBJECT_RECOVERED,
+    SUBJECT_UNKNOWN,
+    SacEvent,
+    event_log_path,
+    log_event,
+    log_pass_completed,
+    read_events,
+)
+from ._verdicts import (
+    EmitOutcome,
+    SubjectState,
+    SubjectVerdict,
+    degraded_state_path,
+    emit_subject_verdicts,
+    recover_absent_subjects,
+)
+
+__all__ = [
+    "EVENT_LOG_ENV",
+    "EVENT_LOG_FILENAME",
+    "KNOWN_EVENTS",
+    "PASS_COMPLETED",
+    "SELF_IMPAIRED",
+    "SELF_RECOVERED",
+    "SUBJECT_DEGRADED",
+    "SUBJECT_RECOVERED",
+    "SUBJECT_UNKNOWN",
+    "EmitOutcome",
+    "SacEvent",
+    "SubjectState",
+    "SubjectVerdict",
+    "degraded_state_path",
+    "emit_subject_verdicts",
+    "event_log_path",
+    "log_event",
+    "log_pass_completed",
+    "read_events",
+    "recover_absent_subjects",
+]

--- a/src/scitex_agent_container/_events/_log.py
+++ b/src/scitex_agent_container/_events/_log.py
@@ -1,0 +1,345 @@
+"""sac's append-only OPERATIONAL EVENT LOG — one JSONL line per fact sac records.
+
+WHY THIS EXISTS
+    sac runs unattended passes on timers: the fleet reconciler, the auth-heal
+    login-expired restarter, the host-sync drift check, the worktree GC, the
+    accounts refresh. Each one makes decisions about the fleet every few
+    minutes, forever, with nobody watching. Until now those decisions were
+    written to a THIRD-PARTY APPLICATION's data store and to stderr. Neither is
+    sac's own record:
+
+    * the stderr line lands in a journal nobody opens, which is exactly how a
+      dead cron job stayed dead for 49 days;
+    * a store owned by another application can be absent, unwritable, or
+      renamed, and when it is, sac retains NO account of what its own timers
+      decided. sac's auditability cannot be contingent on software sac does
+      not own.
+
+    An unlogged decision is an undebuggable one. This module is sac's record of
+    sac's own behaviour, kept by sac, for sac.
+
+WHAT IT IS AND IS NOT
+    It RECORDS. It never detects, restarts, refreshes or remediates anything —
+    the passes own their remediation and keep owning it. A recorder is not an
+    actor.
+
+    It is also not addressed to anybody. These records describe what sac
+    observed and what sac decided, in sac's own vocabulary. Nothing outside sac
+    is modelled here, and no field exists to suit a reader other than sac.
+
+RELATIONSHIP TO :mod:`.._authevents._log`
+    That module is a different log holding different facts: the auth TIMELINE
+    (rotations, 401s, restart attempt/outcome pairs), whose value is that it
+    joins events across accounts and agents on a single account axis. This log
+    holds pass VERDICTS — what a scheduled pass concluded about a subject, and
+    whether the pass ran at all. They are not two doors onto the same data, and
+    neither one is a copy of the other.
+
+FAIL-OPEN, BUT NEVER SILENT
+    Every write is best-effort and returns a bool: a full disk or a read-only
+    mount must never abort the reconcile pass being recorded. The thing
+    observed always outranks the observing of it.
+
+    But a failed write ALWAYS prints, loudly, to stderr — the rail reports its
+    own failure rather than trusting each caller to remember to. A logging rail
+    that can fail quietly is worse than no rail, because it is believed.
+
+TRI-STATE, ALWAYS
+    ``subject``, ``subject_kind`` and ``verdict`` are ALWAYS present and are
+    ``null`` when they do not apply or could not be determined. An absent field
+    and an unknown value are different facts: the first says nobody thought to
+    record it, the second says we looked and could not tell.
+
+    The same discipline governs the event vocabulary. :data:`SUBJECT_UNKNOWN`
+    exists so that "sac could not read this subject" can never be recorded as,
+    or mistaken for, :data:`SUBJECT_RECOVERED`. "I could not look" must never
+    read as "I looked and it was fine".
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+__all__ = [
+    "EVENT_LOG_ENV",
+    "EVENT_LOG_FILENAME",
+    "KNOWN_EVENTS",
+    "PASS_COMPLETED",
+    "SELF_IMPAIRED",
+    "SELF_RECOVERED",
+    "SUBJECT_DEGRADED",
+    "SUBJECT_RECOVERED",
+    "SUBJECT_UNKNOWN",
+    "SacEvent",
+    "event_log_path",
+    "log_event",
+    "log_pass_completed",
+    "read_events",
+]
+
+#: Filename of the append-only log, relative to sac's runtime dir.
+EVENT_LOG_FILENAME = "sac-events.jsonl"
+
+#: Env override for the log location. Lets a test drive a REAL file in a temp
+#: dir (no mocks) and lets an operator relocate the rail without a code change.
+EVENT_LOG_ENV = "SAC_EVENT_LOG"
+
+#: A scheduled pass RAN to completion. Written on EVERY pass, including passes
+#: that found nothing wrong — those are the ticks that prove the mechanism is
+#: alive at all. A record that only appears when there is trouble cannot
+#: distinguish HEALTHY from DEAD, which is the failure this whole rail exists
+#: to abolish.
+PASS_COMPLETED = "pass-completed"
+
+#: sac observed a subject in a bad state it could not remediate itself.
+SUBJECT_DEGRADED = "subject-degraded"
+
+#: sac observed that a previously-degraded subject is well again. Written on
+#: the TRANSITION, so the log records recoveries rather than restating health
+#: every few minutes forever.
+SUBJECT_RECOVERED = "subject-recovered"
+
+#: sac could NOT determine a subject's state. Deliberately its own event and
+#: never folded into either of the two above: an unreadable peer is not a peer
+#: without drift, it is a peer whose drift sac failed to observe.
+SUBJECT_UNKNOWN = "subject-unknown"
+
+#: sac observed that SAC ITSELF cannot do its job — the reconciler that cannot
+#: read its own restart history, for instance. Distinct from a degraded
+#: subject: the fault is sac's, and while it stands sac's other verdicts are
+#: not trustworthy.
+SELF_IMPAIRED = "self-impaired"
+
+#: A previously recorded self-impairment has cleared.
+SELF_RECOVERED = "self-recovered"
+
+#: The closed set. Unknown values are still written (forward-compat: a record
+#: we do not recognise is evidence too) but flagged with ``event_known: false``
+#: so a reader can tell a new event type from a typo.
+KNOWN_EVENTS = frozenset(
+    {
+        PASS_COMPLETED,
+        SUBJECT_DEGRADED,
+        SUBJECT_RECOVERED,
+        SUBJECT_UNKNOWN,
+        SELF_IMPAIRED,
+        SELF_RECOVERED,
+    }
+)
+
+
+def event_log_path() -> Path:
+    """Where the event log lives. Resolved PER CALL, never cached.
+
+    Per-call resolution matters: a module-level constant computed at import
+    cannot be redirected by an env var a test sets afterwards, which is how a
+    suite ends up writing into the REAL fleet runtime dir while believing it is
+    hermetic.
+    """
+    override = os.environ.get(EVENT_LOG_ENV)
+    if override:
+        return Path(override).expanduser()
+    from .._state.state_paths import runtime_root
+
+    return runtime_root() / EVENT_LOG_FILENAME
+
+
+def _resolve_host() -> str:
+    """Best-effort canonical host label. Never raises."""
+    # stx-allow: fallback (reason: the host is a label on an observability
+    # record; a resolver failure must degrade to a short hostname and then to
+    # "unknown", never break the write it annotates.)
+    try:
+        from .._state.state_db_hostname import resolve_host
+
+        return resolve_host(None)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        try:
+            return socket.gethostname()
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            return "unknown"
+
+
+def log_event(
+    *,
+    event: str,
+    subsystem: str,
+    detail: str,
+    subject: str | None = None,
+    subject_kind: str | None = None,
+    verdict: str | None = None,
+    extra: dict[str, Any] | None = None,
+    path: Path | None = None,
+    now: float | None = None,
+    err_stream: Any = None,
+) -> bool:
+    """Append ONE event. Returns whether it was written; NEVER raises.
+
+    A failed write is printed loudly to ``err_stream`` (default stderr) before
+    returning ``False``. Callers do not have to remember to report it, and no
+    caller can accidentally silence it.
+
+    Parameters
+    ----------
+    event
+        One of :data:`KNOWN_EVENTS`. Unknown values are recorded anyway and
+        marked ``event_known: false``.
+    subsystem
+        Which sac pass is speaking (``"fleet-reconcile"``, ``"host-sync"``, …).
+        This is the axis a reader filters on first when asking "did my timer
+        run, and what did it decide".
+    subject
+        The thing observed — an agent, a peer, a repo, an account. ``None``
+        when the fact is fleet-wide and belongs to no single subject.
+    verdict
+        The emitting pass's OWN verdict token, verbatim. Passing it through
+        unmapped is deliberate: a verdict translated on the way into the log
+        can no longer be compared against the code that produced it.
+    """
+    stream = err_stream if err_stream is not None else sys.stderr
+    now_ts = now if now is not None else datetime.now(tz=timezone.utc).timestamp()
+    record: dict[str, Any] = {
+        "timestamp_utc": datetime.fromtimestamp(now_ts, tz=timezone.utc).isoformat(),
+        "event": event,
+        "subsystem": subsystem,
+        # Tri-state, always present: null == does not apply / could not tell.
+        "subject": subject,
+        "subject_kind": subject_kind,
+        "verdict": verdict,
+        "detail": detail,
+        "host": _resolve_host(),
+        "pid": os.getpid(),
+    }
+    if event not in KNOWN_EVENTS:
+        record["event_known"] = False
+    if extra:
+        for key, val in extra.items():
+            record.setdefault(key, val)
+
+    target = Path(path) if path is not None else event_log_path()
+    # stx-allow: fallback (reason: FAIL-OPEN is this rail's contract. Failing to
+    # record an event must never abort the pass being observed — losing a log
+    # line is bad, losing the reconcile that line described is worse. The
+    # failure is printed loudly below, never swallowed.)
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+        return True
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        print(
+            f"[sac-events] FAILED to record {event} for "
+            f"{subsystem}/{subject or 'fleet'} at {target} — {exc}. The pass "
+            f"itself was UNAFFECTED, but this decision is now unrecorded.",
+            file=stream,
+        )
+        return False
+
+
+def log_pass_completed(
+    *,
+    subsystem: str,
+    mode: str,
+    counts: dict[str, int] | None = None,
+    detail: str = "",
+    path: Path | None = None,
+    now: float | None = None,
+    err_stream: Any = None,
+) -> bool:
+    """Record that a scheduled pass RAN. Never raises.
+
+    Called on EVERY pass — above all on a pass that found nothing to do. "0
+    restarted, all healthy" is the most important record there is, because it
+    is the only thing distinguishing a healthy fleet from a pass that stopped
+    running months ago.
+
+    ``mode`` carries whether this was an ``apply`` pass or a dry run, and it is
+    load-bearing rather than cosmetic: a hand-run dry run also writes this
+    record, so a reader who ignores ``mode`` can believe a scheduled timer is
+    alive on the strength of somebody having run the command by hand.
+    """
+    return log_event(
+        event=PASS_COMPLETED,
+        subsystem=subsystem,
+        detail=detail or f"{subsystem} pass completed ({mode})",
+        verdict=mode,
+        extra={"mode": mode, "counts": dict(counts or {})},
+        path=path,
+        now=now,
+        err_stream=err_stream,
+    )
+
+
+@dataclass(frozen=True)
+class SacEvent:
+    """One parsed record. ``raw`` keeps every field, including unknown ones."""
+
+    timestamp_utc: str | None
+    event: str | None
+    subsystem: str | None
+    subject: str | None
+    subject_kind: str | None
+    verdict: str | None
+    detail: str | None
+    raw: dict[str, Any]
+
+
+def _parse(line: str) -> SacEvent | None:
+    # stx-allow: fallback (reason: a half-written or corrupt line must not blind
+    # a reader to the thousands of good ones around it — an append-only log read
+    # during an incident has to degrade, not refuse.)
+    try:
+        obj = json.loads(line)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+    if not isinstance(obj, dict):
+        return None
+    return SacEvent(
+        timestamp_utc=obj.get("timestamp_utc"),
+        event=obj.get("event"),
+        subsystem=obj.get("subsystem"),
+        subject=obj.get("subject"),
+        subject_kind=obj.get("subject_kind"),
+        verdict=obj.get("verdict"),
+        detail=obj.get("detail"),
+        raw=obj,
+    )
+
+
+def read_events(
+    path: Path | None = None,
+    *,
+    subsystem: str | None = None,
+    event: str | None = None,
+) -> list[SacEvent]:
+    """Read the log, skipping unparseable lines. Returns ``[]`` if absent.
+
+    A missing log is an empty reading, not an error — but note it is also NOT
+    evidence that no pass ran. Absence of the rail is absence of evidence, and
+    this function cannot tell those apart for you.
+    """
+    target = Path(path) if path is not None else event_log_path()
+    # stx-allow: fallback (reason: reading is diagnostic; an unreadable log must
+    # degrade to an empty reading rather than raise into an incident.)
+    try:
+        with target.open("r", encoding="utf-8") as handle:
+            found: Iterable[SacEvent] = [
+                parsed for parsed in (_parse(ln) for ln in handle) if parsed
+            ]
+    except FileNotFoundError:
+        return []
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return []
+    return [
+        item
+        for item in found
+        if (subsystem is None or item.subsystem == subsystem)
+        and (event is None or item.event == event)
+    ]

--- a/src/scitex_agent_container/_events/_verdicts.py
+++ b/src/scitex_agent_container/_events/_verdicts.py
@@ -1,0 +1,318 @@
+"""Route a pass's per-subject verdicts into sac's event log — ONE implementation.
+
+WHY THIS IS SHARED
+    Four of sac's unattended passes (the fleet reconciler, the auth-heal
+    restarter, the host-sync drift check, the worktree GC) reach the same
+    shape at the end of their run: a list of subjects, each in one of three
+    states, plus the pass's own verdict token and a human detail line. Each
+    one had grown its OWN near-identical copy of the routing — four
+    hand-maintained variants of the same forty lines, which is how two of them
+    ended up with subtly different rules for the same situation.
+
+    This is the single implementation. A pass's job is to reach a verdict; how
+    a verdict is recorded is not four different questions.
+
+THREE STATES, NEVER TWO
+    :class:`SubjectState` is DEGRADED / UNKNOWN / HEALTHY. UNKNOWN is not a
+    soft HEALTHY — it means sac could not read the subject, so its condition is
+    unobserved rather than absent. Collapsing the two produces a false all-clear
+    in its most durable form: a record saying sac looked and found nothing
+    wrong, on the strength of the pass having failed to look.
+
+TRANSITIONS, NOT A HEARTBEAT PER SUBJECT
+    A DEGRADED subject is remembered in a small sac-owned state file, and its
+    recovery is recorded when it actually recovers. The alternative — writing a
+    record for every healthy subject on every pass — would put roughly a
+    hundred agents into the log every five minutes forever and bury the events
+    that matter under the ones that do not. sac already keeps small state files
+    of exactly this kind for exactly this reason (the accounts-refresh dedupe,
+    the reconciler's restart history), so this is the house pattern rather than
+    a new invention.
+
+    The state file is an OPTIMISATION OF THE RECORD, never an input to a
+    decision. Losing it re-records a degraded subject as newly degraded and
+    misses one recovery edge; it can never cause sac to act, or fail to act, on
+    the fleet.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable
+
+from ._log import (
+    SUBJECT_DEGRADED,
+    SUBJECT_RECOVERED,
+    SUBJECT_UNKNOWN,
+    event_log_path,
+    log_event,
+)
+
+__all__ = [
+    "EmitOutcome",
+    "SubjectState",
+    "SubjectVerdict",
+    "degraded_state_path",
+    "emit_subject_verdicts",
+    "recover_absent_subjects",
+]
+
+
+class SubjectState(str, Enum):
+    """What sac concluded about one subject this pass. Three states, always."""
+
+    #: Observed, and bad in a way this pass could not fix by itself.
+    DEGRADED = "degraded"
+    #: Could NOT be read. Unobserved — never rendered as healthy.
+    UNKNOWN = "unknown"
+    #: Observed, and well.
+    HEALTHY = "healthy"
+
+
+@dataclass(frozen=True)
+class SubjectVerdict:
+    """One subject's outcome, in the emitting pass's OWN vocabulary.
+
+    ``verdict`` is the pass's verdict token verbatim (``"over_budget"``,
+    ``"behind"``, …). It is passed through unmapped on purpose: a verdict
+    translated on the way into the log can no longer be compared against the
+    code that produced it.
+    """
+
+    subject: str
+    state: SubjectState
+    verdict: str
+    detail: str
+    subject_kind: str = "agent"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EmitOutcome:
+    """What the routing recorded this run — so the caller is never silent.
+
+    ``failed`` is orthogonal to the other three: a subject whose record could
+    not be written lands there INSTEAD of its state bucket, because sac cannot
+    claim to have recorded something it did not record.
+    """
+
+    degraded: tuple[str, ...] = ()
+    unknown: tuple[str, ...] = ()
+    recovered: tuple[str, ...] = ()
+    failed: tuple[str, ...] = ()
+
+    def summary_line(self) -> str:
+        """One human line naming what reached the log this run."""
+        parts = [
+            f"{len(self.degraded)} degraded",
+            f"{len(self.unknown)} unknown",
+            f"{len(self.recovered)} recovered",
+        ]
+        if self.failed:
+            parts.append(f"{len(self.failed)} UNRECORDED")
+        return "sac events: " + ", ".join(parts)
+
+
+#: The state file sits beside the log it annotates, so redirecting the log in a
+#: test (or on an operator's host) carries its state with it automatically.
+def degraded_state_path(subsystem: str, *, path: Path | None = None) -> Path:
+    """Where ``subsystem``'s currently-degraded subject set is remembered."""
+    base = Path(path) if path is not None else event_log_path()
+    return base.parent / f"sac-events-{subsystem}-degraded.json"
+
+
+def _load_degraded(target: Path, *, err_stream: Any) -> set[str]:
+    """Read the remembered set. A MISSING file is a normal empty start.
+
+    A file that exists but cannot be read or parsed is NOT normal, and says so
+    loudly: it means sac has forgotten which subjects it had already reported,
+    and will re-report them as newly degraded.
+    """
+    if not target.exists():
+        return set()
+    # stx-allow: fallback (reason: a corrupt or unreadable memory file must
+    # degrade to "remember nothing" rather than crash the pass that owns it —
+    # the cost is one duplicated degraded record, and it is reported loudly
+    # immediately below rather than swallowed.)
+    try:
+        loaded = json.loads(target.read_text(encoding="utf-8"))
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        print(
+            f"[sac-events] could not read {target} — {exc}. Previously reported "
+            f"subjects will be recorded as newly degraded again.",
+            file=err_stream,
+        )
+        return set()
+    if not isinstance(loaded, list):
+        print(
+            f"[sac-events] {target} is not a list of subjects — ignoring it. "
+            f"Previously reported subjects will be recorded as newly degraded.",
+            file=err_stream,
+        )
+        return set()
+    return {str(item) for item in loaded}
+
+
+def _save_degraded(target: Path, subjects: set[str], *, err_stream: Any) -> None:
+    """Persist the remembered set atomically (tmp + rename). Never raises."""
+    # stx-allow: fallback (reason: this file is an optimisation of the RECORD,
+    # never an input to a fleet decision — failing to persist it can only cause
+    # a duplicate degraded record next pass, so it must not crash the pass. The
+    # failure is printed loudly rather than swallowed.)
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_name(target.name + ".tmp")
+        tmp.write_text(json.dumps(sorted(subjects), indent=2), encoding="utf-8")
+        tmp.replace(target)
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        print(
+            f"[sac-events] could not persist {target} — {exc}. Subjects already "
+            f"reported this pass may be recorded as newly degraded next pass.",
+            file=err_stream,
+        )
+
+
+_EVENT_FOR = {
+    SubjectState.DEGRADED: SUBJECT_DEGRADED,
+    SubjectState.UNKNOWN: SUBJECT_UNKNOWN,
+}
+
+
+def emit_subject_verdicts(
+    subsystem: str,
+    verdicts: Iterable[SubjectVerdict],
+    *,
+    path: Path | None = None,
+    now: float | None = None,
+    err_stream: Any = None,
+) -> EmitOutcome:
+    """Record one event per subject that has something to report.
+
+    DEGRADED and UNKNOWN subjects are recorded every pass — an ongoing problem
+    is an ongoing fact, and a log that mentions a wedged agent once and then
+    goes quiet cannot be distinguished from a log written by a pass that died.
+
+    HEALTHY subjects are recorded only on the TRANSITION out of a remembered
+    bad state, so a well fleet does not write a record per agent per tick.
+
+    Never raises: a subject whose record could not be written is reported by
+    the log rail itself and recorded in :attr:`EmitOutcome.failed`, so one
+    unwritable file never suppresses the rest of the fleet's records — nor
+    unwinds work the pass already performed.
+    """
+    stream = err_stream if err_stream is not None else sys.stderr
+    state_file = degraded_state_path(subsystem, path=path)
+    remembered = _load_degraded(state_file, err_stream=stream)
+
+    degraded: list[str] = []
+    unknown: list[str] = []
+    recovered: list[str] = []
+    failed: list[str] = []
+
+    for item in verdicts:
+        if item.state is SubjectState.HEALTHY:
+            if item.subject not in remembered:
+                continue
+            written = log_event(
+                event=SUBJECT_RECOVERED,
+                subsystem=subsystem,
+                subject=item.subject,
+                subject_kind=item.subject_kind,
+                verdict=item.verdict,
+                detail=item.detail,
+                extra=item.extra,
+                path=path,
+                now=now,
+                err_stream=stream,
+            )
+            if written:
+                remembered.discard(item.subject)
+                recovered.append(item.subject)
+            else:
+                failed.append(item.subject)
+            continue
+
+        written = log_event(
+            event=_EVENT_FOR[item.state],
+            subsystem=subsystem,
+            subject=item.subject,
+            subject_kind=item.subject_kind,
+            verdict=item.verdict,
+            detail=item.detail,
+            extra=item.extra,
+            path=path,
+            now=now,
+            err_stream=stream,
+        )
+        if not written:
+            failed.append(item.subject)
+            continue
+        remembered.add(item.subject)
+        (degraded if item.state is SubjectState.DEGRADED else unknown).append(
+            item.subject
+        )
+
+    _save_degraded(state_file, remembered, err_stream=stream)
+    return EmitOutcome(
+        degraded=tuple(degraded),
+        unknown=tuple(unknown),
+        recovered=tuple(recovered),
+        failed=tuple(failed),
+    )
+
+
+def recover_absent_subjects(
+    subsystem: str,
+    observed: Iterable[str],
+    *,
+    detail: str,
+    verdict: str = "absent",
+    subject_kind: str = "agent",
+    path: Path | None = None,
+    now: float | None = None,
+    err_stream: Any = None,
+) -> EmitOutcome:
+    """Record recovery for remembered subjects this pass did NOT see.
+
+    Only meaningful for a pass whose subject list is ITSELF the problem list —
+    one that reports only the agents currently in a bad way. For such a pass,
+    a remembered subject's absence IS the observation that it recovered.
+
+    It is deliberately a separate call rather than a flag on
+    :func:`emit_subject_verdicts`, because for a pass that enumerates the whole
+    fleet an absent subject means something entirely different — it was deleted
+    or has become unreadable, not that it healed — and recording that as a
+    recovery would be a false all-clear. Which meaning applies is a property of
+    the calling pass, so it is stated at the call site.
+    """
+    stream = err_stream if err_stream is not None else sys.stderr
+    state_file = degraded_state_path(subsystem, path=path)
+    remembered = _load_degraded(state_file, err_stream=stream)
+    present = set(observed)
+
+    recovered: list[str] = []
+    failed: list[str] = []
+    for subject in sorted(remembered - present):
+        written = log_event(
+            event=SUBJECT_RECOVERED,
+            subsystem=subsystem,
+            subject=subject,
+            subject_kind=subject_kind,
+            verdict=verdict,
+            detail=detail,
+            path=path,
+            now=now,
+            err_stream=stream,
+        )
+        if written:
+            remembered.discard(subject)
+            recovered.append(subject)
+        else:
+            failed.append(subject)
+
+    _save_degraded(state_file, remembered, err_stream=stream)
+    return EmitOutcome(recovered=tuple(recovered), failed=tuple(failed))

--- a/src/scitex_agent_container/_events/_verdicts.py
+++ b/src/scitex_agent_container/_events/_verdicts.py
@@ -45,6 +45,8 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from ._log import (
+    SELF_IMPAIRED,
+    SELF_RECOVERED,
     SUBJECT_DEGRADED,
     SUBJECT_RECOVERED,
     SUBJECT_UNKNOWN,
@@ -57,8 +59,10 @@ __all__ = [
     "SubjectState",
     "SubjectVerdict",
     "degraded_state_path",
+    "emit_self_state",
     "emit_subject_verdicts",
     "recover_absent_subjects",
+    "self_state_path",
 ]
 
 
@@ -123,6 +127,17 @@ def degraded_state_path(subsystem: str, *, path: Path | None = None) -> Path:
     """Where ``subsystem``'s currently-degraded subject set is remembered."""
     base = Path(path) if path is not None else event_log_path()
     return base.parent / f"sac-events-{subsystem}-degraded.json"
+
+
+def self_state_path(subsystem: str, *, path: Path | None = None) -> Path:
+    """Where ``subsystem``'s own impaired/healthy state is remembered.
+
+    Deliberately a SEPARATE file from the subject set: a pass's own health is
+    not one of its subjects, and sharing one file would need a reserved key
+    that a real subject could one day collide with.
+    """
+    base = Path(path) if path is not None else event_log_path()
+    return base.parent / f"sac-events-{subsystem}-self.json"
 
 
 def _load_degraded(target: Path, *, err_stream: Any) -> set[str]:
@@ -316,3 +331,53 @@ def recover_absent_subjects(
 
     _save_degraded(state_file, remembered, err_stream=stream)
     return EmitOutcome(recovered=tuple(recovered), failed=tuple(failed))
+
+
+def emit_self_state(
+    subsystem: str,
+    *,
+    impaired: bool,
+    detail: str,
+    verdict: str | None = None,
+    extra: dict[str, Any] | None = None,
+    path: Path | None = None,
+    now: float | None = None,
+    err_stream: Any = None,
+) -> bool:
+    """Record a change in whether SAC ITSELF can do this pass's job.
+
+    Returns whether a record was written — ``False`` means nothing changed, not
+    that anything failed.
+
+    Transition-tracked for the same reason subjects are, and the stakes are
+    higher here: a pass runs every few minutes, so recording "I am fine" on
+    every tick would write hundreds of thousands of records a year and, worse,
+    would make :data:`SELF_RECOVERED` mean nothing. A recovery record has to
+    mark an actual recovery, or it is not evidence of one.
+
+    An impairment is re-recorded on every pass while it stands, exactly like a
+    degraded subject: an ongoing refusal to act is an ongoing fact, and a log
+    that mentions it once and goes quiet is indistinguishable from a log
+    written by a pass that has itself died.
+    """
+    stream = err_stream if err_stream is not None else sys.stderr
+    state_file = self_state_path(subsystem, path=path)
+    was_impaired = subsystem in _load_degraded(state_file, err_stream=stream)
+
+    if not impaired and not was_impaired:
+        return False
+
+    written = log_event(
+        event=SELF_IMPAIRED if impaired else SELF_RECOVERED,
+        subsystem=subsystem,
+        verdict=verdict,
+        detail=detail,
+        extra=extra,
+        path=path,
+        now=now,
+        err_stream=stream,
+    )
+    if not written:
+        return False
+    _save_degraded(state_file, {subsystem} if impaired else set(), err_stream=stream)
+    return True

--- a/src/scitex_agent_container/_hostsync/__init__.py
+++ b/src/scitex_agent_container/_hostsync/__init__.py
@@ -30,7 +30,7 @@ The invariants, each one paid for:
   what it verified.
 """
 
-from ._alarm import AlarmOutcome, card_id_for, route_reports_to_cards
+from ._alarm import SUBSYSTEM, record_reports
 from ._apply import FastForwardResult, apply_fast_forward
 from ._ci_guard import DEFAULT_REPO, CiState, CiVerdict, check_ci_idle
 from ._model import GraphState, PeerSyncReport, SyncDecision, sync_decision
@@ -72,7 +72,6 @@ __all__ = [
     "DEFAULT_LISTEN_PORT",
     "DEFAULT_REPO",
     "GENERATED_HEADER_MARK",
-    "AlarmOutcome",
     "CiState",
     "CiVerdict",
     "ConfigVerdict",
@@ -87,7 +86,6 @@ __all__ = [
     "TokenStateResult",
     "TokenVerdict",
     "apply_fast_forward",
-    "card_id_for",
     "check_ci_idle",
     "check_config_peer",
     "check_peer",
@@ -103,7 +101,8 @@ __all__ = [
     "push_master_bearer",
     "render_peer_config",
     "rotate_peer_tokens",
-    "route_reports_to_cards",
+    "SUBSYSTEM",
+    "record_reports",
     "sha12",
     "stable_listen_token_name",
     "sync_decision",

--- a/src/scitex_agent_container/_hostsync/_alarm.py
+++ b/src/scitex_agent_container/_hostsync/_alarm.py
@@ -1,286 +1,122 @@
-"""Route ``sac host sync --check`` drift verdicts to a SEEN surface.
+"""Record ``sac host sync --check`` drift verdicts in sac's own event log.
 
-Stage-0 of the one-way central-sync plan (card
-``sac-one-way-central-sync-staged-plan-20260714``) shipped
-``sac host sync --check`` — a read-only drift detector that mutates
-nothing and exits non-zero on drift. But a detector that only sets an
-exit code is an ALARM WITH NO ONE LISTENING: its shout lands in a
-journald line nobody reads, which is exactly the anti-pattern the plan
-warns against — "an emit is a notification, not a mechanism". That is
-how a five-release-stale checkout stayed invisible until someone looked
-by hand.
+Stage-0 of the one-way central-sync plan shipped ``sac host sync --check`` — a
+read-only drift detector that mutates nothing and exits non-zero on drift. But
+a detector that only sets an exit code is an ALARM WITH NO ONE LISTENING: its
+shout lands in a journald line nobody reads. That is how a five-release-stale
+checkout stayed invisible until someone looked by hand.
 
-This module makes the shout SEEN. For each peer's read-only
-:class:`~._sync.SyncResult` it upserts an IDEMPOTENT scitex-todo card on
-the board's BLOCKING-YOU view (``status=blocked``,
-``blocker=operator-decision`` — the surface the operator already
-monitors), and RESOLVES that card the moment the peer goes clean again so
-a fixed drift stops shouting.
+This module makes the shout DURABLE. Each peer's read-only
+:class:`~._sync.SyncResult` becomes a record in :mod:`..._events` — sac's own
+append-only account of what sac observed and decided.
 
-It is a REPORT, never an enforcer. It mutates nothing on any peer and
-never triggers a sync — that (Stage 1) is deliberately out of scope. The
-only writes it makes are to the shared task board.
+It is a REPORT, never an enforcer. It mutates nothing on any peer and never
+triggers a sync — that (Stage 1) is deliberately out of scope. The only thing
+it writes is sac's own log.
 
 Three-state honest (the rule sac has paid for, twice):
 
-* **DRIFTED** (behind / ahead / diverged / dirty) → a card NAMING the
-  drift (which peer, and how it differs).
-* **UNDETERMINED** (unreachable / no-module / not-a-checkout) → a card
-  too, but clearly labelled UNKNOWN, never rendered as clean. "I could
-  not look" must never read as "I looked and it was fine".
-* **CURRENT / SYNCED** (clean) → resolve the peer's card.
+* **DRIFTED** (behind / ahead / diverged / dirty) → a DEGRADED record naming
+  the peer and how it differs.
+* **UNDETERMINED** (unreachable / no-module / not-a-checkout) → an UNKNOWN
+  record, never rendered as clean. "I could not look" must never read as "I
+  looked and it was fine".
+* **CURRENT / SYNCED** (clean) → a RECOVERED record, if this peer was
+  previously recorded as drifted.
 
-It reuses the existing scitex-todo integration — the same public writer
-sac's account-refresh alarm rail uses (:mod:`.._account.refresh_alarm`) —
-rather than hand-rolling a todo client. Like that rail, delivery is a
-SIDE rail: a per-card failure is printed loudly to stderr and never
-crashes the check that feeds it. And, like a missing scitex-todo install,
-the whole thing degrades to "printed loudly, nothing recorded" rather
-than taking the check down.
+Recording is a SIDE rail: a write failure is printed loudly by the log rail
+itself and never crashes the check that feeds it.
 """
 
 from __future__ import annotations
 
-import sys
-from dataclasses import dataclass
-from datetime import datetime, timezone
 from typing import Any
 
+from .._events import EmitOutcome, SubjectState, SubjectVerdict, emit_subject_verdicts
 from ._model import PeerSyncReport
 from ._sync import SyncResult
 
-__all__ = ["AlarmOutcome", "CARD_ID_PREFIX", "card_id_for", "route_reports_to_cards"]
+__all__ = ["SUBSYSTEM", "record_reports"]
 
-#: Stable per-peer card id, so a re-run updates in place instead of
-#: duplicating (idempotency is by id).
-CARD_ID_PREFIX = "host-sync-drift-"
+#: The pass this module speaks for — the axis a reader filters the log on.
+SUBSYSTEM = "host-sync"
 
-#: The card's owner + author. A pseudo-agent, not a human: the card is a
-#: standing "this peer is not running the centre's code" fact that the
-#: operator resolves, mirroring the accounts-refresh alarm's convention.
-_AGENT = "sac.host-sync-check"
-
-#: A determined-but-drifted card and an undetermined card BOTH land on the
-#: board's BLOCKING-YOU view (``status=blocked`` AND
-#: ``blocker=operator-decision``) — the seen surface the operator already
-#: watches. The card TEXT is what distinguishes drift from unknown.
-_STATUS = "blocked"
-_BLOCKER = "operator-decision"
+_SUBJECT_KIND = "peer"
 
 
-def card_id_for(peer: str) -> str:
-    """The stable card id for ``peer``'s drift alarm."""
-    return f"{CARD_ID_PREFIX}{peer}"
+def _facts(report: PeerSyncReport) -> dict[str, Any]:
+    """The structured drift facts, kept as fields rather than prose.
 
-
-@dataclass(frozen=True)
-class AlarmOutcome:
-    """What the routing did this run — so the caller is never silent.
-
-    Every peer lands in exactly one bucket (``failed`` is orthogonal: a
-    peer whose card write raised is recorded there instead of its verdict
-    bucket).
+    Fields are queryable; a sentence is not. ``state`` and ``target`` are what
+    a reader joins on when asking which peers were stale at a given hour.
     """
-
-    drifted: tuple[str, ...] = ()
-    undetermined: tuple[str, ...] = ()
-    cleared: tuple[str, ...] = ()
-    failed: tuple[str, ...] = ()
-
-    def summary_line(self) -> str:
-        """One human line naming what happened to the board this run."""
-        parts = [
-            f"{len(self.drifted)} drift card(s)",
-            f"{len(self.undetermined)} unknown card(s)",
-            f"{len(self.cleared)} cleared",
-        ]
-        if self.failed:
-            parts.append(f"{len(self.failed)} DELIVERY-FAILED")
-        return "scitex-todo alarm: " + ", ".join(parts)
+    return {
+        "state": report.state.value,
+        "target": report.target or None,
+        "module": report.module or None,
+    }
 
 
-def _now_iso(now: datetime | None) -> str:
-    return (now or datetime.now(timezone.utc)).isoformat()
-
-
-def _drift_card(peer: str, report: PeerSyncReport) -> tuple[str, str]:
-    """Title + note for a peer that DIFFERS from the centre.
-
-    The note names the concrete drift (``report.summary()`` already spells
-    out behind/ahead/diverged/dirty) and the exact next command, so the
-    operator reading only the card knows what to do.
-    """
-    title = f"[host-sync] {peer} DRIFTED from centre — {report.summary()}"
-    note = (
-        f"peer: {peer}\n"
-        f"verdict: {report.summary()}\n"
-        f"state: {report.state.value}\n"
-        f"target: {report.target or '?'}\n"
-        f"module: {report.module or '?'}\n\n"
-        "This peer is NOT running the centre's code. It is a REPORT, not an "
-        "auto-sync — reconcile it deliberately (fast-forward only; sac never "
-        "discards remote work):\n"
-        f"    sac host sync {peer}\n"
-        "Inspect first:\n"
-        f"    sac host sync --check {peer}"
-    )
-    return title, note
-
-
-def _unknown_card(peer: str, report: PeerSyncReport) -> tuple[str, str]:
-    """Title + note for a peer we COULD NOT READ.
-
-    Deliberately worded UNKNOWN, never clean. An undetermined peer is not a
-    peer with no drift — it is a peer whose drift we failed to observe, and
-    conflating the two is the exact false-clean that has bitten sac before.
-    """
-    title = f"[host-sync] {peer} UNKNOWN — could not verify ({report.state.value})"
-    note = (
-        f"peer: {peer}\n"
-        f"verdict: {report.summary()}\n"
-        f"state: {report.state.value}\n\n"
-        "UNKNOWN is NOT clean — sac could not read this peer's code, so its "
-        "drift is unobserved, not absent. Nothing was mutated. Restore "
-        "reachability, then re-check:\n"
-        f"    sac host probe {peer}\n"
-        f"    sac host sync --check {peer}"
-    )
-    return title, note
-
-
-def _card_exists(store: str | None, card_id: str) -> bool:
-    """True when ``card_id`` is already on the board.
-
-    A MISSING store file (nothing carded yet) and a missing id BOTH mean
-    "no such card" — the first run against a fresh board raises
-    ``FileNotFoundError`` from the loader, the later runs raise
-    ``TaskNotFoundError``; neither is an error here.
-    """
-    from scitex_todo import TaskNotFoundError, get_task
-
-    # stx-allow: fallback (reason: "does this card exist yet?" — a missing store file or missing id is a normal False, not an error; any other load failure propagates to the caller's per-peer guard which reports it loudly)
-    try:
-        get_task(store, card_id)
-        return True
-    except (TaskNotFoundError, FileNotFoundError):
-        return False
-
-
-def _upsert(
-    store: str | None,
-    card_id: str,
-    title: str,
-    note: str,
-    now: datetime | None,
-) -> None:
-    """Create the card, or update it in place — never duplicate.
-
-    Always (re)asserts ``status=blocked`` / ``blocker=operator-decision``,
-    which also REOPENS a card that a previous clean run had resolved: a
-    peer that drifts, gets fixed (card resolved), then drifts again must
-    alarm again.
-    """
-    from scitex_todo import add_task, update_task
-
-    if _card_exists(store, card_id):
-        update_task(
-            store,
-            card_id,
-            title=title,
-            note=note,
-            status=_STATUS,
-            blocker=_BLOCKER,
-            last_activity=_now_iso(now),
+def _verdict_for(result: SyncResult) -> SubjectVerdict:
+    """Map one peer's read-only report onto sac's three states."""
+    report = result.before
+    if report.is_undetermined:
+        return SubjectVerdict(
+            subject=result.peer,
+            state=SubjectState.UNKNOWN,
+            verdict=report.state.value,
+            detail=(
+                f"could not verify {result.peer} against the centre — "
+                f"{report.summary()}; nothing was mutated and its drift is "
+                f"unobserved, not absent"
+            ),
+            subject_kind=_SUBJECT_KIND,
+            extra=_facts(report),
         )
-    else:
-        add_task(
-            store,
-            id=card_id,
-            title=title,
-            status=_STATUS,
-            blocker=_BLOCKER,
-            note=note,
-            scope=f"agent:{_AGENT}",
-            assignee=_AGENT,
-            created_by=_AGENT,
+    if report.is_drifted:
+        return SubjectVerdict(
+            subject=result.peer,
+            state=SubjectState.DEGRADED,
+            verdict=report.state.value,
+            detail=(
+                f"{result.peer} is NOT running the centre's code — {report.summary()}"
+            ),
+            subject_kind=_SUBJECT_KIND,
+            extra=_facts(report),
         )
+    return SubjectVerdict(
+        subject=result.peer,
+        state=SubjectState.HEALTHY,
+        verdict=report.state.value,
+        detail=f"{result.peer} matches the centre — {report.summary()}",
+        subject_kind=_SUBJECT_KIND,
+        extra=_facts(report),
+    )
 
 
-def _clear(store: str | None, card_id: str) -> bool:
-    """Resolve the peer's card if present + still open. Returns did-clear.
-
-    Idempotent: no card, or an already-resolved card, is a quiet no-op
-    (a clean peer that was never drifted must not create then resolve a
-    phantom card).
-    """
-    from scitex_todo import get_task, resolve_task
-
-    if not _card_exists(store, card_id):
-        return False
-    existing = get_task(store, card_id)
-    if existing.get("status") == "done":
-        return False
-    resolve_task(store, card_id, actor=_AGENT)
-    return True
-
-
-def route_reports_to_cards(
+def record_reports(
     results: list[SyncResult],
     *,
-    store: str | None = None,
-    now: datetime | None = None,
+    path: Any = None,
+    now: float | None = None,
     err_stream: Any = None,
-) -> AlarmOutcome:
-    """Upsert / resolve one scitex-todo card per peer from ``results``.
+) -> EmitOutcome:
+    """Record one event per peer from ``results``. Never raises.
 
-    ``results`` are the read-only verdicts ``sac host sync --check``
-    produces. For each peer this upserts a drift or unknown card, or
-    resolves the peer's existing card when it is clean. Never raises: a
-    per-peer card-write failure is printed loudly to ``err_stream`` and the
-    peer is recorded in :attr:`AlarmOutcome.failed`, so one unreachable
-    board never suppresses the rest of the fleet's alarms.
+    ``results`` are the read-only verdicts ``sac host sync --check`` produces.
 
     Parameters
     ----------
-    store
-        scitex-todo store path. ``None`` = the resolved canonical store
-        (``~/.scitex/todo/tasks.yaml`` on the centre). Tests pass a real
-        temp path — no mocks.
+    path
+        Event-log path. ``None`` = sac's resolved runtime log. Tests pass a
+        real temp path — no mocks.
     now, err_stream
         Test seams: a fixed clock and a replacement stderr.
     """
-    stream = err_stream if err_stream is not None else sys.stderr
-    drifted: list[str] = []
-    undetermined: list[str] = []
-    cleared: list[str] = []
-    failed: list[str] = []
-
-    for result in results:
-        peer = result.peer
-        report = result.before
-        card_id = card_id_for(peer)
-        # stx-allow: fallback (reason: card delivery is a SIDE rail — one peer's board-write failure must never crash the drift check that feeds it; it is reported loudly on stderr and recorded in AlarmOutcome.failed)
-        try:
-            if report.is_undetermined:
-                _upsert(store, card_id, *_unknown_card(peer, report), now=now)
-                undetermined.append(peer)
-            elif report.is_drifted:
-                _upsert(store, card_id, *_drift_card(peer, report), now=now)
-                drifted.append(peer)
-            elif _clear(store, card_id):
-                cleared.append(peer)
-        except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
-            failed.append(peer)
-            print(
-                f"[host-sync-alarm] {peer}: scitex-todo card delivery FAILED "
-                f"— {exc} (drift verdict unchanged; the --check exit code "
-                "still reflects it)",
-                file=stream,
-            )
-
-    return AlarmOutcome(
-        drifted=tuple(drifted),
-        undetermined=tuple(undetermined),
-        cleared=tuple(cleared),
-        failed=tuple(failed),
+    return emit_subject_verdicts(
+        SUBSYSTEM,
+        [_verdict_for(result) for result in results],
+        path=path,
+        now=now,
+        err_stream=err_stream,
     )

--- a/src/scitex_agent_container/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs_plugin.py
@@ -82,10 +82,10 @@ def provide_jobs() -> "list[JobSpec]":
 
     * ``sac.host-sync-check`` (``kind="timer"``) — the READ-ONLY peer
       drift detector ``sac host sync --check --all``, run hourly with
-      ``--alarm`` so each peer's verdict is routed to an idempotent
-      scitex-todo card (upsert on drift/unknown, resolve on clean). This
-      is what makes the Stage-0 detector (PR #690) actually RUN and be
-      SEEN: shipped but scheduled nowhere, it was an inert alarm. The job
+      ``--alarm`` so each peer's verdict is recorded in sac's own event
+      log (degraded / unknown / recovered). This is what makes the Stage-0
+      detector (PR #690) actually RUN and be SEEN: shipped but scheduled
+      nowhere, it was an inert alarm. The job
       mutates NOTHING on any peer — it never calls the fast-forward
       remedy (that is Stage 1). ``--alarm`` is gated to require
       ``--check`` in the CLI, so this scheduled command is read-only by
@@ -113,7 +113,7 @@ def provide_jobs() -> "list[JobSpec]":
       schedules is a script, not a countermeasure, which is exactly how
       the sprawl accumulated in the first place. It removes ONLY what it
       can prove is safe (clean AND merged AND aged AND idle, never
-      ``--force``) and cards any repo still over its cap. ``--all`` is
+      ``--force``) and RECORDS any repo still over its cap. ``--all`` is
       well-defined here: it sweeps the local git repos declared as agents'
       ``spec.workdir``, so the command is correct as written.
 
@@ -195,10 +195,9 @@ def provide_jobs() -> "list[JobSpec]":
             command="sac host sync --check --all --alarm",
             description=(
                 "Read-only drift check of every peer's sac checkout vs the "
-                "centre; routes each verdict to an idempotent scitex-todo "
-                "card (upsert on drift/unknown, resolve on clean) so the "
-                "shout is SEEN on the board. Mutates nothing on any peer — "
-                "never runs the fast-forward remedy (Stage 1)."
+                "centre; records each verdict in sac's own event log so the "
+                "shout is DURABLE. Mutates nothing on any peer — never runs "
+                "the fast-forward remedy (Stage 1)."
             ),
             kind="timer",
             # First check 10min after boot/login (peers reachable, listen
@@ -220,8 +219,8 @@ def provide_jobs() -> "list[JobSpec]":
                 "Daily git-worktree GC: removes only worktrees PROVEN safe "
                 "(clean AND merged AND older than 24h AND not in use — never "
                 "--force), prunes admin refs whose directory is already gone, "
-                "and upserts an idempotent scitex-todo card for any repo still "
-                "over its worktree cap (resolved when it drops back under). "
+                "and records any repo still over its worktree cap in sac's "
+                "own event log (recorded as recovered when it drops back under). "
                 "The permanent countermeasure to worktree sprawl."
             ),
             kind="timer",
@@ -322,8 +321,8 @@ def provide_jobs() -> "list[JobSpec]":
                 "touches a CORPSE (no session => no context to lose); never a "
                 "live-but-wedged agent (auth-heal owns those) and never a "
                 "deliberately-stopped one. Rate-limited (30min/agent debounce, "
-                "<=2/agent/hour, <=10/pass); an agent it cannot recover gets a "
-                "scitex-todo card instead of an endless bounce."
+                "<=2/agent/hour, <=10/pass); an agent it cannot recover is "
+                "RECORDED as degraded instead of bounced endlessly."
             ),
             kind="timer",
             # THIS JOB IS THE MECHANISM, not an optimisation. `restart.policy`
@@ -359,7 +358,7 @@ def provide_jobs() -> "list[JobSpec]":
                 "restarted); the restart runs through the pool-loading start "
                 "path (cannot strip CCT tokens) and is rate-limited (30min/agent "
                 "debounce, <=2/agent/hour, <=10/pass); an agent still wedged "
-                "after the cap gets a scitex-todo card, not an endless bounce. "
+                "after the cap is RECORDED as degraded, not bounced endlessly. "
                 "DEPLOY GATE: do NOT enable until the host's auth-heal.py "
                 "scan_tui cron is retired (double-supervisor risk)."
             ),

--- a/src/scitex_agent_container/_maintenance/__init__.py
+++ b/src/scitex_agent_container/_maintenance/__init__.py
@@ -13,7 +13,7 @@ The shape every rail in this package follows, learned from
   it was fine".
 * **Report by default, mutate only on request.** ``--dry-run`` is the
   default surface; ``--apply`` is the deliberate act.
-* **The board is a side rail.** A card-delivery failure prints loudly and
+* **Recording is a side rail.** A failed write prints loudly and
   never crashes the maintenance pass that feeds it.
 """
 

--- a/src/scitex_agent_container/_maintenance/__init__.py
+++ b/src/scitex_agent_container/_maintenance/__init__.py
@@ -32,30 +32,26 @@ from ._worktree_gc import (
     running_cwds,
 )
 from ._worktree_gc_alarm import (
-    CARD_ID_PREFIX,
-    AlarmOutcome,
-    card_id_for,
-    route_gc_to_cards,
+    SUBSYSTEM,
+    record_gc_results,
 )
 from ._worktree_gc_repos import discover_repos, spec_workdirs
 
 __all__ = [
-    "CARD_ID_PREFIX",
     "DEFAULT_CAP",
     "DEFAULT_MIN_AGE_HOURS",
-    "AlarmOutcome",
     "GcOutcome",
     "RepoGcResult",
     "WorktreeInfo",
     "WorktreeVerdict",
-    "card_id_for",
     "discover_repos",
     "exit_code_for",
     "gc_repo",
     "gc_repos",
     "gh_pr_merged",
     "list_worktrees",
-    "route_gc_to_cards",
+    "SUBSYSTEM",
+    "record_gc_results",
     "running_cwds",
     "spec_workdirs",
 ]

--- a/src/scitex_agent_container/_maintenance/_worktree_gc_alarm.py
+++ b/src/scitex_agent_container/_maintenance/_worktree_gc_alarm.py
@@ -1,105 +1,51 @@
-"""Route worktree-sprawl over-cap verdicts to a SEEN surface.
+"""Record worktree-sprawl verdicts in sac's own event log.
 
-A GC that quietly reaps what it can and says nothing about what it could
-NOT reap is how a repo reaches 105 worktrees while a green cron line
-scrolls past every night. The reaping is the easy half; the half that
-prevents the incident is SHOUTING about the worktrees the predicate
-refused to touch, because those are the ones that accumulate forever.
+A GC that quietly reaps what it can and says nothing about what it could NOT
+reap is how a repo reaches 105 worktrees while a green cron line scrolls past
+every night. The reaping is the easy half; the half that prevents the incident
+is RECORDING the worktrees the predicate refused to touch, because those are
+the ones that accumulate forever.
 
-So: after a pass, a repo still over its cap upserts an IDEMPOTENT
-scitex-todo card on the board's BLOCKING-YOU view (``status=blocked``,
-``blocker=operator-decision`` — the surface the operator already
-watches), and the card is RESOLVED the moment the repo drops back under
-so a fixed repo stops shouting. Card id is stable per repo
-(``worktree-sprawl-<repo-basename>``), so a nightly re-run updates in
-place instead of tiling the board with duplicates.
+So after a pass, each repo becomes a record in :mod:`..._events`.
 
 Three-state honest, like every rail here:
 
-* **OVER CAP** → a card naming the repo, the count, and the kept-reasons
-  breakdown (``9 dirty, 6 unmerged, 2 in-use``). The breakdown IS the
-  card's value: "17 worktrees" is a number, "9 dirty" is an instruction.
-* **UNREADABLE** (not a git repo, git missing, unreadable path) → a card
-  too, labelled UNKNOWN. "I could not look" must never read as "I looked
-  and it was fine".
-* **UNDER CAP** → resolve the repo's card.
+* **OVER CAP** → a DEGRADED record naming the repo, the count, and the
+  kept-reasons breakdown. The breakdown IS the value: "17 worktrees" is a
+  number, "9 dirty" is an instruction.
+* **UNREADABLE** (not a git repo, git missing, unreadable path) → an UNKNOWN
+  record. "I could not look" must never read as "I looked and it was fine".
+* **UNDER CAP** → a RECOVERED record, if this repo was previously over.
 
-Delivery is a SIDE RAIL. A board-write failure prints loudly to stderr
-and is recorded in :attr:`AlarmOutcome.failed`; it never crashes the GC
-that feeds it, and one unreachable board never suppresses the rest of the
-fleet's alarms. Mirrors ``_hostsync._alarm`` (the drift rail) deliberately
-— same conventions, same public ``scitex_todo`` writer, no shared import.
+Recording is a SIDE rail: a write failure is printed loudly by the log rail
+itself and never crashes the GC that feeds it.
 """
 
 from __future__ import annotations
 
-import sys
-from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .._events import EmitOutcome, SubjectState, SubjectVerdict, emit_subject_verdicts
 from ._worktree_gc_model import RepoGcResult
 
-__all__ = ["AlarmOutcome", "CARD_ID_PREFIX", "card_id_for", "route_gc_to_cards"]
+__all__ = ["SUBSYSTEM", "record_gc_results"]
 
-#: Stable per-repo card id prefix, so a re-run updates in place instead of
-#: duplicating (idempotency is by id).
-CARD_ID_PREFIX = "worktree-sprawl-"
+#: The pass this module speaks for — the axis a reader filters the log on.
+SUBSYSTEM = "worktree-gc"
 
-#: The card's owner + author. A pseudo-agent, not a human: the card is a
-#: standing "this repo is over its worktree cap" fact that the operator
-#: resolves. Mirrors the host-sync drift rail's convention.
-_AGENT = "sac.worktree-gc"
-
-#: An over-cap card and an unreadable-repo card BOTH land on the board's
-#: BLOCKING-YOU view (``status=blocked`` AND ``blocker=operator-decision``)
-#: — the seen surface. The card TEXT distinguishes sprawl from unknown.
-_STATUS = "blocked"
-_BLOCKER = "operator-decision"
+_SUBJECT_KIND = "repo"
 
 
-def card_id_for(repo: str | Path) -> str:
-    """The stable card id for ``repo``'s sprawl alarm.
+def _subject_for(repo: str | Path) -> str:
+    """The repo's stable label in the log.
 
-    Keyed on the repo's BASENAME so the id stays readable on the board.
-    Two checkouts of the same repo under different parents collide by
-    design: the card is about "the repo called scitex-agent-container",
-    which is how the operator thinks about it, and the note carries the
-    full path either way.
+    Keyed on the BASENAME so the label stays readable. Two checkouts of the
+    same repo under different parents collide by design: the fact is about
+    "the repo called scitex-agent-container", and the full path rides along in
+    the record's own ``repo`` field either way.
     """
-    name = Path(str(repo)).name or "repo"
-    return f"{CARD_ID_PREFIX}{name}"
-
-
-@dataclass(frozen=True)
-class AlarmOutcome:
-    """What the routing did this run — so the caller is never silent.
-
-    Every repo lands in exactly one bucket (``failed`` is orthogonal: a
-    repo whose card write raised is recorded there instead of its verdict
-    bucket).
-    """
-
-    exceeded: tuple[str, ...] = ()
-    unreadable: tuple[str, ...] = ()
-    cleared: tuple[str, ...] = ()
-    failed: tuple[str, ...] = ()
-
-    def summary_line(self) -> str:
-        """One human line naming what happened to the board this run."""
-        parts = [
-            f"{len(self.exceeded)} over-cap card(s)",
-            f"{len(self.unreadable)} unknown card(s)",
-            f"{len(self.cleared)} cleared",
-        ]
-        if self.failed:
-            parts.append(f"{len(self.failed)} DELIVERY-FAILED")
-        return "scitex-todo alarm: " + ", ".join(parts)
-
-
-def _now_iso(now: datetime | None) -> str:
-    return (now or datetime.now(timezone.utc)).isoformat()
+    return Path(str(repo)).name or "repo"
 
 
 def _breakdown(result: RepoGcResult) -> str:
@@ -109,182 +55,77 @@ def _breakdown(result: RepoGcResult) -> str:
     return ", ".join(f"{n} {reason}" for reason, n in counts.items())
 
 
-def _over_cap_card(result: RepoGcResult) -> tuple[str, str]:
-    """Title + note for a repo STILL over its cap after the pass.
-
-    The note names the concrete breakdown and the exact next commands, so
-    the operator reading only the card knows what to do.
-    """
-    title = (
-        f"[worktree-gc] {Path(result.repo).name} OVER CAP — "
-        f"{result.count_after} worktrees (cap {result.cap})"
-    )
-    note = (
-        f"repo: {result.repo}\n"
-        f"worktrees: {result.count_after} (cap {result.cap})\n"
-        f"removed this pass: {len(result.removed)}\n"
-        f"kept: {len(result.kept)} — {_breakdown(result)}\n\n"
-        "The GC removed everything it could PROVE was safe (clean AND "
-        "merged AND older than the age gate AND not in use). The kept "
-        "worktrees each failed at least one of those legs — the breakdown "
-        "above says which. They will never be auto-removed; a human decides.\n\n"
-        "Inspect (read-only, removes nothing):\n"
-        f"    sac worktree gc --repo {result.repo}\n"
-        "Then, per worktree: land or drop the branch, or clean the tree.\n"
-        "Dirty worktrees hold work that exists NOWHERE else — commit or "
-        "push before removing anything by hand."
-    )
-    return title, note
-
-
-def _unknown_card(result: RepoGcResult) -> tuple[str, str]:
-    """Title + note for a repo we COULD NOT READ.
-
-    Deliberately worded UNKNOWN, never clean. An unreadable repo is not a
-    repo without sprawl — it is a repo whose sprawl we failed to observe.
-    """
-    title = f"[worktree-gc] {Path(result.repo).name} UNKNOWN — could not read repo"
-    note = (
-        f"repo: {result.repo}\n"
-        f"error: {result.error}\n\n"
-        "UNKNOWN is NOT clean — sac could not enumerate this repo's "
-        "worktrees, so its sprawl is unobserved, not absent. Nothing was "
-        "removed. Check the path still exists and is a git repo, then "
-        "re-run:\n"
-        f"    sac worktree gc --repo {result.repo}"
-    )
-    return title, note
-
-
-def _card_exists(store: str | None, card_id: str) -> bool:
-    """True when ``card_id`` is already on the board.
-
-    A MISSING store file (nothing carded yet) and a missing id BOTH mean
-    "no such card" — the first run against a fresh board raises
-    ``FileNotFoundError`` from the loader, later runs raise
-    ``TaskNotFoundError``; neither is an error here.
-    """
-    from scitex_todo import TaskNotFoundError, get_task
-
-    # stx-allow: fallback (reason: "does this card exist yet?" — a missing store file or missing id is a normal False, not an error; any other load failure propagates to the caller's per-repo guard which reports it loudly)
-    try:
-        get_task(store, card_id)
-        return True
-    except (TaskNotFoundError, FileNotFoundError):
-        return False
-
-
-def _upsert(
-    store: str | None,
-    card_id: str,
-    title: str,
-    note: str,
-    now: datetime | None,
-) -> None:
-    """Create the card, or update it in place — never duplicate.
-
-    Always (re)asserts ``status=blocked`` / ``blocker=operator-decision``,
-    which also REOPENS a card a previous under-cap run had resolved: a
-    repo that sprawls, gets cleaned (card resolved), then sprawls again
-    must alarm again.
-    """
-    from scitex_todo import add_task, update_task
-
-    if _card_exists(store, card_id):
-        update_task(
-            store,
-            card_id,
-            title=title,
-            note=note,
-            status=_STATUS,
-            blocker=_BLOCKER,
-            last_activity=_now_iso(now),
+def _verdict_for(result: RepoGcResult) -> SubjectVerdict:
+    """Map one repo's GC result onto sac's three states."""
+    subject = _subject_for(result.repo)
+    if result.unreadable:
+        return SubjectVerdict(
+            subject=subject,
+            state=SubjectState.UNKNOWN,
+            verdict="unreadable",
+            detail=(
+                f"could not enumerate worktrees for {result.repo} — "
+                f"{result.error}; nothing was removed and its sprawl is "
+                f"unobserved, not absent"
+            ),
+            subject_kind=_SUBJECT_KIND,
+            extra={"repo": str(result.repo), "error": str(result.error)},
         )
-    else:
-        add_task(
-            store,
-            id=card_id,
-            title=title,
-            status=_STATUS,
-            blocker=_BLOCKER,
-            note=note,
-            scope=f"agent:{_AGENT}",
-            assignee=_AGENT,
-            created_by=_AGENT,
+    facts: dict[str, Any] = {
+        "repo": str(result.repo),
+        "count_after": result.count_after,
+        "cap": result.cap,
+        "removed": len(result.removed),
+        "kept": len(result.kept),
+        "keep_reasons": dict(result.keep_reason_breakdown),
+    }
+    if result.exceeds_cap:
+        return SubjectVerdict(
+            subject=subject,
+            state=SubjectState.DEGRADED,
+            verdict="over_cap",
+            detail=(
+                f"{result.repo} still has {result.count_after} worktrees "
+                f"(cap {result.cap}) after removing {len(result.removed)}; "
+                f"kept {len(result.kept)} — {_breakdown(result)}"
+            ),
+            subject_kind=_SUBJECT_KIND,
+            extra=facts,
         )
+    return SubjectVerdict(
+        subject=subject,
+        state=SubjectState.HEALTHY,
+        verdict="under_cap",
+        detail=(
+            f"{result.repo} is within its cap — {result.count_after} "
+            f"worktrees (cap {result.cap})"
+        ),
+        subject_kind=_SUBJECT_KIND,
+        extra=facts,
+    )
 
 
-def _clear(store: str | None, card_id: str) -> bool:
-    """Resolve the repo's card if present + still open. Returns did-clear.
-
-    Idempotent: no card, or an already-resolved card, is a quiet no-op — a
-    healthy repo that was never over cap must not create then resolve a
-    phantom card.
-    """
-    from scitex_todo import get_task, resolve_task
-
-    if not _card_exists(store, card_id):
-        return False
-    existing = get_task(store, card_id)
-    if existing.get("status") == "done":
-        return False
-    resolve_task(store, card_id, actor=_AGENT)
-    return True
-
-
-def route_gc_to_cards(
+def record_gc_results(
     results: list[RepoGcResult],
     *,
-    store: str | None = None,
-    now: datetime | None = None,
+    path: Any = None,
+    now: float | None = None,
     err_stream: Any = None,
-) -> AlarmOutcome:
-    """Upsert / resolve one scitex-todo card per repo from ``results``.
-
-    Never raises: a per-repo card-write failure is printed loudly to
-    ``err_stream`` and the repo is recorded in :attr:`AlarmOutcome.failed`,
-    so a broken board never takes down the GC pass that feeds it.
+) -> EmitOutcome:
+    """Record one event per repo from ``results``. Never raises.
 
     Parameters
     ----------
-    store
-        scitex-todo store path. ``None`` = the resolved canonical store
-        (``~/.scitex/todo/tasks.yaml``). Tests pass a real temp path — no
-        mocks.
+    path
+        Event-log path. ``None`` = sac's resolved runtime log. Tests pass a
+        real temp path — no mocks.
     now, err_stream
         Test seams: a fixed clock and a replacement stderr.
     """
-    stream = err_stream if err_stream is not None else sys.stderr
-    exceeded: list[str] = []
-    unreadable: list[str] = []
-    cleared: list[str] = []
-    failed: list[str] = []
-
-    for result in results:
-        repo = result.repo
-        card_id = card_id_for(repo)
-        # stx-allow: fallback (reason: card delivery is a SIDE rail — one repo's board-write failure must never crash the GC pass that feeds it; it is reported loudly on stderr and recorded in AlarmOutcome.failed)
-        try:
-            if result.unreadable:
-                _upsert(store, card_id, *_unknown_card(result), now=now)
-                unreadable.append(repo)
-            elif result.exceeds_cap:
-                _upsert(store, card_id, *_over_cap_card(result), now=now)
-                exceeded.append(repo)
-            elif _clear(store, card_id):
-                cleared.append(repo)
-        except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
-            failed.append(repo)
-            print(
-                f"[worktree-gc-alarm] {repo}: scitex-todo card delivery FAILED "
-                f"— {exc} (the GC pass itself is unaffected; its exit code "
-                "still reflects the cap verdict)",
-                file=stream,
-            )
-
-    return AlarmOutcome(
-        exceeded=tuple(exceeded),
-        unreadable=tuple(unreadable),
-        cleared=tuple(cleared),
-        failed=tuple(failed),
+    return emit_subject_verdicts(
+        SUBSYSTEM,
+        [_verdict_for(result) for result in results],
+        path=path,
+        now=now,
+        err_stream=err_stream,
     )

--- a/src/scitex_agent_container/_reconcile/__init__.py
+++ b/src/scitex_agent_container/_reconcile/__init__.py
@@ -29,11 +29,7 @@ the ``sac.fleet-reconcile`` JobSpec.
 from __future__ import annotations
 
 from ._alarm import (
-    CARD_ID_PREFIX,
-    HEARTBEAT_CARD_ID,
-    STATE_CARD_ID,
-    AlarmOutcome,
-    card_id_for,
+    SUBSYSTEM,
 )
 from ._budget import (
     DEBOUNCE_S,
@@ -49,21 +45,17 @@ from ._rule import MANAGED_POLICIES, Decision, Verdict, decide
 
 __all__ = [
     "AgentReport",
-    "AlarmOutcome",
     "Budget",
-    "CARD_ID_PREFIX",
     "DEBOUNCE_S",
     "DEFAULT_PASS_CAP",
     "Decision",
-    "HEARTBEAT_CARD_ID",
     "HistoryRead",
     "HistoryState",
     "MANAGED_POLICIES",
     "MAX_RESTARTS_PER_AGENT_PER_HOUR",
     "PassOutcome",
-    "STATE_CARD_ID",
     "Verdict",
-    "card_id_for",
+    "SUBSYSTEM",
     "decide",
     "fleet_spec_paths",
     "read_history",

--- a/src/scitex_agent_container/_reconcile/_alarm.py
+++ b/src/scitex_agent_container/_reconcile/_alarm.py
@@ -49,13 +49,11 @@ from __future__ import annotations
 from typing import Any, Iterable, Mapping
 
 from .._events import (
-    SELF_IMPAIRED,
-    SELF_RECOVERED,
     EmitOutcome,
     SubjectState,
     SubjectVerdict,
+    emit_self_state,
     emit_subject_verdicts,
-    log_event,
     log_pass_completed,
 )
 from ._rule import Verdict
@@ -146,9 +144,9 @@ def record_self_impaired(
     it became permission-denied for fresh processes — while everything still
     LOOKED installed and configured.
     """
-    return log_event(
-        event=SELF_IMPAIRED,
-        subsystem=SUBSYSTEM,
+    return emit_self_state(
+        SUBSYSTEM,
+        impaired=True,
         verdict="state_unreadable",
         detail=(
             f"reconciler cannot read its own restart history at "
@@ -170,10 +168,17 @@ def record_self_recovered(
     now: float | None = None,
     err_stream: Any = None,
 ) -> bool:
-    """Record that the reconciler can read its own memory again. Never raises."""
-    return log_event(
-        event=SELF_RECOVERED,
-        subsystem=SUBSYSTEM,
+    """Record that the reconciler can read its own memory again.
+
+    Returns whether a record was written. ``False`` is the ORDINARY answer: it
+    means the reconciler was not impaired to begin with, so there was no
+    recovery to record. Only a genuine transition writes — a pass runs every
+    few minutes, and a "still fine" record on every tick would drown the log
+    and rob :data:`SELF_RECOVERED` of any meaning.
+    """
+    return emit_self_state(
+        SUBSYSTEM,
+        impaired=False,
         verdict="state_readable",
         detail=(
             f"reconciler can read its restart history at "

--- a/src/scitex_agent_container/_reconcile/_alarm.py
+++ b/src/scitex_agent_container/_reconcile/_alarm.py
@@ -1,447 +1,214 @@
-"""Route reconcile verdicts to a SEEN surface — and prove we are alive.
+"""Record reconcile verdicts in sac's own event log — and prove the pass ran.
 
-Two rails, both idempotent scitex-todo cards, both SIDE rails (a board
-write that fails prints loudly and can NEVER crash or skip the restart
-pass that feeds it — the pass's job is resurrecting corpses; telling the
-board is secondary and must not be able to take the primary down).
+Three rails, all writing to :mod:`..._events`, all SIDE rails (a write that
+fails is printed loudly by the log rail itself and can NEVER crash or skip the
+restart pass that feeds it — the pass's job is resurrecting corpses; recording
+what it did is secondary and must not be able to take the primary down).
 
-1. **Down cards** (``fleet-agent-down-<name>``) — one per agent this
-   enforcer could NOT recover. Upsert on unrecoverable, resolve the moment
-   the agent is back, exactly like :mod:`.._hostsync._alarm` does for peer
-   drift. An enforcer that gives up SILENTLY is just the original bug with
-   extra steps.
+1. **Down records** — one per agent this enforcer could NOT recover. An
+   enforcer that gives up SILENTLY is just the original bug with extra steps.
 
-2. **The heartbeat card** (``fleet-reconciler-heartbeat``) — the answer to
-   "who watches the watcher". The reconciler is correctly independent of
-   the agents it restarts (a systemd timer, outside their failure domain),
-   but that only moves the question: if its timer is never enabled, or its
-   unit fails, or its command silently no-ops, the fleet goes back to dying
-   invisibly and NOTHING says so — because the only thing that would have
-   told us is the thing that died.
+2. **The pass record** (:func:`record_pass_completed`) — the answer to "who
+   watches the watcher". The reconciler is correctly independent of the agents
+   it restarts (a systemd timer, outside their failure domain), but that only
+   moves the question: if its timer is never enabled, or its unit fails, or its
+   command silently no-ops, the fleet goes back to dying invisibly.
 
    Precedent, same failure class (scitex-hpc, 2026-07-13): a walltime trap
-   FIRED on schedule, but its resubmit silently no-op'd because ``sbatch``
-   had been scrubbed off PATH. ~76 CI runners died. SLURM logged a
-   signal-kill, not "renewal failed", so nothing alarmed.
+   FIRED on schedule, but its resubmit silently no-op'd because ``sbatch`` had
+   been scrubbed off PATH. ~76 CI runners died. SLURM logged a signal-kill, not
+   "renewal failed", so nothing alarmed.
 
-   The regress terminates because the alarm is delivered by a DIFFERENT
-   system: scitex-todo's stale-active nudge fires on any ``in_progress``
-   card untouched beyond its threshold, and that nudge rides the
-   scitex-todo agent's own notifyd to a human-watched surface. A reconciler
-   that stops ticking lets its own heartbeat card go stale, and the BOARD
-   shouts. One system's silence becomes another system's alarm — two
-   independent systems watching each other, rather than one script policing
-   itself.
+   Hence a pass record is written on EVERY pass including a dry run, and above
+   all on a pass that found nothing to do: "0 restarted, all healthy" is the
+   most important record there is, because a rail that only writes when there
+   is trouble cannot distinguish HEALTHY from DEAD. The record's ``counts``
+   carry EVERY verdict this pass reached, including the ones that get no
+   per-agent record of their own, so no verdict is ever wholly unrecorded.
 
-   Hence :func:`upsert_heartbeat` runs on EVERY pass including a dry-run,
-   and above all on a pass that found nothing to do: "0 restarted, all
-   healthy" is the most important tick there is, because a heartbeat that
-   only appears when there is trouble cannot distinguish HEALTHY from DEAD.
+3. **Self-impairment** (:func:`record_self_impaired`) — the reconciler cannot
+   read its OWN restart memory, so its rate limits are unenforceable and it has
+   refused to restart anything.
+
+WHICH VERDICTS GET A PER-AGENT RECORD
+    Deliberately narrow, and unchanged from when these were escalations: a
+    per-agent DEGRADED record means sac tried and cannot fix this itself.
+
+    Three DOWN verdicts are deliberately NOT per-agent records, because each
+    resolves itself without anyone intervening: ``COOLING-DOWN`` (inside its
+    30min debounce — the timer ticks every 5min, so a HEALTHY restart is
+    cooling down for its next five ticks), ``CAPPED`` (sac's own per-pass
+    throttle, not the agent's fault), and ``UNOBSERVED``/``UNKNOWN`` blindness
+    that is fleet-WIDE rather than per-agent. They are all still counted in the
+    pass record above, and they all still print and still drive the exit code
+    non-zero — no per-agent record is not the same as unrecorded.
 """
 
 from __future__ import annotations
 
-import sys
-from dataclasses import dataclass
-from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping
 
+from .._events import (
+    SELF_IMPAIRED,
+    SELF_RECOVERED,
+    EmitOutcome,
+    SubjectState,
+    SubjectVerdict,
+    emit_subject_verdicts,
+    log_event,
+    log_pass_completed,
+)
 from ._rule import Verdict
 
 __all__ = [
-    "AlarmOutcome",
-    "CARD_ID_PREFIX",
-    "HEARTBEAT_CARD_ID",
-    "STATE_CARD_ID",
-    "card_id_for",
-    "clear_state_alarm",
-    "route_reports_to_cards",
-    "upsert_heartbeat",
-    "upsert_state_alarm",
+    "SUBSYSTEM",
+    "record_pass_completed",
+    "record_reports",
+    "record_self_impaired",
+    "record_self_recovered",
 ]
 
-#: Stable per-agent card id — idempotency is by id, so a re-run updates in
-#: place instead of duplicating.
-CARD_ID_PREFIX = "fleet-agent-down-"
+#: The pass this module speaks for — the axis a reader filters the log on.
+SUBSYSTEM = "fleet-reconcile"
 
-#: The reconciler's own liveness beacon. ONE card, stable id, forever.
-HEARTBEAT_CARD_ID = "fleet-reconciler-heartbeat"
+_SUBJECT_KIND = "agent"
 
-#: Raised when the reconciler cannot read its OWN restart memory, so its
-#: rate limits are unenforceable and it has refused to restart anything.
-#: One card for the whole pass — the cause is the reconciler's, not any
-#: agent's.
-STATE_CARD_ID = "fleet-reconciler-state-unreadable"
+#: Verdicts meaning "this agent is DOWN and restarting is NOT fixing it".
+_DEGRADED = (Verdict.FAILED, Verdict.OVER_BUDGET)
 
-#: Owner + author of the down cards. A pseudo-agent, not a human.
-_AGENT = "sac.fleet-reconcile"
-
-#: The heartbeat is owned by the PACKAGE identity rather than the
-#: pseudo-agent: a human must own noticing that sac's enforcer went quiet.
-_HEARTBEAT_ASSIGNEE = "scitex-agent-container"
-
-#: A down card lands on the board's BLOCKING-YOU view — the surface the
-#: operator already watches.
-_STATUS = "blocked"
-_BLOCKER = "operator-decision"
-
-#: Verdicts meaning "this agent is DOWN and restarting is NOT fixing it" →
-#: card. Deliberately narrow: a card must mean a human is needed, or the
-#: operator learns to scroll past them.
-_UNRECOVERED = (Verdict.FAILED, Verdict.OVER_BUDGET)
-
-#: Verdicts meaning "this agent is UP" → resolve any card it had.
-#:
-#: Three DOWN verdicts are deliberately in NEITHER bucket — down, but not a
-#: card, because each resolves itself without a human:
-#:
-#: * ``COOLING-DOWN`` — inside its 30min debounce. The timer ticks every
-#:   5min, so a HEALTHY restart is cooling down for its next five ticks;
-#:   carding that would raise a card for every successful heal.
-#: * ``CAPPED`` — our own per-pass throttle, not the agent's fault. The next
-#:   tick tries it. Carding would be noise; resolving would be a lie.
-#: * ``UNKNOWN`` — blindness is fleet-WIDE (we are in a container, or tmux
-#:   is wedged), so carding per-agent would mint ~93 cards for ONE cause.
-#:
-#: All three still print loudly and still drive the exit code non-zero — not
-#: carding is not the same as not saying.
-_RECOVERED = (Verdict.OK, Verdict.RESTARTED)
+#: Verdicts meaning "this agent is UP".
+_HEALTHY = (Verdict.OK, Verdict.RESTARTED)
 
 
-def card_id_for(name: str) -> str:
-    """The stable card id for ``name``'s down alarm."""
-    return f"{CARD_ID_PREFIX}{name}"
+def _verdict_for(report: Any) -> SubjectVerdict | None:
+    """Map one agent's report onto sac's states, or ``None`` for no record.
 
-
-def _now_iso(now: datetime | None) -> str:
-    """A timestamp in scitex-todo's OWN canonical shape, not ours.
-
-    Second resolution and a ``Z`` suffix, byte-identical to the store's
-    private ``_utc_now_iso``. This is not cosmetic on two counts, and both
-    bite the heartbeat specifically:
-
-    * ``last_activity`` is what the board's stale-active nudge reads to
-      decide the reconciler has gone quiet. That nudge IS this design's
-      alarm-for-a-dead-alarm, so a stamp it cannot parse would silently
-      disarm the one rail that reports our own death.
-    * the store's own docstring says the ``Z`` suffix (rather than
-      ``+00:00``) is what makes the string "round-trip losslessly through
-      YAML" — an unquoted ``+00:00`` stamp risks being re-read as a
-      timestamp OBJECT rather than a string.
-
-    Mirrored rather than imported: ``_utc_now_iso`` is private to
-    ``scitex_todo._store``, and this needs the injectable ``now`` seam that
-    a fixed-clock test provides.
+    ``None`` is the documented narrow case described in this module's header —
+    a verdict that resolves itself, counted in the pass record instead.
     """
-    stamp = now or datetime.now(timezone.utc)
-    return stamp.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    if report.verdict in _DEGRADED:
+        return SubjectVerdict(
+            subject=report.name,
+            state=SubjectState.DEGRADED,
+            verdict=report.verdict.value,
+            detail=(
+                f"{report.name} is DOWN and sac could not recover it — {report.detail}"
+            ),
+            subject_kind=_SUBJECT_KIND,
+        )
+    if report.verdict in _HEALTHY:
+        return SubjectVerdict(
+            subject=report.name,
+            state=SubjectState.HEALTHY,
+            verdict=report.verdict.value,
+            detail=f"{report.name} is up — {report.detail}",
+            subject_kind=_SUBJECT_KIND,
+        )
+    return None
 
 
-@dataclass(frozen=True)
-class AlarmOutcome:
-    """What the routing did this run — so the caller is never silent."""
-
-    carded: tuple[str, ...] = ()
-    cleared: tuple[str, ...] = ()
-    failed: tuple[str, ...] = ()
-
-    def summary_line(self) -> str:
-        parts = [f"{len(self.carded)} down card(s)", f"{len(self.cleared)} cleared"]
-        if self.failed:
-            parts.append(f"{len(self.failed)} DELIVERY-FAILED")
-        return "scitex-todo alarm: " + ", ".join(parts)
-
-
-def _card_exists(store: str | None, card_id: str) -> bool:
-    """True when ``card_id`` is already on the board.
-
-    A MISSING store file (nothing carded yet) and a missing id BOTH mean
-    "no such card" — the first run against a fresh board raises
-    ``FileNotFoundError``, later runs raise ``TaskNotFoundError``.
-    """
-    from scitex_todo import TaskNotFoundError, get_task
-
-    # stx-allow: fallback (reason: "does this card exist yet?" — a missing store file or missing id is a normal False, not an error; any other load failure propagates to the caller's per-card guard, which reports it loudly)
-    try:
-        get_task(store, card_id)
-        return True
-    except (TaskNotFoundError, FileNotFoundError):
-        return False
-
-
-def _down_card(name: str, verdict: Verdict, detail: str) -> tuple[str, str]:
-    """Title + note for an agent this enforcer could not bring back."""
-    title = f"[fleet] {name} is DOWN and sac could NOT recover it ({verdict.value})"
-    note = (
-        f"agent: {name}\n"
-        f"verdict: {verdict.value}\n"
-        f"why: {detail}\n\n"
-        "sac's reconciler found this agent's tmux session GONE and its spec "
-        "asking to be kept running, but it did not restart it — the reason is "
-        "above. A restart LOOP is worse than a down agent, so the enforcer "
-        "stops and asks instead of trying harder.\n\n"
-        "Investigate:\n"
-        f"    sac agents list | grep {name}\n"
-        f"    sac agents tail {name}\n"
-        "Restart by hand once the cause is understood:\n"
-        f"    sac agents restart {name} --yes\n"
-        "Preview what the reconciler would do (mutates nothing):\n"
-        "    sac agents reconcile"
-    )
-    return title, note
-
-
-def _upsert(
-    store: str | None,
-    card_id: str,
-    title: str,
-    note: str,
-    now: datetime | None,
-    *,
-    status: str = _STATUS,
-    blocker: str | None = _BLOCKER,
-    assignee: str = _AGENT,
-) -> None:
-    """Create the card, or update it in place — never duplicate.
-
-    Re-asserting ``status`` also REOPENS a card a previous clean run
-    resolved: an agent that dies, is fixed (card resolved), then dies again
-    must alarm again.
-    """
-    from scitex_todo import add_task, update_task
-
-    if _card_exists(store, card_id):
-        kwargs: dict[str, Any] = {
-            "title": title,
-            "note": note,
-            "status": status,
-            "last_activity": _now_iso(now),
-        }
-        if blocker is not None:
-            kwargs["blocker"] = blocker
-        update_task(store, card_id, **kwargs)
-    else:
-        kwargs = {
-            "id": card_id,
-            "title": title,
-            "status": status,
-            "note": note,
-            "scope": f"agent:{assignee}",
-            "assignee": assignee,
-            "created_by": _AGENT,
-        }
-        if blocker is not None:
-            kwargs["blocker"] = blocker
-        add_task(store, **kwargs)
-
-
-def _clear(store: str | None, card_id: str) -> bool:
-    """Resolve the agent's card if present + still open. Returns did-clear.
-
-    Idempotent: no card, or an already-resolved card, is a quiet no-op — a
-    healthy agent that was never down must not create then resolve a
-    phantom card.
-    """
-    from scitex_todo import get_task, resolve_task
-
-    if not _card_exists(store, card_id):
-        return False
-    if get_task(store, card_id).get("status") == "done":
-        return False
-    resolve_task(store, card_id, actor=_AGENT)
-    return True
-
-
-def route_reports_to_cards(
+def record_reports(
     reports: Iterable[Any],
     *,
-    store: str | None = None,
-    now: datetime | None = None,
+    path: Any = None,
+    now: float | None = None,
     err_stream: Any = None,
-) -> AlarmOutcome:
-    """Upsert / resolve one card per agent from this pass's ``reports``.
-
-    Never raises: a per-agent card-write failure is printed loudly to
-    ``err_stream`` and recorded in :attr:`AlarmOutcome.failed`, so one
-    unwritable board never suppresses the rest of the fleet's alarms — and
-    never unwinds a restart that already happened.
+) -> EmitOutcome:
+    """Record one event per agent from this pass's ``reports``. Never raises.
 
     ``reports`` are :class:`._pass.AgentReport` objects (duck-typed here to
     keep this module importable without :mod:`._pass`).
     """
-    stream = err_stream if err_stream is not None else sys.stderr
-    carded: list[str] = []
-    cleared: list[str] = []
-    failed: list[str] = []
-
-    for report in reports:
-        name = report.name
-        card_id = card_id_for(name)
-        # stx-allow: fallback (reason: card delivery is a SIDE rail — one agent's board-write failure must never crash the reconcile pass that feeds it, nor suppress the other agents' alarms; it is reported loudly on stderr and recorded in AlarmOutcome.failed)
-        try:
-            if report.verdict in _UNRECOVERED:
-                _upsert(
-                    store,
-                    card_id,
-                    *_down_card(name, report.verdict, report.detail),
-                    now=now,
-                )
-                carded.append(name)
-            elif report.verdict in _RECOVERED and _clear(store, card_id):
-                cleared.append(name)
-        except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
-            failed.append(name)
-            print(
-                f"[fleet-reconcile-alarm] {name}: scitex-todo card delivery "
-                f"FAILED — {exc} (the reconcile verdict above is UNCHANGED and "
-                f"any restart it performed still happened)",
-                file=stream,
-            )
-
-    return AlarmOutcome(
-        carded=tuple(carded), cleared=tuple(cleared), failed=tuple(failed)
+    verdicts = [v for v in (_verdict_for(report) for report in reports) if v]
+    return emit_subject_verdicts(
+        SUBSYSTEM, verdicts, path=path, now=now, err_stream=err_stream
     )
 
 
-def upsert_state_alarm(
+def record_self_impaired(
     detail: str,
     *,
-    path: Any = "",
-    store: str | None = None,
-    now: datetime | None = None,
+    state_file: Any = "",
+    path: Any = None,
+    now: float | None = None,
     err_stream: Any = None,
 ) -> bool:
-    """Shout that the reconciler cannot read its OWN state. Returns did-write.
+    """Record that the reconciler cannot read its OWN state. Never raises.
 
     The reconciler exists to catch silent death; it must not die silently
-    itself. When its restart history is denied or corrupt the rate limits
-    are unenforceable, so it REFUSES to restart — and a refusal nobody hears
-    is a no-op, which is exactly the "renewal mechanism that cannot report
-    its own failure" class this whole design is built against.
+    itself. When its restart history is denied or corrupt the rate limits are
+    unenforceable, so it REFUSES to restart — and a refusal nobody hears is a
+    no-op, which is exactly the "renewal mechanism that cannot report its own
+    failure" class this whole design is built against.
 
-    Measured precedent (Spartan, 2026-07-16): ``~/.scitex`` is a SYMLINK
-    into a project whose membership was revoked, so every ``$HOME``-resolved
-    path under it became permission-denied for fresh processes — while
-    everything still LOOKED installed and configured.
+    Measured precedent (Spartan, 2026-07-16): ``~/.scitex`` is a SYMLINK into a
+    project whose membership was revoked, so every ``$HOME``-resolved path under
+    it became permission-denied for fresh processes — while everything still
+    LOOKED installed and configured.
     """
-    stream = err_stream if err_stream is not None else sys.stderr
-    title = "[fleet] sac reconciler CANNOT READ ITS OWN STATE — restarts halted"
-    note = (
-        f"state file: {path or '?'}\n"
-        f"problem: {detail}\n\n"
-        "sac's reconciler keeps ONE piece of state: the history of which "
-        "agents it has already auto-restarted. That file is the ONLY thing "
-        "enforcing the debounce (30min/agent) and the hourly cap (2/agent). "
-        "It could not be read, so those limits cannot be enforced — and an "
-        "unenforceable budget is not a budget. Restarting anyway would make "
-        "EVERY corpse restartable on EVERY 5-minute tick, forever.\n\n"
-        "So the reconciler has REFUSED to restart anything. Dead agents are "
-        "currently staying dead. This needs a human.\n\n"
-        "Most likely causes:\n"
-        "  * the state root ($SCITEX_DIR, default ~/.scitex) is unreadable — "
-        "on some hosts it is a SYMLINK into a project whose membership can "
-        "be revoked, which denies every path under it at once;\n"
-        "  * the file is corrupt (delete it to reset the budget DELIBERATELY).\n\n"
-        "Diagnose + pin the state somewhere durable:\n"
-        f"    ls -l {path or '<state file>'}\n"
-        "    sac agents reconcile            # dry-run; names what it sees\n"
-        "    export SAC_RECONCILE_HISTORY=/var/tmp/sac-fleet-reconcile.json"
-    )
-    # stx-allow: fallback (reason: this alarm is the LAST rail — if the board is unreachable too, the loud stderr line and the non-zero exit code must still carry the failure rather than raising into the pass)
-    try:
-        _upsert(store, STATE_CARD_ID, title, note, now)
-        return True
-    except Exception as exc:
-        print(
-            f"[fleet-reconcile-alarm] STATE-UNREADABLE card delivery FAILED "
-            f"— {exc}. The reconciler cannot read its own restart history "
-            f"({detail}) AND cannot tell the board. Restarts are halted.",
-            file=stream,
-        )
-        return False
-
-
-def clear_state_alarm(*, store: str | None = None, err_stream: Any = None) -> bool:
-    """Resolve the state alarm once we can read our own memory again."""
-    stream = err_stream if err_stream is not None else sys.stderr
-    # stx-allow: fallback (reason: side rail — failing to CLEAR a stale alarm must never crash a pass that is otherwise working correctly)
-    try:
-        return _clear(store, STATE_CARD_ID)
-    except Exception as exc:
-        print(
-            f"[fleet-reconcile-alarm] could not resolve {STATE_CARD_ID} — {exc}",
-            file=stream,
-        )
-        return False
-
-
-def _heartbeat_note(
-    stats: Mapping[str, int], *, mode: str, host: str, now: datetime | None
-) -> str:
-    counted = "\n".join(f"  {k:<22} {v}" for k, v in stats.items())
-    return (
-        f"last run: {_now_iso(now)}\n"
-        f"mode:     {mode}\n"
-        f"host:     {host}\n\n"
-        f"{counted}\n\n"
-        "This card is sac's fleet-reconciler LIVENESS BEACON. It is refreshed "
-        "on every pass — including passes that find nothing wrong, which are "
-        "the ticks that prove the mechanism is alive at all.\n\n"
-        "IF THIS CARD IS STALE, THE ENFORCER IS NOT RUNNING, and agents that "
-        "die are once again staying dead unnoticed. That is what the card is "
-        "for: sac cannot alarm on its own silence, so the board does it "
-        "instead (scitex-todo's stale-active nudge on an untouched "
-        "in_progress card).\n\n"
-        "Note the `mode` line: a hand-run `sac agents reconcile` (dry-run) "
-        "also refreshes this card. If mode is not `apply`, the scheduled "
-        "timer may still be dead even though the card looks fresh.\n\n"
-        "Check the timer:\n"
-        "    systemctl --user list-timers | grep fleet-reconcile\n"
-        "    scitex-dev ecosystem timers\n"
-        "Run a pass by hand (mutates nothing):\n"
-        "    sac agents reconcile"
+    return log_event(
+        event=SELF_IMPAIRED,
+        subsystem=SUBSYSTEM,
+        verdict="state_unreadable",
+        detail=(
+            f"reconciler cannot read its own restart history at "
+            f"{state_file or '?'} — {detail}. Rate limits are unenforceable, "
+            f"so it has REFUSED to restart anything; dead agents are staying "
+            f"dead until this is fixed."
+        ),
+        extra={"state_file": str(state_file or "")},
+        path=path,
+        now=now,
+        err_stream=err_stream,
     )
 
 
-def upsert_heartbeat(
+def record_self_recovered(
+    *,
+    state_file: Any = "",
+    path: Any = None,
+    now: float | None = None,
+    err_stream: Any = None,
+) -> bool:
+    """Record that the reconciler can read its own memory again. Never raises."""
+    return log_event(
+        event=SELF_RECOVERED,
+        subsystem=SUBSYSTEM,
+        verdict="state_readable",
+        detail=(
+            f"reconciler can read its restart history at "
+            f"{state_file or '?'} again; rate limits are enforceable and "
+            f"restarts have resumed"
+        ),
+        extra={"state_file": str(state_file or "")},
+        path=path,
+        now=now,
+        err_stream=err_stream,
+    )
+
+
+def record_pass_completed(
     stats: Mapping[str, int],
     *,
     mode: str,
     host: str = "",
-    store: str | None = None,
-    now: datetime | None = None,
+    path: Any = None,
+    now: float | None = None,
     err_stream: Any = None,
 ) -> bool:
-    """Refresh the reconciler's own liveness card. Returns did-write.
+    """Record that a reconcile pass RAN. Returns did-write; never raises.
 
-    Kept ``in_progress`` (NOT ``done``) on purpose: only an OPEN card is
-    watched by scitex-todo's stale-active nudge, and that nudge going off
-    IS the alarm for a dead reconciler. Resolving it would silence the one
-    thing that can report our death.
-
-    A SIDE rail like the down cards: a board-write failure prints loudly
-    and returns ``False``; it never raises into the pass.
+    Note the ``mode`` field: a hand-run ``sac agents reconcile`` (dry run) also
+    writes this record. A reader who ignores ``mode`` can therefore believe the
+    scheduled timer is alive on the strength of somebody having run the command
+    by hand.
     """
-    stream = err_stream if err_stream is not None else sys.stderr
-    # stx-allow: fallback (reason: the heartbeat is a SIDE rail — telling the board we are alive must never crash the pass that restarts corpses; a failure here is printed loudly and reported to the caller)
-    try:
-        _upsert(
-            store,
-            HEARTBEAT_CARD_ID,
-            f"[fleet] sac reconciler heartbeat — last {mode} pass {_now_iso(now)}",
-            _heartbeat_note(stats, mode=mode, host=host, now=now),
-            now,
-            status="in_progress",
-            blocker=None,
-            assignee=_HEARTBEAT_ASSIGNEE,
-        )
-        return True
-    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
-        print(
-            f"[fleet-reconcile-alarm] HEARTBEAT card delivery FAILED — {exc}. "
-            f"The reconcile pass itself was UNAFFECTED, but the board can no "
-            f"longer tell anyone whether this enforcer is alive — fix the "
-            f"scitex-todo store.",
-            file=stream,
-        )
-        return False
+    return log_pass_completed(
+        subsystem=SUBSYSTEM,
+        mode=mode,
+        counts=dict(stats),
+        detail=(f"fleet-reconcile {mode} pass completed on {host or 'this host'}"),
+        path=path,
+        now=now,
+        err_stream=err_stream,
+    )

--- a/src/scitex_agent_container/_reconcile/_pass.py
+++ b/src/scitex_agent_container/_reconcile/_pass.py
@@ -1,14 +1,14 @@
 """One reconcile pass: enumerate specs, observe tmux, resurrect corpses.
 
 The IO half of the enforcer. The decision itself is pure and lives in
-:mod:`._rule`; the rate limits in :mod:`._budget`; the board rails in
+:mod:`._rule`; the rate limits in :mod:`._budget`; the recording rails in
 :mod:`._alarm`. This module only wires facts into the rule and carries out
 whatever the rule authorises.
 
 Every collaborator is an injectable seam with a REAL default, so tests
-drive the whole pass against a real temp ``state.db``, a real temp
-scitex-todo store and a real fake ``tmux`` — with the one and only
-irreversible act (the restart) swapped for a recorder. No mocks.
+drive the whole pass against a real temp ``state.db``, a real temp event
+log and a real fake ``tmux`` — with the one and only irreversible act
+(the restart) swapped for a recorder. No mocks.
 """
 
 from __future__ import annotations
@@ -17,16 +17,15 @@ import os
 import sys
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+from .._events import EmitOutcome
 from ._alarm import (
-    AlarmOutcome,
-    clear_state_alarm,
-    route_reports_to_cards,
-    upsert_heartbeat,
-    upsert_state_alarm,
+    record_pass_completed,
+    record_reports,
+    record_self_impaired,
+    record_self_recovered,
 )
 from ._budget import DEFAULT_PASS_CAP, Budget, history_path, read_history, save_history
 from ._rule import MANAGED_POLICIES, Verdict, decide
@@ -69,7 +68,7 @@ class PassOutcome:
     """Everything one pass concluded and did."""
 
     reports: tuple[AgentReport, ...] = ()
-    alarm: AlarmOutcome | None = None
+    alarm: EmitOutcome | None = None
     heartbeat_ok: bool = False
     applied: bool = False
 
@@ -77,7 +76,7 @@ class PassOutcome:
         return tuple(r for r in self.reports if r.verdict in verdicts)
 
     def counts(self) -> dict[str, int]:
-        """Per-verdict tally — the heartbeat card's payload."""
+        """Per-verdict tally — the pass record's payload."""
         out = {v.value: 0 for v in Verdict}
         for report in self.reports:
             out[report.verdict.value] += 1
@@ -338,7 +337,7 @@ def reconcile_pass(
     specs_dir: Path | None = None,
     db_path: Path | None = None,
     history_file: Path | None = None,
-    store: str | None = None,
+    events_path: Path | None = None,
     alarm: bool = True,
     now: float | None = None,
     restart_fn: Callable[[str], bool] | None = None,
@@ -350,9 +349,9 @@ def reconcile_pass(
     """Run ONE reconcile pass over the fleet.
 
     ``apply=False`` (the default) is a REPORT: it reads tmux and the
-    registry, decides, and mutates no agent. The only board write a dry-run
-    makes is the reconciler's own heartbeat — a liveness beacon about US,
-    never about an agent.
+    registry, decides, and mutates no agent. The only thing a dry run
+    records is the pass itself — proof this ran, never a claim about an
+    agent.
 
     Parameters
     ----------
@@ -360,7 +359,7 @@ def reconcile_pass(
         Actually restart. Default ``False``.
     limit
         Global cap on restarts THIS pass (blast radius of one bad tick).
-    specs_dir, db_path, history_file, store
+    specs_dir, db_path, history_file, events_path
         Real state, redirectable for tests.
     restart_fn
         ``(name) -> bool``. The one irreversible act, injectable so tests
@@ -371,7 +370,6 @@ def reconcile_pass(
     from ..config import load_config
 
     now = now if now is not None else time.time()
-    now_dt = datetime.fromtimestamp(now, tz=timezone.utc)
     restart_fn = restart_fn if restart_fn is not None else _real_restart
     snapshot = _batched_snapshot_fn(snapshot_fn)
     local_host = (local_host_fn or _local_host)()
@@ -462,16 +460,16 @@ def reconcile_pass(
     # decision is already made and carried out, so nothing they do (or fail
     # to do) can change what happened to the fleet.
     if alarm:
-        # A reconciler that cannot read its own state must ALARM, never
+        # A reconciler that cannot read its own state must SAY SO, never
         # quietly do nothing — "did nothing" is indistinguishable from
         # "nothing needed doing", which is the silence this whole command
-        # exists to abolish. Cleared the moment the state is readable again.
+        # exists to abolish. Recorded as recovered the moment it is readable.
         if not read.enforceable:
-            upsert_state_alarm(
+            record_self_impaired(
                 read.detail,
-                path=history_file,
-                store=store,
-                now=now_dt,
+                state_file=history_file,
+                path=events_path,
+                now=now,
                 err_stream=err_stream,
             )
             print(
@@ -479,19 +477,24 @@ def reconcile_pass(
                 file=stream,
             )
         else:
-            clear_state_alarm(store=store, err_stream=err_stream)
+            record_self_recovered(
+                state_file=history_file,
+                path=events_path,
+                now=now,
+                err_stream=err_stream,
+            )
     alarm_outcome = (
-        route_reports_to_cards(reports, store=store, now=now_dt, err_stream=err_stream)
+        record_reports(reports, path=events_path, now=now, err_stream=err_stream)
         if (alarm and apply)
         else None
     )
     heartbeat_ok = (
-        upsert_heartbeat(
+        record_pass_completed(
             outcome.counts(),
             mode="apply" if apply else "dry-run",
             host=local_host,
-            store=store,
-            now=now_dt,
+            path=events_path,
+            now=now,
             err_stream=err_stream,
         )
         if alarm

--- a/src/scitex_agent_container/cli_pkg/_agents_reconcile.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_reconcile.py
@@ -158,7 +158,7 @@ def reconcile(
                     "mode": "apply" if apply else "dry-run",
                     "exit_code": code,
                     "counts": outcome.counts(),
-                    "heartbeat_carded": outcome.heartbeat_ok,
+                    "pass_recorded": outcome.heartbeat_ok,
                     "agents": [r.to_dict() for r in outcome.reports],
                 },
                 indent=2,
@@ -224,9 +224,9 @@ def reconcile(
         )
     if not outcome.heartbeat_ok:
         console.print(
-            "[yellow]note:[/yellow] the reconciler's heartbeat card was NOT "
-            "written — the board cannot tell anyone whether this enforcer is "
-            "alive. See the stderr line above."
+            "[yellow]note:[/yellow] this pass was NOT recorded in sac's "
+            "event log — nothing durable now says whether this enforcer ran. "
+            "See the stderr line above."
         )
     raise SystemExit(code)
 

--- a/src/scitex_agent_container/cli_pkg/_agents_restart_login_expired.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_restart_login_expired.py
@@ -142,7 +142,7 @@ def restart_login_expired(
                     "mode": "apply" if apply else "check",
                     "exit_code": code,
                     "counts": outcome.counts(),
-                    "heartbeat_carded": outcome.heartbeat_ok,
+                    "pass_recorded": outcome.heartbeat_ok,
                     "agents": [r.to_dict() for r in outcome.reports],
                 },
                 indent=2,

--- a/src/scitex_agent_container/cli_pkg/_host_sync.py
+++ b/src/scitex_agent_container/cli_pkg/_host_sync.py
@@ -25,7 +25,7 @@ from .._hostsync import (
     SyncResult,
     check_peer,
     exit_code_for,
-    route_reports_to_cards,
+    record_reports,
     sync_peer,
     syncable_peers,
 )
@@ -229,10 +229,10 @@ def host_sync(
 
     code = exit_code_for([r.outcome for r in results])
 
-    # Make the shout SEEN: route each verdict to an idempotent board card
-    # (upsert on drift/unknown, resolve on clean). This runs in BOTH output
-    # modes — the card is the delivery, independent of the console report.
-    alarm_outcome = route_reports_to_cards(results) if alarm else None
+    # Make the shout DURABLE: record each verdict in sac's own event log.
+    # This runs in BOTH output modes — the record is independent of whatever
+    # the console happens to print.
+    alarm_outcome = record_reports(results) if alarm else None
 
     if _json_flag(ctx, as_json):
         payload: dict = {
@@ -242,9 +242,9 @@ def host_sync(
         }
         if alarm_outcome is not None:
             payload["alarm"] = {
-                "drifted": list(alarm_outcome.drifted),
-                "undetermined": list(alarm_outcome.undetermined),
-                "cleared": list(alarm_outcome.cleared),
+                "degraded": list(alarm_outcome.degraded),
+                "unknown": list(alarm_outcome.unknown),
+                "recovered": list(alarm_outcome.recovered),
                 "failed": list(alarm_outcome.failed),
             }
         click.echo(json.dumps(payload, indent=2))

--- a/src/scitex_agent_container/cli_pkg/_host_sync.py
+++ b/src/scitex_agent_container/cli_pkg/_host_sync.py
@@ -135,8 +135,8 @@ def _print_result(result: SyncResult) -> None:
     default=False,
     help=(
         "READ-ONLY (requires --check): route each peer's verdict to an "
-        "idempotent scitex-todo card — upsert on drift/unknown, resolve on "
-        "clean — so the shout is SEEN on the board, not just in a log. "
+        "record in sac's own event log — degraded / unknown / recovered — so "
+        "the shout is DURABLE rather than a line in a journal. "
         "Mutates no peer."
     ),
 )

--- a/src/scitex_agent_container/cli_pkg/_worktree_gc.py
+++ b/src/scitex_agent_container/cli_pkg/_worktree_gc.py
@@ -25,7 +25,7 @@ from .._maintenance import (
     discover_repos,
     exit_code_for,
     gc_repos,
-    route_gc_to_cards,
+    record_gc_results,
 )
 from ._helpers import _json_flag, console
 
@@ -248,11 +248,10 @@ def worktree_gc(
     )
     code = exit_code_for(outcome)
 
-    # Make the shout SEEN: route each cap verdict to an idempotent board
-    # card. Defaults to riding --apply only — a dry run is a report and
-    # must not mutate the board.
+    # Make the shout DURABLE: record each cap verdict in sac's own event
+    # log. Defaults to riding --apply only, so a dry run stays a pure report.
     do_alarm = apply if alarm is None else alarm
-    alarm_outcome = route_gc_to_cards(list(outcome.results)) if do_alarm else None
+    alarm_outcome = record_gc_results(list(outcome.results)) if do_alarm else None
 
     if _json_flag(ctx, as_json):
         payload: dict = {
@@ -266,9 +265,9 @@ def worktree_gc(
         }
         if alarm_outcome is not None:
             payload["alarm"] = {
-                "exceeded": list(alarm_outcome.exceeded),
-                "unreadable": list(alarm_outcome.unreadable),
-                "cleared": list(alarm_outcome.cleared),
+                "degraded": list(alarm_outcome.degraded),
+                "unknown": list(alarm_outcome.unknown),
+                "recovered": list(alarm_outcome.recovered),
                 "failed": list(alarm_outcome.failed),
             }
         click.echo(json.dumps(payload, indent=2))

--- a/src/scitex_agent_container/cli_pkg/_worktree_gc.py
+++ b/src/scitex_agent_container/cli_pkg/_worktree_gc.py
@@ -159,9 +159,9 @@ def _print_report(outcome: GcOutcome, *, apply: bool) -> None:
     "alarm",
     default=None,
     help=(
-        "Route each repo's cap verdict to an idempotent scitex-todo card "
+        "Record each repo's cap verdict in sac's own event log "
         "(upsert over cap / unknown, resolve back under). Default: on with "
-        "--apply, off on a dry run (a report must not write to the board)."
+        "--apply, off on a dry run (a report stays a pure report)."
     ),
 )
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON (for cron).")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -294,3 +294,45 @@ def _isolate_state_db(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path
             os.environ.pop(_STATE_DB_KEY, None)
         else:
             os.environ[_STATE_DB_KEY] = saved_env
+
+
+# ---------------------------------------------------------------------------
+# sac event log isolation
+# ---------------------------------------------------------------------------
+
+_EVENT_LOG_KEY = "SAC_EVENT_LOG"
+_event_log_seq = itertools.count()
+
+
+# Same shape and the same reason as `_isolate_state_db` above. sac's alarm
+# rails record to an append-only event log whose path is resolved PER CALL
+# from this env var, and several of them default ON (the worktree GC alarms
+# under `--apply`; the reconcile and auth-heal passes record every pass). Any
+# test that exercises one of those paths without this fixture appends to the
+# OPERATOR'S REAL LOG — quietly, because the rail is deliberately fail-open.
+#
+# Per-TEST, not per-session: the rails also keep small "currently degraded"
+# state files BESIDE the log, so a shared log would let one test's remembered
+# degraded subject suppress the next test's degraded record — a cross-test
+# dependency that would only ever show up as a mystifying order-dependent
+# failure under `-p randomly`.
+@pytest.fixture(autouse=True, scope="function")
+def _isolate_event_log(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    """Point this test's sac event log at a private tmp file."""
+    # Computed but deliberately NOT created: the rail mkdirs its parent on
+    # first real write, so a test that records nothing leaves no dir behind.
+    log = (
+        tmp_path_factory.getbasetemp()
+        / "sac-events"
+        / f"t{next(_event_log_seq)}"
+        / "sac-events.jsonl"
+    )
+    saved = os.environ.get(_EVENT_LOG_KEY)
+    os.environ[_EVENT_LOG_KEY] = str(log)
+    try:
+        yield log
+    finally:
+        if saved is None:
+            os.environ.pop(_EVENT_LOG_KEY, None)
+        else:
+            os.environ[_EVENT_LOG_KEY] = saved

--- a/tests/integration/test_card_package_boundary.py
+++ b/tests/integration/test_card_package_boundary.py
@@ -28,6 +28,14 @@ EXACT MATCH, IN BOTH DIRECTIONS
     it. A new import fails the test — and so does quietly fixing one of the
     known two without removing it from the list, because a stale allowance is
     how an empty list eventually becomes a long one again.
+
+WHY IT LIVES IN tests/integration/
+    It asserts a CROSS-PACKAGE property of the whole source tree rather than
+    the behaviour of any one module, so it has no ``src/`` counterpart to
+    mirror and does not belong under ``tests/scitex_agent_container/``. It
+    sits beside ``test_cross_package_imports.py`` — the positive gate listing
+    the cross-package imports sac DOES have — as that gate's negative
+    counterpart.
 """
 
 from __future__ import annotations

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -36,7 +36,6 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_logging",
     "scitex_notification",
     "scitex_todo",
-    "scitex_todo._help_wait",
 ]
 # ===== END AUTO-GENERATED =====
 

--- a/tests/scitex_agent_container/_account/test_refresh_alarm.py
+++ b/tests/scitex_agent_container/_account/test_refresh_alarm.py
@@ -5,9 +5,21 @@ hours and told nobody. These tests lock the alerting contract: first
 failure alerts once; repeats stay quiet; recovery re-arms; a failed
 delivery is retried because nothing was recorded.
 
-No-mocks (PA-306): real JSON state files on tmp_path; the delivery seam
-is a plain recording closure (the module's documented ``notify``
-injection point). AAA marker comments; one assertion per test.
+The DEFAULT delivery (:func:`_default_notify`) has two legs with
+deliberately different failure semantics, and the last block here pins
+that split. The RECORD in sac's own event log comes first and is what
+makes the rail trustworthy — it depends on no lead, no network and no
+other software — so only its failure raises, leaving the dedupe unmarked
+for the next run. The lead ``blocker`` push on top is best-effort: on a
+fleet with no ``lead:`` block there is nowhere to push, and that must not
+re-page the operator on every one of the timer's ~12 daily runs.
+
+No-mocks (PA-306), no monkeypatching: real JSON state files on tmp_path,
+a real temp JSONL event log redirected through the documented
+``SAC_EVENT_LOG`` env var, and a real ``config.yaml`` with no ``lead:``
+block for the unconfigured-push leg. The injected delivery seam is a
+plain recording closure (the module's documented ``notify`` injection
+point). AAA marker comments; one assertion per test.
 """
 
 from __future__ import annotations
@@ -16,7 +28,14 @@ import io
 import json
 from pathlib import Path
 
-from scitex_agent_container._account.refresh_alarm import alert_failed_refreshes
+import pytest
+
+from scitex_agent_container._account.refresh_alarm import (
+    SUBSYSTEM,
+    _default_notify,
+    alert_failed_refreshes,
+)
+from scitex_agent_container._events import EVENT_LOG_ENV, SUBJECT_DEGRADED, read_events
 
 _ERROR_TEXT = (
     "token endpoint https://platform.claude.com/v1/oauth/token did not "
@@ -205,3 +224,122 @@ def test_alerted_account_names_are_returned(tmp_path: Path) -> None:
     )
     # Assert
     assert alerted == ["acct-a"]
+
+
+# --- the DEFAULT delivery: record first, then push best-effort --------------
+
+
+@pytest.fixture
+def no_lead_configured(tmp_path: Path, env_save_restore) -> Path:
+    """A REAL config.yaml with no ``lead:`` block. No mocks.
+
+    This is the fleet this host actually is (2026-07-11): the push leg has
+    nowhere to go and fails for real, which is exactly the condition that
+    must NOT re-page the operator on every one of the timer's ~12 daily runs.
+    """
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("host:\n  aliases: {}\npeers: {}\n")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    return cfg
+
+
+def test_the_default_delivery_records_the_failure(
+    tmp_path: Path, env_save_restore, no_lead_configured
+) -> None:
+    # Arrange — the record is what makes this rail trustworthy: it depends on
+    # no lead, no network and no software sac does not own.
+    log = tmp_path / "sac-events.jsonl"
+    env_save_restore.set(EVENT_LOG_ENV, str(log))
+    # Act
+    _default_notify("acct-a", "summary line", "detail block")
+    # Assert
+    assert [e.event for e in read_events(log, subsystem=SUBSYSTEM)] == [
+        SUBJECT_DEGRADED
+    ]
+
+
+def test_the_recorded_failure_names_the_account(
+    tmp_path: Path, env_save_restore, no_lead_configured
+) -> None:
+    # Arrange
+    log = tmp_path / "sac-events.jsonl"
+    env_save_restore.set(EVENT_LOG_ENV, str(log))
+    # Act
+    _default_notify("acct-a", "summary line", "detail block")
+    # Assert
+    assert read_events(log)[0].subject == "acct-a"
+
+
+def test_the_recorded_failure_is_labelled_an_account(
+    tmp_path: Path, env_save_restore, no_lead_configured
+) -> None:
+    # Arrange — an account is not an agent; the subject_kind keeps the
+    # populations apart in one shared log.
+    log = tmp_path / "sac-events.jsonl"
+    env_save_restore.set(EVENT_LOG_ENV, str(log))
+    # Act
+    _default_notify("acct-a", "summary line", "detail block")
+    # Assert
+    assert read_events(log)[0].subject_kind == "account"
+
+
+def test_the_recorded_failure_carries_the_verdict(
+    tmp_path: Path, env_save_restore, no_lead_configured
+) -> None:
+    # Arrange
+    log = tmp_path / "sac-events.jsonl"
+    env_save_restore.set(EVENT_LOG_ENV, str(log))
+    # Act
+    _default_notify("acct-a", "summary line", "detail block")
+    # Assert
+    assert read_events(log)[0].verdict == "refresh_failed"
+
+
+def test_an_unconfigured_lead_push_does_not_raise(
+    tmp_path: Path, env_save_restore, no_lead_configured
+) -> None:
+    # Arrange — THE dedupe guard. The durable record already succeeded, so a
+    # push failure loses attention-now, not the fact. Raising here would leave
+    # the dedupe unmarked and re-page on every run of a ~2h timer.
+    log = tmp_path / "sac-events.jsonl"
+    env_save_restore.set(EVENT_LOG_ENV, str(log))
+    # Act
+    _default_notify("acct-a", "summary line", "detail block")
+    # Assert — reaching this line at all is the proof; the record still stands.
+    assert read_events(log) != []
+
+
+def test_an_unconfigured_lead_push_is_loud(
+    tmp_path: Path, env_save_restore, no_lead_configured, capsys
+) -> None:
+    # Arrange — best-effort is not silent: nobody has been paged, and that
+    # fact must reach stderr rather than being swallowed.
+    env_save_restore.set(EVENT_LOG_ENV, str(tmp_path / "sac-events.jsonl"))
+    # Act
+    _default_notify("acct-a", "summary line", "detail block")
+    # Assert
+    assert "lead blocker push FAILED" in capsys.readouterr().err
+
+
+def test_a_failed_record_raises_so_the_run_retries(
+    tmp_path: Path, env_save_restore, no_lead_configured
+) -> None:
+    # Arrange — a REALLY read-only dir, so the append fails the way it would
+    # on a broken host. Losing the record is the ONE failure that leaves sac
+    # with no account of the outage at all, so it must reach the caller and
+    # leave the dedupe unmarked.
+    denied = tmp_path / "denied"
+    denied.mkdir()
+    denied.chmod(0o555)
+    env_save_restore.set(EVENT_LOG_ENV, str(denied / "sac-events.jsonl"))
+    raised: list[BaseException] = []
+    try:
+        # Act
+        try:
+            _default_notify("acct-a", "summary line", "detail block")
+        except RuntimeError as exc:
+            raised.append(exc)
+        # Assert
+        assert [type(e).__name__ for e in raised] == ["RuntimeError"]
+    finally:
+        denied.chmod(0o755)

--- a/tests/scitex_agent_container/_authheal/conftest.py
+++ b/tests/scitex_agent_container/_authheal/conftest.py
@@ -1,7 +1,7 @@
 """Real temp state for the login-expired auto-restart suites — no mocks.
 
 Every fixture hands the pass REAL state it can write to and a test can read
-back: an on-disk restart-history file, an on-disk scitex-todo store and an
+back: an on-disk restart-history file, an on-disk sac event log and an
 on-disk fleet registry. Detection is capture-driven (injected panes), so no
 state.db is needed here — but the ROSTER is real, because the pass now checks
 its pane reading against the registry to find the agents that reading failed
@@ -50,9 +50,29 @@ def roster(tmp_path: Path):
 
 
 @pytest.fixture
-def store(tmp_path: Path) -> str:
-    """A real (initially absent) scitex-todo store path — no mocks."""
-    return str(tmp_path / "tasks.yaml")
+def events(tmp_path: Path) -> Path:
+    """A real (initially absent) sac event-log path — no mocks.
+
+    Nothing creates it until a pass records something, so ``events.exists()``
+    is itself the assertion "this pass recorded nothing at all".
+    """
+    return tmp_path / "sac-events.jsonl"
+
+
+@pytest.fixture
+def unwritable(tmp_path: Path):
+    """An event-log path the REAL writer genuinely cannot write. No mocks.
+
+    The parent dir is read-only, so the append fails the way it would on a
+    broken host — the world says no; nothing is injected.
+    """
+    readonly = tmp_path / "readonly-events"
+    readonly.mkdir()
+    readonly.chmod(0o555)
+    try:
+        yield readonly / "sac-events.jsonl"
+    finally:
+        readonly.chmod(0o755)
 
 
 @pytest.fixture

--- a/tests/scitex_agent_container/_authheal/test__alarm.py
+++ b/tests/scitex_agent_container/_authheal/test__alarm.py
@@ -1,66 +1,200 @@
-"""The board rail: escalate the unhealable, resolve the recovered.
+"""The record rail: report the unhealable, record the recovery.
 
-The card is the alternative to an infinite bounce — it must appear when an
-agent is over the hourly cap, and it must go away on its own the moment the
-agent is no longer login-expired, or the operator learns to scroll past a
-board full of stale alarms. Real scitex-todo store, no mocks.
+The record is the alternative to an infinite bounce — it must appear when an
+agent is over the hourly cap, and the recovery must be recorded on its own the
+moment the agent is no longer login-expired, or the log fills with stale
+alarms nobody reads.
+
+ABSENCE MEANS RECOVERY HERE, AND ONLY HERE. This pass reports only the agents
+currently login-expired, so a remembered agent that is NOT in a later pass's
+reports has recovered on its own — which is why this rail sweeps absent
+subjects and a whole-fleet pass such as the reconciler must not.
+
+PA-306: no ``unittest.mock``, no monkeypatching. A REAL temp JSONL event log
+through the module's own ``path=`` seam; every assertion reads it back through
+the production :func:`read_events`.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
 """
 
 from __future__ import annotations
 
-import pytest
+import io
+from pathlib import Path
 
 from scitex_agent_container._authheal._alarm import (
-    card_id_for,
-    route_reports_to_cards,
+    SUBSYSTEM,
+    record_pass_completed,
+    record_reports,
 )
 from scitex_agent_container._authheal._pass import AgentReport
+from scitex_agent_container._events import (
+    PASS_COMPLETED,
+    SUBJECT_DEGRADED,
+    SUBJECT_RECOVERED,
+    read_events,
+)
 from scitex_agent_container._reconcile._rule import Verdict
 
-# Every assertion here reads a card back through the REAL scitex_todo writer, so
-# the whole module needs the board package. It is a runtime dependency that the
-# CI test SIF does not layer in, so skip cleanly there rather than fail — the
-# same guard the sibling ``_reconcile/test__alarm.py`` uses.
-scitex_todo = pytest.importorskip("scitex_todo")
+#: A fixed clock, so no test can be flaky on time.
+NOW = 1_800_000_000.0
 
 
 def _report(name: str, verdict: Verdict) -> AgentReport:
     return AgentReport(name=name, verdict=verdict, reason="t", detail="detail")
 
 
-def test_over_budget_report_creates_a_card(store):
+def _kinds(events: Path) -> list[str]:
+    return [e.event for e in read_events(events, subsystem=SUBSYSTEM)]
+
+
+def test_an_over_budget_report_records_a_degraded_event(events):
     # Arrange — an agent the restarter has given up on.
     reports = [_report("hpc", Verdict.OVER_BUDGET)]
     # Act
-    route_reports_to_cards(reports, store=store)
-    # Assert — the card exists and is a live BLOCKING-YOU alarm.
-    assert scitex_todo.get_task(store, card_id_for("hpc"))["status"] == "blocked"
-
-
-def test_restarted_report_resolves_a_prior_card(store):
-    # Arrange — first over budget (carded), then successfully restarted.
-    route_reports_to_cards([_report("hpc", Verdict.OVER_BUDGET)], store=store)
-    # Act
-    route_reports_to_cards([_report("hpc", Verdict.RESTARTED)], store=store)
+    record_reports(reports, path=events, now=NOW)
     # Assert
-    assert scitex_todo.get_task(store, card_id_for("hpc"))["status"] == "done"
+    assert _kinds(events) == [SUBJECT_DEGRADED]
 
 
-def test_recovered_agent_no_longer_in_reports_is_resolved(store):
-    # Arrange — carded, then the agent recovers on its own (operator logged
-    # in) so it is not login-expired anymore and never appears in a later
-    # pass's reports at all.
-    route_reports_to_cards([_report("hpc", Verdict.OVER_BUDGET)], store=store)
+def test_the_degraded_record_names_the_agent(events):
+    # Arrange — never silent: a reader must see WHICH agent.
+    # Act
+    record_reports([_report("hpc", Verdict.OVER_BUDGET)], path=events, now=NOW)
+    # Assert
+    assert read_events(events)[0].subject == "hpc"
+
+
+def test_the_degraded_record_says_restarting_stopped(events):
+    # Arrange — the record must teach the reader what to conclude: a restart
+    # LOOP is worse than a wedged agent, and the usual cause is an account
+    # that cannot refresh, which no restart fixes.
+    # Act
+    record_reports([_report("hpc", Verdict.OVER_BUDGET)], path=events, now=NOW)
+    # Assert
+    assert "stopped restarting it" in read_events(events)[0].detail
+
+
+def test_a_restarted_report_records_the_recovery(events):
+    # Arrange — first over budget (recorded), then successfully restarted.
+    record_reports([_report("hpc", Verdict.OVER_BUDGET)], path=events, now=NOW)
+    # Act
+    record_reports([_report("hpc", Verdict.RESTARTED)], path=events, now=NOW)
+    # Assert
+    assert _kinds(events) == [SUBJECT_DEGRADED, SUBJECT_RECOVERED]
+
+
+def test_an_agent_absent_from_a_later_pass_is_recovered(events):
+    # Arrange — recorded degraded, then the agent recovers on its own (the
+    # operator logged in) so it is no longer login-expired and never appears
+    # in a later pass's reports at all.
+    record_reports([_report("hpc", Verdict.OVER_BUDGET)], path=events, now=NOW)
     # Act — a subsequent pass finds nothing wrong.
-    route_reports_to_cards([], store=store)
-    # Assert — the stale card is cleared without a human.
-    assert scitex_todo.get_task(store, card_id_for("hpc"))["status"] == "done"
+    record_reports([], path=events, now=NOW)
+    # Assert — the stale alarm clears without a human.
+    assert _kinds(events) == [SUBJECT_DEGRADED, SUBJECT_RECOVERED]
 
 
-def test_over_budget_card_is_reported_as_carded(store):
+def test_the_swept_recovery_says_why_it_recovered(events):
+    # Arrange — absence is the OBSERVATION here, and the record must say so,
+    # or a reader cannot tell it from an observed clean reading.
+    record_reports([_report("hpc", Verdict.OVER_BUDGET)], path=events, now=NOW)
+    # Act
+    record_reports([], path=events, now=NOW)
+    # Assert
+    assert (
+        "absent from this pass"
+        in read_events(events, event=SUBJECT_RECOVERED)[0].detail
+    )
+
+
+def test_an_unobserved_agent_is_never_swept_as_recovered(events):
+    # Arrange — an UNOBSERVED agent IS in the reports, so it must not be swept:
+    # recording a recovery on a reading we never took would be a false
+    # all-clear in its most durable form.
+    record_reports([_report("hpc", Verdict.OVER_BUDGET)], path=events, now=NOW)
+    # Act
+    record_reports([_report("hpc", Verdict.UNOBSERVED)], path=events, now=NOW)
+    # Assert
+    assert _kinds(events) == [SUBJECT_DEGRADED]
+
+
+def test_the_degraded_agent_is_reported_to_the_caller(events):
     # Arrange
     reports = [_report("hpc", Verdict.OVER_BUDGET)]
     # Act
-    outcome = route_reports_to_cards(reports, store=store)
+    outcome = record_reports(reports, path=events, now=NOW)
     # Assert
-    assert outcome.carded == ("hpc",)
+    assert outcome.degraded == ("hpc",)
+
+
+def test_the_swept_agent_is_reported_to_the_caller(events):
+    # Arrange — the sweep's recoveries must reach the caller too, or the CLI
+    # summary silently under-reports what the pass concluded.
+    record_reports([_report("hpc", Verdict.OVER_BUDGET)], path=events, now=NOW)
+    # Act
+    outcome = record_reports([], path=events, now=NOW)
+    # Assert
+    assert outcome.recovered == ("hpc",)
+
+
+def test_a_healthy_agent_without_prior_trouble_records_nothing(events):
+    # Arrange — a restarted agent that was never over budget.
+    # Act
+    record_reports([_report("hpc", Verdict.RESTARTED)], path=events, now=NOW)
+    # Assert
+    assert not events.exists()
+
+
+def test_the_pass_record_is_written_on_a_clean_pass(events):
+    # Arrange — a pass that finds nothing wrong still leaves proof the timer
+    # ticked; a rail that only writes during trouble cannot distinguish a
+    # healthy fleet from a restarter that stopped running months ago.
+    # Act
+    record_pass_completed({}, mode="check", host="host-a", path=events, now=NOW)
+    # Assert
+    assert _kinds(events) == [PASS_COMPLETED]
+
+
+def test_the_pass_record_carries_the_mode(events):
+    # Arrange — a hand-run --check also writes this record.
+    # Act
+    record_pass_completed({}, mode="check", path=events, now=NOW)
+    # Assert
+    assert read_events(events)[0].raw["mode"] == "check"
+
+
+def test_the_pass_record_carries_the_counts(events):
+    # Arrange
+    # Act
+    record_pass_completed({"RESTARTED": 2}, mode="apply", path=events, now=NOW)
+    # Assert
+    assert read_events(events)[0].raw["counts"] == {"RESTARTED": 2}
+
+
+def test_a_recording_failure_does_not_raise(events, unwritable):
+    # Arrange — recording is a SIDE rail and must never crash the restart
+    # pass that feeds it.
+    # Act
+    outcome = record_reports(
+        [_report("hpc", Verdict.OVER_BUDGET)],
+        path=unwritable,
+        now=NOW,
+        err_stream=io.StringIO(),
+    )
+    # Assert
+    assert outcome.failed == ("hpc",)
+
+
+def test_a_recording_failure_is_loud(events, unwritable):
+    # Arrange
+    stream = io.StringIO()
+    # Act
+    record_reports(
+        [_report("hpc", Verdict.OVER_BUDGET)],
+        path=unwritable,
+        now=NOW,
+        err_stream=stream,
+    )
+    # Assert
+    assert "FAILED to record" in stream.getvalue()

--- a/tests/scitex_agent_container/_authheal/test__pass.py
+++ b/tests/scitex_agent_container/_authheal/test__pass.py
@@ -1,13 +1,13 @@
 """One login-expired auto-restart pass, end to end, with real state.
 
 Detection (the real ``evaluate_agents`` corroboration) runs against injected
-panes; the ONE irreversible act (the restart) is a recording callable, and
-the budget/history/cards are real on-disk state. No mocks of anything under
+panes; the ONE irreversible act (the restart) is a recording callable, and the
+budget/history/event-log are real on-disk state. No mocks of anything under
 test.
 
 The load-bearing safety property is that a persistently-failing agent is
-CARDED, never bounced forever: these tests pin the debounce, the hourly cap,
-and the escalation card that replaces an infinite restart loop.
+RECORDED, never bounced forever: these tests pin the debounce, the hourly cap,
+and the durable record that replaces an infinite restart loop.
 
 The second load-bearing property is that a pass cannot report a clean fleet it
 did not look at. An agent whose pane will not capture, and a registered agent
@@ -21,10 +21,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
-from scitex_agent_container._authheal._alarm import CARD_ID_PREFIX, card_id_for
+from scitex_agent_container._authheal._alarm import SUBSYSTEM
 from scitex_agent_container._authheal._pass import auth_heal_pass
+from scitex_agent_container._events import SUBJECT_DEGRADED, read_events
 from scitex_agent_container._reconcile._budget import (
     DEBOUNCE_S,
     MAX_RESTARTS_PER_AGENT_PER_HOUR,
@@ -41,13 +40,13 @@ def _seed_history(path: Path, mapping: dict) -> None:
     save_history(path, mapping, now=NOW)
 
 
-def _run(capture, history, store, rec, **over):
+def _run(capture, history, events, rec, **over):
     kwargs = dict(
         apply=True,
         alarm=False,
         now=NOW,
         history_file=history,
-        store=store,
+        events_path=events,
         capture_fn=lambda: capture,
         restart_fn=rec,
     )
@@ -62,20 +61,20 @@ def _verdict(outcome, name: str) -> Verdict:
 # --- the happy path: a corroborated wedge is restarted --------------------
 
 
-def test_corroborated_login_expired_agent_is_restarted(history, store):
+def test_corroborated_login_expired_agent_is_restarted(history, events):
     # Arrange — one frozen-banner agent, empty history (first sight).
     rec = Recorder()
     # Act
-    _run(stuck("hpc"), history, store, rec)
+    _run(stuck("hpc"), history, events, rec)
     # Assert — the single irreversible act happened, exactly once, for it.
     assert rec.names == ["hpc"]
 
 
-def test_corroborated_agent_reports_restarted(history, store):
+def test_corroborated_agent_reports_restarted(history, events):
     # Arrange
     rec = Recorder()
     # Act
-    outcome = _run(stuck("hpc"), history, store, rec)
+    outcome = _run(stuck("hpc"), history, events, rec)
     # Assert
     assert _verdict(outcome, "hpc") == Verdict.RESTARTED
 
@@ -83,11 +82,11 @@ def test_corroborated_agent_reports_restarted(history, store):
 # --- the safety gate: a transient / single-run flag is NOT restarted ------
 
 
-def test_single_run_transient_agent_is_not_restarted(history, store):
+def test_single_run_transient_agent_is_not_restarted(history, events):
     # Arrange — a banner on run 1, gone on the decisive run 2: not frozen.
     rec = Recorder()
     # Act
-    _run(transient("figrecipe"), history, store, rec)
+    _run(transient("figrecipe"), history, events, rec)
     # Assert — no restart, because it was never corroborated.
     assert rec.names == []
 
@@ -95,20 +94,20 @@ def test_single_run_transient_agent_is_not_restarted(history, store):
 # --- dry-run / --check: report, never act ---------------------------------
 
 
-def test_check_mode_does_not_restart(history, store):
+def test_check_mode_does_not_restart(history, events):
     # Arrange — apply=False is the dry-run the `--check` flag selects.
     rec = Recorder()
     # Act
-    _run(stuck("hpc"), history, store, rec, apply=False)
+    _run(stuck("hpc"), history, events, rec, apply=False)
     # Assert
     assert rec.names == []
 
 
-def test_check_mode_reports_would_restart(history, store):
+def test_check_mode_reports_would_restart(history, events):
     # Arrange
     rec = Recorder()
     # Act
-    outcome = _run(stuck("hpc"), history, store, rec, apply=False)
+    outcome = _run(stuck("hpc"), history, events, rec, apply=False)
     # Assert
     assert _verdict(outcome, "hpc") == Verdict.WOULD_RESTART
 
@@ -116,31 +115,31 @@ def test_check_mode_reports_would_restart(history, store):
 # --- the debounce bound: a just-restarted agent is left to boot ------------
 
 
-def test_agent_inside_the_debounce_is_not_restarted_again(history, store):
+def test_agent_inside_the_debounce_is_not_restarted_again(history, events):
     # Arrange — restarted 100s ago; still login-expired, but restarting again
     # now would kill the recovery in progress.
     _seed_history(history, {"hpc": [NOW - 100]})
     rec = Recorder()
     # Act
-    _run(stuck("hpc"), history, store, rec)
+    _run(stuck("hpc"), history, events, rec)
     # Assert
     assert rec.names == []
 
 
-def test_agent_inside_the_debounce_reports_cooling_down(history, store):
+def test_agent_inside_the_debounce_reports_cooling_down(history, events):
     # Arrange
     _seed_history(history, {"hpc": [NOW - 100]})
     rec = Recorder()
     # Act
-    outcome = _run(stuck("hpc"), history, store, rec)
+    outcome = _run(stuck("hpc"), history, events, rec)
     # Assert
     assert _verdict(outcome, "hpc") == Verdict.COOLING_DOWN
 
 
-# --- the hourly cap: persistently failing → card, NOT an infinite bounce ---
+# --- the hourly cap: persistently failing → record, NOT an infinite bounce -
 
 
-def test_agent_over_the_hourly_cap_is_not_restarted(history, store):
+def test_agent_over_the_hourly_cap_is_not_restarted(history, events):
     # Arrange — already restarted MAX_RESTARTS_PER_AGENT_PER_HOUR times inside
     # the rolling hour and the debounce has since passed; it is STILL wedged.
     # Restarting is not fixing it — a loop is worse than a down agent. Two
@@ -151,55 +150,54 @@ def test_agent_over_the_hourly_cap_is_not_restarted(history, store):
     _seed_history(history, {"hpc": stamps})
     rec = Recorder()
     # Act
-    _run(stuck("hpc"), history, store, rec)
+    _run(stuck("hpc"), history, events, rec)
     # Assert — the loop is refused.
     assert rec.names == []
 
 
-def test_agent_over_the_hourly_cap_reports_over_budget(history, store):
+def test_agent_over_the_hourly_cap_reports_over_budget(history, events):
     # Arrange
     _seed_history(history, {"hpc": [NOW - 3_400, NOW - int(DEBOUNCE_S) - 100]})
     rec = Recorder()
     # Act
-    outcome = _run(stuck("hpc"), history, store, rec)
+    outcome = _run(stuck("hpc"), history, events, rec)
     # Assert
     assert _verdict(outcome, "hpc") == Verdict.OVER_BUDGET
 
 
-def test_over_budget_agent_is_escalated_to_a_board_card(history, store):
+def test_over_budget_agent_is_recorded_as_degraded(history, events):
     # Arrange — the whole point of the cap: instead of bouncing forever, the
-    # agent that cannot be healed is handed to a human via an idempotent card.
-    # This ONE test needs the real board writer; skip cleanly where the CI test
-    # SIF has not layered scitex_todo in (the rest of this module does not).
-    scitex_todo = pytest.importorskip("scitex_todo")
+    # agent that cannot be healed leaves a durable record in sac's own log.
+    # This is the ONE test here that lets the recording rail run (the rest
+    # pass ``alarm=False``, because their subject is the restart decision).
     _seed_history(history, {"hpc": [NOW - 3_400, NOW - int(DEBOUNCE_S) - 100]})
     rec = Recorder()
     # Act
-    _run(stuck("hpc"), history, store, rec, alarm=True)
-    # Assert — exactly one escalation card, for this agent.
-    ids = [c["id"] for c in scitex_todo.list_tasks(store, id_prefix=CARD_ID_PREFIX)]
-    assert ids == [card_id_for("hpc")]
+    _run(stuck("hpc"), history, events, rec, alarm=True)
+    # Assert — exactly one degraded record, for this agent.
+    degraded = read_events(events, subsystem=SUBSYSTEM, event=SUBJECT_DEGRADED)
+    assert [e.subject for e in degraded] == ["hpc"]
 
 
 # --- can't read our own memory → refuse, never a blind loop ---------------
 
 
-def test_unreadable_budget_refuses_to_restart(denied_history, store):
+def test_unreadable_budget_refuses_to_restart(denied_history, events):
     # Arrange — the restart history cannot be created, so the debounce/cap are
     # unenforceable. Restarting anyway would make every wedge restartable on
     # every tick, forever — the exact loop the budget exists to prevent.
     rec = Recorder()
     # Act
-    _run(stuck("hpc"), denied_history, store, rec)
+    _run(stuck("hpc"), denied_history, events, rec)
     # Assert
     assert rec.names == []
 
 
-def test_unreadable_budget_reports_budget_unknown(denied_history, store):
+def test_unreadable_budget_reports_budget_unknown(denied_history, events):
     # Arrange
     rec = Recorder()
     # Act
-    outcome = _run(stuck("hpc"), denied_history, store, rec)
+    outcome = _run(stuck("hpc"), denied_history, events, rec)
     # Assert
     assert _verdict(outcome, "hpc") == Verdict.BUDGET_UNKNOWN
 
@@ -212,33 +210,33 @@ def test_unreadable_budget_reports_budget_unknown(denied_history, store):
 # hours while every pass logged a success.
 
 
-def test_uncapturable_pane_is_reported(history, store):
+def test_uncapturable_pane_is_reported(history, events):
     # Arrange — a live session whose pane cannot be read.
     rec = Recorder()
     # Act
-    outcome = _run({"scitex-hub": (None, None)}, history, store, rec)
+    outcome = _run({"scitex-hub": (None, None)}, history, events, rec)
     # Assert
     assert _verdict(outcome, "scitex-hub") == Verdict.UNOBSERVED
 
 
-def test_uncapturable_pane_makes_the_pass_could_not_determine(history, store):
+def test_uncapturable_pane_makes_the_pass_could_not_determine(history, events):
     # Arrange — THE gate. 0 must mean "we accounted for the roster and nothing
     # is wedged", never "we produced no reports": the second is also what a
     # pass that observed nothing produces, and while both spelled 0 the timer
     # recorded ExecMainStatus=0 for every pass that had failed to look.
     rec = Recorder()
     # Act
-    outcome = _run({"scitex-hub": (None, None)}, history, store, rec)
+    outcome = _run({"scitex-hub": (None, None)}, history, events, rec)
     # Assert
     assert outcome.exit_code() == 2
 
 
-def test_uncapturable_pane_is_never_restarted(history, store):
+def test_uncapturable_pane_is_never_restarted(history, events):
     # Arrange — visible is not the same as actionable. An unread pane is no
     # evidence of a wedge, so making it loud must not make it restartable.
     rec = Recorder()
     # Act
-    _run({"scitex-hub": (None, None)}, history, store, rec)
+    _run({"scitex-hub": (None, None)}, history, events, rec)
     # Assert
     assert rec.names == []
 
@@ -250,48 +248,48 @@ def test_uncapturable_pane_is_never_restarted(history, store):
 # The registry is the independent population that makes it visible.
 
 
-def test_registered_agent_with_no_session_is_reported(roster, history, store):
+def test_registered_agent_with_no_session_is_reported(roster, history, events):
     # Arrange — scitex-hub is registered; the reading contains only some other,
     # healthy agent, so nothing in it mentions scitex-hub.
     register_agents(roster, "scitex-hub")
     rec = Recorder()
     # Act
-    outcome = _run({"writer": (OK, OK)}, history, store, rec)
+    outcome = _run({"writer": (OK, OK)}, history, events, rec)
     # Assert
     assert _verdict(outcome, "scitex-hub") == Verdict.UNOBSERVED
 
 
 def test_registered_agent_with_no_session_could_not_be_determined(
-    roster, history, store
+    roster, history, events
 ):
     # Arrange
     register_agents(roster, "scitex-hub")
     rec = Recorder()
     # Act
-    outcome = _run({"writer": (OK, OK)}, history, store, rec)
+    outcome = _run({"writer": (OK, OK)}, history, events, rec)
     # Assert
     assert outcome.exit_code() == 2
 
 
-def test_registered_agent_with_no_session_is_never_restarted(roster, history, store):
+def test_registered_agent_with_no_session_is_never_restarted(roster, history, events):
     # Arrange — a missing session is fleet-reconcile's half of the fleet. This
     # pass makes it visible; it must not also act on it.
     register_agents(roster, "scitex-hub")
     rec = Recorder()
     # Act
-    _run({"writer": (OK, OK)}, history, store, rec)
+    _run({"writer": (OK, OK)}, history, events, rec)
     # Assert
     assert rec.names == []
 
 
-def test_fully_observed_healthy_roster_exits_clean(roster, history, store):
+def test_fully_observed_healthy_roster_exits_clean(roster, history, events):
     # Arrange — the other half of the gate: 0 must stay REACHABLE, or the exit
     # code carries no information. Every registered agent has a live pane that
     # read clean, so this pass genuinely accounted for the whole roster.
     register_agents(roster, "writer")
     rec = Recorder()
     # Act
-    outcome = _run({"writer": (OK, OK)}, history, store, rec)
+    outcome = _run({"writer": (OK, OK)}, history, events, rec)
     # Assert
     assert outcome.exit_code() == 0
 
@@ -299,27 +297,29 @@ def test_fully_observed_healthy_roster_exits_clean(roster, history, store):
 # --- the roster itself is unreadable → still not a clean fleet -------------
 
 
-def test_unreadable_roster_is_reported(history, store, tmp_path):
+def test_unreadable_roster_is_reported(history, events, tmp_path):
     # Arrange — the registry cannot be enumerated, so we do not know which
     # agents SHOULD have been observed. An empty roster here would silently
     # certify that nobody is missing.
     rec = Recorder()
     # Act
     outcome = _run(
-        {"writer": (OK, OK)}, history, store, rec, specs_dir=tmp_path / "not-there"
+        {"writer": (OK, OK)}, history, events, rec, specs_dir=tmp_path / "not-there"
     )
     # Assert
     assert [r.reason for r in outcome.reports] == ["roster-unreadable"]
 
 
-def test_unreadable_roster_makes_the_pass_could_not_determine(history, store, tmp_path):
+def test_unreadable_roster_makes_the_pass_could_not_determine(
+    history, events, tmp_path
+):
     # Arrange — every pane we did read came back clean, which is exactly the
     # shape that must NOT be allowed to look like a healthy fleet: we cannot
     # say we observed everyone without knowing who everyone is.
     rec = Recorder()
     # Act
     outcome = _run(
-        {"writer": (OK, OK)}, history, store, rec, specs_dir=tmp_path / "not-there"
+        {"writer": (OK, OK)}, history, events, rec, specs_dir=tmp_path / "not-there"
     )
     # Assert
     assert outcome.exit_code() == 2

--- a/tests/scitex_agent_container/_authheal/test__pass_auth_events.py
+++ b/tests/scitex_agent_container/_authheal/test__pass_auth_events.py
@@ -44,7 +44,7 @@ def _events(path: Path, kind: str) -> list:
 
 
 def test_a_restart_that_does_not_take_effect_is_visible_as_unresolved(
-    tmp_path: Path, history: Path, store: str
+    tmp_path: Path, history: Path, events: Path
 ) -> None:
     """THE test: a restart that ran and did not work must be refutable.
 
@@ -62,7 +62,7 @@ def test_a_restart_that_does_not_take_effect_is_visible_as_unresolved(
         apply=True,
         now=NOW,
         history_file=history,
-        store=store,
+        events_path=events,
         alarm=False,
         restart_fn=recorder,
         capture_fn=lambda: stuck("figrecipe"),
@@ -75,7 +75,7 @@ def test_a_restart_that_does_not_take_effect_is_visible_as_unresolved(
 
 
 def test_the_attempt_and_the_outcome_are_two_separate_records(
-    tmp_path: Path, history: Path, store: str
+    tmp_path: Path, history: Path, events: Path
 ) -> None:
     """Conflating them is the exact defect this rail exists to prevent.
 
@@ -91,7 +91,7 @@ def test_the_attempt_and_the_outcome_are_two_separate_records(
         apply=True,
         now=NOW,
         history_file=history,
-        store=store,
+        events_path=events,
         alarm=False,
         restart_fn=recorder,
         capture_fn=lambda: stuck("figrecipe"),
@@ -105,7 +105,7 @@ def test_the_attempt_and_the_outcome_are_two_separate_records(
 
 
 def test_the_failed_outcome_records_that_it_did_not_succeed(
-    tmp_path: Path, history: Path, store: str
+    tmp_path: Path, history: Path, events: Path
 ) -> None:
     """The outcome must carry the refutation explicitly, not by omission."""
     # Arrange
@@ -117,7 +117,7 @@ def test_the_failed_outcome_records_that_it_did_not_succeed(
         apply=True,
         now=NOW,
         history_file=history,
-        store=store,
+        events_path=events,
         alarm=False,
         restart_fn=recorder,
         capture_fn=lambda: stuck("figrecipe"),
@@ -129,7 +129,7 @@ def test_the_failed_outcome_records_that_it_did_not_succeed(
 
 
 def test_a_successful_restart_leaves_nothing_unresolved(
-    tmp_path: Path, history: Path, store: str
+    tmp_path: Path, history: Path, events: Path
 ) -> None:
     """The refutation query must be able to come back clean.
 
@@ -145,7 +145,7 @@ def test_a_successful_restart_leaves_nothing_unresolved(
         apply=True,
         now=NOW,
         history_file=history,
-        store=store,
+        events_path=events,
         alarm=False,
         restart_fn=recorder,
         capture_fn=lambda: stuck("figrecipe"),
@@ -157,7 +157,7 @@ def test_a_successful_restart_leaves_nothing_unresolved(
 
 
 def test_the_attempt_is_recorded_before_the_outcome(
-    tmp_path: Path, history: Path, store: str
+    tmp_path: Path, history: Path, events: Path
 ) -> None:
     """Order is load-bearing: intent is written BEFORE the act it describes.
 
@@ -174,7 +174,7 @@ def test_the_attempt_is_recorded_before_the_outcome(
         apply=True,
         now=NOW,
         history_file=history,
-        store=store,
+        events_path=events,
         alarm=False,
         restart_fn=recorder,
         capture_fn=lambda: stuck("figrecipe"),
@@ -191,7 +191,7 @@ def test_the_attempt_is_recorded_before_the_outcome(
 
 
 def test_a_raising_restart_still_leaves_an_attempt_and_a_failed_outcome(
-    tmp_path: Path, history: Path, store: str
+    tmp_path: Path, history: Path, events: Path
 ) -> None:
     """An exception is an outcome too, and a failed one.
 
@@ -207,7 +207,7 @@ def test_a_raising_restart_still_leaves_an_attempt_and_a_failed_outcome(
         apply=True,
         now=NOW,
         history_file=history,
-        store=store,
+        events_path=events,
         alarm=False,
         restart_fn=recorder,
         capture_fn=lambda: stuck("figrecipe"),
@@ -219,7 +219,7 @@ def test_a_raising_restart_still_leaves_an_attempt_and_a_failed_outcome(
 
 
 def test_the_wedge_is_observed_before_any_restart_decision(
-    tmp_path: Path, history: Path, store: str
+    tmp_path: Path, history: Path, events: Path
 ) -> None:
     """What we SAW is recorded first, and separately from what we DID.
 
@@ -235,7 +235,7 @@ def test_the_wedge_is_observed_before_any_restart_decision(
         apply=True,
         now=NOW,
         history_file=history,
-        store=store,
+        events_path=events,
         alarm=False,
         restart_fn=recorder,
         capture_fn=lambda: stuck("figrecipe"),
@@ -247,7 +247,7 @@ def test_the_wedge_is_observed_before_any_restart_decision(
 
 
 def test_a_check_run_observes_the_wedge_but_attempts_no_restart(
-    tmp_path: Path, history: Path, store: str
+    tmp_path: Path, history: Path, events: Path
 ) -> None:
     """Observing is not acting. A dry run that saw a wedge really did see it.
 
@@ -265,7 +265,7 @@ def test_a_check_run_observes_the_wedge_but_attempts_no_restart(
         apply=False,
         now=NOW,
         history_file=history,
-        store=store,
+        events_path=events,
         alarm=False,
         restart_fn=recorder,
         capture_fn=lambda: stuck("figrecipe"),
@@ -278,7 +278,7 @@ def test_a_check_run_observes_the_wedge_but_attempts_no_restart(
 
 
 def test_each_wedged_agent_gets_its_own_attempt_id(
-    tmp_path: Path, history: Path, store: str
+    tmp_path: Path, history: Path, events: Path
 ) -> None:
     """Six agents dying together must be six traceable stories, not one blur.
 
@@ -294,7 +294,7 @@ def test_each_wedged_agent_gets_its_own_attempt_id(
         apply=True,
         now=NOW,
         history_file=history,
-        store=store,
+        events_path=events,
         alarm=False,
         restart_fn=recorder,
         capture_fn=lambda: stuck("figrecipe", "crossref-local"),
@@ -307,7 +307,7 @@ def test_each_wedged_agent_gets_its_own_attempt_id(
 
 
 def test_an_unresolvable_account_is_recorded_as_null_not_guessed(
-    tmp_path: Path, history: Path, store: str
+    tmp_path: Path, history: Path, events: Path
 ) -> None:
     """The registry here is empty, so the account is genuinely undeterminable.
 
@@ -324,7 +324,7 @@ def test_an_unresolvable_account_is_recorded_as_null_not_guessed(
         apply=True,
         now=NOW,
         history_file=history,
-        store=store,
+        events_path=events,
         alarm=False,
         restart_fn=recorder,
         capture_fn=lambda: stuck("figrecipe"),
@@ -337,7 +337,7 @@ def test_an_unresolvable_account_is_recorded_as_null_not_guessed(
 
 
 def test_an_unwritable_event_log_does_not_stop_the_restart(
-    tmp_path: Path, history: Path, store: str
+    tmp_path: Path, history: Path, events: Path
 ) -> None:
     """FAIL-OPEN, proved end to end against a really read-only directory.
 
@@ -356,7 +356,7 @@ def test_an_unwritable_event_log_does_not_stop_the_restart(
             apply=True,
             now=NOW,
             history_file=history,
-            store=store,
+            events_path=events,
             alarm=False,
             restart_fn=recorder,
             capture_fn=lambda: stuck("figrecipe"),
@@ -370,7 +370,7 @@ def test_an_unwritable_event_log_does_not_stop_the_restart(
 
 
 def test_a_healthy_fleet_writes_no_auth_events(
-    tmp_path: Path, history: Path, store: str
+    tmp_path: Path, history: Path, events: Path
 ) -> None:
     """Silence means nothing was seen — the log must not invent activity.
 
@@ -386,7 +386,7 @@ def test_a_healthy_fleet_writes_no_auth_events(
         apply=True,
         now=NOW,
         history_file=history,
-        store=store,
+        events_path=events,
         alarm=False,
         restart_fn=recorder,
         capture_fn=dict,

--- a/tests/scitex_agent_container/_events/__init__.py
+++ b/tests/scitex_agent_container/_events/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for sac's own append-only operational event log."""

--- a/tests/scitex_agent_container/_events/test__log.py
+++ b/tests/scitex_agent_container/_events/test__log.py
@@ -1,0 +1,489 @@
+"""Tests for ``_events._log`` — the record sac keeps of sac's own decisions.
+
+PA-306: no ``unittest.mock``, no monkeypatching. Every test drives a REAL
+JSONL file in ``tmp_path`` through the module's own ``path=`` seam, reads the
+bytes back through the production :func:`read_events`, and injects a real
+:class:`io.StringIO` where the module expects stderr. The fail-loud leg breaks
+the write ORGANICALLY (a read-only parent directory) rather than injecting a
+raiser — the world says no; nothing is faked.
+
+The behaviours that matter:
+
+* a record round-trips: what was written is what a reader gets back;
+* ``subject`` / ``subject_kind`` / ``verdict`` are PRESENT-and-null when they
+  do not apply, because an absent field ("nobody thought to record it") and a
+  null one ("we looked and could not tell") are different facts;
+* an unrecognised event name is still recorded but FLAGGED, so a reader can
+  tell a new event type from a typo;
+* a write that cannot happen returns ``False``, SHOUTS, and never raises —
+  losing a log line is bad, losing the pass that line described is worse;
+* :func:`log_pass_completed` carries the ``mode`` and the ``counts``, which is
+  the only thing distinguishing a healthy fleet from a timer that died.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from scitex_agent_container._events import (
+    EVENT_LOG_ENV,
+    PASS_COMPLETED,
+    SELF_IMPAIRED,
+    SUBJECT_DEGRADED,
+    event_log_path,
+    log_event,
+    log_pass_completed,
+    read_events,
+)
+
+#: A fixed clock, so no test can be flaky on time and the stamp is assertable.
+NOW = 1_800_000_000.0
+
+
+def _log(tmp_path: Path) -> Path:
+    """The event log this test writes to. Absent until something writes."""
+    return tmp_path / "sac-events.jsonl"
+
+
+def _readonly(tmp_path: Path) -> Path:
+    """An event-log path inside a REALLY read-only dir. No mocks."""
+    denied = tmp_path / "denied"
+    denied.mkdir()
+    denied.chmod(0o555)
+    return denied / "sac-events.jsonl"
+
+
+# --- a record round-trips ---------------------------------------------------
+
+
+def test_a_recorded_event_round_trips_back(tmp_path: Path) -> None:
+    # Arrange
+    log = _log(tmp_path)
+    # Act
+    log_event(
+        event=SUBJECT_DEGRADED,
+        subsystem="host-sync",
+        subject="spartan",
+        subject_kind="peer",
+        verdict="behind",
+        detail="spartan is 4 commits behind the centre",
+        path=log,
+        now=NOW,
+    )
+    # Assert
+    assert read_events(log)[0].event == SUBJECT_DEGRADED
+
+
+def test_the_record_names_its_subsystem(tmp_path: Path) -> None:
+    # Arrange — subsystem is the axis a reader filters on FIRST when asking
+    # "did my timer run, and what did it decide".
+    log = _log(tmp_path)
+    # Act
+    log_event(
+        event=SUBJECT_DEGRADED, subsystem="host-sync", detail="d", path=log, now=NOW
+    )
+    # Assert
+    assert read_events(log)[0].subsystem == "host-sync"
+
+
+def test_the_record_names_the_subject(tmp_path: Path) -> None:
+    # Arrange — never silent: the operator must see WHICH peer.
+    log = _log(tmp_path)
+    # Act
+    log_event(
+        event=SUBJECT_DEGRADED,
+        subsystem="host-sync",
+        subject="spartan",
+        detail="d",
+        path=log,
+        now=NOW,
+    )
+    # Assert
+    assert read_events(log)[0].subject == "spartan"
+
+
+def test_the_pass_verdict_is_kept_verbatim(tmp_path: Path) -> None:
+    # Arrange — a verdict translated on the way in can no longer be compared
+    # against the code that produced it, so it rides through unmapped.
+    log = _log(tmp_path)
+    # Act
+    log_event(
+        event=SUBJECT_DEGRADED,
+        subsystem="host-sync",
+        verdict="behind",
+        detail="d",
+        path=log,
+        now=NOW,
+    )
+    # Assert
+    assert read_events(log)[0].verdict == "behind"
+
+
+def test_the_detail_line_survives_the_round_trip(tmp_path: Path) -> None:
+    # Arrange
+    log = _log(tmp_path)
+    # Act
+    log_event(
+        event=SUBJECT_DEGRADED,
+        subsystem="host-sync",
+        detail="spartan is NOT running the centre's code",
+        path=log,
+        now=NOW,
+    )
+    # Assert
+    assert read_events(log)[0].detail == "spartan is NOT running the centre's code"
+
+
+def test_extra_fields_ride_along_as_fields(tmp_path: Path) -> None:
+    # Arrange — fields are queryable; a sentence is not.
+    log = _log(tmp_path)
+    # Act
+    log_event(
+        event=SUBJECT_DEGRADED,
+        subsystem="host-sync",
+        detail="d",
+        extra={"target": "origin/develop"},
+        path=log,
+        now=NOW,
+    )
+    # Assert
+    assert read_events(log)[0].raw["target"] == "origin/develop"
+
+
+def test_the_injected_clock_stamps_the_record(tmp_path: Path) -> None:
+    # Arrange — a fixed clock makes the stamp assertable without sleeping.
+    log = _log(tmp_path)
+    # Act
+    log_event(
+        event=SUBJECT_DEGRADED, subsystem="host-sync", detail="d", path=log, now=0.0
+    )
+    # Assert
+    assert read_events(log)[0].timestamp_utc == "1970-01-01T00:00:00+00:00"
+
+
+def test_two_records_append_rather_than_replace(tmp_path: Path) -> None:
+    # Arrange — append-only is the whole contract: a log that overwrote its
+    # last line would keep only the least interesting fact it ever held.
+    log = _log(tmp_path)
+    log_event(event=SELF_IMPAIRED, subsystem="a", detail="1", path=log, now=NOW)
+    # Act
+    log_event(event=SELF_IMPAIRED, subsystem="a", detail="2", path=log, now=NOW)
+    # Assert
+    assert [e.detail for e in read_events(log)] == ["1", "2"]
+
+
+# --- tri-state: present-and-null is a DIFFERENT fact from absent ------------
+
+
+def test_an_inapplicable_subject_is_present_and_null(tmp_path: Path) -> None:
+    # Arrange — a fleet-wide fact belongs to no single subject. The key must
+    # still be there: an absent field says nobody thought to record it, a null
+    # one says we looked and it does not apply.
+    log = _log(tmp_path)
+    # Act
+    log_event(event=SELF_IMPAIRED, subsystem="fleet-reconcile", detail="d", path=log)
+    # Assert — ``"MISSING"`` can only survive if the key is absent.
+    assert read_events(log)[0].raw.get("subject", "MISSING") is None
+
+
+def test_an_inapplicable_subject_kind_is_present_and_null(tmp_path: Path) -> None:
+    # Arrange
+    log = _log(tmp_path)
+    # Act
+    log_event(event=SELF_IMPAIRED, subsystem="fleet-reconcile", detail="d", path=log)
+    # Assert
+    assert read_events(log)[0].raw.get("subject_kind", "MISSING") is None
+
+
+def test_an_inapplicable_verdict_is_present_and_null(tmp_path: Path) -> None:
+    # Arrange
+    log = _log(tmp_path)
+    # Act
+    log_event(event=SELF_IMPAIRED, subsystem="fleet-reconcile", detail="d", path=log)
+    # Assert
+    assert read_events(log)[0].raw.get("verdict", "MISSING") is None
+
+
+# --- the event vocabulary is closed, but forward-compatible ----------------
+
+
+def test_an_unrecognised_event_is_flagged_unknown(tmp_path: Path) -> None:
+    # Arrange — a record we do not recognise is evidence too, so it is still
+    # written; the flag is what lets a reader tell a NEW event from a TYPO.
+    log = _log(tmp_path)
+    # Act
+    log_event(event="subject-degrded", subsystem="host-sync", detail="d", path=log)
+    # Assert
+    assert read_events(log)[0].raw["event_known"] is False
+
+
+def test_an_unrecognised_event_is_still_recorded(tmp_path: Path) -> None:
+    # Arrange — flagging it must not mean dropping it.
+    log = _log(tmp_path)
+    # Act
+    log_event(event="subject-degrded", subsystem="host-sync", detail="d", path=log)
+    # Assert
+    assert read_events(log)[0].event == "subject-degrded"
+
+
+def test_a_known_event_carries_no_unknown_flag(tmp_path: Path) -> None:
+    # Arrange — the counterpart: if every record were flagged the flag would
+    # measure nothing.
+    log = _log(tmp_path)
+    # Act
+    log_event(event=SUBJECT_DEGRADED, subsystem="host-sync", detail="d", path=log)
+    # Assert
+    assert "event_known" not in read_events(log)[0].raw
+
+
+# --- fail-open, but NEVER silent -------------------------------------------
+
+
+def test_an_unwritable_path_reports_failure(tmp_path: Path) -> None:
+    # Arrange — a read-only parent dir: the world says no, nothing injected.
+    log = _readonly(tmp_path)
+    try:
+        # Act
+        written = log_event(
+            event=SUBJECT_DEGRADED,
+            subsystem="host-sync",
+            subject="spartan",
+            detail="d",
+            path=log,
+            err_stream=io.StringIO(),
+        )
+        # Assert
+        assert written is False
+    finally:
+        log.parent.chmod(0o755)
+
+
+def test_an_unwritable_path_prints_loudly(tmp_path: Path) -> None:
+    # Arrange — a logging rail that can fail QUIETLY is worse than no rail,
+    # because it is believed. The rail reports its own failure.
+    log = _readonly(tmp_path)
+    stream = io.StringIO()
+    try:
+        # Act
+        log_event(
+            event=SUBJECT_DEGRADED,
+            subsystem="host-sync",
+            subject="spartan",
+            detail="d",
+            path=log,
+            err_stream=stream,
+        )
+        # Assert
+        assert "[sac-events] FAILED to record" in stream.getvalue()
+    finally:
+        log.parent.chmod(0o755)
+
+
+def test_the_loud_line_names_the_lost_subject(tmp_path: Path) -> None:
+    # Arrange — "a write failed" is a number; "spartan's drift is now
+    # unrecorded" is an instruction.
+    log = _readonly(tmp_path)
+    stream = io.StringIO()
+    try:
+        # Act
+        log_event(
+            event=SUBJECT_DEGRADED,
+            subsystem="host-sync",
+            subject="spartan",
+            detail="d",
+            path=log,
+            err_stream=stream,
+        )
+        # Assert
+        assert "host-sync/spartan" in stream.getvalue()
+    finally:
+        log.parent.chmod(0o755)
+
+
+def test_an_unwritable_path_never_raises(tmp_path: Path) -> None:
+    # Arrange — FAIL-OPEN is the contract: the thing observed always outranks
+    # the observing of it. Reaching the assertion at all is the proof.
+    log = _readonly(tmp_path)
+    try:
+        # Act
+        written = log_event(
+            event=SUBJECT_DEGRADED,
+            subsystem="host-sync",
+            detail="d",
+            path=log,
+            err_stream=io.StringIO(),
+        )
+        # Assert
+        assert isinstance(written, bool)
+    finally:
+        log.parent.chmod(0o755)
+
+
+def test_a_successful_write_reports_success(tmp_path: Path) -> None:
+    # Arrange — the counterpart to the failure legs above.
+    log = _log(tmp_path)
+    # Act
+    written = log_event(
+        event=SUBJECT_DEGRADED, subsystem="host-sync", detail="d", path=log
+    )
+    # Assert
+    assert written is True
+
+
+def test_a_successful_write_prints_nothing(tmp_path: Path) -> None:
+    # Arrange — a rail that shouts on every healthy tick trains its reader to
+    # ignore it, which is how the one line that mattered got scrolled past.
+    log = _log(tmp_path)
+    stream = io.StringIO()
+    # Act
+    log_event(
+        event=SUBJECT_DEGRADED,
+        subsystem="host-sync",
+        detail="d",
+        path=log,
+        err_stream=stream,
+    )
+    # Assert
+    assert stream.getvalue() == ""
+
+
+def test_a_missing_parent_directory_is_created(tmp_path: Path) -> None:
+    # Arrange — a first-ever write on a fresh host must not need a mkdir by
+    # hand; a rail that needs installing is a rail that is not installed.
+    log = tmp_path / "never" / "existed" / "sac-events.jsonl"
+    # Act
+    log_event(event=SUBJECT_DEGRADED, subsystem="host-sync", detail="d", path=log)
+    # Assert
+    assert read_events(log)[0].subsystem == "host-sync"
+
+
+# --- the pass record: proof the timer ticked at all ------------------------
+
+
+def test_pass_completed_uses_the_pass_event(tmp_path: Path) -> None:
+    # Arrange
+    log = _log(tmp_path)
+    # Act
+    log_pass_completed(subsystem="fleet-reconcile", mode="apply", path=log, now=NOW)
+    # Assert
+    assert read_events(log)[0].event == PASS_COMPLETED
+
+
+def test_pass_completed_records_the_mode(tmp_path: Path) -> None:
+    # Arrange — load-bearing, not cosmetic: a hand-run dry run writes this
+    # record too, so a reader who ignores ``mode`` can believe a scheduled
+    # timer is alive on the strength of somebody running the command by hand.
+    log = _log(tmp_path)
+    # Act
+    log_pass_completed(subsystem="fleet-reconcile", mode="dry-run", path=log, now=NOW)
+    # Assert
+    assert read_events(log)[0].raw["mode"] == "dry-run"
+
+
+def test_pass_completed_records_the_counts(tmp_path: Path) -> None:
+    # Arrange — the counts carry EVERY verdict the pass reached, including the
+    # ones that get no per-subject record of their own.
+    log = _log(tmp_path)
+    # Act
+    log_pass_completed(
+        subsystem="fleet-reconcile",
+        mode="apply",
+        counts={"OK": 90, "RESTARTED": 3},
+        path=log,
+        now=NOW,
+    )
+    # Assert
+    assert read_events(log)[0].raw["counts"] == {"OK": 90, "RESTARTED": 3}
+
+
+def test_a_clean_pass_still_records_its_counts(tmp_path: Path) -> None:
+    # Arrange — "0 restarted, all healthy" is the MOST important record there
+    # is: a rail that only writes during trouble cannot tell HEALTHY from DEAD.
+    log = _log(tmp_path)
+    # Act
+    log_pass_completed(subsystem="fleet-reconcile", mode="apply", path=log, now=NOW)
+    # Assert
+    assert read_events(log)[0].raw["counts"] == {}
+
+
+def test_pass_completed_failure_does_not_raise(tmp_path: Path) -> None:
+    # Arrange — the beacon is a SIDE rail; it must never take the pass down.
+    log = _readonly(tmp_path)
+    try:
+        # Act
+        written = log_pass_completed(
+            subsystem="fleet-reconcile",
+            mode="apply",
+            path=log,
+            err_stream=io.StringIO(),
+        )
+        # Assert
+        assert written is False
+    finally:
+        log.parent.chmod(0o755)
+
+
+# --- reading -----------------------------------------------------------------
+
+
+def test_read_events_filters_by_subsystem(tmp_path: Path) -> None:
+    # Arrange — one log holds every pass; the subsystem is how a reader asks
+    # about ONE timer.
+    log = _log(tmp_path)
+    log_event(event=SUBJECT_DEGRADED, subsystem="host-sync", detail="a", path=log)
+    log_event(event=SUBJECT_DEGRADED, subsystem="worktree-gc", detail="b", path=log)
+    # Act
+    found = read_events(log, subsystem="worktree-gc")
+    # Assert
+    assert [e.detail for e in found] == ["b"]
+
+
+def test_read_events_filters_by_event(tmp_path: Path) -> None:
+    # Arrange
+    log = _log(tmp_path)
+    log_event(event=SUBJECT_DEGRADED, subsystem="host-sync", detail="a", path=log)
+    log_pass_completed(subsystem="host-sync", mode="apply", path=log)
+    # Act
+    found = read_events(log, event=PASS_COMPLETED)
+    # Assert
+    assert [e.event for e in found] == [PASS_COMPLETED]
+
+
+def test_a_missing_log_reads_as_empty(tmp_path: Path) -> None:
+    # Arrange — a missing log is an empty READING, never an error. It is also
+    # not evidence that no pass ran, and this function cannot tell those apart.
+    # Act
+    found = read_events(tmp_path / "never-written.jsonl")
+    # Assert
+    assert found == []
+
+
+def test_a_corrupt_line_does_not_hide_the_good_ones(tmp_path: Path) -> None:
+    # Arrange — a half-written line (a pass killed mid-write) must not blind a
+    # reader to the thousands of records around it during an incident.
+    log = _log(tmp_path)
+    log_event(event=SUBJECT_DEGRADED, subsystem="host-sync", detail="good", path=log)
+    with log.open("a", encoding="utf-8") as handle:
+        handle.write('{"event": "subject-deg\n')
+    # Act
+    found = read_events(log)
+    # Assert
+    assert [e.detail for e in found] == ["good"]
+
+
+# --- where the log lives ----------------------------------------------------
+
+
+def test_the_env_var_redirects_the_log_path(tmp_path: Path, env_save_restore) -> None:
+    # Arrange — resolved PER CALL, never cached at import: a constant computed
+    # at import cannot be redirected by an env var a test sets afterwards,
+    # which is how a suite ends up writing into the REAL fleet runtime dir.
+    redirected = tmp_path / "elsewhere" / "sac-events.jsonl"
+    env_save_restore.set(EVENT_LOG_ENV, str(redirected))
+    # Act
+    resolved = event_log_path()
+    # Assert
+    assert resolved == redirected

--- a/tests/scitex_agent_container/_events/test__verdicts.py
+++ b/tests/scitex_agent_container/_events/test__verdicts.py
@@ -1,0 +1,601 @@
+"""Tests for ``_events._verdicts`` — the ONE routing every sac pass shares.
+
+PA-306: no ``unittest.mock``, no monkeypatching. Real
+:class:`SubjectVerdict` values, a REAL JSONL log in ``tmp_path`` driven
+through the module's own ``path=`` seam, a real ``io.StringIO`` where the
+module expects stderr, and every assertion reads the bytes back through the
+production :func:`read_events`. The fail-loud leg breaks the write
+ORGANICALLY (a read-only parent dir) rather than injecting a raiser.
+
+The behaviours that matter:
+
+* THREE STATES, NEVER TWO — UNKNOWN is recorded as its own event and can
+  never be mistaken for, or folded into, RECOVERED. "I could not look" must
+  never read as "I looked and it was fine";
+* DEGRADED and UNKNOWN are recorded on EVERY pass, because an ongoing problem
+  is an ongoing fact and a log that mentions a wedged agent once then goes
+  quiet is indistinguishable from a log written by a pass that died;
+* HEALTHY is recorded only on the TRANSITION out of a remembered bad state —
+  otherwise ~100 agents would enter the log every five minutes forever and
+  bury the events that matter;
+* a subject whose record could not be written lands in ``failed`` INSTEAD of
+  its state bucket, because sac cannot claim to have recorded what it did not.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from scitex_agent_container._events import (
+    SELF_IMPAIRED,
+    SELF_RECOVERED,
+    SUBJECT_DEGRADED,
+    SUBJECT_RECOVERED,
+    SUBJECT_UNKNOWN,
+    EmitOutcome,
+    SubjectState,
+    SubjectVerdict,
+    degraded_state_path,
+    emit_self_state,
+    emit_subject_verdicts,
+    read_events,
+    recover_absent_subjects,
+    self_state_path,
+)
+
+#: A fixed clock, so no test can be flaky on time.
+NOW = 1_800_000_000.0
+
+SUBSYSTEM = "host-sync"
+
+
+def _log(tmp_path: Path) -> Path:
+    """The event log this test writes to. Absent until something writes."""
+    return tmp_path / "sac-events.jsonl"
+
+
+def _readonly(tmp_path: Path) -> Path:
+    """An event-log path inside a REALLY read-only dir. No mocks."""
+    denied = tmp_path / "denied"
+    denied.mkdir()
+    denied.chmod(0o555)
+    return denied / "sac-events.jsonl"
+
+
+def _degraded(subject: str = "spartan") -> SubjectVerdict:
+    return SubjectVerdict(
+        subject=subject,
+        state=SubjectState.DEGRADED,
+        verdict="behind",
+        detail=f"{subject} is NOT running the centre's code",
+        subject_kind="peer",
+    )
+
+
+def _healthy(subject: str = "spartan") -> SubjectVerdict:
+    return SubjectVerdict(
+        subject=subject,
+        state=SubjectState.HEALTHY,
+        verdict="current",
+        detail=f"{subject} matches the centre",
+        subject_kind="peer",
+    )
+
+
+def _unknown(subject: str = "nas") -> SubjectVerdict:
+    return SubjectVerdict(
+        subject=subject,
+        state=SubjectState.UNKNOWN,
+        verdict="unreachable",
+        detail=f"could not verify {subject} against the centre",
+        subject_kind="peer",
+    )
+
+
+def _kinds(log: Path) -> list[str]:
+    return [e.event for e in read_events(log)]
+
+
+# --- a degraded subject is recorded, every pass ------------------------------
+
+
+def test_a_degraded_subject_is_recorded(tmp_path: Path) -> None:
+    # Arrange
+    log = _log(tmp_path)
+    # Act
+    emit_subject_verdicts(SUBSYSTEM, [_degraded()], path=log, now=NOW)
+    # Assert
+    assert _kinds(log) == [SUBJECT_DEGRADED]
+
+
+def test_the_degraded_record_names_the_subject(tmp_path: Path) -> None:
+    # Arrange — never silent: a reader must see WHICH peer.
+    log = _log(tmp_path)
+    # Act
+    emit_subject_verdicts(SUBSYSTEM, [_degraded("spartan")], path=log, now=NOW)
+    # Assert
+    assert read_events(log)[0].subject == "spartan"
+
+
+def test_the_degraded_record_keeps_the_pass_verdict(tmp_path: Path) -> None:
+    # Arrange — the pass's own token, verbatim and unmapped.
+    log = _log(tmp_path)
+    # Act
+    emit_subject_verdicts(SUBSYSTEM, [_degraded()], path=log, now=NOW)
+    # Assert
+    assert read_events(log)[0].verdict == "behind"
+
+
+def test_the_degraded_record_carries_the_subject_kind(tmp_path: Path) -> None:
+    # Arrange — a peer, a repo and an agent are not the same population.
+    log = _log(tmp_path)
+    # Act
+    emit_subject_verdicts(SUBSYSTEM, [_degraded()], path=log, now=NOW)
+    # Assert
+    assert read_events(log)[0].subject_kind == "peer"
+
+
+def test_an_ongoing_problem_is_recorded_every_pass(tmp_path: Path) -> None:
+    # Arrange — a log that mentions a wedged subject ONCE and then goes quiet
+    # cannot be told apart from a log written by a pass that died.
+    log = _log(tmp_path)
+    emit_subject_verdicts(SUBSYSTEM, [_degraded()], path=log, now=NOW)
+    # Act
+    emit_subject_verdicts(SUBSYSTEM, [_degraded()], path=log, now=NOW)
+    # Assert
+    assert _kinds(log) == [SUBJECT_DEGRADED, SUBJECT_DEGRADED]
+
+
+def test_the_degraded_subject_is_reported_to_the_caller(tmp_path: Path) -> None:
+    # Arrange
+    log = _log(tmp_path)
+    # Act
+    outcome = emit_subject_verdicts(SUBSYSTEM, [_degraded()], path=log, now=NOW)
+    # Assert
+    assert outcome.degraded == ("spartan",)
+
+
+# --- recovery is a TRANSITION, not a heartbeat per subject -------------------
+
+
+def test_degraded_then_healthy_records_one_recovery(tmp_path: Path) -> None:
+    # Arrange — THE transition test. The subject was recorded degraded, then
+    # it recovered: exactly one of each, in that order, and nothing else.
+    log = _log(tmp_path)
+    emit_subject_verdicts(SUBSYSTEM, [_degraded()], path=log, now=NOW)
+    # Act
+    emit_subject_verdicts(SUBSYSTEM, [_healthy()], path=log, now=NOW)
+    # Assert
+    assert _kinds(log) == [SUBJECT_DEGRADED, SUBJECT_RECOVERED]
+
+
+def test_the_recovery_is_reported_to_the_caller(tmp_path: Path) -> None:
+    # Arrange
+    log = _log(tmp_path)
+    emit_subject_verdicts(SUBSYSTEM, [_degraded()], path=log, now=NOW)
+    # Act
+    outcome = emit_subject_verdicts(SUBSYSTEM, [_healthy()], path=log, now=NOW)
+    # Assert
+    assert outcome.recovered == ("spartan",)
+
+
+def test_a_never_degraded_healthy_subject_records_nothing(tmp_path: Path) -> None:
+    # Arrange — THE noise guard. Writing a record for every healthy subject on
+    # every pass would put ~100 agents into the log every five minutes forever
+    # and bury the events that matter under the ones that do not.
+    log = _log(tmp_path)
+    # Act
+    emit_subject_verdicts(SUBSYSTEM, [_healthy()], path=log, now=NOW)
+    # Assert — not "an empty log": no log at all was ever opened.
+    assert not log.exists()
+
+
+def test_a_healthy_subject_recovers_only_once(tmp_path: Path) -> None:
+    # Arrange — a fixed problem stops shouting, and stops announcing that it
+    # stopped shouting: the memory is discarded on the transition.
+    log = _log(tmp_path)
+    emit_subject_verdicts(SUBSYSTEM, [_degraded()], path=log, now=NOW)
+    emit_subject_verdicts(SUBSYSTEM, [_healthy()], path=log, now=NOW)
+    # Act
+    emit_subject_verdicts(SUBSYSTEM, [_healthy()], path=log, now=NOW)
+    # Assert
+    assert _kinds(log) == [SUBJECT_DEGRADED, SUBJECT_RECOVERED]
+
+
+def test_redegrading_after_a_recovery_records_again(tmp_path: Path) -> None:
+    # Arrange — degraded, then well again (memory cleared).
+    log = _log(tmp_path)
+    emit_subject_verdicts(SUBSYSTEM, [_degraded()], path=log, now=NOW)
+    emit_subject_verdicts(SUBSYSTEM, [_healthy()], path=log, now=NOW)
+    # Act — it goes bad AGAIN; the rail must re-fire, not stay silent.
+    emit_subject_verdicts(SUBSYSTEM, [_degraded()], path=log, now=NOW)
+    # Assert
+    assert _kinds(log) == [SUBJECT_DEGRADED, SUBJECT_RECOVERED, SUBJECT_DEGRADED]
+
+
+# --- THREE states, never two -------------------------------------------------
+
+
+def test_an_unknown_subject_is_recorded_as_unknown(tmp_path: Path) -> None:
+    # Arrange — "I could not look" must never read as "I looked and it was
+    # fine". UNKNOWN is deliberately its own event.
+    log = _log(tmp_path)
+    # Act
+    emit_subject_verdicts(SUBSYSTEM, [_unknown()], path=log, now=NOW)
+    # Assert
+    assert _kinds(log) == [SUBJECT_UNKNOWN]
+
+
+def test_an_unknown_subject_is_never_recorded_recovered(tmp_path: Path) -> None:
+    # Arrange — the durable false all-clear this rail exists to prevent: a
+    # record saying sac looked and found nothing wrong, on the strength of the
+    # pass having FAILED to look.
+    log = _log(tmp_path)
+    # Act
+    emit_subject_verdicts(SUBSYSTEM, [_unknown()], path=log, now=NOW)
+    # Assert
+    assert SUBJECT_RECOVERED not in _kinds(log)
+
+
+def test_unknown_and_degraded_are_separate_buckets(tmp_path: Path) -> None:
+    # Arrange — an unreadable peer is not a peer without drift; it is a peer
+    # whose drift sac failed to observe.
+    log = _log(tmp_path)
+    # Act
+    outcome = emit_subject_verdicts(
+        SUBSYSTEM, [_degraded("spartan"), _unknown("nas")], path=log, now=NOW
+    )
+    # Assert
+    assert (outcome.degraded, outcome.unknown) == (("spartan",), ("nas",))
+
+
+def test_a_remembered_unknown_subject_can_recover(tmp_path: Path) -> None:
+    # Arrange — an unobserved subject is remembered like a degraded one, so
+    # becoming readable-and-well is a real transition worth recording.
+    log = _log(tmp_path)
+    emit_subject_verdicts(SUBSYSTEM, [_unknown("nas")], path=log, now=NOW)
+    # Act
+    emit_subject_verdicts(SUBSYSTEM, [_healthy("nas")], path=log, now=NOW)
+    # Assert
+    assert _kinds(log) == [SUBJECT_UNKNOWN, SUBJECT_RECOVERED]
+
+
+# --- the memory file sits BESIDE the log it annotates ------------------------
+
+
+def test_the_degraded_memory_sits_beside_the_log(tmp_path: Path) -> None:
+    # Arrange — redirecting the log in a test (or on an operator's host) must
+    # carry its state with it automatically, or a suite silently shares one
+    # memory file with the live fleet.
+    log = _log(tmp_path)
+    # Act
+    state_file = degraded_state_path(SUBSYSTEM, path=log)
+    # Assert
+    assert state_file == tmp_path / f"sac-events-{SUBSYSTEM}-degraded.json"
+
+
+def test_the_degraded_memory_is_persisted(tmp_path: Path) -> None:
+    # Arrange — the transition rule needs the memory to survive the process:
+    # the passes run as separate processes on a timer.
+    log = _log(tmp_path)
+    # Act
+    emit_subject_verdicts(SUBSYSTEM, [_degraded()], path=log, now=NOW)
+    # Assert
+    assert "spartan" in degraded_state_path(SUBSYSTEM, path=log).read_text()
+
+
+def test_a_corrupt_memory_file_is_reported_loudly(tmp_path: Path) -> None:
+    # Arrange — a memory sac cannot read means sac has forgotten what it
+    # already reported and will re-report it. That must not be silent.
+    log = _log(tmp_path)
+    degraded_state_path(SUBSYSTEM, path=log).write_text("{not-json")
+    stream = io.StringIO()
+    # Act
+    emit_subject_verdicts(SUBSYSTEM, [_healthy()], path=log, now=NOW, err_stream=stream)
+    # Assert
+    assert "could not read" in stream.getvalue()
+
+
+def test_a_corrupt_memory_file_does_not_raise(tmp_path: Path) -> None:
+    # Arrange — the memory is an OPTIMISATION OF THE RECORD, never an input to
+    # a decision. Losing it costs one duplicated record, never the pass.
+    log = _log(tmp_path)
+    degraded_state_path(SUBSYSTEM, path=log).write_text("{not-json")
+    # Act
+    outcome = emit_subject_verdicts(
+        SUBSYSTEM, [_degraded()], path=log, now=NOW, err_stream=io.StringIO()
+    )
+    # Assert
+    assert outcome.degraded == ("spartan",)
+
+
+# --- fail-open: one unwritable file never suppresses the rest ----------------
+
+
+def test_an_unwritable_log_buckets_the_subject_as_failed(tmp_path: Path) -> None:
+    # Arrange — sac cannot claim to have recorded something it did not, so a
+    # failed subject lands in ``failed`` INSTEAD of its state bucket.
+    log = _readonly(tmp_path)
+    try:
+        # Act
+        outcome = emit_subject_verdicts(
+            SUBSYSTEM, [_degraded()], path=log, now=NOW, err_stream=io.StringIO()
+        )
+        # Assert
+        assert outcome.failed == ("spartan",)
+    finally:
+        log.parent.chmod(0o755)
+
+
+def test_an_unwritable_log_leaves_the_state_bucket_empty(tmp_path: Path) -> None:
+    # Arrange — the other half: a record that failed must not ALSO be counted
+    # as recorded, or the summary line becomes a comfortable lie.
+    log = _readonly(tmp_path)
+    try:
+        # Act
+        outcome = emit_subject_verdicts(
+            SUBSYSTEM, [_degraded()], path=log, now=NOW, err_stream=io.StringIO()
+        )
+        # Assert
+        assert outcome.degraded == ()
+    finally:
+        log.parent.chmod(0o755)
+
+
+def test_one_unwritable_record_does_not_suppress_the_rest(tmp_path: Path) -> None:
+    # Arrange — the whole log is unwritable, so BOTH subjects fail. Neither
+    # may be silently dropped from the outcome.
+    log = _readonly(tmp_path)
+    try:
+        # Act
+        outcome = emit_subject_verdicts(
+            SUBSYSTEM,
+            [_degraded("spartan"), _degraded("nas")],
+            path=log,
+            now=NOW,
+            err_stream=io.StringIO(),
+        )
+        # Assert
+        assert outcome.failed == ("spartan", "nas")
+    finally:
+        log.parent.chmod(0o755)
+
+
+def test_an_unwritable_log_is_reported_loudly(tmp_path: Path) -> None:
+    # Arrange — a failure nobody hears is the anti-pattern this rail exists
+    # to fix.
+    log = _readonly(tmp_path)
+    stream = io.StringIO()
+    try:
+        # Act
+        emit_subject_verdicts(
+            SUBSYSTEM, [_degraded()], path=log, now=NOW, err_stream=stream
+        )
+        # Assert
+        assert "FAILED to record" in stream.getvalue()
+    finally:
+        log.parent.chmod(0o755)
+
+
+# --- absence means recovery, and ONLY for a problem-list pass ----------------
+
+
+def test_absent_remembered_subject_is_recovered(tmp_path: Path) -> None:
+    # Arrange — for a pass that reports ONLY the subjects currently in a bad
+    # way, a remembered subject's absence IS the observation that it recovered.
+    log = _log(tmp_path)
+    emit_subject_verdicts(SUBSYSTEM, [_degraded("spartan")], path=log, now=NOW)
+    # Act
+    recover_absent_subjects(
+        SUBSYSTEM, [], detail="no longer drifted", path=log, now=NOW
+    )
+    # Assert
+    assert _kinds(log) == [SUBJECT_DEGRADED, SUBJECT_RECOVERED]
+
+
+def test_the_swept_subject_is_reported_to_the_caller(tmp_path: Path) -> None:
+    # Arrange
+    log = _log(tmp_path)
+    emit_subject_verdicts(SUBSYSTEM, [_degraded("spartan")], path=log, now=NOW)
+    # Act
+    outcome = recover_absent_subjects(
+        SUBSYSTEM, [], detail="no longer drifted", path=log, now=NOW
+    )
+    # Assert
+    assert outcome.recovered == ("spartan",)
+
+
+def test_a_still_present_subject_is_left_alone(tmp_path: Path) -> None:
+    # Arrange — two remembered subjects; this pass still reports one of them,
+    # so only the OTHER one has recovered. Sweeping the present one would be a
+    # false all-clear about a subject we can still see is broken.
+    log = _log(tmp_path)
+    emit_subject_verdicts(
+        SUBSYSTEM, [_degraded("spartan"), _degraded("nas")], path=log, now=NOW
+    )
+    # Act
+    outcome = recover_absent_subjects(
+        SUBSYSTEM, ["spartan"], detail="no longer drifted", path=log, now=NOW
+    )
+    # Assert
+    assert outcome.recovered == ("nas",)
+
+
+def test_the_present_subject_stays_remembered(tmp_path: Path) -> None:
+    # Arrange — the memory must still hold the subject this pass still sees,
+    # or its eventual recovery would go unrecorded.
+    log = _log(tmp_path)
+    emit_subject_verdicts(
+        SUBSYSTEM, [_degraded("spartan"), _degraded("nas")], path=log, now=NOW
+    )
+    # Act
+    recover_absent_subjects(
+        SUBSYSTEM, ["spartan"], detail="no longer drifted", path=log, now=NOW
+    )
+    # Assert
+    assert "spartan" in degraded_state_path(SUBSYSTEM, path=log).read_text()
+
+
+def test_sweeping_an_empty_memory_records_nothing(tmp_path: Path) -> None:
+    # Arrange — nothing was ever degraded, so nothing can have recovered. The
+    # sweep must not invent a record just because it ran.
+    log = _log(tmp_path)
+    # Act
+    recover_absent_subjects(
+        SUBSYSTEM, ["spartan"], detail="no longer drifted", path=log, now=NOW
+    )
+    # Assert
+    assert not log.exists()
+
+
+def test_the_swept_recovery_carries_its_verdict(tmp_path: Path) -> None:
+    # Arrange — the sweep's verdict token says HOW the recovery was concluded,
+    # which is different evidence from an observed clean reading.
+    log = _log(tmp_path)
+    emit_subject_verdicts(SUBSYSTEM, [_degraded("spartan")], path=log, now=NOW)
+    # Act
+    recover_absent_subjects(
+        SUBSYSTEM, [], detail="no longer drifted", verdict="absent", path=log, now=NOW
+    )
+    # Assert
+    assert read_events(log, event=SUBJECT_RECOVERED)[0].verdict == "absent"
+
+
+# --- sac's OWN state: a transition, never a per-tick assertion ---------------
+#
+# The stakes here are higher than for a subject. A pass runs every few minutes,
+# so recording "I am fine" on every tick would write hundreds of thousands of
+# records a year and, worse, would make SELF_RECOVERED mean nothing: a recovery
+# record has to mark an actual recovery, or it is not evidence of one.
+
+
+def test_a_self_impairment_is_recorded(tmp_path: Path) -> None:
+    # Arrange
+    log = _log(tmp_path)
+    # Act
+    emit_self_state(
+        SUBSYSTEM, impaired=True, detail="cannot read my own memory", path=log, now=NOW
+    )
+    # Assert
+    assert _kinds(log) == [SELF_IMPAIRED]
+
+
+def test_a_recovery_with_no_prior_impairment_records_nothing(tmp_path: Path) -> None:
+    # Arrange — the every-tick case: nothing was ever wrong.
+    log = _log(tmp_path)
+    # Act
+    emit_self_state(SUBSYSTEM, impaired=False, detail="fine", path=log, now=NOW)
+    # Assert — not an empty log: no log was ever opened.
+    assert not log.exists()
+
+
+def test_a_recovery_with_no_prior_impairment_reports_nothing_written(
+    tmp_path: Path,
+) -> None:
+    # Arrange — ``False`` means "nothing changed", never "the write failed".
+    log = _log(tmp_path)
+    # Act
+    written = emit_self_state(SUBSYSTEM, impaired=False, detail="fine", path=log)
+    # Assert
+    assert written is False
+
+
+def test_a_standing_impairment_is_recorded_every_pass(tmp_path: Path) -> None:
+    # Arrange — an ongoing refusal to act is an ongoing fact; a log that
+    # mentions it once and goes quiet reads like a log written by a dead pass.
+    log = _log(tmp_path)
+    emit_self_state(SUBSYSTEM, impaired=True, detail="still denied", path=log, now=NOW)
+    # Act
+    emit_self_state(SUBSYSTEM, impaired=True, detail="still denied", path=log, now=NOW)
+    # Assert
+    assert _kinds(log) == [SELF_IMPAIRED, SELF_IMPAIRED]
+
+
+def test_impaired_then_healthy_records_one_recovery(tmp_path: Path) -> None:
+    # Arrange
+    log = _log(tmp_path)
+    emit_self_state(SUBSYSTEM, impaired=True, detail="denied", path=log, now=NOW)
+    # Act
+    emit_self_state(
+        SUBSYSTEM, impaired=False, detail="readable again", path=log, now=NOW
+    )
+    # Assert
+    assert _kinds(log) == [SELF_IMPAIRED, SELF_RECOVERED]
+
+
+def test_a_second_recovery_records_nothing(tmp_path: Path) -> None:
+    # Arrange — impaired, then recovered (the transition is on the record).
+    log = _log(tmp_path)
+    emit_self_state(SUBSYSTEM, impaired=True, detail="denied", path=log, now=NOW)
+    emit_self_state(SUBSYSTEM, impaired=False, detail="ok", path=log, now=NOW)
+    # Act — the next tick is still healthy and must stay quiet.
+    emit_self_state(SUBSYSTEM, impaired=False, detail="ok", path=log, now=NOW)
+    # Assert
+    assert _kinds(log) == [SELF_IMPAIRED, SELF_RECOVERED]
+
+
+def test_reimpairment_after_a_recovery_records_again(tmp_path: Path) -> None:
+    # Arrange — impaired, then well again (memory cleared).
+    log = _log(tmp_path)
+    emit_self_state(SUBSYSTEM, impaired=True, detail="denied", path=log, now=NOW)
+    emit_self_state(SUBSYSTEM, impaired=False, detail="ok", path=log, now=NOW)
+    # Act — it breaks AGAIN; the rail must re-fire, not stay silent.
+    emit_self_state(SUBSYSTEM, impaired=True, detail="denied", path=log, now=NOW)
+    # Assert
+    assert _kinds(log) == [SELF_IMPAIRED, SELF_RECOVERED, SELF_IMPAIRED]
+
+
+def test_the_self_state_file_is_separate_from_the_subject_set(tmp_path: Path) -> None:
+    # Arrange — a pass's OWN health is not one of its subjects; sharing one
+    # file would need a reserved key a real subject could one day collide with.
+    log = _log(tmp_path)
+    # Act
+    paths = (
+        self_state_path(SUBSYSTEM, path=log),
+        degraded_state_path(SUBSYSTEM, path=log),
+    )
+    # Assert
+    assert paths[0] != paths[1]
+
+
+def test_an_unwritable_self_record_reports_failure(tmp_path: Path) -> None:
+    # Arrange — a SIDE rail: it must never crash the pass it observes.
+    log = _readonly(tmp_path)
+    try:
+        # Act
+        written = emit_self_state(
+            SUBSYSTEM,
+            impaired=True,
+            detail="denied",
+            path=log,
+            err_stream=io.StringIO(),
+        )
+        # Assert
+        assert written is False
+    finally:
+        log.parent.chmod(0o755)
+
+
+# --- the summary line: the caller is never silent ---------------------------
+
+
+def test_the_summary_line_counts_each_bucket(tmp_path: Path) -> None:
+    # Arrange
+    outcome = EmitOutcome(degraded=("a",), unknown=("b",), recovered=("c", "d"))
+    # Act
+    line = outcome.summary_line()
+    # Assert
+    assert line == "sac events: 1 degraded, 1 unknown, 2 recovered"
+
+
+def test_the_summary_line_shouts_about_unrecorded(tmp_path: Path) -> None:
+    # Arrange — a record that never reached the log is the one thing the
+    # summary must not be able to hide.
+    outcome = EmitOutcome(degraded=("a",), failed=("b",))
+    # Act
+    line = outcome.summary_line()
+    # Assert
+    assert "1 UNRECORDED" in line

--- a/tests/scitex_agent_container/_hostsync/test__alarm.py
+++ b/tests/scitex_agent_container/_hostsync/test__alarm.py
@@ -1,34 +1,45 @@
-"""Tests for ``_hostsync._alarm`` — drift verdict → SEEN scitex-todo card.
+"""Tests for ``_hostsync._alarm`` — drift verdict → a record in sac's own log.
 
-PA-306: no ``unittest.mock``. Real :class:`SyncResult` / :class:`PeerSyncReport`
-objects and a REAL temporary scitex-todo store (``tmp_path/tasks.yaml``);
-the routing calls the real ``scitex_todo`` writer and each test reads the
-card back through the real ``scitex_todo`` reader.
+PA-306: no ``unittest.mock``, no monkeypatching. Real :class:`SyncResult` /
+:class:`PeerSyncReport` objects and a REAL temporary JSONL event log
+(``tmp_path/sac-events.jsonl``) passed through the module's own ``path=``
+seam; every assertion reads the bytes back through the production
+:func:`read_events`.
 
 The behaviours that matter:
 
-* drift → an upserted BLOCKING-YOU card (``status=blocked`` /
-  ``blocker=operator-decision``) NAMING the peer,
-* a second drift run UPDATES in place (never duplicates),
-* a clean run RESOLVES the peer's card (a fixed drift stops shouting),
-* UNKNOWN is carded too but labelled UNKNOWN — never rendered as clean,
-* re-drift after a clear REOPENS the card.
+* drift → a DEGRADED record NAMING the peer and its concrete drift class,
+* a second drift run records AGAIN (an ongoing problem is an ongoing fact —
+  a rail that mentions a stale peer once then goes quiet is indistinguishable
+  from a rail that died),
+* a clean run RECORDS THE RECOVERY of a previously drifted peer, once,
+* UNDETERMINED is its own event — never rendered as clean,
+* re-drift after a recovery records again,
+* recording is a SIDE rail: an unwritable log is reported, never raised.
 
 Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
 """
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 
 import pytest
 
-from scitex_agent_container._hostsync import route_reports_to_cards
-from scitex_agent_container._hostsync._alarm import card_id_for
+from scitex_agent_container._events import (
+    SUBJECT_DEGRADED,
+    SUBJECT_RECOVERED,
+    SUBJECT_UNKNOWN,
+    read_events,
+)
+from scitex_agent_container._hostsync import record_reports
+from scitex_agent_container._hostsync._alarm import SUBSYSTEM
 from scitex_agent_container._hostsync._model import GraphState, PeerSyncReport
 from scitex_agent_container._hostsync._sync import Outcome, SyncResult
 
-scitex_todo = pytest.importorskip("scitex_todo")
+#: A fixed clock, so no test can be flaky on time.
+NOW = 1_800_000_000.0
 
 
 def _behind(peer: str = "spartan", behind: int = 4) -> SyncResult:
@@ -70,115 +81,160 @@ def _unreachable(peer: str = "nas") -> SyncResult:
 
 
 @pytest.fixture
-def store(tmp_path: Path) -> str:
-    """A real (initially absent) scitex-todo store path — no mocks."""
-    return str(tmp_path / "tasks.yaml")
+def events(tmp_path: Path) -> Path:
+    """A real (initially absent) sac event-log path — no mocks."""
+    return tmp_path / "sac-events.jsonl"
 
 
-def test_drift_upserts_a_blocking_you_card(store):
+@pytest.fixture
+def unwritable(tmp_path: Path):
+    """An event-log path the REAL writer genuinely cannot write. No mocks.
+
+    The parent dir is read-only, so the append fails the way it would on a
+    broken host — the world says no; nothing is injected.
+    """
+    readonly = tmp_path / "readonly"
+    readonly.mkdir()
+    readonly.chmod(0o555)
+    try:
+        yield readonly / "sac-events.jsonl"
+    finally:
+        readonly.chmod(0o755)
+
+
+def _kinds(events: Path) -> list[str]:
+    return [e.event for e in read_events(events, subsystem=SUBSYSTEM)]
+
+
+def test_drift_records_a_degraded_event(events):
     # Arrange — one peer 4 commits behind the centre.
     # Act
-    route_reports_to_cards([_behind("spartan")], store=store)
-    # Assert — it lands on the board's BLOCKING-YOU seen surface.
-    blocking = scitex_todo.list_tasks(store, blocking_me=True)
-    assert [t["id"] for t in blocking] == [card_id_for("spartan")]
+    record_reports([_behind("spartan")], path=events, now=NOW)
+    # Assert
+    assert _kinds(events) == [SUBJECT_DEGRADED]
 
 
-def test_drift_card_names_the_peer(store):
+def test_the_drift_record_names_the_peer(events):
     # Arrange
     # Act
-    route_reports_to_cards([_behind("spartan")], store=store)
-    # Assert — never silent: the operator must see WHICH peer.
-    card = scitex_todo.get_task(store, card_id_for("spartan"))
-    assert "spartan" in card["title"]
+    record_reports([_behind("spartan")], path=events, now=NOW)
+    # Assert — never silent: a reader must see WHICH peer.
+    assert read_events(events)[0].subject == "spartan"
 
 
-def test_drift_card_names_the_concrete_drift(store):
-    # Arrange — behind is the concrete drift class; the card must say so.
+def test_the_drift_record_names_the_concrete_drift(events):
+    # Arrange — "behind" is the concrete drift class; the record must say so.
     # Act
-    route_reports_to_cards([_behind("spartan", behind=4)], store=store)
+    record_reports([_behind("spartan", behind=4)], path=events, now=NOW)
     # Assert
-    card = scitex_todo.get_task(store, card_id_for("spartan"))
-    assert "behind" in card["note"].lower()
+    assert read_events(events)[0].verdict == "behind"
 
 
-def test_second_drift_run_updates_not_duplicates(store):
-    # Arrange — first run creates the card.
-    route_reports_to_cards([_behind("spartan")], store=store)
-    # Act — a second drift run must UPDATE in place, not add a twin.
-    route_reports_to_cards([_behind("spartan")], store=store)
-    # Assert — exactly one card exists for the peer.
-    assert len(scitex_todo.list_tasks(store)) == 1
+def test_the_drift_record_carries_the_target(events):
+    # Arrange — fields are queryable; a sentence is not. ``target`` is what a
+    # reader joins on when asking which peers were stale at a given hour.
+    # Act
+    record_reports([_behind("spartan")], path=events, now=NOW)
+    # Assert
+    assert read_events(events)[0].raw["target"] == "origin/develop"
 
 
-def test_clean_run_resolves_the_drift_card(store):
-    # Arrange — the peer drifted, so a card exists.
-    route_reports_to_cards([_behind("spartan")], store=store)
+def test_the_drift_record_labels_the_subject_a_peer(events):
+    # Arrange — a peer is not an agent; the subject_kind keeps the populations
+    # apart in one shared log.
+    # Act
+    record_reports([_behind("spartan")], path=events, now=NOW)
+    # Assert
+    assert read_events(events)[0].subject_kind == "peer"
+
+
+def test_a_second_drift_run_records_again(events):
+    # Arrange — first run records the drift.
+    record_reports([_behind("spartan")], path=events, now=NOW)
+    # Act — the peer is STILL stale; an ongoing problem is an ongoing fact.
+    record_reports([_behind("spartan")], path=events, now=NOW)
+    # Assert
+    assert _kinds(events) == [SUBJECT_DEGRADED, SUBJECT_DEGRADED]
+
+
+def test_a_clean_run_records_the_recovery(events):
+    # Arrange — the peer drifted, so a degraded record exists.
+    record_reports([_behind("spartan")], path=events, now=NOW)
     # Act — the peer is now current with the centre.
-    route_reports_to_cards([_current("spartan")], store=store)
-    # Assert — a fixed drift stops shouting (off the BLOCKING-YOU view).
-    assert scitex_todo.list_tasks(store, blocking_me=True) == []
+    record_reports([_current("spartan")], path=events, now=NOW)
+    # Assert — a fixed drift stops shouting, and says so once.
+    assert _kinds(events) == [SUBJECT_DEGRADED, SUBJECT_RECOVERED]
 
 
-def test_clean_run_marks_the_card_done(store):
-    # Arrange
-    route_reports_to_cards([_behind("spartan")], store=store)
-    # Act
-    route_reports_to_cards([_current("spartan")], store=store)
-    # Assert
-    card = scitex_todo.get_task(store, card_id_for("spartan"))
-    assert card["status"] == "done"
-
-
-def test_clean_peer_without_prior_card_is_a_noop(store):
+def test_a_clean_peer_without_prior_drift_records_nothing(events):
     # Arrange — a peer that is current and was NEVER drifted.
     # Act
-    route_reports_to_cards([_current("spartan")], store=store)
-    # Assert — no phantom card is created just to resolve it.
-    assert not Path(store).exists() or scitex_todo.list_tasks(store) == []
+    record_reports([_current("spartan")], path=events, now=NOW)
+    # Assert — a well fleet does not write a record per peer per tick.
+    assert not events.exists()
 
 
-def test_undetermined_peer_gets_a_card(store):
+def test_an_undetermined_peer_is_recorded(events):
     # Arrange — an unreachable peer. UNKNOWN must be surfaced, not swallowed.
     # Act
-    route_reports_to_cards([_unreachable("nas")], store=store)
+    record_reports([_unreachable("nas")], path=events, now=NOW)
     # Assert
-    assert scitex_todo.get_task(store, card_id_for("nas"))["id"] == card_id_for("nas")
+    assert _kinds(events) == [SUBJECT_UNKNOWN]
 
 
-def test_undetermined_card_is_labelled_unknown(store):
+def test_an_undetermined_peer_is_never_recorded_clean(events):
     # Arrange — "I could not look" must never read as "I looked, it's fine".
     # Act
-    route_reports_to_cards([_unreachable("nas")], store=store)
+    record_reports([_unreachable("nas")], path=events, now=NOW)
     # Assert
-    card = scitex_todo.get_task(store, card_id_for("nas"))
-    assert "UNKNOWN" in card["title"]
+    assert SUBJECT_RECOVERED not in _kinds(events)
 
 
-def test_route_buckets_drift_and_unknown_separately(store):
+def test_the_record_buckets_drift_and_unknown_separately(events):
     # Arrange — a drifted peer AND an unreachable peer in one run.
     # Act
-    outcome = route_reports_to_cards(
-        [_behind("spartan"), _unreachable("nas")], store=store
+    outcome = record_reports(
+        [_behind("spartan"), _unreachable("nas")], path=events, now=NOW
     )
     # Assert — drift and unknown are distinct buckets (three-state honest).
-    assert (outcome.drifted, outcome.undetermined) == (("spartan",), ("nas",))
+    assert (outcome.degraded, outcome.unknown) == (("spartan",), ("nas",))
 
 
-def test_route_reports_the_cleared_peer(store):
-    # Arrange — drift first so there is a card to clear.
-    route_reports_to_cards([_behind("spartan")], store=store)
+def test_the_recovered_peer_is_reported_to_the_caller(events):
+    # Arrange — drift first so there is something to recover from.
+    record_reports([_behind("spartan")], path=events, now=NOW)
     # Act
-    outcome = route_reports_to_cards([_current("spartan")], store=store)
+    outcome = record_reports([_current("spartan")], path=events, now=NOW)
     # Assert
-    assert outcome.cleared == ("spartan",)
+    assert outcome.recovered == ("spartan",)
 
 
-def test_redrift_after_clear_reopens_the_card(store):
-    # Arrange — drift, then fixed (card resolved).
-    route_reports_to_cards([_behind("spartan")], store=store)
-    route_reports_to_cards([_current("spartan")], store=store)
-    # Act — the peer drifts AGAIN; the alarm must re-fire, not stay silent.
-    route_reports_to_cards([_behind("spartan")], store=store)
-    # Assert — the card is back on the BLOCKING-YOU view.
-    assert len(scitex_todo.list_tasks(store, blocking_me=True)) == 1
+def test_redrift_after_a_recovery_records_again(events):
+    # Arrange — drift, then fixed (recovery recorded).
+    record_reports([_behind("spartan")], path=events, now=NOW)
+    record_reports([_current("spartan")], path=events, now=NOW)
+    # Act — the peer drifts AGAIN; the rail must re-fire, not stay silent.
+    record_reports([_behind("spartan")], path=events, now=NOW)
+    # Assert
+    assert _kinds(events) == [SUBJECT_DEGRADED, SUBJECT_RECOVERED, SUBJECT_DEGRADED]
+
+
+def test_an_unwritable_log_does_not_raise(events, unwritable):
+    # Arrange — recording is a SIDE rail: it must never crash the read-only
+    # check that feeds it.
+    # Act
+    outcome = record_reports(
+        [_behind("spartan")], path=unwritable, now=NOW, err_stream=io.StringIO()
+    )
+    # Assert — recorded as failed, not raised.
+    assert outcome.failed == ("spartan",)
+
+
+def test_an_unwritable_log_is_printed_loudly(events, unwritable):
+    # Arrange — a failure nobody hears is the anti-pattern this whole rail
+    # exists to fix, so the side rail still SHOUTS on stderr.
+    stream = io.StringIO()
+    # Act
+    record_reports([_behind("spartan")], path=unwritable, now=NOW, err_stream=stream)
+    # Assert
+    assert "FAILED to record" in stream.getvalue()

--- a/tests/scitex_agent_container/_maintenance/test__worktree_gc_alarm.py
+++ b/tests/scitex_agent_container/_maintenance/test__worktree_gc_alarm.py
@@ -1,19 +1,20 @@
-"""Tests for ``_maintenance._worktree_gc_alarm`` — over-cap → SEEN card.
+"""Tests for ``_maintenance._worktree_gc_alarm`` — over-cap → a recorded event.
 
-PA-306: no ``unittest.mock``. Real :class:`RepoGcResult` values and a REAL
-temporary scitex-todo store (``tmp_path/tasks.yaml``); the routing calls
-the real ``scitex_todo`` writer and each test reads the card back through
-the real reader.
+PA-306: no ``unittest.mock``, no monkeypatching. Real :class:`RepoGcResult`
+values and a REAL temporary JSONL event log (``tmp_path/sac-events.jsonl``)
+passed through the module's own ``path=`` seam; every assertion reads the
+bytes back through the production :func:`read_events`.
 
 The behaviours that matter:
 
-* over cap → an upserted BLOCKING-YOU card naming the repo and count,
-* the card carries the kept-reasons BREAKDOWN (the actionable part),
-* a second over-cap run UPDATES in place (never duplicates),
-* back under cap → the card is RESOLVED (a fixed repo stops shouting),
-* UNREADABLE is carded too but labelled UNKNOWN — never rendered clean,
-* re-sprawl after a clear REOPENS the card,
-* a board-write failure NEVER crashes the GC (delivery is a side rail).
+* over cap → a DEGRADED record naming the repo and the count,
+* the record carries the kept-reasons BREAKDOWN (the actionable part: "17
+  worktrees" is a number, "9 dirty" is an instruction),
+* a second over-cap run records AGAIN (an ongoing problem is an ongoing fact),
+* back under cap → the RECOVERY is recorded, once,
+* UNREADABLE is its own event — never rendered as clean,
+* re-sprawl after a recovery records again,
+* a write failure NEVER crashes the GC (recording is a side rail).
 
 Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
 """
@@ -25,9 +26,15 @@ from pathlib import Path
 
 import pytest
 
+from scitex_agent_container._events import (
+    SUBJECT_DEGRADED,
+    SUBJECT_RECOVERED,
+    SUBJECT_UNKNOWN,
+    read_events,
+)
 from scitex_agent_container._maintenance._worktree_gc_alarm import (
-    card_id_for,
-    route_gc_to_cards,
+    SUBSYSTEM,
+    record_gc_results,
 )
 from scitex_agent_container._maintenance._worktree_gc_model import (
     KEEP_DIRTY,
@@ -36,7 +43,8 @@ from scitex_agent_container._maintenance._worktree_gc_model import (
     WorktreeVerdict,
 )
 
-scitex_todo = pytest.importorskip("scitex_todo")
+#: A fixed clock, so no test can be flaky on time.
+NOW = 1_800_000_000.0
 
 
 def _kept(path: str, *reasons: str) -> WorktreeVerdict:
@@ -67,161 +75,186 @@ def _unreadable(repo: str = "/proj/broken") -> RepoGcResult:
 
 
 @pytest.fixture
-def store(tmp_path: Path) -> str:
-    """A real (initially absent) scitex-todo store path — no mocks."""
-    return str(tmp_path / "tasks.yaml")
+def events(tmp_path: Path) -> Path:
+    """A real (initially absent) sac event-log path — no mocks."""
+    return tmp_path / "sac-events.jsonl"
 
 
-def test_over_cap_upserts_a_blocking_you_card(store):
+@pytest.fixture
+def unwritable(tmp_path: Path):
+    """An event-log path the REAL writer genuinely cannot write. No mocks."""
+    readonly = tmp_path / "readonly"
+    readonly.mkdir()
+    readonly.chmod(0o555)
+    try:
+        yield readonly / "sac-events.jsonl"
+    finally:
+        readonly.chmod(0o755)
+
+
+def _kinds(events: Path) -> list[str]:
+    return [e.event for e in read_events(events, subsystem=SUBSYSTEM)]
+
+
+def test_over_cap_records_a_degraded_event(events):
     # Arrange — a repo with more survivors than its cap allows.
     # Act
-    route_gc_to_cards([_over_cap()], store=store)
-    # Assert — it lands on the board's BLOCKING-YOU seen surface.
-    blocking = scitex_todo.list_tasks(store, blocking_me=True)
-    assert [t["id"] for t in blocking] == [card_id_for("/proj/sprawly")]
+    record_gc_results([_over_cap()], path=events, now=NOW)
+    # Assert
+    assert _kinds(events) == [SUBJECT_DEGRADED]
 
 
-def test_over_cap_card_names_the_repo(store):
-    # Arrange
+def test_the_over_cap_record_names_the_repo(events):
+    # Arrange — never silent: a reader must see WHICH repo.
     # Act
-    route_gc_to_cards([_over_cap()], store=store)
-    # Assert — never silent: the operator must see WHICH repo.
-    card = scitex_todo.get_task(store, card_id_for("/proj/sprawly"))
-    assert "sprawly" in card["title"]
+    record_gc_results([_over_cap()], path=events, now=NOW)
+    # Assert
+    assert read_events(events)[0].subject == "sprawly"
 
 
-def test_over_cap_card_names_the_count(store):
+def test_the_over_cap_record_carries_the_full_path(events):
+    # Arrange — the subject is the readable BASENAME, so the full path has to
+    # ride along as a field or two checkouts become indistinguishable.
+    # Act
+    record_gc_results([_over_cap()], path=events, now=NOW)
+    # Assert
+    assert read_events(events)[0].raw["repo"] == "/proj/sprawly"
+
+
+def test_the_over_cap_record_carries_the_count(events):
     # Arrange — two survivors against a cap of one.
     # Act
-    route_gc_to_cards([_over_cap()], store=store)
+    record_gc_results([_over_cap()], path=events, now=NOW)
     # Assert
-    card = scitex_todo.get_task(store, card_id_for("/proj/sprawly"))
-    assert "2 worktrees" in card["title"]
+    assert read_events(events)[0].raw["count_after"] == 2
 
 
-def test_over_cap_card_carries_the_reason_breakdown(store):
-    # Arrange — "2 kept" is a number; "1 dirty, 1 unmerged" is an
-    # instruction. The breakdown is the card's entire value.
+def test_the_over_cap_record_carries_the_reason_breakdown(events):
+    # Arrange — "2 kept" is a number; "1 dirty, 1 unmerged" is an instruction.
+    # The breakdown is this record's entire value.
     # Act
-    route_gc_to_cards([_over_cap()], store=store)
+    record_gc_results([_over_cap()], path=events, now=NOW)
     # Assert
-    card = scitex_todo.get_task(store, card_id_for("/proj/sprawly"))
-    assert "1 dirty" in card["note"] and "1 unmerged" in card["note"]
+    assert read_events(events)[0].raw["keep_reasons"] == {
+        KEEP_DIRTY: 1,
+        KEEP_UNMERGED: 1,
+    }
 
 
-def test_second_over_cap_run_updates_not_duplicates(store):
-    # Arrange — first run creates the card.
-    route_gc_to_cards([_over_cap()], store=store)
-    # Act — a nightly timer must UPDATE in place, not tile the board.
-    route_gc_to_cards([_over_cap()], store=store)
+def test_the_over_cap_record_labels_the_subject_a_repo(events):
+    # Arrange — a repo is not an agent; the subject_kind keeps the populations
+    # apart in one shared log.
+    # Act
+    record_gc_results([_over_cap()], path=events, now=NOW)
     # Assert
-    assert len(scitex_todo.list_tasks(store)) == 1
+    assert read_events(events)[0].subject_kind == "repo"
 
 
-def test_back_under_cap_resolves_the_card(store):
-    # Arrange — the repo sprawled, so a card exists.
-    route_gc_to_cards([_over_cap()], store=store)
+def test_a_second_over_cap_run_records_again(events):
+    # Arrange — first run records the sprawl.
+    record_gc_results([_over_cap()], path=events, now=NOW)
+    # Act — the nightly timer runs again and the repo is STILL over.
+    record_gc_results([_over_cap()], path=events, now=NOW)
+    # Assert
+    assert _kinds(events) == [SUBJECT_DEGRADED, SUBJECT_DEGRADED]
+
+
+def test_back_under_cap_records_the_recovery(events):
+    # Arrange — the repo sprawled, so a degraded record exists.
+    record_gc_results([_over_cap()], path=events, now=NOW)
     # Act — the operator cleaned it up.
-    route_gc_to_cards([_under_cap()], store=store)
-    # Assert — a fixed repo stops shouting (off the BLOCKING-YOU view).
-    assert scitex_todo.list_tasks(store, blocking_me=True) == []
+    record_gc_results([_under_cap()], path=events, now=NOW)
+    # Assert — a fixed repo stops shouting, and says so once.
+    assert _kinds(events) == [SUBJECT_DEGRADED, SUBJECT_RECOVERED]
 
 
-def test_back_under_cap_marks_the_card_done(store):
-    # Arrange
-    route_gc_to_cards([_over_cap()], store=store)
-    # Act
-    route_gc_to_cards([_under_cap()], store=store)
-    # Assert
-    card = scitex_todo.get_task(store, card_id_for("/proj/sprawly"))
-    assert card["status"] == "done"
-
-
-def test_healthy_repo_without_prior_card_is_a_noop(store):
+def test_a_healthy_repo_without_prior_sprawl_records_nothing(events):
     # Arrange — a repo that was never over cap.
     # Act
-    route_gc_to_cards([_under_cap()], store=store)
-    # Assert — no phantom card is created just to resolve it.
-    assert not Path(store).exists() or scitex_todo.list_tasks(store) == []
+    record_gc_results([_under_cap()], path=events, now=NOW)
+    # Assert — no phantom record is created just to say nothing is wrong.
+    assert not events.exists()
 
 
-def test_unreadable_repo_gets_a_card(store):
+def test_an_unreadable_repo_is_recorded(events):
     # Arrange — UNKNOWN must be surfaced, not swallowed.
     # Act
-    route_gc_to_cards([_unreadable()], store=store)
+    record_gc_results([_unreadable()], path=events, now=NOW)
     # Assert
-    card_id = card_id_for("/proj/broken")
-    assert scitex_todo.get_task(store, card_id)["id"] == card_id
+    assert _kinds(events) == [SUBJECT_UNKNOWN]
 
 
-def test_unreadable_card_is_labelled_unknown(store):
+def test_an_unreadable_repo_is_never_recorded_clean(events):
     # Arrange — "I could not look" must never read as "I looked, it's fine".
     # Act
-    route_gc_to_cards([_unreadable()], store=store)
+    record_gc_results([_unreadable()], path=events, now=NOW)
     # Assert
-    card = scitex_todo.get_task(store, card_id_for("/proj/broken"))
-    assert "UNKNOWN" in card["title"]
+    assert SUBJECT_RECOVERED not in _kinds(events)
 
 
-def test_route_buckets_over_cap_and_unknown_separately(store):
+def test_the_unreadable_record_carries_the_error(events):
+    # Arrange — the reason it could not be read is what sends the operator
+    # somewhere useful.
+    # Act
+    record_gc_results([_unreadable()], path=events, now=NOW)
+    # Assert
+    assert read_events(events)[0].raw["error"] == "not a git repository"
+
+
+def test_the_record_buckets_over_cap_and_unknown_separately(events):
     # Arrange — a sprawling repo AND an unreadable one in one run.
     # Act
-    outcome = route_gc_to_cards([_over_cap(), _unreadable()], store=store)
+    outcome = record_gc_results([_over_cap(), _unreadable()], path=events, now=NOW)
     # Assert — three-state honest: distinct buckets, never merged.
-    assert (outcome.exceeded, outcome.unreadable) == (
-        ("/proj/sprawly",),
-        ("/proj/broken",),
-    )
+    assert (outcome.degraded, outcome.unknown) == (("sprawly",), ("broken",))
 
 
-def test_route_reports_the_cleared_repo(store):
-    # Arrange — sprawl first so there is a card to clear.
-    route_gc_to_cards([_over_cap()], store=store)
+def test_the_recovered_repo_is_reported_to_the_caller(events):
+    # Arrange — sprawl first so there is something to recover from.
+    record_gc_results([_over_cap()], path=events, now=NOW)
     # Act
-    outcome = route_gc_to_cards([_under_cap()], store=store)
+    outcome = record_gc_results([_under_cap()], path=events, now=NOW)
     # Assert
-    assert outcome.cleared == ("/proj/sprawly",)
+    assert outcome.recovered == ("sprawly",)
 
 
-def test_resprawl_after_clear_reopens_the_card(store):
-    # Arrange — over cap, then cleaned (card resolved).
-    route_gc_to_cards([_over_cap()], store=store)
-    route_gc_to_cards([_under_cap()], store=store)
-    # Act — it sprawls AGAIN; the alarm must re-fire, not stay silent.
-    route_gc_to_cards([_over_cap()], store=store)
+def test_resprawl_after_a_recovery_records_again(events):
+    # Arrange — over cap, then cleaned (recovery recorded).
+    record_gc_results([_over_cap()], path=events, now=NOW)
+    record_gc_results([_under_cap()], path=events, now=NOW)
+    # Act — it sprawls AGAIN; the rail must re-fire, not stay silent.
+    record_gc_results([_over_cap()], path=events, now=NOW)
     # Assert
-    assert len(scitex_todo.list_tasks(store, blocking_me=True)) == 1
+    assert _kinds(events) == [SUBJECT_DEGRADED, SUBJECT_RECOVERED, SUBJECT_DEGRADED]
 
 
-def test_board_write_failure_does_not_raise(tmp_path):
-    # Arrange — an unwritable store path (a directory where the YAML file
-    # should be). Card delivery is a SIDE rail: it must never crash the GC
-    # pass that feeds it.
-    unwritable = tmp_path / "tasks.yaml"
-    unwritable.mkdir()
+def test_a_write_failure_does_not_raise(unwritable):
+    # Arrange — recording is a SIDE rail: it must never crash the GC pass
+    # that feeds it.
     # Act
-    outcome = route_gc_to_cards(
-        [_over_cap()], store=str(unwritable), err_stream=io.StringIO()
+    outcome = record_gc_results(
+        [_over_cap()], path=unwritable, now=NOW, err_stream=io.StringIO()
     )
     # Assert — recorded as failed, not raised.
-    assert outcome.failed == ("/proj/sprawly",)
+    assert outcome.failed == ("sprawly",)
 
 
-def test_board_write_failure_is_printed_loudly(tmp_path):
+def test_a_write_failure_is_printed_loudly(unwritable):
     # Arrange — a failure nobody hears is the anti-pattern this whole rail
     # exists to fix, so the side rail still SHOUTS on stderr.
-    unwritable = tmp_path / "tasks.yaml"
-    unwritable.mkdir()
     stream = io.StringIO()
     # Act
-    route_gc_to_cards([_over_cap()], store=str(unwritable), err_stream=stream)
+    record_gc_results([_over_cap()], path=unwritable, now=NOW, err_stream=stream)
     # Assert
-    assert "FAILED" in stream.getvalue()
+    assert "FAILED to record" in stream.getvalue()
 
 
-def test_card_id_is_stable_for_a_repo_path():
-    # Arrange — idempotency is BY ID: an unstable id tiles the board.
+def test_the_subject_is_the_readable_repo_name(events):
+    # Arrange — the transition rule is keyed BY SUBJECT, so the label must be
+    # stable AND readable: a full path would work but says nothing at a glance.
     # Act
-    card_id = card_id_for("/home/user/proj/scitex-todo")
+    record_gc_results(
+        [_over_cap("/home/user/proj/scitex-agent-container")], path=events, now=NOW
+    )
     # Assert
-    assert card_id == "worktree-sprawl-scitex-todo"
+    assert read_events(events)[0].subject == "scitex-agent-container"

--- a/tests/scitex_agent_container/_reconcile/_fleet.py
+++ b/tests/scitex_agent_container/_reconcile/_fleet.py
@@ -1,9 +1,10 @@
 """Shared no-mocks helpers for the reconcile suites.
 
 Real on-disk v3 specs, real ``instances`` rows written by the production
-writer, and a real recorder standing in for the ONE irreversible act. Split
-out of ``test__pass.py`` so it and ``test__pass_limits.py`` drive the same
-fleet without either file breaching the 512-line cap.
+writer, a real temp sac event log, and a real recorder standing in for the ONE
+irreversible act. Split out of ``test__pass.py`` so it and
+``test__pass_limits.py`` drive the same fleet without either file breaching
+the 512-line cap.
 """
 
 from __future__ import annotations
@@ -86,18 +87,22 @@ def ended(name: str, reason: str) -> None:
     state_db.record_instance_stop(instance_id, exit_reason=reason)
 
 
-def run_pass(registry, db_path, history, store, **overrides):
+def run_pass(registry, db_path, history, events, **overrides):
     """One pass with every real seam wired to this test's temp state.
 
     Defaults describe a HOST that can see tmux (``in_sif_fn`` False) and an
     EMPTY tmux (``snapshot_fn`` -> ``{}``), i.e. every agent is a corpse —
     the interesting case. Tests override what they are about.
+
+    ``events`` is the sac event log this pass records to — a real temp JSONL
+    path. A test that wants an UNWRITABLE one passes ``events_path=`` as an
+    override, which lands on the same production keyword.
     """
     kwargs = {
         "specs_dir": registry,
         "db_path": db_path,
         "history_file": history,
-        "store": store,
+        "events_path": events,
         "now": NOW,
         "snapshot_fn": lambda **_: {},
         "in_sif_fn": lambda: False,

--- a/tests/scitex_agent_container/_reconcile/conftest.py
+++ b/tests/scitex_agent_container/_reconcile/conftest.py
@@ -2,7 +2,7 @@
 
 Every fixture here hands the pass REAL state it can write to and a test can
 read back: an on-disk ``state.db``, an on-disk fleet registry of v3 specs,
-an on-disk scitex-todo store, an on-disk history file.
+an on-disk sac event log, an on-disk history file.
 
 The ``db_path`` fixture redirects BOTH handles (the env var AND the
 already-baked ``DEFAULT_DB_PATH`` module constant), because the constant is
@@ -50,9 +50,13 @@ def registry(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def store(tmp_path: Path) -> str:
-    """A real (initially absent) scitex-todo store path — no mocks."""
-    return str(tmp_path / "tasks.yaml")
+def events(tmp_path: Path) -> Path:
+    """A real (initially absent) sac event-log path — no mocks.
+
+    Nothing creates it until a pass records something, so ``events.exists()``
+    is itself the assertion "this pass recorded nothing at all".
+    """
+    return tmp_path / "sac-events.jsonl"
 
 
 @pytest.fixture
@@ -63,15 +67,15 @@ def history(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def unwritable(tmp_path: Path):
-    """A store path the REAL writer genuinely cannot write. No mocks.
+    """An event-log path the REAL writer genuinely cannot write. No mocks.
 
-    The parent dir is read-only, so ``scitex_todo``'s own write fails the
-    way it would on a broken host — the world says no; nothing is injected.
+    The parent dir is read-only, so the append fails the way it would on a
+    broken host — the world says no; nothing is injected.
     """
     readonly = tmp_path / "readonly"
     readonly.mkdir()
     readonly.chmod(0o555)
     try:
-        yield str(readonly / "tasks.yaml")
+        yield readonly / "sac-events.jsonl"
     finally:
         readonly.chmod(0o755)

--- a/tests/scitex_agent_container/_reconcile/test__alarm.py
+++ b/tests/scitex_agent_container/_reconcile/test__alarm.py
@@ -1,23 +1,25 @@
-"""Tests for ``_reconcile._alarm`` — down cards + the who-watches-the-watcher beat.
+"""Tests for ``_reconcile._alarm`` — down records, the pass beat, self-impairment.
 
-No mocks: a REAL temporary scitex-todo store (``tmp_path/tasks.yaml``), the
-real ``scitex_todo`` writer, and each assertion reads the card back through
-the real reader. The fail-loud leg breaks the write ORGANICALLY (a read-only
-parent dir) rather than injecting a raiser.
+PA-306: no ``unittest.mock``, no monkeypatching. A REAL temporary JSONL event
+log (``tmp_path/sac-events.jsonl``) passed through each function's own
+``path=`` seam, and every assertion reads the bytes back through the
+production :func:`read_events`. The fail-loud leg breaks the write
+ORGANICALLY (a read-only parent dir) rather than injecting a raiser.
 
 The behaviours that matter:
 
-* an agent we could not recover gets a BLOCKING-YOU card naming it, and a
-  re-run updates in place rather than duplicating;
-* an agent that came back RESOLVES its card — a fixed problem stops shouting;
-* the heartbeat card ticks on EVERY pass, above all the ones that found
-  nothing wrong: a beacon that only appears during trouble cannot tell
-  HEALTHY from DEAD, and telling those apart is its entire purpose;
-* the heartbeat stays ``in_progress`` on purpose — only an OPEN card is
-  watched by scitex-todo's stale-active nudge, and that nudge (delivered by
-  a SEPARATE system) going off IS the alarm for a dead reconciler. Resolving
-  it would silence the one thing that can report our own death;
-* both rails are SIDE rails: a board failure prints loud and never raises.
+* an agent we could NOT recover gets a DEGRADED record naming it, and an
+  agent that came back gets exactly ONE recovery record — an enforcer that
+  gives up silently is just the original bug with extra steps;
+* verdicts that resolve themselves (COOLING-DOWN, CAPPED, UNKNOWN, SKIPPED)
+  get NO per-agent record, because a record per healthy heal on a 5-minute
+  timer trains its reader to ignore the log;
+* the pass record is written on EVERY pass, above all on the ones that found
+  nothing wrong: "0 restarted, all healthy" is the only thing distinguishing
+  a healthy fleet from a timer that stopped running months ago;
+* a reconciler that cannot read its OWN restart memory says so, and says so
+  again when it can — a refusal nobody hears is a no-op;
+* every rail is a SIDE rail: a write failure prints loud and never raises.
 
 Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
 """
@@ -25,24 +27,31 @@ Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
 from __future__ import annotations
 
 import io
-from datetime import datetime, timezone
 from pathlib import Path
 
-import pytest
-
+from scitex_agent_container._events import (
+    PASS_COMPLETED,
+    SELF_IMPAIRED,
+    SELF_RECOVERED,
+    SUBJECT_DEGRADED,
+    SUBJECT_RECOVERED,
+    read_events,
+)
 from scitex_agent_container._reconcile._alarm import (
-    HEARTBEAT_CARD_ID,
-    card_id_for,
-    route_reports_to_cards,
-    upsert_heartbeat,
+    SUBSYSTEM,
+    record_pass_completed,
+    record_reports,
+    record_self_impaired,
+    record_self_recovered,
 )
 from scitex_agent_container._reconcile._pass import AgentReport
 from scitex_agent_container._reconcile._rule import Verdict
 
-scitex_todo = pytest.importorskip("scitex_todo")
+#: A fixed clock, so no test can be flaky on time.
+NOW = 1_800_000_000.0
 
-# ``store`` and ``unwritable`` come from conftest.py — a real temp store and
-# a genuinely read-only one, shared with the _pass suites.
+# ``events`` and ``unwritable`` come from conftest.py — a real temp event log
+# and a genuinely read-only one, shared with the _pass suites.
 
 
 def _report(name: str, verdict: Verdict) -> AgentReport:
@@ -54,257 +63,358 @@ def _report(name: str, verdict: Verdict) -> AgentReport:
     )
 
 
-# --- down cards -------------------------------------------------------------
+def _kinds(events: Path) -> list[str]:
+    return [e.event for e in read_events(events, subsystem=SUBSYSTEM)]
 
 
-def test_over_budget_agent_gets_a_blocking_you_card(store):
+# --- down records -----------------------------------------------------------
+
+
+def test_an_over_budget_agent_is_recorded_degraded(events):
     # Arrange — an agent restarting has plainly not fixed.
     # Act
-    route_reports_to_cards([_report("alpha", Verdict.OVER_BUDGET)], store=store)
-    # Assert — it lands on the surface the operator already watches.
-    assert [t["id"] for t in scitex_todo.list_tasks(store, blocking_me=True)] == [
-        card_id_for("alpha")
-    ]
+    record_reports([_report("alpha", Verdict.OVER_BUDGET)], path=events, now=NOW)
+    # Assert
+    assert _kinds(events) == [SUBJECT_DEGRADED]
 
 
-def test_failed_agent_gets_a_card(store):
+def test_a_failed_agent_is_recorded_degraded(events):
     # Arrange — we tried and it did not come back.
     # Act
-    route_reports_to_cards([_report("alpha", Verdict.FAILED)], store=store)
+    record_reports([_report("alpha", Verdict.FAILED)], path=events, now=NOW)
     # Assert
-    assert scitex_todo.get_task(store, card_id_for("alpha"))["id"] == card_id_for(
-        "alpha"
-    )
+    assert _kinds(events) == [SUBJECT_DEGRADED]
 
 
-def test_down_card_names_the_agent(store):
-    # Arrange — never silent: the operator must see WHICH agent.
+def test_the_down_record_names_the_agent(events):
+    # Arrange — never silent: a reader must see WHICH agent.
     # Act
-    route_reports_to_cards([_report("alpha", Verdict.FAILED)], store=store)
+    record_reports([_report("alpha", Verdict.FAILED)], path=events, now=NOW)
     # Assert
-    assert "alpha" in scitex_todo.get_task(store, card_id_for("alpha"))["title"]
+    assert read_events(events)[0].subject == "alpha"
 
 
-def test_second_down_run_updates_not_duplicates(store):
-    # Arrange — the timer fires every 5 minutes; a card per tick would bury
-    # the board in minutes.
-    route_reports_to_cards([_report("alpha", Verdict.FAILED)], store=store)
+def test_the_down_record_keeps_the_pass_verdict(events):
+    # Arrange — the pass's own token, verbatim, so the record can be compared
+    # against the code that produced it.
     # Act
-    route_reports_to_cards([_report("alpha", Verdict.FAILED)], store=store)
+    record_reports([_report("alpha", Verdict.FAILED)], path=events, now=NOW)
     # Assert
-    assert len(scitex_todo.list_tasks(store)) == 1
+    assert read_events(events)[0].verdict == Verdict.FAILED.value
 
 
-def test_recovered_agent_resolves_its_card(store):
-    # Arrange — alpha was down, so a card exists.
-    route_reports_to_cards([_report("alpha", Verdict.FAILED)], store=store)
+def test_a_second_down_run_records_again(events):
+    # Arrange — the timer fires every 5 minutes and the agent is still down.
+    record_reports([_report("alpha", Verdict.FAILED)], path=events, now=NOW)
+    # Act
+    record_reports([_report("alpha", Verdict.FAILED)], path=events, now=NOW)
+    # Assert — an ongoing problem is an ongoing fact.
+    assert _kinds(events) == [SUBJECT_DEGRADED, SUBJECT_DEGRADED]
+
+
+def test_a_recovered_agent_records_one_recovery(events):
+    # Arrange — alpha was down, so a degraded record exists.
+    record_reports([_report("alpha", Verdict.FAILED)], path=events, now=NOW)
     # Act — alpha is back.
-    route_reports_to_cards([_report("alpha", Verdict.RESTARTED)], store=store)
-    # Assert — a fixed problem stops shouting.
-    assert scitex_todo.list_tasks(store, blocking_me=True) == []
+    record_reports([_report("alpha", Verdict.RESTARTED)], path=events, now=NOW)
+    # Assert — a fixed problem stops shouting, and says so once.
+    assert _kinds(events) == [SUBJECT_DEGRADED, SUBJECT_RECOVERED]
 
 
-def test_healthy_agent_without_prior_card_is_a_noop(store):
+def test_a_healthy_agent_without_prior_trouble_records_nothing(events):
     # Arrange — an OK agent that was never down.
     # Act
-    route_reports_to_cards([_report("alpha", Verdict.OK)], store=store)
-    # Assert — no phantom card is created just to resolve it.
-    assert not Path(store).exists() or scitex_todo.list_tasks(store) == []
+    record_reports([_report("alpha", Verdict.OK)], path=events, now=NOW)
+    # Assert — ~93 healthy agents must not enter the log every five minutes.
+    assert not events.exists()
 
 
-def test_redeath_after_recovery_reopens_the_card(store):
-    # Arrange — down, then fixed (card resolved).
-    route_reports_to_cards([_report("alpha", Verdict.FAILED)], store=store)
-    route_reports_to_cards([_report("alpha", Verdict.RESTARTED)], store=store)
-    # Act — it dies AGAIN; the alarm must re-fire, not stay silent.
-    route_reports_to_cards([_report("alpha", Verdict.FAILED)], store=store)
+def test_redeath_after_a_recovery_records_again(events):
+    # Arrange — down, then fixed (recovery recorded).
+    record_reports([_report("alpha", Verdict.FAILED)], path=events, now=NOW)
+    record_reports([_report("alpha", Verdict.RESTARTED)], path=events, now=NOW)
+    # Act — it dies AGAIN; the rail must re-fire, not stay silent.
+    record_reports([_report("alpha", Verdict.FAILED)], path=events, now=NOW)
     # Assert
-    assert len(scitex_todo.list_tasks(store, blocking_me=True)) == 1
+    assert _kinds(events) == [SUBJECT_DEGRADED, SUBJECT_RECOVERED, SUBJECT_DEGRADED]
 
 
-def test_skipped_agent_gets_no_card(store):
+def test_a_skipped_agent_gets_no_record(events):
     # Arrange — a deliberately-stopped agent is a CORRECT state, not a
-    # problem. Carding it would train the operator to ignore the board.
+    # problem. Recording it would train the reader to ignore the log.
     # Act
-    route_reports_to_cards([_report("alpha", Verdict.SKIPPED)], store=store)
+    record_reports([_report("alpha", Verdict.SKIPPED)], path=events, now=NOW)
     # Assert
-    assert not Path(store).exists() or scitex_todo.list_tasks(store) == []
+    assert not events.exists()
 
 
-def test_unknown_agent_gets_no_per_agent_card(store):
+def test_an_unknown_agent_gets_no_per_agent_record(events):
     # Arrange — blindness is FLEET-wide (we are in a container, or tmux is
-    # wedged). One cause must not mint ~93 cards; the exit code carries it.
+    # wedged). One cause must not mint ~93 records; the pass record carries it.
     # Act
-    route_reports_to_cards([_report("alpha", Verdict.UNKNOWN)], store=store)
+    record_reports([_report("alpha", Verdict.UNKNOWN)], path=events, now=NOW)
     # Assert
-    assert not Path(store).exists() or scitex_todo.list_tasks(store) == []
+    assert not events.exists()
 
 
-def test_route_reports_the_carded_agent(store):
+def test_a_cooling_down_agent_gets_no_record(events):
+    # Arrange — the debounce is 30min and the timer ticks every 5, so a
+    # perfectly HEALTHY restart is cooling down for its next five ticks.
+    # Act
+    record_reports([_report("alpha", Verdict.COOLING_DOWN)], path=events, now=NOW)
+    # Assert
+    assert not events.exists()
+
+
+def test_a_capped_agent_gets_no_record(events):
+    # Arrange — CAPPED is sac's own per-pass throttle, not the agent's fault,
+    # and the next tick picks it up 5 minutes later.
+    # Act
+    record_reports([_report("alpha", Verdict.CAPPED)], path=events, now=NOW)
+    # Assert
+    assert not events.exists()
+
+
+def test_the_recorded_agent_is_reported_to_the_caller(events):
     # Arrange
     # Act
-    outcome = route_reports_to_cards([_report("alpha", Verdict.FAILED)], store=store)
+    outcome = record_reports([_report("alpha", Verdict.FAILED)], path=events, now=NOW)
     # Assert
-    assert outcome.carded == ("alpha",)
+    assert outcome.degraded == ("alpha",)
 
 
-def test_one_bad_card_does_not_suppress_the_rest(store, unwritable):
-    # Arrange — the store cannot be written at all, so BOTH agents' writes
-    # fail. Neither may be silently dropped from the outcome.
+def test_one_bad_record_does_not_suppress_the_rest(events, unwritable):
+    # Arrange — the log cannot be written at all, so BOTH agents' writes fail.
+    # Neither may be silently dropped from the outcome.
     # Act
-    outcome = route_reports_to_cards(
+    outcome = record_reports(
         [_report("alpha", Verdict.FAILED), _report("beta", Verdict.FAILED)],
-        store=unwritable,
+        path=unwritable,
+        now=NOW,
         err_stream=io.StringIO(),
     )
     # Assert
     assert outcome.failed == ("alpha", "beta")
 
 
-def test_card_delivery_failure_is_loud(store, unwritable):
+def test_a_recording_failure_is_loud(events, unwritable):
     # Arrange
     stream = io.StringIO()
     # Act
-    route_reports_to_cards(
-        [_report("alpha", Verdict.FAILED)], store=unwritable, err_stream=stream
+    record_reports(
+        [_report("alpha", Verdict.FAILED)],
+        path=unwritable,
+        now=NOW,
+        err_stream=stream,
     )
     # Assert
-    assert "card delivery FAILED" in stream.getvalue()
+    assert "FAILED to record" in stream.getvalue()
 
 
-def test_card_delivery_failure_does_not_raise(store, unwritable):
-    # Arrange — the pass's job is restarting corpses; telling the board is
+def test_a_recording_failure_does_not_raise(events, unwritable):
+    # Arrange — the pass's job is restarting corpses; recording what it did is
     # secondary and must never be able to take the primary down.
     # Act
-    outcome = route_reports_to_cards(
-        [_report("alpha", Verdict.FAILED)], store=unwritable, err_stream=io.StringIO()
+    outcome = record_reports(
+        [_report("alpha", Verdict.FAILED)],
+        path=unwritable,
+        now=NOW,
+        err_stream=io.StringIO(),
     )
     # Assert
-    assert outcome.carded == ()
+    assert outcome.degraded == ()
 
 
-# --- the heartbeat: who watches the watcher --------------------------------
+# --- the pass record: who watches the watcher ------------------------------
 
 
-def test_heartbeat_is_written_on_a_clean_pass(store):
-    # Arrange — THE most important tick: "0 restarted, all healthy". A
-    # beacon that only appears during trouble cannot prove it is alive.
+def test_the_pass_record_is_written_on_a_clean_pass(events):
+    # Arrange — THE most important tick: "0 restarted, all healthy". A rail
+    # that only writes during trouble cannot prove it is alive.
     # Act
-    upsert_heartbeat({"OK": 93}, mode="apply", host="host-a", store=store)
+    record_pass_completed({"OK": 93}, mode="apply", host="host-a", path=events, now=NOW)
     # Assert
-    assert scitex_todo.get_task(store, HEARTBEAT_CARD_ID)["id"] == HEARTBEAT_CARD_ID
+    assert _kinds(events) == [PASS_COMPLETED]
 
 
-def test_heartbeat_stays_in_progress(store):
-    # Arrange — only an OPEN card is watched by scitex-todo's stale-active
-    # nudge, and that nudge firing IS the alarm for a dead reconciler.
-    # Resolving it would silence the one thing that reports our death.
+def test_the_pass_record_carries_the_counts(events):
+    # Arrange — the counts carry EVERY verdict this pass reached, including
+    # the ones that get no per-agent record of their own.
     # Act
-    upsert_heartbeat({"OK": 1}, mode="apply", host="host-a", store=store)
-    # Assert
-    assert scitex_todo.get_task(store, HEARTBEAT_CARD_ID)["status"] == "in_progress"
-
-
-def test_heartbeat_updates_in_place(store):
-    # Arrange — it ticks every 5 minutes, forever. One card, not 288/day.
-    upsert_heartbeat({"OK": 1}, mode="apply", host="host-a", store=store)
-    # Act
-    upsert_heartbeat({"OK": 2}, mode="apply", host="host-a", store=store)
-    # Assert
-    assert len(scitex_todo.list_tasks(store)) == 1
-
-
-def test_heartbeat_records_the_counts(store):
-    # Arrange — the note is what the operator reads to see the last pass.
-    # Act
-    upsert_heartbeat(
-        {"OK": 90, "RESTARTED": 3}, mode="apply", host="host-a", store=store
+    record_pass_completed(
+        {"OK": 90, "RESTARTED": 3}, mode="apply", host="host-a", path=events, now=NOW
     )
     # Assert
-    assert "RESTARTED" in scitex_todo.get_task(store, HEARTBEAT_CARD_ID)["note"]
+    assert read_events(events)[0].raw["counts"] == {"OK": 90, "RESTARTED": 3}
 
 
-def test_heartbeat_records_the_mode(store):
-    # Arrange — a hand-run dry-run also refreshes this card, so a stale
-    # TIMER must stay visible even when the card itself looks fresh.
+def test_the_pass_record_carries_the_mode(events):
+    # Arrange — a hand-run dry-run also writes this record, so a reader who
+    # ignores ``mode`` can believe the scheduled timer is alive on the
+    # strength of somebody having run the command by hand.
     # Act
-    upsert_heartbeat({"OK": 1}, mode="dry-run", host="host-a", store=store)
-    # Assert
-    assert "dry-run" in scitex_todo.get_task(store, HEARTBEAT_CARD_ID)["note"]
-
-
-def test_heartbeat_refreshes_its_timestamp(store):
-    # Arrange — a stale last_activity is exactly what the board's nudge
-    # keys off, so a live tick MUST move it. A fixed clock makes the
-    # refresh observable without sleeping.
-    upsert_heartbeat({"OK": 1}, mode="apply", host="host-a", store=store)
-    later = datetime(2031, 7, 16, 12, 0, 0, tzinfo=timezone.utc)  # stx-allow: STX-NL001
-    # Act
-    upsert_heartbeat({"OK": 2}, mode="apply", host="host-a", store=store, now=later)
-    # Assert
-    assert (
-        scitex_todo.get_task(store, HEARTBEAT_CARD_ID)["last_activity"]
-        == "2031-07-16T12:00:00Z"
+    record_pass_completed(
+        {"OK": 1}, mode="dry-run", host="host-a", path=events, now=NOW
     )
-
-
-def test_heartbeat_stamp_matches_the_stores_own_format(store):
-    # Arrange — `last_activity` is what the board's stale-active nudge reads
-    # to notice the reconciler went quiet, and that nudge IS the alarm for a
-    # dead reconciler. A stamp in OUR format rather than the store's risks
-    # being unparseable there — silently disarming the one rail that can
-    # report our own death. The store's own helper trims microseconds and
-    # uses `Z` (not `+00:00`) so the string round-trips through YAML.
-    #
-    # The stamp WE write is the one on the UPDATE path — which is every tick
-    # after the very first (the create is stamped by the store itself). So
-    # create first, then drive the refresh with a microsecond-bearing clock.
-    upsert_heartbeat({"OK": 1}, mode="apply", host="host-a", store=store)
-    now = datetime(  # stx-allow: STX-NL001
-        2031, 7, 16, 12, 0, 0, 123_456, tzinfo=timezone.utc
-    )
-    # Act
-    upsert_heartbeat({"OK": 2}, mode="apply", host="host-a", store=store, now=now)
-    # Assert — microseconds trimmed, `Z` suffix, exactly like the store's own.
-    assert (
-        scitex_todo.get_task(store, HEARTBEAT_CARD_ID)["last_activity"]
-        == "2031-07-16T12:00:00Z"
-    )
-
-
-def test_heartbeat_says_what_its_staleness_means(store):
-    # Arrange — the card must teach the reader what to conclude from it,
-    # because its whole value is realised when nobody is expecting it.
-    # Act
-    upsert_heartbeat({"OK": 1}, mode="apply", host="host-a", store=store)
     # Assert
-    assert "NOT RUNNING" in scitex_todo.get_task(store, HEARTBEAT_CARD_ID)["note"]
+    assert read_events(events)[0].raw["mode"] == "dry-run"
 
 
-def test_heartbeat_reports_success(store):
+def test_the_pass_record_names_the_host(events):
+    # Arrange — one log can hold several hosts' timers; the detail says which
+    # machine's reconciler ticked.
+    # Act
+    record_pass_completed({"OK": 1}, mode="apply", host="host-a", path=events, now=NOW)
+    # Assert
+    assert "host-a" in read_events(events)[0].detail
+
+
+def test_the_pass_record_reports_success(events):
     # Arrange
     # Act
-    written = upsert_heartbeat({"OK": 1}, mode="apply", host="host-a", store=store)
+    written = record_pass_completed({"OK": 1}, mode="apply", path=events, now=NOW)
     # Assert
-    assert written
+    assert written is True
 
 
-def test_heartbeat_failure_does_not_raise(store, unwritable):
-    # Arrange — a SIDE rail: telling the board we are alive must never
-    # crash the pass that restarts corpses.
+def test_a_pass_record_failure_does_not_raise(events, unwritable):
+    # Arrange — a SIDE rail: recording that we are alive must never crash the
+    # pass that restarts corpses.
     # Act
-    written = upsert_heartbeat(
-        {"OK": 1}, mode="apply", store=unwritable, err_stream=io.StringIO()
+    written = record_pass_completed(
+        {"OK": 1}, mode="apply", path=unwritable, now=NOW, err_stream=io.StringIO()
     )
     # Assert
-    assert not written
+    assert written is False
 
 
-def test_heartbeat_failure_is_loud(store, unwritable):
+def test_a_pass_record_failure_is_loud(events, unwritable):
     # Arrange — if the beacon dies quietly, nobody learns the watcher is
     # unwatched.
     stream = io.StringIO()
     # Act
-    upsert_heartbeat({"OK": 1}, mode="apply", store=unwritable, err_stream=stream)
+    record_pass_completed(
+        {"OK": 1}, mode="apply", path=unwritable, now=NOW, err_stream=stream
+    )
     # Assert
-    assert "HEARTBEAT card delivery FAILED" in stream.getvalue()
+    assert "FAILED to record" in stream.getvalue()
+
+
+# --- self-impairment: the reconciler cannot read its OWN memory ------------
+
+
+def test_an_unreadable_state_is_recorded_as_self_impaired(events):
+    # Arrange — with no memory the rate limits are unenforceable, so the pass
+    # REFUSES to restart. A refusal nobody hears is a no-op.
+    # Act
+    record_self_impaired(
+        "permission denied", state_file="/denied/hist.json", path=events, now=NOW
+    )
+    # Assert
+    assert _kinds(events) == [SELF_IMPAIRED]
+
+
+def test_the_self_impaired_record_names_the_state_file(events):
+    # Arrange — the operator must be sent to the exact path that is denied.
+    # Act
+    record_self_impaired(
+        "permission denied", state_file="/denied/hist.json", path=events, now=NOW
+    )
+    # Assert
+    assert read_events(events)[0].raw["state_file"] == "/denied/hist.json"
+
+
+def test_the_self_impaired_record_says_restarts_stopped(events):
+    # Arrange — the record must teach the reader what to conclude from it:
+    # dead agents are staying dead until this is fixed.
+    # Act
+    record_self_impaired("permission denied", path=events, now=NOW)
+    # Assert
+    assert "REFUSED to restart" in read_events(events)[0].detail
+
+
+def test_a_readable_state_is_recorded_as_self_recovered(events):
+    # Arrange — the impairment was recorded once; a fixed problem must record
+    # that it is fixed rather than merely going quiet.
+    record_self_impaired("permission denied", path=events, now=NOW)
+    # Act
+    record_self_recovered(state_file="/ok/hist.json", path=events, now=NOW)
+    # Assert
+    assert _kinds(events) == [SELF_IMPAIRED, SELF_RECOVERED]
+
+
+def test_the_self_impaired_record_belongs_to_no_subject(events):
+    # Arrange — the fault is sac's own, not any one agent's. The field is
+    # PRESENT-and-null: it does not apply, rather than nobody having recorded it.
+    # Act
+    record_self_impaired("permission denied", path=events, now=NOW)
+    # Assert
+    assert read_events(events)[0].raw.get("subject", "MISSING") is None
+
+
+def test_a_self_impaired_write_failure_does_not_raise(events, unwritable):
+    # Arrange
+    # Act
+    written = record_self_impaired(
+        "permission denied", path=unwritable, now=NOW, err_stream=io.StringIO()
+    )
+    # Assert
+    assert written is False
+
+
+# --- self-state is a TRANSITION, never a per-tick assertion ----------------
+#
+# The reconciler runs every five minutes forever. Asserting "I am fine" on
+# every tick would write hundreds of thousands of records a year AND would
+# make ``self-recovered`` mean nothing — a recovery record has to mark an
+# actual recovery, or it is not evidence of one. An IMPAIRMENT, by contrast,
+# is re-recorded while it stands: an ongoing refusal to act is an ongoing
+# fact, and a log that mentions it once and goes quiet cannot be told apart
+# from a log written by a pass that has itself died.
+
+
+def test_a_healthy_pass_records_no_self_recovery(events):
+    # Arrange — the reconciler was never impaired, so there is nothing to
+    # recover FROM. This is the every-five-minutes case.
+    # Act
+    record_self_recovered(state_file="/ok/hist.json", path=events, now=NOW)
+    # Assert — not an empty log: no log was ever opened.
+    assert not events.exists()
+
+
+def test_a_healthy_pass_reports_nothing_written(events):
+    # Arrange — ``False`` here means "nothing changed", never "the write
+    # failed"; the caller must not read it as an error.
+    # Act
+    written = record_self_recovered(state_file="/ok/hist.json", path=events, now=NOW)
+    # Assert
+    assert written is False
+
+
+def test_a_standing_impairment_is_recorded_every_pass(events):
+    # Arrange — still denied on the next tick, and still refusing to restart.
+    record_self_impaired("permission denied", path=events, now=NOW)
+    # Act
+    record_self_impaired("permission denied", path=events, now=NOW)
+    # Assert
+    assert _kinds(events) == [SELF_IMPAIRED, SELF_IMPAIRED]
+
+
+def test_a_second_recovery_records_nothing(events):
+    # Arrange — impaired, then recovered (the transition is on the record).
+    record_self_impaired("permission denied", path=events, now=NOW)
+    record_self_recovered(path=events, now=NOW)
+    # Act — the next tick is still healthy; it must stay quiet.
+    record_self_recovered(path=events, now=NOW)
+    # Assert
+    assert _kinds(events) == [SELF_IMPAIRED, SELF_RECOVERED]
+
+
+def test_reimpairment_after_a_recovery_records_again(events):
+    # Arrange — impaired, then readable again (memory cleared).
+    record_self_impaired("permission denied", path=events, now=NOW)
+    record_self_recovered(path=events, now=NOW)
+    # Act — the mount is revoked AGAIN; the rail must re-fire.
+    record_self_impaired("permission denied", path=events, now=NOW)
+    # Assert
+    assert _kinds(events) == [SELF_IMPAIRED, SELF_RECOVERED, SELF_IMPAIRED]

--- a/tests/scitex_agent_container/_reconcile/test__pass.py
+++ b/tests/scitex_agent_container/_reconcile/test__pass.py
@@ -1,12 +1,12 @@
 """Tests for ``_reconcile._pass`` — WHICH agents does a real pass restart?
 
-The rate limits, restart failures, exit codes and board rails live in the
+The rate limits, restart failures, exit codes and recording rails live in the
 sibling ``test__pass_limits.py`` (512-line cap); this file owns the core
 question: given a real fleet on disk, who gets restarted and who does not.
 
 No mocks. Real on-disk v3 ``spec.yaml`` files in a tmp fleet registry, a
 REAL temp ``state.db`` with REAL ``instances`` rows written by the
-production writer, a real temp scitex-todo store, and a real injected clock.
+production writer, a real temp scitex-todo events, and a real injected clock.
 Fixtures live in ``conftest.py``, helpers in ``_fleet.py``.
 
 Two seams, both real callables rather than mocks:
@@ -27,8 +27,8 @@ Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
 
 from __future__ import annotations
 
-import pytest
-
+from scitex_agent_container._events import SUBJECT_DEGRADED, read_events
+from scitex_agent_container._reconcile._alarm import SUBSYSTEM
 from scitex_agent_container._reconcile._budget import load_history
 from scitex_agent_container._reconcile._rule import Verdict
 from tests.scitex_agent_container._reconcile._fleet import (
@@ -42,13 +42,19 @@ from tests.scitex_agent_container._reconcile._fleet import (
     write_spec,
 )
 
-scitex_todo = pytest.importorskip("scitex_todo")
+
+def _degraded_subjects(events) -> list[str]:
+    """Agents this pass recorded as DOWN-and-unrecoverable, in order."""
+    return [
+        e.subject
+        for e in read_events(events, subsystem=SUBSYSTEM, event=SUBJECT_DEGRADED)
+    ]
 
 
 # --- a live session is left alone ------------------------------------------
 
 
-def test_agent_with_live_session_is_not_restarted(registry, db_path, history, store):
+def test_agent_with_live_session_is_not_restarted(registry, db_path, history, events):
     # Arrange — the session EXISTS, so the agent is alive.
     write_spec(registry, "alpha")
     ghost("alpha")
@@ -58,7 +64,7 @@ def test_agent_with_live_session_is_not_restarted(registry, db_path, history, st
         registry,
         db_path,
         history,
-        store,
+        events,
         apply=True,
         snapshot_fn=lambda **_: sessions("alpha"),
         restart_fn=recorder,
@@ -67,19 +73,19 @@ def test_agent_with_live_session_is_not_restarted(registry, db_path, history, st
     assert recorder.names == []
 
 
-def test_agent_with_live_session_reports_ok(registry, db_path, history, store):
+def test_agent_with_live_session_reports_ok(registry, db_path, history, events):
     # Arrange
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
     outcome = run_pass(
-        registry, db_path, history, store, snapshot_fn=lambda **_: sessions("alpha")
+        registry, db_path, history, events, snapshot_fn=lambda **_: sessions("alpha")
     )
     # Assert
     assert verdict_of(outcome, "alpha") is Verdict.OK
 
 
-def test_live_session_outranks_a_crashed_row(registry, db_path, history, store):
+def test_live_session_outranks_a_crashed_row(registry, db_path, history, events):
     # Arrange — the row says crashed but tmux says the session is THERE.
     # tmux is the fact; the registry's view is a hypothesis.
     write_spec(registry, "alpha")
@@ -90,7 +96,7 @@ def test_live_session_outranks_a_crashed_row(registry, db_path, history, store):
         registry,
         db_path,
         history,
-        store,
+        events,
         apply=True,
         snapshot_fn=lambda **_: sessions("alpha"),
         restart_fn=recorder,
@@ -102,7 +108,7 @@ def test_live_session_outranks_a_crashed_row(registry, db_path, history, store):
 # --- THE HEADLINE: tonight's 33 dead agents --------------------------------
 
 
-def test_ghost_active_row_agent_is_restarted(registry, db_path, history, store):
+def test_ghost_active_row_agent_is_restarted(registry, db_path, history, events):
     # Arrange — EXACTLY tonight's state: spec says keep-running, tmux has no
     # session, and the instances row still claims ended_at IS NULL. Nothing
     # recorded an end, so nobody ended it — it died with the OAuth rotation.
@@ -110,62 +116,62 @@ def test_ghost_active_row_agent_is_restarted(registry, db_path, history, store):
     ghost("alpha")
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert — this is the fleet coming back.
     assert recorder.names == ["alpha"]
 
 
-def test_ghost_active_row_is_reported_restarted(registry, db_path, history, store):
+def test_ghost_active_row_is_reported_restarted(registry, db_path, history, events):
     # Arrange
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
-    outcome = run_pass(registry, db_path, history, store, apply=True)
+    outcome = run_pass(registry, db_path, history, events, apply=True)
     # Assert
     assert verdict_of(outcome, "alpha") is Verdict.RESTARTED
 
 
-def test_whole_dead_fleet_is_recovered(registry, db_path, history, store):
+def test_whole_dead_fleet_is_recovered(registry, db_path, history, events):
     # Arrange — the real shape of the incident: many agents, all ghosts.
     for name in ("a1", "a2", "a3", "a4", "a5"):
         write_spec(registry, name)
         ghost(name)
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert — every one of them comes back in a single pass.
     assert sorted(recorder.names) == ["a1", "a2", "a3", "a4", "a5"]
 
 
-def test_crashed_agent_is_restarted(registry, db_path, history, store):
+def test_crashed_agent_is_restarted(registry, db_path, history, events):
     # Arrange — the reaper recorded 'crashed': it died without being asked.
     write_spec(registry, "alpha")
     ended("alpha", "crashed")
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert
     assert recorder.names == ["alpha"]
 
 
-def test_reboot_swept_agent_is_restarted(registry, db_path, history, store):
+def test_reboot_swept_agent_is_restarted(registry, db_path, history, events):
     # Arrange — the host rebooted under it. Nobody chose to stop this agent.
     write_spec(registry, "alpha")
     ended("alpha", "reboot-swept")
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert
     assert recorder.names == ["alpha"]
 
 
-def test_always_policy_is_enforced(registry, db_path, history, store):
+def test_always_policy_is_enforced(registry, db_path, history, events):
     # Arrange — policy: always is the other managed policy.
     write_spec(registry, "alpha", policy="always")
     ghost("alpha")
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert
     assert recorder.names == ["alpha"]
 
@@ -173,83 +179,83 @@ def test_always_policy_is_enforced(registry, db_path, history, store):
 # --- THE OPERATOR'S INTENT IS SACRED ---------------------------------------
 
 
-def test_deliberately_stopped_agent_is_not_restarted(registry, db_path, history, store):
+def test_deliberately_stopped_agent_is_not_restarted(registry, db_path, history, events):
     # Arrange — `sac agents stop` recorded 'stopped'. The operator MEANT it.
     write_spec(registry, "alpha")
     ended("alpha", "stopped")
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert — an enforcer that undoes a stop is one nobody can turn off.
     assert recorder.names == []
 
 
-def test_deliberately_stopped_agent_reports_skipped(registry, db_path, history, store):
+def test_deliberately_stopped_agent_reports_skipped(registry, db_path, history, events):
     # Arrange
     write_spec(registry, "alpha")
     ended("alpha", "stopped")
     # Act
-    outcome = run_pass(registry, db_path, history, store, apply=True)
+    outcome = run_pass(registry, db_path, history, events, apply=True)
     # Assert
     assert verdict_of(outcome, "alpha") is Verdict.SKIPPED
 
 
-def test_stopped_agent_skip_states_its_reason(registry, db_path, history, store):
+def test_stopped_agent_skip_states_its_reason(registry, db_path, history, events):
     # Arrange — never silent: the report must SAY why it stood down.
     write_spec(registry, "alpha")
     ended("alpha", "stopped")
     # Act
-    outcome = run_pass(registry, db_path, history, store, apply=True)
+    outcome = run_pass(registry, db_path, history, events, apply=True)
     # Assert
     assert "DELIBERATELY" in detail_of(outcome, "alpha")
 
 
-def test_deleted_agent_is_not_restarted(registry, db_path, history, store):
+def test_deleted_agent_is_not_restarted(registry, db_path, history, events):
     # Arrange
     write_spec(registry, "alpha")
     ended("alpha", "deleted")
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert
     assert recorder.names == []
 
 
-def test_stopped_agent_raises_no_card(registry, db_path, history, store):
+def test_stopped_agent_records_no_verdict(registry, db_path, history, events):
     # Arrange — a stopped agent is a CORRECT state, not a problem. Carding
-    # it would train the operator to ignore the board.
+    # it would train a reader to ignore the log.
     write_spec(registry, "alpha")
     ended("alpha", "stopped")
     # Act
-    run_pass(registry, db_path, history, store, apply=True)
+    run_pass(registry, db_path, history, events, apply=True)
     # Assert
-    assert scitex_todo.list_tasks(store, blocking_me=True) == []
+    assert _degraded_subjects(events) == []
 
 
-def test_unmanaged_spec_is_not_restarted(registry, db_path, history, store):
+def test_unmanaged_spec_is_not_restarted(registry, db_path, history, events):
     # Arrange — policy=never (also the DEFAULT for a spec with no restart
     # block). sac never promised to keep this one running.
     write_spec(registry, "alpha", policy="never")
     ghost("alpha")
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert
     assert recorder.names == []
 
 
-def test_never_started_spec_is_not_started(registry, db_path, history, store):
+def test_never_started_spec_is_not_started(registry, db_path, history, events):
     # Arrange — a spec with NO instances row. Starting it would be a start
     # nobody asked for; doing that for every unstarted spec is a storm.
     write_spec(registry, "alpha")
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert
     assert recorder.names == []
 
 
-def test_remote_agent_is_not_restarted_locally(registry, db_path, history, store):
+def test_remote_agent_is_not_restarted_locally(registry, db_path, history, events):
     # Arrange — the row belongs to another host, so its tmux is not ours to
     # read and a local restart would DUPLICATE a live remote agent.
     from scitex_agent_container._state import state_db
@@ -258,7 +264,7 @@ def test_remote_agent_is_not_restarted_locally(registry, db_path, history, store
     state_db.record_instance_start(name="alpha", host="host-b", pid=1, remote=True)
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert
     assert recorder.names == []
 
@@ -266,28 +272,28 @@ def test_remote_agent_is_not_restarted_locally(registry, db_path, history, store
 # --- --dry-run mutates NOTHING ---------------------------------------------
 
 
-def test_dry_run_restarts_nothing(registry, db_path, history, store):
+def test_dry_run_restarts_nothing(registry, db_path, history, events):
     # Arrange — a corpse that WOULD be restarted under --apply.
     write_spec(registry, "alpha")
     ghost("alpha")
     recorder = Recorder()
     # Act — apply defaults to False.
-    run_pass(registry, db_path, history, store, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, restart_fn=recorder)
     # Assert — the irreversible act was never invoked.
     assert recorder.names == []
 
 
-def test_dry_run_reports_would_restart(registry, db_path, history, store):
+def test_dry_run_reports_would_restart(registry, db_path, history, events):
     # Arrange — reporting the corpse is the whole point of the dry run.
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
-    outcome = run_pass(registry, db_path, history, store)
+    outcome = run_pass(registry, db_path, history, events)
     # Assert
     assert verdict_of(outcome, "alpha") is Verdict.WOULD_RESTART
 
 
-def test_dry_run_records_no_restart(registry, db_path, history, store):
+def test_dry_run_records_no_restart(registry, db_path, history, events):
     # Arrange — a dry run must not spend budget it never used, or the next
     # --apply would think alpha was already bounced and debounce it.
     #
@@ -301,26 +307,26 @@ def test_dry_run_records_no_restart(registry, db_path, history, store):
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
-    run_pass(registry, db_path, history, store)
+    run_pass(registry, db_path, history, events)
     # Assert
     assert load_history(history) == {}
 
 
-def test_dry_run_raises_no_down_card(registry, db_path, history, store):
-    # Arrange — a dry run reports; it must not mutate the shared board about
+def test_dry_run_records_no_down_verdict(registry, db_path, history, events):
+    # Arrange — a dry run reports; it must not record a claim about
     # an AGENT (its own heartbeat is a different, deliberate rail).
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
-    run_pass(registry, db_path, history, store)
+    run_pass(registry, db_path, history, events)
     # Assert
-    assert scitex_todo.list_tasks(store, blocking_me=True) == []
+    assert _degraded_subjects(events) == []
 
 
 # --- "I could not look" is not "nothing is there" --------------------------
 
 
-def test_blind_probe_restarts_nothing(registry, db_path, history, store):
+def test_blind_probe_restarts_nothing(registry, db_path, history, events):
     # Arrange — snapshot_fn returns None: the probe could not look (tmux
     # wedged, or we are in a container). Inferring death here would restart
     # the ENTIRE fleet at once.
@@ -332,7 +338,7 @@ def test_blind_probe_restarts_nothing(registry, db_path, history, store):
         registry,
         db_path,
         history,
-        store,
+        events,
         apply=True,
         snapshot_fn=lambda **_: None,
         restart_fn=recorder,
@@ -341,20 +347,20 @@ def test_blind_probe_restarts_nothing(registry, db_path, history, store):
     assert recorder.names == []
 
 
-def test_blind_probe_reports_unknown(registry, db_path, history, store):
+def test_blind_probe_reports_unknown(registry, db_path, history, events):
     # Arrange — UNKNOWN must never be rendered as clean.
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
     outcome = run_pass(
-        registry, db_path, history, store, apply=True, snapshot_fn=lambda **_: None
+        registry, db_path, history, events, apply=True, snapshot_fn=lambda **_: None
     )
     # Assert
     assert verdict_of(outcome, "alpha") is Verdict.UNKNOWN
 
 
 def test_empty_fleet_seen_from_a_container_is_blindness(
-    registry, db_path, history, store
+    registry, db_path, history, events
 ):
     # Arrange — THE TRAP: inside a SIF the probe does not fail, it SUCCEEDS
     # and reports an EMPTY fleet (that container's own /tmp has no tmux
@@ -367,7 +373,7 @@ def test_empty_fleet_seen_from_a_container_is_blindness(
         registry,
         db_path,
         history,
-        store,
+        events,
         apply=True,
         snapshot_fn=lambda **_: {},
         in_sif_fn=lambda: True,
@@ -377,7 +383,7 @@ def test_empty_fleet_seen_from_a_container_is_blindness(
     assert recorder.names == []
 
 
-def test_raising_probe_is_unknown_not_dead(registry, db_path, history, store):
+def test_raising_probe_is_unknown_not_dead(registry, db_path, history, events):
     # Arrange — a probe that EXPLODES is a probe that did not look.
     write_spec(registry, "alpha")
     ghost("alpha")
@@ -391,7 +397,7 @@ def test_raising_probe_is_unknown_not_dead(registry, db_path, history, store):
         registry,
         db_path,
         history,
-        store,
+        events,
         apply=True,
         snapshot_fn=_boom,
         restart_fn=recorder,
@@ -400,7 +406,7 @@ def test_raising_probe_is_unknown_not_dead(registry, db_path, history, store):
     assert recorder.names == []
 
 
-def test_tmux_is_probed_once_per_pass(registry, db_path, history, store):
+def test_tmux_is_probed_once_per_pass(registry, db_path, history, events):
     # Arrange — probing per agent costs ~93 tmux spawns a tick, the exact
     # O(N)-subprocess cost that blew the heartbeat tick's budget and got it
     # abandoned. The real probe is batched; this pass must use it that way.
@@ -414,7 +420,7 @@ def test_tmux_is_probed_once_per_pass(registry, db_path, history, store):
         write_spec(registry, name)
         ghost(name)
     # Act
-    run_pass(registry, db_path, history, store, snapshot_fn=_counting)
+    run_pass(registry, db_path, history, events, snapshot_fn=_counting)
     # Assert
     assert len(calls) == 1
 
@@ -422,7 +428,7 @@ def test_tmux_is_probed_once_per_pass(registry, db_path, history, store):
 # --- one bad spec must not strand the fleet --------------------------------
 
 
-def test_unreadable_spec_does_not_abort_the_sweep(registry, db_path, history, store):
+def test_unreadable_spec_does_not_abort_the_sweep(registry, db_path, history, events):
     # Arrange — one malformed spec must not strand the rest of the fleet.
     (registry / "broken").mkdir()
     (registry / "broken" / "spec.yaml").write_text("{[not: valid: yaml")
@@ -430,35 +436,35 @@ def test_unreadable_spec_does_not_abort_the_sweep(registry, db_path, history, st
     ghost("alpha")
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert — alpha is still recovered.
     assert recorder.names == ["alpha"]
 
 
-def test_unreadable_spec_is_reported_unknown(registry, db_path, history, store):
+def test_unreadable_spec_is_reported_unknown(registry, db_path, history, events):
     # Arrange — we cannot know whether it should be running, so we must not
     # guess: it is UNKNOWN, never a corpse.
     (registry / "broken").mkdir()
     (registry / "broken" / "spec.yaml").write_text("{[not: valid: yaml")
     # Act
-    outcome = run_pass(registry, db_path, history, store, apply=True)
+    outcome = run_pass(registry, db_path, history, events, apply=True)
     # Assert
     assert verdict_of(outcome, "broken") is Verdict.UNKNOWN
 
 
-def test_scaffold_dirs_are_not_agents(registry, db_path, history, store):
+def test_scaffold_dirs_are_not_agents(registry, db_path, history, events):
     # Arrange — `_shared` / `_template_*` / `_archive` are scaffolding.
     write_spec(registry, "_template_python")
     # Act
-    outcome = run_pass(registry, db_path, history, store)
+    outcome = run_pass(registry, db_path, history, events)
     # Assert
     assert outcome.reports == ()
 
 
-def test_missing_registry_is_not_a_crash(registry, db_path, history, store, tmp_path):
+def test_missing_registry_is_not_a_crash(registry, db_path, history, events, tmp_path):
     # Arrange — a host with no fleet registry at all reports nothing rather
     # than taking the scheduled pass down.
     # Act
-    outcome = run_pass(tmp_path / "nope", db_path, history, store)
+    outcome = run_pass(tmp_path / "nope", db_path, history, events)
     # Assert
     assert outcome.reports == ()

--- a/tests/scitex_agent_container/_reconcile/test__pass_limits.py
+++ b/tests/scitex_agent_container/_reconcile/test__pass_limits.py
@@ -2,21 +2,21 @@
 
 Sibling of ``test__pass.py`` (which owns WHICH agents get restarted); this
 file owns what happens when the answer is "too many, too often, or not
-working": rate limits, restart failures, exit codes, and the board rails.
+working": rate limits, restart failures, exit codes, and the record rails.
 
-Same no-mocks setup — real temp ``state.db``, real specs, real scitex-todo
-store, real injected clock. Fixtures in ``conftest.py``, helpers in
+Same no-mocks setup — real temp ``state.db``, real specs, a real temp sac
+event log, real injected clock. Fixtures in ``conftest.py``, helpers in
 ``_fleet.py``.
 
 The behaviours that matter:
 
 * the debounce and the hourly cap stop a restart LOOP, which is worse than
   a down agent — it never converges and buries the real cause;
-* COOLING-DOWN (inside the debounce) must NOT card, or every healthy heal
-  raises a card on the next 5-minute tick and the board becomes noise;
-* OVER-BUDGET must card: giving up SILENTLY is the original bug with extra
-  steps;
-* the board is a SIDE rail — a board failure can never unwind, block or
+* COOLING-DOWN (inside the debounce) must NOT record, or every healthy heal
+  leaves a record on the next 5-minute tick and the log becomes noise;
+* OVER-BUDGET must record: giving up SILENTLY is the original bug with
+  extra steps;
+* recording is a SIDE rail — a write failure can never unwind, block or
   rewrite what the pass did to the fleet.
 
 Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
@@ -26,9 +26,13 @@ from __future__ import annotations
 
 import io
 
-import pytest
-
-from scitex_agent_container._reconcile._alarm import HEARTBEAT_CARD_ID, card_id_for
+from scitex_agent_container._events import (
+    PASS_COMPLETED,
+    SUBJECT_DEGRADED,
+    SUBJECT_RECOVERED,
+    read_events,
+)
+from scitex_agent_container._reconcile._alarm import SUBSYSTEM
 from scitex_agent_container._reconcile._budget import DEBOUNCE_S
 from scitex_agent_container._reconcile._rule import Verdict
 from tests.scitex_agent_container._reconcile._fleet import (
@@ -41,13 +45,24 @@ from tests.scitex_agent_container._reconcile._fleet import (
     write_spec,
 )
 
-scitex_todo = pytest.importorskip("scitex_todo")
+
+def _subjects(events, kind: str) -> list[str]:
+    """Subjects this pass recorded under ``kind``, in order."""
+    return [
+        e.subject
+        for e in read_events(events, subsystem=SUBSYSTEM, event=kind)
+    ]
+
+
+def _pass_records(events) -> list:
+    """Every pass-completed record this suite's run(s) left behind."""
+    return read_events(events, subsystem=SUBSYSTEM, event=PASS_COMPLETED)
 
 
 # --- the debounce: a healthy recovery in progress ---------------------------
 
 
-def test_debounce_blocks_a_second_restart(registry, db_path, history, store):
+def test_debounce_blocks_a_second_restart(registry, db_path, history, events):
     # Arrange — restarted 10 min ago (debounce is 30). It is either still
     # booting or something is killing it faster than we can fix it.
     write_spec(registry, "alpha")
@@ -55,52 +70,52 @@ def test_debounce_blocks_a_second_restart(registry, db_path, history, store):
     history.write_text(f'{{"alpha": [{NOW - 600}]}}')
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert
     assert recorder.names == []
 
 
-def test_debounced_agent_reports_cooling_down(registry, db_path, history, store):
+def test_debounced_agent_reports_cooling_down(registry, db_path, history, events):
     # Arrange — a recovery IN PROGRESS, not a failure: it must be
     # distinguishable from "restarting is not fixing it".
     write_spec(registry, "alpha")
     ghost("alpha")
     history.write_text(f'{{"alpha": [{NOW - 600}]}}')
     # Act
-    outcome = run_pass(registry, db_path, history, store, apply=True)
+    outcome = run_pass(registry, db_path, history, events, apply=True)
     # Assert
     assert verdict_of(outcome, "alpha") is Verdict.COOLING_DOWN
 
 
-def test_debounced_agent_raises_no_card(registry, db_path, history, store):
-    # Arrange — THE board-spam guard. The debounce is 30min and the timer
+def test_debounced_agent_records_no_verdict(registry, db_path, history, events):
+    # Arrange — THE log-spam guard. The debounce is 30min and the timer
     # ticks every 5min, so a perfectly HEALTHY restart sits inside its own
-    # debounce for the next five ticks. If that carded, every successful
-    # heal would raise a board card and the operator would learn to ignore
-    # the board — which is how the fleet died unnoticed in the first place.
+    # debounce for the next five ticks. If that recorded, every successful
+    # heal would leave a degraded record and a reader would learn to ignore
+    # the log — which is how the fleet died unnoticed in the first place.
     write_spec(registry, "alpha")
     ghost("alpha")
     history.write_text(f'{{"alpha": [{NOW - 600}]}}')
     # Act
-    run_pass(registry, db_path, history, store, apply=True)
+    run_pass(registry, db_path, history, events, apply=True)
     # Assert
-    assert scitex_todo.list_tasks(store, blocking_me=True) == []
+    assert _subjects(events, SUBJECT_DEGRADED) == []
 
 
 def test_second_pass_inside_debounce_does_not_rebounce(
-    registry, db_path, history, store
+    registry, db_path, history, events
 ):
     # Arrange — a full pass restarts alpha and persists the history.
     write_spec(registry, "alpha")
     ghost("alpha")
-    run_pass(registry, db_path, history, store, apply=True)
+    run_pass(registry, db_path, history, events, apply=True)
     recorder = Recorder()
     # Act — the timer fires again 5 minutes later, agent still down.
     run_pass(
         registry,
         db_path,
         history,
-        store,
+        events,
         apply=True,
         now=NOW + 300,
         restart_fn=recorder,
@@ -109,14 +124,14 @@ def test_second_pass_inside_debounce_does_not_rebounce(
     assert recorder.names == []
 
 
-def test_restart_resumes_after_the_debounce_elapses(registry, db_path, history, store):
+def test_restart_resumes_after_the_debounce_elapses(registry, db_path, history, events):
     # Arrange — one restart, longer ago than the debounce.
     write_spec(registry, "alpha")
     ghost("alpha")
     history.write_text(f'{{"alpha": [{NOW - DEBOUNCE_S - 60}]}}')
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert
     assert recorder.names == ["alpha"]
 
@@ -124,38 +139,36 @@ def test_restart_resumes_after_the_debounce_elapses(registry, db_path, history, 
 # --- the hourly cap: restarting is NOT fixing this --------------------------
 
 
-def test_over_budget_agent_is_not_restarted(registry, db_path, history, store):
+def test_over_budget_agent_is_not_restarted(registry, db_path, history, events):
     # Arrange — 2 restarts inside the hour, the latest past the debounce.
     write_spec(registry, "alpha")
     ghost("alpha")
     history.write_text(f'{{"alpha": [{NOW - 3_500}, {NOW - 1_900}]}}')
     recorder = Recorder()
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert
     assert recorder.names == []
 
 
-def test_over_budget_agent_raises_a_board_card(registry, db_path, history, store):
+def test_over_budget_agent_is_recorded_degraded(registry, db_path, history, events):
     # Arrange — giving up SILENTLY is the original bug with extra steps.
     write_spec(registry, "alpha")
     ghost("alpha")
     history.write_text(f'{{"alpha": [{NOW - 3_500}, {NOW - 1_900}]}}')
     # Act
-    run_pass(registry, db_path, history, store, apply=True)
-    # Assert — it lands on the board's BLOCKING-YOU surface, naming alpha.
-    assert card_id_for("alpha") in [
-        t["id"] for t in scitex_todo.list_tasks(store, blocking_me=True)
-    ]
+    run_pass(registry, db_path, history, events, apply=True)
+    # Assert — it reaches sac's own log as a degraded record, naming alpha.
+    assert _subjects(events, SUBJECT_DEGRADED) == ["alpha"]
 
 
-def test_over_budget_verdict_is_reported(registry, db_path, history, store):
+def test_over_budget_verdict_is_reported(registry, db_path, history, events):
     # Arrange
     write_spec(registry, "alpha")
     ghost("alpha")
     history.write_text(f'{{"alpha": [{NOW - 3_500}, {NOW - 1_900}]}}')
     # Act
-    outcome = run_pass(registry, db_path, history, store, apply=True)
+    outcome = run_pass(registry, db_path, history, events, apply=True)
     # Assert
     assert verdict_of(outcome, "alpha") is Verdict.OVER_BUDGET
 
@@ -163,7 +176,7 @@ def test_over_budget_verdict_is_reported(registry, db_path, history, store):
 # --- the per-pass cap: blast radius of ONE bad tick -------------------------
 
 
-def test_pass_limit_caps_one_tick(registry, db_path, history, store):
+def test_pass_limit_caps_one_tick(registry, db_path, history, events):
     # Arrange — 5 corpses but a limit of 2. If a tmux hiccup ever made the
     # fleet look dead, this is what stops a 93-restart storm.
     for name in ("a1", "a2", "a3", "a4", "a5"):
@@ -172,35 +185,35 @@ def test_pass_limit_caps_one_tick(registry, db_path, history, store):
     recorder = Recorder()
     # Act
     run_pass(
-        registry, db_path, history, store, apply=True, limit=2, restart_fn=recorder
+        registry, db_path, history, events, apply=True, limit=2, restart_fn=recorder
     )
     # Assert
     assert len(recorder.names) == 2
 
 
-def test_capped_agents_are_reported_not_dropped(registry, db_path, history, store):
+def test_capped_agents_are_reported_not_dropped(registry, db_path, history, events):
     # Arrange — the remainder is DEFERRED, not lost, and must be visible.
     for name in ("a1", "a2", "a3"):
         write_spec(registry, name)
         ghost(name)
     # Act
-    outcome = run_pass(registry, db_path, history, store, apply=True, limit=1)
+    outcome = run_pass(registry, db_path, history, events, apply=True, limit=1)
     # Assert
     assert len(outcome.of(Verdict.CAPPED)) == 2
 
 
-def test_capped_agent_gets_no_card(registry, db_path, history, store):
-    # Arrange — CAPPED is retried in 5 minutes; carding it would be noise.
+def test_capped_agent_gets_no_record(registry, db_path, history, events):
+    # Arrange — CAPPED is retried in 5 minutes; recording it would be noise.
     for name in ("a1", "a2"):
         write_spec(registry, name)
         ghost(name)
     # Act
-    run_pass(registry, db_path, history, store, apply=True, limit=1)
+    run_pass(registry, db_path, history, events, apply=True, limit=1)
     # Assert
-    assert scitex_todo.list_tasks(store, blocking_me=True) == []
+    assert _subjects(events, SUBJECT_DEGRADED) == []
 
 
-def test_history_is_persisted_per_restart(registry, db_path, history, store):
+def test_history_is_persisted_per_restart(registry, db_path, history, events):
     # Arrange — the scheduled form runs under a systemd timeout. A pass
     # killed mid-sweep must still remember what it already bounced, or the
     # next tick re-bounces it with the debounce silently disarmed.
@@ -212,7 +225,7 @@ def test_history_is_persisted_per_restart(registry, db_path, history, store):
         registry,
         db_path,
         history,
-        store,
+        events,
         apply=True,
         restart_fn=Recorder(boom=RuntimeError("host died mid-pass")),
     )
@@ -223,19 +236,19 @@ def test_history_is_persisted_per_restart(registry, db_path, history, store):
 # --- restart failures --------------------------------------------------------
 
 
-def test_failed_restart_is_reported_failed(registry, db_path, history, store):
+def test_failed_restart_is_reported_failed(registry, db_path, history, events):
     # Arrange — the restart ran but reported failure; the agent is still down.
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
     outcome = run_pass(
-        registry, db_path, history, store, apply=True, restart_fn=Recorder(ok=False)
+        registry, db_path, history, events, apply=True, restart_fn=Recorder(ok=False)
     )
     # Assert
     assert verdict_of(outcome, "alpha") is Verdict.FAILED
 
 
-def test_raising_restart_does_not_abort_the_sweep(registry, db_path, history, store):
+def test_raising_restart_does_not_abort_the_sweep(registry, db_path, history, events):
     # Arrange — one agent's restart raising must not strand the others: the
     # rest of the fleet is still down and still needs recovering.
     for name in ("a1", "a2"):
@@ -243,94 +256,94 @@ def test_raising_restart_does_not_abort_the_sweep(registry, db_path, history, st
         ghost(name)
     recorder = Recorder(boom=RuntimeError("tmux refused"))
     # Act
-    run_pass(registry, db_path, history, store, apply=True, restart_fn=recorder)
+    run_pass(registry, db_path, history, events, apply=True, restart_fn=recorder)
     # Assert — it tried BOTH.
     assert recorder.names == ["a1", "a2"]
 
 
-def test_failed_restart_raises_a_board_card(registry, db_path, history, store):
+def test_failed_restart_is_recorded_degraded(registry, db_path, history, events):
     # Arrange
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
     run_pass(
-        registry, db_path, history, store, apply=True, restart_fn=Recorder(ok=False)
+        registry, db_path, history, events, apply=True, restart_fn=Recorder(ok=False)
     )
     # Assert
-    assert card_id_for("alpha") in [t["id"] for t in scitex_todo.list_tasks(store)]
+    assert _subjects(events, SUBJECT_DEGRADED) == ["alpha"]
 
 
-def test_recovered_agent_resolves_its_old_card(registry, db_path, history, store):
-    # Arrange — alpha failed once, so a card exists.
+def test_recovered_agent_records_its_recovery(registry, db_path, history, events):
+    # Arrange — alpha failed once, so a degraded record exists.
     write_spec(registry, "alpha")
     ghost("alpha")
     run_pass(
-        registry, db_path, history, store, apply=True, restart_fn=Recorder(ok=False)
+        registry, db_path, history, events, apply=True, restart_fn=Recorder(ok=False)
     )
     # Act — later, alpha is alive again (a fixed problem must stop shouting).
     run_pass(
         registry,
         db_path,
         history,
-        store,
+        events,
         apply=True,
         now=NOW + 99_999,
         snapshot_fn=lambda **_: sessions("alpha"),
     )
     # Assert
-    assert scitex_todo.get_task(store, card_id_for("alpha"))["status"] == "done"
+    assert _subjects(events, SUBJECT_RECOVERED) == ["alpha"]
 
 
 # --- exit codes -------------------------------------------------------------
 
 
-def test_healthy_fleet_exits_clean(registry, db_path, history, store):
+def test_healthy_fleet_exits_clean(registry, db_path, history, events):
     # Arrange
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
     outcome = run_pass(
-        registry, db_path, history, store, snapshot_fn=lambda **_: sessions("alpha")
+        registry, db_path, history, events, snapshot_fn=lambda **_: sessions("alpha")
     )
     # Assert
     assert outcome.exit_code() == 0
 
 
-def test_down_agent_exits_nonzero(registry, db_path, history, store):
+def test_down_agent_exits_nonzero(registry, db_path, history, events):
     # Arrange — cron-friendly: a dry run detecting a corpse must exit != 0.
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
-    outcome = run_pass(registry, db_path, history, store)
+    outcome = run_pass(registry, db_path, history, events)
     # Assert
     assert outcome.exit_code() == 1
 
 
-def test_blind_pass_exits_two(registry, db_path, history, store):
+def test_blind_pass_exits_two(registry, db_path, history, events):
     # Arrange — a pass that could not see the fleet must NOT exit 0 and let
     # a cron log it as a healthy tick. Unknown is not clean.
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
-    outcome = run_pass(registry, db_path, history, store, snapshot_fn=lambda **_: None)
+    outcome = run_pass(registry, db_path, history, events, snapshot_fn=lambda **_: None)
     # Assert
     assert outcome.exit_code() == 2
 
 
-def test_successful_recovery_exits_clean(registry, db_path, history, store):
+def test_successful_recovery_exits_clean(registry, db_path, history, events):
     # Arrange — a pass that healed the fleet did its job; that is a success.
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
-    outcome = run_pass(registry, db_path, history, store, apply=True)
+    outcome = run_pass(registry, db_path, history, events, apply=True)
     # Assert
     assert outcome.exit_code() == 0
 
 
-# --- the heartbeat rides every pass ----------------------------------------
+# --- the pass record rides every pass --------------------------------------
 
 
-def test_clean_pass_still_writes_the_heartbeat(registry, db_path, history, store):
+def test_clean_pass_still_records_the_pass(registry, db_path, history, events):
     # Arrange — "0 restarted, all healthy" is the MOST important tick: a
     # beacon that only appears during trouble cannot prove it is alive.
     write_spec(registry, "alpha")
@@ -340,49 +353,47 @@ def test_clean_pass_still_writes_the_heartbeat(registry, db_path, history, store
         registry,
         db_path,
         history,
-        store,
+        events,
         apply=True,
         snapshot_fn=lambda **_: sessions("alpha"),
     )
     # Assert
-    assert scitex_todo.get_task(store, HEARTBEAT_CARD_ID)["id"] == HEARTBEAT_CARD_ID
+    assert len(_pass_records(events)) == 1
 
 
-def test_empty_fleet_still_writes_the_heartbeat(registry, db_path, history, store):
+def test_empty_fleet_still_records_the_pass(registry, db_path, history, events):
     # Arrange — nothing to do at all is still proof the mechanism ran.
     # Act
-    run_pass(registry, db_path, history, store, apply=True)
+    run_pass(registry, db_path, history, events, apply=True)
     # Assert
-    assert scitex_todo.get_task(store, HEARTBEAT_CARD_ID)["id"] == HEARTBEAT_CARD_ID
+    assert len(_pass_records(events)) == 1
 
 
-def test_dry_run_still_writes_the_heartbeat(registry, db_path, history, store):
+def test_dry_run_still_records_the_pass(registry, db_path, history, events):
     # Arrange — the beacon is about the RECONCILER, not about an agent, so
-    # it ticks in both modes (the note records which).
+    # it ticks in both modes (the record's ``mode`` says which).
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
-    run_pass(registry, db_path, history, store)
+    run_pass(registry, db_path, history, events)
     # Assert
-    assert scitex_todo.get_task(store, HEARTBEAT_CARD_ID)["id"] == HEARTBEAT_CARD_ID
+    assert len(_pass_records(events)) == 1
 
 
-def test_heartbeat_is_reported_to_the_caller(registry, db_path, history, store):
+def test_the_pass_record_is_reported_to_the_caller(registry, db_path, history, events):
     # Arrange
     # Act
-    outcome = run_pass(registry, db_path, history, store, apply=True)
+    outcome = run_pass(registry, db_path, history, events, apply=True)
     # Assert
     assert outcome.heartbeat_ok
 
 
-# --- the board is a SIDE rail: it can never take the pass down -------------
+# --- recording is a SIDE rail: it can never take the pass down -------------
 
 
-def test_board_write_failure_still_restarts(
-    registry, db_path, history, store, unwritable
-):
-    # Arrange — an unwritable store (read-only parent), so the REAL
-    # scitex_todo writer genuinely fails. No mocks: the world says no.
+def test_a_record_write_failure_still_restarts(registry, db_path, history, unwritable):
+    # Arrange — an unwritable event log (read-only parent), so the REAL
+    # event-log writer genuinely fails. No mocks: the world says no.
     write_spec(registry, "alpha")
     ghost("alpha")
     recorder = Recorder(ok=False)
@@ -391,16 +402,16 @@ def test_board_write_failure_still_restarts(
         registry,
         db_path,
         history,
-        store=unwritable,
+        unwritable,
         apply=True,
         restart_fn=recorder,
         err_stream=io.StringIO(),
     )
-    # Assert — the restart still happened; the board rail is secondary.
+    # Assert — the restart still happened; the recording rail is secondary.
     assert recorder.names == ["alpha"]
 
 
-def test_board_write_failure_is_loud(registry, db_path, history, store, unwritable):
+def test_a_record_write_failure_is_loud(registry, db_path, history, unwritable):
     # Arrange — a rail that fails silently is how the fleet died unnoticed.
     write_spec(registry, "alpha")
     ghost("alpha")
@@ -410,7 +421,7 @@ def test_board_write_failure_is_loud(registry, db_path, history, store, unwritab
         registry,
         db_path,
         history,
-        store=unwritable,
+        unwritable,
         apply=True,
         restart_fn=Recorder(ok=False),
         err_stream=stream,
@@ -419,10 +430,8 @@ def test_board_write_failure_is_loud(registry, db_path, history, store, unwritab
     assert "FAILED" in stream.getvalue()
 
 
-def test_board_write_failure_keeps_the_verdict(
-    registry, db_path, history, store, unwritable
-):
-    # Arrange — a board failure must not rewrite what we concluded.
+def test_a_record_write_failure_keeps_the_verdict(registry, db_path, history, unwritable):
+    # Arrange — a recording failure must not rewrite what we concluded.
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
@@ -430,7 +439,7 @@ def test_board_write_failure_keeps_the_verdict(
         registry,
         db_path,
         history,
-        store=unwritable,
+        unwritable,
         apply=True,
         restart_fn=Recorder(ok=False),
         err_stream=io.StringIO(),
@@ -439,9 +448,7 @@ def test_board_write_failure_keeps_the_verdict(
     assert verdict_of(outcome, "alpha") is Verdict.FAILED
 
 
-def test_heartbeat_failure_does_not_stop_restarts(
-    registry, db_path, history, store, unwritable
-):
+def test_a_pass_record_failure_does_not_stop_restarts(registry, db_path, history, unwritable):
     # Arrange — the beacon failing must not cost the fleet its recovery.
     write_spec(registry, "alpha")
     ghost("alpha")
@@ -451,7 +458,7 @@ def test_heartbeat_failure_does_not_stop_restarts(
         registry,
         db_path,
         history,
-        store=unwritable,
+        unwritable,
         apply=True,
         restart_fn=recorder,
         err_stream=io.StringIO(),

--- a/tests/scitex_agent_container/_reconcile/test__pass_state.py
+++ b/tests/scitex_agent_container/_reconcile/test__pass_state.py
@@ -29,9 +29,12 @@ from __future__ import annotations
 
 import io
 
-import pytest
-
-from scitex_agent_container._reconcile._alarm import STATE_CARD_ID
+from scitex_agent_container._events import (
+    SELF_IMPAIRED,
+    SELF_RECOVERED,
+    read_events,
+)
+from scitex_agent_container._reconcile._alarm import SUBSYSTEM
 from scitex_agent_container._reconcile._rule import Verdict
 from tests.scitex_agent_container._reconcile._fleet import (
     Recorder,
@@ -41,7 +44,14 @@ from tests.scitex_agent_container._reconcile._fleet import (
     write_spec,
 )
 
-scitex_todo = pytest.importorskip("scitex_todo")
+
+def _kinds(events) -> list[str]:
+    """The self-state events this pass recorded, in order."""
+    return [
+        e.event
+        for e in read_events(events, subsystem=SUBSYSTEM)
+        if e.event in (SELF_IMPAIRED, SELF_RECOVERED)
+    ]
 
 
 # --- an unreadable BUDGET halts restarts and ALARMS -------------------------
@@ -56,7 +66,7 @@ scitex_todo = pytest.importorskip("scitex_todo")
 # reconciler.
 
 
-def test_unreadable_budget_restarts_nothing(registry, db_path, store, tmp_path):
+def test_unreadable_budget_restarts_nothing(registry, db_path, events, tmp_path):
     # Arrange — a corpse, and a history we are forbidden to read.
     write_spec(registry, "alpha")
     ghost("alpha")
@@ -70,7 +80,7 @@ def test_unreadable_budget_restarts_nothing(registry, db_path, store, tmp_path):
             registry,
             db_path,
             denied / "hist.json",
-            store,
+            events,
             apply=True,
             restart_fn=recorder,
             err_stream=io.StringIO(),
@@ -81,7 +91,7 @@ def test_unreadable_budget_restarts_nothing(registry, db_path, store, tmp_path):
         denied.chmod(0o755)
 
 
-def test_unreadable_budget_is_reported_per_agent(registry, db_path, store, tmp_path):
+def test_unreadable_budget_is_reported_per_agent(registry, db_path, events, tmp_path):
     # Arrange
     write_spec(registry, "alpha")
     ghost("alpha")
@@ -94,7 +104,7 @@ def test_unreadable_budget_is_reported_per_agent(registry, db_path, store, tmp_p
             registry,
             db_path,
             denied / "hist.json",
-            store,
+            events,
             apply=True,
             err_stream=io.StringIO(),
         )
@@ -104,7 +114,7 @@ def test_unreadable_budget_is_reported_per_agent(registry, db_path, store, tmp_p
         denied.chmod(0o755)
 
 
-def test_unreadable_budget_raises_a_state_card(registry, db_path, store, tmp_path):
+def test_unreadable_budget_records_self_impaired(registry, db_path, events, tmp_path):
     # Arrange — a reconciler that quietly does nothing is exactly the
     # "renewal mechanism that cannot report its own failure" class. It must
     # ALARM, not no-op.
@@ -119,17 +129,17 @@ def test_unreadable_budget_raises_a_state_card(registry, db_path, store, tmp_pat
             registry,
             db_path,
             denied / "hist.json",
-            store,
+            events,
             apply=True,
             err_stream=io.StringIO(),
         )
         # Assert
-        assert scitex_todo.get_task(store, STATE_CARD_ID)["id"] == STATE_CARD_ID
+        assert _kinds(events) == [SELF_IMPAIRED]
     finally:
         denied.chmod(0o755)
 
 
-def test_unreadable_budget_is_loud(registry, db_path, store, tmp_path):
+def test_unreadable_budget_is_loud(registry, db_path, events, tmp_path):
     # Arrange
     write_spec(registry, "alpha")
     ghost("alpha")
@@ -143,7 +153,7 @@ def test_unreadable_budget_is_loud(registry, db_path, store, tmp_path):
             registry,
             db_path,
             denied / "hist.json",
-            store,
+            events,
             apply=True,
             err_stream=stream,
         )
@@ -153,7 +163,7 @@ def test_unreadable_budget_is_loud(registry, db_path, store, tmp_path):
         denied.chmod(0o755)
 
 
-def test_unreadable_budget_exits_two(registry, db_path, store, tmp_path):
+def test_unreadable_budget_exits_two(registry, db_path, events, tmp_path):
     # Arrange — being blind about our OWN state must not exit 0 and let a
     # cron log it as a healthy tick.
     write_spec(registry, "alpha")
@@ -167,7 +177,7 @@ def test_unreadable_budget_exits_two(registry, db_path, store, tmp_path):
             registry,
             db_path,
             denied / "hist.json",
-            store,
+            events,
             apply=True,
             err_stream=io.StringIO(),
         )
@@ -177,7 +187,7 @@ def test_unreadable_budget_exits_two(registry, db_path, store, tmp_path):
         denied.chmod(0o755)
 
 
-def test_corrupt_budget_restarts_nothing(registry, db_path, history, store):
+def test_corrupt_budget_restarts_nothing(registry, db_path, history, events):
     # Arrange — a corrupt history means we HAVE a memory and cannot parse
     # it. Treating that as "nothing restarted" disarms the budget just as
     # thoroughly as a permission error.
@@ -190,7 +200,7 @@ def test_corrupt_budget_restarts_nothing(registry, db_path, history, store):
         registry,
         db_path,
         history,
-        store,
+        events,
         apply=True,
         restart_fn=recorder,
         err_stream=io.StringIO(),
@@ -199,24 +209,27 @@ def test_corrupt_budget_restarts_nothing(registry, db_path, history, store):
     assert recorder.names == []
 
 
-def test_readable_budget_resolves_the_state_card(registry, db_path, history, store):
-    # Arrange — the state was unreadable once, so a card exists.
+def test_readable_budget_records_self_recovered(registry, db_path, history, events):
+    # Arrange — the state was unreadable once, so an impairment is on record.
     write_spec(registry, "alpha")
     ghost("alpha")
     history.write_text("{corrupt")
-    run_pass(registry, db_path, history, store, apply=True, err_stream=io.StringIO())
+    run_pass(registry, db_path, history, events, apply=True, err_stream=io.StringIO())
     history.unlink()
-    # Act — the state is readable again; a fixed problem must stop shouting.
-    run_pass(registry, db_path, history, store, apply=True)
+    # Act — the state is readable again; a fixed problem must say so, once.
+    run_pass(registry, db_path, history, events, apply=True)
     # Assert
-    assert scitex_todo.get_task(store, STATE_CARD_ID)["status"] == "done"
+    assert _kinds(events) == [SELF_IMPAIRED, SELF_RECOVERED]
 
 
-def test_healthy_pass_raises_no_state_card(registry, db_path, history, store):
-    # Arrange — a normal first run must not alarm about its own state.
+def test_a_healthy_pass_records_no_self_state(registry, db_path, history, events):
+    # Arrange — a normal first run must not alarm about its own state, AND
+    # must not assert its own health either: the pass runs every five minutes
+    # forever, so a per-tick "I am fine" would both flood the log and empty
+    # ``self-recovered`` of meaning.
     write_spec(registry, "alpha")
     ghost("alpha")
     # Act
-    run_pass(registry, db_path, history, store, apply=True)
+    run_pass(registry, db_path, history, events, apply=True)
     # Assert
-    assert STATE_CARD_ID not in [t["id"] for t in scitex_todo.list_tasks(store)]
+    assert _kinds(events) == []

--- a/tests/scitex_agent_container/cli_pkg/test__account_refresh_alarm_wiring.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_refresh_alarm_wiring.py
@@ -3,22 +3,18 @@
 INCIDENT 2026-07-10: refresh failures reached only the journal; nothing
 paged the operator. These tests drive the REAL CLI against a real
 on-disk account store whose credentials lack a refresh_token (a genuine
-no-network failure path) and verify the alarm chain runs: the lead rail
-is unconfigured in the sandbox, so delivery falls through to the
-scitex-todo help card written into a sandboxed shared store — exactly
-the production fallback order.
+no-network failure path) and verify the alarm chain runs end to end.
 
-No-mocks (PA-306): real store, real CLI, real scitex-todo store file.
-AAA marker comments; one assertion per test.
+The chain's first leg is the DURABLE RECORD in sac's own event log, and
+it is the leg that decides the outcome: the lead ``blocker`` push on top
+is best-effort and is unconfigured in this sandbox (no ``lead:`` block),
+which must NOT stop the account being marked alerted. That is the whole
+point of the split — a fleet with nowhere to push must not re-page on
+every one of the timer's ~12 daily runs.
 
-The whole module requires the OPTIONAL ``scitex_todo`` peer (the
-fallback delivery leg under test) — leaf CI does not install it, so we
-skip there, exactly like ``tests/integration/test_cross_package_imports``
-does for peer modules; the fleet hosts and the umbrella CI (every peer
-installed) run it. Without the peer, the chain ends in the documented
-"ALERT DELIVERY FAILED — every alert rail failed" stderr path (verified
-in CI run 29106433698) instead of a delivered card, so the
-delivered-path assertions below cannot hold there.
+No-mocks (PA-306), no monkeypatching: real account store, real CLI, a
+real temp JSONL event log redirected through the documented
+``SAC_EVENT_LOG`` env var. AAA marker comments; one assertion per test.
 """
 
 from __future__ import annotations
@@ -30,21 +26,22 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-pytest.importorskip("scitex_todo", reason="alarm fallback leg needs scitex-todo")
-
+from scitex_agent_container._events import (
+    EVENT_LOG_ENV,
+    SUBJECT_DEGRADED,
+    read_events,
+)
 from scitex_agent_container._state.account_store import save_account
 from scitex_agent_container.cli_pkg.account_group import account
 
 
 @pytest.fixture(autouse=True)
 def sandbox_env(tmp_path, env_save_restore):
-    """Isolate HOME + every store-resolution env the alarm chain reads."""
+    """Isolate HOME + every path-resolution env the alarm chain reads."""
     home = tmp_path / "home"
     home.mkdir()
     env_save_restore.set("HOME", str(home))
-    env_save_restore.set(
-        "SCITEX_TODO_TASKS_YAML_SHARED", str(tmp_path / "todo-tasks.yaml")
-    )
+    env_save_restore.set(EVENT_LOG_ENV, str(tmp_path / "sac-events.jsonl"))
     env_save_restore.delete("SCITEX_DIR")
     env_save_restore.delete("SAC_NAME")
     env_save_restore.delete("SCITEX_AGENT_CONTAINER_REGISTRY_DIR")
@@ -86,20 +83,23 @@ def test_failed_refresh_prints_alerted_operator_line(
     assert "ALERTED operator" in result.output
 
 
-def test_failed_refresh_upserts_help_card_into_todo_store(
+def test_failed_refresh_records_the_account_in_the_event_log(
     sandbox_env: Path, tmp_path: Path
 ) -> None:
-    # Arrange — the sandbox has no lead: block, so delivery falls
-    # through to the scitex-todo help-card rail (the production
-    # fallback), landing in the sandboxed shared store.
+    # Arrange — the sandbox has no ``lead:`` block, so the push leg fails
+    # for real. The DURABLE RECORD is what must survive that, because it
+    # is the only leg that owes nothing to another host being reachable.
     _seed_stale_account_without_refresh_token(sandbox_env, "stale-acct")
     runner = CliRunner()
     # Act
     runner.invoke(account, ["refresh", "--all"])
-    # Assert — the canonical BLOCKING-YOU card exists for the account.
-    assert "help-accounts-refresh-stale-acct-waiting" in (
-        tmp_path / "todo-tasks.yaml"
-    ).read_text()
+    # Assert
+    degraded = read_events(
+        tmp_path / "sac-events.jsonl",
+        subsystem="accounts-refresh",
+        event=SUBJECT_DEGRADED,
+    )
+    assert [e.subject for e in degraded] == ["stale-acct"]
 
 
 def test_second_run_does_not_realert_for_same_dead_account(

--- a/tests/scitex_agent_container/cli_pkg/test__host_sync.py
+++ b/tests/scitex_agent_container/cli_pkg/test__host_sync.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from scitex_agent_container._events import read_events
 from scitex_agent_container.cli_pkg._host_sync import host_sync
 
 _REPO = "/data/gpfs/projects/punim0264/ywatanabe/scitex-agent-container"
@@ -149,31 +150,29 @@ def test_alarm_without_check_is_a_usage_error(cfg_path):
     assert result.exit_code == 2
 
 
-def test_alarm_writes_a_card_for_a_stale_peer(
+def test_alarm_records_a_stale_peer_as_degraded(
     cfg_path, subprocess_shim, env_save_restore, tmp_path
 ):
-    # Arrange — a real temp board, redirected via the documented env var,
-    # and a peer 4 commits behind the centre.
-    scitex_todo = pytest.importorskip("scitex_todo")
-    store = str(tmp_path / "board.yaml")
-    env_save_restore.set("SCITEX_TODO_TASKS_YAML_SHARED", store)
+    # Arrange — a real temp event log, redirected via the documented env
+    # var, and a peer 4 commits behind the centre.
+    log = tmp_path / "sac-events.jsonl"
+    env_save_restore.set("SAC_EVENT_LOG", str(log))
     subprocess_shim.install(
         "ssh", stdout=_marker_block(head="aaa111", target_sha="bbb222", behind=4)
     )
     # Act — the exact read-only check+alarm form the timer runs.
     CliRunner().invoke(host_sync, ["--check", "spartan", "--alarm"])
-    # Assert — the shout is SEEN: a card for spartan is on the board.
-    ids = [t["id"] for t in scitex_todo.list_tasks(store, blocking_me=True)]
-    assert ids == ["host-sync-drift-spartan"]
+    # Assert — the shout is DURABLE: spartan is recorded degraded.
+    recorded = [(e.event, e.subject) for e in read_events(log)]
+    assert recorded == [("subject-degraded", "spartan")]
 
 
 def test_alarm_is_read_only_and_runs_no_merge(
     cfg_path, subprocess_shim, env_save_restore, tmp_path
 ):
-    # Arrange — a drifted peer plus a redirected board so nothing touches
-    # the real store.
-    pytest.importorskip("scitex_todo")
-    env_save_restore.set("SCITEX_TODO_TASKS_YAML_SHARED", str(tmp_path / "board.yaml"))
+    # Arrange — a drifted peer plus a redirected event log so nothing
+    # touches the real one.
+    env_save_restore.set("SAC_EVENT_LOG", str(tmp_path / "sac-events.jsonl"))
     subprocess_shim.install(
         "ssh", stdout=_marker_block(head="aaa111", target_sha="bbb222", behind=4)
     )

--- a/tests/scitex_agent_container/cli_pkg/test__host_sync.py
+++ b/tests/scitex_agent_container/cli_pkg/test__host_sync.py
@@ -19,6 +19,11 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from scitex_agent_container._events import (
+    EVENT_LOG_ENV,
+    SUBJECT_DEGRADED,
+    read_events,
+)
 from scitex_agent_container.cli_pkg._host_sync import host_sync
 
 _REPO = "/data/gpfs/projects/punim0264/ywatanabe/scitex-agent-container"
@@ -149,31 +154,29 @@ def test_alarm_without_check_is_a_usage_error(cfg_path):
     assert result.exit_code == 2
 
 
-def test_alarm_writes_a_card_for_a_stale_peer(
+def test_alarm_records_an_event_for_a_stale_peer(
     cfg_path, subprocess_shim, env_save_restore, tmp_path
 ):
-    # Arrange — a real temp board, redirected via the documented env var,
+    # Arrange — a real temp event log, redirected via the documented env var,
     # and a peer 4 commits behind the centre.
-    scitex_todo = pytest.importorskip("scitex_todo")
-    store = str(tmp_path / "board.yaml")
-    env_save_restore.set("SCITEX_TODO_TASKS_YAML_SHARED", store)
+    log = tmp_path / "sac-events.jsonl"
+    env_save_restore.set(EVENT_LOG_ENV, str(log))
     subprocess_shim.install(
         "ssh", stdout=_marker_block(head="aaa111", target_sha="bbb222", behind=4)
     )
     # Act — the exact read-only check+alarm form the timer runs.
     CliRunner().invoke(host_sync, ["--check", "spartan", "--alarm"])
-    # Assert — the shout is SEEN: a card for spartan is on the board.
-    ids = [t["id"] for t in scitex_todo.list_tasks(store, blocking_me=True)]
-    assert ids == ["host-sync-drift-spartan"]
+    # Assert — the shout is DURABLE: spartan's drift is in sac's own log.
+    degraded = read_events(log, subsystem="host-sync", event=SUBJECT_DEGRADED)
+    assert [e.subject for e in degraded] == ["spartan"]
 
 
 def test_alarm_is_read_only_and_runs_no_merge(
     cfg_path, subprocess_shim, env_save_restore, tmp_path
 ):
-    # Arrange — a drifted peer plus a redirected board so nothing touches
-    # the real store.
-    pytest.importorskip("scitex_todo")
-    env_save_restore.set("SCITEX_TODO_TASKS_YAML_SHARED", str(tmp_path / "board.yaml"))
+    # Arrange — a drifted peer plus a redirected event log so nothing touches
+    # the real one.
+    env_save_restore.set(EVENT_LOG_ENV, str(tmp_path / "sac-events.jsonl"))
     subprocess_shim.install(
         "ssh", stdout=_marker_block(head="aaa111", target_sha="bbb222", behind=4)
     )

--- a/tests/scitex_agent_container/cli_pkg/test__worktree_gc.py
+++ b/tests/scitex_agent_container/cli_pkg/test__worktree_gc.py
@@ -9,11 +9,11 @@ Two deliberate choices keep this hermetic without faking anything:
   so the merged leg is satisfied locally and ``gh`` is never invoked — no
   network, no flake, and the CLI is exercised with its REAL default seams
   rather than injected ones.
-* ``SCITEX_TODO_TASKS_YAML_SHARED`` is redirected to a temp store for the
-  WHOLE module (verified to be honoured at call time). The alarm defaults
-  ON under ``--apply``, so without this a test would card the operator's
-  real board. Belt and braces: tests whose subject is not the alarm pass
-  ``--no-alarm`` anyway.
+* ``SAC_EVENT_LOG`` is redirected to a temp file for the WHOLE module
+  (resolved at call time, so the redirect is honoured). The alarm defaults
+  ON under ``--apply``, so without this a test would write to the
+  operator's real event log. Belt and braces: tests whose subject is not
+  the alarm pass ``--no-alarm`` anyway.
 
 The assertions that matter are the EXIT CODES and the DISK: ``--dry-run``
 is the default and must leave every directory exactly where it was, and a
@@ -32,6 +32,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from scitex_agent_container._events import read_events
 from scitex_agent_container.cli_pkg._worktree_gc import worktree_gc
 
 
@@ -40,16 +41,16 @@ def _git(repo: Path, *args: str) -> None:
 
 
 @pytest.fixture
-def todo_store(tmp_path: Path, env_save_restore) -> Path:
-    """Redirect scitex-todo to a temp store for this whole module.
+def events_log(tmp_path: Path, env_save_restore) -> Path:
+    """Redirect sac's event log to a temp file for this whole module.
 
     The alarm rides --apply by default; a test must never write to the
-    operator's real board. Env redirect (not a mock) — the same mechanism
+    operator's real log. Env redirect (not a mock) — the same mechanism
     the fleet uses, and it resolves at call time.
     """
-    store = tmp_path / "tasks.yaml"
-    env_save_restore.set("SCITEX_TODO_TASKS_YAML_SHARED", str(store))
-    return store
+    log = tmp_path / "sac-events.jsonl"
+    env_save_restore.set("SAC_EVENT_LOG", str(log))
+    return log
 
 
 @pytest.fixture
@@ -83,7 +84,7 @@ def worktree(repo: Path, tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_dry_run_reports_the_reapable_worktree(repo, worktree, todo_store):
+def test_dry_run_reports_the_reapable_worktree(repo, worktree, events_log):
     # Arrange — a clean, merged worktree; --min-age-hours 0 clears the age gate.
     path = worktree("reapable")
     # Act
@@ -94,7 +95,7 @@ def test_dry_run_reports_the_reapable_worktree(repo, worktree, todo_store):
     assert "would remove" in result.output
 
 
-def test_dry_run_leaves_the_worktree_on_disk(repo, worktree, todo_store):
+def test_dry_run_leaves_the_worktree_on_disk(repo, worktree, events_log):
     # Arrange — the report is a claim; the directory is the fact.
     path = worktree("reapable")
     # Act
@@ -105,7 +106,7 @@ def test_dry_run_leaves_the_worktree_on_disk(repo, worktree, todo_store):
     assert path.is_dir()
 
 
-def test_dry_run_says_it_removed_nothing(repo, worktree, todo_store):
+def test_dry_run_says_it_removed_nothing(repo, worktree, events_log):
     # Arrange — never silent: a dry run must SAY it was a dry run.
     worktree("reapable")
     # Act
@@ -116,7 +117,7 @@ def test_dry_run_says_it_removed_nothing(repo, worktree, todo_store):
     assert "nothing was removed" in result.output
 
 
-def test_dry_run_exits_zero_when_under_cap(repo, worktree, todo_store):
+def test_dry_run_exits_zero_when_under_cap(repo, worktree, events_log):
     # Arrange
     worktree("reapable")
     # Act
@@ -132,7 +133,7 @@ def test_dry_run_exits_zero_when_under_cap(repo, worktree, todo_store):
 # ---------------------------------------------------------------------------
 
 
-def test_apply_removes_the_reapable_worktree(repo, worktree, todo_store):
+def test_apply_removes_the_reapable_worktree(repo, worktree, events_log):
     # Arrange — the one case where deleting is right.
     path = worktree("reapable")
     # Act
@@ -144,7 +145,7 @@ def test_apply_removes_the_reapable_worktree(repo, worktree, todo_store):
     assert not path.exists()
 
 
-def test_apply_keeps_the_dirty_worktree(repo, worktree, todo_store):
+def test_apply_keeps_the_dirty_worktree(repo, worktree, events_log):
     # Arrange — merged + old, but dirty. --apply must not touch it.
     path = worktree("dirty")
     (path / "README.md").write_text("uncommitted\n")
@@ -157,7 +158,7 @@ def test_apply_keeps_the_dirty_worktree(repo, worktree, todo_store):
     assert (path / "README.md").read_text() == "uncommitted\n"
 
 
-def test_apply_names_the_keep_reason(repo, worktree, todo_store):
+def test_apply_names_the_keep_reason(repo, worktree, events_log):
     # Arrange — "kept" alone is useless; WHY is the product.
     path = worktree("dirty")
     (path / "README.md").write_text("uncommitted\n")
@@ -175,7 +176,7 @@ def test_apply_names_the_keep_reason(repo, worktree, todo_store):
 # ---------------------------------------------------------------------------
 
 
-def test_over_cap_exits_non_zero(repo, worktree, todo_store):
+def test_over_cap_exits_non_zero(repo, worktree, events_log):
     # Arrange — one dirty survivor against a cap of 0. An alarm that exits
     # 0 on sprawl is a report nobody reads.
     path = worktree("dirty")
@@ -189,7 +190,7 @@ def test_over_cap_exits_non_zero(repo, worktree, todo_store):
     assert result.exit_code == 1
 
 
-def test_unreadable_repo_exits_two(tmp_path, todo_store):
+def test_unreadable_repo_exits_two(tmp_path, events_log):
     # Arrange — unknown OUTRANKS over-cap: it is a known-bad you cannot see.
     plain = tmp_path / "not-a-repo"
     plain.mkdir()
@@ -199,7 +200,7 @@ def test_unreadable_repo_exits_two(tmp_path, todo_store):
     assert result.exit_code == 2
 
 
-def test_unreadable_repo_is_labelled_unknown(tmp_path, todo_store):
+def test_unreadable_repo_is_labelled_unknown(tmp_path, events_log):
     # Arrange — "could not read" must never render as "clean".
     plain = tmp_path / "not-a-repo"
     plain.mkdir()
@@ -214,7 +215,7 @@ def test_unreadable_repo_is_labelled_unknown(tmp_path, todo_store):
 # ---------------------------------------------------------------------------
 
 
-def test_repo_and_all_together_is_a_usage_error(repo, todo_store):
+def test_repo_and_all_together_is_a_usage_error(repo, events_log):
     # Arrange
     # Act
     result = CliRunner().invoke(worktree_gc, ["--repo", str(repo), "--all"])
@@ -222,7 +223,7 @@ def test_repo_and_all_together_is_a_usage_error(repo, todo_store):
     assert result.exit_code == 2
 
 
-def test_neither_repo_nor_all_is_a_usage_error(todo_store):
+def test_neither_repo_nor_all_is_a_usage_error(events_log):
     # Arrange
     # Act
     result = CliRunner().invoke(worktree_gc, [])
@@ -230,7 +231,7 @@ def test_neither_repo_nor_all_is_a_usage_error(todo_store):
     assert result.exit_code == 2
 
 
-def test_apply_with_dry_run_is_a_usage_error(repo, todo_store):
+def test_apply_with_dry_run_is_a_usage_error(repo, events_log):
     # Arrange — opposites. Silently preferring one would be a coin flip on
     # whether the run destroys anything.
     # Act
@@ -246,7 +247,7 @@ def test_apply_with_dry_run_is_a_usage_error(repo, todo_store):
 # ---------------------------------------------------------------------------
 
 
-def test_json_output_carries_the_exit_code(repo, worktree, todo_store):
+def test_json_output_carries_the_exit_code(repo, worktree, events_log):
     # Arrange — cron reads the JSON; it must agree with the exit code.
     path = worktree("dirty")
     (path / "README.md").write_text("uncommitted\n")
@@ -268,7 +269,7 @@ def test_json_output_carries_the_exit_code(repo, worktree, todo_store):
     assert json.loads(result.output)["exit_code"] == 1
 
 
-def test_json_output_reports_the_keep_reasons(repo, worktree, todo_store):
+def test_json_output_reports_the_keep_reasons(repo, worktree, events_log):
     # Arrange
     path = worktree("dirty")
     (path / "README.md").write_text("uncommitted\n")
@@ -281,7 +282,7 @@ def test_json_output_reports_the_keep_reasons(repo, worktree, todo_store):
     assert json.loads(result.output)["repos"][0]["keep_reasons"] == {"dirty": 1}
 
 
-def test_json_dry_run_reports_zero_removed(repo, worktree, todo_store):
+def test_json_dry_run_reports_zero_removed(repo, worktree, events_log):
     # Arrange
     worktree("reapable")
     # Act
@@ -298,7 +299,7 @@ def test_json_dry_run_reports_zero_removed(repo, worktree, todo_store):
 # ---------------------------------------------------------------------------
 
 
-def test_dry_run_writes_no_card_by_default(repo, worktree, todo_store):
+def test_dry_run_writes_no_card_by_default(repo, worktree, events_log):
     # Arrange — a dry run is a REPORT; it must not mutate the board. Note
     # no --no-alarm here: this pins the DEFAULT.
     path = worktree("dirty")
@@ -308,12 +309,12 @@ def test_dry_run_writes_no_card_by_default(repo, worktree, todo_store):
         worktree_gc, ["--repo", str(repo), "--cap", "0", "--min-age-hours", "0"]
     )
     # Assert
-    assert not todo_store.exists()
+    assert not events_log.exists()
 
 
-def test_apply_over_cap_writes_a_card(repo, worktree, todo_store):
+def test_apply_over_cap_records_the_repo(repo, worktree, events_log):
     # Arrange — the scheduled path: --apply alarms by default, so the
-    # sprawl the GC could NOT fix reaches a surface the operator watches.
+    # sprawl the GC could NOT fix leaves a durable record.
     path = worktree("dirty")
     (path / "README.md").write_text("uncommitted\n")
     # Act
@@ -322,5 +323,5 @@ def test_apply_over_cap_writes_a_card(repo, worktree, todo_store):
         ["--repo", str(repo), "--apply", "--cap", "0", "--min-age-hours", "0"],
     )
     # Assert
-    scitex_todo = pytest.importorskip("scitex_todo")
-    assert len(scitex_todo.list_tasks(str(todo_store), blocking_me=True)) == 1
+    recorded = [e.event for e in read_events(events_log)]
+    assert recorded == ["subject-degraded"]

--- a/tests/scitex_agent_container/cli_pkg/test__worktree_gc.py
+++ b/tests/scitex_agent_container/cli_pkg/test__worktree_gc.py
@@ -9,11 +9,11 @@ Two deliberate choices keep this hermetic without faking anything:
   so the merged leg is satisfied locally and ``gh`` is never invoked — no
   network, no flake, and the CLI is exercised with its REAL default seams
   rather than injected ones.
-* ``SCITEX_TODO_TASKS_YAML_SHARED`` is redirected to a temp store for the
-  WHOLE module (verified to be honoured at call time). The alarm defaults
-  ON under ``--apply``, so without this a test would card the operator's
-  real board. Belt and braces: tests whose subject is not the alarm pass
-  ``--no-alarm`` anyway.
+* ``SAC_EVENT_LOG`` is redirected to a temp file for the WHOLE module
+  (resolved per call, so it is honoured at call time). The alarm defaults
+  ON under ``--apply``, so without this a test would write into the
+  operator's real event log. Belt and braces: tests whose subject is not
+  the alarm pass ``--no-alarm`` anyway.
 
 The assertions that matter are the EXIT CODES and the DISK: ``--dry-run``
 is the default and must leave every directory exactly where it was, and a
@@ -32,6 +32,11 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from scitex_agent_container._events import (
+    EVENT_LOG_ENV,
+    SUBJECT_DEGRADED,
+    read_events,
+)
 from scitex_agent_container.cli_pkg._worktree_gc import worktree_gc
 
 
@@ -40,16 +45,16 @@ def _git(repo: Path, *args: str) -> None:
 
 
 @pytest.fixture
-def todo_store(tmp_path: Path, env_save_restore) -> Path:
-    """Redirect scitex-todo to a temp store for this whole module.
+def event_log(tmp_path: Path, env_save_restore) -> Path:
+    """Redirect sac's event log to a temp file for this whole module.
 
     The alarm rides --apply by default; a test must never write to the
-    operator's real board. Env redirect (not a mock) — the same mechanism
-    the fleet uses, and it resolves at call time.
+    operator's real log. Env redirect (not a mock) — the documented
+    ``SAC_EVENT_LOG`` override, resolved per call by ``event_log_path()``.
     """
-    store = tmp_path / "tasks.yaml"
-    env_save_restore.set("SCITEX_TODO_TASKS_YAML_SHARED", str(store))
-    return store
+    log = tmp_path / "sac-events.jsonl"
+    env_save_restore.set(EVENT_LOG_ENV, str(log))
+    return log
 
 
 @pytest.fixture
@@ -83,7 +88,7 @@ def worktree(repo: Path, tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_dry_run_reports_the_reapable_worktree(repo, worktree, todo_store):
+def test_dry_run_reports_the_reapable_worktree(repo, worktree, event_log):
     # Arrange — a clean, merged worktree; --min-age-hours 0 clears the age gate.
     path = worktree("reapable")
     # Act
@@ -94,7 +99,7 @@ def test_dry_run_reports_the_reapable_worktree(repo, worktree, todo_store):
     assert "would remove" in result.output
 
 
-def test_dry_run_leaves_the_worktree_on_disk(repo, worktree, todo_store):
+def test_dry_run_leaves_the_worktree_on_disk(repo, worktree, event_log):
     # Arrange — the report is a claim; the directory is the fact.
     path = worktree("reapable")
     # Act
@@ -105,7 +110,7 @@ def test_dry_run_leaves_the_worktree_on_disk(repo, worktree, todo_store):
     assert path.is_dir()
 
 
-def test_dry_run_says_it_removed_nothing(repo, worktree, todo_store):
+def test_dry_run_says_it_removed_nothing(repo, worktree, event_log):
     # Arrange — never silent: a dry run must SAY it was a dry run.
     worktree("reapable")
     # Act
@@ -116,7 +121,7 @@ def test_dry_run_says_it_removed_nothing(repo, worktree, todo_store):
     assert "nothing was removed" in result.output
 
 
-def test_dry_run_exits_zero_when_under_cap(repo, worktree, todo_store):
+def test_dry_run_exits_zero_when_under_cap(repo, worktree, event_log):
     # Arrange
     worktree("reapable")
     # Act
@@ -132,7 +137,7 @@ def test_dry_run_exits_zero_when_under_cap(repo, worktree, todo_store):
 # ---------------------------------------------------------------------------
 
 
-def test_apply_removes_the_reapable_worktree(repo, worktree, todo_store):
+def test_apply_removes_the_reapable_worktree(repo, worktree, event_log):
     # Arrange — the one case where deleting is right.
     path = worktree("reapable")
     # Act
@@ -144,7 +149,7 @@ def test_apply_removes_the_reapable_worktree(repo, worktree, todo_store):
     assert not path.exists()
 
 
-def test_apply_keeps_the_dirty_worktree(repo, worktree, todo_store):
+def test_apply_keeps_the_dirty_worktree(repo, worktree, event_log):
     # Arrange — merged + old, but dirty. --apply must not touch it.
     path = worktree("dirty")
     (path / "README.md").write_text("uncommitted\n")
@@ -157,7 +162,7 @@ def test_apply_keeps_the_dirty_worktree(repo, worktree, todo_store):
     assert (path / "README.md").read_text() == "uncommitted\n"
 
 
-def test_apply_names_the_keep_reason(repo, worktree, todo_store):
+def test_apply_names_the_keep_reason(repo, worktree, event_log):
     # Arrange — "kept" alone is useless; WHY is the product.
     path = worktree("dirty")
     (path / "README.md").write_text("uncommitted\n")
@@ -175,7 +180,7 @@ def test_apply_names_the_keep_reason(repo, worktree, todo_store):
 # ---------------------------------------------------------------------------
 
 
-def test_over_cap_exits_non_zero(repo, worktree, todo_store):
+def test_over_cap_exits_non_zero(repo, worktree, event_log):
     # Arrange — one dirty survivor against a cap of 0. An alarm that exits
     # 0 on sprawl is a report nobody reads.
     path = worktree("dirty")
@@ -189,7 +194,7 @@ def test_over_cap_exits_non_zero(repo, worktree, todo_store):
     assert result.exit_code == 1
 
 
-def test_unreadable_repo_exits_two(tmp_path, todo_store):
+def test_unreadable_repo_exits_two(tmp_path, event_log):
     # Arrange — unknown OUTRANKS over-cap: it is a known-bad you cannot see.
     plain = tmp_path / "not-a-repo"
     plain.mkdir()
@@ -199,7 +204,7 @@ def test_unreadable_repo_exits_two(tmp_path, todo_store):
     assert result.exit_code == 2
 
 
-def test_unreadable_repo_is_labelled_unknown(tmp_path, todo_store):
+def test_unreadable_repo_is_labelled_unknown(tmp_path, event_log):
     # Arrange — "could not read" must never render as "clean".
     plain = tmp_path / "not-a-repo"
     plain.mkdir()
@@ -214,7 +219,7 @@ def test_unreadable_repo_is_labelled_unknown(tmp_path, todo_store):
 # ---------------------------------------------------------------------------
 
 
-def test_repo_and_all_together_is_a_usage_error(repo, todo_store):
+def test_repo_and_all_together_is_a_usage_error(repo, event_log):
     # Arrange
     # Act
     result = CliRunner().invoke(worktree_gc, ["--repo", str(repo), "--all"])
@@ -222,7 +227,7 @@ def test_repo_and_all_together_is_a_usage_error(repo, todo_store):
     assert result.exit_code == 2
 
 
-def test_neither_repo_nor_all_is_a_usage_error(todo_store):
+def test_neither_repo_nor_all_is_a_usage_error(event_log):
     # Arrange
     # Act
     result = CliRunner().invoke(worktree_gc, [])
@@ -230,7 +235,7 @@ def test_neither_repo_nor_all_is_a_usage_error(todo_store):
     assert result.exit_code == 2
 
 
-def test_apply_with_dry_run_is_a_usage_error(repo, todo_store):
+def test_apply_with_dry_run_is_a_usage_error(repo, event_log):
     # Arrange — opposites. Silently preferring one would be a coin flip on
     # whether the run destroys anything.
     # Act
@@ -246,7 +251,7 @@ def test_apply_with_dry_run_is_a_usage_error(repo, todo_store):
 # ---------------------------------------------------------------------------
 
 
-def test_json_output_carries_the_exit_code(repo, worktree, todo_store):
+def test_json_output_carries_the_exit_code(repo, worktree, event_log):
     # Arrange — cron reads the JSON; it must agree with the exit code.
     path = worktree("dirty")
     (path / "README.md").write_text("uncommitted\n")
@@ -268,7 +273,7 @@ def test_json_output_carries_the_exit_code(repo, worktree, todo_store):
     assert json.loads(result.output)["exit_code"] == 1
 
 
-def test_json_output_reports_the_keep_reasons(repo, worktree, todo_store):
+def test_json_output_reports_the_keep_reasons(repo, worktree, event_log):
     # Arrange
     path = worktree("dirty")
     (path / "README.md").write_text("uncommitted\n")
@@ -281,7 +286,7 @@ def test_json_output_reports_the_keep_reasons(repo, worktree, todo_store):
     assert json.loads(result.output)["repos"][0]["keep_reasons"] == {"dirty": 1}
 
 
-def test_json_dry_run_reports_zero_removed(repo, worktree, todo_store):
+def test_json_dry_run_reports_zero_removed(repo, worktree, event_log):
     # Arrange
     worktree("reapable")
     # Act
@@ -298,9 +303,9 @@ def test_json_dry_run_reports_zero_removed(repo, worktree, todo_store):
 # ---------------------------------------------------------------------------
 
 
-def test_dry_run_writes_no_card_by_default(repo, worktree, todo_store):
-    # Arrange — a dry run is a REPORT; it must not mutate the board. Note
-    # no --no-alarm here: this pins the DEFAULT.
+def test_dry_run_records_nothing_by_default(repo, worktree, event_log):
+    # Arrange — a dry run is a REPORT; it must record no claim about a repo.
+    # Note no --no-alarm here: this pins the DEFAULT.
     path = worktree("dirty")
     (path / "README.md").write_text("uncommitted\n")
     # Act
@@ -308,12 +313,12 @@ def test_dry_run_writes_no_card_by_default(repo, worktree, todo_store):
         worktree_gc, ["--repo", str(repo), "--cap", "0", "--min-age-hours", "0"]
     )
     # Assert
-    assert not todo_store.exists()
+    assert not event_log.exists()
 
 
-def test_apply_over_cap_writes_a_card(repo, worktree, todo_store):
-    # Arrange — the scheduled path: --apply alarms by default, so the
-    # sprawl the GC could NOT fix reaches a surface the operator watches.
+def test_apply_over_cap_records_an_event(repo, worktree, event_log):
+    # Arrange — the scheduled path: --apply alarms by default, so the sprawl
+    # the GC could NOT fix leaves a durable record in sac's own log.
     path = worktree("dirty")
     (path / "README.md").write_text("uncommitted\n")
     # Act
@@ -322,5 +327,6 @@ def test_apply_over_cap_writes_a_card(repo, worktree, todo_store):
         ["--repo", str(repo), "--apply", "--cap", "0", "--min-age-hours", "0"],
     )
     # Assert
-    scitex_todo = pytest.importorskip("scitex_todo")
-    assert len(scitex_todo.list_tasks(str(todo_store), blocking_me=True)) == 1
+    degraded = read_events(event_log, subsystem="worktree-gc",
+                           event=SUBJECT_DEGRADED)
+    assert len(degraded) == 1

--- a/tests/scitex_agent_container/test__card_package_boundary.py
+++ b/tests/scitex_agent_container/test__card_package_boundary.py
@@ -1,0 +1,170 @@
+"""sac's runtime code must not import the third-party task-card package.
+
+sac and that application are separate lineages. sac emits its own operational
+events to its own log (:mod:`scitex_agent_container._events`) and reads nothing
+of anyone else's; whether anything ever consumes those events is not sac's
+concern and must not appear in sac's imports.
+
+WHY A TEST AND NOT A CONVENTION
+    The boundary was stated in prose before and eroded anyway: five modules
+    grew a direct dependency on that application's public writer, and one on a
+    PRIVATE submodule of it, while every docstring involved went on describing
+    the coupling as deliberate. A rule with no detector is a preference.
+
+    The detector is deliberately file-only — it parses source with ``ast`` and
+    imports nothing — so it cannot flake on an install profile, a missing
+    optional dependency, or whatever happens to be on ``sys.path``. It sees the
+    same bytes a reviewer would.
+
+WHY AST AND NOT A GREP
+    Every one of these modules discusses the card application at length in its
+    docstrings, and several legitimately name its ENV VARS and CLI. A text
+    search cannot tell a sentence about a package from a dependency on it. Only
+    ``import`` / ``from … import`` statements count here.
+
+EXACT MATCH, IN BOTH DIRECTIONS
+    :func:`test_only_known_modules_import_card_package` asserts the offender
+    set EQUALS :data:`KNOWN_IMPORTERS` rather than merely being contained in
+    it. A new import fails the test — and so does quietly fixing one of the
+    known two without removing it from the list, because a stale allowance is
+    how an empty list eventually becomes a long one again.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+#: Import names that mean "the third-party task-card application". Both are
+#: listed because the older name is still installed as an alias shim for the
+#: newer one, so importing either is the same dependency.
+CARD_PACKAGES = frozenset({"scitex_todo", "scitex_cards"})
+
+#: The ONLY files under ``src/`` still permitted to import it, each with the
+#: reason it is not yet gone. Both are out of scope for the change that
+#: introduced this test; neither is a runtime alarm path.
+KNOWN_IMPORTERS: dict[str, str] = {
+    "scitex_agent_container/_lifecycle/_rename_cards.py": (
+        "sac agents rename migrates that application's records to the new "
+        "agent name by calling its store directly. Removing this needs a "
+        "decision about what a rename means across the boundary, not a "
+        "mechanical edit — analysed and proposed separately."
+    ),
+    "scitex_agent_container/containers/sif_symbol_probe.py": (
+        "A BUILD-TIME probe that asserts the package was installed into the "
+        "image for OTHER agents to use. sac distributing a package is not sac "
+        "depending on one — this file is never imported by sac at runtime."
+    ),
+}
+
+_SRC = Path(__file__).resolve().parents[2] / "src"
+
+
+def _imports_card_package(source: str) -> bool:
+    """True when ``source`` contains a real import of the card application.
+
+    Handles both statement forms at any nesting depth, so a lazy import inside
+    a function — which is how every one of the removed dependencies was
+    written — counts exactly like a module-level one.
+    """
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            if any(a.name.split(".")[0] in CARD_PACKAGES for a in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and node.module.split(".")[0] in CARD_PACKAGES:
+                return True
+    return False
+
+
+def _offenders() -> set[str]:
+    """Every file under ``src/`` importing the card application, repo-relative."""
+    found = set()
+    for path in sorted(_SRC.rglob("*.py")):
+        if _imports_card_package(path.read_text(encoding="utf-8")):
+            found.add(path.relative_to(_SRC).as_posix())
+    return found
+
+
+def test_only_known_modules_import_card_package() -> None:
+    # Arrange
+    allowed = set(KNOWN_IMPORTERS)
+
+    # Act
+    offenders = _offenders()
+
+    # Assert
+    assert offenders == allowed, (
+        "sac's import boundary moved. Newly importing the card application: "
+        f"{sorted(offenders - allowed)}. No longer importing it, so it must be "
+        f"dropped from KNOWN_IMPORTERS: {sorted(allowed - offenders)}."
+    )
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "scitex_agent_container/_reconcile/_alarm.py",
+        "scitex_agent_container/_authheal/_alarm.py",
+        "scitex_agent_container/_hostsync/_alarm.py",
+        "scitex_agent_container/_maintenance/_worktree_gc_alarm.py",
+        "scitex_agent_container/_account/refresh_alarm.py",
+    ],
+)
+def test_alarm_rails_do_not_import_card_package(module: str) -> None:
+    """Named individually so a regression says WHICH rail regressed.
+
+    These five wrote to that application's store on every scheduled pass. They
+    are the reason the boundary is enforced rather than described.
+    """
+    # Arrange
+    source = (_SRC / module).read_text(encoding="utf-8")
+
+    # Act
+    imports_it = _imports_card_package(source)
+
+    # Assert
+    assert not imports_it, f"{module} imports the card application again"
+
+
+def test_detector_sees_a_planted_import() -> None:
+    """MUTATION PROOF: the detector must go RED on a reintroduced import.
+
+    A boundary test that cannot fail is decoration. This plants the exact
+    statement form the alarm rails used — a lazy ``from … import`` inside a
+    function body — and asserts the detector catches it. Without this, a
+    detector broken into always returning ``False`` would keep the suite green
+    while the boundary quietly rotted.
+    """
+    # Arrange
+    planted = (
+        "def _upsert():\n    from scitex_todo import add_task\n    return add_task\n"
+    )
+
+    # Act
+    detected = _imports_card_package(planted)
+
+    # Assert
+    assert detected, "the detector failed to see a lazy card-package import"
+
+
+def test_detector_ignores_a_mere_mention() -> None:
+    """The counterpart: prose about the package is not a dependency on it.
+
+    Several modules legitimately name that application's env vars and CLI in
+    docstrings and string constants. A detector that flagged those would be
+    unusable, and would be silenced — which is the real failure mode.
+    """
+    # Arrange
+    prose = (
+        '"""Sets SCITEX_TODO_AGENT_ID; see scitex_todo._store."""\n'
+        'CMD = "scitex-cards may-stop"\n'
+    )
+
+    # Act
+    detected = _imports_card_package(prose)
+
+    # Assert
+    assert not detected, "the detector flagged a docstring mention as an import"


### PR DESCRIPTION
## What this changes

sac's unattended passes — the fleet reconciler, the auth-heal login-expired restarter, the host-sync drift check, the worktree GC, the accounts refresh — decide things about the fleet every few minutes, forever, with nobody watching. Their verdicts went to stderr and into a **third-party application's data store**.

Neither is sac's own record:

- the stderr line lands in a journal nobody opens — which is how a dead cron job stayed dead for 49 days;
- a store sac does not own can be absent, unwritable, or renamed, and when it is, sac retains **no account of what its own timers decided**.

sac's auditability cannot be contingent on software sac does not own. An unlogged decision is an undebuggable one. So sac now keeps its own log, for its own reasons.

`sac` no longer imports any third-party card package on any alarm path.

## The record shape, and why it carries facts

New package `src/scitex_agent_container/_events/`. Append-only JSONL, default `<runtime>/sac-events.jsonl`, relocatable with `SAC_EVENT_LOG`, path resolved **per call** (a module-level constant computed at import cannot be redirected by an env var a test sets afterwards — a trap this repo has already paid for).

```json
{"timestamp_utc": "...", "event": "subject-degraded", "subsystem": "host-sync",
 "subject": "spartan", "subject_kind": "peer", "verdict": "behind",
 "detail": "spartan is NOT running the centre's code — 4 behind",
 "host": "ywata-note-win", "pid": 12345,
 "state": "behind", "target": "origin/develop", "module": "..."}
```

Every field answers a question sac has about **sac**: which of my passes was speaking, what did it look at, what did it conclude, when, on which host, in which process. The vocabulary is sac's own — `pass-completed`, `subject-degraded`, `subject-unknown`, `subject-recovered`, `self-impaired`, `self-recovered`. Nothing outside sac is modelled, and no field exists to suit a reader other than sac.

Concretely, that is why there is **no title, no body text, no status, no assignee, and no dedup key**. A `verdict` is the emitting pass's own token passed through **unmapped**, because a verdict translated on its way into the log can no longer be compared against the code that produced it. Structured facts (`state`, `target`, `count_after`, `cap`, `keep_reasons`) are fields rather than prose because fields are queryable and a sentence is not.

Three design rules, each paid for previously:

- **Tri-state, always present.** `subject` / `subject_kind` / `verdict` are `null` rather than absent when they do not apply. An absent field says nobody thought to record it; a null says we looked and could not tell.
- **`subject-unknown` is its own event.** "I could not read this peer" can never be recorded as, or mistaken for, a recovery. "I could not look" must never read as "I looked and it was fine".
- **Fail-open, but never silent.** A failed write returns `False` and never raises — losing a log line is bad, losing the reconcile it described is worse. But it **always prints loudly** to stderr. The rail reports its own failure rather than trusting each caller to remember to; a logging rail that can fail quietly is worse than no rail, because it is believed.

`pass-completed` is written on **every** pass, including dry runs and passes that found nothing wrong. A rail that only writes when there is trouble cannot distinguish HEALTHY from DEAD. Its `counts` carry every verdict the pass reached, including the ones that get no per-subject record, so no verdict is ever wholly unrecorded. Its `mode` field is load-bearing: a hand-run dry run also writes this record, so a reader ignoring `mode` could believe a scheduled timer is alive on the strength of somebody having run the command by hand.

### Transitions, not a heartbeat per subject

DEGRADED and UNKNOWN are recorded every pass (an ongoing problem is an ongoing fact). HEALTHY produces a record only on the **transition** out of a remembered bad state, tracked in a small sac-owned state file beside the log. Otherwise ~100 agents would enter the log every five minutes forever and bury the events that matter. sac already keeps small state files of exactly this kind for exactly this reason (the accounts-refresh dedupe, the reconciler's restart history), so this is the house pattern rather than a new invention.

That state file is an **optimisation of the record, never an input to a decision**. Losing it re-records a degraded subject as newly degraded and misses one recovery edge; it can never cause sac to act, or fail to act, on the fleet.

## Deduplication: four copies became one

Each of the four alarm modules carried its own near-identical private copy of the same `_card_exists` / `_upsert` / `_clear` routing — four hand-maintained variants of the same ~40 lines, which is how two of them ended up with subtly different rules for the same situation. All four now call one shared implementation (`_events/_verdicts.py`). Net ~240 lines of duplication removed.

`_authheal` needs one thing the others must not have: its pass reports **only** the agents currently wedged, so a remembered subject's absence *is* the observation that it recovered. That is a separate explicit call (`recover_absent_subjects`) rather than a flag, because for a whole-fleet pass an absent subject means something entirely different — deleted or unreadable, not healed — and recording that as a recovery would be a false all-clear. Which meaning applies is a property of the calling pass, so it is stated at the call site.

## Files changed

**New**
- `_events/__init__.py`, `_events/_log.py`, `_events/_verdicts.py`
- `tests/scitex_agent_container/test__card_package_boundary.py`

**Alarm rails — no longer import any card package**
- `_reconcile/_alarm.py`, `_authheal/_alarm.py`, `_hostsync/_alarm.py`, `_maintenance/_worktree_gc_alarm.py`, `_account/refresh_alarm.py`

**Call sites / exports**
- `_reconcile/_pass.py`, `_authheal/_pass.py` — `store` param → `events_path`
- `_reconcile/__init__.py`, `_hostsync/__init__.py`, `_maintenance/__init__.py`
- `cli_pkg/_host_sync.py`, `cli_pkg/_worktree_gc.py`, `cli_pkg/_agents_reconcile.py`, `cli_pkg/_agents_restart_login_expired.py`

**Prose that outlived its behaviour** — `_jobs_plugin.py` (JobSpec descriptions), CLI `--alarm` help, `docs/worktree-gc.md`, `scripts/systemd/README.md`, `CHANGELOG.md`

### Breaking

- `reconcile_pass()` / `auth_heal_pass()` take `events_path` where they took `store`.
- `sac host sync --json` and `sac worktree gc --json`: the `alarm` block now uses the uniform keys `degraded` / `unknown` / `recovered` / `failed` (was `drifted/undetermined/cleared/failed` and `exceeded/unreadable/cleared/failed`).
- `heartbeat_carded` → `pass_recorded` in reconcile / restart-login-expired JSON.

No compat shims, no aliases, no dual path.

## Files deliberately NOT changed

**`containers/apptainer-base.def`, `apptainer-scitex.def`, `spartan-sif-bake.sh`, `containers/sif_symbol_probe.py`** — these install a package into the SIF for other agents to use and probe that it imported. sac distributing a package is not sac depending on one; `sif_symbol_probe.py` is never imported by sac at runtime. Judgement call to report, not act on: it asserts the **retired** import name as well as the current one, so it is stricter than it needs to be.

**`_lifecycle/_rename_cards.py`** — see class (3) below.

**`pyproject.toml` entry-point registration** — see class (2) below.

## Class (2) — sac reaching into a third party's extension points

**Correction to an earlier finding.** An automated pass over this concluded the hook bus was a dead self-loop. I checked it directly against the installed package and **that is wrong** — resolving the group live returns sac's own consumer, so the registration is **live and load-bearing**. Removing it would stop card-event notifications reaching containerized agents, whose a2a ports are unreachable inbound. Reporting rather than ripping out was the right call.

What I found:

- **No file under `_listen/` imports the package at all.** The coupling is (i) a group-name string in `pyproject.toml`, and (ii) a hardcoded store path.
- `pyproject.toml` registers `_listen/_card_event_delivery.py:deliver_card_event` into the group `scitex_todo.hooks`. That callable runs **in the third party's process**, not sac's. The file's own docstring already states the contract is bus-only with no import — so the code was already disciplined; only the registration crosses the line.
- The group name is the **retired** one. The installed package's dispatcher docstring names `scitex_cards.hooks`, and that group is empty — yet the live lookup still resolves sac's registration. The two names are not cleanly separated and I could not establish from the outside which is authoritative going forward.
- `_listen/_liveness_tick.py` is the only `entry_points(group=...)` call in `src/`. `_listen/_deploy_freshness.py` carries a `HOOKS_ENTRY_POINT_GROUP` constant that is **never passed to `entry_points()`** — dead weight.
- **`_listen/_liveness_tick_resolve.py` is the sharper coupling**: it reads `~/.scitex/todo/tasks.yaml` and parses the YAML itself, bypassing the package entirely, with the record schema hardcoded in `_liveness_tick_detect.py`. A store-layout dependency with no import is arguably worse than an import, because nothing type-checks it and no boundary test of the kind added here would ever see it.

**Proposal (not done here):** sac stops reaching into another project's extension points in both directions. sac would keep `/v1/notify` — an inbound HTTP endpoint on sac's own daemon, which is sac's own surface and already generic — and drop the entry-point registration, the entry-point lookup, and the direct YAML read. That removes sac's dependency on another project's plugin protocol, its group naming, and its file format in one move, and leaves anything that wants to notify a containerized agent doing so over a documented HTTP endpoint. This is a behaviour change to a live delivery path, so it wants its own PR and its own verification.

## Class (3) — lifecycle / rename helpers

Only **one** file has a real import: `_lifecycle/_rename_cards.py` does `from scitex_todo import _store` — reaching into a **private, underscore-prefixed submodule** of a package that is **not declared as a dependency anywhere in `pyproject.toml`** (not runtime, not optional, not dev). It is present only because the container image installs it.

It is reachable from `sac agents rename <old> <new>`, it both READs and WRITEs, and it has a rollback path. `_rename_plan.py` and `_rename.py` import it at module level, so removing it un-imports the whole rename subsystem. There is a `--no-cards` flag that skips it, and it already fails loud rather than degrading silently.

Everything else in class (3) is env-var **names** (`_rename_spec.py`, `_twin.py`, `runtimes/_board_identity_env.py`), CLI help text, or docstrings — behavioural in the sense that a rename must rewrite those env vars in sac's own spec files, but not an import.

**Proposal (not done here):** what an agent rename means for records held in another application is not a mechanical edit — it is a question about who owns that migration, and the answer is plausibly "not sac". The undeclared dependency should be resolved either way, because today a `sac agents rename` on a host without that package installed fails at a point the user cannot predict from `pyproject.toml`. Out of scope here; it is one of the two entries in the boundary test's allowlist, so it cannot be forgotten.

## Mutation proof

`tests/scitex_agent_container/test__card_package_boundary.py` parses every file under `src/` with `ast` and asserts the set of files importing a card package **EQUALS** the two-entry allowlist. Exact match in both directions: a new import fails, and so does quietly fixing one of the known two without removing it from the list, because a stale allowance is how an empty list becomes a long one again.

It is file-only — it parses source and imports nothing — so it cannot flake on an install profile, a missing optional dependency, or whatever is on `sys.path`. AST rather than grep because several modules legitimately discuss that application, name its env vars, and shell out to its CLI; a text search cannot tell a sentence about a package from a dependency on it.

**Proven RED.** Planting the exact statement form the alarm rails used — a lazy `from scitex_todo import add_task` inside a function body in `_hostsync/_alarm.py`:

```
tests/scitex_agent_container/test__card_package_boundary.py F..F....
E  AssertionError: sac's import boundary moved. Newly importing the card
   application: ['scitex_agent_container/_hostsync/_alarm.py'].
E  AssertionError: scitex_agent_container/_hostsync/_alarm.py imports the
   card application again
2 failed, 6 passed
```

Reverted, back to 8 passed. Two further tests guard the detector itself: one that it catches a planted lazy import, one that it does **not** flag a docstring mention — a detector that flagged prose would be unusable, and an unusable detector gets silenced.

## A bug this found, and the honest cost

**Found by exercising the real path.** Running an actual `reconcile_pass()` and reading the log back showed `record_self_recovered` writing a `self-recovered` record on **every** pass — every five minutes, forever, on a reconciler that had never been impaired. Import checks and unit-shaped reasoning would not have caught it; only running the thing did. Fixed by applying the same transition discipline (`emit_self_state`), verified across all five cases:

```
recover when never impaired -> False, no record
impair                      -> True,  self-impaired
impair again (still broken) -> True,  self-impaired      (ongoing fact)
recover                     -> True,  self-recovered
recover again               -> False, no record
```

### The visibility cost — stated, not hidden

**A degraded agent, a drifted peer, or a sprawling repo now reaches no human-watched surface at all.** Previously these landed somewhere the operator actually looks. Now they land in a JSONL file that nothing watches and no scheduled job reads. Until something reads this log, **these alarms are effectively invisible**.

This is the direct consequence of the ruling and I have not softened it with a fallback write. Two things narrow the gap, and neither closes it:

- `_account/refresh_alarm.py` still pushes account failures at the lead blocker rail — that rail is sac's own (ADR-0013), so it stays. The record is now the mandatory part and the push is best-effort on top.
- The reconcile / auth-heal CLI still prints loudly and still exits non-zero.

The obvious next step, if the gap matters, is for sac to push degraded records at its **own** lead blocker rail the way the accounts rail already does. That is sac's own mechanism, so it would not reintroduce any dependency — but it changes paging behaviour, so I am proposing it rather than smuggling it in.

## What I could not verify

- **Nothing was run on the real fleet host.** Everything here was exercised locally in this worktree against real temp files: the event log end-to-end, a real `reconcile_pass()`, the CLI help for all five affected commands, and the boundary test with and without a planted mutation. Behaviour on the fleet host under the real timers is unverified.
- **Whether `scitex_todo.hooks` or `scitex_cards.hooks` is authoritative going forward** — the live lookup and the installed dispatcher's own docstring disagree, and that is not resolvable from sac's side.
- **No CLI reader for the log yet.** `read_events()` exists and the file is plain JSONL (`jq`-able), but there is no `sac events` verb. Deliberately not added — it is scope, not a gap in the boundary — but it is part of why the visibility cost above is real today.
- The log **rotates nowhere**. `_state/event_log.py` ring-buffers its own per-agent files; this one grows unbounded. Transition-tracking keeps the rate low (a healthy fleet writes a handful of lines per pass, not one per agent), but on a long-lived host it will need a rotation policy.
