### PR TITLE
chore(ci): trim auto-merge prose comments to minimal one-liners

### DIFF
--- a/.github/workflows/auto-merge-to-develop.yaml
+++ b/.github/workflows/auto-merge-to-develop.yaml
@@ -33,23 +33,8 @@ name: auto-merge-to-develop
 # whole job on schedule, and do NOT make the job exit in a way that leaves no run
 # record. A boring green run every 15 minutes IS the product.
 #
-# *** A github.token MERGE FIRES NOTHING ON develop. *** GitHub suppresses
-# workflow triggers for pushes made with the default workflow token
-# (recursive-run protection), and `gh pr merge` below pushes the merge commit
-# with exactly that token — so every commit this sweep landed arrived on
-# develop with ZERO check runs. Measured, not inferred: bot-merged develop
-# head ae09a078 -> check-runs total_count 0, while its user-pushed neighbours
-# (33c61392 / 8c537754) carried 9 check runs each, with runners online and
-# idle. The develop-health gate below then reads "no checks" as "no red
-# signal to honour" and keeps merging — green-by-absence, the same
-# evidence-that-could-not-have-disagreed shape as the 8-day outage above.
-# workflow_dispatch IS exempt from the suppression (the identical escape
-# hatch autobump-release-sweep.yaml documents for tag pushes), so after a
-# successful merge this sweep explicitly DISPATCHES develop's post-merge
-# gates (POST_MERGE_GATES below) — ONCE per tick, not once per merged PR. A
-# failed dispatch turns this run red ON PURPOSE: an un-CI'd develop head is
-# exactly the silence this file exists to end. Deliberately NO PAT / bot
-# token: explicit dispatch is the sanctioned workaround.
+# A github.token merge push triggers NO workflows (recursive-run
+# suppression), so develop's gates are dispatched explicitly after a merge.
 #
 # GitHub reads schedule- AND check_suite-triggered workflows from the DEFAULT
 # branch (main), so this file lives on main but acts ONLY on PRs whose base is
@@ -166,12 +151,7 @@ jobs:
           # instead of by a human babysitting a loop. Raising this above 1 means
           # merging onto a base whose CI has not run yet. Don't.
           MAX_MERGES: "1"
-          # develop's post-merge gates, dispatched explicitly after a merge
-          # because a github.token merge push triggers NOTHING (see header).
-          # Every entry MUST accept a bare `workflow_dispatch` (all five do —
-          # pinned by tests/develop/test_auto_merge_dispatch.py). Space-
-          # separated (`>-` folds the newlines) so the shell can iterate
-          # without arrays.
+          # Space-separated; every entry must accept a bare workflow_dispatch.
           POST_MERGE_GATES: >-
             pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
             quality-audit-on-ubuntu-latest.yml
@@ -346,16 +326,7 @@ jobs:
 
           echo "sweep complete: $merges merge(s) this run"
 
-          # ---------------------------------------------------------------
-          # POST-MERGE CI DISPATCH — a github.token merge fires NOTHING.
-          # ---------------------------------------------------------------
-          # The merge commit we just pushed carries the default workflow
-          # token, so GitHub suppresses every push-triggered workflow on it
-          # (see header). Without this block develop's new head has ZERO
-          # check runs, and the next tick's develop-health gate reads that
-          # absence as "no red signal" — green-by-absence. workflow_dispatch
-          # is exempt from the suppression, so fire the gates explicitly.
-          # ONCE per tick (merges is the tick's total), never per PR.
+          # github.token pushes fire no workflows — dispatch the gates once per tick.
           if [ "$merges" -gt 0 ]; then
             if [ "$DRY_RUN" = "true" ]; then
               echo "DRY RUN: would dispatch post-merge gates on develop: $POST_MERGE_GATES"
@@ -365,8 +336,6 @@ jobs:
                 if gh workflow run "$wf" --repo "$REPO" --ref develop; then
                   echo "dispatched $wf on develop"
                 else
-                  # LOUD, never silent: an undispatched gate leaves develop's
-                  # new head UN-CHECKED — the exact hole this block closes.
                   echo "::error::failed to dispatch $wf on develop — the merged head has NO CI of its own until something fires it"
                   dispatch_failures=$((dispatch_failures + 1))
                 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- auto-merge-to-develop: trimmed the prose comments added in 0.24.12 to minimal one-liners (operator style ruling — meaning in names, comments minimal); behaviour unchanged.
+
 ## [0.24.11] - 2026-07-22
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.12"
+version = "0.24.14"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/tests/develop/test_auto_merge_dispatch.py
+++ b/tests/develop/test_auto_merge_dispatch.py
@@ -1,30 +1,8 @@
-"""The auto-merge sweep must DISPATCH develop's post-merge gates itself.
+"""auto-merge-to-develop.yaml must dispatch develop's post-merge gates.
 
-GitHub SUPPRESSES workflow triggers for pushes made with the default
-``github.token`` (recursive-run protection), and auto-merge-to-develop.yaml
-merges with exactly that token — so every commit the sweep lands arrives on
-develop with ZERO check runs. Measured on this repo: bot-merged develop head
-``ae09a078`` -> ``check-runs total_count: 0``, while its user-pushed
-neighbours carried 9 check runs each, with runners online and idle. The
-sweep's own develop-health gate then reads "no checks" as "no red signal to
-honour" and keeps merging — green-by-absence, the exact
-``reference-evidence-that-could-not-have-disagreed`` shape the file's header
-warns about.
-
-``workflow_dispatch`` IS exempt from that suppression (the escape hatch
-autobump-release-sweep.yaml already documents for tags), so the merge step
-must explicitly dispatch every develop gate after a successful merge. These
-tests pin that wiring AS TEXT — no network, no gh, cannot flake:
-
-* the merge step names every required gate (``POST_MERGE_GATES``);
-* it dispatches with ``gh workflow run ... --ref develop``;
-* the dispatch is reachable only AFTER a real merge (guarded on the merge
-  count, skipped on dry-run) — N merged PRs must produce ONE dispatch fan-out,
-  not N;
-* the workflow token is actually allowed to dispatch (``actions: write``);
-* every dispatched gate still accepts a bare ``workflow_dispatch`` — a gate
-  that drops the trigger would turn the dispatch into a silent 404, quietly
-  rebuilding the un-CI'd-develop hole this wiring exists to close.
+A github.token merge push triggers no workflows, so the merge step fires
+POST_MERGE_GATES explicitly (once per tick, --ref develop, loud on failure).
+File-only assertions on the workflow YAML — no network, cannot flake.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Follow-up to #809 (merged as `e947b450`), applying the operator's style ruling: no long prose comment blocks — meaning in names, comments minimal.

## What was trimmed (comments only, behaviour unchanged)

| Location | Before | After |
|---|---|---|
| Workflow header block | 17-line narrative (SHAs, counts, reasoning) | 2 lines: github.token pushes trigger no workflows, hence explicit dispatch |
| `POST_MERGE_GATES` env comment | 6 lines | 1 line (keeps the non-inferrable constraint: every entry must accept a bare `workflow_dispatch`) |
| Dispatch-block comment | 10-line boxed prose | 1 line (`once per tick` kept — the guard alone does not say "not per PR") |
| Else-branch comment | 2 lines | deleted (the `::error::` echo says it) |
| Test module docstring | 30 lines | 5 lines |

65 prose lines removed, 9 minimal lines added. Pre-existing headers untouched. The full analysis stays on the board card (`sac-bot-merged-develop-head-gets-no-ci-20260722`) and in #809's body.

## Kept, and why

- "every entry must accept a bare workflow_dispatch" — a genuine constraint a reader cannot infer from the code; a gate that drops the trigger turns the dispatch into a silent 404.
- "once per tick" on the dispatch guard — the placement after the loop makes it structural, but the single line states the intent cheaply.
- The `actions: write  # gh workflow run (...)` permission comment — same minimal style autobump already uses.

## Verification

- `tests/develop/test_auto_merge_dispatch.py`: **17 passed** after the trim (`/opt/venv-sac/bin/python -m pytest ...`); `bash -n` clean on the extracted merge script.
- Assertion audit: **no test asserts on comment text** — all 17 anchor on env values, permission keys, `on:` keys, or executable shell tokens. Empirical proof: this PR deletes every comment block the tests could have matched, and the suite passes unchanged.
- Version 0.24.14 (0.24.12 merged, 0.24.13 verified claimed by open #810, 0.24.14 verified free across all open PRs' pyprojects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wf61fTTKUDcDbbq859vXkv
