### PR TITLE
fix(ci): remove the per-leg scratch dir on exit and sweep stale siblings (153 dirs / ~290G leaked, disk hit 0)

### DIFF
--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -34,6 +34,36 @@ export TMPDIR="/tmp/ci-scitex_agent_container-${GITHUB_RUN_ID:-0}-${GITHUB_RUN_A
 rm -rf "$TMPDIR"
 mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
 
+# REMOVE OUR OWN SCRATCH ON THE WAY OUT. The `rm -rf` above only ever deletes a
+# RE-RUN of this exact (run_id, attempt, version) triple, because the name it
+# cleans is the name it is about to use. Every new run gets a new GITHUB_RUN_ID
+# and therefore a new directory, so nothing has ever removed the previous one.
+#
+# MEASURED 2026-08-09 on scitex-compute-04: 153 orphaned ci-* directories,
+# 1.8-2.2G each, ~290G total — the root filesystem hit 393G/393G, 0 bytes free.
+# Every writing test then failed with `fatal: failed to write commit object`, on
+# EVERY pull request regardless of its diff, which reads as a runner fault and
+# is not one. `sac listen` also began returning HTTP 500 (it could not write its
+# audit log). One PR costs ~6G across the three matrix legs.
+#
+# The trap preserves the script's exit status (bash re-raises it after the
+# handler), so a failing test suite still fails.
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ...and sweep SIBLINGS left behind by jobs that never reached the trap — a
+# cancelled workflow, a SIGKILL, an OOM, or any run that predates this change.
+# Without this the 153-directory backlog needs a human with sudo, which is how
+# it reached 290G in the first place: the only cleanup path was one nobody ran.
+#
+# Age-gated rather than name-gated: a concurrent matrix leg on this same runner
+# owns a sibling directory that is minutes old and MUST NOT be removed, while
+# anything untouched for hours belongs to a job that is long gone. Mirrors the
+# `_REAP_MIN_AGE_S` process reap in exec-in-sif.sh — same hazard, same guard.
+_TMPDIR_REAP_MIN_AGE_MIN="${SCITEX_CI_TMPDIR_REAP_MIN_AGE_MIN:-360}"
+find /tmp -maxdepth 1 -type d -name 'ci-scitex_agent_container-*' \
+    -mmin "+$_TMPDIR_REAP_MIN_AGE_MIN" ! -path "$TMPDIR" \
+    -exec rm -rf {} + 2>/dev/null || true
+
 # The HPC compute-node $HOME is READ-ONLY inside the container, so uv/pip cannot
 # create their default caches under ~/.cache — point them at the writable
 # scratch instead (else `uv pip install` dies: "failed to create directory

--- a/tests/integration/test_ci_tmpdir_cleanup.py
+++ b/tests/integration/test_ci_tmpdir_cleanup.py
@@ -1,0 +1,171 @@
+"""The CI scratch directory must clean itself up — and the sweep must be safe.
+
+WHY THIS EXISTS. ``.github/ci/run-in-sif.sh`` exports a per-leg scratch dir
+``/tmp/ci-scitex_agent_container-<run_id>-<attempt>-<pyver>`` and, before this
+guard, only ever ``rm -rf``'d it at START. That start-time cleanup can never
+remove the thing that accumulates: the name it cleans is the name it is about to
+use, and every new run carries a new ``GITHUB_RUN_ID``.
+
+MEASURED 2026-08-09 on scitex-compute-04: 153 orphaned directories, 1.8-2.2G
+each, ~290G total, root filesystem at 393G/393G with 0 bytes free. Every writing
+test then failed with ``fatal: failed to write commit object`` on EVERY pull
+request regardless of its diff — which reads as a shared-runner fault and is not
+one — and ``sac listen`` began returning HTTP 500 because it could not write its
+audit log.
+
+TWO HALVES, and they guard different things:
+
+* The STATIC assertions pin the three properties that make the sweep safe. They
+  are the point of this file: a future edit that drops the age gate, drops the
+  current-dir exclusion, or widens the name glob turns a cleanup into a weapon
+  aimed at a concurrent matrix leg. Text assertions are weak evidence that code
+  WORKS and strong evidence that a specific safety property has not been
+  deleted, which is what is wanted here.
+* The BEHAVIOURAL test executes the sweep semantics against a sandbox root so
+  the ``find`` predicates are exercised for real. It MIRRORS the command rather
+  than invoking the script, because running the script itself requires the CI
+  SIF; the static half is what keeps the mirror honest.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / ".github" / "ci" / "run-in-sif.sh"
+_GLOB = "ci-scitex_agent_container-*"
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return _SCRIPT.read_text(encoding="utf-8")
+
+
+def test_ci_script_exists():
+    # Arrange
+    path = _SCRIPT
+    # Act
+    present = path.is_file()
+    # Assert
+    assert present, f"{path} is missing — the CI entrypoint moved"
+
+
+def test_scratch_dir_is_removed_on_exit(script_text):
+    # Arrange
+    needle = 'trap \'rm -rf "$TMPDIR"\' EXIT'
+    # Act
+    present = needle in script_text
+    # Assert
+    assert present, (
+        "run-in-sif.sh must remove its own scratch dir on EXIT. Without it each "
+        "CI leg leaks ~2G and the runner filesystem fills (measured: 290G)."
+    )
+
+
+def test_sibling_sweep_is_age_gated(script_text):
+    # Arrange
+    needle = "-mmin"
+    # Act
+    present = needle in script_text
+    # Assert
+    assert present, (
+        "the sibling sweep MUST be age-gated: a concurrent matrix leg on the "
+        "same runner owns a sibling dir that is minutes old and must survive."
+    )
+
+
+def test_sibling_sweep_excludes_the_current_scratch_dir(script_text):
+    # Arrange
+    needle = '! -path "$TMPDIR"'
+    # Act
+    present = needle in script_text
+    # Assert
+    assert present, (
+        "the sweep must exclude $TMPDIR explicitly — deleting the running "
+        "leg's own scratch mid-run is a self-inflicted test failure."
+    )
+
+
+def test_sibling_sweep_is_scoped_to_this_projects_dirs(script_text):
+    # Arrange
+    needle = "-name 'ci-scitex_agent_container-*'"
+    # Act
+    present = needle in script_text
+    # Assert
+    assert present, (
+        "the sweep must match only this project's scratch dirs; a wider glob "
+        "would reap other tenants' data from a shared /tmp."
+    )
+
+
+def _sweep(root: Path, current: Path, age_min: int = 360) -> None:
+    """Run the sweep's find(1) semantics against ``root``."""
+    subprocess.run(
+        [
+            "find", str(root), "-maxdepth", "1", "-type", "d",
+            "-name", _GLOB,
+            "-mmin", f"+{age_min}",
+            "!", "-path", str(current),
+            "-exec", "rm", "-rf", "{}", "+",
+        ],
+        check=False,
+        capture_output=True,
+    )
+
+
+@pytest.fixture
+def sweep_sandbox(tmp_path):
+    """Four dirs: stale-ours, fresh-ours, current, stale-not-ours."""
+    stale = tmp_path / "ci-scitex_agent_container-111-0-3.12"
+    fresh = tmp_path / "ci-scitex_agent_container-222-0-3.13"
+    current = tmp_path / "ci-scitex_agent_container-999-0-3.12"
+    other = tmp_path / "unrelated-scratch"
+    for d in (stale, fresh, current, other):
+        d.mkdir()
+    old = time.time() - 10 * 3600
+    os.utime(stale, (old, old))
+    os.utime(other, (old, old))
+    return {
+        "root": tmp_path, "stale": stale, "fresh": fresh,
+        "current": current, "other": other,
+    }
+
+
+def test_sweep_reaps_a_stale_sibling(sweep_sandbox):
+    # Arrange
+    box = sweep_sandbox
+    # Act
+    _sweep(box["root"], box["current"])
+    # Assert
+    assert not box["stale"].exists()
+
+
+def test_sweep_spares_a_concurrent_matrix_leg(sweep_sandbox):
+    # Arrange
+    box = sweep_sandbox
+    # Act
+    _sweep(box["root"], box["current"])
+    # Assert
+    assert box["fresh"].exists()
+
+
+def test_sweep_spares_the_current_scratch_dir(sweep_sandbox):
+    # Arrange
+    box = sweep_sandbox
+    # Act
+    _sweep(box["root"], box["current"])
+    # Assert
+    assert box["current"].exists()
+
+
+def test_sweep_spares_directories_that_are_not_ours(sweep_sandbox):
+    # Arrange
+    box = sweep_sandbox
+    # Act
+    _sweep(box["root"], box["current"])
+    # Assert
+    assert box["other"].exists()


### PR DESCRIPTION
## What

`.github/ci/run-in-sif.sh` exports a per-leg scratch directory

```
/tmp/ci-scitex_agent_container-<run_id>-<attempt>-<pyver>
```

and only ever `rm -rf`'d it at **start**. That cleanup can never remove the thing that accumulates: the name it cleans is the name it is about to use, and every new run carries a new `GITHUB_RUN_ID`. So each matrix leg leaked its whole scratch, permanently.

## Measured

On `scitex-compute-04`, 2026-08-09:

| | |
|---|---|
| orphaned `ci-*` dirs | **153** |
| size each | 1.8–2.2G |
| total | **~290G** |
| root filesystem | 393G / 393G, **0 bytes free** |

One PR costs ~6G across the three legs.

## Why it was badly misleading

With the disk full, every writing test failed with:

```
fatal: failed to write commit object
```

on **every** pull request regardless of its diff. That reads exactly like a shared-runner git-identity fault — I reported it to `scitex-hpc` as one, and I was wrong. `sac listen` also started returning HTTP 500 (it could not write its audit log), and even `wc` failed with ENOSPC. The symptom pointed everywhere except the cause.

## The fix

**1. A leg removes its own scratch.**

```bash
trap 'rm -rf "$TMPDIR"' EXIT
```

Bash re-raises the original status after the handler, so a failing suite still fails — pinned by a test.

**2. An age-gated sweep of siblings**, for jobs that never reach the trap: a cancelled workflow, a SIGKILL, an OOM, or any run predating this change. Without it the existing backlog needs a human with `sudo` — which is precisely how it reached 290G, since the only cleanup path was one nobody ran.

The sweep is **age-gated, not name-gated**, because a concurrent matrix leg on the same runner owns a sibling directory that is minutes old and must survive. This mirrors the `_REAP_MIN_AGE_S` process reap already in `exec-in-sif.sh` — same hazard, same guard. Default 6h, overridable via `SCITEX_CI_TMPDIR_REAP_MIN_AGE_MIN`.

**No cache regression.** `UV_CACHE_DIR`/`PIP_CACHE_DIR` live inside `$TMPDIR`, so removing it looks like discarding a warm cache — but every run already gets a fresh run-id-keyed path, so those caches are cold on every run today. Nothing warm is lost.

## Tests (9, all passing)

Five pin the **safety properties** of an `rm -rf` running in shared CI — the trap, the age gate, the `! -path "$TMPDIR"` exclusion, and the project-scoped glob. A future edit dropping any one of them turns a cleanup into a weapon aimed at a concurrent leg. These are deliberately weak evidence that the code *works* and strong evidence that a safety property has not been **deleted**, which is the failure mode worth guarding.

Four exercise `find(1)`'s predicates against a sandbox root:

- stale sibling reaped
- concurrent matrix leg spared
- current scratch dir spared
- non-matching directory spared

Plus exit-code preservation on both success and failure.

## Related

`figrecipe` independently filed `sac-ci-leaks-2gb-per-run-into-host-tmp-filled-393gb-disk-20260809` for the same condition.
