### PR TITLE
feat(relocate): the dry run — three answers, and DECLARED never shares a column with OBSERVED

### DIFF
--- a/docs/relocate.md
+++ b/docs/relocate.md
@@ -1,0 +1,283 @@
+# Relocating an agent between hosts
+
+**Scope of this document.** Everything you must do BEFORE a relocation, the
+procedure ITSELF, and what must be true AFTER. Written so that it is sufficient
+on its own: if the relocated agent arrives with no memory of the conversation
+that moved it, handing it this file is enough to continue.
+
+That fallback is a **workaround, not the design**. An agent that needs a
+document to remember what it was doing has not been relocated, it has been
+replaced. Carrying the session is relocate's own job — see
+[§5 Session continuity](#5-session-continuity) for what is built and what is not.
+
+---
+
+## 0. What relocate is, and what it is not
+
+| | axis that changes | identity | count |
+|---|---|---|---|
+| **relocate** | WHERE it runs | unchanged | 1 → 1 |
+| **fork / twin** | WHAT it does | new | 1 → 2 |
+
+The agent relocates. The host does not move. Relocate is *not* a kind of twin,
+and neither verb should be described in terms of the other; they share exactly
+one implementation detail (seeding a session from an existing transcript) and
+nothing else.
+
+**Why the command exists at all.** `cardinality: singleton` is declared in the
+spec and enforced by nothing. Identity lives in the spec and `host:` is just a
+field, so copying a spec to another machine and starting it produces TWO live
+agents under one identity, with no error. There is no "relocate" without this
+command — there is only "copy and start", and copy-and-start makes two. That is
+the root of the 2026-08-07 card-store split-brain.
+
+---
+
+## 1. Before you begin — the failure this is all guarding against
+
+On 2026-08-07 this move was done by hand. Rewriting `host:` alone produced an
+agent that **started, reported healthy, and did nothing**. That is the worst
+failure shape available, because it looks exactly like success and nobody goes
+looking.
+
+Every check in §2 exists because of a specific thing that went wrong that day.
+None of them is hypothetical.
+
+---
+
+## 2. BEFORE — preflight
+
+Run the dry run first. It touches nothing and returns **every** problem, not the
+first one, so you do not have to run it N times to find N problems.
+
+```bash
+sac agents relocate <name> --to <host> --dry-run
+```
+
+### The nine checks
+
+| check | what it catches | the 2026-08-07 instance |
+|---|---|---|
+| `target_reachable` | host does not answer | — nothing else in the report means anything until this passes |
+| `image_present` | SIF absent on the target | a missing image fails at boot, **after** the lease has moved |
+| `binds_exist_on_target` | bind source paths absent there | the spec bound `/mnt/c`, a Windows drive that does not exist on the nas |
+| `card_store_reachable` | agent cannot reach its board | `SCITEX_CARDS_DB` is port 5432 here, 5442 there |
+| `credentials_valid` | **validity, not presence** | the nas had a file expired 2026-05-23 with an empty `refreshToken`, and sac loaded it *in preference to* the good one — every turn 401'd while `sac agents health` still said healthy |
+| `runtime_supported` | target's sac rejects the runtime | nas's sac 0.21.9 rejects `tui` |
+| `spec_schema_accepted` | target's validator rejects a key | a top-level `provider:` key, same older validator |
+| `ports_free` | port already bound there | reassign in the spec before moving |
+| `hub_reachable_from_target` | hub unreachable **from there** | the nas's services bind `127.0.0.1`, so reaching them from HERE proves nothing about THERE |
+
+**Read the credentials row twice.** A presence check passes on an expired file.
+The failure it prevents is silent.
+
+### Three answers, not two
+
+Every check is **three-valued**: pass / fail / **could not determine**. Unknown
+never counts as a pass, and it is reported separately from failure, because
+"this is wrong" and "I could not tell" call for different actions from you.
+
+A probe that fails produces `None` (not observed), never a falsy value. This
+matters more than it looks:
+
+```
+probe raises -> False   a missing image reads as present, a busy port as free.
+                        The relocation proceeds on fiction.
+probe raises -> None    preflight reports UNKNOWN, refuses, names the check.
+                        Nothing proceeds on fiction.
+```
+
+An unobserved fact folded into "pass" is precisely how the 08-07 move reported
+healthy.
+
+### Do not skip the unknowns
+
+If the dry run says UNKNOWN, the answer is to run the missing probe — not to
+proceed because nothing said no.
+
+---
+
+## 3. THE PROCEDURE — an ordered handover of one write lease
+
+### Why a lease and not a handshake
+
+The obvious design is a mutual handshake: the source confirms the target is up,
+the target confirms the source is gone. **Do not do this.** Under a partition,
+mutual confirmation either deadlocks (both wait) or double-commits (both
+proceed) — which is the same failure it was meant to prevent.
+
+Instead there is exactly ONE write-lease token. Whoever holds it may write;
+nobody else can. **Two holders is unrepresentable.** Relocation is the ordered
+handoff of that token, driven by the relocate command as coordinator, never by
+agreement between peers.
+
+### TTL decides reclaim; the fence decides who may write
+
+The lease carries a TTL, and a TTL assumes clocks agree. A stopped container, a
+suspended laptop, or an NTP step hands a source a lease it *honestly believes*
+is valid.
+
+So every lease also carries an integer that only increases, bumped on each
+handoff and each reclaim. A writer presents its fence, and anything below the
+current value is refused. The stale holder is locked out by arithmetic rather
+than by trusting its clock.
+
+### The six phases
+
+```
+PREFLIGHT  ->  TARGET_STANDBY  ->  SOURCE_DRAIN  ->  HANDOVER  ->  SOURCE_STOP  ->  DONE
+                                                     ^^^^^^^^
+                                          the single atomic point
+```
+
+| phase | what happens |
+|---|---|
+| `PREFLIGHT` | validate the target; touch nothing |
+| `TARGET_STANDBY` | start the target **without** the lease — it runs read-only; verify health |
+| `SOURCE_DRAIN` | source finishes in-flight work, stops accepting new |
+| `HANDOVER` | the lease moves source → target |
+| `SOURCE_STOP` | stop the source, and **verify** it stopped |
+| `DONE` | append the residency record |
+
+Every step is idempotent and journalled, so a crash **resumes** rather than
+restarts. Advancing to the phase you are already in succeeds and appends
+nothing: a coordinator that finished the work and died before journalling
+re-runs harmlessly. Skipping is refused, and the refusal names the next legal
+step. Going backward is refused.
+
+### If it dies mid-way
+
+| when | state | what to do |
+|---|---|---|
+| before `HANDOVER` | lease still with the source; target is standby and harmless | re-run: it resumes, or abort cleanly |
+| after `HANDOVER`, before `SOURCE_STOP` | target holds the lease; the source is alive but **cannot write** | re-run: it completes the stop. Fails safe. |
+| target never healthy | abort; the lease never moves; the source is untouched | fix the target, re-run |
+| network partition | the holder that cannot renew **stops writing**; nobody else may claim until the TTL expires | wait, or reclaim deliberately |
+
+**`abort` is refused at or past `HANDOVER`.** Undoing there would mean taking
+write authority back from a live holder — that is itself a relocation and should
+be run as one, not smuggled in under a name that promises the opposite. The
+refusal names the host that now owns the lease.
+
+### What the lease does NOT govern
+
+Only writes to the **shared** hub store. Each host's LOCAL store keeps accepting
+local work while partitioned — every host must stay usable with no network.
+Reconciliation settles it afterwards. A network outage must never become a fleet
+outage.
+
+---
+
+## 4. AFTER — what must be true
+
+1. **The source is stopped, verified.** Not "stop was requested" — confirm it.
+2. **The target holds the lease** and its fence is above the source's.
+3. **The residency record is appended**: `{host, from_ts, to_ts}`.
+   - Boundaries are half-open `[from_ts, to_ts)`, so the handover instant
+     belongs to the **target**. That is the one moment two answers would
+     otherwise be possible.
+   - `to_ts is None` means *still living there* — an open interval, not a
+     missing value.
+   - `host_at(history, ts)` returning `None` means the history genuinely does
+     not know (before the first record, or a gap while stopped). **Never read
+     that as "the current host"** — that guess is what makes a split-brain look
+     explained when it is not.
+4. **The agent answers.** Send it something and confirm the reply. Confirm
+   arrival, not dispatch.
+5. **Its board is reachable from the new host** — re-check, since the card store
+   port differs per host.
+
+### Why residency is worth keeping
+
+The audit trail is the smaller half. The larger half is **attribution**: the
+cards `host` column is NULL on 3247 of 3424 rows, so when two instances of one
+identity disagree, nothing can say which host wrote which row. With residency
+that becomes a lookup instead of an investigation.
+
+---
+
+## 5. Session continuity
+
+### The measurement
+
+The nas instance booted with **no memory** of the originating conversation. The
+transcript lives inside the container overlay, so carrying it means copying it
+explicitly. Nothing about a host change carries it for free.
+
+### The decision
+
+**Relocate implies continuity.** `--no-carry-session` opts out.
+
+Reasoning, from the definition rather than preference: relocate changes WHERE an
+agent runs; identity is unchanged and the count stays 1. It is the SAME agent
+continuing. Making continuity opt-IN would mean the default produces the outcome
+we filed as the defect. The opt-out exists for the deliberate case — a wedged
+session you want to leave behind — and should be loud about what it discards.
+
+### The mechanism
+
+1. Resolve the source's current session uuid from `<state>/session_id`.
+2. Write that uuid as the target's `session_id` marker, so `session: continue`
+   resumes it.
+3. Copy the source's `<uuid>.jsonl` into the target's projects store,
+   **mirroring the source's project subdir name** so claude's cwd encoding
+   matches without recomputing it.
+4. **First boot only.** If the target already has its own marker it has booted
+   and diverged, and re-seeding would discard that history.
+
+### Verify readability ON THE TARGET
+
+Do not trust the copy's exit code. A path inside a container can resolve
+somewhere entirely unexpected — a moved-aside tree, a git worktree — while every
+operation on it succeeds. On 2026-08-08 `~/.scitex` inside a container turned
+out to be a symlink into a dotfiles worktree, created mid-session, with every
+write "succeeding" into a tree a `git clean -xdf` can erase. Read the transcript
+back from the target before declaring the carry done.
+
+### Honest status
+
+The **decision** logic is built and merged (`_session_carry.plan_session_carry`).
+The cross-host **transport** that executes a `carry=True` plan is not. Until it
+lands, a relocation carries no memory, and this document is the stopgap the
+operator asked for.
+
+---
+
+## 6. Current implementation status
+
+| piece | state | what it guarantees |
+|---|---|---|
+| write lease + fence | **merged** (#888) | two writers unrepresentable |
+| phase journal | **merged** (#889) | a crash resumes; a handover is never undone |
+| preflight checks | **merged** (#890) | the target is checked before anything is touched |
+| session-carry decision | **merged** (#891) | whether the transcript follows the agent |
+| residency history | **merged** (#892) | where it lived, and who wrote a row |
+| probe adapter | **merged** (#894) | a failed probe stays UNKNOWN, never a false negative |
+| cross-host transcript transport | **not built** | — |
+| the `relocate` CLI verb | **in progress** | dry-run first |
+
+Six pure pieces, 138+ tests, none of which touches a host — that was deliberate,
+so each is testable without a second machine. The two remaining items are the
+ones that act.
+
+**Until the CLI lands, a relocation is a manual procedure**: follow §2 by hand,
+then §3, then §4. The checks in §2 are the ones a hand-move actually needs; they
+are written down here precisely because they were learned the hard way.
+
+---
+
+## 7. Known gaps
+
+- **Relocate does not yet carry memory.** §5 — decision merged, transport not.
+  This document exists because of that gap and should shrink when it closes.
+- **"Defined" and "running" are not distinguished.** The fleet listing collapses
+  a spec that exists with a process that is alive, so from inside a container
+  `sac agents list` reports the whole fleet — including the agent running the
+  command — as `defined`. Before relocating, confirm what is actually running by
+  another route.
+  Card: `sac-agents-list-blind-inside-container-reports-whole-fleet-defined-20260808`.
+- **Four sources disagree about which agents exist** (18 / 32 / 159 / 111 as
+  measured 2026-08-08). Which is canonical is an open decision.
+- **Host naming is not yet canonical.** Relocate must write the canonical
+  `scitex-<category>-0N` name.
+  Card: `sac-standardize-host-naming-and-fail-loud-during-rename-20260807`.

--- a/src/scitex_agent_container/_lifecycle/_relocate_render.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_render.py
@@ -1,0 +1,147 @@
+"""Render a relocation dry run so DECLARED and OBSERVED never share a column.
+
+The operator's requirement, 2026-08-08: 「定義されているのと、今動いているのって
+違うんで」 — what a spec DECLARES and what a host actually SHOWS are different
+facts, and collapsing them into one column is how `sac agents list` ends up
+reporting a running agent as `defined`. This renderer keeps them in separate
+sections so a reader cannot mistake one for the other.
+
+THREE OUTCOMES, THREE WORDS. ``PASS`` / ``FAIL`` / ``UNKNOWN``, never two.
+:mod:`_relocate_preflight` is three-valued precisely so "I could not tell"
+survives to the operator, and a renderer that prints unknowns as failures (or
+worse, omits them) throws that away at the last step. They call for different
+actions: a FAIL is something to fix, an UNKNOWN is something to go and measure.
+
+WHY THE PROBE ERROR IS PRINTED NEXT TO THE UNKNOWN. ``gather_target_facts``
+keeps the exception text rather than discarding it, so the line can say
+``credentials_valid: UNKNOWN (SSHTimeout: ...)`` instead of the bare "was not
+observed" the checks alone can offer. Without it the operator knows a fact is
+missing but not why, which turns a five-second fix into an investigation.
+
+Pure: strings in, strings out. No click, no console, no colour — the caller
+decides how to paint them, and tests can assert on exact lines.
+"""
+
+from __future__ import annotations
+
+from ._relocate_preflight import PreflightReport
+
+__all__ = [
+    "VERDICT_GO",
+    "VERDICT_REFUSED",
+    "VERDICT_UNKNOWN",
+    "render_declared",
+    "render_dry_run",
+    "render_observed",
+    "verdict_line",
+]
+
+VERDICT_GO = "GO"
+VERDICT_REFUSED = "REFUSED"
+VERDICT_UNKNOWN = "REFUSED (undetermined)"
+
+_LABEL = {True: "PASS", False: "FAIL", None: "UNKNOWN"}
+
+
+def render_declared(declared: dict[str, object]) -> list[str]:
+    """The spec's own claims, labelled as claims.
+
+    Printed BEFORE the observations and explicitly marked unverified, because
+    this section is the input to the checks, not evidence about the target. A
+    reader who skims should not come away thinking the runtime was confirmed
+    merely because it appeared in the output.
+    """
+    lines = ["DECLARED (from the spec — not verified by this run)"]
+    if not declared:
+        lines.append("  (nothing declared)")
+        return lines
+    width = max(len(k) for k in declared)
+    for key, value in declared.items():
+        lines.append(f"  {key:<{width}}  {_fmt(value)}")
+    return lines
+
+
+def _fmt(value: object) -> str:
+    if value is None:
+        return "(unset)"
+    if isinstance(value, (list, tuple)):
+        return ", ".join(str(v) for v in value) if value else "(none)"
+    return str(value)
+
+
+def render_observed(
+    report: PreflightReport, errors: dict[str, str] | None = None
+) -> list[str]:
+    """One line per check, plus the hint and probe error where they exist.
+
+    Every check is printed, including the passes. A dry run that shows only
+    problems leaves the operator unable to tell "this check passed" from "this
+    check was never run" — and that ambiguity is the exact defect the three
+    outcomes exist to remove.
+    """
+    errors = errors or {}
+    lines = [f"OBSERVED (probed on {report.to_host})"]
+    width = max((len(c.name) for c in report.checks), default=0)
+    for check in report.checks:
+        lines.append(f"  {_LABEL[check.ok]:<8} {check.name:<{width}}  {check.detail}")
+        why = errors.get(check.name)
+        if why:
+            lines.append(f"           probe error: {why}")
+        if check.ok is not True and check.hint:
+            lines.append(f"           -> {check.hint}")
+    return lines
+
+
+def verdict_line(report: PreflightReport) -> str:
+    """One sentence a reader can act on, with the counts that justify it.
+
+    An unknown refuses exactly as firmly as a failure — but says so in its own
+    words, so the operator knows to go and measure rather than to go and fix.
+    """
+    n_fail = len(report.failed)
+    n_unknown = len(report.unknown)
+    if report.ok is True:
+        return (
+            f"VERDICT  {VERDICT_GO} — every check passed ({len(report.checks)} checks)"
+        )
+    if report.ok is False:
+        tail = f", {n_unknown} could not be determined" if n_unknown else ""
+        return f"VERDICT  {VERDICT_REFUSED} — {n_fail} failed{tail}"
+    return (
+        f"VERDICT  {VERDICT_UNKNOWN} — nothing failed, but {n_unknown} "
+        "could not be determined; an unmeasured check is not a passing one"
+    )
+
+
+def render_dry_run(
+    report: PreflightReport,
+    *,
+    declared: dict[str, object] | None = None,
+    errors: dict[str, str] | None = None,
+) -> list[str]:
+    """The whole dry run, in the order a reader needs it.
+
+    Header first so the agent and target are unambiguous, then what the spec
+    claims, then what the host showed, then the verdict — and the verdict is
+    repeated as blocking reasons at the end, because the operator asked for a
+    dry run that surfaces EVERY problem in one pass rather than one per run.
+    """
+    lines = [
+        f"relocate {report.agent} -> {report.to_host}   DRY RUN (nothing was touched)",
+        "",
+    ]
+    lines += render_declared(declared or {})
+    lines.append("")
+    lines += render_observed(report, errors)
+    lines.append("")
+    lines.append(verdict_line(report))
+    blocking = report.failed + report.unknown
+    if blocking:
+        lines.append("")
+        lines.append("BLOCKING — fix or measure each of these, then re-run:")
+        # Names and details only. The hints are already printed inline above,
+        # and repeating nine identical "run the probe that supplies this fact"
+        # paragraphs turns the summary — the part that gets pasted into chat —
+        # into the least readable thing on screen.
+        lines += [f"  - {_LABEL[c.ok]:<8} {c.name}: {c.detail}" for c in blocking]
+    return lines

--- a/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
@@ -1,0 +1,199 @@
+"""``sac agents relocate <name> --to <host>`` — the dry run, and nothing else yet.
+
+Relocation moves an agent to a different host. The AGENT relocates; the host
+does not move, and the agent's identity and count are unchanged (1 -> 1). It is
+not a kind of fork/twin, which changes WHAT an agent does and takes the count to
+two — the two verbs share one implementation detail (seeding a session from an
+existing transcript) and nothing else.
+
+WHY THE DRY RUN SHIPS FIRST, ALONE. On 2026-08-07 this move was done by hand.
+Rewriting `host:` alone produced an agent that STARTED, reported HEALTHY, and
+did nothing — the worst failure shape there is, because it looks like success
+and nobody goes looking. Every check in :mod:`.._lifecycle._relocate_preflight`
+exists because of something that went wrong that day. Shipping the check before
+the move means the next hand-move is already safer, even with no executing path.
+
+THE EXECUTING PATH REFUSES rather than half-working. `--dry-run` is currently
+required, and omitting it exits non-zero naming what is missing (the cross-host
+transcript transport). A verb that silently does part of a relocation is exactly
+the "looks like success" failure this command was written to prevent.
+
+WHAT COMES FROM WHERE — the operator's requirement, 2026-08-08:
+「定義されているのと、今動いているのって違うんで」
+
+    DECLARED   read from the spec. Claims, printed as claims.
+    OBSERVED   probed on the target. Evidence, printed separately.
+
+Collapsing those into one column is how `sac agents list` reports a running
+agent as `defined`, and this command must not repeat it.
+
+UNPROBED IS UNKNOWN, AND UNKNOWN REFUSES. Any fact with no probe supplied stays
+``None``, which preflight reports as UNKNOWN and refuses on, exactly as it would
+for a probe that ran and failed. That is deliberate: from the decision's point
+of view "nobody asked" and "asked and could not tell" are the same thing, and
+both differ from an answer. So a dry run with no probes wired is not a green
+light — it is a list of what still has to be measured.
+"""
+
+from __future__ import annotations
+
+import click
+
+from .._lifecycle._relocate_preflight import preflight
+from .._lifecycle._relocate_probe import TargetProbes, gather_target_facts
+from .._lifecycle._relocate_render import render_dry_run
+from ._helpers import console
+
+__all__ = ["declared_from_spec", "register", "relocate"]
+
+#: Exit code when the dry run refuses (a failed or undetermined check). Distinct
+#: from click's own 2 (usage error) so a caller can tell "you asked wrongly"
+#: from "the target is not ready".
+EXIT_REFUSED = 3
+#: Exit code for the not-yet-built executing path. Distinct again, so a script
+#: cannot mistake "unimplemented" for "the target failed preflight".
+EXIT_UNIMPLEMENTED = 4
+
+
+def _dig(body: dict, *path: str) -> object:
+    """Follow ``path`` through nested dicts, yielding ``None`` at any break."""
+    cur: object = body
+    for key in path:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(key)
+    return cur
+
+
+def declared_from_spec(spec: dict) -> dict[str, object]:
+    """Pull the spec's own claims out for the DECLARED section.
+
+    Reads defensively: a missing key yields ``None``, rendered as ``(unset)``. A
+    relocation must be able to report on a half-written spec — refusing to print
+    because a field is absent would hide the very thing the operator needs.
+
+    Binds and image live under ``spec.apptainer``, not at the top of ``spec``.
+    Reading them from the wrong level is the mistake this function exists to
+    make once, here, instead of at every call site: measured 2026-08-08, a
+    top-level ``binds`` lookup reported "(none)" for a spec carrying nineteen of
+    them — and "no binds" is exactly the answer that makes the `/mnt/c` check
+    look satisfied when it was never asked.
+    """
+    body = spec.get("spec") if isinstance(spec.get("spec"), dict) else spec
+    binds = _dig(body, "apptainer", "binds") or []
+    bind_sources = tuple(
+        b.split(":", 1)[0] if isinstance(b, str) else str(b)
+        for b in (binds if isinstance(binds, list) else [])
+    )
+    env = _dig(body, "apptainer", "env")
+    card_store = env.get("SCITEX_CARDS_DB") if isinstance(env, dict) else None
+    return {
+        "runtime": body.get("runtime"),
+        "host": body.get("host"),
+        "image": _dig(body, "apptainer", "image"),
+        "a2a port": _dig(body, "a2a", "port"),
+        "bind sources": bind_sources,
+        "card store": card_store,
+    }
+
+
+def _required_ports(declared: dict[str, object]) -> tuple[int, ...]:
+    """The ports preflight must find free — only when the spec PINS one.
+
+    ``a2a.port: auto`` is not a requirement, it is a deferral: sac picks a free
+    port at boot. Coercing it into a number here would invent a requirement the
+    spec never made, and then fail the relocation on a port clash that cannot
+    happen.
+    """
+    port = declared.get("a2a port")
+    if isinstance(port, bool):
+        return ()
+    if isinstance(port, int):
+        return (port,)
+    if isinstance(port, str) and port.isdigit():
+        return (int(port),)
+    return ()
+
+
+@click.command("relocate")
+@click.argument("name", required=True)
+@click.option("--to", "to_host", required=True, help="Target host to relocate ONTO.")
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=True,
+    show_default=True,
+    help="Check the target and touch nothing. Currently the only supported mode.",
+)
+def relocate(name: str, to_host: str, dry_run: bool) -> None:
+    """Relocate agent NAME onto --to HOST. The AGENT moves, not the host.
+
+    \b
+    Example:
+      $ sac agents relocate scitex-dev --to scitex-compute-03 --dry-run
+
+    The dry run reports EVERY problem in one pass rather than stopping at the
+    first, so you do not have to run it N times to find N problems. It answers
+    in three values, never two: PASS, FAIL, and UNKNOWN. An UNKNOWN refuses just
+    as firmly as a FAIL, but calls for a different action — go and measure it,
+    rather than go and fix it.
+    """
+    # Resolve the spec from DISK, not from the instance registry. Measured
+    # 2026-08-08 while building this command: `Registry().get("scitex-agent-
+    # container")` returned None from inside a container — for the very agent
+    # running the query — because the registry it reads is the container's own
+    # private one. The spec files are bind-visible and the registry is not, so
+    # the DECLARED half of this report must come from the files.
+    import yaml
+
+    from ._helpers._agent_list_discover import _discover_defined_agents
+
+    spec_path = dict(_discover_defined_agents()).get(name)
+    if spec_path is None:
+        console.print(
+            f"[red]no spec found for agent {name!r}[/red]\n"
+            "Looked for <agents>/<name>/spec.yaml under the user (and project) scope."
+        )
+        raise SystemExit(2)
+    # The RAW yaml, not the parsed AgentConfig. DECLARED must show what the spec
+    # literally says: `AgentConfig` fills in defaults (runtime defaults to "tui",
+    # for one), and a default printed under a heading marked DECLARED would be a
+    # claim the operator never made.
+    spec = yaml.safe_load(spec_path.read_text()) or {}
+
+    declared = declared_from_spec(spec)
+    if declared.get("host") == to_host:
+        console.print(
+            f"[yellow]{name} already declares host {to_host!r} — nothing to relocate.[/yellow]\n"
+            "If it is actually running elsewhere, that disagreement is the thing to fix first."
+        )
+        raise SystemExit(EXIT_REFUSED)
+
+    # No probes are wired yet, so every fact is UNOBSERVED and the report is a
+    # list of what must be measured. That is the honest state of this command
+    # and it is preferable to a probe set that guesses.
+    gathered = gather_target_facts(TargetProbes())
+    report = preflight(
+        agent=name,
+        to_host=to_host,
+        facts=gathered.facts,
+        runtime=str(declared.get("runtime") or ""),
+        required_ports=_required_ports(declared),
+    )
+
+    for line in render_dry_run(report, declared=declared, errors=gathered.errors):
+        console.print(line, soft_wrap=True)
+
+    if not dry_run:
+        console.print(
+            "\n[red]refusing to execute:[/red] the cross-host transcript transport "
+            "is not built, so a relocation would arrive with no memory of the "
+            "conversation that moved it. See docs/relocate.md §5."
+        )
+        raise SystemExit(EXIT_UNIMPLEMENTED)
+    if report.ok is not True:
+        raise SystemExit(EXIT_REFUSED)
+
+
+def register(agent_group) -> None:
+    """Attach ``relocate`` to the parent ``agents`` Click group."""
+    agent_group.add_command(relocate)

--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -187,6 +187,14 @@ agent_group.add_command(_rebind(_forget_impl, "forget"))
 from ._spawn_from_here import spawn_from_here as _spawn_from_here_impl  # noqa: E402
 
 agent_group.add_command(_rebind(_spawn_from_here_impl, "spawn-from-here"))
+# `relocate` — move an agent to a DIFFERENT HOST. The agent relocates; the host
+# does not, and identity/count are unchanged (1 -> 1). Distinct from `twin`,
+# which changes WHAT an agent does and takes the count to two. Dry-run only for
+# now: it reports what must be true about the target BEFORE anything is touched,
+# and refuses to execute while the cross-host transcript transport is unbuilt.
+from ._relocate_cmd import register as _register_relocate  # noqa: E402
+
+_register_relocate(agent_group)
 
 # Polysemous noun-leaves (allowed under noun groups by §1 loosening)
 agent_group.add_command(_rebind(_status_impl, "list"))

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""A dry run must not let DECLARED and OBSERVED share a column.
+
+Operator, 2026-08-08: 「定義されているのと、今動いているのって違うんで」. The
+fleet listing collapses "a spec exists" and "a process is alive" into one word,
+which is how a running agent reads as `defined`. This renderer is the place that
+mistake would repeat for relocation, so the separation is pinned by test.
+
+The other property under test is that UNKNOWN survives to the last line. The
+preflight is three-valued so "I could not tell" reaches the operator; a renderer
+that prints it as a failure, or omits it, throws that away at the final step.
+
+Real dataclasses throughout — the preflight types validate themselves, so
+constructing them IS the check that the shapes are right. No mocks.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._lifecycle._relocate_preflight import (
+    Check,
+    PreflightReport,
+    TargetFacts,
+    preflight,
+)
+from scitex_agent_container._lifecycle._relocate_render import (
+    VERDICT_GO,
+    VERDICT_REFUSED,
+    VERDICT_UNKNOWN,
+    render_declared,
+    render_dry_run,
+    render_observed,
+    verdict_line,
+)
+
+AGENT = "scitex-dev"
+HOST = "scitex-compute-03"
+
+ALL_GOOD = TargetFacts(
+    reachable=True,
+    image_present=True,
+    missing_bind_sources=(),
+    card_store_url="postgresql://localhost:5442/cards",
+    card_store_reachable=True,
+    credential_expires_in_s=3600.0,
+    credential_refresh_token_present=True,
+    supported_runtimes=("apptainer", "tui"),
+    rejected_spec_keys=(),
+    ports_in_use=(),
+    hub_reachable_from_target=True,
+)
+
+
+def _report(facts: TargetFacts, runtime: str = "tui") -> PreflightReport:
+    return preflight(agent=AGENT, to_host=HOST, facts=facts, runtime=runtime)
+
+
+def _text(lines: list[str]) -> str:
+    return "\n".join(lines)
+
+
+def test_declared_section_says_it_is_unverified() -> None:
+    # Arrange: the spec's own claims are inputs to the checks, not evidence.
+    declared = {"runtime": "tui", "ports": (19013,)}  # stx-allow: STX-NL001
+    # Act
+    lines = render_declared(declared)
+    # Assert
+    assert "not verified" in lines[0]
+
+
+def test_declared_and_observed_are_separate_sections() -> None:
+    # Arrange: collapsing them is the `agents list` defect this guards against.
+    # Act
+    text = _text(render_dry_run(_report(ALL_GOOD), declared={"runtime": "tui"}))
+    # Assert
+    assert text.index("DECLARED") < text.index("OBSERVED")
+
+
+def test_a_clean_target_reports_go() -> None:
+    # Arrange: positive control. Without it, the refusal tests below could pass
+    # because the fixture is malformed rather than because refusal works.
+    # Act
+    line = verdict_line(_report(ALL_GOOD))
+    # Assert
+    assert VERDICT_GO in line
+
+
+def test_a_failed_check_refuses() -> None:
+    # Arrange: /mnt/c is a Windows drive absent on the nas — the 2026-08-07 case.
+    facts = TargetFacts(**{**ALL_GOOD.__dict__, "missing_bind_sources": ("/mnt/c",)})
+    # Act
+    line = verdict_line(_report(facts))
+    # Assert
+    assert line.startswith(f"VERDICT  {VERDICT_REFUSED}")
+
+
+def test_an_unknown_refuses() -> None:
+    # Arrange: nothing failed; one fact was never observed.
+    facts = TargetFacts(**{**ALL_GOOD.__dict__, "credential_expires_in_s": None})
+    # Act
+    line = verdict_line(_report(facts))
+    # Assert
+    assert "could not be determined" in line
+
+
+def test_an_unknown_is_labelled_undetermined_not_plainly_refused() -> None:
+    # Arrange: same state, opposite half of the contract. A FAIL is something to
+    # fix; an UNKNOWN is something to go and measure, so the two verdicts must
+    # not share a label. (Asserting the word "failed" is absent would be the
+    # wrong test — the honest sentence "nothing failed" contains it.)
+    facts = TargetFacts(**{**ALL_GOOD.__dict__, "credential_expires_in_s": None})
+    # Act
+    line = verdict_line(_report(facts))
+    # Assert
+    assert VERDICT_UNKNOWN in line
+
+
+def test_unknown_is_labelled_unknown_not_fail() -> None:
+    # Arrange: the label is what a skimming reader acts on.
+    facts = TargetFacts(**{**ALL_GOOD.__dict__, "image_present": None})
+    # Act
+    lines = render_observed(_report(facts))
+    row = next(ln for ln in lines if "image_present" in ln)
+    # Assert
+    assert "UNKNOWN" in row and "FAIL" not in row
+
+
+def test_the_probe_error_is_printed_beside_the_unknown() -> None:
+    # Arrange: "missing" without "why" turns a 5-second fix into an investigation.
+    facts = TargetFacts(**{**ALL_GOOD.__dict__, "credential_expires_in_s": None})
+    errors = {"credentials_valid": "SSHTimeout: no route to host"}
+    # Act
+    text = _text(render_observed(_report(facts), errors))
+    # Assert
+    assert "SSHTimeout: no route to host" in text
+
+
+def test_passing_checks_are_printed_too() -> None:
+    # Arrange: showing only problems makes "passed" and "never ran"
+    # indistinguishable — the ambiguity the three outcomes exist to remove.
+    # Act
+    text = _text(render_observed(_report(ALL_GOOD)))
+    # Assert
+    assert text.count("PASS") == len(_report(ALL_GOOD).checks)
+
+
+THREE_BROKEN = TargetFacts(
+    **{
+        **ALL_GOOD.__dict__,
+        "missing_bind_sources": ("/mnt/c",),
+        "card_store_reachable": False,
+        "hub_reachable_from_target": False,
+    }
+)
+
+
+def test_every_problem_is_listed_not_just_the_first() -> None:
+    # Arrange: the operator asked for a dry run that does not need N runs to
+    # find N problems. Counted in the OBSERVED section alone — the BLOCKING
+    # summary repeats each one by design, so counting the whole document would
+    # measure the repetition rather than the coverage.
+    # Act
+    text = _text(render_observed(_report(THREE_BROKEN)))
+    # Assert
+    assert text.count("FAIL") == 3
+
+
+def test_multiple_failures_produce_a_blocking_section() -> None:
+    # Arrange: the summary at the end is what gets pasted into chat.
+    # Act
+    text = _text(render_dry_run(_report(THREE_BROKEN)))
+    # Assert
+    assert "BLOCKING" in text
+
+
+def test_a_clean_run_has_no_blocking_section() -> None:
+    # Arrange: a GO must not print an empty scary heading.
+    # Act
+    text = _text(render_dry_run(_report(ALL_GOOD)))
+    # Assert
+    assert "BLOCKING" not in text
+
+
+def test_the_header_names_both_agent_and_target() -> None:
+    # Arrange: a dry run pasted into chat must be unambiguous on its own.
+    # Act
+    head = render_dry_run(_report(ALL_GOOD))[0]
+    # Assert
+    assert AGENT in head and HOST in head
+
+
+def test_the_header_says_nothing_was_touched() -> None:
+    # Arrange: the whole point of the verb is that it is safe to run.
+    # Act
+    head = render_dry_run(_report(ALL_GOOD))[0]
+    # Assert
+    assert "nothing was touched" in head
+
+
+def test_a_hint_follows_every_non_passing_check() -> None:
+    # Arrange: the preflight validator already refuses a hintless failure; this
+    # asserts the renderer actually SHOWS it, which is a separate thing.
+    facts = TargetFacts(**{**ALL_GOOD.__dict__, "card_store_reachable": False})
+    # Act
+    lines = render_observed(_report(facts))
+    idx = next(i for i, ln in enumerate(lines) if "card_store_reachable" in ln)
+    # Assert
+    assert lines[idx + 1].lstrip().startswith("->")
+
+
+def test_empty_declared_says_so_rather_than_printing_a_bare_heading() -> None:
+    # Arrange: a heading with nothing under it reads as a rendering bug.
+    # Act
+    lines = render_declared({})
+    # Assert
+    assert any("nothing declared" in ln for ln in lines)
+
+
+def test_render_observed_tolerates_a_report_with_one_check() -> None:
+    # Arrange: the column width is computed from the checks; a single short
+    # name must not break the formatting path.
+    report = PreflightReport(
+        agent=AGENT,
+        to_host=HOST,
+        checks=(Check(name="x", ok=True, detail="fine"),),
+    )
+    # Act
+    lines = render_observed(report)
+    # Assert
+    assert any("PASS" in ln and "fine" in ln for ln in lines)

--- a/tests/scitex_agent_container/cli_pkg/test__relocate_cmd.py
+++ b/tests/scitex_agent_container/cli_pkg/test__relocate_cmd.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""`sac agents relocate --dry-run` must refuse on unmeasured facts, not proceed.
+
+The 2026-08-07 hand move rewrote `host:` and produced an agent that started,
+reported healthy, and did nothing. The defect was not a wrong answer — it was an
+UNMEASURED one treated as fine. So the property under test here is that the
+command's default posture is refusal, and that its exit codes let a script tell
+"the target failed" from "you asked wrongly" from "this is not built yet".
+
+`declared_from_spec` is tested against real spec shapes rather than mocks: it is
+pure dict-in/dict-out, and a spec that is half-written is exactly the case the
+operator needs printed rather than rejected.
+"""
+
+from __future__ import annotations
+
+import click
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._relocate_cmd import (
+    EXIT_REFUSED,
+    EXIT_UNIMPLEMENTED,
+    _required_ports,
+    declared_from_spec,
+    register,
+    relocate,
+)
+
+#: Shaped like a real sac spec: binds / image / env live under
+#: ``spec.apptainer``, NOT at the top of ``spec``. A fixture that put them at
+#: the top would let a wrong-level lookup pass its own test.
+FULL_SPEC = {
+    "spec": {
+        "runtime": "tui",
+        "host": "ywata-note-win",
+        "a2a": {"port": 19013},  # stx-allow: STX-NL001
+        "apptainer": {
+            "image": "sac-base.sif",
+            "binds": ["/mnt/c:/mnt/c", "/home/ywatanabe/proj"],
+            "env": {"SCITEX_CARDS_DB": "postgresql://localhost:5432/cards"},
+        },
+    }
+}
+
+
+def test_declared_reads_the_runtime() -> None:
+    # Arrange: runtime is the field whose mismatch stopped the 08-07 move
+    # (the nas's sac 0.21.9 rejected 'tui').
+    # Act
+    declared = declared_from_spec(FULL_SPEC)
+    # Assert
+    assert declared["runtime"] == "tui"
+
+
+def test_declared_splits_bind_sources_from_their_targets() -> None:
+    # Arrange: preflight asks whether the SOURCE path exists on the target host,
+    # so "/mnt/c:/mnt/c" must contribute "/mnt/c", not the whole pair.
+    # Act
+    declared = declared_from_spec(FULL_SPEC)
+    # Assert
+    assert declared["bind sources"] == ("/mnt/c", "/home/ywatanabe/proj")
+
+
+def test_declared_reads_the_card_store_from_env() -> None:
+    # Arrange: 5432 here, 5442 there — an agent that cannot reach its board
+    # runs and records nothing.
+    # Act
+    declared = declared_from_spec(FULL_SPEC)
+    # Assert
+    assert declared["card store"] == "postgresql://localhost:5432/cards"
+
+
+def test_declared_finds_binds_under_apptainer_not_at_the_top() -> None:
+    # Arrange: measured 2026-08-08 — a top-level `binds` lookup reported
+    # "(none)" for a spec carrying nineteen of them, and "no binds" is exactly
+    # the answer that makes the /mnt/c check look satisfied when it never ran.
+    top_level_only = {"spec": {"binds": ["/should/not/be/read"]}}
+    # Act
+    declared = declared_from_spec(top_level_only)
+    # Assert
+    assert declared["bind sources"] == ()
+
+
+def test_declared_reads_the_image_from_apptainer() -> None:
+    # Arrange: a missing image fails at boot — AFTER the lease has moved.
+    # Act
+    declared = declared_from_spec(FULL_SPEC)
+    # Assert
+    assert declared["image"] == "sac-base.sif"
+
+
+def test_a_pinned_port_becomes_a_required_port() -> None:
+    # Arrange: a spec that names a port is asserting it must be free there.
+    # Act
+    ports = _required_ports(declared_from_spec(FULL_SPEC))
+    # Assert
+    assert ports == (19013,)  # stx-allow: STX-NL001
+
+
+def test_auto_is_not_a_required_port() -> None:
+    # Arrange: `a2a.port: auto` is a DEFERRAL, not a requirement — sac picks a
+    # free port at boot. Coercing it would invent a requirement the spec never
+    # made and then fail the move on a clash that cannot happen.
+    spec = {"spec": {"a2a": {"port": "auto"}}}
+    # Act
+    ports = _required_ports(declared_from_spec(spec))
+    # Assert
+    assert ports == ()
+
+
+def test_a_numeric_string_port_is_still_a_requirement() -> None:
+    # Arrange: yaml gives back "19013" for a quoted port; it pins just as hard.
+    spec = {"spec": {"a2a": {"port": "19013"}}}
+    # Act
+    ports = _required_ports(declared_from_spec(spec))
+    # Assert
+    assert ports == (19013,)  # stx-allow: STX-NL001
+
+
+def test_a_half_written_spec_still_yields_a_report() -> None:
+    # Arrange: refusing to print because a field is absent would hide exactly
+    # what the operator needs to see.
+    # Act
+    declared = declared_from_spec({"spec": {"runtime": "apptainer"}})
+    # Assert
+    assert declared["host"] is None
+
+
+def test_a_spec_without_the_outer_key_is_read_directly() -> None:
+    # Arrange: some specs nest under "spec:", some do not. Both are real.
+    # Act
+    declared = declared_from_spec({"runtime": "apptainer"})
+    # Assert
+    assert declared["runtime"] == "apptainer"
+
+
+def test_missing_to_is_a_usage_error_not_a_refusal() -> None:
+    # Arrange: click's own exit 2 must stay distinguishable from EXIT_REFUSED,
+    # so a script can tell "you asked wrongly" from "the target is not ready".
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(relocate, ["scitex-dev"])
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_the_exit_codes_are_distinct() -> None:
+    # Arrange: three outcomes a caller must be able to branch on — usage (2),
+    # target not ready (3), not built yet (4). Collapsing any two is how a
+    # script decides "it worked" from a failure.
+    # Act
+    codes = {2, EXIT_REFUSED, EXIT_UNIMPLEMENTED}
+    # Assert
+    assert len(codes) == 3
+
+
+def test_register_attaches_the_verb_to_a_group() -> None:
+    # Arrange: the CLI leaf must be a VERB under the `agents` noun group.
+    group = click.Group("agents")
+    # Act
+    register(group)
+    # Assert
+    assert "relocate" in group.commands
+
+
+def test_the_help_says_the_agent_moves_not_the_host() -> None:
+    # Arrange: the operator noted that "relocation" reads as if the HOST moves.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(relocate, ["--help"])
+    # Assert
+    assert "The AGENT moves, not the host." in result.output
+
+
+def test_dry_run_is_the_default() -> None:
+    # Arrange: a verb that touches live agent state must not do so by default
+    # while its executing half is unbuilt.
+    param = next(p for p in relocate.params if p.name == "dry_run")
+    # Act
+    default = param.default
+    # Assert
+    assert default is True


### PR DESCRIPTION
feat(relocate): the dry run — three answers, and DECLARED never shares a column with OBSERVED

`sac agents relocate <name> --to <host> --dry-run` now runs end to end. It is
the sixth piece of the relocate card and the first one an operator can type.

WHY THE DRY RUN SHIPS ALONE, BEFORE ANYTHING THAT MOVES
On 2026-08-07 this move was done by hand. Rewriting `host:` alone produced an
agent that STARTED, reported HEALTHY, and did nothing — the worst failure shape
available, because it looks like success and nobody goes looking. Every check in
`_relocate_preflight` (merged in #890) exists because of something that went
wrong that day. Shipping the check before the move makes the next HAND move
safer even with no executing path at all, and right now a relocation is still
done by hand.

`--no-dry-run` therefore REFUSES, with exit code 4 and the reason named: the
cross-host transcript transport is not built, so a relocation would arrive with
no memory of the conversation that moved it. A verb that silently does part of a
relocation is exactly the failure this command exists to prevent.

THE OPERATOR'S REQUIREMENT, 2026-08-08
「定義されているのと、今動いているのって違うんで」 — what a spec DECLARES and what
a host actually SHOWS are different facts. Collapsing them into one column is how
`sac agents list` reports a running agent as `defined` (carded separately). So
the report has two sections that cannot be confused:

    DECLARED (from the spec — not verified by this run)
      runtime       tui
      host          ywata-note-win
      bind sources  /home/ywatanabe, /home/ywatanabe/.ssh, ..., /mnt/c
    OBSERVED (probed on scitex-nas-03)
      UNKNOWN  target_reachable  reachability was not observed on the target
               -> run the probe that supplies this fact before deciding
    VERDICT  REFUSED (undetermined) — nothing failed, but 9 could not be determined

That `/mnt/c` line is the 2026-08-07 landmine, visible before anyone moves.

THREE WORDS, NEVER TWO. PASS / FAIL / UNKNOWN. The preflight is three-valued
precisely so "I could not tell" survives to the operator, and a renderer that
printed unknowns as failures — or omitted them — would throw that away at the
last step. They call for different actions: a FAIL is something to fix, an
UNKNOWN is something to go and measure. `verdict_line` says so in its own words
rather than reusing the failure sentence.

NO PROBES ARE WIRED YET, AND THAT IS WHY THE COMMAND CURRENTLY REFUSES. Every
fact is unobserved, so all nine checks report UNKNOWN and the verdict is REFUSED
(exit 3). That is not a gap in the command, it is the command working: from the
decision's point of view "nobody asked" and "asked and could not tell" are the
same thing, and both differ from an answer. The output is a list of what still
has to be measured.

TWO THINGS THE FIRST REAL RUN CAUGHT, both worth recording because each would
have been a confident wrong answer:

1. `Registry().get("scitex-agent-container")` returned None — for the agent
   RUNNING THE QUERY. Inside a container the registry read resolves to the
   container's own private store. The spec files are bind-visible and the
   registry is not, so DECLARED now comes from `_discover_defined_agents()` on
   disk, and from the RAW yaml rather than the parsed `AgentConfig` (whose
   defaults would appear under a heading marked DECLARED as claims nobody made).

2. A top-level `binds` lookup reported "(none)" for a spec carrying nineteen of
   them — they live under `spec.apptainer`. "No binds" is exactly the answer that
   makes the `/mnt/c` check look satisfied when it never ran.

`a2a.port: auto` is a DEFERRAL, not a requirement, so it contributes no required
port. Coercing it would invent a requirement the spec never made and then fail
the relocation on a clash that cannot happen.

Exit codes are distinct on purpose — 2 usage, 3 target-not-ready, 4 not-built —
so a script cannot mistake "unimplemented" for "the target failed preflight".

32 tests. The renderer's suite includes a positive control (a fully healthy
target must report GO): without it, the refusal tests could pass because the
fixture is malformed rather than because refusal works.

Card: sac-agents-move-relocate-an-agent-between-hosts-atomically-20260807
Remaining on that card: the cross-host transcript transport, then the ssh probe
set that turns these nine UNKNOWNs into answers.

Also carries `docs/relocate.md` — the before / procedure / after document the operator asked for, written to be sufficient on its own so a relocated agent that arrives with no memory can be handed the file and continue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWwZWke4rh2Civ11ybUw4k