### PR TITLE
fix(cct): fail loud when a DECLARED bot slot is broken, not when a template asks

### DIFF
--- a/src/scitex_agent_container/runtimes/_cct_token_pool.py
+++ b/src/scitex_agent_container/runtimes/_cct_token_pool.py
@@ -49,24 +49,38 @@ token deliberately NEVER rides an ``--env`` argv flag (visible in
 ``/proc/<pid>/cmdline``) and its VALUE is never logged — log lines carry
 only the slot NAME, the pool source path(s), and the agent name.
 
-Loud-but-honest contract: when the channel is requested and NO token
-resolves, a scitex-logging WARNING names the pool source, the tried slot
-names, and the fixes. The start itself proceeds — Telegram is a comms rail,
-not a boot dependency — so the absence is loud but never silent, and never
-DRESSED UP AS A STARTUP FAILURE. It used to log at ERROR, which made every
-brand-new agent (no bot yet, by definition) look stillborn in its boot log
-next to the genuinely fatal lines; WARNING + an explicit "the agent starts
-normally" sentence keeps the signal without the false alarm.
+Loud-but-honest contract, at TWO levels, because there are two different
+facts to report and they do not deserve the same volume:
+
+* RESOLUTION failed (:func:`ensure_cct_bot_token`) — a scitex-logging
+  WARNING names the pool source, the tried slot names, and the fixes. The
+  start itself proceeds — Telegram is a comms rail, not a boot dependency —
+  so the absence is loud but never silent, and never DRESSED UP AS A STARTUP
+  FAILURE. It used to log at ERROR, which made every brand-new agent (no bot
+  yet, by definition) look stillborn in its boot log next to the genuinely
+  fatal lines; WARNING + an explicit "the agent starts normally" sentence
+  keeps the signal without the false alarm.
+* A DECLARED mapping is broken (:func:`prune_tokenless_telegrammer_mcp`) —
+  ERROR. Different fact, rarer, severe in consequence (the rail is REMOVED,
+  not merely quiet), so it earns the loud level without reopening the
+  demotion above. Keyed on the DECLARED slot, never on the channel request —
+  see that function for the 80/14/66 measurement behind that choice.
 """
 
 from __future__ import annotations
 
 import json
-import os
 import re
 from pathlib import Path
 
 from ._sdk_channels import _TELEGRAMMER_CHANNEL, _TELEGRAMMER_MCP_KEY
+from ._secret_pool import (
+    _SECRETS_ENVRC_VAR,
+    _pool_env,
+    _pool_source_label,
+    _read_env_file,
+    _write_env_file,
+)
 
 # The env-var the telegrammer MCP reads its bot token from (see the shared
 # baseline ``.mcp.json``: ``"CCT_BOT_TOKEN": "${CCT_BOT_TOKEN}"``).
@@ -77,8 +91,6 @@ _AGENT_ID_VAR = "CCT_AGENT_ID"
 _POOL_PREFIX = "CCT_BOT_TOKEN_"
 # Optional explicit slot override in ``spec.apptainer.env``.
 _SLOT_OVERRIDE_VAR = "CCT_BOT_TOKEN_SLOT"
-# The .envrc secrets-preamble env var (shared with :mod:`._envrc`).
-_SECRETS_ENVRC_VAR = "SAC_SECRETS_ENVRC"
 
 
 def _logger():
@@ -168,86 +180,30 @@ def _slot_candidates(name: str, workdir: str) -> list[str]:
     return candidates
 
 
-def _read_env_file(path: Path) -> dict[str, str]:
-    """Parse a plain ``KEY=VALUE``-per-line env file (the fold's format).
+def _channel_requested(config) -> bool:
+    """True iff ``spec.claude.channels`` asks for the telegrammer rail.
 
-    Tolerates blank lines and ``#`` comments; no shell semantics (the fold
-    writes raw values, no quoting/export).
+    Read by :func:`ensure_cct_bot_token` (whether to resolve at all) and by
+    :func:`prune_tokenless_telegrammer_mcp` (whether resolution was even
+    attempted, before it blames a declared slot for coming up empty).
     """
-    env: dict[str, str] = {}
-    for line in path.read_text(encoding="utf-8").splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        key, sep, val = line.partition("=")
-        if sep:
-            env[key.strip()] = val
-    return env
+    channels = list(getattr(getattr(config, "claude", None), "channels", None) or [])
+    return any(str(c).strip() == _TELEGRAMMER_CHANNEL for c in channels)
 
 
-def _pool_env() -> dict[str, str]:
-    """The pool: ``CCT_BOT_TOKEN_*`` vars from the launching env, overlaid
-    with the secret files (daemon-start path).
+def _declared_slot(config) -> str:
+    """The DECLARED slot from ``spec.apptainer.env: CCT_BOT_TOKEN_SLOT``, else "".
 
-    Resolves the secret files via :func:`._envrc.resolve_secret_files`, which
-    honours an explicit ``SAC_SECRETS_ENVRC`` AND — the 2026-07-18 class fix —
-    falls back to the canonical ``$HOME`` default pool when the var is unset, so
-    a cron / raw-ssh / federated-timer restart that never had the var exported
-    still finds the bot token instead of folding (and STRIPPING) it. Sourced in
-    a strict bash with the same ``set -a`` semantics as the ``.envrc`` fold.
-    Falls back to the plain process env when no secret file resolves, and
-    degrades to the process env (rather than failing the deploy) if a resolved
-    secret file cannot be sourced — the caller's missing-token WARNING then
-    names the pool source anyway.
+    Upper-snaked exactly as the resolution path consumes it, so a log line names
+    the slot sac really looked for rather than the spelling in the spec. It is
+    the one signal here separating "somebody mapped this agent to a bot" from "a
+    template default came along for the ride" — see
+    :func:`prune_tokenless_telegrammer_mcp` for why that, and not the channel
+    request, is what earns an ERROR.
     """
-    import shlex
-
-    from ._envrc import EnvrcEvalError, _capture_env, resolve_secret_files
-
-    files = resolve_secret_files()
-    if not files:
-        return dict(os.environ)
-    preamble = [f". {shlex.quote(str(p))}" for p in files]
-    try:
-        return _capture_env(
-            "\n".join(["set -a", *preamble, "set +a", "env -0"]), Path.cwd()
-        )
-    except EnvrcEvalError as exc:  # stx-allow: fallback (reason: pool read must not abort deploy; missing token is reported loudly by the caller)
-        _logger().warning(
-            "cct pool: failed to source %s (%s); falling back to the "
-            "launching process env only.",
-            _pool_source_label(),
-            exc,
-        )
-        return dict(os.environ)
-
-
-def _pool_source_label() -> str:
-    """Human-readable pool location for log lines (paths only, no values)."""
-    raw = os.environ.get(_SECRETS_ENVRC_VAR, "")
-    if raw:
-        return f"{_SECRETS_ENVRC_VAR}={raw}"
-    # Class fix (2026-07-18): an unset var no longer means an empty pool — the
-    # resolver falls back to the canonical ``$HOME`` default. Report THAT so the
-    # missing-token WARN names where sac actually looked, not a pool it stopped
-    # limiting itself to.
-    from ._envrc import resolve_secret_files
-
-    defaults = resolve_secret_files()
-    if defaults:
-        joined = ":".join(str(p) for p in defaults)
-        return f"{_SECRETS_ENVRC_VAR} unset — using the canonical default pool {joined}"
-    return (
-        f"{_SECRETS_ENVRC_VAR} is UNSET and no canonical default pool files were "
-        "found — pool limited to the launching process environment"
-    )
-
-
-def _write_env_file(path: Path, env: dict[str, str]) -> None:
-    """Rewrite ``path`` as sorted ``KEY=VALUE`` lines, owner-only perms."""
-    body = "".join(f"{k}={v}\n" for k, v in sorted(env.items()))
-    path.write_text(body, encoding="utf-8")
-    os.chmod(path, 0o600)
+    spec_env = getattr(config, "env", None) or {}
+    override = str(spec_env.get(_SLOT_OVERRIDE_VAR, "") or "").strip()
+    return _upper_snake(override) if override else ""
 
 
 def ensure_cct_bot_token(config, dest: Path) -> None:
@@ -263,9 +219,7 @@ def ensure_cct_bot_token(config, dest: Path) -> None:
     does not fail a boot. The token VALUE is never logged; only slot names,
     paths, and the agent name appear.
     """
-    claude_spec = getattr(config, "claude", None)
-    channels = list(getattr(claude_spec, "channels", None) or [])
-    if not any(str(c).strip() == _TELEGRAMMER_CHANNEL for c in channels):
+    if not _channel_requested(config):
         return
     agent_name = getattr(config, "name", "") or ""
     workdir = getattr(config, "workdir", "") or ""
@@ -289,12 +243,8 @@ def ensure_cct_bot_token(config, dest: Path) -> None:
             )
         return
 
-    spec_env = getattr(config, "env", None) or {}
-    override = str(spec_env.get(_SLOT_OVERRIDE_VAR, "") or "").strip()
-    if override:
-        candidates = [_upper_snake(override)]
-    else:
-        candidates = _slot_candidates(agent_name, workdir)
+    declared = _declared_slot(config)
+    candidates = [declared] if declared else _slot_candidates(agent_name, workdir)
 
     pool = _pool_env()
     for slot in candidates:
@@ -319,8 +269,10 @@ def ensure_cct_bot_token(config, dest: Path) -> None:
         "cct: no Telegram bot token for agent %r although spec.claude.channels "
         "requests %r. Tried pool slot(s) %s against the pool (%s). THE AGENT "
         "STARTS NORMALLY — this is NOT a startup failure; only the Telegram "
-        "rail is down (the telegrammer MCP comes up without a token, so the "
-        "bot stays silent until a token is provided). Expected for a "
+        "rail is down, and it is down in BOTH directions: the telegrammer MCP "
+        "entry is REMOVED from the materialised .mcp.json (a server that "
+        "cannot start is worse than an absent one), so this agent is MUTE and "
+        "DEAF on Telegram until a token is provided. Expected for a "
         "brand-new agent that has no bot yet. To wire one up, do ONE of: "
         "(1) add %s<SLOT>=<token> for slot %r to a secrets file listed in %s "
         "(canonical pool; restart `sac listen` afterwards if it provides the "
@@ -370,7 +322,7 @@ def _default_agent_id(agent_name: str, workdir: str) -> str:
     return agent_name
 
 
-def prune_tokenless_telegrammer_mcp(dest: Path) -> bool:
+def prune_tokenless_telegrammer_mcp(dest: Path, *, config=None) -> bool:
     """Drop the telegrammer MCP server from ``dest/.mcp.json`` when no token resolved.
 
     Card ``sac-omit-telegram-mcp-when-no-cct-bot-token-20260702`` (operator
@@ -383,9 +335,35 @@ def prune_tokenless_telegrammer_mcp(dest: Path) -> bool:
     forever — which is noise in the one view the operator actually checks.
 
     That fail-loud is right for a MISCONFIGURED agent and wrong for a
-    deliberately bot-less one. The two cases are indistinguishable once the
-    entry exists, so the fix is to not emit the entry: no token → no server →
-    nothing to fail. An agent WITH a token is untouched.
+    deliberately bot-less one, and the ENTRY cannot tell them apart, so the fix
+    is to not emit the entry: no token → no server → nothing to fail. An agent
+    WITH a token is untouched.
+
+    Removing it SILENTLY, however, is how a misconfigured agent hides. Measured
+    2026-08-10, card ``sac-cct-prune-hides-misconfigured-telegram-agent-20260810``:
+    four agents on a new host went MUTE **and** DEAF on Telegram behind one INFO
+    line each, and the operator — getting no answers — concluded they were
+    ignoring him. Deafness is the half that surprises: the entry's absence kills
+    inbound too, and the agent cannot even self-diagnose, because ``health`` is
+    itself a tool on the very MCP server that just went away.
+
+    So ``config`` is read and the LEVEL splits on what the spec DECLARED:
+    an explicit ``spec.apptainer.env: CCT_BOT_TOKEN_SLOT: <X>`` whose pool slot
+    is absent/empty → ERROR (a stated mapping is broken; unambiguous, and rare
+    enough that ERROR stays quiet); no declared slot → INFO, unchanged, the
+    intentional no-bot path. ``config=None`` keeps the pre-2026-08-10 blind
+    behaviour; the real call site in :func:`._to_home.deploy_to_home` passes one.
+
+    The trigger is deliberately NOT "the spec requests the channel". On
+    compute-04, 2026-08-10: 80 specs request it, 14 resolve a token, 66 do not —
+    and the 66 include ``_template_generalist``, ``_template_python_developer``
+    and ``_template_researcher``. The request is INHERITED FROM THE TEMPLATES,
+    so it measures scaffolding, not intent; keying ERROR on it would print 66
+    red lines into the one panel the operator actually checks — recreating, as
+    a "fix", the exact noise this prune was written to remove. A declared slot
+    is the one thing here that somebody had to type on purpose, and it composes
+    with the operational remedy: give an agent that SHOULD have a bot an
+    explicit override, and from then on any breakage screams.
 
     Ordering is load-bearing: this must run AFTER :func:`ensure_cct_bot_token`,
     because that is what resolves a pool token into ``dest/.env``. Running it
@@ -421,6 +399,32 @@ def prune_tokenless_telegrammer_mcp(dest: Path) -> bool:
         return False
     del servers[_TELEGRAMMER_MCP_KEY]
     mcp_path.write_text(json.dumps(doc, indent=2) + "\n")
+    declared = _declared_slot(config) if config is not None else ""
+    if declared and _channel_requested(config):
+        slot_var = f"{_POOL_PREFIX}{declared}"
+        _logger().error(
+            "cct: agent %r DECLARES pool slot %s via spec.apptainer.env %s, but "
+            "that slot is absent or empty in the pool (%s) — a declared mapping "
+            "that does not work, i.e. a MISCONFIGURATION, not the intentional "
+            "no-bot path. The %r MCP server was REMOVED from %s, so the "
+            "Telegram rail is down BOTH ways: this agent is MUTE (cannot send) "
+            "and DEAF (never receives), and it cannot even self-diagnose, "
+            "because `health` is itself a tool on the server that just went "
+            "away. Fix by EITHER adding %s=<token> to a secrets file listed in "
+            "%s (restart `sac listen` afterwards if it provides the env), OR "
+            "correcting %s to a slot that exists, OR removing the override if "
+            "this agent needs no Telegram rail.",
+            getattr(config, "name", "") or "",
+            slot_var,
+            _SLOT_OVERRIDE_VAR,
+            _pool_source_label(),
+            _TELEGRAMMER_MCP_KEY,
+            mcp_path,
+            slot_var,
+            _SECRETS_ENVRC_VAR,
+            _SLOT_OVERRIDE_VAR,
+        )
+        return True
     _logger().info(
         "cct: no %s resolved for this agent — omitted the %r MCP server from "
         "%s so it does not start and fail on an empty token. This is the "

--- a/src/scitex_agent_container/runtimes/_github_token.py
+++ b/src/scitex_agent_container/runtimes/_github_token.py
@@ -74,7 +74,7 @@ def ensure_github_token(config, dest: Path) -> None:
 
     Never raises. Never logs the token value.
     """
-    from ._cct_token_pool import (  # local import: shared pool, one source
+    from ._secret_pool import (  # the shared pool toolkit, one source
         _pool_env,
         _pool_source_label,
         _read_env_file,

--- a/src/scitex_agent_container/runtimes/_secret_pool.py
+++ b/src/scitex_agent_container/runtimes/_secret_pool.py
@@ -1,0 +1,115 @@
+"""The fleet secrets POOL and the ``.env`` carrier it is folded into.
+
+Extracted from :mod:`._cct_token_pool` (2026-08-10). Nothing here is specific to
+Telegram: it is the generic machinery two token injectors share — read the pool,
+say where the pool lives, read and rewrite the agent's materialised ``.env``.
+:mod:`._github_token` was already importing all four names out of the CCT module
+("shared pool, one source"), which is a GitHub-token module reaching into a
+Telegram module for env-file I/O. Now both import from here and the CCT module
+keeps only CCT policy.
+
+The pool itself is the set of ``<PREFIX>_<SLOT>`` environment variables visible
+to the launching ``sac agents start`` process — the union of its own environment
+and the secret files listed in ``SAC_SECRETS_ENVRC`` (colon-separated absolute
+paths), with a canonical ``$HOME`` fallback when that var is unset. Token VALUES
+never appear in a log line; only slot names and paths do.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# The .envrc secrets-preamble env var (shared with :mod:`._envrc`).
+_SECRETS_ENVRC_VAR = "SAC_SECRETS_ENVRC"
+
+
+def _logger():
+    """scitex-logging logger, imported lazily (same rationale as
+    ``config.__init__._config_logger``: the package auto-configures
+    handlers on first import, which must not tax module import)."""
+    import scitex_logging
+
+    return scitex_logging.getLogger(__name__)
+
+
+def _read_env_file(path: Path) -> dict[str, str]:
+    """Parse a plain ``KEY=VALUE``-per-line env file (the fold's format).
+
+    Tolerates blank lines and ``#`` comments; no shell semantics (the fold
+    writes raw values, no quoting/export).
+    """
+    env: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key, sep, val = line.partition("=")
+        if sep:
+            env[key.strip()] = val
+    return env
+
+
+def _write_env_file(path: Path, env: dict[str, str]) -> None:
+    """Rewrite ``path`` as sorted ``KEY=VALUE`` lines, owner-only perms."""
+    body = "".join(f"{k}={v}\n" for k, v in sorted(env.items()))
+    path.write_text(body, encoding="utf-8")
+    os.chmod(path, 0o600)
+
+
+def _pool_env() -> dict[str, str]:
+    """The pool: secret vars from the launching env, overlaid with the secret
+    files (daemon-start path).
+
+    Resolves the secret files via :func:`._envrc.resolve_secret_files`, which
+    honours an explicit ``SAC_SECRETS_ENVRC`` AND — the 2026-07-18 class fix —
+    falls back to the canonical ``$HOME`` default pool when the var is unset, so
+    a cron / raw-ssh / federated-timer restart that never had the var exported
+    still finds the bot token instead of folding (and STRIPPING) it. Sourced in
+    a strict bash with the same ``set -a`` semantics as the ``.envrc`` fold.
+    Falls back to the plain process env when no secret file resolves, and
+    degrades to the process env (rather than failing the deploy) if a resolved
+    secret file cannot be sourced — the caller's missing-token WARNING then
+    names the pool source anyway.
+    """
+    import shlex
+
+    from ._envrc import EnvrcEvalError, _capture_env, resolve_secret_files
+
+    files = resolve_secret_files()
+    if not files:
+        return dict(os.environ)
+    preamble = [f". {shlex.quote(str(p))}" for p in files]
+    try:
+        return _capture_env(
+            "\n".join(["set -a", *preamble, "set +a", "env -0"]), Path.cwd()
+        )
+    except EnvrcEvalError as exc:  # stx-allow: fallback (reason: pool read must not abort deploy; missing token is reported loudly by the caller)
+        _logger().warning(
+            "secrets pool: failed to source %s (%s); falling back to the "
+            "launching process env only.",
+            _pool_source_label(),
+            exc,
+        )
+        return dict(os.environ)
+
+
+def _pool_source_label() -> str:
+    """Human-readable pool location for log lines (paths only, no values)."""
+    raw = os.environ.get(_SECRETS_ENVRC_VAR, "")
+    if raw:
+        return f"{_SECRETS_ENVRC_VAR}={raw}"
+    # Class fix (2026-07-18): an unset var no longer means an empty pool — the
+    # resolver falls back to the canonical ``$HOME`` default. Report THAT so the
+    # missing-token WARN names where sac actually looked, not a pool it stopped
+    # limiting itself to.
+    from ._envrc import resolve_secret_files
+
+    defaults = resolve_secret_files()
+    if defaults:
+        joined = ":".join(str(p) for p in defaults)
+        return f"{_SECRETS_ENVRC_VAR} unset — using the canonical default pool {joined}"
+    return (
+        f"{_SECRETS_ENVRC_VAR} is UNSET and no canonical default pool files were "
+        "found — pool limited to the launching process environment"
+    )

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -310,8 +310,12 @@ def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
     # shipping one that starts, finds an empty token and fails on every boot.
     # MUST run after ensure_cct_bot_token — that call is what populates the
     # token this reads. See prune_tokenless_telegrammer_mcp (card
-    # sac-omit-telegram-mcp-when-no-cct-bot-token-20260702).
-    prune_tokenless_telegrammer_mcp(dest)
+    # sac-omit-telegram-mcp-when-no-cct-bot-token-20260702). `config` is passed
+    # so the prune can tell a DESIGNED bot-less agent (INFO) from one whose
+    # spec DECLARES a CCT_BOT_TOKEN_SLOT that does not resolve (ERROR — the
+    # removed entry leaves it mute AND deaf; card
+    # sac-cct-prune-hides-misconfigured-telegram-agent-20260810).
+    prune_tokenless_telegrammer_mcp(dest, config=config)
     # GITHUB_TOKEN, same pool and the same ordering rationale: the fleet
     # secrets live in ~/.bash.d/secrets, which only a LOGIN shell sources,
     # and sac starts containers without one — so the token was present and

--- a/tests/scitex_agent_container/runtimes/test__cct_token_pool.py
+++ b/tests/scitex_agent_container/runtimes/test__cct_token_pool.py
@@ -678,3 +678,246 @@ def test_absent_telegrammer_entry_is_a_noop(tmp_path: Path) -> None:
     removed = prune_tokenless_telegrammer_mcp(tmp_path)
     # Assert
     assert removed is False
+
+
+# ---------------------------------------------------------------------------
+# The prune's LEVEL splits on what the spec DECLARED — card
+# sac-cct-prune-hides-misconfigured-telegram-agent-20260810.
+#
+# Removing the entry is right in every tokenless case (a server that cannot
+# start is worse than an absent one), but removing it SILENTLY is how a
+# misconfigured agent hides: four agents went mute AND deaf on a new host
+# behind one INFO line each, and the operator concluded they were ignoring him.
+#
+# The trigger is the DECLARED slot, NOT the channel request. Measured on
+# compute-04: 80 specs request the channel, 14 resolve a token, 66 do not — and
+# the 66 include _template_generalist / _template_python_developer /
+# _template_researcher. The request is inherited from the templates, so an
+# ERROR keyed on it would print 66 red lines into the panel this prune exists
+# to keep clean.
+# ---------------------------------------------------------------------------
+
+
+def _declaring_cfg(name: str, slot: str) -> AgentConfig:
+    """A spec that DECLARES a pool slot — the statement of intent."""
+    return _cfg(name, env={"CCT_BOT_TOKEN_SLOT": slot})
+
+
+def test_declared_slot_that_does_not_resolve_logs_at_error(
+    tmp_path: Path, secrets_envrc: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange — the spec names a slot; the pool does not have it.
+    _pool_file(tmp_path, "export CCT_BOT_TOKEN_ZZ_OTHER=tok-other\n")
+    _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("")
+    # Act
+    with caplog.at_level(scitex_logging.DEBUG):
+        prune_tokenless_telegrammer_mcp(
+            tmp_path, config=_declaring_cfg("zz-declared", "ZZ_GHOST")
+        )
+    # Assert — a stated mapping that does not work is an ERROR, not an INFO.
+    assert [r for r in caplog.records if r.levelno >= scitex_logging.ERROR]
+
+
+def test_declared_slot_miss_still_removes_the_entry(
+    tmp_path: Path, secrets_envrc: None
+) -> None:
+    # Arrange — loud does NOT mean "ship a server that cannot start".
+    _pool_file(tmp_path, "")
+    mcp = _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("")
+    # Act
+    prune_tokenless_telegrammer_mcp(
+        tmp_path, config=_declaring_cfg("zz-declared", "ZZ_GHOST")
+    )
+    # Assert
+    assert _TELEGRAMMER not in _servers_in(mcp)
+
+
+def test_declared_slot_miss_error_names_the_agent(
+    tmp_path: Path, secrets_envrc: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    _pool_file(tmp_path, "")
+    _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("")
+    # Act
+    with caplog.at_level(scitex_logging.ERROR):
+        prune_tokenless_telegrammer_mcp(
+            tmp_path, config=_declaring_cfg("zz-mute-and-deaf", "ZZ_GHOST")
+        )
+    # Assert — the operator must learn WHICH agent went quiet.
+    assert "zz-mute-and-deaf" in caplog.text
+
+
+def test_declared_slot_miss_error_names_the_declared_slot(
+    tmp_path: Path, secrets_envrc: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    _pool_file(tmp_path, "")
+    _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("")
+    # Act
+    with caplog.at_level(scitex_logging.ERROR):
+        prune_tokenless_telegrammer_mcp(
+            tmp_path, config=_declaring_cfg("zz-declared", "ZZ_GHOST")
+        )
+    # Assert — slot NAMES are loggable; token values never are.
+    assert "CCT_BOT_TOKEN_ZZ_GHOST" in caplog.text
+
+
+def test_declared_slot_miss_error_says_mute_and_deaf(
+    tmp_path: Path, secrets_envrc: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange — deafness is the half that surprises: the absent entry kills
+    # INBOUND too, which is why the operator read silence as being ignored.
+    _pool_file(tmp_path, "")
+    _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("")
+    # Act
+    with caplog.at_level(scitex_logging.ERROR):
+        prune_tokenless_telegrammer_mcp(
+            tmp_path, config=_declaring_cfg("zz-declared", "ZZ_GHOST")
+        )
+    # Assert
+    assert "DEAF" in caplog.text
+
+
+def test_declared_slot_miss_error_says_the_agent_cannot_self_diagnose(
+    tmp_path: Path, secrets_envrc: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange — `health` is itself a tool on the server that was just removed,
+    # so the agent cannot check its own rail. Say so, or the next reader will
+    # tell it to "run health".
+    _pool_file(tmp_path, "")
+    _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("")
+    # Act
+    with caplog.at_level(scitex_logging.ERROR):
+        prune_tokenless_telegrammer_mcp(
+            tmp_path, config=_declaring_cfg("zz-declared", "ZZ_GHOST")
+        )
+    # Assert
+    assert "health" in caplog.text
+
+
+def test_declared_slot_miss_error_names_the_pool_source(
+    tmp_path: Path, secrets_envrc: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    _pool_file(tmp_path, "")
+    _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("")
+    # Act
+    with caplog.at_level(scitex_logging.ERROR):
+        prune_tokenless_telegrammer_mcp(
+            tmp_path, config=_declaring_cfg("zz-declared", "ZZ_GHOST")
+        )
+    # Assert — WHERE sac looked, so the fix can be applied to the right file.
+    assert _SECRETS_VAR in caplog.text
+
+
+def test_no_declared_slot_keeps_the_quiet_intentional_no_bot_path(
+    tmp_path: Path, secrets_envrc: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange — the channel IS requested (every template requests it) but no
+    # slot was ever declared. This is 66 of the 80 live specs: silence here is
+    # the whole point, or the fix becomes the noise it was written to remove.
+    _pool_file(tmp_path, "")
+    _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("")
+    # Act
+    with caplog.at_level(scitex_logging.DEBUG):
+        prune_tokenless_telegrammer_mcp(tmp_path, config=_cfg("zz-template-default"))
+    # Assert
+    assert not [r for r in caplog.records if r.levelno >= scitex_logging.ERROR]
+
+
+def test_no_declared_slot_still_says_intentional_no_bot_path(
+    tmp_path: Path, secrets_envrc: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange
+    _pool_file(tmp_path, "")
+    _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("")
+    # Act
+    with caplog.at_level(scitex_logging.INFO):
+        prune_tokenless_telegrammer_mcp(tmp_path, config=_cfg("zz-template-default"))
+    # Assert — unchanged wording for the designed case.
+    assert "intentional no-bot path" in caplog.text
+
+
+def test_no_declared_slot_still_removes_the_entry(
+    tmp_path: Path, secrets_envrc: None
+) -> None:
+    # Arrange
+    _pool_file(tmp_path, "")
+    mcp = _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("")
+    # Act
+    prune_tokenless_telegrammer_mcp(tmp_path, config=_cfg("zz-template-default"))
+    # Assert
+    assert _TELEGRAMMER not in _servers_in(mcp)
+
+
+def test_declared_slot_without_the_channel_is_not_an_error(
+    tmp_path: Path, secrets_envrc: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange — an inert override on a spec that never asked for the rail.
+    # Resolution was never attempted, so the slot cannot be blamed for missing.
+    _pool_file(tmp_path, "")
+    _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("")
+    cfg = _cfg("zz-no-channel", channel=False, env={"CCT_BOT_TOKEN_SLOT": "ZZ_GHOST"})
+    # Act
+    with caplog.at_level(scitex_logging.DEBUG):
+        prune_tokenless_telegrammer_mcp(tmp_path, config=cfg)
+    # Assert
+    assert not [r for r in caplog.records if r.levelno >= scitex_logging.ERROR]
+
+
+def test_declared_slot_that_resolves_leaves_the_entry_alone(
+    tmp_path: Path, secrets_envrc: None
+) -> None:
+    # Arrange — the declared mapping WORKS: ensure_cct_bot_token wrote the
+    # token, so there is nothing to prune and nothing to report.
+    _pool_file(tmp_path, "")
+    mcp = _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("CCT_BOT_TOKEN=123:abc\n")
+    # Act
+    prune_tokenless_telegrammer_mcp(
+        tmp_path, config=_declaring_cfg("zz-working", "ZZ_REAL")
+    )
+    # Assert
+    assert _TELEGRAMMER in _servers_in(mcp)
+
+
+def test_token_present_never_logs_an_error(
+    tmp_path: Path, secrets_envrc: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange — a working agent must stay entirely quiet.
+    _pool_file(tmp_path, "")
+    _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("CCT_BOT_TOKEN=123:abc\n")
+    # Act
+    with caplog.at_level(scitex_logging.DEBUG):
+        prune_tokenless_telegrammer_mcp(
+            tmp_path, config=_declaring_cfg("zz-working", "ZZ_REAL")
+        )
+    # Assert
+    assert not [r for r in caplog.records if r.levelno >= scitex_logging.ERROR]
+
+
+def test_prune_without_a_config_keeps_the_pre_spec_aware_behaviour(
+    tmp_path: Path, secrets_envrc: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange — no spec in hand means the two cases cannot be told apart, so
+    # the blind INFO is the only honest answer.
+    _pool_file(tmp_path, "")
+    _write_mcp_json(tmp_path, _telegrammer_entry())
+    (tmp_path / ".env").write_text("")
+    # Act
+    with caplog.at_level(scitex_logging.DEBUG):
+        prune_tokenless_telegrammer_mcp(tmp_path)
+    # Assert
+    assert not [r for r in caplog.records if r.levelno >= scitex_logging.ERROR]

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -1428,3 +1428,24 @@ class TestTokenlessTelegrammerPrune:
         deploy_to_home(cfg, str(home))
         # Assert
         assert self._TELEGRAMMER in self._mcp_servers(home)
+
+    def test_a_broken_declared_slot_reaches_the_operator_through_deploy(
+        self, tmp_path, caplog
+    ):
+        # Arrange — the SPEC-AWARE half of the prune (card
+        # sac-cct-prune-hides-misconfigured-telegram-agent-20260810). The unit
+        # tests in test__cct_token_pool.py pass a config in by hand, so they stay
+        # green even if deploy_to_home forgets to pass one — and a prune that
+        # never sees the spec is exactly the blind prune that hid four mute-and-
+        # deaf agents. Only the real entry-point proves the wiring.
+        import scitex_logging
+
+        cfg, _root = self._seed(tmp_path)
+        cfg.claude.channels = ["server:claude-code-telegrammer"]
+        cfg.env = {"CCT_BOT_TOKEN_SLOT": "ZZ_GHOST_SLOT"}
+        home = tmp_path / "home"
+        # Act
+        with caplog.at_level(scitex_logging.ERROR):
+            deploy_to_home(cfg, str(home))
+        # Assert — the declared-but-broken mapping is loud at the entry-point.
+        assert "CCT_BOT_TOKEN_ZZ_GHOST_SLOT" in caplog.text


### PR DESCRIPTION
## The measured consequence

`prune_tokenless_telegrammer_mcp` drops the `claude-code-telegrammer` entry from
a materialised `.mcp.json` whenever no `CCT_BOT_TOKEN` resolved, and logs INFO:
*"this is the intentional no-bot path, not an error."*

That is correct for an agent that never wanted a bot, and it is how a
**misconfigured** one hides.

**Measured 2026-08-10: four agents on a new host went MUTE and DEAF on Telegram
behind one INFO line each. The operator, getting no answers, concluded they were
ignoring him.** Deafness is the half that surprises — the absent entry kills
inbound too, and the agent cannot even self-diagnose, because `health` is itself
a tool on the MCP server that just went away.

The prune's docstring claimed the two cases "are indistinguishable once the
entry exists." At that point in the code they are not: the spec distinguishes
them, and `ensure_cct_bot_token` already reads it.

## Why the trigger is the DECLARED slot, not the channel request

This is the part worth keeping, because the obvious "fix" is wrong and the next
person will otherwise revert to it.

The natural trigger looks like *"the spec requests `server:claude-code-telegrammer`
but no token resolved."* Measured on compute-04:

| specs requesting the channel | resolve a token | resolve nothing |
|---|---|---|
| 80 | 14 | **66** |

and the 66 include `_template_generalist`, `_template_python_developer` and
`_template_researcher` — **the templates themselves request the channel**, so
every scaffolded agent inherits the request.

A channel request therefore measures *scaffolding*, not intent. Keying an ERROR
on it would put 66 red lines on every deploy into the one panel the operator
actually checks — recreating, as a "fix", the exact noise the prune was written
to remove.

So the level splits on what was **declared**:

| case | behaviour |
|---|---|
| explicit `spec.apptainer.env: CCT_BOT_TOKEN_SLOT: <X>`, slot absent/empty in the pool | entry removed + **ERROR** |
| no declared slot (the 66) | entry removed + INFO, unchanged |
| token present | untouched |

A declared slot is the one thing here somebody had to type on purpose. It also
composes with the operational remedy: give an agent that *should* have a bot an
explicit override, and from then on any breakage screams.

The ERROR names the agent, the declared slot, the pool source
(`_pool_source_label()`), that the server was REMOVED, that the agent is mute
**and** deaf and cannot self-diagnose, and the two ways to fix it. Slot names,
paths and the agent name only — **never a token value**.

## Also: stale guidance corrected

`ensure_cct_bot_token`'s no-token WARNING still told the reader the rail merely
goes quiet — *"the telegrammer MCP comes up without a token, so the bot stays
silent until a token is provided"*. That stopped being true when the prune
landed. It now states the real consequence (entry REMOVED, mute **and** deaf).
Its three remedies are unchanged.

## Explicitly not done

`_slot_candidates` is untouched. Identity stays **declared, never inferred**
(operator ruling 2026-07-17 — inference is what let one agent take another's
bot). A host-suffixed agent like `scitex-agent-container-04` uses the explicit
`CCT_BOT_TOKEN_SLOT` override, not a stripped suffix.

## Drive-by refactor (forced, and independently right)

The change pushed `_cct_token_pool.py` over the repo's 512-line limit. The cut
was not arbitrary: `_github_token.py` was **already** importing four helpers out
of this module —

```python
from ._cct_token_pool import (  # local import: shared pool, one source
    _pool_env, _pool_source_label, _read_env_file, _write_env_file,
)
```

A GitHub-token module reaching into a Telegram module for generic env-file I/O
is the smell; the size limit only surfaced it. Those four move to a new
`runtimes/_secret_pool.py`; both consumers import from the shared toolkit and
`_cct_token_pool` keeps only CCT policy. No behaviour change.

## Tests

Both branches of the new behaviour plus the untouched case, in the module's
existing style (real files on `tmp_path`, real `AgentConfig`, `caplog` +
`scitex_logging` levels, AAA markers, one assert per test). Plus an end-to-end
test through `deploy_to_home` — the unit tests pass a config in by hand, so they
would stay green even if the call site forgot to pass one, which is exactly the
blind prune that caused the incident.

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/ywatanabe/proj/scitex-agent-container/.worktrees/agent-a029332c3e59194c2
configfile: pyproject.toml
plugins: scitex-dev-0.38.0, anyio-4.14.2, cov-7.1.0, asyncio-1.4.0, xdist-3.8.0, timeout-2.4.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 144 items

tests/scitex_agent_container/runtimes/test__cct_token_pool.py .......... [  6%]
............................................                             [ 37%]
tests/scitex_agent_container/runtimes/test__github_token.py .....        [ 40%]
tests/scitex_agent_container/runtimes/test__to_home.py ................. [ 52%]
....................................................................     [100%]

============================= 144 passed in 57.91s =============================
```

Card: `sac-cct-prune-hides-misconfigured-telegram-agent-20260810`
