### PR TITLE
feat(lifecycle): warn at launch when an agent board identity differs from its name

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_identity_drift.py
+++ b/src/scitex_agent_container/_lifecycle/_identity_drift.py
@@ -1,0 +1,101 @@
+"""Launch-time check: does this agent's BOARD identity match its NAME?
+
+An agent has two names that must agree and are set in different places:
+
+* the agent NAME — its spec dir, its tmux session, how peers address it
+  over a2a;
+* ``SCITEX_TODO_AGENT_ID`` — its identity on the shared card board, which
+  determines which cards it owns and whose inbox it polls.
+
+``_create_templates`` derives the second from the first, so a
+properly-created agent cannot drift. A HAND-EDITED spec can, and does.
+
+INCIDENT 2026-08-09
+-------------------
+The sac maintainer on scitex-compute-04 ran with name
+``scitex-agent-container-04`` and ``SCITEX_TODO_AGENT_ID`` of
+``scitex-agent-container`` — one process, two identities, because the
+spec was hand-made during a host migration. The consequences were all
+SILENT:
+
+* its routine sweep, ``list_tasks(assignee=<board identity>)``, returned
+  ``[]`` and it twice reported "board is clear, holding idle" while a P1
+  with a full implementation brief sat runnable under the OTHER name;
+* its pull-inbox under the agent name accumulated unseen notifications
+  it never polled, including a card another agent filed for it;
+* every ``reassign_task`` it performed came back
+  ``assignee_liveness: unknown``, so a real handoff was indistinguishable
+  from a handoff into the void.
+
+Nothing errored. Both queries succeeded and returned well-formed empty
+results, because "no cards assigned to you" and "no cards assigned to
+THIS SPELLING of you" render identically.
+
+Contract
+--------
+LOUD WARNING, never a block — deliberately the same contract as the
+sibling :func:`._start_preflight._check_spec_source_drift_at_launch`. A
+mismatch is usually a migration artifact on an agent that is otherwise
+working, and refusing to launch would strand it rather than inform its
+operator. Best-effort throughout: this check never crashes a launch.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+#: The env var whose value IS the agent's identity on the card board.
+BOARD_IDENTITY_ENV = "SCITEX_TODO_AGENT_ID"
+
+
+def check_board_identity_at_launch(config) -> str | None:
+    """Warn when the spec's board identity differs from the agent name.
+
+    Returns the mismatching board identity (for tests and callers that
+    want to report it), or ``None`` when they agree, when the spec sets
+    no board identity at all, or when anything is unreadable.
+
+    A spec that sets NO board identity is not a mismatch: the agent
+    inherits whatever the runtime provides, which is the documented
+    default path and not the failure this guards.
+    """
+    # stx-allow: fallback (reason: a launch-time advisory must never crash
+    # the launch; an unreadable spec here simply yields no warning, and the
+    # spec loader itself reports malformed specs far more precisely.)
+    try:
+        name = str(getattr(config, "name", "") or "")
+        spec_env = getattr(config, "env", None) or {}
+        board_id = str(spec_env.get(BOARD_IDENTITY_ENV, "") or "").strip()
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+
+    if not name or not board_id or board_id == name:
+        return None
+
+    logger.warning(
+        "IDENTITY MISMATCH for agent %r: its %s is %r. This agent is ONE "
+        "process with TWO names — peers address it as %r over a2a, while it "
+        "owns cards and polls its inbox as %r. THE AGENT STARTS NORMALLY; "
+        "this is not a startup failure. What it costs: a card sweep by one "
+        "name returns an empty list while work sits runnable under the "
+        "other, and neither query errors, because 'no cards assigned to you' "
+        "and 'no cards assigned to THIS SPELLING of you' look identical. "
+        "Measured 2026-08-09: exactly this hid a P1 from the agent that "
+        "owned it for over an hour. Fix with `sac agents rename %s %s` "
+        "(atomic across the six on-disk locations AND the board — it "
+        "migrates the cards, which is the part that must not be done by "
+        "hand; run it with --dry-run first).",
+        name,
+        BOARD_IDENTITY_ENV,
+        board_id,
+        name,
+        board_id,
+        name,
+        board_id,
+    )
+    return board_id
+
+
+__all__ = ["BOARD_IDENTITY_ENV", "check_board_identity_at_launch"]

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -29,6 +29,7 @@ from ._start_announce import _announce_start_verdict  # noqa: F401
 
 # Re-exported from _start_failure_diag for back-compat: this helper lived here
 # before the 512-line-cap split.
+from ._identity_drift import check_board_identity_at_launch
 from ._start_failure_diag import _format_boot_stderr_section  # noqa: F401
 from ._start_outcome import NOOP_ALREADY_RUNNING
 
@@ -156,6 +157,16 @@ def agent_start(
     # a non-git source / unreachable remote / any error warns-and-continues
     # — the check never crashes a launch (resilience is the contract).
     _check_spec_source_drift_at_launch(config_path, config.name, strict_drift)
+
+    # Launch-time BOARD IDENTITY check, same contract as the drift check
+    # above: LOUD WARNING, never a block, never crashes a launch. An agent
+    # whose name and SCITEX_TODO_AGENT_ID disagree is one process with two
+    # identities — peers address it by one, it owns cards and polls its
+    # inbox as the other — and every symptom is SILENT, because a card
+    # query for the wrong spelling returns a well-formed empty list rather
+    # than an error. Measured 2026-08-09: that hid a P1 from the agent
+    # that owned it for over an hour. See :mod:`._identity_drift`.
+    check_board_identity_at_launch(config)
 
     # CREDS-PHASE1 — auto-rotate ``spec.claude.account`` to a healthy
     # stored account when the pinned one's snapshot is EXPIRED/ABSENT.

--- a/tests/scitex_agent_container/_lifecycle/test__identity_drift.py
+++ b/tests/scitex_agent_container/_lifecycle/test__identity_drift.py
@@ -1,0 +1,131 @@
+"""An agent must not start silently holding two identities.
+
+INCIDENT 2026-08-09 on scitex-compute-04. The sac maintainer ran with
+agent name ``scitex-agent-container-04`` and ``SCITEX_TODO_AGENT_ID`` of
+``scitex-agent-container`` — one process, two names, because the spec was
+hand-made during a host migration.
+
+Every consequence was SILENT:
+
+* its card sweep, ``list_tasks(assignee=<board identity>)``, returned
+  ``[]`` and it twice reported "board is clear, holding idle" while a P1
+  with a full implementation brief sat runnable under the other name;
+* its pull-inbox under the agent name accumulated notifications it never
+  polled, including a card another agent filed for it;
+* every ``reassign_task`` returned ``assignee_liveness: unknown``.
+
+Nothing errored, because "no cards assigned to you" and "no cards
+assigned to THIS SPELLING of you" render identically.
+
+The guard is a WARNING, never a block — the same contract as the sibling
+spec-source drift check. A mismatch is usually a migration artifact on an
+agent that is otherwise working, and refusing to launch would strand it
+rather than inform its operator. :func:`test_mismatch_does_not_raise`
+pins that.
+
+No mocks (PA-306): the function is pure over a spec-shaped object, and
+the warning is observed through pytest's real ``caplog``. AAA markers,
+one assertion per test.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from scitex_agent_container._lifecycle._identity_drift import (
+    BOARD_IDENTITY_ENV,
+    check_board_identity_at_launch,
+)
+
+
+def _config(name: str, board_id: str | None):
+    env = {} if board_id is None else {BOARD_IDENTITY_ENV: board_id}
+    return SimpleNamespace(name=name, env=env)
+
+
+def test_mismatch_is_reported():
+    # Arrange
+    config = _config("scitex-agent-container-04", "scitex-agent-container")
+    # Act
+    result = check_board_identity_at_launch(config)
+    # Assert
+    assert result == "scitex-agent-container"
+
+
+def test_matching_identity_is_silent():
+    # Arrange
+    config = _config("scitex-cards", "scitex-cards")
+    # Act
+    result = check_board_identity_at_launch(config)
+    # Assert
+    assert result is None
+
+
+def test_absent_board_identity_is_not_a_mismatch():
+    # Arrange: a spec setting no board identity inherits the runtime's,
+    # which is the documented default path — not the failure guarded here.
+    config = _config("scitex-db", None)
+    # Act
+    result = check_board_identity_at_launch(config)
+    # Assert
+    assert result is None
+
+
+def test_empty_board_identity_is_not_a_mismatch():
+    # Arrange: an empty value is absence, not a second name.
+    config = _config("scitex-db", "")
+    # Act
+    result = check_board_identity_at_launch(config)
+    # Assert
+    assert result is None
+
+
+def test_mismatch_does_not_raise():
+    # Arrange: LOUD WARNING, never a block. Refusing to launch would
+    # strand an agent that is otherwise working.
+    config = _config("agent-a", "agent-b")
+    # Act
+    check_board_identity_at_launch(config)
+    # Assert
+    assert True
+
+
+def test_unreadable_config_does_not_raise():
+    # Arrange: a launch-time advisory must never crash the launch.
+    config = object()
+    # Act
+    result = check_board_identity_at_launch(config)
+    # Assert
+    assert result is None
+
+
+def test_warning_names_both_identities(caplog):
+    # Arrange
+    config = _config("agent-a", "agent-b")
+    # Act
+    with caplog.at_level(logging.WARNING):
+        check_board_identity_at_launch(config)
+    # Assert
+    assert "agent-a" in caplog.text and "agent-b" in caplog.text
+
+
+def test_warning_points_at_the_rename_command(caplog):
+    # Arrange: an error that only states what broke is half written. The
+    # fix must not be done by hand — the rename migrates the cards.
+    config = _config("agent-a", "agent-b")
+    # Act
+    with caplog.at_level(logging.WARNING):
+        check_board_identity_at_launch(config)
+    # Assert
+    assert "sac agents rename" in caplog.text
+
+
+def test_warning_says_the_agent_still_starts(caplog):
+    # Arrange: the reader must not mistake an advisory for a boot failure.
+    config = _config("agent-a", "agent-b")
+    # Act
+    with caplog.at_level(logging.WARNING):
+        check_board_identity_at_launch(config)
+    # Assert
+    assert "STARTS NORMALLY" in caplog.text


### PR DESCRIPTION
An agent has two names that must agree, set in different places: the agent NAME (spec dir, tmux session, how peers address it over a2a) and `SCITEX_TODO_AGENT_ID` (its identity on the card board, which decides which cards it owns and whose inbox it polls).

`_create_templates` derives the second from the first, so a properly created agent cannot drift. A hand-edited spec can, and did.

## What it cost

2026-08-09: the sac maintainer ran as `scitex-agent-container-04` with a board identity of `scitex-agent-container`. Every consequence was SILENT:

- its card sweep returned `[]` and it reported "board is clear, holding idle" **twice**, while a P1 with a full implementation brief sat runnable under the other name
- its pull-inbox under the agent name accumulated notifications it never polled, including a card another agent filed for it
- every `reassign_task` returned `assignee_liveness: unknown`

Nothing errored: "no cards assigned to you" and "no cards assigned to THIS SPELLING of you" render identically. It went unnoticed for over an hour and was found by accident.

## Contract

LOUD WARNING, never a block — deliberately the same contract as the sibling `_check_spec_source_drift_at_launch` it sits beside. A mismatch is usually a migration artifact on an agent that is otherwise working; refusing to launch would strand it rather than inform its operator. A test pins that it does not raise.

The message names both identities, says the agent starts normally, states what the mismatch costs, and points at `sac agents rename` — atomic across the six on-disk locations AND the board, since it migrates the cards.

A spec that sets NO board identity is deliberately not flagged: that inherits the runtime default, and flagging it would train everyone to ignore the warning.

Tests: 9 new. Lifecycle suite 1289 passed vs 1280 on untouched develop (+9 = these), same 60 pre-existing failures both sides, baselined rather than assumed.