### PR TITLE
fix(binds): a credential bind that mounts nothing must fail loudly, not silently

### DIFF
--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -20,13 +20,14 @@ from typing import Callable
 
 import click
 
-from ..._lifecycle._start_decline import DECLINE_SENTINEL
 from ..._creds import NoHealthyAccountError
+from ..._lifecycle._start_decline import DECLINE_SENTINEL
 from ..._lifecycle._start_outcome import KIND_ALREADY_RUNNING, outcome_kind
 from ..._lifecycle.lifecycle import agent_start
 from ...config import load_config
 from ...config._host import resolve_hostname
 from ...config._resolve import resolve_with_prefix
+from ...runtimes._apptainer_bind_guard import BindCapabilityError
 from .._helpers import console, system_msg
 from ._common import _multiplex_foreground_tails, _resolve_singleton_skip
 from ._dispatch import try_dispatch
@@ -406,6 +407,24 @@ def run_single_targets(
                 else:
                     system_msg(f"{raw_target}: {exc.brief}", style="red")
                     system_msg(str(exc), style="dim")
+            except BindCapabilityError as exc:
+                # A declared credential bind that cannot deliver (2026-08-09
+                # gh hosts.yml incident). Deliberately raised, not a crash —
+                # and the message body already names the agent, the spec file,
+                # the host path, the lost capability and the fix. A traceback
+                # would bury exactly the words the operator needs to read.
+                any_error = True
+                if as_json:
+                    _emit_json(
+                        {
+                            "name": raw_target,
+                            "status": "bind-cannot-deliver",
+                            "error": str(exc),
+                            "dry_run": dry_run,
+                        }
+                    )
+                else:
+                    system_msg(str(exc), style="red")
             except Exception as exc:
                 any_error = True
                 if as_json:

--- a/src/scitex_agent_container/runtimes/_apptainer_bind_guard.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_bind_guard.py
@@ -65,6 +65,25 @@ verdict. The split follows the precedent already in this package
   a fleet over an optional mount would be worse than the bug this module
   exists to fix. Degraded is not the same as falsified.
 
+* A bind — credential or not — whose source cannot be STATTED at all
+  gets a ``logging.error`` and the start CONTINUES, including for a
+  destination in :data:`CAPABILITY_BINDS`. This third case is not a
+  nicety: ``Path.exists()`` swallows only ENOENT/ENOTDIR/EBADF/ELOOP
+  (``pathlib._IGNORED_ERRNOS``) and RE-RAISES everything else, so an
+  EACCES from another user's ``0700`` parent, or an ESTALE/ETIMEDOUT
+  from an autofs/NFS/GPFS hiccup, escapes as a bare ``OSError``. Left
+  unhandled it aborts ``build_run_argv`` for a bind two paragraphs above
+  promise is non-fatal, and surfaces through ``_start_single``'s generic
+  handler as ``[Errno 13]`` plus a traceback — no agent, no spec file,
+  no remedy: precisely what the operator ruled against. And it must not
+  REFUSE either, even for a credential bind: refusal here is earned by
+  PROOF that the mount is empty, and an unanswerable stat proves
+  nothing. Refusing on an unproven premise would ground agents on a
+  transient I/O error, which is the fleet outage this module is
+  explicitly not willing to trade for. So the verdict is: say so, name
+  the errno, and point at this line as the first thing to check if the
+  capability later reports "not configured".
+
 * Fleet-default binds are untouched. They are filtered by existence in
   ``_p3a_default_binds.default_binds_for_host`` and their silent skip is
   documented there as deliberate — they are sac's suggestion, not the
@@ -89,6 +108,7 @@ the one command that makes both work again.
 from __future__ import annotations
 
 import logging
+import socket
 from pathlib import Path
 from typing import Iterable, NamedTuple
 
@@ -177,6 +197,28 @@ def _split_bind(bind_str: str) -> tuple[str, str] | None:
     return src, dst
 
 
+def _probe(path: Path) -> tuple[bool, OSError | None]:
+    """Answer "does this exist" WITHOUT letting the answer kill the start.
+
+    ``Path.exists()`` is not total. It swallows exactly four errnos —
+    ``pathlib._IGNORED_ERRNOS`` is ``ENOENT, ENOTDIR, EBADF, ELOOP`` —
+    and re-raises the rest, so EACCES (a parent directory owned by
+    another user, mode ``0700``), ESTALE (a stale NFS handle), EIO and
+    ETIMEDOUT (autofs / GPFS not answering) all come back as a thrown
+    ``OSError`` rather than as ``False``.
+
+    That distinction is the whole point: "the path is not there" is a
+    FACT this module is entitled to act on, while "I could not find out"
+    is not. Returning the two separately — ``(exists, None)`` when the
+    question was answerable and ``(False, err)`` when it was not — is
+    what lets the callers below refuse only on proof.
+    """
+    try:
+        return path.exists(), None
+    except OSError as exc:  # EACCES / ESTALE / EIO / ETIMEDOUT / ...
+        return False, exc
+
+
 def _rule_for(dst: str) -> CapabilityBind | None:
     """Return the capability rule matching this destination, if any.
 
@@ -198,10 +240,15 @@ def _render_capability_failure(
     spec_path: str,
     bind_str: str,
     source: Path,
+    source_exists: bool,
     required: Path,
     rule: CapabilityBind,
 ) -> str:
-    if not source.exists():
+    # `source_exists` is PASSED IN, never re-statted here: the caller has
+    # already probed it once through _probe, and a second stat could both
+    # disagree with the first and raise the very OSError _probe exists to
+    # contain — from inside the error formatter, of all places.
+    if not source_exists:
         state = (
             f"the host path {source} DOES NOT EXIST, so the bind cannot "
             "deliver anything"
@@ -214,6 +261,7 @@ def _render_capability_failure(
     return (
         f"bind {bind_str!r} declared for agent {agent!r} cannot deliver "
         f"{rule.capability}: {state}.\n"
+        f"  host:       {socket.gethostname()}\n"
         f"  spec file:  {spec_path}\n"
         f"  host path:  {required}\n"
         "  WHY THIS IS FATAL AND NOT A WARNING: the mount would SUCCEED — "
@@ -227,6 +275,45 @@ def _render_capability_failure(
     )
 
 
+def _render_unverifiable(
+    *,
+    agent: str,
+    spec_path: str,
+    bind_str: str,
+    path: Path,
+    error: OSError,
+    rule: CapabilityBind | None,
+) -> str:
+    """The message for a bind source this process could not stat at all."""
+    if rule is None:
+        return (
+            f"bind source UNVERIFIABLE for agent {agent!r}: the spec "
+            f"{spec_path} declares {bind_str!r} but the host path {path} "
+            f"could not be checked ({error.__class__.__name__}: {error}). "
+            f"host: {socket.gethostname()}. NOT fatal — this bind carries no "
+            "credential and the start continues; apptainer will report its "
+            "own error if the mount is genuinely unusable. If the agent "
+            "needs it: fix the permissions or the mount on this host, or "
+            f"fix/remove the bind line in {spec_path}."
+        )
+    return (
+        f"bind {bind_str!r} declared for agent {agent!r} MAY NOT deliver "
+        f"{rule.capability}: the host path {path} could not be checked "
+        f"({error.__class__.__name__}: {error}), so this process can prove "
+        "neither that the credential is there nor that it is missing.\n"
+        f"  host:       {socket.gethostname()}\n"
+        f"  spec file:  {spec_path}\n"
+        f"  host path:  {path}\n"
+        "  NOT REFUSING: a refusal here is earned by PROOF that the "
+        "credential mount is empty, and an unanswerable stat proves "
+        "nothing. Grounding an agent on a permission or transient-I/O error "
+        "would be the fleet outage this guard is explicitly unwilling to "
+        "trade for. The start continues.\n"
+        "  IF the capability later reports 'not configured' inside the "
+        f"container, START HERE — then: {rule.remedy}."
+    )
+
+
 def validate_capability_binds(config: object, spec_binds: Iterable[str]) -> None:
     """Refuse (or loudly report) spec binds that cannot deliver.
 
@@ -235,10 +322,17 @@ def validate_capability_binds(config: object, spec_binds: Iterable[str]) -> None
     docstring for the refuse-vs-log split and why each half is what it
     is.
 
-    Raises :class:`BindCapabilityError` for a credential bind that
-    cannot deliver. Returns ``None`` otherwise, having emitted one
-    ``logging.error`` per non-credential bind whose host source is
-    absent.
+    Three verdicts, and only the first one stops anything:
+
+    * credential bind PROVEN unable to deliver → ``logging.error`` and
+      :class:`BindCapabilityError`;
+    * non-credential bind whose source is PROVEN absent → one
+      ``logging.error``, start continues;
+    * any bind whose source could not be statted at all (EACCES, ESTALE,
+      …) → one ``logging.error`` naming the errno, start continues,
+      credential destinations included. Never refuse on a non-answer.
+
+    Returns ``None`` in the last two cases.
     """
     agent = str(getattr(config, "name", "") or "<unnamed agent>")
     spec_path = str(getattr(config, "config_path", "") or "<spec path unknown>")
@@ -249,8 +343,23 @@ def validate_capability_binds(config: object, spec_binds: Iterable[str]) -> None
         src_raw, dst = parts
         source = Path(src_raw).expanduser()
         rule = _rule_for(dst)
+        src_ok, src_err = _probe(source)
+        if src_err is not None:
+            # Could not find out. Say so; never refuse on a non-answer.
+            logger.error(
+                "%s",
+                _render_unverifiable(
+                    agent=agent,
+                    spec_path=spec_path,
+                    bind_str=str(bind_str),
+                    path=source,
+                    error=src_err,
+                    rule=rule,
+                ),
+            )
+            continue
         if rule is None:
-            if not source.exists():
+            if not src_ok:
                 # Loud, not fatal — a host-specific data/scratch mount.
                 logger.error(
                     "bind source MISSING for agent %r: the spec %s declares "
@@ -270,13 +379,31 @@ def validate_capability_binds(config: object, spec_binds: Iterable[str]) -> None
                 )
             continue
         required = source / rule.proof if rule.proof else source
-        if required.exists():
+        req_ok, req_err = _probe(required)
+        if req_err is not None:
+            # The directory answered but the proof file did not (an
+            # unreadable credential dir, mode 0700 owned by someone else).
+            # Same rule as above: no proof, no refusal.
+            logger.error(
+                "%s",
+                _render_unverifiable(
+                    agent=agent,
+                    spec_path=spec_path,
+                    bind_str=str(bind_str),
+                    path=required,
+                    error=req_err,
+                    rule=rule,
+                ),
+            )
+            continue
+        if req_ok:
             continue
         message = _render_capability_failure(
             agent=agent,
             spec_path=spec_path,
             bind_str=str(bind_str),
             source=source,
+            source_exists=src_ok,
             required=required,
             rule=rule,
         )

--- a/src/scitex_agent_container/runtimes/_apptainer_bind_guard.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_bind_guard.py
@@ -1,0 +1,310 @@
+"""Fail-loud guard for spec-declared binds that carry a CAPABILITY.
+
+The bug (measured 2026-08-09 on scitex-compute-04)
+--------------------------------------------------
+Every agent spec on that host carries, verbatim::
+
+    - /home/ywatanabe/.config/gh:/home/agent/.config/gh:ro
+
+The host directory EXISTED — and held only ``config.yml``. ``hosts.yml``,
+the file that actually carries ``oauth_token``, was absent. So the bind
+SUCCEEDED: apptainer mounted a real directory containing no credential.
+Inside the container ``gh`` answers "not logged in", which is
+indistinguishable from "this agent was never given a token", and neither
+``GH_TOKEN`` nor ``GITHUB_TOKEN`` was set as a fallback (verified via
+``/proc/<pid>/environ``). All 12 agents on the host concluded no GitHub
+token existed; one told the operator it could not merge its own PR and
+asked a peer to do it for it. The mount was wrong for hours and said
+nothing at any point.
+
+Why every existing check missed it
+----------------------------------
+Because they all ask the wrong question. ``_p3a_default_binds`` filters
+fleet defaults on ``expanded.is_dir()``; ``_inline_spec_preflight`` and
+``_relocate_preflight`` stat the source with ``Path(...).exists()``.
+Every one of those passes here — the directory *was* there. **Source
+exists is not the same question as capability delivered.** Nothing in
+the tree had ever looked INSIDE a bind source, so a credential mount
+could be empty and still read as green.
+
+Operator ruling (2026-08-09, stated twice)
+------------------------------------------
+    "when binding fails, it must fail loudly"
+    "bind 失敗 -> うるさく失敗です; spec.yaml を直すかディスクを確認して
+     ください … logging.error で言葉出すだけでは?"
+
+So a message here must name, in one breath: WHICH agent, WHICH spec
+file, WHICH host path is empty or missing, WHICH capability is therefore
+unavailable, and the CONCRETE remedy. An operator reading it should know
+what to fix without asking anyone.
+
+Refuse the start, or only log loudly? — both, split deliberately
+----------------------------------------------------------------
+The two cases are not equally dangerous, so they do not get the same
+verdict. The split follows the precedent already in this package
+(``_apptainer_listen_env`` refuses when the spec explicitly requested
+``server:sac`` and warns when it did not):
+
+* A bind whose destination is in :data:`CAPABILITY_BINDS` — a
+  deliberately TINY, named set of credential destinations — **REFUSES
+  the start** when its source is missing, or present but lacking the one
+  file that proves the credential is there. Justification: the spec
+  named a credential destination, so the capability was explicitly
+  requested; and this is the single case that CANNOT be diagnosed from
+  inside the container, because an empty credential mount and an
+  ungranted credential look identical to ``gh`` / ``claude``. A loud log
+  would still leave a running agent asserting, wrongly and for hours,
+  that it has no token. The escape hatch needs no new config: delete the
+  bind line from the spec if this agent genuinely does not need the
+  capability (same escape ``_sdk_channels`` offers for channels).
+
+* EVERY OTHER spec-declared bind whose source is absent gets a
+  ``logging.error`` and the start CONTINUES. Justification: data /
+  scratch / host-specific mounts (``/mnt/c``, ``/data/gpfs/...``) go
+  missing legitimately when a spec travels between hosts, and grounding
+  a fleet over an optional mount would be worse than the bug this module
+  exists to fix. Degraded is not the same as falsified.
+
+* Fleet-default binds are untouched. They are filtered by existence in
+  ``_p3a_default_binds.default_binds_for_host`` and their silent skip is
+  documented there as deliberate — they are sac's suggestion, not the
+  operator's declaration.
+
+The named set is kept small on purpose: a general "this bind must
+contain X" spec schema is a field nobody would fill in, and an unfilled
+field would have prevented exactly zero of this incident. The two
+entries below are the two credentials sac actually hands an agent, and
+they are the same two ``cli_pkg/_explain._annotate`` already names.
+
+Consequence for ``sac agents explain`` — accepted, not overlooked
+----------------------------------------------------------------
+The gate lives in ``build_run_argv``, which ``sac agents explain`` also
+calls, so ``explain`` on an agent with a broken credential bind prints
+this refusal instead of a mount table. That is the intended answer:
+``explain``'s contract is "what will ``start`` do", and what ``start``
+will do is refuse. The message it prints IS the diagnosis, and it names
+the one command that makes both work again.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable, NamedTuple
+
+logger = logging.getLogger(__name__)
+
+
+class BindCapabilityError(RuntimeError):
+    """A spec-declared credential bind cannot deliver its capability.
+
+    Raised BEFORE any container is launched, so nothing has to be
+    unwound: ``build_run_argv`` is a pure function.
+    """
+
+
+class CapabilityBind(NamedTuple):
+    """One named credential destination and the file that proves it.
+
+    ``dst_suffix``  matched against the CONTAINER-side path of the bind
+                    (suffix match, so ``/home/agent/.config/gh`` and any
+                    other home root both hit).
+    ``proof``       path RELATIVE to the bind source that must exist for
+                    the capability to actually work. Empty string means
+                    the bind source ITSELF is the proof (a file bind).
+    ``capability``  what the agent loses, in the operator's terms.
+    ``remedy``      the concrete fix, runnable or editable.
+    """
+
+    dst_suffix: str
+    proof: str
+    capability: str
+    remedy: str
+
+
+CAPABILITY_BINDS: tuple[CapabilityBind, ...] = (
+    CapabilityBind(
+        dst_suffix="/.config/gh",
+        proof="hosts.yml",
+        capability=(
+            "GitHub CLI authentication — `gh auth`, `gh pr`, `gh api`, and "
+            "therefore this agent's ability to open/review/merge its own PRs"
+        ),
+        remedy=(
+            "run `gh auth login` on THIS host so ~/.config/gh/hosts.yml is "
+            "written — config.yml alone carries NO oauth_token and is what "
+            "made this look configured. Or declare the token explicitly as "
+            "`spec.env.GH_TOKEN` (a bare host export does NOT reach a "
+            "--containall container, so that is not a workaround). Or delete "
+            "this bind line if the agent genuinely does not need gh"
+        ),
+    ),
+    CapabilityBind(
+        dst_suffix="/.credentials.json",
+        proof="",
+        capability="the Claude account credential this agent runs on",
+        remedy=(
+            "run `claude /login` for that account on this host, then "
+            "`sac accounts save <account>`, or re-point this bind line at an "
+            "account file that exists"
+        ),
+    ),
+)
+
+
+def _split_bind(bind_str: str) -> tuple[str, str] | None:
+    """Return ``(host_source, container_destination)`` for a bind string.
+
+    Covers all THREE shapes apptainer's ``--bind`` consumes, because the
+    spec parser accepts all three (``config/_parsers/_apptainer.py`` —
+    ``_validate_dst`` returns early on a colonless entry rather than
+    rejecting it): ``host``, ``host:container`` and
+    ``host:container:mode``. The bare form means src == dst, and it must
+    be checked like any other — a spec line reading simply
+    ``- /home/ywatanabe/.config/gh`` is the SAME credential bind as the
+    two-sided form, so skipping it would reopen this module's own bug.
+    ``None`` only for an entry with no usable source or destination.
+    """
+    bind_str = bind_str.strip()
+    if not bind_str:
+        return None
+    if ":" not in bind_str:
+        return bind_str, bind_str
+    src, _, rest = bind_str.partition(":")
+    dst = rest.split(":", 1)[0]
+    if not src or not dst:
+        return None
+    return src, dst
+
+
+def _rule_for(dst: str) -> CapabilityBind | None:
+    """Return the capability rule matching this destination, if any.
+
+    A trailing slash is stripped first: ``/home/agent/.config/gh/`` and
+    ``/home/agent/.config/gh`` are the same mount, and a rule that missed
+    on the cosmetic difference would fail silently — the exact failure
+    mode this module exists to remove.
+    """
+    dst = dst.rstrip("/") or "/"
+    for rule in CAPABILITY_BINDS:
+        if dst == rule.dst_suffix or dst.endswith(rule.dst_suffix):
+            return rule
+    return None
+
+
+def _render_capability_failure(
+    *,
+    agent: str,
+    spec_path: str,
+    bind_str: str,
+    source: Path,
+    required: Path,
+    rule: CapabilityBind,
+) -> str:
+    if not source.exists():
+        state = (
+            f"the host path {source} DOES NOT EXIST, so the bind cannot "
+            "deliver anything"
+        )
+    else:
+        state = (
+            f"the host path {source} exists but does NOT contain "
+            f"{rule.proof!r} — the one file that carries the credential"
+        )
+    return (
+        f"bind {bind_str!r} declared for agent {agent!r} cannot deliver "
+        f"{rule.capability}: {state}.\n"
+        f"  spec file:  {spec_path}\n"
+        f"  host path:  {required}\n"
+        "  WHY THIS IS FATAL AND NOT A WARNING: the mount would SUCCEED — "
+        "apptainer binds the source whatever is in it — so inside the "
+        "container the capability reports 'not configured', which is "
+        "indistinguishable from 'this agent was never granted it'. That is "
+        "exactly the 2026-08-09 incident: 12 agents spent hours believing no "
+        "GitHub token existed. Refusing to launch an agent whose declared "
+        "credential bind carries no credential.\n"
+        f"  FIX: {rule.remedy}."
+    )
+
+
+def validate_capability_binds(config: object, spec_binds: Iterable[str]) -> None:
+    """Refuse (or loudly report) spec binds that cannot deliver.
+
+    ``spec_binds`` is ``spec.apptainer.binds`` — the OPERATOR-declared
+    entries only. Fleet defaults are excluded by design; see the module
+    docstring for the refuse-vs-log split and why each half is what it
+    is.
+
+    Raises :class:`BindCapabilityError` for a credential bind that
+    cannot deliver. Returns ``None`` otherwise, having emitted one
+    ``logging.error`` per non-credential bind whose host source is
+    absent.
+    """
+    agent = str(getattr(config, "name", "") or "<unnamed agent>")
+    spec_path = str(getattr(config, "config_path", "") or "<spec path unknown>")
+    for bind_str in spec_binds:
+        parts = _split_bind(str(bind_str))
+        if parts is None:
+            continue
+        src_raw, dst = parts
+        source = Path(src_raw).expanduser()
+        rule = _rule_for(dst)
+        if rule is None:
+            if not source.exists():
+                # Loud, not fatal — a host-specific data/scratch mount.
+                logger.error(
+                    "bind source MISSING for agent %r: the spec %s declares "
+                    "'%s' but the host path %s does not exist. The container "
+                    "will see an empty %s, so anything the agent expects "
+                    "there is silently absent. NOT fatal (this bind carries "
+                    "no credential, and host-specific mounts legitimately "
+                    "differ per host) — the start continues. If the agent "
+                    "needs it: create the path on this host, or fix/remove "
+                    "the bind line in %s.",
+                    agent,
+                    spec_path,
+                    bind_str,
+                    source,
+                    dst,
+                    spec_path,
+                )
+            continue
+        required = source / rule.proof if rule.proof else source
+        if required.exists():
+            continue
+        message = _render_capability_failure(
+            agent=agent,
+            spec_path=spec_path,
+            bind_str=str(bind_str),
+            source=source,
+            required=required,
+            rule=rule,
+        )
+        # Log AND raise: the raise reaches whoever called `sac agents
+        # start`, the log reaches the agent's start log for whoever reads
+        # it later. The operator asked for words, not a bare traceback.
+        logger.error("%s", message)
+        raise BindCapabilityError(message)
+
+
+def spec_binds_checked(config: object) -> list[str]:
+    """Read ``spec.apptainer.binds`` and gate them in one call.
+
+    ``build_run_argv`` calls THIS rather than reading the field and
+    validating separately, so the gate cannot be skipped by a future
+    caller that assembles the list itself — the only way to obtain the
+    spec binds is to obtain them checked.
+    """
+    ap = getattr(config, "apptainer", None)
+    binds = [str(b) for b in getattr(ap, "binds", None) or []]
+    validate_capability_binds(config, binds)
+    return binds
+
+
+__all__ = [
+    "CAPABILITY_BINDS",
+    "BindCapabilityError",
+    "CapabilityBind",
+    "spec_binds_checked",
+    "validate_capability_binds",
+]

--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -218,15 +218,15 @@ def build_run_argv(
     # agent inherits the store mount even when its spec doesn't carry
     # the explicit line. Explicit spec entries to the same destination
     # override the default — see ``_p3a_default_binds``.
+    # 2026-08-09 gh-hosts.yml incident: a spec bind reached the argv with NO
+    # check, so a credential dir that EXISTED but was EMPTY mounted fine and
+    # delivered nothing — 12 agents spent hours believing they had no GitHub
+    # token. spec_binds_checked is the gate: a credential bind that cannot
+    # deliver REFUSES the start, any other absent source logs ERROR.
+    from ._apptainer_bind_guard import spec_binds_checked
     from ._p3a_default_binds import apply_default_binds
 
-    ap_for_binds = getattr(config, "apptainer", None)
-    spec_binds = (
-        [str(b) for b in getattr(ap_for_binds, "binds", None) or []]
-        if ap_for_binds is not None
-        else []
-    )
-    for bs in apply_default_binds(spec_binds):
+    for bs in apply_default_binds(spec_binds_checked(config)):
         if ":" in bs:
             _, _, rest = bs.partition(":")
             dst = rest.split(":", 1)[0]

--- a/tests/scitex_agent_container/runtimes/test__apptainer_bind_guard.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_bind_guard.py
@@ -1,0 +1,339 @@
+"""Regression tests — a credential bind that mounts nothing, silently.
+
+Operator incident (2026-08-09, scitex-compute-04): every agent spec bound
+``/home/ywatanabe/.config/gh`` into the container read-only. The directory
+existed but held ONLY ``config.yml`` — ``hosts.yml``, which carries the
+``oauth_token``, was absent. The bind SUCCEEDED, so inside the container
+``gh`` reported "not logged in", indistinguishable from "never granted a
+token". All 12 agents on the host believed no GitHub token existed; one
+told the operator it could not merge its own PR. Every pre-existing check
+passed, because they all ask ``Path(src).exists()`` — and the source DID
+exist. Source-exists is not capability-delivered.
+
+Fix: ``_apptainer_bind_guard.validate_capability_binds``, wired into
+``build_run_argv`` where the spec binds are known. A bind whose
+destination is in the named ``CAPABILITY_BINDS`` set REFUSES the start
+when its proof file is missing; every other absent bind source gets a
+``logging.error`` and the start continues (a host-specific data mount
+must not ground the fleet).
+
+No mocks / no monkeypatch (PA-306/307). Real ``load_config`` on a tmp
+spec; real directories under ``tmp_path``. AAA blocks, markers on their
+own line, one assert per test.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container.config import load_config
+from scitex_agent_container.runtimes._apptainer_bind_guard import (
+    BindCapabilityError,
+    spec_binds_checked,
+    validate_capability_binds,
+)
+from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror test__apptainer_argv_guard.py — real HOME + bearer token)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path) -> Iterator[Path]:
+    # Arrange-side fixture: keep the bearer-token resolver off the real ~.
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+@pytest.fixture
+def listen_bearer_token(_isolate_home: Path) -> Path:
+    # Materialise a real listen bearer so build_run_argv's listen-env
+    # guard doesn't turn a bind test into a RuntimeError.
+    token_dir = _isolate_home / ".scitex" / "agent-container" / "tokens"
+    token_dir.mkdir(parents=True, exist_ok=True)
+    token_path = token_dir / f"listen-{socket.gethostname()}.token"
+    token_path.write_text("test-bearer-token-not-a-secret\n", encoding="utf-8")
+    return token_path
+
+
+def _write_spec(tmp_path: Path, binds_yaml: str) -> Path:
+    spec_dir = tmp_path / "agents" / "agt"
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    spec = spec_dir / "spec.yaml"
+    spec.write_text(
+        explicitize_yaml(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            "metadata:\n"
+            "  labels:\n"
+            "    project: t\n"
+            '    sac-builtin: "off"\n'
+            "spec:\n"
+            "  runtime: tui\n"
+            "  host: ${HOSTNAME}\n"
+            "  workdir: /tmp/agt-work\n"
+            "  apptainer:\n"
+            "    image: /x.sif\n"
+            "    fakeroot: true\n"
+            f"{binds_yaml}"
+            "  health:\n"
+            "    enabled: true\n"
+            "    interval: 60\n"
+            "  restart:\n"
+            "    policy: on-failure\n"
+            "    max_retries: 3\n"
+            "  claude:\n"
+            "    model: claude-opus-4-8[1m]\n"
+        ),
+        encoding="utf-8",
+    )
+    return spec
+
+
+def _gh_bind_yaml(source: Path) -> str:
+    return f"    binds:\n      - {source}:/home/agent/.config/gh:ro\n"
+
+
+def _gh_dir_without_hosts_yml(tmp_path: Path) -> Path:
+    """Reproduce the incident on disk: config.yml present, hosts.yml absent."""
+    gh_dir = tmp_path / "ghconf"
+    gh_dir.mkdir()
+    (gh_dir / "config.yml").write_text("version: 1\n", encoding="utf-8")
+    return gh_dir
+
+
+def _gh_dir_with_hosts_yml(tmp_path: Path) -> Path:
+    gh_dir = _gh_dir_without_hosts_yml(tmp_path)
+    (gh_dir / "hosts.yml").write_text(
+        "github.com:\n    oauth_token: not-a-real-token\n", encoding="utf-8"
+    )
+    return gh_dir
+
+
+# ---------------------------------------------------------------------------
+# build_run_argv — end-to-end (real spec → guard runs before any launch)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_gh_source_refuses_the_start(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — the spec declares a gh bind whose host source does not exist.
+    absent = tmp_path / "no-such-gh-dir"
+    cfg = load_config(str(_write_spec(tmp_path, _gh_bind_yaml(absent))))
+    # Act
+    build = lambda: build_run_argv(
+        cfg, state_dir=tmp_path / "st", sif_path=tmp_path / "x.sif", tui=True
+    )
+    # Assert — refused loudly BEFORE any container is launched.
+    with pytest.raises(BindCapabilityError):
+        build()
+
+
+def test_gh_source_without_hosts_yml_refuses_the_start(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — the exact incident: the directory exists, holds config.yml,
+    # and carries no hosts.yml (so no oauth_token).
+    gh_dir = _gh_dir_without_hosts_yml(tmp_path)
+    cfg = load_config(str(_write_spec(tmp_path, _gh_bind_yaml(gh_dir))))
+    # Act
+    build = lambda: build_run_argv(
+        cfg, state_dir=tmp_path / "st", sif_path=tmp_path / "x.sif", tui=True
+    )
+    # Assert
+    with pytest.raises(BindCapabilityError):
+        build()
+
+
+def test_correct_gh_source_reaches_the_argv(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — hosts.yml present: the capability really is delivered.
+    gh_dir = _gh_dir_with_hosts_yml(tmp_path)
+    cfg = load_config(str(_write_spec(tmp_path, _gh_bind_yaml(gh_dir))))
+    # Act
+    argv = build_run_argv(
+        cfg, state_dir=tmp_path / "st", sif_path=tmp_path / "x.sif", tui=True
+    )
+    # Assert — the guard passed and the bind was emitted verbatim.
+    assert f"{gh_dir}:/home/agent/.config/gh:ro" in argv
+
+
+def test_optional_bind_missing_source_still_builds(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — a host-specific data mount that is absent on this host.
+    absent = tmp_path / "no-such-data-dir"
+    binds = f"    binds:\n      - {absent}:/data:rw\n"
+    cfg = load_config(str(_write_spec(tmp_path, binds)))
+    # Act — must NOT refuse: grounding a fleet on an optional mount would
+    # be worse than the bug this guard exists to fix.
+    argv = build_run_argv(
+        cfg, state_dir=tmp_path / "st", sif_path=tmp_path / "x.sif", tui=True
+    )
+    # Assert
+    assert f"{absent}:/data:rw" in argv
+
+
+# ---------------------------------------------------------------------------
+# validate_capability_binds — the message the operator has to read
+# ---------------------------------------------------------------------------
+
+
+def test_error_message_names_the_spec_file(tmp_path: Path) -> None:
+    # Arrange
+    gh_dir = _gh_dir_without_hosts_yml(tmp_path)
+    spec = _write_spec(tmp_path, _gh_bind_yaml(gh_dir))
+    cfg = load_config(str(spec))
+    message = ""
+    try:
+        validate_capability_binds(cfg, list(cfg.apptainer.binds))
+    except BindCapabilityError as exc:
+        message = str(exc)
+    # Act
+    names_spec = str(spec) in message
+    # Assert — the operator knows which file to open without asking.
+    assert names_spec is True
+
+
+def test_error_message_names_the_host_path(tmp_path: Path) -> None:
+    # Arrange
+    gh_dir = _gh_dir_without_hosts_yml(tmp_path)
+    cfg = load_config(str(_write_spec(tmp_path, _gh_bind_yaml(gh_dir))))
+    message = ""
+    try:
+        validate_capability_binds(cfg, list(cfg.apptainer.binds))
+    except BindCapabilityError as exc:
+        message = str(exc)
+    # Act
+    names_path = str(gh_dir / "hosts.yml") in message
+    # Assert — the operator knows which disk path to check.
+    assert names_path is True
+
+
+def test_error_message_names_the_remedy(tmp_path: Path) -> None:
+    # Arrange
+    gh_dir = _gh_dir_without_hosts_yml(tmp_path)
+    cfg = load_config(str(_write_spec(tmp_path, _gh_bind_yaml(gh_dir))))
+    message = ""
+    try:
+        validate_capability_binds(cfg, list(cfg.apptainer.binds))
+    except BindCapabilityError as exc:
+        message = str(exc)
+    # Act
+    names_remedy = "gh auth login" in message
+    # Assert
+    assert names_remedy is True
+
+
+def test_missing_optional_bind_logs_an_error(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    absent = tmp_path / "no-such-data-dir"
+    binds = f"    binds:\n      - {absent}:/data:rw\n"
+    cfg = load_config(str(_write_spec(tmp_path, binds)))
+    # Act
+    with caplog.at_level(logging.ERROR):
+        validate_capability_binds(cfg, list(cfg.apptainer.binds))
+    # Assert — loud, even though it did not refuse.
+    assert str(absent) in caplog.text
+
+
+def test_present_optional_bind_logs_nothing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    present = tmp_path / "data-dir"
+    present.mkdir()
+    binds = f"    binds:\n      - {present}:/data:rw\n"
+    cfg = load_config(str(_write_spec(tmp_path, binds)))
+    # Act
+    with caplog.at_level(logging.ERROR):
+        validate_capability_binds(cfg, list(cfg.apptainer.binds))
+    # Assert — no noise for a bind that is fine.
+    assert caplog.text == ""
+
+
+def test_missing_credentials_file_bind_refuses(tmp_path: Path) -> None:
+    # Arrange — a spec-declared account credential bind pointing nowhere.
+    absent = tmp_path / "accounts" / "someone" / ".credentials.json"
+    binds = f"    binds:\n      - {absent}:/home/agent/.claude/.credentials.json:ro\n"
+    cfg = load_config(str(_write_spec(tmp_path, binds)))
+    # Act
+    check = lambda: validate_capability_binds(cfg, list(cfg.apptainer.binds))
+    # Assert
+    with pytest.raises(BindCapabilityError):
+        check()
+
+
+def test_spec_binds_checked_returns_declared_binds(tmp_path: Path) -> None:
+    # Arrange — the entry point build_run_argv actually calls: read + gate.
+    gh_dir = _gh_dir_with_hosts_yml(tmp_path)
+    cfg = load_config(str(_write_spec(tmp_path, _gh_bind_yaml(gh_dir))))
+    # Act
+    binds = spec_binds_checked(cfg)
+    # Assert
+    assert binds == [f"{gh_dir}:/home/agent/.config/gh:ro"]
+
+
+def test_spec_binds_checked_refuses_empty_gh_dir(tmp_path: Path) -> None:
+    # Arrange — the gate must not be skippable via the read helper.
+    gh_dir = _gh_dir_without_hosts_yml(tmp_path)
+    cfg = load_config(str(_write_spec(tmp_path, _gh_bind_yaml(gh_dir))))
+    # Act
+    read = lambda: spec_binds_checked(cfg)
+    # Assert
+    with pytest.raises(BindCapabilityError):
+        read()
+
+
+def test_single_path_gh_bind_is_checked(tmp_path: Path) -> None:
+    # Arrange — the colonless spec form the parser also accepts; src == dst,
+    # so it is the SAME credential bind and must not slip past the guard.
+    gh_dir = tmp_path / ".config" / "gh"
+    gh_dir.mkdir(parents=True)
+    (gh_dir / "config.yml").write_text("version: 1\n", encoding="utf-8")
+    cfg = load_config(str(_write_spec(tmp_path, "    binds: []\n")))
+    # Act
+    check = lambda: validate_capability_binds(cfg, [str(gh_dir)])
+    # Assert
+    with pytest.raises(BindCapabilityError):
+        check()
+
+
+def test_trailing_slash_destination_is_checked(tmp_path: Path) -> None:
+    # Arrange — cosmetic trailing slash must not defeat the rule match.
+    gh_dir = _gh_dir_without_hosts_yml(tmp_path)
+    cfg = load_config(str(_write_spec(tmp_path, "    binds: []\n")))
+    bind = f"{gh_dir}:/home/agent/.config/gh/:ro"
+    # Act
+    check = lambda: validate_capability_binds(cfg, [bind])
+    # Assert
+    with pytest.raises(BindCapabilityError):
+        check()
+
+
+def test_empty_bind_entry_is_ignored(tmp_path: Path) -> None:
+    # Arrange — a blank entry carries no source and no destination.
+    cfg = load_config(str(_write_spec(tmp_path, "    binds: []\n")))
+    # Act
+    result = validate_capability_binds(cfg, ["   "])
+    # Assert — no raise, returns None.
+    assert result is None

--- a/tests/scitex_agent_container/runtimes/test__apptainer_bind_guard.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_bind_guard.py
@@ -105,6 +105,26 @@ def _write_spec(tmp_path: Path, binds_yaml: str) -> Path:
     return spec
 
 
+@pytest.fixture
+def unreadable_parent(tmp_path: Path) -> Iterator[Path]:
+    """A real directory whose parent cannot be traversed (mode 0o000).
+
+    Statting anything under it raises ``PermissionError`` — EACCES is NOT
+    in ``pathlib._IGNORED_ERRNOS``, so ``Path.exists()`` throws instead of
+    answering. This is the on-disk stand-in for every "cannot find out"
+    source: another user's 0700 home, a stale NFS handle, an autofs
+    timeout. Restored to 0o700 on teardown so tmp_path cleanup works.
+    """
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    (locked / "child").mkdir()
+    locked.chmod(0o000)
+    try:
+        yield locked / "child"
+    finally:
+        locked.chmod(0o700)
+
+
 def _gh_bind_yaml(source: Path) -> str:
     return f"    binds:\n      - {source}:/home/agent/.config/gh:ro\n"
 
@@ -336,4 +356,103 @@ def test_empty_bind_entry_is_ignored(tmp_path: Path) -> None:
     # Act
     result = validate_capability_binds(cfg, ["   "])
     # Assert — no raise, returns None.
+    assert result is None
+
+
+def test_error_message_names_the_host(tmp_path: Path) -> None:
+    # Arrange — every path in this message is byte-identical across the
+    # fleet, so a relayed log must also say WHICH machine to log in on.
+    gh_dir = _gh_dir_without_hosts_yml(tmp_path)
+    cfg = load_config(str(_write_spec(tmp_path, _gh_bind_yaml(gh_dir))))
+    message = ""
+    try:
+        validate_capability_binds(cfg, list(cfg.apptainer.binds))
+    except BindCapabilityError as exc:
+        message = str(exc)
+    # Act
+    names_host = socket.gethostname() in message
+    # Assert
+    assert names_host is True
+
+
+# ---------------------------------------------------------------------------
+# A source that cannot be STATTED — "could not find out" is not "missing"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root traverses mode-0o000 dirs")
+def test_unstattable_optional_bind_still_builds(
+    tmp_path: Path, listen_bearer_token: Path, unreadable_parent: Path
+) -> None:
+    # Arrange — an optional data mount under a parent this user cannot
+    # traverse. Path.exists() raises EACCES here rather than returning
+    # False, and an escaping OSError would abort a start develop allows.
+    binds = f"    binds:\n      - {unreadable_parent}:/data:rw\n"
+    cfg = load_config(str(_write_spec(tmp_path, binds)))
+    # Act
+    argv = build_run_argv(
+        cfg, state_dir=tmp_path / "st", sif_path=tmp_path / "x.sif", tui=True
+    )
+    # Assert — the start is NOT grounded by an unanswerable stat.
+    assert f"{unreadable_parent}:/data:rw" in argv
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root traverses mode-0o000 dirs")
+def test_unstattable_optional_bind_logs_the_errno(
+    tmp_path: Path, unreadable_parent: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    binds = f"    binds:\n      - {unreadable_parent}:/data:rw\n"
+    cfg = load_config(str(_write_spec(tmp_path, binds)))
+    # Act
+    with caplog.at_level(logging.ERROR):
+        validate_capability_binds(cfg, list(cfg.apptainer.binds))
+    # Assert — silent-continue would be the original bug in a new costume.
+    assert "PermissionError" in caplog.text
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root traverses mode-0o000 dirs")
+def test_unstattable_gh_bind_does_not_refuse(
+    tmp_path: Path, unreadable_parent: Path
+) -> None:
+    # Arrange — the same unanswerable stat on a CREDENTIAL destination.
+    bind = f"{unreadable_parent}:/home/agent/.config/gh:ro"
+    cfg = load_config(str(_write_spec(tmp_path, "    binds: []\n")))
+    # Act — refusal is earned by proof that the mount is empty; EACCES
+    # proves nothing, and grounding an agent on a transient I/O error is
+    # the outage this guard must not trade for.
+    result = validate_capability_binds(cfg, [bind])
+    # Assert
+    assert result is None
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root traverses mode-0o000 dirs")
+def test_unstattable_gh_bind_still_logs_loudly(
+    tmp_path: Path, unreadable_parent: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    bind = f"{unreadable_parent}:/home/agent/.config/gh:ro"
+    cfg = load_config(str(_write_spec(tmp_path, "    binds: []\n")))
+    # Act
+    with caplog.at_level(logging.ERROR):
+        validate_capability_binds(cfg, [bind])
+    # Assert — not refused, but named: the operator still learns of it.
+    assert str(unreadable_parent) in caplog.text
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root traverses mode-0o000 dirs")
+def test_unreadable_gh_dir_does_not_refuse(tmp_path: Path) -> None:
+    # Arrange — the directory itself answers, but hosts.yml inside it
+    # cannot be statted (mode 0o000 on the gh dir). Second probe site,
+    # same rule as the first.
+    gh_dir = _gh_dir_with_hosts_yml(tmp_path)
+    gh_dir.chmod(0o000)
+    cfg = load_config(str(_write_spec(tmp_path, "    binds: []\n")))
+    bind = f"{gh_dir}:/home/agent/.config/gh:ro"
+    try:
+        # Act
+        result = validate_capability_binds(cfg, [bind])
+    finally:
+        gh_dir.chmod(0o700)
+    # Assert
     assert result is None


### PR DESCRIPTION
## The incident this exists for

Measured 2026-08-09 on scitex-compute-04. Every agent spec binds the operator's gh config
into the container read-only:

```
--bind /home/ywatanabe/.config/gh:/home/agent/.config/gh:ro
```

On that host the directory held **only `config.yml`**. `hosts.yml` — the file that actually
carries `oauth_token` — was absent. The bind **succeeded**: apptainer mounted a real directory
containing no credential. Inside the container `gh` answers "not logged in", which is
indistinguishable from "this agent was never given a token". Neither `GH_TOKEN` nor
`GITHUB_TOKEN` was set in any of their environments (verified via `/proc/<pid>/environ`), so
the bind was the only intended path and it delivered nothing, silently, for hours.

All 12 agents on the host concluded no GitHub token existed. One told the operator it could
not merge its own PR and asked a peer to do it for it.

Every pre-existing check passed, because they all ask the wrong question. `_p3a_default_binds`
filters on `expanded.is_dir()`; `_inline_spec_preflight` and `_relocate_preflight` stat the
source with `Path(...).exists()`. The directory *was* there. **Source-exists is not
capability-delivered**, and nothing in the tree had ever looked *inside* a bind source.

Operator ruling, stated twice:

> "when binding fails, it must fail loudly"
>
> "bind 失敗 -> うるさく失敗です; spec.yaml を直すかディスクを確認してください … logging.error で言葉出すだけでは?"

Card: `sac-credential-bind-empty-source-must-fail-loudly-20260809`

## What is now validated

A new pure module, `runtimes/_apptainer_bind_guard.py`, gated into `build_run_argv` via
`spec_binds_checked(config)` — which both *reads* `spec.apptainer.binds` and *validates* them,
so a future caller cannot obtain the binds unchecked. It runs before any container is launched,
so nothing has to be unwound.

Three verdicts, and only the first stops anything:

| case | verdict |
|---|---|
| credential bind **proven** unable to deliver (source absent, or present without its proof file) | `logging.error` **+ refuse the start** |
| non-credential bind source **proven** absent | `logging.error`, **start continues** |
| any bind source that could not be statted at all (EACCES/ESTALE/EIO/…), credential included | `logging.error` naming the errno, **start continues** |

That third row is the card's own closing requirement — *"report each declared capability as
present / absent / unverifiable, **never collapsing the last two**"*.

`CAPABILITY_BINDS` is a deliberately tiny named set rather than a new config schema: a
"this bind must contain X" spec field is one nobody would fill in, and an unfilled field would
have prevented exactly zero of this incident. The two entries are the two credentials sac
actually hands an agent, the same two `cli_pkg/_explain._annotate` already names:

- `/.config/gh` → proof `hosts.yml`
- `/.credentials.json` → proof is the file itself

### Why the credential case refuses and nothing else does

Justified in the module docstring against the in-repo precedent (`_apptainer_listen_env:199`
vs `:210`). The credential case is the **only** one that cannot be diagnosed from inside the
container: an empty credential mount and an ungranted credential are identical to `gh` and to
`claude`. A loud log alone would still leave a running agent asserting, wrongly and for hours,
that it has no token. Everything else warns — `/mnt/c`, `/data/gpfs/...` and friends
legitimately differ per host, and grounding a fleet over an optional mount would be worse than
the bug this fixes. Fleet-default binds are untouched.

Escape hatch needs no new config: delete the bind line if the agent genuinely does not need gh.

## The exact error text emitted

Produced by running the guard against the incident shape rebuilt on disk — a real `spec.yaml`
at the production layout, real `load_config`, real `build_run_argv`. Not a mock:

```
bind '/home/ywatanabe/.config/gh:/home/agent/.config/gh:ro' declared for agent 'scitex-clew'
cannot deliver GitHub CLI authentication — `gh auth`, `gh pr`, `gh api`, and therefore this
agent's ability to open/review/merge its own PRs: the host path /home/ywatanabe/.config/gh
exists but does NOT contain 'hosts.yml' — the one file that carries the credential.
  host:       scitex-compute-04
  spec file:  /home/ywatanabe/.scitex/agent-container/agents/scitex-clew/spec.yaml
  host path:  /home/ywatanabe/.config/gh/hosts.yml
  WHY THIS IS FATAL AND NOT A WARNING: the mount would SUCCEED — apptainer binds the source
  whatever is in it — so inside the container the capability reports 'not configured', which is
  indistinguishable from 'this agent was never granted it'. That is exactly the 2026-08-09
  incident: 12 agents spent hours believing no GitHub token existed. Refusing to launch an agent
  whose declared credential bind carries no credential.
  FIX: run `gh auth login` on THIS host so ~/.config/gh/hosts.yml is written — config.yml alone
  carries NO oauth_token and is what made this look configured. Or declare the token explicitly
  as `spec.env.GH_TOKEN` (a bare host export does NOT reach a --containall container, so that is
  not a workaround). Or delete this bind line if the agent genuinely does not need gh.
```

The sentence about `config.yml` carrying no token *and being what made this look configured* is
the diagnosis the 12 agents never got. The `host:` line was added after review: every path in
the message is byte-identical across all fleet hosts, so a relayed log otherwise could not tell
the operator which of five machines to run `gh auth login` on — precisely the position he was
in during the incident.

The remedy text was corrected during review. The draft advised "export GH_TOKEN in the agent's
environment"; that is false — `rg 'GH_TOKEN|GITHUB_TOKEN' src/` finds no forwarding code, and a
bare host export cannot reach a `--containall` container. The real knob is `spec.env`
(forwarded at `_apptainer_build_argv.py:294`), so the message names `spec.env.GH_TOKEN` and
says outright that a host export is not a workaround.

## What the overreach check tried, and the one thing it broke

An independent adversarial pass ran the real gate over the real fleet and over 22 synthetic
shapes. **It found a genuine regression, which is fixed in the second commit here** — this PR
was held until then.

**The break:** an optional, non-credential bind whose source could not be `stat`'d for any
reason *other than* "not found" killed a start that succeeds on develop.

`Path.exists()` is not total. It swallows exactly `ENOENT/ENOTDIR/EBADF/ELOOP`
(`pathlib._IGNORED_ERRNOS`) and **re-raises everything else** — so EACCES from another user's
`0700` parent, or ESTALE/EIO/ETIMEDOUT from an autofs/NFS/GPFS hiccup, escaped as a bare
`OSError`. Measured, same spec and same disk state, branch vs develop:

```
BRANCH (before fix)   D2 ONLY a non-credential /data mount -> PermissionError: [Errno 13] ...
BASELINE (develop)    D2                                   -> BUILT ok (54 argv tokens)
```

That hit the branch the docstring *promises* is non-fatal, on a spec carrying no credential
bind at all. And because it raised `PermissionError` rather than `BindCapabilityError`, the new
arm at `_start_single.py:410` did not catch it — it fell through to the generic handler at
`:428`, which prints `[Errno 13]` plus `traceback.print_exc()`: no agent, no spec file, no
remedy. The outcome the operator ruled against, reintroduced by the fix for it.

Fixed by `_probe()`, which separates "the path is not there" (a fact the module may act on)
from "I could not find out" (which proves nothing). Re-measured after the fix:

```
BRANCH   D1 gh(valid) + data mount under untraversable parent -> BUILT ok (56 tokens) [1 ERROR log]
BRANCH   D2 ONLY the non-credential data mount                -> BUILT ok (54 tokens) [1 ERROR log]
BRANCH   D3 CREDENTIAL bind whose source is unstattable       -> BUILT ok (54 tokens) [1 ERROR log]
BRANCH   D4 CREDENTIAL dir readable, hosts.yml unstattable    -> BUILT ok (54 tokens) [1 ERROR log]
BRANCH   D5 CONTROL the incident shape (no hosts.yml)         -> BindCapabilityError  [1 ERROR log]
BRANCH   D6 CONTROL a wholly healthy gh bind                  -> BUILT ok (54 tokens) [0 ERROR logs]
BASELINE D1..D6                                               -> BUILT ok, identical token counts
```

Every non-refusing row now matches develop's argv token-for-token. D3/D4 deliberately do **not**
refuse even though the destination is a credential one: a refusal is earned by *proof* that the
mount is empty, and grounding an agent on a permission or transient-I/O error is the fleet
outage this module says outright it will not trade for.

**Everything else held.** From the adversarial pass:

- 106 of 107 live specs on this host pass the real gate, **0 refuse**. (The 1 miss is
  `scitex-todo`, which fails `load_config` on 68 missing required fields *before* the guard —
  pre-existing and unrelated.)
- Fleet bind population: 482 binds, no colonless entries in the wild; 90 specs carry the gh
  bind; **0 specs put `.credentials.json` in `apptainer.binds`**, confirming that rule is
  currently dormant (live specs use `spec.claude.credentials_files`). It is covered by unit
  test only.
- 22/22 synthetic cases correct (was 20/22 before the EACCES fix): optional mount absent, file
  source instead of directory, gh source a symlink to a good dir, `hosts.yml` a symlink to a
  real file, `hosts.yml` chmod 000, spec with no binds, `.config/ghost` lookalike destination,
  colonless bind present and missing, `ro,nosuid` multi-option mode, binding the `.config`
  parent, unexpanded `$VAR`, relative source, `hosts.yml` that is a directory, and both
  end-to-end `build_run_argv` runs.

Two silent-miss classes were closed beyond the original brief, both found by reading the
parser: a **colonless** bind (`- /home/ywatanabe/.config/gh`) is accepted by
`_parsers/_apptainer.py:61` and is the same credential bind with `src == dst`; and a
**trailing-slash** destination (`/home/agent/.config/gh/`) missed the rule match.

## Measured consequence of the refuse decision — design, not defect

Simulating the compute-04 shape across the fleet without touching `~/.config/gh` (each spec's
gh source rewritten in memory to a dir holding only `config.yml`): **90 of 90 gh-declaring
agents refuse to start.** That is the documented decision working as intended, but the number
should be stated plainly: on such a host this converts "12 agents wrongly believe they have no
token" into "every gh-declaring agent on the host is down", including agents that never call
`gh`. The remedy line names the escape (`gh auth login`, or delete the bind line), and the
alternative is agents confidently lying about their own capabilities for hours.

Separately, a full-fleet pass on this host today emits ~54 `logging.error` lines across 34
distinct missing sources (mostly Spartan `/data/gpfs/...` and `/work/...` paths in the
`clew-cohort-*` specs). Loud as intended; that is the steady-state volume.

## Known gap, deliberately not closed

`hosts.yml` present but **empty**, or present without an `oauth_token` key, still passes — the
guard tests `required.exists()` only. Both variants reproduce the incident's mechanism exactly.
Closing it wants a `proof_contains="oauth_token"` field on `CapabilityBind`, which is a small
addition but a real one, and content-sniffing a credential file deserves its own review rather
than riding along here. The module docstring claims the failure *class*; the code closes the
observed *instance*.

## Verification

- New tests: `21 passed` (`tests/.../runtimes/test__apptainer_bind_guard.py`), no mocks, no
  monkeypatch — real `load_config` on tmp specs, real directories, real `chmod 0o000` for the
  unstattable cases (skipped under euid 0, which traverses them).
- Lint exactly as CI runs it (`.github/workflows/lint.yml`):
  `ruff check --select F401,F811 --extend-per-file-ignores '**/__init__.py:F401' src/ tests/`
  → `All checks passed!`
- Line budget respected: `_apptainer_bind_guard.py` 437, its test 458, both under 512.
  `_apptainer_build_argv.py` lands at **510 — its exact develop baseline**, no budget consumed;
  the change was reshaped rather than requesting a refactor exemption when the hook blocked 513.
- Full `runtimes` + `cli_pkg` regression sweep run against the worktree source, and the same
  three failing files run on an untouched `develop` worktree as a control. The failure set is
  identical, so this branch causes none of them: 5 pre-existing failures
  (`test__sdk_common.py` ×2, `test__mcp_spec_env.py` ×1, `test__dev_jobs.py` ×2) plus 19
  pre-existing collection errors, all in `test__sdk_common.py`.

## Not verified

- Behaviour under a real `apptainer exec` — the guard is a pure function ahead of launch, so
  this is argv-time only.
- `sac agents explain` now refuses on a broken credential bind, since it shares
  `build_run_argv`. That is judged correct (explain's contract is "what will start do") and
  documented in the module docstring, but was not exercised against a live broken spec: it
  would need a host whose `hosts.yml` is missing, and this host has one.
