### PR TITLE
fix(image): the base image had no rsync, so no agent could start an agent elsewhere

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -57,9 +57,18 @@ From: ubuntu:24.04
     # `procps`/`lsof`/`strace`/`less` stay because their NON-interactive
     # modes (pgrep, ps, lsof piped, strace -c, less -F) are agent-useful.
     #
-    # git/curl/ca-certificates/openssh-client are listed here so any
+    # git/curl/ca-certificates/openssh-client/rsync are listed here so any
     # future base-image trim cannot silently drop them — sac runtime
     # hard-depends on each one (HTTPS verify chain, SSH dispatch, git).
+    #
+    # rsync earns its place the hard way. `_dispatch_remote_start` shells
+    # `rsync` to sync the workspace before a CROSS-HOST agent start, and it
+    # runs in the CALLER's environment. Every agent runs inside this image,
+    # so while rsync was missing here NO AGENT COULD EVER START AN AGENT ON
+    # ANOTHER HOST — the multi-host feature was unreachable from precisely
+    # the processes meant to use it. Measured 2026-08-05: the first real
+    # cross-host start died with `FileNotFoundError: 'rsync'`, from a
+    # container, against a target host that had rsync installed.
     #
     # libglib2.0-0 is REQUIRED by the scitex stack: without it,
     # libgthread-2.0.so.0 is missing and ``import scitex.io`` silently
@@ -89,6 +98,7 @@ From: ubuntu:24.04
     apt-get install -y --no-install-recommends \
         ca-certificates curl wget gnupg \
         git openssh-client sshpass autossh git-crypt \
+        rsync \
         build-essential pkg-config \
         libffi-dev libssl-dev libgl1-mesa-dev libc6-dev libglib2.0-0 \
         python3 python3-pip python3-venv python3-dev \

--- a/tests/integration/test_apptainer_base_def_cross_host_tools.py
+++ b/tests/integration/test_apptainer_base_def_cross_host_tools.py
@@ -1,0 +1,108 @@
+"""The base image must carry every tool the CALLER needs for a cross-host start.
+
+INCIDENT 2026-08-05: the first real cross-host agent start died with
+
+    FileNotFoundError: [Errno 2] No such file or directory: 'rsync'
+
+raised from ``_dispatch_remote_start``, which shells ``rsync`` to sync the
+workspace before starting an agent on another host. It runs in the CALLER's
+environment — and every agent runs inside this base image, which did not have
+rsync. So no agent could ever start an agent on another host: the multi-host
+feature was unreachable from exactly the processes meant to use it, while the
+TARGET host had rsync installed the whole time.
+
+The failure was loud, which is the only lucky part. What makes it worth a test
+is that the dependency is invisible from the code — nothing in the def says
+"cross-host start needs this", and a future trim of the apt list would be
+reviewed with no reason to keep it.
+
+These pin the CAPABILITY (the tool is installed), not the spelling of the apt
+line, so reordering or resplitting the install is free.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_DEF = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "scitex_agent_container"
+    / "containers"
+    / "apptainer-base.def"
+)
+
+
+def _installed_tokens() -> set[str]:
+    """Package names apt is actually asked to install. COMMENTS EXCLUDED.
+
+    The exclusion is the whole point, and it was learned the hard way: the
+    first version of this helper scanned every token in the file. The def
+    carries a long comment explaining WHY rsync is required — so the test
+    passed against a def where rsync appeared only in prose and was never
+    installed. A test that its own documentation satisfies cannot fail.
+
+    So: parse the ``apt-get install`` continuation block, drop anything after
+    a ``#``, and ignore flags. What is asserted is that apt installs the
+    package, not that someone wrote its name down.
+    """
+    tokens: set[str] = set()
+    in_block = False
+    for raw in _DEF.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0]  # comments carry no packages
+        stripped = line.strip()
+        if "apt-get install" in stripped:
+            in_block = True
+            stripped = stripped.split("apt-get install", 1)[1]
+        elif not in_block:
+            continue
+        continues = stripped.endswith("\\")
+        for tok in stripped.rstrip("\\").split():
+            if not tok.startswith("-"):  # skip -y, --no-install-recommends
+                tokens.add(tok)
+        if not continues:
+            in_block = False
+    return tokens
+
+
+def test_the_base_def_exists_at_the_expected_path() -> None:
+    """Control: if this fails, every other assertion here is vacuous."""
+    # Arrange
+    path = _DEF
+    # Act
+    found = path.is_file()
+    # Assert
+    assert found is True
+
+
+def test_rsync_is_installed_for_cross_host_start() -> None:
+    """`_dispatch_remote_start` shells rsync IN THE CALLER's environment."""
+    # Arrange
+    tokens = _installed_tokens()
+    # Act
+    present = "rsync" in tokens
+    # Assert
+    assert present is True
+
+
+def test_openssh_client_is_installed_for_ssh_dispatch() -> None:
+    """The other half of cross-host dispatch — ssh carries the command."""
+    # Arrange
+    tokens = _installed_tokens()
+    # Act
+    present = "openssh-client" in tokens
+    # Assert
+    assert present is True
+
+
+@pytest.mark.parametrize("tool", ["git", "curl", "ca-certificates"])
+def test_the_hard_dependencies_named_in_the_def_are_installed(tool: str) -> None:
+    """The def's own comment says a trim must not silently drop these."""
+    # Arrange
+    tokens = _installed_tokens()
+    # Act
+    present = tool in tokens
+    # Assert
+    assert present is True


### PR DESCRIPTION
Found by running the first real cross-host agent start, which died:

```
FileNotFoundError: [Errno 2] No such file or directory: 'rsync'
  cli_pkg/lifecycle/_dispatch.py:142, in _dispatch_remote_start
```

## The shape

`_dispatch_remote_start` shells `rsync` to sync the workspace before starting an agent on another host — **in the CALLER's environment.**

| where | rsync |
|---|---|
| my agent container | **absent** |
| the base SIF | **absent** |
| scitex-01 (the target) | present |

Every agent runs inside this image. So while rsync was missing from it, **no agent could ever dispatch a cross-host start** — the multi-host feature was unreachable from precisely the processes meant to use it.

That is also why it survived: only a caller on a bare host could exercise the path, and the people testing it were never in the position of the people using it.

## The test was wrong first, and that is worth reading

Its first version scanned **every token in the def** — and the comment I had just written to explain rsync's necessity contains the word "rsync" several times. So it passed against a def where rsync appeared **only in prose** and was never installed.

A test its own documentation satisfies cannot fail. It now parses the `apt-get install` continuation block, strips comments, and ignores flags, so it asserts that **apt installs the package**, not that someone wrote its name down.

## Proven red — on the third attempt

Two earlier mutation harnesses silently failed to match and reported "passed" for a check that never ran. The harness now prints whether the mutation applied and exits non-zero if it did not, so a no-op mutation cannot masquerade as a red-check.

With rsync removed from the apt line and still present in the comments:

```
FAILED test_rsync_is_installed_for_cross_host_start - assert False is True
1 failed, 5 passed
```

Restored: 6 passed.

## Delivery

This reaches agents only through a **rebaked SIF** — an in-container pip/apt install is the overlay-masking hazard documented in #872. Bakes now run on scitex-01 in ~8 minutes (`apptainer build --fakeroot`, no root).