### PR TITLE
fix(host_exec): don't run a command that would kill the request's own server

### DIFF
--- a/src/scitex_agent_container/_listen/_host_exec.py
+++ b/src/scitex_agent_container/_listen/_host_exec.py
@@ -123,6 +123,12 @@ from ._host_exec_inflight import (
     register_inflight,
     unregister_inflight,
 )
+from ._plane_restart_detach import (
+    PLANE_RESTART_DELAY_S,
+    plane_restart_log_path,
+    spawn_detached_plane_command,
+)
+from ._plane_targeting_argv import targets_listen_plane
 
 # Operator-scoped groups (2026-07-01 Q1a + researcher; ``privileged`` added
 # 2026-07-02 per operator request). Members of these groups are permitted to
@@ -285,6 +291,57 @@ async def host_exec(
         merged_env.update(extra_env)
     else:
         merged_env = None  # inherit parent env
+
+    # DON'T RUN A COMMAND THAT WOULD KILL THIS REQUEST'S OWN SERVER.
+    #
+    # This endpoint is served BY the sac listen daemon, so `systemctl restart
+    # sac-listen` (or `sac listen restart`) run INLINE kills the process group
+    # answering the call. Measured 2026-08-09: exit_code -15, empty stdout, no
+    # status — while the restart had actually SUCCEEDED. The caller cannot tell
+    # "succeeded and killed my reporter" from "failed", so it retries, and a
+    # retry restarts a healthy plane. scitex-storage reported the CLI form of
+    # this on 2026-07-28: such a restart "must report ACCEPTED, else callers
+    # retry and STACK restarts."
+    #
+    # So schedule it DETACHED and answer 202 — the same mechanism
+    # `_agent_restart.py` already uses for agent self-restart (setsid + a short
+    # delay so THIS response flushes before the bounce), rather than inventing a
+    # third variant of "don't decapitate yourself".
+    verdict = targets_listen_plane(argv)
+    if verdict.targets_plane:
+        log_path = plane_restart_log_path()
+        try:
+            spawn_detached_plane_command(argv, env=merged_env, log_path=log_path)
+        except OSError as exc:
+            # Launch failure of the detached child itself — surface it typed,
+            # never a fake "scheduled".
+            return JSONResponse(
+                {
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "argv": argv,
+                    "detached": False,
+                },
+                status_code=500,
+            )
+        return JSONResponse(
+            {
+                "status": "scheduled",
+                "argv": argv,
+                "caller": caller,
+                "reason": verdict.reason,
+                "delay_s": PLANE_RESTART_DELAY_S,
+                "log": log_path,
+                "detail": (
+                    "This command would restart the listen daemon that is serving "
+                    "the request, so it was NOT run inline — running it inline "
+                    "returns exit_code -15 with no output and no way to tell "
+                    f"success from failure. It is scheduled detached in "
+                    f"~{PLANE_RESTART_DELAY_S}s. Verify with an INDEPENDENT probe "
+                    "(e.g. GET /v1/health) rather than by re-running this command."
+                ),
+            },
+            status_code=202,
+        )
 
     started = time.monotonic()
     timed_out = False

--- a/src/scitex_agent_container/_listen/_plane_restart_detach.py
+++ b/src/scitex_agent_container/_listen/_plane_restart_detach.py
@@ -1,0 +1,115 @@
+"""Run a plane-restarting command DETACHED, so it cannot kill its own reporter.
+
+Paired with :mod:`._plane_targeting_argv`, which decides WHETHER a host_exec
+command would restart the listen daemon serving the request. This module is the
+other half: HOW to run it so the caller still gets an answer.
+
+Kept separate from the predicate on purpose — that one is pure and unit-testable
+with no I/O, this one spawns processes. Kept out of ``_host_exec`` because that
+file is near its line cap and this is a distinct responsibility.
+
+THE MECHANISM IS NOT NEW. ``_listen/_agent_restart.py`` already solved the
+identical hazard for agent self-restart (incident 2026-07-12): a synchronous
+bounce deadlocks because the caller cannot die while still awaiting the response
+it is blocked on, so the restart is handed to a ``setsid`` child that sleeps
+past the response flush, and the handler answers 202 immediately. The same three
+ingredients are reproduced here — detach, delay, log — deliberately, so the
+fleet has ONE answer to "don't decapitate yourself" rather than three that drift.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+__all__ = [
+    "PLANE_RESTART_DELAY_S",
+    "build_detached_command",
+    "plane_restart_log_path",
+    "spawn_detached_plane_command",
+]
+
+# Delay before the detached command actually fires. Long enough for the 202 to
+# flush over the wire and the caller's tool-call to unwind BEFORE the daemon
+# goes down — the whole failure being that a caller cannot receive a response
+# from a process that is being killed. Mirrors
+# ``_agent_restart._SELF_RESTART_DELAY_S`` (3s) deliberately: same hazard, same
+# number, so the two cannot drift into different answers.
+PLANE_RESTART_DELAY_S = 3
+
+
+def plane_restart_log_path() -> str:
+    """Where a detached plane command writes its output.
+
+    NEVER ``/dev/null``. The command necessarily outlives the process that could
+    have reported it, so this log is the only post-hoc evidence of what it did —
+    which is precisely what was missing when the inline form returned
+    ``exit_code -15`` with an empty stdout.
+    """
+    return str(
+        Path.home()
+        / ".scitex"
+        / "agent-container"
+        / "runtime"
+        / "logs"
+        / "host_exec-plane-restart.log"
+    )
+
+
+def build_detached_command(
+    argv: list[str] | tuple[str, ...],
+    *,
+    delay_s: int,
+    log_path: str,
+) -> list[str]:
+    """Build the ``setsid sh -c '<inner>'`` argv (PURE — spawns nothing).
+
+    Separated from the spawn so the constructed command is unit-assertable
+    without forking anything, the same seam ``_agent_restart`` uses. ``<inner>``
+    is::
+
+        sleep <delay_s>; ( echo <marker>; date -Is; <cmd> ) >> <log> 2>&1
+
+    Every token is ``shlex.quote``d — the caller's argv is a list by contract
+    (``host_exec`` rejects the shell form), and it must stay one command rather
+    than becoming shell text that could word-split.
+    """
+    inner = " ".join(shlex.quote(tok) for tok in argv)
+    marker = shlex.quote(f"=== host_exec detached plane command: {inner} ===")
+    script = (
+        f"sleep {int(delay_s)}; "
+        f"( echo {marker}; date -Is; {inner} ) >> {shlex.quote(log_path)} 2>&1"
+    )
+    return ["setsid", "sh", "-c", script]
+
+
+def spawn_detached_plane_command(
+    argv: list[str] | tuple[str, ...],
+    *,
+    env: dict[str, str] | None,
+    log_path: str,
+    delay_s: int = PLANE_RESTART_DELAY_S,
+) -> list[str]:
+    """Fire-and-forget ``argv`` after ``delay_s``, fully detached. Returns the argv.
+
+    ``setsid`` plus ``start_new_session=True`` (belt and braces) sever the child
+    from this handler's session AND process group, so restarting the daemon does
+    not take the child with it — which is exactly what happens inline. stdin is
+    ``/dev/null``; stdout/stderr go to ``log_path`` via the inner shell, so the
+    child holds no pipe to a process that is about to die.
+
+    Raises ``OSError`` if the spawn itself fails; the caller must surface that
+    rather than reporting a fake "scheduled".
+    """
+    detached = build_detached_command(argv, delay_s=delay_s, log_path=log_path)
+    Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+    subprocess.Popen(
+        detached,
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+    return detached

--- a/src/scitex_agent_container/_listen/_plane_targeting_argv.py
+++ b/src/scitex_agent_container/_listen/_plane_targeting_argv.py
@@ -1,0 +1,142 @@
+"""Recognise a host_exec command that would restart the plane serving it.
+
+THE INCIDENT THIS CLOSES. ``POST /v1/host_exec`` runs commands on the host, and
+it is SERVED BY the ``sac listen`` daemon. A command that restarts that daemon
+therefore kills the process group serving its own request. Measured 2026-08-09
+while propagating a merged fix::
+
+    systemctl --user restart sac-listen.service   (via host_exec)
+    -> {"exit_code": -15, "stdout": "", ...}
+
+-15 is SIGTERM. Empty stdout, no status, no confirmation. The restart HAD
+succeeded — verified afterwards by an independent probe answering 200 on the
+first attempt — but the command could not say so, because the component
+reporting the result was the component being restarted.
+
+WHY THE CALLER CANNOT RECOVER FROM THAT. These three are indistinguishable:
+
+    (a) the restart succeeded and killed my reporter   <- what happened
+    (b) the restart failed and something killed us both
+    (c) the command was killed for an unrelated reason
+
+An operator or agent reading (a) as (b) retries — restarting a healthy plane,
+or concluding the control plane is broken when it is fine. That is the same
+"succeeded but reported failed" family as the spawn route, and scitex-storage
+reported the CLI form of it on 2026-07-28: "a restart that kills its own
+response connection must report ACCEPTED, else callers retry and STACK
+restarts."
+
+THE ANSWER IS ALREADY IN THIS CODEBASE. ``_listen/_agent_restart.py`` solves the
+identical shape for agent self-restart — a detached, deferred bounce so the
+response flushes first, answered ``202`` with ``self_restart="scheduled"``. This
+module is the DETECTION half for the host_exec surface, so that mechanism can be
+reused rather than a third variant invented.
+
+DELIBERATELY CONSERVATIVE. The constitution warns that pattern matching lies, so
+this matches a small, explicit set of well-known spellings rather than trying to
+be clever, and the asymmetry of its errors is chosen on purpose:
+
+  * a FALSE POSITIVE means a command mentioning the listen service is run
+    detached and answered 202 instead of inline — recoverable, loud, and the
+    caller is told exactly what happened;
+  * a FALSE NEGATIVE is merely the status quo (the -15 above).
+
+So it is safe to be incomplete and unsafe to be aggressive. Nothing here refuses
+work; the caller always gets a real answer.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+__all__ = ["PlaneTargetVerdict", "targets_listen_plane"]
+
+# The systemd unit that runs the daemon on this fleet.
+_LISTEN_UNIT_TOKENS = ("sac-listen",)
+
+# Service managers whose argv can stop/restart that unit.
+_SERVICE_MANAGERS = ("systemctl", "service")
+
+# Verbs that would end the CURRENT daemon process. `start` is deliberately
+# absent: starting an already-running daemon is a no-op and kills nobody, and
+# starting a DOWN one is exactly the recovery we must not make harder.
+_DISRUPTIVE_VERBS = ("stop", "restart", "kill", "reload-or-restart", "try-restart")
+
+# Process-killers pointed at the daemon by name.
+_KILLERS = ("pkill", "killall", "kill")
+
+
+@dataclass(frozen=True)
+class PlaneTargetVerdict:
+    """Fixed shape, always returned — never a bare bool.
+
+    ``targets_plane`` is the decision; ``reason`` explains it in the caller's
+    own terms so a 202 can say WHY it was scheduled rather than run. A caller
+    must not have to guess which field exists on a given call.
+    """
+
+    targets_plane: bool
+    reason: str | None = None
+
+
+def _basename(arg: str) -> str:
+    return os.path.basename(arg.strip()) if arg else ""
+
+
+def targets_listen_plane(argv: list[str] | tuple[str, ...]) -> PlaneTargetVerdict:
+    """Would running ``argv`` inline kill the daemon serving this request?
+
+    Recognised, in order:
+
+    1. a service manager (``systemctl`` / ``service``) whose argv carries a
+       disruptive verb AND names the ``sac-listen`` unit;
+    2. the ``sac listen`` CLI with a disruptive verb (``sac listen restart``);
+    3. a killer (``pkill`` / ``killall`` / ``kill``) whose pattern names the
+       daemon.
+
+    Anything else is ``targets_plane=False`` — including plain reads such as
+    ``systemctl status sac-listen``, which are safe to run inline and must NOT
+    be deferred (deferring a status query would answer 202 to a question that
+    wanted an answer).
+    """
+    if not argv:
+        return PlaneTargetVerdict(False)
+    args = [a for a in argv if isinstance(a, str)]
+    if not args:
+        return PlaneTargetVerdict(False)
+    head = _basename(args[0])
+    lowered = [a.lower() for a in args]
+    joined = " ".join(lowered)
+
+    names_unit = any(tok in joined for tok in _LISTEN_UNIT_TOKENS)
+    has_verb = any(v in lowered for v in _DISRUPTIVE_VERBS)
+
+    if head in _SERVICE_MANAGERS and names_unit and has_verb:
+        return PlaneTargetVerdict(
+            True,
+            f"{head} would {', '.join(v for v in _DISRUPTIVE_VERBS if v in lowered)} "
+            "the sac-listen unit that is serving this request",
+        )
+
+    # `sac listen restart` / `sac listen stop` — the CLI form scitex-storage
+    # reported on 2026-07-28 (it returned HTTP 500 while SUCCEEDING).
+    if head.startswith("sac") and "listen" in lowered and has_verb:
+        return PlaneTargetVerdict(
+            True,
+            "`sac listen` with a disruptive verb would end the daemon serving "
+            "this request",
+        )
+
+    if head in _KILLERS and names_unit:
+        return PlaneTargetVerdict(
+            True,
+            f"{head} names the sac-listen daemon serving this request",
+        )
+    if head in _KILLERS and "sac listen" in joined:
+        return PlaneTargetVerdict(
+            True,
+            f"{head} names the sac listen daemon serving this request",
+        )
+
+    return PlaneTargetVerdict(False)

--- a/tests/scitex_agent_container/_listen/test__plane_restart_detach.py
+++ b/tests/scitex_agent_container/_listen/test__plane_restart_detach.py
@@ -1,0 +1,116 @@
+"""The detached form of a plane-restarting command.
+
+Mirrors ``src/scitex_agent_container/_listen/_plane_restart_detach.py``
+(PS-204 §2).
+
+Asserts the CONSTRUCTED command rather than spawning one — the module exposes
+``build_detached_command`` as a pure seam precisely so these properties are
+checkable without forking a process that would restart the daemon running the
+tests. That is the same save/restore-seam idiom ``_agent_restart`` uses for its
+own detached bounce.
+
+Each property here is load-bearing, and each maps to a way the inline form
+failed on 2026-08-09 (``exit_code -15``, empty stdout, outcome unknowable):
+
+  * ``setsid``      — the child must survive the daemon it is about to restart;
+  * ``sleep <n>``   — the 202 must reach the caller BEFORE the daemon goes down;
+  * append to a LOG — the command outlives whatever could have reported it, so
+                      the log is the only post-hoc evidence it ran;
+  * ``shlex`` quoting — argv is a list by contract and must not word-split into
+                      shell text.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._listen._plane_restart_detach import (
+    PLANE_RESTART_DELAY_S,
+    build_detached_command,
+    plane_restart_log_path,
+)
+
+_ARGV = ["systemctl", "--user", "restart", "sac-listen.service"]
+_LOG = "/tmp/plane-restart-test.log"
+
+
+def test_the_detached_command_starts_a_new_session() -> None:
+    """Without setsid the child dies with the daemon it is restarting."""
+    # Arrange
+    argv = _ARGV
+    # Act
+    built = build_detached_command(argv, delay_s=3, log_path=_LOG)
+    # Assert
+    assert built[0] == "setsid"
+
+
+def test_the_detached_command_runs_through_a_shell() -> None:
+    # Arrange
+    argv = _ARGV
+    # Act
+    built = build_detached_command(argv, delay_s=3, log_path=_LOG)
+    # Assert
+    assert built[1:3] == ["sh", "-c"]
+
+
+def test_the_detached_command_defers_by_the_requested_delay() -> None:
+    """The delay is what lets the 202 reach the caller before the bounce."""
+    # Arrange
+    argv = _ARGV
+    # Act
+    built = build_detached_command(argv, delay_s=7, log_path=_LOG)
+    # Assert
+    assert built[3].startswith("sleep 7;")
+
+
+def test_the_detached_command_carries_the_original_argv() -> None:
+    # Arrange
+    argv = _ARGV
+    # Act
+    built = build_detached_command(argv, delay_s=3, log_path=_LOG)
+    # Assert
+    assert "systemctl --user restart sac-listen.service" in built[3]
+
+
+def test_the_detached_command_appends_to_the_log() -> None:
+    """Never /dev/null: this output is the only evidence the command ran."""
+    # Arrange
+    argv = _ARGV
+    # Act
+    built = build_detached_command(argv, delay_s=3, log_path=_LOG)
+    # Assert
+    assert f">> {_LOG} 2>&1" in built[3]
+
+
+def test_the_detached_command_quotes_hostile_tokens() -> None:
+    """argv is a LIST by contract; it must not become splittable shell text."""
+    # Arrange
+    argv = ["echo", "a b; rm -rf /"]
+    # Act
+    built = build_detached_command(argv, delay_s=3, log_path=_LOG)
+    # Assert
+    assert "'a b; rm -rf /'" in built[3]
+
+
+def test_the_log_path_is_under_the_runtime_logs_dir() -> None:
+    # Arrange
+    # (no setup — the path is derived from HOME)
+    # Act
+    path = plane_restart_log_path()
+    # Assert
+    assert path.endswith(
+        "/.scitex/agent-container/runtime/logs/host_exec-plane-restart.log"
+    )
+
+
+def test_the_default_delay_matches_the_agent_self_restart_delay() -> None:
+    """Same hazard, same number — so the two cannot drift into different answers.
+
+    ``_agent_restart._SELF_RESTART_DELAY_S`` is the original; this pins the
+    host_exec copy to it so a future change to one is visible against the other.
+    """
+    # Arrange
+    from scitex_agent_container._listen._agent_restart import _SELF_RESTART_DELAY_S
+
+    # Act
+    here = PLANE_RESTART_DELAY_S
+    # Assert
+    assert here == _SELF_RESTART_DELAY_S

--- a/tests/scitex_agent_container/_listen/test__plane_targeting_argv.py
+++ b/tests/scitex_agent_container/_listen/test__plane_targeting_argv.py
@@ -1,0 +1,132 @@
+"""Which host_exec commands would kill the daemon serving the request.
+
+Mirrors ``src/scitex_agent_container/_listen/_plane_targeting_argv.py``
+(PS-204 §2).
+
+WHAT THIS GUARDS. ``POST /v1/host_exec`` is served BY the sac listen daemon, so
+a command that restarts that daemon kills its own reporter. Measured 2026-08-09:
+
+    systemctl --user restart sac-listen.service   ->  exit_code -15, stdout ""
+
+The restart had SUCCEEDED; the caller could not be told. This predicate lets the
+handler recognise that class up front and schedule it detached instead.
+
+THE NEGATIVES MATTER AS MUCH AS THE POSITIVES, and are the reason this is a
+predicate rather than a substring search:
+
+  * ``systemctl status sac-listen`` is a READ — deferring it would answer 202
+    to a question that wanted data;
+  * a DIFFERENT unit that merely runs on the same host must not be caught;
+  * ``sac listen start`` kills nobody, and on a DOWN daemon it is the recovery
+    we must not make harder.
+
+No mocks (STX-NM002): the function is pure, so these are plain calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._listen._plane_targeting_argv import targets_listen_plane
+
+# ---------------------------------------------------------------------------
+# Commands that WOULD end the daemon serving the request
+# ---------------------------------------------------------------------------
+
+_DISRUPTIVE = [
+    ["systemctl", "--user", "restart", "sac-listen.service"],
+    ["systemctl", "--user", "stop", "sac-listen.service"],
+    ["systemctl", "restart", "sac-listen"],
+    ["sac", "listen", "restart"],
+    ["sac", "listen", "stop"],
+    ["/home/ywatanabe/.scitex/agent-container/venv/bin/sac", "listen", "restart"],
+    ["pkill", "-f", "sac listen"],
+    ["killall", "sac-listen"],
+]
+
+
+@pytest.mark.parametrize("argv", _DISRUPTIVE, ids=lambda a: " ".join(a)[:48])
+def test_a_plane_ending_command_is_detected(argv) -> None:
+    # Arrange
+    # (argv supplied by parametrize)
+    # Act
+    verdict = targets_listen_plane(argv)
+    # Assert
+    assert verdict.targets_plane is True
+
+
+@pytest.mark.parametrize("argv", _DISRUPTIVE, ids=lambda a: " ".join(a)[:48])
+def test_a_detected_command_carries_a_reason(argv) -> None:
+    """A 202 must be able to say WHY it was scheduled instead of run."""
+    # Arrange
+    # (argv supplied by parametrize)
+    # Act
+    verdict = targets_listen_plane(argv)
+    # Assert
+    assert verdict.reason
+
+
+# ---------------------------------------------------------------------------
+# Commands that must still run INLINE — over-matching breaks ordinary work
+# ---------------------------------------------------------------------------
+
+_SAFE = [
+    # A read of the same unit: the caller wants the output, not a 202.
+    ["systemctl", "--user", "status", "sac-listen.service"],
+    ["systemctl", "--user", "is-active", "sac-listen.service"],
+    # A DIFFERENT unit on the same host.
+    ["systemctl", "--user", "restart", "sac-creds-watch.service"],
+    # start kills nobody, and on a down daemon it is the recovery path.
+    ["sac", "listen", "start"],
+    # Ordinary sac work.
+    ["sac", "agents", "list"],
+    ["sac", "agents", "restart", "some-agent"],
+    # Ordinary shell work.
+    ["echo", "hello"],
+    ["git", "-C", "/repo", "status"],
+]
+
+
+@pytest.mark.parametrize("argv", _SAFE, ids=lambda a: " ".join(a)[:48])
+def test_an_unrelated_command_runs_inline(argv) -> None:
+    # Arrange
+    # (argv supplied by parametrize)
+    # Act
+    verdict = targets_listen_plane(argv)
+    # Assert
+    assert verdict.targets_plane is False
+
+
+# ---------------------------------------------------------------------------
+# Degenerate input must not raise — this runs before every host_exec
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_argv_is_not_plane_targeting() -> None:
+    # Arrange
+    argv: list[str] = []
+    # Act
+    verdict = targets_listen_plane(argv)
+    # Assert
+    assert verdict.targets_plane is False
+
+
+def test_a_non_string_argv_entry_does_not_raise() -> None:
+    """host_exec validates argv first, but this must never be the thing that
+    500s the endpoint."""
+    # Arrange
+    argv = [None, 123]  # type: ignore[list-item]
+    # Act
+    verdict = targets_listen_plane(argv)  # type: ignore[arg-type]
+    # Assert
+    assert verdict.targets_plane is False
+
+
+def test_an_undetected_command_carries_no_reason() -> None:
+    """The shape is fixed either way; only the reason is conditional."""
+    # Arrange
+    argv = ["echo", "hello"]
+    # Act
+    verdict = targets_listen_plane(argv)
+    # Assert
+    assert verdict.reason is None


### PR DESCRIPTION
`POST /v1/host_exec` is SERVED BY the sac listen daemon, so a command that
restarts that daemon kills the process group answering the call. Measured
2026-08-09 while propagating an unrelated merged fix:

    systemctl --user restart sac-listen.service      (via host_exec)
    -> {"exit_code": -15, "stdout": "", ...}

-15 is SIGTERM. Empty stdout, no status line, no confirmation. The restart HAD
succeeded — an independent probe answered 200 on the first attempt — but the
command could not say so, because the component reporting the result was the
component being restarted.

WHY THAT IS UNRECOVERABLE FOR A CALLER. These are indistinguishable:

    (a) the restart succeeded and killed my reporter   <- what happened
    (b) the restart failed and something killed us both
    (c) the command was killed for an unrelated reason

Reading (a) as (b) leads to a retry, which restarts a healthy plane — or to
concluding the control plane is broken when it is fine. scitex-storage reported
the CLI form of exactly this on 2026-07-28 (defect 1 of
sac-listen-restart-defect-cluster): such a restart "must report ACCEPTED, else
callers retry and STACK restarts." It sat open for twelve days and I then hit it
myself.

THE FIX REUSES A MECHANISM THIS REPO ALREADY PROVED. `_listen/_agent_restart.py`
solved the identical hazard for agent self-restart (incident 2026-07-12): hand
the bounce to a `setsid` child that sleeps past the response flush, answer 202
"scheduled" immediately. Same three ingredients here — detach, delay, log — so
the fleet has ONE answer to "don't decapitate yourself" rather than three that
drift. That mattered enough to pin: a test asserts this delay equals
`_agent_restart._SELF_RESTART_DELAY_S`, so the two cannot silently diverge.

Two new modules, split by responsibility:

  _plane_targeting_argv.py   PURE predicate — would this argv end the daemon?
  _plane_restart_detach.py   the detached spawn + its pure argv builder

`_host_exec.py` gains only the branch (464 lines, was 407).

CONSERVATIVE BY DESIGN, because the constitution warns that pattern matching
lies. It matches a small explicit set of spellings, and the error asymmetry is
chosen deliberately:

  * FALSE POSITIVE -> the command runs detached and is answered 202 instead of
    inline. Recoverable, loud, and the caller is told exactly what happened.
  * FALSE NEGATIVE -> status quo (the -15 above).

Safe to be incomplete; unsafe to be aggressive. Nothing is REFUSED — the caller
always gets a real answer.

THE NEGATIVES ARE AS LOAD-BEARING AS THE POSITIVES, and are why this is a
predicate rather than a substring search. All verified:

    systemctl status sac-listen      -> inline   (a READ; 202 would answer the
                                                  wrong question)
    systemctl restart sac-creds-watch-> inline   (different unit)
    sac listen start                 -> inline   (kills nobody, and on a DOWN
                                                  daemon it is the recovery)
    sac agents restart <agent>       -> inline   (an agent, not the plane)

Tests: 35 new (predicate + constructed-command properties, no spawning — the
builder is a pure seam so these cannot restart the daemon running the suite),
plus the existing host_exec suite at 41 passed. Test filenames mirror their src
modules, which the previous two PRs got wrong and CI caught.

REMAINING on that card: defect (3), post-restart `agent_send` 404 — NOT
re-tested, and nothing is claimed about it here.
