### PR TITLE
fix(lifecycle): readable start / start-failure log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Start / start-failure log output is now readable, not a run-on wall**
+  (operator 2026-07-19: "めっちゃ汚い"). Format-only — no control-flow, trigger,
+  or suppression behaviour changed:
+  - The **start-failure diagnostic** (`raise_start_failure` /
+    `_start_failure_diag`) now renders as a headline plus clearly separated,
+    indented sections (`tmux session`, `inner stderr`, `pane tail`) with each
+    section body indented under its label, instead of one flush-left blob.
+  - The per-start **`[sac:creds]` credentials-pool selection notice** is now a
+    headline naming the agent + picked account, followed by indented fields
+    (`file`, `policy=…`, `picked usage`) and a one-entry-per-line ranking-inputs
+    list, instead of a single run-on sentence. It still writes through the
+    caller's `log_stream` (the `preflight_from_config_path` dry-probe
+    suppression seam is preserved — it is NOT routed to a logger).
+  - Hook failures in `_hook_runner` now log at WARNING level (`logger.warning`)
+    instead of `print`-ing `[WARN] …` with the severity baked into the message
+    text.
+
 ## [0.24.1] - 2026-07-20
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.1"
+version = "0.24.2"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/_creds/__init__.py
+++ b/src/scitex_agent_container/_creds/__init__.py
@@ -30,6 +30,7 @@ from ._pick_audit import (
     CandidateAudit,
     audit_candidates,
     format_pick_audit,
+    pick_audit_parts,
 )
 from ._pick_healthy import (
     AccountHealth,
@@ -60,6 +61,7 @@ __all__ = [
     "account_health",
     "audit_candidates",
     "format_pick_audit",
+    "pick_audit_parts",
     "pick_healthy_account",
     "resolve_7d_policy",
 ]

--- a/src/scitex_agent_container/_creds/_pick_audit.py
+++ b/src/scitex_agent_container/_creds/_pick_audit.py
@@ -117,13 +117,18 @@ def _fmt_reset(seconds: float | None) -> str:
     return "?" if seconds is None else f"{seconds / 3600.0:+.1f}h"
 
 
-def format_pick_audit(records: list[CandidateAudit]) -> str:
-    """One log-safe line naming EVERY ranking input for every candidate.
+def pick_audit_parts(records: list[CandidateAudit]) -> list[str]:
+    """Per-candidate ranking-input strings, one string per candidate, in order.
 
-    ``ranking inputs: a(5h=9% 7d=10% 7d_reset=+56.4h), b(...)`` — the
-    flags (``5h-blocked`` / ``7d-near-cap`` / ``7d-expiring``) appear
-    only when set. Contains percentages, relative hours, and account
-    slugs ONLY — never a token value or credential path.
+    The building block behind :func:`format_pick_audit` (which joins these into
+    one comma-run line). Exposed so a caller that wants a readable, one-entry-
+    per-line ranking LIST — the start-time ``[sac:creds]`` notice — can indent
+    each entry on its own line instead of a run-on comma-run (operator
+    2026-07-19: the notice was "めっちゃ汚い"). Each entry is
+    ``a(5h=9% 7d=10% 7d_reset=+56.4h)`` with the flags (``5h-blocked`` /
+    ``7d-near-cap`` / ``7d-expiring``) appended only when set. Contains
+    percentages, relative hours, and account slugs ONLY — never a token value
+    or credential path.
     """
     parts: list[str] = []
     for r in records:
@@ -138,11 +143,24 @@ def format_pick_audit(records: list[CandidateAudit]) -> str:
             f"{r.name}(5h={_fmt_pct(r.pct_5h)} 7d={_fmt_pct(r.pct_7d)} "
             f"7d_reset={_fmt_reset(r.reset_7d_in_s)}{flags})"
         )
-    return "ranking inputs: " + ", ".join(parts)
+    return parts
+
+
+def format_pick_audit(records: list[CandidateAudit]) -> str:
+    """One log-safe line naming EVERY ranking input for every candidate.
+
+    ``ranking inputs: a(5h=9% 7d=10% 7d_reset=+56.4h), b(...)`` — the
+    flags (``5h-blocked`` / ``7d-near-cap`` / ``7d-expiring``) appear
+    only when set. Contains percentages, relative hours, and account
+    slugs ONLY — never a token value or credential path. The per-candidate
+    rendering is :func:`pick_audit_parts` (shared SSOT).
+    """
+    return "ranking inputs: " + ", ".join(pick_audit_parts(records))
 
 
 __all__ = [
     "CandidateAudit",
     "audit_candidates",
     "format_pick_audit",
+    "pick_audit_parts",
 ]

--- a/src/scitex_agent_container/_lifecycle/_hook_runner.py
+++ b/src/scitex_agent_container/_lifecycle/_hook_runner.py
@@ -8,10 +8,20 @@ Extracted from the former monolithic ``lifecycle.py`` (split for the
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from typing import Any, Callable
 
 from ..hooks import run_hook
+
+# Module logger (stdlib, mirroring ._stop_escalate) so hook failures are
+# emitted at a proper WARNING LEVEL — rendered as scitex-logging's coloured
+# ``WARN:`` prefix by the root handler in production — instead of a bare
+# ``print`` with the severity baked into the message text as ``[WARN]``
+# (operator 2026-07-19: severity is DATA, not text). Stdlib ``getLogger`` is
+# free, so this does not tax the CLI import budget the way a top-level
+# ``scitex_logging`` import would (see config._config_logger).
+logger = logging.getLogger(__name__)
 
 
 def _fire_forget_hook(
@@ -32,12 +42,7 @@ def _fire_forget_hook(
     try:
         run_hook(agent_name, hook_name, list(commands or []), context=context)
     except Exception:  # pragma: no cover  # stx-allow: fallback (reason: hook dispatch safety net — hook crashes must not propagate to caller)
-        import sys
-
-        print(
-            f"[WARN] run_hook {hook_name} dispatch failed for {agent_name}",
-            file=sys.stderr,
-        )
+        logger.warning("run_hook %s dispatch failed for %s", hook_name, agent_name)
 
 
 def _run_hooks(
@@ -70,9 +75,9 @@ def _run_hooks(
             continue
         result = runner(hook, shell=True, capture_output=True, text=True, env=env)
         if result.returncode != 0:
-            # Log but don't fail
-            import sys
-
-            print(f"[WARN] Hook failed: {hook}", file=sys.stderr)
+            # Log but don't fail — at WARNING level (severity as data), and
+            # the captured stderr as its own indented follow-on line rather
+            # than a run-on.
+            logger.warning("Hook failed (rc=%s): %s", result.returncode, hook)
             if result.stderr:
-                print(f"       {result.stderr.strip()}", file=sys.stderr)
+                logger.warning("    %s", result.stderr.strip())

--- a/src/scitex_agent_container/_lifecycle/_start_failure_diag.py
+++ b/src/scitex_agent_container/_lifecycle/_start_failure_diag.py
@@ -20,6 +20,18 @@ __all__ = [
 ]
 
 
+def _indent_block(text: str, prefix: str = "      ") -> str:
+    """Indent every line of a multi-line body so it reads as ONE sub-section.
+
+    The start-failure report is a headline + labelled sections; each section's
+    BODY (an inner-stderr tail, a pane capture) is indented under its label so
+    the operator can see at a glance where one section ends and the next begins
+    instead of reading a run-on wall (operator 2026-07-19). Empty-safe.
+    """
+    lines = text.splitlines() or [""]
+    return "\n".join(f"{prefix}{line}" for line in lines)
+
+
 def _format_boot_stderr_section(log: Path) -> str:
     """Formatted 'inner stderr' diagnostic section for a failed TUI start.
 
@@ -29,15 +41,19 @@ def _format_boot_stderr_section(log: Path) -> str:
     (``log``), which SURVIVES the tmux pane's death. Return its tail so a boot
     failure is the LOUD cause in the raised error, never a cause-less
     ``<empty>`` pane fallback. Empty/absent-log safe; never raises.
+
+    Rendered as a labelled section (the ``inner stderr`` label at 2 spaces, the
+    captured body indented under it at 6) so the report reads as distinct,
+    separated sections rather than a flush-left blob.
     """
     tail = ""
     if log.is_file():
         tail = log.read_text(errors="replace")[-4_000:].rstrip()
     body = tail or "<no stderr captured — runtime never launched the process>"
-    return f"  inner stderr ({log}):\n{body}\n"
+    return f"\n  inner stderr ({log}):\n{_indent_block(body)}"
 
 
-_NO_PANE = " (no pane diagnostics available)"
+_NO_PANE = "\n  (no pane diagnostics available)"
 
 
 def raise_start_failure(
@@ -114,9 +130,9 @@ def capture_pane_diag(config: Any) -> str:
     pane = TmuxManager.capture_logs(sess, lines=60).rstrip()
     boot_log = _state_dir(config) / "boot.stderr.log"
     return (
-        f" (tmux session_exists={TmuxManager.exists(sess)})\n"
+        f"\n  tmux session: exists={TmuxManager.exists(sess)} (session {sess!r})"
         f"{_format_boot_stderr_section(boot_log)}"
-        f"  pane tail:\n{pane or '<empty>'}"
+        f"\n  pane tail:\n{_indent_block(pane or '<empty>')}"
     )
 
 

--- a/src/scitex_agent_container/_lifecycle/_start_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_start_preflight.py
@@ -224,7 +224,7 @@ def _rotate_among_credentials_files(
         account_7d_reset_at,
         account_7d_usage,
         audit_candidates,
-        format_pick_audit,
+        pick_audit_parts,
     )
 
     # EVERY ranking input, per candidate — the pick must be auditable
@@ -240,7 +240,7 @@ def _rotate_among_credentials_files(
         for s in slugs
     }
     r7 = {s: account_7d_reset_at(s, quota_cache_path=quota_cache_path) for s in slugs}
-    audit = format_pick_audit(audit_candidates(slugs, u5, u7, reset_7d=r7, now=now))
+    records = audit_candidates(slugs, u5, u7, reset_7d=r7, now=now)
 
     def fmt(v: float | None) -> str:
         return "?" if v is None else f"{v:.0f}%"
@@ -254,12 +254,21 @@ def _rotate_among_credentials_files(
         "accounts, load-balanced per agent by 7d headroom; time-to-reset "
         "counts only within the 2h expiring horizon"
     )
+    # Readable, structured notice (operator 2026-07-19: the run-on one-liner
+    # was "めっちゃ汚い"): a headline naming the agent + picked account, then
+    # indented fields, then the per-candidate ranking inputs as a ONE-ENTRY-
+    # PER-LINE list. Still emitted through ``stream`` (log_stream or stderr)
+    # so ``preflight_from_config_path``'s throwaway-StringIO suppression of the
+    # dry-probe rotation notice keeps working — do NOT route this to a logger.
+    ranking = "\n".join(f"      {part}" for part in pick_audit_parts(records))
     stream = log_stream if log_stream is not None else sys.stderr
     print(
-        f"[sac:creds] agent '{config.name}' selected credentials_files pool "
-        f"entry: account {picked!r} ({picked_path}) among {len(slugs)} listed "
-        f"credentials_files (policy={policy} — {rationale}; picked usage "
-        f"5h={fmt(u5.get(picked))} 7d={fmt(u7.get(picked))}; {audit})",
+        f"[sac:creds] agent '{config.name}' selected credentials pool account "
+        f"{picked!r} ({len(slugs)} candidates listed)\n"
+        f"  file:          {picked_path}\n"
+        f"  policy={policy} — {rationale}\n"
+        f"  picked usage:  5h={fmt(u5.get(picked))} 7d={fmt(u7.get(picked))}\n"
+        f"  ranking inputs:\n{ranking}",
         file=stream,
     )
 

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -317,16 +317,18 @@ def test_run_hooks_skips_https_url_entries() -> None:
     assert calls == []
 
 
-def test_run_hooks_warns_on_nonzero_returncode(capsys: pytest.CaptureFixture) -> None:
+def test_run_hooks_warns_on_nonzero_returncode(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     # Arrange
     def runner(cmd: str, **_kwargs: Any) -> _FakeResult:
         return _FakeResult(returncode=2, stderr="boom")
 
     # Act
-    lc._run_hooks(["false"], runner=runner)
-    # Assert
-    err = capsys.readouterr().err
-    assert "Hook failed" in err and "boom" in err
+    with caplog.at_level("WARNING"):
+        lc._run_hooks(["false"], runner=runner)
+    # Assert — the failure is logged at WARNING level with cmd + stderr.
+    assert "Hook failed" in caplog.text and "boom" in caplog.text
 
 
 def test_run_hooks_real_subprocess_executes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

Operator 2026-07-19 (card `sac-clean-start-failure-log-format-20260719`): the
start-failure / startup log output was "めっちゃ汚い" — a run-on wall of prose.
He wants a readable format (lists, newlines, indents), written through the
logger at proper levels.

**Format/level-only.** No control-flow, failure trigger, or `log_stream`
suppression behaviour changes. The scitex-logging-rendered `WARN:` / `ERRO:`
level prefixes elsewhere are left alone (already correct levels).

## What changed

1. **Start-failure diagnostic** (`_start_failure_diag.raise_start_failure` +
   helpers): headline, then labelled indented sections.
2. **`[sac:creds]` pool-selection notice** (`_start_preflight`): headline +
   indented fields + one-entry-per-line ranking list. **Seam preserved** — still
   `print(..., file=stream)` through the caller's `log_stream`.
3. **`_pick_audit`**: extract `pick_audit_parts()` (SSOT) behind the unchanged
   `format_pick_audit()`, so the notice renders one entry per line without
   duplicating formatting.
4. **`_hook_runner`**: hook failures now `logger.warning(...)` (stdlib module
   logger, mirroring `_stop_escalate`) instead of `print("[WARN] ...")` with the
   severity baked into the message text.

## Before -> After

### Credentials pool-selection notice (every start)

Before (one run-on line):
```
[sac:creds] agent 'alpha' selected credentials_files pool entry: account 'acct-b' (/home/.../accounts/acct-b/.credentials.json) among 2 listed credentials_files (policy=spread — token-fresh gate, avoids 5h-blocked and 7d-near-capped accounts, load-balanced per agent by 7d headroom; time-to-reset counts only within the 2h expiring horizon; picked usage 5h=? 7d=5%; ranking inputs: acct-a(5h=? 7d=95% 7d_reset=? 7d-near-cap), acct-b(5h=? 7d=5% 7d_reset=?))
```

After:
```
[sac:creds] agent 'alpha' selected credentials pool account 'acct-b' (2 candidates listed)
  file:          /home/.../accounts/acct-b/.credentials.json
  policy=spread — token-fresh gate, avoids 5h-blocked and 7d-near-capped accounts, load-balanced per agent by 7d headroom; time-to-reset counts only within the 2h expiring horizon
  picked usage:  5h=? 7d=5%
  ranking inputs:
      acct-a(5h=? 7d=95% 7d_reset=? 7d-near-cap)
      acct-b(5h=? 7d=5% 7d_reset=?)
```

### Start-failure diagnostic (raised RuntimeError + persisted log)

Before:
```
Failed to start agent 'demo': runtime.start() returned False. (tmux session_exists=False)
  inner stderr (/.../boot.stderr.log):
FATAL:   container creation failed: mount /work -> /work: not a directory
apptainer: exec failed: no such process
  pane tail:
claude: Login expired · Please run /login
$
```

After:
```
Failed to start agent 'demo': runtime.start() returned False.
  tmux session: exists=False (session 'tui-demo')
  inner stderr (/.../boot.stderr.log):
      FATAL:   container creation failed: mount /work -> /work: not a directory
      apptainer: exec failed: no such process
  pane tail:
      claude: Login expired · Please run /login
      $
```

Degraded path (capture failed):
```
Failed to start agent 'demo': runtime.start() returned False.
  (no pane diagnostics available)
```

## Suppression seam — preserved

`_rotate_among_credentials_files` still writes the notice through the injectable
stream, so `preflight_from_config_path`'s `log_stream=io.StringIO()` keeps
silencing the dry-probe rotation notice:

```python
stream = log_stream if log_stream is not None else sys.stderr
print( ... , file=stream)
```

Deliberately **not** routed to a logger (that would bypass the suppression).

## Version

CHANGELOG `[Unreleased]` entry + `pyproject.toml` `0.24.1 -> 0.24.2`
(satisfies `tests/integration/test_version_not_spent.py`).

## Tests

`/opt/venv-sac/bin/python3` (py3.12): **141 passed** — `test_version_not_spent`,
full `test_lifecycle` (incl. the `caplog`-converted hook-failure test),
`test__start_failure_diag_persists`, `test__start_boot_stderr`,
`test__start_creds_files_pool`, `test__spend_policy`.

## Not in this PR (deliberate)

Other literal `WARN:` strings live in a different subsystem (the `sac listen`
daemon: `_listen_registry_hooks.py`, `listen_cmds.py`, `_listen/_restart.py`)
and the tmux runner (`_runners/_tmux/_host_cwd.py`). Out of the
agent-start-failure path, each has a stdout/stderr-capturing test, and sweeping
them risks over-scoping — left for a focused follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASLR9KjueRGm4BnZnqUhRF
