### PR TITLE
feat(systemd): track sac's host unit templates — they existed in ONE untracked place

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,18 @@ exclude = [".git"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "src/scitex_agent_container/cron/post-merge-pull.sh" = "scitex_agent_container/cron/post-merge-pull.sh"
+# systemd --user unit TEMPLATES. Shipped in the wheel for the same reason the
+# cron script is: they must be reachable from an INSTALLED sac, on a host where
+# the repo is not on disk. They are templates with @PLACEHOLDER@s and nothing
+# installs them — deploying a unit is an operator action (the listen unit
+# brokers host_exec/spawn/restart for every agent). Tracked at all because
+# until 2026-07-30 these units existed ONLY as untracked live files under
+# ~/.config/systemd/user/ while brokering the whole fleet: no history, no
+# review, and gone if the host were rebuilt.
+"src/scitex_agent_container/systemd/sac-listen.service.template" = "scitex_agent_container/systemd/sac-listen.service.template"
+"src/scitex_agent_container/systemd/sac.accounts-refresh.service.template" = "scitex_agent_container/systemd/sac.accounts-refresh.service.template"
+"src/scitex_agent_container/systemd/sac.accounts-refresh.timer.template" = "scitex_agent_container/systemd/sac.accounts-refresh.timer.template"
+"src/scitex_agent_container/systemd/README.md" = "scitex_agent_container/systemd/README.md"
 # Bundle pyproject.toml + README.md inside the wheel so the
 # source-bundled SIF build (cli_pkg/_image_source_build.py) can
 # reconstruct a pip-installable source tree from the INSTALLED

--- a/src/scitex_agent_container/systemd/README.md
+++ b/src/scitex_agent_container/systemd/README.md
@@ -1,0 +1,80 @@
+# systemd `--user` unit templates
+
+Reference source for sac's host services. **Templates, not deployed artifacts** —
+nothing in sac installs them, and `@PLACEHOLDER@`s must be filled per host.
+
+| template | service |
+|---|---|
+| `sac-listen.service.template` | the fleet's HTTP/JSON control plane (`host_exec`, spawn, restart, liveness) |
+| `sac.accounts-refresh.service.template` + `.timer.template` | headless OAuth refresh for stored Claude accounts |
+
+Placeholders: `@SAC_BIN@` (absolute path to the **current** `sac`),
+`@SAC_SECRETS_ENVRC@` (colon-separated secret `.src` files, host-specific).
+
+## Why these are tracked at all
+
+Until 2026-07-30 both units existed in exactly one place: live-only files under
+`~/.config/systemd/user/`, untracked, with no history and no review — while
+brokering the entire agent fleet. A host rebuild would have taken them, and any
+pin applied to them.
+
+Not committed verbatim: the live listen unit carries an
+`Environment=SAC_SECRETS_ENVRC=` line enumerating ~30 secret file paths under
+the operator's home. Those paths are not themselves secrets, but publishing a
+map of the secrets layout to a public repository is a reconnaissance aid, and a
+template has no reason to carry it.
+
+## The measurement that motivated this
+
+Measured on `ywata-note-win`, 2026-07-30. That host carries **three** `sac`
+installations:
+
+```
+~/.env-3.11/bin/sac                      0.24.20   current release
+~/.scitex/agent-container/venv/bin/sac   0.21.22   2026-07-17 wheel
+~/.local/bin/sac                         0.21.11   src, "metadata only"
+```
+
+**The live listen daemon was running 0.21.22** — thirteen releases behind — read
+off the running process (`pid 1590`), not the unit file, and confirmed by
+importing metadata from the interpreter it was actually using. It had restarted
+that morning and come back onto the old venv, because `ExecStart` pinned it. The
+supervisor re-armed the stale code on every restart.
+
+**The staleness propagates.** `_sac_binary.sac_binary()` resolves a child `sac`
+by falling back to the executable *next to* `sys.executable` — deliberate, for
+venv coherence. So a stale daemon hands its own stale binary to every agent it
+spawns or restarts. One wrong path in one unit becomes a fleet-wide version
+regression that no agent can see in any version string it reads about itself.
+
+The flip side is that repointing `ExecStart` fixes **both** halves at once: the
+daemon's own code, and the binary it hands children.
+
+Separately, `sac.accounts-refresh.service` used `ExecStart=/usr/bin/env sac …` —
+a bare name resolved against the unit's inherited PATH. Measured: bare `sac` is
+**NOT FOUND** under a minimal PATH, so that unit worked only because systemd's
+environment happened to contain one of the three, and which one was unpinned.
+That ambiguity cost two agents a wrong measurement the same night: one reported
+a JSON field "absent from the payload" having invoked the 0.21.22 binary, which
+predates the field.
+
+## Verifying a deployment
+
+Ask the **running process**, never the unit file:
+
+```bash
+pgrep -f 'sac listen'
+tr '\0' ' ' < /proc/<pid>/cmdline          # which interpreter, which sac
+<that venv>/bin/python -c "import importlib.metadata as m; print(m.version('scitex-agent-container'))"
+```
+
+A unit file that pins a stale interpreter is a config that is correct about what
+it *says* and wrong about what it *runs*. `sac`'s own `listen_cmds.py` already
+notes three call sites that invoke `sac` bare, the unit's `ExecStart` among them.
+
+## Deployment is an operator action
+
+Restarting `sac-listen` drops `host_exec` brokering for every agent, so it is
+outward-facing in a way ordinary code changes are not. Note also that these live
+files are **regular files, not symlinks** into any dotfiles repo, so a dotfiles
+deploy will not revert an edit — and will not supply one either.

--- a/src/scitex_agent_container/systemd/__init__.py
+++ b/src/scitex_agent_container/systemd/__init__.py
@@ -1,0 +1,21 @@
+"""Reference systemd ``--user`` unit TEMPLATES for sac's host services.
+
+These are the durable source for units that, until now, existed in exactly one
+place: live-only files under ``~/.config/systemd/user/``, untracked, with no
+history and no review — while brokering the entire agent fleet. If that host is
+rebuilt they are gone, along with any pin applied to them.
+
+THEY ARE TEMPLATES, NOT DEPLOYED ARTIFACTS. Nothing in sac installs them.
+Placeholders (``@SAC_BIN@``, ``@HOME@``, ``@SAC_SECRETS_ENVRC@``) must be filled
+per host, and installing or restarting a unit is an OPERATOR action — the listen
+unit brokers ``host_exec`` / spawn / restart for every agent, so restarting it
+interrupts the whole fleet. See ``README.md`` in this directory for the
+measurement that motivated tracking them.
+
+Deliberately parameterised rather than copied verbatim: the live
+``sac-listen.service`` carries an ``Environment=SAC_SECRETS_ENVRC=`` line
+enumerating ~30 secret file paths under the operator's home. Committing that
+literally would publish a map of the secrets layout to a public repository —
+the paths are not themselves secrets, but they are a reconnaissance aid, and a
+template has no reason to carry them.
+"""

--- a/src/scitex_agent_container/systemd/sac-listen.service.template
+++ b/src/scitex_agent_container/systemd/sac-listen.service.template
@@ -1,0 +1,76 @@
+[Unit]
+Description=sac listen — host-level HTTP/JSON control plane for sac agents
+Documentation=https://github.com/ywatanabe1989/scitex-agent-container
+# Loopback-only by default; the network stack is enough, no internet route
+# required.
+After=network.target
+# DECOUPLED from any agent/lead lifecycle ON PURPOSE. sac listen is FLEET
+# INFRASTRUCTURE (the a2a + registry control plane). Retiring, restarting or
+# crashing any individual agent — or the lead — must NEVER take it down, so
+# there is deliberately NO After=/Requires=/BindsTo=/PartOf= against any
+# agent/lead/scope unit. Incident 2026-06-26: the listen died mid-session with
+# nothing restarting it and the whole fleet lost a2a comms silently.
+#
+# Rate-limit the restart loop so a permanently-broken launch (e.g. an
+# ImportError after a bad upgrade) cannot spin forever. Past 5 restarts in 60s
+# systemd gives up and enters `failed`; the companion sac-listen-health.timer
+# then alarms LOUDLY and runs `systemctl reset-failed && restart`, so a
+# transient burst self-heals while a genuine hard-down stays visible. These two
+# keys belong in [Unit] in modern systemd.
+StartLimitIntervalSec=60s
+StartLimitBurst=5
+
+[Service]
+Type=simple
+# ==========================================================================
+# ExecStart MUST be an ABSOLUTE path, and it MUST point at the CURRENT venv.
+#
+# Absolute, because systemd --user inherits the user's default PATH but never
+# sources ~/.bashrc or ~/.bash_profile, so a venv-rooted `sac` is not on PATH
+# here. (Measured: bare `sac` is NOT FOUND under a minimal PATH.)
+#
+# CURRENT, because of a second effect that is easy to miss and was live on
+# ywata-note-win on 2026-07-30. The daemon was pinned at an OLD venv and so ran
+# sac 0.21.22 (a 2026-07-17 wheel) while the release was 0.24.20 — thirteen
+# releases behind — and the supervisor faithfully re-armed the old code on every
+# restart. Worse, the staleness PROPAGATES: `_sac_binary.sac_binary()` resolves
+# a child `sac` by falling back to the executable NEXT TO ``sys.executable``
+# (deliberate, for venv coherence), so a stale daemon hands its own stale
+# binary to every agent it spawns or restarts. One wrong path here becomes a
+# fleet-wide version regression that no agent could see in any version string
+# it reads about itself.
+#
+# Consequence for whoever edits this: repointing ExecStart fixes BOTH halves at
+# once — the daemon's own code, and the binary it hands children. Verify with
+# the RUNNING PROCESS, never the unit file:
+#   pgrep -f 'sac listen'
+#   tr '\0' ' ' < /proc/<pid>/cmdline      # which interpreter + which sac
+#   <that venv>/bin/python -c "import importlib.metadata as m; \
+#       print(m.version('scitex-agent-container'))"
+# A unit file that pins a stale interpreter is a config that is correct about
+# what it SAYS and wrong about what it RUNS.
+# ==========================================================================
+ExecStart=@SAC_BIN@ listen
+# Single tail point for both streams: `journalctl --user -u sac-listen`. The
+# pre-flight diagnostics from listen_cmds.py (token file / pidfile / health URL)
+# land here, so the boot trace is visible with no extra config.
+StandardOutput=journal
+StandardError=journal
+# Colon-separated list of secret .src files to source. Host-specific; fill in
+# per host. Intentionally NOT committed with real paths — see __init__.py.
+Environment=SAC_SECRETS_ENVRC=@SAC_SECRETS_ENVRC@
+
+# Restart=always, NOT on-failure. Incident 2026-06-26: a listen that exits 0 for
+# ANY reason (a clean uvicorn shutdown from an unexpected SIGTERM, a bug
+# returning 0 on a fatal path, an operator `kill` turned into a graceful exit)
+# must STILL come back. on-failure does not cover a 0-exit, which is exactly how
+# the fleet lost a2a comms silently. The flock-backed single-instance guard
+# prevents a double-bind; the kernel releases the flock on every dirty exit.
+Restart=always
+RestartSec=5s
+# Generous stop window so in-flight SSE responses can flush.
+TimeoutStopSec=20s
+LimitNOFILE=8192
+
+[Install]
+WantedBy=default.target

--- a/src/scitex_agent_container/systemd/sac.accounts-refresh.service.template
+++ b/src/scitex_agent_container/systemd/sac.accounts-refresh.service.template
@@ -1,0 +1,32 @@
+[Unit]
+Description=Headless OAuth access-token refresh for all stored Claude accounts including the active one (sole-refresher model), mirroring the rotation into the live ~/.claude login.
+Documentation=https://github.com/ywatanabe1989/scitex-agent-container
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# ==========================================================================
+# ABSOLUTE path, NOT `/usr/bin/env sac`.
+#
+# The live unit on ywata-note-win used `ExecStart=/usr/bin/env sac accounts
+# refresh …` — a bare name resolved against the unit's inherited PATH. Measured
+# 2026-07-30: bare `sac` is NOT FOUND under a minimal PATH, and that host
+# carries THREE sac installations at different versions:
+#
+#   ~/.env-3.11/bin/sac                        0.24.20  (current release)
+#   ~/.scitex/agent-container/venv/bin/sac     0.21.22  (2026-07-17 wheel)
+#   ~/.local/bin/sac                           0.21.11  (src, metadata only)
+#
+# So the unit worked only because systemd's environment happened to contain one
+# of them, and WHICH one was unpinned. That ambiguity is not theoretical: it
+# cost two agents a wrong measurement on 2026-07-30 — one reported a JSON field
+# as "absent from the payload" when they had in fact invoked the 0.21.22 binary,
+# which predates the field. An absolute path makes "which code answered" a
+# property of the file instead of a property of the environment.
+# ==========================================================================
+ExecStart=@SAC_BIN@ accounts refresh --all --include-active --sync-active-login
+StandardOutput=journal
+StandardError=journal
+RemainAfterExit=no
+TimeoutStartSec=120s

--- a/src/scitex_agent_container/systemd/sac.accounts-refresh.timer.template
+++ b/src/scitex_agent_container/systemd/sac.accounts-refresh.timer.template
@@ -1,0 +1,12 @@
+[Unit]
+Description=Timer for sac.accounts-refresh
+Documentation=https://github.com/ywatanabe1989/scitex-agent-container
+
+[Timer]
+OnBootSec=15min
+OnUnitActiveSec=2h
+Persistent=true
+Unit=sac.accounts-refresh.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
`sac-listen.service` and `sac.accounts-refresh.service` brokered the entire agent fleet while existing **only** as live files under `~/.config/systemd/user/` — untracked, no history, no review. A host rebuild would have taken them. dotfiles confirmed by measurement that they are regular files, **not** symlinks into their repo, so a dotfiles deploy neither reverts an edit nor supplies one: there was no durable source anywhere.

Mirrors the existing `cron/` convention (package dir + `__init__.py` + `force-include`), so the files are reachable from an **installed** sac on a host where the repo isn't on disk.

**Templates, not deployed artifacts.** Nothing installs them; `@SAC_BIN@` / `@SAC_SECRETS_ENVRC@` are filled per host. **No unit is deployed or edited by this PR** — the two live edits it argues for are the operator's call and deliberately not taken.

**Parameterised rather than copied verbatim:** the live listen unit carries an `Environment=SAC_SECRETS_ENVRC=` line enumerating ~30 secret file paths under the operator's home. The paths aren't secrets, but a map of the secrets layout in a public repo is a reconnaissance aid. Verified with a positive control — `bash.d/secrets` and literal operator-home paths: **0 matches**; `@SAC_BIN@`: present in both service templates, so the zero is a measurement and not a broken search.

**The comments carry the measurement, which is the durable half:**

| finding | detail |
|---|---|
| daemon was stale | live `pid 1590` ran sac **0.21.22** (2026-07-17 wheel) against a 0.24.20 release — 13 releases behind. Read off the **running process**, not the unit file. |
| supervisor re-armed it | it had restarted that morning and come back onto the old venv, because `ExecStart` pinned it |
| **staleness propagates** | `_sac_binary.sac_binary()` resolves a child `sac` next to `sys.executable` (deliberate, for venv coherence) — so a stale daemon hands its stale binary to every agent it spawns/restarts. Invisible in any version string an agent reads about itself. Flip side: repointing `ExecStart` fixes both halves at once. |
| bare-name unit | `accounts-refresh` used `/usr/bin/env sac`; bare `sac` is **NOT FOUND** on a minimal PATH, so it worked only because systemd's env happened to hold one of the host's **three** sac installs — unpinned which. That cost two agents a wrong measurement the same night. |
| stale comment | the live unit says "Resolve `sac` against PATH" directly above an absolute-path `ExecStart` |

`listen_cmds.py:68` already noted three bare-`sac` call sites including this unit's `ExecStart` — the pattern was known; the durable source and the live measurement were what was missing.