### PR TITLE
fix(host-config): refuse a host name that is DESIGNED to point elsewhere later

### DIFF
--- a/src/scitex_agent_container/_state/_host_config_blocks.py
+++ b/src/scitex_agent_container/_state/_host_config_blocks.py
@@ -1,0 +1,180 @@
+"""The optional typed blocks of ``config.yaml`` — ``resolve:`` and ``lead:``.
+
+Extracted from :mod:`.host_config` so that file stays under the project's
+512-line ceiling (it had 8 lines of headroom left, which is not headroom).
+Pure extraction — no behaviour change.
+
+Each block here is the same shape: a frozen dataclass plus the one parser
+that builds it from raw YAML and raises ``ValueError`` naming the offending
+peer/path, so an operator typo surfaces at config-load time rather than as an
+opaque ssh or HTTP failure much later. The public import path
+``from scitex_agent_container._state.host_config import LeadConfig`` is
+preserved by a re-export in :mod:`.host_config`.
+
+:class:`HostBlock` and :class:`PeerSpec` deliberately stay in
+:mod:`.host_config`: they are the core schema every caller touches, not
+optional sub-blocks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+_RESOLVE_ALLOWED_SOURCES = ("scitex-hpc",)
+
+
+@dataclass(frozen=True)
+class ResolveSpec:
+    """Dispatch-time peer-target resolution descriptor (Phase 1 schema).
+
+    Carried on a ``PeerSpec`` via the ``resolve`` field. When set, the peer's
+    live ``ssh`` target is to be filled in at dispatch time by querying
+    ``source`` (currently only ``"scitex-hpc"``) instead of being pinned
+    statically in ``peers.yaml``. Phase 1 of the label-style-peer migration
+    only *parses and validates* this field — no resolver code runs. Phase 2
+    will wire the lookup into ``try_dispatch``. Full plan in the lead's
+    planning doc ``sac-dispatch-time-node-resolution.md``.
+
+    Fields:
+      source: backend identifier. Phase 1 accepts only ``"scitex-hpc"``;
+        any other value raises ``ValueError`` at config-load time so
+        operator typos surface immediately, not at dispatch.
+      reservation: the scitex-hpc reservation name (used when
+        ``source == "scitex-hpc"``). Optional at the schema level so
+        future backends can omit it; Phase 2's resolver will enforce
+        presence at resolve time for scitex-hpc.
+    """
+
+    source: str
+    reservation: str | None = None
+
+
+@dataclass(frozen=True)
+class LeadConfig:
+    """``lead:`` block — agent→lead push inbox target (ADR-0013 Phase 1).
+
+    Identifies the lead's ``sac listen`` instance so an agent can POST a
+    typed completion/blocker/status event to it via
+    ``/agents/<name>/message:send``. The lead is just another A2A node
+    on the existing control plane; this block is the one place every
+    agent learns where it lives.
+
+    Fields:
+      name: target name on the lead's listen (used as ``<name>`` in
+        the POST path and as the ACL identity the lead's listen sees).
+      host: peer key (must exist under ``peers:``) used for two
+        independent jobs — looking up the per-host bearer token under
+        ``peer-tokens/<host>.token`` (the credential the agent
+        authenticates with) and naming the destination host for the
+        outbound HTTP request. Reusing the peer key keeps the lead
+        consistent with how every other cross-host node is addressed.
+      a2a_port: TCP port the lead's ``sac listen`` is bound to (the
+        host-wide listen, not a per-agent sidecar). Required because
+        the lead's listen is not registered in any state.db's
+        ``instances`` table — it is not an agent and has no
+        ``record_instance_start`` call.
+
+    Loud failure is the only failure mode. Phase 1 ships the helper
+    plus CLI; the lead-inbox push refuses to dispatch when any of
+    ``name`` / ``host`` / ``a2a_port`` is missing rather than guessing.
+    See :mod:`scitex_agent_container._state.lead_inbox`.
+    """
+
+    name: str
+    host: str
+    a2a_port: int
+
+
+def _parse_lead(raw, *, source_path: Path) -> LeadConfig | None:
+    """Normalize the optional ``lead:`` YAML block into a :class:`LeadConfig`.
+
+    Missing block → ``None`` (config-load stays missing-tolerant; the
+    lead-inbox helpers raise their own loud error when an agent tries
+    to push with no lead configured). Present block → strict
+    validation: ``name`` (non-empty string), ``host`` (non-empty
+    string), ``a2a_port`` (positive int). Any other shape raises
+    ``ValueError`` naming ``source_path`` so operator typos surface
+    at config-load time rather than as opaque HTTP failures from the
+    push helper.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"config.yaml at {source_path}: 'lead' must be a mapping with "
+            f"name:/host:/a2a_port:, got {type(raw).__name__}"
+        )
+    name = raw.get("name")
+    host = raw.get("host")
+    port = raw.get("a2a_port")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError(
+            f"config.yaml at {source_path}: 'lead.name' is required and "
+            f"must be a non-empty string (got {name!r})"
+        )
+    if not isinstance(host, str) or not host.strip():
+        raise ValueError(
+            f"config.yaml at {source_path}: 'lead.host' is required and "
+            f"must be a non-empty string (got {host!r})"
+        )
+    if not isinstance(port, int) or isinstance(port, bool) or port <= 0:
+        raise ValueError(
+            f"config.yaml at {source_path}: 'lead.a2a_port' is required "
+            f"and must be a positive integer (got {port!r})"
+        )
+    return LeadConfig(name=name, host=host, a2a_port=port)
+
+
+def _parse_resolve(name: str, raw) -> ResolveSpec | None:
+    """Normalize a peer's ``resolve:`` YAML field into a :class:`ResolveSpec`.
+
+    Phase 1 of the dispatch-time-resolution architecture (full plan at
+    ``~/proj/scitex-lead/GITIGNORED/FUTURE/sac-dispatch-time-node-resolution.md``).
+    This helper only *parses* the field; no network / scitex-hpc lookup
+    happens here.
+
+    Accepted shapes:
+
+    * Missing / ``None`` → returns ``None`` (peer has no resolver).
+    * A mapping with at minimum ``source:``. Phase 1 accepts only
+      ``source: scitex-hpc``; any other value raises ``ValueError``
+      naming the peer, so operator typos surface at config-load time
+      rather than at dispatch.
+
+    Any other shape (scalar, list, ...) raises ``ValueError``.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"config.yaml: peer '{name}' resolve: must be a mapping with "
+            f"source: (and source-specific keys), got {type(raw).__name__}"
+        )
+    source = raw.get("source")
+    if not isinstance(source, str) or not source.strip():
+        raise ValueError(
+            f"config.yaml: peer '{name}' resolve.source is required and "
+            f"must be a non-empty string"
+        )
+    if source not in _RESOLVE_ALLOWED_SOURCES:
+        raise ValueError(
+            f"config.yaml: peer '{name}' resolve.source={source!r} is "
+            f"unknown; allowed values: {list(_RESOLVE_ALLOWED_SOURCES)}"
+        )
+    reservation = raw.get("reservation")
+    if reservation is not None and not isinstance(reservation, str):
+        raise ValueError(
+            f"config.yaml: peer '{name}' resolve.reservation must be a "
+            f"string if set, got {type(reservation).__name__}"
+        )
+    return ResolveSpec(source=source, reservation=reservation)
+
+
+__all__ = [
+    "LeadConfig",
+    "ResolveSpec",
+    "_RESOLVE_ALLOWED_SOURCES",
+    "_parse_lead",
+    "_parse_resolve",
+]

--- a/src/scitex_agent_container/_state/host_config.py
+++ b/src/scitex_agent_container/_state/host_config.py
@@ -12,14 +12,20 @@ YAML shape::
       aliases:
         Yusukes-MacBook-Air: mba
         spartan-login1:      spartan
-        DXP480TPLUS-994:     nas
+        DXP480TPLUS-994:     nas-03
       fallback: hostname-short      # 'hostname-short' | 'hostname-fqdn'
 
     peers:
       mba:     { ssh: ywatanabe@mba.local }
       spartan: { ssh: ywatanabe@spartan-login1, via: [mba] }
       bm198:   { ssh: bm198, via: [mba, spartan] }
-      nas:     { ssh: admin@192.168.11.22, reverse_ssh: ywata-note-win }
+      nas-03:  { ssh: nas-03, reverse_ssh: ywata-note-win }
+
+Peer keys must be STABLE names. ``nas-03``, not ``nas`` — the bare name is
+re-pointed to the next machine as hardware is replaced, so it keeps resolving
+while addressing a different host. :mod:`.moving_alias` holds the registry and
+:meth:`Config.validate` refuses one as a key. Convenience aliases belong in
+``~/.ssh/config``, where "the current NAS" is what a human means.
 
     lead:                           # ADR-0013 Phase 1 — agent→lead push inbox.
       name: lead                    # Target name on the lead's `sac listen`
@@ -55,6 +61,17 @@ from scitex_config._ecosystem import local_state as _local_state
 
 from .._env import getenv as _sac_env
 
+# ``LeadConfig`` / ``ResolveSpec`` live in ._host_config_blocks but are
+# re-exported here: ``lead_inbox`` and the config tests import them from
+# this module, and the extraction must not move a public import path.
+from ._host_config_blocks import (  # noqa: F401
+    LeadConfig,
+    ResolveSpec,
+    _parse_lead,
+    _parse_resolve,
+)
+from .moving_alias import MovingAliasError, moving_alias_hint
+
 
 def _default_config_path() -> Path:
     """Resolve config.yaml via the SciTeX local-state cascade.
@@ -69,33 +86,6 @@ def _default_config_path() -> Path:
     if override:
         return Path(override)
     return _local_state.path("agent-container", "config.yaml")
-
-
-@dataclass(frozen=True)
-class ResolveSpec:
-    """Dispatch-time peer-target resolution descriptor (Phase 1 schema).
-
-    Carried on a :class:`PeerSpec` via the ``resolve`` field. When set,
-    the peer's live ``ssh`` target is to be filled in at dispatch time
-    by querying ``source`` (currently only ``"scitex-hpc"``) instead of
-    being pinned statically in ``peers.yaml``. Phase 1 of the
-    label-style-peer migration only *parses and validates* this field —
-    no resolver code runs. Phase 2 will wire the lookup into
-    ``try_dispatch``. Full plan in the lead's planning doc
-    ``sac-dispatch-time-node-resolution.md``.
-
-    Fields:
-      source: backend identifier. Phase 1 accepts only ``"scitex-hpc"``;
-        any other value raises ``ValueError`` at config-load time so
-        operator typos surface immediately, not at dispatch.
-      reservation: the scitex-hpc reservation name (used when
-        ``source == "scitex-hpc"``). Optional at the schema level so
-        future backends can omit it; Phase 2's resolver will enforce
-        presence at resolve time for scitex-hpc.
-    """
-
-    source: str
-    reservation: str | None = None
 
 
 @dataclass(frozen=True)
@@ -182,42 +172,6 @@ class HostBlock:
 
 
 @dataclass(frozen=True)
-class LeadConfig:
-    """``lead:`` block — agent→lead push inbox target (ADR-0013 Phase 1).
-
-    Identifies the lead's ``sac listen`` instance so an agent can POST a
-    typed completion/blocker/status event to it via
-    ``/agents/<name>/message:send``. The lead is just another A2A node
-    on the existing control plane; this block is the one place every
-    agent learns where it lives.
-
-    Fields:
-      name: target name on the lead's listen (used as ``<name>`` in
-        the POST path and as the ACL identity the lead's listen sees).
-      host: peer key (must exist under ``peers:``) used for two
-        independent jobs — looking up the per-host bearer token under
-        ``peer-tokens/<host>.token`` (the credential the agent
-        authenticates with) and naming the destination host for the
-        outbound HTTP request. Reusing the peer key keeps the lead
-        consistent with how every other cross-host node is addressed.
-      a2a_port: TCP port the lead's ``sac listen`` is bound to (the
-        host-wide listen, not a per-agent sidecar). Required because
-        the lead's listen is not registered in any state.db's
-        ``instances`` table — it is not an agent and has no
-        ``record_instance_start`` call.
-
-    Loud failure is the only failure mode. Phase 1 ships the helper
-    plus CLI; the lead-inbox push refuses to dispatch when any of
-    ``name`` / ``host`` / ``a2a_port`` is missing rather than guessing.
-    See :mod:`scitex_agent_container._state.lead_inbox`.
-    """
-
-    name: str
-    host: str
-    a2a_port: int
-
-
-@dataclass(frozen=True)
 class Config:
     host: HostBlock = field(default_factory=HostBlock)
     peers: dict[str, PeerSpec] = field(default_factory=dict)
@@ -249,6 +203,17 @@ class Config:
         Peers without ``resolve:`` still require an explicit ``ssh:``.
         """
         errors: list[str] = []
+        for pname in self.peers:
+            hint = moving_alias_hint(pname, context="peer key in config.yaml")
+            if hint:
+                errors.append(f"peer '{pname}': {hint}")
+        for alias_from, alias_to in self.host.aliases.items():
+            # The VALUE is the canonical name every state.db row is stamped
+            # with, so a moving alias there makes THIS machine's identity move.
+            # The KEY is a raw `hostname -s` reading and cannot move.
+            hint = moving_alias_hint(alias_to, context="canonical host name")
+            if hint:
+                errors.append(f"host.aliases['{alias_from}']: {hint}")
         for pname, p in self.peers.items():
             # Skip glob-pattern keys — their ssh is synthesized per-query
             # from the matched hostname (see PeersMap.__getitem__).
@@ -305,6 +270,13 @@ class PeersMap(dict):
         matched = self._glob_match(key)
         if matched is not None:
             return matched
+        # Every sac dispatch target lands here, so this is the one place that
+        # can tell "peer you never defined" from "peer whose name moves".
+        # A bare KeyError('nas') reads as a config typo; it is the opposite —
+        # the name is fine and the MACHINE it names is what changed.
+        hint = moving_alias_hint(key, context="dispatch target")
+        if hint:
+            raise MovingAliasError(hint)
         raise KeyError(key)
 
     def __contains__(self, key):
@@ -354,94 +326,6 @@ def load(path: Path | None = None) -> Config:
     lead = _parse_lead(raw.get("lead"), source_path=p)
 
     return Config(host=host, peers=peers, lead=lead, source_path=p)
-
-
-_RESOLVE_ALLOWED_SOURCES = ("scitex-hpc",)
-
-
-def _parse_lead(raw, *, source_path: Path) -> LeadConfig | None:
-    """Normalize the optional ``lead:`` YAML block into a :class:`LeadConfig`.
-
-    Missing block → ``None`` (config-load stays missing-tolerant; the
-    lead-inbox helpers raise their own loud error when an agent tries
-    to push with no lead configured). Present block → strict
-    validation: ``name`` (non-empty string), ``host`` (non-empty
-    string), ``a2a_port`` (positive int). Any other shape raises
-    ``ValueError`` naming ``source_path`` so operator typos surface
-    at config-load time rather than as opaque HTTP failures from the
-    push helper.
-    """
-    if raw is None:
-        return None
-    if not isinstance(raw, dict):
-        raise ValueError(
-            f"config.yaml at {source_path}: 'lead' must be a mapping with "
-            f"name:/host:/a2a_port:, got {type(raw).__name__}"
-        )
-    name = raw.get("name")
-    host = raw.get("host")
-    port = raw.get("a2a_port")
-    if not isinstance(name, str) or not name.strip():
-        raise ValueError(
-            f"config.yaml at {source_path}: 'lead.name' is required and "
-            f"must be a non-empty string (got {name!r})"
-        )
-    if not isinstance(host, str) or not host.strip():
-        raise ValueError(
-            f"config.yaml at {source_path}: 'lead.host' is required and "
-            f"must be a non-empty string (got {host!r})"
-        )
-    if not isinstance(port, int) or isinstance(port, bool) or port <= 0:
-        raise ValueError(
-            f"config.yaml at {source_path}: 'lead.a2a_port' is required "
-            f"and must be a positive integer (got {port!r})"
-        )
-    return LeadConfig(name=name, host=host, a2a_port=port)
-
-
-def _parse_resolve(name: str, raw) -> ResolveSpec | None:
-    """Normalize a peer's ``resolve:`` YAML field into a :class:`ResolveSpec`.
-
-    Phase 1 of the dispatch-time-resolution architecture (full plan at
-    ``~/proj/scitex-lead/GITIGNORED/FUTURE/sac-dispatch-time-node-resolution.md``).
-    This helper only *parses* the field; no network / scitex-hpc lookup
-    happens here.
-
-    Accepted shapes:
-
-    * Missing / ``None`` → returns ``None`` (peer has no resolver).
-    * A mapping with at minimum ``source:``. Phase 1 accepts only
-      ``source: scitex-hpc``; any other value raises ``ValueError``
-      naming the peer, so operator typos surface at config-load time
-      rather than at dispatch.
-
-    Any other shape (scalar, list, ...) raises ``ValueError``.
-    """
-    if raw is None:
-        return None
-    if not isinstance(raw, dict):
-        raise ValueError(
-            f"config.yaml: peer '{name}' resolve: must be a mapping with "
-            f"source: (and source-specific keys), got {type(raw).__name__}"
-        )
-    source = raw.get("source")
-    if not isinstance(source, str) or not source.strip():
-        raise ValueError(
-            f"config.yaml: peer '{name}' resolve.source is required and "
-            f"must be a non-empty string"
-        )
-    if source not in _RESOLVE_ALLOWED_SOURCES:
-        raise ValueError(
-            f"config.yaml: peer '{name}' resolve.source={source!r} is "
-            f"unknown; allowed values: {list(_RESOLVE_ALLOWED_SOURCES)}"
-        )
-    reservation = raw.get("reservation")
-    if reservation is not None and not isinstance(reservation, str):
-        raise ValueError(
-            f"config.yaml: peer '{name}' resolve.reservation must be a "
-            f"string if set, got {type(reservation).__name__}"
-        )
-    return ResolveSpec(source=source, reservation=reservation)
 
 
 def _parse_env_preamble(name: str, raw) -> tuple[str, ...]:

--- a/src/scitex_agent_container/_state/moving_alias.py
+++ b/src/scitex_agent_container/_state/moving_alias.py
@@ -1,0 +1,88 @@
+"""Host names that are DESIGNED to point at a different machine later.
+
+``nas`` is not a typo for ``nas-03``. It is a name the operator's numbering
+scheme deliberately re-points as hardware is replaced — ``nas-01`` →
+``nas-02`` → ``nas-03`` → … — so it resolves correctly every single time and
+still addresses the wrong machine the day the next generation lands. Nothing
+errors, because the name is valid; only the referent moved. (Operator,
+2026-08-05: *"nas-03 が正しいです … 010203 とだんだん数字が増えていく"*.)
+
+That makes a moving alias fine as a typing convenience and unsafe as an
+IDENTITY. sac keys real decisions on peer names — where a credential is
+pushed, which machine a dispatch lands on, which row in the cross-host
+registry a heartbeat belongs to — and every one of those silently follows the
+alias to the new machine.
+
+So sac refuses a moving alias wherever a name is used as an identity, and the
+refusal names the stable replacement. It stays usable in ``~/.ssh/config``,
+where "the current NAS" is exactly what a human means when they type it.
+
+The registry below is the single place that knows which names move. Adding
+``nas-04`` later means editing ``MOVING_ALIASES`` here and nowhere else.
+"""
+
+from __future__ import annotations
+
+# alias → the stable, generation-pinned name to key on instead.
+MOVING_ALIASES: dict[str, str] = {
+    "nas": "nas-03",
+}
+
+
+class MovingAliasError(KeyError):
+    """Raised when a moving alias is used where an identity is required.
+
+    Subclasses ``KeyError`` so existing ``except KeyError`` handlers around
+    peer lookup keep working — the change is the message they now carry, not
+    the type they catch. ``__str__`` is overridden because ``KeyError`` repr's
+    its argument, which would wrap a multi-sentence hint in quotes and escape
+    the newlines out of it.
+    """
+
+    def __str__(self) -> str:
+        return str(self.args[0]) if self.args else ""
+
+
+def stable_name_for(name: str) -> str | None:
+    """Return the pinned name that ``name`` should be replaced by.
+
+    ``None`` when ``name`` is not a known moving alias — which covers both
+    "this name is stable" and "nobody has registered it as moving yet". Those
+    are genuinely different, but sac treats them the same on purpose: refusing
+    a name merely because it is unrecognised would break every legitimate peer.
+    """
+    return MOVING_ALIASES.get(name)
+
+
+def moving_alias_hint(name: str, *, context: str = "") -> str | None:
+    """Return the actionable refusal message for ``name``, else ``None``.
+
+    ``None`` means "not a moving alias, carry on" — callers branch on it
+    rather than catching an exception, so the check reads as a guard at the
+    top of a function instead of a control-flow surprise.
+
+    ``context`` names what was being attempted ("peer key in config.yaml",
+    "ssh dispatch target"), so the same registry produces a message that fits
+    the caller instead of a generic one the reader has to translate.
+    """
+    stable = stable_name_for(name)
+    if stable is None:
+        return None
+    where = f" as a {context}" if context else ""
+    return (
+        f"'{name}' is a MOVING ALIAS and must not be used{where}: it is "
+        f"re-pointed to a different machine as hardware is replaced "
+        f"({name}-01 → {name}-02 → {stable} → …), so it keeps resolving "
+        f"while silently addressing another host. Use '{stable}' instead. "
+        f"If the current machine has been replaced, update MOVING_ALIASES in "
+        f"scitex_agent_container/_state/moving_alias.py to the new generation "
+        f"— that is the one place sac reads it from."
+    )
+
+
+__all__ = [
+    "MOVING_ALIASES",
+    "MovingAliasError",
+    "moving_alias_hint",
+    "stable_name_for",
+]

--- a/tests/scitex_agent_container/_state/test_host_config_moving_alias.py
+++ b/tests/scitex_agent_container/_state/test_host_config_moving_alias.py
@@ -1,0 +1,143 @@
+"""``config.yaml`` may not key a peer on a name that is designed to move.
+
+Companion to ``test_moving_alias.py``, which pins the registry itself. This
+file pins where sac ENFORCES it, and — just as important — where it does not:
+
+* ``Config.validate`` reports a moving-alias key, so ``sac host add/set``
+  reverts the write and ``sac host validate`` goes red.
+* ``PeersMap`` turns the post-migration ``KeyError('nas')`` into a message
+  that says which machine to name instead. That covers every sac dispatch
+  path at once, not only ssh.
+* ``load`` stays tolerant. A config that still says ``nas`` keeps loading and
+  keeps resolving — breaking it at import time would take the fleet down to
+  fix a name.
+
+NO MOCKS — real config files written to ``tmp_path`` and read by the real
+loader.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._state.host_config import PeersMap, load
+from scitex_agent_container._state.moving_alias import MovingAliasError
+
+
+def _write(path: Path, body: str) -> Path:
+    """Write ``body`` as a config.yaml at ``path`` and return the path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _lookup_failure(peers: PeersMap, key: str) -> KeyError:
+    """Return the error raised by ``peers[key]``; fail if the lookup succeeds.
+
+    Written as a helper rather than ``pytest.raises`` so each test can keep a
+    single assertion — the raises-block itself counts as one, which would
+    leave the message unchecked.
+    """
+    try:
+        peers[key]
+    except KeyError as exc:
+        return exc
+    raise AssertionError(f"expected {key!r} to fail lookup, but it resolved")
+
+
+def test_a_moving_alias_peer_key_is_rejected(tmp_path: Path) -> None:
+    """The live config keyed the production NAS on `nas` for months."""
+    # Arrange
+    cfg_path = _write(tmp_path / "config.yaml", "peers:\n  nas:\n    ssh: nas\n")
+    # Act
+    errors = load(cfg_path).validate()
+    # Assert
+    assert len(errors) == 1
+
+
+def test_the_rejection_names_the_stable_replacement(tmp_path: Path) -> None:
+    """`sac host validate` must print what to change it to, not just that."""
+    # Arrange
+    cfg_path = _write(tmp_path / "config.yaml", "peers:\n  nas:\n    ssh: nas\n")
+    # Act
+    errors = load(cfg_path).validate()
+    # Assert
+    assert "nas-03" in errors[0]
+
+
+def test_the_pinned_generation_validates_clean(tmp_path: Path) -> None:
+    """The migrated config must pass, or the migration cannot be completed."""
+    # Arrange
+    cfg_path = _write(tmp_path / "config.yaml", "peers:\n  nas-03:\n    ssh: nas-03\n")
+    # Act
+    errors = load(cfg_path).validate()
+    # Assert
+    assert errors == []
+
+
+def test_a_moving_alias_as_this_machines_canonical_name_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """host.aliases VALUES stamp every state.db row with this host's identity."""
+    # Arrange
+    cfg_path = _write(
+        tmp_path / "config.yaml",
+        "host:\n  aliases:\n    DXP480TPLUS-994: nas\npeers: {}\n",
+    )
+    # Act
+    errors = load(cfg_path).validate()
+    # Assert
+    assert "DXP480TPLUS-994" in errors[0]
+
+
+def test_an_alias_to_the_pinned_generation_validates_clean(tmp_path: Path) -> None:
+    """The same mapping is correct once it names the generation."""
+    # Arrange
+    cfg_path = _write(
+        tmp_path / "config.yaml",
+        "host:\n  aliases:\n    DXP480TPLUS-994: nas-03\npeers: {}\n",
+    )
+    # Act
+    errors = load(cfg_path).validate()
+    # Assert
+    assert errors == []
+
+
+def test_config_that_still_names_the_alias_still_loads(tmp_path: Path) -> None:
+    """Refusing at LOAD time would take every sac verb down over a name."""
+    # Arrange
+    cfg_path = _write(tmp_path / "config.yaml", "peers:\n  nas:\n    ssh: nas\n")
+    # Act
+    cfg = load(cfg_path)
+    # Assert
+    assert cfg.peers["nas"].ssh == "nas"
+
+
+def test_dispatching_to_a_retired_alias_says_which_host_to_name() -> None:
+    """After the re-key, `nas` is simply absent — and that reads as a typo."""
+    # Arrange
+    peers = PeersMap()
+    # Act
+    failure = _lookup_failure(peers, "nas")
+    # Assert
+    assert "nas-03" in str(failure)
+
+
+def test_an_ordinary_unknown_peer_still_raises_a_plain_keyerror() -> None:
+    """A guard that fires on everything cannot discriminate anything."""
+    # Arrange
+    peers = PeersMap()
+    # Act
+    failure = _lookup_failure(peers, "gpu-box")
+    # Assert
+    assert not isinstance(failure, MovingAliasError)
+
+
+def test_callers_that_opt_into_absence_are_unchanged() -> None:
+    """`.get` means the caller has already decided a miss is acceptable."""
+    # Arrange
+    peers = PeersMap()
+    # Act
+    resolved = peers.get("nas")
+    # Assert
+    assert resolved is None

--- a/tests/scitex_agent_container/_state/test_host_config_reverse_ssh.py
+++ b/tests/scitex_agent_container/_state/test_host_config_reverse_ssh.py
@@ -63,7 +63,9 @@ def test_from_dict_defaults_reverse_ssh_to_empty():
 
 def test_validate_accepts_a_peer_with_reverse_ssh(cfg_path: Path):
     # Arrange
-    cfg_path.write_text("peers:\n  nas:\n    ssh: n\n    reverse_ssh: master-x\n")
+    # nas-03, not nas: the bare name is a moving alias and validate() now
+    # refuses it, so a fixture using it would be asserting on the wrong thing.
+    cfg_path.write_text("peers:\n  nas-03:\n    ssh: n\n    reverse_ssh: master-x\n")
     cfg = load(cfg_path)
     # Act
     errors = cfg.validate()

--- a/tests/scitex_agent_container/_state/test_moving_alias.py
+++ b/tests/scitex_agent_container/_state/test_moving_alias.py
@@ -1,0 +1,112 @@
+"""A name that RESOLVES is not an identity that STAYS PUT.
+
+INCIDENT 2026-08-05: three registries keyed a host on ``nas`` — a name the
+operator's numbering scheme deliberately re-points as hardware is replaced
+(``nas-01`` → ``nas-02`` → ``nas-03`` → …). One of them decided where the
+production OAuth credential is pushed every four hours. Nothing was broken and
+nothing would error: ``nas`` resolves correctly every time, right up to the day
+it resolves to a different machine.
+
+These tests pin the two properties that make the registry usable rather than
+merely present: the moving name is refused, and the PINNED name it points to is
+NOT — a guard that also rejects the replacement is a guard nobody can obey.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._state.moving_alias import (
+    MOVING_ALIASES,
+    MovingAliasError,
+    moving_alias_hint,
+    stable_name_for,
+)
+
+
+def test_bare_nas_maps_to_the_pinned_generation() -> None:
+    """The operator's ruling: nas-03 is correct, nas is the moving alias."""
+    # Arrange
+    alias = "nas"
+    # Act
+    stable = stable_name_for(alias)
+    # Assert
+    assert stable == "nas-03"
+
+
+def test_the_pinned_name_is_not_itself_refused() -> None:
+    """nas-03 must pass, or the hint tells you to use a rejected name."""
+    # Arrange
+    replacement = "nas-03"
+    # Act
+    stable = stable_name_for(replacement)
+    # Assert
+    assert stable is None
+
+
+def test_an_ordinary_peer_is_untouched() -> None:
+    """Only registered movers are refused — not every unrecognised name."""
+    # Arrange
+    peer = "mba"
+    # Act
+    hint = moving_alias_hint(peer)
+    # Assert
+    assert hint is None
+
+
+def test_the_hint_names_the_replacement() -> None:
+    """An error that only states what broke is half-written."""
+    # Arrange
+    alias = "nas"
+    # Act
+    hint = moving_alias_hint(alias) or ""
+    # Assert
+    assert "nas-03" in hint
+
+
+def test_the_hint_names_where_the_registry_lives() -> None:
+    """The next generation lands eventually; say where to record it."""
+    # Arrange
+    alias = "nas"
+    # Act
+    hint = moving_alias_hint(alias) or ""
+    # Assert
+    assert "moving_alias.py" in hint
+
+
+def test_the_hint_carries_the_caller_context() -> None:
+    """The same registry serves config keys and dispatch targets."""
+    # Arrange
+    alias = "nas"
+    # Act
+    hint = moving_alias_hint(alias, context="dispatch target") or ""
+    # Assert
+    assert "as a dispatch target" in hint
+
+
+def test_the_error_is_catchable_as_keyerror() -> None:
+    """Existing `except KeyError` around peer lookup must keep working."""
+    # Arrange
+    raised = MovingAliasError("use nas-03")
+    # Act
+    caught = isinstance(raised, KeyError)
+    # Assert
+    assert caught is True
+
+
+def test_the_error_message_is_not_repr_wrapped() -> None:
+    """Bare KeyError repr's its arg, which would quote-wrap the whole hint."""
+    # Arrange
+    err = MovingAliasError("use nas-03")
+    # Act
+    rendered = str(err)
+    # Assert
+    assert rendered == "use nas-03"
+
+
+def test_every_registered_alias_points_at_a_stable_name() -> None:
+    """A mover whose replacement is itself a mover is an infinite loop."""
+    # Arrange
+    registry = dict(MOVING_ALIASES)
+    # Act
+    circular = [a for a, stable in registry.items() if stable in registry]
+    # Assert
+    assert circular == []


### PR DESCRIPTION
## Why

`nas` is not a typo for `nas-03`. The operator's numbering scheme **deliberately re-points it** as hardware is replaced (`nas-01` → `nas-02` → `nas-03` → …), so it resolves correctly every single time and will one day address a different machine with nothing anywhere reporting a problem.

sac's own `config.yaml` keyed a peer on it, and so did the script that pushes the production OAuth credential to that machine every four hours. **A name that RESOLVES is not an identity that STAYS PUT.**

## What

- **`_state/moving_alias.py`** — the one place that knows which names move and what to use instead. Adding `nas-04` later is an edit here and nowhere else.
- **`Config.validate()`** — reports a moving alias used as a peer key, or as a `host.aliases` **value** (the canonical name stamped on every `state.db` row). `sac host add/set` already reverts on validation failure, so the same check closes the write path and turns `sac host validate` red.
- **`PeersMap.__getitem__`** — turns the post-migration `KeyError('nas')` into a message naming `nas-03`. One insertion point covers every sac dispatch path, which is what the operator asked for: *"SSH だけに限らず"*.

## Deliberately not done

`load()` still accepts a config that says `nas`. Refusing at load time would take every sac verb on every host down in order to fix a name. The gate belongs on validate + lookup, not on import. Pinned by `test_config_that_still_names_the_alias_still_loads`.

## Refactor carried along

`host_config.py` had **8 lines of headroom** under the 512-line cap, so the two optional typed blocks (`resolve:`, `lead:`) and their parsers move to `_host_config_blocks.py`. Pure extraction — `LeadConfig` / `ResolveSpec` are re-exported because `lead_inbox` and the existing tests import them from `host_config`.

## Tests

23 new/changed tests; full `_state` suite green (1174 passed).

One **existing** test changed: `test_validate_accepts_a_peer_with_reverse_ssh` keyed its fixture on `nas`, which the new check correctly flags. The fixture encoded the pattern being refused.

The two properties worth naming, because a guard can fail either way:

- `stable_name_for("nas-03") is None` — a guard that also rejects the replacement is a guard nobody can obey.
- an unregistered miss still raises a **plain** `KeyError` — a guard that fires on everything discriminates nothing.

## Host side (already applied, outside this PR)

`~/.scitex/agent-container/config.yaml` re-keyed to `nas-03`, and `bin/push-hub-cred-to-nas.sh` pinned + given a destination-identity guard. Both refusal and happy paths exercised. The ssh-level alias flip is **held** — one external consumer (`scitex-cloud`'s 5-minute NAS health check) still falls back to bare `nas`. Tracked on card `nas-moving-alias-consumers-before-alias-fails-20260805`.
