### PR TITLE
fix(host): `host:` documented a fallback chain that nothing implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,58 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`host:` documented a fallback chain that nothing implemented.**
+  `HostsSpec.host` has said "list: priority order; first available host wins
+  (fallback chain)" since v3 shipped. Every site that reduced the list took
+  `host[0]` and never asked whether that host was usable, so a chain degraded
+  exactly as well as a string: not at all. Measured across all five reduction
+  sites — `_lifecycle/_verdict_remote.py`, `cli_pkg/lifecycle/_common.py`,
+  `_start_single.py`, `_host_routing.py`, `_dispatch.py` — not one contained a
+  liveness or reachability check.
+
+  On 2026-08-09 specs reverted to a single pinned host, sac ssh-dispatched
+  every lifecycle verb to it, the hop answered `Permission denied (publickey)`,
+  and twelve agents went down. The documented mechanism for degrading instead
+  was sitting inert in the type.
+
+  `cli_pkg/lifecycle/_host_chain.py` is now the ONE place a `spec.host` chain
+  is reduced, and all five sites route through it. A list is walked in
+  priority order and the first candidate not positively REJECTED wins: a local
+  entry wins immediately (we are that machine — an ssh hop to self is never
+  rendered), a remote entry wins if the reachability probe does not say no, and
+  a chain in which every candidate was rejected raises rather than silently
+  starting locally on the wrong machine. The refusal names every candidate and
+  its own reason, because "down" and "mistyped" have different fixes.
+
+  **A plain string `host: <name>` is NEVER probed and behaves byte-identically
+  to before.** It has nothing to fall back to, so a probe could only convert a
+  working dispatch into a refusal — a pure regression. Pinned by test, oracle
+  and all.
+
+  Reachability is three-valued (`reachable` / `unreachable` / `unknown`) and
+  the third value is never folded into either pole, which is this codebase's
+  most-shipped bug class. Only EVIDENCE rejects a host: a probe that answered
+  no, or a name that routes nowhere. "I could not check" — no oracle supplied,
+  a probe that could not run, an oracle that raised — rejects nothing and
+  leaves the operator's priority order standing, which is also what makes the
+  no-oracle call sites (listings, preflights) byte-identical to the old
+  `host[0]`.
+
+  The probe is an injected `(host) -> verdict` callable, matching the
+  `peers` / `local_names` seam `classify_dispatch_host` already uses, so the
+  resolver stays pure and no test touches the network. The production oracle is
+  one bounded ssh round-trip rendered by `build_ssh_argv` — the same primitive
+  the dispatch itself uses, so the probe cannot answer about a different route
+  than the one taken — memoized per verb, and only ever built for a LIST.
+
+  Two further consequences of asking the whole chain instead of its head:
+  `_resolve_singleton_skip` now checks liveness on EVERY bound host (asking
+  only the head reported "not live", released the pin, and started a SECOND
+  copy beside one already running down-chain), and the `--resume` preflight no
+  longer calls a placement remote when the chain names this machine.
+
 ## [0.24.25] - 2026-08-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ versioning follows [SemVer](https://semver.org/).
   `HostsSpec.host` has said "list: priority order; first available host wins
   (fallback chain)" since v3 shipped. Every site that reduced the list took
   `host[0]` and never asked whether that host was usable, so a chain degraded
-  exactly as well as a string: not at all. Measured across all five reduction
+  exactly as well as a string: not at all. Measured across all six reduction
   sites — `_lifecycle/_verdict_remote.py`, `cli_pkg/lifecycle/_common.py`,
-  `_start_single.py`, `_host_routing.py`, `_dispatch.py` — not one contained a
-  liveness or reachability check.
+  `_start_single.py`, `_host_routing.py`, `_dispatch.py` and `_attach.py` —
+  not one contained a liveness or reachability check.
 
   On 2026-08-09 specs reverted to a single pinned host, sac ssh-dispatched
   every lifecycle verb to it, the hop answered `Permission denied (publickey)`,
@@ -23,7 +23,10 @@ versioning follows [SemVer](https://semver.org/).
   was sitting inert in the type.
 
   `cli_pkg/lifecycle/_host_chain.py` is now the ONE place a `spec.host` chain
-  is reduced, and all five sites route through it. A list is walked in
+  is reduced, and all six sites route through it — including `_attach.py`,
+  whose docstring already promised it agreed with `start` about where an agent
+  lives and would otherwise have opened a session on a different machine than
+  the one the agent was launched on. A list is walked in
   priority order and the first candidate not positively REJECTED wins: a local
   entry wins immediately (we are that machine — an ssh hop to self is never
   rendered), a remote entry wins if the reachability probe does not say no, and

--- a/src/scitex_agent_container/_lifecycle/_verdict_remote.py
+++ b/src/scitex_agent_container/_lifecycle/_verdict_remote.py
@@ -37,32 +37,38 @@ __all__ = [
 def _remote_peer_for_config(config: Any) -> str | None:
     """Return the peer name if the agent's ``spec.host`` is a remote peer.
 
-    Uses the SAME ``classify_dispatch_host`` resolver ``sac agents start`` and
-    ``sac agents attach`` route through, so "remote" means one thing across
-    the whole control plane. Best-effort — any resolution failure returns
-    ``None`` and the caller falls back to the ordinary (local) process probe.
-    Imports are LAZY to avoid a ``cli_pkg`` -> ``_lifecycle`` import cycle.
+    Uses the SAME chain resolver ``sac agents start`` and ``sac agents attach``
+    route through, so "remote" means one thing across the whole control plane
+    — including for a FALLBACK CHAIN, whose head is no longer assumed: a chain
+    led by a typo now resolves to the next usable entry rather than reporting
+    "not remote" and probing the wrong (local) tmux.
+
+    Deliberately passes NO reachability oracle. This runs once per agent per
+    listing, and an ssh probe here would double the cost of every
+    ``sac agents list`` to answer a question the caller is about to answer
+    anyway by ssh-probing the peer's tmux. Without an oracle the walk is pure
+    and its answer is the historical head-of-chain, minus the typo bug.
+
+    Best-effort — any resolution failure returns ``None`` and the caller falls
+    back to the ordinary (local) process probe. Imports are LAZY to avoid a
+    ``cli_pkg`` -> ``_lifecycle`` import cycle.
     """
     try:
-        from ..cli_pkg.lifecycle._common import (
-            _local_host_names,
-            classify_dispatch_host,
-        )
+        from ..cli_pkg.lifecycle._common import _local_host_names
+        from ..cli_pkg.lifecycle._host_chain import resolve_host_chain
         from ..config._host import resolve_hostname
 
-        spec = config.hosts_spec
-        host = spec.host
-        target = host if isinstance(host, str) else (host[0] if host else None)
-        if not target:
+        host = config.hosts_spec.host
+        if not host:
             return None
         from .._state.host_config import load as _load_host_config
 
         current = resolve_hostname()
         peers = _load_host_config().peers
-        kind, peer = classify_dispatch_host(
-            target, current, peers, local_names=_local_host_names(current)
+        route = resolve_host_chain(
+            host, current, peers, local_names=_local_host_names(current)
         )
-        return peer if kind == "remote" else None
+        return route.peer
     except Exception:  # stx-allow: fallback (unresolvable host -> treat as local; the local probe still runs)
         return None
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_attach.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_attach.py
@@ -54,9 +54,19 @@ def _classify_agent_host(name: str) -> tuple[str, str | None]:
     """Return ``(kind, peer)`` for the agent's ``spec.host``.
 
     ``kind`` is ``"local"`` / ``"remote"`` / ``"unknown"`` per
-    :func:`._common.classify_dispatch_host` — the SAME resolver
+    :func:`._host_chain.resolve_host_chain` — the SAME reducer
     ``sac agents start`` uses, so attach and start agree on where an agent
-    lives. Best-effort: an unresolvable spec (moved / deleted) degrades to
+    lives. That agreement is the point of routing through the shared
+    resolver rather than re-deriving a target here: once start began walking
+    a FALLBACK CHAIN, a head-only reduction in attach would send the operator
+    to a different machine than the one the agent was launched on.
+
+    Deliberately passes NO reachability oracle. Attach is interactive and
+    already about to open an ssh session that will report its own failure far
+    better than a pre-probe would; without an oracle the walk is pure and
+    answers the historical head-of-chain, minus the unroutable-head bug.
+
+    Best-effort: an unresolvable spec (moved / deleted) degrades to
     ``("local", None)`` so attach still tries the local tmux, preserving the
     historic single-host behaviour.
     """
@@ -65,18 +75,21 @@ def _classify_agent_host(name: str) -> tuple[str, str | None]:
         from ...config import load_config
         from ...config._host import resolve_hostname
         from ...config._resolve import resolve_with_prefix
-        from ._common import _local_host_names, classify_dispatch_host
+        from ._common import _local_host_names
+        from ._host_chain import UNROUTABLE, resolve_host_chain
 
         config = load_config(resolve_with_prefix(name))
         bound = config.hosts_spec.host
-        target = bound if isinstance(bound, str) else (bound[0] if bound else None)
-        if not target:
+        if not bound:
             return ("local", None)
         current = resolve_hostname()
         peers = _load_host_config().peers
-        return classify_dispatch_host(
-            target, current, peers, local_names=_local_host_names(current)
+        route = resolve_host_chain(
+            bound, current, peers, local_names=_local_host_names(current)
         )
+        if route.kind == UNROUTABLE:
+            return ("unknown", None)
+        return (route.kind, route.peer)
     except Exception:  # stx-allow: fallback (unresolved spec/config → local attach)
         return ("local", None)
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_common.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_common.py
@@ -146,27 +146,38 @@ def _local_host_names(current_host: str | None = None) -> set[str]:
     return {n for n in names if n}
 
 
-def _bound_host(config: AgentConfig) -> str | None:
-    """Return the spec-bound preferred host for a singleton config.
+def _bound_hosts(config: AgentConfig) -> list[str]:
+    """Return EVERY host a singleton config is bound to, in priority order.
 
-    Mirrors :func:`_singleton_skip_reason`'s head-of-chain selection —
-    the v3 ``spec.host`` (str or first element of list) wins, then the
-    v2 ``scheduling.preferred_host`` fallback. Returns None when the
-    config is multi-instance or unpinned (no skip would fire and no
-    liveness check is meaningful).
+    The v3 ``spec.host`` chain wins (a string is a one-entry chain), then the
+    v2 ``scheduling.preferred_host`` fallback. Empty when the config is
+    multi-instance or unpinned — no skip would fire, so no liveness check is
+    meaningful.
+
+    Plural on purpose. :func:`_resolve_singleton_skip` asks "is this agent
+    already running on the host it is bound to?", and for a fallback chain the
+    honest question is "on ANY host it is bound to" — the whole point of the
+    chain is that the agent may legitimately be on entry 2. Asking only about
+    the head answers "no", releases the pin, and starts a SECOND copy beside
+    the one already running down-chain.
     """
     spec = config.hosts_spec
     if spec.hosts:
-        return None
-    host = spec.host
-    if host:
-        if isinstance(host, str):
-            return host or None
-        return host[0] if host else None
+        return []
+    if spec.host:
+        from ._host_chain import chain_hosts
+
+        return chain_hosts(spec.host)
     sched = config.scheduling
     if sched.mode != "singleton":
-        return None
-    return sched.preferred_host or None
+        return []
+    return [sched.preferred_host] if sched.preferred_host else []
+
+
+def _bound_host(config: AgentConfig) -> str | None:
+    """Head of :func:`_bound_hosts` — the single highest-priority pin."""
+    hosts = _bound_hosts(config)
+    return hosts[0] if hosts else None
 
 
 def _registry_active_on(name: str, host: str) -> bool:
@@ -217,7 +228,8 @@ def _resolve_singleton_skip(
       2. The singleton check itself yields no skip (host matches, or
          multi-instance config).
       3. The singleton check WOULD fire, but the liveness oracle reports
-         no active instance row on the bound host — the spec-host pin
+         no active instance row on ANY bound host (the whole ``host:``
+         chain, not just its head) — the spec-host pin
          is stale. The lead's bm025 repro (clew pinned to a dead prior
          host with no live row + ``pam_slurm_adopt`` rejecting any ssh
          to it) hung clew because the skip kept deferring to a host
@@ -243,15 +255,16 @@ def _resolve_singleton_skip(
     reason = _singleton_skip_reason(config, hostname)
     if reason is None:
         return None
-    bound = _bound_host(config)
-    if bound is None:
+    bound = _bound_hosts(config)
+    if not bound:
         # No explicit pin → no liveness check can apply; preserve
         # behaviour.
         return reason
     oracle = liveness_oracle if liveness_oracle is not None else _registry_active_on
-    if not oracle(config.name, bound):
+    if not any(oracle(config.name, host) for host in bound):
         # Spec says "should be on X" but the registry has no live row
-        # on X. Skipping would leave the agent unlaunched anywhere —
+        # on X — nor, for a fallback chain, on any other host X falls
+        # back to. Skipping would leave the agent unlaunched anywhere —
         # fall through and start locally instead. This is the lead's
         # bm025 stale-binding repro.
         return None
@@ -457,6 +470,7 @@ __all__ = [
     "classify_dispatch_host",
     "_local_host_names",
     "_bound_host",
+    "_bound_hosts",
     "_registry_active_on",
     "_resolve_dispatch_peer",
     "_resolve_singleton_skip",

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
@@ -35,9 +35,11 @@ from ._common import _local_host_names
 from ._dispatch_paths import local_spec_dir, remote_spec_target
 
 if TYPE_CHECKING:
-    from collections.abc import Collection
+    from collections.abc import Callable, Collection
 
     from ..._state.host_config import PeerSpec
+
+    from ._host_chain import ReachabilityOracle
 
 
 def _spawned_by() -> str:
@@ -326,6 +328,8 @@ def try_dispatch(
     dry_run: bool,
     force: bool,
     local_names: "Collection[str] | None" = None,
+    reachability: "ReachabilityOracle | None" = None,
+    dispatcher: "Callable[..., int] | None" = None,
 ) -> bool:
     """Route ``config`` to a remote peer when its ``spec.host`` demands it.
 
@@ -344,48 +348,53 @@ def try_dispatch(
       handoff (drift-check + rsync + remote ``sac agents start
       --no-redispatch --json`` + lead-side ``state.db.instances`` row) and
       returns ``True``. Only this branch ever reaches ssh.
-    * **unknown** — ``spec.host`` names neither this machine nor a peer.
-      Raises ``RuntimeError`` with the registered-peer list (the
-      ``sac host list`` view) and the concrete fixes — operator directive
-      2026-07-10: a placement that cannot be routed is an ERROR, never a
-      silent local start on the wrong machine. The historical fall-through
+    * **unknown** — nothing in ``spec.host`` is usable: a name that resolves
+      to neither this machine nor a peer, or a fallback CHAIN whose every
+      candidate was rejected. Raises ``RuntimeError`` with the registered-peer
+      list (the ``sac host list`` view) and the concrete fixes — operator
+      directive 2026-07-10: a placement that cannot be routed is an ERROR,
+      never a silent local start on the wrong machine. For a chain the message
+      names EVERY candidate and why it was rejected (unreachable vs unknown
+      name), because those have different fixes. The historical fall-through
       survives in two explicit forms: ``--no-redispatch`` skips this
       dispatcher entirely (the documented force-local escape, which also
-      disarms the singleton skip), and a fallback CHAIN whose tail names
-      THIS machine still classifies local (``classify_spec_host_route``).
-      The negative-safety guarantee is unchanged — an unknown host never
-      becomes an ssh target.
+      disarms the singleton skip), and a chain whose tail names THIS machine
+      still classifies local. The negative-safety guarantee is unchanged — an
+      unknown host never becomes an ssh target.
 
-    ``local_names`` defaults to :func:`_local_host_names` (the union of both
-    hostname authorities); tests inject an explicit set to keep the routing
-    decision pure and hermetic.
+    A LIST ``spec.host`` is walked in priority order with each remote
+    candidate probed by one bounded ssh round-trip, so a head answering
+    ``Permission denied (publickey)`` degrades to the next entry instead of
+    taking the agent down. A plain STRING is never probed and routes exactly
+    as it always has. The walk itself lives in
+    :func:`._host_routing.resolve_start_dispatch_peer`.
+
+    ``local_names`` defaults to :func:`_local_host_names`, ``reachability`` to
+    the real ssh prober (chains only), ``dispatcher`` to
+    :func:`_dispatch_remote_start` — injection seams so tests exercise the
+    routing decision hermetically, with no network and no PATH shim.
 
     Raises:
-        RuntimeError: ``spec.host`` resolves to neither this machine nor a
-            registered peer (message body from
-            ``_host_routing.format_unknown_host_error``).
+        RuntimeError: ``spec.host`` resolves nowhere usable (message body from
+            ``_host_routing.format_route_error``).
     """
-    from ._host_routing import classify_spec_host_route, format_unknown_host_error
+    from ._host_routing import resolve_start_dispatch_peer
 
-    spec_host = config.hosts_spec.host
     if local_names is None:
         local_names = _local_host_names(current_host)
-    kind, dispatch_peer = classify_spec_host_route(
-        spec_host,
+    # ONLY a resolved remote peer triggers ssh dispatch; None means local, so
+    # the caller proceeds with the unchanged local launch.
+    dispatch_peer = resolve_start_dispatch_peer(
+        config.name,
+        config.hosts_spec.host,
         current_host,
         peers,
         local_names=local_names,
+        reachability=reachability,
     )
-    if kind == "unknown":
-        head = spec_host[0] if isinstance(spec_host, list) else spec_host
-        raise RuntimeError(
-            format_unknown_host_error(config.name, str(head), peers, verb="start")
-        )
-    # ONLY a resolved remote peer triggers ssh dispatch; "local" returns
-    # False so the caller proceeds with the unchanged local launch.
-    if kind != "remote" or dispatch_peer is None:
+    if dispatch_peer is None:
         return False
-    _dispatch_remote_start(
+    (dispatcher or _dispatch_remote_start)(
         name=config.name,
         peer=dispatch_peer,
         dry_run=dry_run,

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
@@ -38,7 +38,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Collection
 
     from ..._state.host_config import PeerSpec
-
     from ._host_chain import ReachabilityOracle
 
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_host_chain.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_host_chain.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``host:`` as a FALLBACK CHAIN — the resolver that actually honours it.
+
+``config._types.HostsSpec`` has documented the list form as "priority order;
+first available host wins (fallback chain)" since v3 shipped. Nothing
+implemented it. Every site that reduced the list took ``host[0]`` and never
+asked whether that host was usable, so a chain degraded exactly as well as a
+string: not at all. On 2026-08-09 specs reverted to a single pinned host, sac
+ssh-dispatched every lifecycle verb to it, the hop answered ``Permission
+denied (publickey)``, and twelve agents went down with a documented fallback
+mechanism sitting inert in the type.
+
+This module is that mechanism. It is the ONE place a ``spec.host`` chain is
+reduced to a route, and every reduction site in the control plane calls it.
+
+Three-valued, on purpose
+------------------------
+Reachability is :data:`REACHABLE` / :data:`UNREACHABLE` / :data:`UNKNOWN`, and
+the third value is never folded into either pole — that fold is the bug this
+codebase ships most often (see ``_lifecycle/_verdict``'s "a probe that could
+not run is UNKNOWN, never DEAD" and ``_listen/_reachability``'s "three states,
+never two"). Concretely:
+
+* :data:`UNREACHABLE` is EVIDENCE of failure — a probe ran and said no. Only
+  evidence rejects a candidate.
+* :data:`UNKNOWN` is the absence of evidence — no oracle was supplied, or the
+  probe itself could not run. It rejects nothing.
+
+The selection rule follows from that, and is one line: **take the first
+candidate that has not been positively rejected.** A candidate is rejected
+only by hard evidence — an :data:`UNREACHABLE` probe result, or a name that
+resolves to neither this machine nor a registered peer. An :data:`UNKNOWN`
+candidate still wins its position, because ``host:`` is a PRIORITY order and
+demoting the operator's first choice on no evidence is just the opposite
+collapse of UNKNOWN. That also makes the no-oracle case byte-identical to the
+historical ``host[0]`` reduction, which is why the pure call sites (listings,
+preflights) can adopt this resolver without probing anything.
+
+A plain string is NOT a chain
+-----------------------------
+``host: <name>`` reduces exactly as it always has and is NEVER probed, even
+when the caller supplies an oracle. There is nothing to fall back to, so a
+probe could only convert a working dispatch into a refusal — a pure
+regression. Pinned by test.
+
+Purity
+------
+:func:`resolve_host_chain` never touches the network: reachability arrives as
+an injected ``(host) -> verdict`` callable, exactly as ``peers`` and
+``local_names`` already arrive at :func:`._common.classify_dispatch_host`.
+:func:`ssh_reachability_oracle` builds the production callable and lives below
+a loud divider; the resolver never calls it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable
+
+from ._common import classify_dispatch_host
+
+if TYPE_CHECKING:
+    from ..._state.host_config import PeerSpec
+
+# --- reachability verdicts (deliberately ternary; see module docstring) -----
+REACHABLE = "reachable"
+UNREACHABLE = "unreachable"
+UNKNOWN = "unknown"
+
+#: ``(host) -> REACHABLE | UNREACHABLE | UNKNOWN``. Injected, never imported
+#: by the resolver — the seam that keeps :func:`resolve_host_chain` pure.
+ReachabilityOracle = Callable[[str], str]
+
+# --- route kinds -----------------------------------------------------------
+LOCAL = "local"
+REMOTE = "remote"
+UNROUTABLE = "unroutable"
+
+# Placement kinds as returned by :func:`._common.classify_dispatch_host`.
+_PLACEMENT_LOCAL = "local"
+_PLACEMENT_REMOTE = "remote"
+_PLACEMENT_UNKNOWN = "unknown"
+
+#: Reachability of a candidate that was never probed (local entries, entries
+#: past the winner, and every entry of a plain-string ``host:``).
+NOT_PROBED = ""
+
+
+@dataclass(frozen=True)
+class HostCandidate:
+    """One entry of a ``spec.host`` chain, with why it was taken or rejected.
+
+    ``placement`` is the :func:`._common.classify_dispatch_host` verdict
+    (``local`` / ``remote`` / ``unknown``); ``reachability`` is the oracle's
+    answer, or :data:`NOT_PROBED` when the candidate was never probed (a local
+    entry, an unroutable name, or any entry after the winner — the walk is
+    lazy so a probe costs an ssh round-trip only when it can change the
+    outcome).
+    """
+
+    host: str
+    placement: str
+    reachability: str = NOT_PROBED
+
+    @property
+    def rejected(self) -> bool:
+        """True iff EVIDENCE disqualified this candidate.
+
+        Only two things reject: a name that routes nowhere, and a probe that
+        positively answered :data:`UNREACHABLE`. :data:`UNKNOWN` never
+        rejects — that is the whole point of keeping it distinct.
+        """
+        return (
+            self.placement == _PLACEMENT_UNKNOWN
+            or self.reachability == UNREACHABLE
+        )
+
+    def describe(self) -> str:
+        """One operator-readable line explaining this candidate's disposition."""
+        if self.placement == _PLACEMENT_UNKNOWN:
+            return (
+                f"{self.host} — UNKNOWN HOST: neither this machine nor a "
+                f"registered peer"
+            )
+        if self.placement == _PLACEMENT_LOCAL:
+            return f"{self.host} — LOCAL: this machine"
+        if self.reachability == UNREACHABLE:
+            return (
+                f"{self.host} — UNREACHABLE: registered peer, but the "
+                f"reachability probe failed"
+            )
+        if self.reachability == REACHABLE:
+            return f"{self.host} — REACHABLE: registered peer, probe succeeded"
+        return (
+            f"{self.host} — UNKNOWN REACHABILITY: registered peer, not probed "
+            f"(no evidence against it)"
+        )
+
+
+@dataclass(frozen=True)
+class HostChainRoute:
+    """Where a ``spec.host`` chain resolved to, and the trail that got there.
+
+    ``kind`` is :data:`LOCAL`, :data:`REMOTE` or :data:`UNROUTABLE`. ``peer``
+    is set iff ``kind`` is :data:`REMOTE`. ``host`` is the winning chain entry
+    (``None`` only for an empty / absent ``host:``). ``candidates`` records
+    every entry the walk examined, in priority order, so the fail-loud path
+    can name each one and why it was rejected.
+    """
+
+    kind: str
+    peer: str | None = None
+    host: str | None = None
+    candidates: tuple[HostCandidate, ...] = field(default_factory=tuple)
+
+
+def chain_hosts(spec_host: "str | Sequence[str] | None") -> list[str]:
+    """Normalize ``spec.host`` to an ordered list of non-empty host names.
+
+    The single shared normalizer — a string becomes a one-element list, a list
+    is filtered of empties, and ``None`` / ``""`` becomes ``[]`` (unpinned).
+    """
+    if spec_host is None:
+        return []
+    if isinstance(spec_host, str):
+        return [spec_host] if spec_host else []
+    return [h for h in spec_host if h]
+
+
+def is_remote_placement(
+    spec_host: "str | Sequence[str] | None", current_host: str
+) -> bool:
+    """Will this placement land on a machine OTHER than ``current_host``?
+
+    The peer-table-free question, for callers that must not pay an ssh probe
+    or a config load to answer it (the ``--resume`` preflight). A chain that
+    NAMES this machine anywhere is not remote — the resolver would take the
+    local entry rather than dispatch, so a preflight that called it remote
+    would be pre-flighting the wrong machine. For a plain string this is the
+    identical comparison it has always been.
+    """
+    hosts = chain_hosts(spec_host)
+    return bool(hosts) and current_host not in hosts
+
+
+def resolve_host_chain(
+    spec_host: "str | Sequence[str] | None",
+    current_host: str,
+    peers: Mapping[str, "PeerSpec"],
+    *,
+    local_names: Collection[str] = (),
+    reachability: ReachabilityOracle | None = None,
+) -> HostChainRoute:
+    """Reduce a ``spec.host`` (string OR fallback chain) to one route.
+
+    Pure — never raises, never logs, never reads files, never touches the
+    network. ``peers`` / ``local_names`` / ``reachability`` all arrive from the
+    caller, extending the seam :func:`._common.classify_dispatch_host` already
+    established.
+
+    Walk, in priority order:
+
+    * a LOCAL entry wins immediately — we are that machine, so its availability
+      needs no probe and an ssh hop to self is never rendered;
+    * a REMOTE entry is probed (when an oracle was supplied); :data:`REACHABLE`
+      and :data:`UNKNOWN` both win, :data:`UNREACHABLE` is skipped;
+    * an entry naming neither this machine nor a peer is skipped;
+    * if every entry was skipped the route is :data:`UNROUTABLE` — the caller
+      fails loud with :func:`format_unroutable_chain_error`, never a silent
+      local start.
+
+    A plain STRING is classified exactly as before and never probed (see the
+    module docstring); ``reachability`` is ignored for it entirely.
+
+    An empty / absent ``host:`` is :data:`LOCAL` with no candidates.
+    """
+    hosts = chain_hosts(spec_host)
+    if not hosts:
+        return HostChainRoute(kind=LOCAL)
+
+    # A bare string is not a fallback chain: no probing, ever.
+    probe = None if isinstance(spec_host, str) else reachability
+
+    examined: list[HostCandidate] = []
+    for host in hosts:
+        placement, peer = classify_dispatch_host(
+            host, current_host, peers, local_names=local_names
+        )
+        if placement == _PLACEMENT_LOCAL:
+            examined.append(HostCandidate(host, placement))
+            return HostChainRoute(
+                kind=LOCAL, host=host, candidates=tuple(examined)
+            )
+        if placement == _PLACEMENT_REMOTE and peer is not None:
+            verdict = _probe(probe, host)
+            examined.append(HostCandidate(host, placement, verdict))
+            if verdict != UNREACHABLE:
+                return HostChainRoute(
+                    kind=REMOTE, peer=peer, host=host, candidates=tuple(examined)
+                )
+            continue
+        examined.append(HostCandidate(host, _PLACEMENT_UNKNOWN))
+    return HostChainRoute(kind=UNROUTABLE, candidates=tuple(examined))
+
+
+def _probe(oracle: ReachabilityOracle | None, host: str) -> str:
+    """Ask ``oracle`` about ``host``, degrading any surprise to :data:`UNKNOWN`.
+
+    No oracle means no evidence, which is :data:`UNKNOWN` — NOT
+    :data:`UNREACHABLE`. An oracle that raises or answers with anything outside
+    the three verdicts is likewise "we did not learn anything", never a licence
+    to reject a host the operator asked for.
+    """
+    if oracle is None:
+        return UNKNOWN
+    # stx-allow: fallback (reason: a broken reachability oracle must degrade to
+    # "no evidence" — turning it into UNREACHABLE would let an oracle bug eject
+    # a healthy host from the chain, the exact collapse this module forbids)
+    try:
+        verdict = oracle(host)
+    except Exception:
+        return UNKNOWN
+    return verdict if verdict in (REACHABLE, UNREACHABLE, UNKNOWN) else UNKNOWN
+
+
+def format_unroutable_chain_error(
+    name: str,
+    route: HostChainRoute,
+    peers: Mapping[str, "PeerSpec"],
+    *,
+    verb: str = "start",
+    current_host: str = "",
+) -> str:
+    """Actionable message for a chain in which EVERY candidate was rejected.
+
+    Same shape and intent as :func:`._host_routing.format_unknown_host_error`
+    (which it complements — that one explains a single bad name), but the chain
+    case must account for every entry: an operator staring at ``host: [a, b,
+    c]`` needs to know which of the three are typos and which are simply down,
+    because the fixes differ. So every candidate is listed in priority order
+    with its own reason.
+    """
+    peer_names = ", ".join(sorted(peers)) if peers else "(none registered)"
+    lines = [
+        f"Cannot {verb} agent {name!r}: every host in its `host:` fallback "
+        f"chain was rejected.",
+        "Chain (priority order):",
+    ]
+    for index, candidate in enumerate(route.candidates, start=1):
+        lines.append(f"  {index}. {candidate.describe()}")
+    if current_host:
+        lines.append(f"This machine resolves as: {current_host}")
+    lines.append(f"Registered peers: {peer_names}")
+    lines.append(
+        "  (from ~/.scitex/agent-container/config.yaml `peers:`; "
+        "inspect with `sac host list`)"
+    )
+    lines.append("Fix ONE of:")
+    lines.append(
+        "  * bring one of the chain's hosts back up, then re-check with "
+        "`sac host probe <peer>`,"
+    )
+    lines.append(
+        "  * append this machine to the chain (`host: [..., "
+        f"{current_host or '<this-host>'}]`) so the placement degrades locally "
+        "instead of failing,"
+    )
+    lines.append(
+        "  * correct a mistyped entry, or register it under `peers:` (glob "
+        "patterns like `spartan-*:` with `via: [spartan]` cover "
+        "login-node-fronted compute nodes),"
+    )
+    if verb == "start":
+        lines.append(
+            "  * or pass --no-redispatch to force a LOCAL start despite the pin."
+        )
+    else:
+        lines.append(
+            f"  * or run the verb on the owning host explicitly: "
+            f"`sac --on <peer> agents {verb} {name}`."
+        )
+    return "\n".join(lines)
+
+
+# ===========================================================================
+# IMPURE — the production oracle. Nothing above this line calls it; callers
+# that already own side effects (the dispatchers) wire it in explicitly.
+# ===========================================================================
+
+
+def ssh_reachability_oracle(
+    peers: Mapping[str, "PeerSpec"],
+    *,
+    timeout: int = 5,
+    runner: Callable[[list[str]], int] | None = None,
+) -> ReachabilityOracle:
+    """Build the real ``(host) -> verdict`` probe: one bounded ssh round-trip.
+
+    The argv is rendered by :func:`.._state.host_config.build_ssh_argv` — sac's
+    one canonical dispatch primitive — so a peer's ``via:`` ProxyJump chain and
+    glob pattern apply and a two-tier HPC target is probed the same way it will
+    be dispatched. A probe that agrees with the dispatch is the only kind worth
+    having.
+
+    Verdicts, mapped from the exit code of a remote ``true``:
+
+    * rc 0 -> :data:`REACHABLE` — the hop completed and ran a command.
+    * rc != 0 -> :data:`UNREACHABLE` — ssh reached a verdict and it was no
+      (refused, auth failure, ``Permission denied (publickey)``: the 2026-08-09
+      failure, which a chain must degrade past rather than die on).
+    * ssh could not run at all, or the peer is unresolvable -> :data:`UNKNOWN`.
+      We learned nothing, so we reject nothing.
+
+    Answers are memoized per built oracle: one chain walk must not probe the
+    same host twice, and a lifecycle verb is short enough that a cached answer
+    cannot go stale within it.
+    """
+    cache: dict[str, str] = {}
+
+    def _oracle(host: str) -> str:
+        if host in cache:
+            return cache[host]
+        cache[host] = _ssh_probe(host, peers, timeout=timeout, runner=runner)
+        return cache[host]
+
+    return _oracle
+
+
+def _ssh_probe(
+    host: str,
+    peers: Mapping[str, "PeerSpec"],
+    *,
+    timeout: int,
+    runner: Callable[[list[str]], int] | None,
+) -> str:
+    """One ssh round-trip to ``host``; see :func:`ssh_reachability_oracle`."""
+    # stx-allow: fallback (reason: an unresolvable peer / unbuildable argv means
+    # we could not look, which is UNKNOWN — never a licence to eject the host)
+    try:
+        from ..._state.host_config import build_ssh_argv
+
+        argv = build_ssh_argv(
+            host,
+            ["true"],
+            peers,
+            extra_opts=["-n", "-o", f"ConnectTimeout={timeout}"],
+        )
+    except Exception:
+        return UNKNOWN
+    # stx-allow: fallback (reason: ssh binary missing / probe timed out is "we
+    # could not look" — UNKNOWN, never UNREACHABLE)
+    try:
+        rc = (runner or _run_rc)(argv)
+    except Exception:
+        return UNKNOWN
+    if rc is None:
+        return UNKNOWN
+    return REACHABLE if rc == 0 else UNREACHABLE
+
+
+def _run_rc(argv: list[str]) -> int | None:
+    """Run ``argv``, return its exit code, or None when it could not run."""
+    import subprocess
+
+    # stx-allow: fallback (reason: could-not-run maps to UNKNOWN upstream)
+    try:
+        return subprocess.run(argv, capture_output=True, timeout=30).returncode
+    except Exception:
+        return None
+
+
+__all__ = [
+    "LOCAL",
+    "NOT_PROBED",
+    "REACHABLE",
+    "REMOTE",
+    "UNKNOWN",
+    "UNREACHABLE",
+    "UNROUTABLE",
+    "HostCandidate",
+    "HostChainRoute",
+    "ReachabilityOracle",
+    "chain_hosts",
+    "format_unroutable_chain_error",
+    "is_remote_placement",
+    "resolve_host_chain",
+    "ssh_reachability_oracle",
+]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_host_routing.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_host_routing.py
@@ -50,7 +50,6 @@ from ._host_chain import (
 
 if TYPE_CHECKING:
     from ..._state.host_config import PeerSpec
-
     from ._host_chain import HostChainRoute, ReachabilityOracle
 
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_host_routing.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_host_routing.py
@@ -9,7 +9,10 @@ two existing dispatchers into one coherent routing story:
 
 * ``start`` routes by ``spec.host`` (``_dispatch.try_dispatch`` — the
   instances row does not exist yet at start time). This module contributes
-  the CHAIN-AWARE classification + the fail-loud unknown-host error.
+  the CHAIN-AWARE classification + the fail-loud unknown-host error. The chain
+  walk itself lives in :mod:`._host_chain` (one resolver, one reachability
+  seam); this module adapts it to the lifecycle verbs' shapes and owns the
+  operator-facing messages.
 * ``stop`` / ``restart`` route primarily by the agent's active
   ``state.db.instances`` row (``_dispatch.try_dispatch_remote``). This module
   fills the gap when NO row exists on the caller's state.db — e.g. the agent
@@ -37,10 +40,18 @@ from __future__ import annotations
 from collections.abc import Collection, Mapping
 from typing import TYPE_CHECKING
 
-from ._common import _local_host_names, classify_dispatch_host
+from ._common import _local_host_names
+from ._host_chain import (
+    UNROUTABLE,
+    format_unroutable_chain_error,
+    resolve_host_chain,
+    ssh_reachability_oracle,
+)
 
 if TYPE_CHECKING:
     from ..._state.host_config import PeerSpec
+
+    from ._host_chain import HostChainRoute, ReachabilityOracle
 
 
 class UnknownSpecHostError(RuntimeError):
@@ -98,32 +109,150 @@ def classify_spec_host_route(
     peers: Mapping[str, "PeerSpec"],
     *,
     local_names: Collection[str] = (),
+    reachability: "ReachabilityOracle | None" = None,
 ) -> tuple[str, str | None]:
     """Chain-aware wrapper over :func:`_common.classify_dispatch_host`.
 
-    ``spec.host`` may be a single hostname or a FALLBACK CHAIN (list). The
-    head of the chain drives the routing decision exactly as before, with
-    one refinement: a chain whose head is unknown but whose TAIL contains a
-    spelling of THIS machine classifies ``local`` — the documented
-    fallback-hosts semantics (``_singleton_skip_reason`` accepts the current
-    host anywhere in the chain), which a head-only fail-loud would break.
+    Thin adapter over :func:`._host_chain.resolve_host_chain` (the one place a
+    ``spec.host`` chain is reduced), preserving this function's historic
+    ``(kind, peer)`` shape: ``("local", None)`` / ``("remote", peer)`` /
+    ``("unknown", None)``. An :data:`._host_chain.UNROUTABLE` route maps onto
+    the legacy ``"unknown"`` kind, so existing callers keep failing loud on
+    exactly the cases they already did.
 
-    Returns the same ``(kind, peer)`` shape as ``classify_dispatch_host``:
-    ``("local", None)`` / ``("remote", peer)`` / ``("unknown", None)``.
+    ``spec.host`` may be a single hostname or a FALLBACK CHAIN (list). A plain
+    string routes exactly as before and is never probed. A list is walked in
+    priority order and the first candidate not positively rejected wins — so a
+    chain whose head is unreachable now degrades to the next entry, and a
+    chain whose tail names THIS machine still classifies ``local``.
+
+    ``reachability`` is the injected ``(host) -> verdict`` oracle; without one
+    every remote candidate is :data:`._host_chain.UNKNOWN` and the head wins,
+    which is byte-for-byte the historical reduction.
+
+    Callers that need to SEE the rejected candidates (to render the fail-loud
+    message) want :func:`resolve_spec_host_route` instead.
+    """
+    route = resolve_host_chain(
+        spec_host,
+        current_host,
+        peers,
+        local_names=local_names,
+        reachability=reachability,
+    )
+    return route_to_legacy_kind(route)
+
+
+def route_to_legacy_kind(route: "HostChainRoute") -> tuple[str, str | None]:
+    """Collapse a :class:`._host_chain.HostChainRoute` to ``(kind, peer)``.
+
+    ``UNROUTABLE`` becomes ``"unknown"``: to a caller that only asked "can I
+    ssh somewhere?", a chain in which every host was rejected and a name that
+    resolves nowhere are the same answer — do not dispatch, fail loud.
+    """
+    if route.kind == UNROUTABLE:
+        return ("unknown", None)
+    return (route.kind, route.peer)
+
+
+def resolve_spec_host_route(
+    spec_host: str | list[str] | None,
+    current_host: str,
+    peers: Mapping[str, "PeerSpec"],
+    *,
+    local_names: Collection[str] = (),
+    reachability: "ReachabilityOracle | None" = None,
+) -> "HostChainRoute":
+    """Full chain resolution, candidates and all — see :func:`._host_chain`.
+
+    The richer sibling of :func:`classify_spec_host_route`, for the callers
+    that must explain a refusal rather than merely make one.
+    """
+    return resolve_host_chain(
+        spec_host,
+        current_host,
+        peers,
+        local_names=local_names,
+        reachability=reachability,
+    )
+
+
+def format_route_error(
+    name: str,
+    spec_host: str | list[str] | None,
+    route: "HostChainRoute",
+    peers: Mapping[str, "PeerSpec"],
+    *,
+    verb: str,
+    current_host: str = "",
+) -> str:
+    """Pick the right unroutable message for ``spec_host``'s shape.
+
+    A plain string gets :func:`format_unknown_host_error` VERBATIM — one bad
+    name, one explanation, unchanged from before chains existed. A list gets
+    :func:`._host_chain.format_unroutable_chain_error`, which must account for
+    every entry because the operator cannot otherwise tell which of them is a
+    typo and which is merely down.
     """
     if isinstance(spec_host, list):
-        chain = [h for h in spec_host if h]
-    else:
-        chain = [spec_host] if spec_host else []
-    head = chain[0] if chain else None
-    kind, peer = classify_dispatch_host(
-        head, current_host, peers, local_names=local_names
+        return format_unroutable_chain_error(
+            name, route, peers, verb=verb, current_host=current_host
+        )
+    return format_unknown_host_error(name, str(spec_host), peers, verb=verb)
+
+
+def resolve_start_dispatch_peer(
+    name: str,
+    spec_host: str | list[str] | None,
+    current_host: str,
+    peers: Mapping[str, "PeerSpec"],
+    *,
+    local_names: Collection[str] = (),
+    reachability: "ReachabilityOracle | None" = None,
+) -> str | None:
+    """Peer that ``sac agents start`` should dispatch ``name`` to, or None.
+
+    The start-side twin of :func:`resolve_spec_host_peer` — same decision, but
+    driven by an ALREADY-LOADED spec (start has the config in hand; stop and
+    restart only have a name). Extracted here rather than left inline in
+    ``_dispatch.try_dispatch`` so all four "reduce a placement to a route, and
+    explain a refusal" behaviours live in one module.
+
+    ``None`` means run locally: an empty ``host:``, a pin that spells this
+    machine, or a chain that degraded to this machine. A peer name means ssh.
+
+    A LIST ``spec.host`` gets a real ssh reachability probe (built here when
+    the caller passes none, since this function is on the side of the seam
+    that already authorizes an ssh hop); a plain STRING is never probed.
+
+    Raises:
+        UnknownSpecHostError: nothing in ``spec_host`` is usable — a name that
+            resolves nowhere, or a chain whose every candidate was rejected.
+            Message body from :func:`format_route_error`; a ``RuntimeError``
+            subclass, so callers catching ``RuntimeError`` are unaffected.
+    """
+    if reachability is None and isinstance(spec_host, list):
+        reachability = ssh_reachability_oracle(peers)
+    route = resolve_spec_host_route(
+        spec_host,
+        current_host,
+        peers,
+        local_names=local_names,
+        reachability=reachability,
     )
-    if kind == "unknown" and any(
-        h == current_host or h in local_names for h in chain[1:]
-    ):
-        return ("local", None)
-    return (kind, peer)
+    if route.kind == UNROUTABLE:
+        raise UnknownSpecHostError(
+            format_route_error(
+                name,
+                spec_host,
+                route,
+                peers,
+                verb="start",
+                current_host=current_host,
+            )
+        )
+    kind, peer = route_to_legacy_kind(route)
+    return peer if kind == "remote" else None
 
 
 def has_active_row(name: str) -> bool:
@@ -151,6 +280,7 @@ def resolve_spec_host_peer(
     verb: str,
     current_host: str | None = None,
     local_names: Collection[str] | None = None,
+    reachability: "ReachabilityOracle | None" = None,
 ) -> str | None:
     """Resolve ``name``'s SPEC ``host:`` pin to a remote peer, or None for local.
 
@@ -158,13 +288,22 @@ def resolve_spec_host_peer(
         * ``None`` — proceed with the unchanged local path. Fires when the
           spec cannot be resolved/loaded (the local verb owns those error
           messages), when ``spec.host`` is empty, or when it spells THIS
-          machine.
-        * ``<peer>`` — ``spec.host`` names a registered peer distinct from
-          this machine; the caller dispatches ``verb`` there over ssh.
+          machine — including when a fallback CHAIN degrades to this machine
+          because everything ahead of it was rejected.
+        * ``<peer>`` — the first candidate in ``spec.host`` that was not
+          positively rejected names a registered peer distinct from this
+          machine; the caller dispatches ``verb`` there over ssh.
+
+    ``reachability`` is the injected chain-probe oracle. When ``spec.host`` is
+    a LIST and no oracle is passed, one real ssh prober is built here — this
+    function already loads config and is about to authorize an ssh hop, so it
+    is not a pure resolver and probing is in character. A plain STRING never
+    builds or consults an oracle (see :func:`._host_chain.resolve_host_chain`).
 
     Raises:
-        UnknownSpecHostError: ``spec.host`` names neither this machine nor
-            a registered peer (see :func:`format_unknown_host_error`).
+        UnknownSpecHostError: nothing in ``spec.host`` is usable — a name that
+            resolves nowhere, or a chain whose every candidate was rejected
+            (see :func:`format_route_error`).
     """
     # stx-allow: fallback (reason: an unresolvable/unloadable spec must fall
     # through to the local verb's own established error surface — the
@@ -186,14 +325,27 @@ def resolve_spec_host_peer(
     if local_names is None:
         local_names = _local_host_names(current_host)
     spec_host = config.hosts_spec.host
-    kind, peer = classify_spec_host_route(
-        spec_host, current_host, peers, local_names=local_names
+    if reachability is None and isinstance(spec_host, list):
+        reachability = ssh_reachability_oracle(peers)
+    route = resolve_spec_host_route(
+        spec_host,
+        current_host,
+        peers,
+        local_names=local_names,
+        reachability=reachability,
     )
-    if kind == "unknown":
-        head = spec_host[0] if isinstance(spec_host, list) else spec_host
+    if route.kind == UNROUTABLE:
         raise UnknownSpecHostError(
-            format_unknown_host_error(name, str(head), peers, verb=verb)
+            format_route_error(
+                name,
+                spec_host,
+                route,
+                peers,
+                verb=verb,
+                current_host=current_host or "",
+            )
         )
+    kind, peer = route_to_legacy_kind(route)
     if kind != "remote" or peer is None:
         return None
     return peer
@@ -204,6 +356,7 @@ def spec_host_fallback_peer(
     peers: Mapping[str, "PeerSpec"],
     *,
     verb: str,
+    reachability: "ReachabilityOracle | None" = None,
 ) -> str | None:
     """Peer to route ``verb`` to when ``name`` has NO active instances row.
 
@@ -215,14 +368,20 @@ def spec_host_fallback_peer(
     """
     if has_active_row(name):
         return None
-    return resolve_spec_host_peer(name, peers, verb=verb)
+    return resolve_spec_host_peer(
+        name, peers, verb=verb, reachability=reachability
+    )
 
 
 __all__ = [
     "UnknownSpecHostError",
     "classify_spec_host_route",
+    "format_route_error",
     "format_unknown_host_error",
     "has_active_row",
     "resolve_spec_host_peer",
+    "resolve_spec_host_route",
+    "resolve_start_dispatch_peer",
+    "route_to_legacy_kind",
     "spec_host_fallback_peer",
 ]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_host_routing.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_host_routing.py
@@ -188,16 +188,21 @@ def format_route_error(
     """Pick the right unroutable message for ``spec_host``'s shape.
 
     A plain string gets :func:`format_unknown_host_error` VERBATIM — one bad
-    name, one explanation, unchanged from before chains existed. A list gets
-    :func:`._host_chain.format_unroutable_chain_error`, which must account for
-    every entry because the operator cannot otherwise tell which of them is a
-    typo and which is merely down.
+    name, one explanation, unchanged from before chains existed. Anything else
+    gets :func:`._host_chain.format_unroutable_chain_error`, which must account
+    for every entry because the operator cannot otherwise tell which of them is
+    a typo and which is merely down.
+
+    The "is this a chain?" test is ``isinstance(spec_host, str)`` — the SAME
+    one :func:`._host_chain.resolve_host_chain` uses to decide whether to
+    probe. Two different tests here would eventually disagree about some
+    sequence type and explain a refusal the resolver never made.
     """
-    if isinstance(spec_host, list):
-        return format_unroutable_chain_error(
-            name, route, peers, verb=verb, current_host=current_host
-        )
-    return format_unknown_host_error(name, str(spec_host), peers, verb=verb)
+    if isinstance(spec_host, str):
+        return format_unknown_host_error(name, spec_host, peers, verb=verb)
+    return format_unroutable_chain_error(
+        name, route, peers, verb=verb, current_host=current_host
+    )
 
 
 def resolve_start_dispatch_peer(

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -288,13 +288,14 @@ def run_single_targets(
                         current_host = resolve_hostname()
                     except RuntimeError:  # stx-allow: fallback (reason: hostname resolution failure — treat as local for the preflight)
                         current_host = ""
-                    spec_host = config.hosts_spec.host
-                    target_host = (
-                        (spec_host[0] if spec_host else None)
-                        if isinstance(spec_host, list)
-                        else (spec_host or None)
+                    from ._host_chain import is_remote_placement
+
+                    # A CHAIN that names this machine anywhere can degrade to
+                    # a local start, so pre-flighting it as remote would
+                    # validate the resume id against the wrong machine.
+                    is_remote = is_remote_placement(
+                        config.hosts_spec.host, current_host
                     )
-                    is_remote = bool(target_host) and target_host != current_host
                     preflight_resume_id(
                         config,
                         resume_id,

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_chain.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_chain.py
@@ -1,0 +1,656 @@
+"""Tests for ``cli_pkg.lifecycle._host_chain`` — ``host:`` as a real chain.
+
+The type has promised "priority order; first available host wins (fallback
+chain)" since v3; every reduction site took ``host[0]`` unchecked. These tests
+pin the resolver that closes that gap, and — just as hard — pin that a plain
+string ``host: <name>`` did NOT change: it is never probed, so a chain feature
+cannot regress a pinned placement.
+
+No-mocks: the resolver is pure and exercised directly, the reachability oracle
+is an injected callable (the seam the module exists to provide), and the ssh
+oracle is driven through its ``runner`` seam with a real ``build_ssh_argv``
+and real ``PeerSpec`` rows. Nothing here touches the network. Conforms to
+STX-TQ002 (AAA markers), STX-TQ003 (descriptive names), STX-TQ007 (one assert
+per test).
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._state.host_config import PeerSpec
+from scitex_agent_container.cli_pkg.lifecycle._host_chain import (
+    LOCAL,
+    REACHABLE,
+    REMOTE,
+    UNKNOWN,
+    UNREACHABLE,
+    UNROUTABLE,
+    HostCandidate,
+    HostChainRoute,
+    chain_hosts,
+    format_unroutable_chain_error,
+    is_remote_placement,
+    resolve_host_chain,
+    ssh_reachability_oracle,
+)
+
+_PEERS = {
+    "peer-a": PeerSpec(name="peer-a", ssh="peer-a"),
+    "peer-b": PeerSpec(name="peer-b", ssh="peer-b"),
+}
+_HERE = "this-host"
+_LOCAL_NAMES = {"this-host", "this-host-alias"}
+
+
+def _oracle(**verdicts: str):
+    """Build a recording reachability oracle; unlisted hosts answer UNKNOWN."""
+    calls: list[str] = []
+
+    def _fn(host: str) -> str:
+        calls.append(host)
+        return verdicts.get(host.replace("-", "_"), UNKNOWN)
+
+    _fn.calls = calls  # type: ignore[attr-defined]
+    return _fn
+
+
+def _resolve(spec_host, oracle=None) -> HostChainRoute:
+    """Resolve against the shared fixture topology."""
+    return resolve_host_chain(
+        spec_host, _HERE, _PEERS, local_names=_LOCAL_NAMES, reachability=oracle
+    )
+
+
+# ---------------------------------------------------------------------------
+# chain_hosts — the one normalizer every reduction site shares.
+# ---------------------------------------------------------------------------
+
+
+def test_chain_hosts_wraps_a_string_in_a_single_entry_list():
+    # Arrange
+    spec_host = "peer-a"
+    # Act
+    hosts = chain_hosts(spec_host)
+    # Assert
+    assert hosts == ["peer-a"]
+
+
+def test_chain_hosts_treats_empty_string_as_unpinned():
+    # Arrange
+    spec_host = ""
+    # Act
+    hosts = chain_hosts(spec_host)
+    # Assert
+    assert hosts == []
+
+
+def test_chain_hosts_treats_none_as_unpinned():
+    # Arrange
+    spec_host = None
+    # Act
+    hosts = chain_hosts(spec_host)
+    # Assert
+    assert hosts == []
+
+
+def test_chain_hosts_drops_empty_entries_from_a_list():
+    # Arrange — a hand-edited spec can leave a blank list entry behind.
+    spec_host = ["peer-a", "", "peer-b"]
+    # Act
+    hosts = chain_hosts(spec_host)
+    # Assert
+    assert hosts == ["peer-a", "peer-b"]
+
+
+# ---------------------------------------------------------------------------
+# A PLAIN STRING IS NOT A CHAIN — the hard no-regression requirement.
+# ---------------------------------------------------------------------------
+
+
+def test_string_host_naming_this_machine_routes_local():
+    # Arrange
+    spec_host = "this-host"
+    # Act
+    route = _resolve(spec_host)
+    # Assert
+    assert route.kind == LOCAL
+
+
+def test_string_host_naming_a_local_alias_routes_local():
+    # Arrange — an alias spelling of this machine is still this machine.
+    spec_host = "this-host-alias"
+    # Act
+    route = _resolve(spec_host)
+    # Assert
+    assert route.kind == LOCAL
+
+
+def test_string_host_naming_a_registered_peer_routes_remote():
+    # Arrange
+    spec_host = "peer-a"
+    # Act
+    route = _resolve(spec_host)
+    # Assert
+    assert (route.kind, route.peer) == (REMOTE, "peer-a")
+
+
+def test_string_host_naming_nothing_is_unroutable():
+    # Arrange
+    spec_host = "spartn-typo"
+    # Act
+    route = _resolve(spec_host)
+    # Assert
+    assert route.kind == UNROUTABLE
+
+
+def test_string_host_is_never_handed_to_the_reachability_oracle():
+    # Arrange — a string has nothing to fall back TO, so probing it could
+    # only turn a working dispatch into a refusal.
+    oracle = _oracle(peer_a=UNREACHABLE)
+    # Act
+    _resolve("peer-a", oracle)
+    # Assert
+    assert oracle.calls == []
+
+
+def test_unreachable_string_host_still_routes_remote_unchanged():
+    # Arrange — even with the oracle screaming, a pinned string behaves
+    # byte-identically to the pre-chain resolver.
+    oracle = _oracle(peer_a=UNREACHABLE)
+    # Act
+    route = _resolve("peer-a", oracle)
+    # Assert
+    assert (route.kind, route.peer) == (REMOTE, "peer-a")
+
+
+# ---------------------------------------------------------------------------
+# Unpinned placement.
+# ---------------------------------------------------------------------------
+
+
+def test_absent_host_routes_local():
+    # Arrange
+    spec_host = None
+    # Act
+    route = _resolve(spec_host)
+    # Assert
+    assert route.kind == LOCAL
+
+
+def test_empty_string_host_routes_local():
+    # Arrange
+    spec_host = ""
+    # Act
+    route = _resolve(spec_host)
+    # Assert
+    assert route.kind == LOCAL
+
+
+def test_empty_list_host_routes_local():
+    # Arrange
+    spec_host: list[str] = []
+    # Act
+    route = _resolve(spec_host)
+    # Assert
+    assert route.kind == LOCAL
+
+
+# ---------------------------------------------------------------------------
+# The chain itself — first NOT-REJECTED candidate wins.
+# ---------------------------------------------------------------------------
+
+
+def test_chain_with_reachable_head_routes_to_the_head():
+    # Arrange
+    oracle = _oracle(peer_a=REACHABLE, peer_b=REACHABLE)
+    # Act
+    route = _resolve(["peer-a", "peer-b"], oracle)
+    # Assert
+    assert (route.kind, route.peer) == (REMOTE, "peer-a")
+
+
+def test_chain_skips_an_unreachable_head_for_the_reachable_next():
+    # Arrange — the 2026-08-09 shape: the head answers Permission denied.
+    oracle = _oracle(peer_a=UNREACHABLE, peer_b=REACHABLE)
+    # Act
+    route = _resolve(["peer-a", "peer-b"], oracle)
+    # Assert
+    assert (route.kind, route.peer) == (REMOTE, "peer-b")
+
+
+def test_chain_skips_an_unreachable_head_for_a_local_tail():
+    # Arrange — the degradation the operator actually wants: run here.
+    oracle = _oracle(peer_a=UNREACHABLE)
+    # Act
+    route = _resolve(["peer-a", "this-host"], oracle)
+    # Assert
+    assert route.kind == LOCAL
+
+
+def test_chain_headed_by_this_machine_routes_local():
+    # Arrange
+    oracle = _oracle()
+    # Act
+    route = _resolve(["this-host", "peer-a"], oracle)
+    # Assert
+    assert route.kind == LOCAL
+
+
+def test_chain_headed_by_this_machine_never_yields_a_dispatch_peer():
+    # Arrange — never ssh-dispatch to self, even when this machine is ALSO
+    # registered as a peer (the ``ssh: localhost`` shape that took the
+    # fleet down).
+    peers = dict(_PEERS)
+    peers["this-host"] = PeerSpec(name="this-host", ssh="localhost")
+    # Act
+    route = resolve_host_chain(
+        ["this-host", "peer-a"], _HERE, peers, local_names=_LOCAL_NAMES
+    )
+    # Assert
+    assert route.peer is None
+
+
+def test_local_chain_entry_is_never_probed():
+    # Arrange — we ARE this machine; its availability needs no ssh.
+    oracle = _oracle()
+    # Act
+    _resolve(["this-host", "peer-a"], oracle)
+    # Assert
+    assert oracle.calls == []
+
+
+def test_chain_stops_probing_once_a_candidate_wins():
+    # Arrange — each probe is an ssh round-trip, so the walk must be lazy.
+    oracle = _oracle(peer_a=REACHABLE, peer_b=REACHABLE)
+    # Act
+    _resolve(["peer-a", "peer-b"], oracle)
+    # Assert
+    assert oracle.calls == ["peer-a"]
+
+
+def test_chain_skips_an_unroutable_name_for_the_next_entry():
+    # Arrange — a typo mid-chain must not sink the whole placement.
+    oracle = _oracle(peer_b=REACHABLE)
+    # Act
+    route = _resolve(["spartn-typo", "peer-b"], oracle)
+    # Assert
+    assert (route.kind, route.peer) == (REMOTE, "peer-b")
+
+
+def test_route_records_the_winning_chain_entry():
+    # Arrange
+    oracle = _oracle(peer_a=UNREACHABLE, peer_b=REACHABLE)
+    # Act
+    route = _resolve(["peer-a", "peer-b"], oracle)
+    # Assert
+    assert route.host == "peer-b"
+
+
+# ---------------------------------------------------------------------------
+# THREE-VALUED — UNKNOWN is neither pole, and rejects nothing.
+# ---------------------------------------------------------------------------
+
+
+def test_chain_without_an_oracle_keeps_the_head():
+    # Arrange — no oracle means no evidence, and no evidence rejects
+    # nothing: this is the historical host[0] answer, preserved.
+    spec_host = ["peer-a", "peer-b"]
+    # Act
+    route = _resolve(spec_host)
+    # Assert
+    assert (route.kind, route.peer) == (REMOTE, "peer-a")
+
+
+def test_unknown_reachability_does_not_reject_the_head():
+    # Arrange — probed, but the probe could not reach a verdict.
+    oracle = _oracle(peer_a=UNKNOWN, peer_b=REACHABLE)
+    # Act
+    route = _resolve(["peer-a", "peer-b"], oracle)
+    # Assert — "I could not tell" must not be read as "it is down".
+    assert (route.kind, route.peer) == (REMOTE, "peer-a")
+
+
+def test_unknown_reachability_is_recorded_distinctly_from_reachable():
+    # Arrange
+    oracle = _oracle(peer_a=UNKNOWN)
+    # Act
+    route = _resolve(["peer-a", "peer-b"], oracle)
+    # Assert — the verdict survives into the record; it is not laundered.
+    assert route.candidates[0].reachability == UNKNOWN
+
+
+def test_raising_oracle_degrades_to_unknown_not_unreachable():
+    # Arrange — an oracle bug must not eject a healthy host from the chain.
+    def _boom(host: str) -> str:
+        raise OSError("probe exploded")
+
+    # Act
+    route = _resolve(["peer-a", "peer-b"], _boom)
+    # Assert
+    assert (route.kind, route.peer) == (REMOTE, "peer-a")
+
+
+def test_oracle_answering_outside_the_vocabulary_degrades_to_unknown():
+    # Arrange — a stray truthy string is not a licence to reject.
+    oracle = _oracle(peer_a="probably?")
+    # Act
+    route = _resolve(["peer-a", "peer-b"], oracle)
+    # Assert
+    assert route.candidates[0].reachability == UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# HostCandidate.rejected — only EVIDENCE rejects.
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_candidate_is_rejected():
+    # Arrange
+    candidate = HostCandidate("peer-a", "remote", UNREACHABLE)
+    # Act
+    rejected = candidate.rejected
+    # Assert
+    assert rejected is True
+
+
+def test_unknown_reachability_candidate_is_not_rejected():
+    # Arrange
+    candidate = HostCandidate("peer-a", "remote", UNKNOWN)
+    # Act
+    rejected = candidate.rejected
+    # Assert
+    assert rejected is False
+
+
+def test_unroutable_name_candidate_is_rejected():
+    # Arrange
+    candidate = HostCandidate("spartn-typo", "unknown")
+    # Act
+    rejected = candidate.rejected
+    # Assert
+    assert rejected is True
+
+
+def test_local_candidate_is_not_rejected():
+    # Arrange
+    candidate = HostCandidate("this-host", "local")
+    # Act
+    rejected = candidate.rejected
+    # Assert
+    assert rejected is False
+
+
+# ---------------------------------------------------------------------------
+# The whole chain unusable — LOUD, never a silent local start.
+# ---------------------------------------------------------------------------
+
+
+def test_fully_unreachable_chain_is_unroutable():
+    # Arrange
+    oracle = _oracle(peer_a=UNREACHABLE, peer_b=UNREACHABLE)
+    # Act
+    route = _resolve(["peer-a", "peer-b"], oracle)
+    # Assert
+    assert route.kind == UNROUTABLE
+
+
+def test_fully_unreachable_chain_never_yields_a_peer():
+    # Arrange
+    oracle = _oracle(peer_a=UNREACHABLE, peer_b=UNREACHABLE)
+    # Act
+    route = _resolve(["peer-a", "peer-b"], oracle)
+    # Assert — an unusable chain must not leak an ssh target.
+    assert route.peer is None
+
+
+def test_chain_of_only_unroutable_names_is_unroutable():
+    # Arrange
+    spec_host = ["spartn-typo", "other-typo"]
+    # Act
+    route = _resolve(spec_host)
+    # Assert
+    assert route.kind == UNROUTABLE
+
+
+def test_unroutable_route_records_every_candidate_it_examined():
+    # Arrange
+    oracle = _oracle(peer_a=UNREACHABLE, peer_b=UNREACHABLE)
+    # Act
+    route = _resolve(["peer-a", "spartn-typo", "peer-b"], oracle)
+    # Assert
+    assert [c.host for c in route.candidates] == [
+        "peer-a",
+        "spartn-typo",
+        "peer-b",
+    ]
+
+
+def test_unroutable_route_distinguishes_unreachable_from_unknown_name():
+    # Arrange
+    oracle = _oracle(peer_a=UNREACHABLE)
+    # Act
+    route = _resolve(["peer-a", "spartn-typo"], oracle)
+    # Assert
+    assert [c.reachability for c in route.candidates] == [UNREACHABLE, ""]
+
+
+# ---------------------------------------------------------------------------
+# format_unroutable_chain_error — name every candidate and the fix.
+# ---------------------------------------------------------------------------
+
+
+def _unroutable_message(verb: str = "start") -> str:
+    oracle = _oracle(peer_a=UNREACHABLE)
+    route = _resolve(["peer-a", "spartn-typo"], oracle)
+    return format_unroutable_chain_error(
+        "alpha", route, _PEERS, verb=verb, current_host=_HERE
+    )
+
+
+def test_unroutable_message_names_the_unreachable_candidate():
+    # Arrange
+    verb = "start"
+    # Act
+    msg = _unroutable_message(verb)
+    # Assert
+    assert "peer-a — UNREACHABLE" in msg
+
+
+def test_unroutable_message_names_the_unroutable_name_candidate():
+    # Arrange
+    verb = "start"
+    # Act
+    msg = _unroutable_message(verb)
+    # Assert
+    assert "spartn-typo — UNKNOWN HOST" in msg
+
+
+def test_unroutable_message_names_the_agent():
+    # Arrange
+    verb = "start"
+    # Act
+    msg = _unroutable_message(verb)
+    # Assert
+    assert "'alpha'" in msg
+
+
+def test_unroutable_message_lists_the_registered_peers():
+    # Arrange
+    verb = "start"
+    # Act
+    msg = _unroutable_message(verb)
+    # Assert
+    assert "Registered peers: peer-a, peer-b" in msg
+
+
+def test_unroutable_message_points_at_sac_host_list():
+    # Arrange
+    verb = "start"
+    # Act
+    msg = _unroutable_message(verb)
+    # Assert
+    assert "sac host list" in msg
+
+
+def test_unroutable_message_names_this_machine_as_a_chain_fix():
+    # Arrange
+    verb = "start"
+    # Act
+    msg = _unroutable_message(verb)
+    # Assert — the actionable fix is "append me to the chain".
+    assert "host: [..., this-host]" in msg
+
+
+def test_unroutable_start_message_offers_the_no_redispatch_escape():
+    # Arrange
+    verb = "start"
+    # Act
+    msg = _unroutable_message(verb)
+    # Assert
+    assert "--no-redispatch" in msg
+
+
+def test_unroutable_stop_message_offers_the_on_peer_escape():
+    # Arrange
+    verb = "stop"
+    # Act
+    msg = _unroutable_message(verb)
+    # Assert
+    assert "sac --on" in msg
+
+
+def test_unroutable_message_keeps_the_candidates_in_priority_order():
+    # Arrange
+    verb = "start"
+    # Act
+    msg = _unroutable_message(verb)
+    # Assert
+    assert msg.index("1. peer-a") < msg.index("2. spartn-typo")
+
+
+# ---------------------------------------------------------------------------
+# is_remote_placement — the peer-table-free question (resume preflight).
+# ---------------------------------------------------------------------------
+
+
+def test_string_host_elsewhere_is_a_remote_placement():
+    # Arrange
+    spec_host = "peer-a"
+    # Act
+    remote = is_remote_placement(spec_host, _HERE)
+    # Assert
+    assert remote is True
+
+
+def test_string_host_naming_this_machine_is_not_remote():
+    # Arrange
+    spec_host = _HERE
+    # Act
+    remote = is_remote_placement(spec_host, _HERE)
+    # Assert
+    assert remote is False
+
+
+def test_unpinned_placement_is_not_remote():
+    # Arrange
+    spec_host = ""
+    # Act
+    remote = is_remote_placement(spec_host, _HERE)
+    # Assert
+    assert remote is False
+
+
+def test_chain_containing_this_machine_is_not_a_remote_placement():
+    # Arrange — the head is elsewhere, but the chain can degrade to here,
+    # so a preflight must not assume another machine.
+    spec_host = ["peer-a", _HERE]
+    # Act
+    remote = is_remote_placement(spec_host, _HERE)
+    # Assert
+    assert remote is False
+
+
+def test_chain_without_this_machine_is_a_remote_placement():
+    # Arrange
+    spec_host = ["peer-a", "peer-b"]
+    # Act
+    remote = is_remote_placement(spec_host, _HERE)
+    # Assert
+    assert remote is True
+
+
+# ---------------------------------------------------------------------------
+# ssh_reachability_oracle — the production probe, driven through its runner
+# seam (real build_ssh_argv, real PeerSpec, no network).
+# ---------------------------------------------------------------------------
+
+
+def test_ssh_oracle_reports_reachable_on_exit_zero():
+    # Arrange
+    oracle = ssh_reachability_oracle(_PEERS, runner=lambda argv: 0)
+    # Act
+    verdict = oracle("peer-a")
+    # Assert
+    assert verdict == REACHABLE
+
+
+def test_ssh_oracle_reports_unreachable_on_permission_denied():
+    # Arrange — ssh exits 255 on ``Permission denied (publickey)``, the
+    # 2026-08-09 failure a chain must degrade past.
+    oracle = ssh_reachability_oracle(_PEERS, runner=lambda argv: 255)
+    # Act
+    verdict = oracle("peer-a")
+    # Assert
+    assert verdict == UNREACHABLE
+
+
+def test_ssh_oracle_reports_unknown_when_the_probe_cannot_run():
+    # Arrange — no ssh binary / wedged process is "we could not look".
+    def _explode(argv: list[str]) -> int:
+        raise FileNotFoundError("ssh")
+
+    oracle = ssh_reachability_oracle(_PEERS, runner=_explode)
+    # Act
+    verdict = oracle("peer-a")
+    # Assert
+    assert verdict == UNKNOWN
+
+
+def test_ssh_oracle_reports_unknown_for_an_unregistered_host():
+    # Arrange — build_ssh_argv cannot render a hop we have no peer for.
+    oracle = ssh_reachability_oracle(_PEERS, runner=lambda argv: 0)
+    # Act
+    verdict = oracle("spartn-typo")
+    # Assert
+    assert verdict == UNKNOWN
+
+
+def test_ssh_oracle_probes_each_host_at_most_once():
+    # Arrange
+    calls: list[list[str]] = []
+
+    def _runner(argv: list[str]) -> int:
+        calls.append(argv)
+        return 0
+
+    oracle = ssh_reachability_oracle(_PEERS, runner=_runner)
+    # Act
+    oracle("peer-a")
+    oracle("peer-a")
+    # Assert
+    assert len(calls) == 1
+
+
+def test_ssh_oracle_renders_the_probe_through_build_ssh_argv():
+    # Arrange — the probe must ride the same primitive as the dispatch, or
+    # it is answering about a different route than the one we will take.
+    captured: list[list[str]] = []
+
+    def _runner(argv: list[str]) -> int:
+        captured.append(argv)
+        return 0
+
+    oracle = ssh_reachability_oracle(_PEERS, runner=_runner)
+    # Act
+    oracle("peer-a")
+    # Assert
+    assert captured[0][0] == "ssh"

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_chain_wiring.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_chain_wiring.py
@@ -71,6 +71,23 @@ def _recorder():
     return _fn
 
 
+def _write_peer_config(home, env_save_restore):
+    """Register ``peer-a`` in a REAL config.yaml and pin this machine's name.
+
+    Both hostname env forms are set so the override never conflicts with a
+    pre-set ``SAC_HOSTNAME`` in the runner env (the pattern the sibling
+    routing tests already use).
+    """
+    cfg = home / "config.yaml"
+    cfg.write_text(
+        "host:\n  fallback: hostname-short\npeers:\n  peer-a:\n    ssh: peer-a\n"
+    )
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    env_save_restore.set("SAC_HOSTNAME", _HERE)
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", _HERE)
+    return cfg
+
+
 def _dispatch(config, oracle, dispatcher):
     return try_dispatch(
         config,
@@ -371,6 +388,53 @@ def test_singleton_liveness_probe_stops_at_the_first_live_chain_host():
     )
     # Assert
     assert asked == ["peer-a"]
+
+
+def test_verdict_remote_skips_a_typo_head_for_the_next_chain_entry(
+    tmp_path, env_save_restore
+):
+    # Arrange — chain led by a name that routes nowhere, real peer at entry
+    # 2. Head-only reduction answered "not remote", so the resolver probed
+    # the LOCAL tmux and a live remote agent rendered DEAD in listings.
+    _write_peer_config(tmp_path, env_save_restore)
+    from scitex_agent_container._lifecycle._verdict_remote import (
+        _remote_peer_for_config,
+    )
+
+    # Act
+    peer = _remote_peer_for_config(_cfg(["spartn-typo", "peer-a"]))
+    # Assert
+    assert peer == "peer-a"
+
+
+def test_verdict_remote_still_resolves_a_plain_string_peer(
+    tmp_path, env_save_restore
+):
+    # Arrange — the unchanged single-pin path.
+    _write_peer_config(tmp_path, env_save_restore)
+    from scitex_agent_container._lifecycle._verdict_remote import (
+        _remote_peer_for_config,
+    )
+
+    # Act
+    peer = _remote_peer_for_config(_cfg("peer-a"))
+    # Assert
+    assert peer == "peer-a"
+
+
+def test_verdict_remote_reports_no_peer_for_a_local_placement(
+    tmp_path, env_save_restore
+):
+    # Arrange
+    _write_peer_config(tmp_path, env_save_restore)
+    from scitex_agent_container._lifecycle._verdict_remote import (
+        _remote_peer_for_config,
+    )
+
+    # Act
+    peer = _remote_peer_for_config(_cfg(_HERE))
+    # Assert
+    assert peer is None
 
 
 def test_singleton_liveness_probe_covers_every_chain_host_when_none_are_live():

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_chain_wiring.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_chain_wiring.py
@@ -1,0 +1,390 @@
+"""The reduction sites actually ROUTE through the chain resolver.
+
+``_host_chain`` being correct is worth nothing if the control plane still
+reads ``spec.host[0]``. These tests drive the real call sites — the start
+dispatcher and the singleton-skip liveness gate — and pin the behaviours a
+chain is supposed to buy: a down head degrades, a chain that names this
+machine runs locally, and a chain with nothing usable fails LOUD naming every
+candidate.
+
+No-mocks: real ``AgentConfig`` / ``HostsSpec`` / ``PeerSpec`` objects, and the
+functions' own injection seams (``reachability``, ``dispatcher``,
+``liveness_oracle``) instead of patching. Nothing here touches the network or
+PATH. Conforms to STX-TQ002 (AAA markers), STX-TQ003 (descriptive names),
+STX-TQ007 (one assert per test).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._state.host_config import PeerSpec
+from scitex_agent_container.cli_pkg.lifecycle._common import (
+    _bound_hosts,
+    _resolve_singleton_skip,
+)
+from scitex_agent_container.cli_pkg.lifecycle._dispatch import try_dispatch
+from scitex_agent_container.cli_pkg.lifecycle._host_chain import (
+    REACHABLE,
+    UNKNOWN,
+    UNREACHABLE,
+)
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import HostsSpec, SchedulingSpec
+
+_HERE = "this-host"
+_PEERS = {
+    "peer-a": PeerSpec(name="peer-a", ssh="peer-a"),
+    "peer-b": PeerSpec(name="peer-b", ssh="peer-b"),
+}
+
+
+def _cfg(host, hosts=None, sched_mode="per-host", pref="") -> AgentConfig:
+    """AgentConfig carrying a v3 ``spec.host`` pin (str / list / '')."""
+    c = AgentConfig(name="alpha")
+    c.hosts_spec = HostsSpec(host=host, hosts=hosts or [])
+    c.scheduling = SchedulingSpec(mode=sched_mode, preferred_host=pref)
+    return c
+
+
+def _oracle(**verdicts: str):
+    """Recording reachability oracle; unlisted hosts answer UNKNOWN."""
+    calls: list[str] = []
+
+    def _fn(host: str) -> str:
+        calls.append(host)
+        return verdicts.get(host.replace("-", "_"), UNKNOWN)
+
+    _fn.calls = calls  # type: ignore[attr-defined]
+    return _fn
+
+
+def _recorder():
+    """Recording stand-in for ``_dispatch_remote_start`` (the ssh handoff)."""
+    seen: list[str] = []
+
+    def _fn(*, name: str, peer: str, dry_run: bool, force: bool) -> int:
+        seen.append(peer)
+        return 0
+
+    _fn.seen = seen  # type: ignore[attr-defined]
+    return _fn
+
+
+def _dispatch(config, oracle, dispatcher):
+    return try_dispatch(
+        config,
+        _HERE,
+        _PEERS,
+        dry_run=False,
+        force=False,
+        local_names={_HERE},
+        reachability=oracle,
+        dispatcher=dispatcher,
+    )
+
+
+# ---------------------------------------------------------------------------
+# try_dispatch — the start-side route. A chain must DEGRADE.
+# ---------------------------------------------------------------------------
+
+
+def test_start_dispatches_to_a_reachable_chain_head():
+    # Arrange
+    oracle = _oracle(peer_a=REACHABLE, peer_b=REACHABLE)
+    dispatcher = _recorder()
+    # Act
+    _dispatch(_cfg(["peer-a", "peer-b"]), oracle, dispatcher)
+    # Assert
+    assert dispatcher.seen == ["peer-a"]
+
+
+def test_start_degrades_past_an_unreachable_chain_head():
+    # Arrange — the 2026-08-09 shape: the head answers Permission denied.
+    oracle = _oracle(peer_a=UNREACHABLE, peer_b=REACHABLE)
+    dispatcher = _recorder()
+    # Act
+    _dispatch(_cfg(["peer-a", "peer-b"]), oracle, dispatcher)
+    # Assert
+    assert dispatcher.seen == ["peer-b"]
+
+
+def test_start_returns_true_when_the_chain_degrades_to_a_peer():
+    # Arrange
+    oracle = _oracle(peer_a=UNREACHABLE, peer_b=REACHABLE)
+    dispatcher = _recorder()
+    # Act
+    out = _dispatch(_cfg(["peer-a", "peer-b"]), oracle, dispatcher)
+    # Assert
+    assert out is True
+
+
+def test_start_degrades_to_a_local_chain_tail_without_dispatching():
+    # Arrange — the degradation the operator actually wants: run HERE.
+    oracle = _oracle(peer_a=UNREACHABLE)
+    dispatcher = _recorder()
+    # Act
+    out = _dispatch(_cfg(["peer-a", _HERE]), oracle, dispatcher)
+    # Assert — False means "caller proceeds with the local launch".
+    assert out is False
+
+
+def test_start_never_ssh_dispatches_when_the_chain_degrades_local():
+    # Arrange
+    oracle = _oracle(peer_a=UNREACHABLE)
+    dispatcher = _recorder()
+    # Act
+    _dispatch(_cfg(["peer-a", _HERE]), oracle, dispatcher)
+    # Assert
+    assert dispatcher.seen == []
+
+
+def test_start_raises_when_every_chain_candidate_is_rejected():
+    # Arrange — no silent local start: an unusable placement is an ERROR.
+    oracle = _oracle(peer_a=UNREACHABLE, peer_b=UNREACHABLE)
+    dispatcher = _recorder()
+
+    # Act
+    def _do() -> None:
+        _dispatch(_cfg(["peer-a", "peer-b"]), oracle, dispatcher)
+
+    # Assert
+    with pytest.raises(RuntimeError):
+        _do()
+
+
+def _rejected_chain_message(chain, oracle) -> str:
+    """Message raised when ``chain`` has no usable candidate left."""
+    try:
+        _dispatch(_cfg(chain), oracle, _recorder())
+    except RuntimeError as exc:
+        return str(exc)
+    return ""
+
+
+def test_start_failure_names_the_rejected_chain_head():
+    # Arrange
+    oracle = _oracle(peer_a=UNREACHABLE, peer_b=UNREACHABLE)
+    # Act
+    msg = _rejected_chain_message(["peer-a", "peer-b"], oracle)
+    # Assert
+    assert "peer-a" in msg
+
+
+def test_start_failure_names_the_rejected_chain_tail():
+    # Arrange — the tail is the entry a head-only message would omit.
+    oracle = _oracle(peer_a=UNREACHABLE, peer_b=UNREACHABLE)
+    # Act
+    msg = _rejected_chain_message(["peer-a", "peer-b"], oracle)
+    # Assert
+    assert "peer-b" in msg
+
+
+def test_start_failure_reports_the_unreachable_reason():
+    # Arrange — "down" and "typo" have different fixes, so the message must
+    # separate them rather than lumping both under "unknown host".
+    oracle = _oracle(peer_a=UNREACHABLE)
+    # Act
+    msg = _rejected_chain_message(["peer-a", "spartn-typo"], oracle)
+    # Assert
+    assert "UNREACHABLE" in msg
+
+
+def test_start_failure_reports_the_unknown_host_reason():
+    # Arrange
+    oracle = _oracle(peer_a=UNREACHABLE)
+    # Act
+    msg = _rejected_chain_message(["peer-a", "spartn-typo"], oracle)
+    # Assert
+    assert "UNKNOWN HOST" in msg
+
+
+def test_start_never_dispatches_when_the_whole_chain_is_rejected():
+    # Arrange — negative safety: the raise happens BEFORE any ssh handoff
+    # (the raise itself is asserted by a sibling test and only absorbed
+    # here so this test's single assert stays the dispatch log).
+    oracle = _oracle(peer_a=UNREACHABLE, peer_b=UNREACHABLE)
+    dispatcher = _recorder()
+    # Act
+    try:
+        _dispatch(_cfg(["peer-a", "peer-b"]), oracle, dispatcher)
+    except RuntimeError:
+        pass
+    # Assert
+    assert dispatcher.seen == []
+
+
+# ---------------------------------------------------------------------------
+# try_dispatch — a STRING placement is untouched by all of the above.
+# ---------------------------------------------------------------------------
+
+
+def test_start_with_a_string_host_never_consults_the_oracle():
+    # Arrange — a string has nowhere to fall back to, so probing it could
+    # only turn a working dispatch into a refusal.
+    oracle = _oracle(peer_a=UNREACHABLE)
+    dispatcher = _recorder()
+    # Act
+    _dispatch(_cfg("peer-a"), oracle, dispatcher)
+    # Assert
+    assert oracle.calls == []
+
+
+def test_start_with_an_unreachable_string_host_still_dispatches():
+    # Arrange — byte-identical to the pre-chain behaviour.
+    oracle = _oracle(peer_a=UNREACHABLE)
+    dispatcher = _recorder()
+    # Act
+    _dispatch(_cfg("peer-a"), oracle, dispatcher)
+    # Assert
+    assert dispatcher.seen == ["peer-a"]
+
+
+def test_start_with_a_local_string_host_stays_local():
+    # Arrange
+    oracle = _oracle()
+    dispatcher = _recorder()
+    # Act
+    out = _dispatch(_cfg(_HERE), oracle, dispatcher)
+    # Assert
+    assert out is False
+
+
+def test_start_with_an_absent_host_stays_local():
+    # Arrange
+    oracle = _oracle()
+    dispatcher = _recorder()
+    # Act
+    out = _dispatch(_cfg(""), oracle, dispatcher)
+    # Assert
+    assert out is False
+
+
+def test_start_with_a_typo_string_host_still_raises():
+    # Arrange — the single-bad-name path is unchanged.
+    oracle = _oracle()
+    dispatcher = _recorder()
+
+    # Act
+    def _do() -> None:
+        _dispatch(_cfg("spartn-typo"), oracle, dispatcher)
+
+    # Assert
+    with pytest.raises(RuntimeError, match="peer-a"):
+        _do()
+
+
+# ---------------------------------------------------------------------------
+# _bound_hosts — the singleton pin, now plural.
+# ---------------------------------------------------------------------------
+
+
+def test_bound_hosts_returns_the_whole_chain_in_priority_order():
+    # Arrange
+    config = _cfg(["peer-a", "peer-b", _HERE])
+    # Act
+    hosts = _bound_hosts(config)
+    # Assert
+    assert hosts == ["peer-a", "peer-b", _HERE]
+
+
+def test_bound_hosts_wraps_a_string_pin_in_one_entry():
+    # Arrange
+    config = _cfg("peer-a")
+    # Act
+    hosts = _bound_hosts(config)
+    # Assert
+    assert hosts == ["peer-a"]
+
+
+def test_bound_hosts_is_empty_for_a_multi_instance_config():
+    # Arrange
+    config = _cfg("", hosts=["peer-a", "peer-b"])
+    # Act
+    hosts = _bound_hosts(config)
+    # Assert
+    assert hosts == []
+
+
+def test_bound_hosts_falls_back_to_the_v2_preferred_host():
+    # Arrange
+    config = _cfg("", sched_mode="singleton", pref="peer-a")
+    # Act
+    hosts = _bound_hosts(config)
+    # Assert
+    assert hosts == ["peer-a"]
+
+
+# ---------------------------------------------------------------------------
+# _resolve_singleton_skip — liveness across the WHOLE chain.
+#
+# The skip means "it is already running over there, defer". For a chain the
+# agent may legitimately be on entry 2, so asking only about the head answers
+# "not live", releases the pin, and starts a SECOND copy beside the running
+# one.
+# ---------------------------------------------------------------------------
+
+
+def test_singleton_defers_when_the_agent_lives_on_a_chain_fallback():
+    # Arrange — pinned to [peer-a, peer-b]; we are on this-host; the live
+    # row is on peer-b, the FALLBACK entry.
+    config = _cfg(["peer-a", "peer-b"])
+
+    def _live_on_peer_b(name: str, host: str) -> bool:
+        return host == "peer-b"
+
+    # Act
+    reason = _resolve_singleton_skip(
+        config, _HERE, no_redispatch=False, liveness_oracle=_live_on_peer_b
+    )
+    # Assert — defer, do not start a duplicate here.
+    assert reason is not None
+
+
+def test_singleton_falls_through_when_no_chain_host_has_a_live_row():
+    # Arrange — nothing running anywhere: the pin is stale, start locally.
+    config = _cfg(["peer-a", "peer-b"])
+
+    def _dead(name: str, host: str) -> bool:
+        return False
+
+    # Act
+    reason = _resolve_singleton_skip(
+        config, _HERE, no_redispatch=False, liveness_oracle=_dead
+    )
+    # Assert
+    assert reason is None
+
+
+def test_singleton_liveness_probe_stops_at_the_first_live_chain_host():
+    # Arrange — a state.db read per host is not free; stop once satisfied.
+    config = _cfg(["peer-a", "peer-b"])
+    asked: list[str] = []
+
+    def _live(name: str, host: str) -> bool:
+        asked.append(host)
+        return True
+
+    # Act
+    _resolve_singleton_skip(
+        config, _HERE, no_redispatch=False, liveness_oracle=_live
+    )
+    # Assert
+    assert asked == ["peer-a"]
+
+
+def test_singleton_liveness_probe_covers_every_chain_host_when_none_are_live():
+    # Arrange
+    config = _cfg(["peer-a", "peer-b"])
+    asked: list[str] = []
+
+    def _dead(name: str, host: str) -> bool:
+        asked.append(host)
+        return False
+
+    # Act
+    _resolve_singleton_skip(
+        config, _HERE, no_redispatch=False, liveness_oracle=_dead
+    )
+    # Assert
+    assert asked == ["peer-a", "peer-b"]

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_chain_wiring.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_chain_wiring.py
@@ -437,6 +437,66 @@ def test_verdict_remote_reports_no_peer_for_a_local_placement(
     assert peer is None
 
 
+def _write_chain_spec(home, name: str, host_line: str):
+    """Write a minimal VALID v3 spec pinned by ``host_line`` under fake HOME."""
+    from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
+    d = home / ".scitex" / "agent-container" / "agents" / name
+    d.mkdir(parents=True)
+    body = (
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+        f"  host: {host_line}\n"
+        "  workdir: /tmp/hc-test\n"
+        "  apptainer:\n"
+        "    image: /tmp/does-not-need-to-exist.sif\n"
+        "    binds: []\n"
+        "  claude:\n"
+        "    model: haiku\n"
+        "  health:\n"
+        "    enabled: true\n"
+        "    interval: 60\n"
+        "  restart:\n"
+        "    policy: on-failure\n"
+        "    max_retries: 3\n"
+    )
+    spec = d / "spec.yaml"
+    spec.write_text(explicitize_yaml(body))
+    return spec
+
+
+def test_attach_routes_a_chain_to_the_same_peer_start_would(
+    tmp_path, env_save_restore
+):
+    # Arrange — `sac agents attach` must agree with `sac agents start` about
+    # where an agent lives, or the operator is sent to a different machine
+    # than the one it was launched on. Chain led by an unroutable name.
+    env_save_restore.set("HOME", str(tmp_path))
+    _write_peer_config(tmp_path, env_save_restore)
+    _write_chain_spec(tmp_path, "hc-attach", "[spartn-typo, peer-a]")
+    from scitex_agent_container.cli_pkg.lifecycle._attach import _classify_agent_host
+
+    # Act
+    kind_peer = _classify_agent_host("hc-attach")
+    # Assert
+    assert kind_peer == ("remote", "peer-a")
+
+
+def test_attach_keeps_a_local_chain_entry_local(tmp_path, env_save_restore):
+    # Arrange
+    env_save_restore.set("HOME", str(tmp_path))
+    _write_peer_config(tmp_path, env_save_restore)
+    _write_chain_spec(tmp_path, "hc-attach-local", f"[spartn-typo, {_HERE}]")
+    from scitex_agent_container.cli_pkg.lifecycle._attach import _classify_agent_host
+
+    # Act
+    kind, _peer = _classify_agent_host("hc-attach-local")
+    # Assert
+    assert kind == "local"
+
+
 def test_singleton_liveness_probe_covers_every_chain_host_when_none_are_live():
     # Arrange
     config = _cfg(["peer-a", "peer-b"])

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_routing.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__host_routing.py
@@ -14,12 +14,20 @@ from pathlib import Path
 import pytest
 
 from scitex_agent_container._state.host_config import PeerSpec
+from scitex_agent_container.cli_pkg.lifecycle._host_chain import (
+    REACHABLE,
+    UNKNOWN,
+    UNREACHABLE,
+)
 from scitex_agent_container.cli_pkg.lifecycle._host_routing import (
     UnknownSpecHostError,
     classify_spec_host_route,
+    format_route_error,
     format_unknown_host_error,
     has_active_row,
     resolve_spec_host_peer,
+    resolve_spec_host_route,
+    resolve_start_dispatch_peer,
     spec_host_fallback_peer,
 )
 
@@ -369,5 +377,209 @@ def test_fallback_routes_by_spec_pin_when_no_row_exists(
     _write_spec(fake_home, "hr-fallback", "peer-host")
     # Act
     peer = spec_host_fallback_peer("hr-fallback", _PEERS, verb="restart")
+    # Assert
+    assert peer == "peer-host"
+
+
+# ---------------------------------------------------------------------------
+# FALLBACK CHAIN routing — reachability decides, and a dead chain fails loud.
+#
+# ``_PEERS`` holds only ``peer-host``, so a second peer is registered where a
+# chain needs somewhere to degrade TO.
+# ---------------------------------------------------------------------------
+
+_CHAIN_PEERS = {
+    "peer-host": PeerSpec(name="peer-host", ssh="peer-host"),
+    "peer-two": PeerSpec(name="peer-two", ssh="peer-two"),
+}
+
+
+def _verdicts(**by_host: str):
+    """Injected reachability oracle; unlisted hosts answer UNKNOWN."""
+
+    def _fn(host: str) -> str:
+        return by_host.get(host.replace("-", "_"), UNKNOWN)
+
+    return _fn
+
+
+def test_classify_chain_degrades_past_an_unreachable_head():
+    # Arrange
+    oracle = _verdicts(peer_host=UNREACHABLE, peer_two=REACHABLE)
+    # Act
+    kind_peer = classify_spec_host_route(
+        ["peer-host", "peer-two"],
+        "this-host",
+        _CHAIN_PEERS,
+        local_names={"this-host"},
+        reachability=oracle,
+    )
+    # Assert
+    assert kind_peer == ("remote", "peer-two")
+
+
+def test_classify_chain_degrades_to_this_machine_when_peers_are_down():
+    # Arrange
+    oracle = _verdicts(peer_host=UNREACHABLE)
+    # Act
+    kind_peer = classify_spec_host_route(
+        ["peer-host", "this-host"],
+        "this-host",
+        _CHAIN_PEERS,
+        local_names={"this-host"},
+        reachability=oracle,
+    )
+    # Assert
+    assert kind_peer == ("local", None)
+
+
+def test_classify_fully_unreachable_chain_keeps_the_legacy_unknown_shape():
+    # Arrange — callers that only ask "(kind, peer)" must keep seeing the
+    # historic "unknown" for a placement they must not dispatch.
+    oracle = _verdicts(peer_host=UNREACHABLE, peer_two=UNREACHABLE)
+    # Act
+    kind_peer = classify_spec_host_route(
+        ["peer-host", "peer-two"],
+        "this-host",
+        _CHAIN_PEERS,
+        local_names={"this-host"},
+        reachability=oracle,
+    )
+    # Assert
+    assert kind_peer == ("unknown", None)
+
+
+def test_route_exposes_the_rejected_candidates_for_the_error_message():
+    # Arrange
+    oracle = _verdicts(peer_host=UNREACHABLE, peer_two=UNREACHABLE)
+    # Act
+    route = resolve_spec_host_route(
+        ["peer-host", "peer-two"],
+        "this-host",
+        _CHAIN_PEERS,
+        local_names={"this-host"},
+        reachability=oracle,
+    )
+    # Assert
+    assert [c.host for c in route.candidates] == ["peer-host", "peer-two"]
+
+
+def test_format_route_error_uses_the_single_name_message_for_a_string():
+    # Arrange — a string placement's message is unchanged from before
+    # chains existed.
+    route = resolve_spec_host_route(
+        "spartn-typo", "this-host", _PEERS, local_names={"this-host"}
+    )
+    # Act
+    msg = format_route_error(
+        "alpha", "spartn-typo", route, _PEERS, verb="start", current_host="this-host"
+    )
+    # Assert
+    assert msg == format_unknown_host_error(
+        "alpha", "spartn-typo", _PEERS, verb="start"
+    )
+
+
+def test_format_route_error_uses_the_chain_message_for_a_list():
+    # Arrange
+    oracle = _verdicts(peer_host=UNREACHABLE, peer_two=UNREACHABLE)
+    spec_host = ["peer-host", "peer-two"]
+    route = resolve_spec_host_route(
+        spec_host,
+        "this-host",
+        _CHAIN_PEERS,
+        local_names={"this-host"},
+        reachability=oracle,
+    )
+    # Act
+    msg = format_route_error(
+        "alpha", spec_host, route, _CHAIN_PEERS, verb="start", current_host="this-host"
+    )
+    # Assert
+    assert "Chain (priority order):" in msg
+
+
+def test_resolve_spec_chain_degrades_to_a_reachable_fallback(fake_home):
+    # Arrange
+    _write_spec(fake_home, "hr-chain", "[peer-host, peer-two]")
+    oracle = _verdicts(peer_host=UNREACHABLE, peer_two=REACHABLE)
+    # Act
+    peer = resolve_spec_host_peer(
+        "hr-chain",
+        _CHAIN_PEERS,
+        verb="stop",
+        current_host="this-host",
+        local_names={"this-host"},
+        reachability=oracle,
+    )
+    # Assert
+    assert peer == "peer-two"
+
+
+def test_resolve_spec_chain_with_nothing_usable_raises(fake_home):
+    # Arrange
+    _write_spec(fake_home, "hr-dead-chain", "[peer-host, peer-two]")
+    oracle = _verdicts(peer_host=UNREACHABLE, peer_two=UNREACHABLE)
+
+    # Act
+    def _do() -> None:
+        resolve_spec_host_peer(
+            "hr-dead-chain",
+            _CHAIN_PEERS,
+            verb="restart",
+            current_host="this-host",
+            local_names={"this-host"},
+            reachability=oracle,
+        )
+
+    # Assert
+    with pytest.raises(UnknownSpecHostError, match="peer-two"):
+        _do()
+
+
+def test_start_dispatch_peer_degrades_past_an_unreachable_head():
+    # Arrange
+    oracle = _verdicts(peer_host=UNREACHABLE, peer_two=REACHABLE)
+    # Act
+    peer = resolve_start_dispatch_peer(
+        "alpha",
+        ["peer-host", "peer-two"],
+        "this-host",
+        _CHAIN_PEERS,
+        local_names={"this-host"},
+        reachability=oracle,
+    )
+    # Assert
+    assert peer == "peer-two"
+
+
+def test_start_dispatch_peer_is_none_when_the_chain_reaches_this_machine():
+    # Arrange
+    oracle = _verdicts(peer_host=UNREACHABLE)
+    # Act
+    peer = resolve_start_dispatch_peer(
+        "alpha",
+        ["peer-host", "this-host"],
+        "this-host",
+        _CHAIN_PEERS,
+        local_names={"this-host"},
+        reachability=oracle,
+    )
+    # Assert
+    assert peer is None
+
+
+def test_start_dispatch_peer_with_an_unreachable_string_is_unchanged():
+    # Arrange — a string is never probed; this is the no-regression pin.
+    oracle = _verdicts(peer_host=UNREACHABLE)
+    # Act
+    peer = resolve_start_dispatch_peer(
+        "alpha",
+        "peer-host",
+        "this-host",
+        _CHAIN_PEERS,
+        local_names={"this-host"},
+        reachability=oracle,
+    )
     # Assert
     assert peer == "peer-host"


### PR DESCRIPTION
Opened by **dotfiles**, for your review — not merged. Sibling of #930; together they are the runtime half of the operator's P1 "make agents movable between hosts". The 107 spec edits are mine and come second.

## The defect

`config/_types.py` documents `host` as a fallback chain:

```python
host: str | list[str] = ""
"""- list: priority order; first available host wins (fallback chain)"""
```

**Nothing implemented it.** All five sites that reduce the list took index `[0]` with no availability check — `_verdict_remote.py:55`, `_common.py:165`, `_start_single.py:293`, `_host_routing.py:193`, `_dispatch.py:376`. So `host: [a, b]` picked `a` every time and died exactly as a bare string would.

This is not theoretical. It is the mechanism behind step 2 of the 2026-08-09 scitex-compute-04 outage: specs reverted to `host: ywata-note-win`, and sac then ssh-dispatched every lifecycle verb to `localhost` → `Permission denied (publickey)`. Measured separately: of the 12 agents running on that box, **11 of 11 with tracked specs declare a host they are not on**, and **zero of 107 specs name the host they actually run on**. The field cannot mean "where the agent is".

## Design

- **Three-valued, as doctrine not decoration.** `REACHABLE` / `UNREACHABLE` / `UNKNOWN`. UNREACHABLE is *evidence of failure* — a probe ran and said no. UNKNOWN is *absence of evidence* — no oracle, or the probe could not run — and **it rejects nothing**. A candidate is dropped only on hard evidence. The docstring grounds this in your own precedents (`_lifecycle/_verdict`'s "a probe that could not run is UNKNOWN, never DEAD"; `_listen/_reachability`'s three states).
- **Injected oracle, not a hidden network call.** `ReachabilityOracle` is a `(host) -> verdict` callable, injected exactly as `peers`/`local_names` already are. The module imports neither `socket` nor `subprocess` — the pure resolver stayed pure.
- **A single host is NEVER probed**, even when an oracle is supplied. There is nothing to fall back to, so a probe could only convert a working dispatch into a refusal. That makes `host: <name>` and the no-oracle path byte-identical to today **structurally**, not merely by test.
- **`sac agents attach`** was routing differently from `start` — a fifth consumer beyond the five reduction sites. Fixed, or the chain would have been honoured on one path and ignored on the other.

## Evidence

**I verified this myself.** The worker that wrote it was stopped before reporting, so its own mutation numbers were lost; rather than take the code on trust I re-ran everything from the committed tree.

```
BASELINE (unmutated)                              117 passed
M-A  probe always REACHABLE (head always wins)     30 failed, 87 passed
M-B  UNKNOWN collapsed into UNREACHABLE            16 failed, 101 passed
M-C  local-wins removed (dispatch to self)          3 failed, 114 passed
RESTORED                                          117 passed, tree clean
```

M-B is the one I care about most: collapsing UNKNOWN into a rejection is the failure this codebase's own constitution calls the most common bug it ships, and 16 tests catch it.

11 files, +2185/−113, of which 1382 lines are tests.

## Deliberately not done

- **No spec migrated.** The 107 spec edits wait until this and #930 land; writing host lists today would look like a fix and change nothing.
- Nothing merged — yours to merge, reject, or redirect.

Related: #930 (declared bind intent), same operator P1, independent change.