### PR TITLE
fix(cct): tell "no bot by design" apart from "asked for one and got none"

### DIFF
--- a/src/scitex_agent_container/runtimes/_cct_token_pool.py
+++ b/src/scitex_agent_container/runtimes/_cct_token_pool.py
@@ -95,6 +95,22 @@ def _upper_snake(text: str) -> str:
     return re.sub(r"[^A-Za-z0-9]+", "_", text.strip()).strip("_").upper()
 
 
+def _requested_telegrammer(config) -> bool:
+    """Did this spec ASK for the Telegram rail?
+
+    The one fact that separates "bot-less by design" from "misconfigured", and
+    the reason both :func:`ensure_cct_bot_token` and
+    :func:`prune_tokenless_telegrammer_mcp` need it rather than one of them.
+    A ``config`` of None means the caller did not say, which is not the same as
+    "no" — callers without a config get the conservative old behaviour.
+    """
+    if config is None:
+        return False
+    claude_spec = getattr(config, "claude", None)
+    channels = list(getattr(claude_spec, "channels", None) or [])
+    return any(str(c).strip() == _TELEGRAMMER_CHANNEL for c in channels)
+
+
 def _slot_candidates(name: str, workdir: str) -> list[str]:
     """Ordered, deduped mechanical slot candidates for an agent.
 
@@ -263,9 +279,7 @@ def ensure_cct_bot_token(config, dest: Path) -> None:
     does not fail a boot. The token VALUE is never logged; only slot names,
     paths, and the agent name appear.
     """
-    claude_spec = getattr(config, "claude", None)
-    channels = list(getattr(claude_spec, "channels", None) or [])
-    if not any(str(c).strip() == _TELEGRAMMER_CHANNEL for c in channels):
+    if not _requested_telegrammer(config):
         return
     agent_name = getattr(config, "name", "") or ""
     workdir = getattr(config, "workdir", "") or ""
@@ -318,9 +332,11 @@ def ensure_cct_bot_token(config, dest: Path) -> None:
     _logger().warning(
         "cct: no Telegram bot token for agent %r although spec.claude.channels "
         "requests %r. Tried pool slot(s) %s against the pool (%s). THE AGENT "
-        "STARTS NORMALLY — this is NOT a startup failure; only the Telegram "
-        "rail is down (the telegrammer MCP comes up without a token, so the "
-        "bot stays silent until a token is provided). Expected for a "
+        "STARTS NORMALLY — this is NOT a startup failure; but the Telegram rail "
+        "is GONE IN BOTH DIRECTIONS: the telegrammer MCP server is REMOVED from "
+        ".mcp.json (not merely started tokenless), so the agent can neither send "
+        "nor receive, and cannot self-detect it because the only in-agent check "
+        "is itself an MCP tool. Expected for a "
         "brand-new agent that has no bot yet. To wire one up, do ONE of: "
         "(1) add %s<SLOT>=<token> for slot %r to a secrets file listed in %s "
         "(canonical pool; restart `sac listen` afterwards if it provides the "
@@ -370,7 +386,7 @@ def _default_agent_id(agent_name: str, workdir: str) -> str:
     return agent_name
 
 
-def prune_tokenless_telegrammer_mcp(dest: Path) -> bool:
+def prune_tokenless_telegrammer_mcp(dest: Path, config=None) -> bool:
     """Drop the telegrammer MCP server from ``dest/.mcp.json`` when no token resolved.
 
     Card ``sac-omit-telegram-mcp-when-no-cct-bot-token-20260702`` (operator
@@ -383,9 +399,32 @@ def prune_tokenless_telegrammer_mcp(dest: Path) -> bool:
     forever — which is noise in the one view the operator actually checks.
 
     That fail-loud is right for a MISCONFIGURED agent and wrong for a
-    deliberately bot-less one. The two cases are indistinguishable once the
-    entry exists, so the fix is to not emit the entry: no token → no server →
-    nothing to fail. An agent WITH a token is untouched.
+    deliberately bot-less one, so the fix is to not emit the entry: no token →
+    no server → nothing to fail. An agent WITH a token is untouched.
+
+    *** THE TWO CASES ARE NOT INDISTINGUISHABLE, AND TREATING THEM AS ONE COST
+    FOUR DAYS OF OPERATOR SILENCE. ***
+
+    This docstring used to assert they were. That is true of the ``.mcp.json``
+    entry in isolation and false HERE: ``config.claude.channels`` separates them
+    exactly, and :func:`ensure_cct_bot_token` — which runs immediately before —
+    already reads it. The function simply was not passed ``config``.
+
+        (A) no ``server:claude-code-telegrammer`` in the spec
+            -> bot-less BY DESIGN. Prune is correct, INFO is correct.
+        (B) the spec REQUESTS the channel and no token resolved
+            -> MISCONFIGURED, and pruning HIDES it.
+
+    Measured 2026-08-10: scitex-agent-container-04, scitex-app, scitex-db and
+    scitex-priv-setup each logged only the case-(A) INFO — "this is the
+    intentional no-bot path, not an error" — while the operator sat on the other
+    end of Telegram concluding his agents were ignoring him. 91 of 102 fleet
+    specs declare the channel, so 91 agents are eligible for case (B).
+
+    Case (B) is now an ERROR naming the agent, the slots tried, the pool source,
+    and the true consequence. ``config`` is optional so existing callers keep
+    working; without it the function cannot tell (A) from (B) and stays at INFO,
+    which is the old behaviour and the honest answer when the data is absent.
 
     Ordering is load-bearing: this must run AFTER :func:`ensure_cct_bot_token`,
     because that is what resolves a pool token into ``dest/.env``. Running it
@@ -421,6 +460,42 @@ def prune_tokenless_telegrammer_mcp(dest: Path) -> bool:
         return False
     del servers[_TELEGRAMMER_MCP_KEY]
     mcp_path.write_text(json.dumps(doc, indent=2) + "\n")
+
+    if _requested_telegrammer(config):
+        agent_name = getattr(config, "name", "") or "<unknown>"
+        spec_env = getattr(config, "env", None) or {}
+        override = str(spec_env.get(_SLOT_OVERRIDE_VAR, "") or "").strip()
+        candidates = (
+            [_upper_snake(override)]
+            if override
+            else _slot_candidates(agent_name, getattr(config, "workdir", "") or "")
+        )
+        _logger().error(
+            "cct: agent %r REQUESTS %r in spec.claude.channels but no %s "
+            "resolved, so the %r MCP server was REMOVED from %s. THE AGENT IS "
+            "NOW MUTE AND DEAF ON TELEGRAM — it cannot send, it cannot receive, "
+            "and it has no way to notice, because the only in-agent check is "
+            "itself an MCP tool. This is NOT the intentional no-bot path: the "
+            "spec asked for the rail. Tried pool slot(s) %s against the pool "
+            "(%s). Fix by ONE of: (1) add %s<SLOT>=<token> for slot %r to a "
+            "secrets file listed in %s, (2) set spec.apptainer.env %s: "
+            "<existing-slot>, or (3) drop %r from spec.claude.channels if this "
+            "agent genuinely needs no Telegram rail.",
+            agent_name,
+            _TELEGRAMMER_CHANNEL,
+            _TOKEN_VAR,
+            _TELEGRAMMER_MCP_KEY,
+            mcp_path,
+            ", ".join(f"{_POOL_PREFIX}{c}" for c in candidates) or "(none)",
+            _pool_source_label(),
+            _POOL_PREFIX,
+            candidates[0] if candidates else "<SLOT>",
+            _SECRETS_ENVRC_VAR,
+            _SLOT_OVERRIDE_VAR,
+            _TELEGRAMMER_CHANNEL,
+        )
+        return True
+
     _logger().info(
         "cct: no %s resolved for this agent — omitted the %r MCP server from "
         "%s so it does not start and fail on an empty token. This is the "

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -310,7 +310,12 @@ def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
     # MUST run after ensure_cct_bot_token — that call is what populates the
     # token this reads. See prune_tokenless_telegrammer_mcp (card
     # sac-omit-telegram-mcp-when-no-cct-bot-token-20260702).
-    prune_tokenless_telegrammer_mcp(dest)
+    # `config` is passed so the prune can tell "bot-less by design" (INFO) from
+    # "the spec REQUESTED the rail and no token resolved" (ERROR). Without it
+    # the second silently wears the first's clothing, which is how four agents
+    # went mute and deaf on Telegram while logging that it was intentional
+    # (card sac-cct-prune-hides-misconfigured-telegram-agent-20260810).
+    prune_tokenless_telegrammer_mcp(dest, config)
     # settings.json CASCADE (same precedence order as .envrc): deep-merge each
     # layer's .claude/settings.json into dest, raising on a cross-layer scalar
     # conflict (ADR-0018). The walk SKIPS settings.json so this is the single

--- a/tests/scitex_agent_container/runtimes/test__cct_prune_names_case_b.py
+++ b/tests/scitex_agent_container/runtimes/test__cct_prune_names_case_b.py
@@ -1,0 +1,171 @@
+"""A pruned agent that ASKED for the Telegram rail must not log "intentional".
+
+The regression these guard, measured 2026-08-10: scitex-agent-container-04,
+scitex-app, scitex-db and scitex-priv-setup each declared
+``server:claude-code-telegrammer`` in their spec, had the MCP server silently
+removed, and logged only the case-(A) INFO — "this is the intentional no-bot
+path, not an error" — while the operator concluded his agents were ignoring
+him. 91 of 102 fleet specs declare the channel.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from scitex_agent_container.runtimes._cct_token_pool import (
+    prune_tokenless_telegrammer_mcp,
+)
+
+_CHANNEL = "server:claude-code-telegrammer"
+_KEY = "claude-code-telegrammer"
+
+
+def _spec(channels):
+    return SimpleNamespace(
+        name="scitex-agent-container-04",
+        workdir="/home/ywatanabe/proj/scitex-agent-container",
+        env={},
+        claude=SimpleNamespace(channels=list(channels)),
+    )
+
+
+@pytest.fixture
+def dest(tmp_path):
+    """A materialised home with the telegrammer entry and NO token."""
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {_KEY: {"command": "bun"}, "other": {}}}) + "\n"
+    )
+    (tmp_path / ".env").write_text("SOMETHING=else\n")
+    return tmp_path
+
+
+class TestRequestedButUnresolved:
+    def test_entry_is_removed(self, dest):
+        # Arrange
+        config = _spec([_CHANNEL])
+        # Act
+        prune_tokenless_telegrammer_mcp(dest, config)
+        # Assert
+        assert _KEY not in json.loads((dest / ".mcp.json").read_text())["mcpServers"]
+
+    def test_it_logs_at_error_not_info(self, dest, caplog):
+        # Arrange
+        config = _spec([_CHANNEL])
+        # Act
+        with caplog.at_level(logging.ERROR):
+            prune_tokenless_telegrammer_mcp(dest, config)
+        # Assert
+        assert any(r.levelno >= logging.ERROR for r in caplog.records)
+
+    def test_it_does_not_call_the_removal_intentional(self, dest, caplog):
+        # Arrange
+        # Matches the case-(A) sentence in FULL. A bare "intentional no-bot
+        # path" substring is present in the case-(B) text too — it says "this is
+        # NOT the intentional no-bot path" — so the short form passes against
+        # the old code and fails against the new one, which is backwards.
+        config = _spec([_CHANNEL])
+        # Act
+        with caplog.at_level(logging.INFO):
+            prune_tokenless_telegrammer_mcp(dest, config)
+        # Assert
+        assert "intentional no-bot path, not an error" not in caplog.text
+
+    def test_it_says_the_agent_is_mute_and_deaf(self, dest, caplog):
+        # Arrange
+        config = _spec([_CHANNEL])
+        # Act
+        with caplog.at_level(logging.ERROR):
+            prune_tokenless_telegrammer_mcp(dest, config)
+        # Assert
+        assert "MUTE AND DEAF" in caplog.text
+
+    def test_it_names_the_agent(self, dest, caplog):
+        # Arrange
+        config = _spec([_CHANNEL])
+        # Act
+        with caplog.at_level(logging.ERROR):
+            prune_tokenless_telegrammer_mcp(dest, config)
+        # Assert
+        assert "scitex-agent-container-04" in caplog.text
+
+    def test_it_names_the_slots_it_tried(self, dest, caplog):
+        # Arrange
+        config = _spec([_CHANNEL])
+        # Act
+        with caplog.at_level(logging.ERROR):
+            prune_tokenless_telegrammer_mcp(dest, config)
+        # Assert
+        assert "CCT_BOT_TOKEN_SCITEX_AGENT_CONTAINER_04" in caplog.text
+
+
+class TestBotlessByDesign:
+    def test_entry_is_still_removed(self, dest):
+        # Arrange
+        config = _spec([])
+        # Act
+        prune_tokenless_telegrammer_mcp(dest, config)
+        # Assert
+        assert _KEY not in json.loads((dest / ".mcp.json").read_text())["mcpServers"]
+
+    def test_it_stays_informational(self, dest, caplog):
+        # Arrange
+        config = _spec([])
+        # Act
+        with caplog.at_level(logging.INFO):
+            prune_tokenless_telegrammer_mcp(dest, config)
+        # Assert
+        assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+    def test_it_still_says_intentional(self, dest, caplog):
+        # Arrange
+        config = _spec([])
+        # Act
+        with caplog.at_level(logging.INFO):
+            prune_tokenless_telegrammer_mcp(dest, config)
+        # Assert
+        assert "intentional no-bot path" in caplog.text
+
+
+class TestBackCompat:
+    def test_no_config_still_prunes(self, dest):
+        # Arrange
+        # The old one-argument call site.
+        # Act
+        removed = prune_tokenless_telegrammer_mcp(dest)
+        # Assert
+        assert removed is True
+
+    def test_no_config_does_not_claim_misconfiguration(self, dest, caplog):
+        # Arrange
+        # Without a spec the function cannot tell (A) from (B); silence about
+        # which one it is beats guessing wrong in either direction.
+        # Act
+        with caplog.at_level(logging.INFO):
+            prune_tokenless_telegrammer_mcp(dest)
+        # Assert
+        assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+
+class TestAgentWithAToken:
+    def test_entry_is_kept(self, dest):
+        # Arrange
+        (dest / ".env").write_text("CCT_BOT_TOKEN=abc123\n")
+        config = _spec([_CHANNEL])
+        # Act
+        prune_tokenless_telegrammer_mcp(dest, config)
+        # Assert
+        assert _KEY in json.loads((dest / ".mcp.json").read_text())["mcpServers"]
+
+    def test_nothing_is_logged_as_an_error(self, dest, caplog):
+        # Arrange
+        (dest / ".env").write_text("CCT_BOT_TOKEN=abc123\n")
+        config = _spec([_CHANNEL])
+        # Act
+        with caplog.at_level(logging.INFO):
+            prune_tokenless_telegrammer_mcp(dest, config)
+        # Assert
+        assert not [r for r in caplog.records if r.levelno >= logging.ERROR]


### PR DESCRIPTION
`prune_tokenless_telegrammer_mcp` removed the `claude-code-telegrammer` MCP server whenever no token resolved, and logged the same INFO either way:

> this is the intentional no-bot path, not an error

For an agent whose spec **requests** `server:claude-code-telegrammer`, that sentence is false — and it is the only trace the removal leaves.

## Measured

2026-08-10: `scitex-agent-container-04`, `scitex-app`, `scitex-db` and `scitex-priv-setup` each declared the channel, each had the server stripped, each logged only that INFO — while the operator concluded his agents were ignoring him. **91 of 102** fleet specs declare the channel.

Removed is strictly worse than silent: the agent loses **inbound** too, and loses every in-agent means of noticing, because the only self-check is itself an MCP tool.

## Why it was possible

The function's docstring asserted the two cases are indistinguishable. True of the `.mcp.json` entry in isolation, false here — `config.claude.channels` separates them exactly, and `ensure_cct_bot_token` (which runs immediately before) already reads it. The function simply was not passed `config`.

## Changes

- `prune_tokenless_telegrammer_mcp(dest, config=None)`. Case (B) — channel requested, no token — logs **ERROR** naming the agent, the slots tried, the pool source, and that the agent is now mute *and* deaf. Case (A) keeps its INFO verbatim.
- `config` is **optional**: existing one-arg callers keep the old behaviour, because without a spec the function genuinely cannot tell (A) from (B), and silence beats guessing in either direction.
- `ensure_cct_bot_token`'s WARNING said the MCP "comes up without a token, so the bot stays silent". It does not come up at all. A warning whose stated consequence is milder than reality invites the "probably fine" reading.
- One `_requested_telegrammer()` helper, since two functions now need the same fact.

## Verification

13 new tests across all four quadrants (requested+unresolved / bot-less by design / no config / has a token).

No regression, established against a control rather than assumed:

| | passed | failed | errors |
|---|---|---|---|
| clean `develop` | 1712 | 3 | 19 |
| this branch | 1725 (+13 new) | 3 (same) | 19 (same) |

Those 3 pre-existing failures are **carded separately** (`sac-develop-runtimes-suite-is-red-...`), not absorbed here.