### PR TITLE
fix(listen): the /agents timeout message reports what it observed, and names no cause

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_listen_probe.py
+++ b/src/scitex_agent_container/_lifecycle/_listen_probe.py
@@ -24,16 +24,35 @@ The daemon was UP and answering in under a fifth of a second. It was not
 word that asserts a process is crash-looping, which nobody had looked at.
 A timeout on ONE route licenses a claim about THAT ROUTE, and nothing more.
 
-WHY THE SPLIT IS REAL (it is not an accident of routing)
---------------------------------------------------------
-``BearerAuthMiddleware.PUBLIC_PATHS`` exempts ``/v1/health``, and both
-that route and the middleware's own 401 are ``async`` — they answer ON the
-event loop. Every AUTHENTICATED route dispatches through the shared worker
-pool. So a pool exhausted by stacked-up work wedges the authed routes while
-the public path stays fast: exactly the 0.18s-401 / 25s-timeout split that
-was observed. (Root cause of that exhaustion — abandoned heartbeat ticks
-leaking zombie threads into the pool — is fixed in PR #647; this module is
-about not LYING when it happens again for some other reason.)
+WHAT THIS MODULE MAY AND MAY NOT CONCLUDE
+-----------------------------------------
+It probes exactly ONE route — ``/v1/health``, which is UNAUTHENTICATED —
+so it can settle "is the daemon serving HTTP at all" and nothing else.
+
+It used to go further. A previous version explained the split structurally:
+``BearerAuthMiddleware.PUBLIC_PATHS`` exempts ``/v1/health``, that route and
+the middleware's 401 are ``async`` and answer on the event loop, while
+authenticated routes dispatch through a shared worker pool — therefore an
+exhausted pool wedges the authed routes and spares the public one.
+
+THAT INFERENCE IS REFUTED (scitex-dev, 2026-08-04). ``POST /v1/host_exec``
+is AUTHENTICATED and answered in ~2.4s with a 127KB payload while
+``POST /agents`` hung, measured seconds apart on the same daemon. A pool
+shared by both cannot wedge one and spare the other, so pool exhaustion
+cannot be the mechanism — whatever the routing structure is.
+
+The structural facts above may still be true; what does not follow is the
+CAUSE. One observation on an unauthenticated route cannot distinguish
+authentication, this handler, or the work behind it. So the message names
+no cause and instead tells the reader how to get one: call a second
+AUTHENTICATED route and compare.
+
+This is the SECOND wrong story this message has carried. The first
+("unreachable; it may be flapping") was corrected in 2026-07 by replacing
+it with the pool story — a better-sounding cause rather than no cause. Both
+prescribed ``sac listen restart``, which interrupts every agent on the box.
+The lesson is not "find the right explanation"; it is that this module is
+not positioned to have one.
 
 CONTRACT: any HTTP response at all — 200, 401, 403, 404 — proves the daemon
 is UP and serving HTTP. Only the ABSENCE of an HTTP exchange (connection
@@ -184,19 +203,20 @@ def transport_failure_message(
         return (
             f"{verb} of {name!r} failed: {route} to {base!r} got no response "
             f"within {timeout_s:.0f}s ({exc}).\n"
-            f"MEASURED (not guessed): {probe.evidence()} — so the listen "
-            f"daemon is UP and serving. The daemon is NOT down and this is "
-            f"NOT a 'broker unreachable' failure: it is the AUTHENTICATED "
-            f"route that did not answer.\n"
-            f"Why the two differ: authenticated routes dispatch through "
-            f"listen's shared worker pool; the public {HEALTH_PATH} path is "
-            f"served on the event loop and never touches it. A pool exhausted "
-            f"by stacked-up work therefore wedges one and leaves the other "
-            f"fast.\n"
-            f"Fix: `sac listen restart` on the host clears the wedged pool. "
-            f"If it recurs, the host's sac predates the fix for the heartbeat "
-            f"ticks that leaked threads into that pool (PR #647) — upgrade sac "
-            f"on the host."
+            f"OBSERVED: {probe.evidence()} — so the listen daemon is UP and "
+            f"serving. The daemon is NOT down and this is NOT a 'broker "
+            f"unreachable' failure: this ONE route did not answer.\n"
+            f"NOT ESTABLISHED — why. {HEALTH_PATH} is UNAUTHENTICATED, so it "
+            f"does not tell you whether authentication, this handler, or the "
+            f"work behind it is at fault. Two observations, one of them on a "
+            f"route with different properties, cannot single out a cause.\n"
+            f"NEXT, to find out rather than guess: call a DIFFERENT "
+            f"authenticated route (e.g. POST /v1/host_exec with a trivial "
+            f"argv) and compare. If it answers, the fault is specific to "
+            f"{route} and restarting the daemon will not fix it. If it also "
+            f"hangs, the fault is shared and a restart is worth trying — "
+            f"`sac listen restart` on the host, which interrupts EVERY agent "
+            f"mid-operation, so establish that it is shared first."
         )
     return (
         f"{verb} of {name!r} failed: cannot reach listen at {base!r} ({exc}).\n"

--- a/tests/scitex_agent_container/_lifecycle/test__listen_probe.py
+++ b/tests/scitex_agent_container/_lifecycle/test__listen_probe.py
@@ -72,9 +72,7 @@ def _opener_raising(exc: Exception):
 
 
 def _http_error(status: int) -> urlerror.HTTPError:
-    return urlerror.HTTPError(
-        f"{_BASE}/v1/health", status, "nope", {}, io.BytesIO(b"")
-    )
+    return urlerror.HTTPError(f"{_BASE}/v1/health", status, "nope", {}, io.BytesIO(b""))
 
 
 # ---------------------------------------------------------------------------
@@ -201,14 +199,18 @@ def test_message_says_daemon_is_up_when_it_answered() -> None:
     assert "the listen daemon is UP and serving" in message
 
 
-def test_message_blames_the_authenticated_route_not_the_daemon() -> None:
-    # Arrange
+def test_message_blames_the_route_not_the_daemon() -> None:
+    # Arrange — this test previously pinned the literal phrase "it is the
+    # AUTHENTICATED route that did not answer". Its INTENT (attribute the
+    # failure to the route, not the daemon) was right, but that wording
+    # encoded the very claim scitex-dev refuted on 2026-08-04: that being
+    # AUTHENTICATED is what distinguishes the hanging route. /v1/host_exec is
+    # authenticated and answers fast, so it is not. Asserting the intent
+    # instead keeps the guard and drops the theory.
     # Act
     message = _message(_SERVING)
     # Assert
-    assert "it is the AUTHENTICATED route that did not answer" in message.replace(
-        "\n", " "
-    )
+    assert "this ONE route did not answer" in message.replace("\n", " ")
 
 
 def test_message_quotes_the_measurement_it_made() -> None:
@@ -249,3 +251,69 @@ def test_message_keeps_the_listen_restart_remedy_when_down() -> None:
     message = _message(_DEAD)
     # Assert
     assert "sac listen restart" in message
+
+
+# ---------------------------------------------------------------------------
+# The message must REPORT what it observed, never NAME a cause it has not
+# established (scitex-dev, 2026-08-04).
+#
+# This message has now carried TWO different wrong explanations. The first
+# ("the host listen broker is unreachable; it may be flapping") was corrected
+# on 2026-07-14 by replacing it with a second one: authenticated routes share a
+# worker pool that /v1/health bypasses, therefore the pool is exhausted,
+# therefore restart the daemon. That is also wrong — /v1/host_exec is
+# AUTHENTICATED and answers in ~2.4s while /agents hangs, measured seconds
+# apart on the same daemon, so a shared-pool exhaustion cannot wedge one and
+# spare the other.
+#
+# Both times the fix was a better-sounding cause rather than removing the
+# speculation, and both times the prescription was `sac listen restart` — a
+# SHARED daemon restart that interrupts every other agent. scitex-dev declined
+# it on those grounds and stayed blocked 11 days; I followed it and lost two
+# remedies to a diagnosis that could not have been right.
+#
+# So the guard is not "do not say 'flapping'" or "do not say 'pool'" — a third
+# wrong story would pass both. It is: the ONE observation this code has is an
+# UNAUTHENTICATED health check, and it cannot single out a cause.
+# ---------------------------------------------------------------------------
+
+
+def test_message_does_not_blame_the_worker_pool() -> None:
+    # Arrange — /v1/host_exec is authenticated AND fast, so pool exhaustion
+    # cannot explain one authed route hanging while another answers.
+    # Act
+    message = _message(_SERVING)
+    # Assert
+    assert "worker pool" not in message
+
+
+def test_message_admits_the_cause_is_not_established() -> None:
+    # Arrange — one unauthenticated observation cannot identify a cause.
+    # Act
+    message = _message(_SERVING)
+    # Assert
+    assert "NOT ESTABLISHED" in message
+
+
+def test_message_names_the_health_route_as_unauthenticated() -> None:
+    # Arrange — the reader must know WHY the cheap probe proves so little.
+    # Act
+    message = _message(_SERVING)
+    # Assert
+    assert "UNAUTHENTICATED" in message
+
+
+def test_message_offers_a_second_authed_route_as_the_next_step() -> None:
+    # Arrange — the discriminator that separates "this handler" from "shared".
+    # Act
+    message = _message(_SERVING)
+    # Assert
+    assert "/v1/host_exec" in message
+
+
+def test_message_warns_a_restart_interrupts_every_agent() -> None:
+    # Arrange — the remedy's COST is what made following it blindly expensive.
+    # Act
+    message = _message(_SERVING)
+    # Assert
+    assert "interrupts EVERY agent" in message


### PR DESCRIPTION
## The message named a cause it had not established, twice

`transport_failure_message` is what an agent sees when a brokered POST to the
host `sac listen` gets no HTTP response. Until this PR it printed a mechanism:

> authenticated routes dispatch through listen's shared worker pool; the public
> `/v1/health` path is served on the event loop; a pool exhausted by stacked-up
> work wedges one and leaves the other fast

**scitex-dev refuted it by measurement (2026-08-04):**

| route | auth | result |
|---|---|---|
| `POST /agents` | bearer | no response in 30s |
| `POST /v1/host_exec` | bearer | HTTP 200, ~2.4s, 127KB |

Seconds apart, same daemon, both authenticated. A pool shared by both cannot
wedge one and spare the other.

## The function's own docstring already forbade it

Unchanged, and explicit:

> * the daemon answered the cheap path → ... Say that, and only that.
> * the daemon answered nothing at all → ... still do not speculate about *why*.

The body then speculated for four lines and prescribed a remedy. The contract
was right; the implementation drifted. This restores the contract rather than
adding a new rule.

## Why a wrong story survived review

The message says **"MEASURED (not guessed)"** — and it did measure. One route:
`/v1/health`, which is **UNAUTHENTICATED**. It then generalised to the whole
authenticated *class* without testing a second member. A real measurement welded
to an untested generalisation reads as evidence-backed, which is exactly what
makes it hard to challenge.

The remedy is expensive: `sac listen restart` interrupts **every** agent on the
box. scitex-dev declined it on those grounds and stayed blocked 11 days on work
that needed neither the restart nor that route. I followed it — restarted the
daemon (PID changed, confirmed), then upgraded host sac 0.21.22 → 0.24.22.
Neither helped, because neither addressed the fault.

This is the **second** wrong story here. The first ("unreachable; it may be
flapping") was corrected on 2026-07-14 by replacing it with the pool story — a
better-sounding cause rather than no cause. That is the pattern this PR breaks.

## After

```
OBSERVED: an unauthenticated GET .../v1/health answered HTTP 401 in 0.18s — so
the listen daemon is UP and serving. The daemon is NOT down and this is NOT a
'broker unreachable' failure: this ONE route did not answer.
NOT ESTABLISHED — why. /v1/health is UNAUTHENTICATED, so it does not tell you
whether authentication, this handler, or the work behind it is at fault. Two
observations, one of them on a route with different properties, cannot single
out a cause.
NEXT, to find out rather than guess: call a DIFFERENT authenticated route (e.g.
POST /v1/host_exec with a trivial argv) and compare. If it answers, the fault is
specific to POST /agents/... and restarting the daemon will not fix it. If it
also hangs, the fault is shared and a restart is worth trying — `sac listen
restart` on the host, which interrupts EVERY agent mid-operation, so establish
that it is shared first.
```

A discriminator instead of a prescription. The restart is still reachable, with
its blast radius attached to it.

The module docstring carried the same refuted inference under "WHY THE SPLIT IS
REAL"; it is corrected the same way — the structural facts may still hold, the
CAUSE does not follow from them.

## Guards, mutation-proved

Five new tests: no worker-pool blame / cause admitted unestablished / health
named as unauthenticated / second authed route offered / restart's blast radius
stated. I restored the pool story in the file and re-ran: **5 failed, 15
passed** — each guard goes red against the old behaviour.

Deliberately *not* "never say 'pool'": a third wrong story would pass that. The
guard is that the message admits what it cannot know.

**One existing test changed, and it encoded the bug.** It pinned the literal
`"it is the AUTHENTICATED route that did not answer"`. The intent — blame the
route, not the daemon — is right, but the wording asserts that being
authenticated is the distinguishing property, which is the exact claim
`/v1/host_exec` refutes. It now asserts the intent: `"this ONE route did not
answer"`.

## Verification

- 75 passed — `test__listen_probe.py`, `test__restart_client.py`, `test__spawn_client.py`
- `ruff check --select F401,F811` clean
- Mutation control: 5/5 new guards red against the restored pool story

## Still open

**Why `POST /agents` hangs is unknown.** This PR does not fix it — it stops the
tool from asserting an answer, and hands the reader the next measurement.
Tracked on `sac-list-view-reports-live-agent-as-stopped-20260804` (finding 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dHR46CRG3cRSsVWmhPG1h
