### PR TITLE
feat(system-deps): declare sac apt dependencies in the scitex_dev federation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,15 @@ scitex-agent-container = "scitex_agent_container._linter_plugin:get_plugin"
 [project.entry-points."scitex_dev.jobs"]
 scitex-agent-container = "scitex_agent_container._jobs._jobs_plugin:provide_jobs"
 
+# sac's SYSTEM (apt) dependency declarations, aggregated by
+# scitex_dev.system_deps.discover_system_deps. sac registered NOTHING here
+# until 2026-08-09 while apptainer-base.def hardcoded its apt list — so the
+# BASE image bypassed the federation the SCITEX def calls "SSoT — NOT a
+# hardcoded list". Declaring them is what makes the list auditable; the
+# reason field on each dep is the part that carries the value.
+[project.entry-points."scitex_dev.system_deps"]
+scitex-agent-container = "scitex_agent_container._system_deps:provide"
+
 # C10 — sac's consumer on scitex-todo's shared card-event bus. When
 # scitex-todo's board emits a card-event (commented / created /
 # reassigned / status_changed / completed / committed / pushed /

--- a/src/scitex_agent_container/_system_deps.py
+++ b/src/scitex_agent_container/_system_deps.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_agent_container/_system_deps.py
+"""scitex-agent-container's own SYSTEM (apt) dependency declarations.
+
+sac declared none until now, while ``apptainer-base.def`` hardcoded an apt
+list — so the BASE image bypassed the very federation the SCITEX def calls
+"SSoT — NOT a hardcoded list". This registers sac under the same
+``scitex_dev.system_deps`` entry-point group every leaf uses, so
+``discover_system_deps`` aggregates it like any other provider.
+
+THE REASON FIELD IS THE POINT, not the package list. An apt line records
+WHAT is installed; only the reason records WHY, and "why" is what makes the
+list auditable — it is how a future reader decides whether a dep can be
+dropped. Each entry below names the mechanism that breaks without it, not
+the tool's marketing description.
+
+Note especially the search tools: they are not conveniences here. The
+agent hooks this fleet runs MANDATE ripgrep (``enforce_ripgrep.sh`` denies
+``grep -r`` outright), so an undeclared mandate is one apt-line edit away
+from silently breaking every agent's search. That is exactly the class of
+coupling a declaration exists to make visible.
+"""
+
+from __future__ import annotations
+
+from scitex_dev.system_deps import SystemDepSpec
+
+_PROVIDER = "scitex-agent-container"
+
+
+def provide() -> list[SystemDepSpec]:
+    """System deps sac itself needs at image-build time."""
+    return [
+        SystemDepSpec(
+            "ripgrep",
+            "MANDATED by the agent hooks: enforce_ripgrep.sh DENIES `grep -r` "
+            "and instructs the agent to use `rg`, so removing it breaks every "
+            "agent's search rather than degrading it",
+            _PROVIDER,
+        ),
+        SystemDepSpec(
+            "fd-find",
+            "the hook-sanctioned `find` replacement agents are steered to; "
+            "paired with ripgrep in the same enforcement doctrine",
+            _PROVIDER,
+        ),
+        SystemDepSpec(
+            "gh",
+            "agents open their own pull requests (operator ruling 2026-08-09); "
+            "`gh pr create` is an API call, so SSH transport alone is not "
+            "enough. Present in the container image and deliberately absent "
+            "from the bare host — the host runs the runtime, the container "
+            "runs the tooling",
+            _PROVIDER,
+        ),
+        SystemDepSpec(
+            "git",
+            "the worktree-per-task workflow is enforced by hooks: edits are "
+            "denied outside a linked worktree, so git is load-bearing for the "
+            "agent to do any tracked-file work at all",
+            _PROVIDER,
+        ),
+        SystemDepSpec(
+            "tmux",
+            "an agent session IS a tmux session — sac's TuiSessionRuntime "
+            "starts, stops and injects turns through it, and tmux is also the "
+            "only liveness signal that survives a registry outage",
+            _PROVIDER,
+        ),
+        SystemDepSpec(
+            "openssh-client",
+            "cross-host credential distribution and peer snapshot push "
+            "(_account.snapshot_push) run over ssh; without it a compute host "
+            "cannot pull a refreshed token from the master",
+            _PROVIDER,
+        ),
+        SystemDepSpec(
+            "curl",
+            "bootstrap path for the uv installer in the container entrypoint, "
+            "and the fallback probe for the listen daemon's health endpoint",
+            _PROVIDER,
+        ),
+    ]
+
+
+__all__ = ["provide"]

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -32,6 +32,7 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_dev.linter._rules._base",
     "scitex_dev.linter._rules._lookup",
     "scitex_dev.linter.checker",
+    "scitex_dev.system_deps",
     "scitex_dev.versioning",
     "scitex_logging",
     "scitex_notification",

--- a/tests/scitex_agent_container/test__system_deps.py
+++ b/tests/scitex_agent_container/test__system_deps.py
@@ -1,0 +1,126 @@
+"""sac must DECLARE its system deps, not leave them implicit in an apt line.
+
+`scitex_dev.system_deps` is a working entry-point federation;
+`discover_system_deps` aggregates it; apptainer-scitex.def calls it
+"SSoT — NOT a hardcoded list". sac registered NOTHING in it while
+apptainer-base.def hardcoded apt at :98, :109, :169 and :189-197 — so the
+BASE image bypassed the federation the SCITEX def declares authoritative.
+
+THE REASON FIELD IS THE POINT. An apt line records WHAT is installed; only
+the reason records WHY, and "why" is what lets a future reader decide
+whether a dep can be dropped. So the tests below check that reasons are
+substantive rather than transcriptions of the package name — a declaration
+whose reasons say "installs ripgrep" would satisfy the schema and defeat
+the purpose.
+
+ripgrep gets its own test because it is the sharpest case: the agent hooks
+this fleet runs MANDATE it (enforce_ripgrep.sh DENIES `grep -r`), so an
+undeclared mandate is one apt-line edit away from silently breaking every
+agent's search.
+
+No mocks (PA-306): the real provider, and the real entry-point metadata.
+AAA markers, one assertion per test.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+
+import pytest
+
+from scitex_agent_container._system_deps import provide
+
+_GROUP = "scitex_dev.system_deps"
+
+
+@pytest.fixture
+def sac_entry_point():
+    """The installed entry point, or skip when the package is not installed."""
+    eps = [
+        ep for ep in entry_points(group=_GROUP) if ep.name == "scitex-agent-container"
+    ]
+    if not eps:
+        pytest.skip("scitex-agent-container entry point not installed in this env")
+    return eps[0]
+
+
+def test_provider_returns_at_least_one_dep():
+    # Arrange
+    provider = provide
+    # Act
+    deps = provider()
+    # Assert
+    assert deps
+
+
+def test_every_dep_names_its_provider():
+    # Arrange: the aggregator attributes each dep to the package that needs
+    # it, so an unattributed entry cannot be traced back when questioned.
+    deps = provide()
+    # Act
+    providers = {d.provider for d in deps}
+    # Assert
+    assert providers == {"scitex-agent-container"}
+
+
+def test_every_dep_carries_a_purpose():
+    # Arrange
+    deps = provide()
+    # Act
+    missing = [d.package for d in deps if not (d.purpose or "").strip()]
+    # Assert
+    assert missing == []
+
+
+def test_purposes_are_more_than_a_restatement_of_the_package():
+    # Arrange: "ripgrep — installs ripgrep" would pass a bare non-empty
+    # check and carry nothing. The purpose has to say what BREAKS without it.
+    deps = provide()
+    # Act
+    thin = [d.package for d in deps if len(d.purpose.split()) < 6]
+    # Assert
+    assert thin == []
+
+
+def test_ripgrep_is_declared_because_the_hooks_mandate_it():
+    # Arrange: the sharpest case — enforce_ripgrep.sh denies `grep -r`, so
+    # removing rg breaks every agent's search rather than degrading it.
+    deps = provide()
+    # Act
+    rg = [d for d in deps if d.package == "ripgrep"]
+    # Assert
+    assert rg
+
+
+def test_tmux_is_declared_because_a_session_is_a_tmux_session():
+    # Arrange: sac's TuiSessionRuntime starts, stops and injects turns
+    # through tmux, and tmux is the liveness signal that survives a
+    # registry outage — it is load-bearing, not a convenience.
+    deps = provide()
+    # Act
+    packages = {d.package for d in deps}
+    # Assert
+    assert "tmux" in packages
+
+
+def test_the_entry_point_is_registered(sac_entry_point):
+    # Arrange: the module existing is not enough — the aggregator finds
+    # providers through the entry-point group, so an unregistered provider
+    # is invisible no matter how well it is written. Skipped rather than
+    # failed when the package is not pip-installed in the running env: that
+    # is a property of the environment, not of this declaration.
+    ep = sac_entry_point
+    # Act
+    name = ep.name
+    # Assert
+    assert name == "scitex-agent-container"
+
+
+def test_the_entry_point_resolves_to_this_provider(sac_entry_point):
+    # Arrange: a registered name that loads something else is worse than an
+    # absent one, because it looks correct in the metadata.
+    ep = sac_entry_point
+    # Act
+    loaded = ep.load()
+    # Assert
+    assert loaded is provide


### PR DESCRIPTION
sac registered **nothing** in the `scitex_dev.system_deps` entry-point federation while `apptainer-base.def` hardcoded its apt list at `:98`, `:109` (fd-find ripgrep bat eza), `:169` (gh) and `:189-197` (node). So the BASE image bypassed the federation the SCITEX def calls *"SSoT — NOT a hardcoded list"*, and `base.def:801`s `org.scitex.contains` label — a string — was the closest thing to a declaration sac had.

## The reason field is the point

An apt line records WHAT is installed. Only the purpose records WHY, and *why* is what lets a future reader decide whether a dep can be dropped. Each entry names the mechanism that breaks without it rather than describing the tool. Two worth reading:

**ripgrep** is not a convenience. The agent hooks this fleet runs MANDATE it — `enforce_ripgrep.sh` denies `grep -r` outright and instructs the agent to use `rg`. An undeclared mandate is one apt-line edit away from silently breaking every agent search, which is exactly the coupling a declaration exists to make visible.

**tmux** — an agent session *is* a tmux session. `TuiSessionRuntime` starts, stops and injects turns through it, and on 2026-08-09 tmux was the only liveness signal that survived a registry outage, when `a2a_peers` reported zero agents while twelve were running.

## Scope

Deliberately points (1) and (2) of the card: the provider and its entry point. Point (3) — `base.def` sourcing its list FROM the aggregator — changes image builds and lands separately.

## Tests

8 tests; 2 skip when the package is not pip-installed in the running environment. Those two exercise entry-point metadata, which is a property of the install rather than of this declaration — skipping is honest there, where failing would be noise. They run in CI.

The rest assert the contract that matters: every dep names its provider, every dep carries a purpose, and no purpose is a restatement of the package name — `"ripgrep: installs ripgrep"` would satisfy a non-empty check and carry nothing.

## One correction, recorded

I first wrote these tests against `.name` / `.reason` / `.owner`, inferred from a **call site** in scitex-devs own provider rather than from the class. The real fields are `package` / `purpose` / `provider`. Six tests failed instantly — the cheap version of that mistake. Reading the dataclass would have been cheaper still.