### PR TITLE
feat(to_home): record which layer armed each hook, to runtime

### DIFF
--- a/src/scitex_agent_container/runtimes/_hook_origin_manifest.py
+++ b/src/scitex_agent_container/runtimes/_hook_origin_manifest.py
@@ -1,0 +1,112 @@
+"""Record WHICH to_home layer armed each of an agent's hooks, on disk.
+
+An agent's effective ``.claude/settings.json`` is assembled from a cascade of
+``to_home`` layers (``_layer_merge.deep_merge_layers``). Reading the deployed
+file afterwards tells you which hooks are armed but NOT where any of them came
+from — the layers are flattened into one block and the origin is gone. So the
+operator's question when a guard fires unexpectedly, "where is this hook coming
+from?", had no answer that did not involve re-deriving the whole cascade by
+hand.
+
+This module answers it from a file. At deploy time — where the provenance is
+still known — every armed hook command is written out next to the layer that
+armed it:
+
+    <runtime>/logs/<agent>/hook-origins.json
+
+``<runtime>`` is :func:`_runtime_paths.runtime_base_dir`, so this lands beside
+the existing ``runtime/logs/host_exec.log`` and honours the same relocation env
+var. It is RUNTIME state, deliberately outside version control: it describes
+what one host deployed at one moment, which is exactly the fact a committed
+file cannot carry.
+
+Scope, stated plainly: this records what was ARMED, not what FIRED. It is
+derived from the deploy, so it cannot drift from the deployed settings, and it
+touches nothing on the hook execution path. A record of individual firings
+needs each hook's invocation wrapped, which puts code between Claude and the
+guard's exit code — a different risk class, kept out of this module on purpose.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from .._runtime_paths import runtime_base_dir
+
+logger = logging.getLogger(__name__)
+
+_MANIFEST_NAME = "hook-origins.json"
+_HOOKS_PREFIX = "hooks."
+
+
+def manifest_path(agent_name: str) -> Path:
+    """Where ``agent_name``'s hook-origin manifest lives."""
+    return runtime_base_dir() / "logs" / agent_name / _MANIFEST_NAME
+
+
+def hook_origins(provenance: "dict[str, str]") -> "dict[str, dict[str, str]]":
+    """Reshape a cascade provenance map into ``{event: {command: layer}}``.
+
+    ``provenance`` keys are dotted paths; hooks are recorded as
+    ``hooks.<Event>.<command>`` (see ``_layer_merge._record_hook_commands``).
+    A command may itself contain dots, so the split is bounded to 2 — the
+    remainder is the command verbatim. Non-hook keys are ignored.
+    """
+    origins: dict[str, dict[str, str]] = {}
+    for path, layer in provenance.items():
+        if not path.startswith(_HOOKS_PREFIX):
+            continue
+        parts = path.split(".", 2)
+        if len(parts) != 3:
+            continue
+        _, event, command = parts
+        if not event or not command:
+            continue
+        origins.setdefault(event, {})[command] = layer
+    return origins
+
+
+def write_hook_manifest(agent_name: str, provenance: "dict[str, str]") -> Path | None:
+    """Write ``agent_name``'s hook-origin manifest; return its path.
+
+    Returns ``None`` when the cascade armed no hooks — an agent with no guards
+    gets no file, rather than an empty one that reads like a wiped manifest.
+
+    Never raises: a manifest is an observability aid, and failing a deploy
+    because a log could not be written would trade a real capability for a
+    diagnostic one. A write failure is logged at WARNING with the path, which
+    is the actionable half.
+    """
+    origins = hook_origins(provenance)
+    if not origins:
+        return None
+
+    out = manifest_path(agent_name)
+    payload = {
+        "agent": agent_name,
+        "hook_count": sum(len(cmds) for cmds in origins.values()),
+        "layers": sorted(
+            {layer for cmds in origins.values() for layer in cmds.values()}
+        ),
+        "events": {
+            ev: dict(sorted(cmds.items())) for ev, cmds in sorted(origins.items())
+        },
+    }
+    try:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(payload, indent=2) + "\n")
+    except OSError as exc:  # stx-allow: fallback (observability must not fail a deploy)
+        logger.warning("hook manifest: failed to write %s: %s", out, exc)
+        return None
+    logger.info(
+        "hook manifest: %d hook(s) from %d layer(s) -> %s",
+        payload["hook_count"],
+        len(payload["layers"]),
+        out,
+    )
+    return out
+
+
+__all__ = ["hook_origins", "manifest_path", "write_hook_manifest"]

--- a/src/scitex_agent_container/runtimes/_layer_merge.py
+++ b/src/scitex_agent_container/runtimes/_layer_merge.py
@@ -27,6 +27,9 @@ rather than silently picking one (No-Surprise).
 Provenance: :func:`deep_merge_layers` also returns a map of dotted
 key-path → the layer name that owns each leaf, so ``sac agents explain``
 can show WHERE each effective setting came from (drift made visible).
+Hooks are recorded per ARMED COMMAND rather than per block, because the
+block is the one thing that merges additively and so has no single owner
+to report — see :func:`_record_hook_commands`.
 """
 
 from __future__ import annotations
@@ -48,7 +51,9 @@ def deep_merge_layers(
     ``layers`` is an ordered list of ``(layer_name, data)`` pairs; a
     non-dict ``data`` is skipped. Returns ``(merged, provenance)`` where
     ``provenance`` maps a dotted key-path to the ``layer_name`` that owns
-    its leaf (``hooks`` / merged lists are tagged ``"(merged)"``).
+    its leaf. Merged lists are tagged ``"(merged)"``; the ``hooks`` block is
+    recorded one entry per armed command (``hooks.<Event>.<command>``) so an
+    additively-merged guard still names the layer it came from.
 
     Raises :class:`LayerMergeConflict` when two layers assign the same
     scalar key two different values.
@@ -75,6 +80,44 @@ def _record_subtree(prov: dict[str, str], path: str, value: Any, layer: str) -> 
         prov[path] = layer
 
 
+def _record_hook_commands(
+    prov: dict[str, str], path: str, block: Any, layer: str
+) -> None:
+    """Attribute each individual hook COMMAND to the layer that armed it.
+
+    ``hooks`` is the one part of the cascade that merges ADDITIVELY instead of
+    conflicting — a guard shipped by ``_shared`` and one shipped by the agent's
+    own layer must both run, so there is no single owner to name. Tagging the
+    whole block ``"(merged)"`` answered "several layers" and threw away the
+    only fact anyone actually needs when a hook fires unexpectedly: WHICH layer
+    put THAT hook there. Recording per command keeps the additive semantics and
+    restores the attribution, so ``sac agents explain`` can name an origin for
+    every armed hook rather than shrugging at the whole block.
+
+    Keys are ``hooks.<Event>.<command>``; the command string is the identity
+    because that is exactly what :func:`_merge_hooks_blocks` de-dupes on. The
+    FIRST layer to contribute a command owns it, matching the scalar rule — a
+    lower layer's guard is not re-attributed to whoever repeats it.
+    """
+    if not isinstance(block, dict):
+        return
+    for event, groups in block.items():
+        if not isinstance(groups, list):
+            continue
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            hooks = group.get("hooks")
+            if not isinstance(hooks, list):
+                continue
+            for hook in hooks:
+                if not isinstance(hook, dict):
+                    continue
+                command = hook.get("command")
+                if isinstance(command, str) and command:
+                    prov.setdefault(_join(_join(path, str(event)), command), layer)
+
+
 def _merge_into(
     acc: dict,
     prov: dict[str, str],
@@ -89,10 +132,9 @@ def _merge_into(
         if key == _HOOKS_KEY and isinstance(val, dict):
             if isinstance(acc.get(key), dict):
                 acc[key] = _merge_hooks_blocks(acc[key], val)
-                prov[path] = "(merged)"
             else:
                 acc[key] = deepcopy(val)
-                prov[path] = layer
+            _record_hook_commands(prov, path, val, layer)
             continue
 
         if key not in acc:

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -63,6 +63,7 @@ from pathlib import Path
 from ..config import AgentConfig
 from ._cct_token_pool import ensure_cct_bot_token, prune_tokenless_telegrammer_mcp
 from ._envrc import fold_envrc_cascade_into_env, fold_envrc_into_env
+from ._hook_origin_manifest import write_hook_manifest
 from ._host_commands import deploy_host_claude_commands
 from ._host_skills import deploy_host_skills
 from ._symlink_resolve import DanglingToHomeSymlinkError, deref_copy_symlink
@@ -314,7 +315,13 @@ def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
     # layer's .claude/settings.json into dest, raising on a cross-layer scalar
     # conflict (ADR-0018). The walk SKIPS settings.json so this is the single
     # writer. setup_settings_json later folds SAC's managed keys on top.
-    deploy_settings_cascade(dest, settings_layer_dirs(config))
+    settings_provenance = deploy_settings_cascade(dest, settings_layer_dirs(config))
+    # ...then record WHICH layer armed each hook, to runtime (not to the home
+    # we just wrote). The deployed settings.json is the flattened result, so it
+    # cannot answer "where is this hook coming from?" — the origin only exists
+    # here, while the cascade is still un-flattened. Best-effort by design: an
+    # observability file must never be the reason a deploy fails.
+    write_hook_manifest(getattr(config, "name", "") or "unknown", settings_provenance)
     # HOST DEEP-MERGE (developer agents only). For a FULL-DEVELOPER agent
     # (metadata.labels.group==developer, or group-unset + a developer role),
     # overlay the host operator's ~/.claude/{commands,skills,hooks} as per-file

--- a/tests/scitex_agent_container/runtimes/test__hook_origin_manifest.py
+++ b/tests/scitex_agent_container/runtimes/test__hook_origin_manifest.py
@@ -1,0 +1,169 @@
+"""Tests for the hook-origin manifest (``runtimes._hook_origin_manifest``).
+
+Covers the reshape from cascade provenance to ``{event: {command: layer}}``
+and the runtime write: where it lands, what it records, when it declines to
+write, and that it never fails a deploy.
+
+STX-NM002: no mocks / monkeypatch. The runtime dir is redirected by setting
+the module's own documented relocation env var in a ``yield`` fixture and
+restoring it on teardown, and every filesystem assertion reads real bytes.
+STX-TQ002 / TQ007: AAA markers per test, one fact per test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._runtime_paths import RUNTIME_DIR_ENV
+from scitex_agent_container.runtimes._hook_origin_manifest import (
+    hook_origins,
+    manifest_path,
+    write_hook_manifest,
+)
+
+
+def _set_runtime_dir(value: str) -> "str | None":
+    previous = os.environ.get(RUNTIME_DIR_ENV)
+    os.environ[RUNTIME_DIR_ENV] = value
+    return previous
+
+
+def _restore_runtime_dir(previous: "str | None") -> None:
+    if previous is None:
+        os.environ.pop(RUNTIME_DIR_ENV, None)
+    else:
+        os.environ[RUNTIME_DIR_ENV] = previous
+
+
+@pytest.fixture()
+def runtime_dir(tmp_path: Path) -> Iterator[Path]:
+    """Point the runtime base dir at a throwaway tree for one test."""
+    previous = _set_runtime_dir(str(tmp_path))
+    try:
+        yield tmp_path
+    finally:
+        _restore_runtime_dir(previous)
+
+
+@pytest.fixture()
+def runtime_dir_blocked_by_a_file(tmp_path: Path) -> Iterator[Path]:
+    """Runtime base dir points at a REGULAR FILE, so ``mkdir`` cannot succeed."""
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("")
+    previous = _set_runtime_dir(str(blocker))
+    try:
+        yield blocker
+    finally:
+        _restore_runtime_dir(previous)
+
+
+def test_hook_key_is_reshaped_to_event_and_command() -> None:
+    # Arrange
+    prov = {"hooks.PreToolUse.guard.sh": "user-shared"}
+    # Act
+    origins = hook_origins(prov)
+    # Assert
+    assert origins == {"PreToolUse": {"guard.sh": "user-shared"}}
+
+
+def test_non_hook_keys_are_ignored() -> None:
+    # Arrange
+    prov = {"statusLine": "per-agent", "_comment": "user-shared"}
+    # Act
+    origins = hook_origins(prov)
+    # Assert
+    assert origins == {}
+
+
+def test_command_containing_dots_survives_intact() -> None:
+    # Arrange — the split must be bounded; hook commands are full paths.
+    prov = {"hooks.Stop.$HOME/.claude/hooks/stop/a.b.sh": "per-agent"}
+    # Act
+    origins = hook_origins(prov)
+    # Assert
+    assert origins["Stop"] == {"$HOME/.claude/hooks/stop/a.b.sh": "per-agent"}
+
+
+def test_bare_hooks_key_is_not_mistaken_for_a_command() -> None:
+    # Arrange — the pre-fix sentinel wrote this shape; it names no command.
+    prov = {"hooks": "(merged)"}
+    # Act
+    origins = hook_origins(prov)
+    # Assert
+    assert origins == {}
+
+
+def test_no_hooks_writes_no_file(runtime_dir: Path) -> None:
+    # Arrange
+    prov = {"statusLine": "per-agent"}
+    # Act
+    written = write_hook_manifest("agent-a", prov)
+    # Assert
+    assert written is None
+
+
+def test_manifest_lands_under_runtime_logs_keyed_by_agent(runtime_dir: Path) -> None:
+    # Arrange
+    prov = {"hooks.PreToolUse.guard.sh": "user-shared"}
+    # Act
+    written = write_hook_manifest("agent-a", prov)
+    # Assert
+    assert written == runtime_dir / "logs" / "agent-a" / "hook-origins.json"
+
+
+def test_manifest_records_the_layer_that_armed_each_hook(runtime_dir: Path) -> None:
+    # Arrange
+    prov = {
+        "hooks.PreToolUse.a.sh": "user-shared",
+        "hooks.PreToolUse.b.sh": "per-agent",
+    }
+    # Act
+    write_hook_manifest("agent-a", prov)
+    payload = json.loads(manifest_path("agent-a").read_text())
+    # Assert
+    assert payload["events"]["PreToolUse"] == {
+        "a.sh": "user-shared",
+        "b.sh": "per-agent",
+    }
+
+
+def test_manifest_counts_every_armed_hook(runtime_dir: Path) -> None:
+    # Arrange
+    prov = {
+        "hooks.PreToolUse.a.sh": "user-shared",
+        "hooks.Stop.b.sh": "per-agent",
+    }
+    # Act
+    write_hook_manifest("agent-a", prov)
+    payload = json.loads(manifest_path("agent-a").read_text())
+    # Assert
+    assert payload["hook_count"] == 2
+
+
+def test_manifest_lists_the_contributing_layers(runtime_dir: Path) -> None:
+    # Arrange
+    prov = {
+        "hooks.PreToolUse.a.sh": "user-shared",
+        "hooks.Stop.b.sh": "per-agent",
+    }
+    # Act
+    write_hook_manifest("agent-a", prov)
+    payload = json.loads(manifest_path("agent-a").read_text())
+    # Assert
+    assert payload["layers"] == ["per-agent", "user-shared"]
+
+
+def test_unwritable_runtime_dir_does_not_raise(
+    runtime_dir_blocked_by_a_file: Path,
+) -> None:
+    # Arrange
+    prov = {"hooks.PreToolUse.a.sh": "user-shared"}
+    # Act
+    written = write_hook_manifest("agent-a", prov)
+    # Assert
+    assert written is None

--- a/tests/scitex_agent_container/runtimes/test__layer_merge.py
+++ b/tests/scitex_agent_container/runtimes/test__layer_merge.py
@@ -83,7 +83,10 @@ def test_lists_union_preserving_order() -> None:
 
 def test_comment_key_conflict_is_exempt_and_keeps_first() -> None:
     # Arrange — two layers each document themselves via ``_comment``.
-    layers = [("user", {"_comment": "user layer"}), ("agent", {"_comment": "agent layer"})]
+    layers = [
+        ("user", {"_comment": "user layer"}),
+        ("agent", {"_comment": "agent layer"}),
+    ]
     # Act
     merged, _ = deep_merge_layers(layers)
     # Assert
@@ -123,3 +126,99 @@ def test_hooks_block_is_additive_per_event() -> None:
     merged, _ = deep_merge_layers(layers)
     # Assert
     assert merged["hooks"]["PreToolUse"] == [grp_a, grp_b]
+
+
+def test_lower_layer_hook_names_the_lower_layer() -> None:
+    # Arrange — the additively-merged case: two layers, one guard each.
+    grp_a = {"matcher": "Bash", "hooks": [{"type": "command", "command": "a"}]}
+    grp_b = {"matcher": "Bash", "hooks": [{"type": "command", "command": "b"}]}
+    layers = [
+        ("user", {"hooks": {"PreToolUse": [grp_a]}}),
+        ("agent", {"hooks": {"PreToolUse": [grp_b]}}),
+    ]
+    # Act
+    _, prov = deep_merge_layers(layers)
+    # Assert
+    assert prov["hooks.PreToolUse.a"] == "user"
+
+
+def test_higher_layer_hook_names_the_higher_layer() -> None:
+    # Arrange — the same cascade, asserting the overlay's own guard.
+    grp_a = {"matcher": "Bash", "hooks": [{"type": "command", "command": "a"}]}
+    grp_b = {"matcher": "Bash", "hooks": [{"type": "command", "command": "b"}]}
+    layers = [
+        ("user", {"hooks": {"PreToolUse": [grp_a]}}),
+        ("agent", {"hooks": {"PreToolUse": [grp_b]}}),
+    ]
+    # Act
+    _, prov = deep_merge_layers(layers)
+    # Assert
+    assert prov["hooks.PreToolUse.b"] == "agent"
+
+
+def test_hooks_provenance_is_never_the_merged_sentinel() -> None:
+    # Arrange — the regression: a merged block used to report "(merged)",
+    # which names no layer and so cannot answer "who armed this hook?".
+    grp_a = {"matcher": "Bash", "hooks": [{"type": "command", "command": "a"}]}
+    grp_b = {"matcher": "Bash", "hooks": [{"type": "command", "command": "b"}]}
+    layers = [
+        ("user", {"hooks": {"PreToolUse": [grp_a]}}),
+        ("agent", {"hooks": {"PreToolUse": [grp_b]}}),
+    ]
+    # Act
+    _, prov = deep_merge_layers(layers)
+    # Assert — the bare "hooks" key must be checked too: the regression wrote
+    # the sentinel there, and a "hooks."-prefixed filter alone silently misses
+    # it, which makes this test pass with the fix reverted.
+    owners = {v for k, v in prov.items() if k == "hooks" or k.startswith("hooks.")}
+    assert "(merged)" not in owners
+
+
+def test_repeated_hook_command_stays_owned_by_the_lower_layer() -> None:
+    # Arrange — the same guard shipped by both layers has ONE origin.
+    grp = {"matcher": "Bash", "hooks": [{"type": "command", "command": "guard"}]}
+    layers = [
+        ("user", {"hooks": {"PreToolUse": [grp]}}),
+        ("agent", {"hooks": {"PreToolUse": [grp]}}),
+    ]
+    # Act
+    _, prov = deep_merge_layers(layers)
+    # Assert
+    assert prov["hooks.PreToolUse.guard"] == "user"
+
+
+def test_same_command_on_another_event_keeps_its_own_owner() -> None:
+    # Arrange — identical command text armed on two DIFFERENT events must not
+    # collapse onto one provenance key and mis-attribute the second event.
+    pre = {"matcher": "", "hooks": [{"type": "command", "command": "x"}]}
+    stop = {"matcher": "", "hooks": [{"type": "command", "command": "x"}]}
+    layers = [
+        ("user", {"hooks": {"PreToolUse": [pre]}}),
+        ("agent", {"hooks": {"Stop": [stop]}}),
+    ]
+    # Act
+    _, prov = deep_merge_layers(layers)
+    # Assert
+    assert prov["hooks.Stop.x"] == "agent"
+
+
+def test_malformed_hook_entries_do_not_break_provenance() -> None:
+    # Arrange — a hand-edited layer with junk where groups/hooks should be.
+    layers = [
+        ("user", {"hooks": {"PreToolUse": "not-a-list", "Stop": ["not-a-dict"]}}),
+        (
+            "agent",
+            {
+                "hooks": {
+                    "Stop": [
+                        {"matcher": "", "hooks": [{"type": "command"}]},
+                        {"matcher": "", "hooks": [{"command": "real"}]},
+                    ]
+                }
+            },
+        ),
+    ]
+    # Act
+    _, prov = deep_merge_layers(layers)
+    # Assert
+    assert prov["hooks.Stop.real"] == "agent"


### PR DESCRIPTION
The deployed `.claude/settings.json` is the **flattened** result of the `to_home` cascade. Reading it tells you which hooks are armed and nothing about where any of them came from, so answering *"where is this hook coming from?"* meant re-deriving the whole cascade by hand — which is how a guard nobody recognises ends up simply tolerated.

## Change

Write the origins down at deploy time, while the provenance still exists:

```
<runtime>/logs/<agent>/hook-origins.json
```
```json
{"agent": "scitex-agent-container", "hook_count": 46, "layers": ["user-shared"],
 "events": {"PreToolUse": {"$HOME/.claude/hooks/pre-tool-use/deny_broad_env_dump.sh": "user-shared"}}}
```

`<runtime>` is `runtime_base_dir()`, so this lands beside the existing `runtime/logs/host_exec.log` and honours the same relocation env var. It is **runtime state, deliberately outside version control**: it records what *one host* deployed at *one moment* — precisely the fact a committed file cannot carry.

## Scope, stated rather than implied

This records what was **armed**, not what **fired**.

Being derived from the deploy, it cannot drift from the deployed settings, and it touches **nothing** on the hook execution path. Recording actual firings requires wrapping each hook's invocation, which puts our code between Claude and a guard's exit code — and a wrapper bug there disarms *every* guard at once, silently. That is a different risk class, deliberately not in this PR; it needs its transparency contract tested first.

## Failure behaviour

- Write failure → WARNING with the path, returns `None`. A deploy must not fail because a diagnostic file could not be written.
- No hooks in the cascade → **no file**, rather than an empty one that reads like a wiped manifest.
- Only the config-driven entrypoint writes it. The lower-level `(spec_dir, workspace_home)` path has no agent identity, so it has nothing to key a per-agent manifest on and is left alone.

## Verification

Against the live cascade on this host:

```
hook_count : 46
layers     : ['user-shared']
events     : {'Notification': 1, 'PostToolUse': 5, 'PreToolUse': 34,
              'Stop': 3, 'UserPromptSubmit': 1, 'WorktreeCreate': 1, 'WorktreeRemove': 1}
  user-shared  PreToolUse  $HOME/.claude/hooks/pre-tool-use/deny_broad_env_dump.sh
```

10 unit tests, no `monkeypatch` — the runtime dir is redirected through the module's own documented env var in a `yield` fixture, and every filesystem assertion reads real bytes.

Answers the operator's ask (2026-08-09) to be able to tell from a log where each hook came from. Builds on the per-command provenance from #913, which is what makes the attribution available at all.
