### PR TITLE
feat(maintenance): detect overlay uppers masking base-baked packages (2026-07-22 incident)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Detector: agent overlays that silently mask a base-baked package**
+  (incident 2026-07-22). Historical per-agent `pip install`s left stale
+  `scitex_cards` copies (0.16.0–0.17.4) in overlay UPPER layers
+  (`~/.scitex/agent-container/containers/overlays/<agent>/upper/opt/venv-sac/
+  …/site-packages/`); the upper wins over the base SIF, so restarts onto a
+  rebuilt base were silent no-ops and the all-clear had to be retracted. New
+  `_maintenance._overlay_masking` (+ `_overlay_masking_model`) implements the
+  sweep-validated rule: a `*.dist-info` in the upper for a package the base
+  provides = MASKED; a bare package dir with only `__pycache__` (zero
+  top-level `*.py`, no dist-info) is a benign overlayfs copy-up, NOT masking
+  (counting those once caused a false fleet scare). Three-valued throughout —
+  missing/unreadable overlay or unreadable base package set reports UNKNOWN,
+  never clean. Surfaced per-agent in `sac agents check-health` (human +
+  `--json` `overlay_masking` key, flowing through the MCP `agent_health`
+  tool) as an observation NEXT TO `healthy`, never folded into the exit code;
+  fleet-wide via `sweep_agent_overlays()`. The base package set is read
+  lazily (only when the upper actually carries a dist-info) via an
+  UNFILTERED live `pip list` of the SIF venv, falling back to the baked
+  scitex-\* manifest honestly labelled PARTIAL. The operational rule ships as
+  one string (`OPERATIONAL_RULE`, quoted verbatim by the RED rendering and
+  `docs/isolation.md` §7): NEVER pip-install a base-baked package into a
+  running agent's overlay — hotfix by force-reinstalling the EXACT base
+  version or recreating the overlay. `status_cmds.health`'s inbox rendering
+  moved to `_health_liveness.print_inbox` (512-line per-file cap).
+
 ### Changed
 
 - **BREAKING — every spec field explicit, red-start (operator ruling

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -210,6 +210,29 @@ Semantics:
 - K/KB units are explicitly rejected — apptainer's
   `overlay create --size` takes integer MB.
 
+**Overlay masking of base-baked packages (incident 2026-07-22).**
+The overlay upper WINS over the base SIF. A `pip install` of a package the
+base already bakes into `/opt/venv-sac` lands in
+`<overlay>/upper/opt/venv-sac/.../site-packages/` and silently shadows the
+base copy for that one agent — across every later base rebuild and restart.
+The fleet carried stale `scitex_cards` fossils (0.16.0–0.17.4) this way:
+restarts onto a new base were no-ops, and the all-clear had to be retracted.
+
+The operational rule (also printed by `sac agents check-health` when the
+detector fires): **NEVER pip-install a base-baked package into a running
+agent's overlay.** A hotfix either force-reinstalls the EXACT base version,
+or recreates the overlay (stop the agent, remove
+`<overlay>/upper/opt/venv-sac`, restart onto the base).
+
+Detection (per-agent in `sac agents check-health`, fleet-wide via
+`scitex_agent_container._maintenance.sweep_agent_overlays`): a
+`*.dist-info` in the upper's site-packages for a package the base provides
+= MASKED. A bare package directory holding only `__pycache__` (zero
+top-level `*.py`, no dist-info) is a benign overlayfs copy-up, NOT masking
+— counting those once produced a false fleet scare. The verdict is
+three-valued: an overlay we cannot read (missing root, unreadable upper,
+unreadable base package set) reports UNKNOWN, never clean.
+
 ### 8. `--writable` vs `--writable-tmpfs` confusion
 
 - `--writable` — modifies the SIF itself. Destroys SIF immutability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.11"
+version = "0.24.13"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/_maintenance/__init__.py
+++ b/src/scitex_agent_container/_maintenance/__init__.py
@@ -5,11 +5,8 @@ Two concerns live here:
 * **git worktree sprawl** (:mod:`._worktree_gc`), the standing liability
   behind the incident card ``incident-worktree-sprawl-permanent-gc-20260710``
   — one repo reached 105 worktrees and helped trigger a host load-spike.
-* **overlay masking of base-baked packages**
-  (:mod:`._overlay_masking` / :mod:`._overlay_masking_model`), from the
-  2026-07-22 incident where historical ``pip install``s in agent overlay
-  UPPER layers silently shadowed the base venv's ``scitex_cards`` across
-  base rebuilds. Surfaced per-agent in ``sac agents check-health``.
+* **overlay masking of base-baked packages** (:mod:`._overlay_masking`),
+  surfaced per-agent in ``sac agents check-health``.
 
 The shape every rail in this package follows, learned from
 ``_hostsync``:

--- a/src/scitex_agent_container/_maintenance/__init__.py
+++ b/src/scitex_agent_container/_maintenance/__init__.py
@@ -1,9 +1,15 @@
 """Host-hygiene maintenance rails that run on a schedule, not on a whim.
 
-Today one concern lives here: **git worktree sprawl**
-(:mod:`._worktree_gc`), the standing liability behind the incident card
-``incident-worktree-sprawl-permanent-gc-20260710`` — one repo reached 105
-worktrees and helped trigger a host load-spike.
+Two concerns live here:
+
+* **git worktree sprawl** (:mod:`._worktree_gc`), the standing liability
+  behind the incident card ``incident-worktree-sprawl-permanent-gc-20260710``
+  — one repo reached 105 worktrees and helped trigger a host load-spike.
+* **overlay masking of base-baked packages**
+  (:mod:`._overlay_masking` / :mod:`._overlay_masking_model`), from the
+  2026-07-22 incident where historical ``pip install``s in agent overlay
+  UPPER layers silently shadowed the base venv's ``scitex_cards`` across
+  base rebuilds. Surfaced per-agent in ``sac agents check-health``.
 
 The shape every rail in this package follows, learned from
 ``_hostsync``:
@@ -17,6 +23,18 @@ The shape every rail in this package follows, learned from
   never crashes the maintenance pass that feeds it.
 """
 
+from ._overlay_masking import (
+    base_package_set_for,
+    inspect_agent_overlay,
+    inspect_overlay,
+    sweep_agent_overlays,
+)
+from ._overlay_masking_model import (
+    OPERATIONAL_RULE,
+    BasePackageSet,
+    OverlayMaskVerdict,
+    ShadowInstall,
+)
 from ._worktree_gc import (
     DEFAULT_CAP,
     DEFAULT_MIN_AGE_HOURS,
@@ -40,11 +58,19 @@ from ._worktree_gc_repos import discover_repos, spec_workdirs
 __all__ = [
     "DEFAULT_CAP",
     "DEFAULT_MIN_AGE_HOURS",
+    "OPERATIONAL_RULE",
+    "BasePackageSet",
     "GcOutcome",
+    "OverlayMaskVerdict",
     "RepoGcResult",
+    "ShadowInstall",
     "WorktreeInfo",
     "WorktreeVerdict",
+    "base_package_set_for",
     "discover_repos",
+    "inspect_agent_overlay",
+    "inspect_overlay",
+    "sweep_agent_overlays",
     "exit_code_for",
     "gc_repo",
     "gc_repos",

--- a/src/scitex_agent_container/_maintenance/_overlay_masking.py
+++ b/src/scitex_agent_container/_maintenance/_overlay_masking.py
@@ -1,0 +1,440 @@
+"""Detect agent overlays whose UPPER layer masks a base-baked package.
+
+Engine half of the pair; the vocabulary, dataclasses and the incident
+narrative live in :mod:`._overlay_masking_model`.
+
+THE DETECTION RULE (validated by an actual fleet sweep — do not "improve")
+--------------------------------------------------------------------------
+Count ``*.dist-info`` directories under the overlay upper's
+``<venv>/lib/python*/site-packages``. A dist-info present in the upper for
+a package the base provides = MASKED.
+
+CRITICAL false-scare guard: a bare package directory containing ONLY
+``__pycache__`` and ZERO top-level ``*.py`` files is a BENIGN overlayfs
+copy-up (a byte-compile wrote a ``.pyc``, overlayfs copied the directory
+entry up), NOT masking. Only a dist-info in the upper indicates a real
+shadowing install. This distinction already cost one false fleet alarm.
+
+Three-valued throughout: "could not look" (overlay root missing, unreadable
+upper, unreadable base set) reports UNKNOWN and never reads as clean.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Callable
+
+from .._drift.versions import (
+    DEFAULT_VENV,
+    _apptainer_exec,
+    agent_base_image_name,
+    discover_base_sifs,
+    read_base_manifest,
+)
+from ..runtimes._apptainer_overlay import (
+    OVERLAY_UPPER_DIRNAME,
+    is_image_overlay,
+    resolve_overlay_declaration,
+)
+from ._overlay_masking_model import (
+    REASON_BASE_UNKNOWN,
+    REASON_IMAGE_OVERLAY,
+    REASON_INSPECT_ERROR,
+    REASON_MASKED,
+    REASON_NO_OVERLAY,
+    REASON_NO_SHADOW_INSTALLS,
+    REASON_OVERLAY_MISSING,
+    REASON_OVERLAY_ONLY,
+    REASON_UPPER_UNREADABLE,
+    REASON_UPPER_VENV_UNTOUCHED,
+    SHADOW_BASE_UNKNOWN,
+    SHADOW_MASKED,
+    SHADOW_OVERLAY_ONLY,
+    VERDICT_CLEAN,
+    VERDICT_MASKED,
+    VERDICT_UNKNOWN,
+    BasePackageSet,
+    OverlayMaskVerdict,
+    ShadowInstall,
+    canonical_dist_name,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "base_package_set_for",
+    "inspect_agent_overlay",
+    "inspect_overlay",
+    "sweep_agent_overlays",
+]
+
+_DIST_INFO_SUFFIX = ".dist-info"
+
+
+# ---------------------------------------------------------------------------
+# the scan (pure filesystem; raises OSError so the caller can say UNKNOWN)
+# ---------------------------------------------------------------------------
+def _parse_dist_info_name(dirname: str) -> tuple[str, str]:
+    """``Name-Version.dist-info`` -> ``(canonical_name, version)`` or ``("", "")``."""
+    stem = dirname[: -len(_DIST_INFO_SUFFIX)]
+    name, _, version = stem.rpartition("-")
+    if name and version:
+        return canonical_dist_name(name), version
+    return "", ""
+
+
+def _dir_has_toplevel_py(pkg_dir: Path) -> bool:
+    """True iff ``pkg_dir`` carries at least one TOP-LEVEL ``*.py``.
+
+    Raises OSError when unreadable — the caller must not guess.
+    """
+    return any(child.suffix == ".py" for child in pkg_dir.iterdir())
+
+
+def _scan_site_packages(
+    site: Path,
+) -> tuple[list[tuple[str, str, str]], list[str], list[str]]:
+    """Scan ONE upper site-packages dir per the validated detection rule.
+
+    Returns ``(dist_infos, copyups, strays)``:
+
+    * ``dist_infos`` — ``(canonical_name, version, path)`` per ``*.dist-info``
+      found: the ONLY signal that drives a MASKED verdict.
+    * ``copyups`` — package dirs with NO matching dist-info and ZERO
+      top-level ``*.py``: the benign overlayfs copy-up shape. Reported as
+      evidence precisely because counting these as masking caused a false
+      fleet scare.
+    * ``strays`` — package dirs with no dist-info but WITH top-level
+      ``*.py``. Outside the validated taxonomy, so they NEVER drive the
+      verdict; listed so an operator reading the report sees everything the
+      scan saw.
+
+    Raises OSError when the directory cannot be read (caller -> UNKNOWN).
+    """
+    dist_infos: list[tuple[str, str, str]] = []
+    copyups: list[str] = []
+    strays: list[str] = []
+    entries = sorted(site.iterdir())
+    owned: set[str] = set()
+    for entry in entries:
+        if entry.is_dir() and entry.name.endswith(_DIST_INFO_SUFFIX):
+            name, version = _parse_dist_info_name(entry.name)
+            if name:
+                dist_infos.append((name, version, str(entry)))
+                owned.add(name)
+    for entry in entries:
+        if not entry.is_dir():
+            continue
+        if entry.name.endswith((_DIST_INFO_SUFFIX, ".egg-info")):
+            continue
+        if entry.name == "__pycache__":
+            continue
+        if canonical_dist_name(entry.name) in owned:
+            continue  # the dist-info row above already reports this package
+        if _dir_has_toplevel_py(entry):
+            strays.append(entry.name)
+        else:
+            copyups.append(entry.name)
+    return dist_infos, copyups, strays
+
+
+def _scan_upper_venv(
+    upper_venv_root: Path,
+) -> tuple[list[tuple[str, str, str]], list[str], list[str]]:
+    """Scan every ``lib/python*/site-packages`` under the upper venv root."""
+    dist_infos: list[tuple[str, str, str]] = []
+    copyups: list[str] = []
+    strays: list[str] = []
+    for site in sorted(upper_venv_root.glob("lib/python*/site-packages")):
+        d, c, s = _scan_site_packages(site)
+        dist_infos.extend(d)
+        copyups.extend(c)
+        strays.extend(s)
+    return dist_infos, copyups, strays
+
+
+# ---------------------------------------------------------------------------
+# classification + the tri-state verdict
+# ---------------------------------------------------------------------------
+def _classify(name: str, base: BasePackageSet | None) -> tuple[str, str]:
+    """Classify one upper dist-info against the base set -> (status, base_ver).
+
+    Three-valued by construction: with no base set (or a PARTIAL one that
+    lacks the name) the answer is :data:`SHADOW_BASE_UNKNOWN` — we could
+    not tell, and "could not tell" must never read as clean. Note the rule
+    has NO version qualifier: a same-version dist-info in the upper is
+    still MASKED — it shadows every FUTURE base rebuild just the same.
+    """
+    if base is None:
+        return SHADOW_BASE_UNKNOWN, ""
+    base_version = base.packages.get(name)
+    if base_version is not None:
+        return SHADOW_MASKED, str(base_version)
+    if base.complete:
+        return SHADOW_OVERLAY_ONLY, ""
+    return SHADOW_BASE_UNKNOWN, ""
+
+
+def _shadow_verdict(
+    agent: str,
+    root: Path,
+    dist_infos: list[tuple[str, str, str]],
+    copyups: list[str],
+    strays: list[str],
+    base: BasePackageSet | None,
+) -> OverlayMaskVerdict:
+    """Fold classified shadows into the agent-level verdict."""
+    shadows = tuple(
+        ShadowInstall(
+            package=name,
+            version=version,
+            dist_info=path,
+            status=status,
+            base_version=base_version,
+        )
+        for name, version, path in dist_infos
+        for status, base_version in (_classify(name, base),)
+    )
+    n_masked = sum(1 for s in shadows if s.status == SHADOW_MASKED)
+    n_unknown = sum(1 for s in shadows if s.status == SHADOW_BASE_UNKNOWN)
+    if n_masked:
+        verdict, reason = VERDICT_MASKED, REASON_MASKED
+        detail = (
+            f"{n_masked} base-baked package(s) shadowed by an overlay-upper "
+            "dist-info: "
+            + ", ".join(
+                f"{s.package} {s.version} (base {s.base_version})"
+                for s in shadows
+                if s.status == SHADOW_MASKED
+            )
+        )
+    elif n_unknown:
+        verdict, reason = VERDICT_UNKNOWN, REASON_BASE_UNKNOWN
+        detail = (
+            f"{n_unknown} dist-info(s) in the upper but the base package set "
+            "could not settle them — NOT clean, cannot tell"
+        )
+    else:
+        verdict, reason = VERDICT_CLEAN, REASON_OVERLAY_ONLY
+        detail = (
+            f"{len(shadows)} overlay-only install(s); the complete base set "
+            "provides none of them"
+        )
+    return OverlayMaskVerdict(
+        agent=agent,
+        overlay_root=str(root),
+        verdict=verdict,
+        reason=reason,
+        detail=detail,
+        shadows=shadows,
+        copyups=tuple(copyups),
+        stray_dirs=tuple(strays),
+        base_source=base.source if base is not None else "",
+    )
+
+
+def inspect_overlay(
+    agent: str,
+    overlay_root: Path | str | None,
+    base_provider: Callable[[], BasePackageSet | None] | BasePackageSet | None,
+    *,
+    venv: str = DEFAULT_VENV,
+    overlay_size: str = "",
+) -> OverlayMaskVerdict:
+    """The detector: tri-state masking verdict for ONE agent overlay.
+
+    ``base_provider`` may be a :class:`BasePackageSet`, ``None`` ("could not
+    read the base"), or a zero-arg callable returning either. The callable
+    form is the production shape and is invoked LAZILY — only when the upper
+    actually carries a dist-info — so the overwhelmingly common clean agent
+    costs a pure filesystem scan and never an ``apptainer exec``.
+    """
+    if overlay_root is None:
+        return OverlayMaskVerdict(
+            agent=agent,
+            overlay_root="",
+            verdict=VERDICT_CLEAN,
+            reason=REASON_NO_OVERLAY,
+            detail="spec declares no overlay; nothing can mask the base",
+        )
+    root = Path(overlay_root)
+    if is_image_overlay(root, overlay_size):
+        return OverlayMaskVerdict(
+            agent=agent,
+            overlay_root=str(root),
+            verdict=VERDICT_UNKNOWN,
+            reason=REASON_IMAGE_OVERLAY,
+            detail=(
+                "loopback image overlay — its upper layer is not host-"
+                "readable, so masking can NOT be ruled out from here"
+            ),
+        )
+    if not root.is_dir():
+        # Missing is UNKNOWN, not clean: we cannot distinguish "never
+        # provisioned" from "we are looking on the wrong host / at the
+        # wrong HOME".
+        return OverlayMaskVerdict(
+            agent=agent,
+            overlay_root=str(root),
+            verdict=VERDICT_UNKNOWN,
+            reason=REASON_OVERLAY_MISSING,
+            detail=f"declared overlay root {root} does not exist here",
+        )
+    upper_venv = root / OVERLAY_UPPER_DIRNAME / venv.lstrip("/")
+    if not upper_venv.is_dir():
+        # We READ the overlay root and the upper carries no venv subtree at
+        # all — the fleet-normal state. This is an observed clean, not an
+        # unknown: the readdir succeeded and there is nothing to mask with.
+        return OverlayMaskVerdict(
+            agent=agent,
+            overlay_root=str(root),
+            verdict=VERDICT_CLEAN,
+            reason=REASON_UPPER_VENV_UNTOUCHED,
+            detail=f"overlay upper carries no {venv} subtree",
+        )
+    try:
+        dist_infos, copyups, strays = _scan_upper_venv(upper_venv)
+    except OSError as exc:
+        return OverlayMaskVerdict(
+            agent=agent,
+            overlay_root=str(root),
+            verdict=VERDICT_UNKNOWN,
+            reason=REASON_UPPER_UNREADABLE,
+            detail=f"could not read {upper_venv}: {exc}",
+        )
+    if not dist_infos:
+        return OverlayMaskVerdict(
+            agent=agent,
+            overlay_root=str(root),
+            verdict=VERDICT_CLEAN,
+            reason=REASON_NO_SHADOW_INSTALLS,
+            detail="no dist-info in the upper site-packages",
+            copyups=tuple(copyups),
+            stray_dirs=tuple(strays),
+        )
+    base = base_provider() if callable(base_provider) else base_provider
+    return _shadow_verdict(agent, root, dist_infos, copyups, strays, base)
+
+
+# ---------------------------------------------------------------------------
+# production glue: base-set acquisition + per-agent / fleet entry points
+# ---------------------------------------------------------------------------
+def _read_base_full_live(sif: Path) -> dict[str, str] | None:
+    """UNFILTERED ``pip list --format=json`` of the base venv via apptainer.
+
+    Unlike :func:`.._drift.versions.read_base_live` (scitex-* rows only,
+    for the drift aggregator), masking detection needs the WHOLE base set:
+    an overlay dist-info for ``click`` masks exactly as hard as one for
+    ``scitex-cards``. Returns canonical ``{name: version}`` or ``None``.
+    """
+    cp = _apptainer_exec(sif, [f"{DEFAULT_VENV}/bin/pip", "list", "--format=json"])
+    if cp is None or cp.returncode != 0 or not (cp.stdout or "").strip():
+        return None
+    try:
+        rows = json.loads(cp.stdout)
+    except json.JSONDecodeError:
+        return None
+    out: dict[str, str] = {}
+    for row in rows if isinstance(rows, list) else []:
+        try:
+            out[canonical_dist_name(str(row["name"]))] = str(row["version"])
+        except (KeyError, TypeError):
+            continue
+    return out or None
+
+
+def _resolve_base_sif(config) -> Path | None:
+    """The base SIF this agent runs on, or ``None`` when unresolvable."""
+    ap = getattr(config, "apptainer", None)
+    image = (getattr(ap, "image", "") or "").strip() if ap is not None else ""
+    candidate = Path(image).expanduser() if image else None
+    if candidate is not None and candidate.suffix == ".sif" and candidate.is_file():
+        return candidate
+    wanted = agent_base_image_name(config)
+    for name, sif in discover_base_sifs():
+        if name == wanted:
+            return sif
+    return None
+
+
+def base_package_set_for(config) -> BasePackageSet | None:
+    """Read the base package set for ``config``'s image, honestly labelled.
+
+    Order: full live ``pip list`` (complete — ground truth) first, because
+    this function is only ever consulted AFTER a shadow install was found
+    and completeness now matters more than latency; then the baked scitex-*
+    manifest (partial); then ``None`` — the caller reports UNKNOWN.
+    """
+    sif = _resolve_base_sif(config)
+    if sif is None:
+        return None
+    full = _read_base_full_live(sif)
+    if full is not None:
+        return BasePackageSet(packages=full, complete=True, source="live")
+    partial = read_base_manifest(sif)
+    if partial is not None:
+        return BasePackageSet(
+            packages={r["package"]: r["version"] for r in partial},
+            complete=False,
+            source="manifest",
+        )
+    return None
+
+
+def inspect_agent_overlay(
+    name: str,
+    config,
+    base_provider: Callable[[], BasePackageSet | None] | None = None,
+) -> OverlayMaskVerdict:
+    """Per-agent entry: resolve the overlay from the SPEC, then inspect.
+
+    Uses :func:`..runtimes._apptainer_overlay.resolve_overlay_declaration`
+    — the resolver that answers "what overlay does apptainer actually get?"
+    in every spelling — so the detector looks at the same path the launch
+    does. ``base_provider`` is an injection seam for tests; production
+    leaves it ``None`` (lazy live-then-manifest read of the agent's SIF).
+    """
+    ap = getattr(config, "apptainer", None)
+    overlay_size = (getattr(ap, "overlay_size", "") or "") if ap is not None else ""
+
+    def _default_provider() -> BasePackageSet | None:
+        return base_package_set_for(config)
+
+    return inspect_overlay(
+        name,
+        resolve_overlay_declaration(config),
+        base_provider if base_provider is not None else _default_provider,
+        overlay_size=overlay_size,
+    )
+
+
+def sweep_agent_overlays(agent_configs=None) -> list[OverlayMaskVerdict]:
+    """Fleet sweep: one verdict per registered agent. Never raises.
+
+    ``agent_configs`` is an iterable of ``(name, AgentConfig)``; ``None``
+    enumerates the registry (same seam as ``sac versions``). One agent's
+    failure degrades to an UNKNOWN verdict carrying the reason — a sweep
+    that dies on agent 3 of 40 silently under-reports the other 37.
+    """
+    if agent_configs is None:
+        from .._drift.versions import _load_agent_configs
+
+        agent_configs = _load_agent_configs()
+    out: list[OverlayMaskVerdict] = []
+    for name, config in agent_configs:
+        try:
+            out.append(inspect_agent_overlay(name, config))
+        except Exception as exc:  # stx-allow: fallback (reason: one agent's malformed spec must degrade to an UNKNOWN row, never kill the fleet sweep)
+            logger.debug("overlay-masking: inspect failed for %s: %s", name, exc)
+            out.append(
+                OverlayMaskVerdict(
+                    agent=name,
+                    overlay_root="",
+                    verdict=VERDICT_UNKNOWN,
+                    reason=REASON_INSPECT_ERROR,
+                    detail=f"{type(exc).__name__}: {exc}",
+                )
+            )
+    return out

--- a/src/scitex_agent_container/_maintenance/_overlay_masking.py
+++ b/src/scitex_agent_container/_maintenance/_overlay_masking.py
@@ -1,22 +1,8 @@
 """Detect agent overlays whose UPPER layer masks a base-baked package.
 
-Engine half of the pair; the vocabulary, dataclasses and the incident
-narrative live in :mod:`._overlay_masking_model`.
-
-THE DETECTION RULE (validated by an actual fleet sweep — do not "improve")
---------------------------------------------------------------------------
-Count ``*.dist-info`` directories under the overlay upper's
-``<venv>/lib/python*/site-packages``. A dist-info present in the upper for
-a package the base provides = MASKED.
-
-CRITICAL false-scare guard: a bare package directory containing ONLY
-``__pycache__`` and ZERO top-level ``*.py`` files is a BENIGN overlayfs
-copy-up (a byte-compile wrote a ``.pyc``, overlayfs copied the directory
-entry up), NOT masking. Only a dist-info in the upper indicates a real
-shadowing install. This distinction already cost one false fleet alarm.
-
-Three-valued throughout: "could not look" (overlay root missing, unreadable
-upper, unreadable base set) reports UNKNOWN and never reads as clean.
+Rule (fleet-sweep-validated): a ``*.dist-info`` in the upper's
+site-packages for a package the base provides = MASKED; unknowable
+states report UNKNOWN, never clean. Vocabulary: :mod:`._overlay_masking_model`.
 """
 
 from __future__ import annotations
@@ -73,9 +59,6 @@ __all__ = [
 _DIST_INFO_SUFFIX = ".dist-info"
 
 
-# ---------------------------------------------------------------------------
-# the scan (pure filesystem; raises OSError so the caller can say UNKNOWN)
-# ---------------------------------------------------------------------------
 def _parse_dist_info_name(dirname: str) -> tuple[str, str]:
     """``Name-Version.dist-info`` -> ``(canonical_name, version)`` or ``("", "")``."""
     stem = dirname[: -len(_DIST_INFO_SUFFIX)]
@@ -85,33 +68,19 @@ def _parse_dist_info_name(dirname: str) -> tuple[str, str]:
     return "", ""
 
 
-def _dir_has_toplevel_py(pkg_dir: Path) -> bool:
-    """True iff ``pkg_dir`` carries at least one TOP-LEVEL ``*.py``.
-
-    Raises OSError when unreadable — the caller must not guess.
-    """
-    return any(child.suffix == ".py" for child in pkg_dir.iterdir())
+def _is_benign_overlayfs_copyup(pkg_dir: Path) -> bool:
+    """Zero top-level ``*.py`` = copy-up artefact, not an install. May raise OSError."""
+    return not any(child.suffix == ".py" for child in pkg_dir.iterdir())
 
 
 def _scan_site_packages(
     site: Path,
 ) -> tuple[list[tuple[str, str, str]], list[str], list[str]]:
-    """Scan ONE upper site-packages dir per the validated detection rule.
+    """One site-packages dir -> ``(dist_infos, copyup_dirs, stray_dirs)``.
 
-    Returns ``(dist_infos, copyups, strays)``:
-
-    * ``dist_infos`` — ``(canonical_name, version, path)`` per ``*.dist-info``
-      found: the ONLY signal that drives a MASKED verdict.
-    * ``copyups`` — package dirs with NO matching dist-info and ZERO
-      top-level ``*.py``: the benign overlayfs copy-up shape. Reported as
-      evidence precisely because counting these as masking caused a false
-      fleet scare.
-    * ``strays`` — package dirs with no dist-info but WITH top-level
-      ``*.py``. Outside the validated taxonomy, so they NEVER drive the
-      verdict; listed so an operator reading the report sees everything the
-      scan saw.
-
-    Raises OSError when the directory cannot be read (caller -> UNKNOWN).
+    Only a dist-info marks a shadowing install (a bare package dir does
+    not — see :func:`_is_benign_overlayfs_copyup`). Raises OSError when
+    unreadable so the caller reports UNKNOWN.
     """
     dist_infos: list[tuple[str, str, str]] = []
     copyups: list[str] = []
@@ -132,18 +101,17 @@ def _scan_site_packages(
         if entry.name == "__pycache__":
             continue
         if canonical_dist_name(entry.name) in owned:
-            continue  # the dist-info row above already reports this package
-        if _dir_has_toplevel_py(entry):
-            strays.append(entry.name)
-        else:
+            continue  # already reported via its dist-info
+        if _is_benign_overlayfs_copyup(entry):
             copyups.append(entry.name)
+        else:
+            strays.append(entry.name)
     return dist_infos, copyups, strays
 
 
 def _scan_upper_venv(
     upper_venv_root: Path,
 ) -> tuple[list[tuple[str, str, str]], list[str], list[str]]:
-    """Scan every ``lib/python*/site-packages`` under the upper venv root."""
     dist_infos: list[tuple[str, str, str]] = []
     copyups: list[str] = []
     strays: list[str] = []
@@ -155,17 +123,11 @@ def _scan_upper_venv(
     return dist_infos, copyups, strays
 
 
-# ---------------------------------------------------------------------------
-# classification + the tri-state verdict
-# ---------------------------------------------------------------------------
 def _classify(name: str, base: BasePackageSet | None) -> tuple[str, str]:
-    """Classify one upper dist-info against the base set -> (status, base_ver).
+    """One dist-info vs the base set -> ``(status, base_version)``.
 
-    Three-valued by construction: with no base set (or a PARTIAL one that
-    lacks the name) the answer is :data:`SHADOW_BASE_UNKNOWN` — we could
-    not tell, and "could not tell" must never read as clean. Note the rule
-    has NO version qualifier: a same-version dist-info in the upper is
-    still MASKED — it shadows every FUTURE base rebuild just the same.
+    No version qualifier: a same-version install still shadows every
+    future base rebuild, so it is MASKED too.
     """
     if base is None:
         return SHADOW_BASE_UNKNOWN, ""
@@ -185,7 +147,6 @@ def _shadow_verdict(
     strays: list[str],
     base: BasePackageSet | None,
 ) -> OverlayMaskVerdict:
-    """Fold classified shadows into the agent-level verdict."""
     shadows = tuple(
         ShadowInstall(
             package=name,
@@ -243,13 +204,10 @@ def inspect_overlay(
     venv: str = DEFAULT_VENV,
     overlay_size: str = "",
 ) -> OverlayMaskVerdict:
-    """The detector: tri-state masking verdict for ONE agent overlay.
+    """Tri-state masking verdict for one agent overlay.
 
-    ``base_provider`` may be a :class:`BasePackageSet`, ``None`` ("could not
-    read the base"), or a zero-arg callable returning either. The callable
-    form is the production shape and is invoked LAZILY — only when the upper
-    actually carries a dist-info — so the overwhelmingly common clean agent
-    costs a pure filesystem scan and never an ``apptainer exec``.
+    A callable ``base_provider`` is invoked LAZILY — only when the upper
+    carries a dist-info — so a clean agent never pays an ``apptainer exec``.
     """
     if overlay_root is None:
         return OverlayMaskVerdict(
@@ -272,9 +230,7 @@ def inspect_overlay(
             ),
         )
     if not root.is_dir():
-        # Missing is UNKNOWN, not clean: we cannot distinguish "never
-        # provisioned" from "we are looking on the wrong host / at the
-        # wrong HOME".
+        # Missing != clean: could be never-provisioned OR wrong host/HOME.
         return OverlayMaskVerdict(
             agent=agent,
             overlay_root=str(root),
@@ -284,9 +240,7 @@ def inspect_overlay(
         )
     upper_venv = root / OVERLAY_UPPER_DIRNAME / venv.lstrip("/")
     if not upper_venv.is_dir():
-        # We READ the overlay root and the upper carries no venv subtree at
-        # all — the fleet-normal state. This is an observed clean, not an
-        # unknown: the readdir succeeded and there is nothing to mask with.
+        # Observed clean: readdir succeeded, no venv subtree to mask with.
         return OverlayMaskVerdict(
             agent=agent,
             overlay_root=str(root),
@@ -318,17 +272,9 @@ def inspect_overlay(
     return _shadow_verdict(agent, root, dist_infos, copyups, strays, base)
 
 
-# ---------------------------------------------------------------------------
-# production glue: base-set acquisition + per-agent / fleet entry points
-# ---------------------------------------------------------------------------
 def _read_base_full_live(sif: Path) -> dict[str, str] | None:
-    """UNFILTERED ``pip list --format=json`` of the base venv via apptainer.
-
-    Unlike :func:`.._drift.versions.read_base_live` (scitex-* rows only,
-    for the drift aggregator), masking detection needs the WHOLE base set:
-    an overlay dist-info for ``click`` masks exactly as hard as one for
-    ``scitex-cards``. Returns canonical ``{name: version}`` or ``None``.
-    """
+    """Unfiltered ``pip list --format=json`` of the base venv (the drift
+    readers filter to scitex-*; masking needs the whole set)."""
     cp = _apptainer_exec(sif, [f"{DEFAULT_VENV}/bin/pip", "list", "--format=json"])
     if cp is None or cp.returncode != 0 or not (cp.stdout or "").strip():
         return None
@@ -346,7 +292,6 @@ def _read_base_full_live(sif: Path) -> dict[str, str] | None:
 
 
 def _resolve_base_sif(config) -> Path | None:
-    """The base SIF this agent runs on, or ``None`` when unresolvable."""
     ap = getattr(config, "apptainer", None)
     image = (getattr(ap, "image", "") or "").strip() if ap is not None else ""
     candidate = Path(image).expanduser() if image else None
@@ -360,13 +305,8 @@ def _resolve_base_sif(config) -> Path | None:
 
 
 def base_package_set_for(config) -> BasePackageSet | None:
-    """Read the base package set for ``config``'s image, honestly labelled.
-
-    Order: full live ``pip list`` (complete — ground truth) first, because
-    this function is only ever consulted AFTER a shadow install was found
-    and completeness now matters more than latency; then the baked scitex-*
-    manifest (partial); then ``None`` — the caller reports UNKNOWN.
-    """
+    """Base package set for ``config``'s image: complete live read first,
+    then the partial baked manifest, else ``None`` (caller says UNKNOWN)."""
     sif = _resolve_base_sif(config)
     if sif is None:
         return None
@@ -388,14 +328,8 @@ def inspect_agent_overlay(
     config,
     base_provider: Callable[[], BasePackageSet | None] | None = None,
 ) -> OverlayMaskVerdict:
-    """Per-agent entry: resolve the overlay from the SPEC, then inspect.
-
-    Uses :func:`..runtimes._apptainer_overlay.resolve_overlay_declaration`
-    — the resolver that answers "what overlay does apptainer actually get?"
-    in every spelling — so the detector looks at the same path the launch
-    does. ``base_provider`` is an injection seam for tests; production
-    leaves it ``None`` (lazy live-then-manifest read of the agent's SIF).
-    """
+    """Spec-driven entry: resolves the overlay exactly as the launch does
+    (every ``--overlay`` spelling). ``base_provider`` is a test seam."""
     ap = getattr(config, "apptainer", None)
     overlay_size = (getattr(ap, "overlay_size", "") or "") if ap is not None else ""
 
@@ -411,13 +345,8 @@ def inspect_agent_overlay(
 
 
 def sweep_agent_overlays(agent_configs=None) -> list[OverlayMaskVerdict]:
-    """Fleet sweep: one verdict per registered agent. Never raises.
-
-    ``agent_configs`` is an iterable of ``(name, AgentConfig)``; ``None``
-    enumerates the registry (same seam as ``sac versions``). One agent's
-    failure degrades to an UNKNOWN verdict carrying the reason — a sweep
-    that dies on agent 3 of 40 silently under-reports the other 37.
-    """
+    """One verdict per agent (registry-enumerated when ``agent_configs`` is
+    ``None``); a failing agent degrades to an UNKNOWN row, never a crash."""
     if agent_configs is None:
         from .._drift.versions import _load_agent_configs
 

--- a/src/scitex_agent_container/_maintenance/_overlay_masking_model.py
+++ b/src/scitex_agent_container/_maintenance/_overlay_masking_model.py
@@ -1,0 +1,175 @@
+"""Data + vocabulary for overlay-masking detection. No subprocess, no I/O.
+
+Companion to :mod:`._overlay_masking` (the scanner + verdict engine),
+split model-from-engine exactly like ``_worktree_gc_model`` /
+``_worktree_gc_predicate``.
+
+THE INCIDENT THIS VOCABULARY EXISTS FOR (2026-07-22)
+----------------------------------------------------
+Agent containers run a base SIF whose venv is ``/opt/venv-sac``. Each agent
+also mounts a writable directory overlay whose upper layer lives at::
+
+    ~/.scitex/agent-container/containers/overlays/<agent>/upper/
+
+Historical per-agent ``pip install``s left stale copies of ``scitex_cards``
+(0.16.0 … 0.17.4) in those upper layers. Overlayfs resolves the UPPER layer
+first, so a plain restart onto a rebuilt base did NOT migrate the package —
+the fossil kept winning, silently, forever. Every downstream symptom
+followed (resolve-store hitting a bundled example, coin-toss dist-info,
+cards never reaching the canonical board), plus a no-op restart wave and a
+premature all-clear that had to be retracted.
+
+Nothing in sac installs packages into overlay uppers today — the ``.def``
+bakes installs into ``/opt/venv-sac`` in the BASE, correctly. The fossils
+were hand-upgrades. A hand-cleanup restores the state but leaves the system
+able to re-enter it silently; the DETECTOR is the deliverable.
+
+The verdict / reason strings below are API, not debug text: they land in
+``sac agents check-health --json`` (and through it in the MCP
+``agent_health`` tool).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from .._drift.versions import DEFAULT_VENV
+
+__all__ = [
+    "OPERATIONAL_RULE",
+    "REASON_BASE_UNKNOWN",
+    "REASON_IMAGE_OVERLAY",
+    "REASON_INSPECT_ERROR",
+    "REASON_MASKED",
+    "REASON_NO_OVERLAY",
+    "REASON_NO_SHADOW_INSTALLS",
+    "REASON_OVERLAY_MISSING",
+    "REASON_OVERLAY_ONLY",
+    "REASON_UPPER_UNREADABLE",
+    "REASON_UPPER_VENV_UNTOUCHED",
+    "SHADOW_BASE_UNKNOWN",
+    "SHADOW_MASKED",
+    "SHADOW_OVERLAY_ONLY",
+    "VERDICT_CLEAN",
+    "VERDICT_MASKED",
+    "VERDICT_UNKNOWN",
+    "BasePackageSet",
+    "OverlayMaskVerdict",
+    "ShadowInstall",
+    "canonical_dist_name",
+]
+
+#: THE OPERATIONAL RULE, as ONE string, so the health output and any
+#: card/report quote the same words instead of paraphrasing drift into
+#: being. Documented here because the detector is the enforcement.
+OPERATIONAL_RULE = (
+    "NEVER pip-install a base-baked package into a running agent's overlay: "
+    "the overlay upper masks the base venv from then on, and every later "
+    "base rebuild is silently shadowed for that agent. Hotfix EITHER by "
+    "force-reinstalling the EXACT base version, OR by recreating the "
+    "overlay (stop the agent, remove <overlay>/upper" + DEFAULT_VENV + ", "
+    "restart onto the base)."
+)
+
+# Agent-level verdicts.
+VERDICT_MASKED = "masked"
+VERDICT_CLEAN = "clean"
+VERDICT_UNKNOWN = "unknown"
+
+# Per-shadow-install classifications.
+SHADOW_MASKED = "masked"  # base provides the package -> the upper shadows it
+SHADOW_OVERLAY_ONLY = "overlay-only"  # complete base set lacks it -> legit add
+SHADOW_BASE_UNKNOWN = "base-unknown"  # could not tell what the base provides
+
+# Reason tokens (machine token; the verdict carries a human ``detail`` too).
+REASON_NO_OVERLAY = "no-overlay-declared"
+REASON_IMAGE_OVERLAY = "image-overlay-unscannable"
+REASON_OVERLAY_MISSING = "overlay-root-missing"
+REASON_UPPER_UNREADABLE = "upper-unreadable"
+REASON_UPPER_VENV_UNTOUCHED = "upper-venv-untouched"
+REASON_NO_SHADOW_INSTALLS = "no-shadow-installs"
+REASON_MASKED = "base-baked-package-masked"
+REASON_BASE_UNKNOWN = "base-set-unknown"
+REASON_OVERLAY_ONLY = "overlay-only-installs"
+REASON_INSPECT_ERROR = "inspect-error"
+
+
+def canonical_dist_name(name: str) -> str:
+    """PEP 503-ish canonical dist name (lower, ``_``/``.`` -> ``-``)."""
+    return (name or "").strip().lower().replace("_", "-").replace(".", "-")
+
+
+@dataclass(frozen=True)
+class BasePackageSet:
+    """What the BASE image's venv provides — with honest coverage.
+
+    ``complete=True`` means a full ``pip list`` of the base venv: a package
+    absent from it is genuinely not base-provided. ``complete=False`` means
+    a partial read (the baked ``/opt/scitex-versions.json`` manifest covers
+    scitex-* only): membership proves MASKED, but absence proves nothing —
+    a miss classifies as :data:`SHADOW_BASE_UNKNOWN`, never as clean.
+    """
+
+    packages: Mapping[str, str]  # canonical dist name -> version
+    complete: bool
+    source: str = ""  # "live" | "manifest" | a test label
+
+
+@dataclass(frozen=True)
+class ShadowInstall:
+    """ONE dist-info found in an overlay upper's site-packages."""
+
+    package: str  # canonical dist name
+    version: str  # version the upper carries (i.e. what the agent RUNS)
+    dist_info: str  # host path of the dist-info directory (the evidence)
+    status: str  # SHADOW_MASKED | SHADOW_OVERLAY_ONLY | SHADOW_BASE_UNKNOWN
+    base_version: str = ""  # base's version when status == SHADOW_MASKED
+
+    def to_dict(self) -> dict:
+        return {
+            "package": self.package,
+            "version": self.version,
+            "dist_info": self.dist_info,
+            "status": self.status,
+            "base_version": self.base_version,
+        }
+
+
+@dataclass(frozen=True)
+class OverlayMaskVerdict:
+    """What we concluded about ONE agent's overlay — and the evidence why.
+
+    Three-valued, like every rail in ``_maintenance``: a state we could not
+    read (overlay root missing, unreadable upper, unreadable base package
+    set) is :data:`VERDICT_UNKNOWN` — never collapsed into clean. The
+    asymmetry is deliberate: a false UNKNOWN is a yellow line in health
+    output; a false CLEAN is the 2026-07-22 incident again.
+    """
+
+    agent: str
+    overlay_root: str  # "" when the spec declares no overlay
+    verdict: str  # VERDICT_MASKED | VERDICT_CLEAN | VERDICT_UNKNOWN
+    reason: str  # one REASON_* token
+    detail: str = ""  # human sentence expanding the token
+    shadows: tuple[ShadowInstall, ...] = ()
+    copyups: tuple[str, ...] = ()  # benign copy-up dirs (evidence, not alarm)
+    stray_dirs: tuple[str, ...] = ()  # non-taxonomy dirs, listed not judged
+    base_source: str = ""  # "" when the base set was never consulted
+
+    @property
+    def masked(self) -> tuple[ShadowInstall, ...]:
+        return tuple(s for s in self.shadows if s.status == SHADOW_MASKED)
+
+    def to_dict(self) -> dict:
+        return {
+            "agent": self.agent,
+            "overlay_root": self.overlay_root,
+            "verdict": self.verdict,
+            "reason": self.reason,
+            "detail": self.detail,
+            "shadows": [s.to_dict() for s in self.shadows],
+            "copyups": list(self.copyups),
+            "stray_dirs": list(self.stray_dirs),
+            "base_source": self.base_source,
+        }

--- a/src/scitex_agent_container/_maintenance/_overlay_masking_model.py
+++ b/src/scitex_agent_container/_maintenance/_overlay_masking_model.py
@@ -1,33 +1,4 @@
-"""Data + vocabulary for overlay-masking detection. No subprocess, no I/O.
-
-Companion to :mod:`._overlay_masking` (the scanner + verdict engine),
-split model-from-engine exactly like ``_worktree_gc_model`` /
-``_worktree_gc_predicate``.
-
-THE INCIDENT THIS VOCABULARY EXISTS FOR (2026-07-22)
-----------------------------------------------------
-Agent containers run a base SIF whose venv is ``/opt/venv-sac``. Each agent
-also mounts a writable directory overlay whose upper layer lives at::
-
-    ~/.scitex/agent-container/containers/overlays/<agent>/upper/
-
-Historical per-agent ``pip install``s left stale copies of ``scitex_cards``
-(0.16.0 … 0.17.4) in those upper layers. Overlayfs resolves the UPPER layer
-first, so a plain restart onto a rebuilt base did NOT migrate the package —
-the fossil kept winning, silently, forever. Every downstream symptom
-followed (resolve-store hitting a bundled example, coin-toss dist-info,
-cards never reaching the canonical board), plus a no-op restart wave and a
-premature all-clear that had to be retracted.
-
-Nothing in sac installs packages into overlay uppers today — the ``.def``
-bakes installs into ``/opt/venv-sac`` in the BASE, correctly. The fossils
-were hand-upgrades. A hand-cleanup restores the state but leaves the system
-able to re-enter it silently; the DETECTOR is the deliverable.
-
-The verdict / reason strings below are API, not debug text: they land in
-``sac agents check-health --json`` (and through it in the MCP
-``agent_health`` tool).
-"""
+"""Vocabulary + data types for overlay-masking detection (:mod:`._overlay_masking`)."""
 
 from __future__ import annotations
 
@@ -60,9 +31,7 @@ __all__ = [
     "canonical_dist_name",
 ]
 
-#: THE OPERATIONAL RULE, as ONE string, so the health output and any
-#: card/report quote the same words instead of paraphrasing drift into
-#: being. Documented here because the detector is the enforcement.
+# User-facing output (quoted verbatim by the health rendering), not a comment.
 OPERATIONAL_RULE = (
     "NEVER pip-install a base-baked package into a running agent's overlay: "
     "the overlay upper masks the base venv from then on, and every later "
@@ -72,17 +41,17 @@ OPERATIONAL_RULE = (
     "restart onto the base)."
 )
 
-# Agent-level verdicts.
+# Agent-level verdicts (API strings: `sac agents check-health --json`).
 VERDICT_MASKED = "masked"
 VERDICT_CLEAN = "clean"
 VERDICT_UNKNOWN = "unknown"
 
 # Per-shadow-install classifications.
-SHADOW_MASKED = "masked"  # base provides the package -> the upper shadows it
-SHADOW_OVERLAY_ONLY = "overlay-only"  # complete base set lacks it -> legit add
-SHADOW_BASE_UNKNOWN = "base-unknown"  # could not tell what the base provides
+SHADOW_MASKED = "masked"
+SHADOW_OVERLAY_ONLY = "overlay-only"
+SHADOW_BASE_UNKNOWN = "base-unknown"
 
-# Reason tokens (machine token; the verdict carries a human ``detail`` too).
+# Reason tokens (API; the verdict carries a human ``detail`` too).
 REASON_NO_OVERLAY = "no-overlay-declared"
 REASON_IMAGE_OVERLAY = "image-overlay-unscannable"
 REASON_OVERLAY_MISSING = "overlay-root-missing"
@@ -102,13 +71,10 @@ def canonical_dist_name(name: str) -> str:
 
 @dataclass(frozen=True)
 class BasePackageSet:
-    """What the BASE image's venv provides — with honest coverage.
+    """Packages the BASE image's venv provides.
 
-    ``complete=True`` means a full ``pip list`` of the base venv: a package
-    absent from it is genuinely not base-provided. ``complete=False`` means
-    a partial read (the baked ``/opt/scitex-versions.json`` manifest covers
-    scitex-* only): membership proves MASKED, but absence proves nothing —
-    a miss classifies as :data:`SHADOW_BASE_UNKNOWN`, never as clean.
+    ``complete=False`` (e.g. the baked scitex-* manifest) means absence
+    proves nothing: a miss classifies SHADOW_BASE_UNKNOWN, never clean.
     """
 
     packages: Mapping[str, str]  # canonical dist name -> version
@@ -118,13 +84,13 @@ class BasePackageSet:
 
 @dataclass(frozen=True)
 class ShadowInstall:
-    """ONE dist-info found in an overlay upper's site-packages."""
+    """One dist-info found in an overlay upper's site-packages."""
 
-    package: str  # canonical dist name
-    version: str  # version the upper carries (i.e. what the agent RUNS)
-    dist_info: str  # host path of the dist-info directory (the evidence)
+    package: str
+    version: str  # what the agent actually runs
+    dist_info: str  # evidence path
     status: str  # SHADOW_MASKED | SHADOW_OVERLAY_ONLY | SHADOW_BASE_UNKNOWN
-    base_version: str = ""  # base's version when status == SHADOW_MASKED
+    base_version: str = ""
 
     def to_dict(self) -> dict:
         return {
@@ -138,23 +104,16 @@ class ShadowInstall:
 
 @dataclass(frozen=True)
 class OverlayMaskVerdict:
-    """What we concluded about ONE agent's overlay — and the evidence why.
-
-    Three-valued, like every rail in ``_maintenance``: a state we could not
-    read (overlay root missing, unreadable upper, unreadable base package
-    set) is :data:`VERDICT_UNKNOWN` — never collapsed into clean. The
-    asymmetry is deliberate: a false UNKNOWN is a yellow line in health
-    output; a false CLEAN is the 2026-07-22 incident again.
-    """
+    """Tri-state verdict for one agent's overlay; UNKNOWN never reads clean."""
 
     agent: str
     overlay_root: str  # "" when the spec declares no overlay
     verdict: str  # VERDICT_MASKED | VERDICT_CLEAN | VERDICT_UNKNOWN
     reason: str  # one REASON_* token
-    detail: str = ""  # human sentence expanding the token
+    detail: str = ""
     shadows: tuple[ShadowInstall, ...] = ()
     copyups: tuple[str, ...] = ()  # benign copy-up dirs (evidence, not alarm)
-    stray_dirs: tuple[str, ...] = ()  # non-taxonomy dirs, listed not judged
+    stray_dirs: tuple[str, ...] = ()
     base_source: str = ""  # "" when the base set was never consulted
 
     @property

--- a/src/scitex_agent_container/cli_pkg/_health_liveness.py
+++ b/src/scitex_agent_container/cli_pkg/_health_liveness.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["liveness_payload", "print_liveness"]
+__all__ = ["liveness_payload", "print_inbox", "print_liveness"]
 
 # wedged = present but NOT working — magenta, distinct from unknown's yellow so
 # a "known-stuck, needs a restart" reads apart from a "we could not tell". It is
@@ -84,3 +84,25 @@ def print_liveness(console: Any, liveness: dict) -> None:
         console.print(
             f"[dim]  destructive action NOT authorised on this evidence: {veto}[/dim]"
         )
+
+
+def print_inbox(console: Any, name: str, subscribers: int, reachable: str) -> None:
+    """Render the inbox-reachability observation (moved verbatim from
+    ``status_cmds.health`` — the 512-line per-file cap)."""
+    from .._listen._reachability import UNKNOWN, UNREACHABLE
+
+    if reachable == UNREACHABLE:
+        console.print(
+            f"[yellow]inbox: NOT REACHABLE — 0 live subscribers. "
+            f"a2a_send to '{name}' will reach nobody (messages are queued and "
+            f"replayed when its channel adapter reconnects). The process is "
+            f"up; its inbox adapter is not attached. Do NOT force-restart on "
+            f"this alone.[/yellow]"
+        )
+    elif reachable == UNKNOWN:
+        console.print(
+            "[dim]inbox: unknown (could not reach sac listen to observe "
+            "subscribers)[/dim]"
+        )
+    else:
+        console.print(f"[green]inbox: reachable ({subscribers} subscriber(s))[/green]")

--- a/src/scitex_agent_container/cli_pkg/_health_overlay_masking.py
+++ b/src/scitex_agent_container/cli_pkg/_health_overlay_masking.py
@@ -1,0 +1,73 @@
+"""Overlay-masking verdict, rendered for ``sac agents check-health``.
+
+Sibling of :mod:`._health_liveness`, same doctrine: the observation is
+published NEXT TO the ``healthy`` bool, never folded into it. ``healthy``
+gates the command's exit code and automation keys on that; a MASKED overlay
+is a standing configuration hazard, not a dead process, and must not make a
+live agent read as down. The verdict is three-valued (masked / clean /
+unknown) because the detector can genuinely fail to see (overlay root
+missing on this host, unreadable upper, unreadable base package set) — and
+"could not tell" must render as UNKNOWN, never as clean.
+
+Detector: :mod:`.._maintenance._overlay_masking` (2026-07-22 incident —
+historical pip installs in overlay uppers silently shadowed the base venv's
+``scitex_cards`` across base rebuilds).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["overlay_masking_payload", "print_overlay_masking"]
+
+_VERDICT_COLOUR = {
+    "masked": "red",
+    "clean": "green",
+    "unknown": "yellow",
+}
+
+
+def overlay_masking_payload(name: str, config: Any) -> dict:
+    """Resolve ``name``'s overlay-masking verdict as a JSON-ready dict.
+
+    Tolerant by construction: any failure to gather degrades to an UNKNOWN
+    verdict carrying the reason — never to a fabricated CLEAN, and never to
+    an exception that takes the health command down.
+    """
+    from .._maintenance._overlay_masking import inspect_agent_overlay
+    from .._maintenance._overlay_masking_model import (
+        REASON_INSPECT_ERROR,
+        VERDICT_UNKNOWN,
+        OverlayMaskVerdict,
+    )
+
+    try:
+        return inspect_agent_overlay(name, config).to_dict()
+    except Exception as exc:  # stx-allow: fallback (reason: an un-inspectable overlay is UNKNOWN with its reason — never a fabricated CLEAN, and never a crashed health command)
+        return OverlayMaskVerdict(
+            agent=name,
+            overlay_root="",
+            verdict=VERDICT_UNKNOWN,
+            reason=REASON_INSPECT_ERROR,
+            detail=f"could not inspect overlay ({type(exc).__name__}: {exc})",
+        ).to_dict()
+
+
+def print_overlay_masking(console: Any, payload: dict) -> None:
+    """Print the verdict AND why; on MASKED, print the operational rule."""
+    from .._maintenance._overlay_masking_model import OPERATIONAL_RULE
+
+    verdict = str(payload.get("verdict", "unknown"))
+    colour = _VERDICT_COLOUR.get(verdict, "yellow")
+    detail = payload.get("detail") or payload.get("reason") or "?"
+    console.print(f"[{colour}]overlay: {verdict} — {detail}[/{colour}]")
+    if verdict != "masked":
+        return
+    for shadow in payload.get("shadows", []):
+        if shadow.get("status") == "masked":
+            console.print(
+                f"[red]  {shadow.get('package')} {shadow.get('version')} "
+                f"masks base {shadow.get('base_version')} — "
+                f"{shadow.get('dist_info')}[/red]"
+            )
+    console.print(f"[dim]  {OPERATIONAL_RULE}[/dim]")

--- a/src/scitex_agent_container/cli_pkg/_health_overlay_masking.py
+++ b/src/scitex_agent_container/cli_pkg/_health_overlay_masking.py
@@ -1,17 +1,7 @@
-"""Overlay-masking verdict, rendered for ``sac agents check-health``.
+"""Overlay-masking observation for ``sac agents check-health``.
 
-Sibling of :mod:`._health_liveness`, same doctrine: the observation is
-published NEXT TO the ``healthy`` bool, never folded into it. ``healthy``
-gates the command's exit code and automation keys on that; a MASKED overlay
-is a standing configuration hazard, not a dead process, and must not make a
-live agent read as down. The verdict is three-valued (masked / clean /
-unknown) because the detector can genuinely fail to see (overlay root
-missing on this host, unreadable upper, unreadable base package set) — and
-"could not tell" must render as UNKNOWN, never as clean.
-
-Detector: :mod:`.._maintenance._overlay_masking` (2026-07-22 incident —
-historical pip installs in overlay uppers silently shadowed the base venv's
-``scitex_cards`` across base rebuilds).
+Published NEXT TO ``healthy`` (never folded into the exit code), same as
+:mod:`._health_liveness`. Detector: :mod:`.._maintenance._overlay_masking`.
 """
 
 from __future__ import annotations
@@ -28,12 +18,7 @@ _VERDICT_COLOUR = {
 
 
 def overlay_masking_payload(name: str, config: Any) -> dict:
-    """Resolve ``name``'s overlay-masking verdict as a JSON-ready dict.
-
-    Tolerant by construction: any failure to gather degrades to an UNKNOWN
-    verdict carrying the reason — never to a fabricated CLEAN, and never to
-    an exception that takes the health command down.
-    """
+    """JSON-ready verdict dict; any gather failure degrades to UNKNOWN."""
     from .._maintenance._overlay_masking import inspect_agent_overlay
     from .._maintenance._overlay_masking_model import (
         REASON_INSPECT_ERROR,
@@ -54,7 +39,7 @@ def overlay_masking_payload(name: str, config: Any) -> dict:
 
 
 def print_overlay_masking(console: Any, payload: dict) -> None:
-    """Print the verdict AND why; on MASKED, print the operational rule."""
+    """One verdict line; on MASKED, each shadow plus the operational rule."""
     from .._maintenance._overlay_masking_model import OPERATIONAL_RULE
 
     verdict = str(payload.get("verdict", "unknown"))

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -455,7 +455,6 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
     # a detached inbox adapter, not a dead agent, and anything that
     # auto-restarts on it would destroy a healthy session. Observation only.
     from .._lifecycle.inbox_probe import probe_inbox_reachability
-    from .._listen._reachability import UNKNOWN, UNREACHABLE
 
     subscribers, reachable = probe_inbox_reachability(name)
 
@@ -463,9 +462,18 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
     # alongside the ``healthy`` bool rather than replacing it — a bool cannot
     # say "I could not tell", and ``healthy`` gates this command's exit code.
     # See :mod:`._health_liveness`.
-    from ._health_liveness import liveness_payload, print_liveness
+    from ._health_liveness import liveness_payload, print_inbox, print_liveness
 
     liveness = liveness_payload(name, config)
+
+    # Overlay-masking (2026-07-22 incident): does this agent's overlay UPPER
+    # carry a dist-info that shadows a base-baked package? Three-valued and
+    # observation-only — same restraint as ``liveness``; a MASKED overlay is
+    # a standing hazard, not a dead process, so it never flips ``healthy``.
+    # See :mod:`._health_overlay_masking`.
+    from ._health_overlay_masking import overlay_masking_payload, print_overlay_masking
+
+    overlay_masking = overlay_masking_payload(name, config)
 
     if use_json:
         click.echo(
@@ -477,6 +485,7 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
                     "inbox_subscribers": subscribers,
                     "inbox_reachable": reachable,
                     "liveness": liveness,
+                    "overlay_masking": overlay_masking,
                 },
                 indent=2,
             )
@@ -491,22 +500,8 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
         console.print(f"[red]{message}[/red]")
 
     print_liveness(console, liveness)
-
-    if reachable == UNREACHABLE:
-        console.print(
-            f"[yellow]inbox: NOT REACHABLE — 0 live subscribers. "
-            f"a2a_send to '{name}' will reach nobody (messages are queued and "
-            f"replayed when its channel adapter reconnects). The process is "
-            f"up; its inbox adapter is not attached. Do NOT force-restart on "
-            f"this alone.[/yellow]"
-        )
-    elif reachable == UNKNOWN:
-        console.print(
-            "[dim]inbox: unknown (could not reach sac listen to observe "
-            "subscribers)[/dim]"
-        )
-    else:
-        console.print(f"[green]inbox: reachable ({subscribers} subscriber(s))[/green]")
+    print_overlay_masking(console, overlay_masking)
+    print_inbox(console, name, subscribers, reachable)
 
     if not is_healthy:
         sys.exit(1)

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -466,11 +466,7 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
 
     liveness = liveness_payload(name, config)
 
-    # Overlay-masking (2026-07-22 incident): does this agent's overlay UPPER
-    # carry a dist-info that shadows a base-baked package? Three-valued and
-    # observation-only — same restraint as ``liveness``; a MASKED overlay is
-    # a standing hazard, not a dead process, so it never flips ``healthy``.
-    # See :mod:`._health_overlay_masking`.
+    # Observation-only like ``liveness``: never flips ``healthy``.
     from ._health_overlay_masking import overlay_masking_payload, print_overlay_masking
 
     overlay_masking = overlay_masking_payload(name, config)

--- a/tests/scitex_agent_container/_maintenance/test__overlay_masking.py
+++ b/tests/scitex_agent_container/_maintenance/test__overlay_masking.py
@@ -1,0 +1,460 @@
+"""Mutation-proof tests for the overlay-masking detector (2026-07-22 incident).
+
+Both directions are exercised, because a detector that never fires and one
+that always fires are equally useless:
+
+* RED — a planted stale ``scitex_cards`` dist-info in a temp overlay upper,
+  for a package the base provides, MUST read MASKED.
+* GREEN — the benign overlayfs copy-up shape (package dir with only
+  ``__pycache__``, zero top-level ``*.py``, no dist-info) MUST read CLEAN.
+  Counting these as masking is exactly the false scare the incident sweep
+  already produced once.
+
+No mocks: real temp directory layouts mirroring
+``overlays/<agent>/upper/opt/venv-sac/lib/python3.12/site-packages``; the
+base-set seam is injected data (the ``BasePackageSet`` value object), and
+the apptainer path runs a REAL fake binary on PATH (same pattern as
+``_drift/test_versions.py``). Everything lives under ``tmp_path`` — the
+operator's real ``~/.scitex/agent-container/`` tree is never touched.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scitex_agent_container._maintenance import _overlay_masking as OM
+from scitex_agent_container._maintenance import _overlay_masking_model as M
+
+# The base venv's truth, as a COMPLETE set (full pip list): scitex-cards is
+# base-baked at 0.17.5 — the incident package.
+_BASE = M.BasePackageSet(
+    packages={"scitex-cards": "0.17.5", "click": "8.1.7"},
+    complete=True,
+    source="test-live",
+)
+
+# The same truth read PARTIALLY (baked manifest covers scitex-* only).
+_BASE_PARTIAL = M.BasePackageSet(
+    packages={"scitex-cards": "0.17.5"},
+    complete=False,
+    source="test-manifest",
+)
+
+
+def _overlay(tmp_path: Path, agent: str = "agent-x") -> Path:
+    """A temp overlay mirroring the fleet layout, upper venv provisioned."""
+    root = tmp_path / "overlays" / agent
+    (root / "upper" / "opt/venv-sac/lib/python3.12/site-packages").mkdir(parents=True)
+    (root / "work").mkdir(parents=True)
+    return root
+
+
+def _site(root: Path) -> Path:
+    return root / "upper" / "opt/venv-sac/lib/python3.12/site-packages"
+
+
+def _plant_dist_info(root: Path, name: str, version: str) -> Path:
+    """A REAL pip-install fossil: ``<Name>-<Version>.dist-info`` + pkg dir."""
+    site = _site(root)
+    dist_info = site / f"{name}-{version}.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(f"Name: {name}\nVersion: {version}\n")
+    (dist_info / "RECORD").write_text("")
+    pkg = site / name
+    pkg.mkdir(exist_ok=True)
+    (pkg / "__init__.py").write_text("")
+    return dist_info
+
+
+def _plant_benign_copyup(root: Path, name: str) -> Path:
+    """The benign overlayfs copy-up: only ``__pycache__``, no ``*.py``."""
+    pycache = _site(root) / name / "__pycache__"
+    pycache.mkdir(parents=True)
+    (pycache / "__init__.cpython-312.pyc").write_bytes(b"\x00fake-pyc")
+    return pycache.parent
+
+
+def _config_for(root: Path, **apptainer_extra) -> SimpleNamespace:
+    ap = SimpleNamespace(
+        overlay=str(root), raw_args=[], image="", overlay_size="", **apptainer_extra
+    )
+    return SimpleNamespace(apptainer=ap, workdir=str(root.parent), name="agent-x")
+
+
+# ---------------------------------------------------------------------------
+# RED direction — the planted fossil MUST fire
+# ---------------------------------------------------------------------------
+def test_stale_distinfo_for_base_package_reads_masked(tmp_path):
+    # Arrange — the incident shape: scitex_cards 0.16.1 fossil in the upper.
+    root = _overlay(tmp_path)
+    _plant_dist_info(root, "scitex_cards", "0.16.1")
+    # Act
+    verdict = OM.inspect_overlay("agent-x", root, _BASE)
+    # Assert
+    assert verdict.verdict == M.VERDICT_MASKED
+
+
+def test_masked_shadow_row_carries_fossil_and_base_versions(tmp_path):
+    # Arrange
+    root = _overlay(tmp_path)
+    _plant_dist_info(root, "scitex_cards", "0.16.1")
+    # Act
+    shadow = OM.inspect_overlay("agent-x", root, _BASE).shadows[0]
+    # Assert — canonicalised name, fossil version, base version, evidence path.
+    assert (
+        shadow.package,
+        shadow.version,
+        shadow.base_version,
+        shadow.status,
+    ) == ("scitex-cards", "0.16.1", "0.17.5", M.SHADOW_MASKED)
+
+
+def test_same_version_distinfo_is_still_masked(tmp_path):
+    # Arrange — the rule has no version qualifier: a same-version install
+    # still shadows every FUTURE base rebuild.
+    root = _overlay(tmp_path)
+    _plant_dist_info(root, "scitex_cards", "0.17.5")
+    # Act
+    verdict = OM.inspect_overlay("agent-x", root, _BASE)
+    # Assert
+    assert verdict.verdict == M.VERDICT_MASKED
+
+
+def test_masked_detail_names_the_shadowed_package(tmp_path):
+    # Arrange
+    root = _overlay(tmp_path)
+    _plant_dist_info(root, "scitex_cards", "0.16.1")
+    # Act
+    verdict = OM.inspect_overlay("agent-x", root, _BASE)
+    # Assert
+    assert "scitex-cards 0.16.1 (base 0.17.5)" in verdict.detail
+
+
+# ---------------------------------------------------------------------------
+# GREEN direction — the benign copy-up MUST NOT fire
+# ---------------------------------------------------------------------------
+def test_pycache_only_copyup_reads_clean(tmp_path):
+    # Arrange — the false-scare shape: bare pkg dir, only __pycache__,
+    # zero top-level *.py, NO dist-info.
+    root = _overlay(tmp_path)
+    _plant_benign_copyup(root, "scitex_cards")
+    # Act
+    verdict = OM.inspect_overlay("agent-x", root, _BASE)
+    # Assert
+    assert verdict.verdict == M.VERDICT_CLEAN
+
+
+def test_pycache_only_copyup_is_listed_as_evidence(tmp_path):
+    # Arrange
+    root = _overlay(tmp_path)
+    _plant_benign_copyup(root, "scitex_cards")
+    # Act
+    verdict = OM.inspect_overlay("agent-x", root, _BASE)
+    # Assert — visible in the report, absent from the alarm.
+    assert verdict.copyups == ("scitex_cards",)
+
+
+def test_untouched_upper_venv_reads_clean(tmp_path):
+    # Arrange — the fleet-normal state: overlay exists, upper has no venv.
+    root = tmp_path / "overlays" / "agent-x"
+    (root / "upper").mkdir(parents=True)
+    (root / "work").mkdir(parents=True)
+    # Act
+    verdict = OM.inspect_overlay("agent-x", root, _BASE)
+    # Assert
+    assert (verdict.verdict, verdict.reason) == (
+        M.VERDICT_CLEAN,
+        M.REASON_UPPER_VENV_UNTOUCHED,
+    )
+
+
+def test_no_declared_overlay_reads_clean(tmp_path):
+    # Arrange — no overlay at all: nothing can mask the base.
+    overlay_root = None
+    # Act
+    verdict = OM.inspect_overlay("agent-x", overlay_root, _BASE)
+    # Assert
+    assert (verdict.verdict, verdict.reason) == (
+        M.VERDICT_CLEAN,
+        M.REASON_NO_OVERLAY,
+    )
+
+
+def test_overlay_only_install_with_complete_base_reads_clean(tmp_path):
+    # Arrange — an add the base does not provide: the legitimate use of a
+    # writable overlay, not masking.
+    root = _overlay(tmp_path)
+    _plant_dist_info(root, "requests", "2.31.0")
+    # Act
+    verdict = OM.inspect_overlay("agent-x", root, _BASE)
+    # Assert
+    assert (verdict.verdict, verdict.shadows[0].status) == (
+        M.VERDICT_CLEAN,
+        M.SHADOW_OVERLAY_ONLY,
+    )
+
+
+# ---------------------------------------------------------------------------
+# UNKNOWN direction — "could not tell" must never read clean
+# ---------------------------------------------------------------------------
+def test_missing_overlay_root_reads_unknown_not_clean(tmp_path):
+    # Arrange — declared, but nothing on disk: could be "never provisioned"
+    # or "wrong host / wrong HOME"; we cannot tell which.
+    root = tmp_path / "overlays" / "agent-x"
+    # Act
+    verdict = OM.inspect_overlay("agent-x", root, _BASE)
+    # Assert
+    assert (verdict.verdict, verdict.reason) == (
+        M.VERDICT_UNKNOWN,
+        M.REASON_OVERLAY_MISSING,
+    )
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores 0o000 modes")
+def test_unreadable_site_packages_reads_unknown(tmp_path):
+    # Arrange — a real permission wall, not a mock.
+    root = _overlay(tmp_path)
+    site = _site(root)
+    site.chmod(0o000)
+    try:
+        # Act
+        verdict = OM.inspect_overlay("agent-x", root, _BASE)
+    finally:
+        site.chmod(0o755)
+    # Assert
+    assert (verdict.verdict, verdict.reason) == (
+        M.VERDICT_UNKNOWN,
+        M.REASON_UPPER_UNREADABLE,
+    )
+
+
+def test_shadow_with_unreadable_base_reads_unknown(tmp_path):
+    # Arrange — a dist-info in the upper, but the base set could not be
+    # read: masking can not be ruled out, so this must NOT be clean.
+    root = _overlay(tmp_path)
+    _plant_dist_info(root, "scitex_cards", "0.16.1")
+    # Act
+    verdict = OM.inspect_overlay("agent-x", root, None)
+    # Assert
+    assert (verdict.verdict, verdict.reason) == (
+        M.VERDICT_UNKNOWN,
+        M.REASON_BASE_UNKNOWN,
+    )
+
+
+def test_partial_base_set_miss_reads_unknown(tmp_path):
+    # Arrange — the baked manifest covers scitex-* only; a numpy dist-info
+    # missing from it proves NOTHING about what the base provides.
+    root = _overlay(tmp_path)
+    _plant_dist_info(root, "numpy", "2.0.0")
+    # Act
+    verdict = OM.inspect_overlay("agent-x", root, _BASE_PARTIAL)
+    # Assert
+    assert verdict.verdict == M.VERDICT_UNKNOWN
+
+
+def test_partial_base_set_hit_still_reads_masked(tmp_path):
+    # Arrange — membership in a partial set IS proof: manifest says the
+    # base bakes scitex-cards, and the upper shadows it.
+    root = _overlay(tmp_path)
+    _plant_dist_info(root, "scitex_cards", "0.16.0")
+    # Act
+    verdict = OM.inspect_overlay("agent-x", root, _BASE_PARTIAL)
+    # Assert
+    assert verdict.verdict == M.VERDICT_MASKED
+
+
+def test_image_overlay_reads_unknown(tmp_path):
+    # Arrange — a loopback image overlay is not host-readable.
+    img = tmp_path / "agent-x.overlay.img"
+    img.write_bytes(b"\x00ext3")
+    # Act
+    verdict = OM.inspect_overlay("agent-x", img, _BASE)
+    # Assert
+    assert (verdict.verdict, verdict.reason) == (
+        M.VERDICT_UNKNOWN,
+        M.REASON_IMAGE_OVERLAY,
+    )
+
+
+# ---------------------------------------------------------------------------
+# laziness — a clean agent must never pay for a base read
+# ---------------------------------------------------------------------------
+def test_base_provider_not_consulted_when_upper_is_clean(tmp_path):
+    # Arrange
+    root = _overlay(tmp_path)
+    calls: list[int] = []
+
+    def provider() -> M.BasePackageSet:
+        calls.append(1)
+        return _BASE
+
+    # Act
+    OM.inspect_overlay("agent-x", root, provider)
+    # Assert — no dist-info found, so the (expensive) base read never ran.
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# per-agent entry: spec-driven overlay resolution
+# ---------------------------------------------------------------------------
+def test_agent_inspect_resolves_modeled_overlay_field(tmp_path):
+    # Arrange
+    root = _overlay(tmp_path)
+    _plant_dist_info(root, "scitex_cards", "0.16.1")
+    config = _config_for(root)
+    # Act
+    verdict = OM.inspect_agent_overlay("agent-x", config, lambda: _BASE)
+    # Assert
+    assert verdict.verdict == M.VERDICT_MASKED
+
+
+def test_agent_inspect_resolves_eq_joined_raw_arg_overlay(tmp_path):
+    # Arrange — the =-joined spelling that once made an overlay invisible
+    # to sac's narrower resolver; the detector must see every spelling.
+    root = _overlay(tmp_path)
+    _plant_dist_info(root, "scitex_cards", "0.16.1")
+    ap = SimpleNamespace(
+        overlay="", raw_args=[f"--overlay={root}"], image="", overlay_size=""
+    )
+    config = SimpleNamespace(apptainer=ap, workdir=str(root.parent), name="agent-x")
+    # Act
+    verdict = OM.inspect_agent_overlay("agent-x", config, lambda: _BASE)
+    # Assert
+    assert verdict.verdict == M.VERDICT_MASKED
+
+
+# ---------------------------------------------------------------------------
+# fleet sweep — one bad agent degrades to UNKNOWN, never kills the pass
+# ---------------------------------------------------------------------------
+def test_sweep_reports_one_verdict_per_agent(tmp_path):
+    # Arrange — one agent whose declared overlay is missing (UNKNOWN before
+    # any base consultation — keeps the test hermetic: the sweep must never
+    # be driven into reading the REAL containers dir), one clean.
+    missing_root = tmp_path / "overlays" / "agent-missing"
+    clean_root = _overlay(tmp_path, "agent-clean")
+    configs = [
+        ("agent-missing", _config_for(missing_root)),
+        ("agent-clean", _config_for(clean_root)),
+    ]
+    # Act
+    verdicts = [v.verdict for v in OM.sweep_agent_overlays(configs)]
+    # Assert
+    assert verdicts == [M.VERDICT_UNKNOWN, M.VERDICT_CLEAN]
+
+
+def test_sweep_survives_an_exploding_agent_config(tmp_path):
+    # Arrange
+    class _Boom:
+        @property
+        def apptainer(self):
+            raise RuntimeError("malformed spec")
+
+    clean_root = _overlay(tmp_path, "agent-clean")
+    configs = [("agent-boom", _Boom()), ("agent-clean", _config_for(clean_root))]
+    # Act
+    verdicts = [v.verdict for v in OM.sweep_agent_overlays(configs)]
+    # Assert — the bad agent is an UNKNOWN row, the good one still reported.
+    assert verdicts == [M.VERDICT_UNKNOWN, M.VERDICT_CLEAN]
+
+
+# ---------------------------------------------------------------------------
+# base-set acquisition through a REAL fake apptainer on PATH
+# ---------------------------------------------------------------------------
+_FULL_PIP_LIST = json.dumps(
+    [
+        {"name": "scitex-cards", "version": "0.17.5"},
+        {"name": "click", "version": "8.1.7"},
+        {"name": "numpy", "version": "2.0.0"},
+    ]
+)
+
+
+def _install_branching_apptainer(
+    bin_dir: Path, env, *, piplist_ok: bool, manifest_ok: bool
+) -> None:
+    """A REAL fake ``apptainer`` on PATH branching on inner argv, exactly
+    like ``_drift/test_versions.py`` does — no patched imports."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    script = bin_dir / "apptainer"
+    manifest = json.dumps([{"name": "scitex-cards", "version": "0.17.5"}])
+    body = (
+        f"#!{sys.executable}\n"
+        "import sys\n"
+        "inner = sys.argv[3:] if len(sys.argv) > 3 else []\n"
+        "if 'cat' in sys.argv and any(a.endswith('scitex-versions.json') for a in sys.argv):\n"
+        f"    ok = {manifest_ok!r}\n"
+        f"    sys.stdout.write({manifest!r} if ok else '')\n"
+        "    sys.exit(0 if ok else 1)\n"
+        "if '--format=json' in sys.argv:\n"
+        f"    ok = {piplist_ok!r}\n"
+        f"    sys.stdout.write({_FULL_PIP_LIST!r} if ok else '')\n"
+        "    sys.exit(0 if ok else 1)\n"
+        "sys.exit(2)\n"
+    )
+    script.write_text(body)
+    script.chmod(0o755)
+    env.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+
+
+def test_base_set_prefers_complete_live_pip_list(tmp_path, env_save_restore):
+    # Arrange — a dummy SIF file the config points at directly.
+    sif = tmp_path / "sac-scitex.sif"
+    sif.write_bytes(b"SIF")
+    _install_branching_apptainer(
+        tmp_path / "bin", env_save_restore, piplist_ok=True, manifest_ok=True
+    )
+    config = SimpleNamespace(
+        apptainer=SimpleNamespace(image=str(sif), overlay="", raw_args=[]),
+        workdir=str(tmp_path),
+    )
+    # Act
+    base = OM.base_package_set_for(config)
+    # Assert — the UNFILTERED live read won: complete, and non-scitex rows kept.
+    assert (base.complete, base.source, base.packages["numpy"]) == (
+        True,
+        "live",
+        "2.0.0",
+    )
+
+
+def test_base_set_falls_back_to_partial_manifest(tmp_path, env_save_restore):
+    # Arrange — live pip list fails; the baked manifest still answers.
+    sif = tmp_path / "sac-scitex.sif"
+    sif.write_bytes(b"SIF")
+    _install_branching_apptainer(
+        tmp_path / "bin", env_save_restore, piplist_ok=False, manifest_ok=True
+    )
+    config = SimpleNamespace(
+        apptainer=SimpleNamespace(image=str(sif), overlay="", raw_args=[]),
+        workdir=str(tmp_path),
+    )
+    # Act
+    base = OM.base_package_set_for(config)
+    # Assert — honestly labelled PARTIAL: a miss must classify base-unknown.
+    assert (base.complete, base.source) == (False, "manifest")
+
+
+def test_base_set_unreadable_returns_none(tmp_path, env_save_restore):
+    # Arrange — both reads fail: the answer is "could not tell", never {}.
+    sif = tmp_path / "sac-scitex.sif"
+    sif.write_bytes(b"SIF")
+    _install_branching_apptainer(
+        tmp_path / "bin", env_save_restore, piplist_ok=False, manifest_ok=False
+    )
+    config = SimpleNamespace(
+        apptainer=SimpleNamespace(image=str(sif), overlay="", raw_args=[]),
+        workdir=str(tmp_path),
+    )
+    # Act
+    base = OM.base_package_set_for(config)
+    # Assert
+    assert base is None

--- a/tests/scitex_agent_container/cli_pkg/test__health_overlay_masking.py
+++ b/tests/scitex_agent_container/cli_pkg/test__health_overlay_masking.py
@@ -1,0 +1,101 @@
+"""The overlay-masking observation in ``sac agents check-health``.
+
+Same doctrine as the liveness payload it sits beside: published NEXT TO
+the ``healthy`` bool, tolerant by construction (a failure to gather is an
+UNKNOWN payload, never a crashed health command, never a fabricated CLEAN),
+and the RED rendering must quote THE operational rule verbatim so the
+operator reading a fired detector also reads what not to do next time.
+
+No mocks: real temp overlay layouts; rendering asserted through a real
+``rich.console.Console`` writing to a real ``StringIO``.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from types import SimpleNamespace
+
+from rich.console import Console
+
+from scitex_agent_container._maintenance import _overlay_masking_model as M
+from scitex_agent_container.cli_pkg._health_overlay_masking import (
+    overlay_masking_payload,
+    print_overlay_masking,
+)
+
+
+def _overlay_with_fossil(tmp_path: Path) -> Path:
+    root = tmp_path / "overlays" / "agent-x"
+    site = root / "upper" / "opt/venv-sac/lib/python3.12/site-packages"
+    site.mkdir(parents=True)
+    dist_info = site / "scitex_cards-0.16.1.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text("Name: scitex_cards\nVersion: 0.16.1\n")
+    return root
+
+
+def _config_for(root: Path) -> SimpleNamespace:
+    ap = SimpleNamespace(overlay=str(root), raw_args=[], image="", overlay_size="")
+    return SimpleNamespace(apptainer=ap, workdir=str(root.parent), name="agent-x")
+
+
+def test_payload_reports_clean_for_untouched_overlay(tmp_path):
+    # Arrange
+    root = tmp_path / "overlays" / "agent-x"
+    (root / "upper").mkdir(parents=True)
+    payload = overlay_masking_payload("agent-x", _config_for(root))
+    # Act
+    verdict = payload["verdict"]
+    # Assert
+    assert verdict == M.VERDICT_CLEAN
+
+
+def test_payload_degrades_exploding_config_to_unknown(tmp_path):
+    # Arrange — a config whose attribute access raises must yield an
+    # UNKNOWN payload, never crash the health command or read clean.
+    class _Boom:
+        @property
+        def apptainer(self):
+            raise RuntimeError("malformed spec")
+
+    # Act
+    payload = overlay_masking_payload("agent-x", _Boom())
+    # Assert
+    assert payload["verdict"] == M.VERDICT_UNKNOWN
+
+
+def test_masked_rendering_quotes_the_operational_rule(tmp_path):
+    # Arrange — a real masked verdict (fossil dist-info + injected base).
+    from scitex_agent_container._maintenance._overlay_masking import (
+        inspect_agent_overlay,
+    )
+
+    base = M.BasePackageSet(
+        packages={"scitex-cards": "0.17.5"}, complete=True, source="test-live"
+    )
+    root = _overlay_with_fossil(tmp_path)
+    payload = inspect_agent_overlay(
+        "agent-x", _config_for(root), lambda: base
+    ).to_dict()
+    buffer = io.StringIO()
+    console = Console(file=buffer, width=200, no_color=True)
+    # Act
+    print_overlay_masking(console, payload)
+    # Assert — the RED line carries the rule, verbatim from the one string.
+    assert "NEVER pip-install a base-baked package" in buffer.getvalue()
+
+
+def test_clean_rendering_stays_a_single_green_line(tmp_path):
+    # Arrange
+    root = tmp_path / "overlays" / "agent-x"
+    (root / "upper").mkdir(parents=True)
+    payload = overlay_masking_payload("agent-x", _config_for(root))
+    buffer = io.StringIO()
+    console = Console(file=buffer, width=200, no_color=True)
+    # Act
+    print_overlay_masking(console, payload)
+    # Assert — no rule lecture on a clean agent.
+    assert "NEVER pip-install" not in buffer.getvalue()


### PR DESCRIPTION
## Why

Incident 2026-07-22: historical per-agent `pip install`s left stale `scitex_cards` copies (0.16.0–0.17.4) in agent overlay UPPER layers (`~/.scitex/agent-container/containers/overlays/<agent>/upper/opt/venv-sac/…/site-packages/`). Overlayfs resolves the upper first, so restarts onto a rebuilt base were **silent no-ops** — resolve-store hit a bundled example, dist-info was a coin toss, cards never reached the canonical board, and an all-clear had to be retracted.

Nothing in sac's source installs into overlay uppers today (the `.def` bakes into the base, correctly); these were hand-upgrade fossils. A hand-cleanup restores the state but leaves the system able to re-enter it silently — so **the detector is the deliverable**.

## What

- **`_maintenance/_overlay_masking.py` + `_overlay_masking_model.py`** (model/engine split mirroring `_worktree_gc_*`): the sweep-validated rule —
  - a `*.dist-info` under the upper's `opt/venv-sac/lib/python*/site-packages` for a package the base provides = **MASKED** (no version qualifier: a same-version install still shadows every future base rebuild);
  - a bare package dir with only `__pycache__` (zero top-level `*.py`, no dist-info) is a **benign overlayfs copy-up**, NOT masking — counting those already caused one false fleet scare; they are listed as `copyups` evidence, never alarmed on;
  - **three-valued**: missing overlay root, unreadable upper, image overlay, or unreadable base package set report **UNKNOWN** — "could not tell" never reads as clean.
- **Surfaced in `sac agents check-health`** (human rendering + `--json` `overlay_masking` key, which flows through the MCP `agent_health` tool unchanged). Observation-only, published NEXT TO `healthy` like the liveness verdict — a masked overlay is a standing hazard, not a dead process, so it never flips the exit code. Fleet-wide entry: `sweep_agent_overlays()`.
- **Lazy base-set read**: the base is consulted only when the upper actually carries a dist-info (a clean agent costs a pure FS scan, no `apptainer exec`). When consulted: unfiltered live `pip list` of the SIF venv (complete — an overlay `click` masks as hard as an overlay `scitex-cards`), falling back to the baked scitex-* manifest honestly labelled PARTIAL (a miss there classifies `base-unknown`, not clean).
- **Operational rule documented alongside** as ONE string (`OPERATIONAL_RULE`), quoted verbatim by the RED rendering and by `docs/isolation.md` §7: *NEVER pip-install a base-baked package into a running agent's overlay; hotfix either force-reinstalls the EXACT base version or recreates the overlay.*
- `status_cmds.health`'s inbox rendering extracted to `_health_liveness.print_inbox` (the file sat exactly at the 512-line per-file cap).

## Mutation proof (both directions observed failing)

- **M1 — silenced detector** (dist-info collection disabled): `test_stale_distinfo_for_base_package_reads_masked` FAILED with `assert 'clean' == 'masked'`. The RED test catches a detector that never fires.
- **M2 — false-scare detector** (bare copy-up dirs counted as shadows): `test_pycache_only_copyup_reads_clean` FAILED with `assert 'masked' == 'clean'`. The GREEN test rejects a detector that always fires.
- Reverted; full suites green: 153 passed (`tests/scitex_agent_container/_maintenance/` + `_drift/` + health glue), 45 passed (`tests/scitex_agent_container/cli_pkg/test_status_cmds.py`).

All fixtures under `tmp_path`; the real `~/.scitex/agent-container/` tree is never touched (the fleet-sweep test was deliberately shaped so no code path can even *read* the real containers dir).

```
/opt/venv-sac/bin/python -m pytest tests/scitex_agent_container/_maintenance/test__overlay_masking.py tests/scitex_agent_container/cli_pkg/test__health_overlay_masking.py -v
```

## Version

`0.24.11 → 0.24.13` (`0.24.12` left for the in-flight sibling `fix/auto-merge-dispatches-post-merge-ci`); CHANGELOG entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wf61fTTKUDcDbbq859vXkv
