### PR TITLE
fix(apptainer): argv guard names the culprit instead of always blaming raw_args

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_argv_guard.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_argv_guard.py
@@ -37,6 +37,31 @@ Only the curated + raw flag region is checked. The inner command
 (``bash -c "<preflight>\nexec …"`` or the flat relaxed inner argv) sits
 AFTER the SIF and is the container's business, not apptainer's flag
 parser — so it is excluded.
+
+Naming the culprit
+------------------
+The first version of this message ended with a single unconditional
+sentence: "Fix the spec.apptainer.raw_args ordering." That is the right
+remedy for the common case and the WRONG one for two others — sac's own
+assembly can in principle emit the bad pair, and the message never said
+WHICH agent's spec to open. On 2026-07-23 an operator hit the ``--env
+--env`` form on ``scitex-cards-{chat,gui,mobile}`` (an orphan ``--env``
+left behind when a ``KEY=VALUE`` line was deleted), read the message,
+opened the similarly-named ``scitex-cards`` spec — which was clean — and
+concluded the guard was lying. It was not; it just never named the file.
+
+So the message now reports PROVENANCE as a tri-state, computed from the
+``raw_args`` the caller passes in:
+
+* ``raw_args`` malformed          → the SPEC is at fault; the offending
+  ``raw_args`` index is named.
+* ``raw_args`` present and clean  → the spec is EXONERATED in the text
+  and the reader is told sac's assembly introduced it.
+* ``raw_args`` not supplied       → provenance is stated as UNKNOWN
+  rather than guessed.
+
+The offending flag-region index and a window of neighbouring tokens are
+always printed, so the reader sees the actual argv instead of a rule.
 """
 
 from __future__ import annotations
@@ -71,39 +96,105 @@ class ApptainerArgvError(ValueError):
     """
 
 
-def validate_flag_argv(argv: list[str]) -> None:
+def find_missing_value(tokens: list[str]) -> tuple[int, str, str | None] | None:
+    """First ``(index, flag, swallowed)`` where a value-taking flag has no value.
+
+    ``swallowed`` is the token apptainer would consume as the value, or
+    ``None`` when the flag is last. Returns ``None`` for a well-formed
+    list. Pairs are skipped whole so a value that legitimately starts
+    with ``--`` is not itself re-checked.
+    """
+    i = 0
+    n = len(tokens)
+    while i < n:
+        token = tokens[i]
+        if token in VALUE_TAKING_FLAGS:
+            nxt = tokens[i + 1] if i + 1 < n else None
+            if nxt is None or nxt.startswith("--"):
+                return (i, token, nxt)
+            i += 2
+            continue
+        i += 1
+    return None
+
+
+def validate_flag_argv(
+    argv: list[str],
+    *,
+    raw_args: list[str] | None = None,
+    agent: str | None = None,
+) -> None:
     """Fail loud if a value-taking apptainer flag is missing its value.
 
     Inspects only the flag region between ``apptainer exec`` and the SIF
     path (first positional that is not consumed as a flag value). Raises
-    :class:`ApptainerArgvError` describing the offending flag + the token
-    that would be wrongly swallowed.
+    :class:`ApptainerArgvError` describing the offending flag, the token
+    that would be wrongly swallowed, its index + neighbours, and where the
+    malformation came from.
+
+    ``raw_args`` is ``spec.apptainer.raw_args``. Supplying it is what lets
+    the message ATTRIBUTE the fault instead of always blaming the spec;
+    omitting it yields an explicit "provenance unknown" rather than a
+    guess. ``agent`` names the agent in the message so the reader opens
+    the right spec.
 
     A no-op for a well-formed argv.
     """
-    flag_region = _flag_region(argv)
-    i = 0
-    n = len(flag_region)
-    while i < n:
-        token = flag_region[i]
-        if token in VALUE_TAKING_FLAGS:
-            nxt = flag_region[i + 1] if i + 1 < n else None
-            if nxt is None or nxt.startswith("--"):
-                swallowed = nxt if nxt is not None else "<end-of-flags / the SIF>"
-                raise ApptainerArgvError(
-                    f"apptainer flag {token!r} is missing its required value: "
-                    f"the next token is {swallowed!r}. apptainer would swallow "
-                    f"that token as {token}'s value and, if it is a flag like "
-                    "'--fakeroot', create a stray relative file (e.g. "
-                    "'--fakeroot') in the launch cwd / project root. Fix the "
-                    "spec.apptainer.raw_args ordering so every value-taking "
-                    "flag is immediately followed by its value."
-                )
-            # Skip the value so a value that legitimately starts with
-            # '--' (rare, but possible) isn't itself re-checked.
-            i += 2
-            continue
-        i += 1
+    found = find_missing_value(_flag_region(argv))
+    if found is None:
+        return
+    raise ApptainerArgvError(
+        _render_error(_flag_region(argv), found, raw_args=raw_args, agent=agent)
+    )
+
+
+def _render_error(
+    region: list[str],
+    found: tuple[int, str, str | None],
+    *,
+    raw_args: list[str] | None,
+    agent: str | None,
+) -> str:
+    index, flag, nxt = found
+    swallowed = nxt if nxt is not None else "<end-of-flags / the SIF>"
+    window = region[max(0, index - 3) : index + 4]
+    who = f" for agent {agent!r}" if agent else ""
+    return (
+        f"apptainer flag {flag!r} is missing its required value: the next "
+        f"token is {swallowed!r}. apptainer would swallow that token as "
+        f"{flag}'s value and, if it is a flag like '--fakeroot', create a "
+        "stray relative file (e.g. '--fakeroot') in the launch cwd / project "
+        f"root.\n  at flag-region index {index}; surrounding tokens: {window}\n"
+        f"  {_provenance(raw_args, who)}"
+    )
+
+
+def _provenance(raw_args: list[str] | None, who: str) -> str:
+    if raw_args is None:
+        return (
+            "CAUSE UNKNOWN: spec.apptainer.raw_args was not supplied to this "
+            "check, so it cannot say whether the spec or sac's own argv "
+            "assembly introduced the pair. Check the spec's raw_args first "
+            "for a value-taking flag with no value, then sac's assembly."
+        )
+    tokens = [str(a) for a in raw_args]
+    raw_found = find_missing_value(tokens)
+    if raw_found is None:
+        return (
+            f"CAUSE: NOT the spec — spec.apptainer.raw_args{who} is "
+            f"well-formed ({len(tokens)} tokens checked), so editing it "
+            "cannot fix this. The pair was introduced while sac ASSEMBLED "
+            "the argv; this is a sac bug. Report it with the token window "
+            "above."
+        )
+    raw_index, raw_flag, raw_next = raw_found
+    return (
+        f"CAUSE: spec.apptainer.raw_args{who} is itself malformed at index "
+        f"{raw_index}: {raw_flag!r} is followed by {raw_next!r}. Give that "
+        "flag its value, or delete the orphan flag — an orphan is exactly "
+        "what deleting the VALUE line of an `--env KEY=VALUE` pair leaves "
+        "behind. Run `sac agents find <agent>` for the spec path."
+    )
 
 
 def _flag_region(argv: list[str]) -> list[str]:
@@ -148,4 +239,9 @@ def _flag_region(argv: list[str]) -> list[str]:
     return region
 
 
-__all__ = ["ApptainerArgvError", "VALUE_TAKING_FLAGS", "validate_flag_argv"]
+__all__ = [
+    "ApptainerArgvError",
+    "VALUE_TAKING_FLAGS",
+    "find_missing_value",
+    "validate_flag_argv",
+]

--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -328,10 +328,9 @@ def build_run_argv(
     # appended verbatim after all curated args, before the SIF +
     # inner command. Lets operators bolt on flags sac doesn't model
     # (e.g. ``--userns``, ``--cleanenv``).
-    ap_for_raw = getattr(config, "apptainer", None)
-    if ap_for_raw is not None:
-        for arg in getattr(ap_for_raw, "raw_args", None) or []:
-            argv.append(str(arg))
+    _ap_raw = getattr(config, "apptainer", None)
+    spec_raw_args = [str(a) for a in (getattr(_ap_raw, "raw_args", None) or [])]
+    argv += spec_raw_args
 
     # Relaxed + directory-overlay + explicit ``--home`` shadows the
     # to_home tree. ``deploy_to_home_overlay`` materialises the tree
@@ -392,7 +391,10 @@ def build_run_argv(
 
     # Root-cause guard for the stray ``--fakeroot`` file in the project root
     # (see _apptainer_argv_guard): a value-taking flag missing its value.
-    validate_flag_argv(argv)
+    # raw_args + name let the message attribute the fault and name the spec.
+    validate_flag_argv(
+        argv, raw_args=spec_raw_args, agent=getattr(config, "name", None)
+    )
 
     argv.append(str(sif_path))
 

--- a/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard.py
@@ -22,8 +22,6 @@ AAA blocks, markers on their own line, one assert per test.
 
 from __future__ import annotations
 
-from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
-
 import os
 import socket
 from pathlib import Path
@@ -37,6 +35,7 @@ from scitex_agent_container.runtimes._apptainer_argv_guard import (
     validate_flag_argv,
 )
 from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
 # ---------------------------------------------------------------------------
 # Fixtures (mirror test__apptainer_build_argv.py — real HOME + bearer token)
@@ -73,29 +72,31 @@ def _write_spec(tmp_path: Path, raw_args_yaml: str) -> Path:
     spec_dir.mkdir(parents=True, exist_ok=True)
     spec = spec_dir / "spec.yaml"
     spec.write_text(
-        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
-        "kind: Agent\n"
-        "metadata:\n"
-        "  labels:\n"
-        "    project: t\n"
-        '    sac-builtin: "off"\n'
-        "spec:\n"
-        "  runtime: tui\n"
-        "  host: ${HOSTNAME}\n"
-        "  workdir: /tmp/agt-work\n"
-        "  apptainer:\n"
-        "    image: /x.sif\n"
-        "    fakeroot: true\n"
-        "    binds: []\n"
-        f"{raw_args_yaml}"
-        "  health:\n"
-        "    enabled: true\n"
-        "    interval: 60\n"
-        "  restart:\n"
-        "    policy: on-failure\n"
-        "    max_retries: 3\n"
-        "  claude:\n"
-        "    model: claude-opus-4-8[1m]\n"),
+        explicitize_yaml(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            "metadata:\n"
+            "  labels:\n"
+            "    project: t\n"
+            '    sac-builtin: "off"\n'
+            "spec:\n"
+            "  runtime: tui\n"
+            "  host: ${HOSTNAME}\n"
+            "  workdir: /tmp/agt-work\n"
+            "  apptainer:\n"
+            "    image: /x.sif\n"
+            "    fakeroot: true\n"
+            "    binds: []\n"
+            f"{raw_args_yaml}"
+            "  health:\n"
+            "    enabled: true\n"
+            "    interval: 60\n"
+            "  restart:\n"
+            "    policy: on-failure\n"
+            "    max_retries: 3\n"
+            "  claude:\n"
+            "    model: claude-opus-4-8[1m]\n"
+        ),
         encoding="utf-8",
     )
     return spec
@@ -239,6 +240,104 @@ def test_build_run_argv_no_stray_fakeroot_file_in_cwd(
     stray = clean_cwd / "--fakeroot"
     # Assert
     assert not stray.exists()
+
+
+# ---------------------------------------------------------------------------
+# Provenance — the message must name WHICH artefact is at fault (2026-07-23).
+# The three branches below are the three inputs that make it say something
+# different; without all three the attribution would be untestable.
+# ---------------------------------------------------------------------------
+
+_MALFORMED_ARGV = ["apptainer", "exec", "--env", "--env", "K=V", "/x.sif"]
+
+
+def _message(argv: list[str], **kwargs: object) -> str:
+    try:
+        validate_flag_argv(argv, **kwargs)  # type: ignore[arg-type]
+    except ApptainerArgvError as exc:
+        return str(exc)
+    return ""
+
+
+def test_malformed_raw_args_blames_the_spec() -> None:
+    # Arrange — the orphan --env that scitex-cards-chat carried.
+    raw = ["--env", "--env", "K=V"]
+    # Act
+    message = _message(_MALFORMED_ARGV, raw_args=raw)
+    # Assert
+    assert "spec.apptainer.raw_args" in message and "index 0" in message
+
+
+def test_clean_raw_args_exonerates_the_spec() -> None:
+    # Arrange — spec is well-formed, so the pair came from sac's assembly.
+    raw = ["--userns", "--containall"]
+    # Act
+    message = _message(_MALFORMED_ARGV, raw_args=raw)
+    # Assert — the reader is told NOT to go edit a correct spec.
+    assert "NOT the spec" in message
+
+
+def test_absent_raw_args_reports_unknown_provenance() -> None:
+    # Arrange — caller supplied no raw_args, so attribution is a third state.
+    # Act
+    message = _message(_MALFORMED_ARGV)
+    # Assert
+    assert "CAUSE UNKNOWN" in message
+
+
+def test_message_names_the_agent() -> None:
+    # Arrange
+    # Act
+    message = _message(_MALFORMED_ARGV, raw_args=["--env", "--env"], agent="agt")
+    # Assert — with 100+ specs, an unnamed agent sends the reader to the
+    # wrong file (the 2026-07-23 incident).
+    assert "'agt'" in message
+
+
+def test_message_shows_the_offending_index_and_neighbours() -> None:
+    # Arrange
+    argv = ["apptainer", "exec", "--containall", "--env", "--env", "K=V", "/x.sif"]
+    # Act
+    message = _message(argv, raw_args=["--env", "--env", "K=V"])
+    # Assert — the actual tokens, not just a rule about them.
+    assert "'--containall'" in message
+
+
+def test_build_run_argv_orphan_env_in_raw_args_names_the_raw_args_index(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — the live shape: a `--env KEY=VALUE` whose VALUE line was
+    # deleted, leaving the flag behind.
+    raw = (
+        "    raw_args:\n      - --env\n      - --env\n"
+        "      - SCITEX_CARDS_DB=/home/agent/x.db\n"
+    )
+    cfg = load_config(str(_write_spec(tmp_path, raw)))
+    message = ""
+    try:
+        build_run_argv(
+            cfg, state_dir=tmp_path / "st", sif_path=tmp_path / "x.sif", tui=True
+        )
+    except ApptainerArgvError as exc:
+        message = str(exc)
+    # Act
+    blames_spec = "spec.apptainer.raw_args" in message and "index 0" in message
+    # Assert
+    assert blames_spec is True
+
+
+def test_build_run_argv_repaired_env_pair_does_not_raise(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — the same spec with the orphan removed (the applied fix).
+    raw = "    raw_args:\n      - --env\n      - SCITEX_CARDS_DB=/home/agent/x.db\n"
+    cfg = load_config(str(_write_spec(tmp_path, raw)))
+    # Act
+    argv = build_run_argv(
+        cfg, state_dir=tmp_path / "st", sif_path=tmp_path / "x.sif", tui=True
+    )
+    # Assert
+    assert "SCITEX_CARDS_DB=/home/agent/x.db" in argv
 
 
 @pytest.fixture


### PR DESCRIPTION
An orphan `- --env` in three sibling specs (`scitex-cards-{chat,gui,mobile}`) made `sac-start` fail, and the guard's message told the operator to fix `spec.apptainer.raw_args` without saying **which** spec — so the wrong file got audited.

## Mechanism
The orphan is the remnant of deleting an env var's **value** line while leaving its **flag**. An edit artefact, not a typo — it hit three specs at once, and the same variable was removed cleanly in a fourth.

Swept the real argv for **all 101 host specs** and partitioned them:
```
CLEAN 86 | BUILD FAILED 12 (unrelated, /dev/fuse absent) | SPEC-SIDE 3 | SAC-SIDE 0
```
The `SAC-SIDE 0` is also backed structurally, not just by the sweep: all 37 `--env` emission sites append flag+value in one statement, and the only argv-mutating step removes pairs whole (`i += 2`).

## Change
`validate_flag_argv(argv, *, raw_args=None, agent=None)` reports provenance as a **tri-state**:
- `raw_args` malformed → names the index and the agent
- `raw_args` clean → "NOT the spec … editing it cannot fix this … this is a sac bug"
- `raw_args` absent → `CAUSE UNKNOWN` (does not guess)

Those three branches are exactly the three inputs that make it say something different, so the attribution is testable rather than decorative. Detection logic untouched.

## Mutation proofs
| | |
|---|---|
| baseline | 17 passed |
| plant: blame a clean `raw_args` (old behaviour) | 1 failed, 16 passed |
| plant: guard made inert | 10 failed, 7 passed |
| revert | 17 passed |
| guard + build_argv | 68 passed, 2 skipped |
| standalone harness | **5/5 mutations killed, 0 survived** |

## Follow-up (not in this PR)
Wire `find_missing_value` into `sac agents check` so an orphan is caught pre-flight rather than at launch — carded as `sac-agents-check-should-catch-orphan-flags-preflight-20260723`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWgkiaU3VeiMGSAB5djyjx