### PR TITLE
chore(release): promote develop → main (v0.24.2)

### DIFF
--- a/.github/ci/autobump-in-sif.sh
+++ b/.github/ci/autobump-in-sif.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Inner script for autobump-release-sweep.yaml — runs INSIDE the ci-cpu SIF.
+#
+# The bare Spartan node has NO python (that is the whole reason the SIF exists);
+# autobump.py is pure stdlib, so ANY python3 in the SIF runs it. Invoked as:
+#
+#   bash .github/ci/exec-in-sif.sh autobump-in-sif.sh <autobump-subcommand> [args...]
+#
+# e.g.  ... autobump-in-sif.sh bump --date 2026-07-21
+#       ... autobump-in-sif.sh verify --version 0.24.2   (exit 3 == inconsistent)
+#
+# It only reads the subcommand's EXIT CODE and, for `bump`, the file mutations
+# in the checkout ($PWD is bound into the SIF by exec-in-sif.sh). autobump.py's
+# stdout is not captured through the SIF — the caller recomputes the version in
+# plain shell and cross-checks it with `verify`.
+set -euo pipefail
+
+PY="$(command -v python3 || true)"
+if [ -z "$PY" ]; then
+    for cand in /opt/venv-3.12/bin/python /opt/venv-3.11/bin/python /opt/venv-3.13/bin/python; do
+        [ -x "$cand" ] && PY="$cand" && break
+    done
+fi
+if [ -z "$PY" ] || [ ! -x "$PY" ]; then
+    echo "::error::no python3 available inside the CI SIF for autobump" >&2
+    exit 1
+fi
+
+exec "$PY" .github/ci/autobump.py "$@"

--- a/.github/ci/autobump.py
+++ b/.github/ci/autobump.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# File: .github/ci/autobump.py
+"""Deterministic patch-version bump + CHANGELOG promotion for the
+merge->release sweep (``autobump-release-sweep.yaml``).
+
+Pure stdlib on purpose: no TOML dependency, no build frontend. It must run
+unit-tested AND on the bare Spartan node inside the sweep, where nothing is
+pip-installed.
+
+WHAT IT TOUCHES (and nothing else):
+
+  1. pyproject.toml — the SINGLE column-0 ``version = \"X.Y.Z\"`` line in the
+     ``[project]`` table. This is byte-for-byte the line
+     ``src/hatch_build.py::_declared_version()`` parses (``line.startswith
+     (\"version\")``) and the value hatchling bakes into the wheel at the tagged
+     commit. Indented dependency constraints (``\"click>=8.0\"``), ``requires-
+     python``, and ``[tool.ruff] target-version`` all start with whitespace or a
+     different token, so a col-0 anchor can never hit them. This is the
+     root-cause fix (card req 1): advancing this literal every release changes
+     uv's ``(name, version)`` wheel-cache key, so no stale wheel is ever reused.
+
+  2. CHANGELOG.md — promotes ``## [Unreleased]`` to a released
+     ``## [X.Y.Z] - <UTC-date>`` section (Keep-a-Changelog), leaving a fresh
+     empty ``## [Unreleased]`` on top. The heading shape matches the release
+     pipeline's awk extractor (``^## \\[X.Y.Z\\]``).
+
+Both move together from ONE computed version, so tag == pyproject == CHANGELOG
+can never drift (the ghost-tag-at-birth class).
+
+Subcommands
+-----------
+  current-version              print the bare [project] version (e.g. 0.24.1)
+  next-version                 print the next patch (0.24.1 -> 0.24.2)
+  bump                         rewrite pyproject + promote CHANGELOG to the next
+                               patch; print the new BARE version to stdout
+  verify --version X.Y.Z       exit 3 (fail-loud) unless pyproject == X.Y.Z AND
+                               CHANGELOG carries a released ``## [X.Y.Z]``
+                               section AND a ``## [Unreleased]`` header is
+                               present. (exit 2 is argparse usage, kept distinct
+                               so a usage typo can never masquerade as
+                               \"inconsistent\" — see the exit-code-collision
+                               incident.)
+
+Paths default to the repo root inferred from this file
+(``<root>/.github/ci/autobump.py`` -> ``<root>``); override with ``--root`` in
+tests. All mutations are fail-loud: a missing version line, an unparseable
+version, or a missing ``## [Unreleased]`` heading raises rather than guessing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Col-0 anchored: only the [project] version line, never an indented dep line.
+_VERSION_RE = re.compile(r'^version\s*=\s*"(?P<v>[^"]+)"\s*$', re.MULTILINE)
+_SEMVER_RE = re.compile(r"^(?P<maj>\d+)\.(?P<min>\d+)\.(?P<pat>\d+)$")
+# [ \t]* NOT \s*: \s would greedily swallow the trailing newline(s) after the
+# heading, so the insert point drifts past the blank line and the promoted
+# section butts against the previous one. Anchor to the heading line only.
+_UNRELEASED_RE = re.compile(r"^## \[Unreleased\][ \t]*$", re.MULTILINE)
+
+EXIT_INCONSISTENT = 3
+
+
+class AutobumpError(RuntimeError):
+    """Fail-loud error — the sweep converts this to a red step + off-rail alarm."""
+
+
+def _root_from_here() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _pyproject_path(root: Path) -> Path:
+    return root / "pyproject.toml"
+
+
+def _changelog_path(root: Path) -> Path:
+    return root / "CHANGELOG.md"
+
+
+def read_current_version(root: Path) -> str:
+    """Return the bare ``[project]`` version, e.g. ``0.24.1``. Fail-loud."""
+    text = _pyproject_path(root).read_text(encoding="utf-8")
+    matches = _VERSION_RE.findall(text)
+    if not matches:
+        raise AutobumpError(
+            'no column-0 `version = "..."` line found in pyproject.toml '
+            "(the [project] version is the single source of truth)"
+        )
+    if len(matches) > 1:
+        raise AutobumpError(
+            f"ambiguous: {len(matches)} column-0 version lines in pyproject.toml; "
+            "refusing to guess which one is the [project] version"
+        )
+    v = matches[0]
+    if not _SEMVER_RE.match(v):
+        raise AutobumpError(
+            f"[project] version {v!r} is not a clean X.Y.Z semver; "
+            "patch auto-bump only supports plain three-part versions"
+        )
+    return v
+
+
+def compute_next_patch(version: str) -> str:
+    """0.24.1 -> 0.24.2. Fail-loud on a non-semver input."""
+    m = _SEMVER_RE.match(version)
+    if not m:
+        raise AutobumpError(f"cannot patch-bump non-semver version {version!r}")
+    return f"{m['maj']}.{m['min']}.{int(m['pat']) + 1}"
+
+
+def rewrite_pyproject_version(root: Path, new_version: str) -> None:
+    """Rewrite ONLY the col-0 [project] version line to ``new_version``."""
+    path = _pyproject_path(root)
+    text = path.read_text(encoding="utf-8")
+    new_text, n = _VERSION_RE.subn(f'version = "{new_version}"', text)
+    if n != 1:
+        raise AutobumpError(
+            f"expected exactly 1 column-0 version line to rewrite, changed {n}"
+        )
+    path.write_text(new_text, encoding="utf-8")
+
+
+def promote_changelog(root: Path, new_version: str, date: str | None = None) -> None:
+    """Promote ``## [Unreleased]`` -> ``## [X.Y.Z] - <date>`` + fresh Unreleased.
+
+    Keep-a-Changelog: whatever sat under ``## [Unreleased]`` becomes the body of
+    the new released section; a new empty ``## [Unreleased]`` is left on top.
+    Idempotency guard: refuses if a released ``## [X.Y.Z]`` section already
+    exists (that version was already promoted).
+    """
+    path = _changelog_path(root)
+    text = path.read_text(encoding="utf-8")
+    date = date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    if re.search(rf"^## \[{re.escape(new_version)}\]", text, re.MULTILINE):
+        raise AutobumpError(
+            f"CHANGELOG already has a `## [{new_version}]` section — refusing to "
+            "double-promote (idempotency guard)"
+        )
+    m = _UNRELEASED_RE.search(text)
+    if not m:
+        raise AutobumpError("CHANGELOG.md has no `## [Unreleased]` heading to promote")
+
+    insert_at = m.end()
+    released = f"\n\n## [{new_version}] - {date}"
+    new_text = text[:insert_at] + released + text[insert_at:]
+    path.write_text(new_text, encoding="utf-8")
+
+
+def verify_consistency(root: Path, version: str) -> list[str]:
+    """Return a list of problems; empty list == consistent. Never raises."""
+    problems: list[str] = []
+    try:
+        cur = read_current_version(root)
+    except AutobumpError as exc:
+        return [str(exc)]
+    if cur != version:
+        problems.append(f"pyproject [project] version is {cur!r}, expected {version!r}")
+    text = _changelog_path(root).read_text(encoding="utf-8")
+    if not re.search(rf"^## \[{re.escape(version)}\]", text, re.MULTILINE):
+        problems.append(f"CHANGELOG has no released `## [{version}]` section")
+    if not _UNRELEASED_RE.search(text):
+        problems.append("CHANGELOG has no `## [Unreleased]` heading")
+    return problems
+
+
+def do_bump(root: Path, date: str | None = None) -> str:
+    """Bump pyproject + promote CHANGELOG to the next patch; return new version."""
+    cur = read_current_version(root)
+    new = compute_next_patch(cur)
+    # CHANGELOG first: its idempotency guard fails loud BEFORE we touch
+    # pyproject, so a re-run cannot leave a half-applied bump.
+    promote_changelog(root, new, date=date)
+    rewrite_pyproject_version(root, new)
+    return new
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="autobump", description=__doc__)
+    p.add_argument("--root", type=Path, default=None, help="repo root (test override)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("current-version")
+    sub.add_parser("next-version")
+    b = sub.add_parser("bump")
+    b.add_argument("--date", default=None, help="override the UTC date (tests)")
+    v = sub.add_parser("verify")
+    v.add_argument(
+        "--version", required=True, help="the version to assert, e.g. 0.24.2"
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    root = (args.root or _root_from_here()).resolve()
+    try:
+        if args.cmd == "current-version":
+            print(read_current_version(root))
+        elif args.cmd == "next-version":
+            print(compute_next_patch(read_current_version(root)))
+        elif args.cmd == "bump":
+            print(do_bump(root, date=args.date))
+        elif args.cmd == "verify":
+            version = args.version.lstrip("v")
+            problems = verify_consistency(root, version)
+            if problems:
+                for pr in problems:
+                    print(f"::error::autobump verify: {pr}", file=sys.stderr)
+                return EXIT_INCONSISTENT
+            print(f"OK: pyproject + CHANGELOG are consistent at {version}")
+    except AutobumpError as exc:
+        print(f"::error::autobump: {exc}", file=sys.stderr)
+        return EXIT_INCONSISTENT
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+# EOF

--- a/.github/workflows/autobump-release-sweep.yaml
+++ b/.github/workflows/autobump-release-sweep.yaml
@@ -1,0 +1,488 @@
+name: autobump-release-sweep
+
+# Auto-bump patch + cut a release on every MERGE-to-develop — the automation of
+# the manual ritual (worktree -> bump pyproject + promote CHANGELOG -> PR ->
+# merge -> tag vX.Y.Z -> push tag) done by hand for 0.24.0 / 0.24.1.
+#
+# ─── READ THIS BEFORE TOUCHING TRIGGERS OR CREDENTIALS ───────────────────────
+#
+# WHY A STATE-DRIVEN CRON, not an event bump. Loop-safety here comes from
+# repository STATE, not event bookkeeping. Each tick reads develop's head,
+# V = pyproject version at head, and the tags, then takes EXACTLY ONE branch:
+#
+#   STEADY    tag vV exists AND develop head == the tagged commit  -> do nothing
+#             (belt: also confirm PyPI actually serves V; see GHOST below).
+#   BUMP      tag vV exists AND head has moved past it (new work landed, but
+#             pyproject is still the last-released V) -> gate develop green,
+#             bump V->V+1, land it as a PR merged with --admin, tag the merge
+#             commit, fire the release.
+#   TAG_ONLY  tag vV does NOT exist though pyproject is already V (a prior
+#             tick's bump merged but its tag/dispatch failed) -> RE-TAG the
+#             landed bump, NEVER re-bump. This is the fix for the runaway-bump
+#             loop: an untagged version is re-tagged, it is never re-incremented.
+#   GHOST     tag vV exists, head == tag, but PyPI has NOT served V past a grace
+#             window -> off-rail ALARM + re-dispatch the release. The sweep is a
+#             CONTINUOUS ghost-tag monitor, every tick, on a rail (this workflow)
+#             independent of the release pipeline that failed.
+#
+# The bump PR merge and the tag are done with the DEFAULT github.token, and the
+# release is fired by DISPATCHING the existing release pipeline
+# (pypi-publish-and-github-release-on-tag.yml accepts a `version` input;
+# workflow_dispatch via github.token IS exempt from the recursive-run
+# suppression, unlike a tag PUSH, which is NOT — a github.token tag push fires
+# NOTHING, which is why we dispatch explicitly). NO bot token / PAT is required
+# for the mechanism. (Verified in this repo: a recent release ran as
+# event=workflow_dispatch and succeeded.)
+#
+# THE RUN HISTORY IS THE HEARTBEAT — same doctrine as auto-merge-to-develop.yaml.
+# A scheduled tick that stops appearing is a VISIBLE GAP. Do NOT add an `if:`
+# that skips the whole job, and do NOT exit in a way that leaves no run record.
+#
+# GitHub reads schedule- and workflow_run-triggered workflows from the DEFAULT
+# branch (main). *** THIS FILE TAKES EFFECT ONLY ONCE IT REACHES main. *** Merging
+# it to develop changes NOTHING at runtime until develop is promoted to main —
+# which is the operator's deliberate go-ahead, not an escape hatch.
+#
+# ARMING (second, independent safety): every MUTATING action is gated behind the
+# repo Actions Variable AUTOBUMP_ENABLED == 'true'. Unset/false => the sweep runs
+# as a REPORT-ONLY heartbeat: it computes the decision and prints what it WOULD
+# do, and mutates nothing. So even on main it is inert until the operator arms
+# it, and clearing the variable is the kill switch.
+#
+# RUNNER (operator rule 2026-07-14, absolute): NO GitHub-hosted runners. `gh` is
+# NOT on the bare Spartan node — it is bootstrapped into RUNNER_TEMP exactly as
+# auto-merge does. `jq` is NOT assumed either; every filter goes through
+# `gh --jq`. python is NOT on the bare node — the bump/verify helper runs INSIDE
+# the ci-cpu SIF via exec-in-sif.sh.
+#
+# DOES NOT touch: the release/publish pipeline (it is dispatched, not modified),
+# auto-merge-to-develop.yaml (byte-for-byte untouched), or the release->host
+# deploy cron (req 5, out of scope — already works).
+
+on:
+  schedule:
+    # Every ~15 min, OFF the top of the hour, and offset from auto-merge's
+    # "7,22,37,52" so the two sweeps interleave: auto-merge lands a green PR,
+    # then a couple minutes later this sweep acts on the resulting green head.
+    - cron: "3,18,33,48 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report the decision + what WOULD happen, mutate nothing (overrides AUTOBUMP_ENABLED)."
+        type: boolean
+        default: true
+
+# One sweep at a time per repo. Two concurrent sweeps would race on the tag /
+# bump state machine. Queue, never cancel: a cancelled run mid-merge is how you
+# get a half-applied release.
+concurrency:
+  group: autobump-release-sweep-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write        # push the bump branch + tag ref; --admin merge
+  pull-requests: write   # open + merge the bump PR
+  actions: write         # gh workflow run (dispatch the release / tests)
+
+env:
+  # Pinned, not `latest`: a moving ref is an unreviewed binary on a persistent
+  # node whose $HOME is the operator's real home. Bump deliberately.
+  GH_CLI_VERSION: "2.96.0"
+  SCITEX_CI_APPTAINER: ${{ vars.SCITEX_CI_APPTAINER }}
+  SCITEX_CI_SIF: ${{ vars.SCITEX_CI_SIF }}
+
+jobs:
+  sweep:
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
+    timeout-minutes: 20
+    steps:
+      - name: Ensure the gh CLI exists (the bare Spartan node has none)
+        run: |
+          set -euo pipefail
+          if command -v gh >/dev/null 2>&1; then
+            echo "gh already present: $(gh --version | head -1)"
+            exit 0
+          fi
+          echo "gh not found — installing v${GH_CLI_VERSION} into RUNNER_TEMP"
+          tgz="$RUNNER_TEMP/gh.tar.gz"
+          curl -fsSL --retry 3 --max-time 120 -o "$tgz" \
+            "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz"
+          tar -xzf "$tgz" -C "$RUNNER_TEMP"
+          bindir="$RUNNER_TEMP/gh_${GH_CLI_VERSION}_linux_amd64/bin"
+          "$bindir/gh" --version
+          echo "$bindir" >> "$GITHUB_PATH"
+
+      # fetch-depth:0 + ref:develop — we operate on develop regardless of the
+      # default-branch checkout, and need full history + tags for the state read
+      # and the `git log --grep` bump-commit lookup. persist-credentials (default
+      # true) wires github.token as the origin credential so `git push` works.
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: autobump + release sweep
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # ARM SWITCH. Must be exactly 'true' for ANY mutation. Unset => report-only.
+          AUTOBUMP_ENABLED: ${{ vars.AUTOBUMP_ENABLED }}
+          # workflow_dispatch default is true (safe). On schedule this is '' and
+          # arming is governed solely by AUTOBUMP_ENABLED.
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          PKG: scitex-agent-container
+          RELEASE_WORKFLOW: pypi-publish-and-github-release-on-tag.yml
+          # A tag younger than this whose version is not yet on PyPI is "release
+          # in flight", not a ghost. 45 min covers the SIF matrix + publish.
+          GRACE_SECONDS: "2700"
+          # Off-rail alarm (req 6). Telegram is a rail wholly independent of
+          # GitHub Actions. Optional: absent => degrade to the on-rail red run +
+          # the continuous PyPI monitor (which are the MECHANISMS; the emit is a
+          # notification). Names follow the repo's PS-168 secret-prefix rule.
+          TG_TOKEN: ${{ secrets.SCITEX_AGENT_CONTAINER_TELEGRAM_BOT_TOKEN }}
+          TG_CHAT: ${{ vars.SCITEX_AGENT_CONTAINER_TELEGRAM_CHAT_ID }}
+        run: |
+          set -uo pipefail
+
+          # =====================================================================
+          # helpers
+          # =====================================================================
+          log() { echo "[autobump] $*"; }
+
+          acting() {
+            # mutate only when armed AND not an explicit dry-run
+            [ "${AUTOBUMP_ENABLED:-}" = "true" ] && [ "${DRY_RUN:-}" != "true" ]
+          }
+
+          alarm() {
+            # OFF-RAIL notification. Never fails the step (an alarm that reds the
+            # sweep would put the alarm on the same rail it is reporting about).
+            local msg="$1"
+            echo "::error::[autobump] $msg"
+            if [ -n "${TG_TOKEN:-}" ] && [ -n "${TG_CHAT:-}" ]; then
+              curl -sS --max-time 15 \
+                "https://api.telegram.org/bot${TG_TOKEN}/sendMessage" \
+                --data-urlencode "chat_id=${TG_CHAT}" \
+                --data-urlencode "text=[autobump-release-sweep] ${REPO}: ${msg}" \
+                >/dev/null 2>&1 || echo "::warning::[autobump] Telegram alarm send failed"
+            else
+              echo "::warning::[autobump] no Telegram secret/chat set — off-rail alarm degraded to the on-rail red annotation only"
+            fi
+            # Best-effort durable board card, only where the runner has reach.
+            if command -v sac >/dev/null 2>&1; then
+              sac help-wait autobump-release-sweep --question "$msg" >/dev/null 2>&1 || true
+            fi
+          }
+
+          pypi_serves() {
+            # version-specific JSON with real file count — same contract the
+            # release pipeline's own verify uses. Never trust /simple/ or latest.
+            local v="$1" code out="$RUNNER_TEMP/pypi.json"
+            code=$(curl -sS -o "$out" -w '%{http_code}' --max-time 20 \
+                    "https://pypi.org/pypi/${PKG}/${v}/json" 2>/dev/null || echo 000)
+            if [ "$code" = "200" ] && grep -q '"packagetype"' "$out" 2>/dev/null; then
+              rm -f "$out"; return 0
+            fi
+            rm -f "$out"; return 1
+          }
+
+          tag_sha() {
+            # echo the commit sha a tag points at, or empty if the tag is absent.
+            gh api "repos/$REPO/git/ref/tags/$1" --jq '.object.sha' 2>/dev/null || echo ""
+          }
+
+          commit_age_seconds() {
+            local iso now t
+            iso=$(gh api "repos/$REPO/commits/$1" --jq '.commit.committer.date' 2>/dev/null || echo "")
+            [ -z "$iso" ] && { echo 0; return; }
+            t=$(date -u -d "$iso" +%s 2>/dev/null || echo 0)
+            now=$(date -u +%s)
+            echo $(( now - t ))
+          }
+
+          run_autobump() {
+            # exit code propagates out of the SIF (exec-in-sif.sh uses exec).
+            bash .github/ci/exec-in-sif.sh autobump-in-sif.sh "$@"
+          }
+
+          dispatch_release() {
+            # Fire the existing release pipeline for an EXISTING tag. workflow_dispatch
+            # via github.token DOES create a run (a tag PUSH via github.token does not).
+            local ver="$1"
+            gh workflow run "$RELEASE_WORKFLOW" --repo "$REPO" --ref main -f version="$ver"
+          }
+
+          confirm_release_started() {
+            # Immediate watchdog: a fresh release run should appear within ~2 min.
+            # The continuous PyPI monitor is the durable backstop if this is flaky.
+            local i cutoff fresh
+            cutoff=$(date -u -d '-6 minutes' +%Y-%m-%dT%H:%M:%SZ)
+            for i in $(seq 1 12); do
+              fresh=$(gh run list --repo "$REPO" --workflow "$RELEASE_WORKFLOW" --limit 8 \
+                        --json createdAt --jq "[.[] | select(.createdAt > \"$cutoff\")] | length" \
+                        2>/dev/null || echo 0)
+              [ "${fresh:-0}" -gt 0 ] && return 0
+              sleep 10
+            done
+            return 1
+          }
+
+          # Reads develop head's aggregate check state (ALL non-advisory workflows,
+          # not one, not the PR) — byte-identical 3-valued gate to auto-merge. Sets
+          # GATE to green|busy|red|unknown|nochecks.
+          gate_develop() {
+            local sha="$1" bad busy total
+            bad=$(gh api "repos/$REPO/commits/$sha/check-runs?per_page=100" --jq '
+              [ .check_runs[]
+                | select(((.name // "") | ascii_downcase | test("codecov|readthedocs")) | not)
+                | select(.status == "completed")
+                | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required")
+              ] | length' 2>/dev/null || echo "")
+            busy=$(gh api "repos/$REPO/commits/$sha/check-runs?per_page=100" --jq '
+              [ .check_runs[]
+                | select(((.name // "") | ascii_downcase | test("codecov|readthedocs")) | not)
+                | select(.status != "completed")
+              ] | length' 2>/dev/null || echo "")
+            total=$(gh api "repos/$REPO/commits/$sha/check-runs?per_page=100" --jq '
+              [ .check_runs[]
+                | select(((.name // "") | ascii_downcase | test("codecov|readthedocs")) | not)
+              ] | length' 2>/dev/null || echo "")
+            # THREE STATES, NOT TWO. Unreadable != green.
+            if [ -z "$bad" ] || [ -z "$busy" ] || [ -z "$total" ]; then GATE=unknown; return; fi
+            if [ "$busy" -gt 0 ]; then GATE=busy; return; fi
+            if [ "$bad" -gt 0 ]; then GATE=red; return; fi
+            if [ "$total" -eq 0 ]; then GATE=nochecks; return; fi
+            GATE=green
+          }
+
+          # =====================================================================
+          # read state
+          # =====================================================================
+          if ! acting; then
+            log "REPORT-ONLY (AUTOBUMP_ENABLED='${AUTOBUMP_ENABLED:-}', DRY_RUN='${DRY_RUN:-}') — no mutation this tick."
+          fi
+
+          H=$(git rev-parse HEAD)
+          # V = the [project] version at develop head. Plain col-0 read; it is
+          # cross-checked by `autobump verify` before any tag is cut, so a drift
+          # between this read and the helper's parser goes red rather than ships.
+          V=$(grep -m1 -E '^version[[:space:]]*=[[:space:]]*"' pyproject.toml | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+          if ! printf '%s' "$V" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            alarm "pyproject [project] version '$V' is not clean X.Y.Z — refusing to act."
+            exit 0
+          fi
+          MAJ=${V%%.*}; REST=${V#*.}; MIN=${REST%%.*}; PAT=${REST#*.}
+          NEXT="${MAJ}.${MIN}.$((PAT + 1))"
+          log "develop head=$H  pyproject=$V  next-patch=$NEXT"
+
+          TAGV_SHA=$(tag_sha "v$V")
+
+          DECISION=""
+          if [ -n "$TAGV_SHA" ]; then
+            if [ "$TAGV_SHA" = "$H" ]; then
+              # ---- STEADY / GHOST monitor -----------------------------------
+              if pypi_serves "$V"; then
+                log "STEADY: v$V is tagged at develop head AND served on PyPI. Nothing to do."
+                exit 0
+              fi
+              AGE=$(commit_age_seconds "$H")
+              if [ "$AGE" -lt "$GRACE_SECONDS" ]; then
+                log "release v$V in flight (head age ${AGE}s < grace ${GRACE_SECONDS}s) — waiting for PyPI."
+                exit 0
+              fi
+              alarm "GHOST TAG v$V: tag+release commit present, but PyPI has served nothing for ${AGE}s (> grace)."
+              if acting; then
+                log "recovery: re-dispatching the release for v$V (idempotent; publish self-verifies + PyPI-verifies)."
+                if dispatch_release "v$V"; then
+                  log "re-dispatch submitted for v$V."
+                else
+                  alarm "re-dispatch of the release for v$V FAILED to submit."
+                fi
+              fi
+              exit 0
+            fi
+            DECISION=BUMP
+          else
+            # tag vV absent though pyproject is V => a landed bump awaiting its tag.
+            if run_autobump verify --version "$V"; then
+              DECISION=TAG_ONLY
+            else
+              alarm "INCONSISTENT: pyproject is $V, no tag v$V, and CHANGELOG has no released [$V] section. Refusing to guess."
+              exit 0
+            fi
+          fi
+
+          # =====================================================================
+          # TAG_ONLY — a prior bump landed but its tag/dispatch failed. Re-tag the
+          # bump-merge commit (never re-bump). Locate it so a feature merged on top
+          # afterwards is not tagged under this version.
+          # =====================================================================
+          if [ "$DECISION" = "TAG_ONLY" ]; then
+            M=$(git log origin/develop --grep="autobump/release-v$V" --format=%H -1 2>/dev/null || echo "")
+            [ -z "$M" ] && M=$(git log origin/develop --grep="chore(release): v$V" --format=%H -1 2>/dev/null || echo "")
+            if [ -z "$M" ]; then
+              alarm "TAG_ONLY: pyproject is $V with no tag v$V, but the bump-merge commit could not be located. Manual tag needed."
+              exit 0
+            fi
+            MV=$(git show "$M:pyproject.toml" 2>/dev/null | grep -m1 -E '^version[[:space:]]*=' | sed -E 's/.*"([^"]+)".*/\1/')
+            if [ "$MV" != "$V" ]; then
+              alarm "TAG_ONLY: located commit $M has pyproject '$MV', expected '$V'. Refusing to tag the wrong tree."
+              exit 0
+            fi
+            log "TAG_ONLY: v$V landed but is untagged; will re-tag the bump-merge commit $M."
+            if ! acting; then
+              log "REPORT-ONLY: would tag v$V at $M and dispatch the release."
+              exit 0
+            fi
+            EXIST=$(tag_sha "v$V")
+            if [ -z "$EXIST" ]; then
+              gh api --method POST "repos/$REPO/git/refs" -f ref="refs/tags/v$V" -f sha="$M" >/dev/null \
+                || { alarm "TAG_ONLY: failed to create tag v$V at $M."; exit 1; }
+            elif [ "$EXIST" != "$M" ]; then
+              alarm "TAG_ONLY: tag v$V already exists at $EXIST, not the expected $M. Not moving it."
+              exit 1
+            fi
+            if dispatch_release "v$V"; then
+              confirm_release_started "v$V" || alarm "tag v$V present + dispatch returned, but no release run appeared in the watch window (the PyPI monitor will re-check next tick)."
+              log "TAG_ONLY complete: v$V tagged at $M + release dispatched."
+            else
+              alarm "TAG_ONLY: 'gh workflow run $RELEASE_WORKFLOW -f version=v$V' failed to dispatch."
+              exit 1
+            fi
+            exit 0
+          fi
+
+          # =====================================================================
+          # BUMP — develop advanced past the last release. Gate green, bump, land
+          # via --admin PR merge, tag the merge commit, dispatch the release.
+          # =====================================================================
+          log "BUMP: develop moved past v$V (tagged at $TAGV_SHA) — evaluating a v$NEXT release."
+
+          gate_develop "$H"
+          case "$GATE" in
+            unknown) log "could not read develop's check state — merging/tagging nothing this tick (fail-safe)."; exit 0 ;;
+            busy)    log "develop CI still in flight — the next tick is the wait. Nothing this tick."; exit 0 ;;
+            red)
+              # develop is broken: do NOT release. develop's own red Actions run is
+              # the on-rail signal; we alarm off-rail and stay green (the sweep is
+              # healthy; develop is not).
+              alarm "develop head $H is RED (failing non-advisory checks). Refusing to release onto a broken base — fix develop first."
+              exit 0 ;;
+            nochecks)
+              # Releasing an un-CI'd tree is worse than merging one. Do NOT proceed
+              # (unlike auto-merge). Force develop's matrix so a later tick can gate
+              # on real checks, then wait. (Only `tests` is the required, dispatchable
+              # gate; quality-audit/import-smoke lack workflow_dispatch.)
+              log "develop head has NO non-advisory checks (likely a github.token merge). Not releasing un-CI'd code."
+              if acting; then
+                gh workflow run "pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml" --repo "$REPO" --ref develop >/dev/null 2>&1 \
+                  && log "dispatched the pytest matrix on develop head; will gate on it next tick." \
+                  || log "note: could not dispatch the pytest matrix; next tick re-reads."
+              fi
+              exit 0 ;;
+            green) log "develop head is green (all non-advisory checks passed) — proceeding to v$NEXT." ;;
+          esac
+
+          # Never re-tag a shipped version (ghost-mismatch guard).
+          if [ -n "$(tag_sha "v$NEXT")" ]; then
+            alarm "TAG COLLISION: tag v$NEXT already exists but pyproject is still $V. A shipped version must never be re-tagged. Manual reconciliation needed."
+            exit 1
+          fi
+
+          if ! acting; then
+            log "REPORT-ONLY: would bump $V -> $NEXT, land it as a PR merged --admin to develop, tag v$NEXT at the merge commit, and dispatch the release."
+            exit 0
+          fi
+
+          BRANCH="autobump/release-v$NEXT"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Clean any stale branch/PR from a prior failed tick (prevents a DIRTY
+          # open-PR wedge: we never leave a lingering release PR behind).
+          STALE_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number --jq '.[].number' 2>/dev/null || echo "")
+          for p in $STALE_PR; do gh pr close "$p" --repo "$REPO" --delete-branch >/dev/null 2>&1 || true; done
+          git push origin --delete "$BRANCH" >/dev/null 2>&1 || true
+
+          # Mutate pyproject + CHANGELOG inside the SIF, then cross-check.
+          if ! run_autobump bump --date "$(date -u +%F)"; then
+            alarm "autobump bump failed inside the SIF (V=$V -> NEXT=$NEXT). No changes pushed."
+            exit 1
+          fi
+          if ! run_autobump verify --version "$NEXT"; then
+            alarm "autobump produced an INCONSISTENT tree for $NEXT (pyproject/CHANGELOG disagree). Aborting before any tag."
+            git checkout -- . 2>/dev/null || true
+            exit 1
+          fi
+
+          git checkout -b "$BRANCH"
+          git add pyproject.toml CHANGELOG.md
+          git commit -m "chore(release): v$NEXT" -m "Automated patch bump + CHANGELOG promotion by autobump-release-sweep." >/dev/null
+          if ! git push origin "$BRANCH"; then
+            alarm "failed to push the bump branch $BRANCH."
+            exit 1
+          fi
+
+          # Tighten the tagged tree: if develop moved since the gate read, abort
+          # (next tick re-gates on the new head). Guarantees the merge commit ==
+          # gated-head + inert bump, so what we tag is exactly what we gated.
+          git fetch origin develop >/dev/null 2>&1 || true
+          if [ "$(git rev-parse origin/develop)" != "$H" ]; then
+            log "develop moved during the bump — aborting this tick and cleaning up; next tick re-gates."
+            gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number --jq '.[].number' 2>/dev/null \
+              | while read -r p; do [ -n "$p" ] && gh pr close "$p" --repo "$REPO" >/dev/null 2>&1 || true; done
+            git push origin --delete "$BRANCH" >/dev/null 2>&1 || true
+            exit 0
+          fi
+
+          PR=$(gh pr create --repo "$REPO" --base develop --head "$BRANCH" \
+                 --title "chore(release): v$NEXT" \
+                 --body "Automated patch bump to v$NEXT + CHANGELOG promotion (autobump-release-sweep). Merged with --admin (inert diff); the tagged tree is re-tested by the release pipeline before publish." \
+                 2>/dev/null | grep -oE '[0-9]+$' | tail -1)
+          if [ -z "${PR:-}" ]; then
+            # PR may already exist for this head — recover its number.
+            PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          fi
+          if [ -z "${PR:-}" ]; then
+            alarm "opened no bump PR for $BRANCH and could not find an existing one."
+            exit 1
+          fi
+
+          # --admin lands the inert bump under branch protection (proven primitive;
+          # enforce_admins=false). The bump PR has no CI of its own by design; the
+          # green gate above (develop head) + the release pipeline's re-test of the
+          # tagged tree are what satisfy "post-merge all-green".
+          if ! gh pr merge "$PR" --repo "$REPO" --merge --admin --delete-branch; then
+            state=$(gh pr view "$PR" --repo "$REPO" --json state --jq .state 2>/dev/null || echo "")
+            if [ "$state" != "MERGED" ]; then
+              alarm "failed to --admin merge the bump PR #$PR (state=$state)."
+              exit 1
+            fi
+            log "bump PR #$PR was already merged (race with auto-merge) — continuing."
+          fi
+
+          M=$(gh pr view "$PR" --repo "$REPO" --json mergeCommit --jq '.mergeCommit.oid' 2>/dev/null || echo "")
+          if [ -z "$M" ]; then
+            alarm "bump PR #$PR merged but its merge-commit sha could not be resolved — cannot tag."
+            exit 1
+          fi
+          log "bump v$NEXT merged to develop as $M."
+
+          # Tag the merge commit (github.token; does NOT fire on:push — we dispatch).
+          if ! gh api --method POST "repos/$REPO/git/refs" -f ref="refs/tags/v$NEXT" -f sha="$M" >/dev/null; then
+            existing=$(tag_sha "v$NEXT")
+            if [ "$existing" != "$M" ]; then
+              alarm "bump merged as $M but tag v$NEXT could not be created (existing=$existing). Next tick will TAG_ONLY-recover."
+              exit 1
+            fi
+          fi
+          log "tagged v$NEXT at $M."
+
+          if dispatch_release "v$NEXT"; then
+            confirm_release_started "v$NEXT" \
+              || alarm "tag v$NEXT pushed + dispatch returned, but no release run appeared in the watch window — the PyPI monitor will re-check next tick."
+            log "RELEASE v$NEXT: bump merged ($M), tagged, release dispatched."
+          else
+            alarm "tag v$NEXT created but 'gh workflow run $RELEASE_WORKFLOW -f version=v$NEXT' failed to dispatch. Next tick will TAG_ONLY-recover / re-dispatch."
+            exit 1
+          fi

--- a/.github/workflows/pypi-publish-and-github-release-on-tag.yml
+++ b/.github/workflows/pypi-publish-and-github-release-on-tag.yml
@@ -108,6 +108,21 @@ jobs:
       # inside the SIF, then `python -m build` → dist/. fail-loud on empty dist.
       - name: Build wheel + sdist in the CI SIF (apptainer exec)
         run: bash .github/ci/exec-in-sif.sh build-in-sif.sh 3.12
+      - name: Assert the built wheel carries the tagged version (belt; never trust the version string)
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          V="${VERSION#v}"
+          # A wheel whose baked version != the tag is the ghost-tag-at-birth /
+          # stale-(name,version)-wheel-cache edge — make it RED here, before
+          # publish, not a caught ghost after a partial upload.
+          if ! ls dist/*"${V}"*.whl >/dev/null 2>&1; then
+            echo "::error::no wheel in dist/ carries the tagged version ${V} — built version != tag."
+            ls -la dist/ || true
+            exit 1
+          fi
+          echo "OK: dist/ contains a wheel for the tagged version ${V}."
       # upload-artifact is a JS action — runs fine on the self-hosted runner.
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Merge->release automation: `autobump-release-sweep.yaml`.** A state-driven
+  scheduled sweep (mirroring `auto-merge-to-develop.yaml`'s proven shape) that
+  auto-bumps the patch version and cuts a release on every merge-to-develop —
+  the automation of the manual `bump pyproject + promote CHANGELOG -> PR ->
+  merge -> tag -> push tag` ritual. It advances the version every release so
+  uv's `(name, version)` wheel-cache key changes (no stale-wheel reuse — the
+  root-cause fix, not the by-symbol workaround). Loop-safety is STRUCTURAL
+  (repository state, not event guards): an untagged version is re-tagged, never
+  re-incremented. It gates on develop's post-merge all-green check state, fires
+  the EXISTING release pipeline via `workflow_dispatch` (no bot token / PAT —
+  github.token is used throughout; a github.token tag push does not fire
+  `on: push`, so the release is dispatched explicitly), and runs every tick as a
+  continuous ghost-tag monitor (tag present but PyPI not serving => off-rail
+  Telegram alarm + re-dispatch). Bump/CHANGELOG logic is the tested, dependency-
+  free `.github/ci/autobump.py` (unit-tested in `tests/develop/test_autobump.py`).
+  SHIPS DISARMED: every mutation is gated behind the repo Actions Variable
+  `AUTOBUMP_ENABLED == 'true'`, and the file only executes once on `main` — so
+  merging it changes nothing until the operator deliberately arms it.
+
 ## [0.24.1] - 2026-07-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Start / start-failure log output is now readable, not a run-on wall**
+  (operator 2026-07-19: "めっちゃ汚い"). Format-only — no control-flow, trigger,
+  or suppression behaviour changed:
+  - The **start-failure diagnostic** (`raise_start_failure` /
+    `_start_failure_diag`) now renders as a headline plus clearly separated,
+    indented sections (`tmux session`, `inner stderr`, `pane tail`) with each
+    section body indented under its label, instead of one flush-left blob.
+  - The per-start **`[sac:creds]` credentials-pool selection notice** is now a
+    headline naming the agent + picked account, followed by indented fields
+    (`file`, `policy=…`, `picked usage`) and a one-entry-per-line ranking-inputs
+    list, instead of a single run-on sentence. It still writes through the
+    caller's `log_stream` (the `preflight_from_config_path` dry-probe
+    suppression seam is preserved — it is NOT routed to a logger).
+  - Hook failures in `_hook_runner` now log at WARNING level (`logger.warning`)
+    instead of `print`-ing `[WARN] …` with the severity baked into the message
+    text.
+
 ## [0.24.1] - 2026-07-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.24.2] - 2026-07-21
+
 ### Added
 
 - **Merge->release automation: `autobump-release-sweep.yaml`.** A state-driven
@@ -45,6 +47,16 @@ versioning follows [SemVer](https://semver.org/).
   - Hook failures in `_hook_runner` now log at WARNING level (`logger.warning`)
     instead of `print`-ing `[WARN] …` with the severity baked into the message
     text.
+
+### Fixed
+
+- **Concurrent runner-state writes no longer race on a shared `<name>.tmp`**
+  (#797). Each of the seven runner-state writers wrote to a fixed sibling
+  `<name>.tmp` before the atomic rename, so two writers racing on the same
+  target could clobber each other's temp file. Each now writes to a unique
+  temp path via the `atomic_write_text` helper; the per-session quota group
+  was extracted to `_session_quota.py` to keep the module under the line cap,
+  and a regression test covers the concurrent-writer case.
 
 ## [0.24.1] - 2026-07-20
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.1"
+version = "0.24.2"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/_creds/__init__.py
+++ b/src/scitex_agent_container/_creds/__init__.py
@@ -30,6 +30,7 @@ from ._pick_audit import (
     CandidateAudit,
     audit_candidates,
     format_pick_audit,
+    pick_audit_parts,
 )
 from ._pick_healthy import (
     AccountHealth,
@@ -60,6 +61,7 @@ __all__ = [
     "account_health",
     "audit_candidates",
     "format_pick_audit",
+    "pick_audit_parts",
     "pick_healthy_account",
     "resolve_7d_policy",
 ]

--- a/src/scitex_agent_container/_creds/_pick_audit.py
+++ b/src/scitex_agent_container/_creds/_pick_audit.py
@@ -117,13 +117,18 @@ def _fmt_reset(seconds: float | None) -> str:
     return "?" if seconds is None else f"{seconds / 3600.0:+.1f}h"
 
 
-def format_pick_audit(records: list[CandidateAudit]) -> str:
-    """One log-safe line naming EVERY ranking input for every candidate.
+def pick_audit_parts(records: list[CandidateAudit]) -> list[str]:
+    """Per-candidate ranking-input strings, one string per candidate, in order.
 
-    ``ranking inputs: a(5h=9% 7d=10% 7d_reset=+56.4h), b(...)`` — the
-    flags (``5h-blocked`` / ``7d-near-cap`` / ``7d-expiring``) appear
-    only when set. Contains percentages, relative hours, and account
-    slugs ONLY — never a token value or credential path.
+    The building block behind :func:`format_pick_audit` (which joins these into
+    one comma-run line). Exposed so a caller that wants a readable, one-entry-
+    per-line ranking LIST — the start-time ``[sac:creds]`` notice — can indent
+    each entry on its own line instead of a run-on comma-run (operator
+    2026-07-19: the notice was "めっちゃ汚い"). Each entry is
+    ``a(5h=9% 7d=10% 7d_reset=+56.4h)`` with the flags (``5h-blocked`` /
+    ``7d-near-cap`` / ``7d-expiring``) appended only when set. Contains
+    percentages, relative hours, and account slugs ONLY — never a token value
+    or credential path.
     """
     parts: list[str] = []
     for r in records:
@@ -138,11 +143,24 @@ def format_pick_audit(records: list[CandidateAudit]) -> str:
             f"{r.name}(5h={_fmt_pct(r.pct_5h)} 7d={_fmt_pct(r.pct_7d)} "
             f"7d_reset={_fmt_reset(r.reset_7d_in_s)}{flags})"
         )
-    return "ranking inputs: " + ", ".join(parts)
+    return parts
+
+
+def format_pick_audit(records: list[CandidateAudit]) -> str:
+    """One log-safe line naming EVERY ranking input for every candidate.
+
+    ``ranking inputs: a(5h=9% 7d=10% 7d_reset=+56.4h), b(...)`` — the
+    flags (``5h-blocked`` / ``7d-near-cap`` / ``7d-expiring``) appear
+    only when set. Contains percentages, relative hours, and account
+    slugs ONLY — never a token value or credential path. The per-candidate
+    rendering is :func:`pick_audit_parts` (shared SSOT).
+    """
+    return "ranking inputs: " + ", ".join(pick_audit_parts(records))
 
 
 __all__ = [
     "CandidateAudit",
     "audit_candidates",
     "format_pick_audit",
+    "pick_audit_parts",
 ]

--- a/src/scitex_agent_container/_lifecycle/_hook_runner.py
+++ b/src/scitex_agent_container/_lifecycle/_hook_runner.py
@@ -8,10 +8,20 @@ Extracted from the former monolithic ``lifecycle.py`` (split for the
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from typing import Any, Callable
 
 from ..hooks import run_hook
+
+# Module logger (stdlib, mirroring ._stop_escalate) so hook failures are
+# emitted at a proper WARNING LEVEL — rendered as scitex-logging's coloured
+# ``WARN:`` prefix by the root handler in production — instead of a bare
+# ``print`` with the severity baked into the message text as ``[WARN]``
+# (operator 2026-07-19: severity is DATA, not text). Stdlib ``getLogger`` is
+# free, so this does not tax the CLI import budget the way a top-level
+# ``scitex_logging`` import would (see config._config_logger).
+logger = logging.getLogger(__name__)
 
 
 def _fire_forget_hook(
@@ -32,12 +42,7 @@ def _fire_forget_hook(
     try:
         run_hook(agent_name, hook_name, list(commands or []), context=context)
     except Exception:  # pragma: no cover  # stx-allow: fallback (reason: hook dispatch safety net — hook crashes must not propagate to caller)
-        import sys
-
-        print(
-            f"[WARN] run_hook {hook_name} dispatch failed for {agent_name}",
-            file=sys.stderr,
-        )
+        logger.warning("run_hook %s dispatch failed for %s", hook_name, agent_name)
 
 
 def _run_hooks(
@@ -70,9 +75,9 @@ def _run_hooks(
             continue
         result = runner(hook, shell=True, capture_output=True, text=True, env=env)
         if result.returncode != 0:
-            # Log but don't fail
-            import sys
-
-            print(f"[WARN] Hook failed: {hook}", file=sys.stderr)
+            # Log but don't fail — at WARNING level (severity as data), and
+            # the captured stderr as its own indented follow-on line rather
+            # than a run-on.
+            logger.warning("Hook failed (rc=%s): %s", result.returncode, hook)
             if result.stderr:
-                print(f"       {result.stderr.strip()}", file=sys.stderr)
+                logger.warning("    %s", result.stderr.strip())

--- a/src/scitex_agent_container/_lifecycle/_start_failure_diag.py
+++ b/src/scitex_agent_container/_lifecycle/_start_failure_diag.py
@@ -20,6 +20,18 @@ __all__ = [
 ]
 
 
+def _indent_block(text: str, prefix: str = "      ") -> str:
+    """Indent every line of a multi-line body so it reads as ONE sub-section.
+
+    The start-failure report is a headline + labelled sections; each section's
+    BODY (an inner-stderr tail, a pane capture) is indented under its label so
+    the operator can see at a glance where one section ends and the next begins
+    instead of reading a run-on wall (operator 2026-07-19). Empty-safe.
+    """
+    lines = text.splitlines() or [""]
+    return "\n".join(f"{prefix}{line}" for line in lines)
+
+
 def _format_boot_stderr_section(log: Path) -> str:
     """Formatted 'inner stderr' diagnostic section for a failed TUI start.
 
@@ -29,15 +41,19 @@ def _format_boot_stderr_section(log: Path) -> str:
     (``log``), which SURVIVES the tmux pane's death. Return its tail so a boot
     failure is the LOUD cause in the raised error, never a cause-less
     ``<empty>`` pane fallback. Empty/absent-log safe; never raises.
+
+    Rendered as a labelled section (the ``inner stderr`` label at 2 spaces, the
+    captured body indented under it at 6) so the report reads as distinct,
+    separated sections rather than a flush-left blob.
     """
     tail = ""
     if log.is_file():
         tail = log.read_text(errors="replace")[-4_000:].rstrip()
     body = tail or "<no stderr captured — runtime never launched the process>"
-    return f"  inner stderr ({log}):\n{body}\n"
+    return f"\n  inner stderr ({log}):\n{_indent_block(body)}"
 
 
-_NO_PANE = " (no pane diagnostics available)"
+_NO_PANE = "\n  (no pane diagnostics available)"
 
 
 def raise_start_failure(
@@ -114,9 +130,9 @@ def capture_pane_diag(config: Any) -> str:
     pane = TmuxManager.capture_logs(sess, lines=60).rstrip()
     boot_log = _state_dir(config) / "boot.stderr.log"
     return (
-        f" (tmux session_exists={TmuxManager.exists(sess)})\n"
+        f"\n  tmux session: exists={TmuxManager.exists(sess)} (session {sess!r})"
         f"{_format_boot_stderr_section(boot_log)}"
-        f"  pane tail:\n{pane or '<empty>'}"
+        f"\n  pane tail:\n{_indent_block(pane or '<empty>')}"
     )
 
 

--- a/src/scitex_agent_container/_lifecycle/_start_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_start_preflight.py
@@ -224,7 +224,7 @@ def _rotate_among_credentials_files(
         account_7d_reset_at,
         account_7d_usage,
         audit_candidates,
-        format_pick_audit,
+        pick_audit_parts,
     )
 
     # EVERY ranking input, per candidate — the pick must be auditable
@@ -240,7 +240,7 @@ def _rotate_among_credentials_files(
         for s in slugs
     }
     r7 = {s: account_7d_reset_at(s, quota_cache_path=quota_cache_path) for s in slugs}
-    audit = format_pick_audit(audit_candidates(slugs, u5, u7, reset_7d=r7, now=now))
+    records = audit_candidates(slugs, u5, u7, reset_7d=r7, now=now)
 
     def fmt(v: float | None) -> str:
         return "?" if v is None else f"{v:.0f}%"
@@ -254,12 +254,21 @@ def _rotate_among_credentials_files(
         "accounts, load-balanced per agent by 7d headroom; time-to-reset "
         "counts only within the 2h expiring horizon"
     )
+    # Readable, structured notice (operator 2026-07-19: the run-on one-liner
+    # was "めっちゃ汚い"): a headline naming the agent + picked account, then
+    # indented fields, then the per-candidate ranking inputs as a ONE-ENTRY-
+    # PER-LINE list. Still emitted through ``stream`` (log_stream or stderr)
+    # so ``preflight_from_config_path``'s throwaway-StringIO suppression of the
+    # dry-probe rotation notice keeps working — do NOT route this to a logger.
+    ranking = "\n".join(f"      {part}" for part in pick_audit_parts(records))
     stream = log_stream if log_stream is not None else sys.stderr
     print(
-        f"[sac:creds] agent '{config.name}' selected credentials_files pool "
-        f"entry: account {picked!r} ({picked_path}) among {len(slugs)} listed "
-        f"credentials_files (policy={policy} — {rationale}; picked usage "
-        f"5h={fmt(u5.get(picked))} 7d={fmt(u7.get(picked))}; {audit})",
+        f"[sac:creds] agent '{config.name}' selected credentials pool account "
+        f"{picked!r} ({len(slugs)} candidates listed)\n"
+        f"  file:          {picked_path}\n"
+        f"  policy={policy} — {rationale}\n"
+        f"  picked usage:  5h={fmt(u5.get(picked))} 7d={fmt(u7.get(picked))}\n"
+        f"  ranking inputs:\n{ranking}",
         file=stream,
     )
 

--- a/src/scitex_agent_container/_runners/_atomic.py
+++ b/src/scitex_agent_container/_runners/_atomic.py
@@ -1,0 +1,51 @@
+"""Atomic text writes for the claude-session runner state dir.
+
+The runner persists small state files (``pid``, ``started_at``,
+``heartbeat.json``, ``quota.json``, ``instance_id``, ``session_id``,
+``session_id_history``) with the tmp + ``os.replace`` pattern so a
+concurrent *reader* (``sac agent status``) never sees a half-formed file.
+
+A **fixed** ``<name>.tmp`` sibling is not safe when two *writers* share the
+same state dir — two xdist workers keyed on the same agent name, or two
+runner processes racing on one agent's dir. Both open the SAME tmp path;
+the first ``replace()`` renames it onto the target, and the loser's
+``replace()`` then raises ``FileNotFoundError`` because the tmp it expected
+is already gone. Measured on CI as::
+
+    FileNotFoundError: '.../runtime/alpha/instance_id.tmp'
+      -> '.../runtime/alpha/instance_id'
+
+Giving every writer a UNIQUE tmp (via :func:`tempfile.mkstemp`) removes the
+collision: only the final rename — which is atomic — contends, and it is
+last-writer-wins with no spurious error. This mirrors the existing correct
+helper in ``_account/codex_account._atomic_write``.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_text(dst: Path, text: str) -> None:
+    """Atomically write ``text`` to ``dst`` via a per-writer-unique temp file.
+
+    The temp file is created in ``dst.parent`` (same filesystem, so the
+    rename is atomic) with a unique name, so concurrent writers to the same
+    directory never collide on the temp path. The parent dir is created if
+    absent. On any failure the temp file is removed so a crashed write never
+    leaves a stray ``.tmp`` behind.
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{dst.name}.", suffix=".tmp", dir=dst.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp, dst)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise

--- a/src/scitex_agent_container/_runners/_session_id.py
+++ b/src/scitex_agent_container/_runners/_session_id.py
@@ -26,6 +26,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+# Per-writer-unique atomic text write (unique tmp name) so two processes
+# sharing one state dir never collide on a fixed ``<name>.tmp`` sibling.
+from ._atomic import atomic_write_text
+
 
 def _session_id_history_path(state_dir: Path) -> Path:
     return state_dir / "session_id_history"
@@ -83,9 +87,7 @@ def write_session_id(state_dir: Path, session_id: str) -> None:
     additive.
     """
     state_dir.mkdir(parents=True, exist_ok=True)
-    tmp = state_dir / "session_id.tmp"
-    tmp.write_text(session_id, encoding="utf-8")
-    tmp.replace(state_dir / "session_id")
+    atomic_write_text(state_dir / "session_id", session_id)
     append_session_id_history(state_dir, session_id)
 
 
@@ -184,9 +186,7 @@ def discard_dead_session(state_dir: Path, dead_id: str) -> bool:
 
     survivors = [sid for sid in history if sid != dead_id]
     if survivors:
-        tmp = state_dir / "session_id_history.tmp"
-        tmp.write_text("\n".join(survivors) + "\n", encoding="utf-8")
-        tmp.replace(history_path)
+        atomic_write_text(history_path, "\n".join(survivors) + "\n")
     else:
         try:
             history_path.unlink()

--- a/src/scitex_agent_container/_runners/_session_quota.py
+++ b/src/scitex_agent_container/_runners/_session_quota.py
@@ -1,0 +1,59 @@
+"""Per-agent token-quota totals persisted in the runner state dir.
+
+Extracted from ``_session_state.py`` to keep that module under the
+512-line cap. ``_session_state`` re-exports ``read_quota`` /
+``accumulate_quota`` (explicit ``as`` aliases) so every existing
+``_session_state.read_quota`` / ``.accumulate_quota`` importer keeps
+working unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ._atomic import atomic_write_text
+
+
+def _quota_path(state_dir: Path) -> Path:
+    return state_dir / "quota.json"
+
+
+def read_quota(state_dir: Path) -> dict:
+    """Return the persisted quota totals, or a zeroed dict if absent."""
+    p = _quota_path(state_dir)
+    if not p.is_file():
+        return {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "turns": 0,
+        }
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def accumulate_quota(state_dir: Path, usage: dict | None) -> dict:
+    """Add one ``ResultMessage.usage`` block to the running totals.
+
+    Atomic via a per-writer-unique tmp + rename so a concurrent
+    ``sac agent status`` reader never sees a partial write, and two
+    writers sharing the dir never collide on the tmp name. Returns the
+    new totals.
+    """
+    if not usage:
+        return read_quota(state_dir)
+    totals = read_quota(state_dir)
+    for key in (
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+    ):
+        totals[key] = int(totals.get(key, 0)) + int(usage.get(key, 0) or 0)
+    totals["turns"] = int(totals.get("turns", 0)) + 1
+    atomic_write_text(_quota_path(state_dir), json.dumps(totals))
+    return totals

--- a/src/scitex_agent_container/_runners/_session_state.py
+++ b/src/scitex_agent_container/_runners/_session_state.py
@@ -26,6 +26,11 @@ from pathlib import Path
 # per-agent state root all relocate together.
 from .._runtime_paths import runtime_base_dir
 
+# Per-writer-unique atomic text write: a UNIQUE tmp name so two processes
+# sharing one state dir never collide on a fixed ``<name>.tmp`` sibling
+# (the ``instance_id.tmp`` FileNotFoundError race). See ``_atomic``.
+from ._atomic import atomic_write_text
+
 # Session-id resume marker + append-only history live in a focused
 # module to keep this file under the 512-line cap. Re-exported here
 # (explicit ``as`` aliases mark the intentional re-export) so the
@@ -38,6 +43,12 @@ from ._session_id import discard_dead_session as discard_dead_session
 from ._session_id import read_session_id as read_session_id
 from ._session_id import read_session_id_history as read_session_id_history
 from ._session_id import write_session_id as write_session_id
+
+# Quota totals live in a focused module (keeps this file under the
+# 512-line cap). Re-exported so ``_session_state.{read,accumulate}_quota``
+# importers keep working unchanged.
+from ._session_quota import accumulate_quota as accumulate_quota
+from ._session_quota import read_quota as read_quota
 
 DEFAULT_STATE_ROOT = runtime_base_dir()
 DEFAULT_TICK_SECONDS = 10.0
@@ -69,9 +80,7 @@ def state_dir_for(name: str, root: Path | None = None) -> Path:
 def write_pid(state_dir: Path, pid: int) -> None:
     """Write the runner's PID atomically (tmp + rename)."""
     state_dir.mkdir(parents=True, exist_ok=True)
-    tmp = state_dir / "pid.tmp"
-    tmp.write_text(f"{pid}\n", encoding="utf-8")
-    tmp.replace(state_dir / "pid")
+    atomic_write_text(state_dir / "pid", f"{pid}\n")
 
 
 def read_pid(state_dir: Path) -> int | None:
@@ -102,9 +111,7 @@ def write_started_at(state_dir: Path, started_at: float | None = None) -> float:
     if started_at is None:
         started_at = time.time()
     state_dir.mkdir(parents=True, exist_ok=True)
-    tmp = state_dir / "started_at.tmp"
-    tmp.write_text(repr(float(started_at)), encoding="utf-8")
-    tmp.replace(state_dir / "started_at")
+    atomic_write_text(state_dir / "started_at", repr(float(started_at)))
     return float(started_at)
 
 
@@ -294,9 +301,7 @@ def write_heartbeat(
 
     payload.update(heartbeat_jsonl_fields(state_dir, now))
     payload.update(heartbeat_progress_fields(state_dir))
-    tmp = state_dir / "heartbeat.json.tmp"
-    tmp.write_text(json.dumps(payload), encoding="utf-8")
-    tmp.replace(state_dir / "heartbeat.json")
+    atomic_write_text(state_dir / "heartbeat.json", json.dumps(payload))
     if name and host:
         writer = _resolve_db_writer(db_writer)
         writer.record_heartbeat(
@@ -425,56 +430,6 @@ async def heartbeat_loop(
 
 
 # ---------------------------------------------------------------------------
-# Quota
-# ---------------------------------------------------------------------------
-
-
-def _quota_path(state_dir: Path) -> Path:
-    return state_dir / "quota.json"
-
-
-def read_quota(state_dir: Path) -> dict:
-    """Return the persisted quota totals, or a zeroed dict if absent."""
-    p = _quota_path(state_dir)
-    if not p.is_file():
-        return {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
-            "turns": 0,
-        }
-    try:
-        return json.loads(p.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {}
-
-
-def accumulate_quota(state_dir: Path, usage: dict | None) -> dict:
-    """Add one ``ResultMessage.usage`` block to the running totals.
-
-    Atomic via tmp+rename so a concurrent ``sac agent status`` reader
-    never sees a partial write. Returns the new totals.
-    """
-    if not usage:
-        return read_quota(state_dir)
-    state_dir.mkdir(parents=True, exist_ok=True)
-    totals = read_quota(state_dir)
-    for key in (
-        "input_tokens",
-        "output_tokens",
-        "cache_creation_input_tokens",
-        "cache_read_input_tokens",
-    ):
-        totals[key] = int(totals.get(key, 0)) + int(usage.get(key, 0) or 0)
-    totals["turns"] = int(totals.get("turns", 0)) + 1
-    tmp = state_dir / "quota.json.tmp"
-    tmp.write_text(json.dumps(totals), encoding="utf-8")
-    tmp.replace(_quota_path(state_dir))
-    return totals
-
-
-# ---------------------------------------------------------------------------
 # Session id (resume marker) + append-only history
 #
 # Implementation extracted to ``_session_id.py`` (focused module, keeps
@@ -499,9 +454,7 @@ def accumulate_quota(state_dir: Path, usage: dict | None) -> dict:
 def write_instance_id(state_dir: Path, instance_id: str) -> None:
     """Persist the state.db instance uuid alongside the runner pid."""
     state_dir.mkdir(parents=True, exist_ok=True)
-    tmp = state_dir / "instance_id.tmp"
-    tmp.write_text(instance_id, encoding="utf-8")
-    tmp.replace(state_dir / "instance_id")
+    atomic_write_text(state_dir / "instance_id", instance_id)
 
 
 def read_instance_id(state_dir: Path) -> str | None:

--- a/tests/develop/test_autobump.py
+++ b/tests/develop/test_autobump.py
@@ -1,0 +1,294 @@
+"""`.github/ci/autobump.py` is the write-path of the merge->release sweep.
+
+A hand repair leaves no detector; the sweep's whole safety rests on this helper
+being SURGICAL (touch only the [project] version line) and FAIL-LOUD (never emit
+an inconsistent pyproject/CHANGELOG that would become a ghost tag). So the
+detector ships with it, and the negative cases feed the exact bad input the
+sweep must refuse — a mutation there goes RED here.
+
+Loaded by file path (autobump.py is a CI helper, not an importable package),
+mirroring tests/develop/test_git_hooks.py's loader for scripts/.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+
+_UNRELEASED = "## [Unreleased]"
+
+_PYPROJECT_FIXTURE = """\
+[build-system]
+requires = ["hatchling<1.28"]
+build-backend = "hatchling.build"
+
+[project]
+name = "scitex-agent-container"
+version = "0.24.1"
+requires-python = ">=3.10"
+dependencies = [
+    "click>=8.0",
+    "pyyaml>=6.0",
+]
+
+[tool.ruff]
+target-version = "py310"
+"""
+
+_CHANGELOG_FIXTURE = """\
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- something pending
+
+## [0.24.1] - 2026-07-20
+
+### Fixed
+
+- prior release
+"""
+
+
+@pytest.fixture(scope="module")
+def autobump() -> ModuleType:
+    path = _REPO / ".github" / "ci" / "autobump.py"
+    assert path.exists(), f"autobump helper missing at {path}"
+    spec = importlib.util.spec_from_file_location("autobump", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / "pyproject.toml").write_text(_PYPROJECT_FIXTURE, encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text(_CHANGELOG_FIXTURE, encoding="utf-8")
+    return tmp_path
+
+
+# --------------------------------------------------------------------------
+# version arithmetic
+# --------------------------------------------------------------------------
+def test_read_current_version_returns_project_version(autobump, repo):
+    # Arrange: fixture writes pyproject with version 0.24.1
+    expected = "0.24.1"
+    # Act
+    got = autobump.read_current_version(repo)
+    # Assert
+    assert got == expected
+
+
+def test_compute_next_patch_increments_patch_component(autobump):
+    # Arrange
+    current = "0.24.1"
+    # Act
+    got = autobump.compute_next_patch(current)
+    # Assert
+    assert got == "0.24.2"
+
+
+def test_compute_next_patch_carries_into_double_digits(autobump):
+    # Arrange
+    current = "1.0.9"
+    # Act
+    got = autobump.compute_next_patch(current)
+    # Assert
+    assert got == "1.0.10"
+
+
+def test_compute_next_patch_rejects_non_semver_string(autobump):
+    # Arrange
+    dirty = "0.24.1.dev3+gdead"
+    # Act
+    # Assert
+    with pytest.raises(autobump.AutobumpError):
+        autobump.compute_next_patch(dirty)
+
+
+# --------------------------------------------------------------------------
+# bump is SURGICAL: only the [project] version line moves
+# --------------------------------------------------------------------------
+def test_bump_returns_the_next_patch_version(autobump, repo):
+    # Arrange: pyproject at 0.24.1
+    # Act
+    new = autobump.do_bump(repo, date="2026-07-21")
+    # Assert
+    assert new == "0.24.2"
+
+
+def test_bump_rewrites_the_project_version_line(autobump, repo):
+    # Arrange
+    autobump.do_bump(repo, date="2026-07-21")
+    # Act
+    py = (repo / "pyproject.toml").read_text(encoding="utf-8")
+    # Assert
+    assert 'version = "0.24.2"' in py
+
+
+def test_bump_leaves_no_stale_old_version(autobump, repo):
+    # Arrange
+    autobump.do_bump(repo, date="2026-07-21")
+    # Act
+    py = (repo / "pyproject.toml").read_text(encoding="utf-8")
+    # Assert
+    assert 'version = "0.24.1"' not in py
+
+
+def test_bump_preserves_indented_dependency_constraints(autobump, repo):
+    # Arrange: the col-0 anchor must never hit an indented dep line
+    autobump.do_bump(repo, date="2026-07-21")
+    # Act
+    py = (repo / "pyproject.toml").read_text(encoding="utf-8")
+    # Assert
+    assert '"click>=8.0"' in py
+
+
+def test_bump_preserves_ruff_target_version(autobump, repo):
+    # Arrange: target-version must not be mistaken for the project version
+    autobump.do_bump(repo, date="2026-07-21")
+    # Act
+    py = (repo / "pyproject.toml").read_text(encoding="utf-8")
+    # Assert
+    assert 'target-version = "py310"' in py
+
+
+def test_bump_creates_dated_released_section(autobump, repo):
+    # Arrange
+    autobump.do_bump(repo, date="2026-07-21")
+    # Act
+    cl = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+    # Assert
+    assert "## [0.24.2] - 2026-07-21" in cl
+
+
+def test_bump_keeps_empty_unreleased_on_top(autobump, repo):
+    # Arrange
+    autobump.do_bump(repo, date="2026-07-21")
+    # Act
+    cl = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+    # Assert
+    assert cl.index(_UNRELEASED) < cl.index("## [0.24.2]")
+
+
+def test_bump_moves_unreleased_body_into_release(autobump, repo):
+    # Arrange
+    autobump.do_bump(repo, date="2026-07-21")
+    # Act
+    cl = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+    # Assert
+    assert cl.index("## [0.24.2]") < cl.index("- something pending")
+
+
+def test_bump_orders_new_release_above_prior(autobump, repo):
+    # Arrange
+    autobump.do_bump(repo, date="2026-07-21")
+    # Act
+    cl = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+    # Assert
+    assert cl.index("## [0.24.2]") < cl.index("## [0.24.1]")
+
+
+def test_promote_changelog_refuses_duplicate_version(autobump, repo):
+    # Arrange: 0.24.2 already promoted once
+    autobump.do_bump(repo, date="2026-07-21")
+    # Act
+    # Assert: re-promoting the same version must fail loud, not double-write
+    with pytest.raises(autobump.AutobumpError):
+        autobump.promote_changelog(repo, "0.24.2", date="2026-07-21")
+
+
+def test_bump_fails_without_unreleased_heading(autobump, repo):
+    # Arrange: a CHANGELOG with no [Unreleased] section
+    (repo / "CHANGELOG.md").write_text("# Changelog\n\n## [0.24.1]\n", encoding="utf-8")
+    # Act
+    # Assert
+    with pytest.raises(autobump.AutobumpError):
+        autobump.do_bump(repo, date="2026-07-21")
+
+
+# --------------------------------------------------------------------------
+# verify: the pre-tag consistency gate — MUTATION-PROVE it goes red
+# --------------------------------------------------------------------------
+def test_verify_passes_on_consistent_tree(autobump, repo):
+    # Arrange: fixture is consistent at 0.24.1
+    # Act
+    problems = autobump.verify_consistency(repo, "0.24.1")
+    # Assert
+    assert problems == []
+
+
+def test_verify_flags_pyproject_version_disagreement(autobump, repo):
+    # Arrange: assert tag 0.24.2 against a tree still at 0.24.1 (ghost-at-birth)
+    # Act
+    problems = autobump.verify_consistency(repo, "0.24.2")
+    # Assert
+    assert any("pyproject" in p for p in problems)
+
+
+def test_verify_flags_missing_changelog_section(autobump, repo):
+    # Arrange: pyproject bumped but CHANGELOG promotion never happened
+    autobump.rewrite_pyproject_version(repo, "0.24.2")
+    # Act
+    problems = autobump.verify_consistency(repo, "0.24.2")
+    # Assert
+    assert any("CHANGELOG" in p and "0.24.2" in p for p in problems)
+
+
+def test_verify_flags_missing_version_line(autobump, tmp_path):
+    # Arrange: a pyproject with no [project] version line at all
+    (tmp_path / "CHANGELOG.md").write_text(_CHANGELOG_FIXTURE, encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "x"\n', encoding="utf-8"
+    )
+    # Act
+    problems = autobump.verify_consistency(tmp_path, "0.24.1")
+    # Assert
+    assert problems
+
+
+# --------------------------------------------------------------------------
+# CLI surface the workflow actually calls
+# --------------------------------------------------------------------------
+def test_cli_verify_returns_zero_when_consistent(autobump, repo):
+    # Arrange
+    argv = ["--root", str(repo), "verify", "--version", "0.24.1"]
+    # Act
+    rc = autobump.main(argv)
+    # Assert
+    assert rc == 0
+
+
+def test_cli_verify_tolerates_leading_v_prefix(autobump, repo):
+    # Arrange: the sweep passes tags like v0.24.1
+    argv = ["--root", str(repo), "verify", "--version", "v0.24.1"]
+    # Act
+    rc = autobump.main(argv)
+    # Assert
+    assert rc == 0
+
+
+def test_cli_verify_returns_three_on_mismatch(autobump, repo):
+    # Arrange
+    argv = ["--root", str(repo), "verify", "--version", "0.24.2"]
+    # Act
+    rc = autobump.main(argv)
+    # Assert
+    assert rc == autobump.EXIT_INCONSISTENT
+
+
+def test_cli_bump_prints_new_version_to_stdout(autobump, repo, capsys):
+    # Arrange
+    argv = ["--root", str(repo), "bump", "--date", "2026-07-21"]
+    # Act
+    autobump.main(argv)
+    out = capsys.readouterr().out.strip()
+    # Assert
+    assert out == "0.24.2"

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -317,16 +317,18 @@ def test_run_hooks_skips_https_url_entries() -> None:
     assert calls == []
 
 
-def test_run_hooks_warns_on_nonzero_returncode(capsys: pytest.CaptureFixture) -> None:
+def test_run_hooks_warns_on_nonzero_returncode(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     # Arrange
     def runner(cmd: str, **_kwargs: Any) -> _FakeResult:
         return _FakeResult(returncode=2, stderr="boom")
 
     # Act
-    lc._run_hooks(["false"], runner=runner)
-    # Assert
-    err = capsys.readouterr().err
-    assert "Hook failed" in err and "boom" in err
+    with caplog.at_level("WARNING"):
+        lc._run_hooks(["false"], runner=runner)
+    # Assert — the failure is logged at WARNING level with cmd + stderr.
+    assert "Hook failed" in caplog.text and "boom" in caplog.text
 
 
 def test_run_hooks_real_subprocess_executes(tmp_path: Path) -> None:

--- a/tests/scitex_agent_container/_runners/test__atomic.py
+++ b/tests/scitex_agent_container/_runners/test__atomic.py
@@ -1,0 +1,115 @@
+"""Regression tests for the runner state-dir atomic write helper.
+
+The bug: the runner persisted small state files with a FIXED ``<name>.tmp``
+sibling + ``os.replace``. Two processes sharing one state dir (two xdist
+workers keyed on the same agent name, or two runner processes racing on one
+agent) both open the SAME tmp; the first rename consumes it and the loser's
+``replace()`` raises ``FileNotFoundError``. Measured on CI as
+``.../runtime/alpha/instance_id.tmp -> .../runtime/alpha/instance_id``.
+
+``atomic_write_text`` gives each writer a UNIQUE tmp (via ``mkstemp``), so
+only the final atomic rename contends and nothing raises. The concurrency
+test fails on the pre-fix code and passes on the fix.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from scitex_agent_container._runners._atomic import atomic_write_text
+from scitex_agent_container._runners._session_state import (
+    read_instance_id,
+    write_instance_id,
+)
+
+
+def test_concurrent_writers_sharing_a_dir_do_not_raise(tmp_path):
+    """Eight writers hammering one target must never raise the tmp race.
+
+    On the pre-fix fixed-tmp code this raises FileNotFoundError with high
+    probability; the unique-tmp helper is collision-free by construction.
+    """
+    # Arrange
+    dst = tmp_path / "alpha" / "instance_id"
+    errors: list[BaseException] = []
+    start = threading.Barrier(8)
+
+    def worker(n: int) -> None:
+        start.wait()
+        try:
+            for i in range(200):
+                atomic_write_text(dst, f"id-{n}-{i}")
+        except OSError as exc:  # the race surfaces as FileNotFoundError
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in range(8)]
+
+    # Act
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Assert
+    assert not errors, f"concurrent writers raced: {errors[:3]}"
+
+
+def test_write_persists_the_value(tmp_path):
+    """A completed write leaves the exact bytes at the target."""
+    # Arrange
+    dst = tmp_path / "pid"
+
+    # Act
+    atomic_write_text(dst, "123\n")
+
+    # Assert
+    assert dst.read_text() == "123\n"
+
+
+def test_write_leaves_no_stray_tmp_sibling(tmp_path):
+    """The unique tmp is renamed away, not left behind."""
+    # Arrange
+    dst = tmp_path / "pid"
+
+    # Act
+    atomic_write_text(dst, "123\n")
+
+    # Assert
+    assert [p.name for p in tmp_path.iterdir()] == ["pid"]
+
+
+def test_write_creates_missing_parent_dir(tmp_path):
+    """The helper creates ``dst.parent`` if absent (as the old sites did)."""
+    # Arrange
+    dst = tmp_path / "deep" / "nested" / "started_at"
+
+    # Act
+    atomic_write_text(dst, "1700000000.0")
+
+    # Assert
+    assert dst.read_text() == "1700000000.0"
+
+
+def test_write_instance_id_round_trips(tmp_path):
+    """The measured-failure caller round-trips through the unique-tmp helper."""
+    # Arrange
+    state_dir = tmp_path / "alpha"
+
+    # Act
+    write_instance_id(state_dir, "uuid-7-abc")
+
+    # Assert
+    assert read_instance_id(state_dir) == "uuid-7-abc"
+
+
+def test_write_instance_id_overwrite_leaves_no_tmp(tmp_path):
+    """Overwriting the latest marker leaves no ``.tmp`` behind."""
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    write_instance_id(state_dir, "uuid-7-abc")
+
+    # Act
+    write_instance_id(state_dir, "uuid-7-def")
+
+    # Assert
+    assert not list(state_dir.glob("*.tmp"))


### PR DESCRIPTION
## Promote develop → main for the v0.24.2 release

Deliberate develop→main promotion (per the release-pipeline policy: "develop→main
promotion is a DELIBERATE, separate PR; this pipeline never auto-syncs main").

Brings main up to **0.24.2**:
- **#797** — concurrent runner-state write race fix (unique-tmp atomic writes).
- **#798** — `autobump-release-sweep.yaml` merge→release automation, **DISARMED**
  (gated behind `AUTOBUMP_ENABLED == 'true'`; executes only on `main`, where it now
  lands as a report-only heartbeat until the operator arms it).
- **#799** — clean start / start-failure log format (format-only).
- **#800** — CHANGELOG promotion to `[0.24.2] - 2026-07-21`.

The tag `v0.24.2` rides the release commit and fires the tag-driven release
pipeline (PyPI trusted publish + GitHub Release) independently of this promotion.
