### PR TITLE
fix(spawn): derive the client timeout from the server's own liveness grace

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_spawn_client.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_client.py
@@ -55,7 +55,26 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["SpawnRequestError", "request_spawn"]
 
-_DEFAULT_TIMEOUT_S = 30.0
+# DERIVED from the server's grace, never hand-picked. ``agents_start``
+# deliberately BLOCKS up to ``_POST_ACK_LIVENESS_TIMEOUT_S`` waiting for the
+# spawned agent's apptainer pid to appear and still be alive, so it can answer
+# 502-with-a-diagnostic instead of a misleading success.
+#
+# Measured 2026-08-09: grace 20s, this budget 30s (picked independently here),
+# observed POST 21.97s. Eight seconds of headroom on a host the server's own
+# comment describes as idling at load 60-70 — and when it flips the caller gets
+# a TIMEOUT, which carries no status, so "slow" / "dead" / "already succeeded"
+# become indistinguishable on a MUTATING route. That day the spawn had SUCCEEDED
+# and was reported as failed; the natural retry can start a SECOND agent. Two
+# constants in two modules that must stay ordered will drift, and no reviewer of
+# either file can see the other. ``_agent_exec_liveness`` is import-free.
+from .._listen._agent_exec_liveness import _POST_ACK_LIVENESS_TIMEOUT_S
+
+# Launch work outside the grace window (spec load, account resolution, apptainer
+# exec, and a uv download on first boot). Measured ~2s; generous on purpose.
+_SPAWN_LAUNCH_OVERHEAD_S = 15.0
+
+_DEFAULT_TIMEOUT_S = _POST_ACK_LIVENESS_TIMEOUT_S + _SPAWN_LAUNCH_OVERHEAD_S
 
 
 class SpawnRequestError(RuntimeError):


### PR DESCRIPTION
fix(spawn): derive the client timeout from the server's own liveness grace

A spawn that SUCCEEDED was reported to the caller as failed.

    agent_spawn (MCP, 30s budget)   TIMED OUT, reported failure
    POST /agents (curl, 180s)       200 in 21.97s
    GET /v1/health                  200 in 0.006s   (same seconds)
    GET /v1/host_exec/inflight      200 in 0.005s   (same seconds)

The agent was already running when the "failure" was reported — the retry
answered "canary-resume-test is already running [ALIVE ... heartbeat: beaten
19s ago]".

THE 22s IS NOT WASTE. `agents_start` deliberately blocks up to
`_POST_ACK_LIVENESS_TIMEOUT_S` (20s) waiting for the spawned agent's apptainer
pid to appear and still be alive, so it can answer 502-with-a-diagnostic rather
than a misleading success (_agent_exec.py:326-342). That probe is right and is
NOT touched here.

THE DEFECT IS THE MARGIN between two constants chosen independently in two
modules: 20s of deliberate server wait plus launch overhead lands at ~22s
against a hand-picked 30s client budget — on a host the server's own comment
describes as idling at load 60-70. Four seconds of variance flips it.

When it flips the caller gets a TIMEOUT, which carries no status at all, so
"slow", "dead" and "already succeeded" are indistinguishable. On a MUTATING
route that also invites a retry that starts a SECOND agent, against a
`cardinality: singleton` that specs declare and nothing enforces.

    -_DEFAULT_TIMEOUT_S = 30.0
    +from .._listen._agent_exec_liveness import _POST_ACK_LIVENESS_TIMEOUT_S
    +_SPAWN_LAUNCH_OVERHEAD_S = 15.0
    +_DEFAULT_TIMEOUT_S = _POST_ACK_LIVENESS_TIMEOUT_S + _SPAWN_LAUNCH_OVERHEAD_S

35.0s derived, 13.03s of margin over the observed 21.97s (was 8.03s).

WHY DERIVED, NOT A BIGGER NUMBER. Bumping 30 to 60 fixes today and leaves the
same latent bug: two constants that must stay ordered, where no reviewer of
either file can see the other. The server's comment already makes this exact
argument one layer down — it records raising the grace from 5s to 20s because
"a 5s deadline was not a probe, it was a coin toss". The client's 30s against a
20s grace is the same coin toss, one layer up. `_agent_exec_liveness` has no
imports, so deriving cannot cycle.

STILL THE PREFERRED FIX, not in this change: return 202 + a handle immediately
and let the caller poll. A spawn is inherently slow (container boot, plus a uv
download on first boot); an HTTP reply should not be hostage to it. This is the
cheap correct stopgap.

Tests: 34 passed (spawn_client), 0 failed.
