### PR TITLE
fix(acl): authority is group MEMBERSHIP, not the first element of labels.groups

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_spawn_gate.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_gate.py
@@ -33,13 +33,14 @@ the policy got mis-triaged; keep it in step with
 :func:`._listen._acl.check_spawn`, which is the SSOT):
 
   * admin / operator (no ``SAC_NAME``) — allowed;
-  * a ``developer``- or ``researcher``-group caller — allowed EVEN AS A
-    CHILD (operator ruling: dev and research agents must both be able to
-    start/stop peer agents);
+  * a caller whose named groups INCLUDE ``developer``, ``researcher`` or
+    ``privileged`` — allowed EVEN AS A CHILD (operator ruling: dev and
+    research agents must both be able to start/stop peer agents;
+    ``privileged`` joined them 2026-07-16). Membership, not primary-group
+    equality — ``groups: [generalist, developer]`` IS a developer;
   * a ROOT node (no lineage parent) — allowed;
-  * any other child (``generalist`` / ``privileged`` / isolated solver /
-    ungrouped) — denied, as is any caller with
-    ``spec.lineage.may_spawn=false``.
+  * any other child (``generalist`` / isolated solver / ungrouped) —
+    denied, as is any caller with ``spec.lineage.may_spawn=false``.
 
 Scope (ADR-0010 staged plan): this module is **Phase 2 / Step 1** —
 make ALL spawn paths go through ``check_spawn`` + write the lineage
@@ -72,14 +73,23 @@ def persist_acl_policy(config: Any, db_path: Path | None = None) -> None:
     so ``read_comms_policy`` always finds a row for any started agent.
     """
     from .._state.state_db_nodes import record_comms_policy
-    from ..config._group_resolver import group_from_labels
+    from ..config._group_resolver import all_named_groups, group_from_labels
 
     comms = config.comms
     lineage = config.lineage
-    # Named group (operator 2026-06-25): metadata.labels.group, else
-    # role-derived (developer-ish roles → "developer"). Persisted here so
-    # the ACL check can read it by node name at send/spawn/manage time.
-    group_name = group_from_labels(getattr(config, "labels", None))
+    labels = getattr(config, "labels", None)
+    # TWO projections of the SAME metadata.labels, written together so
+    # they cannot drift (incident 2026-08-10):
+    #   group_name  — the PRIMARY group (labels.group, else the first
+    #                 element of labels.groups, else role-derived). The
+    #                 default-ACL mesh resolves through this single
+    #                 bucket, which keeps an isolated solver isolated.
+    #   group_names — EVERY group the labels name. The AUTHORITY gates
+    #                 (developer / researcher / privileged) read this,
+    #                 so naming a group anywhere in the list grants it
+    #                 and list ORDER stops deciding permissions.
+    group_name = group_from_labels(labels)
+    group_names = all_named_groups(labels)
     record_comms_policy(
         name=config.name,
         outbound_siblings=comms.outbound.siblings,
@@ -89,6 +99,7 @@ def persist_acl_policy(config: Any, db_path: Path | None = None) -> None:
         lineage_group=lineage.group,
         may_spawn=lineage.may_spawn,
         group_name=group_name,
+        group_names=group_names,
         db_path=db_path,
     )
 

--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -450,27 +450,28 @@ def check_spawn(
 
     **Read BOTH layers before concluding what is denied.** The
     ``is_developer`` branch below is a SHORT-CIRCUIT, not the policy —
-    the RESEARCHER allow lives one level down, in :func:`spawn_allowed`.
-    Reading only this file, and seeing ``is_developer`` with no
-    ``is_researcher`` beside it, reads as "researchers fall through to
-    the root-only gate". That is FALSE, and has been mis-triaged that
-    way. Effective policy across both layers:
+    the RESEARCHER + PRIVILEGED allows live one level down, in
+    :func:`spawn_allowed`. Reading only this file, and seeing
+    ``is_developer`` alone, reads as "researchers fall through to the
+    root-only gate". That is FALSE, and has been mis-triaged that way.
+    Effective policy across both layers:
 
       * ``caller=None`` — administrative / operator path. Allowed.
       * ``developer`` group — allowed regardless of the root-only
         default, so a developer CHILD may spawn. Short-circuited here.
-      * ``researcher`` group — likewise allowed, resolved one layer
-        down in :func:`spawn_allowed` (operator ruling: dev AND
-        research agents must both be able to start/stop peers).
+      * ``researcher`` / ``privileged`` — likewise allowed, one layer
+        down in :func:`spawn_allowed` (dev AND research agents must
+        both start/stop peers; denying privileged "is a sac bug").
       * ROOT node (no lineage parent) — allowed.
-      * Any other child — DENIED: ``generalist`` / ``privileged`` /
-        an isolated solver group / ungrouped. Note generalist and
-        privileged DO mesh for *manage* (:func:`check_lineage_acl`)
-        but get NO spawn authority; only developer + researcher do.
+      * Any other child — DENIED: ``generalist`` / an isolated solver
+        group / ungrouped. Generalist DOES mesh for *manage*
+        (:func:`check_lineage_acl`) but gets NO spawn authority.
       * ``spec.lineage.may_spawn=false`` denies even a researcher —
-        but NOT a developer, whose short-circuit here bypasses
-        :func:`spawn_allowed` and the ``may_spawn`` gate with it. An
-        agent that must never spawn has to stay out of ``developer``.
+        but NOT a developer, whose short-circuit here bypasses it.
+
+    All three group checks are MEMBERSHIP over the caller's WHOLE
+    named-group set, never primary-group equality — see
+    :mod:`..._state.state_db_groups` (incident 2026-08-10, grant).
     """
     if caller and is_developer(name=caller, db_path=db_path):
         return ("allow", None)

--- a/src/scitex_agent_container/_listen/_host_exec.py
+++ b/src/scitex_agent_container/_listen/_host_exec.py
@@ -109,8 +109,9 @@ from starlette.responses import JSONResponse
 
 from .._lifecycle._off_loop import run_blocking
 from .._state import state_db as _state_db
-from .._state.state_db_nodes import comms_policy_row_exists
-from ._acl import deny_response, resolve_group_name
+from .._state.state_db_nodes import comms_policy_row_exists, resolve_group_names
+from ..config._group_resolver import groups_intersect
+from ._acl import deny_response
 from ._host_exec_child import (
     _POST_KILL_DRAIN_S,
     _TERM_GRACE_S,
@@ -189,7 +190,7 @@ def _append_audit(entry: dict[str, Any]) -> None:
 async def host_exec(
     request: Request,
     *,
-    group_resolver=resolve_group_name,
+    group_resolver=resolve_group_names,
     registration_probe=comms_policy_row_exists,
     audit_writer=_append_audit,
 ) -> JSONResponse:
@@ -278,11 +279,17 @@ async def host_exec(
             reason="host_exec requires a resolvable caller (per-node bearer or 'caller' body claim)"
         )
 
-    group = group_resolver(name=caller)
-    if group not in ELIGIBLE_GROUPS:
-        # SAME DECISION, HONEST MESSAGE. An empty group means one of two
-        # things, and the old message asserted the first while the truth
-        # was often the second:
+    # MEMBERSHIP over the caller's WHOLE named-group set, not equality
+    # against its primary group (incident 2026-08-10): eligibility is a
+    # capability the operator grants by naming the group anywhere in
+    # ``metadata.labels.groups``. Resolving only the FIRST element made
+    # ``grant`` — whose spec lists privileged AND developer — ineligible
+    # here for the same reason it could not spawn.
+    groups = group_resolver(name=caller)
+    if not groups_intersect(groups, ELIGIBLE_GROUPS):
+        # SAME DECISION, HONEST MESSAGE. An empty group set means one of
+        # two things, and the old message asserted the first while the
+        # truth was often the second:
         #   (a) registered here, genuinely ungrouped -> denial is correct
         #   (b) NOT IN THIS STORE AT ALL            -> we cannot decide,
         #       we are simply refusing, which is the right SAFE action
@@ -295,8 +302,8 @@ async def host_exec(
         registered = registration_probe(name=caller)
         if registered:
             cause = (
-                f"caller {caller!r} IS registered here but resolves to group "
-                f"{group!r}, which is not eligible"
+                f"caller {caller!r} IS registered here but resolves to groups "
+                f"{sorted(groups)}, none of which is eligible"
             )
         else:
             cause = (

--- a/src/scitex_agent_container/_listen/_host_exec.py
+++ b/src/scitex_agent_container/_listen/_host_exec.py
@@ -286,6 +286,9 @@ async def host_exec(
     # ``grant`` — whose spec lists privileged AND developer — ineligible
     # here for the same reason it could not spawn.
     groups = group_resolver(name=caller)
+    # The eligible group(s) this caller actually holds — what AUTHORISED the
+    # exec, and what the audit line records. Sorted so the value is stable.
+    authorised = sorted(ELIGIBLE_GROUPS & {str(g).strip().lower() for g in groups})
     if not groups_intersect(groups, ELIGIBLE_GROUPS):
         # SAME DECISION, HONEST MESSAGE. An empty group set means one of
         # two things, and the old message asserted the first while the
@@ -455,7 +458,8 @@ async def host_exec(
         {
             "ts": time.time(),
             "caller": caller,
-            "caller_group": group,
+            "caller_group": ",".join(authorised),
+            "caller_groups": sorted(str(g).strip() for g in groups),
             "argv": argv,
             "cwd": cwd_raw,
             "timeout_s": timeout_s,

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -54,6 +54,7 @@ from .state_db_migrations import (
     migrate_instances_add_family_tree_cols,
     migrate_legacy_heartbeats,
     migrate_node_comms_policy_add_group_name,
+    migrate_node_comms_policy_add_group_names,
 )
 from .state_db_schema import (
     _SCHEMA_ATTEMPTS,
@@ -178,6 +179,10 @@ def init_schema(db_path: Path | None = None) -> Path:
         # column on a pre-existing ``node_comms_policy`` (operator
         # 2026-06-25). No-op on a fresh DB (DDL already has the column).
         migrate_node_comms_policy_add_group_name(conn)
+        # Same idempotent ADD COLUMN for the MULTI-value ``group_names``
+        # column the authority gates read (incident 2026-08-10 — an agent
+        # whose spec lists several groups was reduced to its FIRST one).
+        migrate_node_comms_policy_add_group_names(conn)
         conn.executescript(_SCHEMA_ATTEMPTS)
         conn.executescript(_SCHEMA_DIARY)
         # Task #27 — ACL block/unblock flow tables. Both CREATE TABLE

--- a/src/scitex_agent_container/_state/state_db_acl_policy.py
+++ b/src/scitex_agent_container/_state/state_db_acl_policy.py
@@ -18,6 +18,8 @@ Schema (see ``_SCHEMA_REGISTRY`` in :mod:`.state_db`):
         inbound_parent    TEXT NOT NULL DEFAULT 'allow',
         lineage_group     TEXT NOT NULL DEFAULT '',
         may_spawn         INTEGER NOT NULL DEFAULT 1,
+        group_name        TEXT NOT NULL DEFAULT '',
+        group_names       TEXT NOT NULL DEFAULT '',
         updated_at        REAL NOT NULL
     );
 
@@ -83,11 +85,63 @@ DEFAULT_COMMS_POLICY: dict[str, Any] = {
     "inbound_parent": "allow",
     "lineage_group": "",
     "may_spawn": True,
-    # Group-based ACL (operator 2026-06-25): the agent's NAMED group.
+    # Group-based ACL (operator 2026-06-25): the agent's PRIMARY named
+    # group — the single bucket the default-ACL mesh resolves through.
     # "" (ungrouped) is the default; absence is byte-equivalent to the
     # pre-group-name behaviour (same-group allow needs a non-empty match).
     "group_name": "",
+    # EVERY named group the spec's ``metadata.labels`` lists (incident
+    # 2026-08-10). The AUTHORITY gates read this set, not the primary
+    # above, so an agent authored as ``groups: [generalist, developer]``
+    # is a developer regardless of list order. Empty tuple on a row
+    # written before the column existed — ``resolve_group_names`` unions
+    # it with ``group_name``, so that row keeps its old meaning exactly.
+    "group_names": (),
 }
+
+
+def _split_group_names(raw: str) -> tuple[str, ...]:
+    """Decode the comma-separated ``group_names`` column into a tuple.
+
+    Blank / whitespace-only members are dropped, so ``""`` decodes to the
+    empty tuple and a trailing comma is harmless.
+    """
+    return tuple(part.strip() for part in str(raw or "").split(",") if part.strip())
+
+
+def _join_group_names(groups) -> str:
+    """Encode an iterable of group names for the ``group_names`` column.
+
+    De-duplicated and SORTED, so the stored string is deterministic for a
+    given set (the column answers a MEMBERSHIP question — order carries
+    no meaning, and a stable encoding keeps diffs and denial messages
+    readable). Blank members are dropped.
+
+    Raises :class:`ValueError` on a name containing a comma: the encoding
+    is comma-separated, so accepting one would silently split a single
+    group into two. Fail loudly rather than corrupt an ACL input.
+    """
+    if groups is None:
+        return ""
+    if isinstance(groups, str):
+        raise ValueError(
+            "group_names must be an iterable of group names, not a bare "
+            f"string ({groups!r}) — pass e.g. ['developer']"
+        )
+    out: set[str] = set()
+    for item in groups:
+        if item is None:
+            continue
+        trimmed = str(item).strip()
+        if not trimmed:
+            continue
+        if "," in trimmed:
+            raise ValueError(
+                f"group name {trimmed!r} contains a comma; the group_names "
+                "column is comma-separated and cannot encode it"
+            )
+        out.add(trimmed)
+    return ",".join(sorted(out))
 
 
 def record_comms_policy(
@@ -100,6 +154,7 @@ def record_comms_policy(
     lineage_group: str = "",
     may_spawn: bool = True,
     group_name: str = "",
+    group_names=None,
     db_path: Path | None = None,
 ) -> None:
     """Upsert the Phase-3 per-spec ACL policy for ``name``.
@@ -108,6 +163,13 @@ def record_comms_policy(
     row always reflects the *current* ``spec.comms`` / ``spec.lineage``
     blocks on disk. A re-start refreshes the row in place (a spec edit
     becomes live on the next start without manual state.db surgery).
+
+    ``group_name`` is the PRIMARY group (the default-ACL mesh bucket);
+    ``group_names`` is EVERY group the spec names (the authority set).
+    Both are projections of the same ``metadata.labels`` and are written
+    together — that is what keeps them from disagreeing. ``group_names``
+    defaults to ``None``, which stores the PRIMARY alone, so an existing
+    caller that passes only ``group_name`` keeps its exact old meaning.
 
     Raises :class:`ValueError` on an empty name or out-of-domain values
     (the parser/validator already reject these — defence-in-depth).
@@ -138,6 +200,19 @@ def record_comms_policy(
         raise ValueError(f"may_spawn must be a bool, got {type(may_spawn).__name__}")
     if not isinstance(group_name, str):
         raise ValueError(f"group_name must be a str, got {type(group_name).__name__}")
+    primary = group_name.strip()
+    # A caller that names only the primary keeps its old meaning: the
+    # stored set is {primary}. A caller that names the full set gets it
+    # stored verbatim, with the primary folded in so the set is never a
+    # strict subset of what the mesh already resolves.
+    if group_names is None:
+        encoded_groups = _join_group_names([primary])
+    elif isinstance(group_names, str):
+        # Reject BEFORE the splat below, which would silently expand a
+        # string into its characters and store those as group names.
+        encoded_groups = _join_group_names(group_names)
+    else:
+        encoded_groups = _join_group_names([*group_names, primary])
     from .state_db import open_db
 
     now = time.time()
@@ -146,8 +221,8 @@ def record_comms_policy(
             "INSERT INTO node_comms_policy ("
             "name, outbound_siblings, outbound_parent, "
             "inbound_siblings, inbound_parent, lineage_group, "
-            "may_spawn, group_name, updated_at"
-            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "may_spawn, group_name, group_names, updated_at"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(name) DO UPDATE SET "
             "outbound_siblings=excluded.outbound_siblings, "
             "outbound_parent=excluded.outbound_parent, "
@@ -156,6 +231,7 @@ def record_comms_policy(
             "lineage_group=excluded.lineage_group, "
             "may_spawn=excluded.may_spawn, "
             "group_name=excluded.group_name, "
+            "group_names=excluded.group_names, "
             "updated_at=excluded.updated_at",
             (
                 name,
@@ -165,7 +241,8 @@ def record_comms_policy(
                 inbound_parent,
                 lineage_group,
                 1 if may_spawn else 0,
-                group_name.strip(),
+                primary,
+                encoded_groups,
                 now,
             ),
         )
@@ -199,7 +276,7 @@ def read_comms_policy(
         row = conn.execute(
             "SELECT outbound_siblings, outbound_parent, "
             "inbound_siblings, inbound_parent, lineage_group, may_spawn, "
-            "group_name "
+            "group_name, group_names "
             "FROM node_comms_policy WHERE name = ?",
             (name,),
         ).fetchone()
@@ -213,6 +290,7 @@ def read_comms_policy(
         "lineage_group": str(row["lineage_group"]),
         "may_spawn": bool(row["may_spawn"]),
         "group_name": str(row["group_name"]),
+        "group_names": _split_group_names(row["group_names"]),
     }
 
 

--- a/src/scitex_agent_container/_state/state_db_groups.py
+++ b/src/scitex_agent_container/_state/state_db_groups.py
@@ -1,0 +1,182 @@
+"""MULTI-value named-group readers — the AUTHORITY half of the group ACL.
+
+Lives in a sibling module so :mod:`.state_db_nodes` stays under the
+per-file line cap. Re-exported from ``state_db_nodes`` so the natural
+import path keeps working::
+
+    from scitex_agent_container._state.state_db_nodes import (
+        is_developer, is_privileged, is_researcher, resolve_group_names,
+    )
+
+Why this module exists (incident 2026-08-10, ``grant``)
+-------------------------------------------------------
+An agent's spec authors its groups as a LIST::
+
+    metadata:
+      labels:
+        groups: [generalist, privileged, developer, researcher, active]
+
+Two readers consumed that list and disagreed, with no error anywhere:
+
+* ``a2a_peers`` reported all five, via the MULTI-value
+  :func:`scitex_agent_container.config._group_resolver.all_named_groups`.
+* The ACL saw exactly ONE — ``group_from_labels`` keeps the FIRST
+  element, that single string was persisted into
+  ``node_comms_policy.group_name``, and every authority gate
+  (``is_developer`` / ``is_researcher`` / the ``privileged`` fallthrough
+  in ``spawn_allowed`` / ``host_exec``'s ``ELIGIBLE_GROUPS``) compared
+  against it.
+
+So ``grant``'s spawn was refused with "is in none of the developer,
+research, or privileged groups" while its registry row listed three of
+them. The agent's authority depended on the ORDER of a YAML list —
+moving ``developer`` to the front would have silently fixed it, which is
+the clearest possible sign the reduction was wrong.
+
+The cut this module draws
+-------------------------
+* **Authority is MEMBERSHIP — any-of.** "May this agent spawn / manage /
+  host-exec" is a capability the operator grants by naming the group
+  ANYWHERE in ``labels.groups``. That is what the functions here answer,
+  over the FULL set.
+* **The default-ACL mesh keeps ONE bucket per agent — first-of.** "Do
+  these two agents coordinate by default" still resolves through
+  :func:`.state_db_nodes.resolve_group_name` (the primary group),
+  deliberately unchanged: a solver authored as ``groups: [solver]`` must
+  stay outside the fleet mesh, and collapsing the two questions is how
+  that isolation guarantee would erode.
+
+Both projections are now written from the SAME ``metadata.labels`` at
+``agent_start`` (:func:`.._lifecycle._spawn_gate.persist_acl_policy`),
+so the persisted set is lossless and the two readers cannot disagree
+about what the spec said.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = [
+    "in_named_group",
+    "is_developer",
+    "is_privileged",
+    "is_researcher",
+    "resolve_group_names",
+]
+
+
+def resolve_group_names(
+    *,
+    name: str,
+    db_path: Path | None = None,
+) -> frozenset[str]:
+    """Return EVERY named group ``name``'s persisted policy row holds.
+
+    Reads ``node_comms_policy.group_names`` (the full authored set) and
+    UNIONS it with ``node_comms_policy.group_name`` (the primary). The
+    union is deliberate and load-bearing in two directions:
+
+    * A row written BEFORE the ``group_names`` column existed has an
+      empty set and a non-empty primary, so it still resolves to
+      ``{primary}`` — byte-equivalent to the pre-multi-group behaviour.
+      No backfill is required for correctness; ``sac agents refresh-acl``
+      (or the agent's next start) upgrades the row to the full set.
+    * The two columns can therefore never disagree in the direction that
+      REMOVES authority, which is the failure mode this whole module
+      exists to make impossible.
+
+    Group names are returned verbatim (whitespace already trimmed at
+    write time); compare through :func:`in_named_group`, which folds
+    case. An unknown / empty name yields the empty set.
+    """
+    if not name:
+        return frozenset()
+    from .state_db_acl_policy import read_comms_policy
+
+    policy = read_comms_policy(name=name, db_path=db_path)
+    out = {str(g).strip() for g in policy.get("group_names", ()) if str(g).strip()}
+    primary = str(policy.get("group_name", "") or "").strip()
+    if primary:
+        out.add(primary)
+    return frozenset(out)
+
+
+def in_named_group(
+    *,
+    name: str,
+    group: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return ``True`` iff ``name``'s persisted groups include ``group``.
+
+    Case-insensitive, whitespace-trimmed on both sides — the same
+    comparison the pure predicates in
+    :mod:`scitex_agent_container.config._group_resolver` apply, lifted
+    from one group to the whole set.
+    """
+    wanted = str(group).strip().lower()
+    if not wanted:
+        return False
+    return any(
+        g.strip().lower() == wanted
+        for g in resolve_group_names(name=name, db_path=db_path)
+    )
+
+
+def is_developer(
+    *,
+    name: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return ``True`` iff ``developer`` is among ``name``'s named groups.
+
+    The developer group has FULL AUTHORITY (operator 2026-06-25):
+    members may CRUD agents (spawn / start / stop / restart / delete)
+    and CRUD the ACL (grant / revoke). The spawn + lineage ACL gates
+    consult this to short-circuit their default (root-only / lineage-
+    descendant) checks.
+
+    MEMBERSHIP, not primary-group equality (incident 2026-08-10): an
+    agent whose spec says ``groups: [generalist, developer]`` is a
+    developer. It previously was not, because only the first element
+    reached the DB.
+    """
+    from ..config._group_resolver import DEVELOPER_GROUP
+
+    return in_named_group(name=name, group=DEVELOPER_GROUP, db_path=db_path)
+
+
+def is_researcher(
+    *,
+    name: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return ``True`` iff ``researcher`` is among ``name``'s named groups.
+
+    Mirrors :func:`is_developer` for the research-role group
+    (:data:`scitex_agent_container.config._group_resolver.RESEARCHER_GROUP`).
+    Per the operator's 2026-07-05 ruling ("dev agents and research
+    agents MUST have full permissions — including the ability to
+    start/stop peer agents"), a researcher-group member gets the same
+    spawn authority as a developer-group member; see
+    :func:`.state_db_nodes.spawn_allowed`.
+    """
+    from ..config._group_resolver import RESEARCHER_GROUP
+
+    return in_named_group(name=name, group=RESEARCHER_GROUP, db_path=db_path)
+
+
+def is_privileged(
+    *,
+    name: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return ``True`` iff ``privileged`` is among ``name``'s named groups.
+
+    Completes the trio of spawn-authorised groups (operator ruling
+    2026-07-16: denying a privileged-group agent — dotfiles — "is a sac
+    bug"). Same membership semantics as :func:`is_developer`.
+    """
+    from ..config._group_resolver import PRIVILEGED_GROUP
+
+    return in_named_group(name=name, group=PRIVILEGED_GROUP, db_path=db_path)

--- a/src/scitex_agent_container/_state/state_db_migrations.py
+++ b/src/scitex_agent_container/_state/state_db_migrations.py
@@ -18,6 +18,9 @@ every :func:`state_db.init_schema`.
   * :func:`migrate_node_comms_policy_add_group_name` — ADD COLUMN the
     ``group_name`` column (group-based ACL, operator 2026-06-25) onto a
     pre-existing ``node_comms_policy`` table.
+  * :func:`migrate_node_comms_policy_add_group_names` — ADD COLUMN the
+    MULTI-value ``group_names`` column (authority-is-membership,
+    incident 2026-08-10) onto a pre-existing ``node_comms_policy``.
 """
 
 from __future__ import annotations
@@ -175,4 +178,44 @@ def migrate_node_comms_policy_add_group_name(conn: sqlite3.Connection) -> None:
         return
     conn.execute(
         "ALTER TABLE node_comms_policy ADD COLUMN group_name TEXT NOT NULL DEFAULT ''"
+    )
+
+
+def migrate_node_comms_policy_add_group_names(conn: sqlite3.Connection) -> None:
+    """ADD the MULTI-value ``group_names`` column to ``node_comms_policy``.
+
+    Authority-is-membership (incident 2026-08-10): ``group_name`` holds
+    only the FIRST group a spec's ``metadata.labels.groups`` list names,
+    so an agent authored as ``groups: [generalist, developer]`` was not a
+    developer to any ACL gate. ``group_names`` holds the WHOLE set
+    (comma-separated, sorted, written from the same labels), and the
+    authority predicates read it.
+
+    ``ALTER TABLE ... ADD COLUMN`` with ``DEFAULT ''`` leaves every
+    pre-existing row with an empty set. That is deliberately NOT a
+    regression: :func:`.state_db_groups.resolve_group_names` unions the
+    set with ``group_name``, so an un-refreshed row still resolves to
+    ``{primary}`` — exactly the pre-migration behaviour. Running
+    ``sac agents refresh-acl`` (or restarting the agent) re-publishes the
+    full set from the on-disk spec.
+
+    Detection: ``node_comms_policy`` exists AND lacks ``group_names``.
+    Idempotent: a no-op once the column is present (or the table is
+    absent).
+    """
+    existing = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    if "node_comms_policy" not in existing:
+        return
+    cols = {
+        r[1] for r in conn.execute("PRAGMA table_info(node_comms_policy)").fetchall()
+    }
+    if "group_names" in cols:
+        return
+    conn.execute(
+        "ALTER TABLE node_comms_policy ADD COLUMN group_names TEXT NOT NULL DEFAULT ''"
     )

--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -24,11 +24,23 @@ the prior limited scope had deferred):
     :func:`grant_send`.
 
   * **Spawn permission** — a node with no parent may call
-    ``sac agents start``; so may a child whose resolved NAMED group
-    is ``developer`` or ``researcher`` (operator ruling 2026-07-05:
-    "dev agents and research agents MUST have full permissions —
-    including the ability to start/stop peer agents"). Any other
-    child is denied. See :func:`spawn_allowed`.
+    ``sac agents start``; so may a child whose NAMED GROUPS INCLUDE
+    ``developer``, ``researcher`` or ``privileged`` (operator ruling
+    2026-07-05: "dev agents and research agents MUST have full
+    permissions — including the ability to start/stop peer agents").
+    Any other child is denied. See :func:`spawn_allowed`.
+
+  * **Two group projections, one source.** ``group_name`` is the
+    PRIMARY group — the single bucket the default-ACL mesh resolves
+    through (:func:`resolve_group_name` / :func:`same_named_group`).
+    ``group_names`` is the FULL set the spec authored, and it is what
+    the AUTHORITY predicates read (:func:`is_developer` /
+    :func:`is_researcher` / :func:`is_privileged`, in
+    :mod:`.state_db_groups`). Both are written from the same
+    ``metadata.labels`` at ``agent_start``. Collapsing authority onto
+    the primary is what made ``grant`` — ``groups: [generalist,
+    privileged, developer, researcher, active]`` — a non-developer to
+    every gate while ``a2a_peers`` listed all five (2026-08-10).
 
 The N-level structural capability of ``lineage`` is preserved —
 nothing here hard-codes "2" or assumes fixed depth.
@@ -67,8 +79,10 @@ __all__ = [
     "derive_group",
     "grant_send",
     "has_grant",
+    "in_named_group",
     "is_developer",
     "is_local_node",
+    "is_privileged",
     "is_researcher",
     "list_comms_grants",
     "list_comms_nodes",
@@ -80,6 +94,7 @@ __all__ = [
     "record_lineage",
     "register_comms_node",
     "resolve_group_name",
+    "resolve_group_names",
     "resolve_node_host",
     "resolve_node_token",
     "revoke_send",
@@ -246,46 +261,18 @@ def same_named_group(
     return target_group == sender_group
 
 
-def is_developer(
-    *,
-    name: str,
-    db_path: Path | None = None,
-) -> bool:
-    """Return ``True`` iff ``name``'s resolved NAMED group is ``developer``.
-
-    The developer group has FULL AUTHORITY (operator 2026-06-25):
-    members may CRUD agents (spawn / start / stop / restart / delete)
-    and CRUD the ACL (grant / revoke). The spawn + lineage ACL gates
-    consult this to short-circuit their default (root-only / lineage-
-    descendant) checks.
-    """
-    from ..config._group_resolver import is_developer_group
-
-    return is_developer_group(resolve_group_name(name=name, db_path=db_path))
-
-
-def is_researcher(
-    *,
-    name: str,
-    db_path: Path | None = None,
-) -> bool:
-    """Return ``True`` iff ``name``'s resolved NAMED group is ``researcher``.
-
-    Mirrors :func:`is_developer` for the research-role group
-    (:data:`scitex_agent_container.config._group_resolver.RESEARCHER_GROUP`).
-    Per the operator's 2026-07-05 ruling ("dev agents and research
-    agents MUST have full permissions — including the ability to
-    start/stop peer agents"), a researcher-group member gets the same
-    spawn authority as a developer-group member; see
-    :func:`spawn_allowed`.
-    """
-    from ..config._group_resolver import RESEARCHER_GROUP
-
-    group = resolve_group_name(name=name, db_path=db_path)
-    if not group:
-        return False
-    return group.strip().lower() == RESEARCHER_GROUP.lower()
-
+# The AUTHORITY predicates (``is_developer`` / ``is_researcher`` /
+# ``is_privileged``) are MULTI-value and live in a sibling module under
+# the per-file line cap. They ask "is <group> among this agent's named
+# groups", NOT "is it the primary group" — see state_db_groups for why
+# that distinction is the whole point (incident 2026-08-10, grant).
+from .state_db_groups import (  # noqa: E402
+    in_named_group,
+    is_developer,
+    is_privileged,
+    is_researcher,
+    resolve_group_names,
+)
 
 # ---------------------------------------------------------------------------
 # spawn permission — root nodes, plus dev/research-role children
@@ -301,18 +288,25 @@ def spawn_allowed(
 
     Current policy (handoff §4 / WI-2, relaxed per operator ruling
     2026-07-05): a *root* node (no parent) is allowed to spawn.
-    A *child* is ALSO allowed when its resolved NAMED group is
+    A *child* is ALSO allowed when its named groups INCLUDE
     ``developer`` or ``researcher`` (:func:`is_developer` /
     :func:`is_researcher`) — the operator's exact words: "Dev agents
     and research agents MUST have full permissions — including the
     ability to start/stop peer agents." The ``privileged`` group is
     allowed on the same footing (operator ruling 2026-07-16: denying
-    a privileged-group agent — dotfiles — "is a sac bug"; checked in
-    the group fallthrough below, which every named path also reaches).
+    a privileged-group agent — dotfiles — "is a sac bug").
     Any other child is denied.
     ``caller=None`` means the administrative / human-operator path
     (e.g., a shell invocation from outside any sac-managed agent) —
     allowed.
+
+    INCLUDE, not "equals the primary group" (incident 2026-08-10):
+    every one of these three checks is a MEMBERSHIP test over the FULL
+    set the spec authored, so authority never depends on where a group
+    sits in a YAML list. ``grant``, whose spec says
+    ``groups: [generalist, privileged, developer, researcher, active]``,
+    was refused here for months because only ``generalist`` — the first
+    element — ever reached the DB.
 
     Returns ``(True, None)`` on allow or ``(False, reason)`` on
     deny. The reason is suitable for inclusion in a 403 body and a
@@ -327,8 +321,17 @@ def spawn_allowed(
         # Admin / human operator. Skips the global root-only check;
         # per-spec may_spawn (Phase-3 Gap-5) layers on top.
         return apply_may_spawn_gate(caller=caller, base=(True, None), db_path=db_path)
-    if is_developer(name=caller, db_path=db_path) or is_researcher(
-        name=caller, db_path=db_path
+    # The three spawn-authorised groups, checked as MEMBERSHIP over the
+    # caller's whole named-group set. Hoisted above the lineage lookup
+    # because the authority is lineage-independent: a developer- /
+    # research- / privileged-group member may spawn or restart a peer to
+    # self-heal a DOWN agent without waiting on the operator (operator
+    # 2026-07-06 ACL incident). The per-spec may_spawn gate still layers
+    # on top, exactly like the root path above.
+    if (
+        is_developer(name=caller, db_path=db_path)
+        or is_researcher(name=caller, db_path=db_path)
+        or is_privileged(name=caller, db_path=db_path)
     ):
         return apply_may_spawn_gate(caller=caller, base=(True, None), db_path=db_path)
     from .state_db import open_db
@@ -339,35 +342,54 @@ def spawn_allowed(
         ).fetchone()
     if parent_row is None:
         return apply_may_spawn_gate(caller=caller, base=(True, None), db_path=db_path)
-    # Child node: denied by default, EXCEPT a developer- or research-group
-    # member may spawn / restart a peer regardless of parent/child lineage
-    # (operator 2026-07-06 ACL incident — a research child such as neurovista
-    # must be able to self-heal a DOWN peer like scitex-clew without waiting
-    # on the operator). The per-spec may_spawn gate still layers on top,
-    # exactly like the root path above.
-    from ..config._group_resolver import (
-        is_developer_group,
-        is_privileged_group,
-        is_research_group,
-    )
+    return (False, _spawn_denied_reason(caller, parent_row["parent_name"], db_path))
 
-    group = resolve_group_name(name=caller, db_path=db_path)
-    if (
-        is_developer_group(group)
-        or is_research_group(group)
-        or is_privileged_group(group)
-    ):
-        return apply_may_spawn_gate(caller=caller, base=(True, None), db_path=db_path)
+
+def _spawn_denied_reason(
+    caller: str,
+    parent: str,
+    db_path: Path | None,
+) -> str:
+    """Compose the spawn-deny reason, naming the groups ACTUALLY resolved.
+
+    The message this replaces asserted the caller "is in none of the
+    developer, research, or privileged groups" — a claim about the
+    AGENT. When the underlying bug made ``grant``'s ``developer`` label
+    unreadable, that sentence was flatly false against the same server's
+    own ``a2a_peers`` output, and it sent the reader after their group
+    labels (which were correct) instead of after the reduction that
+    dropped them. A denial must report what the GATE SAW, never assert
+    what the agent is.
+
+    So this states the resolved set verbatim, distinguishes "no policy
+    row in this store at all" from "registered and ungrouped" (the
+    2026-08-09 host_exec lesson — both produce an empty set and they are
+    different facts), and names the command that re-publishes a stale
+    row. Same decision, honest evidence.
+    """
+    from .state_db_acl_policy import comms_policy_row_exists
+
+    groups = sorted(resolve_group_names(name=caller, db_path=db_path))
+    if groups:
+        seen = (
+            f"the groups this host resolved for it are {groups}, none of "
+            "which grant spawn authority"
+        )
+    elif comms_policy_row_exists(name=caller, db_path=db_path):
+        seen = "it IS registered on this host but resolved to NO named group at all"
+    else:
+        seen = (
+            "this host holds NO node_comms_policy row for it, so its groups "
+            "could not be determined at all — which is not the same as being "
+            "denied groups you hold; check WHICH state.db was consulted"
+        )
     return (
-        False,
-        (
-            f"spawn denied: caller {caller!r} is a child of "
-            f"{parent_row['parent_name']!r} and is in none of the developer, "
-            "research, or privileged groups. Current policy: only root "
-            "nodes, or developer/research/privileged group members, may "
-            "spawn (handoff §4 'lift-able policy' — a single edit to "
-            "spawn_allowed())."
-        ),
+        f"spawn denied: caller {caller!r} is a child of {parent!r} and "
+        f"{seen}. Spawn requires one of: developer, researcher, privileged "
+        "(membership — naming the group anywhere in metadata.labels.groups "
+        "is enough), or being a root node. If the groups above disagree "
+        "with the agent's spec.yaml, this host's row is STALE: run "
+        "'sac agents refresh-acl' to re-publish it from the spec."
     )
 
 

--- a/src/scitex_agent_container/_state/state_db_schema.py
+++ b/src/scitex_agent_container/_state/state_db_schema.py
@@ -279,6 +279,7 @@ CREATE TABLE IF NOT EXISTS node_comms_policy (
     lineage_group     TEXT NOT NULL DEFAULT '',
     may_spawn         INTEGER NOT NULL DEFAULT 1,
     group_name        TEXT NOT NULL DEFAULT '',
+    group_names       TEXT NOT NULL DEFAULT '',
     updated_at        REAL NOT NULL
 );
 """

--- a/src/scitex_agent_container/cli_pkg/refresh_acl.py
+++ b/src/scitex_agent_container/cli_pkg/refresh_acl.py
@@ -26,9 +26,13 @@ Behaviour
   (skipping dirs starting with ``_`` — ``_shared``, ``_template_*``).
   It does NOT route through the cwd-sensitive resolver — the glob is
   deterministic regardless of cwd.
-* For each spec: reads the CURRENTLY persisted ``group_name``, then
+* For each spec: reads the CURRENTLY persisted group SET, then
   ``load_config`` + ``persist_acl_policy`` re-resolves + re-writes the
-  policy, then reads the NEW ``group_name`` and prints a per-agent diff.
+  policy, then reads the NEW set and prints a per-agent diff. The set
+  (not just the primary group) is what the diff shows, because the
+  AUTHORITY gates read the set — an agent listing several groups was
+  reduced to its first one before 2026-08-10, and this command is how a
+  row written by the old code becomes correct without a relaunch.
 * Idempotent + safe — it only refreshes the DB from on-disk specs;
   running it twice is a no-op on the second run.
 * ``--dry-run`` shows the diff WITHOUT writing (the new group is
@@ -106,7 +110,15 @@ def refresh_acl(dry_run: bool) -> None:
     from .._lifecycle._spawn_gate import persist_acl_policy
     from .._state.state_db_nodes import read_comms_policy
     from ..config import load_config
-    from ..config._group_resolver import group_from_labels
+    from ..config._group_resolver import all_named_groups
+
+    def _groups_of(name: str) -> tuple[str, ...]:
+        """The persisted AUTHORITY set for ``name`` (sorted, for display)."""
+        policy = read_comms_policy(name=name)
+        out = {g for g in policy["group_names"] if g}
+        if policy["group_name"]:
+            out.add(policy["group_name"])
+        return tuple(sorted(out))
 
     registry = _fleet_registry_dir()
     if not registry.is_dir():
@@ -141,18 +153,20 @@ def refresh_acl(dry_run: bool) -> None:
             continue
 
         name = config.name
-        old_group = read_comms_policy(name=name)["group_name"]
+        old_groups = _groups_of(name)
 
         if dry_run:
-            new_group = group_from_labels(getattr(config, "labels", None))
+            new_groups = tuple(
+                sorted(all_named_groups(getattr(config, "labels", None)))
+            )
         else:
             persist_acl_policy(config)
-            new_group = read_comms_policy(name=name)["group_name"]
+            new_groups = _groups_of(name)
 
         refreshed += 1
-        old_disp = old_group or "(none)"
-        new_disp = new_group or "(none)"
-        if old_group == new_group:
+        old_disp = ", ".join(old_groups) or "(none)"
+        new_disp = ", ".join(new_groups) or "(none)"
+        if old_groups == new_groups:
             console.print(f"{name}: {old_disp} (unchanged)")
         else:
             changed += 1

--- a/src/scitex_agent_container/config/_group_resolver.py
+++ b/src/scitex_agent_container/config/_group_resolver.py
@@ -64,6 +64,7 @@ __all__ = [
     "RESEARCHER_GROUP",
     "all_named_groups",
     "group_from_labels",
+    "groups_intersect",
     "groups_mesh",
     "is_developer_group",
     "is_privileged_group",
@@ -350,6 +351,32 @@ def is_mesh_group(group: str | None) -> bool:
     if not group:
         return False
     return str(group).strip().lower() in MESH_GROUPS
+
+
+def groups_intersect(groups, wanted) -> bool:
+    """True iff any member of ``groups`` appears in ``wanted``.
+
+    Case-insensitive, whitespace-trimmed on both sides — the set-level
+    counterpart of :func:`is_developer_group` & friends, used wherever a
+    gate asks "does this agent hold ANY of these groups" (host_exec's
+    ``ELIGIBLE_GROUPS``, the spawn authority trio).
+
+    Rejects a BARE STRING for ``groups`` LOUDLY. The callers here used to
+    resolve one group name and now resolve the whole set; a caller still
+    passing a single string would be iterated CHARACTER BY CHARACTER,
+    intersecting nothing — silently denying every agent while looking
+    exactly like a correctly fail-shut ACL. That is the worst shape a
+    permissions bug can take, so it raises instead of denying.
+    """
+    if isinstance(groups, str):
+        raise TypeError(
+            "groups must be a collection of group names, not the bare string "
+            f"{groups!r}: iterating a string yields characters, which would "
+            "silently match nothing"
+        )
+    have = {str(g).strip().lower() for g in groups if str(g).strip()}
+    want = {str(g).strip().lower() for g in wanted if str(g).strip()}
+    return bool(have & want)
 
 
 def groups_mesh(group_a: str | None, group_b: str | None) -> bool:

--- a/tests/scitex_agent_container/_listen/test__acl.py
+++ b/tests/scitex_agent_container/_listen/test__acl.py
@@ -280,16 +280,18 @@ def test_spawn_denies_child_caller(db_path: Path) -> None:
 
 
 def test_spawn_deny_reason_explains_root_only_policy(db_path: Path) -> None:
-    """The 403 body explains the role-based spawn policy."""
+    """The 403 body names the groups that WOULD authorise the spawn.
+
+    It no longer asserts the caller holds none of them — that claim was
+    about the AGENT, and the multi-group defect made it false against
+    the same server's own a2a_peers output (2026-08-10).
+    """
     # Arrange
     record_lineage(child="worker-a", parent="root", db_path=db_path)
     # Act
     _decision, reason = check_spawn(caller="worker-a", db_path=db_path)
     # Assert
-    assert (
-        reason is not None
-        and "none of the developer, research, or privileged groups" in reason
-    )
+    assert reason is not None and "developer, researcher, privileged" in reason
 
 
 # ---------------------------------------------------------------------------
@@ -532,9 +534,7 @@ def test_http_agents_start_403_carries_role_policy_text(
         )
     body_json = r.json()
     # Assert
-    assert "none of the developer, research, or privileged groups" in body_json.get(
-        "reason", ""
-    )
+    assert "developer, researcher, privileged" in body_json.get("reason", "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_listen/test__acl_group.py
+++ b/tests/scitex_agent_container/_listen/test__acl_group.py
@@ -43,7 +43,10 @@ from scitex_agent_container._state.state_db_nodes import (
     record_comms_policy,
     record_lineage,
 )
-from scitex_agent_container.config._group_resolver import group_from_labels
+from scitex_agent_container.config._group_resolver import (
+    all_named_groups,
+    group_from_labels,
+)
 
 
 def _seed_child_from_labels(
@@ -55,15 +58,23 @@ def _seed_child_from_labels(
 ) -> None:
     """Seed a non-root agent EXACTLY as ``agent_start`` would.
 
-    Walks the real production path — ``metadata.labels`` → ``group_from_labels``
-    → ``node_comms_policy.group_name`` — rather than hand-writing the resolved
-    group into the DB. That is what makes these tests able to catch a gap in
-    the RESOLVER (a role that derives no group) and not just in the gate.
+    Walks the real production path — ``metadata.labels`` → the resolvers →
+    ``node_comms_policy`` — rather than hand-writing a resolved group into
+    the DB. That is what makes these tests able to catch a gap in the
+    RESOLVER (a role that derives no group) and not just in the gate.
+
+    BOTH projections are written, exactly like ``persist_acl_policy``:
+    ``group_name`` (PRIMARY, the mesh bucket) and ``group_names`` (the FULL
+    set the authority gates read). Seeding only the primary is what this
+    helper used to do, and it is precisely the reduction that hid the
+    2026-08-10 defect — a helper that no longer mirrors production stops
+    being able to catch a production bug.
     """
     record_lineage(child=name, parent="root-parent", db_path=db_path)
     record_comms_policy(
         name=name,
         group_name=group_from_labels(labels),
+        group_names=all_named_groups(labels),
         may_spawn=may_spawn,
         db_path=db_path,
     )
@@ -293,6 +304,83 @@ def test_non_developer_child_still_denied_spawn(db_path: Path) -> None:
     record_comms_policy(name="worker-a", group_name="analysts", db_path=db_path)
     # Act
     decision, _reason = check_spawn(caller="worker-a", db_path=db_path)
+    # Assert
+    assert decision == "deny"
+
+
+# ---------------------------------------------------------------------------
+# check_spawn — MULTI-GROUP labels, seeded from real spec labels through the
+# real resolvers (incident 2026-08-10, grant).
+#
+# grant's spec authors five groups and `developer` is NOT the first. Every
+# gate resolved only the first element, so the same listen server answered
+# `a2a_peers` with all five and `check_spawn` with "is in none of the
+# developer, research, or privileged groups". Authority hung on YAML list
+# ORDER. These go through `_seed_child_from_labels`, so a future reduction
+# anywhere in labels -> resolver -> DB -> gate fails here, not in production.
+# ---------------------------------------------------------------------------
+
+GRANT_LABELS = {
+    "role": "project-maintainer",
+    "groups": ["generalist", "privileged", "developer", "researcher", "active"],
+}
+
+
+def test_child_with_developer_late_in_its_groups_may_spawn(db_path: Path) -> None:
+    """THE reported bug, end-to-end from grant's real spec labels."""
+    # Arrange
+    _seed_child_from_labels("grant", GRANT_LABELS, db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="grant", db_path=db_path)
+    # Assert
+    assert decision == "allow"
+
+
+def test_child_with_developer_late_in_its_groups_may_manage_peers(
+    db_path: Path,
+) -> None:
+    """The same membership question on the MANAGE gate (tail / stop /
+    restart), which read the identical reduced group."""
+    # Arrange
+    _seed_child_from_labels("grant", GRANT_LABELS, db_path=db_path)
+    # Act
+    decision, _reason = check_lineage_acl(
+        caller="grant", target="unrelated-peer", db_path=db_path
+    )
+    # Assert
+    assert decision == "allow"
+
+
+def test_child_with_researcher_late_in_its_groups_may_spawn(db_path: Path) -> None:
+    # Arrange
+    labels = {"role": "worker", "groups": ["generalist", "researcher"]}
+    _seed_child_from_labels("nv", labels, db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="nv", db_path=db_path)
+    # Assert
+    assert decision == "allow"
+
+
+def test_child_with_privileged_late_in_its_groups_may_spawn(db_path: Path) -> None:
+    # Arrange
+    labels = {"role": "worker", "groups": ["generalist", "privileged"]}
+    _seed_child_from_labels("dotfiles", labels, db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="dotfiles", db_path=db_path)
+    # Assert
+    assert decision == "allow"
+
+
+def test_multi_group_child_with_no_authorising_group_is_still_denied(
+    db_path: Path,
+) -> None:
+    """The gate must still SHUT — a set-valued read that stopped denying
+    would be a worse bug than the one it fixes."""
+    # Arrange
+    labels = {"role": "worker", "groups": ["generalist", "active", "analysts"]}
+    _seed_child_from_labels("worker-b", labels, db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="worker-b", db_path=db_path)
     # Assert
     assert decision == "deny"
 

--- a/tests/scitex_agent_container/_listen/test__host_exec.py
+++ b/tests/scitex_agent_container/_listen/test__host_exec.py
@@ -25,7 +25,6 @@ from scitex_agent_container._listen._host_exec import (
     host_exec,
 )
 
-
 _BAD_BODY = object()
 
 
@@ -134,9 +133,7 @@ def test_host_exec_returns_400_when_env_is_not_a_mapping():
 
 def test_host_exec_returns_400_when_caller_is_not_a_string():
     # Arrange
-    req = _FakeRequest(
-        {"argv": ["echo", "hi"], "caller": 42}, authenticated_node=None
-    )
+    req = _FakeRequest({"argv": ["echo", "hi"], "caller": 42}, authenticated_node=None)
     # Act
     resp = _run(host_exec(req))
     # Assert
@@ -165,7 +162,7 @@ def test_host_exec_denies_when_group_is_not_eligible():
     resp = _run(
         host_exec(
             req,
-            group_resolver=lambda name: "generalist",
+            group_resolver=lambda name: {"generalist"},
             audit_writer=_noop_audit,
         )
     )
@@ -180,7 +177,7 @@ def test_host_exec_allows_the_researcher_group():
     resp = _run(
         host_exec(
             req,
-            group_resolver=lambda name: "researcher",
+            group_resolver=lambda name: {"researcher"},
             audit_writer=_noop_audit,
         )
     )
@@ -195,7 +192,7 @@ def test_host_exec_allows_the_privileged_group():
     resp = _run(
         host_exec(
             req,
-            group_resolver=lambda name: "privileged",
+            group_resolver=lambda name: {"privileged"},
             audit_writer=_noop_audit,
         )
     )
@@ -212,7 +209,7 @@ def test_host_exec_denies_unlabeled_privileged_style_caller_helpfully():
     resp = _run(
         host_exec(
             req,
-            group_resolver=lambda name: "",
+            group_resolver=lambda name: set(),
             audit_writer=_noop_audit,
         )
     )
@@ -234,8 +231,8 @@ def test_host_exec_eligible_groups_set_matches_operator_scope():
 # --------------------------------------------------------------------------
 
 
-def _dev_resolver(name: str) -> str:
-    return "developer"
+def _dev_resolver(name: str) -> set[str]:
+    return {"developer"}
 
 
 def test_host_exec_returns_zero_exit_on_true_command():
@@ -392,12 +389,18 @@ def test_host_exec_does_not_block_the_event_loop():
 
 
 def _deny_reason(caller: str, *, group: str, registered: bool):
-    """Drive the gate with both seams injected; return the response."""
+    """Drive the gate with both seams injected; return the response.
+
+    ``group`` stays a single name for these fixtures' readability; the
+    seam itself answers with the caller's whole group SET (2026-08-10),
+    so an empty ``group`` becomes the empty set — still "ungrouped",
+    still denied, which is exactly what these tests pin.
+    """
     req = _FakeRequest({"argv": ["true"]}, authenticated_node=caller)
     return _run(
         host_exec(
             req,
-            group_resolver=lambda name: group,
+            group_resolver=lambda name: {group} if group else set(),
             registration_probe=lambda name: registered,
             audit_writer=lambda *a, **k: None,
         )

--- a/tests/scitex_agent_container/_listen/test__host_exec_term_grace.py
+++ b/tests/scitex_agent_container/_listen/test__host_exec_term_grace.py
@@ -57,11 +57,11 @@ def _resp_json(resp) -> dict:
     return json.loads(bytes(resp.body).decode("utf-8"))
 
 
-def _dev_resolver(name: str) -> str:
+def _dev_resolver(name: str) -> set[str]:
     # Called by the handler as `group_resolver(name=caller)` — keyword, so the
     # parameter name is part of the seam's contract.
     _ = name
-    return "developer"
+    return {"developer"}
 
 
 def _noop_audit(_entry: dict[str, Any]) -> None:

--- a/tests/scitex_agent_container/_listen/test__host_exec_wedge.py
+++ b/tests/scitex_agent_container/_listen/test__host_exec_wedge.py
@@ -55,8 +55,8 @@ def _resp_json(resp) -> dict:
     return json.loads(bytes(resp.body).decode("utf-8"))
 
 
-def _dev_resolver(name: str) -> str:
-    return "developer"
+def _dev_resolver(name: str) -> set[str]:
+    return {"developer"}
 
 
 def _noop_audit(_entry: dict[str, Any]) -> None:

--- a/tests/scitex_agent_container/_state/test_state_db_groups_authority.py
+++ b/tests/scitex_agent_container/_state/test_state_db_groups_authority.py
@@ -1,0 +1,364 @@
+"""Authority is MEMBERSHIP over an agent's whole named-group set.
+
+REGRESSION — incident 2026-08-10, ``grant``. Its spec authored::
+
+    metadata:
+      labels:
+        groups: [generalist, privileged, developer, researcher, active]
+
+``a2a_peers`` reported all five. ``check_spawn`` on the SAME listen
+server refused the agent with "is in none of the developer, research, or
+privileged groups", because the ACL persisted only the FIRST list
+element (``generalist``) and compared against that one string. Authority
+therefore depended on the ORDER of a YAML list — moving ``developer`` to
+the front would have silently fixed it.
+
+Every test below drives the REAL persistence + REAL lookup against an
+on-disk SQLite state.db (the yield-based ``db_path`` env override the
+sibling group tests use). Nothing is mocked: a mock over
+``resolve_group_name`` / ``read_comms_policy`` is exactly what would have
+let this bug through, since the defect lived in what those functions
+actually stored and returned.
+
+AAA (each marker on its own line), one assertion per test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._listen._acl import check_spawn
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_nodes import (
+    is_developer,
+    is_privileged,
+    is_researcher,
+    read_comms_policy,
+    record_comms_policy,
+    record_lineage,
+    resolve_group_name,
+    resolve_group_names,
+    spawn_allowed,
+)
+
+# grant's spec labels, verbatim and IN ORDER. The order is the whole
+# point: the group that grants authority is never the first element.
+GRANT_GROUPS = ["generalist", "privileged", "developer", "researcher", "active"]
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    # Arrange
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+
+
+def _record_grant_like(name: str, groups: list[str], db: Path) -> None:
+    """Persist an agent the way ``persist_acl_policy`` does: PRIMARY =
+    first authored group, SET = all of them."""
+    record_comms_policy(
+        name=name,
+        group_name=groups[0],
+        group_names=groups,
+        db_path=db,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The exact mismatch: a child whose row lists developer/researcher/privileged
+# NOT in first position. Each of these failed before the fix.
+# ---------------------------------------------------------------------------
+
+
+def test_developer_not_first_in_the_list_is_still_a_developer(db_path: Path) -> None:
+    """``groups: [generalist, developer]`` IS a developer."""
+    # Arrange
+    _record_grant_like("alice", ["generalist", "developer"], db_path)
+    # Act
+    result = is_developer(name="alice", db_path=db_path)
+    # Assert
+    assert result is True
+
+
+def test_researcher_not_first_in_the_list_is_still_a_researcher(db_path: Path) -> None:
+    # Arrange
+    _record_grant_like("alice", ["generalist", "researcher"], db_path)
+    # Act
+    result = is_researcher(name="alice", db_path=db_path)
+    # Assert
+    assert result is True
+
+
+def test_privileged_not_first_in_the_list_is_still_privileged(db_path: Path) -> None:
+    # Arrange
+    _record_grant_like("alice", ["generalist", "privileged"], db_path)
+    # Act
+    result = is_privileged(name="alice", db_path=db_path)
+    # Assert
+    assert result is True
+
+
+def test_grant_child_with_developer_in_its_groups_passes_check_spawn(
+    db_path: Path,
+) -> None:
+    """THE reported bug: grant, a child of scitex-agent-container, denied
+    spawn while its registry row listed developer."""
+    # Arrange
+    _record_grant_like("grant", GRANT_GROUPS, db_path)
+    record_lineage(child="grant", parent="scitex-agent-container", db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="grant", db_path=db_path)
+    # Assert
+    assert decision == "allow"
+
+
+def test_child_with_only_researcher_in_its_groups_passes_check_spawn(
+    db_path: Path,
+) -> None:
+    """The researcher half of the operator's ruling, on the same footing."""
+    # Arrange
+    _record_grant_like("nv", ["generalist", "researcher"], db_path)
+    record_lineage(child="nv", parent="lead", db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="nv", db_path=db_path)
+    # Assert
+    assert decision == "allow"
+
+
+def test_child_with_only_privileged_in_its_groups_passes_check_spawn(
+    db_path: Path,
+) -> None:
+    # Arrange
+    _record_grant_like("dotfiles", ["generalist", "privileged"], db_path)
+    record_lineage(child="dotfiles", parent="lead", db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="dotfiles", db_path=db_path)
+    # Assert
+    assert decision == "allow"
+
+
+# ---------------------------------------------------------------------------
+# The gate still SHUTS. A broadened ACL that stopped denying would be a
+# worse bug than the one being fixed.
+# ---------------------------------------------------------------------------
+
+
+def test_child_in_no_authorising_group_is_still_denied(db_path: Path) -> None:
+    # Arrange
+    _record_grant_like("worker", ["generalist", "active"], db_path)
+    record_lineage(child="worker", parent="lead", db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="worker", db_path=db_path)
+    # Assert
+    assert decision == "deny"
+
+
+def test_ungrouped_child_is_still_denied(db_path: Path) -> None:
+    # Arrange
+    record_comms_policy(name="worker", db_path=db_path)
+    record_lineage(child="worker", parent="lead", db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="worker", db_path=db_path)
+    # Assert
+    assert decision == "deny"
+
+
+def test_isolated_solver_group_gets_no_spawn_authority(db_path: Path) -> None:
+    """A deliberately-isolated solver must not gain authority from the
+    set-valued read."""
+    # Arrange
+    _record_grant_like("solver", ["solver", "capsule"], db_path)
+    record_lineage(child="solver", parent="clew", db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="solver", db_path=db_path)
+    # Assert
+    assert decision == "deny"
+
+
+# ---------------------------------------------------------------------------
+# The MESH bucket stays single-valued. Authority is any-of; the default-ACL
+# mesh keeps ONE group per agent, which is what keeps a solver isolated.
+# ---------------------------------------------------------------------------
+
+
+def test_primary_group_is_still_the_first_authored_group(db_path: Path) -> None:
+    # Arrange
+    _record_grant_like("grant", GRANT_GROUPS, db_path)
+    # Act
+    primary = resolve_group_name(name="grant", db_path=db_path)
+    # Assert
+    assert primary == "generalist"
+
+
+def test_resolve_group_names_returns_every_authored_group(db_path: Path) -> None:
+    # Arrange
+    _record_grant_like("grant", GRANT_GROUPS, db_path)
+    # Act
+    groups = resolve_group_names(name="grant", db_path=db_path)
+    # Assert
+    assert groups == frozenset(GRANT_GROUPS)
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: a row written by the OLD code (primary only, no
+# set) must keep its exact old meaning rather than losing its group.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_row_without_a_set_still_resolves_to_its_primary(
+    db_path: Path,
+) -> None:
+    # Arrange — group_names omitted, exactly like a pre-migration caller.
+    record_comms_policy(name="legacy", group_name="developer", db_path=db_path)
+    # Act
+    groups = resolve_group_names(name="legacy", db_path=db_path)
+    # Assert
+    assert groups == frozenset({"developer"})
+
+
+def test_legacy_developer_row_still_passes_check_spawn(db_path: Path) -> None:
+    # Arrange
+    record_comms_policy(name="legacy", group_name="developer", db_path=db_path)
+    record_lineage(child="legacy", parent="lead", db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="legacy", db_path=db_path)
+    # Assert
+    assert decision == "allow"
+
+
+def test_unknown_agent_resolves_to_no_groups(db_path: Path) -> None:
+    # Arrange — no row at all.
+    # Act
+    groups = resolve_group_names(name="ghost", db_path=db_path)
+    # Assert
+    assert groups == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Round-trip + encoding guards on the new column.
+# ---------------------------------------------------------------------------
+
+
+def test_group_names_round_trip_through_the_policy_row(db_path: Path) -> None:
+    # Arrange
+    _record_grant_like("grant", GRANT_GROUPS, db_path)
+    # Act
+    policy = read_comms_policy(name="grant", db_path=db_path)
+    # Assert
+    assert set(policy["group_names"]) == set(GRANT_GROUPS)
+
+
+def test_group_names_defaults_to_empty_for_an_unrecorded_agent(
+    db_path: Path,
+) -> None:
+    # Arrange — no record_comms_policy call.
+    # Act
+    policy = read_comms_policy(name="never-recorded", db_path=db_path)
+    # Assert
+    assert policy["group_names"] == ()
+
+
+def test_a_group_name_containing_a_comma_is_rejected(db_path: Path) -> None:
+    """The column is comma-separated; silently splitting one group into
+    two would corrupt an ACL input."""
+    # Arrange
+    bad = ["developer,researcher"]
+    # Act
+    raises = pytest.raises(ValueError)
+    # Assert
+    with raises:
+        record_comms_policy(name="alice", group_names=bad, db_path=db_path)
+
+
+def test_a_bare_string_group_names_is_rejected(db_path: Path) -> None:
+    """A string would be iterated character by character — a silent
+    fail-shut that looks like a correct ACL."""
+    # Arrange
+    bad = "developer"
+    # Act
+    raises = pytest.raises(ValueError)
+    # Assert
+    with raises:
+        record_comms_policy(name="alice", group_names=bad, db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# The DENIAL MESSAGE. It sent grant down the wrong path for hours by
+# asserting a fact about the AGENT rather than reporting what the GATE saw.
+# ---------------------------------------------------------------------------
+
+
+def test_denial_names_the_groups_the_gate_actually_resolved(db_path: Path) -> None:
+    # Arrange
+    _record_grant_like("worker", ["generalist", "active"], db_path)
+    record_lineage(child="worker", parent="lead", db_path=db_path)
+    # Act
+    _decision, reason = spawn_allowed(caller="worker", db_path=db_path)
+    # Assert
+    assert "'active', 'generalist'" in reason
+
+
+def test_denial_no_longer_claims_the_caller_holds_none_of_the_groups(
+    db_path: Path,
+) -> None:
+    """The old sentence was flatly false against the same server's own
+    a2a_peers output; it must not come back."""
+    # Arrange
+    _record_grant_like("worker", ["generalist"], db_path)
+    record_lineage(child="worker", parent="lead", db_path=db_path)
+    # Act
+    _decision, reason = spawn_allowed(caller="worker", db_path=db_path)
+    # Assert
+    assert "is in none of the" not in reason
+
+
+def test_denial_spells_researcher_in_full(db_path: Path) -> None:
+    """The old text said "research", which cost a reader a wrong
+    hypothesis about a string mismatch. Name the real group."""
+    # Arrange
+    _record_grant_like("worker", ["generalist"], db_path)
+    record_lineage(child="worker", parent="lead", db_path=db_path)
+    # Act
+    _decision, reason = spawn_allowed(caller="worker", db_path=db_path)
+    # Assert
+    assert "researcher" in reason
+
+
+def test_denial_points_at_refresh_acl_when_the_row_may_be_stale(
+    db_path: Path,
+) -> None:
+    # Arrange
+    _record_grant_like("worker", ["generalist"], db_path)
+    record_lineage(child="worker", parent="lead", db_path=db_path)
+    # Act
+    _decision, reason = spawn_allowed(caller="worker", db_path=db_path)
+    # Assert
+    assert "refresh-acl" in reason
+
+
+def test_denial_distinguishes_an_absent_row_from_an_ungrouped_agent(
+    db_path: Path,
+) -> None:
+    """The 2026-08-09 host_exec lesson, applied to the spawn gate: both
+    produce an empty group set and they are different facts."""
+    # Arrange — a lineage edge but NO policy row for the caller.
+    record_lineage(child="stranger", parent="lead", db_path=db_path)
+    # Act
+    _decision, reason = spawn_allowed(caller="stranger", db_path=db_path)
+    # Assert
+    assert "NO node_comms_policy row" in reason

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -237,15 +237,32 @@ def test_spawn_allowed_returns_false_for_child_node(db_path: Path) -> None:
 def test_spawn_allowed_deny_reason_explains_role_policy(
     db_path: Path,
 ) -> None:
+    """The reason names the groups that WOULD have authorised the spawn.
+
+    It no longer asserts the caller "is in none of" them: that sentence
+    was a claim about the AGENT, and when the multi-group defect made a
+    caller's ``developer`` label unreadable it was flatly false against
+    the same server's own a2a_peers output (2026-08-10).
+    """
     # Arrange
     record_lineage(child="worker-a", parent="root", db_path=db_path)
     # Act
     _allowed, reason = spawn_allowed(caller="worker-a", db_path=db_path)
     # Assert
-    assert (
-        reason is not None
-        and "none of the developer, research, or privileged groups" in reason
-    )
+    assert reason is not None and "developer, researcher, privileged" in reason
+
+
+def test_spawn_deny_reason_for_unregistered_caller_says_it_has_no_row(
+    db_path: Path,
+) -> None:
+    """No policy row and "registered but ungrouped" both resolve to an
+    empty group set, and they are DIFFERENT facts (2026-08-09)."""
+    # Arrange — a lineage edge but no node_comms_policy row.
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    # Act
+    _allowed, reason = spawn_allowed(caller="worker-a", db_path=db_path)
+    # Assert
+    assert "NO node_comms_policy row" in reason
 
 
 def test_spawn_allowed_returns_true_for_developer_group_child(
@@ -308,17 +325,19 @@ def test_spawn_allowed_returns_false_for_non_dev_research_group_child(
 def test_spawn_allowed_deny_reason_for_non_dev_research_group_child(
     db_path: Path,
 ) -> None:
-    """The deny reason names the role-based policy."""
+    """The deny reason reports the group the gate ACTUALLY resolved.
+
+    Reporting what the gate SAW — rather than asserting what the agent
+    is — is what lets a reader tell a correct denial from a stale row
+    without guessing (2026-08-10).
+    """
     # Arrange
     record_lineage(child="worker-a", parent="root", db_path=db_path)
     record_comms_policy(name="worker-a", group_name="analysts", db_path=db_path)
     # Act
     _allowed, reason = spawn_allowed(caller="worker-a", db_path=db_path)
     # Assert
-    assert (
-        reason is not None
-        and "none of the developer, research, or privileged groups" in reason
-    )
+    assert reason is not None and "['analysts']" in reason
 
 
 def test_spawn_allowed_may_spawn_false_still_denies_developer_child(
@@ -434,17 +453,34 @@ def test_spawn_allowed_denies_child_in_neither_group(db_path: Path) -> None:
 
 
 def test_spawn_allowed_deny_reason_names_group_policy(db_path: Path) -> None:
-    """The neither-group deny reason states the new group-scoped policy."""
+    """The neither-group deny reason states the group-scoped policy.
+
+    Spelled ``researcher`` in full. The old text said "research", and a
+    reader reasonably guessed a "research" vs "researcher" string
+    mismatch was the bug — it was not, and the wrong hypothesis cost
+    time (2026-08-10).
+    """
     # Arrange
     record_lineage(child="worker-gen", parent="root", db_path=db_path)
     record_comms_policy(name="worker-gen", group_name="generalist", db_path=db_path)
     # Act
     _allowed, reason = spawn_allowed(caller="worker-gen", db_path=db_path)
     # Assert
-    assert (
-        reason is not None
-        and "developer/research/privileged group members, may" in reason
-    )
+    assert reason is not None and "developer, researcher, privileged" in reason
+
+
+def test_spawn_deny_reason_points_at_refresh_acl_for_a_stale_row(
+    db_path: Path,
+) -> None:
+    """A denial whose group list disagrees with the spec means a STALE
+    row; the message must name the command that re-publishes it."""
+    # Arrange
+    record_lineage(child="worker-gen", parent="root", db_path=db_path)
+    record_comms_policy(name="worker-gen", group_name="generalist", db_path=db_path)
+    # Act
+    _allowed, reason = spawn_allowed(caller="worker-gen", db_path=db_path)
+    # Assert
+    assert "refresh-acl" in reason
 
 
 def test_spawn_allowed_developer_group_child_still_respects_may_spawn(


### PR DESCRIPTION
## The report

`grant` ran `sac agents start scitex-cv --yes` and got a 403:

> spawn denied: caller 'grant' is a child of 'scitex-agent-container' and is in none of the developer, research, or privileged groups.

while the **same listen server's** `a2a_peers` returned grant's row as
`groups: ["generalist", "privileged", "developer", "researcher", "active"]`.

The registry said grant HAS developer. The ACL said it has none. Both answers
came from the same server.

## Mechanism — one sentence

`group_from_labels()` reduces a spec's `metadata.labels.groups` list to its
**first element**, that single string is persisted into
`node_comms_policy.group_name`, and every authority gate compares against it —
so grant's `developer` / `researcher` / `privileged` labels, sitting behind
`generalist` in the list, were invisible to the ACL while `a2a_peers` reported
all five through the MULTI-value `all_named_groups()`.

**Defect site:** `src/scitex_agent_container/_state/state_db_nodes.py:249`
(`is_developer`, pre-fix) reading `resolve_group_name` — the single-group
column — with the same reduction repeated at `state_db_nodes.py:354`
(`spawn_allowed` group fallthrough) and `_listen/_host_exec.py:281`
(`ELIGIBLE_GROUPS` membership).

### Measured, not inferred

Run against the **live production** state.db before the fix:

```
spec labels.groups                       : [generalist, privileged, developer, researcher, active]
all_named_groups()   (a2a_peers view)    : [active, developer, generalist, privileged, researcher]
group_from_labels()  (ACL view)          : "generalist"
read_comms_policy(grant).group_name      : "generalist"
is_developer(grant)                      : false
is_researcher(grant)                     : false
spawn_allowed(grant)                     : [false, "spawn denied: caller 'grant' is a child of
                                            'scitex-agent-container' and is in none of the
                                            developer, research, or privileged groups. ..."]
check_spawn(grant)                       : ["deny", "...same..."]
```

Authority depended on the **order of a YAML list**. Moving `developer` to the
front would have silently fixed it — which is the clearest possible sign the
reduction was wrong.

`host_exec` had the identical latent defect for the same caller
(`ELIGIBLE_GROUPS` vs the reduced single group), so grant's next host command
would have failed the same way. Fixed in the same pass.

## grant's string-mismatch hypothesis: WRONG

grant suspected the denial's "research" (singular) vs the group `researcher`.
Disproved rather than dismissed:

- `is_research_group()` compares against `RESEARCHER_GROUP = "researcher"` —
  correct spelling (`config/_group_resolver.py:311-323`).
- `is_researcher()` compares against `RESEARCHER_GROUP.lower()` — correct.
- `_host_exec.ELIGIBLE_GROUPS = {"developer", "researcher", "privileged"}` —
  correct.
- The only "research" was **prose in the denial text**. No comparison anywhere
  used it.

The measurement above is the direct proof: `is_developer(grant)` returned
`false`, and `developer` has no spelling ambiguity at all.

The prose is fixed anyway — it cost a reader a wrong hypothesis, and that is
reason enough.

## The cut this makes

**Authority is MEMBERSHIP (any-of).** "May this agent spawn / manage /
host-exec" is a capability the operator grants by naming the group *anywhere*
in `labels.groups`.

**The default-ACL mesh keeps ONE bucket per agent (first-of).** "Do these two
agents coordinate by default" still resolves through the PRIMARY group,
deliberately unchanged — a solver authored `groups: [solver]` must stay outside
the fleet mesh, and collapsing the two questions is how that isolation
guarantee would erode.

## Making the disagreement impossible

The spec's `metadata.labels` is the single source of truth; the DB is its
cache. The bug was that the cache **lost information**.

- `node_comms_policy` gains `group_names` holding the **full** authored set.
- `persist_acl_policy` writes BOTH projections from the SAME labels dict, so
  they cannot drift.
- `resolve_group_names` UNIONS the set with the primary, so a row written
  before this change keeps its **exact** old meaning — no backfill needed for
  correctness, and the two columns can never disagree in the direction that
  REMOVES authority.

And where it can still be wrong, it is now **loud**:

- `groups_intersect` raises `TypeError` on a bare string. A resolver still
  returning one name would be iterated character by character, match nothing,
  and silently deny everyone — a fail-shut bug that looks exactly like a
  correct ACL.
- `record_comms_policy` raises on a group name containing a comma (the column
  is comma-separated) rather than splitting one group into two.

## The denial message (task item D)

The old text asserted a fact about the **agent** — "is in none of the ... groups"
— which was flatly false against the same server's own `a2a_peers` output, and
sent grant after its group labels instead of after the reduction that dropped
them. It now reports what the **gate saw**:

```
spawn denied: caller 'worker-gen' is a child of 'root' and the groups this host
resolved for it are ['generalist'], none of which grant spawn authority. Spawn
requires one of: developer, researcher, privileged (membership — naming the
group anywhere in metadata.labels.groups is enough), or being a root node. If
the groups above disagree with the agent's spec.yaml, this host's row is STALE:
run 'sac agents refresh-acl' to re-publish it from the spec.
```

It also distinguishes "no policy row in this store at all" from "registered and
ungrouped" — the 2026-08-09 `host_exec` lesson, which cost ~15 minutes because
both produce an empty group set and they are different facts.

## Not a broadening of who may spawn

Root nodes, `developer`, `researcher` and `privileged` were **already** the
policy. This makes the gate able to see those groups. Tests pin that ungrouped
children, non-authorising groups, and isolated solver groups are all still
denied, and that the primary group is still the first authored one.

## Activation

Rows written by the old code carry only the primary group. `resolve_group_names`
keeps them working exactly as before, and

```
sac agents refresh-acl
```

re-publishes every agent's full set from its on-disk spec — **no fleet
relaunch**. The command's diff now shows the SET rather than the single group.

## Tests

New `tests/scitex_agent_container/_state/test_state_db_groups_authority.py`
(23 tests) plus 5 labels-driven end-to-end tests in `test__acl_group.py` that
walk the real path `metadata.labels -> resolvers -> DB -> gate`. No mocks — a
mock over `resolve_group_name` / `read_comms_policy` is precisely what would
have let this through, since the defect lived in what those functions actually
stored and returned.

`_seed_child_from_labels` in `test__acl_group.py` was itself seeding only the
primary group; that is why the existing suite could not catch this. It now
mirrors `persist_acl_policy` exactly.

Five pre-existing tests pinned the old denial prose and were updated to pin the
new contract (the groups the gate resolved, the full spelling of `researcher`,
the absent-row branch, the `refresh-acl` pointer).

## Symptoms this does NOT fix — filed separately

The coordinator raised three more disagreements-with-reality on the same night.
I measured each. **Only the ACL one is this bug**, and saying otherwise would be
worse than three honest cards:

- **`sac agents tail scitex-cv` -> "not found in registry"** — different root
  cause. Each agent's spec pins
  `SCITEX_AGENT_CONTAINER_STATE_DB=/state/<agent>/state.db`, a private DB; an
  agent started on the host writes its `instances` row to the HOST db only.
  Verified: the host db has `scitex-cv` with `ended_at=None`. **Not `$HOME`** —
  an explicit per-spec override, and `/state` does not exist on the host at all.
  Card `sac-per-agent-statedb-hides-fleet-20260810`.
- **`GET /agents/scitex-agent-container/status` -> 500
  `spec_resolution_failed`** — different root cause. `resolve_config` picks a
  STALE v2-era spec from `~/.dotfiles/src/.scitex/agent-container/agents/` over
  the user-scope one, and it fails v3 validation ("spec.env is no longer
  accepted at the top level"). Two registries claim the name and
  `AmbiguousRegistryScope` did NOT fire, so a 409-shaped conflict surfaced as an
  unclassified 500. Card
  `sac-stale-dotfiles-spec-shadows-registry-20260810`.
- **credentials read from `/home/agent/...` while the real ones are in
  `/home/ywatanabe/...`** — that one genuinely IS `$HOME`, and is unrelated to
  all three above.

The ACL bug is **not** vantage-dependent: it reproduces on the host, in one
process, against the host DB that *does* hold grant's row. The row is simply
lossy.

Fixes the incident reported by `grant` (2026-08-10). Card:
`sac-acl-multi-group-authority-20260810`.
