### PR TITLE
feat(state): notice at boot that the resolved store is not the one you were using

### DIFF
--- a/src/scitex_agent_container/_state/_store_freshness.py
+++ b/src/scitex_agent_container/_state/_store_freshness.py
@@ -1,0 +1,162 @@
+"""Notice at BOOT that the store you resolved is not the one you were using.
+
+2026-08-08, measured. A dotfiles deploy replaced this agent's `~/.scitex` — its
+LIVE STATE ROOT, credentials included — with a symlink into a git worktree, and
+moved the real tree aside as `.scitex_back_<timestamp>`. The agent then booted,
+resolved its message store inside the substituted tree, found 149 rows whose
+newest was a MONTH OLD, and carried on reporting healthy.
+
+Nothing was broken in a way anything checked for. The store existed, opened,
+parsed, and answered queries. It was simply not the store that had been in use
+an hour earlier, and no component asked the one question that would have said
+so: does the newest row in here look like it belongs to a store this process
+has been writing to?
+
+The operator found out four hours later by asking me something I should have
+known and getting a blank. His words: 「忘れている、思い出せない、となると結構
+辛いです。」
+
+This module is that question, as a function. It is deliberately about TIME
+rather than about paths or storage engines: a path check would have to know
+about symlinks, overlays, binds and worktrees and would still miss the next
+mechanism. "The newest thing in my store is far older than my own start" is
+true of every one of those failures and needs to know about none of them.
+
+THE THRESHOLD IS A JUDGEMENT, and the default is deliberately generous. A quiet
+agent legitimately has an old newest-row — it may not have been spoken to for
+days — so this must not cry wolf at every idle boot. What it catches is the
+qualitatively different case: a store whose newest row predates the process by
+far more than the agent has plausibly been idle. Callers that know their own
+cadence should pass their own threshold.
+
+Three-valued, and here the unknown is the common case rather than an edge: a
+brand-new store has no rows at all, and that is neither fresh nor stale.
+Reporting it as stale would make every first boot shout.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+__all__ = [
+    "CODE_EMPTY",
+    "CODE_FRESH",
+    "CODE_FUTURE",
+    "CODE_STALE",
+    "CODE_UNKNOWN",
+    "DEFAULT_STALE_AFTER_S",
+    "FreshnessVerdict",
+    "assess_store_freshness",
+]
+
+#: 24 hours. An agent can plausibly sit idle overnight; a store whose newest row
+#: predates this boot by more than a day, when the agent was demonstrably active
+#: within it, is the shape of a substituted store rather than a quiet one.
+DEFAULT_STALE_AFTER_S: Final = 86_400.0
+
+CODE_FRESH: Final = 200
+CODE_EMPTY: Final = 204
+CODE_STALE: Final = 409
+CODE_FUTURE: Final = 412
+CODE_UNKNOWN: Final = 503
+
+
+@dataclass(frozen=True)
+class FreshnessVerdict:
+    """Whether the resolved store plausibly belongs to this process.
+
+    ``fresh`` is three-valued: ``True`` plausible, ``False`` suspicious,
+    ``None`` cannot tell. Defines no ``__bool__`` so ``if verdict:`` cannot read
+    as an all-clear for a suspicious store.
+    """
+
+    fresh: bool | None
+    code: int
+    reason: str
+    age_s: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.fresh not in (True, False, None):
+            raise ValueError(
+                f"FreshnessVerdict.fresh must be True/False/None, got {self.fresh!r}"
+            )
+        if not self.reason:
+            raise ValueError("FreshnessVerdict.reason must be non-empty")
+        if self.fresh is True and self.code not in (CODE_FRESH, CODE_EMPTY):
+            raise ValueError(
+                f"FreshnessVerdict: fresh=True must carry CODE_FRESH or CODE_EMPTY, got {self.code}"
+            )
+        if self.fresh is None and self.code != CODE_UNKNOWN:
+            raise ValueError(
+                f"FreshnessVerdict: fresh=None must carry CODE_UNKNOWN, got {self.code}"
+            )
+
+
+def assess_store_freshness(
+    *,
+    newest_row_ts: float | None,
+    process_started_at: float,
+    store_label: str,
+    had_rows: bool | None = None,
+    stale_after_s: float = DEFAULT_STALE_AFTER_S,
+) -> FreshnessVerdict:
+    """Does the newest row in this store look like it belongs here?
+
+    ``newest_row_ts`` is None when the store is EMPTY or was not read. Those are
+    different, and ``had_rows`` separates them:
+
+        had_rows=False  -> genuinely empty; a first boot, not a fault
+        had_rows=True   -> rows exist but their timestamp could not be read: UNKNOWN
+        had_rows=None   -> the store was not inspected at all: UNKNOWN
+
+    An empty store passes rather than warns, deliberately: a new agent's first
+    boot must not shout, and a store that is empty when it should not be is a
+    different check (one that knows what the agent expects to find).
+    """
+    if newest_row_ts is None:
+        if had_rows is False:
+            return FreshnessVerdict(
+                fresh=True,
+                code=CODE_EMPTY,
+                reason=f"{store_label} is empty — nothing to compare, which is normal on a first boot",
+            )
+        return FreshnessVerdict(
+            fresh=None,
+            code=CODE_UNKNOWN,
+            reason=(
+                f"could not read the newest row timestamp from {store_label}; "
+                "a store that cannot answer this is not a store known to be healthy"
+            ),
+        )
+
+    age = process_started_at - newest_row_ts
+    if age < 0:
+        return FreshnessVerdict(
+            fresh=False,
+            code=CODE_FUTURE,
+            reason=(
+                f"{store_label} contains a row {abs(age):.0f}s in the FUTURE relative to this "
+                "process's start — either a clock disagreement or another writer, and both "
+                "mean this process is not the only one here"
+            ),
+            age_s=age,
+        )
+    if age > stale_after_s:
+        return FreshnessVerdict(
+            fresh=False,
+            code=CODE_STALE,
+            reason=(
+                f"{store_label}: newest row is {age / 3600.0:.1f}h older than this process's start. "
+                "That is the shape of a SUBSTITUTED store — a moved-aside state root, a fresh "
+                "overlay, a deploy that symlinked the parent away — not of a quiet agent. "
+                "Check what the path actually resolves to (`readlink -f`) before trusting it"
+            ),
+            age_s=age,
+        )
+    return FreshnessVerdict(
+        fresh=True,
+        code=CODE_FRESH,
+        reason=f"{store_label}: newest row is {age / 3600.0:.1f}h before this process's start",
+        age_s=age,
+    )

--- a/tests/scitex_agent_container/_state/test__store_freshness.py
+++ b/tests/scitex_agent_container/_state/test__store_freshness.py
@@ -1,0 +1,274 @@
+"""A store that opens, parses and answers can still be the wrong store.
+
+2026-08-08: a dotfiles deploy replaced this agent's `~/.scitex` — its live state
+root — with a symlink into a git worktree and moved the real tree aside. The
+agent booted, resolved its message store inside the substituted tree, found 149
+rows whose newest was a MONTH old, and reported healthy. Nothing checked the one
+thing that would have said so.
+
+These tests pin that check. It is deliberately about TIME, not paths: a path
+check would need to know about symlinks, overlays, binds and worktrees and would
+still miss the next mechanism. "The newest thing in here is far older than my
+own start" is true of all of them and needs to know about none.
+
+The two failure directions it must NOT have:
+  * shouting on a first boot (empty store) or on a legitimately quiet agent, and
+  * folding "could not read" into a pass, which is how the original incident
+    stayed invisible.
+
+Pure, explicit timestamps, no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._state._store_freshness import (
+    CODE_EMPTY,
+    CODE_FRESH,
+    CODE_FUTURE,
+    CODE_STALE,
+    CODE_UNKNOWN,
+    DEFAULT_STALE_AFTER_S,
+    FreshnessVerdict,
+    assess_store_freshness,
+)
+
+BOOT = 1_000_000.0
+HOUR = 3600.0
+LABEL = "claude-code-telegrammer store"
+
+
+def _assess(**overrides: object) -> FreshnessVerdict:
+    facts: dict[str, object] = dict(
+        newest_row_ts=BOOT - HOUR,
+        process_started_at=BOOT,
+        store_label=LABEL,
+    )
+    facts.update(overrides)
+    return assess_store_freshness(**facts)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# the incident this exists for
+# ---------------------------------------------------------------------------
+
+
+def test_a_month_old_newest_row_is_flagged() -> None:
+    # Arrange: the measured shape of 2026-08-08 — the store resolved fine and
+    # its newest row predated the boot by a month.
+    verdict = _assess(newest_row_ts=BOOT - 30 * 24 * HOUR)
+    # Act
+    fresh = verdict.fresh
+    # Assert
+    assert fresh is False
+
+
+def test_the_stale_verdict_names_the_substitution_shapes() -> None:
+    # Arrange: an error that only states what broke is half-written. The reader
+    # needs to know what class of thing to look for.
+    verdict = _assess(newest_row_ts=BOOT - 30 * 24 * HOUR)
+    # Act
+    reason = verdict.reason
+    # Assert
+    assert "readlink -f" in reason
+
+
+def test_the_stale_verdict_is_coded_distinctly() -> None:
+    # Arrange
+    verdict = _assess(newest_row_ts=BOOT - 30 * 24 * HOUR)
+    # Act
+    code = verdict.code
+    # Assert
+    assert code == CODE_STALE
+
+
+def test_the_age_is_reported_for_the_caller_to_log() -> None:
+    # Arrange
+    verdict = _assess(newest_row_ts=BOOT - 48 * HOUR)
+    # Act
+    age = verdict.age_s
+    # Assert
+    assert age == 48 * HOUR
+
+
+# ---------------------------------------------------------------------------
+# it must not cry wolf
+# ---------------------------------------------------------------------------
+
+
+def test_a_recently_written_store_passes() -> None:
+    # Arrange
+    verdict = _assess()
+    # Act
+    fresh = verdict.fresh
+    # Assert
+    assert fresh is True
+
+
+def test_an_agent_idle_overnight_still_passes() -> None:
+    # Arrange: a quiet agent legitimately has an old newest row. Flagging this
+    # would make the check noise, and noise is how a real alarm gets ignored.
+    verdict = _assess(newest_row_ts=BOOT - 12 * HOUR)
+    # Act
+    fresh = verdict.fresh
+    # Assert
+    assert fresh is True
+
+
+def test_the_default_threshold_is_a_full_day() -> None:
+    # Arrange: documenting the judgement rather than leaving it implicit.
+    threshold = DEFAULT_STALE_AFTER_S
+    # Act
+    hours = threshold / HOUR
+    # Assert
+    assert hours == 24.0
+
+
+def test_a_caller_that_knows_its_cadence_can_tighten_the_threshold() -> None:
+    # Arrange: a chatty agent's store going quiet for an hour IS suspicious.
+    verdict = _assess(newest_row_ts=BOOT - 2 * HOUR, stale_after_s=HOUR)
+    # Act
+    fresh = verdict.fresh
+    # Assert
+    assert fresh is False
+
+
+def test_an_empty_store_is_not_a_fault() -> None:
+    # Arrange: a new agent's first boot must not shout.
+    verdict = _assess(newest_row_ts=None, had_rows=False)
+    # Act
+    fresh = verdict.fresh
+    # Assert
+    assert fresh is True
+
+
+def test_an_empty_store_is_coded_apart_from_a_healthy_one() -> None:
+    # Arrange: "nothing to compare" and "compared, looks right" are different
+    # facts, and a caller may want to treat them differently.
+    verdict = _assess(newest_row_ts=None, had_rows=False)
+    # Act
+    code = verdict.code
+    # Assert
+    assert code == CODE_EMPTY
+
+
+# ---------------------------------------------------------------------------
+# unknown is not a pass
+# ---------------------------------------------------------------------------
+
+
+def test_rows_exist_but_unreadable_timestamp_is_unknown() -> None:
+    # Arrange: a store that cannot answer this is not a store known to be
+    # healthy. Folding it into a pass is how the original incident hid.
+    verdict = _assess(newest_row_ts=None, had_rows=True)
+    # Act
+    fresh = verdict.fresh
+    # Assert
+    assert fresh is None
+
+
+def test_an_uninspected_store_is_unknown() -> None:
+    # Arrange: had_rows=None means nobody looked.
+    verdict = _assess(newest_row_ts=None, had_rows=None)
+    # Act
+    code = verdict.code
+    # Assert
+    assert code == CODE_UNKNOWN
+
+
+def test_the_unknown_verdict_says_why_it_matters() -> None:
+    # Arrange
+    verdict = _assess(newest_row_ts=None, had_rows=True)
+    # Act
+    reason = verdict.reason
+    # Assert
+    assert "not a store known to be healthy" in reason
+
+
+# ---------------------------------------------------------------------------
+# a row from the future means another writer, or a clock
+# ---------------------------------------------------------------------------
+
+
+def test_a_row_newer_than_this_process_is_flagged() -> None:
+    # Arrange: either a clock disagreement or a second writer, and both mean
+    # this process is not alone — which is the split-brain shape.
+    verdict = _assess(newest_row_ts=BOOT + HOUR)
+    # Act
+    fresh = verdict.fresh
+    # Assert
+    assert fresh is False
+
+
+def test_a_future_row_is_coded_apart_from_a_stale_one() -> None:
+    # Arrange: opposite causes, opposite investigations.
+    verdict = _assess(newest_row_ts=BOOT + HOUR)
+    # Act
+    code = verdict.code
+    # Assert
+    assert code == CODE_FUTURE
+
+
+def test_a_future_row_names_the_two_possible_causes() -> None:
+    # Arrange
+    verdict = _assess(newest_row_ts=BOOT + HOUR)
+    # Act
+    reason = verdict.reason
+    # Assert
+    assert "another writer" in reason
+
+
+# ---------------------------------------------------------------------------
+# the shape validates itself
+# ---------------------------------------------------------------------------
+
+
+def test_a_pass_carrying_a_failure_code_is_rejected() -> None:
+    # Arrange: the shape that lets a caller reading one field conclude the
+    # opposite of the other.
+    fields = dict(fresh=True, code=CODE_STALE, reason="contradictory")
+
+    # Act
+    def build() -> FreshnessVerdict:
+        return FreshnessVerdict(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_an_unknown_carrying_a_pass_code_is_rejected() -> None:
+    # Arrange
+    fields = dict(fresh=None, code=CODE_FRESH, reason="contradictory")
+
+    # Act
+    def build() -> FreshnessVerdict:
+        return FreshnessVerdict(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_verdict_refuses_an_empty_reason() -> None:
+    # Arrange
+    fields = dict(fresh=False, code=CODE_STALE, reason="")
+
+    # Act
+    def build() -> FreshnessVerdict:
+        return FreshnessVerdict(**fields)
+
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_suspicious_verdict_is_truthy_so_callers_must_read_the_field() -> None:
+    # Arrange: deliberately no __bool__, so `if verdict:` cannot read as an
+    # all-clear for a substituted store. Documents the trap rather than hiding it.
+    verdict = _assess(newest_row_ts=BOOT - 30 * 24 * HOUR)
+    # Act
+    truthy = bool(verdict)
+    # Assert
+    assert truthy is True


### PR DESCRIPTION
feat(state): notice at boot that the resolved store is not the one you were using

2026-08-08, measured on this agent. A dotfiles deploy replaced `~/.scitex` — the
LIVE STATE ROOT, credentials included — with a symlink into a git worktree and
moved the real tree aside as `.scitex_back_<timestamp>`. The agent then booted,
resolved its message store inside the substituted tree, found 149 rows whose
newest was a MONTH old, and carried on reporting healthy.

Nothing was broken in a way anything checked for. The store existed, opened,
parsed and answered queries. It simply was not the store that had been in use an
hour earlier, and no component asked the one question that would have said so.

The operator found out four hours later by asking me something I should have
known and getting a blank: 「忘れている、思い出せない、となると結構辛いです。」

DELIBERATELY ABOUT TIME, NOT PATHS. A path check would need to know about
symlinks, overlays, binds and git worktrees, and would still miss the next
mechanism. "The newest row in here is far older than my own start" is true of
every one of those failures and needs to know about none of them.

IT MUST NOT CRY WOLF, which is the harder half. A quiet agent legitimately has
an old newest-row — it may not have been spoken to for days — so the default
threshold is a generous 24h and callers that know their own cadence can tighten
it. An EMPTY store passes rather than warns: a new agent's first boot must not
shout, and "the store is empty when it should not be" is a different check that
would need to know what the agent expects to find. Noise is how a real alarm
gets ignored, and this alarm only fires once in a while by design.

UNKNOWN IS NOT A PASS, and here it is not an edge case. `newest_row_ts=None` is
ambiguous between "empty" and "could not read", so `had_rows` separates them:
False is a decided pass, True or None is UNKNOWN. Folding an unreadable store
into a pass is precisely how the original incident stayed invisible.

A row from the FUTURE gets its own code rather than sharing "stale": it means a
clock disagreement or a second writer, both of which say this process is not
alone — the split-brain shape — and both call for a different investigation than
a substituted store.

Same discipline as the relocate modules: pure and injectable, three-valued with
a validator that rejects a pass carrying a failure code, declared numeric codes,
and no `__bool__` so `if verdict:` cannot read as an all-clear for a substituted
store. A test documents that trap rather than hiding it.

20 tests, written against the measured incident rather than an invented one.

Card: sac-cct-store-diverges-across-restart-two-dbs-20260808 (item 3)
Not wired into any boot path yet — this is the predicate. Wiring it is a
separate change, because where it belongs depends on the postgres
standardisation the operator asked for (fleet-postgres-everywhere-one-store-convention-20260808).
