### PR TITLE
fix(auth-heal): a gate that can never go GREEN is as dead as one that can never go red

### DIFF
--- a/src/scitex_agent_container/_authheal/_pass.py
+++ b/src/scitex_agent_container/_authheal/_pass.py
@@ -39,9 +39,16 @@ WHAT A CLEAN PASS IS ALLOWED TO MEAN
     happened to contain. Every registered agent must leave this pass in exactly
     one of three states — wedged, observed-and-fine, or UNOBSERVED — and only
     the wedged ones are ever restarted. That third state is what makes exit 0 a
-    real claim: "we accounted for the whole roster and none of it is wedged",
-    rather than the far weaker "we produced no reports", which is also what a
-    pass that read nothing at all produces.
+    real claim rather than the far weaker "we produced no reports", which is
+    also what a pass that read nothing at all produces.
+
+    UNOBSERVED is not one thing, and the difference decides the exit code. A
+    live session whose pane would not capture is US failing to look. A
+    registered agent with NO session is a determinate reading of something this
+    pass explicitly delegates to fleet-reconcile — and since the roster is spec
+    files on a fleet that registers far more agents than it runs, treating it as
+    an indeterminacy made exit 0 unreachable for every possible fleet state.
+    See :meth:`PassOutcome.indeterminate`.
 
 Every collaborator is an injectable seam with a REAL default, so tests drive the
 whole pass against real panes, a real temp history file and a real temp event
@@ -75,6 +82,16 @@ from ._detect import (
 )
 from ._observe import observe_wedge
 
+# The report record and the NON-RESTART report constructors live in ._reports
+# (extracted for the line cap); re-exported so existing imports of
+# ``AgentReport`` from this module keep resolving.
+from ._reports import (  # noqa: F401
+    _ROSTER_SUBJECT,
+    AgentReport,
+    _roster_unreadable,
+    _unobserved,
+)
+
 __all__ = [
     "DEFAULT_INTERVAL",
     "DEFAULT_PASS_CAP",
@@ -102,11 +119,6 @@ _BUDGET_VERDICTS = {
 #: before the next agent (a killed pass must not forget what it already bounced).
 _SPENT = (Verdict.RESTARTED, Verdict.FAILED)
 
-#: The report subject used when the ROSTER ITSELF could not be read. Not an
-#: agent — it is the population we failed to establish — and named so that a
-#: cron log says WHICH reading failed instead of showing an unexplained exit 2.
-_ROSTER_SUBJECT = "<fleet-roster>"
-
 
 def history_path() -> Path:
     """Where the restart history lives. Resolved PER CALL, never cached."""
@@ -133,24 +145,6 @@ def _real_restart(name: str) -> bool:
 
 
 @dataclass(frozen=True)
-class AgentReport:
-    """One agent's line in the report. ``detail`` is ALWAYS printed."""
-
-    name: str
-    verdict: Verdict
-    reason: str
-    detail: str
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            "verdict": self.verdict.value,
-            "reason": self.reason,
-            "detail": self.detail,
-        }
-
-
-@dataclass(frozen=True)
 class PassOutcome:
     """Everything one pass concluded and did."""
 
@@ -168,23 +162,54 @@ class PassOutcome:
             out[report.verdict.value] += 1
         return {k: v for k, v in out.items() if v}
 
+    def indeterminate(self) -> tuple[AgentReport, ...]:
+        """UNOBSERVED reports that mean THIS pass could not determine something.
+
+        Not every UNOBSERVED is an indeterminacy of ours. ``no-session`` is a
+        DETERMINATE reading: there is no session, therefore there is no pane to
+        be wedged, and :func:`_unobserved` already says whose problem it is —
+        "a missing session is fleet-reconcile's half of the fleet, not ours".
+        A pass cannot both delegate a case and let that case decide its answer.
+
+        ``pane-unreadable`` and ``roster-unreadable`` are the real ones: a live
+        session we failed to read, and not knowing who should have been read at
+        all. Those are this pass failing at its own job.
+
+        The load-bearing assumption, stated so it can be argued with: an agent
+        wedged on auth still HAS its ``tui-`` session — it is sitting at a login
+        prompt, which is exactly what the pane read detects. Sessionless means
+        crashed or never started, a different failure with a different owner. If
+        that ever stops holding, this method is where the bug will be.
+        """
+        return tuple(r for r in self.of(Verdict.UNOBSERVED) if r.reason != "no-session")
+
     def exit_code(self) -> int:
         """0 confirmed-clean · 1 something is wedged · 2 could-not-determine.
 
         0 is the STRONGEST claim this pass can make, so it is reserved for
-        earning it: EVERY agent in the registered roster was actually observed,
-        and none of them is wedged. It is never the answer to "we produced no
-        reports", because a pass that observed nothing at all produces no
-        reports either — and while those two spelled the same 0, a wedged agent
-        could sit for hours while the timer recorded a healthy tick for each
-        pass that had failed to look at it.
+        earning it: every agent this pass COULD observe was observed, and none
+        of them is wedged. It is never the answer to "we produced no reports",
+        because a pass that observed nothing at all produces no reports either —
+        and while those two spelled the same 0, a wedged agent could sit for
+        hours while the timer recorded a healthy tick for each pass that had
+        failed to look at it.
 
-        Anything UNOBSERVED therefore outranks the clean answer and joins
+        A genuine indeterminacy therefore outranks the clean answer and joins
         BUDGET_UNKNOWN at 2. They are one statement in two costumes — we could
         not determine the thing this pass exists to determine — and 2 is the
         code that lets a cron tell that apart from a fleet genuinely healthy.
+
+        WHAT CHANGED, AND WHY. This used to count EVERY UNOBSERVED, including
+        the registered-but-sessionless. The roster is spec FILES, and this fleet
+        has far more registered agents than running ones by design, so every
+        pass carried sessionless reports and the supervisor could NEVER return
+        0 — not "rarely", never, for any fleet state whatsoever. A gate that
+        cannot go green is a gate nobody reads, and the operator had already
+        stopped reading this one. The count is not lost: :meth:`counts` still
+        reports every UNOBSERVED, so a log line says "unobserved: 92" beside
+        exit 0. What it can no longer do is impersonate "we failed to look".
         """
-        if self.of(Verdict.BUDGET_UNKNOWN, Verdict.UNOBSERVED):
+        if self.of(Verdict.BUDGET_UNKNOWN) or self.indeterminate():
             return 2
         if self.of(
             Verdict.FAILED,
@@ -304,55 +329,6 @@ def _perform(
         Verdict.FAILED,
         "restart-returned-false",
         f"{base}; restart ran but reported FAILURE — the agent is still wedged",
-    )
-
-
-def _unobserved(name: str, *, live: bool) -> AgentReport:
-    """An agent we took NO reading of — reported, never restarted.
-
-    There are two ways to be unobserved and the detail must say which, because
-    they send the operator to different places: a LIVE session whose pane would
-    not capture (tmux is there, the read failed), versus a registered agent with
-    no session at all (the reading could not even have had a row for it — the
-    shape that let an agent go missing rather than red). Neither is evidence of
-    a wedge, so neither is restarted; neither is evidence of health either, so
-    neither is silently dropped.
-    """
-    if live:
-        return AgentReport(
-            name,
-            Verdict.UNOBSERVED,
-            "pane-unreadable",
-            f"{name} has a live tui- session but its pane could NOT be captured, "
-            f"so nothing was learned about its auth. NOT restarted (absence of "
-            f"evidence is not evidence of a wedge) and NOT counted healthy",
-        )
-    return AgentReport(
-        name,
-        Verdict.UNOBSERVED,
-        "no-session",
-        f"{name} is REGISTERED but has no live tui- session, so this pass could "
-        f"not read it at all. NOT restarted — a missing session is "
-        f"fleet-reconcile's half of the fleet, not ours — but its absence from "
-        f"the reading is not evidence that {name} is healthy",
-    )
-
-
-def _roster_unreadable(detail: str) -> AgentReport:
-    """The ROSTER is the thing we could not read, so no pass can be clean.
-
-    Without it we do not know which agents SHOULD have been observed, so we
-    cannot claim to have observed them all however many panes we did read. The
-    finding is carried as a report of its own rather than a bare exit code, so
-    the reason travels with the verdict to whoever reads the log.
-    """
-    return AgentReport(
-        _ROSTER_SUBJECT,
-        Verdict.UNOBSERVED,
-        "roster-unreadable",
-        f"could not establish which agents SHOULD be running: {detail}. Agents "
-        f"missing from this pass's reading cannot be told apart from agents that "
-        f"do not exist, so this pass cannot report a clean fleet",
     )
 
 

--- a/src/scitex_agent_container/_authheal/_reports.py
+++ b/src/scitex_agent_container/_authheal/_reports.py
@@ -1,0 +1,102 @@
+"""One agent's line in an auth-heal pass, and the NON-RESTART outcomes.
+
+Extracted from :mod:`._pass` so that file keeps headroom under the 512-line
+cap. Pure extraction — no behaviour change. :mod:`._pass` re-exports every
+name here, so ``from .._authheal._pass import AgentReport`` keeps resolving.
+
+What belongs here: the record itself, plus the constructors for outcomes where
+the pass took NO action. The restart-attempt reports stay next to the code that
+attempts the restart — a report that describes an action should not drift away
+from the action it describes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .._reconcile._rule import Verdict
+
+#: The report subject used when the ROSTER ITSELF could not be read. Not an
+#: agent — it is the population we failed to establish — and named so that a
+#: cron log says WHICH reading failed instead of showing an unexplained exit 2.
+_ROSTER_SUBJECT = "<fleet-roster>"
+
+
+@dataclass(frozen=True)
+class AgentReport:
+    """One agent's line in the report. ``detail`` is ALWAYS printed."""
+
+    name: str
+    verdict: Verdict
+    reason: str
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "verdict": self.verdict.value,
+            "reason": self.reason,
+            "detail": self.detail,
+        }
+
+
+def _unobserved(name: str, *, live: bool) -> AgentReport:
+    """An agent we took NO reading of — reported, never restarted.
+
+    There are two ways to be unobserved and the detail must say which, because
+    they send the operator to different places: a LIVE session whose pane would
+    not capture (tmux is there, the read failed), versus a registered agent with
+    no session at all (the reading could not even have had a row for it — the
+    shape that let an agent go missing rather than red). Neither is evidence of
+    a wedge, so neither is restarted; neither is evidence of health either, so
+    neither is silently dropped.
+
+    The ``reason`` strings are load-bearing, not decoration:
+    :meth:`PassOutcome.indeterminate` reads them to tell "we failed to look"
+    from "there was nothing to look at". Renaming one changes an exit code.
+    """
+    if live:
+        return AgentReport(
+            name,
+            Verdict.UNOBSERVED,
+            "pane-unreadable",
+            f"{name} has a live tui- session but its pane could NOT be captured, "
+            f"so nothing was learned about its auth. NOT restarted (absence of "
+            f"evidence is not evidence of a wedge) and NOT counted healthy",
+        )
+    return AgentReport(
+        name,
+        Verdict.UNOBSERVED,
+        "no-session",
+        f"{name} is REGISTERED but has no live tui- session, so this pass could "
+        f"not read it at all. NOT restarted — a missing session is "
+        f"fleet-reconcile's half of the fleet, not ours — but its absence from "
+        f"the reading is not evidence that {name} is healthy",
+    )
+
+
+def _roster_unreadable(detail: str) -> AgentReport:
+    """The ROSTER is the thing we could not read, so no pass can be clean.
+
+    Without it we do not know which agents SHOULD have been observed, so we
+    cannot claim to have observed them all however many panes we did read. The
+    finding is carried as a report of its own rather than a bare exit code, so
+    the reason travels with the verdict to whoever reads the log.
+    """
+    return AgentReport(
+        _ROSTER_SUBJECT,
+        Verdict.UNOBSERVED,
+        "roster-unreadable",
+        f"could not establish which agents SHOULD be running: {detail}. Agents "
+        f"missing from this pass's reading cannot be told apart from agents that "
+        f"do not exist, so this pass cannot report a clean fleet",
+    )
+
+
+__all__ = [
+    "AgentReport",
+    "_ROSTER_SUBJECT",
+    "_roster_unreadable",
+    "_unobserved",
+]

--- a/tests/scitex_agent_container/_authheal/test__pass.py
+++ b/tests/scitex_agent_container/_authheal/test__pass.py
@@ -259,16 +259,25 @@ def test_registered_agent_with_no_session_is_reported(roster, history, events):
     assert _verdict(outcome, "scitex-hub") == Verdict.UNOBSERVED
 
 
-def test_registered_agent_with_no_session_could_not_be_determined(
+def test_registered_agent_with_no_session_does_not_block_a_clean_exit(
     roster, history, events
 ):
+    """This test used to assert 2, and that assertion was the bug.
+
+    A sessionless agent is still REPORTED (the test above pins that) and still
+    never restarted (the test below pins that) — what changed is that it no
+    longer decides the exit code. The roster is spec files, this fleet
+    registers far more agents than it runs, so the old rule made exit 0
+    unreachable for every possible fleet state: measured 92/92 sessionless on
+    the host, none wedged, exit 2 forever. See PassOutcome.indeterminate.
+    """
     # Arrange
     register_agents(roster, "scitex-hub")
     rec = Recorder()
     # Act
     outcome = _run({"writer": (OK, OK)}, history, events, rec)
     # Assert
-    assert outcome.exit_code() == 2
+    assert outcome.exit_code() == 0
 
 
 def test_registered_agent_with_no_session_is_never_restarted(roster, history, events):

--- a/tests/scitex_agent_container/_authheal/test__pass_exit_code_indeterminacy.py
+++ b/tests/scitex_agent_container/_authheal/test__pass_exit_code_indeterminacy.py
@@ -1,0 +1,145 @@
+"""A supervisor that can never go green is a supervisor nobody reads.
+
+MEASURED 2026-08-05 on the fleet host: `sac agents restart-login-expired`
+returned 2 on every pass, with UNOBSERVED=92 and all 92 carrying the reason
+``no-session``. Not one was wedged. The roster is spec FILES — 231 of them on
+this host — while the number of agents actually running is a fraction of that,
+BY DESIGN. So every pass carried sessionless reports, and exit 0 was unreachable
+for every possible state of the fleet, healthy or not.
+
+That is the shape the constitution names: a gate configured so it cannot fail is
+the same as deleting it. This is its twin — a gate that cannot PASS. Both end
+with a signal nobody reads, and the second is worse for being loud.
+
+These tests pin the discrimination, in both directions, because a fix that just
+made 0 reachable would trade a useless red for a dangerous green.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._authheal._pass import AgentReport, PassOutcome
+from scitex_agent_container._reconcile._rule import Verdict
+
+
+def _sessionless(name: str) -> AgentReport:
+    """A registered agent with no tui- session — the 92-of-92 case."""
+    return AgentReport(name, Verdict.UNOBSERVED, "no-session", f"{name}: no session")
+
+
+def _unreadable(name: str) -> AgentReport:
+    """A LIVE session whose pane would not capture — a real blind spot."""
+    return AgentReport(
+        name, Verdict.UNOBSERVED, "pane-unreadable", f"{name}: pane read failed"
+    )
+
+
+def _healthy(name: str) -> AgentReport:
+    """An agent that WAS read and is fine."""
+    return AgentReport(name, Verdict.OK, "no-login-prompt", f"{name}: fine")
+
+
+def test_a_fleet_of_sessionless_agents_and_no_wedge_is_clean() -> None:
+    """The measured reality: 92 sessionless, 0 wedged. This must be 0."""
+    # Arrange
+    outcome = PassOutcome(reports=tuple(_sessionless(f"a{i}") for i in range(92)))
+    # Act
+    code = outcome.exit_code()
+    # Assert
+    assert code == 0
+
+
+def test_one_observed_agent_among_the_sessionless_is_still_clean() -> None:
+    """The realistic shape — a few running, most registered and idle."""
+    # Arrange
+    reports = tuple(_sessionless(f"a{i}") for i in range(91)) + (_healthy("live"),)
+    outcome = PassOutcome(reports=reports)
+    # Act
+    code = outcome.exit_code()
+    # Assert
+    assert code == 0
+
+
+def test_a_pane_we_could_not_read_is_still_indeterminate() -> None:
+    """This one IS us failing to look, and it must keep outranking clean."""
+    # Arrange
+    reports = tuple(_sessionless(f"a{i}") for i in range(91)) + (_unreadable("live"),)
+    outcome = PassOutcome(reports=reports)
+    # Act
+    code = outcome.exit_code()
+    # Assert
+    assert code == 2
+
+
+def test_an_unreadable_roster_is_still_indeterminate() -> None:
+    """Not knowing WHO should be running defeats any claim about all of them."""
+    # Arrange
+    report = AgentReport(
+        "<fleet-roster>", Verdict.UNOBSERVED, "roster-unreadable", "specs dir gone"
+    )
+    outcome = PassOutcome(reports=(report,))
+    # Act
+    code = outcome.exit_code()
+    # Assert
+    assert code == 2
+
+
+def test_an_unknown_budget_is_still_indeterminate() -> None:
+    """The other half of exit 2 must not be disturbed by this change."""
+    # Arrange
+    report = AgentReport("a1", Verdict.BUDGET_UNKNOWN, "history-unreadable", "no file")
+    outcome = PassOutcome(reports=(report,))
+    # Act
+    code = outcome.exit_code()
+    # Assert
+    assert code == 2
+
+
+def test_a_still_wedged_agent_outranks_a_field_of_sessionless_ones() -> None:
+    """The thing this supervisor exists for must still reach the exit code.
+
+    FAILED, not RESTARTED: a restart that WORKED leaves nothing wedged, so 0 is
+    the right answer there. Writing this test with RESTARTED is how I found out
+    I had the two confused — the exit code was right and my premise was not.
+    """
+    # Arrange
+    wedged = AgentReport("w", Verdict.FAILED, "restart-returned-false", "w: still")
+    outcome = PassOutcome(
+        reports=tuple(_sessionless(f"a{i}") for i in range(91)) + (wedged,)
+    )
+    # Act
+    code = outcome.exit_code()
+    # Assert
+    assert code == 1
+
+
+def test_a_successful_restart_among_sessionless_agents_is_clean() -> None:
+    """A wedge that was FIXED is not a wedge — 0 is the honest answer."""
+    # Arrange
+    fixed = AgentReport("w", Verdict.RESTARTED, "login-expired", "w: restarted")
+    outcome = PassOutcome(
+        reports=tuple(_sessionless(f"a{i}") for i in range(91)) + (fixed,)
+    )
+    # Act
+    code = outcome.exit_code()
+    # Assert
+    assert code == 0
+
+
+def test_sessionless_reports_are_not_indeterminate() -> None:
+    """The predicate itself, so a failure names the cause not the symptom."""
+    # Arrange
+    outcome = PassOutcome(reports=(_sessionless("a1"), _sessionless("a2")))
+    # Act
+    unresolved = outcome.indeterminate()
+    # Assert
+    assert unresolved == ()
+
+
+def test_the_sessionless_count_survives_a_clean_exit() -> None:
+    """Demoted from the exit code, NOT hidden — a reader must still see 92."""
+    # Arrange
+    outcome = PassOutcome(reports=tuple(_sessionless(f"a{i}") for i in range(92)))
+    # Act
+    counted = outcome.counts()
+    # Assert
+    assert counted[Verdict.UNOBSERVED.value] == 92


### PR DESCRIPTION
## The measurement

`sac agents restart-login-expired` returned **2 on every pass** on the fleet host, with `UNOBSERVED=92` and **all 92** carrying reason `no-session`. Not one agent was wedged.

The roster is spec **files** — 231 on this host — while the number of agents actually running is a fraction of that, **by design**. So every pass carried sessionless reports, and exit 0 was unreachable for *every possible state of the fleet*, healthy or not.

## Why that is the same bug the constitution already names

> **A gate that cannot fail is not a gate.** Configuring a check so it is always green is the same as deleting it, except worse: the config still lists it and everyone believes it is working.

This is the twin — a gate that cannot **pass**. It ends the same way, with a supervisor whose output nobody reads, and it is arguably worse for being loud about it.

## The fix is a distinction the code already made in prose, then ignored

`_unobserved` says of the sessionless case, in its own words: *"a missing session is fleet-reconcile's half of the fleet, not ours"*. A pass cannot both **delegate** a case and let that case **decide its exit code**.

`PassOutcome.indeterminate()` now separates them:

| reason | meaning | exit |
|---|---|---|
| `no-session` | **determinate** — no session, therefore no pane to be wedged | does not block 0 |
| `pane-unreadable` | **indeterminate** — a live session we failed to read | 2 |
| `roster-unreadable` | **indeterminate** — we do not know who should have been read | 2 |

`BUDGET_UNKNOWN` is untouched and still 2.

## The assumption, stated so it can be argued with

An agent wedged on auth **still has its `tui-` session** — it is sitting at a login prompt, which is exactly what the pane read detects. Sessionless means crashed or never started: a different failure with a different owner. That sentence is in the method docstring, not just here, because if it ever stops holding, `indeterminate()` is where the bug will be.

## Nothing is hidden

`counts()` still reports every UNOBSERVED, and the CLI already prints the two populations separately, so a reader sees `unobserved: 92` **beside** exit 0. What it can no longer do is impersonate "we failed to look".

## Changed test

`test_registered_agent_with_no_session_could_not_be_determined` asserted the old rule. It now asserts the new one and is renamed, with a docstring saying which assertion was the bug. The neighbouring tests — that a sessionless agent is still **reported** and still **never restarted** — are untouched and still pass.

## Refactor carried along

`_pass.py` was 3 lines under the 512 cap, so `AgentReport` and the non-restart report constructors move to `_reports.py`. Pure extraction, re-exported.

## A note on how the tests were written

My first version asserted that a `RESTARTED` agent among sessionless ones yields 1. It yields **0**, correctly — a wedge that was *fixed* is not a wedge. The code was right and my premise was wrong. Both cases are now pinned (`test_a_still_wedged_agent_...` uses `FAILED`; `test_a_successful_restart_...` pins the 0).

## Tests

241 passed across `_authheal` + `_reconcile`.

**Not yet verified on the host** — I cannot read the fleet's tmux server from a container, so the "returns 0 on the real 92-sessionless roster" confirmation is a host-side run I have not done. The unit tests pin the rule; the host run confirms the population.
