### PR TITLE
fix(pyproject): close the notify extra under `all` (PS-221) — unblocks the whole PR queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Fixed
 
+- **`notify` extra is now closed under `all` (PS-221), unblocking the whole PR
+  queue.** `scitex-notification>=0.2.9` sat in the public `notify` extra but not
+  in `all`, so `pip install scitex-agent-container[all]` silently under-installed
+  the login-relay's email surface. The omission was deliberate and documented —
+  `all` could not reference a version that did not exist on PyPI yet — but 0.2.9
+  has since been published, so the constraint has expired and the comment
+  asserting it was outdated. This single error failed
+  `tests/develop/test_audit.py::test_audit_all_clean` on EVERY open pull
+  request, not just the one that introduced it, because the audit grades the
+  whole checkout rather than the diff.
+
 - **autobump-release-sweep: two state-read defects caught by the first live
   dry-run (2026-07-21), fixed before arming.** (1) `tag_sha` returned an
   ANNOTATED tag's tag-object sha, not the peeled commit — head==tagged-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.3"
+version = "0.24.4"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"
@@ -97,8 +97,8 @@ notify = [
     # auth URL via `scitex_notification.send_email`). Optional + lazily
     # imported (a clear EmailRelayError is raised if absent), so core install
     # and CI need not resolve it. Agents that use the login-relay install
-    # `scitex-agent-container[notify]`. NOT in `[all]` until 0.2.9 is on PyPI
-    # (the public send_email landed in 0.2.9; PyPI currently tops out at 0.2.8).
+    # `scitex-agent-container[notify]`. 0.2.9 floor — that is where the public
+    # send_email landed.
     "scitex-notification>=0.2.9",
 ]
 slurm = [
@@ -178,6 +178,7 @@ docs = [
 all = [
     "scitex-agent-container[mcp]",
     "scitex-agent-container[telegram]",
+    "scitex-agent-container[notify]",
     "scitex-agent-container[slurm]",
     # `openai` is in [all] so CI (`pip install -e ".[all,dev]"`) exercises
     # the real openai-agents SDK paths; the bare install stays Claude-only.


### PR DESCRIPTION
## What

Adds `scitex-agent-container[notify]` to the `all` extra, and corrects the
comment that explained its absence.

## Why this is urgent

This is a one-line dependency fix, but it is currently **blocking every open
pull request in the repo**.

`tests/develop/test_audit.py::test_audit_all_clean` runs
`scitex-dev ecosystem audit-all` against the **whole checkout**, not against
the diff. So a single repo-level error reds the pytest matrix on all three
Python legs of every PR, regardless of what that PR touches. PR #804 — which
changes nothing but a workflow YAML — is red on py3.11/3.12/3.13 for exactly
this reason, and PR #802 is stuck behind the same wall.

The audit's own words:

> `[E] [PS-221 §3 public-extra-not-closed-under-all]` requirement
> `scitex-notification>=0.2.9` in PUBLIC extra
> `[project.optional-dependencies.notify]` is MISSING from the `all` extra.

That was the **only** error. The other two audit findings (§4b `CliHelp`,
§13 `skills` nesting) are warnings and do not fail the gate; they are tracked
separately.

## Why the omission existed, and why it is safe to remove now

The exclusion was deliberate, not an oversight. The old comment read:

> NOT in `[all]` until 0.2.9 is on PyPI (the public `send_email` landed in
> 0.2.9; PyPI currently tops out at 0.2.8).

Putting an unpublished version into `all` would have broken
`pip install scitex-agent-container[all]` outright. That reasoning was
correct when written.

It has since expired: **`scitex-notification` 0.2.9 is now published on
PyPI** (confirmed against the PyPI JSON API — `latest: 0.2.9`). So the
comment was asserting a constraint that no longer holds, and it has been
rewritten to state the real one (the 0.2.9 floor is where the public
`send_email` landed).

## Verification

Two independent checks, not one:

1. `scitex-dev ecosystem audit-project` against the fixed tree.
2. A direct closure check over the resolved `all` graph — it reports
   `notify` as the sole public extra outside `all` **before** the change,
   and none after:

   ```
   develop(unfixed):  PUBLIC EXTRAS NOT IN all: {'notify': [...]}
   worktree(fixed):   PUBLIC EXTRAS NOT IN all: NONE — closed
   ```

## Note on versioning

Takes `0.24.4`. Two other in-flight branches currently also claim `0.24.4`
(the autobump tag-sha 404 fix, and the explicit-spec-fields work). This PR
should land first since it unblocks their CI; the other two will be bumped
above it rather than the reverse.
