### PR TITLE
feat(listen): probe a second AUTHENTICATED route instead of telling the reader to

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_listen_probe.py
+++ b/src/scitex_agent_container/_lifecycle/_listen_probe.py
@@ -140,16 +140,23 @@ class HealthProbe:
         return self.serving and self.status not in (401, 403)
 
     def evidence(self) -> str:
-        """One line of what we measured — quotable in an error message."""
+        """One line of what we measured — quotable in an error message.
+
+        THREE decimals, not two. Measured against the live daemon, the
+        authenticated probe answers in ~0.005s, which two decimals render as
+        "in 0.00s" — a timing that reads like the measurement never ran. In a
+        message whose entire purpose is being trustworthy about what it
+        observed, a real reading must not look like an uninitialised one.
+        """
         kind = "an authenticated" if self.authenticated else "an unauthenticated"
         if self.serving:
             return (
                 f"{kind} GET {self.url} answered HTTP "
-                f"{self.status} in {self.elapsed_s:.2f}s"
+                f"{self.status} in {self.elapsed_s:.3f}s"
             )
         return (
             f"{kind} GET {self.url} got no HTTP response "
-            f"({self.error}) after {self.elapsed_s:.2f}s"
+            f"({self.error}) after {self.elapsed_s:.3f}s"
         )
 
 

--- a/src/scitex_agent_container/_lifecycle/_listen_probe.py
+++ b/src/scitex_agent_container/_lifecycle/_listen_probe.py
@@ -74,13 +74,33 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "HealthProbe",
+    "probe_listen_authed",
     "probe_listen_health",
     "transport_failure_message",
 ]
 
-# The one path ``BearerAuthMiddleware`` exempts (``PUBLIC_PATHS``), served
-# by an ``async`` handler that never touches the shared worker pool.
+# The one path ``BearerAuthMiddleware`` exempts (``PUBLIC_PATHS``).
 HEALTH_PATH = "/v1/health"
+
+# A SECOND, AUTHENTICATED route to compare against — the whole reason this
+# module can now say something instead of only admitting ignorance.
+#
+# scitex-dev asked for exactly this, twice: "the observation is cheap (it
+# already probes /v1/health — probing one authenticated route alongside it
+# would have shown this immediately)". They were right, and the previous
+# version merely TOLD the reader to go run this call.
+#
+# Why this route specifically:
+#   * AUTHENTICATED — not in ``PUBLIC_PATHS``, so it exercises the bearer
+#     path that ``/v1/health`` cannot speak to.
+#   * On a DIFFERENT prefix from ``/agents`` — which is what the observed
+#     failures track (``POST /agents`` and ``POST /agents/<n>/send`` both
+#     hung while ``POST /v1/host_exec`` answered in ~2.4s, same daemon,
+#     same minutes).
+#   * A read-only GET. Deliberately NOT ``POST /v1/host_exec``, which
+#     EXECUTES a command on the host and writes an audit line — unacceptable
+#     in a probe that fires on every transport failure.
+AUTHED_PATH = "/v1/host_exec/inflight"
 
 # The probe must be CHEAP: it runs inside the failure path of a request
 # that has ALREADY timed out, so it must not add another long wait. A
@@ -103,36 +123,52 @@ class HealthProbe:
     elapsed_s: float
     error: str | None
     url: str
+    authenticated: bool = False
+
+    @property
+    def authorized(self) -> bool:
+        """Did an AUTHENTICATED request get past the middleware and be served?
+
+        ``serving`` is deliberately weaker: a 401 is an HTTP response, so it
+        proves the daemon is up. But a 401 is produced by
+        ``BearerAuthMiddleware`` BEFORE the handler runs, so on an
+        authenticated probe it proves nothing about whether authenticated
+        WORK is being served — the exact question this probe exists to
+        answer. Conflating the two would make this probe lie in the one
+        situation it was added for.
+        """
+        return self.serving and self.status not in (401, 403)
 
     def evidence(self) -> str:
         """One line of what we measured — quotable in an error message."""
+        kind = "an authenticated" if self.authenticated else "an unauthenticated"
         if self.serving:
             return (
-                f"an unauthenticated GET {self.url} answered HTTP "
+                f"{kind} GET {self.url} answered HTTP "
                 f"{self.status} in {self.elapsed_s:.2f}s"
             )
         return (
-            f"an unauthenticated GET {self.url} also got no HTTP response "
+            f"{kind} GET {self.url} got no HTTP response "
             f"({self.error}) after {self.elapsed_s:.2f}s"
         )
 
 
-def probe_listen_health(
-    base: str,
+def _probe_get(
+    url: str,
     *,
-    timeout_s: float = _DEFAULT_PROBE_TIMEOUT_S,
-    opener: Optional[Callable] = None,
+    headers: dict,
+    timeout_s: float,
+    opener: Optional[Callable],
+    authenticated: bool,
 ) -> HealthProbe:
-    """GET ``{base}/v1/health`` with NO Authorization header. Never raises.
+    """One GET, every failure mode recorded, never raises.
 
-    Deliberately unauthenticated: sending the bearer would route the probe
-    through the very code path we are trying to rule in or out, and would
-    hang with it. The point is to exercise the path that CANNOT be wedged
-    by a starved worker pool.
+    Shared by both probes so their error handling cannot drift apart — the
+    four branches below are exactly the distinctions the message depends on,
+    and having two copies of them is how one copy quietly stops matching.
     """
-    url = f"{base.rstrip('/')}{HEALTH_PATH}"
     opener_fn = opener if opener is not None else urlrequest.urlopen
-    req = urlrequest.Request(url, method="GET", headers={"Accept": "application/json"})
+    req = urlrequest.Request(url, method="GET", headers=headers)
     started = time.monotonic()
     try:
         with opener_fn(req, timeout=timeout_s) as resp:
@@ -144,18 +180,22 @@ def probe_listen_health(
             elapsed_s=time.monotonic() - started,
             error=None,
             url=url,
+            authenticated=authenticated,
         )
     except urlerror.HTTPError as exc:
-        # A RESPONSE. 401/403/404 all prove the daemon is up and serving —
-        # the reporter's own evidence was a 401. HTTPError subclasses
+        # A RESPONSE. 401/403/404 all prove the daemon is up and SERVING —
+        # the original reporter's own evidence was a 401. HTTPError subclasses
         # URLError, so this MUST be caught first or a serving daemon would
         # be misfiled as unreachable (the exact bug, one level down).
+        # NOTE: for an AUTHENTICATED probe, ``serving`` is not the question —
+        # see ``HealthProbe.authorized``.
         return HealthProbe(
             serving=True,
             status=int(getattr(exc, "code", 0)) or None,
             elapsed_s=time.monotonic() - started,
             error=None,
             url=url,
+            authenticated=authenticated,
         )
     except (urlerror.URLError, OSError, ValueError) as exc:
         # No HTTP exchange at all: connection refused / DNS / timeout.
@@ -165,16 +205,71 @@ def probe_listen_health(
             elapsed_s=time.monotonic() - started,
             error=str(getattr(exc, "reason", None) or exc),
             url=url,
+            authenticated=authenticated,
         )
     except Exception as exc:  # stx-allow: fallback (reason: this probe runs INSIDE another failure path — it exists to IMPROVE an error message and must never replace it with a crash. Any unexpected failure degrades to an honest "could not measure".)  # noqa: BLE001
-        logger.warning("listen health probe raised unexpectedly: %s", exc)
+        logger.warning("listen probe raised unexpectedly: %s", exc)
         return HealthProbe(
             serving=False,
             status=None,
             elapsed_s=time.monotonic() - started,
             error=f"probe failed: {exc}",
             url=url,
+            authenticated=authenticated,
         )
+
+
+def probe_listen_health(
+    base: str,
+    *,
+    timeout_s: float = _DEFAULT_PROBE_TIMEOUT_S,
+    opener: Optional[Callable] = None,
+) -> HealthProbe:
+    """GET ``{base}/v1/health`` with NO Authorization header. Never raises.
+
+    Deliberately unauthenticated: this answers "is the daemon serving HTTP at
+    all", and nothing more. What it CANNOT tell you is whether authenticated
+    work is being served — that is what :func:`probe_listen_authed` is for,
+    and assuming this one covered it is precisely the error that put a wrong
+    diagnosis in this module's output for a month.
+    """
+    return _probe_get(
+        f"{base.rstrip('/')}{HEALTH_PATH}",
+        headers={"Accept": "application/json"},
+        timeout_s=timeout_s,
+        opener=opener,
+        authenticated=False,
+    )
+
+
+def probe_listen_authed(
+    base: str,
+    token: str | None,
+    *,
+    timeout_s: float = _DEFAULT_PROBE_TIMEOUT_S,
+    opener: Optional[Callable] = None,
+) -> HealthProbe | None:
+    """GET an AUTHENTICATED, read-only route with the bearer. Never raises.
+
+    Returns ``None`` when there is no token — with nothing to authenticate
+    with, a request here would 401 and that 401 would say nothing about the
+    daemon. An honest "did not measure" beats a measurement that cannot mean
+    what the reader will take it to mean.
+
+    Read :data:`AUTHED_PATH` for why this route and not ``POST /v1/host_exec``.
+    """
+    if not token:
+        return None
+    return _probe_get(
+        f"{base.rstrip('/')}{AUTHED_PATH}",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+        timeout_s=timeout_s,
+        opener=opener,
+        authenticated=True,
+    )
 
 
 def transport_failure_message(
@@ -186,37 +281,78 @@ def transport_failure_message(
     exc: BaseException,
     timeout_s: float,
     probe: HealthProbe,
+    authed_probe: HealthProbe | None = None,
 ) -> str:
     """The honest message for a brokered POST that got no HTTP response.
 
-    Two cases, and they are the two the caller can actually TELL APART:
+    The daemon answered nothing at all → it is genuinely unreachable. Say
+    that, and do not speculate about *why*.
 
-      * the daemon answered the cheap path → it is UP; the AUTHENTICATED
-        route is what failed. Say that, and only that.
-      * the daemon answered nothing at all → it is genuinely unreachable.
-        Say that, and still do not speculate about *why*.
+    Otherwise the daemon is UP, and what we can say next depends on whether
+    a SECOND, AUTHENTICATED route was measured (``authed_probe``):
+
+      * it answered → the daemon is serving authenticated work, so the fault
+        is specific to THIS route. A restart is not indicated, and we say so.
+      * it also hung → the fault is shared. A restart is worth its cost.
+      * it was rejected (401/403) or not attempted → we measured nothing
+        about authenticated work and must not pretend otherwise.
 
     ``verb`` is the operation ("restart" / "spawn"), ``route`` the path
     that timed out (e.g. ``POST /agents/x/restart``).
     """
     if probe.serving:
-        return (
+        head = (
             f"{verb} of {name!r} failed: {route} to {base!r} got no response "
             f"within {timeout_s:.0f}s ({exc}).\n"
             f"OBSERVED: {probe.evidence()} — so the listen daemon is UP and "
             f"serving. The daemon is NOT down and this is NOT a 'broker "
             f"unreachable' failure: this ONE route did not answer.\n"
-            f"NOT ESTABLISHED — why. {HEALTH_PATH} is UNAUTHENTICATED, so it "
-            f"does not tell you whether authentication, this handler, or the "
-            f"work behind it is at fault. Two observations, one of them on a "
-            f"route with different properties, cannot single out a cause.\n"
-            f"NEXT, to find out rather than guess: call a DIFFERENT "
-            f"authenticated route (e.g. POST /v1/host_exec with a trivial "
-            f"argv) and compare. If it answers, the fault is specific to "
-            f"{route} and restarting the daemon will not fix it. If it also "
-            f"hangs, the fault is shared and a restart is worth trying — "
-            f"`sac listen restart` on the host, which interrupts EVERY agent "
-            f"mid-operation, so establish that it is shared first."
+        )
+        if authed_probe is None:
+            return head + (
+                f"NOT ESTABLISHED — why. {HEALTH_PATH} is UNAUTHENTICATED, so "
+                f"it does not tell you whether authentication, this handler, "
+                f"or the work behind it is at fault, and no authenticated "
+                f"route was measured (no bearer token available).\n"
+                f"NEXT, to find out rather than guess: call an authenticated "
+                f"route (e.g. GET {AUTHED_PATH}) and compare. If it answers, "
+                f"the fault is specific to {route} and restarting the daemon "
+                f"will not fix it. If it also hangs, the fault is shared and "
+                f"a restart is worth trying — `sac listen restart` on the "
+                f"host, which interrupts EVERY agent mid-operation, so "
+                f"establish that it is shared first."
+            )
+        if not authed_probe.serving:
+            return head + (
+                f"ALSO OBSERVED: {authed_probe.evidence()}. So an "
+                f"authenticated route on a DIFFERENT prefix hung too, while "
+                f"the public path answered — the fault is SHARED across "
+                f"authenticated work, not specific to {route}.\n"
+                f"On this evidence `sac listen restart` on the host is worth "
+                f"its cost. It interrupts EVERY agent mid-operation, so say "
+                f"so when you run it."
+            )
+        if not authed_probe.authorized:
+            return head + (
+                f"ALSO OBSERVED: {authed_probe.evidence()} — but that is an "
+                f"AUTH REJECTION, produced by the middleware BEFORE any "
+                f"handler runs, so it says nothing about whether "
+                f"authenticated work is being served.\n"
+                f"NOT ESTABLISHED — why {route} hung. Fix the bearer "
+                f"(SAC_LISTEN_BEARER / the host token file) and retry to get "
+                f"a real second reading. Do NOT restart the daemon on this: "
+                f"nothing here indicates a daemon-wide fault."
+            )
+        return head + (
+            f"ALSO OBSERVED: {authed_probe.evidence()}. So the daemon is "
+            f"serving AUTHENTICATED work fine on a different prefix, in the "
+            f"same seconds that {route} did not answer.\n"
+            f"THEREFORE the fault is specific to {route}, not daemon-wide. "
+            f"Do NOT run `sac listen restart` for this — it interrupts every "
+            f"agent on the box and would not address a per-route fault. "
+            f"Retry, and if it recurs report {route} with these two timings; "
+            f"the route has been seen to answer and then degrade, so a single "
+            f"success afterwards does not mean it was fixed."
         )
     return (
         f"{verb} of {name!r} failed: cannot reach listen at {base!r} ({exc}).\n"

--- a/src/scitex_agent_container/_lifecycle/_restart_client.py
+++ b/src/scitex_agent_container/_lifecycle/_restart_client.py
@@ -166,10 +166,7 @@ def _http_error_message(name: str, status: int, parsed: Any) -> str:
             f"check_lineage_acl MANAGE gate denied this caller. Server "
             f"said: {parsed!r}"
         )
-    return (
-        f"restart of {name!r} rejected: listen returned HTTP "
-        f"{status} ({parsed!r})"
-    )
+    return f"restart of {name!r} rejected: listen returned HTTP {status} ({parsed!r})"
 
 
 def request_restart(
@@ -283,17 +280,29 @@ def request_restart(
         # answering an unauthenticated GET in 0.18s while this authenticated
         # POST hung. Probe the cheap public path and let the EVIDENCE pick
         # the message. See ._listen_probe.
-        from ._listen_probe import probe_listen_health, transport_failure_message
+        from ._listen_probe import (
+            probe_listen_authed,
+            probe_listen_health,
+            transport_failure_message,
+        )
 
         probe = probe_listen_health(base, opener=opener)
+        # The SECOND reading, on an authenticated route with a different
+        # prefix. Probing only the public path is what let a wrong cause
+        # survive in this message for a month: one measurement generalised
+        # to a whole class. Two readings can actually separate "this route"
+        # from "the daemon".
+        authed = probe_listen_authed(base, tok, opener=opener)
         logger.warning(
             "restart_client: POST %s transport error: %s (probe: listen "
-            "serving=%s status=%s in %.2fs)",
+            "serving=%s status=%s in %.2fs; authed serving=%s status=%s)",
             url,
             exc,
             probe.serving,
             probe.status,
             probe.elapsed_s,
+            None if authed is None else authed.serving,
+            None if authed is None else authed.status,
         )
         raise RestartRequestError(
             transport_failure_message(
@@ -304,6 +313,7 @@ def request_restart(
                 exc=exc,
                 timeout_s=timeout_s,
                 probe=probe,
+                authed_probe=authed,
             )
         ) from exc
 

--- a/src/scitex_agent_container/_lifecycle/_spawn_client.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_client.py
@@ -422,22 +422,34 @@ def request_spawn(
         # never gets misreported as 'cannot reach / timed out'.
         #
         # But "no response on THIS route" is NOT yet "the daemon is
-        # unreachable" — the authenticated routes dispatch through listen's
-        # shared worker pool and the public health path does not, so one can
-        # hang while the other answers in 0.18s (observed 2026-07-14). The
-        # old text asserted "unreachable; it may be flapping" and was WRONG.
-        # Probe the cheap public path and let the EVIDENCE pick the message.
-        from ._listen_probe import probe_listen_health, transport_failure_message
+        # unreachable" — the old text asserted "unreachable; it may be
+        # flapping" and was WRONG; the daemon was answering in 0.18s.
+        #
+        # This comment used to explain the split as a shared worker pool that
+        # the public health path bypasses. THAT IS REFUTED (scitex-dev,
+        # 2026-08-04): ``POST /v1/host_exec`` is authenticated and answered in
+        # ~2.4s while ``POST /agents`` hung, same daemon, same minutes. The
+        # failures track the ``/agents`` PREFIX, not authentication. So probe
+        # BOTH the public path and an authenticated route on another prefix,
+        # and let the two readings pick the message. See ._listen_probe.
+        from ._listen_probe import (
+            probe_listen_authed,
+            probe_listen_health,
+            transport_failure_message,
+        )
 
         probe = probe_listen_health(base, opener=opener)
+        authed = probe_listen_authed(base, tok, opener=opener)
         logger.warning(
             "spawn_client: POST %s transport error: %s (probe: listen "
-            "serving=%s status=%s in %.2fs)",
+            "serving=%s status=%s in %.2fs; authed serving=%s status=%s)",
             url,
             exc,
             probe.serving,
             probe.status,
             probe.elapsed_s,
+            None if authed is None else authed.serving,
+            None if authed is None else authed.status,
         )
         raise SpawnRequestError(
             transport_failure_message(
@@ -448,6 +460,7 @@ def request_spawn(
                 exc=exc,
                 timeout_s=timeout_s,
                 probe=probe,
+                authed_probe=authed,
             )
         ) from exc
 

--- a/tests/scitex_agent_container/_lifecycle/test__listen_probe.py
+++ b/tests/scitex_agent_container/_lifecycle/test__listen_probe.py
@@ -219,7 +219,9 @@ def test_message_quotes_the_measurement_it_made() -> None:
     # Act
     message = _message(_SERVING)
     # Assert — the evidence is IN the message, so the operator can check it.
-    assert "answered HTTP 401 in 0.18s" in message
+    # Three decimals: the authenticated probe answers in ~0.005s on the live
+    # daemon, which two decimals rendered as "0.00s".
+    assert "answered HTTP 401 in 0.180s" in message
 
 
 def test_message_never_claims_flapping_when_daemon_answers() -> None:

--- a/tests/scitex_agent_container/_lifecycle/test__listen_probe.py
+++ b/tests/scitex_agent_container/_lifecycle/test__listen_probe.py
@@ -26,6 +26,7 @@ from urllib import error as urlerror
 
 from scitex_agent_container._lifecycle._listen_probe import (
     HealthProbe,
+    probe_listen_authed,
     probe_listen_health,
     transport_failure_message,
 )
@@ -317,3 +318,187 @@ def test_message_warns_a_restart_interrupts_every_agent() -> None:
     message = _message(_SERVING)
     # Assert
     assert "interrupts EVERY agent" in message
+
+
+# ---------------------------------------------------------------------------
+# THE SECOND READING. scitex-dev asked for this twice: "the observation is
+# cheap (it already probes /v1/health — probing one authenticated route
+# alongside it would have shown this immediately)."
+#
+# Their samples, one daemon, one window:
+#     POST /agents              -> timed out at 30s
+#     POST /agents/<n>/send     -> timed out at 30s, TWICE consecutively
+#     POST /v1/host_exec        -> HTTP 200 in ~2.4s
+#     GET  /v1/health           -> 200 in 0.01s
+# The failures track the /agents PREFIX, not authentication. And the same
+# /agents/<n>/send had SUCCEEDED earlier that night, so the handler degrades
+# rather than being dead — the shape that gets dismissed as a flake and
+# "fixed" by a restart that was never needed.
+#
+# With two readings the message can stop saying "go measure" and say what was
+# measured. These pin each of the four arms.
+# ---------------------------------------------------------------------------
+
+
+def _authed(status: int = 200, serving: bool = True) -> HealthProbe:
+    return HealthProbe(
+        serving=serving,
+        status=status if serving else None,
+        elapsed_s=2.40,
+        error=None if serving else "timed out",
+        url=f"{_BASE}/v1/host_exec/inflight",
+        authenticated=True,
+    )
+
+
+def _message2(probe: HealthProbe, authed: HealthProbe | None) -> str:
+    return transport_failure_message(
+        verb="restart",
+        name="neurovista",
+        base=_BASE,
+        route="POST /agents/neurovista/restart",
+        exc=TimeoutError("timed out"),
+        timeout_s=60.0,
+        probe=probe,
+        authed_probe=authed,
+    )
+
+
+def test_message_calls_the_fault_route_specific_when_authed_answers() -> None:
+    # Arrange — authenticated work IS being served, in the same seconds.
+    #
+    # This asserted on "the fault is specific to" and my own mutation control
+    # caught it: that phrase ALSO appears in the no-second-reading arm, so the
+    # test passed with the authed probe ignored entirely. It could not have
+    # disagreed. "not daemon-wide" is the claim only this arm is entitled to
+    # make, because only this arm measured a daemon serving authed work.
+    # Act
+    message = _message2(_SERVING, _authed())
+    # Assert
+    assert "not daemon-wide" in message
+
+
+def test_message_refuses_a_restart_when_authed_answers() -> None:
+    # Arrange — THE point of the second reading. A per-route fault must not
+    # cost every agent on the box a restart; scitex-dev declined exactly that
+    # remedy in July and was right to.
+    # Act
+    message = _message2(_SERVING, _authed())
+    # Assert
+    assert "Do NOT run `sac listen restart`" in message
+
+
+def test_message_warns_the_route_can_answer_then_degrade() -> None:
+    # Arrange — measured intermittency: the same route succeeded earlier the
+    # same night, so one later success is not proof of a fix.
+    # Act
+    message = _message2(_SERVING, _authed())
+    # Assert
+    assert "does not mean it was fixed" in message
+
+
+def test_message_calls_the_fault_shared_when_authed_also_hangs() -> None:
+    # Arrange — both an authenticated route and this one hung while the public
+    # path answered. NOW a daemon-wide fault is the supported reading.
+    # Act
+    message = _message2(_SERVING, _authed(serving=False))
+    # Assert
+    assert "the fault is SHARED" in message
+
+
+def test_message_recommends_a_restart_when_the_fault_is_shared() -> None:
+    # Arrange — the restart is still reachable; it just has to be earned.
+    # Act
+    message = _message2(_SERVING, _authed(serving=False))
+    # Assert
+    assert "worth its cost" in message
+
+
+def test_message_treats_a_401_on_the_authed_probe_as_no_reading() -> None:
+    # Arrange — a 401 comes from the middleware BEFORE any handler runs, so it
+    # proves the daemon is up and says NOTHING about authenticated work. Taking
+    # it as "authenticated work is fine" would make this probe lie in exactly
+    # the case it was added for.
+    # Act
+    message = _message2(_SERVING, _authed(status=401))
+    # Assert
+    assert "AUTH REJECTION" in message
+
+
+def test_message_refuses_a_restart_on_an_auth_rejection() -> None:
+    # Arrange — an unusable second reading is not evidence of a daemon fault.
+    # Act
+    message = _message2(_SERVING, _authed(status=401))
+    # Assert
+    assert "Do NOT restart the daemon on this" in message
+
+
+def test_message_admits_it_measured_nothing_without_a_token() -> None:
+    # Arrange — no bearer, so no second reading was even attempted.
+    # Act
+    message = _message2(_SERVING, None)
+    # Assert
+    assert "no authenticated route was measured" in message
+
+
+# ---------------------------------------------------------------------------
+# probe_listen_authed — what it actually sends
+# ---------------------------------------------------------------------------
+
+
+def test_authed_probe_returns_none_without_a_token() -> None:
+    # Arrange — an honest "did not measure" beats a 401 the reader will
+    # misread as a measurement.
+    opener, _ = _opener_returning()
+    # Act
+    probe = probe_listen_authed(_BASE, None, opener=opener)
+    # Assert
+    assert probe is None
+
+
+def test_authed_probe_sends_the_bearer() -> None:
+    # Arrange — the whole point is to exercise the path /v1/health cannot.
+    opener, captured = _opener_returning()
+    # Act
+    probe_listen_authed(_BASE, "tok-123", opener=opener)
+    # Assert
+    assert captured["headers"]["authorization"] == "Bearer tok-123"
+
+
+def test_authed_probe_hits_a_route_off_the_agents_prefix() -> None:
+    # Arrange — the observed failures track /agents, so a second reading on
+    # /agents would measure the suspect rather than the control.
+    opener, captured = _opener_returning()
+    # Act
+    probe_listen_authed(_BASE, "tok-123", opener=opener)
+    # Assert
+    assert captured["url"] == f"{_BASE}/v1/host_exec/inflight"
+
+
+def test_authed_probe_never_executes_a_host_command() -> None:
+    # Arrange — POST /v1/host_exec RUNS a command on the host and writes an
+    # audit line. A probe that fires on every transport failure must not do
+    # that, however convenient the route is.
+    opener, captured = _opener_returning()
+    # Act
+    probe_listen_authed(_BASE, "tok-123", opener=opener)
+    # Assert
+    assert captured["method"] == "GET"
+
+
+def test_authed_probe_reads_a_401_as_not_authorized() -> None:
+    # Arrange — serving (an HTTP response arrived) but NOT authorized.
+    opener = _opener_raising(_http_error(401))
+    # Act
+    probe = probe_listen_authed(_BASE, "bad-token", opener=opener)
+    # Assert
+    assert probe.authorized is False
+
+
+def test_authed_probe_reads_a_200_as_authorized() -> None:
+    # Arrange
+    opener, _ = _opener_returning(status=200)
+    # Act
+    probe = probe_listen_authed(_BASE, "tok-123", opener=opener)
+    # Assert
+    assert probe.authorized is True


### PR DESCRIPTION
## #860 stopped one step short

It removed the false pool story and admitted the cause was NOT ESTABLISHED —
then **told the reader** to go call an authenticated route and compare.
scitex-dev pointed out the obvious, and they're right:

> the observation is cheap (it already probes /v1/health — probing one
> authenticated route alongside it would have shown this immediately)

## Their third and fourth samples

Same daemon, same window:

| route | auth | result |
|---|---|---|
| `POST /agents` | bearer | timed out at 30s |
| `POST /agents/<name>/send` | bearer | timed out at 30s, **twice consecutively** |
| `POST /v1/host_exec` | bearer | HTTP 200, ~2.4s, 127KB |
| `GET /v1/health` | none | 200 in 0.01s |

The failures track the **`/agents` prefix** — not authentication, not a shared
pool. And it's **intermittent**: that same `/agents/<name>/send` had *succeeded*
earlier the same night before failing twice. The handler degrades rather than
being dead — the shape that gets dismissed as a flake and then "fixed" by a
`sac listen restart` that only appears to work because the degradation hadn't
recurred yet.

## The message now measures both and says what follows

| second reading | what the message says |
|---|---|
| authed **answers** | fault is specific to this route, **"not daemon-wide"**. Explicitly *Do NOT run `sac listen restart`* — it interrupts every agent and wouldn't address a per-route fault. Plus the intermittency warning. |
| authed **hangs** | fault is **SHARED**; a restart is "worth its cost", stated with its blast radius. |
| authed **401/403** | **AUTH REJECTION** — middleware answers before any handler runs, so this says *nothing* about authenticated work. Fix the bearer; don't restart on it. |
| **no token** | no second reading attempted; say so, keep the old NEXT. |

That third arm matters more than it looks. `serving` is true for a 401 (an HTTP
response arrived) — correct for the health probe, and **wrong** as a reading of
authenticated work. Conflating them would make this probe lie in precisely the
case it was added for, so `HealthProbe.authorized` is a separate property with
its own message arm.

## Why `GET /v1/host_exec/inflight`

Authenticated (`PUBLIC_PATHS` is only `/v1/health`), on a different prefix from
`/agents`, and **read-only**. Deliberately *not* `POST /v1/host_exec` despite
that being scitex-dev's example — it executes a command on the host and writes
an audit line, which is unacceptable in a probe that fires on every transport
failure.

## Also fixed

`_spawn_client` still carried the refuted pool story in a **code comment**
("authenticated routes dispatch through listen's shared worker pool and the
public health path does not"). #860 corrected the message and the module
docstring and missed this one.

Both probes share one `_probe_get`, so their four error branches can't drift —
those branches *are* the distinctions the message depends on.

## Mutation-proved — and it caught one of my own tests

Making the message ignore the second reading turns **7 of 8** message guards red
(the 8th is the no-token arm the mutation forces, correctly green).

On the first run only **6** went red.
`test_message_calls_the_fault_route_specific_when_authed_answers` asserted
`"the fault is specific to"` — a phrase the no-second-reading arm *also*
contains — so it passed with the authed probe ignored entirely. A test that
could not have disagreed. Re-pointed at `"not daemon-wide"`, the claim only that
arm is entitled to make.

14 new tests: 8 on the message arms, 6 on what the probe actually sends (returns
`None` without a token; sends the bearer; hits `/v1/host_exec/inflight`; uses
GET so it can never execute a host command; 401 → not authorized; 200 →
authorized).

## Verification

- **97 passed** — `test__listen_probe`, `test__restart_client`, `test__spawn_client`, `test__start_verdict`
- `ruff check --select F401,F811` clean
- Mutation control: ignore the second reading → 7 failed, 27 passed

## Still open

Why `/agents` degrades is still unknown. This doesn't diagnose it — it makes the
tool take the measurement that separates "this route" from "the daemon", so the
next person to hit it gets an answer instead of an instruction.

Refs: `sac-timeout-message-should-probe-an-authed-route-itself-20260804`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dHR46CRG3cRSsVWmhPG1h
