### PR TITLE
fix(host-merge): the full-developer gate reads the field specs actually write

### DIFF
--- a/src/scitex_agent_container/runtimes/_developer_gate.py
+++ b/src/scitex_agent_container/runtimes/_developer_gate.py
@@ -1,0 +1,106 @@
+"""Which agents get the host ``~/.claude`` deep-merge — the classification gate.
+
+Extracted from :mod:`._host_merge` (which was over the line cap) because this
+is a POLICY decision with two independent consumers, not merge mechanics:
+
+  * :mod:`._host_merge` — whether to deep-merge the host ``~/.claude`` on top
+    of the ``_shared`` / per-agent ``to_home`` layers
+  * :mod:`..cli_pkg._explain` — whether ``sac agents explain`` prints the
+    "Settings sources (settings.json key -> to_home layer)" provenance section
+
+That second consumer is why a wrong answer here is expensive out of proportion
+to its size: when the gate says False, the ONE tool that can answer "where did
+this hook come from" silently prints ``off`` instead of the provenance it has
+already computed.
+
+THE BUG THIS MODULE WAS EXTRACTED TO FIX, measured 2026-08-03 across all 102
+fleet specs::
+
+    labels.group   (SINGULAR — what the gate read)   ->   0 specs
+    labels.groups  (PLURAL   — what specs write)     ->  86 specs
+
+The scalar branch had NEVER FIRED. Every agent was classified by the fallback
+alone — i.e. by whether its role STRING sat on a four-item allowlist. So
+``groups: [developer]``, the field the specs and the fleet registry both use,
+had no effect on this gate at all.
+
+Concrete cost: scitex-hub declares ``groups: ["developer"]`` with role
+``product-lead-orchestrator``. When the operator elevated it from maintainer to
+lead on 2026-07-17, that rename moved it off the allowlist and therefore out of
+the host deep-merge — silently, with no warning, and it also switched off the
+provenance display. Two agents then spent an evening searching six locations
+for a hook registration while the tool that would have shown it was disabled
+for that agent.
+
+Honouring ``groups`` flips exactly FIVE agents (dry-run over all 102 specs
+driving this function): scitex-cards-chat, scitex-cards-gui,
+scitex-cards-mobile, scitex-hub, spartan-dev. The other 80 developers already
+pass via the role fallback, so this is a five-agent change, not a fleet-wide
+one — a distinction I got wrong by 17x before measuring it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..config import AgentConfig
+
+#: Role strings that imply full-developer WHEN NO GROUP IS DECLARED. This is a
+#: FALLBACK, deliberately narrow, and it is the reason a role rename can change
+#: an agent's config layers — see the module docstring. Prefer declaring
+#: ``groups`` explicitly over relying on it.
+_DEVELOPER_ROLES: frozenset[str] = frozenset(
+    {"project-maintainer", "maintainer", "dev-agent", "contributor"}
+)
+
+__all__ = ["is_full_developer", "_DEVELOPER_ROLES"]
+
+
+def is_full_developer(config: "AgentConfig") -> bool:
+    """True iff ``config`` is a FULL-DEVELOPER agent (host deep-merge ON).
+
+    Resolution order:
+
+      1. ``metadata.labels.groups`` (LIST) — GRANTS when it contains
+         ``developer``. Additive only: it never refuses.
+      2. ``metadata.labels.group`` (SCALAR) — the historical spelling. Grants on
+         ``developer``, REFUSES on any other non-empty value (e.g. ``solitary``).
+      3. ``metadata.labels.role`` in :data:`_DEVELOPER_ROLES` — fallback, used
+         when neither spelling decided.
+
+    WHY (1) IS ADDITIVE AND (2) IS NOT, since the asymmetry is deliberate and
+    looks like an oversight: making the plural form refuse as well is more
+    principled, and it REVOKES the host deep-merge from SEVEN agents that hold
+    it today (claude-code-telegrammer, neurovista, neurovista-paper-writer,
+    paper-ripple-wm, sales-worker and two templates) — they declare a
+    non-developer ``groups`` while carrying a role on the allowlist. Measured,
+    not guessed: a full old-vs-new diff over 102 specs in separate interpreters.
+
+    Silently stripping config layers from seven working agents as a SIDE EFFECT
+    of fixing a field name is exactly the class of change this gate's own bug
+    already caused once. Refusal semantics for ``groups`` deserve their own
+    deliberate decision and their own migration, not a rider on this fix.
+    """
+    labels = getattr(config, "labels", None) or {}
+
+    raw_groups = labels.get("groups")
+    if raw_groups is not None:
+        if not isinstance(raw_groups, (list, tuple, set)):
+            raw_groups = [raw_groups]
+        groups = {str(g).strip().lower() for g in raw_groups if str(g).strip()}
+        # ADDITIVE ONLY -- it grants, it never refuses. See the module docstring
+        # for why: making an explicit `groups` authoritative in both directions
+        # is defensible in the abstract and REVOKES the host merge from seven
+        # live agents that hold it today.
+        if "developer" in groups:
+            return True
+
+    group = str(labels.get("group", "") or "").strip().lower()
+    if group == "developer":
+        return True
+    if group:  # any explicit non-developer group (e.g. "solitary") -> no merge
+        return False
+
+    role = str(labels.get("role", "") or "").strip().lower()
+    return role in _DEVELOPER_ROLES

--- a/src/scitex_agent_container/runtimes/_host_merge.py
+++ b/src/scitex_agent_container/runtimes/_host_merge.py
@@ -123,12 +123,10 @@ _HOOK_EVENT_SUBDIRS: frozenset[str] = frozenset(
     }
 )
 
-# Roles that, ABSENT an explicit ``metadata.labels.group``, qualify an agent as
-# a full developer (host deep-merge ON). Decoupled from the ACL ``lineage.group``
-# knob on purpose — this gate is about WHO the agent is, not its comms ACL.
-_DEVELOPER_ROLES: frozenset[str] = frozenset(
-    {"project-maintainer", "maintainer", "dev-agent", "contributor"}
-)
+# _DEVELOPER_ROLES moved to ._developer_gate alongside the gate that reads it
+# (re-exported below). Kept in ONE place deliberately: a second copy here would
+# be dead the moment the import lands, and a dead copy of a policy constant is
+# exactly what drifts apart and then gets cited as authoritative.
 
 # Env override for the host ``~/.claude`` root (test seam — NO monkeypatch).
 # When set, host files are read from ``$SAC_HOST_CLAUDE_DIR`` instead of the
@@ -158,29 +156,11 @@ class HostMergeDriftError(RuntimeError):
 # --- gate ------------------------------------------------------------------
 
 
-def is_full_developer(config: AgentConfig) -> bool:
-    """True iff ``config`` is a FULL-DEVELOPER agent (host deep-merge ON).
-
-    Gate (decoupled from the ACL PR):
-
-      * ``metadata.labels.group == "developer"``                         → True
-      * ``metadata.labels.group == "solitary"``                          → False
-        (a capsule/solitary agent gets the ``_shared``/per-agent layers ONLY)
-      * group UNSET and ``metadata.labels.role`` in :data:`_DEVELOPER_ROLES`
-                                                                          → True
-      * otherwise                                                        → False
-
-    ``metadata.labels`` lands on :attr:`AgentConfig.labels` at load time.
-    """
-    labels = getattr(config, "labels", None) or {}
-    group = str(labels.get("group", "") or "").strip().lower()
-    if group == "developer":
-        return True
-    if group:  # any explicit non-developer group (e.g. "solitary") → no merge
-        return False
-    role = str(labels.get("role", "") or "").strip().lower()
-    return role in _DEVELOPER_ROLES
-
+# The gate now lives in ._developer_gate — it is a POLICY decision with two
+# consumers (this module and cli_pkg._explain's provenance section), not merge
+# mechanics, and this module was over the line cap. Re-exported here so every
+# existing `from ._host_merge import is_full_developer` keeps resolving.
+from ._developer_gate import _DEVELOPER_ROLES, is_full_developer  # noqa: E402,F401
 
 # --- host root resolution --------------------------------------------------
 

--- a/tests/scitex_agent_container/runtimes/test__developer_gate.py
+++ b/tests/scitex_agent_container/runtimes/test__developer_gate.py
@@ -1,0 +1,112 @@
+"""The full-developer gate must read the field specs actually write.
+
+MEASURED 2026-08-03 across all 102 fleet specs:
+
+    labels.group   (SINGULAR — what the gate read)   ->   0 specs
+    labels.groups  (PLURAL   — what specs write)     ->  86 specs
+
+So the scalar branch had NEVER FIRED and every agent was classified by the
+fallback alone: whether its role STRING sat on a four-item allowlist. When the
+operator elevated scitex-hub from maintainer to "product-lead-orchestrator" on
+2026-07-17, that rename moved it off the allowlist and silently out of the host
+deep-merge — and switched off the provenance display that would have explained
+where its hooks came from.
+
+The load-bearing test is the FLIP case: groups=["developer"] with an
+off-allowlist role must now be True. It was False before this change, so a gate
+that ignored `groups` would fail it.
+
+The second-most-important is the REFUSAL case: an explicit non-developer group
+must NOT fall through to the role allowlist, or a role name would silently
+re-grant what the group list deliberately withheld.
+
+PA-307 / STX-TQ002 / STX-TQ007 — one assert per test, full AAA markers.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from scitex_agent_container.runtimes._developer_gate import is_full_developer
+
+
+def _cfg(**labels):
+    """An object shaped like AgentConfig for the one attribute the gate reads."""
+    return SimpleNamespace(labels=dict(labels))
+
+
+def test_groups_list_containing_developer_grants():
+    # Arrange — THE FLIP CASE. This is scitex-hub verbatim: the plural field
+    # the specs write, plus a role that is NOT on the allowlist. False before.
+    config = _cfg(groups=["developer"], role="product-lead-orchestrator")
+    # Act
+    result = is_full_developer(config)
+    # Assert
+    assert result
+
+
+def test_a_non_developer_groups_list_does_not_revoke_a_qualifying_role():
+    # Arrange — THE NO-REGRESSION CASE, and it pins a deliberate asymmetry.
+    # My first implementation made `groups` authoritative in BOTH directions.
+    # That is more principled AND it revoked the host deep-merge from SEVEN
+    # live agents (claude-code-telegrammer, neurovista, neurovista-paper-writer,
+    # paper-ripple-wm, sales-worker + 2 templates) which declare a
+    # non-developer group while carrying an allowlisted role. Measured by an
+    # old-vs-new diff over 102 specs -- my dry-run had modelled an ADDITIVE
+    # rule while the code I wrote also refused, so the simulation validated a
+    # different rule than the one under test.
+    config = _cfg(groups=["solitary"], role="project-maintainer")
+    # Act
+    result = is_full_developer(config)
+    # Assert
+    assert result
+
+
+def test_the_scalar_group_still_refuses_a_non_developer_value():
+    # Arrange — the historical scalar form keeps its refusing semantics; only
+    # the new plural form is additive.
+    config = _cfg(group="solitary", role="project-maintainer")
+    # Act
+    result = is_full_developer(config)
+    # Assert
+    assert not result
+
+
+def test_a_bare_string_groups_value_is_tolerated():
+    # Arrange — a spec written with a scalar under the plural key must not
+    # crash or be silently ignored (str is iterable; naive membership would
+    # test characters).
+    config = _cfg(groups="developer")
+    # Act
+    result = is_full_developer(config)
+    # Assert
+    assert result
+
+
+def test_the_historical_scalar_group_still_grants():
+    # Arrange — back-compat: a spec written the old way keeps its meaning.
+    config = _cfg(group="developer")
+    # Act
+    result = is_full_developer(config)
+    # Assert
+    assert result
+
+
+def test_the_role_fallback_still_applies_when_no_group_is_declared():
+    # Arrange — 80 of 102 specs rely on this path today; the change must not
+    # disturb them.
+    config = _cfg(role="project-maintainer")
+    # Act
+    result = is_full_developer(config)
+    # Assert
+    assert result
+
+
+def test_an_off_allowlist_role_with_no_group_still_refuses():
+    # Arrange — the pre-existing behaviour for undeclared agents is unchanged;
+    # this fix grants only where a group was actually declared.
+    config = _cfg(role="product-lead-orchestrator")
+    # Act
+    result = is_full_developer(config)
+    # Assert
+    assert not result


### PR DESCRIPTION
fix(host-merge): the full-developer gate reads the field specs actually write

MEASURED 2026-08-03 across all 102 fleet specs:

    labels.group   (SINGULAR -- what is_full_developer read)   ->   0 specs
    labels.groups  (PLURAL   -- what specs write)              ->  86 specs

The scalar branch had NEVER FIRED. Every agent was classified by the fallback
alone -- whether its role STRING sat on a four-item allowlist -- so
`groups: [developer]`, the field the specs and the fleet registry both use, had
no effect on this gate at all.

WHAT THE GATE CONTROLS, and why a wrong answer is expensive out of proportion
to its size:
  1. the host ~/.claude deep-merge (a False agent gets _shared + per-agent only)
  2. the "Settings sources (settings.json key -> to_home layer)" section of
     `sac agents explain` -- which prints "off (not a full-developer agent)"

That second one is how this was found. scitex-hub declares groups:["developer"]
with role "product-lead-orchestrator". When the operator elevated it from
maintainer to lead on 2026-07-17, the rename moved it off the allowlist, out of
the host merge, and silently switched off the ONE tool that answers "where did
this hook come from". Two agents then spent an evening searching six locations
for a hook registration while that tool sat disabled for the agent in question.

CHANGE: `groups` (list) now GRANTS on membership. The scalar `group` keeps its
existing grant/refuse semantics; the role allowlist stays as the fallback.

THE ASYMMETRY IS DELIBERATE AND MEASURED. My first implementation made `groups`
authoritative in BOTH directions -- more principled, and a REGRESSION: an
old-vs-new diff over 102 specs (separate interpreters, to avoid the sys.path
collision that made my first comparison return a meaningless "0 flipped")
showed it revoking the host merge from SEVEN live agents --
claude-code-telegrammer, neurovista, neurovista-paper-writer, paper-ripple-wm,
sales-worker and two templates -- which declare a non-developer `groups` while
carrying an allowlisted role. Silently stripping config layers from seven
working agents as a SIDE EFFECT of fixing a field name is the same class of
harm this gate's own bug already caused once. Refusal semantics for `groups`
want their own decision and their own migration.

I caught it only because I diffed. My dry-run had modelled an ADDITIVE rule
(`('developer' in groups) or current`) while the code I wrote also refused --
so the simulation validated a different rule than the one under test, and
reported +5/-0 for an implementation that was really +5/-7.

BLAST RADIUS, final and verified against the shipped code:

    old full-developer 80  ->  new 85
    GAINED: scitex-cards-chat, scitex-cards-gui, scitex-cards-mobile,
            scitex-hub, spartan-dev
    LOST:   (none)

All five declare groups:["developer"] deliberately, and hub was elevated by the
operator, so all five SHOULD hold it -- stated as a judgement rather than
assumed.

REFACTOR: _host_merge.py was already over the 512-line cap, so the gate moved
to runtimes/_developer_gate.py -- a policy decision with two independent
consumers, split on responsibility rather than line-count arithmetic.
_host_merge re-exports both names so existing imports (cli_pkg/_explain.py)
keep resolving; the duplicate _DEVELOPER_ROLES was deleted rather than left to
drift. 521 -> 478 lines.

STILL OPEN, and not fixed here: a role rename silently changing which config
layers an agent receives. That is the deeper defect and it survives this fix.
