### PR TITLE
fix(restart): stop logging correct operation as WARNING

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_restart_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_restart_preflight.py
@@ -304,17 +304,21 @@ def assert_successor_auth_usable(config: AgentConfig, *, opener: Any = None) -> 
     usable, kind, reason = probe_credential_usable(credential_path, opener=opener)
     if usable:
         if kind is not None:
-            logger.warning(
-                "restart auth pre-flight for %r: successor credential for "
-                "account %r could not be positively verified (%s: %s) — "
-                "PROCEEDING (fail-open; this is NOT a token rejection, so it "
-                "must not block a healthy restart). If the successor boots "
-                "dead, run `sac accounts refresh %s` and retry.",
+            # NOT A WARNING — this is the HEALTHY path. ``usable`` is True and
+            # the pre-flight is proceeding; the commonest ``kind`` is
+            # ``skipped-token-fresh``, which is the DESIGNED behaviour (probing
+            # would consume the single-use refresh_token and rotate the shared
+            # token for every other agent on the account). Logging correct
+            # operation at WARNING put five alarming lines above every single
+            # restart and trained the reader to skim past the level that is
+            # supposed to mean "look at this". The abort below is where a real
+            # auth failure is reported, and it raises rather than logs.
+            logger.info(
+                "restart auth pre-flight for %r: account %r not probed "
+                "(%s) — proceeding",
                 name,
                 label,
                 kind,
-                reason,
-                label,
             )
         return
 

--- a/src/scitex_agent_container/runtimes/claude_md.py
+++ b/src/scitex_agent_container/runtimes/claude_md.py
@@ -240,14 +240,30 @@ def build_skills_lines(config: AgentConfig) -> list[str]:
 
     def _resolve_warn(name: str) -> list[Path]:
         paths = _resolve_skill(name, roots, strategies, style)
-        if not paths:
-            logger.warning(
-                "skill %r not found under --add-dir roots %s "
-                "(checked name-as-dir <root>/<name>/SKILL.md and "
-                "frontmatter tag match); injection skipped",
+        if paths:
+            return paths
+        if not roots:
+            # A SEARCH WITH NO CORPUS IS NOT A "NOT FOUND". ``roots`` is empty
+            # for every mode except ``at-import``, so this lookup could not
+            # have succeeded for ANY name — warning per skill reports the
+            # skill as missing when the truth is that nothing was searched.
+            # It printed `not found under --add-dir roots []` on every start,
+            # naming the wrong subject and burying the real warnings.
+            logger.debug(
+                "skill %r not resolved: no --add-dir roots to search "
+                "(injection_mode=%r); nothing was searched, so this says "
+                "nothing about whether the skill exists",
                 name,
-                [str(r) for r in roots],
+                mode,
             )
+            return paths
+        logger.warning(
+            "skill %r not found under --add-dir roots %s "
+            "(checked name-as-dir <root>/<name>/SKILL.md and "
+            "frontmatter tag match); injection skipped",
+            name,
+            [str(r) for r in roots],
+        )
         return paths
 
     def _emit_block(heading: str, intro: str, names: list[str]) -> None:


### PR DESCRIPTION
Operator, on a single `sac-restart` transcript: **「きたない！！！！！」**. Two of those lines were not merely verbose — they named the **wrong subject**.

## 1. The auth pre-flight warned on the healthy path

The branch is guarded by `if usable:` — the credential *is* fine and the restart *is* proceeding. The commonest `kind` is `skipped-token-fresh`, which is the **designed** behaviour: probing would consume the single-use `refresh_token` and rotate the shared token for every other agent on that account.

So sac printed five alarming lines above **every** restart — including the words *'PROCEEDING (fail-open; this is NOT a token rejection)'* — to report that everything worked.

A WARNING that fires on success trains the reader to skim past the level that is supposed to mean *look at this*. Demoted to one INFO line. A real auth failure is the `RestartPreflightAbort` directly below it, which **raises**.

## 2. `skill 'scitex-todo' not found under --add-dir roots []`

Note the **empty** roots list. `roots` is `[]` for every `injection_mode` except `at-import`, so that lookup **could not have succeeded for any name**. It reported the skill as *missing* when the truth is that *nothing was searched* — the same shape as a search with an empty corpus reporting `0 hits`.

Now a debug line naming the actual condition. The warning stays for the case it was written for: roots exist and the skill genuinely isn't in them.

## Deliberately untouched

The `[sac:creds]` account-selection block. The operator asked specifically to be able to see **which account** an agent booted on (「1番重要などのアカウントを使ったのかっていうのがわからない」), so that content stays. Routing it through scitex-logging instead of a hand-rolled prefix belongs with the console-API work, not a noise pass.

## Verified by control run

Because *'the failing tests look unrelated'* is not evidence.

| | failed | passed | skipped | errors |
|---|---|---|---|---|
| this branch | 5 | 2636 | 20 | 55 |
| unmodified develop | 5 | 2636 | 20 | 55 |

Identical counts **and** identical test names. This change alters neither.

Those 5 pre-existing failures and 55 errors are not mine and are not tracked anywhere I can find — `test__rename_cards` (2), `test__mcp_spec_env` (1), `test__sdk_common` (2). Raising separately rather than folding them in here.