### PR TITLE
fix(ci): unpin the SIF wrapper from Spartan so CI can leave it

### DIFF
--- a/.github/ci/exec-in-sif.sh
+++ b/.github/ci/exec-in-sif.sh
@@ -32,8 +32,22 @@ APPTAINER="${APPTAINER/#\~/$HOME}"
 SIF="${SIF/#\~/$HOME}"
 export PATH="$HOME/.env-3.11/bin:$PATH"
 
+# The Actions Variable names ONE host's apptainer (~/.env-3.11/bin/apptainer is
+# the Spartan shim); on a runner that ships apptainer in /usr/bin the same
+# variable points at nothing. Fall back to whatever is on PATH.
+#
+# This does NOT weaken the fail-loud rule in the header. That rule forbids
+# falling back to a BARE-RUNNER install — running the suite outside the SIF, in
+# a different environment from the release gate, which is the drift the whole
+# script exists to prevent. Locating the apptainer BINARY elsewhere still execs
+# the same SIF. No apptainer at all is still a hard error.
+if [ ! -x "$APPTAINER" ]; then
+    _found="$(command -v apptainer 2>/dev/null || true)"
+    [ -n "$_found" ] && APPTAINER="$_found"
+fi
 [ -x "$APPTAINER" ] || {
-    echo "::error::apptainer shim not executable at $APPTAINER"
+    echo "::error::apptainer not executable at '$APPTAINER' and not on PATH." \
+         "Set the SCITEX_CI_APPTAINER Actions Variable to this runner's path."
     exit 1
 }
 [ -f "$SIF" ] || {
@@ -41,8 +55,16 @@ export PATH="$HOME/.env-3.11/bin:$PATH"
     exit 1
 }
 
-# apptainer scratch on the shared FS — keeps HOME clean.
-export APPTAINER_TMPDIR="/data/gpfs/projects/punim0264/ywatanabe/ci/apptainer-tmp"
+# apptainer scratch. The GPFS path is Spartan's project filesystem and does not
+# exist on our own machines, where `mkdir -p` under `set -e` would abort the job
+# before a single test ran. Use it when it is there, a node-local scratch when
+# it is not.
+_SPARTAN_PROJ="/data/gpfs/projects/punim0264"
+if [ -d "$_SPARTAN_PROJ" ]; then
+    export APPTAINER_TMPDIR="$_SPARTAN_PROJ/ywatanabe/ci/apptainer-tmp"
+else
+    export APPTAINER_TMPDIR="${TMPDIR:-/tmp}/apptainer-tmp-${USER:-ci}"
+fi
 mkdir -p "$APPTAINER_TMPDIR"
 
 # Reap leaked CI processes from PRIOR runs on this persistent self-hosted node.
@@ -90,7 +112,12 @@ else
          "An unscoped pkill would SIGTERM the sibling matrix legs (see run 29284554656)."
 fi
 
-# --bind punim0264: $HOME/.scitex is a symlink into punim0264; bind it so the
-# symlink resolves inside the container. --pwd "$PWD" keeps the checkout as cwd.
-exec "$APPTAINER" exec --pwd "$PWD" --bind /data/gpfs/projects/punim0264 \
+# --bind punim0264: on Spartan $HOME/.scitex is a symlink into punim0264, so the
+# bind is what makes that symlink resolve inside the container. Elsewhere the
+# path does not exist and apptainer refuses to start with it ("bind path does
+# not exist"), so bind it only where it is real. --pwd "$PWD" keeps the checkout
+# as cwd.
+_BINDS=()
+[ -d "$_SPARTAN_PROJ" ] && _BINDS=(--bind "$_SPARTAN_PROJ")
+exec "$APPTAINER" exec --pwd "$PWD" "${_BINDS[@]+"${_BINDS[@]}"}" \
     "$SIF" bash ".github/ci/$INNER" "$@"


### PR DESCRIPTION
## Why

Constitution (operator, 2026-08-05): 「スパルタンのCIは全面的にやめましょう」.

pytest is still running on Spartan today. Measured on run `31113670058` — all three
legs on `spartan-pooled-cpu-01` / `spartan-cpu-org-01` / `spartan-cpu-org-02`, because
the `CI_RUNS_ON` repo variable names `spartan-cpu`.

Flipping that variable alone would not have worked: `exec-in-sif.sh` could not run
anywhere but Spartan.

| what | why it failed off Spartan |
|---|---|
| `SCITEX_CI_APPTAINER` = `~/.env-3.11/bin/apptainer` | that is the Spartan shim. scitex-04 has apptainer at `/usr/bin/apptainer`, so the `-x` check exits 1 before any test runs. |
| `APPTAINER_TMPDIR` = `/data/gpfs/projects/punim0264/...` | Spartan's project filesystem. `mkdir -p` under `set -e` aborts the job. |
| `--bind /data/gpfs/projects/punim0264` | apptainer refuses to start when a bind source does not exist. |

Each now uses the Spartan path when Spartan is present and the local equivalent when
it is not, so the same script runs on both.

## The fail-loud rule is intact

The header forbids falling back to a **bare-runner install** — running the suite outside
the SIF, in a different environment from the release gate. That is the drift that left
PyPI on 0.21.17 while nine tags shipped nothing, and it stays forbidden. Locating the
apptainer **binary** elsewhere still execs the same SIF, so the PR gate and the release
gate remain the same bytes. No apptainer at all is still a hard error.

## Verification

- This PR's own CI runs on Spartan (the variable is unchanged), which is the control:
  it shows the patch does not break the host it was written for.
- The patched entrypoint was also run by hand on scitex-04, with `SCITEX_CI_APPTAINER`
  deliberately left at the wrong Spartan path, to exercise the fallback.

## Not in this PR

Flipping `CI_RUNS_ON`. A variable pointing at a label nothing carries queues every job
forever, which is worse than running on the wrong machine. The runner is up
(`scitex-04-cpu-01`, online, labels `self-hosted,Linux,X64,scitex-ci,scitex-local-cpu`);
the flip follows once this is merged.

scitex-03 is unreachable (no route to 192.168.11.126) and needs the operator at the
machine, so this is one node, not two.