### PR TITLE
feat(accounts): keepalive — push access-only credentials to peers, verified before restart

### DIFF
--- a/src/scitex_agent_container/_account/_keepalive_guards.py
+++ b/src/scitex_agent_container/_account/_keepalive_guards.py
@@ -1,0 +1,277 @@
+"""The LOCAL guards of ``sac accounts keepalive`` — every refusal lives here.
+
+Split out of :mod:`.token_keepalive` (512-line cap) along a real seam: this
+module answers the questions that need no peer — am I the origin, does this
+payload carry refresh material, is there enough validity left, would this
+downgrade a working remote credential — while ``token_keepalive`` owns the
+ORDER those answers are demanded in. Same convention as
+``snapshot_push`` / ``_snapshot_publish`` next door.
+
+Each guard exists because its absence cost a fleet outage on 2026-08-10;
+the reasoning is on each function. None of them ever returns a token, and
+none of them WRITES anything: note in particular that "does this host hold
+refresh material" is answered by the PRESENCE of a field on disk, never by
+probing whether the refresh token still works. Probing that is a write —
+when a stale refresh token was rejected with 401 that night, Claude Code
+CLEARED the refreshToken field outright.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Mapping
+
+from ._rotation_audit import fingerprint_token
+from .mint_token import MintError, mint_access_only_artifact
+
+#: Minimum remaining validity, in seconds, below which a push is REFUSED.
+#: Inherited verbatim from the shell prototype: a token that dies in
+#: flight is worse than no push, because it looks like a fix.
+MIN_VALIDITY_S = 300
+
+#: Key names that mean "refresh material" in any credential dialect seen so
+#: far. The payload is scanned for these at EVERY depth before it is sent.
+_REFRESH_KEYS = frozenset({"refreshtoken", "refresh_token"})
+
+
+class KeepaliveError(RuntimeError):
+    """A keepalive push was REFUSED or could not be completed and verified.
+
+    Always names the account, the peer or the file. NEVER carries token
+    material.
+    """
+
+
+def find_refresh_keys(payload: Any, *, path: str = "") -> list[str]:
+    """Return the dotted paths of every refresh-material key in ``payload``.
+
+    Recursive on purpose: the guard must not depend on the payload's
+    nesting shape, because the shape is exactly what changed between the
+    ``.credentials.json`` dialects involved in the incident.
+    """
+    found: list[str] = []
+    if isinstance(payload, Mapping):
+        for key, value in payload.items():
+            here = f"{path}.{key}" if path else str(key)
+            if isinstance(key, str) and key.lower() in _REFRESH_KEYS:
+                found.append(here)
+            found.extend(find_refresh_keys(value, path=here))
+    elif isinstance(payload, (list, tuple)):
+        for index, value in enumerate(payload):
+            found.extend(find_refresh_keys(value, path=f"{path}[{index}]"))
+    return found
+
+
+def assert_access_only(payload: Any, *, account: str, peer: str) -> None:
+    """Refuse a payload that still carries refresh material. Fail loud.
+
+    ``mint_access_only_artifact`` strips the refresh token by design, so
+    this guard should never fire — which is precisely why it is here. The
+    one defect this command exists to prevent is refresh material reaching
+    a second host, and a guard that only runs when the stripper is correct
+    guards nothing.
+    """
+    offenders = find_refresh_keys(payload)
+    if offenders:
+        raise KeepaliveError(
+            f"refusing to push account '{account}' to peer '{peer}': the "
+            f"payload still carries refresh material at "
+            f"{', '.join(sorted(offenders))}. Cloning a refreshToken onto a "
+            "second host is the defect this command exists to prevent — an "
+            "OAuth refresh rotates it, so whichever host refreshes first "
+            "silently revokes the other. Nothing was sent."
+        )
+
+
+def holds_refresh_material(
+    account: str,
+    *,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+) -> bool:
+    """Does THIS host's stored credential for ``account`` carry a refresh token?
+
+    The one-bit test for "am I the origin". Exactly one host in the fleet
+    should answer ``True`` for a given session; every other host holds an
+    ACCESS-ONLY copy and has nothing to fan out. Only the PRESENCE of the
+    value is read — never the value, and never its validity (checking
+    whether a refresh token still works is a write, not a read).
+    """
+    from .._state.account_store import _store_path
+    from .claude_usage import _read_tokens_at
+
+    _home = home if home is not None else Path.home()
+    creds = _store_path(store_dir, _home) / account / ".credentials.json"
+    if not creds.is_file():
+        return False
+    _access, refresh, _client_id, _expires = _read_tokens_at(creds)
+    return bool(refresh)
+
+
+def refresh_holder_accounts(
+    *,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+) -> list[str]:
+    """Every stored account THIS host holds refresh material for, sorted.
+
+    On the fleet's single refresh holder this is the exact set that should
+    fan out; on an access-only replica it is empty, which is how the
+    ``--all`` form recognises that it is running on the wrong host.
+    """
+    from .._state.account_store import list_accounts
+
+    _home = home if home is not None else Path.home()
+    names = [str(a.get("name", "")) for a in list_accounts(store_dir, _home)]
+    return sorted(
+        name
+        for name in names
+        if name and holds_refresh_material(name, store_dir=store_dir, home=_home)
+    )
+
+
+def assert_is_refresh_holder(
+    account: str,
+    *,
+    peer: str,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+) -> None:
+    """Refuse to fan out from a host that is itself an access-only replica.
+
+    Distribution has a DIRECTION: refresh holder → everyone else. A replica
+    re-pushing its own borrowed token is at best pointless and at worst
+    papers over the fact that nothing is refreshing anywhere, which is the
+    silent shape of the outage this command exists to end.
+
+    This is also the sac-side mitigation for a real gap: ``scitex_dev``'s
+    ``JobSpec`` has NO host-pinning field, so a scheduled keepalive cannot
+    declare "only on the refresh holder". It can only refuse when it wakes
+    up somewhere else — which is what this does.
+    """
+    if not holds_refresh_material(account, store_dir=store_dir, home=home):
+        raise KeepaliveError(
+            f"refusing to push account '{account}' to peer '{peer}': THIS "
+            "host holds no refresh material for that account, so it is an "
+            "access-only replica, not the origin. Distribution runs refresh "
+            "holder -> replicas, one way. Run this on the host that holds "
+            "the refresh token (`sac accounts list` shows the stored "
+            "accounts; the holder is the one host that can run `sac accounts "
+            "refresh`)."
+        )
+
+
+def seconds_left(expires_at_ms: int | None, now_s: float) -> int:
+    """Whole seconds until ``expires_at_ms`` (unix ms). Negative = expired."""
+    if not expires_at_ms:
+        return 0
+    return int(expires_at_ms / 1_000 - now_s)
+
+
+def build_payload(
+    account: str,
+    *,
+    peer: str,
+    min_validity_s: int = MIN_VALIDITY_S,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Read the master's CURRENT token and render the access-only bytes.
+
+    Delegates the read + strip + health gate wholly to
+    :func:`~.mint_token.mint_access_only_artifact` (no second stripper
+    exists), then applies the two guards that are this command's own: the
+    refresh-material scan and the minimum-validity floor.
+
+    Returns ``{"bytes", "expires_at_ms", "seconds_left", "access_fp"}``.
+    The bytes are the only place a token value appears, and they are never
+    written to a local file.
+
+    Raises:
+        KeepaliveError: unknown/unhealthy account, refresh material
+            present, or too little validity left to be worth pushing.
+    """
+    now_s = now if now is not None else time.time()
+    try:
+        envelope = mint_access_only_artifact(
+            account, store_dir=store_dir, home=home, now=now_s
+        )
+    except MintError as exc:
+        raise KeepaliveError(
+            f"cannot keep account '{account}' alive on peer '{peer}': {exc}"
+        ) from exc
+
+    artifact = envelope["artifact"]
+    assert_access_only(artifact, account=account, peer=peer)
+
+    expires_at_ms = int(envelope["meta"]["expires_at"])
+    left = seconds_left(expires_at_ms, now_s)
+    if left < min_validity_s:
+        raise KeepaliveError(
+            f"refusing to push account '{account}' to peer '{peer}': the "
+            f"master token has {left}s of validity left, under the "
+            f"{min_validity_s}s floor. A token that expires in flight is "
+            "worse than no push — it looks like the problem was addressed. "
+            "Re-run after the master refreshes (`sac accounts refresh`)."
+        )
+
+    # stx-allow: STX-IO006 (reason: stdlib json is REQUIRED here, not a
+    # shortcut. These bytes are OAuth token material headed for a peer's
+    # stdin; routing them through stx.io would mean SERIALISING A SECRET TO
+    # A LOCAL FILE, which this module's secrecy contract forbids outright.
+    # There is also no provenance to track — the payload is a credential,
+    # not a research artifact.)
+    rendered = json.dumps(artifact, ensure_ascii=False)  # stx-allow: STX-IO006
+
+    return {
+        "bytes": rendered.encode("utf-8"),
+        "expires_at_ms": expires_at_ms,
+        "seconds_left": left,
+        "access_fp": fingerprint_token(artifact["claudeAiOauth"]["accessToken"]),
+    }
+
+
+def assert_not_downgrading(
+    state: Mapping[str, Any],
+    *,
+    account: str,
+    peer: str,
+    expires_at_ms: int,
+    now_s: float,
+) -> None:
+    """Refuse to replace a STILL-VALID remote credential with a dead one.
+
+    The validity floor already refuses an expired payload, but that floor
+    is caller-tunable (``--min-validity 0``). This guard is not: a peer
+    whose credential still works must never be knocked over by one that
+    does not, whatever the operator passed.
+    """
+    if state.get("absent"):
+        return
+    remote_left = seconds_left(state.get("expires_at_ms"), now_s)
+    payload_left = seconds_left(expires_at_ms, now_s)
+    if payload_left <= 0 < remote_left:
+        raise KeepaliveError(
+            f"refusing to push account '{account}' to peer '{peer}': the "
+            f"payload is already expired ({payload_left}s) while the peer's "
+            f"current credential is still valid ({remote_left}s left). "
+            "Overwriting a working credential with a dead one would take the "
+            "peer down. The peer was left untouched."
+        )
+
+
+__all__ = [
+    "MIN_VALIDITY_S",
+    "KeepaliveError",
+    "assert_access_only",
+    "assert_is_refresh_holder",
+    "assert_not_downgrading",
+    "build_payload",
+    "find_refresh_keys",
+    "holds_refresh_material",
+    "refresh_holder_accounts",
+    "seconds_left",
+]

--- a/src/scitex_agent_container/_account/_keepalive_remote.py
+++ b/src/scitex_agent_container/_account/_keepalive_remote.py
@@ -1,0 +1,299 @@
+"""Far-side operations for ``sac accounts keepalive`` (probe / backup / verify).
+
+Split out of :mod:`.token_keepalive` (512-line cap) along a real seam: this
+module owns everything that RUNS ON THE PEER, the other owns the local
+guards and the orchestration order.
+
+Every operation rides the SAME injectable
+:class:`~.snapshot_push.PeerTransport` the snapshot push already uses, so
+the peer's ``ssh:`` target, its ``via:`` ProxyJump chain and sac's
+BatchMode / ControlMaster policy all come from the ONE peer table in
+``~/.scitex/agent-container/config.yaml``. No second host config exists.
+
+WHY A PROBE SCRIPT AND NOT A ONE-LINER
+--------------------------------------
+OpenSSH joins the post-host argv with spaces and the peer's login shell
+re-parses the result, so a python ``-c`` one-liner would have to survive
+two parses — and the original shell prototype paid for that with a
+``curl -H "authorization: Bearer $T"``, which puts the ACCESS TOKEN in
+the peer's process table for every user on that box to read.
+
+So the probe is a FILE. It is streamed to the peer over the transport's
+stdin (never an argv, never an environment variable), invoked with two
+whitespace-free tokens (``state`` / ``verify`` plus a validated path),
+reads the credential itself, and prints only an expiry in milliseconds,
+opaque ``sha256:`` fingerprints, and an HTTP status code. A token value
+never enters an argv, a log line, or this module's return values.
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+from .snapshot_push import (
+    DIR_MODE,
+    FILE_MODE,
+    PeerTransport,
+    SnapshotPushError,
+    _assert_safe_remote_path,
+    _op,
+)
+
+#: Name of the probe, dropped beside the credential inside the 0700 account
+#: directory and removed again by the caller's ``finally``. Fixed (not
+#: random) so a crashed run leaves at most ONE stale file, which the next
+#: run overwrites.
+PROBE_NAME = ".sac-keepalive-probe.py"
+#: The probe is executable-by-owner only; it is code, not data.
+PROBE_MODE = "700"
+
+#: The endpoint the far side must answer 200 on. Same one the shell
+#: prototype curl'd — a cheap authenticated GET.
+VERIFY_URL = "https://api.anthropic.com/v1/models"
+
+# The probe. Pure stdlib (urllib, hashlib) so it needs nothing installed on
+# the peer beyond the ``python3`` the prototype already required. It prints
+# ONLY: an integer expiry, `sha256:<12hex>` fingerprints, `-`, `absent:1`,
+# an HTTP status code, or `error:<ExceptionClass>`. Never token material.
+_PROBE_SOURCE = """\
+import hashlib
+import json
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+VERIFY_URL = "__VERIFY_URL__"
+
+
+def fp(value):
+    if not value:
+        return "-"
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+
+
+def main():
+    mode = sys.argv[1]
+    path = pathlib.Path(sys.argv[2])
+    try:
+        raw = json.loads(path.read_text())
+    except Exception:
+        print("absent:1")
+        return 0
+    oauth = raw.get("claudeAiOauth", raw)
+    if not isinstance(oauth, dict):
+        print("absent:1")
+        return 0
+    if mode == "state":
+        try:
+            expiry = int(oauth.get("expiresAt", 0))
+        except (TypeError, ValueError):
+            expiry = 0
+        print("expiry:%d" % expiry)
+        print("access_fp:%s" % fp(oauth.get("accessToken")))
+        print("refresh_fp:%s" % fp(oauth.get("refreshToken")))
+        return 0
+    token = oauth.get("accessToken")
+    if not token:
+        print("notoken:1")
+        return 0
+    request = urllib.request.Request(
+        VERIFY_URL,
+        headers={
+            "authorization": "Bearer " + token,
+            "anthropic-beta": "oauth-2025-04-20",
+            "anthropic-version": "2023-06-01",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            print("http:%d" % response.status)
+    except urllib.error.HTTPError as exc:
+        print("http:%d" % exc.code)
+    except Exception as exc:
+        print("error:%s" % type(exc).__name__)
+    return 0
+
+
+sys.exit(main())
+"""
+
+
+def probe_source(verify_url: str | None = None) -> bytes:
+    """The probe's bytes, with the verify endpoint substituted in.
+
+    ``verify_url`` is a seam so a test can point the REAL probe at a REAL
+    local HTTP server and exercise the real urllib call, rather than
+    mocking the one step whose whole purpose is to make a real request.
+    ``None`` resolves :data:`VERIFY_URL` AT CALL TIME — never as a default
+    argument, which would bind the production endpoint at import and send
+    a test's traffic to the live API.
+    """
+    url = verify_url if verify_url is not None else VERIFY_URL
+    return _PROBE_SOURCE.replace("__VERIFY_URL__", url).encode("utf-8")
+
+
+def probe_path(remote_path: str) -> str:
+    """Where the probe lives on the peer: beside ``remote_path``."""
+    return str(PurePosixPath(remote_path).parent / PROBE_NAME)
+
+
+def ensure_remote_dir(transport: PeerTransport, remote_path: str) -> str:
+    """``mkdir -p`` + ``chmod 700`` the peer's account directory.
+
+    Hardened BEFORE anything is written into it, so neither the probe nor
+    a staged credential can be world-readable for even the instant between
+    creation under the remote umask and its own ``chmod``.
+    """
+    _assert_safe_remote_path(remote_path, transport.peer)
+    remote_dir = str(PurePosixPath(remote_path).parent)
+    _op(transport, ["mkdir", "-p", remote_dir], what="create", path=remote_dir)
+    _op(transport, ["chmod", DIR_MODE, remote_dir], what="harden", path=remote_dir)
+    return remote_dir
+
+
+def install_probe(
+    transport: PeerTransport, remote_path: str, *, verify_url: str | None = None
+) -> str:
+    """Stream the probe onto the peer (0700) and return its path."""
+    path = probe_path(remote_path)
+    _assert_safe_remote_path(path, transport.peer)
+    _op(
+        transport,
+        ["dd", f"of={path}"],
+        what="write",
+        path=path,
+        stdin=probe_source(verify_url),
+    )
+    _op(transport, ["chmod", PROBE_MODE, path], what="harden", path=path)
+    return path
+
+
+def remove_probe(transport: PeerTransport, remote_path: str) -> None:
+    """Best-effort probe removal. Never raises — it runs in a ``finally``."""
+    # stx-allow: fallback (reason: cleanup in a `finally`; a transport error
+    # here must never replace the real diagnosis the caller is raising, and
+    # a leftover 0700 probe carries no secret. The next run overwrites it.)
+    try:
+        transport.run(["rm", "-f", probe_path(remote_path)])
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        pass
+
+
+def _run_probe(
+    transport: PeerTransport, probe: str, mode: str, remote_path: str
+) -> list[str]:
+    """Run the probe in ``mode`` and return its non-blank output lines."""
+    result = transport.run(["python3", probe, mode, remote_path])
+    if result.returncode != 0:
+        raise SnapshotPushError(
+            f"cannot run the keepalive probe on peer '{transport.peer}': "
+            f"`python3 {probe} {mode}` exited {result.returncode}. The peer "
+            f"needs a python3 on PATH. Nothing was changed on {remote_path}."
+        )
+    return [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+
+
+def read_remote_state(
+    transport: PeerTransport, probe: str, remote_path: str
+) -> dict[str, object]:
+    """Describe the credential currently living at ``remote_path``.
+
+    Returns ``{"absent": bool, "expires_at_ms": int | None,
+    "access_fp": str | None, "refresh_fp": str | None}`` — an expiry, two
+    opaque fingerprints, nothing else. ``refresh_fp`` being non-``None`` is
+    itself a finding: it means the peer is holding REFRESH material, i.e.
+    it is a cloned session of the kind this command exists to stop.
+    """
+    lines = _run_probe(transport, probe, "state", remote_path)
+    if not lines or lines[0] == "absent:1":
+        return {
+            "absent": True,
+            "expires_at_ms": None,
+            "access_fp": None,
+            "refresh_fp": None,
+        }
+    fields: dict[str, str] = {}
+    for line in lines:
+        key, sep, value = line.partition(":")
+        if sep:
+            fields[key] = value
+    try:
+        expiry = int(fields.get("expiry", "0"))
+    except ValueError:
+        expiry = 0
+
+    def _fp(key: str) -> str | None:
+        value = fields.get(key, "-")
+        return None if value in ("", "-") else value
+
+    return {
+        "absent": False,
+        "expires_at_ms": expiry or None,
+        "access_fp": _fp("access_fp"),
+        "refresh_fp": _fp("refresh_fp"),
+    }
+
+
+def verify_remote_token(transport: PeerTransport, probe: str, remote_path: str) -> int:
+    """Return the HTTP status the PEER's own copy of the token receives.
+
+    This is the load-bearing step: it proves the far side accepts what was
+    just published BEFORE anything is restarted onto it. A prototype run
+    that skipped it restarted a fleet onto an unverified token and wasted
+    the round.
+
+    Raises :class:`~.snapshot_push.SnapshotPushError` when the probe could
+    not reach a status at all (DNS, TLS, proxy) — an unverifiable token is
+    a failure, never an assumption.
+    """
+    lines = _run_probe(transport, probe, "verify", remote_path)
+    head = lines[0] if lines else ""
+    key, _sep, value = head.partition(":")
+    if key == "http" and value.isdigit():
+        return int(value)
+    if key == "error":
+        raise SnapshotPushError(
+            f"peer '{transport.peer}' could not reach {VERIFY_URL} to verify "
+            f"{remote_path} ({value}). NOT restarting anything."
+        )
+    raise SnapshotPushError(
+        f"peer '{transport.peer}' returned no usable verification result for "
+        f"{remote_path} (probe said {head!r}). NOT restarting anything."
+    )
+
+
+def backup_remote(
+    transport: PeerTransport, remote_path: str, *, stamp: str
+) -> str | None:
+    """Copy the peer's CURRENT credential aside before it is replaced.
+
+    Returns the backup path, or ``None`` when there was nothing to back up
+    (first push to this peer). The copy is re-``chmod``-ed 0600 rather than
+    trusted to ``cp -p``, for the same reason the push reads its mode back:
+    a filesystem that ignores mode bits must not be left holding a
+    world-readable OAuth token.
+    """
+    exists = transport.run(["test", "-f", remote_path])
+    if exists.returncode != 0:
+        return None
+    backup = f"{remote_path}.bak-{stamp}"
+    _assert_safe_remote_path(backup, transport.peer)
+    _op(transport, ["cp", "-p", remote_path, backup], what="back up", path=backup)
+    _op(transport, ["chmod", FILE_MODE, backup], what="harden", path=backup)
+    return backup
+
+
+__all__ = [
+    "PROBE_MODE",
+    "PROBE_NAME",
+    "VERIFY_URL",
+    "backup_remote",
+    "ensure_remote_dir",
+    "install_probe",
+    "probe_path",
+    "probe_source",
+    "read_remote_state",
+    "remove_probe",
+    "verify_remote_token",
+]

--- a/src/scitex_agent_container/_account/_snapshot_publish.py
+++ b/src/scitex_agent_container/_account/_snapshot_publish.py
@@ -1,0 +1,140 @@
+"""Publish a VERIFIED staged credential onto its live path on a peer.
+
+Split out of :mod:`.snapshot_push` (512-line cap) along a real seam: that
+module owns staging + verification, this one owns the last two steps —
+making the staged file live, and proving the live path is what was
+verified.
+
+WHY THIS IS NOT JUST ``mv``
+---------------------------
+The normal publish is an atomic same-directory rename, so an agent that
+happens to open the snapshot mid-push can never read a torn file. But on
+a host where the credential is BIND-MOUNTED into a container, rename onto
+that path fails::
+
+    OSError: [Errno 16] Device or resource busy
+
+A rename cannot cross a bind mount — the destination is a mount point, not
+an ordinary directory entry. Measured 2026-08-10 while stripping the
+laptop's credential to access-only; the write had to be done in place.
+
+Those are exactly the hosts this machinery exists for, so an EBUSY must
+not be a failure and must not be swallowed either. It falls back to a
+DELIBERATE in-place write, and the method actually taken (``"rename"`` or
+``"in-place"``) is returned so every caller can say which one happened.
+The in-place write is honestly worse — it is not atomic, so a concurrent
+reader can observe a partial file for the duration of one small write —
+and it is taken only when the atomic path is impossible.
+"""
+
+from __future__ import annotations
+
+from .snapshot_push import (
+    FILE_MODE,
+    PeerTransport,
+    RunResult,
+    SnapshotPushError,
+    _discard,
+    _op,
+    _tail,
+    stat_remote,
+)
+
+#: Publish methods, in preference order.
+RENAME = "rename"
+IN_PLACE = "in-place"
+
+# What a kernel / coreutils says when a rename hits a mount point. Matched
+# case-insensitively against the remote `mv`'s stderr. Deliberately narrow:
+# ANY other `mv` failure is a real failure and must stay loud.
+_BUSY_MARKERS = (
+    "device or resource busy",
+    "resource busy",
+    "text file busy",
+    "ebusy",
+)
+
+
+def looks_busy(result: RunResult) -> bool:
+    """True when a failed remote ``mv`` failed because the target is busy."""
+    text = (result.stderr or "").lower()
+    return any(marker in text for marker in _BUSY_MARKERS)
+
+
+def publish_verified(
+    account: str,
+    *,
+    transport: PeerTransport,
+    staged: str,
+    remote: str,
+    payload: bytes,
+) -> tuple[str, str, int]:
+    """Make ``staged`` live at ``remote``, then prove the live path.
+
+    Prefers the atomic same-directory rename. On EBUSY — a bind-mounted
+    destination — falls back to writing the bytes in place, re-hardening
+    to 0600 and discarding the staged file. Either way the LIVE path's
+    mode and size are read back off the peer afterwards: ``mv`` preserves
+    both, so a mismatch means the peer's filesystem mutated the file, and
+    the in-place path must prove itself for the same reason the staged
+    write did.
+
+    Args:
+        account: for error messages only.
+        transport: the peer transfer seam.
+        staged: the verified staging path (0600, correct size).
+        remote: the live path to publish onto.
+        payload: the same bytes already staged — re-sent only on the
+            in-place fallback, over the transport's stdin as always.
+
+    Returns:
+        ``(method, mode, size)`` where ``method`` is :data:`RENAME` or
+        :data:`IN_PLACE`. The caller is expected to REPORT the method: an
+        in-place publish is a fact about that host worth seeing.
+
+    Raises:
+        SnapshotPushError: a non-EBUSY ``mv`` failure, a failed in-place
+            write, or a live path that does not verify.
+    """
+    method = RENAME
+    moved = transport.run(["mv", "-f", staged, remote])
+    if moved.returncode != 0:
+        if not looks_busy(moved):
+            raise SnapshotPushError(
+                f"failed to publish {remote} on peer '{transport.peer}' "
+                f"(`mv` exited {moved.returncode})"
+                f"{_tail(moved.stderr)}"
+            )
+        # EBUSY: the destination is a bind mount, so the atomic rename is
+        # IMPOSSIBLE, not merely unlucky. Take the honest, non-atomic path
+        # and say so — never silently.
+        method = IN_PLACE
+        _op(
+            transport,
+            ["dd", f"of={remote}"],
+            what="write in place (bind-mounted, rename refused with EBUSY)",
+            path=remote,
+            stdin=payload,
+        )
+        _op(transport, ["chmod", FILE_MODE, remote], what="harden", path=remote)
+        _discard(transport, staged)
+
+    mode, remote_size = stat_remote(transport, remote)
+    if mode != FILE_MODE or remote_size != len(payload):
+        # A mode/size mismatch on the LIVE path means the peer's filesystem
+        # mutated the file — hostile. Remove it rather than leave a token
+        # whose mode cannot be vouched for. (An unreachable `stat` raises
+        # from `stat_remote` above and deletes nothing: that inode was
+        # already proven complete and 0600 before it was published.)
+        _discard(transport, remote)
+        raise SnapshotPushError(
+            f"account '{account}' published to peer '{transport.peer}' at "
+            f"{remote} via {method} did NOT verify (mode 0{mode}, "
+            f"{remote_size} bytes; expected 0{FILE_MODE}, {len(payload)} "
+            "bytes). The file has been removed from the peer rather than "
+            "left unverified."
+        )
+    return method, mode, remote_size
+
+
+__all__ = ["IN_PLACE", "RENAME", "looks_busy", "publish_verified"]

--- a/src/scitex_agent_container/_account/snapshot_push.py
+++ b/src/scitex_agent_container/_account/snapshot_push.py
@@ -154,9 +154,7 @@ def ssh_op_argv(
     """
     from .._state.host_config import build_ssh_argv
 
-    return build_ssh_argv(
-        peer, list(command), _peers_with_lean_preamble(peer, peers)
-    )
+    return build_ssh_argv(peer, list(command), _peers_with_lean_preamble(peer, peers))
 
 
 @dataclasses.dataclass(frozen=True)
@@ -172,9 +170,7 @@ class SshTransport:
     peers: Mapping[str, "PeerSpec"]
     timeout_s: float = _DEFAULT_TIMEOUT_S
 
-    def run(
-        self, command: Sequence[str], *, stdin: bytes | None = None
-    ) -> RunResult:
+    def run(self, command: Sequence[str], *, stdin: bytes | None = None) -> RunResult:
         argv = ssh_op_argv(self.peer, command, self.peers)
         try:
             proc = subprocess.run(
@@ -336,6 +332,7 @@ def push_snapshot(
     *,
     transport: PeerTransport,
     remote_path: str | None = None,
+    payload: bytes | None = None,
 ) -> dict[str, Any]:
     """Copy one refreshed snapshot to the peer, at the IDENTICAL abs path.
 
@@ -351,29 +348,34 @@ def push_snapshot(
        remote ``dd`` exiting 0 on a TRUNCATED file, which would publish a
        corrupt credential. Any mismatch removes the staged file and raises
        — the peer keeps its previous snapshot, untouched.
-    4. Publish with an atomic same-directory ``mv -f``.
-    5. Prove the LIVE path is what was verified. ``mv`` preserves mode and
-       contents, so a mismatch here means the peer's filesystem mutated the
-       file on rename — hostile; the file is removed rather than left as a
-       token whose mode cannot be vouched for. A ``stat`` that cannot RUN
-       at all (transport failure) still fails the run loud but does NOT
-       delete: that same inode was already proven 0600 and complete before
-       the rename, so deleting would strip the peer of its credentials for
-       no security gain.
+    4. Publish — an atomic same-directory ``mv -f``, or a DELIBERATE
+       in-place write when the destination is a bind mount and rename is
+       therefore impossible (EBUSY). See :mod:`._snapshot_publish`; the
+       method actually taken comes back in the record's ``publish`` key so
+       the caller can report it.
+    5. Prove the LIVE path is what was verified.
 
     Args:
         account: account name, for the returned record + error messages.
         local_path: the freshly-rotated snapshot on THIS host. Must be an
-            absolute path to an existing file.
+            absolute path; must be an existing file unless ``payload``
+            supplies the bytes, in which case it only supplies the peer's
+            identical destination path.
         transport: the transfer seam. Defaults are supplied by the caller
             (:func:`resolve_peer_transport` builds the real ssh one).
         remote_path: override the destination. Defaults to the IDENTICAL
             absolute path — a peer whose layout matches (the fleet's
             ``/home/ywatanabe`` convention) needs no mapping.
+        payload: send THESE bytes instead of reading ``local_path``. The
+            seam ``sac accounts keepalive`` uses to push an ACCESS-ONLY
+            rendering of a snapshot whose on-disk form still carries the
+            refresh token — the stripped bytes exist only in memory and are
+            never written to a local file.
 
     Returns:
-        ``{"account", "peer", "local_path", "remote_path", "mode", "bytes"}``
-        — paths, an account name and a verified mode. Never a token.
+        ``{"account", "peer", "local_path", "remote_path", "mode", "bytes",
+        "publish"}`` — paths, an account name, a verified mode and the
+        publish method. Never a token.
 
     Raises:
         SnapshotPushError: on ANY failure, naming the peer and the path.
@@ -385,7 +387,7 @@ def push_snapshot(
             f"'{transport.peer}': local snapshot path {local!s} is not "
             "absolute, so the peer's identical path cannot be derived."
         )
-    if not local.is_file():
+    if payload is None and not local.is_file():
         raise SnapshotPushError(
             f"refusing to push account '{account}' to peer "
             f"'{transport.peer}': no snapshot at {local!s}."
@@ -396,7 +398,8 @@ def push_snapshot(
     staged = remote + STAGED_SUFFIX
     remote_dir = str(PurePosixPath(remote).parent)
 
-    payload = local.read_bytes()
+    if payload is None:
+        payload = local.read_bytes()
     size = len(payload)
 
     # 1. An 0700 directory FIRST.
@@ -435,20 +438,17 @@ def push_snapshot(
         _discard(transport, staged)
         raise
 
-    # 4. Publish atomically.
-    _op(transport, ["mv", "-f", staged, remote], what="publish", path=remote)
+    # 4-5. Publish (atomic rename, or a deliberate in-place write on a
+    # bind-mounted destination) and prove the LIVE path.
+    from ._snapshot_publish import publish_verified
 
-    # 5. Prove the LIVE path. (See the docstring for why a mode/size
-    # mismatch deletes but an unreachable `stat` does not.)
-    mode, remote_size = stat_remote(transport, remote)
-    if mode != FILE_MODE or remote_size != size:
-        _discard(transport, remote)
-        raise SnapshotPushError(
-            f"account '{account}' published to peer '{transport.peer}' at "
-            f"{remote} did NOT verify (mode 0{mode}, {remote_size} bytes; "
-            f"expected 0{FILE_MODE}, {size} bytes). The file has been "
-            "removed from the peer rather than left unverified."
-        )
+    method, mode, remote_size = publish_verified(
+        account,
+        transport=transport,
+        staged=staged,
+        remote=remote,
+        payload=payload,
+    )
 
     return {
         "account": account,
@@ -456,7 +456,8 @@ def push_snapshot(
         "local_path": str(local),
         "remote_path": remote,
         "mode": mode,
-        "bytes": size,
+        "bytes": remote_size,
+        "publish": method,
     }
 
 

--- a/src/scitex_agent_container/_account/token_keepalive.py
+++ b/src/scitex_agent_container/_account/token_keepalive.py
@@ -1,0 +1,376 @@
+"""Keep a peer's ACCESS-ONLY credential alive — the engine behind ``keepalive``.
+
+WHY THIS EXISTS (measured, 2026-08-10)
+--------------------------------------
+The fleet died three times in one day on ``401 OAuth access token has been
+revoked``. Fingerprinting the credential material across hosts — values
+never read — showed why::
+
+    host              refreshToken fp   accessToken fp
+    laptop            7fcccfdcdf9f      571181f2ae95
+    scitex-compute-04 7fcccfdcdf9f      571181f2ae95   <- IDENTICAL
+    scitex-nas-03     0ca3dd5e0632      705b3573d08b   <- separate session
+
+The laptop and compute-04 were the SAME OAuth session cloned onto two
+machines, REFRESH TOKEN INCLUDED. An OAuth refresh rotates the refresh
+token and invalidates the previous access token, so whichever host
+refreshed first silently revoked the other. There is no error on the
+losing side; it simply starts 401ing.
+
+The invariant is now REAL, not aspirational: ``scitex-nas-03`` holds the
+fleet's ONLY refresh token, and the laptop and compute-04 have been
+stripped to access-only and verified by fingerprint. That state is not
+self-sustaining — an access-only host cannot renew what it holds, so
+without this module those hosts simply expire.
+
+ORDER IS THE WHOLE VALUE
+------------------------
+Each step exists because skipping it cost a fleet outage:
+
+1. **COPY, never mint anew.** Minting ROTATES, and rotation revokes the
+   token every running agent is currently holding — that is what killed
+   ten agents on the morning of 2026-08-10. The master's CURRENT stored
+   token is read and copied; nothing is refreshed here, and no attempt is
+   ever made to PROVOKE a refresh.
+2. **Refuse below ~300s of validity.** A token that expires in flight is
+   worse than none: it looks like the problem was addressed.
+3. **Refuse to overwrite a still-valid remote credential with a dead
+   one**, and refuse outright to send anything carrying refresh material
+   — cloning refresh material is the defect this command prevents.
+4. **Back up what is replaced**, then publish atomically at 0600 (or, on
+   a bind-mounted destination where rename is impossible, deliberately in
+   place — see :mod:`._snapshot_publish`).
+5. **Verify the FAR SIDE returns HTTP 200 before restarting anything.**
+   A round that skipped this restarted agents onto an unverified token
+   and was wasted.
+6. **Only then** sweep the peer's 401ing agents — and only when asked.
+
+CONVERGENT, NOT TICK-DRIVEN
+---------------------------
+Measured the same day: invoking ``claude -p`` on the master did NOT
+rotate anything — the access fingerprint and expiry were identical before
+and after, because Claude Code refreshes only when the token is genuinely
+near expiry. So a job that fires on a clock and pushes unconditionally is
+a no-op for most of a ~7h token's life and does the real work only in the
+run that happens to straddle the refresh. This module instead compares
+FINGERPRINTS and pushes when they differ, which converges after any
+refresh however it was triggered. The schedule then only bounds the
+post-refresh gap; it does not decide what the work is.
+
+SECRECY CONTRACT (HARD)
+-----------------------
+No token value is ever printed, logged, returned or written to a local
+file. Every record this module produces carries paths, hostnames,
+expiry-in-seconds and opaque ``sha256:`` fingerprints — nothing else.
+The access token exists here only as in-memory bytes that travel once,
+over the transport's stdin, into the peer's ``dd``.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from ._keepalive_guards import (
+    MIN_VALIDITY_S,
+    KeepaliveError,
+    assert_access_only,
+    assert_is_refresh_holder,
+    assert_not_downgrading,
+    build_payload,
+    find_refresh_keys,
+    holds_refresh_material,
+    refresh_holder_accounts,
+    seconds_left,
+)
+from ._keepalive_remote import (
+    backup_remote,
+    ensure_remote_dir,
+    install_probe,
+    read_remote_state,
+    remove_probe,
+    verify_remote_token,
+)
+from .snapshot_push import PeerTransport, push_snapshot
+
+#: The one status that licenses a restart on the far side.
+VERIFY_OK = 200
+
+# What a NON-LOGIN remote shell says when the command is not on its PATH.
+# Measured 2026-08-10: `ssh host 'claude ...'` answered "No such file or
+# directory" — not a credential failure, a PATH failure, because sshd's
+# non-login shell never sources the profile block that puts the fleet's
+# tools on PATH. Any remote invocation of a NON-coreutils command has to
+# reckon with this.
+_NOT_FOUND_MARKERS = ("command not found", "no such file or directory")
+_NOT_FOUND_CODES = (126, 127)
+
+
+def keepalive_push(
+    account: str,
+    peer: str,
+    *,
+    transport: PeerTransport | None = None,
+    min_validity_s: int = MIN_VALIDITY_S,
+    remote_path: str | None = None,
+    force: bool = False,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+    now: float | None = None,
+    verify_url: str | None = None,
+) -> dict[str, Any]:
+    """Converge ``peer`` onto the master's access token and PROVE it works.
+
+    Runs the ordering documented at the top of this module. Every failure
+    raises, naming the account and the peer — there is no silent-success
+    path, because a silent failure is exactly how the 2026-08-10 outage
+    stayed invisible for two hours.
+
+    When the peer's fingerprint ALREADY matches the master's, nothing is
+    published (no write, no backup) but the far side is still verified —
+    so a run that has no work to do still answers "is this peer able to
+    authenticate", which is the question that matters. ``force`` publishes
+    regardless.
+
+    Args:
+        account: the stored-account slug on the MASTER (the only host that
+            holds refresh material).
+        peer: a peer key from ``~/.scitex/agent-container/config.yaml``.
+        transport: the transfer seam; ``None`` builds the real ssh
+            transport from sac's peer table.
+        min_validity_s: refuse when the master token has less than this
+            many seconds left.
+        remote_path: override the destination. Defaults to the IDENTICAL
+            absolute path the snapshot occupies on the master.
+        force: publish even when the peer already holds this exact token.
+        store_dir, home, now: test seams.
+        verify_url: the endpoint the peer must answer 200 on. ``None`` uses
+            the real API. A seam so a test can point the REAL probe at a
+            REAL local server instead of faking the one step whose entire
+            purpose is to make a real request.
+
+    Returns:
+        A record of paths, fingerprints and expiries — never a token. Its
+        ``action`` is ``"pushed"`` or ``"already-current"``::
+
+            {"account", "peer", "action", "remote_path", "backup_path",
+             "mode", "bytes", "publish", "expires_at_ms", "seconds_left",
+             "access_fp", "previous_access_fp", "previous_seconds_left",
+             "peer_held_refresh_material", "verify_status"}
+
+    Raises:
+        KeepaliveError: any refusal, or a far side that does not answer 200.
+        SnapshotPushError: a transport / verification failure on the peer.
+    """
+    now_s = now if now is not None else time.time()
+    assert_is_refresh_holder(account, peer=peer, store_dir=store_dir, home=home)
+    payload = build_payload(
+        account,
+        peer=peer,
+        min_validity_s=min_validity_s,
+        store_dir=store_dir,
+        home=home,
+        now=now_s,
+    )
+
+    from .._state.account_store import _store_path
+
+    local_home = home if home is not None else Path.home()
+    local_path = _store_path(store_dir, local_home) / account / ".credentials.json"
+    remote = remote_path if remote_path is not None else str(local_path)
+
+    if transport is None:
+        from .snapshot_push import resolve_peer_transport
+
+        transport = resolve_peer_transport(peer)
+
+    ensure_remote_dir(transport, remote)
+    probe = install_probe(transport, remote, verify_url=verify_url)
+    try:
+        state = read_remote_state(transport, probe, remote)
+        current = (
+            not state["absent"]
+            and state["access_fp"] is not None
+            and state["access_fp"] == payload["access_fp"]
+        )
+
+        backup: str | None = None
+        published: dict[str, Any] = {
+            "remote_path": remote,
+            "mode": None,
+            "bytes": None,
+            "publish": None,
+        }
+        if current and not force:
+            action = "already-current"
+        else:
+            action = "pushed"
+            assert_not_downgrading(
+                state,
+                account=account,
+                peer=peer,
+                expires_at_ms=payload["expires_at_ms"],
+                now_s=now_s,
+            )
+            stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(now_s))
+            backup = backup_remote(transport, remote, stamp=stamp)
+            published = push_snapshot(
+                account,
+                local_path,
+                transport=transport,
+                remote_path=remote,
+                payload=payload["bytes"],
+            )
+
+        status = verify_remote_token(transport, probe, remote)
+        if status != VERIFY_OK:
+            raise KeepaliveError(
+                _reject_message(account, peer, remote, status, action, backup)
+            )
+    finally:
+        remove_probe(transport, remote)
+
+    return {
+        "account": account,
+        "peer": peer,
+        "action": action,
+        "remote_path": published["remote_path"],
+        "backup_path": backup,
+        "mode": published["mode"],
+        "bytes": published["bytes"],
+        "publish": published["publish"],
+        "expires_at_ms": payload["expires_at_ms"],
+        "seconds_left": payload["seconds_left"],
+        "access_fp": payload["access_fp"],
+        "previous_access_fp": state["access_fp"],
+        "previous_seconds_left": (
+            None if state["absent"] else seconds_left(state["expires_at_ms"], now_s)
+        ),
+        "peer_held_refresh_material": bool(state["refresh_fp"]),
+        "verify_status": status,
+    }
+
+
+def _reject_message(
+    account: str,
+    peer: str,
+    remote: str,
+    status: int,
+    action: str,
+    backup: str | None,
+) -> str:
+    """Diagnose a far side that refused the credential. Never a token."""
+    if action == "already-current":
+        # The peer holds EXACTLY the master's token and that token is being
+        # refused — so the master's own token is dead, and no amount of
+        # pushing will fix it. Say that, rather than reporting a peer fault.
+        return (
+            f"peer '{peer}' was ALREADY holding the master's exact token for "
+            f"account '{account}' and it is REJECTED (HTTP {status}). Nothing "
+            "was changed. This is a MASTER-side failure, not a peer one: the "
+            "master's own access token has been revoked or expired. "
+            "Re-authenticate on the refresh holder, then re-run."
+        )
+    return (
+        f"peer '{peer}' REJECTED the credential just published at {remote} "
+        f"(HTTP {status}). NOT restarting anything on '{peer}'. The previous "
+        f"credential is preserved at "
+        f"{backup or '(none — this was the first push)'}."
+    )
+
+
+def _looks_missing(returncode: int, stderr: str) -> bool:
+    """True when a remote command failed because it was not on the PATH."""
+    text = (stderr or "").lower()
+    return returncode in _NOT_FOUND_CODES or any(
+        marker in text for marker in _NOT_FOUND_MARKERS
+    )
+
+
+def sweep_login_expired(peer: str, *, run_fn: Callable[..., Any] | None = None) -> str:
+    """Restart the peer's agents that are wedged on auth. Runs LAST, or never.
+
+    A push alone does not revive a 401ing agent: a running ``claude`` holds
+    its token in memory, so replacing the file on disk changes nothing
+    until the process restarts. This is the sweep leg — the sac-native
+    equivalent of the prototype's ``restart-401.sh``, dispatched as ``sac
+    agents restart-login-expired --apply`` on the peer.
+
+    It is OPT-IN (``--sweep``) and it runs strictly AFTER the far side has
+    returned 200, never before. Restarting agents is a mutating action on
+    another machine, and the peer may already run its own ``auth-heal``
+    supervisor — two restarters on one fleet is the double-supervisor
+    class (see ``cli_pkg/_agents_restart_login_expired.py``).
+
+    THE NON-LOGIN-SHELL TRAP is handled explicitly. sshd hands the command
+    to a NON-login shell, which does not source the profile block that puts
+    ``sac`` on PATH; the first attempt therefore uses sac's normal remote
+    argv (so the peer's ``env_preamble`` and the registry's ``SCITEX_DIR``
+    pin still apply), and a not-found result is RETRIED once through
+    ``bash -lc``. Which form succeeded is stated in the returned output —
+    a silent fallback would hide a peer whose PATH needs fixing.
+
+    Returns the peer's combined output. Raises :class:`KeepaliveError`
+    naming the peer on a non-zero exit.
+    """
+    import shlex
+
+    from .._state.host_config import build_ssh_argv
+    from .._state.host_config import load as load_host_config
+
+    config = load_host_config()
+    if peer not in config.peers:
+        known = ", ".join(sorted(config.peers)) or "(none registered)"
+        raise KeepaliveError(
+            f"cannot sweep peer '{peer}': not found under peers: in "
+            f"{config.source_path}. Registered peers: {known}."
+        )
+    if run_fn is None:
+        import subprocess
+
+        run_fn = subprocess.run
+
+    remote_cmd = ["sac", "agents", "restart-login-expired", "--apply"]
+    argv = build_ssh_argv(peer, remote_cmd, config.peers)
+    proc = run_fn(argv, capture_output=True, text=True, check=False)
+    note = ""
+    if proc.returncode != 0 and _looks_missing(proc.returncode, proc.stderr or ""):
+        # PATH, not auth. Retry through a LOGIN shell, collapsed into ONE
+        # argv element because ssh joins everything after the host with
+        # spaces and the remote shell re-parses it.
+        login = [f"bash -lc {shlex.quote(shlex.join(remote_cmd))}"]
+        argv = build_ssh_argv(peer, login, config.peers)
+        proc = run_fn(argv, capture_output=True, text=True, check=False)
+        note = (
+            f"[sweep] '{peer}' has no `sac` on its NON-login shell PATH; "
+            "retried through `bash -lc`. Fix that host's PATH so the direct "
+            "form works.\n"
+        )
+
+    output = f"{note}{proc.stdout or ''}{proc.stderr or ''}".strip()
+    if proc.returncode != 0:
+        raise KeepaliveError(
+            f"the 401 sweep on peer '{peer}' failed (`sac agents "
+            f"restart-login-expired --apply` exited {proc.returncode}). The "
+            f"credential IS published and verified on '{peer}'; only the "
+            f"restart of its wedged agents did not happen: {output}"
+        )
+    return output
+
+
+__all__ = [
+    "MIN_VALIDITY_S",
+    "VERIFY_OK",
+    "KeepaliveError",
+    "assert_access_only",
+    "assert_is_refresh_holder",
+    "assert_not_downgrading",
+    "build_payload",
+    "find_refresh_keys",
+    "holds_refresh_material",
+    "keepalive_push",
+    "refresh_holder_accounts",
+    "seconds_left",
+    "sweep_login_expired",
+]

--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -21,7 +21,23 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 def provide_jobs() -> "list[JobSpec]":
     """Return sac's federated scheduled jobs.
 
-    Eight jobs today:
+    Nine jobs today:
+
+    * ``sac.accounts-keepalive`` (``kind="timer"``) — the DISTRIBUTION half
+      of the single-refresher model, and the sibling of
+      ``sac.accounts-refresh`` below. That job rotates the token on the ONE
+      host holding refresh material; this one COPIES the result out to the
+      access-only hosts and proves each of them accepts it. Without it those
+      hosts hold a credential nothing can renew and 401 within one
+      access-token lifetime — measured 2026-08-10, three fleet-wide deaths
+      in a day. It never mints (minting rotates, which revokes the token
+      running agents are holding).
+
+      HOST GAP, stated rather than papered over: ``JobSpec`` has no
+      host-pinning field, so nothing here can declare "only on the refresh
+      holder". The verb defends itself instead — ``--all`` resolves to the
+      accounts THIS host holds refresh material for and exits NON-ZERO when
+      that set is empty, so an install on the wrong host is loud, not quiet.
 
     * ``sac.freshness-refresh`` (``kind="timer"``) — the REFRESHER half of
       the version-currency check. The CLI's startup banner reads a cached
@@ -188,6 +204,68 @@ def provide_jobs() -> "list[JobSpec]":
             on_boot_sec="15min",
             on_unit_active_sec="2h",
             timeout_sec=120,
+        ),
+        JobSpec(
+            name="sac.accounts-keepalive",
+            schedule="*/15 * * * *",  # every 15min (cron form; timer below)
+            command=(
+                "sac accounts keepalive --all "
+                "--to ywata-note-win "
+                "--to scitex-compute-03 "
+                "--to scitex-compute-04"
+            ),
+            description=(
+                "The DISTRIBUTION half of the single-refresher model, and "
+                "the only thing keeping the access-only hosts alive. "
+                "sac.accounts-refresh rotates the token on the ONE host that "
+                "holds refresh material (scitex-nas-03 as of 2026-08-10); "
+                "every other host holds an ACCESS-ONLY copy that nothing on "
+                "that box can renew, so without this job those hosts simply "
+                "expire and 401 within one access-token lifetime. COPIES the "
+                "current token (never mints — minting rotates, which revokes "
+                "the token running agents hold), refuses a payload carrying "
+                "refresh material, refuses under 300s of validity, refuses "
+                "to overwrite a valid remote credential with a dead one, "
+                "backs up what it replaces, publishes 0600, and PROVES the "
+                "far side answers HTTP 200. CONVERGENT: it compares "
+                "fingerprints and rewrites a peer only when the master's "
+                "token actually changed, so most runs are cheap verified "
+                "no-ops. WORST-CASE FOLLOWER OUTAGE THE OPERATOR IS "
+                "ACCEPTING AT THIS CADENCE: 15 minutes — the moment the "
+                "master refreshes, every follower's copy is revoked, and "
+                "they stay dead until the next tick converges them. Exits "
+                "non-zero on any peer's failure. NOT armed by this "
+                "declaration."
+            ),
+            kind="timer",
+            # HOST PINNING IS NOT EXPRESSIBLE HERE. JobSpec has no host
+            # field (name/kind/schedule/command/description/on_boot_sec/
+            # on_unit_active_sec/timeout_sec/restart_policy/watchdog_sec/
+            # venv), so WHERE this runs is decided by where the operator
+            # installs it. It must run ONLY on the refresh holder. sac's
+            # own mitigation is inside the verb: `--all` resolves to the
+            # accounts THIS host holds refresh material for, and exits
+            # non-zero when that set is empty — so a keepalive installed on
+            # the wrong host fails loudly instead of pretending to work.
+            #
+            # 15min is a BOUND, not a guess. Measured 2026-08-10: Claude
+            # Code refreshes only when the token is genuinely near expiry,
+            # so the master's token changes ONCE in ~7h at an unpredictable
+            # moment — and the instant it does, every follower's copy is
+            # revoked and its agents 401. The tick therefore does not decide
+            # when work happens (the fingerprint comparison does); it decides
+            # only how long that revoked window lasts. 15min bounds the
+            # follower outage to 15min; hourly would bound it to an hour.
+            # The cost of the extra ticks is near zero because a converged
+            # peer is verified, not rewritten.
+            on_boot_sec="10min",
+            on_unit_active_sec="15min",
+            # Per peer: a handful of coreutils ssh ops plus ONE outbound
+            # HTTPS verification from the peer (15s cap inside the probe).
+            # 300s covers three peers including a slow one without ever
+            # hanging forever. A pass killed here leaves the peer's previous
+            # credential intact — nothing is published unverified.
+            timeout_sec=300,
         ),
         JobSpec(
             name="sac.host-sync-check",

--- a/src/scitex_agent_container/cli_pkg/_account_keepalive.py
+++ b/src/scitex_agent_container/cli_pkg/_account_keepalive.py
@@ -1,0 +1,317 @@
+"""``sac accounts keepalive`` — push ACCESS-ONLY credentials out to peers.
+
+The operator-facing leg of :mod:`.._account.token_keepalive`. Lives in its
+own module (like ``_account_mint_token`` / ``_account_refresh``) to keep
+``account_group`` under the per-file line cap; attached onto the group at
+import time.
+
+THE INVARIANT THIS MAINTAINS
+----------------------------
+Exactly ONE host in the fleet holds OAuth REFRESH material — as of
+2026-08-10 that is ``scitex-nas-03``. Every other host is READ-ONLY with
+respect to the session: it receives ACCESS-ONLY copies and can never
+trigger the refresh-token rotation that would revoke everyone else's
+token. ``sac accounts mint-token`` already mints that shape; this command
+is what DELIVERS it, and what keeps the access-only hosts alive — without
+a run before each expiry they simply go dark.
+
+NOTHING IS SCHEDULED HERE. Running this on a timer is a separate,
+deliberate decision and is expressly NOT hand-rolled as a unit file or a
+cron line — those go missing. The recurrence belongs in scitex-dev's
+periodic-job primitive, declared by sac. This module ships the verb only.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+
+def _render(record: dict[str, Any], out) -> None:
+    """Render ONE successful push. Paths, fingerprints, seconds. No tokens."""
+    peer = record["peer"]
+    if record["action"] == "already-current":
+        out(
+            f"  {peer:20s}  {record['account']}: already current at "
+            f"{record['remote_path']} — same token as the master, nothing "
+            f"written (verified HTTP {record['verify_status']})",
+            err=True,
+        )
+    else:
+        out(
+            f"  {peer:20s}  {record['account']}: pushed -> "
+            f"{record['remote_path']} (mode 0{record['mode']}, "
+            f"{record['bytes']} bytes, {record['publish']}, verified HTTP "
+            f"{record['verify_status']})",
+            err=True,
+        )
+    previous = record.get("previous_access_fp")
+    replaced = (
+        f"replaced {previous} ({record['previous_seconds_left']}s left)"
+        if previous
+        else "no previous credential on this peer"
+    )
+    out(
+        f"  {'':20s}  token {record['access_fp']}, "
+        f"{record['seconds_left']}s left; {replaced}",
+        err=True,
+    )
+    if record.get("backup_path"):
+        out(f"  {'':20s}  backup -> {record['backup_path']}", err=True)
+    if record.get("publish") == "in-place":
+        out(
+            f"  {'':20s}  NOTE: the destination is bind-mounted, so the "
+            "atomic rename was impossible (EBUSY) and the bytes were "
+            "written IN PLACE. Non-atomic by necessity, not by choice.",
+            err=True,
+        )
+    if record.get("peer_held_refresh_material"):
+        out(
+            f"  {'':20s}  WARNING: '{peer}' was holding REFRESH material "
+            "before this push — that host was a CLONE of the master's OAuth "
+            "session and could have revoked it. It now holds access-only "
+            "material. Check for other clones with `sac accounts list`.",
+            err=True,
+        )
+
+
+def register_keepalive_command(group: click.Group) -> None:
+    """Attach the ``keepalive`` subcommand onto ``group``."""
+
+    @group.command("keepalive")
+    @click.option(
+        "--account",
+        "account_labels",
+        multiple=True,
+        help=(
+            "Stored account slug to fan out (repeatable), e.g. "
+            "alpha-example-com. Mutually exclusive with --all."
+        ),
+    )
+    @click.option(
+        "--all",
+        "all_accounts",
+        is_flag=True,
+        default=False,
+        help=(
+            "Fan out EVERY stored account this host holds refresh material "
+            "for — i.e. every account for which this host is the origin. "
+            "Exits non-zero when that set is empty, because a host that is "
+            "not the refresh holder cannot keep anyone alive and must say so "
+            "rather than succeed quietly."
+        ),
+    )
+    @click.option(
+        "--to",
+        "peers",
+        multiple=True,
+        required=True,
+        help=(
+            "Peer to push ACCESS-ONLY material to (repeatable). Must be a "
+            "peer key from ~/.scitex/agent-container/config.yaml."
+        ),
+    )
+    @click.option(
+        "--min-validity",
+        "min_validity",
+        type=int,
+        default=None,
+        help=(
+            "Refuse to push when the master token has fewer than this many "
+            "seconds left (default 300). A token that expires in flight is "
+            "worse than no push."
+        ),
+    )
+    @click.option(
+        "--remote-path",
+        "remote_path",
+        default=None,
+        help=(
+            "Override the destination path on every peer. Defaults to the "
+            "IDENTICAL absolute path the snapshot occupies here."
+        ),
+    )
+    @click.option(
+        "--force",
+        is_flag=True,
+        default=False,
+        help=(
+            "Publish even when the peer already holds the master's exact "
+            "token. Default is CONVERGENT: fingerprints are compared and a "
+            "peer that is already current is verified but not rewritten, so "
+            "a frequent schedule does not bury it in hourly backups."
+        ),
+    )
+    @click.option(
+        "--sweep",
+        is_flag=True,
+        default=False,
+        help=(
+            "After a peer VERIFIES the new credential, restart its agents "
+            "that are wedged on auth (`sac agents restart-login-expired "
+            "--apply` there). Off by default: a running claude holds its "
+            "token in memory, so without this a 401'd agent stays 401'd — "
+            "but the peer may already run its own auth-heal supervisor, and "
+            "two restarters on one fleet fight each other."
+        ),
+    )
+    @click.option(
+        "--json",
+        "as_json",
+        is_flag=True,
+        default=False,
+        help="Emit a JSON array of per-peer records on stdout.",
+    )
+    def account_keepalive(
+        account_labels: tuple[str, ...],
+        all_accounts: bool,
+        peers: tuple[str, ...],
+        min_validity: int | None,
+        remote_path: str | None,
+        force: bool,
+        sweep: bool,
+        as_json: bool,
+    ) -> None:
+        """Copy this host's CURRENT access token to peers, access-only.
+
+        COPIES — it never mints or refreshes. Minting ROTATES the
+        single-use refresh token, which revokes the access token every
+        running agent is holding; that is what killed ten agents on
+        2026-08-10. This reads the master's stored credential as it
+        stands, strips the refreshToken (via the same
+        ``mint_access_only_artifact`` the ``mint-token`` verb uses),
+        refuses to send it if it is nearly dead, backs up whatever it
+        replaces on the peer, publishes at 0600, and PROVES the peer's own
+        copy answers HTTP 200 before anything is restarted.
+
+        Every refusal is loud and names the account and the peer. No token
+        value is ever printed — only paths, hostnames, seconds and opaque
+        sha256 fingerprints.
+
+        \b
+        Examples:
+          $ sac accounts keepalive --account alpha-example-com --to compute-04
+          $ sac accounts keepalive --all --to compute-04 --to laptop
+          $ sac accounts keepalive --all --to compute-04 --sweep
+        """
+        import json as _json
+        import sys
+
+        from .._account.snapshot_push import SnapshotPushError
+        from .._account.token_keepalive import (
+            MIN_VALIDITY_S,
+            KeepaliveError,
+            keepalive_push,
+            refresh_holder_accounts,
+            sweep_login_expired,
+        )
+
+        if bool(account_labels) == all_accounts:
+            raise click.UsageError(
+                "pass exactly one of --account <slug> (repeatable) or --all."
+            )
+
+        accounts = list(account_labels)
+        if all_accounts:
+            accounts = refresh_holder_accounts()
+            if not accounts:
+                click.echo(
+                    "error: --all found no stored account this host holds "
+                    "refresh material for, so this host is not the origin for "
+                    "any session and cannot keep any peer alive. Run it on the "
+                    "host that holds the refresh token.",
+                    err=True,
+                )
+                sys.exit(1)
+            click.echo(
+                f"[keepalive] this host is the refresh holder for: "
+                f"{', '.join(accounts)}",
+                err=True,
+            )
+
+        floor = MIN_VALIDITY_S if min_validity is None else min_validity
+        records: list[dict[str, Any]] = []
+        verified_peers: list[str] = []
+        failed = False
+
+        for account_label in accounts:
+            for peer in peers:
+                # stx-allow: fallback (reason: one unreachable or refusing
+                # peer must NOT abort the remaining peers — each host's
+                # credential is independent, and aborting would leave the
+                # untried hosts to expire silently, which is the exact
+                # failure this command exists to end. Every failure is
+                # rendered loudly here and folded into a non-zero exit
+                # below; none is swallowed.)
+                try:
+                    record = keepalive_push(
+                        account_label,
+                        peer,
+                        min_validity_s=floor,
+                        remote_path=remote_path,
+                        force=force,
+                    )
+                except (
+                    KeepaliveError,
+                    SnapshotPushError,
+                ) as exc:  # stx-allow: fallback (reason: see inline comment)
+                    failed = True
+                    records.append(
+                        {
+                            "account": account_label,
+                            "peer": peer,
+                            "ok": False,
+                            "error": str(exc),
+                        }
+                    )
+                    click.echo(
+                        f"  {peer:20s}  {account_label}: FAILED — {exc}", err=True
+                    )
+                    continue
+
+                record["ok"] = True
+                _render(record, click.echo)
+                records.append(record)
+                if peer not in verified_peers:
+                    verified_peers.append(peer)
+
+        # The sweep runs LAST and ONCE per peer — after every account has
+        # been published AND verified there. Restarting between accounts
+        # would bounce an agent onto a peer that is still mid-update.
+        for peer in verified_peers:
+            if not sweep:
+                click.echo(
+                    f"  {peer:20s}  not sweeping: agents there that are "
+                    "already 401ing hold their old token in memory and will "
+                    "stay wedged until restarted (pass --sweep).",
+                    err=True,
+                )
+                continue
+            # stx-allow: fallback (reason: the credential IS published and
+            # verified at this point; a sweep failure must be reported
+            # against THIS peer and must not discard the successful push or
+            # skip the remaining peers.)
+            try:
+                output = sweep_login_expired(peer)
+            except (
+                KeepaliveError
+            ) as exc:  # stx-allow: fallback (reason: see inline comment)
+                failed = True
+                records.append({"peer": peer, "ok": False, "sweep_error": str(exc)})
+                click.echo(f"  {peer:20s}  SWEEP FAILED — {exc}", err=True)
+                continue
+            records.append({"peer": peer, "ok": True, "sweep_output": output})
+            for line in str(output).splitlines():
+                click.echo(f"    {line}", err=True)
+
+        if as_json:
+            click.echo(  # stx-allow: STX-IO006
+                _json.dumps(records, ensure_ascii=False, indent=2)
+            )
+
+        if failed:
+            sys.exit(1)
+
+
+__all__ = ["register_keepalive_command"]

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -216,6 +216,17 @@ register_mint_token_command(account)
 
 
 # ---------------------------------------------------------------------------
+# keepalive — DELIVER that access-only artifact to peers and prove the far
+# side accepts it. `mint-token` produces the shape; this is what keeps the
+# access-only hosts from silently expiring. Own module (per-file line cap);
+# attached at import time like mint-token / refresh.
+# ---------------------------------------------------------------------------
+from ._account_keepalive import register_keepalive_command
+
+register_keepalive_command(account)
+
+
+# ---------------------------------------------------------------------------
 # login — semi-automated `claude /login` re-auth. Drives claude in a tmux
 # pane, extracts + delivers the OAuth URL to the operator, awaits the
 # browser/code step, then reuses `account save`. Lives in its own module

--- a/tests/scitex_agent_container/_account/test_token_keepalive.py
+++ b/tests/scitex_agent_container/_account/test_token_keepalive.py
@@ -1,0 +1,823 @@
+"""Tests for ``sac accounts keepalive`` — access-only credential distribution.
+
+The invariant under test is the one the 2026-08-10 fleet outage taught:
+exactly ONE host holds refresh material, everyone else holds ACCESS-ONLY
+copies, and nothing is ever restarted onto a credential the far side has
+not accepted.
+
+No-mocks (PA-306 / STX-NM002). The guards are pure functions driven with
+real ``store_dir`` / ``home`` / ``now`` parameters against a real temp
+account store. The far-side tests drive the REAL production transport —
+the real :class:`SshTransport` renders its argv through the real
+``build_ssh_argv`` and the real ``subprocess.run`` resolves ``ssh`` on the
+real ``$PATH``; only the NETWORK HOP is replaced, by the ``ssh_exec_shim``
+helper that runs the remote command LOCALLY exactly as OpenSSH + sshd
+would. The remote ``mkdir`` / ``dd`` / ``chmod`` / ``stat`` / ``cp`` /
+``mv`` are the real coreutils on a real tree, and the probe is the REAL
+probe, executed by the real ``python3``, making a REAL HTTP request to a
+REAL ``http.server`` on loopback.
+
+Distinctive sentinels stand in for token material; every no-leak assertion
+searches for those exact bytes.
+
+AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import json
+import stat as stat_mod
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._account._keepalive_guards import (
+    KeepaliveError,
+    assert_access_only,
+    assert_is_refresh_holder,
+    assert_not_downgrading,
+    build_payload,
+    find_refresh_keys,
+    holds_refresh_material,
+    refresh_holder_accounts,
+)
+from scitex_agent_container._account._keepalive_remote import (
+    backup_remote,
+    ensure_remote_dir,
+    install_probe,
+    probe_source,
+    read_remote_state,
+    remove_probe,
+    verify_remote_token,
+)
+from scitex_agent_container._account._snapshot_publish import (
+    IN_PLACE,
+    publish_verified,
+)
+from scitex_agent_container._account.snapshot_push import (
+    SnapshotPushError,
+    resolve_peer_transport,
+)
+from scitex_agent_container._account.token_keepalive import keepalive_push
+
+_ACCESS = "ACCESS-TOKEN-MUST-NEVER-BE-PRINTED"
+_REFRESH = "REFRESH-TOKEN-MUST-NEVER-BE-PRINTED"
+_LABEL = "alpha-example-com"
+_PEER = "spartan"
+
+# A WHOLE-second `now`. `seconds_left` truncates, so a fractional clock makes
+# a "120s left" fixture report 119 — an off-by-one that says nothing about
+# the code under test. Pinning the second keeps the reported figure exact.
+_WHOLE_NOW = float(int(time.time()))
+
+# A `mv` that fails the way a bind-mounted destination does: rename onto a
+# mount point is EBUSY. Real program, real exit status, real stderr — the
+# same honest-replacement technique the snapshot-push tests use for a
+# lying `chmod`.
+_EBUSY_MV = """#!/bin/sh
+echo "mv: cannot move: Device or resource busy" >&2
+exit 1
+"""
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Answers with whatever status the server was told to answer with."""
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        self.send_response(self.server.reply_status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *_args) -> None:
+        return
+
+
+@pytest.fixture
+def api(request):
+    """A REAL HTTP server on loopback standing in for the Anthropic API."""
+    status = getattr(request, "param", 200)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    server.reply_status = status
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/v1/models"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.fixture
+def peer_config(tmp_path: Path, env_save_restore) -> Path:
+    """A real config.yaml, pinned with the env var sac's peer lookup reads."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("peers:\n  spartan:\n    ssh: ywatanabe@spartan-login1\n")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+    return cfg
+
+
+def _write_account(
+    store: Path, label: str, *, expires_at_ms: int, refresh: str | None = _REFRESH
+) -> Path:
+    """Materialise a stored account. ``refresh=None`` = an access-only replica."""
+    acct = store / label
+    acct.mkdir(parents=True, exist_ok=True)
+    oauth = {"accessToken": _ACCESS, "expiresAt": expires_at_ms, "scopes": ["a"]}
+    if refresh is not None:
+        oauth["refreshToken"] = refresh
+    path = acct / ".credentials.json"
+    path.write_text(json.dumps({"claudeAiOauth": oauth}), encoding="utf-8")
+    (acct / "account.json").write_text(json.dumps({"name": label}), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Path:
+    d = tmp_path / "accounts"
+    d.mkdir()
+    return d
+
+
+def _payload_error(store: Path, home: Path, **kwargs) -> KeepaliveError:
+    """Build a payload that MUST be refused; return the raised error."""
+    try:
+        build_payload(_LABEL, peer=_PEER, store_dir=store, home=home, **kwargs)
+    except KeepaliveError as exc:
+        return exc
+    raise AssertionError("expected build_payload to refuse")
+
+
+def _transport():
+    return resolve_peer_transport(_PEER)
+
+
+def _access_only_error(payload) -> KeepaliveError:
+    """Run a guard that MUST refuse; return the error so the test asserts once."""
+    try:
+        assert_access_only(payload, account=_LABEL, peer=_PEER)
+    except KeepaliveError as exc:
+        return exc
+    raise AssertionError("expected assert_access_only to refuse")
+
+
+def _downgrade_error(state, expires_at_ms: int, now_s: float) -> KeepaliveError:
+    """Run the downgrade guard that MUST refuse; return the error."""
+    try:
+        assert_not_downgrading(
+            state,
+            account=_LABEL,
+            peer=_PEER,
+            expires_at_ms=expires_at_ms,
+            now_s=now_s,
+        )
+    except KeepaliveError as exc:
+        return exc
+    raise AssertionError("expected assert_not_downgrading to refuse")
+
+
+def _holder_error(store: Path, home: Path) -> KeepaliveError:
+    """Run the origin guard that MUST refuse; return the error."""
+    try:
+        assert_is_refresh_holder(_LABEL, peer=_PEER, store_dir=store, home=home)
+    except KeepaliveError as exc:
+        return exc
+    raise AssertionError("expected assert_is_refresh_holder to refuse")
+
+
+def _verify_error(transport, probe: str, remote: str) -> SnapshotPushError:
+    """Run a verification that MUST fail; return the error."""
+    try:
+        verify_remote_token(transport, probe, remote)
+    except SnapshotPushError as exc:
+        return exc
+    raise AssertionError("expected verify_remote_token to fail loud")
+
+
+# ---------------------------------------------------------------------------
+# REFUSAL: refresh material in the payload
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_key_is_found_at_any_depth() -> None:
+    # Arrange — the incident's own shape: refresh material nested one level
+    # down, which a top-level `in` check would miss entirely.
+    payload = {"claudeAiOauth": {"accessToken": _ACCESS, "refreshToken": _REFRESH}}
+    # Act
+    found = find_refresh_keys(payload)
+    # Assert
+    assert found == ["claudeAiOauth.refreshToken"]
+
+
+def test_snake_case_refresh_key_is_also_found() -> None:
+    # Arrange — the other dialect seen on disk.
+    payload = {"claudeAiOauth": {"refresh_token": _REFRESH}}
+    # Act
+    found = find_refresh_keys(payload)
+    # Assert
+    assert found == ["claudeAiOauth.refresh_token"]
+
+
+def test_refresh_bearing_payload_is_refused() -> None:
+    # Arrange
+    payload = {"claudeAiOauth": {"accessToken": _ACCESS, "refreshToken": _REFRESH}}
+    # Act
+    error = _access_only_error(payload)
+    # Assert — the message says WHY, not just that it refused.
+    assert "Cloning a refreshToken onto a second host" in str(error)
+
+
+def test_refusal_message_names_the_offending_key_path() -> None:
+    # Arrange
+    payload = {"claudeAiOauth": {"accessToken": _ACCESS, "refreshToken": _REFRESH}}
+    # Act
+    error = _access_only_error(payload)
+    # Assert — a failure must name what is wrong, never just that it is.
+    assert "claudeAiOauth.refreshToken" in str(error)
+
+
+def test_refusal_message_never_carries_the_refresh_token() -> None:
+    # Arrange
+    payload = {"claudeAiOauth": {"accessToken": _ACCESS, "refreshToken": _REFRESH}}
+    # Act
+    error = _access_only_error(payload)
+    # Assert
+    assert _REFRESH not in str(error)
+
+
+def test_access_only_payload_passes_the_guard() -> None:
+    # Arrange — what `mint_access_only_artifact` actually produces.
+    payload = {"claudeAiOauth": {"accessToken": _ACCESS, "expiresAt": 1}}
+    # Act
+    result = assert_access_only(payload, account=_LABEL, peer=_PEER)
+    # Assert
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# REFUSAL: an expired payload, and too little validity left
+# ---------------------------------------------------------------------------
+
+
+def test_expired_master_token_is_refused(store, tmp_path) -> None:
+    # Arrange — a snapshot whose expiry is an hour in the past.
+    now = time.time()
+    _write_account(store, _LABEL, expires_at_ms=int((now - 3600) * 1000))
+    # Act
+    error = _payload_error(store, tmp_path, now=now)
+    # Assert
+    assert "unhealthy" in str(error)
+
+
+def test_expired_refusal_names_the_account_and_peer(store, tmp_path) -> None:
+    # Arrange
+    now = time.time()
+    _write_account(store, _LABEL, expires_at_ms=int((now - 3600) * 1000))
+    # Act
+    error = _payload_error(store, tmp_path, now=now)
+    # Assert — a failure must name the file or the host, never go silent.
+    assert _LABEL in str(error) and _PEER in str(error)
+
+
+def test_too_little_validity_is_refused(store, tmp_path) -> None:
+    # Arrange — 120s left, under the 300s floor. Still VALID, so this is a
+    # different refusal from the expired one above.
+    now = _WHOLE_NOW
+    _write_account(store, _LABEL, expires_at_ms=int((now + 120) * 1000))
+    # Act
+    error = _payload_error(store, tmp_path, now=now)
+    # Assert
+    assert "under the 300s floor" in str(error)
+
+
+def test_too_little_validity_message_quotes_the_seconds_left(store, tmp_path) -> None:
+    # Arrange — a whole-second `now`, so the reported figure is exact rather
+    # than one short from truncating a fractional remainder.
+    now = _WHOLE_NOW
+    _write_account(store, _LABEL, expires_at_ms=int((now + 120) * 1000))
+    # Act
+    error = _payload_error(store, tmp_path, now=now)
+    # Assert — seconds are safe to print; tokens are not.
+    assert "120s of validity left" in str(error)
+
+
+def test_ample_validity_is_accepted(store, tmp_path) -> None:
+    # Arrange — an hour left, comfortably over the floor.
+    now = _WHOLE_NOW
+    _write_account(store, _LABEL, expires_at_ms=int((now + 3600) * 1000))
+    # Act
+    payload = build_payload(_LABEL, peer=_PEER, store_dir=store, home=tmp_path, now=now)
+    # Assert
+    assert payload["seconds_left"] == 3600
+
+
+def test_built_payload_carries_no_refresh_material(store, tmp_path) -> None:
+    # Arrange
+    now = time.time()
+    _write_account(store, _LABEL, expires_at_ms=int((now + 3600) * 1000))
+    # Act — the bytes that would actually go on the wire.
+    payload = build_payload(_LABEL, peer=_PEER, store_dir=store, home=tmp_path, now=now)
+    # Assert
+    assert _REFRESH.encode() not in payload["bytes"]
+
+
+def test_built_payload_fingerprint_is_opaque(store, tmp_path) -> None:
+    # Arrange
+    now = time.time()
+    _write_account(store, _LABEL, expires_at_ms=int((now + 3600) * 1000))
+    # Act
+    payload = build_payload(_LABEL, peer=_PEER, store_dir=store, home=tmp_path, now=now)
+    # Assert — a fingerprint, never a substring of the token.
+    assert (
+        payload["access_fp"].startswith("sha256:")
+        and _ACCESS not in (payload["access_fp"])
+    )
+
+
+# ---------------------------------------------------------------------------
+# REFUSAL: overwriting a valid remote credential with a dead one
+# ---------------------------------------------------------------------------
+
+
+def test_expired_payload_over_valid_remote_is_refused() -> None:
+    # Arrange — the peer still works; the payload does not.
+    now = time.time()
+    state = {"absent": False, "expires_at_ms": int((now + 3600) * 1000)}
+    # Act
+    error = _downgrade_error(state, int((now - 60) * 1000), now)
+    # Assert
+    assert "left untouched" in str(error)
+
+
+def test_downgrade_refusal_is_not_tunable_away() -> None:
+    # Arrange — this guard runs BELOW --min-validity, so it must still fire
+    # for a caller who lowered the floor to zero.
+    now = time.time()
+    state = {"absent": False, "expires_at_ms": int((now + 3600) * 1000)}
+    # Act
+    error = _downgrade_error(state, int((now - 1) * 1000), now)
+    # Assert
+    assert "still valid" in str(error)
+
+
+def test_fresh_payload_over_valid_remote_is_allowed() -> None:
+    # Arrange
+    now = time.time()
+    state = {"absent": False, "expires_at_ms": int((now + 60) * 1000)}
+    # Act
+    result = assert_not_downgrading(
+        state,
+        account=_LABEL,
+        peer=_PEER,
+        expires_at_ms=int((now + 3600) * 1000),
+        now_s=now,
+    )
+    # Assert
+    assert result is None
+
+
+def test_absent_remote_is_not_a_downgrade() -> None:
+    # Arrange — first push to a peer that has nothing yet.
+    now = time.time()
+    # Act
+    result = assert_not_downgrading(
+        {"absent": True, "expires_at_ms": None},
+        account=_LABEL,
+        peer=_PEER,
+        expires_at_ms=int((now + 3600) * 1000),
+        now_s=now,
+    )
+    # Assert
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# REFUSAL: fanning out from a host that is itself an access-only replica
+# ---------------------------------------------------------------------------
+
+
+def test_replica_cannot_fan_out(store, tmp_path) -> None:
+    # Arrange — an access-only copy: no refreshToken on disk.
+    _write_account(
+        store, _LABEL, expires_at_ms=int((time.time() + 3600) * 1000), refresh=None
+    )
+    # Act
+    error = _holder_error(store, tmp_path)
+    # Assert
+    assert "access-only replica, not the origin" in str(error)
+
+
+def test_refresh_holder_may_fan_out(store, tmp_path) -> None:
+    # Arrange
+    _write_account(store, _LABEL, expires_at_ms=int((time.time() + 3600) * 1000))
+    # Act
+    result = assert_is_refresh_holder(
+        _LABEL, peer=_PEER, store_dir=store, home=tmp_path
+    )
+    # Assert
+    assert result is None
+
+
+def test_holder_detection_reads_presence_not_value(store, tmp_path) -> None:
+    # Arrange
+    _write_account(store, _LABEL, expires_at_ms=int((time.time() + 3600) * 1000))
+    # Act
+    held = holds_refresh_material(_LABEL, store_dir=store, home=tmp_path)
+    # Assert — a bool, never the material.
+    assert held is True
+
+
+def test_all_lists_only_the_accounts_this_host_originates(store, tmp_path) -> None:
+    # Arrange — one origin account and one replica account side by side.
+    future = int((time.time() + 3600) * 1000)
+    _write_account(store, _LABEL, expires_at_ms=future)
+    _write_account(store, "beta-example-com", expires_at_ms=future, refresh=None)
+    # Act
+    holders = refresh_holder_accounts(store_dir=store, home=tmp_path)
+    # Assert
+    assert holders == [_LABEL]
+
+
+# ---------------------------------------------------------------------------
+# Far side — real ssh argv, real coreutils, real probe, real HTTP
+# ---------------------------------------------------------------------------
+
+
+def test_backup_copies_the_previous_credential(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
+    # Arrange
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    remote.parent.mkdir(parents=True)
+    remote.write_text("previous")
+    # Act
+    backup = backup_remote(_transport(), str(remote), stamp="20260810T000000Z")
+    # Assert
+    assert Path(backup).read_text() == "previous"
+
+
+def test_backup_is_0600(tmp_path, peer_config, ssh_exec_shim) -> None:
+    # Arrange
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    remote.parent.mkdir(parents=True)
+    remote.write_text("previous")
+    remote.chmod(0o644)
+    # Act
+    backup = backup_remote(_transport(), str(remote), stamp="20260810T000000Z")
+    # Assert — a copy of a credential must not inherit a loose mode.
+    assert oct(stat_mod.S_IMODE(Path(backup).stat().st_mode))[2:] == "600"
+
+
+def test_backup_of_nothing_is_none(tmp_path, peer_config, ssh_exec_shim) -> None:
+    # Arrange — first push: the peer has no credential yet.
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    remote.parent.mkdir(parents=True)
+    # Act
+    backup = backup_remote(_transport(), str(remote), stamp="20260810T000000Z")
+    # Assert
+    assert backup is None
+
+
+def test_probe_source_carries_no_token(tmp_path) -> None:
+    # Arrange — the probe is a FILE dropped on the peer; it must be inert.
+    sentinels = (_ACCESS.encode(), _REFRESH.encode())
+    # Act
+    source = probe_source()
+    # Assert
+    assert not any(sentinel in source for sentinel in sentinels)
+
+
+def test_remote_state_reports_the_expiry(tmp_path, peer_config, ssh_exec_shim) -> None:
+    # Arrange
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    remote.parent.mkdir(parents=True)
+    remote.write_text(
+        json.dumps({"claudeAiOauth": {"accessToken": _ACCESS, "expiresAt": 4242}})
+    )
+    transport = _transport()
+    probe = install_probe(transport, str(remote))
+    # Act — the REAL probe, run by the REAL python3.
+    state = read_remote_state(transport, probe, str(remote))
+    # Assert
+    assert state["expires_at_ms"] == 4242
+
+
+def test_remote_state_flags_a_peer_still_holding_refresh_material(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
+    # Arrange — the incident's shape: a cloned session on a follower.
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    remote.parent.mkdir(parents=True)
+    remote.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": _ACCESS,
+                    "refreshToken": _REFRESH,
+                    "expiresAt": 4242,
+                }
+            }
+        )
+    )
+    transport = _transport()
+    probe = install_probe(transport, str(remote))
+    # Act
+    state = read_remote_state(transport, probe, str(remote))
+    # Assert — reported as a fingerprint, never as the value.
+    assert state["refresh_fp"].startswith("sha256:")
+
+
+def test_remote_state_of_a_missing_file_is_absent(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
+    # Arrange
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    remote.parent.mkdir(parents=True)
+    transport = _transport()
+    probe = install_probe(transport, str(remote))
+    # Act
+    state = read_remote_state(transport, probe, str(remote))
+    # Assert
+    assert state["absent"] is True
+
+
+def test_probe_is_removed_from_the_peer(tmp_path, peer_config, ssh_exec_shim) -> None:
+    # Arrange
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    remote.parent.mkdir(parents=True)
+    transport = _transport()
+    probe = install_probe(transport, str(remote))
+    # Act
+    remove_probe(transport, str(remote))
+    # Assert
+    assert not Path(probe).exists()
+
+
+def test_far_side_verification_reports_200(
+    tmp_path, peer_config, ssh_exec_shim, api
+) -> None:
+    # Arrange — a REAL credential file and a REAL HTTP server answering 200.
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    remote.parent.mkdir(parents=True)
+    remote.write_text(json.dumps({"claudeAiOauth": {"accessToken": _ACCESS}}))
+    transport = _transport()
+    probe = install_probe(transport, str(remote), verify_url=api)
+    # Act — the real probe makes a real request with the real token.
+    status = verify_remote_token(transport, probe, str(remote))
+    # Assert
+    assert status == 200
+
+
+@pytest.mark.parametrize("api", [401], indirect=True)
+def test_far_side_verification_reports_401(
+    tmp_path, peer_config, ssh_exec_shim, api
+) -> None:
+    # Arrange — the exact failure the fleet saw: a revoked token.
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    remote.parent.mkdir(parents=True)
+    remote.write_text(json.dumps({"claudeAiOauth": {"accessToken": _ACCESS}}))
+    transport = _transport()
+    probe = install_probe(transport, str(remote), verify_url=api)
+    # Act
+    status = verify_remote_token(transport, probe, str(remote))
+    # Assert
+    assert status == 401
+
+
+def test_unreachable_endpoint_fails_loud(tmp_path, peer_config, ssh_exec_shim) -> None:
+    # Arrange — nothing is listening; an unverifiable token is a failure,
+    # never an assumption.
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    remote.parent.mkdir(parents=True)
+    remote.write_text(json.dumps({"claudeAiOauth": {"accessToken": _ACCESS}}))
+    transport = _transport()
+    probe = install_probe(
+        transport, str(remote), verify_url="http://127.0.0.1:1/v1/models"
+    )
+    # Act
+    error = _verify_error(transport, probe, str(remote))
+    # Assert
+    assert "NOT restarting anything" in str(error)
+
+
+# ---------------------------------------------------------------------------
+# Publish — the bind-mount EBUSY fallback
+# ---------------------------------------------------------------------------
+
+
+def test_bind_mounted_destination_falls_back_in_place(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
+    # Arrange — a real `mv` that answers EBUSY, as rename onto a bind mount
+    # does. The staged file is already correct; only publishing must adapt.
+    ssh_exec_shim.install_binary("mv", _EBUSY_MV)
+    remote_dir = tmp_path / "peer" / "acct"
+    remote_dir.mkdir(parents=True)
+    remote = remote_dir / ".credentials.json"
+    staged = Path(str(remote) + ".staged")
+    payload = b'{"claudeAiOauth": {"accessToken": "x"}}'
+    staged.write_bytes(payload)
+    # Act
+    method, _mode, _size = publish_verified(
+        _LABEL,
+        transport=_transport(),
+        staged=str(staged),
+        remote=str(remote),
+        payload=payload,
+    )
+    # Assert — deliberately in place, not a silent failure.
+    assert method == IN_PLACE
+
+
+def test_in_place_fallback_actually_lands_the_bytes(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
+    # Arrange
+    ssh_exec_shim.install_binary("mv", _EBUSY_MV)
+    remote_dir = tmp_path / "peer" / "acct"
+    remote_dir.mkdir(parents=True)
+    remote = remote_dir / ".credentials.json"
+    staged = Path(str(remote) + ".staged")
+    payload = b'{"claudeAiOauth": {"accessToken": "x"}}'
+    staged.write_bytes(payload)
+    # Act
+    publish_verified(
+        _LABEL,
+        transport=_transport(),
+        staged=str(staged),
+        remote=str(remote),
+        payload=payload,
+    )
+    # Assert
+    assert remote.read_bytes() == payload
+
+
+def test_in_place_fallback_still_lands_0600(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
+    # Arrange
+    ssh_exec_shim.install_binary("mv", _EBUSY_MV)
+    remote_dir = tmp_path / "peer" / "acct"
+    remote_dir.mkdir(parents=True)
+    remote = remote_dir / ".credentials.json"
+    staged = Path(str(remote) + ".staged")
+    payload = b'{"claudeAiOauth": {"accessToken": "x"}}'
+    staged.write_bytes(payload)
+    # Act
+    publish_verified(
+        _LABEL,
+        transport=_transport(),
+        staged=str(staged),
+        remote=str(remote),
+        payload=payload,
+    )
+    # Assert — the non-atomic path must not weaken the mode contract.
+    assert oct(stat_mod.S_IMODE(remote.stat().st_mode))[2:] == "600"
+
+
+# ---------------------------------------------------------------------------
+# End to end — the whole ordering, against a real peer tree
+# ---------------------------------------------------------------------------
+
+
+def _keepalive(store, home, remote, api_url, **kwargs):
+    """Drive the real push with the probe pointed at the local API stand-in."""
+    return keepalive_push(
+        _LABEL,
+        _PEER,
+        remote_path=str(remote),
+        store_dir=store,
+        home=home,
+        verify_url=api_url,
+        **kwargs,
+    )
+
+
+def _keepalive_error(store, home, remote, api_url) -> KeepaliveError:
+    """Run a keepalive that MUST fail; return the error."""
+    try:
+        _keepalive(store, home, remote, api_url)
+    except KeepaliveError as exc:
+        return exc
+    raise AssertionError("expected keepalive_push to fail loud")
+
+
+def test_end_to_end_publishes_access_only_bytes(
+    store, tmp_path, peer_config, ssh_exec_shim, api
+) -> None:
+    # Arrange
+    _write_account(store, _LABEL, expires_at_ms=int((time.time() + 3600) * 1000))
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    # Act
+    _keepalive(store, tmp_path, remote, api)
+    # Assert — the refresh token never reached the peer.
+    assert _REFRESH not in remote.read_text()
+
+
+def test_end_to_end_lands_0600(
+    store, tmp_path, peer_config, ssh_exec_shim, api
+) -> None:
+    # Arrange
+    _write_account(store, _LABEL, expires_at_ms=int((time.time() + 3600) * 1000))
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    # Act
+    _keepalive(store, tmp_path, remote, api)
+    # Assert
+    assert oct(stat_mod.S_IMODE(remote.stat().st_mode))[2:] == "600"
+
+
+def test_end_to_end_backs_up_what_it_replaced(
+    store, tmp_path, peer_config, ssh_exec_shim, api
+) -> None:
+    # Arrange — the peer already holds a DIFFERENT credential.
+    _write_account(store, _LABEL, expires_at_ms=int((time.time() + 3600) * 1000))
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    remote.parent.mkdir(parents=True)
+    remote.write_text(json.dumps({"claudeAiOauth": {"accessToken": "OLD-TOKEN"}}))
+    # Act
+    record = _keepalive(store, tmp_path, remote, api)
+    # Assert
+    assert "OLD-TOKEN" in Path(record["backup_path"]).read_text()
+
+
+def test_end_to_end_converges_and_then_stops_rewriting(
+    store, tmp_path, peer_config, ssh_exec_shim, api
+) -> None:
+    # Arrange — a second run with the master's token unchanged. Measured
+    # 2026-08-10: the token does NOT rotate on most ticks, so the second run
+    # must be a verified no-op rather than another write + another backup.
+    _write_account(store, _LABEL, expires_at_ms=int((time.time() + 3600) * 1000))
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    _keepalive(store, tmp_path, remote, api)
+    # Act
+    second = _keepalive(store, tmp_path, remote, api)
+    # Assert
+    assert second["action"] == "already-current"
+
+
+def test_converged_run_writes_no_second_backup(
+    store, tmp_path, peer_config, ssh_exec_shim, api
+) -> None:
+    # Arrange
+    _write_account(store, _LABEL, expires_at_ms=int((time.time() + 3600) * 1000))
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    _keepalive(store, tmp_path, remote, api)
+    # Act
+    second = _keepalive(store, tmp_path, remote, api)
+    # Assert — an every-15-minutes schedule must not bury the peer in backups.
+    assert second["backup_path"] is None
+
+
+def test_changed_master_token_is_pushed(
+    store, tmp_path, peer_config, ssh_exec_shim, api
+) -> None:
+    # Arrange — converge, then rotate the master (as a real refresh would).
+    _write_account(store, _LABEL, expires_at_ms=int((time.time() + 3600) * 1000))
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    _keepalive(store, tmp_path, remote, api)
+    creds = store / _LABEL / ".credentials.json"
+    data = json.loads(creds.read_text())
+    data["claudeAiOauth"]["accessToken"] = "ROTATED-ACCESS-TOKEN"
+    creds.write_text(json.dumps(data))
+    # Act
+    record = _keepalive(store, tmp_path, remote, api)
+    # Assert — convergence, driven by the fingerprint and not by a clock.
+    assert record["action"] == "pushed"
+
+
+@pytest.mark.parametrize("api", [401], indirect=True)
+def test_rejecting_peer_is_a_loud_failure(
+    store, tmp_path, peer_config, ssh_exec_shim, api
+) -> None:
+    # Arrange — the far side refuses the credential we just published.
+    _write_account(store, _LABEL, expires_at_ms=int((time.time() + 3600) * 1000))
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    # Act
+    error = _keepalive_error(store, tmp_path, remote, api)
+    # Assert — nothing may be restarted onto an unverified credential.
+    assert "NOT restarting anything" in str(error)
+
+
+def test_end_to_end_leaves_no_probe_behind(
+    store, tmp_path, peer_config, ssh_exec_shim, api
+) -> None:
+    # Arrange
+    _write_account(store, _LABEL, expires_at_ms=int((time.time() + 3600) * 1000))
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    # Act
+    _keepalive(store, tmp_path, remote, api)
+    # Assert
+    assert not (remote.parent / ".sac-keepalive-probe.py").exists()
+
+
+def test_ensure_remote_dir_hardens_to_0700(
+    tmp_path, peer_config, ssh_exec_shim
+) -> None:
+    # Arrange
+    remote = tmp_path / "peer" / "acct" / ".credentials.json"
+    # Act
+    remote_dir = ensure_remote_dir(_transport(), str(remote))
+    # Assert
+    assert oct(stat_mod.S_IMODE(Path(remote_dir).stat().st_mode))[2:] == "700"

--- a/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
@@ -6,6 +6,12 @@ entry-point group match the federated contract:
 * ``sac.accounts-refresh`` — a periodic systemd timer job that runs
   ``--all --include-active --sync-active-login`` every 2h (the SOLE
   refresher; see the ``--skip-active`` note below).
+* ``sac.accounts-keepalive`` — the DISTRIBUTION half of that same
+  single-refresher model. ``accounts-refresh`` rotates the token on the
+  ONE host holding refresh material; this one copies the result out to
+  the access-only hosts every 15min and proves each accepts it. The two
+  are a pair, and the pair is why a fresh token on the master does not
+  by itself keep the followers alive.
 * ``sac.host-sync-check`` — the hourly READ-ONLY peer drift detector.
 * ``sac.spartan-sif-bake`` — the every-10-minutes remote SIF bake on the Spartan
   lease + pull/verify/atomic-swap on the master (operator directive
@@ -55,15 +61,16 @@ def test_provider_returns_every_expected_job() -> None:
     # moved, so the number gets bumped reflexively and the pin quietly stops
     # meaning anything. Membership names what actually changed.
     #
-    # freshness-refresh is the newest: the refresher half of the
-    # version-currency check, without which the CLI's staleness banner has
-    # no cache to read and is silent forever. `sac listen` is still NOT
-    # federated (see the module docstring and the absence-pin below).
+    # accounts-keepalive is the newest: the DISTRIBUTION half of the
+    # single-refresher model, paired with accounts-refresh below. `sac
+    # listen` is still NOT federated (see the module docstring and the
+    # absence-pin below).
     # Act
     names = {job.name for job in provide_jobs()}
     # Assert
     assert names == {
         "sac.accounts-refresh",
+        "sac.accounts-keepalive",
         "sac.host-sync-check",
         "sac.worktree-gc",
         "sac.spartan-sif-bake",
@@ -146,6 +153,130 @@ def test_provider_job_cadence_is_two_hours() -> None:
     job = _job("sac.accounts-refresh")
     # Assert
     assert job.on_unit_active_sec == "2h"
+
+
+# ---------------------------------------------------------------------------
+# sac.accounts-keepalive — the DISTRIBUTION half of the single-refresher
+# model, and the SIBLING of sac.accounts-refresh above. That job rotates the
+# token on the ONE host holding refresh material; this one copies the result
+# out to the access-only hosts and proves each of them accepts it. Refreshing
+# the master is not enough on its own: every other host holds a copy nothing
+# on that box can renew, so without this job they 401 within one access-token
+# lifetime (measured 2026-08-10, three fleet-wide deaths in a day).
+#
+# HOST PINNING IS NOT EXPRESSIBLE IN A JobSpec — there is no host field — so
+# WHERE this runs is an operator install decision. The verb defends itself
+# instead: `--all` resolves to the accounts THIS host holds refresh material
+# for and exits non-zero when that set is empty, so an install on the wrong
+# host is loud rather than quietly inert. Nothing here arms anything; a
+# JobSpec is inert until `ecosystem up` installs it.
+# ---------------------------------------------------------------------------
+
+
+def test_accounts_keepalive_job_name_is_package_prefixed() -> None:
+    # Arrange — the distribution half of the single-refresher model.
+    # Act
+    job = _job("sac.accounts-keepalive")
+    # Assert
+    assert job.name == "sac.accounts-keepalive"
+
+
+def test_accounts_keepalive_job_kind_is_timer() -> None:
+    # Arrange — a periodic systemd --user timer, so kind="timer". A kind
+    # outside JobSpec.ALLOWED_KINDS raises at construction, and `ecosystem up`
+    # then silently DROPS sac's WHOLE provider (provider-isolated, WARN-only)
+    # — taking the OAuth refresh, the drift check, the worktree GC and both
+    # heal enforcers down with it.
+    # Act
+    job = _job("sac.accounts-keepalive")
+    # Assert
+    assert job.kind == "timer"
+
+
+def test_accounts_keepalive_command_pushes_to_every_access_only_peer() -> None:
+    # Arrange — the peer list IS the job. A keepalive that reaches two of the
+    # three access-only hosts looks healthy (exit 0, verified peers) while the
+    # third silently expires, which is the exact failure this job exists to
+    # end. Pin the whole command so dropping a `--to` is a red test, not a
+    # host nobody notices is dead.
+    # Act
+    job = _job("sac.accounts-keepalive")
+    # Assert
+    assert job.command == (
+        "sac accounts keepalive --all "
+        "--to ywata-note-win "
+        "--to scitex-compute-03 "
+        "--to scitex-compute-04"
+    )
+
+
+def test_accounts_keepalive_command_runs_the_copying_verb_not_a_minting_one() -> None:
+    # Arrange — belt-and-braces, the counterpart of accounts-refresh's
+    # --skip-active guard. This job COPIES the master's current token; minting
+    # rotates it, and a rotation revokes the token every running agent is
+    # holding. Scheduling `accounts refresh` or `accounts login` here would
+    # turn a keepalive into a fleet-wide logout every 15 minutes, so pin the
+    # verb itself rather than trusting the full-command assertion above to be
+    # re-read whenever someone edits the peer list.
+    # Act
+    job = _job("sac.accounts-keepalive")
+    # Assert
+    assert job.command.split()[:3] == ["sac", "accounts", "keepalive"]
+
+
+def test_accounts_keepalive_cadence_bounds_the_follower_outage() -> None:
+    # Arrange — the cadence IS the worst-case follower outage, not a guess at
+    # when work is needed. The master's token changes once in ~7h at an
+    # unpredictable moment, and the instant it does every follower's copy is
+    # revoked; the tick only decides how long that revoked window lasts. A
+    # converged peer is verified rather than rewritten, so the extra ticks are
+    # near free — which is what makes 15min affordable.
+    # Act
+    job = _job("sac.accounts-keepalive")
+    # Assert
+    assert job.on_unit_active_sec == "15min"
+
+
+def test_accounts_keepalive_schedule_mirrors_the_timer_cadence() -> None:
+    # Arrange — the cron form is kept alongside the timer cadence (as every
+    # sibling does) so `ecosystem cron` could derive an equivalent line, and
+    # so the two spellings cannot silently disagree about how often this runs.
+    # Act
+    job = _job("sac.accounts-keepalive")
+    # Assert
+    assert job.schedule == "*/15 * * * *"
+
+
+def test_accounts_keepalive_timeout_outlives_a_three_peer_pass() -> None:
+    # Arrange — per peer: a handful of ssh ops plus ONE outbound HTTPS
+    # verification (15s cap inside the probe). 300s covers three peers
+    # including a slow one. A pass killed here is SAFE — nothing is published
+    # unverified, so the peer keeps its previous credential.
+    # Act
+    job = _job("sac.accounts-keepalive")
+    # Assert
+    assert job.timeout_sec == 300
+
+
+def test_accounts_keepalive_constructs_as_a_real_jobspec() -> None:
+    # Arrange — construction must not raise (a bad field would drop the whole
+    # provider). Assert it is the canonical contract type, not a look-alike.
+    # Act
+    job = _job("sac.accounts-keepalive")
+    # Assert
+    assert isinstance(job, jobs_mod.JobSpec)
+
+
+def test_accounts_keepalive_and_accounts_refresh_are_both_declared() -> None:
+    # Arrange — unlike the heal pair below, these two are NOT alternatives:
+    # they are the two halves of one model and BOTH must be enabled. Refresh
+    # without keepalive leaves the followers holding a revoked copy; keepalive
+    # without refresh distributes a token nothing renews. Deleting either one
+    # breaks the fleet in a way that looks like the other half working.
+    # Act
+    names = {job.name for job in provide_jobs()}
+    # Assert
+    assert {"sac.accounts-refresh", "sac.accounts-keepalive"} <= names
 
 
 def test_provider_does_not_federate_listen_it_would_duplicate_the_supervisor() -> None:


### PR DESCRIPTION
## What

Brings the proven `~/.local/bin/sac-token-keepalive.sh` into sac as a first-class
verb — `sac accounts keepalive` — plus its recurrence, declared through
scitex-dev's `scitex_dev.jobs` primitive rather than a hand-rolled unit.

Operator's ruling on the prototype's location, verbatim:
> なんで `~/.local/bin/` なんて変なところにあるの？それは sac に入れるべきじゃないの？

and on the schedule:
> 一時的なスクリプトだと。今後行方不明になるので、SAC の定期的なとして、
> scitex-development がそういう定期的なものを定義するためのプリミティブを
> 持っているので、それを使って scitex-agent-container の方で用意してもらわないと

## Why (measured, 2026-08-10)

The fleet died three times in one day on `401 OAuth access token has been
revoked`. Fingerprinting the credential material across hosts — values never
read — showed why:

| host | refreshToken fp | accessToken fp | |
| --- | --- | --- | --- |
| laptop | `7fcccfdcdf9f` | `571181f2ae95` | |
| scitex-compute-04 | `7fcccfdcdf9f` | `571181f2ae95` | **IDENTICAL** |
| scitex-nas-03 | `0ca3dd5e0632` | `705b3573d08b` | separate session |

The laptop and compute-04 were the SAME OAuth session cloned onto two machines,
**refresh token included**. An OAuth refresh rotates the refresh token and
invalidates the previous access token, so whichever host refreshed first
silently revoked the other. There is no error on the losing side; it just
starts 401ing.

`sac accounts mint-token` already strips `refreshToken` by design — that design
was right, the laptop/compute-04 pair violated it. What was missing was the
**delivery** leg.

**The invariant is now real, not aspirational.** `scitex-nas-03` holds the
fleet's only refresh token; the laptop and compute-04 have been stripped to
access-only and verified by fingerprint. Direction is nas-03 → everyone else,
and the followers are read-only with respect to the session — exactly the
access-only shape. nas-03 is a sound origin: 12 cores, 62 GB RAM, always-on.
That state is **not self-sustaining**: an access-only host cannot renew what it
holds, so without this command those two hosts simply expire.

## The command

```
sac accounts keepalive (--account <slug>... | --all) --to <peer> [--to <peer>...]
                       [--min-validity SECONDS]   # default 300
                       [--remote-path PATH]
                       [--force]
                       [--sweep]
                       [--json]
```

Ordering is preserved verbatim from the prototype, because the ordering is the
whole value:

1. **COPY, never mint.** Reads the master's CURRENT stored token through the
   same `mint_access_only_artifact` the `mint-token` verb uses (one stripper,
   not two). Minting rotates, and rotation revokes the token running agents are
   holding — that is what killed ten agents that morning.
2. **Refuse under 300s of validity.** A token that expires in flight is worse
   than no push: it looks like the problem was addressed.
3. **Refuse refresh-bearing payloads** (recursive key scan at every depth, both
   `refreshToken` and `refresh_token` dialects) and **refuse to overwrite a
   still-valid remote credential with a dead one** (that second guard sits
   below `--min-validity` and is not tunable away).
4. **Back up what it replaces** on the far side, then publish 0600.
5. **Verify the far side returns HTTP 200 BEFORE restarting anything.**
6. **Only then** sweep 401'd agents — and only with `--sweep`.

### Convergent, not tick-driven

Rehearsal finding: invoking `claude -p` on the master did **not** rotate
anything — access fingerprint and expiry were identical before and after,
because Claude Code refreshes only when the token is genuinely near expiry. A
job that fires on a clock and pushes unconditionally is a no-op for most of a
~7h token's life and does the real work only in the run that straddles the
refresh.

So the unit of work is a **fingerprint comparison**, not a tick: a peer already
holding the master's token is verified but not rewritten (`action:
already-current`, no backup churn), and a peer whose fingerprint differs is
pushed. That converges after any refresh however it was triggered. The schedule
only bounds how long the post-refresh gap lasts.

A peer that already holds the master's exact token and is **rejected** produces
a distinct diagnosis — that is a master-side failure, not a peer one, and the
message says so instead of blaming the peer.

Refresh validity is never probed: `holds_refresh_material` reads only whether
the field is PRESENT on disk. Probing whether a refresh token still works is a
write — when nas-03's stale one was rejected with 401, Claude Code cleared the
field outright.

### Secrecy

No token value is printed, logged, returned or written to a local file. Records
carry paths, hostnames, seconds and opaque `sha256:` fingerprints only. The
access token exists as in-memory bytes that travel once, over the transport's
stdin, into the peer's `dd`.

This also fixes a leak in the prototype: it verified with
`curl -H "authorization: Bearer $T"` inside a remote shell, putting the token in
the peer's process table. The far-side check is now a probe FILE streamed over
stdin, invoked with two whitespace-free tokens, which reads the credential
itself and prints only an HTTP status code.

### Bind-mounted destinations (EBUSY)

Rename onto a bind-mounted path fails with `OSError: [Errno 16] Device or
resource busy` — measured while stripping the laptop. Those are exactly the
hosts this exists for, so `_snapshot_publish.publish_verified` prefers the
atomic same-directory rename and, on EBUSY only, falls back to a **deliberate**
in-place write, re-hardens to 0600, re-verifies mode and size, and REPORTS which
path was taken (`publish: rename | in-place`, plus a loud CLI note that the
write was non-atomic by necessity). Any non-EBUSY `mv` failure stays loud. The
local leg never writes token material at all, so EBUSY can only bite the remote
publish, which is where the fallback lives.

### Non-login shell PATH

`ssh host 'sac ...'` runs in a NON-login shell that never sources the profile
block putting `sac` on PATH — the same trap that made the rehearsal's
verification report `No such file or directory`. The sweep tries sac's normal
remote argv first (so the peer's `env_preamble` and the registry's `SCITEX_DIR`
pin still apply) and retries once through `bash -lc` on a not-found signature,
stating in its output that it had to, so a peer with a broken PATH is visible
rather than papered over.

## Recurrence — declared, NOT armed

`sac.accounts-keepalive` is added to sac's existing `provide_jobs()`
(`src/scitex_agent_container/_jobs/_jobs_plugin.py`), already registered under
the `scitex_dev.jobs` entry-point group in `pyproject.toml`. `kind="timer"`,
`on_unit_active_sec="15min"`, `timeout_sec=300`.

**Nothing is installed, enabled, armed or started by this PR.** Running
`scitex-dev ecosystem jobs cron install` is the operator's action. No systemd
unit file is added — not even an inert example — deliberately: the scheduling
layer is not ours to hand-roll, and an example unit is exactly what the next
person would "helpfully" arm. Please do not add one back.

Failure is loud end-to-end: the verb exits non-zero on any peer's refusal or
failure, and the federation's `ecosystem cron exec` re-raises the child's exit
code (`raise SystemExit(completed.returncode)`) with output redirected to
`~/.scitex/dev/runtime/logs/cron-sac.accounts-keepalive.log` via `log_path_for`.

### 15 minutes is a stated bound, not a guess

The master's token changes ONCE in ~7h at an unpredictable moment, and the
instant it does every follower's copy is revoked and its agents 401. The tick
does not decide when work happens (the fingerprint comparison does); it decides
how long that revoked window lasts. **15min bounds the follower outage to 15
minutes**; hourly would bound it to an hour. This is written into the JobSpec
description so the worst case the operator is accepting is visible where the
schedule is declared. Extra ticks are near-free because a converged peer is
verified, not rewritten.

### Open gap: host pinning — needs an operator decision

This job must run ONLY on `scitex-nas-03`. **`JobSpec` has no host-pinning
field** — verified by reading the installed package
(`scitex_dev/jobs/__init__.py`): the fields are `name`, `kind`, `schedule`,
`command`, `description`, `on_boot_sec`, `on_unit_active_sec`, `timeout_sec`,
`restart_policy`, `watchdog_sec`, `venv`. None of them is a host.

No field was invented. Instead the verb defends itself: `--all` resolves to the
accounts THIS host holds refresh material for, and exits **non-zero** when that
set is empty — so a keepalive installed on the wrong host fails loudly instead
of pretending to work, and `assert_is_refresh_holder` refuses any single-account
push from a replica. Where it is installed is still the operator's call.

## Files

| File | |
| --- | --- |
| `_account/token_keepalive.py` | orchestration: the ordering, convergence, the sweep |
| `_account/_keepalive_guards.py` | every local refusal (origin, refresh material, validity floor, downgrade) |
| `_account/_keepalive_remote.py` | far-side probe / backup / HTTP verification |
| `_account/_snapshot_publish.py` | atomic publish + the EBUSY in-place fallback |
| `_account/snapshot_push.py` | `payload=` seam so stripped bytes never touch a local file; delegates publish |
| `cli_pkg/_account_keepalive.py` | the CLI verb |
| `cli_pkg/account_group.py` | registration |
| `_jobs/_jobs_plugin.py` | the JobSpec |
| `tests/.../test_token_keepalive.py` | the suite |

## Tests

No mocks. Guards are pure functions driven with real `store_dir` / `home` /
`now` against a real temp account store. Far-side tests drive the REAL
production transport — real `SshTransport`, real `build_ssh_argv`, real
`subprocess.run` resolving `ssh` on the real `$PATH` — with only the network hop
replaced by the repo's existing `ssh_exec_shim`, which runs the remote command
locally exactly as OpenSSH + sshd do. The remote `mkdir`/`dd`/`chmod`/`stat`/
`cp`/`mv` are real coreutils on a real tree; the probe is the REAL probe run by
the real `python3` making a REAL HTTP request to a REAL `http.server` on
loopback. EBUSY is modelled with a real `mv` binary that exits 1 with the real
kernel message, the same honest-replacement technique the existing
`test_snapshot_push.py` uses for a lying `chmod`.
