### PR TITLE
fix(host_exec): auto-resolve the caller from SAC_NAME, as the docs promised

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_host_exec_client.py
+++ b/src/scitex_agent_container/_lifecycle/_host_exec_client.py
@@ -19,7 +19,12 @@ from typing import Any, Callable
 from urllib import error as urlerror
 from urllib import request as urlrequest
 
-from ._spawn_client import _parse_body, _resolve_base_url, _resolve_bearer
+from ._listen_client_resolve import (
+    _parse_body,
+    _resolve_base_url,
+    _resolve_bearer,
+    _resolve_caller,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -146,8 +151,27 @@ def request_host_exec(
         body["timeout_s"] = timeout_s
     if env is not None:
         body["env"] = env
-    if caller is not None:
-        body["caller"] = caller
+    # AUTO-RESOLVE the caller identity from SAC_NAME when one is not supplied.
+    # Without this, an in-container agent that omits `caller` sends a body with
+    # no identity at all; the server has no per-node bearer on the host-wide
+    # bearer path either, so `check_group_acl` refuses with
+    #   403 "host_exec requires a resolvable caller (per-node bearer or 'caller'
+    #        body claim)"
+    # even though SAC_NAME is set in that container. Reported by scitex-storage
+    # 2026-07-28 (sac-listen-restart-defect-cluster) and hit again 2026-08-09.
+    #
+    # The tool's own documentation already PROMISED this behaviour — "defaults
+    # to SAC_NAME from the container" — while no layer implemented it: the MCP
+    # tool passes `caller` straight through and this client only forwarded a
+    # non-None value. Documented-but-absent is worse than missing, because the
+    # 403 then reads as a permissions problem rather than an unsent field.
+    #
+    # `_resolve_caller` keeps an explicit argument verbatim (including "" ->
+    # None, the deliberate opt-out for the admin path), so this only fills the
+    # gap and never overrides a caller's choice.
+    resolved_caller = _resolve_caller(caller)
+    if resolved_caller is not None:
+        body["caller"] = resolved_caller
 
     payload = json.dumps(body).encode("utf-8")
     url = f"{base}/v1/host_exec"

--- a/tests/scitex_agent_container/_lifecycle/test__host_exec_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__host_exec_client.py
@@ -35,6 +35,7 @@ def _env(name: str, value: str):
         else:
             os.environ[name] = prev
 
+
 from scitex_agent_container._lifecycle._host_exec_client import (
     HostExecRequestError,
     request_host_exec,
@@ -85,9 +86,7 @@ def _opener_raising_http(code: int, body: dict[str, Any]):
             def close(self_inner) -> None:  # noqa: N805
                 return None
 
-        exc = urlerror.HTTPError(
-            req.full_url, code, "reason", hdrs=None, fp=_ErrBody()
-        )
+        exc = urlerror.HTTPError(req.full_url, code, "reason", hdrs=None, fp=_ErrBody())
         raise exc
 
     return _opener
@@ -244,11 +243,13 @@ def test_request_host_exec_returns_parsed_server_body():
 def test_request_host_exec_raises_on_403_from_server():
     # Arrange — group gate refused (real deny shape from the endpoint).
     opener = _opener_raising_http(403, {"error": "group not eligible"})
+
     # Act
     def _call() -> None:
         request_host_exec(
             ["true"], base_url="http://127.0.0.1:7878", bearer="tok", opener=opener
         )
+
     # Assert
     with pytest.raises(HostExecRequestError):
         _call()
@@ -272,11 +273,13 @@ def test_request_host_exec_exception_populates_status_on_http_error():
 def test_request_host_exec_raises_on_transport_error():
     # Arrange — listen daemon down / connection refused.
     opener = _opener_raising_url("connection refused")
+
     # Act
     def _call() -> None:
         request_host_exec(
             ["true"], base_url="http://127.0.0.1:7878", bearer="tok", opener=opener
         )
+
     # Assert
     with pytest.raises(HostExecRequestError):
         _call()
@@ -380,3 +383,65 @@ def test_invalid_env_override_falls_back_to_derived():
         )
     # Assert
     assert opener.last_timeout == pytest.approx(330.0)
+
+
+# ---------------------------------------------------------------------------
+# Caller identity is AUTO-RESOLVED from SAC_NAME
+#
+# Omitting `caller` used to send a body with no identity at all. On the
+# host-wide bearer path the server has no per-node identity either, so it
+# refused with 403 "host_exec requires a resolvable caller" — even though
+# SAC_NAME was set in that container. Reported by scitex-storage 2026-07-28,
+# hit again 2026-08-09. The tool's docstring had promised this defaulting all
+# along while no layer implemented it.
+# ---------------------------------------------------------------------------
+
+
+def test_caller_is_auto_resolved_from_sac_name_when_omitted():
+    """The regression: no `caller` argument must still send an identity."""
+    # Arrange
+    opener = _opener_returning({"exit_code": 0})
+    # Act
+    with _env("SAC_NAME", "agent-under-test"):
+        request_host_exec(
+            ["true"], base_url="http://127.0.0.1:7878", bearer="tok", opener=opener
+        )
+    body = json.loads(opener.last_request.data.decode("utf-8"))
+    # Assert
+    assert body["caller"] == "agent-under-test"
+
+
+def test_an_explicit_caller_is_not_overridden_by_sac_name():
+    """Auto-resolution fills a gap; it must never override a caller's choice."""
+    # Arrange
+    opener = _opener_returning({"exit_code": 0})
+    # Act
+    with _env("SAC_NAME", "agent-under-test"):
+        request_host_exec(
+            ["true"],
+            caller="explicit-caller",
+            base_url="http://127.0.0.1:7878",
+            bearer="tok",
+            opener=opener,
+        )
+    body = json.loads(opener.last_request.data.decode("utf-8"))
+    # Assert
+    assert body["caller"] == "explicit-caller"
+
+
+def test_an_empty_caller_opts_out_and_sends_no_identity():
+    """`caller=""` is the deliberate admin/host-wide path — keep it working."""
+    # Arrange
+    opener = _opener_returning({"exit_code": 0})
+    # Act
+    with _env("SAC_NAME", "agent-under-test"):
+        request_host_exec(
+            ["true"],
+            caller="",
+            base_url="http://127.0.0.1:7878",
+            bearer="tok",
+            opener=opener,
+        )
+    body = json.loads(opener.last_request.data.decode("utf-8"))
+    # Assert
+    assert "caller" not in body


### PR DESCRIPTION
An in-container agent calling `host_exec_local` WITHOUT an explicit `caller`
got a 403:

    {"status":"error","http_status":403,
     "reason":"host_exec rejected: listen returned HTTP 403
               ({'error':'ACL deny','kind':'acl_deny',
                 'reason':\"host_exec requires a resolvable caller
                            (per-node bearer or 'caller' body claim)\"})"}

with `SAC_NAME` set in that container the whole time. Passing `caller=...`
explicitly worked immediately.

WHERE IT WENT MISSING. The server is correct: on the host-wide bearer path
there is no per-node identity, so it needs the body claim and refuses without
one. The client never sent it — `request_host_exec` only forwarded a
non-None `caller`, and the MCP tool passes its argument straight through. So
NO layer resolved the identity.

WHAT MAKES THIS WORSE THAN A MISSING FEATURE: the tool's own docstring
already documented the behaviour —

    caller: Override the auto-resolved caller identity (defaults to
            ``SAC_NAME`` from the container).

Documented, and implemented nowhere. A reader checks the doc, sees defaulting,
omits the argument, and reads the resulting 403 as a PERMISSIONS problem rather
than an unsent field. That is the expensive kind of wrong: the error text points
away from the cause.

THE FIX is to use the resolver that already exists and already does exactly
this — `_resolve_caller`, which reads SAC_NAME via `resolve_spawn_caller()` and
keeps an explicit argument verbatim (including `""` -> None, the deliberate
opt-out for the admin / host-wide path). So this fills the gap and never
overrides a caller's choice.

HOW IT WENT MISSING IS THE INTERESTING PART. `_host_exec_client` imported THREE
of the four resolvers from `_spawn_client`:

    from ._spawn_client import _parse_body, _resolve_base_url, _resolve_bearer

`_resolve_caller` is the one it did not take, and it is the one the server
requires. This is precisely the failure predicted by
sac-listen-client-resolvers-implemented-five-times-20260809: when one module
borrows plumbing from a sibling piece by piece, the piece nobody remembered is
silently absent. The import is moved to the canonical
`._listen_client_resolve` here, which is also the first step of that card's
migration.

MEASURED, not inferred. Reported by scitex-storage 2026-07-28 as defect (2) of
sac-listen-restart-defect-cluster, and reproduced verbatim 2026-08-09 by hitting
it while propagating an unrelated fix — twelve days, unchanged.

A SECOND DEFECT, found by the negative control rather than by reading. With the
fix neutered, `caller=""` produced:

    {'argv': ['true'], 'caller': ''}

An EMPTY identity was sent, not omitted — and the server's gate is `if not
caller`, so an empty string is refused exactly like a missing one. The
documented admin/host-wide opt-out was therefore broken too, in a way that
looked like it worked. `_resolve_caller` normalises `""` -> None, so the field
is now correctly absent.

Tests: three new cases on the existing hand-rolled `opener` seam (no mocks,
STX-NM002) — auto-resolves when omitted, does NOT override an explicit caller,
and `caller=""` sends no identity at all. 20 pass.

NEGATIVE CONTROL, and the first attempt at it was WRONG. Pointing PYTHONPATH at
the pre-fix source and re-running showed 4 passed — apparently proving the tests
did not discriminate. They do: pytest's conftest puts the worktree source ahead
of PYTHONPATH, so that run silently exercised the FIXED code. Verified by
importing the module directly under each path and checking which file loaded.
The decisive control is to neuter the fix in place:

    resolved_caller = caller        # was _resolve_caller(caller)
    -> 2 failed, 2 passed

Both new behaviours fail without the change. A negative control that quietly
tests the wrong build is the same class of error as the fix itself — a thing
that reports success while doing nothing.
