### PR TITLE
fix(listen-probe): stop asserting a route-specific fault the probes cannot observe

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_listen_probe.py
+++ b/src/scitex_agent_container/_lifecycle/_listen_probe.py
@@ -298,8 +298,11 @@ def transport_failure_message(
     Otherwise the daemon is UP, and what we can say next depends on whether
     a SECOND, AUTHENTICATED route was measured (``authed_probe``):
 
-      * it answered → the daemon is serving authenticated work, so the fault
-        is specific to THIS route. A restart is not indicated, and we say so.
+      * it answered → the daemon is serving authenticated work. That rules
+        OUT a daemon-wide fault. It does NOT establish a route-specific one:
+        a route still WORKING on an operation longer than the timeout is
+        indistinguishable, from outside, from a wedged one. So say what was
+        ruled out, and send the reader to the agent's own state.
       * it also hung → the fault is shared. A restart is worth its cost.
       * it was rejected (401/403) or not attempted → we measured nothing
         about authenticated work and must not pretend otherwise.
@@ -323,11 +326,13 @@ def transport_failure_message(
                 f"route was measured (no bearer token available).\n"
                 f"NEXT, to find out rather than guess: call an authenticated "
                 f"route (e.g. GET {AUTHED_PATH}) and compare. If it answers, "
-                f"the fault is specific to {route} and restarting the daemon "
-                f"will not fix it. If it also hangs, the fault is shared and "
-                f"a restart is worth trying — `sac listen restart` on the "
-                f"host, which interrupts EVERY agent mid-operation, so "
-                f"establish that it is shared first."
+                f"a daemon-wide fault is ruled out and restarting the daemon "
+                f"will not help — note that this still does NOT establish "
+                f"that {route} is faulty, since a route merely slower than "
+                f"{timeout_s:.0f}s looks identical from outside. If it also "
+                f"hangs, the fault is shared and a restart is worth trying — "
+                f"`sac listen restart` on the host, which interrupts EVERY "
+                f"agent mid-operation, so establish that it is shared first."
             )
         if not authed_probe.serving:
             return head + (
@@ -354,12 +359,28 @@ def transport_failure_message(
             f"ALSO OBSERVED: {authed_probe.evidence()}. So the daemon is "
             f"serving AUTHENTICATED work fine on a different prefix, in the "
             f"same seconds that {route} did not answer.\n"
-            f"THEREFORE the fault is specific to {route}, not daemon-wide. "
+            f"RULED OUT: a daemon-wide fault.\n"
+            f"NOT ESTABLISHED: whether {route} is FAULTY or merely SLOWER "
+            f"than {timeout_s:.0f}s. Two fast control routes prove the daemon "
+            f"is up; they CANNOT tell a wedged route from one still working, "
+            f"because from outside those look identical. Measured 2026-08-11: "
+            f"a spawn reported here as 'no response' had in fact been "
+            f"ACCEPTED and ran for 5m12s — the server was fine and this "
+            f"client stopped listening.\n"
+            f"NEXT, to find out rather than guess: read the AGENT's own "
+            f"state, not this HTTP result. `sac agents list {name}` reports "
+            f"running / startup_failed with started_at and failed_at, which "
+            f"distinguishes 'never began', 'still in flight' and 'failed on "
+            f"its own merits'. This timeout distinguishes none of them.\n"
             f"Do NOT run `sac listen restart` for this — it interrupts every "
-            f"agent on the box and would not address a per-route fault. "
-            f"Retry, and if it recurs report {route} with these two timings; "
-            f"the route has been seen to answer and then degrade, so a single "
-            f"success afterwards does not mean it was fixed."
+            f"agent on the box, and the one thing actually established here "
+            f"is that whatever is wrong is not daemon-wide, which is the only "
+            f"condition that remedy addresses.\n"
+            f"Finally: if you retry and it succeeds, that does not mean it "
+            f"was fixed. The same route has been seen to answer and then not "
+            f"answer, which is equally consistent with a genuine fault AND "
+            f"with an operation whose duration varies either side of "
+            f"{timeout_s:.0f}s. One success discriminates neither."
         )
     return (
         f"{verb} of {name!r} failed: cannot reach listen at {base!r} ({exc}).\n"

--- a/tests/scitex_agent_container/_lifecycle/test__listen_probe.py
+++ b/tests/scitex_agent_container/_lifecycle/test__listen_probe.py
@@ -366,7 +366,7 @@ def _message2(probe: HealthProbe, authed: HealthProbe | None) -> str:
     )
 
 
-def test_message_calls_the_fault_route_specific_when_authed_answers() -> None:
+def test_message_rules_out_daemon_wide_when_authed_answers() -> None:
     # Arrange — authenticated work IS being served, in the same seconds.
     #
     # This asserted on "the fault is specific to" and my own mutation control
@@ -374,6 +374,14 @@ def test_message_calls_the_fault_route_specific_when_authed_answers() -> None:
     # test passed with the authed probe ignored entirely. It could not have
     # disagreed. "not daemon-wide" is the claim only this arm is entitled to
     # make, because only this arm measured a daemon serving authed work.
+    #
+    # 2026-08-11 — that last sentence was RIGHT and the message did not obey
+    # it. The message went on to assert "THEREFORE the fault is specific to
+    # <route>", which this arm is NOT entitled to: two fast control routes
+    # rule OUT a daemon-wide fault, but cannot separate a wedged route from
+    # one still working past the timeout. Measured that day: a spawn reported
+    # as "no response within 30s" had been accepted and ran for 5m12s. The
+    # test was more careful than the code; the code now matches the test.
     # Act
     message = _message2(_SERVING, _authed())
     # Assert
@@ -393,6 +401,60 @@ def test_message_refuses_a_restart_when_authed_answers() -> None:
 def test_message_warns_the_route_can_answer_then_degrade() -> None:
     # Arrange — measured intermittency: the same route succeeded earlier the
     # same night, so one later success is not proof of a fix.
+    # Act
+    message = _message2(_SERVING, _authed())
+    # Assert
+    assert "does not mean it was fixed" in message
+
+
+def test_message_refuses_to_call_the_route_faulty_when_authed_answers() -> None:
+    # Arrange — the regression this arm exists to prevent. Ruling OUT a
+    # daemon-wide fault is not ruling IN a route-specific one, and the old
+    # message made exactly that leap in capitals ("THEREFORE the fault is
+    # specific to <route>"). A reader acted on it within two minutes and
+    # filed a P1 against the wrong component.
+    # Act
+    message = _message2(_SERVING, _authed())
+    # Assert
+    assert "fault is specific to" not in message
+
+
+def test_message_says_the_cause_is_not_established_when_authed_answers() -> None:
+    # Arrange — the positive half of the arm above. Refusing the wrong claim
+    # is only useful if the message also states, in the reader's own terms,
+    # that the cause remains open.
+    # Act
+    message = _message2(_SERVING, _authed())
+    # Assert
+    assert "NOT ESTABLISHED" in message
+
+
+def test_message_names_agent_state_as_the_discriminator() -> None:
+    # Arrange — a timeout on the transport says nothing about whether the
+    # WORK happened. The only thing that does is the agent's own state, so
+    # the message must send the reader there rather than leaving them with
+    # an HTTP result they will over-read.
+    # Act
+    message = _message2(_SERVING, _authed())
+    # Assert
+    assert "sac agents list neurovista" in message
+
+
+def test_message_names_startup_failed_as_a_state_worth_reading() -> None:
+    # Arrange — naming the command is not enough; the reader must know what
+    # they are looking FOR. "startup_failed" is the state that distinguishes
+    # "the spawn ran and lost" from "the spawn never began".
+    # Act
+    message = _message2(_SERVING, _authed())
+    # Assert
+    assert "startup_failed" in message
+
+
+def test_message_does_not_read_a_later_success_as_a_fix() -> None:
+    # Arrange — measured intermittency has TWO readings: a genuine fault, or
+    # an operation whose duration straddles the timeout. One later success
+    # discriminates neither, and the message must say so rather than implying
+    # the route "degrades".
     # Act
     message = _message2(_SERVING, _authed())
     # Assert


### PR DESCRIPTION
## What

On a brokered POST timeout, `transport_failure_message` printed:

> **THEREFORE the fault is specific to `<route>`, not daemon-wide.**

That inference does not hold, and it cost real time this morning.

## Why it is wrong

Fast control routes separate **"daemon down"** from **"daemon up"**. They cannot separate
**"this route is wedged"** from **"this route is still working on an operation longer than
the timeout"** — from outside, those two are identical.

## Measured, 2026-08-11, ywata-note-win

```
POST /agents                -> no response in 30s (client gave up)
GET  /v1/health             -> 200 in 0.021s
GET  /v1/host_exec/inflight -> 200 in 0.026s   (authenticated)
```

The message concluded a route fault. The server had in fact **accepted the spawn and worked
on it for 5m12s** — `started_at 06:15:08Z`, `failed_at 06:20:20Z`, `phase
container_creation` — allocating an a2a port along the way. Nothing was wedged; the client
stopped listening.

From the other side, 8/8 unauthenticated probes get `POST /agents` refused in **9–168ms**,
so the route was healthy throughout.

## Cost

Not hypothetical. A reader (me) acted on that sentence within two minutes: filed a P1
against the wrong component, told one peer their maintainer could not be woken because the
spawn path was broken, and told the operator that fleet-wide restarts were impossible. All
three propagated from one over-claiming string, and the string is hardcoded — so it would
have misled every future reader identically.

## Change

This arm now states only what it measured — a daemon-wide fault is **RULED OUT**, the cause
is **NOT ESTABLISHED** — and names the real discriminator: the agent's own state
(`sac agents list <name>`, `running` / `startup_failed` with `started_at` and `failed_at`),
which separates "never began", "still in flight" and "failed on its own merits". The HTTP
timeout separates none of them.

Also corrected:

- the no-second-reading arm, which offered the same unsupported inference as *advice*
  ("If it answers, the fault is specific to `<route>`")
- the docstring, which stated it as the contract
- the answer-then-degrade warning, reframed: intermittency is equally consistent with a real
  fault **and** with a duration straddling the timeout, so one later success discriminates
  neither

## Note on the existing test

The test's own comment already argued that `"not daemon-wide"` was *"the claim only this arm
is entitled to make"*. The test was more careful than the code. The code now matches the
test, and the test is renamed to say what it actually pins.

## Tests

`39 passed`. Four added, including `test_message_refuses_to_call_the_route_faulty_when_authed_answers`,
which fails against the old message.

## Not in this PR

The 30s spawn-client timeout against a 5-minute container creation is a second, separate
defect — a synchronous HTTP call is the wrong shape for a multi-minute operation regardless
of the timeout value. Tracked on `sac-listen-post-agents-route-wedged-20260811`.
