### PR TITLE
test(list): make the todo#254 timeout guard actually run its probe

### DIFF
--- a/tests/scitex_agent_container/cli_pkg/test_status_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_status_cmds.py
@@ -29,8 +29,6 @@ production collaborators:
 
 from __future__ import annotations
 
-from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
-
 import importlib
 import json
 from pathlib import Path
@@ -44,6 +42,7 @@ from scitex_agent_container.cli_pkg.status_cmds import (
     health,
     status,
 )
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
 # ---------------------------------------------------------------------------
 # Real-collaborator fixtures (registry + spec.yaml on disk)
@@ -84,28 +83,30 @@ def _write_spec(parent: Path, name: str, *, body: str | None = None) -> Path:
     agent_dir.mkdir(parents=True, exist_ok=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        explicitize_yaml(body
-        if body is not None
-        else (
-            "apiVersion: scitex-agent-container/v3\n"
-            "kind: Agent\n"
-            "metadata: {}\n"
-            "spec:\n"
-            "  runtime: apptainer\n"
-            "  host: ${HOSTNAME}\n"
-            "  workdir: /home/agent/work\n"
-            "  apptainer:\n"
-            "    image: /x.sif\n"
-            "    binds: []\n"
-            "  claude:\n"
-            "    model: sonnet\n"
-            "  health:\n"
-            "    enabled: true\n"
-            "    interval: 60\n"
-            "  restart:\n"
-            "    policy: on-failure\n"
-            "    max_retries: 3\n"
-        ))
+        explicitize_yaml(
+            body
+            if body is not None
+            else (
+                "apiVersion: scitex-agent-container/v3\n"
+                "kind: Agent\n"
+                "metadata: {}\n"
+                "spec:\n"
+                "  runtime: apptainer\n"
+                "  host: ${HOSTNAME}\n"
+                "  workdir: /home/agent/work\n"
+                "  apptainer:\n"
+                "    image: /x.sif\n"
+                "    binds: []\n"
+                "  claude:\n"
+                "    model: sonnet\n"
+                "  health:\n"
+                "    enabled: true\n"
+                "    interval: 60\n"
+                "  restart:\n"
+                "    policy: on-failure\n"
+                "    max_retries: 3\n"
+            )
+        )
     )
     return spec
 
@@ -374,7 +375,10 @@ def test_status_fleet_json_returns_agents_list(tmp_registry):
     runner = CliRunner()
     # Act
     result = runner.invoke(status, ["--json"])
-    data = json.loads(result.output)
+    # ``result.output`` folds stderr in (click 8.4 dropped mix_stderr), so an
+    # ambient WARN logged during config load lands AHEAD of the payload and
+    # json.loads dies at char 0. Parse the payload stream only.
+    data = json.loads(result.stdout)
     # Assert -- key exists and value is a list (possibly populated by
     # disk-defined agents discovered under ~/.scitex/agent-container).
     assert isinstance(data.get("agents"), list)
@@ -387,7 +391,8 @@ def test_status_fleet_json_includes_registered_agent(tmp_path, tmp_registry):
     runner = CliRunner()
     # Act
     result = runner.invoke(status, ["--json"])
-    data = json.loads(result.output)
+    # See the note above: parse stdout, not the stderr-folded ``output``.
+    data = json.loads(result.stdout)
     names = [row["name"] for row in data["agents"]]
     # Assert
     assert "fleet-agent" in names

--- a/tests/scitex_agent_container/test_cli.py
+++ b/tests/scitex_agent_container/test_cli.py
@@ -494,8 +494,24 @@ class TestListJsonTimeoutBudget:
     status="unknown" + liveness_unknown=True in the output row.
     """
 
+    # ``host`` is REQUIRED since the explicit-placement directive
+    # (2026-06-23). Without it ``load_config`` raises, ``_agent_list`` swallows
+    # that into ``cfg = None``, the agent never enters ``probe_targets``, and
+    # the fake probe below IS NEVER CALLED — while the row still reads
+    # status="unknown" for that unrelated reason. All three hanging-probe
+    # tests then passed while guarding nothing (measured 2026-08-07: 0 probe
+    # invocations). ``_run_fast_probe`` already carried ``host``; this fixture
+    # was missed. The ``calls`` counter below is the positive control that
+    # makes a repeat of that silent voiding FAIL instead of going green.
+    _SPEC = """apiVersion: scitex-agent-container/v3
+kind: Agent
+spec:
+  runtime: apptainer
+  host: ${HOSTNAME}
+"""
+
     @staticmethod
-    def _run_hanging_probe(tmp_path):
+    def _run_probe(tmp_path, probe_factory):
         import time
 
         from scitex_agent_container.cli_pkg import _helpers
@@ -504,35 +520,21 @@ class TestListJsonTimeoutBudget:
         rd = tmp_path / "test-remote"
         rd.mkdir()
         remote_cfg_path = rd / "test-remote.yaml"
-        # v3-realign: spec.remote removed; the agent-list-data probe still
-        # treats agents without a runtime PID as "remote-ish" (liveness
-        # unknown) — that's what this test exercises, so a minimal v3
-        # spec without spec.remote is sufficient.
-        remote_cfg_path.write_text(
-            explicitize_yaml("""apiVersion: scitex-agent-container/v3
-kind: Agent
-spec:
-  runtime: apptainer
-""")
-        )
+        remote_cfg_path.write_text(explicitize_yaml(TestListJsonTimeoutBudget._SPEC))
         ld = tmp_path / "test-local"
         ld.mkdir()
         local_cfg_path = ld / "test-local.yaml"
-        local_cfg_path.write_text(
-            explicitize_yaml("""apiVersion: scitex-agent-container/v3
-kind: Agent
-spec:
-  runtime: apptainer
-""")
-        )
+        local_cfg_path.write_text(explicitize_yaml(TestListJsonTimeoutBudget._SPEC))
+
+        calls = []
+
+        def _counting_probe(cfg):
+            calls.append(cfg)
+            return probe_factory(cfg)
 
         # PA-306: hand-rolled fake injection with explicit restore.
         saved_probe = getattr(_helpers, "probe_local_detail", None)
-        _helpers.probe_local_detail = lambda cfg: _LocalProbe(
-            running=_HangingRuntime().is_running(cfg),
-            runtime="HangingRuntime",
-            error=None,
-        )
+        _helpers.probe_local_detail = _counting_probe
         try:
             t0 = time.monotonic()
             rows = _helpers.get_agent_list_data(
@@ -546,19 +548,70 @@ spec:
                     delattr(_helpers, "probe_local_detail")
             else:
                 _helpers.probe_local_detail = saved_probe
-        return elapsed, rows
+        return elapsed, rows, len(calls)
 
-    def test_hanging_remote_probe_respects_timeout_budget(self, tmp_path):
-        """A hanging remote probe must not exceed the per-probe timeout."""
+    @classmethod
+    def _run_hanging_probe(cls, tmp_path):
+        return cls._run_probe(
+            tmp_path,
+            lambda cfg: _LocalProbe(
+                running=_HangingRuntime().is_running(cfg),
+                runtime="HangingRuntime",
+                error=None,
+            ),
+        )
+
+    @classmethod
+    def _run_instant_probe(cls, tmp_path):
+        """Baseline arm: identical call, only the hang removed."""
+        return cls._run_probe(
+            tmp_path,
+            lambda cfg: _LocalProbe(running=True, runtime="InstantRuntime", error=None),
+        )
+
+    def test_hanging_probe_actually_reaches_the_probe_path(self, tmp_path):
+        """Positive control for the whole hanging-probe suite.
+
+        The other tests are only meaningful if the fake probe RUNS. A spec
+        that fails validation silently skips it and every assertion below
+        still passes, so assert the invocation directly.
+        """
         # Arrange
         probe = self._run_hanging_probe
         # Act
-        elapsed, _rows = probe(tmp_path)
+        _elapsed, _rows, calls = probe(tmp_path)
         # Assert
-        # Bound: the 10s hang must be cut short by the 1s timeout.
-        assert elapsed < 3.0, (
-            f"get_agent_list_data blocked for {elapsed:.1f}s despite 1s "
-            "probe timeout — todo#254 regression re-introduced"
+        assert calls > 0, (
+            "the hanging probe was never invoked — get_agent_list_data "
+            "skipped the probe path (likely load_config rejected the "
+            "fixture spec), so the todo#254 timeout guards are VACUOUS"
+        )
+
+    def test_hanging_remote_probe_respects_timeout_budget(self, tmp_path):
+        """A hanging remote probe must not exceed the per-probe timeout."""
+        # Arrange: baseline arm measures the same call WITHOUT the hang, so
+        # the assertion charges the budget only for the hang. Asserting raw
+        # wall clock instead made this flaky — the non-probe work (config
+        # load, auth states, row build) reached 8.4s on a loaded CI runner
+        # and was charged to the 1s probe timeout, failing and passing on
+        # the SAME commit (1ebfb71f, 2026-08-06).
+        base_dir = tmp_path / "base"
+        base_dir.mkdir()
+        hang_dir = tmp_path / "hang"
+        hang_dir.mkdir()
+        baseline, _rows, _base_calls = self._run_instant_probe(base_dir)
+        # Act
+        elapsed, _rows, _calls = self._run_hanging_probe(hang_dir)
+        # Assert
+        # (that both arms reached the probe path is asserted separately by
+        # test_hanging_probe_actually_reaches_the_probe_path — the positive
+        # control that makes this comparison meaningful.)
+        overshoot = elapsed - baseline
+        # The 10s hang must cost no more than its 1s budget (+ pool overhead).
+        assert overshoot < 2.5, (
+            f"a hung probe added {overshoot:.1f}s over the {baseline:.1f}s "
+            f"baseline despite a 1s probe timeout — todo#254 regression "
+            f"re-introduced"
         )
 
     def test_hanging_remote_probe_marks_status_unknown(self, tmp_path):
@@ -566,7 +619,7 @@ spec:
         # Arrange
         probe = self._run_hanging_probe
         # Act
-        _elapsed, rows = probe(tmp_path)
+        _elapsed, rows, _calls = probe(tmp_path)
         # Assert
         remote_row = next(r for r in rows if r["name"] == "test-remote")
         assert remote_row["status"] == "unknown"
@@ -576,7 +629,7 @@ spec:
         # Arrange
         probe = self._run_hanging_probe
         # Act
-        _elapsed, rows = probe(tmp_path)
+        _elapsed, rows, _calls = probe(tmp_path)
         # Assert
         remote_row = next(r for r in rows if r["name"] == "test-remote")
         assert remote_row.get("liveness_unknown") is True

--- a/tests/scitex_agent_container/test_cli.py
+++ b/tests/scitex_agent_container/test_cli.py
@@ -435,12 +435,26 @@ class TestCLI:
 
 
 class _HangingRuntime:
-    """Fake runtime that simulates a hung probe (todo#254 regression)."""
+    """Fake runtime that simulates a hung probe (todo#254 regression).
+
+    ``release`` is set by the caller once the measurement window closes. The
+    probe still blocks far past the 1s budget while it is being timed -- that
+    is the point -- but a worker thread cannot outlive the test that started
+    it. ``pool.shutdown(wait=False)`` deliberately does not join these
+    threads, so an unconditional ``sleep(10)`` leaves them running inside the
+    xdist worker long after the test returned.
+    """
+
+    def __init__(self, release=None):
+        self._release = release
 
     def is_running(self, cfg):
         import time
 
-        time.sleep(10)  # longer than the probe timeout
+        if self._release is not None:
+            self._release.wait(10)  # longer than the probe timeout
+        else:
+            time.sleep(10)
         return True
 
 
@@ -511,7 +525,7 @@ spec:
 """
 
     @staticmethod
-    def _run_probe(tmp_path, probe_factory):
+    def _run_probe(tmp_path, probe_factory, release=None):
         import time
 
         from scitex_agent_container.cli_pkg import _helpers
@@ -543,6 +557,10 @@ spec:
             )
             elapsed = time.monotonic() - t0
         finally:
+            # Measurement window is closed: let any probe thread the pool
+            # abandoned return NOW rather than sleep out its full hang.
+            if release is not None:
+                release.set()
             if saved_probe is None:
                 if hasattr(_helpers, "probe_local_detail"):
                     delattr(_helpers, "probe_local_detail")
@@ -552,13 +570,18 @@ spec:
 
     @classmethod
     def _run_hanging_probe(cls, tmp_path):
+        import threading
+
+        release = threading.Event()
+        runtime = _HangingRuntime(release)
         return cls._run_probe(
             tmp_path,
             lambda cfg: _LocalProbe(
-                running=_HangingRuntime().is_running(cfg),
+                running=runtime.is_running(cfg),
                 runtime="HangingRuntime",
                 error=None,
             ),
+            release=release,
         )
 
     @classmethod

--- a/tests/scitex_agent_container/test_cli.py
+++ b/tests/scitex_agent_container/test_cli.py
@@ -168,7 +168,12 @@ class TestCLI:
         # Act
         result = runner.invoke(main, ["agents", "list", "--json"])
         # Assert
-        data = json.loads(result.output)
+        # ``result.output`` folds stderr in (click 8.4 dropped mix_stderr).
+        # This command walks the AMBIENT fleet, so a spec whose account has
+        # no saved snapshot logs a WARN during config load -- ahead of the
+        # payload -- and json.loads dies at char 0. Intermittently, because
+        # it depends on what is on disk. Parse the payload stream only.
+        data = json.loads(result.stdout)
         assert isinstance(data, dict) and "agents" in data
 
     def test_removed_ps_command_exits_nonzero(self):


### PR DESCRIPTION
## The red leg on develop was real, but it wasn't the regression it named

`tests` has been failing on develop at `1ebfb71f`:

```
FAILED TestListJsonTimeoutBudget::test_hanging_remote_probe_respects_timeout_budget
AssertionError: get_agent_list_data blocked for 8.4s despite 1s probe timeout
                — todo#254 regression re-introduced
```

That SHA ran three times: **success, failure, failure**. Same code, both
outcomes — so nothing regressed at that commit.

## What was actually wrong: the guard never ran its probe

Measured 2026-08-07 by counting invocations of the injected fake probe:
**0 calls.**

`spec.host` became REQUIRED with the explicit-placement directive
(2026-06-23). This fixture never declared it, so:

1. `load_config` raises
2. `_agent_list.get_agent_list_data` swallows it — `except Exception: pass` → `cfg = None`
3. an agent with `cfg is None` never enters `probe_targets`
4. **the fake hanging probe is never called**
5. the row still comes out `status="unknown"` / `liveness_unknown=True` — for
   the unrelated reason that its config failed to load

So all three hanging-probe tests passed while guarding nothing. They would
have stayed green with the todo#254 regression fully re-introduced.
`_run_fast_probe` in the same class already carried `host: ${HOSTNAME}`;
only this fixture was missed.

## And the assertion charged the wrong work

The 1s budget bounds only the probe fan-out. Everything else in the call —
config load, auth states, port claims, row build — is unbudgeted, but the
test asserted **raw wall clock** (`elapsed < 3.0`). On a loaded CI runner
that unbudgeted work reached 8.4s and was billed to the probe timeout.
Hence pass-and-fail on one SHA.

## Changes

- declare `host: ${HOSTNAME}` so the spec loads and the probe path runs
- count probe invocations and assert `> 0` in its own test — a repeat of this
  silent voiding now FAILS instead of going green
- assert the hang's **overshoot over an instant-probe baseline arm** measured
  in the same test, instead of absolute wall clock: self-calibrating against
  machine load, and it charges the budget only for the hang

## Verification

Probe invocations **0 → 6**. With the probe path live, the budget holds: a
10s hang under a 1s budget costs **1.40s** over baseline (mean of 3).

The new control was mutation-tested — removing `host:` again reproduces the
original defect and shows why nothing else caught it:

```
tests/scitex_agent_container/test_cli.py F.....
FAILED ...::test_hanging_probe_actually_reaches_the_probe_path
E   AssertionError: the hanging probe was never invoked ... guards are VACUOUS
E   assert 0 > 0
================= 1 failed, 5 passed =================
```

**5 passed while the probe never ran** — including the budget test and both
`unknown` assertions. Restored: `43 passed` for the whole file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVdDpWDEzJ4ABTv85hfbQF
