### PR TITLE
fix(image): add the scitex-cards [postgres] extra and raise the floor to 0.31.6

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -481,7 +481,7 @@ From: ubuntu:24.04
     uv pip install --no-cache --python /opt/venv-sac/bin/python -U \
         --reinstall-package scitex-agent-container \
         "claude-agent-sdk" \
-        "scitex-cards[mcp]>=0.19.0" \
+        "scitex-cards[mcp,postgres]>=0.31.6" \
         "/opt/scitex-agent-container-src[openai]"
 
     # ---- 6c. FAIL-LOUD staleness gate — assert BY SYMBOL --------------
@@ -577,6 +577,33 @@ print(
 )
 
 failures = []
+
+# psycopg GATE — the cards store is PostgreSQL, so a container without a
+# USABLE driver cannot read or write the fleet board at all.
+#
+# Assert the ATTRIBUTE, not the import, because the import cannot fail in the
+# way that actually happened. Measured 2026-08-02: site-packages held a bare
+# ``psycopg/`` directory containing only subdirectories — no ``__init__.py``,
+# no ``*.py``, and NO dist-info anywhere. Leftovers from a package that was
+# never requested: the pin was ``scitex-cards[mcp]``, without the ``postgres``
+# extra that carries ``psycopg[binary]``. Python treats such a directory as a
+# NAMESPACE PACKAGE, so ``import psycopg`` SUCCEEDED, ``psycopg.__file__`` was
+# None and ``psycopg.connect`` did not exist. Every agent then failed its card
+# writes with "canonical store postgresql://... does not exist" — blaming the
+# database for a missing driver, and sending three agents to the wrong layer.
+# An import-only check would have passed on that image.
+try:
+    import psycopg as _psycopg
+
+    if not hasattr(_psycopg, "connect"):
+        failures.append(
+            "psycopg imports but exposes no .connect (__file__=%r) — a "
+            "namespace-package phantom, not an install. The cards store is "
+            "PostgreSQL; check that the scitex-cards pin carries the "
+            "[postgres] extra." % (getattr(_psycopg, "__file__", None),)
+        )
+except Exception as _exc:
+    failures.append("psycopg is not importable: %r" % (_exc,))
 
 # The version string lies (uv's wheel cache is version-keyed and sac's
 # version does not advance per-commit). File content cannot lie — but the

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -294,7 +294,7 @@ From: ./sac-base.sif
         # multi-tenant mount). Verified in the artifact: the 0.19.0 wheel has 0
         # occurrences of that fallback, the copy in the CURRENT image has 1.
         uv pip install --python /opt/venv-sac/bin/python -U \
-            "scitex-cards[mcp]>=0.19.0"
+            "scitex-cards[mcp,postgres]>=0.31.6"
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             pip setuptools wheel
@@ -365,7 +365,7 @@ From: ./sac-base.sif
         # databases, and >=0.19.0 is strictly stronger than the >=0.17.2 that
         # was guarding against it.
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
-            "scitex-cards[mcp]>=0.19.0"
+            "scitex-cards[mcp,postgres]>=0.31.6"
     fi
 
     # ---- 2b. FAIL-LOUD staleness gate — assert BY SYMBOL ----------------

--- a/tests/integration/test_apptainer_base_def_scitex_todo.py
+++ b/tests/integration/test_apptainer_base_def_scitex_todo.py
@@ -126,15 +126,48 @@ def test_uv_pip_install_block_mentions_scitex_todo(base_def_text: str) -> None:
     )
 
 
+def _requirement_extras(requirement: str) -> set[str]:
+    """The extras NAMED in a requirement — ``[mcp,postgres]`` -> {mcp, postgres}.
+
+    Parsed rather than substring-matched. The old check was
+    ``"scitex-cards[mcp]" in block``, which asserts the extras list is EXACTLY
+    ``[mcp]`` while reading as "carries the mcp extra": adding a second,
+    equally required extra made the substring vanish and turned a correct
+    change red. A contract test should pin what it claims to pin.
+    """
+    if "[" not in requirement or "]" not in requirement:
+        return set()
+    inner = requirement.split("[", 1)[1].split("]", 1)[0]
+    return {part.strip() for part in inner.split(",") if part.strip()}
+
+
 def test_uv_pip_install_block_carries_mcp_extra(base_def_text: str) -> None:
     # Arrange
     block = _uv_pip_install_block(base_def_text)
     # Act
-    present = "scitex-cards[mcp]" in block
+    extras = _requirement_extras(_scitex_todo_requirement(block))
     # Assert
-    assert present, (
+    assert "mcp" in extras, (
         "scitex-cards install must carry the [mcp] extra (pulls fastmcp>=2.0)"
-        f" in apptainer-base.def:\n{block}"
+        f" in apptainer-base.def; got extras {sorted(extras)} in:\n{block}"
+    )
+
+
+def test_uv_pip_install_block_carries_postgres_extra(base_def_text: str) -> None:
+    # Arrange — the cards store is PostgreSQL. Without this extra there is no
+    # psycopg in the image and EVERY agent's card writes fail, reported as
+    # "canonical store ... does not exist" (measured 2026-08-02: the pin was
+    # [mcp] only, and site-packages held a bare psycopg/ directory with no
+    # __init__.py, which imports as a namespace package and exposes no
+    # .connect).
+    block = _uv_pip_install_block(base_def_text)
+    # Act
+    extras = _requirement_extras(_scitex_todo_requirement(block))
+    # Assert
+    assert "postgres" in extras, (
+        "scitex-cards install must carry the [postgres] extra (pulls "
+        "psycopg[binary]>=3.1; the cards store is PostgreSQL) in "
+        f"apptainer-base.def; got extras {sorted(extras)} in:\n{block}"
     )
 
 


### PR DESCRIPTION
## Agent containers have no PostgreSQL driver

Every card write fails with:

```
canonical store postgresql://scitex_cards@127.0.0.1:5432/scitex_cards does not exist
```

That message names the wrong subsystem. The database is fine and **reachable** — TCP connects from inside a container. What is missing is the **driver**.

## Measured inside a live container

```
site-packages/psycopg/    pq/  types/  __pycache__/   <- subdirectories ONLY
                          no __init__.py, no *.py at top level
                          and NO psycopg*.dist-info anywhere
```

Python treats that as a **namespace package**, so `import psycopg` **succeeds**, `psycopg.__file__` is `None`, and `psycopg.connect` does not exist. The worst shape available: an import-guarded check passes, and the failure surfaces three layers away as a missing database. It sent three agents to the wrong layer today.

## Cause

The pin was `scitex-cards[mcp]` at all three install sites — **no `postgres` extra**, so `psycopg[binary]` was never requested. The stray directories are leftovers, not a corrupted install.

Confirmed against PyPI: scitex-cards declares `postgres` in `provides_extra`, carrying `psycopg[binary]>=3.1`. That extra **did not exist in 0.25.0**, which is what this image actually ships.

## The change

`scitex-cards[mcp]>=0.19.0` → `scitex-cards[mcp,postgres]>=0.31.6` at all **three** sites (`base:484`, `scitex:297` uv branch, `scitex:368` pip fallback).

The floor matters independently of the extra: `>=0.19.0` is satisfied by the 0.25.0 this image runs *and* by the 0.31.3 measured in another container, so the constraint permitted three releases of drift **in silence** against a store already on schema v9. Reported by the scitex-cards agent — the drift and the missing driver were always the same bake.

## Build-time gate

Asserts `psycopg.connect` **exists**, not merely that `psycopg` imports. An import-only check cannot fail in the way this actually failed, and would have passed on the broken image.

## Not done here

Merged is not live. This needs a rebake + agent restart; the accepting test is the scitex-cards agent re-measuring `scitex_cards.__version__` and `SCHEMA_VERSION` from **inside** a freshly started container.