### PR TITLE
fix(image): raise the cards SECURITY floor in the pip-fallback branch too — #836 missed it

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -333,13 +333,39 @@ From: ./sac-base.sif
         # actually moves it past whatever version base baked — without it a
         # satisfied requirement is a no-op and the layer silently freezes on
         # base's build (the 2026-07-12 fleet-drift).
-        # FLOOR RESTORED — mirrors the uv branch above; see it for the full
-        # reason. Short version: 0.17.2 is now a real artifact on PyPI, so the
-        # floor can finally express "the fixed version"; it stays at >=0.17.2
-        # rather than >=0.16.0 because 0.17.0 destroys card databases and a
-        # lower floor lets a resolver reach it again.
+        # SECURITY floor >=0.19.0 — MUST TRACK THE uv BRANCH ABOVE.
+        #
+        # This comment used to say "FLOOR RESTORED — mirrors the uv branch
+        # above" while naming >=0.17.9 against the uv branch's >=0.19.0. It had
+        # stopped mirroring anything: PR #836 raised the uv branch and this one,
+        # eleven lines and one `else` away, was missed. The claim of parallelism
+        # outlived the parallelism, which is the more dangerous half — a reader
+        # checking "do both branches agree?" would have been told yes by the
+        # prose.
+        #
+        # Why the miss happened, recorded so the next person greps differently:
+        # #836's search was `rg -n 'scitex-cards' <def> | head -6` and this site
+        # is the SEVENTH match. The floor was raised everywhere the search
+        # looked. There are TWO install sites in this file, one per branch of
+        # `if command -v uv`, and only a whole-file read shows both.
+        #
+        # The exposure is latent rather than live: the build host has uv, so the
+        # branch above is what runs today. But a host without uv would install
+        # >=0.17.9 — i.e. 0.18.0 is permitted — and 0.18.0 carries the
+        # cross-tenant fallback in `_django/handlers/dm.py` where a request
+        # lacking the injected store attribute reads AND WRITES the host store.
+        # A fallback path is exactly where a weakened security floor survives
+        # unnoticed, because nothing exercises it until the day it matters.
+        #
+        # Retains --upgrade for the reason the uv branch documents: without it a
+        # satisfied requirement is a no-op and the layer silently freezes on
+        # base's build (the 2026-07-12 fleet-drift). Stays a SEPARATE invocation
+        # so its resolve cannot reach into the providers' above. The 0.17.0
+        # exclusion the old text argued for is subsumed — 0.17.0 destroys card
+        # databases, and >=0.19.0 is strictly stronger than the >=0.17.2 that
+        # was guarding against it.
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
-            "scitex-cards[mcp]>=0.17.9"
+            "scitex-cards[mcp]>=0.19.0"
     fi
 
     # ---- 2b. FAIL-LOUD staleness gate — assert BY SYMBOL ----------------


### PR DESCRIPTION
**#836 claimed to fix exactly this and didn't.** Its commit message says it was *"raised in BOTH defs on purpose … that is the half-fix this commit exists to avoid"* — while leaving a half-fix one `else` away.

`apptainer-scitex.def` has **two** install sites, one per branch of `if command -v uv`:

| line | branch | before |
|---|---|---|
| 297 | uv | `>=0.19.0` ← #836 raised this |
| 342 | pip fallback | `>=0.17.9` ← left behind |

**Why it was missed**, which is more useful than the fix: #836's search was `rg -n 'scitex-cards' <def> | head -6` and the fallback site is the **seventh** match. The floor was raised everywhere the search looked. Fourth `head`-truncation miss this session.

**Worse than the pin:** the fallback's comment read *"FLOOR RESTORED — mirrors the uv branch above"* while naming a different version from the branch it claimed to mirror. Anyone auditing "do both branches agree?" would have been told **yes** by the prose. The claim of parallelism outlived the parallelism.

**Exposure is latent, not live.** The build host has uv, so the raised branch runs today. But a host without uv installs `>=0.17.9` — permitting 0.18.0, which carries the cross-tenant fallback in `_django/handlers/dm.py` where a request lacking the injected store attribute reads *and writes* the host store. A fallback path is exactly where a weakened security floor survives unnoticed, because nothing exercises it until the day it matters.

**Verified without truncation this time** — every `scitex-cards[mcp]` pin, whole-file:

```
apptainer-base.def:484     >=0.19.0
apptainer-scitex.def:297   >=0.19.0   (uv branch)
apptainer-scitex.def:368   >=0.19.0   (pip fallback, this PR)

pins below 0.19.0 in containers/: none
CONTROL: same search finds the three 0.19.0 pins → the zero is a measurement
```

The old text's 0.17.0 argument is subsumed rather than discarded: 0.17.0 destroys card databases, and `>=0.19.0` is strictly stronger than the `>=0.17.2` guarding it. `--upgrade` and the separate-invocation property are retained for the reasons the uv branch documents.