### PR TITLE
chore(release): v0.24.0 — sac emits its own event log (#789) + quota fail-loud (#791)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-07-20
+
 ### Changed
 
 - **sac records its own operational events, and no longer writes into a
@@ -38,6 +40,22 @@ versioning follows [SemVer](https://semver.org/).
   `tests/scitex_agent_container/test__card_package_boundary.py` enforces the
   boundary with an AST scan asserting the importer set EXACTLY equals the two
   files still permitted, so both a new import and a stale allowance go red.
+
+### Fixed
+
+- **The account picker booted an agent onto a quota-exhausted account when the
+  quota cache was empty.** It collapsed UNKNOWN quota into "OK" (constitution
+  §2 — unknown is a third state, never a pole), kept a blind pin, and read
+  `5h=? 7d=?` — on 2026-07-20 scitex-cards could not run after a plain restart
+  because the picker kept selecting the exhausted pinned account.
+  `pick_healthy_account` gains `require_quota_evidence`: a blind pin rotates off
+  toward a known-headroom account, and a fully-blind pick fails loud with an
+  actionable `sac accounts refresh-quota-cache` hint. The boot preflight gates
+  it on `quota_cache_present()`, so a host WITH a cache whose populator produced
+  nothing fails loud, while a cache-LESS host (fresh install / CI /
+  quota-cron-less Spartan node) still degrades to freshness-only and boots — the
+  documented never-block invariant is preserved. The health-probing layer moved
+  to `_creds/_account_health.py` (behaviour-neutral extraction).
 
 ## [0.23.0] - 2026-07-20
 


### PR DESCRIPTION
## Release v0.24.0

Cuts the `[Unreleased]` batch as **0.24.0** (CHANGELOG promotion only — no code change). `pyproject.toml` already declares `0.24.0` (set in #789); PyPI's highest published is `0.23.0`, so `0.24.0` is unspent.

Once this merges to `develop`, tagging `v0.24.0` triggers `pypi-publish-and-github-release-on-tag.yml` (PyPI + GitHub release from the tag). A separate `develop→main` PR promotes the release to `main`.

### What v0.24.0 ships

- **#789 `refactor(events)!`** — sac records what its unattended passes (fleet reconciler, auth-heal, host-sync, worktree-GC, accounts refresh) observe and decide to its **own** append-only log `_events/sac-events.jsonl`, and no longer imports the card system on any alarm path. An AST boundary test pins the permitted-importer set.
- **#791 `fix(creds)`** — the account picker collapsed UNKNOWN quota into "OK" and booted an agent onto a quota-exhausted account when the cache was empty (scitex-cards could not run after a plain restart). It now fails loud on a fully-blind pick **when a quota cache exists**, and degrades to freshness-only (never blocked) on a cache-less host (fresh / CI / Spartan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASLR9KjueRGm4BnZnqUhRF
