### PR TITLE
perf(listen): stop YAML-parsing every agent spec to find one self-peer

### DIFF
--- a/src/scitex_agent_container/_listen/_self_peers.py
+++ b/src/scitex_agent_container/_listen/_self_peers.py
@@ -162,6 +162,26 @@ def load_self_peer(path: Path, *, self_identity: str | None = None) -> dict | No
     except OSError as exc:
         log.warning("self-peer: cannot read %s: %s", path, exc)
         return None
+    # Reject before parsing. ``is_self_peer_spec`` requires a non-empty
+    # ``listen_url`` key, and a YAML mapping cannot carry that key unless those
+    # characters appear in the source text — so a file without the substring can
+    # never be a self-peer, and parsing it is pure waste.
+    #
+    # This is the whole cost of the scan, not a micro-optimisation. Measured
+    # 2026-08-09 in the live container: ``discover_self_peers`` took 3.7-4.8s on
+    # EVERY call (not a cold start) and returned ONE peer, because it fully
+    # ``yaml.safe_load``-ed ~114 agent specs per search root to decide they were
+    # not self-peers. That single call dominated ``GET /agents`` (2.4-29.2s),
+    # which is what surfaces to other agents as "cannot start/restart an agent"
+    # once their client timeout is shorter than the tail.
+    #
+    # Verified against the real corpus before relying on it: 106 spec.yaml files
+    # under ~/.scitex/agent-container/agents/, ZERO containing ``listen_url``.
+    # A cache was the obvious alternative and is worse — it needs per-file mtime
+    # invalidation and can go stale, whereas declining to parse what you would
+    # discard cannot.
+    if "listen_url" not in text:
+        return None
     try:
         blob = yaml.safe_load(text)
     except yaml.YAMLError as exc:


### PR DESCRIPTION
perf(listen): stop YAML-parsing every agent spec to find one self-peer

`GET /agents` took 2.4-29.2s. Measured cause: `discover_self_peers` fully
`yaml.safe_load`-ed EVERY agent spec on EVERY call, only to reject nearly all
of them, then returned a single peer.

    discover_self_peers   before   4073 / 4777 / 3718 ms   -> 1 peer
    discover_self_peers   after       39 /   40 /   30 ms   -> 1 peer ['self']

A self-peer is defined by ABSENCE — `listen_url` present, no `apiVersion` and
no `spec:` block — so the decision needs no parse. Reject on the substring
before handing the text to PyYAML.

Verified against the real corpus first: 106 spec.yaml under
~/.scitex/agent-container/agents/, ZERO containing `listen_url`. A YAML mapping
cannot carry that key unless those characters appear in the source, so the gate
cannot change which specs qualify.

Why this and not a cache: a cache needs per-file mtime invalidation and can go
stale; declining to parse what you would discard cannot.

WHY IT MATTERED BEYOND LATENCY: agents call this endpoint to start and restart
each other. Any caller whose HTTP timeout is under the tail sees a timeout and
reports "cannot start/restart the agent" — the service is healthy, the request
eventually succeeds, and the user is told it failed. That is the recurring
fleet complaint this fixes.

Tests: 59 passed (self-peer + agent-list suites), 0 failed.

NO REGRESSION TEST, deliberately. "Did not call the parser" is not observable
here without patching internals, and STX-NM002 forbids monkeypatch/mocker
fleet-wide. Three attempts each PASSED against the unfixed code when negative-
controlled (caplog missed the warning; deep-nested YAML did not blow pytest's
raised recursion limit at 6_000 or 50_000). A test that cannot fail is worse
than none — it converts an unverified property into apparent coverage. The
before/after numbers above and the code comment guard it instead.

Still open, not in this change: the separate first-call `resolve_agent_identity`
cost (2091ms -> 17ms), and bounding the handler so it answers within a deadline
with `unknown` rows rather than letting a client timeout be the error channel.
