### PR TITLE
fix(fleet-env): stop injecting the dead SCITEX_CARDS_READ_BACKEND

### DIFF
--- a/src/scitex_agent_container/runtimes/_fleet_env.py
+++ b/src/scitex_agent_container/runtimes/_fleet_env.py
@@ -79,11 +79,40 @@ CONFIG_SECTION = "fleet_default_env"
 # without an owner ruling — asserted by test_dead_write_routing_key_* in
 # tests/scitex_agent_container/runtimes/test__fleet_env.py.
 #
+# SCITEX_CARDS_READ_BACKEND was dropped 2026-07-29 on the store owner's ruling,
+# for the same reason as the dual-write flag above and with the same evidence
+# standard — scitex-cards searched their READ PATH from source (positive control
+# first: SCITEX_CARDS_DB, 73 hits across 32 files) and found the variable in
+# exactly two places, a comment and a key in ``_RETIRED_VARS``. Neither is a
+# read-for-behaviour. They also checked the expressive-range trap that bit
+# several of us that day: the name is CONSTRUCTED (``prefix + suffix``) rather
+# than written literally, so a plain grep could have missed a dynamic read — it
+# is built for one purpose, ``environ.get(name)`` followed by ``logger.error``.
+# The value is never returned, never branched on, never reaches the store.
+#
+# It was not merely useless, it was ACTIVELY MISLEADING. In scitex-cards' own
+# words, from their retired-vars module: the board's systemd unit carried
+# ``SCITEX_CARDS_READ_BACKEND=sqlite`` while the board served 0 cards from a
+# database holding 2,654 — "it did nothing, but it STATED a read policy, so
+# everyone diagnosing the outage read that line, concluded the read target was
+# configured and correct, and looked elsewhere. An inert setting that appears to
+# answer the question is worse than no setting at all: it spends the
+# diagnostician's trust."
+#
+# scitex-cards KEEPS its retired-var warning deliberately — that warning is what
+# makes a stale config say so out loud, and it is the guard against anyone
+# hand-setting these again once the fleet is clean. So expect it to keep firing
+# per agent until each restarts onto this cleaned environment; that is correct
+# behaviour, not a leftover. Do NOT "fix" it by reintroducing the key.
+#
+# FLEET_DEFAULT_ENV is now EMPTY, and that is a valid state — the mechanism
+# survives for operator overrides via ``config.yaml``'s ``fleet_default_env``.
+# Asserted by test_dead_read_routing_key_* in
+# tests/scitex_agent_container/runtimes/test__fleet_env.py.
+#
 # These are opaque strings to sac. It never reads, parses or branches on them.
 # --------------------------------------------------------------------------
-FLEET_DEFAULT_ENV: dict[str, str] = {
-    "SCITEX_CARDS_READ_BACKEND": "sqlite",
-}
+FLEET_DEFAULT_ENV: dict[str, str] = {}
 
 
 def _config_path() -> Path:

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -1228,27 +1228,47 @@ def _argv_for_env(tmp_path: Path, env_block: str) -> list[str]:
     )
 
 
-def test_fleet_default_env_reaches_the_built_argv(tmp_path) -> None:
+def test_sac_injects_no_fleet_default_env_into_the_built_argv(tmp_path) -> None:
+    """Inverts test_fleet_default_env_reaches_the_built_argv.
+
+    That test asserted the seeded SCITEX_CARDS_READ_BACKEND=sqlite arrived
+    without the spec asking. sac stopped declaring it 2026-07-29 on the store
+    owner's ruling (nothing reads it, and it misled a diagnosis by stating a
+    read policy that was never enforced), so the correct assertion is that a
+    spec declaring no env of its own receives no fleet-injected value.
+    """
     # Arrange — a spec that declares NO env of its own.
     env_block = ""
     # Act
     argv = _argv_for_env(tmp_path, env_block)
-    # Assert — the fleet default arrived without the spec asking for it.
-    assert _env_values(argv, "SCITEX_CARDS_READ_BACKEND") == ["sqlite"]
+    # Assert
+    assert _env_values(argv, "SCITEX_CARDS_READ_BACKEND") == []
 
 
-def test_spec_env_overrides_fleet_default_in_argv(tmp_path) -> None:
-    """THE precedence rule, at the layer that reaches the container.
+def test_spec_env_reaches_the_built_argv_as_the_only_value(tmp_path) -> None:
+    """Was test_spec_env_overrides_fleet_default_in_argv.
 
-    MUTATION-PROOF: reversing the precedence in ``_fleet_env.merge_fleet_env``
-    (applying the defaults AFTER spec.env instead of before) makes this assert
-    read ``1`` and the test FAILS. See the PR body for the recorded run.
+    SCOPE NARROWED DELIBERATELY, and the reason is worth stating so nobody
+    "restores" it: that test proved per-agent-beats-fleet-default AT THE ARGV
+    LAYER, and it could only do so because sac shipped a default of the same
+    name to be overridden. With FLEET_DEFAULT_ENV now empty there is nothing to
+    override, so the original assertion would still pass with the precedence
+    REVERSED — a test that can no longer fail.
+
+    The precedence rule itself keeps real, mutation-capable coverage one layer
+    down, where defaults are an explicit injection seam rather than a shipped
+    constant: test__fleet_env.py::test_spec_env_overrides_a_fleet_default_of_
+    the_same_name and ::test_spec_env_can_neutralise_a_fleet_default_with_an_
+    empty_value, both using an injected SHARED_KEY.
+
+    What survives here is the argv-layer claim that still means something: a
+    spec.env value reaches the container, exactly once.
     """
-    # Arrange — the spec claims a key the fleet also defaults.
+    # Arrange
     env_block = "    env:\n      SCITEX_CARDS_READ_BACKEND: 'yaml'"
     # Act
     argv = _argv_for_env(tmp_path, env_block)
-    # Assert — the per-agent value won, and it is the ONLY one emitted.
+    # Assert — emitted, and emitted only once (no duplicate from a default).
     assert _env_values(argv, "SCITEX_CARDS_READ_BACKEND") == ["yaml"]
 
 

--- a/tests/scitex_agent_container/runtimes/test__fleet_env.py
+++ b/tests/scitex_agent_container/runtimes/test__fleet_env.py
@@ -43,23 +43,53 @@ def _write_config_yaml(path: Path, mapping: dict) -> Path:
 # ----------------------------------------------------------------------
 
 
-def test_fleet_defaults_seeded_with_the_cards_sqlite_read_backend() -> None:
+def test_sac_declares_no_fleet_defaults_of_its_own() -> None:
+    """Replaces test_fleet_defaults_seeded_with_the_cards_sqlite_read_backend.
+
+    sac used to seed SCITEX_CARDS_READ_BACKEND=sqlite. Dropped 2026-07-29 on the
+    store owner's ruling — nothing reads it, and it actively misled a diagnosis
+    by stating a read policy that was never enforced. sac now declares nothing;
+    the cascade exists purely for operator overrides.
+    """
     # Arrange
     absent = Path("/nonexistent/config.yaml")
     # Act
     defaults = declared_fleet_defaults(absent)
     # Assert
-    assert defaults["SCITEX_CARDS_READ_BACKEND"] == "sqlite"
+    assert defaults == {}
 
 
 def test_declared_defaults_do_not_mutate_the_module_constant(tmp_path: Path) -> None:
-    """A caller mutating the result must not poison the next agent's env."""
+    """A caller mutating the result must not poison the next agent's env.
+
+    The mechanism under test is that the returned dict is a COPY. It previously
+    probed that via the seeded read-backend key; with sac declaring nothing, the
+    probe is an operator override instead. The coverage is unchanged — only the
+    key it mutates.
+    """
     # Arrange
     cfg = _write_config_yaml(tmp_path / "config.yaml", {"ADDED": "x"})
     # Act
-    declared_fleet_defaults(cfg)["SCITEX_CARDS_READ_BACKEND"] = "MUTATED"
+    declared_fleet_defaults(cfg)["ADDED"] = "MUTATED"
+    # Assert — the module constant is untouched by a caller's mutation
+    assert "ADDED" not in FLEET_DEFAULT_ENV
+
+
+def test_declared_defaults_return_a_fresh_dict_each_call(tmp_path: Path) -> None:
+    """Second half of the copy guarantee: two calls must not share a dict.
+
+    Added because the original mutation test asserted against a CONSTANT that is
+    now empty, which would pass even if the function returned the constant
+    itself. This asserts the property directly rather than through a key.
+    """
+    # Arrange
+    cfg = _write_config_yaml(tmp_path / "config.yaml", {"ADDED": "x"})
+    # Act
+    first = declared_fleet_defaults(cfg)
+    first["ADDED"] = "MUTATED"
+    second = declared_fleet_defaults(cfg)
     # Assert
-    assert FLEET_DEFAULT_ENV["SCITEX_CARDS_READ_BACKEND"] == "sqlite"
+    assert second["ADDED"] == "x"
 
 
 # ----------------------------------------------------------------------
@@ -99,14 +129,24 @@ def test_config_yaml_values_are_coerced_to_strings(tmp_path: Path) -> None:
 
 
 def test_malformed_config_yaml_degrades_to_sac_defaults(tmp_path: Path) -> None:
-    """An operator typo must not stop the fleet from launching."""
-    # Arrange
+    """An operator typo must not stop the fleet from launching.
+
+    Previously asserted the seeded read-backend key survived the fallback. With
+    sac declaring nothing that assertion would be vacuous — `{} == {}` passes
+    even if parsing silently succeeded. So the malformed file now also CONTAINS
+    a would-be override, and the assertion is that the override did NOT take
+    effect: proof the parse actually failed and the fallback actually ran,
+    rather than a shape that cannot come out the other way.
+    """
+    # Arrange — malformed, and carrying an override that must not be honoured.
     cfg = tmp_path / "config.yaml"
-    cfg.write_text("spec: [this is not: a mapping\n")
+    cfg.write_text(
+        f"spec: [this is not: a mapping\n  {CONFIG_SECTION}:\n    SHOULD_NOT_APPEAR: y\n"
+    )
     # Act
     defaults = declared_fleet_defaults(cfg)
     # Assert
-    assert defaults["SCITEX_CARDS_READ_BACKEND"] == "sqlite"
+    assert "SHOULD_NOT_APPEAR" not in defaults
 
 
 def test_non_mapping_section_is_ignored(tmp_path: Path) -> None:
@@ -388,11 +428,52 @@ def test_dead_write_routing_key_never_reaches_argv(key: str) -> None:
     assert not any(flag.startswith(f"{key}=") for flag in flags)
 
 
-def test_read_backend_default_is_retained() -> None:
-    """Only the dual-write flag was dropped — the SQLite read pin stays."""
+DEAD_READ_ROUTING_KEYS = ("SCITEX_CARDS_READ_BACKEND", "SCITEX_TODO_READ_BACKEND")
+
+
+@pytest.mark.parametrize("key", DEAD_READ_ROUTING_KEYS)
+def test_dead_read_routing_key_is_not_a_fleet_default(key: str) -> None:
+    """sac must not declare a read-routing flag that nothing reads.
+
+    This INVERTS ``test_read_backend_default_is_retained``, which asserted the
+    SQLite read pin "stays". That test was written when the pin was believed to
+    mean something. It does not: scitex-cards searched their read path from
+    source (positive control first) and found the variable only in a comment and
+    a retired-vars key — never read for behaviour. The old test pinned a policy
+    statement that was never true.
+
+    Dropped 2026-07-29 on the store owner's explicit ruling, same standard as
+    DEAD_WRITE_ROUTING_KEYS above. Do NOT reintroduce without a new ruling.
+    """
     # Arrange
     absent = Path("/nonexistent/config.yaml")
     # Act
     defaults = declared_fleet_defaults(absent)
     # Assert
-    assert defaults["SCITEX_CARDS_READ_BACKEND"] == "sqlite"
+    assert key not in defaults and key not in FLEET_DEFAULT_ENV
+
+
+@pytest.mark.parametrize("key", DEAD_READ_ROUTING_KEYS)
+def test_dead_read_routing_key_never_reaches_argv(key: str) -> None:
+    """argv is what actually reaches the container, so assert it there too."""
+    # Arrange
+    config = SimpleNamespace(env={})
+    # Act
+    flags = fleet_env_flags(config, defaults=FLEET_DEFAULT_ENV)
+    # Assert
+    assert not any(flag.startswith(f"{key}=") for flag in flags)
+
+
+def test_an_empty_fleet_default_env_is_a_valid_state() -> None:
+    """Removing the last default must not break the mechanism.
+
+    FLEET_DEFAULT_ENV is now empty. The cascade still exists for operator
+    overrides via config.yaml's ``fleet_default_env``, so this asserts the
+    empty case yields no flags rather than raising or misbehaving.
+    """
+    # Arrange
+    config = SimpleNamespace(env={})
+    # Act
+    flags = fleet_env_flags(config, defaults={})
+    # Assert
+    assert flags == []


### PR DESCRIPTION
fix(fleet-env): stop injecting the dead SCITEX_CARDS_READ_BACKEND

sac seeded `SCITEX_CARDS_READ_BACKEND=sqlite` into every agent. Nothing reads
it. FLEET_DEFAULT_ENV is now empty.

THE OWNER'S RULING, and the evidence they gave for it. scitex-cards searched
their READ PATH from source — positive control first (SCITEX_CARDS_DB: 73 hits
across 32 files, so the instrument works) — and found the variable in exactly
two places, a comment and a key in `_RETIRED_VARS`. Neither is a read for
behaviour. They also checked the expressive-range trap that bit several of us
today: the name is CONSTRUCTED (`prefix + suffix` inside `warn_retired_vars`),
so a literal grep could have missed a dynamic read. It is built for one purpose,
`environ.get(name)` then `logger.error`. Never returned, never branched on,
never reaches the store.

IT WAS NOT MERELY INERT, IT WAS MISLEADING. From their retired-vars module: the
board's systemd unit carried `SCITEX_CARDS_READ_BACKEND=sqlite` while the board
served 0 cards from a database holding 2,654 — "it did nothing, but it STATED a
read policy, so everyone diagnosing the outage read that line, concluded the
read target was configured and correct, and looked elsewhere. An inert setting
that appears to answer the question is worse than no setting at all: it spends
the diagnostician's trust."

Same reasoning that removed SCITEX_CARDS_DUAL_WRITE on 07-28, same standard.
scitex-cards KEEPS their retired-var warning deliberately — it is what makes a
stale config say so out loud — so expect it to keep firing per agent until each
restarts onto the cleaned environment. That is correct, not a leftover.

TESTS — three referenced the removed key, and the mechanisms they covered were
preserved rather than deleted along with it:

  * test_fleet_defaults_seeded_with_the_cards_sqlite_read_backend -> inverted to
    test_sac_declares_no_fleet_defaults_of_its_own.
  * test_declared_defaults_do_not_mutate_the_module_constant asserted against a
    constant that is now EMPTY, which would pass even if the function returned
    the constant itself. Reprobed via an operator override, plus a new
    test_declared_defaults_return_a_fresh_dict_each_call asserting the copy
    property directly.
  * test_malformed_config_yaml_degrades_to_sac_defaults would have become
    `{} == {}` — true even if parsing silently succeeded. The malformed file now
    also carries a would-be override, and the assertion is that it did NOT take
    effect: proof the fallback actually ran.

AND THE ONE THAT MATTERED MOST: test_spec_env_overrides_fleet_default_in_argv
proved per-agent-beats-fleet-default AT THE ARGV LAYER, and could only do so
because sac shipped a default of that name to be overridden. With
FLEET_DEFAULT_ENV empty there is nothing to override, so its assertion would
still pass WITH THE PRECEDENCE REVERSED — a test that survives the change, stays
green, and pins nothing. Scope narrowed explicitly, with the reason in the
docstring so nobody "restores" it. The precedence rule keeps mutation-capable
coverage one layer down in test__fleet_env.py, where defaults are an injectable
seam (SHARED_KEY) rather than a shipped constant.

New guards: DEAD_READ_ROUTING_KEYS parametrised over defaults and argv, mirroring
DEAD_WRITE_ROUTING_KEYS, plus test_an_empty_fleet_default_env_is_a_valid_state.

VERIFIED: test__fleet_env 39/39, test__apptainer_build_argv 51 passed 2 skipped.
Full runtimes suite compared against unmodified develop in the same environment —
develop 3 failed / 1592 passed / 19 errors, this branch 3 failed / 1597 passed /
19 errors. Identical failures and errors; the 5 extra passes are the new tests.
Those 3 failures and 19 errors are pre-existing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKrLQ84QDKnCS2hqqy3oqW