### PR TITLE
feat(to_home): verify a cascade change disarmed nobody, across the fleet

### DIFF
--- a/src/scitex_agent_container/runtimes/_hook_arming_diff.py
+++ b/src/scitex_agent_container/runtimes/_hook_arming_diff.py
@@ -1,0 +1,173 @@
+"""Compare two fleet-wide snapshots of WHICH hooks are armed, and by which layer.
+
+Any change to how the ``to_home`` cascade resolves — a new declaration, a
+collapsed duplicate layer, a migrated spec — can silently disarm an agent. A
+guardless agent looks exactly like a healthy one, so "it deployed fine" proves
+nothing. What proves something is: every agent armed the same hooks before and
+after, attributed to the same layers.
+
+Reading YAML cannot answer that. The hook-origin manifest can
+(:mod:`._hook_origin_manifest`), so this module diffs two of those and returns
+one fixed shape.
+
+THE ANSWER IS THREE-VALUED, and the third value is the point. An agent present
+in ``before`` but missing from ``after`` has NOT been shown unchanged and has
+NOT been shown broken — it was not measured. Folding that into either pole is
+how a migration reports success over agents it never looked at, so it gets its
+own field (:attr:`HookArmingDiff.unmeasured`) and it makes :attr:`safe` false.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# A snapshot is {agent: {event: {command: layer}}} — exactly the shape
+# ``_hook_origin_manifest.hook_origins`` returns, keyed by agent.
+Snapshot = "dict[str, dict[str, dict[str, str]]]"
+
+
+@dataclass(frozen=True)
+class HookArmingDiff:
+    """What changed between two fleet hook-arming snapshots.
+
+    Every field is populated on every comparison — a caller never has to guess
+    which key exists on this call. ``safe`` is the single question a migration
+    asks, and it is deliberately conservative: anything other than "measured
+    both sides, nothing moved" is not safe.
+    """
+
+    agents_compared: int = 0
+    unchanged: "tuple[str, ...]" = ()
+    #: agent -> "<event>: <command>" armed BEFORE and gone AFTER. The dangerous
+    #: direction: a guard that stopped being armed.
+    lost: "dict[str, list[str]]" = field(default_factory=dict)
+    #: agent -> newly armed. Not dangerous, but not free either — an unintended
+    #: gain means the cascade grew a source nobody declared.
+    gained: "dict[str, list[str]]" = field(default_factory=dict)
+    #: agent -> still armed, but now credited to a DIFFERENT layer. The hook
+    #: still runs, so this is not a safety regression; it does mean the origin
+    #: story changed, which is worth a human look before it is normalised.
+    reattributed: "dict[str, list[str]]" = field(default_factory=dict)
+    #: In ``before``, absent from ``after``. NOT unchanged, NOT broken —
+    #: unmeasured. See the module docstring.
+    unmeasured: "tuple[str, ...]" = ()
+    #: In ``after``, absent from ``before``. A new agent, or a snapshot taken
+    #: over a different set. Also unmeasured, in the other direction.
+    unexpected: "tuple[str, ...]" = ()
+
+    def __post_init__(self) -> None:
+        """Every compared agent must land in exactly one outcome bucket.
+
+        The arithmetic matters: an agent is `unchanged`, or it appears in at
+        least one of lost/gained/reattributed — never neither. If the two sides
+        disagree, this diff is under-reporting, and a migration would read a
+        short list as "nothing moved". Failing where the object is BUILT beats
+        discovering it three layers downstream, in a caller that already
+        decided to proceed.
+
+        `unmeasured` / `unexpected` are deliberately NOT in this sum — they are
+        agents that were never compared, which is why they are separate fields.
+        """
+        changed = set(self.lost) | set(self.gained) | set(self.reattributed)
+        accounted = len(self.unchanged) + len(changed)
+        if accounted != self.agents_compared:
+            raise ValueError(
+                f"HookArmingDiff is inconsistent: agents_compared="
+                f"{self.agents_compared} but {accounted} accounted for "
+                f"({len(self.unchanged)} unchanged + {len(changed)} changed). "
+                f"An agent must land in exactly one bucket; a mismatch means "
+                f"the diff is under-reporting and must not be trusted."
+            )
+        overlap = set(self.unmeasured) & set(self.unexpected)
+        if overlap:
+            raise ValueError(
+                f"HookArmingDiff is inconsistent: {sorted(overlap)!r} is both "
+                f"unmeasured (missing after) and unexpected (missing before), "
+                f"which is impossible."
+            )
+
+    @property
+    def safe(self) -> bool:
+        """True only when BOTH sides were measured and nothing moved.
+
+        A migration may proceed on this and nothing weaker. ``gained`` and
+        ``reattributed`` count against it too: the promise being verified is
+        "identical", not "no worse".
+        """
+        return not (
+            self.lost
+            or self.gained
+            or self.reattributed
+            or self.unmeasured
+            or self.unexpected
+        )
+
+    def summary(self) -> str:
+        """One human-readable line, for a migration log or a refusal message."""
+        if self.safe:
+            return f"{self.agents_compared} agent(s): hook arming identical"
+        parts = []
+        if self.lost:
+            parts.append(f"{len(self.lost)} agent(s) LOST hooks")
+        if self.gained:
+            parts.append(f"{len(self.gained)} gained")
+        if self.reattributed:
+            parts.append(f"{len(self.reattributed)} reattributed")
+        if self.unmeasured:
+            parts.append(f"{len(self.unmeasured)} UNMEASURED (missing after)")
+        if self.unexpected:
+            parts.append(f"{len(self.unexpected)} unexpected (missing before)")
+        return f"{self.agents_compared} agent(s) compared: " + ", ".join(parts)
+
+
+def _flatten(origins: "dict[str, dict[str, str]]") -> "dict[str, str]":
+    """``{event: {command: layer}}`` -> ``{"event: command": layer}``.
+
+    Flattening on (event, command) rather than command alone keeps the same
+    command armed on two events distinguishable — they are two separate
+    armings and losing one is a real loss.
+    """
+    flat: dict[str, str] = {}
+    for event, commands in (origins or {}).items():
+        for command, layer in (commands or {}).items():
+            flat[f"{event}: {command}"] = layer
+    return flat
+
+
+def diff_hook_arming(before: dict, after: dict) -> HookArmingDiff:
+    """Compare two ``{agent: {event: {command: layer}}}`` snapshots."""
+    before_agents = set(before or {})
+    after_agents = set(after or {})
+    both = sorted(before_agents & after_agents)
+
+    unchanged: list[str] = []
+    lost: dict[str, list[str]] = {}
+    gained: dict[str, list[str]] = {}
+    reattributed: dict[str, list[str]] = {}
+
+    for agent in both:
+        b, a = _flatten(before[agent]), _flatten(after[agent])
+        gone = sorted(set(b) - set(a))
+        new = sorted(set(a) - set(b))
+        moved = sorted(k for k in set(b) & set(a) if b[k] != a[k])
+        if gone:
+            lost[agent] = gone
+        if new:
+            gained[agent] = new
+        if moved:
+            reattributed[agent] = [f"{k} ({b[k]} -> {a[k]})" for k in moved]
+        if not (gone or new or moved):
+            unchanged.append(agent)
+
+    return HookArmingDiff(
+        agents_compared=len(both),
+        unchanged=tuple(unchanged),
+        lost=lost,
+        gained=gained,
+        reattributed=reattributed,
+        unmeasured=tuple(sorted(before_agents - after_agents)),
+        unexpected=tuple(sorted(after_agents - before_agents)),
+    )
+
+
+__all__ = ["HookArmingDiff", "diff_hook_arming"]

--- a/tests/scitex_agent_container/runtimes/test__hook_arming_diff.py
+++ b/tests/scitex_agent_container/runtimes/test__hook_arming_diff.py
@@ -1,0 +1,155 @@
+"""Tests for the fleet hook-arming diff (``runtimes._hook_arming_diff``).
+
+The verifier a to_home change must pass before it is trusted: every agent armed
+the same hooks, credited to the same layers, on both sides. These pin the
+outcome buckets, the deliberately-conservative ``safe``, the three-valued
+treatment of an agent that was never measured, and the validator that refuses
+an internally inconsistent diff.
+
+STX-NM002: no mocks — pure dict in, dataclass out.
+STX-TQ002 / TQ007: AAA markers per test, one fact per test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.runtimes._hook_arming_diff import (
+    HookArmingDiff,
+    diff_hook_arming,
+)
+
+_ONE = {"a": {"PreToolUse": {"guard.sh": "user-shared"}}}
+
+
+def test_identical_snapshots_are_safe() -> None:
+    # Arrange
+    before = after = _ONE
+    # Act
+    diff = diff_hook_arming(before, after)
+    # Assert
+    assert diff.safe is True
+
+
+def test_identical_snapshots_list_the_agent_as_unchanged() -> None:
+    # Arrange
+    before = after = _ONE
+    # Act
+    diff = diff_hook_arming(before, after)
+    # Assert
+    assert diff.unchanged == ("a",)
+
+
+def test_a_dropped_hook_is_reported_as_lost() -> None:
+    # Arrange — the dangerous direction: a guard stopped being armed.
+    after = {"a": {"PreToolUse": {}}}
+    # Act
+    diff = diff_hook_arming(_ONE, after)
+    # Assert
+    assert diff.lost == {"a": ["PreToolUse: guard.sh"]}
+
+
+def test_a_dropped_hook_is_not_safe() -> None:
+    # Arrange
+    after = {"a": {"PreToolUse": {}}}
+    # Act
+    diff = diff_hook_arming(_ONE, after)
+    # Assert
+    assert diff.safe is False
+
+
+def test_a_gained_hook_is_also_not_safe() -> None:
+    # Arrange — the promise is "identical", not "no worse".
+    after = {"a": {"PreToolUse": {"guard.sh": "user-shared", "new.sh": "per-agent"}}}
+    # Act
+    diff = diff_hook_arming(_ONE, after)
+    # Assert
+    assert diff.safe is False
+
+
+def test_a_relayered_hook_is_reported_as_reattributed() -> None:
+    # Arrange — same hook still armed, credited to a different layer.
+    after = {"a": {"PreToolUse": {"guard.sh": "per-agent"}}}
+    # Act
+    diff = diff_hook_arming(_ONE, after)
+    # Assert
+    assert diff.reattributed == {
+        "a": ["PreToolUse: guard.sh (user-shared -> per-agent)"]
+    }
+
+
+def test_an_agent_missing_after_is_unmeasured_not_unchanged() -> None:
+    # Arrange — the three-valued case: absent is not "fine".
+    # Act
+    diff = diff_hook_arming(_ONE, {})
+    # Assert
+    assert diff.unmeasured == ("a",)
+
+
+def test_an_agent_missing_after_is_not_counted_as_compared() -> None:
+    # Arrange — it was never compared, so it must not inflate the total.
+    # Act
+    diff = diff_hook_arming(_ONE, {})
+    # Assert
+    assert diff.agents_compared == 0
+
+
+def test_an_unmeasured_agent_makes_the_diff_unsafe() -> None:
+    # Arrange — a migration must not pass over agents it never looked at.
+    # Act
+    diff = diff_hook_arming(_ONE, {})
+    # Assert
+    assert diff.safe is False
+
+
+def test_an_agent_missing_before_is_unexpected() -> None:
+    # Arrange
+    # Act
+    diff = diff_hook_arming({}, _ONE)
+    # Assert
+    assert diff.unexpected == ("a",)
+
+
+def test_same_command_on_two_events_counts_as_two_armings() -> None:
+    # Arrange — losing one of them is a real loss, so they must not collapse.
+    before = {
+        "a": {"PreToolUse": {"g.sh": "user-shared"}, "Stop": {"g.sh": "user-shared"}}
+    }
+    after = {"a": {"PreToolUse": {"g.sh": "user-shared"}}}
+    # Act
+    diff = diff_hook_arming(before, after)
+    # Assert
+    assert diff.lost == {"a": ["Stop: g.sh"]}
+
+
+def test_empty_snapshots_compare_safe() -> None:
+    # Arrange — nothing on either side is consistent, if uninteresting.
+    # Act
+    diff = diff_hook_arming({}, {})
+    # Assert
+    assert diff.safe is True
+
+
+def test_summary_names_the_losing_agents_count() -> None:
+    # Arrange
+    after = {"a": {"PreToolUse": {}}}
+    # Act
+    diff = diff_hook_arming(_ONE, after)
+    # Assert
+    assert "1 agent(s) LOST hooks" in diff.summary()
+
+
+def test_inconsistent_diff_is_refused_at_construction() -> None:
+    # Arrange — claims two agents compared but accounts for one.
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="under-reporting"):
+        HookArmingDiff(agents_compared=2, unchanged=("a",))
+
+
+def test_an_agent_cannot_be_both_unmeasured_and_unexpected() -> None:
+    # Arrange — missing from both sides at once is impossible.
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="impossible"):
+        HookArmingDiff(unmeasured=("a",), unexpected=("a",))


### PR DESCRIPTION
Any change to how the `to_home` cascade resolves — a new declaration, a collapsed layer, a migrated spec — can silently disarm an agent. **A guardless agent looks exactly like a healthy one**, so "it deployed fine" proves nothing.

What proves something: every agent armed the same hooks, credited to the same layers, before and after. Reading YAML cannot answer that; the hook-origin manifest (#914) can.

## Shape

`diff_hook_arming(before, after)` returns one fixed `HookArmingDiff` every time, each signal its own named field — `unchanged`, `lost`, `gained`, `reattributed`, `unmeasured`, `unexpected`. No caller guesses which key exists on this call.

**The third value is the point.** An agent present in `before` and absent from `after` has *not* been shown unchanged and has *not* been shown broken — it was never measured. Folding that into either pole is exactly how a migration reports success over agents it never looked at, so `unmeasured` is its own field and it makes `safe` false.

`safe` is deliberately conservative: `gained` and `reattributed` count against it too. The promise is **identical**, not "no worse" — a hook appearing from nowhere means the cascade grew a source nobody declared, the same class of surprise as one vanishing.

Flattening is on `(event, command)`, not command alone: the same command armed on two events is two armings, and losing one is a real loss.

## The validator

Refuses an internally inconsistent diff **at construction** — every compared agent lands in exactly one bucket; nothing is both `unmeasured` and `unexpected`. A diff that under-reports would read as "nothing moved", the worst possible failure for this object, so it fails where it is built rather than downstream in a caller that already decided to proceed.

Worth recording: **the first version of that validator could not fail** — its condition compared a sum against one of its own terms. Caught on re-read, in a module whose entire purpose is verification. Replaced with the real arithmetic and a test that raises.

## Verified on real fleet data

102 agents, with injected regressions as a positive control on the detector itself:

```
identical      -> 102 agent(s): hook arming identical            safe=True
one disarmed   -> 1 agent(s) LOST hooks                          safe=False
                  canary-resume-test: PreToolUse: .../enforce_develop_branch.sh
one missing    -> 101 compared, 1 UNMEASURED (missing after)     safe=False
```

15 unit tests, no mocks.

This is the step-3 gate the 102-spec `to_home_layers` migration must pass before it is trusted. It already earned itself once — the same before/after comparison is what showed the duplicate-layer collapse (#916) changed no agent's hooks.
