### PR TITLE
refactor(creds): extract _blind_cache_remedy to its own module (512-line cap)

### DIFF
--- a/src/scitex_agent_container/_creds/_blind_cache_remedy.py
+++ b/src/scitex_agent_container/_creds/_blind_cache_remedy.py
@@ -1,0 +1,82 @@
+"""The operator-facing remedy line for a BLIND credential pick.
+
+Split out of ``_pick_healthy.py`` to keep that module under the per-file line
+cap; it is a pure message builder — it takes a diagnosis and returns prose,
+sharing no state with the ranking logic it used to sit beside.
+
+Every branch reports only what :func:`.._account.quota_cache.diagnose_quota_cache`
+actually OBSERVED, and always names the file consulted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["_blind_cache_remedy"]
+
+
+def _blind_cache_remedy(quota_cache_path: Path | str | None) -> str:
+    """The remedy line for a blind pick — chosen by WHY the cache is blind.
+
+    Several distinct causes reach the blind gate and they need different
+    instructions; naming only the refresh command sent an operator whose cache
+    holds ZERO entries into a loop, because on a host with no stored accounts
+    that command finds nothing to refresh and changes nothing.
+
+    Every branch below reports only what :func:`diagnose_quota_cache` actually
+    OBSERVED, and always names the file consulted. The previous version branched
+    on ``entry_count == 0`` — which is also what an absent, unreadable or
+    malformed cache returns — and then asserted a cause it had not measured
+    ("the cache exists but holds ZERO account entries, so the populator has
+    never written a successful one"). On 2026-07-29 the operator saw exactly
+    that while the cron populator was writing three accounts every five minutes,
+    re-ran the refresh twice on its advice, and nothing changed: a remedy naming
+    a DIRECTION as if it were the truth costs more than one naming nothing.
+    """
+    from .._account.quota_cache import diagnose_quota_cache
+
+    state, entries, path = diagnose_quota_cache(quota_cache_path)
+    where = f"(read from {path})"
+    if state == "absent":
+        return (
+            f"Cause: NO quota cache exists at the path this pick consulted "
+            f"{where}. Fix: run `sac accounts refresh-quota-cache` on THIS "
+            "host and READ ITS OUTPUT — if it reports no accounts stored "
+            "(exit 3) it cannot help, and the real fix is `sac accounts save "
+            "<name>` (or `sac accounts sync-live`) here first."
+        )
+    if state == "unreadable":
+        return (
+            f"Cause: the quota cache exists but could NOT be read {where} — a "
+            "permissions or mount problem, not a populator problem. Re-running "
+            "the refresh will not fix it. Fix: check ownership/mode on that "
+            "file (the populator writes it 0600 as the invoking user)."
+        )
+    if state == "malformed":
+        return (
+            f"Cause: the quota cache exists but is not valid cache JSON {where} "
+            "— truncated or hand-edited, NOT an unrun populator. Fix: delete "
+            "that file and run `sac accounts refresh-quota-cache` to rewrite "
+            "it (the writer is tmp+rename atomic, so a partial file means "
+            "something outside the populator wrote there)."
+        )
+    if state == "empty":
+        return (
+            f"Cause: the quota cache holds ZERO account entries {where}, so no "
+            "populator run has stored one. Fix: run `sac accounts "
+            "refresh-quota-cache` on THIS host and READ ITS OUTPUT — if it "
+            "reports no accounts stored (exit 3) it cannot help, and the real "
+            "fix is `sac accounts save <name>` (or `sac accounts sync-live`) "
+            "here first, then re-run the refresh. If that refresh POPULATES "
+            "the file and a later pick is blind AGAIN, the populator is not "
+            "the problem — look for another writer on this path before "
+            "re-running the refresh a third time."
+        )
+    return (
+        f"Cause: the quota cache holds {entries} account entr"
+        f"{'y' if entries == 1 else 'ies'} {where}, but none of them covers a "
+        "fresh candidate — it is STALE, or was written for a different account "
+        "set than this agent's credentials pool. Fix: compare those entry keys "
+        "against the pool, then run `sac accounts refresh-quota-cache` (or "
+        "wait for its cron) and restart."
+    )

--- a/src/scitex_agent_container/_creds/_pick_healthy.py
+++ b/src/scitex_agent_container/_creds/_pick_healthy.py
@@ -93,6 +93,7 @@ from ._account_health import (
     _iso_utc,
     account_health,
 )
+from ._blind_cache_remedy import _blind_cache_remedy
 from ._quota_rank import (
     BLOCKED_5H_PCT,
     EXPIRING_7D_HORIZON_S,
@@ -425,70 +426,6 @@ def pick_healthy_account(
         )
 
     return picked
-
-
-def _blind_cache_remedy(quota_cache_path: Path | str | None) -> str:
-    """The remedy line for a blind pick — chosen by WHY the cache is blind.
-
-    Several distinct causes reach the blind gate and they need different
-    instructions; naming only the refresh command sent an operator whose cache
-    holds ZERO entries into a loop, because on a host with no stored accounts
-    that command finds nothing to refresh and changes nothing.
-
-    Every branch below reports only what :func:`diagnose_quota_cache` actually
-    OBSERVED, and always names the file consulted. The previous version branched
-    on ``entry_count == 0`` — which is also what an absent, unreadable or
-    malformed cache returns — and then asserted a cause it had not measured
-    ("the cache exists but holds ZERO account entries, so the populator has
-    never written a successful one"). On 2026-07-29 the operator saw exactly
-    that while the cron populator was writing three accounts every five minutes,
-    re-ran the refresh twice on its advice, and nothing changed: a remedy naming
-    a DIRECTION as if it were the truth costs more than one naming nothing.
-    """
-    from .._account.quota_cache import diagnose_quota_cache
-
-    state, entries, path = diagnose_quota_cache(quota_cache_path)
-    where = f"(read from {path})"
-    if state == "absent":
-        return (
-            f"Cause: NO quota cache exists at the path this pick consulted "
-            f"{where}. Fix: run `sac accounts refresh-quota-cache` on THIS "
-            "host and READ ITS OUTPUT — if it reports no accounts stored "
-            "(exit 3) it cannot help, and the real fix is `sac accounts save "
-            "<name>` (or `sac accounts sync-live`) here first."
-        )
-    if state == "unreadable":
-        return (
-            f"Cause: the quota cache exists but could NOT be read {where} — a "
-            "permissions or mount problem, not a populator problem. Re-running "
-            "the refresh will not fix it. Fix: check ownership/mode on that "
-            "file (the populator writes it 0600 as the invoking user)."
-        )
-    if state == "malformed":
-        return (
-            f"Cause: the quota cache exists but is not valid cache JSON {where} "
-            "— truncated or hand-edited, NOT an unrun populator. Fix: delete "
-            "that file and run `sac accounts refresh-quota-cache` to rewrite "
-            "it (the writer is tmp+rename atomic, so a partial file means "
-            "something outside the populator wrote there)."
-        )
-    if state == "empty":
-        return (
-            f"Cause: the quota cache holds ZERO account entries {where}, so no "
-            "populator run has stored one. Fix: run `sac accounts "
-            "refresh-quota-cache` on THIS host and READ ITS OUTPUT — if it "
-            "reports no accounts stored (exit 3) it cannot help, and the real "
-            "fix is `sac accounts save <name>` (or `sac accounts sync-live`) "
-            "here first, then re-run the refresh."
-        )
-    return (
-        f"Cause: the quota cache holds {entries} account entr"
-        f"{'y' if entries == 1 else 'ies'} {where}, but none of them covers a "
-        "fresh candidate — it is STALE, or was written for a different account "
-        "set than this agent's credentials pool. Fix: compare those entry keys "
-        "against the pool, then run `sac accounts refresh-quota-cache` (or "
-        "wait for its cron) and restart."
-    )
 
 
 __all__ = [


### PR DESCRIPTION
## What

Extracts `_blind_cache_remedy` from `_creds/_pick_healthy.py` into its own module. `_pick_healthy.py` was at 518 lines against the 512-line cap; it is now 429.

The remedy builder is a pure message function — it takes a diagnosis and returns prose, sharing no state with the ranking logic it sat beside — so it moves without touching behaviour. `_pick_healthy` re-imports the name, so the call site and every existing test path are unchanged.

## Verification

152 tests pass across `tests/scitex_agent_container/_creds/` and `tests/scitex_agent_container/_account/test_quota_cache.py`, before and after.

## What this PR deliberately does NOT contain

The branch name says `foreign-schema-detection`, and that feature is **not here** — I wrote it, then disproved its premise and reverted it.

The idea was a `foreign-schema` cache state flagging email-keyed `quota-cache.json` entries as a second writer's, on the theory that `bin/quota-alarm.py` (which keys by email) collides with the picker's populator (which keys by account name). Two independent facts kill it:

1. **The email-keyed shape is the documented one.** `tests/.../_account/test_quota_cache.py` pins a SAMPLE keyed by `alpha@example.com` and labels it "the lead's confirmed wire shape (2026-06-02)". The detector would have flagged the contract those tests exist to protect.

2. **The reader never looks at the key.** `read_quota_entry` iterates `accounts.values()` and matches on each entry's `short` field against the first dash-segment of the account dirname — deliberately, so multi-dot TLDs need no domain parsing. The picker reaches the cache through that same function via `_account_usage_pct`. An email key is invisible to the consumer.

So a key-schema collision cannot produce a blind pick by that mechanism. `quota_cache.py` is reverted to HEAD and the `empty` remedy branch no longer cites a foreign-schema cause.

Retracted on `quota-cache-two-writers-schema-collision-blocks-all-restarts-20260802`. Note the retraction is **scoped**: that card documents two defects and only the schema-collision half falls. The other half — `quota-alarm.py` writing `accounts: {}` over the populator's three entries, measured oscillating 3 → 0 → 3 on the `*/20` cron — is unaffected and still open.
