### PR TITLE
fix(image): raise the scitex-cards floor to the 0.19.0 SECURITY floor

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -361,8 +361,25 @@ From: ubuntu:24.04
     # pyyaml, ruamel-yaml) are already SAC-transitive via the runner
     # plumbing, so the [mcp] extra adds just fastmcp.
     #
-    # scitex-cards: FLOOR (>=0.17.9), not an exact pin (was ==0.16.0). 2026-07-17,
-    # floor raised 0.16.0 -> 0.17.2 on 2026-07-20, -> 0.17.9 on 2026-07-28.
+    # scitex-cards: FLOOR (>=0.19.0), not an exact pin (was ==0.16.0). 2026-07-17,
+    # floor raised 0.16.0 -> 0.17.2 on 2026-07-20, -> 0.17.9 on 2026-07-28,
+    # -> 0.19.0 on 2026-07-30 (SECURITY — see below).
+    #
+    # The 0.19.0 raise is a SECURITY floor, not a freshness bump. Through 0.18.0,
+    # `_django/handlers/dm.py` resolved the store as
+    #     getattr(request, STORE_REQUEST_ATTR, None) or _store_of(request)
+    # — a cross-tenant fallback: a request arriving WITHOUT the injected store
+    # attribute silently reads AND WRITES the host store, so under a multi-tenant
+    # mount one user's writes land in another's board. 0.19.0 drops the fallback
+    # and splits read from write (`_store_of` for reads, `_write_store_of` for
+    # writes). Verified in the ARTIFACT, not the version string, because a
+    # dist-info can sit atop missing files:
+    #     0.19.0 wheel  dm.py: "or _store_of(request)" x0, line 108 is a bare
+    #                   getattr; STORE_REQUEST_ATTR referenced 3x
+    #     the copy installed in the CURRENT image: x1 — i.e. the vulnerable
+    #                   path is live in what the fleet is running today
+    # After any bake, re-check by opening the installed dm.py and confirming the
+    # count is 0. `--version` cannot answer this.
     #
     # The 0.17.9 raise is EXPLICIT ON PURPOSE, not "latest at bake time". 0.17.8
     # was published to PyPI and then MORE code was installed onto the host under
@@ -373,9 +390,11 @@ From: ubuntu:24.04
     # "4", and one sat unread for two hours. A floating "latest" here would
     # silently re-bake 0.17.8 if a bake lands between the merge and the PyPI
     # publish, reproducing the confusion while the CHANGELOG claims the fix is
-    # in. If 0.17.9 is not published yet this build FAILS LOUDLY, which is
-    # intended: a failed bake is cheap, a fleet silently baked with the old
-    # renderer is not.
+    # in. If the pinned floor is not published yet this build FAILS LOUDLY,
+    # which is intended: a failed bake is cheap, a fleet silently baked with the
+    # old renderer is not. (That reasoning is why the floor is written as an
+    # explicit literal and raised deliberately; the literal is now 0.19.0, and
+    # 0.19.0 was confirmed installable from the index before it was written here.)
     #
     # THE RAISE IS A CAPABILITY REQUIREMENT, WHICH IS WHAT A FLOOR IS FOR — not a
     # quarantine, and not a walk-back of the ruling below. 0.17.0 DESTROYS CARD
@@ -462,7 +481,7 @@ From: ubuntu:24.04
     uv pip install --no-cache --python /opt/venv-sac/bin/python -U \
         --reinstall-package scitex-agent-container \
         "claude-agent-sdk" \
-        "scitex-cards[mcp]>=0.17.9" \
+        "scitex-cards[mcp]>=0.19.0" \
         "/opt/scitex-agent-container-src[openai]"
 
     # ---- 6c. FAIL-LOUD staleness gate — assert BY SYMBOL --------------

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -285,8 +285,16 @@ From: ./sac-base.sif
         # have quietly baked a two-month-old tree into every agent image while
         # the release it was standing in for sat published and unused. A pin
         # taken to bridge a gap outlives the gap unless something removes it.
+        # SECURITY floor >=0.19.0 (2026-07-30). This layer builds ON TOP of base
+        # and installs last, so ITS constraint is the effective one in the shipped
+        # image — a floor raised only in apptainer-base.def would be silently
+        # overridden here. Through 0.18.0, `_django/handlers/dm.py` fell back to
+        # `... or _store_of(request)`, so a request without the injected store
+        # attribute read AND WROTE the host store (cross-tenant under a
+        # multi-tenant mount). Verified in the artifact: the 0.19.0 wheel has 0
+        # occurrences of that fallback, the copy in the CURRENT image has 1.
         uv pip install --python /opt/venv-sac/bin/python -U \
-            "scitex-cards[mcp]>=0.17.9"
+            "scitex-cards[mcp]>=0.19.0"
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             pip setuptools wheel


### PR DESCRIPTION
Through 0.18.0, `scitex_cards/_django/handlers/dm.py` resolved the store as `getattr(request, STORE_REQUEST_ATTR, None) or _store_of(request)`. That trailing fallback is cross-tenant: a request without the injected store attribute reads **and writes** the host store, so under a multi-tenant mount one user's writes land in another's board.

Verified in the artifact, not the version string (a dist-info can sit atop missing files):

| check | result |
|---|---|
| 0.19.0 wheel `dm.py` | `or _store_of(request)` **x0**; line 108 a bare `getattr`; `STORE_REQUEST_ATTR` x3 |
| copy in the **current image** | **x1** — the vulnerable path is live in what the fleet runs now |
| installability | `pip download 'scitex-cards[mcp]==0.19.0'` resolves and downloads |

**Raised in BOTH defs deliberately.** `apptainer-scitex.def` builds on top of base and installs last, so *its* constraint is the effective one in the shipped image — raising only `apptainer-base.def` would leave the security floor silently overridden by the later layer.

Reported by scitex-cards, who verified the wheel independently and deliberately did not touch the image path.