### PR TITLE
fix(creds): fail loud on a blind-quota boot pick when a quota cache exists

### DIFF
--- a/src/scitex_agent_container/_account/quota_cache.py
+++ b/src/scitex_agent_container/_account/quota_cache.py
@@ -114,6 +114,30 @@ def _resolve_cache_path(override: Path | str | None) -> Path:
     return host if host is not None else container
 
 
+def quota_cache_present(cache_path: Path | str | None = None) -> bool:
+    """Whether a quota-cache FILE actually exists for the reader to consult.
+
+    This is the discriminator the boot picker's fail-loud gate keys off (see
+    :func:`_creds.pick_healthy_account` ``require_quota_evidence``):
+
+    * ``True`` — a cache source exists (the container bind, or a host
+      ``quota-cache.json`` a populator/cron writes). On such a host an
+      all-UNKNOWN pick is a POPULATOR failure (an empty/stale cache), so the
+      boot should fail loud (constitution §2 — unknown is not "OK") rather than
+      silently launch on an unverifiable, possibly quota-exhausted account
+      (2026-07-20 incident).
+    * ``False`` — no cache source exists at all (a fresh install, CI, or a
+      quota-cron-less host such as a Spartan compute node). The documented
+      graceful-degradation contract holds: the boot degrades to freshness-only
+      and is NEVER blocked on a quota system that this host simply does not run.
+
+    Mirrors :func:`_resolve_cache_path`'s resolution order (container bind →
+    host runtime → legacy). A missing source resolves to the non-existent
+    container default, hence ``False``.
+    """
+    return _resolve_cache_path(cache_path).exists()
+
+
 def _resolve_account(override: str | None) -> str:
     if override is not None:
         return override.strip()
@@ -315,5 +339,6 @@ __all__ = [
     "build_a2a_metadata",
     "default_host_cache_path",
     "host_cache_candidates",
+    "quota_cache_present",
     "write_quota_cache",
 ]

--- a/src/scitex_agent_container/_creds/_account_health.py
+++ b/src/scitex_agent_container/_creds/_account_health.py
@@ -1,0 +1,200 @@
+"""Account-snapshot health probing + operator-facing diagnostics.
+
+The health-model layer beneath :func:`._pick_healthy.pick_healthy_account`.
+Where :mod:`._pick_healthy` answers "which fresh account should run now?",
+this module answers the prior question for ONE account — "is its stored
+credential snapshot usable?" — and renders the fail-loud error message when
+nothing is.
+
+Split out of ``_pick_healthy`` (constitution §3: one cohesive responsibility
+per file) so the picker file stays the pure decision. ``_pick_healthy``
+re-imports every public name here, so
+``from scitex_agent_container._creds._pick_healthy import account_health`` (used
+by :mod:`_account.mint_token`, :mod:`_account.quota_watch`, and tests) keeps
+resolving unchanged.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .._account.creds_sync import (
+    _oauth_expiry_to_seconds,
+    _read_oauth_expiry_raw,
+)
+from .._state.account_store import _store_path
+
+# Health states for one account's snapshot. Mirrors
+# :class:`_account.creds_sync.Freshness` but anchored on a *name* so the
+# picker can return a structured "why I rotated" record to its caller.
+_VALID = "VALID"
+_EXPIRED = "EXPIRED"
+_ABSENT = "ABSENT"
+
+
+class NoHealthyAccountError(RuntimeError):
+    """Raised when no stored account currently has a usable snapshot.
+
+    The message names every probed account and its state so the
+    operator sees the full picture in one error line — they should
+    ``claude /login`` to one of them and ``sac accounts sync-live``,
+    then restart the agent. Surfaced through ``sac agents start``.
+    """
+
+
+@dataclass(frozen=True)
+class AccountHealth:
+    """Health of one stored account's credential snapshot.
+
+    Attributes
+    ----------
+    name
+        The stored-account name (a slug — see
+        :func:`_account.creds_sync.slugify_email`).
+    state
+        ``"VALID"`` (non-expired snapshot present), ``"EXPIRED"`` (a
+        snapshot exists but its ``expiresAt`` is in the past), or
+        ``"ABSENT"`` (no snapshot file on disk, or unparseable).
+    hours_remaining
+        Signed hours to expiry (positive = remaining, negative =
+        past) for VALID/EXPIRED; ``None`` for ABSENT.
+    snapshot_path
+        The EXACT file this probe read (or looked for). INCIDENT
+        2026-07-10: the "EXPIRED (-5.8h)" boot error hid which file it
+        had evaluated, so a snapshot repaired minutes later looked like
+        a false read and cost the investigation hours. Every health
+        record now carries its evidence.
+    expires_at_raw
+        The literal ``claudeAiOauth.expiresAt`` value found in the file
+        (claude-code writes unix milliseconds); ``None`` for ABSENT.
+    """
+
+    name: str
+    state: str
+    hours_remaining: float | None
+    snapshot_path: str | None = None
+    expires_at_raw: float | None = None
+
+    @property
+    def is_healthy(self) -> bool:
+        return self.state == _VALID
+
+
+def account_health(
+    name: str,
+    *,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+    now: float | None = None,
+) -> AccountHealth:
+    """Return the health of one stored account's snapshot.
+
+    Never raises. A missing / unparseable snapshot reads as
+    :class:`AccountHealth` ``state="ABSENT"``.
+
+    This is functionally equivalent to
+    :func:`_account.creds_sync.account_freshness`, re-exposed under a
+    name-anchored shape so :func:`pick_healthy_account` can build the
+    diagnostic error message without losing the account name.
+    """
+    _home = home if home is not None else Path.home()
+    now_ts = now if now is not None else time.time()
+
+    store = _store_path(store_dir, _home)
+    snapshot = store / name / ".credentials.json"
+    # ONE read supplies BOTH the raw evidence value and the normalised
+    # expiry, so the record can never quote a different file state than
+    # the one it judged (a mid-probe rewrite yields a coherent record).
+    raw = _read_oauth_expiry_raw(snapshot) if snapshot.is_file() else None
+    if raw is None:
+        return AccountHealth(
+            name=name,
+            state=_ABSENT,
+            hours_remaining=None,
+            snapshot_path=str(snapshot),
+            expires_at_raw=None,
+        )
+    expiry = _oauth_expiry_to_seconds(raw)
+    hours = (expiry - now_ts) / 3600.0
+    state = _VALID if expiry > now_ts else _EXPIRED
+    return AccountHealth(
+        name=name,
+        state=state,
+        hours_remaining=hours,
+        snapshot_path=str(snapshot),
+        expires_at_raw=raw,
+    )
+
+
+def _discover_candidates(
+    store_dir: Path | None,
+    home: Path,
+) -> list[str]:
+    """Return every stored-account name on disk (sorted, deterministic).
+
+    Best-effort: a missing / unreadable store reads as no candidates
+    (the caller turns that into :class:`NoHealthyAccountError`). We
+    skip the store-internal ``_rotations/`` housekeeping dir so it
+    can never get picked.
+    """
+    store = _store_path(store_dir, home)
+    if not store.is_dir():
+        return []
+    out: list[str] = []
+    # stx-allow: fallback (reason: store iteration is best-effort
+    # discovery; an unreadable dir / partially-created entry must
+    # degrade to "no candidates" so the caller's fail-loud takes over,
+    # never crash with an OSError mid-resolution.)
+    try:
+        for child in sorted(store.iterdir()):
+            if not child.is_dir():
+                continue
+            if child.name.startswith("_"):
+                continue
+            out.append(child.name)
+    except OSError:
+        return []
+    return out
+
+
+def _iso_utc(seconds: float) -> str:
+    """Render a unix-seconds timestamp as a compact ISO-8601 UTC string."""
+    return datetime.fromtimestamp(seconds, tz=timezone.utc).isoformat(
+        timespec="seconds"
+    )
+
+
+def _format_states(healths: list[AccountHealth]) -> str:
+    """Render the operator-facing per-account evidence list for the error.
+
+    Self-diagnosing (INCIDENT 2026-07-10): each entry names the file
+    that was read, the RAW ``expiresAt`` value found in it, and its UTC
+    rendering — so a "this account was fine minutes later!" report can
+    be adjudicated from the error line alone (the snapshot may simply
+    have been rewritten between the probe and the re-check).
+    """
+    parts: list[str] = []
+    for h in healths:
+        if h.hours_remaining is None or h.expires_at_raw is None:
+            parts.append(
+                f"{h.name}={h.state} (no numeric claudeAiOauth.expiresAt; "
+                f"file={h.snapshot_path})"
+            )
+        else:
+            expiry_s = _oauth_expiry_to_seconds(h.expires_at_raw)
+            parts.append(
+                f"{h.name}={h.state} ({h.hours_remaining:+.1f}h; "
+                f"expiresAt={h.expires_at_raw:.0f} = {_iso_utc(expiry_s)}; "
+                f"file={h.snapshot_path})"
+            )
+    return ", ".join(parts) if parts else "(no candidates)"
+
+
+__all__ = [
+    "AccountHealth",
+    "NoHealthyAccountError",
+    "account_health",
+]

--- a/src/scitex_agent_container/_creds/_pick_healthy.py
+++ b/src/scitex_agent_container/_creds/_pick_healthy.py
@@ -14,6 +14,11 @@ hand the start a different account whose snapshot IS healthy; raise
 loudly when NOTHING is healthy (the genuine "all three accounts
 capped/expired" case the operator must fix).
 
+The account-health probing and the operator-facing error rendering it
+uses live in :mod:`._account_health` (``AccountHealth``,
+``account_health``, ``NoHealthyAccountError``); this module is the pure
+pick DECISION on top of them.
+
 Scope (Phase 1, deliberately small)
 -----------------------------------
 * Health is *snapshot freshness*: a non-expired ``claudeAiOauth.
@@ -44,7 +49,8 @@ Scope (Phase 1, deliberately small)
 * GRACEFUL DEGRADATION: the quota cache is best-effort. When it is
   absent / stale / unreadable for an account (or entirely — e.g. a
   host whose cron has not populated it yet), that account degrades to
-  the freshness-only behavior — never a crash, never a blocked boot.
+  the freshness-only behavior — never a crash, never a blocked boot —
+  UNLESS the caller sets ``require_quota_evidence`` (see below).
 * Read-only: this module NEVER writes a snapshot. The existing
   per-agent writable boot-copy in
   :func:`runtimes._apptainer_creds.resolve_cred_file` and its
@@ -59,21 +65,34 @@ operator immediately sees which accounts to refresh. No silent
 fallback to a stale snapshot — running a pinned agent on a known-
 expired token is exactly what the previous fail-loud guard was added
 to prevent.
+
+``require_quota_evidence`` (opt-in, set by the boot preflight) extends
+that contract to the QUOTA axis, per constitution §2 — *unknown is a
+third state, never silently collapsed into "OK"*. When it is set and
+the selected account's cached utilisation is entirely unknown (no 5h
+AND no 7d), the pick is BLIND: the cache told us nothing, so we cannot
+confirm the account has headroom. Rather than boot an agent onto a
+possibly-exhausted account (2026-07-20 incident: an empty cache read
+"5h=? 7d=?" and launched scitex-cards on a 7d=100% account), the picker
+raises. Freshness stays the token gate; this adds "verifiable quota" as
+a boot gate ONLY when the caller asks for it, so library / test callers
+keep the graceful-degradation behaviour by default.
 """
 
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Mapping
 
-from .._account.creds_sync import (
-    _oauth_expiry_to_seconds,
-    _read_oauth_expiry_raw,
+from ._account_health import (
+    AccountHealth,
+    NoHealthyAccountError,
+    _discover_candidates,
+    _format_states,
+    _iso_utc,
+    account_health,
 )
-from .._state.account_store import _store_path
 from ._quota_rank import (
     BLOCKED_5H_PCT,
     EXPIRING_7D_HORIZON_S,
@@ -90,175 +109,10 @@ from ._spend_policy import (
     validate_7d_policy,
 )
 
-# Health states for one account's snapshot. Mirrors
-# :class:`_account.creds_sync.Freshness` but anchored on a *name* so the
-# picker can return a structured "why I rotated" record to its caller.
-_VALID = "VALID"
-_EXPIRED = "EXPIRED"
-_ABSENT = "ABSENT"
-
 # Thresholds live in ._quota_rank (shared with the ranking); the local
 # aliases keep this module's public parameter defaults stable.
 _NEAR_CAP_PCT = NEAR_CAP_7D_PCT
 _BLOCKED_5H_PCT = BLOCKED_5H_PCT
-
-
-class NoHealthyAccountError(RuntimeError):
-    """Raised when no stored account currently has a usable snapshot.
-
-    The message names every probed account and its state so the
-    operator sees the full picture in one error line — they should
-    ``claude /login`` to one of them and ``sac accounts sync-live``,
-    then restart the agent. Surfaced through ``sac agents start``.
-    """
-
-
-@dataclass(frozen=True)
-class AccountHealth:
-    """Health of one stored account's credential snapshot.
-
-    Attributes
-    ----------
-    name
-        The stored-account name (a slug — see
-        :func:`_account.creds_sync.slugify_email`).
-    state
-        ``"VALID"`` (non-expired snapshot present), ``"EXPIRED"`` (a
-        snapshot exists but its ``expiresAt`` is in the past), or
-        ``"ABSENT"`` (no snapshot file on disk, or unparseable).
-    hours_remaining
-        Signed hours to expiry (positive = remaining, negative =
-        past) for VALID/EXPIRED; ``None`` for ABSENT.
-    snapshot_path
-        The EXACT file this probe read (or looked for). INCIDENT
-        2026-07-10: the "EXPIRED (-5.8h)" boot error hid which file it
-        had evaluated, so a snapshot repaired minutes later looked like
-        a false read and cost the investigation hours. Every health
-        record now carries its evidence.
-    expires_at_raw
-        The literal ``claudeAiOauth.expiresAt`` value found in the file
-        (claude-code writes unix milliseconds); ``None`` for ABSENT.
-    """
-
-    name: str
-    state: str
-    hours_remaining: float | None
-    snapshot_path: str | None = None
-    expires_at_raw: float | None = None
-
-    @property
-    def is_healthy(self) -> bool:
-        return self.state == _VALID
-
-
-def account_health(
-    name: str,
-    *,
-    store_dir: Path | None = None,
-    home: Path | None = None,
-    now: float | None = None,
-) -> AccountHealth:
-    """Return the health of one stored account's snapshot.
-
-    Never raises. A missing / unparseable snapshot reads as
-    :class:`AccountHealth` ``state="ABSENT"``.
-
-    This is functionally equivalent to
-    :func:`_account.creds_sync.account_freshness`, re-exposed under a
-    name-anchored shape so :func:`pick_healthy_account` can build the
-    diagnostic error message without losing the account name.
-    """
-    _home = home if home is not None else Path.home()
-    now_ts = now if now is not None else time.time()
-
-    store = _store_path(store_dir, _home)
-    snapshot = store / name / ".credentials.json"
-    # ONE read supplies BOTH the raw evidence value and the normalised
-    # expiry, so the record can never quote a different file state than
-    # the one it judged (a mid-probe rewrite yields a coherent record).
-    raw = _read_oauth_expiry_raw(snapshot) if snapshot.is_file() else None
-    if raw is None:
-        return AccountHealth(
-            name=name,
-            state=_ABSENT,
-            hours_remaining=None,
-            snapshot_path=str(snapshot),
-            expires_at_raw=None,
-        )
-    expiry = _oauth_expiry_to_seconds(raw)
-    hours = (expiry - now_ts) / 3600.0
-    state = _VALID if expiry > now_ts else _EXPIRED
-    return AccountHealth(
-        name=name,
-        state=state,
-        hours_remaining=hours,
-        snapshot_path=str(snapshot),
-        expires_at_raw=raw,
-    )
-
-
-def _discover_candidates(
-    store_dir: Path | None,
-    home: Path,
-) -> list[str]:
-    """Return every stored-account name on disk (sorted, deterministic).
-
-    Best-effort: a missing / unreadable store reads as no candidates
-    (the caller turns that into :class:`NoHealthyAccountError`). We
-    skip the store-internal ``_rotations/`` housekeeping dir so it
-    can never get picked.
-    """
-    store = _store_path(store_dir, home)
-    if not store.is_dir():
-        return []
-    out: list[str] = []
-    # stx-allow: fallback (reason: store iteration is best-effort
-    # discovery; an unreadable dir / partially-created entry must
-    # degrade to "no candidates" so the caller's fail-loud takes over,
-    # never crash with an OSError mid-resolution.)
-    try:
-        for child in sorted(store.iterdir()):
-            if not child.is_dir():
-                continue
-            if child.name.startswith("_"):
-                continue
-            out.append(child.name)
-    except OSError:
-        return []
-    return out
-
-
-def _iso_utc(seconds: float) -> str:
-    """Render a unix-seconds timestamp as a compact ISO-8601 UTC string."""
-    return datetime.fromtimestamp(seconds, tz=timezone.utc).isoformat(
-        timespec="seconds"
-    )
-
-
-def _format_states(healths: list[AccountHealth]) -> str:
-    """Render the operator-facing per-account evidence list for the error.
-
-    Self-diagnosing (INCIDENT 2026-07-10): each entry names the file
-    that was read, the RAW ``expiresAt`` value found in it, and its UTC
-    rendering — so a "this account was fine minutes later!" report can
-    be adjudicated from the error line alone (the snapshot may simply
-    have been rewritten between the probe and the re-check).
-    """
-    parts: list[str] = []
-    for h in healths:
-        if h.hours_remaining is None or h.expires_at_raw is None:
-            parts.append(
-                f"{h.name}={h.state} (no numeric claudeAiOauth.expiresAt; "
-                f"file={h.snapshot_path})"
-            )
-        else:
-            expiry_s = _oauth_expiry_to_seconds(h.expires_at_raw)
-            parts.append(
-                f"{h.name}={h.state} ({h.hours_remaining:+.1f}h; "
-                f"expiresAt={h.expires_at_raw:.0f} = {_iso_utc(expiry_s)}; "
-                f"file={h.snapshot_path})"
-            )
-    return ", ".join(parts) if parts else "(no candidates)"
 
 
 def pick_healthy_account(
@@ -277,6 +131,7 @@ def pick_healthy_account(
     expiring_horizon_s: float = EXPIRING_7D_HORIZON_S,
     spread_key: str | None = None,
     policy: str = POLICY_SPREAD,
+    require_quota_evidence: bool = False,
 ) -> str:
     """Return the stored-account name an agent should run on right now.
 
@@ -288,7 +143,10 @@ def pick_healthy_account(
        unknown) AND it is NOT near-capped (cached 7d utilisation below
        ``near_cap_pct``, or unknown). Unknown quota degrades to
        freshness-only and keeps the preferred — this minimises churn;
-       we only rotate off ``preferred`` on *known* bad quota.
+       we only rotate off ``preferred`` on *known* bad quota. (With
+       ``require_quota_evidence`` a BLIND preferred — no cached 5h AND
+       no cached 7d — is instead rotated off, so a pin we cannot see
+       does not win over a known-headroom alternative.)
     2. Otherwise, the best tier of token-fresh candidates competes —
        see :func:`._quota_rank.pick_ranked`: unblocked-now beats
        5h-blocked, 7d-headroom beats near-capped, known 7d beats
@@ -300,7 +158,9 @@ def pick_healthy_account(
     Quota is a *preference*, not a hard gate: when every fresh
     candidate is blocked or near-capped, the least-bad fresh one is
     still returned (a boot is never blocked on quota — only on there
-    being NOTHING token-fresh, which stays fail-loud).
+    being NOTHING token-fresh, which stays fail-loud). The one
+    exception is ``require_quota_evidence`` (below), which turns a
+    fully-BLIND pick (no cached quota at all) into a loud failure.
 
     Parameters
     ----------
@@ -364,6 +224,16 @@ def pick_healthy_account(
         HIGHEST 7d usage among 5h-unblocked fresh accounts, tie-break
         soonest 7d reset — and a near-capped 7d ``preferred`` is a
         reason to STAY (drain it), never to rotate off.
+    require_quota_evidence
+        Boot-time quota gate (constitution §2 — unknown is not "OK").
+        Default ``False`` preserves graceful degradation for library /
+        test callers. When ``True`` (the ``sac agents start`` boot
+        preflight) a fully-BLIND selection — the picked account has
+        NEITHER a cached 5h NOR a cached 7d utilisation — raises
+        :class:`NoHealthyAccountError` instead of booting an unverifiable
+        account. This fires only when the cache is empty for EVERY fresh
+        candidate (a known-headroom account would have won the ranking);
+        a fleet with known-but-busy quota still returns least-bad.
 
     Returns
     -------
@@ -373,11 +243,12 @@ def pick_healthy_account(
     Raises
     ------
     NoHealthyAccountError
-        When no candidate is :attr:`AccountHealth.is_healthy`. The
-        message names every candidate's state. NEVER falls back to
-        a stale snapshot, and NEVER raised merely because accounts are
-        blocked/near-capped (quota is a preference, freshness is the
-        gate).
+        When no candidate is :attr:`AccountHealth.is_healthy` (the
+        message names every candidate's state; NEVER falls back to a
+        stale snapshot, and NEVER raised merely because accounts are
+        blocked/near-capped — quota is a preference, freshness is the
+        gate). Also raised, when ``require_quota_evidence`` is set, if
+        the selected account's quota is entirely unknown (a blind pick).
     """
     validate_7d_policy(policy)
     _home = home if home is not None else Path.home()
@@ -450,6 +321,8 @@ def pick_healthy_account(
     }
     probe_now = now if now is not None else time.time()
 
+    picked: str | None = None
+
     # 1. Preferred wins when it is fresh AND not blocked-now (5h) AND
     #    not near-capped (7d); unknown quota keeps it (degrade to
     #    freshness-only). Minimises churn: only rotate off `preferred`
@@ -479,8 +352,17 @@ def pick_healthy_account(
             # reason to STAY and drain it, never to rotate off.
             if policy == POLICY_BURN:
                 near_capped = False
-            if not blocked_now and not near_capped:
-                return pref
+            # CONSTITUTION §2 — a BLIND pin (no cached 5h AND no cached
+            # 7d) is NOT "confirmed OK"; under require_quota_evidence do
+            # not keep it. Falling through lets the ranking prefer a
+            # known-headroom account; if none exists (all blind) the
+            # blind-pick gate below turns the pick into a loud failure.
+            pref_blind = pref_5h is None and pref_7d is None
+            keep_pref = not blocked_now and not near_capped
+            if require_quota_evidence and pref_blind:
+                keep_pref = False
+            if keep_pref:
+                picked = pref
 
     # 2. Otherwise the conditional ranking picks among the fresh set —
     #    unblocked beats 5h-blocked, headroom beats near-capped, expiring
@@ -488,18 +370,40 @@ def pick_healthy_account(
     #    load-balances the winning tier across the fleet. Quota is a
     #    preference, not a hard gate: an all-blocked fleet still returns
     #    the least-bad fresh account.
-    return pick_ranked(
-        [h.name for h in fresh],
-        u5,
-        u7,
-        reset_7d=r7,
-        now=probe_now,
-        spread_key=spread_key,
-        near_cap_pct=near_cap_pct,
-        blocked_5h_pct=blocked_5h_pct,
-        expiring_horizon_s=expiring_horizon_s,
-        policy=policy,
-    )
+    if picked is None:
+        picked = pick_ranked(
+            [h.name for h in fresh],
+            u5,
+            u7,
+            reset_7d=r7,
+            now=probe_now,
+            spread_key=spread_key,
+            near_cap_pct=near_cap_pct,
+            blocked_5h_pct=blocked_5h_pct,
+            expiring_horizon_s=expiring_horizon_s,
+            policy=policy,
+        )
+
+    # 4. BLIND-PICK GATE (constitution §2 — unknown is a third state,
+    #    never collapsed into "OK"). Under require_quota_evidence, if the
+    #    selected account has NEITHER a cached 5h NOR a cached 7d reading,
+    #    the quota cache told us nothing about it and we cannot confirm it
+    #    has headroom. Because the ranking prefers a known account over an
+    #    unknown one, a blind winner means EVERY fresh candidate is blind
+    #    (an empty/absent cache) — the 2026-07-20 incident, where the pick
+    #    read "5h=? 7d=?" and booted a 7d=100% account. Refuse rather than
+    #    boot blind; a fleet with known-but-busy quota is unaffected.
+    if require_quota_evidence and u5.get(picked) is None and u7.get(picked) is None:
+        raise NoHealthyAccountError(
+            f"quota cache is blind for the selected account {picked!r} "
+            "(5h=? 7d=? — no cached utilisation for any fresh candidate), "
+            "so the pick cannot be confirmed to have headroom. Refusing to "
+            "boot without verifiable quota (constitution: unknown is not "
+            "'OK'). Fix: populate the cache on THIS host — run `sac accounts "
+            "refresh-quota-cache` (or wait for its cron) — then restart."
+        )
+
+    return picked
 
 
 __all__ = [

--- a/src/scitex_agent_container/_lifecycle/_start_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_start_preflight.py
@@ -147,6 +147,7 @@ def _rotate_among_credentials_files(
     Back-compat: a 1-element pool whose one snapshot is healthy resolves
     to that exact file (no-op — ``credentials_file`` unchanged, no log).
     """
+    from .._account.quota_cache import quota_cache_present
     from .._creds import (
         POLICY_BURN,
         pick_healthy_account,
@@ -203,6 +204,13 @@ def _rotate_among_credentials_files(
         quota_cache_path=quota_cache_path,
         spread_key=config.name,
         policy=policy,
+        # Boot gate (constitution §2): on a host that HAS a quota cache, a
+        # fully-BLIND pick means the populator failed (empty/stale cache) —
+        # fail loud rather than land the agent on an unverifiable, possibly
+        # quota-exhausted account (2026-07-20 incident). A host with NO cache
+        # (fresh install / CI / quota-cron-less Spartan node) still degrades
+        # to freshness-only and boots — the documented never-block invariant.
+        require_quota_evidence=quota_cache_present(quota_cache_path),
     )
 
     picked_path = next(p for slug, p in entries if slug == picked)
@@ -320,6 +328,7 @@ def _rotate_to_healthy_account(
     if not pinned:
         return  # unpinned agent — host live OAuth, untouched.
 
+    from .._account.quota_cache import quota_cache_present
     from .._creds import pick_healthy_account, resolve_7d_policy
 
     policy = resolve_7d_policy()
@@ -331,6 +340,10 @@ def _rotate_to_healthy_account(
         quota_cache_path=quota_cache_path,
         spread_key=config.name,
         policy=policy,
+        # Boot gate (constitution §2): a blind-quota pin fails loud on a host
+        # that HAS a cache (populator failure); a cache-less host degrades and
+        # boots (never-block invariant). See quota_cache_present.
+        require_quota_evidence=quota_cache_present(quota_cache_path),
     )
     if picked == pinned:
         return  # pinned is healthy — no rotation, no log line.

--- a/tests/scitex_agent_container/_creds/test__pick_healthy_require_quota_evidence.py
+++ b/tests/scitex_agent_container/_creds/test__pick_healthy_require_quota_evidence.py
@@ -1,0 +1,235 @@
+"""Blind-quota fail-loud gate for ``_creds._pick_healthy`` (``require_quota_evidence``).
+
+CONSTITUTION §2 — *unknown is a third state, never collapsed into "OK"*. The
+``sac agents start`` boot preflight sets ``require_quota_evidence=True`` so a
+fully-BLIND quota pick — the selected account has NEITHER a cached 5h NOR a
+cached 7d reading — fails loud instead of booting an unverifiable, possibly
+quota-exhausted account. 2026-07-20 incident: an empty quota cache read
+"5h=? 7d=?" and launched scitex-cards on a 7d=100% account.
+
+Default ``require_quota_evidence=False`` must preserve the pre-existing graceful
+degradation (library / test callers, quota-cron-less hosts) — an unknown cache
+never blocks a boot unless the caller opts in.
+
+No mocks (PA-306): real JSON snapshots under a tmp store; quota is injected via
+the ``usage_5h`` / ``usage_7d`` seams. AAA markers (TQ002); descriptive names.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._creds._pick_healthy import (
+    NoHealthyAccountError,
+    pick_healthy_account,
+)
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path):
+    """Force ``Path.home()`` inside ``tmp_path`` for the test's duration."""
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+@pytest.fixture(autouse=True)
+def _isolate_quota_cache(tmp_path: Path):
+    """Point the quota-cache reader at a nonexistent tmp file.
+
+    Agent containers bind the LIVE fleet ``/var/sac/quota-cache.json`` (the
+    reader's default). An explicitly-absent override keeps these tests
+    independent of real production utilisation; quota reaches the picker only
+    through the ``usage_*`` injection seams below.
+    """
+    saved = os.environ.get("SAC_QUOTA_CACHE_PATH")
+    os.environ["SAC_QUOTA_CACHE_PATH"] = str(tmp_path / "absent-quota-cache.json")
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_QUOTA_CACHE_PATH", None)
+        else:
+            os.environ["SAC_QUOTA_CACHE_PATH"] = saved
+
+
+def _write_fresh_snapshot(home: Path, name: str, now: float) -> Path:
+    """Write a token-fresh (future-expiry) credential snapshot for *name*."""
+    path = (
+        home / ".scitex" / "agent-container" / "accounts" / name / ".credentials.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat-not-real",
+                    "refreshToken": "sk-ant-ort-not-real",
+                    "expiresAt": int((now + 100_000) * 1_000),  # far future = VALID
+                    "scopes": ["user:inference"],
+                }
+            }
+        )
+    )
+    return path
+
+
+def test_all_blind_and_required_raises_no_healthy_account_error(_isolate_home):
+    # Arrange: two token-fresh accounts, but the quota cache knows NOTHING
+    # about either (empty injection = every account reads 5h=? 7d=?).
+    home = _isolate_home
+    now = 1_784_530_000.0
+    for name in ("wyusuuke-gmail-com", "ywatanabe-scitex-ai"):
+        _write_fresh_snapshot(home, name, now)
+
+    # Act
+    # Assert: the boot gate refuses a fully-blind pick.
+    with pytest.raises(NoHealthyAccountError):
+        pick_healthy_account(
+            "ywatanabe-scitex-ai",
+            candidates=["wyusuuke-gmail-com", "ywatanabe-scitex-ai"],
+            home=home,
+            now=now,
+            usage_5h={},
+            usage_7d={},
+            require_quota_evidence=True,
+        )
+
+
+def test_all_blind_without_requirement_returns_a_fresh_account(_isolate_home):
+    # Arrange: identical all-blind fleet, but the caller does NOT opt in.
+    home = _isolate_home
+    now = 1_784_530_000.0
+    for name in ("wyusuuke-gmail-com", "ywatanabe-scitex-ai"):
+        _write_fresh_snapshot(home, name, now)
+
+    # Act: default require_quota_evidence=False keeps graceful degradation.
+    picked = pick_healthy_account(
+        "ywatanabe-scitex-ai",
+        candidates=["wyusuuke-gmail-com", "ywatanabe-scitex-ai"],
+        home=home,
+        now=now,
+        usage_5h={},
+        usage_7d={},
+    )
+
+    # Assert: a fresh account is still returned — no fail-loud, no crash.
+    assert picked in {"wyusuuke-gmail-com", "ywatanabe-scitex-ai"}
+
+
+def test_known_headroom_account_wins_over_blind_preferred(_isolate_home):
+    # Arrange: the pinned account is BLIND; a sibling has KNOWN headroom.
+    home = _isolate_home
+    now = 1_784_530_000.0
+    for name in ("ywatanabe-scitex-ai", "wyusuuke-gmail-com"):
+        _write_fresh_snapshot(home, name, now)
+
+    # Act: under the gate a blind pin is rotated off in favour of the account
+    # we can actually see is healthy.
+    picked = pick_healthy_account(
+        "ywatanabe-scitex-ai",  # blind (no injected quota)
+        candidates=["ywatanabe-scitex-ai", "wyusuuke-gmail-com"],
+        home=home,
+        now=now,
+        usage_5h={"wyusuuke-gmail-com": 5.0},
+        usage_7d={"wyusuuke-gmail-com": 5.0},
+        require_quota_evidence=True,
+    )
+
+    # Assert: rotated to the known-headroom account, not the blind pin.
+    assert picked == "wyusuuke-gmail-com"
+
+
+def test_known_but_capped_fleet_returns_least_bad_not_raise(_isolate_home):
+    # Arrange: every account's quota is KNOWN (not blind) but near-capped.
+    home = _isolate_home
+    now = 1_784_530_000.0
+    for name in ("wyusuuke-gmail-com", "ywatanabe-scitex-ai"):
+        _write_fresh_snapshot(home, name, now)
+
+    # Act: the gate fires on BLIND, never on merely-busy — a fleet whose quota
+    # is visible-but-high still returns the least-bad account.
+    picked = pick_healthy_account(
+        None,
+        candidates=["wyusuuke-gmail-com", "ywatanabe-scitex-ai"],
+        home=home,
+        now=now,
+        usage_5h={"wyusuuke-gmail-com": 10.0, "ywatanabe-scitex-ai": 10.0},
+        usage_7d={"wyusuuke-gmail-com": 92.0, "ywatanabe-scitex-ai": 95.0},
+        require_quota_evidence=True,
+    )
+
+    # Assert: no NoHealthyAccountError; a known account is returned.
+    assert picked in {"wyusuuke-gmail-com", "ywatanabe-scitex-ai"}
+
+
+def test_blind_pick_error_names_the_selected_account(_isolate_home):
+    # Arrange: a single fresh account with no quota evidence.
+    home = _isolate_home
+    now = 1_784_530_000.0
+    _write_fresh_snapshot(home, "ywatanabe-scitex-ai", now)
+
+    # Act
+    # Assert: the error identifies which account could not be verified.
+    with pytest.raises(NoHealthyAccountError, match="ywatanabe-scitex-ai"):
+        pick_healthy_account(
+            "ywatanabe-scitex-ai",
+            candidates=["ywatanabe-scitex-ai"],
+            home=home,
+            now=now,
+            usage_5h={},
+            usage_7d={},
+            require_quota_evidence=True,
+        )
+
+
+def test_blind_pick_error_names_the_refresh_command(_isolate_home):
+    # Arrange: a single fresh account with no quota evidence.
+    home = _isolate_home
+    now = 1_784_530_000.0
+    _write_fresh_snapshot(home, "ywatanabe-scitex-ai", now)
+
+    # Act
+    # Assert: the error is actionable — it names the fix command to run.
+    with pytest.raises(NoHealthyAccountError, match="refresh-quota-cache"):
+        pick_healthy_account(
+            "ywatanabe-scitex-ai",
+            candidates=["ywatanabe-scitex-ai"],
+            home=home,
+            now=now,
+            usage_5h={},
+            usage_7d={},
+            require_quota_evidence=True,
+        )
+
+
+def test_known_headroom_preferred_is_kept_under_requirement(_isolate_home):
+    # Arrange: the pinned account has KNOWN headroom on both axes.
+    home = _isolate_home
+    now = 1_784_530_000.0
+    for name in ("ywatanabe-scitex-ai", "wyusuuke-gmail-com"):
+        _write_fresh_snapshot(home, name, now)
+
+    # Act: the gate must not over-fire — a visibly-healthy pin is kept.
+    picked = pick_healthy_account(
+        "ywatanabe-scitex-ai",
+        candidates=["ywatanabe-scitex-ai", "wyusuuke-gmail-com"],
+        home=home,
+        now=now,
+        usage_5h={"ywatanabe-scitex-ai": 10.0, "wyusuuke-gmail-com": 20.0},
+        usage_7d={"ywatanabe-scitex-ai": 10.0, "wyusuuke-gmail-com": 20.0},
+        require_quota_evidence=True,
+    )
+
+    # Assert: the known-good pin is retained.
+    assert picked == "ywatanabe-scitex-ai"

--- a/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
@@ -44,6 +44,28 @@ def _isolate_home(tmp_path: Path) -> Iterator[Path]:
             os.environ["HOME"] = saved
 
 
+@pytest.fixture(autouse=True)
+def _isolate_quota_cache(tmp_path: Path) -> Iterator[None]:
+    """Point the quota-cache reader at a nonexistent tmp file.
+
+    Agent containers bind the LIVE fleet ``/var/sac/quota-cache.json`` (the
+    reader's default). Without this these boot tests would read real fleet
+    utilisation AND, since the fail-loud gate keys off cache PRESENCE, the live
+    bind would make an un-injected pick trip the gate. An absent override keeps
+    them hermetic (no cache present → freshness-only degrade) — quota reaches
+    the picker only through the ``usage_*`` injection seams.
+    """
+    saved = os.environ.get("SAC_QUOTA_CACHE_PATH")
+    os.environ["SAC_QUOTA_CACHE_PATH"] = str(tmp_path / "absent-quota-cache.json")
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_QUOTA_CACHE_PATH", None)
+        else:
+            os.environ["SAC_QUOTA_CACHE_PATH"] = saved
+
+
 def _snapshot_path(home: Path, slug: str) -> Path:
     return (
         home / ".scitex" / "agent-container" / "accounts" / slug / ".credentials.json"

--- a/tests/scitex_agent_container/_lifecycle/test__start_creds_gate_cache_presence.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_creds_gate_cache_presence.py
@@ -1,0 +1,111 @@
+"""Boot fail-loud gate keys off quota-cache PRESENCE (``quota_cache_present``).
+
+The start preflight (:func:`_lifecycle._start._rotate_to_healthy_account`) sets
+``require_quota_evidence`` only when a quota-cache FILE exists on the host. This
+locks the discriminator end-to-end (constitution §2 — unknown is not "OK"):
+
+* a fleet host WITH a cache whose populator produced nothing (empty/stale) →
+  fail loud rather than boot an unverifiable account (2026-07-20 incident:
+  scitex-cards launched on a 7d=100% account read as "5h=? 7d=?");
+* a cache-LESS host (fresh install / CI / quota-cron-less Spartan node) →
+  degrade to freshness-only and boot (the documented never-block invariant).
+
+PA-306: no mocks — real snapshots, real cache files, real ``_rotate`` mutation.
+AAA markers (TQ002); descriptive names; one assertion each (TQ007).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import time
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._creds import NoHealthyAccountError
+from scitex_agent_container._lifecycle._start import _rotate_to_healthy_account
+from scitex_agent_container.config import AgentConfig
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path) -> Iterator[Path]:
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+@pytest.fixture
+def _restore_quota_cache_env() -> Iterator[None]:
+    """Restore ``SAC_QUOTA_CACHE_PATH`` after a test sets it in Arrange.
+
+    Each test points the reader at a DIFFERENT path (a present cache file vs an
+    absent one), so the value is set per-test rather than by an autouse fixture;
+    this only owns teardown.
+    """
+    saved = os.environ.get("SAC_QUOTA_CACHE_PATH")
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_QUOTA_CACHE_PATH", None)
+        else:
+            os.environ["SAC_QUOTA_CACHE_PATH"] = saved
+
+
+def _write_fresh_snapshot(home: Path, slug: str) -> None:
+    path = (
+        home / ".scitex" / "agent-container" / "accounts" / slug / ".credentials.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    future_ms = int((time.time() + 7_200.0) * 1_000)
+    path.write_text(json.dumps({"claudeAiOauth": {"expiresAt": future_ms}}))
+
+
+def _make_pinned_config(name: str, account: str) -> AgentConfig:
+    cfg = AgentConfig(name=name)
+    cfg.claude.account = account
+    return cfg
+
+
+def test_boot_fails_loud_when_cache_present_but_pick_is_blind(
+    _isolate_home: Path, tmp_path: Path, _restore_quota_cache_env: None
+):
+    # Arrange: a token-fresh pinned account, plus a quota cache FILE that
+    # exists but carries NO entry for it (a populator that produced nothing).
+    home = _isolate_home
+    _write_fresh_snapshot(home, "ywatanabe-scitex-ai")
+    cache = tmp_path / "present-quota-cache.json"
+    cache.write_text(json.dumps({"written_at": 1_784_530_000.0, "accounts": {}}))
+    os.environ["SAC_QUOTA_CACHE_PATH"] = str(cache)
+    cfg = _make_pinned_config("cards", "ywatanabe-scitex-ai")
+
+    # Act
+    # Assert: a present-but-blind cache is a populator failure — boot refuses.
+    with pytest.raises(NoHealthyAccountError):
+        _rotate_to_healthy_account(cfg, log_stream=io.StringIO())
+
+
+def test_boot_degrades_and_keeps_pin_when_no_cache_file_exists(
+    _isolate_home: Path, tmp_path: Path, _restore_quota_cache_env: None
+):
+    # Arrange: the same token-fresh pinned account, but NO quota cache file
+    # anywhere the reader looks (a fresh / CI / quota-cron-less host).
+    home = _isolate_home
+    _write_fresh_snapshot(home, "ywatanabe-scitex-ai")
+    os.environ["SAC_QUOTA_CACHE_PATH"] = str(tmp_path / "absent-quota-cache.json")
+    cfg = _make_pinned_config("cards", "ywatanabe-scitex-ai")
+
+    # Act: a cache-less host must never be blocked on a quota system it lacks.
+    _rotate_to_healthy_account(cfg, log_stream=io.StringIO())
+
+    # Assert: the pinned account is kept (degrade to freshness-only, no raise).
+    assert cfg.claude.account == "ywatanabe-scitex-ai"

--- a/tests/scitex_agent_container/_lifecycle/test__start_creds_rotate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_creds_rotate.py
@@ -41,6 +41,28 @@ def _isolate_home(tmp_path: Path) -> Iterator[Path]:
             os.environ["HOME"] = saved
 
 
+@pytest.fixture(autouse=True)
+def _isolate_quota_cache(tmp_path: Path) -> Iterator[None]:
+    """Point the quota-cache reader at a nonexistent tmp file.
+
+    Agent containers bind the LIVE fleet ``/var/sac/quota-cache.json`` (the
+    reader's default). Without this these boot tests would read real fleet
+    utilisation AND, since the fail-loud gate keys off cache PRESENCE, the live
+    bind would make an un-injected pick trip the gate. An absent override keeps
+    them hermetic (no cache present → freshness-only degrade) — quota reaches
+    the picker only through the ``usage_*`` injection seams.
+    """
+    saved = os.environ.get("SAC_QUOTA_CACHE_PATH")
+    os.environ["SAC_QUOTA_CACHE_PATH"] = str(tmp_path / "absent-quota-cache.json")
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_QUOTA_CACHE_PATH", None)
+        else:
+            os.environ["SAC_QUOTA_CACHE_PATH"] = saved
+
+
 def _write_snapshot(home: Path, name: str, expires_at_ms: int) -> None:
     path = (
         home / ".scitex" / "agent-container" / "accounts" / name / ".credentials.json"


### PR DESCRIPTION
## Problem

The account picker collapsed UNKNOWN quota into "OK" (constitution §2 — unknown is a third state, never a pole). With an empty quota cache every account reads `5h=? 7d=?`, so a blind pin was kept and sac booted an agent onto a 7d=100% account — on 2026-07-20 **scitex-cards could not run after a plain restart** because the picker kept selecting the exhausted pinned account.

## Change

- `pick_healthy_account(require_quota_evidence=...)`: a blind pin rotates off toward a known-headroom account; a fully-blind pick raises `NoHealthyAccountError` with an actionable `sac accounts refresh-quota-cache` hint — instead of silently booting unverifiable quota.
- The boot preflight gates on `quota_cache_present()`: a host **with** a cache whose populator produced nothing fails loud; a cache-**less** host (fresh install / CI / quota-cron-less Spartan node) still degrades to freshness-only and boots — the documented never-block invariant is preserved.
- Extract the health-probing + diagnostics layer into `_account_health.py` (behaviour-neutral) so `_pick_healthy.py` clears the 512-line cap.

## Tests

7 picker-gate tests + 2 preflight cache-presence tests (present→fail, absent→boot). The two existing boot-test files now isolate `SAC_QUOTA_CACHE_PATH` (hermetic; they were silently reading the live `/var/sac` bind). **731 passed locally** (`_creds` + `_lifecycle` preflight + `_account`).

## Scope note

The writer-default / apptainer-bind path SSOT was deliberately left OUT — that host-path convention belongs to the scitex-dev cron/path homework. The durable data-flow fix (a `*/5` cron populating the runtime `quota-cache.json`) is already live on ywata-note-win; this PR is the code-side fail-loud defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASLR9KjueRGm4BnZnqUhRF
