### PR TITLE
feat(config)!: every spec field explicit — missing field is a load error (red-start)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING — every spec field explicit, red-start (operator ruling
+  2026-07-21).** `config.load_config` / `load_v3` / `validate_raw` now REQUIRE
+  every author-facing field of an agent `spec.yaml` to be WRITTEN — an omitted
+  field is a load-time ERROR. 86 required keys for `kind: Agent` (78 for
+  `kind: AgentProxy`), derived from the section dataclasses
+  (`config/_explicit_fields.py`) with alias tables where YAML keys differ
+  (`watchdog.responses.*`, `restart.backoff.*`, `python-venv`). There is NO
+  migration phase, NO warn mode, and NO bypass flag — the only entry point is
+  `_explicit_validation.validate(doc, path)`; every under-specified spec in
+  the fleet goes boot-red at its next start, as ruled. The hint contract:
+  ONE error listing ALL missing fields at once (YAML path + expected type +
+  current default), followed by a marker-delimited paste-ready YAML block
+  whose values reproduce exactly what omission used to mean (loader
+  derivations paste `null`: `workdir`, `claude.session`), ending with the
+  loaded file's path. The hint provably clears the condition (round-trip
+  tested). The 2026-06-23 nine-field "no hidden defaults" subset was
+  superseded and removed. Excluded from the required set (each documented in
+  the module): `host`/`hosts` (exactly-one enforced by placement validation),
+  top-level `session` (alias of `claude.session`), banned/relocated keys
+  (`access`, `scheduling`, `container_workdir`, ...), the dead `screen` /
+  `startup` keys, and the four keys `load_v3` reads but `validate_raw`
+  rejects (`multiplexer`, `env-file`, `exclude_hooks`, `exclude_skills` —
+  flagged for operator review). `sac agents create` templates and
+  `examples/agents/*` now render the full explicit field set.
+
 ## [0.24.2] - 2026-07-21
 
 ### Added

--- a/examples/agents/codex-agent/spec.yaml
+++ b/examples/agents/codex-agent/spec.yaml
@@ -21,6 +21,21 @@ spec:
   apptainer:
     image: ~/.scitex/agent-container/containers/sac-scitex.sif
     binds: []
+    env: {}
+    raw_args: []
+    post: ''
+    environment: {}
+    def_file: ''
+    nv: false
+    rocm: false
+    overlay: ''
+    overlay_size: ''
+    overlay_create_if_missing: true
+    tmpfs_size: 2G
+    relaxed: false
+    fakeroot: false
+    jail: false
+    nested_build: false
 
   # Do not set top-level `spec.provider: openai`; that selects a different
   # harness. The nested provider below keeps Claude Code and changes only its
@@ -29,15 +44,90 @@ spec:
     provider: codex
     model: gpt-5.6-sol
     flags:
-      - --dangerously-skip-permissions
-      - --effort=medium
+    - --dangerously-skip-permissions
+    - --effort=medium
 
+    channels: []
+    raw_options: {}
+    session:
+    continue_max_age_minutes:
+    resume_id: ''
+    auto_accept: true
+    account: ''
+    credentials_file: ''
+    credentials_files: []
   health:
     enabled: true
     interval: 60
 
+    timeout: 5
+    method: sdk-alive
   restart:
     policy: on-failure
     max_retries: 3
 
 # EOF
+    backoff:
+      initial: 30
+      max: 300
+      multiplier: 2
+    prune_on_stop: false
+
+  # Explicit-fields ruling (2026-07-21): every spec field is written; values below are the defaults.
+  provider: anthropic
+  python-venv: ''
+  startup_commands: []
+  startup_prompts: []
+  listen: []
+  extensions: {}
+  mcp_servers: {}
+  user: ''
+  to_home: ./to_home
+  container:
+    runtime: none
+    image: scitex-agent-container:latest
+    volumes: []
+    network: host
+    mount_host_claude: false
+  watchdog:
+    enabled: false
+    interval: 1.5
+    responses:
+      y_n: '1'
+      y_y_n: '2'
+      waiting: /speak-and-call
+  autonomous:
+    enabled: false
+    drive_until: DONE
+    max_turns: 50
+    idle_kick_after_s: 120
+    kick_text: Continue. Print DONE when finished.
+  hooks:
+    pre_start: []
+    post_start: []
+    pre_stop: []
+    post_stop: []
+    on_compact: []
+    on_restart: []
+    on_diff: []
+  context_management:
+    trigger_at_percent: 70.0
+    strategy: noop
+    warn_before_n_checks: 0
+    check_interval_seconds: 300
+    state_file: ~/.scitex/agent-container/state/<agent>.json
+  a2a:
+    host: 127.0.0.1
+    port: auto
+  comms:
+    outbound:
+      siblings: allow
+      parent: allow
+    inbound:
+      siblings: allow
+      parent: allow
+    a2a:
+      listen: true
+  lineage:
+    group: ''
+    may_spawn: true

--- a/examples/agents/deepseek-agent/spec.yaml
+++ b/examples/agents/deepseek-agent/spec.yaml
@@ -43,26 +43,116 @@ spec:
     # binds — explicit mounts. This example mounts nothing beyond the
     # agent's own state bind.
     binds: []
+    env: {}
+    raw_args: []
+    post: ''
+    environment: {}
+    def_file: ''
+    nv: false
+    rocm: false
+    overlay: ''
+    overlay_size: ''
+    overlay_create_if_missing: true
+    tmpfs_size: 2G
+    relaxed: false
+    fakeroot: false
+    jail: false
+    nested_build: false
 
   claude:
     # The provider's own model id — accepted because provider is set
     # (the claude-* alias check is relaxed under a provider override).
     model: deepseek-chat
     flags:
-      - --dangerously-skip-permissions
+    - --dangerously-skip-permissions
     provider:
       base_url: https://api.deepseek.com/anthropic
       # NAME of the host env var holding the key — NOT the key value.
       auth_token_env: DEEPSEEK_API_KEY
 
   # health — periodic liveness probe (drives the restart policy below).
+    channels: []
+    raw_options: {}
+    session:
+    continue_max_age_minutes:
+    resume_id: ''
+    auto_accept: true
+    account: ''
+    credentials_file: ''
+    credentials_files: []
   health:
     enabled: true
     interval: 60
 
   # restart — bulk fleet agents are long-lived; restart on failure.
+    timeout: 5
+    method: sdk-alive
   restart:
     policy: on-failure          # never | on-failure | always
     max_retries: 3
 
 # EOF
+    backoff:
+      initial: 30
+      max: 300
+      multiplier: 2
+    prune_on_stop: false
+
+  # Explicit-fields ruling (2026-07-21): every spec field is written; values below are the defaults.
+  provider: anthropic
+  python-venv: ''
+  startup_commands: []
+  startup_prompts: []
+  listen: []
+  extensions: {}
+  mcp_servers: {}
+  user: ''
+  to_home: ./to_home
+  container:
+    runtime: none
+    image: scitex-agent-container:latest
+    volumes: []
+    network: host
+    mount_host_claude: false
+  watchdog:
+    enabled: false
+    interval: 1.5
+    responses:
+      y_n: '1'
+      y_y_n: '2'
+      waiting: /speak-and-call
+  autonomous:
+    enabled: false
+    drive_until: DONE
+    max_turns: 50
+    idle_kick_after_s: 120
+    kick_text: Continue. Print DONE when finished.
+  hooks:
+    pre_start: []
+    post_start: []
+    pre_stop: []
+    post_stop: []
+    on_compact: []
+    on_restart: []
+    on_diff: []
+  context_management:
+    trigger_at_percent: 70.0
+    strategy: noop
+    warn_before_n_checks: 0
+    check_interval_seconds: 300
+    state_file: ~/.scitex/agent-container/state/<agent>.json
+  a2a:
+    host: 127.0.0.1
+    port: auto
+  comms:
+    outbound:
+      siblings: allow
+      parent: allow
+    inbound:
+      siblings: allow
+      parent: allow
+    a2a:
+      listen: true
+  lineage:
+    group: ''
+    may_spawn: true

--- a/examples/agents/full-agent/spec.yaml
+++ b/examples/agents/full-agent/spec.yaml
@@ -165,13 +165,27 @@ spec:
   # ----------------------------------------------------------------------
   # claude block — SDK-scoped knobs (raw_options is the escape hatch).
   # ----------------------------------------------------------------------
+    env: {}
+    raw_args: []
+    post: ''
+    environment: {}
+    def_file: ''
+    nv: false
+    rocm: false
+    overlay: ''
+    overlay_size: ''
+    overlay_create_if_missing: true
+    tmpfs_size: 2G
+    fakeroot: false
+    jail: false
+    nested_build: false
   claude:
     # haiku | sonnet | opus | a full versioned id like claude-opus-4-5
     model: sonnet
 
     # CLI flags forwarded to `claude` (the SDK runs the bundled binary).
     flags:
-      - --dangerously-skip-permissions
+    - --dangerously-skip-permissions
 
     # Session continuity ("fresh by default, opt-in continue", 2026-06-22):
     #   fresh        — DEFAULT. Every launch is an independent session
@@ -230,10 +244,18 @@ spec:
   # With `sac agents start --one-shot` the runner exits after the first.
   # Without --one-shot it stays attached for follow-up turns.
   # ----------------------------------------------------------------------
+    channels: []
+    raw_options: {}
+    continue_max_age_minutes:
+    resume_id: ''
+    account: ''
+    credentials_file: ''
+    credentials_files: []
+    provider:
   startup_prompts:
-    - |
-      You are a generic worker template. Replace this prompt with your
-      agent's actual mission. Reply READY when initialized.
+  - |
+    You are a generic worker template. Replace this prompt with your
+    agent's actual mission. Reply READY when initialized.
 
   # ----------------------------------------------------------------------
   # startup — broader pre-launch policy block.
@@ -299,6 +321,7 @@ spec:
   # (default 19000-19999) and persists in state.db. `sac agents list`
   # shows the assigned port.
   # ----------------------------------------------------------------------
+    prune_on_stop: false
   a2a:
     port: auto                  # default — sac picks from the range
     # port: 7901                # pin only when a stable external URL is needed
@@ -353,6 +376,7 @@ spec:
   # transparently over the host registry's ssh rails. ${HOSTNAME} resolves
   # to the loading machine at load time (portable example/fixture specs).
   # ----------------------------------------------------------------------
+    host: 127.0.0.1
   host: ${HOSTNAME}               # this machine, resolved at load time
   # host: gpu-box                 # pin to a single peer (ssh-dispatched)
   # host: spartan-gpgpu106        # glob peer (spartan-*) — rides the
@@ -361,3 +385,56 @@ spec:
   #                               # — agent name becomes <name>@<host>
 
 # EOF
+
+  # Explicit-fields ruling (2026-07-21): every spec field is written; values below are the defaults.
+  provider: anthropic
+  startup_commands: []
+  listen: []
+  extensions: {}
+  mcp_servers: {}
+  user: ''
+  container:
+    runtime: none
+    image: scitex-agent-container:latest
+    volumes: []
+    network: host
+    mount_host_claude: false
+  watchdog:
+    enabled: false
+    interval: 1.5
+    responses:
+      y_n: '1'
+      y_y_n: '2'
+      waiting: /speak-and-call
+  autonomous:
+    enabled: false
+    drive_until: DONE
+    max_turns: 50
+    idle_kick_after_s: 120
+    kick_text: Continue. Print DONE when finished.
+  hooks:
+    pre_start: []
+    post_start: []
+    pre_stop: []
+    post_stop: []
+    on_compact: []
+    on_restart: []
+    on_diff: []
+  context_management:
+    trigger_at_percent: 70.0
+    strategy: noop
+    warn_before_n_checks: 0
+    check_interval_seconds: 300
+    state_file: ~/.scitex/agent-container/state/<agent>.json
+  comms:
+    outbound:
+      siblings: allow
+      parent: allow
+    inbound:
+      siblings: allow
+      parent: allow
+    a2a:
+      listen: true
+  lineage:
+    group: ''
+    may_spawn: true

--- a/examples/agents/hello-agent/spec.yaml
+++ b/examples/agents/hello-agent/spec.yaml
@@ -24,21 +24,110 @@ spec:
     image: ~/.scitex/agent-container/containers/sac-base.sif
     binds: []                   # explicit mounts; [] = nothing beyond state
 
+    env: {}
+    raw_args: []
+    post: ''
+    environment: {}
+    def_file: ''
+    nv: false
+    rocm: false
+    overlay: ''
+    overlay_size: ''
+    overlay_create_if_missing: true
+    tmpfs_size: 2G
+    relaxed: false
+    fakeroot: false
+    jail: false
+    nested_build: false
   claude:
     model: haiku
     flags:
-      - --dangerously-skip-permissions
+    - --dangerously-skip-permissions
 
+    channels: []
+    raw_options: {}
+    session:
+    continue_max_age_minutes:
+    resume_id: ''
+    auto_accept: true
+    account: ''
+    credentials_file: ''
+    credentials_files: []
+    provider:
   startup_prompts:
-    - "Reply with the string 'Hello! I am hello-agent' and nothing else."
+  - "Reply with the string 'Hello! I am hello-agent' and nothing else."
 
   health:
     enabled: true
     interval: 60
     method: sdk-alive
 
+    timeout: 5
   restart:
     policy: never
     max_retries: 0
 
 # EOF
+    backoff:
+      initial: 30
+      max: 300
+      multiplier: 2
+    prune_on_stop: false
+
+  # Explicit-fields ruling (2026-07-21): every spec field is written; values below are the defaults.
+  provider: anthropic
+  python-venv: ''
+  startup_commands: []
+  listen: []
+  extensions: {}
+  mcp_servers: {}
+  user: ''
+  to_home: ./to_home
+  container:
+    runtime: none
+    image: scitex-agent-container:latest
+    volumes: []
+    network: host
+    mount_host_claude: false
+  watchdog:
+    enabled: false
+    interval: 1.5
+    responses:
+      y_n: '1'
+      y_y_n: '2'
+      waiting: /speak-and-call
+  autonomous:
+    enabled: false
+    drive_until: DONE
+    max_turns: 50
+    idle_kick_after_s: 120
+    kick_text: Continue. Print DONE when finished.
+  hooks:
+    pre_start: []
+    post_start: []
+    pre_stop: []
+    post_stop: []
+    on_compact: []
+    on_restart: []
+    on_diff: []
+  context_management:
+    trigger_at_percent: 70.0
+    strategy: noop
+    warn_before_n_checks: 0
+    check_interval_seconds: 300
+    state_file: ~/.scitex/agent-container/state/<agent>.json
+  a2a:
+    host: 127.0.0.1
+    port: auto
+  comms:
+    outbound:
+      siblings: allow
+      parent: allow
+    inbound:
+      siblings: allow
+      parent: allow
+    a2a:
+      listen: true
+  lineage:
+    group: ''
+    may_spawn: true

--- a/examples/agents/minimal-agent/spec.yaml
+++ b/examples/agents/minimal-agent/spec.yaml
@@ -24,17 +24,108 @@ spec:
     image: ~/.scitex/agent-container/containers/sac-base.sif
     binds: []                   # explicit mounts; [] = nothing beyond state
 
+    env: {}
+    raw_args: []
+    post: ''
+    environment: {}
+    def_file: ''
+    nv: false
+    rocm: false
+    overlay: ''
+    overlay_size: ''
+    overlay_create_if_missing: true
+    tmpfs_size: 2G
+    relaxed: false
+    fakeroot: false
+    jail: false
+    nested_build: false
   claude:
     model: haiku
     flags:
-      - --dangerously-skip-permissions
+    - --dangerously-skip-permissions
 
+    channels: []
+    raw_options: {}
+    session:
+    continue_max_age_minutes:
+    resume_id: ''
+    auto_accept: true
+    account: ''
+    credentials_file: ''
+    credentials_files: []
+    provider:
   health:
     enabled: true
     interval: 60
 
+    timeout: 5
+    method: sdk-alive
   restart:
     policy: never               # never | on-failure | always
     max_retries: 0
 
 # EOF
+    backoff:
+      initial: 30
+      max: 300
+      multiplier: 2
+    prune_on_stop: false
+
+  # Explicit-fields ruling (2026-07-21): every spec field is written; values below are the defaults.
+  provider: anthropic
+  python-venv: ''
+  startup_commands: []
+  startup_prompts: []
+  listen: []
+  extensions: {}
+  mcp_servers: {}
+  user: ''
+  to_home: ./to_home
+  container:
+    runtime: none
+    image: scitex-agent-container:latest
+    volumes: []
+    network: host
+    mount_host_claude: false
+  watchdog:
+    enabled: false
+    interval: 1.5
+    responses:
+      y_n: '1'
+      y_y_n: '2'
+      waiting: /speak-and-call
+  autonomous:
+    enabled: false
+    drive_until: DONE
+    max_turns: 50
+    idle_kick_after_s: 120
+    kick_text: Continue. Print DONE when finished.
+  hooks:
+    pre_start: []
+    post_start: []
+    pre_stop: []
+    post_stop: []
+    on_compact: []
+    on_restart: []
+    on_diff: []
+  context_management:
+    trigger_at_percent: 70.0
+    strategy: noop
+    warn_before_n_checks: 0
+    check_interval_seconds: 300
+    state_file: ~/.scitex/agent-container/state/<agent>.json
+  a2a:
+    host: 127.0.0.1
+    port: auto
+  comms:
+    outbound:
+      siblings: allow
+      parent: allow
+    inbound:
+      siblings: allow
+      parent: allow
+    a2a:
+      listen: true
+  lineage:
+    group: ''
+    may_spawn: true

--- a/examples/agents/proxy-agent/spec.yaml
+++ b/examples/agents/proxy-agent/spec.yaml
@@ -37,6 +37,21 @@ spec:
     # binds — explicit mounts. The proxy needs nothing from the host
     # beyond its own state bind, so the list is empty.
     binds: []
+    env: {}
+    raw_args: []
+    post: ''
+    environment: {}
+    def_file: ''
+    nv: false
+    rocm: false
+    overlay: ''
+    overlay_size: ''
+    overlay_create_if_missing: true
+    tmpfs_size: 2G
+    relaxed: false
+    fakeroot: false
+    jail: false
+    nested_build: false
 
   # Proxy block — required when kind: AgentProxy.
   proxy:
@@ -57,8 +72,8 @@ spec:
     # secret leakage to an untrusted upstream — NOT a substitute for
     # source-side filtering.
     redact:
-      - ANTHROPIC_API_KEY
-      - sk-
+    - ANTHROPIC_API_KEY
+    - sk-
 
     # Per-turn upstream HTTP timeout. Forwards taking longer surface
     # as HTTP 504 to the caller.
@@ -71,13 +86,77 @@ spec:
 
   # health — periodic liveness probe (the proxy backs the same
   # heartbeat/state layout as kind: Agent so `sac agents status` works).
+    host: 127.0.0.1
   health:
     enabled: true
     interval: 60
 
   # restart — restart the forwarder if its process dies or health fails.
+    timeout: 5
+    method: sdk-alive
   restart:
     policy: on-failure          # never | on-failure | always
     max_retries: 3
 
 # EOF
+    backoff:
+      initial: 30
+      max: 300
+      multiplier: 2
+    prune_on_stop: false
+
+  # Explicit-fields ruling (2026-07-21): every spec field is written; values below are the defaults.
+  provider: anthropic
+  python-venv: ''
+  startup_commands: []
+  startup_prompts: []
+  listen: []
+  extensions: {}
+  mcp_servers: {}
+  user: ''
+  to_home: ./to_home
+  container:
+    runtime: none
+    image: scitex-agent-container:latest
+    volumes: []
+    network: host
+    mount_host_claude: false
+  watchdog:
+    enabled: false
+    interval: 1.5
+    responses:
+      y_n: '1'
+      y_y_n: '2'
+      waiting: /speak-and-call
+  autonomous:
+    enabled: false
+    drive_until: DONE
+    max_turns: 50
+    idle_kick_after_s: 120
+    kick_text: Continue. Print DONE when finished.
+  hooks:
+    pre_start: []
+    post_start: []
+    pre_stop: []
+    post_stop: []
+    on_compact: []
+    on_restart: []
+    on_diff: []
+  context_management:
+    trigger_at_percent: 70.0
+    strategy: noop
+    warn_before_n_checks: 0
+    check_interval_seconds: 300
+    state_file: ~/.scitex/agent-container/state/<agent>.json
+  comms:
+    outbound:
+      siblings: allow
+      parent: allow
+    inbound:
+      siblings: allow
+      parent: allow
+    a2a:
+      listen: true
+  lineage:
+    group: ''
+    may_spawn: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.4"
+version = "0.24.8"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.2"
+version = "0.24.4"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/cli_pkg/_create.py
+++ b/src/scitex_agent_container/cli_pkg/_create.py
@@ -50,6 +50,13 @@ from pathlib import Path
 
 import click
 
+# Inline spec templates live in ``_create_templates`` (per-file line
+# cap). Fully-explicit bodies per the red-start ruling 2026-07-21.
+from ._create_templates import (  # noqa: F401
+    _FULL_TEMPLATE,
+    _MINIMAL_TEMPLATE,
+    _TEMPLATES,
+)
 from ._new_dir_template import (
     DirTemplateError,
     discover_dir_templates,
@@ -73,190 +80,6 @@ def _is_valid_agent_name(name: str) -> bool:
     if not name:
         return False
     return all(ch in _VALID_NAME_CHARS for ch in name)
-
-
-_MINIMAL_TEMPLATE = """\
-# {name} — fresh v3 spec scaffolded by ``sac agents create``.
-#
-# This is the minimal shape — every field the validator REQUIRES (no hidden
-# defaults): placement, workdir, image + binds, model, health, restart. Add
-# startup_prompts, channels, etc. as you need them — see
-# ``examples/agents/full-agent/spec.yaml`` for the full annotated tour.
-
-apiVersion: scitex-agent-container/v3
-kind: Agent
-
-spec:
-  runtime: apptainer
-  # Placement: the RESOLVED hostname of the machine this agent runs on
-  # (filled with the creating host at render time; `host: local` is
-  # banned). Edit to a `sac host list` peer name to pin it elsewhere,
-  # or use `hosts:` for one instance per host.
-  host: {host}
-  workdir: ~/proj/{name}
-
-  apptainer:
-    image: ~/.scitex/agent-container/containers/sac-base.sif
-    binds: []
-
-  claude:
-    model: haiku
-    flags:
-      - --dangerously-skip-permissions
-
-  health:
-    enabled: true
-    interval: 60
-
-  restart:
-    policy: on-failure
-    max_retries: 3
-
-# EOF
-"""
-
-
-_FULL_TEMPLATE = """\
-# {name} — fresh v3 DEVELOPER spec scaffolded by ``sac agents create --template full``.
-#
-# This is the PROVEN developer shape the fleet's live dev agents use
-# (card sac-agents-new-template-stale; operator 2026-06-25: "very
-# general, just developer like existing ones") — a ready-to-run
-# project-maintainer agent, NOT a bare skeleton. It ships:
-#   * runtime: tui                interactive in-apptainer Claude TUI
-#   * relaxed + directory overlay persistent per-agent $HOME / installs
-#   * full host reach at the canonical path (so ~/proj/... paths match)
-#   * fleet push channels         server:sac + server:scitex-todo + telegrammer
-#   * SCITEX_TODO_AGENT_ID        todo-store writes attribute to THIS agent
-#   * editable install of the agent's own repo (live dev loop)
-#   * a generic "Start or continue." kick + metadata.labels + opus model
-# Every field validates against the live v3 schema. Edit the labels + the
-# startup prompt for the agent's real mission; delete blocks you don't need.
-
-apiVersion: scitex-agent-container/v3
-kind: Agent
-
-metadata:
-  labels:
-    role: project-maintainer
-    team: scitex
-    project: {name}
-    purpose: {name}-maintainer
-    description: |
-      {name} developer agent — maintains the {name} repo. Replace this
-      description and the startup prompt below with the agent's real mission.
-    capabilities: develop, test, review, release
-    cardinality: singleton
-
-spec:
-  runtime: tui
-  # RESOLVED placement (creating host at render time; `local` is banned).
-  host: {host}
-
-  # The in-container --pwd. The repo is bound at this SAME absolute path
-  # below, so host and container agree (editable install, git, tooling).
-  workdir: {home}/proj/{name}
-
-  # to_home/ sibling — mirrored into the container $HOME (overlay upper
-  # home under relaxed mode). Put CLAUDE.md / .mcp.json / .claude/ there.
-  to_home: ./to_home
-
-  python-venv: auto
-
-  apptainer:
-    # sac-base.sif = the minimal layer; the agent editable-installs its
-    # own stack into the overlay below. Swap to sac-scitex.sif to start
-    # from the full pre-baked scitex stack instead.
-    image: ~/.scitex/agent-container/containers/sac-base.sif
-
-    # Relaxed isolation — the dev agent shares the operator's identity and
-    # host tree (the fleet dev default). Pairs with the raw_args below,
-    # which re-declare the namespace + canonical HOME the overlay needs.
-    relaxed: true
-
-    # Persistent per-agent directory overlay: package installs, caches and
-    # $HOME state survive restarts while the base SIF stays immutable. sac
-    # auto-creates the overlay dir and materialises to_home/ into its upper
-    # home on first start.
-    overlay: ~/.scitex/agent-container/containers/overlays/{name}/
-
-    # Full host reach at the CANONICAL path (source ~ is expanded by sac;
-    # the destination must be absolute). Narrow this to specific project
-    # trees for a capsule-style agent.
-    binds:
-      - {home}:{home}:rw
-
-    # Per-agent env. SCITEX_TODO_AGENT_ID makes scitex-todo writes
-    # attribute to THIS agent. (sac AUTO-injects
-    # SCITEX_AGENT_CONTAINER_STATE_DB + binds the per-agent state dir, so
-    # the state DB needs no manual entry here.)
-    env:
-      SCITEX_TODO_AGENT_ID: {name}
-
-    # Relaxed mode skips sac's curated isolation prepend, so re-declare the
-    # user namespace, filesystem isolation, and the canonical container HOME
-    # that the overlay upper home is materialised under.
-    raw_args:
-      - --userns
-      - --containall
-      - --home=/home/agent
-
-  claude:
-    model: opus[1m]
-    flags:
-      - --dangerously-skip-permissions
-    session: continue
-    auto_accept: true
-
-    # Fleet push channels: sac control bus + shared scitex-todo store + the
-    # Telegram bridge (operator DMs wake the agent). server:sac is also
-    # auto-injected by the loader; listed here for visibility.
-    channels:
-      - server:sac
-      - server:scitex-todo
-      - server:claude-code-telegrammer
-
-    # Pin this agent to a dedicated account by uncommenting and pointing at
-    # that account's LIVE .credentials.json (else the shared host OAuth is
-    # forwarded automatically).
-    # credentials_file: ~/.scitex/agent-container/accounts/<ACCOUNT>/.credentials.json
-
-  # Editable-install the agent's own repo so imports resolve to the live
-  # working tree (edit -> test without reinstall). The `|| true` keeps
-  # startup resilient when the repo has no installable package yet.
-  startup_commands:
-    - command: 'uv pip install -e {home}/proj/{name} --quiet || true'
-
-  # Generic self-resume kick — the agent picks up its board / last state.
-  # Replace with the agent's real first mission.
-  startup_prompts:
-    - Start or continue.
-
-  health:
-    enabled: true
-    interval: 60
-    timeout: 10
-    method: sdk-alive
-
-  restart:
-    policy: on-failure
-    max_retries: 3
-    backoff:
-      initial: 10
-      max: 120
-      multiplier: 2
-
-  a2a:
-    port: auto
-
-# EOF
-"""
-
-
-_TEMPLATES = {
-    "minimal": _MINIMAL_TEMPLATE,
-    "full": _FULL_TEMPLATE,
-}
 
 
 def _default_base_dir() -> Path:

--- a/src/scitex_agent_container/cli_pkg/_create_templates.py
+++ b/src/scitex_agent_container/cli_pkg/_create_templates.py
@@ -1,0 +1,376 @@
+"""Inline spec templates for ``sac agents create`` (minimal / full).
+
+Extracted from ``_create.py`` (per-file line cap). Both templates are
+``str.format`` strings with ``{name}`` / ``{host}`` / ``{home}``
+placeholders — literal YAML braces are escaped as ``{{}}``.
+
+EVERY field is written explicitly (red-start ruling 2026-07-21): a spec
+that omits a field is a load ERROR whose hint lists the whole missing
+set with paste-ready defaults, so anything this module scaffolds must
+already carry the complete field set — the operator edits values, never
+hunts for missing keys.
+"""
+
+from __future__ import annotations
+
+_MINIMAL_TEMPLATE = """\
+# {name} — fresh v3 spec scaffolded by ``sac agents create``.
+#
+# EVERY field is written explicitly (red-start ruling 2026-07-21: an
+# omitted field is a load ERROR whose hint lists the whole missing set
+# with paste-ready defaults). The values below are those defaults except
+# the handful this template curates (runtime / model / health / restart).
+# See ``examples/agents/full-agent/spec.yaml`` for the annotated tour.
+
+apiVersion: scitex-agent-container/v3
+kind: Agent
+
+spec:
+  runtime: apptainer
+  provider: anthropic
+  # Placement: the RESOLVED hostname of the machine this agent runs on
+  # (filled with the creating host at render time; `host: local` is
+  # banned). Edit to a `sac host list` peer name to pin it elsewhere,
+  # or use `hosts:` for one instance per host.
+  host: {host}
+  workdir: ~/proj/{name}
+  python-venv: ""
+  user: ""
+  to_home: ./to_home
+  startup_commands: []
+  startup_prompts: []
+  listen: []
+  extensions: {{}}
+  mcp_servers: {{}}
+
+  container:
+    runtime: none
+    image: scitex-agent-container:latest
+    volumes: []
+    network: host
+    mount_host_claude: false
+
+  apptainer:
+    image: ~/.scitex/agent-container/containers/sac-base.sif
+    binds: []
+    env: {{}}
+    raw_args: []
+    post: ""
+    environment: {{}}
+    def_file: ""
+    nv: false
+    rocm: false
+    overlay: ""
+    overlay_size: ""
+    overlay_create_if_missing: true
+    tmpfs_size: 2G
+    relaxed: false
+    fakeroot: false
+    jail: false
+    nested_build: false
+
+  claude:
+    model: haiku
+    flags:
+      - --dangerously-skip-permissions
+    channels: []
+    raw_options: {{}}
+    # null = role-derived (continue for coordinator roles, fresh otherwise)
+    session: null
+    continue_max_age_minutes: null
+    resume_id: ""
+    auto_accept: true
+    account: ""
+    credentials_file: ""
+    credentials_files: []
+    provider: null
+
+  health:
+    enabled: true
+    interval: 60
+    timeout: 5
+    method: sdk-alive
+
+  watchdog:
+    enabled: false
+    interval: 1.5
+    responses:
+      y_n: "1"
+      y_y_n: "2"
+      waiting: /speak-and-call
+
+  restart:
+    policy: on-failure
+    max_retries: 3
+    prune_on_stop: false
+    backoff:
+      initial: 30
+      max: 300
+      multiplier: 2
+
+  autonomous:
+    enabled: false
+    drive_until: DONE
+    max_turns: 50
+    idle_kick_after_s: 120
+    kick_text: Continue. Print DONE when finished.
+
+  hooks:
+    pre_start: []
+    post_start: []
+    pre_stop: []
+    post_stop: []
+    on_compact: []
+    on_restart: []
+    on_diff: []
+
+  context_management:
+    trigger_at_percent: 70.0
+    strategy: noop
+    warn_before_n_checks: 0
+    check_interval_seconds: 300
+    state_file: ~/.scitex/agent-container/state/<agent>.json
+
+  a2a:
+    host: 127.0.0.1
+    port: auto
+
+  comms:
+    outbound:
+      siblings: allow
+      parent: allow
+    inbound:
+      siblings: allow
+      parent: allow
+    a2a:
+      listen: true
+
+  lineage:
+    group: ""
+    may_spawn: true
+
+# EOF
+"""
+
+
+_FULL_TEMPLATE = """\
+# {name} — fresh v3 DEVELOPER spec scaffolded by ``sac agents create --template full``.
+#
+# This is the PROVEN developer shape the fleet's live dev agents use
+# (card sac-agents-new-template-stale; operator 2026-06-25: "very
+# general, just developer like existing ones") — a ready-to-run
+# project-maintainer agent, NOT a bare skeleton. It ships:
+#   * runtime: tui                interactive in-apptainer Claude TUI
+#   * relaxed + directory overlay persistent per-agent $HOME / installs
+#   * full host reach at the canonical path (so ~/proj/... paths match)
+#   * fleet push channels         server:sac + server:scitex-todo + telegrammer
+#   * SCITEX_TODO_AGENT_ID        todo-store writes attribute to THIS agent
+#   * editable install of the agent's own repo (live dev loop)
+#   * a generic "Start or continue." kick + metadata.labels + opus model
+# EVERY field is written explicitly (red-start ruling 2026-07-21); the
+# non-curated ones sit at their defaults. Edit the labels + the startup
+# prompt for the agent's real mission.
+
+apiVersion: scitex-agent-container/v3
+kind: Agent
+
+metadata:
+  labels:
+    role: project-maintainer
+    team: scitex
+    project: {name}
+    purpose: {name}-maintainer
+    description: |
+      {name} developer agent — maintains the {name} repo. Replace this
+      description and the startup prompt below with the agent's real mission.
+    capabilities: develop, test, review, release
+    cardinality: singleton
+
+spec:
+  runtime: tui
+  provider: anthropic
+  # RESOLVED placement (creating host at render time; `local` is banned).
+  host: {host}
+
+  # The in-container --pwd. The repo is bound at this SAME absolute path
+  # below, so host and container agree (editable install, git, tooling).
+  workdir: {home}/proj/{name}
+
+  # to_home/ sibling — mirrored into the container $HOME (overlay upper
+  # home under relaxed mode). Put CLAUDE.md / .mcp.json / .claude/ there.
+  to_home: ./to_home
+
+  python-venv: auto
+  user: ""
+  listen: []
+  extensions: {{}}
+  mcp_servers: {{}}
+
+  container:
+    runtime: none
+    image: scitex-agent-container:latest
+    volumes: []
+    network: host
+    mount_host_claude: false
+
+  apptainer:
+    # sac-base.sif = the minimal layer; the agent editable-installs its
+    # own stack into the overlay below. Swap to sac-scitex.sif to start
+    # from the full pre-baked scitex stack instead.
+    image: ~/.scitex/agent-container/containers/sac-base.sif
+
+    # Relaxed isolation — the dev agent shares the operator's identity and
+    # host tree (the fleet dev default). Pairs with the raw_args below,
+    # which re-declare the namespace + canonical HOME the overlay needs.
+    relaxed: true
+
+    # Persistent per-agent directory overlay: package installs, caches and
+    # $HOME state survive restarts while the base SIF stays immutable. sac
+    # auto-creates the overlay dir and materialises to_home/ into its upper
+    # home on first start.
+    overlay: ~/.scitex/agent-container/containers/overlays/{name}/
+    overlay_size: ""
+    overlay_create_if_missing: true
+
+    # Full host reach at the CANONICAL path (source ~ is expanded by sac;
+    # the destination must be absolute). Narrow this to specific project
+    # trees for a capsule-style agent.
+    binds:
+      - {home}:{home}:rw
+
+    # Per-agent env. SCITEX_TODO_AGENT_ID makes scitex-todo writes
+    # attribute to THIS agent. (sac AUTO-injects
+    # SCITEX_AGENT_CONTAINER_STATE_DB + binds the per-agent state dir, so
+    # the state DB needs no manual entry here.)
+    env:
+      SCITEX_TODO_AGENT_ID: {name}
+
+    # Relaxed mode skips sac's curated isolation prepend, so re-declare the
+    # user namespace, filesystem isolation, and the canonical container HOME
+    # that the overlay upper home is materialised under.
+    raw_args:
+      - --userns
+      - --containall
+      - --home=/home/agent
+
+    post: ""
+    environment: {{}}
+    def_file: ""
+    nv: false
+    rocm: false
+    tmpfs_size: 2G
+    fakeroot: false
+    jail: false
+    nested_build: false
+
+  claude:
+    model: opus[1m]
+    flags:
+      - --dangerously-skip-permissions
+    session: continue
+    auto_accept: true
+
+    # Fleet push channels: sac control bus + shared scitex-todo store + the
+    # Telegram bridge (operator DMs wake the agent). server:sac is also
+    # auto-injected by the loader; listed here for visibility.
+    channels:
+      - server:sac
+      - server:scitex-todo
+      - server:claude-code-telegrammer
+
+    raw_options: {{}}
+    continue_max_age_minutes: null
+    resume_id: ""
+    account: ""
+    # Pin this agent to a dedicated account by pointing credentials_file at
+    # that account's LIVE .credentials.json (else the shared host OAuth is
+    # forwarded automatically).
+    credentials_file: ""
+    credentials_files: []
+    provider: null
+
+  # Editable-install the agent's own repo so imports resolve to the live
+  # working tree (edit -> test without reinstall). The `|| true` keeps
+  # startup resilient when the repo has no installable package yet.
+  startup_commands:
+    - command: 'uv pip install -e {home}/proj/{name} --quiet || true'
+
+  # Generic self-resume kick — the agent picks up its board / last state.
+  # Replace with the agent's real first mission.
+  startup_prompts:
+    - Start or continue.
+
+  health:
+    enabled: true
+    interval: 60
+    timeout: 10
+    method: sdk-alive
+
+  watchdog:
+    enabled: false
+    interval: 1.5
+    responses:
+      y_n: "1"
+      y_y_n: "2"
+      waiting: /speak-and-call
+
+  restart:
+    policy: on-failure
+    max_retries: 3
+    prune_on_stop: false
+    backoff:
+      initial: 10
+      max: 120
+      multiplier: 2
+
+  autonomous:
+    enabled: false
+    drive_until: DONE
+    max_turns: 50
+    idle_kick_after_s: 120
+    kick_text: Continue. Print DONE when finished.
+
+  hooks:
+    pre_start: []
+    post_start: []
+    pre_stop: []
+    post_stop: []
+    on_compact: []
+    on_restart: []
+    on_diff: []
+
+  context_management:
+    trigger_at_percent: 70.0
+    strategy: noop
+    warn_before_n_checks: 0
+    check_interval_seconds: 300
+    state_file: ~/.scitex/agent-container/state/<agent>.json
+
+  a2a:
+    host: 127.0.0.1
+    port: auto
+
+  comms:
+    outbound:
+      siblings: allow
+      parent: allow
+    inbound:
+      siblings: allow
+      parent: allow
+    a2a:
+      listen: true
+
+  lineage:
+    group: ""
+    may_spawn: true
+
+# EOF
+"""
+
+
+_TEMPLATES = {
+    "minimal": _MINIMAL_TEMPLATE,
+    "full": _FULL_TEMPLATE,
+}
+
+__all__ = ["_FULL_TEMPLATE", "_MINIMAL_TEMPLATE", "_TEMPLATES"]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_cold_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_cold_start.py
@@ -28,12 +28,13 @@ from pathlib import Path
 # digits, hyphen, underscore; must start with a letter.
 _VALID_LABEL = re.compile(r"^[a-z][a-z0-9_-]*$")
 
-# Standardized TUI spec for a cold-started agent. Every APPLICABLE field is
-# written explicitly — NO HIDDEN DEFAULTS (operator directive 2026-06-23): a
-# reader sees placement, image, mounts, model, and lifecycle without consulting
-# code, and the validator REQUIRES them. The sac MCP server + ``server:sac``
-# channel are still auto-injected by the loader. ``host`` is always set
-# (``local`` = the caller's host; dispatch runs remote when it names a peer).
+# Standardized TUI spec for a cold-started agent. EVERY field is written
+# explicitly — red-start ruling 2026-07-21 (superseding the 2026-06-23
+# subset): an omitted field is a load ERROR, so anything sac itself renders
+# must carry the complete required set. Non-curated values sit at their
+# defaults. The sac MCP server + ``server:sac`` channel are still
+# auto-injected by the loader. ``host`` is always set (dispatch runs remote
+# when it names a peer).
 _COLD_START_SPEC = """\
 # {label} — cold-started by `sac start` ({stamp_note}).
 # Standardized TUI spec; edit freely or `sac agents create` for the full tour.
@@ -44,25 +45,113 @@ metadata:
     project: {label}
 spec:
   runtime: tui
+  provider: anthropic
   host: {host}
   workdir: {workdir}
+  python-venv: ""
+  user: ""
+  to_home: ./to_home
+  startup_commands: []
+  startup_prompts: []
+  listen: []
+  extensions: {{}}
+  mcp_servers: {{}}
+  container:
+    runtime: none
+    image: scitex-agent-container:latest
+    volumes: []
+    network: host
+    mount_host_claude: false
   apptainer:
     # Default SIF, named explicitly. ``binds: []`` = no extra mounts; apptainer's
     # default $HOME mount makes the workdir reachable. Add binds for more reach.
     image: ~/.scitex/agent-container/containers/scitex-agent-container.sif
     binds: []
+    env: {{}}
+    raw_args: []
+    post: ""
+    environment: {{}}
+    def_file: ""
+    nv: false
+    rocm: false
+    overlay: ""
+    overlay_size: ""
+    overlay_create_if_missing: true
+    tmpfs_size: 2G
+    relaxed: false
+    fakeroot: false
+    jail: false
+    nested_build: false
   claude:
     model: sonnet
     flags:
       - --dangerously-skip-permissions
+    channels: []
+    raw_options: {{}}
+    # null = role-derived (continue for coordinator roles, fresh otherwise)
+    session: null
+    continue_max_age_minutes: null
+    resume_id: ""
+    auto_accept: true
+    account: ""
+    credentials_file: ""
+    credentials_files: []
+    provider: null
   health:
     enabled: true
     interval: 60
+    timeout: 5
+    method: sdk-alive
+  watchdog:
+    enabled: false
+    interval: 1.5
+    responses:
+      y_n: "1"
+      y_y_n: "2"
+      waiting: /speak-and-call
   restart:
     policy: on-failure
     max_retries: 3
+    prune_on_stop: false
+    backoff:
+      initial: 30
+      max: 300
+      multiplier: 2
+  autonomous:
+    enabled: false
+    drive_until: DONE
+    max_turns: 50
+    idle_kick_after_s: 120
+    kick_text: Continue. Print DONE when finished.
+  hooks:
+    pre_start: []
+    post_start: []
+    pre_stop: []
+    post_stop: []
+    on_compact: []
+    on_restart: []
+    on_diff: []
+  context_management:
+    trigger_at_percent: 70.0
+    strategy: noop
+    warn_before_n_checks: 0
+    check_interval_seconds: 300
+    state_file: ~/.scitex/agent-container/state/<agent>.json
   a2a:
+    host: 127.0.0.1
     port: auto
+  comms:
+    outbound:
+      siblings: allow
+      parent: allow
+    inbound:
+      siblings: allow
+      parent: allow
+    a2a:
+      listen: true
+  lineage:
+    group: ""
+    may_spawn: true
 """
 
 

--- a/src/scitex_agent_container/config/_explicit_fields.py
+++ b/src/scitex_agent_container/config/_explicit_fields.py
@@ -1,0 +1,284 @@
+"""Required-field map for the explicit-spec ruling (2026-07-21).
+
+WHY THIS EXISTS — operator ruling 2026-07-21, verbatim intent:
+
+  * EVERY field in an agent ``spec.yaml`` must be written explicitly.
+    An omitted field is an ERROR at config-load time, with a hint.
+  * NO migration machinery, NO warn phase, NO escape-hatch env flag.
+    Existing under-specified specs going boot-red at once is ACCEPTED
+    and desired ("red start, hard").
+  * The structure must leave no option but compliance.
+
+This module is the DATA side: it derives the required YAML-key map from
+``dataclasses.fields()`` of the section dataclasses wherever the YAML
+key ↔ dataclass field mapping is 1:1, and from explicit alias tables
+where it is not (``watchdog.responses.*``, ``restart.backoff.*``,
+``python-venv``). The parsers in ``config/_parsers`` remain the SSOT of
+which keys exist; the dataclasses remain the SSOT of the value tree.
+The raising walker lives in the sibling ``_explicit_validation``.
+
+Each required entry carries the CURRENT default value so the error hint
+can emit a paste-ready YAML block that reproduces, field for field, the
+exact behaviour the spec had while the field was omitted. Fields whose
+absence triggers a LOADER derivation (workdir, claude.session) paste
+``null`` — present-but-null keeps the derivation, which is the
+behaviour-preserving explicit spelling.
+
+EXCLUDED from the required map, each with its reason:
+
+  * ``spec.host`` / ``spec.hosts`` — mutually exclusive pair; exactly-one
+    presence is already enforced (loudly) by ``_placement_validation``.
+    A require-ALL map cannot demand both.
+  * ``spec.session`` — top-level ergonomic alias of the canonical
+    ``spec.claude.session``; requiring both would force a double
+    declaration. The canonical nested key is required instead.
+  * ``spec.claude.*`` — required only for ``kind: Agent``;
+    ``validate_proxy_coupling`` FORBIDS the block on ``kind: AgentProxy``.
+  * ``spec.proxy.*`` — required only for ``kind: AgentProxy``; the same
+    coupling validator forbids the block on ``kind: Agent``.
+  * ``spec.screen`` — legacy inert metadata (only ``screen.name`` is
+    read, and it no longer drives a multiplexer); requiring it would
+    enshrine a dead field.
+  * ``spec.startup`` — listed in ``_KNOWN_SPEC_KEYS`` but materialised
+    by NO parser (``getattr(config, "startup", None)`` is always None);
+    a dead key cannot be meaningfully required.
+  * ``spec.multiplexer`` / ``spec.env-file`` / ``spec.exclude_hooks`` /
+    ``spec.exclude_skills`` — read by ``load_v3`` but ABSENT from
+    ``_KNOWN_SPEC_KEYS``, so ``validate_raw`` rejects them as unknown;
+    requiring them would be a contradiction (red both ways). Flagged
+    for operator review.
+  * banned/relocated keys stay banned, never required: ``spec.access``,
+    ``spec.scheduling``, ``spec.dockerfile``, top-level ``image`` /
+    ``env`` / ``model`` / ``mounts``, ``spec.skills``, ``spec.dot_claude``,
+    ``spec.remote``, ``metadata.name``, ``apptainer.container_workdir``.
+  * list-ITEM internals (``listen[].port``, ``startup_commands[].command``,
+    ``apptainer.binds`` entries, ``mcp_servers.*`` bodies,
+    ``claude.provider`` dict internals) — the LIST/MAPPING itself is the
+    explicit declaration; item shapes are validated by their parsers.
+  * ``metadata`` / ``metadata.labels`` — outside ``spec``; free-form
+    advisory labels.
+
+PASTE-VALUE OVERRIDES (default shown ≠ value pasted):
+
+  * ``health.method`` — the dataclass default ``multiplexer-alive`` is a
+    fossil ``validate_raw`` REJECTS when written; the only writable
+    value is ``sdk-alive``, so that is pasted.
+  * ``workdir`` / ``claude.session`` — ``null`` pastes the loader
+    derivation (per-agent runtime dir / role-derived session), which is
+    exactly what omission used to mean.
+  * ``proxy.upstream`` — no default exists (the parser hard-requires
+    it); the pasted placeholder matches the existing validator hint.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from ._acl_types import (
+    A2ACommsToggle,
+    InboundCommsSpec,
+    LineageSpec,
+    OutboundCommsSpec,
+)
+from ._apptainer_spec import ApptainerSpec
+from ._proxy_types import ProxySpec
+from ._types import (
+    A2ASpec,
+    AutonomousSpec,
+    ClaudeSpec,
+    ContainerSpec,
+    ContextManagementConfig,
+    HealthSpec,
+    HookSpec,
+    RestartSpec,
+    WatchdogSpec,
+)
+
+__all__ = ["RequiredField", "required_fields_for_kind"]
+
+# Sentinel: "no paste override — paste the dataclass default".
+_NO_OVERRIDE = object()
+
+
+@dataclass(frozen=True)
+class RequiredField:
+    """One required YAML key under ``spec.`` with its hint payload."""
+
+    path: str  # dotted YAML path under spec., e.g. "claude.session"
+    type_str: str  # human-readable expected type
+    default_repr: str  # the CURRENT default, as shown in the hint
+    paste_value: Any  # value emitted in the paste-ready YAML block
+
+
+def _default_of(field: dataclasses.Field) -> Any:
+    if field.default is not dataclasses.MISSING:
+        return field.default
+    return field.default_factory()  # type: ignore[misc]
+
+
+def _section(
+    prefix: str,
+    dc: type,
+    *,
+    alias: Mapping[str, str] | None = None,
+    exclude: tuple[str, ...] = (),
+    paste_overrides: Mapping[str, Any] | None = None,
+    default_notes: Mapping[str, str] | None = None,
+) -> list[RequiredField]:
+    """Derive one section's required keys from ``dataclasses.fields(dc)``.
+
+    ``alias`` maps dataclass field name → YAML key path (relative to
+    ``prefix``) where the two differ. ``paste_overrides`` maps YAML key
+    path → the value pasted instead of the dataclass default.
+    ``default_notes`` appends a clarifying note to the shown default.
+    """
+    alias = alias or {}
+    paste_overrides = paste_overrides or {}
+    default_notes = default_notes or {}
+    out: list[RequiredField] = []
+    for f in dataclasses.fields(dc):
+        if f.name in exclude:
+            continue
+        key = alias.get(f.name, f.name)
+        path = f"{prefix}.{key}" if prefix else key
+        default = _default_of(f)
+        shown = repr(default)
+        if key in default_notes:
+            shown = f"{shown} ({default_notes[key]})"
+        paste = paste_overrides.get(key, _NO_OVERRIDE)
+        if paste is _NO_OVERRIDE:
+            paste = default
+        out.append(
+            RequiredField(
+                path=path,
+                type_str=str(f.type),
+                default_repr=shown,
+                paste_value=paste,
+            )
+        )
+    return out
+
+
+def _top_level_fields() -> list[RequiredField]:
+    """Hand-authored top-level ``spec.*`` scalars (no 1:1 dataclass)."""
+    return [
+        RequiredField("runtime", "str", "'tui'", "tui"),
+        RequiredField("provider", "str", "'anthropic'", "anthropic"),
+        RequiredField(
+            "workdir",
+            "str | None",
+            "None (derived: ~/.scitex/agent-container/runtime/agents/<name>)",
+            None,
+        ),
+        RequiredField("python-venv", "str | list[str]", "''", ""),
+        RequiredField("startup_commands", "list", "[]", []),
+        RequiredField(
+            "startup_prompts",
+            "list[str]",
+            "[] (empty inherits the generic boot kick)",
+            [],
+        ),
+        RequiredField("listen", "list", "[]", []),
+        RequiredField("extensions", "dict", "{}", {}),
+        RequiredField("mcp_servers", "dict", "{}", {}),
+        RequiredField("user", "str", "''", ""),
+        RequiredField("to_home", "str", "'./to_home'", "./to_home"),
+    ]
+
+
+def _both_kinds_fields() -> list[RequiredField]:
+    fields = _top_level_fields()
+    fields += _section("container", ContainerSpec)
+    fields += _section(
+        "health",
+        HealthSpec,
+        paste_overrides={
+            # Dataclass default 'multiplexer-alive' is a fossil the
+            # validator REJECTS when written; 'sdk-alive' is the only
+            # writable value (see module docstring).
+            "method": "sdk-alive",
+        },
+        default_notes={"method": "fossil; write 'sdk-alive'"},
+    )
+    fields += _section(
+        "watchdog",
+        WatchdogSpec,
+        alias={
+            "resp_y_n": "responses.y_n",
+            "resp_y_y_n": "responses.y_y_n",
+            "resp_waiting": "responses.waiting",
+        },
+    )
+    fields += _section(
+        "restart",
+        RestartSpec,
+        alias={
+            "backoff_initial": "backoff.initial",
+            "backoff_max": "backoff.max",
+            "backoff_multiplier": "backoff.multiplier",
+        },
+    )
+    fields += _section("autonomous", AutonomousSpec)
+    fields += _section(
+        "apptainer",
+        ApptainerSpec,
+        # container_workdir is BANNED (removed with spec.access); banned
+        # stays banned, never required.
+        exclude=("container_workdir",),
+    )
+    fields += _section("hooks", HookSpec)
+    fields += _section("context_management", ContextManagementConfig)
+    fields += _section("a2a", A2ASpec)
+    fields += _section("comms.outbound", OutboundCommsSpec)
+    fields += _section("comms.inbound", InboundCommsSpec)
+    fields += _section("comms.a2a", A2ACommsToggle)
+    fields += _section("lineage", LineageSpec)
+    return fields
+
+
+def _claude_fields() -> list[RequiredField]:
+    return _section(
+        "claude",
+        ClaudeSpec,
+        paste_overrides={
+            # null keeps the role-derived session default (continue for
+            # coordinator roles, fresh otherwise) — exactly what omission
+            # used to mean. Writing 'fresh' here would silently flip
+            # coordinators to fresh and lose their working memory.
+            "session": None,
+        },
+        default_notes={
+            "session": "null keeps the role-derived default",
+            "model": "empty uses the runtime default",
+        },
+    )
+
+
+def _proxy_fields() -> list[RequiredField]:
+    return _section(
+        "proxy",
+        ProxySpec,
+        paste_overrides={
+            # No default exists (the parser hard-requires upstream); the
+            # placeholder matches the existing validate_proxy_coupling hint
+            # and MUST be edited to the real forwarding target.
+            "upstream": "http://127.0.0.1:9000",
+        },
+        default_notes={"upstream": "no default — set your real upstream"},
+    )
+
+
+def required_fields_for_kind(kind: object) -> tuple[RequiredField, ...]:
+    """The full required-key map for a ``kind: Agent|AgentProxy`` spec.
+
+    Unknown kinds get the both-kinds set only — ``validate_raw`` already
+    rejects the kind itself with its own error.
+    """
+    fields = _both_kinds_fields()
+    if kind == "Agent":
+        fields += _claude_fields()
+    elif kind == "AgentProxy":
+        fields += _proxy_fields()
+    return tuple(fields)

--- a/src/scitex_agent_container/config/_explicit_validation.py
+++ b/src/scitex_agent_container/config/_explicit_validation.py
@@ -1,0 +1,172 @@
+"""Explicit-spec validation — every field written, or the load is RED.
+
+WHY — operator ruling 2026-07-21 (verbatim intent, do not soften):
+
+  1. EVERY field in an agent ``spec.yaml`` must be written explicitly.
+     An omitted field is an ERROR at config-load time, with a hint.
+  2. NO migration machinery, NO warn phase, NO escape-hatch env flag.
+     Existing specs going boot-red at once is ACCEPTED and desired
+     ("red start, hard; migration ceremony is ridiculous").
+  3. The structure must leave no option but compliance — hence the only
+     entry-point signature is ``validate(doc, path)``: no ``strict=``
+     parameter, no bypass kwarg, nothing to turn off.
+
+The required-key map lives in the sibling ``_explicit_fields`` (derived
+from ``dataclasses.fields()`` of the section dataclasses + explicit
+alias tables). This module is the WALKER: it collects ALL missing
+fields in ONE pass — never fail-on-first, the hint must list everything
+at once — and raises a single :class:`ExplicitSpecError` whose message
+carries, per missing field, its YAML path, expected type and current
+default, followed by a paste-ready YAML block that clears every error
+(hint-clears-the-condition is round-trip TESTED; see the incident memory
+about hints that do not clear their own gate).
+
+Presence semantics match the pre-existing required-field checker
+(operator directive 2026-06-23): a key present with a ``null`` value IS
+an explicit declaration — the author wrote it; value/shape checks
+belong to the section validators and parsers. Only a genuinely absent
+key (or a non-mapping parent) is missing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ._explicit_fields import RequiredField, required_fields_for_kind
+
+__all__ = [
+    "ExplicitSpecError",
+    "explicit_field_errors",
+    "explicit_spec_defaults",
+    "validate",
+]
+
+# Markers delimiting the paste-ready YAML block inside the error message
+# so operators (and the round-trip test) can extract it verbatim.
+PASTE_BEGIN = "# --- paste-ready (values = current defaults) ---"
+PASTE_END = "# --- end paste-ready ---"
+
+
+class ExplicitSpecError(ValueError):
+    """A spec omitted required fields (red-start ruling 2026-07-21)."""
+
+
+def _is_present(spec: dict, path: str) -> bool:
+    """True when every level of the dotted ``path`` exists in ``spec``.
+
+    A key present with ``None`` counts as PRESENT (explicitly declared);
+    a non-mapping parent makes the leaf absent — the shape validators
+    own the "must be a mapping" diagnostic.
+    """
+    cur: Any = spec
+    for part in path.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return False
+        cur = cur[part]
+    return True
+
+
+def _missing_fields(doc: dict) -> list[RequiredField]:
+    spec = doc.get("spec")
+    if not isinstance(spec, dict):
+        # "spec is required and must be a mapping" is validate_raw's
+        # diagnostic; nothing to walk here.
+        return []
+    kind = doc.get("kind")
+    return [
+        field
+        for field in required_fields_for_kind(kind)
+        if not _is_present(spec, field.path)
+    ]
+
+
+def _paste_block(missing: list[RequiredField]) -> str:
+    """Render the missing fields as one merge-ready ``spec:`` YAML doc."""
+    tree: dict = {}
+    for field in missing:
+        cur = tree
+        parts = field.path.split(".")
+        for part in parts[:-1]:
+            cur = cur.setdefault(part, {})
+        cur[parts[-1]] = field.paste_value
+    return yaml.safe_dump(
+        {"spec": tree}, sort_keys=False, default_flow_style=False
+    ).rstrip()
+
+
+def _render_message(missing: list[RequiredField], path: Path | str) -> str:
+    lines = [
+        f"spec is missing {len(missing)} required field(s). EVERY spec "
+        "field must be written explicitly — an omitted field is a load "
+        "ERROR (operator ruling 2026-07-21: red-start; no migration "
+        "phase, no bypass).",
+        "",
+        "Missing fields (YAML path — expected type — current default):",
+    ]
+    lines += [
+        f"  - spec.{field.path} — {field.type_str} — {field.default_repr}"
+        for field in missing
+    ]
+    lines += [
+        "",
+        "Merge this block into the spec to clear every error above "
+        "(values are the current defaults, so behaviour is unchanged):",
+        "",
+        PASTE_BEGIN,
+        _paste_block(missing),
+        PASTE_END,
+        "",
+        f"While loading: {path}",
+    ]
+    return "\n".join(lines)
+
+
+def explicit_field_errors(doc: dict, path: Path | str) -> list[str]:
+    """List-form surface for ``validate_raw`` (0 or 1 consolidated message).
+
+    Returns an empty list when every required field is present, else a
+    single-element list holding the full consolidated message — one
+    error entry, everything listed at once, so the CLI ``sac agents
+    check`` path and ``load_config`` report identically.
+    """
+    if not isinstance(doc, dict):
+        return []
+    missing = _missing_fields(doc)
+    if not missing:
+        return []
+    return [_render_message(missing, path)]
+
+
+def validate(doc: dict, path: Path | str) -> None:
+    """Raise :class:`ExplicitSpecError` unless every field is explicit.
+
+    The ONLY signature — no env flag, no bypass parameter, no
+    ``strict=False``. Wired into ``load_v3`` BEFORE parsing so a red
+    spec fails with the complete hint, not a parser TypeError.
+    """
+    if not isinstance(doc, dict):
+        return
+    missing = _missing_fields(doc)
+    if missing:
+        raise ExplicitSpecError(_render_message(missing, path))
+
+
+def explicit_spec_defaults(kind: object = "Agent") -> dict:
+    """Full ``spec`` mapping with every required field at its paste value.
+
+    The same tree the paste-ready hint would emit for a spec missing
+    everything. Fixture/tooling surface (e.g. test scaffolds and
+    ``sac agents create`` templates) so repo-owned specs can never
+    drift from the required map.
+    """
+    tree: dict = {}
+    for field in required_fields_for_kind(kind):
+        cur = tree
+        parts = field.path.split(".")
+        for part in parts[:-1]:
+            cur = cur.setdefault(part, {})
+        cur[parts[-1]] = field.paste_value
+    return tree

--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from ._explicit_validation import validate as _validate_explicit_fields
 from ._host import (
     contains_hostname_placeholder,
     resolve_hostname,
@@ -262,6 +263,13 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
     No backward compatibility — old apiVersions raise loud validation
     errors at config-load time.
     """
+    # Red-start explicit-fields gate (operator ruling 2026-07-21): every
+    # spec field must be WRITTEN — an omitted field is a load error with
+    # a complete, paste-ready hint. Runs BEFORE any parsing so an
+    # under-specified spec fails with the full field list, not a parser
+    # TypeError. No bypass, no migration phase.
+    _validate_explicit_fields(raw, path)
+
     spec = raw.get("spec", {}) or {}
     hosts_spec = parse_hosts_spec(spec)
 

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -132,85 +132,15 @@ _V3_REMOVED_FIELDS: dict[str, str] = {
 
 
 # ---------------------------------------------------------------------------
-# Required author-facing fields (operator directive 2026-06-23 — NO HIDDEN
-# DEFAULTS). Extends the spec.access removal: just as host-access is now an
-# explicit binds list, every field with a BEHAVIOURAL default-when-absent must
-# be written in the spec, and the validator errors ROUNDLY (naming the field +
-# the fix) when an applicable one is missing. A reader of the spec then sees
-# every setting that actually applies — nothing is silently defaulted.
-#
-# Intentionally NOT required (so the rule stays coherent, not noise):
-#   * opt-in subsystems whose ABSENCE means "feature off" — and is therefore
-#     self-evident, not a hidden default: autonomous, watchdog,
-#     context_management, listen, hooks, comms, lineage, to_home, startup_*,
-#     a2a, env, user, container.*.
-#   * computed / loader-filled fields the author cannot meaningfully supply:
-#     python_venv, screen, expanded_workdir.
-#
-# Dataclass defaults are RETAINED on purpose — internal/test construction is
-# unaffected; enforcement lives HERE, at spec-validate time, where the round
-# errors live. Each entry is ``(dotted-path, multi-line fix hint)``.
-_REQUIRED_FIELDS_BOTH_KINDS: tuple[tuple[str, str], ...] = (
-    ("runtime", "runtime: tui            # tui | claude-agent-sdk"),
-    ("workdir", "workdir: /home/<you>/proj/<repo>   # the in-container --pwd"),
-    ("apptainer.image", "apptainer:\n    image: <path-to>.sif"),
-    (
-        "apptainer.binds",
-        "apptainer:\n    binds: []   # explicit mounts; [] = nothing beyond state",
-    ),
-    ("health.enabled", "health:\n    enabled: true"),
-    ("health.interval", "health:\n    interval: 60"),
-    (
-        "restart.policy",
-        "restart:\n    policy: on-failure   # never | on-failure | always",
-    ),
-    ("restart.max_retries", "restart:\n    max_retries: 3"),
-)
-# kind: Agent only (the SDK/TUI runner reads spec.claude; a proxy has no SDK).
-_REQUIRED_FIELDS_AGENT: tuple[tuple[str, str], ...] = (
-    ("claude.model", "claude:\n    model: claude-opus-4-8[1m]"),
-)
-
-_MISSING = object()
-
-
-def _dotted_get(spec: dict, path: str):
-    """Walk a dotted key path; return ``_MISSING`` if any level is absent.
-
-    A key present with a ``None`` value (e.g. ``binds:`` written with no value)
-    counts as PRESENT — the author declared it explicitly; value-type checks
-    elsewhere handle the shape. Only a genuinely absent key (or a non-mapping
-    parent) is ``_MISSING``.
-    """
-    cur: object = spec
-    for part in path.split("."):
-        if not isinstance(cur, dict) or part not in cur:
-            return _MISSING
-        cur = cur[part]
-    return cur
-
-
-def _missing_required_fields(spec: dict, kind: object) -> list[str]:
-    """Round errors for every REQUIRED author field absent from ``spec``."""
-    required = list(_REQUIRED_FIELDS_BOTH_KINDS)
-    if kind == "Agent":
-        required += list(_REQUIRED_FIELDS_AGENT)
-    # Multi-instance agents (``spec.hosts``) auto-derive a PER-INSTANCE workdir
-    # — the runtime path keyed by the host-suffixed effective id. That is the
-    # intended multi-host behaviour (each instance gets its own scratch), NOT a
-    # hidden default, so workdir is not required there. A singleton
-    # (``spec.host``) opens at a canonical path the operator must state, so it
-    # stays required. (Multi-host MAY still set workdir to share one path.)
-    if "hosts" in spec:
-        required = [(p, h) for (p, h) in required if p != "workdir"]
-    out: list[str] = []
-    for path, hint in required:
-        if _dotted_get(spec, path) is _MISSING:
-            out.append(
-                f"spec.{path} is REQUIRED — declare it explicitly (no hidden "
-                f"defaults; operator directive 2026-06-23). Add:\n  {hint}"
-            )
-    return out
+# Required author-facing fields. The 2026-06-23 "no hidden defaults" subset
+# (runtime/workdir/apptainer.{image,binds}/health/restart/claude.model) was
+# SUPERSEDED by the 2026-07-21 red-start ruling: EVERY spec field must be
+# written explicitly, an omitted field is a load error, and the hint lists
+# every missing field at once with a paste-ready block. The required-key map
+# and the consolidated message live in the sibling ``_explicit_fields`` /
+# ``_explicit_validation`` modules (single source of truth — ``load_v3``
+# raises through the same map for direct callers); ``validate_raw`` delegates
+# below so ``sac agents check`` reports identically to ``load_config``.
 
 
 # ``_validate_provider`` moved to ``_provider_validation.validate_provider``
@@ -315,11 +245,9 @@ def validate_raw(raw: dict, path: str) -> list[str]:
         # spec.provider — AGENT SDK FAMILY selector (openai-compat-1
         # foundation). Distinct from spec.claude.provider (ProviderSpec,
         # validated inside validate_claude) — see the naming-collision
-        # note in config._provider_types.AgentProvider. Optional and
-        # NOT in _REQUIRED_FIELDS_BOTH_KINDS on purpose: the whole point
-        # of this field is a safe, backward-compatible default so no
-        # existing spec needs to change while openai-compat-2/3 land the
-        # actual "openai" runner + entrypoint wiring.
+        # note in config._provider_types.AgentProvider. Presence is
+        # enforced by the explicit-fields map (red-start ruling
+        # 2026-07-21); this check only owns the VALUE diagnostic.
         provider = spec.get("provider")
         if provider and not is_known_agent_provider(str(provider)):
             errors.append(
@@ -482,10 +410,14 @@ def validate_raw(raw: dict, path: str) -> list[str]:
                 "(multi-instance, 'all' or list)."
             )
 
-        # No hidden defaults: every APPLICABLE author field must be declared
-        # explicitly (operator directive 2026-06-23). host/hosts presence is
-        # already enforced above; this covers the rest of the required set.
-        errors.extend(_missing_required_fields(spec, kind))
+        # Red-start explicit-fields ruling (2026-07-21): EVERY spec field
+        # must be written explicitly. host/hosts presence is enforced above
+        # (mutually-exclusive pair — cannot live in a require-all map); the
+        # consolidated one-error-lists-everything message with the
+        # paste-ready block comes from the SSOT module.
+        from ._explicit_validation import explicit_field_errors
+
+        errors.extend(explicit_field_errors(raw, path))
 
     return errors
 

--- a/tests/e2e/test_agent_lifecycle.py
+++ b/tests/e2e/test_agent_lifecycle.py
@@ -28,6 +28,8 @@ stop --force`` so a failing assert does not leave a container behind.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import os
 import shutil
 import subprocess
@@ -59,7 +61,7 @@ def _write_minimal_spec(home: Path, name: str) -> Path:
     agent_dir.mkdir(parents=True, exist_ok=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        textwrap.dedent(
+        explicitize_yaml(textwrap.dedent(
             f"""\
             apiVersion: scitex-agent-container/v3
             kind: Agent
@@ -86,7 +88,7 @@ def _write_minimal_spec(home: Path, name: str) -> Path:
                 policy: on-failure
                 max_retries: 3
             """
-        )
+        ))
     )
     return spec
 

--- a/tests/e2e/test_fleet_bulk_start.py
+++ b/tests/e2e/test_fleet_bulk_start.py
@@ -29,6 +29,8 @@ does not leak two long-lived agents into the operator's environment.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import json
 import os
 import shutil
@@ -63,7 +65,7 @@ def _write_fleet(home: Path, names: list[str]) -> Path:
         agent_dir = fleet_root / name
         agent_dir.mkdir(parents=True, exist_ok=True)
         (agent_dir / "spec.yaml").write_text(
-            textwrap.dedent(
+            explicitize_yaml(textwrap.dedent(
                 f"""\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
@@ -89,7 +91,7 @@ def _write_fleet(home: Path, names: list[str]) -> Path:
                     policy: on-failure
                     max_retries: 3
                 """
-            )
+            ))
         )
     return fleet_root
 

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -92,10 +92,23 @@ def _write_config(data: dict) -> str:
     The helper picks the dir name from ``data["metadata"]["name"]`` (a
     test-only convenience) and then **strips** that field before writing
     so the validator (which now rejects metadata.name) doesn't complain.
+
+    Red-start ruling 2026-07-21: every spec field must be explicit, so
+    the helper merges the validator's own paste defaults BENEATH the
+    test's spec (the test's fields win) before writing.
     """
     import copy
 
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        deep_merge,
+        explicit_spec_defaults,
+    )
+
     data = copy.deepcopy(data)
+    data["spec"] = deep_merge(
+        explicit_spec_defaults(data.get("kind", "Agent")),
+        data.get("spec") or {},
+    )
     metadata = data.get("metadata") or {}
     name = metadata.pop("name", None) or "test-agent"
     if metadata:

--- a/tests/integration/test_config_v2.py
+++ b/tests/integration/test_config_v2.py
@@ -22,7 +22,18 @@ def _write_config(data: dict) -> str:
     """
     import copy
 
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        deep_merge,
+        explicit_spec_defaults,
+    )
+
     data = copy.deepcopy(data)
+    # Red-start ruling 2026-07-21: every spec field must be explicit —
+    # merge the validator's own paste defaults beneath (fixture wins).
+    data["spec"] = deep_merge(
+        explicit_spec_defaults(data.get("kind", "Agent")),
+        data.get("spec") or {},
+    )
     metadata = data.get("metadata") or {}
     name = metadata.pop("name", None) or "test-agent"
     if metadata:

--- a/tests/integration/test_provider_column_specs.py
+++ b/tests/integration/test_provider_column_specs.py
@@ -32,9 +32,9 @@ from typing import Iterator
 
 import pytest
 
-from scitex_agent_container.a2a.executors import EXECUTORS, BaseSyncExecutor
 from scitex_agent_container._runners._provider_session import ProviderSession
 from scitex_agent_container._runners.openai_session import OpenAISession
+from scitex_agent_container.a2a.executors import EXECUTORS, BaseSyncExecutor
 from scitex_agent_container.config import load_config
 from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
 
@@ -94,8 +94,14 @@ def _load_column(tmp_path: Path, name: str, provider_line: str):
     spec_dir = tmp_path / "agents" / name
     spec_dir.mkdir(parents=True, exist_ok=True)
     spec = spec_dir / "spec.yaml"
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
+    # Red-start ruling 2026-07-21: every field explicit (template wins).
     spec.write_text(
-        _SPEC_TEMPLATE.format(provider_line=provider_line), encoding="utf-8"
+        explicitize_yaml(_SPEC_TEMPLATE.format(provider_line=provider_line)),
+        encoding="utf-8",
     )
     return load_config(str(spec))
 

--- a/tests/integration/test_schema_validation_fr3.py
+++ b/tests/integration/test_schema_validation_fr3.py
@@ -31,7 +31,17 @@ def _write_yaml(data: dict, name: str = "test-agent") -> Path:
     """Write YAML into dir-as-SSoT layout; strip metadata.name if present."""
     import copy
 
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        deep_merge,
+        explicit_spec_defaults,
+    )
+
     data = copy.deepcopy(data)
+    # Red-start ruling 2026-07-21: every spec field explicit (fixture wins).
+    if isinstance(data.get("spec"), dict):
+        data["spec"] = deep_merge(
+            explicit_spec_defaults(data.get("kind", "Agent")), data["spec"]
+        )
     metadata = data.get("metadata") or {}
     metadata.pop("name", None)
     if metadata:

--- a/tests/integration/test_shared_host_layout.py
+++ b/tests/integration/test_shared_host_layout.py
@@ -93,14 +93,21 @@ def _write_agent_yaml(
     # defaults). host/hosts is set per-test below; default to local singleton
     # when a test pins neither, so the placement-composition under test stays
     # the only variable.
-    spec: dict = {
-        "runtime": "apptainer",
-        "workdir": "/home/agent/work",
-        "claude": {"model": "sonnet"},
-        "apptainer": {"image": "/x.sif", "binds": []},
-        "health": {"enabled": True, "interval": 60},
-        "restart": {"policy": "on-failure", "max_retries": 3},
-    }
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicit_spec,
+    )
+
+    # Red-start ruling 2026-07-21: every field explicit (curated wins).
+    spec: dict = explicit_spec(
+        {
+            "runtime": "apptainer",
+            "workdir": "/home/agent/work",
+            "claude": {"model": "sonnet"},
+            "apptainer": {"image": "/x.sif", "binds": []},
+            "health": {"enabled": True, "interval": 60},
+            "restart": {"policy": "on-failure", "max_retries": 3},
+        }
+    )
     if host is not None:
         spec["host"] = host
     if hosts is not None:

--- a/tests/integration/test_shared_host_layout.py
+++ b/tests/integration/test_shared_host_layout.py
@@ -20,6 +20,11 @@ from textwrap import dedent
 import pytest
 import yaml
 
+# Red-start ruling 2026-07-21: the TestEffectiveId bodies wrap their inline
+# specs with this at module level (the _write_agent_yaml helper imports its
+# own sibling function-locally and does NOT cover these call sites).
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -457,8 +462,9 @@ class TestEffectiveId:
         head_dir = tmp_path / "head"
         head_dir.mkdir()
         (head_dir / "head.yaml").write_text(
-            explicitize_yaml(dedent(
-                """\
+            explicitize_yaml(
+                dedent(
+                    """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
                 metadata:
@@ -481,7 +487,8 @@ class TestEffectiveId:
                     max_retries: 3
                   hosts: all
                 """
-            ))
+                )
+            )
         )
         # Act
         cfg = load_config(str(head_dir / "head.yaml"))
@@ -497,8 +504,9 @@ class TestEffectiveId:
         head_dir = tmp_path / "head"
         head_dir.mkdir()
         (head_dir / "head.yaml").write_text(
-            explicitize_yaml(dedent(
-                """\
+            explicitize_yaml(
+                dedent(
+                    """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
                 metadata:
@@ -520,7 +528,8 @@ class TestEffectiveId:
                     max_retries: 3
                   hosts: all
                 """
-            ))
+                )
+            )
         )
         # Act
         cfg = load_config(str(head_dir / "head.yaml"))
@@ -536,8 +545,9 @@ class TestEffectiveId:
         head_dir = tmp_path / "head"
         head_dir.mkdir()
         (head_dir / "head.yaml").write_text(
-            explicitize_yaml(dedent(
-                """\
+            explicitize_yaml(
+                dedent(
+                    """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
                 metadata:
@@ -559,7 +569,8 @@ class TestEffectiveId:
                     max_retries: 3
                   hosts: all
                 """
-            ))
+                )
+            )
         )
         # Act
         cfg = load_config(str(head_dir / "head.yaml"))
@@ -577,8 +588,9 @@ class TestEffectiveId:
         head_dir = tmp_path / "head"
         head_dir.mkdir()
         (head_dir / "head.yaml").write_text(
-            explicitize_yaml(dedent(
-                """\
+            explicitize_yaml(
+                dedent(
+                    """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
                 metadata:
@@ -599,7 +611,8 @@ class TestEffectiveId:
                     max_retries: 3
                   hosts: all
                 """
-            ))
+                )
+            )
         )
         # Act
         cfg = load_config(str(head_dir / "head.yaml"))
@@ -616,8 +629,9 @@ class TestEffectiveId:
         d = tmp_path / "lead"
         d.mkdir()
         (d / "lead.yaml").write_text(
-            explicitize_yaml(dedent(
-                """\
+            explicitize_yaml(
+                dedent(
+                    """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
                 metadata:
@@ -643,7 +657,8 @@ class TestEffectiveId:
                     - nas
                     - spartan
                 """
-            ))
+                )
+            )
         )
         # Act
         cfg = load_config(str(d / "lead.yaml"))
@@ -658,8 +673,9 @@ class TestEffectiveId:
         d = tmp_path / "lead"
         d.mkdir()
         (d / "lead.yaml").write_text(
-            explicitize_yaml(dedent(
-                """\
+            explicitize_yaml(
+                dedent(
+                    """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
                 metadata:
@@ -685,7 +701,8 @@ class TestEffectiveId:
                     - nas
                     - spartan
                 """
-            ))
+                )
+            )
         )
         # Act
         cfg = load_config(str(d / "lead.yaml"))
@@ -705,8 +722,9 @@ class TestEffectiveId:
         d = tmp_path / "lead"
         d.mkdir()
         (d / "lead.yaml").write_text(
-            explicitize_yaml(dedent(
-                """\
+            explicitize_yaml(
+                dedent(
+                    """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
                 metadata:
@@ -730,7 +748,8 @@ class TestEffectiveId:
                     - ywata-note-win
                     - mba
                 """
-            ))
+                )
+            )
         )
         # Act
         cfg = load_config(str(d / "lead.yaml"))

--- a/tests/integration/test_shared_host_layout.py
+++ b/tests/integration/test_shared_host_layout.py
@@ -457,7 +457,7 @@ class TestEffectiveId:
         head_dir = tmp_path / "head"
         head_dir.mkdir()
         (head_dir / "head.yaml").write_text(
-            dedent(
+            explicitize_yaml(dedent(
                 """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
@@ -481,7 +481,7 @@ class TestEffectiveId:
                     max_retries: 3
                   hosts: all
                 """
-            )
+            ))
         )
         # Act
         cfg = load_config(str(head_dir / "head.yaml"))
@@ -497,7 +497,7 @@ class TestEffectiveId:
         head_dir = tmp_path / "head"
         head_dir.mkdir()
         (head_dir / "head.yaml").write_text(
-            dedent(
+            explicitize_yaml(dedent(
                 """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
@@ -520,7 +520,7 @@ class TestEffectiveId:
                     max_retries: 3
                   hosts: all
                 """
-            )
+            ))
         )
         # Act
         cfg = load_config(str(head_dir / "head.yaml"))
@@ -536,7 +536,7 @@ class TestEffectiveId:
         head_dir = tmp_path / "head"
         head_dir.mkdir()
         (head_dir / "head.yaml").write_text(
-            dedent(
+            explicitize_yaml(dedent(
                 """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
@@ -559,7 +559,7 @@ class TestEffectiveId:
                     max_retries: 3
                   hosts: all
                 """
-            )
+            ))
         )
         # Act
         cfg = load_config(str(head_dir / "head.yaml"))
@@ -577,7 +577,7 @@ class TestEffectiveId:
         head_dir = tmp_path / "head"
         head_dir.mkdir()
         (head_dir / "head.yaml").write_text(
-            dedent(
+            explicitize_yaml(dedent(
                 """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
@@ -599,7 +599,7 @@ class TestEffectiveId:
                     max_retries: 3
                   hosts: all
                 """
-            )
+            ))
         )
         # Act
         cfg = load_config(str(head_dir / "head.yaml"))
@@ -616,7 +616,7 @@ class TestEffectiveId:
         d = tmp_path / "lead"
         d.mkdir()
         (d / "lead.yaml").write_text(
-            dedent(
+            explicitize_yaml(dedent(
                 """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
@@ -643,7 +643,7 @@ class TestEffectiveId:
                     - nas
                     - spartan
                 """
-            )
+            ))
         )
         # Act
         cfg = load_config(str(d / "lead.yaml"))
@@ -658,7 +658,7 @@ class TestEffectiveId:
         d = tmp_path / "lead"
         d.mkdir()
         (d / "lead.yaml").write_text(
-            dedent(
+            explicitize_yaml(dedent(
                 """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
@@ -685,7 +685,7 @@ class TestEffectiveId:
                     - nas
                     - spartan
                 """
-            )
+            ))
         )
         # Act
         cfg = load_config(str(d / "lead.yaml"))
@@ -705,7 +705,7 @@ class TestEffectiveId:
         d = tmp_path / "lead"
         d.mkdir()
         (d / "lead.yaml").write_text(
-            dedent(
+            explicitize_yaml(dedent(
                 """\
                 apiVersion: scitex-agent-container/v3
                 kind: Agent
@@ -730,7 +730,7 @@ class TestEffectiveId:
                     - ywata-note-win
                     - mba
                 """
-            )
+            ))
         )
         # Act
         cfg = load_config(str(d / "lead.yaml"))

--- a/tests/integration/test_spartan_sif_bake_stdin.py
+++ b/tests/integration/test_spartan_sif_bake_stdin.py
@@ -139,12 +139,18 @@ def _run_piped_on_stdin(body: str, work: Path) -> subprocess.CompletedProcess[st
     srun.write_text(_FAKE_SRUN, encoding="utf-8")
     srun.chmod(0o755)
     script = _HARNESS_PREAMBLE.format(srun=srun, work=work) + body + _HARNESS_TAIL
+    # cwd=work: the lifted blocks are executed for their REDIRECTION shape,
+    # and a mutated block can create relative-path files. Anchoring bash in
+    # the per-test tmp dir keeps any such droppings out of the repo root
+    # (a stray 0-byte SAC_TEST_SCRIPT_TAIL_REACHED once rode a git add -A
+    # into a PR from exactly this seam).
     return subprocess.run(
         ["bash", "-s"],
         input=script,
         capture_output=True,
         text=True,
         timeout=60,
+        cwd=str(work),
     )
 
 

--- a/tests/integration/test_v3_spec_structure.py
+++ b/tests/integration/test_v3_spec_structure.py
@@ -38,34 +38,35 @@ from scitex_agent_container.config import AgentConfig, load_config, validate_con
 # ---------------------------------------------------------------------------
 
 
-# No-hidden-defaults (operator directive 2026-06-23): every applicable
-# author field is REQUIRED at the YAML/load layer. ``_write_spec`` fills the
-# required scaffolding so each test body only has to declare the field it
-# exercises; the body still wins on any key (deep-merged for the nested
-# engine blocks), so round-trip and removed-field assertions are preserved.
+# Explicit-fields red-start ruling (2026-07-21, superseding the 2026-06-23
+# subset): EVERY spec field is REQUIRED at the YAML/load layer. ``_write_spec``
+# fills the full scaffolding from the validator's own paste defaults so each
+# test body only has to declare the field it exercises; the body still wins on
+# any key (deep-merged), so round-trip and removed-field assertions are
+# preserved.
 # NOTE: ``runtime`` is intentionally NOT scaffolded — the body must supply it
 # (every test does), keeping the validator's runtime-required rule honest.
-_REQUIRED_SCAFFOLD: dict = {
-    "host": "${HOSTNAME}",
-    "workdir": "~/.scitex/agent-container/runtime/agents/v3spec",
-    "claude": {"model": "claude-opus-4-8[1m]"},
-    "apptainer": {"image": "/opt/sac/scitex.sif", "binds": []},
-    "health": {"enabled": True, "interval": 60},
-    "restart": {"policy": "on-failure", "max_retries": 3},
-}
+
+
+def _required_scaffold() -> dict:
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicit_spec_defaults,
+    )
+
+    scaffold = explicit_spec_defaults("Agent")
+    del scaffold["runtime"]
+    scaffold["host"] = "${HOSTNAME}"
+    scaffold["workdir"] = "~/.scitex/agent-container/runtime/agents/v3spec"
+    scaffold["claude"]["model"] = "claude-opus-4-8[1m]"
+    scaffold["apptainer"]["image"] = "/opt/sac/scitex.sif"
+    return scaffold
 
 
 def _merge_required(spec_body: dict) -> dict:
     """Deep-merge the required scaffold UNDER ``spec_body`` (body wins)."""
-    import copy
+    from tests.scitex_agent_container._helpers.explicit_spec import deep_merge
 
-    merged = copy.deepcopy(_REQUIRED_SCAFFOLD)
-    for key, value in spec_body.items():
-        if isinstance(value, dict) and isinstance(merged.get(key), dict):
-            merged[key] = {**merged[key], **value}
-        else:
-            merged[key] = value
-    return merged
+    return deep_merge(_required_scaffold(), spec_body)
 
 
 def _write_spec(tmp_path: Path, spec_body: dict, name: str = "v3spec") -> Path:

--- a/tests/scitex_agent_container/_drift/test__local.py
+++ b/tests/scitex_agent_container/_drift/test__local.py
@@ -12,6 +12,8 @@ Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import subprocess
 from pathlib import Path
 
@@ -70,7 +72,7 @@ def spec_repo(tmp_path: Path):
     agents = work / ".scitex" / "agent-container" / "agents" / "foo"
     agents.mkdir(parents=True)
     spec = agents / "spec.yaml"
-    spec.write_text("apiVersion: scitex-agent-container/v3\n")
+    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"))
     _git(work, "add", "-A")
     _git(work, "commit", "-m", "init")
     _git(work, "push", "-u", "origin", "develop")

--- a/tests/scitex_agent_container/_helpers/explicit_spec.py
+++ b/tests/scitex_agent_container/_helpers/explicit_spec.py
@@ -1,0 +1,89 @@
+"""Shared fixture scaffold for the explicit-spec red-start ruling.
+
+Operator ruling 2026-07-21: EVERY spec field must be written explicitly
+— an omitted field is a load error. Test fixtures therefore cannot ship
+minimal specs anymore; this helper deep-merges a test's spec overrides
+on top of the production paste-defaults map (the SSOT in
+``config._explicit_validation``) so fixtures stay green as the required
+map evolves, while each test still spells out only the fields it is
+actually about.
+
+The GREEN-path proof does NOT rely on this helper: the hand-written
+fully-explicit YAML in ``tests/scitex_agent_container/config/
+test__explicit_validation.py`` is authored field by field, so the map
+and the fixtures cannot silently agree by construction.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from scitex_agent_container.config._explicit_validation import (
+    explicit_spec_defaults,
+)
+
+__all__ = ["deep_merge", "explicit_doc", "explicit_spec", "explicitize_yaml"]
+
+
+def deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge ``override`` on top of ``base`` (override wins)."""
+    out = copy.deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(out.get(key), dict):
+            out[key] = deep_merge(out[key], value)
+        else:
+            out[key] = copy.deepcopy(value)
+    return out
+
+
+def explicit_spec(
+    overrides: dict[str, Any] | None = None, *, kind: str = "Agent"
+) -> dict:
+    """Full explicit ``spec`` mapping with ``overrides`` merged on top.
+
+    Placement (``host``/``hosts``) is NOT defaulted here — it is a
+    mutually-exclusive pair the caller must declare, exactly as in a
+    real spec. Callers that don't care write ``{"host": "${HOSTNAME}"}``.
+    """
+    return deep_merge(explicit_spec_defaults(kind), overrides or {})
+
+
+def explicitize_yaml(yaml_text: str) -> str:
+    """Merge explicit-field defaults beneath a YAML doc's spec (spec wins).
+
+    For string-template fixtures: keeps the fixture's readable minimal
+    body as the authored surface while the dump satisfies the red-start
+    validator. Comments are lost (fixture bodies only); placeholder
+    tokens inside VALUES survive verbatim.
+    """
+    import yaml
+
+    doc = yaml.safe_load(yaml_text)
+    kind = doc.get("kind", "Agent")
+    doc["spec"] = deep_merge(explicit_spec_defaults(kind), doc.get("spec") or {})
+    return yaml.safe_dump(doc, sort_keys=False)
+
+
+def explicit_doc(
+    spec_overrides: dict[str, Any] | None = None,
+    *,
+    kind: str = "Agent",
+    metadata: dict | None = None,
+) -> dict:
+    """Full v3 YAML document with an explicit spec (+ default placement).
+
+    Adds ``host: ${HOSTNAME}`` when the overrides carry neither ``host``
+    nor ``hosts`` so single-purpose tests stay terse.
+    """
+    spec = explicit_spec(spec_overrides, kind=kind)
+    if "host" not in spec and "hosts" not in spec:
+        spec["host"] = "${HOSTNAME}"
+    doc: dict[str, Any] = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": kind,
+        "spec": spec,
+    }
+    if metadata is not None:
+        doc["metadata"] = metadata
+    return doc

--- a/tests/scitex_agent_container/_helpers/fleet_root.py
+++ b/tests/scitex_agent_container/_helpers/fleet_root.py
@@ -78,19 +78,117 @@ spec:
       - SCITEX_TODO_AGENT_ID={name}
       - --env
       - GIT_AUTHOR_NAME=Yusuke Watanabe
+    env: {{}}
+    post: ""
+    environment: {{}}
+    def_file: ""
+    nv: false
+    rocm: false
+    overlay: ""
+    overlay_size: ""
+    overlay_create_if_missing: true
+    tmpfs_size: 2G
+    fakeroot: false
+    jail: false
+    nested_build: false
 
   claude:
     model: opus[1m]
     flags:
       - --dangerously-skip-permissions
+    channels: []
+    raw_options: {{}}
+    session:
+    continue_max_age_minutes:
+    resume_id: ""
+    auto_accept: true
+    account: ""
+    credentials_file: ""
+    credentials_files: []
+    provider:
 
   health:
     enabled: true
     interval: 60
+    timeout: 5
+    method: sdk-alive
 
   restart:
     policy: on-failure
     max_retries: 3
+    prune_on_stop: false
+    backoff:
+      initial: 30
+      max: 300
+      multiplier: 2
+
+  # Explicit-fields ruling (2026-07-21): the remainder of the required
+  # field set at its defaults — every spec field is written.
+  provider: anthropic
+  python-venv: ""
+  user: ""
+  to_home: ./to_home
+  startup_commands: []
+  startup_prompts: []
+  listen: []
+  extensions: {{}}
+  mcp_servers: {{}}
+
+  container:
+    runtime: none
+    image: scitex-agent-container:latest
+    volumes: []
+    network: host
+    mount_host_claude: false
+
+  watchdog:
+    enabled: false
+    interval: 1.5
+    responses:
+      y_n: "1"
+      y_y_n: "2"
+      waiting: /speak-and-call
+
+  autonomous:
+    enabled: false
+    drive_until: DONE
+    max_turns: 50
+    idle_kick_after_s: 120
+    kick_text: Continue. Print DONE when finished.
+
+  hooks:
+    pre_start: []
+    post_start: []
+    pre_stop: []
+    post_stop: []
+    on_compact: []
+    on_restart: []
+    on_diff: []
+
+  context_management:
+    trigger_at_percent: 70.0
+    strategy: noop
+    warn_before_n_checks: 0
+    check_interval_seconds: 300
+    state_file: ~/.scitex/agent-container/state/<agent>.json
+
+  a2a:
+    host: 127.0.0.1
+    port: auto
+
+  comms:
+    outbound:
+      siblings: allow
+      parent: allow
+    inbound:
+      siblings: allow
+      parent: allow
+    a2a:
+      listen: true
+
+  lineage:
+    group: ""
+    may_spawn: true
 
 # EOF
 """

--- a/tests/scitex_agent_container/_lifecycle/test__ci_owner.py
+++ b/tests/scitex_agent_container/_lifecycle/test__ci_owner.py
@@ -16,6 +16,8 @@ Conventions: one assertion per test (STX-TQ007); AAA markers; no mocks
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 from pathlib import Path
 
 from scitex_agent_container._lifecycle._ci_owner import resolve_owner, tracked_repos
@@ -25,13 +27,13 @@ def _write_spec(agents_dir: Path, agent_name: str, project: str) -> None:
     d = agents_dir / agent_name
     d.mkdir(parents=True, exist_ok=True)
     (d / "spec.yaml").write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "metadata:\n"
         "  labels:\n"
         f"    project: {project}\n"
         "spec:\n"
-        "  runtime: tui\n"
+        "  runtime: tui\n")
     )
 
 

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
@@ -26,6 +26,8 @@ markers (TQ002), one assertion (TQ007), 3+-word name.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import json
 import os
 from pathlib import Path
@@ -436,7 +438,7 @@ def _write_spec(yaml_root: Path, name: str) -> Path:
     agent_dir.mkdir(parents=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -448,7 +450,7 @@ def _write_spec(yaml_root: Path, name: str) -> Path:
         "    model: sonnet\n"
         "  health:\n"
         "    enabled: false\n"
-        "    interval: 60\n"
+        "    interval: 60\n")
     )
     return spec
 

--- a/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances_auto_grant.py
@@ -18,6 +18,8 @@ stub exposing ``_state_dir`` — no mocks, no monkeypatch.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import importlib
 import os
 from pathlib import Path
@@ -205,7 +207,7 @@ def _write_health_spec(tmp_path: Path, name: str) -> Path:
     agent_dir.mkdir(parents=True, exist_ok=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -214,7 +216,7 @@ def _write_health_spec(tmp_path: Path, name: str) -> Path:
         "  apptainer:\n    image: /x.sif\n    binds: []\n"
         "  health:\n    enabled: true\n    interval: 60\n"
         "  restart:\n    policy: on-failure\n    max_retries: 3\n"
-        "  claude:\n    model: sonnet\n"
+        "  claude:\n    model: sonnet\n")
     )
     return spec
 

--- a/tests/scitex_agent_container/_lifecycle/test__restart_preflight_integration.py
+++ b/tests/scitex_agent_container/_lifecycle/test__restart_preflight_integration.py
@@ -136,8 +136,13 @@ def _write_spec(tmp_path: Path, name: str = "alpha") -> Path:
         "    pre_stop: []\n"
         "    post_stop: []\n"
     )
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
     spec = agent_dir / "spec.yaml"
-    spec.write_text(body)
+    # Red-start ruling 2026-07-21: every field explicit (body wins).
+    spec.write_text(explicitize_yaml(body))
     return spec
 
 

--- a/tests/scitex_agent_container/_lifecycle/test__stale_lease.py
+++ b/tests/scitex_agent_container/_lifecycle/test__stale_lease.py
@@ -366,26 +366,33 @@ def _write_zombie_spec(tmp_path: Path) -> Path:
     directory (dir-as-SSoT), so the spec must live at
     ``<name>/spec.yaml``.
     """
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
     agent_dir = tmp_path / "zombie"
     agent_dir.mkdir(parents=True, exist_ok=True)
     spec = agent_dir / "spec.yaml"
+    # Red-start ruling 2026-07-21: every field explicit (body wins).
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
-        "kind: Agent\n"
-        "spec:\n"
-        "  runtime: apptainer\n"
-        "  host: ${HOSTNAME}\n"
-        f"  workdir: {tmp_path / 'work'}\n"
-        "  apptainer:\n    image: /x.sif\n    binds: []\n"
-        "  health:\n    enabled: true\n    interval: 60\n"
-        "  restart:\n    policy: on-failure\n    max_retries: 3\n"
-        "  claude:\n"
-        "    model: sonnet\n"
-        "  hooks:\n"
-        "    pre_start: []\n"
-        "    post_start: []\n"
-        "    pre_stop: []\n"
-        "    post_stop: []\n"
+        explicitize_yaml(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            "spec:\n"
+            "  runtime: apptainer\n"
+            "  host: ${HOSTNAME}\n"
+            f"  workdir: {tmp_path / 'work'}\n"
+            "  apptainer:\n    image: /x.sif\n    binds: []\n"
+            "  health:\n    enabled: true\n    interval: 60\n"
+            "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+            "  claude:\n"
+            "    model: sonnet\n"
+            "  hooks:\n"
+            "    pre_start: []\n"
+            "    post_start: []\n"
+            "    pre_stop: []\n"
+            "    post_stop: []\n"
+        )
     )
     return spec
 

--- a/tests/scitex_agent_container/_lifecycle/test__start_drift.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_drift.py
@@ -17,6 +17,8 @@ Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import os
 import subprocess
 from pathlib import Path
@@ -105,7 +107,7 @@ def _make_spec_repo(tmp_path: Path, *, drifted: bool) -> Path:
     agent_dir.mkdir(parents=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -117,7 +119,7 @@ def _make_spec_repo(tmp_path: Path, *, drifted: bool) -> Path:
         "    model: sonnet\n"
         "  health:\n"
         "    enabled: false\n"
-        "    interval: 60\n"
+        "    interval: 60\n")
     )
     _git(work, "add", "-A")
     _git(work, "commit", "-m", "init")

--- a/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
@@ -25,6 +25,8 @@ Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import os
 from pathlib import Path
 from typing import Any, Iterator
@@ -137,7 +139,7 @@ def _write_spec(yaml_root: Path, name: str) -> Path:
     agent_dir.mkdir(parents=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -149,7 +151,7 @@ def _write_spec(yaml_root: Path, name: str) -> Path:
         "    model: sonnet\n"
         "  health:\n"
         "    enabled: false\n"
-        "    interval: 60\n"
+        "    interval: 60\n")
     )
     return spec
 

--- a/tests/scitex_agent_container/_lifecycle/test__start_verdict.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_verdict.py
@@ -26,6 +26,8 @@ no-op'd at the runtime rather than relaunched over.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import os
 from pathlib import Path
 from typing import Iterator
@@ -125,7 +127,7 @@ def _write_spec(tmp_path: Path, name: str = "alpha") -> Path:
     agent_dir.mkdir(parents=True, exist_ok=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -141,7 +143,7 @@ def _write_spec(tmp_path: Path, name: str = "alpha") -> Path:
         "    interval: 60\n"
         "  restart:\n"
         "    policy: never\n"
-        "    max_retries: 3\n"
+        "    max_retries: 3\n")
     )
     return spec
 

--- a/tests/scitex_agent_container/_lifecycle/test__status_movement.py
+++ b/tests/scitex_agent_container/_lifecycle/test__status_movement.py
@@ -12,6 +12,8 @@ separate lines; one assertion per test (STX-TQ007).
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import importlib
 import json
 import os
@@ -74,11 +76,11 @@ def _write_valid_spec(parent: Path, name: str) -> Path:
     agent_dir.mkdir(parents=True, exist_ok=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "metadata: {}\n"
         "spec:\n"
-        "  runtime: apptainer\n"
+        "  runtime: apptainer\n")
     )
     return spec
 

--- a/tests/scitex_agent_container/_lifecycle/test__stop_escalate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__stop_escalate.py
@@ -59,32 +59,39 @@ def _write_spec(tmp_path: Path, *, name: str = "alpha", runtime: str = "tui") ->
     ``load_config`` derives the agent name from the parent directory
     (dir-as-SSoT), so the file must live at ``<name>/spec.yaml``.
     """
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
     agent_dir = tmp_path / name
     agent_dir.mkdir(parents=True, exist_ok=True)
     spec = agent_dir / "spec.yaml"
+    # Red-start ruling 2026-07-21: every field explicit (body wins).
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
-        "kind: Agent\n"
-        "spec:\n"
-        f"  runtime: {runtime}\n"
-        "  host: ${HOSTNAME}\n"
-        f"  workdir: {tmp_path / 'work'}\n"
-        "  apptainer:\n"
-        "    image: /x.sif\n"
-        "    binds: []\n"
-        "  claude:\n"
-        "    model: sonnet\n"
-        "  health:\n"
-        "    enabled: true\n"
-        "    interval: 60\n"
-        "  restart:\n"
-        "    policy: on-failure\n"
-        "    max_retries: 3\n"
-        "  hooks:\n"
-        "    pre_start: []\n"
-        "    post_start: []\n"
-        "    pre_stop: []\n"
-        "    post_stop: []\n"
+        explicitize_yaml(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            "spec:\n"
+            f"  runtime: {runtime}\n"
+            "  host: ${HOSTNAME}\n"
+            f"  workdir: {tmp_path / 'work'}\n"
+            "  apptainer:\n"
+            "    image: /x.sif\n"
+            "    binds: []\n"
+            "  claude:\n"
+            "    model: sonnet\n"
+            "  health:\n"
+            "    enabled: true\n"
+            "    interval: 60\n"
+            "  restart:\n"
+            "    policy: on-failure\n"
+            "    max_retries: 3\n"
+            "  hooks:\n"
+            "    pre_start: []\n"
+            "    post_start: []\n"
+            "    pre_stop: []\n"
+            "    post_stop: []\n"
+        )
     )
     return spec
 

--- a/tests/scitex_agent_container/_lifecycle/test__stop_no_rescue.py
+++ b/tests/scitex_agent_container/_lifecycle/test__stop_no_rescue.py
@@ -166,8 +166,13 @@ def _write_spec(tmp_path: Path, workdir: Path, name: str = "alpha") -> Path:
         "    pre_stop: []\n"
         "    post_stop: []\n"
     )
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
     spec = agent_dir / "spec.yaml"
-    spec.write_text(body)
+    # Red-start ruling 2026-07-21: every field explicit (body wins).
+    spec.write_text(explicitize_yaml(body))
     return spec
 
 

--- a/tests/scitex_agent_container/_lifecycle/test__twin.py
+++ b/tests/scitex_agent_container/_lifecycle/test__twin.py
@@ -11,6 +11,8 @@ ApptainerContainerRuntime's resolver API), same as the session-seed suite.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import os
 from pathlib import Path
 
@@ -285,7 +287,7 @@ def _write_parent_spec(agents_dir: Path, name: str) -> None:
     spec_dir = agents_dir / name
     spec_dir.mkdir(parents=True, exist_ok=True)
     (spec_dir / "spec.yaml").write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -305,7 +307,7 @@ def _write_parent_spec(agents_dir: Path, name: str) -> None:
         "    method: sdk-alive\n"
         "  restart:\n"
         "    policy: never\n"
-        "    max_retries: 0\n",
+        "    max_retries: 0\n"),
         encoding="utf-8",
     )
 

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -104,8 +104,14 @@ def _write_spec(
         "    post_stop: []\n"
         f"{extra_spec}"
     )
+    # Red-start ruling 2026-07-21: merge the validator's paste defaults
+    # beneath the composed body (body wins) so every field is explicit.
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
     spec = agent_dir / "spec.yaml"
-    spec.write_text(body)
+    spec.write_text(explicitize_yaml(body))
     return spec
 
 

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -118,18 +118,25 @@ def _write_spec(home: Path, name: str, workdir: str = "/tmp") -> Path:
     """Write a minimal v3 spec.yaml that ``load_config`` will accept."""
     spec_dir = home / ".scitex" / "agent-container" / "agents" / name
     spec_dir.mkdir(parents=True, exist_ok=True)
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicit_spec,
+    )
+
+    # Red-start ruling 2026-07-21: every field explicit (curated wins).
     spec = {
         "apiVersion": "scitex-agent-container/v3",
         "kind": "Agent",
-        "spec": {
-            "runtime": "tui",
-            "host": "${HOSTNAME}",
-            "workdir": workdir,
-            "apptainer": {"image": "/x.sif", "binds": []},
-            "claude": {"model": "claude-sonnet-4-5"},
-            "health": {"enabled": True, "interval": 60},
-            "restart": {"policy": "on-failure", "max_retries": 3},
-        },
+        "spec": explicit_spec(
+            {
+                "runtime": "tui",
+                "host": "${HOSTNAME}",
+                "workdir": workdir,
+                "apptainer": {"image": "/x.sif", "binds": []},
+                "claude": {"model": "claude-sonnet-4-5"},
+                "health": {"enabled": True, "interval": 60},
+                "restart": {"policy": "on-failure", "max_retries": 3},
+            }
+        ),
     }
     p = spec_dir / "spec.yaml"
     p.write_text(yaml.safe_dump(spec), encoding="utf-8")

--- a/tests/scitex_agent_container/_listen/test_server_inline_spec_bind_translate.py
+++ b/tests/scitex_agent_container/_listen/test_server_inline_spec_bind_translate.py
@@ -90,21 +90,28 @@ def _write_parent_spec(home: Path, name: str, host_root: Path) -> Path:
     """
     spec_dir = home / ".scitex" / "agent-container" / "agents" / name
     spec_dir.mkdir(parents=True, exist_ok=True)
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicit_spec,
+    )
+
+    # Red-start ruling 2026-07-21: every field explicit (curated wins).
     spec = {
         "apiVersion": "scitex-agent-container/v3",
         "kind": "Agent",
-        "spec": {
-            "runtime": "tui",
-            "host": "${HOSTNAME}",
-            "workdir": "/tmp",
-            "apptainer": {
-                "image": "/path/to/sac-base.sif",
-                "binds": [f"{host_root}:/work"],
-            },
-            "claude": {"model": "claude-sonnet-4-5"},
-            "health": {"enabled": True, "interval": 60},
-            "restart": {"policy": "on-failure", "max_retries": 3},
-        },
+        "spec": explicit_spec(
+            {
+                "runtime": "tui",
+                "host": "${HOSTNAME}",
+                "workdir": "/tmp",
+                "apptainer": {
+                    "image": "/path/to/sac-base.sif",
+                    "binds": [f"{host_root}:/work"],
+                },
+                "claude": {"model": "claude-sonnet-4-5"},
+                "health": {"enabled": True, "interval": 60},
+                "restart": {"policy": "on-failure", "max_retries": 3},
+            }
+        ),
     }
     spec_path = spec_dir / "spec.yaml"
     spec_path.write_text(yaml.safe_dump(spec))

--- a/tests/scitex_agent_container/_listen/test_server_startup_failed.py
+++ b/tests/scitex_agent_container/_listen/test_server_startup_failed.py
@@ -100,18 +100,25 @@ def _write_spec(home: Path, name: str) -> Path:
 
     spec_dir = home / ".scitex" / "agent-container" / "agents" / name
     spec_dir.mkdir(parents=True, exist_ok=True)
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicit_spec,
+    )
+
+    # Red-start ruling 2026-07-21: every field explicit (curated wins).
     spec = {
         "apiVersion": "scitex-agent-container/v3",
         "kind": "Agent",
-        "spec": {
-            "runtime": "tui",
-            "host": "${HOSTNAME}",
-            "workdir": "/tmp",
-            "apptainer": {"image": "/x.sif", "binds": []},
-            "claude": {"model": "claude-sonnet-4-5"},
-            "health": {"enabled": True, "interval": 60},
-            "restart": {"policy": "on-failure", "max_retries": 3},
-        },
+        "spec": explicit_spec(
+            {
+                "runtime": "tui",
+                "host": "${HOSTNAME}",
+                "workdir": "/tmp",
+                "apptainer": {"image": "/x.sif", "binds": []},
+                "claude": {"model": "claude-sonnet-4-5"},
+                "health": {"enabled": True, "interval": 60},
+                "restart": {"policy": "on-failure", "max_retries": 3},
+            }
+        ),
     }
     spec_path = spec_dir / "spec.yaml"
     spec_path.write_text(yaml.safe_dump(spec))

--- a/tests/scitex_agent_container/_network/test__peer_faillloud.py
+++ b/tests/scitex_agent_container/_network/test__peer_faillloud.py
@@ -18,6 +18,8 @@ through ``resolve_config``. Conforms to STX-TQ002 (AAA markers), STX-TQ003
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import importlib
 import os
 from pathlib import Path
@@ -69,11 +71,11 @@ def _write_auto_port_yaml(tmp_path: Path) -> Path:
     y = tmp_path / "clew" / "clew.yaml"
     y.parent.mkdir(parents=True)
     y.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
-        "  a2a: {port: auto}\n"
+        "  a2a: {port: auto}\n")
     )
     return y
 
@@ -83,11 +85,11 @@ def _write_static_local_yaml(tmp_path: Path) -> Path:
     y = tmp_path / "clew" / "clew.yaml"
     y.parent.mkdir(parents=True)
     y.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
-        "  a2a: {port: 18888, host: 127.0.0.1}\n"
+        "  a2a: {port: 18888, host: 127.0.0.1}\n")
     )
     return y
 

--- a/tests/scitex_agent_container/_reconcile/_fleet.py
+++ b/tests/scitex_agent_container/_reconcile/_fleet.py
@@ -21,13 +21,22 @@ from scitex_agent_container._state import state_db
 NOW = 1_800_000_000.0
 HOST = "host-a"
 
-_SCAFFOLD: dict = {
-    "host": "${HOSTNAME}",
-    "runtime": "apptainer",
-    "claude": {"model": "claude-opus-4-8[1m]"},
-    "apptainer": {"image": "/opt/sac/scitex.sif", "binds": []},
-    "health": {"enabled": True, "interval": 60},
-}
+
+def _scaffold() -> dict:
+    """Fully-explicit spec body (red-start ruling 2026-07-21)."""
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicit_spec,
+    )
+
+    return explicit_spec(
+        {
+            "host": "${HOSTNAME}",
+            "runtime": "apptainer",
+            "claude": {"model": "claude-opus-4-8[1m]"},
+            "apptainer": {"image": "/opt/sac/scitex.sif", "binds": []},
+            "health": {"enabled": True, "interval": 60},
+        }
+    )
 
 
 class Recorder:
@@ -54,9 +63,11 @@ def write_spec(registry: Path, name: str, *, policy: str = "on-failure") -> Path
     """A real dir-as-SSoT v3 ``<name>/spec.yaml`` the loader accepts."""
     agent_dir = registry / name
     agent_dir.mkdir(parents=True, exist_ok=True)
-    body = dict(_SCAFFOLD)
+    body = _scaffold()
     body["workdir"] = f"~/.scitex/agent-container/runtime/agents/{name}"
-    body["restart"] = {"policy": policy, "max_retries": 3}
+    # Update in place — replacing the block would strip the other
+    # required restart keys (red-start ruling: all keys must stay).
+    body["restart"].update({"policy": policy, "max_retries": 3})
     spec = agent_dir / "spec.yaml"
     spec.write_text(
         _yaml.safe_dump(

--- a/tests/scitex_agent_container/_runners/test__session_http.py
+++ b/tests/scitex_agent_container/_runners/test__session_http.py
@@ -15,6 +15,8 @@ env-var isolation uses an explicit save/restore fixture.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import asyncio
 import json
 import os
@@ -251,7 +253,7 @@ def minimal_yaml(tmp_path: Path) -> Path:
     """Write the smallest viable v3 spec.yaml at the test's tmp_path root."""
     yaml_path = tmp_path / "spec.yaml"
     yaml_path.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -260,7 +262,7 @@ def minimal_yaml(tmp_path: Path) -> Path:
         "  apptainer:\n    image: /x.sif\n    binds: []\n"
         "  claude:\n    model: sonnet\n"
         "  health:\n    enabled: true\n    interval: 60\n"
-        "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+        "  restart:\n    policy: on-failure\n    max_retries: 3\n")
     )
     return yaml_path
 

--- a/tests/scitex_agent_container/_state/test_fleet_template.py
+++ b/tests/scitex_agent_container/_state/test_fleet_template.py
@@ -299,23 +299,32 @@ def cli_dry_run_result(tmp_path: Path, env_save_restore):
         encoding="utf-8",
     )
 
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
     template = tmp_path / "template.yaml"
     csv_file = tmp_path / "fleet.csv"
+    # Red-start ruling 2026-07-21: every field explicit (body wins). The
+    # merge introduces no dollar-brace tokens, so expand's leftover check
+    # stays quiet.
     _write(
         template,
-        "apiVersion: scitex-agent-container/v3\n"
-        "kind: Agent\n"
-        "spec:\n  runtime: apptainer\n"
-        # Empty host: (caller's host) — 'local' is banned; a placeholder
-        # would trip expand's leftover check, and a concrete foreign name
-        # would make the post-expand `start --dry-run` fail loud as an
-        # unregistered host.
-        "  host:\n"
-        "  workdir: /tmp/${name}\n"
-        "  apptainer:\n    image: /x.sif\n    binds: []\n"
-        "  claude:\n    model: sonnet\n"
-        "  health:\n    enabled: true\n    interval: 60\n"
-        "  restart:\n    policy: on-failure\n    max_retries: 3\n",
+        explicitize_yaml(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            "spec:\n  runtime: apptainer\n"
+            # Empty host: (caller's host) — 'local' is banned; a placeholder
+            # would trip expand's leftover check, and a concrete foreign name
+            # would make the post-expand `start --dry-run` fail loud as an
+            # unregistered host.
+            "  host:\n"
+            "  workdir: /tmp/${name}\n"
+            "  apptainer:\n    image: /x.sif\n    binds: []\n"
+            "  claude:\n    model: sonnet\n"
+            "  health:\n    enabled: true\n    interval: 60\n"
+            "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+        ),
     )
     _write(csv_file, "name\nalpha\nbeta\n")
     out_dir = tmp_path / "expanded"

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
@@ -21,8 +21,6 @@ no ``SimpleNamespace`` posing as config.
 
 from __future__ import annotations
 
-from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
-
 import json
 from contextlib import contextmanager
 from pathlib import Path
@@ -37,6 +35,7 @@ from scitex_agent_container.cli_pkg._helpers._agent_list import (
     print_agent_list,
     print_agent_list_json,
 )
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
 # ---------------------------------------------------------------------------
 # Real-fake registry — exposes the one method production uses.
@@ -157,7 +156,7 @@ def _write_valid_spec(
             "    max_retries: 3",
         ]
     )
-    spec.write_text("\n".join(lines) + "\n")
+    spec.write_text(explicitize_yaml("\n".join(lines) + "\n"))
     return spec
 
 
@@ -175,8 +174,10 @@ def _write_invalid_spec(dir_: Path) -> Path:
     dir_.mkdir(parents=True, exist_ok=True)
     spec = dir_ / "spec.yaml"
     spec.write_text(
-        explicitize_yaml("apiVersion: scitex-agent-container/v3\nkind: Agent\nmetadata: {}\n"
-        "spec:\n  runtime: docker\n")
+        explicitize_yaml(
+            "apiVersion: scitex-agent-container/v3\nkind: Agent\nmetadata: {}\n"
+            "spec:\n  runtime: docker\n"
+        )
     )
     return spec
 

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
@@ -21,6 +21,8 @@ no ``SimpleNamespace`` posing as config.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import json
 from contextlib import contextmanager
 from pathlib import Path
@@ -173,8 +175,8 @@ def _write_invalid_spec(dir_: Path) -> Path:
     dir_.mkdir(parents=True, exist_ok=True)
     spec = dir_ / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\nkind: Agent\nmetadata: {}\n"
-        "spec:\n  runtime: docker\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\nkind: Agent\nmetadata: {}\n"
+        "spec:\n  runtime: docker\n")
     )
     return spec
 

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_host_display.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_host_display.py
@@ -17,6 +17,8 @@ attributes — mirroring the sibling ``test__agent_list`` conventions.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import json
 import os
 from contextlib import contextmanager
@@ -121,7 +123,7 @@ def _write_valid_spec(dir_: Path) -> Path:
     dir_.mkdir(parents=True, exist_ok=True)
     spec = dir_ / "spec.yaml"
     spec.write_text(
-        "\n".join(
+        explicitize_yaml("\n".join(
             [
                 "apiVersion: scitex-agent-container/v3",
                 "kind: Agent",
@@ -143,7 +145,7 @@ def _write_valid_spec(dir_: Path) -> Path:
                 "    max_retries: 3",
             ]
         )
-        + "\n"
+        + "\n")
     )
     return spec
 

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_movement.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_movement.py
@@ -12,6 +12,8 @@ lines; one assertion per test (STX-TQ007).
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import importlib
 import json
 import time
@@ -61,11 +63,11 @@ def _write_valid_spec(dir_: Path) -> Path:
     dir_.mkdir(parents=True, exist_ok=True)
     spec = dir_ / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "metadata: {}\n"
         "spec:\n"
-        "  runtime: apptainer\n"
+        "  runtime: apptainer\n")
     )
     return spec
 

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_perf.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_perf.py
@@ -14,6 +14,8 @@ seams are save/restore swaps of real module attributes with real callables):
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Iterator
@@ -66,7 +68,7 @@ def _write_valid_spec(dir_: Path) -> Path:
     dir_.mkdir(parents=True, exist_ok=True)
     spec = dir_ / "spec.yaml"
     spec.write_text(
-        "\n".join(
+        explicitize_yaml("\n".join(
             [
                 "apiVersion: scitex-agent-container/v3",
                 "kind: Agent",
@@ -88,7 +90,7 @@ def _write_valid_spec(dir_: Path) -> Path:
                 "    max_retries: 3",
             ]
         )
-        + "\n"
+        + "\n")
     )
     return spec
 

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_remote.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_remote.py
@@ -179,7 +179,12 @@ def _write_valid_spec(
         "    policy: on-failure",
         "    max_retries: 3",
     ]
-    spec.write_text("\n".join(lines) + "\n")
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
+    # Red-start ruling 2026-07-21: every field explicit (body wins).
+    spec.write_text(explicitize_yaml("\n".join(lines) + "\n"))
     return spec
 
 

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__cold_start_materialize.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__cold_start_materialize.py
@@ -16,6 +16,8 @@ exercised through the production ``load_config`` / ``validate_config``).
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 from pathlib import Path
 
 import pytest
@@ -170,7 +172,7 @@ def test_existing_spec_yaml_path_passes_through(tmp_path):
     # Arrange — an explicit spec.yaml path must NOT be cold-started.
     spec = tmp_path / "foo" / "spec.yaml"
     spec.parent.mkdir(parents=True)
-    spec.write_text("apiVersion: scitex-agent-container/v3\nkind: Agent\nspec: {}\n")
+    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\nkind: Agent\nspec: {}\n"))
     # Act
     rewritten, plans = resolve_cold_start_targets(
         [str(spec)], caller_host="h", base_dir=tmp_path / "agents"

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__delete.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__delete.py
@@ -13,6 +13,8 @@ verified (TQ003-compatible), and each test asserts exactly one fact
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import os
 import shutil
 from contextlib import contextmanager
@@ -94,7 +96,7 @@ def _seed_agent(tmp_path: Path, name: str, *, spec=True, runtime=True) -> None:
     if spec:
         d = root / "agents" / name
         d.mkdir(parents=True)
-        (d / "spec.yaml").write_text("apiVersion: scitex-agent-container/v3\n")
+        (d / "spec.yaml").write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"))
     if runtime:
         rt = root / "runtime" / name
         rt.mkdir(parents=True)

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_routing.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_routing.py
@@ -81,8 +81,13 @@ def _write_spec(home: Path, name: str, host_line: str) -> Path:
         "    policy: on-failure\n"
         "    max_retries: 3\n"
     )
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
     spec = d / "spec.yaml"
-    spec.write_text(body)
+    # Red-start ruling 2026-07-21: every field explicit (body wins).
+    spec.write_text(explicitize_yaml(body))
     return spec
 
 

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
@@ -25,6 +25,8 @@ smoke tests.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import json
 import os
 import time
@@ -281,7 +283,7 @@ def _write_singleton_yaml(parent: Path, name: str, host: str) -> Path:
     sub.mkdir(parents=True, exist_ok=True)
     y = sub / f"{name}.yaml"
     y.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -293,7 +295,7 @@ def _write_singleton_yaml(parent: Path, name: str, host: str) -> Path:
         "  health:\n    enabled: true\n    interval: 60\n"
         "  restart:\n    policy: on-failure\n    max_retries: 3\n"
         "  claude:\n"
-        "    model: haiku\n"
+        "    model: haiku\n")
     )
     return y
 
@@ -753,7 +755,7 @@ def _write_local_spec_with_a2a(home: Path, name: str, *, a2a_port: Any) -> Path:
     yaml_path = agents_dir / f"{name}.yaml"
     port_line = "null" if a2a_port is None else json.dumps(a2a_port)
     yaml_path.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "metadata: {}\n"
         "spec:\n"
@@ -764,7 +766,7 @@ def _write_local_spec_with_a2a(home: Path, name: str, *, a2a_port: Any) -> Path:
         "  claude:\n    model: sonnet\n"
         "  health:\n    enabled: true\n    interval: 60\n"
         "  restart:\n    policy: on-failure\n    max_retries: 3\n"
-        f"  a2a:\n    port: {port_line}\n"
+        f"  a2a:\n    port: {port_line}\n")
     )
     return yaml_path
 
@@ -959,7 +961,7 @@ def _write_group_agent_spec(home: Path, name: str, *, host: str, groups_yaml: st
     d.mkdir(parents=True)
     y = d / "spec.yaml"
     y.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "metadata:\n"
         "  labels:\n"
@@ -973,7 +975,7 @@ def _write_group_agent_spec(home: Path, name: str, *, host: str, groups_yaml: st
         "    binds: []\n"
         "  health:\n    enabled: true\n    interval: 60\n"
         "  restart:\n    policy: on-failure\n    max_retries: 3\n"
-        "  claude:\n    model: haiku\n"
+        "  claude:\n    model: haiku\n")
     )
     return y
 

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_force_clears_session.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_force_clears_session.py
@@ -162,8 +162,13 @@ def _write_spec(workdir_root: Path, *, name: str = "alpha") -> Path:
         "    pre_stop: []\n"
         "    post_stop: []\n"
     )
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
     spec = agent_dir / "spec.yaml"
-    spec.write_text(body)
+    # Red-start ruling 2026-07-21: every field explicit (body wins).
+    spec.write_text(explicitize_yaml(body))
     return spec
 
 

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_group_filter.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_group_filter.py
@@ -16,6 +16,8 @@ AAA, one assertion per test, no mocks/monkeypatch (STX-NM002).
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import os
 from pathlib import Path
 
@@ -38,7 +40,7 @@ def _write_agent_spec(agents_root: Path, name: str, *, groups_yaml: str) -> Path
     d = agents_root / name
     d.mkdir(parents=True)
     (d / "spec.yaml").write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "metadata:\n"
         "  labels:\n"
@@ -50,7 +52,7 @@ def _write_agent_spec(agents_root: Path, name: str, *, groups_yaml: str) -> Path
         "  apptainer:\n    image: /x.sif\n    binds: []\n"
         "  health:\n    enabled: true\n    interval: 60\n"
         "  restart:\n    policy: on-failure\n    max_retries: 3\n"
-        "  claude:\n    model: sonnet\n"
+        "  claude:\n    model: sonnet\n")
     )
     return d / "spec.yaml"
 
@@ -175,7 +177,7 @@ class TestResolveGroupTargets:
         d = isolated_agents_root / "ungrouped"
         d.mkdir()
         (d / "spec.yaml").write_text(
-            "apiVersion: scitex-agent-container/v3\n"
+            explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
             "kind: Agent\n"
             "spec:\n"
             "  runtime: tui\n"
@@ -184,7 +186,7 @@ class TestResolveGroupTargets:
             "  apptainer:\n    image: /x.sif\n    binds: []\n"
             "  health:\n    enabled: true\n    interval: 60\n"
             "  restart:\n    policy: on-failure\n    max_retries: 3\n"
-            "  claude:\n    model: sonnet\n"
+            "  claude:\n    model: sonnet\n")
         )
         # Act
         result = resolve_group_targets(("developer",))

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_preflight.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_preflight.py
@@ -21,6 +21,8 @@ preflight) reads ``$HOME`` on linux, so the redirect is honoured.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import json
 from pathlib import Path
 
@@ -205,7 +207,7 @@ def _install_provider_spec(
     agent_dir.mkdir(parents=True, exist_ok=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -220,7 +222,7 @@ def _install_provider_spec(
         "    image: /nonexistent/dummy.sif\n"
         "    binds: []\n"
         "  health:\n    enabled: true\n    interval: 60\n"
-        "  restart:\n    policy: on-failure\n    max_retries: 3\n",
+        "  restart:\n    policy: on-failure\n    max_retries: 3\n"),
         encoding="utf-8",
     )
     return spec
@@ -232,7 +234,7 @@ def _install_anthropic_spec(yaml_dir: Path, name: str) -> Path:
     agent_dir.mkdir(parents=True, exist_ok=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -243,7 +245,7 @@ def _install_anthropic_spec(yaml_dir: Path, name: str) -> Path:
         "    image: /nonexistent/dummy.sif\n"
         "    binds: []\n"
         "  health:\n    enabled: true\n    interval: 60\n"
-        "  restart:\n    policy: on-failure\n    max_retries: 3\n",
+        "  restart:\n    policy: on-failure\n    max_retries: 3\n"),
         encoding="utf-8",
     )
     return spec

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_assume_yes.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_assume_yes.py
@@ -23,6 +23,8 @@ assertion (TQ007), 3+-word name.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import json
 import os
 from pathlib import Path
@@ -109,7 +111,7 @@ def _write_spec(yaml_root: Path, name: str) -> Path:
     agent_dir.mkdir(parents=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -121,7 +123,7 @@ def _write_spec(yaml_root: Path, name: str) -> Path:
         "    model: sonnet\n"
         "  health:\n"
         "    enabled: false\n"
-        "    interval: 60\n"
+        "    interval: 60\n")
     )
     return spec
 

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_verbose_plan.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_verbose_plan.py
@@ -36,6 +36,8 @@ back via ``caplog`` (a real pytest log-capture fixture, not a mock).
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import logging
 import os
 import pty
@@ -76,7 +78,7 @@ def _write_local_spec(home: Path, name: str) -> Path:
     agents_dir.mkdir(parents=True)
     yaml_path = agents_dir / f"{name}.yaml"
     yaml_path.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         # sac-builtin: off — opts out of the default server:sac push channel,
         # which otherwise requires a live `sac listen` bearer token file this
@@ -91,7 +93,7 @@ def _write_local_spec(home: Path, name: str) -> Path:
         "  claude:\n    model: sonnet\n"
         "  health:\n    enabled: true\n    interval: 60\n"
         "  restart:\n    policy: on-failure\n    max_retries: 3\n"
-        "  a2a:\n    port: null\n"
+        "  a2a:\n    port: null\n")
     )
     return yaml_path
 

--- a/tests/scitex_agent_container/cli_pkg/test__account_refresh_pinned_running.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_refresh_pinned_running.py
@@ -21,6 +21,8 @@ AAA marker comments; one assertion per test; ≥3-word names.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import json
 from pathlib import Path
 from typing import Any, Iterator
@@ -77,7 +79,7 @@ def _write_pinned_spec(parent: Path, *, name: str, account: str) -> Path:
     spec_dir.mkdir(parents=True, exist_ok=True)
     spec = spec_dir / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -88,7 +90,7 @@ def _write_pinned_spec(parent: Path, *, name: str, account: str) -> Path:
         "  restart:\n    policy: on-failure\n    max_retries: 3\n"
         f"  claude:\n"
         f"    account: {account}\n"
-        "    model: sonnet\n"
+        "    model: sonnet\n")
     )
     return spec
 
@@ -98,7 +100,7 @@ def _write_unpinned_spec(parent: Path, *, name: str) -> Path:
     spec_dir.mkdir(parents=True, exist_ok=True)
     spec = spec_dir / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -107,7 +109,7 @@ def _write_unpinned_spec(parent: Path, *, name: str) -> Path:
         "  apptainer:\n    image: /x.sif\n    binds: []\n"
         "  claude:\n    model: sonnet\n"
         "  health:\n    enabled: true\n    interval: 60\n"
-        "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+        "  restart:\n    policy: on-failure\n    max_retries: 3\n")
     )
     return spec
 

--- a/tests/scitex_agent_container/cli_pkg/test__agent_prune_claude.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agent_prune_claude.py
@@ -8,6 +8,8 @@ assert per test.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_spec
+
 import json
 import os
 import shutil
@@ -511,7 +513,7 @@ def _registered(tmp_path: Path, env_save_restore):
             {
                 "apiVersion": "scitex-agent-container/v3",
                 "kind": "Agent",
-                "spec": {
+                "spec": explicit_spec({
                     "runtime": "apptainer",
                     "host": "${HOSTNAME}",
                     "workdir": str(workdir),
@@ -519,7 +521,7 @@ def _registered(tmp_path: Path, env_save_restore):
                     "claude": {"model": "sonnet"},
                     "health": {"enabled": True, "interval": 60},
                     "restart": {"policy": "on-failure", "max_retries": 3},
-                },
+                }),
             }
         )
     )

--- a/tests/scitex_agent_container/cli_pkg/test__create.py
+++ b/tests/scitex_agent_container/cli_pkg/test__create.py
@@ -23,6 +23,7 @@ from click.testing import CliRunner
 
 from scitex_agent_container.cli_pkg._create import create as create_cmd
 from scitex_agent_container.config._validation import validate_config
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
 
 def test_create_writes_spec_yaml_at_target(tmp_path: Path) -> None:
@@ -194,8 +195,10 @@ def test_create_default_template_is_minimal(tmp_path: Path) -> None:
     # the prose docstring (the comment legitimately MENTIONS the field
     # name as an "add this if you need it" pointer).
     parsed = yaml.safe_load((base / "defaulty" / "spec.yaml").read_text())
-    # Assert — minimal template omits startup_prompts; the full template ships it.
-    assert "startup_prompts" not in parsed.get("spec", {})
+    # Assert — minimal template ships an EMPTY startup_prompts (explicit-fields
+    # ruling 2026-07-21: the key must be present); the full template ships a
+    # non-empty kick. Empty distinguishes the default=minimal rendering.
+    assert parsed["spec"]["startup_prompts"] == []
 
 
 def test_create_creates_to_home_skeleton(tmp_path: Path) -> None:
@@ -319,6 +322,11 @@ spec:
 # EOF
 """
 
+# Red-start ruling 2026-07-21: fixture templates must carry EVERY field.
+# The readable minimal body above stays the authored surface; the merge
+# fills the remainder with the validator's own paste defaults.
+_DEMO_SPEC = explicitize_yaml(_DEMO_SPEC)
+
 
 def _make_demo_template(base: Path, *, extra_token: str | None = None) -> Path:
     """Create a fake ``_template_demo/`` dir under ``base`` and return it.
@@ -346,9 +354,7 @@ def _no_placeholder_remains(agent_dir: Path) -> bool:
     return True
 
 
-def _invoke_demo(
-    runner: CliRunner, base: Path, name: str, *extra_args: str
-) -> object:
+def _invoke_demo(runner: CliRunner, base: Path, name: str, *extra_args: str) -> object:
     """Instantiate the demo dir-template under ``base`` and return result."""
     return runner.invoke(
         create_cmd,
@@ -426,7 +432,15 @@ def test_create_dir_template_agent_id_defaults_to_name(tmp_path: Path) -> None:
     # Act — omit --agent-id; it must default to <name>.
     runner.invoke(
         create_cmd,
-        ["nameddefault", "--base-dir", str(base), "--template", "demo", "--project", "p"],
+        [
+            "nameddefault",
+            "--base-dir",
+            str(base),
+            "--template",
+            "demo",
+            "--project",
+            "p",
+        ],
     )
     text = (base / "nameddefault" / "to_home" / "CLAUDE.md").read_text()
     # Assert
@@ -455,7 +469,9 @@ def test_create_dir_template_missing_placeholder_names_token(tmp_path: Path) -> 
     assert "SAC_PLACEHOLDER_PROJECT" in result.output
 
 
-def test_create_dir_template_missing_placeholder_leaves_no_output(tmp_path: Path) -> None:
+def test_create_dir_template_missing_placeholder_leaves_no_output(
+    tmp_path: Path,
+) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
@@ -515,9 +531,7 @@ def test_create_inline_minimal_still_works_with_dir_templates_present(
     base = tmp_path / "agents"
     _make_demo_template(base)
     # Act
-    runner.invoke(
-        create_cmd, ["inl", "--base-dir", str(base), "--template", "minimal"]
-    )
+    runner.invoke(create_cmd, ["inl", "--base-dir", str(base), "--template", "minimal"])
     errors = validate_config(base / "inl" / "spec.yaml")
     # Assert
     assert errors == []
@@ -597,6 +611,13 @@ _SCIENTIST_DEMO_SPEC = _DEVELOPER_DEMO_SPEC.replace(
     "SAC_PLACEHOLDER_PROJECT-maintainer", "SAC_PLACEHOLDER_PROJECT-research"
 ).replace("groups: [developer]", "groups: [scientist]")
 
+# Red-start ruling 2026-07-21: fixture templates must carry EVERY field
+# (merged from the validator's own paste defaults; minimal body stays
+# the authored surface). Derive scientist from developer BEFORE the
+# merge so the string replaces still hit the readable bodies.
+_DEVELOPER_DEMO_SPEC = explicitize_yaml(_DEVELOPER_DEMO_SPEC)
+_SCIENTIST_DEMO_SPEC = explicitize_yaml(_SCIENTIST_DEMO_SPEC)
+
 
 def _write_dir_template(base: Path, kind: str, body: str) -> Path:
     """Create a fake ``_template_<kind>/`` dir under ``base`` and return it."""
@@ -614,7 +635,15 @@ def test_create_developer_template_leaves_no_placeholder(tmp_path: Path) -> None
     # Act
     runner.invoke(
         create_cmd,
-        ["dev1", "--base-dir", str(base), "--template", "developer", "--project", "myproj"],
+        [
+            "dev1",
+            "--base-dir",
+            str(base),
+            "--template",
+            "developer",
+            "--project",
+            "myproj",
+        ],
     )
     # Assert
     assert _no_placeholder_remains(base / "dev1")
@@ -628,7 +657,15 @@ def test_create_developer_template_validates(tmp_path: Path) -> None:
     # Act
     runner.invoke(
         create_cmd,
-        ["dev2", "--base-dir", str(base), "--template", "developer", "--project", "myproj"],
+        [
+            "dev2",
+            "--base-dir",
+            str(base),
+            "--template",
+            "developer",
+            "--project",
+            "myproj",
+        ],
     )
     errors = validate_config(base / "dev2" / "spec.yaml")
     # Assert
@@ -643,7 +680,15 @@ def test_create_developer_template_group_label(tmp_path: Path) -> None:
     # Act
     runner.invoke(
         create_cmd,
-        ["dev3", "--base-dir", str(base), "--template", "developer", "--project", "myproj"],
+        [
+            "dev3",
+            "--base-dir",
+            str(base),
+            "--template",
+            "developer",
+            "--project",
+            "myproj",
+        ],
     )
     parsed = yaml.safe_load((base / "dev3" / "spec.yaml").read_text())
     # Assert
@@ -658,7 +703,15 @@ def test_create_scientist_template_leaves_no_placeholder(tmp_path: Path) -> None
     # Act
     runner.invoke(
         create_cmd,
-        ["sci1", "--base-dir", str(base), "--template", "scientist", "--project", "paperx"],
+        [
+            "sci1",
+            "--base-dir",
+            str(base),
+            "--template",
+            "scientist",
+            "--project",
+            "paperx",
+        ],
     )
     # Assert
     assert _no_placeholder_remains(base / "sci1")
@@ -672,7 +725,15 @@ def test_create_scientist_template_validates(tmp_path: Path) -> None:
     # Act
     runner.invoke(
         create_cmd,
-        ["sci2", "--base-dir", str(base), "--template", "scientist", "--project", "paperx"],
+        [
+            "sci2",
+            "--base-dir",
+            str(base),
+            "--template",
+            "scientist",
+            "--project",
+            "paperx",
+        ],
     )
     errors = validate_config(base / "sci2" / "spec.yaml")
     # Assert
@@ -687,7 +748,15 @@ def test_create_scientist_template_group_label(tmp_path: Path) -> None:
     # Act
     runner.invoke(
         create_cmd,
-        ["sci3", "--base-dir", str(base), "--template", "scientist", "--project", "paperx"],
+        [
+            "sci3",
+            "--base-dir",
+            str(base),
+            "--template",
+            "scientist",
+            "--project",
+            "paperx",
+        ],
     )
     parsed = yaml.safe_load((base / "sci3" / "spec.yaml").read_text())
     # Assert
@@ -702,7 +771,15 @@ def test_create_scientist_template_purpose_suffix(tmp_path: Path) -> None:
     # Act
     runner.invoke(
         create_cmd,
-        ["sci4", "--base-dir", str(base), "--template", "scientist", "--project", "paperx"],
+        [
+            "sci4",
+            "--base-dir",
+            str(base),
+            "--template",
+            "scientist",
+            "--project",
+            "paperx",
+        ],
     )
     parsed = yaml.safe_load((base / "sci4" / "spec.yaml").read_text())
     # Assert — scientist purpose is the research suffix (mirrors retired `create`).

--- a/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
@@ -17,6 +17,8 @@ collaborators are real:
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import json
 import os
 import shutil
@@ -435,7 +437,7 @@ def live_serve_yaml(tmp_path: Path) -> Path:
     agent_dir.mkdir()
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "metadata:\n"
         f"  name: {name}\n"
@@ -443,7 +445,7 @@ def live_serve_yaml(tmp_path: Path) -> Path:
         "  a2a:\n"
         "    host: 127.0.0.1\n"
         "    port: 0\n"
-        "    handler: echo\n"
+        "    handler: echo\n")
     )
     return spec
 
@@ -523,7 +525,7 @@ def live_doctor_against_serve(tmp_path: Path) -> Iterator[dict]:
     spec = agent_dir / "spec.yaml"
     port = _free_port()
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "metadata:\n"
         f"  name: {name}\n"
@@ -531,7 +533,7 @@ def live_doctor_against_serve(tmp_path: Path) -> Iterator[dict]:
         "  a2a:\n"
         "    host: 127.0.0.1\n"
         f"    port: {port}\n"
-        "    handler: echo\n"
+        "    handler: echo\n")
     )
     cmd = _sac_cmd() + [
         "a2a",

--- a/tests/scitex_agent_container/cli_pkg/test_agents_prune_claude.py
+++ b/tests/scitex_agent_container/cli_pkg/test_agents_prune_claude.py
@@ -9,6 +9,8 @@ to trip the per-subdir bloat threshold (default 1,000 files).
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_spec
+
 from pathlib import Path
 
 import pytest
@@ -157,7 +159,7 @@ def _registered(tmp_path: Path, env_save_restore):
             {
                 "apiVersion": "scitex-agent-container/v3",
                 "kind": "Agent",
-                "spec": {
+                "spec": explicit_spec({
                     "runtime": "apptainer",
                     "host": "${HOSTNAME}",
                     "workdir": str(workdir),
@@ -165,7 +167,7 @@ def _registered(tmp_path: Path, env_save_restore):
                     "claude": {"model": "sonnet"},
                     "health": {"enabled": True, "interval": 60},
                     "restart": {"policy": "on-failure", "max_retries": 3},
-                },
+                }),
             }
         )
     )
@@ -237,7 +239,7 @@ def test_cli_no_bloat_emits_no_op_message(tmp_path: Path, env_save_restore):
             {
                 "apiVersion": "scitex-agent-container/v3",
                 "kind": "Agent",
-                "spec": {
+                "spec": explicit_spec({
                     "runtime": "apptainer",
                     "host": "${HOSTNAME}",
                     "workdir": str(workdir),
@@ -245,7 +247,7 @@ def test_cli_no_bloat_emits_no_op_message(tmp_path: Path, env_save_restore):
                     "claude": {"model": "sonnet"},
                     "health": {"enabled": True, "interval": 60},
                     "restart": {"policy": "on-failure", "max_retries": 3},
-                },
+                }),
             }
         )
     )

--- a/tests/scitex_agent_container/cli_pkg/test_build_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_build_cmds.py
@@ -60,6 +60,14 @@ spec:
     max_retries: 3
 """
 
+# Red-start ruling 2026-07-21: the VALID fixture must carry every field.
+# Merged once at import; deliberately-invalid bodies below stay raw.
+from tests.scitex_agent_container._helpers.explicit_spec import (  # noqa: E402
+    explicitize_yaml as _explicitize_yaml,
+)
+
+_MINIMAL_VALID_SPEC = _explicitize_yaml(_MINIMAL_VALID_SPEC)
+
 
 def _write_spec(tmp_path: Path, body: str = _MINIMAL_VALID_SPEC) -> Path:
     spec = tmp_path / "spec.yaml"
@@ -90,7 +98,7 @@ def _write_spec_with_binds(tmp_path: Path, binds: list[str]) -> Path:
         "    binds:\n"
         f"{bind_lines}\n"
     )
-    return _write_spec(tmp_path, body)
+    return _write_spec(tmp_path, _explicitize_yaml(body))
 
 
 @contextmanager

--- a/tests/scitex_agent_container/cli_pkg/test_info_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_info_cmds.py
@@ -24,6 +24,8 @@ version exercises real production collaborators:
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import importlib
 import json
 import os
@@ -50,7 +52,7 @@ def _write_spec_dir(tmp_path: Path, name: str, caps: str = "HPC,GPU") -> Path:
     d.mkdir()
     spec = d / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "metadata:\n"
         f"  labels:\n    capabilities: '{caps}'\n    machine: m1\n"
@@ -60,7 +62,7 @@ def _write_spec_dir(tmp_path: Path, name: str, caps: str = "HPC,GPU") -> Path:
         "  apptainer:\n    image: /x.sif\n    binds: []\n"
         "  claude:\n    model: sonnet\n"
         "  health:\n    enabled: true\n    interval: 60\n"
-        "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+        "  restart:\n    policy: on-failure\n    max_retries: 3\n")
     )
     return spec
 

--- a/tests/scitex_agent_container/cli_pkg/test_priority_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_priority_cmds.py
@@ -75,15 +75,21 @@ def _write_spec(
         "    max_retries: 3",
     ]
     if hosts is not None:
-        # multi-instance → workdir auto-derives per host (not required).
+        # multi-instance → workdir: null keeps the per-instance derivation
+        # (the KEY is still required; red-start ruling 2026-07-21).
         lines.append(f"  hosts: {json.dumps(hosts)}")
+        lines.append("  workdir:")
     else:
         # singleton (explicit host, or the local default) → workdir required.
         # 'local' is banned; an EMPTY host: is the caller's-host spelling
         # for the no-host-declared case.
         lines.append(f"  host: {json.dumps(host)}" if host is not None else "  host:")
         lines.append("  workdir: /home/agent/work")
-    spec.write_text("\n".join(lines) + "\n")
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
+    spec.write_text(explicitize_yaml("\n".join(lines) + "\n"))
     return spec
 
 

--- a/tests/scitex_agent_container/cli_pkg/test_refresh_acl.py
+++ b/tests/scitex_agent_container/cli_pkg/test_refresh_acl.py
@@ -49,21 +49,29 @@ def db_path(tmp_path: Path):
             os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
 
 
-_REQUIRED_SCAFFOLD: dict = {
-    "host": "${HOSTNAME}",
-    "runtime": "apptainer",
-    "claude": {"model": "claude-opus-4-8[1m]"},
-    "apptainer": {"image": "/opt/sac/scitex.sif", "binds": []},
-    "health": {"enabled": True, "interval": 60},
-    "restart": {"policy": "on-failure", "max_retries": 3},
-}
+def _required_scaffold() -> dict:
+    """Fully-explicit scaffold (red-start ruling 2026-07-21)."""
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicit_spec,
+    )
+
+    return explicit_spec(
+        {
+            "host": "${HOSTNAME}",
+            "runtime": "apptainer",
+            "claude": {"model": "claude-opus-4-8[1m]"},
+            "apptainer": {"image": "/opt/sac/scitex.sif", "binds": []},
+            "health": {"enabled": True, "interval": 60},
+            "restart": {"policy": "on-failure", "max_retries": 3},
+        }
+    )
 
 
 def _write_spec(registry: Path, name: str, labels: dict | None) -> Path:
     """Write a dir-as-SSoT v3 ``<name>/spec.yaml`` under ``registry``."""
     agent_dir = registry / name
     agent_dir.mkdir(parents=True)
-    spec_body = dict(_REQUIRED_SCAFFOLD)
+    spec_body = _required_scaffold()
     spec_body["workdir"] = f"~/.scitex/agent-container/runtime/agents/{name}"
     metadata = {"labels": labels} if labels is not None else {}
     spec_path = agent_dir / "spec.yaml"

--- a/tests/scitex_agent_container/cli_pkg/test_send_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_send_cmds.py
@@ -15,6 +15,8 @@ into ``pytest.parametrize`` so the matrix stays declarative.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import os
 from contextlib import contextmanager
 from pathlib import Path
@@ -62,7 +64,7 @@ def _seed_agent(tmp_path: Path, name: str, session_id: str) -> Path:
     agent_dir = yaml_root / name
     agent_dir.mkdir(parents=True)
     (agent_dir / "spec.yaml").write_text(
-        f"""apiVersion: scitex-agent-container/v3
+        explicitize_yaml(f"""apiVersion: scitex-agent-container/v3
 kind: Agent
 spec:
   runtime: apptainer
@@ -79,7 +81,7 @@ spec:
   restart:
     policy: on-failure
     max_retries: 3
-"""
+""")
     )
     (tmp_path / "workdir").mkdir()
     state_dir = tmp_path / "state" / name

--- a/tests/scitex_agent_container/cli_pkg/test_status_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_status_cmds.py
@@ -29,6 +29,8 @@ production collaborators:
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import importlib
 import json
 from pathlib import Path
@@ -82,7 +84,7 @@ def _write_spec(parent: Path, name: str, *, body: str | None = None) -> Path:
     agent_dir.mkdir(parents=True, exist_ok=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        body
+        explicitize_yaml(body
         if body is not None
         else (
             "apiVersion: scitex-agent-container/v3\n"
@@ -103,7 +105,7 @@ def _write_spec(parent: Path, name: str, *, body: str | None = None) -> Path:
             "  restart:\n"
             "    policy: on-failure\n"
             "    max_retries: 3\n"
-        )
+        ))
     )
     return spec
 

--- a/tests/scitex_agent_container/cli_pkg/test_status_cmds_workdir_audit.py
+++ b/tests/scitex_agent_container/cli_pkg/test_status_cmds_workdir_audit.py
@@ -46,18 +46,25 @@ def _register_agent_with_workdir(name: str, workdir: Path) -> Path:
     home = Path.home()
     agents_dir = home / ".scitex" / "agent-container" / "agents" / name
     agents_dir.mkdir(parents=True, exist_ok=True)
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicit_spec,
+    )
+
+    # Red-start ruling 2026-07-21: every field explicit (curated wins).
     spec = {
         "apiVersion": "scitex-agent-container/v3",
         "kind": "Agent",
-        "spec": {
-            "runtime": "apptainer",
-            "host": "${HOSTNAME}",
-            "workdir": str(workdir),
-            "apptainer": {"image": "/x.sif", "binds": []},
-            "claude": {"model": "sonnet"},
-            "health": {"enabled": True, "interval": 60},
-            "restart": {"policy": "on-failure", "max_retries": 3},
-        },
+        "spec": explicit_spec(
+            {
+                "runtime": "apptainer",
+                "host": "${HOSTNAME}",
+                "workdir": str(workdir),
+                "apptainer": {"image": "/x.sif", "binds": []},
+                "claude": {"model": "sonnet"},
+                "health": {"enabled": True, "interval": 60},
+                "restart": {"policy": "on-failure", "max_retries": 3},
+            }
+        ),
     }
     spec_path = agents_dir / "spec.yaml"
     spec_path.write_text(yaml.safe_dump(spec))

--- a/tests/scitex_agent_container/config/_parsers/test__proxy.py
+++ b/tests/scitex_agent_container/config/_parsers/test__proxy.py
@@ -226,21 +226,29 @@ def test_parse_proxy_invalid_timeout_raises_value_error(timeout_value) -> None:
 
 
 def _base_proxy_raw(**overrides) -> dict:
+    # Red-start ruling 2026-07-21: every field explicit — merged onto the
+    # validator's own AgentProxy paste defaults (curated fields win). A
+    # proxy has NO claude block (forbidden for kind: AgentProxy);
+    # proxy.upstream is its kind-specific required field.
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicit_spec,
+    )
+
     raw = {
         "apiVersion": "scitex-agent-container/v3",
         "kind": "AgentProxy",
-        "spec": {
-            # Required author fields (no hidden defaults). A proxy has NO
-            # claude block (forbidden for kind: AgentProxy); proxy.upstream is
-            # its kind-specific required field.
-            "runtime": "tui",
-            "host": "${HOSTNAME}",
-            "workdir": "/home/agent/work",
-            "apptainer": {"image": "/x.sif", "binds": []},
-            "health": {"enabled": True, "interval": 60},
-            "restart": {"policy": "always", "max_retries": 3},
-            "proxy": {"upstream": "https://peer.example.com"},
-        },
+        "spec": explicit_spec(
+            {
+                "runtime": "tui",
+                "host": "${HOSTNAME}",
+                "workdir": "/home/agent/work",
+                "apptainer": {"image": "/x.sif", "binds": []},
+                "health": {"enabled": True, "interval": 60},
+                "restart": {"policy": "always", "max_retries": 3},
+                "proxy": {"upstream": "https://peer.example.com"},
+            },
+            kind="AgentProxy",
+        ),
     }
     raw["spec"].update(overrides)
     return raw

--- a/tests/scitex_agent_container/config/test__explicit_validation.py
+++ b/tests/scitex_agent_container/config/test__explicit_validation.py
@@ -1,0 +1,385 @@
+"""Tests for config._explicit_validation (red-start ruling 2026-07-21).
+
+EVERY spec field must be written explicitly; an omitted field is a load
+ERROR listing all missing fields at once with a paste-ready hint that
+actually clears the condition (round-trip proven — the fleet has an
+incident memory about hints that do not clear their own gate).
+
+The GREEN fixture below is HAND-WRITTEN field by field (not generated
+from the production map) so the map and the fixture cannot agree by
+construction; the mutation-proof parametrization then shows each
+sampled field's absence turns the load RED naming that exact path.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scitex_agent_container.config import load_config
+from scitex_agent_container.config._explicit_validation import (
+    PASTE_BEGIN,
+    PASTE_END,
+    ExplicitSpecError,
+    validate,
+)
+
+# Hand-written, fully-explicit kind: Agent spec — every required field
+# spelled out (86 fields + placement).
+_EXPLICIT_YAML = """
+apiVersion: scitex-agent-container/v3
+kind: Agent
+spec:
+  runtime: tui
+  provider: anthropic
+  host: ${HOSTNAME}
+  workdir: /home/agent/work
+  python-venv: ""
+  startup_commands: []
+  startup_prompts: []
+  listen: []
+  extensions: {}
+  mcp_servers: {}
+  user: ""
+  to_home: ./to_home
+  container:
+    runtime: none
+    image: scitex-agent-container:latest
+    volumes: []
+    network: host
+    mount_host_claude: false
+  claude:
+    model: sonnet
+    channels: []
+    flags: []
+    raw_options: {}
+    session: fresh
+    continue_max_age_minutes: null
+    resume_id: ""
+    auto_accept: true
+    account: ""
+    credentials_file: ""
+    credentials_files: []
+    provider: null
+  health:
+    enabled: true
+    interval: 60
+    timeout: 5
+    method: sdk-alive
+  watchdog:
+    enabled: false
+    interval: 1.5
+    responses:
+      y_n: "1"
+      y_y_n: "2"
+      waiting: /speak-and-call
+  restart:
+    policy: never
+    max_retries: 3
+    prune_on_stop: false
+    backoff:
+      initial: 30
+      max: 300
+      multiplier: 2
+  autonomous:
+    enabled: false
+    drive_until: DONE
+    max_turns: 50
+    idle_kick_after_s: 120
+    kick_text: Continue. Print DONE when finished.
+  apptainer:
+    image: /opt/sac/scitex.sif
+    binds: []
+    env: {}
+    raw_args: []
+    post: ""
+    environment: {}
+    def_file: ""
+    nv: false
+    rocm: false
+    overlay: ""
+    overlay_size: ""
+    overlay_create_if_missing: true
+    tmpfs_size: 2G
+    relaxed: false
+    fakeroot: false
+    jail: false
+    nested_build: false
+  hooks:
+    pre_start: []
+    post_start: []
+    pre_stop: []
+    post_stop: []
+    on_compact: []
+    on_restart: []
+    on_diff: []
+  context_management:
+    trigger_at_percent: 70.0
+    strategy: noop
+    warn_before_n_checks: 0
+    check_interval_seconds: 300
+    state_file: ~/.scitex/agent-container/state/<agent>.json
+  a2a:
+    host: 127.0.0.1
+    port: auto
+  comms:
+    outbound:
+      siblings: allow
+      parent: allow
+    inbound:
+      siblings: allow
+      parent: allow
+    a2a:
+      listen: true
+  lineage:
+    group: ""
+    may_spawn: true
+"""
+
+
+def _explicit_doc() -> dict:
+    return yaml.safe_load(_EXPLICIT_YAML)
+
+
+def _write_doc(tmp_path: Path, doc: dict, name: str = "explicit-agent") -> Path:
+    agent_dir = tmp_path / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    path = agent_dir / "spec.yaml"
+    path.write_text(yaml.safe_dump(doc))
+    return path
+
+
+def _remove(doc: dict, dotted: str) -> dict:
+    out = copy.deepcopy(doc)
+    cur = out["spec"]
+    parts = dotted.split(".")
+    for part in parts[:-1]:
+        cur = cur[part]
+    del cur[parts[-1]]
+    return out
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    out = copy.deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(out.get(key), dict):
+            out[key] = _deep_merge(out[key], value)
+        else:
+            out[key] = value
+    return out
+
+
+def _red_error(path: Path) -> ValueError:
+    """Load a spec expected to be RED; return the raised error."""
+    with pytest.raises(ValueError) as excinfo:
+        load_config(path)
+    return excinfo.value
+
+
+def _raised_by(action) -> ValueError:
+    """Run ``action`` expected to raise; return the raised error."""
+    with pytest.raises(ValueError) as excinfo:
+        action()
+    return excinfo.value
+
+
+def _healed_doc(doc: dict, error: ValueError) -> dict:
+    """Merge the error's paste-ready block back into ``doc``."""
+    block = str(error).split(PASTE_BEGIN)[1].split(PASTE_END)[0]
+    return _deep_merge(doc, yaml.safe_load(block))
+
+
+# ---------------------------------------------------------------------------
+# GREEN: the hand-written fully-explicit spec loads.
+# ---------------------------------------------------------------------------
+
+
+def test_fully_explicit_spec_loads_green(tmp_path: Path) -> None:
+    # Arrange
+    path = _write_doc(tmp_path, _explicit_doc())
+    # Act
+    cfg = load_config(path)
+    # Assert
+    assert cfg.name == "explicit-agent"
+
+
+# ---------------------------------------------------------------------------
+# MUTATION-PROOF: removing any sampled field turns the load RED and the
+# error names that exact YAML path. Sample spans top-level, claude,
+# apptainer, health, watchdog, a2a (+ restart/comms/context_management).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "dotted",
+    [
+        "runtime",
+        "workdir",
+        "to_home",
+        "claude.model",
+        "claude.session",
+        "apptainer.binds",
+        "apptainer.tmpfs_size",
+        "health.method",
+        "watchdog.responses.y_n",
+        "a2a.port",
+        "restart.backoff.initial",
+        "comms.a2a.listen",
+        "context_management.strategy",
+    ],
+)
+def test_removing_field_turns_load_red_naming_exact_path(
+    tmp_path: Path, dotted: str
+) -> None:
+    # Arrange
+    path = _write_doc(tmp_path, _remove(_explicit_doc(), dotted))
+    # Act
+    error = _red_error(path)
+    # Assert
+    assert f"spec.{dotted}" in str(error)
+
+
+# ---------------------------------------------------------------------------
+# Completeness: several missing fields are ALL listed in ONE error.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _three_missing_error(tmp_path: Path) -> str:
+    """Error message for a spec missing three fields across sections."""
+    doc = _explicit_doc()
+    for dotted in ("runtime", "claude.session", "a2a.port"):
+        doc = _remove(doc, dotted)
+    return str(_red_error(_write_doc(tmp_path, doc, "three-missing")))
+
+
+def test_error_counts_all_missing_fields(_three_missing_error: str) -> None:
+    # Arrange
+    message = _three_missing_error
+    # Act
+    counted = "3 required field(s)" in message
+    # Assert
+    assert counted
+
+
+@pytest.mark.parametrize("dotted", ["runtime", "claude.session", "a2a.port"])
+def test_error_lists_each_missing_field(_three_missing_error: str, dotted: str) -> None:
+    # Arrange
+    message = _three_missing_error
+    # Act
+    named = f"spec.{dotted}" in message
+    # Assert
+    assert named
+
+
+def test_error_names_the_loaded_file(tmp_path: Path) -> None:
+    # Arrange
+    path = _write_doc(tmp_path, _remove(_explicit_doc(), "runtime"), "named")
+    # Act
+    error = _red_error(path)
+    # Assert
+    assert f"While loading: {path}" in str(error)
+
+
+# ---------------------------------------------------------------------------
+# The hint CLEARS the condition: merging the paste-ready block into the
+# failing spec makes it load green (round-trip).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _round_trip_healed(tmp_path: Path) -> dict:
+    """Red doc (five fields struck across five sections) healed by the hint."""
+    doc = _explicit_doc()
+    for dotted in (
+        "runtime",
+        "claude.session",
+        "apptainer.tmpfs_size",
+        "watchdog.responses.waiting",
+        "a2a.port",
+    ):
+        doc = _remove(doc, dotted)
+    error = _red_error(_write_doc(tmp_path, doc, "red-agent"))
+    return _healed_doc(doc, error)
+
+
+def test_paste_ready_hint_round_trips_to_green(
+    tmp_path: Path, _round_trip_healed: dict
+) -> None:
+    # Arrange
+    healed_path = _write_doc(tmp_path, _round_trip_healed, "healed-agent")
+    # Act
+    cfg = load_config(healed_path)
+    # Assert
+    assert cfg.name == "healed-agent"
+
+
+def test_paste_ready_hint_preserves_omission_behaviour(
+    tmp_path: Path, _round_trip_healed: dict
+) -> None:
+    # Arrange — pasted claude.session must reproduce what omission meant:
+    # role-less agent -> 'fresh' (null keeps the role-derived default).
+    healed_path = _write_doc(tmp_path, _round_trip_healed, "healed-session")
+    # Act
+    cfg = load_config(healed_path)
+    # Assert
+    assert cfg.claude.session == "fresh"
+
+
+# ---------------------------------------------------------------------------
+# Contract shape: error type + no-bypass signature + load_v3 wiring.
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_spec_error_is_a_value_error() -> None:
+    # Arrange
+    error_type = ExplicitSpecError
+    # Act
+    is_value_error = issubclass(error_type, ValueError)
+    # Assert
+    assert is_value_error
+
+
+def test_validate_signature_has_no_bypass_parameter() -> None:
+    # Arrange
+    import inspect
+
+    # Act
+    parameters = list(inspect.signature(validate).parameters)
+    # Assert — doc + path only: no strict=, no env flag, no escape hatch.
+    assert parameters == ["doc", "path"]
+
+
+def test_load_v3_direct_call_raises_explicit_spec_error(tmp_path: Path) -> None:
+    # Arrange — load_v3 guards independently of load_config's validate_raw.
+    from scitex_agent_container.config._loaders import load_v3
+
+    doc = _remove(_explicit_doc(), "health.method")
+    path = _write_doc(tmp_path, doc, "direct-v3")
+    # Act
+    error = _raised_by(lambda: load_v3(doc, path))
+    # Assert
+    assert isinstance(error, ExplicitSpecError)
+
+
+# ---------------------------------------------------------------------------
+# kind: AgentProxy — proxy fields required too.
+# ---------------------------------------------------------------------------
+
+
+def test_agent_proxy_missing_proxy_upstream_is_red(tmp_path: Path) -> None:
+    # Arrange
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicit_doc,
+    )
+
+    doc = explicit_doc(kind="AgentProxy")
+    del doc["spec"]["proxy"]["upstream"]
+    path = _write_doc(tmp_path, doc, "proxy-red")
+    # Act
+    error = _red_error(path)
+    # Assert
+    assert "spec.proxy.upstream" in str(error)

--- a/tests/scitex_agent_container/config/test__loaders.py
+++ b/tests/scitex_agent_container/config/test__loaders.py
@@ -30,6 +30,7 @@ from scitex_agent_container.config._loaders import (
     compose_effective_name,
 )
 from scitex_agent_container.config._types import HostsSpec, StartupCommand
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_spec
 
 
 @pytest.fixture(autouse=True)
@@ -373,15 +374,17 @@ def _v3_minimal_cfg(tmp_path: Path):
     body = {
         "apiVersion": "scitex-agent-container/v3",
         "kind": "Agent",
-        "spec": {
-            "runtime": "apptainer",
-            "host": "${HOSTNAME}",
-            "workdir": "/home/agent/work",
-            "apptainer": {"image": "x.sif", "binds": []},
-            "claude": {"model": "sonnet"},
-            "health": {"enabled": True, "interval": 60},
-            "restart": {"policy": "on-failure", "max_retries": 3},
-        },
+        "spec": explicit_spec(
+            {
+                "runtime": "apptainer",
+                "host": "${HOSTNAME}",
+                "workdir": "/home/agent/work",
+                "apptainer": {"image": "x.sif", "binds": []},
+                "claude": {"model": "sonnet"},
+                "health": {"enabled": True, "interval": 60},
+                "restart": {"policy": "on-failure", "max_retries": 3},
+            }
+        ),
     }
     p.write_text(yaml.safe_dump(body))
     return load_config(p)
@@ -425,14 +428,16 @@ def test_load_config_v3_multi_host_appends_hostname(tmp_path: Path) -> None:
     body = {
         "apiVersion": "scitex-agent-container/v3",
         "kind": "Agent",
-        "spec": {
-            "runtime": "apptainer",
-            "apptainer": {"image": "x.sif", "binds": []},
-            "claude": {"model": "sonnet"},
-            "health": {"enabled": True, "interval": 60},
-            "restart": {"policy": "on-failure", "max_retries": 3},
-            "hosts": ["mba", "spartan"],
-        },
+        "spec": explicit_spec(
+            {
+                "runtime": "apptainer",
+                "apptainer": {"image": "x.sif", "binds": []},
+                "claude": {"model": "sonnet"},
+                "health": {"enabled": True, "interval": 60},
+                "restart": {"policy": "on-failure", "max_retries": 3},
+                "hosts": ["mba", "spartan"],
+            }
+        ),
     }
     p.write_text(yaml.safe_dump(body))
     # Act
@@ -456,15 +461,19 @@ def test_load_config_v3_multi_host_appends_hostname(tmp_path: Path) -> None:
 
 
 def _v3_yaml(tmp_path: Path, name: str, spec_extra: dict) -> Path:
-    spec = {
-        "runtime": "apptainer",
-        "host": "${HOSTNAME}",
-        "workdir": str(tmp_path / "wd"),
-        "apptainer": {"image": "x.sif", "binds": []},
-        "health": {"enabled": True, "interval": 60},
-        "restart": {"policy": "on-failure", "max_retries": 3},
-    }
-    spec.update(spec_extra)
+    spec = explicit_spec(
+        {
+            "runtime": "apptainer",
+            "host": "${HOSTNAME}",
+            "workdir": str(tmp_path / "wd"),
+            "apptainer": {"image": "x.sif", "binds": []},
+            "health": {"enabled": True, "interval": 60},
+            "restart": {"policy": "on-failure", "max_retries": 3},
+        }
+    )
+    # Deep-merge so a claude/apptainer extra doesn't strip the other
+    # required keys of its block (red-start ruling: all keys must stay).
+    spec = deep_merge(spec, spec_extra)
     # Ensure required claude.model survives an extra that overrides claude.
     spec.setdefault("claude", {}).setdefault("model", "sonnet")
     body = {

--- a/tests/scitex_agent_container/config/test__loaders.py
+++ b/tests/scitex_agent_container/config/test__loaders.py
@@ -30,7 +30,10 @@ from scitex_agent_container.config._loaders import (
     compose_effective_name,
 )
 from scitex_agent_container.config._types import HostsSpec, StartupCommand
-from tests.scitex_agent_container._helpers.explicit_spec import explicit_spec
+from tests.scitex_agent_container._helpers.explicit_spec import (
+    deep_merge,
+    explicit_spec,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -679,15 +682,17 @@ def test_load_config_sac_builtin_optout_label_skips_channel(tmp_path: Path) -> N
         "apiVersion": "scitex-agent-container/v3",
         "kind": "Agent",
         "metadata": {"labels": {"sac-builtin": "off"}},
-        "spec": {
-            "runtime": "apptainer",
-            "host": "${HOSTNAME}",
-            "workdir": str(tmp_path / "wd"),
-            "apptainer": {"image": "x.sif", "binds": []},
-            "claude": {"model": "sonnet"},
-            "health": {"enabled": True, "interval": 60},
-            "restart": {"policy": "on-failure", "max_retries": 3},
-        },
+        "spec": explicit_spec(
+            {
+                "runtime": "apptainer",
+                "host": "${HOSTNAME}",
+                "workdir": str(tmp_path / "wd"),
+                "apptainer": {"image": "x.sif", "binds": []},
+                "claude": {"model": "sonnet"},
+                "health": {"enabled": True, "interval": 60},
+                "restart": {"policy": "on-failure", "max_retries": 3},
+            }
+        ),
     }
     p = tmp_path / "sac-off" / "spec.yaml"
     p.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/scitex_agent_container/config/test__resolve.py
+++ b/tests/scitex_agent_container/config/test__resolve.py
@@ -6,6 +6,8 @@ fallbacks to orochi or any other external orchestrator's paths.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 from pathlib import Path
 
 import pytest
@@ -255,9 +257,9 @@ def _mkagent(root: Path, name: str) -> None:
     d = root / name
     d.mkdir(parents=True, exist_ok=True)
     (d / "spec.yaml").write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
-        "spec: { runtime: apptainer }\n"
+        "spec: { runtime: apptainer }\n")
     )
 
 
@@ -380,9 +382,9 @@ def test_resolve_with_prefix_returns_path_argument_unchanged(
     # Arrange
     yaml_path = tmp_path / "explicit.yaml"
     yaml_path.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
-        "spec: { runtime: apptainer }\n"
+        "spec: { runtime: apptainer }\n")
     )
     # Act
     result = resolve_with_prefix(str(yaml_path))

--- a/tests/scitex_agent_container/config/test__session_continuity.py
+++ b/tests/scitex_agent_container/config/test__session_continuity.py
@@ -154,8 +154,17 @@ def test_wants_continue_only_true_for_continue_mode(mode, expected):
 
 
 def _write_spec(tmp_path, body: str):
+    # Red-start ruling 2026-07-21: merge the validator's paste defaults
+    # beneath the fixture body (body wins) so every field is explicit.
+    # The merge NEVER adds claude.session unless already authored —
+    # paste value is null == unauthored — so the role-default scenarios
+    # under test keep their meaning.
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
     p = tmp_path / "spec.yaml"
-    p.write_text(body, encoding="utf-8")
+    p.write_text(explicitize_yaml(body), encoding="utf-8")
     return p
 
 

--- a/tests/scitex_agent_container/config/test__startup_command_validation.py
+++ b/tests/scitex_agent_container/config/test__startup_command_validation.py
@@ -30,19 +30,31 @@ from scitex_agent_container.config._validation import validate_raw
 # Spec builders
 # ---------------------------------------------------------------------------
 
-_COMPLETE_SPEC = {
-    "apiVersion": "scitex-agent-container/v3",
-    "kind": "Agent",
-    "spec": {
-        "runtime": "tui",
-        "host": "${HOSTNAME}",
-        "workdir": "/home/agent/work",
-        "apptainer": {"image": "/x.sif", "binds": []},
-        "claude": {"model": "opus"},
-        "health": {"enabled": True, "interval": 60},
-        "restart": {"policy": "on-failure", "max_retries": 3},
-    },
-}
+
+def _complete_spec() -> dict:
+    """Fully-explicit spec (red-start ruling 2026-07-21: EVERY field)."""
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicit_spec,
+    )
+
+    return {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": explicit_spec(
+            {
+                "runtime": "tui",
+                "host": "${HOSTNAME}",
+                "workdir": "/home/agent/work",
+                "apptainer": {"image": "/x.sif", "binds": []},
+                "claude": {"model": "opus"},
+                "health": {"enabled": True, "interval": 60},
+                "restart": {"policy": "on-failure", "max_retries": 3},
+            }
+        ),
+    }
+
+
+_COMPLETE_SPEC = _complete_spec()
 
 
 def _raw_with_startup(cmds: list) -> dict:

--- a/tests/scitex_agent_container/config/test__validation.py
+++ b/tests/scitex_agent_container/config/test__validation.py
@@ -701,19 +701,31 @@ def test_image_round_trips_into_top_level_image_alias(_loaded_config_with_image)
 # (``host: local`` is BANNED; operator directive 2026-07-10).
 # ---------------------------------------------------------------------------
 
-_COMPLETE_SPEC = {
-    "apiVersion": "scitex-agent-container/v3",
-    "kind": "Agent",
-    "spec": {
-        "runtime": "tui",
-        "host": "${HOSTNAME}",
-        "workdir": "/home/agent/work",
-        "apptainer": {"image": "/x.sif", "binds": []},
-        "claude": {"model": "opus"},
-        "health": {"enabled": True, "interval": 60},
-        "restart": {"policy": "on-failure", "max_retries": 3},
-    },
-}
+
+def _complete_spec() -> dict:
+    """Fully-explicit spec (red-start ruling 2026-07-21: EVERY field)."""
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicit_spec,
+    )
+
+    return {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": explicit_spec(
+            {
+                "runtime": "tui",
+                "host": "${HOSTNAME}",
+                "workdir": "/home/agent/work",
+                "apptainer": {"image": "/x.sif", "binds": []},
+                "claude": {"model": "opus"},
+                "health": {"enabled": True, "interval": 60},
+                "restart": {"policy": "on-failure", "max_retries": 3},
+            }
+        ),
+    }
+
+
+_COMPLETE_SPEC = _complete_spec()
 
 
 def _spec_without(dotted_path: str) -> dict:
@@ -775,7 +787,7 @@ def test_missing_workdir_is_rejected():
     # Act
     errors = validate_raw(raw, path="<test>")
     # Assert
-    assert [e for e in errors if "spec.workdir is REQUIRED" in e]
+    assert [e for e in errors if "spec.workdir" in e]
 
 
 def test_missing_apptainer_image_is_rejected():
@@ -784,7 +796,7 @@ def test_missing_apptainer_image_is_rejected():
     # Act
     errors = validate_raw(raw, path="<test>")
     # Assert
-    assert [e for e in errors if "spec.apptainer.image is REQUIRED" in e]
+    assert [e for e in errors if "spec.apptainer.image" in e]
 
 
 def test_missing_apptainer_binds_is_rejected():
@@ -793,7 +805,7 @@ def test_missing_apptainer_binds_is_rejected():
     # Act
     errors = validate_raw(raw, path="<test>")
     # Assert
-    assert [e for e in errors if "spec.apptainer.binds is REQUIRED" in e]
+    assert [e for e in errors if "spec.apptainer.binds" in e]
 
 
 def test_missing_health_interval_is_rejected():
@@ -802,7 +814,7 @@ def test_missing_health_interval_is_rejected():
     # Act
     errors = validate_raw(raw, path="<test>")
     # Assert
-    assert [e for e in errors if "spec.health.interval is REQUIRED" in e]
+    assert [e for e in errors if "spec.health.interval" in e]
 
 
 def test_missing_restart_policy_is_rejected():
@@ -811,7 +823,7 @@ def test_missing_restart_policy_is_rejected():
     # Act
     errors = validate_raw(raw, path="<test>")
     # Assert
-    assert [e for e in errors if "spec.restart.policy is REQUIRED" in e]
+    assert [e for e in errors if "spec.restart.policy" in e]
 
 
 def test_agentproxy_missing_upstream_is_rejected():
@@ -832,15 +844,32 @@ def test_agentproxy_missing_upstream_is_rejected():
     # Act
     errors = validate_raw(raw, path="<test>")
     # Assert
-    assert [e for e in errors if "spec.proxy.upstream is REQUIRED" in e]
+    assert [e for e in errors if "spec.proxy.upstream" in e]
 
 
-def test_multi_host_does_not_require_workdir():
-    # Arrange — a multi-instance agent derives a per-instance workdir.
+def test_multi_host_requires_workdir_key_too():
+    # Arrange — red-start ruling 2026-07-21: EVERY field is written, multi-
+    # host included. (The old multi-host exemption is gone; a multi-instance
+    # spec writes ``workdir: null`` to keep the per-instance derivation.)
     import copy
 
     raw = copy.deepcopy(_COMPLETE_SPEC)
     raw["spec"].pop("workdir")
+    raw["spec"].pop("host")
+    raw["spec"]["hosts"] = "all"
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "spec.workdir" in e]
+
+
+def test_multi_host_null_workdir_keeps_derivation_green():
+    # Arrange — ``workdir: null`` is the explicit spelling of "derive the
+    # per-instance runtime workdir" (present-but-null counts as declared).
+    import copy
+
+    raw = copy.deepcopy(_COMPLETE_SPEC)
+    raw["spec"]["workdir"] = None
     raw["spec"].pop("host")
     raw["spec"]["hosts"] = "all"
     # Act

--- a/tests/scitex_agent_container/config/test__validation.py
+++ b/tests/scitex_agent_container/config/test__validation.py
@@ -253,8 +253,10 @@ def test_validate_raw_accepts_runtime_apptainer_for_backcompat():
 # ---------------------------------------------------------------------------
 
 
-def test_validate_raw_absent_provider_is_not_an_error():
-    # Arrange — no-op guarantee: omitting spec.provider adds zero errors.
+def test_validate_raw_absent_provider_adds_no_value_error():
+    # Arrange — the VALUE check stays a no-op when spec.provider is absent
+    # (the red-start ruling flags the MISSING field separately; the
+    # "must be one of" value diagnostic must not fire on absence).
     raw = {
         "apiVersion": "scitex-agent-container/v3",
         "kind": "Agent",
@@ -263,7 +265,20 @@ def test_validate_raw_absent_provider_is_not_an_error():
     # Act
     errors = validate_raw(raw, path="<test>")
     # Assert
-    assert not [e for e in errors if "spec.provider" in e]
+    assert not [e for e in errors if "spec.provider must be one of" in e]
+
+
+def test_validate_raw_absent_provider_is_flagged_missing():
+    # Arrange — red-start ruling 2026-07-21: every field explicit.
+    raw = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {"runtime": "tui"},
+    }
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "spec.provider" in e]
 
 
 def test_validate_raw_accepts_provider_anthropic():
@@ -350,8 +365,8 @@ def test_autonomous_default_block_passes_validation():
     assert not [e for e in errors if "spec.autonomous" in e]
 
 
-def test_autonomous_block_is_optional():
-    """No autonomous block at all is fine — defaults apply at parse time."""
+def test_autonomous_block_absent_is_flagged_missing():
+    """Red-start ruling 2026-07-21: the autonomous block must be written."""
     # Arrange
     raw = {
         "apiVersion": "scitex-agent-container/v3",
@@ -361,7 +376,7 @@ def test_autonomous_block_is_optional():
     # Act
     errors = validate_raw(raw, path="<test>")
     # Assert
-    assert not [e for e in errors if "spec.autonomous" in e]
+    assert [e for e in errors if "spec.autonomous.enabled" in e]
 
 
 def test_autonomous_block_must_be_a_mapping():
@@ -652,23 +667,31 @@ def _loaded_config_with_image(tmp_path):
     yaml_dir = tmp_path / "image-set"
     yaml_dir.mkdir()
     yaml_path = yaml_dir / "image-set.yaml"
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicit_spec,
+    )
+
     yaml_path.write_text(
         _yaml.safe_dump(
             {
                 "apiVersion": "scitex-agent-container/v3",
                 "kind": "Agent",
-                "spec": {
-                    "runtime": "apptainer",
-                    "host": "${HOSTNAME}",
-                    "workdir": "/home/agent/work",
-                    "apptainer": {
-                        "image": "~/.scitex/agent-container/containers/sac-scitex.sif",
-                        "binds": [],
-                    },
-                    "claude": {"model": "claude-opus-4-8[1m]"},
-                    "health": {"enabled": True, "interval": 60},
-                    "restart": {"policy": "on-failure", "max_retries": 3},
-                },
+                "spec": explicit_spec(
+                    {
+                        "runtime": "apptainer",
+                        "host": "${HOSTNAME}",
+                        "workdir": "/home/agent/work",
+                        "apptainer": {
+                            "image": (
+                                "~/.scitex/agent-container/containers/sac-scitex.sif"
+                            ),
+                            "binds": [],
+                        },
+                        "claude": {"model": "claude-opus-4-8[1m]"},
+                        "health": {"enabled": True, "interval": 60},
+                        "restart": {"policy": "on-failure", "max_retries": 3},
+                    }
+                ),
             }
         )
     )

--- a/tests/scitex_agent_container/config/test__validation_provider.py
+++ b/tests/scitex_agent_container/config/test__validation_provider.py
@@ -21,17 +21,23 @@ from __future__ import annotations
 
 from scitex_agent_container.config._validation import validate_raw
 
+# Red-start ruling 2026-07-21: every spec field explicit — base fixture
+# merges the validator's own paste defaults beneath the curated fields.
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_spec
+
 _BASE = {
     "apiVersion": "scitex-agent-container/v3",
     "kind": "Agent",
-    "spec": {
-        "runtime": "apptainer",
-        "host": "${HOSTNAME}",
-        "workdir": "/home/agent/work",
-        "apptainer": {"image": "/x.sif", "binds": []},
-        "health": {"enabled": True, "interval": 60},
-        "restart": {"policy": "on-failure", "max_retries": 3},
-    },
+    "spec": explicit_spec(
+        {
+            "runtime": "apptainer",
+            "host": "${HOSTNAME}",
+            "workdir": "/home/agent/work",
+            "apptainer": {"image": "/x.sif", "binds": []},
+            "health": {"enabled": True, "interval": 60},
+            "restart": {"policy": "on-failure", "max_retries": 3},
+        }
+    ),
 }
 
 _PROVIDER = {
@@ -41,7 +47,10 @@ _PROVIDER = {
 
 
 def _claude_spec(claude: dict) -> dict:
-    return {**_BASE, "spec": {**_BASE["spec"], "claude": claude}}
+    # Merge onto the explicit claude defaults so the block keeps every
+    # required key while the test's fields win.
+    merged = {**_BASE["spec"]["claude"], **claude}
+    return {**_BASE, "spec": {**_BASE["spec"], "claude": merged}}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/_fixtures_tui/tui-smoke.yaml
+++ b/tests/scitex_agent_container/runtimes/_fixtures_tui/tui-smoke.yaml
@@ -30,12 +30,109 @@ spec:
   claude:
     model: haiku
     flags:
-      - --dangerously-skip-permissions
+    - --dangerously-skip-permissions
 
+    channels: []
+    raw_options: {}
+    session:
+    continue_max_age_minutes:
+    resume_id: ''
+    auto_accept: true
+    account: ''
+    credentials_file: ''
+    credentials_files: []
+    provider:
   startup_prompts:
-    - "Reply with the string 'tui-runtime-ok' and nothing else."
+  - "Reply with the string 'tui-runtime-ok' and nothing else."
 
   restart:
     policy: never
 
 # EOF
+    max_retries: 3
+    backoff:
+      initial: 30
+      max: 300
+      multiplier: 2
+    prune_on_stop: false
+  provider: anthropic
+  workdir:
+  python-venv: ''
+  startup_commands: []
+  listen: []
+  extensions: {}
+  mcp_servers: {}
+  user: ''
+  to_home: ./to_home
+  container:
+    runtime: none
+    image: scitex-agent-container:latest
+    volumes: []
+    network: host
+    mount_host_claude: false
+  health:
+    enabled: false
+    interval: 30
+    timeout: 5
+    method: sdk-alive
+  watchdog:
+    enabled: false
+    interval: 1.5
+    responses:
+      y_n: '1'
+      y_y_n: '2'
+      waiting: /speak-and-call
+  autonomous:
+    enabled: false
+    drive_until: DONE
+    max_turns: 50
+    idle_kick_after_s: 120
+    kick_text: Continue. Print DONE when finished.
+  apptainer:
+    image: ''
+    binds: []
+    env: {}
+    raw_args: []
+    post: ''
+    environment: {}
+    def_file: ''
+    nv: false
+    rocm: false
+    overlay: ''
+    overlay_size: ''
+    overlay_create_if_missing: true
+    tmpfs_size: 2G
+    relaxed: false
+    fakeroot: false
+    jail: false
+    nested_build: false
+  hooks:
+    pre_start: []
+    post_start: []
+    pre_stop: []
+    post_stop: []
+    on_compact: []
+    on_restart: []
+    on_diff: []
+  context_management:
+    trigger_at_percent: 70.0
+    strategy: noop
+    warn_before_n_checks: 0
+    check_interval_seconds: 300
+    state_file: ~/.scitex/agent-container/state/<agent>.json
+  a2a:
+    host: 127.0.0.1
+    port: auto
+  comms:
+    outbound:
+      siblings: allow
+      parent: allow
+    inbound:
+      siblings: allow
+      parent: allow
+    a2a:
+      listen: true
+  lineage:
+    group: ''
+    may_spawn: true
+  host: ${HOSTNAME}

--- a/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard.py
@@ -22,6 +22,8 @@ AAA blocks, markers on their own line, one assert per test.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import os
 import socket
 from pathlib import Path
@@ -71,7 +73,7 @@ def _write_spec(tmp_path: Path, raw_args_yaml: str) -> Path:
     spec_dir.mkdir(parents=True, exist_ok=True)
     spec = spec_dir / "spec.yaml"
     spec.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "metadata:\n"
         "  labels:\n"
@@ -93,7 +95,7 @@ def _write_spec(tmp_path: Path, raw_args_yaml: str) -> Path:
         "    policy: on-failure\n"
         "    max_retries: 3\n"
         "  claude:\n"
-        "    model: claude-opus-4-8[1m]\n",
+        "    model: claude-opus-4-8[1m]\n"),
         encoding="utf-8",
     )
     return spec

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -100,10 +100,18 @@ def listen_bearer_token(_isolate_home: Path) -> Path:
 
 
 def _write_spec(tmp_path: Path, body: str) -> Path:
+    # Red-start ruling 2026-07-21: every spec field must be explicit —
+    # merge the validator's own paste defaults beneath the fixture body
+    # (the fixture's fields win) so minimal bodies stay the authored
+    # surface while the write satisfies the validator.
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
     spec_dir = tmp_path / "agents" / "agt"
     spec_dir.mkdir(parents=True, exist_ok=True)
     spec = spec_dir / "spec.yaml"
-    spec.write_text(body, encoding="utf-8")
+    spec.write_text(explicitize_yaml(body), encoding="utf-8")
     return spec
 
 

--- a/tests/scitex_agent_container/runtimes/test__apptainer_nested.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_nested.py
@@ -57,7 +57,12 @@ def _cfg(tmp_path: Path, extra: str):
     spec_dir = tmp_path / "agents" / "agt"
     spec_dir.mkdir(parents=True, exist_ok=True)
     spec = spec_dir / "spec.yaml"
-    spec.write_text(_SPEC.format(extra=extra), encoding="utf-8")
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
+    # Red-start ruling 2026-07-21: every field explicit (body wins).
+    spec.write_text(explicitize_yaml(_SPEC.format(extra=extra)), encoding="utf-8")
     return load_config(str(spec))
 
 

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -17,6 +17,8 @@ assert + STX-TQ003 descriptive names.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import json
 import shutil
 import socket
@@ -271,7 +273,7 @@ def test_start_turn_bridge_passes_resolved_port_to_spawn(
 ) -> None:
     # Arrange — a resolved port + config_path; record the spawn argv.
     spec = tmp_path / "spec.yaml"
-    spec.write_text("apiVersion: scitex-agent-container/v3\n", encoding="utf-8")
+    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8")
     recorded: dict = {}
 
     def fake_spawn(argv, **kwargs):
@@ -292,7 +294,7 @@ def test_start_turn_bridge_returns_spawned_pid(
 ) -> None:
     # Arrange
     spec = tmp_path / "spec.yaml"
-    spec.write_text("apiVersion: scitex-agent-container/v3\n", encoding="utf-8")
+    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8")
     config = SimpleNamespace(
         a2a=SimpleNamespace(port=_PORT), name="figrecipe", config_path=str(spec)
     )
@@ -354,7 +356,7 @@ def test_start_turn_bridge_returns_none_on_spawn_failure(
 ) -> None:
     # Arrange — spawn raises; the launcher must swallow it and return None.
     spec = tmp_path / "spec.yaml"
-    spec.write_text("apiVersion: scitex-agent-container/v3\n", encoding="utf-8")
+    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8")
 
     def raising_spawn(argv, **kwargs):
         raise OSError("exec failed")
@@ -394,7 +396,7 @@ def test_start_turn_bridge_kills_preexisting_bridge_before_spawn(
     # (the orphan a port-changing restart would otherwise leave alive), plus
     # a recording spawn for the NEW bridge so no second subprocess is created.
     spec = tmp_path / "spec.yaml"
-    spec.write_text("apiVersion: scitex-agent-container/v3\n", encoding="utf-8")
+    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8")
     config = SimpleNamespace(
         a2a=SimpleNamespace(port=_PORT), name="restart-me", config_path=str(spec)
     )
@@ -418,7 +420,7 @@ def test_start_turn_bridge_records_new_pid_over_prior(
     # start must overwrite it with the freshly-spawned bridge's PID (never
     # leave the orphaned/stale value behind).
     spec = tmp_path / "spec.yaml"
-    spec.write_text("apiVersion: scitex-agent-container/v3\n", encoding="utf-8")
+    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8")
     config = SimpleNamespace(
         a2a=SimpleNamespace(port=_PORT), name="repid-me", config_path=str(spec)
     )
@@ -503,7 +505,7 @@ def test_start_turn_bridge_fails_loud_when_port_stays_busy(
 ) -> None:
     # Arrange — a REAL listener holds the agent's a2a port; spawn must NOT run.
     spec = tmp_path / "spec.yaml"
-    spec.write_text("apiVersion: scitex-agent-container/v3\n", encoding="utf-8")
+    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8")
     held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     held.bind(("127.0.0.1", 0))
     held.listen()

--- a/tests/scitex_agent_container/runtimes/test_claude_md_orientation.py
+++ b/tests/scitex_agent_container/runtimes/test_claude_md_orientation.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from scitex_agent_container.config import load_config
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 from scitex_agent_container.config._types import AgentConfig
 from scitex_agent_container.runtimes.claude_md import (
     ORIENTATION_MAX_LINES,
@@ -62,7 +63,7 @@ def loaded_config(tmp_path):
     """Real AgentConfig loaded from a real minimal spec.yaml fixture."""
     agent_dir = tmp_path / "orient-fixture"
     agent_dir.mkdir()
-    (agent_dir / "spec.yaml").write_text(_MINIMAL_SPEC)
+    (agent_dir / "spec.yaml").write_text(explicitize_yaml(_MINIMAL_SPEC))
     return load_config(agent_dir / "spec.yaml")
 
 

--- a/tests/scitex_agent_container/runtimes/test_tui_session_settings_delivery.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session_settings_delivery.py
@@ -49,6 +49,7 @@ from typing import Iterator
 import pytest
 
 from scitex_agent_container.config import load_config
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 from scitex_agent_container.runtimes import tui_session as _tui
 from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
 from scitex_agent_container.runtimes.tui_session import TuiSessionRuntime
@@ -114,7 +115,7 @@ def _write_spec(tmp_path: Path) -> Path:
     spec_dir = tmp_path / "agents" / "agt"
     spec_dir.mkdir(parents=True, exist_ok=True)
     spec = spec_dir / "spec.yaml"
-    spec.write_text(_SPEC_BODY, encoding="utf-8")
+    spec.write_text(explicitize_yaml(_SPEC_BODY), encoding="utf-8")
     return spec
 
 

--- a/tests/scitex_agent_container/test_cli.py
+++ b/tests/scitex_agent_container/test_cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import json
 import tempfile
 from pathlib import Path
@@ -488,21 +490,21 @@ class TestListJsonTimeoutBudget:
         # unknown) — that's what this test exercises, so a minimal v3
         # spec without spec.remote is sufficient.
         remote_cfg_path.write_text(
-            """apiVersion: scitex-agent-container/v3
+            explicitize_yaml("""apiVersion: scitex-agent-container/v3
 kind: Agent
 spec:
   runtime: apptainer
-"""
+""")
         )
         ld = tmp_path / "test-local"
         ld.mkdir()
         local_cfg_path = ld / "test-local.yaml"
         local_cfg_path.write_text(
-            """apiVersion: scitex-agent-container/v3
+            explicitize_yaml("""apiVersion: scitex-agent-container/v3
 kind: Agent
 spec:
   runtime: apptainer
-"""
+""")
         )
 
         # PA-306: hand-rolled fake injection with explicit restore.
@@ -564,7 +566,7 @@ spec:
         d.mkdir()
         cfg_path = d / "test-fast.yaml"
         cfg_path.write_text(
-            """apiVersion: scitex-agent-container/v3
+            explicitize_yaml("""apiVersion: scitex-agent-container/v3
 kind: Agent
 spec:
   runtime: apptainer
@@ -581,7 +583,7 @@ spec:
   restart:
     policy: on-failure
     max_retries: 3
-"""
+""")
         )
 
         # PA-306: hand-rolled fake injection with explicit restore.

--- a/tests/scitex_agent_container/test_cli.py
+++ b/tests/scitex_agent_container/test_cli.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
-
 import json
 import tempfile
 from pathlib import Path
@@ -13,6 +11,7 @@ import yaml
 from click.testing import CliRunner
 
 from scitex_agent_container.cli import main
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
 VALID_CONFIG = {
     "apiVersion": "scitex-agent-container/v3",
@@ -33,7 +32,17 @@ def _write_config(data: dict, name: str = "cli-test") -> str:
     """Write config under <tmp>/<name>/<name>.yaml (dir-as-SSoT)."""
     import copy
 
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        deep_merge,
+        explicit_spec_defaults,
+    )
+
     data = copy.deepcopy(data)
+    # Red-start ruling 2026-07-21: every spec field explicit (fixture wins).
+    if isinstance(data.get("spec"), dict):
+        data["spec"] = deep_merge(
+            explicit_spec_defaults(data.get("kind", "Agent")), data["spec"]
+        )
     metadata = data.get("metadata") or {}
     metadata.pop("name", None)
     if metadata:
@@ -276,6 +285,11 @@ class TestCLI:
 
     def _find_setup_gpu_agent(self, tmpdir):
         """Shared setup for agents-find tests below."""
+        from tests.scitex_agent_container._helpers.explicit_spec import (
+            explicit_spec,
+        )
+
+        # Red-start ruling 2026-07-21: every spec field explicit.
         config_with_caps = {
             "apiVersion": "scitex-agent-container/v3",
             "kind": "Agent",
@@ -286,15 +300,17 @@ class TestCLI:
                     "capabilities": "gpu,slurm,ml-training",
                 },
             },
-            "spec": {
-                "runtime": "apptainer",
-                "host": "${HOSTNAME}",
-                "workdir": "/home/agent/work",
-                "apptainer": {"image": "/x.sif", "binds": []},
-                "claude": {"model": "sonnet"},
-                "health": {"enabled": True, "interval": 60},
-                "restart": {"policy": "on-failure", "max_retries": 3},
-            },
+            "spec": explicit_spec(
+                {
+                    "runtime": "apptainer",
+                    "host": "${HOSTNAME}",
+                    "workdir": "/home/agent/work",
+                    "apptainer": {"image": "/x.sif", "binds": []},
+                    "claude": {"model": "sonnet"},
+                    "health": {"enabled": True, "interval": 60},
+                    "restart": {"policy": "on-failure", "max_retries": 3},
+                }
+            ),
         }
         agent_dir = Path(tmpdir) / "test-gpu-agent"
         agent_dir.mkdir()

--- a/tests/scitex_agent_container/test_hooks.py
+++ b/tests/scitex_agent_container/test_hooks.py
@@ -14,6 +14,8 @@ otherwise identical.
 
 from __future__ import annotations
 
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
 import http.server
 import json
 import socket
@@ -338,7 +340,7 @@ def _write_v3_config(tmp_path: Path, extra: str = "") -> Path:
     d.mkdir(exist_ok=True)
     p = d / "statustest.yaml"
     p.write_text(
-        "apiVersion: scitex-agent-container/v3\n"
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
         "kind: Agent\n"
         "spec:\n"
         "  runtime: apptainer\n"
@@ -348,7 +350,7 @@ def _write_v3_config(tmp_path: Path, extra: str = "") -> Path:
         "  health:\n    enabled: true\n    interval: 60\n"
         "  restart:\n    policy: on-failure\n    max_retries: 3\n"
         "  claude:\n"
-        "    model: sonnet\n" + extra
+        "    model: sonnet\n" + extra)
     )
     return p
 

--- a/tests/smoke/test_sac_cli_smoke.py
+++ b/tests/smoke/test_sac_cli_smoke.py
@@ -169,7 +169,12 @@ def test_sac_agents_start_dry_run_against_real_spec_yaml(tmp_path, env_save_rest
     _install_fresh_creds(home)
     spec = tmp_path / "smoke-agent" / "spec.yaml"
     spec.parent.mkdir()
-    spec.write_text(_MINIMAL_V3_SPEC)
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
+    # Red-start ruling 2026-07-21: every field explicit (body wins).
+    spec.write_text(explicitize_yaml(_MINIMAL_V3_SPEC))
     # Act
     result = _run("agents", "start", str(spec), "--dry-run", cwd=tmp_path)
     # Assert (one combined assert: exit 0 AND output mentions "dry-run")


### PR DESCRIPTION
## Summary

Implements the operator ruling of 2026-07-21, verbatim intent, not softened:

1. **EVERY field in an agent `spec.yaml` must be written explicitly.** An omitted field is an ERROR at config-load time, with a hint. ("スペックには全部明示的に書いてほしい / 書いて無ければエラーにしてヒントを出してください")
2. **NO migration machinery, NO warn phase, NO escape-hatch env flag.** ("一気にブート不能で大丈夫です。red スタートしましょう。ハードに。移行とかばかばかしい")
3. dataclasses + a validator. 4. The structure leaves no option but compliance ("『揃うしかなくなる』").

**THIS PR INTENTIONALLY BREAKS EVERY UNDER-SPECIFIED SPEC AT ITS NEXT BOOT.** That is the ruling, not a side effect. The error each red spec prints contains a paste-ready YAML block that makes it green again with byte-identical behaviour.

## What lands

- `config/_explicit_fields.py` — the required-key map: **86 required keys for `kind: Agent`, 78 for `kind: AgentProxy`**, across 14 sections. Derived from `dataclasses.fields()` of the section dataclasses wherever YAML key == field name; explicit alias tables where not (`watchdog.responses.{y_n,y_y_n,waiting}`, `restart.backoff.{initial,max,multiplier}`, `python-venv`).
- `config/_explicit_validation.py` — the walker. Collects ALL missing fields in ONE pass; raises a single `ExplicitSpecError(ValueError)` whose message lists, per missing field, its YAML path + expected type + current default, then a marker-delimited **paste-ready YAML block** (merge it in, become green — round-trip TESTED), ending with the file being loaded. The only signature is `validate(doc, path)` — no `strict=`, no env flag, no bypass.
- Wired **twice from one SSOT**: `load_v3` raises before any parsing (a red spec fails with the complete hint, never a parser TypeError), and `validate_raw` appends the same consolidated message so `sac agents check` reports identically to `load_config`.
- The 2026-06-23 nine-field "no hidden defaults" subset in `_validation.py` was superseded and removed.
- Presence semantics: a key present with `null` IS explicit (matches the prior checker). Loader derivations stay: `workdir: null` = per-agent runtime dir; `claude.session: null` = role-derived session. The paste block uses exactly those spellings so pasting cannot change behaviour (a pasted `session: fresh` would have silently flipped coordinators off `continue`; `null` cannot).

## Exclusion list (each documented in `_explicit_fields.py`)

| Excluded | Reason |
|---|---|
| `spec.host` / `spec.hosts` | mutually-exclusive pair; exactly-one presence already enforced loudly by `_placement_validation` — a require-all map cannot demand both |
| `spec.session` (top-level) | ergonomic alias of the canonical `spec.claude.session`; requiring both = forced double declaration |
| `spec.claude.*` on AgentProxy / `spec.proxy.*` on Agent | the kind-coupling validator FORBIDS the cross block |
| `spec.screen` | legacy inert metadata (no longer drives a multiplexer) |
| `spec.startup` | in `_KNOWN_SPEC_KEYS` but materialised by NO parser (dead key) |
| `multiplexer`, `env-file`, `exclude_hooks`, `exclude_skills` | **read by `load_v3` but ABSENT from `_KNOWN_SPEC_KEYS`** — `validate_raw` rejects them as unknown, so requiring them is red-both-ways. **Flagged for operator review** (see below) |
| banned/relocated keys (`access`, `scheduling`, `dockerfile`, top-level `image/env/model/mounts`, `skills`, `dot_claude`, `remote`, `metadata.name`, `apptainer.container_workdir`) | banned stays banned, never required |
| list-item internals (`listen[].port`, `startup_commands[].command`, bind entries, `mcp_servers.*`, `claude.provider` dict internals) | the list/mapping itself is the explicit declaration; item shapes are parser-validated |

## Deserves operator review

- **`multiplexer` / `env-file` / `exclude_hooks` / `exclude_skills`**: `load_v3` reads them but `validate_raw` rejects them as unknown spec keys — they are unreachable through any validated load today. Either add them to `_KNOWN_SPEC_KEYS` + the required map, or delete the dead reads.
- **`health.method` fossil default**: the dataclass default `multiplexer-alive` is REJECTED by the validator when written (`sdk-alive` is the only accepted value). The paste block emits `sdk-alive`; the dataclass default should probably be updated to match.
- **`claude.model` empty-string default**: pasting `model: ''` is valid and means "runtime default (sonnet)" — kept for behaviour preservation.

## Mutation-proof test evidence

`tests/scitex_agent_container/config/test__explicit_validation.py` (25 tests):

- A HAND-WRITTEN fully-explicit spec (all 86 fields typed out, not generated) loads green — the map and the fixture cannot agree by construction.
- Parametrized mutation-proof over **13 distinct fields spanning top-level, claude, apptainer, health, watchdog, a2a, restart, comms, context_management**: removing that one field turns the load RED and the error names that exact YAML path.
- Several-missing case asserts the single error counts and lists ALL of them at once.
- **Round-trip**: the paste-ready block extracted from the error, merged into the failing spec, loads green — and reproduces omission behaviour (`claude.session` heals to the role-derived value, not a hard-coded one).
- `inspect.signature(validate)` is asserted to be exactly `(doc, path)` — no bypass parameter can appear without failing a test.
- Direct `load_v3` call raises `ExplicitSpecError` (wiring is not only via `load_config`).

## Repo-owned specs made explicit (complete list)

- `examples/agents/{codex-agent,deepseek-agent,full-agent,hello-agent,minimal-agent,proxy-agent}/spec.yaml` — all 6, healed comment-preservingly; all load green.
- `sac agents create` inline templates (`minimal` / `full`) — render the complete explicit field set; extracted to `cli_pkg/_create_templates.py` for the 512-line cap (`_create.py` 609 → 333 lines).
- `sac start` cold-start template (`cli_pkg/lifecycle/_cold_start.py::_COLD_START_SPEC`) — sac's own rendered specs now carry the full set.
- Test fixtures across ~45 modules migrated onto `tests/scitex_agent_container/_helpers/explicit_spec.py` (`explicit_spec` / `explicitize_yaml` — deep-merge the validator's own paste defaults BENEATH each fixture, fixture wins), so fixtures track the map by construction while the hand-written green fixture keeps the map honest.

## Out-of-repo spec impact (the merge-safety question)

Every spec that reaches `load_config` / `load_v3` / `validate_raw` is subject to the new gate. My independent read of what boots from specs OUTSIDE this repo:

- **Live fleet specs** (`~/.scitex/agent-container/agents/<name>/spec.yaml`): every under-specified one goes RED at its next `start`/`restart`. That is the ruling's intent, not collateral — and the error each prints is a complete paste-ready fix. Running agents are untouched until their next lifecycle event.
- **Host dir-templates** (`_template_python_developer` / `_template_researcher` / `_template_generalist` + underscore-agent skeleton in the agents root): operator reports these were made explicit earlier today; `sac agents create` copies them verbatim, so an un-healed template would produce red children — worth a `sac agents check` sweep over the agents root after merge (the check command now reports the same consolidated hint).
- **Defensive surfaces stay standing**: the reconciler (`test_scaffold_dirs_are_not_agents` / malformed-spec tolerance), `refresh-acl` (`test_malformed_spec_does_not_abort_the_others`) and the listen daemon's per-agent status handle a failing spec per-agent and continue — a red spec degrades that one agent's row, it does not take the control plane down.
- **Inline specs over the listen `/agents` POST** (a2a spawn / twin): materialised inline specs must now be fully explicit too — an under-specified inline spec is rejected with the same hint (covered by the migrated `_listen` server tests).
- **Pre-existing dead surface, flagged for operator review (NOT newly broken here)**: the MCP `template_render_contributor_spec` template (`_mcp/_tools/_template.py`) still renders top-level `image`/`model`/`multiplexer`, `spec.skills`, `health.method: multiplexer-alive` and an unknown `a2a.handler` — ALL of which the validator already rejected before this PR. Its output could not load before and cannot load now; it needs a rewrite or retirement in a follow-up.

## Verbatim-move audit

- The only code MOVE in this PR is the two `sac agents create` inline template strings, `_create.py` → `_create_templates.py`. The surrounding machinery (`_TEMPLATES` dict, render call) moved verbatim; the template BODIES did not and were not meant to — they were deliberately rewritten to carry the full explicit field set (that rewrite is the point of the PR).
- Nothing touching the provider tool whitelist moved: `rg allowed_tools` over this branch's `src/` diff against develop returns zero hits — `ProviderSpec.allowed_tools` / `_parse_provider` are untouched.

## Known follow-up (from review, deliberately out of this PR)

The reviewer's finding stands: `_agent_list.py` folds a spec load failure into `labels == {}`, so a not-yet-explicit spec vanishes from every FILTERED `sac agents list` view while the red-start makes exactly that failure common. Follow-up: carry a `config_error` third state on the row + report an unreadable-spec count in filtered views.

## Version / changelog

- CHANGELOG `[Unreleased]` → BREAKING entry describing the ruling + hint contract (combined with develop's autobump + PS-221 entries at merge).
- `pyproject.toml` → **0.24.11** (develop moved to 0.24.10 while this PR was in flight; the branch's version stays one ahead of the latest shipped). `tests/integration/test_version_not_spent.py` passes (9/9).
- `origin/develop` is merged up through 0.24.10.

## Pre-existing audit findings (exist on base, not introduced here)

The blocking PS-221 audit error is fixed on develop (#805, merged here). A local `tests/develop/test_audit.py` run earlier also listed pre-existing, non-blocking findings untouched by this PR — §4b CliHelp free-form help, §6a `CODEX_HOME`/`LOG_PATH` env prefixes, §13 `skills` top-level command, §10w import-budget skip (environmental) — all verified present on `origin/develop` blobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASLR9KjueRGm4BnZnqUhRF
