### PR TITLE
fix(lifecycle): a STARTUP_FAILED verdict must be retractable, and a decline is not a failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A `--yes`-less start refusal was recorded as a permanent STARTUP_FAILED**
+  (21 markers on the live fleet, at least 3 confirmed declines). The
+  brokered listen's only discriminator on the `sac agents start` subprocess
+  is its exit code, and a refusal exits 1 exactly like a real launch
+  failure — `write_marker` could not tell them apart. Fix, four pieces:
+  (1) the refusal branch (`cli_pkg/lifecycle/_start_single.py`) now emits a
+  shared sentinel (`_lifecycle._start_decline.DECLINE_SENTINEL`) that
+  `write_marker` matches and refuses to act on — not an exit-code test,
+  since a stale host `sac` binary is known to return rc=2 for an unrelated
+  reason; (2) `retract_marker` renames `STARTUP_FAILED` to
+  `STARTUP_FAILED.retracted` — never deletes, since the marker is the only
+  copy of its `stderr_tail`; (3) the ONE retraction call site is the
+  already-running no-op in `agent_start`, reached only on a positively
+  ALIVE liveness verdict — never on a bare `runtime.start()` returning
+  `True` (a background `Popen` or an existing tmux session name is not
+  evidence the agent came up); (4) `GET /agents/<name>/status` additionally
+  relabels a marker `startup_failed_superseded` when `heartbeat.json`'s
+  MTIME (PROCESS ALIVE) — never the `ts` payload field, which routinely
+  lags MTIME by tens of thousands of seconds for an idle agent — postdates
+  `failed_at` by at least one staleness window. Existing markers are
+  untouched by this change; each is superseded/retracted only the next
+  time its own agent is observed alive.
+
 ### Added
 
 - **Detector: agent overlays that silently mask a base-baked package**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.17"
+version = "0.24.19"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -23,6 +23,10 @@ from ._runtime_select import _get_runtime
 from ._session_reset import _clear_persisted_session_id
 from ._spawn_gate import enforce_spawn_gate, persist_acl_policy
 
+# Re-exported from _start_announce for back-compat: this helper lived here
+# before the 512-line-cap split.
+from ._start_announce import _announce_start_verdict  # noqa: F401
+
 # Re-exported from _start_failure_diag for back-compat: this helper lived here
 # before the 512-line-cap split.
 from ._start_failure_diag import _format_boot_stderr_section  # noqa: F401
@@ -40,28 +44,6 @@ from ._start_preflight import (  # noqa: F401
     _verify_real_liveness,
 )
 from .health import health_monitor
-
-
-def _announce_start_verdict(verdict) -> None:
-    """Print the liveness verdict + its evidence before a non-no-op start.
-
-    An operator staring at ``running | pid=None`` learns nothing. This prints
-    WHY — ``ALIVE (delivery: 1 live inbox subscriber)`` / ``UNKNOWN (heartbeat:
-    beat is 5086s stale …)`` — and, on UNKNOWN, says plainly that we are
-    starting the agent anyway and that doing so destroys nothing.
-    """
-    import sys as _sys
-
-    print(f"[sac:liveness] {verdict.agent}: {verdict.render()}", file=_sys.stderr)
-    if verdict.is_unknown:
-        print(
-            f"[sac:liveness] cannot CONFIRM '{verdict.agent}' is alive, and "
-            f"nothing answers for it — starting it. This is NOT destructive: "
-            f"if it is in fact alive, the runtime's own duplicate-session "
-            f"guard no-ops instead of relaunching over it. (`--force` is the "
-            f"only verb that tears an existing session down.)",
-            file=_sys.stderr,
-        )
 
 
 def agent_start(
@@ -334,6 +316,9 @@ def agent_start(
                 f"[{verdict.render()}]. No-op. Use --force to restart.",
                 file=__import__("sys").stderr,
             )
+            from ._startup_failed import retract_marker_for
+
+            retract_marker_for(config.name)
             return NOOP_ALREADY_RUNNING
     elif force and registry.exists(config.name):
         # Registry says it exists but runtime says not running — stale entry.

--- a/src/scitex_agent_container/_lifecycle/_start_announce.py
+++ b/src/scitex_agent_container/_lifecycle/_start_announce.py
@@ -1,0 +1,27 @@
+"""Liveness-verdict announcement, extracted from ``_start.py`` (512-line cap)."""
+
+from __future__ import annotations
+
+__all__ = ["_announce_start_verdict"]
+
+
+def _announce_start_verdict(verdict) -> None:
+    """Print the liveness verdict + its evidence before a non-no-op start.
+
+    An operator staring at ``running | pid=None`` learns nothing. This prints
+    WHY — ``ALIVE (delivery: 1 live inbox subscriber)`` / ``UNKNOWN (heartbeat:
+    beat is 5086s stale …)`` — and, on UNKNOWN, says plainly that we are
+    starting the agent anyway and that doing so destroys nothing.
+    """
+    import sys as _sys
+
+    print(f"[sac:liveness] {verdict.agent}: {verdict.render()}", file=_sys.stderr)
+    if verdict.is_unknown:
+        print(
+            f"[sac:liveness] cannot CONFIRM '{verdict.agent}' is alive, and "
+            f"nothing answers for it — starting it. This is NOT destructive: "
+            f"if it is in fact alive, the runtime's own duplicate-session "
+            f"guard no-ops instead of relaunching over it. (`--force` is the "
+            f"only verb that tears an existing session down.)",
+            file=_sys.stderr,
+        )

--- a/src/scitex_agent_container/_lifecycle/_start_decline.py
+++ b/src/scitex_agent_container/_lifecycle/_start_decline.py
@@ -1,0 +1,21 @@
+"""The wire signal for 'the operator was asked and did not consent'.
+
+A refusal is not a failure: nothing was mutated, nothing was launched.
+``write_marker`` must never mint a STARTUP_FAILED for it, but the
+listen's only discriminator on the brokered subprocess is its exit code
+(non-zero), which a decline also produces (``_start_single.py`` exits 1
+on refusal). A sentinel this module both emits (the refusal branch) and
+matches (``write_marker``) sidesteps any exit-code collision — including
+the observed rc=2 from a stale host ``sac`` binary's "No such command"
+error, which an exit-code-based carve-out would silently swallow.
+"""
+
+from __future__ import annotations
+
+__all__ = ["DECLINE_SENTINEL", "start_was_declined"]
+
+DECLINE_SENTINEL = "sac:start-declined"
+
+
+def start_was_declined(stdout: str, stderr: str) -> bool:
+    return DECLINE_SENTINEL in (stdout or "") or DECLINE_SENTINEL in (stderr or "")

--- a/src/scitex_agent_container/_lifecycle/_startup_failed.py
+++ b/src/scitex_agent_container/_lifecycle/_startup_failed.py
@@ -66,6 +66,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ._start_decline import start_was_declined
+
 # Schema version. Bump when the shape changes; readers should
 # downgrade gracefully on a higher value.
 SCHEMA_VERSION = 1
@@ -80,6 +82,10 @@ _TAIL_BYTES_LIMIT = 8 * 1024  # 8 KiB
 # style sentinel files — easy to grep, hard to mistake for runtime
 # state the agent owns.
 MARKER_FILENAME = "STARTUP_FAILED"
+
+# Retracted markers are renamed aside, never deleted — this is the ONLY
+# copy of the marker's stderr_tail (runtime/events/*.jsonl carries none).
+RETRACTED_MARKER_FILENAME = "STARTUP_FAILED.retracted"
 
 
 def _now_iso() -> str:
@@ -182,7 +188,7 @@ def write_marker(
     stdout: str,
     stderr: str,
     kind_override: str | None = None,
-) -> Path:
+) -> Path | None:
     """Write ``runtime_dir/STARTUP_FAILED`` and return its path.
 
     ``runtime_dir`` is the agent's per-instance state directory
@@ -207,10 +213,17 @@ def write_marker(
             that already know the cause (e.g. an explicit ``sdk_init``
             failure that doesn't look like an apptainer FATAL).
 
+    Returns ``None``, writing nothing, when ``stdout``/``stderr`` carry
+    the shared decline sentinel (``_start_decline.DECLINE_SENTINEL``) —
+    an operator's `--yes`-less refusal is not a failure and must never
+    be recorded as one.
+
     The write is best-effort atomic: written to a ``.tmp`` sibling
     and ``os.replace``-d into place so partial markers aren't visible
     to ``DELETE`` / ``STATUS`` readers.
     """
+    if start_was_declined(stdout, stderr):
+        return None
     runtime_dir.mkdir(parents=True, exist_ok=True)
     if kind_override is not None:
         kind = kind_override
@@ -266,11 +279,36 @@ def is_stillborn(runtime_dir: Path) -> bool:
     return (runtime_dir / MARKER_FILENAME).is_file()
 
 
+def retract_marker(runtime_dir: Path) -> bool:
+    """Rename ``STARTUP_FAILED`` aside to ``STARTUP_FAILED.retracted``.
+
+    Never deletes: the marker is the only copy of its ``stderr_tail``.
+    Returns ``False`` (no-op, no exception) when there is nothing to
+    retract — a clean runtime_dir, or one already retracted.
+    """
+    target = runtime_dir / MARKER_FILENAME
+    try:
+        target.rename(runtime_dir / RETRACTED_MARKER_FILENAME)
+    except OSError:
+        return False
+    return True
+
+
+def retract_marker_for(name: str) -> bool:
+    """``retract_marker`` keyed by agent name (resolves its state dir)."""
+    from .._runners._session_state import state_dir_for
+
+    return retract_marker(state_dir_for(name))
+
+
 __all__ = [
     "MARKER_FILENAME",
+    "RETRACTED_MARKER_FILENAME",
     "SCHEMA_VERSION",
     "classify_apptainer_failure",
     "is_stillborn",
     "read_marker",
+    "retract_marker",
+    "retract_marker_for",
     "write_marker",
 ]

--- a/src/scitex_agent_container/_lifecycle/_startup_failed_supersede.py
+++ b/src/scitex_agent_container/_lifecycle/_startup_failed_supersede.py
@@ -1,0 +1,59 @@
+"""Read-side supersession: has liveness since refuted a STARTUP_FAILED?
+
+Reads ``heartbeat.json`` MTIME — the field ``_liveness_tick_resolve``
+labels PROCESS ALIVE, never the ``ts`` payload field, which is frequently
+tens of thousands of seconds behind mtime for an idle agent and would
+make this blind for exactly the population it exists to protect.
+
+Never deletes or renames anything — this is a pure read used by
+``sac listen``'s STATUS / DELETE handlers to relabel a marker, not
+retract it. Retraction (the on-disk rename) only ever happens at the
+one write-side call site: the ALIVE no-op in ``_start.agent_start``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ._verdict import ALIVE
+from ._verdict_state import HEARTBEAT_STALE_S, heartbeat_signal
+
+__all__ = ["liveness_since_failure"]
+
+_HEARTBEAT_FILENAME = "heartbeat.json"
+
+
+def liveness_since_failure(
+    state_dir: Path,
+    marker: dict[str, Any],
+    *,
+    name: str,
+    runtime_kind: str = "",
+) -> str | None:
+    """Non-empty detail string iff a fresh beat postdates the failure."""
+    hb = state_dir / _HEARTBEAT_FILENAME
+    try:
+        mtime = hb.stat().st_mtime
+    except OSError:
+        return None
+    failed_at = marker.get("failed_at")
+    if not isinstance(failed_at, str):
+        return None
+    try:
+        failed_ts = (
+            datetime.strptime(failed_at, "%Y-%m-%dT%H:%M:%SZ")
+            .replace(tzinfo=timezone.utc)
+            .timestamp()
+        )
+    except ValueError:
+        return None
+    # One staleness window, so a beat from the same boot attempt cannot
+    # refute the failure that attempt produced.
+    if mtime - failed_ts < HEARTBEAT_STALE_S:
+        return None
+    signal = heartbeat_signal(name, path=hb, runtime_kind=runtime_kind)
+    if signal.verdict != ALIVE:
+        return None
+    return signal.detail

--- a/src/scitex_agent_container/_listen/_agent_delete.py
+++ b/src/scitex_agent_container/_listen/_agent_delete.py
@@ -84,6 +84,8 @@ async def agent_delete(request: Request) -> JSONResponse:
 
         marker = read_marker(sd)
         if marker is not None:
+            from .._lifecycle._startup_failed_supersede import liveness_since_failure
+
             runtime_dir = marker.get("runtime_dir", str(sd.resolve()))
             body: dict[str, Any] = {
                 "name": name,
@@ -96,6 +98,9 @@ async def agent_delete(request: Request) -> JSONResponse:
                 "see_also": f"{runtime_dir}/{MARKER_FILENAME}",
                 "details": marker,
             }
+            refuted_by = liveness_since_failure(sd, marker, name=name)
+            if refuted_by:
+                body["startup_failed_superseded_by"] = refuted_by
             return JSONResponse(body, status_code=410)
         return JSONResponse({"error": "no pid file"}, status_code=404)
     try:

--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -302,12 +302,15 @@ async def agents_start(request: Request) -> JSONResponse:
         except Exception:  # stx-allow: fallback (reason: see inline comment)
             pass
 
+        from .._lifecycle._start_decline import start_was_declined
+
         return JSONResponse(
             {
                 "name": name,
                 "returncode": proc.returncode,
                 "stdout": proc.stdout,
                 "stderr": proc.stderr,
+                "declined": start_was_declined(proc.stdout, proc.stderr),
             },
             status_code=502,
         )

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -89,8 +89,15 @@ async def agent_status(request: Request) -> JSONResponse:
 
     marker = read_marker(sd)
     if marker is not None:
-        body["status"] = "startup_failed"
+        from .._lifecycle._startup_failed_supersede import liveness_since_failure
+
+        refuted_by = liveness_since_failure(
+            sd, marker, name=name, runtime_kind=str(getattr(cfg, "runtime", "") or "")
+        )
+        body["status"] = "startup_failed_superseded" if refuted_by else "startup_failed"
         body["startup_failed"] = marker
+        if refuted_by:
+            body["startup_failed_superseded_by"] = refuted_by
     # Q1 (lead dispatch a2a dc6fd23387f64e329049d218cf85a4d4): surface
     # ``a2a_port`` + derived ``turn_url`` so a status poll yields the
     # same endpoint shape ``GET /agents`` does.

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -20,6 +20,7 @@ from typing import Callable
 
 import click
 
+from ..._lifecycle._start_decline import DECLINE_SENTINEL
 from ..._lifecycle.lifecycle import agent_start
 from ...config import load_config
 from ...config._host import resolve_hostname
@@ -263,6 +264,12 @@ def run_single_targets(
                         "with --yes to launch.",
                         style="yellow",
                     )
+                    # STARTUP_FAILED must never be minted for a decline (the
+                    # host listen's only signal on this subprocess is its
+                    # exit code, and this branch's sys.exit(1) below is
+                    # indistinguishable from a real launch failure without
+                    # this sentinel — see write_marker's guard).
+                    click.echo(DECLINE_SENTINEL, err=True)
                     refused = True
                     continue
 

--- a/tests/scitex_agent_container/_lifecycle/test__start_retracts_marker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_retracts_marker.py
@@ -1,0 +1,310 @@
+"""Tests for the P3 retraction call site: the ALIVE no-op in ``agent_start``.
+
+Exactly ONE place retracts a marker — the already-running no-op reached
+only when ``resolve_start_verdict`` yields ``ALIVE`` (positive liveness
+evidence). Every other exit from ``agent_start`` — dry-run, a failed
+``runtime.start()``, and a launch that merely RETURNED truthy without any
+positive evidence of life — must leave an existing marker untouched.
+``runtimes/_apptainer_runtime.py`` and ``runtimes/tui_session.py`` both
+``return True`` on paths that observed nothing (a bare ``Popen``, a tmux
+session NAME existing), so retracting there would delete a true stillborn
+record on exactly the path the marker exists for.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scitex_agent_container._lifecycle._start import agent_start
+from scitex_agent_container._lifecycle._start_outcome import (
+    KIND_ALREADY_RUNNING,
+    outcome_kind,
+)
+from scitex_agent_container._lifecycle._startup_failed import (
+    MARKER_FILENAME,
+    RETRACTED_MARKER_FILENAME,
+    write_marker,
+)
+from scitex_agent_container._state.registry import Registry
+from scitex_agent_container.config import AgentConfig
+
+# ---------------------------------------------------------------------------
+# Fixtures — real HOME/runtime-dir redirection, real hand-rolled fakes
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_runtime_dir(tmp_path: Path, env_save_restore) -> Path:
+    """Redirect $HOME + the runtime-dir env so ``state_dir_for`` (used by
+    both the test's marker seeding and ``agent_start``'s internal
+    ``retract_marker_for``) resolves to the SAME tmp_path root.
+    """
+    import importlib
+
+    import scitex_agent_container._runners._session_state as ss
+
+    home = tmp_path / "home"
+    home.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    env_save_restore.set("HOME", str(home))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(runtime))
+    importlib.reload(ss)
+    env_save_restore.reload_after_restore(ss)
+    yield runtime
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> Registry:
+    return Registry(registry_dir=tmp_path / "reg")
+
+
+def _write_spec(tmp_path: Path, *, name: str = "alpha") -> Path:
+    agent_dir = tmp_path / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    body = (
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+        "  host: ${HOSTNAME}\n"
+        f"  workdir: {tmp_path / 'work'}\n"
+        "  apptainer:\n    image: /x.sif\n    binds: []\n"
+        "  claude:\n    model: sonnet\n"
+        "  health:\n    enabled: true\n    interval: 60\n"
+        "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+        "  hooks:\n    pre_start: []\n    post_start: []\n"
+        "    pre_stop: []\n    post_stop: []\n"
+    )
+    from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(explicitize_yaml(body))
+    return spec
+
+
+class FakeRuntime:
+    def __init__(self, *, running: bool = False, start_result: bool = True) -> None:
+        self.running = running
+        self.start_result = start_result
+        self.start_calls: list[AgentConfig] = []
+
+    def is_running(self, config: AgentConfig) -> bool:
+        return self.running
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        self.start_calls.append(config)
+        return self.start_result
+
+    def stop(self, config: AgentConfig) -> None:
+        pass
+
+    def logs(self, config: AgentConfig, lines: int) -> str:
+        return ""
+
+
+class FakeHandover:
+    def ensure_instance_uuid(self, config: AgentConfig) -> str:
+        return "fake-uuid"
+
+    def hydrate_from_hub(self, config: AgentConfig) -> bool:
+        return True
+
+    def push_pre_stop_snapshot(self, config: AgentConfig, payload=None) -> bool:
+        return True
+
+    def start_failback_poller(self, config: AgentConfig) -> None:
+        pass
+
+
+def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+def _seed_marker(runtime_dir: Path) -> None:
+    write_marker(
+        runtime_dir,
+        started_at="2026-07-22T00:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr="FATAL: container creation failed: mount source /work/x doesn't exist",
+    )
+
+
+# ---------------------------------------------------------------------------
+# The ALIVE no-op retracts an existing marker
+# ---------------------------------------------------------------------------
+
+
+def test_the_already_running_noop_returns_the_already_running_outcome(
+    tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
+) -> None:
+    # Arrange
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    runtime = FakeRuntime(running=True, start_result=True)
+    # Act
+    ok = agent_start(
+        str(spec),
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        handover_mod=FakeHandover(),
+        sleep_fn=_no_sleep,
+        liveness_verifier=lambda _cfg, _rt: True,
+    )
+    # Assert
+    assert outcome_kind(ok) == KIND_ALREADY_RUNNING
+
+
+def test_the_already_running_noop_retracts_an_existing_marker(
+    tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
+) -> None:
+    # Arrange
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    _seed_marker(isolated_runtime_dir / "alpha")
+    runtime = FakeRuntime(running=True, start_result=True)
+    # Act
+    agent_start(
+        str(spec),
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        handover_mod=FakeHandover(),
+        sleep_fn=_no_sleep,
+        liveness_verifier=lambda _cfg, _rt: True,
+    )
+    # Assert
+    assert not (isolated_runtime_dir / "alpha" / MARKER_FILENAME).exists()
+
+
+def test_the_already_running_noop_leaves_the_retracted_copy(
+    tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
+) -> None:
+    # Arrange
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    _seed_marker(isolated_runtime_dir / "alpha")
+    runtime = FakeRuntime(running=True, start_result=True)
+    # Act
+    agent_start(
+        str(spec),
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        handover_mod=FakeHandover(),
+        sleep_fn=_no_sleep,
+        liveness_verifier=lambda _cfg, _rt: True,
+    )
+    # Assert
+    assert (isolated_runtime_dir / "alpha" / RETRACTED_MARKER_FILENAME).is_file()
+
+
+def test_the_already_running_noop_with_no_marker_does_not_raise(
+    tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
+) -> None:
+    # Arrange — no marker on disk at all; retract_marker_for must be a
+    # silent no-op, never an exception that would break a real no-op start.
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    runtime = FakeRuntime(running=True, start_result=True)
+    # Act
+    ok = agent_start(
+        str(spec),
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        handover_mod=FakeHandover(),
+        sleep_fn=_no_sleep,
+        liveness_verifier=lambda _cfg, _rt: True,
+    )
+    # Assert
+    assert outcome_kind(ok) == KIND_ALREADY_RUNNING
+
+
+# ---------------------------------------------------------------------------
+# A launch that merely RETURNED (no positive liveness evidence) does NOT
+# retract — pins the design decision: runtime.start() truthy is not
+# evidence the agent came up.
+# ---------------------------------------------------------------------------
+
+
+def test_a_launch_that_merely_returned_keeps_the_marker(
+    tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
+) -> None:
+    # Arrange — nothing vouches for liveness (no registry row, no
+    # liveness_verifier): resolve_start_verdict yields UNKNOWN, so
+    # agent_start proceeds to a real start. The fake runtime "returns
+    # True" without having observed anything, exactly like
+    # ``_apptainer_runtime.py``'s bare Popen.
+    spec = _write_spec(tmp_path)
+    _seed_marker(isolated_runtime_dir / "alpha")
+    runtime = FakeRuntime(running=False, start_result=True)
+    # Act
+    agent_start(
+        str(spec),
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        handover_mod=FakeHandover(),
+        sleep_fn=_no_sleep,
+    )
+    # Assert
+    assert (isolated_runtime_dir / "alpha" / MARKER_FILENAME).is_file()
+
+
+# ---------------------------------------------------------------------------
+# A dry run does not retract
+# ---------------------------------------------------------------------------
+
+
+def test_a_dry_run_on_an_alive_agent_keeps_the_marker(
+    tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
+) -> None:
+    # Arrange — ALIVE verdict (registry + running + verifier), but
+    # dry_run=True takes the ``elif dry_run: pass`` branch, never the
+    # no-op else branch that retracts.
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    _seed_marker(isolated_runtime_dir / "alpha")
+    runtime = FakeRuntime(running=True, start_result=True)
+    # Act
+    agent_start(
+        str(spec),
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        handover_mod=FakeHandover(),
+        sleep_fn=_no_sleep,
+        liveness_verifier=lambda _cfg, _rt: True,
+        dry_run=True,
+    )
+    # Assert
+    assert (isolated_runtime_dir / "alpha" / MARKER_FILENAME).is_file()
+
+
+# ---------------------------------------------------------------------------
+# A failed start does not retract
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_start_keeps_the_marker(
+    tmp_path: Path, isolated_runtime_dir: Path, registry: Registry
+) -> None:
+    # Arrange — runtime.start() returns False -> raise_start_failure raises
+    # before any retraction could be reached on this path either way.
+    spec = _write_spec(tmp_path)
+    _seed_marker(isolated_runtime_dir / "alpha")
+    runtime = FakeRuntime(running=False, start_result=False)
+    # Act
+    try:
+        agent_start(
+            str(spec),
+            registry=registry,
+            runtime_factory=lambda _c: runtime,
+            handover_mod=FakeHandover(),
+            sleep_fn=_no_sleep,
+        )
+    except RuntimeError:
+        pass
+    # Assert
+    assert (isolated_runtime_dir / "alpha" / MARKER_FILENAME).is_file()

--- a/tests/scitex_agent_container/_lifecycle/test__startup_failed_declined.py
+++ b/tests/scitex_agent_container/_lifecycle/test__startup_failed_declined.py
@@ -1,0 +1,266 @@
+"""Tests for the P1 decline guard: a `--yes`-less refusal must never mint a
+STARTUP_FAILED marker.
+
+``write_marker`` gains a guard matching the shared
+``_start_decline.DECLINE_SENTINEL``; the refusal branch in
+``cli_pkg/lifecycle/_start_single.py`` emits it. Covers both ends: the
+guard itself (direct ``write_marker`` calls) and the emitter (a real
+interactive refusal through ``run_single_targets``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import pty
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, NamedTuple
+
+import pytest
+
+from scitex_agent_container._lifecycle._start_decline import DECLINE_SENTINEL
+from scitex_agent_container._lifecycle._startup_failed import (
+    MARKER_FILENAME,
+    write_marker,
+)
+from scitex_agent_container.cli_pkg.lifecycle._start_single import run_single_targets
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
+# ---------------------------------------------------------------------------
+# write_marker guard — direct calls, no CLI
+# ---------------------------------------------------------------------------
+
+_DECLINE_STDERR = (
+    "refusing to start x without --yes/-y — the plan above shows exactly "
+    f"what will mount and run; re-run with --yes to launch.\n{DECLINE_SENTINEL}\n"
+)
+
+
+def test_write_marker_returns_none_for_a_declined_start(tmp_path: Path) -> None:
+    # Arrange
+    kwargs = dict(
+        started_at="2026-07-22T00:00:00Z",
+        phase="container_creation",
+        exit_code=1,
+        stdout="",
+        stderr=_DECLINE_STDERR,
+    )
+    # Act
+    target = write_marker(tmp_path, **kwargs)
+    # Assert
+    assert target is None
+
+
+def test_write_marker_writes_no_file_for_a_declined_start(tmp_path: Path) -> None:
+    # Arrange
+    kwargs = dict(
+        started_at="2026-07-22T00:00:00Z",
+        phase="container_creation",
+        exit_code=1,
+        stdout="",
+        stderr=_DECLINE_STDERR,
+    )
+    # Act
+    write_marker(tmp_path, **kwargs)
+    # Assert
+    assert not (tmp_path / MARKER_FILENAME).exists()
+
+
+_REAL_FAILURE_STDERR = (
+    "FATAL: container creation failed: mount source /work/x doesn't exist"
+)
+
+
+def test_write_marker_returns_a_path_for_a_real_failure(tmp_path: Path) -> None:
+    # Arrange
+    kwargs = dict(
+        started_at="2026-07-22T00:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr=_REAL_FAILURE_STDERR,
+    )
+    # Act
+    target = write_marker(tmp_path, **kwargs)
+    # Assert
+    assert target is not None
+
+
+def test_write_marker_creates_the_file_for_a_real_failure(tmp_path: Path) -> None:
+    # Arrange
+    kwargs = dict(
+        started_at="2026-07-22T00:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr=_REAL_FAILURE_STDERR,
+    )
+    # Act
+    write_marker(tmp_path, **kwargs)
+    # Assert
+    assert (tmp_path / MARKER_FILENAME).is_file()
+
+
+def test_write_marker_classifies_a_real_apptainer_failure(tmp_path: Path) -> None:
+    # Arrange
+    kwargs = dict(
+        started_at="2026-07-22T00:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr=_REAL_FAILURE_STDERR,
+    )
+    target = write_marker(tmp_path, **kwargs)
+    # Act
+    payload = json.loads(target.read_text())
+    # Assert
+    assert payload["kind"] == "apptainer_mount_failed"
+
+
+_CLIPPED_DECLINE_STDERR = (
+    "x" * 32_000
+) + f"\nrefusing to start x without --yes/-y\n{DECLINE_SENTINEL}\n"
+
+
+def test_sentinel_survives_the_marker_tail_clip_return_value(tmp_path: Path) -> None:
+    # Arrange — 32 KiB of noise, sentinel at the very end. ``_tail_text``
+    # clips the stored payload to 8 KiB, but the guard must see the FULL
+    # text, not the clipped tail.
+    kwargs = dict(
+        started_at="2026-07-22T00:00:00Z",
+        phase="container_creation",
+        exit_code=1,
+        stdout="",
+        stderr=_CLIPPED_DECLINE_STDERR,
+    )
+    # Act
+    target = write_marker(tmp_path, **kwargs)
+    # Assert
+    assert target is None
+
+
+def test_sentinel_survives_the_marker_tail_clip_no_file(tmp_path: Path) -> None:
+    # Arrange
+    kwargs = dict(
+        started_at="2026-07-22T00:00:00Z",
+        phase="container_creation",
+        exit_code=1,
+        stdout="",
+        stderr=_CLIPPED_DECLINE_STDERR,
+    )
+    # Act
+    write_marker(tmp_path, **kwargs)
+    # Assert
+    assert not (tmp_path / MARKER_FILENAME).exists()
+
+
+# ---------------------------------------------------------------------------
+# The refusal branch emits the sentinel — real interactive run_single_targets
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _real_tty_stdin() -> Iterator[None]:
+    """Swap ``sys.stdin`` for a REAL pty slave — ``isatty()`` genuinely True."""
+    master_fd, slave_fd = pty.openpty()
+    saved_stdin = sys.stdin
+    slave_file = os.fdopen(slave_fd, "r")
+    sys.stdin = slave_file
+    try:
+        yield
+    finally:
+        sys.stdin = saved_stdin
+        slave_file.close()
+        os.close(master_fd)
+
+
+def _write_local_spec(home: Path, name: str) -> Path:
+    agents_dir = home / ".scitex" / "agent-container" / "agents" / name
+    agents_dir.mkdir(parents=True)
+    yaml_path = agents_dir / f"{name}.yaml"
+    yaml_path.write_text(
+        explicitize_yaml(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            'metadata:\n  labels:\n    sac-builtin: "off"\n'
+            "spec:\n"
+            "  runtime: apptainer\n"
+            "  host: ${HOSTNAME}\n"
+            "  workdir: /home/agent/work\n"
+            "  apptainer:\n    image: /x.sif\n    binds: []\n"
+            "  claude:\n    model: sonnet\n"
+            "  health:\n    enabled: true\n    interval: 60\n"
+            "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+            "  a2a:\n    port: null\n"
+        )
+    )
+    return yaml_path
+
+
+class _Refusal(NamedTuple):
+    exit_code: int | None
+    stderr: str
+    log_text: str
+
+
+def _refuse(tmp_path: Path, env_save_restore, capsys, caplog) -> _Refusal:
+    env_save_restore.set("HOME", str(tmp_path))
+    yaml_path = _write_local_spec(tmp_path, "alpha")
+    caplog.set_level(logging.DEBUG)
+    with _real_tty_stdin():
+        with pytest.raises(SystemExit) as exc_info:
+            run_single_targets(
+                [str(yaml_path)],
+                no_preflight=True,
+                force=False,
+                resume_id=None,
+                session_mode=None,
+                dry_run=False,
+                as_json=False,
+                foreground=False,
+                one_shot=False,
+                strict_drift=False,
+                no_redispatch=True,
+                multi_foreground=False,
+                preflight_runner=lambda: None,
+                yes=False,
+            )
+    return _Refusal(
+        exit_code=exc_info.value.code,
+        stderr=capsys.readouterr().err,
+        log_text=caplog.text,
+    )
+
+
+def test_the_refusal_branch_exits_1(tmp_path, env_save_restore, capsys, caplog) -> None:
+    # Arrange
+    # (fixtures above build the isolated HOME + real-tty seam)
+    # Act
+    result = _refuse(tmp_path, env_save_restore, capsys, caplog)
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_the_refusal_branch_emits_the_shared_sentinel(
+    tmp_path, env_save_restore, capsys, caplog
+) -> None:
+    # Arrange
+    # (fixtures above build the isolated HOME + real-tty seam)
+    # Act
+    result = _refuse(tmp_path, env_save_restore, capsys, caplog)
+    # Assert
+    assert DECLINE_SENTINEL in result.stderr
+
+
+def test_the_refusal_branch_still_logs_the_yes_hint(
+    tmp_path, env_save_restore, capsys, caplog
+) -> None:
+    # Arrange
+    # (fixtures above build the isolated HOME + real-tty seam)
+    # Act
+    result = _refuse(tmp_path, env_save_restore, capsys, caplog)
+    # Assert
+    assert "without --yes/-y" in result.log_text

--- a/tests/scitex_agent_container/_lifecycle/test__startup_failed_retract.py
+++ b/tests/scitex_agent_container/_lifecycle/test__startup_failed_retract.py
@@ -1,0 +1,112 @@
+"""Tests for the P2 retraction primitive: ``retract_marker`` renames
+``STARTUP_FAILED`` aside, and NEVER deletes it — the marker is the only
+copy of its ``stderr_tail`` (``runtime/events/*.jsonl`` carries none).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scitex_agent_container._lifecycle._startup_failed import (
+    MARKER_FILENAME,
+    RETRACTED_MARKER_FILENAME,
+    read_marker,
+    retract_marker,
+    write_marker,
+)
+
+_ORIGINAL_STDERR = (
+    "FATAL: container creation failed: mount source /work/x doesn't exist"
+)
+
+
+def _seed_marker(runtime_dir: Path) -> None:
+    write_marker(
+        runtime_dir,
+        started_at="2026-07-22T00:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr=_ORIGINAL_STDERR,
+    )
+
+
+def test_retract_marker_returns_true_when_marker_present(tmp_path: Path) -> None:
+    # Arrange
+    _seed_marker(tmp_path)
+    # Act
+    retracted = retract_marker(tmp_path)
+    # Assert
+    assert retracted is True
+
+
+def test_retract_marker_removes_the_original_file(tmp_path: Path) -> None:
+    # Arrange
+    _seed_marker(tmp_path)
+    # Act
+    retract_marker(tmp_path)
+    # Assert
+    assert not (tmp_path / MARKER_FILENAME).exists()
+
+
+def test_retract_marker_creates_the_retracted_file(tmp_path: Path) -> None:
+    # Arrange
+    _seed_marker(tmp_path)
+    # Act
+    retract_marker(tmp_path)
+    # Assert
+    assert (tmp_path / RETRACTED_MARKER_FILENAME).is_file()
+
+
+def test_retract_marker_retracted_file_preserves_stderr_tail(tmp_path: Path) -> None:
+    # Arrange
+    _seed_marker(tmp_path)
+    retract_marker(tmp_path)
+    # Act
+    payload = json.loads((tmp_path / RETRACTED_MARKER_FILENAME).read_text())
+    # Assert
+    assert _ORIGINAL_STDERR in payload["stderr_tail"]
+
+
+def test_retract_marker_retracted_file_preserves_kind(tmp_path: Path) -> None:
+    # Arrange — the retracted copy is a byte-for-byte rename, not a rewrite;
+    # pin a second field so a "rewrite with a subset of fields" mutation
+    # would also be caught.
+    _seed_marker(tmp_path)
+    retract_marker(tmp_path)
+    # Act
+    payload = json.loads((tmp_path / RETRACTED_MARKER_FILENAME).read_text())
+    # Assert
+    assert payload["kind"] == "apptainer_mount_failed"
+
+
+def test_read_marker_no_longer_sees_a_retracted_marker(tmp_path: Path) -> None:
+    # Arrange — the wire-facing reader keys on the exact MARKER_FILENAME,
+    # so a retraction must fully retract the STATUS/DELETE behaviour too.
+    _seed_marker(tmp_path)
+    retract_marker(tmp_path)
+    # Act
+    result = read_marker(tmp_path)
+    # Assert
+    assert result is None
+
+
+def test_retract_marker_on_a_clean_dir_returns_false(tmp_path: Path) -> None:
+    # Arrange — nothing on disk.
+    # Act
+    retracted = retract_marker(tmp_path)
+    # Assert
+    assert retracted is False
+
+
+def test_retract_marker_on_an_already_retracted_dir_returns_false(
+    tmp_path: Path,
+) -> None:
+    # Arrange — first retraction already happened.
+    _seed_marker(tmp_path)
+    retract_marker(tmp_path)
+    # Act
+    retracted_again = retract_marker(tmp_path)
+    # Assert
+    assert retracted_again is False

--- a/tests/scitex_agent_container/_listen/test__agent_exec_declined.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_declined.py
@@ -1,0 +1,219 @@
+"""P1 wire-level tests: a brokered decline must not mint STARTUP_FAILED,
+and a genuine brokered failure still must.
+
+Real ``TestClient`` + a real fake ``sac`` shim on ``$PATH`` (mirrors
+``test__agent_exec_subprocess.py``) — no mocks. The shim prints the
+exact refusal banner + the shared decline sentinel to stderr and exits
+non-zero, exactly like a real ``sac agents start`` refusal does.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._lifecycle._startup_failed import read_marker
+from scitex_agent_container._listen.server import create_app
+from scitex_agent_container._runners import _session_state as _ss
+from scitex_agent_container._runners._session_state import state_dir_for
+from scitex_agent_container._state import registry as _reg
+from scitex_agent_container._state import state_db
+
+_TOKEN = "test-token-agent-exec-declined"
+
+
+@pytest.fixture
+def isolated_listen_env(tmp_path: Path):
+    """Isolated state.db + registry/runtime dirs (mirrors test__agent_exec_subprocess.py)."""
+    db = tmp_path / "state.db"
+    saved_env_db = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default_db = state_db.DEFAULT_DB_PATH
+    saved_home = os.environ.get("HOME")
+    saved_reg_const = _reg.REGISTRY_DIR
+    saved_state_const = _ss.DEFAULT_STATE_ROOT
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    os.environ["HOME"] = str(tmp_path)
+    _reg.REGISTRY_DIR = tmp_path / "registry"
+    _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
+    try:
+        yield tmp_path
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default_db
+        _reg.REGISTRY_DIR = saved_reg_const
+        _ss.DEFAULT_STATE_ROOT = saved_state_const
+        if saved_env_db is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env_db
+        if saved_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved_home
+
+
+def _install_declining_sac_shim(bin_dir: Path) -> None:
+    """A shim that behaves exactly like a real `--yes`-less refusal."""
+    from scitex_agent_container._lifecycle._start_decline import DECLINE_SENTINEL
+
+    script = bin_dir / "sac"
+    script.write_text(
+        f"#!{sys.executable}\n"
+        "import sys\n"
+        'sys.stderr.write("refusing to start x without --yes/-y — the plan '
+        "above shows exactly what will mount and run; re-run with --yes to "
+        'launch.\\n")\n'
+        f'sys.stderr.write({DECLINE_SENTINEL!r} + "\\n")\n'
+        "sys.exit(1)\n"
+    )
+    script.chmod(0o755)
+
+
+def _install_crashing_sac_shim(bin_dir: Path) -> None:
+    """A shim simulating a genuine apptainer FATAL — no sentinel anywhere."""
+    script = bin_dir / "sac"
+    script.write_text(
+        f"#!{sys.executable}\n"
+        "import sys\n"
+        'sys.stderr.write("FATAL: container creation failed: mount source '
+        "/work/x doesn't exist\\n\")\n"
+        "sys.exit(255)\n"
+    )
+    script.chmod(0o755)
+
+
+class _Posted(NamedTuple):
+    status_code: int
+    body: dict
+    marker: dict | None
+
+
+def _post_agents(
+    env_save_restore, tmp_path: Path, *, name: str, declining: bool
+) -> _Posted:
+    bin_dir = tmp_path / f"sac_bin_{'decline' if declining else 'crash'}"
+    bin_dir.mkdir()
+    if declining:
+        _install_declining_sac_shim(bin_dir)
+    else:
+        _install_crashing_sac_shim(bin_dir)
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    app = create_app(token=_TOKEN)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/agents",
+            json={"name": name},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    return _Posted(
+        status_code=resp.status_code,
+        body=resp.json(),
+        marker=read_marker(state_dir_for(name)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# A declined brokered start writes no marker
+# ---------------------------------------------------------------------------
+
+
+def test_a_declined_brokered_start_returns_502(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    # (fixtures above build the isolated state dirs + shim)
+    # Act
+    result = _post_agents(
+        env_save_restore, tmp_path, name="declined-child", declining=True
+    )
+    # Assert
+    assert result.status_code == 502
+
+
+def test_a_declined_brokered_start_body_marks_declined_true(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    # (fixtures above build the isolated state dirs + shim)
+    # Act
+    result = _post_agents(
+        env_save_restore, tmp_path, name="declined-body", declining=True
+    )
+    # Assert
+    assert result.body["declined"] is True
+
+
+def test_a_declined_brokered_start_writes_no_marker(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    # (fixtures above build the isolated state dirs + shim)
+    # Act
+    result = _post_agents(
+        env_save_restore, tmp_path, name="declined-no-marker", declining=True
+    )
+    # Assert
+    assert result.marker is None
+
+
+# ---------------------------------------------------------------------------
+# A genuine launch failure still writes a marker
+# ---------------------------------------------------------------------------
+
+
+def test_a_genuine_launch_failure_returns_502(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    # (fixtures above build the isolated state dirs + shim)
+    # Act
+    result = _post_agents(
+        env_save_restore, tmp_path, name="crash-child", declining=False
+    )
+    # Assert
+    assert result.status_code == 502
+
+
+def test_a_genuine_launch_failure_body_marks_declined_false(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    # (fixtures above build the isolated state dirs + shim)
+    # Act
+    result = _post_agents(
+        env_save_restore, tmp_path, name="crash-body", declining=False
+    )
+    # Assert
+    assert result.body["declined"] is False
+
+
+def test_a_genuine_launch_failure_writes_a_marker(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    # (fixtures above build the isolated state dirs + shim)
+    # Act
+    result = _post_agents(
+        env_save_restore, tmp_path, name="crash-marker", declining=False
+    )
+    # Assert
+    assert result.marker is not None
+
+
+def test_a_genuine_launch_failure_marker_classifies_apptainer_mount_failed(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    # (fixtures above build the isolated state dirs + shim)
+    # Act
+    result = _post_agents(
+        env_save_restore, tmp_path, name="crash-kind", declining=False
+    )
+    # Assert
+    assert result.marker["kind"] == "apptainer_mount_failed"

--- a/tests/scitex_agent_container/_listen/test_server_startup_failed_superseded.py
+++ b/tests/scitex_agent_container/_listen/test_server_startup_failed_superseded.py
@@ -1,0 +1,268 @@
+"""P4 read-side supersession: has liveness since refuted a STARTUP_FAILED?
+
+``GET /agents/<name>/status`` relabels (never deletes/renames) a marker as
+``startup_failed_superseded`` when ``heartbeat.json``'s MTIME — the field
+documented as PROCESS ALIVE, never the ``ts`` payload field — postdates
+the marker's ``failed_at`` by at least one staleness window
+(``HEARTBEAT_STALE_S``). Mirrors the fixture shape of
+``test_server_startup_failed.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._lifecycle._startup_failed import MARKER_FILENAME
+from scitex_agent_container._lifecycle._verdict_state import HEARTBEAT_STALE_S
+from scitex_agent_container._listen.server import create_app
+
+TOKEN = "test-token-startup-failed-superseded"
+
+
+@pytest.fixture
+def isolated_env(tmp_path: Path, env_save_restore):
+    """Redirect $HOME + the SAC dir envs (mirrors test_server_startup_failed.py)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    yaml_dir = home / ".scitex" / "agent-container" / "agents"
+    yaml_dir.mkdir(parents=True, exist_ok=True)
+    env_save_restore.set("HOME", str(home))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(runtime))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", str(yaml_dir))
+    import importlib
+
+    import scitex_agent_container._runners._session_state as ss
+
+    importlib.reload(ss)
+    env_save_restore.reload_after_restore(ss)
+    yield tmp_path
+
+
+@pytest.fixture
+def client(isolated_env):
+    app = create_app(token=TOKEN)
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def auth_headers():
+    return {"authorization": f"Bearer {TOKEN}"}
+
+
+def _write_spec(home: Path, name: str) -> Path:
+    import yaml
+
+    spec_dir = home / ".scitex" / "agent-container" / "agents" / name
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    from tests.scitex_agent_container._helpers.explicit_spec import explicit_spec
+
+    spec = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": explicit_spec(
+            {
+                "runtime": "tui",
+                "host": "${HOSTNAME}",
+                "workdir": "/tmp",
+                "apptainer": {"image": "/x.sif", "binds": []},
+                "claude": {"model": "claude-sonnet-4-5"},
+                "health": {"enabled": True, "interval": 60},
+                "restart": {"policy": "on-failure", "max_retries": 3},
+            }
+        ),
+    }
+    spec_path = spec_dir / "spec.yaml"
+    spec_path.write_text(yaml.safe_dump(spec))
+    return spec_path
+
+
+def _state_dir(name: str) -> Path:
+    import importlib
+
+    import scitex_agent_container._runners._session_state as ss
+
+    importlib.reload(ss)
+    return ss.state_dir_for(name)
+
+
+def _iso(seconds_ago: float) -> str:
+    t = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+    return t.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _write_marker(runtime_dir: Path, *, failed_seconds_ago: float) -> None:
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "started_at": _iso(failed_seconds_ago),
+        "failed_at": _iso(failed_seconds_ago),
+        "phase": "container_creation",
+        "kind": "apptainer_mount_failed",
+        "exit_code": 255,
+        "runtime_dir": str(runtime_dir.resolve()),
+        "stdout_tail": "",
+        "stderr_tail": "FATAL: mount source /work/x doesn't exist",
+        "remediation_hint": "",
+    }
+    (runtime_dir / MARKER_FILENAME).write_text(json.dumps(payload))
+
+
+def _write_heartbeat(
+    runtime_dir: Path, *, ts_seconds_ago: float, mtime_seconds_ago: float
+) -> None:
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    hb = runtime_dir / "heartbeat.json"
+    hb.write_text(json.dumps({"pid": 0, "ts": time.time() - ts_seconds_ago}))
+    target = time.time() - mtime_seconds_ago
+    os.utime(hb, (target, target))
+
+
+# ---------------------------------------------------------------------------
+# A fresh beat postdating the failure supersedes
+# ---------------------------------------------------------------------------
+
+
+def test_status_supersedes_when_a_fresh_beat_postdates_the_failure(
+    client, auth_headers, isolated_env
+) -> None:
+    # Arrange — failed 19 days ago; beat is fresh (just now).
+    _write_spec(isolated_env / "home", "fresh-beat")
+    sd = _state_dir("fresh-beat")
+    _write_marker(sd, failed_seconds_ago=19 * 86400)
+    _write_heartbeat(sd, ts_seconds_ago=0, mtime_seconds_ago=0)
+    # Act
+    response = client.get("/agents/fresh-beat/status", headers=auth_headers)
+    # Assert
+    assert response.json()["status"] == "startup_failed_superseded"
+
+
+def test_superseded_status_still_carries_the_full_marker(
+    client, auth_headers, isolated_env
+) -> None:
+    # Arrange
+    _write_spec(isolated_env / "home", "fresh-beat-marker")
+    sd = _state_dir("fresh-beat-marker")
+    _write_marker(sd, failed_seconds_ago=19 * 86400)
+    _write_heartbeat(sd, ts_seconds_ago=0, mtime_seconds_ago=0)
+    # Act
+    response = client.get("/agents/fresh-beat-marker/status", headers=auth_headers)
+    # Assert
+    assert response.json()["startup_failed"]["kind"] == "apptainer_mount_failed"
+
+
+def test_superseded_status_names_the_refuting_signal(
+    client, auth_headers, isolated_env
+) -> None:
+    # Arrange
+    _write_spec(isolated_env / "home", "fresh-beat-refuter")
+    sd = _state_dir("fresh-beat-refuter")
+    _write_marker(sd, failed_seconds_ago=19 * 86400)
+    _write_heartbeat(sd, ts_seconds_ago=0, mtime_seconds_ago=0)
+    # Act
+    response = client.get("/agents/fresh-beat-refuter/status", headers=auth_headers)
+    # Assert
+    assert response.json()["startup_failed_superseded_by"] != ""
+
+
+# ---------------------------------------------------------------------------
+# A stale beat does not supersede
+# ---------------------------------------------------------------------------
+
+
+def test_status_does_not_supersede_on_a_stale_beat(
+    client, auth_headers, isolated_env
+) -> None:
+    # Arrange — beat is older than HEARTBEAT_STALE_S.
+    _write_spec(isolated_env / "home", "stale-beat")
+    sd = _state_dir("stale-beat")
+    _write_marker(sd, failed_seconds_ago=19 * 86400)
+    stale = HEARTBEAT_STALE_S + 3000
+    _write_heartbeat(sd, ts_seconds_ago=stale, mtime_seconds_ago=stale)
+    # Act
+    response = client.get("/agents/stale-beat/status", headers=auth_headers)
+    # Assert
+    assert response.json()["status"] == "startup_failed"
+
+
+# ---------------------------------------------------------------------------
+# No heartbeat file at all does not supersede
+# ---------------------------------------------------------------------------
+
+
+def test_status_does_not_supersede_when_there_is_no_heartbeat_file(
+    client, auth_headers, isolated_env
+) -> None:
+    # Arrange — the measured scitex-agentic-journal shape: the one
+    # unambiguously TRUE marker in the fleet has no heartbeat.json at all.
+    _write_spec(isolated_env / "home", "no-heartbeat")
+    sd = _state_dir("no-heartbeat")
+    _write_marker(sd, failed_seconds_ago=19 * 86400)
+    # Act
+    response = client.get("/agents/no-heartbeat/status", headers=auth_headers)
+    # Assert
+    assert response.json()["status"] == "startup_failed"
+
+
+# ---------------------------------------------------------------------------
+# Supersession reads heartbeat MTIME, never the `ts` payload field
+# ---------------------------------------------------------------------------
+
+
+def test_supersession_uses_mtime_when_ts_is_stale_but_mtime_is_fresh(
+    client, auth_headers, isolated_env
+) -> None:
+    # Arrange — real measured scitex-fixture divergence: `ts` is 70182s
+    # stale (would NOT supersede if read), but `mtime` is fresh.
+    _write_spec(isolated_env / "home", "mtime-not-ts-a")
+    sd = _state_dir("mtime-not-ts-a")
+    _write_marker(sd, failed_seconds_ago=19 * 86400)
+    _write_heartbeat(sd, ts_seconds_ago=70182, mtime_seconds_ago=0)
+    # Act
+    response = client.get("/agents/mtime-not-ts-a/status", headers=auth_headers)
+    # Assert
+    assert response.json()["status"] == "startup_failed_superseded"
+
+
+def test_supersession_uses_mtime_when_ts_is_fresh_but_mtime_is_stale(
+    client, auth_headers, isolated_env
+) -> None:
+    # Arrange — inverse: `ts` is fresh (would WRONGLY supersede if read),
+    # but `mtime` is a full day stale.
+    _write_spec(isolated_env / "home", "mtime-not-ts-b")
+    sd = _state_dir("mtime-not-ts-b")
+    _write_marker(sd, failed_seconds_ago=19 * 86400)
+    _write_heartbeat(sd, ts_seconds_ago=0, mtime_seconds_ago=86400)
+    # Act
+    response = client.get("/agents/mtime-not-ts-b/status", headers=auth_headers)
+    # Assert
+    assert response.json()["status"] == "startup_failed"
+
+
+# ---------------------------------------------------------------------------
+# A beat within one staleness window of the failure does not supersede
+# ---------------------------------------------------------------------------
+
+
+def test_a_beat_within_one_staleness_window_of_the_failure_does_not_supersede(
+    client, auth_headers, isolated_env
+) -> None:
+    # Arrange — the failure itself is only 30s old; its own boot attempt's
+    # beat must not be read as refuting it.
+    _write_spec(isolated_env / "home", "same-boot-beat")
+    sd = _state_dir("same-boot-beat")
+    _write_marker(sd, failed_seconds_ago=30)
+    _write_heartbeat(sd, ts_seconds_ago=0, mtime_seconds_ago=0)
+    # Act
+    response = client.get("/agents/same-boot-beat/status", headers=auth_headers)
+    # Assert
+    assert response.json()["status"] == "startup_failed"

--- a/tests/scitex_agent_container/_listen/test_server_startup_failed_superseded.py
+++ b/tests/scitex_agent_container/_listen/test_server_startup_failed_superseded.py
@@ -221,23 +221,39 @@ def test_status_does_not_supersede_when_there_is_no_heartbeat_file(
 def test_supersession_uses_mtime_when_ts_is_stale_but_mtime_is_fresh(
     client, auth_headers, isolated_env
 ) -> None:
-    # Arrange — real measured scitex-fixture divergence: `ts` is 70182s
-    # stale (would NOT supersede if read), but `mtime` is fresh.
+    # Arrange — a TIGHT window, chosen so the choice of clock source is the
+    # ONLY thing that can flip the verdict: the failure is HEARTBEAT_STALE_S
+    # + 100s old; `mtime` is fresh (postdates the failure by >= one window,
+    # via the REAL clock); `ts` claims a moment only 10s after the failure
+    # (postdates it by << one window). A implementation that reads `ts`
+    # instead of `mtime` for the postdates-failure check returns early
+    # (not superseded) here — a WIDE gap (e.g. 19 days failed / 70182s-old
+    # `ts`) does NOT discriminate: both clock sources clear the one-window
+    # bar by an enormous margin regardless of which is read, so a test built
+    # on wide gaps alone would pass against a broken implementation too.
+    failed_seconds_ago = HEARTBEAT_STALE_S + 100
+    ts_seconds_ago = failed_seconds_ago - 10
     _write_spec(isolated_env / "home", "mtime-not-ts-a")
     sd = _state_dir("mtime-not-ts-a")
-    _write_marker(sd, failed_seconds_ago=19 * 86400)
-    _write_heartbeat(sd, ts_seconds_ago=70182, mtime_seconds_ago=0)
+    _write_marker(sd, failed_seconds_ago=failed_seconds_ago)
+    _write_heartbeat(sd, ts_seconds_ago=ts_seconds_ago, mtime_seconds_ago=0)
     # Act
     response = client.get("/agents/mtime-not-ts-a/status", headers=auth_headers)
     # Assert
     assert response.json()["status"] == "startup_failed_superseded"
 
 
-def test_supersession_uses_mtime_when_ts_is_fresh_but_mtime_is_stale(
+def test_a_fresh_ts_does_not_supersede_a_stale_real_mtime(
     client, auth_headers, isolated_env
 ) -> None:
-    # Arrange — inverse: `ts` is fresh (would WRONGLY supersede if read),
-    # but `mtime` is a full day stale.
+    # Arrange — general correctness pin, NOT a clock-source discriminator:
+    # ``heartbeat_signal`` re-reads the real OS mtime independently, so it
+    # gates on the actual stale mtime regardless of which clock the
+    # postdates-check used — this holds even under the ts-reading mutation
+    # the test above catches, since that mutation only ever widens what
+    # reaches ``heartbeat_signal``, never narrows it. Kept as a behavioral
+    # pin against a DIFFERENT future bug (e.g. dropping the
+    # ``heartbeat_signal`` corroboration entirely).
     _write_spec(isolated_env / "home", "mtime-not-ts-b")
     sd = _state_dir("mtime-not-ts-b")
     _write_marker(sd, failed_seconds_ago=19 * 86400)


### PR DESCRIPTION
## What this fixes

A `STARTUP_FAILED` marker was **permanent**. Once written it was never cleared, so an agent that
later started and ran fine still carried a failure verdict that no code path retracted — the fleet
read a durable label describing a transient event.

The sharpest instance: `sac agents start` without `--yes` **declines** and exits 1. A decline is a
refusal, not a failure — nothing was attempted, nothing broke. It was recorded as `STARTUP_FAILED`
anyway, and **21 agents were carrying that verdict** from refusals no code could ever clear.

## What it does

1. **Retract on confirmed-alive start.** When a start is confirmed alive, the marker is cleared —
   the verdict now tracks reality instead of outliving it.
2. **A decline is not a failure.** The declined path (`exit 1` with no attempt) no longer writes the
   marker at all, on both the CLI and listen-broker routes.
3. **Supersede rather than accumulate.** `_startup_failed_supersede.py` makes a newer outcome
   replace an older marker instead of layering on top of it.

## Evidence

- **195 passed** on the startup-related subset (`-k 'startup_failed or startup'`), 11401 deselected.
- Four **mutation proofs**: each defect planted → RED, reverted → GREEN. These exist because a test
  that cannot fail is the failure mode this whole PR is about — a marker that never fires is exactly
  as useless as a check that never fires.
- One test in this branch was **tightened after it failed to fail**: the P4 mtime-vs-ts mutation
  test used a wide time gap that passed under the mutation. Commit `8c9b18f9` narrows it so it
  actually discriminates. Reported here rather than quietly fixed, because "the test was green"
  was not evidence until it could go red.
- **PS-204 clean**, `audit-project` reports no project-structure violations on this tree.

## What I am not claiming

The **full local suite has not completed** — the run has been going ~75 minutes, buffers until exit,
and is competing with other agents' pytest processes on this host. I am not reporting a full-suite
number I do not have. CI runs the same suite properly isolated in ~9 minutes and is the verifier
here; if it goes red, that is real and I will fix it rather than explain it away.

## Note on the base

Rebased onto current `develop` (`d33611ec`, the #816 merge) rather than the stale base it was cut
from.
