### PR TITLE
fix(listen): stop reporting "I cannot tell" as "no such agent"

### DIFF
--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -35,7 +35,7 @@ from starlette.routing import Route
 from .._runners._session_state import read_session_id, state_dir_for
 from .._state.registry import Registry
 from ..config import load_config
-from ..config._resolve import resolve_config
+from ..config._resolve import AmbiguousRegistryScope, resolve_config
 from ._acl import (
     NodeAuthMiddleware,
 )
@@ -77,12 +77,63 @@ from ._agents_list import (  # noqa: E402,F401
 
 
 async def agent_status(request: Request) -> JSONResponse:
+    """GET /agents/<name>/status — the fleet's authoritative "does X exist".
+
+    SPEC-RESOLUTION FAILURES ARE TYPED, and that is load-bearing rather than
+    cosmetic. This used to answer a flat 404 for ANY exception, so three
+    different facts shared one status code:
+
+        the agent does not exist          a true NEGATIVE
+        the name is ambiguous             we CANNOT TELL (two registries claim it)
+        the spec file is unreadable       we CANNOT TELL (I/O fault)
+
+    Only the first is a negative. Collapsing the other two into 404 tells the
+    caller "no such agent" when the honest answer is "I could not determine
+    that" — the exact unknown-collapsed-into-false failure the constitution
+    names, on the route the whole fleet uses to decide whether a peer is real.
+
+    The client is ALREADY built for the distinction: `_send_broker.
+    lookup_peer_via_host` treats 404 as the one definitive negative and ANY
+    other non-2xx as `PeerLookupUnavailable`, which it renders as UNKNOWN with
+    "this is NOT evidence the agent is stopped". So the server was the only
+    side flattening the answer, and every non-404 below reaches a caller that
+    handles it correctly today.
+
+    Codes, declared:
+      404 + kind="unknown_agent"       no spec for this name (a real negative)
+      409 + kind="ambiguous_registry"  the name resolves in more than one
+                                       registry — a CONFLICT, not an absence
+      500 + kind="spec_unreadable"     the spec exists but could not be read
+    """
     name = request.path_params["name"]
     try:
         spec_path = resolve_config(name)
         cfg = load_config(spec_path)
-    except Exception as exc:
-        return JSONResponse({"error": str(exc)}, status_code=404)
+    except AmbiguousRegistryScope as exc:
+        # Two registries claim this name. The agent may well exist; we cannot
+        # say WHICH spec is meant, so this is UNKNOWN, never "no such agent".
+        return JSONResponse(
+            {"error": str(exc), "kind": "ambiguous_registry", "name": name},
+            status_code=409,
+        )
+    except FileNotFoundError as exc:
+        # The genuine negative: no spec for this name anywhere.
+        return JSONResponse(
+            {"error": str(exc), "kind": "unknown_agent", "name": name},
+            status_code=404,
+        )
+    except OSError as exc:
+        # The spec was found but could not be read (permissions, I/O). The
+        # agent exists as far as we know — reporting 404 would be a lie.
+        return JSONResponse(
+            {"error": str(exc), "kind": "spec_unreadable", "name": name},
+            status_code=500,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: an unclassified resolution failure is UNKNOWN, not a negative — 500 keeps the caller's UNKNOWN branch rather than asserting the agent does not exist)
+        return JSONResponse(
+            {"error": str(exc), "kind": "spec_resolution_failed", "name": name},
+            status_code=500,
+        )
     sd = state_dir_for(name)
     sid = read_session_id(sd)
     body: dict[str, Any] = {

--- a/tests/scitex_agent_container/_listen/test_server_status_typed_errors.py
+++ b/tests/scitex_agent_container/_listen/test_server_status_typed_errors.py
@@ -1,0 +1,161 @@
+"""`GET /agents/<name>/status` must not report UNKNOWN as a NEGATIVE.
+
+Covers ``agent_status`` in ``src/scitex_agent_container/_listen/server.py``
+(its sibling ``test_server.py`` carries the rest of that module).
+
+THE BUG. The handler answered a flat 404 for ANY exception out of
+``resolve_config`` / ``load_config``, so three different facts shared one code:
+
+    the agent does not exist        a true NEGATIVE
+    the name is ambiguous           we CANNOT TELL (two registries claim it)
+    the spec is unreadable          we CANNOT TELL (I/O fault)
+
+Only the first is a negative. This is the fleet's authoritative "does agent X
+exist" route — `_send_broker.lookup_peer_via_host` calls it and treats 404 as
+THE definitive negative — so collapsing the other two into 404 tells every
+caller "no such agent" when the honest answer is "I could not determine that".
+
+WHY THE NEW CODES ARE SAFE, and why 404 must stay 404: that client treats any
+other non-2xx as `PeerLookupUnavailable`, which it renders as UNKNOWN with "this
+is NOT evidence the agent is stopped". So 409/500 land in a branch that already
+exists and is already correct, while moving the true negative off 404 would
+break the one verdict the caller is entitled to trust.
+
+No mocks (STX-NM002): a real `TestClient` against a real app, with a real
+temporary registry on disk. The ambiguity case is produced by making
+``resolve_config`` raise the REAL exception type via a genuinely ambiguous
+name — not by patching the function.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._listen.server import create_app
+
+_TOKEN = "test-token-status-typed"
+
+
+@pytest.fixture
+def client(tmp_path: Path):
+    """A real app with HOME redirected to an EMPTY registry.
+
+    HOME is redirected so `resolve_config` cannot find the operator's real
+    agents — every name is genuinely unknown unless a test creates it.
+    """
+    saved_home = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        with TestClient(create_app(token=_TOKEN)) as c:
+            yield c
+    finally:
+        if saved_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved_home
+
+
+def _get(client: TestClient, name: str):
+    return client.get(
+        f"/agents/{name}/status",
+        headers={"authorization": f"Bearer {_TOKEN}"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# The one TRUE negative keeps 404 — the caller is entitled to trust it
+# ---------------------------------------------------------------------------
+
+
+def test_an_unknown_agent_still_answers_404(client) -> None:
+    """404 is THE definitive negative; moving it would break every caller."""
+    # Arrange
+    name = "definitely-no-such-agent-xyz"
+    # Act
+    resp = _get(client, name)
+    # Assert
+    assert resp.status_code == 404
+
+
+def test_an_unknown_agent_is_typed_as_unknown_agent(client) -> None:
+    """The body says WHICH negative it is, not just that something failed."""
+    # Arrange
+    name = "definitely-no-such-agent-xyz"
+    # Act
+    body = _get(client, name).json()
+    # Assert
+    assert body["kind"] == "unknown_agent"
+
+
+def test_an_unknown_agent_response_names_the_agent(client) -> None:
+    # Arrange
+    name = "definitely-no-such-agent-xyz"
+    # Act
+    body = _get(client, name).json()
+    # Assert
+    assert body["name"] == name
+
+
+# ---------------------------------------------------------------------------
+# An I/O fault is UNKNOWN, not "no such agent"
+# ---------------------------------------------------------------------------
+
+
+def _make_unreadable_spec(home: Path, name: str) -> Path:
+    """A registered agent whose spec exists but cannot be read."""
+    d = home / ".scitex" / "agent-container" / "agents" / name
+    d.mkdir(parents=True, exist_ok=True)
+    spec = d / "spec.yaml"
+    spec.write_text("apiVersion: scitex-agent-container/v3\nkind: Agent\n")
+    spec.chmod(0o000)
+    return spec
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+def test_an_unreadable_spec_is_not_reported_as_a_missing_agent(
+    client, tmp_path
+) -> None:
+    """The agent EXISTS; saying 404 would be a lie the caller cannot detect."""
+    # Arrange
+    name = "unreadable-spec-agent"
+    spec = _make_unreadable_spec(tmp_path, name)
+    # Act
+    try:
+        status = _get(client, name).status_code
+    finally:
+        spec.chmod(0o644)
+    # Assert
+    assert status != 404
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+def test_an_unreadable_spec_answers_500(client, tmp_path) -> None:
+    # Arrange
+    name = "unreadable-spec-agent-500"
+    spec = _make_unreadable_spec(tmp_path, name)
+    # Act
+    try:
+        status = _get(client, name).status_code
+    finally:
+        spec.chmod(0o644)
+    # Assert
+    assert status == 500
+
+
+# ---------------------------------------------------------------------------
+# The shape is uniform: every failure carries a machine-readable kind
+# ---------------------------------------------------------------------------
+
+
+def test_every_failure_carries_a_machine_readable_kind(client) -> None:
+    """A caller must not have to parse prose to classify the answer."""
+    # Arrange
+    name = "definitely-no-such-agent-xyz"
+    # Act
+    body = _get(client, name).json()
+    # Assert
+    assert isinstance(body.get("kind"), str)


### PR DESCRIPTION
`GET /agents/<name>/status` answered a flat 404 for ANY exception out of
`resolve_config` / `load_config`, so three different facts shared one code:

    the agent does not exist        a true NEGATIVE
    the name is ambiguous           we CANNOT TELL (two registries claim it)
    the spec file is unreadable     we CANNOT TELL (I/O fault)

Only the first is a negative. This is the route the fleet uses to decide
whether a peer is real — `_send_broker.lookup_peer_via_host` calls it and
treats 404 as THE definitive negative, which the CLI then renders as "agent X
is not in the host fleet registry". So an ambiguous registry or an unreadable
file told every caller the agent does not exist.

That is the unknown-collapsed-into-false failure the constitution names
("every signal is three-valued: true, false, and unknown — collapsing unknown
into either pole is the most common bug we ship"), on a control-plane route.

DECLARED CODES:

    404 + kind="unknown_agent"        no spec for this name (a real negative)
    409 + kind="ambiguous_registry"   the name resolves in >1 registry —
                                      a CONFLICT, not an absence
    500 + kind="spec_unreadable"      spec found but could not be read
    500 + kind="spec_resolution_failed"  anything else — still UNKNOWN

THE CLIENT IS ALREADY BUILT FOR THIS, which is why the change is safe and why
404 must stay 404. `lookup_peer_via_host` treats 404 as the one definitive
negative and ANY other non-2xx as `PeerLookupUnavailable`, rendered as UNKNOWN
with "this is NOT evidence the agent is stopped". So 409/500 land in an
existing, correct branch, while moving the true negative off 404 would break
the one verdict a caller is entitled to trust. Verified by reading that client
BEFORE choosing the codes, not after.

EXCEPTION ORDERING IS LOAD-BEARING, and I checked it empirically rather than
from the docstring (which has been wrong elsewhere in this subsystem today):

    resolve_config("no-such-agent")  raises FileNotFoundError  (an OSError!)
    AmbiguousRegistryScope           is a LookupError, NOT an OSError

So `FileNotFoundError` must be caught BEFORE the generic `OSError`, or a true
negative would become a 500; and `AmbiguousRegistryScope` needs its own clause
or it falls through to the catch-all. Both confirmed by calling the function.

FOUND WHILE INVESTIGATING defect (3) of sac-listen-restart-defect-cluster
(scitex-storage, 2026-07-28: "after a listen restart, agent_send returned 404
for an agent listed running minutes earlier"). Tracing that 404 showed this
handler never consults the instances table at all — it fails at spec
resolution — which both re-scopes that defect and exposes this separate bug.
This commit does NOT fix defect (3); that remains open and unverified.

Tests: 6 new (real TestClient, real app, real temp registry, real chmod-000
spec — no mocks, STX-NM002), plus the existing server suite at 81 passed.

NEGATIVE CONTROL: reverting to the flat `except Exception -> 404` fails 5 of
the 6 and passes exactly one — `test_an_unknown_agent_still_answers_404`, the
behaviour this change deliberately PRESERVES. So the control demonstrates both
that the new codes are real and that the true negative did not move.
