### PR TITLE
fix(image): floor scitex-cards >=0.17.9 (0.17.8 shipped two codebases under one version)

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -361,8 +361,21 @@ From: ubuntu:24.04
     # pyyaml, ruamel-yaml) are already SAC-transitive via the runner
     # plumbing, so the [mcp] extra adds just fastmcp.
     #
-    # scitex-cards: FLOOR (>=0.17.2), not an exact pin (was ==0.16.0). 2026-07-17,
-    # floor raised 0.16.0 -> 0.17.2 on 2026-07-20.
+    # scitex-cards: FLOOR (>=0.17.9), not an exact pin (was ==0.16.0). 2026-07-17,
+    # floor raised 0.16.0 -> 0.17.2 on 2026-07-20, -> 0.17.9 on 2026-07-28.
+    #
+    # The 0.17.9 raise is EXPLICIT ON PURPOSE, not "latest at bake time". 0.17.8
+    # was published to PyPI and then MORE code was installed onto the host under
+    # that same version, so two codebases shared one number: an agent reading
+    # "0.17.8" in its container got the OLD renderer while the fix read as
+    # deployed. That fix makes an inbox notification name its sender and body
+    # instead of a bare count — the operator's DMs reached agents as the number
+    # "4", and one sat unread for two hours. A floating "latest" here would
+    # silently re-bake 0.17.8 if a bake lands between the merge and the PyPI
+    # publish, reproducing the confusion while the CHANGELOG claims the fix is
+    # in. If 0.17.9 is not published yet this build FAILS LOUDLY, which is
+    # intended: a failed bake is cheap, a fleet silently baked with the old
+    # renderer is not.
     #
     # THE RAISE IS A CAPABILITY REQUIREMENT, WHICH IS WHAT A FLOOR IS FOR — not a
     # quarantine, and not a walk-back of the ruling below. 0.17.0 DESTROYS CARD
@@ -449,7 +462,7 @@ From: ubuntu:24.04
     uv pip install --no-cache --python /opt/venv-sac/bin/python -U \
         --reinstall-package scitex-agent-container \
         "claude-agent-sdk" \
-        "scitex-cards[mcp]>=0.17.2" \
+        "scitex-cards[mcp]>=0.17.9" \
         "/opt/scitex-agent-container-src[openai]"
 
     # ---- 6c. FAIL-LOUD staleness gate — assert BY SYMBOL --------------

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -277,7 +277,7 @@ From: ./sac-base.sif
         # the release it was standing in for sat published and unused. A pin
         # taken to bridge a gap outlives the gap unless something removes it.
         uv pip install --python /opt/venv-sac/bin/python -U \
-            "scitex-cards[mcp]>=0.17.2"
+            "scitex-cards[mcp]>=0.17.9"
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             pip setuptools wheel
@@ -321,7 +321,7 @@ From: ./sac-base.sif
         # rather than >=0.16.0 because 0.17.0 destroys card databases and a
         # lower floor lets a resolver reach it again.
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
-            "scitex-cards[mcp]>=0.17.2"
+            "scitex-cards[mcp]>=0.17.9"
     fi
 
     # ---- 2b. FAIL-LOUD staleness gate — assert BY SYMBOL ----------------


### PR DESCRIPTION
## Summary

Raises the `scitex-cards` floor `>=0.17.2` -> `>=0.17.9` in both image recipes (3 sites: base x1, scitex x2).

## Why

`scitex-cards` published **0.17.8** to PyPI and then installed *further code* onto the host under that **same version**. Two codebases, one number.

Measured in this agent's container: `importlib.metadata` reports `0.17.8`, but `_may_stop.py` still emits a bare `"N unread notification(s)"` instead of naming the sender and body. So the fix read as deployed while being unreachable from every agent.

That renderer matters: an operator DM reached this agent as **the number "4"** and sat unread for two hours. The operator is migrating from Telegram to cards DMs, so a notification that names no sender and no subject is unactionable by construction — the operator believes they messaged us, the agent believes nothing arrived, and both are right.

## Why a floor, not "latest at bake time"

If a bake lands between the upstream merge and the PyPI publish, `latest` silently re-resolves 0.17.8 and re-bakes the old renderer **while the CHANGELOG claims the fix is in**. Pinning removes that window.

**0.17.9 is not yet on PyPI**, so a bake attempted now **fails loudly**. That is intended: a failed bake is cheap; a fleet silently baked with the old renderer is not.

## Notes

- Deploy-side copies (`.dotfiles` `sac-base.def` / `sac-scitex.def`) were raised identically, so the two recipe copies do not diverge.
- Value swap only; the rationale is written into the recipe so a future reader sees the failure mode rather than an arbitrary bump.
- Merging + installing on the host reaches **zero** agents — each runs its own `/opt/venv-sac`. The rebake + restart sweep is what actually delivers this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
