### PR TITLE
feat(runtimes): carry GITHUB_TOKEN into agent containers via to_home .env

### DIFF
--- a/src/scitex_agent_container/runtimes/_github_token.py
+++ b/src/scitex_agent_container/runtimes/_github_token.py
@@ -1,0 +1,132 @@
+"""Carry ``GITHUB_TOKEN`` from the fleet secrets pool into an agent container.
+
+WHY — the gap this closes
+-------------------------
+Measured 2026-08-09 on scitex-compute-04, end to end::
+
+    login shell      GITHUB_TOKEN len=40   <- the secret IS present and correct
+    non-login shell  GITHUB_TOKEN len=0    <- it disappears here
+    spec grep for GITHUB_TOKEN / GH_TOKEN  -> 0 matches
+    ~/.config/gh/ on the host              -> EMPTY (no hosts.yml)
+
+The token lives in the dotfiles secrets (``~/.bash.d/secrets``), which only a
+LOGIN shell sources. sac starts containers without a login shell and without
+passing the token through, so ``gh`` inside the container has neither an env
+token nor a config and reports "not logged into any GitHub hosts".
+
+The consequence is not cosmetic: on 2026-08-09 three agents finished tested
+work and NONE could open a pull request. Two finished fixes had to be opened
+by the operator's own session on their authors' behalf. "Can push, cannot open
+a PR" is only half a delivery loop, and it needs a human every single time.
+
+The secrets were NOT missing and NOT undeployed — they simply never crossed
+into the container. That distinction matters: "deploy dotfiles harder" would
+not have fixed this.
+
+Deliberately reuses the ``CCT_BOT_TOKEN`` shape rather than inventing a second
+secrets path: same pool (launching env overlaid with the ``SAC_SECRETS_ENVRC``
+secret files), same ``dest/.env`` destination, same never-fatal / always-loud
+contract, same rule that a hand-authored value wins.
+
+CONTRACT
+--------
+* The token VALUE is never logged, never put in an argv, and never written to
+  a spec. Specs are dotfiles-tracked and reach GitHub; the value comes from
+  the runtime pool only.
+* An unresolvable token WARNs naming exactly what will not work
+  (``gh pr create``) and the fixes. It NEVER fails the boot — an agent without
+  a token still does useful work, it just cannot open pull requests, and
+  discovering that at first push is what cost three agents their afternoon.
+* An existing value in ``dest/.env`` is authoritative and left untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+#: What ``gh`` actually reads. ``GH_TOKEN`` takes precedence in gh itself, but
+#: ``GITHUB_TOKEN`` is the name the fleet secrets already use, so that is the
+#: one we resolve FROM. Both are written so either lookup succeeds.
+_TOKEN_VAR = "GITHUB_TOKEN"
+_GH_ALIAS_VAR = "GH_TOKEN"
+
+
+def _logger():
+    """scitex-logging logger, imported lazily — same rationale as
+    ``_cct_token_pool._logger``: the package auto-configures handlers on
+    first import, which must not tax module import."""
+    import scitex_logging
+
+    return scitex_logging.getLogger(__name__)
+
+
+def ensure_github_token(config, dest: Path) -> None:
+    """Inject ``GITHUB_TOKEN`` into ``dest/.env`` from the fleet secrets pool.
+
+    Called from :func:`._to_home.deploy_to_home` AFTER the ``.envrc`` cascade
+    fold, so an explicit hand-authored mapping always wins — the same ordering
+    :func:`._cct_token_pool.ensure_cct_bot_token` relies on.
+
+    Unlike the Telegram token this is NOT gated on a spec opt-in. Every agent
+    that can push can, in principle, need to open a pull request, and requiring
+    each spec to opt in would reproduce the failure this fixes: the agent finds
+    out it cannot deliver only at the moment it tries.
+
+    Never raises. Never logs the token value.
+    """
+    from ._cct_token_pool import (  # local import: shared pool, one source
+        _pool_env,
+        _pool_source_label,
+        _read_env_file,
+        _write_env_file,
+    )
+
+    agent_name = getattr(config, "name", "") or ""
+    env_file = dest / ".env"
+    existing = _read_env_file(env_file) if env_file.is_file() else {}
+
+    if existing.get(_TOKEN_VAR) or existing.get(_GH_ALIAS_VAR):
+        # Hand-authored .envrc (or a prior deploy) already provided it —
+        # authoritative, exactly as for CCT_BOT_TOKEN.
+        return
+
+    pool = _pool_env()
+    value = pool.get(_TOKEN_VAR, "") or pool.get(_GH_ALIAS_VAR, "")
+    if value:
+        # Write BOTH names. `gh` prefers GH_TOKEN; scripts and hooks around the
+        # fleet read GITHUB_TOKEN. Writing one and not the other is how an
+        # agent ends up with a token that the tool it needs cannot see.
+        existing[_TOKEN_VAR] = value
+        existing[_GH_ALIAS_VAR] = value
+        _write_env_file(env_file, existing)
+        _logger().info(
+            "github: resolved %s for agent %r from the fleet secrets pool "
+            "(value not logged) -> %s; also written as %s.",
+            _TOKEN_VAR,
+            agent_name,
+            env_file,
+            _GH_ALIAS_VAR,
+        )
+        return
+
+    _logger().warning(
+        "github: no %s resolved for agent %r from the pool (%s). THE AGENT "
+        "STARTS NORMALLY — this is NOT a startup failure. What will NOT work: "
+        "`gh pr create`, `gh pr merge`, and anything else authenticating to "
+        "GitHub through gh; the agent can still commit and push over SSH. "
+        "Measured 2026-08-09: three agents each finished tested work and "
+        "discovered this only at PR time, so it is warned HERE, at start, "
+        "rather than there. To fix, do ONE of: (1) add %s=<token> to a secrets "
+        "file listed in the canonical pool (restart `sac listen` afterwards if "
+        "it provides the env), or (2) export %s via the project's .envrc. Do "
+        "NOT put the value in a spec — specs are dotfiles-tracked and reach "
+        "GitHub.",
+        _TOKEN_VAR,
+        agent_name,
+        _pool_source_label(),
+        _TOKEN_VAR,
+        _TOKEN_VAR,
+    )
+
+
+__all__ = ["ensure_github_token"]

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -63,6 +63,7 @@ from pathlib import Path
 from ..config import AgentConfig
 from ._cct_token_pool import ensure_cct_bot_token, prune_tokenless_telegrammer_mcp
 from ._envrc import fold_envrc_cascade_into_env, fold_envrc_into_env
+from ._github_token import ensure_github_token
 from ._hook_origin_manifest import write_hook_manifest
 from ._host_commands import deploy_host_claude_commands
 from ._host_skills import deploy_host_skills
@@ -311,6 +312,17 @@ def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
     # token this reads. See prune_tokenless_telegrammer_mcp (card
     # sac-omit-telegram-mcp-when-no-cct-bot-token-20260702).
     prune_tokenless_telegrammer_mcp(dest)
+    # GITHUB_TOKEN, same pool and the same ordering rationale: the fleet
+    # secrets live in ~/.bash.d/secrets, which only a LOGIN shell sources,
+    # and sac starts containers without one — so the token was present and
+    # correct on the host and simply never crossed the boundary. Measured
+    # 2026-08-09: `gh` inside every container reported "not logged into any
+    # GitHub hosts", three agents finished tested work, and NOT ONE could
+    # open a pull request. Unlike the CCT rail this is not gated on a spec
+    # opt-in: any agent that can push can need to open a PR, and an opt-in
+    # would reproduce the failure (you find out at PR time). Missing token
+    # => LOUD warning naming `gh pr create`; never fatal, value never logged.
+    ensure_github_token(config, dest)
     # settings.json CASCADE (same precedence order as .envrc): deep-merge each
     # layer's .claude/settings.json into dest, raising on a cross-layer scalar
     # conflict (ADR-0018). The walk SKIPS settings.json so this is the single

--- a/tests/scitex_agent_container/runtimes/test__github_token.py
+++ b/tests/scitex_agent_container/runtimes/test__github_token.py
@@ -1,0 +1,140 @@
+"""``GITHUB_TOKEN`` must cross into the agent container.
+
+INCIDENT 2026-08-09, scitex-compute-04. Measured end to end::
+
+    login shell      GITHUB_TOKEN len=40   <- present and correct
+    non-login shell  GITHUB_TOKEN len=0    <- gone
+    ~/.config/gh/                          -> EMPTY
+
+The fleet secrets live in ``~/.bash.d/secrets``, which only a LOGIN shell
+sources; sac starts containers without one and passed nothing through. So
+``gh`` inside every container reported "not logged into any GitHub hosts",
+three agents each finished tested work, and NOT ONE could open a pull
+request — two finished fixes had to be opened by the operator's own
+session on their authors' behalf.
+
+The secrets were never missing. They simply never crossed the boundary.
+
+No mocks (PA-306): a real ``dest/.env`` on disk, and the pool is driven
+through the real ``SAC_SECRETS_ENVRC`` seam with a real secrets file, the
+same way ``_cct_token_pool`` is exercised. Token values here are obvious
+fakes and are asserted on deliberately — they are test fixtures, not
+secrets.
+
+AAA markers, one assertion per test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.runtimes._github_token import ensure_github_token
+
+_FAKE_TOKEN = "ghp-not-a-real-token-0000000000"
+
+
+class _Config:
+    """Minimal stand-in for AgentConfig — only `name` is read."""
+
+    def __init__(self, name: str = "an-agent") -> None:
+        self.name = name
+
+
+@pytest.fixture
+def secrets_pool(tmp_path: Path):
+    """A real secrets file wired through the real SAC_SECRETS_ENVRC seam."""
+    secrets = tmp_path / "secrets"
+    secrets.write_text(f"export GITHUB_TOKEN={_FAKE_TOKEN}\n", encoding="utf-8")
+    key = "SAC_SECRETS_ENVRC"
+    saved = os.environ.get(key)
+    os.environ[key] = str(secrets)
+    try:
+        yield secrets
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+
+
+@pytest.fixture
+def empty_pool(tmp_path: Path):
+    """A resolvable but token-free secrets file — the WARN path."""
+    secrets = tmp_path / "empty-secrets"
+    secrets.write_text("# no token here\n", encoding="utf-8")
+    key = "SAC_SECRETS_ENVRC"
+    saved_envrc = os.environ.get(key)
+    saved_tokens = {
+        k: os.environ.pop(k) for k in ("GITHUB_TOKEN", "GH_TOKEN") if k in os.environ
+    }
+    os.environ[key] = str(secrets)
+    try:
+        yield secrets
+    finally:
+        if saved_envrc is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved_envrc
+        os.environ.update(saved_tokens)
+
+
+def test_token_is_written_into_the_agent_env_file(tmp_path: Path, secrets_pool):
+    # Arrange
+    dest = tmp_path / "to_home"
+    dest.mkdir()
+    # Act
+    ensure_github_token(_Config(), dest)
+    # Assert
+    assert f"GITHUB_TOKEN={_FAKE_TOKEN}" in (dest / ".env").read_text()
+
+
+def test_gh_alias_is_written_too(tmp_path: Path, secrets_pool):
+    # Arrange: gh prefers GH_TOKEN while fleet scripts read GITHUB_TOKEN.
+    # Writing one and not the other is how an agent ends up holding a token
+    # the tool it needs cannot see.
+    dest = tmp_path / "to_home"
+    dest.mkdir()
+    # Act
+    ensure_github_token(_Config(), dest)
+    # Assert
+    assert f"GH_TOKEN={_FAKE_TOKEN}" in (dest / ".env").read_text()
+
+
+def test_hand_authored_token_is_left_untouched(tmp_path: Path, secrets_pool):
+    # Arrange: an explicit .envrc mapping is authoritative, exactly as for
+    # CCT_BOT_TOKEN — the pool must never overwrite it.
+    dest = tmp_path / "to_home"
+    dest.mkdir()
+    (dest / ".env").write_text("GITHUB_TOKEN=hand-authored\n", encoding="utf-8")
+    # Act
+    ensure_github_token(_Config(), dest)
+    # Assert
+    assert "GITHUB_TOKEN=hand-authored" in (dest / ".env").read_text()
+
+
+def test_missing_token_does_not_raise(tmp_path: Path, empty_pool):
+    # Arrange: a missing token degrades PR creation only. It must NEVER fail
+    # the boot — an agent without one still does useful work.
+    dest = tmp_path / "to_home"
+    dest.mkdir()
+    # Act
+    ensure_github_token(_Config(), dest)
+    # Assert
+    assert dest.is_dir()
+
+
+def test_missing_token_writes_no_empty_value(tmp_path: Path, empty_pool):
+    # Arrange: an EMPTY GITHUB_TOKEN is worse than none — it is exactly what
+    # made this incident hard to read, because `[ -n "$VAR" ]` and "is the
+    # name defined" disagree, and env-check reported it as "set".
+    dest = tmp_path / "to_home"
+    dest.mkdir()
+    # Act
+    ensure_github_token(_Config(), dest)
+    # Assert
+    assert not (dest / ".env").is_file() or "GITHUB_TOKEN=" not in (
+        dest / ".env"
+    ).read_text()


### PR DESCRIPTION
## The defect

The GitHub token lives in the operator's dotfiles secrets, which **only a login shell sources**. sac starts agent containers without a login shell, and nothing forwarded the token — so `gh` inside had neither an env token nor a `~/.config/gh`, and reported *"not logged into any GitHub hosts."*

Agents could commit and push but **could not open a pull request**. Half a delivery loop, needing a human every time.

Measured on scitex-compute-04, 2026-08-09 (lengths only — values never read):

| probe | result |
|---|---|
| login shell | `GITHUB_TOKEN` **len=40** — the secret is present |
| non-login shell | `GITHUB_TOKEN` **len=0** — it disappears here |
| spec grep for `GITHUB_TOKEN`/`GH_TOKEN` | **0 matches** |
| `~/.config/gh/` | empty, no `hosts.yml` |
| `gh` on the host | `command not found` — it exists only inside the SIF |

Three agents each lost work time to this, and two finished fixes (#926, #927) had to be delivered by another session on their authors' behalf.

## The change

`ensure_github_token(config, dest)` injects the token into `dest/.env` from the fleet secrets pool, called from `_to_home.deploy_to_home` **after** the `.envrc` cascade fold — so a hand-authored mapping stays authoritative.

It reuses the `CCT_BOT_TOKEN` machinery rather than adding a second secrets path: same pool (launching env overlaid with the `SAC_SECRETS_ENVRC` secret files), same destination, same never-fatal / always-loud contract, value never logged, never written to a spec.

Three decisions the author called out:

1. **Not gated on a spec opt-in**, unlike the Telegram rail. Any agent that can push can need to open a PR, and an opt-in would reproduce the exact failure being fixed — you find out at PR time. A deliberate departure from the CCT precedent.
2. **Both names are written** — `GITHUB_TOKEN` and `GH_TOKEN`. `gh` prefers the latter; fleet scripts and hooks read the former. Writing one is how an agent ends up holding a token the tool it needs cannot see.
3. **An empty value is treated as absent**, with a test pinning it. An empty token is worse than none: it is what made this incident hard to read, because "the name is defined" and `[ -n "$VAR" ]` disagree, and the env-check helper reported it as *set*.

The warning now fires at agent **start**, naming what will not work (`gh pr create`, `gh pr merge`), rather than letting the agent discover it at first push.

## Why this shape over the alternative

A competing implementation (#928, now closed) forwarded the token as `--env` and relied on `redact_secret_env_to_file` lifting it out of the world-readable argv into a 0600 file. That works, but it *introduces a security coupling*: if the redaction predicate ever narrows, the token silently starts leaking into `/proc/<pid>/cmdline` with no other symptom.

This approach writes to `dest/.env` and the value **never enters argv at all**, so there is no coupling to maintain and no window to reason about. It is also the path `CCT_BOT_TOKEN` already takes, so there is one mechanism here, not two.

## Tests

5 new, all green. Runtimes suite 1691 passed.

Baselined honestly: the suite shows one failure, `test__mcp_spec_env.py::test_first_spawn_inheritance_alone_does_not_survive_the_respawn`. It is **pre-existing** — untouched `develop` gives "1 failed, 1686 passed", this branch gives "1 failed, 1691 passed" (the +5 are the new tests), same single failure on both sides. `test__sdk_common.py` errors on a missing SDK import in that venv; environmental, also present on develop.

## Not live until merged and restarted

This changes what a *future* `deploy_to_home` writes. Agents already running keep their current tokenless env until restarted.

## Provenance

Authored by the `scitex-agent-container` agent on scitex-compute-04, which pushed `8bafaa0` but cannot open a PR — the very gap this fixes. Opened from the laptop session on its behalf.

Card: `sac-github-token-never-reaches-agent-containers-20260809`
