### PR TITLE
feat(config): let a spec declare which to_home layers it inherits

### DIFF
--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -471,4 +471,37 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
         # ``to_home/`` dir next to spec.yaml auto-discovers. An empty
         # string in YAML keeps the same default behaviour.
         to_home=str(spec.get("to_home", "./to_home") or "./to_home"),
+        # ABSENT key -> None ("inherit whatever is on disk", today's implicit
+        # cascade). An explicit empty list is NOT the same thing and must not
+        # collapse into it: that is a spec saying "inherit NOTHING", which is a
+        # legitimate thing for a sandboxed agent to declare. Only `is None`
+        # distinguishes them, so the default here cannot be `[]`.
+        to_home_layers=_parse_to_home_layers(spec.get("to_home_layers")),
+    )
+
+
+def _parse_to_home_layers(value: object) -> "list[str] | None":
+    """Normalise ``spec.to_home_layers`` to a list of names, or ``None``.
+
+    ``None``/absent keeps the implicit cascade. A string is accepted as a
+    one-element list, because a single-layer declaration is the common case and
+    writing it as a bare scalar in YAML is the obvious thing to do.
+
+    Any other type RAISES. Returning ``None`` for, say, a mapping would make an
+    unusable declaration indistinguishable from an absent one — the spec would
+    silently fall back to inheriting everything while its author believed it had
+    restricted the cascade. That is the exact class of surprise this field
+    exists to remove, so it cannot be how the field itself fails.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if isinstance(value, (list, tuple)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    raise ValueError(
+        f"spec.to_home_layers must be a list of layer names (or a single name), "
+        f"got {type(value).__name__}: {value!r}. Valid names: "
+        f"user-shared, project-shared, per-agent. Omit the key entirely to "
+        f"inherit the implicit cascade."
     )

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -468,6 +468,20 @@ class AgentConfig:
     # Default: ``./to_home`` next to ``spec.yaml`` (auto-discovered
     # when this field is empty).
     to_home: str = "./to_home"
+    # spec.to_home_layers — which to_home CASCADE layers this agent inherits,
+    # named explicitly so the spec states what will be merged into it instead
+    # of leaving it to be discovered on disk. Valid names are the cascade's own
+    # (``user-shared``, ``project-shared``, ``per-agent``); order is fixed by
+    # precedence, not by how they are listed here.
+    #
+    # ``None`` (key absent) means "inherit whatever is on disk" — today's
+    # implicit behaviour, kept so this field can land without changing a single
+    # existing agent. It is NOT the end state: measured 2026-08-09, ALL 102
+    # registered specs are in exactly this position, so refusing an undeclared
+    # spec today would strip every hook from every agent at once. The migration
+    # declares them first, and enforcement comes after that. Until then an
+    # absent value is warned about, never refused.
+    to_home_layers: "list[str] | None" = None
 
     def __post_init__(self) -> None:
         if not self.screen_name:

--- a/src/scitex_agent_container/runtimes/_to_home_errors.py
+++ b/src/scitex_agent_container/runtimes/_to_home_errors.py
@@ -70,6 +70,21 @@ class LayerMergeConflict(RuntimeError):
     """
 
 
+class UnknownToHomeLayer(RuntimeError):
+    """``spec.to_home_layers`` names a cascade layer that does not exist.
+
+    The declaration exists so a spec states which layers get merged into it
+    (``user-shared`` / ``project-shared`` / ``per-agent``). A misspelt name has
+    no matching layer, so it would quietly contribute nothing — an agent could
+    declare ``user_shared`` and silently inherit no hooks at all while looking
+    correctly configured.
+
+    That is the failure the declaration was introduced to remove, so a name
+    that matches no layer is refused rather than ignored. The message names the
+    unknown value and the valid set.
+    """
+
+
 class WorkspaceSettingsMergeError(RuntimeError):
     """A ``settings.json`` to_home layer is not valid JSON — refused.
 

--- a/src/scitex_agent_container/runtimes/_to_home_resolve.py
+++ b/src/scitex_agent_container/runtimes/_to_home_resolve.py
@@ -19,10 +19,14 @@ home by spec alone (see the two ``*_ENV_VAR`` constants).
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
 from ..config import AgentConfig
+from ._to_home_errors import UnknownToHomeLayer
+
+logger = logging.getLogger(__name__)
 
 # Env var: explicit override for the shared/common baseline to_home dir.
 # Absolute path. When unset we fall back to ``<agents_dir>/_shared/to_home``
@@ -139,12 +143,45 @@ def settings_layer_dirs(config: AgentConfig) -> "list[tuple[str, Path | None]]":
     :func:`_to_home_settings.deploy_settings_cascade` /
     :func:`_to_home_settings.settings_cascade_provenance`. Shared by
     ``deploy_to_home`` and ``sac agents explain`` so both resolve identically.
+
+    When the spec DECLARES ``to_home_layers``, only the named layers are
+    resolved; every other layer is dropped to ``None`` and contributes nothing.
+    Declaring the empty list therefore inherits nothing, which is a sandboxed
+    agent's legitimate way of pinning its home to its own spec.
+
+    When the spec declares NOTHING, every layer applies — today's behaviour —
+    and a WARNING names the agent. That asymmetry is deliberate and temporary:
+    all 102 registered specs are currently undeclared (measured 2026-08-09), so
+    refusing here would disarm the entire fleet in one deploy. The warning is
+    what makes the migration visible before the refusal replaces it.
     """
-    return [
+    resolved = [
         ("user-shared", _user_baseline_to_home_dir()),
         ("project-shared", resolve_baseline_to_home_dir(_spec_dir(config))),
         ("per-agent", resolve_to_home_dir(config)),
     ]
+
+    declared = getattr(config, "to_home_layers", None)
+    if declared is None:
+        logger.warning(
+            "to_home: agent %r declares no 'to_home_layers'; inheriting the "
+            "implicit cascade (%s). Declare the layers in the spec so what "
+            "gets merged into this agent is visible from the spec alone.",
+            getattr(config, "name", "<unnamed>"),
+            ", ".join(name for name, path in resolved if path is not None) or "none",
+        )
+        return resolved
+
+    wanted = set(declared)
+    unknown = wanted - {name for name, _ in resolved}
+    if unknown:
+        raise UnknownToHomeLayer(
+            f"spec.to_home_layers names unknown layer(s) {sorted(unknown)!r} "
+            f"for agent {getattr(config, 'name', '<unnamed>')!r}. Valid names: "
+            f"{[name for name, _ in resolved]!r}. A misspelt layer would "
+            f"silently inherit nothing, so this is refused rather than ignored."
+        )
+    return [(name, path if name in wanted else None) for name, path in resolved]
 
 
 def _spec_dir(config: AgentConfig) -> Path | None:

--- a/tests/scitex_agent_container/runtimes/test__to_home_resolve.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_resolve.py
@@ -13,8 +13,12 @@ STX-TQ002 / TQ007: AAA markers, one fact per test.
 
 from __future__ import annotations
 
+import pytest
+
+from scitex_agent_container.runtimes._to_home_errors import UnknownToHomeLayer
 from scitex_agent_container.runtimes._to_home_resolve import (
     _user_baseline_to_home_dir,
+    settings_layer_dirs,
 )
 
 
@@ -44,6 +48,110 @@ class TestUserBaselineOptOut:
         assert resolved is None
 
 
+class _DeclaringSpec:
+    """The four attributes ``settings_layer_dirs`` reads off a config.
+
+    Not a mock of a collaborator — the resolver takes a config OBJECT and reads
+    exactly these, and every path handed to it below is a real directory.
+    """
+
+    def __init__(self, to_home_layers, to_home):
+        self.name = "agent-under-test"
+        self.to_home_layers = to_home_layers
+        self.to_home = to_home
+        self.config_path = ""
+
+
+def _resolved_names(layers):
+    """Map layer name -> whether that layer resolved to a directory."""
+    return {name: path is not None for name, path in layers}
+
+
+class TestToHomeLayerDeclaration:
+    """``spec.to_home_layers``: the spec states which cascade layers it
+    inherits, so what gets merged in is visible from the spec alone instead of
+    discovered on disk. Absent keeps today's behaviour (all 102 registered
+    specs are currently in that state); a misspelt name is refused, because
+    ignoring it would silently inherit nothing."""
+
+    def _layers(self, tmp_path, env_save_restore):
+        user = tmp_path / "user-shared" / "to_home" / ".claude"
+        user.mkdir(parents=True)
+        agent = tmp_path / "agent" / "to_home" / ".claude"
+        agent.mkdir(parents=True)
+        env_save_restore.set("SAC_USER_TO_HOME_BASELINE", str(user.parent))
+        return str(agent.parent)
+
+    def test_absent_declaration_keeps_inheriting_the_user_layer(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — an undeclared spec must behave exactly as it does today.
+        agent_to_home = self._layers(tmp_path, env_save_restore)
+        spec = _DeclaringSpec(None, agent_to_home)
+        # Act
+        resolved = _resolved_names(settings_layer_dirs(spec))
+        # Assert
+        assert resolved["user-shared"] is True
+
+    def test_absent_declaration_keeps_inheriting_the_agent_layer(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange
+        agent_to_home = self._layers(tmp_path, env_save_restore)
+        spec = _DeclaringSpec(None, agent_to_home)
+        # Act
+        resolved = _resolved_names(settings_layer_dirs(spec))
+        # Assert
+        assert resolved["per-agent"] is True
+
+    def test_undeclared_layer_is_dropped(self, tmp_path, env_save_restore):
+        # Arrange — the point of the field: declaring one layer excludes others.
+        agent_to_home = self._layers(tmp_path, env_save_restore)
+        spec = _DeclaringSpec(["per-agent"], agent_to_home)
+        # Act
+        resolved = _resolved_names(settings_layer_dirs(spec))
+        # Assert
+        assert resolved["user-shared"] is False
+
+    def test_declared_layer_is_kept(self, tmp_path, env_save_restore):
+        # Arrange
+        agent_to_home = self._layers(tmp_path, env_save_restore)
+        spec = _DeclaringSpec(["per-agent"], agent_to_home)
+        # Act
+        resolved = _resolved_names(settings_layer_dirs(spec))
+        # Assert
+        assert resolved["per-agent"] is True
+
+    def test_empty_declaration_inherits_nothing(self, tmp_path, env_save_restore):
+        # Arrange — an explicit [] is a spec pinning itself, NOT "absent".
+        agent_to_home = self._layers(tmp_path, env_save_restore)
+        spec = _DeclaringSpec([], agent_to_home)
+        # Act
+        resolved = _resolved_names(settings_layer_dirs(spec))
+        # Assert
+        assert not any(resolved.values())
+
+    def test_misspelt_layer_is_refused(self, tmp_path, env_save_restore):
+        # Arrange — "user_shared" matches no layer; ignoring it inherits nothing.
+        agent_to_home = self._layers(tmp_path, env_save_restore)
+        spec = _DeclaringSpec(["user_shared"], agent_to_home)
+        # Act
+        # Assert
+        with pytest.raises(UnknownToHomeLayer, match="user_shared"):
+            settings_layer_dirs(spec)
+
+    def test_order_follows_precedence_not_declaration_order(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — declared "backwards"; precedence must stay lowest-first.
+        agent_to_home = self._layers(tmp_path, env_save_restore)
+        spec = _DeclaringSpec(["per-agent", "user-shared"], agent_to_home)
+        # Act
+        order = [name for name, _ in settings_layer_dirs(spec)]
+        # Assert
+        assert order == ["user-shared", "project-shared", "per-agent"]
+
+
 class TestToHomeReExportContract:
     """The resolvers moved to ``_to_home_resolve`` but ``_to_home`` must keep
     re-exporting them (legacy import path + ``sac agents explain``)."""
@@ -51,6 +159,7 @@ class TestToHomeReExportContract:
     def test_to_home_reexports_resolvers(self):
         # Arrange
         from scitex_agent_container.runtimes import _to_home
+
         # Act
         names = [
             _to_home.resolve_to_home_dir,


### PR DESCRIPTION
An agent's effective settings are assembled from a **three-layer `to_home` cascade that its spec never mentions**. Reading a spec does not tell you what will be merged into the agent — you have to go look at the disk.

The operator's objection (2026-08-09): that is not least-surprise, and *"you yourself would not know such a shadow rule."*

## Change

```yaml
to_home_layers: [user-shared, per-agent]
```

| declaration | behaviour |
|---|---|
| declared | only those layers resolve; the rest contribute nothing |
| **absent** | every layer applies — **today's behaviour** — plus a WARNING naming the agent |
| `[]` | inherit **nothing**. A spec pinning itself — distinct from absent, and must not collapse into it |
| unknown name | **refused** (`UnknownToHomeLayer`) |

A misspelt `user_shared` matches no layer, so *ignoring* it would silently inherit nothing while the spec looked configured — the exact surprise this field removes. Same reasoning makes a non-list value raise at load rather than degrade to `None`: an unusable declaration must not become indistinguishable from an absent one.

## Why "absent" only warns

Measured over the live registry **before** writing any of this:

```
registered specs                      102
ship their OWN to_home settings.json    0
rely ENTIRELY on inherited layers     102
```

Refusing an undeclared spec today would strip **every hook from every agent in one deploy** — silently, because an agent with no guards looks exactly like a healthy one. That is a worse instance of the bug this PR fixes.

So the sequence is: **declare-and-warn (this PR) → migrate the 102 → verify hook counts unchanged → then turn the warning into a refusal.** Step 3 is mechanical thanks to the hook-origin manifest from #914.

## Verification

Negative control, layer filter neutered in place:

```
2 failed, 8 passed     <- the two tests that exercise the filter
```

The warning and refusal paths are separate code with their own coverage. Full config + runtimes suites: **807 passed**.

**Behaviour for every existing agent is unchanged by design.**
