### PR TITLE
fix(mcp): resume the inbox stream from Last-Event-ID so a reconnect stops dropping messages

### DIFF
--- a/src/scitex_agent_container/_mcp/_channel_sse.py
+++ b/src/scitex_agent_container/_mcp/_channel_sse.py
@@ -139,12 +139,43 @@ async def _consume_sse(
     if bearer:
         headers["Authorization"] = f"Bearer {bearer}"
 
+    # Replay cursor: the SQLite row id of the last event we actually
+    # dispatched, echoed back as ``Last-Event-ID`` so a reconnect resumes
+    # where we stopped instead of at "now".
+    #
+    # WITHOUT THIS, EVERY DISCONNECT SILENTLY DROPS MESSAGES. The server
+    # side has always supported replay — ``a2a/_inbox_stream.py`` stamps the
+    # row id on every frame's ``id:`` line and replays ``id > Last-Event-ID``
+    # from ``channel_events`` — but this consumer parsed only ``data:``,
+    # discarded the ``id:`` line, and rebuilt no header on reconnect. So the
+    # durable log kept everything and the agent was simply never handed the
+    # events that arrived while it was re-dialing.
+    #
+    # Measured 2026-08-09: across ONE `sac listen` restart my a2a_inbox went
+    # 10 items -> 2 and scitex-storage's 2 -> 0, and we jointly filed it as a
+    # durability defect ("it cost a real message"). It had not: channel_events
+    # held 355 rows, 51 addressed to me, spanning the restart, 350 stamped
+    # delivered — including the message I reported lost. The loss was in the
+    # asking, not in the storing.
+    #
+    # None means "no cursor yet" (first connect) and is DISTINCT from 0, which
+    # would be a valid row id meaning "replay everything". Only send the header
+    # once we hold an id the server gave us: the server 400s a malformed
+    # cursor, and inventing one would turn a reconnect into a hard failure.
+    last_event_id: str | None = None
+
     backoff = _SSE_BACKOFF_START_S
     sse_timeout = httpx.Timeout(_SSE_CONNECT_TIMEOUT_S, read=_sse_read_timeout_s())
     while True:
         try:
+            # Rebuild per attempt so the cursor advances across reconnects.
+            # A dict built once outside the loop would pin the FIRST cursor
+            # forever and replay the same window on every re-dial.
+            attempt_headers = dict(headers)
+            if last_event_id is not None:
+                attempt_headers["Last-Event-ID"] = last_event_id
             async with httpx.AsyncClient(timeout=sse_timeout) as client:
-                async with client.stream("GET", url, headers=headers) as resp:
+                async with client.stream("GET", url, headers=attempt_headers) as resp:
                     if resp.status_code != 200:
                         body = await resp.aread()
                         log.warning(
@@ -156,12 +187,15 @@ async def _consume_sse(
                     else:
                         backoff = _SSE_BACKOFF_START_S
                         data_lines: list[str] = []
+                        frame_id: str | None = None
                         async for line in resp.aiter_lines():
                             if not line:
                                 # frame separator — dispatch what we have
                                 if data_lines:
                                     payload = "\n".join(data_lines)
                                     data_lines = []
+                                    pending_id = frame_id
+                                    frame_id = None
                                     try:
                                         event = json.loads(payload)
                                     except json.JSONDecodeError:
@@ -171,9 +205,23 @@ async def _consume_sse(
                                         )
                                         continue
                                     await on_event(event)
+                                    # Advance the cursor ONLY after on_event
+                                    # returns. Advancing on receipt would ack
+                                    # an event we then failed to hand over —
+                                    # the reconnect would skip past it and the
+                                    # message would be lost for good, which is
+                                    # the exact failure this whole change
+                                    # exists to close.
+                                    if pending_id is not None:
+                                        last_event_id = pending_id
+                                else:
+                                    frame_id = None
                                 continue
                             if line.startswith(":"):
                                 continue  # comment frame (incl. the keepalive beat)
+                            if line.startswith("id:"):
+                                frame_id = line[3:].strip()
+                                continue
                             if line.startswith("data:"):
                                 data_lines.append(line[5:].lstrip())
         except Exception as exc:  # stx-allow: fallback (reason: long-lived SSE — must retry on any transient error, including the ReadTimeout that a silently-dead stream now raises)

--- a/tests/scitex_agent_container/_mcp/test__channel_sse.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_sse.py
@@ -1,0 +1,189 @@
+"""Tests for the SSE consumer's replay cursor (``Last-Event-ID``).
+
+THE DEFECT THESE GUARD. ``a2a/_inbox_stream.py`` has always supported
+replay: it stamps the ``channel_events`` row id on every frame's ``id:``
+line and, given a ``Last-Event-ID`` header, replays every row with
+``id > cursor``. The consumer never used it — it parsed only ``data:``
+lines, discarded ``id:`` entirely, and built its header dict once before
+the reconnect loop. So a reconnect resumed at "now" and every event that
+arrived while it was re-dialing was never handed to the session.
+
+Measured 2026-08-09 across one ``sac listen`` restart: two agents' inboxes
+went 10→2 and 2→0, and we filed it as a DURABILITY defect. It was not —
+``channel_events`` held 355 rows, 350 stamped delivered, spanning the
+restart in both directions. The storing was fine; the asking was missing.
+
+Same harness as ``test_channel_reconnect.py`` (a real asyncio TCP server
+speaking SSE) with one addition: this server RECORDS the request headers
+of every connection, which is the only way to assert what the client
+actually sent on re-dial.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from scitex_agent_container._mcp.channel import _consume_sse
+
+
+class _HeaderRecordingServer:
+    """SSE server that records each connection's request headers.
+
+    First connection emits ``first_batch`` (each entry an ``(id, event)``
+    pair, ``id`` may be ``None`` to omit the ``id:`` line) then EOF, so the
+    client is forced to reconnect. Later connections just hold open.
+    """
+
+    def __init__(self) -> None:
+        self.first_batch: list[tuple[str | None, dict[str, Any]]] = []
+        self.headers_seen: list[dict[str, str]] = []
+        self._server: asyncio.base_events.Server | None = None
+        self.host: str = "127.0.0.1"
+        self.port: int = 0
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(self._handle, host=self.host, port=0)
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    async def _handle(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        which = len(self.headers_seen) + 1
+        try:
+            await reader.readline()  # request line
+            headers: dict[str, str] = {}
+            while True:
+                line = await reader.readline()
+                if line in (b"\r\n", b"\n", b""):
+                    break
+                raw = line.decode("latin-1").strip()
+                if ":" in raw:
+                    key, _, value = raw.partition(":")
+                    # Header names are case-insensitive on the wire; normalise
+                    # so a test asserting "Last-Event-ID" cannot pass or fail
+                    # on the client's choice of capitalisation.
+                    headers[key.strip().lower()] = value.strip()
+            self.headers_seen.append(headers)
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/event-stream\r\n"
+                b"Cache-Control: no-cache\r\n"
+                b"Connection: keep-alive\r\n"
+                b"\r\n"
+                b": keep-alive\n\n"
+            )
+            await writer.drain()
+            if which == 1:
+                for event_id, ev in self.first_batch:
+                    frame = ""
+                    if event_id is not None:
+                        frame += f"id: {event_id}\n"
+                    frame += f"data: {json.dumps(ev)}\n\n"
+                    writer.write(frame.encode())
+                    await writer.drain()
+                await asyncio.sleep(0.05)
+            else:
+                # Hold the second connection open; the test cancels the
+                # consumer once it has the header it came for.
+                await asyncio.sleep(5.0)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:  # stx-allow: defensive on writer close
+                pass
+
+
+@pytest_asyncio.fixture
+async def header_server():
+    server = _HeaderRecordingServer()
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+async def _run_until_reconnect(server: _HeaderRecordingServer) -> None:
+    """Drive ``_consume_sse`` until the server has seen two connections."""
+    received: list[dict[str, Any]] = []
+
+    async def on_event(ev: dict[str, Any]) -> None:
+        received.append(ev)
+
+    url = f"{server.base_url}/agents/alice/inbox/stream"
+    task = asyncio.create_task(_consume_sse(url, None, on_event))
+    try:
+        for _ in range(200):
+            if len(server.headers_seen) >= 2:
+                break
+            await asyncio.sleep(0.05)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):  # stx-allow: teardown
+            pass
+
+
+@pytest.mark.asyncio
+async def test_first_connection_sends_no_last_event_id(header_server):
+    # Arrange
+    header_server.first_batch = [("42", {"msg_id": "m1", "content": "one"})]
+    # Act
+    await _run_until_reconnect(header_server)
+    # Assert
+    assert "last-event-id" not in header_server.headers_seen[0]
+
+
+@pytest.mark.asyncio
+async def test_reconnect_sends_last_event_id_from_the_id_line(header_server):
+    # Arrange
+    header_server.first_batch = [("42", {"msg_id": "m1", "content": "one"})]
+    # Act
+    await _run_until_reconnect(header_server)
+    # Assert
+    assert header_server.headers_seen[1].get("last-event-id") == "42"
+
+
+@pytest.mark.asyncio
+async def test_reconnect_cursor_is_the_latest_id_not_the_first(header_server):
+    # Arrange
+    header_server.first_batch = [
+        ("42", {"msg_id": "m1", "content": "one"}),
+        ("43", {"msg_id": "m2", "content": "two"}),
+    ]
+    # Act
+    await _run_until_reconnect(header_server)
+    # Assert
+    assert header_server.headers_seen[1].get("last-event-id") == "43"
+
+
+@pytest.mark.asyncio
+async def test_reconnect_sends_no_cursor_when_server_stamped_no_id(header_server):
+    # Arrange — a server that omits ``id:`` gives us nothing to resume from,
+    # and inventing a cursor would earn a 400 from the real listen.
+    header_server.first_batch = [(None, {"msg_id": "m1", "content": "one"})]
+    # Act
+    await _run_until_reconnect(header_server)
+    # Assert
+    assert "last-event-id" not in header_server.headers_seen[1]


### PR DESCRIPTION
## What

The MCP channel's SSE consumer never asked the server to replay. It parsed only `data:` lines, discarded the `id:` line entirely, and built its header dict once before the reconnect loop — so every re-dial resumed at "now", and every event that arrived while it was disconnected was never handed to the agent's session.

The server half has supported replay all along. `a2a/_inbox_stream.py` stamps the `channel_events` row id onto each frame's `id:` line, accepts a `Last-Event-ID` header, and replays every row with `id > cursor`. Only the client was missing.

## Why it went unnoticed

The module's own docstring asserted the property it did not implement:

> Messages are NOT lost in that window — they are persisted before publish and **replayed on connect** — so the cost of the cap is latency, not delivery.

It was cited as the justification for capping the retry ladder. The cost was delivery.

## Evidence

Measured 2026-08-09. Across one `sac listen` restart, two agents' inboxes went 10 → 2 and 2 → 0. We filed it jointly as a **durability** defect — "it cost a real message".

It had not. `channel_events` on the host store:

| | |
|---|---|
| total rows | 355 |
| addressed to `scitex-agent-container-04` | 51 (10:07:11Z … 13:06:38Z) |
| NULL `delivered_at` | 5 of 355 |

The span crosses the restart in both directions, and the specific message reported lost is row 197 — persisted **and** stamped delivered. The storing was never the problem; the asking was missing. The durability card has been corrected and dropped P1 → P3.

## Three details that matter more than the diff

1. **The cursor advances only after `on_event` returns.** Advancing on receipt would ack an event that then failed to hand over, and the next reconnect would skip past it — recreating, permanently, the exact loss this closes.
2. **Headers are rebuilt per attempt.** A dict built once outside the loop would pin the first cursor forever and replay the same window on every re-dial.
3. **No cursor is sent when the server stamped no `id:`.** `None` means "no cursor yet" and is deliberately distinct from `0`, a valid row id meaning "replay everything". The real listen `400`s a malformed cursor, so inventing one would turn a reconnect into a hard failure.

## Tests

Four, over the same real-asyncio-TCP-server harness as `test_channel_reconnect.py`, with the server additionally **recording each connection's request headers** — the only way to assert what the client actually sent on re-dial.

Verified to **discriminate**, by stashing the source change and re-running:

```
2 failed, 2 passed
FAILED test_reconnect_sends_last_event_id_from_the_id_line
FAILED test_reconnect_cursor_is_the_latest_id_not_the_first
```

The two failures are the positive assertions. The two negative guards — no header on first connect, no header when the server stamped no `id:` — pass both ways by design, which is the correct signature rather than a gap.

Worth flagging for anyone else verifying this way: `PYTHONPATH=<main-checkout>/src pytest <worktree>/tests/…` does **not** test the main checkout's code. `pyproject.toml` sets `pythonpath = [".", "src"]`, which pytest inserts at `sys.path[0]` relative to **rootdir**, so the worktree's `src/` always wins and PYTHONPATH is ignored. A before/after check done that way exercises the fixed code twice and silently proves nothing. Removing the change (`git stash`) is the reliable method.

Full `_mcp` suite: **404 passed, 2 skipped**, including the 6 existing reconnect tests.
