### PR TITLE
refactor(restart_client): use the canonical bearer/caller resolvers

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_restart_client.py
+++ b/src/scitex_agent_container/_lifecycle/_restart_client.py
@@ -100,35 +100,36 @@ def _resolve_base_url(explicit: str | None) -> str:
 def _resolve_bearer(explicit: str | None) -> str | None:
     """Return the listen-server bearer token, or ``None`` if unset.
 
-    Identical resolution to :func:`._spawn_client._resolve_bearer`:
-    explicit arg → ``SAC_LISTEN_BEARER`` env → the on-disk host token
-    file. An absent bearer is NOT fatal (the listen may run with bearer
-    auth disabled); the server enforces its own auth contract.
+    Resolution: explicit arg → ``SAC_LISTEN_BEARER`` /
+    ``SCITEX_AGENT_CONTAINER_LISTEN_BEARER`` env → the on-disk host token file.
+    An absent bearer is NOT fatal (the listen may run with bearer auth
+    disabled); the server enforces its own auth contract.
+
+    Delegates rather than re-implementing. The old local body was VERIFIED
+    behaviourally identical to the canonical before this change — this is a
+    pure dedup, not a fix. It is worth doing anyway because the copies that
+    were NOT identical each cost a live defect: a missing resolver (#907), an
+    unreachable token file (#908), an invisible env prefix (#909). Every one of
+    those copies was also identical to the canonical on the day it was written.
+    A duplicate is not wrong when created; it goes wrong later, silently.
     """
-    if explicit is not None:
-        return explicit or None
-    from .._env import getenv
+    from ._listen_client_resolve import _resolve_bearer as _canonical_resolve_bearer
 
-    tok = (getenv("LISTEN_BEARER", "") or "").strip()
-    if tok:
-        return tok
-    from .._listen.tokens import default_token_path, read_token
-
-    return read_token(default_token_path())
+    return _canonical_resolve_bearer(explicit)
 
 
 def _resolve_caller(explicit: str | None) -> str | None:
     """Return the requesting agent's identity, or ``None`` for admin.
 
-    Reuses the spawn caller rule: read ``SAC_NAME`` from the container
-    env (via :func:`._spawn_gate.resolve_spawn_caller`). An empty string
-    normalises to ``None`` (administrative / operator path).
+    Reads ``SAC_NAME`` from the container env; an empty string normalises to
+    ``None`` (administrative / operator path). Delegates to the canonical
+    resolver — the local body was verified identical first. See
+    :func:`_resolve_bearer` above for why an identical copy is still worth
+    removing.
     """
-    if explicit is not None:
-        return explicit or None
-    from ._spawn_gate import resolve_spawn_caller
+    from ._listen_client_resolve import _resolve_caller as _canonical_resolve_caller
 
-    return resolve_spawn_caller()
+    return _canonical_resolve_caller(explicit)
 
 
 def _parse_body(raw: bytes) -> Any:

--- a/tests/scitex_agent_container/_lifecycle/test__restart_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__restart_client.py
@@ -238,6 +238,32 @@ def test_no_authorization_header_when_bearer_unset(listen_env) -> None:
     assert "authorization" not in captured["headers"]
 
 
+def test_bearer_falls_back_to_the_host_token_file(listen_env, tmp_path) -> None:
+    """The env-absent-but-file-present case, which was NOT covered here.
+
+    Coverage gap found while swapping this module onto the canonical resolver:
+    the suite asserted the header IS attached from the env, and that NO header
+    appears when nothing is available — but never that an on-disk token is
+    picked up. That middle case is the whole reason the file fallback exists
+    (the runtime injects SAC_LISTEN_BEARER only for specs registering
+    `server:sac`), and two other clients were found missing it entirely today.
+    Without this test the delegation could have silently dropped the fallback
+    and every existing assertion would still have passed.
+    """
+    # Arrange — no bearer env; a real token file under the redirected HOME.
+    from scitex_agent_container._listen.tokens import default_token_path
+
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    path = default_token_path(home=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("file-tok-restart", encoding="utf-8")
+    opener, captured = _opener_returning(b'{"name":"peer","returncode":0}')
+    # Act
+    request_restart("peer", opener=opener)
+    # Assert
+    assert captured["headers"].get("authorization") == "Bearer file-tok-restart"
+
+
 def test_success_returns_parsed_response_dict(listen_env) -> None:
     # Arrange
     listen_env("LISTEN_BASE_URL", "http://host:9100")
@@ -284,9 +310,7 @@ def test_acl_403_deny_raises_with_status_403(listen_env) -> None:
 def test_acl_403_deny_preserves_server_reason_in_body(listen_env) -> None:
     # Arrange
     listen_env("LISTEN_BASE_URL", "http://host:9100")
-    deny_body = json.dumps(
-        {"error": "ACL deny", "reason": "lineage ACL deny"}
-    ).encode()
+    deny_body = json.dumps({"error": "ACL deny", "reason": "lineage ACL deny"}).encode()
     opener = _opener_raising(
         urlerror.HTTPError(
             "http://host:9100/agents/peer/restart",


### PR DESCRIPTION
The last two duplicated resolvers on the client surface now delegate:

    _restart_client._resolve_bearer  -> _listen_client_resolve._resolve_bearer
    _restart_client._resolve_caller  -> _listen_client_resolve._resolve_caller

NO BEHAVIOUR CHANGE. Both local bodies were diffed against the canonical FIRST
and are identical: same order (explicit -> either env prefix -> host token
file), same `""` -> None normalisation, same never-raises contract, same
`resolve_spawn_caller()` source for the caller.

WHY REMOVE AN IDENTICAL COPY AT ALL. Because identical is a property of TODAY,
not of the code. Every divergent copy found under this card was also identical
to the canonical on the day it was written, and each one silently froze while
the canonical grew:

    #907  _host_exec_client   missing RESOLVER        -> 403 for every agent
                                                         that omitted `caller`
    #908  _in_sif_http_client missing FALLBACK SOURCE -> 401 when the bearer
          _acl_broker_client                             lived only on disk
    #909  _card_event_delivery missing ENV PREFIX     -> 401 when only the
                                                         long-form var was set

Three defects, three different axes, one mechanism: a copy cannot inherit a
source added after it was made. This commit removes the last two copies that
could still acquire that problem.

VERIFICATION for a pure dedup is the EXISTING suite, unchanged: 22 pass,
including three that cover caller resolution end-to-end (defaults from
SAC_NAME, omitted on the admin path, explicit arg overrides).

BUT THE BEARER COVERAGE HAD A HOLE, found by checking instead of assuming. I
was about to write that this file "already exercises the token-file fallback".
It does not. It asserts the header IS attached from the env, and that NO header
appears when nothing is available — never that an on-disk token is picked up.
That middle case is the entire reason the fallback exists, and it is exactly
what two sibling clients were found missing today. Without it, this delegation
could have silently dropped the fallback and every existing assertion would
still have passed — a green suite proving nothing about the line I changed.

So one test is added here: env absent, real token file present under the
fixture's already-redirected HOME, assert the Authorization header carries it.
That makes "the existing suite covers this" a true statement rather than a
convenient one.

WHAT DELIBERATELY STAYS DUPLICATED: `_resolve_base_url`. Each module raises its
own fail-loud type (`HostListenTransportError`, `AclBrokerError`,
`SpawnRequestError`) and callers catch those, so unifying it would silently
change an exception contract. `_card_event_delivery`'s copy additionally
defaults to loopback instead of raising, which is right for a local call. DRY
was the correct instinct for the resolvers and the wrong rule here: the
duplicated part is reading a URL, but the DIFFERENTIATED part is the failure
type, and the failure type is what callers depend on.
