### PR TITLE
fix(autobump): absent tag read as gh's 404 JSON — false TAG COLLISION on the first scheduled tick

### DIFF
--- a/.github/workflows/autobump-release-sweep.yaml
+++ b/.github/workflows/autobump-release-sweep.yaml
@@ -193,12 +193,27 @@ jobs:
             # peel, head == tagged-commit still reads as "moved past" and
             # STEADY is unreachable for annotated tags (operator-cut releases
             # like v0.24.2 are annotated; first dry-run 2026-07-21 caught it).
-            local sha type
+            # ABSENT tag: `gh api` on a 404 prints the ERROR JSON BODY to
+            # STDOUT (only the "gh: Not Found" line goes to stderr), so
+            # capturing stdout yields a non-empty JSON blob, not "". The
+            # first scheduled tick (run 29804531483) read that blob as a
+            # sha: BUMP fired instead of TAG_ONLY and a "TAG COLLISION"
+            # alarm fired for v0.24.4, WHICH DOES NOT EXIST. Only a
+            # 40-hex string is a sha; anything else is treated as absent.
+            local sha type peeled
             sha=$(gh api "repos/$REPO/git/ref/tags/$1" --jq '.object.sha' 2>/dev/null || echo "")
-            [ -z "$sha" ] && { echo ""; return; }
+            case "$sha" in
+              *[!0-9a-f]*|"") echo ""; return;;
+            esac
+            [ "${#sha}" -eq 40 ] || { echo ""; return; }
             type=$(gh api "repos/$REPO/git/ref/tags/$1" --jq '.object.type' 2>/dev/null || echo "")
             if [ "$type" = "tag" ]; then
-              gh api "repos/$REPO/git/tags/$sha" --jq '.object.sha' 2>/dev/null || echo ""
+              peeled=$(gh api "repos/$REPO/git/tags/$sha" --jq '.object.sha' 2>/dev/null || echo "")
+              case "$peeled" in
+                *[!0-9a-f]*|"") echo ""; return;;
+              esac
+              [ "${#peeled}" -eq 40 ] || { echo ""; return; }
+              echo "$peeled"
             else
               echo "$sha"
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Fixed
 
+- **autobump-release-sweep: an ABSENT tag read as a garbage sha — first
+  scheduled tick raised a false TAG COLLISION for v0.24.4, which does not
+  exist.** `gh api` on a 404 prints the error JSON to STDOUT, so `tag_sha`
+  captured a JSON blob instead of "": BUMP fired where TAG_ONLY belonged and
+  the collision guard tripped on a phantom tag (run 29804531483, fail-loud
+  alarm — report-only held, no mutation). `tag_sha` now accepts only a
+  40-hex sha at both the ref and peel reads; anything else is treated as
+  absent. Verified live: v0.24.4 (absent) → empty; v0.24.2 (annotated) →
+  peeled develop commit.
+
+### Fixed
+
 - **autobump-release-sweep: two state-read defects caught by the first live
   dry-run (2026-07-21), fixed before arming.** (1) `tag_sha` returned an
   ANNOTATED tag's tag-object sha, not the peeled commit — head==tagged-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.3"
+version = "0.24.4"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
The first scheduled tick (run 29804531483, main's workflow copy) failed with "TAG COLLISION: v0.24.4 already exists" — **v0.24.4 does not exist**. Mechanism, proven live: `gh api` on a 404 prints the error JSON body to STDOUT (only `gh: Not Found` goes to stderr), so `tag_sha` captured the blob as a non-empty sha. Consequences on the old code path: BUMP fired where TAG_ONLY belonged, the 404 JSON leaked into the decision log, and the collision guard tripped on a phantom tag. Report-only held throughout — no mutation.

Fix: accept only a 40-hex sha at both the ref read and the peel read; anything else = absent. Verified live: v0.24.4 (absent) → empty, v0.24.2 (annotated) → peeled develop commit.

Note: this completes #803's tag_sha repair (peel was fixed; the 404-on-stdout case was not). Both fixes take effect on the SCHEDULED tick only after develop→main promotion — the schedule runs main's copy. Bump 0.24.3→0.24.4 (version-not-spent).