### PR TITLE
feat(runtimes): predict the dist-info collision a restart creates in overlay agents

### DIFF
--- a/src/scitex_agent_container/runtimes/_overlay_distinfo.py
+++ b/src/scitex_agent_container/runtimes/_overlay_distinfo.py
@@ -1,0 +1,109 @@
+"""Predict the dist-info collision a RESTART would create in an overlay agent.
+
+The bake-time guards in ``containers/apptainer-*.def`` already assert that a
+freshly built image carries exactly one ``.dist-info`` per distribution. They
+are correct and they are not enough, because they can only see the IMAGE. An
+agent's runtime ``site-packages`` is the MERGED view of the base image and its
+per-agent overlay, and the merge is where this breaks.
+
+Why a healthy agent becomes broken without anyone touching it
+-------------------------------------------------------------
+An overlayfs whiteout masks exactly ONE NAME. When an agent runs
+``pip install`` INSIDE its container, pip first uninstalls the copy it is
+replacing — the copy in whatever base was mounted AT THAT MOMENT — and that
+uninstall lands in the overlay as a whiteout for that one directory name.
+
+Nothing re-evaluates that whiteout later. Swap the base image underneath and
+the whiteout still masks the OLD name, which is no longer there, while the NEW
+base's ``.dist-info`` is masked by nothing at all. The merged view then shows
+TWO, and ``importlib.metadata`` refuses the distribution — so the agent dies at
+BOOT, on an image that is itself clean, having changed nothing.
+
+The consequence that makes this worth predicting rather than detecting: a
+rolling restart to pick up a newer base does not merely fail to repair such an
+agent, it CREATES the failure in agents that were working. "Keep everything
+current" is the trigger, so the check has to run BEFORE the restart, not after.
+
+Measured 2026-07-28: two agents held the SAME package version over the SAME
+base and were both healthy, yet one predicted 1 and the other 2 at next boot.
+The only difference was WHICH names their whiteouts covered — i.e. which base
+happened to be mounted when each ran its install. That asymmetry is invisible
+from inside either container (the process sees only the merged view, never the
+whiteout names), which is precisely why this lives host-side.
+
+Why these functions take NAMES and not paths
+--------------------------------------------
+Classifying an overlay entry is a filesystem question — a whiteout is a
+character-special file, and :func:`os.stat` answers it — but PREDICTING the
+merge is pure set algebra over directory names. Splitting them keeps the rule
+that actually encodes the bug testable without root, without apptainer, and
+without fabricating device nodes: the caller collects three name collections,
+these functions decide. Nothing here touches a disk.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+
+#: ``scitex_cards-0.17.9.dist-info`` -> distribution ``scitex_cards``, version
+#: ``0.17.9``. Anchored, and the version group is deliberately permissive: a
+#: local or pre-release segment (``1.2.3+local``, ``2.0.0rc1``) is still one
+#: distribution, and treating it as a different one would MISS a collision.
+_DIST_INFO = re.compile(r"^(?P<dist>.+?)-(?P<version>[^-]+)\.dist-info$")
+
+
+def parse_dist_info(name: str) -> tuple[str, str] | None:
+    """Split a ``.dist-info`` directory name into ``(distribution, version)``.
+
+    Returns ``None`` for anything that is not a ``.dist-info`` name, so callers
+    can hand over a raw directory listing without pre-filtering.
+    """
+    match = _DIST_INFO.match(name)
+    if match is None:
+        return None
+    return match.group("dist"), match.group("version")
+
+
+def predict_merged_names(
+    base_names: object,
+    overlay_real: object,
+    overlay_whiteouts: object,
+) -> set[str]:
+    """Return the ``.dist-info`` names visible after the overlay is merged.
+
+    This is the whole semantics of the bug in one expression: a whiteout
+    subtracts the ONE name it spells, and the overlay's own directories are
+    added. A whiteout naming a version the new base does not contain therefore
+    subtracts NOTHING, which is exactly how the collision appears.
+    """
+    return (set(base_names) - set(overlay_whiteouts)) | set(overlay_real)
+
+
+def find_collisions(names: object) -> dict[str, list[str]]:
+    """Map each distribution seen more than once to its sorted versions.
+
+    A distribution appearing once is omitted: the result is empty exactly when
+    the merged view is safe, so it doubles as the boolean the caller wants.
+    """
+    versions: dict[str, list[str]] = defaultdict(list)
+    for name in names:
+        parsed = parse_dist_info(name)
+        if parsed is not None:
+            versions[parsed[0]].append(parsed[1])
+    return {dist: sorted(found) for dist, found in versions.items() if len(found) > 1}
+
+
+def predict_restart_collisions(
+    base_names: object,
+    overlay_real: object,
+    overlay_whiteouts: object,
+) -> dict[str, list[str]]:
+    """Collisions a restart onto ``base_names`` would produce for this overlay.
+
+    Empty means the restart is safe for metadata resolution. A non-empty result
+    names every distribution that would refuse, and with which versions — the
+    form an operator needs to decide whether to reconcile the overlay first.
+    """
+    merged = predict_merged_names(base_names, overlay_real, overlay_whiteouts)
+    return find_collisions(merged)

--- a/tests/scitex_agent_container/runtimes/test__overlay_distinfo.py
+++ b/tests/scitex_agent_container/runtimes/test__overlay_distinfo.py
@@ -1,0 +1,172 @@
+"""Restart-collision prediction for overlay agents — the whiteout is name-specific.
+
+Mirrors ``src/scitex_agent_container/runtimes/_overlay_distinfo.py``.
+
+The load-bearing property is that a whiteout subtracts EXACTLY ONE NAME. Every
+other behaviour here follows from it, including the one that makes the bug
+dangerous: a whiteout spelling a version the NEW base does not contain removes
+nothing, so the new base's ``.dist-info`` survives alongside the overlay's and
+the distribution refuses at boot.
+
+The important assertion is the CONTRAST between
+``test_uninstalled_under_old_base_collides_after_restart`` and
+``test_uninstalled_under_current_base_is_restart_safe``. They are built from a
+real 2026-07-28 measurement of two agents holding the SAME package version over
+the SAME base image, both healthy, predicting OPPOSITE outcomes at next
+restart. They are split only because one assertion per test is required — read
+them together: a prediction that could not separate those two would be
+worthless exactly where it is needed.
+
+Pure name algebra, so no device nodes, no root and no apptainer are required to
+exercise the rule that encodes the bug (PA-306: no mocks — there is nothing to
+mock, the functions take plain collections).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.runtimes._overlay_distinfo import (
+    find_collisions,
+    parse_dist_info,
+    predict_merged_names,
+    predict_restart_collisions,
+)
+
+# The base image both measured agents were sitting on.
+BASE_0_17_9 = ["scitex_cards-0.17.9.dist-info", "pyyaml-6.0.2.dist-info"]
+
+# Both agents held this same overlay copy and were both healthy at the time.
+OVERLAY_0_17_10 = ["scitex_cards-0.17.10.dist-info"]
+
+# The only difference between them: which base was mounted when each ran its
+# in-container install, i.e. which name its whiteout spells.
+WHITEOUTS_UNINSTALLED_UNDER_OLD_BASE = [
+    "scitex_cards-0.17.5.dist-info",
+    "scitex_cards-0.17.7.dist-info",
+]
+WHITEOUTS_UNINSTALLED_UNDER_CURRENT_BASE = [
+    "scitex_cards-0.17.7.dist-info",
+    "scitex_cards-0.17.9.dist-info",
+]
+
+
+def test_parse_dist_info_splits_distribution_from_version() -> None:
+    # Arrange
+    name = "scitex_cards-0.17.9.dist-info"
+    # Act
+    parsed = parse_dist_info(name)
+    # Assert
+    assert parsed == ("scitex_cards", "0.17.9")
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["scitex_cards", "scitex_cards-0.17.9.egg-info", "README.md", ""],
+)
+def test_parse_dist_info_returns_none_for_non_dist_info(name: str) -> None:
+    """Callers hand over raw listings, so non-matches must not raise."""
+    # Arrange
+    candidate = name
+    # Act
+    parsed = parse_dist_info(candidate)
+    # Assert
+    assert parsed is None
+
+
+def test_whiteout_removes_the_base_name_it_spells() -> None:
+    # Arrange
+    whiteouts = ["scitex_cards-0.17.9.dist-info"]
+    # Act
+    merged = predict_merged_names(BASE_0_17_9, OVERLAY_0_17_10, whiteouts)
+    # Assert
+    assert "scitex_cards-0.17.9.dist-info" not in merged
+
+
+def test_overlay_copy_is_visible_in_the_merged_view() -> None:
+    # Arrange
+    whiteouts = ["scitex_cards-0.17.9.dist-info"]
+    # Act
+    merged = predict_merged_names(BASE_0_17_9, OVERLAY_0_17_10, whiteouts)
+    # Assert
+    assert "scitex_cards-0.17.10.dist-info" in merged
+
+
+def test_uninstalled_under_old_base_collides_after_restart() -> None:
+    """THE BUG — the whiteout names a version the NEW base does not carry.
+
+    Nothing re-evaluates the whiteout when the base changes, so it subtracts
+    nothing and the new base's copy survives beside the overlay's.
+    """
+    # Arrange
+    whiteouts = WHITEOUTS_UNINSTALLED_UNDER_OLD_BASE
+    # Act
+    collisions = predict_restart_collisions(BASE_0_17_9, OVERLAY_0_17_10, whiteouts)
+    # Assert
+    assert collisions == {"scitex_cards": ["0.17.10", "0.17.9"]}
+
+
+def test_uninstalled_under_current_base_is_restart_safe() -> None:
+    """The CONTROL — same version, same base, whiteout covers the base copy."""
+    # Arrange
+    whiteouts = WHITEOUTS_UNINSTALLED_UNDER_CURRENT_BASE
+    # Act
+    collisions = predict_restart_collisions(BASE_0_17_9, OVERLAY_0_17_10, whiteouts)
+    # Assert
+    assert collisions == {}
+
+
+def test_overlay_holding_the_same_version_as_base_does_not_collide() -> None:
+    """Identical names are ONE directory in the merged view, not two."""
+    # Arrange
+    overlay_real = ["scitex_cards-0.17.9.dist-info"]
+    # Act
+    collisions = predict_restart_collisions(BASE_0_17_9, overlay_real, [])
+    # Assert
+    assert collisions == {}
+
+
+def test_overlay_copy_with_no_whiteout_at_all_collides() -> None:
+    """An overlay that never uninstalled leaves the base copy fully exposed."""
+    # Arrange
+    overlay_real = ["scitex_cards-0.17.5.dist-info"]
+    # Act
+    collisions = predict_restart_collisions(BASE_0_17_9, overlay_real, [])
+    # Assert
+    assert collisions == {"scitex_cards": ["0.17.5", "0.17.9"]}
+
+
+def test_reconciled_overlay_predicts_no_collision() -> None:
+    """The repaired state: the base shows through untouched."""
+    # Arrange
+    reconciled: list[str] = []
+    # Act
+    collisions = predict_restart_collisions(BASE_0_17_9, reconciled, reconciled)
+    # Assert
+    assert collisions == {}
+
+
+def test_unrelated_distributions_are_not_conflated() -> None:
+    # Arrange
+    names = [
+        "scitex_cards-0.17.9.dist-info",
+        "scitex_cards-0.17.10.dist-info",
+        "pyyaml-6.0.2.dist-info",
+    ]
+    # Act
+    collisions = find_collisions(names)
+    # Assert
+    assert set(collisions) == {"scitex_cards"}
+
+
+def test_prerelease_and_local_versions_stay_one_distribution() -> None:
+    """A local/pre-release segment must not read as a different distribution."""
+    # Arrange
+    names = [
+        "scitex_cards-1.2.3+local.dist-info",
+        "scitex_cards-2.0.0rc1.dist-info",
+    ]
+    # Act
+    collisions = find_collisions(names)
+    # Assert
+    assert collisions == {"scitex_cards": ["1.2.3+local", "2.0.0rc1"]}


### PR DESCRIPTION
The bake-time guards in `containers/apptainer-*.def` assert one `.dist-info` per distribution in a freshly built image. They are correct and **insufficient**: they can only see the IMAGE, while an agent runtime `site-packages` is the MERGED view of base image plus per-agent overlay.

## The mechanism

An overlayfs whiteout masks exactly **one name**. When an agent runs `pip install` INSIDE its container, the uninstall lands as a whiteout for the copy in whatever base was mounted *at that moment*. Nothing re-evaluates it later — so swapping the base leaves the whiteout masking a name that is gone, while the new base `.dist-info` is masked by nothing. The merged view shows two, `importlib.metadata` refuses the distribution, and the agent dies **at boot**, on an image that is itself clean, having changed nothing.

That is why this **predicts** rather than detects:

> A rolling restart to pick up a newer base does not merely fail to repair such an agent — it **CREATES** the failure in agents that were working. "Keep everything current" is the trigger, so the check must run *before* the restart.

## Evidence

Measured 2026-07-28 on the live fleet. Two agents held the **same** package version over the **same** base and were **both healthy**, yet predicted opposite outcomes at next boot:

| overlay | whiteouts | next boot |
|---|---|---|
| 0.17.10 | 0.17.5, 0.17.7 | **2 — breaks** |
| 0.17.10 | 0.17.7, **0.17.9** | 1 — safe |

The only difference is which base was mounted when each ran its install. That asymmetry is invisible from inside either container (the process sees only the merged view, never the whiteout names), which is why this lives host-side.

## Design

Functions take **name collections, not paths**. Classifying an overlay entry is a filesystem question (a whiteout is character-special); predicting the merge is pure set algebra. Splitting them keeps the rule that encodes the bug testable without root, without apptainer, and without fabricating device nodes. Nothing here touches a disk.

## Verification

- 14 passed; sibling `test__fleet_env.py` 30 passed.
- **Mutation-proved**: reimplementing the whiteout as masking a whole DISTRIBUTION rather than an exact NAME — the plausible wrong version, and the one that would report the broken agents as **safe** — fails `test_uninstalled_under_old_base_collides_after_restart` (reports `{}` where a collision is expected). Reverted; suite green again.

## Scope

Pure predicate plus tests. Wiring it into the start path / a fleet preflight is deliberately a separate change.

Known: CI on this repo is currently red for an unrelated reason (PS-224 — a live `~/.scitex/dev/hosts.yaml` edit reddens every repo audit leg).