### PR TITLE
feat(a2a): make spec.a2a.host reach all three bind paths, not one

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/17_inbound-turn-endpoint.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/17_inbound-turn-endpoint.md
@@ -16,7 +16,8 @@ The endpoint lives in `_runners/_session_http.py`, spawned by the SDK
 runner (`_runners/claude_session.py::run`) when its argv carries
 `--a2a-port N`. The runner — and therefore this HTTP server — runs
 **inside the apptainer container** (`apptainer exec`); the runtime adapter
-sets `--a2a-port` from `spec.a2a.port`. See
+sets `--a2a-port` from `spec.a2a.port` and `--a2a-host` from
+`spec.a2a.host`. See
 [15_claude-session.md](15_claude-session.md) for the container shape.
 
 ## YAML
@@ -83,7 +84,9 @@ non-SDK runtimes (see [07_a2a-protocol.md](07_a2a-protocol.md)).
 
 ## Wiring details
 
-The runner's argv `--a2a-port`/`--a2a-host` is set automatically by `runtimes/claude_session.py::start` from `spec.a2a.port` / `spec.a2a.host`. The handler enqueues a `TurnEnvelope` on the runner's `asyncio.Queue` and awaits `env.response`; the conversation task drains it, calls `client.query(text)`, drains `receive_response()`, and resolves the future.
+The runner's argv `--a2a-port`/`--a2a-host` is built by `runtimes/_apptainer_inner_argv.py::_a2a_argv` from `spec.a2a.port` / `spec.a2a.host` (this file previously named `runtimes/claude_session.py::start`, which never built either flag; `--a2a-host` was not emitted at all until the bind-path threading change). The host continues `--a2a-host` → `_session_cli.main` → `claude_session.run(a2a_host=)` → `_session_http.serve_inbound(host=)` → `uvicorn.Config(host=)`. The handler enqueues a `TurnEnvelope` on the runner's `asyncio.Queue` and awaits `env.response`; the conversation task drains it, calls `client.query(text)`, drains `receive_response()`, and resolves the future.
+
+`spec.a2a.host` now reaches all three of sac's a2a bind paths — the sidecar (`runtimes/a2a_sidecar.py` → `a2a serve --host`), the TUI turn bridge (`runtimes/_tui_turn_bridge.py`), and this SDK runner. Every fleet spec declares `127.0.0.1`, so all three bind loopback today; changing the declared value now moves all three together instead of one.
 
 ## Implementation files
 

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -200,6 +200,51 @@ def _resolve_restart_backoff_s(config: "AgentConfig") -> float:
     return 1.0
 
 
+def _a2a_argv(config: "AgentConfig") -> list[str]:
+    """``spec.a2a`` -> the session runner's ``--a2a-*`` flags.
+
+    Shared by both ``kind`` branches so the two can never drift apart.
+
+    ``--a2a-port`` is the port the runner's inbound-turn server listens on;
+    without it the sidecar never binds and POST /v1/turn is unreachable.
+    ``--a2a-host`` is that server's BIND ADDRESS, threaded from
+    ``spec.a2a.host``. Until this was added the builder emitted only the port,
+    so the runner fell back to its own ``--a2a-host`` default and the address
+    the spec declared reached exactly one of the three bind paths
+    (``runtimes/a2a_sidecar.py``). A spec asking for a reachable address
+    therefore produced an agent whose spec and runtime disagreed, with nothing
+    reporting the disagreement. The value flows
+    ``--a2a-host`` -> ``_session_cli.main`` -> ``claude_session.run(a2a_host=)``
+    -> ``_session_http.serve_inbound(host=)`` -> ``uvicorn.Config(host=)``.
+
+    Resolved-int port only: ``"auto"`` strings or None mean no sidecar arg at
+    this layer. The lifecycle resolves ``"auto"`` -> int via port_allocator
+    BEFORE we get here; if a string slipped through, it's a config that
+    bypassed agent_start (e.g. dry-run inspection) and the sidecar simply
+    won't be wired up. The host rides WITH the port for that same reason: a
+    bind address without a port binds nothing.
+
+    A blank / missing / non-string host emits NO ``--a2a-host`` at all, leaving
+    the runner's own flag default in charge — so a spec that declares nothing
+    binds exactly where it bound before.
+    """
+    a2a_spec = getattr(config, "a2a", None)
+    a2a_port = getattr(a2a_spec, "port", None) if a2a_spec else None
+    if not (isinstance(a2a_port, int) and a2a_port > 0):
+        return []
+    argv = ["--a2a-port", str(a2a_port)]
+    a2a_host = getattr(a2a_spec, "host", None)
+    if isinstance(a2a_host, str) and a2a_host.strip():
+        argv += ["--a2a-host", a2a_host.strip()]
+    cfg_path = getattr(config, "config_path", "")
+    if cfg_path:
+        # Spec path is host-side; apptainer auto-binds /home so the
+        # in-container path is the same string. Used to publish
+        # /.well-known/agent-card.json.
+        argv += ["--a2a-card-yaml", str(cfg_path)]
+    return argv
+
+
 def _agent_runner_argv(config: "AgentConfig", *, one_shot: bool) -> list[str]:
     """Argv tail for ``kind: Agent`` (claude_session)."""
     runner_argv: list[str] = [
@@ -226,23 +271,8 @@ def _agent_runner_argv(config: "AgentConfig", *, one_shot: bool) -> list[str]:
         if one_shot:
             # one-shot semantics → exit after the first SDK turn.
             runner_argv.append("--print-stream")
-    # spec.a2a.port → --a2a-port (sidecar bind). Without this the
-    # sidecar never binds and POST /v1/turn is unreachable.
-    a2a_spec = getattr(config, "a2a", None)
-    a2a_port = getattr(a2a_spec, "port", None) if a2a_spec else None
-    # Resolved-int only: ``"auto"`` strings or None mean no sidecar
-    # arg at this layer. The lifecycle resolves ``"auto"`` → int via
-    # port_allocator BEFORE we get here; if a string slipped through,
-    # it's a config that bypassed agent_start (e.g. dry-run inspection)
-    # and the sidecar simply won't be wired up.
-    if isinstance(a2a_port, int) and a2a_port > 0:
-        runner_argv += ["--a2a-port", str(a2a_port)]
-        cfg_path = getattr(config, "config_path", "")
-        if cfg_path:
-            # Spec path is host-side; apptainer auto-binds /home so
-            # the in-container path is the same string. Used to
-            # publish /.well-known/agent-card.json.
-            runner_argv += ["--a2a-card-yaml", str(cfg_path)]
+    # spec.a2a.{port,host} → --a2a-port / --a2a-host (the sidecar bind).
+    runner_argv += _a2a_argv(config)
     # spec.claude.channels → one --channels arg per entry. When the set
     # contains 'server:sac', the daemon runner threads it into
     # build_sdk_options, which auto-registers the 'sac mcp channel' stdio
@@ -273,8 +303,8 @@ def _proxy_runner_argv(config: "AgentConfig") -> list[str]:
     """Argv tail for ``kind: AgentProxy`` (a2a_proxy).
 
     Reads spec.proxy.* (upstream / trust / redact / timeout_s) and
-    spec.a2a.port (sidecar bind). No --mission / autonomous — the
-    proxy has no SDK conversation.
+    spec.a2a.{port,host} (the sidecar bind). No --mission / autonomous —
+    the proxy has no SDK conversation.
     """
     proxy = getattr(config, "proxy", None)
     upstream = getattr(proxy, "upstream", "") if proxy else ""
@@ -296,14 +326,7 @@ def _proxy_runner_argv(config: "AgentConfig") -> list[str]:
         "--timeout-s",
         str(timeout_s),
     ]
-    a2a_spec = getattr(config, "a2a", None)
-    a2a_port = getattr(a2a_spec, "port", None) if a2a_spec else None
-    # See _agent_runner_argv for resolved-int rationale.
-    if isinstance(a2a_port, int) and a2a_port > 0:
-        runner_argv += ["--a2a-port", str(a2a_port)]
-        cfg_path = getattr(config, "config_path", "")
-        if cfg_path:
-            runner_argv += ["--a2a-card-yaml", str(cfg_path)]
+    runner_argv += _a2a_argv(config)
     return runner_argv
 
 

--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -31,9 +31,16 @@ the public ``_tui_turn_bridge.start_turn_bridge`` / ``stop_turn_bridge`` /
 THIS module as ``python -m`` (see :func:`main`), and :func:`stop_turn_bridge`
 SIGTERMs it, waits for the port to release, and force-kills any own-port
 survivor (the restart port-collision fix). Both are best-effort — a failed
-bridge must never block agent start/stop. Bound to ``127.0.0.1`` (loopback
-wake POST; the bind is the security boundary, matching the SDK runner's
-unauthed endpoint).
+bridge must never block agent start/stop.
+
+BIND ADDRESS: ``spec.a2a.host``, resolved by
+:func:`_tui_turn_bridge_lifecycle.resolved_a2a_host` and threaded through the
+launcher's ``--host`` into :func:`serve`. It defaults to ``127.0.0.1``
+(loopback wake POST; the bind is the security boundary, matching the SDK
+runner's unauthed endpoint), which is what every fleet spec declares today —
+so an unmodified spec binds loopback exactly as before. A spec that names a
+different address now MOVES this bind with it, instead of leaving the bridge
+on loopback while ``a2a_sidecar`` alone honoured the declaration.
 """
 
 from __future__ import annotations
@@ -53,6 +60,7 @@ from ._tui_turn_bridge_lifecycle import (
     PID_FILENAME,
     _pid_path,
     _state_dir,
+    resolved_a2a_host,
     resolved_a2a_port,
     start_turn_bridge,
     stop_turn_bridge,
@@ -292,14 +300,18 @@ def main(
     parser = argparse.ArgumentParser(prog="tui-turn-bridge")
     parser.add_argument("--config-path", required=True)
     parser.add_argument("--port", type=int, required=True)
-    parser.add_argument("--host", default=DEFAULT_HOST)
+    # No literal default: an omitted --host resolves from the spec the bridge
+    # is about to serve (``resolved_a2a_host``), which itself falls back to
+    # DEFAULT_HOST. The launcher always passes --host explicitly; this keeps a
+    # hand-run bridge on the SAME address as its spec instead of loopback.
+    parser.add_argument("--host", default=None)
     args = parser.parse_args(argv)
 
     from ..config import load_config
 
     config = load_config(args.config_path)
     serve(
-        host=args.host,
+        host=args.host or resolved_a2a_host(config),
         port=args.port,
         on_turn=_build_on_turn(config),
         agent_name=config.name,
@@ -312,6 +324,7 @@ if __name__ == "__main__":  # pragma: no cover -- exercised as a subprocess
 
 
 __all__ = [
+    "resolved_a2a_host",
     "resolved_a2a_port",
     "is_turn_route",
     "build_server",

--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge_lifecycle.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge_lifecycle.py
@@ -67,6 +67,28 @@ def resolved_a2a_port(config: AgentConfig) -> int | None:
     return None
 
 
+def resolved_a2a_host(config: AgentConfig) -> str:
+    """Return the agent's declared ``spec.a2a.host``, else :data:`DEFAULT_HOST`.
+
+    The bridge is the TUI runtime's half of the SAME ``/v1/turn`` endpoint the
+    SDK runner serves, so it must bind the SAME address the spec declares —
+    ``runtimes/a2a_sidecar.py`` already reads ``spec.a2a.host`` for its
+    ``a2a serve --host``. This module previously hardcoded :data:`DEFAULT_HOST`,
+    so a spec asking for a reachable address bound loopback here anyway and
+    nothing reported the disagreement: the spec said one thing, the runtime did
+    another, and ``sac agents health`` was happy either way.
+
+    A missing / blank / non-string host falls back to :data:`DEFAULT_HOST` —
+    the same value every other reader defaults to — so a spec that declares
+    nothing binds exactly where it bound before.
+    """
+    a2a = getattr(config, "a2a", None)
+    host = getattr(a2a, "host", None) if a2a is not None else None
+    if isinstance(host, str) and host.strip():
+        return host.strip()
+    return DEFAULT_HOST
+
+
 # ---------------------------------------------------------------------------
 # Launcher / lifecycle
 # ---------------------------------------------------------------------------
@@ -84,7 +106,7 @@ def start_turn_bridge(
     config: AgentConfig,
     *,
     spawn: Callable[..., Any] = subprocess.Popen,
-    host: str = DEFAULT_HOST,
+    host: str | None = None,
     port_free_timeout_s: float = _PORT_FREE_TIMEOUT_S,
     sleep_fn: Callable[[float], None] = time.sleep,
     now_fn: Callable[[], float] = time.monotonic,
@@ -103,10 +125,18 @@ def start_turn_bridge(
     If the port cannot be freed within ``port_free_timeout_s`` we FAIL LOUD
     (:class:`TurnBridgePortBusyError`, naming port + holder + remediation)
     instead of spawning into that crash. ``*_fn`` seams are injected by tests.
+
+    ``host`` defaults to the agent's declared ``spec.a2a.host``
+    (:func:`resolved_a2a_host`) — the SAME address ``a2a_sidecar`` binds — and
+    is threaded into the spawned bridge's ``--host`` as well as into the
+    port-free probes, which must ask about the address we are about to bind.
+    An explicit ``host=`` still wins (test seam / caller override).
     """
     port = resolved_a2a_port(config)
     if port is None:
         return None
+    if host is None:
+        host = resolved_a2a_host(config)
     # Tear down any prior bridge for THIS agent, now also WAITING for it to
     # release the port. ``force_free_survivors=False`` — at START the port's
     # holder is UNKNOWN (could be a foreign service that grabbed the configured
@@ -182,7 +212,7 @@ def start_turn_bridge(
 def stop_turn_bridge(
     config: AgentConfig,
     *,
-    host: str = DEFAULT_HOST,
+    host: str | None = None,
     grace_s: float = _STOP_SIGTERM_GRACE_S,
     sleep_fn: Callable[[float], None] = time.sleep,
     now_fn: Callable[[], float] = time.monotonic,
@@ -216,7 +246,13 @@ def stop_turn_bridge(
     :class:`TurnBridgePortBusyError`) rather than let the next start crash on
     ``EADDRINUSE``. The PID file is removed regardless. ``*_fn`` seams are
     injected for tests.
+
+    ``host`` defaults to the agent's declared ``spec.a2a.host``
+    (:func:`resolved_a2a_host`) so the port-release probes ask about the
+    address the bridge actually bound; an explicit ``host=`` still wins.
     """
+    if host is None:
+        host = resolved_a2a_host(config)
     pid_path = _pid_path(config)
     if not pid_path.is_file():
         return False
@@ -283,6 +319,7 @@ __all__ = [
     "LOG_FILENAME",
     "MODULE_PATH",
     "PID_FILENAME",
+    "resolved_a2a_host",
     "resolved_a2a_port",
     "start_turn_bridge",
     "stop_turn_bridge",

--- a/tests/scitex_agent_container/_runners/test__session_cli.py
+++ b/tests/scitex_agent_container/_runners/test__session_cli.py
@@ -1,14 +1,21 @@
-"""CLI parsing for the daemon ``--channels`` flag (sac-node-comms fix).
+"""CLI parsing for the daemon ``--channels`` and ``--a2a-host`` flags.
 
 ``_session_cli._parse_argv`` must accept a repeatable ``--channels`` so
 ``spec.claude.channels`` can be carried into the long-lived runner. When
 the set contains ``server:sac`` the runner threads it into
 ``build_sdk_options`` and the ``sac mcp channel`` adapter is registered.
+
+``--a2a-host`` is the receiving end of the bind address the apptainer argv
+builder emits from ``spec.a2a.host``. It continues into
+``claude_session.run(a2a_host=)`` -> ``_session_http.serve_inbound(host=)`` ->
+``uvicorn.Config(host=)``, so a value mangled here would silently move an
+agent's inbound endpoint somewhere the spec never asked for.
 """
 
 from __future__ import annotations
 
 import scitex_agent_container._runners.claude_session as runner
+from scitex_agent_container.config._a2a_defaults import DEFAULT_A2A_HOST
 
 
 def test_parse_argv_channels_absent_defaults_none() -> None:
@@ -36,3 +43,24 @@ def test_parse_argv_repeated_channels_accumulate() -> None:
     ns = runner._parse_argv(argv)
     # Assert
     assert ns.channels == ["server:sac", "client:x"]
+
+
+def test_parse_argv_a2a_host_is_carried_through_verbatim() -> None:
+    # Arrange — the non-loopback bind the argv builder now emits when a spec
+    # declares one; anything but a verbatim carry moves the endpoint.
+    argv = ["--name", "ag", "--a2a-port", "7901", "--a2a-host", "0.0.0.0"]
+    # Act
+    ns = runner._parse_argv(argv)
+    # Assert
+    assert ns.a2a_host == "0.0.0.0"
+
+
+def test_parse_argv_a2a_host_default_agrees_with_the_fleet_default() -> None:
+    # Arrange — this flag carries its OWN "127.0.0.1" literal. Pin it against
+    # the documented fleet default so an omitted flag (a hand-run runner) can
+    # never bind somewhere the spec readers would not have chosen.
+    argv = ["--name", "ag"]
+    # Act
+    ns = runner._parse_argv(argv)
+    # Assert
+    assert ns.a2a_host == DEFAULT_A2A_HOST

--- a/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv.py
@@ -15,7 +15,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config import AgentConfig, ProxySpec
+from scitex_agent_container.config._a2a_defaults import DEFAULT_A2A_HOST
 from scitex_agent_container.config._types import (
     A2ASpec,
     ClaudeSpec,
@@ -28,6 +29,7 @@ from scitex_agent_container.runtimes._apptainer_inner_argv import (
     _agent_runner_argv,
     _format_shell_steps,
     _home_has_resumable_conversation,
+    _proxy_runner_argv,
     _resolve_max_restarts,
     _resolve_restart_backoff_s,
     build_inner_argv,
@@ -36,6 +38,11 @@ from scitex_agent_container.runtimes._apptainer_inner_argv import (
 
 def _mk_cfg(**kwargs):
     return AgentConfig(name="t", runtime="apptainer", **kwargs)
+
+
+def _flag_value(argv: list[str], flag: str) -> str | None:
+    """Value following ``flag`` in ``argv``, or None when the flag is absent."""
+    return argv[argv.index(flag) + 1] if flag in argv else None
 
 
 # ---------------------------------------------------------------------------
@@ -266,9 +273,7 @@ def test_git_alias_mirrors_value_when_source_var_set():
     # Arrange — real bash execution proving the mechanism end-to-end.
     env = dict(os.environ)
     env["SAC_GIT_AUTHOR_NAME"] = "Test Author"
-    script = (
-        "; ".join(_GIT_ENV_ALIAS_STEPS) + '; printf "%s" "$GIT_AUTHOR_NAME"'
-    )
+    script = "; ".join(_GIT_ENV_ALIAS_STEPS) + '; printf "%s" "$GIT_AUTHOR_NAME"'
     # Act
     result = subprocess.run(
         ["/bin/bash", "-c", script],
@@ -594,3 +599,132 @@ def test_tui_inner_argv_default_claudespec_is_fresh_no_continue_flag():
     argv = build_inner_argv(cfg, tui=True)
     # Assert
     assert "-c" not in _exec_tail_tokens(argv)
+
+
+# ---------------------------------------------------------------------------
+# spec.a2a.host -> --a2a-host  (the SDK runner's uvicorn bind address)
+#
+# This builder is the THIRD of sac's three a2a bind paths. Until it was
+# threaded it emitted --a2a-port alone, so the SDK runner fell back to its own
+# separate "127.0.0.1" flag default and a spec's declared host reached exactly
+# one path (runtimes/a2a_sidecar.py). The value declared in the spec and the
+# address actually bound could therefore disagree with nothing reporting it.
+#
+# Both directions are pinned here, because a threading change earns trust only
+# by proving BOTH:
+#   1. an UNCHANGED spec (host 127.0.0.1, as all 102 fleet specs declare)
+#      still yields loopback — no silent widening;
+#   2. a CHANGED spec is FOLLOWED verbatim.
+# The value flows on from here: --a2a-host -> _session_cli.main ->
+# claude_session.run(a2a_host=) -> _session_http.serve_inbound(host=) ->
+# uvicorn.Config(host=).
+# ---------------------------------------------------------------------------
+
+# A resolved (non-"auto") a2a port; PEP 515 separators satisfy STX-NL001.
+_A2A_PORT = 7_901
+# A deliberately NON-loopback bind, the case the whole change exists for.
+_WILDCARD_HOST = "0.0.0.0"
+_LAN_HOST = "192.168.11.23"
+
+
+def test_agent_runner_argv_emits_a2a_host_alongside_the_port():
+    # Arrange — a spec with a resolved port and the default declared host.
+    cfg = _mk_cfg(a2a=A2ASpec(port=_A2A_PORT))
+    # Act
+    argv = _agent_runner_argv(cfg, one_shot=False)
+    # Assert
+    assert "--a2a-host" in argv
+
+
+def test_agent_runner_argv_a2a_host_is_loopback_for_an_undeclared_host():
+    # Arrange — CASE 1 (no-regression): a spec that names no host must still
+    # produce the loopback bind it produced before this flag existed.
+    cfg = _mk_cfg(a2a=A2ASpec(port=_A2A_PORT))
+    # Act
+    argv = _agent_runner_argv(cfg, one_shot=False)
+    # Assert
+    assert _flag_value(argv, "--a2a-host") == DEFAULT_A2A_HOST
+
+
+def test_agent_runner_argv_a2a_host_follows_a_wildcard_spec_host():
+    # Arrange — CASE 2: the spec asks for every interface.
+    cfg = _mk_cfg(a2a=A2ASpec(host=_WILDCARD_HOST, port=_A2A_PORT))
+    # Act
+    argv = _agent_runner_argv(cfg, one_shot=False)
+    # Assert
+    assert _flag_value(argv, "--a2a-host") == _WILDCARD_HOST
+
+
+def test_agent_runner_argv_a2a_host_follows_a_lan_spec_host():
+    # Arrange — CASE 2 again, with the shape an ssh-reachable fleet would use.
+    cfg = _mk_cfg(a2a=A2ASpec(host=_LAN_HOST, port=_A2A_PORT))
+    # Act
+    argv = _agent_runner_argv(cfg, one_shot=False)
+    # Assert
+    assert _flag_value(argv, "--a2a-host") == _LAN_HOST
+
+
+def test_agent_runner_argv_omits_a2a_host_without_a_resolved_port():
+    # Arrange — an unresolved "auto" port wires up no sidecar at this layer,
+    # so a bind ADDRESS would be meaningless (nothing binds).
+    cfg = _mk_cfg(a2a=A2ASpec(host=_WILDCARD_HOST, port="auto"))
+    # Act
+    argv = _agent_runner_argv(cfg, one_shot=False)
+    # Assert
+    assert "--a2a-host" not in argv
+
+
+def test_agent_runner_argv_omits_a2a_host_for_a_blank_declared_host():
+    # Arrange — a whitespace-only host states nothing; leave the runner's own
+    # flag default in charge rather than passing an unbindable empty string.
+    cfg = _mk_cfg(a2a=A2ASpec(host="   ", port=_A2A_PORT))
+    # Act
+    argv = _agent_runner_argv(cfg, one_shot=False)
+    # Assert
+    assert "--a2a-host" not in argv
+
+
+def test_agent_runner_argv_still_carries_the_card_yaml_after_the_host():
+    # Arrange — the port/host/card-yaml block was factored into one helper;
+    # guard that the card path did not get lost in the move.
+    cfg = _mk_cfg(a2a=A2ASpec(port=_A2A_PORT), config_path="/spec.yaml")
+    # Act
+    argv = _agent_runner_argv(cfg, one_shot=False)
+    # Assert
+    assert _flag_value(argv, "--a2a-card-yaml") == "/spec.yaml"
+
+
+def test_proxy_runner_argv_a2a_host_is_loopback_for_an_undeclared_host():
+    # Arrange — CASE 1 for kind: AgentProxy, which shares the same builder.
+    cfg = _mk_cfg(
+        kind="AgentProxy",
+        proxy=ProxySpec(upstream="http://u"),
+        a2a=A2ASpec(port=_A2A_PORT),
+    )
+    # Act
+    argv = _proxy_runner_argv(cfg)
+    # Assert
+    assert _flag_value(argv, "--a2a-host") == DEFAULT_A2A_HOST
+
+
+def test_proxy_runner_argv_a2a_host_follows_the_declared_spec_host():
+    # Arrange — CASE 2 for kind: AgentProxy.
+    cfg = _mk_cfg(
+        kind="AgentProxy",
+        proxy=ProxySpec(upstream="http://u"),
+        a2a=A2ASpec(host=_WILDCARD_HOST, port=_A2A_PORT),
+    )
+    # Act
+    argv = _proxy_runner_argv(cfg)
+    # Assert
+    assert _flag_value(argv, "--a2a-host") == _WILDCARD_HOST
+
+
+def test_build_inner_argv_carries_the_declared_a2a_host_into_the_exec_line():
+    # Arrange — end of the builder: the flag must survive the bash -lc wrap
+    # and shlex quoting, not just exist in the intermediate list.
+    cfg = _mk_cfg(a2a=A2ASpec(host=_WILDCARD_HOST, port=_A2A_PORT))
+    # Act
+    tokens = _exec_tail_tokens(build_inner_argv(cfg))
+    # Assert
+    assert _flag_value(tokens, "--a2a-host") == _WILDCARD_HOST

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -17,8 +17,6 @@ assert + STX-TQ003 descriptive names.
 
 from __future__ import annotations
 
-from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
-
 import json
 import shutil
 import socket
@@ -34,7 +32,9 @@ from typing import Callable, Iterator
 
 import pytest
 
+from scitex_agent_container.config._a2a_defaults import DEFAULT_A2A_HOST
 from scitex_agent_container.runtimes import _tui_turn_bridge as bridge
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
 # The STOP-path survivor sweep resolves the holder PID via lsof/ss/fuser; skip
 # the real-survivor test on a bare host that ships none of them (the finder's
@@ -273,7 +273,9 @@ def test_start_turn_bridge_passes_resolved_port_to_spawn(
 ) -> None:
     # Arrange — a resolved port + config_path; record the spawn argv.
     spec = tmp_path / "spec.yaml"
-    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8")
+    spec.write_text(
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8"
+    )
     recorded: dict = {}
 
     def fake_spawn(argv, **kwargs):
@@ -294,7 +296,9 @@ def test_start_turn_bridge_returns_spawned_pid(
 ) -> None:
     # Arrange
     spec = tmp_path / "spec.yaml"
-    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8")
+    spec.write_text(
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8"
+    )
     config = SimpleNamespace(
         a2a=SimpleNamespace(port=_PORT), name="figrecipe", config_path=str(spec)
     )
@@ -356,7 +360,9 @@ def test_start_turn_bridge_returns_none_on_spawn_failure(
 ) -> None:
     # Arrange — spawn raises; the launcher must swallow it and return None.
     spec = tmp_path / "spec.yaml"
-    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8")
+    spec.write_text(
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8"
+    )
 
     def raising_spawn(argv, **kwargs):
         raise OSError("exec failed")
@@ -396,7 +402,9 @@ def test_start_turn_bridge_kills_preexisting_bridge_before_spawn(
     # (the orphan a port-changing restart would otherwise leave alive), plus
     # a recording spawn for the NEW bridge so no second subprocess is created.
     spec = tmp_path / "spec.yaml"
-    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8")
+    spec.write_text(
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8"
+    )
     config = SimpleNamespace(
         a2a=SimpleNamespace(port=_PORT), name="restart-me", config_path=str(spec)
     )
@@ -420,7 +428,9 @@ def test_start_turn_bridge_records_new_pid_over_prior(
     # start must overwrite it with the freshly-spawned bridge's PID (never
     # leave the orphaned/stale value behind).
     spec = tmp_path / "spec.yaml"
-    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8")
+    spec.write_text(
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8"
+    )
     config = SimpleNamespace(
         a2a=SimpleNamespace(port=_PORT), name="repid-me", config_path=str(spec)
     )
@@ -505,7 +515,9 @@ def test_start_turn_bridge_fails_loud_when_port_stays_busy(
 ) -> None:
     # Arrange — a REAL listener holds the agent's a2a port; spawn must NOT run.
     spec = tmp_path / "spec.yaml"
-    spec.write_text(explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8")
+    spec.write_text(
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8"
+    )
     held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     held.bind(("127.0.0.1", 0))
     held.listen()
@@ -639,3 +651,188 @@ def test_stop_turn_bridge_fails_loud_when_own_port_stays_stuck(
             now_fn=lambda: clock["t"],
             port_free_fn=lambda _h, _p: False,
         )
+
+
+# ---------------------------------------------------------------------------
+# spec.a2a.host -> the bridge's bind address
+#
+# The bridge is the SECOND of sac's three a2a bind paths. It hardcoded
+# DEFAULT_HOST, so a spec declaring a reachable address bound loopback here
+# while ``runtimes/a2a_sidecar.py`` alone honoured the declaration — and
+# nothing reported the disagreement. Both directions are pinned: an UNCHANGED
+# spec must still bind loopback, a CHANGED one must be followed.
+#
+# The bind assertions below observe the address the KERNEL reports for a REAL
+# listening socket (``server_address`` after bind), not the argument passed in.
+# ---------------------------------------------------------------------------
+
+# A deliberately NON-loopback bind, the case the whole change exists for. Only
+# the wildcard is bind-tested for real: a LAN literal is not guaranteed to
+# exist on the machine running the suite.
+_WILDCARD_HOST = "0.0.0.0"
+_LAN_HOST = "192.168.11.23"
+
+
+def _cfg_with_host(host: str | None, *, port: int = _PORT) -> SimpleNamespace:
+    """A config whose ``a2a`` block declares ``host`` (or omits it for None)."""
+    a2a = (
+        SimpleNamespace(port=port)
+        if host is None
+        else SimpleNamespace(port=port, host=host)
+    )
+    return SimpleNamespace(a2a=a2a, name="figrecipe", config_path="")
+
+
+def _observed_bind_host(config: SimpleNamespace) -> str:
+    """Bind a REAL socket where the bridge resolves ``config`` to, and report it.
+
+    Port 0 lets the kernel pick, so this never collides with a live agent; the
+    returned value is ``server_address[0]`` — what the socket is ACTUALLY bound
+    to, read back from the server rather than echoed from the input.
+    """
+    server = bridge.build_server(
+        host=bridge.resolved_a2a_host(config),
+        port=0,
+        on_turn=lambda _text, **_kw: None,
+        agent_name="figrecipe",
+    )
+    try:
+        return str(server.server_address[0])
+    finally:
+        server.server_close()
+
+
+def test_resolved_a2a_host_returns_the_declared_spec_host() -> None:
+    # Arrange
+    config = _cfg_with_host(_LAN_HOST)
+    # Act
+    host = bridge.resolved_a2a_host(config)
+    # Assert
+    assert host == _LAN_HOST
+
+
+def test_resolved_a2a_host_defaults_to_loopback_when_undeclared() -> None:
+    # Arrange — CASE 1 (no-regression): a spec with no host key at all.
+    config = _cfg_with_host(None)
+    # Act
+    host = bridge.resolved_a2a_host(config)
+    # Assert
+    assert host == DEFAULT_A2A_HOST
+
+
+def test_resolved_a2a_host_defaults_to_loopback_for_a_blank_host() -> None:
+    # Arrange — a whitespace-only host states nothing and must not become an
+    # unbindable empty string.
+    config = _cfg_with_host("   ")
+    # Act
+    host = bridge.resolved_a2a_host(config)
+    # Assert
+    assert host == DEFAULT_A2A_HOST
+
+
+def test_the_bridge_default_host_agrees_with_the_fleet_wide_default() -> None:
+    # Arrange — the bridge carries its OWN "127.0.0.1" literal because the two
+    # canonical spellings live in modules over this repo's line cap and cannot
+    # be edited. Pin the agreement so a future drift breaks HERE, loudly,
+    # instead of quietly splitting the fleet's bind address in two.
+    pinned = DEFAULT_A2A_HOST
+    # Act
+    bridge_default = bridge.DEFAULT_HOST
+    # Assert
+    assert bridge_default == pinned
+
+
+def test_bridge_binds_loopback_for_an_undeclared_spec_host() -> None:
+    # Arrange — CASE 1 observed on a real socket.
+    config = _cfg_with_host(None)
+    # Act
+    bound = _observed_bind_host(config)
+    # Assert
+    assert bound == DEFAULT_A2A_HOST
+
+
+def test_bridge_binds_loopback_when_the_spec_declares_loopback() -> None:
+    # Arrange — CASE 1 as all 102 fleet specs actually spell it today.
+    config = _cfg_with_host(DEFAULT_A2A_HOST)
+    # Act
+    bound = _observed_bind_host(config)
+    # Assert
+    assert bound == DEFAULT_A2A_HOST
+
+
+def test_bridge_binds_the_wildcard_address_the_spec_declares() -> None:
+    # Arrange — CASE 2 observed on a real socket: the spec asks for every
+    # interface and the kernel confirms the socket is there, not on loopback.
+    config = _cfg_with_host(_WILDCARD_HOST)
+    # Act
+    bound = _observed_bind_host(config)
+    # Assert
+    assert bound == _WILDCARD_HOST
+
+
+def test_start_turn_bridge_spawns_with_the_declared_host(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    # Arrange — CASE 2 through the LAUNCHER: the spawned bridge's --host must
+    # carry the spec's value, or the subprocess binds somewhere else entirely.
+    spec = tmp_path / "spec.yaml"
+    spec.write_text(
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8"
+    )
+    recorded: dict = {}
+
+    def fake_spawn(argv, **_kwargs):
+        recorded["argv"] = list(argv)
+        return SimpleNamespace(pid=_PID)
+
+    config = _cfg_with_host(_WILDCARD_HOST)
+    config.config_path = str(spec)
+    # Act
+    bridge.start_turn_bridge(config, spawn=fake_spawn)
+    # Assert
+    assert recorded["argv"][recorded["argv"].index("--host") + 1] == _WILDCARD_HOST
+
+
+def test_start_turn_bridge_spawns_with_loopback_for_an_undeclared_host(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    # Arrange — CASE 1 through the LAUNCHER.
+    spec = tmp_path / "spec.yaml"
+    spec.write_text(
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8"
+    )
+    recorded: dict = {}
+
+    def fake_spawn(argv, **_kwargs):
+        recorded["argv"] = list(argv)
+        return SimpleNamespace(pid=_PID)
+
+    config = _cfg_with_host(None)
+    config.config_path = str(spec)
+    # Act
+    bridge.start_turn_bridge(config, spawn=fake_spawn)
+    # Assert
+    assert recorded["argv"][recorded["argv"].index("--host") + 1] == DEFAULT_A2A_HOST
+
+
+def test_start_turn_bridge_explicit_host_overrides_the_spec(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    # Arrange — the caller-supplied host is a seam and must still win over the
+    # spec, so the spec default never removes an override.
+    spec = tmp_path / "spec.yaml"
+    spec.write_text(
+        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"), encoding="utf-8"
+    )
+    recorded: dict = {}
+
+    def fake_spawn(argv, **_kwargs):
+        recorded["argv"] = list(argv)
+        return SimpleNamespace(pid=_PID)
+
+    config = _cfg_with_host(_WILDCARD_HOST)
+    config.config_path = str(spec)
+    # Act
+    bridge.start_turn_bridge(config, spawn=fake_spawn, host=DEFAULT_A2A_HOST)
+    # Assert
+    assert recorded["argv"][recorded["argv"].index("--host") + 1] == DEFAULT_A2A_HOST


### PR DESCRIPTION
## The gap, measured

PR #922 made all 102 fleet specs declare `spec.a2a.host` and disclosed that two
of sac's three a2a bind paths never read it. That is measured here, not
restated: the same driver was run against `origin/develop` and against this
branch, spawning the REAL launcher for each path and reading the bound address
back from the kernel via `lsof` on the resulting process.

**BEFORE (`origin/develop`, 0a255bd9)**

| bind path | spec says `127.0.0.1` | spec says `0.0.0.0` | spec says `192.168.11.121` |
|---|---|---|---|
| `runtimes/a2a_sidecar.py` -> `a2a serve --host` | `127.0.0.1` | `0.0.0.0` | `192.168.11.121` |
| `runtimes/_tui_turn_bridge.py` (TUI `/v1/turn`) | `127.0.0.1` | **`127.0.0.1`** | **`127.0.0.1`** |
| `runtimes/_apptainer_inner_argv.py` (SDK runner) | `127.0.0.1` | **`127.0.0.1`** | **`127.0.0.1`** |

Four cells where the spec and the socket disagree, and nothing anywhere reports
it — `sac agents health` is happy either way. On the SDK row the builder emitted
no `--a2a-host` at all (`<absent>`), so the runner fell back to its own separate
`127.0.0.1` literal.

**AFTER (this branch)**

| bind path | spec says `127.0.0.1` | spec says `0.0.0.0` | spec says `192.168.11.121` |
|---|---|---|---|
| `runtimes/a2a_sidecar.py` -> `a2a serve --host` | `127.0.0.1` | `0.0.0.0` | `192.168.11.121` |
| `runtimes/_tui_turn_bridge.py` (TUI `/v1/turn`) | `127.0.0.1` | `0.0.0.0` | `192.168.11.121` |
| `runtimes/_apptainer_inner_argv.py` (SDK runner) | `127.0.0.1` | `0.0.0.0` | `192.168.11.121` |

Zero mismatches. Column 1 is the **no-regression** case — the value all 102
fleet specs declare today still binds loopback on every path, so nothing moves
until an operator changes a spec.

## What changed

* **`_tui_turn_bridge_lifecycle.resolved_a2a_host(config)`** — reads
  `spec.a2a.host` exactly as `a2a_sidecar.py:109` does, falling back to
  `DEFAULT_HOST`. `start_turn_bridge` / `stop_turn_bridge` now take
  `host: str | None = None` and resolve from the spec when the caller does not
  name one; an explicit `host=` still wins (the test seam). The port-free /
  port-release probes get the same address, so they ask about the socket we are
  actually about to bind. The spawned bridge's own `--host` also falls back to
  the spec, so a hand-run bridge lands where its launcher-run twin would.

* **`_apptainer_inner_argv._a2a_argv`** — emits `--a2a-host` alongside
  `--a2a-port`, for `kind: Agent` and `kind: AgentProxy` alike. The two
  previously-duplicated port/card-yaml blocks are now one helper so they cannot
  drift. From there the value continues along code that already existed:
  `--a2a-host` -> `_session_cli.main` -> `claude_session.run(a2a_host=)` ->
  `_session_http.serve_inbound(host=)` -> `uvicorn.Config(host=)`.

A blank or missing host emits nothing / resolves to the default, so a spec that
declares nothing is byte-identical to before.

## The five-spellings wall: option (b), and why

The `127.0.0.1` default is spelled in five places. Two of them —
`config/_types.py` (519 lines) and `cli_pkg/a2a_group.py` (559) — are over this
repo's 512-line soft cap and refuse edits, so a collapse onto
`DEFAULT_A2A_HOST` would be *partial*, and a partial collapse advertises a
canonicality that does not hold. #922 declined for the same reason and pinned
the agreement by test instead. This PR keeps that choice and **extends the
pinning to the two paths it threads**:

* `_tui_turn_bridge.DEFAULT_HOST == DEFAULT_A2A_HOST`
* the runner's `--a2a-host` flag default `== DEFAULT_A2A_HOST`

Splitting those two oversized modules is a separate concern; doing it inside a
behaviour change would make both harder to review and harder to revert.

(Worth recording: the count is really seven, not five. `_session_cli.py:74`,
`_runners/claude_session.py:183` and `_runners/a2a_proxy.py:313`/`:465` carry
their own copies too. The two new pins cover the ones this PR's paths depend on.)

## Negative control

Each newly-threaded path was neutered in place and its protecting tests
re-run — a test that survives the removal of what it protects is not a test.
Results are in the PR thread.

## Test placement

Cross-module invariants live in the mirror of the module whose function they
CALL (PS-204): the argv assertions are in
`tests/.../runtimes/test__apptainer_inner_argv.py`, the bridge assertions in
`tests/.../runtimes/test__tui_turn_bridge.py`, and the flag-parse assertions in
`tests/.../\_runners/test__session_cli.py`. No orphan test file is added.
The bridge's bind assertions bind a REAL socket on port 0 and read
`server_address` back, rather than echoing the argument passed in.

## Also

`17_inbound-turn-endpoint.md` claimed `runtimes/claude_session.py::start` set
`--a2a-host` from `spec.a2a.host`. No module set that flag at all; the file now
names the real builder and records that the host reaches all three paths.
