### PR TITLE
chore(release): promote v0.24.1 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-07-20
+
 ### Fixed
 
 - **The v0.24.0 quota fail-loud hard-blocked `sac agents restart` and its own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The v0.24.0 quota fail-loud hard-blocked `sac agents restart` and its own
+  documented fix did nothing.** The boot picker reads the RUNTIME
+  `~/.scitex/agent-container/runtime/quota-cache.json`, but `sac accounts
+  refresh-quota-cache` defaulted to the LEGACY `~/.scitex/quota-cache.json` — so
+  when the picker went blind (a transient stale-cache window), its error told
+  the operator to run `refresh-quota-cache`, which populated a file the picker
+  never read, leaving the restart hard-blocked (2026-07-20: `sac-restart
+  scitex-dev`). The populator's default and the apptainer bind now resolve to
+  the SAME runtime path the reader reads first, so the fail-loud's actionable
+  hint actually clears the block. A path-SSOT test (`test_quota_cache_path_ssot`)
+  pins writer-default == reader-first-candidate == bind so a re-split goes red.
+
 ## [0.24.0] - 2026-07-20
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.0"
+version = "0.24.1"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/_account/quota_cache.py
+++ b/src/scitex_agent_container/_account/quota_cache.py
@@ -252,18 +252,27 @@ def build_a2a_metadata() -> dict[str, Any]:
 
 # ---------------------------------------------------------------------------
 # Writer side — the POPULATOR that produces the aggregate quota-cache.json
-# the reader above consumes. The reader's DEFAULT_QUOTA_CACHE_PATH
-# (/var/sac/quota-cache.json) is the *in-container* bind target; the writer
-# runs on the HOST (via `sac accounts refresh-quota-cache`, typically a cron)
-# and writes the canonical host file ``~/.scitex/quota-cache.json`` that the
-# apptainer runtime binds into each agent at the in-container path. Both ends
-# honour the ``SAC_QUOTA_CACHE_PATH`` override so host-side readers/writers and
-# tests can co-locate on one path.
-DEFAULT_HOST_QUOTA_CACHE_SUBPATH = Path(".scitex") / "quota-cache.json"
+# the reader above consumes. Its default MUST be the SAME path the reader's
+# first candidate resolves to (``HOST_RUNTIME_CACHE_SUBPATH``), or the two
+# silently diverge: a prior split (writer → legacy ~/.scitex/quota-cache.json,
+# reader → runtime) meant `sac accounts refresh-quota-cache` wrote a file the
+# picker never read, so the picker stayed BLIND and the fail-loud boot gate's
+# own actionable hint ("run refresh-quota-cache") could not clear the block
+# (2026-07-20 incident: `sac-restart scitex-dev` hard-failed and the documented
+# fix did nothing). Writer default == reader first candidate == apptainer bind
+# is the SSOT that makes that hint actually work. ``SAC_QUOTA_CACHE_PATH``
+# overrides both ends so host readers/writers and tests co-locate on one path.
+DEFAULT_HOST_QUOTA_CACHE_SUBPATH = HOST_RUNTIME_CACHE_SUBPATH
 
 
 def default_host_cache_path(home: Path | None = None) -> Path:
-    """Canonical HOST path the populator writes (``~/.scitex/quota-cache.json``)."""
+    """Canonical HOST path the populator writes.
+
+    ``~/.scitex/agent-container/runtime/quota-cache.json`` — the SAME path
+    :func:`host_cache_candidates` returns first (the reader) and the apptainer
+    bind resolves to, so a plain ``sac accounts refresh-quota-cache`` populates
+    exactly the file the boot picker reads.
+    """
     _home = home if home is not None else Path.home()
     return _home / DEFAULT_HOST_QUOTA_CACHE_SUBPATH
 

--- a/src/scitex_agent_container/runtimes/_apptainer_quota_cache.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_quota_cache.py
@@ -21,20 +21,47 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-QUOTA_CACHE_HOST_PATH_DEFAULT = "/home/ywatanabe/.scitex/quota-cache.json"
+# The canonical host source is sac's OWN runtime dir — SSOT with the writer's
+# default (:data:`_account.quota_cache.HOST_RUNTIME_CACHE_SUBPATH`) and the
+# reader's first candidate. Binding the legacy top-level path while the writer
+# had migrated to runtime is what let the in-container reader read a stale file
+# (2026-07-20 quota-blind incident); all three layers must agree on ONE path.
+QUOTA_CACHE_HOST_PATH_DEFAULT = (
+    "/home/ywatanabe/.scitex/agent-container/runtime/quota-cache.json"
+)
 QUOTA_CACHE_CONTAINER_PATH = "/var/sac/quota-cache.json"
 QUOTA_CACHE_HOST_PATH_ENV = "SAC_QUOTA_CACHE_HOST_PATH"
+# Retired write target (pre-2026-07 top-level path). Kept ONLY as a read-only
+# bind FALLBACK for a host whose populator has not migrated to the runtime dir
+# yet — a stale-but-present legacy cache is never worse than no bind at all.
+QUOTA_CACHE_HOST_PATH_LEGACY = "/home/ywatanabe/.scitex/quota-cache.json"
 
 
 def _resolve_quota_cache_host_path() -> Path:
-    """The host path to bind, honouring the ``SAC_QUOTA_CACHE_HOST_PATH`` override."""
+    """The host path to bind, honouring the ``SAC_QUOTA_CACHE_HOST_PATH`` override.
+
+    No override → the canonical runtime path when it exists, else the retired
+    legacy top-level path when THAT exists (transitional), else the runtime
+    path. A non-existent source makes the bind a conditional no-op, so the
+    in-container reader degrades to an honest ``None`` rather than binding a
+    ghost file — mirrors the reader's runtime-first / legacy-fallback order.
+    """
     override = os.environ.get(QUOTA_CACHE_HOST_PATH_ENV, "").strip()
-    return Path(override) if override else Path(QUOTA_CACHE_HOST_PATH_DEFAULT)
+    if override:
+        return Path(override)
+    runtime = Path(QUOTA_CACHE_HOST_PATH_DEFAULT)
+    if runtime.exists():
+        return runtime
+    legacy = Path(QUOTA_CACHE_HOST_PATH_LEGACY)
+    if legacy.exists():
+        return legacy
+    return runtime
 
 
 __all__ = [
     "QUOTA_CACHE_CONTAINER_PATH",
     "QUOTA_CACHE_HOST_PATH_DEFAULT",
     "QUOTA_CACHE_HOST_PATH_ENV",
+    "QUOTA_CACHE_HOST_PATH_LEGACY",
     "_resolve_quota_cache_host_path",
 ]

--- a/tests/scitex_agent_container/_account/test_quota_cache_path_ssot.py
+++ b/tests/scitex_agent_container/_account/test_quota_cache_path_ssot.py
@@ -1,0 +1,78 @@
+"""Writer default / reader / apptainer-bind must resolve ONE host path (SSOT).
+
+2026-07-20 INCIDENT: the boot picker's fail-loud gate ("quota cache is blind …
+run `sac accounts refresh-quota-cache`") HARD-BLOCKED `sac-restart scitex-dev`,
+and the documented fix did nothing — because the writer's default wrote the
+LEGACY `~/.scitex/quota-cache.json` while the reader's first candidate is the
+RUNTIME `~/.scitex/agent-container/runtime/quota-cache.json`. A plain
+`refresh-quota-cache` populated a file the picker never read, so the picker
+stayed blind. These tests pin the invariant that makes that hint work: the
+populator's default path IS the path the reader reads first (and the container
+bind resolves to the same place). Revert either fix → these go RED.
+
+PA-307 / STX-TQ002 / STX-TQ007 — real tmp I/O (no mocks), AAA markers,
+one assertion per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._account.quota_cache import (
+    HOST_RUNTIME_CACHE_SUBPATH,
+    default_host_cache_path,
+    host_cache_candidates,
+    write_quota_cache,
+)
+from scitex_agent_container.runtimes._apptainer_quota_cache import (
+    QUOTA_CACHE_HOST_PATH_DEFAULT,
+)
+
+
+def test_writer_default_path_equals_reader_first_candidate(tmp_path: Path):
+    # Arrange: a fixed home so both ends resolve deterministically.
+    home = tmp_path
+
+    # Act: the populator's default write path and the reader's first candidate.
+    writer_default = default_host_cache_path(home)
+    reader_first = host_cache_candidates(home)[0]
+
+    # Assert: they are the SAME file, so `refresh-quota-cache` (no --cache-path)
+    # populates exactly the file the boot picker reads first.
+    assert writer_default == reader_first
+
+
+def test_writer_default_write_lands_at_reader_first_candidate(tmp_path: Path):
+    # Arrange: an account payload written via the populator's DEFAULT path.
+    home = tmp_path
+    accounts = {"acct": {"short": "acct", "h5": 5.0, "d7": 5.0, "ttl_h": 7.0}}
+
+    # Act: write with no explicit cache_path (the `refresh-quota-cache` default).
+    write_quota_cache(accounts, home=home)
+
+    # Assert: the file now exists at the reader's first candidate path.
+    assert host_cache_candidates(home)[0].is_file()
+
+
+def test_writer_default_is_under_the_runtime_dir_not_the_scitex_root(
+    tmp_path: Path,
+):
+    # Arrange
+    home = tmp_path
+
+    # Act: the resolved default write path, relative to home.
+    rel = default_host_cache_path(home).relative_to(home)
+
+    # Assert: it is sac's package-scoped runtime path, not the top-level
+    # `.scitex/quota-cache.json` the reader never consults first.
+    assert rel == HOST_RUNTIME_CACHE_SUBPATH
+
+
+def test_apptainer_bind_default_is_the_runtime_path():
+    # Arrange
+    # Act
+    # Assert: the in-container bind source is the runtime path, so agents read
+    # the same freshly-written file the host picker does (not stale legacy).
+    assert QUOTA_CACHE_HOST_PATH_DEFAULT.endswith(
+        "/.scitex/agent-container/runtime/quota-cache.json"
+    )


### PR DESCRIPTION
Promotes the released **v0.24.1** from `develop` to `main`.

v0.24.1 is a patch cutting the `[Unreleased]` batch — it ships **#794 `fix(creds)`**: the v0.24.0 quota fail-loud hard-blocked `sac agents restart` and its own documented fix (`refresh-quota-cache`) did nothing, because the boot picker reads the **runtime** `quota-cache.json` while `refresh-quota-cache` defaulted to the **legacy** path — the hint populated a file the picker never read. Writer default + apptainer bind now resolve to the same runtime path the reader reads first, so the fail-loud's actionable hint actually clears the block. A path-SSOT test pins `writer == reader-first-candidate == bind`.

Tag `v0.24.1` is pushed; PyPI + GitHub release run is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASLR9KjueRGm4BnZnqUhRF
