### PR TITLE
fix(runtimes): bind the operator's message store, so a restart stops losing it

### DIFF
--- a/src/scitex_agent_container/runtimes/_p3a_default_binds.py
+++ b/src/scitex_agent_container/runtimes/_p3a_default_binds.py
@@ -84,6 +84,25 @@ _FLEET_DEFAULT_BINDS: tuple[str, ...] = (
     # in-container stat confirmed one directory / two names before this went
     # fleet-wide.
     "~/.scitex/cards:/home/agent/.scitex/cards:rw",
+    # The operator's OWN MESSAGE HISTORY — third store to pay the toll above,
+    # and the one whose absence he felt directly. On 2026-08-08 he asked whether
+    # I remembered eleven things he had sent an hour earlier; my previous run had
+    # answered every one of them, and my restarted run could find none. He
+    # forwarded the whole conversation back by hand: 「忘れている、思い出せない、
+    # となると結構辛いです。」
+    #
+    # cct had done its part correctly — it migrated that day to the
+    # scitex-standard deterministic path (ts/lib/config.ts::resolveStateDir,
+    # ~/.scitex/claude-code-telegrammer/runtime/<agent>), whose own docstring
+    # names "a drifting default path opened a fresh empty DB and lost the
+    # operator's message history" as the reason it exists. sac never grew the
+    # matching bind, so that store landed OVERLAY-LOCAL — the exact shape the
+    # cards note above records from 2026-07-16, one store later.
+    #
+    # Bound at the PACKAGE root (not .../runtime/<agent>) so the per-agent
+    # subdir cct creates on first boot lands on the host rather than in the
+    # overlay; a bind of a not-yet-existing leaf would skip silently.
+    "~/.scitex/claude-code-telegrammer:/home/agent/.scitex/claude-code-telegrammer:rw",
     # 2026-06-13 STOPGAP (lead a2a b6f3916c) — bind the host's working
     # ``scitex_agent_container`` source over the in-SIF install so
     # agents pick up new CLI surface (e.g., ``sac pytest spartan run``

--- a/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
+++ b/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
@@ -72,6 +72,55 @@ def test_default_binds_for_host_skips_todo_bind_when_host_dir_missing(
     assert not any("/.scitex/todo:" in b for b in binds)
 
 
+def test_default_binds_for_host_returns_telegrammer_bind_when_host_dir_exists(
+    fake_home: Path,
+) -> None:
+    # Arrange — the operator's message history. Without this bind cct's store
+    # lands overlay-local, which is how his 2026-08-08 messages became
+    # unreachable to the run that restarted after answering them.
+    (fake_home / ".scitex" / "claude-code-telegrammer").mkdir(parents=True)
+    # Act
+    binds = default_binds_for_host()
+    # Assert
+    assert any("/.scitex/claude-code-telegrammer:" in b for b in binds)
+
+
+def test_default_binds_for_host_skips_telegrammer_bind_when_host_dir_missing(
+    fake_home: Path,
+) -> None:
+    # Arrange — no .scitex subtree, so the candidate path does not exist and
+    # skip-if-missing applies (a silent no-op, per this module's contract).
+    # Act
+    binds = default_binds_for_host()
+    # Assert
+    assert not any("/.scitex/claude-code-telegrammer:" in b for b in binds)
+
+
+def test_the_telegrammer_bind_is_writable(fake_home: Path) -> None:
+    # Arrange — the poller WRITES every inbound message here; a read-only bind
+    # would fail in the one direction that matters and look mounted.
+    (fake_home / ".scitex" / "claude-code-telegrammer").mkdir(parents=True)
+    # Act
+    entry = next(
+        b for b in default_binds_for_host() if "/.scitex/claude-code-telegrammer:" in b
+    )
+    # Assert
+    assert entry.endswith(":rw")
+
+
+def test_the_telegrammer_bind_does_not_expose_the_scitex_parent(
+    fake_home: Path,
+) -> None:
+    # Arrange — ~/.scitex also holds agent-container/accounts (the credential
+    # store), so this store must pay its own narrow line rather than widening
+    # the parent. Guarding the rule the module comment states.
+    (fake_home / ".scitex" / "claude-code-telegrammer").mkdir(parents=True)
+    # Act
+    destinations = [b.split(":")[1] for b in default_binds_for_host() if ":" in b]
+    # Assert
+    assert "/home/agent/.scitex" not in destinations
+
+
 def test_default_binds_for_host_returns_tuple_for_caller_immutability(
     fake_home: Path,
 ) -> None:


### PR DESCRIPTION
## The report

2026-08-08. The operator asked whether I remembered the eleven things he had sent an hour earlier. My previous run had received and answered every one of them. My restarted run could find none — not in the channel store, not in a2a, not in the card DMs. He forwarded the whole conversation back by hand:

> 忘れている、思い出せない、となると結構辛いです。

Then, in one line, he diagnosed it himself:

> restart すると違う db になっていたりするのですかね。

## What was actually wrong

cct had done its part correctly. It migrated that morning (01:47) to the scitex-standard deterministic path — `~/.scitex/claude-code-telegrammer/runtime/<agent>`, `ts/lib/config.ts::resolveStateDir` — whose own docstring names *"a drifting default path opened a fresh empty DB and lost the operator's message history"* as the reason that resolver exists.

**sac never grew the matching bind.** `_FLEET_DEFAULT_BINDS` carries one line per store — `todo`, `cards` — and `/home/agent/.scitex` **itself is overlay-local**. So cct's new store landed in the container overlay instead of on the host.

The comment block immediately above this change records the identical failure hitting cards on 2026-07-16:

> Measured 2026-07-16 by scitex-cards: `db import` SUCCEEDED into the container overlay and reported success, because `/home/agent/.scitex/todo` was a bind but `/home/agent/.scitex` itself was overlay-local.

Same shape, one store later, and this time it was the operator's own message history.

## The change

One line, plus the reasoning that earns it:

```
"~/.scitex/claude-code-telegrammer:/home/agent/.scitex/claude-code-telegrammer:rw",
```

**The narrowness stays deliberately.** `~/.scitex` also holds `agent-container/accounts` — the credential store — so widening the parent would expose credentials to every agent. The existing comment states the rule: *"one bind per store; each new store pays its own explicit line. That cost is the feature."* This pays the toll for cct rather than removing it.

Bound at the **package root**, not at `.../runtime/<agent>`: the per-agent subdir is created by cct on first boot, and a bind whose source does not yet exist is skipped silently.

## Tests

Four, following the file's existing per-store convention — 23 pass:

- present when the host dir exists
- skipped when it does not (the documented skip-if-missing contract)
- **writable** — the poller writes every inbound message, so a read-only bind would fail in the only direction that matters while still looking mounted
- `/home/agent/.scitex` never appears as a bind destination, making the credential-exposure rule mechanical instead of remembered

## Verifying the rollout

**By inode, never by argv.** Skip-if-missing makes a bind for an absent host dir a silent no-op, so the argv cannot distinguish a bind that landed from one that was skipped. Compare `dev:inode` from inside a booted container against the host — exactly as the cards entry prescribes. The host dir must exist first, or this line does nothing.

## Scope

Card `sac-cct-store-diverges-across-restart-two-dbs-20260808`. This does **not** close it. The missing bind explains why the store is *exposed*; it does not yet explain why the 00:52–01:10 rows are absent from both the pre- and post-migration files (both were unbound, and the older one survived a month). That forensic question stays open on the card.

Related: the operator's standing directive `fleet-postgres-everywhere-one-store-convention-20260808` — one postgres per host, synced across hosts, the way scitex-cards already works — is the durable answer to "three SQLite files for one channel". This bind is the cheap protection for his history until that lands.
