### PR TITLE
test(runners): retrieve the parked turn-failure future before it hits GC

### DIFF
--- a/tests/scitex_agent_container/_runners/test__session_conversation_auth.py
+++ b/tests/scitex_agent_container/_runners/test__session_conversation_auth.py
@@ -101,7 +101,8 @@ def _run_until_done(sdk_mod, writer, *, build_options_fn, max_restarts=0):
     async def _go():
         inbox = make_inbox()
         loop = asyncio.get_running_loop()
-        await inbox.put(TurnEnvelope(text="go", response=loop.create_future()))
+        response = loop.create_future()
+        await inbox.put(TurnEnvelope(text="go", response=response))
         await runner._run_conversation(
             "agent-x",
             Path("/tmp"),  # state_dir not asserted on; writes go via db_writer
@@ -115,6 +116,12 @@ def _run_until_done(sdk_mod, writer, *, build_options_fn, max_restarts=0):
             db_writer=writer,
             max_restarts=max_restarts,
         )
+        # The supervisor parks the injected turn failure on this future.
+        # Retrieve it here; otherwise asyncio logs "Future exception was
+        # never retrieved" at GC time — into whatever unrelated test is
+        # running on the worker by then (broke CI's db-export JSON parse).
+        if response.done() and not response.cancelled():
+            response.exception()
 
     asyncio.run(_go())
 


### PR DESCRIPTION
## Problem

Develop CI run 31368146901 failed on `test_db_export_tables_flag_emits_only_named_table` with `JSONDecodeError` — but that test is the victim, not the bug.

The auth-failure supervisor tests (`test__session_conversation_auth.py`) seed the inbox with a `TurnEnvelope` whose `response` future receives the injected 401 via `set_exception()` (`_session_turn.py:246`), and nothing ever awaits it. When the future is garbage-collected, asyncio logs `Future exception was never retrieved` — at an arbitrary later point, into whatever test the same xdist worker is running by then. On gw20 it landed inside the db-export test's CliRunner capture and broke its JSON parse.

## Fix

`_run_until_done` now holds the future and retrieves its exception after `_run_conversation` returns, so GC never has anything to complain about.

## Verification

- Pre-fix: the auth test file emits the GC message **2×** (`pytest -s | grep -c`)
- Post-fix: **0** occurrences; auth + db-export files together: 27/27 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)