### PR TITLE
feat(maintenance): sweep to_home_layers into every spec, gated on hook arming

### DIFF
--- a/src/scitex_agent_container/_maintenance/__init__.py
+++ b/src/scitex_agent_container/_maintenance/__init__.py
@@ -54,6 +54,17 @@ from ._install_integrity_probe import (
     read_site_evidence,
     resolve_site_packages,
 )
+from ._layers_migration_gate import (
+    ArmingGateVerdict,
+    ArmingSnapshot,
+    fleet_arming_snapshot,
+    gate_arming,
+)
+from ._layers_migration_plan import (
+    already_declared,
+    plan_migration,
+    resolved_layer_names,
+)
 from ._overlay_masking import (
     base_package_set_for,
     inspect_agent_overlay,
@@ -100,6 +111,8 @@ __all__ = [
     "STATE_BROKEN",
     "STATE_OK",
     "STATE_UNKNOWN",
+    "ArmingGateVerdict",
+    "ArmingSnapshot",
     "BasePackageSet",
     "DistributionEvidence",
     "DistributionVerdict",
@@ -113,6 +126,11 @@ __all__ = [
     "install_integrity_exit_code",
     "read_site_evidence",
     "resolve_site_packages",
+    "already_declared",
+    "fleet_arming_snapshot",
+    "gate_arming",
+    "plan_migration",
+    "resolved_layer_names",
     "OverlayMaskVerdict",
     "RepoGcResult",
     "ShadowInstall",

--- a/src/scitex_agent_container/_maintenance/_layers_migration_gate.py
+++ b/src/scitex_agent_container/_maintenance/_layers_migration_gate.py
@@ -1,0 +1,199 @@
+"""The GATE the ``to_home_layers`` sweep must pass: nobody got disarmed.
+
+:mod:`..runtimes._hook_arming_diff` compares two fleet snapshots of what is
+armed. It was merged with nothing to feed it and nothing consuming it. This
+module is both halves — the collector that builds a snapshot, and the verdict
+that decides whether a sweep may stand on one.
+
+**Snapshots are DERIVED, never read back off disk.** ``hook-origins.json`` is
+written at deploy time, so on a fleet that has not redeployed since that
+landed, zero manifests exist. Reading them would compare nothing against
+nothing. Deriving the cascade here — load the spec, resolve its layers, merge,
+reshape the provenance — measures the specs as they are RIGHT NOW, which is
+the only thing a pre/post-write comparison can honestly be about.
+
+**An agent that could not be measured is never recorded as "no hooks".** The
+tempting shortcut is to catch the error and store ``{}``; two such agents then
+compare equal and the diff reports them UNCHANGED. That is the exact collapse
+of "I could not tell" into "it is fine" that the diff's own ``unmeasured``
+field exists to prevent, so an unmeasurable agent is kept OUT of the snapshot
+map and named in :attr:`ArmingSnapshot.unmeasurable` instead.
+
+**The gate is not the diff.** ``diff_hook_arming({}, {})`` is ``safe`` — 0
+agents compared, nothing moved, deliberately so. Wire a sweep straight to that
+and it waves through a migration over a fleet it never looked at, which is not
+a hypothetical: an empty comparison is what a collector that silently found
+nothing produces. :class:`ArmingGateVerdict` therefore adds a FLOOR — the
+comparison must cover the number of agents the plan covers, and that number
+must not be zero — and refuses while either side has an unmeasurable agent.
+``safe`` on the diff alone is necessary and nowhere near sufficient.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ..config import load_config
+from ..runtimes._hook_arming_diff import HookArmingDiff, diff_hook_arming
+from ..runtimes._hook_origin_manifest import hook_origins
+
+# Shared with the planner on purpose: an agent named as unreadable by the plan
+# and unmeasurable by the gate must render identically, or a report reads like
+# two different agents had two different problems.
+from ._layers_migration_plan import _reason
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ArmingSnapshot:
+    """What every measurable agent arms, plus the ones we could NOT measure."""
+
+    #: agent -> {event: {command: layer}}. Only agents actually measured.
+    origins: "dict[str, dict[str, dict[str, str]]]" = field(default_factory=dict)
+    #: ``"<agent>: <reason>"`` for each agent whose arming could not be derived.
+    unmeasurable: "tuple[str, ...]" = ()
+
+    @property
+    def measured(self) -> int:
+        return len(self.origins)
+
+
+def agent_arming(config) -> "dict[str, dict[str, str]]":
+    """Derive ONE agent's ``{event: {command: layer}}`` from its config.
+
+    The same three calls ``deploy_to_home`` makes, in the same order, so this
+    measures the cascade the deploy would actually build rather than a parallel
+    re-implementation that could drift from it.
+    """
+    from ..runtimes._to_home_resolve import settings_layer_dirs
+    from ..runtimes._to_home_settings import settings_cascade_provenance
+
+    return hook_origins(settings_cascade_provenance(settings_layer_dirs(config)))
+
+
+def fleet_arming_snapshot(spec_paths: "list[Path]") -> ArmingSnapshot:
+    """Measure hook arming across ``spec_paths``, right now, from the specs.
+
+    Every spec is re-loaded on every call. That is not waste — it is the
+    contract: the ``after`` snapshot has to see the bytes the sweep just wrote,
+    and a cached parse would report the pre-write cascade and pass the gate on
+    a file it never re-read. (``config._spec_cache`` keys on size+mtime_ns and
+    the insert changes both, so it misses; this call does not depend on that.)
+    """
+    origins: dict[str, dict[str, dict[str, str]]] = {}
+    unmeasurable: list[str] = []
+    for path in spec_paths:
+        agent = path.parent.name
+        # stx-allow: fallback (reason: an agent we cannot measure must become
+        # the THIRD value, not an empty arming map that would compare as
+        # "unchanged" against another empty one.)
+        try:
+            origins[agent] = agent_arming(load_config(path))
+        except Exception as exc:
+            logger.error("arming snapshot: could not measure %s — %s", path, exc)
+            unmeasurable.append(_reason(agent, exc))
+    return ArmingSnapshot(origins=origins, unmeasurable=tuple(unmeasurable))
+
+
+@dataclass(frozen=True)
+class ArmingGateVerdict:
+    """May the sweep stand? ``safe``/``summary()`` match what the apply reads.
+
+    Deliberately the same two-member surface
+    :func:`.._layers_migration_apply.apply_migration` expects of its ``verify``
+    callable, so this drops in without the apply learning anything about hooks.
+    """
+
+    diff: HookArmingDiff
+    #: How many agents the comparison MUST cover — the size of the population
+    #: the plan touched. Anything less means agents went unlooked-at.
+    expected: int
+    before_unmeasurable: "tuple[str, ...]" = ()
+    after_unmeasurable: "tuple[str, ...]" = ()
+
+    @property
+    def floor_met(self) -> bool:
+        """Did the comparison actually cover the whole population?
+
+        ``expected > 0`` is not pedantry. A comparison of zero agents against
+        zero agents satisfies every other condition here, and a collector that
+        found nothing produces exactly that — so without this clause the gate's
+        most likely failure mode reads as its strongest pass.
+        """
+        return self.expected > 0 and self.diff.agents_compared == self.expected
+
+    @property
+    def safe(self) -> bool:
+        """True only when the whole population was measured BOTH sides, unchanged."""
+        return (
+            self.diff.safe
+            and self.floor_met
+            and not self.before_unmeasurable
+            and not self.after_unmeasurable
+        )
+
+    def summary(self) -> str:
+        """One line. Says which condition failed, never just that one did."""
+        parts: list[str] = []
+        if not self.diff.safe:
+            parts.append(self.diff.summary())
+        if not self.floor_met:
+            parts.append(
+                f"FLOOR NOT MET: {self.diff.agents_compared} agent(s) compared, "
+                f"{self.expected} expected — the sweep was not verified over "
+                f"the population it touched"
+            )
+        if self.before_unmeasurable:
+            parts.append(
+                f"{len(self.before_unmeasurable)} agent(s) UNMEASURABLE before"
+            )
+        if self.after_unmeasurable:
+            parts.append(f"{len(self.after_unmeasurable)} agent(s) UNMEASURABLE after")
+        if not parts:
+            return (
+                f"{self.diff.agents_compared} agent(s) measured both sides: "
+                f"hook arming identical"
+            )
+        return "; ".join(parts)
+
+    def to_dict(self) -> dict:
+        """JSON-shaped, with every field present on every call."""
+        return {
+            "safe": self.safe,
+            "floor_met": self.floor_met,
+            "expected": self.expected,
+            "agents_compared": self.diff.agents_compared,
+            "unchanged": list(self.diff.unchanged),
+            "lost": {k: list(v) for k, v in self.diff.lost.items()},
+            "gained": {k: list(v) for k, v in self.diff.gained.items()},
+            "reattributed": {k: list(v) for k, v in self.diff.reattributed.items()},
+            "unmeasured": list(self.diff.unmeasured),
+            "unexpected": list(self.diff.unexpected),
+            "before_unmeasurable": list(self.before_unmeasurable),
+            "after_unmeasurable": list(self.after_unmeasurable),
+            "summary": self.summary(),
+        }
+
+
+def gate_arming(
+    before: ArmingSnapshot, after: ArmingSnapshot, *, expected: int
+) -> ArmingGateVerdict:
+    """Compare two snapshots against the population the sweep was supposed to cover."""
+    return ArmingGateVerdict(
+        diff=diff_hook_arming(before.origins, after.origins),
+        expected=expected,
+        before_unmeasurable=before.unmeasurable,
+        after_unmeasurable=after.unmeasurable,
+    )
+
+
+__all__ = [
+    "ArmingGateVerdict",
+    "ArmingSnapshot",
+    "agent_arming",
+    "fleet_arming_snapshot",
+    "gate_arming",
+]

--- a/src/scitex_agent_container/_maintenance/_layers_migration_plan.py
+++ b/src/scitex_agent_container/_maintenance/_layers_migration_plan.py
@@ -1,0 +1,195 @@
+"""Build the ``to_home_layers`` :class:`MigrationPlan` — the missing half.
+
+:mod:`._layers_migration_model` defines the plan's SHAPE and
+:mod:`._layers_migration_apply` consumes it, but nothing ever filled one in.
+That gap was invisible because the model's own docstring names a
+``plan_migration`` that was never written, so the migration read as complete
+while its entry point did not exist. This module is that entry point.
+
+What a plan is derived FROM, and why it matters:
+
+The declaration written into a spec is the cascade that spec resolves TODAY —
+:func:`settings_layer_dirs` with the layers it actually contributes, not a
+guess and not a constant. That is the whole zero-behaviour-change argument:
+declaring what is already true cannot change what an agent inherits. Deriving
+it instead from a fixed list, or from the layer NAMES without checking which
+resolved to a real directory, would write declarations that differ from
+today's behaviour on any host whose layout differs from this one.
+
+Three outcomes per spec, kept apart on purpose:
+
+* **writable** — a single-line insert, ready to apply.
+* **refused** — no ``to_home:`` line to anchor to. Expected, named, counted,
+  and NOT a failure: a human resolves it. (Explicitly not an error exit.)
+* **unreadable** — the spec could not be loaded at all, so its layers could
+  not be derived and no edit could be planned. This is NOT a refusal: a
+  refusal is the editor declining a shape it knows it does not handle, while
+  this never reached the editor. It makes the plan unsafe to apply, because a
+  plan that cannot describe every spec does not describe the sweep.
+
+A fourth, quieter outcome exists: a spec that ALREADY declares the key. It is
+neither written nor refused, so it appears in ``edits`` carrying no
+``new_text`` and no ``refusal`` — see :func:`already_declared`. This is what
+makes the sweep re-runnable without either duplicating a key or reporting the
+second run as a fleet of refusals.
+
+``unreadable`` entries are formatted ``"<agent>: <reason>"`` so a report names
+the spec AND why it could not be read; the agent name is everything before the
+first ``": "``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from pathlib import Path
+
+from ..config import load_config
+from ..config._to_home_layers_line import insert_to_home_layers
+from ._layers_migration_model import MigrationPlan, SpecEdit, count_added_lines
+
+logger = logging.getLogger(__name__)
+
+_NO_ANCHOR = "no 'to_home:' line to anchor the declaration to"
+_RESOLVE_LOGGER = "scitex_agent_container.runtimes._to_home_resolve"
+#: An unreadable spec's reason, capped. The full exception is logged; this is
+#: the one-line form a report and a JSON field can carry without either
+#: swallowing the useful half or spilling a 60-line validation dump per spec.
+_REASON_CHARS = 240
+
+
+def _reason(agent: str, exc: BaseException) -> str:
+    """``"<agent>: <Type>: <message>"``, whitespace-collapsed and capped.
+
+    Collapsed rather than first-line-only: ``load_config``'s validation error
+    puts "Config validation failed for <path>:" on line one and the fields
+    that are actually missing on the lines after, so taking line one alone
+    reports that something is wrong while discarding what.
+    """
+    flat = " ".join(str(exc).split())
+    if len(flat) > _REASON_CHARS:
+        flat = flat[: _REASON_CHARS - 1] + "…"
+    return f"{agent}: {type(exc).__name__}: {flat}"
+
+
+@contextlib.contextmanager
+def quiet_undeclared_warning():
+    """Silence ``settings_layer_dirs``' per-agent "declares no layers" WARNING.
+
+    That warning exists to make this migration visible, and it works: measured
+    on this host it fires 101 times in one dry-run, once per undeclared spec.
+    Inside THIS verb it is pure noise — the command's entire output is that
+    same finding, counted, attributed and per-agent, and 101 copies on stderr
+    bury the report they duplicate.
+
+    Scoped as tightly as it can be: one named logger, restored in ``finally``,
+    and never touched on any production path. Suppressing it anywhere else
+    would hide the signal instead of rendering it.
+    """
+    log = logging.getLogger(_RESOLVE_LOGGER)
+    previous = log.level
+    log.setLevel(logging.ERROR)
+    try:
+        yield
+    finally:
+        log.setLevel(previous)
+
+
+def fleet_spec_paths(specs_dir: "Path | None" = None) -> "list[Path]":
+    """Every fleet spec, via the registry's own enumerator.
+
+    Re-exported rather than re-implemented. ``_reconcile._pass`` already owns
+    the answer to "which specs are the fleet", including the ``_``-prefix rule
+    that keeps ``_shared`` / ``_template_*`` scaffolding out — measured on this
+    host, a raw ``*/spec.yaml`` glob returns 107 where the fleet is 102. Two
+    sweeps of one fleet must never disagree about which agents exist.
+    """
+    from .._reconcile._pass import fleet_spec_paths as _paths
+
+    return _paths(specs_dir)
+
+
+def resolved_layer_names(config) -> "list[str]":
+    """The layer names that CONTRIBUTE to ``config`` today, in cascade order.
+
+    A layer resolving to ``None`` contributes nothing — it is either absent on
+    this host or collapsed as a duplicate of an earlier layer — so naming it in
+    the declaration would claim an inheritance the agent does not have.
+    """
+    from ..runtimes._to_home_resolve import settings_layer_dirs
+
+    return [name for name, path in settings_layer_dirs(config) if path is not None]
+
+
+def already_declared(plan: MigrationPlan) -> "tuple[SpecEdit, ...]":
+    """Specs that already declare the key: no write, and no refusal either.
+
+    Separate from both other buckets because it is the only one that is
+    finished. Folding it into ``refused`` would make a completed re-run look
+    like a fleet needing manual attention; folding it into ``writable`` would
+    have the apply rewrite files it does not need to touch.
+    """
+    return tuple(e for e in plan.edits if e.new_text is None and e.refusal is None)
+
+
+def plan_spec(path: Path) -> "SpecEdit | str":
+    """Plan ONE spec. Returns the edit, or an ``"<agent>: <reason>"`` string.
+
+    The string return is the unreadable case. It is a distinct TYPE rather than
+    a ``SpecEdit`` with an empty refusal so a caller cannot accidentally treat
+    "could not read this spec" as "this spec needs no edit".
+    """
+    agent = path.parent.name
+    # stx-allow: fallback (reason: this classifies a spec as UNREADABLE — the
+    # honest third value. Enumerating exception types would promote any new
+    # failure mode into a crash of the whole 102-spec sweep, which is the one
+    # outcome a bulk operation must not have.)
+    try:
+        config = load_config(path)
+        layers = tuple(resolved_layer_names(config))
+        original = path.read_text()
+    except Exception as exc:
+        logger.error("migrate-layers: cannot read spec %s — %s", path, exc)
+        return _reason(agent, exc)
+
+    if getattr(config, "to_home_layers", None) is not None:
+        return SpecEdit(agent=agent, path=path, layers=layers)
+
+    new_text, changed = insert_to_home_layers(original, list(layers))
+    if not changed:
+        return SpecEdit(agent=agent, path=path, layers=layers, refusal=_NO_ANCHOR)
+    return SpecEdit(
+        agent=agent,
+        path=path,
+        layers=layers,
+        new_text=new_text,
+        lines_added=count_added_lines(original, new_text),
+    )
+
+
+def plan_migration(spec_paths: "list[Path] | None" = None) -> MigrationPlan:
+    """What the sweep WOULD do, over every fleet spec. Reads only.
+
+    ``spec_paths`` defaults to the fleet registry. Passing it explicitly is how
+    a test points this at a corpus that is not the operator's live fleet.
+    """
+    paths = list(spec_paths) if spec_paths is not None else fleet_spec_paths()
+    edits: list[SpecEdit] = []
+    unreadable: list[str] = []
+    for path in paths:
+        outcome = plan_spec(path)
+        if isinstance(outcome, str):
+            unreadable.append(outcome)
+        else:
+            edits.append(outcome)
+    return MigrationPlan(edits=tuple(edits), unreadable=tuple(unreadable))
+
+
+__all__ = [
+    "already_declared",
+    "fleet_spec_paths",
+    "plan_migration",
+    "plan_spec",
+    "quiet_undeclared_warning",
+    "resolved_layer_names",
+]

--- a/src/scitex_agent_container/cli_pkg/_agents_migrate_layers.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_migrate_layers.py
@@ -1,0 +1,348 @@
+"""``sac agents migrate-layers`` — declare each spec's ``to_home`` cascade.
+
+Step 3 of the ``to_home_layers`` migration, and the only step that writes.
+Every fleet spec gains one line naming the cascade layers it ALREADY resolves,
+so what an agent inherits becomes readable from its spec instead of derivable
+only by re-running the resolver. Step 4 — turning the "no declaration" warning
+into a refusal — is deliberately NOT here: it is only safe once this has
+actually run, and shipping both together would let one command disarm the
+fleet on a bad plan.
+
+Registered onto ``sac agents`` by :func:`register`, exactly as ``reconcile``
+is, and it reaches the CLI through ``_main.py``'s existing lazy ``agents``
+entry — no new top-level noun. A ``spec`` group invented for one command that
+becomes a permanent no-op the day it succeeds would cost more than it buys.
+
+**Dry-run is the DEFAULT.** ``--apply`` is the deliberate act.
+
+**The gate.** Declaring the cascade an agent already resolves cannot change
+what it inherits — that is the argument, and an argument is not a measurement.
+So the apply measures what every agent ARMS before writing, re-measures after,
+and rolls every spec back unless the two are identical over the whole
+population (:mod:`.._maintenance._layers_migration_gate`). An agent it could
+not measure on either side blocks the sweep rather than being skipped.
+
+**Exit codes**, and the distinction that drives them:
+
+  0  the plan is sound (refusals included), or the apply was verified
+  1  a spec is MALFORMED or UNREADABLE — the plan does not describe the sweep
+  2  the apply was refused or rolled back by the arming gate
+
+A REFUSAL is not a failure. "This spec has no ``to_home:`` line to anchor to"
+is an expected outcome that a human resolves; exiting non-zero on it would
+train every reader to ignore the exit code of a command whose whole job is to
+be trusted about what it did.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+
+import click
+from rich.markup import escape
+
+from .._maintenance._layers_migration_apply import apply_migration
+from .._maintenance._layers_migration_gate import fleet_arming_snapshot, gate_arming
+from .._maintenance._layers_migration_plan import (
+    already_declared,
+    fleet_spec_paths,
+    plan_migration,
+    quiet_undeclared_warning,
+)
+from ._helpers import _json_flag, console
+
+_EXIT_OK = 0
+_EXIT_PLAN_UNSOUND = 1
+_EXIT_GATE_REFUSED = 2
+
+
+# Every dynamic value printed through `console` goes through rich's markup
+# escaper. This is not defensive habit — MEASURED: the layer list renders as
+# `[user-shared]`, which rich parses as a style tag and SWALLOWS, so the first
+# run of this command reported a correct histogram with all 101 layer sets
+# blank. A report whose most important line silently empties itself is worse
+# than one that crashes.
+def _lit(text: str) -> str:
+    return escape(str(text))
+
+
+def _archive_dir():
+    """Where originals are parked before the first byte changes."""
+    from .._runtime_paths import runtime_base_dir
+
+    stamp = _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return runtime_base_dir() / "layers-migration" / stamp
+
+
+def _layer_histogram(edits) -> "dict[str, int]":
+    """How many specs resolve each distinct layer set, most common first.
+
+    The single most useful number in a dry-run: it says what the sweep would
+    actually declare across the fleet, which a per-spec list of 102 lines
+    hides rather than shows.
+    """
+    hist: dict[str, int] = {}
+    for edit in edits:
+        key = ", ".join(edit.layers) or "(none)"
+        hist[key] = hist.get(key, 0) + 1
+    return dict(sorted(hist.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def _plan_payload(plan) -> dict:
+    """Everything the plan knows, with every key present on every call."""
+    return {
+        "specs": len(plan.edits) + len(plan.unreadable),
+        "writable": len(plan.writable),
+        "refused": [
+            {"agent": e.agent, "reason": e.refusal, "path": str(e.path)}
+            for e in plan.refused
+        ],
+        "already_declared": [e.agent for e in already_declared(plan)],
+        "malformed": [
+            {"agent": e.agent, "lines_added": e.lines_added} for e in plan.malformed
+        ],
+        "unreadable": list(plan.unreadable),
+        "layer_sets": _layer_histogram(plan.writable),
+        "safe_to_apply": plan.safe_to_apply,
+        "summary": plan.summary(),
+    }
+
+
+def _render_plan(plan, *, verbose: bool) -> None:
+    payload = _plan_payload(plan)
+    console.print(
+        f"[bold]{payload['specs']} spec(s)[/bold] — "
+        f"{payload['writable']} would gain a to_home_layers declaration\n"
+    )
+    for layers, count in payload["layer_sets"].items():
+        console.print(f"  [green]{count:4d}[/green]  {_lit('[' + layers + ']')}")
+    if payload["already_declared"]:
+        console.print(
+            f"\n[dim]{len(payload['already_declared'])} spec(s) already declare "
+            f"the key — nothing to do for those.[/dim]"
+        )
+    # Never silent about a decision: refusals print whether or not -v is given.
+    for entry in payload["refused"]:
+        console.print(
+            f"\n[yellow]REFUSED[/yellow] {_lit(entry['agent'])}: "
+            f"{_lit(entry['reason'])}",
+            soft_wrap=True,
+        )
+        console.print(f"    [dim]{_lit(entry['path'])}[/dim]", soft_wrap=True)
+    for entry in payload["malformed"]:
+        console.print(
+            f"\n[red]MALFORMED[/red] {_lit(entry['agent'])}: the planned edit "
+            f"touches {entry['lines_added']} line(s), not 1 — this is a DEFECT "
+            f"in the editor, not a spec needing attention",
+            soft_wrap=True,
+        )
+    for entry in payload["unreadable"]:
+        console.print(f"\n[red]UNREADABLE[/red] {_lit(entry)}", soft_wrap=True)
+    if verbose:
+        console.print("")
+        for edit in plan.writable:
+            layers = _lit("[" + ", ".join(edit.layers) + "]")
+            console.print(
+                f"  [dim]{_lit(edit.agent)}[/dim] -> {layers}", soft_wrap=True
+            )
+    console.print(f"\n[bold]{_lit(payload['summary'])}[/bold]")
+
+
+def _run_apply(plan, covered) -> "tuple[int, dict]":
+    """Snapshot, write, re-snapshot, and undo unless the arming is identical."""
+    before = fleet_arming_snapshot(covered)
+    if before.unmeasurable:
+        # Refuse BEFORE writing. The gate would catch this after the fact too,
+        # but writing 100 files to learn something knowable beforehand is not a
+        # safety property, it is a rollback waiting to be needed.
+        return _EXIT_GATE_REFUSED, {
+            "mode": "apply",
+            "written": [],
+            # `apply_refused`, NOT `refused`: the plan payload already owns
+            # `refused` as the per-spec list of specs the EDITOR declined.
+            # Reusing that key would make one JSON field mean a list of specs
+            # in dry-run and a sentence in apply mode, which is how a consumer
+            # ends up reading "the sweep refused nothing" off a refusal.
+            "apply_refused": (
+                f"{len(before.unmeasurable)} agent(s) could not be measured "
+                f"BEFORE the sweep, so no post-write comparison could prove "
+                f"them unchanged"
+            ),
+            "before_unmeasurable": list(before.unmeasurable),
+        }
+
+    expected = len(covered)
+    verdicts: list = []
+
+    def _verify():
+        after = fleet_arming_snapshot(covered)
+        verdict = gate_arming(before, after, expected=expected)
+        verdicts.append(verdict)
+        return verdict
+
+    result = apply_migration(plan, _archive_dir(), _verify)
+    gate = verdicts[-1].to_dict() if verdicts else None
+    payload = {
+        "mode": "apply",
+        "written": list(result.written),
+        "archive_dir": str(result.archive_dir) if result.archive_dir else None,
+        "apply_refused": result.refused,
+        "rolled_back": result.rolled_back,
+        "applied": result.applied,
+        "gate": gate,
+    }
+    if result.applied:
+        return _EXIT_OK, payload
+    return _EXIT_GATE_REFUSED, payload
+
+
+def _render_apply(payload: dict) -> None:
+    if payload.get("applied"):
+        console.print(
+            f"[green]APPLIED[/green] {len(payload['written'])} spec(s) written "
+            f"and verified.\n  [dim]originals archived at "
+            f"{_lit(payload['archive_dir'])}[/dim]"
+        )
+        console.print(f"  [dim]{_lit(payload['gate']['summary'])}[/dim]")
+        return
+    if payload.get("rolled_back"):
+        console.print(
+            f"[red]ROLLED BACK[/red] — the specs were written, the arming gate "
+            f"refused them, and every original was restored.\n"
+            f"  {_lit(payload['rolled_back'])}"
+        )
+        return
+    console.print(
+        f"[red]REFUSED[/red] — nothing was written.\n  {_lit(payload['apply_refused'])}"
+    )
+    for entry in payload.get("before_unmeasurable", []):
+        console.print(
+            f"    [magenta]UNMEASURABLE[/magenta] {_lit(entry)}", soft_wrap=True
+        )
+
+
+@click.command(name="migrate-layers")
+@click.option(
+    "--apply",
+    "apply",
+    is_flag=True,
+    default=False,
+    help="ACTUALLY write the declarations. Without this, nothing is written.",
+)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="Report only, write nothing. This is already the DEFAULT.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="Also list every spec that would be written, not just the counts.",
+)
+@click.pass_context
+def migrate_layers(
+    ctx: click.Context,
+    apply: bool,
+    dry_run: bool,
+    as_json: bool,
+    verbose: bool,
+) -> None:
+    """Declare each spec's ``to_home`` cascade in the spec. Dry-run by default.
+
+    Writes ONE line per spec — ``to_home_layers: [...]`` naming the layers that
+    spec already resolves. Behaviour-preserving by construction and verified by
+    measurement: the apply compares what every agent ARMS before and after, and
+    restores every original unless the two are identical.
+
+    \b
+    Preview (read-only — the DEFAULT):
+      $ sac agents migrate-layers
+      $ sac agents migrate-layers --json
+    \b
+    Write:
+      $ sac agents migrate-layers --apply
+
+    Exits 0 when the plan is sound (a named REFUSAL is not a failure), 1 when a
+    spec is malformed or unreadable, 2 when the apply was refused or rolled
+    back by the arming gate.
+    """
+    if apply and dry_run:
+        raise click.UsageError(
+            "--apply and --dry-run are contradictory. Dry-run is the DEFAULT: "
+            "drop both flags to preview, pass --apply to write."
+        )
+
+    # Quieted around the resolver calls only: the "declares no layers" WARNING
+    # fires once per undeclared spec (101 on this host) and this command's whole
+    # output IS that finding, aggregated. See quiet_undeclared_warning.
+    with quiet_undeclared_warning():
+        plan = plan_migration(fleet_spec_paths())
+    payload = _plan_payload(plan)
+    payload["mode"] = "apply" if apply else "dry-run"
+
+    if not apply:
+        code = _EXIT_OK if plan.safe_to_apply else _EXIT_PLAN_UNSOUND
+        payload["exit_code"] = code
+        if _json_flag(ctx, as_json):
+            click.echo(json.dumps(payload, indent=2))
+            raise SystemExit(code)
+        console.print("[bold]sac agents migrate-layers[/bold]  dry-run (read-only)\n")
+        _render_plan(plan, verbose=verbose)
+        if plan.writable:
+            console.print(
+                "\nNothing was written — this is a dry-run. To act:\n"
+                "    sac agents migrate-layers --apply"
+            )
+        raise SystemExit(code)
+
+    if not plan.safe_to_apply:
+        payload["exit_code"] = _EXIT_PLAN_UNSOUND
+        payload["apply_refused"] = f"plan is not safe to apply: {plan.summary()}"
+        if _json_flag(ctx, as_json):
+            click.echo(json.dumps(payload, indent=2))
+            raise SystemExit(_EXIT_PLAN_UNSOUND)
+        console.print("[bold]sac agents migrate-layers[/bold]  apply\n")
+        _render_plan(plan, verbose=verbose)
+        console.print(
+            "\n[red]REFUSED[/red] — nothing was written. A plan that cannot "
+            "describe every spec does not describe the sweep."
+        )
+        raise SystemExit(_EXIT_PLAN_UNSOUND)
+
+    if not plan.writable:
+        payload["exit_code"] = _EXIT_OK
+        payload["written"] = []
+        if _json_flag(ctx, as_json):
+            click.echo(json.dumps(payload, indent=2))
+            raise SystemExit(_EXIT_OK)
+        console.print(
+            "[green]Nothing to write[/green] — every spec already declares its "
+            "layers. The sweep is idempotent; this is what a completed one "
+            "looks like."
+        )
+        raise SystemExit(_EXIT_OK)
+
+    with quiet_undeclared_warning():
+        code, applied = _run_apply(plan, [e.path for e in plan.edits])
+    payload.update(applied)
+    payload["exit_code"] = code
+    if _json_flag(ctx, as_json):
+        click.echo(json.dumps(payload, indent=2))
+        raise SystemExit(code)
+    console.print("[bold]sac agents migrate-layers[/bold]  apply\n")
+    _render_apply(payload)
+    raise SystemExit(code)
+
+
+def register(agent_group) -> None:
+    """Attach ``migrate-layers`` to the parent ``agents`` Click group."""
+    agent_group.add_command(migrate_layers)
+
+
+__all__ = ["migrate_layers", "register"]

--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -78,6 +78,7 @@ class _AgentsGroup(HelpRecursiveGroup):
                 "archive-claude-bloat",
                 "refresh-acl",
                 "declare-a2a-host",
+                "migrate-layers",
             ],
         ),
     ]
@@ -248,6 +249,17 @@ agent_group.add_command(_rebind(_archive_claude_bloat_impl, "archive-claude-bloa
 from .refresh_acl import refresh_acl as _refresh_acl_impl  # noqa: E402
 
 agent_group.add_command(_refresh_acl_impl)
+# `migrate-layers` — step 3 of the to_home_layers migration: write into each
+# spec the ``to_home`` cascade it ALREADY resolves, so what an agent inherits
+# is readable from the spec instead of only derivable by re-running the
+# resolver. Dry-run by default. Behaviour-preserving by construction AND by
+# measurement: the apply compares what every agent ARMS before and after and
+# restores every original unless they are identical over the whole population.
+# Agent-spec-scoped, so it lives here rather than under a new top-level noun
+# that would outlive the one-shot verb needing it.
+from ._agents_migrate_layers import register as _register_migrate_layers  # noqa: E402
+
+_register_migrate_layers(agent_group)
 
 # `declare-a2a-host` — one-shot fleet sweep making every spec state its own
 # a2a bind address instead of inheriting one from a code default. Sits beside

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -95,6 +95,16 @@ _KNOWN_SPEC_KEYS = frozenset(
         "apptainer",  # F-CS18 — apptainer-specific build extension
         "user",  # container user: "host" | "uid:gid" | "" (image default)
         "to_home",  # ADR-0006 — directory mirrored into container $HOME
+        # ADR-0006/0018 — WHICH to_home cascade layers this agent inherits.
+        # `_types`/`_loaders` gained the field but this allowlist did not, so
+        # every spec declaring it failed to load with "Unknown spec field" —
+        # which made the whole declaration mechanism unreachable, and would
+        # have made the fleet-wide migration sweep write 101 specs that then
+        # could not be parsed. OPTIONAL, deliberately: it is absent from the
+        # explicit-required map in `_explicit_fields`, so a spec that omits it
+        # still loads and still inherits the implicit cascade. Turning that
+        # omission into an error is a separate, later step.
+        "to_home_layers",
         "comms",  # Phase-3 ACL: outbound/inbound + a2a listen toggle
         "lineage",  # Phase-3 ACL: group=solitary + may_spawn
         # v3 removed (rejected explicitly below with relocation hints):

--- a/tests/scitex_agent_container/_maintenance/test__layers_migration_gate.py
+++ b/tests/scitex_agent_container/_maintenance/test__layers_migration_gate.py
@@ -1,0 +1,231 @@
+"""The arming gate: may the ``to_home_layers`` sweep stand?
+
+The tests that matter most here are the ones about NOT passing. A gate is only
+worth having if it fails when it should, and the two ways this one could fail
+open are both cheap to write and easy to leave untested:
+
+* comparing an EMPTY population against an empty population, which the
+  underlying ``diff_hook_arming`` reports as ``safe`` by design, and
+* an agent that could not be measured being quietly dropped so the remaining
+  agents compare clean.
+
+STX-NM002: no mocks — real snapshot values and real spec files under tmp_path.
+STX-TQ002 / TQ007: AAA markers per test, one fact per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._maintenance._layers_migration_gate import (
+    ArmingSnapshot,
+    fleet_arming_snapshot,
+    gate_arming,
+)
+
+_ARMED = {"PreToolUse": {"guard.sh": "user-shared"}}
+_ALSO_ARMED = {"PreToolUse": {"other.sh": "per-agent"}}
+
+
+def _snapshot(**agents) -> ArmingSnapshot:
+    return ArmingSnapshot(origins=dict(agents))
+
+
+# ---------------------------------------------------------------------------
+# The floor — the gate's whole reason to exist beyond the raw diff
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_comparison_is_never_safe() -> None:
+    # Arrange — `diff_hook_arming({}, {})` is `safe` on its own, deliberately.
+    # A collector that silently found nothing produces exactly this, so the
+    # gate's most likely failure mode must not read as its strongest pass.
+    empty = ArmingSnapshot()
+    # Act
+    verdict = gate_arming(empty, empty, expected=0)
+    # Assert
+    assert verdict.safe is False
+
+
+def test_an_empty_comparison_fails_the_floor() -> None:
+    # Arrange
+    empty = ArmingSnapshot()
+    # Act
+    verdict = gate_arming(empty, empty, expected=0)
+    # Assert
+    assert verdict.floor_met is False
+
+
+def test_a_comparison_short_of_the_population_is_not_safe() -> None:
+    # Arrange — one agent measured where the sweep touched two.
+    before = _snapshot(a=_ARMED)
+    after = _snapshot(a=_ARMED)
+    # Act
+    verdict = gate_arming(before, after, expected=2)
+    # Assert
+    assert verdict.safe is False
+
+
+def test_the_floor_failure_names_both_counts() -> None:
+    # Arrange — "not verified" is useless without "over how many".
+    before = _snapshot(a=_ARMED)
+    # Act
+    summary = gate_arming(before, _snapshot(a=_ARMED), expected=2).summary()
+    # Assert
+    assert "1 agent(s) compared, 2 expected" in summary
+
+
+def test_a_full_identical_comparison_is_safe() -> None:
+    # Arrange — the only shape that may proceed.
+    before = _snapshot(a=_ARMED, b=_ALSO_ARMED)
+    after = _snapshot(a=_ARMED, b=_ALSO_ARMED)
+    # Act
+    verdict = gate_arming(before, after, expected=2)
+    # Assert
+    assert verdict.safe is True
+
+
+def test_the_safe_summary_says_both_sides_were_measured() -> None:
+    # Arrange
+    before = _snapshot(a=_ARMED)
+    # Act
+    summary = gate_arming(before, _snapshot(a=_ARMED), expected=1).summary()
+    # Assert
+    assert "measured both sides" in summary
+
+
+# ---------------------------------------------------------------------------
+# Unmeasurable on either side blocks — an UNKNOWN must never pass
+# ---------------------------------------------------------------------------
+
+
+def test_an_unmeasurable_before_agent_blocks_the_sweep() -> None:
+    # Arrange — the agents we CAN see are identical; one we could not read.
+    before = ArmingSnapshot(origins={"a": _ARMED}, unmeasurable=("b: ValueError: x",))
+    after = _snapshot(a=_ARMED)
+    # Act
+    verdict = gate_arming(before, after, expected=1)
+    # Assert
+    assert verdict.safe is False
+
+
+def test_an_unmeasurable_after_agent_blocks_the_sweep() -> None:
+    # Arrange — measurable before, unreadable after: the migration broke it.
+    before = _snapshot(a=_ARMED)
+    after = ArmingSnapshot(origins={"a": _ARMED}, unmeasurable=("b: ValueError: x",))
+    # Act
+    verdict = gate_arming(before, after, expected=1)
+    # Assert
+    assert verdict.safe is False
+
+
+def test_an_unmeasurable_agent_is_named_in_the_summary() -> None:
+    # Arrange
+    before = ArmingSnapshot(origins={"a": _ARMED}, unmeasurable=("b: ValueError: x",))
+    # Act
+    summary = gate_arming(before, _snapshot(a=_ARMED), expected=1).summary()
+    # Assert
+    assert "UNMEASURABLE before" in summary
+
+
+# ---------------------------------------------------------------------------
+# The diff's own verdicts still count against the gate
+# ---------------------------------------------------------------------------
+
+
+def test_a_lost_hook_is_not_safe() -> None:
+    # Arrange — the dangerous direction: a guard stopped being armed.
+    before = _snapshot(a=_ARMED)
+    after = _snapshot(a={})
+    # Act
+    verdict = gate_arming(before, after, expected=1)
+    # Assert
+    assert verdict.safe is False
+
+
+def test_a_gained_hook_is_not_safe() -> None:
+    # Arrange — the promise verified is "identical", not "no worse".
+    before = _snapshot(a={})
+    after = _snapshot(a=_ARMED)
+    # Act
+    verdict = gate_arming(before, after, expected=1)
+    # Assert
+    assert verdict.safe is False
+
+
+def test_a_reattributed_hook_is_not_safe() -> None:
+    # Arrange — same command, different owning layer.
+    before = _snapshot(a={"PreToolUse": {"guard.sh": "user-shared"}})
+    after = _snapshot(a={"PreToolUse": {"guard.sh": "per-agent"}})
+    # Act
+    verdict = gate_arming(before, after, expected=1)
+    # Assert
+    assert verdict.safe is False
+
+
+def test_the_verdict_dict_carries_every_field_on_every_call() -> None:
+    # Arrange — a consumer must never have to guess which key exists today.
+    verdict = gate_arming(_snapshot(a=_ARMED), _snapshot(a=_ARMED), expected=1)
+    expected_keys = {
+        "safe",
+        "floor_met",
+        "expected",
+        "agents_compared",
+        "unchanged",
+        "lost",
+        "gained",
+        "reattributed",
+        "unmeasured",
+        "unexpected",
+        "before_unmeasurable",
+        "after_unmeasurable",
+        "summary",
+    }
+    # Act
+    payload = verdict.to_dict()
+    # Assert
+    assert set(payload) == expected_keys
+
+
+# ---------------------------------------------------------------------------
+# The collector — an agent it cannot read must not become "no hooks"
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def broken_spec(tmp_path: Path) -> Path:
+    # Arrange — a real file that real `load_config` really refuses.
+    agent_dir = tmp_path / "broken-agent"
+    agent_dir.mkdir()
+    spec = agent_dir / "spec.yaml"
+    spec.write_text("this: is not a valid agent spec\n")
+    yield spec
+
+
+def test_an_unmeasurable_spec_stays_out_of_the_origins_map(broken_spec: Path) -> None:
+    # Arrange — recording it as `{}` would compare EQUAL to another `{}` and
+    # be reported UNCHANGED, which is "I could not tell" read as "it is fine".
+    # Act
+    snapshot = fleet_arming_snapshot([broken_spec])
+    # Assert
+    assert snapshot.origins == {}
+
+
+def test_an_unmeasurable_spec_is_named_with_its_reason(broken_spec: Path) -> None:
+    # Arrange
+    # Act
+    snapshot = fleet_arming_snapshot([broken_spec])
+    # Assert
+    assert snapshot.unmeasurable[0].startswith("broken-agent: ")
+
+
+def test_an_unmeasurable_spec_leaves_the_measured_count_at_zero(
+    broken_spec: Path,
+) -> None:
+    # Arrange — `measured` is what the CLI compares against the population.
+    # Act
+    snapshot = fleet_arming_snapshot([broken_spec])
+    # Assert
+    assert snapshot.measured == 0

--- a/tests/scitex_agent_container/_maintenance/test__layers_migration_plan.py
+++ b/tests/scitex_agent_container/_maintenance/test__layers_migration_plan.py
@@ -1,0 +1,287 @@
+"""Planning the ``to_home_layers`` sweep over a real corpus of real spec files.
+
+The plan is what an operator reads before letting anything write to 100+
+hand-maintained files, so the properties under test are the ones that decide
+whether that reading is trustworthy:
+
+* the declaration written is the cascade the spec ALREADY resolves (the entire
+  zero-behaviour-change argument), and
+* the three not-written outcomes stay apart — a REFUSAL (a shape the editor
+  declines), an UNREADABLE spec (never reached the editor), and an
+  ALREADY-DECLARED spec (finished) mean completely different things, and
+  collapsing any two lets a sweep report "done" over specs it never touched.
+
+STX-NM002: no mocks — real spec files on disk, loaded by the real loader,
+resolved by the real resolver. The cascade roots are pinned to tmp_path via
+the two documented env seams so no test can read the operator's fleet.
+STX-TQ002 / TQ007: AAA markers per test, one fact per test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scitex_agent_container._maintenance._layers_migration_plan import (
+    already_declared,
+    plan_migration,
+    plan_spec,
+)
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
+
+_SETTINGS = {"hooks": {"PreToolUse": [{"hooks": [{"command": "guard.sh"}]}]}}
+
+
+def _write_settings(to_home: Path) -> None:
+    claude = to_home / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    (claude / "settings.json").write_text(json.dumps(_SETTINGS))
+
+
+def _write_spec(agents_dir: Path, name: str, *, flow: bool = False, **overrides):
+    """A real, loadable v3 spec with a real per-agent ``to_home/`` beside it.
+
+    ``flow`` dumps the document in FLOW style. That spec loads exactly like any
+    other, but no line in it BEGINS with ``to_home:``, so the line-anchored
+    editor has nothing to anchor to — a genuine refusal, reachable without
+    hand-crafting a file the loader would reject for some unrelated reason.
+    """
+    agent_dir = agents_dir / name
+    agent_dir.mkdir(parents=True)
+    _write_settings(agent_dir / "to_home")
+    doc = explicit_doc({"to_home": "./to_home", **overrides})
+    (agent_dir / "spec.yaml").write_text(
+        yaml.safe_dump(doc, sort_keys=False, default_flow_style=flow)
+    )
+    return agent_dir / "spec.yaml"
+
+
+@pytest.fixture
+def fleet(tmp_path: Path):
+    """A tmp fleet whose whole cascade is pinned inside tmp_path.
+
+    Both baselines are given DISTINCT directories on purpose: where they point
+    at the same place the resolver collapses one as a duplicate, which is what
+    happens on the live host and would hide any bug in the multi-layer path.
+    """
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    _write_settings(agents_dir / "_shared" / "to_home")
+    user_shared = tmp_path / "user-baseline" / "to_home"
+    _write_settings(user_shared)
+
+    keys = {
+        "SCITEX_AGENT_CONTAINER_AGENTS_DIR": str(agents_dir),
+        "SCITEX_AGENT_CONTAINER_RUNTIME_DIR": str(tmp_path / "runtime"),
+        "SAC_USER_TO_HOME_BASELINE": str(user_shared),
+        "SAC_SPEC_CACHE_DISABLE": "1",
+    }
+    saved = {k: os.environ.get(k) for k in keys}
+    os.environ.update(keys)
+    try:
+        yield agents_dir
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+# ---------------------------------------------------------------------------
+# The writable path — and what it writes
+# ---------------------------------------------------------------------------
+
+
+def test_a_normal_spec_is_planned_as_writable(fleet: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    edit = plan_spec(spec)
+    # Assert
+    assert edit.will_write is True
+
+
+def test_a_planned_edit_adds_exactly_one_line(fleet: Path) -> None:
+    # Arrange — anything else is a DEFECT in the editor, not a bigger success.
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    edit = plan_spec(spec)
+    # Assert
+    assert edit.lines_added == 1
+
+
+def test_the_declaration_names_the_layers_that_resolve_today(fleet: Path) -> None:
+    # Arrange — all three cascade layers exist and are distinct in this fixture.
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    edit = plan_spec(spec)
+    # Assert
+    assert edit.layers == ("user-shared", "project-shared", "per-agent")
+
+
+def test_a_spec_without_its_own_to_home_dir_omits_that_layer(fleet: Path) -> None:
+    # Arrange — a layer that contributes nothing must not be declared, or the
+    # spec would claim an inheritance the agent does not have.
+    agent_dir = fleet / "beta"
+    agent_dir.mkdir()
+    doc = explicit_doc({"to_home": "./to_home"})
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(yaml.safe_dump(doc, sort_keys=False))
+    # Act
+    edit = plan_spec(spec)
+    # Assert
+    assert "per-agent" not in edit.layers
+
+
+def test_the_new_text_contains_the_rendered_declaration(fleet: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    edit = plan_spec(spec)
+    # Assert
+    assert "to_home_layers: [user-shared, project-shared, per-agent]" in edit.new_text
+
+
+# ---------------------------------------------------------------------------
+# Refused — expected, named, and NOT a failure
+# ---------------------------------------------------------------------------
+
+
+def test_a_spec_with_no_anchor_line_is_refused(fleet: Path) -> None:
+    # Arrange — flow style: loads fine, but no line starts with `to_home:`.
+    spec = _write_spec(fleet, "flowed", flow=True)
+    # Act
+    edit = plan_spec(spec)
+    # Assert
+    assert edit.refusal is not None
+
+
+def test_a_refused_spec_is_not_written(fleet: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "flowed", flow=True)
+    # Act
+    edit = plan_spec(spec)
+    # Assert
+    assert edit.will_write is False
+
+
+def test_a_refusal_alone_leaves_the_plan_safe_to_apply(fleet: Path) -> None:
+    # Arrange — a named, counted refusal is a legitimate outcome a human
+    # resolves; it must not block the other 100 specs.
+    _write_spec(fleet, "alpha")
+    _write_spec(fleet, "flowed", flow=True)
+    # Act
+    plan = plan_migration(sorted(fleet.glob("*/spec.yaml")))
+    # Assert
+    assert plan.safe_to_apply is True
+
+
+# ---------------------------------------------------------------------------
+# Unreadable — a different thing from refused, and it DOES block
+# ---------------------------------------------------------------------------
+
+
+def test_an_unloadable_spec_is_reported_as_unreadable(fleet: Path) -> None:
+    # Arrange
+    agent_dir = fleet / "broken"
+    agent_dir.mkdir()
+    (agent_dir / "spec.yaml").write_text("this: is not an agent spec\n")
+    # Act
+    plan = plan_migration(sorted(fleet.glob("*/spec.yaml")))
+    # Assert
+    assert len(plan.unreadable) == 1
+
+
+def test_an_unreadable_spec_makes_the_plan_unsafe(fleet: Path) -> None:
+    # Arrange — a plan that cannot describe every spec does not describe the
+    # sweep, so it must not be applied.
+    _write_spec(fleet, "alpha")
+    broken = fleet / "broken"
+    broken.mkdir()
+    (broken / "spec.yaml").write_text("this: is not an agent spec\n")
+    # Act
+    plan = plan_migration(sorted(fleet.glob("*/spec.yaml")))
+    # Assert
+    assert plan.safe_to_apply is False
+
+
+def test_an_unreadable_spec_is_not_counted_as_refused(fleet: Path) -> None:
+    # Arrange — a refusal is the editor declining a shape it knows; this never
+    # reached the editor, and conflating them hides a real blocker.
+    broken = fleet / "broken"
+    broken.mkdir()
+    (broken / "spec.yaml").write_text("this: is not an agent spec\n")
+    # Act
+    plan = plan_migration(sorted(fleet.glob("*/spec.yaml")))
+    # Assert
+    assert plan.refused == ()
+
+
+def test_the_unreadable_reason_names_the_agent(fleet: Path) -> None:
+    # Arrange
+    broken = fleet / "broken"
+    broken.mkdir()
+    (broken / "spec.yaml").write_text("this: is not an agent spec\n")
+    # Act
+    plan = plan_migration(sorted(fleet.glob("*/spec.yaml")))
+    # Assert
+    assert plan.unreadable[0].startswith("broken: ")
+
+
+def test_the_unreadable_reason_survives_a_multiline_error(fleet: Path) -> None:
+    # Arrange — the validator puts "Config validation failed for <path>:" on
+    # line one and WHAT is wrong on the lines after, so a first-line-only
+    # reason reports that something is wrong while discarding what.
+    broken = fleet / "broken"
+    broken.mkdir()
+    (broken / "spec.yaml").write_text("this: is not an agent spec\n")
+    # Act
+    plan = plan_migration(sorted(fleet.glob("*/spec.yaml")))
+    # Assert
+    assert "Unknown top-level field 'this'" in plan.unreadable[0]
+
+
+# ---------------------------------------------------------------------------
+# Already declared — the third not-written outcome, and the one that is done
+# ---------------------------------------------------------------------------
+
+
+def test_an_already_declared_spec_is_not_written_again(fleet: Path) -> None:
+    # Arrange — re-running the sweep must not duplicate the key.
+    spec = _write_spec(fleet, "declared", to_home_layers=["user-shared"])
+    # Act
+    edit = plan_spec(spec)
+    # Assert
+    assert edit.will_write is False
+
+
+def test_an_already_declared_spec_is_not_a_refusal(fleet: Path) -> None:
+    # Arrange — a completed re-run must not read as a fleet needing attention.
+    spec = _write_spec(fleet, "declared", to_home_layers=["user-shared"])
+    # Act
+    edit = plan_spec(spec)
+    # Assert
+    assert edit.refusal is None
+
+
+def test_an_already_declared_spec_lands_in_its_own_bucket(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "declared", to_home_layers=["user-shared"])
+    # Act
+    plan = plan_migration(sorted(fleet.glob("*/spec.yaml")))
+    # Assert
+    assert [e.agent for e in already_declared(plan)] == ["declared"]
+
+
+def test_a_declared_spec_reports_only_the_layers_it_declared(fleet: Path) -> None:
+    # Arrange — the resolver honours the declaration, so the plan must too.
+    spec = _write_spec(fleet, "declared", to_home_layers=["user-shared"])
+    # Act
+    edit = plan_spec(spec)
+    # Assert
+    assert edit.layers == ("user-shared",)

--- a/tests/scitex_agent_container/cli_pkg/test__agents_migrate_layers.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agents_migrate_layers.py
@@ -1,0 +1,336 @@
+"""``sac agents migrate-layers`` — the CLI surface of the to_home_layers sweep.
+
+Real ``CliRunner`` against the real click command, over a real tmp fleet of
+real spec files. The whole cascade is pinned inside ``tmp_path`` through the
+documented env seams, so no test can read or rewrite the operator's live specs.
+
+What only the CLI owns, and what these pin:
+
+* **dry-run is the DEFAULT** — the single most important safety property of a
+  verb that edits 100+ hand-maintained files;
+* the exit-code contract, in particular that a named REFUSAL is NOT a failure
+  while a malformed or unreadable spec IS; and
+* that the sweep is behaviour-preserving in the only way that counts —
+  measured, by re-deriving what every agent arms after the write.
+
+STX-NM002: no mocks. STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from scitex_agent_container._maintenance._layers_migration_gate import (
+    fleet_arming_snapshot,
+)
+from scitex_agent_container.cli_pkg._agents_migrate_layers import migrate_layers
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
+
+_SETTINGS = {"hooks": {"PreToolUse": [{"hooks": [{"command": "guard.sh"}]}]}}
+
+
+def _write_settings(to_home: Path) -> None:
+    claude = to_home / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    (claude / "settings.json").write_text(json.dumps(_SETTINGS))
+
+
+def _write_spec(
+    agents_dir: Path, name: str, *, flow: bool = False, **overrides
+) -> Path:
+    agent_dir = agents_dir / name
+    agent_dir.mkdir(parents=True)
+    _write_settings(agent_dir / "to_home")
+    doc = explicit_doc({"to_home": "./to_home", **overrides})
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(yaml.safe_dump(doc, sort_keys=False, default_flow_style=flow))
+    return spec
+
+
+@pytest.fixture
+def fleet(tmp_path: Path):
+    """A tmp fleet with every cascade root pinned inside tmp_path."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    _write_settings(agents_dir / "_shared" / "to_home")
+    user_shared = tmp_path / "user-baseline" / "to_home"
+    _write_settings(user_shared)
+
+    keys = {
+        "SCITEX_AGENT_CONTAINER_AGENTS_DIR": str(agents_dir),
+        "SCITEX_AGENT_CONTAINER_RUNTIME_DIR": str(tmp_path / "runtime"),
+        "SAC_USER_TO_HOME_BASELINE": str(user_shared),
+        "SAC_SPEC_CACHE_DISABLE": "1",
+    }
+    saved = {k: os.environ.get(k) for k in keys}
+    os.environ.update(keys)
+    try:
+        yield agents_dir
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _run(*args) -> "object":
+    """Assert on ``result.stdout``, never ``result.output``.
+
+    ``Result.output`` is stdout and stderr COMBINED; the scheduled form of this
+    command is ``--json`` piped to a parser, where they were never merged. A
+    single log line on stderr would otherwise make ``json.loads`` fail on a
+    command that behaved perfectly.
+    """
+    return CliRunner().invoke(migrate_layers, list(args), catch_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# Dry-run is the DEFAULT
+# ---------------------------------------------------------------------------
+
+
+def test_the_default_invocation_writes_nothing(fleet: Path) -> None:
+    # Arrange — the single most important property of this verb.
+    spec = _write_spec(fleet, "alpha")
+    before = spec.read_text()
+    # Act
+    _run()
+    # Assert
+    assert spec.read_text() == before
+
+
+def test_the_default_invocation_reports_dry_run_mode(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    # Act
+    result = _run("--json")
+    # Assert
+    assert json.loads(result.stdout)["mode"] == "dry-run"
+
+
+def test_apply_and_dry_run_together_are_rejected(fleet: Path) -> None:
+    # Arrange — contradictory intent must never be silently resolved.
+    _write_spec(fleet, "alpha")
+    # Act
+    result = CliRunner().invoke(migrate_layers, ["--apply", "--dry-run"])
+    # Assert
+    assert "contradictory" in result.output
+
+
+def test_the_dry_run_counts_the_writable_specs(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    _write_spec(fleet, "beta")
+    # Act
+    result = _run("--json")
+    # Assert
+    assert json.loads(result.stdout)["writable"] == 2
+
+
+def test_the_dry_run_reports_the_resolved_layer_sets(fleet: Path) -> None:
+    # Arrange — the histogram is the line an operator actually reads.
+    _write_spec(fleet, "alpha")
+    # Act
+    payload = json.loads(_run("--json").stdout)
+    # Assert
+    assert payload["layer_sets"] == {"user-shared, project-shared, per-agent": 1}
+
+
+# ---------------------------------------------------------------------------
+# Exit codes — a REFUSAL is not a failure, a malformed spec is
+# ---------------------------------------------------------------------------
+
+
+def test_a_clean_plan_exits_zero(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    # Act
+    result = _run()
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_a_refusal_alone_still_exits_zero(fleet: Path) -> None:
+    # Arrange — "no anchor" is an expected outcome the report names, not a
+    # failure. Exiting non-zero on it teaches readers to ignore the code.
+    _write_spec(fleet, "alpha")
+    _write_spec(fleet, "flowed", flow=True)
+    # Act
+    result = _run()
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_a_refusal_is_named_in_the_report(fleet: Path) -> None:
+    # Arrange — never silent about a decision.
+    _write_spec(fleet, "flowed", flow=True)
+    # Act
+    payload = json.loads(_run("--json").stdout)
+    # Assert
+    assert payload["refused"][0]["agent"] == "flowed"
+
+
+def test_an_unreadable_spec_exits_non_zero(fleet: Path) -> None:
+    # Arrange
+    broken = fleet / "broken"
+    broken.mkdir()
+    (broken / "spec.yaml").write_text("this: is not an agent spec\n")
+    # Act
+    result = _run()
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_an_apply_refusal_does_not_overwrite_the_refused_list(fleet: Path) -> None:
+    # Arrange — `refused` is the per-spec list the EDITOR declined; the
+    # apply-level refusal is a sentence. One key meaning both would let a
+    # consumer read "the sweep refused nothing" straight off a refusal.
+    _write_spec(fleet, "flowed", flow=True)
+    broken = fleet / "broken"
+    broken.mkdir()
+    (broken / "spec.yaml").write_text("this: is not an agent spec\n")
+    # Act
+    payload = json.loads(_run("--apply", "--json").stdout)
+    # Assert
+    assert payload["refused"][0]["agent"] == "flowed"
+
+
+def test_an_unreadable_spec_refuses_the_apply(fleet: Path) -> None:
+    # Arrange — a plan that cannot describe every spec must write nothing.
+    spec = _write_spec(fleet, "alpha")
+    broken = fleet / "broken"
+    broken.mkdir()
+    (broken / "spec.yaml").write_text("this: is not an agent spec\n")
+    before = spec.read_text()
+    # Act
+    _run("--apply")
+    # Assert
+    assert spec.read_text() == before
+
+
+# ---------------------------------------------------------------------------
+# Apply — and the measurement that lets it stand
+# ---------------------------------------------------------------------------
+
+
+def test_the_apply_writes_the_declaration(fleet: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    # Act
+    _run("--apply")
+    # Assert
+    assert "to_home_layers:" in spec.read_text()
+
+
+def test_the_apply_exits_zero_when_verified(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    # Act
+    result = _run("--apply")
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_the_apply_adds_exactly_one_line_per_spec(fleet: Path) -> None:
+    # Arrange
+    spec = _write_spec(fleet, "alpha")
+    before = len(spec.read_text().splitlines())
+    # Act
+    _run("--apply")
+    # Assert
+    assert len(spec.read_text().splitlines()) == before + 1
+
+
+def test_the_apply_leaves_hook_arming_unchanged(fleet: Path) -> None:
+    # Arrange — requirement 6, MEASURED rather than argued: the sweep must not
+    # alter what any agent inherits. Re-derived from the specs, not read back
+    # from a manifest that no deploy has written.
+    spec = _write_spec(fleet, "alpha")
+    before = fleet_arming_snapshot([spec]).origins
+    # Act
+    _run("--apply")
+    # Assert
+    assert fleet_arming_snapshot([spec]).origins == before
+
+
+def test_the_verified_apply_reports_a_met_floor(fleet: Path) -> None:
+    # Arrange — `safe` on the diff alone would pass over an empty population.
+    _write_spec(fleet, "alpha")
+    _write_spec(fleet, "beta")
+    # Act
+    payload = json.loads(_run("--apply", "--json").stdout)
+    # Assert
+    assert payload["gate"]["floor_met"] is True
+
+
+def test_the_gate_compares_the_whole_population(fleet: Path) -> None:
+    # Arrange — a refused spec is still measured: it was not written, and
+    # proving that is exactly what the comparison is for.
+    _write_spec(fleet, "alpha")
+    _write_spec(fleet, "flowed", flow=True)
+    # Act
+    payload = json.loads(_run("--apply", "--json").stdout)
+    # Assert
+    assert payload["gate"]["agents_compared"] == 2
+
+
+def test_a_second_apply_writes_nothing_more(fleet: Path) -> None:
+    # Arrange — idempotent: a completed sweep re-run must not duplicate a key.
+    spec = _write_spec(fleet, "alpha")
+    _run("--apply")
+    after_first = spec.read_text()
+    # Act
+    _run("--apply")
+    # Assert
+    assert spec.read_text() == after_first
+
+
+def test_a_completed_sweep_re_run_exits_zero(fleet: Path) -> None:
+    # Arrange
+    _write_spec(fleet, "alpha")
+    _run("--apply")
+    # Act
+    result = _run("--apply")
+    # Assert
+    assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Registration — the verb has to actually be reachable
+# ---------------------------------------------------------------------------
+
+
+def test_the_verb_resolves_through_the_main_lazy_registry() -> None:
+    # Arrange — `agents` is `_main.py`'s lazy entry; a leaf that never resolves
+    # through it half-exists, which is the failure the three-touch-point
+    # registry is prone to.
+    from click import Context
+
+    from scitex_agent_container.cli_pkg._main import main
+
+    # Act
+    with Context(main) as ctx:
+        group = main.get_command(ctx, "agents")
+        with Context(group) as sub:
+            command = group.get_command(sub, "migrate-layers")
+    # Assert
+    assert command is not None
+
+
+def test_the_verb_is_listed_under_maintenance() -> None:
+    # Arrange — a command absent from the categories renders in no help
+    # section, so it exists but cannot be found.
+    from scitex_agent_container.cli_pkg.agent_group import _AgentsGroup
+
+    categories = dict(_AgentsGroup.COMMAND_CATEGORIES)
+    # Act
+    maintenance = categories["Maintenance"]
+    # Assert
+    assert "migrate-layers" in maintenance

--- a/tests/scitex_agent_container/config/test__validation.py
+++ b/tests/scitex_agent_container/config/test__validation.py
@@ -1153,3 +1153,47 @@ def test_labels_groups_only_is_accepted():
     errors = validate_raw(raw, path="<test>")
     # Assert
     assert not [e for e in errors if "metadata.labels" in e]
+
+
+# ---------------------------------------------------------------------------
+# spec.to_home_layers — the field must be PERMITTED, and must stay OPTIONAL
+# ---------------------------------------------------------------------------
+#
+# ``config._types`` / ``config._loaders`` gained ``to_home_layers``, but
+# ``_KNOWN_SPEC_KEYS`` did not — so every spec that declared it failed to load
+# with "Unknown spec field 'to_home_layers'". That made the whole declaration
+# mechanism unreachable, and would have had the fleet-wide migration sweep
+# write the key into ~101 specs that could then no longer be parsed at all.
+
+
+def _layers_spec(spec_extra: dict) -> dict:
+    return {**_BASE, "spec": {**_BASE["spec"], **spec_extra}}
+
+
+def test_to_home_layers_is_an_accepted_spec_field():
+    # Arrange — a spec declaring the cascade it inherits.
+    raw = _layers_spec({"to_home_layers": ["user-shared", "per-agent"]})
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert not [e for e in errors if "to_home_layers" in e]
+
+
+def test_a_misspelt_layers_field_is_still_rejected():
+    # Arrange — CONTROL: the acceptance above must not come from the
+    # unknown-field check having stopped rejecting anything.
+    raw = _layers_spec({"to_home_layerz": ["user-shared"]})
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "to_home_layerz" in e]
+
+
+def test_omitting_to_home_layers_is_not_an_error():
+    # Arrange — it stays OPTIONAL: an undeclared spec still loads and still
+    # inherits the implicit cascade. Requiring it is a separate, later step.
+    raw = _layers_spec({})
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert not [e for e in errors if "to_home_layers" in e]


### PR DESCRIPTION
Steps 2 and 3 of the `to_home_layers` migration. **Step 4 (warning → refusal) is deliberately NOT in this PR.**

## What was actually missing

`_layers_migration_model` defined a `MigrationPlan` and `_layers_migration_apply` consumed one, but **nothing ever built one** — the model's own docstring names a `plan_migration` that did not exist. Likewise `_hook_arming_diff` shipped with nothing feeding it and nothing reading it. Production callers of the four non-manifest modules from #916–#919: **zero**. This wires both ends and puts a verb on top.

## The verb

`sac agents migrate-layers` — **dry-run by DEFAULT**, `--apply` to write, `--json` for a machine, `-v` to list every spec.

It lives on the existing `agents` noun group under **Maintenance** (beside `prune-claude` / `refresh-acl`) and reaches the CLI through `_main.py`'s existing lazy `agents` entry, so `_main.py` itself needs no edit — a new top-level noun for a command that becomes a no-op the day it succeeds would cost more than it buys. A test resolves the verb *through* `_main.py`'s lazy registry rather than off the group directly, because a leaf that never resolves that way half-exists.

## The gate

Declaring the cascade an agent already resolves cannot change what it inherits. That is an argument, not a measurement. So `--apply` derives what every agent **arms** before writing, re-derives it after, and restores every original unless the two are identical over the whole population.

Two holes the raw diff could not close on its own, both now closed:

- **There was no fleet snapshot collector at all.** `fleet_arming_snapshot` **derives** arming from the specs rather than reading `hook-origins.json` off disk. Zero manifests exist on this host — none of the 102 agents has redeployed since #914 landed — so a disk-reading gate would compare nothing against nothing.
- **`diff_hook_arming({}, {})` is `safe` by design** (0 compared, nothing moved), which is exactly what a collector that silently found nothing produces. `ArmingGateVerdict` adds a **floor**: the comparison must cover the population the plan touched, and that count must not be zero. An agent unmeasurable on *either* side blocks the sweep instead of being skipped — an UNKNOWN never passes.

## Fixes a latent fleet-wide breakage, found by running the sweep

`_types` and `_loaders` gained `to_home_layers` in #915, but `config._validation._KNOWN_SPEC_KEYS` did not. Any spec declaring the field failed to load with `Unknown spec field 'to_home_layers'`.

The declaration mechanism was therefore **unreachable**, and the sweep would have written the key into 101 specs that could then no longer be parsed at all. **The gate caught it**: every agent went unmeasurable after the write and the apply rolled back. The field is permitted here and stays **optional** (absent from the explicit-required map in `_explicit_fields`), so an undeclared spec still loads and still inherits the implicit cascade.

## Exit codes

| code | meaning |
|---|---|
| 0 | plan is sound (refusals included), or the apply was verified |
| 1 | a spec is MALFORMED or UNREADABLE — the plan does not describe the sweep |
| 2 | the apply was refused or rolled back by the arming gate |

A named **refusal** ("no `to_home:` line to anchor to") is *not* a failure. Exiting non-zero on it would train readers to ignore the exit code of a command whose whole job is to be trusted about what it did.

## Dry-run over the live fleet (nothing written)

```
$ sac agents migrate-layers
sac agents migrate-layers  dry-run (read-only)

102 spec(s) — 101 would gain a to_home_layers declaration

    65  [user-shared]
    36  [user-shared, per-agent]

UNREADABLE scitex-todo: ValueError: Config validation failed for
  .../agents/scitex-todo/spec.yaml: - spec is missing 68 required field(s). …

101 spec(s) would be written; 1 unreadable

Nothing was written — this is a dry-run. To act:
    sac agents migrate-layers --apply
```
Exit 1. Every writable edit is exactly `lines_added == 1`. No spec resolves `project-shared` — the "three-layer cascade" is empirically two.

**Corpus is 102, not 107.** A raw `*/spec.yaml` glob returns 107; `fleet_spec_paths()` excludes 5 `_`-prefixed scaffolding dirs (`_shared`, `_template_*`). Reusing that enumerator rather than globbing means this sweep and `reconcile` cannot disagree about which agents exist.

**`scitex-todo` blocks the apply today**, and that is the intended behaviour: it is `unreadable`, not `refused`, so `safe_to_apply` is False and `--apply` writes nothing fleet-wide. That spec fails validation on 68 missing fields for reasons unrelated to this work. There is deliberately **no bypass flag** — a switch that turns off a safety gate is the thing the gate exists to prevent.

## Zero behaviour change, verified two ways

- `test_the_apply_leaves_hook_arming_unchanged` re-derives arming from the specs after a real `--apply` over a real tmp fleet and asserts it is identical.
- On the live fleet: 0 specs contain `to_home_layers` after all runs (positive control: `to_home:` is found in 106, so the search works).

## Negative control (mandatory)

Neutering `ArmingGateVerdict.safe` to `return self.diff.safe` alone **fails 4 tests**:

```
FAILED test_an_empty_comparison_is_never_safe
FAILED test_a_comparison_short_of_the_population_is_not_safe
FAILED test_an_unmeasurable_before_agent_blocks_the_sweep
FAILED test_an_unmeasurable_after_agent_blocks_the_sweep
```
Restored; the full gate is what is committed.

## Two defects found in my own output before commit

- The layer histogram rendered **blank** for all 101 rows: `[user-shared]` is valid rich markup and was being swallowed as a style tag. Every dynamic value now goes through `rich.markup.escape`.
- The apply-level refusal string reused the `refused` JSON key, which in dry-run is the per-spec list — one field meaning two things across modes. Renamed to `apply_refused`, with a test pinning the distinction.

## Tests

262 passed across the affected files. The one-line `_KNOWN_SPEC_KEYS` change is covered by three tests including a control that a *misspelt* `to_home_layerz` is still rejected, so the acceptance cannot pass by the unknown-field check having stopped rejecting anything.
