### PR TITLE
fix(registry): cleanup_stale deleted the record of every LIVE agent

### DIFF
--- a/src/scitex_agent_container/_state/registry.py
+++ b/src/scitex_agent_container/_state/registry.py
@@ -21,6 +21,44 @@ REGISTRY_DIR = Path(
 )
 
 
+def _default_session_probe(session: str) -> bool | None:
+    """Is ``session`` alive? ``True`` / ``False`` / ``None`` when UNKNOWABLE.
+
+    THREE-VALUED ON PURPOSE. The previous implementation returned a bare bool
+    and treated every failure as "dead", so a host without ``tmux`` on PATH
+    reported every agent gone — ``FileNotFoundError`` is an ``OSError``, and
+    the caller unlinked on ``OSError``. A probe that cannot run must say so,
+    not vote for deletion.
+
+    ``True`` from either multiplexer wins. ``False`` requires a probe that
+    ACTUALLY RAN and reported absence. If neither could run, the answer is
+    ``None`` and the caller keeps the entry.
+    """
+    import subprocess
+
+    verdicts: list[bool] = []
+    # stx-allow: fallback (reason: a missing/failing multiplexer binary is
+    # UNKNOWN, never evidence of death -- see the docstring incident.)
+    try:
+        rc = subprocess.run(
+            ["tmux", "has-session", "-t", session], capture_output=True
+        ).returncode
+        verdicts.append(rc == 0)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        pass
+    try:
+        out = subprocess.run(
+            ["screen", "-ls", session], capture_output=True, text=True
+        ).stdout
+        verdicts.append(session in out)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        pass
+
+    if not verdicts:
+        return None
+    return True if any(verdicts) else False
+
+
 class Registry:
     """File-based registry for tracking running agent instances."""
 
@@ -73,7 +111,10 @@ class Registry:
             try:
                 with open(path) as f:
                     entries.append(json.load(f))
-            except (json.JSONDecodeError, OSError):  # stx-allow: fallback (reason: malformed JSON tolerated)
+            except (
+                json.JSONDecodeError,
+                OSError,
+            ):  # stx-allow: fallback (reason: malformed JSON tolerated)
                 continue
         return entries
 
@@ -81,49 +122,100 @@ class Registry:
         """Check if an agent is registered."""
         return self._path(name).exists()
 
-    def cleanup_stale(self) -> int:
-        """Remove entries whose multiplexer sessions no longer exist.
+    def session_candidates(self, data: dict) -> list[str]:
+        """Every session name this entry could legitimately be running under.
 
-        Probes tmux first (tmux has-session), then screen (-ls).  An entry is
-        removed only when the session is absent from *both* multiplexers.  This
-        makes cleanup safe on mixed fleets where agents may run under either
-        tmux or GNU screen.
+        The stored ``screen`` field holds the BARE agent name, but the runtime
+        creates ``tui-<name>`` (``runtimes.tui_session.session_name_for``, the
+        SSOT). Probing the stored value alone therefore misses EVERY live
+        agent — measured 2026-08-02 on the live host:
+
+            tmux has-session -t scitex-dev      -> not found
+            tmux has-session -t tui-scitex-dev  -> ALIVE
+
+        So resolve through the SSOT and keep the stored value as well, because
+        entries written by older sac versions carry only the bare name. The
+        prefix is NOT hardcoded here: hardcoding ``tui-`` would be the same
+        brittleness pointing the other way, and would break again the next time
+        the runtime renames its sessions.
+        """
+        names: list[str] = []
+        # stx-allow: fallback (reason: a spec that no longer loads, or an entry
+        # written before `config` was recorded, must not make the agent
+        # UNPROBEABLE -- those are exactly the stale-looking entries most at
+        # risk of being swept while alive.)
+        try:
+            from ..config import AgentConfig, load_config
+            from ..runtimes.tui_session import session_name_for
+
+            config_path = str(data.get("config") or "")
+            config = None
+            if config_path:
+                try:
+                    config = load_config(config_path)
+                except Exception:  # stx-allow: fallback (reason: see above)
+                    config = None
+            if config is None and data.get("name"):
+                # Ask the SSOT what it WOULD name this agent's session. Still
+                # no hardcoded prefix here -- session_name_for owns the format,
+                # so a future rename moves this with it.
+                config = AgentConfig(name=str(data["name"]))
+            if config is not None:
+                names.append(session_name_for(config))
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            pass
+        stored = str(data.get("screen") or "")
+        if stored and stored not in names:
+            names.append(stored)
+        return names
+
+    def cleanup_stale(self, *, probe=None) -> int:
+        """Remove entries whose multiplexer sessions are POSITIVELY gone.
+
+        Three-valued by design. Each probe returns True (alive), False (this
+        multiplexer does not have it) or None (could not tell — the binary is
+        missing, or it errored). An entry is unlinked ONLY when every candidate
+        session was positively reported absent by a probe that actually ran.
+
+        An UNKNOWN never deletes. That is the whole point: this sweep used to
+        convert "I could not tell" into "it does not exist", and every consumer
+        downstream — a2a_peers, `sac agents list`, agent_health — inherited that
+        as fact. It cost scitex-cards ~6 messages to an agent that was never
+        unreachable, because they followed the documented procedure and the
+        procedure read a record this sweep had removed.
+
+        ``probe`` is the injection seam: ``(session_name) -> bool | None``.
 
         Returns count removed.
         """
-        import subprocess
-
         if not self.dir.exists():
             return 0
 
-        def _tmux_alive(session: str) -> bool:
-            r = subprocess.run(
-                ["tmux", "has-session", "-t", session],
-                capture_output=True,
-            )
-            return r.returncode == 0
-
-        def _screen_alive(session: str) -> bool:
-            r = subprocess.run(
-                ["screen", "-ls", session],
-                capture_output=True,
-                text=True,
-            )
-            return session in r.stdout
+        probe_fn = probe or _default_session_probe
 
         cleaned = 0
         for path in list(self.dir.glob("*.json")):
+            # stx-allow: fallback (reason: an unreadable entry is UNKNOWN, not
+            # dead. The old code unlinked on OSError -- which meant a missing
+            # tmux binary (FileNotFoundError IS an OSError) deleted the whole
+            # registry. Skip and leave it for a human.)
             try:
                 with open(path) as f:
                     data = json.load(f)
-                session_name = data.get("screen", "")
-                if not session_name:
-                    continue
-                if not _tmux_alive(session_name) and not _screen_alive(session_name):
-                    path.unlink()
-                    cleaned += 1
-            except (json.JSONDecodeError, OSError):  # stx-allow: fallback (reason: malformed JSON tolerated)
-                path.unlink(missing_ok=True)
-                cleaned += 1
+            except Exception:  # stx-allow: fallback (reason: see inline comment)
+                continue
+
+            names = self.session_candidates(data)
+            if not names:
+                continue  # nothing to probe -> UNKNOWN -> keep
+
+            verdicts = [probe_fn(n) for n in names]
+            if any(v is True for v in verdicts):
+                continue  # alive under at least one name
+            if not any(v is False for v in verdicts):
+                continue  # no probe positively said "gone" -> UNKNOWN -> keep
+
+            path.unlink(missing_ok=True)
+            cleaned += 1
 
         return cleaned

--- a/tests/scitex_agent_container/_state/test_registry_cleanup_stale.py
+++ b/tests/scitex_agent_container/_state/test_registry_cleanup_stale.py
@@ -1,0 +1,109 @@
+"""``cleanup_stale`` must not delete the record of a LIVING agent.
+
+MEASURED 2026-08-02 on the live host — the defect these tests pin:
+
+    tmux has-session -t scitex-dev      -> not found
+    tmux has-session -t tui-scitex-dev  -> ALIVE
+
+The registry entry's ``screen`` field holds the BARE agent name while the
+runtime creates ``tui-<name>``, so the old probe returned False for EVERY live
+agent and the sweep unlinked the whole fleet's records. Downstream, a2a_peers /
+``sac agents list`` / agent_health then reported those agents as nonexistent
+rather than unknown — which cost scitex-cards ~6 messages to an agent that was
+never unreachable.
+
+WHY THESE ASSERT PRESENCE, NOT ABSENCE (dotfiles' catch, and it is the point):
+"cleanup_stale removed 0 entries" passes when the fix works, when the sweep
+never ran, when it errored before the removal step, and when it found nothing
+to consider. Four causes, one observation, no discrimination — the same defect
+as a fixture that cannot exercise the failure. So each test demands a specific
+POSITIVE outcome the buggy code cannot produce: the entry SURVIVES a sweep in
+which the probe was actually called with the tui-prefixed name.
+
+PA-307 / STX-TQ002 / STX-TQ007 — one assert per test, full AAA markers.
+"""
+
+from __future__ import annotations
+
+import json
+
+from scitex_agent_container._state.registry import Registry
+
+
+def _write_entry(reg_dir, name: str, screen: str) -> None:
+    """Write a registry entry the way older sac versions did: BARE screen."""
+    (reg_dir / f"{name}.json").write_text(
+        json.dumps({"name": name, "config": "", "pid": 4242, "screen": screen})
+    )
+
+
+def test_live_agent_under_prefixed_session_is_probed_for_that_name(tmp_path):
+    # Arrange — the real fleet shape: entry says "demo", session is "tui-demo".
+    reg = Registry(registry_dir=tmp_path)
+    _write_entry(tmp_path, "demo", "demo")
+    asked: list[str] = []
+
+    def probe(session: str):
+        asked.append(session)
+        return session == "tui-demo"
+
+    # Act
+    reg.cleanup_stale(probe=probe)
+    # Assert — the buggy code asks ONLY "demo" and never the prefixed name.
+    assert "tui-demo" in asked
+
+
+def test_live_agent_under_prefixed_session_survives_the_sweep(tmp_path):
+    # Arrange
+    reg = Registry(registry_dir=tmp_path)
+    _write_entry(tmp_path, "demo", "demo")
+
+    def probe(session: str):
+        return session == "tui-demo"
+
+    # Act
+    reg.cleanup_stale(probe=probe)
+    # Assert — POSITIVE: the record is still there to be read.
+    assert reg.exists("demo")
+
+
+def test_an_unknowable_probe_never_deletes(tmp_path):
+    # Arrange — no multiplexer binary available: every probe returns None.
+    # The old code treated that as death (FileNotFoundError is an OSError and
+    # the caller unlinked on OSError), so an absent tmux wiped the registry.
+    reg = Registry(registry_dir=tmp_path)
+    _write_entry(tmp_path, "demo", "demo")
+
+    def probe(session: str):
+        return None
+
+    # Act
+    reg.cleanup_stale(probe=probe)
+    # Assert
+    assert reg.exists("demo")
+
+
+def test_a_positively_absent_session_is_still_removed(tmp_path):
+    # Arrange — the sweep must keep WORKING; "never delete" would be a gate
+    # that cannot fire, which is the opposite defect.
+    reg = Registry(registry_dir=tmp_path)
+    _write_entry(tmp_path, "demo", "demo")
+
+    def probe(session: str):
+        return False
+
+    # Act
+    reg.cleanup_stale(probe=probe)
+    # Assert
+    assert not reg.exists("demo")
+
+
+def test_unreadable_entry_is_kept_rather_than_unlinked(tmp_path):
+    # Arrange — malformed JSON is UNKNOWN, not dead. The old code deleted it.
+    reg = Registry(registry_dir=tmp_path)
+    (tmp_path / "broken.json").write_text("{not json")
+
+    # Act
+    reg.cleanup_stale(probe=lambda s: False)
+    # Assert
+    assert (tmp_path / "broken.json").exists()


### PR DESCRIPTION
## Measured on the live host

The probe could not see a single running session:

```
tmux has-session -t scitex-dev      -> not found
tmux has-session -t tui-scitex-dev  -> ALIVE
```

The registry entry stores the **bare** agent name in `screen`; the runtime creates `tui-<name>` (`runtimes.tui_session.session_name_for`, the SSOT). `cleanup_stale` probed the stored value, got `False` from both multiplexers for **every** agent, and unlinked the entry. It is dormant in practice, which is the only reason the fleet is not already invisible.

## The severity is the direction of the error

A liveness sweep that cannot see a living session converts *'I could not tell'* into *'it does not exist'*, and every consumer inherits that as fact — `a2a_peers` omits the agent, `sac agents list` omits it, `agent_health` says 'not found in registry'.

That cost scitex-cards **~6 messages today** to an agent that was never unreachable. They followed the tool's own documented procedure (*'check inbox_subscribers via a2a_peers before handing work to a peer'*) and the procedure read a swept record.

## A second deletion path, worse and easy to miss

The old code unlinked on `OSError`. `FileNotFoundError` **is** an `OSError`, so a host without `tmux` on PATH deleted the **entire registry** — the probe failing to run voted for death.

## Three changes

- `session_candidates()` resolves through `session_name_for`, falling back to a minimal `AgentConfig` built from the entry name when the spec won't load — those entries are exactly the ones most at risk. **The prefix is not hardcoded**; the SSOT owns the format, so a future rename moves with it. The stored value is still probed, for entries written by older versions.
- The probe is **three-valued**: `True` / `False` / `None`. `None` means it could not run, and an unknown never deletes.
- An unreadable entry is kept, not unlinked.

## Tests assert presence, not absence

dotfiles caught my first accepting test — *'cleanup_stale removes 0 entries'* — as an absence claim that passes when the sweep never ran, when it errored, and when it found nothing to consider. Four causes, one observation, no discrimination.

Each test now demands a positive outcome the buggy code **cannot** produce: that the prefixed name was actually **probed**, and that the entry **survived**. Plus the converse — a positively-absent session is still removed, so this doesn't become a gate that cannot fire.

**1150 passed** in `tests/scitex_agent_container/_state/`.