### PR TITLE
fix(ci): auto-merge dispatches develop's post-merge gates — a github.token merge fires NOTHING

### DIFF
--- a/.github/workflows/auto-merge-to-develop.yaml
+++ b/.github/workflows/auto-merge-to-develop.yaml
@@ -33,6 +33,24 @@ name: auto-merge-to-develop
 # whole job on schedule, and do NOT make the job exit in a way that leaves no run
 # record. A boring green run every 15 minutes IS the product.
 #
+# *** A github.token MERGE FIRES NOTHING ON develop. *** GitHub suppresses
+# workflow triggers for pushes made with the default workflow token
+# (recursive-run protection), and `gh pr merge` below pushes the merge commit
+# with exactly that token — so every commit this sweep landed arrived on
+# develop with ZERO check runs. Measured, not inferred: bot-merged develop
+# head ae09a078 -> check-runs total_count 0, while its user-pushed neighbours
+# (33c61392 / 8c537754) carried 9 check runs each, with runners online and
+# idle. The develop-health gate below then reads "no checks" as "no red
+# signal to honour" and keeps merging — green-by-absence, the same
+# evidence-that-could-not-have-disagreed shape as the 8-day outage above.
+# workflow_dispatch IS exempt from the suppression (the identical escape
+# hatch autobump-release-sweep.yaml documents for tag pushes), so after a
+# successful merge this sweep explicitly DISPATCHES develop's post-merge
+# gates (POST_MERGE_GATES below) — ONCE per tick, not once per merged PR. A
+# failed dispatch turns this run red ON PURPOSE: an un-CI'd develop head is
+# exactly the silence this file exists to end. Deliberately NO PAT / bot
+# token: explicit dispatch is the sanctioned workaround.
+#
 # GitHub reads schedule- AND check_suite-triggered workflows from the DEFAULT
 # branch (main), so this file lives on main but acts ONLY on PRs whose base is
 # develop. codecov + readthedocs checks are ignored (advisory). Fail-safe: if a
@@ -83,6 +101,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write         # gh workflow run (dispatch develop's post-merge gates)
 
 # One sweep at a time per repo. Two concurrent sweeps would race on the
 # one-merge-per-run budget and could land two PRs against the same unverified
@@ -147,6 +166,18 @@ jobs:
           # instead of by a human babysitting a loop. Raising this above 1 means
           # merging onto a base whose CI has not run yet. Don't.
           MAX_MERGES: "1"
+          # develop's post-merge gates, dispatched explicitly after a merge
+          # because a github.token merge push triggers NOTHING (see header).
+          # Every entry MUST accept a bare `workflow_dispatch` (all five do —
+          # pinned by tests/develop/test_auto_merge_dispatch.py). Space-
+          # separated (`>-` folds the newlines) so the shell can iterate
+          # without arrays.
+          POST_MERGE_GATES: >-
+            pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+            quality-audit-on-ubuntu-latest.yml
+            lint.yml
+            import-smoke-on-ubuntu-py3-12.yml
+            no-hosted-runners-guard-on-self-hosted.yml
         run: |
           set -uo pipefail
 
@@ -314,3 +345,36 @@ jobs:
           done
 
           echo "sweep complete: $merges merge(s) this run"
+
+          # ---------------------------------------------------------------
+          # POST-MERGE CI DISPATCH — a github.token merge fires NOTHING.
+          # ---------------------------------------------------------------
+          # The merge commit we just pushed carries the default workflow
+          # token, so GitHub suppresses every push-triggered workflow on it
+          # (see header). Without this block develop's new head has ZERO
+          # check runs, and the next tick's develop-health gate reads that
+          # absence as "no red signal" — green-by-absence. workflow_dispatch
+          # is exempt from the suppression, so fire the gates explicitly.
+          # ONCE per tick (merges is the tick's total), never per PR.
+          if [ "$merges" -gt 0 ]; then
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "DRY RUN: would dispatch post-merge gates on develop: $POST_MERGE_GATES"
+            else
+              dispatch_failures=0
+              for wf in $POST_MERGE_GATES; do
+                if gh workflow run "$wf" --repo "$REPO" --ref develop; then
+                  echo "dispatched $wf on develop"
+                else
+                  # LOUD, never silent: an undispatched gate leaves develop's
+                  # new head UN-CHECKED — the exact hole this block closes.
+                  echo "::error::failed to dispatch $wf on develop — the merged head has NO CI of its own until something fires it"
+                  dispatch_failures=$((dispatch_failures + 1))
+                fi
+              done
+              if [ "$dispatch_failures" -gt 0 ]; then
+                echo "::error::$dispatch_failures post-merge gate dispatch(es) failed. The merge itself LANDED; this run is red ON PURPOSE so an un-CI'd develop head cannot pass unnoticed."
+                exit 1
+              fi
+              echo "post-merge gates dispatched on develop"
+            fi
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,30 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Fixed
 
+- **auto-merge-to-develop: bot-merged commits landed on develop with ZERO CI —
+  the sweep now dispatches the post-merge gates itself.** GitHub suppresses
+  workflow triggers for pushes made with the default `github.token`
+  (recursive-run protection), and the sweep merges with exactly that token, so
+  every commit it landed arrived on develop with no check runs at all
+  (measured: bot-merged develop head `ae09a078` → check-runs `total_count: 0`;
+  its user-pushed neighbours `33c61392`/`8c537754` → 9 check runs each, with
+  runners online and idle — not a capacity problem). The sweep's own
+  develop-health gate then read that absence as "no red signal to honour" and
+  kept merging: green-by-absence. The repo already documents the identical
+  hazard for tag pushes in `autobump-release-sweep.yaml` and works around it
+  by dispatching explicitly — `workflow_dispatch` is exempt from the
+  suppression — but the merge path never got the same treatment. Now, after a
+  successful merge, the sweep fires the five develop gates (`POST_MERGE_GATES`:
+  pytest matrix, quality audit, lint, import smoke, hosted-runner guard) via
+  `gh workflow run … --ref develop` — ONCE per tick, never per merged PR;
+  skipped on dry-run; `permissions.actions: write` added for the dispatch. A
+  failed dispatch is `::error::`-loud and turns the run red ON PURPOSE (the
+  run record stays, per the file's heartbeat doctrine). No PAT/bot token
+  introduced. Pinned by `tests/develop/test_auto_merge_dispatch.py`
+  (file-only, cannot flake) and mutation-proven: pre-fix workflow → 11/17
+  fail; dispatch line neutered → 3 fail; `--ref main` → ref test fails;
+  restored → 17 pass.
+
 - **An unreadable OpenAI store deleted the Claude account view.** `sac accounts
   list` called `read_codex_accounts_metadata()` unguarded, on the line *above*
   both the `--json` branch and the Claude credential block. That function raises

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.11"
+version = "0.24.12"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/tests/develop/test_auto_merge_dispatch.py
+++ b/tests/develop/test_auto_merge_dispatch.py
@@ -1,0 +1,197 @@
+"""The auto-merge sweep must DISPATCH develop's post-merge gates itself.
+
+GitHub SUPPRESSES workflow triggers for pushes made with the default
+``github.token`` (recursive-run protection), and auto-merge-to-develop.yaml
+merges with exactly that token — so every commit the sweep lands arrives on
+develop with ZERO check runs. Measured on this repo: bot-merged develop head
+``ae09a078`` -> ``check-runs total_count: 0``, while its user-pushed
+neighbours carried 9 check runs each, with runners online and idle. The
+sweep's own develop-health gate then reads "no checks" as "no red signal to
+honour" and keeps merging — green-by-absence, the exact
+``reference-evidence-that-could-not-have-disagreed`` shape the file's header
+warns about.
+
+``workflow_dispatch`` IS exempt from that suppression (the escape hatch
+autobump-release-sweep.yaml already documents for tags), so the merge step
+must explicitly dispatch every develop gate after a successful merge. These
+tests pin that wiring AS TEXT — no network, no gh, cannot flake:
+
+* the merge step names every required gate (``POST_MERGE_GATES``);
+* it dispatches with ``gh workflow run ... --ref develop``;
+* the dispatch is reachable only AFTER a real merge (guarded on the merge
+  count, skipped on dry-run) — N merged PRs must produce ONE dispatch fan-out,
+  not N;
+* the workflow token is actually allowed to dispatch (``actions: write``);
+* every dispatched gate still accepts a bare ``workflow_dispatch`` — a gate
+  that drops the trigger would turn the dispatch into a silent 404, quietly
+  rebuilding the un-CI'd-develop hole this wiring exists to close.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO = Path(__file__).resolve().parents[2]
+_WORKFLOWS = _REPO / ".github" / "workflows"
+_AUTO_MERGE = _WORKFLOWS / "auto-merge-to-develop.yaml"
+
+# The develop-facing gates. Keep in lockstep with POST_MERGE_GATES in
+# auto-merge-to-develop.yaml — test_gate_list_is_exactly_the_required_set
+# fails on any drift in either direction.
+REQUIRED_GATES = (
+    "pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml",
+    "quality-audit-on-ubuntu-latest.yml",
+    "lint.yml",
+    "import-smoke-on-ubuntu-py3-12.yml",
+    "no-hosted-runners-guard-on-self-hosted.yml",
+)
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    return yaml.safe_load(_AUTO_MERGE.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def merge_step(workflow: dict) -> dict:
+    """The step that performs the merges (found by behaviour, not by name)."""
+    steps = workflow["jobs"]["automerge"]["steps"]
+    merging = [s for s in steps if "gh pr merge" in s.get("run", "")]
+    assert len(merging) == 1, "expected exactly one merging step"
+    return merging[0]
+
+
+def _gates_env(merge_step: dict) -> str:
+    return merge_step.get("env", {}).get("POST_MERGE_GATES", "")
+
+
+def _dispatch_lines(merge_step: dict) -> list[str]:
+    return [
+        line for line in merge_step["run"].splitlines() if "gh workflow run" in line
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The dispatch exists and covers every gate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("gate", REQUIRED_GATES)
+def test_every_required_gate_is_dispatched(merge_step: dict, gate: str) -> None:
+    # Arrange
+    declared = _gates_env(merge_step)
+    # Act
+    gates = declared.split()
+    # Assert
+    assert gate in gates, (
+        f"{gate} is not in POST_MERGE_GATES — a github.token merge fires no "
+        "triggers, so an undispatched gate simply never runs on develop"
+    )
+
+
+def test_gate_list_is_exactly_the_required_set(merge_step: dict) -> None:
+    # Arrange
+    declared = _gates_env(merge_step)
+    # Act: drift in EITHER direction is a finding — a missing gate is a hole,
+    # a surplus one is an undocumented dependency of the sweep.
+    gates = declared.split()
+    # Assert
+    assert sorted(gates) == sorted(REQUIRED_GATES)
+
+
+def test_merge_step_runs_workflow_dispatch(merge_step: dict) -> None:
+    # Arrange
+    run = merge_step["run"]
+    # Act
+    lines = [line for line in run.splitlines() if "gh workflow run" in line]
+    # Assert
+    assert lines, "the merge step never runs `gh workflow run`"
+
+
+def test_every_dispatch_targets_develop(merge_step: dict) -> None:
+    # Arrange: non-emptiness is pinned by test_merge_step_runs_workflow_dispatch.
+    lines = _dispatch_lines(merge_step)
+    # Act
+    off_ref = [line for line in lines if "--ref develop" not in line]
+    # Assert
+    assert off_ref == [], (
+        "a dispatch without --ref develop runs the gate from the DEFAULT "
+        "branch ref, not against the head the merge just produced"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reachable only AFTER a merge — once per tick, never per PR, never dry.
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_is_guarded_by_the_merge_count(merge_step: dict) -> None:
+    # Arrange
+    run = merge_step["run"]
+    # Act: locate the end of the per-PR merge loop (the first column-0 `done`
+    # after `gh pr merge`), the merge-count guard, and the dispatch.
+    loop_end_at = run.index("\ndone\n", run.index("gh pr merge"))
+    guard_at = run.index('[ "$merges" -gt 0 ]')
+    dispatch_at = run.index("gh workflow run")
+    # Assert: the guard opens after the merge loop and before the dispatch,
+    # so N merges fan out to ONE dispatch round, not N.
+    assert loop_end_at < guard_at < dispatch_at, (
+        "the dispatch must be guarded on `merges > 0` after the merge loop — "
+        "a per-PR or unconditional dispatch is the wrong shape"
+    )
+
+
+def test_dry_run_does_not_dispatch(merge_step: dict) -> None:
+    # Arrange
+    run = merge_step["run"]
+    # Act: the dry-run branch must be decided between the guard and the
+    # dispatch — a dry run merges nothing, so firing real CI from it would
+    # be dispatching gates for a merge that never happened.
+    guarded_block = run[run.index('[ "$merges" -gt 0 ]') : run.index("gh workflow run")]
+    # Assert
+    assert '"$DRY_RUN" = "true"' in guarded_block
+
+
+def test_dispatch_failure_is_loud(merge_step: dict) -> None:
+    # Arrange
+    run = merge_step["run"]
+    # Act
+    after_guard = run[run.index('[ "$merges" -gt 0 ]') :]
+    # Assert: a failed dispatch leaves develop's new head UN-CHECKED — the
+    # precise silence this wiring exists to end — so it must go ::error::
+    # red, not vanish into an `|| true`.
+    assert "::error::" in after_guard, (
+        "a failed gate dispatch must be loud (::error:: + red run), "
+        "not silently swallowed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The token and the targets can actually honour the dispatch.
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_token_may_dispatch(workflow: dict) -> None:
+    # Arrange
+    permissions = workflow.get("permissions", {})
+    # Act: `gh workflow run` needs actions:write; without it every
+    # dispatch 403s and the sweep is back to landing un-CI'd commits.
+    granted = permissions.get("actions")
+    # Assert
+    assert granted == "write"
+
+
+@pytest.mark.parametrize("gate", REQUIRED_GATES)
+def test_dispatched_gate_accepts_workflow_dispatch(gate: str) -> None:
+    # Arrange
+    doc = yaml.safe_load((_WORKFLOWS / gate).read_text(encoding="utf-8"))
+    # Act: YAML 1.1 parses a bare `on:` key as boolean True — read both.
+    triggers = doc.get("on", doc.get(True, {}))
+    # Assert
+    assert "workflow_dispatch" in triggers, (
+        f"{gate} no longer accepts workflow_dispatch — dispatching it "
+        "would 404 and develop's head would sit un-checked again"
+    )


### PR DESCRIPTION
## Mechanism

GitHub **suppresses workflow triggers for pushes made with the default `github.token`** (recursive-run protection). `auto-merge-to-develop.yaml` merges with exactly that token (`GH_TOKEN: ${{ github.token }}` + `gh pr merge --admin`), so every commit the sweep lands arrives on develop with **no post-merge CI at all**. The sweep's own develop-health gate then reads "no check runs" as "no red signal to honour" and keeps merging — green-by-absence, the exact `evidence-that-could-not-have-disagreed` shape the file's own header warns about.

## Evidence

- Bot-merged develop head `ae09a078` ("Merge pull request #806", author github-actions[bot]): `GET /commits/ae09a078/check-runs` → `{"total_count":0,"check_runs":[]}`
- Neighbouring user-pushed commits `33c61392` / `8c537754` → 9 check runs each, all green
- Runners were online and idle at the time — not a capacity problem
- The repo already documents the identical hazard for tags in `autobump-release-sweep.yaml`'s header ("a github.token tag push fires NOTHING, which is why we dispatch explicitly") — the merge path never got the same treatment

## Fix

After the merge loop, if at least one PR merged this tick, the sweep explicitly dispatches develop's five post-merge gates (`workflow_dispatch` is exempt from the suppression):

- `pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml`
- `quality-audit-on-ubuntu-latest.yml`
- `lint.yml`
- `import-smoke-on-ubuntu-py3-12.yml`
- `no-hosted-runners-guard-on-self-hosted.yml`

Properties:

- **Once per tick, never per merged PR** — the dispatch block sits outside the per-PR loop, guarded on the tick's merge count (N merges cannot fan out to 5N runs)
- **Dry-run safe** — a dry run merges nothing, so it only prints what it would dispatch
- **Fail-loud** — a failed dispatch is `::error::`-logged and turns the run red ON PURPOSE, leaving a run record per the file's "run history IS the heartbeat" doctrine (no whole-job `if:`, no record-less exit)
- **No PAT / bot token** — explicit dispatch is the sanctioned workaround, mirroring autobump
- `permissions` gains `actions: write` (required by `gh workflow run`); all filters stay `gh --jq` (no bare `jq`)
- Header updated with the measured mechanism; autobump-release-sweep.yaml untouched

Note: this file takes effect only once it reaches `main` (GitHub reads schedule/check_suite workflows from the default branch — stated in the file's header).

## Test + mutation proof

`tests/develop/test_auto_merge_dispatch.py` — file-only YAML assertions (no network, cannot flake): every required gate listed, `--ref develop`, guard after the merge loop, dry-run exclusion, loud failure, `actions: write`, and a cross-check that each dispatched gate still accepts a bare `workflow_dispatch`.

Command: `/opt/venv-sac/bin/python -m pytest tests/develop/test_auto_merge_dispatch.py`

Observed, in order:

1. **RED on pre-fix workflow**: 11 failed, 6 passed (the 6 are gate-file cross-checks + one deliberately-vacuous filter)
2. **GREEN after fix**: 17 passed
3. **Mutation — dispatch line neutered** (`if true "$wf"`): 3 failed (`test_merge_step_runs_workflow_dispatch`, `test_dispatch_is_guarded_by_the_merge_count`, `test_dry_run_does_not_dispatch`)
4. **Mutation — `--ref main`**: 1 failed (`test_every_dispatch_targets_develop`) — proving the ref assertion bites (it passed vacuously pre-fix)
5. **Restored**: 17 passed; `bash -n` clean on the extracted merge script

## Pre-existing findings surfaced (not addressed here)

- `autobump-release-sweep.yaml` line ~414 claims "quality-audit/import-smoke lack workflow_dispatch" — stale; both accept it now (this PR deliberately does not touch that file)
- Local `scitex-dev ecosystem audit-all` reports 5 pre-existing CLI-surface errors (§4b free-form help, §6a `CODEX_HOME`/`LOG_PATH` prefixes, §10 import 2545ms, §13 top-level `skills`) under scitex-dev 0.34.0; CI's pinned audit was green on the same tree (`33c61392`). None relate to this diff. The local venv also has a broken dual scitex-dev install (0.26.1.dev9 + 0.34.0 dist-info both present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wf61fTTKUDcDbbq859vXkv
