### PR TITLE
docs(image): the psycopg-gate comment names [all], not the deleted postgres extra

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -585,13 +585,26 @@ failures = []
 # way that actually happened. Measured 2026-08-02: site-packages held a bare
 # ``psycopg/`` directory containing only subdirectories — no ``__init__.py``,
 # no ``*.py``, and NO dist-info anywhere. Leftovers from a package that was
-# never requested: the pin was ``scitex-cards[mcp]``, without the ``postgres``
-# extra that carries ``psycopg[binary]``. Python treats such a directory as a
-# NAMESPACE PACKAGE, so ``import psycopg`` SUCCEEDED, ``psycopg.__file__`` was
-# None and ``psycopg.connect`` did not exist. Every agent then failed its card
-# writes with "canonical store postgresql://... does not exist" — blaming the
-# database for a missing driver, and sending three agents to the wrong layer.
-# An import-only check would have passed on that image.
+# never requested: the pin then was ``scitex-cards[mcp]``, a hand-picked
+# PARTIAL extras set that omitted the driver. Python treats such a directory as
+# a NAMESPACE PACKAGE, so ``import psycopg`` SUCCEEDED, ``psycopg.__file__``
+# was None and ``psycopg.connect`` did not exist. Every agent then failed its
+# card writes with "canonical store postgresql://... does not exist" — blaming
+# the database for a missing driver, and sending three agents to the wrong
+# layer. An import-only check would have passed on that image.
+#
+# THE CURRENT PIN IS ``scitex-cards[all]`` (scitex-dev ADR-0005: extras are a
+# subset of {all, dev, docs}). Do NOT "fix" a future recurrence by naming
+# ``postgres`` — scitex-cards has DELETED mcp/web/currency/postgres and folded
+# them into ``all``, and a pin naming a deleted extra does not fail:
+#
+#     uv pip install --dry-run 'pkg[nonexistent]'
+#     -> warning: does not have an extra named `nonexistent`   EXIT=0
+#
+# Warning, not error. So that pin installs less and SUCCEEDS — reproducing this
+# very outage from the fix rather than the bug. This paragraph exists because
+# the sentence above names ``postgres`` as the thing that was missing, and a
+# reader arriving later would reasonably take that as the remedy.
 try:
     import psycopg as _psycopg
 

--- a/tests/integration/test_apptainer_base_def_scitex_todo.py
+++ b/tests/integration/test_apptainer_base_def_scitex_todo.py
@@ -1,4 +1,14 @@
-"""Static contract: ``apptainer-base.def`` must install scitex-cards[mcp].
+"""Static contract: ``apptainer-base.def`` must install scitex-cards with
+extras that PROVIDE fastmcp and psycopg.
+
+The pin is ``scitex-cards[all]`` (scitex-dev ADR-0005: extras are a subset of
+{all, dev, docs}). This docstring used to say "must install
+scitex-cards[mcp]", which is what the assertions below used to check — and
+both were wrong the moment the fleet moved to ``[all]``. The assertions were
+rewritten to test the CAPABILITY (``extras & {"mcp", "all"}``); this sentence
+was not, and a peer read it and concluded the suite still demanded the deleted
+extras. A stale summary line is as misleading as a stale assertion, and
+cheaper to overlook because nothing executes it.
 
 Package renamed scitex-todo -> scitex-cards (2026-07-16, migration S1-S3).
 The wheel ships BOTH console scripts (``scitex-todo`` and ``scitex-cards``)


### PR DESCRIPTION
A peer flagged that `apptainer-base.def` carries a dated comment explaining the card-store outage, saying the pin *'was `scitex-cards[mcp]`, without the `postgres` extra that carries `psycopg[binary]`'*.

Past tense and accurate about the incident. The problem is what it implies as the **remedy**: scitex-cards has deleted `mcp`/`web`/`currency`/`postgres` and folded them into `all` (scitex-dev ADR-0005 — extras are a subset of `{all, dev, docs}`). A reader arriving after that deletion would pin an extra that no longer exists.

And that failure is **silent**, measured by scitex-cards:

```
uv pip install --dry-run 'pkg[nonexistent]'
  -> warning: does not have an extra named `nonexistent`
  -> EXIT=0
```

Warning, not error. The build succeeds, installs less, and the outage returns **from the fix**.

The comment now states the current pin and says explicitly not to reach for `postgres`. No behaviour change — the pins themselves already read `[all]` at all three sites on develop.

## The general shape, worth keeping

A stale **explanation** next to corrected code outlives the state it describes and reads as current. scitex-cards found this outage's origin was prose in a skill doc rather than a def file — same class. Their detector matching `.md`/`.yml`/`.def`/`.py` for dead-extra pin shapes will catch prose like this too.