### PR TITLE
feat(installation): add `sac installation check` — install-integrity guard

### DIFF
--- a/src/scitex_agent_container/_maintenance/__init__.py
+++ b/src/scitex_agent_container/_maintenance/__init__.py
@@ -1,12 +1,17 @@
 """Host-hygiene maintenance rails that run on a schedule, not on a whim.
 
-Two concerns live here:
+Three concerns live here:
 
 * **git worktree sprawl** (:mod:`._worktree_gc`), the standing liability
   behind the incident card ``incident-worktree-sprawl-permanent-gc-20260710``
   — one repo reached 105 worktrees and helped trigger a host load-spike.
 * **overlay masking of base-baked packages** (:mod:`._overlay_masking`),
   surfaced per-agent in ``sac agents check-health``.
+* **install integrity** (:mod:`._install_integrity_probe`), surfaced as
+  ``sac installation check`` — dead/shadowed editable pointers, orphaned
+  and duplicated dist-info. Twice now (2026-07-16, 2026-08-09) an agent
+  has executed code from a deleted or abandoned tree while ``--version``
+  reported a healthy number; only path-level inspection exposes it.
 
 The shape every rail in this package follows, learned from
 ``_hostsync``:
@@ -20,6 +25,35 @@ The shape every rail in this package follows, learned from
   never crashes the maintenance pass that feeds it.
 """
 
+from ._install_integrity_model import (
+    IMPORTS_LIVE,
+    IMPORTS_UNAVAILABLE,
+    REASON_DEAD_POINTER,
+    REASON_DUPLICATE_DIST_INFO,
+    REASON_ORPHANED_DIST_INFO,
+    REASON_RESOLVES_OUTSIDE,
+    REASON_SHADOWED_POINTER,
+    STATE_BROKEN,
+    STATE_OK,
+    STATE_UNKNOWN,
+    DistributionEvidence,
+    DistributionVerdict,
+    EditablePointer,
+    InstallIntegrityReport,
+    SiteEvidence,
+)
+from ._install_integrity_predicate import (
+    build_report,
+    classify_distribution,
+)
+from ._install_integrity_predicate import (
+    exit_code_for as install_integrity_exit_code,
+)
+from ._install_integrity_probe import (
+    inspect_install,
+    read_site_evidence,
+    resolve_site_packages,
+)
 from ._overlay_masking import (
     base_package_set_for,
     inspect_agent_overlay,
@@ -55,9 +89,30 @@ from ._worktree_gc_repos import discover_repos, spec_workdirs
 __all__ = [
     "DEFAULT_CAP",
     "DEFAULT_MIN_AGE_HOURS",
+    "IMPORTS_LIVE",
+    "IMPORTS_UNAVAILABLE",
     "OPERATIONAL_RULE",
+    "REASON_DEAD_POINTER",
+    "REASON_DUPLICATE_DIST_INFO",
+    "REASON_ORPHANED_DIST_INFO",
+    "REASON_RESOLVES_OUTSIDE",
+    "REASON_SHADOWED_POINTER",
+    "STATE_BROKEN",
+    "STATE_OK",
+    "STATE_UNKNOWN",
     "BasePackageSet",
+    "DistributionEvidence",
+    "DistributionVerdict",
+    "EditablePointer",
     "GcOutcome",
+    "InstallIntegrityReport",
+    "SiteEvidence",
+    "build_report",
+    "classify_distribution",
+    "inspect_install",
+    "install_integrity_exit_code",
+    "read_site_evidence",
+    "resolve_site_packages",
     "OverlayMaskVerdict",
     "RepoGcResult",
     "ShadowInstall",

--- a/src/scitex_agent_container/_maintenance/_install_integrity_model.py
+++ b/src/scitex_agent_container/_maintenance/_install_integrity_model.py
@@ -1,0 +1,345 @@
+"""Data + vocabulary for install-integrity. No subprocess, no I/O.
+
+The types every other ``_install_integrity*`` module speaks in, kept apart
+from the code that observes the world (:mod:`._install_integrity_probe`)
+and the code that decides (:mod:`._install_integrity_predicate`) — the
+same split :mod:`._worktree_gc_model` uses.
+
+WHY THIS EXISTS — two recurrences of ONE failure class, where the code an
+agent executes is not the code anybody believes is installed:
+
+* 2026-07-16 (scitex-dev container): site-packages held an orphaned
+  ``scitex_dev-0.31.0.dist-info/`` with no code behind it, plus an
+  ``__editable__.scitex_dev-....pth`` redirecting imports into an
+  ABANDONED PR scratch worktree. Commands ran from a disposable temp
+  directory for days.
+* 2026-08-09 (sac container, ``/opt/venv-sac``):
+  ``_editable_impl_scitex_agent_container.pth`` points at
+  ``.worktrees/persist-boot-failure-diag/.worktrees/agent-aae4c0d9a337e71b6/src``
+  — a path that no longer exists, on a branch that no longer exists. A
+  REAL ``scitex_agent_container/`` directory sits in site-packages next to
+  it, so every import succeeds and ``sac --version`` reports 0.24.25
+  happily, while the editable pointer — the thing that was supposed to
+  propagate new code — has been inert the whole time.
+
+THE OBVIOUS PREDICATE IS NOT ENOUGH. "Flag anything whose ``__file__``
+resolves outside site-packages" catches July and calls August CLEAN,
+because the shadowing copy makes ``__file__`` resolve INSIDE
+site-packages. ``--version`` is useless for the entire class (confirmed
+twice) — only path-level inspection exposes it. Hence five reasons, not
+one, and a state that is allowed to say "I could not tell".
+
+The reason strings below are API, not debug text: they land in
+``sac installation check --json`` and in the console report.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ._overlay_masking_model import canonical_dist_name
+
+__all__ = [
+    "IMPORTS_LIVE",
+    "IMPORTS_UNAVAILABLE",
+    "POINTER_FINDER",
+    "POINTER_PTH_IMPORT",
+    "POINTER_PTH_PATH",
+    "REASON_DEAD_POINTER",
+    "REASON_DUPLICATE_DIST_INFO",
+    "REASON_ORDER",
+    "REASON_ORPHANED_DIST_INFO",
+    "REASON_RESOLVES_OUTSIDE",
+    "REASON_SHADOWED_POINTER",
+    "STATE_BROKEN",
+    "STATE_OK",
+    "STATE_UNKNOWN",
+    "UNKNOWN_DIST_ABSENT",
+    "UNKNOWN_NO_DIST_INFO",
+    "UNKNOWN_OWNERSHIP_UNKNOWN",
+    "UNKNOWN_POINTER_UNPARSABLE",
+    "UNKNOWN_READ_ERROR",
+    "UNKNOWN_SITE_UNREADABLE",
+    "UNKNOWN_TARGET_UNSTATABLE",
+    "DistributionEvidence",
+    "DistributionVerdict",
+    "EditablePointer",
+    "InstallIntegrityReport",
+    "SiteEvidence",
+    "canonical_dist_name",
+]
+
+# --------------------------------------------------------------------------
+# States. THREE-VALUED, and UNKNOWN never collapses into either pole:
+# it is the absence of evidence, reported as loudly as a failure. A check
+# that cannot say "I could not tell" is worse than no check, because it
+# launders ignorance into a green tick.
+# --------------------------------------------------------------------------
+STATE_OK = "ok"
+STATE_BROKEN = "broken"
+STATE_UNKNOWN = "unknown"
+
+# --------------------------------------------------------------------------
+# BROKEN reasons. Each one is a shape that has actually shipped.
+# --------------------------------------------------------------------------
+#: The imported module resolves outside site-packages and NO live editable
+#: pointer for this distribution explains it — an unexplained redirect (a
+#: worktree winning on PYTHONPATH, a stray .pth from another dist).
+#: Qualified on purpose: an editable install resolving to its OWN live
+#: target is what an editable install IS, and flagging that would make the
+#: check scream on every healthy dev venv. The July shape is still caught,
+#: by ORPHANED_DIST_INFO (and by DEAD_POINTER once the scratch tree goes).
+REASON_RESOLVES_OUTSIDE = "resolves-outside-site-packages"
+
+#: An editable pointer exists whose target path does NOT exist. Whatever
+#: that pointer was supposed to serve is served by nothing.
+REASON_DEAD_POINTER = "dead-pointer"
+
+#: An editable pointer AND a real package directory both exist for the
+#: same distribution. The copy WINS and the pointer is inert, so imports
+#: succeed and propagation is silently dead. The August 2026 shape — the
+#: one a ``__file__``-outside-site-packages check reports as clean.
+REASON_SHADOWED_POINTER = "shadowed-pointer"
+
+#: A dist-info is present with no code behind it: nothing in
+#: site-packages, and no live pointer serving it from elsewhere. It keeps
+#: advertising a version whose code is gone.
+REASON_ORPHANED_DIST_INFO = "orphaned-dist-info"
+
+#: More than one dist-info for the same distribution. One of them is a
+#: fossil. (Prior instance: two ``scitex_cards`` dist-info dirs, 0.17.5
+#: and 0.17.7, in one site-packages.)
+REASON_DUPLICATE_DIST_INFO = "duplicate-dist-info"
+
+#: Deterministic render/serialise order — never set-iteration order.
+REASON_ORDER = (
+    REASON_RESOLVES_OUTSIDE,
+    REASON_DEAD_POINTER,
+    REASON_SHADOWED_POINTER,
+    REASON_ORPHANED_DIST_INFO,
+    REASON_DUPLICATE_DIST_INFO,
+)
+
+# --------------------------------------------------------------------------
+# UNKNOWN reasons. Never folded into OK ("nothing found, looks fine") nor
+# into BROKEN ("can't read it, call it broken") — both are lies, with
+# different signs.
+# --------------------------------------------------------------------------
+UNKNOWN_SITE_UNREADABLE = "site-packages-unreadable"
+UNKNOWN_DIST_ABSENT = "distribution-absent"
+UNKNOWN_READ_ERROR = "distribution-unreadable"
+UNKNOWN_OWNERSHIP_UNKNOWN = "owned-modules-undeterminable"
+UNKNOWN_POINTER_UNPARSABLE = "pointer-target-unparsable"
+UNKNOWN_TARGET_UNSTATABLE = "pointer-target-unstatable"
+UNKNOWN_NO_DIST_INFO = "no-dist-info-for-pointer"
+
+# --------------------------------------------------------------------------
+# Editable-pointer shapes pip / uv / setuptools actually emit.
+# --------------------------------------------------------------------------
+#: ``__editable__*.pth`` / ``*_editable_impl_*.pth`` / a plain ``.pth``
+#: holding a bare absolute path on its own line.
+POINTER_PTH_PATH = "pth-path"
+#: A ``.pth`` whose line is an ``import __editable___x_finder; ...install()``
+#: statement — the path lives in the finder module it names.
+POINTER_PTH_IMPORT = "pth-import"
+#: ``__editable___*_finder.py`` — its MAPPING dict maps module -> real dir.
+POINTER_FINDER = "finder-module"
+
+# --------------------------------------------------------------------------
+# Whether import resolution was observable at all.
+# --------------------------------------------------------------------------
+#: The inspected site-packages IS the running interpreter's, so where an
+#: import really lands is observable.
+IMPORTS_LIVE = "live"
+#: A foreign venv was inspected. Its import resolution cannot be observed
+#: from here, so REASON_RESOLVES_OUTSIDE is NEVER decided; the other four
+#: reasons are pure path-level facts and stay fully decidable.
+IMPORTS_UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class EditablePointer:
+    """One redirect file found in site-packages, as observed.
+
+    ``target_exists`` is deliberately tri-state: ``None`` means the stat
+    itself failed (permissions, a dangling mount), which is UNKNOWN — not
+    "the target is missing", which would be a fabricated BROKEN.
+    """
+
+    path: str  # the .pth / *_finder.py file itself
+    shape: str  # one POINTER_* token
+    target: str = ""  # absolute path it redirects to; "" = unparsable
+    target_exists: bool | None = None
+
+    @property
+    def dead(self) -> bool:
+        """Parsed a target, and it provably is not there."""
+        return bool(self.target) and self.target_exists is False
+
+    @property
+    def live(self) -> bool:
+        """Parsed a target, and it provably IS there."""
+        return bool(self.target) and self.target_exists is True
+
+    def to_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "shape": self.shape,
+            "target": self.target,
+            "target_exists": self.target_exists,
+        }
+
+
+@dataclass(frozen=True)
+class DistributionEvidence:
+    """Everything the probe saw on disk about ONE distribution.
+
+    This is the decision layer's whole input surface. Building one by hand
+    is how the tests reach every reason without constructing a real venv.
+    """
+
+    name: str  # canonical dist name
+    dist_infos: tuple[str, ...] = ()  # every *.dist-info / *.egg-info dir
+    top_level_names: tuple[str, ...] = ()  # modules the dist claims to own
+    top_level_known: bool = False  # False -> ownership undeterminable
+    code_paths: tuple[str, ...] = ()  # of those, what really exists INSIDE site
+    pointers: tuple[EditablePointer, ...] = ()
+    declared_editable: bool = False  # PEP 610 direct_url.json says editable
+    imported_path: str = ""  # where `import <top-level>` really landed
+    import_resolution_known: bool = False
+    absent: bool = False  # asked for by name; nothing found at all
+    read_error: str = ""  # this dist's metadata could not be read
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "dist_infos": list(self.dist_infos),
+            "top_level_names": list(self.top_level_names),
+            "top_level_known": self.top_level_known,
+            "code_paths": list(self.code_paths),
+            "pointers": [p.to_dict() for p in self.pointers],
+            "declared_editable": self.declared_editable,
+            "imported_path": self.imported_path,
+            "import_resolution_known": self.import_resolution_known,
+            "absent": self.absent,
+            "read_error": self.read_error,
+        }
+
+
+@dataclass(frozen=True)
+class DistributionVerdict:
+    """Tri-state verdict for one distribution; UNKNOWN never reads OK.
+
+    ``reasons`` is a TUPLE, not a single token, because the shapes really
+    do co-occur: the August case is SHADOWED_POINTER *and* DEAD_POINTER at
+    once, and reporting only the first would hide half the repair.
+    """
+
+    name: str
+    state: str  # STATE_OK | STATE_BROKEN | STATE_UNKNOWN
+    reasons: tuple[str, ...] = ()
+    unknown_reasons: tuple[str, ...] = ()
+    details: tuple[str, ...] = ()
+    evidence: DistributionEvidence | None = None
+
+    @property
+    def broken(self) -> bool:
+        return self.state == STATE_BROKEN
+
+    @property
+    def unknown(self) -> bool:
+        return self.state == STATE_UNKNOWN
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "state": self.state,
+            "reasons": list(self.reasons),
+            "unknown_reasons": list(self.unknown_reasons),
+            "details": list(self.details),
+            "evidence": self.evidence.to_dict() if self.evidence else None,
+        }
+
+
+@dataclass(frozen=True)
+class SiteEvidence:
+    """One site-packages directory as observed, plus its distributions."""
+
+    site_packages: str
+    readable: bool = True
+    read_error: str = ""
+    venv: str = ""
+    import_resolution: str = IMPORTS_UNAVAILABLE
+    note: str = ""  # e.g. several site-packages matched; which one we took
+    distributions: tuple[DistributionEvidence, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class InstallIntegrityReport:
+    """The whole pass over one site-packages. Never a bare bool."""
+
+    site_packages: str
+    venv: str = ""
+    site_state: str = STATE_OK
+    site_detail: str = ""
+    import_resolution: str = IMPORTS_UNAVAILABLE
+    note: str = ""
+    verdicts: tuple[DistributionVerdict, ...] = ()
+
+    @property
+    def broken(self) -> tuple[DistributionVerdict, ...]:
+        return tuple(v for v in self.verdicts if v.broken)
+
+    @property
+    def unknown(self) -> tuple[DistributionVerdict, ...]:
+        return tuple(v for v in self.verdicts if v.unknown)
+
+    @property
+    def ok(self) -> tuple[DistributionVerdict, ...]:
+        return tuple(v for v in self.verdicts if v.state == STATE_OK)
+
+    @property
+    def site_unknown(self) -> bool:
+        """The directory itself could not be read — no verdict is possible."""
+        return self.site_state == STATE_UNKNOWN
+
+    def reason_breakdown(self) -> dict[str, int]:
+        """``{"shadowed-pointer": 1, "duplicate-dist-info": 2}`` — WHY.
+
+        "3 broken" tells an operator nothing; the breakdown tells them
+        which repair each one needs.
+        """
+        counts: dict[str, int] = {}
+        for verdict in self.verdicts:
+            for reason in verdict.reasons:
+                counts[reason] = counts.get(reason, 0) + 1
+        return {r: counts[r] for r in REASON_ORDER if r in counts}
+
+    def summary_line(self) -> str:
+        parts = [
+            f"{len(self.verdicts)} distribution(s)",
+            f"{len(self.ok)} ok",
+            f"{len(self.broken)} BROKEN",
+            f"{len(self.unknown)} UNKNOWN",
+        ]
+        if self.import_resolution != IMPORTS_LIVE:
+            parts.append("import-resolution UNOBSERVABLE")
+        return ", ".join(parts)
+
+    def to_dict(self) -> dict:
+        return {
+            "site_packages": self.site_packages,
+            "venv": self.venv,
+            "site_state": self.site_state,
+            "site_detail": self.site_detail,
+            "import_resolution": self.import_resolution,
+            "note": self.note,
+            "counts": {
+                "total": len(self.verdicts),
+                "ok": len(self.ok),
+                "broken": len(self.broken),
+                "unknown": len(self.unknown),
+            },
+            "reason_breakdown": self.reason_breakdown(),
+            "distributions": [v.to_dict() for v in self.verdicts],
+        }

--- a/src/scitex_agent_container/_maintenance/_install_integrity_pointers.py
+++ b/src/scitex_agent_container/_maintenance/_install_integrity_pointers.py
@@ -1,0 +1,264 @@
+"""Editable-pointer discovery + parsing — every shape pip/uv/setuptools emit.
+
+An "editable pointer" is any file in site-packages that redirects imports
+somewhere else on disk. There is no single format: the tooling has emitted
+at least four shapes, and a guard that knows only one of them reports the
+other three as clean.
+
+  __editable__.<name>-<ver>.pth        setuptools "compat" mode — one bare
+                                       absolute path on a line
+  __editable__.<name>-<ver>.pth        setuptools "strict" mode — instead an
+                                       ``import __editable___..._finder;
+                                       ...install()`` exec line
+  __editable___<name>_<ver>_finder.py  the module that exec line names; the
+                                       real paths live in its MAPPING dict
+  _editable_impl_<name>.pth            uv / hatchling — one bare absolute
+                                       path (the /opt/venv-sac shape)
+  <anything>.pth                       a plain path-adding .pth
+
+Parsing is deliberately STATIC: the finder module is read with
+:mod:`ast`, never imported or ``exec``'d. These files are the ones we
+already suspect of pointing at abandoned trees; running them to find out
+where they point is exactly the wrong instinct.
+
+Only the two ``exists``-flavoured helpers touch the filesystem; everything
+else is string/AST work, so the shapes can be tested from literal text.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import re
+from pathlib import Path
+
+from ._install_integrity_model import (
+    POINTER_FINDER,
+    POINTER_PTH_IMPORT,
+    POINTER_PTH_PATH,
+    EditablePointer,
+    canonical_dist_name,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "EDITABLE_PTH_MARKERS",
+    "candidate_dist_names",
+    "collect_pointers",
+    "finder_targets",
+    "is_editable_pth_name",
+    "pth_targets",
+    "target_exists",
+]
+
+#: A ``.pth`` whose NAME carries one of these is an editable pointer even
+#: when we cannot parse a target out of it — that unparsable state is a
+#: reportable UNKNOWN, not something to drop on the floor. A plain ``.pth``
+#: without one of these markers is only a pointer if it really does carry
+#: an absolute path (which is what keeps coverage/site hooks out).
+EDITABLE_PTH_MARKERS = ("__editable__", "_editable_impl_", "editable")
+
+_FINDER_RE = re.compile(r"__editable___\w+_finder")
+#: Trailing ``_0_31_0``-style version segments a finder filename embeds.
+_TRAILING_VERSION_RE = re.compile(r"(?:_\d+)+$")
+
+
+def _content_lines(text: str) -> list[str]:
+    """Non-blank, non-comment lines — how ``site.py`` reads a ``.pth``."""
+    out = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line and not line.startswith("#"):
+            out.append(line)
+    return out
+
+
+def is_editable_pth_name(name: str) -> bool:
+    """Does this ``.pth`` filename advertise itself as an editable pointer?"""
+    lowered = name.lower()
+    return any(marker in lowered for marker in EDITABLE_PTH_MARKERS)
+
+
+def pth_targets(text: str) -> list[tuple[str, str]]:
+    """``.pth`` content -> ``[(shape, target_or_finder_module), ...]``.
+
+    Two shapes come out of here. A bare ABSOLUTE path line is a
+    :data:`POINTER_PTH_PATH` whose target is that path. An ``import
+    __editable___x_finder; ...`` exec line is a :data:`POINTER_PTH_IMPORT`
+    whose "target" is the finder MODULE NAME — the caller resolves it to
+    real paths via :func:`finder_targets`.
+
+    Exec lines that name no finder (coverage bootstraps, ``site`` hooks)
+    yield nothing: they redirect no imports, and reporting them would bury
+    the real findings under noise every venv has.
+    """
+    found: list[tuple[str, str]] = []
+    for line in _content_lines(text):
+        if line.startswith(("import ", "import\t")):
+            match = _FINDER_RE.search(line)
+            if match:
+                found.append((POINTER_PTH_IMPORT, match.group(0)))
+            continue
+        # site.py treats any other line as a path to add to sys.path. Only
+        # absolute ones are unambiguous evidence of a redirect.
+        if line.startswith("/"):
+            found.append((POINTER_PTH_PATH, line))
+    return found
+
+
+def finder_targets(text: str) -> list[str]:
+    """``__editable___*_finder.py`` source -> the real directories it maps to.
+
+    Reads the module's ``MAPPING``/``NAMESPACES`` dict literals with
+    :func:`ast.literal_eval`. Never imports or execs the file.
+    """
+    # stx-allow: fallback (reason: a finder module we cannot parse must degrade to "no targets" -> an UNKNOWN leg, never crash the check that exists to read it)
+    try:
+        tree = ast.parse(text)
+    except (SyntaxError, ValueError) as exc:
+        logger.debug("install-integrity: unparsable finder module: %s", exc)
+        return []
+    targets: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        names = {t.id for t in node.targets if isinstance(t, ast.Name)}
+        if not names & {"MAPPING", "NAMESPACES"}:
+            continue
+        try:
+            value = ast.literal_eval(node.value)
+        except (
+            ValueError,
+            SyntaxError,
+        ):  # stx-allow: fallback (reason: a non-literal MAPPING is unreadable evidence, not a crash)
+            continue
+        if isinstance(value, dict):
+            targets.extend(str(v) for v in value.values() if v)
+    # Preserve first-seen order, drop repeats.
+    return list(dict.fromkeys(targets))
+
+
+def candidate_dist_names(filename: str) -> list[str]:
+    """Pointer filename -> canonical dist-name candidates, longest first.
+
+    The filename is the only attribution signal these files carry, and
+    every emitter spells it differently::
+
+        __editable__.scitex_dev-0.31.0.pth   -> scitex_dev-0.31.0
+        __editable___scitex_dev_0_31_0_finder.py -> scitex_dev_0_31_0
+        _editable_impl_scitex_agent_container.pth -> scitex_agent_container
+
+    Version fragments are not separable from name fragments by rule (an
+    underscore means both), so this returns PROGRESSIVELY SHORTER
+    prefixes and lets the caller pick the first that matches a dist it
+    actually saw. Guessing a single answer here would mis-attribute
+    pointers to distributions that do not exist.
+    """
+    stem = Path(filename).stem
+    for prefix in ("__editable___", "__editable__.", "__editable__", "_editable_impl_"):
+        if stem.startswith(prefix):
+            stem = stem[len(prefix) :]
+            break
+    if stem.endswith("_finder"):
+        stem = stem[: -len("_finder")]
+    stem = stem.split("-")[0]  # `name-1.2.3` -> `name`
+    stem = _TRAILING_VERSION_RE.sub("", stem)  # `name_1_2_3` -> `name`
+    if not stem:
+        return []
+    parts = stem.split("_")
+    return [canonical_dist_name("_".join(parts[:n])) for n in range(len(parts), 0, -1)]
+
+
+def target_exists(path: str) -> bool | None:
+    """Does ``path`` exist? ``None`` when the stat itself failed.
+
+    Tri-state on purpose: "I could not stat it" must never be recorded as
+    "it is not there", which would fabricate a DEAD_POINTER out of a
+    permissions error.
+    """
+    # stx-allow: fallback (reason: an unreadable/dangling mount must report UNKNOWN, never a fabricated "missing")
+    try:
+        return Path(path).exists()
+    except OSError as exc:
+        logger.debug("install-integrity: cannot stat %s: %s", path, exc)
+        return None
+
+
+def _finder_pointer(
+    site: Path, module_name: str, source: Path
+) -> list[EditablePointer]:
+    """Resolve a ``pth-import`` line into the finder module's real targets."""
+    finder = site / f"{module_name}.py"
+    # stx-allow: fallback (reason: an unreadable finder module is an UNKNOWN leg, reported as an unparsable pointer)
+    try:
+        text = finder.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        logger.debug("install-integrity: cannot read finder %s: %s", finder, exc)
+        return [EditablePointer(path=str(source), shape=POINTER_PTH_IMPORT, target="")]
+    targets = finder_targets(text)
+    if not targets:
+        return [EditablePointer(path=str(finder), shape=POINTER_FINDER, target="")]
+    return [
+        EditablePointer(
+            path=str(finder),
+            shape=POINTER_FINDER,
+            target=target,
+            target_exists=target_exists(target),
+        )
+        for target in targets
+    ]
+
+
+def collect_pointers(site: Path, entry_names: list[str]) -> list[EditablePointer]:
+    """Every editable pointer in ``site``, from its already-listed entries.
+
+    ``entry_names`` is passed in rather than re-listed so the probe reads
+    the directory exactly once (and so an unreadable directory is handled
+    in one place, by the caller).
+    """
+    pointers: list[EditablePointer] = []
+    listed = set(entry_names)
+    for name in sorted(entry_names):
+        if not name.endswith(".pth"):
+            continue
+        source = site / name
+        # stx-allow: fallback (reason: an unreadable .pth is evidence we could not read, reported as an unparsable pointer — never a crash)
+        try:
+            text = source.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            logger.debug("install-integrity: cannot read %s: %s", source, exc)
+            if is_editable_pth_name(name):
+                pointers.append(
+                    EditablePointer(path=str(source), shape=POINTER_PTH_PATH, target="")
+                )
+            continue
+        parsed = pth_targets(text)
+        if not parsed and is_editable_pth_name(name):
+            # Named like a pointer, target unreadable -> an honest UNKNOWN.
+            pointers.append(
+                EditablePointer(path=str(source), shape=POINTER_PTH_PATH, target="")
+            )
+            continue
+        for shape, value in parsed:
+            if shape == POINTER_PTH_IMPORT:
+                pointers.extend(_finder_pointer(site, value, source))
+            else:
+                pointers.append(
+                    EditablePointer(
+                        path=str(source),
+                        shape=shape,
+                        target=value,
+                        target_exists=target_exists(value),
+                    )
+                )
+    # A finder module with no .pth naming it still redirects nothing on its
+    # own, but its presence is evidence; pick up orphaned ones too.
+    claimed = {p.path for p in pointers}
+    for name in sorted(listed):
+        if not (name.startswith("__editable___") and name.endswith("_finder.py")):
+            continue
+        if str(site / name) in claimed:
+            continue
+        pointers.extend(_finder_pointer(site, name[: -len(".py")], site / name))
+    return pointers

--- a/src/scitex_agent_container/_maintenance/_install_integrity_predicate.py
+++ b/src/scitex_agent_container/_maintenance/_install_integrity_predicate.py
@@ -1,0 +1,268 @@
+"""DECISION for install-integrity. PURE — takes evidence, returns verdicts.
+
+Nothing here touches the filesystem: every function consumes the
+dataclasses :mod:`._install_integrity_model` defines and returns a
+verdict, so the tests reach all five reasons by constructing evidence
+rather than by building real venvs. Observation lives next door, in
+:mod:`._install_integrity_probe`.
+
+The precedence rule, stated once and applied everywhere below:
+
+* a positively-observed BROKEN reason OUTRANKS an UNKNOWN leg, because a
+  definite finding is more actionable than a gap — but the gap is still
+  carried in ``unknown_reasons``, so the report never implies the picture
+  was complete;
+* UNKNOWN outranks OK, for the same reason in reverse: never claim clean
+  off evidence we do not have.
+"""
+
+from __future__ import annotations
+
+from ._install_integrity_model import (
+    REASON_DEAD_POINTER,
+    REASON_DUPLICATE_DIST_INFO,
+    REASON_ORPHANED_DIST_INFO,
+    REASON_RESOLVES_OUTSIDE,
+    REASON_SHADOWED_POINTER,
+    STATE_BROKEN,
+    STATE_OK,
+    STATE_UNKNOWN,
+    UNKNOWN_DIST_ABSENT,
+    UNKNOWN_NO_DIST_INFO,
+    UNKNOWN_OWNERSHIP_UNKNOWN,
+    UNKNOWN_POINTER_UNPARSABLE,
+    UNKNOWN_READ_ERROR,
+    UNKNOWN_TARGET_UNSTATABLE,
+    DistributionEvidence,
+    DistributionVerdict,
+    InstallIntegrityReport,
+    SiteEvidence,
+)
+
+__all__ = [
+    "build_report",
+    "classify_distribution",
+    "exit_code_for",
+    "is_under",
+]
+
+
+def is_under(child: str, parent: str) -> bool:
+    """Path containment on plain strings — no filesystem access.
+
+    Both sides are compared with a trailing separator appended, so
+    ``/a/bc`` is never read as living under ``/a/b``.
+    """
+    if not child or not parent:
+        return False
+    child_n = child.rstrip("/")
+    parent_n = parent.rstrip("/")
+    return child_n == parent_n or child_n.startswith(parent_n + "/")
+
+
+def _explained_by_live_pointer(ev: DistributionEvidence) -> bool:
+    """Is the out-of-site import path served by this dist's OWN live pointer?
+
+    That is exactly what a healthy editable install looks like, and it
+    must not be reported as an unexplained redirect.
+    """
+    return any(p.live and is_under(ev.imported_path, p.target) for p in ev.pointers)
+
+
+def _check_resolves_outside(
+    ev: DistributionEvidence, site_packages: str
+) -> tuple[str, str] | None:
+    if not ev.import_resolution_known or not ev.imported_path:
+        return None
+    if is_under(ev.imported_path, site_packages):
+        return None
+    if _explained_by_live_pointer(ev):
+        return None
+    return (
+        REASON_RESOLVES_OUTSIDE,
+        f"imports resolve to {ev.imported_path}, outside {site_packages}, and no "
+        f"live editable pointer for {ev.name} explains it — the running code is "
+        f"not the installed code",
+    )
+
+
+def _check_dead_pointer(ev: DistributionEvidence) -> tuple[str, str] | None:
+    dead = [p for p in ev.pointers if p.dead]
+    if not dead:
+        return None
+    listed = ", ".join(f"{p.path} -> {p.target}" for p in dead)
+    return (
+        REASON_DEAD_POINTER,
+        f"{len(dead)} editable pointer(s) target a path that does not exist: "
+        f"{listed} — whatever they were meant to serve is served by nothing",
+    )
+
+
+def _check_shadowed_pointer(ev: DistributionEvidence) -> tuple[str, str] | None:
+    if not ev.pointers or not ev.code_paths:
+        return None
+    pointers = ", ".join(p.path for p in ev.pointers)
+    copies = ", ".join(ev.code_paths)
+    return (
+        REASON_SHADOWED_POINTER,
+        f"an editable pointer ({pointers}) AND a real package directory "
+        f"({copies}) both exist for {ev.name} — the copy WINS, so the pointer is "
+        f"inert and nothing it targets ever propagates, while imports keep "
+        f"succeeding and --version keeps looking right",
+    )
+
+
+def _check_orphaned_dist_info(ev: DistributionEvidence) -> tuple[str, str] | None:
+    if not ev.dist_infos or not ev.top_level_known or ev.code_paths:
+        return None
+    # Only a pointer PROVEN dead leaves the dist-info unserved. A live one
+    # means an editable install legitimately keeps its code elsewhere; an
+    # UNSETTLED one (target unparsable, or a path we could not stat) might
+    # be serving it too, and calling that an orphan would launder an
+    # unknown into a definite verdict — the exact move this module exists
+    # to prevent. The unsettled leg is still reported, as an UNKNOWN.
+    if any(not pointer.dead for pointer in ev.pointers):
+        return None
+    owned = ", ".join(ev.top_level_names) or "(nothing declared)"
+    return (
+        REASON_ORPHANED_DIST_INFO,
+        f"dist-info present ({', '.join(ev.dist_infos)}) but none of the modules "
+        f"it claims to own ({owned}) exist in site-packages, and no live pointer "
+        f"serves them — it advertises a version whose code is gone",
+    )
+
+
+def _check_duplicate_dist_info(ev: DistributionEvidence) -> tuple[str, str] | None:
+    if len(ev.dist_infos) < 2:
+        return None
+    return (
+        REASON_DUPLICATE_DIST_INFO,
+        f"{len(ev.dist_infos)} dist-info dirs for {ev.name}: "
+        f"{', '.join(ev.dist_infos)} — at least one is a fossil",
+    )
+
+
+def _unknown_legs(ev: DistributionEvidence) -> list[tuple[str, str]]:
+    """Every leg we could NOT settle. Reported alongside any BROKEN reason."""
+    legs: list[tuple[str, str]] = []
+    if ev.read_error:
+        legs.append((UNKNOWN_READ_ERROR, f"metadata unreadable: {ev.read_error}"))
+    if ev.dist_infos and not ev.top_level_known:
+        legs.append(
+            (
+                UNKNOWN_OWNERSHIP_UNKNOWN,
+                "neither top_level.txt nor RECORD said which modules this dist "
+                "owns, so 'has code behind it' cannot be decided",
+            )
+        )
+    if not ev.dist_infos and ev.pointers:
+        legs.append(
+            (
+                UNKNOWN_NO_DIST_INFO,
+                "an editable pointer exists with no dist-info to describe it — "
+                "what it is meant to serve cannot be established",
+            )
+        )
+    for pointer in ev.pointers:
+        if not pointer.target:
+            legs.append(
+                (
+                    UNKNOWN_POINTER_UNPARSABLE,
+                    f"no target could be parsed out of {pointer.path}",
+                )
+            )
+        elif pointer.target_exists is None:
+            legs.append(
+                (
+                    UNKNOWN_TARGET_UNSTATABLE,
+                    f"could not stat {pointer.target} (from {pointer.path})",
+                )
+            )
+    return legs
+
+
+def classify_distribution(
+    ev: DistributionEvidence, site_packages: str
+) -> DistributionVerdict:
+    """One distribution's evidence -> one tri-state verdict. PURE."""
+    if ev.absent:
+        return DistributionVerdict(
+            name=ev.name,
+            state=STATE_UNKNOWN,
+            unknown_reasons=(UNKNOWN_DIST_ABSENT,),
+            details=(f"no dist-info, pointer, or code found for {ev.name}",),
+            evidence=ev,
+        )
+
+    checks = (
+        _check_resolves_outside(ev, site_packages),
+        _check_dead_pointer(ev),
+        _check_shadowed_pointer(ev),
+        _check_orphaned_dist_info(ev),
+        _check_duplicate_dist_info(ev),
+    )
+    hits = [c for c in checks if c is not None]
+    unknowns = _unknown_legs(ev)
+
+    reasons = tuple(r for r, _ in hits)
+    details = tuple(d for _, d in hits) + tuple(d for _, d in unknowns)
+    unknown_reasons = tuple(dict.fromkeys(r for r, _ in unknowns))
+
+    if reasons:
+        state = STATE_BROKEN
+    elif unknown_reasons:
+        state = STATE_UNKNOWN
+    else:
+        state = STATE_OK
+    return DistributionVerdict(
+        name=ev.name,
+        state=state,
+        reasons=reasons,
+        unknown_reasons=unknown_reasons,
+        details=details,
+        evidence=ev,
+    )
+
+
+def build_report(site: SiteEvidence) -> InstallIntegrityReport:
+    """Whole-site evidence -> the report the CLI renders. PURE."""
+    if not site.readable:
+        return InstallIntegrityReport(
+            site_packages=site.site_packages,
+            venv=site.venv,
+            site_state=STATE_UNKNOWN,
+            site_detail=(
+                f"could not read {site.site_packages}: {site.read_error} — that is "
+                f"UNKNOWN, not clean: nothing about this install was observed"
+            ),
+            import_resolution=site.import_resolution,
+            note=site.note,
+        )
+    verdicts = tuple(
+        classify_distribution(ev, site.site_packages)
+        for ev in sorted(site.distributions, key=lambda e: e.name)
+    )
+    return InstallIntegrityReport(
+        site_packages=site.site_packages,
+        venv=site.venv,
+        site_state=STATE_OK,
+        import_resolution=site.import_resolution,
+        note=site.note,
+        verdicts=verdicts,
+    )
+
+
+def exit_code_for(report: InstallIntegrityReport, *, strict: bool = False) -> int:
+    """0 clean, 1 any distribution BROKEN, 2 UNKNOWN under ``strict``.
+
+    UNKNOWN alone is NOT a failure by default: it is an absence of
+    evidence, and turning "I could not look" into a red build teaches
+    people to append ``|| true``. It is still printed as loudly as a
+    break, and ``strict=True`` exists for callers who genuinely require a
+    COMPLETE answer (a deploy gate) rather than merely no bad news.
+    """
+    if report.broken:
+        return 1
+    if strict and (report.site_unknown or report.unknown):
+        return 2
+    return 0

--- a/src/scitex_agent_container/_maintenance/_install_integrity_probe.py
+++ b/src/scitex_agent_container/_maintenance/_install_integrity_probe.py
@@ -1,0 +1,339 @@
+"""OBSERVATION for install-integrity — everything that touches the world.
+
+Isolated from the decision logic (:mod:`._install_integrity_predicate`) on
+purpose: every read here can fail for reasons that have nothing to do with
+the install (an unreadable site-packages, a truncated RECORD, a dangling
+mount), and each one converts that failure into an honest UNKNOWN leg on
+the evidence rather than into a convenient boolean. The predicate then only
+has to know how to report an unknown — it never has to guess whether an
+answer is real.
+
+READ-ONLY, ALWAYS. This module inspects; it never repairs. Repairing a
+venv is a separate, deliberate act that belongs behind this guard, not
+inside it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sysconfig
+from pathlib import Path
+
+from ._install_integrity_model import (
+    IMPORTS_LIVE,
+    IMPORTS_UNAVAILABLE,
+    DistributionEvidence,
+    EditablePointer,
+    InstallIntegrityReport,
+    SiteEvidence,
+    canonical_dist_name,
+)
+from ._install_integrity_pointers import candidate_dist_names, collect_pointers
+from ._install_integrity_predicate import build_report
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "inspect_install",
+    "read_site_evidence",
+    "resolve_site_packages",
+    "running_site_packages",
+]
+
+_DIST_SUFFIXES = (".dist-info", ".egg-info")
+_SKIP_TOP_LEVEL = {"__pycache__", "", "."}
+
+#: pip renames a distribution's first character to ``~`` while it replaces
+#: it, and leaves the directory behind if the run is interrupted. Such a
+#: dir is debris BY CONSTRUCTION: no distribution is named ``~foo``, so it
+#: can never be imported, and its RECORD describes the OTHER (real)
+#: distribution's modules. Attributing that RECORD to it would credit it
+#: with code it does not own — which is exactly how the fossil hides.
+_PIP_DEBRIS_PREFIX = "~"
+
+
+def running_site_packages() -> str:
+    """The site-packages of the venv the RUNNING interpreter belongs to."""
+    return sysconfig.get_paths()["purelib"]
+
+
+def resolve_site_packages(target: str | Path | None) -> tuple[str, str]:
+    """``target`` -> ``(site_packages, note)``. ``None`` = this interpreter's.
+
+    Accepts a venv root, a site-packages directory directly, or ``None``.
+    A venv with several ``lib/python*/site-packages`` (two interpreters
+    installed into one prefix) is NOT merged — merging would invent
+    duplicate dist-infos that do not exist for either interpreter. The
+    highest version is inspected and the rest are named in the note.
+    """
+    if target is None:
+        return running_site_packages(), ""
+    root = Path(target).expanduser()
+    if root.name == "site-packages":
+        return str(root), ""
+    matches = sorted(root.glob("lib/python*/site-packages")) + sorted(
+        root.glob("Lib/site-packages")
+    )
+    if not matches:
+        return str(root / "lib" / "pythonX.Y" / "site-packages"), (
+            f"no lib/python*/site-packages under {root}"
+        )
+    chosen = matches[-1]
+    if len(matches) == 1:
+        return str(chosen), ""
+    others = ", ".join(str(m) for m in matches[:-1])
+    return str(chosen), (
+        f"{len(matches)} site-packages dirs under {root}; inspected {chosen} "
+        f"(not merged with: {others})"
+    )
+
+
+def _parse_dist_dirname(dirname: str) -> str:
+    """``Name-Version.dist-info`` / ``Name.egg-info`` -> canonical name."""
+    for suffix in _DIST_SUFFIXES:
+        if dirname.endswith(suffix):
+            stem = dirname[: -len(suffix)]
+            break
+    else:
+        return ""
+    name, _, version = stem.rpartition("-")
+    return canonical_dist_name(name if name and version else stem)
+
+
+def _read_text(path: Path) -> str | None:
+    # stx-allow: fallback (reason: unreadable metadata is an UNKNOWN leg on the evidence, never a crash of the check that reads it)
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        logger.debug("install-integrity: cannot read %s: %s", path, exc)
+        return None
+
+
+def _top_level_from_record(text: str) -> list[str]:
+    """First path segment of every RECORD row that is not metadata."""
+    names: list[str] = []
+    for raw in text.splitlines():
+        row = raw.split(",", 1)[0].strip()
+        if not row or row.startswith(("../", "/")):
+            continue
+        head = row.split("/", 1)[0]
+        if head.endswith(_DIST_SUFFIXES) or head.endswith(".data"):
+            continue
+        if head in _SKIP_TOP_LEVEL:
+            continue
+        names.append(head[:-3] if head.endswith(".py") else head)
+    return list(dict.fromkeys(names))
+
+
+def _owned_modules(dist_infos: list[Path]) -> tuple[tuple[str, ...], bool]:
+    """What a dist claims to own -> ``(names, known)``.
+
+    ``top_level.txt`` first (explicit), then ``RECORD`` (derived). When
+    NEITHER answers, ``known`` is False and the caller must NOT decide
+    "has code behind it" — that is the difference between reporting an
+    orphan and inventing one.
+    """
+    names: list[str] = []
+    known = False
+    for dist_info in dist_infos:
+        top_level = _read_text(dist_info / "top_level.txt")
+        if top_level and top_level.split():
+            names.extend(top_level.split())
+            known = True
+            continue
+        record = _read_text(dist_info / "RECORD")
+        if record is not None:
+            derived = _top_level_from_record(record)
+            if derived:
+                names.extend(derived)
+                known = True
+    return tuple(dict.fromkeys(names)), known
+
+
+def _declared_editable(dist_infos: list[Path]) -> bool:
+    """PEP 610: does any dist-info say this was installed ``-e``?"""
+    for dist_info in dist_infos:
+        raw = _read_text(dist_info / "direct_url.json")
+        if not raw:
+            continue
+        # stx-allow: fallback (reason: malformed direct_url.json means "cannot tell it is editable", not a crash)
+        try:
+            data = json.loads(raw)
+        except ValueError:
+            continue
+        if isinstance(data, dict) and data.get("dir_info", {}).get("editable"):
+            return True
+    return False
+
+
+def _code_paths(
+    site: Path, names: tuple[str, ...], entries: set[str]
+) -> tuple[str, ...]:
+    """Which of ``names`` really exist as code INSIDE site-packages."""
+    found: list[str] = []
+    for name in names:
+        if name in entries and (site / name).is_dir():
+            found.append(str(site / name))
+        elif f"{name}.py" in entries:
+            found.append(str(site / f"{name}.py"))
+    return tuple(found)
+
+
+def _resolve_import(name: str) -> str:
+    """Where ``import <name>`` really lands, or ``""`` if unresolvable.
+
+    ``find_spec`` on a TOP-LEVEL name runs the path finders without
+    executing the module, so this observes resolution without importing
+    the very code we suspect.
+    """
+    import importlib.util
+
+    # stx-allow: fallback (reason: a broken third-party meta-path finder must leave the import leg UNKNOWN, never crash the inspection)
+    try:
+        spec = importlib.util.find_spec(name)
+    except (ImportError, AttributeError, ValueError, OSError) as exc:
+        logger.debug("install-integrity: find_spec(%s) failed: %s", name, exc)
+        return ""
+    if spec is None:
+        return ""
+    if spec.origin and spec.origin not in ("built-in", "frozen"):
+        return str(Path(spec.origin).parent)
+    locations = list(getattr(spec, "submodule_search_locations", None) or [])
+    return str(locations[0]) if locations else ""
+
+
+def _attribute_pointers(
+    pointers: list[EditablePointer], known: set[str]
+) -> dict[str, list[EditablePointer]]:
+    """Group pointers by the distribution their FILENAME points at.
+
+    A candidate that matches no dist we saw keeps its longest form and
+    becomes its own row, so a pointer for a distribution that no longer
+    has a dist-info is still reported rather than dropped.
+    """
+    grouped: dict[str, list[EditablePointer]] = {}
+    for pointer in pointers:
+        candidates = candidate_dist_names(Path(pointer.path).name)
+        match = next((c for c in candidates if c in known), "")
+        key = match or (candidates[0] if candidates else "unattributed-pointer")
+        grouped.setdefault(key, []).append(pointer)
+    return grouped
+
+
+def read_site_evidence(
+    site_packages: str, *, live_imports: bool, note: str = "", venv: str = ""
+) -> SiteEvidence:
+    """Observe one site-packages directory. Never raises."""
+    site = Path(site_packages)
+    # stx-allow: fallback (reason: an unreadable site-packages is the headline UNKNOWN this check exists to report honestly)
+    try:
+        entry_names = [e.name for e in site.iterdir()]
+    except OSError as exc:
+        return SiteEvidence(
+            site_packages=site_packages,
+            readable=False,
+            read_error=f"{type(exc).__name__}: {exc}",
+            venv=venv,
+            note=note,
+            import_resolution=IMPORTS_LIVE if live_imports else IMPORTS_UNAVAILABLE,
+        )
+
+    entries = set(entry_names)
+    dist_dirs: dict[str, list[Path]] = {}
+    for name in sorted(entry_names):
+        if not name.endswith(_DIST_SUFFIXES):
+            continue
+        canonical = _parse_dist_dirname(name)
+        if canonical:
+            dist_dirs.setdefault(canonical, []).append(site / name)
+
+    pointers = collect_pointers(site, entry_names)
+    by_dist = _attribute_pointers(pointers, set(dist_dirs))
+
+    evidence: list[DistributionEvidence] = []
+    for canonical in sorted(set(dist_dirs) | set(by_dist)):
+        dist_infos = dist_dirs.get(canonical, [])
+        if canonical.startswith(_PIP_DEBRIS_PREFIX):
+            # Interrupted-pip debris: it owns no modules OF ITS OWN (its
+            # RECORD describes the distribution it was replacing), and
+            # nothing can import it. Stating that plainly makes the
+            # orphan check fire on it instead of crediting it with the
+            # real distribution's code.
+            evidence.append(
+                DistributionEvidence(
+                    name=canonical,
+                    dist_infos=tuple(str(p) for p in dist_infos),
+                    top_level_known=True,
+                )
+            )
+            continue
+        owned, known = _owned_modules(dist_infos)
+        if not owned:
+            # No dist-info (pointer-only row): the filename is all we have.
+            owned = (canonical.replace("-", "_"),)
+        code = _code_paths(site, owned, entries)
+        imported = _resolve_import(owned[0]) if live_imports and owned else ""
+        evidence.append(
+            DistributionEvidence(
+                name=canonical,
+                dist_infos=tuple(str(p) for p in dist_infos),
+                top_level_names=owned,
+                top_level_known=known,
+                code_paths=code,
+                pointers=tuple(by_dist.get(canonical, [])),
+                declared_editable=_declared_editable(dist_infos),
+                imported_path=imported,
+                import_resolution_known=live_imports,
+            )
+        )
+    return SiteEvidence(
+        site_packages=site_packages,
+        readable=True,
+        venv=venv,
+        note=note,
+        import_resolution=IMPORTS_LIVE if live_imports else IMPORTS_UNAVAILABLE,
+        distributions=tuple(evidence),
+    )
+
+
+def _absent(name: str) -> DistributionEvidence:
+    return DistributionEvidence(name=canonical_dist_name(name), absent=True)
+
+
+def inspect_install(
+    venv: str | Path | None = None, *, dists: tuple[str, ...] = ()
+) -> InstallIntegrityReport:
+    """Inspect a venv's install layout. READ-ONLY. Never raises.
+
+    ``venv=None`` inspects the venv the running interpreter belongs to,
+    which is the only case where import resolution is observable; a venv
+    given explicitly is inspected at the path level only, and the report
+    says so rather than implying the import leg came back clean.
+
+    ``dists`` narrows the report to named distributions. One that is not
+    present comes back UNKNOWN (distribution-absent) — never OK, because
+    "I did not find it" is not "it is fine".
+    """
+    site_packages, note = resolve_site_packages(venv)
+    # Import resolution is observable ONLY for our own interpreter's
+    # site-packages. Anything else is a foreign venv we can read but not run.
+    live = site_packages.rstrip("/") == running_site_packages().rstrip("/")
+    site = read_site_evidence(
+        site_packages,
+        live_imports=live,
+        note=note,
+        venv=str(Path(venv).expanduser()) if venv is not None else "",
+    )
+    if dists and site.readable:
+        wanted = [canonical_dist_name(d) for d in dists]
+        seen = {ev.name: ev for ev in site.distributions}
+        site = SiteEvidence(
+            site_packages=site.site_packages,
+            readable=True,
+            venv=site.venv,
+            note=site.note,
+            import_resolution=site.import_resolution,
+            distributions=tuple(seen.get(name) or _absent(name) for name in wanted),
+        )
+    return build_report(site)

--- a/src/scitex_agent_container/cli_pkg/_installation_check.py
+++ b/src/scitex_agent_container/cli_pkg/_installation_check.py
@@ -205,4 +205,4 @@ def register(install_group) -> None:
     install_group.add_command(installation_check)
 
 
-__all__ = ["STATE_BROKEN", "installation_check", "register"]
+__all__ = ["installation_check", "register"]

--- a/src/scitex_agent_container/cli_pkg/_installation_check.py
+++ b/src/scitex_agent_container/cli_pkg/_installation_check.py
@@ -1,0 +1,208 @@
+"""``sac installation check`` — is this venv's install layout still true?
+
+WHY HERE, and not somewhere else. Three homes were candidates:
+
+* ``sac doctor`` is scoped, by its own docstring and its ``--fleet`` /
+  ``--strict`` contract, to ONE subject: agent-spec source git drift.
+  Folding a venv-layout audit under the same verb would make one exit
+  code mean two unrelated things.
+* ``sac provenance`` is the closest in CONCERN ("which code is really
+  loaded") but is SELF-scoped by construction: it audits only
+  ``scitex-agent-container``'s own dist, on the running ``sys.path``, and
+  its whole product is the identity of the loaded code. This check is
+  VENV-scoped and ALL-distributions, and can inspect a venv the current
+  interpreter is not running from.
+* ``sac installation`` is the INSTALL noun — already in the "Build &
+  Install" help category, already the home of ``boot`` and ``setup-cron``.
+  Those are both mutators; a read-only ``check`` is the completion of the
+  noun rather than a new one, because "is this installation coherent?" is
+  a property OF an installation.
+
+Rendering rule, inherited from ``sac worktree gc``: **there is no quiet
+success path, and UNKNOWN is never quiet either.** A distribution nobody
+could read is printed as loudly as a broken one, because the entire
+failure class this guard exists for spent days looking green.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from .._maintenance import (
+    IMPORTS_LIVE,
+    DistributionVerdict,
+    InstallIntegrityReport,
+    inspect_install,
+    install_integrity_exit_code,
+)
+from ._helpers import _json_flag, console
+
+_STATE_STYLE = {"ok": "green", "broken": "red", "unknown": "magenta"}
+
+
+def _evidence(text: str) -> None:
+    """One evidence line WITHOUT rich's word-wrap.
+
+    A wrapped absolute path is a path you cannot grep out of a cron log,
+    and every line here exists to be read back later.
+    """
+    console.print(text, soft_wrap=True)
+
+
+def _print_verdict(verdict: DistributionVerdict) -> None:
+    style = _STATE_STYLE.get(verdict.state, "white")
+    label = verdict.state.upper()
+    tokens = ", ".join(verdict.reasons + verdict.unknown_reasons)
+    _evidence(
+        f"[{style}]{label:<8}[/{style}] {verdict.name}"
+        + (f"  [dim]({tokens})[/dim]" if tokens else "")
+    )
+    for detail in verdict.details:
+        _evidence(f"    [dim]{detail}[/dim]")
+
+
+def _print_report(report: InstallIntegrityReport, *, show_all: bool) -> None:
+    console.print(f"[bold]sac installation check[/bold]  {report.site_packages}\n")
+    if report.note:
+        _evidence(f"[yellow]note:[/yellow] {report.note}\n")
+
+    if report.site_unknown:
+        _evidence(f"[magenta]UNKNOWN[/magenta]  {report.site_detail}")
+        return
+
+    shown = report.verdicts if show_all else (report.broken + report.unknown)
+    for verdict in shown:
+        _print_verdict(verdict)
+    if shown:
+        console.print("")
+
+    if report.import_resolution != IMPORTS_LIVE:
+        _evidence(
+            "[magenta]import resolution UNOBSERVABLE[/magenta] [dim]— a venv other "
+            "than this interpreter's was inspected, so 'where does an import really "
+            "land' was NOT checked. The path-level findings above are complete; "
+            "that one leg is absent, not clean.[/dim]"
+        )
+
+    breakdown = report.reason_breakdown()
+    if breakdown:
+        summary = ", ".join(f"{n} {reason}" for reason, n in breakdown.items())
+        _evidence(f"[red]BROKEN by reason:[/red] {summary}")
+    if report.unknown:
+        _evidence(
+            f"[magenta]{len(report.unknown)} distribution(s) UNKNOWN[/magenta] "
+            "[dim]— unknown is not clean; it is evidence nobody has.[/dim]"
+        )
+    if not report.broken and not report.unknown:
+        _evidence(
+            "[green]every distribution's install layout is coherent[/green] "
+            "[dim](no dead/shadowed pointer, no orphaned or duplicated "
+            "dist-info)[/dim]"
+        )
+    if not show_all and report.ok:
+        _evidence(f"[dim]{len(report.ok)} ok row(s) hidden — pass --all to list.[/dim]")
+
+
+@click.command("check")
+@click.argument("venv", required=False, type=click.Path())
+@click.option(
+    "--dist",
+    "dists",
+    multiple=True,
+    help="Only inspect these distributions (repeatable). Absent ones read UNKNOWN.",
+)
+@click.option(
+    "--all",
+    "show_all",
+    is_flag=True,
+    default=False,
+    help="List OK rows too (default prints only BROKEN and UNKNOWN).",
+)
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Also exit non-zero (2) on UNKNOWN — for a gate that needs a COMPLETE answer.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output as JSON.")
+@click.pass_context
+def installation_check(
+    ctx: click.Context,
+    venv: str | None,
+    dists: tuple[str, ...],
+    show_all: bool,
+    strict: bool,
+    as_json: bool,
+) -> None:
+    """Audit a venv's install layout: dead/shadowed pointers, fossil dist-info.
+
+    READ-ONLY. Answers the question ``--version`` provably cannot: is the
+    code this venv would run the code anybody thinks is installed?
+
+    \b
+    Two incidents, one class — the code executed was not the code believed
+    installed, and BOTH reported a healthy version string the whole time:
+      2026-07-16  an orphaned scitex_dev dist-info with no code behind it,
+                  plus a .pth redirecting imports into an abandoned PR
+                  worktree. Commands ran from a temp dir for days.
+      2026-08-09  /opt/venv-sac's editable pointer targets a deleted
+                  worktree on a deleted branch, while a real package dir
+                  next to it shadows the pointer. Imports succeed;
+                  propagation has been dead the whole time.
+
+    \b
+    Detects, per distribution:
+      resolves-outside-site-packages  imports land outside site-packages and
+                                      no LIVE editable pointer explains it
+      dead-pointer                    an editable pointer whose target is gone
+      shadowed-pointer                pointer AND a real package dir coexist —
+                                      the copy wins, the pointer is inert
+      orphaned-dist-info              dist-info with no code behind it
+      duplicate-dist-info             two dist-info dirs for one distribution
+
+    \b
+    Every distribution is THREE-VALUED. UNKNOWN (unreadable site-packages,
+    an absent distribution, evidence too thin to decide) is never folded
+    into either pole: it prints as loudly as a break but does NOT fail the
+    exit code, because "I could not look" is not "it is broken". Pass
+    --strict when you need a complete answer rather than no bad news.
+
+    \b
+    Examples:
+      $ sac installation check                      # this interpreter's venv
+      $ sac installation check /opt/venv-sac        # an explicit venv
+      $ sac installation check --dist scitex-dev --all
+      $ sac installation check --json
+
+    \b
+    Exit codes:  0 = nothing broken.  1 = at least one distribution BROKEN.
+    2 = --strict and something is UNKNOWN.
+    """
+    report = inspect_install(venv, dists=dists)
+    code = install_integrity_exit_code(report, strict=strict)
+
+    if _json_flag(ctx, as_json):
+        payload = report.to_dict()
+        payload["exit_code"] = code
+        payload["strict"] = strict
+        click.echo(json.dumps(payload, indent=2))
+        raise SystemExit(code)
+
+    _print_report(report, show_all=show_all)
+    console.print(f"[dim]{report.summary_line()}[/dim]")
+    if report.broken:
+        console.print(
+            "[dim]This command REPAIRS NOTHING on purpose — it is the guard the "
+            "repair is gated behind.[/dim]"
+        )
+    raise SystemExit(code)
+
+
+def register(install_group) -> None:
+    """Attach ``check`` to the parent ``installation`` Click group."""
+    install_group.add_command(installation_check)
+
+
+__all__ = ["STATE_BROKEN", "installation_check", "register"]

--- a/src/scitex_agent_container/cli_pkg/installation_group.py
+++ b/src/scitex_agent_container/cli_pkg/installation_group.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import click
 
+from . import _installation_check
 from ._helpers import console
 
 # ---------------------------------------------------------------------------
@@ -51,7 +52,13 @@ def _cron_line() -> str:
 
 @click.group("installation")
 def install_group() -> None:
-    """Bootstrap and install helpers for a new fleet host."""
+    """Bootstrap and install helpers for a new fleet host.
+
+    \b
+    Create an install:  boot, setup-cron
+    Verify one:         check  (read-only — dead/shadowed editable
+                        pointers, orphaned or duplicated dist-info)
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -377,3 +384,9 @@ install_group.add_command(
         epilog=install_post_merge_cron.epilog,
     )
 )
+
+# The read-only half of the noun: `boot` and `setup-cron` CREATE an
+# install, `check` asks whether an existing one still describes reality.
+# Attached by its own module's register(), mirroring how `worktree_group`
+# collects `_worktree_gc`.
+_installation_check.register(install_group)

--- a/tests/scitex_agent_container/_maintenance/test__install_integrity_model.py
+++ b/tests/scitex_agent_container/_maintenance/test__install_integrity_model.py
@@ -1,0 +1,230 @@
+"""Tests for the install-integrity data types (the serialisation contract).
+
+The reason strings and the ``to_dict`` shapes here are API: they land in
+``sac installation check --json``, which is what a cron line and a repair
+step read. A silently renamed reason token, or a dropped key, breaks
+consumers that never see a traceback — so the vocabulary is pinned here
+rather than left to the renderer to imply.
+
+The DECISIONS that produce these values are tested in
+``test__install_integrity_predicate.py``; this file only pins the shapes.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name
+(TQ003). No monkeypatch (NM002).
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._maintenance import _install_integrity_model as M
+
+_SITE = "/opt/venv-sac/lib/python3.12/site-packages"
+
+
+def _pointer(**over) -> M.EditablePointer:
+    base = dict(
+        path=_SITE + "/_editable_impl_pkg.pth",
+        shape=M.POINTER_PTH_PATH,
+        target="/home/u/proj/pkg/src",
+        target_exists=True,
+    )
+    base.update(over)
+    return M.EditablePointer(**base)
+
+
+# ---------------------------------------------------------------------------
+# Pointer liveness is tri-state, and neither pole absorbs the third
+# ---------------------------------------------------------------------------
+def test_pointer_with_present_target_is_live():
+    # Arrange
+    pointer = _pointer(target_exists=True)
+    # Act
+    live = pointer.live
+    # Assert
+    assert live
+
+
+def test_pointer_with_missing_target_is_dead():
+    # Arrange
+    pointer = _pointer(target_exists=False)
+    # Act
+    dead = pointer.dead
+    # Assert
+    assert dead
+
+
+def test_unstatable_pointer_is_not_dead():
+    # Arrange — "could not stat" must never read as "not there".
+    pointer = _pointer(target_exists=None)
+    # Act
+    dead = pointer.dead
+    # Assert
+    assert not dead
+
+
+def test_unstatable_pointer_is_not_live():
+    # Arrange — nor as "there".
+    pointer = _pointer(target_exists=None)
+    # Act
+    live = pointer.live
+    # Assert
+    assert not live
+
+
+def test_unparsable_pointer_is_not_live():
+    # Arrange — no target parsed means nothing was proven either way.
+    pointer = _pointer(target="", target_exists=True)
+    # Act
+    live = pointer.live
+    # Assert
+    assert not live
+
+
+# ---------------------------------------------------------------------------
+# Report partitioning
+# ---------------------------------------------------------------------------
+def _report(*states: str) -> M.InstallIntegrityReport:
+    return M.InstallIntegrityReport(
+        site_packages=_SITE,
+        verdicts=tuple(
+            M.DistributionVerdict(name="d" + str(i), state=state)
+            for i, state in enumerate(states)
+        ),
+    )
+
+
+def test_report_partitions_broken_rows():
+    # Arrange
+    report = _report(M.STATE_OK, M.STATE_BROKEN, M.STATE_UNKNOWN)
+    # Act
+    broken = report.broken
+    # Assert
+    assert len(broken) == 1
+
+
+def test_report_partitions_unknown_rows():
+    # Arrange
+    report = _report(M.STATE_OK, M.STATE_BROKEN, M.STATE_UNKNOWN)
+    # Act
+    unknown = report.unknown
+    # Assert
+    assert len(unknown) == 1
+
+
+def test_unknown_rows_are_not_counted_as_ok():
+    # Arrange — the whole doctrine in one assertion.
+    report = _report(M.STATE_OK, M.STATE_UNKNOWN, M.STATE_UNKNOWN)
+    # Act
+    ok = report.ok
+    # Assert
+    assert len(ok) == 1
+
+
+def test_summary_names_unobservable_imports():
+    # Arrange — a foreign venv must say the leg was not run.
+    report = M.InstallIntegrityReport(
+        site_packages=_SITE, import_resolution=M.IMPORTS_UNAVAILABLE
+    )
+    # Act
+    line = report.summary_line()
+    # Assert
+    assert "UNOBSERVABLE" in line
+
+
+def test_summary_omits_the_note_when_imports_are_live():
+    # Arrange
+    report = M.InstallIntegrityReport(
+        site_packages=_SITE, import_resolution=M.IMPORTS_LIVE
+    )
+    # Act
+    line = report.summary_line()
+    # Assert
+    assert "UNOBSERVABLE" not in line
+
+
+def test_reason_breakdown_follows_declared_order():
+    # Arrange — deterministic output, never set-iteration order.
+    report = M.InstallIntegrityReport(
+        site_packages=_SITE,
+        verdicts=(
+            M.DistributionVerdict(
+                name="a",
+                state=M.STATE_BROKEN,
+                reasons=(M.REASON_DUPLICATE_DIST_INFO, M.REASON_DEAD_POINTER),
+            ),
+        ),
+    )
+    # Act
+    keys = list(report.reason_breakdown())
+    # Assert
+    assert keys == [M.REASON_DEAD_POINTER, M.REASON_DUPLICATE_DIST_INFO]
+
+
+# ---------------------------------------------------------------------------
+# JSON contract
+# ---------------------------------------------------------------------------
+def test_report_dict_carries_the_counts_block():
+    # Arrange
+    report = _report(M.STATE_OK, M.STATE_BROKEN, M.STATE_UNKNOWN)
+    # Act
+    payload = report.to_dict()
+    # Assert
+    assert payload["counts"] == {"total": 3, "ok": 1, "broken": 1, "unknown": 1}
+
+
+def test_report_dict_names_the_import_resolution():
+    # Arrange — a consumer must be able to tell a skipped leg from a clean one.
+    report = M.InstallIntegrityReport(
+        site_packages=_SITE, import_resolution=M.IMPORTS_UNAVAILABLE
+    )
+    # Act
+    payload = report.to_dict()
+    # Assert
+    assert payload["import_resolution"] == M.IMPORTS_UNAVAILABLE
+
+
+def test_verdict_dict_carries_its_evidence():
+    # Arrange
+    verdict = M.DistributionVerdict(
+        name="pkg",
+        state=M.STATE_BROKEN,
+        reasons=(M.REASON_DEAD_POINTER,),
+        evidence=M.DistributionEvidence(name="pkg", pointers=(_pointer(),)),
+    )
+    # Act
+    payload = verdict.to_dict()
+    # Assert — the pointer path is the repair instruction; it must survive.
+    assert payload["evidence"]["pointers"][0]["path"].endswith("_editable_impl_pkg.pth")
+
+
+def test_verdict_dict_without_evidence_is_null():
+    # Arrange
+    verdict = M.DistributionVerdict(name="pkg", state=M.STATE_OK)
+    # Act
+    payload = verdict.to_dict()
+    # Assert
+    assert payload["evidence"] is None
+
+
+def test_every_reason_appears_in_the_declared_order():
+    # Arrange — a new reason that forgets REASON_ORDER would vanish from
+    # every breakdown without failing anything else.
+    declared = {
+        M.REASON_RESOLVES_OUTSIDE,
+        M.REASON_DEAD_POINTER,
+        M.REASON_SHADOWED_POINTER,
+        M.REASON_ORPHANED_DIST_INFO,
+        M.REASON_DUPLICATE_DIST_INFO,
+    }
+    # Act
+    ordered = set(M.REASON_ORDER)
+    # Assert
+    assert ordered == declared
+
+
+def test_canonical_name_folds_underscores_and_case():
+    # Arrange
+    raw = "SciTeX_Agent_Container"
+    # Act
+    canonical = M.canonical_dist_name(raw)
+    # Assert
+    assert canonical == "scitex-agent-container"

--- a/tests/scitex_agent_container/_maintenance/test__install_integrity_pointers.py
+++ b/tests/scitex_agent_container/_maintenance/test__install_integrity_pointers.py
@@ -1,0 +1,211 @@
+"""Tests for editable-pointer parsing — the four shapes the tooling emits.
+
+The shapes here are LITERAL: each ``.pth`` body is transcribed from a real
+file (``/opt/venv-sac``'s ``_editable_impl_scitex_agent_container.pth``,
+setuptools' compat and strict outputs, and the coverage bootstrap ``.pth``
+that must NOT be mistaken for a redirect). A parser that knows only one
+shape reports the other three as clean, which is how the failure class
+survived twice.
+
+Parsing is checked WITHOUT importing or exec'ing anything: these are the
+files we already suspect of pointing at abandoned trees, and running them
+to find out where they point is precisely the wrong instinct.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name
+(TQ003). No monkeypatch (NM002).
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._maintenance import _install_integrity_model as M
+from scitex_agent_container._maintenance import _install_integrity_pointers as PT
+
+# Verbatim from /opt/venv-sac (uv/hatchling shape): one bare absolute path.
+_UV_PTH = "/home/u/proj/sac/.worktrees/persist/.worktrees/agent-aae4/src\n"
+
+# setuptools "strict" mode: the path lives in the finder module it names.
+_SETUPTOOLS_STRICT_PTH = (
+    "import __editable___scitex_dev_0_31_0_finder; "
+    "__editable___scitex_dev_0_31_0_finder.install()\n"
+)
+
+# The coverage bootstrap every venv carries. Redirects NOTHING.
+_COVERAGE_PTH = (
+    "import os\n"
+    "if os.environ.get('COVERAGE_PROCESS_START'):\n"
+    "    import coverage\n"
+    "    coverage.process_startup()\n"
+)
+
+_FINDER_SOURCE = (
+    "import sys\n"
+    "MAPPING = {'scitex_dev': '/home/u/proj/scitex-dev/src/scitex_dev'}\n"
+    "NAMESPACES = {}\n"
+    "PATH_PLACEHOLDER = '__editable__.scitex_dev-0.31.0.finder'\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Shape 1 + 4 — a bare absolute path in a .pth
+# ---------------------------------------------------------------------------
+def test_bare_absolute_path_yields_one_target():
+    # Arrange
+    text = _UV_PTH
+    # Act
+    parsed = PT.pth_targets(text)
+    # Assert
+    assert parsed == [(M.POINTER_PTH_PATH, _UV_PTH.strip())]
+
+
+def test_relative_path_line_is_not_a_pointer():
+    # Arrange — only an ABSOLUTE path is unambiguous evidence of a redirect.
+    text = "./somewhere/relative\n"
+    # Act
+    parsed = PT.pth_targets(text)
+    # Assert
+    assert parsed == []
+
+
+def test_comment_and_blank_lines_are_ignored():
+    # Arrange
+    text = "\n# a comment\n\n/real/target\n"
+    # Act
+    parsed = PT.pth_targets(text)
+    # Assert
+    assert parsed == [(M.POINTER_PTH_PATH, "/real/target")]
+
+
+# ---------------------------------------------------------------------------
+# Shape 2 — the setuptools strict .pth naming a finder module
+# ---------------------------------------------------------------------------
+def test_finder_import_line_names_the_finder_module():
+    # Arrange
+    text = _SETUPTOOLS_STRICT_PTH
+    # Act
+    parsed = PT.pth_targets(text)
+    # Assert
+    assert parsed == [(M.POINTER_PTH_IMPORT, "__editable___scitex_dev_0_31_0_finder")]
+
+
+def test_coverage_bootstrap_pth_is_not_a_pointer():
+    # Arrange — GREEN: an exec line naming no finder redirects nothing.
+    # Counting these would bury real findings under noise every venv has.
+    text = _COVERAGE_PTH
+    # Act
+    parsed = PT.pth_targets(text)
+    # Assert
+    assert parsed == []
+
+
+# ---------------------------------------------------------------------------
+# Shape 3 — the finder module's MAPPING dict
+# ---------------------------------------------------------------------------
+def test_finder_mapping_yields_the_real_directory():
+    # Arrange
+    source = _FINDER_SOURCE
+    # Act
+    targets = PT.finder_targets(source)
+    # Assert
+    assert targets == ["/home/u/proj/scitex-dev/src/scitex_dev"]
+
+
+def test_unparsable_finder_source_yields_no_targets():
+    # Arrange — a truncated finder is unreadable evidence, not a crash.
+    source = "MAPPING = {'a': "
+    # Act
+    targets = PT.finder_targets(source)
+    # Assert
+    assert targets == []
+
+
+def test_finder_without_mapping_yields_no_targets():
+    # Arrange
+    source = "import sys\nPATH_PLACEHOLDER = 'x'\n"
+    # Act
+    targets = PT.finder_targets(source)
+    # Assert
+    assert targets == []
+
+
+# ---------------------------------------------------------------------------
+# Attribution — which distribution does a pointer file belong to?
+# ---------------------------------------------------------------------------
+def test_editable_impl_filename_attributes_to_dist():
+    # Arrange — the /opt/venv-sac filename.
+    filename = "_editable_impl_scitex_agent_container.pth"
+    # Act
+    candidates = PT.candidate_dist_names(filename)
+    # Assert
+    assert "scitex-agent-container" in candidates
+
+
+def test_dotted_editable_filename_strips_version():
+    # Arrange — setuptools compat: `__editable__.<name>-<version>.pth`.
+    filename = "__editable__.scitex_dev-0.31.0.pth"
+    # Act
+    candidates = PT.candidate_dist_names(filename)
+    # Assert
+    assert candidates[0] == "scitex-dev"
+
+
+def test_finder_filename_strips_underscored_version():
+    # Arrange — `__editable___<name>_<v>_<v>_<v>_finder.py`.
+    filename = "__editable___scitex_dev_0_31_0_finder.py"
+    # Act
+    candidates = PT.candidate_dist_names(filename)
+    # Assert
+    assert "scitex-dev" in candidates
+
+
+def test_candidates_are_ordered_longest_first():
+    # Arrange — the caller picks the first that matches a dist it SAW, so
+    # a longer, more specific name must be offered before a shorter one.
+    filename = "_editable_impl_scitex_agent_container.pth"
+    # Act
+    candidates = PT.candidate_dist_names(filename)
+    # Assert
+    assert candidates == [
+        "scitex-agent-container",
+        "scitex-agent",
+        "scitex",
+    ]
+
+
+def test_editable_marker_is_recognised_in_filename():
+    # Arrange
+    filename = "__editable__.pkg-1.0.pth"
+    # Act
+    recognised = PT.is_editable_pth_name(filename)
+    # Assert
+    assert recognised
+
+
+def test_plain_pth_name_is_not_an_editable_marker():
+    # Arrange
+    filename = "a1_coverage.pth"
+    # Act
+    recognised = PT.is_editable_pth_name(filename)
+    # Assert
+    assert not recognised
+
+
+# ---------------------------------------------------------------------------
+# Existence probing is tri-state
+# ---------------------------------------------------------------------------
+def test_missing_target_reports_false(tmp_path):
+    # Arrange
+    missing = str(tmp_path / "gone")
+    # Act
+    exists = PT.target_exists(missing)
+    # Assert
+    assert exists is False
+
+
+def test_present_target_reports_true(tmp_path):
+    # Arrange
+    present = tmp_path / "here"
+    present.mkdir()
+    # Act
+    exists = PT.target_exists(str(present))
+    # Assert
+    assert exists is True

--- a/tests/scitex_agent_container/_maintenance/test__install_integrity_predicate.py
+++ b/tests/scitex_agent_container/_maintenance/test__install_integrity_predicate.py
@@ -1,0 +1,451 @@
+"""Mutation-proof tests for the install-integrity DECISION layer.
+
+Both directions are exercised for every reason, because a detector that
+never fires and one that always fires are equally useless:
+
+* RED — the evidence shape from a real incident MUST read BROKEN with the
+  right reason.
+* GREEN — the shape that merely LOOKS like it (a healthy editable install
+  resolving to its own live target; a pointer we could not stat) MUST NOT.
+
+Every reason here was neutered in place and the corresponding test
+confirmed to FAIL before this file was accepted — a test that passes with
+the logic removed is not a test.
+
+The decision layer is PURE, so nothing here builds a venv: evidence is
+constructed as dataclasses. The real-filesystem end of the same five
+reasons lives in ``test__install_integrity_probe.py``.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name
+(TQ003). No monkeypatch (NM002) — there is no global state to patch.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._maintenance import _install_integrity_model as M
+from scitex_agent_container._maintenance import _install_integrity_predicate as P
+
+_SITE = "/opt/venv-sac/lib/python3.12/site-packages"
+
+
+def _pointer(
+    target: str, exists: bool | None = True, path: str = ""
+) -> M.EditablePointer:
+    return M.EditablePointer(
+        path=path or (_SITE + "/_editable_impl_pkg.pth"),
+        shape=M.POINTER_PTH_PATH,
+        target=target,
+        target_exists=exists,
+    )
+
+
+def _evidence(**over) -> M.DistributionEvidence:
+    """A HEALTHY wheel install, overridden per test to make one thing wrong."""
+    base = dict(
+        name="scitex-agent-container",
+        dist_infos=(_SITE + "/scitex_agent_container-0.24.25.dist-info",),
+        top_level_names=("scitex_agent_container",),
+        top_level_known=True,
+        code_paths=(_SITE + "/scitex_agent_container",),
+        pointers=(),
+        imported_path=_SITE + "/scitex_agent_container",
+        import_resolution_known=True,
+    )
+    base.update(over)
+    return M.DistributionEvidence(**base)
+
+
+# ---------------------------------------------------------------------------
+# Baseline — the healthy shape must read OK, or every RED below is vacuous
+# ---------------------------------------------------------------------------
+def test_healthy_wheel_install_reads_ok():
+    # Arrange
+    evidence = _evidence()
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert verdict.state == M.STATE_OK
+
+
+# ---------------------------------------------------------------------------
+# Reason 1 — RESOLVES_OUTSIDE_SITE_PACKAGES
+# ---------------------------------------------------------------------------
+def test_unexplained_outside_resolution_reads_broken():
+    # Arrange — imports land in a worktree no pointer accounts for.
+    evidence = _evidence(imported_path="/home/u/proj/pkg/.worktrees/scratch/src/pkg")
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.REASON_RESOLVES_OUTSIDE in verdict.reasons
+
+
+def test_outside_resolution_names_the_real_path():
+    # Arrange
+    outside = "/home/u/proj/pkg/.worktrees/scratch/src/pkg"
+    evidence = _evidence(imported_path=outside)
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert — the evidence path is IN the message, not just a token.
+    assert any(outside in detail for detail in verdict.details)
+
+
+def test_live_editable_pointer_explains_outside_resolution():
+    # Arrange — GREEN: a healthy editable install IS outside site-packages.
+    target = "/home/u/proj/pkg/src"
+    evidence = _evidence(
+        code_paths=(),
+        imported_path=target + "/pkg",
+        pointers=(_pointer(target, exists=True),),
+    )
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.REASON_RESOLVES_OUTSIDE not in verdict.reasons
+
+
+def test_unobservable_import_never_reads_outside():
+    # Arrange — GREEN: a foreign venv; the leg was not run, so it cannot fire.
+    evidence = _evidence(imported_path="", import_resolution_known=False)
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.REASON_RESOLVES_OUTSIDE not in verdict.reasons
+
+
+# ---------------------------------------------------------------------------
+# Reason 2 — DEAD_POINTER
+# ---------------------------------------------------------------------------
+def test_dead_pointer_reads_broken():
+    # Arrange — the August shape's pointer: target deleted with its worktree.
+    evidence = _evidence(
+        code_paths=(),
+        pointers=(_pointer("/home/u/proj/sac/.worktrees/gone/src", exists=False),),
+    )
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.REASON_DEAD_POINTER in verdict.reasons
+
+
+def test_live_pointer_is_not_dead():
+    # Arrange — GREEN
+    evidence = _evidence(code_paths=(), pointers=(_pointer("/home/u/proj/x/src"),))
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.REASON_DEAD_POINTER not in verdict.reasons
+
+
+def test_unstatable_pointer_target_is_not_dead():
+    # Arrange — GREEN: "could not stat" must never fabricate a dead pointer.
+    evidence = _evidence(code_paths=(), pointers=(_pointer("/mnt/gone", exists=None),))
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.REASON_DEAD_POINTER not in verdict.reasons
+
+
+def test_unstatable_pointer_target_reads_unknown():
+    # Arrange — and it must not read OK either.
+    evidence = _evidence(code_paths=(), pointers=(_pointer("/mnt/gone", exists=None),))
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert verdict.state == M.STATE_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Reason 3 — SHADOWED_POINTER (the 2026-08-09 case)
+# ---------------------------------------------------------------------------
+def test_pointer_beside_real_package_reads_shadowed():
+    # Arrange — pointer AND a real package dir: imports work, pointer inert.
+    evidence = _evidence(pointers=(_pointer("/home/u/proj/sac/src"),))
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.REASON_SHADOWED_POINTER in verdict.reasons
+
+
+def test_pointer_without_real_package_is_not_shadowed():
+    # Arrange — GREEN: a plain editable install has no copy to shadow it.
+    evidence = _evidence(code_paths=(), pointers=(_pointer("/home/u/proj/sac/src"),))
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.REASON_SHADOWED_POINTER not in verdict.reasons
+
+
+def test_shadowing_alone_reads_broken():
+    # Arrange — shadowing WITHOUT a dead pointer: `pip install -e .` then
+    # `pip install .` on top. The target is alive, imports resolve INSIDE
+    # site-packages, nothing is missing — and the pointer is still inert,
+    # so propagation is silently dead. Isolated from every other reason on
+    # purpose: shadowing has to stand on its own, or the August case is
+    # only ever caught by accident through its dead pointer.
+    evidence = _evidence(pointers=(_pointer("/home/u/proj/sac/src", exists=True),))
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert verdict.state == M.STATE_BROKEN
+
+
+def test_shadowing_alone_names_only_that_reason():
+    # Arrange — same isolated shape; nothing else may fire.
+    evidence = _evidence(pointers=(_pointer("/home/u/proj/sac/src", exists=True),))
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert verdict.reasons == (M.REASON_SHADOWED_POINTER,)
+
+
+def test_august_shape_reports_both_shadowed_and_dead():
+    # Arrange — one verdict must carry BOTH findings; either alone hides half
+    # the repair.
+    evidence = _evidence(
+        pointers=(_pointer("/home/u/proj/sac/.worktrees/gone/src", exists=False),)
+    )
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert set(verdict.reasons) == {
+        M.REASON_DEAD_POINTER,
+        M.REASON_SHADOWED_POINTER,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reason 4 — ORPHANED_DIST_INFO (the 2026-07-16 case)
+# ---------------------------------------------------------------------------
+def test_dist_info_without_code_reads_orphaned():
+    # Arrange — dist-info advertising a version whose code is gone.
+    evidence = _evidence(code_paths=(), imported_path="")
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.REASON_ORPHANED_DIST_INFO in verdict.reasons
+
+
+def test_live_pointer_prevents_orphan_verdict():
+    # Arrange — GREEN: an editable install legitimately keeps code elsewhere.
+    evidence = _evidence(
+        code_paths=(),
+        imported_path="",
+        pointers=(_pointer("/home/u/proj/x/src"),),
+        declared_editable=True,
+    )
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.REASON_ORPHANED_DIST_INFO not in verdict.reasons
+
+
+def test_undeterminable_ownership_prevents_orphan_verdict():
+    # Arrange — GREEN: no top_level.txt and no RECORD means we cannot say
+    # what code SHOULD be there, so "no code behind it" is not decidable.
+    evidence = _evidence(code_paths=(), imported_path="", top_level_known=False)
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.REASON_ORPHANED_DIST_INFO not in verdict.reasons
+
+
+def test_undeterminable_ownership_reads_unknown():
+    # Arrange — and it must not read OK either.
+    evidence = _evidence(code_paths=(), imported_path="", top_level_known=False)
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert verdict.state == M.STATE_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Reason 5 — DUPLICATE_DIST_INFO
+# ---------------------------------------------------------------------------
+def test_two_dist_infos_read_duplicate():
+    # Arrange — the measured scitex_cards shape: 0.17.5 beside 0.17.7.
+    evidence = _evidence(
+        dist_infos=(
+            _SITE + "/scitex_cards-0.17.5.dist-info",
+            _SITE + "/scitex_cards-0.17.7.dist-info",
+        )
+    )
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.REASON_DUPLICATE_DIST_INFO in verdict.reasons
+
+
+def test_single_dist_info_is_not_duplicate():
+    # Arrange — GREEN
+    evidence = _evidence()
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.REASON_DUPLICATE_DIST_INFO not in verdict.reasons
+
+
+def test_duplicate_detail_lists_both_dist_infos():
+    # Arrange
+    evidence = _evidence(
+        dist_infos=(
+            _SITE + "/scitex_cards-0.17.5.dist-info",
+            _SITE + "/scitex_cards-0.17.7.dist-info",
+        )
+    )
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert — both fossils named, so the operator knows which to remove.
+    assert all(version in " ".join(verdict.details) for version in ("0.17.5", "0.17.7"))
+
+
+# ---------------------------------------------------------------------------
+# UNKNOWN never collapses into either pole
+# ---------------------------------------------------------------------------
+def test_absent_distribution_reads_unknown():
+    # Arrange
+    evidence = M.DistributionEvidence(name="not-installed", absent=True)
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert verdict.state == M.STATE_UNKNOWN
+
+
+def test_absent_distribution_is_never_broken():
+    # Arrange
+    evidence = M.DistributionEvidence(name="not-installed", absent=True)
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert verdict.reasons == ()
+
+
+def test_unreadable_site_reads_unknown_report():
+    # Arrange
+    site = M.SiteEvidence(
+        site_packages="/opt/venv-sac/lib/python3.12/site-packages",
+        readable=False,
+        read_error="PermissionError: [Errno 13]",
+    )
+    # Act
+    report = P.build_report(site)
+    # Assert
+    assert report.site_unknown
+
+
+def test_unreadable_site_yields_no_verdicts():
+    # Arrange
+    site = M.SiteEvidence(site_packages=_SITE, readable=False, read_error="boom")
+    # Act
+    report = P.build_report(site)
+    # Assert — nothing was observed, so nothing may be claimed.
+    assert report.verdicts == ()
+
+
+def test_broken_distribution_still_carries_unknown_legs():
+    # Arrange — a definite finding must not erase the gap beside it.
+    evidence = _evidence(
+        dist_infos=(_SITE + "/a-1.dist-info", _SITE + "/a-2.dist-info"),
+        pointers=(_pointer("/mnt/gone", exists=None),),
+    )
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert M.UNKNOWN_TARGET_UNSTATABLE in verdict.unknown_reasons
+
+
+def test_broken_outranks_unknown_in_state():
+    # Arrange — same evidence: the STATE is the actionable one.
+    evidence = _evidence(
+        dist_infos=(_SITE + "/a-1.dist-info", _SITE + "/a-2.dist-info"),
+        pointers=(_pointer("/mnt/gone", exists=None),),
+    )
+    # Act
+    verdict = P.classify_distribution(evidence, _SITE)
+    # Assert
+    assert verdict.state == M.STATE_BROKEN
+
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+def _report_with(evidence: M.DistributionEvidence) -> M.InstallIntegrityReport:
+    return P.build_report(
+        M.SiteEvidence(site_packages=_SITE, readable=True, distributions=(evidence,))
+    )
+
+
+def test_exit_code_is_one_when_broken():
+    # Arrange
+    report = _report_with(_evidence(code_paths=(), imported_path=""))
+    # Act
+    code = P.exit_code_for(report)
+    # Assert
+    assert code == 1
+
+
+def test_exit_code_is_zero_when_only_unknown():
+    # Arrange — UNKNOWN alone is an absence of evidence, not a failure.
+    report = _report_with(M.DistributionEvidence(name="ghost", absent=True))
+    # Act
+    code = P.exit_code_for(report)
+    # Assert
+    assert code == 0
+
+
+def test_strict_exit_code_is_two_when_only_unknown():
+    # Arrange
+    report = _report_with(M.DistributionEvidence(name="ghost", absent=True))
+    # Act
+    code = P.exit_code_for(report, strict=True)
+    # Assert
+    assert code == 2
+
+
+def test_exit_code_is_zero_when_clean():
+    # Arrange
+    report = _report_with(_evidence())
+    # Act
+    code = P.exit_code_for(report)
+    # Assert
+    assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Reporting helpers
+# ---------------------------------------------------------------------------
+def test_reason_breakdown_counts_by_reason():
+    # Arrange — two distributions, both duplicated.
+    dup = dict(dist_infos=(_SITE + "/a-1.dist-info", _SITE + "/a-2.dist-info"))
+    report = P.build_report(
+        M.SiteEvidence(
+            site_packages=_SITE,
+            readable=True,
+            distributions=(
+                _evidence(name="a", **dup),
+                _evidence(name="b", **dup),
+            ),
+        )
+    )
+    # Act
+    breakdown = report.reason_breakdown()
+    # Assert
+    assert breakdown[M.REASON_DUPLICATE_DIST_INFO] == 2
+
+
+def test_sibling_prefix_is_not_inside_directory():
+    # Arrange — /a/bc must never count as living under /a/b, or every
+    # containment answer above it is unsound.
+    child, parent = "/a/bc", "/a/b"
+    # Act
+    inside = P.is_under(child, parent)
+    # Assert
+    assert not inside
+
+
+def test_child_path_is_inside_directory():
+    # Arrange
+    child, parent = "/a/b/c", "/a/b"
+    # Act
+    inside = P.is_under(child, parent)
+    # Assert
+    assert inside

--- a/tests/scitex_agent_container/_maintenance/test__install_integrity_probe.py
+++ b/tests/scitex_agent_container/_maintenance/test__install_integrity_probe.py
@@ -1,0 +1,387 @@
+"""End-to-end tests for the install-integrity PROBE, on real directories.
+
+No mocks and no monkeypatch: every test builds a REAL venv layout under
+``tmp_path`` — ``venv/lib/python3.12/site-packages`` with real
+``*.dist-info`` dirs, real ``RECORD``/``top_level.txt`` files, real
+``.pth`` pointers and real package directories. That is the point: the
+predicate's unit tests prove the DECISIONS, and these prove the probe
+turns actual on-disk shapes into the right evidence. A parser bug lives
+exactly in the gap between those two.
+
+Each venv is inspected as a FOREIGN venv (not this interpreter's), so the
+import-resolution leg is honestly reported as unobservable rather than
+answered from the test runner's own ``sys.path``.
+
+The operator's real ``/opt/venv-sac`` is never touched — this whole module
+is read-only against ``tmp_path``.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name
+(TQ003).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._maintenance import _install_integrity_model as M
+from scitex_agent_container._maintenance import _install_integrity_probe as PR
+
+_PY = "python3.12"
+
+
+@pytest.fixture
+def venv(tmp_path):
+    """A real, empty venv layout. Yield-fixture: no monkeypatch (NM002)."""
+    root = tmp_path / "venv"
+    (root / "lib" / _PY / "site-packages").mkdir(parents=True)
+    yield root
+
+
+def _site(venv_root: Path) -> Path:
+    return venv_root / "lib" / _PY / "site-packages"
+
+
+def _dist_info(
+    venv_root: Path,
+    name: str,
+    version: str,
+    *,
+    top_level: str | None = None,
+    record_rows: list[str] | None = None,
+) -> Path:
+    """A REAL dist-info: METADATA + RECORD, optional top_level.txt."""
+    dist_info = _site(venv_root) / (name + "-" + version + ".dist-info")
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Name: " + name + "\nVersion: " + version + "\n"
+    )
+    rows = record_rows if record_rows is not None else [name + "/__init__.py,,"]
+    rows = rows + [dist_info.name + "/METADATA,,", dist_info.name + "/RECORD,,"]
+    (dist_info / "RECORD").write_text("\n".join(rows) + "\n")
+    if top_level is not None:
+        (dist_info / "top_level.txt").write_text(top_level + "\n")
+    return dist_info
+
+
+def _package(venv_root: Path, name: str) -> Path:
+    """A REAL importable package directory inside site-packages."""
+    pkg = _site(venv_root) / name
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("")
+    return pkg
+
+
+def _pth(venv_root: Path, filename: str, body: str) -> Path:
+    path = _site(venv_root) / filename
+    path.write_text(body)
+    return path
+
+
+def _verdict_for(venv_root: Path, name: str) -> M.DistributionVerdict:
+    report = PR.inspect_install(venv_root)
+    return next(v for v in report.verdicts if v.name == name)
+
+
+# ---------------------------------------------------------------------------
+# Baseline — a healthy wheel install on real disk
+# ---------------------------------------------------------------------------
+def test_healthy_wheel_install_reads_ok(venv):
+    # Arrange
+    _dist_info(venv, "scitex_cards", "0.32.3", top_level="scitex_cards")
+    _package(venv, "scitex_cards")
+    # Act
+    verdict = _verdict_for(venv, "scitex-cards")
+    # Assert
+    assert verdict.state == M.STATE_OK
+
+
+def test_foreign_venv_reports_imports_unobservable(venv):
+    # Arrange
+    _dist_info(venv, "scitex_cards", "0.32.3", top_level="scitex_cards")
+    _package(venv, "scitex_cards")
+    # Act
+    report = PR.inspect_install(venv)
+    # Assert — never silently answered from the test runner's own sys.path.
+    assert report.import_resolution == M.IMPORTS_UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Reason 2 — DEAD_POINTER, through each emitted shape
+# ---------------------------------------------------------------------------
+def test_uv_pth_with_missing_target_reads_dead(venv, tmp_path):
+    # Arrange — the /opt/venv-sac shape: a bare path to a deleted worktree.
+    _dist_info(venv, "scitex_agent_container", "0.24.25", top_level="x_not_here")
+    _pth(venv, "_editable_impl_scitex_agent_container.pth", str(tmp_path / "gone/src"))
+    # Act
+    verdict = _verdict_for(venv, "scitex-agent-container")
+    # Assert
+    assert M.REASON_DEAD_POINTER in verdict.reasons
+
+
+def test_setuptools_finder_with_missing_target_reads_dead(venv, tmp_path):
+    # Arrange — the strict-mode pair: .pth naming a finder, finder holding
+    # a MAPPING to a directory that is gone.
+    _dist_info(venv, "scitex_dev", "0.31.0", top_level="x_not_here")
+    _pth(
+        venv,
+        "__editable__.scitex_dev-0.31.0.pth",
+        "import __editable___scitex_dev_0_31_0_finder; "
+        "__editable___scitex_dev_0_31_0_finder.install()\n",
+    )
+    _pth(
+        venv,
+        "__editable___scitex_dev_0_31_0_finder.py",
+        "MAPPING = {'scitex_dev': '" + str(tmp_path / "gone" / "scitex_dev") + "'}\n",
+    )
+    # Act
+    verdict = _verdict_for(venv, "scitex-dev")
+    # Assert
+    assert M.REASON_DEAD_POINTER in verdict.reasons
+
+
+def test_pth_with_live_target_is_not_dead(venv, tmp_path):
+    # Arrange — GREEN: a healthy editable install.
+    live = tmp_path / "checkout" / "src"
+    (live / "scitex_dev").mkdir(parents=True)
+    _dist_info(venv, "scitex_dev", "0.31.0", top_level="scitex_dev")
+    _pth(venv, "__editable__.scitex_dev-0.31.0.pth", str(live))
+    # Act
+    verdict = _verdict_for(venv, "scitex-dev")
+    # Assert
+    assert M.REASON_DEAD_POINTER not in verdict.reasons
+
+
+def test_coverage_pth_never_becomes_a_pointer(venv):
+    # Arrange — GREEN: the bootstrap .pth every venv carries.
+    _dist_info(venv, "scitex_cards", "0.32.3", top_level="scitex_cards")
+    _package(venv, "scitex_cards")
+    _pth(
+        venv,
+        "a1_coverage.pth",
+        "import os\nif os.environ.get('COVERAGE_PROCESS_START'):\n    pass\n",
+    )
+    # Act
+    report = PR.inspect_install(venv)
+    # Assert
+    assert report.broken == ()
+
+
+# ---------------------------------------------------------------------------
+# Reason 3 — SHADOWED_POINTER (the 2026-08-09 /opt/venv-sac shape)
+# ---------------------------------------------------------------------------
+def test_pointer_beside_real_package_reads_shadowed(venv, tmp_path):
+    # Arrange — the measured August state, reproduced on disk.
+    _dist_info(
+        venv, "scitex_agent_container", "0.24.25", top_level="scitex_agent_container"
+    )
+    _package(venv, "scitex_agent_container")
+    _pth(venv, "_editable_impl_scitex_agent_container.pth", str(tmp_path / "gone/src"))
+    # Act
+    verdict = _verdict_for(venv, "scitex-agent-container")
+    # Assert
+    assert M.REASON_SHADOWED_POINTER in verdict.reasons
+
+
+def test_august_shape_reports_both_shadowed_and_dead(venv, tmp_path):
+    # Arrange — the measured /opt/venv-sac state end to end. Imports would
+    # resolve INSIDE site-packages here, which is exactly what makes the
+    # naive __file__ predicate call it clean. BOTH findings must surface;
+    # either alone hides half the repair.
+    _dist_info(
+        venv, "scitex_agent_container", "0.24.25", top_level="scitex_agent_container"
+    )
+    _package(venv, "scitex_agent_container")
+    _pth(venv, "_editable_impl_scitex_agent_container.pth", str(tmp_path / "gone/src"))
+    # Act
+    verdict = _verdict_for(venv, "scitex-agent-container")
+    # Assert
+    assert set(verdict.reasons) == {
+        M.REASON_DEAD_POINTER,
+        M.REASON_SHADOWED_POINTER,
+    }
+
+
+def test_shadowing_alone_reads_broken_on_real_disk(venv, tmp_path):
+    # Arrange — shadowing WITHOUT a dead pointer: `pip install -e .` then
+    # `pip install .` over it. The target is alive and nothing is missing;
+    # the pointer is merely inert. Isolated so this reason must stand on
+    # its own rather than riding the dead-pointer finding.
+    live = tmp_path / "checkout" / "src"
+    (live / "scitex_agent_container").mkdir(parents=True)
+    _dist_info(
+        venv, "scitex_agent_container", "0.24.25", top_level="scitex_agent_container"
+    )
+    _package(venv, "scitex_agent_container")
+    _pth(venv, "_editable_impl_scitex_agent_container.pth", str(live))
+    # Act
+    verdict = _verdict_for(venv, "scitex-agent-container")
+    # Assert
+    assert verdict.reasons == (M.REASON_SHADOWED_POINTER,)
+
+
+def test_editable_install_without_copy_is_not_shadowed(venv, tmp_path):
+    # Arrange — GREEN
+    live = tmp_path / "checkout" / "src"
+    (live / "scitex_dev").mkdir(parents=True)
+    _dist_info(venv, "scitex_dev", "0.31.0", top_level="scitex_dev")
+    _pth(venv, "__editable__.scitex_dev-0.31.0.pth", str(live))
+    # Act
+    verdict = _verdict_for(venv, "scitex-dev")
+    # Assert
+    assert M.REASON_SHADOWED_POINTER not in verdict.reasons
+
+
+# ---------------------------------------------------------------------------
+# Reason 4 — ORPHANED_DIST_INFO (the 2026-07-16 shape)
+# ---------------------------------------------------------------------------
+def test_dist_info_with_no_code_reads_orphaned(venv):
+    # Arrange — dist-info claiming a module that is not there.
+    _dist_info(venv, "scitex_dev", "0.31.0", top_level="scitex_dev")
+    # Act
+    verdict = _verdict_for(venv, "scitex-dev")
+    # Assert
+    assert M.REASON_ORPHANED_DIST_INFO in verdict.reasons
+
+
+def test_record_supplies_ownership_without_top_level(venv):
+    # Arrange — modern wheels ship no top_level.txt; RECORD must answer, or
+    # every one of them would read as an orphan.
+    _dist_info(venv, "gitpython", "3.1.50", record_rows=["git/__init__.py,,"])
+    _package(venv, "git")
+    # Act
+    verdict = _verdict_for(venv, "gitpython")
+    # Assert
+    assert verdict.state == M.STATE_OK
+
+
+def test_metadata_only_dist_reads_unknown_not_orphaned(venv):
+    # Arrange — a real meta-package (measured: fastmcp 3.4.6) lists no
+    # modules at all, so "has code behind it" is undeterminable.
+    _dist_info(venv, "fastmcp", "3.4.6", record_rows=[])
+    # Act
+    verdict = _verdict_for(venv, "fastmcp")
+    # Assert
+    assert verdict.state == M.STATE_UNKNOWN
+
+
+def test_interrupted_pip_debris_reads_orphaned(venv):
+    # Arrange — pip renames a dist's first char to `~` while replacing it
+    # and leaves the dir behind if interrupted. Measured live in
+    # /opt/venv-sac: `~citex_agent_container-0.21.13.dist-info`.
+    _dist_info(
+        venv,
+        "~citex_agent_container",
+        "0.21.13",
+        record_rows=["scitex_agent_container/__init__.py,,"],
+    )
+    _package(venv, "scitex_agent_container")
+    # Act
+    verdict = _verdict_for(venv, "~citex-agent-container")
+    # Assert — it must NOT be credited with the real dist's code.
+    assert M.REASON_ORPHANED_DIST_INFO in verdict.reasons
+
+
+# ---------------------------------------------------------------------------
+# Reason 5 — DUPLICATE_DIST_INFO
+# ---------------------------------------------------------------------------
+def test_two_dist_infos_read_duplicate(venv):
+    # Arrange — the measured scitex_cards shape: 0.17.5 beside 0.17.7.
+    _dist_info(venv, "scitex_cards", "0.17.5", top_level="scitex_cards")
+    _dist_info(venv, "scitex_cards", "0.17.7", top_level="scitex_cards")
+    _package(venv, "scitex_cards")
+    # Act
+    verdict = _verdict_for(venv, "scitex-cards")
+    # Assert
+    assert M.REASON_DUPLICATE_DIST_INFO in verdict.reasons
+
+
+def test_duplicate_verdict_lists_both_dist_infos(venv):
+    # Arrange
+    _dist_info(venv, "scitex_cards", "0.17.5", top_level="scitex_cards")
+    _dist_info(venv, "scitex_cards", "0.17.7", top_level="scitex_cards")
+    _package(venv, "scitex_cards")
+    # Act
+    verdict = _verdict_for(venv, "scitex-cards")
+    # Assert
+    assert len(verdict.evidence.dist_infos) == 2
+
+
+# ---------------------------------------------------------------------------
+# UNKNOWN paths through the probe
+# ---------------------------------------------------------------------------
+def test_missing_site_packages_reads_site_unknown(tmp_path):
+    # Arrange — a venv path that does not exist at all.
+    # Act
+    report = PR.inspect_install(tmp_path / "no-such-venv")
+    # Assert
+    assert report.site_unknown
+
+
+def test_missing_site_packages_produces_no_verdicts(tmp_path):
+    # Arrange
+    # Act
+    report = PR.inspect_install(tmp_path / "no-such-venv")
+    # Assert — nothing observed, so nothing claimed.
+    assert report.verdicts == ()
+
+
+def test_requested_absent_dist_reads_unknown(venv):
+    # Arrange
+    _dist_info(venv, "scitex_cards", "0.32.3", top_level="scitex_cards")
+    _package(venv, "scitex_cards")
+    # Act
+    report = PR.inspect_install(venv, dists=("not-installed",))
+    # Assert
+    assert report.unknown[0].unknown_reasons == (M.UNKNOWN_DIST_ABSENT,)
+
+
+def test_dist_filter_narrows_the_report(venv):
+    # Arrange
+    _dist_info(venv, "scitex_cards", "0.32.3", top_level="scitex_cards")
+    _package(venv, "scitex_cards")
+    _dist_info(venv, "scitex_dev", "0.43.0", top_level="scitex_dev")
+    _package(venv, "scitex_dev")
+    # Act
+    report = PR.inspect_install(venv, dists=("scitex-cards",))
+    # Assert
+    assert [v.name for v in report.verdicts] == ["scitex-cards"]
+
+
+# ---------------------------------------------------------------------------
+# site-packages resolution
+# ---------------------------------------------------------------------------
+def test_site_packages_path_is_accepted_directly(venv):
+    # Arrange
+    site = _site(venv)
+    # Act
+    resolved, _note = PR.resolve_site_packages(site)
+    # Assert
+    assert resolved == str(site)
+
+
+def test_venv_root_resolves_to_its_site_packages(venv):
+    # Arrange
+    # Act
+    resolved, _note = PR.resolve_site_packages(venv)
+    # Assert
+    assert resolved == str(_site(venv))
+
+
+def test_two_python_dirs_are_not_merged(venv):
+    # Arrange — merging would invent duplicate dist-infos that exist for
+    # neither interpreter.
+    (venv / "lib" / "python3.11" / "site-packages").mkdir(parents=True)
+    # Act
+    _resolved, note = PR.resolve_site_packages(venv)
+    # Assert
+    assert "not merged" in note
+
+
+def test_default_target_is_this_interpreters_venv():
+    # Arrange
+    # Act
+    resolved, _note = PR.resolve_site_packages(None)
+    # Assert
+    assert resolved == PR.running_site_packages()

--- a/tests/scitex_agent_container/cli_pkg/test__installation_check.py
+++ b/tests/scitex_agent_container/cli_pkg/test__installation_check.py
@@ -1,0 +1,226 @@
+"""CLI tests for ``sac installation check``.
+
+PA-306: no mocks. ``CliRunner`` drives the real click command against a
+REAL venv layout built under ``tmp_path`` — real dist-info dirs, real
+``.pth`` pointers, real package directories. The operator's
+``/opt/venv-sac`` is never touched.
+
+The exit-code contract is the load-bearing part and is asserted from both
+ends: BROKEN must fail the command, and UNKNOWN alone must NOT — turning
+"I could not look" into a red build is how a check gets ``|| true``'d into
+uselessness. ``--strict`` is the opt-in for callers who need a complete
+answer rather than merely no bad news.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name
+(TQ003). No monkeypatch (NM002).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._installation_check import installation_check
+
+_PY = "python3.12"
+
+
+@pytest.fixture
+def runner():
+    """Real click runner. Yield-fixture: no monkeypatch (NM002)."""
+    yield CliRunner()
+
+
+@pytest.fixture
+def clean_venv(tmp_path):
+    """A real venv whose single distribution is coherent."""
+    root = tmp_path / "clean"
+    site = root / "lib" / _PY / "site-packages"
+    site.mkdir(parents=True)
+    _dist_info(site, "scitex_cards", "0.32.3")
+    _package(site, "scitex_cards")
+    yield root
+
+
+@pytest.fixture
+def broken_venv(tmp_path):
+    """A real venv reproducing the 2026-08-09 shape: dead + shadowed."""
+    root = tmp_path / "broken"
+    site = root / "lib" / _PY / "site-packages"
+    site.mkdir(parents=True)
+    _dist_info(site, "scitex_agent_container", "0.24.25")
+    _package(site, "scitex_agent_container")
+    (site / "_editable_impl_scitex_agent_container.pth").write_text(
+        str(tmp_path / "deleted-worktree" / "src")
+    )
+    yield root
+
+
+def _dist_info(site: Path, name: str, version: str) -> Path:
+    dist_info = site / (name + "-" + version + ".dist-info")
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text("Name: " + name + "\n")
+    (dist_info / "top_level.txt").write_text(name + "\n")
+    (dist_info / "RECORD").write_text(name + "/__init__.py,,\n")
+    return dist_info
+
+
+def _package(site: Path, name: str) -> Path:
+    pkg = site / name
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("")
+    return pkg
+
+
+# ---------------------------------------------------------------------------
+# Exit-code contract
+# ---------------------------------------------------------------------------
+def test_broken_venv_exits_non_zero(runner, broken_venv):
+    # Arrange
+    # Act
+    result = runner.invoke(installation_check, [str(broken_venv)])
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_clean_venv_exits_zero(runner, clean_venv):
+    # Arrange
+    # Act
+    result = runner.invoke(installation_check, [str(clean_venv)])
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_unknown_alone_exits_zero(runner, clean_venv):
+    # Arrange — an absent distribution is UNKNOWN, and UNKNOWN is not a
+    # failure: it is an absence of evidence.
+    # Act
+    result = runner.invoke(
+        installation_check, [str(clean_venv), "--dist", "not-installed"]
+    )
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_strict_makes_unknown_exit_two(runner, clean_venv):
+    # Arrange
+    # Act
+    result = runner.invoke(
+        installation_check, [str(clean_venv), "--dist", "not-installed", "--strict"]
+    )
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_missing_venv_exits_zero_without_strict(runner, tmp_path):
+    # Arrange — an unreadable site-packages is UNKNOWN, not BROKEN.
+    # Act
+    result = runner.invoke(installation_check, [str(tmp_path / "no-such-venv")])
+    # Assert
+    assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Output — UNKNOWN must be VISIBLE even though it does not fail
+# ---------------------------------------------------------------------------
+def test_unknown_row_is_printed(runner, clean_venv):
+    # Arrange
+    # Act
+    result = runner.invoke(
+        installation_check, [str(clean_venv), "--dist", "not-installed"]
+    )
+    # Assert
+    assert "UNKNOWN" in result.output
+
+
+def test_missing_venv_says_why(runner, tmp_path):
+    # Arrange
+    # Act
+    result = runner.invoke(installation_check, [str(tmp_path / "no-such-venv")])
+    # Assert
+    assert "UNKNOWN" in result.output
+
+
+def test_broken_row_names_the_reason(runner, broken_venv):
+    # Arrange
+    # Act
+    result = runner.invoke(installation_check, [str(broken_venv)])
+    # Assert
+    assert "shadowed-pointer" in result.output
+
+
+def test_clean_venv_hides_ok_rows_by_default(runner, clean_venv):
+    # Arrange
+    # Act
+    result = runner.invoke(installation_check, [str(clean_venv)])
+    # Assert
+    assert "scitex-cards" not in result.output
+
+
+def test_all_flag_lists_ok_rows(runner, clean_venv):
+    # Arrange
+    # Act
+    result = runner.invoke(installation_check, [str(clean_venv), "--all"])
+    # Assert
+    assert "scitex-cards" in result.output
+
+
+def test_foreign_venv_declares_imports_unobservable(runner, clean_venv):
+    # Arrange — never let a skipped leg read as a clean one.
+    # Act
+    result = runner.invoke(installation_check, [str(clean_venv)])
+    # Assert
+    assert "UNOBSERVABLE" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --json contract
+# ---------------------------------------------------------------------------
+def test_json_output_parses(runner, broken_venv):
+    # Arrange
+    # Act
+    result = runner.invoke(installation_check, [str(broken_venv), "--json"])
+    # Assert
+    assert json.loads(result.output)["counts"]["broken"] == 1
+
+
+def test_json_carries_the_exit_code(runner, broken_venv):
+    # Arrange
+    # Act
+    result = runner.invoke(installation_check, [str(broken_venv), "--json"])
+    # Assert
+    assert json.loads(result.output)["exit_code"] == 1
+
+
+def test_json_reason_breakdown_names_shadowed(runner, broken_venv):
+    # Arrange
+    # Act
+    result = runner.invoke(installation_check, [str(broken_venv), "--json"])
+    # Assert
+    assert "shadowed-pointer" in json.loads(result.output)["reason_breakdown"]
+
+
+def test_json_carries_the_dead_pointer_path(runner, broken_venv):
+    # Arrange — the pointer path IS the repair instruction.
+    # Act
+    result = runner.invoke(installation_check, [str(broken_venv), "--json"])
+    payload = json.loads(result.output)
+    row = next(d for d in payload["distributions"] if d["state"] == "broken")
+    # Assert
+    assert row["evidence"]["pointers"][0]["target_exists"] is False
+
+
+# ---------------------------------------------------------------------------
+# Wiring — the verb must actually be reachable as `sac installation check`
+# ---------------------------------------------------------------------------
+def test_check_is_registered_on_the_installation_group():
+    # Arrange
+    from scitex_agent_container.cli_pkg.installation_group import install_group
+
+    # Act
+    names = list(install_group.commands)
+    # Assert
+    assert "check" in names


### PR DESCRIPTION
## Why

Twice now an agent has executed code that nobody believed was installed — and **both times `--version` reported a healthy number throughout**:

- **2026-07-16** (scitex-dev container): an orphaned `scitex_dev-0.31.0.dist-info/` with no code behind it, plus `__editable__.scitex_dev-*.pth` redirecting imports into an **abandoned PR scratch worktree**. Commands ran from a disposable temp dir for days.
- **2026-08-09** (`/opt/venv-sac`): `_editable_impl_scitex_agent_container.pth` targets `.worktrees/persist-boot-failure-diag/.worktrees/agent-aae4c0d9a337e71b6/src` — a path that is gone, on a branch that is gone. A **real** `scitex_agent_container/` directory sits beside it in site-packages, so imports succeed and `sac --version` cheerfully reports 0.24.25 while the editable pointer has been inert the whole time.

**The obvious predicate is insufficient.** "Flag whatever resolves outside site-packages" catches July and reports August as **CLEAN**, because the shadowing copy makes `__file__` resolve *inside* site-packages. `--version` is useless for the whole class (confirmed twice). Only path-level inspection exposes it.

## What

`sac installation check [VENV]` — read-only, with `--json`, `--strict`, `--dist`, `--all`.

Five reasons, three-valued per distribution:

| reason | shape |
|---|---|
| `resolves-outside-site-packages` | imports land outside site-packages and no **live** editable pointer explains it |
| `dead-pointer` | an editable pointer whose target does not exist |
| `shadowed-pointer` | pointer **and** a real package dir coexist — the copy wins, the pointer is inert |
| `orphaned-dist-info` | dist-info with no code behind it |
| `duplicate-dist-info` | two dist-info dirs for one distribution |

`UNKNOWN` never collapses into either pole (unreadable site-packages, absent distribution, evidence too thin to decide). It prints as loudly as a break but does **not** fail the exit code — turning "I could not look" into a red build is how a check gets `|| true`'d. `--strict` (exit 2) is the opt-in for callers needing a *complete* answer rather than merely no bad news.

Pointer parsing covers every shape pip/uv/setuptools emit — `__editable__*.pth`, `*_editable_impl_*.pth`, `__editable___*_finder.py`, and plain `.pth` files carrying an absolute path — read **statically via `ast`**, never imported or `exec`'d. These are the files we already suspect of pointing at abandoned trees; running them to find out where they point is the wrong instinct. The coverage-bootstrap `.pth` files every venv carries are correctly *not* treated as pointers.

Reason 1 is deliberately qualified as an **unexplained** redirect. An editable install resolving to its own live target is what an editable install *is*; the unqualified form would report every healthy dev venv as BROKEN. The July shape is still caught — by `orphaned-dist-info`, and by `dead-pointer` once the scratch tree is removed.

### Where the verb lives, and why

- `sac doctor` is scoped by its own docstring, `--fleet` and exit-code contract to **one** subject: agent-spec git drift. Folding a venv audit in would make one exit code mean two unrelated things.
- `sac provenance` is closest in concern but **self-scoped**: it audits only this package's own dist on the running `sys.path`. This check is venv-scoped, all-distributions, and can inspect a venv the current interpreter is not running from.
- `sac installation` is the **install noun**, already in the "Build & Install" category and already home to `boot` and `setup-cron` — both mutators. A read-only `check` completes the noun rather than inventing one.

### Layout

Mirrors the existing `_worktree_gc_*` split: `_model` (data + vocabulary), `_predicate` (pure decisions), `_pointers` (parsing), `_probe` (filesystem observation). The pure layers take a description of what was found on disk, so the tests reach all five reasons without building real venvs.

## Measured against the live `/opt/venv-sac`

Read-only, path-level (import leg deliberately isolated so the harness's own `PYTHONPATH` cannot contaminate it):

```
145 distribution(s), 137 ok, 7 BROKEN, 1 UNKNOWN, import-resolution UNOBSERVABLE
breakdown: {'dead-pointer': 1, 'shadowed-pointer': 1, 'orphaned-dist-info': 1, 'duplicate-dist-info': 5}

BROKEN scitex-agent-container  ('dead-pointer', 'shadowed-pointer')   <-- as predicted
BROKEN ~citex-agent-container  ('orphaned-dist-info',)
BROKEN cyclopts / openai / openai-agents / scitex-dev / tqdm  ('duplicate-dist-info',)
UNKNOWN fastmcp                ('owned-modules-undeterminable',)
```

`scitex-agent-container` reports **exactly** the `shadowed-pointer` + `dead-pointer` state described in the incident. Three further findings were **not** anticipated and are real:

1. **5 duplicate dist-info pairs** — `cyclopts` 4.21.2/4.22.5, `openai` 2.45.0/2.53.0, `openai-agents` 0.18.1/0.19.4, `scitex-dev` 0.38.0/0.43.0, `tqdm` 4.68.3/4.70.0. Independently corroborated: scitex-dev's own linter emits `ambiguous metadata — 2 dist-info directories claim it` for `scitex-dev` on every lint run in this container.
2. **`~citex_agent_container-0.21.13.dist-info`** — pip renames a dist's first character to `~` while replacing it, and leaves the directory behind if interrupted. Handled explicitly: such a dir owns no modules *of its own* (its RECORD describes the distribution it was replacing), and crediting it with that code is exactly how the fossil hides.
3. **`fastmcp` UNKNOWN is correct, not a bug** — 3.4.6 is a genuine meta-package whose RECORD lists only dist-info files, so "which modules does it own" is genuinely undeterminable.

**This PR repairs nothing.** Fixing `/opt/venv-sac` is a separate, deliberate step gated behind this guard.

## Tests — 107 new, negative-controlled

Each of the five detection branches was **neutered in place** (unconditional `return None`), its tests confirmed to **FAIL**, then restored.

| reason | tests | under neutering |
|---|---|---|
| `resolves-outside-site-packages` | 2 | 2 failed |
| `dead-pointer` | 5 | 5 failed |
| `shadowed-pointer` | 7 | 7 failed |
| `orphaned-dist-info` | 3 | 3 failed |
| `duplicate-dist-info` | 3 | 3 failed |

Restored: **107 passed**, zero neuter residue. Full `_maintenance` + `installation` suites: **239 passed**, no regressions.

The exercise found two real defects, both fixed here rather than papered over:

- **A bug in the predicate.** `orphaned-dist-info` fired when a pointer's target was *unstattable* — but such a pointer might well be serving the code, so claiming an orphan laundered an unknown into a definite verdict. Now only a pointer **proven dead** leaves a dist-info unserved; the unsettled leg is reported as UNKNOWN.
- **A weak test.** The first negative-control pass showed 2 shadowed-pointer tests still passing with the branch removed — they asserted only `state == BROKEN`, which stayed true via the surviving dead-pointer finding. Replaced with an isolated shadowing shape (live target, real copy, imports resolving inside site-packages — i.e. `pip install -e .` then `pip install .` over it), so the reason must stand on its own. All 7 now discriminate.

No mocks, no `monkeypatch` (yield fixtures throughout), real temp venv layouts on disk, one logical assert per test, AAA markers.

## Pre-existing issue surfaced, not fixed

`src/scitex_agent_container/cli_pkg/_main.py` is **516 lines** — over the repo's 512-line hook limit — before this PR touches anything. That blocked updating the `LAZY_SHORT_HELPS` mirror for the `installation` group. Worked around by keeping the group docstring's **first line** byte-identical to the mirror (click derives `short_help` from it) and describing the widened scope on the following lines, so the mirror stays accurate. Refactoring `_main.py` belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWwZWke4rh2Civ11ybUw4k
