### PR TITLE
fix(image): install scitex-cards[all], and assert the capability not the spelling

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -481,7 +481,7 @@ From: ubuntu:24.04
     uv pip install --no-cache --python /opt/venv-sac/bin/python -U \
         --reinstall-package scitex-agent-container \
         "claude-agent-sdk" \
-        "scitex-cards[mcp,postgres]>=0.31.6" \
+        "scitex-cards[all]>=0.31.6" \
         "/opt/scitex-agent-container-src[openai]"
 
     # ---- 6c. FAIL-LOUD staleness gate — assert BY SYMBOL --------------

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -294,7 +294,7 @@ From: ./sac-base.sif
         # multi-tenant mount). Verified in the artifact: the 0.19.0 wheel has 0
         # occurrences of that fallback, the copy in the CURRENT image has 1.
         uv pip install --python /opt/venv-sac/bin/python -U \
-            "scitex-cards[mcp,postgres]>=0.31.6"
+            "scitex-cards[all]>=0.31.6"
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             pip setuptools wheel
@@ -365,7 +365,7 @@ From: ./sac-base.sif
         # databases, and >=0.19.0 is strictly stronger than the >=0.17.2 that
         # was guarding against it.
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
-            "scitex-cards[mcp,postgres]>=0.31.6"
+            "scitex-cards[all]>=0.31.6"
     fi
 
     # ---- 2b. FAIL-LOUD staleness gate — assert BY SYMBOL ----------------

--- a/tests/integration/test_apptainer_base_def_scitex_todo.py
+++ b/tests/integration/test_apptainer_base_def_scitex_todo.py
@@ -141,32 +141,44 @@ def _requirement_extras(requirement: str) -> set[str]:
     return {part.strip() for part in inner.split(",") if part.strip()}
 
 
-def test_uv_pip_install_block_carries_mcp_extra(base_def_text: str) -> None:
+# Extras sets that PROVIDE each capability, per scitex-cards' published
+# metadata. Assert the CAPABILITY, never the spelling: the fleet convention
+# moved from hand-picked sets to ``[all]`` on 2026-08-02, and a test naming one
+# spelling calls the other a regression. This file has now had that bug twice
+# — first as `"scitex-cards[mcp]" in block`, then as `"postgres" in extras` —
+# so the third version pins what the image must be ABLE to do.
+_EXTRAS_PROVIDING_FASTMCP = {"mcp", "all"}
+_EXTRAS_PROVIDING_PSYCOPG = {"postgres", "all"}
+
+
+def test_uv_pip_install_block_can_provide_fastmcp(base_def_text: str) -> None:
     # Arrange
     block = _uv_pip_install_block(base_def_text)
     # Act
     extras = _requirement_extras(_scitex_todo_requirement(block))
     # Assert
-    assert "mcp" in extras, (
-        "scitex-cards install must carry the [mcp] extra (pulls fastmcp>=2.0)"
-        f" in apptainer-base.def; got extras {sorted(extras)} in:\n{block}"
+    assert extras & _EXTRAS_PROVIDING_FASTMCP, (
+        "scitex-cards install must carry an extra that pulls fastmcp>=2.0 "
+        f"(any of {sorted(_EXTRAS_PROVIDING_FASTMCP)}) in apptainer-base.def; "
+        f"got extras {sorted(extras)} in:\n{block}"
     )
 
 
-def test_uv_pip_install_block_carries_postgres_extra(base_def_text: str) -> None:
-    # Arrange — the cards store is PostgreSQL. Without this extra there is no
-    # psycopg in the image and EVERY agent's card writes fail, reported as
-    # "canonical store ... does not exist" (measured 2026-08-02: the pin was
-    # [mcp] only, and site-packages held a bare psycopg/ directory with no
-    # __init__.py, which imports as a namespace package and exposes no
-    # .connect).
+def test_uv_pip_install_block_can_provide_psycopg(base_def_text: str) -> None:
+    # Arrange — the cards store is PostgreSQL. With no psycopg-providing extra
+    # there is no driver in the image and EVERY agent's card writes fail,
+    # reported as "canonical store ... does not exist" — naming the database,
+    # which is fine. Measured 2026-08-02: the pin was [mcp] only, and
+    # site-packages held a bare psycopg/ directory with no __init__.py, which
+    # imports as a NAMESPACE PACKAGE and exposes no .connect, so an
+    # import-guarded check passed while the fleet's board was unreachable.
     block = _uv_pip_install_block(base_def_text)
     # Act
     extras = _requirement_extras(_scitex_todo_requirement(block))
     # Assert
-    assert "postgres" in extras, (
-        "scitex-cards install must carry the [postgres] extra (pulls "
-        "psycopg[binary]>=3.1; the cards store is PostgreSQL) in "
+    assert extras & _EXTRAS_PROVIDING_PSYCOPG, (
+        "scitex-cards install must carry an extra that pulls "
+        f"psycopg[binary]>=3.1 (any of {sorted(_EXTRAS_PROVIDING_PSYCOPG)}) in "
         f"apptainer-base.def; got extras {sorted(extras)} in:\n{block}"
     )
 


### PR DESCRIPTION
## Complies with scitex-dev's ADR-0005 (PR #490)

Extras are `all` or bare only. scitex-cards had already rewritten 25 partial-extra install instructions across 17 files after root-causing that a hand-picked partial set (`[mcp]`, missing `postgres`) took the fleet's card board down today.

My `[mcp,postgres]` was the odd one out — and was itself a hand-picked partial set, committed an hour after agreeing that hand-picked partial sets were the defect. The operator caught it before the bake.

```
scitex-cards[mcp,postgres]>=0.31.6  ->  scitex-cards[all]>=0.31.6
```

at all three sites (`base:484`, `scitex:297` uv branch, `scitex:368` pip fallback). Verified against published metadata rather than assumed: 0.31.7 declares `all`, and it carries `psycopg[binary]>=3.1`, so the driver still lands.

## The tests now assert the capability, not the extra name

This file has had the same bug **twice in one day**:

| version | reads as | actually asserts |
|---|---|---|
| `"scitex-cards[mcp]" in block` | 'carries the mcp extra' | extras list is **exactly** `[mcp]` — adding `postgres` turned a correct change red |
| `"postgres" in extras` (mine) | 'carries the postgres extra' | that exact spelling — then called `[all]` a regression |

Both encoded the **current spelling** rather than the **required property**, so each went red precisely when someone fixed something. The third version asks what the image must be *able to do*:

```python
extras & {"mcp", "all"}       # can provide fastmcp
extras & {"postgres", "all"}  # can provide psycopg
```

**14 passed** in `tests/integration/test_apptainer_base_def_scitex_todo.py`.

## The floor stays `>=0.31.6`, deliberately

scitex-cards' #754 makes psycopg a **hard** dependency but is **not published** — PyPI serves 0.31.7, where psycopg is still extras-only. A floor naming it would name a version that does not exist.

Raising it is a separate edit once that publishes, and it is worth doing: `>=0.31.6` is satisfied by 0.31.6 itself, so the constraint permits an image that still needs the extra to be correct. Correct today by construction, under-specified as a guarantee.