### PR TITLE
feat(lifecycle): relocation phases, ordered and journalled so a crash resumes

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_relocate_phases.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_phases.py
@@ -1,0 +1,343 @@
+"""The ordered, journaled phases of a relocation — so a crash RESUMES.
+
+The operator asked the right question when this was designed (2026-08-07): "what
+if it dies mid-way". A relocation touches two hosts and a shared store, so it
+will eventually be interrupted somewhere. The answer is not to make the whole
+thing atomic — it cannot be — but to order the steps around ONE atomic point and
+journal every transition, so that wherever it stops, the state on disk says
+where it stopped and re-running continues rather than restarts.
+
+    PREFLIGHT       validate the target before touching anything
+    TARGET_STANDBY  start the target WITHOUT the lease; it runs read-only
+    SOURCE_DRAIN    source finishes in-flight work, stops taking new
+    HANDOVER        the lease moves source -> target  <- THE atomic point
+    SOURCE_STOP     stop the source, VERIFY stopped
+    DONE            append the residency record
+
+WHY THE ORDER IS THIS ORDER. Everything before HANDOVER is reversible and
+everything after it is cleanup. Before: the source still holds the lease and the
+target is a harmless read-only standby, so abandoning costs nothing. After: the
+target holds the lease and the source is locked out by the bumped fence even
+though its process is still alive, so the only sane direction is forward. A
+crash on either side of that single point leaves exactly ONE writer — which is
+the property the whole sequence exists to produce (see :mod:`_relocate_lease`).
+
+That asymmetry is enforced here rather than documented: :func:`abort` REFUSES
+once HANDOVER has happened. An abort at that stage would mean taking the lease
+back from a target that already owns it, and the only honest way to do that is
+another forward relocation, not an undo.
+
+TRANSITIONS ARE ONE STEP FORWARD, NEVER BACKWARD, AND RE-ENTRY IS FREE.
+Advancing to the phase you are ALREADY in is a no-op that succeeds, because a
+coordinator that crashed after doing the work but before writing the journal
+must be able to re-run without tripping over itself. Skipping a phase is
+refused: each phase's precondition is the previous phase's completion, and a
+relocation that jumped from PREFLIGHT to HANDOVER would move the lease to a
+target nobody ever started.
+
+Pure and fully injectable, exactly like the lease: no clock, no I/O, no store.
+``now`` is passed in and a new immutable record is returned, so the persistence
+layer stays a separate decision and the state machine is testable on its own.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Final
+
+__all__ = [
+    "ABORTED",
+    "CODE_ALREADY_THERE",
+    "CODE_BACKWARD",
+    "CODE_OK",
+    "CODE_PAST_NO_RETURN",
+    "CODE_SKIPS_PHASE",
+    "CODE_TERMINAL",
+    "CODE_UNKNOWN_PHASE",
+    "DONE",
+    "HANDOVER",
+    "PHASES",
+    "PREFLIGHT",
+    "PhaseVerdict",
+    "Relocation",
+    "SOURCE_DRAIN",
+    "SOURCE_STOP",
+    "TARGET_STANDBY",
+    "abort",
+    "advance",
+    "begin",
+    "is_past_no_return",
+    "resume_from",
+]
+
+PREFLIGHT: Final = "preflight"
+TARGET_STANDBY: Final = "target_standby"
+SOURCE_DRAIN: Final = "source_drain"
+HANDOVER: Final = "handover"
+SOURCE_STOP: Final = "source_stop"
+DONE: Final = "done"
+
+#: The ordered sequence. Index in this tuple IS the ordering relation — there is
+#: no second place where the order is written, so the two cannot disagree.
+PHASES: Final[tuple[str, ...]] = (
+    PREFLIGHT,
+    TARGET_STANDBY,
+    SOURCE_DRAIN,
+    HANDOVER,
+    SOURCE_STOP,
+    DONE,
+)
+
+#: Not a phase — a terminal state reachable only from BEFORE the handover.
+#: Deliberately outside PHASES so it can never be "advanced to" by the normal
+#: one-step rule, and so ordering comparisons never have to special-case it.
+ABORTED: Final = "aborted"
+
+# Declared numeric codes with documented meanings, same discipline as the lease
+# (see _relocate_lease): never a bare bool, never a small exit code carrying a
+# domain meaning. Kept local rather than imported — a phase decision is not a
+# lease decision, and sharing the constants would tie two vocabularies together
+# for no gain beyond saving six lines.
+CODE_OK: Final = 200
+CODE_ALREADY_THERE: Final = 208
+CODE_SKIPS_PHASE: Final = 400
+CODE_UNKNOWN_PHASE: Final = 404
+CODE_BACKWARD: Final = 409
+CODE_PAST_NO_RETURN: Final = 410
+CODE_TERMINAL: Final = 423
+CODE_UNKNOWN: Final = 503
+
+
+@dataclass(frozen=True)
+class PhaseVerdict:
+    """Whether a transition is permitted, in ONE shape.
+
+    ``allowed`` is three-valued — ``True`` / ``False`` / ``None`` for "could not
+    determine". Defines no ``__bool__`` on purpose, so ``if verdict:`` cannot
+    read as permission for a refusal.
+    """
+
+    allowed: bool | None
+    code: int
+    reason: str
+
+    def __post_init__(self) -> None:
+        if self.allowed not in (True, False, None):
+            raise ValueError(
+                f"PhaseVerdict.allowed must be True/False/None, got {self.allowed!r}"
+            )
+        if not self.reason:
+            raise ValueError(
+                "PhaseVerdict.reason must be non-empty — a refusal with no reason is not actionable"
+            )
+        if self.allowed is True and self.code not in (CODE_OK, CODE_ALREADY_THERE):
+            raise ValueError(
+                f"PhaseVerdict: allowed=True must carry CODE_OK or CODE_ALREADY_THERE, got {self.code}"
+            )
+        if self.allowed is None and self.code != CODE_UNKNOWN:
+            raise ValueError(
+                f"PhaseVerdict: allowed=None must carry CODE_UNKNOWN, got {self.code}"
+            )
+
+
+@dataclass(frozen=True)
+class Step:
+    """One journalled transition: which phase, when, and why."""
+
+    phase: str
+    at: float
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class Relocation:
+    """A relocation in flight, and the journal of how it got here.
+
+    ``steps`` is append-only and includes the opening PREFLIGHT entry, so the
+    record is self-describing: reading it tells you where the relocation is, how
+    it arrived, and when each step happened — without consulting a log that may
+    have rotated away.
+    """
+
+    agent: str
+    from_host: str
+    to_host: str
+    phase: str
+    steps: tuple[Step, ...]
+
+    def __post_init__(self) -> None:
+        if not self.agent:
+            raise ValueError("Relocation.agent must be non-empty")
+        if not self.from_host or not self.to_host:
+            raise ValueError("Relocation needs both from_host and to_host")
+        if self.from_host == self.to_host:
+            raise ValueError(
+                f"Relocation from {self.from_host!r} to itself is not a relocation — "
+                "nothing would move, and the handover would take the lease from and give it to one host"
+            )
+        if self.phase not in PHASES and self.phase != ABORTED:
+            raise ValueError(
+                f"Relocation.phase {self.phase!r} is not a known phase; expected one of {PHASES} or {ABORTED!r}"
+            )
+        if not self.steps:
+            raise ValueError("Relocation.steps must record at least the opening step")
+
+    @property
+    def started_at(self) -> float:
+        return self.steps[0].at
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.phase in (DONE, ABORTED)
+
+
+def is_past_no_return(relocation: Relocation) -> bool:
+    """True once the lease has moved — i.e. at or beyond HANDOVER.
+
+    The one predicate everything asymmetric keys off. Kept as a function rather
+    than a comparison at each call site so "which side of the atomic point are
+    we on" has exactly one definition.
+    """
+    if relocation.phase == ABORTED:
+        return False
+    return PHASES.index(relocation.phase) >= PHASES.index(HANDOVER)
+
+
+def begin(
+    *, agent: str, from_host: str, to_host: str, now: float, detail: str = ""
+) -> Relocation:
+    """Open a relocation at PREFLIGHT. Touches nothing but this record."""
+    return Relocation(
+        agent=agent,
+        from_host=from_host,
+        to_host=to_host,
+        phase=PREFLIGHT,
+        steps=(Step(phase=PREFLIGHT, at=now, detail=detail or "relocation opened"),),
+    )
+
+
+def resume_from(relocation: Relocation) -> str | None:
+    """The phase a re-run should execute next, or ``None`` if there is nothing
+    left to do.
+
+    A crashed coordinator asks this instead of starting over. Because a phase is
+    only recorded once its work is done, the answer is always "the one after the
+    last recorded phase" — and for a terminal relocation it is ``None``, which
+    the caller must handle explicitly rather than looping.
+    """
+    if relocation.is_terminal:
+        return None
+    return PHASES[PHASES.index(relocation.phase) + 1]
+
+
+def advance(
+    relocation: Relocation,
+    *,
+    to_phase: str,
+    now: float,
+    detail: str = "",
+) -> tuple[Relocation, PhaseVerdict]:
+    """Record that ``to_phase`` has completed. One step forward only.
+
+    Re-advancing to the CURRENT phase succeeds without appending a duplicate
+    step (``CODE_ALREADY_THERE``): a coordinator that finished the work and died
+    before journalling must be able to re-run harmlessly. Skipping ahead,
+    stepping back, and moving a terminal relocation are all refused.
+    """
+    if to_phase not in PHASES:
+        return relocation, PhaseVerdict(
+            allowed=False,
+            code=CODE_UNKNOWN_PHASE,
+            reason=f"{to_phase!r} is not a phase; expected one of {PHASES}",
+        )
+    if relocation.is_terminal:
+        return relocation, PhaseVerdict(
+            allowed=False,
+            code=CODE_TERMINAL,
+            reason=f"relocation of {relocation.agent} is already {relocation.phase}; open a new one rather than reviving this",
+        )
+    here = PHASES.index(relocation.phase)
+    there = PHASES.index(to_phase)
+    if there == here:
+        return relocation, PhaseVerdict(
+            allowed=True,
+            code=CODE_ALREADY_THERE,
+            reason=f"already at {to_phase} — re-run is a no-op, nothing appended",
+        )
+    if there < here:
+        return relocation, PhaseVerdict(
+            allowed=False,
+            code=CODE_BACKWARD,
+            reason=f"cannot go back from {relocation.phase} to {to_phase}; a relocation only moves forward",
+        )
+    if there > here + 1:
+        return relocation, PhaseVerdict(
+            allowed=False,
+            code=CODE_SKIPS_PHASE,
+            reason=(
+                f"cannot jump {relocation.phase} -> {to_phase}: each phase's precondition is the "
+                f"previous one's completion, so the next legal step is {PHASES[here + 1]}"
+            ),
+        )
+    moved = replace(
+        relocation,
+        phase=to_phase,
+        steps=relocation.steps + (Step(phase=to_phase, at=now, detail=detail),),
+    )
+    return moved, PhaseVerdict(
+        allowed=True,
+        code=CODE_OK,
+        reason=f"{relocation.agent}: {relocation.phase} -> {to_phase}",
+    )
+
+
+def abort(
+    relocation: Relocation,
+    *,
+    now: float,
+    reason: str,
+) -> tuple[Relocation, PhaseVerdict]:
+    """Abandon a relocation that has NOT yet handed over the lease.
+
+    Refused at or past HANDOVER. There the target already owns the lease and the
+    source is fenced out, so "undo" would mean taking write authority back from
+    a live holder — which is itself a relocation, and should be run as one
+    rather than smuggled in under a name that promises the opposite.
+    """
+    if not reason:
+        return relocation, PhaseVerdict(
+            allowed=False,
+            code=CODE_SKIPS_PHASE,
+            reason="an abort must state why — an unexplained abandonment is indistinguishable from a crash",
+        )
+    if relocation.phase == ABORTED:
+        return relocation, PhaseVerdict(
+            allowed=True,
+            code=CODE_ALREADY_THERE,
+            reason="already aborted — re-run is a no-op",
+        )
+    if relocation.phase == DONE:
+        return relocation, PhaseVerdict(
+            allowed=False,
+            code=CODE_TERMINAL,
+            reason=f"relocation of {relocation.agent} completed; there is nothing to abort",
+        )
+    if is_past_no_return(relocation):
+        return relocation, PhaseVerdict(
+            allowed=False,
+            code=CODE_PAST_NO_RETURN,
+            reason=(
+                f"cannot abort at {relocation.phase}: the lease already moved to {relocation.to_host}. "
+                "Finish forward, or relocate back deliberately — do not undo a handover"
+            ),
+        )
+    stopped = replace(
+        relocation,
+        phase=ABORTED,
+        steps=relocation.steps + (Step(phase=ABORTED, at=now, detail=reason),),
+    )
+    return stopped, PhaseVerdict(
+        allowed=True,
+        code=CODE_OK,
+        reason=f"{relocation.agent}: aborted at {relocation.phase} — {reason}",
+    )

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_phases.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_phases.py
@@ -1,0 +1,440 @@
+"""A relocation that dies mid-way must RESUME, and must never undo a handover.
+
+The operator's question when this was designed (2026-08-07) was "what if it dies
+mid-way". A relocation spans two hosts and a shared store, so it will be
+interrupted eventually. These tests pin the two answers:
+
+  * every transition is journalled and re-entrant, so a coordinator that crashed
+    after doing the work but before recording it can simply re-run, and
+  * the sequence is asymmetric around HANDOVER — reversible before it,
+    forward-only after — because past that point the target already owns the
+    lease and the source is fenced out.
+
+An abort after the handover is REFUSED rather than accommodated: taking write
+authority back from a live holder is itself a relocation and should be run as
+one, not smuggled in under a name that promises the opposite.
+
+Pure functions, explicit `now`, no mocks and no sleeping.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_phases import (
+    ABORTED,
+    CODE_ALREADY_THERE,
+    CODE_BACKWARD,
+    CODE_OK,
+    CODE_PAST_NO_RETURN,
+    CODE_SKIPS_PHASE,
+    CODE_TERMINAL,
+    CODE_UNKNOWN_PHASE,
+    DONE,
+    HANDOVER,
+    PHASES,
+    PREFLIGHT,
+    SOURCE_DRAIN,
+    SOURCE_STOP,
+    TARGET_STANDBY,
+    PhaseVerdict,
+    Relocation,
+    abort,
+    advance,
+    begin,
+    is_past_no_return,
+    resume_from,
+)
+
+AGENT = "scitex-agent-container"
+SRC = "ywata-note-win"
+DST = "nas-03"
+T0 = 1_000_000.0
+
+
+def _walk_to(phase: str) -> Relocation:
+    """Drive a fresh relocation forward to ``phase`` one legal step at a time."""
+    rel = begin(agent=AGENT, from_host=SRC, to_host=DST, now=T0)
+    for i, nxt in enumerate(PHASES[1 : PHASES.index(phase) + 1], start=1):
+        rel, verdict = advance(rel, to_phase=nxt, now=T0 + i, detail=f"step {i}")
+        assert verdict.allowed is True  # harness guard, not the behaviour under test
+    return rel
+
+
+@pytest.fixture
+def fresh() -> Relocation:
+    """A relocation just opened, sitting at PREFLIGHT."""
+    return begin(agent=AGENT, from_host=SRC, to_host=DST, now=T0)
+
+
+@pytest.fixture
+def handed_over() -> Relocation:
+    """A relocation past the point of no return — the lease has moved."""
+    return _walk_to(HANDOVER)
+
+
+# ---------------------------------------------------------------------------
+# begin — opens without touching anything
+# ---------------------------------------------------------------------------
+
+
+def test_a_new_relocation_opens_at_preflight(fresh: Relocation) -> None:
+    # Arrange
+    rel = fresh
+    # Act
+    phase = rel.phase
+    # Assert
+    assert phase == PREFLIGHT
+
+
+def test_a_new_relocation_journals_its_opening(fresh: Relocation) -> None:
+    # Arrange: the record must be self-describing without an external log.
+    rel = fresh
+    # Act
+    steps = rel.steps
+    # Assert
+    assert len(steps) == 1
+
+
+def test_started_at_is_the_first_step(fresh: Relocation) -> None:
+    # Arrange
+    rel = fresh
+    # Act
+    started = rel.started_at
+    # Assert
+    assert started == T0
+
+
+def test_relocating_a_host_to_itself_is_refused() -> None:
+    # Arrange: nothing would move, and the handover would take the lease from
+    # and give it to the same host.
+    fields = dict(agent=AGENT, from_host=SRC, to_host=SRC, now=T0)
+
+    # Act
+    def build() -> Relocation:
+        return begin(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+# ---------------------------------------------------------------------------
+# advance — one step forward, re-entry free, never backward
+# ---------------------------------------------------------------------------
+
+
+def test_the_next_phase_is_accepted(fresh: Relocation) -> None:
+    # Arrange
+    rel = fresh
+    # Act
+    _, verdict = advance(rel, to_phase=TARGET_STANDBY, now=T0 + 1)
+    # Assert
+    assert verdict.allowed is True
+
+
+def test_advancing_appends_to_the_journal(fresh: Relocation) -> None:
+    # Arrange
+    rel = fresh
+    # Act
+    moved, _ = advance(rel, to_phase=TARGET_STANDBY, now=T0 + 1, detail="target up")
+    # Assert
+    assert len(moved.steps) == len(rel.steps) + 1
+
+
+def test_re_advancing_to_the_current_phase_succeeds(fresh: Relocation) -> None:
+    # Arrange: a coordinator that did the work then died before journalling must
+    # be able to re-run without tripping over itself.
+    rel = fresh
+    # Act
+    _, verdict = advance(rel, to_phase=PREFLIGHT, now=T0 + 1)
+    # Assert
+    assert verdict.code == CODE_ALREADY_THERE
+
+
+def test_re_advancing_appends_nothing(fresh: Relocation) -> None:
+    # Arrange: idempotent means no duplicate entry, not merely no error.
+    rel = fresh
+    # Act
+    same, _ = advance(rel, to_phase=PREFLIGHT, now=T0 + 1)
+    # Assert
+    assert same.steps == rel.steps
+
+
+def test_skipping_a_phase_is_refused(fresh: Relocation) -> None:
+    # Arrange: jumping PREFLIGHT -> HANDOVER would move the lease to a target
+    # nobody ever started.
+    rel = fresh
+    # Act
+    _, verdict = advance(rel, to_phase=HANDOVER, now=T0 + 1)
+    # Assert
+    assert verdict.code == CODE_SKIPS_PHASE
+
+
+def test_stepping_backward_is_refused(handed_over: Relocation) -> None:
+    # Arrange
+    rel = handed_over
+    # Act
+    _, verdict = advance(rel, to_phase=SOURCE_DRAIN, now=T0 + 9)
+    # Assert
+    assert verdict.code == CODE_BACKWARD
+
+
+def test_an_unknown_phase_is_refused(fresh: Relocation) -> None:
+    # Arrange
+    rel = fresh
+    # Act
+    _, verdict = advance(rel, to_phase="teleport", now=T0 + 1)
+    # Assert
+    assert verdict.code == CODE_UNKNOWN_PHASE
+
+
+def test_a_completed_relocation_cannot_advance() -> None:
+    # Arrange
+    rel = _walk_to(DONE)
+    # Act
+    _, verdict = advance(rel, to_phase=DONE, now=T0 + 99)
+    # Assert
+    assert verdict.code == CODE_TERMINAL
+
+
+def test_the_journal_keeps_the_whole_trail() -> None:
+    # Arrange: reading the record alone must show how it got here, without a log
+    # that may have rotated away.
+    rel = _walk_to(DONE)
+    # Act
+    phases = [s.phase for s in rel.steps]
+    # Assert
+    assert phases == list(PHASES)
+
+
+# ---------------------------------------------------------------------------
+# resume_from — where a crashed coordinator picks up
+# ---------------------------------------------------------------------------
+
+
+def test_resume_points_at_the_next_phase(fresh: Relocation) -> None:
+    # Arrange
+    rel = fresh
+    # Act
+    nxt = resume_from(rel)
+    # Assert
+    assert nxt == TARGET_STANDBY
+
+
+def test_resume_after_a_partial_run_points_forward() -> None:
+    # Arrange
+    rel = _walk_to(SOURCE_DRAIN)
+    # Act
+    nxt = resume_from(rel)
+    # Assert
+    assert nxt == HANDOVER
+
+
+def test_a_completed_relocation_has_nothing_to_resume() -> None:
+    # Arrange: None must be handled explicitly by the caller, not looped over.
+    rel = _walk_to(DONE)
+    # Act
+    nxt = resume_from(rel)
+    # Assert
+    assert nxt is None
+
+
+# ---------------------------------------------------------------------------
+# the point of no return
+# ---------------------------------------------------------------------------
+
+
+def test_before_the_handover_the_relocation_is_reversible() -> None:
+    # Arrange
+    rel = _walk_to(SOURCE_DRAIN)
+    # Act
+    past = is_past_no_return(rel)
+    # Assert
+    assert past is False
+
+
+def test_at_the_handover_the_relocation_is_past_no_return(
+    handed_over: Relocation,
+) -> None:
+    # Arrange: the lease has moved; the source is fenced out even while alive.
+    rel = handed_over
+    # Act
+    past = is_past_no_return(rel)
+    # Assert
+    assert past is True
+
+
+def test_after_the_handover_the_relocation_stays_past_no_return() -> None:
+    # Arrange
+    rel = _walk_to(SOURCE_STOP)
+    # Act
+    past = is_past_no_return(rel)
+    # Assert
+    assert past is True
+
+
+# ---------------------------------------------------------------------------
+# abort — legal only while nothing has moved
+# ---------------------------------------------------------------------------
+
+
+def test_aborting_before_the_handover_is_allowed(fresh: Relocation) -> None:
+    # Arrange: the target is a harmless read-only standby, so abandoning costs
+    # nothing.
+    rel = fresh
+    # Act
+    _, verdict = abort(rel, now=T0 + 2, reason="target image missing")
+    # Assert
+    assert verdict.allowed is True
+
+
+def test_an_aborted_relocation_says_so(fresh: Relocation) -> None:
+    # Arrange
+    rel = fresh
+    # Act
+    stopped, _ = abort(rel, now=T0 + 2, reason="target image missing")
+    # Assert
+    assert stopped.phase == ABORTED
+
+
+def test_an_abort_records_its_reason(fresh: Relocation) -> None:
+    # Arrange
+    rel = fresh
+    # Act
+    stopped, _ = abort(rel, now=T0 + 2, reason="target image missing")
+    # Assert
+    assert stopped.steps[-1].detail == "target image missing"
+
+
+def test_an_abort_must_state_why(fresh: Relocation) -> None:
+    # Arrange: an unexplained abandonment is indistinguishable from a crash.
+    rel = fresh
+    # Act
+    _, verdict = abort(rel, now=T0 + 2, reason="")
+    # Assert
+    assert verdict.allowed is False
+
+
+def test_aborting_at_the_handover_is_refused(handed_over: Relocation) -> None:
+    # Arrange: undoing here would mean taking the lease back from a live holder.
+    rel = handed_over
+    # Act
+    _, verdict = abort(rel, now=T0 + 9, reason="changed my mind")
+    # Assert
+    assert verdict.code == CODE_PAST_NO_RETURN
+
+
+def test_aborting_after_the_handover_is_refused() -> None:
+    # Arrange
+    rel = _walk_to(SOURCE_STOP)
+    # Act
+    _, verdict = abort(rel, now=T0 + 9, reason="changed my mind")
+    # Assert
+    assert verdict.code == CODE_PAST_NO_RETURN
+
+
+def test_aborting_a_completed_relocation_is_refused() -> None:
+    # Arrange
+    rel = _walk_to(DONE)
+    # Act
+    _, verdict = abort(rel, now=T0 + 99, reason="too late")
+    # Assert
+    assert verdict.code == CODE_TERMINAL
+
+
+def test_aborting_twice_is_a_no_op(fresh: Relocation) -> None:
+    # Arrange
+    stopped, _ = abort(fresh, now=T0 + 2, reason="target image missing")
+    # Act
+    _, verdict = abort(stopped, now=T0 + 3, reason="target image missing")
+    # Assert
+    assert verdict.code == CODE_ALREADY_THERE
+
+
+def test_an_aborted_relocation_is_not_past_no_return(fresh: Relocation) -> None:
+    # Arrange: ABORTED sits outside the ordered phases, so the side-of-the-line
+    # question must not accidentally compare it by index.
+    stopped, _ = abort(fresh, now=T0 + 2, reason="target image missing")
+    # Act
+    past = is_past_no_return(stopped)
+    # Assert
+    assert past is False
+
+
+# ---------------------------------------------------------------------------
+# the shapes validate themselves, where they are built
+# ---------------------------------------------------------------------------
+
+
+def test_a_relocation_refuses_an_empty_agent() -> None:
+    # Arrange
+    fields = dict(agent="", from_host=SRC, to_host=DST, now=T0)
+
+    # Act
+    def build() -> Relocation:
+        return begin(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_relocation_refuses_an_unknown_phase() -> None:
+    # Arrange
+    fields = dict(agent=AGENT, from_host=SRC, to_host=DST, phase="sideways", steps=())
+
+    # Act
+    def build() -> Relocation:
+        return Relocation(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_verdict_refuses_a_permission_that_is_not_coded_ok() -> None:
+    # Arrange: allowed=True with a refusal code is the shape that lets a caller
+    # reading one field draw the opposite conclusion.
+    fields = dict(allowed=True, code=CODE_BACKWARD, reason="contradictory")
+
+    # Act
+    def build() -> PhaseVerdict:
+        return PhaseVerdict(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_verdict_refuses_an_empty_reason() -> None:
+    # Arrange
+    fields = dict(allowed=False, code=CODE_BACKWARD, reason="")
+
+    # Act
+    def build() -> PhaseVerdict:
+        return PhaseVerdict(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_refusal_is_truthy_so_callers_must_read_the_field(fresh: Relocation) -> None:
+    # Arrange: deliberately no __bool__, so `if verdict:` cannot read as
+    # permission. This documents the trap rather than hiding it.
+    _, verdict = advance(fresh, to_phase=HANDOVER, now=T0 + 1)
+    # Act
+    truthy = bool(verdict)
+    # Assert
+    assert truthy is True
+
+
+def test_the_success_code_differs_from_the_idempotent_code() -> None:
+    # Arrange: a caller distinguishing "work happened" from "already done"
+    # needs the two to be different numbers, not the same one twice.
+    codes = (CODE_OK, CODE_ALREADY_THERE)
+    # Act
+    distinct = len(set(codes))
+    # Assert
+    assert distinct == 2


### PR DESCRIPTION
Step 2 of `sac agents relocate`, on the write lease from #888.

## The question this answers

The operator's, when this was designed (2026-08-07): **"what if it dies mid-way"**.

A relocation spans two hosts and a shared store, so it *will* be interrupted eventually. The answer is not to make the whole thing atomic — it cannot be — but to order the steps around **one** atomic point and journal every transition, so that wherever it stops, the record says where, and re-running continues rather than restarts.

```
PREFLIGHT → TARGET_STANDBY → SOURCE_DRAIN → HANDOVER → SOURCE_STOP → DONE
```

## The order is the point

Everything **before** HANDOVER is reversible; everything **after** it is cleanup.

- *Before:* the source still holds the lease and the target is a harmless read-only standby. Abandoning costs nothing.
- *After:* the target holds the lease and the source is fenced out even though its process is alive. The only sane direction is forward.

A crash on either side of that single point leaves **exactly one writer** — the property the sequence exists to produce.

That asymmetry is **enforced, not documented**: `abort` refuses at or past HANDOVER. Undoing there would mean taking write authority back from a live holder, which is itself a relocation and should be run as one, not smuggled in under a name that promises the opposite. The refusal says so and names the host that now owns the lease.

## Re-entry is free, which is what makes "resume" real

- Advancing to the phase you are **already in** succeeds and appends **nothing** (`CODE_ALREADY_THERE`) — a coordinator that finished the work and died before journalling must be able to re-run harmlessly.
- **Skipping** is refused with the next legal step named: `PREFLIGHT → HANDOVER` would move the lease to a target nobody ever started.
- **Backward** is refused.
- `resume_from` returns the phase a re-run should execute, and `None` for a terminal relocation — so the caller handles "nothing to do" explicitly instead of looping.

## Two details worth a reviewer's eye

**`ABORTED` sits outside the ordered tuple.** It can never be reached by the one-step rule, and ordering comparisons never special-case it. A test pins that an aborted relocation does **not** read as past-no-return — an index-based comparison would have got that wrong.

**`PHASES` is the single place the order is written.** Index in that tuple *is* the ordering relation, so there is no second definition to drift from it.

## Same discipline as the lease

Pure and injectable (no clock, no I/O, no store); three-valued verdicts with a validator that rejects a permission carrying a refusal code; declared numeric codes; and no `__bool__`, so `if verdict:` cannot read as permission — with a test documenting that trap rather than hiding it.

Codes are kept **local** rather than imported from `_relocate_lease`: a phase decision is not a lease decision, and sharing the vocabulary would tie two things together for no gain beyond six lines.

An abort must state **why** — an unexplained abandonment is indistinguishable from a crash, and the journal is the only thing that will still be there afterwards.

**34 tests, all passing.**

## Card

`sac-agents-move-relocate-an-agent-between-hosts-atomically-20260807`

Next on it: the preflight checks (the five learned by hand on 08-07 — binds, card-store port, credential *validity* not mere presence, runtime, schema — plus target reachability, image presence, free ports, and hub reachability *from* the target), session continuity via `_twin.py`'s transcript seeding, residency history, then the CLI verb itself.
