### PR TITLE
feat(maintenance): plan the to_home_layers sweep, and apply it transactionally

### DIFF
--- a/src/scitex_agent_container/_maintenance/_layers_migration_apply.py
+++ b/src/scitex_agent_container/_maintenance/_layers_migration_apply.py
@@ -1,0 +1,157 @@
+"""Apply the ``to_home_layers`` sweep TRANSACTIONALLY, or leave nothing changed.
+
+The sweep edits ~101 hand-maintained ``spec.yaml`` files. Two things can go
+wrong that a per-file check cannot see:
+
+* the plan itself is wrong (an edit touches more than the one intended line), and
+* the edits are individually fine but change what an agent ARMS.
+
+The second only becomes visible AFTER writing, by re-deriving hook arming from
+the migrated specs. So "check, then write" is not available — the honest shape
+is write, verify, and UNDO if the verification fails. That is why every
+original is archived first: the archive is not a courtesy copy, it is the
+rollback path, and without it the post-write gate would have nothing to offer
+but a report of damage already done.
+
+Ordering, and why each step is where it is:
+
+  1. refuse unless :attr:`MigrationPlan.safe_to_apply` — never write from a
+     plan that does not describe what would happen
+  2. archive every target to ``.old/<timestamp>/`` — the rollback path exists
+     before the first byte changes
+  3. write
+  4. re-derive hook arming and diff it against the pre-write snapshot
+  5. if the diff is not ``safe``, RESTORE from the archive and report refusal
+
+A partially-applied sweep is the one outcome this must never produce, because
+it leaves the fleet in a state no one planned and no one can describe.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from ._layers_migration_model import MigrationPlan
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    """What the apply did. Same shape whether it succeeded, refused, or undid.
+
+    ``refused`` and ``rolled_back`` are distinct on purpose: refusing BEFORE
+    writing and undoing AFTER writing leave the filesystem identical but say
+    very different things about what was learned, and an operator reading this
+    needs to know which happened.
+    """
+
+    written: "tuple[str, ...]" = ()
+    archive_dir: "Path | None" = None
+    #: Set when the apply declined to write at all. None means it wrote.
+    refused: "str | None" = None
+    #: Set when it wrote, failed verification, and restored the originals.
+    rolled_back: "str | None" = None
+
+    @property
+    def applied(self) -> bool:
+        """True only when edits were written AND survived verification."""
+        return bool(self.written) and not self.refused and not self.rolled_back
+
+
+def archive_originals(plan: MigrationPlan, archive_dir: Path) -> "list[Path]":
+    """Copy every spec the plan would write into ``archive_dir``.
+
+    Flat, keyed by agent name, because two agents' specs share the basename
+    ``spec.yaml`` and a flat copy of both would silently keep only one — an
+    archive that loses half its entries is worse than none, since it invites a
+    rollback that cannot complete.
+    """
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    copied: list[Path] = []
+    for edit in plan.writable:
+        dest = archive_dir / f"{edit.agent}__{edit.path.name}"
+        shutil.copy2(edit.path, dest)
+        copied.append(dest)
+    return copied
+
+
+def restore_from_archive(plan: MigrationPlan, archive_dir: Path) -> "list[str]":
+    """Put every archived original back. Returns the agents restored.
+
+    Best-effort per file and LOUD about any it could not restore: a rollback
+    that half-completes must not report success, because that is the
+    partially-applied state this module exists to prevent.
+    """
+    restored: list[str] = []
+    for edit in plan.writable:
+        src = archive_dir / f"{edit.agent}__{edit.path.name}"
+        if not src.is_file():
+            logger.error(
+                "rollback: no archived original for %s at %s — that spec is "
+                "left MIGRATED while others were reverted",
+                edit.agent,
+                src,
+            )
+            continue
+        try:
+            shutil.copy2(src, edit.path)
+            restored.append(edit.agent)
+        except OSError as exc:  # stx-allow: fallback (report, keep restoring)
+            logger.error("rollback: failed to restore %s: %s", edit.agent, exc)
+    return restored
+
+
+def apply_migration(
+    plan: MigrationPlan,
+    archive_dir: Path,
+    verify: "callable",
+) -> MigrationResult:
+    """Write the plan, verify, and undo if verification fails.
+
+    ``verify`` is called with no arguments AFTER the writes and must return an
+    object with a truthy/falsey ``safe`` attribute plus a ``summary()`` — the
+    shape :class:`.._hook_arming_diff.HookArmingDiff` already has. Injecting it
+    keeps this module free of any opinion about WHAT is verified; it only knows
+    that something must be, and what to do when it is not.
+    """
+    if not plan.safe_to_apply:
+        return MigrationResult(refused=f"plan is not safe to apply: {plan.summary()}")
+    if not plan.writable:
+        return MigrationResult(refused="plan would write nothing")
+
+    archive_originals(plan, archive_dir)
+
+    written: list[str] = []
+    for edit in plan.writable:
+        edit.path.write_text(edit.new_text or "")
+        written.append(edit.agent)
+
+    verdict = verify()
+    if not getattr(verdict, "safe", False):
+        restored = restore_from_archive(plan, archive_dir)
+        detail = verdict.summary() if hasattr(verdict, "summary") else str(verdict)
+        logger.error(
+            "migration ROLLED BACK: %s (restored %d/%d)",
+            detail,
+            len(restored),
+            len(written),
+        )
+        return MigrationResult(
+            written=(),
+            archive_dir=archive_dir,
+            rolled_back=f"{detail}; restored {len(restored)}/{len(written)}",
+        )
+
+    return MigrationResult(written=tuple(written), archive_dir=archive_dir)
+
+
+__all__ = [
+    "MigrationResult",
+    "apply_migration",
+    "archive_originals",
+    "restore_from_archive",
+]

--- a/src/scitex_agent_container/_maintenance/_layers_migration_model.py
+++ b/src/scitex_agent_container/_maintenance/_layers_migration_model.py
@@ -1,0 +1,120 @@
+"""Plan the ``to_home_layers`` sweep over every registered spec — no writes.
+
+The migration adds one declaration line to ~101 hand-maintained ``spec.yaml``
+files. The constitution's rule for a bulk operation is that you read what it
+WOULD do before it does anything, and that the dry-run prints the counts and
+the affected set rather than a summary you are asked to trust. This module is
+that dry-run, as a value: :func:`plan_migration` performs no I/O beyond reading,
+and the object it returns is what the applying half consumes.
+
+Two things it refuses to blur:
+
+* A spec whose shape the editor does not recognise is REFUSED and named, not
+  silently skipped. Skipping is how a sweep reports "101 done" over a fleet of
+  102 and nobody notices the one.
+* A planned edit that would change more than a single line is a DEFECT, not a
+  bigger success. The plan carries that per spec, so the apply can refuse
+  before touching a file rather than after.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SpecEdit:
+    """One spec's planned edit. ``new_text`` is None when nothing will be written."""
+
+    agent: str
+    path: Path
+    layers: "tuple[str, ...]"
+    new_text: "str | None" = None
+    #: Why this spec will NOT be written. None means it will be.
+    refusal: "str | None" = None
+    #: How many lines differ between the original and ``new_text``. Anything
+    #: other than 1 means the editor did something unintended.
+    lines_added: int = 0
+
+    @property
+    def will_write(self) -> bool:
+        return self.new_text is not None and self.refusal is None
+
+
+@dataclass(frozen=True)
+class MigrationPlan:
+    """What the sweep would do, in full, before it does any of it."""
+
+    edits: "tuple[SpecEdit, ...]" = ()
+    #: Specs found on disk that could not be parsed into an edit at all.
+    unreadable: "tuple[str, ...]" = field(default=())
+
+    @property
+    def writable(self) -> "tuple[SpecEdit, ...]":
+        return tuple(e for e in self.edits if e.will_write)
+
+    @property
+    def refused(self) -> "tuple[SpecEdit, ...]":
+        return tuple(e for e in self.edits if e.refusal is not None)
+
+    @property
+    def malformed(self) -> "tuple[SpecEdit, ...]":
+        """Planned writes that would touch other than exactly one line.
+
+        Separated from ``refused`` deliberately: a refusal is the editor
+        declining a shape it does not know, which is correct behaviour. This is
+        the editor accepting a shape and then producing a diff nobody asked
+        for, which is a bug. Conflating them would let a real defect be read as
+        "one more spec needing manual attention".
+        """
+        return tuple(e for e in self.writable if e.lines_added != 1)
+
+    @property
+    def safe_to_apply(self) -> bool:
+        """True only when every planned write is a clean single-line insert.
+
+        Refusals do NOT make a plan unsafe — a named, counted refusal is a
+        legitimate outcome that a human resolves. A malformed edit or an
+        unreadable spec does, because both mean the plan does not describe what
+        would actually happen.
+        """
+        return not self.malformed and not self.unreadable
+
+    def summary(self) -> str:
+        parts = [f"{len(self.writable)} spec(s) would be written"]
+        if self.refused:
+            parts.append(
+                f"{len(self.refused)} REFUSED ("
+                + ", ".join(sorted(e.agent for e in self.refused))
+                + ")"
+            )
+        if self.malformed:
+            parts.append(f"{len(self.malformed)} MALFORMED — do not apply")
+        if self.unreadable:
+            parts.append(f"{len(self.unreadable)} unreadable")
+        return "; ".join(parts)
+
+
+def count_added_lines(before: str, after: str) -> int:
+    """Lines present in ``after`` and not in ``before``, positionally.
+
+    A set difference would call a moved line "unchanged" and a duplicated line
+    "no change at all", which is precisely the damage a bulk YAML edit does.
+    Comparing sequences keeps a reordering visible as what it is.
+    """
+    b, a = before.splitlines(), after.splitlines()
+    if len(a) < len(b):
+        return len(a) - len(b)
+    i = j = added = 0
+    while i < len(b) and j < len(a):
+        if b[i] == a[j]:
+            i += 1
+            j += 1
+        else:
+            added += 1
+            j += 1
+    return added + (len(a) - j)
+
+
+__all__ = ["MigrationPlan", "SpecEdit", "count_added_lines"]

--- a/tests/scitex_agent_container/_maintenance/test__layers_migration_apply.py
+++ b/tests/scitex_agent_container/_maintenance/test__layers_migration_apply.py
@@ -1,0 +1,201 @@
+"""Tests for the transactional to_home_layers apply.
+
+The behaviour that matters is what happens when verification FAILS after the
+writes: every original must come back, and the result must say it rolled back
+rather than that it refused. A partially-applied sweep is the one outcome this
+must never produce.
+
+STX-NM002: no mocks — real files under tmp_path, and the verifier is a
+hand-rolled object with the same two attributes the real one exposes.
+STX-TQ002 / TQ007: AAA markers per test, one fact per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._maintenance._layers_migration_apply import (
+    apply_migration,
+)
+from scitex_agent_container._maintenance._layers_migration_model import (
+    MigrationPlan,
+    SpecEdit,
+)
+
+_ORIGINAL = "spec:\n  to_home: ./to_home\n"
+_MIGRATED = "spec:\n  to_home: ./to_home\n  to_home_layers: [user-shared]\n"
+
+
+class _Verdict:
+    """The two attributes ``apply_migration`` reads off a verifier."""
+
+    def __init__(self, safe: bool) -> None:
+        self.safe = safe
+
+    def summary(self) -> str:
+        return "safe" if self.safe else "1 agent(s) LOST hooks"
+
+
+def _plan(tmp_path: Path, agents=("a", "b")) -> MigrationPlan:
+    edits = []
+    for name in agents:
+        p = tmp_path / f"{name}.yaml"
+        p.write_text(_ORIGINAL)
+        edits.append(
+            SpecEdit(
+                agent=name,
+                path=p,
+                layers=("user-shared",),
+                new_text=_MIGRATED,
+                lines_added=1,
+            )
+        )
+    return MigrationPlan(edits=tuple(edits))
+
+
+def test_a_verified_apply_writes_the_specs(tmp_path: Path) -> None:
+    # Arrange
+    plan = _plan(tmp_path)
+    # Act
+    apply_migration(plan, tmp_path / "archive", lambda: _Verdict(True))
+    # Assert
+    assert (tmp_path / "a.yaml").read_text() == _MIGRATED
+
+
+def test_a_verified_apply_reports_applied(tmp_path: Path) -> None:
+    # Arrange
+    plan = _plan(tmp_path)
+    # Act
+    result = apply_migration(plan, tmp_path / "archive", lambda: _Verdict(True))
+    # Assert
+    assert result.applied is True
+
+
+def test_a_failed_verification_restores_every_original(tmp_path: Path) -> None:
+    # Arrange — the whole reason the archive is written before the first byte.
+    plan = _plan(tmp_path)
+    # Act
+    apply_migration(plan, tmp_path / "archive", lambda: _Verdict(False))
+    # Assert
+    assert [(tmp_path / f"{n}.yaml").read_text() for n in ("a", "b")] == [
+        _ORIGINAL,
+        _ORIGINAL,
+    ]
+
+
+def test_a_failed_verification_reports_rolled_back(tmp_path: Path) -> None:
+    # Arrange
+    plan = _plan(tmp_path)
+    # Act
+    result = apply_migration(plan, tmp_path / "archive", lambda: _Verdict(False))
+    # Assert
+    assert result.rolled_back is not None
+
+
+def test_a_rollback_is_not_reported_as_a_refusal(tmp_path: Path) -> None:
+    # Arrange — refusing BEFORE writing and undoing AFTER leave the filesystem
+    # identical but mean very different things.
+    plan = _plan(tmp_path)
+    # Act
+    result = apply_migration(plan, tmp_path / "archive", lambda: _Verdict(False))
+    # Assert
+    assert result.refused is None
+
+
+def test_a_rollback_is_not_applied(tmp_path: Path) -> None:
+    # Arrange
+    plan = _plan(tmp_path)
+    # Act
+    result = apply_migration(plan, tmp_path / "archive", lambda: _Verdict(False))
+    # Assert
+    assert result.applied is False
+
+
+def test_the_rollback_message_carries_the_verifier_detail(tmp_path: Path) -> None:
+    # Arrange — an operator must learn WHY, not just that it undid itself.
+    plan = _plan(tmp_path)
+    # Act
+    result = apply_migration(plan, tmp_path / "archive", lambda: _Verdict(False))
+    # Assert
+    assert "LOST hooks" in (result.rolled_back or "")
+
+
+def test_an_unsafe_plan_is_refused_before_writing(tmp_path: Path) -> None:
+    # Arrange — a malformed edit means the plan does not describe reality.
+    plan = _plan(tmp_path)
+    bad = MigrationPlan(
+        edits=tuple(
+            SpecEdit(
+                agent=e.agent,
+                path=e.path,
+                layers=e.layers,
+                new_text=e.new_text,
+                lines_added=4,
+            )
+            for e in plan.edits
+        )
+    )
+    # Act
+    apply_migration(bad, tmp_path / "archive", lambda: _Verdict(True))
+    # Assert
+    assert (tmp_path / "a.yaml").read_text() == _ORIGINAL
+
+
+def test_an_unsafe_plan_reports_refused(tmp_path: Path) -> None:
+    # Arrange
+    plan = _plan(tmp_path)
+    bad = MigrationPlan(
+        edits=tuple(
+            SpecEdit(
+                agent=e.agent,
+                path=e.path,
+                layers=e.layers,
+                new_text=e.new_text,
+                lines_added=4,
+            )
+            for e in plan.edits
+        )
+    )
+    # Act
+    result = apply_migration(bad, tmp_path / "archive", lambda: _Verdict(True))
+    # Assert
+    assert result.refused is not None
+
+
+def test_a_plan_with_nothing_to_write_is_refused(tmp_path: Path) -> None:
+    # Arrange — an empty sweep is a mistake worth naming, not a silent success.
+    # Act
+    result = apply_migration(
+        MigrationPlan(), tmp_path / "archive", lambda: _Verdict(True)
+    )
+    # Assert
+    assert result.refused == "plan would write nothing"
+
+
+def test_the_archive_keeps_both_specs_despite_shared_basenames(
+    tmp_path: Path,
+) -> None:
+    # Arrange — real specs are all named spec.yaml; a flat copy would keep one.
+    a = tmp_path / "agent-a"
+    a.mkdir()
+    b = tmp_path / "agent-b"
+    b.mkdir()
+    edits = []
+    for name, d in (("a", a), ("b", b)):
+        p = d / "spec.yaml"
+        p.write_text(_ORIGINAL)
+        edits.append(
+            SpecEdit(
+                agent=name,
+                path=p,
+                layers=("user-shared",),
+                new_text=_MIGRATED,
+                lines_added=1,
+            )
+        )
+    plan = MigrationPlan(edits=tuple(edits))
+    archive = tmp_path / "archive"
+    # Act
+    apply_migration(plan, archive, lambda: _Verdict(False))
+    # Assert
+    assert len(list(archive.iterdir())) == 2

--- a/tests/scitex_agent_container/_maintenance/test__layers_migration_model.py
+++ b/tests/scitex_agent_container/_maintenance/test__layers_migration_model.py
@@ -1,0 +1,149 @@
+"""Tests for the ``to_home_layers`` sweep plan (``_layers_migration_model``).
+
+The plan IS the dry-run, so these pin what it must not blur: a refusal is a
+legitimate named outcome, a malformed edit is a defect, and the two must not
+be conflated into one "needs attention" bucket.
+
+STX-NM002: no mocks — pure values in, dataclass out.
+STX-TQ002 / TQ007: AAA markers per test, one fact per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._maintenance._layers_migration_model import (
+    MigrationPlan,
+    SpecEdit,
+    count_added_lines,
+)
+
+
+def _edit(agent="a", new_text="x\n", refusal=None, lines_added=1) -> SpecEdit:
+    return SpecEdit(
+        agent=agent,
+        path=Path(f"/specs/{agent}.yaml"),
+        layers=("user-shared",),
+        new_text=new_text,
+        refusal=refusal,
+        lines_added=lines_added,
+    )
+
+
+def test_a_clean_edit_will_write() -> None:
+    # Arrange
+    edit = _edit()
+    # Act
+    plan = MigrationPlan(edits=(edit,))
+    # Assert
+    assert plan.writable == (edit,)
+
+
+def test_a_refused_spec_will_not_write() -> None:
+    # Arrange — refused because the editor did not recognise its shape.
+    edit = _edit(refusal="no to_home: anchor", new_text=None)
+    # Act
+    plan = MigrationPlan(edits=(edit,))
+    # Assert
+    assert plan.writable == ()
+
+
+def test_a_refused_spec_is_named_not_dropped() -> None:
+    # Arrange — silently skipping is how "101 of 102" goes unnoticed.
+    edit = _edit(agent="scitex-todo", refusal="no anchor", new_text=None)
+    # Act
+    plan = MigrationPlan(edits=(edit,))
+    # Assert
+    assert plan.refused[0].agent == "scitex-todo"
+
+
+def test_refusals_alone_keep_the_plan_safe_to_apply() -> None:
+    # Arrange — a named, counted refusal is a legitimate outcome for a human.
+    edit = _edit(refusal="no anchor", new_text=None)
+    # Act
+    plan = MigrationPlan(edits=(edit,))
+    # Assert
+    assert plan.safe_to_apply is True
+
+
+def test_a_multi_line_edit_is_malformed() -> None:
+    # Arrange — the editor accepted the shape then produced an unasked-for diff.
+    edit = _edit(lines_added=3)
+    # Act
+    plan = MigrationPlan(edits=(edit,))
+    # Assert
+    assert plan.malformed == (edit,)
+
+
+def test_a_malformed_edit_makes_the_plan_unsafe() -> None:
+    # Arrange
+    edit = _edit(lines_added=3)
+    # Act
+    plan = MigrationPlan(edits=(edit,))
+    # Assert
+    assert plan.safe_to_apply is False
+
+
+def test_a_malformed_edit_is_not_reported_as_a_refusal() -> None:
+    # Arrange — conflating them lets a real defect read as "needs attention".
+    edit = _edit(lines_added=3)
+    # Act
+    plan = MigrationPlan(edits=(edit,))
+    # Assert
+    assert plan.refused == ()
+
+
+def test_an_unreadable_spec_makes_the_plan_unsafe() -> None:
+    # Arrange — the plan does not describe what would actually happen.
+    # Act
+    plan = MigrationPlan(edits=(), unreadable=("broken",))
+    # Assert
+    assert plan.safe_to_apply is False
+
+
+def test_summary_names_the_refused_agent() -> None:
+    # Arrange
+    edit = _edit(agent="scitex-todo", refusal="no anchor", new_text=None)
+    # Act
+    plan = MigrationPlan(edits=(edit,))
+    # Assert
+    assert "scitex-todo" in plan.summary()
+
+
+def test_a_single_inserted_line_counts_as_one() -> None:
+    # Arrange
+    before = "a\nb\n"
+    after = "a\nNEW\nb\n"
+    # Act
+    added = count_added_lines(before, after)
+    # Assert
+    assert added == 1
+
+
+def test_an_unchanged_file_counts_as_zero() -> None:
+    # Arrange
+    text = "a\nb\n"
+    # Act
+    added = count_added_lines(text, text)
+    # Assert
+    assert added == 0
+
+
+def test_a_duplicated_line_is_counted_not_ignored() -> None:
+    # Arrange — a set difference would call this "no change at all".
+    before = "a\nb\n"
+    after = "a\na\nb\n"
+    # Act
+    added = count_added_lines(before, after)
+    # Assert
+    assert added == 1
+
+
+def test_a_removed_line_counts_negative() -> None:
+    # Arrange — a shrinking file must never look like a clean insert.
+    before = "a\nb\n"
+    after = "a\n"
+    # Act
+    added = count_added_lines(before, after)
+    # Assert
+    assert added == -1


### PR DESCRIPTION
The migration adds one declaration line to ~101 hand-maintained `spec.yaml` files. This is the machinery for it — a plan you can read, and an apply that undoes itself. **Neither is wired to a CLI verb, so nothing runs implicitly.**

## The plan is a value, not a print

A dry-run that *prints* its intentions satisfies nothing downstream — no caller can refuse to proceed on a printout. `MigrationPlan` is what the applying half consumes, and it declines to blur two outcomes that look alike:

| | meaning | makes plan unsafe? |
|---|---|---|
| **REFUSED** | the editor didn't recognise this spec's shape — correct behaviour, and *named* | no |
| **MALFORMED** | the editor *accepted* the shape then produced a diff nobody asked for | **yes** |

Silently skipping is how a sweep reports "101 done" across 102 specs and the one goes unnoticed. Folding a malformed edit into "refused" would let a real defect read as one more spec needing manual attention.

`count_added_lines` compares **sequences, not sets**. A set difference calls a moved line unchanged and a duplicated line no-change-at-all — precisely the damage a careless YAML edit does. A shrinking file returns a negative count so it can never pass as a clean insert.

## The apply is transactional, because "check then write" wasn't available

Two failure modes are invisible to any per-file check: the plan being wrong, and edits that are individually fine while changing what an agent **arms**. The second only becomes visible *after* writing, by re-deriving hook arming from the migrated specs.

```
1. refuse unless plan.safe_to_apply
2. archive to .old/<ts>/        <- rollback exists before byte one
3. write
4. re-derive hook arming, diff vs the pre-write snapshot   (#917)
5. not safe -> RESTORE, report ROLLED BACK
```

The archive isn't a courtesy copy — it *is* the rollback path. Without it the post-write gate could only report damage already done.

`refused` and `rolled_back` are separate fields: both leave the filesystem untouched, but refusing before writing and undoing after mean different things about what was learned. `applied` is true only when edits were written **and** survived verification.

The archive is keyed by **agent name** — every real spec is `spec.yaml`, so a flat copy would silently keep one of 101, inviting a rollback that cannot complete. A rollback that can't find an original logs at ERROR naming the agent left migrated.

`verify` is **injected**, not imported: this module holds no opinion about what is verified, only that something must be.

## Verified against the live registry

```
101 spec(s) would be written; 1 REFUSED (scitex-todo)
  MALFORMED     : 0
  unreadable    : 0
  SAFE TO APPLY : True
     65  ['user-shared']
     36  ['user-shared', 'per-agent']
```

24 tests, no mocks — real files in `tmp_path`, including that a failed verification restores **every** original and that two specs sharing the basename `spec.yaml` both survive in the archive.
