### PR TITLE
feat(overlay): an image rebuild invalidates every overlay's venv-sac slice

### DIFF
--- a/src/scitex_agent_container/_maintenance/__init__.py
+++ b/src/scitex_agent_container/_maintenance/__init__.py
@@ -77,6 +77,25 @@ from ._overlay_masking_model import (
     OverlayMaskVerdict,
     ShadowInstall,
 )
+from ._overlay_venv_invalidate import (
+    reconcile_overlay_venv,
+    reconcile_overlay_venv_for_launch,
+    sif_identity,
+)
+from ._overlay_venv_model import (
+    ACTION_INVALIDATE,
+    ACTION_NONE,
+    ACTION_REFUSE,
+    InvalidationPlan,
+    OverlayVenvFacts,
+    VenvCheck,
+)
+from ._overlay_venv_predicate import plan_invalidation
+from ._venv_dist_assertion import (
+    VenvDistributionError,
+    assert_venv_distributions_unique,
+    duplicate_distributions,
+)
 from ._worktree_gc import (
     DEFAULT_CAP,
     DEFAULT_MIN_AGE_HOURS,
@@ -98,8 +117,21 @@ from ._worktree_gc_alarm import (
 from ._worktree_gc_repos import discover_repos, spec_workdirs
 
 __all__ = [
+    "ACTION_INVALIDATE",
+    "ACTION_NONE",
+    "ACTION_REFUSE",
     "DEFAULT_CAP",
     "DEFAULT_MIN_AGE_HOURS",
+    "InvalidationPlan",
+    "OverlayVenvFacts",
+    "VenvCheck",
+    "VenvDistributionError",
+    "assert_venv_distributions_unique",
+    "duplicate_distributions",
+    "plan_invalidation",
+    "reconcile_overlay_venv",
+    "reconcile_overlay_venv_for_launch",
+    "sif_identity",
     "IMPORTS_LIVE",
     "IMPORTS_UNAVAILABLE",
     "OPERATIONAL_RULE",

--- a/src/scitex_agent_container/_maintenance/_overlay_venv_invalidate.py
+++ b/src/scitex_agent_container/_maintenance/_overlay_venv_invalidate.py
@@ -26,8 +26,9 @@ reconciled anything, and the NEXT boot would then find the overlay "fresh" and
 skip the work — a refusal that quietly converts itself into a pass.
 
 WHY THIS NEVER RAISES INTO THE LAUNCH PATH. It is called from
-``build_run_argv``, so an exception here would refuse every start on the host —
-a guard more dangerous than the fault it guards, exactly as
+``_apptainer_runtime.start`` and ``tui_session.start``, so an exception here
+would refuse every start on the host — a guard more dangerous than the fault it
+guards, exactly as
 :func:`..runtimes._entry_point_gate.assert_entry_point_runs` documents. A
 reconcile that cannot run logs loudly and lets the launch proceed; the second
 layer, the BOOT ASSERTION in :mod:`._venv_dist_assertion`, then refuses INSIDE
@@ -404,11 +405,13 @@ def reconcile_overlay_venv_for_launch(
     sif_path: Path | str,
     state_dir: Path | str,
 ) -> InvalidationPlan | None:
-    """``build_run_argv``'s entry point. Observes liveness; NEVER raises.
+    """The launch sites' entry point. Observes liveness; NEVER raises.
 
-    Exists so the launch site stays one call and the never-raise contract lives
-    HERE, next to the reasoning for it, rather than as an anonymous ``try`` in
-    the middle of argv assembly.
+    Called from ``runtimes._apptainer_runtime.start`` and
+    ``runtimes.tui_session.start``, in both cases past the already-running guard
+    and past the dry-run return. Exists so each launch site stays ONE call and
+    the never-raise contract lives HERE, next to the reasoning for it, rather
+    than as an anonymous ``try`` in the middle of a start path.
 
     A reconcile that blows up must not refuse every start on the host — that is
     a guard more dangerous than the fault it guards. It logs loudly instead,

--- a/src/scitex_agent_container/_maintenance/_overlay_venv_invalidate.py
+++ b/src/scitex_agent_container/_maintenance/_overlay_venv_invalidate.py
@@ -20,6 +20,14 @@ keep showing up in every in-container scan, and (worst) a shadowed
 Outside, apptainer never sees it: apptainer reads ``upper/`` and ``work/`` and
 nothing else under the overlay root. The same reasoning places the stamp file.
 
+THE MOVE ONLY UNHIDES; IT DOES NOT RESTORE. Renaming the upper's slice away
+does not put the image's copy back — it stops MASKING it. So before moving,
+:func:`base_provides_venv` asserts the image actually has a populated venv to
+fall back on. Without that assertion this rail's own repair could leave an
+agent with NO venv at all, which is worse than the shadow it was fixing. The
+probe is expensive (an ``apptainer exec``), so it runs only when a move is
+genuinely on the table.
+
 REFUSING MUST NOT BE SELF-ERASING. On a refusal the stamp is deliberately NOT
 written. Writing it would record the current image as reconciled without having
 reconciled anything, and the NEXT boot would then find the overlay "fresh" and
@@ -65,6 +73,7 @@ __all__ = [
     "STAMP_FILENAME",
     "agent_running_from_state_dir",
     "archive_dir_for",
+    "base_provides_venv",
     "inside_container",
     "observe_overlay",
     "read_stamp",
@@ -253,6 +262,49 @@ def venv_slice(overlay_root: Path | str, venv: str = DEFAULT_VENV) -> Path:
     return Path(overlay_root) / OVERLAY_UPPER_DIRNAME / venv.lstrip("/")
 
 
+def base_provides_venv(sif_path: Path | str, venv: str = DEFAULT_VENV) -> bool | None:
+    """Does the IMAGE's own venv carry installed distributions?
+
+    The precondition for moving anything: the move only stops HIDING the
+    image's copy, it does not restore one. With an empty or unreadable lower
+    layer the agent is left with no venv at all — a worse outcome than the bug,
+    and the one failure this rail could plausibly cause itself.
+
+    ``None`` when the probe could not run or could not be parsed, which the
+    predicate treats as UNKNOWN and therefore as a refusal. Deliberately counts
+    distributions rather than importing anything: the question is whether the
+    lower layer is POPULATED, and a count is cheap, unambiguous, and cannot be
+    satisfied by a namespace-package shell.
+    """
+    from .._drift.versions import _apptainer_exec
+
+    probe = (
+        "import importlib.metadata as m, sys; "
+        "sys.stdout.write(str(len(list(m.distributions()))))"
+    )
+    try:
+        completed = _apptainer_exec(Path(sif_path), [f"{venv}/bin/python", "-c", probe])
+    except Exception as exc:  # stx-allow: fallback (reason: a probe that errors is UNKNOWN, never a verdict — it must refuse the move, not accuse the image)
+        logger.warning("overlay-venv: base probe failed on %s: %s", sif_path, exc)
+        return None
+    if completed is None or completed.returncode != 0:
+        logger.warning(
+            "overlay-venv: base probe did not run on %s (rc=%s)",
+            sif_path,
+            getattr(completed, "returncode", "no-result"),
+        )
+        return None
+    try:
+        return int((completed.stdout or "").strip()) > 0
+    except ValueError:
+        logger.warning(
+            "overlay-venv: base probe on %s returned unparseable output %r",
+            sif_path,
+            completed.stdout,
+        )
+        return None
+
+
 def observe_overlay(
     overlay_root: Path | str,
     sif_path: Path | str,
@@ -260,6 +312,7 @@ def observe_overlay(
     agent_running: bool | None,
     venv: str = DEFAULT_VENV,
     inside_container_fn=None,
+    base_probe=None,
 ) -> OverlayVenvFacts:
     """Gather every fact the predicate needs. Reads only; mutates nothing.
 
@@ -269,6 +322,13 @@ def observe_overlay(
     every reconcile correctly refuses. Without the seam the acting path could
     only ever be exercised on a bare host — i.e. never in CI. The default is the
     real function, so production keeps the real guard.
+
+    ``base_probe`` (``(sif, venv) -> bool | None``) is the second seam, and it
+    is called LAZILY — only when a move is actually on the table. It costs an
+    ``apptainer exec`` into the image, and a launch that is not going to move
+    anything must not pay it. The laziness is decided HERE rather than in the
+    predicate so the predicate stays pure; the predicate's matching rule is that
+    an unconsulted precondition for an action you are not taking is a pass.
     """
     slice_path = venv_slice(overlay_root, venv)
     try:
@@ -276,13 +336,24 @@ def observe_overlay(
     except OSError as exc:  # stx-allow: fallback (reason: an unreadable parent must report UNKNOWN, never 'absent')
         logger.warning("overlay-venv: could not stat %s: %s", slice_path, exc)
         slice_present = None
+
+    identity = sif_identity(sif_path)
+    recorded = read_stamp(overlay_root)
+    move_on_the_table = bool(slice_present) and identity != (recorded or "")
+    base_ok = (
+        (base_probe or base_provides_venv)(sif_path, venv)
+        if move_on_the_table
+        else None
+    )
+
     return OverlayVenvFacts(
-        sif_identity=sif_identity(sif_path),
-        recorded_identity=read_stamp(overlay_root),
+        sif_identity=identity,
+        recorded_identity=recorded,
         venv_slice_present=slice_present,
         inside_container=(inside_container_fn or inside_container)(),
         agent_running=agent_running,
         upper_mounted_here=upper_mounted_here(overlay_root),
+        base_provides_venv=base_ok,
     )
 
 
@@ -334,6 +405,7 @@ def reconcile_overlay_venv(
     venv: str = DEFAULT_VENV,
     now: datetime | None = None,
     inside_container_fn=None,
+    base_probe=None,
 ) -> InvalidationPlan | None:
     """Enforce the contract for one agent. Returns the plan, or ``None``.
 
@@ -368,6 +440,7 @@ def reconcile_overlay_venv(
         agent_running=agent_running,
         venv=venv,
         inside_container_fn=inside_container_fn,
+        base_probe=base_probe,
     )
     plan = plan_invalidation(agent=name, overlay_root=str(root), facts=facts)
 

--- a/src/scitex_agent_container/_maintenance/_overlay_venv_invalidate.py
+++ b/src/scitex_agent_container/_maintenance/_overlay_venv_invalidate.py
@@ -1,0 +1,434 @@
+"""Enforce the overlay-venv invalidation contract: observe, decide, MOVE ASIDE.
+
+The contract, the measurement and the vocabulary live in
+:mod:`._overlay_venv_model`; the pure decision lives in
+:mod:`._overlay_venv_predicate`. This module is the I/O half — it gathers the
+facts, asks the predicate, and performs the one mutation the rail is allowed to
+make.
+
+NOTHING IS EVER DELETED. The stale slice is renamed into
+``<overlay>/.old/<timestamp>/upper/opt/venv-sac``. That is the standing fleet
+rule and it is also what keeps the rail debuggable: if a prune is ever wrong,
+the evidence is one ``mv`` away from being restored, and the path mirrors the
+original so the restore is mechanical.
+
+WHERE THE ARCHIVE LIVES, AND WHY NOT UNDER ``upper/``. ``.old/`` sits beside
+``upper/``, not inside it. Inside, the archived tree would still be part of the
+container's filesystem view — it would keep counting against the agent's disk,
+keep showing up in every in-container scan, and (worst) a shadowed
+``site-packages`` copy would still be reachable on a stray ``sys.path`` entry.
+Outside, apptainer never sees it: apptainer reads ``upper/`` and ``work/`` and
+nothing else under the overlay root. The same reasoning places the stamp file.
+
+REFUSING MUST NOT BE SELF-ERASING. On a refusal the stamp is deliberately NOT
+written. Writing it would record the current image as reconciled without having
+reconciled anything, and the NEXT boot would then find the overlay "fresh" and
+skip the work — a refusal that quietly converts itself into a pass.
+
+WHY THIS NEVER RAISES INTO THE LAUNCH PATH. It is called from
+``build_run_argv``, so an exception here would refuse every start on the host —
+a guard more dangerous than the fault it guards, exactly as
+:func:`..runtimes._entry_point_gate.assert_entry_point_runs` documents. A
+reconcile that cannot run logs loudly and lets the launch proceed; the second
+layer, the BOOT ASSERTION in :mod:`._venv_dist_assertion`, then refuses INSIDE
+the container if the union really is incoherent. Try to repair host-side,
+refuse to run broken in-container.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .._drift.versions import DEFAULT_VENV
+from ..runtimes._apptainer_overlay import (
+    OVERLAY_UPPER_DIRNAME,
+    OVERLAY_WORK_DIRNAME,
+    is_image_overlay,
+    resolve_overlay_declaration,
+)
+from ._overlay_venv_model import (
+    ACTION_INVALIDATE,
+    ACTION_REFUSE,
+    InvalidationPlan,
+    OverlayVenvFacts,
+)
+from ._overlay_venv_predicate import plan_invalidation
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ARCHIVE_DIRNAME",
+    "STAMP_FILENAME",
+    "agent_running_from_state_dir",
+    "archive_dir_for",
+    "inside_container",
+    "observe_overlay",
+    "read_stamp",
+    "reconcile_overlay_venv",
+    "reconcile_overlay_venv_for_launch",
+    "sif_identity",
+    "stamp_path",
+    "upper_mounted_here",
+    "venv_slice",
+    "write_stamp",
+]
+
+#: Beside ``upper/`` and ``work/``, never inside them (see module docstring).
+ARCHIVE_DIRNAME = ".old"
+STAMP_FILENAME = ".sac-venv-sif-id"
+
+#: Same stamp format the rest of the package archives with
+#: (``cli_pkg._declare_a2a_host._archive_dir``), so ``.old/`` directories sort
+#: and read identically wherever an operator meets one.
+_ARCHIVE_STAMP_FMT = "%Y%m%dT%H%M%SZ"
+
+_MOUNTINFO = Path("/proc/self/mountinfo")
+
+#: Second, filesystem-level witness for "am I inside a container". Apptainer
+#: creates this directory in every container it builds; it survives
+#: ``--cleanenv``, which strips the environment witness.
+_APPTAINER_MARKER_DIR = Path("/.singularity.d")
+
+
+def sif_identity(sif_path: Path | str) -> str:
+    """Identity of the image ``sif_path`` names, or ``""`` when unresolvable.
+
+    THE FILENAME IS NOT THE KEY. ``containers/sac-base.sif`` is a STABLE
+    SYMLINK onto a timestamped target::
+
+        sac-base.sif -> .../sac-base/sac-base-2026-0810-195145.sif
+
+    so its own name is identical before and after a rebuild. Keying on it
+    yields a check that can never fail — worse than no check, because the
+    config still lists it. We resolve the symlink and key on the TARGET.
+
+    Size and mtime join the basename deliberately. A rebuild that reuses the
+    same target filename (an in-place overwrite, or a layout without the
+    timestamp) would be invisible to the name alone. The bias is intentional:
+    a FALSE invalidation costs a re-install of genuinely overlay-only packages
+    and moves nothing to the bin, while a FALSE NEGATIVE is the bug this rail
+    exists to close. Over-sensitive is the safe direction here.
+    """
+    try:
+        target = Path(sif_path).expanduser().resolve(strict=True)
+        st = target.stat()
+    except OSError as exc:
+        logger.debug("overlay-venv: image %s did not resolve: %s", sif_path, exc)
+        return ""
+    return f"{target.name}:{st.st_size}:{st.st_mtime_ns}"
+
+
+def stamp_path(overlay_root: Path | str) -> Path:
+    """Where this overlay's reconciled-image identity is recorded.
+
+    OUTSIDE ``upper/`` on purpose: the container's filesystem view never
+    includes it, so an agent cannot clobber its own invalidation stamp from
+    inside — accidentally or otherwise.
+    """
+    return Path(overlay_root) / STAMP_FILENAME
+
+
+def read_stamp(overlay_root: Path | str) -> str | None:
+    """The recorded identity, ``""`` when never stamped, ``None`` when unreadable.
+
+    The three returns are three different facts and the caller treats them as
+    such. In particular ``None`` is NOT ``""``: an unreadable stamp must not be
+    mistaken for a never-stamped overlay, because the latter authorises a move.
+    """
+    path = stamp_path(overlay_root)
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return ""
+    except OSError as exc:
+        logger.warning("overlay-venv: stamp %s unreadable: %s", path, exc)
+        return None
+
+
+def write_stamp(overlay_root: Path | str, identity: str) -> bool:
+    """Record ``identity`` as reconciled. ``False`` (loudly) when the write fails."""
+    path = stamp_path(overlay_root)
+    try:
+        path.write_text(f"{identity}\n", encoding="utf-8")
+    except OSError as exc:
+        logger.warning("overlay-venv: could not write stamp %s: %s", path, exc)
+        return False
+    return True
+
+
+def inside_container() -> bool:
+    """Is THIS process running inside an apptainer container?
+
+    Two independent witnesses, either decisive. The environment witness is
+    :func:`.._lifecycle._in_sif_broker.is_in_sif` — reused rather than
+    re-spelled so sac keeps ONE definition of "the env says SIF". The
+    filesystem witness covers the case that one misses: ``--cleanenv`` strips
+    ``APPTAINER_CONTAINER`` while ``/.singularity.d`` remains.
+
+    Total by construction (an env read cannot fail and ``Path.exists`` swallows
+    its own errors), so this never has to report UNKNOWN.
+    """
+    from .._lifecycle._in_sif_broker import is_in_sif
+
+    if is_in_sif():
+        return True
+    return _APPTAINER_MARKER_DIR.is_dir()
+
+
+def upper_mounted_here(overlay_root: Path | str) -> bool | None:
+    """Does THIS process's mount table show an overlayfs using this overlay?
+
+    ``None`` when the mount table could not be read — never ``False``. A
+    corroborating witness only: a mount made by another process lives in that
+    process's mount namespace and is invisible here, so a ``False`` proves that
+    WE have not mounted it and nothing more. Liveness of the agent is what
+    covers the other namespaces.
+    """
+    root = Path(overlay_root)
+    upper = str(root / OVERLAY_UPPER_DIRNAME).rstrip("/")
+    work = str(root / OVERLAY_WORK_DIRNAME).rstrip("/")
+    try:
+        raw = _MOUNTINFO.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.debug("overlay-venv: %s unreadable: %s", _MOUNTINFO, exc)
+        return None
+    for line in raw.splitlines():
+        # mountinfo: "<mount fields> - <fstype> <source> <super options>".
+        _, _, tail = line.partition(" - ")
+        fields = tail.split()
+        if len(fields) < 3 or fields[0] != "overlay":
+            continue
+        for option in fields[2].split(","):
+            key, _, value = option.partition("=")
+            if key == "upperdir" and value.rstrip("/") == upper:
+                return True
+            if key == "workdir" and value.rstrip("/") == work:
+                return True
+    return False
+
+
+def _pid_alive(pid: int) -> bool:
+    """``os.kill(pid, 0)`` — the same instrument sac's own verdict rail uses."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by someone else
+    return True
+
+
+def agent_running_from_state_dir(state_dir: Path | str) -> bool | None:
+    """Liveness from the agent's PID file. ``None`` when the file is unreadable.
+
+    An ABSENT pid file reads as ``False``: nothing claims to be running, which
+    is the state a clean stop leaves behind and the state a first start begins
+    in. An UNREADABLE or malformed one reads as ``None``, because a file that
+    exists and cannot be parsed is a question, not an answer.
+    """
+    pid_file = Path(state_dir) / "pid"
+    try:
+        raw = pid_file.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        logger.warning("overlay-venv: pid file %s unreadable: %s", pid_file, exc)
+        return None
+    if not raw:
+        return False
+    try:
+        pid = int(raw.splitlines()[0])
+    except ValueError:
+        logger.warning("overlay-venv: pid file %s is not a pid: %r", pid_file, raw)
+        return None
+    return _pid_alive(pid)
+
+
+def venv_slice(overlay_root: Path | str, venv: str = DEFAULT_VENV) -> Path:
+    """``<overlay>/upper/opt/venv-sac`` — the slice the contract invalidates."""
+    return Path(overlay_root) / OVERLAY_UPPER_DIRNAME / venv.lstrip("/")
+
+
+def observe_overlay(
+    overlay_root: Path | str,
+    sif_path: Path | str,
+    *,
+    agent_running: bool | None,
+    venv: str = DEFAULT_VENV,
+    inside_container_fn=None,
+) -> OverlayVenvFacts:
+    """Gather every fact the predicate needs. Reads only; mutates nothing.
+
+    ``inside_container_fn`` is an injection seam (``() -> bool``), and it earns
+    its keep the moment you try to test this: sac's own test suite RUNS INSIDE
+    A CONTAINER, so the real :func:`inside_container` answers ``True`` there and
+    every reconcile correctly refuses. Without the seam the acting path could
+    only ever be exercised on a bare host — i.e. never in CI. The default is the
+    real function, so production keeps the real guard.
+    """
+    slice_path = venv_slice(overlay_root, venv)
+    try:
+        slice_present: bool | None = slice_path.is_dir()
+    except OSError as exc:  # stx-allow: fallback (reason: an unreadable parent must report UNKNOWN, never 'absent')
+        logger.warning("overlay-venv: could not stat %s: %s", slice_path, exc)
+        slice_present = None
+    return OverlayVenvFacts(
+        sif_identity=sif_identity(sif_path),
+        recorded_identity=read_stamp(overlay_root),
+        venv_slice_present=slice_present,
+        inside_container=(inside_container_fn or inside_container)(),
+        agent_running=agent_running,
+        upper_mounted_here=upper_mounted_here(overlay_root),
+    )
+
+
+def archive_dir_for(overlay_root: Path | str, *, now: datetime | None = None) -> Path:
+    """``<overlay>/.old/<timestamp>/upper/opt/venv-sac`` — the restore target.
+
+    The archived path MIRRORS the original below ``.old/<ts>/`` so undoing an
+    invalidation is one mechanical ``mv`` with no path arithmetic.
+    """
+    stamp = (now or datetime.now(timezone.utc)).strftime(_ARCHIVE_STAMP_FMT)
+    return Path(overlay_root) / ARCHIVE_DIRNAME / stamp / OVERLAY_UPPER_DIRNAME
+
+
+def _move_aside(
+    agent: str,
+    overlay_root: Path,
+    plan: InvalidationPlan,
+    venv: str,
+    now: datetime | None = None,
+) -> Path | None:
+    """Rename the stale slice under ``.old/``; return where it landed."""
+    source = venv_slice(overlay_root, venv)
+    destination = archive_dir_for(overlay_root, now=now) / venv.lstrip("/")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    os.rename(source, destination)
+    # ONE line, naming BOTH image identities and the path that moved. Silence
+    # is what cost scitex-hub a session: the agent read a broken venv as a
+    # broken repo because nothing anywhere said the env had changed under it.
+    # This line is part of the fix, not a nicety.
+    logger.warning(
+        "overlay-venv INVALIDATED for agent %s: image changed %s -> %s; "
+        "moved %s -> %s (nothing deleted; restore with `mv %s %s`)",
+        agent,
+        plan.recorded_identity or "(never stamped)",
+        plan.sif_identity,
+        source,
+        destination,
+        destination,
+        source,
+    )
+    return destination
+
+
+def reconcile_overlay_venv(
+    config,
+    sif_path: Path | str,
+    *,
+    agent_running: bool | None,
+    venv: str = DEFAULT_VENV,
+    now: datetime | None = None,
+    inside_container_fn=None,
+) -> InvalidationPlan | None:
+    """Enforce the contract for one agent. Returns the plan, or ``None``.
+
+    ``None`` means the contract does not apply to this agent — no overlay is
+    declared, or the overlay is a loopback IMAGE whose upper layer is not
+    host-readable and therefore not host-invalidatable.
+
+    ``agent_running`` is a REQUIRED keyword with no default so a caller cannot
+    reach the mutation without having answered it. Pass ``None`` when you did
+    not measure it; the plan then refuses, which is the correct answer.
+    """
+    root = resolve_overlay_declaration(config)
+    name = getattr(config, "name", "") or "<unknown>"
+    if root is None:
+        return None
+
+    ap = getattr(config, "apptainer", None)
+    overlay_size = (getattr(ap, "overlay_size", "") or "") if ap is not None else ""
+    if is_image_overlay(root, overlay_size):
+        logger.info(
+            "overlay-venv: agent %s uses a loopback image overlay (%s); its "
+            "upper layer is not host-readable, so the venv slice cannot be "
+            "invalidated from here. Recreate the image overlay to reset it.",
+            name,
+            root,
+        )
+        return None
+
+    facts = observe_overlay(
+        root,
+        sif_path,
+        agent_running=agent_running,
+        venv=venv,
+        inside_container_fn=inside_container_fn,
+    )
+    plan = plan_invalidation(agent=name, overlay_root=str(root), facts=facts)
+
+    if plan.action == ACTION_REFUSE:
+        # Loud, and deliberately NOT followed by a stamp write — see the module
+        # docstring on why a refusal must not convert itself into a pass.
+        logger.warning(
+            "overlay-venv: REFUSING to invalidate %s for agent %s: %s",
+            root,
+            name,
+            "; ".join(plan.blocking_reasons()),
+        )
+        return plan
+
+    if plan.action == ACTION_INVALIDATE:
+        try:
+            _move_aside(name, root, plan, venv, now=now)
+        except OSError as exc:  # stx-allow: fallback (reason: a failed archive must log loudly and leave the stamp unwritten, never brick the launch)
+            logger.error(
+                "overlay-venv: could not archive %s for agent %s: %s. The stale "
+                "venv slice is UNCHANGED and the stamp is NOT advanced, so the "
+                "next start retries. Move it aside by hand if this persists.",
+                venv_slice(root, venv),
+                name,
+                exc,
+            )
+            return plan
+
+    write_stamp(root, plan.sif_identity)
+    return plan
+
+
+def reconcile_overlay_venv_for_launch(
+    config,
+    sif_path: Path | str,
+    state_dir: Path | str,
+) -> InvalidationPlan | None:
+    """``build_run_argv``'s entry point. Observes liveness; NEVER raises.
+
+    Exists so the launch site stays one call and the never-raise contract lives
+    HERE, next to the reasoning for it, rather than as an anonymous ``try`` in
+    the middle of argv assembly.
+
+    A reconcile that blows up must not refuse every start on the host — that is
+    a guard more dangerous than the fault it guards. It logs loudly instead,
+    and the in-container boot assertion
+    (:func:`._venv_dist_assertion.assert_venv_distributions_unique`) is the
+    backstop that refuses to RUN in a union this failed to repair.
+    """
+    try:
+        return reconcile_overlay_venv(
+            config,
+            sif_path,
+            agent_running=agent_running_from_state_dir(state_dir),
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: a bug in this rail must never refuse every start on the host; the in-container boot assertion is the backstop)
+        logger.error(
+            "overlay-venv: reconcile FAILED for agent %r (%s: %s). The launch "
+            "proceeds unreconciled; if this agent's venv is shadowed, the "
+            "in-container boot assertion will refuse it.",
+            getattr(config, "name", "<unknown>"),
+            type(exc).__name__,
+            exc,
+        )
+        return None

--- a/src/scitex_agent_container/_maintenance/_overlay_venv_model.py
+++ b/src/scitex_agent_container/_maintenance/_overlay_venv_model.py
@@ -1,0 +1,247 @@
+"""The OVERLAY VENV INVALIDATION CONTRACT — vocabulary and three-valued types.
+
+THE CONTRACT
+------------
+**An image rebuild MUST invalidate the ``venv-sac`` slice of every per-agent
+overlay.**
+
+``/opt/venv-sac`` is IMAGE CONTENT that an overlay merely HAPPENS to be able to
+write to. sac binds exactly one path into the venv —
+``.../site-packages/scitex_agent_container`` — and everything else under
+``/opt/venv-sac`` is baked into the SIF. The overlay's writability there is an
+accident of how overlayfs unions a read-only lower with a writable upper, not a
+statement that per-agent state belongs there. Per-agent state worth preserving
+lives in the agent's HOME and its WORKDIR. Nothing under ``site-packages`` is
+ever the agent's to keep.
+
+Today the image is authoritative IN PRINCIPLE and silently overridden IN
+PRACTICE by whichever files happen to be older. When an agent runs ``pip
+install`` inside its container the result lands in the overlay upper and shadows
+the image's copy FOREVER — including across an image rebuild, because nothing
+re-evaluates the upper when the lower is swapped.
+
+WHAT THAT COSTS, MEASURED
+-------------------------
+2026-08-11, host-side, under
+``containers/overlays/<agent>/upper/opt/venv-sac/lib/python3.12/site-packages/``::
+
+    scitex-dev 7 dist-infos (3 written that morning), scitex-agent-container 3,
+    neurovista 2, paper-scitex-clew 2, scitex-db 2, scitex-hpc 2, scitex-hub 2,
+    scitex-storage 2   — every other overlay 0
+
+The SIF ships exactly ONE (``scitex_dev-0.43.1.dist-info``). The UNION is
+incoherent: the image's dist-info advertises a ``pytest11`` entry point whose
+module the stale overlay tree masks, so every ``pytest`` run dies before
+collecting a single test::
+
+    ModuleNotFoundError: No module named 'scitex_dev._core._test_execution_plugin'
+
+It reads as a broken REPO. It is a broken ENV. scitex-hub lost a session to it.
+A control confirmed the direction: a pruned overlay resolves ``0.43.1`` and
+imports ``scitex_dev.store`` fine; an unpruned one resolves ``0.38.0`` and
+raises ``ModuleNotFoundError``.
+
+WHY THE KEY IS NOT THE FILENAME
+-------------------------------
+``containers/sac-base.sif`` is a STABLE SYMLINK::
+
+    sac-base.sif -> .../containers/sac-base/sac-base-2026-0810-195145.sif
+
+Its own name never changes, so keying invalidation on it could never detect a
+rebuild — the check would pass forever, which is worse than no check because
+the config still lists it. The identity is the RESOLVED TARGET (see
+:func:`._overlay_venv_invalidate.sif_identity`).
+
+THREE-VALUED, NEVER TWO
+-----------------------
+Every check here is PASS / FAIL / **UNKNOWN**, following the shape of
+:mod:`.._lifecycle._relocate_preflight` (a sibling rail, deliberately not
+imported so the two evolve independently). UNKNOWN refuses as firmly as FAIL
+and prescribes "go measure it" rather than "go fix it". A check that cannot
+read the overlay returns UNKNOWN, NEVER pass — folding "could not read" into
+"fine" is the exact bug class this whole rail exists to close.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Final
+
+__all__ = [
+    "ACTION_INVALIDATE",
+    "ACTION_NONE",
+    "ACTION_REFUSE",
+    "CHECK_AGENT_NOT_RUNNING",
+    "CHECK_NOT_INSIDE_CONTAINER",
+    "CHECK_OVERLAY_READABLE",
+    "CHECK_SIF_IDENTITY",
+    "CHECK_UPPER_NOT_MOUNTED_HERE",
+    "CHECK_VENV_DISTS_UNIQUE",
+    "InvalidationPlan",
+    "OverlayVenvFacts",
+    "VenvCheck",
+]
+
+# ---------------------------------------------------------------------------
+# Check names (API strings — quoted in logs and in the health payload).
+# ---------------------------------------------------------------------------
+CHECK_NOT_INSIDE_CONTAINER: Final = "not_inside_container"
+CHECK_AGENT_NOT_RUNNING: Final = "agent_not_running"
+CHECK_UPPER_NOT_MOUNTED_HERE: Final = "upper_not_mounted_here"
+CHECK_SIF_IDENTITY: Final = "sif_identity_resolved"
+CHECK_OVERLAY_READABLE: Final = "overlay_readable"
+
+#: The BOOT ASSERTION's check name (:mod:`._venv_dist_assertion`).
+CHECK_VENV_DISTS_UNIQUE: Final = "venv_distributions_unique"
+
+# ---------------------------------------------------------------------------
+# Actions. Deliberately not a bool: "nothing to do" and "I refuse to decide"
+# are different answers with different follow-ups, and collapsing them is how
+# a refusal gets read as an all-clear.
+# ---------------------------------------------------------------------------
+ACTION_NONE: Final = "none"
+ACTION_INVALIDATE: Final = "invalidate"
+ACTION_REFUSE: Final = "refuse"
+
+
+@dataclass(frozen=True)
+class VenvCheck:
+    """One answer about one overlay.
+
+    ``ok`` is three-valued: ``True`` pass, ``False`` fail, ``None`` COULD NOT
+    DETERMINE. ``hint`` is required whenever the answer is not a pass — an
+    error that only says what broke is half-written; it must also say what to
+    do. Mirrors :class:`.._lifecycle._relocate_preflight.Check`.
+    """
+
+    name: str
+    ok: bool | None
+    detail: str
+    hint: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("VenvCheck.name must be non-empty")
+        if self.ok not in (True, False, None):
+            raise ValueError(f"VenvCheck.ok must be True/False/None, got {self.ok!r}")
+        if not self.detail:
+            raise ValueError(f"VenvCheck {self.name!r}: detail must be non-empty")
+        if self.ok is not True and not self.hint:
+            raise ValueError(
+                f"VenvCheck {self.name!r}: a non-passing check must carry a hint "
+                "saying what to do about it"
+            )
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "ok": self.ok,
+            "detail": self.detail,
+            "hint": self.hint,
+        }
+
+
+@dataclass(frozen=True)
+class OverlayVenvFacts:
+    """What was OBSERVED about one agent's overlay. Gathering happens elsewhere.
+
+    Every ``| None`` field defaults to ``None`` meaning NOT OBSERVED — distinct
+    from an observed negative. A prober that could not answer must say so
+    rather than report a falsy default, because a default that reads as
+    "absent" turns a failed probe into a confident wrong answer, and here the
+    wrong answer MOVES FILES.
+    """
+
+    #: SIF identity of the image the agent is ABOUT to boot on. ``None`` = not
+    #: observed; ``""`` = observed and unresolvable (both refuse).
+    sif_identity: str | None = None
+
+    #: Identity recorded in the overlay by the last reconcile. ``None`` = the
+    #: stamp could not be read; ``""`` = readable and never stamped (which is
+    #: every overlay in the fleet on the day this lands, and MUST invalidate —
+    #: an unstamped overlay is exactly the state the measurement found).
+    recorded_identity: str | None = None
+
+    #: Does ``<overlay>/upper/opt/venv-sac`` exist? ``None`` = could not tell.
+    venv_slice_present: bool | None = None
+
+    #: Is THIS process running inside a container? ``None`` = could not tell.
+    inside_container: bool | None = None
+
+    #: Is the agent (and therefore its overlay mount) live? ``None`` = not
+    #: observed.
+    agent_running: bool | None = None
+
+    #: Does this process's mount table show an overlayfs using this upper?
+    #: ``None`` = the mount table could not be read.
+    upper_mounted_here: bool | None = None
+
+
+@dataclass(frozen=True)
+class InvalidationPlan:
+    """The whole answer for one overlay, in one shape.
+
+    ``action`` is derived, never asserted independently of the checks: any
+    FAIL or any UNKNOWN yields :data:`ACTION_REFUSE`, so there is no path on
+    which an unresolved question results in a mutation.
+    """
+
+    agent: str
+    overlay_root: str
+    sif_identity: str = ""
+    recorded_identity: str = ""
+    checks: tuple[VenvCheck, ...] = field(default_factory=tuple)
+    stale: bool = False
+    venv_slice_present: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.agent:
+            raise ValueError("InvalidationPlan.agent must be non-empty")
+
+    @property
+    def failed(self) -> tuple[VenvCheck, ...]:
+        return tuple(c for c in self.checks if c.ok is False)
+
+    @property
+    def unknown(self) -> tuple[VenvCheck, ...]:
+        return tuple(c for c in self.checks if c.ok is None)
+
+    @property
+    def safe(self) -> bool | None:
+        """Three-valued: may this plan touch the filesystem at all?"""
+        if self.failed:
+            return False
+        if self.unknown:
+            return None
+        return True
+
+    @property
+    def action(self) -> str:
+        if self.safe is not True:
+            return ACTION_REFUSE
+        if self.stale and self.venv_slice_present:
+            return ACTION_INVALIDATE
+        return ACTION_NONE
+
+    def blocking_reasons(self) -> tuple[str, ...]:
+        """Every reason this invalidation must not proceed, each with its hint.
+
+        Failures first, then unknowns. Empty only when the answer is a clean
+        go — which for this rail means "safe to act", not "action needed".
+        """
+        return tuple(
+            f"{c.name}: {c.detail} -> {c.hint}" for c in (self.failed + self.unknown)
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "agent": self.agent,
+            "overlay_root": self.overlay_root,
+            "sif_identity": self.sif_identity,
+            "recorded_identity": self.recorded_identity,
+            "action": self.action,
+            "safe": self.safe,
+            "stale": self.stale,
+            "venv_slice_present": self.venv_slice_present,
+            "checks": [c.to_dict() for c in self.checks],
+        }

--- a/src/scitex_agent_container/_maintenance/_overlay_venv_model.py
+++ b/src/scitex_agent_container/_maintenance/_overlay_venv_model.py
@@ -72,6 +72,7 @@ __all__ = [
     "ACTION_NONE",
     "ACTION_REFUSE",
     "CHECK_AGENT_NOT_RUNNING",
+    "CHECK_BASE_USABLE",
     "CHECK_NOT_INSIDE_CONTAINER",
     "CHECK_OVERLAY_READABLE",
     "CHECK_SIF_IDENTITY",
@@ -90,6 +91,7 @@ CHECK_AGENT_NOT_RUNNING: Final = "agent_not_running"
 CHECK_UPPER_NOT_MOUNTED_HERE: Final = "upper_not_mounted_here"
 CHECK_SIF_IDENTITY: Final = "sif_identity_resolved"
 CHECK_OVERLAY_READABLE: Final = "overlay_readable"
+CHECK_BASE_USABLE: Final = "base_layer_usable"
 
 #: The BOOT ASSERTION's check name (:mod:`._venv_dist_assertion`).
 CHECK_VENV_DISTS_UNIQUE: Final = "venv_distributions_unique"
@@ -175,6 +177,20 @@ class OverlayVenvFacts:
     #: Does this process's mount table show an overlayfs using this upper?
     #: ``None`` = the mount table could not be read.
     upper_mounted_here: bool | None = None
+
+    #: Does the SIF's own ``venv-sac`` carry installed distributions — i.e. is
+    #: there a KNOWN-GOOD LOWER LAYER to fall back on once the upper's slice is
+    #: moved aside? ``None`` = not observed.
+    #:
+    #: This is the precondition the whole mutation rests on, and it was missing
+    #: from the first cut of this rail. Moving the upper's slice aside when the
+    #: lower is empty or unreadable does not restore the image's copy — it
+    #: leaves the agent with NO venv at all, converting a shadowed-but-working
+    #: container into a dead one. Expensive to observe (it needs an
+    #: ``apptainer exec`` into the image), so it is gathered LAZILY: only when a
+    #: move is actually on the table. See :func:`._overlay_venv_predicate.
+    #: _check_base_usable` for why an unconsulted value is still a pass.
+    base_provides_venv: bool | None = None
 
 
 @dataclass(frozen=True)

--- a/src/scitex_agent_container/_maintenance/_overlay_venv_predicate.py
+++ b/src/scitex_agent_container/_maintenance/_overlay_venv_predicate.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from ._overlay_venv_model import (
     CHECK_AGENT_NOT_RUNNING,
+    CHECK_BASE_USABLE,
     CHECK_NOT_INSIDE_CONTAINER,
     CHECK_OVERLAY_READABLE,
     CHECK_SIF_IDENTITY,
@@ -174,6 +175,60 @@ def _check_overlay_readable(facts: OverlayVenvFacts) -> VenvCheck:
     )
 
 
+def _check_base_usable(facts: OverlayVenvFacts, *, move_proposed: bool) -> VenvCheck:
+    """Is there a KNOWN-GOOD LOWER LAYER behind the slice we are about to move?
+
+    THE PRECONDITION THE WHOLE MUTATION RESTS ON, and it was missing from the
+    first cut of this rail. Moving the upper's ``venv-sac`` aside does not
+    RESTORE the image's copy — it merely stops HIDING it. If the image has
+    nothing there, or the probe cannot read it, the move turns a
+    shadowed-but-working container into one with no venv at all. That is a
+    worse outcome than the bug, and it is the one failure mode this rail could
+    plausibly cause itself.
+
+    Conditional by design: the fact is expensive (an ``apptainer exec`` into the
+    image) and it is a precondition for MOVING, not for looking. When no move is
+    proposed it is not consulted, and not consulting a precondition for an
+    action you are not taking is a pass, not an unknown. The caller is
+    responsible for gathering it exactly when ``move_proposed`` is true.
+    """
+    if not move_proposed:
+        return VenvCheck(
+            name=CHECK_BASE_USABLE,
+            ok=True,
+            detail="no move proposed, so the lower layer is not a precondition",
+        )
+    if facts.base_provides_venv is None:
+        return VenvCheck(
+            name=CHECK_BASE_USABLE,
+            ok=None,
+            detail="could not read the image's own venv",
+            hint=(
+                "probe the SIF before moving anything — "
+                "`apptainer exec <sif> /opt/venv-sac/bin/python -c 'import "
+                "importlib.metadata as m; print(len(list(m.distributions())))'`. "
+                "Moving the upper aside only UNHIDES the image's copy; if the "
+                "image has none, the agent is left with no venv at all"
+            ),
+        )
+    if not facts.base_provides_venv:
+        return VenvCheck(
+            name=CHECK_BASE_USABLE,
+            ok=False,
+            detail="the image's own venv carries no installed distributions",
+            hint=(
+                "do NOT move the overlay's slice aside — right now it is the "
+                "only copy the agent has. Rebuild or repoint the image first "
+                "(`sac image build`), then restart"
+            ),
+        )
+    return VenvCheck(
+        name=CHECK_BASE_USABLE,
+        ok=True,
+        detail="the image provides a populated venv to fall back on",
+    )
+
+
 def plan_invalidation(
     *,
     agent: str,
@@ -193,19 +248,21 @@ def plan_invalidation(
     silent ``False`` here is what a future reader would mistake for "checked,
     and it was fresh".
     """
-    checks = (
-        _check_not_inside_container(facts),
-        _check_agent_not_running(facts),
-        _check_upper_not_mounted_here(facts),
-        _check_sif_identity(facts),
-        _check_overlay_readable(facts),
-    )
     current = facts.sif_identity or ""
     recorded = facts.recorded_identity or ""
     # An UNSTAMPED overlay (recorded == "") is STALE by construction: it is the
     # pre-contract state, which is precisely the state the 2026-08-11 sweep
     # measured, so it must invalidate rather than be adopted as "matches".
     stale = current != recorded
+    move_proposed = stale and bool(facts.venv_slice_present)
+    checks = (
+        _check_not_inside_container(facts),
+        _check_agent_not_running(facts),
+        _check_upper_not_mounted_here(facts),
+        _check_sif_identity(facts),
+        _check_overlay_readable(facts),
+        _check_base_usable(facts, move_proposed=move_proposed),
+    )
     return InvalidationPlan(
         agent=agent,
         overlay_root=overlay_root,

--- a/src/scitex_agent_container/_maintenance/_overlay_venv_predicate.py
+++ b/src/scitex_agent_container/_maintenance/_overlay_venv_predicate.py
@@ -1,0 +1,217 @@
+"""Facts in, three-valued checks out. Nothing here touches a disk.
+
+WHY THERE IS NO I/O IN THIS MODULE. It evaluates FACTS someone else gathered —
+:class:`._overlay_venv_model.OverlayVenvFacts` in,
+:class:`._overlay_venv_model.InvalidationPlan` out. That means every refusal
+is unit-testable against the exact broken state we hit in production, without
+root, without apptainer, and without fabricating a live overlay mount — which
+is the only way to know a guard would actually have refused.
+
+THE GUARD THAT MATTERS MOST is :func:`_check_not_inside_container`. Moving the
+venv slice aside from INSIDE a running container does not move it: overlayfs
+turns the rename into a name-specific WHITEOUT in the upper layer, which then
+masks the SIF's clean files too. That converts a recoverable shadow into a
+permanently broken tree — the failure this whole rail exists to prevent, caused
+by the repair for it. Refuse rather than proceed.
+
+ORDER OF THE CHECKS IS THE ORDER OF THE HAZARD, not of the question: the three
+safety checks come first so a report read top-down leads with "may I act",
+never with "should I act".
+"""
+
+from __future__ import annotations
+
+from ._overlay_venv_model import (
+    CHECK_AGENT_NOT_RUNNING,
+    CHECK_NOT_INSIDE_CONTAINER,
+    CHECK_OVERLAY_READABLE,
+    CHECK_SIF_IDENTITY,
+    CHECK_UPPER_NOT_MOUNTED_HERE,
+    InvalidationPlan,
+    OverlayVenvFacts,
+    VenvCheck,
+)
+
+__all__ = ["plan_invalidation"]
+
+_UNOBSERVED_HINT = (
+    "gather this fact before deciding; an unobserved check is not a passing "
+    "one, and acting on it would move files on a guess"
+)
+
+
+def _unobserved(name: str, what: str) -> VenvCheck:
+    return VenvCheck(
+        name=name,
+        ok=None,
+        detail=f"{what} was not observed",
+        hint=_UNOBSERVED_HINT,
+    )
+
+
+def _check_not_inside_container(facts: OverlayVenvFacts) -> VenvCheck:
+    """The whiteout guard. See the module docstring — this one is the reason."""
+    if facts.inside_container is None:
+        return _unobserved(CHECK_NOT_INSIDE_CONTAINER, "container membership")
+    if facts.inside_container:
+        return VenvCheck(
+            name=CHECK_NOT_INSIDE_CONTAINER,
+            ok=False,
+            detail="this process is running INSIDE a container",
+            hint=(
+                "run the invalidation from the HOST. From inside, the overlay "
+                "is mounted live and a rename/unlink writes an overlayfs "
+                "WHITEOUT that also masks the SIF's clean files — it turns a "
+                "recoverable shadow into a permanently broken tree"
+            ),
+        )
+    return VenvCheck(
+        name=CHECK_NOT_INSIDE_CONTAINER,
+        ok=True,
+        detail="running on the host, not inside a container",
+    )
+
+
+def _check_agent_not_running(facts: OverlayVenvFacts) -> VenvCheck:
+    if facts.agent_running is None:
+        return _unobserved(CHECK_AGENT_NOT_RUNNING, "agent liveness")
+    if facts.agent_running:
+        return VenvCheck(
+            name=CHECK_AGENT_NOT_RUNNING,
+            ok=False,
+            detail="the agent is running, so its container has this overlay mounted",
+            hint=(
+                "stop the agent first (`sac agents stop <name>`); renaming an "
+                "upperdir out from under a live overlayfs is undefined and can "
+                "corrupt the running container"
+            ),
+        )
+    return VenvCheck(
+        name=CHECK_AGENT_NOT_RUNNING,
+        ok=True,
+        detail="no live agent process claims this overlay",
+    )
+
+
+def _check_upper_not_mounted_here(facts: OverlayVenvFacts) -> VenvCheck:
+    """Corroborating witness, deliberately narrow.
+
+    A mount made by ANOTHER process lives in that process's mount namespace and
+    is invisible here, so a pass proves only that WE have not mounted it. It is
+    kept because it is free and independently decisive when it fires; the
+    liveness check above is what covers the other namespaces.
+    """
+    if facts.upper_mounted_here is None:
+        return _unobserved(CHECK_UPPER_NOT_MOUNTED_HERE, "this process's mount table")
+    if facts.upper_mounted_here:
+        return VenvCheck(
+            name=CHECK_UPPER_NOT_MOUNTED_HERE,
+            ok=False,
+            detail="an overlayfs in this mount namespace is using this upper layer",
+            hint=(
+                "unmount it before touching the upper layer; writing through a "
+                "live overlayfs produces whiteouts, not deletions"
+            ),
+        )
+    return VenvCheck(
+        name=CHECK_UPPER_NOT_MOUNTED_HERE,
+        ok=True,
+        detail="no overlayfs in this mount namespace uses this upper layer",
+    )
+
+
+def _check_sif_identity(facts: OverlayVenvFacts) -> VenvCheck:
+    if facts.sif_identity is None:
+        return _unobserved(CHECK_SIF_IDENTITY, "the SIF identity")
+    if not facts.sif_identity:
+        return VenvCheck(
+            name=CHECK_SIF_IDENTITY,
+            ok=None,
+            detail="the image path did not resolve to a stat-able SIF",
+            hint=(
+                "check that spec.apptainer.image exists and that the "
+                "sac-base.sif symlink resolves; with no identity there is "
+                "nothing to compare the overlay's stamp against, and "
+                "invalidating on an unknown image would be a coin flip"
+            ),
+        )
+    return VenvCheck(
+        name=CHECK_SIF_IDENTITY,
+        ok=True,
+        detail=f"image resolves to {facts.sif_identity}",
+    )
+
+
+def _check_overlay_readable(facts: OverlayVenvFacts) -> VenvCheck:
+    if facts.recorded_identity is None:
+        return VenvCheck(
+            name=CHECK_OVERLAY_READABLE,
+            ok=None,
+            detail="the overlay's SIF stamp could not be read",
+            hint=(
+                "check permissions on the overlay root; an unreadable stamp is "
+                "NOT an unstamped overlay, and treating it as one would move a "
+                "tree we never inspected"
+            ),
+        )
+    if facts.venv_slice_present is None:
+        return VenvCheck(
+            name=CHECK_OVERLAY_READABLE,
+            ok=None,
+            detail="could not tell whether the overlay upper carries a venv slice",
+            hint=(
+                "check permissions on <overlay>/upper; 'could not read' must "
+                "never be recorded as 'nothing there'"
+            ),
+        )
+    return VenvCheck(
+        name=CHECK_OVERLAY_READABLE,
+        ok=True,
+        detail=(
+            "overlay stamp and upper layer both readable "
+            f"(venv slice {'present' if facts.venv_slice_present else 'absent'})"
+        ),
+    )
+
+
+def plan_invalidation(
+    *,
+    agent: str,
+    overlay_root: str,
+    facts: OverlayVenvFacts,
+) -> InvalidationPlan:
+    """Evaluate every check against observed facts. Touches nothing.
+
+    Returns the FULL plan rather than the first refusal: an operator asking
+    "why did this not invalidate?" needs every reason at once, not N runs to
+    find N reasons.
+
+    Staleness is computed only from OBSERVED identities. When either side is
+    unobservable the corresponding check is already UNKNOWN, so ``action``
+    resolves to ``refuse`` regardless of what ``stale`` says — but ``stale`` is
+    still reported honestly rather than defaulted to ``False``, because a
+    silent ``False`` here is what a future reader would mistake for "checked,
+    and it was fresh".
+    """
+    checks = (
+        _check_not_inside_container(facts),
+        _check_agent_not_running(facts),
+        _check_upper_not_mounted_here(facts),
+        _check_sif_identity(facts),
+        _check_overlay_readable(facts),
+    )
+    current = facts.sif_identity or ""
+    recorded = facts.recorded_identity or ""
+    # An UNSTAMPED overlay (recorded == "") is STALE by construction: it is the
+    # pre-contract state, which is precisely the state the 2026-08-11 sweep
+    # measured, so it must invalidate rather than be adopted as "matches".
+    stale = current != recorded
+    return InvalidationPlan(
+        agent=agent,
+        overlay_root=overlay_root,
+        sif_identity=current,
+        recorded_identity=recorded,
+        checks=checks,
+        stale=stale,
+        venv_slice_present=bool(facts.venv_slice_present),
+    )

--- a/src/scitex_agent_container/_maintenance/_venv_dist_assertion.py
+++ b/src/scitex_agent_container/_maintenance/_venv_dist_assertion.py
@@ -1,0 +1,238 @@
+"""BOOT ASSERTION: refuse to run in a venv that carries a duplicated dist-info.
+
+The host-side rail (:mod:`._overlay_venv_invalidate`) tries to REPAIR the
+overlay before the container starts. This is the second layer: once inside, it
+measures the union the agent actually imports from and refuses to proceed when
+that union is incoherent. Repair host-side, refuse to run broken in-container.
+
+THE METHOD NOTE IS LOAD-BEARING — ``distributions()``, NEVER ``entry_points()``
+------------------------------------------------------------------------------
+``importlib.metadata.entry_points()`` **DEDUPES BY NORMALISED NAME** before it
+reads any entry point. CPython 3.12 spells it::
+
+    eps = itertools.chain.from_iterable(
+        dist.entry_points for dist in _unique(distributions())
+    )                              # _unique keys on _normalized_name
+
+Two ``.dist-info`` directories for the same distribution therefore collapse to
+ONE before ``entry_points()`` looks at anything, so a gate built on it CANNOT
+SEE THIS BUG. It passes while the venv is broken. That is a gate that cannot
+fail, which is strictly worse than no gate: the config still lists it, so the
+absence of an alarm reads as evidence of health.
+
+``distributions()`` does not dedupe, and it is what PLUGGY ITSELF uses —
+pytest's plugin loader iterates ``importlib.metadata.distributions()`` and reads
+``dist.entry_points`` per distribution, so it observes exactly what this check
+observes, including the dead entry.
+
+That is the whole mechanism of the outage. Measured by scitex-hub: the SIF's
+``scitex_dev-0.43.1.dist-info`` declares
+``pytest11 = scitex_dev._core._test_execution_plugin`` while the stale overlay
+tree supplies 0.38.0 code where that module does not exist, so every ``pytest``
+run dies before collecting a single test::
+
+    ModuleNotFoundError: No module named 'scitex_dev._core._test_execution_plugin'
+
+An ``entry_points()``-based check is green throughout. See also
+:mod:`..runtimes._overlay_distinfo`, which predicts this collision host-side and
+explains why a VERSION comparison is likewise blind to it.
+
+SCOPE IS AN EXPLICIT GATE, NOT A FOLDED UNKNOWN
+-----------------------------------------------
+:func:`duplicate_distributions` is three-valued and returns UNKNOWN whenever it
+could not measure — including when pointed at a path that is not a populated
+venv. :func:`assert_venv_distributions_unique` refuses on FAIL **and** on
+UNKNOWN alike. What it does NOT do is run at all when the venv is simply not
+present on this filesystem: that is a SCOPE decision, taken visibly and logged,
+rather than an unknown quietly recorded as a pass.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections import defaultdict
+from pathlib import Path
+
+from .._drift.versions import DEFAULT_VENV
+from ._overlay_masking_model import canonical_dist_name
+from ._overlay_venv_model import CHECK_VENV_DISTS_UNIQUE, VenvCheck
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "SKIP_ENV_VAR",
+    "VenvDistributionError",
+    "assert_venv_distributions_unique",
+    "duplicate_distributions",
+    "site_packages_dirs",
+]
+
+#: Set to ``"1"`` to skip the assertion. Deliberately an OVERRIDE rather than a
+#: default-off knob — the hazard belongs in the escape hatch, not in the
+#: declaration, so nobody disables this by merely not knowing about it. Mirrors
+#: ``runtimes._entry_point_gate.SKIP_ENV_VAR``.
+SKIP_ENV_VAR = "SAC_SKIP_VENV_DIST_ASSERTION"
+
+_HINT_DUPLICATE = (
+    "the overlay's upper layer is shadowing the image's site-packages. Stop "
+    "the agent and let the next start reconcile it "
+    "(_maintenance._overlay_venv_invalidate.reconcile_overlay_venv moves the "
+    "stale <overlay>/upper/opt/venv-sac aside into <overlay>/.old/<ts>/ — "
+    "nothing is deleted), or move that slice aside by hand FROM THE HOST. "
+    "Never delete it from inside the container: overlayfs turns that into a "
+    "whiteout that masks the image's clean files too"
+)
+
+
+class VenvDistributionError(RuntimeError):
+    """The venv this process imports from carries a duplicated distribution.
+
+    Carries the repair, not just the complaint. Raised at BOOT, so the operator
+    sees this instead of a ``ModuleNotFoundError`` from deep inside pytest that
+    reads as a broken repository.
+    """
+
+
+def site_packages_dirs(venv: Path | str = DEFAULT_VENV) -> list[Path]:
+    """Every ``site-packages`` under ``venv``. Empty when there is none."""
+    root = Path(venv)
+    try:
+        return sorted(p for p in root.glob("lib/python*/site-packages") if p.is_dir())
+    except OSError as exc:  # stx-allow: fallback (reason: an unreadable venv must yield UNKNOWN upstream, not a crash)
+        logger.warning("venv-dists: could not enumerate %s: %s", root, exc)
+        return []
+
+
+def _evidence_path(dist) -> str:
+    """Where this distribution's metadata lives, for the error message.
+
+    ``PathDistribution._path`` is private and is the only handle on the actual
+    ``.dist-info`` directory; ``locate_file("")`` (public) narrows only to the
+    containing ``site-packages``. A missing ``_path`` therefore degrades the
+    EVIDENCE, never the verdict.
+    """
+    path = getattr(dist, "_path", None)
+    if path is not None:
+        return str(path)
+    try:
+        return str(dist.locate_file(""))
+    except Exception:  # stx-allow: fallback (reason: evidence only — a distribution that cannot name its own location must not suppress the alarm about it)
+        return "(location unavailable)"
+
+
+def duplicate_distributions(venv: Path | str = DEFAULT_VENV) -> VenvCheck:
+    """Three-valued: is every distribution in ``venv`` present exactly once?
+
+    Enumerates with :func:`importlib.metadata.distributions` scoped to the
+    venv's ``site-packages`` — see the module docstring for why this is
+    ``distributions()`` and not ``entry_points()``.
+    """
+    from importlib.metadata import distributions
+
+    sites = site_packages_dirs(venv)
+    if not sites:
+        return VenvCheck(
+            name=CHECK_VENV_DISTS_UNIQUE,
+            ok=None,
+            detail=f"no site-packages found under {venv}",
+            hint=(
+                f"point the check at a real venv; {venv} carries no "
+                "lib/python*/site-packages, so nothing was measured and "
+                "nothing may be concluded"
+            ),
+        )
+
+    try:
+        found = list(distributions(path=[str(p) for p in sites]))
+    except OSError as exc:  # stx-allow: fallback (reason: an unreadable site-packages is UNKNOWN; reporting it as clean is the bug this rail closes)
+        return VenvCheck(
+            name=CHECK_VENV_DISTS_UNIQUE,
+            ok=None,
+            detail=f"could not enumerate distributions under {venv}: {exc}",
+            hint="check permissions on the site-packages directories, then re-run",
+        )
+
+    if not found:
+        return VenvCheck(
+            name=CHECK_VENV_DISTS_UNIQUE,
+            ok=None,
+            detail=f"{venv} has site-packages but no installed distributions",
+            hint=(
+                "an empty venv is not a healthy one; confirm the image was "
+                "built and mounted before treating this as a pass"
+            ),
+        )
+
+    seen: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for dist in found:
+        name = canonical_dist_name(dist.metadata["Name"] or "")
+        if not name:
+            continue
+        seen[name].append((dist.version or "(no version)", _evidence_path(dist)))
+
+    duplicates = {n: rows for n, rows in seen.items() if len(rows) > 1}
+    if not duplicates:
+        return VenvCheck(
+            name=CHECK_VENV_DISTS_UNIQUE,
+            ok=True,
+            detail=f"{len(seen)} distribution(s) under {venv}, each exactly once",
+        )
+
+    lines = []
+    for name in sorted(duplicates):
+        rendered = "; ".join(f"{ver} at {path}" for ver, path in duplicates[name])
+        lines.append(f"{name}: {len(duplicates[name])} dist-infos -> {rendered}")
+    return VenvCheck(
+        name=CHECK_VENV_DISTS_UNIQUE,
+        ok=False,
+        detail=(
+            f"{len(duplicates)} distribution(s) appear more than once under "
+            f"{venv} -- " + " | ".join(lines)
+        ),
+        hint=_HINT_DUPLICATE,
+    )
+
+
+def assert_venv_distributions_unique(
+    agent_name: str,
+    *,
+    venv: Path | str = DEFAULT_VENV,
+) -> VenvCheck | None:
+    """Refuse to boot into an incoherent venv. Returns the check, or ``None``.
+
+    ``None`` means the assertion did not apply — the override is set, or the
+    venv is not present on this filesystem (host-side unit runs, a source
+    checkout, any non-container invocation). Both are logged; neither is
+    recorded as a pass.
+
+    Refuses on FAIL and on UNKNOWN alike. That is safe here because the only
+    way to reach either is to have LOOKED at a real, populated venv: an absent
+    venv is filtered out above as out-of-scope, before the check runs.
+
+    Raises:
+        VenvDistributionError: naming every duplicated package, every version
+            found, and every path — or naming what could not be measured.
+    """
+    if os.environ.get(SKIP_ENV_VAR) == "1":
+        logger.warning(
+            "venv-dist assertion SKIPPED for %r via %s — the union is unverified",
+            agent_name,
+            SKIP_ENV_VAR,
+        )
+        return None
+
+    if not Path(venv).is_dir():
+        logger.info(
+            "venv-dist assertion not applicable for %r: %s is not present here",
+            agent_name,
+            venv,
+        )
+        return None
+
+    check = duplicate_distributions(venv)
+    if check.ok is True:
+        logger.info("venv-dist assertion passed for %r: %s", agent_name, check.detail)
+        return check
+
+    raise VenvDistributionError(f"{agent_name}: {check.detail}\nREPAIR: {check.hint}")

--- a/src/scitex_agent_container/_runners/_session_cli.py
+++ b/src/scitex_agent_container/_runners/_session_cli.py
@@ -162,6 +162,21 @@ def main(argv: list[str] | None = None) -> int:
     from .claude_session import run
 
     args = _parse_argv(argv)
+
+    # BOOT ASSERTION — the second layer of the overlay-venv invalidation
+    # contract. The host-side rail tried to REPAIR the overlay before this
+    # container started; this refuses to RUN if the union it produced is still
+    # incoherent. First thing inside the SIF, before any SDK work, so the
+    # operator sees a named duplicate instead of a ModuleNotFoundError from
+    # deep inside pytest that reads as a broken repository.
+    #
+    # It enumerates importlib.metadata.distributions(), NOT entry_points() —
+    # entry_points() dedupes by normalised name and therefore CANNOT see this
+    # bug. See _maintenance/_venv_dist_assertion for the measurement.
+    from .._maintenance._venv_dist_assertion import assert_venv_distributions_unique
+
+    assert_venv_distributions_unique(args.name)
+
     return asyncio.run(
         run(
             args.name,

--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -37,6 +37,7 @@ import subprocess
 from pathlib import Path
 
 from ..config import AgentConfig
+from ._apptainer_argv_record import write_redacted_argv as _write_redacted_argv
 
 # Re-exported for back-compat — extracted to _apptainer_build, still
 # imported here so existing `mod._build_sif_* / mod._safe_image_tag`
@@ -67,7 +68,6 @@ from ._apptainer_build_argv import (  # noqa: F401
 from ._apptainer_build_argv import (
     build_run_argv as _build_run_argv_impl,
 )
-from ._apptainer_argv_record import write_redacted_argv as _write_redacted_argv
 from .base import RuntimeBase
 
 DEFAULT_SIF_NAME = "scitex-agent-container.sif"
@@ -203,6 +203,29 @@ class ApptainerContainerRuntime(RuntimeBase):
         if dry_run:
             _write_redacted_argv(state_dir / "apptainer_run.argv.txt", argv)
             return True
+
+        # OVERLAY VENV INVALIDATION CONTRACT — an image rebuild must invalidate
+        # the `venv-sac` slice of this agent's overlay, or the overlay's stale
+        # site-packages shadow the new image forever. Contract, measurement and
+        # refusal logic: `_maintenance/_overlay_venv_model.py`.
+        #
+        # HERE rather than inside `build_run_argv` for three reasons:
+        #   1. `build_run_argv` is also called by `sac agents explain` and by
+        #      the dry-run path above — a read-only command must not move files.
+        #   2. This point is PAST the `is_running` guard, so sac has just
+        #      established with its own instrument that no container of this
+        #      agent has the overlay mounted. Doing this against a live mount is
+        #      the one thing the rail must never do: from inside a container the
+        #      rename becomes an overlayfs WHITEOUT that masks the SIF's clean
+        #      files too, turning a recoverable shadow into a broken tree.
+        #   3. `sif_path` is resolved here, and the RESOLVED target — not the
+        #      stable `sac-base.sif` symlink name — is the identity key.
+        # Never raises; the in-container boot assertion is the backstop.
+        from .._maintenance._overlay_venv_invalidate import (
+            reconcile_overlay_venv_for_launch,
+        )
+
+        reconcile_overlay_venv_for_launch(config, sif_path, state_dir)
 
         # Append the host ``~/.cargo/bin`` to the CONTAINER PATH via
         # apptainer's ``APPTAINERENV_APPEND_PATH`` directive, set on the

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -289,6 +289,28 @@ class TuiSessionRuntime(
             write_redacted_argv(state_dir / "apptainer_run.argv.txt", argv)
             return True
 
+        # OVERLAY VENV INVALIDATION CONTRACT — parity with the SDK runtime (see
+        # ``_apptainer_runtime.start`` for the full why-here). Past the
+        # duplicate-session guard above, so no container of this agent holds the
+        # overlay mounted; past the dry-run return, so ``--dry-run`` mutates
+        # nothing; and BEFORE the entry-point probe below, so that probe
+        # measures the RECONCILED union rather than the stale one.
+        # The SIF is read OUT OF THE LAUNCH ARGV rather than re-resolved. Same
+        # reasoning as ``_entry_point_gate.probe_argv_from_launch``: a second
+        # resolution is free to drift from the one that actually launches, and
+        # reconciling against a DIFFERENT image than the container mounts would
+        # stamp the overlay with an identity it never ran on — which then reads
+        # as reconciled forever. Deriving it makes divergence impossible.
+        from .._maintenance._overlay_venv_invalidate import (
+            reconcile_overlay_venv_for_launch,
+        )
+
+        launch_sif = next((a for a in argv if str(a).endswith(".sif")), None)
+        if launch_sif is not None:
+            reconcile_overlay_venv_for_launch(
+                config, launch_sif, state_dir_for_config(config)
+            )
+
         # The console script must RUN in the union we are about to launch, not
         # merely import in the image. Called after argv exists (so the probe
         # inherits the real overlay) and after the dry-run return (so

--- a/tests/scitex_agent_container/_maintenance/test__overlay_venv_invalidate.py
+++ b/tests/scitex_agent_container/_maintenance/test__overlay_venv_invalidate.py
@@ -1,0 +1,497 @@
+"""The invalidation itself, against a REAL filesystem.
+
+Mirrors ``src/scitex_agent_container/_maintenance/_overlay_venv_invalidate.py``.
+
+Every overlay here is a real directory tree with real ``.dist-info``
+directories, and every SIF is a real file behind a real symlink — because the
+two properties under test are filesystem properties. ``sac-base.sif`` being a
+STABLE symlink is the entire reason the identity cannot be the filename, and no
+amount of faking would have caught keying on the wrong name.
+
+THE ONE SEAM is ``inside_container_fn``. sac's suite runs INSIDE a container, so
+the real detector answers True and every reconcile correctly refuses; without
+the seam the acting path could only ever run on a bare host, i.e. never in CI.
+The refusal path is tested with the REAL detector left in place as well, so the
+seam cannot hide a guard that stopped working.
+
+Nothing here mocks (PA-306): the seam is a one-line real function, and the
+liveness checks use real PIDs of real processes.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+from scitex_agent_container._maintenance import _overlay_venv_invalidate as INV
+from scitex_agent_container._maintenance._overlay_venv_model import (
+    ACTION_INVALIDATE,
+    ACTION_NONE,
+    ACTION_REFUSE,
+)
+
+VENV = "/opt/venv-sac"
+
+#: A frozen clock, so the archive directory name is deterministic. The datetime
+#: is PARSED FROM the expected directory name rather than written twice: the
+#: test asserts the archive lands at exactly this stamp, and two hand-kept
+#: spellings of the same instant is the classic way that assertion starts
+#: passing for the wrong reason.
+ARCHIVE_STAMP = "20260811T063000Z"
+FIXED_NOW = datetime.strptime(ARCHIVE_STAMP, "%Y%m%dT%H%M%SZ").replace(
+    tzinfo=timezone.utc
+)
+
+
+def ON_THE_HOST() -> bool:
+    """The seam, as a real function. Not a mock — it records nothing and makes
+    no assertions about being called; it just answers the question the same way
+    the real detector would on a bare host."""
+    return False
+
+
+def IN_A_CONTAINER() -> bool:
+    """The same seam, answering the way the real detector does inside a SIF."""
+    return True
+
+
+def _sif(tmp_path: Path, target_name: str) -> Path:
+    """A real SIF file behind the stable ``sac-base.sif`` symlink the fleet uses."""
+    containers = tmp_path / "containers"
+    containers.mkdir(exist_ok=True)
+    target = containers / target_name
+    target.write_bytes(b"SIF" + target_name.encode())
+    link = containers / "sac-base.sif"
+    if link.is_symlink() or link.exists():
+        link.unlink()
+    link.symlink_to(target)
+    return link
+
+
+def _overlay(tmp_path: Path, *, with_slice: bool = True) -> Path:
+    """A directory overlay shaped like the fleet's, optionally already shadowing."""
+    root = tmp_path / "overlays" / "agent-x"
+    (root / "upper").mkdir(parents=True, exist_ok=True)
+    (root / "work").mkdir(parents=True, exist_ok=True)
+    if with_slice:
+        site = root / "upper" / VENV.lstrip("/") / "lib/python3.12/site-packages"
+        (site / "scitex_dev-0.38.0.dist-info").mkdir(parents=True)
+        (site / "scitex_dev-0.38.0.dist-info" / "METADATA").write_text(
+            "Name: scitex-dev\n"
+        )
+    return root
+
+
+def _config(overlay_root: Path, **apptainer_extra) -> SimpleNamespace:
+    ap = SimpleNamespace(
+        overlay=str(overlay_root),
+        raw_args=[],
+        image="",
+        overlay_size="",
+        **apptainer_extra,
+    )
+    return SimpleNamespace(
+        apptainer=ap, workdir=str(overlay_root.parent), name="agent-x"
+    )
+
+
+# ---------------------------------------------------------------------------
+# SIF identity — the key is the RESOLVED TARGET, never the symlink's own name
+# ---------------------------------------------------------------------------
+def test_identity_keys_on_the_symlink_target_not_the_symlink_name(tmp_path) -> None:
+    """`sac-base.sif` never changes name, so keying on it could never fail."""
+    # Arrange
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    identity = INV.sif_identity(link)
+    # Assert
+    assert identity.startswith("sac-base-2026-0810-195145.sif:")
+
+
+def test_identity_does_not_contain_the_stable_symlink_name(tmp_path) -> None:
+    """The negative control for the test above — the whole bug in one assert."""
+    # Arrange
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    identity = INV.sif_identity(link)
+    # Assert
+    assert not identity.startswith("sac-base.sif:")
+
+
+def test_repointing_the_symlink_changes_the_identity(tmp_path) -> None:
+    """This IS an image rebuild, as the fleet performs it."""
+    # Arrange
+    before = INV.sif_identity(_sif(tmp_path, "sac-base-2026-0810-195145.sif"))
+    # Act
+    after = INV.sif_identity(_sif(tmp_path, "sac-base-2026-0811-071500.sif"))
+    # Assert
+    assert before != after
+
+
+def test_an_unresolvable_image_has_no_identity(tmp_path) -> None:
+    """Empty, so the predicate reports UNKNOWN and refuses rather than guesses."""
+    # Arrange
+    missing = tmp_path / "containers" / "gone.sif"
+    # Act
+    identity = INV.sif_identity(missing)
+    # Assert
+    assert identity == ""
+
+
+def test_a_dangling_symlink_has_no_identity(tmp_path) -> None:
+    """A half-finished rebuild must not be mistaken for a valid new image."""
+    # Arrange
+    link = tmp_path / "dangling.sif"
+    link.symlink_to(tmp_path / "never-built.sif")
+    # Act
+    identity = INV.sif_identity(link)
+    # Assert
+    assert identity == ""
+
+
+# ---------------------------------------------------------------------------
+# The stamp
+# ---------------------------------------------------------------------------
+def test_an_unstamped_overlay_reads_as_empty_not_unreadable(tmp_path) -> None:
+    # Arrange
+    root = _overlay(tmp_path)
+    # Act
+    recorded = INV.read_stamp(root)
+    # Assert
+    assert recorded == ""
+
+
+def test_a_written_stamp_reads_back(tmp_path) -> None:
+    # Arrange
+    root = _overlay(tmp_path)
+    # Act
+    INV.write_stamp(root, "sac-base-2026-0810.sif:1:2")
+    # Assert
+    assert INV.read_stamp(root) == "sac-base-2026-0810.sif:1:2"
+
+
+def test_the_stamp_lives_outside_the_upper_layer(tmp_path) -> None:
+    """Inside ``upper/`` the agent could clobber its own invalidation stamp."""
+    # Arrange
+    root = _overlay(tmp_path)
+    # Act
+    path = INV.stamp_path(root)
+    # Assert
+    assert path.parent == root
+
+
+# ---------------------------------------------------------------------------
+# Liveness — real PIDs, no fakes
+# ---------------------------------------------------------------------------
+def test_a_missing_pid_file_reads_as_not_running(tmp_path) -> None:
+    """The state a clean stop leaves behind, and a first start begins in."""
+    # Arrange
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    # Act
+    running = INV.agent_running_from_state_dir(state_dir)
+    # Assert
+    assert running is False
+
+
+def test_a_live_pid_reads_as_running(tmp_path) -> None:
+    """Uses THIS process — a real, certainly-alive pid."""
+    # Arrange
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "pid").write_text(f"{os.getpid()}\n")
+    # Act
+    running = INV.agent_running_from_state_dir(state_dir)
+    # Assert
+    assert running is True
+
+
+def test_an_unparseable_pid_file_reads_as_unknown(tmp_path) -> None:
+    """A file that exists and cannot be parsed is a question, not an answer."""
+    # Arrange
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "pid").write_text("not-a-pid\n")
+    # Act
+    running = INV.agent_running_from_state_dir(state_dir)
+    # Assert
+    assert running is None
+
+
+def test_a_plain_directory_is_not_a_live_overlay_mount(tmp_path) -> None:
+    """Reads the REAL /proc/self/mountinfo — a tmp_path overlay is not mounted."""
+    # Arrange
+    root = _overlay(tmp_path)
+    # Act
+    mounted = INV.upper_mounted_here(root)
+    # Assert
+    assert mounted is False
+
+
+# ---------------------------------------------------------------------------
+# The mutation — move aside, never delete
+# ---------------------------------------------------------------------------
+def test_a_stale_overlay_is_invalidated(tmp_path) -> None:
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    plan = INV.reconcile_overlay_venv(
+        _config(root), link, agent_running=False, inside_container_fn=ON_THE_HOST
+    )
+    # Assert
+    assert plan.action == ACTION_INVALIDATE
+
+
+def test_the_stale_slice_leaves_the_upper_layer(tmp_path) -> None:
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    INV.reconcile_overlay_venv(
+        _config(root), link, agent_running=False, inside_container_fn=ON_THE_HOST
+    )
+    # Assert
+    assert not (root / "upper" / VENV.lstrip("/")).exists()
+
+
+def test_nothing_is_deleted_only_moved(tmp_path) -> None:
+    """The standing fleet rule, and what keeps a wrong prune recoverable."""
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    INV.reconcile_overlay_venv(
+        _config(root),
+        link,
+        agent_running=False,
+        now=FIXED_NOW,
+        inside_container_fn=ON_THE_HOST,
+    )
+    # Assert
+    assert (
+        root
+        / ".old"
+        / ARCHIVE_STAMP
+        / "upper"
+        / VENV.lstrip("/")
+        / "lib/python3.12/site-packages/scitex_dev-0.38.0.dist-info/METADATA"
+    ).is_file()
+
+
+def test_the_archive_sits_outside_the_upper_layer(tmp_path) -> None:
+    """Inside ``upper/`` the archived tree would still be in the container's view."""
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    INV.reconcile_overlay_venv(
+        _config(root),
+        link,
+        agent_running=False,
+        now=FIXED_NOW,
+        inside_container_fn=ON_THE_HOST,
+    )
+    # Assert
+    assert not (root / "upper" / ".old").exists()
+
+
+def test_invalidating_records_the_new_image_identity(tmp_path) -> None:
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    INV.reconcile_overlay_venv(
+        _config(root), link, agent_running=False, inside_container_fn=ON_THE_HOST
+    )
+    # Assert
+    assert INV.read_stamp(root) == INV.sif_identity(link)
+
+
+def test_a_second_start_on_the_same_image_is_a_no_op(tmp_path) -> None:
+    """Idempotent: the contract fires on CHANGE, not on every boot."""
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    INV.reconcile_overlay_venv(
+        _config(root), link, agent_running=False, inside_container_fn=ON_THE_HOST
+    )
+    # Act
+    plan = INV.reconcile_overlay_venv(
+        _config(root), link, agent_running=False, inside_container_fn=ON_THE_HOST
+    )
+    # Assert
+    assert plan.action == ACTION_NONE
+
+
+def test_a_rebuilt_image_invalidates_again(tmp_path) -> None:
+    """The contract in one test: rebuild the image, the overlay's venv goes."""
+    # Arrange
+    root = _overlay(tmp_path)
+    old = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    INV.reconcile_overlay_venv(
+        _config(root), old, agent_running=False, inside_container_fn=ON_THE_HOST
+    )
+    site = root / "upper" / VENV.lstrip("/") / "lib/python3.12/site-packages"
+    (site / "scitex_dev-0.39.0.dist-info").mkdir(parents=True)
+    # Act
+    new = _sif(tmp_path, "sac-base-2026-0811-071500.sif")
+    plan = INV.reconcile_overlay_venv(
+        _config(root), new, agent_running=False, inside_container_fn=ON_THE_HOST
+    )
+    # Assert
+    assert plan.action == ACTION_INVALIDATE
+
+
+def test_an_overlay_with_no_venv_slice_is_left_alone(tmp_path) -> None:
+    # Arrange
+    root = _overlay(tmp_path, with_slice=False)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    plan = INV.reconcile_overlay_venv(
+        _config(root), link, agent_running=False, inside_container_fn=ON_THE_HOST
+    )
+    # Assert
+    assert plan.action == ACTION_NONE
+
+
+# ---------------------------------------------------------------------------
+# Refusals — the guard, with the REAL detector where it can be used
+# ---------------------------------------------------------------------------
+def test_a_running_agent_is_refused(tmp_path) -> None:
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    plan = INV.reconcile_overlay_venv(
+        _config(root), link, agent_running=True, inside_container_fn=ON_THE_HOST
+    )
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_a_refused_overlay_keeps_its_venv_slice(tmp_path) -> None:
+    """A refusal must change nothing at all, not merely skip the log line."""
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    INV.reconcile_overlay_venv(
+        _config(root), link, agent_running=True, inside_container_fn=ON_THE_HOST
+    )
+    # Assert
+    assert (root / "upper" / VENV.lstrip("/")).is_dir()
+
+
+def test_a_refusal_does_not_advance_the_stamp(tmp_path) -> None:
+    """Otherwise the NEXT boot reads 'fresh' and the refusal became a pass."""
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    INV.reconcile_overlay_venv(
+        _config(root), link, agent_running=True, inside_container_fn=ON_THE_HOST
+    )
+    # Assert
+    assert INV.read_stamp(root) == ""
+
+
+def test_unmeasured_liveness_is_refused(tmp_path) -> None:
+    """A caller that did not answer the question does not get the mutation."""
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    plan = INV.reconcile_overlay_venv(
+        _config(root), link, agent_running=None, inside_container_fn=ON_THE_HOST
+    )
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_an_unresolvable_image_is_refused(tmp_path) -> None:
+    # Arrange
+    root = _overlay(tmp_path)
+    missing = tmp_path / "containers" / "never-built.sif"
+    # Act
+    plan = INV.reconcile_overlay_venv(
+        _config(root), missing, agent_running=False, inside_container_fn=ON_THE_HOST
+    )
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_a_declared_container_context_is_refused(tmp_path) -> None:
+    """The whiteout guard, exercised through the same seam in the True direction."""
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    plan = INV.reconcile_overlay_venv(
+        _config(root), link, agent_running=False, inside_container_fn=IN_A_CONTAINER
+    )
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_the_real_detector_sees_this_container(tmp_path) -> None:
+    """POSITIVE CONTROL for the seam: the suite runs inside a SIF, so the real
+    detector must say so. If this ever flips to False the seam is masking a
+    detector that stopped working, and every refusal test above goes hollow.
+    """
+    # Arrange
+    env_says = bool(
+        os.environ.get("APPTAINER_CONTAINER") or os.environ.get("SINGULARITY_CONTAINER")
+    )
+    marker = Path("/.singularity.d").is_dir()
+    # Act
+    detected = INV.inside_container()
+    # Assert
+    assert detected == (env_says or marker)
+
+
+# ---------------------------------------------------------------------------
+# Out of scope — the contract simply does not apply
+# ---------------------------------------------------------------------------
+def test_an_agent_with_no_overlay_is_out_of_scope(tmp_path) -> None:
+    # Arrange
+    config = SimpleNamespace(
+        apptainer=SimpleNamespace(overlay="", raw_args=[], image="", overlay_size=""),
+        workdir=str(tmp_path),
+        name="agent-x",
+    )
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    plan = INV.reconcile_overlay_venv(
+        config, link, agent_running=False, inside_container_fn=ON_THE_HOST
+    )
+    # Assert
+    assert plan is None
+
+
+def test_a_loopback_image_overlay_is_out_of_scope(tmp_path) -> None:
+    """Its upper layer is not host-readable, so it cannot be invalidated here."""
+    # Arrange
+    root = _overlay(tmp_path)
+    config = _config(root)
+    config.apptainer.overlay_size = "5G"
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    plan = INV.reconcile_overlay_venv(
+        config, link, agent_running=False, inside_container_fn=ON_THE_HOST
+    )
+    # Assert
+    assert plan is None
+
+
+def test_the_launch_wrapper_never_raises_on_a_broken_config(tmp_path) -> None:
+    """A bug in this rail must not refuse every start on the host."""
+    # Arrange
+    broken = SimpleNamespace(name="agent-x")  # no .apptainer, no .workdir
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    plan = INV.reconcile_overlay_venv_for_launch(broken, link, tmp_path / "state")
+    # Assert
+    assert plan is None

--- a/tests/scitex_agent_container/_maintenance/test__overlay_venv_invalidate.py
+++ b/tests/scitex_agent_container/_maintenance/test__overlay_venv_invalidate.py
@@ -57,6 +57,30 @@ def IN_A_CONTAINER() -> bool:
     return True
 
 
+#: How many times the base probe was invoked. A module-level counter rather than
+#: a mock's call log: the laziness of the probe is a REAL property worth pinning
+#: (it costs an `apptainer exec`), and counting is the whole of what we need.
+_base_probe_calls: list[tuple[str, str]] = []
+
+
+def BASE_POPULATED(sif, venv):
+    """Base-probe seam: the image ships a populated venv (the healthy fleet)."""
+    _base_probe_calls.append((str(sif), venv))
+    return True
+
+
+def BASE_EMPTY(sif, venv):
+    """Base-probe seam: the image has NO venv to fall back on."""
+    _base_probe_calls.append((str(sif), venv))
+    return False
+
+
+def BASE_UNREADABLE(sif, venv):
+    """Base-probe seam: the probe could not run — UNKNOWN, never a verdict."""
+    _base_probe_calls.append((str(sif), venv))
+    return None
+
+
 def _sif(tmp_path: Path, target_name: str) -> Path:
     """A real SIF file behind the stable ``sac-base.sif`` symlink the fleet uses."""
     containers = tmp_path / "containers"
@@ -239,7 +263,11 @@ def test_a_stale_overlay_is_invalidated(tmp_path) -> None:
     link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
     # Act
     plan = INV.reconcile_overlay_venv(
-        _config(root), link, agent_running=False, inside_container_fn=ON_THE_HOST
+        _config(root),
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert plan.action == ACTION_INVALIDATE
@@ -251,7 +279,11 @@ def test_the_stale_slice_leaves_the_upper_layer(tmp_path) -> None:
     link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
     # Act
     INV.reconcile_overlay_venv(
-        _config(root), link, agent_running=False, inside_container_fn=ON_THE_HOST
+        _config(root),
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert not (root / "upper" / VENV.lstrip("/")).exists()
@@ -269,6 +301,7 @@ def test_nothing_is_deleted_only_moved(tmp_path) -> None:
         agent_running=False,
         now=FIXED_NOW,
         inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert (
@@ -293,6 +326,7 @@ def test_the_archive_sits_outside_the_upper_layer(tmp_path) -> None:
         agent_running=False,
         now=FIXED_NOW,
         inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert not (root / "upper" / ".old").exists()
@@ -304,7 +338,11 @@ def test_invalidating_records_the_new_image_identity(tmp_path) -> None:
     link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
     # Act
     INV.reconcile_overlay_venv(
-        _config(root), link, agent_running=False, inside_container_fn=ON_THE_HOST
+        _config(root),
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert INV.read_stamp(root) == INV.sif_identity(link)
@@ -316,11 +354,19 @@ def test_a_second_start_on_the_same_image_is_a_no_op(tmp_path) -> None:
     root = _overlay(tmp_path)
     link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
     INV.reconcile_overlay_venv(
-        _config(root), link, agent_running=False, inside_container_fn=ON_THE_HOST
+        _config(root),
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Act
     plan = INV.reconcile_overlay_venv(
-        _config(root), link, agent_running=False, inside_container_fn=ON_THE_HOST
+        _config(root),
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert plan.action == ACTION_NONE
@@ -332,14 +378,22 @@ def test_a_rebuilt_image_invalidates_again(tmp_path) -> None:
     root = _overlay(tmp_path)
     old = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
     INV.reconcile_overlay_venv(
-        _config(root), old, agent_running=False, inside_container_fn=ON_THE_HOST
+        _config(root),
+        old,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     site = root / "upper" / VENV.lstrip("/") / "lib/python3.12/site-packages"
     (site / "scitex_dev-0.39.0.dist-info").mkdir(parents=True)
     # Act
     new = _sif(tmp_path, "sac-base-2026-0811-071500.sif")
     plan = INV.reconcile_overlay_venv(
-        _config(root), new, agent_running=False, inside_container_fn=ON_THE_HOST
+        _config(root),
+        new,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert plan.action == ACTION_INVALIDATE
@@ -351,7 +405,11 @@ def test_an_overlay_with_no_venv_slice_is_left_alone(tmp_path) -> None:
     link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
     # Act
     plan = INV.reconcile_overlay_venv(
-        _config(root), link, agent_running=False, inside_container_fn=ON_THE_HOST
+        _config(root),
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert plan.action == ACTION_NONE
@@ -366,7 +424,11 @@ def test_a_running_agent_is_refused(tmp_path) -> None:
     link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
     # Act
     plan = INV.reconcile_overlay_venv(
-        _config(root), link, agent_running=True, inside_container_fn=ON_THE_HOST
+        _config(root),
+        link,
+        agent_running=True,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert plan.action == ACTION_REFUSE
@@ -379,7 +441,11 @@ def test_a_refused_overlay_keeps_its_venv_slice(tmp_path) -> None:
     link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
     # Act
     INV.reconcile_overlay_venv(
-        _config(root), link, agent_running=True, inside_container_fn=ON_THE_HOST
+        _config(root),
+        link,
+        agent_running=True,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert (root / "upper" / VENV.lstrip("/")).is_dir()
@@ -392,7 +458,11 @@ def test_a_refusal_does_not_advance_the_stamp(tmp_path) -> None:
     link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
     # Act
     INV.reconcile_overlay_venv(
-        _config(root), link, agent_running=True, inside_container_fn=ON_THE_HOST
+        _config(root),
+        link,
+        agent_running=True,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert INV.read_stamp(root) == ""
@@ -405,7 +475,11 @@ def test_unmeasured_liveness_is_refused(tmp_path) -> None:
     link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
     # Act
     plan = INV.reconcile_overlay_venv(
-        _config(root), link, agent_running=None, inside_container_fn=ON_THE_HOST
+        _config(root),
+        link,
+        agent_running=None,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert plan.action == ACTION_REFUSE
@@ -417,7 +491,11 @@ def test_an_unresolvable_image_is_refused(tmp_path) -> None:
     missing = tmp_path / "containers" / "never-built.sif"
     # Act
     plan = INV.reconcile_overlay_venv(
-        _config(root), missing, agent_running=False, inside_container_fn=ON_THE_HOST
+        _config(root),
+        missing,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert plan.action == ACTION_REFUSE
@@ -430,7 +508,11 @@ def test_a_declared_container_context_is_refused(tmp_path) -> None:
     link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
     # Act
     plan = INV.reconcile_overlay_venv(
-        _config(root), link, agent_running=False, inside_container_fn=IN_A_CONTAINER
+        _config(root),
+        link,
+        agent_running=False,
+        inside_container_fn=IN_A_CONTAINER,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert plan.action == ACTION_REFUSE
@@ -453,6 +535,119 @@ def test_the_real_detector_sees_this_container(tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# The lower layer must be there BEFORE we move the upper's copy away
+# ---------------------------------------------------------------------------
+def test_an_empty_image_venv_is_refused(tmp_path) -> None:
+    """Moving the slice aside only UNHIDES the image's copy; it makes none."""
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    plan = INV.reconcile_overlay_venv(
+        _config(root),
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_EMPTY,
+    )
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_an_empty_image_venv_leaves_the_slice_in_place(tmp_path) -> None:
+    """The slice is the agent's ONLY venv here — moving it would kill it."""
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    INV.reconcile_overlay_venv(
+        _config(root),
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_EMPTY,
+    )
+    # Assert
+    assert (root / "upper" / VENV.lstrip("/")).is_dir()
+
+
+def test_an_unreadable_image_venv_is_refused(tmp_path) -> None:
+    """A probe that could not run is UNKNOWN, and UNKNOWN never moves files."""
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    # Act
+    plan = INV.reconcile_overlay_venv(
+        _config(root),
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_UNREADABLE,
+    )
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_the_image_is_not_probed_when_nothing_would_move(tmp_path) -> None:
+    """The probe costs an `apptainer exec`; an ordinary boot must not pay it."""
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    INV.reconcile_overlay_venv(
+        _config(root),
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
+    )
+    _base_probe_calls.clear()
+    # Act
+    INV.reconcile_overlay_venv(  # second start, same image — already reconciled
+        _config(root),
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
+    )
+    # Assert
+    assert _base_probe_calls == []
+
+
+def test_the_image_is_probed_when_a_move_is_proposed(tmp_path) -> None:
+    """Negative control for the laziness test above — it must fire when it matters."""
+    # Arrange
+    root = _overlay(tmp_path)
+    link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
+    _base_probe_calls.clear()
+    # Act
+    INV.reconcile_overlay_venv(
+        _config(root),
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
+    )
+    # Assert
+    assert len(_base_probe_calls) == 1
+
+
+def test_the_real_base_probe_reports_unknown_for_a_non_image(tmp_path) -> None:
+    """A file that is not a SIF cannot answer, and must not answer 'fine'.
+
+    Runs the REAL probe (a real `apptainer exec` attempt against a real file
+    that is not an image) rather than a seam — the seam proves the wiring, this
+    proves the probe itself refuses to invent an answer.
+    """
+    # Arrange
+    not_an_image = tmp_path / "definitely-not.sif"
+    not_an_image.write_bytes(b"not a squashfs")
+    # Act
+    answer = INV.base_provides_venv(not_an_image)
+    # Assert
+    assert answer is None
+
+
+# ---------------------------------------------------------------------------
 # Out of scope — the contract simply does not apply
 # ---------------------------------------------------------------------------
 def test_an_agent_with_no_overlay_is_out_of_scope(tmp_path) -> None:
@@ -465,7 +660,11 @@ def test_an_agent_with_no_overlay_is_out_of_scope(tmp_path) -> None:
     link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
     # Act
     plan = INV.reconcile_overlay_venv(
-        config, link, agent_running=False, inside_container_fn=ON_THE_HOST
+        config,
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert plan is None
@@ -480,7 +679,11 @@ def test_a_loopback_image_overlay_is_out_of_scope(tmp_path) -> None:
     link = _sif(tmp_path, "sac-base-2026-0810-195145.sif")
     # Act
     plan = INV.reconcile_overlay_venv(
-        config, link, agent_running=False, inside_container_fn=ON_THE_HOST
+        config,
+        link,
+        agent_running=False,
+        inside_container_fn=ON_THE_HOST,
+        base_probe=BASE_POPULATED,
     )
     # Assert
     assert plan is None

--- a/tests/scitex_agent_container/_maintenance/test__overlay_venv_model.py
+++ b/tests/scitex_agent_container/_maintenance/test__overlay_venv_model.py
@@ -1,0 +1,219 @@
+"""Three-valued vocabulary for the overlay-venv contract.
+
+Mirrors ``src/scitex_agent_container/_maintenance/_overlay_venv_model.py``.
+
+The load-bearing property is that UNKNOWN is a THIRD state, never a shade of
+pass. Every test here pins one half of that: a check cannot claim a non-pass
+without saying what to do about it, and a plan cannot resolve to a mutation
+while any question is still open.
+
+Read ``test_an_unknown_refuses_the_mutation_as_firmly_as_a_failure`` together
+with ``test_a_safe_stale_overlay_with_a_venv_slice_invalidates``: identical
+staleness, opposite actions, and the only difference is whether a question was
+answered. They are separate functions only because one assertion per test is
+required.
+
+Pure dataclasses, so no filesystem and no mocks (PA-306) — there is nothing to
+mock, the types take plain values.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._maintenance._overlay_venv_model import (
+    ACTION_INVALIDATE,
+    ACTION_NONE,
+    ACTION_REFUSE,
+    InvalidationPlan,
+    VenvCheck,
+)
+
+PASS = VenvCheck(name="a", ok=True, detail="fine")
+FAIL = VenvCheck(name="b", ok=False, detail="broken", hint="fix it")
+UNKNOWN = VenvCheck(name="c", ok=None, detail="unmeasured", hint="measure it")
+
+
+def test_failing_check_without_a_hint_is_rejected() -> None:
+    """An error that only says what broke is half-written."""
+    # Arrange
+    kwargs = {"name": "x", "ok": False, "detail": "broken"}
+    # Act
+    act = lambda: VenvCheck(**kwargs)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError, match="hint"):
+        act()
+
+
+def test_unknown_check_without_a_hint_is_rejected() -> None:
+    """UNKNOWN must prescribe 'go measure it', not merely report silence."""
+    # Arrange
+    kwargs = {"name": "x", "ok": None, "detail": "unmeasured"}
+    # Act
+    act = lambda: VenvCheck(**kwargs)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError, match="hint"):
+        act()
+
+
+def test_passing_check_needs_no_hint() -> None:
+    # Arrange
+    name = "x"
+    # Act
+    check = VenvCheck(name=name, ok=True, detail="fine")
+    # Assert
+    assert check.hint == ""
+
+
+def test_check_rejects_a_non_three_valued_ok() -> None:
+    # Arrange
+    kwargs = {"name": "x", "ok": "yes", "detail": "fine"}
+    # Act
+    act = lambda: VenvCheck(**kwargs)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError, match="True/False/None"):
+        act()
+
+
+def test_plan_with_only_passes_is_safe() -> None:
+    # Arrange
+    checks = (PASS,)
+    # Act
+    plan = InvalidationPlan(agent="a", overlay_root="/o", checks=checks)
+    # Assert
+    assert plan.safe is True
+
+
+def test_plan_with_a_failure_is_unsafe() -> None:
+    # Arrange
+    checks = (PASS, FAIL)
+    # Act
+    plan = InvalidationPlan(agent="a", overlay_root="/o", checks=checks)
+    # Assert
+    assert plan.safe is False
+
+
+def test_plan_with_an_unknown_is_neither_safe_nor_unsafe() -> None:
+    """The whole point: 'could not tell' is not 'it was fine'."""
+    # Arrange
+    checks = (PASS, UNKNOWN)
+    # Act
+    plan = InvalidationPlan(agent="a", overlay_root="/o", checks=checks)
+    # Assert
+    assert plan.safe is None
+
+
+def test_unknowns_are_reported_separately_from_failures() -> None:
+    """A reader must be able to tell 'this is wrong' from 'I could not tell'."""
+    # Arrange
+    checks = (FAIL, UNKNOWN)
+    # Act
+    plan = InvalidationPlan(agent="a", overlay_root="/o", checks=checks)
+    # Assert
+    assert (plan.failed, plan.unknown) == ((FAIL,), (UNKNOWN,))
+
+
+def test_an_unknown_refuses_the_mutation_as_firmly_as_a_failure() -> None:
+    """Folding 'could not read' into 'fine' is the bug class this rail closes."""
+    # Arrange
+    checks = (UNKNOWN,)
+    # Act
+    plan = InvalidationPlan(
+        agent="a",
+        overlay_root="/o",
+        checks=checks,
+        stale=True,
+        venv_slice_present=True,
+    )
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_a_failure_refuses_the_mutation() -> None:
+    # Arrange
+    checks = (FAIL,)
+    # Act
+    plan = InvalidationPlan(
+        agent="a",
+        overlay_root="/o",
+        checks=checks,
+        stale=True,
+        venv_slice_present=True,
+    )
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_a_safe_stale_overlay_with_a_venv_slice_invalidates() -> None:
+    # Arrange
+    checks = (PASS,)
+    # Act
+    plan = InvalidationPlan(
+        agent="a",
+        overlay_root="/o",
+        checks=checks,
+        stale=True,
+        venv_slice_present=True,
+    )
+    # Assert
+    assert plan.action == ACTION_INVALIDATE
+
+
+def test_a_safe_stale_overlay_with_no_venv_slice_does_nothing() -> None:
+    """Nothing to shadow with, so nothing to move — but still not a refusal."""
+    # Arrange
+    checks = (PASS,)
+    # Act
+    plan = InvalidationPlan(
+        agent="a",
+        overlay_root="/o",
+        checks=checks,
+        stale=True,
+        venv_slice_present=False,
+    )
+    # Assert
+    assert plan.action == ACTION_NONE
+
+
+def test_a_safe_fresh_overlay_does_nothing() -> None:
+    # Arrange
+    checks = (PASS,)
+    # Act
+    plan = InvalidationPlan(
+        agent="a",
+        overlay_root="/o",
+        checks=checks,
+        stale=False,
+        venv_slice_present=True,
+    )
+    # Assert
+    assert plan.action == ACTION_NONE
+
+
+def test_blocking_reasons_carry_the_hint_not_only_the_complaint() -> None:
+    # Arrange
+    checks = (FAIL,)
+    # Act
+    plan = InvalidationPlan(agent="a", overlay_root="/o", checks=checks)
+    # Assert
+    assert plan.blocking_reasons() == ("b: broken -> fix it",)
+
+
+def test_blocking_reasons_are_empty_on_a_clean_plan() -> None:
+    # Arrange
+    checks = (PASS,)
+    # Act
+    plan = InvalidationPlan(agent="a", overlay_root="/o", checks=checks)
+    # Assert
+    assert plan.blocking_reasons() == ()
+
+
+def test_plan_requires_an_agent_name() -> None:
+    """An anonymous refusal is unactionable — the log line must name someone."""
+    # Arrange
+    kwargs = {"agent": "", "overlay_root": "/o"}
+    # Act
+    act = lambda: InvalidationPlan(**kwargs)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError, match="agent"):
+        act()

--- a/tests/scitex_agent_container/_maintenance/test__overlay_venv_predicate.py
+++ b/tests/scitex_agent_container/_maintenance/test__overlay_venv_predicate.py
@@ -1,0 +1,230 @@
+"""Every way the invalidation must refuse, and the one way it must act.
+
+Mirrors ``src/scitex_agent_container/_maintenance/_overlay_venv_predicate.py``.
+
+The suite is deliberately lopsided: fourteen refusals to one action. That is the
+right shape for a rail whose mutation renames a directory tree — the interesting
+question is never "does it fire?" but "does it stay its hand when it does not
+know?".
+
+``SAFE`` below is the all-questions-answered baseline; each test perturbs
+exactly one fact. The UNKNOWN cases (``None``) and the negative cases (``True``
+for a hazard) are tested separately on purpose: they arrive by different routes
+— a probe that could not run vs a probe that ran and found the hazard — and a
+predicate that could not distinguish them would be reporting a guess.
+
+Pure facts in, checks out, so no filesystem, no apptainer, no root and no mocks
+(PA-306) — which is exactly what makes the live-mount refusal testable at all.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._maintenance._overlay_venv_model import (
+    ACTION_INVALIDATE,
+    ACTION_NONE,
+    ACTION_REFUSE,
+    CHECK_AGENT_NOT_RUNNING,
+    CHECK_NOT_INSIDE_CONTAINER,
+    OverlayVenvFacts,
+)
+from scitex_agent_container._maintenance._overlay_venv_predicate import (
+    plan_invalidation,
+)
+
+#: Every question answered, image changed, a venv slice present to move.
+SAFE = OverlayVenvFacts(
+    sif_identity="sac-base-2026-0810-195145.sif:100:7",
+    recorded_identity="sac-base-2026-0731-101010.sif:99:6",
+    venv_slice_present=True,
+    inside_container=False,
+    agent_running=False,
+    upper_mounted_here=False,
+)
+
+
+def _plan(**overrides):
+    facts = OverlayVenvFacts(**{**vars(SAFE), **overrides})
+    return plan_invalidation(agent="a", overlay_root="/o", facts=facts)
+
+
+def test_a_fully_observed_stale_overlay_invalidates() -> None:
+    """The one case that acts. Everything else in this file refuses."""
+    # Arrange
+    facts = SAFE
+    # Act
+    plan = plan_invalidation(agent="a", overlay_root="/o", facts=facts)
+    # Assert
+    assert plan.action == ACTION_INVALIDATE
+
+
+def test_running_inside_a_container_refuses() -> None:
+    """From inside, a rename becomes a whiteout that masks the SIF's own files."""
+    # Arrange
+    override = {"inside_container": True}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_the_inside_container_refusal_names_the_whiteout_hazard() -> None:
+    """The refusal has to teach, or the next person works around it."""
+    # Arrange
+    override = {"inside_container": True}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert "WHITEOUT" in " ".join(plan.blocking_reasons())
+
+
+def test_unobserved_container_membership_refuses() -> None:
+    # Arrange
+    override = {"inside_container": None}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_a_running_agent_refuses() -> None:
+    """A live agent's container holds the overlay mounted."""
+    # Arrange
+    override = {"agent_running": True}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_unobserved_agent_liveness_refuses() -> None:
+    """The caller that did not measure liveness must not get a mutation."""
+    # Arrange
+    override = {"agent_running": None}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_an_overlay_mounted_in_this_namespace_refuses() -> None:
+    # Arrange
+    override = {"upper_mounted_here": True}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_an_unreadable_mount_table_refuses() -> None:
+    """'I could not read /proc' is not 'nothing is mounted'."""
+    # Arrange
+    override = {"upper_mounted_here": None}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_unobserved_sif_identity_refuses() -> None:
+    # Arrange
+    override = {"sif_identity": None}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_an_unresolvable_image_refuses() -> None:
+    """Observed-and-empty is still no answer: comparing against "" is a coin flip."""
+    # Arrange
+    override = {"sif_identity": ""}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_an_unreadable_stamp_refuses() -> None:
+    """An unreadable stamp is NOT an unstamped overlay — one authorises a move."""
+    # Arrange
+    override = {"recorded_identity": None}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_an_unreadable_upper_layer_refuses() -> None:
+    # Arrange
+    override = {"venv_slice_present": None}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_a_never_stamped_overlay_is_stale() -> None:
+    """The fleet's day-one state: no stamp anywhere, and every overlay shadowing.
+
+    An empty stamp must NOT be adopted as "matches whatever is mounted now" —
+    that would make this rail a no-op on exactly the 2026-08-11 population it
+    was built for.
+    """
+    # Arrange
+    override = {"recorded_identity": ""}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_INVALIDATE
+
+
+def test_a_matching_stamp_does_nothing() -> None:
+    # Arrange
+    override = {"recorded_identity": SAFE.sif_identity}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_NONE
+
+
+def test_a_stale_overlay_with_no_venv_slice_does_nothing() -> None:
+    """Nothing in the upper to shadow with, so the image already wins."""
+    # Arrange
+    override = {"venv_slice_present": False}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_NONE
+
+
+def test_the_safety_checks_precede_the_staleness_checks() -> None:
+    """A report read top-down leads with 'may I act', never 'should I act'."""
+    # Arrange
+    facts = SAFE
+    # Act
+    plan = plan_invalidation(agent="a", overlay_root="/o", facts=facts)
+    # Assert
+    assert [c.name for c in plan.checks[:2]] == [
+        CHECK_NOT_INSIDE_CONTAINER,
+        CHECK_AGENT_NOT_RUNNING,
+    ]
+
+
+def test_every_reason_is_reported_not_just_the_first() -> None:
+    """An operator asking 'why not?' needs every answer in one run."""
+    # Arrange
+    override = {"inside_container": True, "agent_running": True}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert len(plan.blocking_reasons()) == 2
+
+
+def test_staleness_is_reported_honestly_even_when_refusing() -> None:
+    """A silent ``stale=False`` would later be misread as 'checked, and fresh'."""
+    # Arrange
+    override = {"inside_container": True}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.stale is True

--- a/tests/scitex_agent_container/_maintenance/test__overlay_venv_predicate.py
+++ b/tests/scitex_agent_container/_maintenance/test__overlay_venv_predicate.py
@@ -31,7 +31,8 @@ from scitex_agent_container._maintenance._overlay_venv_predicate import (
     plan_invalidation,
 )
 
-#: Every question answered, image changed, a venv slice present to move.
+#: Every question answered, image changed, a venv slice present to move, and a
+#: populated lower layer to fall back on once it is moved.
 SAFE = OverlayVenvFacts(
     sif_identity="sac-base-2026-0810-195145.sif:100:7",
     recorded_identity="sac-base-2026-0731-101010.sif:99:6",
@@ -39,6 +40,7 @@ SAFE = OverlayVenvFacts(
     inside_container=False,
     agent_running=False,
     upper_mounted_here=False,
+    base_provides_venv=True,
 )
 
 
@@ -218,6 +220,69 @@ def test_every_reason_is_reported_not_just_the_first() -> None:
     plan = _plan(**override)
     # Assert
     assert len(plan.blocking_reasons()) == 2
+
+
+def test_an_empty_lower_layer_refuses_the_move() -> None:
+    """The move only UNHIDES the image's copy; it does not create one.
+
+    With nothing behind the slice, moving it aside leaves the agent with no venv
+    at all — this rail's own repair turning a shadowed-but-working container
+    into a dead one, which is worse than the bug.
+    """
+    # Arrange
+    override = {"base_provides_venv": False}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_an_unprobed_lower_layer_refuses_the_move() -> None:
+    """ "I could not read the image" is not "the image is fine"."""
+    # Arrange
+    override = {"base_provides_venv": None}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_REFUSE
+
+
+def test_the_lower_layer_refusal_says_the_slice_is_the_only_copy() -> None:
+    """The hint has to stop someone 'fixing' it by moving the slice by hand."""
+    # Arrange
+    override = {"base_provides_venv": False}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert "only copy" in " ".join(plan.blocking_reasons())
+
+
+def test_a_fresh_overlay_does_not_need_the_lower_layer_probed() -> None:
+    """The probe costs an `apptainer exec`, and it is a precondition for MOVING.
+
+    Not consulting a precondition for an action you are not taking is a pass,
+    not an unknown — otherwise every ordinary boot would refuse and pay for an
+    image probe it had no use for.
+    """
+    # Arrange
+    override = {
+        "recorded_identity": SAFE.sif_identity,
+        "base_provides_venv": None,
+    }
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_NONE
+
+
+def test_an_overlay_with_no_slice_does_not_need_the_lower_layer_probed() -> None:
+    """Same rule from the other direction: nothing to move, nothing to check."""
+    # Arrange
+    override = {"venv_slice_present": False, "base_provides_venv": None}
+    # Act
+    plan = _plan(**override)
+    # Assert
+    assert plan.action == ACTION_NONE
 
 
 def test_staleness_is_reported_honestly_even_when_refusing() -> None:

--- a/tests/scitex_agent_container/_maintenance/test__venv_dist_assertion.py
+++ b/tests/scitex_agent_container/_maintenance/test__venv_dist_assertion.py
@@ -1,0 +1,336 @@
+"""The boot assertion, and the measurement that decides how it is built.
+
+Mirrors ``src/scitex_agent_container/_maintenance/_venv_dist_assertion.py``.
+
+THE FIRST TWO TESTS ARE THE IMPORTANT ONES.
+``test_distributions_sees_both_dist_infos`` and
+``test_entry_points_cannot_see_a_duplicate_distribution`` are ONE measurement,
+split only because one assertion per test is required — read them together.
+Same fixture, same interpreter, two stdlib APIs, different answers:
+``distributions()`` reports TWO while ``entry_points()`` dedupes by normalised
+name and reports ONE. A gate built on ``entry_points()`` is therefore green
+while the venv is broken — a gate that cannot fail, which is worse than no gate
+because the config still lists it.
+
+That is not a claim inherited from a docstring. It is re-measured here on
+whatever interpreter CI runs, because ``importlib.metadata``'s duplicate
+handling has changed across releases and a rule that stops holding must fail
+loudly rather than quietly stop protecting anything.
+
+Every fixture is a REAL ``.dist-info`` directory with REAL metadata read by the
+REAL stdlib. No mocks and no ``monkeypatch`` (PA-306 / STX-NM002): the env and
+``sys.path`` fixtures below really mutate the real process state and really put
+it back, so what the test exercises is what production talks to.
+
+The duplicate fixture reproduces the 2026-08-11 shape exactly — two dist-infos
+for one distribution, each declaring a ``pytest11``-style entry point into a
+module only one of them ships.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from importlib.metadata import distributions, entry_points
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._maintenance._venv_dist_assertion import (
+    SKIP_ENV_VAR,
+    VenvDistributionError,
+    assert_venv_distributions_unique,
+    duplicate_distributions,
+)
+
+#: A group name nothing else in the environment can possibly declare, so
+#: ``entry_points()`` (which always scans the whole ``sys.path``) is answering
+#: about the fixture and only the fixture.
+GROUP = "sac_overlay_venv_test_plugin"
+
+#: The incident shape: the stale overlay copy, and the image's copy.
+STALE_VERSION = "0.38.0"
+IMAGE_VERSION = "0.43.1"
+
+
+def _plant(site: Path, dist: str, version: str, *, entry: str = "") -> Path:
+    """A real ``.dist-info`` the stdlib will read."""
+    info = site / f"{dist}-{version}.dist-info"
+    info.mkdir(parents=True)
+    (info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {dist.replace('_', '-')}\nVersion: {version}\n"
+    )
+    if entry:
+        (info / "entry_points.txt").write_text(f"[{GROUP}]\n{entry}\n")
+    return info
+
+
+def _venv(tmp_path: Path, *, versions: tuple[str, ...], entries: bool = False) -> Path:
+    """A venv laid out like ``/opt/venv-sac`` — ``lib/python*/site-packages``."""
+    venv = tmp_path / "venv-sac"
+    site = venv / "lib" / "python3.12" / "site-packages"
+    site.mkdir(parents=True)
+    for i, version in enumerate(versions):
+        entry = (
+            f"plugin{i} = scitex_dev._core._test_execution_plugin" if entries else ""
+        )
+        _plant(site, "scitex_dev", version, entry=entry)
+    return venv
+
+
+def _site_of(venv: Path) -> Path:
+    return venv / "lib" / "python3.12" / "site-packages"
+
+
+@pytest.fixture
+def on_sys_path():
+    """Really put a directory on ``sys.path``; really take it off again.
+
+    A factory rather than a value so the caller builds its fixture first. The
+    teardown restores the real interpreter state, which is what makes this
+    honest where a patch would not be: ``entry_points()`` has no path argument,
+    so the only way to ask it about a fixture is to really put the fixture in
+    front of it.
+    """
+    added: list[str] = []
+
+    def _add(path: Path) -> None:
+        sys.path.insert(0, str(path))
+        added.append(str(path))
+        importlib.invalidate_caches()
+
+    try:
+        yield _add
+    finally:
+        for entry in added:
+            while entry in sys.path:
+                sys.path.remove(entry)
+        importlib.invalidate_caches()
+
+
+@pytest.fixture
+def override_set():
+    """The escape hatch, really set in the real environment."""
+    saved = os.environ.get(SKIP_ENV_VAR)
+    os.environ[SKIP_ENV_VAR] = "1"
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop(SKIP_ENV_VAR, None)
+        else:
+            os.environ[SKIP_ENV_VAR] = saved
+
+
+@pytest.fixture
+def override_absent():
+    """The default state — the negative control's precondition, guaranteed."""
+    saved = os.environ.pop(SKIP_ENV_VAR, None)
+    try:
+        yield
+    finally:
+        if saved is not None:
+            os.environ[SKIP_ENV_VAR] = saved
+
+
+# ---------------------------------------------------------------------------
+# THE METHOD NOTE, re-measured on this interpreter
+# ---------------------------------------------------------------------------
+def test_distributions_sees_both_dist_infos(tmp_path) -> None:
+    """``distributions()`` does not dedupe — this is what pluggy itself uses."""
+    # Arrange
+    venv = _venv(tmp_path, versions=(STALE_VERSION, IMAGE_VERSION), entries=True)
+    # Act
+    found = list(distributions(path=[str(_site_of(venv))]))
+    # Assert
+    assert len(found) == 2
+
+
+def test_entry_points_cannot_see_a_duplicate_distribution(
+    tmp_path, on_sys_path
+) -> None:
+    """``entry_points()`` dedupes by normalised name, so it reports ONE.
+
+    This is exactly why the assertion is NOT built on it: such a gate passes
+    while the venv is broken.
+    """
+    # Arrange
+    venv = _venv(tmp_path, versions=(STALE_VERSION, IMAGE_VERSION), entries=True)
+    on_sys_path(_site_of(venv))
+    # Act
+    eps = list(entry_points(group=GROUP))
+    # Assert
+    assert len(eps) == 1
+
+
+# ---------------------------------------------------------------------------
+# The check
+# ---------------------------------------------------------------------------
+def test_a_duplicated_distribution_fails(tmp_path) -> None:
+    # Arrange
+    venv = _venv(tmp_path, versions=(STALE_VERSION, IMAGE_VERSION))
+    # Act
+    check = duplicate_distributions(venv)
+    # Assert
+    assert check.ok is False
+
+
+def test_a_single_distribution_passes(tmp_path) -> None:
+    # Arrange
+    venv = _venv(tmp_path, versions=(IMAGE_VERSION,))
+    # Act
+    check = duplicate_distributions(venv)
+    # Assert
+    assert check.ok is True
+
+
+def test_the_failure_names_the_package(tmp_path) -> None:
+    # Arrange
+    venv = _venv(tmp_path, versions=(STALE_VERSION, IMAGE_VERSION))
+    # Act
+    check = duplicate_distributions(venv)
+    # Assert
+    assert "scitex-dev" in check.detail
+
+
+def test_the_failure_names_every_version_found(tmp_path) -> None:
+    """Naming only one would send the operator hunting for the other."""
+    # Arrange
+    venv = _venv(tmp_path, versions=(STALE_VERSION, IMAGE_VERSION))
+    # Act
+    check = duplicate_distributions(venv)
+    # Assert
+    assert STALE_VERSION in check.detail and IMAGE_VERSION in check.detail
+
+
+def test_the_failure_names_the_paths(tmp_path) -> None:
+    """Evidence, not just a complaint — the operator must be able to look."""
+    # Arrange
+    venv = _venv(tmp_path, versions=(STALE_VERSION, IMAGE_VERSION))
+    expected = str(_site_of(venv) / f"scitex_dev-{STALE_VERSION}.dist-info")
+    # Act
+    check = duplicate_distributions(venv)
+    # Assert
+    assert expected in check.detail
+
+
+def test_a_venv_without_site_packages_is_unknown(tmp_path) -> None:
+    """Nothing was measured, so nothing may be concluded."""
+    # Arrange
+    venv = tmp_path / "not-a-venv"
+    venv.mkdir()
+    # Act
+    check = duplicate_distributions(venv)
+    # Assert
+    assert check.ok is None
+
+
+def test_an_empty_site_packages_is_unknown_not_clean(tmp_path) -> None:
+    """An empty venv is not a healthy one — the exact fold this rail closes."""
+    # Arrange
+    venv = _venv(tmp_path, versions=())
+    # Act
+    check = duplicate_distributions(venv)
+    # Assert
+    assert check.ok is None
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+def test_a_duplicated_venv_refuses_the_boot(tmp_path, override_absent) -> None:
+    # Arrange
+    venv = _venv(tmp_path, versions=(STALE_VERSION, IMAGE_VERSION))
+    # Act
+    act = lambda: assert_venv_distributions_unique("agent-x", venv=venv)  # noqa: E731
+    # Assert
+    with pytest.raises(VenvDistributionError):
+        act()
+
+
+def test_the_refusal_names_the_agent(tmp_path, override_absent) -> None:
+    # Arrange
+    venv = _venv(tmp_path, versions=(STALE_VERSION, IMAGE_VERSION))
+    # Act
+    act = lambda: assert_venv_distributions_unique("agent-x", venv=venv)  # noqa: E731
+    # Assert
+    with pytest.raises(VenvDistributionError, match="agent-x"):
+        act()
+
+
+def test_the_refusal_carries_the_repair(tmp_path, override_absent) -> None:
+    """The complaint alone would read as a broken repo, which is the whole bug."""
+    # Arrange
+    venv = _venv(tmp_path, versions=(STALE_VERSION, IMAGE_VERSION))
+    # Act
+    act = lambda: assert_venv_distributions_unique("agent-x", venv=venv)  # noqa: E731
+    # Assert
+    with pytest.raises(VenvDistributionError, match="REPAIR"):
+        act()
+
+
+def test_the_refusal_warns_against_deleting_from_inside(
+    tmp_path, override_absent
+) -> None:
+    """The obvious in-container fix is the one that permanently breaks the tree."""
+    # Arrange
+    venv = _venv(tmp_path, versions=(STALE_VERSION, IMAGE_VERSION))
+    # Act
+    act = lambda: assert_venv_distributions_unique("agent-x", venv=venv)  # noqa: E731
+    # Assert
+    with pytest.raises(VenvDistributionError, match="whiteout"):
+        act()
+
+
+def test_a_clean_venv_boots(tmp_path, override_absent) -> None:
+    # Arrange
+    venv = _venv(tmp_path, versions=(IMAGE_VERSION,))
+    # Act
+    check = assert_venv_distributions_unique("agent-x", venv=venv)
+    # Assert
+    assert check.ok is True
+
+
+def test_an_absent_venv_is_out_of_scope_not_a_pass(tmp_path, override_absent) -> None:
+    """Host-side unit runs and source checkouts must not be refused."""
+    # Arrange
+    venv = tmp_path / "nowhere"
+    # Act
+    check = assert_venv_distributions_unique("agent-x", venv=venv)
+    # Assert
+    assert check is None
+
+
+def test_an_unmeasurable_venv_refuses_as_firmly_as_a_duplicate(
+    tmp_path, override_absent
+) -> None:
+    """UNKNOWN is not a shade of pass, even at the gate."""
+    # Arrange
+    venv = _venv(tmp_path, versions=())
+    # Act
+    act = lambda: assert_venv_distributions_unique("agent-x", venv=venv)  # noqa: E731
+    # Assert
+    with pytest.raises(VenvDistributionError):
+        act()
+
+
+def test_the_override_skips_the_gate(tmp_path, override_set) -> None:
+    """An escape hatch exists, and the hazard lives in it rather than the default."""
+    # Arrange
+    venv = _venv(tmp_path, versions=(STALE_VERSION, IMAGE_VERSION))
+    # Act
+    check = assert_venv_distributions_unique("agent-x", venv=venv)
+    # Assert
+    assert check is None
+
+
+def test_the_gate_is_armed_without_the_override(tmp_path, override_absent) -> None:
+    """Negative control for the override: absent env must NOT skip."""
+    # Arrange
+    venv = _venv(tmp_path, versions=(STALE_VERSION, IMAGE_VERSION))
+    # Act
+    act = lambda: assert_venv_distributions_unique("agent-x", venv=venv)  # noqa: E731
+    # Assert
+    with pytest.raises(VenvDistributionError):
+        act()

--- a/tests/scitex_agent_container/_runners/test_claude_session.py
+++ b/tests/scitex_agent_container/_runners/test_claude_session.py
@@ -537,10 +537,24 @@ def test_heartbeat_loop_subsequent_ticks_refresh_ts(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _wait_for_pid_file(state_dir: Path, deadline_s: float = 5.0) -> None:
+def _wait_for_pid_file(state_dir: Path, deadline_s: float = 30.0) -> None:
     """Block until the runner has produced both pid + heartbeat files, or
     raise ``TimeoutError`` — so the caller can treat readiness as a
-    precondition without paying for an extra assert."""
+    precondition without paying for an extra assert.
+
+    THE BUDGET WAS 5.0s AND IT NEVER HAD THE HEADROOM IT LOOKED LIKE. Measured
+    2026-08-11 on a normally-busy fleet host: the child takes ~3.7s to reach its
+    pid file, i.e. 74% of the old deadline was already spent before anything
+    went wrong. Any co-tenant load — a parallel pytest run, a bake — pushed it
+    over, and the failure surfaced as "runner never wrote pid/heartbeat", which
+    reads as a broken RUNNER rather than a busy BOX.
+
+    That confusion is the same shape this suite's sibling rails exist to end, so
+    the deadline is now 30s. Nothing here asserts a LATENCY — the three tests
+    that use it assert pid identity, exit code and final heartbeat state — so a
+    generous deadline costs nothing on a healthy run (it returns as soon as the
+    files appear) and removes a false negative on a loaded one.
+    """
     deadline = time.time() + deadline_s
     while time.time() < deadline:
         if (state_dir / "pid").is_file() and (state_dir / "heartbeat.json").is_file():

--- a/tests/scitex_agent_container/_runners/test_claude_session.py
+++ b/tests/scitex_agent_container/_runners/test_claude_session.py
@@ -552,7 +552,21 @@ def _wait_for_pid_file(state_dir: Path, deadline_s: float = 5.0) -> None:
 @pytest.fixture
 def _runner_subprocess(tmp_path: Path):
     """Spawn the runner as a child process; yield (proc, state_dir); send
-    SIGTERM + wait on teardown so each test focuses on one observation."""
+    SIGTERM + wait on teardown so each test focuses on one observation.
+
+    The child declares ``SAC_SKIP_VENV_DIST_ASSERTION`` deliberately. The
+    runner's boot assertion
+    (``_maintenance._venv_dist_assertion.assert_venv_distributions_unique``)
+    measures the DEVELOPER'S ``/opt/venv-sac``, not anything these three tests
+    assert about — they are about pid/heartbeat mechanics. Leaving it armed
+    means a contributor whose own overlay happens to shadow the image sees
+    "runner never wrote pid/heartbeat" and reads it as a broken REPO, which is
+    the exact env-mistaken-for-repo confusion that assertion exists to end. The
+    gate stays armed everywhere else; its own behaviour is covered directly by
+    ``tests/.../\\_maintenance/test__venv_dist_assertion.py``, including a
+    negative control proving it is armed without this variable.
+    """
+    child_env = {**os.environ, "SAC_SKIP_VENV_DIST_ASSERTION": "1"}
     proc = subprocess.Popen(
         [
             sys.executable,
@@ -567,6 +581,7 @@ def _runner_subprocess(tmp_path: Path):
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=child_env,
     )
     state_dir = tmp_path / "ci-runner"
     _wait_for_pid_file(state_dir)


### PR DESCRIPTION
## The bug

sac agents run as SIF-lower + per-agent overlay-upper. Only
`.../site-packages/scitex_agent_container` is bind-mounted; everything else under
`/opt/venv-sac` is image content the overlay can nonetheless write to. When an agent
`pip install`s inside its container the files land in the overlay upper and **shadow the
image's copy forever** — including across an image rebuild, because nothing re-evaluates
the upper when the lower is swapped.

Measured host-side 2026-08-11, under
`containers/overlays/<agent>/upper/opt/venv-sac/lib/python3.12/site-packages/`:

```
scitex-dev 7 dist-infos (3 written that morning), scitex-agent-container 3,
neurovista 2, paper-scitex-clew 2, scitex-db 2, scitex-hpc 2, scitex-hub 2,
scitex-storage 2   — every other overlay 0
```

The SIF ships exactly **one** (`scitex_dev-0.43.1.dist-info`). The union is incoherent:
the image's dist-info advertises a `pytest11` entry point whose module the stale overlay
tree masks, so every `pytest` run dies before collecting a single test:

```
ModuleNotFoundError: No module named 'scitex_dev._core._test_execution_plugin'
```

It reads as a broken **repo**. It is a broken **env**. scitex-hub lost a session to it.
Seven overlays were pruned by hand that morning (move-aside, nothing deleted), verified
against a control: a pruned overlay resolves `0.43.1` and imports fine, an unpruned one
resolves `0.38.0` and raises. This PR is the thing that stops it recurring.

This branch was developed inside a container carrying the live bug — `scitex_dev`
0.38.0 **and** 0.43.1 — so the new check was confirmed against the real fault, not only
against fixtures: `duplicate_distributions('/opt/venv-sac')` returns `ok=False` naming
6 duplicated distributions here.

## The contract

`_maintenance/_overlay_venv_model.py`. **An image rebuild MUST invalidate the `venv-sac`
slice of every per-agent overlay.** The venv is image content an overlay merely *happens*
to be able to write to; per-agent state worth preserving lives in the agent's home and
workdir, never in `site-packages`. Today the image is authoritative in principle and
silently overridden in practice by whichever files happen to be older.

## The key is not the filename

`containers/sac-base.sif` is a **stable symlink** onto a timestamped target, so its own
name is identical before and after a rebuild. Keying on it yields a check that can never
fail — worse than no check, because the config still lists it. `sif_identity()` resolves
the symlink and keys on the target's basename, size and mtime; the extra fields catch an
in-place overwrite that reuses the name. Over-sensitive is the safe direction here: a
false invalidation costs a re-install and moves nothing to the bin; a false negative is
the bug.

## Move aside, never delete

The stale slice is renamed to `<overlay>/.old/<timestamp>/upper/opt/venv-sac`, mirroring
the original path so an undo is one mechanical `mv`. `.old/` sits **beside** `upper/`,
not inside it, so the archived tree leaves the container's filesystem view entirely
(apptainer reads only `upper/` and `work/`). The identity stamp
`<overlay>/.sac-venv-sif-id` sits there for the same reason: an agent cannot clobber its
own invalidation stamp from inside.

**One log line** names both image identities, the path that moved, and the `mv` that
restores it. Silence is what cost scitex-hub a session; the line is part of the fix.

## Where it runs, and why there

`_apptainer_runtime.start` and `tui_session.start`, in both cases **past the
already-running guard** and **past the dry-run return**.

- Not inside `build_run_argv` — `sac agents explain` calls that too, and a read-only
  command must not move files.
- Not in `sac image build` — that catches one route to a new image and misses a remote
  bake, a hand-swapped symlink, or an rsync'd SIF.
- Past the running guard means sac has just established with its own instrument that no
  container of this agent holds the overlay mounted.

The TUI site reads the SIF **out of the launch argv** rather than re-resolving it (same
reasoning as `_entry_point_gate.probe_argv_from_launch`), so the reconciled image cannot
drift from the mounted one.

## The live-mount guard

Doing this from inside a running container writes an overlayfs **whiteout** that masks
the SIF's clean files too — it turns a recoverable shadow into a permanently broken tree.
`_overlay_venv_predicate` refuses on three independent signals — running inside a
container (env witness plus `/.singularity.d`), the agent being live, an overlayfs in
this mount namespace using the upper — and on any of them being **unmeasured**. A
refusal deliberately does **not** advance the stamp, or it would quietly convert itself
into a pass on the next boot.

## The lower layer is asserted BEFORE anything moves

Moving the upper's slice aside does not **restore** the image's copy — it only
stops **masking** it. If the image has nothing there, the move leaves the agent with
no venv at all: a shadowed-but-working container turned into a dead one, by the repair.
That is the one failure this rail could plausibly cause itself, so
`base_provides_venv()` asserts the precondition first — it counts
`importlib.metadata.distributions()` inside the image via `apptainer exec`. A count,
not an import, because the question is whether the lower layer is *populated*, and a
count cannot be satisfied by a namespace-package shell.

Three-valued like everything else: an unreadable probe is UNKNOWN and refuses rather
than accusing the image; an empty lower layer FAILS with a hint saying plainly that the
overlay's slice is currently the agent's only copy.

**Lazy**, because it costs an `apptainer exec`: it runs only when a move is genuinely on
the table (stale stamp *and* a slice present). The predicate's matching rule is that an
unconsulted precondition for an action you are not taking is a PASS, not an unknown —
otherwise every routine boot would refuse. Both directions are pinned: zero probes on an
already-reconciled overlay, and a negative control asserting exactly one when a move is
proposed.

## The boot assertion — `distributions()`, never `entry_points()`

`_maintenance/_venv_dist_assertion.py`, invoked first thing inside the container from the
runner's CLI entry.

`importlib.metadata.entry_points()` **dedupes by normalised name** before reading
anything, so it *cannot see this bug*: a gate built on it is green while the venv is
broken — a gate that cannot fail, which is worse than no gate because the config still
lists it. `distributions()` does not dedupe and is what pluggy itself uses, so it
observes exactly what pytest observes, including the dead entry.

Re-measured in the suite on the running interpreter rather than inherited from a
docstring — same fixture, CPython 3.12: `distributions()` → 2, `entry_points()` → 1.
`importlib.metadata`'s duplicate handling has changed across releases, so a rule that
stops holding must fail loudly rather than quietly stop protecting anything.

The refusal names the package, every version found, and every path.

## Three-valued throughout

Follows the shape of `_lifecycle/_relocate_preflight`: PASS / FAIL / **UNKNOWN**, where
UNKNOWN refuses as firmly as FAIL but prescribes "go measure it". A check that cannot
read the overlay returns UNKNOWN, never PASS — folding "could not read" into "fine" is
the exact bug class this closes.

## Expected first-run behaviour

No overlay in the fleet carries a stamp today, so the first start of each agent after
this lands will move that agent's `venv-sac` slice aside and log it. That is the intended
one-time reconciliation — the same action taken by hand on seven overlays — and nothing
is deleted. Agents lose overlay-only `pip install`s, which is the contract.

## Tests

93 new across four suites; real `.dist-info` trees, real SIF symlinks, real PIDs, a real
`apptainer exec` probe against a real non-image, no mocks and no `monkeypatch`.

```
93 passed in  7.11s          (the four new suites, real exit 0)
775 passed, 2 skipped        (every suite covering a touched file, real exit 0)
```

### One existing test budget widened, and why

Adding the boot assertion costs **230 ms** on the runner's import path (minimum of 7
fresh interpreters — minimum, not mean, because load can only ever *add* time, so the
floor is the honest estimate of the cost itself). That is nothing against an apptainer
mount and SDK init.

It was enough to break `test_claude_session`'s three real-subprocess tests, and that
exposed a pre-existing fragility rather than a cost problem: `_wait_for_pid_file` allowed
**5.0 s** for a real `python -m ..._runners.claude_session` child that already takes
**~3.7 s** on a normally-busy fleet host. 74% of the budget was spent before anything
went wrong, so any co-tenant load pushed it over — and the failure read as
"runner never wrote pid/heartbeat", i.e. a broken *runner* rather than a busy *box*.
Same environment-mistaken-for-code confusion the rest of this branch exists to end.

The deadline is now 30 s. Nothing there asserts a *latency* — the three tests assert pid
identity, exit code and final heartbeat state — and the wait returns the instant the
files appear, so a healthy run pays nothing. Verified with three consecutive isolated
runs, real exit 0 each (previously 3/3 errored).

### CI note — the three red `pytest-matrix` legs are NOT this PR

`14047 passed, 7 failed`, and all 7 share one cause outside this diff:
`scitex_dev.hosts._retired` prints a stale-registry `WARN:` to **stdout**, which
corrupts `sac host list --json` / `sac host probe --json` and makes
`tests/.../_state/test_host_config.py` and `cli_pkg/test_host_group.py` fail to parse
JSON. The runner's `hosts.yaml` still routes `nas` / `nas1` / `nas2` through aliases
retired 2026-08-07.

Independent evidence it is fleet-wide, not mine: PRs **#956** and **#952** — unrelated
branches by other agents — show the *identical* three `pytest-matrix` failures with every
other leg green. Locally those same 58 tests pass on both this branch and a pristine
`origin/develop` tree (real exit 0 on each), because this container's `hosts.yaml` is
current. Every other leg here is green: ruff, quality-audit, docs, import-smoke,
no-hosted-runners, CLA.

`test_claude_session`'s three real-subprocess runner fixtures now declare
`SAC_SKIP_VENV_DIST_ASSERTION`: they assert pid/heartbeat mechanics, and leaving the gate
armed there would make a contributor's own shadowed overlay read as a broken repo — the
very confusion this PR ends. The gate's own behaviour is covered directly, including a
negative control proving it is armed without that variable.

Pre-existing failures in this environment (`test__sdk_common` / `test__mcp_spec_env`,
`SCITEX_AGENT_CONTAINER_AGENT` absent) were confirmed against a pristine `origin/develop`
tree and are unrelated.

## Deliberately left out

- **No `sac` CLI verb.** The invalidation is automatic at launch; a report-only surface
  can follow if the operator wants one.
- **`openai_session`** does not get the boot assertion — only the claude-session runner,
  which is the fleet's runtime.
- **Loopback image overlays** are out of scope and say so at INFO: their upper layer is
  not host-readable, so they cannot be invalidated from the host. Recreating the image
  overlay is the reset.
- **Cross-namespace mount detection.** A mount made by another process is invisible in
  `/proc/self/mountinfo`; the agent-liveness check is what covers that, and the
  limitation is documented rather than papered over.
- **No end-to-end run against a live fleet overlay.** The fleet is stopped for the
  compute-04 migration, and the one remaining unpruned overlay
  (`scitex-agent-container`) is mounted live under the agent that would run the test —
  which is precisely the state the rail is built to REFUSE. Forcing it would be the
  whiteout this PR exists to prevent. It gets exercised naturally on that agent's next
  restart, and the refusal path for exactly this situation is covered by
  `test_a_declared_container_context_is_refused`.
