### PR TITLE
fix(runtimes): a boot fault must not throw away the screen that explains it

### DIFF
--- a/src/scitex_agent_container/runtimes/_pane_context_log.py
+++ b/src/scitex_agent_container/runtimes/_pane_context_log.py
@@ -1,38 +1,145 @@
-"""Emit a captured pane as CONTEXT at INFO, apart from the fault that names it.
+"""Report a pane-backed fault: one loud line, a DURABLE snapshot, a quiet tail.
 
-A pane tail is a transcription of ANOTHER session's screen. Carried inside the
-error record that reports a boot fault it inherits that record's level, and the
-log formatter stamps the level onto EVERY line — so a start that succeeded
-scrolls past as::
+Two rules, learned from two different operator reports, pull in opposite
+directions. This module is where they are reconciled, so every fault path can
+obey both by calling one function.
+
+**Rule 1 — a pane tail is CONTEXT, not a fault** (operator, 2026-07-23). A pane
+tail is a transcription of ANOTHER session's screen. Carried inside the error
+record that reports a boot fault it inherits that record's level, and the log
+formatter stamps the level onto EVERY line — so a start that succeeded scrolls
+past as::
 
     sac-start ERRO: TuiSessionRuntime: stale compose buffer ... Pane tail:
     ERRO: ✻ Running scheduled task (Jul 23 1:25am)
     ERRO: ❯ /compact
     SUCC: grant started
 
-Fourteen lines of someone else's UI, all labelled as failures, with the one
-line that IS the fault indistinguishable among them. Splitting the
-transcription into its own INFO record keeps the fault loud and its evidence
-quiet; the final SUCC/ERROR line stays the outcome.
+Fourteen lines of someone else's UI, all labelled as failures, with the one line
+that IS the fault indistinguishable among them. So the transcription is logged
+as its own INFO record.
 
-The fault message itself is unchanged and stays at whatever level it earned —
-"the compose buffer did not clear after 8 attempts" is a real condition and
-belongs at error.
+**Rule 2 — the evidence must SURVIVE that demotion** (operator, 2026-08-08,
+card ``sac-boot-failure-drops-its-own-pane-evidence-20260808``). Rule 1 alone
+throws the evidence away: ``sac-start`` renders at a level that shows ERRO and
+drops INFO, so the operator got two boot faults and no screen at all::
+
+    ERRO: TuiSessionRuntime: stale compose buffer for tui-... did NOT clear ...
+    ERRO: TuiSessionRuntime: startup_prompt ... stayed pasted-but-UNSENT ...
+    SUCC: scitex-agent-container started
+
+「まあやはりまずはログを取ることからかと。ターミナルのスナップショットぐらい
+取れると思うんですよね。」 — and the tail was only ever 14 rows anyway, a tail
+rather than a snapshot.
+
+:func:`log_pane_fault` satisfies both: it writes the FULL pane to a file first,
+names that file INSIDE the single-line fault record (so the loud line is
+self-sufficient at any console level), then logs the tail at INFO for the reader
+who is already looking. A write that fails says so in that same loud line — a
+snapshot that silently did not happen would be worse than none, because the
+absence would read as "there was nothing to see".
 """
 
 from __future__ import annotations
 
 import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
 
 #: Rendered when the caller has no pane to show. A pane tail that is empty
 #: because the session was already gone is evidence too, and silently logging
 #: a blank record would read as "nothing was wrong here".
 NO_PANE_CAPTURED = "(nothing captured)"
 
+#: Directory under the runtime base that collects every pane snapshot, one
+#: append-only file per tmux session. Deliberately NOT each agent's own state
+#: dir: that dir is project-scope dependent (see
+#: ``tui_session.state_dir_for_config``) and cannot be resolved from a session
+#: name alone, so guessing it would sometimes write the evidence somewhere
+#: other than where this docstring promises. One predictable tree, greppable
+#: across every agent, is the honest trade.
+SNAPSHOT_SUBDIR = "pane-faults"
+
 _PANE_CONTEXT_TEMPLATE = (
     "TuiSessionRuntime: pane tail for %s — a copy of that session's screen, "
     "logged as context for the message above (not itself a fault):\n%s"
 )
+
+#: Appended to every fault message so the loud record names its own evidence.
+_SNAPSHOT_SUFFIX = " Full pane snapshot: %s"
+
+
+@dataclass(frozen=True)
+class PaneSnapshot:
+    """Where a pane snapshot was meant to land, and whether it did.
+
+    Three-valued on purpose: ``path`` set means it landed, ``error`` set means
+    it did not and says why, and ``target`` is populated either way so a
+    failure can still tell the reader WHERE to look (a bare ``None`` would
+    leave the fault line unable to say anything useful).
+    """
+
+    target: Path
+    path: Path | None = None
+    error: str | None = None
+
+    def describe(self) -> str:
+        """One-line rendering for the fault record — never empty."""
+        if self.path is not None:
+            return str(self.path)
+        return f"NOT SAVED to {self.target} ({self.error or 'unknown error'})"
+
+
+def snapshot_path_for(session_name: str, *, root: Path | None = None) -> Path:
+    """Return the append-only snapshot file for ``session_name``.
+
+    ``root`` defaults to the sac runtime base, so relocating the runtime tree
+    (``SCITEX_AGENT_CONTAINER_RUNTIME_DIR``) moves the snapshots with it rather
+    than stranding them on a full filesystem.
+    """
+    if root is None:
+        from .._runtime_paths import runtime_base_dir
+
+        root = runtime_base_dir()
+    # A session name reaches us from a caller, not from a user prompt, but it
+    # ends up as a filename — so strip anything that could climb out of the
+    # snapshot dir rather than trusting the caller to have been careful.
+    safe = session_name.replace("/", "_").replace("\\", "_").strip(".") or "unnamed"
+    return Path(root) / SNAPSHOT_SUBDIR / f"{safe}.log"
+
+
+def write_pane_snapshot(
+    session_name: str,
+    pane: str,
+    *,
+    root: Path | None = None,
+    time_fn: Callable[[], float] = time.time,
+) -> PaneSnapshot:
+    """Append the FULL captured pane, under a timestamped header.
+
+    Append rather than one-file-per-fault: a boot typically trips more than one
+    fault, and reading them in order in a single file is how the sequence
+    ("the clear gave up, THEN the submit never landed") becomes visible.
+
+    Never raises. A failure to record evidence must not replace the fault the
+    caller was in the middle of reporting — it is returned instead, and
+    :func:`log_pane_fault` prints it on the same loud line.
+    """
+    target = snapshot_path_for(session_name, root=root)
+    stamp = time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime(time_fn()))
+    body = pane if pane else NO_PANE_CAPTURED
+    header = f"===== {stamp} {session_name} ====="
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as fh:
+            fh.write(f"{header}\n{body}")
+            if not body.endswith("\n"):
+                fh.write("\n")
+        return PaneSnapshot(target=target, path=target)
+    except OSError as exc:
+        return PaneSnapshot(target=target, error=f"{type(exc).__name__}: {exc}")
 
 
 def pane_tail(pane: str, lines: int = 14) -> str:
@@ -58,8 +165,39 @@ def log_pane_context(
     log.info(_PANE_CONTEXT_TEMPLATE, name, tail if tail else NO_PANE_CAPTURED)
 
 
+def log_pane_fault(
+    log: logging.Logger,
+    name: str,
+    pane: str,
+    message: str,
+    *args: Any,
+    lines: int = 14,
+    root: Path | None = None,
+    write_fn: Callable[..., PaneSnapshot] = write_pane_snapshot,
+) -> PaneSnapshot:
+    """Report one pane-backed fault, with its evidence made durable.
+
+    ``message`` is the caller's own ``%``-style fault template and ``args`` its
+    arguments — unchanged, so each fault keeps saying what only it can say.
+    This function appends the snapshot location to that single line, then logs
+    the tail as INFO context.
+
+    Order matters: the snapshot is written BEFORE the fault is logged, so the
+    loud line can name a file that already exists.
+    """
+    snapshot = write_fn(name, pane, root=root)
+    log.error(message + _SNAPSHOT_SUFFIX, *args, snapshot.describe())
+    log_pane_context(log, name, pane, lines=lines)
+    return snapshot
+
+
 __all__ = [
     "NO_PANE_CAPTURED",
+    "SNAPSHOT_SUBDIR",
+    "PaneSnapshot",
     "log_pane_context",
+    "log_pane_fault",
     "pane_tail",
+    "snapshot_path_for",
+    "write_pane_snapshot",
 ]

--- a/src/scitex_agent_container/runtimes/_tui_compose.py
+++ b/src/scitex_agent_container/runtimes/_tui_compose.py
@@ -36,7 +36,7 @@ import re
 import time
 from typing import Callable
 
-from ._pane_context_log import log_pane_context
+from ._pane_context_log import log_pane_fault
 from ._pane_context_log import pane_tail as _pane_tail
 
 __all__ = [
@@ -238,7 +238,10 @@ def clear_compose_buffer(
         # A dev-channels / "Esc to cancel" modal is up: an Escape here would
         # CANCEL the launch and kill the session. Refuse to clear now — the
         # modal drainer must dismiss it (Enter → option 1) first.
-        log.error(
+        log_pane_fault(
+            log,
+            name,
+            pane,
             "TuiSessionRuntime: REFUSING compose-buffer clear for %s — a "
             "cancelable modal ('Esc to cancel', e.g. dev-channels) is on "
             "screen; sending Escape would CANCEL the launch and kill the "
@@ -248,7 +251,6 @@ def clear_compose_buffer(
             name,
             name,
         )
-        log_pane_context(log, name, pane)
         return False
     if is_fresh_boot_welcome_screen(pane):
         # BUG 3 — the fresh-boot welcome/model-info/promo screen is up and
@@ -272,13 +274,15 @@ def clear_compose_buffer(
         # attempts, and an Escape into it would cancel/kill the session.
         current = capture_fn(name)
         if _prompts.has_esc_cancel_modal(current):
-            log.error(
+            log_pane_fault(
+                log,
+                name,
+                current,
                 "TuiSessionRuntime: aborting compose-buffer clear for %s "
                 "mid-loop — a cancelable modal appeared; Escape would kill the "
                 "session. Let the modal drainer dismiss it first.",
                 name,
             )
-            log_pane_context(log, name, current)
             return False
         if is_fresh_boot_welcome_screen(current):
             # BUG 3 — (re)appeared mid-loop (a slow mount can outlast the
@@ -303,7 +307,10 @@ def clear_compose_buffer(
         # every Escape send (BUG 3 guard), so it would be misleading to blame
         # "the Ink TUI kept dropping the clear keystroke" — no keystroke was
         # ever sent. The welcome screen itself never released within budget.
-        log.error(
+        log_pane_fault(
+            log,
+            name,
+            last_pane,
             "TuiSessionRuntime: compose-buffer clear for %s gave up after "
             "%d attempts — the fresh-boot welcome/model-info screen never "
             "cleared within the wait budget, so no Escape was sent at all "
@@ -314,10 +321,12 @@ def clear_compose_buffer(
             max_attempts,
             name,
         )
-        log_pane_context(log, name, last_pane)
         return False
 
-    log.error(
+    log_pane_fault(
+        log,
+        name,
+        last_pane,
         "TuiSessionRuntime: stale compose buffer for %s did NOT clear after "
         "%d attempts of %r — the Ink TUI kept dropping the clear keystroke (or "
         "new text keeps arriving). Boot will proceed (verify_submit_by_advancement "
@@ -328,7 +337,6 @@ def clear_compose_buffer(
         list(_COMPOSE_CLEAR_KEYS),
         name,
     )
-    log_pane_context(log, name, last_pane)
     return False
 
 
@@ -451,7 +459,10 @@ def verify_submit_by_advancement(
         # 2d — not advanced; loop to next attempt (re-checks idle).
 
     pane = capture_fn(name)
-    log.error(
+    log_pane_fault(
+        log,
+        name,
+        pane or last_pane,
         "TuiSessionRuntime: startup_prompt for %s stayed pasted-but-UNSENT "
         "after %d wait-for-idle Enter attempts — the Ink TUI keeps dropping "
         "Enter (or the pane never left BUSY). Attach to inspect/recover: "
@@ -460,5 +471,4 @@ def verify_submit_by_advancement(
         max_resends,
         name,
     )
-    log_pane_context(log, name, pane or last_pane)
     return False

--- a/src/scitex_agent_container/runtimes/_tui_drain.py
+++ b/src/scitex_agent_container/runtimes/_tui_drain.py
@@ -31,7 +31,7 @@ import time
 from typing import Callable
 
 from . import prompts as _prompts
-from ._pane_context_log import log_pane_context
+from ._pane_context_log import log_pane_fault
 
 __all__ = [
     "drain_modals_until_ready",
@@ -150,7 +150,10 @@ def drain_modals_until_ready(
         # Fail FAST on session death — a dead session can never reach ready;
         # polling out the whole window here is a silent stall.
         if not exists_fn(name):
-            log.error(
+            log_pane_fault(
+                log,
+                name,
+                last_pane,
                 "TuiSessionRuntime: boot-drain ABORTED for %s — the inner "
                 "claude process EXITED during boot (tmux session gone), so it "
                 "can never reach ready. This is NOT a login wall or a timeout; "
@@ -159,7 +162,6 @@ def drain_modals_until_ready(
                 name,
                 name,
             )
-            log_pane_context(log, name, last_pane)
             return False
         pane = capture_fn(name)
         if pane.strip():
@@ -175,7 +177,10 @@ def drain_modals_until_ready(
             continue
         n = resends.get(modal, 0)
         if n >= max_resends:
-            log.error(
+            log_pane_fault(
+                log,
+                name,
+                last_pane or pane,
                 "TuiSessionRuntime: boot-drain STUCK on modal %r for %s — its "
                 "keystrokes did NOT dismiss it after %d verified resends. The "
                 "detector/keys in runtimes/prompts.py are likely stale for this "
@@ -186,7 +191,6 @@ def drain_modals_until_ready(
                 n,
                 name,
             )
-            log_pane_context(log, name, last_pane or pane)
             return False
         # BUG 2 — wait for the pane to SETTLE before sending keys, so a large
         # --continue replay's re-render race does not eat them. Re-detect after
@@ -233,7 +237,10 @@ def drain_modals_until_ready(
             "Session has EXITED — the inner command died (read the last pane "
             "for the cause; this is NOT a credential/login problem)."
         )
-    log.error(
+    log_pane_fault(
+        log,
+        name,
+        last_pane,
         "TuiSessionRuntime: boot-drain window (%.0fs) elapsed for %s without a "
         "ready signal. %s Reproduce live: `tmux attach -t %s`.",
         timeout_s,
@@ -241,7 +248,6 @@ def drain_modals_until_ready(
         diagnosis,
         name,
     )
-    log_pane_context(log, name, last_pane)
     return False
 
 

--- a/tests/scitex_agent_container/runtimes/test__pane_context_log.py
+++ b/tests/scitex_agent_container/runtimes/test__pane_context_log.py
@@ -13,6 +13,19 @@ lines::
 The condition itself is real and stays at ERROR. What moves is the
 transcription of ANOTHER session's screen: its own record, at INFO.
 
+...and the evidence must SURVIVE that move (operator, 2026-08-08, card
+``sac-boot-failure-drops-its-own-pane-evidence-20260808``). ``sac-start``
+renders at a level that shows ERRO and drops INFO, so demoting the pane deleted
+it from the only output the operator reads::
+
+    ERRO: TuiSessionRuntime: stale compose buffer for tui-... did NOT clear ...
+    ERRO: TuiSessionRuntime: startup_prompt ... stayed pasted-but-UNSENT ...
+    SUCC: scitex-agent-container started
+
+Two faults, no screen. So the second half of this file asserts the other
+direction: the full pane is written to a FILE, and the single loud line names
+that file — including when the write fails.
+
 Real callables (a scripted ``capture_fn`` + recording ``send_keys_fn``), no
 mocks — same fakes as ``test_tui_session_clear_compose.py``.
 """
@@ -21,11 +34,19 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
 
 from scitex_agent_container.runtimes._pane_context_log import (
     NO_PANE_CAPTURED,
+    SNAPSHOT_SUBDIR,
+    PaneSnapshot,
     log_pane_context,
+    log_pane_fault,
     pane_tail,
+    snapshot_path_for,
+    write_pane_snapshot,
 )
 from scitex_agent_container.runtimes._tui_compose import (
     _COMPOSE_CLEAR_KEYS,
@@ -174,3 +195,179 @@ def test_pane_tail_keeps_only_the_last_rows() -> None:
     tail = pane_tail(pane, lines=3)
     # Assert
     assert tail == "row27\nrow28\nrow29"
+
+
+# ---------------------------------------------------------------------------
+# ...and the evidence SURVIVES that demotion: a durable snapshot, named loudly
+# ---------------------------------------------------------------------------
+
+#: A pane taller than the 14-row tail, so "the tail carried it" can never be
+#: mistaken for "the snapshot carried it". Row 0 is reachable ONLY from the file.
+_TALL_PANE = "\n".join(f"row{i}" for i in range(40))
+_ONLY_IN_THE_FULL_PANE = "row0"
+
+#: What the loud line says when the snapshot could not be written.
+_NOT_SAVED = "NOT SAVED"
+
+
+def _fault(log, name, pane, *, root=None) -> PaneSnapshot:
+    """Drive one fault through the helper every real call site now uses."""
+    return log_pane_fault(log, name, pane, "boot fault for %s", name, root=root)
+
+
+@pytest.fixture
+def tall_pane_snapshot(tmp_path) -> PaneSnapshot:
+    """One fault reported against ``_TALL_PANE``, written under ``tmp_path``."""
+    log = logging.getLogger("test-pane-snapshot")
+    return _fault(log, "grant", _TALL_PANE, root=tmp_path)
+
+
+@pytest.fixture
+def blocked_root(tmp_path) -> Path:
+    """A root whose snapshot dir CANNOT be created — a file occupies its path."""
+    (tmp_path / SNAPSHOT_SUBDIR).write_text("not a directory", encoding="utf-8")
+    return tmp_path
+
+
+def test_the_fault_line_names_the_snapshot_file(caplog) -> None:
+    # Arrange — the operator reads a console that shows ERRO and drops INFO, so
+    # the loud line must be self-sufficient about where the screen went.
+    sender = _RecordingSend()
+    # Act
+    _exhaust_the_clear(caplog, sender)
+    # Assert
+    expected = str(snapshot_path_for("grant"))
+    assert any(expected in m for m in _records_at(caplog, logging.ERROR))
+
+
+def test_a_reported_fault_writes_its_snapshot(tall_pane_snapshot) -> None:
+    # Arrange — the fixture already reported one fault.
+    # Act
+    path = tall_pane_snapshot.path
+    # Assert
+    assert path is not None and path.is_file()
+
+
+def test_the_snapshot_holds_rows_the_tail_would_have_dropped(
+    tall_pane_snapshot,
+) -> None:
+    # Arrange — 40 rows; the INFO tail shows only the last 14.
+    # Act
+    written = tall_pane_snapshot.path.read_text(encoding="utf-8")
+    # Assert
+    assert _ONLY_IN_THE_FULL_PANE in written
+
+
+def test_the_tail_alone_would_have_dropped_those_rows() -> None:
+    # Arrange — guards the test above: if the tail happened to include row0,
+    # its assertion would pass without the snapshot doing any work.
+    pane = _TALL_PANE
+    # Act
+    tail = pane_tail(pane)
+    # Assert
+    assert _ONLY_IN_THE_FULL_PANE not in tail
+
+
+def test_the_snapshot_lands_under_the_runtime_root(tmp_path) -> None:
+    # Arrange
+    session = "tui-grant"
+    # Act
+    path = snapshot_path_for(session, root=tmp_path)
+    # Assert
+    assert path == tmp_path / SNAPSHOT_SUBDIR / "tui-grant.log"
+
+
+def test_a_second_fault_keeps_the_first_one(tmp_path) -> None:
+    # Arrange — a boot usually trips more than one fault and the SEQUENCE is
+    # the diagnosis, so an overwrite would leave only the last one.
+    log = logging.getLogger("test-pane-snapshot-append")
+    _fault(log, "grant", "first pane\n", root=tmp_path)
+    # Act
+    snapshot = _fault(log, "grant", "second pane\n", root=tmp_path)
+    # Assert
+    assert "first pane" in snapshot.path.read_text(encoding="utf-8")
+
+
+def test_a_second_fault_also_records_itself(tmp_path) -> None:
+    # Arrange
+    log = logging.getLogger("test-pane-snapshot-append")
+    _fault(log, "grant", "first pane\n", root=tmp_path)
+    # Act
+    snapshot = _fault(log, "grant", "second pane\n", root=tmp_path)
+    # Assert
+    assert "second pane" in snapshot.path.read_text(encoding="utf-8")
+
+
+def test_an_empty_pane_is_still_recorded_as_evidence(tmp_path) -> None:
+    # Arrange — a session that already died leaves nothing to capture, and THAT
+    # is the finding. A zero-byte record would read as "nothing was wrong here".
+    log = logging.getLogger("test-pane-snapshot-empty")
+    # Act
+    snapshot = _fault(log, "grant", "", root=tmp_path)
+    # Assert
+    assert NO_PANE_CAPTURED in snapshot.path.read_text(encoding="utf-8")
+
+
+def test_a_failed_write_is_reported_as_unsaved(blocked_root) -> None:
+    # Arrange — silently skipping would be the worst outcome: the absent
+    # snapshot would read as "there was nothing to see".
+    log = logging.getLogger("test-pane-snapshot-failed")
+    # Act
+    snapshot = _fault(log, "grant", _TALL_PANE, root=blocked_root)
+    # Assert
+    assert snapshot.path is None
+
+
+def test_a_failed_write_says_why(blocked_root) -> None:
+    # Arrange
+    log = logging.getLogger("test-pane-snapshot-failed")
+    # Act
+    snapshot = _fault(log, "grant", _TALL_PANE, root=blocked_root)
+    # Assert
+    assert snapshot.error
+
+
+def test_a_failed_write_names_the_target_on_the_loud_line(blocked_root, caplog) -> None:
+    # Arrange — the reader must still learn WHERE it was supposed to land.
+    log = logging.getLogger("test-pane-snapshot-failed-loud")
+    # Act
+    with caplog.at_level(logging.DEBUG, logger="test-pane-snapshot-failed-loud"):
+        snapshot = _fault(log, "grant", _TALL_PANE, root=blocked_root)
+    # Assert
+    assert any(
+        _NOT_SAVED in m and str(snapshot.target) in m
+        for m in _records_at(caplog, logging.ERROR)
+    )
+
+
+def test_a_failed_write_never_raises_over_the_fault_it_reports(
+    blocked_root,
+) -> None:
+    # Arrange — losing the evidence must not also lose the fault.
+    pane = _TALL_PANE
+    # Act
+    snapshot = write_pane_snapshot("grant", pane, root=blocked_root)
+    # Assert
+    assert isinstance(snapshot, PaneSnapshot)
+
+
+def test_the_snapshot_filename_cannot_climb_out_of_its_directory(tmp_path) -> None:
+    # Arrange — the session name becomes a filename.
+    session = "../../escape"
+    # Act
+    path = snapshot_path_for(session, root=tmp_path)
+    # Assert
+    assert path.parent == tmp_path / SNAPSHOT_SUBDIR
+
+
+def test_the_loud_line_still_carries_no_pane_content(tmp_path, caplog) -> None:
+    # Arrange — the 2026-07-23 fix must not regress: the ERROR record names the
+    # file, it does not paste the screen back into it.
+    log = logging.getLogger("test-pane-snapshot-quiet")
+    # Act
+    with caplog.at_level(logging.DEBUG, logger="test-pane-snapshot-quiet"):
+        _fault(log, "grant", _TALL_PANE, root=tmp_path)
+    # Assert
+    assert not any(
+        _ONLY_IN_THE_FULL_PANE in m for m in _records_at(caplog, logging.ERROR)
+    )


### PR DESCRIPTION
## What the operator saw

`sac-start scitex-agent-container`, 2026-08-08:

```
ERRO: TuiSessionRuntime: stale compose buffer for tui-scitex-agent-container did NOT clear after 5 attempts of ['Escape', 'Escape'] ...
ERRO: TuiSessionRuntime: startup_prompt for tui-scitex-agent-container stayed pasted-but-UNSENT after 8 wait-for-idle Enter attempts ...
SUCC: scitex-agent-container started
```

Two boot faults, and not one line of the screen that would explain either.
The operator's reply was the whole brief: 「まあやはりまずはログを取ることからかと。ターミナルのスナップショットぐらい取れると思うんですよね。」

## Why the evidence was missing

Both paths **did** capture the pane. They hand it to `log_pane_context`, which logs it at **INFO**. `sac-start` renders a level that shows `ERRO` and drops `INFO`, so the fault survived and its evidence was thrown away — at exactly the moment it was needed.

The INFO demotion is not the bug. It was added deliberately (2026-07-23) because an inlined pane tail made the formatter stamp `ERRO:` onto fourteen lines of *another session's* UI, burying the one line that was the actual fault. That reasoning still holds. What was missing is that the evidence has to **survive** the demotion.

Second defect on the same path: `pane_tail()` keeps the last 14 non-empty rows. Even when visible, that is a tail, not a snapshot.

## The change

`log_pane_fault` reconciles both rules, and every fault path now goes through it:

1. Write the **full** pane to `<runtime>/pane-faults/<session>.log` **first**.
2. Name that file **inside** the single-line fault record, so the loud line is self-sufficient at any console level.
3. Log the 14-row tail at INFO exactly as before.

A write that fails is reported on that same loud line — `NOT SAVED to <path> (<reason>)` — rather than skipped. A snapshot that silently did not happen is worse than none, because its absence reads as "there was nothing to see". `write_pane_snapshot` returns a `PaneSnapshot` (`target` / `path` / `error` as named fields) so no caller infers meaning from a bare `None`, and it never raises over the fault it was called to document.

It appends rather than writing one file per fault: a boot usually trips more than one, and the sequence — the clear gave up, *then* the submit never landed — is the diagnosis.

All eight fault sites in `_tui_compose.py` and `_tui_drain.py` now call it, replacing the duplicated `log.error()` + `log_pane_context()` pair.

### Why not each agent's own state dir

`state_dir_for_config` is project-scope dependent and cannot be resolved from a session name alone, so deriving it here would sometimes put the evidence somewhere other than where the message promises. One predictable tree, greppable across every agent, honours the relocation knob (`SCITEX_AGENT_CONTAINER_RUNTIME_DIR`) and does not lie about where it wrote.

## Tests

22 in `tests/scitex_agent_container/runtimes/test__pane_context_log.py`, all passing — including that the loud line still carries **no** pane content (the 2026-07-23 fix must not regress), that the snapshot holds rows the tail would have dropped, and that a failed write is named rather than swallowed.

```
22 passed in 4.11s
```

Pre-existing and unrelated: `test__mcp_spec_env.py` / `test__sdk_common.py` report 3 failed + 19 errors **in this container on untouched develop as well** (identical counts and test ids) — `SAC_SPEC_ENV_KEYS` names `SCITEX_AGENT_CONTAINER_AGENT`, which is unset here. Tracked separately as `sac-spec-env-contract-broken-in-my-own-container-20260808`.

## Cards

- Fixes `sac-boot-failure-drops-its-own-pane-evidence-20260808`
- Unblocks `sac-agent-dies-unattended-operator-restarts-by-hand-20260808` (diagnosing a death with no capture is guessing)
- Unblocks the operator's own hypothesis — that Escape/Enter get dropped while claude is compacting — which is untestable until a real capture exists
