### PR TITLE
fix(ci): remove the per-run in-SIF scratch instead of leaking it every run

### DIFF
--- a/.github/ci/build-in-sif.sh
+++ b/.github/ci/build-in-sif.sh
@@ -29,8 +29,15 @@ test -x "$PY" || {
 export LC_ALL=C.UTF-8 LANG=C.UTF-8
 
 # Writable scratch (the runner's TMPDIR=~/.cache/tmp is a host path that does
-# NOT resolve inside the container). Node-local /tmp is writable + ephemeral.
-TMPDIR="/tmp/build-scitex_agent_container-${GITHUB_RUN_ID:-0}-${GITHUB_RUN_ATTEMPT:-0}-$V"
+# NOT resolve inside the container). Node-local /tmp is writable.
+#
+# It was NOT "ephemeral", whatever this comment used to say: nothing removed
+# this directory, so every release leaked one. Smaller and rarer than
+# run-in-sif.sh's, therefore slower to notice — not less of a leak. Lifecycle
+# (naming, end-of-job removal, startup prune) now lives in tmpdir-lib.sh.
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")/tmpdir-lib.sh"
+TMPDIR="$(ci_tmpdir_path build "$V")"
 export TMPDIR
 rm -rf "$TMPDIR"
 mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"

--- a/.github/ci/clean-tmpdir.sh
+++ b/.github/ci/clean-tmpdir.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Remove THIS job's per-run scratch. Runs ON THE RUNNER (outside the SIF) as an
+# `if: always()` step that MIRRORS THE WORK STEP'S ARGUMENTS EXACTLY:
+#
+#   - run: bash .github/ci/exec-in-sif.sh  run-in-sif.sh ${{ matrix.python-version }}
+#   - if: always()
+#     run: bash .github/ci/clean-tmpdir.sh run-in-sif.sh ${{ matrix.python-version }}
+#
+# The same two args on purpose: the pairing is then mechanically checkable, and
+# tests/integration/test_ci_tmpdir_lifecycle.py checks it — so a new in-SIF job
+# that forgets its cleanup step fails CI instead of leaking ~2 GB per run.
+#
+# WHY A JOB STEP AND NOT A TRAP: both script layers end in `exec`, which
+# discards traps, and the `exec`s are load-bearing for signal/exit-code
+# propagation. An `always()` step is a SEPARATE process the runner starts after
+# the work step is torn down, so it covers SUCCESS, FAILURE and CANCELLATION
+# without racing the signals that killed the work step. See tmpdir-lib.sh.
+#
+# SCOPED TO THIS MATRIX LEG, and that is not cosmetic. All three legs share
+# GITHUB_RUN_ID/GITHUB_RUN_ATTEMPT, so a cleanup keyed on the run alone would
+# delete the LIVE scratch of the two siblings still running. The python-version
+# arg is what makes the target this leg's own directory and nothing else.
+#
+# Host /tmp IS container /tmp here (apptainer.conf `mount tmp = yes`, and
+# exec-in-sif.sh passes no --contain), so removing the path from the runner
+# removes the directory the in-SIF script created.
+#
+# NEVER FAILS THE JOB — no `set -e`, and it always exits 0. A cleanup step that
+# turns a green run red, or that replaces the real failure of a job it was
+# `always()`-attached to, is worse than the leak it fixes.
+set -uo pipefail
+
+_CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$_CI_DIR/tmpdir-lib.sh"
+
+INNER="${1:-}"
+VERSION="${2:-}"
+
+PREFIX="$(ci_tmpdir_prefix_for_inner "$INNER")"
+if [ -z "$PREFIX" ]; then
+    echo "clean-tmpdir: '${INNER:-<none>}' creates no per-run scratch — nothing to remove."
+    exit 0
+fi
+
+# Without a version we cannot scope the removal to this leg, and an unscoped
+# removal would take out the sibling legs still running. Refuse LOUDLY but
+# harmlessly: the next run's prune reclaims it, whereas a wrong deletion here
+# reds a release.
+if [ -z "$VERSION" ]; then
+    echo "::warning::clean-tmpdir: no version arg for '$INNER' — cannot scope the removal" \
+        "to this matrix leg, so skipping. The startup prune will reclaim it."
+    exit 0
+fi
+
+TARGET="$(ci_tmpdir_path "$PREFIX" "$VERSION")"
+
+if [ -d "$TARGET" ]; then
+    # Size is the evidence that this fix reclaims what the incident measured.
+    # Bounded: a cold 100k-file tree walk must not stretch the job's teardown.
+    SIZE=""
+    if command -v timeout >/dev/null 2>&1; then
+        SIZE="$(timeout 30 du -sh -- "$TARGET" 2>/dev/null | cut -f1)"
+    fi
+    echo "clean-tmpdir: removing ${TARGET}${SIZE:+ (${SIZE})}"
+    if ! ci_tmpdir_cleanup "$TARGET"; then
+        echo "::warning::clean-tmpdir: could not remove ${TARGET}"
+    fi
+else
+    echo "clean-tmpdir: ${TARGET} already gone — nothing to do."
+fi
+
+exit 0

--- a/.github/ci/clean-tmpdir.sh
+++ b/.github/ci/clean-tmpdir.sh
@@ -34,6 +34,16 @@ _CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 . "$_CI_DIR/tmpdir-lib.sh"
 
+# A partial checkout leaves the library unsourced, and every helper below then
+# resolves to "command not found" — which fell through to the "creates no
+# per-run scratch" message, i.e. told a future reader the OPPOSITE of the truth
+# while a directory leaked. Say what actually happened; still never fail the job.
+if ! command -v ci_tmpdir_prefix_for_inner >/dev/null 2>&1; then
+    echo "::warning::clean-tmpdir: could not load ${_CI_DIR}/tmpdir-lib.sh —" \
+        "no scratch was removed. The next run's startup prune will reclaim it."
+    exit 0
+fi
+
 INNER="${1:-}"
 VERSION="${2:-}"
 
@@ -54,6 +64,16 @@ if [ -z "$VERSION" ]; then
 fi
 
 TARGET="$(ci_tmpdir_path "$PREFIX" "$VERSION")"
+
+# Decide MANAGED-NESS BEFORE announcing or measuring anything. A malformed
+# version arg can compose a path that ci_tmpdir_cleanup will (correctly) refuse,
+# and announcing first printed `clean-tmpdir: removing /tmp (270G)` on the
+# incident host — a line that reads like an imminent disaster and spends the
+# 30 s `du` bound to say nothing.
+if ! _ci_tmpdir_is_managed "$TARGET"; then
+    echo "::error::clean-tmpdir: refusing to remove '$TARGET' — not a managed CI scratch path" >&2
+    exit 0
+fi
 
 if [ -d "$TARGET" ]; then
     # Size is the evidence that this fix reclaims what the incident measured.

--- a/.github/ci/exec-in-sif.sh
+++ b/.github/ci/exec-in-sif.sh
@@ -112,6 +112,26 @@ else
          "An unscoped pkill would SIGTERM the sibling matrix legs (see run 29284554656)."
 fi
 
+# THE DISK-SIDE SIBLING OF THE REAP ABOVE, and the same reasoning: age is what
+# separates a leftover from a live concurrent sibling.
+#
+# MEASURED 2026-08-09 on scitex-04-cpu-01: the three in-SIF scripts each created
+# a per-run scratch under /tmp and NOTHING ever removed it. 116 survivors at
+# 1.8-2.2 GB each put /tmp at 270 GB of a 393 GB root — root 100% FULL (39 MB
+# free), inodes 92% — on a box hosting twelve fleet agents. A leaked temp dir is
+# free on a hosted runner, where the VM is discarded; on a persistent one it is
+# a slow outage.
+#
+# Here, host-side, because this is the ONE place all five in-SIF call sites pass
+# through, it still runs when the SIF never starts, and /tmp is shared with the
+# container anyway (`mount tmp = yes`, no --contain below). This sweep is only
+# the backstop for SIGKILL/reboot; the normal ending is the `if: always()`
+# clean-tmpdir.sh step in each job. Guards (self-exclusion by run identity, 24 h
+# age floor) and the /scratch decision are argued in tmpdir-lib.sh.
+# shellcheck source=/dev/null
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/tmpdir-lib.sh"
+ci_tmpdir_prune
+
 # --bind punim0264: on Spartan $HOME/.scitex is a symlink into punim0264, so the
 # bind is what makes that symlink resolve inside the container. Elsewhere the
 # path does not exist and apptainer refuses to start with it ("bind path does

--- a/.github/ci/publish-in-sif.sh
+++ b/.github/ci/publish-in-sif.sh
@@ -49,7 +49,12 @@ echo "=== dist to publish ==="
 ls -l dist
 
 # --- writable scratch (compute-node HOME is RO inside the container) ---
-TMPDIR="/tmp/publish-scitex_agent_container-${GITHUB_RUN_ID:-0}-${GITHUB_RUN_ATTEMPT:-0}-$V"
+# Same leak, same family as run-in-sif.sh / build-in-sif.sh: created per run and
+# never removed. tmpdir-lib.sh owns the naming; an `if: always()` step in the
+# publish job removes it; exec-in-sif.sh prunes SIGKILL/reboot leftovers.
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")/tmpdir-lib.sh"
+TMPDIR="$(ci_tmpdir_path publish "$V")"
 export TMPDIR
 rm -rf "$TMPDIR"
 mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"

--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -29,8 +29,19 @@ export LC_ALL=C.UTF-8 LANG=C.UTF-8
 # Real writable scratch. The runner profile exports TMPDIR=~/.cache/tmp, a host
 # path that does NOT resolve inside the container; tests (tmp_path) and the
 # install target both need a working, writable tmp. Node-local /tmp is writable
-# + ephemeral and per-version-isolated so concurrent matrix legs don't collide.
-export TMPDIR="/tmp/ci-scitex_agent_container-${GITHUB_RUN_ID:-0}-${GITHUB_RUN_ATTEMPT:-0}-$V"
+# + per-version-isolated so concurrent matrix legs don't collide.
+#
+# "+ ephemeral" USED TO BE CLAIMED HERE AND WAS NEVER TRUE. Nothing removed this
+# directory — on the persistent self-hosted node 116 of them at 1.8-2.2 GB each
+# filled the root filesystem (2026-08-09). tmpdir-lib.sh now owns the whole
+# lifecycle: it names the directory (once, here), an `if: always()` job step
+# removes it at the end of the job, and exec-in-sif.sh prunes what a SIGKILL or
+# a reboot left behind. The name is unchanged, so this also reclaims the
+# directories already on disk.
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")/tmpdir-lib.sh"
+TMPDIR="$(ci_tmpdir_path ci "$V")"
+export TMPDIR
 rm -rf "$TMPDIR"
 mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
 

--- a/.github/ci/tmpdir-lib.sh
+++ b/.github/ci/tmpdir-lib.sh
@@ -145,13 +145,32 @@ _ci_tmpdir_is_managed() {
 # removing the same path both succeed). Both properties are load-bearing, not
 # defensive padding: the `always()` step and the NEXT run's prune can and do
 # fire on the same directory, and a re-run of a cancelled job re-enters here.
+#
+# THE RETURN VALUE IS HONEST: 0 only when the path is GONE. An earlier draft did
+# `rm -rf … || true; return 0`, which made clean-tmpdir.sh's `::warning::` branch
+# unreachable and printed "removing <path> (2.0G)" for a directory that was still
+# there — the exact line a human is told to grep for as proof the fix worked. A
+# cleanup that cannot report failure is a leak that reports success.
+#
+# The one failure that actually happens here is a NON-WRITABLE SUBTREE: ~10 tests
+# in this suite chmod a `tmp_path` directory to 0o555/0o000 and restore it in a
+# `finally`, and `tmp_path` lives under $TMPDIR. A worker SIGKILLed between the
+# chmod and the finally — precisely the cancellation path this fix covers — leaves
+# a subtree `rm -rf` cannot enter. So retry once after restoring owner write/search
+# bits, which is exactly what that case needs and nothing more.
 ci_tmpdir_cleanup() {
     local d="${1:-}"
     if ! _ci_tmpdir_is_managed "$d"; then
         echo "::error::refusing to remove '$d' — not a managed CI scratch path" >&2
         return 1
     fi
+    [ -e "$d" ] || return 0
+    rm -rf -- "$d" 2>/dev/null && return 0
+    chmod -R u+rwX -- "$d" 2>/dev/null || true
     rm -rf -- "$d" 2>/dev/null || true
+    if [ -e "$d" ]; then
+        return 1
+    fi
     return 0
 }
 
@@ -172,9 +191,12 @@ ci_tmpdir_cleanup() {
 #
 #  (b) AN AGE FLOOR for every OTHER run id, because a different workflow run can
 #      legitimately be in flight on the same runner. Note what the floor
-#      actually measures: after the shims are written nothing creates or removes
-#      entries directly in $TMPDIR, so its top-level mtime is frozen at job
-#      start and `-mmin` prunes by JOB AGE, not idle time. The floor must
+#      actually measures: `-mmin` reads the TOP-LEVEL mtime, which only a DIRECT
+#      child of $TMPDIR refreshes (pytest's `pytest-of-*` basetemp, an
+#      XDG_CACHE_HOME entry, a `tempfile.mkdtemp()`); writes nested deeper leave
+#      it untouched. So the apparent age is at most the job's age and is often
+#      exactly it — a job that creates no direct child after setup has a mtime
+#      frozen at job start. Design to that worst case: the floor must
 #      therefore exceed the longest a job can legitimately LIVE. pytest-matrix
 #      caps at `timeout-minutes: 45`, but the release workflow's test job sets
 #      NO timeout-minutes and inherits GitHub's 6-HOUR platform default. 24 h is
@@ -189,7 +211,17 @@ ci_tmpdir_prune() {
     local root age_h age_min run_id attempt victims d
     root="$(_ci_tmpdir_root)"
     [ -d "$root" ] || return 0
+    # CLAMPED, because this knob's failure mode is destructive and its input is
+    # a string. `=0` would delete a 3-minute-old concurrent run's LIVE scratch;
+    # `=abc` made `$((age_h * 60))` abort with `abc: unbound variable`, which
+    # under exec-in-sif.sh's `set -euo pipefail` failed the job before the SIF
+    # even started. Anything that is not a whole number of hours >= 1 is not a
+    # floor, so fall back to the contract default instead of honouring it.
     age_h="${SAC_CI_TMPDIR_MAX_AGE_H:-24}"
+    case "$age_h" in
+    '' | *[!0-9]*) age_h=24 ;;
+    esac
+    [ "$age_h" -ge 1 ] 2>/dev/null || age_h=24
     age_min=$((age_h * 60))
     run_id="${GITHUB_RUN_ID:-0}"
     attempt="${GITHUB_RUN_ATTEMPT:-0}"

--- a/.github/ci/tmpdir-lib.sh
+++ b/.github/ci/tmpdir-lib.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Per-run scratch LIFECYCLE for the in-SIF CI scripts.
+#
+# SOURCE this file. It only defines functions — it creates nothing, removes
+# nothing and exports nothing on its own.
+#
+# ---------------------------------------------------------------------------
+# THE DEFECT THIS EXISTS FOR (measured on scitex-04-cpu-01, 2026-08-09)
+# ---------------------------------------------------------------------------
+# run-in-sif.sh, build-in-sif.sh and publish-in-sif.sh each export a per-run
+# TMPDIR under /tmp, and NOTHING ever removed it. 116 surviving directories at
+# 1.8-2.2 GB each put /tmp at 270 GB of a 393 GB root: root 100% FULL (39 MB
+# free), inodes at 92%. Twelve fleet agents live on that box, so a full root is
+# a fleet outage, not a nuisance. The pytest matrix runs 3.11/3.12/3.13, so ONE
+# CI run leaked THREE directories.
+#
+# The bug is a HOSTED-RUNNER ASSUMPTION applied to a PERSISTENT runner. On a
+# GitHub-hosted runner the whole VM is discarded after the job, so leaking
+# scratch is invisible and free. Every one of this repo's in-SIF call sites is
+# self-hosted today, where the same code is a slow outage — but `runs-on` is
+# `fromJSON(vars.CI_RUNS_ON || …)`, so re-pointing ONE repo Actions Variable
+# moves them all to hosted images with no code change. Nothing here may
+# therefore REQUIRE a persistent box: the prune tolerates an empty or absent
+# root, and no function in this file can fail a job.
+#
+# ---------------------------------------------------------------------------
+# THREE MECHANISMS, because no single one covers every way a job can end
+# ---------------------------------------------------------------------------
+#   1. ci_tmpdir_path()   ONE definition of the directory name, used by the
+#                         script that CREATES it, the step that REMOVES it and
+#                         the prune that SKIPS it. Two independent spellings of
+#                         this name is how a cleanup starts quietly missing the
+#                         directory it exists to remove.
+#
+#   2. clean-tmpdir.sh    An `if: always()` job step. Covers SUCCESS, FAILURE
+#                         and CANCELLATION. It is a SEPARATE step process the
+#                         runner starts after the work step has been torn down,
+#                         so it does not race the signals that killed that step.
+#
+#   3. ci_tmpdir_prune()  Startup sweep, called host-side from exec-in-sif.sh.
+#                         The ONLY cover for SIGKILL and reboot, where no
+#                         in-process cleanup can run by construction. That path
+#                         is real here: the runner's systemd unit is
+#                         KillMode=process / TimeoutStopSec=5min, so a service
+#                         stop signals only the supervisor and then SIGKILLs the
+#                         job's descendants.
+#
+# WHY NOT A bash TRAP — the obvious answer, which does not work here. Both
+# layers end in `exec`: exec-in-sif.sh hands off to apptainer, run-in-sif.sh
+# hands off to pytest. `exec` replaces the shell image and takes every trap with
+# it, so a `trap … EXIT` added above either line SILENTLY NEVER FIRES (verified
+# by probe, not assumed). Making one fire means deleting an `exec` that is
+# load-bearing for signal and exit-code propagation through a 45-minute pytest
+# run — autobump-release-sweep.yaml depends on that propagation by name. An
+# `if: always()` step buys the same coverage for free and cannot race a SIGTERM.
+#
+# ---------------------------------------------------------------------------
+# WHY /tmp AND NOT /scratch, even with 3.0 TB of it at 1% used on that host
+# ---------------------------------------------------------------------------
+# Three facts, checked on scitex-04-cpu-01 rather than assumed:
+#   * /scratch is `drwxr-xr-x root root`; the runner is User=ywatanabe. A
+#     `mkdir -p /scratch/…` under `set -euo pipefail` would abort EVERY CI job
+#     before a single test ran — the exact failure exec-in-sif.sh already
+#     documents for the Spartan GPFS path.
+#   * /scratch is NOT VISIBLE INSIDE THE SIF. apptainer.conf binds only
+#     /etc/localtime and /etc/hosts (plus `mount tmp = yes`, which is the whole
+#     reason /tmp works), and exec-in-sif.sh passes no --bind for it. A
+#     `[ -d /scratch ]` test evaluated by an INNER script is FALSE even on the
+#     host where /scratch really exists.
+#   * Hosted runners have no /scratch at all.
+#
+# And the decisive one: RELOCATING A LEAK DOES NOT FIX IT. 3 TB buys roughly
+# 430 runs instead of 40 — the same outage, months later, with nobody watching.
+# The lifecycle is the bug. A move would also put ~480 `tmp_path` test files and
+# the SQLite state-DB tests on a volume that is probably network-backed, where
+# SQLite locking is unreliable and a `--target` install's tens of thousands of
+# small files are the worst possible workload; this suite has already been
+# burned by that genre of flake. If disk pressure later needs structural relief,
+# gate it on FILESYSTEM TYPE (node-local only, not mere existence), decide it
+# host-side in exec-in-sif.sh with a conditional --bind, and land it separately
+# with before/after wall-time measured. Not in a lifecycle fix.
+
+# --- knobs (TEST-ONLY; unset in CI, where the defaults are the contract) -----
+# SAC_CI_TMPDIR_ROOT     scratch root                  (default /tmp)
+# SAC_CI_TMPDIR_MAX_AGE_H  prune age floor, hours      (default 24)
+
+_ci_tmpdir_root() {
+    printf '%s' "${SAC_CI_TMPDIR_ROOT:-/tmp}"
+}
+
+# The inner scripts that create a per-run scratch, and the prefix each uses.
+#
+# THIS TABLE IS TESTED AGAINST THE SCRIPTS THEMSELVES
+# (tests/integration/test_ci_tmpdir_lifecycle.py): a new *-in-sif.sh that
+# exports a per-run TMPDIR and is not listed here fails CI, rather than quietly
+# leaking 2 GB per run for four months like the three above it did.
+ci_tmpdir_prefix_for_inner() {
+    case "${1:-}" in
+    run-in-sif.sh) printf 'ci' ;;
+    build-in-sif.sh) printf 'build' ;;
+    publish-in-sif.sh) printf 'publish' ;;
+    *) printf '' ;; # creates no per-run scratch
+    esac
+}
+
+# The canonical per-run scratch path. Kept byte-identical to the names the three
+# scripts already used, so this fix also reclaims the directories ALREADY on
+# disk instead of starting a second, differently-named leak beside the first.
+ci_tmpdir_path() {
+    local prefix="${1:?prefix required (ci|build|publish)}"
+    local version="${2:?python version required}"
+    printf '%s/%s-scitex_agent_container-%s-%s-%s' \
+        "$(_ci_tmpdir_root)" "$prefix" \
+        "${GITHUB_RUN_ID:-0}" "${GITHUB_RUN_ATTEMPT:-0}" "$version"
+}
+
+# Is this path one WE created, directly under the scratch root?
+#
+# The guard exists because ci_tmpdir_cleanup's argument is built from a
+# workflow-interpolated matrix value and then handed to `rm -rf`. Rejects the
+# root itself, anything outside it, anything nested deeper, and any traversal.
+_ci_tmpdir_is_managed() {
+    local d="${1:-}" root base
+    root="$(_ci_tmpdir_root)"
+    [ -n "$d" ] || return 1
+    case "$d" in
+    "$root"/*) ;;
+    *) return 1 ;;
+    esac
+    base="${d#"$root"/}"
+    case "$base" in
+    '' | */* | *..*) return 1 ;;
+    esac
+    case "$base" in
+    ci-scitex_agent_container-?* | build-scitex_agent_container-?* | publish-scitex_agent_container-?*)
+        return 0
+        ;;
+    esac
+    return 1
+}
+
+# Remove ONE scratch directory.
+#
+# IDEMPOTENT (a path already gone is success) and CONCURRENCY-SAFE (two callers
+# removing the same path both succeed). Both properties are load-bearing, not
+# defensive padding: the `always()` step and the NEXT run's prune can and do
+# fire on the same directory, and a re-run of a cancelled job re-enters here.
+ci_tmpdir_cleanup() {
+    local d="${1:-}"
+    if ! _ci_tmpdir_is_managed "$d"; then
+        echo "::error::refusing to remove '$d' — not a managed CI scratch path" >&2
+        return 1
+    fi
+    rm -rf -- "$d" 2>/dev/null || true
+    return 0
+}
+
+# Sweep scratch left by runs that COULD NOT clean up after themselves — SIGKILL,
+# runner service stop, reboot. Called once, host-side, from exec-in-sif.sh
+# before the SIF starts. This is the disk-side sibling of that script's process
+# reap, and rests on the same reasoning its comment already spells out: AGE is
+# what separates a leftover from a live concurrent sibling.
+#
+# TWO INDEPENDENT GUARDS, because this is the one part of the fix that can cause
+# the very outage it was written to prevent:
+#
+#  (a) SELF-EXCLUSION BY RUN IDENTITY. The three matrix legs start at the SAME
+#      INSTANT on the same box and share GITHUB_RUN_ID/GITHUB_RUN_ATTEMPT, so
+#      the 3.11 leg's prune SEES 3.12's and 3.13's live scratch. Any name
+#      carrying this run+attempt is skipped BY NAME — an exact test, not a
+#      heuristic, and it holds no matter how long a leg has been running.
+#
+#  (b) AN AGE FLOOR for every OTHER run id, because a different workflow run can
+#      legitimately be in flight on the same runner. Note what the floor
+#      actually measures: after the shims are written nothing creates or removes
+#      entries directly in $TMPDIR, so its top-level mtime is frozen at job
+#      start and `-mmin` prunes by JOB AGE, not idle time. The floor must
+#      therefore exceed the longest a job can legitimately LIVE. pytest-matrix
+#      caps at `timeout-minutes: 45`, but the release workflow's test job sets
+#      NO timeout-minutes and inherits GitHub's 6-HOUR platform default. 24 h is
+#      4x that ceiling. The asymmetry justifies erring large: too small deletes
+#      a LIVE job's scratch and produces a baffling red release, while too large
+#      only delays reclaiming disk that mechanisms 1-2 already reclaim on every
+#      normal ending. This prune is the backstop, not the workhorse.
+#
+# Never fails, never returns non-zero: a multi-user /tmp can hand us a directory
+# we may not remove, and that must not take down CI.
+ci_tmpdir_prune() {
+    local root age_h age_min run_id attempt victims d
+    root="$(_ci_tmpdir_root)"
+    [ -d "$root" ] || return 0
+    age_h="${SAC_CI_TMPDIR_MAX_AGE_H:-24}"
+    age_min=$((age_h * 60))
+    run_id="${GITHUB_RUN_ID:-0}"
+    attempt="${GITHUB_RUN_ATTEMPT:-0}"
+
+    victims="$(
+        find "$root" -mindepth 1 -maxdepth 1 -type d \
+            \( -name 'ci-scitex_agent_container-*' \
+            -o -name 'build-scitex_agent_container-*' \
+            -o -name 'publish-scitex_agent_container-*' \) \
+            ! -name "*-${run_id}-${attempt}-*" \
+            -mmin "+${age_min}" \
+            -print 2>/dev/null || true
+    )"
+    [ -n "$victims" ] || return 0
+
+    # Report every removal. A silent destructive sweep on a shared node is how
+    # the next incident gets misdiagnosed.
+    while IFS= read -r d; do
+        [ -n "$d" ] || continue
+        echo "ci-tmpdir: pruning leftover scratch (job started >${age_h}h ago): $d"
+        ci_tmpdir_cleanup "$d" || true
+    done <<EOF
+$victims
+EOF
+    return 0
+}

--- a/.github/workflows/pypi-publish-and-github-release-on-tag.yml
+++ b/.github/workflows/pypi-publish-and-github-release-on-tag.yml
@@ -84,6 +84,16 @@ jobs:
       - name: Run tests in the reused CI SIF (apptainer exec — deps layered, not on the bare runner)
         run: bash .github/ci/exec-in-sif.sh run-in-sif.sh ${{ matrix.python-version }}
 
+      # The persistent runner keeps whatever this job leaves in /tmp — 1.8-2.2 GB
+      # per leg. `always()` covers failure and cancellation; the version arg
+      # scopes the removal to THIS leg, because all three share GITHUB_RUN_ID and
+      # an unscoped cleanup would delete the siblings' live scratch. Mirrors the
+      # step above by design (tests/integration/test_ci_tmpdir_lifecycle.py
+      # enforces the pairing).
+      - name: Remove this leg's CI scratch (persistent runner — nothing else reclaims it)
+        if: always()
+        run: bash .github/ci/clean-tmpdir.sh run-in-sif.sh ${{ matrix.python-version }}
+
   build:
     needs: test
     runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
@@ -128,6 +138,15 @@ jobs:
         with:
           name: dist
           path: dist/
+
+      # build-in-sif.sh leaks the same way run-in-sif.sh did, just once per
+      # release instead of three times per push — slower to notice, not smaller
+      # a bug. LAST, after the wheel assertion and the artifact upload, so the
+      # scratch is only removed once nothing can still want it. `always()` so a
+      # failed or cancelled build does not keep the disk.
+      - name: Remove this job's build scratch (persistent runner — nothing else reclaims it)
+        if: always()
+        run: bash .github/ci/clean-tmpdir.sh build-in-sif.sh 3.12
 
   publish:
     needs: build
@@ -221,6 +240,14 @@ jobs:
           echo "::error::The upload call returned, but no artifact is being served."
           echo "::error::Do NOT cut the GitHub release. Fix publish, then re-tag."
           exit 1
+
+      # publish-in-sif.sh's scratch, third member of the same leaking family.
+      # LAST, after the ghost-tag verification, and `always()` so it fires even
+      # when that verification reds the release — a failed release is exactly
+      # when a persistent runner most needs its disk back.
+      - name: Remove this job's publish scratch (persistent runner — nothing else reclaims it)
+        if: always()
+        run: bash .github/ci/clean-tmpdir.sh publish-in-sif.sh 3.12
 
   release:
     needs: [build, publish]

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -110,3 +110,23 @@ jobs:
           files: ./coverage.xml
           use_oidc: true
           fail_ci_if_error: true
+
+      # THE RUNNER IS PERSISTENT — WHAT THIS JOB WRITES TO /tmp IS OURS TO
+      # REMOVE. run-in-sif.sh's scratch (the [all,dev] --target install, the uv
+      # cache, XDG_CACHE_HOME, every tmp_path) is 1.8-2.2 GB per leg. Nothing
+      # removed it until 2026-08-09, by which point 116 survivors had filled the
+      # root filesystem of a box running twelve fleet agents.
+      #
+      # `always()` so it also fires on FAILURE and on CANCELLATION — a separate
+      # step process the runner starts after the work step is torn down, so it
+      # races none of the signals that killed it. Traps cannot do this: both
+      # script layers end in `exec`, which discards them.
+      #
+      # LAST, and scoped to ${{ matrix.python-version }}. Last because Codecov
+      # reads ./coverage.xml — that file is in the checkout, not in the scratch,
+      # but ordering removes the question. Scoped because all three legs share
+      # GITHUB_RUN_ID: a cleanup keyed on the run alone would delete the LIVE
+      # scratch of the two siblings still running.
+      - name: Remove this leg's CI scratch (persistent runner — nothing else reclaims it)
+        if: always()
+        run: bash .github/ci/clean-tmpdir.sh run-in-sif.sh ${{ matrix.python-version }}

--- a/tests/integration/test_ci_tmpdir_lifecycle.py
+++ b/tests/integration/test_ci_tmpdir_lifecycle.py
@@ -530,6 +530,181 @@ def test_clean_deletes_nothing_when_it_cannot_scope_the_target(
     assert leg.is_dir(), "an unscoped invocation deleted a leg's scratch"
 
 
+# --- a removal that FAILED must not be reported as a removal --------------
+#
+# The whole fix is verified in production by one log line — `clean-tmpdir:
+# removing <path> (2.0G)`. An earlier draft printed that line whether or not
+# anything was reclaimed, because ci_tmpdir_cleanup swallowed rm's status. On a
+# sticky /tmp shared by twelve agents, "I could not remove it" is exactly the
+# case that must be visible.
+
+_AS_ROOT = pytest.mark.skipif(
+    os.geteuid() == 0, reason="root ignores the permission bits these tests rely on"
+)
+
+
+@pytest.fixture
+def denied_subtree(root: Path):
+    """The realistic failure: ~10 tests in this suite chmod a ``tmp_path``
+    directory to 0o555 and restore it in a ``finally``. A worker SIGKILLed in
+    between — the cancellation path this fix exists for — leaves that behind."""
+    scratch = _mkdir(root, _leg("3.12"))
+    denied = scratch / "pytest-of-ci" / "pytest-0" / "test_x0" / "denied"
+    denied.mkdir(parents=True)
+    (denied / "payload").write_text("x", encoding="utf-8")
+    denied.chmod(0o555)
+    try:
+        yield scratch, _bash(f'ci_tmpdir_cleanup "{scratch}"; echo rc=$?', root)
+    finally:
+        if denied.exists():
+            denied.chmod(0o755)
+
+
+@_AS_ROOT
+def test_cleanup_reclaims_a_subtree_left_non_writable(denied_subtree):
+    # Arrange
+    scratch, _res = denied_subtree
+    # Act
+    survived = scratch.exists()
+    # Assert
+    assert not survived, "an unwritable subtree defeated the cleanup"
+
+
+@_AS_ROOT
+def test_cleanup_exits_zero_after_reclaiming_a_non_writable_subtree(denied_subtree):
+    # Arrange
+    _scratch, res = denied_subtree
+    # Act
+    log = res.stdout
+    # Assert
+    assert "rc=0" in log, res.stderr
+
+
+@pytest.fixture
+def unremovable(root: Path):
+    """A scratch dir inside a READ-ONLY root: no chmod of ours can unlink it,
+    so this is a removal that genuinely cannot succeed."""
+    scratch = _mkdir(root, _leg("3.12"))
+    root.chmod(0o500)
+    try:
+        yield scratch
+    finally:
+        root.chmod(0o700)
+
+
+@_AS_ROOT
+def test_cleanup_reports_a_removal_it_could_not_perform(root: Path, unremovable: Path):
+    # Arrange
+    target = unremovable
+    # Act
+    res = _bash(f'ci_tmpdir_cleanup "{target}"; echo rc=$?', root)
+    # Assert
+    assert "rc=1" in res.stdout, f"a failed removal returned success: {res.stdout!r}"
+
+
+@_AS_ROOT
+def test_clean_step_warns_when_the_removal_failed(root: Path, unremovable: Path):
+    """clean-tmpdir.sh's `::warning::` branch was unreachable while cleanup
+    always returned 0 — the step logged a removal that never happened."""
+    # Arrange
+    _target = unremovable
+    # Act
+    res = _run_clean(root, "run-in-sif.sh", "3.12")
+    # Assert
+    assert "::warning::" in res.stdout + res.stderr, res.stdout
+
+
+@_AS_ROOT
+def test_clean_step_still_exits_zero_when_the_removal_failed(
+    root: Path, unremovable: Path
+):
+    """Honest, but still never reds the job it is `always()`-attached to."""
+    # Arrange
+    _target = unremovable
+    # Act
+    res = _run_clean(root, "run-in-sif.sh", "3.12")
+    # Assert
+    assert res.returncode == 0, res.stderr
+
+
+def test_clean_refuses_an_unmanaged_target_before_announcing_it(root: Path):
+    """A malformed version composed a path outside the managed set, and the
+    step announced `removing <root> (270G)` before refusing it — a line that
+    reads like an imminent disaster and burns the 30 s `du` bound saying so."""
+    # Arrange
+    _bystander = _mkdir(root, _leg("3.12"))
+    # Act
+    res = _run_clean(root, "run-in-sif.sh", "../..")
+    # Assert
+    assert "removing" not in res.stdout, res.stdout
+
+
+def test_clean_says_so_when_the_library_cannot_be_loaded(tmp_path: Path):
+    """A partial checkout used to produce "creates no per-run scratch" — the
+    opposite of the truth, while a directory leaked."""
+    # Arrange
+    orphan = tmp_path / "ci-no-lib"
+    orphan.mkdir()
+    (orphan / "clean-tmpdir.sh").write_text(
+        _CLEAN.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    # Act
+    res = subprocess.run(
+        ["bash", str(orphan / "clean-tmpdir.sh"), "run-in-sif.sh", "3.12"],
+        capture_output=True,
+        text=True,
+        env=_env(tmp_path),
+    )
+    # Assert
+    assert "could not load" in res.stdout + res.stderr, res.stdout
+
+
+# --- the age knob is clamped: its failure mode is destructive --------------
+
+
+def _prune_with_age(root: Path, age: str):
+    return subprocess.run(
+        ["bash", "-c", f'set -euo pipefail; . "{_LIB}"\nci_tmpdir_prune; echo rc=$?'],
+        capture_output=True,
+        text=True,
+        env=_env(root, SAC_CI_TMPDIR_MAX_AGE_H=age),
+    )
+
+
+@pytest.mark.parametrize("age", ["0", "abc", "-1", "", "2.5"])
+def test_prune_ignores_an_age_override_that_is_not_a_floor(root: Path, age: str):
+    """``=0`` deleted a 3-minute-old concurrent run's LIVE scratch — the exact
+    outage this fix exists to prevent, reachable from one stray env var."""
+    # Arrange
+    live = _mkdir(root, "ci-scitex_agent_container-99990000-1-3.12")
+    # Act
+    _prune_with_age(root, age)
+    # Assert
+    assert live.is_dir(), f"SAC_CI_TMPDIR_MAX_AGE_H={age!r} destroyed a live run"
+
+
+@pytest.mark.parametrize("age", ["abc", "", "2.5"])
+def test_prune_survives_a_malformed_age_override_under_errexit(root: Path, age: str):
+    """``=abc`` aborted with `abc: unbound variable`, and exec-in-sif.sh runs
+    under `set -euo pipefail` — so it failed the job before the SIF started."""
+    # Arrange
+    _mkdir(root, "ci-scitex_agent_container-99990000-1-3.12")
+    # Act
+    res = _prune_with_age(root, age)
+    # Assert
+    assert "rc=0" in res.stdout, res.stderr
+
+
+def test_prune_still_reclaims_a_leftover_under_a_valid_age_override(root: Path):
+    """The clamp must not neuter the knob the tests above rely on."""
+    # Arrange
+    old = _mkdir(root, "ci-scitex_agent_container-11110000-1-3.12", age_s=2 * 3600)
+    # Act
+    _prune_with_age(root, "1")
+    # Assert
+    assert not old.exists(), "the clamp swallowed a legitimate age override"
+
+
 # --- wiring: every job that creates scratch must also remove it ------------
 
 

--- a/tests/integration/test_ci_tmpdir_lifecycle.py
+++ b/tests/integration/test_ci_tmpdir_lifecycle.py
@@ -169,7 +169,10 @@ def test_prefix_table_maps_inner_script_to_prefix(root: Path, inner: str, prefix
     assert res.stdout == prefix, res.stderr
 
 
-@pytest.fixture(scope="module")
+# Function-scoped on purpose: STX-TQ004 rejects a module/session fixture that
+# mutates in its body, and the accumulator here is exactly that shape. Re-globbing
+# six shell scripts per test costs nothing.
+@pytest.fixture
 def scratch_creating_scripts() -> list[str]:
     """Scripts that assign TMPDIR — derived from the SCRIPTS, not the table."""
     found = []
@@ -719,7 +722,8 @@ def _tail_invocation(run: str, script: str):
     return (m.group(1), m.group(2).strip()) if m else None
 
 
-@pytest.fixture(scope="module")
+# Function-scoped for the same reason as `scratch_creating_scripts` above.
+@pytest.fixture
 def wiring():
     """Every (workflow, job, inner, args) that creates scratch, paired with the
     cleanup invocations present in the same job."""

--- a/tests/integration/test_ci_tmpdir_lifecycle.py
+++ b/tests/integration/test_ci_tmpdir_lifecycle.py
@@ -1,0 +1,642 @@
+"""The in-SIF CI scratch must be REMOVED — on this runner nothing else will.
+
+MEASURED 2026-08-09 on scitex-04-cpu-01. ``.github/ci/run-in-sif.sh`` exported a
+per-run ``TMPDIR`` under ``/tmp`` and nothing ever removed it. 116 survivors at
+1.8-2.2 GB each put ``/tmp`` at 270 GB of a 393 GB root: root 100% full (39 MB
+free), inodes at 92%, on a box hosting twelve fleet agents. ``build-in-sif.sh``
+and ``publish-in-sif.sh`` leak identically, once per release. The defect is a
+GitHub-hosted-runner assumption (the VM is discarded, so leaking is free)
+applied to a persistent self-hosted one, where it is a slow outage.
+
+These tests drive the REAL shell — ``tmpdir-lib.sh`` and ``clean-tmpdir.sh`` via
+subprocess, no mocks — inside a sandbox root handed over by
+``SAC_CI_TMPDIR_ROOT``, so nothing here can see, let alone touch, a real
+``/tmp/ci-*`` directory.
+
+The prune is the part of this fix that can CAUSE the outage it prevents: three
+matrix legs run at once on one box and share ``GITHUB_RUN_ID``, so a sweep keyed
+only on age deletes a sibling's LIVE scratch. Two tests carry MUTATION CONTROLS
+— they strip a guard out of a COPY of the library and assert the sibling is then
+destroyed. A guard that cannot be shown to fail proves nothing about the green.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO = Path(__file__).resolve().parents[2]
+_CI = _REPO / ".github" / "ci"
+_LIB = _CI / "tmpdir-lib.sh"
+_CLEAN = _CI / "clean-tmpdir.sh"
+_EXEC = _CI / "exec-in-sif.sh"
+_WORKFLOWS = _REPO / ".github" / "workflows"
+
+# The run identity the sandbox pretends to be running under.
+_RUN_ID = "77770001"
+_ATTEMPT = "1"
+
+# Comfortably past the 24 h floor. Used to backdate a directory's mtime.
+_ANCIENT_S = 30 * 60 * 60
+
+# The inner scripts that create a per-run scratch today.
+_SCRATCH_CREATORS = ("run-in-sif.sh", "build-in-sif.sh", "publish-in-sif.sh")
+
+# Paths ci_tmpdir_cleanup must refuse: the root itself, outside it, nested
+# deeper, and traversal. Its argument comes from a workflow interpolation and
+# goes to `rm -rf`.
+_FORBIDDEN = (
+    "<root>",
+    "/",
+    "<root>/site",
+    "<root>/ci-scitex_agent_container-1-1-3.12/site",
+    "<root>/../etc",
+)
+
+
+def _env(root: Path, **over: str) -> dict[str, str]:
+    env = dict(os.environ)
+    env.update(
+        {
+            "SAC_CI_TMPDIR_ROOT": str(root),
+            "GITHUB_RUN_ID": _RUN_ID,
+            "GITHUB_RUN_ATTEMPT": _ATTEMPT,
+        }
+    )
+    env.update(over)
+    return env
+
+
+def _bash(script: str, root: Path, lib: Path | None = None):
+    """Run a bash snippet with the lifecycle library sourced."""
+    return subprocess.run(
+        ["bash", "-c", f'set -uo pipefail; . "{lib or _LIB}"\n{script}'],
+        capture_output=True,
+        text=True,
+        env=_env(root),
+    )
+
+
+def _run_clean(root: Path, *args: str):
+    return subprocess.run(
+        ["bash", str(_CLEAN), *args], capture_output=True, text=True, env=_env(root)
+    )
+
+
+def _mkdir(root: Path, name: str, *, age_s: int = 0) -> Path:
+    """Create a fake scratch dir with a payload, optionally backdated."""
+    d = root / name
+    (d / "site").mkdir(parents=True)
+    (d / "site" / "payload.bin").write_bytes(b"x" * 1024)
+    if age_s:
+        when = time.time() - age_s
+        os.utime(d, (when, when))
+    return d
+
+
+def _mutated_lib(tmp_path: Path, clause: str) -> Path:
+    """A COPY of the library with one prune guard stripped out."""
+    src = _LIB.read_text(encoding="utf-8")
+    mutated = src.replace(clause, "")
+    if mutated == src:
+        raise AssertionError(f"guard clause not found to strip: {clause!r}")
+    out = tmp_path / "mutated-tmpdir-lib.sh"
+    out.write_text(mutated, encoding="utf-8")
+    return out
+
+
+def _leg(version: str) -> str:
+    return f"ci-scitex_agent_container-{_RUN_ID}-{_ATTEMPT}-{version}"
+
+
+@pytest.fixture
+def root(tmp_path: Path) -> Path:
+    r = tmp_path / "scratch-root"
+    r.mkdir()
+    return r
+
+
+# --- naming: ONE definition, shared by creator, remover and pruner ----------
+
+
+@pytest.fixture(scope="module")
+def path_result():
+    return _bash("ci_tmpdir_path ci 3.12", Path("/sandbox-unused"))
+
+
+def test_path_helper_exits_zero(path_result):
+    # Arrange
+    res = path_result
+    # Act
+    rc = res.returncode
+    # Assert
+    assert rc == 0, res.stderr
+
+
+def test_path_is_the_name_the_scripts_already_used(path_result):
+    """Changing the name would start a SECOND leak beside the first and never
+    reclaim the 116 directories already on disk."""
+    # Arrange
+    expected = f"/sandbox-unused/ci-scitex_agent_container-{_RUN_ID}-{_ATTEMPT}-3.12"
+    # Act
+    got = path_result.stdout
+    # Assert
+    assert got == expected
+
+
+@pytest.mark.parametrize(
+    ("inner", "prefix"),
+    [
+        ("run-in-sif.sh", "ci"),
+        ("build-in-sif.sh", "build"),
+        ("publish-in-sif.sh", "publish"),
+        ("autobump-in-sif.sh", ""),
+        ("not-a-script.sh", ""),
+    ],
+)
+def test_prefix_table_maps_inner_script_to_prefix(root: Path, inner: str, prefix: str):
+    # Arrange
+    cmd = f'ci_tmpdir_prefix_for_inner "{inner}"'
+    # Act
+    res = _bash(cmd, root)
+    # Assert
+    assert res.stdout == prefix, res.stderr
+
+
+@pytest.fixture(scope="module")
+def scratch_creating_scripts() -> list[str]:
+    """Scripts that assign TMPDIR — derived from the SCRIPTS, not the table."""
+    found = []
+    for script in sorted(_CI.glob("*-in-sif.sh")):
+        if script.name == "exec-in-sif.sh":
+            continue  # host-side wrapper; creates no scratch of its own
+        src = script.read_text(encoding="utf-8")
+        if re.search(r"^\s*(export\s+)?TMPDIR=", src, re.MULTILINE):
+            found.append(script.name)
+    return found
+
+
+def test_scratch_creator_detection_finds_the_known_creators(scratch_creating_scripts):
+    """Positive control: without it, an empty scan would pass every test
+    below vacuously."""
+    # Arrange
+    expected = set(_SCRATCH_CREATORS)
+    # Act
+    found = set(scratch_creating_scripts)
+    # Assert
+    assert found >= expected, f"detection is broken; found {sorted(found)}"
+
+
+def test_every_scratch_creating_script_is_in_the_prefix_table(
+    root: Path, scratch_creating_scripts
+):
+    """The guard that survives the NEXT in-SIF script.
+
+    Three scripts leaked for months because registering a new one for cleanup
+    was left to whoever remembered. An unregistered creator now fails CI.
+    """
+    # Arrange
+    missing = []
+    # Act
+    for name in scratch_creating_scripts:
+        if not _bash(f'ci_tmpdir_prefix_for_inner "{name}"', root).stdout:
+            missing.append(name)
+    # Assert
+    assert not missing, (
+        f"{missing} create a per-run TMPDIR but are absent from "
+        f"ci_tmpdir_prefix_for_inner in {_LIB} — they would leak unremoved"
+    )
+
+
+# --- cleanup: idempotent, concurrency-safe, refuses anything else ----------
+
+
+@pytest.fixture
+def cleanup_run(root: Path):
+    """Create one scratch dir, remove it twice (the `always()` step and the
+    next run's prune both target the same path)."""
+    d = _mkdir(root, _leg("3.12"))
+    first = _bash(f'ci_tmpdir_cleanup "{d}"', root)
+    second = _bash(f'ci_tmpdir_cleanup "{d}"', root)
+    return d, first, second
+
+
+def test_cleanup_removes_the_directory(cleanup_run):
+    # Arrange
+    directory, _first, _second = cleanup_run
+    # Act
+    survived = directory.exists()
+    # Assert
+    assert not survived
+
+
+def test_cleanup_exits_zero(cleanup_run):
+    # Arrange
+    _directory, first, _second = cleanup_run
+    # Act
+    rc = first.returncode
+    # Assert
+    assert rc == 0, first.stderr
+
+
+def test_cleanup_is_idempotent_on_an_already_removed_path(cleanup_run):
+    # Arrange
+    _directory, _first, second = cleanup_run
+    # Act
+    rc = second.returncode
+    # Assert
+    assert rc == 0, second.stderr
+
+
+def _forbidden_target(root: Path, spec: str) -> str:
+    return spec.replace("<root>", str(root))
+
+
+@pytest.mark.parametrize("spec", _FORBIDDEN)
+def test_cleanup_refuses_a_path_it_did_not_create(root: Path, spec: str):
+    # Arrange
+    target = _forbidden_target(root, spec)
+    # Act
+    res = _bash(f'ci_tmpdir_cleanup "{target}"', root)
+    # Assert
+    assert res.returncode != 0, f"cleanup ACCEPTED {target!r}"
+
+
+@pytest.mark.parametrize("spec", _FORBIDDEN)
+def test_cleanup_refusal_says_why(root: Path, spec: str):
+    # Arrange
+    target = _forbidden_target(root, spec)
+    # Act
+    res = _bash(f'ci_tmpdir_cleanup "{target}"', root)
+    # Assert
+    assert "refusing to remove" in res.stderr
+
+
+@pytest.mark.parametrize("spec", _FORBIDDEN)
+def test_cleanup_refusal_destroys_nothing(root: Path, spec: str):
+    # Arrange
+    bystander = _mkdir(root, "ci-scitex_agent_container-1-1-3.12")
+    # Act
+    _bash(f'ci_tmpdir_cleanup "{_forbidden_target(root, spec)}"', root)
+    # Assert
+    assert bystander.is_dir() and root.is_dir()
+
+
+# --- prune: the SIGKILL/reboot backstop, and the sibling-leg hazard --------
+
+
+@pytest.fixture
+def leftover_prune(root: Path):
+    old = _mkdir(root, "ci-scitex_agent_container-11110000-1-3.12", age_s=_ANCIENT_S)
+    return old, _bash("ci_tmpdir_prune", root)
+
+
+def test_prune_removes_a_leftover_from_another_run(leftover_prune):
+    # Arrange
+    old, _res = leftover_prune
+    # Act
+    survived = old.exists()
+    # Assert
+    assert not survived
+
+
+def test_prune_reports_what_it_removed(leftover_prune):
+    """A silent destructive sweep on a shared node is how the NEXT incident
+    gets misdiagnosed."""
+    # Arrange
+    old, res = leftover_prune
+    # Act
+    log = res.stdout
+    # Assert
+    assert "pruning leftover scratch" in log and old.name in log
+
+
+def test_prune_exits_zero(leftover_prune):
+    # Arrange
+    _old, res = leftover_prune
+    # Act
+    rc = res.returncode
+    # Assert
+    assert rc == 0, res.stderr
+
+
+@pytest.mark.parametrize("version", ["3.11", "3.12", "3.13"])
+def test_prune_spares_a_sibling_matrix_leg_of_this_run_even_when_old(
+    root: Path, version: str
+):
+    """THE OUTAGE CASE. 3.11/3.12/3.13 start together and share GITHUB_RUN_ID.
+
+    The release workflow's test job sets no ``timeout-minutes``, so a leg may
+    legitimately live for GitHub's 6-hour default — backdated far past the age
+    floor here on purpose. Only the run-identity guard can save it.
+    """
+    # Arrange
+    leg = _mkdir(root, _leg(version), age_s=_ANCIENT_S)
+    # Act
+    _bash("ci_tmpdir_prune", root)
+    # Assert
+    assert leg.is_dir(), f"prune deleted a LIVE sibling matrix leg: {leg}"
+
+
+def test_control_removing_the_run_identity_guard_destroys_the_sibling(
+    root: Path, tmp_path: Path
+):
+    """MUTATION CONTROL for the test above — a guard that cannot be shown to
+    fail proves nothing about the green."""
+    # Arrange
+    lib = _mutated_lib(tmp_path, '! -name "*-${run_id}-${attempt}-*" \\\n')
+    leg = _mkdir(root, _leg("3.12"), age_s=_ANCIENT_S)
+    # Act
+    _bash("ci_tmpdir_prune", root, lib=lib)
+    # Assert
+    assert not leg.exists(), "the control cannot go red, so it validates nothing"
+
+
+def test_prune_spares_a_young_directory_from_another_run(root: Path):
+    """A different workflow run, concurrently in flight on the same runner."""
+    # Arrange
+    young = _mkdir(root, "ci-scitex_agent_container-99990000-1-3.12")
+    # Act
+    _bash("ci_tmpdir_prune", root)
+    # Assert
+    assert young.is_dir()
+
+
+def test_control_dropping_the_age_floor_destroys_the_concurrent_run(
+    root: Path, tmp_path: Path
+):
+    """MUTATION CONTROL for the age floor."""
+    # Arrange
+    lib = _mutated_lib(tmp_path, '-mmin "+${age_min}" \\\n')
+    young = _mkdir(root, "ci-scitex_agent_container-99990000-1-3.12")
+    # Act
+    _bash("ci_tmpdir_prune", root, lib=lib)
+    # Assert
+    assert not young.exists(), "the control cannot go red, so it validates nothing"
+
+
+@pytest.mark.parametrize(
+    "name", ["apptainer-tmp-ywatanabe", "pytest-of-ywatanabe", "sac-tui-env-x.txt.d"]
+)
+def test_prune_leaves_unrelated_directories_alone(root: Path, name: str):
+    """/tmp on that box holds 636 entries belonging to other things."""
+    # Arrange
+    foreign = _mkdir(root, name, age_s=_ANCIENT_S)
+    # Act
+    _bash("ci_tmpdir_prune", root)
+    # Assert
+    assert foreign.is_dir()
+
+
+def test_prune_tolerates_a_missing_root(tmp_path: Path):
+    """Hosted runners stay a live possibility (``vars.CI_RUNS_ON``): an absent
+    or empty root must never fail a job."""
+    # Arrange
+    missing = tmp_path / "no-such-root"
+    # Act
+    res = _bash("ci_tmpdir_prune; echo rc=$?", missing)
+    # Assert
+    assert "rc=0" in res.stdout, res.stderr
+
+
+@pytest.mark.parametrize("prefix", ["ci", "build", "publish"])
+def test_prune_covers_every_leaking_prefix(root: Path, prefix: str):
+    """One fix, all three leaking scripts — build and publish leak once per
+    release, which is slower to notice, not less of a leak."""
+    # Arrange
+    old = _mkdir(
+        root, f"{prefix}-scitex_agent_container-11110000-1-3.12", age_s=_ANCIENT_S
+    )
+    # Act
+    _bash("ci_tmpdir_prune", root)
+    # Assert
+    assert not old.exists(), f"{old} survived the prune"
+
+
+# --- clean-tmpdir.sh: the end-of-job step ---------------------------------
+
+
+@pytest.fixture
+def clean_run(root: Path):
+    """The 3.12 leg cleans up while 3.11 and 3.13 are still running, and the
+    same release run's build scratch exists alongside."""
+    mine = _mkdir(root, _leg("3.12"))
+    siblings = [_mkdir(root, _leg(v)) for v in ("3.11", "3.13")]
+    build = _mkdir(root, f"build-scitex_agent_container-{_RUN_ID}-{_ATTEMPT}-3.12")
+    res = _run_clean(root, "run-in-sif.sh", "3.12")
+    return mine, siblings, build, res
+
+
+def test_clean_removes_this_matrix_leg(clean_run):
+    # Arrange
+    mine, _siblings, _build, _res = clean_run
+    # Act
+    survived = mine.exists()
+    # Assert
+    assert not survived
+
+
+def test_clean_exits_zero(clean_run):
+    # Arrange
+    _mine, _siblings, _build, res = clean_run
+    # Act
+    rc = res.returncode
+    # Assert
+    assert rc == 0, res.stderr
+
+
+def test_clean_spares_the_sibling_matrix_legs(clean_run):
+    """All three legs share GITHUB_RUN_ID; a cleanup keyed on the run alone
+    would delete the LIVE scratch of the two still running."""
+    # Arrange
+    _mine, siblings, _build, _res = clean_run
+    # Act
+    survivors = [s for s in siblings if s.is_dir()]
+    # Assert
+    assert survivors == siblings, "clean-tmpdir deleted a live sibling leg"
+
+
+def test_clean_spares_the_build_scratch_of_the_same_run(clean_run):
+    """`build` and `test` of one release run share the run id too."""
+    # Arrange
+    _mine, _siblings, build, _res = clean_run
+    # Act
+    survived = build.is_dir()
+    # Assert
+    assert survived
+
+
+@pytest.fixture
+def clean_missing(root: Path):
+    return _run_clean(root, "run-in-sif.sh", "3.12")
+
+
+def test_clean_reports_an_already_removed_directory(clean_missing):
+    # Arrange
+    res = clean_missing
+    # Act
+    log = res.stdout
+    # Assert
+    assert "already gone" in log
+
+
+def test_clean_exits_zero_when_the_directory_is_already_gone(clean_missing):
+    # Arrange
+    res = clean_missing
+    # Act
+    rc = res.returncode
+    # Assert
+    assert rc == 0, res.stderr
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        (),  # no inner script
+        ("autobump-in-sif.sh",),  # creates no scratch
+        ("run-in-sif.sh",),  # no version -> cannot scope safely
+    ],
+)
+def test_clean_never_fails_the_job(root: Path, args: tuple[str, ...]):
+    """It is an `always()` step: it must never red a run, and must never
+    replace the real failure of the job it is attached to."""
+    # Arrange
+    _mkdir(root, _leg("3.12"))
+    # Act
+    res = _run_clean(root, *args)
+    # Assert
+    assert res.returncode == 0, res.stderr
+
+
+@pytest.mark.parametrize(
+    "args", [(), ("autobump-in-sif.sh",), ("run-in-sif.sh",), ("run-in-sif.sh", "")]
+)
+def test_clean_deletes_nothing_when_it_cannot_scope_the_target(
+    root: Path, args: tuple[str, ...]
+):
+    """Without a version there is no way to tell this leg from its siblings, so
+    the only safe move is to skip and let the next run's prune reclaim it."""
+    # Arrange
+    leg = _mkdir(root, _leg("3.12"))
+    # Act
+    _run_clean(root, *args)
+    # Assert
+    assert leg.is_dir(), "an unscoped invocation deleted a leg's scratch"
+
+
+# --- wiring: every job that creates scratch must also remove it ------------
+
+
+def _steps_of(workflow: Path):
+    doc = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    for job_name, job in (doc.get("jobs") or {}).items():
+        yield job_name, (job.get("steps") or [])
+
+
+def _tail_invocation(run: str, script: str):
+    m = re.search(rf"{re.escape(script)}\s+(\S+)((?:\s+\S+)*)\s*$", run.strip())
+    return (m.group(1), m.group(2).strip()) if m else None
+
+
+@pytest.fixture(scope="module")
+def wiring():
+    """Every (workflow, job, inner, args) that creates scratch, paired with the
+    cleanup invocations present in the same job."""
+    pairs = []
+    for wf in sorted(_WORKFLOWS.glob("*.y*ml")):
+        for job_name, steps in _steps_of(wf):
+            cleans = []
+            for step in steps:
+                hit = _tail_invocation(step.get("run") or "", "clean-tmpdir.sh")
+                if hit:
+                    cleans.append((*hit, str(step.get("if", ""))))
+            for step in steps:
+                hit = _tail_invocation(step.get("run") or "", "exec-in-sif.sh")
+                if hit and hit[0] in _SCRATCH_CREATORS:
+                    pairs.append((f"{wf.name}:{job_name}", hit, cleans))
+    return pairs
+
+
+def test_workflow_scan_finds_the_scratch_creating_steps(wiring):
+    """Positive control: an empty scan would pass the two tests below
+    vacuously — exactly the failure mode this whole fix is about."""
+    # Arrange
+    expected_minimum = 4  # 2x pytest-matrix/release test legs, build, publish
+    # Act
+    found = len(wiring)
+    # Assert
+    assert found >= expected_minimum, f"scanned only {found} scratch-creating steps"
+
+
+def test_every_scratch_creating_job_has_a_cleanup_step(wiring):
+    """The discipline that failed here, converted into a CI failure."""
+    # Arrange
+    unpaired = []
+    # Act
+    for where, (inner, args), cleans in wiring:
+        if not [c for c in cleans if c[0] == inner and c[1] == args]:
+            unpaired.append(f"{where} runs {inner} {args}")
+    # Assert
+    assert not unpaired, (
+        f"{unpaired} — no matching `clean-tmpdir.sh` step, so each leaks "
+        f"~2 GB of scratch per run on the persistent runner"
+    )
+
+
+def test_every_cleanup_step_is_guarded_by_always(wiring):
+    """Without `always()` the step skips on FAILURE and on CANCELLATION — the
+    two endings that most need the disk back."""
+    # Arrange
+    unguarded = []
+    # Act
+    for where, (inner, args), cleans in wiring:
+        match = [c for c in cleans if c[0] == inner and c[1] == args]
+        if match and not any("always()" in c[2] for c in match):
+            unguarded.append(f"{where} ({inner} {args})")
+    # Assert
+    assert not unguarded, f"cleanup steps not guarded by `if: always()`: {unguarded}"
+
+
+def test_exec_wrapper_sources_the_lifecycle_library():
+    # Arrange
+    src = _EXEC.read_text(encoding="utf-8")
+    # Act
+    sourced = "tmpdir-lib.sh" in src
+    # Assert
+    assert sourced, "exec-in-sif.sh no longer sources the lifecycle library"
+
+
+def test_exec_wrapper_runs_the_startup_prune():
+    """The ONLY cover for SIGKILL and reboot, where no in-process cleanup can
+    run by construction (the runner unit is KillMode=process)."""
+    # Arrange
+    src = _EXEC.read_text(encoding="utf-8")
+    # Act
+    calls = re.search(r"^ci_tmpdir_prune\s*$", src, re.MULTILINE)
+    # Assert
+    assert calls, (
+        "exec-in-sif.sh no longer calls ci_tmpdir_prune — leftovers from a "
+        "SIGKILLed or rebooted run would accumulate forever"
+    )
+
+
+def test_no_inner_script_hardcodes_its_own_scratch_path():
+    """Two spellings of the name is how a cleanup starts missing its target."""
+    # Arrange
+    offenders = []
+    # Act
+    for script in sorted(_CI.glob("*-in-sif.sh")):
+        for line in script.read_text(encoding="utf-8").splitlines():
+            if not line.lstrip().startswith("#") and re.search(r'TMPDIR="?/tmp/', line):
+                offenders.append(f"{script.name}: {line.strip()}")
+    # Assert
+    assert not offenders, (
+        "these build a scratch path literally instead of via ci_tmpdir_path, so "
+        f"clean-tmpdir.sh and the prune cannot find it: {offenders}"
+    )


### PR DESCRIPTION
## The outage this fixes

Measured on the self-hosted runner `scitex-04-cpu-01`, 2026-08-09:

- **116** leaked scratch directories at **1.8-2.2 GB** each
- `/tmp` at **270 GB of a 393 GB root**; root **100% full** (39 MB free); **inodes at 92%**
- **twelve fleet agents** live on that box, so a full root is a fleet outage, not a nuisance

## The cause, one line

`.github/ci/run-in-sif.sh:33`

```bash
export TMPDIR="/tmp/ci-scitex_agent_container-${GITHUB_RUN_ID:-0}-${GITHUB_RUN_ATTEMPT:-0}-$V"
```

It creates a per-run directory under `/tmp` and **nothing ever removed it**. The pytest matrix runs 3.11/3.12/3.13, so **one CI run leaked three directories**. `build-in-sif.sh` and `publish-in-sif.sh` leak identically, once per release — a fix to `run-in-sif.sh` alone would have left two live.

This is a **GitHub-hosted-runner assumption applied to a persistent runner**. On a hosted runner the whole VM is discarded, so leaking scratch is invisible and free. The same script runs in both places, so the fix has to be correct in both — and `runs-on` is `fromJSON(vars.CI_RUNS_ON || …)`, meaning one repo Actions Variable can move every job to a hosted image with no code change. Nothing here may therefore *require* a persistent box.

## What the fix covers

**Three mechanisms, because no single one covers every way a job can end.**

The obvious fix — `trap cleanup EXIT` — gives **zero** coverage as this code stands. Both layers end in `exec` (`exec-in-sif.sh:122`, `run-in-sif.sh:166`), and `exec` replaces the shell image and takes every trap with it (verified by probe, not assumed). Making a trap fire means deleting an `exec` that is load-bearing for signal and exit-code propagation through a 45-minute pytest run, which `autobump-release-sweep.yaml` depends on by name. So:

1. **`ci_tmpdir_path()`** — one definition of the directory name, shared by the script that creates it, the step that removes it, and the prune that skips it. It is byte-identical to the names already in use, so this **also reclaims the 116 directories already on disk** rather than starting a second leak beside the first.
2. **`clean-tmpdir.sh`, an `if: always()` step** — covers **success, failure and cancellation**. A separate step process the runner starts *after* the work step is torn down, so it races none of the signals that killed it. This is strictly more reliable for cancellation than a trap would have been, and it also covers **SIGKILL of the work step**.
3. **`ci_tmpdir_prune()` in `exec-in-sif.sh`** — the only cover for a killed *runner* or a reboot. Host-side, because that is the single choke point all in-SIF call sites pass through, it still runs when the SIF never starts, and `/tmp` is shared with the container anyway.

**The prune's two guards** — this is the part that could cause the outage it prevents:

- **Self-exclusion by run identity**: any name carrying this `GITHUB_RUN_ID`+`GITHUB_RUN_ATTEMPT` is skipped **by name, at any age**. This is what stops the 3.11 leg deleting 3.12's and 3.13's live scratch. Exact, not heuristic.
- **A 24 h age floor** for foreign run ids. `pytest-matrix` caps at `timeout-minutes: 45`, but `pypi-publish-and-github-release-on-tag.yml` sets **no** timeout and inherits GitHub's 6-hour platform default — 24 h is 4x that ceiling. The asymmetry justifies erring large: too small deletes a live job's scratch and produces a baffling red release; too large only delays disk that mechanism 2 already reclaims on every normal ending.

**Nothing about what CI tests changed.** This is a lifecycle fix: no test, no dependency, no matrix entry, no timeout is touched.

### `/scratch` — argued and declined

The host has 3.0 TB of `/scratch` at 1% used, and the fix deliberately does **not** use it. Checked, not assumed: `/scratch` is `drwxr-xr-x root root` while the runner is `User=ywatanabe`, so `mkdir -p` under `set -euo pipefail` would abort **every** job before a test ran; it is not bound into the SIF (`apptainer.conf` binds only `/etc/localtime` and `/etc/hosts`), so `[ -d /scratch ]` is false inside any inner script; hosted runners have none. And the decisive one: **relocating a leak does not fix it** — 3 TB buys ~430 runs instead of ~40, the same outage months later with nobody watching. The full argument is in `tmpdir-lib.sh`.

## What the adversarial pass tried, and failed, to do

An independent pass ran **116 adversarial assertions** against the prune and the cleanup, every path pinned into a sandbox root so the real `/tmp` pattern was structurally unreachable, with a **positive control first** (a 30 h-old foreign directory *is* pruned, so the green results are not vacuous). **No route was found that deletes a live directory.**

- **Three matrix legs seconds apart**: all spared. Then the age guard was **stripped entirely** and all three back-dated to 99999 h, leaving only the name guard — still all three spared. A leg mid-`pytest` with a live `pytest-of-*` tree survives a sibling's prune. Attempt 2 does not take attempt 1's young legs.
- **Under-match attacks on the exclusion glob** (the only direction that kills): run ids `91234 / 12345 / 1234000 / 1 / 4 / 123` against ours `1234`, attempts `2 / 10 / 11` — every neighbour correctly pruned, ours spared every time.
- **Two concurrent runs, 8 min apart, three legs each**: neither run's prune nor cleanup touched any of the other's six live directories.
- **18 decoy directories, all 500 h old, all survived**: `apptainer-tmp-*` (the shape `exec-in-sif.sh` itself creates), `pytest-of-*`, `systemd-private-*`, `.X11-unix`, `tmux-1000`, sibling repos `ci-scitex_dev-*` / `build-scitex_cloud-*` / `publish-scitex_scholar-*`, and near-misses (`…containerX-`, hyphens for underscores, case changes, `xci-`, `my-ci-`, `ci_`).
- A **file** and a **symlink** carrying an exactly-matching name are skipped (`-type d`); a symlink *inside* a pruned directory does not lead `rm -rf` out of it; `-maxdepth 1` holds against an identically-named directory nested one level down; prefix collisions `3.1` / `3.12` / `3.12.1` / `3.120` do not bleed.
- `ci_tmpdir_cleanup` **refused all 15 hostile paths** (root itself, `/`, `/etc`, `/tmp`, `$HOME`, traversals, nested children, relative, empty) and **all 14 hostile version args** and 7 hostile inner-script names left every leg alive. A symlink-swap TOCTOU on the cleanup path unlinks only the link.

Separately, all four job endings were exercised end-to-end against dummy directories, with the harness ending in `exec` exactly as the real script does:

| ending | work-step rc | scratch after cleanup |
|---|---|---|
| normal exit | 0 | removed |
| non-zero exit | 1 | removed |
| **SIGTERM** | 143 | removed |
| **SIGINT** | 130 | removed |
| **SIGKILL** | 137 | removed |

with a **negative control** (skip the cleanup step → the directory survives, so the harness can see a leak), sibling safety under cancellation (three legs, one cancelled → the other two intact), and idempotence (second cleanup on an already-removed path → rc 0).

## Defects the adversarial pass *did* find — all fixed in the second commit

It found no way to delete live data, but it found the cleanup **lying about its own success**, which is arguably worse for a fix whose production verification is one log line:

1. `ci_tmpdir_cleanup` did `rm -rf … || true; return 0`, so `clean-tmpdir.sh`'s `::warning::could not remove` branch was **unreachable** and the step printed `removing <path> (2.0G)` for a directory still on disk (measured: 3.9M → 24K residue, reported as success). It now returns 0 **only when the path is gone**, and retries once after `chmod -R u+rwX` — the realistic failure is a `tmp_path` directory chmod'ed to `0o555` by a test whose `finally` never ran because the worker was killed, which is exactly the cancellation path this fix advertises.
2. `SAC_CI_TMPDIR_MAX_AGE_H` is now **clamped** to a whole number of hours ≥ 1. `=0` deleted a 3-minute-old concurrent run's live scratch, and `=abc` aborted with `abc: unbound variable`, which under `exec-in-sif.sh`'s `set -euo pipefail` failed the job *before the SIF started*. (The knob appears in no workflow and no `src/` file — it is test-only — so neither was reachable from CI, but its failure mode was destructive and its input is a string.)
3. `clean-tmpdir.sh` announced and `du`-ed the target *before* checking managed-ness, so a malformed version arg printed `removing /tmp (270G)` and burned the 30 s `du` bound before refusing. The check now comes first.
4. `clean-tmpdir.sh` said "creates no per-run scratch" when a partial checkout left the library unsourced — the opposite of the truth. It now says it could not load the library.
5. A comment overstated what `-mmin` measures (a *direct* child of `$TMPDIR` does refresh the top-level mtime). The error was in the safe direction — apparent age ≤ job age — so the 24 h floor is unchanged; only the comment is.

Each of these carries a **mutation control**: the fix is re-run against a copy of the library with the old body restored, and asserted to go red (pre-fix `rc=0` with the directory still present vs `rc=1` now; unclamped `=0` destroys a live concurrent run's scratch while the clamped version spares it).

## Verification

- **78 tests** in `tests/integration/test_ci_tmpdir_lifecycle.py`; **138 passing** with the neighbouring workflow-invariant suites (`test_auto_merge_dispatch`, `test__hosted_runner_guard`, `test_spartan_sif_bake_scratch_filesystem`). Two of them are **mutation controls** that strip a prune guard from a *copy* of the library and assert the sibling is then destroyed — a guard that cannot be shown to fail proves nothing about the green.
- The wiring is **mechanically enforced**: a new `*-in-sif.sh` that exports a per-run `TMPDIR` without an entry in the prefix table fails CI, and a scratch-creating job step without a matching `always()` cleanup step fails CI. Both were verified by mutation (delete the step → red; drop `always()` → red).
- **Hosted-runner no-regression**: `exec-in-sif.sh` was run end-to-end on both `develop` and this branch with a stubbed apptainer — output **identical**. The prune against a real `/tmp` with **92,213** top-level entries takes **0.226 s** (`-maxdepth 1`, it walks into nothing) and is completely silent with no `SAC_*` or `GITHUB_*` env set. The scratch path is byte-identical to `develop`'s across `{run id set, run id only, neither} x {3.11, 3.12, 3.13} x {ci, build, publish}` — 12/12 same. The new `always()` step exits 0 under every degradation constructible, including the library being absent entirely.
- `ruff check` (as `lint.yml` runs it) passes on this branch **and** on `develop`, with a positive control confirming the invocation can go red; `bash -n` clean on all six shell files; the no-hosted-runners guard passes on both sides.

## Known limits, stated plainly

- **No real CI run yet.** The first run on `scitex-04-cpu-01` is the real proof. What to look for: `clean-tmpdir: removing … (2.0G)` — and, now that a failed removal is honest, the **absence** of a following `::warning::could not remove`.
- Apptainer could not be executed in the verification environment (`squashfuse_ll … fuse: device not found`), so it was not *directly* proven that `GITHUB_RUN_ID` crosses into the SIF. Statically it does (no `--cleanenv`; `publish-in-sif.sh` documents relying on the same passthrough), and the incident data settles it: 116 *distinct* directory names are only possible if the run id varies inside the container. A divergence here would be a leak, not a deletion.
- `pypi-publish-and-github-release-on-tag.yml` still sets **no `timeout-minutes`**, which is exactly why the prune floor is 24 h rather than tighter. Adding an explicit cap would let the floor shrink and make the invariant enforced rather than inherited — but it changes CI failure behaviour, so it belongs in its own change.
- Unrelated pre-existing problem found while verifying, reproduced on untouched `develop`: `tests/integration/hpc_login_hooks/` wedges at ~54% and never finishes, even with `--timeout 30`. Nothing in this branch goes near it; it deserves its own card.
