### PR TITLE
fix(runtimes): forward GITHUB_TOKEN into agent containers so gh can authenticate

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -149,18 +149,10 @@ def build_run_argv(
     if env_file.is_file():
         argv += ["--env-file", str(env_file)]
 
-    # Quota-cache bind (#16) — see module-level docstring in
-    # _apptainer_runtime. Bind read-only + advertise the in-container
-    # path to the telegrammer bridge so its default-path lookup hits
-    # the bind without any per-agent spec change.
-    quota_src = _resolve_quota_cache_host_path()
-    if quota_src.is_file():
-        argv += [
-            "--bind",
-            f"{quota_src}:{QUOTA_CACHE_CONTAINER_PATH}:ro",
-            "--env",
-            f"CCT_QUOTA_CACHE_PATH={QUOTA_CACHE_CONTAINER_PATH}",
-        ]
+    # Quota-cache bind (#16) — extracted to _apptainer_quota_env.
+    from ._apptainer_quota_env import quota_cache_flags
+
+    argv += quota_cache_flags()
 
     # Host access + working directory are the SOLE responsibility of the
     # explicit ``apptainer.binds`` + ``spec.workdir`` — there is NO
@@ -310,6 +302,13 @@ def build_run_argv(
     from ._apptainer_listen_env import listen_env_flags
 
     argv += listen_env_flags(config)
+
+    # GitHub token for the in-container ``gh``. Safe as ``--env`` ONLY because
+    # redact_secret_env_to_file below lifts ``*_TOKEN`` out of the argv. Why
+    # this is needed at all: see _github_token.
+    from ._github_token import github_token_env_flags
+
+    argv += github_token_env_flags(agent_name=config.name)
 
     # TUI parity with the SDK's telegrammer wake (apply_channels →
     # _wire_telegrammer_wake): inject CLAUDE_CODE_TELEGRAMMER_TURN_URL so an

--- a/src/scitex_agent_container/runtimes/_apptainer_quota_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_quota_env.py
@@ -1,0 +1,37 @@
+"""Quota-cache bind + in-container path advertisement for agent containers.
+
+Extracted verbatim from :mod:`_apptainer_build_argv` (issue #16; see the
+module-level docstring in ``_apptainer_runtime`` for what the quota cache is
+and why the telegrammer bridge wants it). Behaviour is unchanged — this is a
+move, not a rewrite — and it joins the existing ``_apptainer_*`` family
+alongside ``_apptainer_listen_env`` / ``_apptainer_secret_env``, which package
+one env-wiring concern each.
+"""
+
+from __future__ import annotations
+
+__all__ = ["quota_cache_flags"]
+
+
+def quota_cache_flags() -> list[str]:
+    """Bind the quota cache read-only and advertise its in-container path.
+
+    Read-only bind plus ``CCT_QUOTA_CACHE_PATH`` so the telegrammer bridge's
+    default-path lookup hits the bind without any per-agent spec change.
+    Returns ``[]`` when the host has no quota cache file, which is the normal
+    state on a freshly provisioned host.
+    """
+    from ._apptainer_quota_cache import (
+        QUOTA_CACHE_CONTAINER_PATH,
+        _resolve_quota_cache_host_path,
+    )
+
+    quota_src = _resolve_quota_cache_host_path()
+    if not quota_src.is_file():
+        return []
+    return [
+        "--bind",
+        f"{quota_src}:{QUOTA_CACHE_CONTAINER_PATH}:ro",
+        "--env",
+        f"CCT_QUOTA_CACHE_PATH={QUOTA_CACHE_CONTAINER_PATH}",
+    ]

--- a/src/scitex_agent_container/runtimes/_github_token.py
+++ b/src/scitex_agent_container/runtimes/_github_token.py
@@ -1,0 +1,136 @@
+"""Resolve the GitHub token for an agent container from the fleet secret pool.
+
+WHY THIS EXISTS
+---------------
+The token lives in the operator's dotfiles secrets (``~/.bash.d/secrets``),
+which ONLY a login shell sources. sac starts agent containers without a login
+shell and, before this module, without forwarding the token — so ``gh`` inside
+the container had neither an env token nor a ``~/.config/gh`` and reported
+"not logged into any GitHub hosts".
+
+Measured on scitex-compute-04, 2026-08-09 (lengths only, values never read)::
+
+    login shell      GITHUB_TOKEN len=40   <- the secret IS present
+    non-login shell  GITHUB_TOKEN len=0    <- it disappears here
+    spec grep for GITHUB_TOKEN|GH_TOKEN    -> 0 matches
+    ~/.config/gh/                          -> empty, no hosts.yml
+    `gh` on the host                       -> command not found (it is in the SIF)
+
+The cost was concrete: three agents each lost work time to it, and two finished,
+tested fixes (PR #926, #927) had to be opened by a different session on their
+authors' behalf. "Can push but cannot open a PR" is half a delivery loop.
+
+DESIGN — deliberately the SAME shape as the Telegram bot token
+--------------------------------------------------------------
+``_cct_token_pool`` already solves exactly this problem for ``CCT_BOT_TOKEN``:
+resolve from the secret-file pool at start, warn loudly and actionably when the
+slot is missing, never write the value into a spec. This module reuses that
+pool rather than inventing a second secrets path — one place to rotate, one
+place to reason about.
+
+SECURITY
+--------
+The caller emits the resolved value as ``--env GITHUB_TOKEN=...``. That is safe
+ONLY because ``_apptainer_secret_env.redact_secret_env_to_file`` lifts
+secret-shaped pairs out of the world-readable argv into a per-agent 0600
+env-file before exec, and its predicate matches ``*_TOKEN`` — which both
+``GITHUB_TOKEN`` and ``GH_TOKEN`` satisfy. If that predicate ever narrows, this
+value would leak into ``/proc/<pid>/cmdline``; the test suite pins the
+relationship so the coupling cannot rot silently.
+
+This module NEVER logs the token value — only whether one was found, and its
+length, which is what makes a "wrong token" diagnosable without exposing it.
+"""
+
+from __future__ import annotations
+
+import logging
+
+__all__ = [
+    "GITHUB_TOKEN_VARS",
+    "github_token_env_flags",
+    "resolve_github_token",
+]
+
+logger = logging.getLogger(__name__)
+
+#: Both spellings are forwarded. ``gh`` prefers ``GH_TOKEN`` and falls back to
+#: ``GITHUB_TOKEN``; git credential helpers and most CI tooling read
+#: ``GITHUB_TOKEN``. Setting one and not the other is a common half-fix that
+#: works for one tool and mystifies the next.
+GITHUB_TOKEN_VARS = ("GITHUB_TOKEN", "GH_TOKEN")
+
+
+def resolve_github_token(pool_env: dict[str, str] | None = None) -> str | None:
+    """Return the GitHub token from the fleet secret pool, or ``None``.
+
+    ``pool_env`` is injectable for tests; by default it is the same pool the
+    Telegram bot token resolves from (``_cct_token_pool._pool_env``), which
+    honours ``SAC_SECRETS_ENVRC`` and falls back to the canonical ``$HOME``
+    pool so a cron / raw-ssh start still finds the secret files.
+
+    Returns ``None`` — never an empty string — when nothing resolves, so the
+    caller can distinguish "absent" from "present but empty". An empty value is
+    treated as absent: a defined-but-empty ``GITHUB_TOKEN`` is exactly what the
+    containers reported on 2026-08-09, and forwarding it would reproduce the
+    bug while looking like a fix.
+    """
+    if pool_env is None:
+        from ._cct_token_pool import _pool_env
+
+        try:
+            pool_env = _pool_env()
+        except Exception as exc:  # pragma: no cover - defensive
+            # A pool that cannot be read is UNKNOWN, not "no token". Say so.
+            logger.warning(
+                "github-token: could not read the secret pool (%s); "
+                "`gh` inside the container will be unauthenticated",
+                exc,
+            )
+            return None
+
+    for var in GITHUB_TOKEN_VARS:
+        value = (pool_env.get(var) or "").strip()
+        if value:
+            return value
+    return None
+
+
+def github_token_env_flags(
+    *,
+    agent_name: str,
+    pool_env: dict[str, str] | None = None,
+) -> list[str]:
+    """``--env`` flags carrying the GitHub token, or ``[]`` with a loud warning.
+
+    The warning is deliberately actionable and names the CONSEQUENCE rather
+    than just the missing variable: an agent that learns at first ``gh pr
+    create`` that it has no token has already finished the work it cannot
+    deliver.
+    """
+    token = resolve_github_token(pool_env)
+    if not token:
+        logger.warning(
+            "github-token: no GITHUB_TOKEN/GH_TOKEN in the secret pool for "
+            "agent %r. THE AGENT STARTS NORMALLY, but `gh` inside the "
+            "container will be unauthenticated, so `gh pr create` will fail "
+            "with 'not logged into any GitHub hosts' — the agent can commit "
+            "and push but cannot open a pull request. To fix: add "
+            "GITHUB_TOKEN=<token> to a secrets file listed in "
+            "SAC_SECRETS_ENVRC (the same pool CCT_BOT_TOKEN_<SLOT> uses), "
+            "then restart this agent.",
+            agent_name,
+        )
+        return []
+
+    logger.info(
+        "github-token: forwarding a %d-character token to agent %r as %s "
+        "(value redacted into the per-agent 0600 env-file before exec)",
+        len(token),
+        agent_name,
+        "/".join(GITHUB_TOKEN_VARS),
+    )
+    flags: list[str] = []
+    for var in GITHUB_TOKEN_VARS:
+        flags += ["--env", f"{var}={token}"]
+    return flags

--- a/tests/scitex_agent_container/runtimes/test__github_token.py
+++ b/tests/scitex_agent_container/runtimes/test__github_token.py
@@ -1,0 +1,147 @@
+"""Tests for GitHub-token forwarding into agent containers.
+
+The defect these guard (measured on scitex-compute-04, 2026-08-09): the token
+lives in dotfiles secrets that only a LOGIN shell sources, sac starts containers
+without one, and nothing forwarded it — so ``gh`` inside reported "not logged
+into any GitHub hosts" and no agent could open a pull request.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from scitex_agent_container.runtimes._apptainer_secret_env import is_secret_env_key
+from scitex_agent_container.runtimes._github_token import (
+    GITHUB_TOKEN_VARS,
+    github_token_env_flags,
+    resolve_github_token,
+)
+
+
+class TestResolveGithubToken:
+    def test_returns_none_when_pool_is_empty(self):
+        # Arrange
+        pool: dict[str, str] = {}
+        # Act
+        got = resolve_github_token(pool)
+        # Assert
+        assert got is None
+
+    def test_prefers_github_token_over_gh_token(self):
+        # Arrange
+        pool = {"GITHUB_TOKEN": "aaa", "GH_TOKEN": "bbb"}
+        # Act
+        got = resolve_github_token(pool)
+        # Assert
+        assert got == "aaa"
+
+    def test_falls_back_to_gh_token(self):
+        # Arrange
+        pool = {"GH_TOKEN": "bbb"}
+        # Act
+        got = resolve_github_token(pool)
+        # Assert
+        assert got == "bbb"
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t", "\n"])
+    def test_blank_token_is_absent_not_present(self, blank):
+        """A defined-but-EMPTY token is the exact state the containers were in.
+
+        Forwarding it would reproduce the bug while looking like a fix, so it
+        must be indistinguishable from absent.
+        """
+        # Arrange
+        pool = {"GITHUB_TOKEN": blank}
+        # Act
+        got = resolve_github_token(pool)
+        # Assert
+        assert got is None
+
+    def test_strips_surrounding_whitespace(self):
+        # Arrange
+        pool = {"GITHUB_TOKEN": "  ghp_x  "}
+        # Act
+        got = resolve_github_token(pool)
+        # Assert
+        assert got == "ghp_x"
+
+
+class TestGithubTokenEnvFlags:
+    def test_absent_token_yields_no_flags(self):
+        # Arrange
+        pool: dict[str, str] = {}
+        # Act
+        flags = github_token_env_flags(agent_name="a", pool_env=pool)
+        # Assert
+        assert flags == []
+
+    def test_absent_token_warning_names_the_agent(self, caplog):
+        # Arrange
+        caplog.set_level(logging.WARNING)
+        # Act
+        github_token_env_flags(agent_name="scitex-dev", pool_env={})
+        # Assert
+        assert "scitex-dev" in caplog.text
+
+    def test_absent_token_warning_names_the_consequence(self, caplog):
+        """Silence here is what let three agents each lose work time.
+
+        The warning must name what will FAIL, not just the missing variable.
+        """
+        # Arrange
+        caplog.set_level(logging.WARNING)
+        # Act
+        github_token_env_flags(agent_name="a", pool_env={})
+        # Assert
+        assert "gh pr create" in caplog.text
+
+    def test_absent_token_warning_names_the_remedy(self, caplog):
+        # Arrange
+        caplog.set_level(logging.WARNING)
+        # Act
+        github_token_env_flags(agent_name="a", pool_env={})
+        # Assert
+        assert "SAC_SECRETS_ENVRC" in caplog.text
+
+    def test_present_token_sets_both_spellings(self):
+        # Arrange
+        pool = {"GITHUB_TOKEN": "ghp_secret"}
+        # Act
+        flags = github_token_env_flags(agent_name="a", pool_env=pool)
+        # Assert
+        assert flags == [
+            "--env",
+            "GITHUB_TOKEN=ghp_secret",
+            "--env",
+            "GH_TOKEN=ghp_secret",
+        ]
+
+    def test_token_value_is_never_logged(self, caplog):
+        """The log may carry the LENGTH; it must never carry the value."""
+        # Arrange
+        caplog.set_level(logging.DEBUG)
+        # Act
+        github_token_env_flags(agent_name="a", pool_env={"GITHUB_TOKEN": "ghp_sekrit"})
+        # Assert
+        assert "ghp_sekrit" not in caplog.text
+
+
+class TestRedactionCoupling:
+    def test_every_forwarded_var_is_recognised_as_secret_shaped(self):
+        """THE SECURITY INVARIANT — do not delete this test.
+
+        The token is emitted as ``--env KEY=VALUE``, which lands in a
+        world-readable argv (a tmux ``bash -c`` pane cmd; /proc/<pid>/cmdline
+        leaks it to any local process). That is acceptable ONLY because
+        ``redact_secret_env_to_file`` lifts secret-shaped pairs into a 0600
+        env-file before exec. If its predicate ever narrows so these names stop
+        matching, the token silently starts leaking with no other symptom.
+        """
+        # Arrange
+        forwarded = list(GITHUB_TOKEN_VARS)
+        # Act
+        unrecognised = [var for var in forwarded if not is_secret_env_key(var)]
+        # Assert
+        assert unrecognised == []


### PR DESCRIPTION
## The defect

The GitHub token lives in the operator's dotfiles secrets, which **only a login shell sources**. sac starts agent containers without a login shell, and nothing forwarded the token — so `gh` inside had neither an env token nor a `~/.config/gh`, and reported *"not logged into any GitHub hosts."*

Agents could commit and push but **could not open a pull request**. That is half a delivery loop, and it needs a human every time.

Measured on scitex-compute-04, 2026-08-09 (lengths only — values never read):

| probe | result |
|---|---|
| login shell | `GITHUB_TOKEN` **len=40** — the secret is present |
| non-login shell | `GITHUB_TOKEN` **len=0** — it disappears here |
| spec grep for `GITHUB_TOKEN`/`GH_TOKEN` | **0 matches** |
| `~/.config/gh/` | empty, no `hosts.yml` |
| `gh` on the host | `command not found` — it exists only inside the SIF |

Three agents each lost work time to this, and two finished, tested fixes (#926, #927) had to be opened by a different session on their authors' behalf.

## The change

`_github_token` resolves from the **same pool as `CCT_BOT_TOKEN`** (`SAC_SECRETS_ENVRC`, with the canonical `$HOME` fallback) rather than adding a second secrets path — one place to rotate, one place to reason about. It mirrors that module's loud-warning shape:

- An absent token warns **at start**, naming what will fail (`gh pr create`) and how to fix it — instead of letting an agent discover it only after finishing work it cannot deliver.
- A **defined-but-empty** token is treated as absent. That is exactly the state the containers were in; forwarding it would reproduce the bug while looking like a fix.
- Both `GITHUB_TOKEN` and `GH_TOKEN` are set. `gh` prefers the latter, git credential helpers and most CI read the former; setting one is a half-fix that works for one tool and mystifies the next.

## Security

The value is emitted as `--env`, which is safe **only** because `redact_secret_env_to_file` lifts secret-shaped pairs out of the world-readable argv (a tmux `bash -c` pane cmd; `/proc/<pid>/cmdline` leaks it to any local process) into a per-agent 0600 env-file before exec — and its predicate matches `*_TOKEN`.

`TestRedactionCoupling` pins that relationship. If the predicate ever narrows so these names stop matching, the token would silently start leaking with no other symptom, and this test is what catches it.

The value is never logged — only its length, which keeps a *wrong* token diagnosable without exposing it.

## The extraction

`_apptainer_build_argv` was at **510 of its 512-line budget**, so the feature did not fit without genuine extraction. The quota-cache block moved verbatim to `_apptainer_quota_env`, joining the existing `_apptainer_*` env-wiring family. Behaviour unchanged; net **509**.

This is called out because "drive-by refactor in a feature PR" is usually a smell — here the line budget made it a precondition, not a preference.

## Tests

- 15 new in `test__github_token.py`.
- 109 passed / 2 skipped across `build_argv` + `secret_env` + this module.
- **Negative control:** reverting the blank-token guard fails 5 tests; restoring passes 15. The tests bite rather than passing vacuously.
- Run with `PYTHONPATH` pointed at the worktree src, so they exercise *this* branch's code and not the main checkout's.

## Not in scope

The git **push** identity is still scitex-hub's read-only deploy key, so pushes need an explicit `git@gh-ywatanabe:…` URL. That is a privilege decision for the operator (per-repo write deploy keys / a fleet machine-user key / the personal key as default) and is tracked separately in `sac-fleet-git-push-blocked-wrong-repo-readonly-deploy-key-20260809`.

Card: `sac-github-token-never-reaches-agent-containers-20260809`
