### PR TITLE
fix(audit): exempt the deliberately-hosted CLA job from PS-224

### DIFF
--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -6,6 +6,38 @@ project-type:
   - pip
 
 audit:
+  exemptions:
+    # PS-224 (runner-destination-unregistered). `ubuntu-latest` is unserved BY
+    # DESIGN — we do not pay for hosted runners — so this red is real content,
+    # not a registry artefact. It is exempted rather than fixed because the
+    # blocker is SECURITY, not capability, and moving the job to Spartan would
+    # be a regression. The full argument lives in the block comment at the top
+    # of .github/workflows/cla.yml; the short version is four facts that only
+    # bite when combined:
+    #   1. `issue_comment` / `pull_request_target` are UNAUTHENTICATED triggers
+    #      on a public repo — a GitHub account is the entire barrier to entry.
+    #   2. The fork-PR approval gate covers `pull_request`, NOT these two.
+    #   3. The job body is third-party code (SHA-pinned here, not tag-pinned).
+    #   4. Spartan runners are PERSISTENT and $HOME is the operator's real home,
+    #      holding ~/.claude/.credentials.json — the live fleet credential.
+    # Composed: repointing would let any stranger run third-party code on the
+    # machine holding the fleet's credentials by leaving a comment. Revisit
+    # when an ephemeral/isolated runner exists for untrusted-trigger workflows
+    # (option (a) in the cla.yml comment); that closes this exemption properly.
+    PS-224:
+      - path: .github/workflows/cla.yml::CLAssistant
+        line: 0
+        reason: >-
+          Deliberately GitHub-hosted, escalated to the operator as a named
+          exception. This workflow runs a third-party action under the
+          UNAUTHENTICATED `issue_comment` and `pull_request_target` triggers,
+          which the fork-PR approval gate does not cover. Spartan runners are
+          persistent and their $HOME is the operator's real home holding the
+          live fleet credential, so repointing would let any stranger execute
+          third-party code next to that credential by commenting on an issue —
+          a security regression, not a compliance win. Kept hosted until an
+          ephemeral/isolated runner exists for untrusted-trigger workflows.
+
   # PS-103: legitimate top-level dirs that are not part of the wheel
   # but are operator-facing artefacts:
   #   - config/      declarative YAML schema + templates the CLI


### PR DESCRIPTION
## What

PS-224 (`runner-destination-unregistered`) fails **every PR in this repo** on
`.github/workflows/cla.yml::CLAssistant`, which targets `ubuntu-latest`.
Measured on PRs #826/#827/#828: `12546 passed, 1 failed` — that one failure.

## Why an exemption and not a repoint

The red is **real content**, not a registry artefact: a GitHub-hosted image is a
destination we have deliberately decided not to serve.

But the blocker here is **security, not capability**. `cla.yml` already carries an
argued, escalated block comment; the short version is four facts that only bite
when combined:

1. `issue_comment` / `pull_request_target` are **unauthenticated** triggers on a public repo.
2. The fork-PR approval gate covers `pull_request`, **not** these two.
3. The job body is third-party code.
4. Spartan runners are **persistent**, and `$HOME` is the operator's real home holding the live fleet credential.

Composed: repointing would let any stranger execute third-party code beside the
fleet credential by leaving a comment on an issue.

## Verification (not "the config is present")

A malformed `exemptions` block is silently dropped, so presence proves nothing.
Ran the real check through the real config loader against both trees:

| tree | cla findings | accepted | rejected |
|---|---|---|---|
| `develop` (no exemption) | **1** | `[]` | `[]` |
| this branch | **0** | the entry | `[]` |

Also confirmed the entry is pinned to one site: a file-scoped `path` (without
`::CLAssistant`) still reports the finding.

## Follow-up

scitex-dev is adding a recognised class for unauthenticated-trigger workflows
(this repo's block comment is the reasoning going into the rule). Once that
lands, this exemption becomes inert and should be deleted.