### PR TITLE
fix(worktree-hooks): unpin the interpreter the fragment's own comment says must not be pinned

### DIFF
--- a/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/settings.local.json.fragment.json
+++ b/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/settings.local.json.fragment.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/opt/venv-agent/bin/python3 $HOME/.claude/hooks/claude_worktree_hooks/worktree_create.py"
+            "command": "python3 $HOME/.claude/hooks/claude_worktree_hooks/worktree_create.py"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/opt/venv-agent/bin/python3 $HOME/.claude/hooks/claude_worktree_hooks/worktree_remove.py"
+            "command": "python3 $HOME/.claude/hooks/claude_worktree_hooks/worktree_remove.py"
           }
         ]
       }
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/opt/venv-agent/bin/python3 $HOME/.claude/hooks/claude_worktree_hooks/session_start_reap_stale.py"
+            "command": "python3 $HOME/.claude/hooks/claude_worktree_hooks/session_start_reap_stale.py"
           }
         ]
       }


### PR DESCRIPTION
The shipped WorktreeCreate / WorktreeRemove / SessionStart hook fragment invoked `/opt/venv-agent/bin/python3`. **That path does not exist** — `ls -d /opt/venv-agent` → *No such file or directory* — so all three hooks pointed at a missing interpreter on every agent that materialises this fragment.

## The file documents the rule it breaks

Line 2 of the same file:

> `python3` is PATH-based (**NOT pinned to `/opt/venv-agent/bin/python3`**) because fleet-wide WorktreeCreate breakage on 2026-06-13 (lead a2a 07a9187b/777d0a5a) traced to an interpreter-path drift across SIFs.

The comment records a fleet-wide outage, names its cause, states the rule that prevents it — and the three `command` lines below it violate that rule verbatim, re-arming the exact 2026-06-13 break.

## Fix

`/opt/venv-agent/bin/python3` → `python3` at all three sites, which is what the comment specifies. JSON re-parsed after the edit; zero remaining `"command": "/opt/venv-agent` occurrences.

## Why a comment did not hold

This is the pave-the-road case. The rule was written down, in the right file, with its incident reference attached — and it still drifted back, because **nothing mechanical checks it**. Worth a follow-up: a test asserting no command in the shipped baseline assets names an absolute interpreter path. A rule that must be remembered is forgotten at exactly the moment it matters.

## Provenance

Surfaced by the deferred-backlog triage (`sac-worktree-hooks-fragment-pins-nonexistent-interpreter-20260723`) and **verified independently before fixing** — the missing directory and the three pinned lines were both re-measured in this tree rather than taken from the card.