### PR TITLE
fix(runners): unique-tmp atomic writes so concurrent state writers don't race on <name>.tmp

### DIFF
--- a/src/scitex_agent_container/_runners/_atomic.py
+++ b/src/scitex_agent_container/_runners/_atomic.py
@@ -1,0 +1,51 @@
+"""Atomic text writes for the claude-session runner state dir.
+
+The runner persists small state files (``pid``, ``started_at``,
+``heartbeat.json``, ``quota.json``, ``instance_id``, ``session_id``,
+``session_id_history``) with the tmp + ``os.replace`` pattern so a
+concurrent *reader* (``sac agent status``) never sees a half-formed file.
+
+A **fixed** ``<name>.tmp`` sibling is not safe when two *writers* share the
+same state dir — two xdist workers keyed on the same agent name, or two
+runner processes racing on one agent's dir. Both open the SAME tmp path;
+the first ``replace()`` renames it onto the target, and the loser's
+``replace()`` then raises ``FileNotFoundError`` because the tmp it expected
+is already gone. Measured on CI as::
+
+    FileNotFoundError: '.../runtime/alpha/instance_id.tmp'
+      -> '.../runtime/alpha/instance_id'
+
+Giving every writer a UNIQUE tmp (via :func:`tempfile.mkstemp`) removes the
+collision: only the final rename — which is atomic — contends, and it is
+last-writer-wins with no spurious error. This mirrors the existing correct
+helper in ``_account/codex_account._atomic_write``.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_text(dst: Path, text: str) -> None:
+    """Atomically write ``text`` to ``dst`` via a per-writer-unique temp file.
+
+    The temp file is created in ``dst.parent`` (same filesystem, so the
+    rename is atomic) with a unique name, so concurrent writers to the same
+    directory never collide on the temp path. The parent dir is created if
+    absent. On any failure the temp file is removed so a crashed write never
+    leaves a stray ``.tmp`` behind.
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{dst.name}.", suffix=".tmp", dir=dst.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp, dst)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise

--- a/src/scitex_agent_container/_runners/_session_id.py
+++ b/src/scitex_agent_container/_runners/_session_id.py
@@ -26,6 +26,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+# Per-writer-unique atomic text write (unique tmp name) so two processes
+# sharing one state dir never collide on a fixed ``<name>.tmp`` sibling.
+from ._atomic import atomic_write_text
+
 
 def _session_id_history_path(state_dir: Path) -> Path:
     return state_dir / "session_id_history"
@@ -83,9 +87,7 @@ def write_session_id(state_dir: Path, session_id: str) -> None:
     additive.
     """
     state_dir.mkdir(parents=True, exist_ok=True)
-    tmp = state_dir / "session_id.tmp"
-    tmp.write_text(session_id, encoding="utf-8")
-    tmp.replace(state_dir / "session_id")
+    atomic_write_text(state_dir / "session_id", session_id)
     append_session_id_history(state_dir, session_id)
 
 
@@ -184,9 +186,7 @@ def discard_dead_session(state_dir: Path, dead_id: str) -> bool:
 
     survivors = [sid for sid in history if sid != dead_id]
     if survivors:
-        tmp = state_dir / "session_id_history.tmp"
-        tmp.write_text("\n".join(survivors) + "\n", encoding="utf-8")
-        tmp.replace(history_path)
+        atomic_write_text(history_path, "\n".join(survivors) + "\n")
     else:
         try:
             history_path.unlink()

--- a/src/scitex_agent_container/_runners/_session_quota.py
+++ b/src/scitex_agent_container/_runners/_session_quota.py
@@ -1,0 +1,59 @@
+"""Per-agent token-quota totals persisted in the runner state dir.
+
+Extracted from ``_session_state.py`` to keep that module under the
+512-line cap. ``_session_state`` re-exports ``read_quota`` /
+``accumulate_quota`` (explicit ``as`` aliases) so every existing
+``_session_state.read_quota`` / ``.accumulate_quota`` importer keeps
+working unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ._atomic import atomic_write_text
+
+
+def _quota_path(state_dir: Path) -> Path:
+    return state_dir / "quota.json"
+
+
+def read_quota(state_dir: Path) -> dict:
+    """Return the persisted quota totals, or a zeroed dict if absent."""
+    p = _quota_path(state_dir)
+    if not p.is_file():
+        return {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "turns": 0,
+        }
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def accumulate_quota(state_dir: Path, usage: dict | None) -> dict:
+    """Add one ``ResultMessage.usage`` block to the running totals.
+
+    Atomic via a per-writer-unique tmp + rename so a concurrent
+    ``sac agent status`` reader never sees a partial write, and two
+    writers sharing the dir never collide on the tmp name. Returns the
+    new totals.
+    """
+    if not usage:
+        return read_quota(state_dir)
+    totals = read_quota(state_dir)
+    for key in (
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+    ):
+        totals[key] = int(totals.get(key, 0)) + int(usage.get(key, 0) or 0)
+    totals["turns"] = int(totals.get("turns", 0)) + 1
+    atomic_write_text(_quota_path(state_dir), json.dumps(totals))
+    return totals

--- a/src/scitex_agent_container/_runners/_session_state.py
+++ b/src/scitex_agent_container/_runners/_session_state.py
@@ -26,6 +26,11 @@ from pathlib import Path
 # per-agent state root all relocate together.
 from .._runtime_paths import runtime_base_dir
 
+# Per-writer-unique atomic text write: a UNIQUE tmp name so two processes
+# sharing one state dir never collide on a fixed ``<name>.tmp`` sibling
+# (the ``instance_id.tmp`` FileNotFoundError race). See ``_atomic``.
+from ._atomic import atomic_write_text
+
 # Session-id resume marker + append-only history live in a focused
 # module to keep this file under the 512-line cap. Re-exported here
 # (explicit ``as`` aliases mark the intentional re-export) so the
@@ -38,6 +43,12 @@ from ._session_id import discard_dead_session as discard_dead_session
 from ._session_id import read_session_id as read_session_id
 from ._session_id import read_session_id_history as read_session_id_history
 from ._session_id import write_session_id as write_session_id
+
+# Quota totals live in a focused module (keeps this file under the
+# 512-line cap). Re-exported so ``_session_state.{read,accumulate}_quota``
+# importers keep working unchanged.
+from ._session_quota import accumulate_quota as accumulate_quota
+from ._session_quota import read_quota as read_quota
 
 DEFAULT_STATE_ROOT = runtime_base_dir()
 DEFAULT_TICK_SECONDS = 10.0
@@ -69,9 +80,7 @@ def state_dir_for(name: str, root: Path | None = None) -> Path:
 def write_pid(state_dir: Path, pid: int) -> None:
     """Write the runner's PID atomically (tmp + rename)."""
     state_dir.mkdir(parents=True, exist_ok=True)
-    tmp = state_dir / "pid.tmp"
-    tmp.write_text(f"{pid}\n", encoding="utf-8")
-    tmp.replace(state_dir / "pid")
+    atomic_write_text(state_dir / "pid", f"{pid}\n")
 
 
 def read_pid(state_dir: Path) -> int | None:
@@ -102,9 +111,7 @@ def write_started_at(state_dir: Path, started_at: float | None = None) -> float:
     if started_at is None:
         started_at = time.time()
     state_dir.mkdir(parents=True, exist_ok=True)
-    tmp = state_dir / "started_at.tmp"
-    tmp.write_text(repr(float(started_at)), encoding="utf-8")
-    tmp.replace(state_dir / "started_at")
+    atomic_write_text(state_dir / "started_at", repr(float(started_at)))
     return float(started_at)
 
 
@@ -294,9 +301,7 @@ def write_heartbeat(
 
     payload.update(heartbeat_jsonl_fields(state_dir, now))
     payload.update(heartbeat_progress_fields(state_dir))
-    tmp = state_dir / "heartbeat.json.tmp"
-    tmp.write_text(json.dumps(payload), encoding="utf-8")
-    tmp.replace(state_dir / "heartbeat.json")
+    atomic_write_text(state_dir / "heartbeat.json", json.dumps(payload))
     if name and host:
         writer = _resolve_db_writer(db_writer)
         writer.record_heartbeat(
@@ -425,56 +430,6 @@ async def heartbeat_loop(
 
 
 # ---------------------------------------------------------------------------
-# Quota
-# ---------------------------------------------------------------------------
-
-
-def _quota_path(state_dir: Path) -> Path:
-    return state_dir / "quota.json"
-
-
-def read_quota(state_dir: Path) -> dict:
-    """Return the persisted quota totals, or a zeroed dict if absent."""
-    p = _quota_path(state_dir)
-    if not p.is_file():
-        return {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
-            "turns": 0,
-        }
-    try:
-        return json.loads(p.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {}
-
-
-def accumulate_quota(state_dir: Path, usage: dict | None) -> dict:
-    """Add one ``ResultMessage.usage`` block to the running totals.
-
-    Atomic via tmp+rename so a concurrent ``sac agent status`` reader
-    never sees a partial write. Returns the new totals.
-    """
-    if not usage:
-        return read_quota(state_dir)
-    state_dir.mkdir(parents=True, exist_ok=True)
-    totals = read_quota(state_dir)
-    for key in (
-        "input_tokens",
-        "output_tokens",
-        "cache_creation_input_tokens",
-        "cache_read_input_tokens",
-    ):
-        totals[key] = int(totals.get(key, 0)) + int(usage.get(key, 0) or 0)
-    totals["turns"] = int(totals.get("turns", 0)) + 1
-    tmp = state_dir / "quota.json.tmp"
-    tmp.write_text(json.dumps(totals), encoding="utf-8")
-    tmp.replace(_quota_path(state_dir))
-    return totals
-
-
-# ---------------------------------------------------------------------------
 # Session id (resume marker) + append-only history
 #
 # Implementation extracted to ``_session_id.py`` (focused module, keeps
@@ -499,9 +454,7 @@ def accumulate_quota(state_dir: Path, usage: dict | None) -> dict:
 def write_instance_id(state_dir: Path, instance_id: str) -> None:
     """Persist the state.db instance uuid alongside the runner pid."""
     state_dir.mkdir(parents=True, exist_ok=True)
-    tmp = state_dir / "instance_id.tmp"
-    tmp.write_text(instance_id, encoding="utf-8")
-    tmp.replace(state_dir / "instance_id")
+    atomic_write_text(state_dir / "instance_id", instance_id)
 
 
 def read_instance_id(state_dir: Path) -> str | None:

--- a/tests/scitex_agent_container/_runners/test__atomic.py
+++ b/tests/scitex_agent_container/_runners/test__atomic.py
@@ -1,0 +1,115 @@
+"""Regression tests for the runner state-dir atomic write helper.
+
+The bug: the runner persisted small state files with a FIXED ``<name>.tmp``
+sibling + ``os.replace``. Two processes sharing one state dir (two xdist
+workers keyed on the same agent name, or two runner processes racing on one
+agent) both open the SAME tmp; the first rename consumes it and the loser's
+``replace()`` raises ``FileNotFoundError``. Measured on CI as
+``.../runtime/alpha/instance_id.tmp -> .../runtime/alpha/instance_id``.
+
+``atomic_write_text`` gives each writer a UNIQUE tmp (via ``mkstemp``), so
+only the final atomic rename contends and nothing raises. The concurrency
+test fails on the pre-fix code and passes on the fix.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from scitex_agent_container._runners._atomic import atomic_write_text
+from scitex_agent_container._runners._session_state import (
+    read_instance_id,
+    write_instance_id,
+)
+
+
+def test_concurrent_writers_sharing_a_dir_do_not_raise(tmp_path):
+    """Eight writers hammering one target must never raise the tmp race.
+
+    On the pre-fix fixed-tmp code this raises FileNotFoundError with high
+    probability; the unique-tmp helper is collision-free by construction.
+    """
+    # Arrange
+    dst = tmp_path / "alpha" / "instance_id"
+    errors: list[BaseException] = []
+    start = threading.Barrier(8)
+
+    def worker(n: int) -> None:
+        start.wait()
+        try:
+            for i in range(200):
+                atomic_write_text(dst, f"id-{n}-{i}")
+        except OSError as exc:  # the race surfaces as FileNotFoundError
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in range(8)]
+
+    # Act
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Assert
+    assert not errors, f"concurrent writers raced: {errors[:3]}"
+
+
+def test_write_persists_the_value(tmp_path):
+    """A completed write leaves the exact bytes at the target."""
+    # Arrange
+    dst = tmp_path / "pid"
+
+    # Act
+    atomic_write_text(dst, "123\n")
+
+    # Assert
+    assert dst.read_text() == "123\n"
+
+
+def test_write_leaves_no_stray_tmp_sibling(tmp_path):
+    """The unique tmp is renamed away, not left behind."""
+    # Arrange
+    dst = tmp_path / "pid"
+
+    # Act
+    atomic_write_text(dst, "123\n")
+
+    # Assert
+    assert [p.name for p in tmp_path.iterdir()] == ["pid"]
+
+
+def test_write_creates_missing_parent_dir(tmp_path):
+    """The helper creates ``dst.parent`` if absent (as the old sites did)."""
+    # Arrange
+    dst = tmp_path / "deep" / "nested" / "started_at"
+
+    # Act
+    atomic_write_text(dst, "1700000000.0")
+
+    # Assert
+    assert dst.read_text() == "1700000000.0"
+
+
+def test_write_instance_id_round_trips(tmp_path):
+    """The measured-failure caller round-trips through the unique-tmp helper."""
+    # Arrange
+    state_dir = tmp_path / "alpha"
+
+    # Act
+    write_instance_id(state_dir, "uuid-7-abc")
+
+    # Assert
+    assert read_instance_id(state_dir) == "uuid-7-abc"
+
+
+def test_write_instance_id_overwrite_leaves_no_tmp(tmp_path):
+    """Overwriting the latest marker leaves no ``.tmp`` behind."""
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    write_instance_id(state_dir, "uuid-7-abc")
+
+    # Act
+    write_instance_id(state_dir, "uuid-7-def")
+
+    # Assert
+    assert not list(state_dir.glob("*.tmp"))


### PR DESCRIPTION
## What

The runner persists small state files (`pid`, `started_at`, `heartbeat.json`, `quota.json`, `instance_id`, `session_id`, `session_id_history`) with a **fixed** `<name>.tmp` sibling + `os.replace`. Two processes sharing one state dir — two xdist workers keyed on the same agent name, or two runner processes racing on one agent's dir — both open the **same** tmp; the first rename consumes it and the loser's `replace()` raises `FileNotFoundError`:

```
FileNotFoundError: '.../runtime/alpha/instance_id.tmp'
  -> '.../runtime/alpha/instance_id'
```

## Fix

New `_runners/_atomic.atomic_write_text(dst, text)` gives each writer a **unique** tmp via `tempfile.mkstemp` (same dir → rename stays atomic), mirroring the existing correct `_account/codex_account._atomic_write`. Only the final atomic rename contends; last-writer-wins, no spurious error. Reader-safety (never observe a half-written file) is preserved. All **seven** sites now route through it.

To land the edit, the over-cap `_session_state.py` (542 → 490 lines) had the cohesive quota group (`read_quota` / `accumulate_quota` / `_quota_path`) extracted to `_runners/_session_quota.py`; `_session_state` **re-exports** `read_quota` / `accumulate_quota` (explicit `as` aliases) so every importer is unchanged — same pattern already used for the `_session_id` re-exports.

## Test

`tests/scitex_agent_container/_runners/test__atomic.py` — 8 threads × 200 writes to one target raise `FileNotFoundError` on the **pre-fix** code and pass on the fix, plus round-trip / no-stray-tmp / parent-creation coverage. One assert + AAA per test (STX-TQ).

Verified locally on the host (py3.11): new file 6/6, and `test_claude_session.py` + `test_agent_meta.py` (the re-export consumers) 161 passed / 3 skipped / 0 failed.

## Card

`sac-tests-write-real-runtime-dir-20260719` — **defect 1**, the production race. **Defect 2** (test writes escaping to the operator's real runtime dir) is already guarded on develop by the conftest state-floor + post-test breach alarm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASLR9KjueRGm4BnZnqUhRF
