### PR TITLE
feat(start): a bad spec refuses to start — one named override per condition, and the duplicate warning is gone

### DIFF
--- a/src/scitex_agent_container/_drift/_local.py
+++ b/src/scitex_agent_container/_drift/_local.py
@@ -19,9 +19,20 @@ Design constraints (per the work item):
 * **RESILIENT** — never raises. A missing git binary, a
   non-repo source dir, an unreachable remote, or any subprocess error
   degrades to ``NOT_A_REPO`` / ``UNREACHABLE`` and the launch proceeds.
-* **DEFAULT = warn loud, NOT block** — hosts like spartan legitimately
-  carry local commits; a hard block would break every start there.
-  ``--strict-drift`` / ``SAC_STRICT_DRIFT=1`` escalate to a hard block.
+* **DEFAULT = REFUSE on a STALE spec** (operator ruling 2026-08-10:
+  「スペックがおかしかったら起動不可っていうのをデフォルトに」). A spec source
+  that is BEHIND / DIVERGED may launch an old spec, so the start is
+  refused and the named override ``--allow-stale-spec`` /
+  ``SAC_ALLOW_STALE_SPEC=1`` is the way past it.
+
+  AHEAD is deliberately NOT a refusal — see :attr:`DriftStatus.is_stale`.
+  Unpushed local commits mean the spec will not PROPAGATE; the spec about
+  to launch is still the newest one that exists, and hosts like spartan
+  legitimately carry local commits. AHEAD stays a loud warning.
+
+  NOT_A_REPO / UNREACHABLE never refuse: drift is *unknown* there, not
+  present, and refusing on "I could not check" would ground every agent
+  the moment the network hiccups.
 """
 
 from __future__ import annotations
@@ -43,6 +54,12 @@ _FETCH_TTL_S = 60
 # unreachable remote must not hang a launch; we bound it and treat a
 # timeout as UNREACHABLE.
 _GIT_TIMEOUT_S = 15
+
+# The NAMED override for the stale-spec refusal. One flag per condition —
+# never a blanket ``--force`` / ``--ignore-warnings``, which skips every check
+# at once and leaves no record of WHICH one was bypassed.
+ALLOW_STALE_FLAG = "--allow-stale-spec"
+ALLOW_STALE_ENV = "SAC_ALLOW_STALE_SPEC"
 
 
 def _run_git(repo: Path, *args: str, timeout: int = _GIT_TIMEOUT_S):
@@ -278,13 +295,19 @@ def check_spec_source_drift(
     )
 
 
-def drift_warning_lines(status: DriftStatus, *, agent: str | None = None) -> list[str]:
-    """Build the loud stderr warning lines for a drifted spec source.
+def drift_warning_lines(
+    status: DriftStatus, *, agent: str | None = None, refusing: bool = False
+) -> list[str]:
+    """Build the loud stderr lines for a drifted spec source.
 
     Returns an empty list when ``status`` is CURRENT (nothing to warn).
     NOT_A_REPO / UNREACHABLE produce a single soft note (drift unknown).
     BEHIND / AHEAD / DIVERGED produce a prominent banner that names the
     drift and the exact fix command.
+
+    ``refusing`` switches the banner from WARNING to ERROR and adds the named
+    override, so the message the operator reads matches what actually happened.
+    A refusal that still says "WARNING" trains the reader to expect a launch.
     """
     if status.state is DriftState.CURRENT:
         return []
@@ -318,14 +341,18 @@ def drift_warning_lines(status: DriftStatus, *, agent: str | None = None) -> lis
             "stale AND unpushed."
         )
     bar = "!" * 72
-    return [
+    lines = [
         bar,
-        f"sac-drift WARNING{who}:",
+        f"sac-drift {'ERROR' if refusing else 'WARNING'}{who}:",
         f"  {why}",
         f"  repo:     {repo}",
         f"  fix:      {fix}",
-        bar,
     ]
+    if refusing:
+        lines.append("  refusing to start — resolve the drift, or start anyway with:")
+        lines.append(f"  override: {ALLOW_STALE_FLAG}   /   {ALLOW_STALE_ENV}=1")
+    lines.append(bar)
+    return lines
 
 
 def warn_if_spec_source_drifted(
@@ -336,13 +363,16 @@ def warn_if_spec_source_drifted(
     do_fetch: bool = True,
     stream=None,
 ) -> DriftStatus:
-    """Check + emit the launch-time drift warning to ``stream``.
+    """Check + emit the launch-time drift report to ``stream``.
 
     Always returns the computed :class:`DriftStatus`. When ``strict`` is
-    True AND the source is genuinely drifted (BEHIND / AHEAD / DIVERGED),
-    raises :class:`SpecSourceDriftError` so the caller can hard-block the
-    launch. NOT_A_REPO / UNREACHABLE never block, even under strict —
-    drift is *unknown* there, not present.
+    True AND the local spec is STALE (BEHIND / DIVERGED — see
+    :attr:`DriftStatus.is_stale`), raises :class:`SpecSourceDriftError` so
+    the caller hard-blocks the launch.
+
+    AHEAD does NOT block even under strict: the spec about to launch is the
+    newest one that exists, it merely has not propagated. NOT_A_REPO /
+    UNREACHABLE never block either — drift is *unknown* there, not present.
 
     ``stream`` defaults to ``None`` and is resolved to ``sys.stderr`` at
     CALL time (not import time) so a test's ``capsys`` / a runtime
@@ -365,20 +395,20 @@ def warn_if_spec_source_drifted(
             state=DriftState.UNREACHABLE,
             detail=f"drift check raised {type(exc).__name__}: {exc}",
         )
-    lines = drift_warning_lines(status, agent=agent)
-    for line in lines:
+    refusing = bool(strict and status.is_stale)
+    for line in drift_warning_lines(status, agent=agent, refusing=refusing):
         print(line, file=stream, flush=True)
-    if strict and status.is_drifted:
+    if refusing:
         raise SpecSourceDriftError(status, agent=agent)
     return status
 
 
 class SpecSourceDriftError(RuntimeError):
-    """Raised under ``--strict-drift`` when the spec source is drifted.
+    """Raised when the spec source is STALE and the start was not overridden.
 
     Carries the offending :class:`DriftStatus` so the CLI layer can set
-    a clear non-zero exit. Only fires for BEHIND / AHEAD / DIVERGED —
-    NOT_A_REPO / UNREACHABLE never escalate.
+    a clear non-zero exit. Only fires for BEHIND / DIVERGED — AHEAD,
+    NOT_A_REPO and UNREACHABLE never escalate.
     """
 
     def __init__(self, status: DriftStatus, *, agent: str | None = None):
@@ -386,12 +416,16 @@ class SpecSourceDriftError(RuntimeError):
         self.agent = agent
         who = f" for agent '{agent}'" if agent else ""
         super().__init__(
-            f"strict-drift: spec source{who} is drifted ({status.summary()}); "
-            "refusing to launch. Resolve the drift or drop --strict-drift."
+            f"sac-drift: spec source{who} is STALE ({status.summary()}); "
+            f"refusing to launch a spec that may be out of date. Pull the "
+            f"repo, or start anyway with {ALLOW_STALE_FLAG} / "
+            f"{ALLOW_STALE_ENV}=1."
         )
 
 
 __all__ = [
+    "ALLOW_STALE_ENV",
+    "ALLOW_STALE_FLAG",
     "SpecSourceDriftError",
     "check_spec_source_drift",
     "drift_warning_lines",

--- a/src/scitex_agent_container/_drift/_status.py
+++ b/src/scitex_agent_container/_drift/_status.py
@@ -70,6 +70,20 @@ class DriftStatus:
             DriftState.DIVERGED,
         )
 
+    @property
+    def is_stale(self) -> bool:
+        """True when the LOCAL spec may be OUT OF DATE (BEHIND or DIVERGED).
+
+        The narrower half of :attr:`is_drifted`, and the one a start-time
+        refusal keys off. AHEAD is drift but it is not staleness: unpushed
+        local commits mean the spec will not PROPAGATE to other hosts, while
+        the spec this host is about to launch is the newest one that exists.
+        Refusing on AHEAD would stop hosts that legitimately carry local
+        commits from booting at all, which is a different (and worse) failure
+        than the one the refusal is for.
+        """
+        return self.state in (DriftState.BEHIND, DriftState.DIVERGED)
+
     def summary(self) -> str:
         """One-line human summary of the drift verdict."""
         if self.state is DriftState.CURRENT:

--- a/src/scitex_agent_container/_lifecycle/_layers_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_layers_preflight.py
@@ -1,0 +1,194 @@
+"""Launch-time gate: a spec must DECLARE the ``to_home`` layers it inherits.
+
+Why this is a launch preflight and not a resolver concern
+---------------------------------------------------------
+The "declares no ``to_home_layers``" finding used to be a ``logger.warning``
+inside :func:`..runtimes._to_home_resolve.settings_layer_dirs`. That function
+is a PURE resolver — it answers "which directories cascade into this agent" —
+and a start calls it **twice**: once for the workspace home
+(``claude_session.py`` -> ``deploy_to_home``) and once for the apptainer overlay
+upper (``deploy_to_home_overlay`` -> ``deploy_to_home``). The TUI runtime does
+the same. So one agent's start printed the same paragraph two times, which is
+how a message teaches people to scroll past it.
+
+The finding is not a property of a path lookup. It is a property of the SPEC,
+decided ONCE, before any deploy work happens. Putting it here fixes the
+duplication structurally (one call site, in ``agent_start``) and puts the
+refusal where a refusal belongs: before the runtime is built or touched.
+
+The refusal, and its escape hatch
+---------------------------------
+Operator ruling 2026-08-10: a bad spec REFUSES TO START by default, with an
+explicit named override rather than a blanket ``--force``. So:
+
+* undeclared layers -> :class:`UndeclaredToHomeLayers` raised before launch;
+* ``--allow-undeclared-layers`` / ``SAC_ALLOW_UNDECLARED_LAYERS=1`` starts
+  anyway, and says so at ERROR level naming the condition AND the agent. An
+  override that is silent is just a slower version of the warning nobody read.
+
+The override NAMES THE CONDITION on purpose. A generic ``--force`` skips every
+check at once, leaves no record of which one was bypassed, and gets reused by
+the next person for an unrelated failure — ``git --no-verify`` is the
+cautionary example, and this fleet bans that idiom by hook.
+
+Sequencing: :data:`ENFORCE_BY_DEFAULT`
+--------------------------------------
+Measured 2026-08-10 on the live registry: 101 of 102 fleet specs are
+UNDECLARED. Flipping the refusal on before those specs are migrated would stop
+the entire fleet from booting, so enforcement is currently OPT-IN via
+``SAC_ENFORCE_TO_HOME_LAYERS=1``.
+
+:data:`ENFORCE_BY_DEFAULT` is the one-line switch. Flip it to ``True`` once
+``sac agents migrate-layers --apply`` has landed in the dotfiles repo (the
+specs are tracked files in a SHARED repo, so that is a PR there, not a sweep
+here). The env var and this constant then become redundant and should be
+deleted together; ``--allow-undeclared-layers`` is the part that survives.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ..runtimes._to_home_errors import UndeclaredToHomeLayers
+
+logger = logging.getLogger(__name__)
+
+#: Flip to ``True`` to make an undeclared spec refuse to start by DEFAULT.
+#: Gated on the fleet's 102 specs being migrated first — see the module
+#: docstring. ``SAC_ENFORCE_TO_HOME_LAYERS=1`` enables it per-invocation today.
+ENFORCE_BY_DEFAULT = False
+
+#: The named override. One flag per condition, never a blanket ``--force``.
+ALLOW_FLAG = "--allow-undeclared-layers"
+ALLOW_ENV = "SAC_ALLOW_UNDECLARED_LAYERS"
+ENFORCE_ENV = "SAC_ENFORCE_TO_HOME_LAYERS"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    """Read a sac env flag (either prefix), falling back to ``default``.
+
+    ``name`` is passed WITHOUT the ``SAC_`` prefix to the sac env helper, which
+    accepts both ``SAC_<NAME>`` and ``SCITEX_AGENT_CONTAINER_<NAME>``.
+    """
+    from .._env import getenv as _sac_env
+
+    raw = (_sac_env(name.removeprefix("SAC_"), "") or "").strip().lower()
+    if not raw:
+        return default
+    return raw in _TRUTHY
+
+
+def _resolve_allow_undeclared(allow: "bool | None") -> bool:
+    """Effective override state: explicit arg wins, else the env, else off."""
+    if allow is not None:
+        return allow
+    return _env_flag(ALLOW_ENV, False)
+
+
+def _resolve_enforce(enforce: "bool | None") -> bool:
+    """Effective enforcement state: explicit arg wins, else env, else default."""
+    if enforce is not None:
+        return enforce
+    return _env_flag(ENFORCE_ENV, ENFORCE_BY_DEFAULT)
+
+
+def _inherited_layer_names(config) -> str:
+    """The layers this undeclared spec is silently inheriting, for the message.
+
+    Best-effort by design: the point of the message is the MISSING declaration,
+    and a resolver hiccup must not replace a precise complaint with a stack
+    trace about something else.
+    """
+    # stx-allow: fallback (reason: this only enriches an error message; a
+    # resolution failure here must not mask the declaration complaint itself)
+    try:
+        from ..runtimes._to_home_resolve import settings_layer_dirs
+
+        names = [name for name, path in settings_layer_dirs(config) if path is not None]
+    except Exception as exc:
+        return f"<unresolvable: {type(exc).__name__}: {exc}>"
+    return ", ".join(names) or "none"
+
+
+def undeclared_layers_lines(config, *, bypassed: bool = False) -> "list[str]":
+    """The banner for an undeclared spec — the refusal, or the bypass notice.
+
+    Named ``ERROR`` in both forms. A bypass is not a milder event than the
+    refusal it replaced: it is the same defect, deliberately admitted.
+    """
+    name = getattr(config, "name", "<unnamed>") or "<unnamed>"
+    spec = getattr(config, "config_path", "") or "<unknown spec path>"
+    inherited = _inherited_layer_names(config)
+    bar = "!" * 72
+    verdict = (
+        f"sac-layers BYPASSED for agent '{name}': starting anyway because "
+        f"{ALLOW_FLAG} / {ALLOW_ENV} was given."
+        if bypassed
+        else f"sac-layers ERROR for agent '{name}': refusing to start."
+    )
+    return [
+        bar,
+        verdict,
+        "  the spec declares no 'to_home_layers', so what gets merged into",
+        "  this agent is invisible from the spec alone.",
+        f"  spec:      {spec}",
+        f"  inherits:  {inherited}",
+        "  fix:       sac agents migrate-layers --apply   "
+        "(writes the one line it already resolves)",
+        f"  override:  {ALLOW_FLAG}   /   {ALLOW_ENV}=1",
+        bar,
+    ]
+
+
+def check_to_home_layers_at_launch(
+    config,
+    *,
+    allow_undeclared: "bool | None" = None,
+    enforce: "bool | None" = None,
+) -> bool:
+    """Refuse (or loudly permit) a spec that declares no ``to_home_layers``.
+
+    Returns ``True`` when the spec is declared (or enforcement is off and the
+    spec is undeclared — reported, not raised). Raises
+    :class:`UndeclaredToHomeLayers` when the spec is undeclared, enforcement is
+    on, and no override was given.
+
+    Called EXACTLY ONCE per :func:`.._start.agent_start`, which is the whole
+    point: the resolver it replaced ran twice per start.
+    """
+    if getattr(config, "to_home_layers", None) is not None:
+        return True
+
+    allow = _resolve_allow_undeclared(allow_undeclared)
+    if not _resolve_enforce(enforce):
+        # Not yet enforcing: one line, once, naming the agent and the fix.
+        # Deliberately NOT the full banner — until the flip this is a to-do
+        # list for the migration, not an event anyone must act on right now.
+        logger.warning(
+            "to_home: agent %r declares no 'to_home_layers' and is inheriting "
+            "the implicit cascade (%s). Fix: sac agents migrate-layers --apply. "
+            "This becomes a start REFUSAL once the fleet's specs are migrated.",
+            getattr(config, "name", "<unnamed>"),
+            _inherited_layer_names(config),
+        )
+        return True
+
+    lines = undeclared_layers_lines(config, bypassed=allow)
+    for line in lines:
+        logger.error("%s", line)
+    if allow:
+        return True
+    raise UndeclaredToHomeLayers("\n".join(lines))
+
+
+__all__ = [
+    "ALLOW_ENV",
+    "ALLOW_FLAG",
+    "ENFORCE_BY_DEFAULT",
+    "ENFORCE_ENV",
+    "UndeclaredToHomeLayers",
+    "check_to_home_layers_at_launch",
+    "undeclared_layers_lines",
+]

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -17,8 +17,13 @@ from ..config import AgentConfig, load_config, resolve_config
 from ._a2a_port import resolve_a2a_port
 from ._handover_loader import _load_handover_module
 from ._hook_runner import _fire_forget_hook, _run_hooks
+
+# Re-exported from _start_failure_diag for back-compat: this helper lived here
+# before the 512-line-cap split.
+from ._identity_drift import check_board_identity_at_launch
 from ._instances import make_restart_callback as _make_restart_callback
 from ._instances import record_local_instance as _record_local_instance
+from ._layers_preflight import check_to_home_layers_at_launch
 from ._runtime_select import _get_runtime
 from ._session_reset import _clear_persisted_session_id
 from ._spawn_gate import enforce_spawn_gate, persist_acl_policy
@@ -26,10 +31,6 @@ from ._spawn_gate import enforce_spawn_gate, persist_acl_policy
 # Re-exported from _start_announce for back-compat: this helper lived here
 # before the 512-line-cap split.
 from ._start_announce import _announce_start_verdict  # noqa: F401
-
-# Re-exported from _start_failure_diag for back-compat: this helper lived here
-# before the 512-line-cap split.
-from ._identity_drift import check_board_identity_at_launch
 from ._start_failure_diag import _format_boot_stderr_section  # noqa: F401
 from ._start_outcome import NOOP_ALREADY_RUNNING
 
@@ -96,10 +97,11 @@ def agent_start(
             though ``-y`` was explicitly passed at the CLI. Ignored on
             the non-SIF (direct) path — it has no interactive gate of
             its own to satisfy.
-        strict_drift: Escalate a drifted spec-source git repo from a
-            loud warning to a hard block (raise before launch). ``None``
-            (default) reads ``SAC_STRICT_DRIFT`` / ``--strict-drift`` is
-            not set; ``True`` forces strict, ``False`` forces lenient.
+        strict_drift: Whether a STALE spec source blocks the launch.
+            ``None`` (default) resolves to STRICT unless
+            ``SAC_ALLOW_STALE_SPEC`` / ``SAC_STRICT_DRIFT=0`` says
+            otherwise; ``True`` forces strict, ``False`` forces lenient
+            (what ``--allow-stale-spec`` passes).
         runtime_factory: Injectable real callable that builds an SDK
             runtime from an :class:`AgentConfig`. Default is the real
             :func:`_get_runtime`.
@@ -147,16 +149,16 @@ def agent_start(
     ):
         return True
 
-    # Launch-time LOCAL spec-source drift check. Verifies the git repo
-    # backing this spec.yaml (on these hosts ``~/.scitex/agent-container/
-    # agents`` symlinks into ``~/.dotfiles``) is current with its remote.
-    # Stale (BEHIND) → may run an old spec; unpushed (AHEAD/DIVERGED) →
-    # won't propagate. Default = LOUD WARNING, never a block (hosts like
-    # spartan legitimately carry local commits). ``--strict-drift`` /
-    # ``SAC_STRICT_DRIFT=1`` escalate to a hard block. Always best-effort:
-    # a non-git source / unreachable remote / any error warns-and-continues
-    # — the check never crashes a launch (resilience is the contract).
+    # TWO SPEC-SANITY GATES, refuse-by-default, each with its OWN named
+    # override (operator ruling 2026-08-10 — never a blanket --force).
+    # (1) spec source BEHIND/DIVERGED = a possibly STALE spec; escape hatch
+    # ``--allow-stale-spec``. AHEAD / non-git / unreachable still start.
+    # (2) undeclared ``to_home_layers``; escape hatch
+    # ``--allow-undeclared-layers``, and the refusal itself is still gated
+    # on the fleet migration (``_layers_preflight.ENFORCE_BY_DEFAULT``).
+    # (2) is called HERE, once, not in the resolver a start invokes twice.
     _check_spec_source_drift_at_launch(config_path, config.name, strict_drift)
+    check_to_home_layers_at_launch(config)
 
     # Launch-time BOARD IDENTITY check, same contract as the drift check
     # above: LOUD WARNING, never a block, never crashes a launch. An agent

--- a/src/scitex_agent_container/_lifecycle/_start_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_start_preflight.py
@@ -7,6 +7,7 @@ Extracted from ``_start.py`` (split for the 512-line module limit).
 
 from __future__ import annotations
 
+import logging
 import traceback
 from pathlib import Path
 from typing import Any, Callable, Mapping
@@ -72,18 +73,39 @@ def _verify_real_liveness(
 
 
 def _resolve_strict_drift(strict_drift: bool | None) -> bool:
-    """Resolve effective strict-drift mode (arg wins, else env).
+    """Resolve effective strict-drift mode. STRICT IS NOW THE DEFAULT.
 
-    ``strict_drift=True/False`` from ``--strict-drift`` takes priority.
-    ``None`` falls back to ``SAC_STRICT_DRIFT`` (``1``/``true``/``yes``
-    → strict). Read through the sac env helper so either prefix works.
+    Operator ruling 2026-08-10: a spec that is wrong refuses to start, and the
+    way past it is an explicitly NAMED override rather than a blanket force.
+    So the precedence is:
+
+      1. ``strict_drift=True/False`` — the caller said so outright
+         (``--strict-drift`` forces strict; ``--allow-stale-spec`` passes
+         ``False``). An explicit argument always wins.
+      2. ``SAC_ALLOW_STALE_SPEC`` truthy → lenient. The named env override.
+      3. ``SAC_STRICT_DRIFT`` — the legacy opt-in knob, still honoured in
+         BOTH directions so an existing ``SAC_STRICT_DRIFT=0`` in someone's
+         environment keeps meaning "do not block me" rather than silently
+         becoming a no-op the day the default flipped.
+      4. otherwise STRICT.
+
+    Read through the sac env helper so either env prefix works. Note that
+    "strict" only ever refuses a STALE spec (BEHIND / DIVERGED) — AHEAD,
+    NOT_A_REPO and UNREACHABLE still start. See ``_drift._local``.
     """
     if strict_drift is not None:
         return strict_drift
+    from .._drift._local import ALLOW_STALE_ENV
     from .._env import getenv as _sac_env
 
-    raw = (_sac_env("STRICT_DRIFT", "") or "").strip().lower()
-    return raw in ("1", "true", "yes", "on")
+    truthy = ("1", "true", "yes", "on")
+    allow = (_sac_env(ALLOW_STALE_ENV.removeprefix("SAC_"), "") or "").strip().lower()
+    if allow in truthy:
+        return False
+    legacy = (_sac_env("STRICT_DRIFT", "") or "").strip().lower()
+    if legacy:
+        return legacy in truthy
+    return True
 
 
 def _slug_of_credentials_file(path: Path) -> str:
@@ -389,19 +411,35 @@ def _rotate_to_healthy_account(
 def _check_spec_source_drift_at_launch(
     config_path: str, agent_name: str, strict_drift: bool | None
 ) -> None:
-    """Run the launch-time drift check; warn loud (or block if strict).
+    """Run the launch-time drift check; REFUSE on a stale spec by default.
 
     Fully guarded: the underlying check never raises except the
     deliberate strict-mode :class:`SpecSourceDriftError`. We let that
     propagate (the CLI / caller turns it into a non-zero exit); any
     other unexpected failure here is swallowed so a launch is never
     crashed by the drift guard.
+
+    When the refusal was OVERRIDDEN and the spec really is stale, that fact is
+    logged at ERROR naming the condition and the agent. A silent override is
+    just a slower version of the warning nobody read.
     """
     from .._drift import SpecSourceDriftError, warn_if_spec_source_drifted
+    from .._drift._local import ALLOW_STALE_ENV, ALLOW_STALE_FLAG
 
     strict = _resolve_strict_drift(strict_drift)
     try:
-        warn_if_spec_source_drifted(config_path, agent=agent_name, strict=strict)
+        status = warn_if_spec_source_drifted(
+            config_path, agent=agent_name, strict=strict
+        )
+        if not strict and status.is_stale:
+            logging.getLogger(__name__).error(
+                "sac-drift BYPASSED for agent %r: the spec source is STALE (%s) "
+                "and the start was allowed anyway by %s / %s.",
+                agent_name,
+                status.summary(),
+                ALLOW_STALE_FLAG,
+                ALLOW_STALE_ENV,
+            )
     except SpecSourceDriftError:
         # Deliberate strict-mode block — propagate so the caller exits
         # non-zero. This is the ONE thing this guard is allowed to raise.

--- a/src/scitex_agent_container/_maintenance/_layers_migration_plan.py
+++ b/src/scitex_agent_container/_maintenance/_layers_migration_plan.py
@@ -40,7 +40,6 @@ first ``": "``.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 from pathlib import Path
 
@@ -52,7 +51,6 @@ from ._roster_state import inspect_roster
 logger = logging.getLogger(__name__)
 
 _NO_ANCHOR = "no 'to_home:' line to anchor the declaration to"
-_RESOLVE_LOGGER = "scitex_agent_container.runtimes._to_home_resolve"
 #: An unreadable spec's reason, capped. The full exception is logged; this is
 #: the one-line form a report and a JSON field can carry without either
 #: swallowing the useful half or spilling a 60-line validation dump per spec.
@@ -71,29 +69,6 @@ def _reason(agent: str, exc: BaseException) -> str:
     if len(flat) > _REASON_CHARS:
         flat = flat[: _REASON_CHARS - 1] + "…"
     return f"{agent}: {type(exc).__name__}: {flat}"
-
-
-@contextlib.contextmanager
-def quiet_undeclared_warning():
-    """Silence ``settings_layer_dirs``' per-agent "declares no layers" WARNING.
-
-    That warning exists to make this migration visible, and it works: measured
-    on this host it fires 101 times in one dry-run, once per undeclared spec.
-    Inside THIS verb it is pure noise — the command's entire output is that
-    same finding, counted, attributed and per-agent, and 101 copies on stderr
-    bury the report they duplicate.
-
-    Scoped as tightly as it can be: one named logger, restored in ``finally``,
-    and never touched on any production path. Suppressing it anywhere else
-    would hide the signal instead of rendering it.
-    """
-    log = logging.getLogger(_RESOLVE_LOGGER)
-    previous = log.level
-    log.setLevel(logging.ERROR)
-    try:
-        yield
-    finally:
-        log.setLevel(previous)
 
 
 def fleet_spec_paths(specs_dir: "Path | None" = None) -> "list[Path]":
@@ -223,6 +198,5 @@ __all__ = [
     "fleet_spec_paths",
     "plan_migration",
     "plan_spec",
-    "quiet_undeclared_warning",
     "resolved_layer_names",
 ]

--- a/src/scitex_agent_container/cli_pkg/_agents_migrate_layers.py
+++ b/src/scitex_agent_container/cli_pkg/_agents_migrate_layers.py
@@ -51,11 +51,7 @@ from rich.markup import escape
 
 from .._maintenance._layers_migration_apply import apply_migration
 from .._maintenance._layers_migration_gate import fleet_arming_snapshot, gate_arming
-from .._maintenance._layers_migration_plan import (
-    already_declared,
-    plan_migration,
-    quiet_undeclared_warning,
-)
+from .._maintenance._layers_migration_plan import already_declared, plan_migration
 from ._helpers import _json_flag, console
 
 _EXIT_OK = 0
@@ -296,15 +292,17 @@ def migrate_layers(
             "drop both flags to preview, pass --apply to write."
         )
 
-    # Quieted around the resolver calls only: the "declares no layers" WARNING
-    # fires once per undeclared spec (101 on this host) and this command's whole
-    # output IS that finding, aggregated. See quiet_undeclared_warning.
-    with quiet_undeclared_warning():
-        # No arguments: plan_migration resolves the roster AND records the root
-        # it searched. Handing it fleet_spec_paths() would give it the same
-        # paths and hide where they came from, which is exactly how a run
-        # against a non-existent root reported a sound plan.
-        plan = plan_migration()
+    # No arguments: plan_migration resolves the roster AND records the root it
+    # searched. Handing it fleet_spec_paths() would give it the same paths and
+    # hide where they came from, which is exactly how a run against a
+    # non-existent root reported a sound plan.
+    #
+    # This used to run inside a ``quiet_undeclared_warning()`` context, because
+    # the resolver logged "declares no layers" once per undeclared spec and 101
+    # copies buried the report they duplicated. The resolver no longer logs at
+    # all (the finding moved to the launch gate), so the silencer was deleted
+    # rather than left in place muting a logger nothing writes to.
+    plan = plan_migration()
     payload = _plan_payload(plan)
     payload["mode"] = "apply" if apply else "dry-run"
 
@@ -355,8 +353,7 @@ def migrate_layers(
         )
         raise SystemExit(_EXIT_OK)
 
-    with quiet_undeclared_warning():
-        code, applied = _run_apply(plan, [e.path for e in plan.edits])
+    code, applied = _run_apply(plan, [e.path for e in plan.edits])
     payload.update(applied)
     payload["exit_code"] = code
     if _json_flag(ctx, as_json):

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
@@ -16,6 +16,7 @@ import click
 
 from .._helpers import agent_name_complete, console
 from ._common import _iter_agent_yamls
+from ._start_gate_options import spec_gate_options
 from ._start_group_filter import apply_group_targets, group_option
 from ._start_preflight_gate import make_preflight_runner
 
@@ -52,7 +53,11 @@ from ._start_preflight_gate import make_preflight_runner
     "and overrides the YAML's claude.session / claude.resume_id.",
 )
 @click.option(
-    "-n", "--tail-lines", "tail_lines", type=int, default=None,
+    "-n",
+    "--tail-lines",
+    "tail_lines",
+    type=int,
+    default=None,
     help="Trailing transcript messages to preview per resumable session "
     "on a stale --resume (sac-session-candidates-tail-preview).",
 )
@@ -180,14 +185,7 @@ from ._start_preflight_gate import make_preflight_runner
     default=False,
     help="Replace existing materialised yamls under --params-out.",
 )
-@click.option(
-    "--strict-drift",
-    "strict_drift",
-    is_flag=True,
-    default=False,
-    help="Hard-block (non-zero exit) on a drifted spec-source git repo "
-    "instead of warn-and-launch. Equivalent to SAC_STRICT_DRIFT=1.",
-)
+@spec_gate_options
 @click.option(
     "--no-redispatch",
     "no_redispatch",

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
@@ -254,7 +254,7 @@ def start(
     params_file: Path | None,
     params_out: Path | None,
     params_overwrite: bool,
-    strict_drift: bool,
+    strict_drift: bool | None,
     no_redispatch: bool,
     broker_self: bool,
     concurrency: int,

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_gate_options.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_gate_options.py
@@ -45,6 +45,21 @@ from ..._drift._local import ALLOW_STALE_ENV
 from ..._lifecycle._layers_preflight import ALLOW_ENV as ALLOW_LAYERS_ENV
 
 
+def _true_or_unset(ctx, param, value):  # noqa: ARG001 - click callback signature
+    """``--strict-drift`` yields ``True`` when passed and ``None`` when not.
+
+    NOT ``False``. This is load-bearing and it is easy to get wrong: since the
+    refusal became the DEFAULT, ``_resolve_strict_drift`` treats an explicit
+    ``False`` as "the caller demanded leniency" and returns it unchanged. A
+    click flag's natural default IS ``False``, so leaving it would have had the
+    CLI silently disable the gate on every single start — the flag nobody
+    passed would be the one turning the refusal off. ``None`` means "no
+    instruction", which is what an absent flag actually means, and lets the
+    default policy (and the env overrides) apply.
+    """
+    return True if value else None
+
+
 def _set_env_when_given(env_var: str):
     """Build a click callback that sets ``env_var=1`` when the flag is passed.
 
@@ -70,6 +85,7 @@ def spec_gate_options(func):
             "strict_drift",
             is_flag=True,
             default=False,
+            callback=_true_or_unset,
             help="Hard-block on a STALE spec-source git repo. This is now the "
             "DEFAULT; the flag remains so a caller can state it explicitly.",
         ),

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_gate_options.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_gate_options.py
@@ -1,0 +1,101 @@
+"""The ``sac agents start`` SPEC-GATE options, and how they reach the gates.
+
+Two launch-time gates refuse a start by default (operator ruling 2026-08-10:
+「スペックがおかしかったら起動不可っていうのをデフォルトに」):
+
+* the spec source is STALE — BEHIND / DIVERGED from its remote, so the spec
+  about to launch may be an old one; and
+* the spec declares no ``to_home_layers``, so what gets merged into the agent
+  is invisible from the spec alone.
+
+Each gate has exactly ONE named override. Deliberately not a blanket
+``--force`` / ``--ignore-warnings``: a generic override skips every check at
+once, leaves no record of WHICH check was bypassed, and gets reused by the next
+person for an unrelated failure. ``git --no-verify`` is the cautionary example,
+and this fleet already bans that idiom by hook.
+
+**How an override reaches the gate: the env var, set from a click callback.**
+Both overrides are ``expose_value=False`` — click never passes them to the
+command function; their callbacks set the gate's env var instead. That is not
+a shortcut around plumbing, it is the only transport that survives the
+PARALLEL path: a multi-target ``sac agents start`` re-execs itself as one
+SUBPROCESS PER AGENT (``_start_parallel``), and a subprocess inherits the
+environment, not the parent's local variables. Threading two more keywords
+through ``start -> maybe_run_parallel -> run_single_targets -> agent_start``
+would also have to append two more flags to that child argv to work at all.
+
+The gates themselves read those env vars as their documented override
+(``_lifecycle._start_preflight._resolve_strict_drift`` and
+``_lifecycle._layers_preflight``), so the CLI adds no second source of truth.
+
+PRECEDENCE, stated because both can be passed at once: an explicit
+``--strict-drift`` wins over ``--allow-stale-spec``, because
+``_resolve_strict_drift`` gives an explicit argument priority over the env.
+The stricter of two contradictory instructions is the safe winner, and the
+``--allow-stale-spec`` help says so rather than leaving it to be discovered.
+"""
+
+from __future__ import annotations
+
+import os
+
+import click
+
+from ..._drift._local import ALLOW_STALE_ENV
+from ..._lifecycle._layers_preflight import ALLOW_ENV as ALLOW_LAYERS_ENV
+
+
+def _set_env_when_given(env_var: str):
+    """Build a click callback that sets ``env_var=1`` when the flag is passed.
+
+    Only ever SETS the variable. A flag that is absent must leave an
+    environment the operator exported themselves alone — silently unsetting it
+    would make ``SAC_ALLOW_STALE_SPEC=1 sac agents start x`` behave differently
+    from the same export two lines earlier in a shell script.
+    """
+
+    def _callback(ctx, param, value):  # noqa: ARG001 - click callback signature
+        if value:
+            os.environ[env_var] = "1"
+        return value
+
+    return _callback
+
+
+def spec_gate_options(func):
+    """Apply the three spec-gate flags to a click command, in help order."""
+    options = (
+        click.option(
+            "--strict-drift",
+            "strict_drift",
+            is_flag=True,
+            default=False,
+            help="Hard-block on a STALE spec-source git repo. This is now the "
+            "DEFAULT; the flag remains so a caller can state it explicitly.",
+        ),
+        click.option(
+            "--allow-stale-spec",
+            is_flag=True,
+            default=False,
+            expose_value=False,
+            callback=_set_env_when_given(ALLOW_STALE_ENV),
+            help="Start even though the spec source is BEHIND/DIVERGED from "
+            f"its remote ({ALLOW_STALE_ENV}=1). Ignored if --strict-drift is "
+            "also passed.",
+        ),
+        click.option(
+            "--allow-undeclared-layers",
+            is_flag=True,
+            default=False,
+            expose_value=False,
+            callback=_set_env_when_given(ALLOW_LAYERS_ENV),
+            help="Start even though the spec declares no 'to_home_layers' "
+            f"({ALLOW_LAYERS_ENV}=1).",
+        ),
+    )
+    for option in reversed(options):
+        func = option(func)
+    return func
+
+
+__all__ = ["spec_gate_options"]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_parallel.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_parallel.py
@@ -62,7 +62,7 @@ def build_child_argv(
     no_preflight: bool,
     force: bool,
     session_mode: str | None,
-    strict_drift: bool,
+    strict_drift: bool | None,
     broker_self: bool,
 ) -> list[str]:
     """Build the child ``sac agents start <target> ...`` argv.
@@ -96,7 +96,7 @@ def run_parallel_targets(
     no_preflight: bool,
     force: bool,
     session_mode: str | None,
-    strict_drift: bool,
+    strict_drift: bool | None,
     broker_self: bool,
 ) -> None:
     """Launch ``targets`` as bounded-parallel child subprocesses.
@@ -178,7 +178,7 @@ def maybe_run_parallel(
     no_preflight: bool,
     force: bool,
     session_mode: str | None,
-    strict_drift: bool,
+    strict_drift: bool | None,
     broker_self: bool,
     foreground: bool,
     multi_foreground: bool,

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -70,7 +70,7 @@ def run_single_targets(
     as_json: bool,
     foreground: bool,
     one_shot: bool,
-    strict_drift: bool,
+    strict_drift: bool | None,
     no_redispatch: bool,
     multi_foreground: bool,
     preflight_runner: Callable[[], None],

--- a/src/scitex_agent_container/runtimes/_to_home_errors.py
+++ b/src/scitex_agent_container/runtimes/_to_home_errors.py
@@ -85,6 +85,22 @@ class UnknownToHomeLayer(RuntimeError):
     """
 
 
+class UndeclaredToHomeLayers(RuntimeError):
+    """The spec declares no ``to_home_layers`` at all — refused at launch.
+
+    The sibling of :class:`UnknownToHomeLayer`: that one is a declaration that
+    names nothing real, this one is the absence of a declaration. Both leave
+    the reader unable to tell from the spec what gets merged into the agent,
+    which is the exact failure the field exists to remove.
+
+    Raised by :func:`.._lifecycle._layers_preflight.check_to_home_layers_at_launch`
+    BEFORE the runtime is built, so a refusal never leaves a half-deployed
+    workspace behind. ``--allow-undeclared-layers`` /
+    ``SAC_ALLOW_UNDECLARED_LAYERS=1`` starts anyway and logs the bypass at
+    ERROR level naming the agent.
+    """
+
+
 class WorkspaceSettingsMergeError(RuntimeError):
     """A ``settings.json`` to_home layer is not valid JSON — refused.
 
@@ -98,6 +114,8 @@ class WorkspaceSettingsMergeError(RuntimeError):
 
 __all__ = [
     "LayerMergeConflict",
+    "UndeclaredToHomeLayers",
+    "UnknownToHomeLayer",
     "WorkspaceSettingsMergeError",
     "WorkspaceCLAUDEMarkerError",
     "WorkspaceCredentialLeakError",

--- a/src/scitex_agent_container/runtimes/_to_home_resolve.py
+++ b/src/scitex_agent_container/runtimes/_to_home_resolve.py
@@ -199,10 +199,15 @@ def settings_layer_dirs(config: AgentConfig) -> "list[tuple[str, Path | None]]":
     agent's legitimate way of pinning its home to its own spec.
 
     When the spec declares NOTHING, every layer applies — today's behaviour —
-    and a WARNING names the agent. That asymmetry is deliberate and temporary:
-    all 102 registered specs are currently undeclared (measured 2026-08-09), so
-    refusing here would disarm the entire fleet in one deploy. The warning is
-    what makes the migration visible before the refusal replaces it.
+    and this function says nothing about it. It used to log a WARNING here, and
+    that was the wrong place: this is a PURE resolver, and a single start calls
+    it TWICE (workspace home, then the apptainer overlay upper — see
+    ``_to_home_overlay.deploy_to_home_overlay``), so one agent produced two
+    identical paragraphs. The missing declaration is a property of the SPEC,
+    decided once per launch, so the complaint — and, once the fleet's specs are
+    migrated, the REFUSAL — lives in
+    :func:`.._lifecycle._layers_preflight.check_to_home_layers_at_launch`,
+    which ``agent_start`` calls exactly once.
     """
     resolved = _collapse_duplicate_paths(
         [
@@ -214,13 +219,6 @@ def settings_layer_dirs(config: AgentConfig) -> "list[tuple[str, Path | None]]":
 
     declared = getattr(config, "to_home_layers", None)
     if declared is None:
-        logger.warning(
-            "to_home: agent %r declares no 'to_home_layers'; inheriting the "
-            "implicit cascade (%s). Declare the layers in the spec so what "
-            "gets merged into this agent is visible from the spec alone.",
-            getattr(config, "name", "<unnamed>"),
-            ", ".join(name for name, path in resolved if path is not None) or "none",
-        )
         return resolved
 
     wanted = set(declared)

--- a/tests/scitex_agent_container/_lifecycle/test__layers_preflight.py
+++ b/tests/scitex_agent_container/_lifecycle/test__layers_preflight.py
@@ -1,0 +1,410 @@
+"""Tests for the ``to_home_layers`` launch gate and its de-duplication.
+
+Two facts are pinned here, and they are separate:
+
+1. **The gate.** An undeclared spec refuses to start once enforcement is on,
+   and the NAMED override (``--allow-undeclared-layers`` /
+   ``SAC_ALLOW_UNDECLARED_LAYERS``) starts it anyway while saying so at ERROR.
+2. **The duplication.** The finding used to be logged inside
+   ``settings_layer_dirs`` — a pure resolver that ONE start calls TWICE
+   (workspace home, then the apptainer overlay upper), which is why the
+   operator's paste showed the same paragraph twice for one agent. The
+   resolver must now log nothing, and ``agent_start`` must report it once.
+
+PA-306 no-mocks: real spec objects, a real spec.yaml on disk, a real
+hand-rolled runtime/handover surface. STX-TQ002/TQ007: AAA markers, one fact
+per test.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from scitex_agent_container._lifecycle._layers_preflight import (
+    ALLOW_ENV,
+    ENFORCE_BY_DEFAULT,
+    ENFORCE_ENV,
+    check_to_home_layers_at_launch,
+)
+from scitex_agent_container._lifecycle._start import agent_start
+from scitex_agent_container._state.registry import Registry
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.runtimes._to_home_errors import UndeclaredToHomeLayers
+from scitex_agent_container.runtimes._to_home_resolve import settings_layer_dirs
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
+_RESOLVER_LOGGER = "scitex_agent_container.runtimes._to_home_resolve"
+_GATE_LOGGER = "scitex_agent_container._lifecycle._layers_preflight"
+
+
+class _Spec:
+    """The four attributes the gate and the resolver read off a config.
+
+    A real object with real attributes, not a stand-in for a collaborator:
+    both functions take a config and read exactly these.
+    """
+
+    def __init__(self, to_home_layers, *, name="agent-under-test", to_home=""):
+        self.name = name
+        self.to_home_layers = to_home_layers
+        self.to_home = to_home
+        self.config_path = "/nonexistent/agent-under-test/spec.yaml"
+
+
+def _refusal_message(spec) -> str:
+    """The text of the refusal the gate raises for ``spec``.
+
+    Captured with try/except rather than ``pytest.raises`` so each caller keeps
+    exactly ONE assertion (STX-TQ007 counts a ``raises`` block as an assert).
+    Returns ``""`` when nothing was raised, which fails the content assertions
+    honestly instead of erroring somewhere unrelated.
+    """
+    try:
+        check_to_home_layers_at_launch(spec, enforce=True)
+    except UndeclaredToHomeLayers as exc:
+        return str(exc)
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# the gate itself
+# ---------------------------------------------------------------------------
+
+
+class TestDeclaredSpecPasses:
+    """A spec that states its layers is exactly what the gate wants."""
+
+    def test_declared_spec_returns_true(self):
+        # Arrange
+        spec = _Spec(["user-shared"])
+        # Act
+        allowed = check_to_home_layers_at_launch(spec, enforce=True)
+        # Assert
+        assert allowed is True
+
+    def test_declared_spec_logs_nothing(self, caplog):
+        # Arrange
+        spec = _Spec(["user-shared"])
+        # Act
+        with caplog.at_level(logging.WARNING, logger=_GATE_LOGGER):
+            check_to_home_layers_at_launch(spec, enforce=True)
+        # Assert
+        assert caplog.records == []
+
+    def test_empty_declaration_is_a_declaration(self):
+        # Arrange — an explicit [] pins the agent to its own spec; not absent.
+        spec = _Spec([])
+        # Act
+        allowed = check_to_home_layers_at_launch(spec, enforce=True)
+        # Assert
+        assert allowed is True
+
+
+class TestUndeclaredSpecRefuses:
+    """Undeclared + enforcing = a start-time REFUSAL, not a warning.
+
+    The operator's reason, verbatim in intent: nobody fixes warnings. This one
+    had been printing for months.
+    """
+
+    def test_undeclared_spec_raises_when_enforcing(self):
+        # Arrange
+        spec = _Spec(None)
+        # Act
+        # Assert
+        with pytest.raises(UndeclaredToHomeLayers):
+            check_to_home_layers_at_launch(spec, enforce=True)
+
+    def test_refusal_names_the_agent(self):
+        # Arrange
+        message = _refusal_message(_Spec(None, name="grant"))
+        # Act
+        # Assert
+        assert "grant" in message
+
+    def test_refusal_names_the_fix_command(self):
+        # Arrange
+        message = _refusal_message(_Spec(None))
+        # Act
+        # Assert
+        assert "sac agents migrate-layers --apply" in message
+
+    def test_refusal_names_the_override(self):
+        # Arrange — a refusal with no stated way past it is a dead end.
+        message = _refusal_message(_Spec(None))
+        # Act
+        # Assert
+        assert "--allow-undeclared-layers" in message
+
+
+class TestNamedOverride:
+    """``--allow-undeclared-layers`` starts the agent — loudly."""
+
+    def test_override_allows_the_start(self):
+        # Arrange
+        spec = _Spec(None)
+        # Act
+        allowed = check_to_home_layers_at_launch(
+            spec, enforce=True, allow_undeclared=True
+        )
+        # Assert
+        assert allowed is True
+
+    def test_override_is_logged_at_error(self, caplog):
+        # Arrange — a silent override is a slower version of the ignored warning.
+        spec = _Spec(None)
+        # Act
+        with caplog.at_level(logging.ERROR, logger=_GATE_LOGGER):
+            check_to_home_layers_at_launch(spec, enforce=True, allow_undeclared=True)
+        # Assert
+        assert any("BYPASSED" in rec.getMessage() for rec in caplog.records)
+
+    def test_override_log_names_the_agent(self, caplog):
+        # Arrange
+        spec = _Spec(None, name="grant")
+        # Act
+        with caplog.at_level(logging.ERROR, logger=_GATE_LOGGER):
+            check_to_home_layers_at_launch(spec, enforce=True, allow_undeclared=True)
+        # Assert
+        assert any("grant" in rec.getMessage() for rec in caplog.records)
+
+    def test_env_override_is_honoured(self, env_save_restore):
+        # Arrange
+        env_save_restore.set(ALLOW_ENV, "1")
+        spec = _Spec(None)
+        # Act
+        allowed = check_to_home_layers_at_launch(spec, enforce=True)
+        # Assert
+        assert allowed is True
+
+    def test_explicit_arg_beats_the_env(self, env_save_restore):
+        # Arrange — an explicit False must not be overridden by a stale export.
+        env_save_restore.set(ALLOW_ENV, "1")
+        spec = _Spec(None)
+        # Act
+        # Assert
+        with pytest.raises(UndeclaredToHomeLayers):
+            check_to_home_layers_at_launch(spec, enforce=True, allow_undeclared=False)
+
+
+class TestEnforcementSequencing:
+    """The refusal is REAL but not yet the default: 101 of the fleet's 102
+    specs are undeclared, so flipping it before the dotfiles migration lands
+    would stop every agent booting. This pins the sequencing, not a preference.
+    """
+
+    def test_enforcement_is_still_opt_in(self):
+        # Arrange
+        # Act
+        # Assert — flip this (and the constant) only after the specs migrate.
+        assert ENFORCE_BY_DEFAULT is False
+
+    def test_undeclared_spec_starts_while_not_enforcing(self):
+        # Arrange
+        spec = _Spec(None)
+        # Act
+        allowed = check_to_home_layers_at_launch(spec, enforce=False)
+        # Assert
+        assert allowed is True
+
+    def test_not_enforcing_still_warns(self, caplog):
+        # Arrange — visible as a migration to-do, just not a refusal yet.
+        spec = _Spec(None)
+        # Act
+        with caplog.at_level(logging.WARNING, logger=_GATE_LOGGER):
+            check_to_home_layers_at_launch(spec, enforce=False)
+        # Assert
+        assert any("to_home_layers" in rec.getMessage() for rec in caplog.records)
+
+    def test_env_switch_turns_enforcement_on(self, env_save_restore):
+        # Arrange
+        env_save_restore.set(ENFORCE_ENV, "1")
+        spec = _Spec(None)
+        # Act
+        # Assert
+        with pytest.raises(UndeclaredToHomeLayers):
+            check_to_home_layers_at_launch(spec)
+
+
+# ---------------------------------------------------------------------------
+# the duplication: the resolver must be silent, the start must report once
+# ---------------------------------------------------------------------------
+
+
+class TestResolverIsSilent:
+    """``settings_layer_dirs`` is a PURE resolver. It logged the finding, and a
+    single start calls it twice — once for the workspace home and once for the
+    apptainer overlay upper — which is why one agent produced two identical
+    paragraphs. It must now say nothing at all."""
+
+    def test_resolver_logs_nothing_when_undeclared(self, caplog):
+        # Arrange
+        spec = _Spec(None)
+        # Act
+        with caplog.at_level(logging.DEBUG, logger=_RESOLVER_LOGGER):
+            settings_layer_dirs(spec)
+        # Assert
+        assert [r for r in caplog.records if "to_home_layers" in r.getMessage()] == []
+
+    def test_two_resolutions_stay_silent(self, caplog):
+        # Arrange — the exact shape of the duplication: resolve, then resolve.
+        spec = _Spec(None)
+        # Act
+        with caplog.at_level(logging.DEBUG, logger=_RESOLVER_LOGGER):
+            settings_layer_dirs(spec)
+            settings_layer_dirs(spec)
+        # Assert
+        assert [r for r in caplog.records if "to_home_layers" in r.getMessage()] == []
+
+    def test_resolver_still_returns_the_implicit_cascade(self):
+        # Arrange — silence must not change WHAT an undeclared spec inherits.
+        spec = _Spec(None)
+        # Act
+        names = [name for name, _ in settings_layer_dirs(spec)]
+        # Assert
+        assert names == ["user-shared", "project-shared", "per-agent"]
+
+
+class _FakeRuntime:
+    """Real runtime surface; records whether start() was reached."""
+
+    def __init__(self) -> None:
+        self.started: list[AgentConfig] = []
+
+    def is_running(self, config: AgentConfig) -> bool:
+        return False
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        self.started.append(config)
+        return True
+
+    def stop(self, config: AgentConfig) -> None:  # pragma: no cover - unused
+        pass
+
+
+class _FakeHandover:
+    """Real handover surface; no-op for the module callables."""
+
+    def ensure_instance_uuid(self, config: AgentConfig) -> str:
+        return "uuid"
+
+    def hydrate_from_hub(self, config: AgentConfig) -> bool:
+        return True
+
+    def start_failback_poller(self, config: AgentConfig) -> None:
+        pass
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path) -> Iterator[Path]:
+    """HOME + SCITEX_DIR inside tmp_path so nothing touches the real fleet."""
+    home = tmp_path / "home"
+    home.mkdir()
+    previous = {k: os.environ.get(k) for k in ("HOME", "SCITEX_DIR")}
+    os.environ["HOME"] = str(home)
+    os.environ["SCITEX_DIR"] = str(home / ".scitex")
+    try:
+        yield home
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _write_undeclared_spec(tmp_path: Path) -> Path:
+    """A real, loadable spec.yaml that declares no ``to_home_layers``.
+
+    Deliberately NOT inside a git repo: the sibling drift gate then reports
+    NOT_A_REPO (drift unknown, never a refusal), so this test measures the
+    layers gate alone.
+    """
+    agent_dir = tmp_path / "agents" / "alpha"
+    agent_dir.mkdir(parents=True)
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(
+        explicitize_yaml(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            "spec:\n"
+            "  runtime: apptainer\n"
+            "  host: ${HOSTNAME}\n"
+            f"  workdir: {tmp_path / 'work'}\n"
+            "  apptainer:\n    image: /x.sif\n    binds: []\n"
+            "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+            "  claude:\n"
+            "    model: sonnet\n"
+            "  health:\n"
+            "    enabled: false\n"
+            "    interval: 60\n"
+        )
+    )
+    return spec
+
+
+class TestReportedOncePerStart:
+    """The whole point of moving the check out of the resolver: ONE start, ONE
+    report. Before the move this same start produced two."""
+
+    def test_start_reports_undeclared_layers_exactly_once(
+        self, tmp_path, isolated_home, caplog
+    ):
+        # Arrange
+        spec = _write_undeclared_spec(tmp_path)
+        runtime = _FakeRuntime()
+        # Act
+        with caplog.at_level(logging.WARNING, logger=_GATE_LOGGER):
+            agent_start(
+                str(spec),
+                registry=Registry(registry_dir=tmp_path / "reg"),
+                runtime_factory=lambda _c: runtime,
+                handover_mod=_FakeHandover(),
+                sleep_fn=lambda _s: None,
+            )
+        # Assert
+        hits = [r for r in caplog.records if "to_home_layers" in r.getMessage()]
+        assert len(hits) == 1
+
+    def test_start_still_reaches_the_runtime_while_not_enforcing(
+        self, tmp_path, isolated_home
+    ):
+        # Arrange
+        spec = _write_undeclared_spec(tmp_path)
+        runtime = _FakeRuntime()
+        # Act
+        agent_start(
+            str(spec),
+            registry=Registry(registry_dir=tmp_path / "reg"),
+            runtime_factory=lambda _c: runtime,
+            handover_mod=_FakeHandover(),
+            sleep_fn=lambda _s: None,
+        )
+        # Assert
+        assert len(runtime.started) == 1
+
+    def test_start_refuses_an_undeclared_spec_when_enforcing(
+        self, tmp_path, isolated_home, env_save_restore
+    ):
+        # Arrange
+        env_save_restore.set(ENFORCE_ENV, "1")
+        spec = _write_undeclared_spec(tmp_path)
+        runtime = _FakeRuntime()
+        # Act
+        try:
+            agent_start(
+                str(spec),
+                registry=Registry(registry_dir=tmp_path / "reg"),
+                runtime_factory=lambda _c: runtime,
+                handover_mod=_FakeHandover(),
+                sleep_fn=lambda _s: None,
+            )
+        except UndeclaredToHomeLayers:
+            pass
+        # Assert — refused BEFORE the runtime was touched.
+        assert runtime.started == []

--- a/tests/scitex_agent_container/_lifecycle/test__start_drift.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_drift.py
@@ -6,18 +6,18 @@ in tmp_path); a real hand-rolled fake runtime/handover capture whether
 the drift fetch-cache and Path.home() never touch the developer's home.
 
 Covers:
-  * default (lenient) → drifted source warns but the runtime still starts.
-  * --strict-drift → drifted source raises SpecSourceDriftError BEFORE
-    the runtime is touched.
-  * env SAC_STRICT_DRIFT honoured by ``_resolve_strict_drift`` (arg wins).
-  * a clean (current) source launches normally under strict.
+  * DEFAULT (2026-08-10 operator ruling) → a STALE source REFUSES to start,
+    raising SpecSourceDriftError BEFORE the runtime is touched.
+  * --allow-stale-spec / SAC_ALLOW_STALE_SPEC → starts anyway, loudly.
+  * AHEAD (unpushed local commits) is NOT staleness → still starts by default.
+  * env SAC_ALLOW_STALE_SPEC / legacy SAC_STRICT_DRIFT honoured by
+    ``_resolve_strict_drift`` (an explicit arg wins over both).
+  * a clean (current) source launches normally.
 
 Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
 """
 
 from __future__ import annotations
-
-from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
 import os
 import subprocess
@@ -30,6 +30,7 @@ from scitex_agent_container._drift import SpecSourceDriftError
 from scitex_agent_container._lifecycle._start import _resolve_strict_drift, agent_start
 from scitex_agent_container._state.registry import Registry
 from scitex_agent_container.config import AgentConfig
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -107,19 +108,21 @@ def _make_spec_repo(tmp_path: Path, *, drifted: bool) -> Path:
     agent_dir.mkdir(parents=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
-        "kind: Agent\n"
-        "spec:\n"
-        "  runtime: apptainer\n"
-        "  host: ${HOSTNAME}\n"
-        f"  workdir: {tmp_path / 'work'}\n"
-        "  apptainer:\n    image: /x.sif\n    binds: []\n"
-        "  restart:\n    policy: on-failure\n    max_retries: 3\n"
-        "  claude:\n"
-        "    model: sonnet\n"
-        "  health:\n"
-        "    enabled: false\n"
-        "    interval: 60\n")
+        explicitize_yaml(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            "spec:\n"
+            "  runtime: apptainer\n"
+            "  host: ${HOSTNAME}\n"
+            f"  workdir: {tmp_path / 'work'}\n"
+            "  apptainer:\n    image: /x.sif\n    binds: []\n"
+            "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+            "  claude:\n"
+            "    model: sonnet\n"
+            "  health:\n"
+            "    enabled: false\n"
+            "    interval: 60\n"
+        )
     )
     _git(work, "add", "-A")
     _git(work, "commit", "-m", "init")
@@ -160,19 +163,97 @@ def registry(tmp_path: Path) -> Registry:
 # ---------------------------------------------------------------------------
 
 
-def test_drifted_source_still_starts_by_default(tmp_path, registry, capsys):
+def test_stale_source_blocks_by_default(tmp_path, registry):
+    # Arrange — the flip: no flag at all, and a BEHIND source refuses.
+    spec = _make_spec_repo(tmp_path, drifted=True)
+    runtime = _FakeRuntime()
+    # Act
+    ctx = pytest.raises(SpecSourceDriftError)
+    # Assert
+    with ctx:
+        _start(spec, registry, runtime)
+
+
+def test_stale_source_does_not_reach_runtime_by_default(tmp_path, registry):
     # Arrange
     spec = _make_spec_repo(tmp_path, drifted=True)
     runtime = _FakeRuntime()
     # Act
-    _start(spec, registry, runtime)
-    # Assert — lenient default: the runtime is reached despite drift.
+    try:
+        _start(spec, registry, runtime)
+    except SpecSourceDriftError:
+        pass
+    # Assert — start() never ran.
+    assert runtime.started == []
+
+
+def test_stale_source_banner_says_error_not_warning(tmp_path, registry, capsys):
+    # Arrange — a refusal that still reads "WARNING" trains the wrong reflex.
+    spec = _make_spec_repo(tmp_path, drifted=True)
+    runtime = _FakeRuntime()
+    # Act
+    try:
+        _start(spec, registry, runtime)
+    except SpecSourceDriftError:
+        pass
+    # Assert
+    assert "sac-drift ERROR" in capsys.readouterr().err
+
+
+def test_refusal_names_the_named_override(tmp_path, registry, capsys):
+    # Arrange — one flag per condition; never a blanket --force.
+    spec = _make_spec_repo(tmp_path, drifted=True)
+    runtime = _FakeRuntime()
+    # Act
+    try:
+        _start(spec, registry, runtime)
+    except SpecSourceDriftError:
+        pass
+    # Assert
+    assert "--allow-stale-spec" in capsys.readouterr().err
+
+
+def test_allow_stale_spec_starts_the_agent(tmp_path, registry):
+    # Arrange — the escape hatch, passed the way --allow-stale-spec passes it.
+    spec = _make_spec_repo(tmp_path, drifted=True)
+    runtime = _FakeRuntime()
+    # Act
+    _start(spec, registry, runtime, strict_drift=False)
+    # Assert
     assert len(runtime.started) == 1
 
 
-def test_drifted_source_emits_loud_warning_by_default(tmp_path, registry, capsys):
-    # Arrange
+def test_allow_stale_spec_env_starts_the_agent(tmp_path, registry, env_save_restore):
+    # Arrange — same override, env transport (what the parallel path inherits).
+    env_save_restore.set("SAC_ALLOW_STALE_SPEC", "1")
     spec = _make_spec_repo(tmp_path, drifted=True)
+    runtime = _FakeRuntime()
+    # Act
+    _start(spec, registry, runtime)
+    # Assert
+    assert len(runtime.started) == 1
+
+
+def test_unpushed_local_commits_still_start(tmp_path, registry):
+    # Arrange — AHEAD is not staleness: the spec here IS the newest that
+    # exists. Hosts like spartan legitimately carry local commits.
+    spec = _make_spec_repo(tmp_path, drifted=False)
+    (spec.parent / "local.txt").write_text("local only")
+    _git(spec.parent.parent.parent, "add", "-A")
+    _git(spec.parent.parent.parent, "commit", "-m", "local work")
+    runtime = _FakeRuntime()
+    # Act
+    _start(spec, registry, runtime)
+    # Assert
+    assert len(runtime.started) == 1
+
+
+def test_unpushed_local_commits_still_warn(tmp_path, registry, capsys):
+    # Arrange — not refusing is not the same as staying quiet.
+    spec = _make_spec_repo(tmp_path, drifted=False)
+    (spec.parent / "local.txt").write_text("local only")
+    _git(spec.parent.parent.parent, "add", "-A")
+    _git(spec.parent.parent.parent, "commit", "-m", "local work")
     runtime = _FakeRuntime()
     # Act
     _start(spec, registry, runtime)
@@ -180,31 +261,7 @@ def test_drifted_source_emits_loud_warning_by_default(tmp_path, registry, capsys
     assert "sac-drift WARNING" in capsys.readouterr().err
 
 
-def test_strict_drift_blocks_before_runtime_start(tmp_path, registry):
-    # Arrange
-    spec = _make_spec_repo(tmp_path, drifted=True)
-    runtime = _FakeRuntime()
-    # Act
-    ctx = pytest.raises(SpecSourceDriftError)
-    # Assert
-    with ctx:
-        _start(spec, registry, runtime, strict_drift=True)
-
-
-def test_strict_drift_does_not_reach_runtime(tmp_path, registry):
-    # Arrange
-    spec = _make_spec_repo(tmp_path, drifted=True)
-    runtime = _FakeRuntime()
-    # Act
-    try:
-        _start(spec, registry, runtime, strict_drift=True)
-    except SpecSourceDriftError:
-        pass
-    # Assert — start() never ran.
-    assert runtime.started == []
-
-
-def test_clean_source_starts_even_under_strict(tmp_path, registry):
+def test_clean_source_starts_normally(tmp_path, registry):
     # Arrange
     spec = _make_spec_repo(tmp_path, drifted=False)
     runtime = _FakeRuntime()
@@ -221,27 +278,49 @@ def test_clean_source_starts_even_under_strict(tmp_path, registry):
 
 def test_explicit_true_arg_wins_over_env(env_save_restore):
     # Arrange
-    env_save_restore.set("SAC_STRICT_DRIFT", "0")
+    env_save_restore.set("SAC_ALLOW_STALE_SPEC", "1")
     # Act
     resolved = _resolve_strict_drift(True)
     # Assert
     assert resolved is True
 
 
-def test_env_truthy_enables_strict_when_arg_none(env_save_restore):
-    # Arrange
+def test_explicit_false_arg_wins_over_env(env_save_restore):
+    # Arrange — what --allow-stale-spec passes; a stale export must not undo it.
     env_save_restore.set("SAC_STRICT_DRIFT", "1")
     # Act
-    resolved = _resolve_strict_drift(None)
+    resolved = _resolve_strict_drift(False)
     # Assert
-    assert resolved is True
+    assert resolved is False
 
 
-def test_env_unset_defaults_to_lenient(env_save_restore):
+def test_allow_stale_env_disables_strict(env_save_restore):
     # Arrange
-    env_save_restore.delete("SAC_STRICT_DRIFT")
-    env_save_restore.delete("SCITEX_AGENT_CONTAINER_STRICT_DRIFT")
+    env_save_restore.set("SAC_ALLOW_STALE_SPEC", "1")
     # Act
     resolved = _resolve_strict_drift(None)
     # Assert
     assert resolved is False
+
+
+def test_legacy_strict_drift_zero_still_disables_strict(env_save_restore):
+    # Arrange — an existing SAC_STRICT_DRIFT=0 meant "do not block me"; the
+    # flipped default must not silently turn that export into a no-op.
+    env_save_restore.delete("SAC_ALLOW_STALE_SPEC")
+    env_save_restore.set("SAC_STRICT_DRIFT", "0")
+    # Act
+    resolved = _resolve_strict_drift(None)
+    # Assert
+    assert resolved is False
+
+
+def test_env_unset_now_defaults_to_strict(env_save_restore):
+    # Arrange — the operator ruling, pinned.
+    env_save_restore.delete("SAC_STRICT_DRIFT")
+    env_save_restore.delete("SCITEX_AGENT_CONTAINER_STRICT_DRIFT")
+    env_save_restore.delete("SAC_ALLOW_STALE_SPEC")
+    env_save_restore.delete("SCITEX_AGENT_CONTAINER_ALLOW_STALE_SPEC")
+    # Act
+    resolved = _resolve_strict_drift(None)
+    # Assert
+    assert resolved is True

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_gate_options.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_gate_options.py
@@ -1,0 +1,153 @@
+"""Tests for the ``sac agents start`` spec-gate flags.
+
+These exist because of a defect that EVERY other test in this change missed.
+The gates default to refusing, and ``_resolve_strict_drift`` treats an explicit
+``False`` as "the caller demanded leniency". A click flag's natural default is
+``False`` — so wiring ``--strict-drift`` straight through would have had the
+CLI hand the resolver an explicit ``False`` on every single start and silently
+disable the gate, while the unit tests (which call ``agent_start`` without the
+keyword, i.e. ``None``) all stayed green.
+
+So the fact under test is not "the flag works". It is: **an absent flag must
+mean NO INSTRUCTION, not an instruction to be lenient.**
+
+PA-306 no-mocks: the real click callbacks and the real command object.
+STX-TQ002/TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+import click
+
+from scitex_agent_container._drift._local import ALLOW_STALE_ENV
+from scitex_agent_container._lifecycle._layers_preflight import ALLOW_ENV
+from scitex_agent_container._lifecycle._start_preflight import _resolve_strict_drift
+from scitex_agent_container.cli_pkg.lifecycle._start_gate_options import (
+    _set_env_when_given,
+    _true_or_unset,
+    spec_gate_options,
+)
+
+
+def _params(func) -> "dict[str, click.Parameter]":
+    """The click parameters the decorator attached, by name/flag."""
+    command = click.command()(func)
+    return {p.name or p.opts[0]: p for p in command.params}
+
+
+@click.command()
+def _bare():  # pragma: no cover - only its parameter list is inspected
+    pass
+
+
+class TestAbsentFlagMeansNoInstruction:
+    """The defect this file exists for."""
+
+    def test_unpassed_strict_drift_resolves_to_none(self):
+        # Arrange — click hands a bare flag ``False`` when it is not passed.
+        # Act
+        resolved = _true_or_unset(None, None, False)
+        # Assert — None, NOT False: "no instruction", not "be lenient".
+        assert resolved is None
+
+    def test_passed_strict_drift_resolves_to_true(self):
+        # Arrange
+        # Act
+        resolved = _true_or_unset(None, None, True)
+        # Assert
+        assert resolved is True
+
+    def test_the_cli_default_still_refuses_a_stale_spec(self, env_save_restore):
+        # Arrange — the end-to-end shape of the bug: what the CLI passes when
+        # NO flag is given must still reach the resolver as STRICT.
+        env_save_restore.delete("SAC_ALLOW_STALE_SPEC")
+        env_save_restore.delete("SCITEX_AGENT_CONTAINER_ALLOW_STALE_SPEC")
+        env_save_restore.delete("SAC_STRICT_DRIFT")
+        env_save_restore.delete("SCITEX_AGENT_CONTAINER_STRICT_DRIFT")
+        # Act
+        resolved = _resolve_strict_drift(_true_or_unset(None, None, False))
+        # Assert
+        assert resolved is True
+
+
+class TestOverridesSetTheirEnvVar:
+    """Both overrides travel as env vars so the parallel path — one SUBPROCESS
+    per agent — inherits them. A local variable would not survive that."""
+
+    def test_allow_stale_callback_sets_its_env_var(self, env_save_restore):
+        # Arrange
+        env_save_restore.delete(ALLOW_STALE_ENV)
+        callback = _set_env_when_given(ALLOW_STALE_ENV)
+        # Act
+        callback(None, None, True)
+        # Assert
+        import os
+
+        assert os.environ[ALLOW_STALE_ENV] == "1"
+
+    def test_allow_layers_callback_sets_its_env_var(self, env_save_restore):
+        # Arrange
+        env_save_restore.delete(ALLOW_ENV)
+        callback = _set_env_when_given(ALLOW_ENV)
+        # Act
+        callback(None, None, True)
+        # Assert
+        import os
+
+        assert os.environ[ALLOW_ENV] == "1"
+
+    def test_absent_flag_leaves_an_exported_env_var_alone(self, env_save_restore):
+        # Arrange — `SAC_ALLOW_STALE_SPEC=1 sac agents start x` must behave the
+        # same as the export two lines earlier in a shell script.
+        env_save_restore.set(ALLOW_STALE_ENV, "1")
+        callback = _set_env_when_given(ALLOW_STALE_ENV)
+        # Act
+        callback(None, None, False)
+        # Assert
+        import os
+
+        assert os.environ[ALLOW_STALE_ENV] == "1"
+
+
+class TestFlagsAreAttached:
+    """All three flags reach the command, and only ``--strict-drift`` is passed
+    to the function body — the two overrides are ``expose_value=False``."""
+
+    def test_strict_drift_is_exposed_to_the_command(self):
+        # Arrange
+        # Act
+        names = _params(lambda **kw: None)
+        # Assert
+        assert "strict_drift" not in names  # undecorated control
+
+    def test_decorator_exposes_strict_drift(self):
+        # Arrange
+        decorated = spec_gate_options(lambda **kw: None)
+        # Act
+        names = _params(decorated)
+        # Assert
+        assert "strict_drift" in names
+
+    def test_decorator_attaches_the_allow_stale_flag(self):
+        # Arrange
+        decorated = spec_gate_options(lambda **kw: None)
+        # Act
+        flags = [opt for p in _params(decorated).values() for opt in p.opts]
+        # Assert
+        assert "--allow-stale-spec" in flags
+
+    def test_decorator_attaches_the_allow_layers_flag(self):
+        # Arrange
+        decorated = spec_gate_options(lambda **kw: None)
+        # Act
+        flags = [opt for p in _params(decorated).values() for opt in p.opts]
+        # Assert
+        assert "--allow-undeclared-layers" in flags
+
+    def test_overrides_are_not_passed_to_the_command_body(self):
+        # Arrange — expose_value=False; they travel by env, not by keyword.
+        decorated = spec_gate_options(lambda **kw: None)
+        # Act
+        exposed = [p.name for p in _params(decorated).values() if p.expose_value]
+        # Assert
+        assert exposed == ["strict_drift"]


### PR DESCRIPTION
## What the operator asked for

He pasted the output of `sac-restart grant`:

```
sac-drift WARNING for agent 'grant':
  the spec source is 5 commit(s) BEHIND origin/develop — you may be launching a STALE spec.
WARN: to_home: agent 'grant' declares no 'to_home_layers'; inheriting the implicit cascade ...
WARN: to_home: agent 'grant' declares no 'to_home_layers'; inheriting the implicit cascade ...
```

and said 「ワーニングだと誰も直さない」— nobody fixes warnings. Then, when asked
how far to take it: 「スペックがおかしかったら起動不可っていうのをデフォルトにして、
ただフォースオプションをつけて起動するみたいな」— refuse by default, with a flag to
start anyway.

Both conditions in his paste now do exactly that.

## 1. The duplicate line was structural, not cosmetic

`to_home: agent 'grant' declares no 'to_home_layers'` printed **twice for one
agent**. It was a `logger.warning` inside `settings_layer_dirs`, which is a
**pure resolver** — and a single start calls it **twice**:

* `claude_session.py` → `deploy_to_home(config, home_dir)`
* `claude_session.py` → `deploy_to_home_overlay(config)` → `deploy_to_home(...)`

(`_tui_workspace.py` does the same pair.)

Suppressing the second copy would have been a patch. The real problem is that a
missing declaration is a property of the **spec**, decided **once per launch**,
not of a path lookup that legitimately runs per deploy. So the check moved to
`_lifecycle/_layers_preflight.check_to_home_layers_at_launch`, which
`agent_start` calls exactly once — and, being a launch preflight, it now refuses
**before** the runtime is built rather than after half a workspace is deployed.

`settings_layer_dirs` logs nothing at all now. The `quiet_undeclared_warning()`
context manager that existed solely to mute it inside `migrate-layers` is
**deleted** rather than left in place muting a logger nothing writes to.

## 2. `to_home_layers` undeclared → refusal (gated on the spec migration)

`UndeclaredToHomeLayers` is raised before launch. Override:
`--allow-undeclared-layers` / `SAC_ALLOW_UNDECLARED_LAYERS=1`.

**It is not on by default yet, and that is the sequencing you asked for.**
Measured on the live registry today:

```
root      : /home/agent/.scitex/agent-container/agents
             -> /home/ywatanabe/.dotfiles/src/.scitex/agent-container/agents
specs     : 102
undeclared: 101
```

Flipping it before those specs are migrated stops the entire fleet booting. So
`_layers_preflight.ENFORCE_BY_DEFAULT = False`, `SAC_ENFORCE_TO_HOME_LAYERS=1`
turns it on per-invocation today, and a test pins the constant so the flip is a
deliberate one-line change with a failing test to update.

**What remains, and who owns it.** The 102 specs are TRACKED files in
`~/.dotfiles`, so the sweep is a dotfiles PR, not a sac sweep — and the
`enforce_worktree_path` hook confines this agent's worktrees to this project, so
I could not create that branch. Handed to `dotfiles` as card
`dotfiles-declare-to-home-layers-in-101-specs-20260810`, with the plan verified
read-only against the live registry:

```
with the scitex-todo spec removed (dotfiles PR #201, already open):
specs     : 101      writable  : 101     already: 0
refused   : 0        unreadable: 0       malformed: 0
layer sets: 65 x [user-shared]
            36 x [user-shared, per-agent]
safe_to_apply: True
```

Today the sweep **refuses** (`safe_to_apply: False`) because the `scitex-todo`
spec is unreadable — 68 missing required fields. dotfiles PR #201 deletes that
spec, which is why it is the unblocker.

Order of operations: **dotfiles spec PR merges → flip `ENFORCE_BY_DEFAULT` →
delete `SAC_ENFORCE_TO_HOME_LAYERS`.** Merging this PR first is safe; it changes
nothing for an undeclared spec beyond printing one line instead of two.

## 3. Spec drift → refuse, and the judgement call I want overruled if you disagree

`--strict-drift` was opt-in. Strict is now the **default**: a spec source that is
BEHIND or DIVERGED refuses to start. Override: `--allow-stale-spec` /
`SAC_ALLOW_STALE_SPEC=1`.

**AHEAD does not refuse.** This is the one place I read the ruling rather than
applying it literally, so it is stated plainly for you to overrule in one line:

* BEHIND / DIVERGED = the spec on disk **may be out of date**. That is
  「スペックがおかしい」and it refuses.
* AHEAD = unpushed local commits. The spec will not **propagate** to other
  hosts, but the spec this host is about to launch is the **newest one that
  exists**. Nothing is wrong with it. Refusing here would ground every host that
  legitimately carries local commits — spartan does, routinely — for a condition
  that is not a bad spec. AHEAD stays a loud warning.
* NOT_A_REPO / UNREACHABLE also keep starting: drift is *unknown* there, not
  present, and refusing on "I could not check" grounds the fleet on a network
  hiccup.

**The consequence you are accepting, stated so it is not a surprise:** a host
whose `~/.dotfiles` checkout falls behind `origin` **stops booting agents** until
someone pulls or passes `--allow-stale-spec`. That is live today — this host's
dotfiles is 5 commits behind, which is exactly the paste that started this. If
that trade is wrong, the fix is one word: make BEHIND a warning and keep only
DIVERGED as the refusal.

## 4. Why named flags and not `--force`

One flag per condition. A blanket `--force` / `--ignore-warnings` skips every
check at once, leaves no record of **which** check was bypassed, and gets reused
by the next person for an unrelated failure — `git --no-verify` is the
cautionary example, and this fleet already bans that idiom by hook.

Using an override logs at **ERROR** naming the condition *and* the agent. A
silent override is just a slower version of the warning nobody read.

Both flags reach their gate through the gate's **env var**, set from a click
callback (`expose_value=False`). That is not a shortcut around plumbing — it is
the only transport that survives the parallel path, which re-execs `sac agents
start` as one **subprocess per agent**. Legacy `SAC_STRICT_DRIFT` is still
honoured in **both** directions, so an existing `SAC_STRICT_DRIFT=0` export keeps
meaning "do not block me" instead of silently becoming a no-op.

## Tests

```
tests/scitex_agent_container/_lifecycle/test__layers_preflight.py ......  [ 11%]
................                                                         [ 42%]
tests/scitex_agent_container/_lifecycle/test__start_drift.py ...........  [ 63%]
...                                                                      [ 69%]
tests/scitex_agent_container/runtimes/test__to_home_resolve.py .........  [ 86%]
.......                                                                  [100%]

============================= 52 passed in 27.27s ==============================
```

The duplication is guarded by two facts, not one: the resolver stays silent
across **two** consecutive calls (the exact shape of the old bug), and a real
`agent_start` produces the finding **exactly once**.

Wider regression run over every touched area:

```
================ 2566 passed, 10 warnings in 447.21s (0:07:27) =================
```
(`_lifecycle/`, `_maintenance/`, `config/`, `runtimes/test__to_home_resolve.py`,
`cli_pkg/test__agents_migrate_layers.py`)

```
============================= 66 passed in 54.67s ==============================
```
(`_drift/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9aNXY7Tx3jP7vRBSpRJYw
