### PR TITLE
feat(relocate): give the preflight eyes — the probe adapter, batched but honest per fact

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_relocate_probe_adapter.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe_adapter.py
@@ -1,0 +1,479 @@
+"""The eleven callables :class:`.._relocate_probe.TargetProbes` asks for.
+
+:mod:`_relocate_probe` is the PORT — pure orchestration that turns any raising
+callable into ``None``. This is the ADAPTER: it reads the agent's spec, asks the
+target once (:mod:`_relocate_probe_ssh` + :mod:`_relocate_probe_script`), and
+hands back eleven closures over that single answer.
+
+HOW PER-FACT DEGRADATION SURVIVES BATCHING — the design point of this file.
+One remote call answers all eleven questions, which is the only way this is fast
+enough to be run casually. The obvious way to do that is also the dangerous one:
+one blob, one status, eleven facts that stand or fall together. Three rules keep
+them independent, and they compose:
+
+    the SCRIPT   prints each answer on its own marker line the moment it is
+                 known, and never runs under ``set -e``, so a section that dies
+                 cannot retract or prevent the others (see
+                 :mod:`_relocate_probe_script`).
+    the PARSER   reports only what it SAW. A line that never arrived leaves no
+                 key; it does not leave a default.
+    THIS FILE    gives every fact its own accessor, and an accessor whose
+                 evidence is missing RAISES — with a sentence saying which
+                 evidence and why it might be absent. ``probe()`` turns that
+                 raise into ``None`` plus the reason, so the operator reads
+                 "credentials_valid: UNKNOWN (no credential file exists on the
+                 target among: …)" rather than a bare UNKNOWN.
+
+So a run that answers eight of eleven yields eight OBSERVED facts and three
+unknowns, each naming its own cause. A transport failure yields eleven unknowns
+sharing one cause. Neither yields a single ``False``.
+
+NEVER ``False`` FOR "I COULD NOT TELL". Every accessor below either returns
+something the target actually said or raises. There is no ``except: return
+False`` here, and there must never be: it would turn "no route to the host" into
+"the host has no image", and the relocation would then proceed on fiction — the
+exact 2026-08-07 failure this command exists to prevent.
+
+WHAT IS MEASURED VS WHAT IS READ. Ten facts are measured on the target. One —
+``card_store_url`` — is READ FROM THE SPEC: it is the URL the agent WOULD dial
+after the move, and preflight uses it only to name the endpoint in a failure
+message. It is supplied because a failure that says "card store not reachable"
+without saying WHICH is an error message that starts an investigation instead of
+ending one.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable
+from urllib.parse import urlparse
+
+from ._relocate_probe import TargetProbes
+from ._relocate_probe_script import (
+    REMOTE_DEFAULT_CREDENTIAL,
+    RemoteQuestions,
+    RemoteReadout,
+    parse_probe_output,
+    render_probe_script,
+)
+from ._relocate_probe_ssh import (
+    DEFAULT_TIMEOUT_S,
+    ProbeTransportError,
+    RemoteRun,
+    peer_preamble,
+    run_probe_script,
+)
+
+__all__ = [
+    "FactUnavailable",
+    "TargetBatch",
+    "build_target_probes",
+    "card_store_url_from_spec",
+    "hub_address",
+    "questions_from_spec",
+]
+
+#: Operator override for the hub address AS SEEN FROM THE TARGET, ``host:port``.
+HUB_ADDR_ENV = "SAC_RELOCATE_HUB_ADDR"
+
+_LOOPBACK = frozenset({"127.0.0.1", "localhost", "::1", "0.0.0.0", ""})
+
+
+class FactUnavailable(RuntimeError):
+    """This fact was not observed, and here is the sentence explaining why.
+
+    Raised — never returned as a falsy value. :func:`.._relocate_probe.probe`
+    catches it, records the message, and leaves the fact ``None``.
+    """
+
+
+def _body(spec: dict) -> dict:
+    inner = spec.get("spec")
+    return inner if isinstance(inner, dict) else spec
+
+
+def _apptainer(spec: dict) -> dict:
+    app = _body(spec).get("apptainer")
+    return app if isinstance(app, dict) else {}
+
+
+def card_store_url_from_spec(spec: dict) -> str:
+    """The ``SCITEX_CARDS_DB`` the agent would use, wherever the spec hides it.
+
+    Two places, both real: ``apptainer.env`` and the ``--env KEY=VALUE`` pairs in
+    ``apptainer.raw_args``. This repo's own spec uses the second and leaves the
+    first an empty mapping, so a reader of ``env`` alone concludes the agent has
+    no card store — and then the store check has nothing to check while looking
+    like it passed.
+    """
+    app = _apptainer(spec)
+    env = app.get("env")
+    if isinstance(env, dict):
+        value = env.get("SCITEX_CARDS_DB")
+        if isinstance(value, str) and value:
+            return value
+    raw = app.get("raw_args")
+    if isinstance(raw, list):
+        for item in raw:
+            if isinstance(item, str) and item.startswith("SCITEX_CARDS_DB="):
+                return item.split("=", 1)[1]
+    return ""
+
+
+def _endpoint(url: str) -> tuple[str, int]:
+    """``postgresql://user@host:5432/db`` -> ``("host", 5432)``; ``("", 0)`` if unusable."""
+    if not url:
+        return ("", 0)
+    try:
+        parsed = urlparse(url)
+        host = parsed.hostname or ""
+        port = parsed.port or 0
+    except ValueError:
+        return ("", 0)
+    return (host, port) if host and port else ("", 0)
+
+
+def _credential_paths(spec: dict) -> tuple[str, ...]:
+    claude = _body(spec).get("claude")
+    if not isinstance(claude, dict):
+        return ()
+    paths: list[str] = []
+    single = claude.get("credentials_file")
+    if isinstance(single, str) and single.strip():
+        paths.append(single.strip())
+    listed = claude.get("credentials_files")
+    if isinstance(listed, list):
+        paths += [p.strip() for p in listed if isinstance(p, str) and p.strip()]
+    return tuple(dict.fromkeys(paths))
+
+
+def _bind_sources(spec: dict) -> tuple[str, ...]:
+    binds = _apptainer(spec).get("binds")
+    if not isinstance(binds, list):
+        return ()
+    return tuple(
+        b.split(":", 1)[0] for b in binds if isinstance(b, str) and b.split(":", 1)[0]
+    )
+
+
+def hub_address(env: dict[str, str] | None = None) -> tuple[str, int, str]:
+    """The hub as an address that MEANS SOMETHING ON THE TARGET, or a refusal.
+
+    Returns ``(host, port, reason_it_cannot_be_probed)``; exactly one side is
+    populated.
+
+    THE LOOPBACK TRAP IS WHY THIS RETURNS A REASON RATHER THAN A GUESS. sac's
+    listen daemon is normally reached at ``http://127.0.0.1:7878``. Handing that
+    to the target would measure the TARGET's own loopback — answering a
+    different question, confidently, in the same words. That is precisely the
+    mistake :data:`.._relocate_preflight.CHECK_HUB_FROM_TARGET` was written
+    about ("reaching them from HERE proves nothing about THERE"), so a loopback
+    hub address yields an honest UNKNOWN naming the override to set.
+
+    The card store is deliberately NOT treated this way: there, loopback is the
+    right thing to probe, because after the move the agent runs on the target
+    and ``127.0.0.1`` means the target's own database.
+    """
+    env = os.environ if env is None else env
+    override = (env.get(HUB_ADDR_ENV) or "").strip()
+    if override:
+        host, _, raw_port = override.rpartition(":")
+        if host and raw_port.isdigit():
+            return (host, int(raw_port), "")
+        return (
+            "",
+            0,
+            f"{HUB_ADDR_ENV}={override!r} is not a 'host:port' address",
+        )
+    base = (env.get("SAC_LISTEN_BASE_URL") or "").strip()
+    host, port = _endpoint(base)
+    if host and host not in _LOOPBACK:
+        return (host, port, "")
+    where = base or "(SAC_LISTEN_BASE_URL unset)"
+    return (
+        "",
+        0,
+        f"the hub is only known by a loopback address here ({where}); probing that "
+        f"FROM the target would measure the TARGET's loopback, not the hub. Set "
+        f"{HUB_ADDR_ENV}=<host:port> to the address the target should reach it on.",
+    )
+
+
+def questions_from_spec(
+    spec: dict,
+    *,
+    required_ports: tuple[int, ...] = (),
+    env: dict[str, str] | None = None,
+) -> RemoteQuestions:
+    """Turn the agent's spec into the set of questions to ask its future host."""
+    store_host, store_port = _endpoint(card_store_url_from_spec(spec))
+    hub_host, hub_port, _ = hub_address(env)
+    image = _apptainer(spec).get("image")
+    return RemoteQuestions(
+        image=image if isinstance(image, str) else "",
+        bind_sources=_bind_sources(spec),
+        card_store_host=store_host,
+        card_store_port=store_port,
+        credential_paths=_credential_paths(spec),
+        required_ports=tuple(required_ports),
+        hub_host=hub_host,
+        hub_port=hub_port,
+    )
+
+
+class TargetBatch:
+    """One ssh round trip, memoized, read eleven different ways.
+
+    The run happens on first access and NOT in ``__init__``: a caller that
+    builds probes but never gathers must not open a connection. The outcome —
+    success or transport failure — is remembered, so eleven accessors cost one
+    ssh, and a target that is down is not dialled eleven times.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        questions: RemoteQuestions,
+        *,
+        spec: dict | None = None,
+        runner: Callable[..., RemoteRun] | None = None,
+        preamble: str | None = None,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        self.host = host
+        self.questions = questions
+        self.spec = spec or {}
+        self._runner = runner if runner is not None else run_probe_script
+        self._preamble = peer_preamble(host) if preamble is None else preamble
+        self._timeout_s = timeout_s
+        self._hub_reason = hub_address(env)[2]
+        self._run: RemoteRun | None = None
+        self._readout: RemoteReadout | None = None
+        self._error: ProbeTransportError | None = None
+
+    # -- the single call ---------------------------------------------------
+    def _ensure(self) -> None:
+        if self._readout is not None or self._error is not None:
+            return
+        script = render_probe_script(self.questions, preamble=self._preamble)
+        try:
+            self._run = self._runner(self.host, script, timeout_s=self._timeout_s)
+        except ProbeTransportError as exc:
+            self._error = exc
+            return
+        self._readout = parse_probe_output(self._run.stdout)
+
+    def readout(self) -> RemoteReadout:
+        self._ensure()
+        if self._error is not None:
+            raise FactUnavailable(str(self._error))
+        assert self._readout is not None
+        return self._readout
+
+    def _field(self, key: str, what: str) -> str:
+        value = self.readout().fields.get(key)
+        if value is None:
+            raise FactUnavailable(
+                f"the target printed no {what} line; that section of the probe "
+                "did not run (the earlier sections' answers are still good)"
+            )
+        return value
+
+    # -- the eleven facts --------------------------------------------------
+    def reachable(self) -> bool:
+        """True when the target ran our script; False only when ssh itself failed."""
+        self._ensure()
+        if self._error is not None:
+            raise FactUnavailable(str(self._error))
+        if self._readout is not None and self._readout.started:
+            return True
+        run = self._run
+        if run is not None and run.ssh_failed:
+            # ssh's own exit 255: the connection did not happen. That IS an
+            # observation about the target, unlike a transport failure above.
+            return False
+        tail = (run.stderr.strip().splitlines()[-1:] or [""])[0] if run else ""
+        raise FactUnavailable(
+            f"ssh to {self.host} exited {run.exit_code if run else '?'} without the "
+            f"probe's opening marker, so whether the host answered is undetermined: {tail[:160]}"
+        )
+
+    def image_present(self) -> bool:
+        if not self.questions.image:
+            raise FactUnavailable(
+                "the spec declares no apptainer image, so nothing was asked about "
+                "on the target; add spec.apptainer.image to make this measurable"
+            )
+        value = self._field("image", "image")
+        if value == "present":
+            return True
+        if value == "absent":
+            return False
+        raise FactUnavailable(f"the target reported image={value!r}, which is neither")
+
+    def missing_bind_sources(self) -> tuple[str, ...]:
+        wanted = self.questions.bind_sources
+        if not wanted:
+            # Nothing declared: no bind source can be missing. Observed by
+            # construction, not by defaulting.
+            return ()
+        checked = self._field("binds_checked", "bind-check")
+        if checked != str(len(wanted)):
+            raise FactUnavailable(
+                f"the target reported checking {checked!r} of {len(wanted)} bind "
+                "sources; a partial sweep cannot distinguish 'present' from 'not reached'"
+            )
+        return self.readout().missing_binds
+
+    def card_store_url(self) -> str:
+        url = card_store_url_from_spec(self.spec)
+        if not url:
+            raise FactUnavailable(
+                "no SCITEX_CARDS_DB is declared for this agent (checked "
+                "spec.apptainer.env and the --env pairs in spec.apptainer.raw_args)"
+            )
+        return url
+
+    def card_store_reachable(self) -> bool:
+        if not self.questions.card_store_host:
+            raise FactUnavailable(
+                "the declared SCITEX_CARDS_DB has no host:port to dial, so "
+                "reachability from the target could not be measured"
+            )
+        return self._yes_no("cardstore", "card-store")
+
+    def _yes_no(self, key: str, what: str) -> bool:
+        value = self._field(key, what)
+        if value == "yes":
+            return True
+        if value == "no":
+            return False
+        raise FactUnavailable(
+            f"the target could not run a TCP probe for the {what} (neither python3 "
+            "nor a -z-capable nc is installed there), so this is undetermined "
+            "rather than closed"
+        )
+
+    def _chosen_credential(self):
+        """The credential the target would actually be able to use.
+
+        Among the files that EXIST there, the one expiring LAST — mirroring
+        sac's own healthy-account picker. Both credential facts read this same
+        file, so the report never describes an expiry from one file and a
+        refresh token from another.
+        """
+        creds = self.readout().credentials
+        dated = [c for c in creds if c.expires_at_ms is not None]
+        if not dated:
+            candidates = ", ".join(
+                (*self.questions.credential_paths, REMOTE_DEFAULT_CREDENTIAL)
+            )
+            raise FactUnavailable(
+                "no credential file with a readable claudeAiOauth.expiresAt exists "
+                f"on the target among: {candidates}"
+            )
+        return max(dated, key=lambda c: c.expires_at_ms or 0.0)
+
+    def credential_expires_in_s(self) -> float:
+        chosen = self._chosen_credential()
+        raw_epoch = self._field("epoch", "clock")
+        try:
+            epoch = float(raw_epoch)
+        except ValueError as exc:
+            raise FactUnavailable(
+                f"the target's clock came back as {raw_epoch!r}"
+            ) from exc
+        # The TARGET's clock, not ours: an expiry compared against the wrong
+        # machine's time is wrong by exactly the skew between them.
+        return (chosen.expires_at_ms or 0.0) / 1000.0 - epoch
+
+    def credential_refresh_token_present(self) -> bool:
+        chosen = self._chosen_credential()
+        if chosen.refresh_present is None:
+            raise FactUnavailable(
+                f"the target could not report whether {chosen.path} carries a refreshToken"
+            )
+        return chosen.refresh_present
+
+    def supported_runtimes(self) -> tuple[str, ...]:
+        value = self.readout().fields.get("runtimes")
+        if not value:
+            raise FactUnavailable(
+                "the target's sac did not report which runtimes it accepts — sac is "
+                "not importable there, or is too old to carry the symbol. Check with: "
+                f"ssh {self.host} 'sac --version'"
+            )
+        return tuple(v for v in value.split(",") if v)
+
+    def rejected_spec_keys(self) -> tuple[str, ...]:
+        value = self.readout().fields.get("speckeys")
+        if not value:
+            raise FactUnavailable(
+                "the target's sac did not report which top-level spec keys it knows, "
+                "so whether it would reject this spec is undetermined"
+            )
+        known = {k for k in value.split(",") if k}
+        ours = [k for k in self.spec if isinstance(k, str)]
+        return tuple(sorted(k for k in ours if k not in known))
+
+    def ports_in_use(self) -> tuple[int, ...]:
+        wanted = self.questions.required_ports
+        if not wanted:
+            # The spec pins no port (``a2a.port: auto`` defers to boot), so none
+            # of the required ports can clash. No tool on the target is needed
+            # to know that, and none was asked for.
+            return ()
+        checked = self.readout().fields.get("ports_checked")
+        if checked != str(len(wanted)):
+            raise FactUnavailable(
+                f"the target could not list listening ports (neither ss nor netstat "
+                f"is installed there), so whether {wanted} are free is undetermined"
+            )
+        return self.readout().ports_in_use
+
+    def hub_reachable_from_target(self) -> bool:
+        if not self.questions.hub_host:
+            raise FactUnavailable(self._hub_reason or "the hub address is unknown")
+        return self._yes_no("hub", "hub")
+
+
+def build_target_probes(
+    to_host: str,
+    spec: dict,
+    *,
+    required_ports: tuple[int, ...] = (),
+    runner: Callable[..., RemoteRun] | None = None,
+    preamble: str | None = None,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    env: dict[str, str] | None = None,
+) -> tuple[TargetProbes, TargetBatch]:
+    """Bind the eleven accessors of one :class:`TargetBatch` into a probe set.
+
+    Returns the probes and the batch, so a caller that wants the raw readout
+    (for diagnostics) does not have to run the probe twice.
+    """
+    questions = questions_from_spec(spec, required_ports=required_ports, env=env)
+    batch = TargetBatch(
+        to_host,
+        questions,
+        spec=spec,
+        runner=runner,
+        preamble=preamble,
+        timeout_s=timeout_s,
+        env=env,
+    )
+    probes = TargetProbes(
+        reachable=batch.reachable,
+        image_present=batch.image_present,
+        missing_bind_sources=batch.missing_bind_sources,
+        card_store_url=batch.card_store_url,
+        card_store_reachable=batch.card_store_reachable,
+        credential_expires_in_s=batch.credential_expires_in_s,
+        credential_refresh_token_present=batch.credential_refresh_token_present,
+        supported_runtimes=batch.supported_runtimes,
+        rejected_spec_keys=batch.rejected_spec_keys,
+        ports_in_use=batch.ports_in_use,
+        hub_reachable_from_target=batch.hub_reachable_from_target,
+    )
+    return probes, batch

--- a/src/scitex_agent_container/_lifecycle/_relocate_probe_script.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe_script.py
@@ -1,0 +1,410 @@
+"""One remote script, one round trip, and an answer that degrades PER FACT.
+
+:mod:`_relocate_probe` defines the port — eleven callables, and a failed one
+must produce ``None``. This module is half the adapter: the POSIX-sh script the
+target runs, and the parser that turns its output back into facts. Nothing here
+opens a connection; it renders a string and reads a string, so every parse rule
+below is unit-testable against captured output from a real host.
+
+WHY ONE BATCHED CALL. Eleven sequential ssh round trips to a NAS across a home
+LAN is tens of seconds for a command whose entire job is to say "not yet". The
+script answers everything in one connection.
+
+WHY BATCHING IS DANGEROUS, AND WHAT IS DONE ABOUT IT. The obvious batched
+implementation returns one blob and one status: if anything goes wrong the
+caller has eleven unknowns, or — far worse — eleven confident falses. Three
+rules keep the batch honest, and they are the reason this module exists as its
+own file:
+
+    1. NO ``set -e``.  A section that fails must not abort the sections after
+       it. Each answer is printed the moment it is known, so a later failure
+       cannot retract an earlier measurement.
+    2. EVERY FACT IS ITS OWN MARKER LINE.  Facts are never positional and never
+       share a line, so an unparseable field can only cost its own fact. The
+       parser reads keys, never offsets.
+    3. A FACT IS ONLY OBSERVED IF ITS LINE IS PRESENT.  Absence is never read as
+       a negative. :func:`parse_probe_output` returns what it SAW; the adapter
+       raises for anything missing, which :func:`.._relocate_probe.probe` turns
+       into ``None``.
+
+Together those mean a script that dies halfway still yields honest partial
+facts: the ones printed before the failure are observed, the rest are unknown,
+and no fact is ever inferred from another fact's absence.
+
+THE MARKER PREFIX IS LOAD-BEARING. A login shell prints motd, direnv notices,
+Lmod chatter and "Welcome to Ubuntu" banners onto the same stdout. Every line we
+consume starts with ``SAC_RELOC ``, so a peer's noise can never be mistaken for a
+measurement — the same defence :mod:`.._hostsync._probe` uses, for the same
+reason.
+
+TWO TARGET SHELLS ARE NOT BASH. scitex-nas-01 and scitex-nas-02 are QNAP
+busybox. So: no ``[[``, no ``local``, no arrays, no ``/dev/tcp``, no process
+substitution, and no ``awk`` programs carrying quotes. Anything richer is a
+script that renders fine, runs on the developer's laptop, and prints garbage on
+the machine the fleet is actually moving onto.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass, field
+
+__all__ = [
+    "MARKER",
+    "REMOTE_DEFAULT_CREDENTIAL",
+    "CredentialLine",
+    "RemoteQuestions",
+    "RemoteReadout",
+    "parse_probe_output",
+    "render_probe_script",
+]
+
+#: Prefix on every line this module consumes. Peer motd/banner noise never
+#: carries it, so it cannot be mistaken for a measurement.
+MARKER = "SAC_RELOC"
+
+#: The SDK's default credential location, expanded BY THE TARGET's shell. It is
+#: always checked in addition to whatever the spec declares.
+REMOTE_DEFAULT_CREDENTIAL = "$HOME/.claude/.credentials.json"
+
+# Connect timeout for the TCP reachability probes RUN ON THE TARGET. Short on
+# purpose: this is a dry run, and a port that needs more than 3s to answer is
+# not a port an agent should be booted against.
+_TCP_TIMEOUT_S = 3
+
+
+@dataclass(frozen=True)
+class RemoteQuestions:
+    """What to ask the target. Each field an empty default meaning DO NOT ASK.
+
+    An unasked question is not a negative answer: the section is omitted from
+    the script, the marker never appears, and the adapter reports the fact as
+    unknown with a reason. That keeps "the spec declares no image" from
+    rendering as "the image is missing on the target".
+    """
+
+    #: Absolute path of the agent's SIF on the target.
+    image: str = ""
+    #: Bind SOURCE paths (the left half of ``src:dst:mode``).
+    bind_sources: tuple[str, ...] = ()
+    #: Card store endpoint AS THE AGENT WOULD DIAL IT FROM THE TARGET. A
+    #: loopback host is correct here and is deliberately probed: after the move
+    #: the agent runs ON the target, so ``127.0.0.1:5432`` means the TARGET's
+    #: postgres — which is exactly the 2026-08-07 failure (5432 here, 5442
+    #: there).
+    card_store_host: str = ""
+    card_store_port: int = 0
+    #: Candidate credential files, in the spec's own order.
+    credential_paths: tuple[str, ...] = ()
+    #: Ports the spec PINS. The script answers "which of THESE are listening",
+    #: not "enumerate every port" — the check only ever intersects.
+    required_ports: tuple[int, ...] = ()
+    #: The hub, as an address that means something ON THE TARGET. Unlike the
+    #: card store, a loopback hub address must NOT be probed: from the target it
+    #: would measure the TARGET's own loopback and report the hub down (or up)
+    #: for a reason that has nothing to do with the hub.
+    hub_host: str = ""
+    hub_port: int = 0
+
+
+@dataclass(frozen=True)
+class CredentialLine:
+    """One credential file that EXISTS on the target, described without leaking.
+
+    ``expires_at_ms`` is the raw ``claudeAiOauth.expiresAt``; ``refresh_present``
+    says only whether ``refreshToken`` is a non-empty string. The token value
+    itself is never printed by the script and never travels — an ssh transcript
+    of a preflight must not be a credential leak.
+    """
+
+    path: str
+    expires_at_ms: float | None
+    refresh_present: bool | None
+
+
+@dataclass(frozen=True)
+class RemoteReadout:
+    """What the target actually said. Only what it said.
+
+    ``complete`` records whether the closing marker arrived. It is reported, not
+    acted on: a truncated run still yields every fact printed before the cut,
+    because each was true when printed.
+    """
+
+    started: bool = False
+    complete: bool = False
+    fields: dict[str, str] = field(default_factory=dict)
+    missing_binds: tuple[str, ...] = ()
+    credentials: tuple[CredentialLine, ...] = ()
+    ports_in_use: tuple[int, ...] = ()
+
+
+def _q(value: str) -> str:
+    return shlex.quote(value)
+
+
+def _tcp_section(name: str, host: str, port: int) -> str:
+    if not host or port <= 0:
+        return ""
+    return f'echo "$M {name}=$(sacreloc_tcp {_q(host)} {port})"\n'
+
+
+def render_probe_script(questions: RemoteQuestions, *, preamble: str = "") -> str:
+    """Render the POSIX-sh script that measures ``questions`` on the target.
+
+    ``preamble`` is the peer's ``env_preamble`` from ``config.yaml`` (Spartan's
+    Lmod loads, scitex-compute-03's venv PATH). It runs first because without it
+    ``sac`` is not on PATH there, and the two facts that ask the target's own
+    validator would silently go unanswered on exactly the hosts the fleet is
+    moving onto.
+
+    Every interpolated value is ``shlex.quote``d. Paths come from a spec file,
+    which is operator-authored but not therefore harmless — a bind source with a
+    space in it would otherwise split into two failing tests and report a
+    missing path that does not exist.
+    """
+    parts: list[str] = []
+    if preamble.strip():
+        parts.append(preamble.strip())
+    # No `set -e`: a section that fails must not abort the sections after it.
+    # That single omission is what makes this batch degrade per fact.
+    parts.append(f"M={MARKER}")
+    parts.append(_HELPERS)
+    parts.append('echo "$M begin"')
+    parts.append('echo "$M epoch=$(date +%s)"')
+
+    if questions.image:
+        parts.append(
+            f"if [ -e {_q(questions.image)} ]; then\n"
+            '  echo "$M image=present"\n'
+            "else\n"
+            '  echo "$M image=absent"\n'
+            "fi"
+        )
+
+    if questions.bind_sources:
+        listed = " ".join(_q(b) for b in questions.bind_sources)
+        parts.append(
+            f"for b in {listed}; do\n"
+            '  if [ -e "$b" ]; then :; else echo "$M bind_missing=$b"; fi\n'
+            "done\n"
+            f'echo "$M binds_checked={len(questions.bind_sources)}"'
+        )
+
+    card = _tcp_section(
+        "cardstore", questions.card_store_host, questions.card_store_port
+    )
+    if card:
+        parts.append(card.rstrip("\n"))
+
+    # ALWAYS asked, even when the spec names no candidate: the SDK's default
+    # location is where a stale file actually bit us (2026-08-07), and `~` cannot
+    # be expanded here — it would expand to the CALLER's home, not the target's.
+    # So `$HOME` is left for the remote shell, unquoted, on purpose.
+    cred_paths = " ".join(_q(c) for c in questions.credential_paths)
+    parts.append(
+        f'for c in {cred_paths} "{REMOTE_DEFAULT_CREDENTIAL}"; do\n'
+        '  if [ -f "$c" ]; then sacreloc_cred "$c"; fi\n'
+        "done\n"
+        f'echo "$M creds_checked={len(questions.credential_paths) + 1}"'
+    )
+
+    if questions.required_ports:
+        listed = " ".join(str(p) for p in questions.required_ports)
+        parts.append(
+            "ports_out=$(sacreloc_listening)\n"
+            "if [ $? -eq 0 ]; then\n"
+            f"  for p in {listed}; do\n"
+            '    if printf "%s\\n" "$ports_out" | grep -qE "[:.]$p([[:space:]]|$)"; then\n'
+            '      echo "$M port_in_use=$p"\n'
+            "    fi\n"
+            "  done\n"
+            f'  echo "$M ports_checked={len(questions.required_ports)}"\n'
+            "else\n"
+            '  echo "$M ports_tool=none"\n'
+            "fi"
+        )
+    else:
+        # Nothing pinned: the honest answer is "none of the zero required ports
+        # is in use", which needs no tool on the target and cannot be wrong.
+        parts.append('echo "$M ports_checked=0"')
+
+    hub = _tcp_section("hub", questions.hub_host, questions.hub_port)
+    if hub:
+        parts.append(hub.rstrip("\n"))
+
+    parts.append(_SAC_SECTION)
+    parts.append('echo "$M end"')
+    return "\n".join(parts) + "\n"
+
+
+# The remote helpers, kept out of the renderer so the shell is readable as
+# shell. Every one prints a value or the literal `unknown` — never a silent
+# empty string, which the parser would have to guess about.
+_HELPERS = f"""
+SACRELOC_TCP_PY=$(cat <<'SACRELOCPY'
+import socket, sys
+s = socket.socket()
+s.settimeout({_TCP_TIMEOUT_S})
+sys.exit(s.connect_ex((sys.argv[1], int(sys.argv[2]))))
+SACRELOCPY
+)
+
+# python3 FIRST, nc second. `nc -z` is not universal — some netcat builds reject
+# the flag, and a rejected flag exits non-zero, which reads as "port closed".
+# That is the failure this whole design exists to prevent, so nc is used only
+# after its own usage text is confirmed to mention -z.
+sacreloc_tcp() {{
+  if command -v python3 >/dev/null 2>&1; then
+    if python3 -c "$SACRELOC_TCP_PY" "$1" "$2" >/dev/null 2>&1; then
+      echo yes
+    else
+      echo no
+    fi
+    return 0
+  fi
+  if command -v nc >/dev/null 2>&1 && nc -h 2>&1 | grep -q -- '-z'; then
+    if nc -z -w {_TCP_TIMEOUT_S} "$1" "$2" >/dev/null 2>&1; then
+      echo yes
+    else
+      echo no
+    fi
+    return 0
+  fi
+  echo unknown
+}}
+
+sacreloc_listening() {{
+  if command -v ss >/dev/null 2>&1; then
+    ss -ltn 2>/dev/null
+    return 0
+  fi
+  if command -v netstat >/dev/null 2>&1; then
+    netstat -ltn 2>/dev/null
+    return 0
+  fi
+  return 1
+}}
+
+# Prints `cred=<path>|<expiresAt>|<yes|no>`. The refreshToken VALUE never
+# leaves the target — only whether it is a non-empty string.
+sacreloc_cred() {{
+  _e=$(tr ',' '\\n' < "$1" | sed -n 's/.*"expiresAt"[ ]*:[ ]*\\([0-9][0-9]*\\).*/\\1/p' | head -1)
+  _r=$(tr ',' '\\n' < "$1" | sed -n 's/.*"refreshToken"[ ]*:[ ]*"\\([^"]*\\)".*/\\1/p' | head -1)
+  if [ -n "$_r" ]; then _p=yes; else _p=no; fi
+  echo "$M cred=$1|$_e|$_p"
+}}
+"""
+
+
+# The two facts only the TARGET's own sac can answer: which runtimes its
+# validator accepts, and which top-level spec keys it knows. Asked through the
+# interpreter that BACKS the `sac` console script (read off its shebang), not
+# whatever python3 is first on PATH — probing a different interpreter measures a
+# different installation, which is the mistake `_hostsync._probe` documents at
+# length. Both are best-effort: an older sac without these symbols prints
+# nothing, the marker never appears, and the fact stays honestly unknown.
+_SAC_SECTION = """
+SACRELOC_RUNTIMES_PY=$(cat <<'SACRELOCPY'
+from scitex_agent_container.config._validation import _VALID_RUNTIMES as r
+print(",".join(sorted(x for x in r if x)))
+SACRELOCPY
+)
+SACRELOC_KEYS_PY=$(cat <<'SACRELOCPY'
+from scitex_agent_container.config._validation import _KNOWN_TOP_LEVEL_KEYS as k
+print(",".join(sorted(k)))
+SACRELOCPY
+)
+py=python3
+sacbin=$(command -v sac 2>/dev/null)
+if [ -n "$sacbin" ]; then
+  sb=$(head -1 "$sacbin" 2>/dev/null | sed -n 's|^#!\\([^ ]*\\).*|\\1|p')
+  if [ -n "$sb" ] && [ -x "$sb" ]; then py=$sb; fi
+fi
+if command -v "$py" >/dev/null 2>&1; then
+  rt=$("$py" -c "$SACRELOC_RUNTIMES_PY" 2>/dev/null)
+  if [ -n "$rt" ]; then echo "$M runtimes=$rt"; fi
+  sk=$("$py" -c "$SACRELOC_KEYS_PY" 2>/dev/null)
+  if [ -n "$sk" ]; then echo "$M speckeys=$sk"; fi
+fi
+"""
+
+
+def _parse_cred(value: str) -> CredentialLine | None:
+    """``<path>|<expiresAt>|<yes|no>`` -> a :class:`CredentialLine`.
+
+    A malformed field costs only itself: an unparseable expiry yields ``None``
+    for the expiry while the path and the refresh-token flag survive.
+    """
+    path, sep, rest = value.partition("|")
+    if not sep or not path:
+        return None
+    raw_expiry, _, raw_refresh = rest.partition("|")
+    try:
+        expires_at_ms: float | None = float(raw_expiry)
+    except ValueError:
+        expires_at_ms = None
+    refresh: bool | None
+    if raw_refresh == "yes":
+        refresh = True
+    elif raw_refresh == "no":
+        refresh = False
+    else:
+        refresh = None
+    return CredentialLine(
+        path=path, expires_at_ms=expires_at_ms, refresh_present=refresh
+    )
+
+
+def parse_probe_output(stdout: str) -> RemoteReadout:
+    """Read marker lines into a :class:`RemoteReadout`. Never raises.
+
+    Reports what was SEEN and nothing else. There is deliberately no defaulting
+    here: a fact whose line never arrived is simply absent from ``fields``, and
+    it is the adapter — not the parser — that turns absence into an unknown. A
+    parser that filled in ``False`` for a missing line would destroy the whole
+    three-valued chain in one convenient-looking place.
+    """
+    fields: dict[str, str] = {}
+    missing_binds: list[str] = []
+    credentials: list[CredentialLine] = []
+    ports: list[int] = []
+    started = False
+    complete = False
+
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line.startswith(MARKER + " "):
+            continue
+        body = line[len(MARKER) + 1 :]
+        if body == "begin":
+            started = True
+            continue
+        if body == "end":
+            complete = True
+            continue
+        key, sep, value = body.partition("=")
+        if not sep:
+            continue
+        if key == "bind_missing":
+            missing_binds.append(value)
+        elif key == "cred":
+            parsed = _parse_cred(value)
+            if parsed is not None:
+                credentials.append(parsed)
+        elif key == "port_in_use":
+            try:
+                ports.append(int(value))
+            except ValueError:
+                continue
+        else:
+            fields[key] = value
+
+    return RemoteReadout(
+        started=started,
+        complete=complete,
+        fields=fields,
+        missing_binds=tuple(missing_binds),
+        credentials=tuple(credentials),
+        ports_in_use=tuple(ports),
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_probe_ssh.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe_ssh.py
@@ -1,0 +1,225 @@
+"""Ship one probe script to the target, over the only route a container has.
+
+THE ROUTE, AND WHY IT IS NOT PLAIN SSH. An agent runs inside an apptainer SIF
+whose ``$HOME/.ssh`` is a READ-ONLY bind. OpenSSH there cannot create its
+ControlMaster socket and refuses the connection outright::
+
+    cannot bind to path /home/agent/.ssh/.control... : Read-only file system
+
+So the container does not ssh. It asks the ``sac listen`` daemon on the BARE
+HOST to run the ssh for it (:mod:`._host_exec_client`, the same ``/v1/host_exec``
+bypass the ``host_exec_local`` MCP tool uses), and the host's ssh — with a
+writable home, the operator's ``~/.ssh/config``, and the fleet's keys — reaches
+the target. Measured 2026-08-09 against scitex-compute-03/-04, scitex-nas-01/-02
+/-03 and mba.
+
+WHY THE SCRIPT IS ONE ARGV ELEMENT. ssh joins everything after the destination
+with spaces and hands the result to the REMOTE login shell, which re-parses it.
+Passing ``["sh", "-c", script]`` therefore does NOT do what it reads like: the
+remote shell sees ``sh -c <first-word-of-script> <second-word> …`` and runs the
+first word alone with the rest as positional parameters. Measured the same day:
+``ssh host sh -c 'echo MARK; uname -s'`` printed an EMPTY line where ``MARK``
+should have been — ``echo`` ran with ``MARK`` as ``$0`` — and then ``uname``
+executed anyway, from the OUTER shell. Half the script silently ran in a
+different shell than intended. One string, one parse, no surprises.
+
+WHY NOT :func:`.._state.host_config.build_ssh_argv`. It is sac's remote-dispatch
+choke point and this deliberately does not ride it, for two reasons that are
+specific to shipping a SCRIPT from a CONTAINER:
+
+    * Its ``env_preamble`` branch renders ``bash -c '<preamble> && <shlex.join
+      (command)>'``. That is right for an argv command list and wrong for a
+      script: ``shlex.join`` collapses the whole script into ONE quoted word, so
+      bash would try to execute a command whose name is the entire program.
+      Here the preamble is prepended INSIDE the script instead, which also works
+      on the busybox targets where ``bash`` does not exist.
+    * Its ControlMaster options are resolved in the CONTAINER (a ``$TMPDIR``
+      path) and would then be used by ssh on the HOST — a path computed on one
+      machine and bound on another.
+
+The ``via:`` ProxyJump chain and ``env_preamble`` still come from the same
+``config.yaml``, so multi-hop peers keep working; only the argv rendering is
+local to this file.
+
+AN SSH FAILURE IS EVIDENCE; A TRANSPORT FAILURE IS NOT. If the listen daemon
+cannot be reached, we have learned NOTHING about the target and say so by
+raising. If ssh itself ran and failed, the target did not answer us, and that is
+a measurement the caller is entitled to use.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+__all__ = [
+    "ProbeTransportError",
+    "RemoteRun",
+    "build_probe_argv",
+    "peer_preamble",
+    "run_probe_script",
+]
+
+#: ssh reserves exit 255 for its OWN failures (handshake, auth, no route) as
+#: opposed to relaying the remote command's status. It is the one exit code that
+#: means "the connection did not happen".
+SSH_FAILURE_EXIT = 255
+
+#: Wall-clock cap for the whole batched probe on the host side. One ssh round
+#: trip that also runs a handful of `[ -e ]` tests and two python one-liners;
+#: anything past this is a wedged host, and a dry run must not hang on one.
+DEFAULT_TIMEOUT_S = 60.0
+
+
+class ProbeTransportError(RuntimeError):
+    """The probe never reached the target — nothing about it was measured.
+
+    Distinct from a target that answered badly. Raised only when the container
+    could not get its command onto the host at all, which must leave EVERY fact
+    unknown rather than any fact false.
+    """
+
+
+@dataclass(frozen=True)
+class RemoteRun:
+    """The raw result of one batched probe: what ssh printed, and how it exited."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+
+    @property
+    def ssh_failed(self) -> bool:
+        """True when ssh itself could not connect (as opposed to the script failing)."""
+        return self.exit_code == SSH_FAILURE_EXIT
+
+
+def peer_preamble(host: str, peers=None) -> str:
+    """The peer's ``env_preamble`` from ``config.yaml``, or ``""``.
+
+    Load-bearing on the hosts the fleet is actually moving onto: ssh runs a
+    NON-login shell, sac lives in a venv on scitex-compute-03/-04, and without
+    the preamble the two facts that ask the target's own validator go
+    unanswered there. Missing config, an unknown peer, or a malformed file all
+    yield ``""`` — a probe must still run against a host that ``~/.ssh/config``
+    knows and ``config.yaml`` does not.
+    """
+    spec = _peer_spec(host, peers)
+    return spec.joined_preamble() if spec is not None else ""
+
+
+def _peer_spec(host: str, peers=None):
+    if peers is None:
+        try:
+            from .._state.host_config import load
+
+            peers = load().peers
+        except Exception:  # stx-allow: fallback (reason: an unreadable config must degrade to a direct ssh, not abort a preflight that ~/.ssh/config can still serve)
+            return None
+    try:
+        return peers.get(host)
+    except Exception:  # stx-allow: fallback (reason: PeersMap raises MovingAliasError for retired names; a probe of an unregistered host is still a legitimate probe)
+        return None
+
+
+def build_probe_argv(host: str, script: str, peers=None) -> list[str]:
+    """Render the ssh argv the HOST will run, with the script as one element.
+
+    ``-o BatchMode=yes`` because there is no terminal on the far end of a
+    listen-daemon exec — a password or known-hosts prompt would hang until the
+    timeout instead of failing. ``StrictHostKeyChecking=accept-new`` matches
+    sac's existing dispatch policy: accept a first-touch key, still refuse a
+    CHANGED one.
+
+    A host with no ``config.yaml`` entry is addressed directly by name; the
+    host's own ``~/.ssh/config`` resolves it (scitex-nas-01 and -02 are reached
+    exactly that way today). Refusing to probe an unregistered host would turn a
+    measurable fact into an unknown for a bookkeeping reason.
+    """
+    if not host:
+        raise ValueError("build_probe_argv: host must be non-empty")
+    argv = ["ssh"]
+    spec = _peer_spec(host, peers)
+    target = host
+    if spec is not None:
+        target = spec.ssh or host
+        chain = spec.jump_chain(peers) if peers is not None else _chain(spec)
+        if chain:
+            argv += ["-J", ",".join(chain)]
+    argv += [
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=10",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        target,
+        script,
+    ]
+    return argv
+
+
+def _chain(spec) -> list[str]:
+    if not spec.via:
+        return []
+    try:
+        from .._state.host_config import load
+
+        return spec.jump_chain(load().peers)
+    except Exception:  # stx-allow: fallback (reason: an unresolvable jump chain must degrade to a direct attempt, whose failure is then an honest observation)
+        return []
+
+
+def run_probe_script(
+    host: str,
+    script: str,
+    *,
+    exec_fn: Callable[..., dict] | None = None,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    peers=None,
+) -> RemoteRun:
+    """Run ``script`` on ``host`` through the listen daemon and return what it said.
+
+    ``exec_fn`` is the seam: it takes the same arguments as
+    :func:`.._lifecycle._host_exec_client.request_host_exec` and returns its
+    ``{"exit_code", "stdout", "stderr", …}`` body. Tests pass a real callable
+    that returns canned output, so no transport is mocked and no monkeypatching
+    is needed.
+
+    Raises :class:`ProbeTransportError` when the exec never happened, when it
+    timed out, or when the body is not the documented shape. It never returns a
+    fabricated success — a caller that cannot tell "the target said no" from "I
+    never asked" is the failure this whole feature exists to prevent.
+    """
+    if exec_fn is None:
+        from ._host_exec_client import request_host_exec
+
+        exec_fn = request_host_exec
+
+    argv = build_probe_argv(host, script, peers)
+    try:
+        body = exec_fn(argv, timeout_s=timeout_s)
+    except Exception as exc:  # stx-allow: fallback (reason: re-raised as ProbeTransportError so every fact stays UNKNOWN; nothing is swallowed and nothing degrades to False)
+        raise ProbeTransportError(
+            f"could not run the probe on the host for {host}: {type(exc).__name__}: {exc}"
+        ) from exc
+
+    if not isinstance(body, dict):
+        raise ProbeTransportError(
+            f"host_exec returned {type(body).__name__}, not the documented body"
+        )
+    if body.get("timed_out"):
+        raise ProbeTransportError(
+            f"the probe of {host} timed out after {timeout_s:.0f}s; "
+            "nothing about the target was measured"
+        )
+    exit_code = body.get("exit_code")
+    if not isinstance(exit_code, int):
+        raise ProbeTransportError(
+            f"host_exec body carried no integer exit_code (got {exit_code!r})"
+        )
+    return RemoteRun(
+        stdout=str(body.get("stdout") or ""),
+        stderr=str(body.get("stderr") or ""),
+        exit_code=exit_code,
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_render.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_render.py
@@ -18,6 +18,11 @@ keeps the exception text rather than discarding it, so the line can say
 observed" the checks alone can offer. Without it the operator knows a fact is
 missing but not why, which turns a five-second fix into an investigation.
 
+That lookup goes through :data:`_CHECK_FACTS`, because the errors are keyed by
+FACT and the report is written in CHECKS, and four of the nine are named
+differently on the two sides. Keying only by check name silently drops exactly
+those four reasons — they are present, correct, and never shown.
+
 Pure: strings in, strings out. No click, no console, no colour — the caller
 decides how to paint them, and tests can assert on exact lines.
 """
@@ -41,6 +46,44 @@ VERDICT_REFUSED = "REFUSED"
 VERDICT_UNKNOWN = "REFUSED (undetermined)"
 
 _LABEL = {True: "PASS", False: "FAIL", None: "UNKNOWN"}
+
+#: Which FACTS feed each CHECK. ``gather_target_facts`` keys its failures by
+#: fact name, and four checks are named differently from the fact behind them
+#: (``credentials_valid`` is fed by ``credential_expires_in_s``, and so on).
+#: Without this map those four print a bare UNKNOWN while the reason for it sits
+#: unused in the errors dict — measured 2026-08-09 against a busybox NAS, where
+#: four of five unknowns lost their explanation on the way to the screen.
+_CHECK_FACTS: dict[str, tuple[str, ...]] = {
+    "target_reachable": ("reachable",),
+    "image_present": ("image_present",),
+    "binds_exist_on_target": ("missing_bind_sources",),
+    "card_store_reachable": ("card_store_reachable", "card_store_url"),
+    "credentials_valid": (
+        "credential_expires_in_s",
+        "credential_refresh_token_present",
+    ),
+    "runtime_supported": ("supported_runtimes",),
+    "spec_schema_accepted": ("rejected_spec_keys",),
+    "ports_free": ("ports_in_use",),
+    "hub_reachable_from_target": ("hub_reachable_from_target",),
+}
+
+
+def _why(check_name: str, errors: dict[str, str]) -> str:
+    """The probe failure behind ``check_name``, by its own key or its facts'.
+
+    The check's own name wins, so a caller that already keyed by check name
+    keeps working; the fact names are the fallback that makes the adapter's
+    reasons reach the reader.
+    """
+    direct = errors.get(check_name)
+    if direct:
+        return direct
+    for fact in _CHECK_FACTS.get(check_name, ()):
+        reason = errors.get(fact)
+        if reason:
+            return reason
+    return ""
 
 
 def render_declared(declared: dict[str, object]) -> list[str]:
@@ -84,7 +127,7 @@ def render_observed(
     width = max((len(c.name) for c in report.checks), default=0)
     for check in report.checks:
         lines.append(f"  {_LABEL[check.ok]:<8} {check.name:<{width}}  {check.detail}")
-        why = errors.get(check.name)
+        why = _why(check.name, errors)
         if why:
             lines.append(f"           probe error: {why}")
         if check.ok is not True and check.hint:

--- a/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
@@ -27,12 +27,18 @@ WHAT COMES FROM WHERE — the operator's requirement, 2026-08-08:
 Collapsing those into one column is how `sac agents list` reports a running
 agent as `defined`, and this command must not repeat it.
 
-UNPROBED IS UNKNOWN, AND UNKNOWN REFUSES. Any fact with no probe supplied stays
-``None``, which preflight reports as UNKNOWN and refuses on, exactly as it would
-for a probe that ran and failed. That is deliberate: from the decision's point
-of view "nobody asked" and "asked and could not tell" are the same thing, and
-both differ from an answer. So a dry run with no probes wired is not a green
-light — it is a list of what still has to be measured.
+UNPROBED IS UNKNOWN, AND UNKNOWN REFUSES. Any fact a probe could not answer
+stays ``None``, which preflight reports as UNKNOWN and refuses on, exactly as it
+would for a probe that ran and failed. That is deliberate: from the decision's
+point of view "nobody asked" and "asked and could not tell" are the same thing,
+and both differ from an answer. A dry run that cannot measure something is not a
+green light — it is a list of what still has to be measured, each entry carrying
+the reason it could not be.
+
+THE PROBES ARE ONE ssh ROUND TRIP, NOT ELEVEN. See
+:mod:`.._lifecycle._relocate_probe_adapter`: the batch is deliberately built so
+that a partial answer degrades PER FACT — eight measured and three unknown,
+never eleven of either because one section failed.
 """
 
 from __future__ import annotations
@@ -40,7 +46,11 @@ from __future__ import annotations
 import click
 
 from .._lifecycle._relocate_preflight import preflight
-from .._lifecycle._relocate_probe import TargetProbes, gather_target_facts
+from .._lifecycle._relocate_probe import gather_target_facts
+from .._lifecycle._relocate_probe_adapter import (
+    build_target_probes,
+    card_store_url_from_spec,
+)
 from .._lifecycle._relocate_render import render_dry_run
 from ._helpers import console
 
@@ -85,8 +95,12 @@ def declared_from_spec(spec: dict) -> dict[str, object]:
         b.split(":", 1)[0] if isinstance(b, str) else str(b)
         for b in (binds if isinstance(binds, list) else [])
     )
-    env = _dig(body, "apptainer", "env")
-    card_store = env.get("SCITEX_CARDS_DB") if isinstance(env, dict) else None
+    # Read through the SAME resolver the probe uses, so DECLARED and OBSERVED
+    # cannot disagree about which store this agent has. An ``apptainer.env``-only
+    # lookup printed "(unset)" for this repo's own spec — which carries the URL
+    # in a ``--env`` raw arg — while the probe went and successfully dialled it:
+    # two sections of one report describing the same agent differently.
+    card_store = card_store_url_from_spec(spec) or None
     return {
         "runtime": body.get("runtime"),
         "host": body.get("host"),
@@ -168,10 +182,14 @@ def relocate(name: str, to_host: str, dry_run: bool) -> None:
         )
         raise SystemExit(EXIT_REFUSED)
 
-    # No probes are wired yet, so every fact is UNOBSERVED and the report is a
-    # list of what must be measured. That is the honest state of this command
-    # and it is preferable to a probe set that guesses.
-    gathered = gather_target_facts(TargetProbes())
+    # ONE batched ssh round trip answers all eleven facts; each is parsed on its
+    # own marker line, so a section that fails costs only its own fact. See
+    # `.._lifecycle._relocate_probe_adapter` for how per-fact degradation
+    # survives the batching.
+    probes, _batch = build_target_probes(
+        to_host, spec, required_ports=_required_ports(declared)
+    )
+    gathered = gather_target_facts(probes)
     report = preflight(
         agent=name,
         to_host=to_host,

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe_adapter.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe_adapter.py
@@ -1,0 +1,454 @@
+"""Eleven facts from one call, and a partial answer that costs only its own facts.
+
+Two properties are pinned here, and the second is the reason the first is safe.
+
+THE INVARIANT: could-not-determine is ``None``, NEVER ``False``. A probe that
+degrades a failure into a negative turns "no route to the host" into "the host
+has no image", and preflight then refuses — or passes — for a reason nobody can
+trace. Several tests below fail loudly if any accessor grows an
+``except: return False``; that is deliberate, and they were verified to fail
+against a deliberately neutered implementation before being kept.
+
+PER-FACT DEGRADATION UNDER BATCHING: one remote call answers everything, so the
+tempting failure mode is all-or-nothing — eleven unknowns because one section
+died, or (worse) eleven falses. The tests drive truncated, partial and malformed
+readouts and assert that the facts printed BEFORE the failure are still observed
+while only the unprinted ones are unknown.
+
+The transport is driven through the ``runner`` seam with real callables that
+return canned :class:`RemoteRun` values — the exact shape
+:func:`.._relocate_probe_ssh.run_probe_script` returns. Nothing is mocked and
+nothing is monkeypatched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_preflight import preflight
+from scitex_agent_container._lifecycle._relocate_probe import gather_target_facts
+from scitex_agent_container._lifecycle._relocate_probe_adapter import (
+    build_target_probes,
+    card_store_url_from_spec,
+    hub_address,
+)
+from scitex_agent_container._lifecycle._relocate_probe_ssh import (
+    ProbeTransportError,
+    RemoteRun,
+)
+
+# A healthy target, in the shape the real script prints. `epoch` and the
+# credential expiry are chosen so the credential has an hour left.
+HEALTHY = """SAC_RELOC begin
+SAC_RELOC epoch=1786246196
+SAC_RELOC image=present
+SAC_RELOC binds_checked=2
+SAC_RELOC cardstore=yes
+SAC_RELOC cred=/creds/a.json|1786249796000|yes
+SAC_RELOC creds_checked=2
+SAC_RELOC ports_checked=0
+SAC_RELOC hub=yes
+SAC_RELOC runtimes=apptainer,claude-agent-sdk,tui
+SAC_RELOC speckeys=apiVersion,kind,metadata,spec
+SAC_RELOC end
+"""
+
+# An env with a routable hub, so the hub section is asked about at all.
+HUB_ENV = {"SAC_RELOCATE_HUB_ADDR": "hub.example:7878"}
+
+
+@pytest.fixture
+def spec():
+    """A spec in this repo's real shape: card store in a --env raw arg."""
+    yield {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "metadata": {},
+        "spec": {
+            "runtime": "tui",
+            "host": "ywata-note-win",
+            "apptainer": {
+                "image": "/srv/sac-base.sif",
+                "binds": ["/home/ywatanabe:/home/ywatanabe:rw", "/mnt/c:/mnt/c:rw"],
+                "env": {},
+                "raw_args": [
+                    "--env",
+                    "SCITEX_CARDS_DB=postgresql://cards@127.0.0.1:5432/cards",
+                ],
+            },
+            "claude": {"credentials_files": ["/creds/a.json"]},
+        },
+    }
+
+
+def _runner(stdout, *, exit_code=0, stderr="", calls=None):
+    """A real ``run_probe_script``-shaped callable returning canned output."""
+
+    def run(host, script, *, timeout_s=60.0, **kwargs):
+        if calls is not None:
+            calls.append(host)
+        return RemoteRun(stdout=stdout, stderr=stderr, exit_code=exit_code)
+
+    return run
+
+
+def _runner_raising(exc):
+    def run(host, script, *, timeout_s=60.0, **kwargs):
+        raise exc
+
+    return run
+
+
+def _facts(spec, stdout, *, exit_code=0, stderr="", required_ports=(), env=None):
+    probes, _ = build_target_probes(
+        "target",
+        spec,
+        required_ports=required_ports,
+        runner=_runner(stdout, exit_code=exit_code, stderr=stderr),
+        preamble="",
+        env=HUB_ENV if env is None else env,
+    )
+    return gather_target_facts(probes)
+
+
+# ---------------------------------------------------------------------------
+# THE INVARIANT: a failure is UNKNOWN, never a negative
+# ---------------------------------------------------------------------------
+
+
+def test_a_transport_failure_leaves_reachability_unknown(spec) -> None:
+    # Arrange: the listen daemon could not be reached, so NOTHING about the
+    # target was measured. `False` here would claim the host refused us.
+    probes, _ = build_target_probes(
+        "target",
+        spec,
+        runner=_runner_raising(ProbeTransportError("listen daemon refused")),
+        preamble="",
+        env=HUB_ENV,
+    )
+    # Act
+    facts = gather_target_facts(probes).facts
+    # Assert
+    assert facts.reachable is None
+
+
+def test_a_transport_failure_leaves_the_image_unknown(spec) -> None:
+    # Arrange: `False` here would read as "the image is absent on the target"
+    # and send someone to rebuild an image that is already there.
+    probes, _ = build_target_probes(
+        "target",
+        spec,
+        runner=_runner_raising(ProbeTransportError("listen daemon refused")),
+        preamble="",
+        env=HUB_ENV,
+    )
+    # Act
+    facts = gather_target_facts(probes).facts
+    # Assert
+    assert facts.image_present is None
+
+
+def test_a_transport_failure_leaves_the_card_store_unknown(spec) -> None:
+    # Arrange
+    probes, _ = build_target_probes(
+        "target",
+        spec,
+        runner=_runner_raising(ProbeTransportError("listen daemon refused")),
+        preamble="",
+        env=HUB_ENV,
+    )
+    # Act
+    facts = gather_target_facts(probes).facts
+    # Assert
+    assert facts.card_store_reachable is None
+
+
+def test_a_transport_failure_makes_preflight_refuse_as_undetermined(spec) -> None:
+    # Arrange: the end-to-end statement of the invariant — a dead transport must
+    # produce "could not determine", not a decided refusal built on falses.
+    probes, _ = build_target_probes(
+        "target",
+        spec,
+        runner=_runner_raising(ProbeTransportError("listen daemon refused")),
+        preamble="",
+        env=HUB_ENV,
+    )
+    gathered = gather_target_facts(probes)
+    # Act
+    report = preflight(agent="a", to_host="target", facts=gathered.facts, runtime="tui")
+    # Assert
+    assert report.ok is None
+
+
+def test_a_transport_failure_says_why_each_fact_is_missing(spec) -> None:
+    # Arrange: a bare UNKNOWN turns a five-second fix into an investigation.
+    probes, _ = build_target_probes(
+        "target",
+        spec,
+        runner=_runner_raising(ProbeTransportError("listen daemon refused")),
+        preamble="",
+        env=HUB_ENV,
+    )
+    # Act
+    errors = gather_target_facts(probes).errors
+    # Assert
+    assert "listen daemon refused" in errors["image_present"]
+
+
+def test_a_target_with_no_tcp_tool_is_unknown_not_unreachable(spec) -> None:
+    # Arrange: the script reports `unknown` when the target has neither python3
+    # nor a -z-capable nc. That is "I could not test", not "the port is shut".
+    stdout = HEALTHY.replace("cardstore=yes", "cardstore=unknown")
+    # Act
+    facts = _facts(spec, stdout).facts
+    # Assert
+    assert facts.card_store_reachable is None
+
+
+def test_a_missing_credential_file_is_unknown_not_expired(spec) -> None:
+    # Arrange: no file means no expiry to report. Inventing a negative number
+    # would fabricate a measurement nobody made.
+    stdout = HEALTHY.replace("SAC_RELOC cred=/creds/a.json|1786249796000|yes\n", "")
+    # Act
+    facts = _facts(spec, stdout).facts
+    # Assert
+    assert facts.credential_expires_in_s is None
+
+
+def test_a_partial_bind_sweep_is_unknown_rather_than_clean(spec) -> None:
+    # Arrange: the target reported checking fewer paths than we asked about, so
+    # "no missing binds" would mean "none among the ones it got to".
+    stdout = HEALTHY.replace("binds_checked=2", "binds_checked=1")
+    # Act
+    facts = _facts(spec, stdout).facts
+    # Assert
+    assert facts.missing_bind_sources is None
+
+
+def test_a_target_that_cannot_list_ports_is_unknown_not_free(spec) -> None:
+    # Arrange: a pinned port and no ss/netstat on the target.
+    stdout = HEALTHY.replace("ports_checked=0", "ports_tool=none")
+    # Act
+    facts = _facts(spec, stdout, required_ports=(7001,)).facts
+    # Assert
+    assert facts.ports_in_use is None
+
+
+def test_a_loopback_hub_is_unknown_rather_than_unreachable(spec) -> None:
+    # Arrange: probing 127.0.0.1 FROM the target measures the TARGET's loopback.
+    # Reporting that as the hub would be a confident answer to another question.
+    env = {"SAC_LISTEN_BASE_URL": "http://127.0.0.1:7878"}
+    # Act
+    facts = _facts(spec, HEALTHY, env=env).facts
+    # Assert
+    assert facts.hub_reachable_from_target is None
+
+
+def test_a_loopback_hub_names_the_override_that_would_measure_it(spec) -> None:
+    # Arrange
+    env = {"SAC_LISTEN_BASE_URL": "http://127.0.0.1:7878"}
+    # Act
+    errors = _facts(spec, HEALTHY, env=env).errors
+    # Assert
+    assert "SAC_RELOCATE_HUB_ADDR" in errors["hub_reachable_from_target"]
+
+
+# ---------------------------------------------------------------------------
+# observed negatives must survive — the invariant must not blunt real answers
+# ---------------------------------------------------------------------------
+
+
+def test_an_absent_image_is_an_observed_negative(spec) -> None:
+    # Arrange: the mirror of the invariant. If everything degraded to unknown
+    # the checks would never fail, which is just as useless.
+    stdout = HEALTHY.replace("image=present", "image=absent")
+    # Act
+    facts = _facts(spec, stdout).facts
+    # Assert
+    assert facts.image_present is False
+
+
+def test_an_ssh_connection_failure_is_an_observed_unreachable(spec) -> None:
+    # Arrange: ssh ran and could not connect (its exit 255). Unlike a transport
+    # failure, that IS a measurement about the target.
+    # Act
+    facts = _facts(spec, "", exit_code=255, stderr="ssh: connect: timed out").facts
+    # Assert
+    assert facts.reachable is False
+
+
+def test_an_expired_credential_is_reported_as_negative_seconds(spec) -> None:
+    # Arrange: the 2026-08-07 failure — a file that is PRESENT and useless.
+    stdout = HEALTHY.replace("1786249796000", "1780000000000")
+    # Act
+    expires_in = _facts(spec, stdout).facts.credential_expires_in_s
+    # Assert
+    assert expires_in < 0
+
+
+def test_an_empty_refresh_token_is_an_observed_negative(spec) -> None:
+    # Arrange: valid now and unrenewable — the agent dies at the first refresh.
+    stdout = HEALTHY.replace("|1786249796000|yes", "|1786249796000|no")
+    # Act
+    facts = _facts(spec, stdout).facts
+    # Assert
+    assert facts.credential_refresh_token_present is False
+
+
+# ---------------------------------------------------------------------------
+# per-fact degradation: a partial batch costs only the facts it did not print
+# ---------------------------------------------------------------------------
+
+
+def test_a_truncated_batch_keeps_the_facts_it_printed(spec) -> None:
+    # Arrange: the script died before the sac section. Everything printed
+    # earlier was true when printed.
+    truncated = HEALTHY.split("SAC_RELOC runtimes")[0]
+    # Act
+    facts = _facts(spec, truncated).facts
+    # Assert
+    assert facts.image_present is True
+
+
+def test_a_truncated_batch_loses_only_the_facts_it_never_printed(spec) -> None:
+    # Arrange
+    truncated = HEALTHY.split("SAC_RELOC runtimes")[0]
+    # Act
+    facts = _facts(spec, truncated).facts
+    # Assert
+    assert facts.supported_runtimes is None
+
+
+def test_a_truncated_batch_still_measures_most_of_the_checks(spec) -> None:
+    # Arrange: the whole argument for batching — a partial answer is still an
+    # answer for the parts that arrived.
+    truncated = HEALTHY.split("SAC_RELOC runtimes")[0]
+    gathered = _facts(spec, truncated)
+    # Act
+    unobserved = set(gathered.errors)
+    # Assert
+    assert unobserved == {"supported_runtimes", "rejected_spec_keys"}
+
+
+def test_an_old_sac_on_the_target_costs_only_its_own_two_facts(spec) -> None:
+    # Arrange: a target whose sac is too old to carry the validator symbols
+    # prints neither line; everything the shell could answer still arrives.
+    stdout = HEALTHY.replace(
+        "SAC_RELOC runtimes=apptainer,claude-agent-sdk,tui\n", ""
+    ).replace("SAC_RELOC speckeys=apiVersion,kind,metadata,spec\n", "")
+    # Act
+    facts = _facts(spec, stdout).facts
+    # Assert
+    assert facts.card_store_reachable is True
+
+
+# ---------------------------------------------------------------------------
+# the facts themselves
+# ---------------------------------------------------------------------------
+
+
+def test_the_batch_runs_once_for_all_eleven_facts(spec) -> None:
+    # Arrange: eleven ssh round trips to a NAS is tens of seconds for a command
+    # whose job is to say "not yet".
+    calls: list[str] = []
+    probes, _ = build_target_probes(
+        "target",
+        spec,
+        runner=_runner(HEALTHY, calls=calls),
+        preamble="",
+        env=HUB_ENV,
+    )
+    # Act
+    gather_target_facts(probes)
+    # Assert
+    assert len(calls) == 1
+
+
+def test_a_dead_target_is_not_dialled_once_per_fact(spec) -> None:
+    # Arrange: the failure is memoized too, or a down host costs eleven timeouts.
+    calls: list[str] = []
+
+    def run(host, script, *, timeout_s=60.0, **kwargs):
+        calls.append(host)
+        raise ProbeTransportError("down")
+
+    probes, _ = build_target_probes(
+        "target", spec, runner=run, preamble="", env=HUB_ENV
+    )
+    # Act
+    gather_target_facts(probes)
+    # Assert
+    assert len(calls) == 1
+
+
+def test_the_card_store_url_is_found_in_a_raw_env_arg(spec) -> None:
+    # Arrange: this repo's own spec leaves apptainer.env empty and carries the
+    # URL in a --env raw arg, so an env-only reader reports "(unset)".
+    # Act
+    url = card_store_url_from_spec(spec)
+    # Assert
+    assert url == "postgresql://cards@127.0.0.1:5432/cards"
+
+
+def test_rejected_spec_keys_are_the_ones_the_target_does_not_know(spec) -> None:
+    # Arrange: the 2026-08-07 failure — a top-level `provider:` the older
+    # validator rejects.
+    spec["provider"] = "anthropic"
+    # Act
+    facts = _facts(spec, HEALTHY).facts
+    # Assert
+    assert facts.rejected_spec_keys == ("provider",)
+
+
+def test_a_spec_the_target_fully_understands_rejects_nothing(spec) -> None:
+    # Arrange
+    # Act
+    facts = _facts(spec, HEALTHY).facts
+    # Assert
+    assert facts.rejected_spec_keys == ()
+
+
+def test_the_credential_expiry_uses_the_targets_own_clock(spec) -> None:
+    # Arrange: comparing against OUR clock would be wrong by exactly the skew
+    # between the two machines. 1786249796 - 1786246196 = 3600.
+    # Act
+    expires_in = _facts(spec, HEALTHY).facts.credential_expires_in_s
+    # Assert
+    assert expires_in == pytest.approx(3600.0)
+
+
+def test_an_unpinned_port_needs_no_tool_on_the_target(spec) -> None:
+    # Arrange: `a2a.port: auto` pins nothing, so no required port can clash and
+    # nothing had to be listed to know it.
+    # Act
+    facts = _facts(spec, HEALTHY).facts
+    # Assert
+    assert facts.ports_in_use == ()
+
+
+def test_an_explicit_hub_address_is_probed_from_the_target(spec) -> None:
+    # Arrange
+    # Act
+    facts = _facts(spec, HEALTHY).facts
+    # Assert
+    assert facts.hub_reachable_from_target is True
+
+
+def test_a_routable_listen_url_needs_no_override() -> None:
+    # Arrange: only a LOOPBACK hub is unprobeable; a real address is usable.
+    env = {"SAC_LISTEN_BASE_URL": "http://hub.internal:7878"}
+    # Act
+    host, port, reason = hub_address(env)
+    # Assert
+    assert (host, port, reason) == ("hub.internal", 7878, "")
+
+
+def test_a_healthy_target_reaches_preflight_as_a_go(spec) -> None:
+    # Arrange: the positive control. Without it the unknown-propagation tests
+    # could pass because the probe set is broken rather than because unknown
+    # propagates.
+    gathered = _facts(spec, HEALTHY)
+    # Act
+    report = preflight(agent="a", to_host="target", facts=gathered.facts, runtime="tui")
+    # Assert
+    assert report.ok is True

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe_script.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe_script.py
@@ -1,0 +1,261 @@
+"""The batched script must degrade per fact, and the parser must never default.
+
+Batching eleven questions into one remote call buys speed and risks honesty: the
+naive version returns one blob and one status, so a single failure costs all
+eleven answers — or, worse, turns them all into confident falses. These tests
+pin the three properties that keep the batch honest:
+
+    * the script never runs under ``set -e``, so a failing section cannot abort
+      the sections after it;
+    * every answer is its own marker line, so an unparseable field costs only
+      itself;
+    * the parser reports what it SAW and defaults nothing, so a missing line
+      stays missing rather than becoming a negative.
+
+No mocks: the renderer takes a dataclass and returns a string, the parser takes
+a string and returns a dataclass. Both are driven with real values, including
+captured output from a real host.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_probe_script import (
+    MARKER,
+    RemoteQuestions,
+    parse_probe_output,
+    render_probe_script,
+)
+
+# Captured verbatim from scitex-compute-03 on 2026-08-09. Used as-is so the
+# parser is tested against what a real host prints, banners and all.
+REAL_OUTPUT = """Welcome to Ubuntu 24.04.2 LTS
+SAC_RELOC begin
+SAC_RELOC epoch=1786246196
+SAC_RELOC image=present
+SAC_RELOC bind_missing=/home/ywatanabe/.config/gh
+SAC_RELOC bind_missing=/mnt/c
+SAC_RELOC binds_checked=5
+SAC_RELOC cardstore=no
+SAC_RELOC cred=/home/ywatanabe/.claude/.credentials.json|1786300000000|yes
+SAC_RELOC creds_checked=2
+SAC_RELOC ports_checked=0
+SAC_RELOC runtimes=apptainer,claude-agent-sdk,tui
+SAC_RELOC speckeys=apiVersion,kind,metadata,spec
+SAC_RELOC end
+"""
+
+
+@pytest.fixture
+def questions():
+    """A full question set — every section of the script is exercised."""
+    yield RemoteQuestions(
+        image="/srv/sac-base.sif",
+        bind_sources=("/home/ywatanabe", "/mnt/c"),
+        card_store_host="127.0.0.1",
+        card_store_port=5432,
+        credential_paths=("/creds/a.json",),
+        required_ports=(7001,),
+        hub_host="hub.example",
+        hub_port=7878,
+    )
+
+
+# ---------------------------------------------------------------------------
+# the script: a failing section must not take the others with it
+# ---------------------------------------------------------------------------
+
+
+def test_the_script_never_enables_errexit(questions) -> None:
+    # Arrange: `set -e` would abort at the first failing section, so one
+    # unreadable path would cost every fact printed after it.
+    script = render_probe_script(questions)
+    # Act
+    has_errexit = "set -e" in script
+    # Assert
+    assert has_errexit is False
+
+
+def test_every_answer_is_its_own_marker_line(questions) -> None:
+    # Arrange: positional output would let one bad field shift every later one.
+    script = render_probe_script(questions)
+    # Act
+    marker_echoes = script.count('echo "$M ')
+    # Assert
+    assert marker_echoes >= 6
+
+
+def test_the_preamble_runs_before_anything_is_measured(questions) -> None:
+    # Arrange: without it `sac` is off PATH on scitex-compute-03 and the two
+    # facts only the target's validator can answer go silently unanswered.
+    script = render_probe_script(questions, preamble='export PATH="$HOME/x:$PATH"')
+    # Act
+    first_line = script.splitlines()[0]
+    # Assert
+    assert first_line == 'export PATH="$HOME/x:$PATH"'
+
+
+def test_a_path_with_a_space_is_quoted_rather_than_split() -> None:
+    # Arrange: an unquoted path would split into two tests, both failing, and
+    # report a missing bind source that does not exist.
+    script = render_probe_script(RemoteQuestions(bind_sources=("/mnt/my disk",)))
+    # Act
+    quoted = "'/mnt/my disk'" in script
+    # Assert
+    assert quoted is True
+
+
+def test_an_undeclared_image_is_never_asked_about() -> None:
+    # Arrange: "the spec names no image" must not render as "the image is
+    # missing on the target".
+    script = render_probe_script(RemoteQuestions(bind_sources=("/x",)))
+    # Act
+    asks = "image=" in script
+    # Assert
+    assert asks is False
+
+
+def test_a_loopback_hub_is_never_probed_from_the_target() -> None:
+    # Arrange: an empty hub address means the caller refused to guess one;
+    # probing it would measure the TARGET's loopback and call it the hub.
+    script = render_probe_script(RemoteQuestions(hub_host="", hub_port=0))
+    # Act
+    asks = "hub=" in script
+    # Assert
+    assert asks is False
+
+
+def test_the_default_credential_path_is_expanded_by_the_target() -> None:
+    # Arrange: `~` here would expand to the CALLER's home, naming a file on the
+    # wrong machine. `$HOME` is left for the remote shell on purpose.
+    script = render_probe_script(RemoteQuestions())
+    # Act
+    remote_home = '"$HOME/.claude/.credentials.json"' in script
+    # Assert
+    assert remote_home is True
+
+
+def test_the_refresh_token_value_is_never_printed(questions) -> None:
+    # Arrange: an ssh transcript of a preflight must not be a credential leak;
+    # the script reports presence, never the secret.
+    script = render_probe_script(questions)
+    # Act
+    echoes_token = 'echo "$M cred_token=$_r"' in script
+    # Assert
+    assert echoes_token is False
+
+
+def test_no_bashism_reaches_the_busybox_targets(questions) -> None:
+    # Arrange: scitex-nas-01/-02 are QNAP busybox — no `[[ ]]`, no /dev/tcp, no
+    # `local`. (The token is `[[ ` with the space: `[[:space:]]` is a POSIX
+    # character class busybox grep handles fine, and matching on a bare `[[`
+    # would flag it.)
+    script = render_probe_script(questions)
+    # Act
+    bashisms = [tok for tok in ("[[ ", "/dev/tcp", "local ") if tok in script]
+    # Assert
+    assert bashisms == []
+
+
+# ---------------------------------------------------------------------------
+# the parser: report what was seen, default nothing
+# ---------------------------------------------------------------------------
+
+
+def test_a_real_hosts_banner_is_not_mistaken_for_a_measurement() -> None:
+    # Arrange
+    readout = parse_probe_output(REAL_OUTPUT)
+    # Act
+    keys = set(readout.fields)
+    # Assert
+    assert "Welcome to Ubuntu 24.04.2 LTS" not in keys
+
+
+def test_a_completed_run_is_reported_as_complete() -> None:
+    # Arrange
+    readout = parse_probe_output(REAL_OUTPUT)
+    # Act
+    complete = readout.complete
+    # Assert
+    assert complete is True
+
+
+def test_a_truncated_run_keeps_the_facts_it_managed_to_print() -> None:
+    # Arrange: the script died after the binds. Everything printed before the
+    # cut was true when printed, and must survive.
+    truncated = REAL_OUTPUT.split("SAC_RELOC cardstore")[0]
+    readout = parse_probe_output(truncated)
+    # Act
+    image = readout.fields.get("image")
+    # Assert
+    assert image == "present"
+
+
+def test_a_truncated_run_is_not_reported_as_complete() -> None:
+    # Arrange
+    truncated = REAL_OUTPUT.split("SAC_RELOC cardstore")[0]
+    readout = parse_probe_output(truncated)
+    # Act
+    complete = readout.complete
+    # Assert
+    assert complete is False
+
+
+def test_a_fact_whose_line_never_arrived_is_absent_not_false() -> None:
+    # Arrange: the whole three-valued chain dies here if the parser defaults.
+    truncated = REAL_OUTPUT.split("SAC_RELOC runtimes")[0]
+    readout = parse_probe_output(truncated)
+    # Act
+    runtimes = readout.fields.get("runtimes")
+    # Assert
+    assert runtimes is None
+
+
+def test_missing_binds_are_collected_by_name() -> None:
+    # Arrange
+    readout = parse_probe_output(REAL_OUTPUT)
+    # Act
+    missing = readout.missing_binds
+    # Assert
+    assert missing == ("/home/ywatanabe/.config/gh", "/mnt/c")
+
+
+def test_a_credential_line_yields_its_expiry() -> None:
+    # Arrange
+    readout = parse_probe_output(REAL_OUTPUT)
+    # Act
+    expiry = readout.credentials[0].expires_at_ms
+    # Assert
+    assert expiry == 1786300000000.0
+
+
+def test_an_unparseable_expiry_costs_only_the_expiry() -> None:
+    # Arrange: one bad field must not discard the other two on the same line.
+    text = f"{MARKER} begin\n{MARKER} cred=/c.json|not-a-number|yes\n{MARKER} end\n"
+    readout = parse_probe_output(text)
+    # Act
+    refresh = readout.credentials[0].refresh_present
+    # Assert
+    assert refresh is True
+
+
+def test_an_unparseable_line_does_not_poison_the_other_facts() -> None:
+    # Arrange: the batching trap, stated as a test — one bad line, ten good ones.
+    text = REAL_OUTPUT.replace(
+        "SAC_RELOC binds_checked=5", "SAC_RELOC port_in_use=not-a-port"
+    )
+    readout = parse_probe_output(text)
+    # Act
+    runtimes = readout.fields.get("runtimes")
+    # Assert
+    assert runtimes == "apptainer,claude-agent-sdk,tui"
+
+
+def test_output_with_no_marker_at_all_started_nothing() -> None:
+    # Arrange: a host that printed only its motd told us nothing.
+    readout = parse_probe_output("Welcome to Ubuntu\nLast login: never\n")
+    # Act
+    started = readout.started
+    # Assert
+    assert started is False

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe_ssh.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe_ssh.py
@@ -1,0 +1,231 @@
+"""An ssh failure is evidence; a transport failure is not, and they must not blur.
+
+Two failures look alike from a distance and mean opposite things:
+
+    the listen daemon could not be reached   -> we learned NOTHING about the
+                                                target; every fact must stay
+                                                unknown
+    ssh ran and could not connect            -> the target did not answer us,
+                                                which IS a measurement
+
+This module raises for the first and returns for the second, and these tests pin
+that boundary. They also pin the argv shape, because the one-argv-element rule is
+not cosmetic: passing ``["sh", "-c", script]`` makes the REMOTE login shell run
+only the script's first word with the rest as positional parameters — measured
+2026-08-09, where ``echo MARK`` printed an empty line and the rest of the script
+ran in a different shell than intended.
+
+The transport seam is a real callable supplied by the test, never a mock: an
+``exec_fn`` that returns a canned body is exactly the shape
+``request_host_exec`` has.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_probe_ssh import (
+    ProbeTransportError,
+    RemoteRun,
+    build_probe_argv,
+    peer_preamble,
+    run_probe_script,
+)
+from scitex_agent_container._state.host_config import PeerSpec
+
+SCRIPT = 'M=SAC_RELOC\necho "$M begin"\necho "$M end"\n'
+
+
+@pytest.fixture
+def peers():
+    """A peers map in the shape ``config.yaml`` parses into."""
+    yield {
+        "hop": PeerSpec(name="hop", ssh="user@hop"),
+        "far": PeerSpec(name="far", ssh="far.internal", via=("hop",)),
+        "venv-host": PeerSpec(
+            name="venv-host",
+            ssh="venv-host",
+            env_preamble=('export PATH="$HOME/.env-sac/bin:$PATH"',),
+        ),
+    }
+
+
+def _exec_returning(body):
+    """A real ``request_host_exec``-shaped callable that returns ``body``."""
+
+    def exec_fn(argv, *, timeout_s=None, **kwargs):
+        return body
+
+    return exec_fn
+
+
+def _exec_raising(exc):
+    def exec_fn(argv, *, timeout_s=None, **kwargs):
+        raise exc
+
+    return exec_fn
+
+
+# ---------------------------------------------------------------------------
+# argv shape
+# ---------------------------------------------------------------------------
+
+
+def test_the_script_is_a_single_argv_element(peers) -> None:
+    # Arrange: split across elements, ssh joins them and the remote shell runs
+    # only the first word — silently, with the rest as positional parameters.
+    argv = build_probe_argv("hop", SCRIPT, peers)
+    # Act
+    last = argv[-1]
+    # Assert
+    assert last == SCRIPT
+
+
+def test_the_peers_ssh_target_is_used_rather_than_the_key(peers) -> None:
+    # Arrange
+    argv = build_probe_argv("hop", SCRIPT, peers)
+    # Act
+    target = argv[-2]
+    # Assert
+    assert target == "user@hop"
+
+
+def test_a_multi_hop_peer_gets_its_proxy_jump_chain(peers) -> None:
+    # Arrange
+    argv = build_probe_argv("far", SCRIPT, peers)
+    # Act
+    jump = argv[argv.index("-J") + 1]
+    # Assert
+    assert jump == "user@hop"
+
+
+def test_an_unregistered_host_is_still_probed_by_name(peers) -> None:
+    # Arrange: scitex-nas-01 and -02 are reached through ~/.ssh/config today and
+    # are absent from config.yaml. Refusing to probe them would turn a
+    # measurable fact into an unknown for a bookkeeping reason.
+    argv = build_probe_argv("scitex-nas-01", SCRIPT, peers)
+    # Act
+    target = argv[-2]
+    # Assert
+    assert target == "scitex-nas-01"
+
+
+def test_batch_mode_is_forced(peers) -> None:
+    # Arrange: there is no terminal at the far end of a listen-daemon exec, so a
+    # password prompt would hang until the timeout instead of failing.
+    argv = build_probe_argv("hop", SCRIPT, peers)
+    # Act
+    batch = "BatchMode=yes" in argv
+    # Assert
+    assert batch is True
+
+
+def test_an_empty_host_is_refused_rather_than_guessed(peers) -> None:
+    # Arrange
+    script = SCRIPT
+
+    # Act
+    def run() -> list[str]:
+        return build_probe_argv("", script, peers)
+
+    # Assert
+    with pytest.raises(ValueError):
+        run()
+
+
+def test_the_peer_preamble_is_read_from_the_config(peers) -> None:
+    # Arrange: without it `sac` is off PATH on scitex-compute-03, and the two
+    # facts only the target's own validator can answer go unanswered there.
+    preamble = peer_preamble("venv-host", peers)
+    # Act
+    exported = preamble
+    # Assert
+    assert exported == 'export PATH="$HOME/.env-sac/bin:$PATH"'
+
+
+def test_a_host_with_no_preamble_gets_an_empty_one(peers) -> None:
+    # Arrange
+    preamble = peer_preamble("hop", peers)
+    # Act
+    empty = preamble
+    # Assert
+    assert empty == ""
+
+
+# ---------------------------------------------------------------------------
+# transport failure vs ssh failure
+# ---------------------------------------------------------------------------
+
+
+def test_a_reachable_target_returns_its_stdout(peers) -> None:
+    # Arrange
+    body = {"exit_code": 0, "stdout": "SAC_RELOC begin\n", "stderr": ""}
+    run = run_probe_script("hop", SCRIPT, exec_fn=_exec_returning(body), peers=peers)
+    # Act
+    stdout = run.stdout
+    # Assert
+    assert stdout == "SAC_RELOC begin\n"
+
+
+def test_an_unreachable_listen_daemon_raises_rather_than_returning(peers) -> None:
+    # Arrange: a returned "empty result" here would read downstream as "the
+    # target answered nothing", which is a different and false claim.
+    exec_fn = _exec_raising(OSError("connection refused"))
+
+    # Act
+    def run() -> RemoteRun:
+        return run_probe_script("hop", SCRIPT, exec_fn=exec_fn, peers=peers)
+
+    # Assert
+    with pytest.raises(ProbeTransportError):
+        run()
+
+
+def test_a_timed_out_exec_raises_rather_than_returning_a_blank(peers) -> None:
+    # Arrange
+    body = {"exit_code": 124, "stdout": "", "stderr": "", "timed_out": True}
+
+    # Act
+    def run() -> RemoteRun:
+        return run_probe_script(
+            "hop", SCRIPT, exec_fn=_exec_returning(body), peers=peers
+        )
+
+    # Assert
+    with pytest.raises(ProbeTransportError):
+        run()
+
+
+def test_a_body_without_an_exit_code_raises(peers) -> None:
+    # Arrange: a malformed body is a transport we cannot interpret, not a
+    # target that failed.
+    exec_fn = _exec_returning({"stdout": "x"})
+
+    # Act
+    def run() -> RemoteRun:
+        return run_probe_script("hop", SCRIPT, exec_fn=exec_fn, peers=peers)
+
+    # Assert
+    with pytest.raises(ProbeTransportError):
+        run()
+
+
+def test_an_ssh_connection_failure_is_returned_not_raised(peers) -> None:
+    # Arrange: ssh ran and could not connect. That is a measurement about the
+    # target, and the caller is entitled to use it.
+    body = {"exit_code": 255, "stdout": "", "stderr": "ssh: connect: timed out"}
+    run = run_probe_script("hop", SCRIPT, exec_fn=_exec_returning(body), peers=peers)
+    # Act
+    failed = run.ssh_failed
+    # Assert
+    assert failed is True
+
+
+def test_a_script_that_exits_non_zero_is_not_an_ssh_failure(peers) -> None:
+    # Arrange: the remote script's own status must not be mistaken for ssh's.
+    body = {"exit_code": 1, "stdout": "SAC_RELOC begin\n", "stderr": ""}
+    run = run_probe_script("hop", SCRIPT, exec_fn=_exec_returning(body), peers=peers)
+    # Act
+    failed = run.ssh_failed
+    # Assert
+    assert failed is False

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
@@ -134,6 +134,19 @@ def test_the_probe_error_is_printed_beside_the_unknown() -> None:
     assert "SSHTimeout: no route to host" in text
 
 
+def test_a_probe_error_keyed_by_fact_still_reaches_the_reader() -> None:
+    # Arrange: `gather_target_facts` keys its failures by FACT name, and four
+    # checks are named differently from the fact behind them. Looking up by
+    # check name alone drops exactly those four reasons — present, correct, and
+    # never shown (measured 2026-08-09 against a busybox NAS).
+    facts = TargetFacts(**{**ALL_GOOD.__dict__, "supported_runtimes": None})
+    errors = {"supported_runtimes": "FactUnavailable: sac is not importable there"}
+    # Act
+    text = _text(render_observed(_report(facts), errors))
+    # Assert
+    assert "sac is not importable there" in text
+
+
 def test_passing_checks_are_printed_too() -> None:
     # Arrange: showing only problems makes "passed" and "never ran"
     # indistinguishable — the ambiguity the three outcomes exist to remove.


### PR DESCRIPTION
## The gap

`sac agents relocate <name> --to <host> --dry-run` already decided correctly and refused correctly. It could not **see**:

```
VERDICT  REFUSED (undetermined) — nothing failed, but 9 could not be determined
```

All nine facts were UNKNOWN because no probes were wired. This PR is the **adapter** side of the port `_relocate_probe` defines — nothing else changes. `_relocate_preflight` still takes facts and returns checks; `_relocate_probe` is still pure and still turns any raising callable into `None`.

## After (real run, scitex-compute-03)

```
OBSERVED (probed on scitex-compute-03)
  PASS     target_reachable           scitex-compute-03 answered
  PASS     image_present              image present
  FAIL     binds_exist_on_target      bind sources absent on scitex-compute-03: /home/ywatanabe/.config/gh, /home/ywatanabe/.scitex/cards, /mnt/c
  PASS     card_store_reachable       card store reachable from scitex-compute-03
  FAIL     credentials_valid          target credential expired 298156s ago
  PASS     runtime_supported          runtime 'tui' supported
  PASS     spec_schema_accepted       target's validator accepts the spec
  PASS     ports_free                 required ports are free on the target
  UNKNOWN  hub_reachable_from_target  ... (reason below)

VERDICT  REFUSED — 2 failed, 1 could not be determined
```

**8 of 9 checks now carry a measured value.** Both failures are real and were previously invisible: `/mnt/c` (the exact 2026-08-07 bind) plus two more bind sources are absent on that host, and its credential expired 3.4 days ago — the silent-401 failure the credential check was written for.

## New modules, and why there

| module | role |
|---|---|
| `_lifecycle/_relocate_probe_script.py` | the POSIX-sh script and its parser. **Pure** — string in, string out — so every parse rule is testable against output captured from a real host. |
| `_lifecycle/_relocate_probe_ssh.py` | the transport edge: one ssh argv shipped through the listen daemon's `/v1/host_exec`. Its own file because it is the only impure one of the three. |
| `_lifecycle/_relocate_probe_adapter.py` | the eleven closures, plus the spec reading that decides what to ask. |

`_host_exec_client` is **reused as-is** — it fit exactly, so no new transport was written.

## How per-fact degradation survives batching

Eleven sequential ssh round trips is tens of seconds for a command whose job is to say "not yet", so all eleven questions ride **one** connection. The obvious batched version is also the dangerous one: one blob, one status, eleven facts that stand or fall together. Three rules keep them independent, and they compose:

1. **The script** never runs under `set -e`, and prints each answer on its own marker line the moment it is known — so a section that dies can neither retract nor prevent the sections after it.
2. **The parser** reports only what it SAW. A line that never arrived leaves no key; it does not leave a default.
3. **The adapter** gives every fact its own accessor, and an accessor whose evidence is missing **raises**, with a sentence naming the missing evidence. `probe()` turns that into `None` + the reason, so the operator reads *why*, not just *unknown*.

Measured end to end on a busybox QNAP (`scitex-nas-01` — no `python3`, no `nc`, no `sac`, no credential file): **4 facts measured, 5 honest unknowns**, each with its own stated cause. Not one degraded to a false negative.

```
PASS     target_reachable           scitex-nas-01 answered
FAIL     image_present              the agent's image is absent on scitex-nas-01
FAIL     binds_exist_on_target      bind sources absent: ... (all 5)
UNKNOWN  card_store_reachable       probe error: neither python3 nor a -z-capable nc is installed there,
                                    so this is undetermined rather than closed
UNKNOWN  credentials_valid          no credential file with a readable expiresAt exists on the target
UNKNOWN  runtime_supported          the target's sac did not report which runtimes it accepts
UNKNOWN  spec_schema_accepted       ... likewise
PASS     ports_free                 required ports are free on the target
UNKNOWN  hub_reachable_from_target  ... (reason below)
```

## The invariant, and its negative control

Every accessor returns something the target actually said, or raises. There is no `except: return False` in the adapter — that turns "no route to the host" into "the host has no image", and the relocation then proceeds on fiction.

**Negative control (run, not asserted):** the two transport-failure paths were neutered in place to `return False`, and four tests failed —

```
test_a_transport_failure_leaves_reachability_unknown        AssertionError: assert False is None
test_a_transport_failure_leaves_the_image_unknown           AssertionError: assert False is None
test_a_transport_failure_makes_preflight_refuse_as_undetermined
                                                            AssertionError: assert False is None
test_a_transport_failure_says_why_each_fact_is_missing      KeyError: 'image_present'
  where TargetFacts(reachable=False, image_present=False, ...)   <- for a host never reached
```

The third is the one that matters: with the invariant broken the verdict flips from "could not be determined" to a **decided refusal built on facts nobody measured**. Restored afterwards; the tests are green on the shipped code.

## Two unknowns left honestly unknown

* **`hub_reachable_from_target`** — sac's listen is known here only as `http://127.0.0.1:7878`. Handing a loopback address to the target would measure the *target's* loopback: a confident answer to a different question, which is precisely what `CHECK_HUB_FROM_TARGET` warns about. The probe refuses and names `SAC_RELOCATE_HUB_ADDR=<host:port>` as the way to measure it. No probe was fabricated to turn this green.
  * The card store is deliberately **not** treated this way: there, loopback is the right thing to probe, because after the move the agent runs on the target and `127.0.0.1` means its own database. That asymmetry is documented at both sites.
* **Credentials on a host with no credential file** — no file means no expiry to report. Returning a negative number would fabricate a measurement.

## Two defects surfaced and fixed on the way

* `declared_from_spec` read the card store from `apptainer.env` only and printed `(unset)` for this repo's own spec — which carries it in a `--env` raw arg — while the probe went and successfully dialled it. Two sections of one report describing the same agent differently. Both now read through one resolver.
* The renderer looked up probe errors by **check** name while `gather_target_facts` keys them by **fact** name. Four of nine checks are named differently on the two sides, so their reasons were present, correct, and never shown (measured on the NAS run above: 4 of 5 unknowns lost their explanation on the way to the screen).

## Transport notes (both measured 2026-08-09, both non-obvious)

* A container cannot ssh: `$HOME/.ssh` is a read-only bind and OpenSSH refuses when it cannot create its ControlMaster socket. The route is the listen daemon's `host_exec` on the bare host, then ssh from there.
* The script must be **one** argv element. `ssh host sh -c '<script>'` does not do what it reads like — ssh joins everything after the destination and the *remote* shell re-parses it, so `echo MARK` ran with `MARK` as `$0` and printed an empty line while the rest of the script executed in the outer shell. `_hostsync/_probe.py` has the same shape and works only by that accident.
* `build_ssh_argv` is deliberately not ridden here: its `env_preamble` branch `shlex.join`s the command into one quoted word (right for an argv list, wrong for a script), and its ControlMaster path is resolved in the container but used on the host. The `via:` chain and `env_preamble` still come from the same `config.yaml`.

## Tests

`213 passed` across the relocate suite (`-k relocate`), `15 passed` for the CLI verb. Layout mirrors source, no `monkeypatch` (yield fixtures), one logical assert per test, real callables at every seam — the callable-based port is exactly what makes that possible.

Pre-existing and unrelated: `tests/.../test__broker_self.py` fails identically against the main checkout's code.

## Not in this change

The executing relocation path. `--dry-run` remains required.
