### PR TITLE
feat(lifecycle): residency history — where an agent lived, and who wrote a row

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_residency.py
+++ b/src/scitex_agent_container/_lifecycle/_residency.py
@@ -1,0 +1,146 @@
+"""Where an agent has lived, and — the part that pays for itself — where a row came from.
+
+The operator's idea (2026-08-07), and it has two payoffs that look unrelated
+until you write them down:
+
+  1. An AUDIT: which host was this agent on, and when. Useful on its own.
+  2. The missing ATTRIBUTION signal. The cards `host` column is NULL on 3247 of
+     3424 rows, so when two instances of one identity disagree, nothing can say
+     which host wrote which row. A residency record makes that answerable after
+     the fact, from a timestamp alone.
+
+(2) is why this is worth building rather than nice to have. The 2026-08-07
+split-brain was diagnosable only because someone happened to be watching; with
+residency, "who wrote this" is a lookup.
+
+THE INVARIANT THIS MODULE EXISTS TO HOLD: an agent lives in exactly ONE place at
+a time. At most one residency is OPEN (``to_ts is None``), and opening a new one
+CLOSES the previous in the same operation, so the "two homes at once" state is
+unreachable rather than merely discouraged. That is the same shape as the write
+lease — the illegal state cannot be expressed — applied to history rather than
+to authority.
+
+A record whose end precedes its start is refused where it is built, because a
+history that can lie about time is worse than no history: it answers the
+attribution question CONFIDENTLY and wrongly.
+
+Pure: no clock, no storage, no I/O. ``now`` is passed in and a new immutable
+tuple comes back.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+__all__ = [
+    "Residency",
+    "current_host",
+    "host_at",
+    "open_residency",
+]
+
+
+@dataclass(frozen=True)
+class Residency:
+    """One stay: this agent lived on ``host`` from ``from_ts`` until ``to_ts``.
+
+    ``to_ts is None`` means STILL LIVING THERE — an open interval, not a missing
+    value. The two are worth distinguishing out loud, because a reader who takes
+    None as "unknown end" will draw the opposite conclusion about the present.
+    """
+
+    host: str
+    from_ts: float
+    to_ts: float | None = None
+
+    def __post_init__(self) -> None:
+        if not self.host:
+            raise ValueError("Residency.host must be non-empty")
+        if self.to_ts is not None and self.to_ts < self.from_ts:
+            raise ValueError(
+                f"Residency on {self.host!r} ends ({self.to_ts}) before it starts ({self.from_ts}) — "
+                "a history that can lie about time answers attribution confidently and wrongly"
+            )
+
+    @property
+    def is_open(self) -> bool:
+        return self.to_ts is None
+
+    def covers(self, when: float) -> bool:
+        """True if the agent was on this host at ``when``.
+
+        Half-open [from_ts, to_ts): the instant a stay ends belongs to the NEXT
+        one, so a moment can never be claimed by two hosts. With relocation, the
+        handover instant is exactly the moment two answers would be possible.
+        """
+        if when < self.from_ts:
+            return False
+        return self.to_ts is None or when < self.to_ts
+
+
+def open_residency(
+    history: tuple[Residency, ...],
+    *,
+    host: str,
+    now: float,
+) -> tuple[Residency, ...]:
+    """Record a move to ``host``, closing any open stay in the same step.
+
+    Idempotent on the host already open: re-recording a move that already
+    happened returns the history unchanged rather than splitting one stay into
+    two adjacent identical ones. A relocation coordinator re-running after a
+    crash must not litter the record with the evidence of its own retries.
+
+    Refuses to backdate: ``now`` before the open stay's start would make the
+    closed interval end before it began, and the timestamps are the whole value
+    of the record.
+    """
+    if not host:
+        raise ValueError("cannot open a residency with no host")
+    if not history:
+        return (Residency(host=host, from_ts=now),)
+
+    latest = history[-1]
+    if latest.is_open:
+        if latest.host == host:
+            return history
+        if now < latest.from_ts:
+            raise ValueError(
+                f"cannot move to {host!r} at {now}: the current stay on {latest.host!r} "
+                f"began later, at {latest.from_ts}"
+            )
+        closed = replace(latest, to_ts=now)
+        return history[:-1] + (closed, Residency(host=host, from_ts=now))
+
+    if now < (latest.to_ts or latest.from_ts):
+        raise ValueError(
+            f"cannot open a stay on {host!r} at {now}: it precedes the end of the previous stay "
+            f"({latest.to_ts})"
+        )
+    return history + (Residency(host=host, from_ts=now),)
+
+
+def current_host(history: tuple[Residency, ...]) -> str | None:
+    """The host the agent lives on now, or ``None`` if it lives nowhere.
+
+    ``None`` is a real answer, not a gap: an agent whose last stay was closed
+    and never reopened has been stopped, not misplaced.
+    """
+    if not history:
+        return None
+    latest = history[-1]
+    return latest.host if latest.is_open else None
+
+
+def host_at(history: tuple[Residency, ...], when: float) -> str | None:
+    """Which host wrote a row stamped ``when`` — ``None`` if nothing covers it.
+
+    This is the attribution lookup. ``None`` genuinely means the history does
+    not know: before the first recorded stay, or inside a gap when the agent was
+    stopped. It must not be read as "the current host" — that guess is exactly
+    the kind that makes a split-brain look explained when it is not.
+    """
+    for stay in history:
+        if stay.covers(when):
+            return stay.host
+    return None

--- a/tests/scitex_agent_container/_lifecycle/test__residency.py
+++ b/tests/scitex_agent_container/_lifecycle/test__residency.py
@@ -1,0 +1,269 @@
+"""An agent lives in exactly one place at a time, and a row can name its writer.
+
+Two things this record buys, from the operator's 2026-08-07 idea:
+
+  * an audit of where an agent has lived, and
+  * the ATTRIBUTION signal that is missing today — the cards `host` column is
+    NULL on 3247 of 3424 rows, so when two instances of one identity disagree,
+    nothing can say which host wrote which row.
+
+The second is what makes it worth building. The 08-07 split-brain was
+diagnosable only because someone happened to be watching; with residency it is a
+lookup.
+
+The invariant under test is that "two homes at once" is UNREACHABLE, not merely
+discouraged: opening a stay closes the previous one in the same operation. And
+the boundary is half-open, so the handover instant — the one moment two answers
+would otherwise be possible — belongs to exactly one host.
+
+Pure, explicit timestamps, no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._residency import (
+    Residency,
+    current_host,
+    host_at,
+    open_residency,
+)
+
+SRC = "ywata-note-win"
+DST = "nas-03"
+T0 = 1_000_000.0
+T1 = T0 + 3600.0
+T2 = T1 + 3600.0
+
+
+@pytest.fixture
+def moved() -> tuple[Residency, ...]:
+    """Lived on SRC from T0, relocated to DST at T1."""
+    history = open_residency((), host=SRC, now=T0)
+    return open_residency(history, host=DST, now=T1)
+
+
+# ---------------------------------------------------------------------------
+# one home at a time
+# ---------------------------------------------------------------------------
+
+
+def test_a_first_move_opens_a_stay() -> None:
+    # Arrange
+    history = open_residency((), host=SRC, now=T0)
+    # Act
+    host = current_host(history)
+    # Assert
+    assert host == SRC
+
+
+def test_moving_closes_the_previous_stay(moved: tuple[Residency, ...]) -> None:
+    # Arrange: "two homes at once" must be unreachable, not discouraged.
+    history = moved
+    # Act
+    still_open = [r for r in history if r.is_open]
+    # Assert
+    assert len(still_open) == 1
+
+
+def test_the_closed_stay_ends_when_the_new_one_begins(
+    moved: tuple[Residency, ...],
+) -> None:
+    # Arrange
+    history = moved
+    # Act
+    previous = history[0]
+    # Assert
+    assert previous.to_ts == T1
+
+
+def test_after_moving_the_agent_lives_on_the_target(
+    moved: tuple[Residency, ...],
+) -> None:
+    # Arrange
+    history = moved
+    # Act
+    host = current_host(history)
+    # Assert
+    assert host == DST
+
+
+def test_re_recording_the_same_move_changes_nothing() -> None:
+    # Arrange: a coordinator re-running after a crash must not litter the record
+    # with the evidence of its own retries.
+    history = open_residency((), host=SRC, now=T0)
+    # Act
+    again = open_residency(history, host=SRC, now=T1)
+    # Assert
+    assert again == history
+
+
+def test_an_agent_with_no_history_lives_nowhere() -> None:
+    # Arrange
+    history: tuple[Residency, ...] = ()
+    # Act
+    host = current_host(history)
+    # Assert
+    assert host is None
+
+
+def test_a_closed_history_means_stopped_not_misplaced() -> None:
+    # Arrange: every stay ended and none reopened.
+    history = (Residency(host=SRC, from_ts=T0, to_ts=T1),)
+    # Act
+    host = current_host(history)
+    # Assert
+    assert host is None
+
+
+# ---------------------------------------------------------------------------
+# attribution — which host wrote a row stamped `when`
+# ---------------------------------------------------------------------------
+
+
+def test_a_row_from_before_the_move_is_attributed_to_the_source(
+    moved: tuple[Residency, ...],
+) -> None:
+    # Arrange
+    history = moved
+    # Act
+    who = host_at(history, T0 + 1.0)
+    # Assert
+    assert who == SRC
+
+
+def test_a_row_from_after_the_move_is_attributed_to_the_target(
+    moved: tuple[Residency, ...],
+) -> None:
+    # Arrange
+    history = moved
+    # Act
+    who = host_at(history, T1 + 1.0)
+    # Assert
+    assert who == DST
+
+
+def test_the_handover_instant_belongs_to_the_target(
+    moved: tuple[Residency, ...],
+) -> None:
+    # Arrange: half-open [from, to) — the one moment two answers would otherwise
+    # be possible resolves to exactly one host.
+    history = moved
+    # Act
+    who = host_at(history, T1)
+    # Assert
+    assert who == DST
+
+
+def test_a_row_from_before_any_recorded_stay_is_unattributable(
+    moved: tuple[Residency, ...],
+) -> None:
+    # Arrange: None means the history does not know — reading it as "the current
+    # host" is the guess that makes a split-brain look explained when it is not.
+    history = moved
+    # Act
+    who = host_at(history, T0 - 1.0)
+    # Assert
+    assert who is None
+
+
+def test_a_row_from_a_gap_when_the_agent_was_stopped_is_unattributable() -> None:
+    # Arrange: stopped at T1, restarted elsewhere at T2.
+    history = (
+        Residency(host=SRC, from_ts=T0, to_ts=T1),
+        Residency(host=DST, from_ts=T2),
+    )
+    # Act
+    who = host_at(history, T1 + 1.0)
+    # Assert
+    assert who is None
+
+
+def test_an_open_stay_attributes_everything_after_it() -> None:
+    # Arrange
+    history = (Residency(host=DST, from_ts=T0),)
+    # Act
+    who = host_at(history, T0 + 999_999.0)
+    # Assert
+    assert who == DST
+
+
+# ---------------------------------------------------------------------------
+# time cannot be lied about
+# ---------------------------------------------------------------------------
+
+
+def test_a_stay_that_ends_before_it_starts_is_refused() -> None:
+    # Arrange: the timestamps are the whole value of the record.
+    fields = dict(host=SRC, from_ts=T1, to_ts=T0)
+
+    # Act
+    def build() -> Residency:
+        return Residency(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_stay_with_no_host_is_refused() -> None:
+    # Arrange
+    fields = dict(host="", from_ts=T0)
+
+    # Act
+    def build() -> Residency:
+        return Residency(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_backdating_a_move_before_the_current_stay_is_refused() -> None:
+    # Arrange: it would close an interval that ends before it began.
+    history = open_residency((), host=SRC, now=T1)
+
+    # Act
+    def move_backwards() -> tuple[Residency, ...]:
+        return open_residency(history, host=DST, now=T0)
+
+    # Assert
+    with pytest.raises(ValueError):
+        move_backwards()
+
+
+def test_opening_a_stay_before_the_previous_one_ended_is_refused() -> None:
+    # Arrange: overlapping stays would make attribution ambiguous, which is the
+    # one thing this record exists to prevent.
+    history = (Residency(host=SRC, from_ts=T0, to_ts=T2),)
+
+    # Act
+    def overlap() -> tuple[Residency, ...]:
+        return open_residency(history, host=DST, now=T1)
+
+    # Assert
+    with pytest.raises(ValueError):
+        overlap()
+
+
+def test_moving_with_no_host_is_refused() -> None:
+    # Arrange
+    history = open_residency((), host=SRC, now=T0)
+
+    # Act
+    def move_nowhere() -> tuple[Residency, ...]:
+        return open_residency(history, host="", now=T1)
+
+    # Assert
+    with pytest.raises(ValueError):
+        move_nowhere()
+
+
+def test_a_reopened_history_records_both_stays() -> None:
+    # Arrange: stopped, then started again on another host.
+    history = (Residency(host=SRC, from_ts=T0, to_ts=T1),)
+    # Act
+    reopened = open_residency(history, host=DST, now=T2)
+    # Assert
+    assert len(reopened) == 2


### PR DESCRIPTION
feat(lifecycle): residency history — where an agent lived, and who wrote a row

The operator's idea (2026-08-07). Two payoffs that look unrelated until written
down:

  1. an AUDIT of where an agent has lived, and
  2. the missing ATTRIBUTION signal — the cards `host` column is NULL on 3247 of
     3424 rows, so when two instances of one identity disagree, nothing can say
     which host wrote which row.

(2) is why this is worth building rather than nice to have. The 2026-08-07
split-brain was diagnosable only because someone happened to be watching. With
residency, "who wrote this" is `host_at(history, row_timestamp)`.

THE INVARIANT: an agent lives in exactly ONE place at a time. At most one stay
is open, and opening a new one CLOSES the previous in the same operation — so
"two homes at once" is unreachable rather than discouraged. Same shape as the
write lease (#888): make the illegal state inexpressible, here applied to
history instead of authority.

THE BOUNDARY IS HALF-OPEN, [from_ts, to_ts), which matters more than it looks:
the instant a stay ends belongs to the NEXT one. With relocation the handover
instant is precisely the moment two answers would otherwise be possible, and a
test pins that it resolves to the target.

`to_ts is None` means STILL LIVING THERE — an open interval, not a missing
value. Worth saying out loud because a reader who takes None as "unknown end"
draws the opposite conclusion about the present.

`host_at` returns None for a timestamp no stay covers — before the first record,
or inside a gap when the agent was stopped. That None must not be read as "the
current host": that guess is exactly what makes a split-brain look explained
when it is not, which is the failure this record exists to prevent.

Refused where they are built, because a history that can lie about time answers
the attribution question CONFIDENTLY and wrongly: a stay ending before it
starts, a backdated move, and a stay opening before the previous one ended.
Re-recording a move to the host already open is idempotent — a coordinator
re-running after a crash must not litter the record with evidence of its retries.

Pure: no clock, no storage, no I/O.

19 tests. Card: sac-agents-move-relocate-an-agent-between-hosts-atomically-20260807
Remaining: the cross-host transcript transport (which must VERIFY readability on
the target, not trust the copy's exit code), then the CLI verb.
