### PR TITLE
chore(release): v0.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.24.2] - 2026-07-21
+
 ### Added
 
 - **Merge->release automation: `autobump-release-sweep.yaml`.** A state-driven
@@ -45,6 +47,16 @@ versioning follows [SemVer](https://semver.org/).
   - Hook failures in `_hook_runner` now log at WARNING level (`logger.warning`)
     instead of `print`-ing `[WARN] …` with the severity baked into the message
     text.
+
+### Fixed
+
+- **Concurrent runner-state writes no longer race on a shared `<name>.tmp`**
+  (#797). Each of the seven runner-state writers wrote to a fixed sibling
+  `<name>.tmp` before the atomic rename, so two writers racing on the same
+  target could clobber each other's temp file. Each now writes to a unique
+  temp path via the `atomic_write_text` helper; the per-session quota group
+  was extracted to `_session_quota.py` to keep the module under the line cap,
+  and a regression test covers the concurrent-writer case.
 
 ## [0.24.1] - 2026-07-20
 


### PR DESCRIPTION
## Release cut: v0.24.2

Promotes `CHANGELOG.md` `[Unreleased]` → `[0.24.2] - 2026-07-21` and adds the
`#797` `### Fixed` note that merged to develop without a changelog entry.
`pyproject` is already at `0.24.2` (bumped in #798/#799) — this PR only assembles
the release notes.

### What ships in 0.24.2
- **#798** — `autobump-release-sweep.yaml`: merge→release automation. Ships
  **DISARMED** (gated behind `AUTOBUMP_ENABLED == 'true'`; executes only on `main`).
- **#799** — clean start / start-failure log format (format-only; suppression seam preserved).
- **#797** — concurrent runner-state write race fix (unique-tmp atomic writes).

### Release flow (after this merges to develop)
1. develop → main promotion PR (deliberate, per release-pipeline policy).
2. Tag `v0.24.2` on this release commit + push → tag-driven release pipeline
   (matrix pytest inside the SIF → build → PyPI trusted publish → GitHub Release).

The `version-not-spent` guard passes 9/9 locally against this changelog.
