### PR TITLE
fix(health): `sac agents health` could never pass for the DEFAULT runtime

### DIFF
--- a/src/scitex_agent_container/_lifecycle/health.py
+++ b/src/scitex_agent_container/_lifecycle/health.py
@@ -18,17 +18,19 @@ def health_check(
     """Run a single health check. Returns (is_healthy, message).
 
     Two methods:
-      * ``sdk-alive`` (default) — ask the SDK runtime whether its
-        container/process is up.
+      * ``sdk-alive`` (default) — ask THE CONFIG'S runtime whether its
+        process is up. The name is historical: it resolves through
+        ``_get_runtime``, so a ``tui`` spec is asked via
+        ``TuiSessionRuntime`` and an SDK spec via ``ClaudeSessionRuntime``.
       * ``a2a-card`` — probe the A2A AgentCard endpoint (higher
         fidelity, confirms the HTTP surface is actually serving).
 
     Parameters
     ----------
     runtime:
-        Optional injected SDK runtime (real collaborator). Used by
-        ``sdk-alive``. Default ``None`` instantiates the real
-        ``ClaudeSessionRuntime`` lazily.
+        Optional injected runtime (real collaborator). Used by
+        ``sdk-alive``. Default ``None`` resolves the config's runtime via
+        ``_get_runtime`` lazily.
     """
     method = config.health.method or "sdk-alive"
     if method == "sdk-alive":
@@ -43,19 +45,49 @@ def _check_sdk_alive(
     *,
     runtime: object | None = None,
 ) -> tuple[bool, str]:
-    """Ask the SDK runtime whether the container/runner is up.
+    """Ask THE CONFIG'S runtime whether its process is up.
 
-    ``runtime`` is an injectable real collaborator (default: a freshly
-    instantiated ``ClaudeSessionRuntime``). It must expose
-    ``is_running(config) -> bool``.
+    ``runtime`` is an injectable real collaborator. Default ``None``
+    resolves via :func:`._runtime_select._get_runtime` — the canonical
+    selector every other lifecycle path already uses.
+
+    IT USED TO HARDCODE ``ClaudeSessionRuntime``, and that made this check
+    UNPASSABLE for most of the fleet. ``ClaudeSessionRuntime.is_running``
+    delegates to ``_container_runtime_for``, which resolves only
+    ``apptainer`` / ``claude-agent-sdk`` and returns ``None`` for anything
+    else; ``is_running`` then maps that "no runtime to ask" onto ``False``
+    — unknown reported as dead. Since ``spec.runtime`` DEFAULTS to ``tui``
+    (``config/_types.py``), the default configuration reported
+    ``unhealthy: SDK runner not running`` while being demonstrably alive,
+    and ``status_cmds`` gates ``sys.exit(1)`` on it — so ``sac agents
+    health`` failed for every TUI agent, permanently. A check that cannot
+    pass, which is the mirror of the checks that cannot fail.
+
+    Measured on the host for a live ``runtime: tui`` agent before/after:
+
+        ClaudeSessionRuntime().is_running(cfg)        -> False   (the bug)
+        ApptainerContainerRuntime().is_running(cfg)   -> False   (naive fix,
+                                                        ALSO wrong: a tui
+                                                        agent is `apptainer
+                                                        exec` in a tmux pane,
+                                                        not a named instance)
+        TuiSessionRuntime().is_running(cfg)           -> True    (correct)
+
+    ``_get_runtime`` returns the third one for ``tui``/unset and the SDK
+    runtime for the explicit SDK values, so routing through it fixes the
+    default case without changing behaviour for SDK specs.
     """
     if runtime is None:
-        from ..runtimes.claude_session import ClaudeSessionRuntime
+        from ._runtime_select import _get_runtime
 
-        runtime = ClaudeSessionRuntime()
+        runtime = _get_runtime(config)
     if runtime.is_running(config):
         return True, "healthy"
-    return False, "unhealthy: SDK runner not running"
+    # Name WHICH runtime said no. The old text said "SDK runner" regardless
+    # of the runtime actually consulted, which sent readers looking for an
+    # SDK process that a tui agent never had.
+    kind = (getattr(config, "runtime", "") or "tui").strip() or "tui"
+    return False, f"unhealthy: {kind} runtime reports its process not running"
 
 
 def _check_a2a_card(config: AgentConfig) -> tuple[bool, str]:

--- a/tests/scitex_agent_container/_lifecycle/test_health.py
+++ b/tests/scitex_agent_container/_lifecycle/test_health.py
@@ -226,14 +226,76 @@ def test_check_sdk_alive_unhealthy_flag_when_runtime_stopped() -> None:
     assert ok is False
 
 
-def test_check_sdk_alive_unhealthy_message_when_runtime_stopped() -> None:
+def test_check_sdk_alive_unhealthy_message_names_the_runtime_kind() -> None:
+    """REPLACES an assertion on the literal "SDK runner not running".
+
+    That text was emitted for EVERY runtime, including ``tui`` agents that
+    have no SDK runner at all, so it sent readers hunting a process that
+    never existed. The message now names the runtime actually consulted.
+    """
     # Arrange
     cfg = _make_cfg()
     runtime = FakeRuntime(running=False)
     # Act
     _ok, msg = health_mod._check_sdk_alive(cfg, runtime=runtime)
     # Assert
-    assert "SDK runner not running" in msg
+    assert "tui runtime reports its process not running" in msg
+
+
+def test_check_sdk_alive_unhealthy_message_names_an_explicit_sdk_runtime() -> None:
+    # Arrange
+    cfg = _make_cfg()
+    cfg.runtime = "claude-agent-sdk"
+    runtime = FakeRuntime(running=False)
+    # Act
+    _ok, msg = health_mod._check_sdk_alive(cfg, runtime=runtime)
+    # Assert
+    assert "claude-agent-sdk runtime reports its process not running" in msg
+
+
+def test_default_runtime_resolution_uses_the_canonical_selector() -> None:
+    """The regression this PR exists for.
+
+    ``_check_sdk_alive`` used to hardcode ``ClaudeSessionRuntime``, whose
+    ``is_running`` returns False for any spec the container-runtime lookup
+    cannot resolve — and ``spec.runtime`` DEFAULTS to ``tui``. So the default
+    configuration reported unhealthy while alive, and ``sac agents health``
+    exits non-zero on that bool. Pinning the resolution to the canonical
+    selector is what fixes it, so the test pins the resolution, not a message.
+    """
+    # Arrange
+    from scitex_agent_container._lifecycle._runtime_select import _get_runtime
+    from scitex_agent_container.runtimes.tui_session import TuiSessionRuntime
+
+    cfg = _make_cfg()
+    # Act
+    resolved = _get_runtime(cfg)
+    # Assert
+    assert isinstance(resolved, TuiSessionRuntime)
+
+
+def test_default_runtime_is_tui_so_the_default_path_is_the_tui_path() -> None:
+    """Pins WHY the bug was fleet-wide rather than opt-in."""
+    # Arrange
+    cfg = _make_cfg()
+    # Act
+    runtime_kind = getattr(cfg, "runtime", "")
+    # Assert
+    assert runtime_kind == "tui"
+
+
+def test_explicit_sdk_runtime_still_resolves_to_the_sdk_runtime() -> None:
+    """The fix must not change behaviour for specs that really are SDK."""
+    # Arrange
+    from scitex_agent_container._lifecycle._runtime_select import _get_runtime
+    from scitex_agent_container.runtimes.claude_session import ClaudeSessionRuntime
+
+    cfg = _make_cfg()
+    cfg.runtime = "claude-agent-sdk"
+    # Act
+    resolved = _get_runtime(cfg)
+    # Assert
+    assert isinstance(resolved, ClaudeSessionRuntime)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`sac agents health <agent>` returned `"healthy": false, "message": "unhealthy: SDK runner not running"` for agents that were demonstrably alive — while the **liveness block in the same payload** said ALIVE.

**Cause.** `_check_sdk_alive` hardcoded `ClaudeSessionRuntime`, whose `is_running` delegates to `_container_runtime_for` — which resolves only `apptainer`/`claude-agent-sdk` and returns `None` otherwise. `is_running` maps that "no runtime to ask" onto `False`: **unknown reported as dead.** And `spec.runtime` **defaults to `tui`**, so this was the default path, not an edge case. `status_cmds` gates `sys.exit(1)` on the bool, so the verb exited non-zero for every TUI agent, permanently — a check that cannot pass, the mirror of the ones that cannot fail.

The same function's comments record this exact bug being fixed once for `claude-agent-sdk`. `tui` was never added.

**Fix.** Route through `_get_runtime`, the canonical selector every other lifecycle path already uses. No new probe — the correct one existed.

**I measured the obvious fix failing first**, host-side on a live agent:

| runtime asked | result |
|---|---|
| `ClaudeSessionRuntime` | `False` ← the bug |
| `ApptainerContainerRuntime` | `False` ← naive fix, **also wrong** |
| `TuiSessionRuntime` (via `_get_runtime`) | **`True`** |

Mapping `tui` to the apptainer runtime looks right and isn't: a tui agent is `apptainer exec` in a tmux pane, not a named instance.

**Verified in both directions** across all 102 host specs, because a fix that makes everything pass is just the opposite defect:

    healthy=True  :  9  (the live fleet)
    healthy=False : 93  (templates, clew capsules, agents not running)
    errors        :  0

Those 9 match the live set measured independently from `/proc/*/environ` by a different instrument.

Message now names the runtime that actually answered, instead of saying "SDK runner" for runtimes that have none.

One existing test asserted the literal old text — it **encoded the bug**, so it's rewritten (not deleted) with a docstring saying why, plus tests pinning the *resolution* (tui→Tui, explicit sdk→ClaudeSession) so the regression is caught at the mechanism. 72 tests pass.

Found by dotfiles, who reported the contradiction and was right that the instrument block was the trustworthy half.