### PR TITLE
fix(ci): stop the test suite signing its throwaway commits (unblocks ALL PRs — 13 failed/120 errors on every one)

### DIFF
--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -26,6 +26,41 @@ test -x "$VENV/bin/python" || {
 
 export LC_ALL=C.UTF-8 LANG=C.UTF-8
 
+# NEVER SIGN COMMITS MADE BY THE TEST SUITE. Dozens of tests build throwaway
+# git repos under tmp_path and commit into them (worktree GC, prune, drift,
+# doctor, the git-identity hooks). They inherit the AMBIENT global config, and
+# the operator's dotfiles set:
+#
+#     ~/.dotfiles/src/.gitconfig
+#       commit.gpgsign  = true
+#       tag.gpgsign     = true
+#       gpg.format      = ssh
+#       user.signingkey = ~/.ssh/id_ed25519_scitex.pub
+#
+# When that key is absent — as it was on 2026-08-09 — every one of those
+# commits dies, and git reports it like this:
+#
+#     error: Couldn't load public key .../id_ed25519_scitex.pub: No such file
+#     fatal: failed to write commit object
+#     exit 128
+#
+# THAT SECOND LINE IS THE TRAP. "failed to write commit object" reads as disk
+# I/O, so the obvious diagnosis is a full filesystem or a broken runner. It
+# cost most of an afternoon and two WRONG root causes broadcast to other
+# agents (a shared-runner git-identity fault, then ENOSPC) before anyone read
+# the line above it. Reproduced exactly, and verified fixed, before this
+# landed — see tests/integration/test_ci_commit_signing_disabled.py.
+#
+# A test's scratch repo has no business carrying a signature. Signing stays ON
+# for real commits; this scopes it off for CI only, and additively — two
+# overrides on top of the ambient config rather than replacing it, so
+# safe.directory and everything else the runner relies on survives.
+export GIT_CONFIG_COUNT=2
+export GIT_CONFIG_KEY_0=commit.gpgsign
+export GIT_CONFIG_VALUE_0=false
+export GIT_CONFIG_KEY_1=tag.gpgsign
+export GIT_CONFIG_VALUE_1=false
+
 # Real writable scratch. The runner profile exports TMPDIR=~/.cache/tmp, a host
 # path that does NOT resolve inside the container; tests (tmp_path) and the
 # install target both need a working, writable tmp. Node-local /tmp is writable

--- a/tests/integration/test_ci_commit_signing_disabled.py
+++ b/tests/integration/test_ci_commit_signing_disabled.py
@@ -1,0 +1,135 @@
+"""A scratch repo must be able to commit even when ambient config signs.
+
+WHY THIS EXISTS. Dozens of tests build throwaway git repos under ``tmp_path``
+and commit into them. They inherit the AMBIENT global git config, and the
+operator's dotfiles (``~/.dotfiles/src/.gitconfig``) set ``commit.gpgsign =
+true`` with ``gpg.format = ssh`` and a ``user.signingkey`` pointing at
+``~/.ssh/id_ed25519_scitex.pub``. On 2026-08-09 that key was absent, so every
+such commit failed:
+
+    error: Couldn't load public key .../id_ed25519_scitex.pub: No such file
+    fatal: failed to write commit object
+    exit 128
+
+13 failures and 120 errors, on EVERY pull request regardless of its diff.
+
+THE SECOND LINE IS WHY THIS TEST EXISTS RATHER THAN A COMMENT. "failed to
+write commit object" reads as disk I/O. It produced two confidently-wrong root
+causes broadcast to other agents — a shared-runner git-identity fault, then
+ENOSPC (the disk WAS also full, separately, which made the wrong answer fit).
+The real cause was one line higher in the log the whole time.
+
+These tests reproduce the exact condition and pin the fix, so the next person
+meets a red test naming signing instead of a symptom pointing at hardware.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / ".github" / "ci" / "run-in-sif.sh"
+
+
+def _git(repo: Path, *args: str, env: dict | None = None):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, env=env,
+    )
+
+
+@pytest.fixture
+def signing_repo(tmp_path):
+    """A repo whose config signs with a key that does not exist.
+
+    The GIT_CONFIG_* vars are cleared for the duration and restored after.
+    That is not hygiene, it is CORRECTNESS: in CI ``run-in-sif.sh`` exports the
+    very override under test, so without clearing it the "reproduce the
+    failure" cases would see signing already disabled and assert the opposite
+    of what they mean.
+    """
+    saved = {k: v for k, v in os.environ.items() if k.startswith("GIT_CONFIG_")}
+    for key in saved:
+        del os.environ[key]
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", ".")
+    for key, value in (
+        ("user.email", "t@example.com"),
+        ("user.name", "t"),
+        ("commit.gpgsign", "true"),
+        ("gpg.format", "ssh"),
+        ("user.signingkey", str(tmp_path / "absent-key.pub")),
+    ):
+        _git(repo, "config", key, value)
+    try:
+        yield repo
+    finally:
+        for key, value in saved.items():
+            os.environ[key] = value
+
+
+def test_missing_signing_key_breaks_commit_without_the_fix(signing_repo):
+    # Arrange
+    repo = signing_repo
+    # Act
+    result = _git(repo, "commit", "--allow-empty", "-q", "-m", "seed")
+    # Assert
+    assert result.returncode != 0, (
+        "expected the unfixed condition to fail — if this passes, the ambient "
+        "signing config changed and this whole guard needs revisiting"
+    )
+
+
+def test_the_failure_names_signing_not_disk(signing_repo):
+    # Arrange
+    repo = signing_repo
+    # Act
+    result = _git(repo, "commit", "--allow-empty", "-q", "-m", "seed")
+    # Assert — the misleading half is 'failed to write commit object'; the
+    # diagnostic half is the public-key line. Pin that it is present, because
+    # reading only the former is exactly how this cost an afternoon.
+    assert "public key" in result.stderr, result.stderr
+
+
+def test_signing_override_lets_a_scratch_repo_commit(signing_repo):
+    # Arrange
+    env = dict(os.environ)
+    env.update({
+        "GIT_CONFIG_COUNT": "2",
+        "GIT_CONFIG_KEY_0": "commit.gpgsign", "GIT_CONFIG_VALUE_0": "false",
+        "GIT_CONFIG_KEY_1": "tag.gpgsign", "GIT_CONFIG_VALUE_1": "false",
+    })
+    # Act
+    result = _git(signing_repo, "commit", "--allow-empty", "-q", "-m", "seed", env=env)
+    # Assert
+    assert result.returncode == 0, result.stderr
+
+
+def test_ci_entrypoint_disables_commit_signing():
+    # Arrange
+    text = _SCRIPT.read_text(encoding="utf-8")
+    # Act
+    present = "GIT_CONFIG_KEY_0=commit.gpgsign" in text
+    # Assert
+    assert present, (
+        "run-in-sif.sh must disable commit signing for the test suite; without "
+        "it every scratch-repo commit dies when the signing key is absent."
+    )
+
+
+def test_ci_entrypoint_keeps_the_override_additive():
+    # Arrange
+    text = _SCRIPT.read_text(encoding="utf-8")
+    # Act
+    replaces_global = "GIT_CONFIG_GLOBAL=" in text
+    # Assert — GIT_CONFIG_COUNT layers ON TOP of ambient config; setting
+    # GIT_CONFIG_GLOBAL instead would REPLACE it wholesale and silently drop
+    # safe.directory and anything else the runner depends on.
+    assert not replaces_global, (
+        "use the additive GIT_CONFIG_COUNT overrides, not GIT_CONFIG_GLOBAL, "
+        "so the rest of the ambient git config survives"
+    )


### PR DESCRIPTION
## What

Every pull request has been failing with **13 failed, 120 errors** — the same tests, on every PR, regardless of its diff. The cause is commit signing, not the runner and not the disk.

Dozens of tests build scratch git repos under `tmp_path` and commit into them (worktree GC, prune, drift, doctor, the git-identity hooks). They inherit the **ambient global config**, and the operator's dotfiles set:

```
~/.dotfiles/src/.gitconfig
  commit.gpgsign  = true
  tag.gpgsign     = true
  gpg.format      = ssh
  user.signingkey = ~/.ssh/id_ed25519_scitex.pub
```

That key is not present on the runner, so every such commit dies:

```
error: Couldn't load public key .../id_ed25519_scitex.pub: No such file or directory
fatal: failed to write commit object
exit 128
```

## The second line is the trap

`fatal: failed to write commit object` reads as disk I/O. So the obvious diagnoses are a full filesystem or a broken runner — and I published **both** to other agents before reading the line above it:

1. **"shared-runner git identity fault"** — sent `scitex-hpc` after infrastructure that was fine.
2. **"ENOSPC"** — I issued this as a *correction* to (1). The disk genuinely was full (a separate, real ~290G leak, fixed in #938), which made the wrong answer fit the evidence beautifully.

It reproduces with **244G free**. Both were wrong; the diagnostic line was in the log the whole time, one line up.

## Verified, not inferred

Reproduced the exact condition and confirmed the fix before this landed:

```
A: scratch repo, commit.gpgsign=true, key absent   -> exit 128, same two lines
B: same repo, GIT_CONFIG_COUNT override applied    -> exit 0, commit created
```

## The fix

Two env overrides in `run-in-sif.sh`. **Additive**: `GIT_CONFIG_COUNT` layers on top of the ambient config rather than replacing it, so `safe.directory` and everything else the runner relies on survives. `GIT_CONFIG_GLOBAL` would have replaced it wholesale — a test pins that we didn't do that.

Signing stays **on** for real commits. A test's throwaway repo has no business carrying a signature.

## Tests (5, all passing)

- two reproduce the failure — non-zero exit, and stderr naming the **public key** rather than only the misleading write-failure line
- one proves the override fixes it
- two pin the CI entrypoint: that it disables signing at all, and that it stays additive

The fixture clears `GIT_CONFIG_*` and restores after. That's correctness, not hygiene: in CI `run-in-sif.sh` exports the very override under test, so without clearing it the reproduction cases would assert the opposite of what they mean.

## Merge order

**This one first.** No other PR can go green until it lands — including #938.

## Open question for the operator

The signing key is missing on the host entirely. This PR only stops *test* commits depending on it; whether the key should be restored for real commits is a separate decision I've raised separately.
