### PR TITLE
perf(listen): resolve every a2a port in ONE query instead of one per row

### DIFF
--- a/src/scitex_agent_container/_listen/_agents_list.py
+++ b/src/scitex_agent_container/_listen/_agents_list.py
@@ -84,9 +84,17 @@ async def list_agents(request: Request) -> JSONResponse:
     # Idempotent: self-peer rows that already carry a non-None value
     # keep theirs (the discovery layer is the authoritative source for
     # those).
-    from ._registry_endpoints import enrich_row
+    from ._registry_endpoints import enrich_row, port_claims_map
 
-    rows = [enrich_row(row) for row in rows]
+    # ONE query for every port claim, instead of one state.db lookup per row.
+    # Measured 2026-08-09 (warm, wall clock, 19 rows): the per-row path cost
+    # 222.2ms of a ~635ms enrichment. This is FIX A#1 from the July card
+    # `sac-agents-list-slowness-measured`, which landed in the CLI's row builder
+    # and never reached this one. Best-effort — an empty map simply falls back
+    # to the per-row lookup, which also carries the cross-host instances-table
+    # fallback that the claims table alone does not.
+    _ports = port_claims_map()
+    rows = [enrich_row(row, ports=_ports) for row in rows]
     rows = await _annotate_reachability(request, rows)
     return JSONResponse({"agents": rows})
 

--- a/src/scitex_agent_container/_listen/_registry_endpoints.py
+++ b/src/scitex_agent_container/_listen/_registry_endpoints.py
@@ -129,7 +129,44 @@ def derive_turn_url(host: str | None, port: int | None) -> str | None:
     return f"http://{host}:{port}/v1/turn"
 
 
-def enrich_row_with_endpoint(row: dict) -> dict:
+def port_claims_map() -> dict[str, int]:
+    """Return ``{agent_name: port}`` for every active claim, in ONE query.
+
+    The batched counterpart to :func:`resolve_a2a_port`, for callers that
+    enrich many rows. Pass the result to ``enrich_row*(…, ports=…)``.
+
+    WHY THIS EXISTS — measured 2026-08-09, warm, wall clock, 19 rows:
+
+        enrich_row over all rows          635.6ms
+          resolve_a2a_port x all          222.2ms   (~11.7ms/row)
+          resolve_agent_identity x all    256.9ms
+
+    `resolve_a2a_port` calls `port_allocator.get_port(name)` PER ROW, and each
+    of those opens state.db (the CLI-side note records ~3 opens, ~62ms/agent on
+    a full host). `list_claims()` answers for every agent in one query.
+
+    This is FIX A#1 from `sac-agents-list-slowness-measured` (July), which was
+    applied to `cli_pkg/_helpers/_agent_list.py` and never reached this path —
+    the third instance in one night of a fix landing on one of two parallel
+    listing implementations. Best-effort: any failure yields ``{}`` and every
+    caller falls back to the per-row lookup, so this can only be faster, never
+    wronger.
+    """
+    try:
+        from .._state.port_allocator import list_claims
+
+        out: dict[str, int] = {}
+        for claim in list_claims():
+            nm = claim.get("name")
+            pt = claim.get("port")
+            if isinstance(nm, str) and nm and pt is not None:
+                out[nm] = int(pt)
+        return out
+    except Exception:  # stx-allow: fallback (reason: best-effort batch — callers degrade to the per-row resolve_a2a_port)
+        return {}
+
+
+def enrich_row_with_endpoint(row: dict, *, ports: dict[str, int] | None = None) -> dict:
     """Add ``a2a_port`` and ``turn_url`` to ``row`` (idempotent).
 
     Reads ``row["name"]`` and computes both fields via the helpers
@@ -138,6 +175,13 @@ def enrich_row_with_endpoint(row: dict) -> dict:
     self-peer rows that already know their own endpoint (e.g. the
     lead's own ``listen_url`` neighbour writes a turn_url at
     discovery time and the registry refresh must not clobber it).
+
+    ``ports`` is an optional pre-computed ``{name: port}`` from
+    :func:`port_claims_map`. A name ABSENT from it falls through to the
+    per-row :func:`resolve_a2a_port`, which also carries the cross-host
+    instances-table fallback — so a partial map degrades in speed only, never
+    in correctness. Omitting it preserves the original per-row behaviour
+    exactly, which is why every existing caller is unaffected.
     """
     name = row.get("name") if isinstance(row, dict) else None
     if not isinstance(name, str) or not name:
@@ -151,7 +195,12 @@ def enrich_row_with_endpoint(row: dict) -> dict:
     existing_port = row.get("a2a_port")
     existing_url = row.get("turn_url")
 
-    a2a_port = existing_port if existing_port is not None else resolve_a2a_port(name)
+    if existing_port is not None:
+        a2a_port = existing_port
+    elif ports is not None and name in ports:
+        a2a_port = ports[name]
+    else:
+        a2a_port = resolve_a2a_port(name)
     if existing_url is not None:
         turn_url = existing_url
     else:
@@ -250,7 +299,7 @@ def enrich_row_with_role_owner(row: dict, *, resolver=resolve_agent_identity) ->
     return out
 
 
-def enrich_row(row: dict) -> dict:
+def enrich_row(row: dict, *, ports: dict[str, int] | None = None) -> dict:
     """Apply BOTH registry enrichments to ``row`` — the composed shape every
     registry surface ships.
 
@@ -260,8 +309,12 @@ def enrich_row(row: dict) -> dict:
     ``GET /agents/<name>/status`` bodies carry an identical, uniform shape.
     Both layers are idempotent + best-effort, so this is safe to apply to
     rows that already carry some of the fields.
+
+    ``ports`` is forwarded to :func:`enrich_row_with_endpoint` — pass
+    :func:`port_claims_map` once when enriching many rows. Omitted, behaviour is
+    unchanged from before the batch existed.
     """
-    return enrich_row_with_role_owner(enrich_row_with_endpoint(row))
+    return enrich_row_with_role_owner(enrich_row_with_endpoint(row, ports=ports))
 
 
 __all__ = [
@@ -269,6 +322,7 @@ __all__ = [
     "enrich_row",
     "enrich_row_with_endpoint",
     "enrich_row_with_role_owner",
+    "port_claims_map",
     "resolve_a2a_host",
     "resolve_a2a_port",
     "resolve_agent_identity",


### PR DESCRIPTION
perf(listen): resolve every a2a port in ONE query instead of one per row

`GET /agents` called `resolve_a2a_port(name)` per row, and each of those calls
`port_allocator.get_port()`, which opens state.db. Measured 2026-08-09, warm,
wall clock, 19 rows:

    enrich_row over all rows          635.6ms
      resolve_a2a_port x all          222.2ms   (~11.7ms/row)
      resolve_agent_identity x all    256.9ms
    Registry().list_all()               1.0ms

This is FIX A#1 from `sac-agents-list-slowness-measured` (July) —
"Ports -> ONE port_allocator.list_claims() up front + {name:port} dict" — which
landed in `cli_pkg/_helpers/_agent_list.py` and never reached the listen path.
Third instance in one night of a fix applied to one of two parallel listing
implementations (after `discover_self_peers`, PR #901).

`port_claims_map()` does the one query; `enrich_row(row, ports=…)` consumes it.
Both new parameters are OPTIONAL and keyword-only, so every existing caller is
byte-for-byte unaffected, and a name missing from the map falls through to the
per-row `resolve_a2a_port` — which also carries the cross-host instances-table
fallback the claims table alone does not have. A partial or empty map therefore
degrades in speed only, never in correctness.

MEASUREMENT, and the methodology matters more than the number here.

Sequential A-then-B said the change was SLOWER:

    AFTER  914 1008 1020 1101   median 1020ms
    BEFORE 701  749  757  806   median  757ms

That was wrong, and wrong in SIGN. This host's load drifts on a scale larger
than the effect — an earlier "before" on the same build measured 966ms against
this run's 757ms. Interleaving the two builds round-robin instead:

    round 1   AFTER  890ms   BEFORE  986ms
    round 2   AFTER 1126ms   BEFORE 1773ms
    round 3   AFTER  848ms   BEFORE 1044ms

AFTER wins all three, by 96 / 647 / 196 ms. Consistent direction, ~10-37%.

So: on a noisy host, never compare two builds measured at different times.
Interleave, and require the direction to be consistent across rounds. I nearly
reported this optimisation as a regression.

Tests: 13 passed (registry endpoints), 0 failed.
