### PR TITLE
fix(creds): blind account must not outrank sighted near-capped ones under the boot quota gate

### DIFF
--- a/src/scitex_agent_container/_creds/_pick_healthy.py
+++ b/src/scitex_agent_container/_creds/_pick_healthy.py
@@ -231,9 +231,13 @@ def pick_healthy_account(
         preflight) a fully-BLIND selection — the picked account has
         NEITHER a cached 5h NOR a cached 7d utilisation — raises
         :class:`NoHealthyAccountError` instead of booting an unverifiable
-        account. This fires only when the cache is empty for EVERY fresh
-        candidate (a known-headroom account would have won the ranking);
-        a fleet with known-but-busy quota still returns least-bad.
+        account. Blind candidates are also excluded from the ranking while
+        any SIGHTED (cached-quota) candidate exists — a blind account can
+        never pass the gate, so it must not displace one that can (even a
+        near-capped one: least-bad sighted beats unverifiable). The gate
+        therefore fires only when the cache is empty for EVERY fresh
+        candidate; a fleet with known-but-busy quota still returns
+        least-bad.
 
     Returns
     -------
@@ -370,9 +374,26 @@ def pick_healthy_account(
     #    load-balances the winning tier across the fleet. Quota is a
     #    preference, not a hard gate: an all-blocked fleet still returns
     #    the least-bad fresh account.
+    #
+    #    Under require_quota_evidence a BLIND candidate (no cached 5h AND
+    #    no cached 7d) can never boot — the gate below refuses it — so it
+    #    must not displace a SIGHTED one in the ranking either. Without
+    #    this restriction the tier order (d7-unknown sorts ahead of
+    #    near-capped) hands the gate a blind winner whenever every sighted
+    #    account is near-capped, and the boot is refused even though a
+    #    verifiable least-bad account exists (2026-07-25 incident: a
+    #    cancelled account's usage fetch FAILED → no cache entry → it
+    #    outranked two 7d≥90% siblings and blocked the restart).
     if picked is None:
+        rank_pool = [h.name for h in fresh]
+        if require_quota_evidence:
+            sighted = [
+                n for n in rank_pool if u5.get(n) is not None or u7.get(n) is not None
+            ]
+            if sighted:
+                rank_pool = sighted
         picked = pick_ranked(
-            [h.name for h in fresh],
+            rank_pool,
             u5,
             u7,
             reset_7d=r7,
@@ -388,11 +409,12 @@ def pick_healthy_account(
     #    never collapsed into "OK"). Under require_quota_evidence, if the
     #    selected account has NEITHER a cached 5h NOR a cached 7d reading,
     #    the quota cache told us nothing about it and we cannot confirm it
-    #    has headroom. Because the ranking prefers a known account over an
-    #    unknown one, a blind winner means EVERY fresh candidate is blind
-    #    (an empty/absent cache) — the 2026-07-20 incident, where the pick
-    #    read "5h=? 7d=?" and booted a 7d=100% account. Refuse rather than
-    #    boot blind; a fleet with known-but-busy quota is unaffected.
+    #    has headroom. Because the ranking above is restricted to sighted
+    #    candidates whenever any exist, a blind winner means EVERY fresh
+    #    candidate is blind (an empty/absent cache) — the 2026-07-20
+    #    incident, where the pick read "5h=? 7d=?" and booted a 7d=100%
+    #    account. Refuse rather than boot blind; a fleet with
+    #    known-but-busy quota is unaffected.
     if require_quota_evidence and u5.get(picked) is None and u7.get(picked) is None:
         raise NoHealthyAccountError(
             f"quota cache is blind for the selected account {picked!r} "

--- a/tests/scitex_agent_container/_creds/test__pick_healthy_require_quota_evidence.py
+++ b/tests/scitex_agent_container/_creds/test__pick_healthy_require_quota_evidence.py
@@ -173,6 +173,40 @@ def test_known_but_capped_fleet_returns_least_bad_not_raise(_isolate_home):
     assert picked in {"wyusuuke-gmail-com", "ywatanabe-scitex-ai"}
 
 
+def test_blind_pin_with_sighted_near_capped_siblings_boots_on_a_sighted_one(
+    _isolate_home,
+):
+    # Arrange: the 2026-07-25 incident shape. The pinned account is BLIND
+    # (cancelled — its usage fetch FAILED so the cache has no entry), and
+    # every sighted sibling is near-capped (7d ≥ 90). The blind account's
+    # tier (not blocked, not near-capped, d7-unknown) sorts AHEAD of the
+    # sighted-but-capped tier, so without the sighted-pool restriction the
+    # ranking hands the gate a blind winner and the boot is refused even
+    # though a verifiable least-bad account exists.
+    home = _isolate_home
+    now = 1_784_530_000.0
+    for name in ("wyusuuke-gmail-com", "ywata1989-gmail-com", "ywatanabe-scitex-ai"):
+        _write_fresh_snapshot(home, name, now)
+
+    # Act: under the gate, blind candidates must not displace sighted ones.
+    picked = pick_healthy_account(
+        "wyusuuke-gmail-com",  # blind pin (no cached quota at all)
+        candidates=[
+            "wyusuuke-gmail-com",
+            "ywata1989-gmail-com",
+            "ywatanabe-scitex-ai",
+        ],
+        home=home,
+        now=now,
+        usage_5h={"ywata1989-gmail-com": 0.0, "ywatanabe-scitex-ai": 1.0},
+        usage_7d={"ywata1989-gmail-com": 100.0, "ywatanabe-scitex-ai": 90.0},
+        require_quota_evidence=True,
+    )
+
+    # Assert: least-bad SIGHTED account (lowest 7d %), not a refusal.
+    assert picked == "ywatanabe-scitex-ai"
+
+
 def test_blind_pick_error_names_the_selected_account(_isolate_home):
     # Arrange: a single fresh account with no quota evidence.
     home = _isolate_home


### PR DESCRIPTION
## Problem (2026-07-25, `sac-restart scitex-hub`)

The cancelled account `wyusuuke-gmail-com` fails its usage fetch, so `refresh-quota-cache` writes no cache entry for it — it is BLIND. Both sighted accounts were near-capped (`ywata1989` 7d=100%, `ywatanabe-scitex-ai` 7d=90%). The ranking tier `(blocked_now, near_capped, d7_unknown)` sorts the blind account `(F, F, T)` **ahead of** the sighted-but-capped ones `(F, T, F)`, so the blind account won the pick — and then the `require_quota_evidence` blind-pick gate refused the boot:

```
Error: quota cache is blind for the selected account 'wyusuuke-gmail-com' …
```

…even though `ywatanabe-scitex-ai` (5h=1%) was fresh, sighted, and usable. The gate's own comment claimed "a blind winner means EVERY fresh candidate is blind", which is false exactly when all sighted candidates are near-capped.

## Fix

Under `require_quota_evidence`, a blind candidate can never boot (the gate refuses it), so it must not displace a sighted one in the ranking either: restrict the ranking pool to sighted candidates whenever any exist. The gate now genuinely fires only when EVERY fresh candidate is blind. Default (no gate) behaviour is unchanged.

## Test

`test_blind_pin_with_sighted_near_capped_siblings_boots_on_a_sighted_one` reproduces the incident shape (blind pin + two near-capped sighted siblings) — red before, green after. Full `_creds` + creds-gate suites: 100 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)