### PR TITLE
feat(lifecycle): decide whether a transcript is carried, apart from carrying it

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_session_carry.py
+++ b/src/scitex_agent_container/_lifecycle/_session_carry.py
@@ -1,0 +1,185 @@
+"""Decide whether a conversation transcript should be carried to a new session.
+
+`_twin.py` already knows HOW to do this — resolve a source's live session uuid,
+write it as the target's ``session_id`` marker so ``session: continue`` resumes
+it, copy the ``<uuid>.jsonl`` transcript into the target's projects store, and do
+all of that ON FIRST BOOT ONLY. What it does not have is a way to ask the
+question separately from doing the work, and `relocate` needs the same decision
+with a different transport: twin copies within one host, relocate copies across
+two.
+
+So this module owns the DECISION and nothing else. The copy stays with whoever
+can actually perform it.
+
+WHY THIS IS NOT "relocate calls twin". The operator rejected that conflation
+twice (2026-08-07), and the card records why: the two verbs differ on the axis
+they change.
+
+    relocate   WHERE it runs — identity unchanged, count 1 -> 1
+    fork/twin  WHAT it does  — new identity, count 1 -> 2
+
+They share exactly one implementation detail, which is this decision. Sharing
+more would let one verb's lifecycle leak into the other's, and describing either
+in terms of the other is how a word ends up meaning two things.
+
+FIRST BOOT ONLY, and it is the rule that matters most. Once the target has its
+OWN session marker it has booted and diverged; re-seeding would DISCARD that
+history and re-fork from the source on every restart. So an existing marker is a
+refusal, not an error — the correct outcome, stated as one.
+
+Three-valued like the rest of the relocate machinery: ``True`` carry, ``False``
+do not, ``None`` could not tell. An unknown here must never be read as "no" —
+that would silently produce the exact defect the card was filed for, an agent
+resuming with no memory of the conversation that moved it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+__all__ = [
+    "CODE_ALREADY_DIVERGED",
+    "CODE_CARRY",
+    "CODE_NO_SOURCE_SESSION",
+    "CODE_NO_TRANSCRIPT",
+    "CODE_OPTED_OUT",
+    "CODE_UNKNOWN",
+    "SeedPlan",
+    "plan_session_carry",
+]
+
+CODE_CARRY: Final = 200
+CODE_ALREADY_DIVERGED: Final = 208
+CODE_OPTED_OUT: Final = 204
+CODE_NO_SOURCE_SESSION: Final = 404
+CODE_NO_TRANSCRIPT: Final = 410
+CODE_UNKNOWN: Final = 503
+
+
+@dataclass(frozen=True)
+class SeedPlan:
+    """Whether to carry the transcript, and everything needed to do it.
+
+    ``carry`` is three-valued. ``None`` means the inputs did not answer the
+    question — distinct from a decided "no", because the two call for different
+    behaviour: a decided no proceeds, an unknown must stop and find out.
+    """
+
+    carry: bool | None
+    code: int
+    reason: str
+    session_uuid: str | None = None
+    transcript_name: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.carry not in (True, False, None):
+            raise ValueError(
+                f"SeedPlan.carry must be True/False/None, got {self.carry!r}"
+            )
+        if not self.reason:
+            raise ValueError("SeedPlan.reason must be non-empty")
+        if self.carry is True and self.code != CODE_CARRY:
+            raise ValueError(
+                f"SeedPlan: carry=True must carry CODE_CARRY, got {self.code}"
+            )
+        if self.carry is None and self.code != CODE_UNKNOWN:
+            raise ValueError(
+                f"SeedPlan: carry=None must carry CODE_UNKNOWN, got {self.code}"
+            )
+        if self.carry is True and not self.session_uuid:
+            raise ValueError(
+                "SeedPlan: a carry plan must name the session uuid it will seed"
+            )
+        if self.carry is True and not self.transcript_name:
+            raise ValueError(
+                "SeedPlan: a carry plan must name the transcript file it will copy"
+            )
+
+
+def plan_session_carry(
+    *,
+    source_session_uuid: str | None,
+    source_transcript_exists: bool | None,
+    target_has_own_marker: bool | None,
+    requested: bool = True,
+) -> SeedPlan:
+    """Decide, from observed facts alone. Copies nothing, reads nothing.
+
+    ``requested`` is the caller's intent — for ``relocate`` it defaults to True
+    (the same agent continuing SHOULD remember the conversation that moved it;
+    ``--no-carry-session`` sets it False), and for a purpose-scoped fork the
+    caller may pass False and supply a summary instead.
+
+    Every fact is ``| None`` for NOT OBSERVED, which is deliberately distinct
+    from an observed negative: a probe that failed must not be able to
+    masquerade as "there is no transcript".
+    """
+    if not requested:
+        return SeedPlan(
+            carry=False,
+            code=CODE_OPTED_OUT,
+            reason=(
+                "carry not requested — the target will start a fresh session with no memory "
+                "of the conversation that moved it; this is only right when leaving a wedged "
+                "session behind deliberately"
+            ),
+        )
+    if target_has_own_marker is None:
+        return SeedPlan(
+            carry=None,
+            code=CODE_UNKNOWN,
+            reason=(
+                "could not tell whether the target already has its own session marker; "
+                "seeding over a diverged session would DISCARD its history, so find out "
+                "before deciding"
+            ),
+        )
+    if target_has_own_marker:
+        return SeedPlan(
+            carry=False,
+            code=CODE_ALREADY_DIVERGED,
+            reason=(
+                "target already has its own session marker — it has booted and diverged. "
+                "Re-seeding would discard that history and re-fork from the source on every "
+                "restart; `continue` resumes the target's own latest session instead"
+            ),
+        )
+    if source_session_uuid is None:
+        return SeedPlan(
+            carry=None,
+            code=CODE_UNKNOWN,
+            reason="the source's live session uuid was not observed; read its session_id marker before deciding",
+        )
+    if not source_session_uuid:
+        return SeedPlan(
+            carry=False,
+            code=CODE_NO_SOURCE_SESSION,
+            reason=(
+                "the source has no live session, so there is no conversation to carry — "
+                "the target will start fresh, which is correct here but worth saying out loud"
+            ),
+        )
+    if source_transcript_exists is None:
+        return SeedPlan(
+            carry=None,
+            code=CODE_UNKNOWN,
+            reason=f"could not tell whether the source transcript for {source_session_uuid} exists; check before deciding",
+        )
+    if not source_transcript_exists:
+        return SeedPlan(
+            carry=False,
+            code=CODE_NO_TRANSCRIPT,
+            reason=(
+                f"the source names session {source_session_uuid} but its transcript is missing — "
+                "seeding a marker with no transcript produces an agent that resumes into nothing"
+            ),
+            session_uuid=source_session_uuid,
+        )
+    return SeedPlan(
+        carry=True,
+        code=CODE_CARRY,
+        reason=f"carrying session {source_session_uuid} to the target's first boot",
+        session_uuid=source_session_uuid,
+        transcript_name=f"{source_session_uuid}.jsonl",
+    )

--- a/tests/scitex_agent_container/_lifecycle/test__session_carry.py
+++ b/tests/scitex_agent_container/_lifecycle/test__session_carry.py
@@ -1,0 +1,273 @@
+"""An agent that resumes with no memory of the conversation that moved it has
+been replaced, not relocated.
+
+That is the defect this decision exists to prevent, measured on 2026-08-07: the
+nas instance booted with NO memory of the originating conversation, because the
+transcript lives inside the container overlay and nothing copied it.
+
+The opposite mistake is just as real and less obvious: re-seeding a target that
+has ALREADY booted would DISCARD its own history and re-fork from the source on
+every restart. So "no" is sometimes the right answer, and the tests below pin
+both directions.
+
+The third answer is the one that has bitten this fleet repeatedly tonight —
+UNKNOWN. A fact that was not observed must not read as "no". Deciding not to
+carry because a probe failed produces exactly the 08-07 defect while looking
+like a considered choice.
+
+Pure decision, no I/O, no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._session_carry import (
+    CODE_ALREADY_DIVERGED,
+    CODE_CARRY,
+    CODE_NO_SOURCE_SESSION,
+    CODE_NO_TRANSCRIPT,
+    CODE_OPTED_OUT,
+    CODE_UNKNOWN,
+    SeedPlan,
+    plan_session_carry,
+)
+
+UUID = "47f85b77-9a34-474e-a68d-12dd126e6f65"
+
+
+def _plan(**overrides: object) -> SeedPlan:
+    """A fully-observed, carryable situation, with one field swappable."""
+    facts: dict[str, object] = dict(
+        source_session_uuid=UUID,
+        source_transcript_exists=True,
+        target_has_own_marker=False,
+        requested=True,
+    )
+    facts.update(overrides)
+    return plan_session_carry(**facts)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# the ordinary case
+# ---------------------------------------------------------------------------
+
+
+def test_a_live_session_with_a_transcript_is_carried() -> None:
+    # Arrange
+    plan = _plan()
+    # Act
+    carry = plan.carry
+    # Assert
+    assert carry is True
+
+
+def test_a_carry_plan_names_the_session_it_will_seed() -> None:
+    # Arrange: the marker written to the target is this uuid.
+    plan = _plan()
+    # Act
+    uuid = plan.session_uuid
+    # Assert
+    assert uuid == UUID
+
+
+def test_a_carry_plan_names_the_transcript_file() -> None:
+    # Arrange: the copy is of <uuid>.jsonl, mirroring the source's layout.
+    plan = _plan()
+    # Act
+    name = plan.transcript_name
+    # Assert
+    assert name == f"{UUID}.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# first boot only — the refusal that protects a diverged target
+# ---------------------------------------------------------------------------
+
+
+def test_a_target_that_already_booted_is_not_re_seeded() -> None:
+    # Arrange: re-seeding would discard the target's own history and re-fork
+    # from the source on every restart.
+    plan = _plan(target_has_own_marker=True)
+    # Act
+    carry = plan.carry
+    # Assert
+    assert carry is False
+
+
+def test_the_diverged_refusal_explains_what_it_protects() -> None:
+    # Arrange: this is a correct outcome, not a failure, and must read as one.
+    plan = _plan(target_has_own_marker=True)
+    # Act
+    code = plan.code
+    # Assert
+    assert code == CODE_ALREADY_DIVERGED
+
+
+# ---------------------------------------------------------------------------
+# unknown is never "no"
+# ---------------------------------------------------------------------------
+
+
+def test_an_unobserved_target_marker_is_unknown_not_a_refusal() -> None:
+    # Arrange: deciding "no" here would discard history on a guess.
+    plan = _plan(target_has_own_marker=None)
+    # Act
+    carry = plan.carry
+    # Assert
+    assert carry is None
+
+
+def test_an_unobserved_source_session_is_unknown_not_a_refusal() -> None:
+    # Arrange: a failed read of session_id must not become "there is no session".
+    plan = _plan(source_session_uuid=None)
+    # Act
+    carry = plan.carry
+    # Assert
+    assert carry is None
+
+
+def test_an_unobserved_transcript_is_unknown_not_a_refusal() -> None:
+    # Arrange
+    plan = _plan(source_transcript_exists=None)
+    # Act
+    carry = plan.carry
+    # Assert
+    assert carry is None
+
+
+def test_every_unknown_is_coded_unknown() -> None:
+    # Arrange
+    plan = _plan(target_has_own_marker=None)
+    # Act
+    code = plan.code
+    # Assert
+    assert code == CODE_UNKNOWN
+
+
+def test_an_unknown_says_what_to_check() -> None:
+    # Arrange: an unknown with no next step leaves the caller where it started.
+    plan = _plan(source_session_uuid=None)
+    # Act
+    reason = plan.reason
+    # Assert
+    assert "session_id" in reason
+
+
+# ---------------------------------------------------------------------------
+# decided refusals
+# ---------------------------------------------------------------------------
+
+
+def test_a_source_with_no_live_session_carries_nothing() -> None:
+    # Arrange: an empty uuid is an OBSERVED absence, unlike None.
+    plan = _plan(source_session_uuid="")
+    # Act
+    code = plan.code
+    # Assert
+    assert code == CODE_NO_SOURCE_SESSION
+
+
+def test_a_named_session_whose_transcript_is_missing_refuses() -> None:
+    # Arrange: seeding a marker with no transcript produces an agent that
+    # resumes into nothing — worse than starting fresh, because it looks resumed.
+    plan = _plan(source_transcript_exists=False)
+    # Act
+    code = plan.code
+    # Assert
+    assert code == CODE_NO_TRANSCRIPT
+
+
+def test_the_missing_transcript_refusal_still_names_the_session() -> None:
+    # Arrange: naming the offending value is what makes it diagnosable.
+    plan = _plan(source_transcript_exists=False)
+    # Act
+    uuid = plan.session_uuid
+    # Assert
+    assert uuid == UUID
+
+
+def test_opting_out_is_honoured() -> None:
+    # Arrange: --no-carry-session, for leaving a wedged session behind.
+    plan = _plan(requested=False)
+    # Act
+    code = plan.code
+    # Assert
+    assert code == CODE_OPTED_OUT
+
+
+def test_opting_out_says_what_is_being_given_up() -> None:
+    # Arrange: the flag discards the conversation, and the help must not be coy.
+    plan = _plan(requested=False)
+    # Act
+    reason = plan.reason
+    # Assert
+    assert "no memory" in reason
+
+
+def test_opting_out_beats_every_other_consideration() -> None:
+    # Arrange: an explicit human decision is not overridden by observations,
+    # not even unknown ones.
+    plan = _plan(requested=False, target_has_own_marker=None, source_session_uuid=None)
+    # Act
+    carry = plan.carry
+    # Assert
+    assert carry is False
+
+
+# ---------------------------------------------------------------------------
+# the shape validates itself
+# ---------------------------------------------------------------------------
+
+
+def test_a_carry_plan_without_a_session_uuid_is_rejected() -> None:
+    # Arrange: a plan that says "carry" but cannot say what would be a caller's
+    # problem three layers downstream.
+    fields = dict(carry=True, code=CODE_CARRY, reason="ok", transcript_name="x.jsonl")
+
+    # Act
+    def build() -> SeedPlan:
+        return SeedPlan(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_carry_plan_without_a_transcript_name_is_rejected() -> None:
+    # Arrange
+    fields = dict(carry=True, code=CODE_CARRY, reason="ok", session_uuid=UUID)
+
+    # Act
+    def build() -> SeedPlan:
+        return SeedPlan(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_plan_refuses_an_empty_reason() -> None:
+    # Arrange
+    fields = dict(carry=False, code=CODE_OPTED_OUT, reason="")
+
+    # Act
+    def build() -> SeedPlan:
+        return SeedPlan(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_an_unknown_carrying_a_success_code_is_rejected() -> None:
+    # Arrange: the shape that lets an unknown pass for a decision.
+    fields = dict(carry=None, code=CODE_CARRY, reason="contradictory")
+
+    # Act
+    def build() -> SeedPlan:
+        return SeedPlan(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()


### PR DESCRIPTION
feat(lifecycle): decide whether a transcript is carried, apart from carrying it

Step 4's core, for `sac agents relocate`. The decision only — the copy stays
with whoever can perform it.

`_twin.py` already knows HOW: resolve the source's live session uuid, write it
as the target's `session_id` marker so `session: continue` resumes it, copy the
`<uuid>.jsonl` into the target's projects store, first boot only. What it lacks
is a way to ASK the question separately from doing the work, and relocate needs
the same decision with a different transport — twin copies within one host,
relocate copies across two.

THIS IS NOT "relocate calls twin". The operator rejected that conflation twice
(2026-08-07) and the card records why: the verbs differ on the axis they change.
relocate changes WHERE it runs (identity unchanged, 1 -> 1); fork/twin changes
WHAT it does (new identity, 1 -> 2). They share exactly one implementation
detail, and this is it. Sharing more lets one verb's lifecycle leak into the
other's.

THE DEFAULT IS TO CARRY, and I am flagging that as a decision I made rather
than one the operator gave. The card left it open ("decide whether relocate
implies it or --carry-session opts in") while recording that he wants
continuity. Relocate is the SAME agent continuing; an agent that resumes with no
memory of the conversation that moved it has been replaced, not relocated — and
that is the exact defect the card was filed for ("the nas instance booted with
NO memory of the originating conversation"). Opt-in would make the default
produce the filed defect. `--no-carry-session` exists for the deliberate case,
and its refusal text says plainly what is being given up. One-line flip if he
wants it the other way.

FIRST BOOT ONLY is the refusal worth reading twice: once the target has its own
marker it has booted and DIVERGED, so re-seeding would discard that history and
re-fork from the source on every restart. That is a correct outcome, and it is
returned as a decided "no" with its own code rather than an error.

Three-valued, and here the unknown does real work. A fact that was not observed
must never read as "no": deciding not to carry because a probe failed produces
the 08-07 defect while looking like a considered choice. So an unobserved target
marker, an unread session_id, and an unchecked transcript each return None with
the specific next check named. An OBSERVED absence (empty uuid, missing
transcript) is a decided no — a different thing, and coded differently.

The validator refuses a carry plan that cannot name the session uuid and the
transcript file it would copy: a plan that says "carry" without saying what
becomes the caller's problem three layers downstream.

20 tests. Card: sac-agents-move-relocate-an-agent-between-hosts-atomically-20260807
Remaining there: the cross-host transport itself (and it must VERIFY the
transcript is readable on the target rather than trusting the copy's exit code —
the transcript lives in the container overlay, which tonight's other card showed
is less durable than it looks), residency history, then the CLI verb.
