### PR TITLE
docs(runtimes): the bind list's parent can be SUBSTITUTED, not just overlay-local

### DIFF
--- a/src/scitex_agent_container/runtimes/_p3a_default_binds.py
+++ b/src/scitex_agent_container/runtimes/_p3a_default_binds.py
@@ -75,6 +75,24 @@ _FLEET_DEFAULT_BINDS: tuple[str, ...] = (
     # widening would expose it to every agent. One bind per store; each new
     # store pays its own explicit line. That cost is the feature.
     #
+    # AND THE PARENT IS NOT ONLY "overlay-local" — 2026-08-08 measured a SECOND
+    # way it moves under you, which none of these binds defend against. A
+    # dotfiles deploy ran inside a container, treated ~/.scitex as a DOTFILE,
+    # moved the real tree aside as .scitex_back_<timestamp> and symlinked its
+    # own copy in:
+    #     /home/agent/.scitex -> ~/.dotfiles/.worktrees/<branch>/src/.scitex
+    # The agent then booted into the substituted tree with a month-stale message
+    # store and reported healthy, and the credential path resolved to a
+    # directory that does not exist. The operator lost an hour of his evening to
+    # it (card sac-cct-store-diverges-across-restart-two-dbs-20260808).
+    #
+    # WHY THAT MATTERS TO WHOEVER EDITS THIS LIST: a per-store bind here cannot
+    # survive its PARENT being replaced. These lines make each store
+    # host-persistent, which is necessary and not sufficient. Do not read a
+    # green bind as proof the agent is using the store you think it is —
+    # `readlink -f` the path from INSIDE the container, which is the only check
+    # that sees a substituted parent.
+    #
     # Skip-if-missing applies (see default_binds_for_host): on a host with no
     # ~/.scitex/cards this entry is a SILENT no-op — safe, but NOT a signal.
     # Verify a rollout by comparing dev:inode from INSIDE a booted container


### PR DESCRIPTION
docs(runtimes): the bind list's parent can be SUBSTITUTED, not just overlay-local

Comment only. The list is unchanged and its 23 tests still pass.

`_FLEET_DEFAULT_BINDS` teaches its next editor that the reason each store pays
its own line is that `/home/agent/.scitex` is "overlay-local" (measured
2026-07-16 by scitex-cards). That is true and incomplete, and the missing half
cost the operator an hour of his evening on 2026-08-08.

The second way the parent moves under you: a dotfiles deploy ran INSIDE a
container, treated `~/.scitex` as a dotfile, moved the real tree aside as
`.scitex_back_<timestamp>` and symlinked its own copy in —

    /home/agent/.scitex -> ~/.dotfiles/.worktrees/<branch>/src/.scitex

The agent then booted into the substituted tree with a month-stale message
store and reported healthy; the credential path resolved to a directory that
does not exist. He noticed by asking me something I should have known and
getting a blank.

WHY THIS BELONGS IN THIS COMMENT SPECIFICALLY: a per-store bind cannot survive
its PARENT being replaced. Someone reading this list — including me, four hours
ago — can reasonably conclude that adding a line makes a store safe. It makes it
host-persistent, which is necessary and not sufficient. The comment now says so,
and names the only check that sees a substituted parent: `readlink -f` from
INSIDE the container. Reading the argv, or trusting a green bind, cannot.

That is the same lesson the block already teaches about skip-if-missing (a bind
for a nonexistent host dir is a silent no-op), one level up: the argv proves
what was requested, never what resolved.

Cause and fix are dotfiles' and tracked there
(dotfiles-deploy-replaces-agent-state-root-with-a-symlink-20260808). This change
only stops sac's own comment from teaching half the story.
