### PR TITLE
fix(start): gate the credential the agent actually uses, not the lead's

### DIFF
--- a/src/scitex_agent_container/_state/_preflight_creds.py
+++ b/src/scitex_agent_container/_state/_preflight_creds.py
@@ -1,16 +1,42 @@
 """Pre-dispatch OAuth credential expiry check.
 
-When ``sac agents start`` dispatches an agent that runs Claude via the
-Pro/Max OAuth flow, the lead's ``~/.claude/.credentials.json`` is the
-authoritative auth artefact — it gets bind-mounted into the container
-at ``/tmp/sac-claude/.credentials.json`` by the apptainer runtime
-auto-bind (see ``runtimes/_apptainer_runtime.py``).
+If the OAuth ``accessToken`` an agent will authenticate with is already
+expired (or about to expire), the in-container ``claude`` 401s and exits
+before rendering — surfacing only as an empty pane with no cause. This
+module catches that condition *before* dispatch fires so the operator
+gets a clear, actionable message instead.
 
-If the OAuth ``accessToken`` is already expired (or about to expire),
-the agent will fail authentication mid-flight without an obvious
-cause. This module catches that condition *before* dispatch fires so
-the operator gets a clear, actionable message instead of a confusing
-runtime error inside the container.
+WHICH FILE the gate reads is the whole point (outage 2026-08-10). An
+agent authenticates with the credential ITS SPEC declares, and for most
+of the fleet that is NOT the lead's ``~/.claude/.credentials.json``:
+
+* ``spec.claude.credentials_files`` (the account POOL) — or the singular
+  ``spec.claude.credentials_file`` treated as a 1-element pool — is
+  collapsed to ONE picked entry at launch by
+  :func:`_lifecycle._start_preflight._rotate_to_healthy_account`, and
+  :func:`runtimes._apptainer_auth_bind.credentials_file_bind` binds THAT
+  file at the container's ``$HOME/.claude/.credentials.json``. For a
+  designated file :func:`runtimes._apptainer_auth.auth_argv` returns
+  early, so ``~/.claude/`` is not bound for such an agent at all.
+* ``spec.claude.account`` resolves to the stored snapshot at
+  ``<account-store>/<account>/.credentials.json``
+  (:func:`runtimes._apptainer_creds.resolve_cred_file`); that snapshot's
+  DIRECTORY is what gets dir-bound at ``/tmp/sac-claude``.
+* ONLY a fully-unpinned spec (no pool, no file, no account, no provider)
+  falls back to the lead's ``~/.claude/`` — which IS still dir-bound at
+  ``/tmp/sac-claude`` with ``CLAUDE_CONFIG_DIR`` pointed at it for that
+  branch. So the lead file remains load-bearing, but it is one artefact
+  among several rather than *the* authoritative one.
+
+:func:`check_spec_oauth_credentials` therefore resolves the same
+candidate list the runtime will, in the same order, and proceeds when
+ANY candidate is usable — the launch-time picker then makes the
+quota-aware choice among them and fails loud on its own health model if
+it rejects them all. It refuses only when EVERY declared candidate is
+expired/missing/malformed, and its message names each one. Before this,
+the gate always read ``~/.claude/.credentials.json`` and so refused
+every start on a host whose lead token had lapsed while a dozen agents
+ran happily on fresh pool credentials — a false negative, not a guard.
 
 Hard rules (no silent fallbacks):
 
@@ -44,7 +70,13 @@ EXPIRY_SKEW_SECONDS = 300
 
 
 def _default_credentials_path() -> Path:
-    """Return the canonical lead-host credentials path.
+    """Return the lead-host live credentials path.
+
+    The FALLBACK candidate only — it is what a fully-unpinned spec (no
+    ``credentials_files`` / ``credentials_file`` / ``account`` /
+    ``provider``) actually authenticates with, via the ``~/.claude/``
+    dir-bind at ``/tmp/sac-claude``. A spec that declares any credential
+    of its own never reaches this path; see the module docstring.
 
     Kept as a helper (not a module-level constant) so tests can monkey-
     free-replace it via the ``creds_path`` parameter without touching
@@ -176,7 +208,133 @@ def check_oauth_token_expiry(
         )
 
 
+def spec_credential_candidates(
+    claude_spec: object, *, home: Path | None = None
+) -> tuple[list[tuple[str, Path]], bool]:
+    """Return ``(candidates, declared_by_spec)`` for one agent's claude spec.
+
+    Each candidate is an ``(origin, path)`` pair: ``origin`` is the spec
+    field (with its list index) the path came from, so a failure message
+    can say WHICH declaration is broken rather than just quoting a path.
+
+    The order is NOT invented here — it mirrors
+    :func:`_lifecycle._start_preflight._rotate_to_healthy_account`, the
+    function that actually decides what the agent runs on, entry point by
+    entry point:
+
+    1. ``credentials_files`` (plural) — the account POOL, in declared
+       order. The launch-time picker chooses one of exactly these.
+    2. else ``credentials_file`` (singular) — treated as a 1-element pool
+       by that same function.
+    3. else ``account`` — the stored snapshot at
+       ``<account-store>/<account>/.credentials.json``, resolved through
+       the same :func:`_state.account_store._store_path` cascade
+       :func:`runtimes._apptainer_creds.resolve_cred_file` uses.
+    4. else the lead's ``~/.claude/.credentials.json`` — the ONLY case
+       where ``declared_by_spec`` is ``False``.
+
+    ``home`` is the test seam for (3) and (4); production passes ``None``
+    → ``Path.home()``.
+    """
+    raw_pool = getattr(claude_spec, "credentials_files", None) or []
+    files = [str(p).strip() for p in raw_pool if str(p).strip()]
+    single = str(getattr(claude_spec, "credentials_file", "") or "").strip()
+    if files:
+        return (
+            [
+                (f"spec.claude.credentials_files[{idx}]", Path(raw).expanduser())
+                for idx, raw in enumerate(files)
+            ],
+            True,
+        )
+    if single:
+        return [("spec.claude.credentials_file", Path(single).expanduser())], True
+
+    account = str(getattr(claude_spec, "account", "") or "").strip()
+    if account:
+        from .account_store import _store_path
+
+        _home = home if home is not None else Path.home()
+        snapshot = _store_path(None, _home) / account / ".credentials.json"
+        return [(f"spec.claude.account={account!r}", snapshot)], True
+
+    if home is not None:
+        return [
+            ("~/.claude/.credentials.json", home / ".claude" / ".credentials.json")
+        ], False
+    return [("~/.claude/.credentials.json", _default_credentials_path())], False
+
+
+def check_spec_oauth_credentials(
+    config: object,
+    *,
+    now: float | None = None,
+    skew_seconds: int = EXPIRY_SKEW_SECONDS,
+    home: Path | None = None,
+) -> Path | None:
+    """Raise unless SOME credential the agent may actually use is usable.
+
+    ``config`` is an :class:`~scitex_agent_container.config.AgentConfig`
+    (anything exposing ``.claude`` and ``.name`` works). Candidates come
+    from :func:`spec_credential_candidates`; each is put through
+    :func:`check_oauth_token_expiry`.
+
+    Passing is an ANY, not an ALL: the pool exists precisely so one
+    expired account does not ground the agent, and the launch-time
+    quota-aware picker (which applies its own, stricter health model and
+    fails loud by itself) decides which entry actually gets bound. This
+    gate only has to establish that a start is not doomed before it
+    starts.
+
+    Returns the first usable path, or ``None`` when the check was skipped
+    because ``ANTHROPIC_API_KEY`` / ``SAC_ANTHROPIC_API_KEY`` is set.
+
+    Raises
+    ------
+    FileNotFoundError, ValueError, RuntimeError
+        For an UNDECLARED spec the single default-path failure propagates
+        verbatim, so the no-spec-credential case keeps exactly the message
+        and exception type it has always had.
+    RuntimeError
+        When a spec DECLARES credentials and every one of them fails. The
+        message names each candidate, its path, and its own reason — the
+        operator has to see which accounts to refresh, not just the first.
+    """
+    if _api_key_env_is_set():
+        return None
+
+    claude_spec = getattr(config, "claude", None)
+    candidates, declared = spec_credential_candidates(claude_spec, home=home)
+
+    if not declared:
+        _origin, path = candidates[0]
+        check_oauth_token_expiry(path, now=now, skew_seconds=skew_seconds)
+        return path
+
+    failures: list[str] = []
+    for origin, path in candidates:
+        try:
+            check_oauth_token_expiry(path, now=now, skew_seconds=skew_seconds)
+        except (FileNotFoundError, ValueError, RuntimeError) as exc:
+            failures.append(f"  - {origin} ({path!s}): {exc}")
+            continue
+        return path
+
+    name = str(getattr(config, "name", "") or "") or "<unnamed>"
+    detail = "\n".join(failures)
+    raise RuntimeError(
+        f"agent {name!r}: every credential its spec declares is unusable "
+        f"({len(failures)} candidate(s) checked, none passed):\n{detail}\n"
+        "Fix: `claude /login` to one of those accounts then "
+        "`sac accounts sync-live` on this host, or export "
+        "ANTHROPIC_API_KEY / SAC_ANTHROPIC_API_KEY to use the API-key "
+        "auth path instead."
+    )
+
+
 __all__ = [
     "EXPIRY_SKEW_SECONDS",
     "check_oauth_token_expiry",
+    "check_spec_oauth_credentials",
+    "spec_credential_candidates",
 ]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_preflight_gate.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_preflight_gate.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""OAuth-need predicate for ``sac agents start`` preflight gating.
+"""Credential gating for ``sac agents start``.
 
 Extracted from :mod:`._start` to keep the click entry point inside the
-per-file 512-line cap. The predicate is a self-contained spec-loading
-helper — it decides whether the parent's Anthropic OAuth preflight is
-relevant for the targets at hand. ``_start.py`` re-imports it so the
-``_run_preflight_once`` closure keeps working unchanged.
+per-file 512-line cap; ``_start.py`` imports
+:func:`make_preflight_runner` so the ``_run_preflight_once`` closure
+keeps working unchanged.
+
+The gate loads each target's spec ONCE and asks two questions of it:
+does this target use Anthropic OAuth at all (a provider-backed spec does
+not), and if so, is any credential IT declares usable? The second
+question is answered by
+:func:`_state._preflight_creds.check_spec_oauth_credentials` — the
+lead's ``~/.claude/.credentials.json`` is only one possible answer, and
+for the pool-backed fleet it is not the answer at all.
 """
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Iterator
 
 import click
 
@@ -28,12 +35,26 @@ def make_preflight_runner(
     Lazy / one-shot: the returned callable runs the credential-expiry
     check only on the FIRST call (subsequent calls are no-ops), skips on
     ``--no-redispatch`` (peer-side invocation) and on ``--broker-self``
-    (orchestrator-only — never talks to Anthropic), and skips when EVERY
-    target's spec is provider-backed (the SDK session routes through a
-    non-Anthropic backend; the bind-mounted Anthropic creds are never
-    read). On a real failure it exits 1 with the helper's message on
-    stderr, no traceback. Shared by the single, bulk, and parallel
-    dispatch paths so the gating is identical across all three.
+    (orchestrator-only — never talks to Anthropic), and skips any target
+    whose spec is provider-backed (the SDK session routes through a
+    non-Anthropic backend; the Anthropic creds are never read). On a real
+    failure it exits 1 with the helper's message on stderr, no traceback.
+    Shared by the single, bulk, and parallel dispatch paths so the gating
+    is identical across all three.
+
+    The check is PER TARGET, against the credentials THAT target's spec
+    declares (:func:`_state._preflight_creds.check_spec_oauth_credentials`)
+    — the pool in ``claude.credentials_files``, the singular
+    ``claude.credentials_file``, or the ``claude.account`` snapshot. Only
+    a spec that declares none of those is gated on the lead's
+    ``~/.claude/.credentials.json``. Checking the lead file for EVERY
+    agent is what took the whole fleet down on 2026-08-10: the lead token
+    had lapsed, every declared pool credential was fresh, and every start
+    on the host was refused anyway.
+
+    A spec that will not load is gated on the lead file, keeping the old
+    defensive default — better to ask for creds and let the dispatch loop
+    surface the real spec error than to skip the gate on a broken spec.
     """
     ran = {"done": False}
 
@@ -43,17 +64,44 @@ def make_preflight_runner(
         ran["done"] = True
         if broker_self:
             return
-        if not any_target_needs_anthropic_oauth(single_targets, bulk_yamls):
-            return
-        from ..._state._preflight_creds import check_oauth_token_expiry
+        from ..._state._preflight_creds import (
+            check_oauth_token_expiry,
+            check_spec_oauth_credentials,
+        )
 
         try:
-            check_oauth_token_expiry()
+            for cfg in _iter_target_configs(single_targets, bulk_yamls):
+                if cfg is None:
+                    check_oauth_token_expiry()
+                    continue
+                if getattr(getattr(cfg, "claude", None), "provider", None) is not None:
+                    continue
+                check_spec_oauth_credentials(cfg)
         except (FileNotFoundError, ValueError, RuntimeError) as exc:
             click.echo(f"Error: {exc}", err=True)
             raise SystemExit(1)
 
     return _run_preflight_once
+
+
+def _iter_target_configs(
+    single_targets: list[str], bulk_yamls: list[str]
+) -> Iterator[object | None]:
+    """Yield each target's loaded ``AgentConfig``, or ``None`` when it won't load.
+
+    One resolve+load per target, shared by the preflight runner and
+    :func:`any_target_needs_anthropic_oauth` so the two can never disagree
+    about what a target's spec says.
+    """
+    from ...config import load_config
+    from ...config._resolve import resolve_with_prefix
+
+    for raw in list(single_targets) + list(bulk_yamls):
+        try:
+            cfg: object | None = load_config(resolve_with_prefix(raw))
+        except Exception:  # stx-allow: fallback (reason: defensive — an unloadable spec must not skip the gate; see make_preflight_runner)
+            cfg = None
+        yield cfg
 
 
 def any_target_needs_anthropic_oauth(
@@ -63,10 +111,9 @@ def any_target_needs_anthropic_oauth(
 
     PR#314 (lead msg 24a8b27c): provider-backed specs (LiteLLM, vLLM,
     DeepSeek, gateway via ``ANTHROPIC_BASE_URL``) route the SDK session
-    through a non-Anthropic backend; the parent's
-    ``~/.claude/.credentials.json`` is bind-mounted but never read.
-    When EVERY target has ``spec.claude.provider`` non-None, the
-    parent's OAuth preflight is moot.
+    through a non-Anthropic backend; the Anthropic OAuth credentials are
+    bind-mounted but never read. When EVERY target has
+    ``spec.claude.provider`` non-None, the OAuth preflight is moot.
 
     Defensive default: if a spec fails to load (unresolvable name,
     unparseable YAML, schema error), assume it needs OAuth. Better to
@@ -74,17 +121,10 @@ def any_target_needs_anthropic_oauth(
     actual dispatch loop than to skip the gate silently on a broken
     spec the operator hasn't noticed yet.
     """
-    from ...config import load_config
-    from ...config._resolve import resolve_with_prefix
-
-    for raw in list(single_targets) + list(bulk_yamls):
-        try:
-            cfg_path = resolve_with_prefix(raw)
-            cfg = load_config(cfg_path)
-        except Exception:  # stx-allow: fallback (reason: defensive — see docstring)
+    for cfg in _iter_target_configs(single_targets, bulk_yamls):
+        if cfg is None:
             return True
-        provider = getattr(getattr(cfg, "claude", None), "provider", None)
-        if provider is None:
+        if getattr(getattr(cfg, "claude", None), "provider", None) is None:
             return True
     return False
 

--- a/tests/scitex_agent_container/_state/test__preflight_creds_spec.py
+++ b/tests/scitex_agent_container/_state/test__preflight_creds_spec.py
@@ -1,0 +1,327 @@
+"""Tests for the SPEC-AWARE half of the start preflight.
+
+The gate must read the credentials the agent will ACTUALLY authenticate
+with — the ``claude.credentials_files`` pool, the singular
+``claude.credentials_file``, or the ``claude.account`` snapshot — and
+only fall back to the lead's ``~/.claude/.credentials.json`` when the
+spec declares none of them.
+
+The regression these pin is the 2026-08-10 host outage: the lead file
+had lapsed ~16h earlier, every pool credential the fleet's specs declare
+was fresh, twelve agents were running on them, and ``sac agents start``
+refused EVERY start on the host because the gate only ever looked at the
+lead file. A false negative, not a safety net.
+
+Style rules in force here (mirroring ``test__preflight_creds.py``):
+* One assert per test (STX-TQ007).
+* AAA markers each on their own line.
+* No monkeypatch / mocker fixture params (STX-NM002) — env mutation
+  uses ``os.environ`` save/restore in a fixture.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._state._preflight_creds import (
+    check_spec_oauth_credentials,
+    spec_credential_candidates,
+)
+from scitex_agent_container.config import AgentConfig
+
+_FROZEN_NOW = 1_700_000_000.0
+_FROZEN_NOW_MS = 1_700_000_000_000
+_ONE_HOUR_MS = 3_600_000
+
+
+def _write_creds(path: Path, expires_at_ms: int) -> Path:
+    """Materialise a ``.credentials.json`` with the given ``expiresAt``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat-fake",
+                    "refreshToken": "sk-ant-ort-fake",
+                    "expiresAt": expires_at_ms,
+                    "scopes": ["user:inference"],
+                    "subscriptionType": "max",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _fresh(path: Path) -> Path:
+    return _write_creds(path, _FROZEN_NOW_MS + _ONE_HOUR_MS)
+
+
+def _stale(path: Path) -> Path:
+    return _write_creds(path, _FROZEN_NOW_MS - _ONE_HOUR_MS)
+
+
+@pytest.fixture
+def clean_env() -> Iterator[None]:
+    """Strip the API-key env vars so the OAuth branch is actually taken."""
+    # Arrange
+    snapshot = {
+        "ANTHROPIC_API_KEY": os.environ.pop("ANTHROPIC_API_KEY", None),
+        "SAC_ANTHROPIC_API_KEY": os.environ.pop("SAC_ANTHROPIC_API_KEY", None),
+    }
+    try:
+        yield
+    finally:
+        for key, value in snapshot.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+@pytest.fixture
+def expired_lead_home(tmp_path: Path, clean_env) -> Iterator[Path]:
+    """Pin ``$HOME`` to a tmp dir holding an EXPIRED lead credentials file.
+
+    This is the outage's shape: the fallback artefact is dead. Any test
+    that passes under this fixture proves the gate did not consult it.
+    """
+    # Arrange
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    _stale(tmp_path / ".claude" / ".credentials.json")
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def _pool_config(name: str, paths: list[Path]) -> AgentConfig:
+    cfg = AgentConfig(name=name)
+    cfg.claude.credentials_files = [str(p) for p in paths]
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# The live bug: a declared pool credential is fresh, the lead file is not.
+# ---------------------------------------------------------------------------
+
+
+class TestDeclaredPoolWins:
+    def test_valid_pool_entry_passes_while_lead_file_is_expired(
+        self, expired_lead_home: Path
+    ) -> None:
+        # Arrange
+        good = _fresh(expired_lead_home / "accounts" / "alpha" / ".credentials.json")
+        cfg = _pool_config("dotfiles", [good])
+        # Act
+        picked = check_spec_oauth_credentials(cfg, now=_FROZEN_NOW)
+        # Assert
+        assert picked == good
+
+    def test_second_pool_entry_rescues_an_expired_first(
+        self, expired_lead_home: Path
+    ) -> None:
+        # Arrange
+        dead = _stale(expired_lead_home / "accounts" / "alpha" / ".credentials.json")
+        good = _fresh(expired_lead_home / "accounts" / "beta" / ".credentials.json")
+        cfg = _pool_config("dotfiles", [dead, good])
+        # Act
+        picked = check_spec_oauth_credentials(cfg, now=_FROZEN_NOW)
+        # Assert
+        assert picked == good
+
+    def test_singular_credentials_file_is_honoured(
+        self, expired_lead_home: Path
+    ) -> None:
+        # Arrange
+        good = _fresh(expired_lead_home / "accounts" / "alpha" / ".credentials.json")
+        cfg = AgentConfig(name="dotfiles")
+        cfg.claude.credentials_file = str(good)
+        # Act
+        picked = check_spec_oauth_credentials(cfg, now=_FROZEN_NOW)
+        # Assert
+        assert picked == good
+
+    def test_account_snapshot_is_honoured(self, tmp_path: Path, clean_env) -> None:
+        # Arrange
+        store = tmp_path / ".scitex" / "agent-container" / "accounts"
+        good = _fresh(store / "ywata1989-gmail-com" / ".credentials.json")
+        cfg = AgentConfig(name="dotfiles")
+        cfg.claude.account = "ywata1989-gmail-com"
+        # Act
+        picked = check_spec_oauth_credentials(cfg, now=_FROZEN_NOW, home=tmp_path)
+        # Assert
+        assert picked == good
+
+
+# ---------------------------------------------------------------------------
+# Still an ERROR, never a warning — but about the RIGHT files.
+# ---------------------------------------------------------------------------
+
+
+class TestEveryCandidateFails:
+    def test_all_pool_entries_expired_refuses(self, expired_lead_home: Path) -> None:
+        # Arrange
+        dead_a = _stale(expired_lead_home / "accounts" / "alpha" / ".credentials.json")
+        dead_b = _stale(expired_lead_home / "accounts" / "beta" / ".credentials.json")
+        cfg = _pool_config("dotfiles", [dead_a, dead_b])
+        # Act
+        action = lambda: check_spec_oauth_credentials(cfg, now=_FROZEN_NOW)
+        # Assert
+        with pytest.raises(RuntimeError, match="every credential its spec declares"):
+            action()
+
+    def test_refusal_names_every_candidate_not_just_the_first(
+        self, expired_lead_home: Path
+    ) -> None:
+        # Arrange
+        dead = _stale(expired_lead_home / "accounts" / "alpha" / ".credentials.json")
+        missing = expired_lead_home / "accounts" / "beta" / ".credentials.json"
+        cfg = _pool_config("dotfiles", [dead, missing])
+        # Act
+        try:
+            check_spec_oauth_credentials(cfg, now=_FROZEN_NOW)
+            message = ""
+        except RuntimeError as exc:
+            message = str(exc)
+        # Assert
+        assert str(dead) in message and str(missing) in message
+
+    def test_refusal_states_why_each_candidate_failed(
+        self, expired_lead_home: Path
+    ) -> None:
+        # Arrange
+        dead = _stale(expired_lead_home / "accounts" / "alpha" / ".credentials.json")
+        missing = expired_lead_home / "accounts" / "beta" / ".credentials.json"
+        cfg = _pool_config("dotfiles", [dead, missing])
+        # Act
+        try:
+            check_spec_oauth_credentials(cfg, now=_FROZEN_NOW)
+            message = ""
+        except RuntimeError as exc:
+            message = str(exc)
+        # Assert
+        assert "expired" in message and "not found" in message
+
+    def test_undeclared_spec_still_refuses_on_an_expired_lead_file(
+        self, expired_lead_home: Path
+    ) -> None:
+        # Arrange
+        cfg = AgentConfig(name="unpinned")
+        # Act
+        action = lambda: check_spec_oauth_credentials(cfg, now=_FROZEN_NOW)
+        # Assert
+        with pytest.raises(RuntimeError, match=r"expired \d+ seconds ago"):
+            action()
+
+
+# ---------------------------------------------------------------------------
+# API-key bypass — unchanged, and it must win over every candidate.
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeyBypass:
+    def test_api_key_env_skips_the_spec_check(self, expired_lead_home: Path) -> None:
+        # Arrange
+        dead = _stale(expired_lead_home / "accounts" / "alpha" / ".credentials.json")
+        cfg = _pool_config("dotfiles", [dead])
+        os.environ["ANTHROPIC_API_KEY"] = "sk-ant-fake"
+        # Act
+        picked = check_spec_oauth_credentials(cfg, now=_FROZEN_NOW)
+        # Assert
+        assert picked is None
+
+    def test_sac_api_key_env_skips_the_spec_check(
+        self, expired_lead_home: Path
+    ) -> None:
+        # Arrange
+        cfg = AgentConfig(name="unpinned")
+        os.environ["SAC_ANTHROPIC_API_KEY"] = "sk-ant-fake"
+        # Act
+        picked = check_spec_oauth_credentials(cfg, now=_FROZEN_NOW)
+        # Assert
+        assert picked is None
+
+
+# ---------------------------------------------------------------------------
+# Candidate resolution mirrors the runtime's own precedence.
+# ---------------------------------------------------------------------------
+
+
+class TestCandidateResolution:
+    def test_plural_pool_outranks_the_singular_field(self, tmp_path: Path) -> None:
+        # Arrange
+        cfg = AgentConfig(name="dotfiles")
+        cfg.claude.credentials_files = [str(tmp_path / "pool.json")]
+        cfg.claude.credentials_file = str(tmp_path / "single.json")
+        # Act
+        candidates, _declared = spec_credential_candidates(cfg.claude, home=tmp_path)
+        # Assert
+        assert [p for _o, p in candidates] == [tmp_path / "pool.json"]
+
+    def test_pool_outranks_a_named_account_pin(self, tmp_path: Path) -> None:
+        # Arrange
+        cfg = AgentConfig(name="dotfiles")
+        cfg.claude.credentials_files = [str(tmp_path / "pool.json")]
+        cfg.claude.account = "alpha"
+        # Act
+        candidates, _declared = spec_credential_candidates(cfg.claude, home=tmp_path)
+        # Assert
+        assert [p for _o, p in candidates] == [tmp_path / "pool.json"]
+
+    def test_pool_order_is_the_declared_order(self, tmp_path: Path) -> None:
+        # Arrange
+        cfg = AgentConfig(name="dotfiles")
+        cfg.claude.credentials_files = [
+            str(tmp_path / "b.json"),
+            str(tmp_path / "a.json"),
+        ]
+        # Act
+        candidates, _declared = spec_credential_candidates(cfg.claude, home=tmp_path)
+        # Assert
+        assert [p.name for _o, p in candidates] == ["b.json", "a.json"]
+
+    def test_each_candidate_carries_its_spec_field_origin(self, tmp_path: Path) -> None:
+        # Arrange
+        cfg = AgentConfig(name="dotfiles")
+        cfg.claude.credentials_files = [
+            str(tmp_path / "a.json"),
+            str(tmp_path / "b.json"),
+        ]
+        # Act
+        candidates, _declared = spec_credential_candidates(cfg.claude, home=tmp_path)
+        # Assert
+        assert [o for o, _p in candidates] == [
+            "spec.claude.credentials_files[0]",
+            "spec.claude.credentials_files[1]",
+        ]
+
+    def test_an_undeclared_spec_reports_declared_false(self, tmp_path: Path) -> None:
+        # Arrange
+        cfg = AgentConfig(name="unpinned")
+        # Act
+        _candidates, declared = spec_credential_candidates(cfg.claude, home=tmp_path)
+        # Assert
+        assert declared is False
+
+    def test_an_undeclared_spec_falls_back_to_the_lead_file(
+        self, tmp_path: Path
+    ) -> None:
+        # Arrange
+        cfg = AgentConfig(name="unpinned")
+        # Act
+        candidates, _declared = spec_credential_candidates(cfg.claude, home=tmp_path)
+        # Assert
+        assert [p for _o, p in candidates] == [
+            tmp_path / ".claude" / ".credentials.json"
+        ]

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_preflight_gate.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_preflight_gate.py
@@ -1,0 +1,203 @@
+"""CLI-seam tests for the ``sac agents start`` credential preflight gate.
+
+These drive the REAL click entry point (``cli_pkg.lifecycle._start.start``)
+rather than the resolver alone, because the seam is where the last defect
+of this class hid: PR #949 shipped a click default the resolver read as
+"be lenient", silently disabling a gate on every CLI start, and every
+unit test passed because none crossed click → gate → resolver.
+
+The gate itself is unit-tested in
+``tests/scitex_agent_container/_state/test__preflight_creds_spec.py``.
+What is proved HERE is only that the CLI reaches it, with the target's
+own spec, and honours its verdict in both directions.
+
+Style: one assert per test, AAA markers, no monkeypatch fixture params.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.lifecycle._start import start
+from tests.scitex_agent_container._helpers.explicit_spec import explicit_doc
+
+_ONE_HOUR_S = 3600
+
+
+def _write_creds(path: Path, expires_at_ms: int) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat-fake",
+                    "refreshToken": "sk-ant-ort-fake",
+                    "expiresAt": expires_at_ms,
+                    "scopes": ["user:inference"],
+                    "subscriptionType": "max",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _fresh(path: Path) -> Path:
+    import time
+
+    return _write_creds(path, int((time.time() + _ONE_HOUR_S) * 1000))
+
+
+def _stale(path: Path) -> Path:
+    import time
+
+    return _write_creds(path, int((time.time() - _ONE_HOUR_S) * 1000))
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path) -> Iterator[Path]:
+    """Pin ``$HOME`` to a tmp dir and strip the API-key opt-out env vars."""
+    # Arrange
+    saved = {
+        "HOME": os.environ.get("HOME"),
+        "ANTHROPIC_API_KEY": os.environ.pop("ANTHROPIC_API_KEY", None),
+        "SAC_ANTHROPIC_API_KEY": os.environ.pop("SAC_ANTHROPIC_API_KEY", None),
+    }
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _write_spec(home: Path, name: str, pool: list[Path]) -> Path:
+    """Materialise a loadable v3 spec declaring ``pool`` as its account pool.
+
+    ``host`` names a peer that is deliberately NOT registered, so the run
+    stops at the cross-host dispatch guard immediately after the preflight
+    — the gate's verdict is observed without launching anything.
+    """
+    doc = explicit_doc(
+        {
+            "host": "sac-test-unregistered-peer",
+            "workdir": str(home),
+            "claude": {"credentials_files": [str(p) for p in pool]},
+        }
+    )
+    spec_dir = home / "agents" / name
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    spec_path = spec_dir / f"{name}.yaml"
+    spec_path.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
+    return spec_path
+
+
+class TestStartHonoursTheSpecsOwnCredentials:
+    def test_start_is_not_refused_when_a_declared_pool_entry_is_fresh(
+        self, isolated_home: Path
+    ) -> None:
+        # Arrange — the 2026-08-10 outage shape: lead token dead, pool fresh.
+        _stale(isolated_home / ".claude" / ".credentials.json")
+        good = _fresh(isolated_home / "accounts" / "alpha" / ".credentials.json")
+        spec = _write_spec(isolated_home, "poolagent", [good])
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(start, [str(spec), "-y"])
+        # Assert — the lead file is never even named; it is not this agent's.
+        assert ".claude/.credentials.json expired" not in result.output
+
+    def test_start_is_refused_when_every_declared_entry_is_expired(
+        self, isolated_home: Path
+    ) -> None:
+        # Arrange — inverse control: lead token FRESH (the old gate would
+        # have waved this through), every declared credential dead.
+        _fresh(isolated_home / ".claude" / ".credentials.json")
+        dead_a = _stale(isolated_home / "accounts" / "alpha" / ".credentials.json")
+        dead_b = _stale(isolated_home / "accounts" / "beta" / ".credentials.json")
+        spec = _write_spec(isolated_home, "deadpool", [dead_a, dead_b])
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(start, [str(spec), "-y"])
+        # Assert
+        assert "every credential its spec declares is unusable" in result.output
+
+    def test_refusal_exits_nonzero(self, isolated_home: Path) -> None:
+        # Arrange — the gate is an ERROR, never a warning: a refusal must
+        # cost the caller a non-zero exit, not just a line of output.
+        _fresh(isolated_home / ".claude" / ".credentials.json")
+        dead = _stale(isolated_home / "accounts" / "alpha" / ".credentials.json")
+        spec = _write_spec(isolated_home, "deadpool", [dead])
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(start, [str(spec), "-y"])
+        # Assert
+        assert result.exit_code == 1
+
+    def test_refusal_happens_before_any_dispatch_attempt(
+        self, isolated_home: Path
+    ) -> None:
+        # Arrange — the spec pins an unregistered peer, so reaching the
+        # dispatch stage is loudly visible. The gate must fire first.
+        _fresh(isolated_home / ".claude" / ".credentials.json")
+        dead = _stale(isolated_home / "accounts" / "alpha" / ".credentials.json")
+        spec = _write_spec(isolated_home, "deadpool", [dead])
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(start, [str(spec), "-y"])
+        # Assert
+        assert "registered peer" not in result.output
+
+    def test_refusal_names_every_declared_candidate(self, isolated_home: Path) -> None:
+        # Arrange
+        _fresh(isolated_home / ".claude" / ".credentials.json")
+        dead_a = _stale(isolated_home / "accounts" / "alpha" / ".credentials.json")
+        dead_b = _stale(isolated_home / "accounts" / "beta" / ".credentials.json")
+        spec = _write_spec(isolated_home, "deadpool", [dead_a, dead_b])
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(start, [str(spec), "-y"])
+        # Assert
+        assert str(dead_a) in result.output and str(dead_b) in result.output
+
+    def test_api_key_env_skips_the_gate_at_the_cli_seam(
+        self, isolated_home: Path
+    ) -> None:
+        # Arrange — every credential dead, but the operator opted into the
+        # API-key auth path, so the OAuth gate must not fire at all.
+        _stale(isolated_home / ".claude" / ".credentials.json")
+        dead = _stale(isolated_home / "accounts" / "alpha" / ".credentials.json")
+        spec = _write_spec(isolated_home, "keyagent", [dead])
+        os.environ["ANTHROPIC_API_KEY"] = "sk-ant-fake"
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(start, [str(spec), "-y"])
+        # Assert
+        assert "every credential its spec declares is unusable" not in result.output
+
+
+class TestUndeclaredSpecKeepsTheLeadFileGate:
+    def test_unloadable_spec_still_gates_on_the_expired_lead_file(
+        self, isolated_home: Path
+    ) -> None:
+        # Arrange — a spec that will not parse keeps the defensive default:
+        # gate on the lead file rather than skip the check.
+        _stale(isolated_home / ".claude" / ".credentials.json")
+        agents_dir = isolated_home / "agents"
+        (agents_dir / "broken").mkdir(parents=True)
+        (agents_dir / "broken" / "broken.yaml").write_text("{{{ not yaml")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(start, [str(agents_dir), "-y"])
+        # Assert
+        assert "expired" in result.output


### PR DESCRIPTION
## The outage

`sac agents start <any agent>` failed on ywata-note-win, by every route — direct host CLI and the host listen `/agents` spawn endpoint (HTTP 502):

```
Error: OAuth token in /home/ywatanabe/.claude/.credentials.json expired 59803 seconds ago.
       Run `claude login` to refresh.
```

Twelve agents were running at that moment. **None of them use that file.** Their specs declare a pool under `claude:`:

```yaml
credentials_files:
  - /home/ywatanabe/.scitex/agent-container/accounts/wyusuuke-gmail-com/.credentials.json
  - /home/ywatanabe/.scitex/agent-container/accounts/ywata1989-gmail-com/.credentials.json
```

Expiry measured during the outage:

| file | state |
|---|---|
| `~/.claude/.credentials.json` | **EXPIRED 16.6h ago** |
| `accounts/wyusuuke-gmail-com` | valid, +1.7h |
| `accounts/ywata1989-gmail-com` | valid, +5.3h |
| `accounts/ywatanabe-scitex-ai` | valid, +7.7h |

So the gate was a **false negative** — it refused starts that would have succeeded.

## Cause

`cli_pkg/lifecycle/_start_preflight_gate.make_preflight_runner` called `check_oauth_token_expiry()` with no argument. That resolves `Path.home()/".claude"/".credentials.json"` unconditionally (`_state/_preflight_creds.py:109`), and nothing in the dispatch path ever passed a path — so the gate could only ever judge the lead file, an artefact most of the fleet never binds.

## The fix

The gate now resolves each target's **own** candidates and passes when **any** of them is usable. The order is not a new precedence rule — it mirrors `_lifecycle/_start_preflight._rotate_to_healthy_account`, the function that actually decides what gets bound at launch:

1. `claude.credentials_files` (the pool), in declared order
2. else `claude.credentials_file` (its 1-element form)
3. else `claude.account` → `<account-store>/<account>/.credentials.json` (same `_store_path` cascade `resolve_cred_file` uses)
4. else `~/.claude/.credentials.json`

Only case 4 — a spec declaring nothing — keeps today's exact message and exception type. A spec that will not load also falls to case 4, preserving the old defensive default. The `ANTHROPIC_API_KEY` / `SAC_ANTHROPIC_API_KEY` skip is untouched.

**Still an error, never a warning.** When every declared candidate fails, the start is refused with exit 1 and the message names each candidate, its path, and its own reason:

```
Error: agent 'dotfiles': every credential its spec declares is unusable (2 candidate(s) checked, none passed):
  - spec.claude.credentials_files[0] (/…/alpha/.credentials.json): OAuth token in … expired 3600 seconds ago. …
  - spec.claude.credentials_files[1] (/…/beta/.credentials.json): OAuth credentials file not found at … 
Fix: `claude /login` to one of those accounts then `sac accounts sync-live` on this host, or export …
```

Checking is now **per target** rather than one global check; a bulk start of provider-backed specs still skips entirely.

## Docstring claim: checked, and it was wrong for most of the fleet

The module asserted `~/.claude/.credentials.json` "is the authoritative auth artefact", bind-mounted at `/tmp/sac-claude/.credentials.json`. Traced through `runtimes/`:

- With a designated `credentials_file` — which the pool **collapses to** at launch (`_rotate_among_credentials_files` writes `config.claude.credentials_file`, `_lifecycle/_start.py:180`, before `runtime.start` at 454) — `_apptainer_auth.auth_argv` **returns early** (`_apptainer_auth.py:96-102`): no `/tmp/sac-claude` bind, no `CLAUDE_CONFIG_DIR`. `_apptainer_auth_bind.credentials_file_bind` mounts the picked file at `<container_home>/.claude/.credentials.json` instead.
- With `claude.account`, `resolve_cred_file` returns the account snapshot and its **parent dir** is what gets bound at `/tmp/sac-claude`.
- Only a fully-unpinned spec (no pool, no file, no account, no provider) dir-binds `~/.claude/` at `/tmp/sac-claude` with `CLAUDE_CONFIG_DIR` pointed at it.

**That last branch is live**, so the bind is kept — the docstring now says which agents the lead file is authoritative *for*, instead of implying it is the only artefact.

## Tests

New: `tests/scitex_agent_container/_state/test__preflight_creds_spec.py` (16) and `tests/scitex_agent_container/cli_pkg/lifecycle/test__start_preflight_gate.py` (7).

The CLI file drives the **real click entry point**, not only the resolver. PR #949 shipped a defect at exactly that seam — a click default the resolver read as "be lenient", silently disabling a gate on every CLI start, with every unit test green.

Verified against the pre-fix code with the tests stashed in place:

- ✗ → ✓ `test_start_is_not_refused_when_a_declared_pool_entry_is_fresh` (the outage's own shape)
- ✗ → ✓ `test_start_is_refused_when_every_declared_entry_is_expired`
- ✗ → ✓ `test_refusal_names_every_declared_candidate`
- ✗ → ✓ `test_refusal_happens_before_any_dispatch_attempt`
- ✓ → ✓ `test_api_key_env_skips_the_gate_at_the_cli_seam` (invariant)
- ✓ → ✓ `test_unloadable_spec_still_gates_on_the_expired_lead_file` (invariant)
- ✓ → ✓ `test_refusal_exits_nonzero` (invariant: error, not warning)

No credential file was read for content, modified, moved, or copied by this change; no `claude login` was run.

## Adjacent finding, NOT fixed here

`cli_pkg/_send_preflight.preflight_send_creds` has the same defect on a different surface: it checks `~/.claude/.credentials.json` unconditionally (`_send_preflight.py:155`) and `_send.py:291` calls it on every `send_to_agent`. With the lead token expired, **every `sac agents send` on this host returns `status="creds-expired"`** even though the target agent is authenticated on a fresh pool credential. Left out of this PR to keep the outage fix reviewable — its contract differs (returns a status payload, and also ssh-probes peers). Carded as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9aNXY7Tx3jP7vRBSpRJYw
