### PR TITLE
chore(release): 0.24.20 — ship the accounts-list display change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.24.20] - 2026-07-29
+
+### Changed
+
+- **`sac accounts list` grew an Average block and lost two lines the operator
+  reads past.** Their monitor re-renders this view every 10s, so what it does
+  NOT show matters as much as what it does: the per-account rolling-window
+  legend and the fleet-capacity line are gone, and a trailing
+  `- Average (n=N)` / `7d (…) [bar] (NN%)` pair now summarises the fleet's 7d
+  capacity in one reading. The Average hint participates in the shared
+  `hint_width`, so its bar stays column-aligned with the per-account bars
+  instead of forming a second ragged edge (`cli_pkg/_account_usage_bars.py`,
+  `cli_pkg/_account_list_cmd.py`). `needs_rolling_legend` /
+  `rolling_legend_line` stay in `_account_list_render.py` — exported and
+  separately tested, so dropping the *echo* is not dropping the *renderer*.
+
 ### Fixed
 
 - **A `--yes`-less start refusal was recorded as a permanent STARTUP_FAILED**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.19"
+version = "0.24.20"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
#834 merged at `0d433572`; `v0.24.19` was cut from `e7009b68`, which predates it. The operator's monitor renders the HOST's installed `sac` every 10s, so the Average block and the dropped legend/fleet lines cannot reach the person who asked for them until a version lands on PyPI.

Bumped with `.github/ci/autobump.py bump` — one computed version drives the pyproject line, the CHANGELOG heading and the tag, so they cannot drift.

The release sweep is on `main` and ticking, but `AUTOBUMP_ENABLED` is unset, so every tick printed `REPORT-ONLY: would bump 0.24.19 -> 0.24.20` at this exact head and mutated nothing. This hand-cut agrees with the decision it computed; it does not race it.

Adds the missing CHANGELOG entry for #834 — the accumulated Unreleased body named the fix work but not the display change.