### PR TITLE
fix(verdict): an abstention is not a dissent — fold the silent signals to a count

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_verdict.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict.py
@@ -351,7 +351,7 @@ class LivenessVerdict:
 
         e.g. ``ALIVE (delivery: 1 live inbox subscriber)``
              ``UNKNOWN (heartbeat: pid=0 in heartbeat.json)``
-             ``DEAD (process: tmux has no session for this agent) | also: heartbeat[alive], registry[unknown]``
+             ``DEAD (process: tmux has no session for this agent) | also: heartbeat[alive] | 2 signals had no reading``
 
         Each signal's ``detail`` is deliberately verbose and educational — the
         justification an operator can read once and learn from. But a STATUS
@@ -361,6 +361,27 @@ class LivenessVerdict:
         reduces the dissenters to ``source[verdict]`` tags. The complete
         reasoning for every signal is always one ``--json`` away in
         :meth:`to_dict` (``evidence[].detail``) — nothing is lost, only folded.
+
+        AN ABSTENTION IS NOT A DISSENT, and conflating the two is what the
+        operator called dirty. Every non-agreeing signal used to be tagged the
+        same way, so a routine ``sac-restart`` printed::
+
+            DEAD (process: tmux probe SUCCEEDED and the tmux server has NO
+            session for this agent) | also: delivery[unknown],
+            heartbeat[unknown], registry[unknown], screen[unknown]
+
+        Four tags, four times the same non-statement. An UNKNOWN signal holds
+        no opinion to disagree with — it did not observe anything — so listing
+        each by name spends the reader's attention on the instruments that had
+        nothing to say, and buries any instrument that genuinely DISAGREES in
+        the same list.
+
+        The count is NOT dropped, because it is real evidence about the
+        verdict's STRENGTH: DEAD on one instrument with four abstentions is a
+        much weaker reading than DEAD on one with four agreeing, and the reader
+        must be able to see that at a glance. So abstentions fold to a count
+        and genuine opposition is always named, never folded — that tag is the
+        one that vetoes destruction, and it must not be crowded out by silence.
         """
         if not self.signals:
             return f"{self.verdict.upper()} (no signals gathered)"
@@ -371,9 +392,17 @@ class LivenessVerdict:
         parts = [f"{s.source}: {_first_clause(s.detail)}" for s in agreeing]
         why = "; ".join(parts) if parts else "no corroborating signal"
         out = f"{self.verdict.upper()} ({why})"
-        if dissenting:
-            tags = ", ".join(f"{s.source}[{s.verdict}]" for s in dissenting)
+        # Split the non-agreeing signals by whether they actually hold a
+        # contrary opinion. (When the verdict IS unknown, the abstainers agree
+        # with it, so this list is empty by construction.)
+        opposing = [s for s in dissenting if s.verdict != UNKNOWN]
+        abstaining = [s for s in dissenting if s.verdict == UNKNOWN]
+        if opposing:
+            tags = ", ".join(f"{s.source}[{s.verdict}]" for s in opposing)
             out += f" | also: {tags}"
+        if abstaining:
+            noun = "signal" if len(abstaining) == 1 else "signals"
+            out += f" | {len(abstaining)} {noun} had no reading"
         return out
 
     def to_dict(self) -> dict:

--- a/tests/scitex_agent_container/_lifecycle/test__verdict.py
+++ b/tests/scitex_agent_container/_lifecycle/test__verdict.py
@@ -556,6 +556,89 @@ def test_render_omits_a_dissenters_verbose_prose(dissenting_heartbeat_signals):
 
 
 # --------------------------------------------------------------------------
+# AN ABSTENTION IS NOT A DISSENT. The operator pasted this from a routine
+# ``sac-restart grant`` and called it dirty:
+#
+#   DEAD (process: tmux probe SUCCEEDED and the tmux server has NO session for
+#   this agent) | also: delivery[unknown], heartbeat[unknown],
+#   registry[unknown], screen[unknown]
+#
+# Four tags carrying four copies of the same non-statement. An UNKNOWN signal
+# has no opinion to disagree with, so naming each one spends the reader's
+# attention on the instruments that had nothing to say — and buries any
+# instrument that genuinely DISAGREES in the same undifferentiated list.
+#
+# The count is kept, because it is evidence about the verdict's STRENGTH:
+# DEAD on one instrument with four abstentions is much weaker than DEAD on one
+# with four agreeing. Folding must not become hiding.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def one_dead_four_abstaining():
+    """The operator's exact case: one DEAD reading, four instruments silent."""
+    return [
+        Signal(
+            SOURCE_PROCESS,
+            DEAD,
+            "tmux probe SUCCEEDED and the tmux server has NO session for this agent",
+            INSTRUMENT_HOST_TMUX,
+        ),
+        Signal(SOURCE_DELIVERY, UNKNOWN, "no listen to ask", INSTRUMENT_LISTEN_BROKER),
+        Signal(SOURCE_HEARTBEAT, UNKNOWN, "no beat file", INSTRUMENT_AGENT_SELF),
+        Signal(SOURCE_REGISTRY, UNKNOWN, "no registry row", INSTRUMENT_PID_NAMESPACE),
+        Signal(SOURCE_SCREEN, UNKNOWN, "no pane to capture", INSTRUMENT_HOST_TMUX),
+    ]
+
+
+def test_render_does_not_tag_each_abstaining_signal_by_name(one_dead_four_abstaining):
+    # Arrange — one_dead_four_abstaining fixture
+    # Act
+    rendered = decide("grant", one_dead_four_abstaining).render()
+    # Assert — the four-tag splurge the operator objected to.
+    assert "registry[unknown]" not in rendered
+
+
+def test_render_counts_the_abstaining_signals_instead(one_dead_four_abstaining):
+    # Arrange — one_dead_four_abstaining fixture
+    # Act
+    rendered = decide("grant", one_dead_four_abstaining).render()
+    # Assert — folded, not dropped: four instruments observed nothing, and that
+    # is what makes this DEAD a weak reading.
+    assert "4 signals had no reading" in rendered
+
+
+def test_render_says_signal_singular_for_one_abstention():
+    # Arrange — a lone abstention must not read "1 signals".
+    signals = [
+        Signal(SOURCE_PROCESS, DEAD, "no session", INSTRUMENT_HOST_TMUX),
+        Signal(SOURCE_DELIVERY, UNKNOWN, "no listen to ask", INSTRUMENT_LISTEN_BROKER),
+    ]
+    # Act
+    rendered = decide("grant", signals).render()
+    # Assert
+    assert "1 signal had no reading" in rendered
+
+
+def test_render_still_names_a_signal_that_actually_disagrees():
+    # Arrange — the property folding must never eat: a signal holding a real
+    # contrary reading stays NAMED even when it is outnumbered by silence.
+    # A live heartbeat vetoes the DEAD (one live signal is decisive), so the
+    # verdict is ALIVE and it is the process DEAD reading that dissents — and
+    # that is precisely the reading an operator must not lose behind a count.
+    signals = [
+        Signal(SOURCE_PROCESS, DEAD, "no session", INSTRUMENT_HOST_TMUX),
+        Signal(SOURCE_HEARTBEAT, ALIVE, "beaten 12s ago", INSTRUMENT_AGENT_SELF),
+        Signal(SOURCE_DELIVERY, UNKNOWN, "no listen to ask", INSTRUMENT_LISTEN_BROKER),
+        Signal(SOURCE_SCREEN, UNKNOWN, "no pane to capture", INSTRUMENT_HOST_TMUX),
+    ]
+    # Act
+    rendered = decide("grant", signals).render()
+    # Assert
+    assert "process[dead]" in rendered
+
+
+# --------------------------------------------------------------------------
 # WEDGED — present but NOT working. The P0: a tmux-GREEN agent stuck under a
 # frozen auth banner read ALIVE (false-green; clew sat dead two days). The
 # screen instrument observes WORKING, not mere presence, so a wedged agent now


### PR DESCRIPTION
## The tail #859 left behind

The operator pasted this from a routine `sac-restart grant` and called it dirty:

```
[sac:liveness] grant: DEAD (process: tmux probe SUCCEEDED and the tmux server
has NO session for this agent) | also: delivery[unknown], heartbeat[unknown],
registry[unknown], screen[unknown]
```

#859 fixed the prefix and the level. It deliberately left this tail, because
suppressing it lives in `LivenessVerdict.render()`, which every status surface
shares.

## The defect is a category error, not verbosity

`render()` split signals into agreeing and "dissenting", where dissenting meant
nothing more than `verdict != self.verdict`. So an **UNKNOWN got the same
`source[verdict]` tag as a signal that genuinely DISAGREES.**

An UNKNOWN holds no opinion to disagree with — it did not observe anything.
Naming four of them spends the reader's attention on the instruments that had
nothing to say, and buries any instrument that actually contradicts the verdict
in the same undifferentiated list. **That second half is the one that matters:**
a dissenting tag is the reading that vetoes a destructive action, and it must
not be crowded out by silence.

## The count is kept — dropping it was the easy wrong fix

Four abstentions is real evidence about the verdict's **strength**. DEAD on one
instrument with four silent ones is a much weaker reading than DEAD on one with
four agreeing, and the operator has to see that at a glance.

```
DEAD (process: tmux probe SUCCEEDED and the tmux server has NO session for
this agent) | 4 signals had no reading

ALIVE (heartbeat: beaten 12s ago) | also: process[dead] | 2 signals had no reading
```

Singular for one (`1 signal had no reading`). When the verdict *is* unknown the
abstainers agree with it, so the fold is empty by construction.

## Guards, mutation-proved

Reverting to the old single-list render turns the three new-behaviour guards red
(no per-name unknown tag / the count is present / singular wording):
**3 failed, 40 passed.**

The fourth guard — *a genuinely opposing signal stays NAMED* — passes under
**both** versions, and that is the point: it is a regression guard on the safety
property the fold must never eat, not a guard on the new behaviour. Saying so
explicitly beats letting it look like mutation coverage it does not provide.

One of those four caught my own wrong premise as I wrote it. I arranged a DEAD
process + ALIVE heartbeat + two unknowns and asserted `heartbeat[alive]` would
be the dissenting tag. It is not — a live signal **vetoes** the DEAD, so the
verdict resolves to ALIVE and it is `process[dead]` that dissents. The test was
wrong, not the code. The arrangement is kept, because it exercises exactly the
interaction I wanted (opposition named beside a fold), with the assertion
corrected.

## Nothing parses this string

`render()` feeds a display call in `_start_announce.py` and the `summary` field
of `to_dict()`. No consumer in `src/` or `tests/` greps `also:` — checked before
changing the format. Per-signal reasoning stays one `--json` away in
`evidence[].detail`: folded, never lost.

## Verification

- **103 passed** — `test__verdict.py` plus every other test file that touches
  render output (`test__jobs_audit.py`, `test__hosted_runner_guard.py`,
  `test__start_noop_notice.py`), found by grepping `tests/` for `.render()`,
  `[unknown]` and `no corroborating`
- `ruff check --select F401,F811` clean
- Mutation control: old render → 3 failed, 40 passed

Refs: `sac-verdict-render-emits-four-unknown-tags-20260804`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dHR46CRG3cRSsVWmhPG1h
