### PR TITLE
feat(relocate): the phase driver, an agentic handshake, and host in the db not the spec

### DIFF
--- a/docs/relocate.md
+++ b/docs/relocate.md
@@ -54,7 +54,7 @@ first one, so you do not have to run it N times to find N problems.
 sac agents relocate <name> --to <host> --dry-run
 ```
 
-### The nine checks
+### The eleven checks
 
 | check | what it catches | the 2026-08-07 instance |
 |---|---|---|
@@ -67,9 +67,26 @@ sac agents relocate <name> --to <host> --dry-run
 | `spec_schema_accepted` | target's validator rejects a key | a top-level `provider:` key, same older validator |
 | `ports_free` | port already bound there | reassign in the spec before moving |
 | `hub_reachable_from_target` | hub unreachable **from there** | the nas's services bind `127.0.0.1`, so reaching them from HERE proves nothing about THERE |
+| `sac_present_on_target` | remote `sac` calls will fail | on scitex-compute-04 sac lives at `/home/ywatanabe/.env-sac/bin/sac` and is **not** on the non-interactive ssh PATH, so `ssh host sac …` answers "No such file or directory" while sac is installed and working (2026-08-11) |
+| `source_work_committed` | uncommitted/unpushed work on the host being **left** | a relocation carries the spec and the transcript and nothing else; a half-finished branch stays on a machine nobody is watching |
 
 **Read the credentials row twice.** A presence check passes on an expired file.
 The failure it prevents is silent.
+
+**`sac_present_on_target` is one check answering two questions.** "Not installed"
+and "installed but invisible to ssh" produce the *identical* error and need
+*opposite* fixes — install it, versus put it on the PATH (or set the peer's
+`env_preamble`). The check reports them separately, resolving sac by login shell
+and by absolute path, so nobody is sent to install a second copy of something
+that already works. When it can see that sac is off the PATH but cannot
+establish whether it exists at all, the answer is UNKNOWN, not a guess.
+
+**`source_work_committed` is the only check about the source.** Its facts are
+gathered locally rather than over ssh, and an unscanned repo is UNKNOWN — never
+"clean". A failed `git status --porcelain` prints nothing and so does a clean
+tree; counting lines conflates them, and the conflation clears exactly the repo
+the check exists to protect. A branch with no upstream is likewise unmeasured
+rather than zero-unpushed.
 
 ### Three answers, not two
 
@@ -122,22 +139,78 @@ handoff and each reclaim. A writer presents its fence, and anything below the
 current value is refused. The stale holder is locked out by arithmetic rather
 than by trusting its clock.
 
-### The six phases
+### The seven phases
 
 ```
-PREFLIGHT  ->  TARGET_STANDBY  ->  SOURCE_DRAIN  ->  HANDOVER  ->  SOURCE_STOP  ->  DONE
-                                                     ^^^^^^^^
-                                          the single atomic point
+PREFLIGHT -> TARGET_STANDBY -> HANDSHAKE -> SOURCE_DRAIN -> HANDOVER -> SOURCE_STOP -> DONE
+                                                            ^^^^^^^^
+                                                 the single atomic point
 ```
 
 | phase | what happens |
 |---|---|
-| `PREFLIGHT` | validate the target; touch nothing |
-| `TARGET_STANDBY` | start the target **without** the lease — it runs read-only; verify health |
+| `PREFLIGHT` | validate the target and the source; touch nothing |
+| `TARGET_STANDBY` | start the target **without** the lease — it runs read-only |
+| `HANDSHAKE` | target → source round trip; the source must **observe** the reply |
 | `SOURCE_DRAIN` | source finishes in-flight work, stops accepting new |
 | `HANDOVER` | the lease moves source → target |
 | `SOURCE_STOP` | stop the source, and **verify** it stopped |
-| `DONE` | append the residency record |
+| `DONE` | append the residency record — **which is the host write** |
+
+### Where the host is written: the db, never the spec
+
+Operator, 2026-08-11, after asking whether the spec is a file or a db:
+
+> 設定ファイル、人が書くものはファイル、状態は db
+
+`host` was in the spec for years and it was **never intent**. Where an agent
+actually runs is an *observation*; a human typing `host: nas-03` is recording a
+fact, and a fact hand-written into a git-tracked file that exists in one copy
+per machine will eventually be wrong in at least one of them.
+
+So **a relocation writes nothing to any spec file.** The residency record
+appended at `DONE` *is* the host write. There is deliberately no spec-editing
+phase — an earlier draft had one, with an undo, and removing it also removed the
+only pre-handover step that changed anything durable. That is why `abort` has no
+compensation to perform.
+
+**Migration — seed once, then ignore.** Every spec on disk still carries `host:`
+(106 of 106, measured 2026-08-11).
+
+| the db… | what happens to the spec's `host:` |
+|---|---|
+| has an open residency | **ignored.** Not compared, not merged, not warned about on every read |
+| knows nothing | read **once** to seed the db, and the seeding is recorded (`host_seeded_from_spec`) so the value's provenance survives |
+| knows nothing, no spec host | **UNKNOWN.** Not "local", not the current hostname |
+
+The dry run prints a one-line notice whenever a spec still carries the field,
+saying plainly that it is ignored and which value is authoritative. A field that
+is authoritative on Tuesday and ignored on Wednesday is worse than either, so
+the seeding branch is a migration and not a fallback that keeps running.
+
+### The handshake: A → B is not a handshake
+
+Measured 2026-08-11: **a2a between two live agents delivered nothing**, and
+nobody noticed until a human asked. Every one-way signal was green throughout —
+both processes ran, both sidecars listened, both dispatch calls returned
+accepted. A relocation gated on "the target started" would have handed the lease
+straight into that, and `abort` is refused past the handover.
+
+So the handshake requires four things, and each rules out a way that "green" was
+wrong:
+
+1. the target **accepted** the challenge — otherwise its agent was never asked
+   anything;
+2. a reply was **observed**, on the source side — arrival, not dispatch;
+3. the reply carries **this challenge's nonce** — otherwise a reply left over
+   from an earlier turn passes, and a relocation retried three times will
+   eventually find one;
+4. the reply proves **work** — an answer the loop had to compute, because an
+   echo proves the transport and not the agent.
+
+Anything not observed is UNKNOWN, which refuses. A timeout waiting for a reply
+is "I did not see one in the time I waited", not "the target is broken", and the
+two call for different actions.
 
 Every step is idempotent and journalled, so a crash **resumes** rather than
 restarts. Advancing to the phase you are already in succeeds and appends
@@ -236,10 +309,28 @@ back from the target before declaring the carry done.
 
 ### Honest status
 
-The **decision** logic is built and merged (`_session_carry.plan_session_carry`).
-The cross-host **transport** that executes a `carry=True` plan is not. Until it
-lands, a relocation carries no memory, and this document is the stopgap the
+The **decision** logic is built and merged (`_session_carry.plan_session_carry`),
+and so is the **verification** contract (`_relocate_transcript.carry_transcript`):
+it reads the transcript back from the target and compares digests, and an
+unverifiable copy is `carried=None` rather than a soft yes. What is missing is
+the pair of callables that actually move bytes between two hosts. Until those
+land, a relocation carries no memory, and this document is the stopgap the
 operator asked for.
+
+### If the move goes wrong: the origin record
+
+`DONE` also writes an **origin record** — where the source was, in enough detail
+to go back by hand: the workdir, the state dir, the session uuid, the transcript
+path (with whether it was verified on the target, or UNKNOWN), and every repo
+with its uncommitted and unpushed counts. `recovery_lines()` renders it as
+instructions rather than a field dump, because its reader is by definition
+dealing with a relocation that already went wrong.
+
+Two rules make it worth having. A record naming **no path at all** is refused at
+construction — "it came from ywata-note-win" sends someone to a machine with no
+idea where to look. And a repo that was never scanned is listed under **NOT
+MEASURED**, separately from the clean ones, because a recovery aid that cannot
+tell "clean" from "not looked at" is worse than none.
 
 ---
 
@@ -253,16 +344,46 @@ operator asked for.
 | session-carry decision | **merged** (#891) | whether the transcript follows the agent |
 | residency history | **merged** (#892) | where it lived, and who wrote a row |
 | probe adapter | **merged** (#894) | a failed probe stays UNKNOWN, never a false negative |
-| cross-host transcript transport | **not built** | — |
-| the `relocate` CLI verb | **in progress** | dry-run first |
+| transcript carry + read-back | **merged** | the copy is verified ON the target, by digest |
+| agentic handshake | **in review** | the target proved it can do agent work |
+| host-in-db + one-time seed | **in review** | the spec never holds an observation |
+| origin record | **in review** | a bad move is recoverable by hand |
+| the phase driver | **in review** | the order, the journal, and abort-vs-report |
+| cross-host transcript **transport adapters** | **not built** | — |
+| the executing CLI adapters | **not built** | — |
+
+**What "in review" buys and what it does not.** The pure machinery is complete
+and tested: given effects, the driver runs the phases in order, journals each,
+refuses on any non-yes, and aborts only where an abort is legal. What is *not*
+built is the set of adapters that perform those effects against two real hosts —
+starting the standby, running the challenge, moving the lease, stopping the
+source. Until those land, `--no-dry-run` has nothing to call.
+
+**The lease is recorded, not yet enforced.** `check_write` exists and no writer
+in sac calls it. So a handover moves an authoritative *record* of who may write;
+it does not currently exclude a second writer. Two live instances remain
+possible by copy-and-start, which is what the lease was designed to make
+unrepresentable. That gap is in the enforcement, not the model.
 
 Six pure pieces, 138+ tests, none of which touches a host — that was deliberate,
 so each is testable without a second machine. The two remaining items are the
 ones that act.
 
-**Until the CLI lands, a relocation is a manual procedure**: follow §2 by hand,
-then §3, then §4. The checks in §2 are the ones a hand-move actually needs; they
-are written down here precisely because they were learned the hard way.
+**Until the executing adapters land, a relocation is a manual procedure**:
+follow §2 by hand, then §3, then §4. The checks in §2 are the ones a hand-move
+actually needs; they are written down here precisely because they were learned
+the hard way.
+
+One of them is worth doing by hand before anything else, because it is cheap and
+it invalidates the rest when it fails:
+
+```bash
+ssh <target> 'command -v sac'                 # the PATH remote sac calls get
+ssh <target> 'bash -lc "command -v sac"'      # the login shell's answer
+```
+
+Two different answers mean sac is installed and unreachable the way sac calls
+it — a PATH fix, not an install.
 
 ---
 
@@ -273,9 +394,26 @@ are written down here precisely because they were learned the hard way.
 - **"Defined" and "running" are not distinguished.** The fleet listing collapses
   a spec that exists with a process that is alive, so from inside a container
   `sac agents list` reports the whole fleet — including the agent running the
-  command — as `defined`. Before relocating, confirm what is actually running by
-  another route.
+  command — as `defined`. That is a SPEC fact ("a file exists") sitting in a
+  STATE column called `status`, and it is why the registry reported 0 agents
+  running while 24 were live. The same listing prints `host` as the literal
+  string `'local'` on every row — a placeholder where an observation belongs.
+  Relocate does not build on either: it reads the host from the state db and
+  returns `None` when nothing knows. Before relocating, confirm what is actually
+  running by another route.
   Card: `sac-agents-list-blind-inside-container-reports-whole-fleet-defined-20260808`.
+- **`host` still lives in the spec schema everywhere else.** Relocate no longer
+  reads it, but `validate_placement` still *requires* `spec.host` (or `hosts`),
+  and eleven runtime sites resolve placement from `config.hosts_spec.host` —
+  cross-host dispatch, stop/restart routing, `attach`, cold-start reuse, the
+  priority report, and remote liveness. Moving those to the db is a separate
+  migration; until it lands, `host` is db-authoritative *for relocate* and
+  spec-authoritative for dispatch. That split is deliberate and temporary, and
+  it is the next thing to close.
+- **There is no residency table.** The host is read from `instances.host`, which
+  gives the current stay and no history — so "where does it live now" is
+  answerable and "which host wrote this row in March" is not. Attribution, the
+  larger half of why residency was built, needs the table.
 - **Four sources disagree about which agents exist** (18 / 32 / 159 / 111 as
   measured 2026-08-08). Which is canonical is an open decision.
 - **Host naming is not yet canonical.** Relocate must write the canonical

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,15 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "click>=8.0",
+    # >=8.2, not >=8.0: the test suite asserts that a ``--json`` command's
+    # payload reaches STDOUT ALONE (``CliRunner`` ``result.stdout``), which
+    # is only a separate stream from 8.2 on. Before 8.2, ``CliRunner``
+    # defaulted to ``mix_stderr=True`` and ``result.stdout`` WAS the merged
+    # stream — so those assertions would silently pass on merged output and
+    # stop pinning anything. ``mix_stderr`` was removed in 8.2, so no single
+    # call spells "stdout only" on both sides of the boundary and a
+    # compatibility shim is not possible; the floor has to move instead.
+    "click>=8.2",
     "pyyaml>=6.0",
     # Round-trip YAML writer used by ``sac host add/remove/set`` so
     # operator-authored comments + key order in config.yaml survive a

--- a/src/scitex_agent_container/_lifecycle/_relocate_checks.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_checks.py
@@ -1,0 +1,383 @@
+"""The eleven predicates, one per thing that went wrong when this was done by hand.
+
+Every check here was learned by doing the move manually on 2026-08-07 (and the
+sac-present one on 2026-08-11). None of them is hypothetical: rewriting `host:`
+alone produced an agent that STARTED, reported HEALTHY, and did nothing, which
+is the worst failure shape available because it looks exactly like success.
+
+    binds        the spec bound /mnt/c — a Windows drive absent on the nas
+    card store   SCITEX_CARDS_DB is 5432 here and 5442 there
+    credentials  the nas had a stale file (expired 2026-05-23, empty
+                 refreshToken) that sac loaded IN PREFERENCE to the good one;
+                 every turn 401'd while `sac agents health` still said healthy
+    runtime      `tui` is rejected by the nas's older sac
+    schema       a top-level `provider:` key is rejected by that same validator
+    sac present  `sac` on compute-04 lives at /home/ywatanabe/.env-sac/bin/sac
+                 and is NOT on the non-interactive ssh PATH, so `ssh host sac …`
+                 answers "No such file or directory" while sac is installed and
+                 working
+    source work  uncommitted or unpushed work on the machine being LEFT — the
+                 one check here that is about the source rather than the target
+  + reachability, image presence, free ports, and whether the hub is reachable
+    FROM the target (the nas's services bind 127.0.0.1, so "I can reach it" from
+    here proves nothing about there)
+
+CREDENTIALS IS THE ONE TO READ TWICE. Checking PRESENCE passes on an expired
+file. The check has to be about VALIDITY, and the failure it prevents is silent.
+
+SAC-PRESENT LOOKS LIKE ONE CHECK AND IS TWO. "not installed there" and
+"installed there and ssh cannot see it" produce the identical error and need
+opposite fixes — install it, versus put it on the PATH. A check that reports
+only "sac not found" sends the reader to install a second copy of something that
+is already working, which is why the two are separated here by evidence rather
+than merged into one message.
+
+NO I/O. These evaluate FACTS someone else gathered — facts in, :class:`Check`s
+out — so sac does not learn how to probe a host here, and every check is
+unit-testable against the exact broken state we hit in production. That is the
+only way to know a check would actually have caught it.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from ._relocate_preflight_facts import Check, SourceFacts, TargetFacts
+
+__all__ = [
+    "CHECK_BINDS",
+    "CHECK_CARD_STORE",
+    "CHECK_CREDENTIALS",
+    "CHECK_HUB_FROM_TARGET",
+    "CHECK_IMAGE",
+    "CHECK_PORTS",
+    "CHECK_REACHABLE",
+    "CHECK_RUNTIME",
+    "CHECK_SAC_PRESENT",
+    "CHECK_SCHEMA",
+    "CHECK_SOURCE_WORK",
+    "check_binds",
+    "check_card_store",
+    "check_credentials",
+    "check_hub_from_target",
+    "check_image",
+    "check_ports",
+    "check_reachable",
+    "check_runtime",
+    "check_sac_present",
+    "check_schema",
+    "check_source_work",
+]
+
+CHECK_REACHABLE: Final = "target_reachable"
+CHECK_IMAGE: Final = "image_present"
+CHECK_BINDS: Final = "binds_exist_on_target"
+CHECK_CARD_STORE: Final = "card_store_reachable"
+CHECK_CREDENTIALS: Final = "credentials_valid"
+CHECK_RUNTIME: Final = "runtime_supported"
+CHECK_SCHEMA: Final = "spec_schema_accepted"
+CHECK_PORTS: Final = "ports_free"
+CHECK_HUB_FROM_TARGET: Final = "hub_reachable_from_target"
+CHECK_SAC_PRESENT: Final = "sac_present_on_target"
+CHECK_SOURCE_WORK: Final = "source_work_committed"
+
+
+def _unobserved(name: str, what: str) -> Check:
+    return Check(
+        name=name,
+        ok=None,
+        detail=f"{what} was not observed on the target",
+        hint=(
+            "run the probe that supplies this fact before deciding; an unobserved "
+            "check is not a passing one, and proceeding on it is how a relocation "
+            "reports healthy while doing nothing"
+        ),
+    )
+
+
+def check_reachable(facts: TargetFacts, to_host: str) -> Check:
+    if facts.reachable is None:
+        return _unobserved(CHECK_REACHABLE, "reachability")
+    if not facts.reachable:
+        return Check(
+            name=CHECK_REACHABLE,
+            ok=False,
+            detail=f"{to_host} did not answer",
+            hint=f"check ssh/network to {to_host}; nothing else in this report is meaningful until it answers",
+        )
+    return Check(name=CHECK_REACHABLE, ok=True, detail=f"{to_host} answered")
+
+
+def check_image(facts: TargetFacts, to_host: str) -> Check:
+    if facts.image_present is None:
+        return _unobserved(CHECK_IMAGE, "the agent image")
+    if not facts.image_present:
+        return Check(
+            name=CHECK_IMAGE,
+            ok=False,
+            detail=f"the agent's image is absent on {to_host}",
+            hint=f"build or copy the SIF to {to_host} before relocating; a missing image fails at boot, after the lease has moved",
+        )
+    return Check(name=CHECK_IMAGE, ok=True, detail="image present")
+
+
+def check_binds(facts: TargetFacts, to_host: str) -> Check:
+    if facts.missing_bind_sources is None:
+        return _unobserved(CHECK_BINDS, "bind sources")
+    if facts.missing_bind_sources:
+        missing = ", ".join(facts.missing_bind_sources)
+        return Check(
+            name=CHECK_BINDS,
+            ok=False,
+            detail=f"bind sources absent on {to_host}: {missing}",
+            hint=(
+                "remove or re-point these binds in the spec for the target host "
+                "(2026-08-07: /mnt/c is a Windows drive that does not exist on the nas)"
+            ),
+        )
+    return Check(
+        name=CHECK_BINDS, ok=True, detail="every bind source exists on the target"
+    )
+
+
+def check_card_store(facts: TargetFacts, to_host: str) -> Check:
+    if facts.card_store_reachable is None:
+        return _unobserved(CHECK_CARD_STORE, "the card store")
+    if not facts.card_store_reachable:
+        url = facts.card_store_url or "(no url recorded)"
+        return Check(
+            name=CHECK_CARD_STORE,
+            ok=False,
+            detail=f"card store {url} not reachable from {to_host}",
+            hint=(
+                "set SCITEX_CARDS_DB to the target's own store before relocating "
+                "(2026-08-07: 5432 here, 5442 there) — an agent that cannot reach its "
+                "board runs and records nothing"
+            ),
+        )
+    return Check(
+        name=CHECK_CARD_STORE, ok=True, detail=f"card store reachable from {to_host}"
+    )
+
+
+def check_credentials(facts: TargetFacts) -> Check:
+    """VALIDITY, not presence. Presence passes on an expired file."""
+    if (
+        facts.credential_expires_in_s is None
+        or facts.credential_refresh_token_present is None
+    ):
+        return _unobserved(CHECK_CREDENTIALS, "credential validity")
+    if facts.credential_expires_in_s <= 0:
+        return Check(
+            name=CHECK_CREDENTIALS,
+            ok=False,
+            detail=f"target credential expired {abs(facts.credential_expires_in_s):.0f}s ago",
+            hint=(
+                "refresh or replace the target-local credential; sac loads it IN PREFERENCE "
+                "to a good one, so every turn 401s while `sac agents health` still says healthy"
+            ),
+        )
+    if not facts.credential_refresh_token_present:
+        return Check(
+            name=CHECK_CREDENTIALS,
+            ok=False,
+            detail="target credential has an empty refreshToken",
+            hint=(
+                "replace it — it is valid now and unrenewable, so the agent dies at the "
+                "first refresh with no warning beforehand"
+            ),
+        )
+    return Check(
+        name=CHECK_CREDENTIALS,
+        ok=True,
+        detail=f"credential valid for {facts.credential_expires_in_s:.0f}s with a refresh token",
+    )
+
+
+def check_runtime(facts: TargetFacts, runtime: str) -> Check:
+    if facts.supported_runtimes is None:
+        return _unobserved(CHECK_RUNTIME, "supported runtimes")
+    if runtime not in facts.supported_runtimes:
+        supported = ", ".join(facts.supported_runtimes) or "(none reported)"
+        return Check(
+            name=CHECK_RUNTIME,
+            ok=False,
+            detail=f"target does not support runtime {runtime!r}; it supports: {supported}",
+            hint=(
+                "either upgrade sac on the target or set the spec's runtime to one it accepts "
+                "(2026-08-07: the nas's sac 0.21.9 rejected 'tui')"
+            ),
+        )
+    return Check(name=CHECK_RUNTIME, ok=True, detail=f"runtime {runtime!r} supported")
+
+
+def check_schema(facts: TargetFacts) -> Check:
+    if facts.rejected_spec_keys is None:
+        return _unobserved(CHECK_SCHEMA, "spec-schema acceptance")
+    if facts.rejected_spec_keys:
+        keys = ", ".join(facts.rejected_spec_keys)
+        return Check(
+            name=CHECK_SCHEMA,
+            ok=False,
+            detail=f"target's validator rejects spec key(s): {keys}",
+            hint=(
+                "remove those keys for the target, or upgrade its sac "
+                "(2026-08-07: a top-level 'provider:' key was rejected by the older validator)"
+            ),
+        )
+    return Check(
+        name=CHECK_SCHEMA, ok=True, detail="target's validator accepts the spec"
+    )
+
+
+def check_ports(facts: TargetFacts, required_ports: tuple[int, ...]) -> Check:
+    if facts.ports_in_use is None:
+        return _unobserved(CHECK_PORTS, "port availability")
+    clashes = tuple(p for p in required_ports if p in facts.ports_in_use)
+    if clashes:
+        return Check(
+            name=CHECK_PORTS,
+            ok=False,
+            detail=f"port(s) already in use on the target: {', '.join(str(p) for p in clashes)}",
+            hint="free them or reassign the agent's ports in the spec before relocating",
+        )
+    return Check(
+        name=CHECK_PORTS, ok=True, detail="required ports are free on the target"
+    )
+
+
+def check_hub_from_target(facts: TargetFacts, to_host: str) -> Check:
+    if facts.hub_reachable_from_target is None:
+        return _unobserved(CHECK_HUB_FROM_TARGET, "hub reachability FROM the target")
+    if not facts.hub_reachable_from_target:
+        return Check(
+            name=CHECK_HUB_FROM_TARGET,
+            ok=False,
+            detail=f"the hub is not reachable from {to_host}",
+            hint=(
+                "check what the hub's services bind to — reaching them from HERE proves "
+                "nothing about THERE (the nas binds 127.0.0.1, so nothing cross-host reaches it)"
+            ),
+        )
+    return Check(
+        name=CHECK_HUB_FROM_TARGET, ok=True, detail=f"hub reachable from {to_host}"
+    )
+
+
+def check_sac_present(facts: TargetFacts, to_host: str) -> Check:
+    """Installed AND findable are two questions; the answer names which failed.
+
+    Measured 2026-08-11 on scitex-compute-04: sac lives at
+    ``/home/ywatanabe/.env-sac/bin/sac`` and is absent from the non-interactive
+    ssh PATH, so ``ssh compute-04 sac agents list`` answers "No such file or
+    directory" — the same words a machine with no sac at all produces. Every
+    remote step of a relocation runs under exactly that PATH.
+    """
+    if facts.sac_on_path is None:
+        return _unobserved(CHECK_SAC_PRESENT, "whether sac is on the target's ssh PATH")
+    if facts.sac_on_path:
+        where = f" at {facts.sac_resolved_path}" if facts.sac_resolved_path else ""
+        return Check(
+            name=CHECK_SAC_PRESENT,
+            ok=True,
+            detail=f"sac is on {to_host}'s non-interactive ssh PATH{where}",
+        )
+    if facts.sac_resolved_path is None:
+        return Check(
+            name=CHECK_SAC_PRESENT,
+            ok=None,
+            detail=(
+                f"sac is not on {to_host}'s non-interactive ssh PATH, and whether it is "
+                "installed there at all was not established"
+            ),
+            hint=(
+                "look for it directly before concluding anything: "
+                f"ssh {to_host} 'bash -lc \"command -v sac\"', and check the known venv "
+                "(~/.env-sac/bin/sac). 'Not on PATH' and 'not installed' produce the "
+                "same error and need opposite fixes"
+            ),
+        )
+    if not facts.sac_resolved_path:
+        return Check(
+            name=CHECK_SAC_PRESENT,
+            ok=False,
+            detail=f"sac is NOT INSTALLED on {to_host} — not on the ssh PATH and at no known location",
+            hint=(
+                f"install sac on {to_host} before relocating onto it. Every remote step "
+                "of the relocation — starting the target, verifying the source stopped — "
+                "is a sac call over ssh"
+            ),
+        )
+    return Check(
+        name=CHECK_SAC_PRESENT,
+        ok=False,
+        detail=(
+            f"sac IS INSTALLED on {to_host} at {facts.sac_resolved_path}, but is not on "
+            "the non-interactive ssh PATH that remote sac calls run under"
+        ),
+        hint=(
+            "do NOT install a second copy — set the peer's env_preamble in config.yaml "
+            "so it is on PATH (that is what env_preamble is for), or address it by "
+            f"absolute path. The evidence: ssh {to_host} 'command -v sac' printed "
+            f"nothing while {facts.sac_resolved_path} exists there"
+        ),
+    )
+
+
+def check_source_work(source: SourceFacts, from_host: str) -> Check:
+    """Relocating away from unsaved work strands it on a host nobody watches.
+
+    The agent arrives on the target intact and its half-finished branch does
+    not. Nothing fails, nothing is logged, and the work is found missing later
+    by someone who assumed a relocation moved everything.
+    """
+    where = from_host or "the source"
+    if source.repos is None:
+        return Check(
+            name=CHECK_SOURCE_WORK,
+            ok=None,
+            detail=f"un-saved work on {where} was not looked for",
+            hint=(
+                f"scan the agent's repos on {where} with `git status --porcelain` and a "
+                "`@{u}..` count, and record the numbers; a relocation carries the spec "
+                "and the transcript, so anything unsaved stays behind"
+            ),
+        )
+    unmeasured = tuple(r for r in source.repos if r.has_work is None)
+    if unmeasured:
+        listed = ", ".join(r.path for r in unmeasured)
+        return Check(
+            name=CHECK_SOURCE_WORK,
+            ok=None,
+            detail=f"un-saved work on {where} was not measured for: {listed}",
+            hint=(
+                "run `git status --porcelain` and a `@{u}..` count in each and record "
+                "the numbers; an unscanned repo is not a clean one"
+            ),
+        )
+    dirty = tuple(r for r in source.repos if r.has_work is True)
+    if dirty:
+        parts = []
+        for repo in dirty:
+            counts = []
+            if repo.uncommitted:
+                counts.append(f"{repo.uncommitted} uncommitted file(s)")
+            if repo.unpushed:
+                counts.append(f"{repo.unpushed} unpushed commit(s)")
+            branch = f" on {repo.branch}" if repo.branch else ""
+            parts.append(f"{repo.path}{branch}: {', '.join(counts)}")
+        return Check(
+            name=CHECK_SOURCE_WORK,
+            ok=False,
+            detail=f"un-saved work on {where} — " + "; ".join(parts),
+            hint=(
+                "commit and push it, or stash it deliberately, before moving. A "
+                "relocation carries the spec and the transcript and nothing else, so "
+                "this work stays on a machine the agent will no longer be looking at"
+            ),
+        )
+    return Check(
+        name=CHECK_SOURCE_WORK,
+        ok=True,
+        detail=f"every repo scanned on {where} is committed and pushed ({len(source.repos)} scanned)",
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_execute.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_execute.py
@@ -1,0 +1,339 @@
+"""The driver: walk the phases, journal each one, and stop the moment one is not a yes.
+
+Everything else in the relocate machinery decides. This is the piece that ACTS —
+and its entire design problem is that it must act without ever inventing a
+result. Each phase is an injected callable returning a three-valued
+:class:`StepResult`; this module owns the ORDER, the journal, and the one rule
+that makes the sequence safe:
+
+    BEFORE the handover, a non-yes ABORTS and nothing persistent has changed.
+    AT or AFTER it, a non-yes STOPS AND REPORTS — it never rolls back.
+
+THERE IS NOTHING TO ROLL BACK BEFORE THE HANDOVER, and that is a property of the
+phase order rather than luck. No pre-handover phase writes anything durable: the
+target standby is a started process, the handshake is messages. The host is not
+written until DONE, because where an agent runs is an OBSERVATION and the
+residency record IS that write (operator, 2026-08-11: 「設定ファイル、人が書く
+ものはファイル、状態は db」). An earlier draft had a phase that rewrote the
+spec's ``host:`` and therefore needed an undo; removing it removed the only
+reversible-but-durable step, which is why ``abort`` here has no compensation to
+perform and none is offered.
+
+That asymmetry is not a choice made here; it is enforced by
+:func:`.._relocate_phases.abort`, which refuses at or past HANDOVER. This module
+simply must not fight it: past that point the target already owns the lease and
+the source is fenced out, so an "undo" would mean taking write authority back
+from a live holder. The honest response to a failure there is to say exactly
+where it stopped and what is now true, because the fix is forward.
+
+UNKNOWN STOPS AS FIRMLY AS FAILURE, AND SAYS SOMETHING DIFFERENT. A step that
+could not be measured has not succeeded. The two are reported apart because they
+call for different actions — go and measure it, versus go and fix it — but
+neither continues. This is where that discipline is most load-bearing: a step
+whose unknown was folded into success would hand the lease to a target nobody
+established was working, which is the 2026-08-07 failure with the source already
+stopped.
+
+WHY THE EFFECTS ARE INJECTED, GIVEN THAT THIS IS THE PART THAT DOES I/O. Because
+the ORDER is what has to be tested, and the order is exactly what a two-host
+integration test cannot pin reliably. With effects as callables, every path —
+each phase failing, each phase unknown, a failure on either side of the atomic
+point, a resume from a half-finished journal — is a test with real callables
+returning real values, no mocks and no second machine. The CLI supplies the
+adapters that actually ssh.
+
+RE-ENTRY IS FREE, because :func:`.._relocate_phases.advance` makes it so:
+advancing to the phase already recorded is a no-op that succeeds. A coordinator
+that did the work and died before journalling re-runs harmlessly, which is the
+only reason a crash "resumes" rather than restarts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Final
+
+from ._relocate_phases import (
+    DONE,
+    HANDOVER,
+    HANDSHAKE,
+    PHASES,
+    PREFLIGHT,
+    SOURCE_DRAIN,
+    SOURCE_STOP,
+    TARGET_STANDBY,
+    Relocation,
+    abort,
+    advance,
+    is_past_no_return,
+)
+
+__all__ = [
+    "CODE_ABORTED",
+    "CODE_COMPLETED",
+    "CODE_JOURNAL_REFUSED",
+    "CODE_STOPPED_PAST_NO_RETURN",
+    "CODE_UNKNOWN",
+    "ExecuteOutcome",
+    "PhaseEffects",
+    "StepResult",
+    "execute",
+]
+
+#: Every phase through DONE completed.
+CODE_COMPLETED: Final = 200
+#: A phase refused BEFORE the handover; the relocation was aborted and undone.
+CODE_ABORTED: Final = 409
+#: A phase refused AT or AFTER the handover. Not undone — cannot be.
+CODE_STOPPED_PAST_NO_RETURN: Final = 410
+#: The phase machine refused a transition (a skip, a backward step, a terminal
+#: relocation). A coordinator bug rather than a host problem, and reported as
+#: its own thing so the two are never confused.
+CODE_JOURNAL_REFUSED: Final = 412
+#: A step could not be measured. Refuses as firmly as a failure, differently.
+CODE_UNKNOWN: Final = 503
+
+
+@dataclass(frozen=True)
+class StepResult:
+    """What one phase's effect achieved, in the same three-valued shape as the rest.
+
+    ``ok`` is ``True`` done, ``False`` it did not happen, ``None`` COULD NOT
+    TELL. No ``__bool__``: ``if result:`` would be true for a refusal, and the
+    step after this one may be the handover.
+
+    ``detail`` lands in the journal, so it is the sentence a reader gets months
+    later when asking what this relocation actually did. It is required for the
+    same reason a refusal must carry a reason.
+    """
+
+    ok: bool | None
+    detail: str
+    hint: str = ""
+
+    def __post_init__(self) -> None:
+        if self.ok not in (True, False, None):
+            raise ValueError(f"StepResult.ok must be True/False/None, got {self.ok!r}")
+        if not self.detail:
+            raise ValueError(
+                "StepResult.detail must be non-empty — it is what the journal records, "
+                "and an unexplained step is indistinguishable from one that never ran"
+            )
+        if self.ok is not True and not self.hint:
+            raise ValueError(
+                "StepResult: a step that did not succeed must carry a hint naming the next action"
+            )
+
+
+@dataclass
+class PhaseEffects:
+    """One callable per phase. There is no undo, because there is nothing to undo.
+
+    Every phase after PREFLIGHT is required. An omitted effect is not treated as
+    a skipped no-op: a relocation missing its handover would journal its way to
+    DONE having moved nothing, which is the single most convincing way to
+    produce the "looks exactly like success" failure this whole feature exists
+    to prevent. :func:`execute` refuses to start without all of them.
+
+    NO ROLLBACK IS OFFERED AND NONE IS NEEDED. No pre-handover phase writes
+    anything durable — the standby is a started process and the handshake is
+    messages — and the host is written by ``finish`` at DONE, past the point
+    where an abort is legal at all. TARGET_STANDBY does leave a started standby
+    behind on an abort, which is deliberate and is called out in the outcome
+    rather than silently cleaned up: stopping it would be another remote action
+    taken during an abort, at the moment least is known about the state of
+    things.
+    """
+
+    start_target_standby: Callable[[], StepResult] | None = None
+    handshake: Callable[[], StepResult] | None = None
+    drain_source: Callable[[], StepResult] | None = None
+    hand_over_lease: Callable[[], StepResult] | None = None
+    stop_source: Callable[[], StepResult] | None = None
+    finish: Callable[[], StepResult] | None = None
+
+    def for_phase(self, phase: str) -> Callable[[], StepResult] | None:
+        return {
+            TARGET_STANDBY: self.start_target_standby,
+            HANDSHAKE: self.handshake,
+            SOURCE_DRAIN: self.drain_source,
+            HANDOVER: self.hand_over_lease,
+            SOURCE_STOP: self.stop_source,
+            DONE: self.finish,
+        }.get(phase)
+
+
+@dataclass(frozen=True)
+class ExecuteOutcome:
+    """Where the relocation got to, and what is true of the world now.
+
+    ``completed`` is three-valued: True every phase through DONE; False it
+    stopped and the stop is understood; None it stopped because something could
+    not be measured. ``relocation`` is the journal as it stands, so a re-run
+    reads it and resumes.
+    """
+
+    completed: bool | None
+    code: int
+    reason: str
+    relocation: Relocation
+    stopped_at: str = ""
+    hint: str = ""
+    #: True when the target was started and then abandoned by an abort. Reported
+    #: rather than cleaned up: stopping it would be another remote action taken
+    #: at the moment least is known about the state of things.
+    standby_left_running: bool = False
+    log: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if self.completed not in (True, False, None):
+            raise ValueError(
+                f"ExecuteOutcome.completed must be True/False/None, got {self.completed!r}"
+            )
+        if not self.reason:
+            raise ValueError("ExecuteOutcome.reason must be non-empty")
+        if self.completed is True and self.code != CODE_COMPLETED:
+            raise ValueError(
+                f"ExecuteOutcome: completed=True must carry CODE_COMPLETED, got {self.code}"
+            )
+        if self.completed is not True and not self.hint:
+            raise ValueError(
+                "ExecuteOutcome: a relocation that did not complete must say what to do next"
+            )
+
+    @property
+    def past_no_return(self) -> bool:
+        return is_past_no_return(self.relocation)
+
+
+def _missing_effects(effects: PhaseEffects) -> tuple[str, ...]:
+    return tuple(p for p in PHASES if p != PREFLIGHT and effects.for_phase(p) is None)
+
+
+def _standby_running(last_done: str, failing: str, unknown: bool) -> bool:
+    """Whether an abort here leaves a started target behind.
+
+    True once TARGET_STANDBY has completed, and also when the standby phase
+    ITSELF returned UNKNOWN: an effect that could not say whether the target
+    came up may well have started it, and reporting "nothing was left running"
+    on that basis is the kind of reassurance that sends nobody to look.
+    """
+    if failing == TARGET_STANDBY:
+        return unknown
+    return PHASES.index(last_done) >= PHASES.index(TARGET_STANDBY)
+
+
+def execute(
+    relocation: Relocation,
+    *,
+    effects: PhaseEffects,
+    now: Callable[[], float],
+) -> ExecuteOutcome:
+    """Drive ``relocation`` forward from wherever its journal says it is.
+
+    ``now`` is a callable rather than a value because a relocation spans real
+    time and each journalled step should carry the moment it actually happened —
+    a single timestamp captured up front would make a twenty-minute sequence
+    look instantaneous, and the journal's whole purpose is telling a later
+    reader when things happened.
+
+    Returns rather than raises for every expected outcome, including refusals:
+    the caller needs the journal back in order to resume, and an exception
+    carries a message where a resumable record is wanted.
+    """
+    missing = _missing_effects(effects)
+    if missing:
+        raise ValueError(
+            f"refusing to execute: no effect supplied for {', '.join(missing)}. A phase "
+            "with no effect would journal as done having changed nothing, which is the "
+            "most convincing possible imitation of a successful relocation"
+        )
+
+    log: list[str] = []
+    current = relocation
+
+    for phase in PHASES[PHASES.index(current.phase) + 1 :]:
+        effect = effects.for_phase(phase)
+        assert effect is not None  # guaranteed by _missing_effects above
+        result = effect()
+        log.append(f"{phase}: {result.detail}")
+
+        if result.ok is not True:
+            unknown = result.ok is None
+            if is_past_no_return(current):
+                # The lease has already moved. Saying so is the useful part: the
+                # target owns write authority and the source may still be
+                # running, which is a state someone has to settle deliberately.
+                return ExecuteOutcome(
+                    completed=None if unknown else False,
+                    code=CODE_UNKNOWN if unknown else CODE_STOPPED_PAST_NO_RETURN,
+                    reason=(
+                        f"{phase} did not complete AFTER the lease moved to "
+                        f"{current.to_host}: {result.detail}"
+                    ),
+                    relocation=current,
+                    stopped_at=phase,
+                    hint=(
+                        f"{result.hint} This cannot be rolled back — {current.to_host} "
+                        f"holds the lease and {current.from_host} is fenced out. Finish "
+                        "forward: re-run to resume from this phase"
+                    ),
+                    log=tuple(log),
+                )
+            stopped, verdict = abort(
+                current,
+                now=now(),
+                reason=f"{phase}: {result.detail}",
+            )
+            left_running = _standby_running(current.phase, phase, unknown)
+            return ExecuteOutcome(
+                completed=None if unknown else False,
+                code=CODE_UNKNOWN if unknown else CODE_ABORTED,
+                reason=f"{phase} did not complete: {result.detail}",
+                relocation=stopped if verdict.allowed is True else current,
+                stopped_at=phase,
+                hint=(
+                    f"{result.hint} Nothing was handed over; the lease is still with "
+                    f"{current.from_host}, and the host in the state db is unchanged."
+                    + (
+                        f" The standby on {current.to_host} was started and is STILL "
+                        "RUNNING — stop it deliberately, or leave it for the re-run."
+                        if left_running
+                        else ""
+                    )
+                ),
+                standby_left_running=left_running,
+                log=tuple(log),
+            )
+
+        current, verdict = advance(
+            current, to_phase=phase, now=now(), detail=result.detail
+        )
+        if verdict.allowed is not True:
+            # The machine refused a transition we believed was legal. That is a
+            # bug in this driver, not a fact about a host, so it is reported as
+            # its own code rather than folded into a phase failure.
+            return ExecuteOutcome(
+                completed=False,
+                code=CODE_JOURNAL_REFUSED,
+                reason=f"the phase journal refused {current.phase} -> {phase}: {verdict.reason}",
+                relocation=current,
+                stopped_at=phase,
+                hint=(
+                    "the effect for this phase reported success but the journal would not "
+                    "record it. Read the journal before re-running — the relocation may "
+                    "have already progressed past this point in an earlier run"
+                ),
+                log=tuple(log),
+            )
+
+    return ExecuteOutcome(
+        completed=True,
+        code=CODE_COMPLETED,
+        reason=(
+            f"{current.agent}: {current.from_host} -> {current.to_host}, every phase "
+            f"through {DONE} recorded"
+        ),
+        relocation=current,
+        log=tuple(log),
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_handshake.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_handshake.py
@@ -1,0 +1,271 @@
+"""A -> B is not a handshake. B -> A, OBSERVED BY A, is the only thing that counts.
+
+The operator's item #7: before the lease moves, the target must contact the
+source "agentically", and that contact must include a liveness/behaviour check —
+not a port answering, not a process existing, but the agent's own loop taking a
+turn and producing something only a working loop could produce.
+
+WHY THE ONE-WAY VERSION IS WORTHLESS, MEASURED. On 2026-08-11 a2a between two
+LIVE agents delivered nothing, and nobody noticed until a human asked. Every
+one-way signal was green throughout: both processes ran, both sidecars listened,
+both dispatch calls returned accepted. A relocation gated on "the target
+started" would have handed over the lease into exactly that, and the failure
+would then have looked like the 2026-08-07 one — started, healthy, doing nothing
+— with the source already stopped and no way back (:func:`.._relocate_phases.
+abort` refuses past HANDOVER, correctly).
+
+So this module refuses to call anything a handshake unless FOUR things hold, and
+each rules out a specific way the previous sentence's "green" was wrong:
+
+    the challenge was ACCEPTED        the target's sidecar took the message
+    a reply was OBSERVED BY THE SOURCE not "sent" — arrival, on the source side
+    the reply CARRIES THIS NONCE      not a queued reply to an earlier prompt
+    the reply PROVES WORK             an answer the loop had to compute
+
+THE NONCE IS NOT CEREMONY. Without correlation, a reply that was already sitting
+in the inbox from some earlier turn satisfies "a reply was observed", and a
+relocation retried three times will eventually find one. The nonce is what makes
+"a reply" mean "the reply to THIS challenge".
+
+PROOF OF WORK, AND WHY IT IS NOT A PING. An echo proves the transport; it does
+not prove the agent. The challenge must therefore ask for something the loop has
+to DO — read a file, run a command, report a value it cannot know without
+looking — and this module compares the answer it got with the answer the caller
+computed independently. What that question is belongs to the caller, because it
+depends on what the target can reach; what does NOT belong to the caller is the
+option to skip it, so an absent expected answer is a refusal rather than a
+waived requirement.
+
+THREE-VALUED, and here the unknowns are the common case: a timeout waiting for a
+reply is NOT "the target is broken", it is "I did not see one in the time I
+waited". Those call for different actions — go and measure again with a longer
+wait, versus go and fix the target — and folding the first into the second gets
+a healthy relocation abandoned while folding it the other way is the 08-07 bug.
+
+Pure: no transport, no clock, no sleeping. Observations in, a verdict out.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+__all__ = [
+    "CODE_NONCE_MISMATCH",
+    "CODE_NOT_ACCEPTED",
+    "CODE_NO_REPLY",
+    "CODE_OK",
+    "CODE_UNKNOWN",
+    "CODE_WORK_NOT_PROVEN",
+    "HandshakeFacts",
+    "HandshakeVerdict",
+    "evaluate_handshake",
+]
+
+#: Round trip complete: accepted, replied, correlated, and the work was proven.
+CODE_OK: Final = 200
+#: The target's sidecar did not take the challenge. Nothing was asked of the agent.
+CODE_NOT_ACCEPTED: Final = 502
+#: The challenge was accepted and no reply arrived. THE 2026-08-11 failure.
+CODE_NO_REPLY: Final = 504
+#: A reply arrived that is not the reply to this challenge.
+CODE_NONCE_MISMATCH: Final = 409
+#: The agent answered and the answer is wrong — it echoed, it did not work.
+CODE_WORK_NOT_PROVEN: Final = 422
+#: Something was not observed. Refuses as firmly as a failure, differently worded.
+CODE_UNKNOWN: Final = 503
+
+
+@dataclass(frozen=True)
+class HandshakeFacts:
+    """What was OBSERVED about one challenge/reply exchange.
+
+    Every field is ``| None`` for NOT OBSERVED, which is deliberately distinct
+    from an observed negative — the same discipline as
+    :class:`.._relocate_preflight.TargetFacts`, and for the same reason: a
+    dispatch call that raised must not be able to masquerade as "the target
+    refused".
+
+    ``observed_by`` names WHO saw the reply. It is required and it is not
+    decoration: "the coordinator saw a reply" and "the source agent saw a reply"
+    are different measurements, and a report that does not say which invites the
+    reader to assume the stronger one.
+    """
+
+    #: The target's sidecar accepted the challenge for delivery.
+    challenge_accepted: bool | None = None
+    #: A reply arrived back — ARRIVAL, not dispatch.
+    reply_observed: bool | None = None
+    #: Who observed the reply, e.g. "the source agent" or "the coordinator".
+    observed_by: str = ""
+    #: The correlation token echoed in the reply, as read out of it.
+    reply_nonce: str | None = None
+    #: The answer the target gave to the proof-of-work question.
+    reply_answer: str | None = None
+
+
+@dataclass(frozen=True)
+class HandshakeVerdict:
+    """Whether the target proved it can do agent work, in ONE shape.
+
+    ``proven`` is three-valued and there is no ``__bool__``: ``if verdict:``
+    would be true for a refusal, and this is the last gate before the lease
+    moves.
+    """
+
+    proven: bool | None
+    code: int
+    reason: str
+    hint: str = ""
+
+    def __post_init__(self) -> None:
+        if self.proven not in (True, False, None):
+            raise ValueError(
+                f"HandshakeVerdict.proven must be True/False/None, got {self.proven!r}"
+            )
+        if not self.reason:
+            raise ValueError(
+                "HandshakeVerdict.reason must be non-empty — a refusal with no reason is not actionable"
+            )
+        if self.proven is True and self.code != CODE_OK:
+            raise ValueError(
+                f"HandshakeVerdict: proven=True must carry CODE_OK, got {self.code}"
+            )
+        if self.proven is None and self.code != CODE_UNKNOWN:
+            raise ValueError(
+                f"HandshakeVerdict: proven=None must carry CODE_UNKNOWN, got {self.code}"
+            )
+        if self.proven is not True and not self.hint:
+            raise ValueError(
+                "HandshakeVerdict: a non-passing verdict must carry a hint saying what to do next"
+            )
+
+
+def _unknown(what: str, hint: str) -> HandshakeVerdict:
+    return HandshakeVerdict(
+        proven=None,
+        code=CODE_UNKNOWN,
+        reason=f"{what} was not observed",
+        hint=hint,
+    )
+
+
+def evaluate_handshake(
+    facts: HandshakeFacts,
+    *,
+    nonce: str,
+    expected_answer: str,
+) -> HandshakeVerdict:
+    """Did the target prove, to the source, that it can do agent work?
+
+    ``nonce`` is the correlation token the challenge carried; ``expected_answer``
+    is what a working loop must have replied, computed by the caller from
+    something the target had to go and look at.
+
+    Both are required. An empty ``nonce`` would make every reply correlate and an
+    empty ``expected_answer`` would make every reply prove the work, so each is
+    refused at the top rather than silently weakening the gate — a check that can
+    be disabled by passing nothing is a check that will eventually be disabled by
+    passing nothing.
+    """
+    if not nonce:
+        raise ValueError(
+            "evaluate_handshake needs a non-empty nonce — without correlation, a reply "
+            "left over from an earlier turn satisfies 'a reply was observed'"
+        )
+    if not expected_answer:
+        raise ValueError(
+            "evaluate_handshake needs a non-empty expected_answer — an echo proves the "
+            "transport, not the agent, and this gate exists for the agent"
+        )
+
+    if facts.challenge_accepted is None:
+        return _unknown(
+            "whether the target accepted the challenge",
+            "re-send the challenge and record whether the target's sidecar took it; "
+            "a dispatch call that raised is not a refusal by the target",
+        )
+    if not facts.challenge_accepted:
+        return HandshakeVerdict(
+            proven=False,
+            code=CODE_NOT_ACCEPTED,
+            reason="the target did not accept the challenge, so its agent was never asked anything",
+            hint=(
+                "check that the target instance is running and its a2a sidecar is "
+                "listening on the port the spec declares; nothing about the agent's "
+                "behaviour has been measured yet"
+            ),
+        )
+
+    if facts.reply_observed is None:
+        return _unknown(
+            "whether a reply came back",
+            "watch the source side for the reply and say what you saw; a send that "
+            "returned accepted says nothing about arrival",
+        )
+    who = facts.observed_by or "(nobody named)"
+    if not facts.reply_observed:
+        return HandshakeVerdict(
+            proven=False,
+            code=CODE_NO_REPLY,
+            reason=(
+                f"the challenge was accepted by the target and no reply reached {who}"
+            ),
+            hint=(
+                "do NOT hand over the lease. Accepted-but-silent is the exact shape "
+                "measured on 2026-08-11, where a2a between two live agents delivered "
+                "nothing while every one-way signal stayed green. Check delivery end "
+                "to end before retrying"
+            ),
+        )
+
+    if facts.reply_nonce is None:
+        return _unknown(
+            "the correlation token in the reply",
+            "read the nonce out of the reply body; without it, a reply queued from an "
+            "earlier turn cannot be told from the answer to this challenge",
+        )
+    if facts.reply_nonce != nonce:
+        return HandshakeVerdict(
+            proven=False,
+            code=CODE_NONCE_MISMATCH,
+            reason=(
+                f"the reply carries nonce {facts.reply_nonce!r}, not the {nonce!r} this "
+                "challenge sent — it answers some other message"
+            ),
+            hint=(
+                "drain the stale replies and re-run the handshake; a relocation retried "
+                "until 'a reply' appears will eventually find one that proves nothing"
+            ),
+        )
+
+    if facts.reply_answer is None:
+        return _unknown(
+            "the target's answer to the proof-of-work question",
+            "read the answer out of the reply body; a correlated reply with no answer "
+            "shows the message round-tripped, not that the loop did anything",
+        )
+    if facts.reply_answer != expected_answer:
+        return HandshakeVerdict(
+            proven=False,
+            code=CODE_WORK_NOT_PROVEN,
+            reason=(
+                f"the target replied {facts.reply_answer!r} where a working loop had to "
+                f"reply {expected_answer!r}"
+            ),
+            hint=(
+                "the message path works and the agent's turn did not produce the right "
+                "answer — check the target's credentials and its tool access before "
+                "relocating onto it; this is the 'started, reported healthy, did "
+                "nothing' shape, caught before the lease moved"
+            ),
+        )
+
+    return HandshakeVerdict(
+        proven=True,
+        code=CODE_OK,
+        reason=(
+            f"round trip complete: {who} observed a reply carrying nonce {nonce} and "
+            "the answer a working loop had to compute"
+        ),
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_host_record.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_host_record.py
@@ -1,0 +1,220 @@
+"""Where an agent runs is OBSERVED, so the answer comes from the db — not the spec.
+
+The operator settled this on 2026-08-11, after asking the sharp version of the
+question (「spec がファイルか db か、迷うところ。」):
+
+    設定ファイル、人が書くものはファイル、状態は db
+
+``host`` was in the spec for years and it was never intent. A human typing
+``host: nas-03`` is not declaring a preference, they are recording a fact — and
+a fact recorded by hand in a git-tracked file that exists in two copies on two
+machines is a fact that will eventually be wrong in at least one of them. So the
+host moves to the state db, and this module is the single place that answers
+"where does this agent live".
+
+WHY A RELOCATION THEN NEEDS NO SPEC-EDITING PHASE. Writing the db IS the move.
+:mod:`_residency` already records which host an agent lives on and when, with at
+most one stay open at a time; appending to it at DONE is the whole of the
+operator's item #1. An earlier draft of this work had a SPEC_REWRITE phase with
+an undo; it is gone, not dormant.
+
+THE MIGRATION, AND IT IS THE PART THAT MATTERS. Every spec on disk today carries
+``host:``. The rule here is SEED ONCE, THEN IGNORE:
+
+    the db knows the agent   -> the db wins, always. The spec's host: is not
+                                consulted, not compared, and not warned about
+                                on every read.
+    the db knows nothing     -> the spec's host: seeds the db, ONCE, and the
+                                seeding is recorded (``host_seeded_from_spec``)
+                                so the value's provenance is not lost.
+    neither knows            -> UNKNOWN. Not "local", not the current hostname.
+
+The middle branch exists so that no agent has to be re-registered by hand; it is
+not a fallback that keeps running. A field that is authoritative on Tuesday and
+ignored on Wednesday is worse than either, so once the db has an answer the
+spec's copy is dead text — and :func:`legacy_spec_host_notice` exists to say so
+in the dry run rather than leaving the operator to infer it from silence.
+
+WHAT THIS DOES NOT DO: guess. ``sac agents list`` prints ``host`` as the literal
+string ``'local'`` on every row today, which is a placeholder standing where an
+observation belongs, and it prints ``defined`` — a SPEC fact, "a file exists" —
+in a STATE column called ``status``. Between them that is why the listing
+reported zero agents running while two dozen were live. This module returns
+``None`` when it does not know, and ``None`` must not be rendered as a hostname.
+
+Pure: no db handle, no file read. The stored residency history comes in and an
+answer goes out, so the resolution rule is testable without either.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from ._residency import Residency, current_host, open_residency
+
+__all__ = [
+    "CODE_FROM_DB",
+    "CODE_SEEDED_FROM_SPEC",
+    "CODE_UNKNOWN",
+    "HostAnswer",
+    "legacy_spec_host_notice",
+    "record_move",
+    "resolve_host",
+]
+
+#: The db knew. The ordinary answer, and the only one after the first seeding.
+CODE_FROM_DB: Final = 200
+#: The db knew nothing and a legacy spec ``host:`` seeded it, once.
+CODE_SEEDED_FROM_SPEC: Final = 201
+#: Nobody knows. NOT a hostname, NOT "local".
+CODE_UNKNOWN: Final = 503
+
+
+@dataclass(frozen=True)
+class HostAnswer:
+    """Where the agent runs, and — load-bearing — WHERE THAT CAME FROM.
+
+    ``host`` is ``None`` for "not known", which callers must handle rather than
+    render. ``seeded_from_spec`` records that this answer originated in a legacy
+    spec field, so the provenance survives into the db row instead of the value
+    arriving there looking like something that was measured.
+    """
+
+    host: str | None
+    code: int
+    reason: str
+    seeded_from_spec: bool = False
+    #: The history AFTER any seeding, for the caller to persist. Unchanged when
+    #: nothing was seeded.
+    history: tuple[Residency, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.reason:
+            raise ValueError("HostAnswer.reason must be non-empty")
+        if self.host is None and self.code != CODE_UNKNOWN:
+            raise ValueError(
+                f"HostAnswer: an unknown host must carry CODE_UNKNOWN, got {self.code}"
+            )
+        if self.host is not None and not self.host.strip():
+            raise ValueError(
+                "HostAnswer.host must be a real hostname or None — a blank string "
+                "renders as an answer while meaning nothing"
+            )
+        if self.seeded_from_spec and self.code != CODE_SEEDED_FROM_SPEC:
+            raise ValueError(
+                "HostAnswer: seeded_from_spec must carry CODE_SEEDED_FROM_SPEC"
+            )
+
+
+def resolve_host(
+    history: tuple[Residency, ...],
+    *,
+    legacy_spec_host: str | None = None,
+    now: float | None = None,
+) -> HostAnswer:
+    """Answer "where does this agent run" from the db, seeding once if it must.
+
+    ``history`` is the agent's residency history as stored. ``legacy_spec_host``
+    is the ``host:`` still sitting in an old spec file — passed in explicitly so
+    that a caller has to decide to offer it, rather than this module reaching
+    into a spec on its own.
+
+    ``now`` is required to seed (a residency record without a start time is not
+    a record); omitting it while a seed is needed yields UNKNOWN naming the
+    reason, instead of inventing a timestamp.
+    """
+    known = current_host(history)
+    if known:
+        return HostAnswer(
+            host=known,
+            code=CODE_FROM_DB,
+            reason=f"the state db has {known} as the open residency",
+            history=history,
+        )
+
+    candidate = (legacy_spec_host or "").strip()
+    if not candidate:
+        return HostAnswer(
+            host=None,
+            code=CODE_UNKNOWN,
+            reason=(
+                "the state db has no open residency for this agent and no legacy "
+                "spec host: was offered — where it runs is genuinely unknown. Record "
+                "it with a residency before relying on it; do NOT substitute the "
+                "local hostname, which is the guess that makes a split-brain look "
+                "explained"
+            ),
+            history=history,
+        )
+    if now is None:
+        return HostAnswer(
+            host=None,
+            code=CODE_UNKNOWN,
+            reason=(
+                f"the db knows nothing and the legacy spec says {candidate!r}, but no "
+                "timestamp was supplied to open a residency with — a stay with no "
+                "start time cannot answer an attribution question later"
+            ),
+            history=history,
+        )
+    return HostAnswer(
+        host=candidate,
+        code=CODE_SEEDED_FROM_SPEC,
+        reason=(
+            f"seeded {candidate!r} from the spec's legacy host: field, ONCE. From now "
+            "on the db is the answer and that field is ignored"
+        ),
+        seeded_from_spec=True,
+        history=open_residency(history, host=candidate, now=now),
+    )
+
+
+def record_move(
+    history: tuple[Residency, ...], *, to_host: str, now: float
+) -> tuple[Residency, ...]:
+    """The item-#1 write: the agent now runs on ``to_host``.
+
+    Delegates to :func:`.._residency.open_residency`, which closes the previous
+    stay in the same step — so "living in two places at once" stays
+    unrepresentable rather than merely discouraged — and is idempotent on a move
+    already recorded, so a coordinator re-running after a crash does not litter
+    the history with the evidence of its own retries.
+
+    This is the ONLY write a relocation makes on the host's behalf. Nothing goes
+    to any spec file.
+    """
+    if not to_host or not to_host.strip():
+        raise ValueError(
+            "record_move needs the host the agent moved TO — an empty destination "
+            "would open a residency that answers no question"
+        )
+    return open_residency(history, host=to_host.strip(), now=now)
+
+
+def legacy_spec_host_notice(*, spec_host: str | None, db_host: str | None) -> str:
+    """One line for the dry run about a spec that still carries ``host:``.
+
+    Returns ``""`` when there is nothing to say. Otherwise it states plainly
+    which value is authoritative, because the failure mode being avoided is an
+    operator reading ``host: nas-03`` in a file, believing it, and being wrong —
+    the field is still THERE, it just stopped meaning anything.
+    """
+    stale = (spec_host or "").strip()
+    if not stale:
+        return ""
+    if db_host and stale != db_host:
+        return (
+            f"the spec still carries host: {stale}, which is IGNORED — the state db "
+            f"says {db_host} and the db is authoritative. Delete the field from the "
+            "spec; it is an observation sitting in a file of declarations"
+        )
+    if db_host:
+        return (
+            f"the spec still carries host: {stale}; it is ignored (the db agrees, at "
+            f"{db_host}). Delete the field — it will not be consulted again"
+        )
+    return (
+        f"the spec carries host: {stale} and the state db knows nothing yet, so this "
+        "value will SEED the db once and then be ignored"
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_origin.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_origin.py
@@ -1,0 +1,201 @@
+"""Where the agent CAME FROM, written down so a bad move is recoverable by hand.
+
+The operator's item #10: the target records where its source was, so that when
+something goes wrong the memory, the temp files and the unfinished git work can
+be recovered — agentically, by whoever picks it up, without a human who happens
+to remember.
+
+WHY THIS IS NOT THE RESIDENCY HISTORY. :mod:`_residency` answers "which host was
+this agent on at time T", which is an ATTRIBUTION question about rows already
+written. This answers a RECOVERY question — "the move went wrong, what is left
+behind on the old machine and where exactly" — and the two need different
+fields. Residency needs a host and two timestamps. Recovery needs paths: the
+workdir, the state dir, the transcript, and every repo that had work in it. A
+host name alone sends the reader to a machine with no idea where to look.
+
+WHAT IS WORTH RECORDING IS WHAT IS NOT COPIED. The relocation carries the spec
+and (when the transport runs) the transcript. Everything else stays on the
+source: scratch files, a half-finished branch, a stash, an unpushed commit,
+whatever the agent had open. Those are precisely what a recovery needs and
+precisely what nothing else in sac points at, so this record names them
+individually rather than pointing at a home directory and wishing the reader
+luck.
+
+UNCOMMITTED WORK IS RECORDED EVEN THOUGH PREFLIGHT REFUSES ON IT. The check in
+:mod:`_relocate_preflight` fails a relocation that would strand uncommitted work,
+so in the ordinary case this list is empty. It is recorded anyway for the case
+that matters: a relocation run with the check overridden, or work that appeared
+between the check and the move. A recovery record that only describes tidy
+departures is a recovery record for the case nobody needs it.
+
+AN EMPTY RECORD IS REFUSED. A record naming no host and no path is not a
+recovery aid; it is a row that makes the state db look like it answered. So
+:class:`OriginRecord` validates at construction, where the mistake is visible,
+rather than letting an empty one be discovered by someone who needed it.
+
+Pure: no clock, no filesystem, no git. The observations are gathered elsewhere
+and passed in, so the record is testable without a repo and without a move.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = [
+    "OriginRecord",
+    "RepoWork",
+    "recovery_lines",
+]
+
+
+@dataclass(frozen=True)
+class RepoWork:
+    """One repository on the source and what was left un-saved in it.
+
+    ``uncommitted`` and ``unpushed`` are counts, ``None`` for NOT MEASURED. Zero
+    and unmeasured are different answers and the difference decides whether a
+    reader has to go and look: 0 says the repo was clean, ``None`` says nobody
+    asked.
+    """
+
+    path: str
+    branch: str = ""
+    uncommitted: int | None = None
+    unpushed: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.path:
+            raise ValueError(
+                "RepoWork.path must be non-empty — a repo with no path is not findable"
+            )
+        for name in ("uncommitted", "unpushed"):
+            value = getattr(self, name)
+            if value is not None and value < 0:
+                raise ValueError(f"RepoWork.{name} must be >= 0 or None, got {value}")
+
+    @property
+    def has_work(self) -> bool | None:
+        """True if anything is un-saved, ``None`` if neither count was measured."""
+        if self.uncommitted is None and self.unpushed is None:
+            return None
+        return bool(self.uncommitted or self.unpushed)
+
+
+@dataclass(frozen=True)
+class OriginRecord:
+    """Everything a recovery needs to reach back into the source host.
+
+    Written at DONE and RETAINED (item #9): the fact of a migration is never
+    discarded, so this stays in the state db after the relocation succeeds, not
+    only while it is in flight. A record deleted on success is a record that
+    exists exactly when it is not needed.
+    """
+
+    agent: str
+    from_host: str
+    to_host: str
+    at: float
+    #: The agent's working directory on the SOURCE.
+    workdir: str = ""
+    #: Where the source kept session markers, pidfiles and scratch state.
+    state_dir: str = ""
+    #: The session the agent was living in when it moved.
+    session_uuid: str = ""
+    #: The transcript file on the SOURCE, whether or not it was carried.
+    transcript_path: str = ""
+    #: Whether the transcript was verified on the target — three-valued, and the
+    #: unknown is the case a recovery cares about most.
+    transcript_carried: bool | None = None
+    repos: tuple[RepoWork, ...] = field(default_factory=tuple)
+    #: Anything else worth pointing at, in the recorder's own words.
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not self.agent:
+            raise ValueError("OriginRecord.agent must be non-empty")
+        if not self.from_host:
+            raise ValueError(
+                "OriginRecord.from_host must be non-empty — a recovery record that does "
+                "not name the machine to go back to is not one"
+            )
+        if not self.to_host:
+            raise ValueError("OriginRecord.to_host must be non-empty")
+        if self.from_host == self.to_host:
+            raise ValueError(
+                f"OriginRecord: from_host and to_host are both {self.from_host!r}; "
+                "nothing moved, so there is nothing to recover from"
+            )
+        if self.transcript_carried not in (True, False, None):
+            raise ValueError(
+                f"OriginRecord.transcript_carried must be True/False/None, got {self.transcript_carried!r}"
+            )
+        if not (self.workdir or self.state_dir or self.transcript_path or self.repos):
+            raise ValueError(
+                "OriginRecord names no workdir, state dir, transcript or repo — a record "
+                f"that only says {self.from_host!r} sends a recovery to a machine with no "
+                "idea where to look. Record at least one path"
+            )
+
+    @property
+    def repos_with_work(self) -> tuple[RepoWork, ...]:
+        """Repos known to hold un-saved work. Unmeasured repos are NOT included.
+
+        They are surfaced separately by :attr:`repos_unmeasured`, because "clean"
+        and "not looked at" must not share a bucket in a record whose whole job
+        is telling someone where to look.
+        """
+        return tuple(r for r in self.repos if r.has_work is True)
+
+    @property
+    def repos_unmeasured(self) -> tuple[RepoWork, ...]:
+        return tuple(r for r in self.repos if r.has_work is None)
+
+
+def recovery_lines(record: OriginRecord) -> list[str]:
+    """The record rendered as instructions someone can follow.
+
+    Written as "go here and look at this", not as a field dump, because the
+    reader of this record is by definition dealing with a relocation that went
+    wrong and should not also have to work out what the fields mean.
+
+    Pure strings out; the caller decides where they are printed or stored.
+    """
+    lines = [
+        f"ORIGIN  {record.agent} came from {record.from_host} (moved to {record.to_host} at {record.at:.0f})",
+        f"  ssh {record.from_host}   # everything below is a path ON THAT HOST",
+    ]
+    if record.workdir:
+        lines.append(f"  workdir         {record.workdir}")
+    if record.state_dir:
+        lines.append(f"  state dir       {record.state_dir}")
+    if record.session_uuid:
+        lines.append(f"  session         {record.session_uuid}")
+    if record.transcript_path:
+        carried = {
+            True: "verified on the target",
+            False: "NOT carried — this file is the only copy",
+            None: "UNKNOWN whether it arrived — check the target before deleting anything here",
+        }[record.transcript_carried]
+        lines.append(f"  transcript      {record.transcript_path}  ({carried})")
+
+    dirty = record.repos_with_work
+    if dirty:
+        lines.append("  UNSAVED WORK left on the source:")
+        for repo in dirty:
+            counts = []
+            if repo.uncommitted:
+                counts.append(f"{repo.uncommitted} uncommitted")
+            if repo.unpushed:
+                counts.append(f"{repo.unpushed} unpushed")
+            branch = f" on {repo.branch}" if repo.branch else ""
+            lines.append(f"    {repo.path}{branch}: {', '.join(counts)}")
+
+    unmeasured = record.repos_unmeasured
+    if unmeasured:
+        lines.append("  NOT MEASURED (go and look — this is not 'clean'):")
+        for repo in unmeasured:
+            lines.append(f"    {repo.path}")
+
+    for note in record.notes:
+        lines.append(f"  note            {note}")
+    return lines

--- a/src/scitex_agent_container/_lifecycle/_relocate_phases.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_phases.py
@@ -9,10 +9,20 @@ where it stopped and re-running continues rather than restarts.
 
     PREFLIGHT       validate the target before touching anything
     TARGET_STANDBY  start the target WITHOUT the lease; it runs read-only
+    HANDSHAKE       target -> source round trip; the source must OBSERVE a reply
     SOURCE_DRAIN    source finishes in-flight work, stops taking new
     HANDOVER        the lease moves source -> target  <- THE atomic point
     SOURCE_STOP     stop the source, VERIFY stopped
-    DONE            append the residency record
+    DONE            append the residency record — WHICH IS the host write
+
+THERE IS NO SPEC-EDITING PHASE, and its absence is a decision rather than an
+omission (operator, 2026-08-11: 「設定ファイル、人が書くものはファイル、状態は
+db」). A relocation writes NOTHING to a spec file. Where an agent actually runs
+is an OBSERVATION, so the host lives in the state db and the residency record
+appended at DONE *is* the write that moves it. A phase that edited spec.yaml
+would have had a relocation modifying a git-tracked, human-authored file on two
+machines whose copies are free to diverge — and it would have put an observation
+back into the document that is supposed to hold only intent.
 
 WHY THE ORDER IS THIS ORDER. Everything before HANDOVER is reversible and
 everything after it is cleanup. Before: the source still holds the lease and the
@@ -21,6 +31,21 @@ target holds the lease and the source is locked out by the bumped fence even
 though its process is still alive, so the only sane direction is forward. A
 crash on either side of that single point leaves exactly ONE writer — which is
 the property the whole sequence exists to produce (see :mod:`_relocate_lease`).
+
+THE ADDED PHASE IS BEFORE HANDOVER, and that placement is the whole reason it is
+safe to add: HANDSHAKE only sends messages and reads replies, so it moves no
+write authority and the reversible-before / forward-after asymmetry is
+unchanged. A new phase placed AFTER the handover would have broken it, because
+:func:`abort` would then be refused for a step that is trivially undoable.
+
+WHY THE HANDSHAKE IS A PHASE AND NOT PART OF TARGET_STANDBY. "The process
+started" and "the agent can do agent work" are different measurements, and
+2026-08-11 showed the gap is real: a2a between two live agents delivered nothing
+and nobody noticed until a human did. A relocation that folded the two together
+would have declared the target ready on the strength of a running process, which
+is the same "started, reported healthy, did nothing" shape the preflight checks
+were written for. Separating them means the journal records WHICH of the two
+failed, and a re-run resumes at the one that did.
 
 That asymmetry is enforced here rather than documented: :func:`abort` REFUSES
 once HANDOVER has happened. An abort at that stage would mean taking the lease
@@ -56,6 +81,7 @@ __all__ = [
     "CODE_UNKNOWN_PHASE",
     "DONE",
     "HANDOVER",
+    "HANDSHAKE",
     "PHASES",
     "PREFLIGHT",
     "PhaseVerdict",
@@ -72,6 +98,7 @@ __all__ = [
 
 PREFLIGHT: Final = "preflight"
 TARGET_STANDBY: Final = "target_standby"
+HANDSHAKE: Final = "handshake"
 SOURCE_DRAIN: Final = "source_drain"
 HANDOVER: Final = "handover"
 SOURCE_STOP: Final = "source_stop"
@@ -82,6 +109,7 @@ DONE: Final = "done"
 PHASES: Final[tuple[str, ...]] = (
     PREFLIGHT,
     TARGET_STANDBY,
+    HANDSHAKE,
     SOURCE_DRAIN,
     HANDOVER,
     SOURCE_STOP,

--- a/src/scitex_agent_container/_lifecycle/_relocate_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_preflight.py
@@ -1,43 +1,58 @@
-"""What must be true about the TARGET before a relocation touches anything.
+"""What must be true before a relocation touches anything — the whole answer, once.
 
-Every check here was learned by doing this move by hand on 2026-08-07, and each
-one exists because rewriting `host:` alone produced an agent that STARTED,
-reported HEALTHY, and did nothing. That is the worst failure shape available: it
-looks exactly like success, so nobody goes looking.
+This module is the entry point and nothing else: it runs every check against the
+observations it is given and returns the full report. The observable SHAPES live
+in :mod:`_relocate_preflight_facts` and the eleven predicates in
+:mod:`_relocate_checks`; both are re-exported here, so a caller keeps importing
+``TargetFacts`` / ``Check`` / ``CHECK_*`` from this one place.
 
-    binds        the spec bound /mnt/c — a Windows drive absent on the nas
-    card store   SCITEX_CARDS_DB is 5432 here and 5442 there
-    credentials  the nas had a stale file (expired 2026-05-23, empty
-                 refreshToken) that sac loaded IN PREFERENCE to the good one;
-                 every turn 401'd while `sac agents health` still said healthy
-    runtime      `tui` is rejected by the nas's older sac
-    schema       a top-level `provider:` key is rejected by that same validator
-  + reachability, image presence, free ports, and whether the hub is reachable
-    FROM the target (the nas's services bind 127.0.0.1, so "I can reach it" from
-    here proves nothing about there)
+WHY EVERY CHECK, NOT THE FIRST FAILURE. The operator asked for a dry run, and a
+dry run that stops at the first problem makes him run it N times to find N
+problems. Ten of the eleven checks were learned by hitting them one at a time on
+2026-08-07; that is exactly the experience this shape exists to prevent
+repeating.
 
-CREDENTIALS IS THE ONE TO READ TWICE. Checking PRESENCE passes on an expired
-file. The check has to be about VALIDITY, and the failure it prevents is silent:
-a healthy-looking agent whose every turn 401s.
+UNKNOWN NEVER COUNTS AS PASS. Each check is three-valued, and the aggregate
+refuses on unknowns just as it refuses on failures — reported separately so the
+reader can tell "this is wrong" from "I could not tell". An unknown folded into
+pass is precisely how the 08-07 move reported healthy: the credential check had
+no answer, and something treated that as fine.
 
-WHY THERE IS NO I/O IN THIS MODULE. It evaluates FACTS someone else gathered —
-`TargetFacts` in, `Check`s out. sac does not learn how to probe a host here, and
-a caller can substitute observations from ssh, from a listen daemon, or from a
-test without this file changing. It also means every check is unit-testable
-against the exact broken state we hit in production, which is the only way to
-know a check would have caught it.
-
-UNKNOWN NEVER COUNTS AS PASS. Each check is three-valued, and
-:func:`preflight` refuses on unknowns just as it refuses on failures — reported
-separately so the reader can tell "this is wrong" from "I could not tell". An
-unknown folded into pass is precisely how the 08-07 move reported healthy: the
-credential check had no answer, and something treated that as fine.
+TEN CHECKS ARE ABOUT THE TARGET AND ONE IS ABOUT THE SOURCE. The odd one out —
+``source_work_committed`` — asks whether the machine being LEFT still holds
+uncommitted or unpushed work, because a relocation carries the spec and the
+transcript and nothing else. Its facts come in separately
+(:class:`SourceFacts`), gathered locally rather than over ssh, so a target probe
+can never accidentally fill a field about the source.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Final
+from ._relocate_checks import (
+    CHECK_BINDS,
+    CHECK_CARD_STORE,
+    CHECK_CREDENTIALS,
+    CHECK_HUB_FROM_TARGET,
+    CHECK_IMAGE,
+    CHECK_PORTS,
+    CHECK_REACHABLE,
+    CHECK_RUNTIME,
+    CHECK_SAC_PRESENT,
+    CHECK_SCHEMA,
+    CHECK_SOURCE_WORK,
+    check_binds,
+    check_card_store,
+    check_credentials,
+    check_hub_from_target,
+    check_image,
+    check_ports,
+    check_reachable,
+    check_runtime,
+    check_sac_present,
+    check_schema,
+    check_source_work,
+)
+from ._relocate_preflight_facts import Check, PreflightReport, SourceFacts, TargetFacts
 
 __all__ = [
     "CHECK_BINDS",
@@ -48,304 +63,15 @@ __all__ = [
     "CHECK_PORTS",
     "CHECK_REACHABLE",
     "CHECK_RUNTIME",
+    "CHECK_SAC_PRESENT",
     "CHECK_SCHEMA",
+    "CHECK_SOURCE_WORK",
     "Check",
     "PreflightReport",
+    "SourceFacts",
     "TargetFacts",
     "preflight",
 ]
-
-CHECK_REACHABLE: Final = "target_reachable"
-CHECK_IMAGE: Final = "image_present"
-CHECK_BINDS: Final = "binds_exist_on_target"
-CHECK_CARD_STORE: Final = "card_store_reachable"
-CHECK_CREDENTIALS: Final = "credentials_valid"
-CHECK_RUNTIME: Final = "runtime_supported"
-CHECK_SCHEMA: Final = "spec_schema_accepted"
-CHECK_PORTS: Final = "ports_free"
-CHECK_HUB_FROM_TARGET: Final = "hub_reachable_from_target"
-
-
-@dataclass(frozen=True)
-class Check:
-    """One preflight answer.
-
-    ``ok`` is three-valued: ``True`` pass, ``False`` fail, ``None`` COULD NOT
-    DETERMINE. ``hint`` is required whenever the answer is not a pass — an error
-    that only says what broke is half-written; it must also say what to do.
-    """
-
-    name: str
-    ok: bool | None
-    detail: str
-    hint: str = ""
-
-    def __post_init__(self) -> None:
-        if not self.name:
-            raise ValueError("Check.name must be non-empty")
-        if self.ok not in (True, False, None):
-            raise ValueError(f"Check.ok must be True/False/None, got {self.ok!r}")
-        if not self.detail:
-            raise ValueError(f"Check {self.name!r}: detail must be non-empty")
-        if self.ok is not True and not self.hint:
-            raise ValueError(
-                f"Check {self.name!r}: a non-passing check must carry a hint saying what to do about it"
-            )
-
-
-@dataclass(frozen=True)
-class TargetFacts:
-    """What was OBSERVED about the target host. Gathering happens elsewhere.
-
-    Every field is ``| None`` and defaults to ``None`` meaning NOT OBSERVED —
-    distinct from an observed negative. A prober that could not answer must say
-    so rather than reporting a falsy default, because a default that reads as
-    "absent" turns a failed probe into a confident wrong answer.
-    """
-
-    reachable: bool | None = None
-    image_present: bool | None = None
-    #: Bind SOURCE paths that do not exist on the target (e.g. /mnt/c on nas).
-    missing_bind_sources: tuple[str, ...] | None = None
-    card_store_url: str | None = None
-    card_store_reachable: bool | None = None
-    #: Seconds until the target-local credential expires. Negative = expired.
-    credential_expires_in_s: float | None = None
-    credential_refresh_token_present: bool | None = None
-    supported_runtimes: tuple[str, ...] | None = None
-    #: Top-level spec keys the target's validator rejects (e.g. "provider").
-    rejected_spec_keys: tuple[str, ...] | None = None
-    ports_in_use: tuple[int, ...] | None = None
-    hub_reachable_from_target: bool | None = None
-
-
-@dataclass(frozen=True)
-class PreflightReport:
-    """The whole answer, in one shape.
-
-    ``ok`` is three-valued and derived, never asserted independently of the
-    checks: True only when every check passed, None when nothing failed but
-    something is unknown, False when anything failed. Unknowns are reported
-    SEPARATELY from failures so a reader can tell "this is wrong" from "I could
-    not tell" — and neither reads as go.
-    """
-
-    agent: str
-    to_host: str
-    checks: tuple[Check, ...] = field(default_factory=tuple)
-
-    def __post_init__(self) -> None:
-        if not self.agent:
-            raise ValueError("PreflightReport.agent must be non-empty")
-        if not self.to_host:
-            raise ValueError("PreflightReport.to_host must be non-empty")
-
-    @property
-    def failed(self) -> tuple[Check, ...]:
-        return tuple(c for c in self.checks if c.ok is False)
-
-    @property
-    def unknown(self) -> tuple[Check, ...]:
-        return tuple(c for c in self.checks if c.ok is None)
-
-    @property
-    def ok(self) -> bool | None:
-        if self.failed:
-            return False
-        if self.unknown:
-            return None
-        return True
-
-    def blocking_reasons(self) -> tuple[str, ...]:
-        """Every reason this relocation must not proceed, each with its hint.
-
-        Failures first, then unknowns. Empty only when the answer is a clean go.
-        """
-        return tuple(
-            f"{c.name}: {c.detail} -> {c.hint}" for c in (self.failed + self.unknown)
-        )
-
-
-def _unobserved(name: str, what: str) -> Check:
-    return Check(
-        name=name,
-        ok=None,
-        detail=f"{what} was not observed on the target",
-        hint=(
-            "run the probe that supplies this fact before deciding; an unobserved "
-            "check is not a passing one, and proceeding on it is how a relocation "
-            "reports healthy while doing nothing"
-        ),
-    )
-
-
-def _check_reachable(facts: TargetFacts, to_host: str) -> Check:
-    if facts.reachable is None:
-        return _unobserved(CHECK_REACHABLE, "reachability")
-    if not facts.reachable:
-        return Check(
-            name=CHECK_REACHABLE,
-            ok=False,
-            detail=f"{to_host} did not answer",
-            hint=f"check ssh/network to {to_host}; nothing else in this report is meaningful until it answers",
-        )
-    return Check(name=CHECK_REACHABLE, ok=True, detail=f"{to_host} answered")
-
-
-def _check_image(facts: TargetFacts, to_host: str) -> Check:
-    if facts.image_present is None:
-        return _unobserved(CHECK_IMAGE, "the agent image")
-    if not facts.image_present:
-        return Check(
-            name=CHECK_IMAGE,
-            ok=False,
-            detail=f"the agent's image is absent on {to_host}",
-            hint=f"build or copy the SIF to {to_host} before relocating; a missing image fails at boot, after the lease has moved",
-        )
-    return Check(name=CHECK_IMAGE, ok=True, detail="image present")
-
-
-def _check_binds(facts: TargetFacts, to_host: str) -> Check:
-    if facts.missing_bind_sources is None:
-        return _unobserved(CHECK_BINDS, "bind sources")
-    if facts.missing_bind_sources:
-        missing = ", ".join(facts.missing_bind_sources)
-        return Check(
-            name=CHECK_BINDS,
-            ok=False,
-            detail=f"bind sources absent on {to_host}: {missing}",
-            hint=(
-                "remove or re-point these binds in the spec for the target host "
-                "(2026-08-07: /mnt/c is a Windows drive that does not exist on the nas)"
-            ),
-        )
-    return Check(
-        name=CHECK_BINDS, ok=True, detail="every bind source exists on the target"
-    )
-
-
-def _check_card_store(facts: TargetFacts, to_host: str) -> Check:
-    if facts.card_store_reachable is None:
-        return _unobserved(CHECK_CARD_STORE, "the card store")
-    if not facts.card_store_reachable:
-        url = facts.card_store_url or "(no url recorded)"
-        return Check(
-            name=CHECK_CARD_STORE,
-            ok=False,
-            detail=f"card store {url} not reachable from {to_host}",
-            hint=(
-                "set SCITEX_CARDS_DB to the target's own store before relocating "
-                "(2026-08-07: 5432 here, 5442 there) — an agent that cannot reach its "
-                "board runs and records nothing"
-            ),
-        )
-    return Check(
-        name=CHECK_CARD_STORE, ok=True, detail=f"card store reachable from {to_host}"
-    )
-
-
-def _check_credentials(facts: TargetFacts) -> Check:
-    """VALIDITY, not presence. Presence passes on an expired file."""
-    if (
-        facts.credential_expires_in_s is None
-        or facts.credential_refresh_token_present is None
-    ):
-        return _unobserved(CHECK_CREDENTIALS, "credential validity")
-    if facts.credential_expires_in_s <= 0:
-        return Check(
-            name=CHECK_CREDENTIALS,
-            ok=False,
-            detail=f"target credential expired {abs(facts.credential_expires_in_s):.0f}s ago",
-            hint=(
-                "refresh or replace the target-local credential; sac loads it IN PREFERENCE "
-                "to a good one, so every turn 401s while `sac agents health` still says healthy"
-            ),
-        )
-    if not facts.credential_refresh_token_present:
-        return Check(
-            name=CHECK_CREDENTIALS,
-            ok=False,
-            detail="target credential has an empty refreshToken",
-            hint=(
-                "replace it — it is valid now and unrenewable, so the agent dies at the "
-                "first refresh with no warning beforehand"
-            ),
-        )
-    return Check(
-        name=CHECK_CREDENTIALS,
-        ok=True,
-        detail=f"credential valid for {facts.credential_expires_in_s:.0f}s with a refresh token",
-    )
-
-
-def _check_runtime(facts: TargetFacts, runtime: str) -> Check:
-    if facts.supported_runtimes is None:
-        return _unobserved(CHECK_RUNTIME, "supported runtimes")
-    if runtime not in facts.supported_runtimes:
-        supported = ", ".join(facts.supported_runtimes) or "(none reported)"
-        return Check(
-            name=CHECK_RUNTIME,
-            ok=False,
-            detail=f"target does not support runtime {runtime!r}; it supports: {supported}",
-            hint=(
-                "either upgrade sac on the target or set the spec's runtime to one it accepts "
-                "(2026-08-07: the nas's sac 0.21.9 rejected 'tui')"
-            ),
-        )
-    return Check(name=CHECK_RUNTIME, ok=True, detail=f"runtime {runtime!r} supported")
-
-
-def _check_schema(facts: TargetFacts) -> Check:
-    if facts.rejected_spec_keys is None:
-        return _unobserved(CHECK_SCHEMA, "spec-schema acceptance")
-    if facts.rejected_spec_keys:
-        keys = ", ".join(facts.rejected_spec_keys)
-        return Check(
-            name=CHECK_SCHEMA,
-            ok=False,
-            detail=f"target's validator rejects spec key(s): {keys}",
-            hint=(
-                "remove those keys for the target, or upgrade its sac "
-                "(2026-08-07: a top-level 'provider:' key was rejected by the older validator)"
-            ),
-        )
-    return Check(
-        name=CHECK_SCHEMA, ok=True, detail="target's validator accepts the spec"
-    )
-
-
-def _check_ports(facts: TargetFacts, required_ports: tuple[int, ...]) -> Check:
-    if facts.ports_in_use is None:
-        return _unobserved(CHECK_PORTS, "port availability")
-    clashes = tuple(p for p in required_ports if p in facts.ports_in_use)
-    if clashes:
-        return Check(
-            name=CHECK_PORTS,
-            ok=False,
-            detail=f"port(s) already in use on the target: {', '.join(str(p) for p in clashes)}",
-            hint="free them or reassign the agent's ports in the spec before relocating",
-        )
-    return Check(
-        name=CHECK_PORTS, ok=True, detail="required ports are free on the target"
-    )
-
-
-def _check_hub_from_target(facts: TargetFacts, to_host: str) -> Check:
-    if facts.hub_reachable_from_target is None:
-        return _unobserved(CHECK_HUB_FROM_TARGET, "hub reachability FROM the target")
-    if not facts.hub_reachable_from_target:
-        return Check(
-            name=CHECK_HUB_FROM_TARGET,
-            ok=False,
-            detail=f"the hub is not reachable from {to_host}",
-            hint=(
-                "check what the hub's services bind to — reaching them from HERE proves "
-                "nothing about THERE (the nas binds 127.0.0.1, so nothing cross-host reaches it)"
-            ),
-        )
-    return Check(
-        name=CHECK_HUB_FROM_TARGET, ok=True, detail=f"hub reachable from {to_host}"
-    )
 
 
 def preflight(
@@ -355,22 +81,31 @@ def preflight(
     facts: TargetFacts,
     runtime: str,
     required_ports: tuple[int, ...] = (),
+    source_facts: SourceFacts | None = None,
+    from_host: str = "",
 ) -> PreflightReport:
     """Evaluate every check against observed facts. Touches nothing.
 
-    Returns the full report rather than the first failure: the operator asked
-    for a dry run, and a dry run that stops at the first problem makes him run
-    it N times to find N problems.
+    Returns the full report rather than the first failure, so one run surfaces
+    every problem.
+
+    ``source_facts`` defaults to nothing observed, which reports the source-work
+    check as UNKNOWN and therefore refuses. That default is deliberate: a caller
+    that has not looked at the source has not established the move is safe, and
+    inheriting a pass for a check it never ran is the shape of every bug this
+    module was written about.
     """
     checks = (
-        _check_reachable(facts, to_host),
-        _check_image(facts, to_host),
-        _check_binds(facts, to_host),
-        _check_card_store(facts, to_host),
-        _check_credentials(facts),
-        _check_runtime(facts, runtime),
-        _check_schema(facts),
-        _check_ports(facts, required_ports),
-        _check_hub_from_target(facts, to_host),
+        check_reachable(facts, to_host),
+        check_image(facts, to_host),
+        check_binds(facts, to_host),
+        check_card_store(facts, to_host),
+        check_credentials(facts),
+        check_runtime(facts, runtime),
+        check_schema(facts),
+        check_ports(facts, required_ports),
+        check_hub_from_target(facts, to_host),
+        check_sac_present(facts, to_host),
+        check_source_work(source_facts or SourceFacts(), from_host),
     )
     return PreflightReport(agent=agent, to_host=to_host, checks=checks)

--- a/src/scitex_agent_container/_lifecycle/_relocate_preflight_facts.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_preflight_facts.py
@@ -1,0 +1,152 @@
+"""The SHAPES a relocation preflight is written in: observations in, a verdict out.
+
+Split out of :mod:`_relocate_preflight` so that the vocabulary (what can be
+observed, and what one answer looks like) is readable without scrolling past
+eleven predicates. The predicates live in :mod:`_relocate_checks`; the
+orchestration and the public API stay in :mod:`_relocate_preflight`.
+
+THE ONE RULE THESE TYPES ENCODE. Every observable is ``| None`` and defaults to
+``None`` meaning NOT OBSERVED, which is deliberately distinct from an observed
+negative. A prober that could not answer must say so rather than reporting a
+falsy default, because a default that reads as "absent" turns a failed probe
+into a confident wrong answer — and an unknown folded into a pass is exactly how
+the 2026-08-07 move reported healthy while doing nothing.
+
+Pure data. No I/O, no clock, no decisions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ._relocate_origin import RepoWork
+
+__all__ = [
+    "Check",
+    "PreflightReport",
+    "SourceFacts",
+    "TargetFacts",
+]
+
+
+@dataclass(frozen=True)
+class Check:
+    """One preflight answer.
+
+    ``ok`` is three-valued: ``True`` pass, ``False`` fail, ``None`` COULD NOT
+    DETERMINE. ``hint`` is required whenever the answer is not a pass — an error
+    that only says what broke is half-written; it must also say what to do.
+    """
+
+    name: str
+    ok: bool | None
+    detail: str
+    hint: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("Check.name must be non-empty")
+        if self.ok not in (True, False, None):
+            raise ValueError(f"Check.ok must be True/False/None, got {self.ok!r}")
+        if not self.detail:
+            raise ValueError(f"Check {self.name!r}: detail must be non-empty")
+        if self.ok is not True and not self.hint:
+            raise ValueError(
+                f"Check {self.name!r}: a non-passing check must carry a hint saying what to do about it"
+            )
+
+
+@dataclass(frozen=True)
+class TargetFacts:
+    """What was OBSERVED about the target host. Gathering happens elsewhere.
+
+    Every field is ``| None`` and defaults to ``None`` meaning NOT OBSERVED —
+    distinct from an observed negative. A prober that could not answer must say
+    so rather than reporting a falsy default, because a default that reads as
+    "absent" turns a failed probe into a confident wrong answer.
+    """
+
+    reachable: bool | None = None
+    image_present: bool | None = None
+    #: Bind SOURCE paths that do not exist on the target (e.g. /mnt/c on nas).
+    missing_bind_sources: tuple[str, ...] | None = None
+    card_store_url: str | None = None
+    card_store_reachable: bool | None = None
+    #: Seconds until the target-local credential expires. Negative = expired.
+    credential_expires_in_s: float | None = None
+    credential_refresh_token_present: bool | None = None
+    supported_runtimes: tuple[str, ...] | None = None
+    #: Top-level spec keys the target's validator rejects (e.g. "provider").
+    rejected_spec_keys: tuple[str, ...] | None = None
+    ports_in_use: tuple[int, ...] | None = None
+    hub_reachable_from_target: bool | None = None
+    #: Whether ``command -v sac`` finds it in the NON-INTERACTIVE ssh PATH —
+    #: which is the PATH every remote sac call actually runs under.
+    sac_on_path: bool | None = None
+    #: Where sac was found by looking directly (login shell, known venvs).
+    #: ``""`` means LOOKED AND FOUND NOTHING; ``None`` means nobody looked. The
+    #: distinction is the whole check: not-on-PATH plus found-at-a-path is a
+    #: PATH problem, not-on-PATH plus found-nowhere is a missing install.
+    sac_resolved_path: str | None = None
+
+
+@dataclass(frozen=True)
+class SourceFacts:
+    """What was observed about the host being LEFT.
+
+    A separate type rather than more fields on :class:`TargetFacts`, because the
+    two are gathered by different means — the target's facts come back over ssh,
+    the source's are read locally — and merging them would make it possible to
+    fill a source field from a target probe without anything noticing.
+    """
+
+    #: Every repo the agent works in, with its un-saved counts. ``None`` means
+    #: no scan ran; an empty tuple means a scan ran and found no repos.
+    repos: tuple[RepoWork, ...] | None = None
+
+
+@dataclass(frozen=True)
+class PreflightReport:
+    """The whole answer, in one shape.
+
+    ``ok`` is three-valued and derived, never asserted independently of the
+    checks: True only when every check passed, None when nothing failed but
+    something is unknown, False when anything failed. Unknowns are reported
+    SEPARATELY from failures so a reader can tell "this is wrong" from "I could
+    not tell" — and neither reads as go.
+    """
+
+    agent: str
+    to_host: str
+    checks: tuple[Check, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not self.agent:
+            raise ValueError("PreflightReport.agent must be non-empty")
+        if not self.to_host:
+            raise ValueError("PreflightReport.to_host must be non-empty")
+
+    @property
+    def failed(self) -> tuple[Check, ...]:
+        return tuple(c for c in self.checks if c.ok is False)
+
+    @property
+    def unknown(self) -> tuple[Check, ...]:
+        return tuple(c for c in self.checks if c.ok is None)
+
+    @property
+    def ok(self) -> bool | None:
+        if self.failed:
+            return False
+        if self.unknown:
+            return None
+        return True
+
+    def blocking_reasons(self) -> tuple[str, ...]:
+        """Every reason this relocation must not proceed, each with its hint.
+
+        Failures first, then unknowns. Empty only when the answer is a clean go.
+        """
+        return tuple(
+            f"{c.name}: {c.detail} -> {c.hint}" for c in (self.failed + self.unknown)
+        )

--- a/src/scitex_agent_container/_lifecycle/_relocate_probe.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe.py
@@ -89,6 +89,8 @@ class TargetProbes:
     rejected_spec_keys: Callable[[], tuple[str, ...]] | None = None
     ports_in_use: Callable[[], tuple[int, ...]] | None = None
     hub_reachable_from_target: Callable[[], bool] | None = None
+    sac_on_path: Callable[[], bool] | None = None
+    sac_resolved_path: Callable[[], str] | None = None
 
 
 @dataclass(frozen=True)
@@ -120,6 +122,8 @@ _FIELDS: tuple[str, ...] = (
     "rejected_spec_keys",
     "ports_in_use",
     "hub_reachable_from_target",
+    "sac_on_path",
+    "sac_resolved_path",
 )
 
 

--- a/src/scitex_agent_container/_lifecycle/_relocate_probe_adapter.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe_adapter.py
@@ -1,14 +1,14 @@
-"""The eleven callables :class:`.._relocate_probe.TargetProbes` asks for.
+"""The thirteen callables :class:`.._relocate_probe.TargetProbes` asks for.
 
 :mod:`_relocate_probe` is the PORT — pure orchestration that turns any raising
 callable into ``None``. This is the ADAPTER: it reads the agent's spec, asks the
 target once (:mod:`_relocate_probe_ssh` + :mod:`_relocate_probe_script`), and
-hands back eleven closures over that single answer.
+hands back thirteen closures over that single answer.
 
 HOW PER-FACT DEGRADATION SURVIVES BATCHING — the design point of this file.
-One remote call answers all eleven questions, which is the only way this is fast
+One remote call answers all thirteen questions, which is the only way this is fast
 enough to be run casually. The obvious way to do that is also the dangerous one:
-one blob, one status, eleven facts that stand or fall together. Three rules keep
+one blob, one status, thirteen facts that stand or fall together. Three rules keep
 them independent, and they compose:
 
     the SCRIPT   prints each answer on its own marker line the moment it is
@@ -24,8 +24,8 @@ them independent, and they compose:
                  "credentials_valid: UNKNOWN (no credential file exists on the
                  target among: …)" rather than a bare UNKNOWN.
 
-So a run that answers eight of eleven yields eight OBSERVED facts and three
-unknowns, each naming its own cause. A transport failure yields eleven unknowns
+So a run that answers ten of thirteen yields ten OBSERVED facts and three
+unknowns, each naming its own cause. A transport failure yields thirteen unknowns
 sharing one cause. Neither yields a single ``False``.
 
 NEVER ``False`` FOR "I COULD NOT TELL". Every accessor below either returns
@@ -34,7 +34,7 @@ False`` here, and there must never be: it would turn "no route to the host" into
 "the host has no image", and the relocation would then proceed on fiction — the
 exact 2026-08-07 failure this command exists to prevent.
 
-WHAT IS MEASURED VS WHAT IS READ. Ten facts are measured on the target. One —
+WHAT IS MEASURED VS WHAT IS READ. Twelve facts are measured on the target. One —
 ``card_store_url`` — is READ FROM THE SPEC: it is the URL the agent WOULD dial
 after the move, and preflight uses it only to name the endpoint in a failure
 message. It is supplied because a failure that says "card store not reachable"
@@ -222,12 +222,12 @@ def questions_from_spec(
 
 
 class TargetBatch:
-    """One ssh round trip, memoized, read eleven different ways.
+    """One ssh round trip, memoized, read thirteen different ways.
 
     The run happens on first access and NOT in ``__init__``: a caller that
     builds probes but never gathers must not open a connection. The outcome —
-    success or transport failure — is remembered, so eleven accessors cost one
-    ssh, and a target that is down is not dialled eleven times.
+    success or transport failure — is remembered, so thirteen accessors cost one
+    ssh, and a target that is down is not dialled thirteen times.
     """
 
     def __init__(
@@ -280,7 +280,7 @@ class TargetBatch:
             )
         return value
 
-    # -- the eleven facts --------------------------------------------------
+    # -- the thirteen facts --------------------------------------------------
     def reachable(self) -> bool:
         """True when the target ran our script; False only when ssh itself failed."""
         self._ensure()
@@ -437,6 +437,25 @@ class TargetBatch:
             raise FactUnavailable(self._hub_reason or "the hub address is unknown")
         return self._yes_no("hub", "hub")
 
+    def sac_on_path(self) -> bool:
+        """Whether ``command -v sac`` answers under the RAW ssh PATH.
+
+        An empty value is the ANSWER (nothing on PATH), not a missing one — the
+        script prints the line either way. Only a line that never arrived is
+        unknown, which :meth:`_field` raises for.
+        """
+        return bool(self._field("sac_path", "sac-on-PATH").strip())
+
+    def sac_resolved_path(self) -> str:
+        """Where sac actually is, or ``""`` for looked-and-found-nothing.
+
+        The empty string is load-bearing and must NOT be turned into a raise:
+        it is what separates "sac is not installed on this host" from "sac is
+        installed and the ssh PATH cannot see it", and those need opposite
+        fixes. Only an absent line is undetermined.
+        """
+        return self._field("sac_found", "sac-location").strip()
+
 
 def build_target_probes(
     to_host: str,
@@ -448,7 +467,7 @@ def build_target_probes(
     timeout_s: float = DEFAULT_TIMEOUT_S,
     env: dict[str, str] | None = None,
 ) -> tuple[TargetProbes, TargetBatch]:
-    """Bind the eleven accessors of one :class:`TargetBatch` into a probe set.
+    """Bind the thirteen accessors of one :class:`TargetBatch` into a probe set.
 
     Returns the probes and the batch, so a caller that wants the raw readout
     (for diagnostics) does not have to run the probe twice.
@@ -475,5 +494,7 @@ def build_target_probes(
         rejected_spec_keys=batch.rejected_spec_keys,
         ports_in_use=batch.ports_in_use,
         hub_reachable_from_target=batch.hub_reachable_from_target,
+        sac_on_path=batch.sac_on_path,
+        sac_resolved_path=batch.sac_resolved_path,
     )
     return probes, batch

--- a/src/scitex_agent_container/_lifecycle/_relocate_probe_script.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe_script.py
@@ -164,6 +164,12 @@ def render_probe_script(questions: RemoteQuestions, *, preamble: str = "") -> st
     missing path that does not exist.
     """
     parts: list[str] = []
+    # Captured BEFORE the preamble, which exists precisely to put things on PATH.
+    # The sac-presence question is about the PATH a bare `ssh host sac …` runs
+    # under, so measuring it after the preamble would answer a different
+    # question in the same words — and answer it "yes" on exactly the hosts
+    # (scitex-compute-03/-04) where the bare form fails.
+    parts.append('SACRELOC_PATH0="$PATH"')
     if preamble.strip():
         parts.append(preamble.strip())
     # No `set -e`: a section that fails must not abort the sections after it.
@@ -233,6 +239,7 @@ def render_probe_script(questions: RemoteQuestions, *, preamble: str = "") -> st
     if hub:
         parts.append(hub.rstrip("\n"))
 
+    parts.append(_SAC_WHERE_SECTION)
     parts.append(_SAC_SECTION)
     parts.append('echo "$M end"')
     return "\n".join(parts) + "\n"
@@ -294,6 +301,38 @@ sacreloc_cred() {{
   if [ -n "$_r" ]; then _p=yes; else _p=no; fi
   echo "$M cred=$1|$_e|$_p"
 }}
+"""
+
+
+# WHERE sac IS, asked twice on purpose. `sac_path` is `command -v sac` under the
+# RAW non-interactive PATH — the one a bare `ssh host sac …` gets. `sac_found`
+# looks harder: the login shell first (which is where a venv PATH comes from),
+# then the locations sac is actually installed in across this fleet.
+#
+# Measured 2026-08-11 on scitex-compute-04: sac_path is empty and sac_found is
+# /home/ywatanabe/.env-sac/bin/sac. Those two lines together say "installed, not
+# reachable the way you are calling it", which is a different fix from "install
+# it" — and a single lookup cannot tell them apart, because both produce the
+# same "No such file or directory".
+#
+# An EMPTY value is a measurement here, not a missing one: `sac_found=` means
+# looked-and-found-nothing. A section that never ran prints no line at all, and
+# the adapter turns that absence into UNKNOWN.
+_SAC_WHERE_SECTION = """
+sacreloc_find_sac() {
+  if [ -n "$SHELL" ] && [ -x "$SHELL" ]; then
+    _p=$("$SHELL" -lc 'command -v sac' 2>/dev/null | tail -1)
+    if [ -n "$_p" ] && [ -x "$_p" ]; then echo "$_p"; return 0; fi
+  fi
+  for _c in "$HOME/.env-sac/bin/sac" "$HOME/.local/bin/sac" \
+            /opt/venv-sac/bin/sac /usr/local/bin/sac /usr/bin/sac; do
+    if [ -x "$_c" ]; then echo "$_c"; return 0; fi
+  done
+  echo ""
+}
+sacreloc_raw=$(PATH="$SACRELOC_PATH0" command -v sac 2>/dev/null)
+echo "$M sac_path=$sacreloc_raw"
+echo "$M sac_found=$(sacreloc_find_sac)"
 """
 
 

--- a/src/scitex_agent_container/_lifecycle/_relocate_records.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_records.py
@@ -1,0 +1,195 @@
+"""SPEC is declared intent. STATE DB is observed reality. Neither may hold the other.
+
+The operator's item #2, and he was explicit that it is a CONSTRAINT rather than
+a step in the sequence: 「sac は spec と状態 db を明確に使い分ける！」. A
+relocation is where the two are most easily confused, so this module gives each
+vocabulary a name and refuses a write that mixes them.
+
+    SPEC       what a human declared. Authored, committed to git, diffable,
+               true before anything runs and still true while nothing runs.
+               NOTHING MACHINE-WRITTEN EVER LANDS HERE.
+    STATE DB   what was observed. Written by machines, never by hand, and
+               meaningless without a timestamp.
+
+``host`` IS A STATE FIELD, AND THAT IS THE WHOLE POINT OF THE SPLIT. It was in
+the spec for years and it was never intent: where an agent actually runs is an
+OBSERVATION, and a human writing it down is guessing about a fact rather than
+declaring a preference. The operator settled it on 2026-08-11 —「設定ファイル、
+人が書くものはファイル、状態は db」— which is why a relocation writes the host to
+the db and writes NOTHING to any spec file. That also removes the last reason a
+machine would ever touch a git-tracked, human-authored document that exists in
+two copies on two hosts, free to diverge.
+
+A consequence worth stating out loud, because it is what makes this a refusal
+rather than a note: ``spec_patch(host=…)`` now RAISES. Any code path that tried
+to write a host into a spec fails at the call site with the field named.
+
+THE BUG NOT TO IMITATE, and it is live today. ``sac agents list`` returns
+``status`` values ``defined / stopped / unknown / invalid``. "defined" is a SPEC
+fact — a file exists — rendered in a STATE column, which is why the listing
+reports zero running agents while agents are demonstrably running: the column
+answers "is there a spec" and is read as "is there a process". The same listing
+reports ``host`` as the literal string ``'local'`` on every row, which is a
+placeholder in a field that is supposed to carry an observation. Both are the
+failure this module exists to make unrepresentable for relocation's own writes.
+
+WHY A REFUSAL AND NOT A CONVENTION. A comment saying "do not put runtime state
+in the spec" is obeyed until the first hurry. :func:`spec_patch` and
+:func:`state_record` each know both vocabularies and raise on a field from the
+wrong one, so the mistake fails at the call site with the field named, and a
+test can pin it. The cost is that a genuinely new field has to be declared here
+before it can be written — which is the point, since that is exactly the moment
+someone should be asked which of the two it is.
+
+FIELDS NOT IN EITHER SET ARE REFUSED TOO, rather than passed through. A
+pass-through default means the next unfamiliar key lands wherever it was sent,
+and the separation holds only for the fields someone remembered to list.
+
+Pure: dicts in, dicts out.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+__all__ = [
+    "SPEC_FIELDS",
+    "STATE_FIELDS",
+    "classify_field",
+    "spec_patch",
+    "state_record",
+]
+
+#: DECLARED INTENT. Everything here is authored by a human and lives in the spec
+#: file. A relocation writes NONE of them — they are listed so that sending one
+#: to the state db is caught rather than accepted.
+#:
+#: ``host`` is deliberately ABSENT. See the module docstring: it is an
+#: observation, it now lives in the state db, and a spec write naming it must
+#: fail rather than succeed quietly.
+SPEC_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "runtime",
+        "image",
+        "binds",
+        "raw_args",
+        "env",
+        "a2a_port",
+        "cardinality",
+        "model",
+        "repo",
+        "workdir",
+        "labels",
+        "role",
+    }
+)
+
+#: OBSERVED REALITY. Written by the coordinator from measurements, never by
+#: hand. ``migration_retained`` is the item-#9 flag: the fact of a migration
+#: stays in the state db after the relocation completes and is never discarded.
+STATE_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "agent",
+        #: WHERE THE AGENT ACTUALLY RUNS. Moved here from the spec on
+        #: 2026-08-11; a relocation's DONE phase is the only thing that writes
+        #: it, via the residency record.
+        "host",
+        "host_seeded_from_spec",
+        "from_host",
+        "to_host",
+        "phase",
+        "steps",
+        "started_at",
+        "finished_at",
+        "lease_holder",
+        "lease_fence",
+        "handshake_proven",
+        "handshake_observed_by",
+        "source_stopped_verified",
+        "standby_left_running",
+        "transcript_carried",
+        "origin",
+        "residency",
+        "migration_retained",
+        "outcome_code",
+        "outcome_reason",
+    }
+)
+
+
+def classify_field(name: str) -> str:
+    """``"spec"``, ``"state"``, or a raise naming the field.
+
+    Refuses a name in BOTH sets as loudly as a name in neither: a field that
+    could legitimately be written to either place is the ambiguity this module
+    exists to remove, and silently preferring one would hide it.
+    """
+    in_spec = name in SPEC_FIELDS
+    in_state = name in STATE_FIELDS
+    if in_spec and in_state:
+        raise ValueError(
+            f"{name!r} is declared in BOTH SPEC_FIELDS and STATE_FIELDS — decide which "
+            "it is. A field that means declared intent in one place and an observation "
+            "in another is how `sac agents list` ends up reporting 'defined' as a status"
+        )
+    if in_spec:
+        return "spec"
+    if in_state:
+        return "state"
+    raise ValueError(
+        f"{name!r} is in neither SPEC_FIELDS nor STATE_FIELDS. Declare it in one of "
+        "them first — passing unknown fields through means the separation only holds "
+        "for the fields someone remembered to list"
+    )
+
+
+def _partition(values: dict[str, Any], *, want: str, other: str) -> dict[str, Any]:
+    wrong = sorted(k for k in values if classify_field(k) != want)
+    if wrong:
+        raise ValueError(
+            f"refusing to write {', '.join(repr(k) for k in wrong)} to the {want.upper()}: "
+            f"{'that field is' if len(wrong) == 1 else 'those fields are'} {other} data. "
+            f"The {want} carries "
+            + (
+                "what a human declared; observations belong in the state db"
+                if want == "spec"
+                else "what was observed; declarations belong in the spec file"
+            )
+        )
+    return dict(values)
+
+
+def spec_patch(**values: Any) -> dict[str, Any]:
+    """The subset of ``values`` a spec file may carry, or a raise naming the rest.
+
+    RELOCATION NEVER CALLS THIS, and that is the point rather than an oversight:
+    a relocation writes only the state db, so the one field it once wanted here
+    (``host``) is now refused. The function exists so the refusal is available to
+    every OTHER spec write in sac — the moment one of them reaches for an
+    observation, it fails at the call site with the field named instead of
+    quietly putting a machine-owned fact into a human-authored file.
+    """
+    if not values:
+        raise ValueError(
+            "spec_patch() with no fields writes nothing; call it with the edit"
+        )
+    return _partition(values, want="spec", other="observed")
+
+
+def state_record(**values: Any) -> dict[str, Any]:
+    """The subset of ``values`` the state db may carry, or a raise naming the rest.
+
+    ``agent``, ``from_host`` and ``to_host`` are required: a relocation row that
+    does not say who moved and between which hosts is a row that cannot be
+    joined to anything, which is how the cards table ended up with a NULL
+    ``host`` on 3247 of 3424 rows.
+    """
+    record = _partition(values, want="state", other="declared")
+    missing = [k for k in ("agent", "from_host", "to_host") if not record.get(k)]
+    if missing:
+        raise ValueError(
+            f"a relocation state row must name {', '.join(missing)} — a row that does "
+            "not say who moved and between which hosts cannot be joined to anything "
+            "later, which is exactly the attribution gap residency was added to close"
+        )
+    return record

--- a/src/scitex_agent_container/_lifecycle/_relocate_render.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_render.py
@@ -66,6 +66,11 @@ _CHECK_FACTS: dict[str, tuple[str, ...]] = {
     "spec_schema_accepted": ("rejected_spec_keys",),
     "ports_free": ("ports_in_use",),
     "hub_reachable_from_target": ("hub_reachable_from_target",),
+    "sac_present_on_target": ("sac_on_path", "sac_resolved_path"),
+    # Gathered locally rather than over ssh, so its failures are keyed by the
+    # check's own name; the tuple is here so the map covers every check and a
+    # reader does not have to wonder whether the omission means something.
+    "source_work_committed": ("source_repos",),
 }
 
 

--- a/src/scitex_agent_container/_lifecycle/_relocate_source_scan.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_source_scan.py
@@ -1,0 +1,142 @@
+"""Count what is un-saved in the repos on the host being LEFT.
+
+Supplies :class:`.._relocate_preflight.SourceFacts` — the one preflight check
+that is about the source rather than the target. A relocation carries the spec
+and (when the transport runs) the transcript; a half-finished branch, a stash and
+an unpushed commit stay exactly where they are, on a machine the agent will no
+longer be looking at.
+
+WHY THE COUNTS ARE TAKEN LOCALLY AND NOT OVER ssh. The source is where the
+coordinator runs. Routing this through the same batched remote probe would mean
+measuring the machine the command is on by going out to the network and back —
+more ways to fail for a question that needs none of them.
+
+A FAILED SCAN IS ``None``, NEVER ZERO. This is the same rule as
+:mod:`_relocate_probe_adapter` and it is even easier to break here, because
+``git status --porcelain`` failing and a clean tree BOTH produce no output
+lines. Counting lines on a failed run yields 0, "clean", and a relocation that
+strands the work it was checking for. So every command's exit code is inspected
+and anything other than a clean success leaves the count ``None``, which the
+check reports as UNKNOWN and refuses on.
+
+UNPUSHED IS COUNTED AGAINST THE UPSTREAM, AND NO UPSTREAM IS NOT ZERO. A branch
+with no upstream has nowhere to have been pushed TO, so every commit on it is
+unreachable from any other machine. Reporting 0 there would be the most
+expensive kind of wrong — it is precisely the branch a relocation strands. It is
+reported as un-measured, with the reason, rather than as clean.
+
+The runner is injected, so the decision logic is testable against captured git
+output with no repo and no subprocess.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+from ._relocate_origin import RepoWork
+from ._relocate_preflight import SourceFacts
+
+__all__ = [
+    "CommandResult",
+    "run_git",
+    "scan_repo",
+    "scan_source",
+]
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """One command's output and how it exited. ``exit_code`` is never assumed."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+
+    @property
+    def ok(self) -> bool:
+        return self.exit_code == 0
+
+
+def run_git(argv: Sequence[str], *, timeout_s: float = 20.0) -> CommandResult:
+    """Run a git command, returning its result rather than raising on failure.
+
+    A non-zero exit is DATA here — it is what tells :func:`scan_repo` to leave a
+    count unmeasured instead of reading an empty stdout as "clean". Only a
+    failure to run git at all becomes an exceptional exit code (127), so the
+    caller still sees "this was not measured" rather than a crash mid-preflight.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603
+            list(argv),
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: a git that could not run must leave the count UNMEASURED, never 0; the reason is preserved on stderr)
+        return CommandResult(
+            stdout="", stderr=f"{type(exc).__name__}: {exc}", exit_code=127
+        )
+    return CommandResult(
+        stdout=proc.stdout or "", stderr=proc.stderr or "", exit_code=proc.returncode
+    )
+
+
+def scan_repo(
+    path: str,
+    *,
+    runner: Callable[[Sequence[str]], CommandResult] = run_git,
+) -> RepoWork:
+    """Measure one repo. Any command that did not succeed leaves its count ``None``.
+
+    Three questions, each independent so a failure costs only its own answer:
+    the branch name, the working-tree status, and the commits ahead of the
+    upstream. A repo whose branch could not be read is still worth counting
+    files in.
+    """
+    if not path:
+        raise ValueError("scan_repo needs a repo path")
+
+    branch_run = runner(["git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD"])
+    branch = branch_run.stdout.strip() if branch_run.ok else ""
+
+    status_run = runner(["git", "-C", path, "status", "--porcelain"])
+    uncommitted: int | None
+    if status_run.ok:
+        uncommitted = len([ln for ln in status_run.stdout.splitlines() if ln.strip()])
+    else:
+        # An empty stdout from a FAILED status is indistinguishable from a clean
+        # tree. Refusing to count it is the whole reason this branch exists.
+        uncommitted = None
+
+    ahead_run = runner(["git", "-C", path, "rev-list", "--count", "@{u}..HEAD"])
+    unpushed: int | None
+    if ahead_run.ok:
+        raw = ahead_run.stdout.strip()
+        unpushed = int(raw) if raw.isdigit() else None
+    else:
+        # Usually "no upstream configured". That is NOT zero unpushed commits —
+        # it is a branch that exists on this machine only, which is exactly the
+        # work a relocation would strand.
+        unpushed = None
+
+    return RepoWork(
+        path=path, branch=branch, uncommitted=uncommitted, unpushed=unpushed
+    )
+
+
+def scan_source(
+    repo_paths: Sequence[str],
+    *,
+    runner: Callable[[Sequence[str]], CommandResult] = run_git,
+) -> SourceFacts:
+    """Scan every repo the agent works in, into the facts preflight consumes.
+
+    An empty ``repo_paths`` yields an empty tuple, which is an OBSERVED "no
+    repos to strand" and passes the check. That is different from passing no
+    facts at all (``SourceFacts()``), which is "nobody looked" and refuses —
+    and the difference is the caller's to state deliberately, which is why this
+    function does not try to discover repos on its own.
+    """
+    return SourceFacts(repos=tuple(scan_repo(p, runner=runner) for p in repo_paths))

--- a/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
@@ -43,6 +43,8 @@ never eleven of either because one section failed.
 
 from __future__ import annotations
 
+import time
+
 import click
 
 from .._lifecycle._relocate_preflight import preflight
@@ -78,6 +80,16 @@ def _dig(body: dict, *path: str) -> object:
 def declared_from_spec(spec: dict) -> dict[str, object]:
     """Pull the spec's own claims out for the DECLARED section.
 
+    ``host`` IS DELIBERATELY NOT HERE. It is an observation, not a declaration
+    (operator, 2026-08-11: 「設定ファイル、人が書くものはファイル、状態は db」), so
+    it comes from the state db and is printed under OBSERVED. Leaving it in this
+    dict would put a machine-owned fact under a heading that reads "from the
+    spec — not verified by this run", which is the same collapse that makes
+    `sac agents list` report a running agent as `defined`. The legacy field
+    still present in every spec on disk is reported by
+    :func:`.._lifecycle._relocate_host_record.legacy_spec_host_notice`, which
+    says out loud that it is ignored.
+
     Reads defensively: a missing key yields ``None``, rendered as ``(unset)``. A
     relocation must be able to report on a half-written spec — refusing to print
     because a field is absent would hide the very thing the operator needs.
@@ -103,12 +115,62 @@ def declared_from_spec(spec: dict) -> dict[str, object]:
     card_store = card_store_url_from_spec(spec) or None
     return {
         "runtime": body.get("runtime"),
-        "host": body.get("host"),
         "image": _dig(body, "apptainer", "image"),
         "a2a port": _dig(body, "a2a", "port"),
         "bind sources": bind_sources,
         "card store": card_store,
     }
+
+
+def _residency_history(name: str):
+    """The agent's stays, read from the STATE DB — the only authority on host.
+
+    THERE IS NO RESIDENCY TABLE YET, and pretending otherwise would be the worse
+    of the two available lies. What exists is ``instances.host``, which
+    ``record_instance_start`` canonicalises and writes when a process starts —
+    an observation, and the right kind of one. So an active instance row becomes
+    a single OPEN stay and that is the whole history.
+
+    The cost is stated rather than hidden: with one row there is no audit trail,
+    so ``host_at(history, t)`` can answer "where does it live now" and cannot
+    answer "which host wrote this row in March". Closing that needs a residency
+    table; until then this returns the shortest history that is TRUE rather than
+    a longer one that is invented.
+
+    No row yields ``()`` — genuinely "the db knows nothing", which is what lets
+    a legacy spec ``host:`` seed it once.
+    """
+    from .._lifecycle._residency import Residency
+    from .._state.state_db_instances import list_active_instances
+
+    rows = [r for r in list_active_instances() if r.get("name") == name]
+    if not rows:
+        return ()
+    row = rows[0]
+    host = (row.get("host") or "").strip()
+    if not host:
+        return ()
+    return (Residency(host=host, from_ts=_epoch(row.get("started_at"))),)
+
+
+def _epoch(started_at: object) -> float:
+    """``instances.started_at`` is an ISO TEXT column; residency wants seconds.
+
+    An unparseable stamp yields ``0.0`` rather than raising. That is safe HERE
+    and only here: the stay is open, so ``current_host`` reads the host and
+    never consults the start time, and a relocation must not be blocked by a
+    malformed timestamp on a row whose host is perfectly legible. It would NOT
+    be safe for the attribution lookup, which is one more reason that needs a
+    real residency table rather than this row.
+    """
+    if not isinstance(started_at, str) or not started_at.strip():
+        return 0.0
+    from datetime import datetime
+
+    try:
+        return datetime.fromisoformat(started_at.strip()).timestamp()
+    except ValueError:  # stx-allow: fallback (reason: an open stay is read for its HOST; a malformed start time must not block a relocation whose host is legible)
+        return 0.0
 
 
 def _required_ports(declared: dict[str, object]) -> tuple[int, ...]:
@@ -175,15 +237,40 @@ def relocate(name: str, to_host: str, dry_run: bool) -> None:
     spec = yaml.safe_load(spec_path.read_text()) or {}
 
     declared = declared_from_spec(spec)
-    if declared.get("host") == to_host:
+
+    # WHERE IT RUNS NOW comes from the STATE DB, never from the spec. The spec's
+    # `host:` is a legacy field: it is read at most ONCE, to seed a db that knows
+    # nothing, and is ignored from then on. Reading it here instead would make
+    # this command answer "where does it run" from a hand-written file that
+    # exists in one copy per machine — the confusion the 2026-08-11 ruling
+    # removed (「設定ファイル、人が書くものはファイル、状態は db」).
+    from .._lifecycle._relocate_host_record import (
+        legacy_spec_host_notice,
+        resolve_host,
+    )
+
+    body = spec.get("spec") if isinstance(spec.get("spec"), dict) else spec
+    legacy_host = body.get("host") if isinstance(body, dict) else None
+    where = resolve_host(
+        _residency_history(name),
+        legacy_spec_host=legacy_host if isinstance(legacy_host, str) else None,
+        now=time.time(),
+    )
+    notice = legacy_spec_host_notice(
+        spec_host=legacy_host if isinstance(legacy_host, str) else None,
+        db_host=where.host,
+    )
+    if notice:
+        console.print(f"[yellow]note:[/yellow] {notice}", soft_wrap=True)
+    if where.host == to_host:
         console.print(
-            f"[yellow]{name} already declares host {to_host!r} — nothing to relocate.[/yellow]\n"
-            "If it is actually running elsewhere, that disagreement is the thing to fix first."
+            f"[yellow]{name} is already recorded on {to_host!r} — nothing to relocate.[/yellow]\n"
+            f"Source of that answer: {where.reason}"
         )
         raise SystemExit(EXIT_REFUSED)
 
-    # ONE batched ssh round trip answers all eleven facts; each is parsed on its
-    # own marker line, so a section that fails costs only its own fact. See
+    # ONE batched ssh round trip answers all thirteen facts; each is parsed on
+    # its own marker line, so a section that fails costs only its own fact. See
     # `.._lifecycle._relocate_probe_adapter` for how per-fact degradation
     # survives the batching.
     probes, _batch = build_target_probes(

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_execute.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_execute.py
@@ -1,0 +1,448 @@
+"""The driver's whole job is the ORDER, and the asymmetry around the atomic point.
+
+Before HANDOVER a failure aborts, and nothing durable has been written to undo:
+the host goes to the state db at DONE and to no spec file at any point. At or
+after the handover a failure STOPS AND REPORTS — there is no rollback, because
+the target already owns the lease and the source is fenced out, so an "undo"
+would mean taking write authority back from a live holder.
+
+The property that is easiest to lose and most expensive to lose is the third
+one: an UNKNOWN stops as firmly as a failure. A step whose unknown was folded
+into success would hand the lease to a target nobody established was working —
+the 2026-08-07 failure, with the source already stopped.
+
+Effects are real callables returning real values. Nothing is mocked and nothing
+touches a host: that is exactly why every branch below is reachable in a test.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_execute import (
+    CODE_ABORTED,
+    CODE_COMPLETED,
+    CODE_STOPPED_PAST_NO_RETURN,
+    CODE_UNKNOWN,
+    ExecuteOutcome,
+    PhaseEffects,
+    StepResult,
+    execute,
+)
+from scitex_agent_container._lifecycle._relocate_phases import (
+    ABORTED,
+    DONE,
+    HANDOVER,
+    HANDSHAKE,
+    PHASES,
+    SOURCE_STOP,
+    TARGET_STANDBY,
+    Relocation,
+    advance,
+    begin,
+)
+
+AGENT = "scitex-agent-container"
+SRC = "ywata-note-win"
+DST = "scitex-compute-04"
+T0 = 1_000_000.0
+
+
+def _clock():
+    """A monotonic clock as a callable — real time, just not wall time."""
+    ticks = itertools.count(T0)
+    return lambda: float(next(ticks))
+
+
+def _ok(what: str) -> StepResult:
+    return StepResult(ok=True, detail=what)
+
+
+def _fail(what: str) -> StepResult:
+    return StepResult(ok=False, detail=what, hint="fix it and re-run")
+
+
+def _unknown(what: str) -> StepResult:
+    return StepResult(ok=None, detail=what, hint="go and measure it")
+
+
+def _effects(**overrides) -> PhaseEffects:
+    """Every phase succeeds unless a test replaces one."""
+    base = dict(
+        start_target_standby=lambda: _ok("target started read-only"),
+        handshake=lambda: _ok("round trip observed"),
+        drain_source=lambda: _ok("source drained"),
+        hand_over_lease=lambda: _ok("lease moved at fence 4"),
+        stop_source=lambda: _ok("source stopped and verified"),
+        finish=lambda: _ok("residency and origin recorded"),
+    )
+    base.update(overrides)
+    return PhaseEffects(**base)
+
+
+def _fresh() -> Relocation:
+    return begin(agent=AGENT, from_host=SRC, to_host=DST, now=T0)
+
+
+def _at(phase: str) -> Relocation:
+    """A relocation whose journal already records everything up to ``phase``."""
+    rel = _fresh()
+    for i, nxt in enumerate(PHASES[1 : PHASES.index(phase) + 1], start=1):
+        rel, verdict = advance(rel, to_phase=nxt, now=T0 + i, detail=f"step {i}")
+        assert verdict.allowed is True  # harness guard, not the behaviour tested
+    return rel
+
+
+# ---------------------------------------------------------------------------
+# the happy path
+# ---------------------------------------------------------------------------
+
+
+def test_every_phase_succeeding_completes_the_relocation() -> None:
+    # Arrange
+    effects = _effects()
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.completed is True
+
+
+def test_a_completed_relocation_ends_at_done() -> None:
+    # Arrange
+    effects = _effects()
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.relocation.phase == DONE
+
+
+def test_a_completed_relocation_journals_every_phase_in_order() -> None:
+    # Arrange
+    effects = _effects()
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert tuple(s.phase for s in outcome.relocation.steps) == PHASES
+
+
+def test_the_first_thing_a_relocation_does_is_start_the_standby() -> None:
+    # Arrange: the order is the design, so it is asserted rather than assumed.
+    # Nothing precedes the standby — in particular no spec is edited.
+    effects = _effects()
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.log[0].startswith(TARGET_STANDBY)
+
+
+def test_the_handshake_runs_before_the_handover() -> None:
+    # Arrange
+    effects = _effects()
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.log.index(
+        next(x for x in outcome.log if x.startswith(HANDSHAKE))
+    ) < outcome.log.index(next(x for x in outcome.log if x.startswith(HANDOVER)))
+
+
+def test_a_completed_relocation_carries_the_completed_code() -> None:
+    # Arrange
+    effects = _effects()
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.code == CODE_COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# resuming — a crash continues, it does not restart
+# ---------------------------------------------------------------------------
+
+
+def test_a_resumed_relocation_does_not_re_run_the_phases_already_journalled() -> None:
+    # Arrange: a coordinator that died after the handshake re-runs from drain.
+    effects = _effects()
+    # Act
+    outcome = execute(_at(HANDSHAKE), effects=effects, now=_clock())
+    # Assert
+    assert outcome.log[0].startswith("source_drain")
+
+
+def test_a_resumed_relocation_still_reaches_done() -> None:
+    # Arrange
+    effects = _effects()
+    # Act
+    outcome = execute(_at(HANDOVER), effects=effects, now=_clock())
+    # Assert
+    assert outcome.relocation.phase == DONE
+
+
+# ---------------------------------------------------------------------------
+# before the atomic point — abort and undo
+# ---------------------------------------------------------------------------
+
+
+def test_a_handshake_failure_aborts_the_relocation() -> None:
+    # Arrange: this is the gate the 2026-08-11 silence would have hit.
+    effects = _effects(handshake=lambda: _fail("no reply reached the source"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.relocation.phase == ABORTED
+
+
+def test_a_pre_handover_failure_carries_the_aborted_code() -> None:
+    # Arrange
+    effects = _effects(handshake=lambda: _fail("no reply reached the source"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.code == CODE_ABORTED
+
+
+def test_a_pre_handover_abort_leaves_the_recorded_host_unchanged() -> None:
+    # Arrange: the host is written to the db at DONE and nowhere else, so an
+    # abort has nothing to reverse — and the message must say so rather than
+    # leaving the reader to wonder what state a file is in.
+    effects = _effects(handshake=lambda: _fail("no reply reached the source"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert "host in the state db is unchanged" in outcome.hint
+
+
+def test_a_pre_handover_failure_says_the_lease_never_moved() -> None:
+    # Arrange
+    effects = _effects(start_target_standby=lambda: _fail("the target did not boot"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert f"lease is still with {SRC}" in outcome.hint
+
+
+def test_a_failure_names_the_phase_it_stopped_at() -> None:
+    # Arrange
+    effects = _effects(start_target_standby=lambda: _fail("the target did not boot"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.stopped_at == TARGET_STANDBY
+
+
+def test_a_failure_to_start_the_standby_leaves_nothing_running() -> None:
+    # Arrange: an observed "it did not boot" is a real answer, so there is no
+    # abandoned process to warn about.
+    effects = _effects(start_target_standby=lambda: _fail("the target did not boot"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.standby_left_running is False
+
+
+def test_an_unconfirmed_standby_start_is_reported_as_possibly_left_running() -> None:
+    # Arrange: an effect that could not say whether the target came up may well
+    # have started it, and "nothing was left running" would send nobody to look.
+    effects = _effects(start_target_standby=lambda: _unknown("no health line seen"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.standby_left_running is True
+
+
+def test_an_abort_after_the_standby_warns_that_it_is_still_running() -> None:
+    # Arrange: stopping it here would be another remote action taken at the
+    # moment least is known, so it is reported rather than cleaned up.
+    effects = _effects(handshake=lambda: _fail("no reply reached the source"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert "STILL RUNNING" in outcome.hint
+
+
+# ---------------------------------------------------------------------------
+# unknown stops as firmly as failure, and says something different
+# ---------------------------------------------------------------------------
+
+
+def test_an_unknown_step_does_not_continue_to_the_next_phase() -> None:
+    # Arrange: an unknown handshake folded into success hands the lease to a
+    # target nobody established was working.
+    effects = _effects(handshake=lambda: _unknown("no reply seen in 60s"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.stopped_at == HANDSHAKE
+
+
+def test_an_unknown_step_reports_completed_as_unknown_not_false() -> None:
+    # Arrange
+    effects = _effects(handshake=lambda: _unknown("no reply seen in 60s"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.completed is None
+
+
+def test_an_unknown_step_carries_its_own_code() -> None:
+    # Arrange: go-and-measure is a different action from go-and-fix.
+    effects = _effects(handshake=lambda: _unknown("no reply seen in 60s"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.code == CODE_UNKNOWN
+
+
+def test_an_unknown_step_keeps_the_measure_it_hint() -> None:
+    # Arrange
+    effects = _effects(handshake=lambda: _unknown("no reply seen in 60s"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert "go and measure it" in outcome.hint
+
+
+# ---------------------------------------------------------------------------
+# at or after the atomic point — no rollback, ever
+# ---------------------------------------------------------------------------
+
+
+def test_a_failure_after_the_handover_is_not_aborted() -> None:
+    # Arrange: aborting would mean taking the lease back from a live holder.
+    effects = _effects(stop_source=lambda: _fail("the source is still running"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.relocation.phase != ABORTED
+
+
+def test_a_failure_after_the_handover_carries_the_past_no_return_code() -> None:
+    # Arrange
+    effects = _effects(stop_source=lambda: _fail("the source is still running"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.code == CODE_STOPPED_PAST_NO_RETURN
+
+
+def test_a_failure_after_the_handover_says_it_cannot_be_rolled_back() -> None:
+    # Arrange
+    effects = _effects(stop_source=lambda: _fail("the source is still running"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert "cannot be rolled back" in outcome.hint
+
+
+def test_a_failure_after_the_handover_names_the_host_that_now_holds_the_lease() -> None:
+    # Arrange
+    effects = _effects(stop_source=lambda: _fail("the source is still running"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert f"{DST} holds the lease" in outcome.hint
+
+
+def test_a_failure_after_the_handover_does_not_warn_about_an_abandoned_standby() -> (
+    None
+):
+    # Arrange: past the atomic point the "standby" is the live agent. Calling it
+    # something to clean up would invite stopping the only running instance.
+    effects = _effects(stop_source=lambda: _fail("the source is still running"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.standby_left_running is False
+
+
+def test_a_failure_at_the_handover_itself_is_still_reversible() -> None:
+    # Arrange: the lease did NOT move, so this side of the point is the safe one.
+    effects = _effects(hand_over_lease=lambda: _fail("the lease was held by another"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.relocation.phase == ABORTED
+
+
+def test_a_failure_at_the_handover_says_the_host_record_is_untouched() -> None:
+    # Arrange: the db write happens at DONE, so an abort here leaves the
+    # recorded host exactly where it was.
+    effects = _effects(hand_over_lease=lambda: _fail("the lease was held by another"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert "host in the state db is unchanged" in outcome.hint
+
+
+def test_a_stopped_relocation_past_the_atomic_point_reports_it() -> None:
+    # Arrange
+    effects = _effects(stop_source=lambda: _fail("the source is still running"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.past_no_return is True
+
+
+# ---------------------------------------------------------------------------
+# a missing effect is refused, not skipped
+# ---------------------------------------------------------------------------
+
+
+def test_a_relocation_with_no_handover_effect_refuses_to_start() -> None:
+    # Arrange: journalling its way to DONE having moved nothing is the most
+    # convincing possible imitation of a successful relocation.
+    effects = _effects(hand_over_lease=None)
+    # Act
+    call = lambda: execute(_fresh(), effects=effects, now=_clock())  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError, match=HANDOVER):
+        call()
+
+
+def test_the_missing_effect_refusal_names_every_phase_that_has_none() -> None:
+    # Arrange
+    effects = _effects(stop_source=None, finish=None)
+    # Act
+    call = lambda: execute(_fresh(), effects=effects, now=_clock())  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError, match=SOURCE_STOP):
+        call()
+
+
+# ---------------------------------------------------------------------------
+# the result shapes refuse to be half-written
+# ---------------------------------------------------------------------------
+
+
+def test_a_step_that_did_not_succeed_must_name_the_next_action() -> None:
+    # Arrange
+    build = lambda: StepResult(ok=False, detail="it broke")  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="hint")
+    # Assert
+    with caught:
+        build()
+
+
+def test_a_step_with_no_detail_is_unrepresentable() -> None:
+    # Arrange: the detail is what the journal records months later.
+    build = lambda: StepResult(ok=True, detail="")  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="detail")
+    # Assert
+    with caught:
+        build()
+
+
+def test_an_incomplete_outcome_must_say_what_to_do_next() -> None:
+    # Arrange
+    build = lambda: ExecuteOutcome(  # noqa: E731
+        completed=False, code=CODE_ABORTED, reason="stopped", relocation=_fresh()
+    )
+    # Act
+    caught = pytest.raises(ValueError, match="what to do next")
+    # Assert
+    with caught:
+        build()

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_handshake.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_handshake.py
@@ -1,0 +1,276 @@
+"""A one-way signal is not a handshake, and these tests are the reason why.
+
+Measured 2026-08-11: a2a between two LIVE agents delivered nothing, and nobody
+noticed until a human asked. Every one-way signal was green — both processes
+ran, both sidecars listened, both dispatch calls returned accepted. A relocation
+gated on "the target started" would have handed the lease into exactly that, and
+`abort` refuses past the handover, so there would have been no way back.
+
+So each test below removes exactly one of the four things a real round trip has
+to show, and pins that removing it refuses:
+
+    accepted only               -> the agent was never asked anything
+    accepted, no reply          -> THE 08-11 failure
+    reply with the wrong nonce  -> it answers some other message
+    reply with the wrong answer -> the transport works, the loop did not
+
+Pure predicates over observations. No transport, no sleeping, no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_handshake import (
+    CODE_NO_REPLY,
+    CODE_NONCE_MISMATCH,
+    CODE_NOT_ACCEPTED,
+    CODE_OK,
+    CODE_UNKNOWN,
+    CODE_WORK_NOT_PROVEN,
+    HandshakeFacts,
+    HandshakeVerdict,
+    evaluate_handshake,
+)
+
+NONCE = "reloc-7f3a91"
+ANSWER = "scitex-compute-04:19019"
+OBSERVER = "the source agent"
+
+
+def _facts(**overrides: object) -> HandshakeFacts:
+    """A complete, honest round trip. Each test removes exactly one part."""
+    base = dict(
+        challenge_accepted=True,
+        reply_observed=True,
+        observed_by=OBSERVER,
+        reply_nonce=NONCE,
+        reply_answer=ANSWER,
+    )
+    base.update(overrides)
+    return HandshakeFacts(**base)  # type: ignore[arg-type]
+
+
+def _run(**overrides: object) -> HandshakeVerdict:
+    return evaluate_handshake(_facts(**overrides), nonce=NONCE, expected_answer=ANSWER)
+
+
+# ---------------------------------------------------------------------------
+# the whole round trip
+# ---------------------------------------------------------------------------
+
+
+def test_a_complete_round_trip_proves_the_target_can_do_agent_work() -> None:
+    # Arrange
+    facts = _facts()
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert verdict.proven is True
+
+
+def test_a_complete_round_trip_carries_the_ok_code() -> None:
+    # Arrange
+    facts = _facts()
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert verdict.code == CODE_OK
+
+
+def test_a_proven_handshake_names_who_observed_the_reply() -> None:
+    # Arrange: "the coordinator saw it" and "the source saw it" are different
+    # measurements, and a report that omits which invites the stronger reading.
+    facts = _facts()
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert OBSERVER in verdict.reason
+
+
+# ---------------------------------------------------------------------------
+# A -> B alone
+# ---------------------------------------------------------------------------
+
+
+def test_a_challenge_the_target_refused_proves_nothing() -> None:
+    # Arrange
+    facts = _facts(challenge_accepted=False)
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert verdict.code == CODE_NOT_ACCEPTED
+
+
+def test_a_refused_challenge_says_the_agent_was_never_asked() -> None:
+    # Arrange: the distinction matters — nothing has been learned about the
+    # agent's behaviour, only about its sidecar.
+    facts = _facts(challenge_accepted=False)
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert "never asked" in verdict.reason
+
+
+def test_an_unobserved_acceptance_is_unknown_not_a_refusal() -> None:
+    # Arrange: a dispatch call that raised is not a refusal by the target.
+    facts = _facts(challenge_accepted=None)
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert verdict.proven is None
+
+
+# ---------------------------------------------------------------------------
+# accepted but silent — the measured failure
+# ---------------------------------------------------------------------------
+
+
+def test_accepted_with_no_reply_refuses() -> None:
+    # Arrange: this is the exact 2026-08-11 shape.
+    facts = _facts(reply_observed=False)
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert verdict.proven is False
+
+
+def test_accepted_with_no_reply_carries_its_own_code() -> None:
+    # Arrange
+    facts = _facts(reply_observed=False)
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert verdict.code == CODE_NO_REPLY
+
+
+def test_a_silent_target_tells_the_operator_not_to_hand_over_the_lease() -> None:
+    # Arrange
+    facts = _facts(reply_observed=False)
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert "do NOT hand over the lease" in verdict.hint
+
+
+def test_an_unobserved_reply_is_unknown_because_waiting_longer_may_answer_it() -> None:
+    # Arrange: "I did not see one in the time I waited" is not "the target is
+    # broken", and the two call for different next actions.
+    facts = _facts(reply_observed=None)
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert verdict.code == CODE_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# correlation — a reply must be THE reply
+# ---------------------------------------------------------------------------
+
+
+def test_a_reply_carrying_another_nonce_is_refused() -> None:
+    # Arrange: without correlation, a relocation retried three times eventually
+    # finds a reply that proves nothing.
+    facts = _facts(reply_nonce="an-older-turn")
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert verdict.code == CODE_NONCE_MISMATCH
+
+
+def test_a_mismatched_nonce_names_both_values() -> None:
+    # Arrange
+    facts = _facts(reply_nonce="an-older-turn")
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert "an-older-turn" in verdict.reason
+
+
+def test_a_reply_with_no_readable_nonce_is_unknown() -> None:
+    # Arrange
+    facts = _facts(reply_nonce=None)
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert verdict.proven is None
+
+
+def test_an_empty_nonce_is_refused_at_the_call_rather_than_weakening_the_gate() -> None:
+    # Arrange: an empty nonce would make every reply correlate.
+    facts = _facts()
+    # Act
+    call = lambda: evaluate_handshake(facts, nonce="", expected_answer=ANSWER)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError, match="non-empty nonce"):
+        call()
+
+
+# ---------------------------------------------------------------------------
+# proof of work — an echo is not an agent
+# ---------------------------------------------------------------------------
+
+
+def test_a_correlated_reply_with_the_wrong_answer_is_refused() -> None:
+    # Arrange: the message path works and the loop did not do the work.
+    facts = _facts(reply_answer="i am fine thanks")
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert verdict.code == CODE_WORK_NOT_PROVEN
+
+
+def test_an_unproven_answer_is_caught_before_the_lease_moves() -> None:
+    # Arrange
+    facts = _facts(reply_answer="i am fine thanks")
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert "before the lease moved" in verdict.hint
+
+
+def test_a_reply_with_no_answer_at_all_is_unknown() -> None:
+    # Arrange: a correlated reply with nothing in it shows the message
+    # round-tripped, not that the loop did anything.
+    facts = _facts(reply_answer=None)
+    # Act
+    verdict = evaluate_handshake(facts, nonce=NONCE, expected_answer=ANSWER)
+    # Assert
+    assert verdict.proven is None
+
+
+def test_an_empty_expected_answer_is_refused_rather_than_waiving_the_check() -> None:
+    # Arrange: a check that can be disabled by passing nothing will be.
+    facts = _facts()
+    # Act
+    call = lambda: evaluate_handshake(facts, nonce=NONCE, expected_answer="")  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError, match="non-empty expected_answer"):
+        call()
+
+
+# ---------------------------------------------------------------------------
+# the verdict shape itself
+# ---------------------------------------------------------------------------
+
+
+def test_a_refusal_without_a_next_action_is_unrepresentable() -> None:
+    # Arrange
+    build = lambda: HandshakeVerdict(  # noqa: E731
+        proven=False, code=CODE_NO_REPLY, reason="nothing came back"
+    )
+    # Act
+    caught = pytest.raises(ValueError, match="hint")
+    # Assert
+    with caught:
+        build()
+
+
+def test_the_verdict_defines_no_bool_so_a_refusal_cannot_read_as_permission() -> None:
+    # Arrange: `if verdict:` on a dataclass is true even for a refusal, and the
+    # step after this one is the handover.
+    verdict = _run(reply_observed=False)
+    # Act
+    has_bool = "__bool__" in type(verdict).__dict__
+    # Assert
+    assert has_bool is False

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_host_record.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_host_record.py
@@ -1,0 +1,275 @@
+"""The db answers "where does this agent run". The spec's `host:` is dead text.
+
+Operator, 2026-08-11:「設定ファイル、人が書くものはファイル、状態は db」. Where an
+agent runs is an OBSERVATION, so it lives in the state db, and a relocation
+writes it there and nowhere else.
+
+The migration is the part with teeth, and these tests pin it: SEED ONCE, THEN
+IGNORE. Once the db has an answer the spec's copy is never consulted again — not
+compared, not warned about on every read — because a field that is authoritative
+on Tuesday and ignored on Wednesday is worse than either.
+
+The other property under test is that not-knowing is an answer. `sac agents
+list` prints `host` as the literal string 'local' on every row today, which is a
+placeholder standing where an observation belongs. This module returns None
+instead, and None must not be rendered as a hostname.
+
+Pure functions over a residency history. No db, no files, no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_host_record import (
+    CODE_FROM_DB,
+    CODE_SEEDED_FROM_SPEC,
+    CODE_UNKNOWN,
+    HostAnswer,
+    legacy_spec_host_notice,
+    record_move,
+    resolve_host,
+)
+from scitex_agent_container._lifecycle._residency import Residency, current_host
+
+SRC = "ywata-note-win"
+DST = "scitex-compute-04"
+T0 = 1_000_000.0
+
+
+def _living_on(host: str) -> tuple[Residency, ...]:
+    return (Residency(host=host, from_ts=T0),)
+
+
+# ---------------------------------------------------------------------------
+# the db wins
+# ---------------------------------------------------------------------------
+
+
+def test_the_db_answers_when_it_knows() -> None:
+    # Arrange
+    history = _living_on(SRC)
+    # Act
+    answer = resolve_host(history)
+    # Assert
+    assert answer.host == SRC
+
+
+def test_an_answer_from_the_db_says_so() -> None:
+    # Arrange
+    history = _living_on(SRC)
+    # Act
+    answer = resolve_host(history)
+    # Assert
+    assert answer.code == CODE_FROM_DB
+
+
+def test_a_legacy_spec_host_never_overrides_the_db() -> None:
+    # Arrange: the spec still says one thing and the db says another. The db is
+    # authoritative, full stop — no comparison, no merge, no warning-per-read.
+    history = _living_on(DST)
+    # Act
+    answer = resolve_host(history, legacy_spec_host=SRC, now=T0 + 10)
+    # Assert
+    assert answer.host == DST
+
+
+def test_reading_a_known_host_does_not_seed_from_the_spec() -> None:
+    # Arrange
+    history = _living_on(DST)
+    # Act
+    answer = resolve_host(history, legacy_spec_host=SRC, now=T0 + 10)
+    # Assert
+    assert answer.seeded_from_spec is False
+
+
+def test_reading_a_known_host_leaves_the_history_untouched() -> None:
+    # Arrange
+    history = _living_on(DST)
+    # Act
+    answer = resolve_host(history, legacy_spec_host=SRC, now=T0 + 10)
+    # Assert
+    assert answer.history == history
+
+
+# ---------------------------------------------------------------------------
+# seed once
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_db_is_seeded_from_the_legacy_spec_host() -> None:
+    # Arrange: so no agent has to be re-registered by hand.
+    history: tuple[Residency, ...] = ()
+    # Act
+    answer = resolve_host(history, legacy_spec_host=SRC, now=T0)
+    # Assert
+    assert answer.host == SRC
+
+
+def test_a_seeded_answer_records_that_it_came_from_the_spec() -> None:
+    # Arrange: the provenance must survive into the db row, or the value arrives
+    # there looking like something that was measured.
+    history: tuple[Residency, ...] = ()
+    # Act
+    answer = resolve_host(history, legacy_spec_host=SRC, now=T0)
+    # Assert
+    assert answer.seeded_from_spec is True
+
+
+def test_a_seeded_answer_carries_its_own_code() -> None:
+    # Arrange
+    history: tuple[Residency, ...] = ()
+    # Act
+    answer = resolve_host(history, legacy_spec_host=SRC, now=T0)
+    # Assert
+    assert answer.code == CODE_SEEDED_FROM_SPEC
+
+
+def test_seeding_returns_a_history_the_caller_can_persist() -> None:
+    # Arrange
+    history: tuple[Residency, ...] = ()
+    # Act
+    answer = resolve_host(history, legacy_spec_host=SRC, now=T0)
+    # Assert
+    assert current_host(answer.history) == SRC
+
+
+def test_the_second_read_after_seeding_comes_from_the_db() -> None:
+    # Arrange: this is the "then ignore" half. Seeding happens once.
+    seeded = resolve_host((), legacy_spec_host=SRC, now=T0)
+    # Act
+    again = resolve_host(seeded.history, legacy_spec_host=SRC, now=T0 + 1)
+    # Assert
+    assert again.code == CODE_FROM_DB
+
+
+# ---------------------------------------------------------------------------
+# not knowing is an answer
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_db_with_no_legacy_host_is_unknown() -> None:
+    # Arrange
+    history: tuple[Residency, ...] = ()
+    # Act
+    answer = resolve_host(history)
+    # Assert
+    assert answer.host is None
+
+
+def test_an_unknown_host_refuses_to_be_guessed_from_the_local_hostname() -> None:
+    # Arrange: the guess is what makes a split-brain look explained.
+    history: tuple[Residency, ...] = ()
+    # Act
+    answer = resolve_host(history)
+    # Assert
+    assert "do NOT substitute the local hostname" in answer.reason
+
+
+def test_seeding_without_a_timestamp_is_unknown_rather_than_backdated() -> None:
+    # Arrange: a stay with no start time cannot answer an attribution question.
+    history: tuple[Residency, ...] = ()
+    # Act
+    answer = resolve_host(history, legacy_spec_host=SRC)
+    # Assert
+    assert answer.code == CODE_UNKNOWN
+
+
+def test_a_closed_history_reports_unknown_rather_than_the_last_host() -> None:
+    # Arrange: an agent whose stay was closed and never reopened runs nowhere.
+    history = (Residency(host=SRC, from_ts=T0, to_ts=T0 + 5),)
+    # Act
+    answer = resolve_host(history)
+    # Assert
+    assert answer.host is None
+
+
+def test_a_blank_host_cannot_be_expressed_as_an_answer() -> None:
+    # Arrange: an empty string renders as an answer while meaning nothing.
+    build = lambda: HostAnswer(host="  ", code=CODE_FROM_DB, reason="x")  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="real hostname or None")
+    # Assert
+    with caught:
+        build()
+
+
+# ---------------------------------------------------------------------------
+# record_move — the whole of the operator's item #1
+# ---------------------------------------------------------------------------
+
+
+def test_recording_a_move_makes_the_target_the_current_host() -> None:
+    # Arrange
+    history = _living_on(SRC)
+    # Act
+    moved = record_move(history, to_host=DST, now=T0 + 10)
+    # Assert
+    assert current_host(moved) == DST
+
+
+def test_recording_a_move_closes_the_previous_stay_in_the_same_step() -> None:
+    # Arrange: "living in two places at once" stays unrepresentable.
+    history = _living_on(SRC)
+    # Act
+    moved = record_move(history, to_host=DST, now=T0 + 10)
+    # Assert
+    assert moved[0].to_ts == T0 + 10
+
+
+def test_re_recording_the_same_move_does_not_litter_the_history() -> None:
+    # Arrange: a coordinator re-running after a crash must not leave the
+    # evidence of its own retries in the record.
+    once = record_move(_living_on(SRC), to_host=DST, now=T0 + 10)
+    # Act
+    twice = record_move(once, to_host=DST, now=T0 + 20)
+    # Assert
+    assert twice == once
+
+
+def test_a_move_with_no_destination_is_refused() -> None:
+    # Arrange
+    call = lambda: record_move(_living_on(SRC), to_host="", now=T0)  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="moved TO")
+    # Assert
+    with caught:
+        call()
+
+
+# ---------------------------------------------------------------------------
+# telling the operator the spec field is dead
+# ---------------------------------------------------------------------------
+
+
+def test_a_stale_spec_host_that_disagrees_is_called_out_as_ignored() -> None:
+    # Arrange: the failure being avoided is an operator reading `host: nas-03`
+    # in a file, believing it, and being wrong.
+    # Act
+    notice = legacy_spec_host_notice(spec_host=SRC, db_host=DST)
+    # Assert
+    assert "IGNORED" in notice
+
+
+def test_the_notice_names_the_authoritative_value() -> None:
+    # Arrange
+    # Act
+    notice = legacy_spec_host_notice(spec_host=SRC, db_host=DST)
+    # Assert
+    assert DST in notice
+
+
+def test_a_spec_host_with_an_empty_db_is_described_as_a_one_time_seed() -> None:
+    # Arrange
+    # Act
+    notice = legacy_spec_host_notice(spec_host=SRC, db_host=None)
+    # Assert
+    assert "SEED the db once" in notice
+
+
+def test_a_spec_with_no_host_produces_no_notice() -> None:
+    # Arrange: nothing to say, so nothing is said.
+    # Act
+    notice = legacy_spec_host_notice(spec_host=None, db_host=DST)
+    # Assert
+    assert notice == ""

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_origin.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_origin.py
@@ -1,0 +1,242 @@
+"""A recovery record that names only a host sends someone to a machine to guess.
+
+The operator's item #10 is about what happens when a move goes wrong: the
+memory, the temp files and the unfinished git work are still on the source, and
+somebody has to find them. So the tests here pin the two properties that decide
+whether that is possible — the record must name at least one PATH, and "clean"
+must never be confused with "not looked at".
+
+Pure data with validation at construction. No filesystem, no git, no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_origin import (
+    OriginRecord,
+    RepoWork,
+    recovery_lines,
+)
+
+AGENT = "scitex-agent-container"
+SRC = "ywata-note-win"
+DST = "scitex-compute-04"
+T0 = 1_000_000.0
+
+
+def _record(**overrides: object) -> OriginRecord:
+    base = dict(
+        agent=AGENT,
+        from_host=SRC,
+        to_host=DST,
+        at=T0,
+        workdir="/home/ywatanabe/proj/scitex-agent-container",
+        state_dir="/home/ywatanabe/.scitex/agent-container/agents/sac",
+        session_uuid="b68520e1-78fb-404f-a84d-b78cf7cf6e31",
+        transcript_path="/home/agent/.claude/projects/x/b68520e1.jsonl",
+    )
+    base.update(overrides)
+    return OriginRecord(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# RepoWork — clean is not the same as unscanned
+# ---------------------------------------------------------------------------
+
+
+def test_a_repo_with_uncommitted_files_has_work() -> None:
+    # Arrange
+    repo = RepoWork(path="/repo", uncommitted=3, unpushed=0)
+    # Act
+    answer = repo.has_work
+    # Assert
+    assert answer is True
+
+
+def test_a_repo_with_unpushed_commits_has_work() -> None:
+    # Arrange: pushed-nowhere is unreachable from any other machine.
+    repo = RepoWork(path="/repo", uncommitted=0, unpushed=2)
+    # Act
+    answer = repo.has_work
+    # Assert
+    assert answer is True
+
+
+def test_a_measured_clean_repo_has_no_work() -> None:
+    # Arrange
+    repo = RepoWork(path="/repo", uncommitted=0, unpushed=0)
+    # Act
+    answer = repo.has_work
+    # Assert
+    assert answer is False
+
+
+def test_an_unmeasured_repo_answers_unknown_rather_than_clean() -> None:
+    # Arrange: 0 says the repo was clean; None says nobody asked, and the
+    # difference decides whether a reader has to go and look.
+    repo = RepoWork(path="/repo")
+    # Act
+    answer = repo.has_work
+    # Assert
+    assert answer is None
+
+
+def test_a_repo_with_no_path_is_unrepresentable() -> None:
+    # Arrange
+    build = lambda: RepoWork(path="")  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="path")
+    # Assert
+    with caught:
+        build()
+
+
+def test_a_negative_count_is_refused_where_it_is_built() -> None:
+    # Arrange
+    build = lambda: RepoWork(path="/repo", uncommitted=-1)  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="uncommitted")
+    # Assert
+    with caught:
+        build()
+
+
+# ---------------------------------------------------------------------------
+# OriginRecord — it must be findable
+# ---------------------------------------------------------------------------
+
+
+def test_a_record_naming_no_path_at_all_is_refused() -> None:
+    # Arrange: a row saying only "it came from ywata-note-win" is not a
+    # recovery aid.
+    build = lambda: OriginRecord(  # noqa: E731
+        agent=AGENT, from_host=SRC, to_host=DST, at=T0
+    )
+    # Act
+    caught = pytest.raises(ValueError, match="no idea where to look")
+    # Assert
+    with caught:
+        build()
+
+
+def test_a_record_with_only_a_repo_is_enough_to_be_findable() -> None:
+    # Arrange
+    record = OriginRecord(
+        agent=AGENT,
+        from_host=SRC,
+        to_host=DST,
+        at=T0,
+        repos=(RepoWork(path="/repo", uncommitted=0, unpushed=0),),
+    )
+    # Act
+    where = record.repos[0].path
+    # Assert
+    assert where == "/repo"
+
+
+def test_a_record_whose_hosts_are_the_same_is_refused() -> None:
+    # Arrange: nothing moved, so there is nothing to recover from.
+    build = lambda: _record(to_host=SRC)  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="nothing moved")
+    # Assert
+    with caught:
+        build()
+
+
+def test_a_record_with_no_source_host_is_refused() -> None:
+    # Arrange
+    build = lambda: _record(from_host="")  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="from_host")
+    # Assert
+    with caught:
+        build()
+
+
+def test_dirty_repos_are_listed_apart_from_unmeasured_ones() -> None:
+    # Arrange
+    record = _record(
+        repos=(
+            RepoWork(path="/dirty", uncommitted=4, unpushed=0),
+            RepoWork(path="/unknown"),
+            RepoWork(path="/clean", uncommitted=0, unpushed=0),
+        )
+    )
+    # Act
+    dirty = tuple(r.path for r in record.repos_with_work)
+    # Assert
+    assert dirty == ("/dirty",)
+
+
+def test_an_unmeasured_repo_is_not_counted_as_holding_work() -> None:
+    # Arrange
+    record = _record(
+        repos=(RepoWork(path="/dirty", uncommitted=4), RepoWork(path="/unknown"))
+    )
+    # Act
+    unmeasured = tuple(r.path for r in record.repos_unmeasured)
+    # Assert
+    assert unmeasured == ("/unknown",)
+
+
+# ---------------------------------------------------------------------------
+# recovery_lines — instructions, not a field dump
+# ---------------------------------------------------------------------------
+
+
+def test_the_recovery_lines_start_by_naming_the_machine_to_go_back_to() -> None:
+    # Arrange
+    record = _record()
+    # Act
+    lines = recovery_lines(record)
+    # Assert
+    assert f"ssh {SRC}" in lines[1]
+
+
+def test_the_recovery_lines_name_the_transcript_path_on_the_source() -> None:
+    # Arrange
+    record = _record()
+    # Act
+    rendered = "\n".join(recovery_lines(record))
+    # Assert
+    assert "/home/agent/.claude/projects/x/b68520e1.jsonl" in rendered
+
+
+def test_an_uncarried_transcript_is_flagged_as_the_only_copy() -> None:
+    # Arrange
+    record = _record(transcript_carried=False)
+    # Act
+    rendered = "\n".join(recovery_lines(record))
+    # Assert
+    assert "only copy" in rendered
+
+
+def test_an_unverified_transcript_warns_before_anything_is_deleted() -> None:
+    # Arrange: unknown is the case a recovery cares about most.
+    record = _record(transcript_carried=None)
+    # Act
+    rendered = "\n".join(recovery_lines(record))
+    # Assert
+    assert "UNKNOWN whether it arrived" in rendered
+
+
+def test_unsaved_work_is_rendered_with_its_counts() -> None:
+    # Arrange
+    record = _record(
+        repos=(RepoWork(path="/repo", branch="feat/x", uncommitted=7, unpushed=2),)
+    )
+    # Act
+    rendered = "\n".join(recovery_lines(record))
+    # Assert
+    assert "7 uncommitted" in rendered
+
+
+def test_unmeasured_repos_are_rendered_as_not_measured_not_as_clean() -> None:
+    # Arrange
+    record = _record(repos=(RepoWork(path="/never-scanned"),))
+    # Act
+    rendered = "\n".join(recovery_lines(record))
+    # Assert
+    assert "NOT MEASURED" in rendered

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_preflight.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_preflight.py
@@ -19,20 +19,25 @@ from __future__ import annotations
 
 import pytest
 
+from scitex_agent_container._lifecycle._relocate_origin import RepoWork
 from scitex_agent_container._lifecycle._relocate_preflight import (
     CHECK_BINDS,
     CHECK_CREDENTIALS,
     CHECK_HUB_FROM_TARGET,
     CHECK_PORTS,
     CHECK_RUNTIME,
+    CHECK_SAC_PRESENT,
     CHECK_SCHEMA,
+    CHECK_SOURCE_WORK,
     Check,
+    SourceFacts,
     TargetFacts,
     preflight,
 )
 
 AGENT = "scitex-agent-container"
 DST = "nas-03"
+SRC = "ywata-note-win"
 RUNTIME = "apptainer"
 PORTS = (19019,)
 
@@ -51,18 +56,29 @@ def _healthy_facts(**overrides: object) -> TargetFacts:
         rejected_spec_keys=(),
         ports_in_use=(),
         hub_reachable_from_target=True,
+        sac_on_path=True,
+        sac_resolved_path="/usr/local/bin/sac",
     )
     base.update(overrides)
     return TargetFacts(**base)  # type: ignore[arg-type]
 
 
-def _run(**overrides: object):
+def _clean_source() -> SourceFacts:
+    """A source that was scanned and holds nothing un-saved."""
+    return SourceFacts(
+        repos=(RepoWork(path="/repo", branch="develop", uncommitted=0, unpushed=0),)
+    )
+
+
+def _run(source_facts: SourceFacts | None = None, **overrides: object):
     return preflight(
         agent=AGENT,
         to_host=DST,
         facts=_healthy_facts(**overrides),
         runtime=RUNTIME,
         required_ports=PORTS,
+        source_facts=source_facts if source_facts is not None else _clean_source(),
+        from_host=SRC,
     )
 
 
@@ -354,3 +370,192 @@ def test_an_unobserved_check_still_explains_what_to_run() -> None:
     check = report.unknown[0]
     # Assert
     assert "probe" in check.hint
+
+
+# ---------------------------------------------------------------------------
+# sac_present_on_target — installed and findable are two questions
+#
+# Measured 2026-08-11 on scitex-compute-04: sac lives at
+# /home/ywatanabe/.env-sac/bin/sac and is absent from the non-interactive ssh
+# PATH, so `ssh compute-04 sac …` answers "No such file or directory" — the same
+# words a machine with no sac at all produces, needing the opposite fix.
+# ---------------------------------------------------------------------------
+
+
+def test_sac_on_the_ssh_path_passes() -> None:
+    # Arrange
+    report = _run()
+    # Act
+    check = _named(report, CHECK_SAC_PRESENT)
+    # Assert
+    assert check.ok is True
+
+
+def test_sac_installed_but_off_the_ssh_path_fails() -> None:
+    # Arrange: the compute-04 case.
+    report = _run(
+        sac_on_path=False, sac_resolved_path="/home/ywatanabe/.env-sac/bin/sac"
+    )
+    # Act
+    check = _named(report, CHECK_SAC_PRESENT)
+    # Assert
+    assert check.ok is False
+
+
+def test_sac_off_the_path_is_reported_as_installed_rather_than_missing() -> None:
+    # Arrange
+    report = _run(
+        sac_on_path=False, sac_resolved_path="/home/ywatanabe/.env-sac/bin/sac"
+    )
+    # Act
+    check = _named(report, CHECK_SAC_PRESENT)
+    # Assert
+    assert "IS INSTALLED" in check.detail
+
+
+def test_sac_off_the_path_names_where_it_actually_is() -> None:
+    # Arrange
+    report = _run(
+        sac_on_path=False, sac_resolved_path="/home/ywatanabe/.env-sac/bin/sac"
+    )
+    # Act
+    check = _named(report, CHECK_SAC_PRESENT)
+    # Assert
+    assert "/home/ywatanabe/.env-sac/bin/sac" in check.detail
+
+
+def test_sac_off_the_path_tells_the_reader_not_to_install_a_second_copy() -> None:
+    # Arrange: the wrong fix here is to install sac again, which is what a
+    # single "sac not found" message would send the reader off to do.
+    report = _run(
+        sac_on_path=False, sac_resolved_path="/home/ywatanabe/.env-sac/bin/sac"
+    )
+    # Act
+    check = _named(report, CHECK_SAC_PRESENT)
+    # Assert
+    assert "do NOT install a second copy" in check.hint
+
+
+def test_sac_absent_everywhere_fails_as_not_installed() -> None:
+    # Arrange: "" means looked and found nothing.
+    report = _run(sac_on_path=False, sac_resolved_path="")
+    # Act
+    check = _named(report, CHECK_SAC_PRESENT)
+    # Assert
+    assert "NOT INSTALLED" in check.detail
+
+
+def test_sac_absent_everywhere_asks_for_an_install() -> None:
+    # Arrange
+    report = _run(sac_on_path=False, sac_resolved_path="")
+    # Act
+    check = _named(report, CHECK_SAC_PRESENT)
+    # Assert
+    assert "install sac" in check.hint
+
+
+def test_sac_off_the_path_with_no_direct_lookup_is_unknown() -> None:
+    # Arrange: not-on-PATH alone cannot tell the two failures apart, and
+    # guessing either way sends the reader to the wrong fix.
+    report = _run(sac_on_path=False, sac_resolved_path=None)
+    # Act
+    check = _named(report, CHECK_SAC_PRESENT)
+    # Assert
+    assert check.ok is None
+
+
+def test_an_unprobed_sac_presence_is_unknown() -> None:
+    # Arrange
+    report = _run(sac_on_path=None, sac_resolved_path=None)
+    # Act
+    check = _named(report, CHECK_SAC_PRESENT)
+    # Assert
+    assert check.ok is None
+
+
+# ---------------------------------------------------------------------------
+# source_work_committed — relocating away from unsaved work strands it
+# ---------------------------------------------------------------------------
+
+
+def test_a_scanned_and_clean_source_passes() -> None:
+    # Arrange
+    report = _run()
+    # Act
+    check = _named(report, CHECK_SOURCE_WORK)
+    # Assert
+    assert check.ok is True
+
+
+def test_uncommitted_work_on_the_source_fails_the_relocation() -> None:
+    # Arrange
+    source = SourceFacts(
+        repos=(RepoWork(path="/proj/sac", branch="feat/x", uncommitted=7, unpushed=0),)
+    )
+    # Act
+    check = _named(_run(source_facts=source), CHECK_SOURCE_WORK)
+    # Assert
+    assert check.ok is False
+
+
+def test_the_uncommitted_failure_reports_the_file_count() -> None:
+    # Arrange
+    source = SourceFacts(
+        repos=(RepoWork(path="/proj/sac", branch="feat/x", uncommitted=7, unpushed=0),)
+    )
+    # Act
+    check = _named(_run(source_facts=source), CHECK_SOURCE_WORK)
+    # Assert
+    assert "7 uncommitted file(s)" in check.detail
+
+
+def test_the_uncommitted_failure_reports_the_repo_path() -> None:
+    # Arrange
+    source = SourceFacts(
+        repos=(RepoWork(path="/proj/sac", branch="feat/x", uncommitted=7, unpushed=0),)
+    )
+    # Act
+    check = _named(_run(source_facts=source), CHECK_SOURCE_WORK)
+    # Assert
+    assert "/proj/sac" in check.detail
+
+
+def test_unpushed_commits_on_the_source_fail_too() -> None:
+    # Arrange: a branch pushed nowhere is unreachable from any other machine.
+    source = SourceFacts(
+        repos=(RepoWork(path="/proj/sac", branch="feat/x", uncommitted=0, unpushed=3),)
+    )
+    # Act
+    check = _named(_run(source_facts=source), CHECK_SOURCE_WORK)
+    # Assert
+    assert "3 unpushed commit(s)" in check.detail
+
+
+def test_an_unscanned_repo_is_unknown_rather_than_clean() -> None:
+    # Arrange: a failed `git status` prints nothing, exactly like a clean tree.
+    source = SourceFacts(repos=(RepoWork(path="/proj/sac"),))
+    # Act
+    check = _named(_run(source_facts=source), CHECK_SOURCE_WORK)
+    # Assert
+    assert check.ok is None
+
+
+def test_a_source_nobody_looked_at_refuses_the_relocation() -> None:
+    # Arrange: the default. A caller that has not looked at the source has not
+    # established the move is safe.
+    report = preflight(
+        agent=AGENT, to_host=DST, facts=_healthy_facts(), runtime=RUNTIME
+    )
+    # Act
+    check = _named(report, CHECK_SOURCE_WORK)
+    # Assert
+    assert check.ok is None
+
+
+def test_a_source_with_no_repos_at_all_passes_when_it_was_scanned() -> None:
+    # Arrange: an observed "nothing to strand" is different from "nobody asked".
+    source = SourceFacts(repos=())
+    # Act
+    check = _named(_run(source_facts=source), CHECK_SOURCE_WORK)
+    # Assert
+    assert check.ok is True

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 
 import pytest
 
-from scitex_agent_container._lifecycle._relocate_preflight import preflight
+from scitex_agent_container._lifecycle._relocate_origin import RepoWork
+from scitex_agent_container._lifecycle._relocate_preflight import SourceFacts, preflight
 from scitex_agent_container._lifecycle._relocate_probe import (
     TargetProbes,
     gather_target_facts,
@@ -221,11 +222,20 @@ def test_a_fully_healthy_probe_set_passes_preflight() -> None:
         rejected_spec_keys=lambda: (),
         ports_in_use=lambda: (),
         hub_reachable_from_target=lambda: True,
+        sac_on_path=lambda: True,
+        sac_resolved_path=lambda: "/usr/local/bin/sac",
     )
     gathered = gather_target_facts(probes)
     # Act
     report = preflight(
-        agent="a", to_host="nas-03", facts=gathered.facts, runtime="apptainer"
+        agent="a",
+        to_host="nas-03",
+        facts=gathered.facts,
+        runtime="apptainer",
+        source_facts=SourceFacts(
+            repos=(RepoWork(path="/proj/x", uncommitted=0, unpushed=0),)
+        ),
+        from_host="ywata-note-win",
     )
     # Assert
     assert report.ok is True

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe_adapter.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe_adapter.py
@@ -25,7 +25,8 @@ from __future__ import annotations
 
 import pytest
 
-from scitex_agent_container._lifecycle._relocate_preflight import preflight
+from scitex_agent_container._lifecycle._relocate_origin import RepoWork
+from scitex_agent_container._lifecycle._relocate_preflight import SourceFacts, preflight
 from scitex_agent_container._lifecycle._relocate_probe import gather_target_facts
 from scitex_agent_container._lifecycle._relocate_probe_adapter import (
     build_target_probes,
@@ -48,10 +49,23 @@ SAC_RELOC cred=/creds/a.json|1786249796000|yes
 SAC_RELOC creds_checked=2
 SAC_RELOC ports_checked=0
 SAC_RELOC hub=yes
+SAC_RELOC sac_path=/usr/local/bin/sac
+SAC_RELOC sac_found=/usr/local/bin/sac
 SAC_RELOC runtimes=apptainer,claude-agent-sdk,tui
 SAC_RELOC speckeys=apiVersion,kind,metadata,spec
 SAC_RELOC end
 """
+
+#: The scitex-compute-04 readout, measured 2026-08-11: sac is installed and the
+#: non-interactive ssh PATH cannot see it, so `ssh compute-04 sac …` answers
+#: "No such file or directory" while sac works perfectly well there.
+SAC_OFF_PATH = HEALTHY.replace(
+    "SAC_RELOC sac_path=/usr/local/bin/sac",
+    "SAC_RELOC sac_path=",
+).replace(
+    "SAC_RELOC sac_found=/usr/local/bin/sac",
+    "SAC_RELOC sac_found=/home/ywatanabe/.env-sac/bin/sac",
+)
 
 # An env with a routable hub, so the hub section is asked about at all.
 HUB_ENV = {"SAC_RELOCATE_HUB_ADDR": "hub.example:7878"}
@@ -449,6 +463,38 @@ def test_a_healthy_target_reaches_preflight_as_a_go(spec) -> None:
     # propagates.
     gathered = _facts(spec, HEALTHY)
     # Act
-    report = preflight(agent="a", to_host="target", facts=gathered.facts, runtime="tui")
+    report = preflight(
+        agent="a",
+        to_host="target",
+        facts=gathered.facts,
+        runtime="tui",
+        # The source-work check is gathered locally, not by this batch. A scanned
+        # and clean source is supplied so the probe adapter is what is measured.
+        source_facts=SourceFacts(
+            repos=(RepoWork(path="/proj/x", uncommitted=0, unpushed=0),)
+        ),
+        from_host="ywata-note-win",
+    )
     # Assert
     assert report.ok is True
+
+
+def test_sac_installed_off_the_ssh_path_is_read_as_a_path_problem(spec) -> None:
+    # Arrange: the scitex-compute-04 readout. `command -v sac` prints nothing
+    # while /home/ywatanabe/.env-sac/bin/sac exists and works — two different
+    # states behind one "No such file or directory".
+    gathered = _facts(spec, SAC_OFF_PATH)
+    # Act
+    resolved = gathered.facts.sac_resolved_path
+    # Assert
+    assert resolved == "/home/ywatanabe/.env-sac/bin/sac"
+
+
+def test_an_empty_sac_path_line_is_an_answer_not_a_missing_fact(spec) -> None:
+    # Arrange: `sac_path=` means looked-and-found-nothing. Only a line that
+    # never arrived is undetermined.
+    gathered = _facts(spec, SAC_OFF_PATH)
+    # Act
+    on_path = gathered.facts.sac_on_path
+    # Assert
+    assert on_path is False

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe_script.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe_script.py
@@ -91,9 +91,21 @@ def test_the_preamble_runs_before_anything_is_measured(questions) -> None:
     # facts only the target's validator can answer go silently unanswered.
     script = render_probe_script(questions, preamble='export PATH="$HOME/x:$PATH"')
     # Act
+    second_line = script.splitlines()[1]
+    # Assert
+    assert second_line == 'export PATH="$HOME/x:$PATH"'
+
+
+def test_the_raw_path_is_captured_before_the_preamble_changes_it(questions) -> None:
+    # Arrange: the sac-presence question is about the PATH a bare `ssh host sac`
+    # runs under. Measuring it AFTER the preamble — whose whole job is putting
+    # sac on PATH — answers a different question in the same words, and answers
+    # it "yes" on exactly the hosts where the bare form fails.
+    script = render_probe_script(questions, preamble='export PATH="$HOME/x:$PATH"')
+    # Act
     first_line = script.splitlines()[0]
     # Assert
-    assert first_line == 'export PATH="$HOME/x:$PATH"'
+    assert first_line == 'SACRELOC_PATH0="$PATH"'
 
 
 def test_a_path_with_a_space_is_quoted_rather_than_split() -> None:

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_records.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_records.py
@@ -1,0 +1,207 @@
+"""`sac agents list` reports "defined" as a status. That is the bug these tests pin.
+
+"defined" is a SPEC fact — a file exists — rendered in a STATE column, which is
+why the listing reports zero running agents while agents are demonstrably
+running. The same listing puts the literal string 'local' in a `host` column
+that is supposed to carry an observation.
+
+The operator's item #2 asks for the two to be clearly separated. A comment
+saying so is obeyed until the first hurry, so the separation is a REFUSAL: a
+write that names a field from the wrong vocabulary raises with the field named,
+and a field in neither vocabulary raises too — because a pass-through default
+means the separation only holds for the fields someone remembered to list.
+
+Pure dict in, dict out.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_records import (
+    SPEC_FIELDS,
+    STATE_FIELDS,
+    classify_field,
+    spec_patch,
+    state_record,
+)
+
+AGENT = "scitex-agent-container"
+SRC = "ywata-note-win"
+DST = "scitex-compute-04"
+
+
+# ---------------------------------------------------------------------------
+# the two vocabularies do not overlap
+# ---------------------------------------------------------------------------
+
+
+def test_no_field_is_declared_in_both_vocabularies() -> None:
+    # Arrange: a field meaning intent in one place and an observation in another
+    # is exactly how a status column ends up saying "defined".
+    both = SPEC_FIELDS & STATE_FIELDS
+    # Act
+    overlap = sorted(both)
+    # Assert
+    assert overlap == []
+
+
+def test_a_spec_field_classifies_as_spec() -> None:
+    # Arrange
+    name = "runtime"
+    # Act
+    kind = classify_field(name)
+    # Assert
+    assert kind == "spec"
+
+
+def test_host_classifies_as_state_because_it_is_observed_not_declared() -> None:
+    # Arrange: the 2026-08-11 ruling —「設定ファイル、人が書くものはファイル、
+    # 状態は db」. A human typing `host: nas-03` is recording a fact, not
+    # declaring a preference, and a fact in a git-tracked file that exists in
+    # two copies on two machines will eventually be wrong in one of them.
+    name = "host"
+    # Act
+    kind = classify_field(name)
+    # Assert
+    assert kind == "state"
+
+
+def test_a_state_field_classifies_as_state() -> None:
+    # Arrange
+    name = "phase"
+    # Act
+    kind = classify_field(name)
+    # Assert
+    assert kind == "state"
+
+
+def test_an_undeclared_field_is_refused_rather_than_passed_through() -> None:
+    # Arrange
+    call = lambda: classify_field("some_new_thing")  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="neither")
+    # Assert
+    with caught:
+        call()
+
+
+# ---------------------------------------------------------------------------
+# spec_patch — declarations only
+# ---------------------------------------------------------------------------
+
+
+def test_a_declaration_is_a_legal_spec_patch() -> None:
+    # Arrange
+    values = {"runtime": "apptainer"}
+    # Act
+    patch = spec_patch(**values)
+    # Assert
+    assert patch == {"runtime": "apptainer"}
+
+
+def test_writing_the_host_into_a_spec_now_raises() -> None:
+    # Arrange: this is the enforcement, not a note. Any code path that tried to
+    # write a host into a spec fails at the call site with the field named.
+    call = lambda: spec_patch(host=DST)  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="host")
+    # Assert
+    with caught:
+        call()
+
+
+def test_writing_an_observation_into_the_spec_is_refused() -> None:
+    # Arrange: `phase` is something that was observed, not something declared.
+    call = lambda: spec_patch(runtime="apptainer", phase="handover")  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="observed data")
+    # Assert
+    with caught:
+        call()
+
+
+def test_the_spec_refusal_names_the_offending_field() -> None:
+    # Arrange
+    call = lambda: spec_patch(runtime="apptainer", lease_fence=4)  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="lease_fence")
+    # Assert
+    with caught:
+        call()
+
+
+def test_the_host_is_a_legal_state_record_field() -> None:
+    # Arrange: the other half — it is refused in the spec and accepted here.
+    values = dict(agent=AGENT, from_host=SRC, to_host=DST, host=DST)
+    # Act
+    record = state_record(**values)
+    # Assert
+    assert record["host"] == DST
+
+
+def test_an_empty_spec_patch_is_refused_because_it_writes_nothing() -> None:
+    # Arrange
+    call = lambda: spec_patch()  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="writes nothing")
+    # Assert
+    with caught:
+        call()
+
+
+# ---------------------------------------------------------------------------
+# state_record — observations only, and it must be joinable
+# ---------------------------------------------------------------------------
+
+
+def test_a_relocation_outcome_is_a_legal_state_record() -> None:
+    # Arrange
+    values = dict(agent=AGENT, from_host=SRC, to_host=DST, phase="done")
+    # Act
+    record = state_record(**values)
+    # Assert
+    assert record["phase"] == "done"
+
+
+def test_writing_a_declaration_into_the_state_db_is_refused() -> None:
+    # Arrange: `runtime` is what a human declared; it is not an observation.
+    call = lambda: state_record(  # noqa: E731
+        agent=AGENT, from_host=SRC, to_host=DST, runtime="apptainer"
+    )
+    # Act
+    caught = pytest.raises(ValueError, match="declared data")
+    # Assert
+    with caught:
+        call()
+
+
+def test_a_state_row_that_names_no_agent_is_refused() -> None:
+    # Arrange: a row that cannot be joined is the cards `host` column all over
+    # again — NULL on 3247 of 3424 rows, so attribution is unanswerable.
+    call = lambda: state_record(agent="", from_host=SRC, to_host=DST)  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="agent")
+    # Assert
+    with caught:
+        call()
+
+
+def test_a_state_row_that_names_no_destination_is_refused() -> None:
+    # Arrange
+    call = lambda: state_record(agent=AGENT, from_host=SRC, to_host="")  # noqa: E731
+    # Act
+    caught = pytest.raises(ValueError, match="to_host")
+    # Assert
+    with caught:
+        call()
+
+
+def test_the_migration_retained_flag_is_a_state_field() -> None:
+    # Arrange: item #9 — the fact of a migration is never discarded, so it lives
+    # in the state db rather than being cleaned up on success.
+    values = dict(agent=AGENT, from_host=SRC, to_host=DST, migration_retained=True)
+    # Act
+    record = state_record(**values)
+    # Assert
+    assert record["migration_retained"] is True

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
@@ -16,9 +16,11 @@ constructing them IS the check that the shapes are right. No mocks.
 
 from __future__ import annotations
 
+from scitex_agent_container._lifecycle._relocate_origin import RepoWork
 from scitex_agent_container._lifecycle._relocate_preflight import (
     Check,
     PreflightReport,
+    SourceFacts,
     TargetFacts,
     preflight,
 )
@@ -47,11 +49,27 @@ ALL_GOOD = TargetFacts(
     rejected_spec_keys=(),
     ports_in_use=(),
     hub_reachable_from_target=True,
+    sac_on_path=True,
+    sac_resolved_path="/usr/local/bin/sac",
+)
+
+#: The source scanned and clean. Supplied on every render so the rendering
+#: itself is what is under test — a report that refuses because nobody scanned
+#: the source would exercise the renderer's refusal path in every case.
+CLEAN_SOURCE = SourceFacts(
+    repos=(RepoWork(path="/proj/x", branch="develop", uncommitted=0, unpushed=0),)
 )
 
 
 def _report(facts: TargetFacts, runtime: str = "tui") -> PreflightReport:
-    return preflight(agent=AGENT, to_host=HOST, facts=facts, runtime=runtime)
+    return preflight(
+        agent=AGENT,
+        to_host=HOST,
+        facts=facts,
+        runtime=runtime,
+        source_facts=CLEAN_SOURCE,
+        from_host="ywata-note-win",
+    )
 
 
 def _text(lines: list[str]) -> str:

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_source_scan.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_source_scan.py
@@ -1,0 +1,181 @@
+"""A failed `git status` prints nothing. So does a clean tree. Counting lines conflates them.
+
+That is the one mistake this scanner exists to not make: reading an empty stdout
+as "0 uncommitted files" turns a git that could not run into a confident
+"nothing to strand", and the relocation proceeds away from work it was supposed
+to be protecting.
+
+The second is subtler and costs more: a branch with NO UPSTREAM makes
+`rev-list @{u}..HEAD` fail, and reporting 0 there would clear exactly the branch
+that exists on one machine only.
+
+The runner is a real callable returning real captured git output. Nothing is
+mocked, no repo is created, and no subprocess runs.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from scitex_agent_container._lifecycle._relocate_source_scan import (
+    CommandResult,
+    scan_repo,
+    scan_source,
+)
+
+REPO = "/home/ywatanabe/proj/scitex-agent-container"
+
+
+def _runner(answers: dict[str, CommandResult]):
+    """Answer by git subcommand, so a test states only what it cares about."""
+
+    def run(argv: Sequence[str]) -> CommandResult:
+        key = argv[3]
+        return answers.get(key, CommandResult(stdout="", stderr="", exit_code=1))
+
+    return run
+
+
+def _ok(stdout: str) -> CommandResult:
+    return CommandResult(stdout=stdout, stderr="", exit_code=0)
+
+
+def _broken(stderr: str) -> CommandResult:
+    return CommandResult(stdout="", stderr=stderr, exit_code=128)
+
+
+def _healthy(**overrides: CommandResult):
+    answers = {
+        "rev-parse": _ok("develop\n"),
+        "status": _ok(""),
+        "rev-list": _ok("0\n"),
+    }
+    answers.update(overrides)
+    return _runner(answers)
+
+
+# ---------------------------------------------------------------------------
+# counting what is there
+# ---------------------------------------------------------------------------
+
+
+def test_a_clean_repo_reports_zero_uncommitted() -> None:
+    # Arrange
+    runner = _healthy()
+    # Act
+    repo = scan_repo(REPO, runner=runner)
+    # Assert
+    assert repo.uncommitted == 0
+
+
+def test_modified_files_are_counted_one_per_porcelain_line() -> None:
+    # Arrange
+    runner = _healthy(status=_ok(" M src/a.py\n?? new.py\n M src/b.py\n"))
+    # Act
+    repo = scan_repo(REPO, runner=runner)
+    # Assert
+    assert repo.uncommitted == 3
+
+
+def test_commits_ahead_of_the_upstream_are_counted() -> None:
+    # Arrange
+    runner = _healthy(**{"rev-list": _ok("4\n")})
+    # Act
+    repo = scan_repo(REPO, runner=runner)
+    # Assert
+    assert repo.unpushed == 4
+
+
+def test_the_branch_name_is_recorded_for_the_recovery_record() -> None:
+    # Arrange
+    runner = _healthy(**{"rev-parse": _ok("feat/relocate-execute-path\n")})
+    # Act
+    repo = scan_repo(REPO, runner=runner)
+    # Assert
+    assert repo.branch == "feat/relocate-execute-path"
+
+
+def test_a_clean_scanned_repo_holds_no_work() -> None:
+    # Arrange
+    runner = _healthy()
+    # Act
+    repo = scan_repo(REPO, runner=runner)
+    # Assert
+    assert repo.has_work is False
+
+
+# ---------------------------------------------------------------------------
+# a failed command leaves its count UNMEASURED, never zero
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_status_leaves_the_file_count_unmeasured() -> None:
+    # Arrange: an empty stdout from a FAILED status is indistinguishable from a
+    # clean tree, and counting it as 0 is the whole failure this guards.
+    runner = _healthy(status=_broken("fatal: not a git repository"))
+    # Act
+    repo = scan_repo(REPO, runner=runner)
+    # Assert
+    assert repo.uncommitted is None
+
+
+def test_a_branch_with_no_upstream_leaves_the_unpushed_count_unmeasured() -> None:
+    # Arrange: `rev-list @{u}..` fails with no upstream. Reporting 0 would clear
+    # exactly the branch that exists on one machine only.
+    runner = _healthy(**{"rev-list": _broken("fatal: no upstream configured")})
+    # Act
+    repo = scan_repo(REPO, runner=runner)
+    # Assert
+    assert repo.unpushed is None
+
+
+def test_a_repo_whose_counts_all_failed_answers_unknown_rather_than_clean() -> None:
+    # Arrange
+    runner = _healthy(status=_broken("fatal"), **{"rev-list": _broken("fatal")})
+    # Act
+    repo = scan_repo(REPO, runner=runner)
+    # Assert
+    assert repo.has_work is None
+
+
+def test_a_non_numeric_ahead_count_is_unmeasured_not_zero() -> None:
+    # Arrange: garbage on stdout with exit 0 is still not a number.
+    runner = _healthy(**{"rev-list": _ok("not a number\n")})
+    # Act
+    repo = scan_repo(REPO, runner=runner)
+    # Assert
+    assert repo.unpushed is None
+
+
+def test_a_failed_branch_lookup_costs_only_the_branch_name() -> None:
+    # Arrange: three independent questions, so one failure does not cost the
+    # others — a repo whose branch is unreadable is still worth counting.
+    runner = _healthy(**{"rev-parse": _broken("fatal")})
+    # Act
+    repo = scan_repo(REPO, runner=runner)
+    # Assert
+    assert repo.uncommitted == 0
+
+
+# ---------------------------------------------------------------------------
+# the whole source
+# ---------------------------------------------------------------------------
+
+
+def test_scanning_several_repos_produces_one_entry_each() -> None:
+    # Arrange
+    runner = _healthy()
+    # Act
+    facts = scan_source(["/a", "/b", "/c"], runner=runner)
+    # Assert
+    assert len(facts.repos or ()) == 3
+
+
+def test_scanning_no_repos_is_an_observed_empty_rather_than_nothing_observed() -> None:
+    # Arrange: () passes the preflight check; None refuses it. The difference is
+    # deliberate and the caller must state which it means.
+    runner = _healthy()
+    # Act
+    facts = scan_source([], runner=runner)
+    # Assert
+    assert facts.repos == ()

--- a/tests/scitex_agent_container/_state/test_host_config.py
+++ b/tests/scitex_agent_container/_state/test_host_config.py
@@ -38,7 +38,19 @@ def _parse_probe_json(result, *, expect_exit: int = 0) -> dict:
 
     1. The CLI exit code matches ``expect_exit`` (probe payload is only
        trustworthy when the command ran to completion).
-    2. ``result.output`` parses as a JSON object.
+    2. ``result.stdout`` parses as a JSON object.
+
+    **stdout, not ``result.output``.** Since click 8.2 ``result.output``
+    is not a proxy for stdout — it is an independent stream that mixes
+    stdout and stderr in write order. Any library that logs a WARNING
+    while the command runs (scitex-logging's console handler resolves
+    ``sys.stderr`` per emit, so it follows click's isolated streams)
+    lands in ``.output`` and makes it unparseable, while the payload a
+    real ``sac host probe --json | jq`` consumer receives is untouched.
+    Asserting on ``.stdout`` is both the passing assertion and the
+    faithful one. Pinned by
+    ``test_json_payload_parses_from_stdout_despite_a_library_warning``
+    in ``tests/scitex_agent_container/cli_pkg/test_host_group.py``.
 
     Returns the parsed payload so callers assert on a structured field
     (``payload["remote_canonical"]``) rather than on exact / ordered
@@ -46,14 +58,15 @@ def _parse_probe_json(result, *, expect_exit: int = 0) -> dict:
     """
     assert result.exit_code == expect_exit, (
         f"host probe exit_code={result.exit_code} (expected {expect_exit}); "
-        f"exception={result.exception!r}; output={result.output!r}"
+        f"exception={result.exception!r}; output(stdout+stderr)={result.output!r}"
     )
     try:
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
     except ValueError as exc:  # JSONDecodeError subclasses ValueError
         raise AssertionError(
             f"host probe --json did not emit parseable JSON: {exc}; "
-            f"raw output={result.output!r}"
+            f"raw stdout={result.stdout!r}; "
+            f"stdout+stderr={result.output!r}"
         ) from exc
     assert isinstance(payload, dict), (
         f"host probe --json payload is not an object: {payload!r}"
@@ -290,7 +303,7 @@ def test_host_list_returns_empty_peers_with_no_config(cfg_path: Path):
     # Act
     result = CliRunner().invoke(host_list, ["--json"])
     # Assert
-    assert json.loads(result.output)["peers"] == []
+    assert json.loads(result.stdout)["peers"] == []
 
 
 def test_host_list_renders_configured_peers(cfg_path: Path):
@@ -309,7 +322,7 @@ peers:
     # Act
     result = CliRunner().invoke(host_list, ["--json"])
     # Assert
-    assert sorted(p["name"] for p in json.loads(result.output)["peers"]) == [
+    assert sorted(p["name"] for p in json.loads(result.stdout)["peers"]) == [
         "mba",
         "spartan",
     ]
@@ -323,7 +336,7 @@ def test_host_validate_passes_for_clean_config(cfg_path: Path):
     # Act
     result = CliRunner().invoke(host_validate, ["--json"])
     # Assert
-    assert json.loads(result.output)["errors"] == []
+    assert json.loads(result.stdout)["errors"] == []
 
 
 def test_host_validate_fails_for_unknown_via(cfg_path: Path):
@@ -341,7 +354,7 @@ peers:
     # Act
     result = CliRunner().invoke(host_validate, ["--json"])
     # Assert
-    assert "does-not-exist" in json.loads(result.output)["errors"][0]
+    assert "does-not-exist" in json.loads(result.stdout)["errors"][0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/cli_pkg/test__relocate_cmd.py
+++ b/tests/scitex_agent_container/cli_pkg/test__relocate_cmd.py
@@ -123,7 +123,19 @@ def test_a_half_written_spec_still_yields_a_report() -> None:
     # Act
     declared = declared_from_spec({"spec": {"runtime": "apptainer"}})
     # Assert
-    assert declared["host"] is None
+    assert declared["image"] is None
+
+
+def test_the_host_is_not_a_declared_field() -> None:
+    # Arrange: where an agent runs is an OBSERVATION (operator, 2026-08-11).
+    # Printing it under "DECLARED (from the spec — not verified by this run)"
+    # is the same collapse that makes `sac agents list` report a running agent
+    # as `defined`, so it comes from the state db and appears under OBSERVED.
+    spec = {"spec": {"host": "ywata-note-win", "runtime": "apptainer"}}
+    # Act
+    declared = declared_from_spec(spec)
+    # Assert
+    assert "host" not in declared
 
 
 def test_a_spec_without_the_outer_key_is_read_directly() -> None:

--- a/tests/scitex_agent_container/cli_pkg/test_host_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_host_group.py
@@ -17,8 +17,10 @@ carries a 3+-word behaviour name (TQ003).
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -182,7 +184,7 @@ def test_host_probe_unknown_peer_json_reports_unreachable(cfg_path: Path):
     # Act
     result = CliRunner().invoke(host_probe, ["ghost", "--json"])
     # Assert
-    assert json.loads(result.output)["reachable"] is False
+    assert json.loads(result.stdout)["reachable"] is False
 
 
 def test_host_probe_unknown_peer_json_exits_with_code_2(cfg_path: Path):
@@ -252,4 +254,82 @@ def test_host_probe_malformed_remote_stdout_yields_null_canonical(
     # Act
     result = CliRunner().invoke(host_probe, ["mba", "--json"])
     # Assert
-    assert json.loads(result.output)["remote_canonical"] is None
+    assert json.loads(result.stdout)["remote_canonical"] is None
+
+
+# ---------------------------------------------------------------------------
+# `--json` payloads belong to STDOUT — the stream a `| jq` consumer reads.
+# ---------------------------------------------------------------------------
+
+
+_RETIRED_ALIAS_WARNING = (
+    "'nas' is a RETIRED host alias — use 'scitex-nas-03'. "
+    "The seeder cannot repair this on its own."
+)
+
+
+@pytest.fixture
+def json_run_with_library_warning(cfg_path: Path):
+    """Run sac's real ``host list --json`` while a library logs a WARNING.
+
+    Reproduces the condition that took ``pytest-matrix`` red across 18 open
+    PRs. ``sac host list --json`` resolves the host registry through
+    ``scitex_dev.hosts``, whose seeder logs a WARNING when it meets a RETIRED
+    host alias — it names the successor and explains why it cannot repair
+    itself. The warning is correctly on STDERR, so a real
+    ``sac host list --json | jq`` was never broken; what broke was every
+    ASSERTION written against ``result.output``. From click 8.2 that
+    attribute stopped proxying stdout and became an independent stream
+    MIXING stdout and stderr in write order, and scitex-logging's console
+    handler re-resolves ``sys.stderr`` on every emit — so it follows click's
+    isolated streams and its ``WARN:`` line interleaves ahead of the payload.
+
+    Everything is real (PA-306, no mocks): a real ``logging`` logger, a real
+    click command, and sac's real ``host list`` callback reached through
+    ``ctx.invoke``. ``cfg_path`` names a file that is never written, so the
+    payload's ``peers`` list is legitimately empty.
+    """
+
+    @click.command("warn-then-list")
+    @click.pass_context
+    def warn_then_list(ctx: click.Context) -> None:
+        logging.getLogger("scitex_dev.hosts._retired").warning(_RETIRED_ALIAS_WARNING)
+        ctx.invoke(host_list, all_interfaces=False, as_json=True)
+
+    return CliRunner().invoke(warn_then_list, [])
+
+
+def test_json_payload_parses_from_stdout_despite_a_library_warning(
+    json_run_with_library_warning,
+):
+    """The ``--json`` payload parses from STDOUT ALONE — what ``| jq`` gets.
+
+    ``result.stdout``, never ``result.output``: an assertion on the merged
+    stream passes while the bug is present, which is worse than no test. It
+    also fails loudly under click < 8.2, where ``mix_stderr=True`` made
+    ``result.stdout`` the merged stream too — that is what the ``click>=8.2``
+    floor in pyproject.toml exists to guarantee.
+    """
+    # Arrange
+    result = json_run_with_library_warning
+    # Act
+    payload = json.loads(result.stdout)
+    # Assert
+    assert payload["peers"] == []
+
+
+def test_library_warning_reaches_the_merged_cli_runner_output(
+    json_run_with_library_warning,
+):
+    """The warning IS emitted — so the sibling stdout test cannot pass vacuously.
+
+    Its presence in ``result.output`` is also the direct evidence for why
+    that attribute is unusable as a JSON source: click 8.2 interleaves the
+    stderr ``WARN:`` line into it, ahead of the payload.
+    """
+    # Arrange
+    result = json_run_with_library_warning
+    # Act
+    merged = result.output
+    # Assert
+    assert _RETIRED_ALIAS_WARNING in merged


### PR DESCRIPTION
## What

The execute path for `sac agents relocate`. The phase machine, lease, journal and preflight already existed; `--dry-run` was documented as "currently the only supported mode". This adds the driver and the two phases the operator asked for.

Built to the operator's 10-point spec (2026-08-11), polished against what already existed.

## Phases

```
PREFLIGHT → TARGET_STANDBY → HANDSHAKE → SOURCE_DRAIN → HANDOVER → SOURCE_STOP → DONE
```

One new phase, **before** the atomic point, so everything prior to HANDOVER stays reversible.

## The driver — `_relocate_execute.py`

Injected effect per phase; owns order, journal, and the asymmetry (before HANDOVER a non-yes aborts; at or after, it stops and reports). UNKNOWN stops as firmly as FAIL and carries a *different* next action.

**A missing effect raises rather than being skipped** — a phase that journals as done having changed nothing is the most convincing possible imitation of success.

## HANDSHAKE (op#7) — the agentic round trip

Four requirements, each ruling out a way silence looked green on 2026-08-11:

- challenge accepted
- reply **observed on the source side**
- reply carries **this** challenge's nonce
- reply answers a question the loop had to compute

Empty nonce or empty expected-answer are refused at the call rather than silently weakening the gate.

This exists because a2a between two live agents delivered nothing that day and nobody noticed until a human did. A relocation that verified only "the process started" would have declared success on exactly that.

## `host` moves to the db (replaces op#1)

The operator's ruling: *spec is what a human declares; where it actually runs is observed state.*

- `_relocate_host_record.py` — seed-once-then-ignore. db wins when it knows; a legacy spec `host:` seeds the db once (recorded as `host_seeded_from_spec`); neither-knows is UNKNOWN, **never** `'local'`.
- `_relocate_records.py` encodes the split as a **refusal**: `host` lives in `STATE_FIELDS`, so `spec_patch(host=...)` **raises**. Enforced at the call site, not documented.
- A `SPEC_REWRITE` phase had already been built when the correction arrived; it is **moved aside** to `.old/20260811-165614/`, removed from `PHASES`, and its undo path deleted. Nothing dormant.

Removing it also removed the only pre-handover step that changed anything durable, so `abort` now has no compensation to perform — documented as the reason rather than left as a coincidence.

## Origin record (op#10)

Refuses a record naming no path. Repos with work are separated from repos **NOT MEASURED**; `recovery_lines()` renders instructions rather than a field dump.

## Two preflight checks (now 11)

- **`sac_present_on_target`** — three-valued, and separates NOT INSTALLED from INSTALLED-BUT-OFF-PATH *by evidence*. Captures the raw PATH **before** the peer preamble runs, or it would answer "yes" on exactly compute-03/-04. Written because sac on compute-04 lives at `~/.env-sac/bin/sac`, works, and is simply absent from the non-interactive ssh PATH — I reported it as "not installed" and was wrong.
- **`source_work_committed`** — FAIL with repo path and counts. An unscanned repo and a no-upstream branch are UNKNOWN, never "clean".

`_relocate_preflight.py` hit the 512-line limit and was split into facts / checks / orchestrator; public API unchanged and re-exported.

## Deliberately NOT in this PR

1. **The executing adapters.** `--no-dry-run` still has nothing to call. The pure driver is complete and tested; the callables that act against two live hosts are not written. An adapter that fabricates a success is exactly the failure this feature exists to prevent.
2. **The cross-host transcript transport** — contract already merged, byte-moving callables absent.
3. **The fleet-wide `host` migration** — `validate_placement` still *requires* `spec.host`, 106/106 specs carry it, and 11 runtime sites resolve placement from `config.hosts_spec.host`. Only relocate's own two sites are converted, so `host` is db-authoritative for relocate and spec-authoritative for dispatch. Deliberate, temporary, documented in `docs/relocate.md` §7.
4. **A residency table** — reads `instances.host`, so "where now" is answerable and "which host wrote this row in March" is not.

## Known conflict, stated rather than papered over

**The lease is recorded, not enforced.** `check_write` exists and nothing in sac calls it — verified independently: `rg 'check_write' src/` returns exactly two hits, its `__all__` entry and its definition, against a control that returns many. So a handover moves an authoritative *record*, not a mutual exclusion; two live instances via copy-and-start remain possible, which is what the lease was designed to make unrepresentable.

Not fixed here — enforcement touches every writer. But it must not be described as "the lease guarantees one writer" until something calls it.

## Tests

- relocate suite: **410 passed, real exit code 0** (captured to a file, never a pipeline tail). ~120 new.
- `_lifecycle` + `cli_pkg` + `config`: **4917 passed, 2 failed, 1 skipped**.

The 2 failures are `test__dev_jobs.py::test_systemd_list_filters_out_foreign_jobs` and `::test_systemd_list_json_reports_the_real_kind`. **Proven pre-existing by two independent A/B runs** against plain `develop` — identical failures, no relocate code involved. Root cause is environmental: `ModuleNotFoundError: No module named 'scitex_agent_container._jobs_plugin'`, an entry point advertised by a dist-info whose module is absent in the local venv.

No host was contacted and no agent started; every test is a pure function over injected callables.
