### PR TITLE
feat(start): tell a restarted agent to go and read what it missed

### DIFF
--- a/src/scitex_agent_container/runtimes/_boot_recovery.py
+++ b/src/scitex_agent_container/runtimes/_boot_recovery.py
@@ -1,0 +1,59 @@
+"""On restart, make the agent go and READ what it missed.
+
+OPERATOR DIRECTIVE 2026-08-03: 「リスタートした時に取りこぼしのある指示を
+自分で読ませるべき」 — when an agent is restarted, it should read for itself
+the instructions that were dropped.
+
+THE CONCRETE LOSS THAT PROMPTED IT. scitex-hub's telegram MCP server was dead,
+so operator messages were not reaching it. I restarted hub to fix that. The
+operator had sent a message eight minutes BEFORE the restart; it died with the
+old session. The rail was repaired and the instruction was still lost, and the
+only reason anyone noticed is that the operator asked a third time.
+
+Restarting is not neutral. It is the one moment when an agent is guaranteed to
+have a gap, because the thing being replaced is the thing that was holding the
+queue. Every restart therefore owes a read-back, and the agent is the only
+party positioned to do it — the sender does not know a restart happened, and
+the operator should never be the retry mechanism.
+
+WHY THIS LIVES IN SAC AND NOT IN THE SPECS. The fleet's boot kick is
+duplicated across 83 ``spec.startup_prompts`` entries, 81 of them byte
+identical. Adding a line there means 83 edits that immediately begin to drift,
+and a new agent created tomorrow inherits whichever copy it was cloned from.
+Injected here it is a fleet invariant: one definition, applies to every agent
+including ones that do not exist yet, and cannot be half-applied.
+
+DELIBERATELY PHRASED AS "check and act", NOT "you have missed messages". At
+injection time sac does not know whether anything was actually missed, and a
+prompt that asserts a backlog that may be empty trains the reader to skip it.
+"""
+
+from __future__ import annotations
+
+#: Injected as the FIRST turn of every restarted session, ahead of the spec's
+#: own prompts. Short on purpose: it costs a few tokens on every boot of every
+#: agent, so it earns its place by being one instruction, not a briefing.
+MISSED_INPUT_RECOVERY_PROMPT = (
+    "You have just (re)started, so anything sent to you while you were down is "
+    "NOT in this session. Before doing anything else, go and read it: check "
+    "your operator channel for unread/recent messages (e.g. the telegrammer "
+    "get_unread / get_history tools) and poll your card notifications. Act on "
+    "anything still outstanding, and if something was addressed to you that you "
+    "can no longer recover, say so plainly rather than staying silent. Do NOT "
+    "assume a quiet inbox means nothing was sent -- a restart drops in-flight "
+    "messages, and the sender does not know you restarted."
+)
+
+
+def with_missed_input_recovery(prompts) -> list[str]:
+    """The spec's startup prompts, preceded by the read-back instruction.
+
+    Pure, and total over its input — this is the seam the tests drive.
+
+    Returns the recovery prompt even when the spec declares NO startup prompts.
+    That is the point rather than an oversight: an agent with no boot kick is
+    not an agent with nothing to catch up on, and it is the one least likely to
+    look on its own.
+    """
+    tail = [p for p in list(prompts or []) if p]
+    return [MISSED_INPUT_RECOVERY_PROMPT, *tail]

--- a/src/scitex_agent_container/runtimes/_tui_inject.py
+++ b/src/scitex_agent_container/runtimes/_tui_inject.py
@@ -64,12 +64,24 @@ class StartupPromptInjectorMixin:
         restart (e.g. a burst of stale ``/compact``); clearing before the first
         paste stops the boot submit from committing that stale stack.
         """
+        from ._boot_recovery import with_missed_input_recovery
         from .tui_session import session_name_for
 
         log = logging.getLogger(__name__)
-        prompts = list(getattr(config, "startup_prompts", []) or [])
-        if not prompts:
+        spec_prompts = list(getattr(config, "startup_prompts", []) or [])
+        # An EXPLICITLY empty startup_prompts stays a no-op. That guard predates
+        # me and I did not establish why it exists, so I am not overwriting it
+        # to deliver the read-back: an agent deliberately left silent (a
+        # non-interactive runner, say) must not suddenly receive a boot turn.
+        # Coverage is effectively complete anyway -- 83 of the fleet's specs
+        # carry a boot kick -- so the narrow reading costs nothing real.
+        if not spec_prompts:
             return
+        # A restart is the one moment an agent is GUARANTEED to have a gap: the
+        # process being replaced is the one that held the queue. So the
+        # read-back instruction LEADS -- see _boot_recovery for the lost
+        # operator message this rule was written from.
+        prompts = with_missed_input_recovery(spec_prompts)
         name = session_name_for(config)
         # Short pre-clear drain: the boot-drain already spent the long window;
         # this only needs to CONFIRM no cancelable modal remains before the

--- a/tests/scitex_agent_container/runtimes/test__boot_recovery.py
+++ b/tests/scitex_agent_container/runtimes/test__boot_recovery.py
@@ -1,0 +1,86 @@
+"""A restarted agent must be told to go and read what it missed.
+
+OPERATOR DIRECTIVE 2026-08-03: when an agent is restarted it should read for
+itself the instructions that were dropped.
+
+THE LOSS BEING PINNED: scitex-hub's telegram MCP was dead, so operator messages
+were not reaching it. Restarting fixed the rail — and destroyed a message the
+operator had sent eight minutes earlier, because it was queued against the
+session being replaced. Rail repaired, instruction still lost.
+
+SCOPE, stated so these are not read as more than they are: these test the pure
+composition function. The INJECTOR keeps its pre-existing early return on an
+explicitly empty ``startup_prompts`` — that guard predates this change and its
+rationale was not established, so it was left alone rather than overwritten to
+deliver the read-back. An agent deliberately left silent must not suddenly
+receive a boot turn. In practice 83 of the fleet's specs carry a boot kick, so
+the narrow reading costs no real coverage.
+
+PA-307 / STX-TQ002 / STX-TQ007 — one assert per test, full AAA markers.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.runtimes._boot_recovery import (
+    MISSED_INPUT_RECOVERY_PROMPT,
+    with_missed_input_recovery,
+)
+
+
+def test_the_recovery_prompt_leads():
+    # Arrange — it must come FIRST; a read-back after the agent has already
+    # started working is a read-back of a decision already taken.
+    spec_prompts = ["Start or continue. Scan your scitex-cards slices."]
+    # Act
+    result = with_missed_input_recovery(spec_prompts)
+    # Assert
+    assert result[0] == MISSED_INPUT_RECOVERY_PROMPT
+
+
+def test_the_specs_own_prompts_are_preserved_in_order():
+    # Arrange — the boot kick must still work; this adds, never replaces.
+    spec_prompts = ["first", "second"]
+    # Act
+    result = with_missed_input_recovery(spec_prompts)
+    # Assert
+    assert result[1:] == ["first", "second"]
+
+
+def test_the_composer_yields_the_recovery_even_for_an_empty_list():
+    # Arrange — a property of the COMPOSER, not of the injector: the injector
+    # still early-returns on an explicitly empty startup_prompts. Pinned so a
+    # future caller that does want the empty case gets defined behaviour.
+    spec_prompts = []
+    # Act
+    result = with_missed_input_recovery(spec_prompts)
+    # Assert
+    assert result == [MISSED_INPUT_RECOVERY_PROMPT]
+
+
+def test_none_is_treated_as_no_prompts():
+    # Arrange — spec.startup_prompts is absent rather than empty.
+    spec_prompts = None
+    # Act
+    result = with_missed_input_recovery(spec_prompts)
+    # Assert
+    assert result == [MISSED_INPUT_RECOVERY_PROMPT]
+
+
+def test_empty_entries_are_dropped_rather_than_injected_as_blank_turns():
+    # Arrange — a blank prompt would submit an empty turn on boot.
+    spec_prompts = ["", "real", ""]
+    # Act
+    result = with_missed_input_recovery(spec_prompts)
+    # Assert
+    assert result == [MISSED_INPUT_RECOVERY_PROMPT, "real"]
+
+
+def test_the_prompt_does_not_assert_that_messages_were_missed():
+    # Arrange — sac cannot know at injection time whether anything was missed,
+    # and a prompt that asserts a backlog which may be empty trains the reader
+    # to skip it. It must instruct a CHECK, not report a fact.
+    text = MISSED_INPUT_RECOVERY_PROMPT
+    # Act
+    asserts_a_backlog = "you have missed" in text.lower()
+    # Assert
+    assert not asserts_a_backlog

--- a/tests/scitex_agent_container/runtimes/test_tui_session_startup_prompt_enter.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session_startup_prompt_enter.py
@@ -204,8 +204,12 @@ def test_startup_prompt_inject_pastes_text_literally(
     config = _Config(name="figrecipe", startup_prompts=["go work"])
     # Act — full start path runs the inject under the runtime's own gate.
     runtime.start(config, boot_drain_timeout_s=0.01)
-    # Assert — the prompt reached the LITERAL (``-l``) paste primitive, once.
-    assert _literal_calls(mux) == [("send_text_literal", "tui-figrecipe", "go work")]
+    # Assert — the prompt reached the LITERAL (``-l``) paste primitive.
+    # Asserted by MEMBERSHIP, not by an exact call list: sac also injects the
+    # missed-input read-back ahead of the spec's prompts (see _boot_recovery),
+    # so an equality assertion here pins the injected COUNT rather than the
+    # property this test is named for.
+    assert ("send_text_literal", "tui-figrecipe", "go work") in _literal_calls(mux)
 
 
 def test_startup_prompt_inject_never_uses_non_literal_submit(
@@ -231,8 +235,11 @@ def test_startup_prompt_inject_submits_via_single_idle_gated_enter(
     config = _Config(name="neurovista", startup_prompts=["mission"])
     # Act
     runtime.start(config, boot_drain_timeout_s=0.01)
-    # Assert — exactly one Enter (no blind + no defensive; just the gated one).
-    assert len(_enter_calls(mux)) == 1
+    # Assert — ONE Enter per injected prompt: no blind and no defensive extra.
+    # There are two injected prompts now (the missed-input read-back precedes
+    # the spec's own), so the invariant is enters == pastes, which is what
+    # "exactly one gated Enter each" actually means.
+    assert len(_enter_calls(mux)) == len(_literal_calls(mux))
 
 
 def test_startup_prompt_inject_pastes_before_it_submits(
@@ -292,5 +299,14 @@ def test_startup_prompt_inject_each_prompt_pasted_and_submitted(
     config = _Config(name="multi", startup_prompts=["first turn", "second turn"])
     # Act
     runtime.start(config, boot_drain_timeout_s=0.01)
-    # Assert — exactly 2 literal pastes + 2 idle-gated Enters.
-    assert (len(_literal_calls(mux)), len(_enter_calls(mux))) == (2, 2)
+    # Assert — BOTH spec prompts pasted literally, each with its own gated
+    # Enter. Stated as membership + the enters==pastes invariant rather than a
+    # fixed (2, 2): sac prepends the missed-input read-back, and a raw count
+    # would fail for a correct change while saying nothing about "each prompt
+    # was pasted AND submitted", which is the property under test.
+    pasted = [c[2] for c in _literal_calls(mux)]
+    assert (
+        "first turn" in pasted
+        and "second turn" in pasted
+        and len(_enter_calls(mux)) == len(_literal_calls(mux))
+    )


### PR DESCRIPTION
feat(start): tell a restarted agent to go and read what it missed

OPERATOR DIRECTIVE 2026-08-03: "リスタートした時に取りこぼしのある指示を
自分で読ませるべき" -- when an agent is restarted it should read for itself
the instructions that were dropped.

THE CONCRETE LOSS. scitex-hub's telegram MCP server was dead, so operator
messages were not reaching it. I restarted hub to repair that rail. The
operator had sent a message eight minutes BEFORE the restart; it died with
the old session. Rail repaired, instruction still lost, and the only reason
anyone noticed is that the operator asked a third time.

A restart is the one moment an agent is GUARANTEED to have a gap, because the
process being replaced is the one holding the queue. The sender does not know
a restart happened, so the agent is the only party positioned to close it --
and the operator must never be the retry mechanism.

WHY IN SAC AND NOT IN THE SPECS: the fleet's boot kick is duplicated across
83 spec.startup_prompts entries, 81 byte-identical. Adding a line there is 83
edits that immediately drift, and an agent created tomorrow inherits whichever
copy it was cloned from. Here it is one definition that cannot be
half-applied.

The prompt instructs a CHECK rather than asserting a backlog: sac cannot know
at injection time whether anything was missed, and a prompt that claims a
backlog which may be empty trains the reader to skip it.

WHAT I DID NOT DO. The injector's early return on an explicitly empty
startup_prompts is LEFT INTACT. That guard predates this change and I did not
establish why it exists, so I did not overwrite it to deliver the read-back --
an agent deliberately left silent must not suddenly receive a boot turn. 83
specs carry a kick, so the narrow reading costs no real coverage.

THREE EXISTING TESTS were failing against this change and I treated them as
evidence rather than obstacles. Each asserted a raw injected COUNT (2 pastes,
1 Enter) while being named for a different property. Rewritten to assert the
property: the spec's prompts are pasted (membership) and enters == pastes,
which is what "one gated Enter each" actually means. A count-based assertion
would fail for any correct change to what gets injected.

6 new tests. Full runtimes suite on this branch: 1623 passed, 3 failed,
19 errors -- and that is NOT 'green'. Those 3 failures and 19 errors are
develop's PRE-EXISTING baseline in test__sdk_common.py and
test__mcp_spec_env.py, established by running the same files on untouched
develop as a control earlier today and getting an identical result. The
first draft of this message said 'suite green', written while the run was
at 70%; it is corrected here rather than left to read as a stronger claim
than the evidence supports.