### PR TITLE
fix(agents list): one shared deadline for the remote probe pass (NOT the CI-red fix its commit message claims)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_discover.py
@@ -323,6 +323,7 @@ def _probe_remote_statuses(
     not run is not evidence a remote agent died, but neither is it evidence it
     is running, so it must not render as a comforting green.
     """
+    import time as _time
     from concurrent.futures import ThreadPoolExecutor
     from concurrent.futures import TimeoutError as _FuturesTimeout
 
@@ -335,13 +336,23 @@ def _probe_remote_statuses(
         future_to_name = {
             pool.submit(probe, c["name"], c["host"]): c["name"] for c in candidates
         }
+        # ONE shared wall-clock budget for the batch. future.result(timeout=T)
+        # in submission order restarts the deadline PER FUTURE, so n stalled
+        # probes cost about ceil(n/workers)*T even though the pool is parallel
+        # -- precisely the serialization the docstring above promises cannot
+        # happen. The local pass in _agent_list.get_agent_list_data was fixed
+        # for todo#254 and its comment already claims "same defect, same fix, as
+        # _probe_remote_statuses"; the fix never landed here. A comment is not a
+        # fix, and only the test caught the difference.
+        _deadline = _time.monotonic() + probe_timeout_s
         for future in list(future_to_name):
             name = future_to_name[future]
+            _remaining = max(0.0, _deadline - _time.monotonic())
             # stx-allow: fallback (a per-probe timeout/exception is "unknown" —
             # hidden from the default view + counted in the footer; a probe that
             # could not run must not masquerade as a running remote row)
             try:
-                statuses[name] = future.result(timeout=probe_timeout_s)
+                statuses[name] = future.result(timeout=_remaining)
             except _FuturesTimeout:  # stx-allow: fallback (reason: see inline comment)
                 statuses[name] = "unknown"
                 future.cancel()

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_remote.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_remote.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 import importlib
 import os
+import threading
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Iterator
@@ -42,6 +44,7 @@ from scitex_agent_container.cli_pkg._helpers._agent_list import (
 )
 from scitex_agent_container.cli_pkg._helpers._agent_list_discover import (
     _default_remote_status_probe,
+    _probe_remote_statuses,
 )
 
 # ---------------------------------------------------------------------------
@@ -560,3 +563,74 @@ def test_remote_row_account_is_spec_derived(isolated_state_db, tmp_path):
     rows = _remote_rows_direct(run_ssh=lambda argv: 0, discover=_disc)
     # Assert — same spec-derived label, and demonstrably non-empty (not "").
     assert _spartan_row(rows)["account"] == expected != ""
+
+
+# ---------------------------------------------------------------------------
+# 11. The remote probe pass spends ONE budget for the whole batch, not one per
+#     probe. `future.result(timeout=T)` called once per future in submission
+#     order hands each future the FULL budget, so n wedged peers cost about
+#     ceil(n/workers)*T -- exactly the serialization _probe_remote_statuses'
+#     own docstring promises cannot happen.
+#
+#     ASSERTED AS A RATIO, DELIBERATELY. The absolute-bound form of this
+#     assertion already exists (test_cli.py: `elapsed < 3.0` against a 1s
+#     budget) and it is the assertion that goes red under 32-way xdist load --
+#     load inflates the measurement while the bound stays put, so the test
+#     reports a defect that is not there. A ratio moves both arms together: a
+#     loaded machine makes the baseline slow too, and the comparison survives.
+#     The two implementations stay far apart either way -- a shared budget puts
+#     the batch at ~1x the single-probe cost, a per-future budget at ~16x.
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _wedged_probe() -> Iterator[Callable[[str, str], str]]:
+    """A real probe callable that blocks until the context exits.
+
+    No mock: this is an ordinary function that waits on a real Event, which is
+    what a peer whose ssh never answers looks like from the pool's side.
+    """
+    release = threading.Event()
+
+    def probe(name: str, host: str) -> str:
+        release.wait(30)
+        return "running"
+
+    try:
+        yield probe
+    finally:
+        release.set()
+
+
+def _batch_seconds(
+    probe: Callable[[str, str], str], n_peers: int, budget_s: float
+) -> float:
+    """Wall-clock cost of probing ``n_peers`` wedged peers under one budget."""
+    peers = [{"name": f"peer-{i}", "host": "unreachable"} for i in range(n_peers)]
+    started = time.monotonic()
+    # max_parallel_probes=1 on purpose: a pool wide enough to run the whole
+    # batch at once would hide the defect, because the WAITING is what
+    # serializes, not the work.
+    _probe_remote_statuses(peers, probe, 1, budget_s)
+    return time.monotonic() - started
+
+
+def test_remote_probe_batch_spends_one_budget_not_one_per_peer():
+    # Arrange — every probe wedges, so every future must be cut off by the
+    # budget rather than by finishing.
+    budget_s = 0.3
+    n_peers = 16
+    with _wedged_probe() as probe:
+        # Act — one peer establishes what a single budget costs ON THIS
+        # MACHINE, RIGHT NOW; sixteen peers must not cost sixteen of them.
+        one_peer = _batch_seconds(probe, 1, budget_s)
+        many_peers = _batch_seconds(probe, n_peers, budget_s)
+    # Assert
+    ratio = many_peers / max(one_peer, 1e-9)
+    assert ratio < 5.0, (
+        f"{n_peers} wedged peers cost {many_peers:.2f}s against a "
+        f"{one_peer:.2f}s single-peer baseline ({ratio:.1f}x). One shared "
+        f"batch budget is ~1x; ~{n_peers}x means future.result(timeout=...) "
+        "restarts the deadline per future, so the pool's parallelism never "
+        "reaches the waiting -- todo#254, remote half."
+    )


### PR DESCRIPTION
## The commit message on this branch overclaims. Read this instead.

`95208a6` says this fixes the red that appeared when CI moved to scitex-04.
**It does not.** I ran the A/B afterwards — full suite, real entrypoint, fixed
arm vs unfixed arm — and **both arms failed identically (1 failure each)**. This
change is not the cause of that failure and does not repair it. I could not
force-push a correction onto a pushed commit, so the record is corrected here.

What actually explains the red is flakiness, proven by run
[31120506600](https://github.com/scitex-ai/scitex-agent-container/actions/runs/31120506600):
one commit, one machine, **py3.11 SUCCESS / py3.12 FAILURE / py3.13 SUCCESS**.
Three arms of the same matrix disagreeing on identical code is not a defect this
diff can reach. That failure is carded separately and needs a decision on the
assertion, not a fix here.

## What this change *is* worth on its own

An independently verifiable defect in `_probe_remote_statuses`, readable
straight from the source without any experiment:

```python
for future in list(future_to_name):
    statuses[name] = future.result(timeout=probe_timeout_s)   # deadline RESTARTS
```

`future.result(timeout=T)` called once per future in submission order gives each
future the **full** budget. `n` stalled probes therefore cost roughly
`ceil(n/workers) * T`, not `T` — the pool is parallel but the *waiting* is
serialized. That is exactly what the function's own docstring promises cannot
happen:

> so one wedged peer cannot serialize (or hang) the whole `sac agents list`

The fix is one shared wall-clock deadline, mirroring what
`_agent_list.get_agent_list_data` already does for the local pass. That local
fix even carries the comment *"Same defect, same fix, as
`_agent_list_discover._probe_remote_statuses`"* — while the fix had never landed
here. A comment asserting a remedy is not the remedy.

Abstention semantics are unchanged: a probe that runs out of budget is
`"unknown"` — hidden from the default view, counted in the footer, never a green
row.

## Line cap: this PR crosses it, but the cap is not a build gate

This section has been corrected twice. Here is the settled version.

| | lines | bytes |
|---|---|---|
| `origin/develop` | **512** | 23574 |
| `origin/fix/probe-budget` | **523** | 24323 |

My first draft said develop was already over at 513 — wrong. develop's copy of
this file sits *exactly at* 512, so this PR is what crosses the line, by 11.

But I then implied that made it a blocker, and the evidence says otherwise.
Counting every tracked `.py` on this branch:

- **`src/`: 9 files already exceed 512** on develop — up to **870**
  (`_workdir_audit.py`), including this file's own sibling `_agent_list.py` at
  532.
- **`tests/`: 103 of 762 files exceed it**, up to 3239.

develop is green with all of those in place, so `scitex-dev quality audit-lines`
does not hard-fail the build above 512. The cap is advisory here, or carries
exemptions. It is still worth respecting, and the split for this file is carded
separately — but it is not a reason to hold this PR.

I could not confirm that by running the auditor: the `scitex-dev` install in
this container is broken (two dist-info directories; `audit_line_limits.py`
missing from the installed tree; both the deprecated and current entrypoints
exit 2 without evaluating the rule). Carded. The conclusion above rests on the
file census plus develop being green, not on the tool.

## Verification — the gap is now closed

An earlier revision of this section said I had no test that fails before and
passes after, and offered to merge on a source-level argument alone. That gap is
filled; the second commit adds the test.

| source under test | result |
|---|---|
| develop's per-future deadline | **FAIL — 15.9x** (16 wedged peers cost 4.81s vs a 0.30s single-peer baseline) |
| this branch's shared deadline | **PASS** |

The measured **15.9x lands on n_peers = 16**. The test does not merely observe
"slower" — it observes slower by exactly the factor the defect predicts, which
is what makes it evidence for the mechanism rather than evidence of a busy
machine.

**It asserts a ratio, not a bound, on purpose.** The absolute-bound form already
exists — `test_cli.py` asserts `elapsed < 3.0` against a 1s budget — and that is
precisely the assertion that goes red under 32-way xdist load, because load
inflates the measurement while the bound stays put. Comparing against a
single-peer baseline taken on the same machine moments earlier moves both arms
together. At 15.9x vs ~1x, the 5.0x threshold has wide room on both sides.

**No mocks**, per the suite's own header: the probe is an ordinary function
waiting on a real `threading.Event` — what a peer whose ssh never answers looks
like from the pool's side — and `_probe_remote_statuses` runs its real
`ThreadPoolExecutor` over real futures. `max_parallel_probes=1` deliberately: a
pool wide enough to run the batch at once hides the defect, because what
serializes is the *waiting*, not the work.

Whole remote suite: **23/23 pass**. The before-arm swapped develop's source in
and back out; the tree is byte-identical to HEAD afterwards.

Still true, and unchanged by this: the CI red that the first commit message
blamed on this code is a **separate flake**, and this test deliberately does not
touch it.
