### PR TITLE
feat(containers): add scitex-storage to the :scitex layer

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -207,10 +207,18 @@ From: ./sac-base.sif
         # resolve exit-255); that is how a >=0.7.38 scitex-todo floor bricked
         # this recipe once already. Never raise a floor without checking that
         # the version exists.
-        #   scitex-dev   >=0.29.0 — keystone aggregator (list/install/check-superset)
-        #   scitex-writer>=2.29.0 — texlive provider (ships the soul.sty fix)
-        #   scitex-audio >=0.3.0  — ffmpeg/portaudio provider
-        #   scitex-cv    >=0.2.0  — opencv-python-headless; provider declares []
+        #   scitex-dev    >=0.29.0 — keystone aggregator (list/install/check-superset)
+        #   scitex-writer >=2.29.0 — texlive provider (ships the soul.sty fix)
+        #   scitex-audio  >=0.3.0  — ffmpeg/portaudio provider
+        #   scitex-cv     >=0.2.0  — opencv-python-headless; provider declares []
+        #   scitex-storage>=0.3.0  — structural recipe detector
+        #       (`scitex-storage find-recipe`). Added 2026-07-29: it was in NO
+        #       recipe at all, so paper-scitex-clew's merged post-run cleanup
+        #       (clew PR #212) could not be armed — its purge decision delegates
+        #       to that detector, which did not resolve in sac-scitex.sif. That
+        #       was an ABSENCE, not a propagation failure: no rebake could ever
+        #       have delivered it. Matters most for the Spartan solver container,
+        #       which runs the launcher.
         #
         # scitex-cards — FLOOR (>=0.16.0) + ``-U``, replacing the ==0.16.0 pin
         # (2026-07-17). The two halves do different jobs and BOTH are needed:
@@ -250,7 +258,8 @@ From: ./sac-base.sif
             "scitex-dev>=0.29.0" \
             "scitex-writer>=2.29.0" \
             "scitex-audio>=0.3.0" \
-            "scitex-cv>=0.2.0"
+            "scitex-cv>=0.2.0" \
+            "scitex-storage>=0.3.0"
         # Separate invocation with -U: an exact-version sibling in the same
         # resolve would be a no-op against base's inherited venv (the
         # 2026-07-12 fleet-drift: a floor the inherited version already
@@ -306,7 +315,8 @@ From: ./sac-base.sif
             "scitex-dev>=0.29.0" \
             "scitex-writer>=2.29.0" \
             "scitex-audio>=0.3.0" \
-            "scitex-cv>=0.2.0"
+            "scitex-cv>=0.2.0" \
+            "scitex-storage>=0.3.0"
         # scitex-cards — UNPINNED + ``--upgrade``, mirroring the uv branch
         # above (see it for the operator's 2026-07-17 ruling and why the
         # regression that motivated the pin belongs to the shipping package's


### PR DESCRIPTION
## What

`scitex-storage` was in **no recipe at all** — not `:base`, not `:scitex`.

Reported by **paper-scitex-clew**, who measured it four times across two days:
`import scitex_storage` raises, `which scitex-storage` finds nothing, `pip show`
is empty — including *after* 0.3.0 landed on PyPI and was verified working from a
clean venv elsewhere.

## Why it wasn't a propagation problem

An **absence**, not drift. No rebake could ever have delivered it and no publish
could have fixed it. Their measurements were right; the natural
"published-but-not-propagated" reading was a tidy story that fit the evidence and
was false.

## What it blocks

clew PR #212's post-run cleanup delegates its purge decision to
`scitex-storage find-recipe`, so a **merged** P1 fix sits inert. The launcher runs
in the **Spartan solver container**, which is the case that matters most.

## Placement

`:scitex`, not `:base` — exact precedent of `scitex-audio` / `scitex-cv` /
`scitex-writer`: scitex-* siblings `scitex[all]` does not pull, named individually
with a floor. `:base` carries only fleet infrastructure
(`scitex-agent-container`, `scitex-cards[mcp]`).

## Verification

- **Floor exists**, per this file's own instruction ("never raise a floor without
  checking that the version exists" — a >=0.7.38 scitex-todo floor bricked this
  recipe once). PyPI latest is `0.3.0` and `0.3.0` is present, so the floor is
  satisfiable.
- **Both install branches updated**, not one. This recipe has *two* invocation
  sites (uv and pip) plus a comment block; updating a subset is the drift class
  this file has been bitten by. Sibling counts verified symmetric: **5 and 5**.

## Note

Delivery is gated on a bake, which is currently **held** behind two unrelated
hazards. Merging this does not put `scitex-storage` in anyone's container — I'll
report to clew when an image they can actually see carries it, not when this merges.