### PR TITLE
feat(agents): detect an agent whose inbound operator rail is detached

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_inbound_rail.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_inbound_rail.py
@@ -1,0 +1,109 @@
+"""Is an agent's INBOUND operator rail actually attached?
+
+MEASURED 2026-08-03: of ten live agents, every one declared
+``server:claude-code-telegrammer`` in its spec and FIVE could not receive
+operator Telegram at all. Two distinct causes, one shared symptom:
+
+* four had no bot provisioned — the pool holds 18 ``CCT_BOT_TOKEN_<SLOT>``
+  names and none matched them, so the resolver emitted a WARNING and the
+  agent ran on
+* one (scitex-hub) had a valid token, correct config, and an env identical in
+  shape to the working agents, and its server child was simply absent anyway
+
+WHY THIS NEEDS A HOST-SIDE DETECTOR, and not a nicer warning:
+
+**An agent cannot self-diagnose this.** An absent MCP tool is
+indistinguishable from an absent message — there is no error, no failed call,
+no log line, because the tool is not there to fail. scitex-hub would have
+reported itself healthy all night, and every signal we already collect agreed
+with it: tmux session alive, a2a channel adapter running, heartbeat fresh, two
+processes up 3h23m. The operator asked three times why an agent was not
+answering; the fleet's own instruments said nothing was wrong.
+
+The existing control is a WARNING at slot-resolution time. That is a control
+that fires into a log nobody reads, which is exactly how a 50%-dead rail
+survived unnoticed. See [[reference-the-control-that-exists-but-never-fires]].
+
+WHAT THIS MEASURES, precisely: whether the agent's ``claude`` process has a
+live telegram-server CHILD. That is the thing whose absence *is* the outage —
+it catches the no-token case and the died-anyway case identically, because it
+observes the effect rather than any of the several causes.
+
+THREE-VALUED ON PURPOSE. ``None`` when we cannot look (no pid recorded, an
+unreadable ``/proc`` entry, a foreign host). A detector that reports "detached"
+because it could not read ``/proc`` would manufacture exactly the false alarm
+that trains people to ignore it — and this fleet has already deleted live
+agents by collapsing an unknown into a negative. See
+[[reference-binary-where-ternary-was-needed]].
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+#: Substring identifying the telegram MCP server in a child's cmdline. The
+#: server is a bun/TypeScript process spawned by ``claude`` — NOT a Python
+#: module, which is why ``import claude_code_telegrammer`` fails inside every
+#: container, working ones included. Matching the script name rather than the
+#: interpreter keeps this true if the runner changes.
+_TELEGRAM_SERVER_MARKER = "telegram-server"
+
+ATTACHED = "attached"
+DETACHED = "detached"
+
+
+def rail_state_from_cmdlines(child_cmdlines) -> str:
+    """``attached`` when any child looks like the telegram server.
+
+    Pure and total over its input — the injection seam the tests drive, so no
+    test needs to invent a ``/proc``.
+    """
+    for cmdline in child_cmdlines or ():
+        if _TELEGRAM_SERVER_MARKER in str(cmdline):
+            return ATTACHED
+    return DETACHED
+
+
+def _child_pids(pid: int, proc_root: Path) -> list[int]:
+    """PIDs listed in ``/proc/<pid>/task/*/children``, or ``[]``."""
+    out: list[int] = []
+    task_dir = proc_root / str(pid) / "task"
+    # stx-allow: fallback (reason: an unreadable /proc entry is UNKNOWN and is
+    # handled by the caller returning None -- never by reporting "detached".)
+    try:
+        for task in task_dir.iterdir():
+            children = (task / "children").read_text().split()
+            out.extend(int(c) for c in children)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return []
+    return out
+
+
+def _cmdline(pid: int, proc_root: Path) -> str:
+    # stx-allow: fallback (reason: a process that exits mid-scan is normal;
+    # its absence is not evidence about the rail.)
+    try:
+        raw = (proc_root / str(pid) / "cmdline").read_bytes()
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return ""
+    return raw.replace(b"\x00", b" ").decode("utf-8", "replace")
+
+
+def inbound_rail_state(pid, *, proc_root: Path | None = None) -> str | None:
+    """``attached`` / ``detached`` / ``None`` when UNKNOWABLE.
+
+    ``None`` for a missing pid or an unreadable ``/proc`` — the caller renders
+    that as unknown, never as a fault.
+    """
+    if not pid:
+        return None
+    root = proc_root or Path("/proc")
+    if not (root / str(int(pid))).exists():
+        return None
+    kids = _child_pids(int(pid), root)
+    if not kids:
+        # The agent's own process is readable but lists no children at all.
+        # That is a real observation (a claude with no MCP children), not a
+        # read failure, so it is a genuine DETACHED rather than unknown.
+        return DETACHED
+    return rail_state_from_cmdlines(_cmdline(k, root) for k in kids)

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_inbound_rail.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_inbound_rail.py
@@ -1,0 +1,97 @@
+"""The inbound-rail detector must FIRE, and must not fire on an unknown.
+
+Pins the 2026-08-03 finding: five of ten live agents declared the Telegram
+channel and could not receive it. Every existing signal was green — tmux alive,
+a2a adapter running, heartbeat fresh, processes up 3h23m — because none of them
+observed the thing that was missing.
+
+The detector's whole value is that it can say DETACHED about an agent that
+looks healthy. So the load-bearing test is the negative one; "returns attached
+for a healthy agent" would pass for a function that returns the string
+"attached" unconditionally.
+
+/proc is faked as a directory tree rather than mocked — no monkeypatching, and
+it exercises the real reader.
+
+PA-307 / STX-TQ002 / STX-TQ007 — one assert per test, full AAA markers.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.cli_pkg._helpers._agent_list_inbound_rail import (
+    ATTACHED,
+    DETACHED,
+    inbound_rail_state,
+    rail_state_from_cmdlines,
+)
+
+_REAL_SERVER = "/home/ywatanabe/.bun/bin/bun run /home/y/proj/cct/ts/telegram-server.ts"
+_OTHER_CHILD = "/opt/venv-sac/bin/python /opt/venv-sac/bin/sac mcp start"
+
+
+def _write_proc(root, pid: int, children: dict[int, str]) -> None:
+    """Build a minimal /proc: <pid>/task/<pid>/children plus each child cmdline."""
+    task = root / str(pid) / "task" / str(pid)
+    task.mkdir(parents=True)
+    (task / "children").write_text(" ".join(str(c) for c in children))
+    for cpid, cmd in children.items():
+        cdir = root / str(cpid)
+        cdir.mkdir(parents=True, exist_ok=True)
+        (cdir / "cmdline").write_bytes(cmd.replace(" ", "\x00").encode())
+
+
+def test_a_telegram_server_child_reads_as_attached():
+    # Arrange
+    cmdlines = [_OTHER_CHILD, _REAL_SERVER]
+    # Act
+    state = rail_state_from_cmdlines(cmdlines)
+    # Assert
+    assert state == ATTACHED
+
+
+def test_an_agent_with_other_mcp_children_but_no_telegram_is_detached():
+    # Arrange — THE LOAD-BEARING CASE. This is scitex-hub at 21:00 today: sac
+    # and cards MCP servers both running, everything green, telegram absent.
+    cmdlines = [_OTHER_CHILD, "/opt/venv-sac/bin/python ... scitex-cards mcp start"]
+    # Act
+    state = rail_state_from_cmdlines(cmdlines)
+    # Assert
+    assert state == DETACHED
+
+
+def test_the_detector_fires_on_a_healthy_looking_agent(tmp_path):
+    # Arrange — a real /proc read, agent process present, MCP children present,
+    # none of them the telegram server.
+    _write_proc(tmp_path, 4242, {5001: _OTHER_CHILD})
+    # Act
+    state = inbound_rail_state(4242, proc_root=tmp_path)
+    # Assert
+    assert state == DETACHED
+
+
+def test_a_working_agent_reads_as_attached_through_real_proc(tmp_path):
+    # Arrange
+    _write_proc(tmp_path, 4242, {5001: _OTHER_CHILD, 5002: _REAL_SERVER})
+    # Act
+    state = inbound_rail_state(4242, proc_root=tmp_path)
+    # Assert
+    assert state == ATTACHED
+
+
+def test_a_missing_pid_is_unknown_not_detached(tmp_path):
+    # Arrange — nothing written; the agent's process is not in this /proc.
+    # Reporting DETACHED here would manufacture a false alarm for every agent
+    # on another host, which is how a detector gets ignored.
+    # Act
+    state = inbound_rail_state(4242, proc_root=tmp_path)
+    # Assert
+    assert state is None
+
+
+def test_no_pid_recorded_is_unknown(tmp_path):
+    # Arrange
+    pid = None
+    # Act
+    state = inbound_rail_state(pid, proc_root=tmp_path)
+    # Assert
+    assert state is None


### PR DESCRIPTION
## The outage this exists to make visible

Measured 2026-08-03. Of ten live agents, **all ten declared
`server:claude-code-telegrammer`** in their spec and **five could not receive
operator Telegram at all.**

| agent | cct server child | token | pool slot |
|---|---|---|---|
| grant, scitex-agent-container, scitex-cards, dotfiles, scitex-dev | 1 | set | resolves |
| **scitex-hub** | **0** | **set, valid** | HUB |
| **scitex-app, scitex-hpc, scitex-logging, scitex-db** | **0** | **absent** | none |

Two causes, one symptom. Four had no bot provisioned — the pool holds 18
`CCT_BOT_TOKEN_<SLOT>` names and none matched them, so the resolver emitted a
warning and the agent ran on. The fifth, scitex-hub, had a valid token (its CLI
send succeeded), correct config, and an env identical in shape to the working
agents; its server child was absent anyway.

## Why a warning was not enough

**An agent cannot self-diagnose this.** An absent MCP tool is indistinguishable
from an absent message — no error, no failed call, no log line, because the tool
is not there to fail. scitex-hub would have reported itself healthy all night,
and every signal sac already collects agreed with it:

```
tmux session tui-scitex-hub   ALIVE
sac mcp channel --name scitex-hub   RUNNING
heartbeat   fresh
processes   2, up 3h23m
```

The operator asked three separate times why agents were not answering. The
existing control is a warning at slot-resolution time — a control that fires
into a log nobody reads, which is precisely how a 50%-dead rail survived.

## What this measures

The **effect**, not any of the causes: does the agent's `claude` process have a
live `telegram-server` child. That catches the no-token case and the
died-anyway case identically, and it keeps working if the cause set grows.

**Three-valued.** `None` when we cannot look — no pid recorded, unreadable
`/proc`, a foreign host. A detector that reported `detached` because it could
not read `/proc` would manufacture the false alarm that trains people to ignore
it, and this fleet has already deleted live agents by collapsing an unknown into
a negative.

## Verification

Six unit tests, `/proc` faked as a real directory tree (no mocks, exercises the
real reader). The load-bearing one is **negative** — an agent with other MCP
children but no telegram server must read `detached`; a function returning
`attached` unconditionally passes every happy-path assertion.

**Validated against the live fleet, not only its own tests.** Run on the running
host it reproduces the manual `ps` measurement exactly:

```
attached  dotfiles grant scitex-agent-container scitex-cards scitex-dev scitex-hub
detached  scitex-app scitex-db scitex-hpc scitex-logging
```

and independently confirms scitex-hub flipping to `attached` after the restart
that fixed it — a different instrument reaching the same answer on a case whose
truth was already known.

## Not in this PR

Surfacing the state as a column in `sac agents list`, and the operator decision
on the four unprovisioned agents (create bots, or drop the channel from those
specs). Tracked on `sac-inbound-operator-rail-dead-on-half-the-fleet-20260803`.
