### PR TITLE
feat(lifecycle): the probe adapter — a failed probe stays UNKNOWN, never "no"

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_relocate_probe.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe.py
@@ -1,0 +1,145 @@
+"""Turn probe results into :class:`TargetFacts`, where a failed probe stays UNKNOWN.
+
+:mod:`_relocate_preflight` decides; this fills in what it decides about. The
+split is the operator's ports-and-adapters point (2026-08-08): sac's core must
+not learn how to reach a host, so the checks take facts and this takes
+callables. Swap ssh for the listen daemon, or for a test double, and the
+decision logic never changes.
+
+THE ONE RULE THIS MODULE EXISTS TO ENFORCE: a probe that FAILS produces
+``None`` (not observed), never a falsy value. That distinction is the whole
+point of the three-valued preflight, and it is trivially easy to destroy here —
+one bare ``except: return False`` in a prober turns "I could not reach the host"
+into "the host says no", and the report then refuses (or worse, passes) for a
+reason nobody can trace.
+
+It is worth being explicit about which direction each mistake goes:
+
+    probe raises -> False   a missing image reads as present, a busy port as
+                            free. The relocation proceeds on fiction.
+    probe raises -> None    preflight reports UNKNOWN, refuses, and names the
+                            check to re-run. Nothing proceeds on fiction.
+
+So every call here is wrapped, every exception becomes ``None``, and the
+exception text is kept on the side so the caller can say WHY a fact is missing
+rather than only that it is.
+
+Pure orchestration: no ssh, no subprocess, no imports of anything that talks to
+a network. The callables are the caller's.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, TypeVar
+
+from ._relocate_preflight import TargetFacts
+
+__all__ = ["ProbeOutcome", "TargetProbes", "gather_target_facts", "probe"]
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class ProbeOutcome:
+    """One probe's result, with the failure kept rather than discarded."""
+
+    value: object | None
+    error: str | None = None
+
+    @property
+    def observed(self) -> bool:
+        return self.error is None
+
+
+def probe(fn: Callable[[], T]) -> ProbeOutcome:
+    """Run ``fn``; on ANY exception record it and return an unobserved outcome.
+
+    Deliberately catches broadly. A prober can fail in as many ways as a network
+    can, and enumerating them here would mean the un-enumerated one becomes an
+    uncaught crash mid-preflight — which is a worse outcome than an honest
+    "could not tell". The exception is preserved, so nothing is actually
+    swallowed; it just stops being fatal.
+    """
+    try:
+        return ProbeOutcome(value=fn())
+    except Exception as exc:  # stx-allow: fallback (reason: a probe failure must become UNOBSERVED, never a false negative; the exception is preserved on the outcome)
+        return ProbeOutcome(value=None, error=f"{type(exc).__name__}: {exc}")
+
+
+@dataclass
+class TargetProbes:
+    """The callables that answer each preflight question.
+
+    Every one is optional. An omitted probe leaves its fact ``None`` — which
+    preflight reports as UNKNOWN and refuses on, exactly as it would for a probe
+    that ran and failed. "Nobody asked" and "asked and could not tell" are the
+    same thing from the decision's point of view, and both are distinct from an
+    answer.
+    """
+
+    reachable: Callable[[], bool] | None = None
+    image_present: Callable[[], bool] | None = None
+    missing_bind_sources: Callable[[], tuple[str, ...]] | None = None
+    card_store_url: Callable[[], str] | None = None
+    card_store_reachable: Callable[[], bool] | None = None
+    credential_expires_in_s: Callable[[], float] | None = None
+    credential_refresh_token_present: Callable[[], bool] | None = None
+    supported_runtimes: Callable[[], tuple[str, ...]] | None = None
+    rejected_spec_keys: Callable[[], tuple[str, ...]] | None = None
+    ports_in_use: Callable[[], tuple[int, ...]] | None = None
+    hub_reachable_from_target: Callable[[], bool] | None = None
+
+
+@dataclass(frozen=True)
+class GatherResult:
+    """The facts, plus why any of them are missing.
+
+    ``errors`` maps fact name -> failure text. A caller rendering the preflight
+    report can then say "credentials: UNKNOWN (SSHTimeout: ...)" instead of the
+    bare "not observed" the checks alone can offer.
+    """
+
+    facts: TargetFacts
+    errors: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def all_observed(self) -> bool:
+        return not self.errors
+
+
+_FIELDS: tuple[str, ...] = (
+    "reachable",
+    "image_present",
+    "missing_bind_sources",
+    "card_store_url",
+    "card_store_reachable",
+    "credential_expires_in_s",
+    "credential_refresh_token_present",
+    "supported_runtimes",
+    "rejected_spec_keys",
+    "ports_in_use",
+    "hub_reachable_from_target",
+)
+
+
+def gather_target_facts(probes: TargetProbes) -> GatherResult:
+    """Run every supplied probe, collecting facts and failures side by side.
+
+    Runs ALL of them rather than stopping at the first failure — the same
+    reasoning as preflight returning every check: a dry run that stops early
+    makes the operator run it N times to find N problems. A probe that fails
+    does not prevent the others from answering.
+    """
+    values: dict[str, object] = {}
+    errors: dict[str, str] = {}
+    for name in _FIELDS:
+        fn = getattr(probes, name, None)
+        if fn is None:
+            continue
+        outcome = probe(fn)
+        if outcome.observed:
+            values[name] = outcome.value
+        else:
+            errors[name] = outcome.error or "unknown failure"
+    return GatherResult(facts=TargetFacts(**values), errors=errors)  # type: ignore[arg-type]

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe.py
@@ -1,0 +1,271 @@
+"""A probe that fails must say "I could not tell", never "no".
+
+`_relocate_preflight` is three-valued so that a failed check cannot masquerade
+as a decided one. That guarantee is trivially destroyed one layer down: a single
+`except: return False` in a prober turns "I could not reach the host" into "the
+host says no", and the report then refuses — or worse, passes — for a reason
+nobody can trace back.
+
+The two directions, since only one of them is safe:
+
+    probe raises -> False   a missing image reads as present, a busy port as
+                            free; the relocation proceeds on fiction
+    probe raises -> None    preflight reports UNKNOWN, refuses, and names the
+                            check to re-run
+
+These tests pin the second. They also pin that the failure TEXT survives, so a
+report can say why a fact is missing rather than only that it is.
+
+Real callables, including ones that raise. No mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_preflight import preflight
+from scitex_agent_container._lifecycle._relocate_probe import (
+    TargetProbes,
+    gather_target_facts,
+    probe,
+)
+
+
+class Boom(RuntimeError):
+    """A prober failing the way a network does."""
+
+
+def _raises() -> bool:
+    raise Boom("ssh: connect to host nas-03 port 22: Connection timed out")
+
+
+# ---------------------------------------------------------------------------
+# a failed probe is unobserved, not false
+# ---------------------------------------------------------------------------
+
+
+def test_a_successful_probe_is_observed() -> None:
+    # Arrange
+    outcome = probe(lambda: True)
+    # Act
+    observed = outcome.observed
+    # Assert
+    assert observed is True
+
+
+def test_a_raising_probe_is_not_observed() -> None:
+    # Arrange
+    outcome = probe(_raises)
+    # Act
+    observed = outcome.observed
+    # Assert
+    assert observed is False
+
+
+def test_a_raising_probe_yields_no_value() -> None:
+    # Arrange: the value must be None, NOT False — False is an answer.
+    outcome = probe(_raises)
+    # Act
+    value = outcome.value
+    # Assert
+    assert value is None
+
+
+def test_a_raising_probe_keeps_the_failure_text() -> None:
+    # Arrange: nothing is swallowed; it just stops being fatal.
+    outcome = probe(_raises)
+    # Act
+    error = outcome.error
+    # Assert
+    assert "Connection timed out" in (error or "")
+
+
+def test_a_probe_returning_false_is_still_an_answer() -> None:
+    # Arrange: the distinction only works if an observed negative survives it.
+    outcome = probe(lambda: False)
+    # Act
+    observed = outcome.observed
+    # Assert
+    assert observed is True
+
+
+# ---------------------------------------------------------------------------
+# gathering
+# ---------------------------------------------------------------------------
+
+
+def test_supplied_probes_populate_their_facts() -> None:
+    # Arrange
+    probes = TargetProbes(reachable=lambda: True, image_present=lambda: True)
+    # Act
+    result = gather_target_facts(probes)
+    # Assert
+    assert result.facts.reachable is True
+
+
+def test_an_omitted_probe_leaves_its_fact_unobserved() -> None:
+    # Arrange: "nobody asked" and "asked and could not tell" are the same thing
+    # from the decision's point of view, and both differ from an answer.
+    probes = TargetProbes(reachable=lambda: True)
+    # Act
+    result = gather_target_facts(probes)
+    # Assert
+    assert result.facts.image_present is None
+
+
+def test_a_failing_probe_leaves_its_fact_unobserved() -> None:
+    # Arrange: the failure this module exists to prevent is this becoming False.
+    probes = TargetProbes(image_present=_raises)
+    # Act
+    result = gather_target_facts(probes)
+    # Assert
+    assert result.facts.image_present is None
+
+
+def test_a_failing_probe_is_reported_by_name() -> None:
+    # Arrange
+    probes = TargetProbes(image_present=_raises)
+    # Act
+    result = gather_target_facts(probes)
+    # Assert
+    assert "image_present" in result.errors
+
+
+def test_the_failure_reason_is_available_to_the_report() -> None:
+    # Arrange: so a reader sees "UNKNOWN (ssh timed out)", not bare "UNKNOWN".
+    probes = TargetProbes(image_present=_raises)
+    # Act
+    result = gather_target_facts(probes)
+    # Assert
+    assert "Connection timed out" in result.errors["image_present"]
+
+
+def test_one_failing_probe_does_not_stop_the_others() -> None:
+    # Arrange: a dry run that stops early makes the operator run it N times to
+    # find N problems — the same reasoning as preflight returning every check.
+    probes = TargetProbes(reachable=_raises, image_present=lambda: True)
+    # Act
+    result = gather_target_facts(probes)
+    # Assert
+    assert result.facts.image_present is True
+
+
+def test_all_observed_is_true_when_nothing_failed() -> None:
+    # Arrange
+    probes = TargetProbes(reachable=lambda: True)
+    # Act
+    result = gather_target_facts(probes)
+    # Assert
+    assert result.all_observed is True
+
+
+def test_all_observed_is_false_when_something_failed() -> None:
+    # Arrange
+    probes = TargetProbes(reachable=_raises)
+    # Act
+    result = gather_target_facts(probes)
+    # Assert
+    assert result.all_observed is False
+
+
+def test_no_probes_at_all_yields_entirely_unobserved_facts() -> None:
+    # Arrange: a caller that ran nothing must not produce a go.
+    probes = TargetProbes()
+    # Act
+    result = gather_target_facts(probes)
+    # Assert
+    assert result.facts.reachable is None
+
+
+# ---------------------------------------------------------------------------
+# the two layers agree: a failed probe reaches preflight as UNKNOWN
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_probe_makes_preflight_refuse_rather_than_pass() -> None:
+    # Arrange: everything healthy EXCEPT one probe that cannot answer. If the
+    # adapter degraded that to False the verdict would be a decided refusal; if
+    # it degraded to True it would be a go. It must be neither.
+    probes = TargetProbes(
+        reachable=lambda: True,
+        image_present=lambda: True,
+        missing_bind_sources=lambda: (),
+        card_store_reachable=lambda: True,
+        credential_expires_in_s=lambda: 3600.0,
+        credential_refresh_token_present=_raises,  # <- cannot answer
+        supported_runtimes=lambda: ("apptainer",),
+        rejected_spec_keys=lambda: (),
+        ports_in_use=lambda: (),
+        hub_reachable_from_target=lambda: True,
+    )
+    gathered = gather_target_facts(probes)
+    # Act
+    report = preflight(
+        agent="a", to_host="nas-03", facts=gathered.facts, runtime="apptainer"
+    )
+    # Assert
+    assert report.ok is None
+
+
+def test_a_fully_healthy_probe_set_passes_preflight() -> None:
+    # Arrange: the positive control — without it, the test above could pass
+    # because the probe set is wrong rather than because unknown propagates.
+    probes = TargetProbes(
+        reachable=lambda: True,
+        image_present=lambda: True,
+        missing_bind_sources=lambda: (),
+        card_store_reachable=lambda: True,
+        credential_expires_in_s=lambda: 3600.0,
+        credential_refresh_token_present=lambda: True,
+        supported_runtimes=lambda: ("apptainer",),
+        rejected_spec_keys=lambda: (),
+        ports_in_use=lambda: (),
+        hub_reachable_from_target=lambda: True,
+    )
+    gathered = gather_target_facts(probes)
+    # Act
+    report = preflight(
+        agent="a", to_host="nas-03", facts=gathered.facts, runtime="apptainer"
+    )
+    # Assert
+    assert report.ok is True
+
+
+def test_an_observed_negative_still_reaches_preflight_as_a_refusal() -> None:
+    # Arrange: the adapter must not blunt real answers into unknowns either.
+    probes = TargetProbes(
+        reachable=lambda: True,
+        image_present=lambda: False,  # <- a real, observed "no"
+        missing_bind_sources=lambda: (),
+        card_store_reachable=lambda: True,
+        credential_expires_in_s=lambda: 3600.0,
+        credential_refresh_token_present=lambda: True,
+        supported_runtimes=lambda: ("apptainer",),
+        rejected_spec_keys=lambda: (),
+        ports_in_use=lambda: (),
+        hub_reachable_from_target=lambda: True,
+    )
+    gathered = gather_target_facts(probes)
+    # Act
+    report = preflight(
+        agent="a", to_host="nas-03", facts=gathered.facts, runtime="apptainer"
+    )
+    # Assert
+    assert report.ok is False
+
+
+def test_a_keyboard_interrupt_is_not_swallowed_as_a_probe_failure() -> None:
+    # Arrange: broad catching is deliberate for probe errors, but an operator
+    # pressing Ctrl-C must still stop the run rather than become "unobserved".
+    def interrupted() -> bool:
+        raise KeyboardInterrupt
+
+    probes = TargetProbes(reachable=interrupted)
+
+    # Act
+    def run() -> object:
+        return gather_target_facts(probes)
+
+    # Assert
+    with pytest.raises(KeyboardInterrupt):
+        run()


### PR DESCRIPTION
feat(lifecycle): the probe adapter — a failed probe stays UNKNOWN, never "no"

The adapter half of the preflight split (#890). That module decides; this fills
in what it decides about, and keeps sac's core from learning how to reach a
host — the operator's ports-and-adapters point, applied where it actually bites.

THE ONE RULE THIS EXISTS TO ENFORCE. #890 is three-valued so a check that could
not answer cannot masquerade as one that did. That guarantee is trivially
destroyed one layer down: a single `except: return False` in a prober turns "I
could not reach the host" into "the host says no". Which direction the mistake
goes decides whether a relocation proceeds on fiction:

    probe raises -> False   a missing image reads as present, a busy port as
                            free; the relocation proceeds on fiction
    probe raises -> None    preflight reports UNKNOWN, refuses, and names the
                            check to re-run

So every call is wrapped, every exception becomes None, and the exception TEXT
is kept beside the facts. Nothing is swallowed — it stops being fatal, and a
report can say "credentials: UNKNOWN (ssh timed out)" rather than bare
"not observed".

The catch is deliberately broad. A prober fails in as many ways as a network
does, and enumerating them means the un-enumerated one crashes mid-preflight —
worse than an honest "could not tell". KeyboardInterrupt still propagates
(BaseException, not Exception), and there is a test for that: broad catching
must not stop an operator pressing Ctrl-C.

An OMITTED probe leaves its fact None too. "Nobody asked" and "asked and could
not tell" are the same thing from the decision's point of view, and both differ
from an answer.

All probes run even when one fails — same reasoning as preflight returning every
check rather than the first failure: a dry run that stops early makes the
operator run it N times to find N problems.

Three tests cover the seam between the layers rather than either alone: a failed
probe reaches preflight as UNKNOWN (not a refusal, not a pass), a fully healthy
set passes — the positive control, without which the first test could pass
because the probe set is malformed rather than because unknown propagates — and
an OBSERVED negative still arrives as a refusal, so the adapter does not blunt
real answers into unknowns either.

18 tests. Card: sac-agents-move-relocate-an-agent-between-hosts-atomically-20260807
Remaining there: the cross-host transcript transport, then the CLI verb. This
was the last piece that touches nothing.
