### PR TITLE
docs(creds): make account selection + 7d spend policy discoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- **Account-selection + 7d spend policy are now discoverable** (operator
+  2026-07-21: 「burn というポリシーがあるのを初めて聞いた」). New §4 in
+  `26_credentials-rotation.md`: `claude.account` pin vs unpinned picker,
+  the explicit-`account: ""` spec convention, and
+  `SAC_CREDS_7D_POLICY: spread | burn` — spread's headroom-ranking vs
+  burn's use-it-or-lose-it ordering, and WHY burn stays gated on the
+  fleet reconciler. Host spec templates got the same values as inline
+  comments plus an explicit `account: ""` field.
+
 ## [0.24.2] - 2026-07-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.2"
+version = "0.24.3"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.4"
+version = "0.24.6"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-account-selection.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-account-selection.md
@@ -2,7 +2,7 @@
 description: |
   [TOPIC] scitex-agent-container — which OAuth account an agent boots on, and how the 7d quota window is spent.
   [DETAILS] The boot-time decision in `_lifecycle/_start_preflight.py`: `claude.account: <store-name>` as a genuine PIN vs `account: ""` + `credentials_files: [...]` handed to the boot picker (`_creds/_pick_healthy.py`). The `SAC_CREDS_7D_POLICY: spread | burn` spend policy (`_creds/_spend_policy.py`), why 5h and 7d are different kinds of resource, and why `burn` is gated on automatic restart. Reallocation today = restart. On-disk credential model + auth mechanics live in [26_credentials-rotation.md](26_credentials-rotation.md).
-tags: [scitex-agent-container-credentials-rotation]
+tags: [scitex-agent-container-credentials-account-selection]
 ---
 
 # SAC account selection at boot + the 7d spend policy

--- a/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-account-selection.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-account-selection.md
@@ -1,0 +1,67 @@
+---
+description: |
+  [TOPIC] scitex-agent-container — which OAuth account an agent boots on, and how the 7d quota window is spent.
+  [DETAILS] The boot-time decision in `_lifecycle/_start_preflight.py`: `claude.account: <store-name>` as a genuine PIN vs `account: ""` + `credentials_files: [...]` handed to the boot picker (`_creds/_pick_healthy.py`). The `SAC_CREDS_7D_POLICY: spread | burn` spend policy (`_creds/_spend_policy.py`), why 5h and 7d are different kinds of resource, and why `burn` is gated on automatic restart. Reallocation today = restart. On-disk credential model + auth mechanics live in [26_credentials-rotation.md](26_credentials-rotation.md).
+tags: [scitex-agent-container-credentials-rotation]
+---
+
+# SAC account selection at boot + the 7d spend policy
+
+> On-disk credential model, the binds, and preflight:
+> [26_credentials-rotation.md](26_credentials-rotation.md).
+> Refresh mechanics + host-side ops:
+> [26_credentials-rotation-host.md](26_credentials-rotation-host.md).
+
+Which account an agent boots on is decided ONCE, at start
+(`_lifecycle/_start_preflight.py`). Two declarative options in the spec
+(operator convention 2026-07-21: write the field explicitly even when
+unset — `account: ""` reads as "deliberately unpinned", not "forgot"):
+
+- **`claude.account: <store-name>`** — a genuine PIN to one stored
+  OAuth account (`sac accounts list` names). Mutually exclusive with
+  `claude.provider`. Credentials resolve to the per-account snapshot
+  (the post-#262 live bind).
+- **`claude.account: ""` + `claude.credentials_files: [...]`** —
+  unpinned: the boot picker ranks the listed candidates by token
+  freshness and quota (`_creds/_pick_healthy.py`, quota-conditional via
+  the cached `quota-cache.json`).
+
+## The 7d spend policy — `SAC_CREDS_7D_POLICY: spread | burn`
+
+The 5h and 7d quota windows are different kinds of resource
+(`_creds/_spend_policy.py`, operator ruling 2026-07-17):
+
+- **5h — rolling.** Hitting the cap costs a short wait; capacity
+  returns on its own. Avoiding a blocked-now account is cheap.
+- **7d — weekly, use-it-or-lose-it.** Unspent 7d quota is DESTROYED at
+  the window boundary. "Avoid the near-capped account" preserves
+  nothing — it throws the remainder away.
+
+Valid values:
+
+- **`spread`** (default) — demote 7d-near-capped accounts and spread
+  the fleet by 7d headroom via weighted rendezvous hashing. Safe, but
+  wastes the perishable remainder of a near-reset account.
+- **`burn`** (opt-in) — among token-fresh, 5h-unblocked accounts prefer
+  the HIGHEST 7d usage (spend the weekly bucket to zero), tie-break by
+  SOONEST 7d reset (`pick_burn`).
+
+**`burn` is deliberately gated.** Burn-to-zero manufactures agent
+deaths (「落ちたら再起動」) and is only safe when restart is AUTOMATIC.
+Until the fleet reconciler restarts quota-dead agents on its own, the
+default stays `spread`; opt in per host with `SAC_CREDS_7D_POLICY=burn`
+once it does. An unknown value raises — an operator who asked for a
+policy must never silently get another.
+
+Reallocation today = restart (the pick happens only at boot). To move a
+running agent onto a specific account: set `claude.account`, then
+restart it once its in-flight work allows.
+
+## See also
+
+- [26_credentials-rotation.md](26_credentials-rotation.md) — on-disk
+  model, binds, preflight.
+- [26_credentials-rotation-host.md](26_credentials-rotation-host.md) —
+  refresh mechanics + one-refresher invariant + host cron.
+- Source files cited: `_lifecycle/_start_preflight.py`,
+  `_creds/_pick_healthy.py`, `_creds/_spend_policy.py`.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
@@ -176,6 +176,53 @@ Refresh mechanics, the one-account-one-refresher invariant, and host-side
 ops (cron, watch-live daemon, CI rotation) are in
 [26_credentials-rotation-host.md](26_credentials-rotation-host.md).
 
+## 4. Account selection at boot — pin vs picker, and the 7d spend policy
+
+Which account an agent boots on is decided ONCE, at start
+(`_lifecycle/_start_preflight.py`). Two declarative options in the spec
+(operator convention 2026-07-21: write the field explicitly even when
+unset — `account: ""` reads as "deliberately unpinned", not "forgot"):
+
+- **`claude.account: <store-name>`** — a genuine PIN to one stored
+  OAuth account (`sac accounts list` names). Mutually exclusive with
+  `claude.provider`. Credentials resolve to the per-account snapshot
+  (§2, post-#262 live bind).
+- **`claude.account: ""` + `claude.credentials_files: [...]`** —
+  unpinned: the boot picker ranks the listed candidates by token
+  freshness and quota (`_creds/_pick_healthy.py`, quota-conditional via
+  the cached `quota-cache.json`).
+
+### The 7d spend policy — `SAC_CREDS_7D_POLICY: spread | burn`
+
+The 5h and 7d quota windows are different kinds of resource
+(`_creds/_spend_policy.py`, operator ruling 2026-07-17):
+
+- **5h — rolling.** Hitting the cap costs a short wait; capacity
+  returns on its own. Avoiding a blocked-now account is cheap.
+- **7d — weekly, use-it-or-lose-it.** Unspent 7d quota is DESTROYED at
+  the window boundary. "Avoid the near-capped account" preserves
+  nothing — it throws the remainder away.
+
+Valid values:
+
+- **`spread`** (default) — demote 7d-near-capped accounts and spread
+  the fleet by 7d headroom via weighted rendezvous hashing. Safe, but
+  wastes the perishable remainder of a near-reset account.
+- **`burn`** (opt-in) — among token-fresh, 5h-unblocked accounts prefer
+  the HIGHEST 7d usage (spend the weekly bucket to zero), tie-break by
+  SOONEST 7d reset (`pick_burn`).
+
+**`burn` is deliberately gated.** Burn-to-zero manufactures agent
+deaths (「落ちたら再起動」) and is only safe when restart is AUTOMATIC.
+Until the fleet reconciler restarts quota-dead agents on its own, the
+default stays `spread`; opt in per host with `SAC_CREDS_7D_POLICY=burn`
+once it does. An unknown value raises — an operator who asked for a
+policy must never silently get another.
+
+Reallocation today = restart (the pick happens only at boot). To move a
+running agent onto a specific account: set `claude.account`, then
+restart it once its in-flight work allows.
+
 ## See also
 
 - [26_credentials-rotation-host.md](26_credentials-rotation-host.md) —

--- a/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
@@ -176,54 +176,11 @@ Refresh mechanics, the one-account-one-refresher invariant, and host-side
 ops (cron, watch-live daemon, CI rotation) are in
 [26_credentials-rotation-host.md](26_credentials-rotation-host.md).
 
-## 4. Account selection at boot — pin vs picker, and the 7d spend policy
-
-Which account an agent boots on is decided ONCE, at start
-(`_lifecycle/_start_preflight.py`). Two declarative options in the spec
-(operator convention 2026-07-21: write the field explicitly even when
-unset — `account: ""` reads as "deliberately unpinned", not "forgot"):
-
-- **`claude.account: <store-name>`** — a genuine PIN to one stored
-  OAuth account (`sac accounts list` names). Mutually exclusive with
-  `claude.provider`. Credentials resolve to the per-account snapshot
-  (§2, post-#262 live bind).
-- **`claude.account: ""` + `claude.credentials_files: [...]`** —
-  unpinned: the boot picker ranks the listed candidates by token
-  freshness and quota (`_creds/_pick_healthy.py`, quota-conditional via
-  the cached `quota-cache.json`).
-
-### The 7d spend policy — `SAC_CREDS_7D_POLICY: spread | burn`
-
-The 5h and 7d quota windows are different kinds of resource
-(`_creds/_spend_policy.py`, operator ruling 2026-07-17):
-
-- **5h — rolling.** Hitting the cap costs a short wait; capacity
-  returns on its own. Avoiding a blocked-now account is cheap.
-- **7d — weekly, use-it-or-lose-it.** Unspent 7d quota is DESTROYED at
-  the window boundary. "Avoid the near-capped account" preserves
-  nothing — it throws the remainder away.
-
-Valid values:
-
-- **`spread`** (default) — demote 7d-near-capped accounts and spread
-  the fleet by 7d headroom via weighted rendezvous hashing. Safe, but
-  wastes the perishable remainder of a near-reset account.
-- **`burn`** (opt-in) — among token-fresh, 5h-unblocked accounts prefer
-  the HIGHEST 7d usage (spend the weekly bucket to zero), tie-break by
-  SOONEST 7d reset (`pick_burn`).
-
-**`burn` is deliberately gated.** Burn-to-zero manufactures agent
-deaths (「落ちたら再起動」) and is only safe when restart is AUTOMATIC.
-Until the fleet reconciler restarts quota-dead agents on its own, the
-default stays `spread`; opt in per host with `SAC_CREDS_7D_POLICY=burn`
-once it does. An unknown value raises — an operator who asked for a
-policy must never silently get another.
-
-Reallocation today = restart (the pick happens only at boot). To move a
-running agent onto a specific account: set `claude.account`, then
-restart it once its in-flight work allows.
-
 ## See also
+
+- [26_credentials-account-selection.md](26_credentials-account-selection.md) —
+  which account an agent boots on (`claude.account` pin vs the boot
+  picker) and the `SAC_CREDS_7D_POLICY: spread | burn` spend policy.
 
 - [26_credentials-rotation-host.md](26_credentials-rotation-host.md) —
   refresh mechanics + one-refresher invariant + host cron / watch-live /

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -68,7 +68,7 @@ session inside Apptainer (local or remote via SSH), observe via
 - [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — `to_home`→`$HOME`, overlay, settings hook
 - [26_credentials-rotation.md](26_credentials-rotation.md) — OAuth + auth mechanics
 - [26_credentials-rotation-host.md](26_credentials-rotation-host.md) — refresh + one-refresher invariant + host cron
-- [26_credentials-account-selection.md](26_credentials-account-selection.md) — which account an agent boots on + the 7d spend policy
+- [26-acct](26_credentials-account-selection.md) — boot account pin/picker + 7d policy
 - [27_credentials-relogin.md](27_credentials-relogin.md) — verified re-login + 401 recovery
 - [28_credential-refresh.md](28_credential-refresh.md) — refresh creds without restart; agents re-read next turn
 - [29_progress-reporting-to-lead.md](29_progress-reporting-to-lead.md) — milestone push via a2a_send

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -68,6 +68,7 @@ session inside Apptainer (local or remote via SSH), observe via
 - [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — `to_home`→`$HOME`, overlay, settings hook
 - [26_credentials-rotation.md](26_credentials-rotation.md) — OAuth + auth mechanics
 - [26_credentials-rotation-host.md](26_credentials-rotation-host.md) — refresh + one-refresher invariant + host cron
+- [26_credentials-account-selection.md](26_credentials-account-selection.md) — which account an agent boots on + the 7d spend policy
 - [27_credentials-relogin.md](27_credentials-relogin.md) — verified re-login + 401 recovery
 - [28_credential-refresh.md](28_credential-refresh.md) — refresh creds without restart; agents re-read next turn
 - [29_progress-reporting-to-lead.md](29_progress-reporting-to-lead.md) — milestone push via a2a_send


### PR DESCRIPTION
## Make account selection + the 7d spend policy discoverable

Operator 2026-07-21: 「burn というポリシーがあるのを初めて聞いた」「spec には
コメントで有効な値を書いておくべき」「spec には全部明示的に書いてほしい」.

The `SAC_CREDS_7D_POLICY: spread | burn` policy (operator's own 2026-07-17
use-it-or-lose-it ruling) and the `claude.account` pin existed only in module
docstrings — invisible to the operator writing a spec.

### Changes
- **`26_credentials-rotation.md` — new §4 "Account selection at boot"**:
  `claude.account` pin vs unpinned picker, the explicit-`account: ""` spec
  convention, spread vs burn semantics, and WHY burn stays gated on the fleet
  reconciler (burn-to-zero manufactures quota-death restarts). Reallocation
  today = restart (pick happens only at boot).
- CHANGELOG `[Unreleased]` entry + version bump 0.24.2 → 0.24.3
  (version-not-spent guard passes 9/9 locally).

### Host-side (already applied, not in this PR)
The 4 host spec templates (`_minimal_template`, `_template_generalist`,
`_template_python_developer`, `_template_researcher`) now carry an explicit
`account: ""` field + the same values as inline comments (parse-verified).
