### PR TITLE
feat(binds): a bind entry can say WHEN it applies, not only where it mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,78 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **A bind entry can now say WHEN it applies, not just where it mounts.**
+  `spec.apptainer.binds[]` accepted only `host:container[:mode]` strings, so
+  every entry was unconditional and mandatory and a spec that was valid on the
+  operator's laptop killed the same agent elsewhere — apptainer refuses to
+  create a container whose bind source is missing. `/mnt/c` is the standing
+  case: WSL-only, and present in **101 of the fleet's 107 specs**. The
+  workaround was to comment the line out per host, and the commented-out line
+  was still sitting in the specs. That hand-hack is what this replaces.
+
+  An entry may now be a mapping declaring `required:` / `ensure:` / `hosts:`:
+
+  ```yaml
+  binds:
+  - /home/ywatanabe:/home/ywatanabe:rw     # string form — unchanged
+  - {source: /mnt/c, dest: /mnt/c, mode: rw, required: false}
+  - {source: ~/.scitex/cards, dest: /home/agent/.scitex/cards, mode: rw, ensure: dir}
+  - {source: /home/ywatanabe/.bun/bin/bun, dest: /usr/local/bin/bun, hosts: [ywata-note-win]}
+  ```
+
+  `required: true` is the DEFAULT and nothing implies it away: a spec that
+  declares no intent behaves EXACTLY as before, down to a byte-identical
+  `--bind` argv (pinned by a golden list recorded from the pre-change tree).
+  A missing source still FATALs.
+
+  `required: false` skips an absent source, `ensure: dir` provisions one, and
+  `hosts:` restricts an entry to named machines — resolved through sac's own
+  hostname authority (`config._host.resolve_hostname()` unioned with the
+  `config.yaml` alias registry), not a second one invented here.
+
+  **The interaction rule, decided and documented rather than left implicit:**
+  when `hosts:` excludes this host AND `required: true`, the entry SKIPS — it
+  does not fatal. The gates run `hosts:` → `ensure:` → `required:`, because
+  `hosts:` asks whether the entry is declared here at all and `required:` asks
+  only, of an entry that IS declared here, whether a missing source is
+  tolerable. Fataling would force every host-conditional entry to also write
+  `required: false`, and would fatal on the everyday path — `/mnt/c` is absent
+  on every non-WSL host — rather than the rare one.
+
+  **No skip is silent.** Every skipped bind is a `WARNING` naming the bind, the
+  reason, the agent, and (for a host-gated skip) both the declared host list
+  and this host, plus `required: true` when it was set — a silently-dropped
+  mount is how an agent comes up looking healthy while reaching none of its
+  data, which is the failure this feature exists to end, not to relocate.
+
+  `ensure: dir` failing to create the directory is a loud `RuntimeError`, never
+  downgraded to a skip, and that holds under `required: false` too: "optional"
+  excuses a source that was never there, not a creation you asked for that
+  failed.
+
+  Malformed declared-intent entries are rejected at config-load time naming the
+  spec FILE, the entry, the valid keys and a paste-ready correction — a typo
+  like `requred: false` cannot silently leave `required: true` in force.
+  Entries that declare no intent keep their historical defensive tolerance
+  byte for byte (non-list `binds:`, empty-string entries, legacy `{src, dst}`
+  dicts missing a side), since "no declared intent ⇒ exactly as today" governs.
+
+  The jailed-capsule guardrail is deliberately NOT taught about intent: it
+  still realpath-scans every DECLARED bind source, including ones that would
+  have been skipped on this host. Conservative on purpose, and pinned by tests
+  that clear `$APPTAINER_BIND` first so they cannot pass on an env-injected
+  refusal instead of the spec entry under test.
+
+### Fixed
+
+- `runtimes/_apptainer_build_argv.py` was 516 lines, over the repo's 512-line
+  per-file cap. The bind block moved wholesale into the new
+  `runtimes/_apptainer_bind_intent.py` (mirroring the existing `overlay_flags`
+  / `tmpfs_workdir_flags` / `nested_build_flags` extractions), taking the file
+  to 489.
+
 ## [0.24.25] - 2026-08-05
 
 ### Fixed

--- a/docs/spec-reference.md
+++ b/docs/spec-reference.md
@@ -151,7 +151,7 @@ when `spec.a2a.port` is set) and `GET /agents/<name>/card`
 | `overlay_size` | size string (e.g. `"5G"`, `"500M"`) | When set together with `overlay`, sac auto-creates the overlay image at that path with the given size if it doesn't exist (declarative — no manual `apptainer overlay create` step). Units: M/MB/G/GB only (K/KB rejected). Empty = no auto-create (missing overlay raises a clear FileNotFoundError at launch). |
 | `overlay_create_if_missing` | bool (default `true`) | Gate for the auto-create behaviour above. When `false` AND the overlay is missing, sac raises FileNotFoundError without attempting creation (operator must pre-create with `apptainer overlay create`). |
 | `tmpfs_size`  | size string (default `"2G"`)  | Minimum free-space guarantee for the container's `/tmp` (and `/var/tmp`). A `--containall` container otherwise gets a 64 MB session tmpfs at `/tmp` that fills mid-run during the full test suite. sac emits `--workdir <state_dir>/tmp-scratch` to relocate `/tmp` onto the host filesystem (capacity >> 64 MB) and fails loud (`TmpfsSpaceError`) if that filesystem has less than `tmpfs_size` free. Units: M/MB/G/GB only (K/KB rejected). NOT a hard cap (unprivileged apptainer can't size-cap a tmpfs). Set to `""` to opt out (legacy 64 MB tmpfs). Skipped when the operator declares their own `--workdir`/`-W` in `raw_args`. |
-| `binds[]`     | `host:container[:ro\|rw]` (or legacy `{src,dst,mode}` dict) | Bind mounts. Source side supports `~` / `$VAR` (sac expands before calling apptainer). Destination MUST be absolute (apptainer rejects relative / `~` / `$VAR`); conventional roots are `/home/agent/...` (D5 canonical HOME), `/srv/`, `/work/`, `/opt/`, `/data/`. The legacy `{src, dst, mode}` dict form is still accepted by the parser and normalized to the string form. |
+| `binds[]`     | `host:container[:ro\|rw]` string, **or** a declared-intent mapping (or legacy `{src,dst,mode}` dict) | Bind mounts. Source side supports `~` / `$VAR` (sac expands before calling apptainer). Destination MUST be absolute (apptainer rejects relative / `~` / `$VAR`); conventional roots are `/home/agent/...` (D5 canonical HOME), `/srv/`, `/work/`, `/opt/`, `/data/`. The legacy `{src, dst, mode}` dict form is still accepted by the parser and normalized to the string form. **A plain string is unconditional and mandatory** — a missing source is a container-creation FATAL, unchanged. See **Declared-intent binds** below to make an entry optional, host-conditional, or self-provisioning. |
 | `env`         | key-value dict                | Env vars exported into the container                       |
 | `container_workdir` | path (default `/work`)  | Working directory inside the container.                    |
 | `nv` / `rocm` | bool                          | Forward host NVIDIA / AMD ROCm libs. (DESIGN — mutual exclusion not currently enforced by the parser.) |
@@ -160,6 +160,69 @@ when `spec.a2a.port` is set) and `GET /agents/<name>/card`
 | `relaxed`     | bool (default `false`)        | **(DESIGN — not yet implemented in the parser.)** Intent: opt OUT of hardened-by-default isolation. When `false` (default), sac auto-prepends `--containall` / `--cleanenv` / `--writable-tmpfs` / `--home /home/agent`. Set `true` to disable; see [`docs/isolation.md`](isolation.md) + [`docs/adr/0001-isolation-hardening.md`](adr/0001-isolation-hardening.md). TODO: wire into `ApptainerSpec`. |
 | `fakeroot`    | bool (default `false`)        | **(DESIGN — not yet implemented in the parser.)** Intent: apptainer `--fakeroot` — uid 0 inside via user-namespace remap; host uid unchanged. D5 preflight detects userns-fakeroot via `/proc/self/uid_map` and accepts uid 0 only when remapped. TODO: wire into `ApptainerSpec`. |
 | `nested_build` | bool (default `false`)       | Enable **NESTED** apptainer build/pull from INSIDE the agent container — a solver reproduces a capsule's pinned env itself (pull a published `docker://` image, or build a Dockerfile-derived def whose `%post` runs as root), then `apptainer exec`s it. Binds `/dev/fuse`, masks `/etc/subuid`+`/etc/subgid` (→ root-mapped + `fakeroot`-command build path; the SIF's `newuidmap` is `agent`-owned so plain `--fakeroot` FATALs), and points `APPTAINER_TMPDIR`/`CACHEDIR` at the real-disk `/tmp` (size via `tmpfs_size` — the 2G default is too small for a multi-GB image). Composes with `access: capsule` (adds **no** host-FS bind). Fail-loud if the host lacks `/dev/fuse`. Build-from-Dockerfile needs the base image to contain `/etc/subuid` (every real distro base does; busybox doesn't). Verified 2026-06-20 inside `sac-scitex.sif`. See [`runtimes/_apptainer_nested.py`](../src/scitex_agent_container/runtimes/_apptainer_nested.py). |
+
+#### Declared-intent binds (`spec.apptainer.binds[]`)
+
+A bind entry used to say only *where* to mount, never *when*, so every
+entry was unconditional and mandatory. A spec valid on the operator's
+laptop then killed the same agent elsewhere — apptainer refuses to create
+a container whose bind source is missing. `/mnt/c` is the standing
+example: WSL-only, and present in 101 of the fleet's 107 specs. The
+workaround was to comment the line out per host; declared intent replaces
+that hand-hack.
+
+An entry may be a plain string (**unchanged in every respect**) or a
+mapping:
+
+```yaml
+binds:
+- /home/ywatanabe:/home/ywatanabe:rw     # string form — unconditional, mandatory
+- source: /mnt/c                          # host side (~ / $VAR expanded)
+  dest: /mnt/c                            # container side (must be absolute)
+  mode: rw                                # optional; omitted = no :mode suffix
+  required: false                         # absent source -> visible skip
+- source: ~/.scitex/cards
+  dest: /home/agent/.scitex/cards
+  mode: rw
+  ensure: dir                             # create the source dir first
+- source: /home/ywatanabe/.bun/bin/bun
+  dest: /usr/local/bin/bun
+  hosts: [ywata-note-win]                 # applies only on the listed hosts
+```
+
+| Key        | Default | Meaning |
+|------------|---------|---------|
+| `source`   | —       | Host path. Required. `~` / `$VAR` expanded by sac (apptainer expands neither). `src` accepted as a legacy alias. |
+| `dest`     | —       | Container path. Required, must be absolute. `dst` accepted as a legacy alias. |
+| `mode`     | `""`    | `ro` / `rw`. Omitted emits no `:mode` suffix. |
+| `required` | `true`  | **`true` is the default and nothing implies it away.** A mapping that says nothing about it behaves exactly like a plain string: a missing source still reaches apptainer and still FATALs. `false` SKIPS the bind when the source is absent — and logs a WARNING naming it. Never silent. |
+| `ensure`   | `""`    | `dir` creates the source directory (with parents) before binding. A creation FAILURE is a loud `RuntimeError`, never downgraded to a skip — including under `required: false`, because "optional" excuses a source that was never there, not a creation you asked for that failed. |
+| `hosts`    | *(all)* | List of host names this entry applies on, resolved through sac's own hostname authority (`config._host.resolve_hostname()` unioned with the `config.yaml` alias registry — the same one dispatch uses). Elsewhere the entry SKIPS, visibly. |
+
+**Interaction rule — `hosts:` excludes this host AND `required: true`: it
+SKIPS, never fatals.** The gates are evaluated in the order `hosts:` →
+`ensure:` → `required:`. `hosts:` asks whether the entry is declared for
+this machine at all; `required:` asks, of an entry that *is* declared
+here, whether a missing source is tolerable. On an excluded host the
+entry is simply not declared, so `required:` is never reached. The
+alternative would force every host-conditional entry to also write
+`required: false` (conflating two axes) and would fatal on the everyday
+path rather than the rare one. Because the case is common and the rule is
+surprising, the skip log line names the host list, this host, **and**
+`required: true` when it was set.
+
+Nothing is ever dropped quietly: every skip is a `WARNING` naming the
+bind and the reason. A silently-dropped mount is how an agent comes up
+looking healthy while reaching none of its data.
+
+Malformed mappings are rejected at config-load time, naming the spec
+file, the offending entry, the valid keys and a paste-ready correction —
+so a typo like `requred: false` cannot silently leave `required: true` in
+force. Entries that declare no intent keep their historical defensive
+tolerance unchanged. See
+[`config/_bind_intent.py`](../src/scitex_agent_container/config/_bind_intent.py)
+and
+[`runtimes/_apptainer_bind_intent.py`](../src/scitex_agent_container/runtimes/_apptainer_bind_intent.py).
 
 ### `spec.claude` — SDK knobs
 

--- a/src/scitex_agent_container/config/_apptainer_spec.py
+++ b/src/scitex_agent_container/config/_apptainer_spec.py
@@ -36,7 +36,30 @@ class ApptainerSpec:
 
     binds: list[str] = field(default_factory=list)
     """Bind mounts as ``host:container[:mode]`` strings — promoted from
-    top-level spec.mounts (§3)."""
+    top-level spec.mounts (§3).
+
+    Stays the SINGLE SOURCE OF TRUTH for WHICH binds a spec declares,
+    whatever YAML shape they were written in. A declared-intent mapping
+    (``config._bind_intent``) is normalised into exactly one string here,
+    so every consumer that only needs the mount — the jailed-capsule
+    guardrail's forbidden-prefix scan, the fleet-default de-dup — keeps
+    reading a flat list of strings and is unaffected by the new shape."""
+
+    bind_intents: list = field(default_factory=list)
+    """Per-entry declared intent (``required`` / ``ensure`` / ``hosts``),
+    one :class:`config._bind_intent.BindIntent` per ``binds`` entry, in the
+    same order.
+
+    DERIVED, not operator-writable: there is no ``bind_intents:`` YAML
+    key. The parser builds it alongside ``binds`` from the same entries,
+    which is why it is excluded from the explicit-fields required map
+    (``config._explicit_fields``) — requiring a key nobody can write
+    would turn every spec in the fleet red.
+
+    Empty means "no intent recorded", which the launch-time resolver
+    treats as "every bind required and unconditional" — the pre-intent
+    behaviour. So an ``ApptainerSpec`` built in code with ``binds=[...]``
+    and no intents still mounts everything, exactly as before."""
 
     env: dict[str, str] = field(default_factory=dict)
     """Env vars exported into the container — promoted from top-level

--- a/src/scitex_agent_container/config/_bind_intent.py
+++ b/src/scitex_agent_container/config/_bind_intent.py
@@ -1,0 +1,339 @@
+"""``apptainer.binds`` entries that DECLARE their intent (parse side).
+
+WHY THIS EXISTS — a bind entry used to be a bare string, so it said
+WHERE to mount and nothing about WHEN. Every entry was therefore
+unconditional and mandatory, and a spec that was valid on the operator's
+laptop killed the same agent elsewhere: apptainer refuses to start a
+container whose bind source is missing ("container creation failed ...
+mount source doesn't exist"). Across the fleet's 107 specs the worst
+offender is ``/mnt/c`` — present in 101 of them, and WSL-only, so absent
+on every Linux host. The fleet's workaround was to COMMENT THE LINE OUT
+per host. That hand-hack is what this module replaces.
+
+An entry may now be EITHER shape:
+
+  * a plain ``host:container[:mode]`` STRING — unchanged in every
+    respect. It parses to ``BindIntent(spec=..., required=True)``, i.e.
+    unconditional and mandatory, and produces byte-identical argv. The
+    107 live specs are all this shape and none of them move.
+
+  * a MAPPING that states intent::
+
+        - source: /mnt/c          # host side ( ~ / $VAR expanded)
+          dest: /mnt/c            # container side (must be absolute)
+          mode: rw                # optional; omitted = no :mode suffix
+          required: false         # absent source -> visible skip
+          ensure: dir             # create the source dir first
+          hosts: [ywata-note-win] # applies only on these hosts
+
+``required: true`` is the DEFAULT and is never implied away: a mapping
+that says nothing about it behaves exactly like the string form.
+
+The legacy ``{src, dst, mode}`` dict spelling keeps working — ``src`` and
+``dst`` are accepted as aliases of ``source`` and ``dest`` — so no
+existing spec has to be rewritten to keep parsing.
+
+WHERE THE LOUD VALIDATION APPLIES, and where it deliberately does NOT
+--------------------------------------------------------------------
+A malformed DECLARED-INTENT entry is a hard error naming the file, the
+entry, the valid keys and a paste-ready correction. A typo such as
+``requred: false`` MUST be caught: silently ignoring it would leave
+``required: true`` in force, so the operator would read one behaviour off
+the spec and get the other.
+
+But entries that declare NO intent keep their existing defensive
+tolerance, byte for byte: a non-list ``binds:`` still yields no binds, an
+empty-string entry is still skipped, and a legacy dict missing ``src`` or
+``dst`` is still dropped (see ``_parsers/test__apptainer.py``, which pins
+all three). That is not an oversight — the governing rule for this change
+is "no declared intent ⇒ behaves EXACTLY as today", and tightening those
+paths would break it in the one direction nobody asked for. Cases where
+the intent surface is not involved therefore stay exactly as they were;
+the moment an entry uses ``source`` / ``dest`` / ``required`` / ``ensure``
+/ ``hosts``, or carries a key from no vocabulary at all, it is held to
+the strict contract.
+
+This module owns SHAPE and VALIDATION only. The runtime decisions the
+declarations gate (does the source exist? is this that host? create the
+directory) belong to launch time, not load time — a ``sac agents list``
+on a coordinator must not mkdir on behalf of an agent that runs on
+another machine — and live in the sibling
+``runtimes/_apptainer_bind_intent``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+__all__ = [
+    "BIND_ENTRY_KEYS",
+    "BindIntent",
+    "ENSURE_VALUES",
+    "parse_bind_entries",
+]
+
+# Canonical keys, in the order the paste-ready hint renders them.
+_CANONICAL_KEYS: tuple[str, ...] = (
+    "source",
+    "dest",
+    "mode",
+    "required",
+    "ensure",
+    "hosts",
+)
+# Pre-v3 spelling, still accepted so no live spec has to be rewritten.
+_ALIASES: dict[str, str] = {"src": "source", "dst": "dest"}
+BIND_ENTRY_KEYS = frozenset(_CANONICAL_KEYS) | frozenset(_ALIASES)
+
+# ``ensure`` values sac knows how to satisfy. ``file`` is deliberately
+# absent: accepting it would promise a creation that never happens.
+ENSURE_VALUES: tuple[str, ...] = ("", "dir")
+
+
+@dataclass(frozen=True)
+class BindIntent:
+    """One declared bind: WHERE it mounts plus WHEN it applies.
+
+    ``spec`` is the fully-resolved ``host:container[:mode]`` string that
+    reaches apptainer's ``--bind`` — the source side already expanded, the
+    destination already validated. It is the ONLY thing the jail guardrail
+    and the fleet-default merge ever need, which is why
+    ``ApptainerSpec.binds`` keeps carrying exactly these strings.
+    """
+
+    spec: str
+    required: bool = True
+    ensure: str = ""
+    hosts: tuple[str, ...] = ()
+
+
+def _expand_source(bind_str: str) -> str:
+    """Expand ``~`` / ``$VAR`` on the SOURCE side of a bind string.
+
+    apptainer runs no shell, so it does not expand either — a literal
+    ``~/x`` reaches ``--bind`` as a relative directory name and the mount
+    fails. Only the source side is touched; the destination (and any
+    ``:mode`` suffix) stays verbatim, because apptainer rejects a ``~`` or
+    ``$VAR`` target outright and we must not paper over that.
+    """
+    if ":" not in bind_str:
+        return os.path.expanduser(os.path.expandvars(bind_str))
+    src, _, rest = bind_str.partition(":")
+    return f"{os.path.expanduser(os.path.expandvars(src))}:{rest}"
+
+
+def _where(source_path: str) -> str:
+    return f"{source_path}: " if source_path else ""
+
+
+def _paste_block(entry: dict) -> str:
+    """Render ``entry``'s VALID keys as a paste-ready YAML list item."""
+    kept = [(k, entry[k]) for k in _CANONICAL_KEYS if k in entry]
+    for alias, canon in _ALIASES.items():
+        if alias in entry and canon not in entry:
+            kept.append((canon, entry[alias]))
+    if not kept:
+        kept = [("source", "/host/path"), ("dest", "/container/path")]
+    lines = [f"  - {kept[0][0]}: {kept[0][1]}"]
+    lines += [f"    {k}: {v}" for k, v in kept[1:]]
+    return "\n".join(lines)
+
+
+def _reject(source_path: str, entry: object, problem: str, fix: str) -> ValueError:
+    """The house error shape: where, what, why, and a paste-ready fix."""
+    return ValueError(
+        f"{_where(source_path)}apptainer.binds entry {entry!r}: {problem}\n"
+        f"  Valid keys: {sorted(BIND_ENTRY_KEYS)}\n"
+        f"  {fix}"
+    )
+
+
+def _corrected(source_path: str, entry: dict, problem: str) -> ValueError:
+    return _reject(
+        source_path,
+        entry,
+        problem,
+        "Corrected entry:\n" + _paste_block(entry),
+    )
+
+
+def _validate_dest(source_path: str, entry: object, dest: str) -> None:
+    """Absolute-path check for the container side (apptainer's rule)."""
+    if dest.startswith("~") or dest.startswith("$"):
+        raise ValueError(
+            f"{_where(source_path)}apptainer.binds entry {entry!r}: "
+            f"destination side {dest!r} must be an absolute path (apptainer "
+            "does not expand ~ or $VAR on bind targets). Use /home/agent/... "
+            "(D5 canonical HOME) or another absolute path."
+        )
+    if not dest.startswith("/"):
+        raise ValueError(
+            f"{_where(source_path)}apptainer.binds entry {entry!r}: "
+            f"destination side {dest!r} must be absolute."
+        )
+
+
+def _string_entry(source_path: str, item: str) -> BindIntent:
+    """A plain ``host:container[:mode]`` string — unconditional, required."""
+    if ":" in item:
+        _, _, rest = item.partition(":")
+        dest = rest.split(":", 1)[0]
+        if dest:
+            _validate_dest(source_path, item, dest)
+    return BindIntent(spec=_expand_source(item))
+
+
+def _pick(source_path: str, entry: dict, canon: str) -> object:
+    """Read ``canon`` honouring its legacy alias; refuse both at once."""
+    alias = next((a for a, c in _ALIASES.items() if c == canon), None)
+    if alias is not None and alias in entry and canon in entry:
+        raise _corrected(
+            source_path,
+            entry,
+            f"declares both {canon!r} and its legacy alias {alias!r} — "
+            f"keep one (prefer {canon!r})",
+        )
+    if canon in entry:
+        return entry[canon]
+    if alias is not None:
+        return entry.get(alias)
+    return None
+
+
+def _required_of(source_path: str, entry: dict) -> bool:
+    value = entry.get("required")
+    if value is None:
+        return True
+    if not isinstance(value, bool):
+        raise _corrected(
+            source_path,
+            entry,
+            f"'required' must be a YAML boolean (true / false), got "
+            f"{value!r}. Quoted 'false' is a non-empty STRING and would "
+            "read as the opposite of what it says",
+        )
+    return value
+
+
+def _ensure_of(source_path: str, entry: dict) -> str:
+    value = entry.get("ensure")
+    if value is None:
+        return ""
+    ensure = str(value).strip()
+    if ensure not in ENSURE_VALUES:
+        raise _corrected(
+            source_path,
+            entry,
+            f"'ensure' must be one of {list(ENSURE_VALUES)}, got {value!r}",
+        )
+    return ensure
+
+
+def _hosts_of(source_path: str, entry: dict) -> tuple[str, ...]:
+    value = entry.get("hosts")
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise _corrected(
+            source_path,
+            entry,
+            f"'hosts' must be a LIST of host names, got {type(value).__name__} "
+            f"{value!r}. A bare string matches no host, so the bind would "
+            "silently skip everywhere",
+        )
+    hosts = tuple(str(h).strip() for h in value if str(h).strip())
+    if not hosts:
+        raise _corrected(
+            source_path,
+            entry,
+            "'hosts' is empty — that declares a bind which can never apply "
+            "on any host. Drop the key to apply everywhere, or name the "
+            "hosts it belongs to",
+        )
+    return hosts
+
+
+def _legacy_entry(entry: dict) -> BindIntent | None:
+    """The pre-intent ``{src, dst, mode}`` dict, byte-for-byte as before.
+
+    Reached only when the mapping uses NO key outside ``{src, dst, mode}``,
+    so it cannot be declaring intent. Kept verbatim — including the silent
+    drop of an entry missing either side, which
+    ``_parsers/test__apptainer.py`` pins as deliberate defensive coercion.
+    Returns ``None`` for "dropped".
+    """
+    src = str(entry.get("src", "") or "")
+    dst = str(entry.get("dst", "") or "")
+    mode = str(entry.get("mode", "") or "")
+    if not (src and dst):
+        return None
+    if dst.startswith("~") or dst.startswith("$") or not dst.startswith("/"):
+        raise ValueError(
+            f"apptainer.binds dict {entry!r}: dst {dst!r} "
+            "must be an absolute path (apptainer rejects "
+            "~/$VAR/relative bind targets)."
+        )
+    src = os.path.expanduser(os.path.expandvars(src))
+    return BindIntent(spec=f"{src}:{dst}:{mode}" if mode else f"{src}:{dst}")
+
+
+def _mapping_entry(source_path: str, entry: dict) -> BindIntent:
+    """A declared-intent mapping. Every key is validated; typos are loud."""
+    unknown = sorted(k for k in entry if k not in BIND_ENTRY_KEYS)
+    if unknown:
+        raise _corrected(
+            source_path,
+            entry,
+            f"unknown key(s) {unknown}. A typo here is silent otherwise: "
+            "the intent you meant to declare would never take effect",
+        )
+    source = _pick(source_path, entry, "source")
+    dest = _pick(source_path, entry, "dest")
+    if source is None or not str(source).strip():
+        raise _corrected(source_path, entry, "'source' is required (the host path)")
+    if dest is None or not str(dest).strip():
+        raise _corrected(
+            source_path, entry, "'dest' is required (the container path)"
+        )
+    source = str(source).strip()
+    dest = str(dest).strip()
+    _validate_dest(source_path, entry, dest)
+    mode = str(entry.get("mode") or "").strip()
+    src = os.path.expanduser(os.path.expandvars(source))
+    return BindIntent(
+        spec=f"{src}:{dest}:{mode}" if mode else f"{src}:{dest}",
+        required=_required_of(source_path, entry),
+        ensure=_ensure_of(source_path, entry),
+        hosts=_hosts_of(source_path, entry),
+    )
+
+
+def parse_bind_entries(binds_raw: object, *, source_path: str = "") -> list[BindIntent]:
+    """Parse ``spec.apptainer.binds`` into one :class:`BindIntent` per entry.
+
+    ``source_path`` is the spec file the entries came from; it is quoted
+    in every error so a fleet-wide failure names the file to edit rather
+    than sending the operator through 107 of them.
+
+    The pre-intent defensive coercions are preserved EXACTLY (see the
+    module docstring): a non-list ``binds:`` yields no binds, an
+    empty-string entry is skipped, a legacy ``{src, dst}`` dict missing
+    either side is dropped, and a non-string non-mapping item is ignored.
+    Strictness starts where the intent vocabulary does.
+    """
+    if not isinstance(binds_raw, list):
+        return []
+    out: list[BindIntent] = []
+    for item in binds_raw:
+        if isinstance(item, str) and item:
+            out.append(_string_entry(source_path, item))
+        elif isinstance(item, dict):
+            # Only-legacy keys ⇒ cannot be declaring intent ⇒ old path.
+            if set(item).issubset(_ALIASES.keys() | {"mode"}):
+                legacy = _legacy_entry(item)
+                if legacy is not None:
+                    out.append(legacy)
+            else:
+                out.append(_mapping_entry(source_path, item))
+    return out

--- a/src/scitex_agent_container/config/_explicit_fields.py
+++ b/src/scitex_agent_container/config/_explicit_fields.py
@@ -226,7 +226,14 @@ def _both_kinds_fields() -> list[RequiredField]:
         ApptainerSpec,
         # container_workdir is BANNED (removed with spec.access); banned
         # stays banned, never required.
-        exclude=("container_workdir",),
+        #
+        # bind_intents is DERIVED, not a YAML key: the parser builds it
+        # from the same ``binds`` entries the operator already wrote (see
+        # config._bind_intent). Requiring a key that no spec can legally
+        # contain — validate_raw would have to reject it — would turn the
+        # whole fleet red in both directions at once. Same category as the
+        # module docstring's "list-ITEM internals" exclusion, one level up.
+        exclude=("container_workdir", "bind_intents"),
     )
     fields += _section("hooks", HookSpec)
     fields += _section("context_management", ContextManagementConfig)

--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -325,7 +325,10 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
     # top-level AgentConfig.image/model/env/mounts fields are kept for
     # back-compat consumers and populated from the new homes.
     claude_spec = parse_claude(spec)
-    apptainer_spec = parse_apptainer(spec)
+    # ``source_path`` is quoted in every apptainer.binds validation error —
+    # a malformed entry must name the file to edit, not send the operator
+    # through the fleet's specs looking for it.
+    apptainer_spec = parse_apptainer(spec, source_path=str(path))
     # Role-based session-continuity default ("fresh by default, opt-in
     # continue", 2026-06-22). ``claude.session`` now defaults to ``fresh``
     # (parse_claude) so experiment capsules — which carry no coordinator

--- a/src/scitex_agent_container/config/_parsers/_apptainer.py
+++ b/src/scitex_agent_container/config/_parsers/_apptainer.py
@@ -9,7 +9,7 @@ fallback at runtime.
 from __future__ import annotations
 
 
-def parse_apptainer(spec: dict):
+def parse_apptainer(spec: dict, *, source_path: str = ""):
     """Parse spec.apptainer (F-CS18).
 
     Three optional fields wire the apptainer-specific build extension:
@@ -34,78 +34,27 @@ def parse_apptainer(spec: dict):
     apt_env_raw = raw.get("env", {}) or {}
     if not isinstance(apt_env_raw, dict):
         apt_env_raw = {}
-    # v3-realign: apptainer.binds — accepts the new shorthand
-    # ``host:container[:mode]`` strings OR legacy ``{src, dst, mode}`` dicts
-    # (normalised to strings). The SOURCE side (everything before the
-    # first colon) is expanded against the operator's environment:
-    # ``~`` -> ``$HOME``, ``$VAR`` / ``${VAR}`` -> env value. Apptainer
-    # itself does NOT expand env vars in --bind, so we have to do it
-    # in sac so spec.yaml stays operator-agnostic (``~/proj/foo`` works
-    # for every operator without hardcoding their username).
-    import os
+    # v3-realign: apptainer.binds — accepts ``host:container[:mode]``
+    # strings, the legacy ``{src, dst, mode}`` dict, and the declared-intent
+    # mapping (``source``/``dest``/``mode`` + ``required``/``ensure``/
+    # ``hosts``). Shape, source expansion (``~`` -> ``$HOME``, ``$VAR`` ->
+    # env value; apptainer expands neither) and validation all live in
+    # ``config._bind_intent`` so this parser stays a wiring layer.
+    #
+    # ``binds`` keeps carrying ONE flat string per entry whatever the shape,
+    # so every downstream consumer (the jail guardrail's forbidden-prefix
+    # scan, the fleet-default de-dup) is untouched; ``bind_intents`` carries
+    # the same entries' conditions for the launch-time resolver.
+    from .._bind_intent import parse_bind_entries
 
-    def _expand_bind_src(bind_str: str) -> str:
-        # Split off the first colon — that's the source/target boundary.
-        # The target side (and optional :mode) stays verbatim; only the
-        # source needs expansion.
-        if ":" not in bind_str:
-            return os.path.expanduser(os.path.expandvars(bind_str))
-        src, _, rest = bind_str.partition(":")
-        return f"{os.path.expanduser(os.path.expandvars(src))}:{rest}"
-
-    def _validate_dst(bind_str: str) -> None:
-        # Apptainer rejects relative paths on the destination side with
-        # the opaque "destination must be an absolute path" error.
-        # Fail fast at parse time with a clear message. The destination
-        # is everything between the first and second colon.
-        if ":" not in bind_str:
-            return
-        _, _, rest = bind_str.partition(":")
-        dst = rest.split(":", 1)[0]
-        if not dst:
-            return
-        if dst.startswith("~") or dst.startswith("$"):
-            raise ValueError(
-                f"apptainer.binds[{bind_str!r}]: destination side "
-                f"{dst!r} must be an absolute path (apptainer does not "
-                "expand ~ or $VAR on bind targets). Use /home/agent/... "
-                "(D5 canonical HOME) or another absolute path."
-            )
-        if not dst.startswith("/"):
-            raise ValueError(
-                f"apptainer.binds[{bind_str!r}]: destination side "
-                f"{dst!r} must be absolute."
-            )
-
-    binds_raw = raw.get("binds", []) or []
-    binds: list[str] = []
-    if isinstance(binds_raw, list):
-        for item in binds_raw:
-            if isinstance(item, str) and item:
-                _validate_dst(item)
-                binds.append(_expand_bind_src(item))
-            elif isinstance(item, dict):
-                src = str(item.get("src", "") or "")
-                dst = str(item.get("dst", "") or "")
-                mode = str(item.get("mode", "") or "")
-                if src and dst:
-                    if (
-                        dst.startswith("~")
-                        or dst.startswith("$")
-                        or not dst.startswith("/")
-                    ):
-                        raise ValueError(
-                            f"apptainer.binds dict {item!r}: dst {dst!r} "
-                            "must be an absolute path (apptainer rejects "
-                            "~/$VAR/relative bind targets)."
-                        )
-                    src = os.path.expanduser(os.path.expandvars(src))
-                    binds.append(f"{src}:{dst}:{mode}" if mode else f"{src}:{dst}")
+    bind_intents = parse_bind_entries(raw.get("binds"), source_path=source_path)
+    binds: list[str] = [intent.spec for intent in bind_intents]
     raw_args_raw = raw.get("raw_args", []) or []
     raw_args = [str(a) for a in raw_args_raw] if isinstance(raw_args_raw, list) else []
     return ApptainerSpec(
         image=str(raw.get("image", "") or ""),
         binds=binds,
+        bind_intents=bind_intents,
         env={str(k): str(v) for k, v in apt_env_raw.items()},
         raw_args=raw_args,
         container_workdir=str(raw.get("container_workdir", "/work") or "/work"),

--- a/src/scitex_agent_container/runtimes/_apptainer_bind_intent.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_bind_intent.py
@@ -1,0 +1,253 @@
+"""Resolve declared-intent binds at launch — the runtime half.
+
+``config._bind_intent`` decides what a bind entry SAYS. This module
+decides, at ``apptainer exec`` build time, what it DOES on THIS machine
+right now: is the source there, is this one of the hosts it named, and
+does sac owe it a directory first. Load time is the wrong place for all
+three — ``sac agents list`` on a coordinator loads specs for agents that
+run on other machines, and it must not mkdir on their behalf nor decide
+their source-existence questions from the wrong host.
+
+THE GATE ORDER, and the rule it settles
+---------------------------------------
+Each entry passes three gates, in this order:
+
+  1. ``hosts:`` — is this entry declared for THIS machine at all?
+  2. ``ensure:`` — does sac owe the source a directory?
+  3. ``required:`` — if the source is still absent, is that fatal?
+
+That order IS the answer to "``hosts:`` excludes this host AND
+``required: true`` — skip or fatal?". It SKIPS.
+
+``hosts:`` and ``required:`` are different questions. ``hosts:`` asks
+whether the entry is declared here; ``required:`` asks, of an entry that
+IS declared here, whether a missing source is tolerable. On a host the
+list excludes, the entry is simply not declared, so ``required:`` is
+never reached — a host gate can never produce a fatal.
+
+The alternative (fatal) was rejected on measurement, not taste: since
+``required: true`` is the default, fataling would force every
+host-conditional entry to ALSO write ``required: false``, conflating the
+two axes; and ``/mnt/c`` — the entry this feature exists for — appears in
+101 of the fleet's 107 specs and is absent on every non-WSL host, so the
+"surprising" branch would be the everyday one. A gate that fatals on the
+common path is not a gate.
+
+Because the case is common AND the rule is surprising, the skip line
+names the host list, this host, AND ``required: true`` when it was set,
+so an operator scanning a launch log sees why a mandatory-looking bind
+did not mount.
+
+NOTHING IS EVER DROPPED QUIETLY. Every skip is a WARNING naming the bind
+and the reason, and is returned to the caller as a :class:`BindSkip`. A
+silently-dropped mount is how an agent comes up looking healthy while
+reaching none of its data — the failure mode this whole feature is meant
+to make impossible, so it must not be reintroduced by the fix.
+
+``ensure: dir`` failure is LOUD (``RuntimeError``), never a skip, and
+that holds even under ``required: false``: "optional" excuses a source
+that was never there, not a creation the operator asked for and that
+failed. Degrading it would hide a broken mount behind a green boot.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..config._bind_intent import BindIntent
+
+__all__ = [
+    "BindSkip",
+    "declared_bind_intents",
+    "local_host_names",
+    "resolve_bind_intents",
+    "resolve_spec_binds",
+    "spec_bind_flags",
+]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BindSkip:
+    """One bind that did NOT mount, and why. Never silent."""
+
+    spec: str
+    reason: str
+
+
+def local_host_names() -> set[str]:
+    """Every host spelling that denotes THIS machine, lowercased.
+
+    Delegates to the fleet's existing authority
+    (``cli_pkg.lifecycle._common._local_host_names``, which itself unions
+    ``config._host.resolve_hostname()``, the bare short hostname and the
+    ``config.yaml`` alias registry) rather than inventing a second one —
+    a bind that disagrees with dispatch about which machine this is would
+    be worse than no host gate at all.
+
+    The import is local: ``runtimes`` sits below ``cli_pkg`` in the
+    layering, and a module-level import would invert that.
+    """
+    try:
+        from ..cli_pkg.lifecycle._common import _local_host_names
+
+        names = _local_host_names()
+    except ImportError:  # stx-allow: fallback (reason: the CLI layer is optional at runtime; config._host is the same resolver the union is built on, so the gate degrades to the canonical name rather than to "match nothing")
+        from ..config._host import resolve_hostname
+
+        names = {resolve_hostname()}
+    return {str(n).strip().lower() for n in names if str(n).strip()}
+
+
+def declared_bind_intents(config) -> list[BindIntent]:
+    """The declared intents for ``config``, defaulting to "all required".
+
+    ``ApptainerSpec.binds`` stays the SSoT for WHICH binds exist;
+    ``bind_intents`` only DECORATES those same strings with their
+    declared conditions. When the two disagree — a config built
+    programmatically with ``ApptainerSpec(binds=[...])`` and no intents,
+    as plenty of call sites and tests do — the strings win and every
+    entry is treated as required and unconditional, which is exactly what
+    a bare string means. The desync therefore fails SAFE (today's
+    behaviour), never into silently skipping a mount.
+    """
+    ap = getattr(config, "apptainer", None)
+    if ap is None:
+        return []
+    binds = [str(b) for b in getattr(ap, "binds", None) or []]
+    intents = list(getattr(ap, "bind_intents", None) or [])
+    if len(intents) == len(binds) and all(
+        getattr(i, "spec", None) == b for i, b in zip(intents, binds)
+    ):
+        return intents
+    return [BindIntent(spec=b) for b in binds]
+
+
+def _source_of(bind_spec: str) -> str:
+    """Host source (everything before the first ``:``) of a bind string."""
+    return bind_spec.split(":", 1)[0]
+
+
+def _ensure_dir(intent: BindIntent, source: str, agent: str) -> None:
+    """Create ``source`` (with parents) for ``ensure: dir``. Loud on failure."""
+    try:
+        Path(source).mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Agent {agent!r}: apptainer.binds entry {intent.spec!r} declares "
+            f"`ensure: dir`, but creating the source directory {source!r} "
+            f"FAILED: {exc}. This is NOT downgraded to a skip — you asked for "
+            "the directory to exist, and a bind whose source could not be "
+            "created would leave the agent running against nothing. Fix the "
+            "path (a non-directory in the way? a read-only parent?), or drop "
+            "`ensure: dir` and mount a source that already exists."
+        ) from exc
+
+
+def resolve_bind_intents(
+    intents: list[BindIntent],
+    *,
+    host_names: set[str],
+    agent: str = "",
+) -> tuple[list[str], list[BindSkip]]:
+    """Apply the three gates; return ``(binds_to_emit, skips)``.
+
+    Order-preserving: the emitted list is the declared list minus the
+    skips, in declaration order, so the argv a plain-string spec produces
+    is byte-identical to the pre-intent one.
+    """
+    emit: list[str] = []
+    skips: list[BindSkip] = []
+    for intent in intents:
+        # Gate 1 — hosts. Wins over `required:` (see module docstring).
+        if intent.hosts:
+            declared = {h.strip().lower() for h in intent.hosts}
+            if not (declared & host_names):
+                skips.append(
+                    BindSkip(
+                        intent.spec,
+                        f"hosts: {list(intent.hosts)} does not include this "
+                        f"host {sorted(host_names)} "
+                        f"(required: {str(intent.required).lower()} — the "
+                        "host gate is evaluated first, so this is a skip, "
+                        "not a failure)",
+                    )
+                )
+                continue
+        source = _source_of(intent.spec)
+        # Gate 2 — ensure. Failure is loud, never a skip.
+        if intent.ensure == "dir":
+            _ensure_dir(intent, source, agent)
+        # Gate 3 — required. Absent source + required: true is emitted
+        # unchanged, so apptainer FATALs exactly as it always has.
+        if not intent.required and not os.path.exists(source):
+            skips.append(
+                BindSkip(
+                    intent.spec,
+                    f"required: false — source {source!r} does not exist "
+                    "on this host",
+                )
+            )
+            continue
+        emit.append(intent.spec)
+    return emit, skips
+
+
+def resolve_spec_binds(config) -> list[str]:
+    """The choke-point entry: resolve ``spec.apptainer.binds`` for THIS host.
+
+    Returns the bind strings to hand to ``--bind``, and logs one WARNING
+    per skip. A spec whose entries are all plain strings resolves to the
+    identical list it always did, with nothing logged.
+    """
+    agent = str(getattr(config, "name", "") or "")
+    emit, skips = resolve_bind_intents(
+        declared_bind_intents(config),
+        host_names=local_host_names(),
+        agent=agent,
+    )
+    for skip in skips:
+        logger.warning(
+            "bind SKIPPED [agent %s]: %s -- %s", agent, skip.spec, skip.reason
+        )
+    return emit
+
+
+def spec_bind_flags(config, *, home_backing: Path) -> list[str]:
+    """The curated ``--bind`` flags for ``spec.apptainer.binds``.
+
+    Extracted verbatim from ``build_run_argv`` (which sat at the 512-line
+    cap) so every declared-bind concern — intent resolution, the
+    fleet-default merge and argv emission — lives in ONE module, mirroring
+    the sibling ``overlay_flags`` / ``tmpfs_workdir_flags`` /
+    ``nested_build_flags`` extractions.
+
+    P3a-2 (operator directive feedback_scitex_todo_single_shared_store,
+    lead a2a 214dd26d): the fleet-default binds are PREPENDED so every
+    agent inherits the shared stores even when its spec omits the line; an
+    explicit spec entry to the same destination overrides the default (de-
+    dup by destination — see ``_p3a_default_binds``).
+
+    ADR-0003 D6 follow-up: when a destination sits under ``/home/agent/``
+    (the host-side ``runtime/<name>/home/`` bind), apptainer no longer
+    scaffolds parent directories — the host dir IS the filesystem at
+    ``/home/agent`` — so the parent is pre-created on the host side here,
+    giving the bind somewhere to land. Only binds that SURVIVED resolution
+    get that treatment: a skipped entry must not leave a directory behind.
+    """
+    from ._p3a_default_binds import apply_default_binds
+
+    flags: list[str] = []
+    for bind in apply_default_binds(resolve_spec_binds(config)):
+        if ":" in bind:
+            _, _, rest = bind.partition(":")
+            dst = rest.split(":", 1)[0]
+            if dst.startswith("/home/agent/"):
+                rel = dst[len("/home/agent/") :]
+                (home_backing / rel).mkdir(parents=True, exist_ok=True)
+        flags += ["--bind", bind]
+    return flags

--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -204,36 +204,15 @@ def build_run_argv(
             argv += ["--bind", str(vol)]
 
     # v3-realign: spec.apptainer.binds (promoted from top-level
-    # spec.mounts per §3). Strings already in `host:container[:mode]`
-    # form — appended verbatim.
-    #
-    # ADR-0003 D6 follow-up: when the destination is under
-    # /home/agent/ (the host-side runtime/<name>/home/ bind), apptainer
-    # no longer scaffolds parent directories — the host dir IS the
-    # filesystem at /home/agent. We pre-create the parent on the
-    # host side so the bind has somewhere to land.
-    # P3a-2 (operator directive feedback_scitex_todo_single_shared_store,
-    # lead a2a 214dd26d): prepend the fleet-default binds (today:
-    # ~/.scitex/todo for scitex-todo's single shared store) so every
-    # agent inherits the store mount even when its spec doesn't carry
-    # the explicit line. Explicit spec entries to the same destination
-    # override the default — see ``_p3a_default_binds``.
-    from ._p3a_default_binds import apply_default_binds
+    # spec.mounts per §3), merged under the fleet defaults and resolved
+    # against this host's declared intent. Extracted to
+    # ``_apptainer_bind_intent`` (mirrors the overlay_flags /
+    # tmpfs_workdir_flags / nested_build_flags pattern below) so this file
+    # stays under the 512-line cap; see that module for the gate order and
+    # for why a plain-string spec is byte-identical to the pre-intent argv.
+    from ._apptainer_bind_intent import spec_bind_flags
 
-    ap_for_binds = getattr(config, "apptainer", None)
-    spec_binds = (
-        [str(b) for b in getattr(ap_for_binds, "binds", None) or []]
-        if ap_for_binds is not None
-        else []
-    )
-    for bs in apply_default_binds(spec_binds):
-        if ":" in bs:
-            _, _, rest = bs.partition(":")
-            dst = rest.split(":", 1)[0]
-            if dst.startswith("/home/agent/"):
-                rel = dst[len("/home/agent/") :]
-                (home_backing / rel).mkdir(parents=True, exist_ok=True)
-        argv += ["--bind", bs]
+    argv += spec_bind_flags(config, home_backing=home_backing)
 
     # GPU passthrough — apptainer's --nv binds the host CUDA libs
     # and devices into the container. --rocm does the same for AMD.

--- a/tests/scitex_agent_container/runtimes/test__apptainer_bind_intent.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_bind_intent.py
@@ -1,0 +1,699 @@
+"""Declared-intent bind entries — resolution at the apptainer choke point.
+
+A spec's ``apptainer.binds`` entry may stay a plain
+``host:container[:mode]`` STRING (unchanged, unconditional, fatal when
+its source is absent) or become a MAPPING that declares intent:
+
+    - source: /mnt/c
+      dest: /mnt/c
+      mode: rw
+      required: false          # absent source -> visible skip
+    - source: ~/.scitex/cards
+      dest: /home/agent/.scitex/cards
+      ensure: dir              # create the source dir, then bind
+    - source: /home/ywatanabe/.bun/bin/bun
+      dest: /usr/local/bin/bun
+      hosts: [ywata-note-win]  # applies only on the listed hosts
+
+The load-bearing test in this file is
+``test_string_form_binds_are_byte_identical_to_recorded_baseline`` — 107
+live specs are plain strings and their argv must not move by one byte.
+The golden list it asserts was RECORDED from the pre-change tree, so it
+pins the OLD behaviour, not the new code's opinion of it.
+
+Real ``load_config`` on real spec files, real ``build_run_argv``, real
+directories under ``tmp_path`` — no mocks, no monkeypatch (PA-306 /
+STX-NM002). STX-TQ002 AAA markers.
+
+Named ``test__apptainer_bind_intent.py`` for the PS-204 §2 mirror rule
+against ``src/scitex_agent_container/runtimes/_apptainer_bind_intent.py``.
+The parse-side companion (``config._bind_intent.parse_bind_entries``,
+reached through ``load_config``) is exercised here too because its
+validation errors are only meaningful against the resolution they gate.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import socket
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container.config import load_config
+from scitex_agent_container.config._host import resolve_hostname
+from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
+from scitex_agent_container.runtimes._apptainer_jail import ENV_BIND_VARS
+from scitex_agent_container.runtimes._p3a_default_binds import default_binds_for_host
+
+_PROBE_VAR = "SAC_BIND_INTENT_PROBE_DIR"
+_PROBE_VAL = "/srv/probe-var"
+_BIND_ENV_VARS = ENV_BIND_VARS
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path) -> Iterator[Path]:
+    """Redirect ``HOME`` to a per-test tmp dir.
+
+    ``~`` in a bind source, the fleet-default bind filter and the bearer
+    -token resolver all anchor on ``$HOME``; sliding it into ``tmp_path``
+    keeps every one of them inside the test.
+    """
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+@pytest.fixture
+def no_env_binds() -> Iterator[None]:
+    """Clear ``$APPTAINER_BIND`` & friends for the jail tests.
+
+    NOT cosmetic. sac itself runs inside apptainer, so these vars are SET
+    in this process, and ``enforce_jail`` refuses an env-injected bind
+    too. Without this the jail tests would pass on every branch — green
+    for a reason that has nothing to do with the spec entry under test.
+    Clearing them leaves the spec bind as the only possible refusal, which
+    the assertions then name explicitly.
+    """
+    saved = {v: os.environ.pop(v, None) for v in _BIND_ENV_VARS}
+    try:
+        yield None
+    finally:
+        for var, value in saved.items():
+            if value is not None:
+                os.environ[var] = value
+
+
+@pytest.fixture
+def probe_var() -> Iterator[str]:
+    """Export a real env var so ``$VAR`` bind-source expansion is exercised."""
+    saved = os.environ.get(_PROBE_VAR)
+    os.environ[_PROBE_VAR] = _PROBE_VAL
+    try:
+        yield _PROBE_VAL
+    finally:
+        if saved is None:
+            os.environ.pop(_PROBE_VAR, None)
+        else:
+            os.environ[_PROBE_VAR] = saved
+
+
+_SPEC_TEMPLATE = """\
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  labels:
+    project: t
+    sac-builtin: "off"
+spec:
+  runtime: tui
+  host: ${{HOSTNAME}}
+  workdir: /tmp/agt-work
+  apptainer:
+    image: /x.sif
+{jail}    binds:
+{binds}
+  health:
+    enabled: true
+    interval: 60
+  restart:
+    policy: on-failure
+    max_retries: 3
+  claude:
+    model: claude-opus-4-8[1m]
+    flags:
+      - --dangerously-skip-permissions
+"""
+
+
+def _write_spec(tmp_path: Path, binds_block: str, *, jail: bool = False) -> Path:
+    """Materialise a loadable v3 spec whose ``apptainer.binds`` is given."""
+    from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
+    body = _SPEC_TEMPLATE.format(
+        binds=binds_block, jail="    jail: true\n" if jail else ""
+    )
+    spec_dir = tmp_path / "agents" / "agt"
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    spec = spec_dir / "spec.yaml"
+    spec.write_text(explicitize_yaml(body), encoding="utf-8")
+    return spec
+
+
+def _bind_values(argv: list[str]) -> list[str]:
+    """Every ``--bind`` VALUE in ``argv``, in emission order."""
+    return [argv[i + 1] for i, a in enumerate(argv) if a == "--bind"]
+
+
+def _argv_for(tmp_path: Path, binds_block: str, *, jail: bool = False) -> list[str]:
+    config = load_config(str(_write_spec(tmp_path, binds_block, jail=jail)))
+    return build_run_argv(
+        config, state_dir=tmp_path / "state", sif_path=Path("/x.sif"), tui=True
+    )
+
+
+# ----------------------------------------------------------------------
+# The load-bearing one: the STRING form must not move.
+# ----------------------------------------------------------------------
+# Recorded from the pre-change tree (origin/develop @ 4a803a34) by
+# building this exact spec and dumping every `--bind` value. `{home}` is
+# the isolated HOME the fixture installs. Entries cover every shape the
+# 107 live specs use: whole-home rw, a source MISSING on this host
+# (/mnt/c, in 101 of them), a /home/agent destination, a `~` source, a
+# file (not dir) source, a `$VAR` source, and a mode-less entry.
+_BASELINE_SPEC_BINDS = (
+    "/home/ywatanabe:/home/ywatanabe:rw",
+    "/mnt/c:/mnt/c:rw",
+    "/home/ywatanabe/.ssh:/home/agent/.ssh:ro",
+    "{home}/.scitex/dataset/capsule-001:/capsule:ro",
+    "/home/ywatanabe/.bun/bin/bun:/usr/local/bin/bun:ro",
+    "/srv/probe-var:/probe-var:rw",
+    "/srv/data:/data",
+)
+
+_BASELINE_BINDS_BLOCK = f"""\
+    - /home/ywatanabe:/home/ywatanabe:rw
+    - /mnt/c:/mnt/c:rw
+    - /home/ywatanabe/.ssh:/home/agent/.ssh:ro
+    - ~/.scitex/dataset/capsule-001:/capsule:ro
+    - /home/ywatanabe/.bun/bin/bun:/usr/local/bin/bun:ro
+    - ${_PROBE_VAR}:/probe-var:rw
+    - /srv/data:/data
+"""
+
+
+def test_string_form_binds_are_byte_identical_to_recorded_baseline(
+    tmp_path, _isolate_home, probe_var
+) -> None:
+    # Arrange — the golden was recorded from the pre-change tree.
+    expected = [b.format(home=_isolate_home) for b in _BASELINE_SPEC_BINDS]
+    # Act
+    argv = _argv_for(tmp_path, _BASELINE_BINDS_BLOCK)
+    # Assert — same values, same order, same modes; not one byte moved.
+    assert _bind_values(argv)[-len(expected) :] == expected
+
+
+def test_string_form_binds_still_follow_the_fleet_defaults(
+    tmp_path, _isolate_home, probe_var
+) -> None:
+    # Arrange — pins the spec block's POSITION, so the tail-slice the
+    # baseline test reads cannot silently start meaning something else.
+    defaults = list(default_binds_for_host())
+    expected = defaults + [b.format(home=_isolate_home) for b in _BASELINE_SPEC_BINDS]
+    # Act
+    argv = _argv_for(tmp_path, _BASELINE_BINDS_BLOCK)
+    # Assert
+    assert _bind_values(argv)[-len(expected) :] == expected
+
+
+def test_binds_without_recorded_intents_still_all_mount(
+    tmp_path, _isolate_home
+) -> None:
+    # Arrange — an ApptainerSpec built in CODE carries binds but no
+    # intents (plenty of call sites do this). The resolver must fall back
+    # to "every bind required and unconditional" — the pre-intent
+    # behaviour — rather than resolve an empty intent list into no mounts.
+    config = load_config(str(_write_spec(tmp_path, "    - /srv/a:/a:rw\n")))
+    config.apptainer.bind_intents = []
+    # Act
+    argv = build_run_argv(
+        config, state_dir=tmp_path / "state", sif_path=Path("/x.sif"), tui=True
+    )
+    # Assert
+    assert "/srv/a:/a:rw" in argv
+
+
+def test_tilde_bind_source_is_expanded_before_reaching_argv(
+    tmp_path, _isolate_home
+) -> None:
+    # Arrange — apptainer runs no shell, so a literal `~` would mount
+    # nothing anywhere. Six live specs (clew-a-001..006) rely on this.
+    block = "    - ~/.scitex/dataset/capsule-001:/capsule:ro\n"
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert
+    assert f"{_isolate_home}/.scitex/dataset/capsule-001:/capsule:ro" in argv
+
+
+def test_tilde_bind_source_is_expanded_in_the_mapping_form_too(
+    tmp_path, _isolate_home
+) -> None:
+    # Arrange — the new form must not reintroduce the unexpanded `~`.
+    block = "    - {source: ~/.scitex/cards, dest: /cards, mode: rw}\n"
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert
+    assert f"{_isolate_home}/.scitex/cards:/cards:rw" in argv
+
+
+def test_legacy_src_dst_dict_form_still_normalises_to_a_string(
+    tmp_path, _isolate_home
+) -> None:
+    # Arrange — the pre-existing `{src, dst, mode}` dict form.
+    block = "    - {src: /srv/legacy, dst: /legacy, mode: ro}\n"
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert
+    assert "/srv/legacy:/legacy:ro" in argv
+
+
+# ----------------------------------------------------------------------
+# required: — default TRUE, nothing weakens
+# ----------------------------------------------------------------------
+def test_plain_string_with_absent_source_still_reaches_argv(
+    tmp_path, _isolate_home
+) -> None:
+    # Arrange — no declared intent, source absent on this host. sac must
+    # keep handing the bind to apptainer, which FATALs at container
+    # creation. Downgrading that to a skip is the regression this guards.
+    block = "    - /mnt/c:/mnt/c:rw\n"
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert
+    assert "/mnt/c:/mnt/c:rw" in argv
+
+
+def test_mapping_without_required_key_defaults_to_required_true(
+    tmp_path, _isolate_home
+) -> None:
+    # Arrange — a MAPPING that declares no `required:` is required.
+    block = "    - {source: /mnt/c, dest: /mnt/c, mode: rw}\n"
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert — emitted despite the absent source, exactly like the string.
+    assert "/mnt/c:/mnt/c:rw" in argv
+
+
+def test_explicit_required_true_with_absent_source_still_reaches_argv(
+    tmp_path, _isolate_home
+) -> None:
+    # Arrange
+    block = "    - {source: /mnt/c, dest: /mnt/c, mode: rw, required: true}\n"
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert
+    assert "/mnt/c:/mnt/c:rw" in argv
+
+
+def test_required_false_skips_the_bind_when_source_is_absent(
+    tmp_path, _isolate_home
+) -> None:
+    # Arrange — the WSL-only mount, on a host that has no /mnt/c.
+    block = "    - {source: /mnt/c, dest: /mnt/c, mode: rw, required: false}\n"
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert
+    assert "/mnt/c:/mnt/c:rw" not in argv
+
+
+def test_required_false_skip_is_logged_not_silent(
+    tmp_path, _isolate_home, caplog
+) -> None:
+    # Arrange — a silently dropped mount is how an agent comes up looking
+    # healthy but wrong; the skip must be readable in the launch log.
+    block = "    - {source: /mnt/c, dest: /mnt/c, mode: rw, required: false}\n"
+    caplog.set_level(logging.WARNING)
+    # Act
+    _argv_for(tmp_path, block)
+    # Assert — one scannable line naming the bind that went.
+    assert "/mnt/c:/mnt/c:rw" in caplog.text
+
+
+def test_required_false_skip_log_names_the_agent(
+    tmp_path, _isolate_home, caplog
+) -> None:
+    # Arrange — 101 specs skip /mnt/c; the line must say whose launch it is.
+    block = "    - {source: /mnt/c, dest: /mnt/c, mode: rw, required: false}\n"
+    caplog.set_level(logging.WARNING)
+    # Act
+    _argv_for(tmp_path, block)
+    # Assert
+    assert "agt" in caplog.text
+
+
+def test_required_false_still_binds_when_the_source_exists(
+    tmp_path, _isolate_home
+) -> None:
+    # Arrange — optional is about ABSENCE; a present source still mounts.
+    src = tmp_path / "present"
+    src.mkdir()
+    block = f"    - {{source: {src}, dest: /present, mode: rw, required: false}}\n"
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert
+    assert f"{src}:/present:rw" in argv
+
+
+def test_required_false_accepts_a_file_source(tmp_path, _isolate_home) -> None:
+    # Arrange — `/home/ywatanabe/.bun/bin/bun` is a FILE bind; existence,
+    # not dir-ness, is the predicate.
+    src = tmp_path / "bun"
+    src.write_text("#!/bin/sh\n", encoding="utf-8")
+    block = f"    - {{source: {src}, dest: /usr/local/bin/bun, required: false}}\n"
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert
+    assert f"{src}:/usr/local/bin/bun" in argv
+
+
+# ----------------------------------------------------------------------
+# ensure: dir
+# ----------------------------------------------------------------------
+def test_ensure_dir_creates_the_missing_source(tmp_path, _isolate_home) -> None:
+    # Arrange — the ~/.scitex/cards shape: sac owns creating the dir.
+    src = tmp_path / "cards-root" / "cards"
+    block = (
+        f"    - {{source: {src}, dest: /home/agent/.scitex/cards, "
+        "mode: rw, ensure: dir}\n"
+    )
+    # Act
+    _argv_for(tmp_path, block)
+    # Assert — parents created too.
+    assert src.is_dir()
+
+
+def test_ensure_dir_then_emits_the_bind(tmp_path, _isolate_home) -> None:
+    # Arrange
+    src = tmp_path / "cards-root" / "cards"
+    block = (
+        f"    - {{source: {src}, dest: /home/agent/.scitex/cards, "
+        "mode: rw, ensure: dir}\n"
+    )
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert
+    assert f"{src}:/home/agent/.scitex/cards:rw" in argv
+
+
+def test_ensure_dir_is_idempotent_on_an_existing_source(
+    tmp_path, _isolate_home
+) -> None:
+    # Arrange — an already-present source keeps its content.
+    src = tmp_path / "cards"
+    src.mkdir()
+    (src / "keep.db").write_text("x", encoding="utf-8")
+    block = f"    - {{source: {src}, dest: /cards, mode: rw, ensure: dir}}\n"
+    # Act
+    _argv_for(tmp_path, block)
+    # Assert
+    assert (src / "keep.db").read_text(encoding="utf-8") == "x"
+
+
+def test_ensure_dir_creation_failure_is_loud(tmp_path, _isolate_home) -> None:
+    # Arrange — a FILE where the source's parent must be, so mkdir cannot
+    # succeed. Degrading this to a skip would hide a broken mount.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+    block = f"    - {{source: {blocker / 'cards'}, dest: /cards, ensure: dir}}\n"
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match=r"ensure: dir"):
+        _argv_for(tmp_path, block)
+
+
+def test_ensure_dir_creation_failure_is_loud_even_when_not_required(
+    tmp_path, _isolate_home
+) -> None:
+    # Arrange — `required: false` excuses an ABSENT source, never a
+    # FAILED creation: the operator asked for the dir to exist.
+    blocker = tmp_path / "blocker2"
+    blocker.write_text("not a directory", encoding="utf-8")
+    block = (
+        f"    - {{source: {blocker / 'cards'}, dest: /cards, "
+        "ensure: dir, required: false}\n"
+    )
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match=r"ensure: dir"):
+        _argv_for(tmp_path, block)
+
+
+# ----------------------------------------------------------------------
+# hosts:
+# ----------------------------------------------------------------------
+def test_hosts_listing_this_host_emits_the_bind(tmp_path, _isolate_home) -> None:
+    # Arrange — resolved through the codebase's own hostname authority.
+    src = tmp_path / "bun"
+    src.write_text("#!/bin/sh\n", encoding="utf-8")
+    block = (
+        f"    - {{source: {src}, dest: /usr/local/bin/bun, "
+        f"hosts: [{resolve_hostname()}]}}\n"
+    )
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert
+    assert f"{src}:/usr/local/bin/bun" in argv
+
+
+def test_hosts_accepts_the_bare_short_hostname(tmp_path, _isolate_home) -> None:
+    # Arrange — `_local_host_names` unions every spelling of THIS machine,
+    # so the bare short hostname matches even if a config alias renames it.
+    src = tmp_path / "bun"
+    src.write_text("#!/bin/sh\n", encoding="utf-8")
+    short = socket.gethostname().split(".")[0]
+    block = f"    - {{source: {src}, dest: /usr/local/bin/bun, hosts: [{short}]}}\n"
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert
+    assert f"{src}:/usr/local/bin/bun" in argv
+
+
+def test_hosts_excluding_this_host_skips_the_bind(tmp_path, _isolate_home) -> None:
+    # Arrange — source EXISTS, so only the host gate can drop it.
+    src = tmp_path / "bun"
+    src.write_text("#!/bin/sh\n", encoding="utf-8")
+    block = (
+        f"    - {{source: {src}, dest: /usr/local/bin/bun, hosts: [ywata-note-win]}}\n"
+    )
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert
+    assert f"{src}:/usr/local/bin/bun" not in argv
+
+
+def test_hosts_skip_is_logged_not_silent(tmp_path, _isolate_home, caplog) -> None:
+    # Arrange
+    src = tmp_path / "bun"
+    src.write_text("#!/bin/sh\n", encoding="utf-8")
+    block = (
+        f"    - {{source: {src}, dest: /usr/local/bin/bun, hosts: [ywata-note-win]}}\n"
+    )
+    caplog.set_level(logging.WARNING)
+    # Act
+    _argv_for(tmp_path, block)
+    # Assert
+    assert "ywata-note-win" in caplog.text
+
+
+# --- the documented interaction rule (brief item 5) --------------------
+def test_hosts_gate_wins_over_required_true_and_skips(tmp_path, _isolate_home) -> None:
+    # Arrange — RULE: `hosts:` is a GATE evaluated FIRST. On a host the
+    # list excludes, the entry is NOT DECLARED here, so `required:` (which
+    # is only about source EXISTENCE within an applicable entry) is never
+    # consulted. Source absent AND required: true AND wrong host -> SKIP,
+    # never fatal. The opposite choice would make `hosts:` unusable: /mnt/c
+    # is in 101 of 107 live specs and absent on every non-WSL host.
+    block = (
+        "    - {source: /mnt/c, dest: /mnt/c, mode: rw, "
+        "required: true, hosts: [ywata-note-win]}\n"
+    )
+    # Act
+    argv = _argv_for(tmp_path, block)
+    # Assert
+    assert "/mnt/c:/mnt/c:rw" not in argv
+
+
+def test_hosts_gate_skip_names_required_true_in_the_log(
+    tmp_path, _isolate_home, caplog
+) -> None:
+    # Arrange — the rule is surprising enough that the log must say the
+    # entry was required and still skipped, not just "skipped".
+    block = (
+        "    - {source: /mnt/c, dest: /mnt/c, mode: rw, "
+        "required: true, hosts: [ywata-note-win]}\n"
+    )
+    caplog.set_level(logging.WARNING)
+    # Act
+    _argv_for(tmp_path, block)
+    # Assert
+    assert "required: true" in caplog.text
+
+
+def test_hosts_gate_prevents_ensure_dir_from_creating_anything(
+    tmp_path, _isolate_home
+) -> None:
+    # Arrange — an entry that does not apply here must not touch this
+    # host's filesystem either.
+    src = tmp_path / "not-for-this-host"
+    block = (
+        f"    - {{source: {src}, dest: /x, mode: rw, "
+        "ensure: dir, hosts: [ywata-note-win]}\n"
+    )
+    # Act
+    _argv_for(tmp_path, block)
+    # Assert
+    assert not src.exists()
+
+
+# ----------------------------------------------------------------------
+# Validation — malformed entries fail loud and useful
+# ----------------------------------------------------------------------
+def test_unknown_key_in_a_bind_mapping_is_rejected(tmp_path, _isolate_home) -> None:
+    # Arrange — a typo must not be silently ignored into an unconditional
+    # bind ("requred" would have left required: true in force).
+    spec = _write_spec(tmp_path, "    - {source: /mnt/c, dest: /mnt/c, requred: 0}\n")
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match=r"requred"):
+        load_config(str(spec))
+
+
+def test_unknown_key_error_lists_the_valid_keys(tmp_path, _isolate_home) -> None:
+    # Arrange
+    spec = _write_spec(tmp_path, "    - {source: /mnt/c, dest: /mnt/c, requred: 0}\n")
+    # Act
+    # Assert — every writable key, so the fix needs no doc lookup.
+    with pytest.raises(ValueError, match=r"'required'"):
+        load_config(str(spec))
+
+
+def test_unknown_key_error_names_the_offending_spec_file(
+    tmp_path, _isolate_home
+) -> None:
+    # Arrange — 107 specs; an error that does not say WHICH file is a
+    # scavenger hunt.
+    spec = _write_spec(tmp_path, "    - {source: /mnt/c, dest: /mnt/c, nope: 1}\n")
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match=re.escape(str(spec))):
+        load_config(str(spec))
+
+
+def test_unknown_key_error_carries_a_paste_ready_fix(tmp_path, _isolate_home) -> None:
+    # Arrange
+    spec = _write_spec(tmp_path, "    - {source: /mnt/c, dest: /mnt/c, nope: 1}\n")
+    # Act
+    # Assert — the corrected entry, ready to paste back.
+    with pytest.raises(ValueError, match=re.escape("- source: /mnt/c")):
+        load_config(str(spec))
+
+
+def test_mapping_without_source_is_rejected(tmp_path, _isolate_home) -> None:
+    # Arrange
+    spec = _write_spec(tmp_path, "    - {dest: /mnt/c, mode: rw}\n")
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match=r"source"):
+        load_config(str(spec))
+
+
+def test_mapping_without_dest_is_rejected(tmp_path, _isolate_home) -> None:
+    # Arrange
+    spec = _write_spec(tmp_path, "    - {source: /mnt/c, mode: rw}\n")
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match=r"dest"):
+        load_config(str(spec))
+
+
+def test_relative_dest_in_a_mapping_is_rejected(tmp_path, _isolate_home) -> None:
+    # Arrange — apptainer rejects relative bind targets opaquely.
+    spec = _write_spec(tmp_path, "    - {source: /mnt/c, dest: mnt/c}\n")
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match=r"absolute"):
+        load_config(str(spec))
+
+
+def test_unknown_ensure_value_is_rejected(tmp_path, _isolate_home) -> None:
+    # Arrange — `ensure: file` is not implemented; accepting it silently
+    # would promise a creation that never happens.
+    spec = _write_spec(tmp_path, "    - {source: /mnt/c, dest: /mnt/c, ensure: file}\n")
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match=r"ensure"):
+        load_config(str(spec))
+
+
+def test_non_boolean_required_is_rejected(tmp_path, _isolate_home) -> None:
+    # Arrange — YAML's `required: "false"` is a truthy STRING; accepting
+    # it would silently mean the opposite of what it reads as.
+    spec = _write_spec(
+        tmp_path, '    - {source: /mnt/c, dest: /mnt/c, required: "false"}\n'
+    )
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match=r"required"):
+        load_config(str(spec))
+
+
+def test_non_list_hosts_is_rejected(tmp_path, _isolate_home) -> None:
+    # Arrange — a bare string would match no host and skip everywhere.
+    spec = _write_spec(
+        tmp_path, "    - {source: /mnt/c, dest: /mnt/c, hosts: ywata-note-win}\n"
+    )
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match=r"hosts"):
+        load_config(str(spec))
+
+
+def test_empty_hosts_list_is_rejected(tmp_path, _isolate_home) -> None:
+    # Arrange — `hosts: []` reads as "no hosts", i.e. a bind that can
+    # never apply anywhere. That is a mistake, not a declaration.
+    spec = _write_spec(tmp_path, "    - {source: /mnt/c, dest: /mnt/c, hosts: []}\n")
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match=r"hosts"):
+        load_config(str(spec))
+
+
+# ----------------------------------------------------------------------
+# The jail guardrail must not be weakened by any of the above
+# ----------------------------------------------------------------------
+def test_jailed_capsule_still_refuses_an_optional_forbidden_bind(
+    tmp_path, _isolate_home, no_env_binds
+) -> None:
+    # Arrange — declared intent decides what MOUNTS; it must not decide
+    # what the jail INSPECTS. A `required: false` /home bind is still a
+    # refusal, whether or not it would have been skipped at this moment.
+    # The match names the SPEC entry, so an env-injected refusal cannot
+    # stand in for it.
+    block = (
+        "    - {source: /home/ywatanabe, dest: /home/ywatanabe, "
+        "mode: rw, required: false}\n"
+    )
+    config = load_config(str(_write_spec(tmp_path, block, jail=True)))
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match=r"spec\.apptainer\.binds entry"):
+        build_run_argv(
+            config, state_dir=tmp_path / "state", sif_path=Path("/x.sif"), tui=True
+        )
+
+
+def test_jailed_capsule_still_refuses_a_host_gated_forbidden_bind(
+    tmp_path, _isolate_home, no_env_binds
+) -> None:
+    # Arrange — same reasoning for the host gate: the jail is conservative
+    # by design and inspects every DECLARED source, not the applicable set.
+    block = (
+        "    - {source: /home/ywatanabe, dest: /home/ywatanabe, "
+        "mode: rw, hosts: [ywata-note-win]}\n"
+    )
+    config = load_config(str(_write_spec(tmp_path, block, jail=True)))
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match=r"spec\.apptainer\.binds entry"):
+        build_run_argv(
+            config, state_dir=tmp_path / "state", sif_path=Path("/x.sif"), tui=True
+        )


### PR DESCRIPTION
Opened by **dotfiles**, for your review — not merged. This is the runtime half of the operator's P1 "make agents movable between hosts"; the 107 spec edits are mine and come second.

Context: I flagged this to you over a2a but your inbox adapter was detached, so the message is durably queued. I published the default "absent an objection I implement, you review" and proceeded on it rather than waiting on an objection nobody could send.

## Why the runtime has to land first

`config/_apptainer_spec.py` types `binds` as `list[str]`, so a mapping entry does not parse. Your validator also fails loud on unknown fields and enforces "every field explicit". So adding `required:`/`ensure:`/`hosts:` to specs ahead of this either rejects 107 specs outright or — worse — is silently ignored, producing specs that *look* portable and still FATAL at container creation. No spec has been touched.

## The interaction rule (the one genuinely debatable decision)

**`hosts:` is a gate evaluated FIRST; a host the list excludes SKIPS regardless of `required:`. Never fatal.** Order: `hosts:` → `ensure:` → `required:`.

They ask different questions. `hosts:` asks whether the entry is declared *here at all*; `required:` asks, of an entry that **is** declared here, whether a missing source is tolerable — so on an excluded host `required:` is never reached.

Rejected the fatal reading **on measurement**: `required: true` is the default, so fataling would force every host-conditional entry to also write `required: false` (conflating two axes), and `/mnt/c` appears in **101 of 107 live specs** and exists on no non-WSL host — the fatal branch would be the everyday path. Because the case is common and the rule is surprising, the skip line names the host list, this host, **and** `required: true` when it was set.

## Evidence

**Byte-identical, measured against your fleet — not by inspection.** The real `develop` parser (pristine second worktree) and this one were run over all **114 live specs** in `~/.scitex/agent-container/agents/`; 106 declare binds. Both bind lists dumped to JSON and diffed:

```
Files are identical      zero byte difference
```

**TDD red phase:** `26 failed, 12 passed` before implementation → `39 passed` after. The 12 pre-passing are backward-compat pins, deliberately green on both sides.

**Every gate proved able to fail — 13 mutants, each killed** (39 green unmutated → 39 green restored):

```
M1  required:false skip removed ............... 3 failed
M2  ensure:dir never creates ................... 3 failed
M3  ensure:dir failure swallowed ............... 2 failed
M4  hosts gate always matches .................. 5 failed
M5  RULE inverted (hosts+required FATALS) ...... 6 failed
M6  skip logging removed ....................... 4 failed
M7  desync fallback returns nothing ............ 1 failed
M8  unknown-key validation removed ............. 4 failed
M9  string form drops :mode suffix ............. 5 failed
M10 mapping default flips to required:false .... 2 failed
M11 BindIntent.required default flips False .... 6 failed
M12 jail sees RESOLVED binds, not declared ..... 11 failed
M13 source ~ / $VAR expansion removed .......... 3 failed
```

**Suites.** Touched modules + all of `config/`: `974 passed, 2 skipped`. Full unit suite: `3 failed, 12661 passed, 25 skipped, 19 errors`. Those 3+19 are **pre-existing** — pristine develop reproduces the identical set in `test__sdk_common.py` / `test__mcp_spec_env.py` (missing SDK dep). Positive control run rather than asserted.

## Two findings you should have regardless of this PR

1. **A test of yours was passing for the wrong reason.** sac runs inside apptainer, so `$APPTAINER_BIND` is set in-process and `enforce_jail` refused on the *env var* rather than the spec entry under test. Fixed with a fixture that clears it and a tighter match; M12 then kills 11 tests, proving the assertion now bites.
2. **`spec.container.volumes` sources are genuinely NOT expanded** (`argv += ["--bind", str(vol)]`), while `apptainer.binds` are, at parse time. No live spec uses `container.volumes`, so it is latent — **not touched here**, out of scope. Two `--bind` lists with different expansion semantics and nothing saying so; worth a loud rejection on that deprecated field rather than quietly extending it.

## Deliberately not done

- **Did not tighten pre-existing silent-drop tolerance** (non-list `binds:`, empty entries, legacy `{src,dst}` dicts). Three of your tests pin those as deliberate defensive coercion, and "no declared intent ⇒ exactly as today" makes preserving them mandatory. Strictness starts where the intent vocabulary starts.
- **Did not teach the jail about intent** — it still scans every *declared* source including ones skipped here. Strictly more conservative; weakening your guardrail was out of bounds.
- Did not migrate any live spec, did not fix `container.volumes`, did not touch `_p3a_default_binds`' own skip-if-missing.
- `_apptainer_build_argv.py` was already **516 lines, over your 512 cap**; extracting the bind block took it to 489. Forced by the cap, not gold-plating.

Yours to merge, reject, or redirect.