### PR TITLE
fix(host): warn when a DIFFERENT home holds a config.yaml, so a shadow copy cannot read as the fleet's

### DIFF
--- a/src/scitex_agent_container/_state/host_config_diagnose.py
+++ b/src/scitex_agent_container/_state/host_config_diagnose.py
@@ -77,6 +77,90 @@ def describe_config_resolution(path: Path | None = None) -> dict[str, str | None
     }
 
 
+#: Where per-user homes live. Injectable ONLY so the check is testable against
+#: a tmp tree — a hardcoded ``/home`` would make this function unreachable from
+#: a test, and an untested guard is the kind that quietly stops firing.
+HOMES_ROOT = Path("/home")
+
+
+def find_shadowing_configs(
+    resolved: Path, homes_root: Path | None = None
+) -> list[tuple[Path, int]]:
+    """Other readable ``config.yaml`` files under a DIFFERENT home.
+
+    Returns ``[(path, peer_count), ...]``, empty when there is nothing to
+    warn about.
+
+    INCIDENT 2026-08-05 (scitex-dev, reproduced from their report): they ran
+    ``sac host add`` twice inside a container and then ``sac host validate``,
+    which answered ``ok, valid (2 peers)``. The rows had landed in a 127-byte
+    ``/home/agent/.scitex/agent-container/config.yaml`` created that same day,
+    while the operator's real four-peer config under ``/home/ywatanabe`` — WHICH
+    IS BIND-MOUNTED AND READABLE FROM INSIDE THE CONTAINER — was never touched.
+    Both the add and the validate reported success about the wrong file, and
+    the card was reported CLOSED on the strength of it, then retracted.
+
+    This is NOT the 2026-07-30 case this module was written for. That one was
+    ABSENT — no file at the resolved path — and is already caught. Here the
+    file EXISTS and is well-formed, so every state check passes: the resolved
+    config is a legitimate-looking config that simply is not the fleet's.
+    ``STATE_POPULATED`` emitted no diagnostic at all, so the one shape that
+    silently diverges from fleet state was the one shape we said nothing about.
+
+    THE DISCRIMINATOR WAS ALREADY ON SCREEN AND BOTH OF US WALKED PAST IT: the
+    resolved config had 2 peers, the operator's had 4. The COUNT named the
+    split. That is why this returns the peer count per candidate rather than
+    just the paths — a reader comparing "2" against "4" sees it instantly,
+    whereas two paths side by side still look like a choice someone made.
+
+    Deliberately CONSERVATIVE, because a false positive here trains people to
+    ignore the warning:
+      * only ``/home/*/.scitex/agent-container/config.yaml`` — the one layout
+        the bind actually produces; no unbounded filesystem walk;
+      * only files that PARSE and are readable;
+      * never the resolved path itself, and never a path that resolves to the
+        same file (a symlink or bind alias is not a shadow — measured today,
+        the live and dotfiles spec paths share one inode).
+    """
+    try:
+        resolved_real = resolved.resolve()
+    except OSError:
+        resolved_real = resolved
+
+    root = homes_root if homes_root is not None else HOMES_ROOT
+    out: list[tuple[Path, int]] = []
+
+    # Only meaningful for a HOME-DERIVED resolution. If the caller pointed at an
+    # explicit path outside the homes root (SCITEX_AGENT_CONTAINER_CONFIG, a
+    # test fixture, a checkout-scoped config), they named the file deliberately
+    # and a "did you mean another home?" warning is noise. Skipping here also
+    # keeps the check hermetic: without it, every unit test that builds a config
+    # in tmp_path picks up whatever the real /home happens to hold, so the
+    # diagnosis would depend on the machine the suite runs on.
+    try:
+        resolved_real.relative_to(root.resolve())
+    except (ValueError, OSError):
+        return out
+
+    try:
+        candidates = sorted(root.glob("*/.scitex/agent-container/config.yaml"))
+    except OSError:
+        return out
+
+    for cand in candidates:
+        try:
+            if cand.resolve() == resolved_real:
+                continue  # same file by another name — not a shadow
+            parsed = yaml.safe_load(cand.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        peers = parsed.get("peers")
+        out.append((cand, len(peers) if isinstance(peers, dict) else 0))
+    return out
+
+
 def diagnose_host_config(path: Path | None = None) -> tuple[str, int, Path]:
     """Return ``(state, peer_count, resolved_path)`` for config.yaml.
 
@@ -157,6 +241,27 @@ def config_state_problems(
             f"config.yaml at {resolved} defines no peers — correct for a "
             f"single-host install, but multi-host commands will report every "
             f"peer as undefined."
+        )
+
+    # A PRESENT, well-formed config can still be the WRONG ONE. Every state
+    # above describes the resolved file on its own terms; none of them can see
+    # that a different home holds the fleet's real config. Checked for every
+    # state, including POPULATED — that is the shape that says nothing and
+    # diverges silently.
+    shadowing = find_shadowing_configs(resolved)
+    if shadowing:
+        detail["shadowing"] = [{"path": str(p), "peers": n} for p, n in shadowing]
+        others = "; ".join(f"{p} ({n} peers)" for p, n in shadowing)
+        warnings.append(
+            f"ANOTHER config.yaml exists under a different home: {others}. "
+            f"This command resolved {resolved} ({peer_count} peers) because "
+            f"the path is HOME-derived (HOME={resolution['home']!r}). If you "
+            f"are in a container, the fleet's real config is almost certainly "
+            f"the other one, and WRITES HERE WILL NOT REACH IT — `sac host "
+            f"add` will report success against this copy while fleet state is "
+            f"unchanged. Compare the peer counts: they are the fastest tell. "
+            f"To act on the fleet config, run on the host or point at it with "
+            f"SCITEX_AGENT_CONTAINER_CONFIG=<path>."
         )
 
     return errors, warnings, detail

--- a/tests/scitex_agent_container/_state/test_host_config_shadow.py
+++ b/tests/scitex_agent_container/_state/test_host_config_shadow.py
@@ -1,0 +1,154 @@
+"""A PRESENT, well-formed ``config.yaml`` can still be the WRONG one.
+
+INCIDENT 2026-08-05 (scitex-dev): they ran ``sac host add`` twice inside a
+container, then ``sac host validate``, which answered ``ok, valid (2 peers)``.
+The rows had landed in a 127-byte ``/home/agent/.scitex/agent-container/
+config.yaml`` created that same day, while the operator's real four-peer config
+under ``/home/ywatanabe`` — bind-mounted and readable from inside the container
+— was never touched. Both commands reported success about the wrong file, and
+the card was reported CLOSED on the strength of it, then retracted.
+
+This is NOT the 2026-07-30 ABSENT case the module was written for; that one is
+already caught. Here every state check legitimately passes, because the
+resolved file really is a valid config — just not the fleet's. ``POPULATED``
+emitted no diagnostic at all, so the one shape that silently diverges from
+fleet state was the one shape we said nothing about.
+
+NO MOCKS — real files in ``tmp_path``, with the homes root injected so the
+guard is reachable from a test at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._state.host_config_diagnose import (
+    config_state_problems,
+    find_shadowing_configs,
+)
+
+
+def _write_config(path: Path, peers: int) -> Path:
+    """Write a well-formed config with ``peers`` named peer entries."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = "peers:\n" + "".join(
+        f"  peer{i}:\n    ssh: user@peer{i}\n" for i in range(peers)
+    )
+    path.write_text(body if peers else "peers: {}\n", encoding="utf-8")
+    return path
+
+
+def test_config_under_another_home_is_reported(tmp_path: Path) -> None:
+    """The operator's config in a different home must be surfaced."""
+    # Arrange — a container-style home and an operator home, both valid.
+    homes = tmp_path / "home"
+    mine = _write_config(homes / "agent" / ".scitex/agent-container/config.yaml", 2)
+    _write_config(homes / "ywatanabe" / ".scitex/agent-container/config.yaml", 4)
+    # Act
+    found = find_shadowing_configs(mine, homes_root=homes)
+    # Assert
+    assert [p.parent.parent.parent.name for p, _ in found] == ["ywatanabe"]
+
+
+def test_peer_count_of_the_other_config_is_reported(tmp_path: Path) -> None:
+    """The COUNT is the discriminator — 2 vs 4 is what names the split."""
+    # Arrange
+    homes = tmp_path / "home"
+    mine = _write_config(homes / "agent" / ".scitex/agent-container/config.yaml", 2)
+    _write_config(homes / "ywatanabe" / ".scitex/agent-container/config.yaml", 4)
+    # Act
+    found = find_shadowing_configs(mine, homes_root=homes)
+    # Assert
+    assert found[0][1] == 4
+
+
+def test_resolved_config_is_not_its_own_shadow(tmp_path: Path) -> None:
+    """The file we resolved must never be reported as shadowing itself."""
+    # Arrange
+    homes = tmp_path / "home"
+    mine = _write_config(homes / "agent" / ".scitex/agent-container/config.yaml", 2)
+    # Act
+    found = find_shadowing_configs(mine, homes_root=homes)
+    # Assert
+    assert found == []
+
+
+def test_same_file_reached_by_symlink_is_not_a_shadow(tmp_path: Path) -> None:
+    """A second NAME for one file is not a second file.
+
+    Measured 2026-08-05: the live spec path and the dotfiles path share one
+    inode (4076503). Reporting an alias as a shadow would cry wolf on a
+    perfectly normal layout, and a warning that cries wolf gets ignored on the
+    day it is right.
+    """
+    # Arrange — real config under one home, the other home a symlink to it.
+    homes = tmp_path / "home"
+    real = _write_config(homes / "ywatanabe" / ".scitex/agent-container/config.yaml", 4)
+    link_home = homes / "agent" / ".scitex" / "agent-container"
+    link_home.mkdir(parents=True)
+    (link_home / "config.yaml").symlink_to(real)
+    # Act
+    found = find_shadowing_configs(link_home / "config.yaml", homes_root=homes)
+    # Assert
+    assert found == []
+
+
+def test_unparseable_other_config_is_ignored(tmp_path: Path) -> None:
+    """Garbage elsewhere is not evidence of a fleet config."""
+    # Arrange
+    homes = tmp_path / "home"
+    mine = _write_config(homes / "agent" / ".scitex/agent-container/config.yaml", 2)
+    junk = homes / "someone" / ".scitex" / "agent-container"
+    junk.mkdir(parents=True)
+    (junk / "config.yaml").write_text("::: not yaml :::\n", encoding="utf-8")
+    # Act
+    found = find_shadowing_configs(mine, homes_root=homes)
+    # Assert
+    assert found == []
+
+
+def test_populated_config_now_warns_when_shadowed(tmp_path: Path) -> None:
+    """THE REGRESSION GUARD: POPULATED used to emit nothing at all.
+
+    scitex-dev's config was present, well-formed and populated, so every
+    existing branch passed in silence. If a future refactor drops the shadow
+    check, this test goes red instead of an agent reporting a false success.
+    """
+    # Arrange
+    homes = tmp_path / "home"
+    mine = _write_config(homes / "agent" / ".scitex/agent-container/config.yaml", 2)
+    _write_config(homes / "ywatanabe" / ".scitex/agent-container/config.yaml", 4)
+    # Act
+    import scitex_agent_container._state.host_config_diagnose as diag
+
+    saved, diag.HOMES_ROOT = diag.HOMES_ROOT, homes
+    try:
+        _errors, warnings, _detail = config_state_problems(mine)
+    finally:
+        diag.HOMES_ROOT = saved
+    # Assert
+    assert any("ANOTHER config.yaml" in w for w in warnings)
+
+
+def test_shadow_does_not_fail_the_gate(tmp_path: Path) -> None:
+    """A shadow is a WARNING, not an error — validate must still exit 0.
+
+    Two homes holding configs is legitimate on a bare host; only the container
+    case is suspicious, and this module cannot tell them apart with certainty.
+    Failing here would teach operators to ignore the check, which is how the
+    2026-07-30 absent-config defect survived.
+    """
+    # Arrange
+    homes = tmp_path / "home"
+    mine = _write_config(homes / "agent" / ".scitex/agent-container/config.yaml", 2)
+    _write_config(homes / "ywatanabe" / ".scitex/agent-container/config.yaml", 4)
+    # Act
+    import scitex_agent_container._state.host_config_diagnose as diag
+
+    saved, diag.HOMES_ROOT = diag.HOMES_ROOT, homes
+    try:
+        errors, _warnings, _detail = config_state_problems(mine)
+    finally:
+        diag.HOMES_ROOT = saved
+    # Assert
+    assert errors == []


### PR DESCRIPTION
`sac host add` run **inside a container** wrote two peers into a 127-byte `/home/agent/.scitex/agent-container/config.yaml` created that same day. `sac host validate` then answered **"ok, valid (2 peers)"**. The operator's real config under `/home/ywatanabe` — bind-mounted and readable from inside the container — was never touched.

Both commands reported success about the wrong file. The card was reported closed on the strength of it, then retracted. Reported by `scitex-dev`.

## Why the existing guard missed it

This module was written for the 2026-07-30 **ABSENT** case, which it catches. Here every state check *legitimately* passes — the resolved file really is a valid config, just not the fleet's. `STATE_POPULATED` emitted no diagnostic at all, so **the one shape that silently diverges from fleet state was the one shape we said nothing about.**

## The discriminator was already on screen

Resolved config: **2 peers**. Operator's: **4**. The count named the split, and both of us read `ok` and stopped. So the warning reports the peer count per candidate — comparing 2 against 4 is instant, whereas two paths side by side still look like a deliberate choice.

## Deliberately conservative

A false positive here trains people to ignore the warning, so it only fires on:

- `/home/*/.scitex/agent-container/config.yaml` — the layout the bind actually produces; no unbounded walk
- files that parse and are readable
- **never** the resolved path, and never a path resolving to the *same file* — an alias is not a shadow (measured today: the live and dotfiles spec paths share one inode)
- only when the resolved path is itself HOME-derived — an explicit `SCITEX_AGENT_CONTAINER_CONFIG` was named deliberately. This also keeps the check **hermetic**: otherwise every `tmp_path` unit test picks up the real `/home`.

A **warning, not an error** — two homes holding configs is legitimate on a bare host, and this module cannot tell that from the container case with certainty. Failing here would teach operators to ignore the check, which is how the 2026-07-30 defect survived.

## Scope

Makes the condition **visible**; does not stop the write. Host-mutating verbs resolving to the container shadow is tracked on `sac-host-mutating-verbs-write-the-container-shadow-and-report-success-20260805`.

## Verification

- 7 new tests, including a regression guard for the POPULATED-emits-nothing case
- **live positive control** from inside this container: correctly reports `/home/ywatanabe/.scitex/agent-container/config.yaml (5 peers)` as shadowing
- 5 unrelated `test_lead_inbox` failures in the full-dir run are **test-interaction flake** — 20/20 pass in isolation, and that module does not touch `host_config_diagnose`