### PR TITLE
fix(image): pin scitex-cards bare at >=0.32.0 and assert the capability, not the extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **The container defs pin `scitex-cards>=0.32.0`, BARE.** scitex-cards moved
+  psycopg, django and fastmcp into core, so there is no extras subset left to
+  pick wrong — which is what took the fleet's board down twice. Verified against
+  published PyPI metadata rather than the release notes: `psycopg[binary]>=3.1`,
+  `django>=4.2` and `fastmcp>=2.0` are all `CORE=True` at 0.32.0.
+
+  **The floor is 0.32.0 and not lower on purpose.** psycopg became core in
+  0.31.8, not 0.31.6 — a peer stated 0.31.6 and measuring says otherwise, and a
+  bare pin at that floor would resolve a version with NO DRIVER and succeed.
+  Same failure, arrived at from the fix.
+
+  The def contract tests now assert the capability by EITHER route: a
+  qualifying extra, or a floor at-or-above the release where the dep became
+  core. This file's assertions have now been wrong three times in one day —
+  `"scitex-cards[mcp]" in block` (freezes the extras list to exactly `[mcp]`),
+  `"postgres" in extras` (calls `[all]` a regression), and
+  `extras & {"mcp","all"}` (correct for extras, blind to the pin going bare).
+  Each encoded a spelling, so each went red exactly when someone fixed
+  something. The predicate now has its own rejection cases — `[mcp]>=0.19.0`,
+  bare `>=0.31.6`, bare `>=0.31.7`, bare unpinned — so "provides psycopg" is
+  demonstrably able to say no.
+
 ## [0.24.22] - 2026-08-02
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.22"
+version = "0.24.23"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -481,7 +481,7 @@ From: ubuntu:24.04
     uv pip install --no-cache --python /opt/venv-sac/bin/python -U \
         --reinstall-package scitex-agent-container \
         "claude-agent-sdk" \
-        "scitex-cards[all]>=0.31.6" \
+        "scitex-cards>=0.32.0" \
         "/opt/scitex-agent-container-src[openai]"
 
     # ---- 6c. FAIL-LOUD staleness gate — assert BY SYMBOL --------------
@@ -593,18 +593,31 @@ failures = []
 # the database for a missing driver, and sending three agents to the wrong
 # layer. An import-only check would have passed on that image.
 #
-# THE CURRENT PIN IS ``scitex-cards[all]`` (scitex-dev ADR-0005: extras are a
-# subset of {all, dev, docs}). Do NOT "fix" a future recurrence by naming
-# ``postgres`` — scitex-cards has DELETED mcp/web/currency/postgres and folded
-# them into ``all``, and a pin naming a deleted extra does not fail:
+# THE CURRENT PIN IS BARE: ``scitex-cards>=0.32.0``. As of 0.32.0 psycopg,
+# django and fastmcp are CORE dependencies — verified against the published
+# metadata, not the changelog:
+#
+#     psycopg   CORE=True   psycopg[binary]>=3.1
+#     django    CORE=True   django>=4.2
+#     fastmcp   CORE=True   fastmcp>=2.0
+#
+# so a bare install yields a complete client and there is no extras subset left
+# to pick wrong. The floor is 0.32.0 and NOT lower on purpose: psycopg only
+# became core in 0.31.8, so a bare pin admitting 0.31.6/0.31.7 would install NO
+# DRIVER and succeed.
+#
+# Do NOT "fix" a future recurrence by naming ``postgres`` or ``all``. A pin
+# naming an extra that no longer exists does not fail:
 #
 #     uv pip install --dry-run 'pkg[nonexistent]'
 #     -> warning: does not have an extra named `nonexistent`   EXIT=0
 #
 # Warning, not error. So that pin installs less and SUCCEEDS — reproducing this
 # very outage from the fix rather than the bug. This paragraph exists because
-# the sentence above names ``postgres`` as the thing that was missing, and a
-# reader arriving later would reasonably take that as the remedy.
+# the sentences above name ``mcp``/``postgres`` as things that were missing,
+# and a reader arriving later would reasonably take those as the remedy. This
+# comment has already gone stale twice in one day; if you change the pin,
+# change this too.
 try:
     import psycopg as _psycopg
 

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -294,7 +294,7 @@ From: ./sac-base.sif
         # multi-tenant mount). Verified in the artifact: the 0.19.0 wheel has 0
         # occurrences of that fallback, the copy in the CURRENT image has 1.
         uv pip install --python /opt/venv-sac/bin/python -U \
-            "scitex-cards[all]>=0.31.6"
+            "scitex-cards>=0.32.0"
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             pip setuptools wheel
@@ -365,7 +365,7 @@ From: ./sac-base.sif
         # databases, and >=0.19.0 is strictly stronger than the >=0.17.2 that
         # was guarding against it.
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
-            "scitex-cards[all]>=0.31.6"
+            "scitex-cards>=0.32.0"
     fi
 
     # ---- 2b. FAIL-LOUD staleness gate — assert BY SYMBOL ----------------

--- a/tests/integration/test_apptainer_base_def_scitex_todo.py
+++ b/tests/integration/test_apptainer_base_def_scitex_todo.py
@@ -1,14 +1,17 @@
-"""Static contract: ``apptainer-base.def`` must install scitex-cards with
-extras that PROVIDE fastmcp and psycopg.
+"""Static contract: ``apptainer-base.def``'s scitex-cards install must PROVIDE
+fastmcp and psycopg — by an extra, or by core at a high enough floor.
 
-The pin is ``scitex-cards[all]`` (scitex-dev ADR-0005: extras are a subset of
-{all, dev, docs}). This docstring used to say "must install
-scitex-cards[mcp]", which is what the assertions below used to check — and
-both were wrong the moment the fleet moved to ``[all]``. The assertions were
-rewritten to test the CAPABILITY (``extras & {"mcp", "all"}``); this sentence
-was not, and a peer read it and concluded the suite still demanded the deleted
-extras. A stale summary line is as misleading as a stale assertion, and
-cheaper to overlook because nothing executes it.
+The pin is BARE: ``scitex-cards>=0.32.0``. Both deps are core from 0.32.0
+(psycopg from 0.31.8), so there is no extras subset left to pick wrong, and the
+floor is what carries the guarantee.
+
+This docstring has been WRONG THREE TIMES: it said "must install
+scitex-cards[mcp]", then "the pin is ``scitex-cards[all]``", each time
+outliving the assertions below by hours. Once, a peer read the stale line and
+concluded the suite still demanded a deleted extra. A stale summary is as
+misleading as a stale assertion and cheaper to overlook, because nothing
+executes it — so state the PROPERTY (provides fastmcp + psycopg) and mention
+today's spelling only as an example.
 
 Package renamed scitex-todo -> scitex-cards (2026-07-16, migration S1-S3).
 The wheel ships BOTH console scripts (``scitex-todo`` and ``scitex-cards``)
@@ -151,44 +154,77 @@ def _requirement_extras(requirement: str) -> set[str]:
     return {part.strip() for part in inner.split(",") if part.strip()}
 
 
-# Extras sets that PROVIDE each capability, per scitex-cards' published
-# metadata. Assert the CAPABILITY, never the spelling: the fleet convention
-# moved from hand-picked sets to ``[all]`` on 2026-08-02, and a test naming one
-# spelling calls the other a regression. This file has now had that bug twice
-# — first as `"scitex-cards[mcp]" in block`, then as `"postgres" in extras` —
-# so the third version pins what the image must be ABLE to do.
+# A capability can be provided TWO ways: by an extra, or by CORE at a
+# sufficient floor. Asserting only the extras spelling has now failed this file
+# THREE times in one day:
+#   1. `"scitex-cards[mcp]" in block`  -- froze the extras list to exactly [mcp];
+#      adding `postgres` turned a correct change red
+#   2. `"postgres" in extras`          -- my replacement; then called `[all]`
+#      a regression for the same reason
+#   3. `extras & {"mcp","all"}`        -- correct for extras, and blind to the
+#      pin going BARE when 0.32.0 moved the deps to core
+# So the fourth version asks the real question: WILL THIS INSTALL PROVIDE THE
+# CAPABILITY -- from an extra, or from core because the floor is high enough.
 _EXTRAS_PROVIDING_FASTMCP = {"mcp", "all"}
 _EXTRAS_PROVIDING_PSYCOPG = {"postgres", "all"}
+
+#: scitex-cards versions at which each dep became a CORE requirement, verified
+#: against published PyPI metadata rather than the changelog. psycopg went core
+#: in 0.31.8 -- NOT 0.31.6, which is what a peer told me and what would have
+#: made a bare pin admit two driverless versions.
+_CORE_SINCE_FASTMCP = (0, 32, 0)
+_CORE_SINCE_PSYCOPG = (0, 31, 8)
+
+
+def _provides(requirement: str, extras_providing: set[str], core_since) -> bool:
+    """Does this requirement deliver the capability, by EITHER route?
+
+    Reuses ``_requirement_floor`` deliberately. A second, local floor parser is
+    how ">=0.32" would compare LESS than (0, 32, 0) — the padding bug that
+    function already carries a comment about. One parser, one behaviour.
+    """
+    if _requirement_extras(requirement) & extras_providing:
+        return True
+    floor = _requirement_floor(requirement)
+    return floor is not None and floor >= core_since
 
 
 def test_uv_pip_install_block_can_provide_fastmcp(base_def_text: str) -> None:
     # Arrange
     block = _uv_pip_install_block(base_def_text)
+    requirement = _scitex_todo_requirement(block)
     # Act
-    extras = _requirement_extras(_scitex_todo_requirement(block))
+    provided = _provides(requirement, _EXTRAS_PROVIDING_FASTMCP, _CORE_SINCE_FASTMCP)
     # Assert
-    assert extras & _EXTRAS_PROVIDING_FASTMCP, (
-        "scitex-cards install must carry an extra that pulls fastmcp>=2.0 "
-        f"(any of {sorted(_EXTRAS_PROVIDING_FASTMCP)}) in apptainer-base.def; "
-        f"got extras {sorted(extras)} in:\n{block}"
+    assert provided, (
+        "scitex-cards install must PROVIDE fastmcp — via an extra "
+        f"{sorted(_EXTRAS_PROVIDING_FASTMCP)} or a floor >= "
+        f"{'.'.join(map(str, _CORE_SINCE_FASTMCP))} where it is core. "
+        f"Got {requirement!r} in:\n{block}"
     )
 
 
 def test_uv_pip_install_block_can_provide_psycopg(base_def_text: str) -> None:
-    # Arrange — the cards store is PostgreSQL. With no psycopg-providing extra
-    # there is no driver in the image and EVERY agent's card writes fail,
-    # reported as "canonical store ... does not exist" — naming the database,
-    # which is fine. Measured 2026-08-02: the pin was [mcp] only, and
-    # site-packages held a bare psycopg/ directory with no __init__.py, which
-    # imports as a NAMESPACE PACKAGE and exposes no .connect, so an
-    # import-guarded check passed while the fleet's board was unreachable.
+    # Arrange — the cards store is PostgreSQL. Without a driver EVERY agent's
+    # card writes fail, reported as "canonical store ... does not exist" —
+    # naming the database, which is fine. Measured 2026-08-02: the pin was
+    # [mcp] only, and site-packages held a bare psycopg/ directory with no
+    # __init__.py, which imports as a NAMESPACE PACKAGE and exposes no
+    # .connect, so an import-guarded check passed while the board was down.
+    #
+    # The floor matters as much as the extra here: psycopg became core in
+    # 0.31.8, so a BARE pin of >=0.31.6 would resolve a driverless version and
+    # succeed. That is why this asserts the floor and not merely bareness.
     block = _uv_pip_install_block(base_def_text)
+    requirement = _scitex_todo_requirement(block)
     # Act
-    extras = _requirement_extras(_scitex_todo_requirement(block))
+    provided = _provides(requirement, _EXTRAS_PROVIDING_PSYCOPG, _CORE_SINCE_PSYCOPG)
     # Assert
-    assert extras & _EXTRAS_PROVIDING_PSYCOPG, (
-        "scitex-cards install must carry an extra that pulls "
-        f"psycopg[binary]>=3.1 (any of {sorted(_EXTRAS_PROVIDING_PSYCOPG)}) in "
+    assert provided, (
+        "scitex-cards install must PROVIDE psycopg — via an extra "
+        f"{sorted(_EXTRAS_PROVIDING_PSYCOPG)} or a floor >= "
+        f"{'.'.join(map(str, _CORE_SINCE_PSYCOPG))} where it is core. "
+        f"Got {requirement!r} in:\n{block}. Old form kept for reference: "
         f"apptainer-base.def; got extras {sorted(extras)} in:\n{block}"
     )
 
@@ -274,3 +310,47 @@ def test_requirement_floor_rejects_unpinned_or_pre_wip_gate(requirement: str) ->
     floor = _requirement_floor(requirement)
     # Assert
     assert floor is None or floor < minimum, requirement
+
+
+# ---------------------------------------------------------------------------
+# ...and the CAPABILITY predicate itself. Without these, "provides psycopg"
+# passes for the same reason the fixture-that-cannot-fail passes: nothing
+# demonstrates the predicate can say NO. The rejection cases below are the ones
+# that actually shipped the outage.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "requirement",
+    [
+        "scitex-cards>=0.32.0",  # today's bare pin — psycopg is core
+        "scitex-cards>=0.31.8",  # the release psycopg became core in
+        "scitex-cards[postgres]>=0.20.0",  # the old extras route
+        "scitex-cards[all]>=0.31.6",  # the interim [all] pin
+    ],
+)
+def test_provides_psycopg_accepts_extras_or_a_core_floor(requirement: str) -> None:
+    # Arrange
+    providing = _EXTRAS_PROVIDING_PSYCOPG
+    # Act
+    provided = _provides(requirement, providing, _CORE_SINCE_PSYCOPG)
+    # Assert
+    assert provided, requirement
+
+
+@pytest.mark.parametrize(
+    "requirement",
+    [
+        "scitex-cards[mcp]>=0.19.0",  # THE OUTAGE: mcp only, no driver
+        "scitex-cards>=0.31.6",  # bare but BELOW core — driverless
+        "scitex-cards>=0.31.7",  # ditto, the release right before
+        "scitex-cards",  # bare and unpinned — resolves to anything
+    ],
+)
+def test_provides_psycopg_rejects_a_driverless_install(requirement: str) -> None:
+    # Arrange
+    providing = _EXTRAS_PROVIDING_PSYCOPG
+    # Act
+    provided = _provides(requirement, providing, _CORE_SINCE_PSYCOPG)
+    # Assert
+    assert not provided, requirement


### PR DESCRIPTION
## What

All three container-def install sites pin `scitex-cards>=0.32.0` **bare** —
no extras.

| site | before | after |
|---|---|---|
| `apptainer-base.def:484` | `scitex-cards[all]>=0.31.6` | `scitex-cards>=0.32.0` |
| `apptainer-scitex.def:297` (uv) | `scitex-cards[all]>=0.31.6` | `scitex-cards>=0.32.0` |
| `apptainer-scitex.def:368` (pip fallback) | `scitex-cards[all]>=0.31.6` | `scitex-cards>=0.32.0` |

## Why

scitex-cards 0.32.0 moves psycopg, django and fastmcp into **core**, so the
extras subset that took the fleet's card board down twice no longer exists to be
picked wrong. Verified against published PyPI metadata rather than the release
notes:

```
latest on PyPI: 0.32.0
psycopg   CORE=True  ['psycopg[binary]>=3.1']
django    CORE=True  ['django>=4.2']
fastmcp   CORE=True  ['fastmcp>=2.0']
```

### The floor is 0.32.0 and not lower on purpose

psycopg became core in **0.31.8**. A peer stated 0.31.6; measuring 0.31.6 and
0.31.7 gives `CORE=False`. A bare pin admitting those resolves an install with
**no driver** and exits 0 — the same outage, arrived at from the fix. That is
also why the test asserts a floor and not merely "the pin is bare".

## The contract tests

They now ask whether the requirement **provides** each capability by either
route: a qualifying extra, **or** a floor at-or-above the release where the dep
became core.

These assertions have now been wrong three times in one day, each time by
encoding a spelling instead of a property:

1. `"scitex-cards[mcp]" in block` — reads as "carries the mcp extra", actually
   freezes the extras list to exactly `[mcp]`; adding `postgres` turned a
   correct change red.
2. `"postgres" in extras` — my replacement; then called `[all]` a regression for
   the same reason.
3. `extras & {"mcp","all"}` — correct for extras, and blind to the pin going
   bare.

So the predicate now carries its own rejection cases — `[mcp]>=0.19.0` (the
outage), bare `>=0.31.6`, bare `>=0.31.7`, bare unpinned — because "provides
psycopg" passing proves nothing unless it can be shown to say **no**.

The `apptainer-base.def` comment block naming the current pin is rewritten for
the third time today. It now says that, and says to change it with the pin.

## Verification

```
22 passed in tests/integration/test_apptainer_base_def_scitex_todo.py
```

Post-merge this needs a release + host `deploy-freshness` + SIF rebake before
any agent sees it; the images are what actually install the pin.
