### PR TITLE
test(agents list): the guard for "live agent reads stopped" could not fail

### DIFF
--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
@@ -22,9 +22,14 @@ no ``SimpleNamespace`` posing as config.
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Iterator
+
+import pytest
 
 import scitex_agent_container.cli_pkg._helpers._agent_list as _al
 from scitex_agent_container.cli_pkg._helpers._agent_list import (
@@ -267,10 +272,23 @@ def test_probe_local_never_raises_returns_bool_or_none_on_real_runtime(tmp_path)
 # ClaudeSessionRuntime. The default runtime is ``tui``; probing a live
 # TUI agent through ClaudeSessionRuntime → ApptainerContainerRuntime read
 # a nonexistent apptainer_pid and reported "stopped" for a running agent.
+#
+# THE TWO TESTS BELOW DID NOT GUARD THAT, AND WERE NAMED AS IF THEY DID.
+# Neither called ``_probe_local``: one asserted ``_get_runtime``'s mapping,
+# the other ``TuiSessionRuntime.is_running``'s rule — both true statements
+# about components the probe HAPPENS to use, neither an assertion that the
+# probe uses them. Measured 2026-08-04: restoring the exact historical bug
+# (``_probe_local`` hardcoding ``ClaudeSessionRuntime``) left this whole
+# file at 68 passed. A defect that has now recurred TWICE had no test that
+# could go red for it.
+#
+# They are renamed to say what they actually check, and the real guard —
+# ``test_probe_local_reports_a_live_tui_session_as_running`` below — drives
+# ``_probe_local`` itself against a live tmux session.
 # ---------------------------------------------------------------------------
 
 
-def test_probe_local_uses_the_declared_runtime_for_a_tui_config():
+def test_get_runtime_maps_a_tui_config_to_the_tui_runtime():
     # Arrange — default AgentConfig resolves runtime="tui".
     from scitex_agent_container._lifecycle._runtime_select import _get_runtime
     from scitex_agent_container.config._types import AgentConfig
@@ -279,14 +297,14 @@ def test_probe_local_uses_the_declared_runtime_for_a_tui_config():
     cfg = AgentConfig(name="tui-probe-agent")
     # Act
     runtime = _get_runtime(cfg)
-    # Assert — the runtime _probe_local now routes through is the TUI one.
+    # Assert — the SELECTOR's mapping only. Says nothing about its callers.
     assert isinstance(runtime, TuiSessionRuntime)
 
 
-def test_probe_local_agrees_with_status_runtime_selection():
-    # Arrange — a tui config with an injected multiplexer that reports a
-    # live, fresh session; _probe_local must observe the SAME liveness the
-    # declared-runtime probe (what agent_status uses) reports: running.
+def test_tui_runtime_reports_a_live_session_as_running():
+    # Arrange — a tui runtime over an in-memory multiplexer reporting a live
+    # session. Pins the RUNTIME's liveness rule; again says nothing about
+    # which runtime _probe_local reaches.
     import time
 
     from scitex_agent_container.config._types import AgentConfig
@@ -310,9 +328,34 @@ def test_probe_local_agrees_with_status_runtime_selection():
     cfg = AgentConfig(name="tui-live-agent")
     runtime = TuiSessionRuntime(multiplexer=_LiveMux)
     del session_name_for  # imported only to document the tui-<name> convention
-    # Act — the declared-runtime probe (the exact one _probe_local calls
-    # after routing through _get_runtime) sees the live session.
+    # Act
     running = runtime.is_running(cfg)
+    # Assert
+    assert running is True
+
+
+@pytest.mark.skipif(
+    shutil.which("tmux") is None,
+    reason="this guard drives the real probe against a real tmux session",
+)
+def test_probe_local_reports_a_live_tui_session_as_running():
+    # Arrange — a REAL tmux session under the ``tui-<name>`` convention
+    # TuiSessionRuntime keys on, with a live pane process. The original
+    # defect in one line: a running TUI agent the list must not call
+    # "stopped". Hardcode ClaudeSessionRuntime back into _probe_local and
+    # this goes RED (no apptainer pidfile → False) — which is exactly what
+    # the two tests above could not do.
+    from scitex_agent_container.config._types import AgentConfig
+
+    session = f"tui-probe-guard-{os.getpid()}"
+    subprocess.run(
+        ["tmux", "new-session", "-d", "-s", session, "sleep 120"], check=True
+    )
+    try:
+        # Act — the production probe, not its parts.
+        running = _probe_local(AgentConfig(name=session[len("tui-") :]))
+    finally:
+        subprocess.run(["tmux", "kill-session", "-t", session], check=False)
     # Assert
     assert running is True
 


### PR DESCRIPTION
## The guard for a twice-recurring defect could not fail

I restored the exact historical bug in `_probe_local`:

```diff
-from ..._lifecycle._runtime_select import _get_runtime
-return _get_runtime(cfg).is_running(cfg)
+from ...runtimes.claude_session import ClaudeSessionRuntime
+return ClaudeSessionRuntime().is_running(cfg)
```

and ran the file that is supposed to guard it:

```
68 passed in 34.35s
```

That is the bug `_probe_local`'s own docstring records being fixed **twice** —
`liveness-live-agents-read-stopped`, then `sac-fix-live-agents-read-stopped`
(2026-07-08). It had no test that could go red for it.

## Why the old tests could not fail

Neither called `_probe_local`.

| test | what it actually asserts |
|---|---|
| `test_probe_local_uses_the_declared_runtime_for_a_tui_config` | `isinstance(_get_runtime(cfg), TuiSessionRuntime)` |
| `test_probe_local_agrees_with_status_runtime_selection` | `TuiSessionRuntime(multiplexer=_LiveMux).is_running(cfg) is True` |

Both are true statements about components the probe *happens to* use. Neither
asserts that the probe uses them — which is the entire content of the bug.

The second even carries the comment *"the exact one `_probe_local` calls after
routing through `_get_runtime`"*: an assumption written exactly where the
assertion should have been. Named for `_probe_local`, they read as coverage of
it. That is why a third recurrence found the same hole open.

## The new guard

Drives the production function against a **real tmux session** under the
`tui-<name>` convention `TuiSessionRuntime` keys on, with a live pane process —
i.e. a running TUI agent, the thing the list must not call "stopped".

**Mutation control: 1 failed, 68 passed.** It is the only test in the file that
can see the bug, and the 68 that stay green are the same 68 that passed under
it.

No mocks: a real `tmux new-session`, killed in a `finally`, session name keyed
to the pid so parallel runs cannot collide. `skipif` when tmux is absent — the
guard needs a real multiplexer, and a skip that says so beats an assertion that
cannot mean anything. It does **not** skip here (69 collected, 69 passed).

The two old tests are **kept and renamed** to what they actually check
(`test_get_runtime_maps_a_tui_config_to_the_tui_runtime`,
`test_tui_runtime_reports_a_live_session_as_running`). Both are worth having as
unit facts; neither may keep a name that claims to guard the probe.

## What this does not do

Reported by scitex-dev, who measured `sac agents list --json` showing
`scitex-logging` as `stopped` while `sac agents start` on the same agent
reported ALIVE with a 38s-old heartbeat.

**I could not reproduce that exact case** — the host rebooted between their
measurement and mine, so the population moved. This PR does not claim to fix
it. It closes the reason a third occurrence would again have to be argued from
scratch.

Also not in scope, carded as
`sac-list-stopped-verdict-records-no-adapter-20260804`: a `stopped` row still
records nothing about *how* it was reached — which adapter answered, or which
exception produced an `unknown` (line 112 is a bare `except Exception: return
None` that discards the exception). Fixing that means the probe returns detail,
which changes a swap seam three test files patch — real work, unrelated to the
missing guard.

## Verification

- 231 passed — `cli_pkg/_helpers/`, `test_cli.py`
- `ruff check --select F401,F811` clean
- Mutation control run twice: bug restored → 68 passed before this PR, 1 failed / 68 passed after

Refs: `sac-list-view-reports-live-agent-as-stopped-20260804` (finding 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dHR46CRG3cRSsVWmhPG1h
