### PR TITLE
fix(agents list): read the Account column from the LIVE credential bind

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -35,8 +35,20 @@ from ._agent_list_auth import (  # noqa: F401
     resolve_auth,
 )
 
+# The LIVE credential bind — ground truth for a running local agent, and the
+# STRONGEST of the three Account signals. Same re-import rationale as above.
+from ._agent_list_bound_account import bound_accounts_by_agent  # noqa: F401
+
 # Host-DISPLAY resolution (Host column) — sibling module, 512-line cap split.
 from ._agent_list_host import _host_display_for, _resolve_display_host
+
+# Row shaping + the movement trio. Re-exported so the bare-name call sites
+# here, and the test seams that rebind ``_al._movement_fields``, keep working.
+from ._agent_list_row import (  # noqa: F401
+    _MOVEMENT_DEFAULTS,
+    _movement_fields,
+    build_agent_row,
+)
 
 
 def _all_port_claims() -> dict[str, int]:
@@ -57,42 +69,6 @@ def _all_port_claims() -> dict[str, int]:
         return {c["name"]: c["port"] for c in port_allocator.list_claims()}
     except Exception:  # stx-allow: fallback (reason: see inline comment)
         return {}
-
-
-# The always-present movement trio in its empty shape — the tolerant fallback
-# AND what a PERF-deferred (hidden, non-running) row carries in place of the
-# movement IO. One definition so the two paths can never drift.
-_MOVEMENT_DEFAULTS: dict = {
-    "session_jsonl_bytes": 0,
-    "session_jsonl_last_write": "",
-    "heartbeat_at": "",
-}
-
-
-def _movement_fields(name: str) -> dict:
-    """Return the three movement keys for ``name`` (always all-present).
-
-    Operator mandate (lead a2a 1781e82a, 2026-06-14): the fleet view's
-    per-agent rows must carry the same ``session_jsonl_bytes`` /
-    ``session_jsonl_last_write`` / ``heartbeat_at`` trio that the
-    per-agent ``agent_status`` payload exposes, so a single fleet
-    ``--json`` read answers "is each agent producing?".
-
-    Tolerant: any state-dir resolution / IO failure degrades to the
-    all-defaults shape (zero bytes + empty ISO strings) so the list
-    command never crashes on a movement-probe hiccup.
-    """
-    # stx-allow: fallback (reason: list output must never crash on a
-    # state-dir probe hiccup; explicit empty-values shape is the right UX.)
-    try:
-        from ..._lifecycle._session_movement import (
-            resolve_state_dir,
-            status_movement_fields,
-        )
-
-        return status_movement_fields(resolve_state_dir(name))
-    except Exception:  # stx-allow: fallback (reason: see inline comment)
-        return dict(_MOVEMENT_DEFAULTS)
 
 
 def _probe_local(cfg) -> bool | None:
@@ -230,6 +206,11 @@ def get_agent_list_data(
     from concurrent.futures import TimeoutError as _FuturesTimeout
 
     entries = registry.list_all()
+
+    # Live credential binds, measured ONCE for this listing (one /proc walk,
+    # not one per row). Re-measured on every call, so ``--watch`` never
+    # renders a bind read minutes ago.
+    live_binds = bound_accounts_by_agent()
 
     # Host DISPLAY column hostname, resolved ONCE (test-swappable seam).
     display_host = _resolve_display_host()
@@ -416,34 +397,31 @@ def get_agent_list_data(
         else:
             account_label = _safe_account_for(cfg)
             if is_live_status(status_val):
-                runtime_label = _runtime_account_for(name)
-                if runtime_label:
-                    account_label = runtime_label
-        row: dict = {
-            "name": name,
-            "status": status_val,
-            "screen": screen_name,
-            "multiplexer": multiplexer,
-            "started_at": started,
-            "host": host_label,
-            "host_display": _host_display_for(host_label, display_host),
-            "path": spec_path,
-            "a2a_port": a2a_port,
-            "account": account_label,
-        }
-        # Operator mandate (lead a2a 1781e82a, 2026-06-14): surface
-        # session.jsonl movement + last heartbeat per row of ``sac agents
-        # status --json``. All three keys are ALWAYS present; a deferred
-        # (hidden, non-running) row gets the default empty shape instead of
-        # the movement IO.
-        row.update(dict(_MOVEMENT_DEFAULTS) if deferred else _movement_fields(name))
-        if errors:
-            row["validation_errors"] = errors
-        if liveness_unknown:
-            row["liveness_unknown"] = True
-        if labels:
-            row["labels"] = labels
-        results.append(row)
+                # Precedence: live BIND > runtime login RECORD > spec label.
+                # See ``_agent_list_bound_account`` for why leading with the
+                # record was wrong — it is a PAST login, measured 11-37 days
+                # stale, and the spec label collapses to one host identity.
+                account_label = (
+                    live_binds.get(name) or _runtime_account_for(name) or account_label
+                )
+        results.append(
+            build_agent_row(
+                name=name,
+                status_val=status_val,
+                screen_name=screen_name,
+                multiplexer=multiplexer,
+                started=started,
+                host_label=host_label,
+                host_display=_host_display_for(host_label, display_host),
+                spec_path=spec_path,
+                a2a_port=a2a_port,
+                account_label=account_label,
+                deferred=deferred,
+                errors=errors,
+                liveness_unknown=liveness_unknown,
+                labels=labels,
+            )
+        )
 
     # Merge in agents recorded as running on a REMOTE peer (master-authoritative
     # cross-host visibility). The master already wrote an ``instances`` row on

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_bound_account.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_bound_account.py
@@ -1,0 +1,137 @@
+"""Live credential-BIND resolution for the agent list's Account column.
+
+The column answered "which account is this agent on?" from the agent's
+``<runtime>/home/.claude.json`` — Claude Code's own persisted login record.
+That record is NOT rewritten when the credential bind changes, and when it
+carries no ``oauthAccount`` key the caller falls back to the SPEC label, which
+for a pool agent (``credentials_files`` with no singular ``account`` pin)
+collapses to the host's shared OAuth identity so every such agent renders
+identically.
+
+Measured 2026-08-02, the day it cost an hour: the fleet had ALREADY been moved
+onto one account and the column still showed three. The login records behind
+those cells were 11 to 37 days old (mtimes 06-26, 06-28, 07-08, 07-09, 07-19,
+07-22), and the one row that looked correct matched by coincidence.
+
+This module reads the BIND instead: the kernel's own record, in each live
+container's ``mountinfo``, of which host credentials file is mounted at the
+container's ``~/.claude/.credentials.json``. For a RUNNING agent that is
+ground truth rather than a derived value — it is what the process will
+actually authenticate with.
+
+Scope, stated because a silent gap here is how the previous version misled:
+this resolves LOCAL containers only. An agent on another host has no
+``/proc`` entry here and resolves to ``None``, so the caller falls back to the
+older, weaker signals. It never invents an answer.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from pathlib import Path
+
+# The bind SOURCE is ``.../accounts/[<provider>/]<account>/.credentials.json``.
+# The provider segment (``anthropic``) is optional so an older layout without
+# it still resolves.
+_BIND_SOURCE_RE = re.compile(
+    r"accounts/(?:[A-Za-z0-9_-]+/)?([A-Za-z0-9._-]+)/\.credentials\.json"
+)
+# The bind TARGET inside the container. Matching on it keeps an unrelated
+# accounts-shaped path elsewhere in the mount table from being read as the
+# credential bind.
+_BIND_TARGET = "/.claude/.credentials.json"
+
+__all__ = [
+    "account_from_mountinfo",
+    "bound_account_for",
+    "bound_accounts_by_agent",
+]
+
+
+def account_from_mountinfo(mountinfo: str) -> str:
+    """The account slug bound at the container's credentials path, or ``""``.
+
+    Pure: takes the text of a ``mountinfo`` file and returns what it says.
+    Split from the ``/proc`` walk so it can be tested against REAL captured
+    mount tables instead of a mocked filesystem — the parsing is where a
+    wrong answer would come from, and it is the part worth pinning.
+
+    A line is only read when it binds ONTO the container credentials path, so
+    an unrelated accounts-shaped mount elsewhere in the table is not mistaken
+    for the credential bind.
+    """
+    for line in mountinfo.splitlines():
+        if _BIND_TARGET not in line:
+            continue
+        match = _BIND_SOURCE_RE.search(line)
+        if match:
+            return match.group(1)
+    return ""
+
+
+@lru_cache(maxsize=1)
+def bound_accounts_by_agent() -> dict[str, str]:
+    """Map ``SAC_NAME`` -> bound account slug for every LIVE local container.
+
+    One ``/proc`` walk, cached, because the list renders many rows and a scan
+    per row would be quadratic. The cache is per-process and MUST be cleared
+    at the start of each list invocation — a long-lived caller (``--watch``)
+    would otherwise report a bind from minutes ago, which is the exact class
+    of staleness this module exists to remove.
+    """
+    found: dict[str, str] = {}
+    proc = Path("/proc")
+    if not proc.is_dir():  # non-Linux / no procfs — resolve nothing, claim nothing
+        return found
+    for entry in proc.iterdir():
+        if not entry.name.isdigit():
+            continue
+        name = _sac_name_of(entry)
+        if not name or name in found:
+            continue
+        account = _bound_account_of(entry)
+        if account:
+            found[name] = account
+    return found
+
+
+def _sac_name_of(proc_entry: Path) -> str:
+    """The agent name a process belongs to, from ``SAC_NAME`` in its environ."""
+    # stx-allow: fallback (reason: a process may exit mid-walk, or belong to
+    # another user; either way it is simply not one of our agents.)
+    try:
+        raw = (proc_entry / "environ").read_bytes().decode("utf-8", "replace")
+    except OSError:
+        return ""
+    for pair in raw.split("\0"):
+        if pair.startswith("SAC_NAME="):
+            return pair[len("SAC_NAME=") :]
+    return ""
+
+
+def _bound_account_of(proc_entry: Path) -> str:
+    """The account slug bound at the container's credentials path, or ``""``."""
+    # stx-allow: fallback (reason: see _sac_name_of — a vanished or foreign
+    # process is not an error, it is not our agent.)
+    try:
+        mounts = (proc_entry / "mountinfo").read_text()
+    except OSError:
+        return ""
+    return account_from_mountinfo(mounts)
+
+
+def bound_account_for(name: str) -> str | None:
+    """The account ``name`` is CURRENTLY bound to, or ``None`` if unresolvable.
+
+    ``None`` means "this host cannot see that agent's mounts" — a remote agent,
+    a stopped agent, or no procfs. It never means "no account": the caller
+    falls back to the spec/runtime label and the cell degrades to the older
+    signal rather than to a wrong one.
+    """
+    # stx-allow: fallback (reason: the Account column must never crash the
+    # list; an unresolvable bind degrades to the caller's weaker signals.)
+    try:
+        return bound_accounts_by_agent().get(name) or None
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_row.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_row.py
@@ -1,0 +1,104 @@
+"""Shape ONE agent-list row.
+
+Extracted from :mod:`._agent_list` (512-line cap split), mirroring the
+existing ``_agent_list_account`` / ``_agent_list_auth`` / ``_agent_list_remote``
+siblings. One responsibility: take the already-resolved per-agent facts and
+return the row dict every consumer of ``sac agents list`` reads — the human
+table, ``--json``, and the fleet payload.
+
+Resolution stays in the caller on purpose. ``_agent_list`` computes the
+account label there because the suite rebinds ``_al._safe_account_for`` /
+``_al._runtime_account_for`` as test seams, and a resolver called from THIS
+module would ignore that rebinding — measured 2026-08-02, 85 helper tests
+failed when the account precedence was moved out of ``_agent_list``.
+"""
+
+from __future__ import annotations
+
+__all__ = ["_MOVEMENT_DEFAULTS", "_movement_fields", "build_agent_row"]
+
+# The always-present movement trio in its empty shape — the tolerant fallback
+# AND what a PERF-deferred (hidden, non-running) row carries in place of the
+# movement IO. One definition so the two paths can never drift.
+_MOVEMENT_DEFAULTS: dict = {
+    "session_jsonl_bytes": 0,
+    "session_jsonl_last_write": "",
+    "heartbeat_at": "",
+}
+
+
+def _movement_fields(name: str) -> dict:
+    """Return the three movement keys for ``name`` (always all-present).
+
+    Operator mandate (lead a2a 1781e82a, 2026-06-14): the fleet view's
+    per-agent rows must carry the same ``session_jsonl_bytes`` /
+    ``session_jsonl_last_write`` / ``heartbeat_at`` trio that the
+    per-agent ``agent_status`` payload exposes, so a single fleet
+    ``--json`` read answers "is each agent producing?".
+
+    Tolerant: any state-dir resolution / IO failure degrades to the
+    all-defaults shape (zero bytes + empty ISO strings) so the list
+    command never crashes on a movement-probe hiccup.
+    """
+    # stx-allow: fallback (reason: list output must never crash on a
+    # state-dir probe hiccup; explicit empty-values shape is the right UX.)
+    try:
+        from ..._lifecycle._session_movement import (
+            resolve_state_dir,
+            status_movement_fields,
+        )
+
+        return status_movement_fields(resolve_state_dir(name))
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return dict(_MOVEMENT_DEFAULTS)
+
+
+def build_agent_row(
+    *,
+    name: str,
+    status_val: str,
+    screen_name: str,
+    multiplexer: str,
+    started,
+    host_label: str,
+    host_display: str,
+    spec_path: str,
+    a2a_port,
+    account_label: str,
+    deferred: bool,
+    errors,
+    liveness_unknown: bool,
+    labels,
+) -> dict:
+    """Build one row dict.
+
+    ``deferred`` is the DEFAULT-view perf hint: a row that will be discarded
+    before rendering skips the per-row session-movement IO and gets the empty
+    movement shape instead. The three movement keys are ALWAYS present either
+    way (operator mandate, lead a2a 1781e82a) so a JSON consumer never has to
+    test for their existence.
+
+    The optional keys (``validation_errors`` / ``liveness_unknown`` /
+    ``labels``) are attached only when they carry something, keeping an
+    ordinary row free of empty noise.
+    """
+    row: dict = {
+        "name": name,
+        "status": status_val,
+        "screen": screen_name,
+        "multiplexer": multiplexer,
+        "started_at": started,
+        "host": host_label,
+        "host_display": host_display,
+        "path": spec_path,
+        "a2a_port": a2a_port,
+        "account": account_label,
+    }
+    row.update(dict(_MOVEMENT_DEFAULTS) if deferred else _movement_fields(name))
+    if errors:
+        row["validation_errors"] = errors
+    if liveness_unknown:
+        row["liveness_unknown"] = True
+    if labels:
+        row["labels"] = labels
+    return row

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_bound_account.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_bound_account.py
@@ -1,0 +1,91 @@
+"""Tests for the Account column's LIVE credential-bind resolver.
+
+Fixtures are REAL ``mountinfo`` lines captured from a running agent container
+on 2026-08-02, not hand-invented shapes — the previous Account resolver was
+wrong precisely because nobody checked it against what the system actually
+holds, and a hand-written fixture would have reproduced my assumption rather
+than the machine's answer.
+
+PA-307 / STX-TQ002 / STX-TQ007 — one assert per test, full AAA markers.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.cli_pkg._helpers._agent_list_bound_account import (
+    account_from_mountinfo,
+    bound_account_for,
+)
+
+# Captured verbatim from /proc/<pid>/mountinfo of a live container.
+REAL_BIND_LINE = (
+    "2749 2730 8:48 "
+    "/home/ywatanabe/.dotfiles/src/.scitex/agent-container/accounts/anthropic/"
+    "wyusuuke-gmail-com/.credentials.json "
+    "/home/agent/.claude/.credentials.json rw,nosuid,nodev,relatime master:797 "
+    "- ext4 /dev/sdd rw,discard,errors=remount-ro,data=ordered"
+)
+
+# A same-container line that is NOT the credential bind.
+UNRELATED_LINE = (
+    "2748 2730 8:48 /home/ywatanabe/proj/scitex-agent-container /work "
+    "rw,nosuid,nodev,relatime master:797 - ext4 /dev/sdd rw,discard"
+)
+
+
+def test_extracts_account_from_real_bind_line() -> None:
+    # Arrange
+    mountinfo = f"{UNRELATED_LINE}\n{REAL_BIND_LINE}\n"
+    # Act
+    account = account_from_mountinfo(mountinfo)
+    # Assert
+    assert account == "wyusuuke-gmail-com"
+
+
+def test_ignores_mount_table_without_credential_bind() -> None:
+    # Arrange — a table holding only non-credential mounts.
+    mountinfo = f"{UNRELATED_LINE}\n"
+    # Act
+    account = account_from_mountinfo(mountinfo)
+    # Assert
+    assert account == ""
+
+
+def test_does_not_read_an_accounts_path_bound_elsewhere() -> None:
+    # Arrange — the SOURCE looks like an account credentials file but it is
+    # NOT mounted onto the container credentials path. Reading it would
+    # report an account the agent does not authenticate with.
+    decoy = REAL_BIND_LINE.replace(
+        "/home/agent/.claude/.credentials.json", "/home/agent/backup/creds.json"
+    )
+    # Act
+    account = account_from_mountinfo(decoy)
+    # Assert
+    assert account == ""
+
+
+def test_layout_without_provider_segment_still_resolves() -> None:
+    # Arrange — the older accounts/<name>/ layout, with no provider segment.
+    legacy = REAL_BIND_LINE.replace("accounts/anthropic/", "accounts/")
+    # Act
+    account = account_from_mountinfo(legacy)
+    # Assert
+    assert account == "wyusuuke-gmail-com"
+
+
+def test_empty_mount_table_resolves_to_nothing() -> None:
+    # Arrange
+    mountinfo = ""
+    # Act
+    account = account_from_mountinfo(mountinfo)
+    # Assert
+    assert account == ""
+
+
+def test_unknown_agent_resolves_to_none_not_a_guess() -> None:
+    # Arrange — a name no live container claims. The caller must fall back to
+    # its weaker signals, so this MUST be None rather than a stand-in string.
+    name = "no-such-agent-nobody-is-running-this"
+    # Act
+    resolved = bound_account_for(name)
+    # Assert
+    assert resolved is None


### PR DESCRIPTION
## The column reported a login record, not the account

`sac agents list` answered *'which account is this agent on?'* from the agent's `<runtime>/home/.claude.json` — Claude Code's own persisted **login record**. That record is not rewritten when the credential bind changes. When it carries no `oauthAccount` key at all, the caller fell back to the **spec label**, which for a pool agent collapses to the host's shared OAuth identity — so every such row renders identically.

**Measured 2026-08-02, the day it cost an hour:** the fleet had *already* been moved onto one account and the column still showed three. The records behind those cells were **11 to 37 days old** (mtimes 06-26, 06-28, 07-08, 07-09, 07-19, 07-22). The one row that looked correct matched by **coincidence**.

## The fix

A third signal, placed **first**: the live bind, read from each running container's own `mountinfo` — the kernel's record of which host credentials file is mounted at the container's `~/.claude/.credentials.json`.

Precedence is now **bind → runtime record → spec label**. Falling *back* is fine and expected; *leading* with the record was the defect.

## Verified against the live fleet, not only in tests

The resolver reports all **10 running agents on `wyusuuke-gmail-com`**, matching the binds read by hand.

## Scope, stated in the module rather than left implicit

Local containers only. A remote agent has no `/proc` entry here and resolves to `None`, so the cell degrades to the older signals rather than to a wrong one. Run from *inside* a container it sees only that container — `sac agents list` runs on the host, where it sees all ten.

## Refactor carried along

The edit was blocked by the 512-line cap (the file was at 507):

- `_agent_list_row.py` — `build_agent_row()` plus the movement trio, extracted from `_agent_list`, which re-exports both so the seams rebinding `_al._movement_fields` keep working.
- `_agent_list.py`: 507 → 485.

The account precedence deliberately **stays** in `_agent_list`: the suite rebinds `_al._safe_account_for` / `_al._runtime_account_for` as test seams, and a resolver called from another module ignores that rebinding — measured, **85 helper tests failed** when the precedence was moved out.

## Tests

6 new, driven by **real** `mountinfo` lines captured from a live container rather than invented shapes — including the decoy case where an accounts-shaped source is bound somewhere *other* than the credentials path.

**166 passed** in `tests/scitex_agent_container/cli_pkg/_helpers/`.