### PR TITLE
fix(fleet-env): stop injecting SCITEX_CARDS_DUAL_WRITE fleet-wide

### DIFF
--- a/src/scitex_agent_container/runtimes/_fleet_env.py
+++ b/src/scitex_agent_container/runtimes/_fleet_env.py
@@ -63,20 +63,25 @@ CONFIG_SECTION = "fleet_default_env"
 # THE DATA. Fleet-wide environment defaults, declared once, inherited by every
 # agent that does not override the key in its own ``spec.env``.
 #
-# SCITEX_CARDS_DUAL_WRITE / SCITEX_CARDS_READ_BACKEND (2026-07-18, stage 1 of
-# the operator's YAML→DB ruling, requested by scitex-cards): the board's
-# ``get_board()`` re-parses a ~9 MB tasks YAML at ~4.6 s and every store write
-# invalidates the cache, which is why the operator's board takes ~30 s.
-# scitex-cards has a SQLite mirror that serves the same rows, but it refuses to
-# serve while the mirror is stale — and the mirror goes stale within seconds
-# unless EVERY writer dual-writes. Every writer is every agent, so this flag
-# only works if it reaches the whole fleet at once. That is exactly the layer
-# this module adds; before it, there was no way to say this to N agents.
+# SCITEX_CARDS_READ_BACKEND (2026-07-18, the operator's YAML→DB ruling,
+# requested by scitex-cards): pins the board's read path to the SQLite store.
+#
+# SCITEX_CARDS_DUAL_WRITE was injected alongside it to keep a SQLite mirror
+# fresh next to a ~9 MB tasks YAML. That YAML tier was DELETED 2026-07-21, so
+# from then on the flag gated nothing while still being injected into every
+# container — and scitex-cards' ``health`` FAILS its ``single_write_target``
+# check purely on its presence, so every agent reported an unhealthy store for
+# a reason that no longer existed. A false alarm that cannot be cleared trains
+# people to ignore the real one, and this exact flag shape (a stale toggle
+# pointing at a dead store while every call returns success) is what silently
+# lost a session of card writes once already. Dropped 2026-07-28 on the store
+# owner's explicit decision. Do NOT reintroduce a write-routing flag here
+# without an owner ruling — asserted by test_dead_write_routing_key_* in
+# tests/scitex_agent_container/runtimes/test__fleet_env.py.
 #
 # These are opaque strings to sac. It never reads, parses or branches on them.
 # --------------------------------------------------------------------------
 FLEET_DEFAULT_ENV: dict[str, str] = {
-    "SCITEX_CARDS_DUAL_WRITE": "1",
     "SCITEX_CARDS_READ_BACKEND": "sqlite",
 }
 

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -1234,7 +1234,7 @@ def test_fleet_default_env_reaches_the_built_argv(tmp_path) -> None:
     # Act
     argv = _argv_for_env(tmp_path, env_block)
     # Assert — the fleet default arrived without the spec asking for it.
-    assert _env_values(argv, "SCITEX_CARDS_DUAL_WRITE") == ["1"]
+    assert _env_values(argv, "SCITEX_CARDS_READ_BACKEND") == ["sqlite"]
 
 
 def test_spec_env_overrides_fleet_default_in_argv(tmp_path) -> None:
@@ -1245,11 +1245,11 @@ def test_spec_env_overrides_fleet_default_in_argv(tmp_path) -> None:
     read ``1`` and the test FAILS. See the PR body for the recorded run.
     """
     # Arrange — the spec claims a key the fleet also defaults.
-    env_block = "    env:\n      SCITEX_CARDS_DUAL_WRITE: '0'"
+    env_block = "    env:\n      SCITEX_CARDS_READ_BACKEND: 'yaml'"
     # Act
     argv = _argv_for_env(tmp_path, env_block)
     # Assert — the per-agent value won, and it is the ONLY one emitted.
-    assert _env_values(argv, "SCITEX_CARDS_DUAL_WRITE") == ["0"]
+    assert _env_values(argv, "SCITEX_CARDS_READ_BACKEND") == ["yaml"]
 
 
 def test_spec_env_key_not_in_fleet_defaults_still_reaches_argv(tmp_path) -> None:

--- a/tests/scitex_agent_container/runtimes/test__fleet_env.py
+++ b/tests/scitex_agent_container/runtimes/test__fleet_env.py
@@ -43,15 +43,6 @@ def _write_config_yaml(path: Path, mapping: dict) -> Path:
 # ----------------------------------------------------------------------
 
 
-def test_fleet_defaults_seeded_with_the_cards_dual_write_flag() -> None:
-    # Arrange
-    absent = Path("/nonexistent/config.yaml")
-    # Act
-    defaults = declared_fleet_defaults(absent)
-    # Assert
-    assert defaults["SCITEX_CARDS_DUAL_WRITE"] == "1"
-
-
 def test_fleet_defaults_seeded_with_the_cards_sqlite_read_backend() -> None:
     # Arrange
     absent = Path("/nonexistent/config.yaml")
@@ -66,9 +57,9 @@ def test_declared_defaults_do_not_mutate_the_module_constant(tmp_path: Path) -> 
     # Arrange
     cfg = _write_config_yaml(tmp_path / "config.yaml", {"ADDED": "x"})
     # Act
-    declared_fleet_defaults(cfg)["SCITEX_CARDS_DUAL_WRITE"] = "MUTATED"
+    declared_fleet_defaults(cfg)["SCITEX_CARDS_READ_BACKEND"] = "MUTATED"
     # Assert
-    assert FLEET_DEFAULT_ENV["SCITEX_CARDS_DUAL_WRITE"] == "1"
+    assert FLEET_DEFAULT_ENV["SCITEX_CARDS_READ_BACKEND"] == "sqlite"
 
 
 # ----------------------------------------------------------------------
@@ -87,11 +78,13 @@ def test_config_yaml_can_add_a_new_fleet_default(tmp_path: Path) -> None:
 
 def test_config_yaml_overrides_a_sac_declared_default(tmp_path: Path) -> None:
     # Arrange
-    cfg = _write_config_yaml(tmp_path / "config.yaml", {"SCITEX_CARDS_DUAL_WRITE": "0"})
+    cfg = _write_config_yaml(
+        tmp_path / "config.yaml", {"SCITEX_CARDS_READ_BACKEND": "yaml"}
+    )
     # Act
     defaults = declared_fleet_defaults(cfg)
     # Assert
-    assert defaults["SCITEX_CARDS_DUAL_WRITE"] == "0"
+    assert defaults["SCITEX_CARDS_READ_BACKEND"] == "yaml"
 
 
 def test_config_yaml_values_are_coerced_to_strings(tmp_path: Path) -> None:
@@ -113,7 +106,7 @@ def test_malformed_config_yaml_degrades_to_sac_defaults(tmp_path: Path) -> None:
     # Act
     defaults = declared_fleet_defaults(cfg)
     # Assert
-    assert defaults["SCITEX_CARDS_DUAL_WRITE"] == "1"
+    assert defaults["SCITEX_CARDS_READ_BACKEND"] == "sqlite"
 
 
 def test_non_mapping_section_is_ignored(tmp_path: Path) -> None:
@@ -359,3 +352,47 @@ def test_raw_args_identity_wins_over_the_spec_env_identity() -> None:
     merged = effective_env(config, defaults={})
     # Assert
     assert merged["SCITEX_CARDS_AGENT_ID"] == "from-raw-args"
+
+
+# ----------------------------------------------------------------------
+# Dual-write must stay GONE. The YAML tier it gated was deleted 2026-07-21;
+# after that the flag routed nothing while still reaching every container,
+# and scitex-cards' health FAILED single_write_target purely on its presence
+# (a false alarm nobody could clear). Dropped 2026-07-28 on the store owner's
+# decision. These assert the absence at BOTH layers, because a key removed
+# from the dict but still rendered into argv would be the same bug.
+# ----------------------------------------------------------------------
+
+DEAD_WRITE_ROUTING_KEYS = ("SCITEX_CARDS_DUAL_WRITE", "SCITEX_TODO_DUAL_WRITE")
+
+
+@pytest.mark.parametrize("key", DEAD_WRITE_ROUTING_KEYS)
+def test_dead_write_routing_key_is_not_a_fleet_default(key: str) -> None:
+    """sac must not declare a write-routing flag for a store tier that is gone."""
+    # Arrange
+    absent = Path("/nonexistent/config.yaml")
+    # Act
+    defaults = declared_fleet_defaults(absent)
+    # Assert
+    assert key not in defaults and key not in FLEET_DEFAULT_ENV
+
+
+@pytest.mark.parametrize("key", DEAD_WRITE_ROUTING_KEYS)
+def test_dead_write_routing_key_never_reaches_argv(key: str) -> None:
+    """argv is what actually reaches the container, so assert it there too."""
+    # Arrange
+    config = SimpleNamespace(env={})
+    # Act
+    flags = fleet_env_flags(config, defaults=FLEET_DEFAULT_ENV)
+    # Assert
+    assert not any(flag.startswith(f"{key}=") for flag in flags)
+
+
+def test_read_backend_default_is_retained() -> None:
+    """Only the dual-write flag was dropped — the SQLite read pin stays."""
+    # Arrange
+    absent = Path("/nonexistent/config.yaml")
+    # Act
+    defaults = declared_fleet_defaults(absent)
+    # Assert
+    assert defaults["SCITEX_CARDS_READ_BACKEND"] == "sqlite"


### PR DESCRIPTION
## Summary

Stops sac injecting `SCITEX_CARDS_DUAL_WRITE=1` into every container.

The YAML store tier this flag gated was **deleted 2026-07-21**. Since then it routed nothing while still reaching every agent, and scitex-cards' `health` **FAILS its `single_write_target` check purely on its presence** — so every agent in the fleet reported an unhealthy store for a reason that no longer existed. A false alarm nobody can clear trains people to ignore the real one, and this exact shape (a stale toggle pointing at a dead store while every call returns success) already cost a session of card writes once.

Dropped on the **store owner's (scitex-cards) explicit decision**. It also actively cost diagnosis time: a new agent mis-attributed a write refusal to this flag before the real cause (an unset `SCITEX_CARDS_DB`) was found.

`SCITEX_CARDS_READ_BACKEND=sqlite` is **retained** — only the dual-write flag was approved for removal.

## Why it was here, not in the specs

A dry-run over all 102 agent specs found only **one** declaring this key. The injection was in sac source (`runtimes/_fleet_env.py`), which is why every container carried it regardless of spec.

## Tests

- New `test_dead_write_routing_key_*` assert the key is absent from **both** the declared defaults **and** the rendered apptainer argv — a key removed from the dict but still rendered into argv would be the same bug.
- **Mutation-proved**: reintroducing the key turns both new tests red (2 failed), so they are not vacuous.
- Three existing tests encoded the old contract and were updated — including `test_config_yaml_overrides_a_sac_declared_default`, which would otherwise have become **vacuous** by asserting an override of a key sac no longer declares.
- Suite: **34 passed** (`tests/scitex_agent_container/runtimes/test__fleet_env.py`).

## Rollout

Takes effect per agent on its next restart; folded into the pending fleet restart sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
