### PR TITLE
fix(a2a): key the sidecar pid/log per agent, so one workdir stops meaning one sidecar

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/07_a2a-protocol.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/07_a2a-protocol.md
@@ -32,7 +32,9 @@ sac a2a doctor <agent.yaml>    [--host H] [--port N] [--timeout 5.0] [--json]
 
 ## Auto-launch via `spec.a2a`
 
-When a v3 YAML declares `spec.a2a.port`, `sac agents start` spawns the A2A server as a sidecar subprocess after the multiplexer is up. PID lives at `{workdir}/a2a-sidecar.pid`, output at `{workdir}/a2a-sidecar.log`; `sac agents stop` SIGTERMs it via the PID file.
+When a v3 YAML declares `spec.a2a.port`, `sac agents start` spawns the A2A server as a sidecar subprocess after the multiplexer is up. PID lives at `<runtime-root>/<agent>/a2a-sidecar.pid`, output at `<runtime-root>/<agent>/a2a-sidecar.log` — the agent's OWN runtime state dir, next to its `pid` / `heartbeat.json` / `session.jsonl`. `sac agents stop` SIGTERMs it via the PID file.
+
+Both files used to sit at `{workdir}/a2a-sidecar.*`, with no agent identity in the path: two agents sharing one workdir shared one PID file, and the second `start` logged "already running; skipping" and returned the FIRST agent's PID — looking healthy while having no sidecar of its own. Keying on the agent directory removes that collision by construction. A sidecar started before this change is still recorded at the legacy workdir path; `start` adopts it (and moves the record) and `stop` terminates it, but only when `/proc/<pid>/cmdline` confirms the process is serving THIS agent's spec — a co-tenant's sidecar is never touched.
 
 ```yaml
 apiVersion: scitex-agent-container/v3

--- a/src/scitex_agent_container/runtimes/a2a_sidecar.py
+++ b/src/scitex_agent_container/runtimes/a2a_sidecar.py
@@ -11,8 +11,9 @@ Lifecycle:
 
 * :func:`start_sidecar` — called from ``ClaudeCodeRuntime.start`` after
   the multiplexer is up. ``Popen``-spawns the server, captures stdout/
-  stderr to ``{workdir}/a2a-sidecar.log``, writes the PID to
-  ``{workdir}/a2a-sidecar.pid``. No-op if ``spec.a2a.port`` is unset.
+  stderr to ``<runtime>/<agent>/a2a-sidecar.log``, writes the PID to
+  ``<runtime>/<agent>/a2a-sidecar.pid``. No-op if ``spec.a2a.port`` is
+  unset.
 * :func:`stop_sidecar` — called from ``ClaudeCodeRuntime.stop`` (and
   ``cleanup``). Reads the PID file, sends SIGTERM, removes the file.
   No-op if the file is absent.
@@ -20,6 +21,30 @@ Lifecycle:
 Errors are logged and swallowed — a failed sidecar must NOT block
 agent start/stop. The PID file is the source of truth; if the file
 is gone the sidecar is considered stopped.
+
+**Per-agent keying.** The pid/log pair used to live at
+``{workdir}/a2a-sidecar.{pid,log}``, with NO agent identity in the
+path. Two agents sharing one workdir therefore shared one pid file,
+and the second :func:`start_sidecar` logged "already running;
+skipping" and handed back the *other* agent's PID — a silent
+false-positive: the second agent looked healthy while having no
+sidecar of its own and being undriveable over A2A. That is latent only
+while every agent owns its workdir; cloning / twinning / relocating
+breaks the assumption. The files now live in the agent's own runtime
+state dir (``state_dir_for_config`` — the same
+``<runtime-root>/<agent>/`` that already holds ``pid``,
+``heartbeat.json``, ``session.jsonl`` and ``runner.log``), so the
+identity is in the DIRECTORY, exactly like every other per-agent
+artefact. A config with no ``name`` REFUSES to resolve a path rather
+than falling back to a shared one.
+
+**Migrating a sidecar started before that change.** A live pre-keying
+sidecar is still recorded at ``{workdir}/a2a-sidecar.pid`` and still
+holds the port; ignoring it would make the next spawn fail to bind.
+Both entry points therefore consult the legacy path as well — but only
+adopt/kill a process the kernel confirms is *ours*
+(``/proc/<pid>/cmdline`` names THIS agent's spec file). A stranger's
+pre-keying sidecar is left strictly alone.
 """
 
 from __future__ import annotations
@@ -42,12 +67,46 @@ PID_FILENAME = "a2a-sidecar.pid"
 LOG_FILENAME = "a2a-sidecar.log"
 
 
+def _state_dir(config: AgentConfig) -> Path:
+    """Return the agent's own runtime state dir. REFUSES an unnamed agent.
+
+    Delegates to ``tui_session.state_dir_for_config`` — the SSOT both
+    host runtimes already use for per-agent files — so the sidecar's
+    pid/log land next to that agent's ``pid`` / ``heartbeat.json`` /
+    ``session.jsonl`` and relocate with ``$SCITEX_AGENT_CONTAINER_
+    RUNTIME_DIR`` like everything else under ``runtime/<agent>/``.
+
+    An empty ``config.name`` raises instead of degrading to a shared
+    path: a silent fallback here would reproduce the very collision
+    the per-agent keying exists to prevent. Both call sites already
+    log-and-continue around this module, so refusing costs at most the
+    sidecar, never the agent.
+    """
+    name = (getattr(config, "name", "") or "").strip()
+    if not name:
+        raise ValueError(
+            "a2a sidecar: refusing to resolve a pid/log path for an agent "
+            "with an empty name — an unnamed agent would silently share one "
+            "sidecar with every other unnamed agent"
+        )
+    # Imported lazily: ``tui_session`` pulls the runner package in, and
+    # ``_runners._tmux.claude_code`` imports THIS module at module scope.
+    from .tui_session import state_dir_for_config
+
+    return state_dir_for_config(config)
+
+
 def _pid_path(config: AgentConfig) -> Path:
-    return Path(config.expanded_workdir) / PID_FILENAME
+    return _state_dir(config) / PID_FILENAME
 
 
 def _log_path(config: AgentConfig) -> Path:
-    return Path(config.expanded_workdir) / LOG_FILENAME
+    return _state_dir(config) / LOG_FILENAME
+
+
+def _legacy_pid_path(config: AgentConfig) -> Path:
+    """The PRE-KEYING, workdir-shared pid path. Read-only compatibility."""
+    return Path(config.expanded_workdir) / PID_FILENAME
 
 
 def _read_a2a_block(config: AgentConfig) -> dict[str, Any] | None:
@@ -59,7 +118,10 @@ def _read_a2a_block(config: AgentConfig) -> dict[str, Any] | None:
         return None
     try:
         v3 = yaml.safe_load(yaml_path.read_text()) or {}
-    except (OSError, yaml.YAMLError) as exc:  # stx-allow: fallback (reason: file system operation failure)
+    except (
+        OSError,
+        yaml.YAMLError,
+    ) as exc:  # stx-allow: fallback (reason: file system operation failure)
         log.warning("a2a sidecar: cannot parse %s: %s", yaml_path, exc)
         return None
     spec = v3.get("spec") or {}
@@ -74,11 +136,84 @@ def _read_a2a_block(config: AgentConfig) -> dict[str, Any] | None:
 def _process_alive(pid: int) -> bool:
     try:
         os.kill(pid, 0)
-    except (ProcessLookupError, PermissionError):  # stx-allow: fallback (reason: process probe expected failure)
+    except (
+        ProcessLookupError,
+        PermissionError,
+    ):  # stx-allow: fallback (reason: process probe expected failure)
         return False
     except OSError:  # stx-allow: fallback (reason: file system operation failure)
         return False
     return True
+
+
+def _proc_argv(pid: int) -> list[str]:
+    """The kernel's own record of ``pid``'s argv, or ``[]`` if unreadable."""
+    try:
+        raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+    except OSError:  # stx-allow: fallback (reason: file system operation failure)
+        return []
+    return [part for part in raw.decode("utf-8", "replace").split("\0") if part]
+
+
+def _legacy_sidecar_pid(config: AgentConfig) -> int | None:
+    """PID recorded at the legacy workdir path, iff that process is OURS.
+
+    Ownership is settled by the kernel, not by the file: a sidecar is
+    spawned as ``... a2a serve <config_path> ...``, and two agents
+    sharing a workdir necessarily have DISTINCT spec files, so the
+    config path in ``/proc/<pid>/cmdline`` names the owner without
+    ambiguity. Returns None when the file is absent, unparseable, names
+    a dead process, or names a process belonging to a different agent —
+    a stranger's sidecar is never adopted and never killed.
+    """
+    legacy = _legacy_pid_path(config)
+    if not legacy.exists():
+        return None
+    try:
+        pid = int(legacy.read_text().strip())
+    except (
+        OSError,
+        ValueError,
+    ):  # stx-allow: fallback (reason: file system operation failure)
+        return None
+    if pid <= 0 or not _process_alive(pid):
+        return None
+    if str(config.config_path) not in _proc_argv(pid):
+        return None
+    return pid
+
+
+def _adopt_legacy_sidecar(config: AgentConfig, pid_path: Path) -> int | None:
+    """Move a live pre-keying sidecar's record to the per-agent path.
+
+    Adoption rather than a kill+respawn: the process is already serving
+    this agent's port, so re-pointing the bookkeeping costs no downtime
+    and no port churn. Returns the adopted PID, or None when there is
+    no legacy sidecar of ours to adopt.
+    """
+    pid = _legacy_sidecar_pid(config)
+    if pid is None:
+        return None
+    try:
+        pid_path.parent.mkdir(parents=True, exist_ok=True)
+        pid_path.write_text(str(pid))
+    except (
+        OSError
+    ) as exc:  # stx-allow: fallback (reason: file system operation failure)
+        log.warning("a2a sidecar: cannot write PID file %s: %s", pid_path, exc)
+        return pid
+    try:
+        _legacy_pid_path(config).unlink()
+    except OSError:  # stx-allow: fallback (reason: file system operation failure)
+        pass
+    log.info(
+        "a2a sidecar for %s adopted from legacy %s (pid=%d); record now at %s",
+        config.name,
+        _legacy_pid_path(config),
+        pid,
+        pid_path,
+    )
+    return pid
 
 
 def start_sidecar(config: AgentConfig) -> int | None:
@@ -91,7 +226,10 @@ def start_sidecar(config: AgentConfig) -> int | None:
     if pid_path.exists():
         try:
             existing = int(pid_path.read_text().strip())
-        except (OSError, ValueError):  # stx-allow: fallback (reason: file system operation failure)
+        except (
+            OSError,
+            ValueError,
+        ):  # stx-allow: fallback (reason: file system operation failure)
             existing = -1
         if existing > 0 and _process_alive(existing):
             log.info(
@@ -105,6 +243,13 @@ def start_sidecar(config: AgentConfig) -> int | None:
         except OSError:  # stx-allow: fallback (reason: file system operation failure)
             pass
 
+    # First start after the per-agent keying landed: our own sidecar may
+    # still be recorded at the legacy workdir path and still holding the
+    # port. Adopt it instead of spawning a second one that cannot bind.
+    adopted = _adopt_legacy_sidecar(config, pid_path)
+    if adopted is not None:
+        return adopted
+
     port = int(a2a["port"])
     host = str(a2a.get("host", "127.0.0.1"))
     handler = str(a2a.get("handler", "echo"))
@@ -112,6 +257,7 @@ def start_sidecar(config: AgentConfig) -> int | None:
     workdir = Path(config.expanded_workdir)
     workdir.mkdir(parents=True, exist_ok=True)
     log_path = _log_path(config)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
 
     cmd = [
         sys.executable,
@@ -132,7 +278,9 @@ def start_sidecar(config: AgentConfig) -> int | None:
     log_fp = None
     try:
         log_fp = log_path.open("ab")
-    except OSError as exc:  # stx-allow: fallback (reason: file system operation failure)
+    except (
+        OSError
+    ) as exc:  # stx-allow: fallback (reason: file system operation failure)
         log.warning("a2a sidecar: cannot open log %s: %s", log_path, exc)
 
     stdout_target = log_fp if log_fp is not None else subprocess.DEVNULL
@@ -146,7 +294,9 @@ def start_sidecar(config: AgentConfig) -> int | None:
             stderr=subprocess.STDOUT,
             start_new_session=True,
         )
-    except OSError as exc:  # stx-allow: fallback (reason: file system operation failure)
+    except (
+        OSError
+    ) as exc:  # stx-allow: fallback (reason: file system operation failure)
         log.warning("a2a sidecar: spawn failed for %s: %s", config.name, exc)
         if log_fp is not None:
             log_fp.close()
@@ -157,7 +307,9 @@ def start_sidecar(config: AgentConfig) -> int | None:
 
     try:
         pid_path.write_text(str(proc.pid))
-    except OSError as exc:  # stx-allow: fallback (reason: file system operation failure)
+    except (
+        OSError
+    ) as exc:  # stx-allow: fallback (reason: file system operation failure)
         log.warning("a2a sidecar: cannot write PID file %s: %s", pid_path, exc)
 
     log.info(
@@ -172,30 +324,13 @@ def start_sidecar(config: AgentConfig) -> int | None:
     return proc.pid
 
 
-def stop_sidecar(config: AgentConfig) -> bool:
-    """Stop the A2A sidecar for ``config``. Return True if a process was killed."""
-    pid_path = _pid_path(config)
-    if not pid_path.exists():
-        return False
-    try:
-        pid = int(pid_path.read_text().strip())
-    except (OSError, ValueError):  # stx-allow: fallback (reason: file system operation failure)
-        try:
-            pid_path.unlink()
-        except OSError:  # stx-allow: fallback (reason: file system operation failure)
-            pass
-        return False
-
-    if pid <= 0 or not _process_alive(pid):
-        try:
-            pid_path.unlink()
-        except OSError:  # stx-allow: fallback (reason: file system operation failure)
-            pass
-        return False
-
+def _terminate_recorded(config: AgentConfig, pid_path: Path, pid: int) -> bool:
+    """SIGTERM ``pid`` and drop ``pid_path``. Always removes the file."""
     try:
         os.kill(pid, signal.SIGTERM)
-    except OSError as exc:  # stx-allow: fallback (reason: file system operation failure)
+    except (
+        OSError
+    ) as exc:  # stx-allow: fallback (reason: file system operation failure)
         log.warning("a2a sidecar: kill %d failed for %s: %s", pid, config.name, exc)
     log.info("a2a sidecar for %s stopped (pid=%d)", config.name, pid)
     try:
@@ -203,3 +338,43 @@ def stop_sidecar(config: AgentConfig) -> bool:
     except OSError:  # stx-allow: fallback (reason: file system operation failure)
         pass
     return True
+
+
+def _stop_legacy_sidecar(config: AgentConfig) -> bool:
+    """Tear down a live pre-keying sidecar of ours. Return True if killed.
+
+    Without this an agent that is stopped (not restarted) after the
+    keying change would leave its pre-keying sidecar running forever,
+    still holding the port against the next start.
+    """
+    pid = _legacy_sidecar_pid(config)
+    if pid is None:
+        return False
+    return _terminate_recorded(config, _legacy_pid_path(config), pid)
+
+
+def stop_sidecar(config: AgentConfig) -> bool:
+    """Stop the A2A sidecar for ``config``. Return True if a process was killed."""
+    pid_path = _pid_path(config)
+    if not pid_path.exists():
+        return _stop_legacy_sidecar(config)
+    try:
+        pid = int(pid_path.read_text().strip())
+    except (
+        OSError,
+        ValueError,
+    ):  # stx-allow: fallback (reason: file system operation failure)
+        try:
+            pid_path.unlink()
+        except OSError:  # stx-allow: fallback (reason: file system operation failure)
+            pass
+        return _stop_legacy_sidecar(config)
+
+    if pid <= 0 or not _process_alive(pid):
+        try:
+            pid_path.unlink()
+        except OSError:  # stx-allow: fallback (reason: file system operation failure)
+            pass
+        return _stop_legacy_sidecar(config)
+
+    return _terminate_recorded(config, pid_path, pid)

--- a/tests/scitex_agent_container/config/test__a2a_host_line.py
+++ b/tests/scitex_agent_container/config/test__a2a_host_line.py
@@ -15,7 +15,7 @@ two ways:
 
   1. through :func:`parse_a2a` into ``A2ASpec.host`` — covered by calling it;
   2. by ``a2a_block.get("host", "127.0.0.1")`` on the raw YAML dict —
-     ``runtimes/a2a_sidecar.py:109`` (the BIND: it becomes ``a2a serve
+     ``runtimes/a2a_sidecar.py:254`` (the BIND: it becomes ``a2a serve
      --host``), ``_lifecycle/health.py:110`` and ``cli_pkg/a2a_group.py:163``
      (probe URLs). All three are the same expression, exercised here against
      the real before/after documents.
@@ -270,7 +270,7 @@ def _raw_reader_host(text: str) -> str:
 
 
 def test_the_bind_path_resolves_to_the_same_host_before_and_after() -> None:
-    # Arrange — this is the expression at a2a_sidecar.py:109, which becomes
+    # Arrange — this is the expression at a2a_sidecar.py:254, which becomes
     # the `--host` argv of the `a2a serve` process. THE bind.
     after = insert_a2a_host(_BEFORE).text
     # Act

--- a/tests/scitex_agent_container/runtimes/test_a2a_sidecar.py
+++ b/tests/scitex_agent_container/runtimes/test_a2a_sidecar.py
@@ -11,9 +11,12 @@ Each test follows the AAA shape with a single, narrow assert.
 
 from __future__ import annotations
 
+import functools
 import os
+import signal
 import socket
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -24,6 +27,9 @@ from scitex_agent_container.config import AgentConfig
 from scitex_agent_container.runtimes.a2a_sidecar import (
     LOG_FILENAME,
     PID_FILENAME,
+    _log_path,
+    _pid_path,
+    _proc_argv,
     _process_alive,
     _read_a2a_block,
     start_sidecar,
@@ -62,12 +68,32 @@ def _wait_pid_alive(pid: int, timeout: float = 5.0) -> bool:
     return False
 
 
-def _write_yaml(path: Path, *, port: int | None, handler: str = "echo") -> Path:
+def _marked_sleeper(marker: Path) -> subprocess.Popen:
+    """A live process whose KERNEL argv carries ``marker``.
+
+    ``python -c ... <marker>`` rather than ``sh -c``: a shell tail-execs
+    its single command and the extra argv word is lost with it, which
+    would silently defeat the ownership probe this stands in for.
+    """
+    return subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)", str(marker)]
+    )
+
+
+def _kill(pid: int | None) -> None:
+    if pid is not None and _process_alive(pid):
+        os.kill(pid, 15)  # SIGTERM
+        _wait_pid_dead(pid, timeout=5.0)
+
+
+def _write_yaml(
+    path: Path, *, port: int | None, handler: str = "echo", name: str = "sidecar-test"
+) -> Path:
     """Write a minimal v3 agent YAML with the requested ``spec.a2a`` block."""
     doc: dict = {
         "apiVersion": "scitex/v3",
         "kind": "Agent",
-        "metadata": {"name": "sidecar-test"},
+        "metadata": {"name": name},
         "spec": {},
     }
     if port is not None:
@@ -91,13 +117,63 @@ def _config(
     workdir: Path,
     *,
     config_path: str = "",
+    name: str = "alpha",
 ) -> AgentConfig:
     return AgentConfig(
-        name="alpha",
+        name=name,
         runtime="apptainer",
         workdir=str(workdir),
         config_path=config_path,
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-agent keying of the pid/log pair
+#
+# The defect: pid + log used to live at ``{workdir}/a2a-sidecar.*`` with no
+# agent identity in the path, so two agents sharing a workdir shared one
+# sidecar and the second start silently returned the FIRST agent's pid.
+# ---------------------------------------------------------------------------
+
+
+def test_pid_path_differs_per_agent_in_one_shared_workdir(workdir: Path) -> None:
+    # Arrange: two agents, ONE workdir — the clone / twin / relocate shape.
+    cfg_a = _config(workdir, name="shared-wd-alpha")
+    cfg_b = _config(workdir, name="shared-wd-bravo")
+    # Act
+    paths = {_pid_path(cfg_a), _pid_path(cfg_b)}
+    # Assert
+    assert len(paths) == 2
+
+
+def test_log_path_differs_per_agent_in_one_shared_workdir(workdir: Path) -> None:
+    # Arrange
+    cfg_a = _config(workdir, name="shared-wd-alpha")
+    cfg_b = _config(workdir, name="shared-wd-bravo")
+    # Act
+    paths = {_log_path(cfg_a), _log_path(cfg_b)}
+    # Assert
+    assert len(paths) == 2
+
+
+def test_pid_path_is_keyed_by_the_agent_name_directory(workdir: Path) -> None:
+    # Arrange: identity belongs in the DIRECTORY, like every other per-agent
+    # runtime artefact (pid / heartbeat.json / session.jsonl / runner.log).
+    cfg = _config(workdir, name="dir-keyed-agent")
+    # Act
+    parent_name = _pid_path(cfg).parent.name
+    # Assert
+    assert parent_name == "dir-keyed-agent"
+
+
+def test_pid_path_refuses_an_unnamed_agent(workdir: Path) -> None:
+    # Arrange: a silent fallback to a shared path here would reproduce the bug.
+    cfg = _config(workdir, name="")
+    # Act
+    resolve = functools.partial(_pid_path, cfg)
+    # Assert
+    with pytest.raises(ValueError, match="empty name"):
+        resolve()
 
 
 # ---------------------------------------------------------------------------
@@ -210,9 +286,11 @@ def test_start_sidecar_returns_existing_pid_when_already_running(
     # Arrange: real sleep process + real PID file pre-populated.
     port = _free_port()
     yaml_path = _write_yaml(tmp_path / "agent.yaml", port=port)
-    cfg = _config(workdir, config_path=str(yaml_path))
+    cfg = _config(workdir, config_path=str(yaml_path), name="already-running-agent")
+    pid_path = _pid_path(cfg)
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
     sleeper = subprocess.Popen(["sleep", "30"])
-    (workdir / PID_FILENAME).write_text(str(sleeper.pid))
+    pid_path.write_text(str(sleeper.pid))
     try:
         # Act
         returned = start_sidecar(cfg)
@@ -221,6 +299,7 @@ def test_start_sidecar_returns_existing_pid_when_already_running(
     finally:
         sleeper.terminate()
         sleeper.wait(timeout=5)
+        pid_path.unlink(missing_ok=True)
 
 
 def test_start_sidecar_spawns_real_subprocess_and_writes_pid_file(
@@ -229,38 +308,35 @@ def test_start_sidecar_spawns_real_subprocess_and_writes_pid_file(
     # Arrange: claim+release a free port; real CLI will rebind it.
     port = _free_port()
     yaml_path = _write_yaml(tmp_path / "agent.yaml", port=port)
-    cfg = _config(workdir, config_path=str(yaml_path))
+    cfg = _config(workdir, config_path=str(yaml_path), name="spawn-writes-pid-agent")
     # Act
     pid = start_sidecar(cfg)
     try:
         # Wait for the real subprocess to come up enough that os.kill(pid, 0)
         # succeeds — this exercises the production write-then-spawn ordering.
         _wait_pid_alive(pid, timeout=5.0)
-        pid_on_disk = int((workdir / PID_FILENAME).read_text().strip())
+        pid_on_disk = int(_pid_path(cfg).read_text().strip())
         # Assert: on-disk PID matches the value returned by start_sidecar.
         assert pid_on_disk == pid
     finally:
-        if pid is not None and _process_alive(pid):
-            os.kill(pid, 15)  # SIGTERM
-            _wait_pid_dead(pid, timeout=5.0)
-        (workdir / PID_FILENAME).unlink(missing_ok=True)
+        _kill(pid)
+        _pid_path(cfg).unlink(missing_ok=True)
 
 
 def test_start_sidecar_creates_log_file(workdir: Path, tmp_path: Path) -> None:
     # Arrange
     port = _free_port()
     yaml_path = _write_yaml(tmp_path / "agent.yaml", port=port)
-    cfg = _config(workdir, config_path=str(yaml_path))
+    cfg = _config(workdir, config_path=str(yaml_path), name="log-file-agent")
     # Act
     pid = start_sidecar(cfg)
     try:
         # Assert: log file is opened for append by start_sidecar itself,
         # so it exists regardless of whether the child has written yet.
-        assert (workdir / LOG_FILENAME).exists()
+        assert _log_path(cfg).exists()
     finally:
-        if pid is not None and _process_alive(pid):
-            os.kill(pid, 15)
-            _wait_pid_dead(pid, timeout=5.0)
+        _kill(pid)
+        _pid_path(cfg).unlink(missing_ok=True)
 
 
 def test_start_sidecar_clears_stale_pid_file_and_respawns(
@@ -271,20 +347,220 @@ def test_start_sidecar_clears_stale_pid_file_and_respawns(
     proc = subprocess.Popen(["true"])
     proc.wait(timeout=5)
     dead_pid = proc.pid
-    (workdir / PID_FILENAME).write_text(str(dead_pid))
 
     port = _free_port()
     yaml_path = _write_yaml(tmp_path / "agent.yaml", port=port)
-    cfg = _config(workdir, config_path=str(yaml_path))
+    cfg = _config(workdir, config_path=str(yaml_path), name="stale-pid-agent")
+    pid_path = _pid_path(cfg)
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text(str(dead_pid))
     # Act
     new_pid = start_sidecar(cfg)
     try:
         # Assert: a different, live PID was spawned.
         assert new_pid is not None and new_pid != dead_pid
     finally:
-        if new_pid is not None and _process_alive(new_pid):
-            os.kill(new_pid, 15)
-            _wait_pid_dead(new_pid, timeout=5.0)
+        _kill(new_pid)
+        pid_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Two agents, ONE workdir — the reported defect, end to end with real sidecars
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def shared_workdir_pair(tmp_path: Path):
+    """Two REAL sidecars for two agents sharing ONE workdir.
+
+    Function-scoped (each test gets its own pair) so no assertion can
+    depend on another having run first.
+    """
+    root = tmp_path / "pair"
+    root.mkdir()
+    wd = root / "SHARED-WORKDIR"
+    wd.mkdir()
+    port_a, port_b = _free_port(), _free_port()
+    spec_a = _write_yaml(root / "a.yaml", port=port_a, name="pair-alpha")
+    spec_b = _write_yaml(root / "b.yaml", port=port_b, name="pair-bravo")
+    cfg_a = _config(wd, config_path=str(spec_a), name="pair-alpha")
+    cfg_b = _config(wd, config_path=str(spec_b), name="pair-bravo")
+
+    pid_a = start_sidecar(cfg_a)
+    pid_b = start_sidecar(cfg_b)
+    _wait_pid_alive(pid_a, timeout=10.0)
+    _wait_pid_alive(pid_b, timeout=10.0)
+    yield {
+        "cfg_a": cfg_a,
+        "cfg_b": cfg_b,
+        "pid_a": pid_a,
+        "pid_b": pid_b,
+        "port_b": port_b,
+    }
+    _kill(pid_a)
+    _kill(pid_b)
+    _pid_path(cfg_a).unlink(missing_ok=True)
+    _pid_path(cfg_b).unlink(missing_ok=True)
+
+
+def test_second_agent_in_a_shared_workdir_gets_its_own_pid(
+    shared_workdir_pair: dict,
+) -> None:
+    # Arrange: pre-fix, the second start logged "already running" and handed
+    # back the FIRST agent's pid.
+    pair = shared_workdir_pair
+    # Act
+    pids = {pair["pid_a"], pair["pid_b"]}
+    # Assert
+    assert len(pids) == 2
+
+
+def test_second_agent_in_a_shared_workdir_gets_its_own_pid_file(
+    shared_workdir_pair: dict,
+) -> None:
+    # Arrange
+    pair = shared_workdir_pair
+    # Act
+    recorded = {
+        _pid_path(pair["cfg_a"]).read_text().strip(),
+        _pid_path(pair["cfg_b"]).read_text().strip(),
+    }
+    # Assert: two files, two distinct recorded pids.
+    assert len(recorded) == 2
+
+
+def test_second_agents_recorded_pid_is_a_process_serving_its_own_port(
+    shared_workdir_pair: dict,
+) -> None:
+    # Arrange: read the pid back off disk, then ask the KERNEL what that
+    # process actually is — not the value start_sidecar returned.
+    pair = shared_workdir_pair
+    recorded_b = int(_pid_path(pair["cfg_b"]).read_text().strip())
+    # Act
+    argv = _proc_argv(recorded_b)
+    # Assert
+    assert str(pair["port_b"]) in argv
+
+
+# ---------------------------------------------------------------------------
+# Migration off the pre-keying ``{workdir}/a2a-sidecar.pid``
+# ---------------------------------------------------------------------------
+
+
+def test_start_sidecar_adopts_a_live_legacy_sidecar_of_ours(
+    workdir: Path, tmp_path: Path
+) -> None:
+    # Arrange: an agent already running when the keying change lands — its
+    # sidecar is recorded ONLY at the legacy workdir path.
+    port = _free_port()
+    yaml_path = _write_yaml(tmp_path / "agent.yaml", port=port)
+    cfg = _config(workdir, config_path=str(yaml_path), name="adopt-legacy-agent")
+    legacy = workdir / PID_FILENAME
+    incumbent = _marked_sleeper(yaml_path)
+    legacy.write_text(str(incumbent.pid))
+    try:
+        # Act
+        returned = start_sidecar(cfg)
+        # Assert: adopted, not duplicated — no second bind attempt.
+        assert returned == incumbent.pid
+    finally:
+        incumbent.terminate()
+        incumbent.wait(timeout=5)
+        _pid_path(cfg).unlink(missing_ok=True)
+        legacy.unlink(missing_ok=True)
+
+
+def test_adopting_a_legacy_sidecar_moves_the_record_to_the_per_agent_path(
+    workdir: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    port = _free_port()
+    yaml_path = _write_yaml(tmp_path / "agent.yaml", port=port)
+    cfg = _config(workdir, config_path=str(yaml_path), name="adopt-moves-record-agent")
+    legacy = workdir / PID_FILENAME
+    incumbent = _marked_sleeper(yaml_path)
+    legacy.write_text(str(incumbent.pid))
+    try:
+        # Act
+        start_sidecar(cfg)
+        # Assert
+        assert _pid_path(cfg).read_text().strip() == str(incumbent.pid)
+    finally:
+        incumbent.terminate()
+        incumbent.wait(timeout=5)
+        _pid_path(cfg).unlink(missing_ok=True)
+        legacy.unlink(missing_ok=True)
+
+
+def test_start_sidecar_ignores_a_legacy_pid_file_owned_by_another_agent(
+    workdir: Path, tmp_path: Path
+) -> None:
+    # Arrange: the legacy file names a LIVE process that belongs to a DIFFERENT
+    # agent (its kernel argv carries the other agent's spec).
+    other_yaml = _write_yaml(tmp_path / "other.yaml", port=_free_port())
+    port = _free_port()
+    yaml_path = _write_yaml(tmp_path / "agent.yaml", port=port)
+    cfg = _config(workdir, config_path=str(yaml_path), name="ignore-stranger-agent")
+    legacy = workdir / PID_FILENAME
+    stranger = _marked_sleeper(other_yaml)
+    legacy.write_text(str(stranger.pid))
+    pid = None
+    try:
+        # Act
+        pid = start_sidecar(cfg)
+        # Assert: we spawned our OWN sidecar rather than adopting a stranger's.
+        assert pid is not None and pid != stranger.pid
+    finally:
+        stranger.terminate()
+        stranger.wait(timeout=5)
+        _kill(pid)
+        _pid_path(cfg).unlink(missing_ok=True)
+        legacy.unlink(missing_ok=True)
+
+
+def test_stop_sidecar_terminates_a_live_legacy_sidecar_of_ours(
+    workdir: Path, tmp_path: Path
+) -> None:
+    # Arrange: stopped (not restarted) right after the keying change — the
+    # legacy sidecar would otherwise hold the port forever.
+    yaml_path = _write_yaml(tmp_path / "agent.yaml", port=_free_port())
+    cfg = _config(workdir, config_path=str(yaml_path), name="stop-legacy-agent")
+    legacy = workdir / PID_FILENAME
+    incumbent = _marked_sleeper(yaml_path)
+    legacy.write_text(str(incumbent.pid))
+    try:
+        # Act
+        stop_sidecar(cfg)
+        # Assert: wait() reaps, so the exit code reports the signal that
+        # killed it. (os.kill(pid, 0) still succeeds on an unreaped zombie,
+        # which is why liveness alone would not be evidence here.)
+        assert incumbent.wait(timeout=5) == -signal.SIGTERM
+    finally:
+        if incumbent.poll() is None:
+            incumbent.kill()
+            incumbent.wait(timeout=5)
+        legacy.unlink(missing_ok=True)
+
+
+def test_stop_sidecar_leaves_another_agents_legacy_sidecar_alive(
+    workdir: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    other_yaml = _write_yaml(tmp_path / "other.yaml", port=_free_port())
+    yaml_path = _write_yaml(tmp_path / "agent.yaml", port=_free_port())
+    cfg = _config(workdir, config_path=str(yaml_path), name="stop-stranger-agent")
+    legacy = workdir / PID_FILENAME
+    stranger = _marked_sleeper(other_yaml)
+    legacy.write_text(str(stranger.pid))
+    try:
+        # Act
+        stop_sidecar(cfg)
+        # Assert
+        assert _process_alive(stranger.pid) is True
+    finally:
+        stranger.terminate()
+        stranger.wait(timeout=5)
+        legacy.unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------
@@ -294,7 +570,7 @@ def test_start_sidecar_clears_stale_pid_file_and_respawns(
 
 def test_stop_sidecar_returns_false_when_pid_file_absent(workdir: Path) -> None:
     # Arrange
-    cfg = _config(workdir)
+    cfg = _config(workdir, name="stop-absent-agent")
     # Act
     result = stop_sidecar(cfg)
     # Assert
@@ -303,42 +579,57 @@ def test_stop_sidecar_returns_false_when_pid_file_absent(workdir: Path) -> None:
 
 def test_stop_sidecar_clears_pid_file_with_garbage_contents(workdir: Path) -> None:
     # Arrange
-    (workdir / PID_FILENAME).write_text("not-a-pid\n")
-    cfg = _config(workdir)
+    cfg = _config(workdir, name="stop-garbage-agent")
+    pid_path = _pid_path(cfg)
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text("not-a-pid\n")
     # Act
-    result = stop_sidecar(cfg)
+    stop_sidecar(cfg)
     # Assert
-    assert result is False and not (workdir / PID_FILENAME).exists()
+    assert not pid_path.exists()
 
 
 def test_stop_sidecar_clears_pid_file_when_process_already_dead(
     workdir: Path,
 ) -> None:
     # Arrange: reaped PID — _process_alive returns False.
+    cfg = _config(workdir, name="stop-dead-agent")
+    pid_path = _pid_path(cfg)
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
     proc = subprocess.Popen(["true"])
     proc.wait(timeout=5)
-    (workdir / PID_FILENAME).write_text(str(proc.pid))
-    cfg = _config(workdir)
+    pid_path.write_text(str(proc.pid))
     # Act
-    result = stop_sidecar(cfg)
+    stop_sidecar(cfg)
     # Assert
-    assert result is False and not (workdir / PID_FILENAME).exists()
+    assert not pid_path.exists()
 
 
 def test_stop_sidecar_kills_live_process_and_removes_pid_file(
     workdir: Path,
 ) -> None:
     # Arrange: real long-running sleep process registered via PID file.
+    cfg = _config(workdir, name="stop-live-agent")
+    pid_path = _pid_path(cfg)
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
     sleeper = subprocess.Popen(["sleep", "30"])
-    (workdir / PID_FILENAME).write_text(str(sleeper.pid))
-    cfg = _config(workdir)
+    pid_path.write_text(str(sleeper.pid))
     try:
         # Act
         result = stop_sidecar(cfg)
         sleeper.wait(timeout=5)
         # Assert
-        assert result is True and not (workdir / PID_FILENAME).exists()
+        assert result is True and not pid_path.exists()
     finally:
         if sleeper.poll() is None:
             sleeper.kill()
             sleeper.wait(timeout=5)
+
+
+def test_log_filename_constant_is_the_sidecar_log_basename(workdir: Path) -> None:
+    # Arrange
+    cfg = _config(workdir, name="log-basename-agent")
+    # Act
+    basename = _log_path(cfg).name
+    # Assert
+    assert basename == LOG_FILENAME


### PR DESCRIPTION
## The defect

`runtimes/a2a_sidecar.py` derived its pid and log paths from `spec.workdir` alone — `{workdir}/a2a-sidecar.{pid,log}`, with no agent identity anywhere in the path. Two agents sharing a workdir therefore shared one PID file, and the second `start_sidecar` logged `already running; skipping` and returned the **first** agent's PID. The second agent then reported healthy while owning no sidecar at all and being undriveable over A2A.

Reported by the agent that landed #924, which hit it as a real false negative in its own test run. It is latent today only because each agent owns its workdir — cloning, twinning and relocating all break that assumption, which is exactly the work in flight.

## What changed

`src/scitex_agent_container/runtimes/a2a_sidecar.py`

| line | what |
|---|---|
| `70-96` | new `_state_dir(config)` — resolves the agent's own runtime state dir, **raises** on an empty `config.name` |
| `99-104` | `_pid_path` / `_log_path` now key off `_state_dir` instead of `expanded_workdir` |
| `107-109` | `_legacy_pid_path` — the pre-keying workdir path, read-only compatibility |
| `149-155` | `_proc_argv` — the kernel's record of a pid's argv |
| `158-183` | `_legacy_sidecar_pid` — legacy pid **iff** `/proc/<pid>/cmdline` says it is ours |
| `186-216` | `_adopt_legacy_sidecar` — take over a live pre-keying sidecar, move the record |
| `246-251` | `start_sidecar` consults the legacy path after the per-agent one |
| `327-353` | `_terminate_recorded` / `_stop_legacy_sidecar` |
| `356-380` | `stop_sidecar` drains the legacy path too |

Also: `_skills/scitex-agent-container/07_a2a-protocol.md` (documented paths + migration), and two stale `a2a_sidecar.py:109` line references in `tests/.../config/test__a2a_host_line.py`.

### Directory, not filename

`<runtime-root>/<agent>/a2a-sidecar.{pid,log}` — resolved through `tui_session.state_dir_for_config`, the SSOT both host runtimes already use, i.e. the same `runtime/<agent-id>/` that holds `pid`, `heartbeat.json`, `session.jsonl` and `runner.log`.

The identity goes in the **directory** because that is what every other per-agent artefact does, and the surrounding machinery is built around it:

* `_lifecycle/_rename.py` renames `runtime/<name>/` as a unit — a flat `a2a-sidecar-<agent>.pid` sitting in a workdir would be missed;
* `$SCITEX_AGENT_CONTAINER_RUNTIME_DIR` (the GPFS inode fix) relocates the tree as a unit, and now covers sidecar state too;
* `state_dir_for_config` keeps a **project-scoped** agent's state under its own repo, so two same-named agents in two different repos do not collide — a filename-keyed scheme reintroduces exactly that class of collision while fixing another;
* it stops writing runtime junk into what is usually a git checkout.

### Where the agent id comes from

`config.name`. It is a required (non-defaulted) `AgentConfig` field sourced from the spec's `metadata.name`, and it is the same key the registry, `state.db` and `screen_name` use, so it is always populated at sidecar-start time.

Rejected:

* **`SAC_NAME`** — injected *into the container* (`runtimes/_apptainer_listen_env.py:84`, `hooks.py:115`). `start_sidecar` runs on the **host**, inside `sac agents start`, where it is unset; worse, when one agent starts another it carries the **calling** agent's name, which is the same collision class in a new costume.
* **`SCITEX_AGENT_CONTAINER_AGENT`** — same story: an in-container identity fallback (`_never_stop_when_task_remains/_identity.py:43`), not a host-side fact.

An empty name **raises** rather than falling back to a shared path. A silent fallback there would reproduce the exact bug this fixes. Both call sites (`_runners/_tmux/claude_code.py:602-605, 626-629`) already log-and-continue around this module, so refusing costs at most the sidecar, never the agent.

## What happens to an agent running RIGHT NOW

Nothing, until its next stop or start — the sidecar is spawned at agent start, so landing this changes no running process.

On that next lifecycle event, a live pre-keying sidecar is still recorded only at `{workdir}/a2a-sidecar.pid` and is still holding the port. Ignoring it would make the fresh spawn fail to bind and the agent would come up sidecar-less. So both entry points consult the legacy path:

* **`start_sidecar` adopts it** — writes the pid to the per-agent path, unlinks the legacy file, returns that pid. No kill, no port churn, no downtime; the running sidecar simply becomes correctly bookkept.
* **`stop_sidecar` terminates it** — for the agent that gets stopped rather than restarted, so its sidecar does not outlive it holding the port.

Both are gated on **ownership decided by the kernel**: `/proc/<pid>/cmdline` must contain *this* agent's `config_path`. Two agents sharing a workdir necessarily have distinct spec files, so a co-tenant's pre-keying sidecar is never adopted and never killed — it keeps running and keeps serving, and the co-tenant adopts it on its own next start. A legacy file we cannot prove is ours is left untouched.

## Evidence — two agents, one workdir

Same script both sides; pids read back from the **kernel** (`lsof -t -i @127.0.0.1:<port> -sTCP:LISTEN`) and from `/proc/<pid>/cmdline`, never from `start_sidecar`'s return value.

**BEFORE** — `git archive origin/develop`, `PYTHONPATH` at the extracted tree:

```
shared workdir : /uvwork/tmp/twoagents-uxh5ipmy/SHARED-WORKDIR
alpha port     : 59224
bravo port     : 60350

start_sidecar(alpha) returned : 379599
start_sidecar(bravo) returned : 379599          <-- bravo handed alpha's pid

KERNEL pid LISTENing on alpha's port 59224 : 379599
   argv: ... a2a serve /uvwork/tmp/twoagents-uxh5ipmy/alpha.yaml --port 59224 ...
KERNEL pid LISTENing on bravo's port 60350 : None    <-- bravo never served

pid files on disk:
   /uvwork/tmp/twoagents-uxh5ipmy/SHARED-WORKDIR/a2a-sidecar.pid  ->  379599

   distinct pid FILES   : 1
   distinct KERNEL pids : 1
   both ports served    : False
   COLLISION            : True
```

**AFTER** — this branch:

```
shared workdir : /uvwork/tmp/twoagents-bll45uum/SHARED-WORKDIR
alpha port     : 58578
bravo port     : 58742

start_sidecar(alpha) returned : 391653
start_sidecar(bravo) returned : 391677

KERNEL pid LISTENing on alpha's port 58578 : 391653
   argv: ... a2a serve /uvwork/tmp/twoagents-bll45uum/alpha.yaml --port 58578 ...
KERNEL pid LISTENing on bravo's port 58742 : 391677
   argv: ... a2a serve /uvwork/tmp/twoagents-bll45uum/bravo.yaml --port 58742 ...

pid files on disk:
   /uvwork/tmp/twoagents-bll45uum/runtime-root/alpha/a2a-sidecar.pid  ->  391653
   /uvwork/tmp/twoagents-bll45uum/runtime-root/bravo/a2a-sidecar.pid  ->  391677

   distinct pid FILES   : 2
   distinct KERNEL pids : 2
   both ports served    : True
   COLLISION            : False
```

Two distinct sidecars, two distinct pids, two distinct pid files — and each kernel argv names its own spec and its own port.

## Negative control

Reverted the keying in place (`_pid_path` / `_log_path` back to `Path(config.expanded_workdir) / …`), same tests:

```
8 failed, 21 passed in 67.45s      <-- reverted
29 passed in ~66s                  <-- restored
```

The eight that fail are exactly the collision-catching ones:

```
test_pid_path_differs_per_agent_in_one_shared_workdir
test_log_path_differs_per_agent_in_one_shared_workdir
test_pid_path_is_keyed_by_the_agent_name_directory
test_pid_path_refuses_an_unnamed_agent
test_second_agent_in_a_shared_workdir_gets_its_own_pid
test_second_agent_in_a_shared_workdir_gets_its_own_pid_file
test_second_agents_recorded_pid_is_a_process_serving_its_own_port
test_start_sidecar_ignores_a_legacy_pid_file_owned_by_another_agent
```

with, e.g. — the reported bug reproduced by the suite:

```
test_second_agent_in_a_shared_workdir_gets_its_own_pid_file
    assert len(recorded) == 2
E   AssertionError: assert 1 == 2
E    +  where 1 = len({'489129'})
```

## Tests

29 in `tests/scitex_agent_container/runtimes/test_a2a_sidecar.py` (was 19), all real: real pid files, real `Popen`, real socket binds, real `os.kill`, `/proc` read for argv. No mocks, no monkeypatch, one assert each.

Wider run — `runtimes/` + `config/` + `_lifecycle/test_health.py`: **932 passed, 1 failed**. The one failure is `test__tui_turn_bridge.py::test_stop_turn_bridge_force_frees_survivor_on_own_port`, a load flake in a file this PR does not touch (`python -c pass` exceeding a 5 s `wait`); it passes on its own in 4.42 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWwZWke4rh2Civ11ybUw4k
