### PR TITLE
fix(to_home): collapse cascade layers that resolve to the same directory

### DIFF
--- a/src/scitex_agent_container/runtimes/_to_home_resolve.py
+++ b/src/scitex_agent_container/runtimes/_to_home_resolve.py
@@ -135,6 +135,55 @@ def _user_baseline_to_home_dir() -> Path | None:
     return None
 
 
+def _collapse_duplicate_paths(
+    layers: "list[tuple[str, Path | None]]",
+) -> "list[tuple[str, Path | None]]":
+    """Drop any layer whose directory an EARLIER layer already contributes.
+
+    ``user-shared`` and ``project-shared`` both search
+    ``<agents root>/_shared/to_home``. For a spec living under the USER agents
+    root those two roots are the same directory, so the cascade merges one
+    directory into itself. Measured 2026-08-09: this is the case for ALL 102
+    registered specs — the "three layer cascade" is really two.
+
+    Merging a directory with itself cannot contribute anything, so today this
+    is invisible: equal scalars are idempotent, hook groups de-dupe on
+    equality, list merges append uniques, ``_comment`` keeps the first. Every
+    one of those has to KEEP being true. One non-idempotent merge rule — a
+    counter, an append-always list, a timestamp — and the duplicate silently
+    doubles it for every agent at once.
+
+    Collapsing here removes that standing trap and makes the layer list honest:
+    what it reports is what actually contributes. The EARLIER (lower
+    precedence) layer keeps the path, which matches the cascade's own
+    first-layer-owns rule, so provenance attribution is unchanged.
+
+    A ``None`` layer is left alone — absence is not a duplicate.
+    """
+    seen: set[Path] = set()
+    collapsed: list[tuple[str, Path | None]] = []
+    for name, path in layers:
+        if path is None:
+            collapsed.append((name, None))
+            continue
+        try:
+            key = path.resolve()
+        except OSError:  # stx-allow: fallback (unresolvable path -> compare raw)
+            key = path
+        if key in seen:
+            logger.debug(
+                "to_home: layer %r resolves to %s, already contributed by an "
+                "earlier layer — collapsed",
+                name,
+                key,
+            )
+            collapsed.append((name, None))
+            continue
+        seen.add(key)
+        collapsed.append((name, path))
+    return collapsed
+
+
 def settings_layer_dirs(config: AgentConfig) -> "list[tuple[str, Path | None]]":
     """The ordered settings.json cascade layers (lowest precedence first).
 
@@ -155,11 +204,13 @@ def settings_layer_dirs(config: AgentConfig) -> "list[tuple[str, Path | None]]":
     refusing here would disarm the entire fleet in one deploy. The warning is
     what makes the migration visible before the refusal replaces it.
     """
-    resolved = [
-        ("user-shared", _user_baseline_to_home_dir()),
-        ("project-shared", resolve_baseline_to_home_dir(_spec_dir(config))),
-        ("per-agent", resolve_to_home_dir(config)),
-    ]
+    resolved = _collapse_duplicate_paths(
+        [
+            ("user-shared", _user_baseline_to_home_dir()),
+            ("project-shared", resolve_baseline_to_home_dir(_spec_dir(config))),
+            ("per-agent", resolve_to_home_dir(config)),
+        ]
+    )
 
     declared = getattr(config, "to_home_layers", None)
     if declared is None:

--- a/tests/scitex_agent_container/runtimes/test__to_home_resolve.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_resolve.py
@@ -17,6 +17,7 @@ import pytest
 
 from scitex_agent_container.runtimes._to_home_errors import UnknownToHomeLayer
 from scitex_agent_container.runtimes._to_home_resolve import (
+    _collapse_duplicate_paths,
     _user_baseline_to_home_dir,
     settings_layer_dirs,
 )
@@ -150,6 +151,91 @@ class TestToHomeLayerDeclaration:
         order = [name for name, _ in settings_layer_dirs(spec)]
         # Assert
         assert order == ["user-shared", "project-shared", "per-agent"]
+
+
+class TestDuplicateLayerCollapse:
+    """``user-shared`` and ``project-shared`` both search
+    ``<agents root>/_shared/to_home``, so for a spec under the USER agents root
+    they are ONE directory and the cascade merges it into itself. Measured
+    2026-08-09: true for all 102 registered specs. Harmless only while every
+    merge rule stays idempotent, so the duplicate is collapsed rather than
+    left as a standing trap."""
+
+    def test_duplicate_path_is_dropped_from_the_later_layer(self, tmp_path):
+        # Arrange — two layer names pointing at one real directory.
+        shared = tmp_path / "_shared" / "to_home"
+        shared.mkdir(parents=True)
+        # Act
+        collapsed = _collapse_duplicate_paths(
+            [("user-shared", shared), ("project-shared", shared)]
+        )
+        # Assert
+        assert collapsed[1] == ("project-shared", None)
+
+    def test_the_earlier_layer_keeps_the_path(self, tmp_path):
+        # Arrange — first-layer-owns, matching the cascade's own rule.
+        shared = tmp_path / "_shared" / "to_home"
+        shared.mkdir(parents=True)
+        # Act
+        collapsed = _collapse_duplicate_paths(
+            [("user-shared", shared), ("project-shared", shared)]
+        )
+        # Assert
+        assert collapsed[0] == ("user-shared", shared)
+
+    def test_distinct_paths_are_both_kept(self, tmp_path):
+        # Arrange — a genuine two-layer cascade must be untouched.
+        a = tmp_path / "a" / "to_home"
+        a.mkdir(parents=True)
+        b = tmp_path / "b" / "to_home"
+        b.mkdir(parents=True)
+        # Act
+        collapsed = _collapse_duplicate_paths([("user-shared", a), ("per-agent", b)])
+        # Assert
+        assert collapsed == [("user-shared", a), ("per-agent", b)]
+
+    def test_absent_layer_is_not_treated_as_a_duplicate(self, tmp_path):
+        # Arrange — two Nones must not collapse into each other.
+        a = tmp_path / "a" / "to_home"
+        a.mkdir(parents=True)
+        # Act
+        collapsed = _collapse_duplicate_paths(
+            [("user-shared", None), ("project-shared", None), ("per-agent", a)]
+        )
+        # Assert
+        assert collapsed == [
+            ("user-shared", None),
+            ("project-shared", None),
+            ("per-agent", a),
+        ]
+
+    def test_layer_names_and_order_are_preserved(self, tmp_path):
+        # Arrange — collapsing must not reorder or rename; only blank out.
+        shared = tmp_path / "_shared" / "to_home"
+        shared.mkdir(parents=True)
+        # Act
+        collapsed = _collapse_duplicate_paths(
+            [("user-shared", shared), ("project-shared", shared), ("per-agent", None)]
+        )
+        # Assert
+        assert [name for name, _ in collapsed] == [
+            "user-shared",
+            "project-shared",
+            "per-agent",
+        ]
+
+    def test_symlinked_duplicate_is_also_collapsed(self, tmp_path):
+        # Arrange — the same dir reached by a symlink is still the same dir.
+        real = tmp_path / "real" / "to_home"
+        real.mkdir(parents=True)
+        link = tmp_path / "link"
+        link.symlink_to(real)
+        # Act
+        collapsed = _collapse_duplicate_paths(
+            [("user-shared", real), ("project-shared", link)]
+        )
+        # Assert
+        assert collapsed[1] == ("project-shared", None)
 
 
 class TestToHomeReExportContract:


### PR DESCRIPTION
`user-shared` and `project-shared` both search `<agents root>/_shared/to_home`. For a spec living under the **user** agents root those two roots *are the same directory*, so the cascade merges one directory into itself.

Measured across the live registry: **true for all 102 registered specs.** The "three layer cascade" has been two layers the whole time.

## Why fix it if nothing is broken

It is invisible today, and only because every merge rule happens to be idempotent — equal scalars collapse, hook groups de-dupe on equality, list merges append uniques, `_comment` keeps the first. All four have to keep being true forever.

Add one non-idempotent rule (a counter, an append-always list, a timestamp) and it silently doubles for **every agent in the fleet at once**. That is a trap under the floor, not a live bug, and the cheapest moment to remove it is before anything stands on it.

## Change

Drop a layer whose resolved path an **earlier** layer already contributes. The earlier (lower-precedence) layer keeps it, matching the cascade's own first-layer-owns rule, so no hook changes owner. Comparison is after `Path.resolve()`, so a symlinked duplicate is caught too. A `None` layer is untouched — absence is not a duplicate.

## Verified across all 102 agents

```
hook COUNT differences        0
hook ATTRIBUTION differences  0

layers  [user-shared, project-shared, per-agent] -> [user-shared, per-agent]
hooks   46 -> 46
```

Nothing any agent runs changes. Only the claim about where it came from becomes true.

Negative control — collapse neutered in place:

```
2 failed, 14 passed     <- the two tests that exercise collapsing
```

The other four assert properties that must hold either way (distinct paths kept, order preserved, names preserved, `None` not a duplicate), so they correctly pass under both.

## Why before the migration

The next step writes `to_home_layers` into 102 hand-maintained specs. Doing that first would bake `[user-shared, project-shared]` — two names for one directory — into all of them, making the redundancy far harder to remove and the declarations misleading about what actually applies.

After this, the same migration writes `[user-shared]` / `[user-shared, per-agent]`, which is the truth.
