### PR TITLE
chore(release): v0.24.1 — quota-cache writer/reader path SSOT (#794)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-07-20
+
 ### Fixed
 
 - **The v0.24.0 quota fail-loud hard-blocked `sac agents restart` and its own


### PR DESCRIPTION
## Release v0.24.1 (patch)

Cuts the `[Unreleased]` batch as **0.24.1** (CHANGELOG promotion only — code already merged in #794). `pyproject.toml` already declares `0.24.1`; PyPI's highest is `0.24.0`, so `0.24.1` is unspent.

Once this merges to `develop`, tagging `v0.24.1` triggers the PyPI + GitHub release; a separate `develop→main` PR promotes it.

### What v0.24.1 ships

- **#794 `fix(creds)`** — the v0.24.0 quota fail-loud hard-blocked `sac agents restart` and its own documented fix did nothing: the boot picker reads the **runtime** `quota-cache.json` but `refresh-quota-cache` defaulted to the **legacy** path, so the hint populated a file the picker never read. Writer default + apptainer bind now resolve to the same runtime path the reader reads first, so the fail-loud's actionable hint actually clears the block. A path-SSOT test pins `writer == reader-first-candidate == bind`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASLR9KjueRGm4BnZnqUhRF
