### PR TITLE
fix(maintenance): a sweep over a roster it never searched is not a sound plan

### DIFF
--- a/src/scitex_agent_container/_maintenance/_layers_migration_model.py
+++ b/src/scitex_agent_container/_maintenance/_layers_migration_model.py
@@ -7,7 +7,7 @@ the affected set rather than a summary you are asked to trust. This module is
 that dry-run, as a value: :func:`plan_migration` performs no I/O beyond reading,
 and the object it returns is what the applying half consumes.
 
-Two things it refuses to blur:
+Three things it refuses to blur:
 
 * A spec whose shape the editor does not recognise is REFUSED and named, not
   silently skipped. Skipping is how a sweep reports "101 done" over a fleet of
@@ -15,12 +15,20 @@ Two things it refuses to blur:
 * A planned edit that would change more than a single line is a DEFECT, not a
   bigger success. The plan carries that per spec, so the apply can refuse
   before touching a file rather than after.
+* A roster that was never SEARCHED is not a fleet with nothing to do. "0 of 0"
+  is the limit case of the first bullet — a sweep reporting completion over a
+  population it never saw — and it is the one this module shipped wrong; see
+  :mod:`._roster_state`.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ._roster_state import RosterState
 
 
 @dataclass(frozen=True)
@@ -49,6 +57,11 @@ class MigrationPlan:
     edits: "tuple[SpecEdit, ...]" = ()
     #: Specs found on disk that could not be parsed into an edit at all.
     unreadable: "tuple[str, ...]" = field(default=())
+    #: What the roster this plan was built from actually WAS — absent, empty or
+    #: populated. None when the caller did not say, which keeps a plan built
+    #: from an explicit list of edits (tests, callers holding their own paths)
+    #: judged exactly as before.
+    roster: "RosterState | None" = None
 
     @property
     def writable(self) -> "tuple[SpecEdit, ...]":
@@ -78,10 +91,23 @@ class MigrationPlan:
         legitimate outcome that a human resolves. A malformed edit or an
         unreadable spec does, because both mean the plan does not describe what
         would actually happen.
+
+        AN UNSEARCHED ROSTER DOES TOO, and it is the one this property used to
+        get wrong. With no specs discovered, ``malformed`` and ``unreadable``
+        are both trivially empty and this returned True — sound, over nothing.
+        A plan that describes no specs does not describe the sweep any more than
+        one that cannot describe a spec it found; see :mod:`._roster_state`.
         """
+        if self.roster is not None and not self.roster.is_populated:
+            return False
         return not self.malformed and not self.unreadable
 
     def summary(self) -> str:
+        # The roster line comes FIRST and alone: when the roster was not
+        # searched, "0 spec(s) would be written" is not a smaller truth to
+        # append to, it is the misreading itself.
+        if self.roster is not None and not self.roster.is_populated:
+            return self.roster.describe()
         parts = [f"{len(self.writable)} spec(s) would be written"]
         if self.refused:
             parts.append(

--- a/src/scitex_agent_container/_maintenance/_layers_migration_plan.py
+++ b/src/scitex_agent_container/_maintenance/_layers_migration_plan.py
@@ -47,6 +47,7 @@ from pathlib import Path
 from ..config import load_config
 from ..config._to_home_layers_line import insert_to_home_layers
 from ._layers_migration_model import MigrationPlan, SpecEdit, count_added_lines
+from ._roster_state import inspect_roster
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +110,18 @@ def fleet_spec_paths(specs_dir: "Path | None" = None) -> "list[Path]":
     return _paths(specs_dir)
 
 
+def fleet_agents_dir() -> Path:
+    """WHERE :func:`fleet_spec_paths` looks, from the same resolver it uses.
+
+    Re-exported for the same reason as ``fleet_spec_paths``: a report that
+    names a root it did not actually search would be a second answer about one
+    fleet, which is the class of bug this whole module now guards.
+    """
+    from .._reconcile._pass import fleet_agents_dir as _dir
+
+    return _dir()
+
+
 def resolved_layer_names(config) -> "list[str]":
     """The layer names that CONTRIBUTE to ``config`` today, in cascade order.
 
@@ -167,13 +180,28 @@ def plan_spec(path: Path) -> "SpecEdit | str":
     )
 
 
-def plan_migration(spec_paths: "list[Path] | None" = None) -> MigrationPlan:
+def plan_migration(
+    spec_paths: "list[Path] | None" = None,
+    *,
+    root: "Path | None" = None,
+) -> MigrationPlan:
     """What the sweep WOULD do, over every fleet spec. Reads only.
 
     ``spec_paths`` defaults to the fleet registry. Passing it explicitly is how
     a test points this at a corpus that is not the operator's live fleet.
+
+    ``root`` is the directory ``spec_paths`` came out of, recorded so the plan
+    can tell an UNSEARCHED roster from an empty one. It defaults to the fleet
+    registry whenever ``spec_paths`` does — the common call is
+    ``plan_migration()`` and it must not have to remember to say where it
+    looked. A caller passing paths but no root gets the old judgement: it
+    supplied its own population, so there is no directory to be wrong about.
     """
-    paths = list(spec_paths) if spec_paths is not None else fleet_spec_paths()
+    if spec_paths is None:
+        root = fleet_agents_dir() if root is None else root
+        paths = fleet_spec_paths()
+    else:
+        paths = list(spec_paths)
     edits: list[SpecEdit] = []
     unreadable: list[str] = []
     for path in paths:
@@ -182,11 +210,16 @@ def plan_migration(spec_paths: "list[Path] | None" = None) -> MigrationPlan:
             unreadable.append(outcome)
         else:
             edits.append(outcome)
-    return MigrationPlan(edits=tuple(edits), unreadable=tuple(unreadable))
+    return MigrationPlan(
+        edits=tuple(edits),
+        unreadable=tuple(unreadable),
+        roster=inspect_roster(root, paths),
+    )
 
 
 __all__ = [
     "already_declared",
+    "fleet_agents_dir",
     "fleet_spec_paths",
     "plan_migration",
     "plan_spec",

--- a/src/scitex_agent_container/_maintenance/_roster_state.py
+++ b/src/scitex_agent_container/_maintenance/_roster_state.py
@@ -1,0 +1,123 @@
+"""Is the spec roster ABSENT, EMPTY, or POPULATED? — three states, not two.
+
+WHY THIS EXISTS. :func:`fleet_spec_paths` returns ``[]`` for a root that does
+not exist and ``[]`` for a fleet with no specs in it. A sweep consuming that
+list cannot tell "I looked nowhere" from "there was nothing to do", so it
+reports the second when the first is true.
+
+Measured 2026-08-10 inside an agent container, same host, seconds apart:
+
+    sac agents migrate-layers --json
+      {"specs": 0, "writable": 0, "unreadable": [], "safe_to_apply": true,
+       "summary": "0 spec(s) would be written", "exit_code": 0}
+
+    SCITEX_AGENT_CONTAINER_AGENTS_DIR=/home/ywatanabe/.scitex/agent-container/agents \\
+    sac agents migrate-layers --json
+      {"specs": 102, "writable": 102, "safe_to_apply": true, "exit_code": 0}
+
+The fleet root is ``$HOME/.scitex/agent-container/agents``; ``$HOME`` is
+``/home/agent`` inside a container and ``/home/ywatanabe`` on the host, so the
+first run searched a directory that does not exist. It exited 0 and called the
+plan sound. Worse, ``--apply`` down that path prints "every spec already
+declares its layers ... this is what a completed one looks like" — the command
+ASSERTS the migration is finished after looking nowhere.
+
+THE THREE STATES, and they need three different responses:
+
+    absent      the root is not a directory   -> wrong root, or nothing has ever
+                                                 been registered here. No claim
+                                                 about the fleet is licensed.
+    empty       the root exists, no specs     -> a real, reportable fact: this
+                                                 registry has no agents.
+    populated   N specs found                 -> the only state in which "0 to
+                                                 write" means the sweep is done.
+
+Collapsing ``absent`` into ``empty`` is the defect. Only ``populated`` licenses
+a factual claim about what the sweep would do.
+
+Design note carried from :mod:`.._state.state_db_health` (``StoreState``): the
+distinction belongs at the REPORTING boundary, not in the enumerator.
+``fleet_spec_paths`` keeps returning a plain list — ``.._authheal._detect``
+shares it and a raising enumerator would break a caller that is not reporting
+to anyone. This is for the sweep that tells a human what it did.
+
+A ROOT THAT EXISTS IS NOT A ROOT THAT IS RIGHT: ``/home/agent/.scitex`` exists
+(it is a real directory, mode 0775) and only ``agent-container/agents`` beneath
+it is missing. Any check that stops at "is the state root there" says yes. That
+is why this inspects the SPEC DIRECTORY itself and counts what it found.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+#: The three distinguishable states of a spec roster.
+ROSTER_STATES = ("absent", "empty", "populated")
+
+
+@dataclass(frozen=True)
+class RosterState:
+    """What the roster at ``root`` actually is, and what it licenses."""
+
+    root: Path
+    state: str
+    n_specs: int = 0
+
+    def __post_init__(self) -> None:
+        if self.state not in ROSTER_STATES:
+            raise ValueError(
+                f"unknown roster state {self.state!r}; expected one of {ROSTER_STATES}"
+            )
+
+    @property
+    def is_populated(self) -> bool:
+        """True only when a count of zero may be reported as a fact."""
+        return self.state == "populated"
+
+    def describe(self) -> str:
+        """One line naming the state AND the root, because the root is the bug.
+
+        A message that says "0 specs" without saying where it looked is the
+        message that let this ship: it is equally true of a finished migration
+        and a total discovery failure.
+        """
+        if self.state == "absent":
+            return (
+                f"no spec roster at {self.root} — the directory does not exist, "
+                f"so nothing was searched. This is NOT an empty fleet. Set "
+                f"SCITEX_AGENT_CONTAINER_AGENTS_DIR to the registry you mean "
+                f"(inside a container $HOME is not the host's)."
+            )
+        if self.state == "empty":
+            return f"{self.root} exists but holds no specs — the registry is empty"
+        return f"{self.n_specs} spec(s) under {self.root}"
+
+
+def inspect_roster(root: "Path | None", spec_paths) -> RosterState:
+    """Classify the roster ``spec_paths`` was enumerated from.
+
+    ``spec_paths`` is passed in rather than re-globbed: re-enumerating could
+    disagree with the list the plan was actually built from, and two answers
+    about one fleet is the failure this module exists to prevent.
+
+    ``root`` of None means the caller supplied paths directly (a test corpus,
+    an explicit list). There is no directory to judge, so a non-empty list is
+    populated and an empty one is empty — never ``absent``, because nothing was
+    claimed to exist in the first place.
+    """
+    paths = list(spec_paths)
+    if root is None:
+        return RosterState(
+            root=Path("(explicit paths)"),
+            state="populated" if paths else "empty",
+            n_specs=len(paths),
+        )
+    if not Path(root).is_dir():
+        return RosterState(root=Path(root), state="absent", n_specs=0)
+    if not paths:
+        return RosterState(root=Path(root), state="empty", n_specs=0)
+    return RosterState(root=Path(root), state="populated", n_specs=len(paths))
+
+
+__all__ = ["ROSTER_STATES", "RosterState", "inspect_roster"]

--- a/src/scitex_agent_container/cli_pkg/_agents_migrate_layers.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_migrate_layers.py
@@ -53,7 +53,6 @@ from .._maintenance._layers_migration_apply import apply_migration
 from .._maintenance._layers_migration_gate import fleet_arming_snapshot, gate_arming
 from .._maintenance._layers_migration_plan import (
     already_declared,
-    fleet_spec_paths,
     plan_migration,
     quiet_undeclared_warning,
 )

--- a/src/scitex_agent_container/cli_pkg/_agents_migrate_layers.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_migrate_layers.py
@@ -25,8 +25,15 @@ not measure on either side blocks the sweep rather than being skipped.
 **Exit codes**, and the distinction that drives them:
 
   0  the plan is sound (refusals included), or the apply was verified
-  1  a spec is MALFORMED or UNREADABLE — the plan does not describe the sweep
+  1  a spec is MALFORMED or UNREADABLE, or NO ROSTER WAS SEARCHED — in every
+     case the plan does not describe the sweep
   2  the apply was refused or rolled back by the arming gate
+
+The third case in ``1`` was measured, not imagined: run inside an agent
+container the fleet root resolves under ``$HOME`` = ``/home/agent``, which does
+not exist there, so the sweep discovered 0 specs and called the plan sound.
+A sweep over a roster it never searched is never sound — see
+:mod:`.._maintenance._roster_state`.
 
 A REFUSAL is not a failure. "This spec has no ``to_home:`` line to anchor to"
 is an expected outcome that a human resolves; exiting non-zero on it would
@@ -93,6 +100,11 @@ def _plan_payload(plan) -> dict:
     """Everything the plan knows, with every key present on every call."""
     return {
         "specs": len(plan.edits) + len(plan.unreadable),
+        # WHERE it looked, on every call. A consumer reading `specs: 0` cannot
+        # otherwise tell a finished migration from a searched-nowhere one, and
+        # that ambiguity is what shipped.
+        "root": str(plan.roster.root) if plan.roster else None,
+        "roster": plan.roster.state if plan.roster else None,
         "writable": len(plan.writable),
         "refused": [
             {"agent": e.agent, "reason": e.refusal, "path": str(e.path)}
@@ -111,8 +123,15 @@ def _plan_payload(plan) -> dict:
 
 def _render_plan(plan, *, verbose: bool) -> None:
     payload = _plan_payload(plan)
+    if plan.roster is not None and not plan.roster.is_populated:
+        # Print the roster verdict INSTEAD of the counts, not above them. A
+        # "0 spec(s) — 0 would gain a declaration" headline over a root that
+        # does not exist is a true sentence that answers a question nobody
+        # asked, and it is the sentence that read as success.
+        console.print(f"[red]NO ROSTER SEARCHED[/red] — {_lit(plan.roster.describe())}")
+        return
     console.print(
-        f"[bold]{payload['specs']} spec(s)[/bold] — "
+        f"[bold]{payload['specs']} spec(s)[/bold] under {_lit(payload['root'])} — "
         f"{payload['writable']} would gain a to_home_layers declaration\n"
     )
     for layers, count in payload["layer_sets"].items():
@@ -282,7 +301,11 @@ def migrate_layers(
     # fires once per undeclared spec (101 on this host) and this command's whole
     # output IS that finding, aggregated. See quiet_undeclared_warning.
     with quiet_undeclared_warning():
-        plan = plan_migration(fleet_spec_paths())
+        # No arguments: plan_migration resolves the roster AND records the root
+        # it searched. Handing it fleet_spec_paths() would give it the same
+        # paths and hide where they came from, which is exactly how a run
+        # against a non-existent root reported a sound plan.
+        plan = plan_migration()
     payload = _plan_payload(plan)
     payload["mode"] = "apply" if apply else "dry-run"
 
@@ -321,10 +344,15 @@ def migrate_layers(
         if _json_flag(ctx, as_json):
             click.echo(json.dumps(payload, indent=2))
             raise SystemExit(_EXIT_OK)
+        # Names the root and the count it is making this claim about. The
+        # unqualified form of this sentence — "every spec already declares its
+        # layers ... this is what a completed one looks like" — was printed
+        # verbatim by a run that had discovered ZERO specs. An assertion that
+        # the migration is FINISHED is the last place to omit its population.
         console.print(
-            "[green]Nothing to write[/green] — every spec already declares its "
-            "layers. The sweep is idempotent; this is what a completed one "
-            "looks like."
+            f"[green]Nothing to write[/green] — all {payload['specs']} spec(s) "
+            f"under {_lit(payload['root'])} already declare their layers. The "
+            f"sweep is idempotent; this is what a completed one looks like."
         )
         raise SystemExit(_EXIT_OK)
 

--- a/tests/scitex_agent_container/_maintenance/test__roster_state.py
+++ b/tests/scitex_agent_container/_maintenance/test__roster_state.py
@@ -1,0 +1,231 @@
+"""A roster that was never searched must not read as a roster with nothing in it.
+
+The regression these guard, measured 2026-08-10 inside an agent container:
+
+    sac agents migrate-layers --json
+    {"specs": 0, "writable": 0, "safe_to_apply": true, "exit_code": 0}
+
+against a live fleet of 102 specs, because ``$HOME`` differs host-vs-container
+and the resolved root did not exist there.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._maintenance._layers_migration_model import (
+    MigrationPlan,
+    SpecEdit,
+)
+from scitex_agent_container._maintenance._roster_state import (
+    RosterState,
+    inspect_roster,
+)
+
+
+@pytest.fixture
+def root(tmp_path):
+    """An existing, empty registry directory."""
+    d = tmp_path / "agents"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def missing(tmp_path):
+    """A registry path that does not exist — the container case."""
+    return tmp_path / "nope" / "agents"
+
+
+def _spec(parent, agent: str):
+    d = parent / agent
+    d.mkdir(parents=True)
+    p = d / "spec.yaml"
+    p.write_text("to_home: {}\n")
+    return p
+
+
+@pytest.fixture
+def one_spec(root):
+    return _spec(root, "alpha")
+
+
+class TestInspectRoster:
+    def test_absent_root_is_classified_absent(self, missing):
+        # Arrange
+        paths: list = []
+        # Act
+        state = inspect_roster(missing, paths)
+        # Assert
+        assert state.state == "absent"
+
+    def test_absent_root_does_not_license_a_claim(self, missing):
+        # Arrange
+        paths: list = []
+        # Act
+        state = inspect_roster(missing, paths)
+        # Assert
+        assert state.is_populated is False
+
+    def test_existing_root_with_no_specs_is_empty(self, root):
+        # Arrange
+        paths: list = []
+        # Act
+        state = inspect_roster(root, paths)
+        # Assert
+        assert state.state == "empty"
+
+    def test_empty_root_does_not_license_a_claim(self, root):
+        # Arrange
+        paths: list = []
+        # Act
+        state = inspect_roster(root, paths)
+        # Assert
+        assert state.is_populated is False
+
+    def test_root_with_specs_is_populated(self, root, one_spec):
+        # Arrange
+        paths = [one_spec]
+        # Act
+        state = inspect_roster(root, paths)
+        # Assert
+        assert state.state == "populated"
+
+    def test_populated_roster_counts_its_specs(self, root, one_spec):
+        # Arrange
+        paths = [one_spec, _spec(root, "beta")]
+        # Act
+        state = inspect_roster(root, paths)
+        # Assert
+        assert state.n_specs == 2
+
+    def test_absent_and_empty_differ_despite_the_same_zero(self, root, missing):
+        # Arrange
+        no_paths: list = []
+        # Act
+        absent, empty = (
+            inspect_roster(missing, no_paths),
+            inspect_roster(root, no_paths),
+        )
+        # Assert
+        assert absent.state != empty.state
+
+    def test_explicit_empty_paths_are_empty_not_absent(self):
+        # Arrange
+        paths: list = []
+        # Act
+        state = inspect_roster(None, paths)
+        # Assert
+        assert state.state == "empty"
+
+    def test_explicit_paths_with_specs_are_populated(self, one_spec):
+        # Arrange
+        paths = [one_spec]
+        # Act
+        state = inspect_roster(None, paths)
+        # Assert
+        assert state.state == "populated"
+
+    def test_unknown_state_is_rejected(self, root):
+        # Arrange
+        bad = "fine"
+        # Act / Assert is a single raises block
+        # Assert
+        with pytest.raises(ValueError, match="unknown roster state"):
+            RosterState(root=root, state=bad)
+
+    def test_absent_describe_names_the_root(self, missing):
+        # Arrange
+        state = inspect_roster(missing, [])
+        # Act
+        text = state.describe()
+        # Assert
+        assert str(missing) in text
+
+    def test_empty_describe_names_the_root(self, root):
+        # Arrange
+        state = inspect_roster(root, [])
+        # Act
+        text = state.describe()
+        # Assert
+        assert str(root) in text
+
+    def test_populated_describe_names_the_root(self, root, one_spec):
+        # Arrange
+        state = inspect_roster(root, [one_spec])
+        # Act
+        text = state.describe()
+        # Assert
+        assert str(root) in text
+
+    def test_absent_describe_denies_it_is_an_empty_fleet(self, missing):
+        # Arrange
+        state = inspect_roster(missing, [])
+        # Act
+        text = state.describe()
+        # Assert
+        assert "NOT an empty fleet" in text
+
+    def test_absent_describe_names_the_lever_that_fixes_it(self, missing):
+        # Arrange
+        state = inspect_roster(missing, [])
+        # Act
+        text = state.describe()
+        # Assert
+        assert "SCITEX_AGENT_CONTAINER_AGENTS_DIR" in text
+
+
+class TestPlanSafety:
+    def test_absent_roster_makes_the_plan_unsafe(self, missing):
+        # Arrange
+        roster = inspect_roster(missing, [])
+        # Act
+        plan = MigrationPlan(roster=roster)
+        # Assert
+        assert plan.safe_to_apply is False
+
+    def test_empty_roster_makes_the_plan_unsafe(self, root):
+        # Arrange
+        roster = inspect_roster(root, [])
+        # Act
+        plan = MigrationPlan(roster=roster)
+        # Assert
+        assert plan.safe_to_apply is False
+
+    def test_populated_roster_with_clean_edits_is_safe(self, root, one_spec):
+        # Arrange
+        edit = SpecEdit(
+            agent="alpha",
+            path=one_spec,
+            layers=("project-shared",),
+            new_text="x",
+            lines_added=1,
+        )
+        # Act
+        plan = MigrationPlan(edits=(edit,), roster=inspect_roster(root, [one_spec]))
+        # Assert
+        assert plan.safe_to_apply is True
+
+    def test_plan_without_a_roster_is_judged_exactly_as_before(self):
+        # Arrange
+        # A caller that supplied its own population claimed no directory.
+        # Act
+        plan = MigrationPlan()
+        # Assert
+        assert plan.safe_to_apply is True
+
+    def test_unsearched_summary_drops_the_would_be_written_count(self, missing):
+        # Arrange
+        plan = MigrationPlan(roster=inspect_roster(missing, []))
+        # Act
+        summary = plan.summary()
+        # Assert
+        assert "would be written" not in summary
+
+    def test_unsearched_summary_names_the_root(self, missing):
+        # Arrange
+        plan = MigrationPlan(roster=inspect_roster(missing, []))
+        # Act
+        summary = plan.summary()
+        # Assert
+        assert str(missing) in summary


### PR DESCRIPTION
`sac agents migrate-layers` reported `safe_to_apply: true` and exited 0 after discovering **zero** specs, against a live fleet of 102.

## Measured

Same host, seconds apart; the only difference is which root it resolved:

| | `specs` | `safe_to_apply` | exit |
|---|---|---|---|
| default (inside a container) | **0** | **true** | **0** |
| `SCITEX_AGENT_CONTAINER_AGENTS_DIR=<real>` | 102 | true | 0 |

The fleet root is `$HOME/.scitex/agent-container/agents`. `$HOME` is `/home/agent` inside a container and `/home/ywatanabe` on the host, so the root did not exist and `fleet_spec_paths` returned `[]`. An **absent** root and a **fully-migrated** fleet produce the same empty list, and `safe_to_apply` was then computed over an empty universe — nothing was malformed or unreadable because nothing was seen.

Worse than exiting 0: `--apply` down that path printed *"every spec already declares its layers … this is what a completed one looks like"*. The command **asserted the migration was finished after looking nowhere**.

## Approach

Adds `RosterState` (`absent` / `empty` / `populated`), mirroring `StoreState` in `_state/state_db_health.py`, and puts the distinction at the **reporting boundary**. `fleet_spec_paths` still returns a plain list — `_authheal._detect` shares it, and a raising enumerator would break a caller that reports to nobody. Only `populated` licenses a claim about what the sweep would do.

- `plan_migration` resolves and records the root it searched; the verb calls it with no arguments so the paths and the root cannot disagree
- `safe_to_apply` is False unless the roster is populated
- `summary()` and the rendered output name the root, and say what to set
- the "nothing to write" success message now names the population it is making that claim about

## Verification

End-to-end, both directions:

- in-container: now exits **1**, `roster: absent`, root named, remedy stated
- pointed at the real fleet: **unchanged** — 102 specs, `populated`, exit 0

**2915 passed, 1 skipped** across `_maintenance`, `cli_pkg` and `_reconcile`; 21 new tests.

## Note

This is one of three defects found the same night sharing one premise: code written against the host's `$HOME`, executed where `$HOME` is `/home/agent`. The others are the CCT token pool (`$HOME/.bash.d/secrets` → 0 secrets → the telegrammer MCP server is silently pruned) and missing image-layer deps. Each degrades to a confident, well-formed wrong answer.