### PR TITLE
fix(dispatch): make a remote-sac rc=127 name env_preamble as its remedy

### DIFF
--- a/src/scitex_agent_container/_state/_remote_sac_hint.py
+++ b/src/scitex_agent_container/_state/_remote_sac_hint.py
@@ -1,0 +1,111 @@
+"""Name the remedy when a remote ``sac`` invocation dies with rc=127.
+
+WHY THIS EXISTS — measured 2026-08-06, and the cost was paid twice: once in
+debugging, once in a host mutation that should never have happened.
+
+``sac agents restart <agent>`` for an agent placed on ``scitex-01`` failed::
+
+    Error: Remote `sac agents restart compute-pilot-01` failed on 'scitex-01'
+    (rc=127)
+    stderr: bash: line 1: sac: command not found
+
+sac WAS installed on that host. ssh runs a NON-LOGIN shell, so the venv's
+``bin`` was not on ``PATH``. Every cross-host lifecycle op against the new
+compute nodes failed this way, which blocked the agent migration those hosts
+were provisioned for.
+
+sac already had the fix. :func:`~._host_ssh.build_ssh_argv` — the documented
+single choke point every remote-sac invocation funnels through — wraps the
+command in ``bash -c '<preamble> && <cmd>'`` whenever the peer declares an
+``env_preamble``, and Spartan has used exactly that for exactly this purpose
+for as long as it has been a peer::
+
+    env_preamble: 'export PATH="$HOME/.env-3.11/bin:$PATH"'
+
+The new peers simply had no preamble. But NOTHING IN THE ERROR SAID SO. It
+reported a shell's "command not found" and left the reader to rediscover the
+mechanism, so the first fix reached for was a sudo symlink into
+``/usr/local/bin`` on two hosts — a mutation that bypassed a facility that
+already existed. That is the failure this module addresses: not the missing
+PATH, which is per-peer config and correctly so, but the fact that the
+failure did not name its own remedy, so it invites a worse fix every time a
+host is added.
+
+Hint discipline (see the fail-loud-hint rule): the suggestion must CLEAR the
+condition. The emitted line is the exact YAML that made the real dispatch
+succeed, verified by removing the symlinks first, confirming bare ``sac`` was
+"command not found" again, and then restarting cross-host with only the
+preamble in place.
+
+DELIBERATELY NARROW. The hint is added only when all three hold — rc is 127,
+the stderr looks like a shell not-found, and the peer has NO preamble. A peer
+that already declares one has a different problem (a wrong path, a broken
+profile), and pointing it at ``env_preamble`` would be a confident wrong
+answer.
+"""
+
+from __future__ import annotations
+
+# POSIX shells exit 127 for "command not found". Named rather than inlined
+# so the condition reads as the contract it is.
+_RC_COMMAND_NOT_FOUND = 127
+
+_NOT_FOUND_MARKERS = ("command not found", "No such file or directory")
+
+
+def _peer_has_preamble(peer_name: str, peers: object) -> bool:
+    """True when ``peer_name`` already declares an ``env_preamble``.
+
+    Defensive on purpose: this runs on an error path that is already
+    reporting a failure, so a lookup problem here must never replace the
+    caller's real message with a traceback. Any doubt returns True, which
+    SUPPRESSES the hint — a missing hint is a small loss, a misleading one
+    sends the reader somewhere wrong.
+    """
+    try:
+        peer = peers[peer_name]  # type: ignore[index]
+    except Exception:  # stx-allow: fallback (reason: hint enrichment on an error path must never mask the caller's real failure)
+        return True
+    try:
+        return bool(peer.joined_preamble())
+    except Exception:  # stx-allow: fallback (reason: same — a peer shape without a preamble accessor must not crash the error report)
+        return True
+
+
+def remote_sac_not_found_hint(
+    peer_name: str,
+    returncode: int,
+    stderr: str,
+    peers: object,
+) -> str:
+    """Return a paste-ready ``env_preamble`` hint, or ``""`` when not applicable.
+
+    Callers append the result to the ``RuntimeError`` they were already
+    raising, so an empty string leaves the existing message byte-identical.
+    """
+    if returncode != _RC_COMMAND_NOT_FOUND:
+        return ""
+    text = stderr or ""
+    if not any(marker in text for marker in _NOT_FOUND_MARKERS):
+        return ""
+    if _peer_has_preamble(peer_name, peers):
+        return ""
+    return (
+        f"\n\nHINT: rc=127 is the shell's 'command not found', and peer "
+        f"{peer_name!r} declares no `env_preamble`. ssh runs a NON-LOGIN "
+        "shell, so a sac installed in a venv is not on PATH there even "
+        "though it IS installed. Declare the peer's PATH once, in "
+        "~/.scitex/agent-container/config.yaml:\n"
+        f"    {peer_name}:\n"
+        f"      ssh: {peer_name}\n"
+        "      env_preamble: 'export PATH=\"$HOME/.env-sac/bin:$PATH\"'\n"
+        "(adjust the venv path to where `sac` actually lives on that host — "
+        "`ssh <peer> 'command -v sac || ls -d ~/.env*/bin/sac'`). "
+        "build_ssh_argv then wraps every remote sac call in "
+        "`bash -c '<preamble> && ...'`. This is the same mechanism the "
+        "spartan peer already uses; do NOT symlink sac into /usr/local/bin "
+        "to work around it, which mutates the host to paper over config."
+    )
+
+
+__all__ = ["remote_sac_not_found_hint"]

--- a/src/scitex_agent_container/cli_pkg/info_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/info_cmds.py
@@ -14,6 +14,7 @@ from rich.table import Table
 from ..config import load_config
 from ._api_tree import get_api_tree
 from ._helpers import _json_flag, agent_name_complete, console
+from .._state._remote_sac_hint import remote_sac_not_found_hint
 
 
 @click.command()
@@ -288,6 +289,7 @@ def _tail_one_remote(
             f"(rc={rc}):\n"
             f"argv: {' '.join(shlex.quote(a) for a in ssh_argv)}\n"
             f"stderr:\n{err}"
+            + remote_sac_not_found_hint(peer, rc, err, peers)
         )
     return True
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
@@ -230,6 +230,7 @@ def _dispatch_remote_start(
     import json as _json
 
     from ..._state.host_config import build_ssh_argv
+    from ..._state._remote_sac_hint import remote_sac_not_found_hint
     from ..._state.host_config import load as _load_host_config
     from ..._state.state_db import record_instance_start
 
@@ -256,6 +257,9 @@ def _dispatch_remote_start(
             f"argv: {' '.join(shlex.quote(a) for a in ssh_argv)}\n"
             f"stdout:\n{ssh_result.stdout}\n"
             f"stderr:\n{ssh_result.stderr}"
+            + remote_sac_not_found_hint(
+                peer, ssh_result.returncode, ssh_result.stderr, peers_map
+            )
         )
     try:
         peer_state = _json.loads(ssh_result.stdout)

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_restart_remote.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_restart_remote.py
@@ -28,6 +28,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from ..._state._remote_sac_hint import remote_sac_not_found_hint
 from ..._state.host_config import build_ssh_argv
 from ..._state.state_db import record_instance_start, record_instance_stop
 
@@ -119,6 +120,7 @@ def _dispatch_remote_restart(peer: str, row: dict, peers: dict, name: str) -> di
             f"argv: {' '.join(shlex.quote(a) for a in ssh_argv)}\n"
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
+            + remote_sac_not_found_hint(peer, result.returncode, result.stderr, peers)
         )
     try:
         envelope = _json.loads(result.stdout)

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_stop.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_stop.py
@@ -35,6 +35,7 @@ from pathlib import Path
 import click
 
 from ..._lifecycle.lifecycle import agent_stop
+from ..._state._remote_sac_hint import remote_sac_not_found_hint
 from ..._state.host_config import build_ssh_argv
 from ..._state.host_config import load as _load_host_config
 from ..._state.state_db import now_iso, record_instance_stop
@@ -148,7 +149,8 @@ def _dispatch_remote_stop(peer: str, row: dict, peers: dict, name: str) -> dict:
             f"(rc={result.returncode}):\n"
             f"argv: {' '.join(shlex.quote(a) for a in ssh_argv)}\n"
             f"stdout:\n{result.stdout}\n"
-            f"stderr:\n{result.stderr}",
+            f"stderr:\n{result.stderr}"
+            + remote_sac_not_found_hint(peer, result.returncode, result.stderr, peers),
             peer=peer,
         )
     try:

--- a/tests/scitex_agent_container/_state/test__remote_sac_hint.py
+++ b/tests/scitex_agent_container/_state/test__remote_sac_hint.py
@@ -1,0 +1,145 @@
+"""A remote-sac rc=127 must name `env_preamble` as its own remedy.
+
+INCIDENT 2026-08-06. Cross-host lifecycle ops against a newly provisioned
+compute node all failed with::
+
+    Remote `sac agents restart compute-pilot-01` failed on 'scitex-01'
+    (rc=127)
+    stderr: bash: line 1: sac: command not found
+
+sac WAS installed there; ssh runs a non-login shell, so the venv bin was not
+on PATH. sac already had the fix — a peer's ``env_preamble``, which
+``build_ssh_argv`` wraps into ``bash -c '<preamble> && ...'``, and which the
+spartan peer has always used for exactly this. But the error never mentioned
+it, so the first fix reached for was a sudo symlink into /usr/local/bin on two
+hosts: a host mutation to work around a config gap.
+
+That is what these tests pin. Not the PATH (correctly per-peer config), but
+that the FAILURE NAMES ITS REMEDY, so the next person to add a host does not
+repeat the worse fix.
+
+The suppression cases matter as much as the emission case: a hint offered
+when it does not apply is a confident wrong answer pointing someone at the
+wrong knob, which is worse than the bare rc=127 they get today.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._state._remote_sac_hint import (
+    remote_sac_not_found_hint,
+)
+
+_NOT_FOUND = "bash: line 1: sac: command not found\n"
+
+
+class _Peer:
+    def __init__(self, preamble: str = "") -> None:
+        self._preamble = preamble
+
+    def joined_preamble(self) -> str:
+        return self._preamble
+
+
+def _peers(preamble: str = "") -> dict:
+    return {"scitex-01": _Peer(preamble)}
+
+
+# --------------------------------------------------------------------------
+# Emission
+# --------------------------------------------------------------------------
+
+
+def test_a_preamble_less_peer_gets_the_hint() -> None:
+    """The incident case: rc=127, shell not-found, no preamble declared."""
+    # Arrange
+    peers = _peers()
+    # Act
+    hint = remote_sac_not_found_hint("scitex-01", 127, _NOT_FOUND, peers)
+    # Assert
+    assert "env_preamble" in hint
+
+
+def test_the_hint_carries_a_paste_ready_config_line() -> None:
+    """A direction is not enough — it must be the line that fixes it."""
+    # Arrange
+    peers = _peers()
+    # Act
+    hint = remote_sac_not_found_hint("scitex-01", 127, _NOT_FOUND, peers)
+    # Assert
+    assert "env_preamble: 'export PATH=\"$HOME/.env-sac/bin:$PATH\"'" in hint
+
+
+def test_the_hint_names_the_offending_peer() -> None:
+    # Arrange
+    peers = _peers()
+    # Act
+    hint = remote_sac_not_found_hint("scitex-01", 127, _NOT_FOUND, peers)
+    # Assert
+    assert "scitex-01" in hint
+
+
+def test_the_hint_warns_against_the_symlink_workaround() -> None:
+    """The wrong fix I actually reached for, so the next reader does not."""
+    # Arrange
+    peers = _peers()
+    # Act
+    hint = remote_sac_not_found_hint("scitex-01", 127, _NOT_FOUND, peers)
+    # Assert
+    assert "/usr/local/bin" in hint
+
+
+# --------------------------------------------------------------------------
+# Suppression — a hint that does not apply is a wrong answer
+# --------------------------------------------------------------------------
+
+
+def test_a_peer_that_already_has_a_preamble_gets_no_hint() -> None:
+    """Its problem is a WRONG path, not a missing one. Pointing it at
+    env_preamble would send the reader to a knob already turned."""
+    # Arrange
+    peers = _peers('export PATH="$HOME/.env-3.11/bin:$PATH"')
+    # Act
+    hint = remote_sac_not_found_hint("scitex-01", 127, _NOT_FOUND, peers)
+    # Assert
+    assert hint == ""
+
+
+def test_a_non_127_failure_gets_no_hint() -> None:
+    """rc=1 from a real sac error is not a PATH problem."""
+    # Arrange
+    peers = _peers()
+    # Act
+    hint = remote_sac_not_found_hint("scitex-01", 1, "boom\n", peers)
+    # Assert
+    assert hint == ""
+
+
+def test_a_127_without_a_not_found_stderr_gets_no_hint() -> None:
+    """127 alone is suggestive, not conclusive; require the shell's own words."""
+    # Arrange
+    peers = _peers()
+    # Act
+    hint = remote_sac_not_found_hint("scitex-01", 127, "segfault\n", peers)
+    # Assert
+    assert hint == ""
+
+
+def test_an_unknown_peer_gets_no_hint_instead_of_raising() -> None:
+    """This runs on an error path already reporting a failure. A lookup
+    problem here must never replace the caller's real message."""
+    # Arrange
+    peers = _peers()
+    # Act
+    hint = remote_sac_not_found_hint("no-such-peer", 127, _NOT_FOUND, peers)
+    # Assert
+    assert hint == ""
+
+
+def test_a_peer_object_without_a_preamble_accessor_gets_no_hint() -> None:
+    """Defensive: an unexpected peer shape must degrade, not crash."""
+    # Arrange
+    peers = {"scitex-01": object()}
+    # Act
+    hint = remote_sac_not_found_hint("scitex-01", 127, _NOT_FOUND, peers)
+    # Assert
+    assert hint == ""


### PR DESCRIPTION
Cross-host lifecycle ops against a newly provisioned compute node all failed:

    Remote `sac agents restart compute-pilot-01` failed on 'scitex-01' (rc=127)
    stderr: bash: line 1: sac: command not found

sac WAS installed there. ssh runs a NON-LOGIN shell, so the venv's bin was not
on PATH, and every cross-host op against the new nodes failed this way —
blocking the agent migration those hosts were provisioned for.

sac already had the fix. build_ssh_argv — the documented single choke point
every remote-sac invocation funnels through — wraps the command in
`bash -c '<preamble> && ...'` whenever the peer declares an env_preamble, and
the spartan peer has used exactly that, for exactly this reason, for as long
as it has been a peer. The new peers simply had no preamble.

BUT NOTHING IN THE ERROR SAID SO. It reported a shell's "command not found"
and left the reader to rediscover the mechanism. What I actually reached for
first was a sudo symlink into /usr/local/bin on two hosts — mutating hosts to
work around a config gap, bypassing a facility that already existed. I have
since reverted that and configured the preamble instead.

So the defect fixed here is NOT the missing PATH, which is per-peer config and
correctly so. It is that the failure did not name its own remedy, which invites
the worse fix every time a host is added. The config change is per-peer and
leaves no detector; this does.

The hint is emitted at all four remote-sac raise sites (start / restart / stop
/ tail) and carries the paste-ready YAML, the peer's own name, how to locate
sac on that host, and an explicit warning against the symlink workaround.

DELIBERATELY NARROW — three conditions must all hold: rc is 127, stderr looks
like a shell not-found, and the peer has NO preamble. A peer that already
declares one has a different problem (a wrong path, a broken profile), and
pointing it at env_preamble would be a confident wrong answer. Suppression is
tested as heavily as emission for that reason.

Defensive by design: the helper runs on a path that is already reporting a
failure, so any lookup trouble returns "" and leaves the caller's message
byte-identical rather than replacing a real error with a traceback.

Verified: the suggested line is the one that made the real dispatch succeed —
confirmed by removing the symlinks first, checking bare `sac` was "command not
found" again on both nodes, then restarting cross-host with only the preamble
in place. 9 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbkepAbn5pDEFCXXJx9KKd
