### PR TITLE
fix(db): db show / db query name the store they read

### DIFF
--- a/src/scitex_agent_container/_mcp/_tools/_db.py
+++ b/src/scitex_agent_container/_mcp/_tools/_db.py
@@ -20,7 +20,23 @@ def db_query(
     limit: int = 50,
 ) -> dict[str, Any]:
     """Query the state-db. Filter by table / agent / host. Mirrors
-    ``sac db query --json``."""
+    ``sac db query --json``.
+
+    The result carries ``store`` — the database the rows came from —
+    because an MCP caller never sees the CLI's console rendering, and an
+    empty ``data`` is otherwise indistinguishable from having queried the
+    WRONG database. ``SCITEX_AGENT_CONTAINER_STATE_DB`` is set per-agent
+    in every sac container, so each agent reads its own shard, which
+    never holds fleet rows. On 2026-08-09 three agents independently
+    concluded the fleet registry had been wiped from all-zero output
+    here; two escalated it as P1 data loss while the host DB was healthy.
+
+    It is a SIBLING key: ``data`` keeps its exact shape, and the CLI's
+    stdout stays a bare array. The store deliberately does NOT travel on
+    stderr — ``invoke_cli_json`` reads Click's merged ``result.output``,
+    so a stderr line would make ``data`` unparseable and hand every
+    caller ``None``.
+    """
     argv = ["db", "query", "--json", "--limit", str(limit)]
     if table:
         argv += ["--table", table]
@@ -28,7 +44,14 @@ def db_query(
         argv += ["--agent", agent]
     if host:
         argv += ["--host", host]
-    return invoke_cli_json(argv)
+    result = invoke_cli_json(argv)
+    # Read through the MODULE: the constant binds from the environment at
+    # import time, so a captured copy goes stale and would report a path
+    # that is not the one just queried.
+    from ..._state import state_db as _state_db
+
+    result["store"] = str(_state_db.DEFAULT_DB_PATH)
+    return result
 
 
 def db_clean(heartbeat_stale_seconds: int = 600) -> dict[str, Any]:

--- a/src/scitex_agent_container/cli_pkg/db_group.py
+++ b/src/scitex_agent_container/cli_pkg/db_group.py
@@ -58,8 +58,10 @@ def db_show(ctx: click.Context, as_json: bool) -> None:
     container, so an agent reads its OWN shard — which never holds
     fleet rows — while the populated registry sits elsewhere. Without
     the path, all-zero counts look exactly like a wiped fleet registry:
-    on 2026-08-09 two agents independently escalated P1 data loss from
-    their own empty shard while the host DB was healthy.
+    on 2026-08-09 THREE agents independently reached that conclusion from
+    their own empty shard (two escalating P1 data loss) while the host DB
+    was healthy — three, independently, is what makes it a tool defect
+    rather than a coincidence.
 
     \b
     Example:
@@ -140,10 +142,14 @@ def db_query(
         rows = [dict(r) for r in conn.execute(sql, (limit,)).fetchall()]
 
     if _json_flag(ctx, as_json):
-        # Stays a bare ARRAY on purpose: wrapping it to carry the store
-        # path (as `db show` now does) would break every consumer that
-        # indexes the result, and a published output contract is a
-        # MIGRATION, not a rename. Tracked separately.
+        # Bare ARRAY, and NOTHING else on this path — not even stderr.
+        # Wrapping breaks consumers that index it (a published contract
+        # is a MIGRATION). A stderr line is worse than it looks: the MCP
+        # wrapper reads Click's `result.output`, which MERGES stderr into
+        # stdout, so one extra line makes the JSON unparseable and agents
+        # get `data: None` instead of rows. Measured, not assumed.
+        # An MCP caller gets the store from the wrapper (_mcp/_tools/_db)
+        # as a sibling key, where it cannot corrupt the payload.
         click.echo(json.dumps(rows, indent=2))
         return
     console.print(f"[dim]store: {_state_db.DEFAULT_DB_PATH}[/dim]")

--- a/src/scitex_agent_container/cli_pkg/db_group.py
+++ b/src/scitex_agent_container/cli_pkg/db_group.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import click
 
+from .._state import state_db as _state_db
 from .._state.state_db import (
     KNOWN_TABLES,
     export_state,
@@ -52,17 +53,34 @@ def db_group() -> None:
 def db_show(ctx: click.Context, as_json: bool) -> None:
     """Schema overview + per-table row counts.
 
+    The output NAMES THE DATABASE IT READ (``store``).
+    ``SCITEX_AGENT_CONTAINER_STATE_DB`` is set per-agent in every sac
+    container, so an agent reads its OWN shard — which never holds
+    fleet rows — while the populated registry sits elsewhere. Without
+    the path, all-zero counts look exactly like a wiped fleet registry:
+    on 2026-08-09 two agents independently escalated P1 data loss from
+    their own empty shard while the host DB was healthy.
+
     \b
     Example:
       $ sac db show
       $ sac db show --json
     """
     counts = table_counts()
-    payload = {"tables": counts, "known_tables": list(KNOWN_TABLES)}
+    # Read through the MODULE, not a from-import: the constant is bound
+    # at import time from the env, so a captured copy goes stale the
+    # moment anything re-resolves it. Reporting a stale path would be
+    # the very bug this line exists to prevent.
+    payload = {
+        "store": str(_state_db.DEFAULT_DB_PATH),
+        "tables": counts,
+        "known_tables": list(KNOWN_TABLES),
+    }
     if _json_flag(ctx, as_json):
         click.echo(json.dumps(payload, indent=2))
         return
     console.print("[bold]sac state.db[/bold]")
+    console.print(f"  [dim]store: {_state_db.DEFAULT_DB_PATH}[/dim]")
     for table in KNOWN_TABLES:
         n = counts.get(table, 0)
         console.print(f"  {table:<14}  {n:>6}")
@@ -122,8 +140,13 @@ def db_query(
         rows = [dict(r) for r in conn.execute(sql, (limit,)).fetchall()]
 
     if _json_flag(ctx, as_json):
+        # Stays a bare ARRAY on purpose: wrapping it to carry the store
+        # path (as `db show` now does) would break every consumer that
+        # indexes the result, and a published output contract is a
+        # MIGRATION, not a rename. Tracked separately.
         click.echo(json.dumps(rows, indent=2))
         return
+    console.print(f"[dim]store: {_state_db.DEFAULT_DB_PATH}[/dim]")
     if not rows:
         console.print(f"[dim]({table}: no rows)[/dim]")
         return

--- a/tests/scitex_agent_container/cli_pkg/test_db_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_db_group.py
@@ -74,6 +74,51 @@ def test_db_show_console_output_lists_instances_table_row(db_path: Path):
 
 
 # ---------------------------------------------------------------------------
+# db show — names the store it read
+#
+# INCIDENT 2026-08-09: SCITEX_AGENT_CONTAINER_STATE_DB is set per-agent in
+# every sac container, so an agent calling `db show` reads its OWN shard,
+# which never holds fleet rows. All-zero counts then look identical to a
+# wiped fleet registry, and two agents independently escalated P1 data
+# loss from their own empty shard while the host DB was healthy. The
+# payload must say WHICH database produced the numbers.
+# ---------------------------------------------------------------------------
+
+
+def test_db_show_json_payload_names_the_store_it_read(db_path: Path):
+    # Arrange
+    from scitex_agent_container.cli_pkg.db_group import db_show
+
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(db_show, ["--json"])
+    # Assert
+    assert json.loads(result.output)["store"] == str(db_path)
+
+
+def test_db_show_console_output_names_the_store_it_read(db_path: Path):
+    # Arrange
+    from scitex_agent_container.cli_pkg.db_group import db_show
+
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(db_show, [])
+    # Assert
+    assert db_path.name in result.output
+
+
+def test_db_query_console_output_names_the_store_it_read(db_path: Path):
+    # Arrange
+    from scitex_agent_container.cli_pkg.db_group import db_query
+
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(db_query, ["--table", "instances", "--limit", "5"])
+    # Assert
+    assert "store:" in result.output
+
+
+# ---------------------------------------------------------------------------
 # db query — --where branch + non-JSON renderings (lines 104, 124-132)
 # ---------------------------------------------------------------------------
 

--- a/tests/scitex_agent_container/cli_pkg/test_db_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_db_group.py
@@ -118,6 +118,42 @@ def test_db_query_console_output_names_the_store_it_read(db_path: Path):
     assert "store:" in result.output
 
 
+def test_db_query_json_still_emits_a_bare_array(db_path: Path):
+    # Arrange: the published contract. Consumers index this result, so
+    # wrapping it would be a migration, not a rename.
+    from scitex_agent_container.cli_pkg.db_group import db_query
+
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(db_query, ["--table", "instances", "--json"])
+    # Assert
+    assert json.loads(result.stdout) == []
+
+
+def test_db_query_mcp_result_names_the_store(db_path: Path):
+    # Arrange: an MCP caller never sees the console rendering, so the
+    # provenance has to ride on the RESULT. Sibling key, not an envelope
+    # — and deliberately not stderr, which invoke_cli_json merges into
+    # stdout and which would make `data` unparseable.
+    from scitex_agent_container._mcp._tools._db import db_query as mcp_db_query
+
+    # Act
+    result = mcp_db_query(table="instances")
+    # Assert
+    assert result["store"] == str(db_path)
+
+
+def test_db_query_mcp_data_still_parses(db_path: Path):
+    # Arrange: the guard against "fixing" this with a stderr line again,
+    # which is what turns `data` into None for every agent.
+    from scitex_agent_container._mcp._tools._db import db_query as mcp_db_query
+
+    # Act
+    result = mcp_db_query(table="instances")
+    # Assert
+    assert result["data"] == []
+
+
 # ---------------------------------------------------------------------------
 # db query — --where branch + non-JSON renderings (lines 104, 124-132)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The defect

`db show` and `db query` report counts and rows **without naming the database they read**.

`SCITEX_AGENT_CONTAINER_STATE_DB` is set per-agent in the specs, so an agent inside a container reads its own small shard, while the fleet registry lives in the host's state DB. The output looks identical either way — a table of counts with no indication of provenance.

## What that cost

On 2026-08-09, **two agents independently escalated fleet-wide data loss** on the same afternoon after reading all-zero counts off their own container shard:

- `db_show` reported definitions 0, instances 0, heartbeats 0, events 0, lineage 0.
- The host DB was in fact healthy the whole time — instances 30, events 48, channel_events 111, a2a_ports 14.

Neither agent was careless. The output simply lacked the one fact needed to interpret it. A third agent (this one) then built a coherent but wrong root-cause story on top of the same misreading, and had to retract it.

## The change

- `db show --json` gains a `store` field; the console rendering prints it under the header.
- `db query` prints the store above its rows.
- The path is read through the **module** (`_state_db.DEFAULT_DB_PATH`) rather than captured by a from-import. The constant is bound at import time from the environment, so a captured copy goes stale the moment anything re-resolves it — and reporting a **stale** path would be precisely the bug this change exists to prevent. The existing test fixture reloads that module, which is what surfaced the distinction.
- `db query --json` deliberately stays a bare array. Wrapping it to carry the store path would break every consumer that indexes the result; changing a published output contract is a **migration**, not a rename. Noted in-code and left for a deliberate pass.

## Tests

25 passed in `test_db_group.py` — 22 existing plus 3 new, pinning the store path in the JSON payload and in both console renderings.

## Why this one first

It is the cheapest of the three defects on the card and it is the one that **manufactured** the other confusion. Credit to scitex-db for identifying it as a tool defect rather than accepting it as two agents being sloppy.

## Still open on the card

1. An unresolvable identity resolves to group `''` and produces a clean, authoritative 403 — making a transient condition indistinguishable from a permanent one. Must fail closed *loudly*: "cannot determine group for `<caller>`".
2. An empty registry returned as a successful empty list. "I cannot see the registry" and "there are no agents" are different answers, and only one of them was true.

## Provenance

Authored by the `scitex-agent-container` agent on scitex-compute-04, which pushed `86dd6e7` but cannot open a PR: `gh` cannot authenticate from any agent container on that host. Opened from the laptop session on its behalf.

Card: `sac-per-agent-state-db-shard-detaches-a2a-registry-20260809`.
