### PR TITLE
chore(release): v0.24.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.24.11] - 2026-07-22
+
 ### Changed
 
 - **BREAKING — every spec field explicit, red-start (operator ruling


### PR DESCRIPTION
Promotes the `[Unreleased]` CHANGELOG section to `[0.24.11]` so the release pipeline can extract real notes for the tag.

## Why this is CHANGELOG-only (no version bump)

`pyproject.toml` already declares `0.24.11` — the feature PRs bumped it as they landed — while the newest tag is `v0.24.2`. In the autobump state machine that is the **TAG_ONLY** case: *"tag vV does NOT exist though pyproject is already V -> RE-TAG the landed bump, NEVER re-bump."* So this PR does not touch the version.

## Verification done before cutting

Develop's head `ae09a078` (the bot merge of #806, the BREAKING spec red-start) carried **zero check-runs**:

```
GET /commits/ae09a078/check-runs -> {"total_count":0,"check_runs":[]}
```

Pushes made with the default `github.token` do not fire workflows, and `auto-merge-to-develop.yaml` merges with exactly that token — so no post-merge CI had ever run on this tree. Runners were online and idle, so it was not a capacity problem. Tracked separately; the durable fix (dispatch-after-merge) is in flight.

The five gates were therefore dispatched explicitly against develop, and all passed:

| gate | result |
|---|---|
| tests (pytest-matrix py3.11 / 3.12 / 3.13) | success |
| quality | success |
| lint | success |
| import-smoke | success |
| no-hosted-runners | success |

Additionally, because #806 makes an under-specified spec a hard load error, all **101 live fleet specs** were verified against the red-start validator using the host's own python 3.11 and this exact `origin/develop` tree: `parse failures 0, failing 0`. They also still load under the currently-installed 0.24.2, so the fleet boots both before and after deploy.

## Notes extraction

The pipeline selects notes with `awk '$0 ~ "^## \\[" v "\\]"'`. Run against this file with the pipeline's own awk, it extracts the full 134-line section rather than falling back to the generic stub.