### PR TITLE
feat(config): insert to_home_layers into a spec as a text edit, or refuse

### DIFF
--- a/src/scitex_agent_container/config/_to_home_layers_line.py
+++ b/src/scitex_agent_container/config/_to_home_layers_line.py
@@ -1,0 +1,96 @@
+"""Insert a ``to_home_layers:`` declaration into a spec, as a TEXT edit.
+
+Migrating the fleet to declare its ``to_home`` cascade means touching 102
+hand-maintained ``spec.yaml`` files. A full ruamel/pyyaml load+dump cycle would
+do it in three lines and reformat unrelated content along the way — quote
+styles, flow-vs-block, blank lines, comment placement. :mod:`._group_sync`
+already rejected that trade for exactly this reason, and this module follows
+the same convention rather than inventing a second one: a targeted line edit
+that leaves every byte it did not intend to touch.
+
+The anchor is the spec's own ``to_home:`` line. That is the natural sibling of
+the new key, and it is present in 106 of the 107 spec files on this host, so
+the insertion point is well-defined almost everywhere. Where it is NOT — one
+spec today — the edit is REFUSED rather than guessed at. A spec is an agent's
+identity; "needs manual attention" is a far better outcome than a plausible
+insertion into the wrong block.
+
+Idempotent: a spec that already declares ``to_home_layers`` is left untouched,
+so the migration can be re-run without accumulating duplicates.
+"""
+
+from __future__ import annotations
+
+import re
+
+_TO_HOME_RE = re.compile(r"^(?P<indent>[ \t]*)to_home:[ \t]*(?P<value>\S.*)?$")
+_ALREADY_RE = re.compile(r"^[ \t]*to_home_layers:")
+
+
+def _split_ending(raw: str) -> "tuple[str, str]":
+    if raw.endswith("\r\n"):
+        return raw[:-2], "\r\n"
+    if raw.endswith("\n"):
+        return raw[:-1], "\n"
+    return raw, ""
+
+
+def render_layers_value(layers: "list[str]") -> str:
+    """Render ``layers`` as the flow list the fleet's specs author.
+
+    Flow style (``[a, b]``) matches how ``groups:`` is written in these specs,
+    so a migrated file still reads like the files around it. An empty list
+    renders as ``[]`` — a spec inheriting nothing, which is a real declaration
+    and not the same as omitting the key.
+    """
+    return "[" + ", ".join(layers) + "]"
+
+
+def insert_to_home_layers(text: str, layers: "list[str]") -> "tuple[str, bool]":
+    """Add ``to_home_layers: [...]`` after the spec's ``to_home:`` line.
+
+    Returns ``(new_text, changed)``. ``changed`` is False — and ``text`` comes
+    back byte-identical — when:
+
+      * the spec already declares ``to_home_layers`` (idempotent re-run), or
+      * no ``to_home:`` line exists to anchor to (refused, not guessed).
+
+    A False return is a request for human attention, never a silent success.
+    Only the FIRST ``to_home:`` line is used; these specs author exactly one,
+    and touching more would be guessing about a shape we have not seen.
+    """
+    lines = text.splitlines(keepends=True)
+    bodies = [_split_ending(raw)[0] for raw in lines]
+
+    # Idempotence, checked PER LINE. A bare `search()` would need re.MULTILINE
+    # to see anything past the first line, and silently matching only at
+    # position 0 is the kind of near-miss that makes a re-run duplicate a key.
+    if any(_ALREADY_RE.match(body) for body in bodies):
+        return text, False
+
+    for i, raw in enumerate(lines):
+        body, ending = _split_ending(raw)
+        m = _TO_HOME_RE.match(body)
+        if not m:
+            continue
+        # Reuse the anchor's own indent and line ending so the inserted line is
+        # indistinguishable from a hand-authored neighbour.
+        #
+        # When the anchor is the file's last line and carries NO terminator,
+        # terminating only the NEW line is not enough — the two keys fuse onto
+        # one line ("to_home: ./x  to_home_layers: [...]"), which is valid YAML
+        # for neither. The anchor itself has to gain the terminator. Caught by
+        # test, after a comment here claimed it was already handled.
+        terminator = ending or "\n"
+        if not ending:
+            lines[i] = body + terminator
+        new_line = (
+            f"{m.group('indent')}to_home_layers: "
+            f"{render_layers_value(layers)}{terminator}"
+        )
+        lines.insert(i + 1, new_line)
+        return "".join(lines), True
+    return text, False
+
+
+__all__ = ["insert_to_home_layers", "render_layers_value"]

--- a/tests/scitex_agent_container/config/test__to_home_layers_line.py
+++ b/tests/scitex_agent_container/config/test__to_home_layers_line.py
@@ -1,0 +1,146 @@
+"""Tests for the ``to_home_layers`` spec text editor.
+
+The migration touches 102 hand-maintained spec.yaml files, so these pin the
+things a bulk rewrite gets wrong: everything the edit did not intend to touch
+stays byte-identical, a re-run does not duplicate the key, and a spec whose
+shape is unrecognised is REFUSED rather than guessed at.
+
+STX-NM002: no mocks — pure string in, string out.
+STX-TQ002 / TQ007: AAA markers per test, one fact per test.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.config._to_home_layers_line import (
+    insert_to_home_layers,
+    render_layers_value,
+)
+
+_SPEC = (
+    "apiVersion: scitex-agent-container/v3\n"
+    "kind: Agent\n"
+    "spec:\n"
+    "  runtime: tui\n"
+    "  to_home: ./to_home\n"
+    "  # a trailing comment that must survive\n"
+    "  workdir: /home/ywatanabe/proj/x\n"
+)
+
+
+def test_declaration_is_inserted_after_the_anchor() -> None:
+    # Arrange
+    text = _SPEC
+    # Act
+    new, _ = insert_to_home_layers(text, ["user-shared", "per-agent"])
+    # Assert
+    assert "  to_home: ./to_home\n  to_home_layers: [user-shared, per-agent]\n" in new
+
+
+def test_insertion_reports_changed() -> None:
+    # Arrange
+    text = _SPEC
+    # Act
+    _, changed = insert_to_home_layers(text, ["user-shared"])
+    # Assert
+    assert changed is True
+
+
+def test_every_other_line_survives_byte_identical() -> None:
+    # Arrange — the whole point of a line edit over a load+dump cycle.
+    text = _SPEC
+    # Act
+    new, _ = insert_to_home_layers(text, ["user-shared"])
+    # Assert
+    assert [ln for ln in new.splitlines() if "to_home_layers" not in ln] == (
+        text.splitlines()
+    )
+
+
+def test_the_anchor_indent_is_reused() -> None:
+    # Arrange — a deeper-nested spec must not get a flat insertion.
+    text = "spec:\n  nested:\n      to_home: ./to_home\n"
+    # Act
+    new, _ = insert_to_home_layers(text, ["user-shared"])
+    # Assert
+    assert "\n      to_home_layers: [user-shared]\n" in new
+
+
+def test_rerunning_does_not_duplicate_the_key() -> None:
+    # Arrange — idempotence; the migration must be safe to re-run.
+    once, _ = insert_to_home_layers(_SPEC, ["user-shared"])
+    # Act
+    twice, _ = insert_to_home_layers(once, ["user-shared"])
+    # Assert
+    assert twice.count("to_home_layers:") == 1
+
+
+def test_rerunning_reports_unchanged() -> None:
+    # Arrange
+    once, _ = insert_to_home_layers(_SPEC, ["user-shared"])
+    # Act
+    _, changed = insert_to_home_layers(once, ["user-shared"])
+    # Assert
+    assert changed is False
+
+
+def test_an_existing_declaration_below_line_one_is_still_detected() -> None:
+    # Arrange — a bare regex search without MULTILINE only sees position 0,
+    # which would silently duplicate the key on every re-run.
+    text = "spec:\n  to_home: ./to_home\n  to_home_layers: [user-shared]\n"
+    # Act
+    _, changed = insert_to_home_layers(text, ["per-agent"])
+    # Assert
+    assert changed is False
+
+
+def test_a_spec_without_the_anchor_is_refused() -> None:
+    # Arrange — one real spec on this host has no to_home: line.
+    text = "spec:\n  runtime: tui\n  workdir: /tmp\n"
+    # Act
+    _, changed = insert_to_home_layers(text, ["user-shared"])
+    # Assert
+    assert changed is False
+
+
+def test_a_refused_spec_is_returned_untouched() -> None:
+    # Arrange — refusal must not be a partial write.
+    text = "spec:\n  runtime: tui\n"
+    # Act
+    new, _ = insert_to_home_layers(text, ["user-shared"])
+    # Assert
+    assert new == text
+
+
+def test_crlf_line_endings_are_preserved() -> None:
+    # Arrange — a spec edited on Windows must not gain a lone LF.
+    text = "spec:\r\n  to_home: ./to_home\r\n  workdir: /tmp\r\n"
+    # Act
+    new, _ = insert_to_home_layers(text, ["user-shared"])
+    # Assert
+    assert "\r\n  to_home_layers: [user-shared]\r\n" in new
+
+
+def test_an_unterminated_final_line_gains_a_terminator() -> None:
+    # Arrange — without one, the insert would fuse two keys onto one line.
+    text = "spec:\n  to_home: ./to_home"
+    # Act
+    new, _ = insert_to_home_layers(text, ["user-shared"])
+    # Assert
+    assert new == "spec:\n  to_home: ./to_home\n  to_home_layers: [user-shared]\n"
+
+
+def test_an_empty_declaration_renders_as_an_empty_flow_list() -> None:
+    # Arrange — "inherit nothing" is a real declaration, not an omission.
+    # Act
+    rendered = render_layers_value([])
+    # Assert
+    assert rendered == "[]"
+
+
+def test_only_the_first_anchor_is_used() -> None:
+    # Arrange — two to_home: lines is a shape we have not seen; touch one.
+    text = "a:\n  to_home: ./x\nb:\n  to_home: ./y\n"
+    # Act
+    new, _ = insert_to_home_layers(text, ["user-shared"])
+    # Assert
+    assert new.count("to_home_layers:") == 1

--- a/tests/scitex_agent_container/config/test__to_home_layers_line.py
+++ b/tests/scitex_agent_container/config/test__to_home_layers_line.py
@@ -137,6 +137,40 @@ def test_an_empty_declaration_renders_as_an_empty_flow_list() -> None:
     assert rendered == "[]"
 
 
+def test_it_composes_with_the_other_spec_editor_in_either_order() -> None:
+    # Arrange — `_group_sync.sync_groups_line` ALREADY bulk-edits these same
+    # hand-maintained spec files. Two independent line editors over 102 files
+    # is exactly the shape that yields a corrupted spec nobody can attribute,
+    # so their independence is pinned rather than assumed.
+    from scitex_agent_container.config._group_sync import sync_groups_line
+
+    spec = (
+        "metadata:\n"
+        "  labels:\n"
+        "    groups: [developer, infra]\n"
+        "spec:\n"
+        "  to_home: ./to_home\n"
+    )
+    # Act
+    a, _ = sync_groups_line(insert_to_home_layers(spec, ["user-shared"])[0], "active")
+    b, _ = insert_to_home_layers(sync_groups_line(spec, "active")[0], ["user-shared"])
+    # Assert
+    assert a == b
+
+
+def test_the_other_editors_line_is_left_intact() -> None:
+    # Arrange — neither editor may disturb the line the other owns.
+    from scitex_agent_container.config._group_sync import sync_groups_line
+
+    spec = "metadata:\n  groups: [developer]\nspec:\n  to_home: ./to_home\n"
+    # Act
+    both, _ = sync_groups_line(
+        insert_to_home_layers(spec, ["user-shared"])[0], "active"
+    )
+    # Assert
+    assert "  groups: [developer, active]\n" in both
+
+
 def test_only_the_first_anchor_is_used() -> None:
     # Arrange — two to_home: lines is a shape we have not seen; touch one.
     text = "a:\n  to_home: ./x\nb:\n  to_home: ./y\n"


### PR DESCRIPTION
Declaring the `to_home` cascade means editing **102 hand-maintained `spec.yaml` files**. A ruamel/pyyaml load+dump cycle does that in three lines and reformats unrelated content on the way out — quote styles, flow-vs-block, blank lines, comment placement.

`_group_sync.sync_groups_line` already rejected that trade for exactly this reason, so this follows the same convention rather than inventing a second one: a targeted line edit that leaves every byte it did not intend to touch.

**Anchor**: the spec's own `to_home:` line — the natural sibling of the new key, present in 106 of 107 spec files on this host. Where it is absent the edit is **refused**, not guessed at. A spec is an agent's identity, and "needs manual attention" beats a plausible insertion into the wrong block. Exactly one spec (`scitex-todo`) is in that position, and the dry-run names it.

Idempotent — a spec already declaring `to_home_layers` comes back untouched, so the migration is safe to re-run.

## Two bugs caught before they could touch a file

Both looked fine:

- `f"{ending or '\n'}"` — a backslash inside an f-string expression is a **SyntaxError before Python 3.12** (PEP 701). CI runs a 3.11 leg, so this would have failed there and nowhere locally.
- When the anchor is the file's **last line with no terminator**, terminating only the *new* line still fuses the two keys onto one (`to_home: ./x  to_home_layers: [...]`). The anchor itself has to gain the terminator. A comment in the code claimed this was handled; it was not, and the test caught the comment lying.

## Dry-run over all 102 registered specs, writing nothing

```
would write   : 101
REFUSED       :   1  ['scitex-todo']   <- no to_home: anchor
   65  ['user-shared']
   36  ['user-shared', 'per-agent']
every write touched exactly ONE line (asserted per spec)
```

That last assertion is the point of the approach: the dry-run doesn't just count files, it verifies each rewrite differs from the original by a **single added line**. A bulk edit that cannot prove that is one nobody should run.

## Tests

13 unit tests — byte-identity of untouched lines, indent reuse, CRLF preservation, refusal returning the input untouched, and idempotence *including a declaration below line one* (a bare regex `search` without `MULTILINE` only sees position 0 and would duplicate the key on every re-run).

**The sweep that uses this is not in this PR.** It lands behind #917, so the before/after hook-arming gate exists before the thing it gates.
