### PR TITLE
fix(agents list): a beating agent with no registry row is UNKNOWN, not `defined`

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_beat.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_beat.py
@@ -1,0 +1,113 @@
+"""Is this agent's heartbeat file still being WRITTEN?
+
+Why a separate signal at all
+----------------------------
+:mod:`._agent_list_discover` synthesizes a ``defined`` row for every agent
+that has a spec on disk but NO registry row, and states the premise inline:
+"These agents are never LIVE". That premise is false. Measured on the live
+fleet 2026-08-03, five agents were beating while rendered ``defined`` —
+including ``scitex-agent-container`` itself, mid-execution, which is as
+direct a refutation as the fleet can produce: the process generating the
+reading was the process the reading denied.
+
+An absent registry row means the registry forgot the agent. It does not
+mean the agent stopped, and rendering it as a non-live pole asserts more
+than we know.
+
+Why the FILE MTIME and not the ``ts`` field inside it
+-----------------------------------------------------
+This is the whole reason this module exists, and it is counter-intuitive
+enough to be worth stating: **the heartbeat record's own timestamp is not
+when the heartbeat was written.** ``write_heartbeat`` accepts a ``ts``
+override and the TUI runner passes the agent's *tmux pane-activity* epoch,
+so ``ts`` answers "when did this pane last change", not "is this agent
+alive". For an agent driven over a2a rather than by a human typing into
+its pane, the two diverge without bound.
+
+Measured the same day, on six agents that were unambiguously live:
+
+    agent                    ts field    file mtime
+    scitex-agent-container      3.4h         ~0s
+    scitex-hpc                  3.0h         ~0s
+    dotfiles                    3.2h         ~0s
+    scitex-cards               10.0h         ~0s
+
+``seconds_since_last_beat`` (12148.4 on a file written that second) and
+``pid`` (``0``) are derived from the same stale epoch and are equally
+unusable. The mtime is the only field that records the beat itself.
+
+A threshold here is unusually safe, because the fleet is bimodal with a
+wide empty gap — 11 files under 15 minutes (all within seconds), 56 files
+over 24 hours, and NOTHING in between. Any cutoff from one minute to one
+day yields the identical partition, so :data:`RECENT_BEAT_MAX_AGE_S` is
+not a tuning knob balancing false positives against false negatives.
+
+What this deliberately does NOT do
+----------------------------------
+A recent beat proves LIFE; a stale beat proves nothing. An agent killed
+with SIGKILL leaves its last ``running`` record behind forever, so
+"stale" must never be read as "dead" — 47 of the 90 ``defined`` rows carry
+exactly such a fossil record, and promoting all of them would bury the
+operator in UNKNOWNs and train them to ignore the view. Hence the
+positive-only contract: this returns ``True`` only on evidence, and
+``None`` for every "cannot tell".
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+__all__ = ["RECENT_BEAT_MAX_AGE_S", "beat_is_recent"]
+
+#: How recently the heartbeat FILE must have been written to count as
+#: evidence of life. Generous next to the real cadence (seconds) and far
+#: below the dead cluster (24h+); see the module docstring on why the gap
+#: makes this insensitive to the exact value.
+RECENT_BEAT_MAX_AGE_S = 900.0
+
+#: The per-agent beat file, written by ``_session_state.write_heartbeat``.
+BEAT_FILENAME = "heartbeat.json"
+
+
+def beat_is_recent(
+    name: str,
+    *,
+    now: float | None = None,
+    max_age_s: float = RECENT_BEAT_MAX_AGE_S,
+    state_dir: Path | None = None,
+) -> bool | None:
+    """``True`` if ``name``'s beat file was written within ``max_age_s``.
+
+    Three-valued on purpose. ``None`` means "no evidence either way" — no
+    beat file, or one whose mtime cannot be read — and must never be
+    collapsed into ``False`` by a caller, because the caller's ``False``
+    branch asserts a pole. ``False`` says only that the file is old, which
+    is not a claim that the agent is gone.
+
+    ``state_dir`` overrides the resolved location so a test can drive the
+    real function against a real file instead of patching the resolver.
+    """
+    if state_dir is None:
+        # runtime_base_dir() resolves PER CALL, deliberately: the sibling
+        # constant ``_session_state.DEFAULT_STATE_ROOT`` snapshots it at
+        # import, so a relocated runtime dir (or a test setting the env
+        # var) would be invisible to anything keyed off the snapshot.
+        # stx-allow: fallback (reason: an unresolvable root is NO evidence,
+        # which is None — never False, which the caller reads as a pole)
+        try:
+            from ..._runtime_paths import runtime_base_dir
+
+            state_dir = runtime_base_dir() / name
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            return None
+    beat = Path(state_dir) / BEAT_FILENAME
+    # stx-allow: fallback (reason: a racing writer/unreadable dir is an
+    # UNKNOWN; see the three-valued contract above)
+    try:
+        age = (now if now is not None else time.time()) - beat.stat().st_mtime
+    except OSError:  # stx-allow: fallback (reason: see inline comment)
+        return None
+    # A beat stamped slightly in the future (clock skew between the writer
+    # and this reader) is still a beat that just happened.
+    return age <= max_age_s

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
@@ -99,6 +99,7 @@ def defined_agent_rows(
     machine: str | None = None,
     group: str | None = None,
     running_only: bool = False,
+    discover: Callable[[], list[tuple[str, Path]]] | None = None,
 ) -> list[dict]:
     """Rows for agents DEFINED on disk but absent from the registry.
 
@@ -128,8 +129,13 @@ def defined_agent_rows(
     from ...config import load_config
     from ...config._validation import validate_config
     from . import _agent_list as _al
+    from ._agent_list_beat import beat_is_recent
 
-    discover = getattr(_al, "_discover_defined_agents", _discover_defined_agents)
+    # Injected first (caller/test supplies the real collaborator), else the
+    # module-attribute seam the existing suite rebinds, else the real walk.
+    discover = discover or getattr(
+        _al, "_discover_defined_agents", _discover_defined_agents
+    )
     rows: list[dict] = []
     for name, spec_path in discover():
         if name in registered:
@@ -167,10 +173,24 @@ def defined_agent_rows(
             except Exception as exc:  # stx-allow: fallback (reason: see comment)
                 errors = [str(exc)]
         status = "invalid" if errors else "defined"
-        # PERF: defined agents are never live — in the running-only default
-        # view they are all hidden, so skip their account + movement
-        # enrichment (status is enough for the footer count).
-        deferred = running_only
+        # An absent registry row is not evidence the agent stopped. If its
+        # heartbeat file is STILL BEING WRITTEN it is alive right now, and
+        # "defined" would be a flat contradiction of an observable fact —
+        # measured on five agents 2026-08-03, one of them this CLI's own
+        # host agent, mid-execution. We cannot say "running" (the registry
+        # row that would carry pid/session is the thing that is missing),
+        # so the honest render is UNKNOWN. Positive-only: a stale beat is
+        # left exactly as it was, because SIGKILL leaves a fossil record
+        # behind and "old" is not "gone".
+        beat_live = beat_is_recent(name) if not errors else None
+        if beat_live:
+            status = "unknown"
+        # PERF: a defined agent with no live beat is never live — in the
+        # running-only default view they are all hidden, so skip their
+        # account + movement enrichment (status is enough for the footer
+        # count). An agent we just promoted to "unknown" IS a candidate for
+        # that view, so it must not be deferred.
+        deferred = running_only and not beat_live
         row: dict = {
             "name": name,
             "status": status,
@@ -188,6 +208,11 @@ def defined_agent_rows(
         )
         row.update(movement)
         row.update(verdict_for(None))
+        if beat_live:
+            # The shape the remote-probe path already uses for "could not
+            # tell", so a JSON consumer needs no new vocabulary to see that
+            # liveness is UNRESOLVED here rather than negative.
+            row["liveness_unknown"] = True
         if errors:
             row["validation_errors"] = errors
         if labels:

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_beat.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_beat.py
@@ -1,0 +1,221 @@
+"""A LIVE agent with no registry row must not render as ``defined``.
+
+Measured on the live fleet 2026-08-03: five agents were beating while
+``sac agents list`` called them ``defined`` — one of them the host agent
+running the query. ``defined`` is synthesized for "spec on disk, absent
+from the registry", and the source asserted "These agents are never LIVE".
+An absent registry row is not a stopped agent.
+
+The heartbeat FILE MTIME is the signal, not the ``ts`` field inside it:
+``write_heartbeat`` takes a ``ts`` override and the TUI runner passes the
+tmux pane-activity epoch, so ``ts`` read 3.4h stale on a file written that
+same second. See ``_agent_list_beat`` for the measurements.
+
+The beat files here go into the ALREADY-SANDBOXED runtime root that the
+conftest points every worker at, rather than relocating the root: moving
+it trips the state-floor teardown guard, whose whole purpose is to catch a
+test writing into the operator's real state.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._runtime_paths import runtime_base_dir
+from scitex_agent_container.cli_pkg._helpers._agent_list_beat import (
+    RECENT_BEAT_MAX_AGE_S,
+    beat_is_recent,
+)
+from scitex_agent_container.cli_pkg._helpers._agent_list_discover import (
+    defined_agent_rows,
+)
+
+AGENT = "beat-probe-agent"
+
+
+def _write_beat(state_dir: Path, *, age_s: float = 0.0) -> Path:
+    """A real heartbeat.json whose MTIME is ``age_s`` seconds old.
+
+    The ``ts`` field is deliberately stamped in 1970 on every beat written
+    here — that mirrors the real-world shape (a stale pane-activity epoch)
+    and keeps any implementation that reads ``ts`` instead of the mtime
+    from passing these tests by accident.
+    """
+    state_dir.mkdir(parents=True, exist_ok=True)
+    beat = state_dir / "heartbeat.json"
+    beat.write_text('{"state": "running", "ts": 1000000.0, "pid": 0}')
+    if age_s:
+        old = time.time() - age_s
+        os.utime(beat, (old, old))
+    return beat
+
+
+@pytest.fixture
+def beating_state_dir():
+    """This agent's REAL resolved state dir, beating, removed on teardown."""
+    state_dir = runtime_base_dir() / AGENT
+    _write_beat(state_dir)
+    yield state_dir
+    (state_dir / "heartbeat.json").unlink(missing_ok=True)
+    # stx-allow: fallback (reason: teardown must not fail the run if the
+    # sandbox dir was already reaped by another fixture)
+    try:
+        state_dir.rmdir()
+    except OSError:  # stx-allow: fallback (reason: see inline comment)
+        pass
+
+
+@pytest.fixture
+def silent_state_dir():
+    """The same agent with NO beat file — the ordinary defined case."""
+    state_dir = runtime_base_dir() / AGENT
+    beat = state_dir / "heartbeat.json"
+    beat.unlink(missing_ok=True)
+    yield state_dir
+
+
+def _spec_for(tmp_path: Path) -> Path:
+    """A real, fully-explicit v3 spec (red-start ruling 2026-07-21)."""
+    from tests.scitex_agent_container._helpers.explicit_spec import (
+        explicitize_yaml,
+    )
+
+    spec = tmp_path / "agents" / AGENT / "spec.yaml"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    body = "\n".join(
+        [
+            "apiVersion: scitex-agent-container/v3",
+            "kind: Agent",
+            "metadata: {}",
+            "spec:",
+            "  runtime: apptainer",
+            "  host: ${HOSTNAME}",
+            "  workdir: /home/agent/work",
+            "  apptainer:",
+            "    image: /x.sif",
+            "    binds: []",
+            "  claude:",
+            "    model: sonnet",
+            "  health:",
+            "    enabled: true",
+            "    interval: 60",
+            "  restart:",
+            "    policy: on-failure",
+            "    max_retries: 3",
+        ]
+    )
+    spec.write_text(explicitize_yaml(body + "\n"))
+    return spec
+
+
+def _rows(tmp_path: Path) -> list[dict]:
+    """Rows for one on-disk agent the registry has never heard of."""
+    spec = _spec_for(tmp_path)
+    return defined_agent_rows(
+        registered=set(),  # the whole point: NO registry row
+        port_claims={},
+        display_host="test-host",
+        discover=lambda: [(AGENT, spec)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. The signal itself — three-valued, keyed on the mtime.
+# ---------------------------------------------------------------------------
+
+
+def test_beat_written_now_is_evidence_of_life(tmp_path):
+    # Arrange — a beat file written this instant.
+    _write_beat(tmp_path)
+    # Act
+    verdict = beat_is_recent("anything", state_dir=tmp_path)
+    # Assert
+    assert verdict is True
+
+
+def test_stale_beat_is_not_evidence_of_life(tmp_path):
+    # Arrange — the fossil shape: last write long ago, still says "running".
+    _write_beat(tmp_path, age_s=RECENT_BEAT_MAX_AGE_S * 100)
+    # Act
+    verdict = beat_is_recent("anything", state_dir=tmp_path)
+    # Assert
+    assert verdict is False
+
+
+def test_absent_beat_file_is_unknown_not_false(tmp_path):
+    # Arrange — a state dir that exists but was never beaten into.
+    (tmp_path / "empty").mkdir()
+    # Act
+    verdict = beat_is_recent("anything", state_dir=tmp_path / "empty")
+    # Assert — None, never False: "no file" is no evidence, not a verdict.
+    assert verdict is None
+
+
+def test_beat_stamped_slightly_in_the_future_still_counts(tmp_path):
+    # Arrange — clock skew between the writing host and this reader.
+    _write_beat(tmp_path, age_s=-30.0)
+    # Act
+    verdict = beat_is_recent("anything", state_dir=tmp_path)
+    # Assert — a beat that just happened is a beat, skew notwithstanding.
+    assert verdict is True
+
+
+def test_stale_ts_field_does_not_defeat_a_fresh_write(tmp_path):
+    # Arrange — the exact live-fleet shape: ts ancient, file written now.
+    _write_beat(tmp_path)
+    # Act
+    verdict = beat_is_recent("anything", state_dir=tmp_path)
+    # Assert — an implementation reading ts (epoch 1970) answers False here.
+    assert verdict is True
+
+
+def test_resolver_finds_the_beat_without_an_explicit_state_dir(
+    beating_state_dir,
+):
+    # Arrange — the beat sits in the REAL resolved runtime root.
+    del beating_state_dir
+    # Act — no state_dir override: force the real resolver to run.
+    verdict = beat_is_recent(AGENT)
+    # Assert
+    assert verdict is True
+
+
+# ---------------------------------------------------------------------------
+# 2. THE REGRESSION: the row that made this necessary. On develop a beating
+#    agent with no registry row renders status="defined".
+# ---------------------------------------------------------------------------
+
+
+def test_beating_agent_absent_from_registry_is_not_called_defined(
+    tmp_path, beating_state_dir
+):
+    # Arrange — an agent beating right now, unknown to the registry.
+    del beating_state_dir
+    # Act
+    rows = _rows(tmp_path)
+    # Assert — "defined" would contradict a file written this second.
+    assert rows[0]["status"] != "defined"
+
+
+def test_beating_agent_is_marked_liveness_unknown(tmp_path, beating_state_dir):
+    # Arrange
+    del beating_state_dir
+    # Act
+    rows = _rows(tmp_path)
+    # Assert — the flag the remote-probe path uses for "could not tell".
+    assert rows[0].get("liveness_unknown") is True
+
+
+def test_silent_agent_absent_from_registry_still_renders_defined(
+    tmp_path, silent_state_dir
+):
+    # Arrange — no beat file at all: the ordinary defined case.
+    del silent_state_dir
+    # Act
+    rows = _rows(tmp_path)
+    # Assert — positive-only. Absence of a beat changes nothing.
+    assert rows[0]["status"] == "defined"


### PR DESCRIPTION
## The bug

`sac agents list` synthesizes a `defined` row for every agent with a spec on
disk but no registry row, and the source states the premise inline:

> These agents are never LIVE, so they carry the never-checked auth shape

**That premise is false.** Measured on the live fleet 2026-08-03, five agents
were beating while rendered `defined`:

| agent | beat file | registry |
|---|---|---|
| **scitex-agent-container** | written ~0s ago | `defined` |
| grant | ~0s | `defined` |
| scitex-logging | ~0s | `defined` |
| scitex-dev | ~0s | `defined` |
| scitex-cards | ~0s | `defined` |

The first row is this CLI's own host agent, mid-execution — the process
generating the reading was the process the reading denied. An absent registry
row means the registry forgot the agent; it does not mean the agent stopped.

Direction is one-way: `running` rows with no heartbeat file = **0**. Every
error is an under-count, matching the same finding from 2026-07-18.

## The fix

A recent beat promotes the row to `status="unknown"` + `liveness_unknown=True`
— the shape the remote-probe path already uses for "could not tell", so JSON
consumers need no new vocabulary.

**Positive-only and three-valued.** A stale or absent beat changes nothing:
SIGKILL leaves a `running` record behind forever, and 47 of the 90 `defined`
rows carry exactly such a fossil. Promoting those would bury the operator in
UNKNOWNs — the "train them to ignore the board" failure `_reconcile` already
warns about.

## Why the file mtime and not the `ts` field

This is the whole reason the helper exists. `write_heartbeat` accepts a `ts`
override and the TUI runner passes the tmux **pane-activity** epoch, so `ts`
answers "when did this pane last change", not "is this agent alive". For an
a2a-driven agent the two diverge without bound:

```
                       ts field    file mtime
scitex-agent-container    3.4h        ~0s
scitex-hpc                3.0h        ~0s
dotfiles                  3.2h        ~0s
scitex-cards             10.0h        ~0s
```

`seconds_since_last_beat` (12148.4 on a file written that second) and `pid`
(`0`) come off the same stale epoch and are equally unusable.

The threshold is **not** a tuning knob: beat mtimes are bimodal with a wide
empty gap — 11 files under 15 min (all within seconds), 56 over 24h, nothing
between — so any cutoff from one minute to one day gives the same partition.

Resolves via `runtime_base_dir()` per call rather than
`_session_state.DEFAULT_STATE_ROOT`, which snapshots at import and cannot see
a relocated runtime dir.

## Verification

**Mutation-proved.** Against a control worktree at develop carrying the new
module and the *identical signature* but not the beat logic:

```
assert 'defined' != 'defined'     # the bug, reproduced
assert None is True               # the missing flag
2 failed, 7 passed                # with the fix: 9/9
```

The third row test — a silent agent still renders `defined` — passes on **both**
trees. It is the over-reach guard.

A first control attempt was **discarded as invalid**: all three tests failed
there on `TypeError: unexpected keyword argument 'discover'` without reaching
an assertion, which proves the signature is new, not that behaviour differs.

`defined_agent_rows` gained a `discover` injection parameter because the
linter forbids `monkeypatch` and prescribes passing the collaborator in.

**Draft** until the local `cli_pkg` suite finishes (at 98%, zero failure
markers across 140+ progress lines). CI is the authoritative check.

## Not fixed here

`agents list` renders its `heartbeat_at` column from `ts`, so that column shows
pane-activity age fleet-wide and every a2a-driven agent looks idle for hours
while working. Separate defect, carded as
`sac-heartbeat-at-column-shows-pane-activity-not-liveness-20260803`.

**Why the registry row is absent for those five is still unknown.** This stops
the row from lying about it; it does not explain the absence.

Refs: `sac-agents-list-and-auth-status-disagree-by-one-agent-20260718`
