### PR TITLE
fix(start): report the account that was actually chosen, and why

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_start_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_start_preflight.py
@@ -167,6 +167,8 @@ def _rotate_among_credentials_files(
     :class:`_creds.NoHealthyAccountError` propagates (agent NOT started).
     Back-compat: a 1-element pool whose one snapshot is healthy resolves
     to that exact file (no-op — ``credentials_file`` unchanged, no log).
+    A pool of TWO OR MORE always narrates the pick, INCLUDING when the
+    winner is the entry already bound — see the guard below.
     """
     from .._creds import POLICY_BURN, pick_healthy_account, resolve_7d_policy
     from ._quota_evidence import pick_with_quota_evidence
@@ -241,8 +243,18 @@ def _rotate_among_credentials_files(
     picked_path = next(p for slug, p in entries if slug == picked)
     claude.credentials_file = str(picked_path)
 
-    if str(picked_path) == prior:
-        return  # 1-element / already-selected pool — no change, no log.
+    # SILENT ONLY WHEN NOTHING WAS CHOSEN. This guard used to read
+    # ``str(picked_path) == prior`` — "the binding did not move, so say
+    # nothing" — which is backwards for a POOL: re-confirming one account
+    # over two REJECTED siblings is the decision the operator most needs to
+    # see, and it is the COMMON case, because churn-minimisation prefers the
+    # currently-bound entry whenever it is still healthy. Measured 2026-08-11
+    # on the live ``scitex-agent-container`` spec (a 3-entry pool): the picker
+    # re-confirmed the bound account every boot, so start/restart narrated the
+    # account NEVER — the pick was correct and 100% invisible. A 1-element
+    # pool genuinely made no choice; that one stays quiet.
+    if len(entries) <= 1 and str(picked_path) == prior:
+        return  # 1-element pool kept its only entry — no choice, no log.
 
     from .._creds import (
         account_5h_usage,
@@ -299,7 +311,15 @@ def _rotate_among_credentials_files(
     from ..cli_pkg._helpers._console import system_msg
 
     system_msg(headline, style="info")
-    system_msg(detail, style="dim")
+    # INFO, not "dim". ``"dim"`` maps to ``scitex_logging.DEBUG``
+    # (``cli_pkg._helpers._console._STYLE_TO_LEVEL``), which is BELOW the
+    # project logger's effective level (measured: 20 / INFO), so everything
+    # carrying the REASON — the active policy, the rationale sentence and the
+    # per-candidate ranking inputs — was dropped at the logger while the
+    # headline alone survived. That is precisely the "reasoned pick is
+    # indistinguishable from a lucky one" defect ``_creds._pick_audit`` was
+    # written to close, so it must not be emitted below the level anyone reads.
+    system_msg(detail, style="info")
 
 
 def _rotate_to_healthy_account(

--- a/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
@@ -407,6 +407,76 @@ def test_pool_keeps_currently_effective_entry_when_it_is_healthy(
     assert cfg.claude.credentials_file == str(p_a)
 
 
+# ---------------------------------------------------------------------------
+# The pick must be VISIBLE — operator 2026-08-11: `sac agents start` /
+# `sac agents restart` printed nothing about the account, so a correct,
+# well-reasoned pick was indistinguishable from no pick at all.
+# ---------------------------------------------------------------------------
+
+
+def test_pool_narrates_the_pick_even_when_it_keeps_the_bound_entry(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — the live fleet shape: a 3-entry pool whose currently bound
+    # entry is still the healthiest, so churn-minimisation re-confirms it and
+    # the binding does not move. That was the SILENT case, and it is the
+    # case that happens on nearly every boot.
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _future_ms())
+    p_b = _write_snapshot(home, "acct-b", _future_ms())
+    p_c = _write_snapshot(home, "acct-c", _future_ms())
+    cfg = _make_pool_config("alpha", [p_a, p_b, p_c])
+    cfg.claude.credentials_file = str(p_a)
+    log = io.StringIO()
+    # Act — both siblings are 7d near-capped, so acct-a is re-confirmed.
+    _rotate_to_healthy_account(
+        cfg,
+        log_stream=log,
+        usage_5h={"acct-a": 20.0, "acct-b": 4.0, "acct-c": 0.0},
+        usage_7d={"acct-a": 25.0, "acct-b": 99.0, "acct-c": 100.0},
+    )
+    # Assert — re-confirming one account over two rejected siblings IS a
+    # decision, and an unnarrated decision cannot be told from none.
+    assert "acct-a" in _without_quota_warning(log.getvalue())
+
+
+@pytest.fixture
+def _logger_at_info() -> Iterator[None]:
+    """Pin the project logger to INFO — the level an operator's console runs at.
+
+    Measured inside a live sac container: ``getEffectiveLevel() == 20`` and
+    ``isEnabledFor(DEBUG) is False``. Pinning it makes the DEBUG-vs-INFO
+    discrimination a property of THIS test rather than of whatever configured
+    logging first in the session.
+    """
+    from scitex_agent_container.cli_pkg._helpers._console import logger
+
+    saved = logger.level
+    logger.setLevel(20)
+    try:
+        yield
+    finally:
+        logger.setLevel(saved)
+
+
+def test_pool_notice_reason_is_emitted_at_info_not_debug(
+    _isolate_home: Path,
+    _logger_at_info: None,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    # Arrange — the WHY (policy, rationale, per-candidate ranking inputs) went
+    # out under style="dim", which maps to DEBUG, so the logger dropped it and
+    # only the headline ever reached the operator.
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _future_ms())
+    p_b = _write_snapshot(home, "acct-b", _future_ms())
+    cfg = _make_pool_config("alpha", [p_a, p_b])
+    # Act — no log_stream, so the notice takes the real system_msg path.
+    _rotate_to_healthy_account(cfg, usage_7d={"acct-a": 95.0, "acct-b": 5.0})
+    # Assert — the ranking inputs survive an INFO-level console.
+    assert "ranking inputs:" in capfd.readouterr().err
+
+
 def test_pool_first_listed_entry_is_not_implicitly_preferred(
     _isolate_home: Path,
 ) -> None:


### PR DESCRIPTION
The operator asked, watching a restart scroll past: 「何でどのアカウントが選ばれたのか出てこないの？」

He was right to ask, and right to suspect something. Tonight the fleet stalled because
agents were hard-pinned to exhausted accounts; the pins were removed and every spec now
carries a 3-account pool, so the quota-aware picker is live again. But its output was
invisible, so there was no way to tell a correct pick from a broken one — and he
reasonably concluded the LOGIC was broken when it was not.

## THE PICKER WAS ALWAYS CORRECT. THE WHOLE DEFECT WAS OUTPUT.

Two independent silences, either of which alone would have hidden the pick:

1. `_start_preflight.py:244` returned before ANY notice was assembled whenever the
   picked file equalled the already-bound one. For a pool that is the COMMON case,
   because `preferred` (churn minimisation, :209) keeps the currently-bound entry
   whenever it is still healthy. So a 3-entry fleet pool re-confirmed its account
   every boot and narrated it never.

2. Even on a genuine rotation, only the INFO headline survived. The reason block — the
   file, `policy=<p> — <rationale>`, and the per-candidate ranking inputs from
   `_creds/_pick_audit.pick_audit_parts` — went out as `system_msg(detail,
   style="dim")` at :302, and `"dim"` maps to `scitex_logging.DEBUG`
   (`_helpers/_console.py:49`), below the project logger's measured effective level of
   20/INFO. The WHY was computed in full and dropped at the logger.

## THE CHANGE — two lines, both reusing the notice that was already built

    :256   if str(picked_path) == prior:
        -> if len(entries) <= 1 and str(picked_path) == prior:

    :322   system_msg(detail, style="dim")  ->  style="info"

A pool of two or more always narrates its pick, including when the winner is the entry
already bound. A 1-element pool (no choice made) stays quiet, so the existing
`test_singular_credentials_file_emits_no_notice` contract is untouched.

No new module, no new formatting code. The credentials-file PATH stays inside `detail`;
the headline carries slugs and percentages only, which `_creds/_pick_audit` guarantees
is log-safe. No token value or fingerprint is printed.

## WHAT THE OPERATOR NOW SEES

    INFO: alpha: account acct-b (5h=? 7d=5%)
    INFO:   file:          .../accounts/acct-b/.credentials.json
    INFO|   policy=spread — token-fresh gate, avoids 5h-blocked and 7d-near-capped
            accounts, load-balanced per agent by 7d headroom; time-to-reset counts
            only within the 2h expiring horizon
    INFO|   ranking inputs:
    INFO|       acct-a(5h=? 7d=95% 7d_reset=? 7d-near-cap)
    INFO|       acct-b(5h=? 7d=5% 7d_reset=?)

## TESTS — fail before, pass after, with the failure text being the defect

BEFORE (source reverted to develop, new tests present):

    collected 17 items ... FF.
    test__start_creds_files_pool.py:440: AssertionError: assert 'acct-a' in ''
    test__start_creds_files_pool.py:477: assert 'ranking inputs:' in
      "...INFO: alpha: account acct-b (5h=? 7d=5%)\n"
    2 failed, 15 passed in 126.34s

`assert 'acct-a' in ''` is silence #1 — the notice was never built. The second shows
the INFO stream carrying the headline and nothing else — silence #2.

AFTER: 17 passed in 78.63s.

No regression across every neighbouring creds/restart suite:

    test__start_creds_files_pool.py test__start_creds_rotate.py
    test__start_creds_no_cache_builds_quota_evidence.py
    test__start_creds_gate_cache_presence.py
    test__restart_preflight.py test__restart_preflight_no_rotate_fresh.py
    58 passed in 111.69s

`caplog` is deliberately NOT used: `scitex_logging.SciTeXLogger` does not surface these
records to pytest's capture handler, so a caplog-based test would have gone green for
the wrong reason. The test pins the project logger to INFO and asserts on captured
stderr through the real `system_msg` path.

## DELIBERATELY NOT CHANGED

`_lifecycle/_restart_preflight.py:360` still captures this notice into a discarded
`io.StringIO()` for its pre-stop dry probe. The real in-process `agent_start`
(`_stop.py` -> `_start.py:180`, `log_stream=None`) narrates the launch that actually
happens; un-suppressing the probe would print the account twice per restart.

`_start_preflight.py` is 468 lines, under its 512 limit.
