### PR TITLE
fix(listen): answer POST /agents within a declared deadline, 202 when in flight

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_listen_client_resolve.py
+++ b/src/scitex_agent_container/_lifecycle/_listen_client_resolve.py
@@ -1,0 +1,181 @@
+"""Where do I send this, and as whom — shared ``sac listen`` client plumbing.
+
+Extracted from :mod:`._spawn_client`, which had grown to hold two unrelated
+responsibilities: the spawn CALL (``request_spawn`` — its body shape, status
+handling and transport diagnosis) and the generic question of how to address a
+listen server at all. Only the first is about spawning.
+
+The evidence that the second was never spawn-specific is that other modules
+already reached into the spawn client to borrow it —
+``_host_exec_client.py`` imports ``_parse_body`` / ``_resolve_base_url`` /
+``_resolve_bearer`` from it, which is a module borrowing plumbing from a
+sibling because that is where it happened to be written down first.
+
+NAMED FOR WHAT IT IS, not for the caller that owned the file. ``_resolve_base_url``
+and ``_resolve_bearer`` are currently implemented FIVE times across the tree
+(``_spawn_client``, ``_restart_client``, ``_in_sif_http_client``,
+``_state/_acl_broker_client``, ``_listen/_card_event_delivery``), and
+``_resolve_caller`` twice. That is the same structural defect as the agent
+listing existing twice (CLI + listen), where a fix reached one copy and not the
+other. Migrating the remaining four onto this module is a separate card; this
+module exists in a shape that makes that migration a deletion rather than
+another move.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+__all__ = [
+    "SpawnRequestError",
+    "_parse_body",
+    "_read_bearer_token_file",
+    "_resolve_base_url",
+    "_resolve_bearer",
+    "_resolve_caller",
+]
+
+
+class SpawnRequestError(RuntimeError):
+    """Raised when the host-side spawn POST cannot be completed.
+
+    Carries the structured failure information so the caller (CLI / MCP
+    tool / log line) can show *why* the spawn failed without re-parsing
+    a free-text message:
+
+    * ``status`` — HTTP status code returned by the listen server
+      (``None`` for transport errors before any HTTP exchange happened
+      or for missing-env failures).
+    * ``body`` — parsed response dict, or the raw text fallback if the
+      body was not JSON, or ``None`` when no body was received.
+
+    The fail-loud invariants this class encodes (ADR-0010 + handoff §0):
+
+    * A 403 ACL deny is an ERROR for the caller — never silently
+      swallowed. The reason from the server is forwarded verbatim in
+      ``body``.
+    * A transport error (host listen unreachable, refused, timed out)
+      is an ERROR — never converted to "ok with empty result".
+    * A missing ``SAC_LISTEN_BASE_URL`` is an ERROR — the container is
+      misconfigured (the apptainer runtime forgot to inject it), and
+      pretending the spawn succeeded would leave the lineage row
+      unwritten on the host.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int | None = None,
+        body: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+def _resolve_base_url(explicit: str | None) -> str:
+    """Return the listen-server base URL or raise loudly.
+
+    Resolution order: explicit argument → ``SAC_LISTEN_BASE_URL``
+    (via :func:`_env.getenv` so the long-form alias also works).
+    Trailing slash is stripped so callers can safely concatenate
+    ``/agents``.
+    """
+    if explicit:
+        return explicit.rstrip("/")
+    from .._env import getenv
+
+    raw = getenv("LISTEN_BASE_URL", "") or ""
+    raw = raw.strip()
+    if not raw:
+        raise SpawnRequestError(
+            "spawn request requires SAC_LISTEN_BASE_URL (the host-stable "
+            "`sac listen` URL injected into the container by the apptainer "
+            "runtime). Got empty/unset."
+        )
+    return raw.rstrip("/")
+
+
+def _resolve_bearer(explicit: str | None) -> str | None:
+    """Return the listen-server bearer token, or ``None`` if unset.
+
+    Resolution order:
+
+    1. ``explicit`` argument (tests pass a value, or ``""`` to force the
+       unauthenticated branch).
+    2. ``SAC_LISTEN_BEARER`` env var — injected by the apptainer runtime
+       (:mod:`runtimes._apptainer_listen_env`) for agents whose spec
+       registers the ``server:sac`` channel.
+    3. The host bearer **token file** at
+       ``~/.scitex/agent-container/tokens/listen-<host>.token`` — the
+       same credential the listen server validates against
+       (:func:`_listen.tokens.default_token_path`). This fallback is
+       what makes :func:`request_spawn` authenticate even when the
+       spawning agent's spec did NOT include ``server:sac`` (so the
+       runtime injected only ``SAC_LISTEN_BASE_URL``, not the bearer).
+       Without it, the spawn POST goes out unauthenticated and the
+       listen server rejects it with 401 — the bug this resolver path
+       closes (card sac-agent-cannot-spawn-agents-listen-7878-...).
+
+    Unlike ``SAC_LISTEN_BASE_URL``, an absent bearer is NOT fatal here:
+    the listen server may have been started with bearer auth disabled,
+    in which case the request still goes through unauthenticated. The
+    server enforces its own auth contract; we just forward whatever
+    credential we can resolve.
+    """
+    if explicit is not None:
+        return explicit or None
+    from .._env import getenv
+
+    raw = getenv("LISTEN_BEARER", "") or ""
+    tok = raw.strip()
+    if tok:
+        return tok
+    # Env unset/empty — fall back to the on-disk host token file, the
+    # same path the listen server reads its accepted token from. The
+    # bind that exposes ``~/.scitex/agent-container`` into the container
+    # makes this readable from inside the SIF.
+    return _read_bearer_token_file()
+
+
+def _read_bearer_token_file() -> str | None:
+    """Return the host listen bearer from its token file, or ``None``.
+
+    Never raises — a missing/unreadable token file yields ``None`` so
+    the caller proceeds (and the server's 401 then surfaces as a clear
+    auth error via :func:`request_spawn`).
+    """
+    from .._listen.tokens import default_token_path, read_token
+
+    return read_token(default_token_path())
+
+
+def _resolve_caller(explicit: str | None) -> str | None:
+    """Return the spawning agent's identity, or ``None`` for the admin path.
+
+    Reuses the same resolution rule as the in-process
+    :func:`_lifecycle._spawn_gate.resolve_spawn_caller`: read ``SAC_NAME``
+    from the parent container's env. An empty string is normalised to
+    ``None`` (admin / human-operator launch — always allowed by the
+    server's current root-only ``check_spawn`` policy).
+    """
+    if explicit is not None:
+        return explicit or None
+    from ._spawn_gate import resolve_spawn_caller
+
+    return resolve_spawn_caller()
+
+
+def _parse_body(raw: bytes) -> Any:
+    """Return JSON-parsed body or raw text fallback."""
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except ValueError:
+        # stx-allow: fallback (reason: non-JSON body surfaced verbatim
+        # to the caller via SpawnRequestError.body — never silently
+        # dropped or converted into a fake success).
+        return raw.decode("utf-8", errors="replace")

--- a/src/scitex_agent_container/_lifecycle/_spawn_client.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_client.py
@@ -55,170 +55,43 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["SpawnRequestError", "request_spawn"]
 
-# DERIVED from the server's grace, never hand-picked. ``agents_start``
-# deliberately BLOCKS up to ``_POST_ACK_LIVENESS_TIMEOUT_S`` waiting for the
-# spawned agent's apptainer pid to appear and still be alive, so it can answer
-# 502-with-a-diagnostic instead of a misleading success.
+# DERIVED from the server's DECLARED answer-by deadline, never hand-picked.
+# ``agents_start`` now GUARANTEES an answer within ``AGENT_START_DEADLINE_S``:
+# 200/502 when the outcome is known, 202 when the spawn is still in flight — so
+# a client only has to outlive that deadline plus transport, and
+# ``client_timeout_for`` owns the margin. One constant, one derivation.
 #
-# Measured 2026-08-09: grace 20s, this budget 30s (picked independently here),
-# observed POST 21.97s. Eight seconds of headroom on a host the server's own
-# comment describes as idling at load 60-70 — and when it flips the caller gets
-# a TIMEOUT, which carries no status, so "slow" / "dead" / "already succeeded"
-# become indistinguishable on a MUTATING route. That day the spawn had SUCCEEDED
-# and was reported as failed; the natural retry can start a SECOND agent. Two
-# constants in two modules that must stay ordered will drift, and no reviewer of
-# either file can see the other. ``_agent_exec_liveness`` is import-free.
-from .._listen._agent_exec_liveness import _POST_ACK_LIVENESS_TIMEOUT_S
+# This replaces TWO independently-picked constants (grace 20s there, budget 30s
+# here) that had to stay ordered with no reviewer of either file able to see the
+# other. Measured 2026-08-09: observed POST 21.97s — eight seconds of headroom
+# on a host the server's own comment describes as idling at load 60-70. When
+# that flips, the caller gets a TIMEOUT, which carries no status, so "slow" /
+# "dead" / "already succeeded" become indistinguishable on a MUTATING route:
+# that day the spawn had SUCCEEDED and was reported failed, and the natural
+# retry can start a SECOND agent. Raising this number could not have fixed it —
+# the server's wait is unbounded by construction (the OAuth settle window is
+# held INSIDE an exclusive flock), so the fix had to be the server learning to
+# SAY "still in flight". ``_handler_deadline`` is import-free (stdlib only).
+from .._listen._handler_deadline import client_timeout_for
 
-# Launch work outside the grace window (spec load, account resolution, apptainer
-# exec, and a uv download on first boot). Measured ~2s; generous on purpose.
-_SPAWN_LAUNCH_OVERHEAD_S = 15.0
-
-_DEFAULT_TIMEOUT_S = _POST_ACK_LIVENESS_TIMEOUT_S + _SPAWN_LAUNCH_OVERHEAD_S
-
-
-class SpawnRequestError(RuntimeError):
-    """Raised when the host-side spawn POST cannot be completed.
-
-    Carries the structured failure information so the caller (CLI / MCP
-    tool / log line) can show *why* the spawn failed without re-parsing
-    a free-text message:
-
-    * ``status`` — HTTP status code returned by the listen server
-      (``None`` for transport errors before any HTTP exchange happened
-      or for missing-env failures).
-    * ``body`` — parsed response dict, or the raw text fallback if the
-      body was not JSON, or ``None`` when no body was received.
-
-    The fail-loud invariants this class encodes (ADR-0010 + handoff §0):
-
-    * A 403 ACL deny is an ERROR for the caller — never silently
-      swallowed. The reason from the server is forwarded verbatim in
-      ``body``.
-    * A transport error (host listen unreachable, refused, timed out)
-      is an ERROR — never converted to "ok with empty result".
-    * A missing ``SAC_LISTEN_BASE_URL`` is an ERROR — the container is
-      misconfigured (the apptainer runtime forgot to inject it), and
-      pretending the spawn succeeded would leave the lineage row
-      unwritten on the host.
-    """
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        status: int | None = None,
-        body: Any = None,
-    ) -> None:
-        super().__init__(message)
-        self.status = status
-        self.body = body
+_DEFAULT_TIMEOUT_S = client_timeout_for()
 
 
-def _resolve_base_url(explicit: str | None) -> str:
-    """Return the listen-server base URL or raise loudly.
-
-    Resolution order: explicit argument → ``SAC_LISTEN_BASE_URL``
-    (via :func:`_env.getenv` so the long-form alias also works).
-    Trailing slash is stripped so callers can safely concatenate
-    ``/agents``.
-    """
-    if explicit:
-        return explicit.rstrip("/")
-    from .._env import getenv
-
-    raw = getenv("LISTEN_BASE_URL", "") or ""
-    raw = raw.strip()
-    if not raw:
-        raise SpawnRequestError(
-            "spawn request requires SAC_LISTEN_BASE_URL (the host-stable "
-            "`sac listen` URL injected into the container by the apptainer "
-            "runtime). Got empty/unset."
-        )
-    return raw.rstrip("/")
-
-
-def _resolve_bearer(explicit: str | None) -> str | None:
-    """Return the listen-server bearer token, or ``None`` if unset.
-
-    Resolution order:
-
-    1. ``explicit`` argument (tests pass a value, or ``""`` to force the
-       unauthenticated branch).
-    2. ``SAC_LISTEN_BEARER`` env var — injected by the apptainer runtime
-       (:mod:`runtimes._apptainer_listen_env`) for agents whose spec
-       registers the ``server:sac`` channel.
-    3. The host bearer **token file** at
-       ``~/.scitex/agent-container/tokens/listen-<host>.token`` — the
-       same credential the listen server validates against
-       (:func:`_listen.tokens.default_token_path`). This fallback is
-       what makes :func:`request_spawn` authenticate even when the
-       spawning agent's spec did NOT include ``server:sac`` (so the
-       runtime injected only ``SAC_LISTEN_BASE_URL``, not the bearer).
-       Without it, the spawn POST goes out unauthenticated and the
-       listen server rejects it with 401 — the bug this resolver path
-       closes (card sac-agent-cannot-spawn-agents-listen-7878-...).
-
-    Unlike ``SAC_LISTEN_BASE_URL``, an absent bearer is NOT fatal here:
-    the listen server may have been started with bearer auth disabled,
-    in which case the request still goes through unauthenticated. The
-    server enforces its own auth contract; we just forward whatever
-    credential we can resolve.
-    """
-    if explicit is not None:
-        return explicit or None
-    from .._env import getenv
-
-    raw = getenv("LISTEN_BEARER", "") or ""
-    tok = raw.strip()
-    if tok:
-        return tok
-    # Env unset/empty — fall back to the on-disk host token file, the
-    # same path the listen server reads its accepted token from. The
-    # bind that exposes ``~/.scitex/agent-container`` into the container
-    # makes this readable from inside the SIF.
-    return _read_bearer_token_file()
-
-
-def _read_bearer_token_file() -> str | None:
-    """Return the host listen bearer from its token file, or ``None``.
-
-    Never raises — a missing/unreadable token file yields ``None`` so
-    the caller proceeds (and the server's 401 then surfaces as a clear
-    auth error via :func:`request_spawn`).
-    """
-    from .._listen.tokens import default_token_path, read_token
-
-    return read_token(default_token_path())
-
-
-def _resolve_caller(explicit: str | None) -> str | None:
-    """Return the spawning agent's identity, or ``None`` for the admin path.
-
-    Reuses the same resolution rule as the in-process
-    :func:`_lifecycle._spawn_gate.resolve_spawn_caller`: read ``SAC_NAME``
-    from the parent container's env. An empty string is normalised to
-    ``None`` (admin / human-operator launch — always allowed by the
-    server's current root-only ``check_spawn`` policy).
-    """
-    if explicit is not None:
-        return explicit or None
-    from ._spawn_gate import resolve_spawn_caller
-
-    return resolve_spawn_caller()
-
-
-def _parse_body(raw: bytes) -> Any:
-    """Return JSON-parsed body or raw text fallback."""
-    if not raw:
-        return None
-    try:
-        return json.loads(raw)
-    except ValueError:
-        # stx-allow: fallback (reason: non-JSON body surfaced verbatim
-        # to the caller via SpawnRequestError.body — never silently
-        # dropped or converted into a fake success).
-        return raw.decode("utf-8", errors="replace")
+# Request-construction plumbing — where do I send this, and as whom — now lives
+# in ._listen_client_resolve. It was never spawn-specific: _host_exec_client
+# already imported _parse_body / _resolve_base_url / _resolve_bearer FROM HERE,
+# which is a module borrowing plumbing from a sibling because that is where it
+# happened to get written down first. Re-exported so every existing import path
+# (_host_exec_client, the MCP tools, _in_sif_broker, cli_pkg/lifecycle/_twin and
+# the tests) keeps working byte-identically.
+from ._listen_client_resolve import (  # noqa: F401
+    SpawnRequestError,
+    _parse_body,
+    _read_bearer_token_file,
+    _resolve_base_url,
+    _resolve_bearer,
+    _resolve_caller,
+)
 
 
 def _http_error_message(child_name: str, status: int, parsed: Any) -> str:
@@ -506,5 +379,20 @@ def request_spawn(
             f"listen response was not a JSON object: {parsed!r}",
             status=status,
             body=parsed,
+        )
+    if status == 202:
+        # ACCEPTED, not completed: the server reached its declared deadline with
+        # the spawn STILL IN FLIGHT, and said so. This is the honest answer that
+        # REPLACES a client-side timeout, so two things must not happen to it.
+        # It is not "the agent is running" — the outcome is genuinely unknown and
+        # ``parsed["poll"]`` carries the route that will know. And it must NOT be
+        # retried: a retry on a MUTATING route is exactly what starts a SECOND
+        # agent, which is the damage the old timeout-as-error-channel caused.
+        logger.info(
+            "spawn_client: POST %s -> 202 accepted (phase=%s); spawn in flight, "
+            "poll %s",
+            url,
+            parsed.get("phase"),
+            parsed.get("poll"),
         )
     return parsed

--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -15,6 +15,7 @@ import path keeps working unchanged.
 
 from __future__ import annotations
 
+import asyncio
 import os
 
 from starlette.requests import Request
@@ -254,13 +255,48 @@ async def agents_start(request: Request) -> JSONResponse:
     # it (single, interactive, long-lived — a fleet-wide lock held that long
     # would serialize everything for no safety gain).
     from ._credential_refresh_lock import run_brokered_launch
+    from ._handler_deadline import AGENT_START_DEADLINE_S, Deadline, accepted_payload
+    from ._spawn_detach import detach_launch
 
-    try:
-        proc = await run_brokered_launch(
+    # DECLARED answer-by budget for the whole handler (see _handler_deadline).
+    # Before this, the handler could block for as long as the credential boot
+    # gate made it: the OAuth settle window is held INSIDE an exclusive flock,
+    # so waiter N pays N-1 predecessors x (launch + up to 20s) before its own
+    # launch begins. The caller had no way to learn it was QUEUED — from
+    # outside, a queue and a dead host are the same silence — so its socket
+    # timeout became the error channel and a SUCCEEDING spawn was reported as
+    # a failure. Bounding the handler is what makes "still in flight" sayable.
+    #
+    # foreground / one_shot are EXEMPT: they block for a whole interactive
+    # session by construction, so that caller explicitly asked to wait and a
+    # 202 would be an unhelpful answer to a question it did not ask.
+    bounded = not (foreground or one_shot)
+    deadline = Deadline(AGENT_START_DEADLINE_S)
+    launch = asyncio.ensure_future(
+        run_brokered_launch(
             inner_argv,
             child_env,
             foreground=bool(foreground),
             one_shot=bool(one_shot),
+        )
+    )
+    try:
+        if bounded:
+            # shield() is load-bearing: wait_for CANCELS its inner awaitable on
+            # timeout, which is the exact opposite of what the 202 promises.
+            # The spawn keeps running and detach_launch adopts it below.
+            proc = await asyncio.wait_for(
+                asyncio.shield(launch), timeout=deadline.remaining()
+            )
+        else:
+            proc = await launch
+    except asyncio.TimeoutError:
+        # Still queued behind the boot gate, or the start subprocess is still
+        # running. ACCEPTED, outcome unknown — never a failure code.
+        detach_launch(launch, name=name, started_at=started_at)
+        return JSONResponse(
+            accepted_payload(name, phase="launch", deadline_s=AGENT_START_DEADLINE_S),
+            status_code=202,
         )
     except OSError as exc:
         # Launch-time failure (e.g. the resolved sac_bin vanished between
@@ -379,11 +415,28 @@ async def agents_start(request: Request) -> JSONResponse:
     # ``apptainer_pid`` file that a ``tui`` agent — the fleet's DEFAULT runtime —
     # never writes, and then stamps ``startup_failed`` on a perfectly healthy
     # agent. See :mod:`._agent_exec_liveness`.
+    # Truncate the grace window to what remains of the handler's budget — and
+    # then REFUSE TO CONVICT on the truncated result. A probe that ran out of
+    # budget has not observed a failure, it ran out of time; that is UNKNOWN,
+    # and UNKNOWN answers 202, never 502. Convicting on a short probe is the
+    # precise mistake this module's own docstring records: a 5s window "was not
+    # a probe, it was a coin toss", and a lost toss stamps ``startup_failed`` on
+    # a healthy agent, whose remedy is destructive.
+    probe_budget = env_timeout
+    truncated = False
+    if bounded and deadline.remaining() < env_timeout:
+        probe_budget = deadline.remaining()
+        truncated = True
     liveness_failure = _probe_post_ack_liveness(
         runtime_dir,
         name=name,
-        timeout_s=env_timeout,
+        timeout_s=probe_budget,
     )
+    if liveness_failure is not None and truncated:
+        return JSONResponse(
+            accepted_payload(name, phase="liveness", deadline_s=AGENT_START_DEADLINE_S),
+            status_code=202,
+        )
     if liveness_failure is not None:
         kind, hint = liveness_failure
         # stx-allow: fallback (reason: marker write is observability;

--- a/src/scitex_agent_container/_listen/_handler_deadline.py
+++ b/src/scitex_agent_container/_listen/_handler_deadline.py
@@ -1,0 +1,156 @@
+"""Declared answer-by deadlines for the long-running listen lifecycle routes.
+
+THE BUG THIS EXISTS TO KILL
+---------------------------
+``POST /agents`` had no answer-by guarantee. On the background path it spends
+its time in four places (``_agent_exec.agents_start`` ->
+``_credential_refresh_lock.run_brokered_launch``)::
+
+    1. flock acquire (creds-refresh.lock)     BLOCKING, UNBOUNDED
+    2. subprocess.run(sac agents start ...)   no timeout
+    3. OAuth settle window                    up to 20s  <- HELD INSIDE THE LOCK
+    4. post-ack liveness probe                up to 20s  <- outside the lock
+
+A single spawn on an idle host is (2)+(4) ~= 22s, measured. But the settle
+window (3) is held INSIDE the exclusive flock, so under N concurrent spawns
+waiter N waits for N-1 predecessors x (launch + up to 20s) BEFORE its own
+launch starts. Three concurrent spawns put the third caller past 60s.
+
+Nothing in the protocol told that caller it was QUEUED. From outside, waiting
+in a queue and talking to a dead host are the same silence — so the caller's
+socket timeout became the error channel, and a spawn that SUCCEEDED was
+reported to the fleet as a failure. That is the standing "I can't start
+agents" complaint.
+
+Raising the client timeout does not fix it. It was raised 20s -> 35s (PR #902),
+which covers a single idle-host spawn and does not cover the queued case; no
+single constant can, because the wait above is unbounded by construction.
+
+THE CONTRACT
+------------
+The server declares a deadline and ALWAYS answers within it::
+
+    accepted, completed, alive        200   true
+    accepted, ran, observably failed  502   false
+    accepted, STILL IN FLIGHT         202   unknown -- poll GET /agents/<name>/status
+    bad body / ACL deny               400 / 403
+
+``202`` is the load-bearing row and it is NOT an error: the spawn was accepted
+and is running, we simply do not know the outcome yet. This is the SAME
+three-valued discipline :mod:`._agent_exec_liveness` already applies one layer
+down, in its own words: "an INCONCLUSIVE probe now returns 'no failure' rather
+than manufacturing one: UNKNOWN authorises nothing." The probe stopped
+manufacturing a failure from an inconclusive result; the HTTP layer in front of
+it had not — it manufactured one by staying silent until the client gave up.
+
+Because the deadline is declared HERE, the client timeout is DERIVED from it
+(:func:`client_timeout_for`) instead of guessed independently. Two independent
+constants that must satisfy ``client > server`` is a bug waiting for a load
+spike; one constant plus a margin cannot drift.
+"""
+
+from __future__ import annotations
+
+import time
+
+__all__ = [
+    "AGENT_START_DEADLINE_S",
+    "CLIENT_MARGIN_S",
+    "Deadline",
+    "accepted_payload",
+    "client_timeout_for",
+]
+
+
+# Answer-by guarantee for ``POST /agents``. The handler returns SOMETHING
+# within this window — 200/502 when the outcome is known, 202 when it is not.
+#
+# 30s, and the floor is not arbitrary: a single spawn on an idle host costs the
+# launch (~2s) plus the 20s post-ack liveness grace (_POST_ACK_LIVENESS_TIMEOUT_S,
+# itself raised 5s -> 20s because a lost coin toss stamps ``startup_failed`` on a
+# healthy agent). A deadline at or below ~22s would turn EVERY spawn into a 202
+# and throw away the synchronous answer, which carries strictly more information
+# than "poll me". 30s keeps the common case synchronous with ~8s of headroom;
+# anything beyond it means the caller is genuinely queued behind another spawn,
+# which is exactly the case that should be REPORTED rather than waited out.
+AGENT_START_DEADLINE_S = 30.0
+
+# How much longer a CLIENT waits than the server's own deadline. Covers the
+# HTTP round trip, JSON encode/decode, and host scheduling jitter between the
+# server deciding to answer and the client seeing bytes. Generous on purpose:
+# the failure mode it prevents (client gives up while the server is composing
+# its honest 202) is precisely the bug this module exists to kill, and the cost
+# of being wrong in the safe direction is a few idle seconds.
+CLIENT_MARGIN_S = 10.0
+
+
+def client_timeout_for(server_deadline_s: float = AGENT_START_DEADLINE_S) -> float:
+    """Return the socket timeout a client should use against a bounded route.
+
+    Derived, never guessed: a client MUST outlive the server's own answer-by
+    deadline, otherwise it destroys the very 202 that tells it the work is
+    still in flight — and then reports the timeout as a failure, which is the
+    original bug wearing a new number.
+    """
+    return float(server_deadline_s) + CLIENT_MARGIN_S
+
+
+def accepted_payload(
+    name: str,
+    *,
+    phase: str,
+    deadline_s: float = AGENT_START_DEADLINE_S,
+) -> dict:
+    """Body for the ``202`` answer: accepted, in flight, outcome not yet known.
+
+    ``phase`` says WHERE the deadline was reached — ``"launch"`` (still queued
+    behind the credential boot gate, or the ``sac agents start`` subprocess is
+    still running) or ``"liveness"`` (the launch returned rc=0 and the post-ack
+    grace window had not concluded). The distinction matters to a caller
+    deciding how long to keep polling: ``"liveness"`` means the agent has
+    already been kicked off, ``"launch"`` means it may still be queued.
+
+    ``poll`` is deliberately an EXISTING route. A 202 needs the outcome to be
+    discoverable, and the agent's own liveness already is — inventing a job
+    store to answer a question ``GET /agents/<name>/status`` already answers
+    would add a second source of truth about whether an agent is running, which
+    is how the two of them start disagreeing.
+    """
+    return {
+        "name": name,
+        "status": "accepted",
+        "phase": phase,
+        "deadline_s": float(deadline_s),
+        "poll": f"/agents/{name}/status",
+        "detail": (
+            f"start of {name!r} was accepted and is still in flight at the "
+            f"{float(deadline_s):.0f}s server deadline (phase={phase!r}). This is "
+            f"NOT a failure: the spawn is running. Poll GET /agents/{name}/status "
+            f"for the outcome — a failure will carry a startup_failed marker."
+        ),
+    }
+
+
+class Deadline:
+    """Monotonic answer-by budget for a single request.
+
+    Uses ``time.monotonic`` so a wall-clock step (NTP, suspend/resume) can
+    neither expire a healthy request early nor extend a hung one — the whole
+    point is a bound that holds under exactly the disturbed conditions that
+    produce the bug.
+    """
+
+    __slots__ = ("_expires_at",)
+
+    def __init__(self, budget_s: float) -> None:
+        self._expires_at = time.monotonic() + max(0.0, float(budget_s))
+
+    def remaining(self) -> float:
+        """Seconds left, floored at 0.0 (never negative — callers pass this
+        straight to ``asyncio.wait_for`` / probe timeouts, which reject
+        negatives)."""
+        return max(0.0, self._expires_at - time.monotonic())
+
+    def expired(self) -> bool:
+        """True once the budget is exhausted."""
+        return self.remaining() <= 0.0

--- a/src/scitex_agent_container/_listen/_spawn_detach.py
+++ b/src/scitex_agent_container/_listen/_spawn_detach.py
@@ -1,0 +1,126 @@
+"""Keep a deadline-exceeded spawn alive, and record its outcome anyway.
+
+When ``POST /agents`` hits its declared answer-by deadline
+(:mod:`._handler_deadline`) the handler answers ``202 Accepted`` — but the
+launch it started is STILL RUNNING and must not be disturbed. Two things then
+have to be true, and neither is automatic:
+
+1. THE LAUNCH MUST NOT BE CANCELLED. ``asyncio.wait_for`` cancels its inner
+   awaitable on timeout, which is the opposite of what we want here — the whole
+   claim of the 202 is "your spawn is in flight". The handler therefore wraps
+   the launch in ``asyncio.shield``; this module owns what happens next.
+
+2. THE OUTCOME MUST STILL BE OBSERVABLE. A caller that got a 202 polls
+   ``GET /agents/<name>/status``. For a spawn that later FAILS, that route is
+   only informative because something wrote a ``STARTUP_FAILED`` marker — and
+   on the synchronous path the handler writes it. Detach without this module
+   and a post-202 failure would leave the agent merely "not running", with the
+   rc and stderr that explain WHY discarded when the task was garbage
+   collected. The 202 would then have traded one silence for another.
+
+There is a third, quieter reason: an abandoned ``asyncio.Task`` whose exception
+is never retrieved is collected with a "Task exception was never retrieved"
+warning and the error is gone. Holding a strong reference until the done
+callback runs is what makes the failure reportable at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+__all__ = ["detach_launch", "inflight_count"]
+
+
+# Strong references to launches that outlived their handler's deadline. Without
+# this, the event loop holds only a weak reference and a still-running spawn can
+# be garbage collected mid-flight — taking its exception (and any chance of
+# writing the failure marker) with it. Entries are removed by the done callback.
+_INFLIGHT: set[asyncio.Task] = set()
+
+
+def inflight_count() -> int:
+    """Number of launches currently outliving their handler (observability)."""
+    return len(_INFLIGHT)
+
+
+def _write_launch_marker(
+    name: str,
+    *,
+    started_at: str,
+    exit_code: int,
+    stdout: str,
+    stderr: str,
+) -> None:
+    """Best-effort ``STARTUP_FAILED`` write for a launch that failed AFTER 202.
+
+    Mirrors the synchronous path's marker exactly (same ``phase``, same
+    fields) so a caller polling ``GET /agents/<name>/status`` cannot tell
+    whether the failure was reported inside the deadline or after it — the
+    diagnostic is identical either way. That equivalence is the point: the
+    202 must not be a degraded mode.
+    """
+    try:
+        from .._lifecycle._startup_failed import write_marker
+        from .._runners._session_state import state_dir_for
+
+        write_marker(
+            state_dir_for(name),
+            started_at=started_at,
+            phase="container_creation",
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+        )
+    except Exception:  # stx-allow: fallback (reason: the marker is observability for an already-answered request; a write failure must not raise inside a done callback, where it would be swallowed by the loop anyway)
+        pass
+
+
+def _on_launch_done(task: "asyncio.Task", *, name: str, started_at: str) -> None:
+    """Done callback: drop the strong ref, then record a failing outcome.
+
+    A SUCCESSFUL launch needs nothing written — the agent's own liveness is the
+    record, and that is exactly what ``GET /agents/<name>/status`` reports. Only
+    failure needs a marker, because a failed spawn is otherwise indistinguishable
+    from an agent that was never asked to start.
+    """
+    _INFLIGHT.discard(task)
+    if task.cancelled():
+        # Should not happen (the launch is shielded), but a cancelled task has
+        # no result to inspect and calling .result() would raise here.
+        return
+    exc = task.exception()
+    if exc is not None:
+        _write_launch_marker(
+            name,
+            started_at=started_at,
+            exit_code=-1,
+            stdout="",
+            stderr=f"{type(exc).__name__}: {exc}",
+        )
+        return
+    proc: Any = task.result()
+    returncode = getattr(proc, "returncode", None)
+    if returncode not in (0, None):
+        _write_launch_marker(
+            name,
+            started_at=started_at,
+            exit_code=int(returncode),
+            stdout=getattr(proc, "stdout", "") or "",
+            stderr=getattr(proc, "stderr", "") or "",
+        )
+
+
+def detach_launch(task: "asyncio.Task", *, name: str, started_at: str) -> None:
+    """Adopt ``task`` so it survives the handler that started it.
+
+    Called ONLY when the handler has already decided to answer 202. Holds a
+    strong reference until completion, then records a failing outcome via
+    :func:`_write_launch_marker` so the caller's follow-up
+    ``GET /agents/<name>/status`` carries the same diagnostic it would have
+    carried on the synchronous path.
+    """
+    _INFLIGHT.add(task)
+    task.add_done_callback(
+        lambda t: _on_launch_done(t, name=name, started_at=started_at)
+    )

--- a/tests/scitex_agent_container/_listen/test__agent_exec_deadline.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_deadline.py
@@ -1,0 +1,336 @@
+"""``POST /agents`` must ANSWER within its declared deadline, not go silent.
+
+The bug: the handler had no answer-by bound. Its wait is unbounded by
+construction — the OAuth settle window is held INSIDE an exclusive flock
+(``_credential_refresh_lock``), so under N concurrent spawns waiter N pays N-1
+predecessors before its own launch even starts. The caller had no way to learn
+it was QUEUED, because from outside a queue and a dead host produce the same
+silence. Its socket timeout became the error channel, and a spawn that
+SUCCEEDED was reported to the fleet as a failure — the standing "I can't start
+agents" complaint. A retry on that mutating route starts a SECOND agent.
+
+Same convention as ``test__agent_exec_declined.py`` / ``test__agent_exec_
+subprocess.py``: a real ``TestClient`` against a real fake ``sac`` shim on
+``$PATH``. No mocks — the slow shim really sleeps and the failing shim really
+exits non-zero, so these exercise the actual asyncio timeout/shield path rather
+than a stubbed stand-in for it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._lifecycle._startup_failed import read_marker
+from scitex_agent_container._listen import _handler_deadline
+from scitex_agent_container._listen.server import create_app
+from scitex_agent_container._runners import _session_state as _ss
+from scitex_agent_container._runners._session_state import state_dir_for
+from scitex_agent_container._state import registry as _reg
+from scitex_agent_container._state import state_db
+
+_TOKEN = "test-token-agent-exec-deadline"
+
+# The shim sleeps this long; the handler's deadline is set well below it, so the
+# handler MUST answer while the launch is still running.
+_SHIM_SLEEP_S = 2.0
+_TEST_DEADLINE_S = 0.3
+
+
+@pytest.fixture
+def isolated_listen_env(tmp_path: Path):
+    """Isolated state.db + registry/runtime dirs (mirrors the sibling tests)."""
+    db = tmp_path / "state.db"
+    saved_env_db = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default_db = state_db.DEFAULT_DB_PATH
+    saved_home = os.environ.get("HOME")
+    saved_reg_const = _reg.REGISTRY_DIR
+    saved_state_const = _ss.DEFAULT_STATE_ROOT
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    os.environ["HOME"] = str(tmp_path)
+    _reg.REGISTRY_DIR = tmp_path / "registry"
+    _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
+    try:
+        yield tmp_path
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default_db
+        _reg.REGISTRY_DIR = saved_reg_const
+        _ss.DEFAULT_STATE_ROOT = saved_state_const
+        if saved_env_db is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env_db
+        if saved_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved_home
+
+
+@pytest.fixture
+def short_deadline():
+    """Shrink the handler's answer-by budget (save/restore seam).
+
+    ``agents_start`` imports ``AGENT_START_DEADLINE_S`` INSIDE the function
+    body, so reassigning the module attribute is picked up on the next call —
+    the same save/restore-seam idiom the sibling tests use for
+    ``state_db.DEFAULT_DB_PATH``.
+    """
+    saved = _handler_deadline.AGENT_START_DEADLINE_S
+    _handler_deadline.AGENT_START_DEADLINE_S = _TEST_DEADLINE_S
+    try:
+        yield _TEST_DEADLINE_S
+    finally:
+        _handler_deadline.AGENT_START_DEADLINE_S = saved
+
+
+def _install_slow_sac_shim(bin_dir: Path, *, exit_code: int, done_flag: Path) -> None:
+    """A shim that outlives the handler's deadline, then finishes for real.
+
+    Touches ``done_flag`` on the way out so a test can prove the launch was
+    NOT cancelled by the 202 — the whole promise of the ``asyncio.shield``.
+    """
+    script = bin_dir / "sac"
+    script.write_text(
+        f"#!{sys.executable}\n"
+        "import sys, time, pathlib\n"
+        f"time.sleep({_SHIM_SLEEP_S})\n"
+        f"pathlib.Path({str(done_flag)!r}).write_text('done')\n"
+        'sys.stderr.write("slow shim finished\\n")\n'
+        f"sys.exit({exit_code})\n"
+    )
+    script.chmod(0o755)
+
+
+def _install_fast_sac_shim(bin_dir: Path) -> None:
+    """An immediate success — the deadline must NOT fire for this one."""
+    script = bin_dir / "sac"
+    script.write_text(f"#!{sys.executable}\nimport sys\nsys.exit(0)\n")
+    script.chmod(0o755)
+
+
+def _prepare_env(env_save_restore, bin_dir: Path) -> None:
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    # Skip the post-ack liveness grace: this module is about the HANDLER's
+    # deadline, and a 20s probe would dominate every timing here.
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
+
+
+def _post(client: TestClient, name: str):
+    return client.post(
+        "/agents",
+        json={"name": name},
+        headers={"authorization": f"Bearer {_TOKEN}"},
+    )
+
+
+class _SlowSpawn(NamedTuple):
+    status_code: int
+    body: dict
+    elapsed_s: float
+    launch_completed: bool
+    marker: dict | None
+
+
+def _run_slow_spawn(
+    env_save_restore, tmp_path: Path, *, name: str, exit_code: int
+) -> _SlowSpawn:
+    """POST against a shim that outlives the deadline, then watch the aftermath.
+
+    Returns the immediate response AND what happened after it, so each test can
+    assert exactly one thing about a single expensive (~4s) run.
+    """
+    flag = tmp_path / f"flag_{name}"
+    bin_dir = tmp_path / f"sac_bin_{name}"
+    bin_dir.mkdir()
+    _install_slow_sac_shim(bin_dir, exit_code=exit_code, done_flag=flag)
+    _prepare_env(env_save_restore, bin_dir)
+    with TestClient(create_app(token=_TOKEN)) as client:
+        started = time.monotonic()
+        resp = _post(client, name)
+        elapsed = time.monotonic() - started
+        # Stay inside the client context so the app's event loop is alive and
+        # the detached done-callback can actually run.
+        watch_until = time.monotonic() + _SHIM_SLEEP_S * 3
+        marker = None
+        while time.monotonic() < watch_until:
+            marker = read_marker(state_dir_for(name))
+            if flag.exists() and (exit_code == 0 or marker is not None):
+                break
+            time.sleep(0.1)
+    return _SlowSpawn(
+        status_code=resp.status_code,
+        body=resp.json(),
+        elapsed_s=elapsed,
+        launch_completed=flag.exists(),
+        marker=marker,
+    )
+
+
+@pytest.fixture
+def slow_ok_spawn(isolated_listen_env, short_deadline, env_save_restore, tmp_path):
+    """One slow SUCCEEDING spawn, shared by the assertions about it."""
+    return _run_slow_spawn(env_save_restore, tmp_path, name="slow-ok", exit_code=0)
+
+
+@pytest.fixture
+def slow_failing_spawn(isolated_listen_env, short_deadline, env_save_restore, tmp_path):
+    """One slow FAILING spawn — the late-failure diagnosability case."""
+    return _run_slow_spawn(env_save_restore, tmp_path, name="slow-fail", exit_code=255)
+
+
+# ---------------------------------------------------------------------------
+# A launch that outlives the deadline is ACCEPTED, not failed and not silent
+# ---------------------------------------------------------------------------
+
+
+def test_a_launch_past_the_deadline_answers_202(slow_ok_spawn) -> None:
+    # Arrange
+    result = slow_ok_spawn
+    # Act
+    status = result.status_code
+    # Assert
+    assert status == 202
+
+
+def test_a_launch_past_the_deadline_answers_before_the_launch_finishes(
+    slow_ok_spawn,
+) -> None:
+    """The point of the deadline: the ANSWER beats the work, by a wide margin."""
+    # Arrange
+    result = slow_ok_spawn
+    # Act
+    elapsed = result.elapsed_s
+    # Assert — without the deadline the handler blocks for the full shim sleep.
+    assert elapsed < _SHIM_SLEEP_S / 2
+
+
+def test_a_202_body_reports_status_accepted(slow_ok_spawn) -> None:
+    # Arrange
+    result = slow_ok_spawn
+    # Act
+    status_field = result.body["status"]
+    # Assert
+    assert status_field == "accepted"
+
+
+def test_a_202_body_reports_the_launch_phase(slow_ok_spawn) -> None:
+    """``phase`` tells the caller whether the agent was even kicked off yet."""
+    # Arrange
+    result = slow_ok_spawn
+    # Act
+    phase = result.body["phase"]
+    # Assert
+    assert phase == "launch"
+
+
+def test_a_202_body_names_a_poll_route(slow_ok_spawn) -> None:
+    """202 is only honest if it says where the outcome will appear."""
+    # Arrange
+    result = slow_ok_spawn
+    # Act
+    poll = result.body["poll"]
+    # Assert
+    assert poll == "/agents/slow-ok/status"
+
+
+def test_a_202_does_not_cancel_the_running_launch(slow_ok_spawn) -> None:
+    """The shield: answering 202 must leave the spawn running, not kill it."""
+    # Arrange
+    result = slow_ok_spawn
+    # Act
+    completed = result.launch_completed
+    # Assert
+    assert completed is True
+
+
+def test_a_failure_after_the_202_still_writes_its_marker(slow_failing_spawn) -> None:
+    """A 202 must not be a degraded mode: a LATE failure stays diagnosable.
+
+    Without the detach bookkeeping the task is abandoned, its rc and stderr go
+    with it, and a caller polling ``/agents/<name>/status`` sees an agent that is
+    merely "not running" with nothing saying why.
+    """
+    # Arrange
+    result = slow_failing_spawn
+    # Act
+    marker = result.marker
+    # Assert
+    assert marker is not None
+
+
+def test_a_late_failure_marker_carries_the_real_exit_code(slow_failing_spawn) -> None:
+    # Arrange
+    result = slow_failing_spawn
+    # Act
+    marker = result.marker or {}
+    # Assert
+    assert marker.get("exit_code") == 255
+
+
+# ---------------------------------------------------------------------------
+# The fast path is UNCHANGED — the deadline must not steal the definite answer
+# ---------------------------------------------------------------------------
+
+
+def test_a_launch_inside_the_deadline_still_answers_200(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """A synchronous 200 carries strictly more information than "poll me"."""
+    # Arrange
+    bin_dir = tmp_path / "sac_bin_fast"
+    bin_dir.mkdir()
+    _install_fast_sac_shim(bin_dir)
+    _prepare_env(env_save_restore, bin_dir)
+    # Act
+    with TestClient(create_app(token=_TOKEN)) as client:
+        resp = _post(client, "fast-child")
+    # Assert
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# The client/server contract that replaced two independently-picked constants
+# ---------------------------------------------------------------------------
+
+
+def test_a_client_timeout_outlives_the_server_deadline() -> None:
+    """If this inverts, the client destroys the 202 it exists to receive.
+
+    Not hypothetical: the pre-fix pair (server grace 20s, client budget 30s,
+    both hand-picked in files that never import each other) left eight seconds
+    of headroom on a host idling at load 60-70, and when it flipped the caller
+    reported a SUCCEEDING spawn as failed.
+    """
+    # Arrange
+    server = _handler_deadline.AGENT_START_DEADLINE_S
+    # Act
+    client = _handler_deadline.client_timeout_for(server)
+    # Assert
+    assert client > server
+
+
+def test_a_deadline_never_reports_negative_remaining() -> None:
+    """Callers hand this straight to asyncio.wait_for, which rejects negatives."""
+    # Arrange
+    deadline = _handler_deadline.Deadline(0.0)
+    # Act
+    remaining = deadline.remaining()
+    # Assert
+    assert remaining == 0.0
+
+
+def test_a_zero_budget_deadline_reports_expired() -> None:
+    # Arrange
+    deadline = _handler_deadline.Deadline(0.0)
+    # Act
+    expired = deadline.expired()
+    # Assert
+    assert expired is True


### PR DESCRIPTION
The fleet's standing complaint — "I can't start agents" — is a SUCCEEDING
spawn reported as a failure. This is the protocol fix, not another timeout
bump.

MECHANISM. `POST /agents` on the background path spends its time in four
places (`_agent_exec.agents_start` -> `_credential_refresh_lock`):

    1. flock acquire (creds-refresh.lock)     BLOCKING, UNBOUNDED
    2. subprocess.run(sac agents start ...)   no timeout
    3. OAuth settle window                    up to 20s  <- HELD INSIDE THE LOCK
    4. post-ack liveness probe                up to 20s  <- outside the lock

A single spawn on an idle host is (2)+(4) ~= 22s, measured. But (3) is held
INSIDE the exclusive flock, so under N concurrent spawns waiter N pays N-1
predecessors x (launch + up to 20s) BEFORE its own launch starts. Three
concurrent spawns put the third caller past 60s.

Nothing told that caller it was QUEUED. From outside, waiting in a queue and
talking to a dead host are the same silence, so the caller's socket timeout
became the error channel — and a timeout carries no status, so "slow" /
"dead" / "already succeeded" are indistinguishable on a MUTATING route. The
natural retry then starts a SECOND agent.

WHY RAISING THE CLIENT TIMEOUT COULD NOT FIX IT. PR #902 raised the spawn
client 20s -> 35s. That covers a single idle-host spawn and cannot cover the
queued case, because the wait above is unbounded by construction. No client
constant is large enough. The server had to learn to SAY "still in flight".

THE CONTRACT (new `_listen/_handler_deadline.py`):

    accepted, completed, alive        200   true
    accepted, ran, observably failed  502   false
    accepted, STILL IN FLIGHT         202   unknown -- poll /agents/<name>/status
    bad body / ACL deny               400 / 403   (unchanged)

202 is the load-bearing row and is NOT an error. This is the same three-valued
discipline `_agent_exec_liveness` already applies one layer down, in its own
words: "an INCONCLUSIVE probe now returns 'no failure' rather than
manufacturing one: UNKNOWN authorises nothing." The probe stopped
manufacturing failures from inconclusive results; the HTTP layer in front of
it had not — it manufactured one by staying silent until the client gave up.

Deadline 30s: a single spawn (~22s) still answers 200/502 synchronously with
~8s of headroom, because a definite answer carries strictly more information
than "poll me". Past that the caller is genuinely queued, which is the case
that should be REPORTED rather than waited out.

DETAILS THAT MAKE THE 202 HONEST:

* `asyncio.shield` — `wait_for` CANCELS its inner awaitable on timeout, the
  exact opposite of what a 202 promises. New `_listen/_spawn_detach.py` adopts
  the still-running launch, holds a strong reference (an abandoned Task is GC'd
  with its exception unretrieved), and writes the same STARTUP_FAILED marker
  the synchronous path would have written. A 202 must not be a degraded mode:
  a LATE failure stays as diagnosable as an early one.
* A TRUNCATED liveness probe never convicts. When the remaining budget is
  shorter than the grace window the probe runs short, and a short probe that
  reports failure has not OBSERVED one — it ran out of time. That is UNKNOWN,
  so it answers 202, never 502. `_agent_exec_liveness` records why this matters:
  a 5s window "was not a probe, it was a coin toss", and a lost toss stamps
  `startup_failed` on a healthy agent, whose remedy is destructive.
* foreground / one-shot are EXEMPT — they block for a whole interactive session
  by construction, so that caller asked to wait and a 202 answers a question it
  did not ask.
* The client timeout is now DERIVED (`client_timeout_for()`), replacing two
  independently-picked constants in files that never import each other.

REFACTOR (required, not incidental): `_spawn_client.py` was at 510/512 lines,
so the 202 branch did not fit. It held two responsibilities — the spawn CALL,
and the generic question of how to address a listen server. The second was
never spawn-specific, proven by `_host_exec_client` already importing
`_parse_body` / `_resolve_base_url` / `_resolve_bearer` FROM it. Extracted to
`_lifecycle/_listen_client_resolve.py` (510 -> 398), re-exported so every
existing import path is byte-identical.

That extraction exposed a bigger problem, filed separately rather than bundled:
`_resolve_base_url` + `_resolve_bearer` are implemented FIVE times
(`_spawn_client`, `_restart_client`, `_in_sif_http_client`,
`_state/_acl_broker_client`, `_listen/_card_event_delivery`). One copy carries
a bearer fallback added to fix a real 401; whether the other four carry it is
UNVERIFIED. Same defect as the agent listing existing twice, where July's fixes
only ever reached the CLI copy.

VERIFICATION. 12 new tests, real TestClient + real `sac` shim on $PATH, no
mocks. NEGATIVE CONTROL run before claiming anything, because a test that
passes without its fix is theatre:

    pre-fix emulation (deadline 30s > 4s shim)   200 after 4.34s
    with fix          (deadline 0.5s < 4s shim)  202 after 0.52s

The 202 assertions fail under pre-fix behaviour. Suite: 1355 passed
(_lifecycle + _mcp spawn + _listen agent_exec), 0 failed.

NOT YET LIVE. Like #901, this needs propagating into the daemon venv before any
of it applies in production.
