### PR TITLE
chore(release): v0.23.0 — cut the [Unreleased] batch, carrying the in-container restart broker fix (#787)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-07-20
+
 ### Fixed
 
 - **`sac agents restart` inside a container reported success while restarting


### PR DESCRIPTION
Cuts the accumulated `[Unreleased]` batch as **0.23.0**.

## Why this release is not routine

**#787** fixed a P0: an in-container `sac agents restart` returned `rc=0` while restarting **nothing**. The host-broker fallback was gated on an error-message substring (`"not found in registry"`) that a bind-mounted spec file prevents from ever being raised — so the broker never fired, the restart ran locally inside the SIF where it cannot touch the host tmux session, and it printed success.

It is merged to develop but **not on the host**. Symbol probe (not version string) against both host interpreters:

```
/home/ywatanabe/.env-3.11/bin/python                    -> must_broker_to_host: False, old gate: True
/home/ywatanabe/.scitex/agent-container/venv/bin/python -> must_broker_to_host: False, old gate: True
```

Restarts silently no-op on this host until a release propagates. That is what this release is for.

## Version choice: 0.23.0

- PyPI's highest published version is **0.22.1** (verified against the `releases` map, not `info.version`).
- `pyproject.toml` has declared `0.23.0` since #783 — this PR does **not** bump it, it cuts the CHANGELOG to match.
- 0.23.0 is unspent on PyPI, so the `(name, version)`-keyed wheel cache cannot serve an older build back under it.
- The batch includes a new `[codex]` extra, so a minor bump is the honest SemVer.

## Change

CHANGELOG only: `## [Unreleased]` -> `## [0.23.0] - 2026-07-20`, leaving a fresh empty `[Unreleased]`.

The version-lie guard (`tests/integration/test_version_not_spent.py`) passes — 9/9, with `unreleased_body` now empty.