### PR TITLE
feat(lifecycle): a write lease, so two instances of one agent cannot both write

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_relocate_lease.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_lease.py
@@ -1,0 +1,379 @@
+"""The write lease that makes two live instances of one agent unrepresentable.
+
+sac declares ``cardinality: singleton`` in a spec and enforces it with nothing.
+The identity lives in the spec and ``host:`` is just a field, so copying a spec
+to another machine and starting it produces TWO agents under ONE identity, with
+no error anywhere. That is the root of the 2026-08-07 card-store split-brain:
+two instances, one id, two postgres stores, neither seeing the other's writes.
+
+There is no "relocate" today — there is only copy-and-start, and copy-and-start
+makes two. This module is the primitive the relocate verb hands off.
+
+WHY A LEASE AND NOT A HANDSHAKE (operator, 2026-08-07). His first instinct was
+a mutual handshake: source confirms the target is up, target confirms the source
+is gone. Under a partition that either deadlocks (both wait) or double-commits
+(both proceed) — the same failure it is meant to prevent. He agreed to this
+instead: ONE token. Whoever holds it may write; nobody else can. Two holders is
+not a race to be detected, it is a state that cannot be expressed. Relocation is
+the ORDERED HANDOFF of that token, driven by the relocate command as
+coordinator, never by agreement between peers.
+
+WHY A FENCE AND NOT ONLY A TTL. A TTL alone assumes clocks agree. A source that
+is paused (a stopped container, a suspended laptop, an NTP step) can wake up
+believing its lease is still valid and write into a store the target now owns —
+and it does so honestly, with a token that WAS legitimate. So every lease also
+carries a FENCE: an integer that only ever increases, bumped on every handoff.
+A writer presents its fence; anything below the current one is refused. The
+stale holder is then locked out by arithmetic rather than by trusting its clock.
+The TTL decides when a lease may be RECLAIMED; the fence decides who may WRITE.
+
+SCOPE, and this is the operator's explicit requirement: the lease governs writes
+to the SHARED store only. Each host's LOCAL store keeps accepting local work
+while partitioned — every machine stays usable with no network — and
+reconciliation settles it afterwards. A lease that stopped local work would make
+a network outage into an outage of the whole fleet.
+
+Pure and fully injectable: no clock, no I/O, no store. Every function takes the
+current state and ``now`` and returns the next state plus a verdict, so the
+state machine is unit-testable without two hosts, and the persistence layer
+(state.db or the cards postgres) is a separate decision.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Final
+
+__all__ = [
+    "CODE_EXPIRED",
+    "CODE_HELD_BY_OTHER",
+    "CODE_NOT_HELD",
+    "CODE_OK",
+    "CODE_STALE_FENCE",
+    "CODE_UNKNOWN",
+    "CODE_WRONG_TOKEN",
+    "Lease",
+    "LeaseVerdict",
+    "check_write",
+    "claim",
+    "handoff",
+    "renew",
+]
+
+# Declared numeric codes. Documented meanings, stable across the boundary —
+# never a bare bool, and never a small exit code overloaded with a domain
+# meaning (1 and 2 already mean "generic failure" and "usage error" to every
+# CLI framework, so a renamed verb would impersonate a success value).
+CODE_OK: Final = 200
+CODE_NOT_HELD: Final = 404
+CODE_WRONG_TOKEN: Final = 403
+CODE_HELD_BY_OTHER: Final = 409
+CODE_EXPIRED: Final = 410
+CODE_STALE_FENCE: Final = 412
+#: The caller could not be told anything true — e.g. no lease record was
+#: supplied at all. Distinct from "no", on purpose: see LeaseVerdict.allowed.
+CODE_UNKNOWN: Final = 503
+
+
+@dataclass(frozen=True)
+class Lease:
+    """Who currently holds the right to write for ``agent``.
+
+    ``fence`` only ever increases. ``expires_at`` is an absolute epoch second,
+    not a duration, so a record carries its own deadline and no reader has to
+    know when it was issued.
+    """
+
+    agent: str
+    holder: str
+    token: str
+    expires_at: float
+    fence: int
+
+    def __post_init__(self) -> None:
+        # Validate where the value is BUILT, so a malformed lease fails here
+        # rather than three layers downstream in whatever tried to write.
+        if not self.agent:
+            raise ValueError("Lease.agent must be non-empty")
+        if not self.holder:
+            raise ValueError("Lease.holder must be non-empty")
+        if not self.token:
+            raise ValueError(
+                "Lease.token must be non-empty — an empty token would let any caller pass the token check"
+            )
+        if self.fence < 0:
+            raise ValueError(f"Lease.fence must be >= 0, got {self.fence}")
+
+    def is_expired(self, now: float) -> bool:
+        """True once ``now`` has passed the deadline. Exactly AT the deadline
+        the lease is already gone: a boundary that favours the holder would let
+        two writers overlap on one shared instant."""
+        return now >= self.expires_at
+
+
+@dataclass(frozen=True)
+class LeaseVerdict:
+    """The answer to every lease question, in ONE shape.
+
+    ``allowed`` is THREE-VALUED — ``True`` / ``False`` / ``None`` for "could not
+    determine". Collapsing unknown into either pole is the bug this fleet ships
+    most often: an unknown folded into ``True`` writes from two hosts, an
+    unknown folded into ``False`` stops an agent that was fine.
+
+    Callers must branch on ``allowed is True`` explicitly. ``if verdict:`` is a
+    truthiness test on the dataclass, not on the field, and would be true even
+    for a refusal — so this class deliberately does NOT define ``__bool__``.
+    """
+
+    allowed: bool | None
+    code: int
+    reason: str
+    holder: str | None = None
+    fence: int | None = None
+    expires_at: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.allowed not in (True, False, None):
+            raise ValueError(
+                f"LeaseVerdict.allowed must be True/False/None, got {self.allowed!r}"
+            )
+        if not self.reason:
+            raise ValueError(
+                "LeaseVerdict.reason must be non-empty — a refusal with no reason is not actionable"
+            )
+        if self.allowed is True and self.code != CODE_OK:
+            raise ValueError(
+                f"LeaseVerdict: allowed=True must carry CODE_OK, got {self.code}"
+            )
+        if self.allowed is None and self.code != CODE_UNKNOWN:
+            raise ValueError(
+                f"LeaseVerdict: allowed=None must carry CODE_UNKNOWN, got {self.code}"
+            )
+
+
+def _ok(lease: Lease, reason: str) -> LeaseVerdict:
+    return LeaseVerdict(
+        allowed=True,
+        code=CODE_OK,
+        reason=reason,
+        holder=lease.holder,
+        fence=lease.fence,
+        expires_at=lease.expires_at,
+    )
+
+
+def _no(code: int, reason: str, lease: Lease | None = None) -> LeaseVerdict:
+    return LeaseVerdict(
+        allowed=False,
+        code=code,
+        reason=reason,
+        holder=lease.holder if lease else None,
+        fence=lease.fence if lease else None,
+        expires_at=lease.expires_at if lease else None,
+    )
+
+
+def claim(
+    lease: Lease | None,
+    *,
+    agent: str,
+    holder: str,
+    token: str,
+    now: float,
+    ttl_s: float,
+) -> tuple[Lease | None, LeaseVerdict]:
+    """Take an unheld or EXPIRED lease. Returns ``(lease, verdict)``.
+
+    Refuses while another holder's lease is live — that refusal is the whole
+    point, and it is why a second copy-and-start cannot quietly become a second
+    writer. Re-claiming by the SAME holder is idempotent (it renews), so a
+    retrying coordinator is never punished for retrying.
+
+    The fence advances on every successful claim, including a reclaim after
+    expiry: the previous holder may still be alive and unaware, and must be
+    locked out even if its clock disagrees about when the lease ended.
+    """
+    if lease is not None and lease.agent != agent:
+        # UNKNOWN, not a refusal: this record says nothing about `agent` either
+        # way, and answering "no" would read as "someone else holds it" when in
+        # fact we were handed the wrong record. The caller must fix its lookup,
+        # not retry against a verdict it misread. Returns the lease untouched.
+        return lease, LeaseVerdict(
+            allowed=None,
+            code=CODE_UNKNOWN,
+            reason=(
+                f"lease record describes agent {lease.agent!r}, not {agent!r} — "
+                "cannot answer for an agent this record is not about"
+            ),
+        )
+    if lease is not None and not lease.is_expired(now) and lease.holder != holder:
+        return lease, _no(
+            CODE_HELD_BY_OTHER,
+            f"{agent}: held by {lease.holder!r} until {lease.expires_at} — {holder!r} may not write",
+            lease,
+        )
+    next_fence = 0 if lease is None else lease.fence + 1
+    granted = Lease(
+        agent=agent,
+        holder=holder,
+        token=token,
+        expires_at=now + ttl_s,
+        fence=next_fence,
+    )
+    was = (
+        "unheld"
+        if lease is None
+        else ("expired" if lease.is_expired(now) else "already ours")
+    )
+    return granted, _ok(
+        granted, f"{agent}: claimed by {holder!r} (previous state: {was})"
+    )
+
+
+def renew(
+    lease: Lease | None,
+    *,
+    holder: str,
+    token: str,
+    fence: int,
+    now: float,
+    ttl_s: float,
+) -> tuple[Lease | None, LeaseVerdict]:
+    """Extend a lease you already hold. Never resurrects an expired one.
+
+    An expired lease must go back through :func:`claim` so the fence advances —
+    letting renew revive it would hand a paused holder its old fence back, which
+    is exactly the writer the fence exists to exclude.
+    """
+    if lease is None:
+        return None, _no(CODE_NOT_HELD, f"no lease record for {holder!r} to renew")
+    if lease.holder != holder:
+        return lease, _no(
+            CODE_HELD_BY_OTHER, f"held by {lease.holder!r}, not {holder!r}", lease
+        )
+    if lease.token != token:
+        return lease, _no(
+            CODE_WRONG_TOKEN, f"token mismatch for holder {holder!r}", lease
+        )
+    if lease.fence != fence:
+        return lease, _no(
+            CODE_STALE_FENCE, f"fence {fence} != current {lease.fence}", lease
+        )
+    if lease.is_expired(now):
+        return lease, _no(
+            CODE_EXPIRED,
+            f"lease expired at {lease.expires_at}; re-claim it so the fence advances rather than renewing a dead lease",
+            lease,
+        )
+    extended = replace(lease, expires_at=now + ttl_s)
+    return extended, _ok(extended, f"{lease.agent}: renewed by {holder!r}")
+
+
+def handoff(
+    lease: Lease | None,
+    *,
+    from_holder: str,
+    token: str,
+    fence: int,
+    to_holder: str,
+    to_token: str,
+    now: float,
+    ttl_s: float,
+) -> tuple[Lease | None, LeaseVerdict]:
+    """Move the lease source -> target. THE single atomic point of a relocate.
+
+    Everything before this is reversible and everything after it is a cleanup:
+    before, the source still writes and the target is a harmless standby; after,
+    the target writes and the source is locked out by the bumped fence even
+    while its process is still alive. A crash between the two leaves exactly one
+    writer either way, which is the property the whole phase order exists for.
+
+    Refuses if the caller is not the current holder, presents the wrong token,
+    or presents a stale fence. Handing off an EXPIRED lease is refused too: the
+    coordinator has lost the authority it is trying to delegate, and should
+    re-claim (advancing the fence) before trying again.
+    """
+    if lease is None:
+        return None, _no(
+            CODE_NOT_HELD, f"no lease to hand from {from_holder!r} to {to_holder!r}"
+        )
+    if lease.holder != from_holder:
+        return lease, _no(
+            CODE_HELD_BY_OTHER, f"held by {lease.holder!r}, not {from_holder!r}", lease
+        )
+    if lease.token != token:
+        return lease, _no(
+            CODE_WRONG_TOKEN, f"token mismatch for holder {from_holder!r}", lease
+        )
+    if lease.fence != fence:
+        return lease, _no(
+            CODE_STALE_FENCE, f"fence {fence} != current {lease.fence}", lease
+        )
+    if lease.is_expired(now):
+        return lease, _no(
+            CODE_EXPIRED,
+            f"lease expired at {lease.expires_at}; the coordinator no longer holds what it is trying to hand over",
+            lease,
+        )
+    moved = Lease(
+        agent=lease.agent,
+        holder=to_holder,
+        token=to_token,
+        expires_at=now + ttl_s,
+        fence=lease.fence + 1,
+    )
+    return moved, _ok(
+        moved,
+        f"{lease.agent}: handed {from_holder!r} -> {to_holder!r} at fence {moved.fence}",
+    )
+
+
+def check_write(
+    lease: Lease | None,
+    *,
+    holder: str,
+    token: str,
+    fence: int,
+    now: float,
+) -> LeaseVerdict:
+    """May ``holder`` write to the SHARED store right now?
+
+    Returns ``allowed=None`` when there is no lease record at all. That is not a
+    refusal and not a permission — it is "this question has no answer here yet",
+    and a caller that folds it into either pole reintroduces the split-brain.
+    A fresh deployment with no lease row must decide deliberately (bootstrap a
+    lease, or refuse and say so), never inherit a default.
+    """
+    if lease is None:
+        return LeaseVerdict(
+            allowed=None,
+            code=CODE_UNKNOWN,
+            reason=f"no lease record for {holder!r} — cannot determine write authority; bootstrap a lease or refuse deliberately",
+        )
+    if lease.holder != holder:
+        return _no(
+            CODE_HELD_BY_OTHER, f"held by {lease.holder!r}, not {holder!r}", lease
+        )
+    if lease.token != token:
+        return _no(CODE_WRONG_TOKEN, f"token mismatch for holder {holder!r}", lease)
+    if fence < lease.fence:
+        return _no(
+            CODE_STALE_FENCE,
+            f"fence {fence} is behind current {lease.fence} — this holder was superseded while it was not looking",
+            lease,
+        )
+    if fence > lease.fence:
+        return _no(
+            CODE_STALE_FENCE,
+            f"fence {fence} is AHEAD of current {lease.fence} — the caller's record is not one this store issued",
+            lease,
+        )
+    if lease.is_expired(now):
+        return _no(
+            CODE_EXPIRED,
+            f"lease expired at {lease.expires_at}; stop writing and re-claim",
+            lease,
+        )
+    return _ok(
+        lease, f"{lease.agent}: {holder!r} holds the lease at fence {lease.fence}"
+    )

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_lease.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_lease.py
@@ -1,0 +1,523 @@
+"""Two live writers for one agent must be UNREPRESENTABLE, not merely detected.
+
+The 2026-08-07 split-brain: one identity, two hosts, two postgres stores,
+neither seeing the other's writes. Nothing was broken — sac simply has no way to
+say "only this instance may write", because `cardinality: singleton` is declared
+in a spec and enforced by nothing.
+
+These tests pin the two properties that make the lease worth having:
+
+  * a second holder is REFUSED while the first lease is live (the lease), and
+  * a holder that was superseded while paused is refused even if its clock says
+    otherwise (the fence).
+
+The fence is the one that catches the case a TTL cannot: a stopped container, a
+suspended laptop or an NTP step can hand a source a lease it honestly believes
+is valid. Arithmetic locks it out where clock comparison would not.
+
+Pure functions, explicit `now`, no mocks and no sleeping.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_lease import (
+    CODE_EXPIRED,
+    CODE_HELD_BY_OTHER,
+    CODE_NOT_HELD,
+    CODE_OK,
+    CODE_STALE_FENCE,
+    CODE_UNKNOWN,
+    CODE_WRONG_TOKEN,
+    Lease,
+    LeaseVerdict,
+    check_write,
+    claim,
+    handoff,
+    renew,
+)
+
+AGENT = "scitex-agent-container"
+SRC = "ywata-note-win"
+DST = "nas-03"
+T0 = 1_000_000.0
+TTL = 60.0
+
+
+@pytest.fixture
+def held() -> Lease:
+    """A live lease held by the source at fence 0, valid T0 .. T0+TTL."""
+    lease, _ = claim(None, agent=AGENT, holder=SRC, token="tok-src", now=T0, ttl_s=TTL)
+    assert lease is not None  # harness guard, not the behaviour under test
+    return lease
+
+
+# ---------------------------------------------------------------------------
+# claim — the refusal that prevents a second writer
+# ---------------------------------------------------------------------------
+
+
+def test_claim_grants_an_unheld_lease(held: Lease) -> None:
+    # Arrange: the fixture claimed against no prior lease.
+    lease = held
+    # Act
+    holder = lease.holder
+    # Assert
+    assert holder == SRC
+
+
+def test_a_first_claim_starts_the_fence_at_zero(held: Lease) -> None:
+    # Arrange
+    lease = held
+    # Act
+    fence = lease.fence
+    # Assert
+    assert fence == 0
+
+
+def test_claim_refuses_a_second_holder_while_the_lease_is_live(held: Lease) -> None:
+    # Arrange — this is the copy-and-start case that made two writers.
+    # Act
+    _, verdict = claim(
+        held, agent=AGENT, holder=DST, token="tok-dst", now=T0 + 1, ttl_s=TTL
+    )
+    # Assert
+    assert verdict.allowed is False
+
+
+def test_the_refused_second_holder_is_told_who_holds_it(held: Lease) -> None:
+    # Arrange
+    # Act
+    _, verdict = claim(
+        held, agent=AGENT, holder=DST, token="tok-dst", now=T0 + 1, ttl_s=TTL
+    )
+    # Assert
+    assert verdict.code == CODE_HELD_BY_OTHER
+
+
+def test_a_refused_claim_leaves_the_existing_lease_untouched(held: Lease) -> None:
+    # Arrange
+    # Act
+    after, _ = claim(
+        held, agent=AGENT, holder=DST, token="tok-dst", now=T0 + 1, ttl_s=TTL
+    )
+    # Assert
+    assert after == held
+
+
+def test_reclaiming_by_the_same_holder_is_idempotent(held: Lease) -> None:
+    # Arrange — a retrying coordinator must not be punished for retrying.
+    # Act
+    _, verdict = claim(
+        held, agent=AGENT, holder=SRC, token="tok-src", now=T0 + 1, ttl_s=TTL
+    )
+    # Assert
+    assert verdict.allowed is True
+
+
+def test_an_expired_lease_can_be_claimed_by_someone_else(held: Lease) -> None:
+    # Arrange — past the deadline the previous holder has no authority.
+    # Act
+    _, verdict = claim(
+        held, agent=AGENT, holder=DST, token="tok-dst", now=T0 + TTL + 1, ttl_s=TTL
+    )
+    # Assert
+    assert verdict.allowed is True
+
+
+def test_reclaiming_after_expiry_advances_the_fence(held: Lease) -> None:
+    # Arrange — the previous holder may still be alive and unaware. The bumped
+    # fence is what locks it out; without it, expiry alone trusts two clocks.
+    # Act
+    after, _ = claim(
+        held, agent=AGENT, holder=DST, token="tok-dst", now=T0 + TTL + 1, ttl_s=TTL
+    )
+    # Assert
+    assert after is not None and after.fence == held.fence + 1
+
+
+def test_a_lease_for_a_different_agent_answers_unknown(held: Lease) -> None:
+    # Arrange — the wrong record says nothing about this agent either way, and
+    # "no" would be misread as "someone else holds it".
+    # Act
+    _, verdict = claim(
+        held, agent="some-other-agent", holder=DST, token="t", now=T0, ttl_s=TTL
+    )
+    # Assert
+    assert verdict.allowed is None
+
+
+def test_a_lease_for_a_different_agent_is_coded_unknown(held: Lease) -> None:
+    # Arrange
+    # Act
+    _, verdict = claim(
+        held, agent="some-other-agent", holder=DST, token="t", now=T0, ttl_s=TTL
+    )
+    # Assert
+    assert verdict.code == CODE_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# expiry boundary
+# ---------------------------------------------------------------------------
+
+
+def test_a_lease_is_already_gone_at_its_deadline(held: Lease) -> None:
+    # Arrange — a boundary favouring the holder would let two writers overlap
+    # on one shared instant.
+    # Act
+    expired = held.is_expired(T0 + TTL)
+    # Assert
+    assert expired is True
+
+
+def test_a_lease_is_live_just_before_its_deadline(held: Lease) -> None:
+    # Arrange
+    # Act
+    expired = held.is_expired(T0 + TTL - 0.001)
+    # Assert
+    assert expired is False
+
+
+# ---------------------------------------------------------------------------
+# renew — extends, never resurrects
+# ---------------------------------------------------------------------------
+
+
+def test_renew_extends_the_deadline(held: Lease) -> None:
+    # Arrange
+    # Act
+    after, _ = renew(held, holder=SRC, token="tok-src", fence=0, now=T0 + 10, ttl_s=TTL)
+    # Assert
+    assert after is not None and after.expires_at == T0 + 10 + TTL
+
+
+def test_renew_keeps_the_fence_unchanged(held: Lease) -> None:
+    # Arrange — renewing is not a change of authority, so nothing is superseded.
+    # Act
+    after, _ = renew(held, holder=SRC, token="tok-src", fence=0, now=T0 + 10, ttl_s=TTL)
+    # Assert
+    assert after is not None and after.fence == held.fence
+
+
+def test_renew_refuses_a_different_holder(held: Lease) -> None:
+    # Arrange
+    # Act
+    _, verdict = renew(
+        held, holder=DST, token="tok-src", fence=0, now=T0 + 10, ttl_s=TTL
+    )
+    # Assert
+    assert verdict.code == CODE_HELD_BY_OTHER
+
+
+def test_renew_refuses_a_wrong_token(held: Lease) -> None:
+    # Arrange
+    # Act
+    _, verdict = renew(
+        held, holder=SRC, token="guessed", fence=0, now=T0 + 10, ttl_s=TTL
+    )
+    # Assert
+    assert verdict.code == CODE_WRONG_TOKEN
+
+
+def test_renew_refuses_a_stale_fence(held: Lease) -> None:
+    # Arrange
+    # Act
+    _, verdict = renew(
+        held, holder=SRC, token="tok-src", fence=99, now=T0 + 10, ttl_s=TTL
+    )
+    # Assert
+    assert verdict.code == CODE_STALE_FENCE
+
+
+def test_renew_never_resurrects_an_expired_lease(held: Lease) -> None:
+    # Arrange — reviving it would hand a paused holder its OLD fence back,
+    # which is exactly the writer the fence exists to exclude.
+    # Act
+    _, verdict = renew(
+        held, holder=SRC, token="tok-src", fence=0, now=T0 + TTL + 1, ttl_s=TTL
+    )
+    # Assert
+    assert verdict.code == CODE_EXPIRED
+
+
+def test_renew_without_a_lease_reports_not_held() -> None:
+    # Arrange
+    # Act
+    _, verdict = renew(None, holder=SRC, token="t", fence=0, now=T0, ttl_s=TTL)
+    # Assert
+    assert verdict.code == CODE_NOT_HELD
+
+
+# ---------------------------------------------------------------------------
+# handoff — the single atomic point of a relocate
+# ---------------------------------------------------------------------------
+
+
+def test_handoff_moves_the_lease_to_the_target(held: Lease) -> None:
+    # Arrange
+    # Act
+    after, _ = handoff(
+        held,
+        from_holder=SRC,
+        token="tok-src",
+        fence=0,
+        to_holder=DST,
+        to_token="tok-dst",
+        now=T0 + 5,
+        ttl_s=TTL,
+    )
+    # Assert
+    assert after is not None and after.holder == DST
+
+
+def test_handoff_advances_the_fence(held: Lease) -> None:
+    # Arrange — this is what locks the source out even while its process lives.
+    # Act
+    after, _ = handoff(
+        held,
+        from_holder=SRC,
+        token="tok-src",
+        fence=0,
+        to_holder=DST,
+        to_token="tok-dst",
+        now=T0 + 5,
+        ttl_s=TTL,
+    )
+    # Assert
+    assert after is not None and after.fence == held.fence + 1
+
+
+def test_the_source_cannot_write_after_the_handoff(held: Lease) -> None:
+    # Arrange — the property the whole phase order exists for: after the single
+    # atomic point there is exactly one writer, even mid-crash.
+    after, _ = handoff(
+        held,
+        from_holder=SRC,
+        token="tok-src",
+        fence=0,
+        to_holder=DST,
+        to_token="tok-dst",
+        now=T0 + 5,
+        ttl_s=TTL,
+    )
+    # Act
+    verdict = check_write(after, holder=SRC, token="tok-src", fence=0, now=T0 + 6)
+    # Assert
+    assert verdict.allowed is False
+
+
+def test_the_target_can_write_after_the_handoff(held: Lease) -> None:
+    # Arrange
+    after, _ = handoff(
+        held,
+        from_holder=SRC,
+        token="tok-src",
+        fence=0,
+        to_holder=DST,
+        to_token="tok-dst",
+        now=T0 + 5,
+        ttl_s=TTL,
+    )
+    # Act
+    verdict = check_write(after, holder=DST, token="tok-dst", fence=1, now=T0 + 6)
+    # Assert
+    assert verdict.allowed is True
+
+
+def test_handoff_refuses_a_caller_that_does_not_hold_the_lease(held: Lease) -> None:
+    # Arrange
+    # Act
+    _, verdict = handoff(
+        held,
+        from_holder=DST,
+        token="tok-src",
+        fence=0,
+        to_holder="third",
+        to_token="t",
+        now=T0 + 5,
+        ttl_s=TTL,
+    )
+    # Assert
+    assert verdict.code == CODE_HELD_BY_OTHER
+
+
+def test_handoff_refuses_an_expired_lease(held: Lease) -> None:
+    # Arrange — the coordinator no longer holds what it is trying to delegate.
+    # Act
+    _, verdict = handoff(
+        held,
+        from_holder=SRC,
+        token="tok-src",
+        fence=0,
+        to_holder=DST,
+        to_token="tok-dst",
+        now=T0 + TTL + 1,
+        ttl_s=TTL,
+    )
+    # Assert
+    assert verdict.code == CODE_EXPIRED
+
+
+def test_handoff_without_a_lease_reports_not_held() -> None:
+    # Arrange
+    # Act
+    _, verdict = handoff(
+        None,
+        from_holder=SRC,
+        token="t",
+        fence=0,
+        to_holder=DST,
+        to_token="t2",
+        now=T0,
+        ttl_s=TTL,
+    )
+    # Assert
+    assert verdict.code == CODE_NOT_HELD
+
+
+# ---------------------------------------------------------------------------
+# check_write — three-valued on purpose
+# ---------------------------------------------------------------------------
+
+
+def test_no_lease_record_answers_unknown_not_refusal() -> None:
+    # Arrange — folding this into False stops a healthy agent; folding it into
+    # True reintroduces the split-brain. It is neither.
+    # Act
+    verdict = check_write(None, holder=SRC, token="t", fence=0, now=T0)
+    # Assert
+    assert verdict.allowed is None
+
+
+def test_the_holder_may_write_while_the_lease_is_live(held: Lease) -> None:
+    # Arrange
+    # Act
+    verdict = check_write(held, holder=SRC, token="tok-src", fence=0, now=T0 + 1)
+    # Assert
+    assert verdict.allowed is True
+
+
+def test_a_stale_record_from_the_same_holder_is_refused_by_the_fence(
+    held: Lease,
+) -> None:
+    # Arrange — the case a TTL cannot catch and the holder check does not see.
+    # The source paused, its lease expired, and it re-claimed on waking. Its
+    # OLD in-memory record has the right NAME and the right TOKEN; only the
+    # fence betrays that the world moved on. A holder-name check passes here.
+    reclaimed, _ = claim(
+        held, agent=AGENT, holder=SRC, token="tok-src", now=T0 + TTL + 1, ttl_s=TTL
+    )
+    # Act
+    verdict = check_write(
+        reclaimed, holder=SRC, token="tok-src", fence=held.fence, now=T0 + TTL + 2
+    )
+    # Assert
+    assert verdict.code == CODE_STALE_FENCE
+
+
+def test_a_fence_ahead_of_the_store_is_refused(held: Lease) -> None:
+    # Arrange — a record this store never issued. Accepting it would let a
+    # caller invent authority by counting upward.
+    # Act
+    verdict = check_write(held, holder=SRC, token="tok-src", fence=7, now=T0 + 1)
+    # Assert
+    assert verdict.code == CODE_STALE_FENCE
+
+
+def test_an_expired_lease_refuses_writes(held: Lease) -> None:
+    # Arrange
+    # Act
+    verdict = check_write(held, holder=SRC, token="tok-src", fence=0, now=T0 + TTL + 1)
+    # Assert
+    assert verdict.code == CODE_EXPIRED
+
+
+def test_a_wrong_token_refuses_writes(held: Lease) -> None:
+    # Arrange
+    # Act
+    verdict = check_write(held, holder=SRC, token="guessed", fence=0, now=T0 + 1)
+    # Assert
+    assert verdict.code == CODE_WRONG_TOKEN
+
+
+# ---------------------------------------------------------------------------
+# the shapes validate themselves, where they are built
+# ---------------------------------------------------------------------------
+
+
+def test_a_lease_refuses_an_empty_token() -> None:
+    # Arrange: an empty token would let any caller pass the token check.
+    fields = dict(agent=AGENT, holder=SRC, token="", expires_at=T0, fence=0)
+
+    # Act
+    def build() -> Lease:
+        return Lease(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_lease_refuses_a_negative_fence() -> None:
+    # Arrange: the fence only ever increases, so a negative one is nonsense.
+    fields = dict(agent=AGENT, holder=SRC, token="t", expires_at=T0, fence=-1)
+
+    # Act
+    def build() -> Lease:
+        return Lease(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_verdict_refuses_a_permission_that_is_not_coded_ok() -> None:
+    # Arrange: allowed=True with a refusal code is the shape that lets a caller
+    # reading only one field draw the opposite conclusion.
+    fields = dict(allowed=True, code=CODE_EXPIRED, reason="contradictory")
+
+    # Act
+    def build() -> LeaseVerdict:
+        return LeaseVerdict(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_verdict_refuses_an_unknown_that_is_not_coded_unknown() -> None:
+    # Arrange: an unknown wearing a success code is how unknown becomes yes.
+    fields = dict(allowed=None, code=CODE_OK, reason="contradictory")
+
+    # Act
+    def build() -> LeaseVerdict:
+        return LeaseVerdict(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_verdict_refuses_an_empty_reason() -> None:
+    # Arrange: a refusal with no reason is not actionable.
+    fields = dict(allowed=False, code=CODE_EXPIRED, reason="")
+
+    # Act
+    def build() -> LeaseVerdict:
+        return LeaseVerdict(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_refusal_is_truthy_so_callers_must_read_the_field(held: Lease) -> None:
+    # Arrange — deliberately NO __bool__: `if verdict:` must not silently pass
+    # for a refusal. This test documents the trap rather than hiding it.
+    verdict = check_write(held, holder=DST, token="tok-dst", fence=0, now=T0 + 1)
+    # Act
+    truthy = bool(verdict)
+    # Assert
+    assert truthy is True


### PR DESCRIPTION
First piece of `sac agents relocate` — the primitive everything else hands off.

## The problem it removes

`cardinality: singleton` is declared in a spec and **enforced by nothing**. The identity lives in the spec and `host:` is just a field, so copying a spec to another machine and starting it produces two agents under one identity, silently. That is the root of the 2026-08-07 split-brain: one id, two hosts, two postgres stores, neither seeing the other's writes.

There is no "relocate" today — only copy-and-start, and copy-and-start makes two.

## A lease, not a handshake

The operator's first instinct (2026-08-07) was a mutual handshake: source confirms the target is up, target confirms the source is gone. Under a partition that deadlocks (both wait) or double-commits (both proceed) — the failure it exists to prevent. He agreed to **one token** instead: whoever holds it may write.

Two holders is not a race to be detected. It is a state that cannot be expressed.

## A fence, not only a TTL

A TTL assumes clocks agree. A stopped container, a suspended laptop, or an NTP step hands a source a lease it *honestly* believes is valid — and it writes into a store the target now owns.

So the lease also carries an integer that only increases, bumped on every handoff and every reclaim. A writer presents its fence; anything below current is refused.

> **The TTL decides when a lease may be RECLAIMED. The fence decides who may WRITE.**

**Writing the tests corrected my own account of this**, which is why one test name differs from what I first assumed. After a handoff the source is refused by the **holder** check (409) — the fence never gets a look in. Its real job is the case the holder check *cannot* see: a stale record from the **same holder**, right name and right token, whose fence alone reveals the world moved on while it was paused. That is what the test now asserts, and it is the scenario worth having the mechanism for.

## Three-valued by construction

`allowed` is `True` / `False` / `None`. No lease record returns `None` — not a refusal, not a permission. Folding it into `False` stops a healthy agent; folding it into `True` reinstates the split-brain.

- The dataclasses validate themselves **where they are built** — a permission carrying a refusal code raises, an unknown carrying a success code raises, an empty reason raises.
- `LeaseVerdict` deliberately defines **no `__bool__`**, so `if verdict:` cannot silently pass for a refusal. A test pins that trap rather than hiding it.
- Codes are declared numbers (200 / 403 / 404 / 409 / 410 / 412 / 503), never a small exit code overloaded with a domain meaning.

## Scope — deliberately narrow

The lease governs writes to the **shared** store only. Each host's **local** store keeps accepting local work while partitioned — the operator's explicit requirement that every machine stays usable with no network — and reconciliation settles it afterwards. A lease that stopped local work would turn a network outage into a fleet outage.

## Testability

Pure and fully injectable: no clock, no I/O, no store. Every function takes the current state plus `now` and returns the next state and a verdict — so the state machine is testable without two hosts, and the persistence layer (state.db or the cards postgres) stays a separate decision rather than being baked in here.

**38 tests, all passing.**

## Card and what comes next

`sac-agents-move-relocate-an-agent-between-hosts-atomically-20260807`

Still to build on that card: the phase journal (`PREFLIGHT → TARGET_STANDBY → SOURCE_DRAIN → HANDOVER → SOURCE_STOP → DONE`, each step idempotent so a crash resumes rather than restarts), the preflight checks, and the CLI verb. The handoff here is the single atomic point those phases are ordered around: before it the source still writes and the target is a harmless standby; after it the target writes and the source is locked out by the bumped fence even while its process is still alive. A crash on either side of it leaves exactly one writer.
