### PR TITLE
fix(autobump): peel annotated tags + latest-run-per-name develop gate

### DIFF
--- a/.github/workflows/autobump-release-sweep.yaml
+++ b/.github/workflows/autobump-release-sweep.yaml
@@ -187,8 +187,21 @@ jobs:
           }
 
           tag_sha() {
-            # echo the commit sha a tag points at, or empty if the tag is absent.
-            gh api "repos/$REPO/git/ref/tags/$1" --jq '.object.sha' 2>/dev/null || echo ""
+            # echo the COMMIT sha a tag ultimately points at, or empty if the
+            # tag is absent. An ANNOTATED tag ref's object.sha is the tag
+            # OBJECT, not the commit — peel via /git/tags/<sha>. Without the
+            # peel, head == tagged-commit still reads as "moved past" and
+            # STEADY is unreachable for annotated tags (operator-cut releases
+            # like v0.24.2 are annotated; first dry-run 2026-07-21 caught it).
+            local sha type
+            sha=$(gh api "repos/$REPO/git/ref/tags/$1" --jq '.object.sha' 2>/dev/null || echo "")
+            [ -z "$sha" ] && { echo ""; return; }
+            type=$(gh api "repos/$REPO/git/ref/tags/$1" --jq '.object.type' 2>/dev/null || echo "")
+            if [ "$type" = "tag" ]; then
+              gh api "repos/$REPO/git/tags/$sha" --jq '.object.sha' 2>/dev/null || echo ""
+            else
+              echo "$sha"
+            fi
           }
 
           commit_age_seconds() {
@@ -228,25 +241,36 @@ jobs:
           }
 
           # Reads develop head's aggregate check state (ALL non-advisory workflows,
-          # not one, not the PR) — byte-identical 3-valued gate to auto-merge. Sets
-          # GATE to green|busy|red|unknown|nochecks.
+          # not one, not the PR) — same 3-valued shape as auto-merge's gate,
+          # plus a latest-run-per-name projection auto-merge does not have yet
+          # (candidate for upstreaming there — its miss is only over-conservative).
+          # Sets GATE to green|busy|red|unknown|nochecks.
           gate_develop() {
+            # LATEST RUN PER CHECK NAME. A re-run does not replace its failed
+            # predecessor — the commit keeps BOTH check-run rows, so counting
+            # raw failures reads a flaky-then-green check as permanently red
+            # (first dry-run 2026-07-21: pytest-matrix-py3.11 failed once,
+            # re-ran green, gate said RED). Branch protection judges by the
+            # newest run per name; project by group_by(.name)|max_by(started_at)
+            # before classifying, exactly like it.
             local sha="$1" bad busy total
             bad=$(gh api "repos/$REPO/commits/$sha/check-runs?per_page=100" --jq '
               [ .check_runs[]
                 | select(((.name // "") | ascii_downcase | test("codecov|readthedocs")) | not)
-                | select(.status == "completed")
-                | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required")
-              ] | length' 2>/dev/null || echo "")
+              ] | group_by(.name) | map(max_by(.started_at // ""))
+                | map(select(.status == "completed"))
+                | map(select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required"))
+                | length' 2>/dev/null || echo "")
             busy=$(gh api "repos/$REPO/commits/$sha/check-runs?per_page=100" --jq '
               [ .check_runs[]
                 | select(((.name // "") | ascii_downcase | test("codecov|readthedocs")) | not)
-                | select(.status != "completed")
-              ] | length' 2>/dev/null || echo "")
+              ] | group_by(.name) | map(max_by(.started_at // ""))
+                | map(select(.status != "completed"))
+                | length' 2>/dev/null || echo "")
             total=$(gh api "repos/$REPO/commits/$sha/check-runs?per_page=100" --jq '
               [ .check_runs[]
                 | select(((.name // "") | ascii_downcase | test("codecov|readthedocs")) | not)
-              ] | length' 2>/dev/null || echo "")
+              ] | group_by(.name) | length' 2>/dev/null || echo "")
             # THREE STATES, NOT TWO. Unreadable != green.
             if [ -z "$bad" ] || [ -z "$busy" ] || [ -z "$total" ]; then GATE=unknown; return; fi
             if [ "$busy" -gt 0 ]; then GATE=busy; return; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **autobump-release-sweep: two state-read defects caught by the first live
+  dry-run (2026-07-21), fixed before arming.** (1) `tag_sha` returned an
+  ANNOTATED tag's tag-object sha, not the peeled commit — head==tagged-commit
+  read as "moved past" and STEADY was unreachable for operator-cut annotated
+  tags. Now peels via `/git/tags/<sha>`. (2) `gate_develop` counted every
+  completed check-run, so a flaky-then-rerun-green check (two rows for one
+  name) kept develop RED forever. Now projects latest-run-per-name
+  (`group_by(.name) | max_by(.started_at)`) before classifying, matching
+  branch-protection semantics. Both verified against the live commit that
+  produced the false readings (bad=0, gate=green; peel=develop head).
+
 ## [0.24.2] - 2026-07-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.2"
+version = "0.24.3"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
First live dry-run (run 29798420329, report-only) caught two state-read defects; both fixed and verified against the live data that produced them.

1. **Annotated-tag peel**: `tag_sha` returned the tag OBJECT sha for annotated tags (e.g. operator-cut v0.24.2), so head==tagged-commit read as BUMP and STEADY was unreachable. Armed, that would have cut a same-code 0.24.3 release. Now peels `/git/tags/<sha>` → verified peel of v0.24.2 = develop head 4782e34f.
2. **Latest-run-per-name gate**: a re-run adds a second check-run row; the failed first attempt of pytest-matrix-py3.11 kept `gate_develop` RED though the re-run was green. Now `group_by(.name) | map(max_by(.started_at))` before classifying (branch-protection semantics) → verified bad=0/busy=0/total=15 (green) on 4782e34f.

Note for review: auto-merge-to-develop's gate shares the raw-count shape; its miss is only over-conservative (refuses a mergeable PR), candidate for the same projection in a follow-up.

Bump 0.24.2→0.24.3 (version-not-spent). Conflicts with open #802 on CHANGELOG/version are expected; second-to-merge resolves.