### PR TITLE
fix(listen): re-export _resolve_runtime_self_identity — its absence disabled self-peers silently

### DIFF
--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -61,7 +61,19 @@ async def health(_request: Request) -> JSONResponse:
 # REACHABLE — see ``_reachability``). Re-imported here so route
 # registration and the historical
 # ``from ..._listen.server import list_agents`` import path keep working.
-from ._agents_list import list_agents  # noqa: E402,F401
+#
+# ``_resolve_runtime_self_identity`` moved in that same extraction and must
+# be re-exported on the same terms: three callers still import it from here
+# (``_self_peer_persistence``, ``_agents_list`` itself, and
+# ``_mcp._channel_self_peer_discovery``). It was left out, and because both
+# self-peer call sites import it inside a try/except that degrades to a
+# warning, the resulting ImportError disabled self-peer persistence SILENTLY
+# rather than failing — listen kept serving while reporting "continues
+# without persisted self-peers".
+from ._agents_list import (  # noqa: E402,F401
+    _resolve_runtime_self_identity,
+    list_agents,
+)
 
 
 async def agent_status(request: Request) -> JSONResponse:

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -1567,3 +1567,81 @@ def test_self_peer_persistence_can_resolve_identity_without_falling_back() -> No
     assert _resolve_runtime_self_identity() is None or isinstance(
         _resolve_runtime_self_identity(), str
     )
+
+
+# ---------------------------------------------------------------------------
+# The FAMILY guard, not just this instance
+#
+# Fixing one missing re-export leaves the class unguarded: any symbol imported
+# from `_listen.server` that this module does not export fails the same way,
+# and both self-peer call sites absorb that ImportError into a warning, so it
+# degrades silently instead of failing. `_resolve_runtime_self_identity` sat
+# broken on develop for exactly that reason.
+#
+# This scans the shipped package for every `from ... _listen.server import X`
+# and asserts X actually resolves. It catches the whole family at import-graph
+# level, without needing anyone to have anticipated the specific symbol.
+# ---------------------------------------------------------------------------
+
+
+def _symbols_imported_from_listen_server() -> list[tuple[str, str]]:
+    """Return (filename, symbol) for every import taken from `_listen.server`.
+
+    Covers all three spellings in the tree: `from .server import X` inside
+    `_listen/`, `from .._listen.server import X`, and the absolute form.
+    """
+    import ast
+    from pathlib import Path
+
+    from scitex_agent_container._listen import server as _server
+
+    listen_dir = Path(_server.__file__).parent
+    pkg_root = listen_dir.parent
+    found: list[tuple[str, str]] = []
+    for py in pkg_root.rglob("*.py"):
+        if "__pycache__" in py.parts:
+            continue
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8", errors="replace"))
+        except (SyntaxError, OSError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            mod = node.module or ""
+            targets = (
+                (node.level == 1 and mod == "server" and py.parent == listen_dir)
+                or (node.level >= 1 and mod.endswith("_listen.server"))
+                or (node.level == 0 and mod.endswith("_listen.server"))
+            )
+            if targets:
+                found.extend((py.name, a.name) for a in node.names if a.name != "*")
+    return found
+
+
+def test_listen_server_import_scan_is_not_vacuous() -> None:
+    # Arrange — a scan that finds nothing would make the guard below pass
+    # for the wrong reason. This is that guard's positive control.
+    expected_at_least = 2
+
+    # Act
+    found = _symbols_imported_from_listen_server()
+
+    # Assert
+    assert len(found) >= expected_at_least, f"scan found only {found}"
+
+
+def test_every_symbol_imported_from_listen_server_resolves() -> None:
+    # Arrange
+    from scitex_agent_container._listen import server as _server
+
+    requested = _symbols_imported_from_listen_server()
+
+    # Act
+    missing = [(f, n) for f, n in requested if not hasattr(_server, n)]
+
+    # Assert
+    assert not missing, (
+        "imported from _listen.server but not exported by it — this fails "
+        f"SILENTLY at runtime where the caller catches ImportError: {missing}"
+    )

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -1514,3 +1514,56 @@ def test_message_send_threads_dispatch_id_into_published_event(
     event = _roundtrip_local_send(cross_host_env, metadata=metadata)
     # Assert
     assert event.get("dispatch_id") == "d-route-99"
+
+
+# ---------------------------------------------------------------------------
+# Re-export surface — a missing one degraded SILENTLY
+#
+# `_resolve_runtime_self_identity` moved into `_agents_list` alongside
+# `list_agents`, but only `list_agents` was re-exported here. Both self-peer
+# callers import it inside a try/except that falls back to a warning, so the
+# ImportError disabled self-peer persistence WITHOUT failing anything: listen
+# kept serving and logged "continues without persisted self-peers". It reached
+# develop and survived there, because nothing asserted the import.
+#
+# These assert the import SITE, not the behaviour, which is the thing that
+# actually broke. Delete either name from the re-export and they go red.
+# ---------------------------------------------------------------------------
+
+
+def test_server_reexports_resolve_runtime_self_identity() -> None:
+    # Arrange — the historical import path three callers still use.
+    from scitex_agent_container._listen import server
+
+    # Act
+    resolved = getattr(server, "_resolve_runtime_self_identity", None)
+
+    # Assert
+    assert callable(resolved)
+
+
+def test_server_reexports_list_agents() -> None:
+    # Arrange — the sibling that WAS re-exported; guards the pair.
+    from scitex_agent_container._listen import server
+
+    # Act
+    resolved = getattr(server, "list_agents", None)
+
+    # Assert
+    assert callable(resolved)
+
+
+def test_self_peer_persistence_can_resolve_identity_without_falling_back() -> None:
+    # Arrange — the real consumer whose except-branch masked the breakage.
+    from scitex_agent_container._listen import _self_peer_persistence  # noqa: F401
+
+    # Act
+    from scitex_agent_container._listen.server import (
+        _resolve_runtime_self_identity,
+    )
+
+    # Assert — resolving to None is a legitimate answer (no `lead:` block);
+    # raising ImportError is not, and that is what this pins.
+    assert _resolve_runtime_self_identity() is None or isinstance(
+        _resolve_runtime_self_identity(), str
+    )


### PR DESCRIPTION
## A feature that was off, and reported itself as fine

`_resolve_runtime_self_identity` was extracted into `_agents_list` in the same refactor that
extracted `list_agents` — but **only `list_agents` was re-exported from `server`.** Three callers
still import it from there:

| caller | line |
|---|---|
| `_listen/_self_peer_persistence.py` | 250 |
| `_listen/_agents_list.py` (its own definition site is 192) | 145 |
| `_mcp/_channel_self_peer_discovery.py` | 135 |

Both self-peer call sites perform that import **inside a `try`/`except` that degrades to a
warning**. So the `ImportError` never failed anything: listen kept serving and logged

    self-peer persistence ... listen continues without persisted self-peers

Self-peer persistence has therefore been **disabled on develop**, while the system reported normal
operation. It reached develop and survived because nothing asserted the import — the except-branch
was doing exactly what it was written to do, and that is what hid it.

## Reproduced before fixing

On clean `develop` (`d33611ec`), untouched:

    ImportError: cannot import name '_resolve_runtime_self_identity'
                 from 'scitex_agent_container._listen.server'

## The fix

Re-export it on the same terms as its sibling, and extend the existing comment to record that the
pair must move together and why the omission was invisible.

## Mutation proof

The three tests pin the **import site**, not the behaviour, because the import is what broke.

    with the fix          -> 3 passed
    re-export removed     -> 2 failed, 1 passed
    restored              -> 3 passed

The `list_agents` test staying **green** through the mutation is deliberate: it shows the two
failures are specific to the removed symbol rather than to having broken the module generally.

## Why this may matter beyond the warning

The operator has reported confusion around a2a peers — messages not moving, `peers` being
misleading. `_mcp/_channel_self_peer_discovery.py` is one of the broken importers, so self-peer
discovery has been degraded on this path. I am **not** claiming this explains that report; I have
not traced it end to end. It is a live defect in that area and worth checking against those
symptoms.

## Scope

Found while investigating a `develop` CI failure. That run also contained an unrelated infra flake
(`OSError: [Errno 98] address already in use` binding `127.0.0.1:34595` on the self-hosted runner,
consistent with parallel-pytest contention). **Not addressed here** — different problem, and this PR
stays one fix.
