### PR TITLE
fix(listen): fail fast and name the port when a sidecar refuses, and bound the resume fallback

### DIFF
--- a/src/scitex_agent_container/_listen/_agent_exec_send.py
+++ b/src/scitex_agent_container/_listen/_agent_exec_send.py
@@ -32,6 +32,41 @@ __all__ = [
 ]
 
 
+#: Bound on the ``claude --resume`` fallback, in seconds. Generous by
+#: design — a real turn can take minutes, and the point of the bound is
+#: that one EXISTS, not that it is tight. Override per-host with
+#: ``SAC_LISTEN_RESUME_TIMEOUT_S``.
+DEFAULT_RESUME_TIMEOUT_S = 300.0
+
+
+def _resume_timeout_s() -> float:
+    """Read the re-launch bound from the environment, or fail loud.
+
+    A malformed value RAISES rather than quietly reverting to the
+    default: an operator who writes ``SAC_LISTEN_RESUME_TIMEOUT_S=30s``
+    has stated an intent, and silently ignoring it would restore the
+    very "looks configured, isn't" shape this whole change is about.
+    """
+    raw = os.environ.get("SAC_LISTEN_RESUME_TIMEOUT_S")
+    if raw is None or raw == "":
+        return DEFAULT_RESUME_TIMEOUT_S
+    try:
+        value = float(raw)
+    except ValueError:
+        raise ValueError(
+            f"SAC_LISTEN_RESUME_TIMEOUT_S={raw!r} is not a number of seconds. "
+            f"Set it to a bare float (e.g. '300') or unset it to use the "
+            f"default {DEFAULT_RESUME_TIMEOUT_S:g}s."
+        ) from None
+    if value <= 0:
+        raise ValueError(
+            f"SAC_LISTEN_RESUME_TIMEOUT_S={raw!r} must be > 0. A zero or "
+            f"negative bound would kill every re-launch instantly. Unset it "
+            f"to use the default {DEFAULT_RESUME_TIMEOUT_S:g}s."
+        )
+    return value
+
+
 def _find_claude_binary() -> str:
     """Same resolver as send_cmds — bundled SDK copy first, then PATH."""
     bundled = (
@@ -169,14 +204,63 @@ async def agent_send(request: Request) -> Response:
         )
 
     # Buffered branch (default): run to completion, return one JSON blob.
-    proc = await asyncio.to_thread(
-        subprocess.run,
-        argv,
-        cwd=workdir,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    #
+    # BOUNDED ON PURPOSE. This ran with no timeout at all, so a claude
+    # invocation that never returned held the request open forever while
+    # every caller absorbed the wait privately and then blamed its own
+    # 30s client deadline on a `sac listen` outage. An unbounded wait on
+    # a subprocess is not patience, it is a hang with no upper bound and
+    # no signal — the daemon looked healthy the whole time because, on
+    # every other route, it was.
+    try:
+        timeout_s = _resume_timeout_s()
+    except ValueError as exc:
+        # Misconfiguration, not a transport fault — say so, and say which
+        # variable, rather than dying as a bodyless ASGI 500.
+        return JSONResponse(
+            {"name": name, "kind": "bad_config", "error": str(exc)},
+            status_code=500,
+        )
+    try:
+        proc = await asyncio.to_thread(
+            subprocess.run,
+            argv,
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        # subprocess.run kills the child before raising, so we are not
+        # leaking a claude process here.
+        return JSONResponse(
+            {
+                "name": name,
+                "session_id": sid,
+                "kind": "resume_timeout",
+                "timeout_s": timeout_s,
+                "error": (
+                    f"the `claude --resume` re-launch for {name!r} did not "
+                    f"finish within {timeout_s:g}s and was killed. The agent "
+                    f"itself is untouched — this bounds the RE-LAUNCH, not "
+                    f"the agent."
+                ),
+                "hint": (
+                    f"Raise the bound with SAC_LISTEN_RESUME_TIMEOUT_S if "
+                    f"long turns are expected here. If {name!r} is actually "
+                    f"running, prefer its live rail instead of a re-launch: "
+                    f"`sac a2a send {name} ...`."
+                ),
+                "stdout_tail": (exc.stdout or "")[-2_000:]
+                if isinstance(exc.stdout, str)
+                else "",
+                "stderr_tail": (exc.stderr or "")[-2_000:]
+                if isinstance(exc.stderr, str)
+                else "",
+            },
+            status_code=504,
+        )
     return JSONResponse(
         {
             "name": name,

--- a/src/scitex_agent_container/_listen/_forward.py
+++ b/src/scitex_agent_container/_listen/_forward.py
@@ -18,6 +18,35 @@ The ``"auto"`` sentinel on ``cfg.a2a.port`` is intentionally NOT
 treated as a port — it only ever means "the start-time allocator
 should pick one." A non-numeric value here means the agent was
 never started, so there's nothing live to forward to.
+
+WHY THE TRANSPORT OUTCOME IS A DECLARED SHAPE, not a bare sentinel
+------------------------------------------------------------------
+This module used to answer every transport failure with the single
+value ``-1``, which the caller turned into ``None`` — the SAME answer
+it gives for "this agent has no port at all" (case 3 above). Two
+states with opposite meanings collapsed into one:
+
+  * NO_PORT  — nothing was ever bound; re-launching is correct.
+  * REFUSED  — a port IS recorded and the kernel refused instantly;
+    the agent is very likely ALIVE with its sidecar down.
+
+Because both arrived as ``None``, a REFUSED send fell through to the
+``claude --resume`` re-launch, which is wrong twice over. It is slow
+(the caller's own 30s client timeout fires long before a fresh claude
+finishes, so the reply is never seen and the work is burned invisibly),
+and it is UNSAFE: re-launching ``claude --resume <sid>`` against a
+session id that a live agent still holds puts two processes on one
+session file. The information needed to avoid both was available
+immediately — nothing was listening — and collapsing it into a timeout
+is what made a routine unbound sidecar read as a daemon-wide outage
+(card sac-listen-send-endpoint-wedged-fleet-wide-20260803, where the
+misreading cost two wrong remedies before the right test was run).
+
+So the transport now answers with :class:`ForwardOutcome` — one shape,
+every signal a named field, ``kind`` validated at construction — and
+REFUSED / TIMEOUT / UNREACHABLE each get their own loud HTTP status
+naming the port. ``None`` is reserved for NO_PORT alone, which is what
+the docstring above always said it meant.
 """
 
 from __future__ import annotations
@@ -26,16 +55,226 @@ import asyncio
 import json as _json
 import urllib.error as _urlerror
 import urllib.request as _urlrequest
+from dataclasses import dataclass
 
 from starlette.responses import JSONResponse
 
 from .._state import port_allocator
 
+__all__ = [
+    "ForwardOutcome",
+    "forward_to_live_runner",
+    "post_to_live_runner",
+]
+
+#: The complete set of transport outcomes. Every send lands on exactly
+#: one of these — there is no "other" and no implicit fallthrough.
+KINDS = frozenset(
+    {
+        "reached",  # the sidecar answered (``http_status`` is set)
+        "refused",  # kernel refused the connection: nothing is bound
+        "timeout",  # bound but did not answer within the deadline
+        "unreachable",  # any other transport error (DNS, network, ...)
+    }
+)
+
+
+@dataclass(frozen=True)
+class ForwardOutcome:
+    """One send's transport result, in a fixed shape with a validator.
+
+    ``kind`` is the multi-valued signal the old ``-1`` destroyed.
+    ``http_status`` is set if and only if ``kind == "reached"`` — a
+    status on any other kind would be an invented answer, so the
+    validator refuses to build one.
+    """
+
+    kind: str
+    port: int
+    url: str
+    http_status: int | None = None
+    payload: bytes = b""
+    detail: str = ""
+
+    def __post_init__(self) -> None:
+        if self.kind not in KINDS:
+            raise ValueError(
+                f"ForwardOutcome.kind={self.kind!r} is not one of {sorted(KINDS)}"
+            )
+        if self.kind == "reached":
+            if self.http_status is None:
+                raise ValueError("kind='reached' requires an http_status")
+        elif self.http_status is not None:
+            raise ValueError(
+                f"kind={self.kind!r} must not carry http_status="
+                f"{self.http_status!r} — only a reached sidecar has one"
+            )
+
+    @property
+    def failed(self) -> bool:
+        return self.kind != "reached"
+
+
+async def post_to_live_runner(
+    url: str, port: int, prompt: str, *, timeout: float
+) -> ForwardOutcome:
+    """POST ``prompt`` to a runner sidecar and classify what happened.
+
+    Split from :func:`forward_to_live_runner` so the transport decides
+    only WHAT HAPPENED and the caller decides WHAT TO DO — the two were
+    entangled in the collapsed-sentinel version.
+    """
+    body = _json.dumps({"text": prompt}).encode("utf-8")
+    req = _urlrequest.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    def _do_post() -> ForwardOutcome:
+        try:
+            with _urlrequest.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+                return ForwardOutcome(
+                    kind="reached",
+                    port=port,
+                    url=url,
+                    http_status=resp.status,
+                    payload=resp.read(),
+                )
+        except _urlerror.HTTPError as exc:
+            # An HTTP error IS an answer — the sidecar is up and spoke.
+            return ForwardOutcome(
+                kind="reached",
+                port=port,
+                url=url,
+                http_status=exc.code,
+                payload=exc.read(),
+            )
+        except _urlerror.URLError as exc:
+            reason = exc.reason
+            if isinstance(reason, ConnectionRefusedError):
+                return ForwardOutcome(
+                    kind="refused", port=port, url=url, detail=str(reason)
+                )
+            # socket.timeout is an alias of TimeoutError on py3.10+.
+            if isinstance(reason, TimeoutError):
+                return ForwardOutcome(
+                    kind="timeout", port=port, url=url, detail=str(reason)
+                )
+            return ForwardOutcome(
+                kind="unreachable", port=port, url=url, detail=str(reason)
+            )
+        except TimeoutError as exc:
+            # urllib raises the bare socket timeout on the read side.
+            return ForwardOutcome(kind="timeout", port=port, url=url, detail=str(exc))
+
+    return await asyncio.to_thread(_do_post)
+
+
+def _refused_response(name: str, outcome: ForwardOutcome) -> JSONResponse:
+    """503 for a recorded-but-unbound sidecar, naming the port.
+
+    Deliberately NOT a death verdict, and deliberately not a re-launch.
+    Most agents in this fleet never bind ``/v1/turn`` and are reached on
+    the a2a subscriber channel instead, so "nothing is listening" says
+    the TRANSPORT is unavailable, never that the agent is gone. The same
+    distinction is drawn, in the same words, by the CLI-side preflight in
+    ``cli_pkg/_send.py`` — keep the two wordings in step.
+    """
+    return JSONResponse(
+        {  # stx-allow: STX-SAC001 (reason: a transport ERROR payload — name+url+a2a_port of the sidecar we failed to reach — NOT an A2A AgentCard; the v0-field heuristic false-positives on the name+url pair, exactly as it does on the send-reply contract in cli_pkg/_send.py)
+            "name": name,
+            "route": "live-runner",
+            "kind": "refused",
+            "a2a_port": outcome.port,
+            "url": outcome.url,
+            "error": (
+                f"agent {name!r}: nothing is listening on a2a port "
+                f"{outcome.port}, so the /v1/turn transport cannot carry "
+                f"this prompt. This is NOT a death verdict — most agents "
+                f"in this fleet never bind /v1/turn and are reached over "
+                f"the a2a subscriber channel instead."
+            ),
+            "hint": (
+                f"Deliver with `sac a2a send {name} ...` (or the a2a_send "
+                f"tool), which does not need this port. To check the port "
+                f"itself: `ss -ltn | grep {outcome.port}`. Do NOT "
+                f"force-restart the agent on this signal, and do NOT read "
+                f"it as a `sac listen` outage — the daemon answered you "
+                f"instantly to say this."
+            ),
+        },
+        status_code=503,
+    )
+
+
+def _timeout_response(
+    name: str, outcome: ForwardOutcome, timeout: float
+) -> JSONResponse:
+    """504 for a sidecar that accepted the connection and went quiet."""
+    return JSONResponse(
+        {  # stx-allow: STX-SAC001 (reason: a transport ERROR payload, not an A2A AgentCard — see the note on _refused_response)
+            "name": name,
+            "route": "live-runner",
+            "kind": "timeout",
+            "a2a_port": outcome.port,
+            "url": outcome.url,
+            "timeout_s": timeout,
+            "error": (
+                f"agent {name!r}: the sidecar on a2a port {outcome.port} "
+                f"accepted the connection but sent no reply within "
+                f"{timeout:g}s. Something IS bound — this is not the "
+                f"'no listener' case — so the runner is wedged or the turn "
+                f"is genuinely still running."
+            ),
+            "hint": (
+                f"Check whether the runner is mid-turn before restarting "
+                f"anything: `sac agents status {name}`. If it is wedged, "
+                f"`sac agents restart {name}`."
+            ),
+        },
+        status_code=504,
+    )
+
+
+def _unreachable_response(name: str, outcome: ForwardOutcome) -> JSONResponse:
+    """502 for a transport error that is neither refused nor timeout."""
+    return JSONResponse(
+        {  # stx-allow: STX-SAC001 (reason: a transport ERROR payload, not an A2A AgentCard — see the note on _refused_response)
+            "name": name,
+            "route": "live-runner",
+            "kind": "unreachable",
+            "a2a_port": outcome.port,
+            "url": outcome.url,
+            "error": (
+                f"agent {name!r}: transport error reaching {outcome.url} — "
+                f"{outcome.detail}"
+            ),
+            "hint": (
+                f"This is not a refused port and not a timeout, so the "
+                f"usual sidecar remedies do not apply. Verify the host and "
+                f"port in the agent's spec, then retry: `sac agents status "
+                f"{name}`."
+            ),
+        },
+        status_code=502,
+    )
+
 
 async def forward_to_live_runner(
     cfg, name: str, prompt: str, options: dict, timeout: float = 600.0
 ) -> JSONResponse | None:
-    """Push a prompt onto the live runner's inbox via its sidecar."""
+    """Push a prompt onto the live runner's inbox via its sidecar.
+
+    Returns ``None`` — and ONLY ``None`` — when no port is resolvable,
+    i.e. case 3 of the module docstring: there is no live runner, so the
+    caller's ``claude --resume`` re-launch is the right next step.
+
+    Every other outcome is a response, never a silent fallthrough: a
+    reached sidecar's reply, or a loud 503 / 504 / 502 that names the
+    port and says what to do about it.
+    """
     port = port_allocator.get_port(name)
     if not port:
         a2a = getattr(cfg, "a2a", None)
@@ -48,33 +287,25 @@ async def forward_to_live_runner(
     host = getattr(a2a, "host", None) or "127.0.0.1"
 
     url = f"http://{host}:{port}/v1/turn"
-    body = _json.dumps({"text": prompt}).encode("utf-8")
-    req = _urlrequest.Request(
-        url,
-        data=body,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
+    outcome = await post_to_live_runner(url, port, prompt, timeout=timeout)
 
-    def _do_post() -> tuple[int, bytes]:
-        try:
-            with _urlrequest.urlopen(req, timeout=timeout) as resp:  # noqa: S310
-                return resp.status, resp.read()
-        except _urlerror.HTTPError as exc:
-            return exc.code, exc.read()
-        except _urlerror.URLError:
-            return -1, b""
+    if outcome.kind == "refused":
+        return _refused_response(name, outcome)
+    if outcome.kind == "timeout":
+        return _timeout_response(name, outcome, timeout)
+    if outcome.kind == "unreachable":
+        return _unreachable_response(name, outcome)
 
-    status, payload = await asyncio.to_thread(_do_post)
-    if status == -1:
-        return None
+    status = outcome.http_status
+    if status is None:  # unreachable: the validator guarantees it is set
+        raise AssertionError("reached outcome without http_status")
     if status >= 400:
         return JSONResponse(
             {
                 "name": name,
                 "route": "live-runner",
                 "status": status,
-                "error": payload.decode("utf-8", "replace"),
+                "error": outcome.payload.decode("utf-8", "replace"),
             },
             status_code=status,
         )
@@ -82,6 +313,6 @@ async def forward_to_live_runner(
         {
             "name": name,
             "route": "live-runner",
-            "text": _json.loads(payload.decode("utf-8"))["text"],
+            "text": _json.loads(outcome.payload.decode("utf-8"))["text"],
         }
     )

--- a/tests/scitex_agent_container/_listen/test__agent_exec_send_resume_timeout.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_send_resume_timeout.py
@@ -1,0 +1,117 @@
+"""The ``claude --resume`` fallback must be BOUNDED, and say so when it fires.
+
+Why this exists: the buffered fallback in
+:func:`scitex_agent_container._listen._agent_exec_send.agent_send` ran
+``subprocess.run(...)`` with no ``timeout=`` at all. A re-launch that
+never returned held the request open forever; every caller absorbed the
+wait privately and then blamed its own client deadline on a `sac listen`
+outage. The daemon looked healthy throughout because, on every other
+route, it was — which is what made the misdiagnosis so persuasive
+(card sac-listen-send-endpoint-wedged-fleet-wide-20260803).
+
+An unbounded wait on a subprocess is not patience. It is a hang with no
+upper bound and no signal.
+
+The bound is deliberately generous (a real turn takes minutes); the point
+is that one EXISTS and is overridable per host, not that it is tight.
+
+NO MOCKS — these drive the real ``_resume_timeout_s`` against real
+environment variables via the package ``env_save_restore`` fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._listen._agent_exec_send import (
+    DEFAULT_RESUME_TIMEOUT_S,
+    _resume_timeout_s,
+)
+
+
+def test_unset_env_uses_the_default_bound(env_save_restore) -> None:
+    """No override → the documented default, not "no timeout"."""
+    # Arrange
+    env_save_restore.set("SAC_LISTEN_RESUME_TIMEOUT_S", "")
+    # Act
+    value = _resume_timeout_s()
+    # Assert
+    assert value == DEFAULT_RESUME_TIMEOUT_S
+
+
+def test_default_bound_is_finite() -> None:
+    """The whole point: there IS an upper bound.
+
+    A regression that restored ``None``/``inf`` here would reinstate the
+    original defect while every other test still passed.
+    """
+    # Arrange
+    # Act
+    value = DEFAULT_RESUME_TIMEOUT_S
+    # Assert
+    assert 0 < value < float("inf")
+
+
+def test_env_override_is_honoured(env_save_restore) -> None:
+    """An operator who sets the bound gets the bound they set."""
+    # Arrange
+    env_save_restore.set("SAC_LISTEN_RESUME_TIMEOUT_S", "42")
+    # Act
+    value = _resume_timeout_s()
+    # Assert
+    assert value == 42.0
+
+
+def test_malformed_env_raises_rather_than_silently_defaulting(
+    env_save_restore,
+) -> None:
+    """``"30s"`` is a stated intent; ignoring it would be a silent fallback.
+
+    Reverting to the default here would leave the operator believing a
+    30-second bound was in force while a 300-second one actually was —
+    the "looks configured, isn't" shape this change exists to remove.
+    """
+    # Arrange
+    env_save_restore.set("SAC_LISTEN_RESUME_TIMEOUT_S", "30s")
+    # Act
+    # Assert
+    with pytest.raises(ValueError):
+        _resume_timeout_s()
+
+
+def test_malformed_env_error_names_the_variable(env_save_restore) -> None:
+    """Actionable: the message must say WHICH knob is wrong.
+
+    An error that only says "invalid timeout" leaves the reader grepping
+    for which of several env vars they fat-fingered.
+    """
+    # Arrange
+    env_save_restore.set("SAC_LISTEN_RESUME_TIMEOUT_S", "abc")
+    # Act — capture without pytest.raises so this stays a single assertion.
+    try:
+        _resume_timeout_s()
+        message = ""
+    except ValueError as exc:
+        message = str(exc)
+    # Assert
+    assert "SAC_LISTEN_RESUME_TIMEOUT_S" in message
+
+
+def test_zero_bound_is_rejected(env_save_restore) -> None:
+    """A zero bound would kill every re-launch instantly — refuse it."""
+    # Arrange
+    env_save_restore.set("SAC_LISTEN_RESUME_TIMEOUT_S", "0")
+    # Act
+    # Assert
+    with pytest.raises(ValueError):
+        _resume_timeout_s()
+
+
+def test_negative_bound_is_rejected(env_save_restore) -> None:
+    """Same for a negative one; nonsense must not become policy."""
+    # Arrange
+    env_save_restore.set("SAC_LISTEN_RESUME_TIMEOUT_S", "-5")
+    # Act
+    # Assert
+    with pytest.raises(ValueError):
+        _resume_timeout_s()

--- a/tests/scitex_agent_container/_listen/test__forward.py
+++ b/tests/scitex_agent_container/_listen/test__forward.py
@@ -108,6 +108,49 @@ class _LoopbackHTTP:
         await self._server.wait_closed()
 
 
+class _SilentHTTP:
+    """A real socket that ACCEPTS the connection and then never replies.
+
+    This is the state a bare "connection failed" sentinel cannot tell
+    apart from a refused port, and the two need opposite remedies:
+    refused → start the sidecar; silent → something IS bound and is
+    stuck or busy, so restarting on that signal can kill a healthy
+    mid-turn runner. Holding the reader open (rather than closing it)
+    is what makes the client's own deadline the thing that fires.
+    """
+
+    def __init__(self) -> None:
+        self._server: asyncio.base_events.Server | None = None
+        self.port: int = _free_port()
+        self._held: list[asyncio.StreamWriter] = []
+
+    async def _handle(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        # Hold the connection open and write nothing at all.
+        self._held.append(writer)
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            pass
+
+    async def __aenter__(self) -> "_SilentHTTP":
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", self.port)
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        assert self._server is not None
+        for w in self._held:
+            try:
+                w.close()
+            except Exception:  # stx-allow: fallback (reason: test teardown must not mask the assertion under test)
+                pass
+        self._server.close()
+        await self._server.wait_closed()
+
+
 # --- Common fixture: isolate port_allocator's state.db ----------------------
 
 
@@ -159,17 +202,147 @@ def test_returns_none_when_port_is_auto_sentinel(isolated_state_db):
     assert result is None
 
 
-def test_returns_none_when_runner_unreachable(isolated_state_db):
-    # Arrange — explicit port the kernel will refuse on (nothing bound).
+def _refuse(name: str = "ghost"):
+    """Drive a send at a port the kernel will refuse, and return the response.
+
+    Not a fixture: this file's convention is self-contained tests that
+    show their own Arrange/Act, and the lint requires all three AAA
+    markers in every test body regardless.
+    """
     from scitex_agent_container._listen import _forward
 
-    cfg = _Cfg(a2a=_A2A(host="127.0.0.1", port=_free_port()))
-    # Act
-    result = asyncio.run(
-        _forward.forward_to_live_runner(cfg, "ghost", "hi", {}, timeout=2.0)
+    port = _free_port()
+    cfg = _Cfg(a2a=_A2A(host="127.0.0.1", port=port))
+    return port, asyncio.run(
+        _forward.forward_to_live_runner(cfg, name, "hi", {}, timeout=2.0)
     )
+
+
+def test_refused_port_does_not_return_none(isolated_state_db):
+    """A RECORDED-but-unbound port must fail loud, never return ``None``.
+
+    THIS TEST REPLACES ``test_returns_none_when_runner_unreachable``,
+    which asserted the opposite and in doing so pinned the defect.
+
+    ``None`` is the caller's instruction to re-launch the agent with
+    ``claude --resume <sid>``. That is right when NO port exists (the
+    agent was never started) and wrong when a port IS recorded and the
+    kernel refused instantly, because a refused sidecar usually belongs
+    to an agent that is very much ALIVE. Re-launching then puts a second
+    claude process on the live agent's own session file, and — since a
+    fresh claude takes far longer than the caller's 30s client deadline
+    — the reply is never seen and the work is burned invisibly.
+
+    The old assertion made both states indistinguishable, which is how a
+    routine unbound sidecar got diagnosed as a fleet-wide `sac listen`
+    outage (card sac-listen-send-endpoint-wedged-fleet-wide-20260803).
+    """
+    # Arrange — explicit port the kernel will refuse on (nothing bound).
+    # Act
+    _, result = _refuse()
+    # Assert — emphatically NOT the re-launch signal.
+    assert result is not None, "refused port fell through to the re-launch path"
+
+
+def test_refused_port_uses_503(isolated_state_db):
+    """Service-unavailable is the honest code: the transport, not the agent."""
+    # Arrange
+    # Act
+    _, result = _refuse()
     # Assert
-    assert result is None
+    assert result.status_code == 503
+
+
+def test_refused_response_reports_the_port_as_a_field(isolated_state_db):
+    """Machine-readable: callers branch on the field, not on prose."""
+    # Arrange
+    # Act
+    port, result = _refuse()
+    # Assert
+    assert json.loads(result.body)["a2a_port"] == port
+
+
+def test_refused_error_text_names_the_port(isolated_state_db):
+    """Human-readable: the port is the one actionable fact, so say it."""
+    # Arrange
+    # Act
+    port, result = _refuse()
+    # Assert
+    assert str(port) in json.loads(result.body)["error"]
+
+
+def test_refused_response_points_at_the_a2a_rail(isolated_state_db):
+    """The hint must name the rail that DOES work for most agents."""
+    # Arrange
+    # Act
+    _, result = _refuse()
+    # Assert
+    assert "a2a send" in json.loads(result.body)["hint"]
+
+
+def test_refused_response_is_not_a_death_verdict(isolated_state_db):
+    """Wording guard: must not tell the reader the agent crashed.
+
+    Most agents in this fleet never bind ``/v1/turn`` at all and are
+    reached on the a2a subscriber channel, so "nothing is listening"
+    says the TRANSPORT is down, never that the agent is. A death verdict
+    here invites `--force --fresh`, which destroys a healthy agent.
+    """
+    # Arrange
+    # Act
+    _, result = _refuse()
+    # Assert
+    assert "crashed" not in json.loads(result.body)["error"].lower()
+
+
+def test_refused_is_distinguishable_from_timeout(isolated_state_db):
+    """``kind`` must separate the two — collapsing them caused the incident."""
+    # Arrange
+    # Act
+    _, result = _refuse()
+    # Assert
+    assert json.loads(result.body)["kind"] == "refused"
+
+
+def test_silent_sidecar_is_a_timeout_504(isolated_state_db):
+    """Bound-but-mute → 504, never the 503 that means "nothing is bound".
+
+    The discriminator matters operationally: ``refused`` means start the
+    sidecar, ``timeout`` means something IS bound and is stuck or busy.
+    Prescribing the wrong remedy is what the collapsed sentinel caused.
+    """
+    # Arrange — a real socket that accepts and then says nothing at all.
+    from scitex_agent_container._listen import _forward
+
+    async def _run() -> object:
+        async with _SilentHTTP() as srv:
+            cfg = _Cfg(a2a=_A2A(host="127.0.0.1", port=srv.port))
+            return await _forward.forward_to_live_runner(
+                cfg, "mute-agent", "hi", {}, timeout=1.0
+            )
+
+    # Act
+    result = asyncio.run(_run())
+    # Assert
+    assert result.status_code == 504
+
+
+def test_silent_sidecar_kind_is_timeout(isolated_state_db):
+    """The named signal, not merely the status code."""
+    # Arrange
+    from scitex_agent_container._listen import _forward
+
+    async def _run() -> object:
+        async with _SilentHTTP() as srv:
+            cfg = _Cfg(a2a=_A2A(host="127.0.0.1", port=srv.port))
+            return await _forward.forward_to_live_runner(
+                cfg, "mute-agent", "hi", {}, timeout=1.0
+            )
+
+    # Act
+    result = asyncio.run(_run())
+    # Assert
+    assert json.loads(result.body)["kind"] == "timeout"
 
 
 def test_explicit_port_from_cfg_reaches_live_runner(isolated_state_db):


### PR DESCRIPTION
## The collapse

`_forward.py` answered **every** transport failure with `-1`, which the caller turned into `None` — the same value it returns for *"this agent has no port at all"*. Two states with opposite remedies became one:

| state | meaning | correct action |
|---|---|---|
| `NO_PORT` | nothing was ever bound | re-launch is right |
| `REFUSED` | a port **is** recorded, kernel refused instantly | agent is very likely **alive**, sidecar down |

Because both arrived as `None`, a refused send fell through to the `claude --resume` re-launch. That is wrong twice over:

1. **Slow** — the caller's own 30s deadline fires long before a fresh claude finishes, so the reply is never seen and the work is burned invisibly.
2. **Unsafe** — re-launching `claude --resume <sid>` against a session id a **live** agent still holds puts two processes on one session file.

With 7 of 9 running agents having no `/v1/turn` listener, this was the *normal* path, not an edge case.

The information needed to avoid both was available immediately — nothing was listening. Turning it into a timeout is what made a routine unbound sidecar read as a daemon-wide outage, costing two wrong remedies before the right test was run.

## What changed

- `ForwardOutcome` — one declared shape, every signal a named field, `kind` validated at construction, `http_status` present **iff** the sidecar answered.
- `refused` → **503**, `timeout` → **504**, other → **502**, each **naming the port** and the next step. `None` is now reserved for `NO_PORT` alone — which is what the module docstring always said it meant.
- The refused text is deliberately **not a death verdict** and points at `sac a2a send`, since most agents here never bind `/v1/turn`. A death verdict invites `--force --fresh`, which destroys a healthy agent.
- The buffered `claude --resume` fallback ran `subprocess.run` with **no timeout at all**. Now bounded (`SAC_LISTEN_RESUME_TIMEOUT_S`, default 300s) and loud on expiry. A malformed value **raises** rather than silently reverting — a stated intent must not be ignored.

## The test that pinned the bug

`test_returns_none_when_runner_unreachable` asserted that a refused port returns `None`. The fixture encoded the defect, so the suite stayed green throughout. It is replaced with tests for the loud contract.

## Verification

These tests are guards, not decoration — checked by running them against the **pre-fix** implementation:

| target | result |
|---|---|
| new tests vs **old** `_forward.py` | **9 failed**, 10 passed |
| new tests vs the fix | **19 passed** |
| full `_listen` suite | **841 passed** |

Card: `sac-listen-send-endpoint-wedged-fleet-wide-20260803`

## Not claimed here

- `inbox_reachable` still reports "reachable" while a send fails — it is not computed from the path a message takes. Untouched.
- The root cause of the original 2026-08-03 event is **not** established, and I did not manufacture one from the fix.
