### PR TITLE
feat(relocate): carry the transcript, and PROVE it landed on the target

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_relocate_transcript.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_transcript.py
@@ -1,0 +1,208 @@
+"""Carry an agent's transcript to the host it is relocating to, and PROVE it landed.
+
+`_session_carry.plan_session_carry` decides WHETHER the transcript follows the
+agent. This executes a ``carry=True`` plan across two hosts — and then reads the
+transcript BACK FROM THE TARGET and compares digests before saying it worked.
+
+WHY READ-BACK RATHER THAN A SUCCESSFUL COPY. Measured 2026-08-08: inside a
+container, ``~/.scitex`` turned out to be a symlink into a dotfiles git worktree,
+created mid-session. Every write to it SUCCEEDED. The bytes went somewhere a
+``git clean -xdf`` can erase, and nothing in any exit code said so. A transcript
+copy is exactly that shape of operation — a write to a path inside a container
+overlay — so "the copy returned 0" is not evidence that the agent will find its
+memory when it boots. Confirm arrival, not dispatch.
+
+A DIGEST, NOT A SIZE. A size check passes on a file truncated and re-padded, on
+a partially-flushed write that happens to land on the same length, and on a
+target path that already held a DIFFERENT transcript of the same size — which is
+not far-fetched here, because a relocation target may have been this agent's home
+before. Comparing content is barely more work and answers the question actually
+being asked.
+
+UNVERIFIABLE IS UNKNOWN, NEVER SUCCESS. If the read-back cannot run, the outcome
+is ``carried=None``. That is the difference between "the transcript is there" and
+"I could not check", and collapsing them is how the 2026-08-07 relocation
+reported healthy while the agent had no memory at all. The caller must treat an
+unknown as a reason to stop, not as a soft yes.
+
+NO I/O HERE. The copy and the read-back are callables the caller supplies, so
+this module never learns ssh, rsync, or the listen daemon — the same
+ports-and-adapters split as `_relocate_preflight` and `_relocate_probe`. It also
+means the whole verification contract is testable without a second machine.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Callable, Final
+
+__all__ = [
+    "CODE_CARRIED",
+    "CODE_MISMATCH",
+    "CODE_NOTHING_TO_CARRY",
+    "CODE_SOURCE_UNREADABLE",
+    "CODE_UNVERIFIABLE",
+    "CarryOutcome",
+    "carry_transcript",
+    "digest",
+]
+
+#: Copied AND read back from the target with a matching digest.
+CODE_CARRIED: Final = 200
+#: The plan said not to carry (opted out, already diverged, nothing to copy).
+CODE_NOTHING_TO_CARRY: Final = 204
+#: The target's copy does not match the source. The relocation must not proceed.
+CODE_MISMATCH: Final = 409
+#: The source transcript could not be read; there is nothing to send.
+CODE_SOURCE_UNREADABLE: Final = 410
+#: The copy may or may not have landed — the read-back could not answer.
+CODE_UNVERIFIABLE: Final = 503
+
+
+def digest(payload: bytes) -> str:
+    """Content fingerprint used on both sides of the comparison."""
+    return hashlib.sha256(payload).hexdigest()
+
+
+@dataclass(frozen=True)
+class CarryOutcome:
+    """What happened, in one shape, with the evidence attached.
+
+    ``carried`` is three-valued: True the transcript is on the target and was
+    verified there, False it was deliberately not carried, None UNKNOWN. There is
+    deliberately no ``__bool__`` — ``if outcome:`` must not quietly read an
+    unknown as a yes, which is the exact mistake this module exists to prevent.
+    """
+
+    carried: bool | None
+    code: int
+    reason: str
+    source_digest: str | None = None
+    target_digest: str | None = None
+    byte_count: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.carried not in (True, False, None):
+            raise ValueError(
+                f"CarryOutcome.carried must be True/False/None, got {self.carried!r}"
+            )
+        if not self.reason:
+            raise ValueError("CarryOutcome.reason must be non-empty")
+        if self.carried is True and self.code != CODE_CARRIED:
+            raise ValueError(
+                f"CarryOutcome: carried=True must carry CODE_CARRIED, got {self.code}"
+            )
+        if self.carried is True and not self.target_digest:
+            raise ValueError(
+                "CarryOutcome: a success must carry the digest READ BACK from the "
+                "target — without it nothing was verified"
+            )
+        if self.carried is True and self.source_digest != self.target_digest:
+            raise ValueError(
+                "CarryOutcome: carried=True with mismatched digests is unrepresentable"
+            )
+
+
+def carry_transcript(
+    *,
+    carry: bool | None,
+    read_source: Callable[[], bytes],
+    send: Callable[[bytes], None],
+    read_back: Callable[[], bytes],
+) -> CarryOutcome:
+    """Execute a carry plan and verify it ON THE TARGET.
+
+    ``carry`` is `SeedPlan.carry` — passed in rather than the whole plan so this
+    stays independent of that module's shape.
+
+    ``read_source`` returns the source transcript's bytes. ``send`` puts them on
+    the target. ``read_back`` returns what the TARGET now holds; it must read
+    through the same path the agent will use at boot, or it proves nothing about
+    the case that matters.
+
+    Every callable may raise — a network is entitled to fail in ways nobody
+    enumerated. Each failure maps to its own outcome rather than to a generic
+    error, because "there was nothing to send", "it did not arrive intact", and
+    "I could not check" call for three different next actions.
+    """
+    if carry is None:
+        return CarryOutcome(
+            carried=None,
+            code=CODE_UNVERIFIABLE,
+            reason=(
+                "the carry decision itself was unknown; resolve it before "
+                "moving anything — proceeding would guess about the agent's memory"
+            ),
+        )
+    if carry is False:
+        return CarryOutcome(
+            carried=False,
+            code=CODE_NOTHING_TO_CARRY,
+            reason="the plan declined to carry the transcript",
+        )
+
+    try:
+        payload = read_source()
+    except Exception as exc:  # stx-allow: fallback (reason: an unreadable source must become a NAMED outcome, not a crash mid-relocation; the exception text is preserved in the reason)
+        return CarryOutcome(
+            carried=False,
+            code=CODE_SOURCE_UNREADABLE,
+            reason=f"the source transcript could not be read ({type(exc).__name__}: {exc})",
+        )
+
+    src = digest(payload)
+
+    try:
+        send(payload)
+    except Exception as exc:  # stx-allow: fallback (reason: a failed send is UNKNOWN, not a clean no — bytes may have partially landed, and only the read-back can say)
+        return CarryOutcome(
+            carried=None,
+            code=CODE_UNVERIFIABLE,
+            reason=(
+                f"the copy failed ({type(exc).__name__}: {exc}); the target may hold "
+                "a partial transcript — check it before retrying"
+            ),
+            source_digest=src,
+            byte_count=len(payload),
+        )
+
+    try:
+        landed = read_back()
+    except Exception as exc:  # stx-allow: fallback (reason: THE central rule — an unverifiable copy is UNKNOWN and must never be reported as carried)
+        return CarryOutcome(
+            carried=None,
+            code=CODE_UNVERIFIABLE,
+            reason=(
+                f"the copy returned success but could not be read back from the "
+                f"target ({type(exc).__name__}: {exc}) — a successful write to a "
+                "path inside a container overlay is not evidence the agent will "
+                "find it at boot"
+            ),
+            source_digest=src,
+            byte_count=len(payload),
+        )
+
+    tgt = digest(landed)
+    if tgt != src:
+        return CarryOutcome(
+            carried=False,
+            code=CODE_MISMATCH,
+            reason=(
+                "the target's copy does not match the source "
+                f"({len(landed)} bytes there vs {len(payload)} sent) — do NOT hand "
+                "over the lease; the agent would resume from a corrupted transcript"
+            ),
+            source_digest=src,
+            target_digest=tgt,
+            byte_count=len(payload),
+        )
+
+    return CarryOutcome(
+        carried=True,
+        code=CODE_CARRIED,
+        reason=f"transcript verified on the target ({len(payload)} bytes)",
+        source_digest=src,
+        target_digest=tgt,
+        byte_count=len(payload),
+    )

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_transcript.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_transcript.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""A copy that returned 0 is not a transcript the agent will find at boot.
+
+Measured 2026-08-08: inside a container `~/.scitex` was a symlink into a dotfiles
+git worktree, created mid-session. Every write SUCCEEDED and the bytes landed
+where a `git clean -xdf` erases them. So the property under test is not "did the
+copy work" but "is it readable ON THE TARGET, and is it the same content".
+
+The sharpest test here is the one where the send SUCCEEDS and the read-back
+FAILS. That is the 2026-08-07 relocation exactly — an agent that booted healthy
+with no memory of the conversation that moved it — and the outcome must be
+UNKNOWN, never carried.
+
+Real callables raising real exceptions. No mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_transcript import (
+    CODE_CARRIED,
+    CODE_MISMATCH,
+    CODE_NOTHING_TO_CARRY,
+    CODE_SOURCE_UNREADABLE,
+    CODE_UNVERIFIABLE,
+    CarryOutcome,
+    carry_transcript,
+    digest,
+)
+
+PAYLOAD = b'{"type":"user","text":"the conversation that moved it"}\n' * 40
+
+
+def _landed(store: dict):
+    """A target that keeps whatever was sent — the happy transport."""
+
+    def send(payload: bytes) -> None:
+        store["bytes"] = payload
+
+    def read_back() -> bytes:
+        return store["bytes"]
+
+    return send, read_back
+
+
+def _ok_source() -> bytes:
+    return PAYLOAD
+
+
+def _boom():
+    raise OSError("no route to host")
+
+
+def test_a_verified_copy_reports_carried() -> None:
+    # Arrange: the positive control. Without it the refusal tests below could
+    # pass because the fixture is broken rather than because refusal works.
+    send, read_back = _landed({})
+    # Act
+    out = carry_transcript(
+        carry=True, read_source=_ok_source, send=send, read_back=read_back
+    )
+    # Assert
+    assert out.carried is True
+
+
+def test_a_verified_copy_carries_the_success_code() -> None:
+    # Arrange: callers branch on the code, not on prose.
+    send, read_back = _landed({})
+    # Act
+    out = carry_transcript(
+        carry=True, read_source=_ok_source, send=send, read_back=read_back
+    )
+    # Assert
+    assert out.code == CODE_CARRIED
+
+
+def test_the_reported_digest_is_the_one_read_back_from_the_target() -> None:
+    # Arrange: reporting the SOURCE digest would let a success be claimed
+    # without the target ever being consulted.
+    send, read_back = _landed({})
+    # Act
+    out = carry_transcript(
+        carry=True, read_source=_ok_source, send=send, read_back=read_back
+    )
+    # Assert
+    assert out.target_digest == digest(PAYLOAD)
+
+
+def test_a_send_that_lands_but_cannot_be_read_back_is_unknown() -> None:
+    # Arrange: THE case this module exists for. The write succeeded; whether the
+    # agent will find it is unanswered.
+    def send(_: bytes) -> None:
+        return None
+
+    # Act
+    out = carry_transcript(
+        carry=True, read_source=_ok_source, send=send, read_back=_boom
+    )
+    # Assert
+    assert out.carried is None
+
+
+def test_an_unverifiable_copy_is_not_reported_as_carried() -> None:
+    # Arrange: the same state, stated as the negative — an unknown must never
+    # be softened into a yes on the way out.
+    def send(_: bytes) -> None:
+        return None
+
+    # Act
+    out = carry_transcript(
+        carry=True, read_source=_ok_source, send=send, read_back=_boom
+    )
+    # Assert
+    assert out.code == CODE_UNVERIFIABLE
+
+
+def test_a_content_mismatch_is_refused() -> None:
+    # Arrange: the target holds something of its own — plausible, because a
+    # relocation target may have been this agent's home before.
+    def send(_: bytes) -> None:
+        return None
+
+    def read_back() -> bytes:
+        return b"a different transcript entirely"
+
+    # Act
+    out = carry_transcript(
+        carry=True, read_source=_ok_source, send=send, read_back=read_back
+    )
+    # Assert
+    assert out.code == CODE_MISMATCH
+
+
+def test_a_mismatch_is_a_decided_no_not_an_unknown() -> None:
+    # Arrange: we DID reach the target and it disagreed. That is an answer, and
+    # it calls for a different action than "could not check".
+    def send(_: bytes) -> None:
+        return None
+
+    def read_back() -> bytes:
+        return b"a different transcript entirely"
+
+    # Act
+    out = carry_transcript(
+        carry=True, read_source=_ok_source, send=send, read_back=read_back
+    )
+    # Assert
+    assert out.carried is False
+
+
+def test_a_same_length_but_different_payload_is_still_caught() -> None:
+    # Arrange: this is why the check is a digest and not a size. A truncated and
+    # re-padded file has the right length.
+    def send(_: bytes) -> None:
+        return None
+
+    def read_back() -> bytes:
+        return b"X" * len(PAYLOAD)
+
+    # Act
+    out = carry_transcript(
+        carry=True, read_source=_ok_source, send=send, read_back=read_back
+    )
+    # Assert
+    assert out.code == CODE_MISMATCH
+
+
+def test_a_failed_send_is_unknown_not_a_clean_no() -> None:
+    # Arrange: bytes may have partially landed; only the target can say.
+    # Reporting "not carried" would invite a retry onto a half-written file.
+    # Act
+    out = carry_transcript(
+        carry=True, read_source=_ok_source, send=_boom, read_back=_boom
+    )
+    # Assert
+    assert out.carried is None
+
+
+def test_an_unreadable_source_names_its_own_outcome() -> None:
+    # Arrange: nothing was sent, so this is a decided no — distinct from a send
+    # that may have half-landed.
+    send, read_back = _landed({})
+    # Act
+    out = carry_transcript(
+        carry=True, read_source=_boom, send=send, read_back=read_back
+    )
+    # Assert
+    assert out.code == CODE_SOURCE_UNREADABLE
+
+
+def test_the_failure_reason_carries_the_underlying_error() -> None:
+    # Arrange: "could not read" without WHY turns a five-second fix into an
+    # investigation.
+    send, read_back = _landed({})
+    # Act
+    out = carry_transcript(
+        carry=True, read_source=_boom, send=send, read_back=read_back
+    )
+    # Assert
+    assert "no route to host" in out.reason
+
+
+def test_a_declined_plan_copies_nothing() -> None:
+    # Arrange: --no-carry-session, or a target that already diverged.
+    def send(_: bytes) -> None:
+        raise AssertionError("send must not run for a declined plan")
+
+    # Act
+    out = carry_transcript(
+        carry=False, read_source=_ok_source, send=send, read_back=_boom
+    )
+    # Assert
+    assert out.code == CODE_NOTHING_TO_CARRY
+
+
+def test_an_undecided_plan_refuses_rather_than_guessing() -> None:
+    # Arrange: `SeedPlan.carry is None` means the inputs did not answer. Acting
+    # on it either way would guess about the agent's memory.
+    def send(_: bytes) -> None:
+        raise AssertionError("send must not run for an undecided plan")
+
+    # Act
+    out = carry_transcript(
+        carry=None, read_source=_ok_source, send=send, read_back=_boom
+    )
+    # Assert
+    assert out.carried is None
+
+
+def test_a_success_without_a_target_digest_is_unrepresentable() -> None:
+    # Arrange: the validator refuses to let anyone construct a "carried" outcome
+    # that never consulted the target — the invariant lives in the type.
+    fields = {
+        "carried": True,
+        "code": CODE_CARRIED,
+        "reason": "x",
+        "source_digest": "a",
+    }
+    # Act
+    build = lambda: CarryOutcome(**fields)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_success_with_mismatched_digests_is_unrepresentable() -> None:
+    # Arrange: same reasoning, the other way — a success may not disagree with
+    # its own evidence.
+    fields = {
+        "carried": True,
+        "code": CODE_CARRIED,
+        "reason": "x",
+        "source_digest": "a",
+        "target_digest": "b",
+    }
+    # Act
+    build = lambda: CarryOutcome(**fields)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_the_outcome_defines_no_bool() -> None:
+    # Arrange: `if outcome:` on an UNKNOWN would read as a yes, which is the
+    # exact defect this module prevents. Python falls back to truthy for any
+    # object, so the guard is that we never DEFINE __bool__ — pinned here so a
+    # future convenience addition has to argue with a test.
+    # Act
+    defined = "__bool__" in vars(CarryOutcome)
+    # Assert
+    assert defined is False


### PR DESCRIPTION
feat(relocate): carry the transcript, and PROVE it landed on the target

The relocate card's last unbuilt decision-layer piece. `_session_carry` decides
WHETHER the transcript follows the agent; this executes a `carry=True` plan and
then reads the transcript BACK FROM THE TARGET, comparing digests, before it will
say the carry worked.

WHY READ-BACK RATHER THAN A SUCCESSFUL COPY — this is the whole point of the
module, and it has a measurement behind it rather than a principle. On
2026-08-08 `~/.scitex` inside a container turned out to be a symlink into a
dotfiles git worktree, created mid-session. Every write to it SUCCEEDED. The
bytes landed where a `git clean -xdf` erases them, and no exit code said so. A
transcript copy is exactly that shape — a write to a path inside a container
overlay — so "the copy returned 0" is not evidence the agent will find its memory
at boot. On 2026-08-07 the relocated instance booted healthy with NO memory of
the conversation that moved it; this is the check that would have caught it.

A DIGEST, NOT A SIZE. A size check passes on a file truncated and re-padded, on a
partial write that lands on the same length, and on a target path that already
held a DIFFERENT transcript of the same size — not far-fetched, since a
relocation target may have been this agent's home before. A test pins the
same-length-different-content case specifically.

FIVE OUTCOMES, NOT TWO, because they call for different next actions:
  200 CARRIED             copied and verified on the target
  204 NOTHING_TO_CARRY    the plan declined (opted out / already diverged)
  409 MISMATCH            we reached the target and it disagreed — a decided NO
  410 SOURCE_UNREADABLE   nothing was sent; a decided no, distinct from a
                          half-landed send
  503 UNVERIFIABLE        UNKNOWN — the copy may or may not be there

The distinction that matters most: a FAILED SEND and an UNREADABLE READ-BACK are
both UNKNOWN, not "not carried". Bytes may have partially landed, and reporting a
clean no invites a retry onto a half-written file. Only the target can settle it.

THE INVARIANT IS IN THE TYPE, not in the caller's discipline. `__post_init__`
refuses to construct a `carried=True` outcome that has no target digest (nothing
was verified) or whose digests disagree (a success contradicting its own
evidence). And `CarryOutcome` deliberately defines no `__bool__`, so `if outcome:`
cannot quietly read an UNKNOWN as a yes — a test pins the absence, because the
tempting future "convenience" addition would silently re-open the exact defect.

NO I/O. The copy and read-back are callables the caller supplies, so this module
never learns ssh, rsync, or the listen daemon — same ports-and-adapters split as
`_relocate_preflight` and `_relocate_probe`, and it means the verification
contract is fully testable without a second machine.

16 tests, including a positive control (a healthy transport DOES report carried —
without it the refusal tests could pass because the fixture is broken).

Card: sac-agents-move-relocate-an-agent-between-hosts-atomically-20260807
Remaining after this: the ssh adapter that supplies these two callables, and
wiring the CLI's `--no-dry-run` path to the phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWwZWke4rh2Civ11ybUw4k