### PR TITLE
feat(watchdog): see a question addressed to the operator, and refuse to answer it

### DIFF
--- a/src/scitex_agent_container/_runners/_tmux/prompts.py
+++ b/src/scitex_agent_container/_runners/_tmux/prompts.py
@@ -356,6 +356,51 @@ PROMPT_HANDLERS: list[PromptHandler] = [
 ]
 
 
+def _detect_operator_question(content: str) -> bool:
+    """The agent is ASKING THE OPERATOR something (AskUserQuestion).
+
+    MEASURED 2026-08-03: scitex-app sat parked on one of these indefinitely.
+    Every other detector in this file keys on ``"Enter to confirm"`` (16
+    occurrences). This dialog's footer reads ``"Enter to select · ↑/↓ to
+    navigate · n to add notes · Esc to cancel"`` -- a string that appears
+    NOWHERE in this module, so no handler matched, the watchdog never saw it,
+    and the agent waited forever for input nobody was going to give.
+
+    THIS HANDLER DELIBERATELY CARRIES NO KEYS. The other handlers answer SETUP
+    dialogs with a known-correct response -- theme, trust, login method. This
+    one is the opposite: the agent raised it BECAUSE it needs the operator's
+    judgement, and the options are usually not interchangeable. In the observed
+    case option 1 was a packaging decision that contradicted a standing
+    operator ruling. Auto-selecting would fabricate consent, which is worse
+    than hanging: hanging is at least visible once something reports it.
+
+    So the bug being fixed is not "it goes unanswered" -- it is that it goes
+    unanswered SILENTLY.
+    """
+    c = normalize_tui_whitespace(content)
+    return (
+        "Enter to select" in c
+        and ("to navigate" in c or "add notes" in c)
+        # Never fire on the known radio dialogs, which all say "confirm".
+        and "Enter to confirm" not in c
+    )
+
+
+#: Detect-only, appended after the auto-accept handlers are defined. Priority 0
+#: so it is evaluated FIRST: if the agent is genuinely asking the operator
+#: something, no lower-priority auto-accepter may reach it and answer on the
+#: operator's behalf.
+PROMPT_HANDLERS.append(
+    PromptHandler(
+        name="operator-question",
+        detect=_detect_operator_question,
+        keys=[],  # INTENTIONALLY EMPTY -- see the docstring above.
+        priority=0,
+    )
+)
+PROMPT_HANDLERS.sort(key=lambda h: h.priority)
+
+
 def register_prompt(handler: PromptHandler) -> None:
     """Add a custom prompt handler to the registry."""
     PROMPT_HANDLERS.append(handler)
@@ -381,6 +426,25 @@ def detect_and_respond(
         if handler.name in accepted:
             continue
         if handler.detect(content):
+            if not handler.keys:
+                # DETECT-ONLY. A handler with no keys is an ESCALATION, not an
+                # acceptance: the pane is showing something this watchdog must
+                # NOT answer. Returning the name (rather than None) is what
+                # stops a lower-priority auto-accepter from reaching it and
+                # answering on the operator's behalf -- but nothing is sent,
+                # and it must never be logged as "accepted", because that line
+                # is how a silently-unanswered prompt would read as handled.
+                logger.warning(
+                    "OPERATOR INPUT REQUIRED (%s): the pane is showing a "
+                    "question addressed to the operator. The watchdog "
+                    "deliberately did NOT answer it -- the options are not "
+                    "interchangeable and choosing one would fabricate consent. "
+                    "This agent is BLOCKED until a human answers. Attach with "
+                    "`sac agents attach <name>` (or `tmux attach -t tui-<name>`)"
+                    " and answer it.",
+                    handler.name,
+                )
+                return handler.name
             for key in handler.keys:
                 send_keys_fn(key)
             logger.info("Auto-accepted prompt: %s", handler.name)

--- a/tests/scitex_agent_container/_runners/_tmux/test_prompts_operator_question.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test_prompts_operator_question.py
@@ -1,0 +1,107 @@
+"""A question addressed to the OPERATOR must be seen, and must not be answered.
+
+MEASURED 2026-08-03: scitex-app sat parked on an AskUserQuestion dialog
+indefinitely. Every detector in prompts.py keys on "Enter to confirm" (16
+occurrences); this dialog's footer says "Enter to select · ↑/↓ to navigate ·
+n to add notes", a string that appeared NOWHERE in the module. No handler
+matched, so the watchdog never saw it.
+
+TWO PROPERTIES, and the second is the one that makes this safe:
+  1. it is DETECTED (previously invisible)
+  2. it is NOT ANSWERED -- the agent raised it because it needs the operator's
+     judgement. In the observed case option 1 was a packaging decision that
+     contradicted a standing operator ruling, so auto-selecting would have
+     fabricated consent. The defect is that it hung SILENTLY, not that it hung.
+
+The load-bearing test is therefore the negative one: zero keystrokes sent.
+"Returns the handler name" would pass for a handler that answered it.
+
+PA-307 / STX-TQ002 / STX-TQ007 -- one assert per test, full AAA markers.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._runners._tmux.prompts import (
+    _detect_operator_question,
+    detect_and_respond,
+)
+
+# The real shape, from the operator's screenshot of scitex-app.
+_ASK_USER_QUESTION = """
+ PS-221 blocks every PR in scitex-app. How do you want it resolved?
+
+ ❯ 1. Land the one-line fix now (Recommended)
+   2. Finish #60 instead (PEP 735 groups)
+   3. Config exemption with your directive as the reason
+
+ Enter to select · ↑/↓ to navigate · n to add notes · Esc to cancel
+"""
+
+# A known auto-accept dialog, kept as the discriminator: it must NOT be
+# mistaken for an operator question, or the watchdog would stop answering
+# setup prompts it is supposed to answer.
+#
+# The option strings are taken VERBATIM from _detect_file_trust_radio's own
+# required substrings, not invented. My first draft of this fixture said
+# "1. Yes, proceed" and matched NOTHING -- so the test that was supposed to
+# prove "auto-accept still works" passed zero keystrokes and failed, and it
+# would have been just as easy to "fix" it by weakening the assertion. A
+# fixture that cannot trigger the handler it names proves nothing about it.
+_TRUST_RADIO = """
+ Is this a project you created or one you trust?
+
+   1. Yes, I trust this folder
+   2. No, exit
+
+ Enter to confirm · Esc to exit
+"""
+
+
+def test_the_operator_question_dialog_is_detected():
+    # Arrange — previously invisible: no detector contained "Enter to select".
+    content = _ASK_USER_QUESTION
+    # Act
+    detected = _detect_operator_question(content)
+    # Assert
+    assert detected
+
+
+def test_a_confirm_style_setup_dialog_is_not_an_operator_question():
+    # Arrange — THE DISCRIMINATOR. If this matched, the new handler (priority 0)
+    # would shadow the auto-accepters and the watchdog would stop answering
+    # setup prompts entirely.
+    content = _TRUST_RADIO
+    # Act
+    detected = _detect_operator_question(content)
+    # Assert
+    assert not detected
+
+
+def test_no_keystrokes_are_sent_for_an_operator_question():
+    # Arrange — THE LOAD-BEARING CASE. Answering would fabricate the operator's
+    # consent; in the observed instance option 1 contradicted a standing ruling.
+    sent: list[str] = []
+    # Act
+    detect_and_respond(_ASK_USER_QUESTION, set(), lambda k: sent.append(k))
+    # Assert
+    assert sent == []
+
+
+def test_the_operator_question_is_reported_by_name():
+    # Arrange — it must return a name rather than None, so the caller can
+    # surface it and no lower-priority handler is reached.
+    sent: list[str] = []
+    # Act
+    matched = detect_and_respond(_ASK_USER_QUESTION, set(), lambda k: sent.append(k))
+    # Assert
+    assert matched == "operator-question"
+
+
+def test_a_normal_prompt_still_gets_its_keystrokes():
+    # Arrange — the escalation path must not have broken auto-accept; a
+    # detect-only handler is the exception, not the new rule.
+    sent: list[str] = []
+    # Act
+    detect_and_respond(_TRUST_RADIO, set(), lambda k: sent.append(k))
+    # Assert
+    assert sent != []


### PR DESCRIPTION
feat(watchdog): see a question addressed to the operator, and refuse to answer it

MEASURED 2026-08-03: scitex-app sat parked on an AskUserQuestion dialog
indefinitely, and nothing reported it. The operator spotted it in a pane and
asked whether we handled the case. We did not.

WHY IT WAS INVISIBLE: every detector in prompts.py keys on "Enter to confirm"
-- 16 occurrences. The AskUserQuestion footer reads

    Enter to select · ↑/↓ to navigate · n to add notes · Esc to cancel

and the strings "Enter to select", "to navigate" and "add notes" appeared
NOWHERE in the module. No handler matched, so the watchdog never saw it. The
operator's own guess was right: the pattern is new and the matcher never
learned it.

THIS HANDLER CARRIES NO KEYS, ON PURPOSE. The other thirteen answer SETUP
dialogs that have a known-correct response -- theme, file trust, login method,
external imports. An AskUserQuestion is the opposite: the agent raised it
BECAUSE it needs the operator's judgement, and the options are not
interchangeable. In the observed instance option 1 was a packaging decision
that contradicted a standing operator ruling from 2026-07-13, so auto-selecting
would have fabricated the operator's consent -- worse than hanging, because a
hang is at least recoverable once something reports it.

So the defect being fixed is not "it goes unanswered". It is that it goes
unanswered SILENTLY.

detect_and_respond now treats a keyless handler as an ESCALATION rather than an
acceptance: nothing is sent, a WARNING names the agent as BLOCKED and gives the
attach command, and the handler name is returned so no lower-priority
auto-accepter can reach the pane and answer on the operator's behalf. It is
deliberately NOT logged as "Auto-accepted", because that line is exactly how a
silently-unanswered prompt would read as handled.

TESTS -- the load-bearing one is negative. "Returns the handler name" would
pass for a handler that answered it; "zero keystrokes sent" would not.

A FIXTURE BUG WORTH RECORDING, because it nearly inverted a test: my first
_TRUST_RADIO fixture said "1. Yes, proceed" and matched no real handler, so the
test asserting "auto-accept still works" observed zero keystrokes and failed.
The easy fix was to weaken the assertion; the right one was to rebuild the
fixture from _detect_file_trust_radio's own required substrings. A fixture that
cannot trigger the handler it is named for proves nothing about that handler.

103 passed in tests/scitex_agent_container/_runners/_tmux/.
