### PR TITLE
fix(to_home): name the layer that armed each hook, not "(merged)"

### DIFF
--- a/src/scitex_agent_container/runtimes/_layer_merge.py
+++ b/src/scitex_agent_container/runtimes/_layer_merge.py
@@ -27,6 +27,9 @@ rather than silently picking one (No-Surprise).
 Provenance: :func:`deep_merge_layers` also returns a map of dotted
 key-path → the layer name that owns each leaf, so ``sac agents explain``
 can show WHERE each effective setting came from (drift made visible).
+Hooks are recorded per ARMED COMMAND rather than per block, because the
+block is the one thing that merges additively and so has no single owner
+to report — see :func:`_record_hook_commands`.
 """
 
 from __future__ import annotations
@@ -48,7 +51,9 @@ def deep_merge_layers(
     ``layers`` is an ordered list of ``(layer_name, data)`` pairs; a
     non-dict ``data`` is skipped. Returns ``(merged, provenance)`` where
     ``provenance`` maps a dotted key-path to the ``layer_name`` that owns
-    its leaf (``hooks`` / merged lists are tagged ``"(merged)"``).
+    its leaf. Merged lists are tagged ``"(merged)"``; the ``hooks`` block is
+    recorded one entry per armed command (``hooks.<Event>.<command>``) so an
+    additively-merged guard still names the layer it came from.
 
     Raises :class:`LayerMergeConflict` when two layers assign the same
     scalar key two different values.
@@ -75,6 +80,44 @@ def _record_subtree(prov: dict[str, str], path: str, value: Any, layer: str) -> 
         prov[path] = layer
 
 
+def _record_hook_commands(
+    prov: dict[str, str], path: str, block: Any, layer: str
+) -> None:
+    """Attribute each individual hook COMMAND to the layer that armed it.
+
+    ``hooks`` is the one part of the cascade that merges ADDITIVELY instead of
+    conflicting — a guard shipped by ``_shared`` and one shipped by the agent's
+    own layer must both run, so there is no single owner to name. Tagging the
+    whole block ``"(merged)"`` answered "several layers" and threw away the
+    only fact anyone actually needs when a hook fires unexpectedly: WHICH layer
+    put THAT hook there. Recording per command keeps the additive semantics and
+    restores the attribution, so ``sac agents explain`` can name an origin for
+    every armed hook rather than shrugging at the whole block.
+
+    Keys are ``hooks.<Event>.<command>``; the command string is the identity
+    because that is exactly what :func:`_merge_hooks_blocks` de-dupes on. The
+    FIRST layer to contribute a command owns it, matching the scalar rule — a
+    lower layer's guard is not re-attributed to whoever repeats it.
+    """
+    if not isinstance(block, dict):
+        return
+    for event, groups in block.items():
+        if not isinstance(groups, list):
+            continue
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            hooks = group.get("hooks")
+            if not isinstance(hooks, list):
+                continue
+            for hook in hooks:
+                if not isinstance(hook, dict):
+                    continue
+                command = hook.get("command")
+                if isinstance(command, str) and command:
+                    prov.setdefault(_join(_join(path, str(event)), command), layer)
+
+
 def _merge_into(
     acc: dict,
     prov: dict[str, str],
@@ -89,10 +132,9 @@ def _merge_into(
         if key == _HOOKS_KEY and isinstance(val, dict):
             if isinstance(acc.get(key), dict):
                 acc[key] = _merge_hooks_blocks(acc[key], val)
-                prov[path] = "(merged)"
             else:
                 acc[key] = deepcopy(val)
-                prov[path] = layer
+            _record_hook_commands(prov, path, val, layer)
             continue
 
         if key not in acc:

--- a/tests/scitex_agent_container/runtimes/test__layer_merge.py
+++ b/tests/scitex_agent_container/runtimes/test__layer_merge.py
@@ -83,7 +83,10 @@ def test_lists_union_preserving_order() -> None:
 
 def test_comment_key_conflict_is_exempt_and_keeps_first() -> None:
     # Arrange — two layers each document themselves via ``_comment``.
-    layers = [("user", {"_comment": "user layer"}), ("agent", {"_comment": "agent layer"})]
+    layers = [
+        ("user", {"_comment": "user layer"}),
+        ("agent", {"_comment": "agent layer"}),
+    ]
     # Act
     merged, _ = deep_merge_layers(layers)
     # Assert
@@ -123,3 +126,99 @@ def test_hooks_block_is_additive_per_event() -> None:
     merged, _ = deep_merge_layers(layers)
     # Assert
     assert merged["hooks"]["PreToolUse"] == [grp_a, grp_b]
+
+
+def test_lower_layer_hook_names_the_lower_layer() -> None:
+    # Arrange — the additively-merged case: two layers, one guard each.
+    grp_a = {"matcher": "Bash", "hooks": [{"type": "command", "command": "a"}]}
+    grp_b = {"matcher": "Bash", "hooks": [{"type": "command", "command": "b"}]}
+    layers = [
+        ("user", {"hooks": {"PreToolUse": [grp_a]}}),
+        ("agent", {"hooks": {"PreToolUse": [grp_b]}}),
+    ]
+    # Act
+    _, prov = deep_merge_layers(layers)
+    # Assert
+    assert prov["hooks.PreToolUse.a"] == "user"
+
+
+def test_higher_layer_hook_names_the_higher_layer() -> None:
+    # Arrange — the same cascade, asserting the overlay's own guard.
+    grp_a = {"matcher": "Bash", "hooks": [{"type": "command", "command": "a"}]}
+    grp_b = {"matcher": "Bash", "hooks": [{"type": "command", "command": "b"}]}
+    layers = [
+        ("user", {"hooks": {"PreToolUse": [grp_a]}}),
+        ("agent", {"hooks": {"PreToolUse": [grp_b]}}),
+    ]
+    # Act
+    _, prov = deep_merge_layers(layers)
+    # Assert
+    assert prov["hooks.PreToolUse.b"] == "agent"
+
+
+def test_hooks_provenance_is_never_the_merged_sentinel() -> None:
+    # Arrange — the regression: a merged block used to report "(merged)",
+    # which names no layer and so cannot answer "who armed this hook?".
+    grp_a = {"matcher": "Bash", "hooks": [{"type": "command", "command": "a"}]}
+    grp_b = {"matcher": "Bash", "hooks": [{"type": "command", "command": "b"}]}
+    layers = [
+        ("user", {"hooks": {"PreToolUse": [grp_a]}}),
+        ("agent", {"hooks": {"PreToolUse": [grp_b]}}),
+    ]
+    # Act
+    _, prov = deep_merge_layers(layers)
+    # Assert — the bare "hooks" key must be checked too: the regression wrote
+    # the sentinel there, and a "hooks."-prefixed filter alone silently misses
+    # it, which makes this test pass with the fix reverted.
+    owners = {v for k, v in prov.items() if k == "hooks" or k.startswith("hooks.")}
+    assert "(merged)" not in owners
+
+
+def test_repeated_hook_command_stays_owned_by_the_lower_layer() -> None:
+    # Arrange — the same guard shipped by both layers has ONE origin.
+    grp = {"matcher": "Bash", "hooks": [{"type": "command", "command": "guard"}]}
+    layers = [
+        ("user", {"hooks": {"PreToolUse": [grp]}}),
+        ("agent", {"hooks": {"PreToolUse": [grp]}}),
+    ]
+    # Act
+    _, prov = deep_merge_layers(layers)
+    # Assert
+    assert prov["hooks.PreToolUse.guard"] == "user"
+
+
+def test_same_command_on_another_event_keeps_its_own_owner() -> None:
+    # Arrange — identical command text armed on two DIFFERENT events must not
+    # collapse onto one provenance key and mis-attribute the second event.
+    pre = {"matcher": "", "hooks": [{"type": "command", "command": "x"}]}
+    stop = {"matcher": "", "hooks": [{"type": "command", "command": "x"}]}
+    layers = [
+        ("user", {"hooks": {"PreToolUse": [pre]}}),
+        ("agent", {"hooks": {"Stop": [stop]}}),
+    ]
+    # Act
+    _, prov = deep_merge_layers(layers)
+    # Assert
+    assert prov["hooks.Stop.x"] == "agent"
+
+
+def test_malformed_hook_entries_do_not_break_provenance() -> None:
+    # Arrange — a hand-edited layer with junk where groups/hooks should be.
+    layers = [
+        ("user", {"hooks": {"PreToolUse": "not-a-list", "Stop": ["not-a-dict"]}}),
+        (
+            "agent",
+            {
+                "hooks": {
+                    "Stop": [
+                        {"matcher": "", "hooks": [{"type": "command"}]},
+                        {"matcher": "", "hooks": [{"command": "real"}]},
+                    ]
+                }
+            },
+        ),
+    ]
+    # Act
+    _, prov = deep_merge_layers(layers)
+    # Assert
+    assert prov["hooks.Stop.real"] == "agent"


### PR DESCRIPTION
The `to_home` cascade raises `LayerMergeConflict` when two layers assign one scalar key different values — every key has exactly one owner. The `hooks` block is the deliberate exception: it merges additively, because a guard from `_shared` and a guard from the agent's own layer must **both** run.

That exception left provenance with nothing to report, so the whole block was tagged `"(merged)"`.

**`"(merged)"` names no layer.** It answers "several" to the only question anyone asks when a hook fires unexpectedly — *who armed this?* — and hooks are precisely the part of the cascade where that question is safety-relevant.

Measured on this host: **46 armed hook commands across two layers collapsed into one provenance entry** reading `(merged)`.

## Change

Record per **command** (`hooks.<Event>.<command>` → layer) rather than per block. The command string is the natural identity because it is exactly what `_merge_hooks_blocks` de-dupes on; the first layer to contribute one owns it, matching the scalar rule. **Merge semantics are untouched** — only the bookkeeping changes.

`sac agents explain` improves with no change there: it groups provenance by top-level key, so the rollup now reads `hooks: per-agent, user-shared` instead of `hooks: (merged)`.

Merged **lists** keep `"(merged)"`, deliberately — a list really is the union of every layer, with no per-element origin to recover.

## Verification

Negative control, with the recording reverted in place:

```
6 failed, 11 passed     <- fix neutered
17 passed               <- fix restored
```

One of the six initially passed under **both**: it filtered on the `"hooks."` prefix while the regression writes the bare `"hooks"` key. It was tightened until it discriminated — a test that passes without its fix is not a test.

Live cascade after the change:

```
user-shared     PreToolUse   .../deny_commit_push_on_main_develop.sh
user-shared     PreToolUse   .../deny_edit_on_main_branch.sh
user-shared     PostToolUse  .../run_lint.sh
...   46 commands, each naming its layer
```

## Why now

Groundwork for the operator's ask (2026-08-09) for a runtime hook log naming where each hook came from — that log needs this attribution as its input.