### PR TITLE
feat(account list): add the Average block; drop the legend and fleet lines

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_cmd.py
@@ -93,15 +93,10 @@ def account_list(as_json: bool, refresh: bool) -> None:
         build_provider_accounts_json,
         build_stored_json,
         build_stored_rows,
-        needs_rolling_legend,
         render_stored_table,
-        rolling_legend_line,
     )
     from ._account_openai import format_openai_account_block
-    from ._account_usage_bars import (
-        fleet_capacity_used_line,
-        render_usage_bars_block,
-    )
+    from ._account_usage_bars import render_usage_bars_block
     from ._helpers import console
     from .status_cmds import _format_claude_account_block
 
@@ -199,14 +194,16 @@ def account_list(as_json: bool, refresh: bool) -> None:
     if bars_block:
         click.echo("")
         click.echo(bars_block)
-    # When the upstream usage API didn't return per-row reset
-    # timestamps (older caches / API outage), the per-line `(→...)`
-    # hint can't render. Print a one-line legend below the bars so the
-    # operator still sees the rolling-window contract instead of
-    # guessing.
-    if needs_rolling_legend(rows):
-        click.echo(rolling_legend_line())
-    click.echo(fleet_capacity_used_line(rows))
+    # Legend and the `Fleet 7d capacity used:` line both DROPPED
+    # (operator 2026-07-30). The legend explained a rolling-window
+    # contract the per-line `(in ...)` hints already carry, and the fleet
+    # line stated in prose the number the new `- Average (n=N)` block now
+    # renders as a bar — the same arithmetic mean, in the visual language
+    # of the rest of the section instead of a sentence under it.
+    #
+    # `needs_rolling_legend` / `rolling_legend_line` are intentionally left
+    # in _account_list_render for now: they are exported and separately
+    # tested, and deleting them is a wider change than the display request.
 
 
 def register_list_command(group: click.Group) -> None:

--- a/src/scitex_agent_container/cli_pkg/_account_usage_bars.py
+++ b/src/scitex_agent_container/cli_pkg/_account_usage_bars.py
@@ -74,7 +74,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Iterable
 
-from ._timefmt import format_relative_until
+from ._timefmt import _coerce_dt, format_relative_until
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from ._account_list_render import AccountRow
@@ -187,6 +187,66 @@ def render_account_block(
     ]
 
 
+def _mean_reset_at(rows: Iterable["AccountRow"]) -> datetime | None:
+    """Mean 7-day reset instant across rows that have one, or ``None``.
+
+    Averaging absolute reset instants is the reading consistent with the
+    block's label: the Average block answers "where does the fleet sit, and
+    when does that position typically reset". The EARLIEST reset would answer
+    a different question (when does the first account free up) and would not
+    be an average of anything.
+
+    ``reset_at_7d`` is ``str | datetime | None`` — the cache stores ISO-8601
+    strings and only some callers pre-parse. Coerced through the SAME
+    ``_timefmt._coerce_dt`` the per-line hints use, rather than a second
+    parser here: two parsers for one field is how the bars and the Average
+    would come to disagree about the same timestamp. (The first version of
+    this called ``.timestamp()`` directly and crashed on the string form —
+    caught by four pre-existing tests in test__account_usage_bars.py.)
+
+    Unparseable entries are dropped, matching ``format_relative_until``'s
+    contract of degrading to no hint rather than raising.
+    """
+    stamps = [dt for dt in (_coerce_dt(r.reset_at_7d) for r in rows) if dt is not None]
+    if not stamps:
+        return None
+    return datetime.fromtimestamp(
+        sum(s.timestamp() for s in stamps) / len(stamps), tz=stamps[0].tzinfo
+    )
+
+
+def render_average_block(
+    rows: Iterable["AccountRow"],
+    *,
+    hint_width: int,
+    width: int = _DEFAULT_BAR_WIDTH,
+    now: datetime | None = None,
+) -> list[str]:
+    """The Average block (operator request 2026-07-30):
+
+    ``- Average (n=3)`` then a single 7d window line. 7d only, because the
+    5h windows reset on staggered anchors and their mean is not a quantity
+    an operator can act on; the 7d mean is the fleet-capacity number that
+    used to be the ``Fleet 7d capacity used:`` line, rendered in the same
+    visual language as every other bar instead of as prose.
+
+    ``n`` counts only accounts WITH cached 7d usage — the same denominator
+    :func:`fleet_7d_capacity_used` averages over, so the percentage and the
+    count can never describe different populations. Returns ``[]`` when no
+    account has data, so the caller emits nothing rather than an empty bar
+    that would read as 0%.
+    """
+    row_list = list(rows)
+    pct, n = fleet_7d_capacity_used(r.used_pct_7d for r in row_list)
+    if pct is None:
+        return []
+    hint = _wrap_hint(format_relative_until(_mean_reset_at(row_list), now=now))
+    return [
+        f"- Average (n={n})",
+        render_window_line("7d", pct, hint=hint, hint_width=hint_width, width=width),
+    ]
+
+
 def render_usage_bars_block(
     rows: Iterable["AccountRow"],
     *,
@@ -220,7 +280,12 @@ def render_usage_bars_block(
     hints_7d = [
         _wrap_hint(format_relative_until(r.reset_at_7d, now=now)) for r in row_list
     ]
-    hint_width = max(len(h) for h in (*hints_5h, *hints_7d))
+    # The Average block's hint participates in hint_width: computing the
+    # width over the per-account hints alone would leave the Average bar
+    # starting one or two columns left of every other bar, which is exactly
+    # the vertical scan this block exists to provide.
+    hint_avg = _wrap_hint(format_relative_until(_mean_reset_at(row_list), now=now))
+    hint_width = max(len(h) for h in (*hints_5h, *hints_7d, hint_avg))
     lines = ["Usage bars (5h / 7d out of 100%):"]
     for index, (r, hint_5h, hint_7d) in enumerate(zip(row_list, hints_5h, hints_7d)):
         if index:
@@ -234,6 +299,12 @@ def render_usage_bars_block(
                 width=width,
             )
         )
+    average = render_average_block(
+        row_list, hint_width=hint_width, width=width, now=now
+    )
+    if average:
+        lines.append("")
+        lines.extend(average)
     return "\n".join(lines)
 
 

--- a/tests/scitex_agent_container/cli_pkg/test__account_usage_bars.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_usage_bars.py
@@ -232,10 +232,12 @@ def test_render_usage_bars_block_marks_each_account_with_dash():
     # Act
     block = render_usage_bars_block(rows, width=20)
     markers = [ln for ln in block.splitlines() if ln.startswith("- ")]
-    # Assert — one "- <name>" marker per account (operator mockup).
+    # Assert — one "- <name>" marker per account, then the Average block
+    # (operator 2026-07-30: the Average replaced the prose fleet line).
     assert markers == [
         "- claude-code:alpha-example-com",
         "- claude-code:beta-example-com",
+        "- Average (n=2)",
     ]
 
 
@@ -244,8 +246,10 @@ def test_render_usage_bars_block_blank_line_between_accounts():
     rows = _two_bar_rows()
     # Act
     block = render_usage_bars_block(rows, width=20)
-    # Assert — exactly one separator between the two account blocks.
-    assert block.splitlines().count("") == 1
+    # Assert — one separator between the two account blocks, plus one before
+    # the Average block (operator 2026-07-30). The Average is separated the
+    # same way an account is, so the section reads as a uniform list.
+    assert block.splitlines().count("") == 2
 
 
 def test_render_usage_bars_block_hintless_rows_share_bar_column():
@@ -355,6 +359,9 @@ def test_render_usage_bars_block_matches_operator_mockup_exactly():
             "- claude-code:beta-example-com",
             "  5h            [██░░░░░░░░░░] (14%)",
             "  7d            [██░░░░░░░░░░] (15%)",
+            "",
+            "- Average (n=2)",
+            "  7d (in 2d03h) [█████░░░░░░░] (40%)",
         ]
     )
 

--- a/tests/scitex_agent_container/cli_pkg/test__account_usage_bars_average.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_usage_bars_average.py
@@ -1,0 +1,152 @@
+"""The ``- Average (n=N)`` block in the usage-bars section.
+
+Operator request 2026-07-30: drop the prose ``Fleet 7d capacity used: 52%
+(3 accounts)`` line and render the same arithmetic mean as a bar, in the
+visual language of the rest of the section.
+
+The number MUST stay identical to what the dropped line reported — this is a
+re-rendering, not a new statistic — so one test pins the Average percentage
+against ``fleet_7d_capacity_used`` directly rather than against a literal.
+
+PA-306: no mocks — real AccountRow-shaped objects, real renderer.
+AAA markers (TQ002); descriptive names; one assertion each (TQ007).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from scitex_agent_container.cli_pkg._account_usage_bars import (
+    fleet_7d_capacity_used,
+    render_average_block,
+    render_usage_bars_block,
+)
+
+_NOW = datetime(2026, 7, 30, 2, 52, tzinfo=timezone.utc)
+
+
+def _row(name, pct_5h, pct_7d, *, in_5h=1.0, in_7d=100.0):
+    return SimpleNamespace(
+        provider="claude-code",
+        name=name,
+        used_pct_5h=pct_5h,
+        used_pct_7d=pct_7d,
+        reset_at_5h=_NOW + timedelta(hours=in_5h),
+        reset_at_7d=_NOW + timedelta(hours=in_7d),
+    )
+
+
+def _rows():
+    # The operator's real 2026-07-30 readings.
+    return [
+        _row("wyusuuke-gmail-com", 16, 64, in_5h=0.95, in_7d=91),
+        _row("ywata1989-gmail-com", 13, 41, in_5h=3.95, in_7d=134),
+        _row("ywatanabe-scitex-ai", 4, 52, in_5h=3.6, in_7d=125),
+    ]
+
+
+def test_the_average_header_carries_the_counted_population() -> None:
+    # Arrange
+    rows = _rows()
+
+    # Act
+    block = render_average_block(rows, hint_width=12, now=_NOW)
+
+    # Assert
+    assert block[0] == "- Average (n=3)"
+
+
+def test_the_average_percentage_equals_the_dropped_fleet_number() -> None:
+    # Arrange — this is a re-rendering, not a new statistic. Pinning against a
+    # literal would let the two drift apart silently; pinning against the
+    # aggregate function makes that impossible.
+    rows = _rows()
+    expected_pct, _ = fleet_7d_capacity_used(r.used_pct_7d for r in rows)
+
+    # Act
+    line = render_average_block(rows, hint_width=12, now=_NOW)[1]
+
+    # Assert
+    assert f"({int(round(expected_pct))}%)" in line
+
+
+def test_the_average_block_renders_only_the_7d_window() -> None:
+    # Arrange — 5h windows reset on staggered anchors; their mean is not
+    # actionable, so the block deliberately carries a single window line.
+    rows = _rows()
+
+    # Act
+    block = render_average_block(rows, hint_width=12, now=_NOW)
+
+    # Assert
+    assert len(block) == 2 and block[1].strip().startswith("7d")
+
+
+def test_the_average_reset_hint_is_the_mean_of_the_rows_resets() -> None:
+    # Arrange — resets at 91h, 134h and 125h, so the mean is 116.67h = 4d20h.
+    rows = _rows()
+
+    # Act
+    line = render_average_block(rows, hint_width=12, now=_NOW)[1]
+
+    # Assert
+    assert "(in 4d20h)" in line
+
+
+def test_an_account_without_7d_usage_is_excluded_from_the_count() -> None:
+    # Arrange — n must describe the same population the mean averages over, or
+    # the percentage and the count describe different things.
+    rows = _rows() + [_row("no-data", None, None)]
+
+    # Act
+    block = render_average_block(rows, hint_width=12, now=_NOW)
+
+    # Assert
+    assert block[0] == "- Average (n=3)"
+
+
+def test_no_average_block_when_no_account_has_usage_data() -> None:
+    # Arrange — an empty bar would read as 0%, which is a claim, not an absence.
+    rows = [_row("a", None, None), _row("b", None, None)]
+
+    # Act
+    block = render_average_block(rows, hint_width=12, now=_NOW)
+
+    # Assert
+    assert block == []
+
+
+def test_the_average_appears_in_the_full_bars_block() -> None:
+    # Arrange
+    rows = _rows()
+
+    # Act
+    out = render_usage_bars_block(rows, now=_NOW)
+
+    # Assert
+    assert "- Average (n=3)" in out
+
+
+def test_the_average_bar_starts_at_the_same_column_as_the_account_bars() -> None:
+    # Arrange — the whole point of the section is a vertical scan. If the
+    # Average hint were excluded from hint_width its bar would sit left of the
+    # others. Regression guard for exactly that.
+    out = render_usage_bars_block(_rows(), now=_NOW)
+
+    # Act
+    cols = {line.index("[") for line in out.splitlines() if "[" in line}
+
+    # Assert
+    assert len(cols) == 1
+
+
+def test_the_average_is_last_so_the_per_account_order_is_unchanged() -> None:
+    # Arrange
+    out = render_usage_bars_block(_rows(), now=_NOW)
+
+    # Act
+    headers = [ln for ln in out.splitlines() if ln.startswith("- ")]
+
+    # Assert
+    assert headers[-1] == "- Average (n=3)"

--- a/tests/scitex_agent_container/cli_pkg/test_account_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_account_group.py
@@ -800,15 +800,22 @@ def test_account_list_human_shows_dash_last_update_when_no_cache(sandbox_home):
     assert " - " in output
 
 
-def test_account_list_human_prints_legend_after_bars_when_no_reset(sandbox_home):
-    """With no cached reset timestamps the rolling-window legend prints
-    BELOW the usage-bars block it explains (2026-07-11 relocation)."""
+def test_account_list_human_prints_no_legend_even_without_resets(sandbox_home):
+    """INVERTED 2026-07-30: the rolling-window legend is no longer printed.
+
+    Was ``..._prints_legend_after_bars_when_no_reset``, which pinned the
+    2026-07-11 relocation of the legend below the bars. The operator dropped
+    the legend outright, so the assertion is inverted rather than deleted —
+    the removal is now the pinned behaviour, and a re-added legend fails here.
+    The no-cached-reset case is kept deliberately: that is the ONLY case that
+    ever emitted the legend, so it is the only one where a regression shows.
+    """
     # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
     home = sandbox_home
     # Act
     output = _invoke_account_list_with_no_usage_cache(home)
-    # Assert — bars section first, legend after it.
-    assert output.index("Usage bars") < output.index("Legend:")
+    # Assert
+    assert "Legend:" not in output
 
 
 def test_account_list_json_includes_plan_label(sandbox_home):


### PR DESCRIPTION
feat(account list): add the Average block; drop the legend and fleet lines

Operator request 2026-07-30, from a live `sac accounts list` reading.

DROPPED — the rolling-window legend. Every window line already carries its
own `(in 4h05m)` / `(in 5d05h)` hint, so the legend explained a contract the
bars state per-line. It only ever printed when NO row had a cached reset.

DROPPED — `Fleet 7d capacity used: 52% (3 accounts)`.

ADDED — the same number, rendered as a bar in the section's own visual
language instead of as a sentence under it:

    - claude-code:ywatanabe-scitex-ai
      5h (in 3h36m) [█░░░░░░░░░░░░░░░░░░░] (4%)
      7d (in 5d05h) [██████████░░░░░░░░░░] (52%)

    - Average (n=3)
      7d (in 4d20h) [██████████░░░░░░░░░░] (52%)

Three decisions worth stating, since each could reasonably have gone the
other way:

7d ONLY. The 5h windows reset on staggered anchors (57m / 3h57m / 3h36m in
the operator's reading); their mean is not a quantity anyone can act on. The
7d mean is the fleet-capacity number the dropped line reported.

THE HINT IS THE MEAN OF THE RESET INSTANTS, not the earliest. "Average"
labels a mean; the earliest reset answers a different question (when does the
first account free up) and would not be an average of anything.

n COUNTS ONLY ACCOUNTS WITH DATA — the same denominator
`fleet_7d_capacity_used` averages over, so the percentage and the count can
never describe different populations. With no account having data the block
is omitted entirely rather than rendering an empty bar, because a 0% bar is
a claim and the situation is an absence.

The Average hint participates in `hint_width`, so its bar lands in the same
column as every other bar — the vertical scan is the whole point of the
section, and computing the width over the per-account hints alone would have
left the Average one or two columns adrift.

TESTS — 9 new, and three existing ones UPDATED rather than deleted:
  * `..._marks_each_account_with_dash` and `..._blank_line_between_accounts`
    pinned the old shape; both now include the Average.
  * `..._prints_legend_after_bars_when_no_reset` is INVERTED to
    `..._prints_no_legend_even_without_resets`. Deleting it would have
    removed the only guard against someone re-adding the legend; the
    no-cached-reset case is kept because that was the ONLY case that ever
    emitted it.
One new test pins the Average percentage against `fleet_7d_capacity_used`
rather than a literal, so the re-rendering cannot silently drift away from
the number it replaced.

A BUG THE EXISTING TESTS CAUGHT, recorded because it is the interesting part:
the first `_mean_reset_at` called `.timestamp()` on `reset_at_7d` directly.
That field is `str | datetime | None` — the cache stores ISO-8601 strings —
and four pre-existing tests crashed with `AttributeError: 'str' object has no
attribute 'timestamp'`. Fixed by coercing through the SAME
`_timefmt._coerce_dt` the per-line hints use; a second parser for one field
is how the bars and the Average would come to disagree about one timestamp.

Verified: 103 passed across test__account_usage_bars, the new average file,
and test_account_group. The 6 failures in cli_pkg/lifecycle/test__rename.py
and test__dev_jobs.py are PRE-EXISTING — the same 6 fail on unmodified
develop, measured in the same environment.

`needs_rolling_legend` / `rolling_legend_line` are left in
_account_list_render: they are exported and separately tested, and removing
them is wider than this display request.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKrLQ84QDKnCS2hqqy3oqW