### PR TITLE
feat(agents list): a row says HOW its status was reached, not just what it is

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_helpers/__init__.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/__init__.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
         is_live_status,
         print_agent_list,
         print_agent_list_json,
+        probe_local_detail,
     )
     from ._completion import agent_name_complete  # noqa: F401
     from ._console import console, system_msg  # noqa: F401
@@ -57,6 +58,7 @@ _LAZY_ATTR_SOURCES = {
     "_discover_defined_agents": "._agent_list",
     "_extract_damaged_fields": "._agent_list",
     "_probe_local": "._agent_list",
+    "probe_local_detail": "._agent_list",
     "get_agent_list_data": "._agent_list",
     "is_live_status": "._agent_list",
     "print_agent_list": "._agent_list",

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -42,6 +42,12 @@ from ._agent_list_bound_account import bound_accounts_by_agent  # noqa: F401
 # Host-DISPLAY resolution (Host column) — sibling module, 512-line cap split.
 from ._agent_list_host import _host_display_for, _resolve_display_host
 
+# The local liveness probe AND its record of how it answered. Kept in a
+# sibling so the adapter name can only ever come from the probe call itself
+# — see that module's header for why a separately-computed label would lie
+# in exactly the case it exists to catch.
+from ._agent_list_probe import LocalProbe, probe_local_detail  # noqa: F401
+
 # Row shaping + the movement trio. Re-exported so the bare-name call sites
 # here, and the test seams that rebind ``_al._movement_fields``, keep working.
 from ._agent_list_row import (  # noqa: F401
@@ -101,16 +107,16 @@ def _probe_local(cfg) -> bool | None:
 
     Returns None on exception (e.g. malformed config) so the caller
     surfaces ``status='unknown'`` rather than crashing the list.
-    """
-    # stx-allow: fallback (reason: runtime may be missing or state-dir may
-    # not exist for an agent that never ran; either case maps to
-    # liveness_unknown rather than a hard error.)
-    try:
-        from ..._lifecycle._runtime_select import _get_runtime
 
-        return _get_runtime(cfg).is_running(cfg)
-    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
-        return None
+    THE TRI-STATE ANSWER ONLY. The probe itself now lives in
+    :func:`._agent_list_probe.probe_local_detail`, which additionally
+    records WHICH adapter answered and, on an abstention, why. This
+    remains the bool-or-None view because that is what the merged
+    regression guard drives (``test_probe_local_reports_a_live_tui_session
+    _as_running``) and what external callers have always had. It delegates
+    rather than re-implementing, so the two can never disagree.
+    """
+    return probe_local_detail(cfg).running
 
 
 def _label_group_matches(labels: dict, wanted: str) -> bool:
@@ -280,19 +286,19 @@ def get_agent_list_data(
     # Explicit shutdown(wait=False) instead of ``with ... as pool:``
     # so the context manager's __exit__ doesn't join all workers
     # (todo#254 regression: that would defeat the per-probe timeout).
-    probe_results: dict[int, bool | None] = {}
+    probe_results: dict[int, LocalProbe] = {}
     probe_targets = [
         (prep["idx"], prep["cfg"]) for prep in prepared if prep["cfg"] is not None
     ]
     if probe_targets:
-        # Resolve _probe_local via the parent package at call time so
-        # test monkeypatching of ``_helpers._probe_local`` still takes
-        # effect (tests historically patched the flat-module attribute;
-        # the __init__ re-export keeps that contract working post-split).
+        # Resolve the probe via the parent package at call time so a test
+        # swapping ``_helpers.probe_local_detail`` still takes effect (tests
+        # historically patched the flat-module attribute; the __init__
+        # re-export keeps that contract working post-split).
         import sys as _sys
 
         _pkg = _sys.modules[__name__.rsplit(".", 1)[0]]
-        _probe_fn = getattr(_pkg, "_probe_local", _probe_local)
+        _probe_fn = getattr(_pkg, "probe_local_detail", probe_local_detail)
 
         pool = ThreadPoolExecutor(max_workers=max_parallel_probes)
         try:
@@ -301,15 +307,23 @@ def get_agent_list_data(
             }
             for future in list(future_to_idx):
                 idx = future_to_idx[future]
-                # stx-allow: fallback (reason: per-probe runtime exception
-                # maps to None = "liveness unknown", not "stopped")
+                # stx-allow: fallback (reason: an abstention, NOT a "stopped" —
+                # and it says which of the two ways it abstained, because a
+                # verdict that cannot explain itself is what made the third
+                # "live agent reads stopped" report undiagnosable.)
                 try:
                     probe_results[idx] = future.result(timeout=remote_probe_timeout_s)
                 except _FuturesTimeout:  # stx-allow: fallback (reason: expected failure — see inline comment)
-                    probe_results[idx] = None
+                    probe_results[idx] = LocalProbe(
+                        running=None,
+                        runtime=None,
+                        error=f"probe exceeded {remote_probe_timeout_s}s",
+                    )
                     future.cancel()
-                except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
-                    probe_results[idx] = None
+                except Exception as exc:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+                    probe_results[idx] = LocalProbe(
+                        running=None, runtime=None, error=f"probe raised: {exc}"
+                    )
         finally:
             pool.shutdown(wait=False)
 
@@ -337,15 +351,25 @@ def get_agent_list_data(
 
         liveness_unknown = False
         probe = probe_results.get(prep["idx"])
+        # HOW the verdict was reached, carried on the row. A bare "stopped"
+        # is exactly what made the 2026-08-04 report undiagnosable once the
+        # host had rebooted: no adapter, no reason, nothing to re-derive from.
+        probe_runtime: str | None = None
+        probe_error: str | None = None
         if cfg is None:
             # Couldn't load the yaml — can't probe.
             is_running = False
             liveness_unknown = True
-        elif probe is None:
+            probe_error = "spec did not load"
+        elif probe is None or probe.running is None:
             is_running = False
             liveness_unknown = True
+            if probe is not None:
+                probe_runtime = probe.runtime
+                probe_error = probe.error
         else:
-            is_running = bool(probe)
+            is_running = probe.running
+            probe_runtime = probe.runtime
 
         status_val: str
         if liveness_unknown:
@@ -419,6 +443,8 @@ def get_agent_list_data(
                 deferred=deferred,
                 errors=errors,
                 liveness_unknown=liveness_unknown,
+                probe_runtime=probe_runtime,
+                probe_error=probe_error,
                 labels=labels,
             )
         )

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_probe.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_probe.py
@@ -1,0 +1,96 @@
+"""The local liveness probe, and a RECORD of how it answered.
+
+WHY THIS MODULE EXISTS. ``sac agents list`` has reported a demonstrably
+running agent as ``stopped`` three times now. Twice it was fixed
+(``liveness-live-agents-read-stopped``; ``sac-fix-live-agents-read-stopped``,
+2026-07-08). The third report (scitex-dev, 2026-08-04) could not be
+diagnosed AT ALL: the host rebooted between their measurement and the
+investigation, the population moved, and the verdict itself carried no
+trace of how it had been reached. A ``stopped`` row said "stopped" and
+nothing else — not which runtime adapter answered, and for an ``unknown``
+row, not which exception produced it (the old ``except Exception: return
+None`` discarded the exception object entirely).
+
+That is a MISSING FACILITY, not poor investigation. A defect that keeps
+recurring and keeps having to be re-derived from scratch is telling you
+the subsystem cannot answer questions about itself. So this module makes
+the probe RECORD what it did, and the recording rides in
+``sac agents list --json`` where it needs no debug flag and no
+reproduction: a third occurrence will read ``stopped via
+ClaudeSessionRuntime`` on a ``tui`` agent, which IS the bug, stated.
+
+THE LABEL MUST COME FROM INSIDE THE PROBE. The cheap alternative — have
+the row builder call ``_get_runtime(cfg).__class__.__name__`` on its own —
+is worse than no label at all. If the probe were ever hardcoded to one
+adapter again (the exact historical bug), the row would report the
+CORRECTLY selected adapter while the probe used the wrong one: a label
+that lies precisely in the case it exists to catch. So the adapter name
+is a return value of the probe call itself and cannot disagree with it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["LocalProbe", "probe_local_detail"]
+
+
+@dataclass(frozen=True)
+class LocalProbe:
+    """What the local liveness probe did, not merely what it concluded.
+
+    ``running`` keeps the original tri-state and its meaning is unchanged:
+    ``True``/``False`` are answers, ``None`` is an ABSTENTION (the probe
+    could not run) and must never be read as "stopped".
+
+    ``runtime`` is the adapter class that actually answered — ``None`` only
+    when runtime selection itself failed, i.e. when nothing answered.
+    ``error`` is populated exactly when ``running is None``, and says which
+    step failed.
+    """
+
+    running: bool | None
+    runtime: str | None
+    error: str | None
+
+
+def probe_local_detail(cfg) -> LocalProbe:
+    """Probe an agent's liveness via its DECLARED runtime adapter.
+
+    Must select the SAME runtime ``agent_status`` uses
+    (:func:`_lifecycle._runtime_select._get_runtime`, which branches on
+    ``spec.runtime``) — NOT a hardcoded ``ClaudeSessionRuntime``. That
+    hardcode was the root cause of "live agent reads stopped": the DEFAULT
+    runtime is ``tui``, whose liveness is the ``tui-<name>`` tmux session's
+    pane process. Probing a live TUI agent through ``ClaudeSessionRuntime``
+    reached ``ApptainerContainerRuntime.is_running`` → ``os.kill(read_pid,
+    0)``, but a TUI agent NEVER writes an ``apptainer_pid`` file, so
+    ``_read_pid`` returned ``None`` → ``is_running`` returned ``False`` →
+    status "stopped" for a provably-running agent.
+
+    Never raises. The two failure modes are recorded SEPARATELY because
+    they mean different things: selection failing means we never chose an
+    instrument, while ``is_running`` raising means a NAMED instrument was
+    asked and could not answer. Collapsing both to a bare ``None`` is what
+    made the third recurrence undiagnosable.
+    """
+    # stx-allow: fallback (reason: runtime may be missing or the spec may be
+    # unloadable for an agent that never ran; that is an ABSTENTION, not a
+    # crash and not a "stopped" — and the reason is kept, not discarded.)
+    try:
+        from ..._lifecycle._runtime_select import _get_runtime
+
+        runtime = _get_runtime(cfg)
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        return LocalProbe(running=None, runtime=None, error=f"runtime select: {exc}")
+    label = type(runtime).__name__
+    # stx-allow: fallback (reason: a named instrument was asked and could not
+    # answer; record WHICH one, because that is the whole diagnostic value.)
+    try:
+        return LocalProbe(
+            running=bool(runtime.is_running(cfg)), runtime=label, error=None
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        return LocalProbe(
+            running=None, runtime=label, error=f"{label}.is_running: {exc}"
+        )

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_row.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_row.py
@@ -69,6 +69,8 @@ def build_agent_row(
     errors,
     liveness_unknown: bool,
     labels,
+    probe_runtime: str | None = None,
+    probe_error: str | None = None,
 ) -> dict:
     """Build one row dict.
 
@@ -99,6 +101,17 @@ def build_agent_row(
         row["validation_errors"] = errors
     if liveness_unknown:
         row["liveness_unknown"] = True
+    # HOW the status was reached. ``probe_runtime`` names the adapter that
+    # actually answered, so ``status: "stopped"`` with
+    # ``probe_runtime: "ClaudeSessionRuntime"`` on a ``tui`` agent IS the
+    # thrice-recurring "live agent reads stopped" defect, stated on the row
+    # rather than re-derived from scratch after the fact. ``probe_error`` says
+    # why an ``unknown`` abstained. Both optional, same as the keys above: an
+    # ordinary row stays free of empty noise.
+    if probe_runtime:
+        row["probe_runtime"] = probe_runtime
+    if probe_error:
+        row["probe_error"] = probe_error
     if labels:
         row["labels"] = labels
     return row

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
@@ -33,6 +33,7 @@ import pytest
 
 import scitex_agent_container.cli_pkg._helpers._agent_list as _al
 from scitex_agent_container.cli_pkg._helpers._agent_list import (
+    LocalProbe,
     _extract_damaged_fields,
     _is_self_peer_marker,
     _probe_local,
@@ -64,28 +65,49 @@ class _FakeRegistry:
 
 
 @contextmanager
-def _swap_probe(impl: Callable[[Any], bool | None]) -> Iterator[None]:
-    """Swap ``_probe_local`` for a real callable returning a fixed value.
+def _swap_probe(impl: Callable[[Any], Any]) -> Iterator[None]:
+    """Swap ``probe_local_detail`` for a real callable returning a fixed value.
 
     Production resolves the probe via the parent ``cli_pkg._helpers``
-    package (``getattr(_pkg, "_probe_local", _probe_local)``) so the
-    swap must land on BOTH the inner module and the parent package
+    package (``getattr(_pkg, "probe_local_detail", probe_local_detail)``)
+    so the swap must land on BOTH the inner module and the parent package
     re-export to actually intercept the call.
+
+    The seam MOVED from ``_probe_local`` to ``probe_local_detail`` when the
+    probe started recording which adapter answered. That rename is not
+    cosmetic: had these swaps been left pointing at ``_probe_local``, the
+    pool would have stopped consulting them and every test built on this
+    fixture would have gone on passing while testing nothing — the exact
+    silently-blind failure mode #861 was about.
+    ``_running(...)`` below builds the value the pool now expects.
     """
     import scitex_agent_container.cli_pkg._helpers as _pkg
 
-    saved_al = _al._probe_local
-    saved_pkg = getattr(_pkg, "_probe_local", None)
-    _al._probe_local = impl  # type: ignore[assignment]
-    _pkg._probe_local = impl  # type: ignore[assignment]
+    saved_al = _al.probe_local_detail
+    saved_pkg = getattr(_pkg, "probe_local_detail", None)
+    _al.probe_local_detail = impl  # type: ignore[assignment]
+    _pkg.probe_local_detail = impl  # type: ignore[assignment]
     try:
         yield
     finally:
-        _al._probe_local = saved_al  # type: ignore[assignment]
+        _al.probe_local_detail = saved_al  # type: ignore[assignment]
         if saved_pkg is None:
-            delattr(_pkg, "_probe_local")
+            delattr(_pkg, "probe_local_detail")
         else:
-            _pkg._probe_local = saved_pkg  # type: ignore[assignment]
+            _pkg.probe_local_detail = saved_pkg  # type: ignore[assignment]
+
+
+def _running(value: bool | None, runtime: str = "TestRuntime"):
+    """A probe callable answering ``value`` — the shape the pool consumes."""
+
+    def impl(cfg):
+        return LocalProbe(
+            running=value,
+            runtime=runtime if value is not None else None,
+            error=None if value is not None else "test abstention",
+        )
+
+    return impl
 
 
 @contextmanager
@@ -396,7 +418,7 @@ def test_get_data_with_capability_filter_includes_matching_agent(tmp_path):
     ]
     registry = _FakeRegistry(entries)
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         out = get_agent_list_data(registry, capability="HPC")
     # Assert
     assert len(out) == 1 and out[0]["name"] == "x"
@@ -408,7 +430,7 @@ def test_get_data_with_capability_filter_excludes_non_matching_agent(tmp_path):
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         out = get_agent_list_data(registry, capability="HPC")
     # Assert
     assert out == []
@@ -420,7 +442,7 @@ def test_get_data_with_machine_filter_excludes_non_matching_agent(tmp_path):
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         out = get_agent_list_data(registry, machine="m1")
     # Assert
     assert out == []
@@ -444,7 +466,7 @@ def test_get_data_with_group_filter_includes_matching_agent(tmp_path):
     ]
     registry = _FakeRegistry(entries)
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         out = get_agent_list_data(registry, group="active")
     # Assert
     assert [r["name"] for r in out] == ["x"]
@@ -456,7 +478,7 @@ def test_get_data_with_group_filter_excludes_non_matching_agent(tmp_path):
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         out = get_agent_list_data(registry, group="active")
     # Assert
     assert out == []
@@ -468,7 +490,7 @@ def test_get_data_with_group_filter_matches_any_of_multiple_wanted_values(tmp_pa
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         out = get_agent_list_data(registry, group="active,researcher")
     # Assert — OR-match: any overlap between wanted and carried groups hits.
     assert [r["name"] for r in out] == ["x"]
@@ -482,7 +504,7 @@ def test_get_data_with_group_filter_matches_a_non_first_group(tmp_path):
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         out = get_agent_list_data(registry, group="active")
     # Assert
     assert [r["name"] for r in out] == ["x"]
@@ -494,7 +516,7 @@ def test_get_data_with_group_filter_ungrouped_agent_is_excluded(tmp_path):
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         out = get_agent_list_data(registry, group="active")
     # Assert
     assert out == []
@@ -506,7 +528,7 @@ def test_get_data_without_group_filter_includes_ungrouped_agent(tmp_path):
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         out = get_agent_list_data(registry)
     # Assert
     assert [r["name"] for r in out] == ["x"]
@@ -548,7 +570,7 @@ def test_get_data_group_filter_selects_what_the_tags_filter_used_to_select(tmp_p
         ]
     )
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         out = get_agent_list_data(registry, group="active")
     # Assert — exactly the formerly-tagged agent, not the whole developer set.
     assert [r["name"] for r in out] == ["figrecipe"]
@@ -575,7 +597,7 @@ def test_get_data_row_status_running_when_probe_returns_true(tmp_path):
     entries = [{"name": "x", "config": str(spec), "screen": "-", "started_at": "-"}]
     registry = _FakeRegistry(entries)
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         out = get_agent_list_data(registry)
     # Assert
     assert out[0]["status"] == "running"
@@ -587,7 +609,7 @@ def test_get_data_row_status_stopped_when_probe_returns_false(tmp_path):
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: False):
+    with _swap_discover(_no_discover), _swap_probe(_running(False)):
         out = get_agent_list_data(registry)
     # Assert
     assert out[0]["status"] == "stopped"
@@ -599,7 +621,7 @@ def test_get_data_row_status_unknown_when_probe_returns_none(tmp_path):
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: None):
+    with _swap_discover(_no_discover), _swap_probe(_running(None)):
         out = get_agent_list_data(registry)
     # Assert
     assert out[0]["status"] == "unknown"
@@ -611,10 +633,89 @@ def test_get_data_row_liveness_unknown_flagged_when_probe_returns_none(tmp_path)
     entries = [{"name": "x", "config": str(spec)}]
     registry = _FakeRegistry(entries)
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: None):
+    with _swap_discover(_no_discover), _swap_probe(_running(None)):
         out = get_agent_list_data(registry)
     # Assert
     assert out[0].get("liveness_unknown") is True
+
+
+# ---------------------------------------------------------------------------
+# HOW the verdict was reached, carried on the row.
+#
+# scitex-dev measured a live agent reading `stopped` on 2026-08-04. By the time
+# it was investigated the host had rebooted, the population had moved, and the
+# row said "stopped" and nothing else — no adapter, no reason. The defect had
+# already been fixed twice and each diagnosis had to be rebuilt from scratch,
+# because the verdict could not say how it was reached. These pin the record.
+# ---------------------------------------------------------------------------
+
+
+def test_get_data_row_names_the_adapter_that_answered(tmp_path):
+    # Arrange
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(_running(True, "TuiSessionRuntime")):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert out[0]["probe_runtime"] == "TuiSessionRuntime"
+
+
+def test_get_data_stopped_row_names_the_adapter_that_answered(tmp_path):
+    # Arrange — the diagnostic case. "stopped" + the adapter that said so is
+    # what turns a third recurrence into a statement instead of an argument:
+    # ClaudeSessionRuntime on a tui agent IS the bug.
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
+    # Act
+    with (
+        _swap_discover(_no_discover),
+        _swap_probe(_running(False, "ClaudeSessionRuntime")),
+    ):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert out[0]["probe_runtime"] == "ClaudeSessionRuntime"
+
+
+def test_get_data_row_label_comes_from_the_probe_not_a_second_lookup(tmp_path):
+    # Arrange — THE design constraint. A row builder that computed the adapter
+    # itself would report the CORRECTLY selected one while the probe used
+    # another, i.e. it would read clean in exactly the case it exists to catch.
+    # The spec here declares runtime `apptainer`; the probe reports answering
+    # through something else entirely. The row must repeat the PROBE.
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
+    # Act
+    with (
+        _swap_discover(_no_discover),
+        _swap_probe(_running(False, "NotTheSelectedOne")),
+    ):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert out[0]["probe_runtime"] == "NotTheSelectedOne"
+
+
+def test_get_data_unknown_row_says_why_it_abstained(tmp_path):
+    # Arrange — an abstention used to discard its own exception, so `unknown`
+    # meant "no answer, and no way to find out why".
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(_running(None)):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert out[0]["probe_error"] == "test abstention"
+
+
+def test_probe_detail_records_the_adapter_for_a_tui_config():
+    # Arrange — the real probe, no swap: a tui config must be answered by the
+    # tui adapter, and the record must say so.
+    from scitex_agent_container.config._types import AgentConfig
+
+    # Act
+    probe = _al.probe_local_detail(AgentConfig(name="detail-probe-agent"))
+    # Assert
+    assert probe.runtime == "TuiSessionRuntime"
 
 
 def test_get_data_merges_in_defined_agents_absent_from_registry(tmp_path):
@@ -670,7 +771,7 @@ def test_print_agent_list_renders_agent_name_in_table(capsys, tmp_path):
         [{"name": "x", "config": str(spec), "screen": "s", "started_at": "ts"}]
     )
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         print_agent_list(registry)
     # Assert
     assert "x" in capsys.readouterr().out
@@ -683,7 +784,7 @@ def test_print_agent_list_renders_status_word_for_running_agent(capsys, tmp_path
         [{"name": "x", "config": str(spec), "screen": "s", "started_at": "ts"}]
     )
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         print_agent_list(registry)
     # Assert — rich may color, the text always contains the word.
     assert "running" in capsys.readouterr().out
@@ -696,7 +797,7 @@ def test_print_agent_list_prints_full_validation_errors_under_table(capsys, tmp_
     spec = _write_invalid_spec(tmp_path / "x")
     registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         print_agent_list(registry, verbose=True)
     # Assert
     assert "spec.runtime" in capsys.readouterr().out
@@ -707,7 +808,7 @@ def test_print_agent_list_json_emits_agent_name_in_first_row(capsys, tmp_path):
     spec = _write_valid_spec(tmp_path / "x")
     registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         print_agent_list_json(registry)
     # Assert
     data = json.loads(capsys.readouterr().out)
@@ -900,7 +1001,7 @@ def test_get_data_row_carries_account_field(tmp_path):
     # Act
     with (
         _swap_discover(_no_discover),
-        _swap_probe(lambda cfg: True),
+        _swap_probe(_running(True)),
         _swap_account(lambda cfg: "alice@example.com"),
     ):
         out = get_agent_list_data(registry)
@@ -931,7 +1032,7 @@ def test_print_agent_list_renders_account_column_header(capsys, tmp_path):
     # Act
     with (
         _swap_discover(_no_discover),
-        _swap_probe(lambda cfg: True),
+        _swap_probe(_running(True)),
         _swap_account(lambda cfg: "alice@example.com"),
     ):
         print_agent_list(registry)
@@ -948,7 +1049,7 @@ def test_print_agent_list_renders_account_value(capsys, tmp_path):
     # Act
     with (
         _swap_discover(_no_discover),
-        _swap_probe(lambda cfg: True),
+        _swap_probe(_running(True)),
         _swap_account(lambda cfg: "acct-x"),
     ):
         print_agent_list(registry)
@@ -963,7 +1064,7 @@ def test_print_agent_list_json_emits_account_in_row(capsys, tmp_path):
     # Act
     with (
         _swap_discover(_no_discover),
-        _swap_probe(lambda cfg: True),
+        _swap_probe(_running(True)),
         _swap_account(lambda cfg: "alice@example.com"),
     ):
         print_agent_list_json(registry)
@@ -1084,7 +1185,7 @@ def test_print_agent_list_hides_ghost_and_shows_hidden_footer(capsys, tmp_path):
         ]
     )
     # Act — default view.
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         print_agent_list(registry)
     # Assert — ghost row hidden + footer shown ("deadrow" avoids collision
     # with the footer's own "stale/ghost" wording).
@@ -1098,7 +1199,7 @@ def test_print_agent_list_show_all_includes_ghost(capsys, tmp_path):
         [{"name": "ghost", "config": str(tmp_path / "gone" / "spec.yaml")}]
     )
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         print_agent_list(registry, show_all=True)
     # Assert
     assert "ghost" in capsys.readouterr().out
@@ -1111,7 +1212,7 @@ def test_print_agent_list_verbose_adds_path_column(capsys, tmp_path):
         [{"name": "good", "config": str(good), "screen": "s", "started_at": "ts"}]
     )
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         print_agent_list(registry, verbose=True)
     # Assert — the Path header appears only in verbose mode.
     assert "Path" in capsys.readouterr().out
@@ -1124,7 +1225,7 @@ def test_print_agent_list_default_omits_path_column(capsys, tmp_path):
         [{"name": "good", "config": str(good), "screen": "s", "started_at": "ts"}]
     )
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         print_agent_list(registry)
     # Assert
     assert "Path" not in capsys.readouterr().out
@@ -1187,7 +1288,7 @@ def test_print_agent_list_default_shows_running_agent(capsys, tmp_path):
     # Arrange
     registry, discover = _running_plus_defined_and_invalid(tmp_path)
     # Act — default view.
-    with _swap_discover(discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(discover), _swap_probe(_running(True)):
         print_agent_list(registry)
     # Assert
     assert "runner" in capsys.readouterr().out
@@ -1197,7 +1298,7 @@ def test_print_agent_list_default_hides_definition_and_invalid(capsys, tmp_path)
     # Arrange
     registry, discover = _running_plus_defined_and_invalid(tmp_path)
     # Act
-    with _swap_discover(discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(discover), _swap_probe(_running(True)):
         print_agent_list(registry)
     # Assert — the definition ("def1") + invalid ("bad1") rows are hidden.
     out = capsys.readouterr().out
@@ -1208,7 +1309,7 @@ def test_print_agent_list_default_footer_counts_hidden(capsys, tmp_path):
     # Arrange
     registry, discover = _running_plus_defined_and_invalid(tmp_path)
     # Act
-    with _swap_discover(discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(discover), _swap_probe(_running(True)):
         print_agent_list(registry)
     # Assert — footer names both hidden categories.
     out = capsys.readouterr().out
@@ -1220,7 +1321,7 @@ def test_print_agent_list_default_omits_validation_blocks(capsys, tmp_path):
     # print in the default view (the wall the operator asked us to remove).
     registry, discover = _running_plus_defined_and_invalid(tmp_path)
     # Act
-    with _swap_discover(discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(discover), _swap_probe(_running(True)):
         print_agent_list(registry)
     # Assert
     assert "spec.runtime" not in capsys.readouterr().out
@@ -1231,7 +1332,7 @@ def test_print_agent_list_default_hides_stopped_agent(capsys, tmp_path):
     spec = _write_valid_spec(tmp_path / "stopper")
     registry = _FakeRegistry([{"name": "stopper", "config": str(spec)}])
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: False):
+    with _swap_discover(_no_discover), _swap_probe(_running(False)):
         print_agent_list(registry)
     # Assert — no table (name absent); footer reports the hidden stopped one.
     out = capsys.readouterr().out
@@ -1243,7 +1344,7 @@ def test_print_agent_list_verbose_includes_stopped_agent(capsys, tmp_path):
     spec = _write_valid_spec(tmp_path / "stopper")
     registry = _FakeRegistry([{"name": "stopper", "config": str(spec)}])
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: False):
+    with _swap_discover(_no_discover), _swap_probe(_running(False)):
         print_agent_list(registry, verbose=True)
     # Assert
     assert "stopper" in capsys.readouterr().out
@@ -1253,7 +1354,7 @@ def test_print_agent_list_verbose_includes_definition_and_validation(capsys, tmp
     # Arrange
     registry, discover = _running_plus_defined_and_invalid(tmp_path)
     # Act — -v shows every status AND the per-agent validation-error detail.
-    with _swap_discover(discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(discover), _swap_probe(_running(True)):
         print_agent_list(registry, verbose=True)
     # Assert
     out = capsys.readouterr().out
@@ -1277,7 +1378,7 @@ def test_get_data_running_row_prefers_runtime_account(tmp_path):
     # Act — running (probe True): runtime account wins over the spec label.
     with (
         _swap_discover(_no_discover),
-        _swap_probe(lambda cfg: True),
+        _swap_probe(_running(True)),
         _swap_account(lambda cfg: "spec-label (host@example.com)"),
         _swap_runtime_account(lambda name: "runtime-pick@example.com"),
     ):
@@ -1293,7 +1394,7 @@ def test_get_data_stopped_row_uses_spec_account_not_runtime(tmp_path):
     # Act — stopped (probe False): the runtime probe is NOT consulted.
     with (
         _swap_discover(_no_discover),
-        _swap_probe(lambda cfg: False),
+        _swap_probe(_running(False)),
         _swap_account(lambda cfg: "spec-label"),
         _swap_runtime_account(lambda name: "should-not-be-used@example.com"),
     ):
@@ -1309,7 +1410,7 @@ def test_get_data_running_row_falls_back_to_spec_when_runtime_unresolved(tmp_pat
     # Act
     with (
         _swap_discover(_no_discover),
-        _swap_probe(lambda cfg: True),
+        _swap_probe(_running(True)),
         _swap_account(lambda cfg: "spec-fallback"),
         _swap_runtime_account(lambda name: None),
     ):

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_host_display.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_host_display.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterator
 
 import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+from scitex_agent_container.cli_pkg._helpers._agent_list_probe import LocalProbe
 from scitex_agent_container.cli_pkg._helpers._agent_list import (
     get_agent_list_data,
     print_agent_list,
@@ -59,18 +60,27 @@ def _swap_probe(impl: Callable[[Any], bool | None]) -> Iterator[None]:
     """Swap ``_probe_local`` on BOTH the module + parent-package re-export."""
     import scitex_agent_container.cli_pkg._helpers as _pkg
 
-    saved_al = _al._probe_local
-    saved_pkg = getattr(_pkg, "_probe_local", None)
-    _al._probe_local = impl  # type: ignore[assignment]
-    _pkg._probe_local = impl  # type: ignore[assignment]
+    saved_al = _al.probe_local_detail
+    saved_pkg = getattr(_pkg, "probe_local_detail", None)
+    _al.probe_local_detail = impl  # type: ignore[assignment]
+    _pkg.probe_local_detail = impl  # type: ignore[assignment]
     try:
         yield
     finally:
-        _al._probe_local = saved_al  # type: ignore[assignment]
+        _al.probe_local_detail = saved_al  # type: ignore[assignment]
         if saved_pkg is None:
-            delattr(_pkg, "_probe_local")
+            delattr(_pkg, "probe_local_detail")
         else:
-            _pkg._probe_local = saved_pkg  # type: ignore[assignment]
+            _pkg.probe_local_detail = saved_pkg  # type: ignore[assignment]
+
+
+def _running(value: bool | None, runtime: str = "TestRuntime"):
+    """A probe callable answering ``value`` — the shape the pool consumes."""
+
+    def impl(cfg):
+        return LocalProbe(running=value, runtime=runtime, error=None)
+
+    return impl
 
 
 @contextmanager
@@ -224,7 +234,7 @@ def test_registered_row_carries_resolved_host_display(tmp_path):
     spec = _write_valid_spec(tmp_path / "x")
     registry = _FakeRegistry([{"name": "x", "config": str(spec), "started_at": "ts"}])
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True), _swap_display_host(
+    with _swap_discover(_no_discover), _swap_probe(_running(True)), _swap_display_host(
         "ywata-note-win"
     ):
         out = get_agent_list_data(registry)
@@ -238,7 +248,7 @@ def test_registered_row_keeps_raw_host_local_for_backward_compat(tmp_path):
     spec = _write_valid_spec(tmp_path / "x")
     registry = _FakeRegistry([{"name": "x", "config": str(spec), "started_at": "ts"}])
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True), _swap_display_host(
+    with _swap_discover(_no_discover), _swap_probe(_running(True)), _swap_display_host(
         "ywata-note-win"
     ):
         out = get_agent_list_data(registry)
@@ -283,7 +293,7 @@ def test_json_row_exposes_both_host_and_host_display(tmp_path, capsys):
     spec = _write_valid_spec(tmp_path / "x")
     registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True), _swap_display_host(
+    with _swap_discover(_no_discover), _swap_probe(_running(True)), _swap_display_host(
         "ywata-note-win"
     ):
         print_agent_list_json(registry)
@@ -304,7 +314,7 @@ def test_json_started_at_keeps_raw_iso(tmp_path, capsys):
         [{"name": "x", "config": str(spec), "started_at": _STARTED_ISO}]
     )
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True), _swap_display_host(
+    with _swap_discover(_no_discover), _swap_probe(_running(True)), _swap_display_host(
         "ywata-note-win"
     ):
         print_agent_list_json(registry)
@@ -325,9 +335,7 @@ def test_print_agent_list_renders_resolved_hostname_in_host_column(tmp_path, cap
         [{"name": "x", "config": str(spec), "started_at": _STARTED_ISO}]
     )
     # Act
-    with _env_set("COLUMNS", "240"), _swap_discover(_no_discover), _swap_probe(
-        lambda cfg: True
-    ), _swap_display_host("ywata-note-win"):
+    with _env_set("COLUMNS", "240"), _swap_discover(_no_discover), _swap_probe(_running(True)), _swap_display_host("ywata-note-win"):
         print_agent_list(registry)
     # Assert — the resolved hostname shows, not the literal "local" sentinel.
     out = capsys.readouterr().out
@@ -343,7 +351,7 @@ def test_print_agent_list_started_column_renders_pinned_jst(tmp_path, capsys):
     # Act
     with _env_set("SAC_DISPLAY_TZ", "Asia/Tokyo"), _env_set(
         "COLUMNS", "240"
-    ), _swap_discover(_no_discover), _swap_probe(lambda cfg: True), _swap_display_host(
+    ), _swap_discover(_no_discover), _swap_probe(_running(True)), _swap_display_host(
         "ywata-note-win"
     ):
         print_agent_list(registry)

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_perf.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_perf.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterator
 
 import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+from scitex_agent_container.cli_pkg._helpers._agent_list_probe import LocalProbe
 from scitex_agent_container.cli_pkg._helpers._agent_list import get_agent_list_data
 
 
@@ -36,18 +37,27 @@ class _FakeRegistry:
 def _swap_probe(impl: Callable[[Any], bool | None]) -> Iterator[None]:
     import scitex_agent_container.cli_pkg._helpers as _pkg
 
-    saved_al = _al._probe_local
-    saved_pkg = getattr(_pkg, "_probe_local", None)
-    _al._probe_local = impl  # type: ignore[assignment]
-    _pkg._probe_local = impl  # type: ignore[assignment]
+    saved_al = _al.probe_local_detail
+    saved_pkg = getattr(_pkg, "probe_local_detail", None)
+    _al.probe_local_detail = impl  # type: ignore[assignment]
+    _pkg.probe_local_detail = impl  # type: ignore[assignment]
     try:
         yield
     finally:
-        _al._probe_local = saved_al  # type: ignore[assignment]
+        _al.probe_local_detail = saved_al  # type: ignore[assignment]
         if saved_pkg is None:
-            delattr(_pkg, "_probe_local")
+            delattr(_pkg, "probe_local_detail")
         else:
-            _pkg._probe_local = saved_pkg  # type: ignore[assignment]
+            _pkg.probe_local_detail = saved_pkg  # type: ignore[assignment]
+
+
+def _running(value: bool | None, runtime: str = "TestRuntime"):
+    """A probe callable answering ``value`` — the shape the pool consumes."""
+
+    def impl(cfg):
+        return LocalProbe(running=value, runtime=runtime, error=None)
+
+    return impl
 
 
 @contextmanager
@@ -122,7 +132,7 @@ def test_ports_come_from_a_single_list_claims_call(tmp_path):
     # Act
     with _swap_attr(port_allocator, "list_claims", _fake_list_claims), _swap_attr(
         port_allocator, "get_port", _fake_get_port
-    ), _swap_probe(lambda cfg: True):
+    ), _swap_probe(_running(True)):
         with _swap_attr(_al, "_discover_defined_agents", _no_discover):
             out = get_agent_list_data(registry)
     # Assert — exactly one bulk query for two agents; no per-agent get_port.
@@ -139,9 +149,7 @@ def test_port_from_claims_map_lands_on_the_row(tmp_path):
     spec_a = _write_valid_spec(tmp_path / "a")
     registry = _FakeRegistry([{"name": "a", "config": str(spec_a)}])
     # Act
-    with _swap_attr(port_allocator, "list_claims", _fake_list_claims), _swap_probe(
-        lambda cfg: True
-    ), _swap_attr(_al, "_discover_defined_agents", _no_discover):
+    with _swap_attr(port_allocator, "list_claims", _fake_list_claims), _swap_probe(_running(True)), _swap_attr(_al, "_discover_defined_agents", _no_discover):
         out = get_agent_list_data(registry)
     # Assert
     assert out[0]["a2a_port"] == 19001
@@ -154,9 +162,7 @@ def test_port_none_when_agent_has_no_claim(tmp_path):
     spec_a = _write_valid_spec(tmp_path / "a")
     registry = _FakeRegistry([{"name": "a", "config": str(spec_a)}])
     # Act
-    with _swap_attr(port_allocator, "list_claims", lambda **_k: []), _swap_probe(
-        lambda cfg: True
-    ), _swap_attr(_al, "_discover_defined_agents", _no_discover):
+    with _swap_attr(port_allocator, "list_claims", lambda **_k: []), _swap_probe(_running(True)), _swap_attr(_al, "_discover_defined_agents", _no_discover):
         out = get_agent_list_data(registry)
     # Assert
     assert out[0]["a2a_port"] is None
@@ -180,9 +186,7 @@ def test_validate_config_skipped_when_load_succeeds(tmp_path):
     spec = _write_valid_spec(tmp_path / "a")
     registry = _FakeRegistry([{"name": "a", "config": str(spec)}])
     # Act
-    with _swap_attr(_validation, "validate_config", _counting_validate), _swap_probe(
-        lambda cfg: True
-    ), _swap_attr(_al, "_discover_defined_agents", _no_discover):
+    with _swap_attr(_validation, "validate_config", _counting_validate), _swap_probe(_running(True)), _swap_attr(_al, "_discover_defined_agents", _no_discover):
         out = get_agent_list_data(registry)
     # Assert — a valid, loaded config is not re-parsed/re-validated.
     assert calls["n"] == 0 and out[0]["status"] == "running"
@@ -220,7 +224,7 @@ def test_running_only_enriches_the_running_row(tmp_path):
     spec = _write_valid_spec(tmp_path / "a")
     registry = _FakeRegistry([{"name": "a", "config": str(spec)}])
     # Act
-    with _swap_probe(lambda cfg: True), _swap_attr(
+    with _swap_probe(_running(True)), _swap_attr(
         _al, "_safe_account_for", lambda cfg: "ACCT"
     ), _swap_attr(_al, "_runtime_account_for", lambda name: None), _swap_attr(
         _al, "_discover_defined_agents", _no_discover
@@ -235,7 +239,7 @@ def test_running_only_defers_account_for_stopped_row(tmp_path):
     spec = _write_valid_spec(tmp_path / "a")
     registry = _FakeRegistry([{"name": "a", "config": str(spec)}])
     # Act
-    with _swap_probe(lambda cfg: False), _swap_attr(
+    with _swap_probe(_running(False)), _swap_attr(
         _al, "_safe_account_for", lambda cfg: "ACCT"
     ), _swap_attr(_al, "_discover_defined_agents", _no_discover):
         out = get_agent_list_data(registry, running_only=True)
@@ -248,7 +252,7 @@ def test_running_only_false_still_enriches_stopped_row(tmp_path):
     spec = _write_valid_spec(tmp_path / "a")
     registry = _FakeRegistry([{"name": "a", "config": str(spec)}])
     # Act
-    with _swap_probe(lambda cfg: False), _swap_attr(
+    with _swap_probe(_running(False)), _swap_attr(
         _al, "_safe_account_for", lambda cfg: "ACCT"
     ), _swap_attr(_al, "_discover_defined_agents", _no_discover):
         out = get_agent_list_data(registry, running_only=False)
@@ -261,7 +265,7 @@ def test_deferred_row_keeps_the_movement_key_contract(tmp_path):
     spec = _write_valid_spec(tmp_path / "a")
     registry = _FakeRegistry([{"name": "a", "config": str(spec)}])
     # Act
-    with _swap_probe(lambda cfg: False), _swap_attr(
+    with _swap_probe(_running(False)), _swap_attr(
         _al, "_safe_account_for", lambda cfg: "ACCT"
     ), _swap_attr(_al, "_discover_defined_agents", _no_discover):
         out = get_agent_list_data(registry, running_only=True)

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_remote.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_remote.py
@@ -36,6 +36,7 @@ import scitex_agent_container.cli_pkg._helpers._agent_list as _al
 from scitex_agent_container._state.registry import Registry
 from scitex_agent_container.cli_pkg._helpers import is_live_status
 from scitex_agent_container.cli_pkg._helpers._agent_list import (
+    LocalProbe,
     get_agent_list_data,
     remote_instance_rows,
 )
@@ -119,22 +120,37 @@ def _swap_discover(
 
 
 @contextmanager
-def _swap_probe(impl: Callable[[Any], bool | None]) -> Iterator[None]:
-    """Swap the LOCAL liveness probe (both module + parent-package re-export)."""
+def _swap_probe(impl: Callable[[Any], Any]) -> Iterator[None]:
+    """Swap the LOCAL liveness probe (both module + parent-package re-export).
+
+    Keyed on ``probe_local_detail``, which is what the pool resolves since
+    the probe began recording which adapter answered. Left on the old
+    ``_probe_local`` name this swap would simply stop being consulted, and
+    the tests below would keep passing without exercising anything.
+    """
     import scitex_agent_container.cli_pkg._helpers as _pkg
 
-    saved_al = _al._probe_local
-    saved_pkg = getattr(_pkg, "_probe_local", None)
-    _al._probe_local = impl  # type: ignore[assignment]
-    _pkg._probe_local = impl  # type: ignore[assignment]
+    saved_al = _al.probe_local_detail
+    saved_pkg = getattr(_pkg, "probe_local_detail", None)
+    _al.probe_local_detail = impl  # type: ignore[assignment]
+    _pkg.probe_local_detail = impl  # type: ignore[assignment]
     try:
         yield
     finally:
-        _al._probe_local = saved_al  # type: ignore[assignment]
+        _al.probe_local_detail = saved_al  # type: ignore[assignment]
         if saved_pkg is None:
-            delattr(_pkg, "_probe_local")
+            delattr(_pkg, "probe_local_detail")
         else:
-            _pkg._probe_local = saved_pkg  # type: ignore[assignment]
+            _pkg.probe_local_detail = saved_pkg  # type: ignore[assignment]
+
+
+def _running(value: bool | None, runtime: str = "TestRuntime"):
+    """A probe callable answering ``value`` — the shape the pool consumes."""
+
+    def impl(cfg):
+        return LocalProbe(running=value, runtime=runtime, error=None)
+
+    return impl
 
 
 def _no_discover() -> list[tuple[str, Path]]:
@@ -341,7 +357,7 @@ def test_local_registry_row_wins_over_remote_instance(isolated_state_db, tmp_pat
     registry.add("spartan-dev", str(spec), "tui-spartan-dev")
     _record_remote()
     # Act
-    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+    with _swap_discover(_no_discover), _swap_probe(_running(True)):
         rows = get_agent_list_data(registry, remote_run_ssh=lambda argv: 0)
     # Assert — one row, and it is the local one.
     matching = [r for r in rows if r["name"] == "spartan-dev"]

--- a/tests/scitex_agent_container/test_cli.py
+++ b/tests/scitex_agent_container/test_cli.py
@@ -11,6 +11,9 @@ import yaml
 from click.testing import CliRunner
 
 from scitex_agent_container.cli import main
+from scitex_agent_container.cli_pkg._helpers._agent_list_probe import (
+    LocalProbe as _LocalProbe,
+)
 from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
 VALID_CONFIG = {
@@ -524,8 +527,12 @@ spec:
         )
 
         # PA-306: hand-rolled fake injection with explicit restore.
-        saved_probe = getattr(_helpers, "_probe_local", None)
-        _helpers._probe_local = lambda cfg: _HangingRuntime().is_running(cfg)
+        saved_probe = getattr(_helpers, "probe_local_detail", None)
+        _helpers.probe_local_detail = lambda cfg: _LocalProbe(
+            running=_HangingRuntime().is_running(cfg),
+            runtime="HangingRuntime",
+            error=None,
+        )
         try:
             t0 = time.monotonic()
             rows = _helpers.get_agent_list_data(
@@ -535,10 +542,10 @@ spec:
             elapsed = time.monotonic() - t0
         finally:
             if saved_probe is None:
-                if hasattr(_helpers, "_probe_local"):
-                    delattr(_helpers, "_probe_local")
+                if hasattr(_helpers, "probe_local_detail"):
+                    delattr(_helpers, "probe_local_detail")
             else:
-                _helpers._probe_local = saved_probe
+                _helpers.probe_local_detail = saved_probe
         return elapsed, rows
 
     def test_hanging_remote_probe_respects_timeout_budget(self, tmp_path):
@@ -603,18 +610,20 @@ spec:
         )
 
         # PA-306: hand-rolled fake injection with explicit restore.
-        saved_probe = getattr(_helpers, "_probe_local", None)
-        _helpers._probe_local = lambda cfg: True
+        saved_probe = getattr(_helpers, "probe_local_detail", None)
+        _helpers.probe_local_detail = lambda cfg: _LocalProbe(
+            running=True, runtime="TestRuntime", error=None
+        )
         try:
             rows = _helpers.get_agent_list_data(
                 _FakeRegistryOneAgent(cfg_path), remote_probe_timeout_s=5.0
             )
         finally:
             if saved_probe is None:
-                if hasattr(_helpers, "_probe_local"):
-                    delattr(_helpers, "_probe_local")
+                if hasattr(_helpers, "probe_local_detail"):
+                    delattr(_helpers, "probe_local_detail")
             else:
-                _helpers._probe_local = saved_probe
+                _helpers.probe_local_detail = saved_probe
         return rows[0]
 
     def test_fast_remote_probe_reports_running_status(self, tmp_path):


### PR DESCRIPTION
## The row could not say how it got there

scitex-dev measured a live agent reading `stopped` on 2026-08-04. By the time I
investigated, the host had rebooted and the population had moved — and the row
itself said `"stopped"` and nothing else. No adapter, no reason. There was
nothing to work from.

That is the actual recurring problem here. The defect has been fixed **twice**
(`liveness-live-agents-read-stopped`; `sac-fix-live-agents-read-stopped`,
2026-07-08) and each time the diagnosis had to be rebuilt from scratch, because
the verdict has never been able to explain itself. #861 gave it a guard that can
fail. This gives it a record.

## What a row carries now

```json
{"name": "...", "status": "stopped", "probe_runtime": "ClaudeSessionRuntime"}
```

On a `tui` agent, that **is** the bug — stated, in `sac agents list --json`,
with no debug flag and no reproduction. `probe_error` does the same for an
abstention.

## The label comes from inside the probe, and that is the whole design

The cheap version — have the row builder call
`_get_runtime(cfg).__class__.__name__` itself — is **worse than no label**. If
the probe were ever hardcoded to one adapter again, the row would report the
correctly-*selected* adapter while the probe used the wrong one: a label that
reads clean in exactly the case it exists to catch.

So the adapter name is a return value of the probe call and cannot disagree with
it. `test_get_data_row_label_comes_from_the_probe_not_a_second_lookup` pins
that: the spec declares `apptainer`, the probe reports answering through
something else, and the row must repeat the **probe**.

The two abstention paths are also kept apart, because they mean different
things — runtime *selection* failing means no instrument was ever chosen, while
`is_running` raising means a **named** instrument was asked and could not
answer. The old code collapsed both to a bare `None` and discarded the exception
object. That erasure is the specific reason the third report was undiagnosable.

`_probe_local` still returns bool-or-None and now **delegates** rather than
re-implementing, so the tri-state view and the detailed one cannot drift. #861's
tmux guard drives it unchanged.

## The seam moved, and that was the risky part

The pool now resolves `probe_local_detail`; five test files swapped
`_probe_local`. Left alone, those swaps would simply have **stopped being
consulted** and the tests would have gone on passing while exercising nothing —
the exact silently-blind failure #861 was about, re-created by the fix for it.

Two of the five I initially missed (`test__agent_list_perf`,
`test__agent_list_host_display`). They surfaced as **4 red tests** rather than
silent green, because the real probe then ran against fixture specs. Migrated
across 5 files: 51 `_swap_probe(...)` call sites (36 + 8 + 6 + 1) plus
`test_cli.py`'s 2 direct swaps and their restores, each file's own seam
retargeted. Verified by re-grepping for leftover `lambda cfg:` swaps — none
remain.

## Mutation-proved

Restoring the historical hardcode inside the new probe turns **two** tests red —
#861's tmux guard and the new
`test_probe_detail_records_the_adapter_for_a_tui_config`. The recorder does not
merely exist; it names the wrong adapter when there is one.

## Verification

- **236 passed** — `cli_pkg/_helpers/`, `test_cli.py` (231 pre-existing + 5 new guards)
- `ruff check --select F401,F811` clean
- Mutation control: hardcoded adapter → 2 failed, 72 passed

## Still open

This does not explain *why* a live agent read `stopped`, and does not claim to.
It makes the next occurrence self-describing instead of unreproducible.
scitex-dev's remaining suggestion — reconcile the list against the same liveness
probe `start` uses — is untouched and is the durable shape.

Refs: `sac-list-stopped-verdict-records-no-adapter-20260804`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dHR46CRG3cRSsVWmhPG1h
