### PR TITLE
fix(preflight): the blind-quota gate was armed only when the cache EXISTED, so it could never fire

### DIFF
--- a/src/scitex_agent_container/_account/quota_cache.py
+++ b/src/scitex_agent_container/_account/quota_cache.py
@@ -117,9 +117,6 @@ def _resolve_cache_path(override: Path | str | None) -> Path:
 def quota_cache_present(cache_path: Path | str | None = None) -> bool:
     """Whether a quota-cache FILE actually exists for the reader to consult.
 
-    This is the discriminator the boot picker's fail-loud gate keys off (see
-    :func:`_creds.pick_healthy_account` ``require_quota_evidence``):
-
     * ``True`` — a cache source exists (the container bind, or a host
       ``quota-cache.json`` a populator/cron writes). On such a host an
       all-UNKNOWN pick is a POPULATOR failure (an empty/stale cache), so the
@@ -127,9 +124,24 @@ def quota_cache_present(cache_path: Path | str | None = None) -> bool:
       silently launch on an unverifiable, possibly quota-exhausted account
       (2026-07-20 incident).
     * ``False`` — no cache source exists at all (a fresh install, CI, or a
-      quota-cron-less host such as a Spartan compute node). The documented
-      graceful-degradation contract holds: the boot degrades to freshness-only
-      and is NEVER blocked on a quota system that this host simply does not run.
+      quota-cron-less host such as a Spartan compute node).
+
+    NOT the boot gate's discriminator, though it was used as one. The start
+    preflight armed :func:`_creds.pick_healthy_account`'s
+    ``require_quota_evidence`` with this predicate directly, which meant the
+    gate could not fire in the situation it was built for: it protects against
+    "the cache tells us nothing", yet it was armed only when a cache FILE
+    already existed, so a host with NO cache — the blind case — ran DISARMED
+    (2026-08-06, scitex-02: an agent booted onto a d7=100% account and answered
+    "You've hit your weekly limit" on every turn while startup reported
+    success). :func:`_lifecycle._quota_evidence.pick_with_quota_evidence` owns
+    that decision now: a ``False`` here means "try to BUILD the evidence", and
+    only a build that genuinely cannot run degrades to freshness-only — loudly.
+
+    The never-block invariant this predicate exists to protect is unchanged and
+    deliberate: a boot is NEVER blocked merely because this host runs no quota
+    system. The defect was never that sac declined to block; it was that sac
+    went silent.
 
     Mirrors :func:`_resolve_cache_path`'s resolution order (container bind →
     host runtime → legacy). A missing source resolves to the non-existent

--- a/src/scitex_agent_container/_lifecycle/_quota_evidence.py
+++ b/src/scitex_agent_container/_lifecycle/_quota_evidence.py
@@ -1,0 +1,295 @@
+"""Arm the boot-time quota gate — and BUILD the evidence it needs.
+
+The blind-pick gate (:func:`_creds.pick_healthy_account` ``require_quota_evidence``,
+raising :class:`_creds.BlindQuotaCacheError`) refuses to boot an agent onto an
+account whose quota the cache cannot confirm. The start preflight armed it with::
+
+    require_quota_evidence=quota_cache_present(quota_cache_path)
+
+which guarantees the gate cannot fire in the situation it was built for. The gate
+protects against "the cache tells us nothing"; that condition armed it only when a
+cache FILE already existed. On a host with NO cache — precisely the blind case —
+the gate was DISARMED and the boot proceeded blind. The armed path's auto-refresh
+self-repair (operator 2026-08-02: 「refresh quota cache 勝手にやれよ」) sat behind the
+same predicate, so the host that most needed its cache built was the one host that
+never tried to build it.
+
+MEASURED 2026-08-06, scitex-02 (a newly-provisioned compute node, no quota cron, no
+``quota-cache.json``): ``quota_cache_present()`` returned False, the gate was
+disarmed, and the pick read "5h=? 7d=?" and landed agent ``figrecipe`` on
+``wyusuuke-gmail-com`` at **d7=100.0%**. sac printed ``SUCC``, tmux was alive, the
+TUI rendered — and every turn answered "You've hit your weekly limit". Startup
+reported success; the agent was functionally dead. Copying ``quota-cache.json`` by
+hand fixed it, a repair that leaves no detector.
+
+What is preserved, and what changes
+-----------------------------------
+The never-block invariant is REAL and stays (see
+:func:`_account.quota_cache.quota_cache_present`): a boot is never blocked merely
+because this host runs no quota system — a CI box or a quota-cron-less Spartan node
+must not be bricked. The defect was never that sac declined to block. It was that
+sac went SILENT. So:
+
+1. NO cache → attempt :func:`_account.quota_cache_refresh.refresh_quota_cache` ONCE
+   before picking (idempotent, seconds — the same remedy the armed path already
+   applies). Evidence built ⇒ arm the gate and pick with it. This alone would have
+   prevented scitex-02.
+2. The refresh genuinely cannot run (no accounts, no credentials, no network) ⇒
+   degrade to freshness-only exactly as before, but emit ONE loud, actionable
+   warning naming the picked account. Never proceed wordlessly.
+3. Cache already present ⇒ unchanged: armed gate, one auto-refresh on
+   :class:`BlindQuotaCacheError`, and the refusal stands if the cache is still blind.
+
+Both preflight call sites route through :func:`pick_with_quota_evidence` rather than
+repeating the policy, so the gate cannot be armed one way in one place and another
+way in the other.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+#: Stable marker opening the degraded-boot warning. A grep target for the
+#: operator and the one token a test can key on without matching the ordinary
+#: selection notice.
+UNVERIFIABLE_MARKER = "QUOTA UNVERIFIABLE"
+
+__all__ = ["UNVERIFIABLE_MARKER", "pick_with_quota_evidence"]
+
+
+def pick_with_quota_evidence(
+    pick: Callable[[bool], str],
+    *,
+    agent_name: str,
+    quota_cache_path: Path | str | None = None,
+    store_dir: Path | None = None,
+    log_stream: Any = None,
+) -> str:
+    """Run *pick* with the quota gate armed whenever evidence can be had.
+
+    Parameters
+    ----------
+    pick
+        Called as ``pick(require_quota_evidence)`` and must return the picked
+        stored-account name. A callable rather than a kwargs bundle because the
+        two preflight call sites pass different candidate universes; only the
+        ARMING policy is shared, and that is the whole point of this helper.
+    agent_name
+        The booting agent — named in every log line so a fleet restart's output
+        attributes each decision.
+    quota_cache_path
+        Cache override, threaded to the reader, the populator and the picker
+        alike so all three agree on which file is under discussion.
+    store_dir
+        Account store the pick is choosing among. Passed to the populator so an
+        on-demand refresh measures THIS pool rather than whatever the default
+        cascade happens to discover.
+    log_stream
+        Follows the preflight's convention: a caller-supplied stream means the
+        output is being CAPTURED (the dry-probe suppression path), so it must
+        not reach a logger.
+
+    Raises
+    ------
+    _creds.NoHealthyAccountError
+        Propagated from *pick* unchanged — including
+        :class:`_creds.BlindQuotaCacheError` when a host that HAS a cache is
+        still blind after one refresh.
+    """
+    from .._account.quota_cache import quota_cache_present
+
+    if quota_cache_present(quota_cache_path):
+        return _pick_armed(
+            pick,
+            agent_name=agent_name,
+            quota_cache_path=quota_cache_path,
+            store_dir=store_dir,
+        )
+
+    blocker = _build_evidence_once(
+        agent_name=agent_name,
+        quota_cache_path=quota_cache_path,
+        store_dir=store_dir,
+    )
+    if blocker is None:
+        return _pick_armed(
+            pick,
+            agent_name=agent_name,
+            quota_cache_path=quota_cache_path,
+            store_dir=store_dir,
+        )
+
+    picked = pick(False)
+    _warn_unverifiable(
+        picked,
+        agent_name=agent_name,
+        blocker=blocker,
+        quota_cache_path=quota_cache_path,
+        log_stream=log_stream,
+    )
+    return picked
+
+
+def _pick_armed(
+    pick: Callable[[bool], str],
+    *,
+    agent_name: str,
+    quota_cache_path: Path | str | None,
+    store_dir: Path | None,
+) -> str:
+    """Pick with the gate ARMED, self-repairing a blind cache once.
+
+    AUTO-REFRESH, THEN RE-PICK — operator 2026-08-02: 「refresh quota cache
+    勝手にやれよ」. A blind cache told the operator to run `sac accounts
+    refresh-quota-cache` and retry BY HAND, and it blocked three of five agents in
+    ONE `sac-restart` invocation. sac knows the remedy, and the remedy is
+    idempotent and takes seconds — so sac runs it instead of printing it.
+
+    ONE attempt, and ONLY for :class:`BlindQuotaCacheError`. Refusing to boot on
+    unverifiable quota (constitution §2: unknown is not 'OK') is unchanged: if the
+    cache is STILL blind after a successful refresh, the refusal stands and its
+    remedy text is then CORRECT rather than misleading — "the populator is not the
+    problem; look for another writer".
+    """
+    from .._creds import BlindQuotaCacheError
+
+    try:
+        return pick(True)
+    except BlindQuotaCacheError as blind:
+        logger.info(
+            "quota cache blind for %r — refreshing it once before refusing",
+            agent_name,
+        )
+        try:
+            _refresh(quota_cache_path=quota_cache_path, store_dir=store_dir)
+        except Exception:  # stx-allow: fallback (reason: the refresh is a BEST-EFFORT self-repair. If it fails, the operator must see the ORIGINAL blind refusal and its remedy — not a refresh traceback that hides why the boot was refused.)
+            raise blind from None
+        return pick(True)
+
+
+def _build_evidence_once(
+    *,
+    agent_name: str,
+    quota_cache_path: Path | str | None,
+    store_dir: Path | None,
+) -> str | None:
+    """Populate a MISSING quota cache. ``None`` when the gate can now be armed.
+
+    Returns the reason the gate must stay disarmed otherwise — prose for the
+    warning, so the operator is told what sac actually observed rather than a
+    guess. Only ever called when no cache exists.
+    """
+    from .._account.quota_cache import quota_cache_present
+    from .._account.quota_cache_refresh import REASON_NO_ACCOUNTS
+
+    logger.info(
+        "no quota cache on this host — building one before picking an account for %r",
+        agent_name,
+    )
+    try:
+        result = _refresh(quota_cache_path=quota_cache_path, store_dir=store_dir)
+    except Exception as exc:  # stx-allow: fallback (reason: the on-demand build is BEST-EFFORT; a populator that raises must degrade to the documented freshness-only boot, never crash a start that would previously have succeeded.)
+        return f"the quota refresh raised {exc.__class__.__name__}: {exc}"
+
+    if not isinstance(result, dict):
+        return "the quota refresh returned no result"
+    if result.get("reason") == REASON_NO_ACCOUNTS:
+        return "no accounts are stored on this host, so there is nothing to measure"
+
+    measured = _as_int(result.get("ok"))
+    if measured <= 0:
+        # EVERY account failed (no credentials, no network, a lapsed refresh
+        # token). The populator still WROTE — see _discard_unusable_cache.
+        _discard_unusable_cache(quota_cache_path)
+        found = _as_int(result.get("accounts_found"))
+        return (
+            f"all {found} stored account(s) failed to report usage "
+            "(no credentials or no network reachable from here)"
+        )
+    if not quota_cache_present(quota_cache_path):
+        return "the quota refresh reported success but left no readable cache"
+    return None
+
+
+def _discard_unusable_cache(quota_cache_path: Path | str | None) -> None:
+    """Remove the EMPTY cache a failed on-demand build just materialised.
+
+    :func:`refresh_quota_cache` writes unconditionally once the store holds any
+    account, so a round in which every account fails still publishes
+    ``{"accounts": {}}``. That file's mere EXISTENCE is what
+    :func:`_account.quota_cache.quota_cache_present` reports, and therefore what
+    arms the gate — so leaving it behind converts this host's never-block degrade
+    into a PERMANENT hard refusal on every later boot. The self-repair would have
+    built the brick.
+
+    Two measured preconditions, never assumptions: the caller only reaches here
+    after :func:`quota_cache_present` said the file did not exist, and the unlink
+    only runs when :func:`diagnose_quota_cache` observes ``empty`` right now — so
+    a populated cache (including one a concurrent boot just wrote) is never
+    touched.
+    """
+    from .._account.quota_cache import diagnose_quota_cache
+
+    state, _entries, path = diagnose_quota_cache(quota_cache_path)
+    if state != "empty":
+        return
+    try:
+        path.unlink()
+    except OSError:  # stx-allow: fallback (reason: failing to remove the empty cache degrades to today's behaviour — a later boot arms the gate and refuses loudly. A start must not crash over cleanup.)
+        logger.warning("could not remove the empty quota cache at %s", path)
+
+
+def _warn_unverifiable(
+    picked: str,
+    *,
+    agent_name: str,
+    blocker: str,
+    quota_cache_path: Path | str | None,
+    log_stream: Any,
+) -> None:
+    """Say — once, loudly — that this boot's quota could not be confirmed.
+
+    The never-block invariant means this boot proceeds. It must not proceed
+    SILENTLY: on scitex-02 the silence is the whole defect, because every other
+    signal (``SUCC``, a live tmux, a rendered TUI) reported success while the
+    agent answered "You've hit your weekly limit" on every turn.
+    """
+    from .._account.quota_cache import diagnose_quota_cache
+
+    _state, _entries, path = diagnose_quota_cache(quota_cache_path)
+    text = (
+        f"{UNVERIFIABLE_MARKER} — {agent_name}: starting on account {picked} "
+        f"WITHOUT confirming it has 5h/7d headroom. No quota cache at {path}, and "
+        f"sac could not build one ({blocker}). {picked} may already be at its cap: "
+        "the agent will start and report success while every turn answers "
+        '"You\'ve hit your weekly limit" (measured 2026-08-06, scitex-02). '
+        "Fix: on THIS host run `sac accounts save <name>` (or `sac accounts "
+        "sync-live`) if it holds no accounts, then `sac accounts "
+        "refresh-quota-cache` — and install its cron so the next boot can see "
+        "quota without asking."
+    )
+    if log_stream is not None:
+        print(f"[sac:creds] {text}", file=log_stream)
+        return
+
+    from ..cli_pkg._helpers._console import system_msg
+
+    system_msg(text, style="warn")
+
+
+def _refresh(
+    *,
+    quota_cache_path: Path | str | None,
+    store_dir: Path | None,
+) -> dict[str, Any]:
+    from .._account.quota_cache_refresh import refresh_quota_cache
+
+    return refresh_quota_cache(cache_path=quota_cache_path, store_dir=store_dir)
+
+
+def _as_int(value: Any) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0

--- a/src/scitex_agent_container/_lifecycle/_start_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_start_preflight.py
@@ -146,14 +146,8 @@ def _rotate_among_credentials_files(
     Back-compat: a 1-element pool whose one snapshot is healthy resolves
     to that exact file (no-op — ``credentials_file`` unchanged, no log).
     """
-    from .._account.quota_cache import quota_cache_present
-    from .._account.quota_cache_refresh import refresh_quota_cache
-    from .._creds import (
-        POLICY_BURN,
-        BlindQuotaCacheError,
-        pick_healthy_account,
-        resolve_7d_policy,
-    )
+    from .._creds import POLICY_BURN, pick_healthy_account, resolve_7d_policy
+    from ._quota_evidence import pick_with_quota_evidence
 
     entries: list[tuple[str, Path]] = []
     grandparents: set[str] = set()
@@ -195,7 +189,7 @@ def _rotate_among_credentials_files(
     else:
         preferred = None
 
-    def _pick() -> str:
+    def _pick(require_quota_evidence: bool) -> str:
         return pick_healthy_account(
             preferred,
             candidates=slugs,
@@ -206,39 +200,21 @@ def _rotate_among_credentials_files(
             quota_cache_path=quota_cache_path,
             spread_key=config.name,
             policy=policy,
-            # Boot gate (constitution §2): on a host that HAS a quota cache, a
-            # fully-BLIND pick means the populator failed (empty/stale cache) —
-            # fail loud rather than land the agent on an unverifiable, possibly
-            # quota-exhausted account (2026-07-20 incident). A host with NO
-            # cache (fresh install / CI / quota-cron-less Spartan node) still
-            # degrades to freshness-only and boots — the never-block invariant.
-            require_quota_evidence=quota_cache_present(quota_cache_path),
+            require_quota_evidence=require_quota_evidence,
         )
 
-    try:
-        picked = _pick()
-    except BlindQuotaCacheError as blind:
-        # AUTO-REFRESH, THEN RE-PICK — operator 2026-08-02:
-        # 「refresh quota cache 勝手にやれよ」. A blind cache told the operator
-        # to run `sac accounts refresh-quota-cache` and retry BY HAND, and it
-        # blocked three of five agents in ONE `sac-restart` invocation. sac
-        # knows the remedy, and the remedy is idempotent and takes seconds —
-        # so sac runs it instead of printing it.
-        #
-        # ONE attempt, and ONLY for BlindQuotaCacheError. Refusing to boot on
-        # unverifiable quota (constitution: unknown is not 'OK') is unchanged:
-        # if the cache is STILL blind after a successful refresh, the refusal
-        # stands and its remedy text is then CORRECT rather than misleading —
-        # "the populator is not the problem; look for another writer".
-        logger.info(
-            "quota cache blind for %r — refreshing it once before refusing",
-            config.name,
-        )
-        try:
-            refresh_quota_cache(cache_path=quota_cache_path)
-        except Exception:  # stx-allow: fallback (reason: the refresh is a BEST-EFFORT self-repair. If it fails, the operator must see the ORIGINAL blind refusal and its remedy — not a refresh traceback that hides why the boot was refused.)
-            raise blind from None
-        picked = _pick()
+    # Boot gate (constitution §2 — unknown is not "OK"). Arming it is NOT the
+    # same question as "does a cache file exist": that predicate disarms the
+    # gate on exactly the host it was built for (see ._quota_evidence for the
+    # scitex-02 measurement). The helper builds the missing evidence first, and
+    # only degrades — loudly, never silently — when it genuinely cannot.
+    picked = pick_with_quota_evidence(
+        _pick,
+        agent_name=config.name,
+        quota_cache_path=quota_cache_path,
+        store_dir=store_dir,
+        log_stream=log_stream,
+    )
 
     picked_path = next(p for slug, p in entries if slug == picked)
     claude.credentials_file = str(picked_path)
@@ -368,22 +344,30 @@ def _rotate_to_healthy_account(
     if not pinned:
         return  # unpinned agent — host live OAuth, untouched.
 
-    from .._account.quota_cache import quota_cache_present
     from .._creds import pick_healthy_account, resolve_7d_policy
+    from ._quota_evidence import pick_with_quota_evidence
 
     policy = resolve_7d_policy()
-    picked = pick_healthy_account(
-        pinned,
-        now=now,
-        usage_5h=usage_5h,
-        usage_7d=usage_7d,
+
+    def _pick(require_quota_evidence: bool) -> str:
+        return pick_healthy_account(
+            pinned,
+            now=now,
+            usage_5h=usage_5h,
+            usage_7d=usage_7d,
+            quota_cache_path=quota_cache_path,
+            spread_key=config.name,
+            policy=policy,
+            require_quota_evidence=require_quota_evidence,
+        )
+
+    # Same arming policy as the pool path above — shared, not restated, so the
+    # gate can never be armed one way here and another way there.
+    picked = pick_with_quota_evidence(
+        _pick,
+        agent_name=config.name,
         quota_cache_path=quota_cache_path,
-        spread_key=config.name,
-        policy=policy,
-        # Boot gate (constitution §2): a blind-quota pin fails loud on a host
-        # that HAS a cache (populator failure); a cache-less host degrades and
-        # boots (never-block invariant). See quota_cache_present.
-        require_quota_evidence=quota_cache_present(quota_cache_path),
+        log_stream=log_stream,
     )
     if picked == pinned:
         return  # pinned is healthy — no rotation, no log line.

--- a/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
@@ -27,8 +27,23 @@ from typing import Iterator
 import pytest
 
 from scitex_agent_container._creds import NoHealthyAccountError
+from scitex_agent_container._lifecycle._quota_evidence import UNVERIFIABLE_MARKER
 from scitex_agent_container._lifecycle._start import _rotate_to_healthy_account
 from scitex_agent_container.config import AgentConfig
+
+
+def _without_quota_warning(log: str) -> str:
+    """Drop the unverifiable-quota warning, keeping every other line.
+
+    The autouse fixture below points the reader at an ABSENT cache, so the
+    preflight now warns once per boot that it could not confirm the picked
+    account's headroom (see ``._quota_evidence``). That is an orthogonal
+    signal; the assertions here are about POOL-SELECTION output. The marker is
+    imported rather than spelled out so a reworded warning cannot silently
+    start slipping past this filter.
+    """
+    kept = [line for line in log.splitlines() if UNVERIFIABLE_MARKER not in line]
+    return "".join(f"{line}\n" for line in kept)
 
 
 @pytest.fixture
@@ -274,8 +289,8 @@ def test_singular_credentials_file_emits_no_notice(_isolate_home: Path) -> None:
     log = io.StringIO()
     # Act
     _rotate_to_healthy_account(cfg, log_stream=log)
-    # Assert — a 1-element pool that keeps its entry logs nothing.
-    assert log.getvalue() == ""
+    # Assert — a 1-element pool that keeps its entry narrates no selection.
+    assert _without_quota_warning(log.getvalue()) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_lifecycle/test__start_creds_no_cache_builds_quota_evidence.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_creds_no_cache_builds_quota_evidence.py
@@ -1,0 +1,403 @@
+"""A host with NO quota cache must BUILD the evidence, never go silent.
+
+The blind-pick gate (:func:`_creds.pick_healthy_account` ``require_quota_evidence``)
+exists for the case "the cache tells us nothing", yet the start preflight armed it
+only when a cache FILE already existed. On a host with NO cache — exactly the blind
+case — the gate was DISARMED and the boot proceeded blind, AND the armed path's
+auto-refresh self-repair never ran either. The host that most needs the cache built
+was the one host that never tried to build it.
+
+MEASURED 2026-08-06, scitex-02 (a newly-provisioned compute node with no quota cron
+and no ``quota-cache.json``): the pick read "5h=? 7d=?", landed agent ``figrecipe``
+on ``wyusuuke-gmail-com`` at d7=100.0%, sac printed ``SUCC``, tmux was alive, the
+TUI rendered — and every turn answered "You've hit your weekly limit". Startup
+reported success; the agent was functionally dead.
+
+What is locked here
+-------------------
+1. No cache + a refresh that SUCCEEDS → evidence is built, the gate ends up armed,
+   and the exhausted account is NOT picked while a healthy sibling exists.
+2. No cache + a refresh that genuinely CANNOT run → the boot still proceeds (the
+   never-block invariant: a boot is never blocked merely because this host runs no
+   quota system) AND a loud warning NAMES the picked account.
+3. That degraded boot leaves no durable brick: a SECOND boot on the same host still
+   proceeds. A failed refresh writes ``{"accounts": {}}``, and the mere EXISTENCE of
+   that file arms ``require_quota_evidence`` on every later boot — which would
+   convert the never-block degrade into a permanent hard refusal.
+
+PA-306: no mocks. Real snapshots, real store, real ``refresh_quota_cache`` through
+its ordinary code path, real ``_rotate_to_healthy_account`` mutation. The refresh is
+kept offline WITHOUT patching it: :func:`_account.claude_usage.fetch_usage_for_credentials`
+consults its production per-account cache (``<account_dir>/usage.json``, 5-min TTL)
+BEFORE any token read or network call, so seeding that real file is enough for the
+success case, and a snapshot with no ``accessToken`` is enough for the failure case.
+AAA markers (TQ002); descriptive names; one assertion each (TQ007).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._creds import BlindQuotaCacheError
+from scitex_agent_container._lifecycle._start import _rotate_to_healthy_account
+from scitex_agent_container.config import AgentConfig
+
+# The scitex-02 incident pair. Distinct first dash-segments, because that
+# segment is the quota cache's per-account match key (``short``).
+_EXHAUSTED = "wyusuuke-gmail-com"  # d7 = 100.0% — the account that was picked
+_HEALTHY = "ywatanabe-scitex-ai"  # d7 = 5.0% — the sibling that should have won
+
+# One agent name per fleet member. With every account's quota UNKNOWN the pick
+# falls to per-agent rendezvous hashing, which spreads the fleet across BOTH
+# accounts; with evidence the near-capped account is a whole tier worse and no
+# agent lands on it. A fleet therefore separates "picked blind" from "picked
+# with evidence" deterministically, where a single agent could agree by luck.
+_FLEET = tuple(f"figrecipe-{i}" for i in range(12))
+
+# The degraded-boot warning's stable marker. Asserted as a SPACED phrase on
+# purpose: pytest derives ``tmp_path`` from the test's own name, and the
+# selection notice prints that path — so a single-word marker echoed by the
+# path would make the assertion pass against a build that warns about
+# nothing. A space cannot occur in these paths. (Measured on the unfixed
+# tree: a `"unverifiable" in log` assertion passed for exactly that reason.)
+_MARKER = "QUOTA UNVERIFIABLE"
+
+
+def _warning_line(log: str) -> str:
+    """The degraded-boot warning only — never the ordinary selection notice.
+
+    The notice already names the agent and the picked account, so an
+    unscoped substring search cannot tell "warned about this account" from
+    "mentioned it while reporting a normal pick".
+    """
+    return "\n".join(line for line in log.splitlines() if _MARKER in line)
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path) -> Iterator[Path]:
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+@pytest.fixture
+def _no_quota_cache(tmp_path: Path) -> Iterator[Path]:
+    """Point the cache READER and the populator at one path holding NO file.
+
+    ``SAC_QUOTA_CACHE_PATH`` is the shared override for both ends, so this is
+    the honest shape of a quota-cron-less host: nothing to read, and a refresh
+    would write exactly where the reader looks.
+    """
+    saved = os.environ.get("SAC_QUOTA_CACHE_PATH")
+    cache = tmp_path / "runtime" / "quota-cache.json"
+    os.environ["SAC_QUOTA_CACHE_PATH"] = str(cache)
+    try:
+        yield cache
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_QUOTA_CACHE_PATH", None)
+        else:
+            os.environ["SAC_QUOTA_CACHE_PATH"] = saved
+
+
+def _write_snapshot(store: Path, slug: str, *, with_token: bool) -> Path:
+    """Write one account's ``.credentials.json`` and return its path.
+
+    ``with_token`` decides whether the usage fetch can even begin: without an
+    ``accessToken`` :func:`fetch_usage_for_credentials` returns an error dict
+    before touching the network, which is the offline stand-in for "no
+    credentials on this host".
+    """
+    path = store / slug / ".credentials.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    oauth: dict[str, object] = {"expiresAt": int((time.time() + 7_200.0) * 1_000)}
+    if with_token:
+        oauth["accessToken"] = "not-a-real-token"
+    path.write_text(json.dumps({"claudeAiOauth": oauth}))
+    return path
+
+
+def _seed_usage_cache(creds: Path, *, pct_5h: float, pct_7d: float) -> None:
+    """Seed the REAL per-account usage cache the populator's fetcher reads.
+
+    ``<account_dir>/usage.json`` is production state, not a test double: it is
+    the file :func:`_account.claude_usage.fetch_usage_for_credentials` writes
+    and consults first (5-min TTL), and the same file
+    ``_state.account_store.read_account_usage_cache`` reads. Seeding it lets
+    ``refresh_quota_cache`` succeed through its ordinary path with no network.
+    """
+    (creds.parent / "usage.json").write_text(
+        json.dumps(
+            {
+                "used_pct_5h": pct_5h,
+                "used_pct_7d": pct_7d,
+                "reset_at_5h": None,
+                "reset_at_7d": None,
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+                "error": None,
+            }
+        )
+    )
+
+
+def _default_store(home: Path) -> Path:
+    return home / ".scitex" / "agent-container" / "accounts"
+
+
+def _pool_config(name: str, paths: list[Path]) -> AgentConfig:
+    cfg = AgentConfig(name=name)
+    cfg.claude.credentials_files = [str(p) for p in paths]
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# 1. No cache + a refresh that SUCCEEDS — build the evidence, then use it.
+# ---------------------------------------------------------------------------
+
+
+def test_no_cache_host_builds_evidence_and_never_picks_the_exhausted_account(
+    _isolate_home: Path, _no_quota_cache: Path
+) -> None:
+    # Arrange — the scitex-02 shape: two token-fresh accounts, one at its
+    # weekly cap, and NO quota cache anywhere the reader looks. Both accounts
+    # are measurable offline (seeded per-account usage cache), so the
+    # on-demand refresh can succeed.
+    store = _default_store(_isolate_home)
+    p_hot = _write_snapshot(store, _EXHAUSTED, with_token=True)
+    p_cool = _write_snapshot(store, _HEALTHY, with_token=True)
+    _seed_usage_cache(p_hot, pct_5h=12.0, pct_7d=100.0)
+    _seed_usage_cache(p_cool, pct_5h=3.0, pct_7d=5.0)
+
+    # Act — boot a fleet that all lists the same pool.
+    picks = set()
+    for agent in _FLEET:
+        cfg = _pool_config(agent, [p_hot, p_cool])
+        _rotate_to_healthy_account(cfg, log_stream=io.StringIO())
+        picks.add(cfg.claude.credentials_file)
+
+    # Assert — nobody lands on the d7=100% account; the cache-less host
+    # measured the pool instead of guessing.
+    assert picks == {str(p_cool)}
+
+
+def test_no_cache_host_leaves_a_populated_quota_cache_behind(
+    _isolate_home: Path, _no_quota_cache: Path
+) -> None:
+    # Arrange
+    store = _default_store(_isolate_home)
+    p_hot = _write_snapshot(store, _EXHAUSTED, with_token=True)
+    p_cool = _write_snapshot(store, _HEALTHY, with_token=True)
+    _seed_usage_cache(p_hot, pct_5h=12.0, pct_7d=100.0)
+    _seed_usage_cache(p_cool, pct_5h=3.0, pct_7d=5.0)
+    cfg = _pool_config("figrecipe", [p_hot, p_cool])
+
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=io.StringIO())
+
+    # Assert — the evidence is durable, so the NEXT boot (and the operator)
+    # can see the same utilisation without re-measuring.
+    assert json.loads(_no_quota_cache.read_text())["accounts"].keys() == {
+        _EXHAUSTED,
+        _HEALTHY,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2. No cache + a refresh that genuinely CANNOT run — degrade, but LOUDLY.
+# ---------------------------------------------------------------------------
+
+
+def test_boot_proceeds_when_no_cache_exists_and_the_refresh_cannot_run(
+    _isolate_home: Path, _no_quota_cache: Path
+) -> None:
+    # Arrange — token-fresh snapshots with no usable credential for the usage
+    # API (the CI / fresh-install / quota-cron-less shape). The refresh runs
+    # and measures nothing.
+    store = _default_store(_isolate_home)
+    p_a = _write_snapshot(store, _EXHAUSTED, with_token=False)
+    p_b = _write_snapshot(store, _HEALTHY, with_token=False)
+    cfg = _pool_config("figrecipe", [p_a, p_b])
+
+    # Act — a boot is never blocked merely because this host runs no quota
+    # system.
+    _rotate_to_healthy_account(cfg, log_stream=io.StringIO())
+
+    # Assert
+    assert cfg.claude.credentials_file in {str(p_a), str(p_b)}
+
+
+def test_degraded_boot_warning_line_names_the_account_it_could_not_verify(
+    _isolate_home: Path, _no_quota_cache: Path
+) -> None:
+    # Arrange — same unmeasurable host as above.
+    store = _default_store(_isolate_home)
+    p_a = _write_snapshot(store, _EXHAUSTED, with_token=False)
+    p_b = _write_snapshot(store, _HEALTHY, with_token=False)
+    cfg = _pool_config("figrecipe", [p_a, p_b])
+    log = io.StringIO()
+
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+
+    # Assert — the slug must appear IN THE WARNING, not merely somewhere in
+    # the output: the ordinary selection notice already names it, so an
+    # unscoped search would pass against a build that warns about nothing.
+    picked_slug = Path(cfg.claude.credentials_file).parent.name
+    assert picked_slug in _warning_line(log.getvalue())
+
+
+def test_degraded_boot_warning_states_the_condition(
+    _isolate_home: Path, _no_quota_cache: Path
+) -> None:
+    # Arrange
+    store = _default_store(_isolate_home)
+    p_a = _write_snapshot(store, _EXHAUSTED, with_token=False)
+    p_b = _write_snapshot(store, _HEALTHY, with_token=False)
+    cfg = _pool_config("figrecipe", [p_a, p_b])
+    log = io.StringIO()
+
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+
+    # Assert — the warning states the CONDITION, not just the pick.
+    assert _MARKER in log.getvalue()
+
+
+def test_degraded_boot_warning_gives_the_command_that_populates_the_cache(
+    _isolate_home: Path, _no_quota_cache: Path
+) -> None:
+    # Arrange
+    store = _default_store(_isolate_home)
+    p_a = _write_snapshot(store, _EXHAUSTED, with_token=False)
+    p_b = _write_snapshot(store, _HEALTHY, with_token=False)
+    cfg = _pool_config("figrecipe", [p_a, p_b])
+    log = io.StringIO()
+
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+
+    # Assert — actionable, not merely alarming.
+    assert "sac accounts refresh-quota-cache" in log.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# 3. The degraded boot must not brick the NEXT one.
+# ---------------------------------------------------------------------------
+
+
+def test_failed_refresh_does_not_arm_the_gate_for_the_next_boot(
+    _isolate_home: Path, _no_quota_cache: Path
+) -> None:
+    # Arrange — a failed refresh writes ``{"accounts": {}}``, and the mere
+    # EXISTENCE of that file is what arms ``require_quota_evidence``. If it is
+    # left behind, every later boot on this host hard-refuses instead of
+    # degrading — a permanent brick built by the self-repair itself.
+    store = _default_store(_isolate_home)
+    p_a = _write_snapshot(store, _EXHAUSTED, with_token=False)
+    p_b = _write_snapshot(store, _HEALTHY, with_token=False)
+    _rotate_to_healthy_account(
+        _pool_config("figrecipe", [p_a, p_b]), log_stream=io.StringIO()
+    )
+    second = _pool_config("figrecipe", [p_a, p_b])
+
+    # Act — the SECOND boot on the same host.
+    _rotate_to_healthy_account(second, log_stream=io.StringIO())
+
+    # Assert — still never blocked.
+    assert second.claude.credentials_file in {str(p_a), str(p_b)}
+
+
+# ---------------------------------------------------------------------------
+# 4. Present cache — the armed path is UNCHANGED (auto-refresh once, then the
+#    refusal stands). These lock behaviour the fix must not disturb.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _blind_quota_cache(tmp_path: Path) -> Iterator[Path]:
+    """A cache FILE that exists and holds NOTHING — the armed-but-blind host."""
+    saved = os.environ.get("SAC_QUOTA_CACHE_PATH")
+    cache = tmp_path / "runtime" / "quota-cache.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"written_at": 1_784_530_000.0, "accounts": {}}))
+    os.environ["SAC_QUOTA_CACHE_PATH"] = str(cache)
+    try:
+        yield cache
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_QUOTA_CACHE_PATH", None)
+        else:
+            os.environ["SAC_QUOTA_CACHE_PATH"] = saved
+
+
+def test_present_but_blind_cache_is_auto_refreshed_and_then_ranked(
+    _isolate_home: Path, _blind_quota_cache: Path
+) -> None:
+    # Arrange — the operator's 2026-08-02 ask (「refresh quota cache 勝手にやれよ」):
+    # a present-but-empty cache must be repaired by sac, not by hand. Both
+    # accounts are measurable offline, so the one auto-refresh succeeds.
+    store = _default_store(_isolate_home)
+    p_hot = _write_snapshot(store, _EXHAUSTED, with_token=True)
+    p_cool = _write_snapshot(store, _HEALTHY, with_token=True)
+    _seed_usage_cache(p_hot, pct_5h=12.0, pct_7d=100.0)
+    _seed_usage_cache(p_cool, pct_5h=3.0, pct_7d=5.0)
+    cfg = _pool_config("figrecipe", [p_hot, p_cool])
+
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=io.StringIO())
+
+    # Assert — repaired, then ranked on the repaired evidence.
+    assert cfg.claude.credentials_file == str(p_cool)
+
+
+def test_present_cache_still_blind_after_the_refresh_refuses_the_boot(
+    _isolate_home: Path, _blind_quota_cache: Path
+) -> None:
+    # Arrange — a cache exists but nothing can be measured, so the refresh
+    # cannot clear the blindness. Refusing to boot on unverifiable quota
+    # (constitution §2: unknown is not "OK") must still stand.
+    store = _default_store(_isolate_home)
+    p_a = _write_snapshot(store, _EXHAUSTED, with_token=False)
+    p_b = _write_snapshot(store, _HEALTHY, with_token=False)
+    cfg = _pool_config("figrecipe", [p_a, p_b])
+
+    # Act
+    ctx = pytest.raises(BlindQuotaCacheError)
+
+    # Assert
+    with ctx:
+        _rotate_to_healthy_account(cfg, log_stream=io.StringIO())
+
+
+def test_populated_cache_boot_emits_no_unverifiable_warning(
+    _isolate_home: Path, _blind_quota_cache: Path
+) -> None:
+    # Arrange — evidence is available, so the degraded path must not fire. A
+    # warning that also appears on healthy boots is one nobody reads.
+    store = _default_store(_isolate_home)
+    p_hot = _write_snapshot(store, _EXHAUSTED, with_token=True)
+    p_cool = _write_snapshot(store, _HEALTHY, with_token=True)
+    _seed_usage_cache(p_hot, pct_5h=12.0, pct_7d=100.0)
+    _seed_usage_cache(p_cool, pct_5h=3.0, pct_7d=5.0)
+    cfg = _pool_config("figrecipe", [p_hot, p_cool])
+    log = io.StringIO()
+
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+
+    # Assert
+    assert _MARKER not in log.getvalue()

--- a/tests/scitex_agent_container/_lifecycle/test__start_creds_rotate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_creds_rotate.py
@@ -24,8 +24,23 @@ from typing import Iterator
 import pytest
 
 from scitex_agent_container._creds import NoHealthyAccountError
+from scitex_agent_container._lifecycle._quota_evidence import UNVERIFIABLE_MARKER
 from scitex_agent_container._lifecycle._start import _rotate_to_healthy_account
 from scitex_agent_container.config import AgentConfig
+
+
+def _without_quota_warning(log: str) -> str:
+    """Drop the unverifiable-quota warning, keeping every other line.
+
+    These fixtures describe a host with no quota cache and no measurable
+    account, so the preflight now warns once per boot that it could not
+    confirm the picked account's headroom (see ``._quota_evidence``). That is
+    an orthogonal signal; the assertions here are about ROTATION output. The
+    marker is imported rather than spelled out so a reworded warning cannot
+    silently start slipping past this filter.
+    """
+    kept = [line for line in log.splitlines() if UNVERIFIABLE_MARKER not in line]
+    return "".join(f"{line}\n" for line in kept)
 
 
 @pytest.fixture
@@ -135,8 +150,12 @@ def test_pinned_healthy_agent_emits_no_rotation_line(_isolate_home: Path) -> Non
     log = io.StringIO()
     # Act
     _rotate_to_healthy_account(cfg, log_stream=log)
-    # Assert — quiet when no rotation happened.
-    assert log.getvalue() == ""
+    # Assert — quiet when no rotation happened. Scoped to ROTATION output:
+    # these fixtures also describe a host with no quota cache, which now emits
+    # its own unverifiable-quota warning (see ._quota_evidence). That warning
+    # is a different signal on a different condition, and this guard is about
+    # not narrating a pick that did not change anything.
+    assert _without_quota_warning(log.getvalue()) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug, measured today

Provisioning the compute node scitex-02, sac booted `figrecipe` onto an account at **d7 = 100.0%**. It printed `SUCC`, tmux was alive, the TUI rendered — and every turn answered *"You've hit your weekly limit"*. Startup reported success; the agent was functionally dead. The operator's standing rule names this class exactly: 「fail fast, fail loud, no silent fallbacks」.

sac already had the guard. `_creds/_pick_healthy.py` has a BLIND-PICK GATE that raises `BlindQuotaCacheError` when the quota cache knows nothing about the picked account — its docstring even cites the 2026-07-20 incident of launching onto a 7d=100% account. It is opt-in, and `_start_preflight.py` armed it at two sites like this:

```python
require_quota_evidence=quota_cache_present(quota_cache_path)
```

**The gate protects against "the cache tells us nothing". It is armed only when a cache FILE EXISTS.** On a host with no cache — precisely the blind case — the gate is disarmed and the boot proceeds blind. The arming predicate is the negation of the failure condition, so the gate is live exactly when it has nothing to do.

Each half is defensible alone, which is why it survived review. "Don't block a boot on a quota system this host doesn't run" is a real invariant with real reasons (CI boxes, quota-cron-less nodes). The bug lives only in the join.

## A second defect, worse, found while fixing the first

`_start_preflight.py:233` calls `logger.info(...)` inside the `except BlindQuotaCacheError` handler — in a module that **never imports `logging` and never binds `logger`**. Reproduced live on develop:

```
src/scitex_agent_container/_lifecycle/_start_preflight.py:233: in _rotate_among_credentials_files
    logger.info(
E   NameError: name 'logger' is not defined
```

So the auto-refresh the operator asked for (「refresh quota cache 勝手にやれよ」) was not merely gated behind cache-presence — **it raised `NameError` every time it was reached**. It existed only on the pool path; the named-account path had none. It had no test, which is why it survived.

## What this changes

Preserves "a boot is never blocked merely because this host runs no quota system", and removes the silent path:

1. **No cache → attempt `refresh_quota_cache` once before picking.** If it succeeds, arm the gate normally and pick with evidence. This alone would have prevented the scitex-02 failure.
2. **Refresh genuinely cannot run → degrade as before, but emit one loud, actionable warning** naming the picked account and stating its quota is unverifiable here. Never proceed wordlessly.
3. `BlindQuotaCacheError` semantics and the armed-path auto-refresh are intact — and the latter now actually runs.

`pick_with_quota_evidence` is the single shared helper; both preflight sites call it, and neither restates the arming policy.

### A trap in the fix itself

`refresh_quota_cache` writes unconditionally once the store holds any account, so a round where *every* account fails still publishes `{"accounts": {}}` — and that file's mere existence is what arms the gate. A naive on-demand refresh would therefore convert a cache-less host's never-block degrade into a **permanent hard refusal on every later boot**. `_discard_unusable_cache` removes it under two measured preconditions (file absent on entry; `diagnose_quota_cache` reports `empty` right now), never touching a populated cache. Guarded by `test_failed_refresh_does_not_arm_the_gate_for_the_next_boot`.

## Proof the test fails before and passes after

Run against a **pristine develop tree** (`git archive develop` extracted), not a `PYTHONPATH` swap — `pyproject.toml` pins `pythonpath = ["src"]`, which pytest puts *ahead of* `PYTHONPATH`, so the first baseline attempt silently ran the fixed code and reported 10 passed. Caught and redone.

**develop:**
```
test_no_cache_host_builds_evidence_and_never_picks_the_exhausted_account FAILED
E   AssertionError: assert {...} == {...}
E     Extra items in the left set:
E     '.../accounts/wyusuuke-gmail-com/.credentials.json'
```
develop's own log reproduces the incident verbatim: `figrecipe: account wyusuuke-gmail-com (5h=? 7d=?)`. Whole file on develop: **8 failed, 2 passed** (the 2 passing are the never-block guards, which must pass on both).

**This branch:** `10 passed in 0.68s`.

## Test counts

Full run over `_lifecycle/`, `_creds/`, `_account/`, `cli_pkg/lifecycle/`: **7 failed, 2350 passed, 36 errors**. All 7 failures and all 36 errors are **pre-existing on develop, verified not assumed** — 6 failures + 15 errors reproduce on the pristine develop tree (root cause `scitex_cards.StoreUnavailableError`, an external package); the 1 `test__broker_self.py` failure is a `sac listen` port-collision flake that passes isolated on both.

Targeted creds suites: **35 passed**, zero failures in `_creds/` or `_account/`.

## Behaviour change worth noting before merge

On a host with no quota evidence, **every** boot now emits one warning line. Two existing assertions were narrowed from "no output at all" to "no rotation/selection output" — intent intact (don't narrate a pick that changed nothing), and the filter imports the marker so a reworded warning cannot silently slip past it.

Also worth knowing: two of the new warning tests initially passed on develop for a bogus reason — pytest derives `tmp_path` from the test name, so `assert "unverifiable" in log` was satisfied by the *path*, not the warning. Rewritten to assert a spaced marker (`QUOTA UNVERIFIABLE`) that cannot occur in a path.
