### PR TITLE
fix(start): refuse to launch an agent whose console script does not run

### DIFF
--- a/src/scitex_agent_container/runtimes/_entry_point_gate.py
+++ b/src/scitex_agent_container/runtimes/_entry_point_gate.py
@@ -1,0 +1,203 @@
+"""Start-time gate: the console scripts must RUN in the union the agent gets.
+
+MEASURED 2026-08-03. scitex-hub's a2a inbox rail was dead from 2026-07-18 to
+2026-08-03 -- sixteen days -- because three console-script wrappers were masked
+in its overlay::
+
+    <overlay>/upper/opt/venv-sac/bin/sac                     char device 0:0
+    <overlay>/upper/opt/venv-sac/bin/sac-statusline          char device 0:0
+    <overlay>/upper/opt/venv-sac/bin/scitex-agent-container  char device 0:0
+
+Deleting a file that exists in the LOWER layer does not remove it; overlayfs
+writes a name-specific WHITEOUT that hides the lower copy permanently. The SIF
+shipped all three the whole time and `sac --version` exited 0 inside it. Only
+the union was broken, and the union is what the agent runs in.
+
+WHY THE EXISTING GATES COULD NOT SEE IT, both of them:
+
+* ``containers/sif_symbol_probe.py`` runs at BAKE time, inside the SIF, with no
+  overlay. It was GREEN for all sixteen days, correctly, about a different
+  filesystem than the one that was broken.
+* Any check of the form ``import scitex_agent_container`` is blind here by
+  construction. site-packages was intact and the dist metadata still DECLARED
+  both console scripts; the package imported perfectly. The failure is
+  "importable but not invokable" -- one layer below what an import observes.
+
+That is the same shape as the psycopg hole the day before, where a bare
+``psycopg/`` directory with no ``__init__.py`` imported as a NAMESPACE PACKAGE
+and ``hasattr(psycopg, "connect")`` was True with no driver underneath. Twice in
+two days a gate sat one layer above the thing that actually breaks.
+
+So this gate asserts the ENTRY POINT RUNS, and asserts it against the sif +
+overlay union rather than the image.
+
+THE PROBE ARGV IS DERIVED FROM THE REAL LAUNCH ARGV, deliberately. Rebuilding
+the apptainer preamble here would create a second copy of the overlay/bind/
+isolation logic, free to drift from the one that launches the agent -- and a
+probe that measures a DIFFERENT union than the agent runs in is worse than no
+probe, because it reports on a filesystem nobody uses. Reusing the launch argv
+makes divergence impossible: same flags, same overlay, same image, by
+construction rather than by discipline.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+# Probe timeout. Generous: the first exec of a cold SIF pays a mount cost, and
+# a probe that times out on a slow host would be reported as UNKNOWN anyway.
+PROBE_TIMEOUT_S = 120
+
+#: Set to ``"1"`` to skip the gate. Deliberately an OVERRIDE rather than a
+#: default-off knob — the hazard belongs in the escape hatch, not in the
+#: declaration, so nobody disables this by merely not knowing about it.
+SKIP_ENV_VAR = "SAC_SKIP_ENTRY_POINT_GATE"
+
+#: The ONLY exit codes that are evidence about the SCRIPT rather than about
+#: apptainer. POSIX shells use 127 for "command not found" and 126 for "found
+#: but not executable" — precisely the two states a masked wrapper produces.
+#: Every other non-zero code (255 for a missing image, mount failures, an
+#: overlay that will not attach) is a fault in the CONTAINER, with a different
+#: repair, and must never be reported as a missing console script.
+COMMAND_NOT_FOUND_CODES = (126, 127)
+
+# The console script whose absence silently kills the agent's rails. `sac mcp
+# start` (the MCP server) and `sac mcp channel` (the inbox adapter) are both
+# spawned through this wrapper, so when it is missing the agent boots, works,
+# and is unreachable -- which is exactly how hub went sixteen days unnoticed.
+DEFAULT_CONSOLE_SCRIPT = "/opt/venv-sac/bin/sac"
+
+_SIF_SUFFIX = ".sif"
+
+
+class EntryPointGateError(RuntimeError):
+    """A console script does not run in the union this agent will launch in.
+
+    Carries the repair, not just the complaint -- the constitution's
+    fail-fast/fail-loud/actionable-hint contract. Raised BEFORE the session
+    starts, so the operator sees this instead of an agent that comes up
+    healthy-looking and answers nobody.
+    """
+
+
+def probe_argv_from_launch(
+    launch_argv: list[str],
+    *,
+    script: str = DEFAULT_CONSOLE_SCRIPT,
+) -> list[str]:
+    """Derive an entry-point probe argv from the agent's REAL launch argv.
+
+    Keeps the apptainer preamble up to and including the ``.sif`` -- which is
+    what carries ``--overlay``, the binds and the isolation flags -- and
+    replaces the inner command with ``<script> --version``.
+
+    Returns ``[]`` when no ``.sif`` appears in ``launch_argv``: with no image
+    there is no union to probe, and a probe that cannot run must say so rather
+    than invent a command. The caller treats empty as UNKNOWN, never as a pass.
+    """
+    argv = [str(a) for a in (launch_argv or [])]
+    for i, arg in enumerate(argv):
+        if arg.endswith(_SIF_SUFFIX):
+            return [*argv[: i + 1], script, "--version"]
+    return []
+
+
+def entry_point_violation(
+    launch_argv: list[str],
+    *,
+    runner,
+    script: str = DEFAULT_CONSOLE_SCRIPT,
+) -> str | None:
+    """``None`` when the console script runs; an actionable message when not.
+
+    ``runner`` is the injection seam: ``(argv) -> returncode``. Three-valued in
+    spirit -- an UNPROBEABLE launch argv (no image) returns ``None`` rather than
+    a violation, because "I could not look" must never be reported as "it is
+    broken". Only a probe that ACTUALLY RAN and came back non-zero accuses.
+    """
+    probe = probe_argv_from_launch(launch_argv, script=script)
+    if not probe:
+        return None
+
+    returncode = runner(probe)
+    if returncode == 0:
+        return None
+    if returncode not in COMMAND_NOT_FOUND_CODES:
+        # EXIT-CODE COLLISION, and it is the whole reason this branch exists.
+        # `apptainer exec` returns the INNER command's status on success, but
+        # its OWN failures (image missing, mount error, overlay unavailable)
+        # arrive as non-zero too -- 255, typically. Reading "non-zero" as "the
+        # wrapper is gone" therefore accuses the console script whenever
+        # apptainer merely could not run, which is a different fault with a
+        # different repair. Measured: the tui_session suite injects a
+        # deterministic fake argv naming an image that does not exist, and the
+        # first version of this gate refused 29 legitimate starts on exit 255.
+        # Only "command not found / not executable" is evidence about the
+        # SCRIPT; everything else is UNKNOWN and must not accuse.
+        logger.info(
+            "entry-point probe inconclusive (exit %s, not a not-found code): %s",
+            returncode,
+            probe,
+        )
+        return None
+
+    return (
+        f"{script} does not run in this agent's sif+overlay union "
+        f"(exit {returncode}). The package can be perfectly installed and still "
+        f"fail this way: an overlay whiteout masks the image's copy by NAME, so "
+        f"site-packages stays intact, `import scitex_agent_container` succeeds, "
+        f"and the wrapper is gone. That kills `sac mcp start` and "
+        f"`sac mcp channel`, so the agent boots, looks healthy, and answers "
+        f"nobody on the a2a inbox rail.\n"
+        f"REPAIR: look for character-device whiteouts in the overlay's upper "
+        f"layer at <overlay>/upper/opt/venv-sac/bin/ "
+        f"(`find <upper>/opt/venv-sac/bin -maxdepth 1 -type c`). Deleting those "
+        f"entries unmasks the image's originals -- which is a REVEAL, not a "
+        f"write, so it adds no overlay drift for a future rebake to fight. "
+        f"Verify with `{script} --version` returning 0.\n"
+        f"Probe argv: {probe}"
+    )
+
+
+def _subprocess_runner(probe_argv: list[str]) -> int:
+    return subprocess.run(
+        probe_argv, capture_output=True, timeout=PROBE_TIMEOUT_S
+    ).returncode
+
+
+def assert_entry_point_runs(agent_name: str, launch_argv: list[str], *, runner=None):
+    """Refuse to launch an agent whose console script does not run.
+
+    RAISES rather than logs, deliberately. Logging would reproduce the very
+    failure being prevented: the agent starts, every liveness probe calls it
+    healthy, and it answers nobody — scitex-hub sat in exactly that state for
+    sixteen days while its warning-shaped evidence sat in a log.
+
+    Refusing is safe BY CONSTRUCTION here, because the underlying check is
+    three-valued. An unprobeable launch argv yields no violation, and a probe
+    that raises is caught below and treated as UNKNOWN. Only a probe that
+    ACTUALLY RAN and returned non-zero can refuse a start — so a bug in the
+    probe itself cannot brick the fleet, which is the failure mode that makes
+    start-time gates dangerous.
+    """
+    if os.environ.get(SKIP_ENV_VAR) == "1":
+        logger.info("entry-point gate skipped for %r via %s", agent_name, SKIP_ENV_VAR)
+        return
+
+    try:
+        violation = entry_point_violation(
+            launch_argv, runner=runner or _subprocess_runner
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        # A probe that ERRORS is UNKNOWN, never a verdict. Treating a timeout
+        # or a missing apptainer as "the wrapper is gone" would refuse every
+        # start on this host — a gate more dangerous than the fault it guards.
+        logger.info("entry-point gate could not run for %r: %s", agent_name, exc)
+        return
+
+    if violation:
+        raise EntryPointGateError(f"{agent_name}: {violation}")

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -32,15 +32,15 @@ from .._runners._tmux.tmux import (
 )
 from ..config import AgentConfig
 from ._apptainer_build_argv import build_run_argv
+from ._tui_auth_stage import TuiAuthStageError
+from ._tui_boot_drain import TuiBootDrainMixin
+from ._tui_bridge_seam import TurnBridgeSeamMixin
 from ._tui_compose import (
     _compose_pending_live,
     clear_compose_buffer,
     verify_submit_by_advancement,
 )
 from ._tui_drain import drain_modals_until_ready
-from ._tui_auth_stage import TuiAuthStageError
-from ._tui_boot_drain import TuiBootDrainMixin
-from ._tui_bridge_seam import TurnBridgeSeamMixin
 from ._tui_inject import StartupPromptInjectorMixin
 from ._tui_liveness import (
     is_responsive_from_activity,
@@ -205,9 +205,7 @@ class TuiSessionRuntime(
         for the per-step rationale (SDK-parity $HOME surface, settings.json USER
         scope, overlay upper-home, onboarding pre-seed).
         """
-        return _materialize_workspace(
-            config, state_dir_for_config=state_dir_for_config
-        )
+        return _materialize_workspace(config, state_dir_for_config=state_dir_for_config)
 
     def start(
         self,
@@ -290,6 +288,14 @@ class TuiSessionRuntime(
             state_dir.mkdir(parents=True, exist_ok=True)
             write_redacted_argv(state_dir / "apptainer_run.argv.txt", argv)
             return True
+
+        # The console script must RUN in the union we are about to launch, not
+        # merely import in the image. Called after argv exists (so the probe
+        # inherits the real overlay) and after the dry-run return (so
+        # ``--dry-run`` stays subprocess-free).
+        from ._entry_point_gate import assert_entry_point_runs
+
+        assert_entry_point_runs(config.name, argv)
 
         # The host workdir is only the tmux launch cwd — the agent's real cwd is
         # ``--pwd`` inside the SIF; no session HOME/env (the container sets its own).

--- a/tests/scitex_agent_container/runtimes/test__entry_point_gate.py
+++ b/tests/scitex_agent_container/runtimes/test__entry_point_gate.py
@@ -1,0 +1,223 @@
+"""The entry-point gate must observe the UNION, and must be able to say NO.
+
+Pins the 2026-08-03 incident: scitex-hub's a2a inbox rail was dead for sixteen
+days because three console-script wrappers were masked by overlay whiteouts.
+The SIF shipped them and `import scitex_agent_container` succeeded throughout,
+so every gate that existed was green about a filesystem that was not broken.
+
+Two properties carry the weight here, and neither is "it returns None":
+
+1. THE PROBE MEASURES THE SAME UNION THE AGENT LAUNCHES IN. A probe that
+   rebuilt the apptainer preamble itself could drift from the real launch and
+   report on an overlay nobody runs in. So the tests assert the probe inherits
+   the launch argv's `--overlay` value, not merely that a probe was produced.
+
+2. THE GATE CAN FIRE. "violation is None" passes when the gate works, when it
+   never ran, and when it cannot fail -- three causes, one observation. So a
+   non-zero runner must produce an accusation naming the repair.
+
+No mocks: `runner` is a plain injected callable, the same seam used by
+`Registry.cleanup_stale(probe=...)`.
+
+PA-307 / STX-TQ002 / STX-TQ007 -- one assert per test, full AAA markers.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.runtimes._entry_point_gate import (
+    DEFAULT_CONSOLE_SCRIPT,
+    EntryPointGateError,
+    assert_entry_point_runs,
+    entry_point_violation,
+    probe_argv_from_launch,
+)
+
+# A realistic launch argv: isolation flags, the overlay that actually broke
+# hub, the image, then the inner command the probe must REPLACE.
+_OVERLAY = "/home/ywatanabe/.scitex/agent-container/containers/overlays/scitex-hub/"
+_SIF = "/home/ywatanabe/.scitex/.../sac-base-2026-0802-225220.sif"
+_LAUNCH = [
+    "apptainer",
+    "exec",
+    "--containall",
+    "--overlay",
+    _OVERLAY,
+    _SIF,
+    "claude",
+    "--dangerously-skip-permissions",
+]
+
+
+def _runner_returning(code: int):
+    """A probe runner that reports ``code`` and records what it was asked."""
+
+    calls: list[list[str]] = []
+
+    def runner(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return code
+
+    runner.calls = calls  # type: ignore[attr-defined]
+    return runner
+
+
+def test_probe_inherits_the_launch_overlay():
+    # Arrange — the whiteout lives in the OVERLAY; a probe that dropped this
+    # flag would exercise the pristine image and pass while the agent is broken.
+    launch = list(_LAUNCH)
+    # Act
+    probe = probe_argv_from_launch(launch)
+    # Assert
+    assert _OVERLAY in probe
+
+
+def test_probe_keeps_the_image_it_was_given():
+    # Arrange
+    launch = list(_LAUNCH)
+    # Act
+    probe = probe_argv_from_launch(launch)
+    # Assert
+    assert _SIF in probe
+
+
+def test_probe_replaces_the_inner_command_with_the_console_script():
+    # Arrange — the agent's own command must NOT run; this is a probe.
+    launch = list(_LAUNCH)
+    # Act
+    probe = probe_argv_from_launch(launch)
+    # Assert
+    assert probe[-2:] == [DEFAULT_CONSOLE_SCRIPT, "--version"]
+
+
+def test_probe_does_not_carry_the_agents_own_command():
+    # Arrange
+    launch = list(_LAUNCH)
+    # Act
+    probe = probe_argv_from_launch(launch)
+    # Assert
+    assert "claude" not in probe
+
+
+def test_an_argv_with_no_image_is_unprobeable():
+    # Arrange — nothing to mount means nothing to measure.
+    launch = ["apptainer", "exec", "--containall"]
+    # Act
+    probe = probe_argv_from_launch(launch)
+    # Assert
+    assert probe == []
+
+
+def test_a_working_console_script_is_not_a_violation():
+    # Arrange
+    runner = _runner_returning(0)
+    # Act
+    violation = entry_point_violation(_LAUNCH, runner=runner)
+    # Assert
+    assert violation is None
+
+
+def test_the_gate_actually_runs_the_probe():
+    # Arrange — "no violation" must come from EXERCISING the union, not from
+    # inspecting the argv's shape. If the runner is never called, the gate is
+    # deciding on paper.
+    runner = _runner_returning(0)
+    # Act
+    entry_point_violation(_LAUNCH, runner=runner)
+    # Assert
+    assert runner.calls == [[*_LAUNCH[:6], DEFAULT_CONSOLE_SCRIPT, "--version"]]
+
+
+def test_a_missing_console_script_is_a_violation():
+    # Arrange — THE MUTATION PROOF. Exit 127 is what a masked wrapper gives.
+    runner = _runner_returning(127)
+    # Act
+    violation = entry_point_violation(_LAUNCH, runner=runner)
+    # Assert
+    assert violation is not None
+
+
+def test_the_violation_names_the_whiteout_repair():
+    # Arrange — a gate that fires without naming the fix costs the next reader
+    # the same sixteen days of diagnosis.
+    runner = _runner_returning(127)
+    # Act
+    violation = entry_point_violation(_LAUNCH, runner=runner)
+    # Assert
+    assert "whiteout" in violation
+
+
+def test_an_unprobeable_launch_never_accuses():
+    # Arrange — no image: the probe cannot run. "I could not look" must not be
+    # reported as "it is broken"; the same tri-state rule that stopped the
+    # registry sweep from deleting live agents.
+    runner = _runner_returning(127)
+    # Act
+    violation = entry_point_violation(["apptainer", "exec"], runner=runner)
+    # Assert
+    assert violation is None
+
+
+# ---------------------------------------------------------------------------
+# The wired gate. An unwired checker is a remedy written, not exercised — the
+# start path must actually REFUSE, because a log line would reproduce the exact
+# failure being prevented (an agent that looks healthy and answers nobody).
+# ---------------------------------------------------------------------------
+
+
+def test_the_gate_refuses_a_start_when_the_console_script_is_missing():
+    # Arrange
+    runner = _runner_returning(127)
+    raised = None
+    # Act
+    try:
+        assert_entry_point_runs("scitex-hub", _LAUNCH, runner=runner)
+    except EntryPointGateError as exc:
+        raised = exc
+    # Assert
+    assert isinstance(raised, EntryPointGateError)
+
+
+def test_the_gate_allows_a_start_when_the_console_script_runs():
+    # Arrange — the gate must not be a wall; a working agent has to start.
+    runner = _runner_returning(0)
+    # Act
+    result = assert_entry_point_runs("scitex-hub", _LAUNCH, runner=runner)
+    # Assert
+    assert result is None
+
+
+def test_an_apptainer_level_failure_is_not_blamed_on_the_console_script():
+    # Arrange — EXIT-CODE COLLISION, caught the hard way. `apptainer exec`
+    # returns the inner command's status on success, but its OWN failures
+    # (missing image, mount error) come back non-zero too — 255, typically.
+    # The first version of this gate read any non-zero as "wrapper missing" and
+    # refused 29 legitimate starts in the tui_session suite, which injects a
+    # fake argv naming an image that does not exist. 255 is UNKNOWN, not guilt.
+    runner = _runner_returning(255)
+    # Act
+    violation = entry_point_violation(_LAUNCH, runner=runner)
+    # Assert
+    assert violation is None
+
+
+def test_a_not_executable_wrapper_is_still_a_violation():
+    # Arrange — 126 is the other half of the not-found pair; narrowing to 127
+    # alone would let a present-but-unrunnable wrapper through.
+    runner = _runner_returning(126)
+    # Act
+    violation = entry_point_violation(_LAUNCH, runner=runner)
+    # Assert
+    assert violation is not None
+
+
+def test_a_probe_that_raises_never_blocks_a_start():
+    # Arrange — THE ANTI-BRICK CASE. A probe bug (missing apptainer, timeout)
+    # must not refuse every start on the host; that would be a gate more
+    # dangerous than the fault it guards.
+    def exploding_runner(argv):
+        raise OSError("apptainer not found")
+
+    # Act
+    result = assert_entry_point_runs("scitex-hub", _LAUNCH, runner=exploding_runner)
+    # Assert
+    assert result is None


### PR DESCRIPTION
## What

A start-time gate that refuses to launch an agent whose console script does not
**run** in the sif+overlay union it is about to launch in.

`runtimes/_entry_point_gate.py` + 15 tests, wired into `TuiSessionRuntime.start`.

## Why — a sixteen-day silent outage

scitex-hub's a2a inbox rail was dead from **2026-07-18 to 2026-08-03**. Three
console-script wrappers were masked by character-device whiteouts in its overlay:

```
<overlay>/upper/opt/venv-sac/bin/sac                     c 0:0
<overlay>/upper/opt/venv-sac/bin/sac-statusline          c 0:0
<overlay>/upper/opt/venv-sac/bin/scitex-agent-container  c 0:0
```

Deleting a file that exists in the **lower** layer does not remove it — overlayfs
writes a name-specific whiteout that hides the image's copy permanently. The SIF
shipped all three the whole time and `sac --version` exited 0 inside it. Only the
union was broken, and the union is what the agent runs in.

`sac mcp start` and `sac mcp channel` are both spawned through that wrapper, so
the agent booted, passed every liveness probe, and answered nobody.

### Neither existing gate could observe it

| gate | why it was green |
|---|---|
| `containers/sif_symbol_probe.py` | runs at **bake** time, inside the SIF, no overlay — correctly green about a different filesystem |
| anything of the form `import scitex_agent_container` | site-packages was intact and the dist metadata still **declared** both console scripts; the package imported perfectly |

"Importable is not invokable." Same shape as the psycopg hole the day before,
where a bare `psycopg/` directory with no `__init__.py` imported as a namespace
package and `hasattr(psycopg, "connect")` was True with no driver underneath.
Twice in two days, a gate sat one layer above the thing that actually breaks.

## Design

**The probe argv is derived from the real launch argv**, not rebuilt. A second
copy of the overlay/bind/isolation logic would be free to drift, and a probe that
measures a *different* union than the agent runs in is worse than no probe — it
reports on a filesystem nobody uses. A test asserts the probe inherits the launch
`--overlay` value, because that is the layer the fault lives in.

**It raises rather than logs.** A warning would reproduce the failure it
prevents: hub's evidence was warning-shaped and went unread for sixteen days.

**Three-valued, so it cannot brick the fleet.** No verdict is returned for an
unprobeable argv, a probe that raises, or any exit code outside 126/127. Only a
probe that actually ran and reported not-found can refuse a start.
`SAC_SKIP_ENTRY_POINT_GATE=1` is an override, deliberately not a default.

## The correction that mattered

The first version treated **any** non-zero exit as "wrapper missing".
`apptainer exec` returns the inner command's status on success, but its *own*
failures — missing image, mount error — arrive non-zero too, typically **255**.
So it accused the console script whenever apptainer merely could not run, and it
**refused 29 legitimate starts** in the `tui_session` suite, which injects a fake
argv naming an image that does not exist.

One small integer carrying two meanings. Now only 126/127 (not-found /
not-executable — the two states a masked wrapper actually produces) accuse;
everything else is logged inconclusive. Both are pinned by tests, including the
255 case that caught me.

I found it only by running the same tests on untouched `develop` as a **control**
(47/47 green). Without that I would have filed the 29 as pre-existing — develop
does carry known failures, so the wrong story was available and comfortable.

## Verification

- `test__entry_point_gate.py` — 15 passed, including the mutation proof that the
  gate can fire and the 255 non-accusation case.
- Full `tests/.../runtimes/` suite: **1617 passed, 3 failed, 19 errors**.
- Control on untouched develop for those same files: **identical 3 failed, 19
  errors** (`test__sdk_common.py`, `test__mcp_spec_env.py`) — pre-existing,
  measured rather than assumed.
