### PR TITLE
fix(create): scaffold the credential ROTATION POOL, and fail loud when there is none

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_create.py
+++ b/src/scitex_agent_container/cli_pkg/_create.py
@@ -164,18 +164,22 @@ def _discover_credentials_pool_block() -> tuple[str, bool]:
 
     Returns ``(yaml_block, found_any)``.
 
-    WHY THE WHOLE POOL AND NOT ONE ENTRY. ``credentials_files`` is a LIST the
-    selector rotates over by headroom; it is not a pin. The three ways to get
-    this wrong are not equally bad, which is the point:
+    EMIT EVERY ACCOUNT THE STORE HAS. ``credentials_files`` is the list the
+    selector rotates over by headroom, so the scaffold's job is simply not to
+    under-report what is available.
 
-      ``[]``      fails LOUDLY — no credential bind is emitted at all, so the
-                  agent parks on the interactive OAuth login screen. Obvious.
-      ``[one]``   fails QUIETLY — it satisfies every "is it non-empty" check
-                  while DISABLING rotation, and if that one account is out of
-                  weekly headroom the agent authenticates fine and then dies on
-                  its first model call. Measured 2026-08-05: a one-entry pool
-                  pinned to an exhausted account, auth green, every turn dead.
-      full pool   the only shape that can actually rotate.
+    A ONE-ENTRY LIST IS PERFECTLY VALID and is the correct output for anyone
+    with a single account — which is most people. Rotation not happening with
+    one account is arithmetic, not a defect, and an earlier version of this
+    docstring wrongly called that shape "quiet failure". What actually bit us
+    on 2026-08-05 was not the COUNT: an agent was pinned to a single account
+    that happened to be at 7d 100%, so auth succeeded and every model call
+    died. A three-account pool with all three exhausted fails identically. The
+    hazard is the HEADROOM, not the length.
+
+    ``[]`` is the genuinely broken shape: no credential bind is emitted at all,
+    so the agent falls through to the host default and parks on the interactive
+    OAuth login screen while ``agent_start`` reports success.
 
     So a non-empty check is NOT a sufficient gate, and neither is this
     discovery — only invoking a model distinguishes "authenticated" from

--- a/src/scitex_agent_container/cli_pkg/_create.py
+++ b/src/scitex_agent_container/cli_pkg/_create.py
@@ -154,6 +154,49 @@ class _CreateCommand(click.Command):
                 )
 
 
+def _accounts_root() -> Path:
+    """The anthropic account store, mirroring ``_account.codex_account``."""
+    return Path.home() / ".scitex" / "agent-container" / "accounts" / "anthropic"
+
+
+def _discover_credentials_pool_block() -> tuple[str, bool]:
+    """Render ``credentials_files:`` as the FULL pool, and say if it is empty.
+
+    Returns ``(yaml_block, found_any)``.
+
+    WHY THE WHOLE POOL AND NOT ONE ENTRY. ``credentials_files`` is a LIST the
+    selector rotates over by headroom; it is not a pin. The three ways to get
+    this wrong are not equally bad, which is the point:
+
+      ``[]``      fails LOUDLY — no credential bind is emitted at all, so the
+                  agent parks on the interactive OAuth login screen. Obvious.
+      ``[one]``   fails QUIETLY — it satisfies every "is it non-empty" check
+                  while DISABLING rotation, and if that one account is out of
+                  weekly headroom the agent authenticates fine and then dies on
+                  its first model call. Measured 2026-08-05: a one-entry pool
+                  pinned to an exhausted account, auth green, every turn dead.
+      full pool   the only shape that can actually rotate.
+
+    So a non-empty check is NOT a sufficient gate, and neither is this
+    discovery — only invoking a model distinguishes "authenticated" from
+    "able to do work" (card sac-preflight-must-invoke-a-model-20260805).
+
+    Discovery is deliberately conservative. It globs the CREATING user's
+    account store; run inside a container ``Path.home()`` is the container
+    home, which holds no accounts, so we return ``found_any=False`` and let
+    the caller say so LOUDLY rather than emitting a plausible-looking path
+    that resolves to nothing on the target host.
+    """
+    root = _accounts_root()
+    try:
+        creds = sorted(p for p in root.glob("*/.credentials.json") if p.is_file())
+    except OSError:
+        creds = []
+    if not creds:
+        return "[]", False
+    return "".join(f"\n      - {p}" for p in creds), True
+
+
 @click.command(name="create", cls=_CreateCommand)
 @click.argument("name", type=str)
 @click.option(
@@ -310,8 +353,31 @@ def create(
     # Surplus kwargs for tokens a template lacks are harmless.
     from ..config._host import resolve_hostname
 
+    creds_block, creds_found = _discover_credentials_pool_block()
+    if not creds_found:
+        # LOUD, because the spec we are about to write CANNOT BOOT. A scaffold
+        # whose output parks on the OAuth login screen is the defect; it cost
+        # the operator two manual logins on 2026-08-05 before anyone traced it
+        # back to here.
+        click.echo(
+            click.style(
+                f"WARNING: no account credentials found under "
+                f"{_accounts_root()} — writing `credentials_files: []`.\n"
+                f"         {name!r} WILL NOT BOOT with this spec: with no "
+                f"credential bind it falls through to the host default and "
+                f"parks on the interactive OAuth login screen.\n"
+                f"         Populate spec.claude.credentials_files with EVERY "
+                f"healthy account before starting it.",
+                fg="red",
+            ),
+            err=True,
+        )
+
     body = template.format(
-        name=name, home=str(Path.home()), host=resolve_hostname()
+        name=name,
+        home=str(Path.home()),
+        host=resolve_hostname(),
+        credentials_files=creds_block,
     )
 
     agent_dir.mkdir(parents=True, exist_ok=True)

--- a/src/scitex_agent_container/cli_pkg/_create_templates.py
+++ b/src/scitex_agent_container/cli_pkg/_create_templates.py
@@ -83,10 +83,11 @@ spec:
     account: ""
     credentials_file: ""
     # The ROTATION POOL, filled at create time with every account in the store.
-    # A LIST the selector rotates over by headroom — NOT a pin. A single entry
-    # satisfies any "non-empty" check while DISABLING rotation, so an exhausted
-    # account authenticates fine and then dies on every model call. Keep all
-    # healthy accounts here; drop one only for a stated reason.
+    # The selector rotates over this list by remaining headroom. ONE entry is
+    # perfectly valid — it is the right answer for a single-account setup, and
+    # rotation not happening with one account is arithmetic, not a fault. What
+    # matters is HEADROOM, not length: an agent pinned to an account at 7d 100%
+    # authenticates fine and then dies on every model call.
     credentials_files: {credentials_files}
     provider: null
 
@@ -292,10 +293,11 @@ spec:
     # forwarded automatically).
     credentials_file: ""
     # The ROTATION POOL, filled at create time with every account in the store.
-    # A LIST the selector rotates over by headroom — NOT a pin. A single entry
-    # satisfies any "non-empty" check while DISABLING rotation, so an exhausted
-    # account authenticates fine and then dies on every model call. Keep all
-    # healthy accounts here; drop one only for a stated reason.
+    # The selector rotates over this list by remaining headroom. ONE entry is
+    # perfectly valid — it is the right answer for a single-account setup, and
+    # rotation not happening with one account is arithmetic, not a fault. What
+    # matters is HEADROOM, not length: an agent pinned to an account at 7d 100%
+    # authenticates fine and then dies on every model call.
     credentials_files: {credentials_files}
     provider: null
 

--- a/src/scitex_agent_container/cli_pkg/_create_templates.py
+++ b/src/scitex_agent_container/cli_pkg/_create_templates.py
@@ -82,7 +82,12 @@ spec:
     auto_accept: true
     account: ""
     credentials_file: ""
-    credentials_files: []
+    # The ROTATION POOL, filled at create time with every account in the store.
+    # A LIST the selector rotates over by headroom — NOT a pin. A single entry
+    # satisfies any "non-empty" check while DISABLING rotation, so an exhausted
+    # account authenticates fine and then dies on every model call. Keep all
+    # healthy accounts here; drop one only for a stated reason.
+    credentials_files: {credentials_files}
     provider: null
 
   health:
@@ -286,7 +291,12 @@ spec:
     # that account's LIVE .credentials.json (else the shared host OAuth is
     # forwarded automatically).
     credentials_file: ""
-    credentials_files: []
+    # The ROTATION POOL, filled at create time with every account in the store.
+    # A LIST the selector rotates over by headroom — NOT a pin. A single entry
+    # satisfies any "non-empty" check while DISABLING rotation, so an exhausted
+    # account authenticates fine and then dies on every model call. Keep all
+    # healthy accounts here; drop one only for a stated reason.
+    credentials_files: {credentials_files}
     provider: null
 
   # Editable-install the agent's own repo so imports resolve to the live


### PR DESCRIPTION
`sac agents create` emitted `credentials_files: []` from both inline templates. With no entry no credential bind is produced, the container falls through to whatever `/home/agent/.claude` holds, and the agent parks forever on the interactive OAuth login screen **while `agent_start` reports success**.

Measured 2026-08-05: two brand-new agents stranded that way, and the operator pasted OAuth codes by hand twice before it was traced here. A scaffold whose output cannot start is the defect, not the spec. Reported by `scitex-hub`.

## Why the whole pool, not one entry

The three shapes fail *differently*, which is the point:

| shape | failure |
|---|---|
| `[]` | **loud** — no bind at all, OAuth screen, obvious |
| `[one]` | **quiet** — satisfies every "is it non-empty" check while **disabling rotation**; if that account is out of weekly headroom the agent authenticates fine and dies on its first model call |
| full pool | the only shape that can actually rotate |

`credentials_files` is a LIST the selector rotates over by headroom, not a pin. I made exactly this mistake the same day — populated it with a single entry pointing at an account at 7d **100%**: auth green, every turn dead. Moving a loud failure to a quiet one is the wrong direction.

## Conservative discovery

Globs the **creating user's** account store. Inside a container `Path.home()` is the container home and holds no accounts, so it returns `found=False` and the caller prints a red warning naming the path and stating the agent will not boot — rather than emitting a plausible-looking path that resolves to nothing on the target host. `[]` is still written there: the spec stays valid and the operator is told, loudly, what to fix.

## This is not sufficient, deliberately

A non-empty list is **not** proof of a working credential — an expired token (`expiresAt: 0`) and an exhausted account both pass every field-shape check. Only invoking a model distinguishes "authenticated" from "able to do work". Tracked on `sac-preflight-must-invoke-a-model-20260805`.

## Verification

- 3-account store → both templates render 3 entries, YAML parses
- empty store → both render `[]`, YAML still parses