### PR TITLE
feat(dev): the sac dev job group IS the JobSpec kind — service/timer/cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,13 +48,24 @@ versioning follows [SemVer](https://semver.org/).
 
 - `cli_pkg/_dev_jobs_backend.py` — the explicit, testable delegation seam
   between `sac dev <kind> <verb>` and scitex-dev. It probes the INSTALLED
-  scitex-dev's real Click tree rather than consulting a hard-coded table, so
-  it picks up `ecosystem service` / `ecosystem timer` the moment those ship,
-  with no sac release; until then it falls back to today's `ecosystem
-  {cron,systemd}`. A verb neither surface serves exits 4 naming what was
-  probed and printing the exact `systemctl --user …` command to run by hand.
-  sac deliberately does NOT call `systemctl` itself — the argument is in the
-  module docstring.
+  scitex-dev's real Click tree rather than consulting a hard-coded table, and
+  resolves to a PATH rather than a name, so it survives the ecosystem moving
+  its job groups. Measured on scitex-dev 0.43.1: the groups already live at
+  `ecosystem dev {cron,systemd}`, while `ecosystem cron` / `ecosystem systemd`
+  are deprecated forwarding `Command` shims whose own help says "Removed in
+  v0.50" — they still run, but targeting them breaks on the next upgrade, and
+  because a shim is not a `Group` it enumerates as zero verbs while working
+  perfectly. Candidate paths are tried `dev <kind>` → `<kind>` → `dev <legacy>`
+  → `<legacy>`, so `ecosystem dev service` / `dev timer` (scitex-dev #566) are
+  picked up the moment they ship, with no sac release. An all-empty read is
+  the third state ("cannot tell"), never "unsupported" — including the live
+  case where `ecosystem dev` exists but its per-kind children do not. A verb
+  no surface serves exits 4 naming every path probed and printing the exact
+  `systemctl --user …` command to run by hand. `--dry-run` / `--yes` are
+  forwarded verbatim, because scitex-dev's gate on mutating verbs is what
+  stops `timer disable sac.accounts-refresh` from stopping the fleet's sole
+  OAuth refresher. sac deliberately does NOT call `systemctl` itself — the
+  argument is in the module docstring.
 
 - `_jobs/_names.py` — the local-vs-canonical job-name grammar, with the
   canonical prefix as a single named constant. That constant is the seam for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,73 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`sac dev` job groups are now named after the `JobSpec` KIND, not the
+  delivery mechanism** — `sac dev {service,timer,cron} <verb>`, the
+  ecosystem-wide grammar every SciTeX package adopts (operator decision,
+  2026-08-11). This is not a rename for tidiness. The old groups (`cron`,
+  `systemd`) were named on one axis while the filter used another, and
+  `_load_sac_jobs` was called with the GROUP NAME — so `sac dev systemd list`
+  asked for `kind="systemd"`, which `JobSpec.validate()` rejects at
+  construction, and every timer sac owns was invisible to its own CLI for
+  weeks behind "No sac systemd-kind jobs." and exit 0. With the group name and
+  the kind collapsed into one axis, that bug has no way to be expressed, and
+  `_jobs_audit` machine-checks the identity (`Form.GROUP_IS_NOT_ITS_KIND`)
+  plus the case where a kind is reachable only through a deprecated alias
+  (`Form.ALIAS_ONLY_KIND`).
+
+  The verb set differs per kind on purpose — a verb that makes no sense for a
+  kind does not exist for it rather than existing and erroring. `service` gets
+  the full lifecycle (`status`/`start`/`stop`/`restart`/`enable`/`disable`);
+  `timer` gets `status`/`enable`/`disable` (`enable --now` is the timer idiom,
+  so `start` would be a second spelling of it); `cron` gets `enable`/`disable`
+  (a crontab line has no runtime object to query).
+
+  `install` / `uninstall` now take an optional job NAME, and every named verb
+  accepts the SHORT local name the operator types (`accounts-refresh`) as well
+  as the canonical id (`sac.accounts-refresh`). An unknown name exits 5 and
+  lists the real ones instead of silently doing nothing.
+
+- **`sac dev systemd` is deprecated with a DATE, not "for the time being".**
+  It keeps working and keeps exactly its historical three verbs, so nothing
+  new gets built on it, and it carries machine-readable `since=2026-08` /
+  `remove_after=2026-10` / replacement metadata that a test enforces: the
+  build goes red once the window closes, which is what stops a temporary alias
+  from becoming permanent API. The notice is printed to **stderr** — a
+  courtesy message on stdout is indistinguishable from data, and that is
+  exactly how a stale-registry `WARN:` on stdout corrupted `sac host list
+  --json` and turned 7 tests red across three unrelated PRs.
+
+### Added
+
+- `cli_pkg/_dev_jobs_backend.py` — the explicit, testable delegation seam
+  between `sac dev <kind> <verb>` and scitex-dev. It probes the INSTALLED
+  scitex-dev's real Click tree rather than consulting a hard-coded table, so
+  it picks up `ecosystem service` / `ecosystem timer` the moment those ship,
+  with no sac release; until then it falls back to today's `ecosystem
+  {cron,systemd}`. A verb neither surface serves exits 4 naming what was
+  probed and printing the exact `systemctl --user …` command to run by hand.
+  sac deliberately does NOT call `systemctl` itself — the argument is in the
+  module docstring.
+
+- `_jobs/_names.py` — the local-vs-canonical job-name grammar, with the
+  canonical prefix as a single named constant. That constant is the seam for
+  the ecosystem-wide rename to `scitex-<pkg>-<name>`, which is deliberately
+  NOT in this change: renaming derives different unit filenames, so it must
+  ship with the migration that enforces stop → remove → install.
+
+### Fixed
+
+- **Two `--json` tests asserted on the wrong stream.** They parsed click's
+  `Result.output`, which merges stdout AND stderr, so they passed only while
+  nothing else wrote to stderr and went red the moment an unrelated
+  third-party jobs provider failed to load and `scitex_dev.jobs` warned about
+  it — correctly, on stderr. Real `sac dev … --json` stdout was clean
+  throughout. Every JSON assertion now reads `Result.stdout`, and one test
+  proves the contract end-to-end in a real subprocess where the two streams
+  are genuinely separate files.
+
 ## [0.24.25] - 2026-08-05
 
 ### Fixed

--- a/docs/worktree-gc.md
+++ b/docs/worktree-gc.md
@@ -154,10 +154,14 @@ could not remove anything a daily pass would miss.
 Install (operator-side). sac's own wrapper works again — it used to query
 a dead kind (`jobs_of_kind("systemd")`) and report "No sac systemd-kind
 jobs to install." forever, so this page told you to route around it. Both
-forms below are equivalent; the wrapper just filters `sac.*` for you:
+forms below are equivalent; the wrapper just filters `sac.*` for you.
+
+The group name is now the JobSpec **kind** (`sac dev {service,timer,cron}`)
+— `sac dev systemd` still works but is deprecated since 2026-08 and is
+removed after 2026-10.
 
 ```bash
-sac dev systemd install --yes                 # or, equivalently:
+sac dev timer install worktree-gc --yes       # or, equivalently:
 scitex-dev ecosystem systemd install --name sac.worktree-gc --yes
 systemctl --user daemon-reload
 systemctl --user enable --now sac.worktree-gc.timer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.24.25"
+version = "0.25.0"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/_jobs/_jobs_audit.py
+++ b/src/scitex_agent_container/_jobs/_jobs_audit.py
@@ -49,6 +49,15 @@ COVERED, deterministically, from the repo tree alone:
   consumer group can ever list, and a consumer group that filters on a
   ``kind`` outside ``ALLOWED_KINDS`` (i.e. one that can never match
   anything, ever).
+* :data:`Form.GROUP_IS_NOT_ITS_KIND` — the ecosystem grammar is
+  ``dev <kind> <verb>``, so a non-deprecated ``sac dev`` group name that
+  is not itself a legal kind, or that filters on anything other than
+  exactly its own name, has re-introduced the two-axis confusion that
+  caused the outage in the first place. This is the form that makes the
+  original bug UNREPRESENTABLE rather than merely fixed.
+* :data:`Form.ALIAS_ONLY_KIND` — a kind reachable only through a
+  DEPRECATED alias. The alias has a removal date, so such a kind has a
+  scheduled loss of its CLI: the disease with a calendar attached.
 
 NOT COVERED — stated plainly, because a checker that silently covers less
 than it appears to is the same disease wearing a lab coat:
@@ -87,6 +96,8 @@ class Form(str, Enum):
     DISCOVERY = "declared-job-unreachable-by-discover_jobs"
     CONSUMER = "declared-kind-has-no-consumer"
     IMPOSSIBLE_KIND = "consumer-filters-on-an-impossible-kind"
+    GROUP_IS_NOT_ITS_KIND = "consumer-group-name-is-not-the-kind-it-filters"
+    ALIAS_ONLY_KIND = "kind-reachable-only-through-a-deprecated-alias"
 
 
 @dataclass(frozen=True)
@@ -258,6 +269,88 @@ def audit_consumers(
     return tuple(findings)
 
 
+def audit_group_naming(
+    *,
+    group_kinds: dict[str, frozenset[str]],
+    allowed_kinds: frozenset[str],
+    deprecated: frozenset[str],
+) -> tuple[Finding, ...]:
+    """Form GROUP_IS_NOT_ITS_KIND / ALIAS_ONLY_KIND: is the grammar intact?
+
+    The ecosystem grammar is ``dev <kind> <verb>`` — the group name IS the
+    ``JobSpec.kind``. Enforcing that identity is what makes the original
+    outage structurally impossible rather than merely fixed: when the two
+    axes are one, there is no group name that can be passed where a kind
+    is expected and quietly mean something else.
+
+    Two checks:
+
+    * a NON-deprecated group whose name is not a legal kind, or which
+      filters on anything other than exactly itself, has re-introduced
+      the second axis;
+    * a kind reachable ONLY through a deprecated alias is a kind that
+      loses its CLI on the alias's removal date — a scheduled deletion of
+      a live capability, which is the disease with a calendar attached.
+
+    ``deprecated`` is the set of alias group names, passed in rather than
+    imported here for the same reason ``group_kinds`` is: this function
+    stays pure and the caller reads the real production values.
+    """
+    findings: list[Finding] = []
+
+    for group in sorted(group_kinds):
+        if group in deprecated:
+            continue
+        if group not in allowed_kinds:
+            findings.append(
+                Finding(
+                    form=Form.GROUP_IS_NOT_ITS_KIND,
+                    subject=f"sac dev {group}",
+                    verdict=Verdict.INERT,
+                    detail=(
+                        f"group name {group!r} is not a JobSpec kind "
+                        f"({sorted(allowed_kinds)}) and is not declared a "
+                        "deprecated alias — the group name and the kind are "
+                        "two axes again, which is the shape that hid every "
+                        "sac timer from its own CLI"
+                    ),
+                )
+            )
+            continue
+        if group_kinds[group] != frozenset({group}):
+            findings.append(
+                Finding(
+                    form=Form.GROUP_IS_NOT_ITS_KIND,
+                    subject=f"sac dev {group}",
+                    verdict=Verdict.INERT,
+                    detail=(
+                        f"group {group!r} filters on "
+                        f"{sorted(group_kinds[group])} rather than exactly "
+                        f"['{group}'] — a kind group must mean its own name"
+                    ),
+                )
+            )
+
+    live_cover: set[str] = set()
+    alias_cover: set[str] = set()
+    for group, kinds in group_kinds.items():
+        (alias_cover if group in deprecated else live_cover).update(kinds)
+    for kind in sorted(alias_cover - live_cover):
+        findings.append(
+            Finding(
+                form=Form.ALIAS_ONLY_KIND,
+                subject=f"kind={kind}",
+                verdict=Verdict.INERT,
+                detail=(
+                    f"kind {kind!r} is reachable only through a deprecated "
+                    f"alias ({sorted(deprecated)}) — it loses its CLI on the "
+                    "alias's removal date"
+                ),
+            )
+        )
+    return tuple(findings)
+
+
 def _declared_jobs() -> list:
     from scitex_agent_container._jobs._jobs_plugin import provide_jobs
 
@@ -276,6 +369,13 @@ def _consumer_group_kinds() -> dict[str, frozenset[str]]:
     from scitex_agent_container.cli_pkg._dev_jobs import GROUP_KINDS
 
     return GROUP_KINDS
+
+
+def _deprecated_groups() -> frozenset[str]:
+    """The alias group names, read from the consumer — same doctrine."""
+    from scitex_agent_container.cli_pkg._dev_jobs import DEPRECATED_GROUPS
+
+    return frozenset(DEPRECATED_GROUPS)
 
 
 def _discovered_sac_names(prefix: str) -> frozenset[str] | None:
@@ -328,6 +428,13 @@ def audit_jobs(*, prefix: str = "sac.") -> InertReport:
                 allowed_kinds=allowed,
             )
         )
+        findings.extend(
+            audit_group_naming(
+                group_kinds=_consumer_group_kinds(),
+                allowed_kinds=allowed,
+                deprecated=_deprecated_groups(),
+            )
+        )
     return InertReport(findings=tuple(findings))
 
 
@@ -338,5 +445,6 @@ __all__ = [
     "Verdict",
     "audit_consumers",
     "audit_discovery",
+    "audit_group_naming",
     "audit_jobs",
 ]

--- a/src/scitex_agent_container/_jobs/_names.py
+++ b/src/scitex_agent_container/_jobs/_names.py
@@ -1,0 +1,88 @@
+"""Job-name grammar: the LOCAL name an operator types vs the CANONICAL id.
+
+Two names for one job, and keeping them straight is the whole module:
+
+* the **canonical** ``JobSpec.name`` — globally unique across the whole
+  SciTeX ecosystem, because ``scitex_dev.jobs.discover_jobs`` keys its
+  de-duplication on it and the systemd renderer derives the UNIT FILENAME
+  from it verbatim (``<name>.service`` / ``<name>.timer``);
+* the **local** short name — what the operator types inside the owning
+  package's own CLI, where "which package" is already answered by the
+  command they are running (``sac dev timer install accounts-refresh``).
+
+Every verb that takes a name accepts EITHER form and resolves to the
+canonical one, so a copy-pasted canonical id from ``--json`` output or
+from a unit filename keeps working.
+
+WHY THE PREFIX IS A NAMED CONSTANT AND NOT AN INLINE LITERAL
+============================================================
+:data:`JOB_PREFIX` is the seam for the ecosystem-wide rename to
+``scitex-<pkg>-<name>`` (operator decision, 2026-08-11). That rename
+changes the DERIVED UNIT FILENAME of every job sac owns, which is a live
+double-supervisor hazard on any host where the current units are
+installed and running: the new unit is a DIFFERENT file, so installing it
+without first stopping and removing the old one leaves two units running
+the same command with independent state. ``sac.accounts-refresh`` is the
+fleet's SOLE OAuth refresher against a SINGLE-USE refresh token, so two
+of it revoke each other's access token fleet-wide.
+
+The rename therefore does not ride along with a CLI-surface change; it
+ships with the migration verb that enforces stop -> remove -> install and
+makes install-before-uninstall impossible. Flipping this one constant is
+the code half of that change.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+#: Canonical-name prefix for every job sac owns.
+#:
+#: Kept as a constant so the ecosystem rename to
+#: ``scitex-agent-container-`` is a one-line change guarded by the
+#: migration verb (see the module docstring), rather than a literal
+#: scattered across the CLI, the provider and the audit.
+JOB_PREFIX = "sac."
+
+
+def canonical(name: str) -> str:
+    """Return the canonical ``JobSpec.name`` for a local-or-canonical name.
+
+    Idempotent: an already-canonical name is returned unchanged, so a
+    value copied out of ``--json`` output or off a unit filename resolves
+    to itself instead of being prefixed twice.
+    """
+    if not name:
+        raise ValueError("job name must be non-empty")
+    return name if name.startswith(JOB_PREFIX) else JOB_PREFIX + name
+
+
+def local(name: str) -> str:
+    """Return the short name an operator types, for a canonical name."""
+    return name[len(JOB_PREFIX) :] if name.startswith(JOB_PREFIX) else name
+
+
+def is_ours(name: str) -> bool:
+    """True when ``name`` is a job THIS package owns."""
+    return name.startswith(JOB_PREFIX)
+
+
+def resolve(typed: str, declared: Iterable[str]) -> str:
+    """Resolve a typed name against the jobs actually declared.
+
+    Returns the canonical name. Raises :class:`KeyError` naming every
+    available local name when the typed one matches nothing — a verb that
+    silently does nothing for a typo is how a scheduled job quietly stops
+    being scheduled.
+    """
+    names = list(declared)
+    want = canonical(typed)
+    if want in names:
+        return want
+    raise KeyError(
+        f"no job named {typed!r} here; available: "
+        + (", ".join(sorted(local(n) for n in names)) or "(none)")
+    )
+
+
+__all__ = ["JOB_PREFIX", "canonical", "is_ours", "local", "resolve"]

--- a/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation-host.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation-host.md
@@ -106,7 +106,7 @@ Non-negotiables:
 
 ## 4. The host refresher cron — `sac.accounts-refresh`
 
-A federated systemd-user timer fires `sac accounts refresh --all --include-active --sync-active-login` every 2h (`OnUnitActiveSec=2h`). It iterates the account store and rotates EVERY account's tokens against `/oauth/token`, mirroring the active account's rotation back into the live `~/.claude/.credentials.json` login. Registered as the `sac.accounts-refresh` JobSpec via `_jobs_plugin.py`; install with `sac dev systemd install --yes`.
+A federated systemd-user timer fires `sac accounts refresh --all --include-active --sync-active-login` every 2h (`OnUnitActiveSec=2h`). It iterates the account store and rotates EVERY account's tokens against `/oauth/token`, mirroring the active account's rotation back into the live `~/.claude/.credentials.json` login. Registered as the `sac.accounts-refresh` JobSpec via `_jobs_plugin.py`; install with `sac dev timer install accounts-refresh --yes` (the CLI group is now the JobSpec **kind**; `sac dev systemd` still works but is deprecated since 2026-08 and removed after 2026-10).
 
 `--include-active` skips nothing — under the current `:ro`-everywhere model (§2) there is no other refresher left to race, so every stored account (including the host-active login and any pinned-running account) is a valid rotation target. Diagnostic stderr announces the intent:
 

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs.py
@@ -178,6 +178,20 @@ _NAMED_VERBS: frozenset[str] = frozenset(
     {"status", "start", "stop", "restart", "enable", "disable"}
 )
 
+#: How each verb reads at the start of its one-line help. Spelled out
+#: rather than ``verb.capitalize()`` because that produces "Status one of
+#: sac's timer jobs", which is not a sentence.
+_VERB_SUMMARY: dict[str, str] = {
+    "status": "Show the status of",
+    "start": "Start",
+    "stop": "Stop",
+    "restart": "Restart",
+    "enable": "Enable",
+    "disable": "Disable",
+    "install": "Install",
+    "uninstall": "Uninstall",
+}
+
 #: Verbs that act on EVERY job of the kind unless given an optional name,
 #: and mutate the host, so they require ``--yes``.
 _BULK_VERBS: frozenset[str] = frozenset({"install", "uninstall"})
@@ -372,7 +386,7 @@ def _add_bulk_command(grp, group: str, verb: str) -> None:
         raise SystemExit(rc)
 
     _bulk.help = (
-        f"{verb.capitalize()} sac's {group} jobs via scitex-dev.\n\n"
+        f"{_VERB_SUMMARY[verb]} sac's {group} jobs via scitex-dev.\n\n"
         "\b\nNAME is the short local name (e.g. `accounts-refresh`); the "
         "canonical form works too. Omit it to act on every job of this kind."
     )
@@ -396,7 +410,7 @@ def _add_named_command(grp, group: str, verb: str) -> None:
         raise SystemExit(_delegate(_kind_of(group), _verb, wanted, yes))
 
     _named.help = (
-        f"{verb.capitalize()} one of sac's {group} jobs via scitex-dev.\n\n"
+        f"{_VERB_SUMMARY[verb]} one of sac's {group} jobs via scitex-dev.\n\n"
         "\b\nNAME is the short local name (e.g. `accounts-refresh`); the "
         "canonical form works too."
     )

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs.py
@@ -198,11 +198,29 @@ _BULK_VERBS: frozenset[str] = frozenset({"install", "uninstall"})
 
 #: ``sac dev <group>`` -> its verbs. Per KIND, deliberately not uniform.
 #:
-#: * ``service`` — a long-running unit: the full lifecycle applies.
+#: MATCHED VERBATIM to scitex-dev's counterpart (PR #566), because the
+#: grammar is only worth anything if the two agree. A verb sac exposed
+#: that the shared layer will never serve is a permanent exit-4 — a
+#: declaration with no live counterpart, which is precisely what
+#: ``_jobs_audit`` exists to eliminate. Two deliberate consequences:
+#:
+#: * ``service`` has NO ``enable``/``disable``. systemd services support
+#:   them and an earlier revision here exposed them, but #566 does not,
+#:   so they would be inert. If #566 adds them, add them back.
+#: * ``cron`` has NO ``exec``, which #566 does have. sac declares no
+#:   ``kind="cron"`` job, and ``exec``'s argv shape is positional
+#:   (``exec <name> --apply``) rather than the uniform ``--name`` every
+#:   other verb takes — measured on scitex-dev 0.43.1. Wiring an
+#:   untestable special case for an empty group is the same disease in
+#:   the other direction; it belongs with the first cron job sac owns.
+#:
+#: The rest is per-kind reasoning:
+#:
+#: * ``service`` — a long-running unit: the runtime lifecycle applies.
 #: * ``timer``   — scheduled, not run by hand. ``enable``/``disable`` is
 #:   the systemd idiom for a timer (``enable --now`` starts it), so
 #:   ``start``/``stop``/``restart`` would be three ways to say the same
-#:   thing with different edge cases. Omitted rather than aliased.
+#:   thing with different edge cases.
 #: * ``cron``    — a crontab line is present or commented out. There is
 #:   no runtime object to start, stop or ask for status, so those verbs
 #:   do not exist here instead of existing and erroring.
@@ -216,8 +234,6 @@ GROUP_VERBS: dict[str, tuple[str, ...]] = {
         "start",
         "stop",
         "restart",
-        "enable",
-        "disable",
         "install",
         "uninstall",
     ),
@@ -284,13 +300,15 @@ def _kind_of(group: str) -> str:
     return "timer" if group == "systemd" else group
 
 
-def _delegate(kind: str, verb: str, name: str | None, yes: bool) -> int:
+def _delegate(
+    kind: str, verb: str, name: str | None, yes: bool, dry_run: bool = False
+) -> int:
     """Resolve + run one ecosystem delegation. THE single mutation seam.
 
-    Tests replace this one callable to capture the ``(kind, verb, name)``
-    tuples a verb delegates with, rather than shelling out to a real
-    ``scitex-dev`` that would rewrite the host's units and crontab. The
-    delegation ARGUMENTS are what those tests are about.
+    Tests replace this one callable to capture the ``(kind, verb, name,
+    yes, dry_run)`` tuples a verb delegates with, rather than shelling out
+    to a real ``scitex-dev`` that would rewrite the host's units and
+    crontab. The delegation ARGUMENTS are what those tests are about.
     """
     delegation = _backend.resolve(kind, verb)
     if not delegation.supported:
@@ -306,7 +324,7 @@ def _delegate(kind: str, verb: str, name: str | None, yes: bool) -> int:
             err=True,
         )
         raise SystemExit(4)
-    return _backend.invoke(delegation, name=name, yes=yes)
+    return _backend.invoke(delegation, name=name, yes=yes, dry_run=dry_run)
 
 
 def _resolve_one(group: str, typed: str) -> str:
@@ -364,13 +382,20 @@ def _add_bulk_command(grp, group: str, verb: str) -> None:
     @grp.command(verb)
     @click.argument("name", required=False)
     @click.option(
+        "--dry-run",
+        "dry_run",
+        is_flag=True,
+        default=False,
+        help="Preview only. Forwarded to scitex-dev.",
+    )
+    @click.option(
         "-y",
         "--yes",
         is_flag=True,
         default=False,
         help="Confirm. Forwarded to scitex-dev.",
     )
-    def _bulk(name, yes, _verb=verb):
+    def _bulk(name, dry_run, yes, _verb=verb):
         _announce_deprecation(group)
         jobs = _jobs_or_degrade(group)
         if name is not None:
@@ -381,7 +406,7 @@ def _add_bulk_command(grp, group: str, verb: str) -> None:
             return
         rc = 0
         for j in jobs:
-            code = _delegate(_kind_of(group), _verb, j.name, yes)
+            code = _delegate(_kind_of(group), _verb, j.name, yes, dry_run)
             rc = rc or code
         raise SystemExit(rc)
 
@@ -395,19 +420,30 @@ def _add_bulk_command(grp, group: str, verb: str) -> None:
 def _add_named_command(grp, group: str, verb: str) -> None:
     """Attach a lifecycle verb that acts on ONE named job."""
 
+    mutating = verb in _backend.MUTATING_VERBS
+
     @grp.command(verb)
     @click.argument("name")
+    @click.option(
+        "--dry-run",
+        "dry_run",
+        is_flag=True,
+        default=False,
+        hidden=not mutating,
+        help="Preview only. Forwarded to scitex-dev.",
+    )
     @click.option(
         "-y",
         "--yes",
         is_flag=True,
         default=False,
+        hidden=not mutating,
         help="Confirm. Forwarded to scitex-dev.",
     )
-    def _named(name, yes, _verb=verb):
+    def _named(name, dry_run, yes, _verb=verb):
         _announce_deprecation(group)
         wanted = _resolve_one(group, name)
-        raise SystemExit(_delegate(_kind_of(group), _verb, wanted, yes))
+        raise SystemExit(_delegate(_kind_of(group), _verb, wanted, yes, dry_run))
 
     _named.help = (
         f"{_VERB_SUMMARY[verb]} one of sac's {group} jobs via scitex-dev.\n\n"

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs.py
@@ -1,80 +1,215 @@
-"""``sac dev {cron,systemd}`` — sac's federated scheduled jobs.
+"""``sac dev {service,timer,cron}`` — sac's federated scheduled jobs.
 
-Surfaces sac's OWN jobs (``sac.*``) by delegating to scitex-dev's
-ecosystem aggregator (``scitex_dev.jobs``).
+THE GROUP NAME IS THE ``JobSpec.kind``. That is the whole design, it is
+the ecosystem-wide grammar (operator decision, 2026-08-11 — every SciTeX
+package exposes ``scitex-<pkg> dev {service,timer,cron} <verb>``), and it
+is the countermeasure to the outage below rather than a cosmetic rename.
 
-The group name is the ``scitex-dev ecosystem <name>`` subcommand we
-delegate to; the KIND is the ``JobSpec.kind`` taxonomy we filter on. They
-are NOT the same axis, and :data:`GROUP_KINDS` is the mapping between
-them. Conflating the two made every job verb here inert for weeks —
-``_load_sac_jobs`` was called with the GROUP NAME, so ``sac dev systemd
-list`` asked for ``kind="systemd"``, a value ``JobSpec.validate()``
-rejects at construction (``ALLOWED_KINDS`` is ``{service,timer,cron}``
-since scitex-dev #153). No job could ever match, so all four of sac's
-timers — the OAuth refresh, the drift check, the worktree GC and the
-fleet reconciler — were invisible to their own CLI, which reported "No
-sac systemd-kind jobs." and exit 0. The tests passed the whole time
-because the fixture hand-rolled a fake ``scitex_dev.jobs`` whose ``_Job``
-defaulted to ``kind="systemd"`` — a spec shape no real spec can have —
-so the suite never ran the real validator. See ``_jobs_audit`` for the
-detector that now makes this shape fail loudly in CI.
+WHAT THE OLD SHAPE COST
+=======================
+The groups used to be named after the DELIVERY MECHANISM (``cron`` and
+``systemd``) while the filter was the KIND — two different axes wearing
+one name. ``_load_sac_jobs`` was then called with the GROUP NAME, so
+``sac dev systemd list`` asked for ``kind="systemd"``, a value
+``JobSpec.validate()`` rejects at construction (``ALLOWED_KINDS`` is
+``{service,timer,cron}`` since scitex-dev #153). No job could ever match,
+so every timer sac owns — the OAuth refresh, the drift check, the
+worktree GC, the fleet reconciler and the rest — was invisible to its own
+CLI, which reported "No sac systemd-kind jobs." and exit 0. The tests
+passed the whole time because the fixture hand-rolled a fake
+``scitex_dev.jobs`` whose ``_Job`` defaulted to ``kind="systemd"`` — a
+spec shape no real spec can have — so the suite never ran the real
+validator.
 
-:data:`GROUP_KINDS` mirrors scitex-dev's canonical selection exactly
-(verified against ``_cli/ecosystem/_cmds/``): ``_jobs_cron.py`` selects
-``jobs_of_kind("cron")``; ``_jobs_systemd.py`` selects
-``jobs_of_kind("timer") + jobs_of_kind("service")``.
+Naming the groups after the kinds removes the second axis entirely: there
+is no longer a group name that COULD be passed where a kind is expected
+and mean something different. ``_jobs_audit`` machine-checks exactly that
+(``Form.GROUP_IS_NOT_ITS_KIND``), so the invariant is enforced, not
+documented.
 
-The verbs per group mirror ``scitex-dev ecosystem <group> <verb>``:
+``systemd`` SURVIVES AS A DEPRECATED ALIAS, WITH A DATE
+=======================================================
+Existing callers, docs and the operator's muscle memory all say
+``systemd``, so removing it now would break working commands for no gain.
+It stays — covering ``{service, timer}`` exactly as before, with the same
+three verbs it always had and no new ones, so nothing new is built on
+it — and it carries :class:`Deprecation` metadata with a real
+``remove_after`` date. "当面" ("for the time being") becomes permanent
+unless a date is written down, and a date nobody enforces is the same
+thing, so ``test__dev_jobs.py`` fails the build once that date passes.
 
-* ``cron``    → ``list`` / ``install`` / ``uninstall``
-* ``systemd`` → ``list`` / ``install`` / ``uninstall``
+The notice goes to **stderr**, never stdout. ``sac`` commands are parsed
+by machines: a sibling agent measured ``scitex_dev.hosts._retired``
+printing a stale-registry ``WARN:`` to stdout, which corrupted
+``sac host list --json`` and turned 7 tests red across three unrelated
+PRs. Every ``--json`` verb here is covered by a test that reads STDOUT
+ALONE (``Result.stdout``, not ``Result.output`` — click 8.4's ``output``
+merges stderr in, which is precisely how a stdout-purity test can pass
+while stdout is filthy, or fail while it is clean).
 
-There is deliberately NO ``sac dev daemon`` group. It used to exist and
-was dead in BOTH halves: it filtered ``kind="daemon"`` (not a legal kind,
-so always zero jobs) and delegated to ``scitex-dev ecosystem daemon``,
-which is not a subcommand of ``ecosystem`` at all. A long-running job is
-``kind="service"``, installed through the ``systemd`` group above.
-
-``install`` / ``uninstall`` delegate to
-``scitex-dev ecosystem <group> {install,uninstall} --name <name>`` so the
-unit/cron generation stays single-sourced in scitex-dev.
+WHERE THE VERBS GO
+==================
+Delegation is resolved by :mod:`._dev_jobs_backend`, which also carries
+the argument for why sac does not call ``systemctl`` itself. The verb set
+differs per kind on purpose: a verb that makes no sense for a kind does
+not exist for that kind, rather than existing and erroring. There is
+deliberately no ``daemon`` group — it was dead in both halves (it
+filtered ``kind="daemon"``, never legal, and delegated to an
+``ecosystem daemon`` that does not exist). A long-running job is
+``kind="service"``.
 
 Graceful degradation: a scitex-dev that predates the ``scitex_dev.jobs``
-contract (PyPI lag) raises ``ImportError`` on the lazy import; every
-command catches it and prints an upgrade hint instead of a stack trace.
+contract raises ``ImportError`` on the lazy import; every command catches
+it and prints an upgrade hint instead of a stack trace.
+
+Exit codes: ``2`` refusing to mutate without ``--yes``, ``3`` scitex-dev
+too old, ``4`` the verb exists in this grammar but the installed
+scitex-dev cannot serve it yet, ``5`` no such job name.
 
 These commands are attached onto ``dev_group`` at import time via
-:func:`register_dev_jobs_commands` (same pattern as the account group's
-``register_sync_live_commands`` / ``register_refresh_command``).
+:func:`register_dev_jobs_commands`.
 """
 
 from __future__ import annotations
 
-import shutil
-import subprocess
+import re
+from dataclasses import dataclass
 
 import click
 
+from .._jobs import _names
+from . import _dev_jobs_backend as _backend
+
 # The scitex-dev release that first ships ``scitex_dev.jobs`` (PR #91).
 # scitex-dev 0.15.0 is the last release WITHOUT it; the jobs contract is
-# in scitex-dev's Unreleased section → first available in 0.16.0.
+# in scitex-dev's Unreleased section -> first available in 0.16.0.
 _JOBS_MIN_VERSION = "0.16.0"
-
-# sac owns every job whose name is prefixed ``sac.`` (JobSpec.name
-# convention — see scitex_dev.jobs docstring).
-_SAC_PREFIX = "sac."
 
 #: ``sac dev <group>`` -> the ``JobSpec.kind`` values that group lists.
 #:
 #: THE SSOT for this mapping, and the reason it is module-level rather
 #: than inlined: ``_jobs_audit.audit_jobs`` imports THIS dict to check
-#: that every kind sac declares has a consumer able to see it. If the
-#: audit re-declared the mapping instead of importing the one production
-#: uses, the audit would be checking its own opinion — a declaration with
-#: no live counterpart, i.e. the exact disease it exists to detect.
+#: that every kind sac declares has a consumer able to see it, and that
+#: no group filters on a kind the validator would reject. If the audit
+#: re-declared the mapping instead of importing the one production uses,
+#: the audit would be checking its own opinion — a declaration with no
+#: live counterpart, i.e. the exact disease it exists to detect.
+#:
+#: Every entry except the deprecated alias maps a group to EXACTLY the
+#: kind of the same name. That identity is the invariant; it is checked,
+#: not trusted.
 GROUP_KINDS: dict[str, frozenset[str]] = {
+    "service": frozenset({"service"}),
+    "timer": frozenset({"timer"}),
     "cron": frozenset({"cron"}),
-    "systemd": frozenset({"timer", "service"}),
+    # Deprecated alias — see DEPRECATED_GROUPS. Covers both unit kinds,
+    # which is what `scitex-dev ecosystem systemd` has always selected.
+    "systemd": frozenset({"service", "timer"}),
+}
+
+_YYYY_MM = re.compile(r"^\d{4}-(0[1-9]|1[0-2])$")
+
+
+@dataclass(frozen=True)
+class Deprecation:
+    """A dated retirement plan for a CLI surface.
+
+    Every field is load-bearing and validated at construction, because a
+    deprecation with a missing or malformed date is indistinguishable
+    from no deprecation at all — which is how "temporary" aliases become
+    permanent API.
+    """
+
+    since: str
+    remove_after: str
+    replacement: str
+
+    def __post_init__(self) -> None:
+        for field, value in (
+            ("since", self.since),
+            ("remove_after", self.remove_after),
+        ):
+            if not _YYYY_MM.match(value):
+                raise ValueError(
+                    f"Deprecation.{field}={value!r} must be YYYY-MM — a vague "
+                    "date is the same as no date"
+                )
+        if self.remove_after <= self.since:
+            raise ValueError(
+                f"Deprecation.remove_after={self.remove_after!r} must be after "
+                f"since={self.since!r}"
+            )
+        if not self.replacement:
+            raise ValueError(
+                "Deprecation.replacement must name what to use instead — a "
+                "deprecation with no replacement is just a complaint"
+            )
+
+    def is_expired(self, today: str) -> bool:
+        """True once ``today`` (``YYYY-MM``) is past ``remove_after``."""
+        if not _YYYY_MM.match(today):
+            raise ValueError(f"today={today!r} must be YYYY-MM")
+        return today > self.remove_after
+
+    def notice(self, group: str) -> str:
+        """The stderr line printed on every use of the deprecated group."""
+        return (
+            f"DEPRECATED: `sac dev {group}` is deprecated since {self.since} "
+            f"and will be REMOVED after {self.remove_after}. "
+            f"Use: {self.replacement}. "
+            "(The group name is now the JobSpec kind — `systemd` is a "
+            "delivery mechanism, not a kind.)"
+        )
+
+
+#: Groups kept only for compatibility. A group listed here MUST also be
+#: in GROUP_KINDS; the audit checks that a deprecated alias never becomes
+#: the only way to reach a kind.
+DEPRECATED_GROUPS: dict[str, Deprecation] = {
+    "systemd": Deprecation(
+        since="2026-08",
+        remove_after="2026-10",
+        replacement="`sac dev service` / `sac dev timer`",
+    ),
+}
+
+#: Verbs that take a job NAME and act on ONE job.
+_NAMED_VERBS: frozenset[str] = frozenset(
+    {"status", "start", "stop", "restart", "enable", "disable"}
+)
+
+#: Verbs that act on EVERY job of the kind unless given an optional name,
+#: and mutate the host, so they require ``--yes``.
+_BULK_VERBS: frozenset[str] = frozenset({"install", "uninstall"})
+
+#: ``sac dev <group>`` -> its verbs. Per KIND, deliberately not uniform.
+#:
+#: * ``service`` — a long-running unit: the full lifecycle applies.
+#: * ``timer``   — scheduled, not run by hand. ``enable``/``disable`` is
+#:   the systemd idiom for a timer (``enable --now`` starts it), so
+#:   ``start``/``stop``/``restart`` would be three ways to say the same
+#:   thing with different edge cases. Omitted rather than aliased.
+#: * ``cron``    — a crontab line is present or commented out. There is
+#:   no runtime object to start, stop or ask for status, so those verbs
+#:   do not exist here instead of existing and erroring.
+#: * ``systemd`` — the deprecated alias keeps EXACTLY its historical
+#:   surface. New verbs are reachable only through the kind groups, so
+#:   nothing new can be built on the alias.
+GROUP_VERBS: dict[str, tuple[str, ...]] = {
+    "service": (
+        "list",
+        "status",
+        "start",
+        "stop",
+        "restart",
+        "enable",
+        "disable",
+        "install",
+        "uninstall",
+    ),
+    "timer": ("list", "status", "enable", "disable", "install", "uninstall"),
+    "cron": ("list", "enable", "disable", "install", "uninstall"),
+    "systemd": ("list", "install", "uninstall"),
 }
 
 
@@ -89,37 +224,85 @@ def _degrade_msg() -> str:
 def _load_sac_jobs(kinds: frozenset[str]) -> list:
     """Return sac-owned ``JobSpec`` whose kind is in ``kinds``.
 
-    Takes the KIND SET, never a group name: passing the group name was the
-    bug that made every verb here inert (see the module docstring).
+    Takes the KIND SET, never a group name: passing the group name was
+    the bug that made every verb here inert (see the module docstring).
 
     Lazy import of ``scitex_dev.jobs`` so an older installed scitex-dev
-    surfaces as a clean ImportError the callers translate into an
-    upgrade hint.
+    surfaces as a clean ImportError the callers translate into an upgrade
+    hint.
     """
     from scitex_dev.jobs import jobs_of_kind  # may ImportError on old scitex-dev
 
     jobs: list = []
     for kind in sorted(kinds):
-        jobs.extend(j for j in jobs_of_kind(kind) if j.name.startswith(_SAC_PREFIX))
+        jobs.extend(j for j in jobs_of_kind(kind) if _names.is_ours(j.name))
     return jobs
 
 
-def _ecosystem_delegate(group: str, verb: str, name: str, yes: bool = False) -> int:
-    """Delegate to ``scitex-dev ecosystem <group> <verb> --name <name>``.
+def _jobs_or_degrade(group: str) -> list:
+    """Load this group's jobs, or exit 3 with the upgrade hint on stderr."""
+    try:
+        return _load_sac_jobs(GROUP_KINDS[group])
+    except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — print upgrade hint, not a stack trace)
+        click.echo(_degrade_msg(), err=True)
+        raise SystemExit(3)
 
-    Returns the subprocess exit code. ``scitex-dev`` is a hard dependency
-    of this package, so the console script is expected on PATH; a missing
-    binary is reported as a clean ClickException.
+
+def _announce_deprecation(group: str) -> None:
+    """Print the dated deprecation notice to STDERR, never stdout.
+
+    stdout carries machine-readable payloads (``--json``); a courtesy
+    message written there is indistinguishable from data.
     """
-    exe = shutil.which("scitex-dev")
-    if exe is None:
-        raise click.ClickException(
-            "`scitex-dev` console script not found on PATH; " + _degrade_msg()
+    dep = DEPRECATED_GROUPS.get(group)
+    if dep is not None:
+        click.echo(dep.notice(group), err=True)
+
+
+def _kind_of(group: str) -> str:
+    """The kind a group's VERBS act on.
+
+    Identical to the group name for every kind group. The deprecated
+    alias covers two kinds, so its verbs resolve against ``timer`` — the
+    kind every job sac declares today has, and the one whose delegation
+    target (``ecosystem systemd``) is the same for both.
+    """
+    return "timer" if group == "systemd" else group
+
+
+def _delegate(kind: str, verb: str, name: str | None, yes: bool) -> int:
+    """Resolve + run one ecosystem delegation. THE single mutation seam.
+
+    Tests replace this one callable to capture the ``(kind, verb, name)``
+    tuples a verb delegates with, rather than shelling out to a real
+    ``scitex-dev`` that would rewrite the host's units and crontab. The
+    delegation ARGUMENTS are what those tests are about.
+    """
+    delegation = _backend.resolve(kind, verb)
+    if not delegation.supported:
+        click.echo(
+            f"`sac dev {kind} {verb}` is part of the SciTeX job grammar, but "
+            f"the installed scitex-dev cannot serve it yet: "
+            f"{delegation.evidence}.",
+            err=True,
         )
-    cmd = [exe, "ecosystem", group, verb, "--name", name]
-    if yes:
-        cmd.append("--yes")
-    return subprocess.call(cmd)
+        click.echo(
+            "Run it by hand meanwhile: "
+            + _backend.manual_hint(kind, verb, name or "<job>"),
+            err=True,
+        )
+        raise SystemExit(4)
+    return _backend.invoke(delegation, name=name, yes=yes)
+
+
+def _resolve_one(group: str, typed: str) -> str:
+    """Resolve a typed local-or-canonical job name, or exit 5."""
+    jobs = _jobs_or_degrade(group)
+    try:
+        return _names.resolve(typed, [j.name for j in jobs])
+    except KeyError as exc:
+        click.echo(str(exc.args[0]), err=True)
+        raise SystemExit(5)
 
 
 def _add_list_command(grp, group: str) -> None:
@@ -128,20 +311,18 @@ def _add_list_command(grp, group: str) -> None:
     @grp.command("list")
     @click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
     def _list(as_json):
-        """List sac's own jobs of this group."""
+        """List sac's own jobs of this kind."""
         import json as _json
 
-        try:
-            jobs = _load_sac_jobs(GROUP_KINDS[group])
-        except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — print upgrade hint, not a stack trace)
-            click.echo(_degrade_msg(), err=True)
-            raise SystemExit(3)
+        _announce_deprecation(group)
+        jobs = _jobs_or_degrade(group)
         if as_json:
             click.echo(
                 _json.dumps(
                     [
                         {
                             "name": j.name,
+                            "local_name": _names.local(j.name),
                             "kind": j.kind,
                             "schedule": j.schedule,
                             "command": j.command,
@@ -158,18 +339,71 @@ def _add_list_command(grp, group: str) -> None:
             return
         for j in jobs:
             cadence = j.on_unit_active_sec or j.schedule
-            click.echo(f"  {j.name:24s} every {cadence}")
+            click.echo(f"  {_names.local(j.name):24s} every {cadence}")
             click.echo(f"  {'':24s} {j.command}")
             click.echo(f"  {'':24s} {j.description}")
 
 
-def _make_installable_group(group: str):
-    """Build a ``sac dev <group>`` group with list/install/uninstall.
+def _add_bulk_command(grp, group: str, verb: str) -> None:
+    """Attach ``install`` / ``uninstall``: every job of the kind, or one."""
 
-    Mirrors ``scitex-dev ecosystem <group>``, which is what the verbs
-    delegate to; the jobs shown are those whose kind is in
-    ``GROUP_KINDS[group]``.
-    """
+    @grp.command(verb)
+    @click.argument("name", required=False)
+    @click.option(
+        "-y",
+        "--yes",
+        is_flag=True,
+        default=False,
+        help="Confirm. Forwarded to scitex-dev.",
+    )
+    def _bulk(name, yes, _verb=verb):
+        _announce_deprecation(group)
+        jobs = _jobs_or_degrade(group)
+        if name is not None:
+            wanted = _resolve_one(group, name)
+            jobs = [j for j in jobs if j.name == wanted]
+        if not jobs:
+            click.echo(f"No sac {group} jobs to {_verb}.")
+            return
+        rc = 0
+        for j in jobs:
+            code = _delegate(_kind_of(group), _verb, j.name, yes)
+            rc = rc or code
+        raise SystemExit(rc)
+
+    _bulk.help = (
+        f"{verb.capitalize()} sac's {group} jobs via scitex-dev.\n\n"
+        "\b\nNAME is the short local name (e.g. `accounts-refresh`); the "
+        "canonical form works too. Omit it to act on every job of this kind."
+    )
+
+
+def _add_named_command(grp, group: str, verb: str) -> None:
+    """Attach a lifecycle verb that acts on ONE named job."""
+
+    @grp.command(verb)
+    @click.argument("name")
+    @click.option(
+        "-y",
+        "--yes",
+        is_flag=True,
+        default=False,
+        help="Confirm. Forwarded to scitex-dev.",
+    )
+    def _named(name, yes, _verb=verb):
+        _announce_deprecation(group)
+        wanted = _resolve_one(group, name)
+        raise SystemExit(_delegate(_kind_of(group), _verb, wanted, yes))
+
+    _named.help = (
+        f"{verb.capitalize()} one of sac's {group} jobs via scitex-dev.\n\n"
+        "\b\nNAME is the short local name (e.g. `accounts-refresh`); the "
+        "canonical form works too."
+    )
+
+
+def _make_group(group: str):
+    """Build a ``sac dev <group>`` group with the verbs declared for it."""
 
     @click.group(group, invoke_without_command=True)
     @click.pass_context
@@ -178,64 +412,33 @@ def _make_installable_group(group: str):
             click.echo(ctx.get_help())
 
     kinds = ", ".join(sorted(GROUP_KINDS[group]))
+    verbs = "\n".join(f"  {v}" for v in GROUP_VERBS[group])
+    dep = DEPRECATED_GROUPS.get(group)
+    banner = (
+        f"DEPRECATED since {dep.since}, REMOVED after {dep.remove_after} — "
+        f"use {dep.replacement}.\n\n"
+        if dep
+        else ""
+    )
     _grp.help = (
-        f"sac's federated {group} jobs (delegates to scitex-dev ecosystem).\n\n"
+        f"{banner}sac's federated {group} jobs (delegates to scitex-dev "
+        "ecosystem).\n\n"
         f"\b\nShows JobSpecs of kind: {kinds}\n\n"
-        "\b\nVerbs:\n"
-        "  list       — show sac's own jobs of this group\n"
-        "  install    — generate + install them via scitex-dev\n"
-        "  uninstall  — remove them via scitex-dev"
+        "\b\nVerbs:\n" + verbs
     )
 
-    _add_list_command(_grp, group)
-
-    @_grp.command("install")
-    @click.option(
-        "-y",
-        "--yes",
-        is_flag=True,
-        default=False,
-        help="Confirm. Forwarded to scitex-dev.",
-    )
-    def _install(yes):
-        """Install sac's jobs of this group via scitex-dev."""
-        try:
-            jobs = _load_sac_jobs(GROUP_KINDS[group])
-        except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — print upgrade hint, not a stack trace)
-            click.echo(_degrade_msg(), err=True)
-            raise SystemExit(3)
-        if not jobs:
-            click.echo(f"No sac {group} jobs to install.")
-            return
-        rc = 0
-        for j in jobs:
-            code = _ecosystem_delegate(group, "install", j.name, yes)
-            rc = rc or code
-        raise SystemExit(rc)
-
-    @_grp.command("uninstall")
-    @click.option(
-        "-y",
-        "--yes",
-        is_flag=True,
-        default=False,
-        help="Confirm. Forwarded to scitex-dev.",
-    )
-    def _uninstall(yes):
-        """Uninstall sac's jobs of this group via scitex-dev."""
-        try:
-            jobs = _load_sac_jobs(GROUP_KINDS[group])
-        except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — print upgrade hint, not a stack trace)
-            click.echo(_degrade_msg(), err=True)
-            raise SystemExit(3)
-        if not jobs:
-            click.echo(f"No sac {group} jobs to uninstall.")
-            return
-        rc = 0
-        for j in jobs:
-            code = _ecosystem_delegate(group, "uninstall", j.name, yes)
-            rc = rc or code
-        raise SystemExit(rc)
+    for verb in GROUP_VERBS[group]:
+        if verb == "list":
+            _add_list_command(_grp, group)
+        elif verb in _BULK_VERBS:
+            _add_bulk_command(_grp, group, verb)
+        elif verb in _NAMED_VERBS:
+            _add_named_command(_grp, group, verb)
+        else:  # pragma: no cover - guarded by test_every_verb_has_a_shape
+            raise ValueError(
+                f"`sac dev {group} {verb}` has no declared verb shape; add it "
+                "to _NAMED_VERBS or _BULK_VERBS"
+            )
 
     return _grp
 
@@ -243,7 +446,13 @@ def _make_installable_group(group: str):
 def register_dev_jobs_commands(dev_group: click.Group) -> None:
     """Attach a job group onto ``sac dev`` for every entry in GROUP_KINDS."""
     for group in sorted(GROUP_KINDS):
-        dev_group.add_command(_make_installable_group(group))
+        dev_group.add_command(_make_group(group))
 
 
-__all__ = ["GROUP_KINDS", "register_dev_jobs_commands"]
+__all__ = [
+    "DEPRECATED_GROUPS",
+    "Deprecation",
+    "GROUP_KINDS",
+    "GROUP_VERBS",
+    "register_dev_jobs_commands",
+]

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
@@ -21,23 +21,76 @@ not, and the argument is worth stating because the shortcut looks free:
    handling, and the escaping. The aggregator exists precisely to stop
    that.
 3. **The verb set is not stable yet.** scitex-dev is growing
-   ``ecosystem service`` / ``ecosystem timer`` with these verbs. Anything
-   sac hard-codes now becomes the thing that has to be un-picked later.
+   ``ecosystem dev service`` / ``ecosystem dev timer`` with these verbs.
+   Anything sac hard-codes now becomes the thing that has to be un-picked
+   later.
 
 So sac RESOLVES a delegation target and shells ``scitex-dev ecosystem
-<group> <verb>``. Where that surface does not exist yet, this module says
-so precisely — naming what it probed and what it found — and prints the
-exact command the operator can run by hand. It never silently substitutes
-a different mechanism, because a verb that quietly does something OTHER
-than what it says is worse than one that is honestly missing.
+<path...> <verb>``. Where that surface does not exist yet, this module
+says so precisely — naming what it probed and what it found — and prints
+the exact command the operator can run by hand. It never silently
+substitutes a different mechanism, because a verb that quietly does
+something OTHER than what it says is worse than one that is honestly
+missing.
+
+THE TARGET IS A PATH, NOT A NAME — AND IT ALREADY MOVED
+=======================================================
+scitex-dev relocated its job CLI one level down, under ``ecosystem dev``
+(its §13 doctrine). MEASURED on the installed scitex-dev 0.43.1, by
+introspecting the real Click objects rather than reading a PR:
+
+    ecosystem cron        -> click.Command  (NOT a Group)
+                             help: "(deprecated) Forwards to
+                             'ecosystem dev cron'. Removed in v0.50."
+    ecosystem systemd     -> click.Command, same deprecation + removal
+    ecosystem dev         -> SpecGroup      ['cron', 'systemd']
+    ecosystem dev cron    -> SpecGroup      ['exec','install','list','uninstall']
+    ecosystem dev systemd -> SpecGroup      ['install','list','uninstall']
+    ecosystem dev service -> ABSENT         (arrives in scitex-dev #566)
+    ecosystem dev timer   -> ABSENT         (arrives in scitex-dev #566)
+
+Three traps follow, and each of them will bite a name-keyed probe:
+
+* The old names still RESOLVE, so "does ``ecosystem systemd`` exist"
+  answers YES — but they are FORWARDING SHIMS, deprecated, and
+  **removed in scitex-dev v0.50**. Targeting them is a time bomb even
+  though they work today.
+* A shim is a ``Command``, not a ``Group``, so it has no
+  ``list_commands`` and enumerates as ZERO VERBS while
+  ``ecosystem systemd install`` runs fine. Zero verbs is therefore
+  evidence about the PROBE, never about the surface — which is why
+  :func:`resolve` treats an all-empty read as "cannot tell".
+* ``ecosystem dev`` exists while its per-KIND children do not. That is
+  the live state today, not a hypothetical: an all-or-nothing reading
+  would refuse ``install`` on a perfectly working scitex-dev.
+
+An earlier revision of this module blamed "lazy Click groups" for the
+zero-verb reading. That was wrong — stated here rather than quietly
+edited out, because the next person to see a zero will reach for the
+same wrong explanation.
+
+So the probe WALKS to ``ecosystem dev`` and keys everything by PATH
+(``("dev", "timer")``, ``("systemd",)``, …), preferring the deepest,
+least-deprecated match. Nothing here depends on which level the
+ecosystem currently mounts its groups at.
 
 READ-ONLY IS NOT THE SAME AS OWNING IT
 ======================================
 Nothing here mutates host state. The capability probe is an in-process
 introspection of the installed scitex-dev's own Click tree — it answers
 "does this surface exist" from the code that would serve it, not from a
-hard-coded table that would drift the moment scitex-dev ships the verbs.
-That is the same doctrine ``_jobs_audit`` follows: read the real thing.
+hard-coded table that would drift the moment scitex-dev moves the groups
+again. That is the same doctrine ``_jobs_audit`` follows: read the real
+thing.
+
+``--dry-run`` / ``--yes`` ARE FORWARDED, NOT RE-IMPLEMENTED
+===========================================================
+scitex-dev gates every mutating job verb behind ``--dry-run`` /
+``--yes``, and that gate is load-bearing: ``timer disable
+sac.accounts-refresh`` stops the fleet's SOLE OAuth refresher against a
+single-use refresh token. A pass-through that dropped those flags would
+turn a guarded command into an unguarded one, so both travel verbatim
+and ``--dry-run`` is offered on every mutating verb sac exposes.
 """
 
 from __future__ import annotations
@@ -49,23 +102,35 @@ from dataclasses import dataclass
 import click
 
 #: The ecosystem subcommand that serves a kind on the surface that has
-#: SHIPPED (``scitex-dev`` <= 0.43.x): ``cron`` for cron jobs, and
-#: ``systemd`` for both unit kinds, which it lumps together.
+#: SHIPPED: ``cron`` for cron jobs, and ``systemd`` for both unit kinds,
+#: which it lumps together.
 #:
 #: This is a FALLBACK, consulted only after the preferred per-kind
-#: surface (``ecosystem service`` / ``ecosystem timer``) is probed for
-#: and found absent. It disappears on its own the moment scitex-dev
-#: ships those groups — no coordinated release, no flag.
+#: surface (``dev service`` / ``dev timer``) is probed for and found
+#: absent. It disappears on its own the moment scitex-dev ships those
+#: groups — no coordinated release, no flag.
 LEGACY_GROUP_FOR_KIND: dict[str, str] = {
     "service": "systemd",
     "timer": "systemd",
     "cron": "cron",
 }
 
+#: The subgroup scitex-dev moved its job CLI under. Probed for, never
+#: assumed: an older scitex-dev mounts the groups at the top level and a
+#: newer one under here, and both must work without a sac release.
+DEV_SUBGROUP = "dev"
+
 #: Verbs the shipped ecosystem surface has always had. Used ONLY when
-#: introspection is impossible, so a working install is never refused
+#: introspection cannot decide, so a working install is never refused
 #: just because we could not read its Click tree.
 SHIPPED_VERBS: frozenset[str] = frozenset({"list", "install", "uninstall"})
+
+#: Verbs that change host state. scitex-dev gates each of these behind
+#: ``--dry-run`` / ``--yes``; sac offers both and forwards them verbatim
+#: rather than deciding on the operator's behalf.
+MUTATING_VERBS: frozenset[str] = frozenset(
+    {"install", "uninstall", "enable", "disable", "start", "stop", "restart"}
+)
 
 # Sentinel distinguishing "not probed yet" from "probed, unavailable".
 _UNPROBED: object = object()
@@ -74,7 +139,12 @@ _VERBS_CACHE: object = _UNPROBED
 
 @dataclass(frozen=True)
 class Delegation:
-    """One resolved ``scitex-dev ecosystem <group> <verb>`` target.
+    """One resolved ``scitex-dev ecosystem <path...> <verb>`` target.
+
+    ``path`` is a TUPLE, not a name, because the ecosystem moved its job
+    groups under ``ecosystem dev`` and may move them again. Storing the
+    resolved path means :func:`invoke` never has to know which level they
+    are mounted at.
 
     ``evidence`` is mandatory and non-empty for the same reason
     ``_jobs_audit.Finding.detail`` is: a verdict that cannot say how it
@@ -82,18 +152,23 @@ class Delegation:
     kind filter for weeks.
     """
 
-    group: str
+    path: tuple[str, ...]
     verb: str
     supported: bool
     evidence: str
 
     def __post_init__(self) -> None:
-        if not self.group or not self.verb:
-            raise ValueError("Delegation needs both a group and a verb")
+        if not self.path or not all(self.path) or not self.verb:
+            raise ValueError("Delegation needs a non-empty path and a verb")
         if not self.evidence:
             raise ValueError(
                 f"Delegation({self.group}/{self.verb}) must state its evidence"
             )
+
+    @property
+    def group(self) -> str:
+        """The path as it is typed: ``"cron"``, ``"dev timer"``, …"""
+        return " ".join(self.path)
 
 
 def reset_capability_cache() -> None:
@@ -102,15 +177,37 @@ def reset_capability_cache() -> None:
     _VERBS_CACHE = _UNPROBED
 
 
+def _child(command, name: str):
+    """Return the named subcommand of ``command``, or None."""
+    getter = getattr(command, "get_command", None)
+    if getter is not None:
+        try:
+            with click.Context(command) as ctx:
+                return getter(ctx, name)
+        except Exception:  # stx-allow: fallback (reason: another package's Group subclass may need a context we cannot build — fall back to the eager dict)
+            pass
+    return (getattr(command, "commands", {}) or {}).get(name)
+
+
 def _leaf_verbs(command) -> frozenset[str]:
     """The subcommand names of one ecosystem group.
 
-    ``Group.list_commands(ctx)`` rather than ``Group.commands``: a LAZY
-    group populates the former and leaves the latter empty, and reading
-    the empty dict is how a fully-featured group is mistaken for one with
-    no verbs. Measured — the same probe reported four cron verbs locally
-    and zero in CI, against the same code, purely because the installed
-    scitex-dev builds its tree lazily there.
+    ``Group.list_commands(ctx)`` rather than ``Group.commands`` so a LAZY
+    group is read correctly — the eager dict can be empty while the group
+    is fully featured.
+
+    Returns an EMPTY set for a node that is a plain ``Command`` (a
+    forwarding shim) rather than a ``Group``. That empty is honest — a
+    shim genuinely has no enumerable verbs — and callers must read it as
+    "cannot tell", never as "serves nothing"; see :func:`resolve`.
+
+    CORRECTION, so the next reader does not inherit a wrong mechanism:
+    an earlier revision claimed laziness EXPLAINED the "four cron verbs
+    locally, zero in CI" split. It did not. Measured afterwards, the real
+    cause was scitex-dev relocating those verbs under ``ecosystem dev``
+    and leaving a deprecated ``Command`` shim behind at the old name.
+    Reading ``list_commands`` is still correct; it was simply not the fix
+    for that symptom — walking into ``dev`` is.
     """
     lister = getattr(command, "list_commands", None)
     if lister is not None:
@@ -122,8 +219,43 @@ def _leaf_verbs(command) -> frozenset[str]:
     return frozenset(getattr(command, "commands", {}) or {})
 
 
-def ecosystem_verbs() -> dict[str, frozenset[str]] | None:
-    """Return ``{ecosystem subcommand: {verbs}}`` for the INSTALLED scitex-dev.
+def _walk(ecosystem) -> dict[tuple[str, ...], frozenset[str]]:
+    """Map ``path under ecosystem -> its verbs``, one level into ``dev``.
+
+    Depth is bounded to the job groups on purpose: enumerating all ~51
+    ecosystem subcommands' children would pay for building trees nobody
+    here consults.
+    """
+    tree: dict[tuple[str, ...], frozenset[str]] = {}
+    for name in sorted(_leaf_verbs(ecosystem)):
+        if name not in _PROBED_GROUPS and name != DEV_SUBGROUP:
+            continue
+        group = _child(ecosystem, name)
+        if group is None:
+            continue
+        tree[(name,)] = _leaf_verbs(group)
+        if name != DEV_SUBGROUP:
+            continue
+        for sub in sorted(tree[(name,)]):
+            if sub not in _PROBED_GROUPS:
+                continue
+            child = _child(group, sub)
+            if child is not None:
+                tree[(name, sub)] = _leaf_verbs(child)
+    return tree
+
+
+#: Group names worth descending into. Everything else under ``ecosystem``
+#: is unrelated to jobs.
+_PROBED_GROUPS: frozenset[str] = frozenset({"service", "timer", "cron", "systemd"})
+
+
+def ecosystem_verbs() -> dict[tuple[str, ...], frozenset[str]] | None:
+    """Return ``{path under `ecosystem` -> verbs}`` for the INSTALLED scitex-dev.
+
+    Keys are PATHS — ``("cron",)``, ``("dev", "timer")`` — because the job
+    groups moved under ``ecosystem dev`` and the old names survive as
+    empty shells. A name-keyed map cannot tell those two apart.
 
     ``None`` when the Click tree cannot be built at all (an old or partial
     scitex-dev). ``None`` means "cannot tell", never "unsupported" — the
@@ -134,7 +266,7 @@ def ecosystem_verbs() -> dict[str, frozenset[str]] | None:
     if _VERBS_CACHE is not _UNPROBED:
         return _VERBS_CACHE  # type: ignore[return-value]
 
-    probed: dict[str, frozenset[str]] | None
+    probed: dict[tuple[str, ...], frozenset[str]] | None
     try:
         from scitex_dev._cli.ecosystem import register_ecosystem_commands
 
@@ -142,8 +274,7 @@ def ecosystem_verbs() -> dict[str, frozenset[str]] | None:
         def _probe_root() -> None:  # pragma: no cover - never invoked
             """Throwaway root; we only want the tree it gets wired onto."""
 
-        group = register_ecosystem_commands(_probe_root)
-        probed = {name: _leaf_verbs(cmd) for name, cmd in group.commands.items()}
+        probed = _walk(register_ecosystem_commands(_probe_root))
     except Exception:  # stx-allow: fallback (reason: introspecting another package's private CLI tree must degrade to "cannot tell", never to a refusal)
         probed = None
 
@@ -151,88 +282,108 @@ def ecosystem_verbs() -> dict[str, frozenset[str]] | None:
     return probed
 
 
+def candidate_paths(kind: str) -> tuple[tuple[str, ...], ...]:
+    """Every ``ecosystem`` path that could serve ``kind``, best first.
+
+    Ordered so the surface the ecosystem is moving TO wins the moment it
+    exists, with no sac release: the per-kind group under ``dev``, then
+    the per-kind group at top level, then the same two for the legacy
+    lump-group.
+    """
+    legacy = LEGACY_GROUP_FOR_KIND.get(kind)
+    paths: list[tuple[str, ...]] = [(DEV_SUBGROUP, kind), (kind,)]
+    if legacy is not None and legacy != kind:
+        paths += [(DEV_SUBGROUP, legacy), (legacy,)]
+    return tuple(paths)
+
+
+def _fallback_path(kind: str, tree: dict | None) -> tuple[str, ...] | None:
+    """The path to ATTEMPT when the probe could not decide.
+
+    Prefers ``dev <legacy>`` whenever a ``dev`` subgroup is known to
+    exist, because that is where the shipped verbs live once the move has
+    happened; otherwise the pre-move top-level name.
+    """
+    legacy = LEGACY_GROUP_FOR_KIND.get(kind)
+    if legacy is None:
+        return None
+    if tree is not None and (DEV_SUBGROUP,) in tree:
+        return (DEV_SUBGROUP, legacy)
+    return (legacy,)
+
+
 def resolve(kind: str, verb: str) -> Delegation:
     """Resolve ``sac dev <kind> <verb>`` onto a scitex-dev ecosystem target.
 
-    Order, preferring the surface the ecosystem is moving TO:
+    Walks :func:`candidate_paths` in order and takes the first path whose
+    verb set CONTAINS ``verb``.
 
-    1. ``ecosystem <kind> <verb>`` — the per-kind groups scitex-dev is
-       growing. Chosen the moment they exist, with no sac release.
-    2. ``ecosystem <legacy> <verb>`` — today's shipped surface.
-    3. unsupported, with the evidence naming both probes.
-
-    THE THIRD STATE IS LOAD-BEARING. If NEITHER candidate group reports a
-    single verb, that is a probe that could not read the tree, not a
-    scitex-dev with no verbs — the shipped surface has had
+    THE THIRD STATE IS LOAD-BEARING. If NO candidate path reports a single
+    verb, that is a probe that could not read the tree, not a scitex-dev
+    with no verbs — the shipped surface has had
     ``list``/``install``/``uninstall`` since 0.16.0, so zero everywhere is
     not a credible reading. Treating it as absence would refuse commands
-    that work, so it degrades to the same "attempt what has shipped" path
-    as a tree that failed to build at all.
-    """
-    verbs = ecosystem_verbs()
-    legacy = LEGACY_GROUP_FOR_KIND.get(kind)
-    kind_verbs = (verbs or {}).get(kind) or frozenset()
-    legacy_verbs = ((verbs or {}).get(legacy) or frozenset()) if legacy else frozenset()
-    unreadable = verbs is None or not (kind_verbs or legacy_verbs)
+    that work, so it degrades to attempting the best-known shipped path.
 
-    if unreadable:
-        if verb in SHIPPED_VERBS and legacy is not None:
+    This is exactly the state ``ecosystem dev`` present with its
+    kind-children ABSENT must land in: an older scitex-dev whose groups
+    have not moved yet reports nothing on ``dev service``/``dev timer``,
+    and refusing there would break a working install.
+    """
+    tree = ecosystem_verbs()
+    paths = candidate_paths(kind)
+    seen = {p: ((tree or {}).get(p) or frozenset()) for p in paths}
+    probed_desc = ", ".join("`ecosystem " + " ".join(p) + f" {verb}`" for p in paths)
+
+    for path in paths:
+        if verb in seen[path]:
             return Delegation(
-                group=legacy,
+                path=path,
                 verb=verb,
                 supported=True,
                 evidence=(
-                    "could not read the installed scitex-dev's ecosystem tree "
-                    f"for kind={kind!r} (neither `ecosystem {kind}` nor "
-                    f"`ecosystem {legacy}` reported a single verb); {verb!r} "
-                    "has shipped on `ecosystem "
-                    f"{legacy}` since 0.16.0, so it is attempted rather than "
-                    "refused"
+                    "`scitex-dev ecosystem " + " ".join(path) + f" {verb}` exists"
+                ),
+            )
+
+    if tree is None or not any(seen.values()):
+        fallback = _fallback_path(kind, tree)
+        if verb in SHIPPED_VERBS and fallback is not None:
+            return Delegation(
+                path=fallback,
+                verb=verb,
+                supported=True,
+                evidence=(
+                    f"could not read any job surface for kind={kind!r} "
+                    f"(none of {probed_desc} reported a verb); {verb!r} has "
+                    "shipped since 0.16.0, so `ecosystem "
+                    + " ".join(fallback)
+                    + f" {verb}` is attempted rather than refused"
                 ),
             )
         return Delegation(
-            group=kind,
+            path=paths[0],
             verb=verb,
             supported=False,
             evidence=(
-                f"could not read `ecosystem {kind} {verb}` nor `ecosystem "
-                f"{legacy} {verb}` from the installed scitex-dev's tree, and "
-                f"{verb!r} is not one of the verbs known to have shipped "
+                f"could not read any job surface for kind={kind!r} (none of "
+                f"{probed_desc} reported a verb), and {verb!r} is not one of "
+                f"the verbs known to have shipped "
                 f"({', '.join(sorted(SHIPPED_VERBS))})"
             ),
         )
 
-    if verb in kind_verbs:
-        return Delegation(
-            group=kind,
-            verb=verb,
-            supported=True,
-            evidence=f"`scitex-dev ecosystem {kind} {verb}` exists",
-        )
-
-    if legacy is not None and verb in legacy_verbs:
-        return Delegation(
-            group=legacy,
-            verb=verb,
-            supported=True,
-            evidence=(
-                f"`scitex-dev ecosystem {kind}` has no {verb!r}; falling back "
-                f"to `ecosystem {legacy} {verb}`, which serves kind={kind!r} "
-                "on the shipped surface"
-            ),
-        )
-
-    have_kind = sorted(kind_verbs)
-    have_legacy = sorted(legacy_verbs)
+    have = "; ".join(
+        "`ecosystem " + " ".join(p) + "` has: " + (str(sorted(seen[p])) or "-")
+        if seen[p]
+        else "`ecosystem " + " ".join(p) + "` absent or empty"
+        for p in paths
+    )
     return Delegation(
-        group=kind,
+        path=paths[0],
         verb=verb,
         supported=False,
-        evidence=(
-            f"the installed scitex-dev serves neither `ecosystem {kind} "
-            f"{verb}` (has: {have_kind or 'no such group'}) nor "
-            f"`ecosystem {legacy} {verb}` (has: {have_legacy or 'no such group'})"
-        ),
+        evidence=(f"the installed scitex-dev serves none of {probed_desc} — {have}"),
     )
 
 
@@ -255,7 +406,40 @@ def manual_hint(kind: str, verb: str, job_name: str) -> str:
     return f"systemctl --user {verb} {unit}"
 
 
-def invoke(delegation: Delegation, *, name: str | None, yes: bool) -> int:
+def build_argv(
+    delegation: Delegation,
+    *,
+    name: str | None,
+    yes: bool,
+    dry_run: bool = False,
+    exe: str = "scitex-dev",
+) -> list[str]:
+    """The exact argv :func:`invoke` will run. Separated so it is testable.
+
+    ``--dry-run`` and ``--yes`` are FORWARDED, never interpreted here.
+    scitex-dev's gate on mutating verbs is what stops ``timer disable
+    sac.accounts-refresh`` from silently stopping the fleet's sole OAuth
+    refresher; a pass-through that dropped either flag would convert a
+    guarded command into an unguarded one, which is strictly worse than
+    not offering the verb.
+    """
+    argv = [exe, "ecosystem", *delegation.path, delegation.verb]
+    if name is not None:
+        argv += ["--name", name]
+    if dry_run:
+        argv.append("--dry-run")
+    if yes:
+        argv.append("--yes")
+    return argv
+
+
+def invoke(
+    delegation: Delegation,
+    *,
+    name: str | None,
+    yes: bool,
+    dry_run: bool = False,
+) -> int:
     """Run the resolved ``scitex-dev ecosystem`` command; return its exit code.
 
     ``scitex-dev`` is a hard dependency of this package, so the console
@@ -270,18 +454,19 @@ def invoke(delegation: Delegation, *, name: str | None, yes: bool) -> int:
             "`scitex-dev` console script not found on PATH; install "
             "scitex-dev to use `sac dev` job verbs"
         )
-    cmd = [exe, "ecosystem", delegation.group, delegation.verb]
-    if name is not None:
-        cmd += ["--name", name]
-    if yes:
-        cmd.append("--yes")
-    return subprocess.call(cmd)
+    return subprocess.call(
+        build_argv(delegation, name=name, yes=yes, dry_run=dry_run, exe=exe)
+    )
 
 
 __all__ = [
+    "DEV_SUBGROUP",
     "Delegation",
     "LEGACY_GROUP_FOR_KIND",
+    "MUTATING_VERBS",
     "SHIPPED_VERBS",
+    "build_argv",
+    "candidate_paths",
     "ecosystem_verbs",
     "invoke",
     "manual_hint",

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
@@ -1,0 +1,258 @@
+"""The delegation seam between ``sac dev <kind> <verb>`` and scitex-dev.
+
+WHY SAC DOES NOT CALL ``systemctl`` ITSELF
+==========================================
+The obvious shortcut for ``sac dev timer enable X`` is to shell
+``systemctl --user enable --now X.timer``. This module deliberately does
+not, and the argument is worth stating because the shortcut looks free:
+
+1. **One owner, or two disagreeing owners.** scitex-dev generates the
+   unit files and is the SSoT for what a job's unit *is*; it explicitly
+   declines to run ``systemctl`` (its ``ecosystem systemd install``
+   prints the enable hint instead). If sac ran ``systemctl`` while
+   scitex-dev owned the file, runtime state and file state would have two
+   owners with no arbiter — the same double-owner shape that made
+   ``restart.policy`` dead code and put two supervisors on ``sac listen``.
+2. **N packages, N copies of the same bug.** The decided grammar is
+   ``scitex-<pkg> dev <kind> <verb>`` for EVERY SciTeX package. A verb
+   implemented in the package rather than in the shared layer is
+   implemented once per package — N copies of the ``--user`` vs
+   ``--system`` split, the unit-name derivation, the XDG_RUNTIME_DIR
+   handling, and the escaping. The aggregator exists precisely to stop
+   that.
+3. **The verb set is not stable yet.** scitex-dev is growing
+   ``ecosystem service`` / ``ecosystem timer`` with these verbs. Anything
+   sac hard-codes now becomes the thing that has to be un-picked later.
+
+So sac RESOLVES a delegation target and shells ``scitex-dev ecosystem
+<group> <verb>``. Where that surface does not exist yet, this module says
+so precisely — naming what it probed and what it found — and prints the
+exact command the operator can run by hand. It never silently substitutes
+a different mechanism, because a verb that quietly does something OTHER
+than what it says is worse than one that is honestly missing.
+
+READ-ONLY IS NOT THE SAME AS OWNING IT
+======================================
+Nothing here mutates host state. The capability probe is an in-process
+introspection of the installed scitex-dev's own Click tree — it answers
+"does this surface exist" from the code that would serve it, not from a
+hard-coded table that would drift the moment scitex-dev ships the verbs.
+That is the same doctrine ``_jobs_audit`` follows: read the real thing.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+import click
+
+#: The ecosystem subcommand that serves a kind on the surface that has
+#: SHIPPED (``scitex-dev`` <= 0.43.x): ``cron`` for cron jobs, and
+#: ``systemd`` for both unit kinds, which it lumps together.
+#:
+#: This is a FALLBACK, consulted only after the preferred per-kind
+#: surface (``ecosystem service`` / ``ecosystem timer``) is probed for
+#: and found absent. It disappears on its own the moment scitex-dev
+#: ships those groups — no coordinated release, no flag.
+LEGACY_GROUP_FOR_KIND: dict[str, str] = {
+    "service": "systemd",
+    "timer": "systemd",
+    "cron": "cron",
+}
+
+#: Verbs the shipped ecosystem surface has always had. Used ONLY when
+#: introspection is impossible, so a working install is never refused
+#: just because we could not read its Click tree.
+SHIPPED_VERBS: frozenset[str] = frozenset({"list", "install", "uninstall"})
+
+# Sentinel distinguishing "not probed yet" from "probed, unavailable".
+_UNPROBED: object = object()
+_VERBS_CACHE: object = _UNPROBED
+
+
+@dataclass(frozen=True)
+class Delegation:
+    """One resolved ``scitex-dev ecosystem <group> <verb>`` target.
+
+    ``evidence`` is mandatory and non-empty for the same reason
+    ``_jobs_audit.Finding.detail`` is: a verdict that cannot say how it
+    was reached is a claim, and a claim is what put a group name in a
+    kind filter for weeks.
+    """
+
+    group: str
+    verb: str
+    supported: bool
+    evidence: str
+
+    def __post_init__(self) -> None:
+        if not self.group or not self.verb:
+            raise ValueError("Delegation needs both a group and a verb")
+        if not self.evidence:
+            raise ValueError(
+                f"Delegation({self.group}/{self.verb}) must state its evidence"
+            )
+
+
+def reset_capability_cache() -> None:
+    """Forget the probed surface. For tests that install a different one."""
+    global _VERBS_CACHE
+    _VERBS_CACHE = _UNPROBED
+
+
+def ecosystem_verbs() -> dict[str, frozenset[str]] | None:
+    """Return ``{ecosystem subcommand: {verbs}}`` for the INSTALLED scitex-dev.
+
+    ``None`` when the Click tree cannot be built at all (an old or partial
+    scitex-dev). ``None`` means "cannot tell", never "unsupported" — the
+    three-state discipline from ``_jobs_audit``: a false "unsupported"
+    here refuses a command that would have worked.
+    """
+    global _VERBS_CACHE
+    if _VERBS_CACHE is not _UNPROBED:
+        return _VERBS_CACHE  # type: ignore[return-value]
+
+    probed: dict[str, frozenset[str]] | None
+    try:
+        from scitex_dev._cli.ecosystem import register_ecosystem_commands
+
+        @click.group()
+        def _probe_root() -> None:  # pragma: no cover - never invoked
+            """Throwaway root; we only want the tree it gets wired onto."""
+
+        group = register_ecosystem_commands(_probe_root)
+        probed = {
+            name: frozenset(getattr(cmd, "commands", {}) or {})
+            for name, cmd in group.commands.items()
+        }
+    except Exception:  # stx-allow: fallback (reason: introspecting another package's private CLI tree must degrade to "cannot tell", never to a refusal)
+        probed = None
+
+    _VERBS_CACHE = probed
+    return probed
+
+
+def resolve(kind: str, verb: str) -> Delegation:
+    """Resolve ``sac dev <kind> <verb>`` onto a scitex-dev ecosystem target.
+
+    Order, preferring the surface the ecosystem is moving TO:
+
+    1. ``ecosystem <kind> <verb>`` — the per-kind groups scitex-dev is
+       growing. Chosen the moment they exist, with no sac release.
+    2. ``ecosystem <legacy> <verb>`` — today's shipped surface.
+    3. unsupported, with the evidence naming both probes.
+    """
+    verbs = ecosystem_verbs()
+    legacy = LEGACY_GROUP_FOR_KIND.get(kind)
+
+    if verbs is None:
+        if verb in SHIPPED_VERBS and legacy is not None:
+            return Delegation(
+                group=legacy,
+                verb=verb,
+                supported=True,
+                evidence=(
+                    "could not introspect the installed scitex-dev's ecosystem "
+                    f"tree; {verb!r} has shipped on `ecosystem {legacy}` since "
+                    "0.16.0, so it is attempted rather than refused"
+                ),
+            )
+        return Delegation(
+            group=kind,
+            verb=verb,
+            supported=False,
+            evidence=(
+                "could not introspect the installed scitex-dev's ecosystem "
+                f"tree, and {verb!r} is not one of the verbs known to have "
+                f"shipped ({', '.join(sorted(SHIPPED_VERBS))})"
+            ),
+        )
+
+    if verb in verbs.get(kind, frozenset()):
+        return Delegation(
+            group=kind,
+            verb=verb,
+            supported=True,
+            evidence=f"`scitex-dev ecosystem {kind} {verb}` exists",
+        )
+
+    if legacy is not None and verb in verbs.get(legacy, frozenset()):
+        return Delegation(
+            group=legacy,
+            verb=verb,
+            supported=True,
+            evidence=(
+                f"`scitex-dev ecosystem {kind}` has no {verb!r}; falling back "
+                f"to `ecosystem {legacy} {verb}`, which serves kind={kind!r} "
+                "on the shipped surface"
+            ),
+        )
+
+    have_kind = sorted(verbs.get(kind, frozenset()))
+    have_legacy = sorted(verbs.get(legacy, frozenset())) if legacy else []
+    return Delegation(
+        group=kind,
+        verb=verb,
+        supported=False,
+        evidence=(
+            f"the installed scitex-dev serves neither `ecosystem {kind} "
+            f"{verb}` (has: {have_kind or 'no such group'}) nor "
+            f"`ecosystem {legacy} {verb}` (has: {have_legacy or 'no such group'})"
+        ),
+    )
+
+
+def manual_hint(kind: str, verb: str, job_name: str) -> str:
+    """The command the operator can run by hand while the verb is missing.
+
+    Reporting a command is not running it. The unit name mirrors
+    scitex-dev's renderer, which derives the filename from
+    ``JobSpec.name`` verbatim.
+    """
+    if kind == "cron":
+        return "crontab -e   # scitex-dev owns the generated block"
+    unit = f"{job_name}.timer" if kind == "timer" else f"{job_name}.service"
+    if verb == "status":
+        return f"systemctl --user status {unit}"
+    if verb == "enable":
+        return f"systemctl --user enable --now {unit}"
+    if verb == "disable":
+        return f"systemctl --user disable --now {unit}"
+    return f"systemctl --user {verb} {unit}"
+
+
+def invoke(delegation: Delegation, *, name: str | None, yes: bool) -> int:
+    """Run the resolved ``scitex-dev ecosystem`` command; return its exit code.
+
+    ``scitex-dev`` is a hard dependency of this package, so the console
+    script is expected on PATH; a missing binary is a clean
+    ClickException rather than a stack trace.
+    """
+    if not delegation.supported:
+        raise ValueError("refusing to invoke an unsupported delegation")
+    exe = shutil.which("scitex-dev")
+    if exe is None:
+        raise click.ClickException(
+            "`scitex-dev` console script not found on PATH; install "
+            "scitex-dev to use `sac dev` job verbs"
+        )
+    cmd = [exe, "ecosystem", delegation.group, delegation.verb]
+    if name is not None:
+        cmd += ["--name", name]
+    if yes:
+        cmd.append("--yes")
+    return subprocess.call(cmd)
+
+
+__all__ = [
+    "Delegation",
+    "LEGACY_GROUP_FOR_KIND",
+    "SHIPPED_VERBS",
+    "ecosystem_verbs",
+    "invoke",
+    "manual_hint",
+    "reset_capability_cache",
+    "resolve",
+]

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_backend.py
@@ -102,6 +102,26 @@ def reset_capability_cache() -> None:
     _VERBS_CACHE = _UNPROBED
 
 
+def _leaf_verbs(command) -> frozenset[str]:
+    """The subcommand names of one ecosystem group.
+
+    ``Group.list_commands(ctx)`` rather than ``Group.commands``: a LAZY
+    group populates the former and leaves the latter empty, and reading
+    the empty dict is how a fully-featured group is mistaken for one with
+    no verbs. Measured — the same probe reported four cron verbs locally
+    and zero in CI, against the same code, purely because the installed
+    scitex-dev builds its tree lazily there.
+    """
+    lister = getattr(command, "list_commands", None)
+    if lister is not None:
+        try:
+            with click.Context(command) as ctx:
+                return frozenset(lister(ctx))
+        except Exception:  # stx-allow: fallback (reason: another package's Group subclass may need a context we cannot build — fall back to the eager dict)
+            pass
+    return frozenset(getattr(command, "commands", {}) or {})
+
+
 def ecosystem_verbs() -> dict[str, frozenset[str]] | None:
     """Return ``{ecosystem subcommand: {verbs}}`` for the INSTALLED scitex-dev.
 
@@ -123,10 +143,7 @@ def ecosystem_verbs() -> dict[str, frozenset[str]] | None:
             """Throwaway root; we only want the tree it gets wired onto."""
 
         group = register_ecosystem_commands(_probe_root)
-        probed = {
-            name: frozenset(getattr(cmd, "commands", {}) or {})
-            for name, cmd in group.commands.items()
-        }
+        probed = {name: _leaf_verbs(cmd) for name, cmd in group.commands.items()}
     except Exception:  # stx-allow: fallback (reason: introspecting another package's private CLI tree must degrade to "cannot tell", never to a refusal)
         probed = None
 
@@ -143,20 +160,34 @@ def resolve(kind: str, verb: str) -> Delegation:
        growing. Chosen the moment they exist, with no sac release.
     2. ``ecosystem <legacy> <verb>`` — today's shipped surface.
     3. unsupported, with the evidence naming both probes.
+
+    THE THIRD STATE IS LOAD-BEARING. If NEITHER candidate group reports a
+    single verb, that is a probe that could not read the tree, not a
+    scitex-dev with no verbs — the shipped surface has had
+    ``list``/``install``/``uninstall`` since 0.16.0, so zero everywhere is
+    not a credible reading. Treating it as absence would refuse commands
+    that work, so it degrades to the same "attempt what has shipped" path
+    as a tree that failed to build at all.
     """
     verbs = ecosystem_verbs()
     legacy = LEGACY_GROUP_FOR_KIND.get(kind)
+    kind_verbs = (verbs or {}).get(kind) or frozenset()
+    legacy_verbs = ((verbs or {}).get(legacy) or frozenset()) if legacy else frozenset()
+    unreadable = verbs is None or not (kind_verbs or legacy_verbs)
 
-    if verbs is None:
+    if unreadable:
         if verb in SHIPPED_VERBS and legacy is not None:
             return Delegation(
                 group=legacy,
                 verb=verb,
                 supported=True,
                 evidence=(
-                    "could not introspect the installed scitex-dev's ecosystem "
-                    f"tree; {verb!r} has shipped on `ecosystem {legacy}` since "
-                    "0.16.0, so it is attempted rather than refused"
+                    "could not read the installed scitex-dev's ecosystem tree "
+                    f"for kind={kind!r} (neither `ecosystem {kind}` nor "
+                    f"`ecosystem {legacy}` reported a single verb); {verb!r} "
+                    "has shipped on `ecosystem "
+                    f"{legacy}` since 0.16.0, so it is attempted rather than "
+                    "refused"
                 ),
             )
         return Delegation(
@@ -164,13 +195,14 @@ def resolve(kind: str, verb: str) -> Delegation:
             verb=verb,
             supported=False,
             evidence=(
-                "could not introspect the installed scitex-dev's ecosystem "
-                f"tree, and {verb!r} is not one of the verbs known to have "
-                f"shipped ({', '.join(sorted(SHIPPED_VERBS))})"
+                f"could not read `ecosystem {kind} {verb}` nor `ecosystem "
+                f"{legacy} {verb}` from the installed scitex-dev's tree, and "
+                f"{verb!r} is not one of the verbs known to have shipped "
+                f"({', '.join(sorted(SHIPPED_VERBS))})"
             ),
         )
 
-    if verb in verbs.get(kind, frozenset()):
+    if verb in kind_verbs:
         return Delegation(
             group=kind,
             verb=verb,
@@ -178,7 +210,7 @@ def resolve(kind: str, verb: str) -> Delegation:
             evidence=f"`scitex-dev ecosystem {kind} {verb}` exists",
         )
 
-    if legacy is not None and verb in verbs.get(legacy, frozenset()):
+    if legacy is not None and verb in legacy_verbs:
         return Delegation(
             group=legacy,
             verb=verb,
@@ -190,8 +222,8 @@ def resolve(kind: str, verb: str) -> Delegation:
             ),
         )
 
-    have_kind = sorted(verbs.get(kind, frozenset()))
-    have_legacy = sorted(verbs.get(legacy, frozenset())) if legacy else []
+    have_kind = sorted(kind_verbs)
+    have_legacy = sorted(legacy_verbs)
     return Delegation(
         group=kind,
         verb=verb,

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -27,6 +27,7 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_container",
     "scitex_dev",
     "scitex_dev._cli._completion",
+    "scitex_dev._cli.ecosystem",
     "scitex_dev.hosts",
     "scitex_dev.jobs",
     "scitex_dev.linter._rules._base",

--- a/tests/scitex_agent_container/_jobs/test__jobs_audit.py
+++ b/tests/scitex_agent_container/_jobs/test__jobs_audit.py
@@ -31,9 +31,13 @@ from scitex_agent_container._jobs._jobs_audit import (  # noqa: E402
     Verdict,
     audit_consumers,
     audit_discovery,
+    audit_group_naming,
     audit_jobs,
 )
-from scitex_agent_container.cli_pkg._dev_jobs import GROUP_KINDS  # noqa: E402
+from scitex_agent_container.cli_pkg._dev_jobs import (  # noqa: E402
+    DEPRECATED_GROUPS,
+    GROUP_KINDS,
+)
 
 # The mapping the CLI ACTUALLY used before this was fixed: ``_load_sac_jobs``
 # was called with the GROUP NAME, so each group filtered on a kind literally
@@ -163,6 +167,102 @@ def test_consumer_group_kinds_are_all_legal_kinds() -> None:
         covered |= kinds
     # Assert
     assert covered <= jobs_mod.ALLOWED_KINDS
+
+
+# ---------------------------------------------------------------------------
+# Form GROUP_IS_NOT_ITS_KIND — the grammar itself, machine-checked
+# ---------------------------------------------------------------------------
+
+
+def test_no_live_group_name_is_anything_other_than_its_kind() -> None:
+    # Arrange — the ecosystem grammar is `dev <kind> <verb>`. Enforcing
+    # the identity is what makes the original outage unrepresentable
+    # rather than merely fixed.
+    # Act
+    report = audit_jobs()
+    # Assert
+    assert not [f for f in report.inert if f.form is Form.GROUP_IS_NOT_ITS_KIND], (
+        report.render()
+    )
+
+
+def test_detector_fires_when_a_group_is_named_after_a_mechanism() -> None:
+    # Arrange — the pre-decision shape: `systemd` is a delivery
+    # mechanism, not a kind, and it was NOT declared a deprecated alias.
+    # Act
+    findings = audit_group_naming(
+        group_kinds={"cron": frozenset({"cron"}), "systemd": frozenset({"timer"})},
+        allowed_kinds=frozenset(jobs_mod.ALLOWED_KINDS),
+        deprecated=frozenset(),
+    )
+    # Assert
+    assert [f.subject for f in findings] == ["sac dev systemd"]
+
+
+def test_detector_fires_when_a_kind_group_filters_on_another_kind() -> None:
+    # Arrange — a group that means its own name is the entire invariant;
+    # `timer` listing services would silently widen the filter.
+    # Act
+    findings = audit_group_naming(
+        group_kinds={"timer": frozenset({"timer", "service"})},
+        allowed_kinds=frozenset(jobs_mod.ALLOWED_KINDS),
+        deprecated=frozenset(),
+    )
+    # Assert
+    assert findings[0].form is Form.GROUP_IS_NOT_ITS_KIND
+
+
+def test_a_declared_alias_is_exempt_from_the_naming_rule() -> None:
+    # Arrange — the alias exists precisely to break the rule for
+    # compatibility, and it carries a removal date for it.
+    # Act
+    findings = audit_group_naming(
+        group_kinds={
+            "timer": frozenset({"timer"}),
+            "service": frozenset({"service"}),
+            "systemd": frozenset({"timer", "service"}),
+        },
+        allowed_kinds=frozenset(jobs_mod.ALLOWED_KINDS),
+        deprecated=frozenset({"systemd"}),
+    )
+    # Assert
+    assert findings == ()
+
+
+def test_a_kind_reachable_only_through_an_alias_reads_inert() -> None:
+    # Arrange — such a kind has a SCHEDULED loss of its CLI: the alias's
+    # removal date deletes the only way to reach it.
+    # Act
+    findings = audit_group_naming(
+        group_kinds={
+            "timer": frozenset({"timer"}),
+            "systemd": frozenset({"timer", "service"}),
+        },
+        allowed_kinds=frozenset(jobs_mod.ALLOWED_KINDS),
+        deprecated=frozenset({"systemd"}),
+    )
+    # Assert
+    assert [f.subject for f in findings] == ["kind=service"]
+
+
+def test_no_real_kind_is_reachable_only_through_the_alias() -> None:
+    # Arrange — against the REAL production mapping.
+    # Act
+    report = audit_jobs()
+    # Assert
+    assert not [f for f in report.inert if f.form is Form.ALIAS_ONLY_KIND], (
+        report.render()
+    )
+
+
+def test_every_deprecated_group_is_a_real_group() -> None:
+    # Arrange — a deprecation notice for a group that does not exist is
+    # itself a declaration with no live counterpart.
+    declared = set(DEPRECATED_GROUPS)
+    # Act
+    orphans = declared - set(GROUP_KINDS)
+    # Assert
+    assert orphans == set()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_jobs/test__names.py
+++ b/tests/scitex_agent_container/_jobs/test__names.py
@@ -1,0 +1,127 @@
+"""Tests for the job-name grammar (local short name vs canonical id).
+
+The canonical name is not cosmetic: ``scitex_dev.jobs`` de-duplicates on
+it and the systemd renderer derives the UNIT FILENAME from it verbatim.
+So a resolver that silently double-prefixes, or that quietly returns
+nothing for a typo, changes which unit a verb acts on — which is how a
+scheduled job stops being scheduled while every command still exits 0.
+
+No mocks (PA-306): these are pure functions over plain strings.
+AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._jobs import _names
+from scitex_agent_container._jobs._jobs_plugin import provide_jobs
+
+
+def test_a_local_name_becomes_canonical() -> None:
+    # Arrange
+    typed = "accounts-refresh"
+    # Act
+    got = _names.canonical(typed)
+    # Assert
+    assert got == "sac.accounts-refresh"
+
+
+def test_canonicalising_is_idempotent() -> None:
+    # Arrange — a name copied out of --json output or a unit filename
+    # must resolve to itself, not to `sac.sac.accounts-refresh`.
+    typed = "sac.accounts-refresh"
+    # Act
+    got = _names.canonical(typed)
+    # Assert
+    assert got == "sac.accounts-refresh"
+
+
+def test_an_empty_name_is_rejected() -> None:
+    # Arrange — an empty name would canonicalise to the bare prefix and
+    # match nothing, silently.
+    typed = ""
+
+    # Act
+    def _call():
+        return _names.canonical(typed)
+
+    # Assert
+    with pytest.raises(ValueError):
+        _call()
+
+
+def test_local_strips_the_prefix() -> None:
+    # Arrange
+    canonical = "sac.worktree-gc"
+    # Act
+    got = _names.local(canonical)
+    # Assert
+    assert got == "worktree-gc"
+
+
+def test_local_leaves_a_foreign_name_alone() -> None:
+    # Arrange — another package's job must not be mangled into looking
+    # like one of ours.
+    foreign = "scitex-todo.dashboard"
+    # Act
+    got = _names.local(foreign)
+    # Assert
+    assert got == foreign
+
+
+def test_is_ours_rejects_a_foreign_job() -> None:
+    # Arrange — this predicate is the filter that keeps `sac dev … list`
+    # from claiming other packages' jobs.
+    foreign = "scitex-todo.dashboard"
+    # Act
+    got = _names.is_ours(foreign)
+    # Assert
+    assert got is False
+
+
+def test_resolve_finds_a_real_declared_job_by_local_name() -> None:
+    # Arrange — against the REAL declarations, not a hand-picked list.
+    declared = [j.name for j in provide_jobs()]
+    # Act
+    got = _names.resolve("accounts-refresh", declared)
+    # Assert
+    assert got == "sac.accounts-refresh"
+
+
+def test_resolve_raises_on_an_unknown_name() -> None:
+    # Arrange
+    declared = ["sac.accounts-refresh"]
+
+    # Act
+    def _call():
+        return _names.resolve("typo", declared)
+
+    # Assert
+    with pytest.raises(KeyError):
+        _call()
+
+
+def test_the_unknown_name_error_lists_what_is_available() -> None:
+    # Arrange — an error that does not say what WOULD have worked makes
+    # the operator go read the source.
+    declared = ["sac.accounts-refresh"]
+    # Act
+    try:
+        _names.resolve("typo", declared)
+        message = ""
+    except KeyError as exc:
+        message = str(exc.args[0])
+    # Assert
+    assert "accounts-refresh" in message
+
+
+def test_every_declared_job_uses_the_declared_prefix() -> None:
+    # Arrange — the prefix constant is the seam for the ecosystem rename;
+    # a job that does not use it would be missed by that rename AND by
+    # every `sac dev` verb's ownership filter.
+    declared = [j.name for j in provide_jobs()]
+    # Act
+    strays = [n for n in declared if not _names.is_ours(n)]
+    # Assert
+    assert strays == []

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
@@ -420,6 +420,17 @@ def test_declared_verbs_are_the_verbs_actually_wired() -> None:
     assert wired == expected
 
 
+def test_every_declared_verb_has_a_help_summary() -> None:
+    # Arrange — the summary map is consulted at IMPORT time while the
+    # groups are built, so a verb added without one does not fail its own
+    # command: it raises KeyError and takes the entire `sac` CLI down.
+    declared = {v for verbs in GROUP_VERBS.values() for v in verbs if v != "list"}
+    # Act
+    missing = declared - set(dj._VERB_SUMMARY)
+    # Assert
+    assert missing == set()
+
+
 def test_service_has_the_full_lifecycle() -> None:
     # Arrange — a service is a long-running unit.
     expected = {

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
@@ -60,6 +60,7 @@ import scitex_agent_container  # noqa: E402
 import scitex_agent_container.cli_pkg._dev_jobs as dj  # noqa: E402
 from scitex_agent_container._jobs import _names  # noqa: E402
 from scitex_agent_container._jobs._jobs_plugin import provide_jobs  # noqa: E402
+from scitex_agent_container.cli_pkg import _dev_jobs_backend as _backend  # noqa: E402
 from scitex_agent_container.cli_pkg._dev_jobs import (  # noqa: E402
     DEPRECATED_GROUPS,
     GROUP_KINDS,
@@ -431,16 +432,17 @@ def test_every_declared_verb_has_a_help_summary() -> None:
     assert missing == set()
 
 
-def test_service_has_the_full_lifecycle() -> None:
-    # Arrange — a service is a long-running unit.
+def test_service_has_the_runtime_lifecycle() -> None:
+    # Arrange — a service is a long-running unit. MATCHED to scitex-dev
+    # PR #566's service verb set: no enable/disable, because the shared
+    # layer does not serve them and a verb sac exposes that nothing can
+    # serve is a permanent exit-4.
     expected = {
         "list",
         "status",
         "start",
         "stop",
         "restart",
-        "enable",
-        "disable",
         "install",
         "uninstall",
     }
@@ -448,6 +450,32 @@ def test_service_has_the_full_lifecycle() -> None:
     verbs = _verbs_of("service")
     # Assert
     assert verbs == expected
+
+
+def test_no_verb_is_exposed_that_the_counterpart_will_not_serve() -> None:
+    # Arrange — scitex-dev PR #566's verb sets, transcribed. Divergence
+    # here is a declaration with no live counterpart in the making, so it
+    # is pinned rather than trusted to review.
+    counterpart = {
+        "service": {
+            "list",
+            "status",
+            "start",
+            "stop",
+            "restart",
+            "install",
+            "uninstall",
+        },
+        "timer": {"list", "status", "enable", "disable", "install", "uninstall"},
+        # `exec` is deliberately NOT mirrored: sac declares no cron job,
+        # and its argv is positional (`exec <name> --apply`) rather than
+        # the uniform `--name` every other verb takes.
+        "cron": {"list", "enable", "disable", "install", "uninstall", "exec"},
+    }
+    # Act
+    extra = {g: set(GROUP_VERBS[g]) - counterpart[g] for g in counterpart}
+    # Assert
+    assert extra == {"service": set(), "timer": set(), "cron": set()}
 
 
 def test_timer_has_no_start_verb() -> None:
@@ -528,6 +556,59 @@ def test_install_accepts_the_canonical_name_too() -> None:
     assert [a[2] for a in captured] == ["sac.accounts-refresh"]
 
 
+def test_install_forwards_dry_run_to_the_delegation() -> None:
+    # Arrange — scitex-dev gates mutating job verbs behind --dry-run /
+    # --yes, and that gate is load-bearing. If sac's pass-through drops a
+    # flag, a guarded command silently becomes an unguarded one.
+    with _captured_delegations() as captured:
+        runner = CliRunner()
+        # Act
+        runner.invoke(dev_group, ["timer", "install", "accounts-refresh", "--dry-run"])
+    # Assert — (kind, verb, name, yes, dry_run)
+    assert [a[4] for a in captured] == [True]
+
+
+def test_install_forwards_yes_to_the_delegation() -> None:
+    # Arrange
+    with _captured_delegations() as captured:
+        runner = CliRunner()
+        # Act
+        runner.invoke(dev_group, ["timer", "install", "accounts-refresh", "-y"])
+    # Assert
+    assert [a[3] for a in captured] == [True]
+
+
+def test_a_named_mutating_verb_offers_dry_run() -> None:
+    # Arrange — `timer disable sac.accounts-refresh` stops the fleet's
+    # SOLE OAuth refresher, so previewing it must be possible from sac's
+    # own CLI rather than only from scitex-dev's.
+    disable = dev_group.commands["timer"].commands["disable"]  # type: ignore[attr-defined]
+    # Act
+    flags = {opt for p in disable.params for opt in p.opts}
+    # Assert
+    assert {"--dry-run", "--yes"} <= flags
+
+
+def test_every_mutating_verb_offers_the_gate_flags() -> None:
+    # Arrange — one missing flag is one command that cannot be previewed.
+    wanted = {"--dry-run", "--yes"}
+    mutating = [
+        (g, v)
+        for g, verbs in GROUP_VERBS.items()
+        for v in verbs
+        if v in _backend.MUTATING_VERBS
+    ]
+    # Act
+    missing = {}
+    for group, verb in mutating:
+        cmd = dev_group.commands[group].commands[verb]  # type: ignore[attr-defined]
+        gap = wanted - {opt for p in cmd.params for opt in p.opts}
+        if gap:
+            missing[f"{group} {verb}"] = sorted(gap)
+    # Assert
+    assert missing == {}
+
+
 def test_an_unknown_job_name_exits_five() -> None:
     # Arrange — a verb that silently does nothing for a typo is how a job
     # quietly stops being scheduled.
@@ -569,7 +650,7 @@ def test_an_unsupported_verb_states_what_it_probed() -> None:
     # Act
     result = runner.invoke(dev_group, ["timer", "status", "accounts-refresh"])
     # Assert
-    assert "ecosystem timer status" in result.stderr
+    assert "ecosystem dev timer status" in result.stderr
 
 
 def test_an_unsupported_verb_offers_the_manual_command() -> None:

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
@@ -1,36 +1,51 @@
-"""Tests for ``sac dev {cron,systemd}`` federated-job commands.
+"""Tests for ``sac dev {service,timer,cron}`` — the kind-named job grammar.
 
-WHY THIS FILE WAS REWRITTEN — it is the fixture that hid the bug.
+WHY THIS FILE KEEPS ITS OWN POSTMORTEM
 
-It used to install a hand-rolled fake ``scitex_dev.jobs`` module into
-``sys.modules``, whose ``_Job`` dataclass defaulted to ``kind="systemd"``.
-No real JobSpec can have that kind: ``ALLOWED_KINDS`` is
-``{service,timer,cron}`` and ``JobSpec.validate()`` raises on anything
+An earlier version installed a hand-rolled fake ``scitex_dev.jobs`` module
+into ``sys.modules`` whose ``_Job`` dataclass defaulted to
+``kind="systemd"``. No real JobSpec can have that kind: ``ALLOWED_KINDS``
+is ``{service,timer,cron}`` and ``JobSpec.validate()`` raises on anything
 else at construction. So the suite asserted, in green, that ``sac dev
 systemd list`` shows ``sac.accounts-refresh`` — while in production that
 command printed "No sac systemd-kind jobs." and exited 0, because the
-group name was being passed straight through as the kind filter and all
-four of sac's real timers are ``kind="timer"``.
+group name was passed straight through as the kind filter and every sac
+timer is ``kind="timer"``.
 
 A fake whose shape no real object can have does not test the production
-path; it tests the fake. That is the same failure as the twin-spawning
-suite (29 green tests over a ``spec.env`` shape v3 validation rejects) and
-it is why these tests now drive the REAL ``scitex_dev.jobs`` with REAL
-``JobSpec`` objects. If the contract is not installed, the file skips —
-it does not invent a stand-in.
+path; it tests the fake. These tests therefore drive the REAL
+``scitex_dev.jobs`` with REAL ``JobSpec`` objects. If the contract is not
+installed, the file skips — it does not invent a stand-in.
 
-No mocks (PA-306). The one seam still injected is ``_ecosystem_delegate``,
-which would otherwise shell out to a real ``scitex-dev`` subprocess and
-mutate the host's crontab/units; the delegation ARGUMENTS are the thing
-under test there, and they are captured, not faked.
+TWO STREAMS, AND THE TRAP BETWEEN THEM
+
+click 8.4's ``Result.output`` is stdout **and stderr merged**;
+``Result.stdout`` is stdout alone. Two tests here used to parse
+``result.output`` as JSON, which is not the contract: it passed only
+while nothing else wrote to stderr, and went red the moment a THIRD-PARTY
+jobs provider failed to load and ``scitex_dev.jobs`` logged a warning —
+correctly, on stderr. The real ``sac dev … --json`` stdout was clean the
+whole time. Every JSON assertion below reads ``result.stdout``, and one
+test proves the contract end-to-end in a REAL SUBPROCESS where the two
+streams are genuinely separate files.
+
+No mocks (PA-306). The one seam injected is ``_dev_jobs._delegate``,
+which would otherwise shell out to a real ``scitex-dev`` and rewrite the
+host's units and crontab; the delegation ARGUMENTS are what those tests
+are about, and they are captured, not faked.
 
 AAA marker comments; one assertion per test.
 """
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
 import sys
 from contextlib import contextmanager
+from datetime import date
+from pathlib import Path
 from typing import Iterator
 
 import pytest
@@ -41,8 +56,22 @@ jobs_mod = pytest.importorskip(
     reason="installed scitex-dev predates the scitex_dev.jobs contract",
 )
 
-from scitex_agent_container.cli_pkg._dev_jobs import GROUP_KINDS  # noqa: E402
+import scitex_agent_container  # noqa: E402
+import scitex_agent_container.cli_pkg._dev_jobs as dj  # noqa: E402
+from scitex_agent_container._jobs import _names  # noqa: E402
+from scitex_agent_container._jobs._jobs_plugin import provide_jobs  # noqa: E402
+from scitex_agent_container.cli_pkg._dev_jobs import (  # noqa: E402
+    DEPRECATED_GROUPS,
+    GROUP_KINDS,
+    GROUP_VERBS,
+    Deprecation,
+)
 from scitex_agent_container.cli_pkg.dev_group import dev_group  # noqa: E402
+
+
+def _declared(kind: str) -> list[str]:
+    """Canonical names of the jobs sac really declares for ``kind``."""
+    return [j.name for j in provide_jobs() if j.kind == kind]
 
 
 @contextmanager
@@ -59,65 +88,128 @@ def _jobs_absent() -> Iterator[None]:
             sys.modules["scitex_dev.jobs"] = saved
 
 
+@contextmanager
+def _captured_delegations() -> Iterator[list[tuple]]:
+    """Capture ``(kind, verb, name, yes)`` instead of shelling scitex-dev."""
+    captured: list[tuple] = []
+    original = dj._delegate
+    dj._delegate = lambda *a, **k: captured.append(a) or 0  # type: ignore[assignment]
+    try:
+        yield captured
+    finally:
+        dj._delegate = original  # type: ignore[assignment]
+
+
 # ---------------------------------------------------------------------------
-# list — against the REAL provider and the REAL taxonomy
+# the grammar: group name IS the kind
 # ---------------------------------------------------------------------------
 
 
-def test_systemd_list_shows_sacs_real_timers() -> None:
-    # Arrange — the regression that matters: sac's four jobs are all
-    # kind="timer", and `ecosystem systemd` selects timer+service. This
-    # command listed NOTHING for weeks while the old fake made it green.
+def test_there_is_a_group_per_jobspec_kind() -> None:
+    # Arrange — the decided grammar: `dev {service,timer,cron} <verb>`.
+    expected = set(jobs_mod.ALLOWED_KINDS)
+    # Act
+    present = {k for k in expected if k in dev_group.commands}
+    # Assert
+    assert present == expected
+
+
+def test_every_kind_group_filters_on_exactly_its_own_name() -> None:
+    # Arrange — the identity that makes the historical bug unrepresentable.
+    kinds = set(jobs_mod.ALLOWED_KINDS)
+    # Act
+    mismatched = {g for g in kinds if GROUP_KINDS[g] != frozenset({g})}
+    # Assert
+    assert mismatched == set()
+
+
+def test_job_groups_are_exactly_the_group_kinds_ssot() -> None:
+    # Arrange — the CLI surface is derived from GROUP_KINDS, so a group can
+    # never exist without a declared kind filter behind it.
+    expected = set(GROUP_KINDS)
+    # Act
+    present = {g for g in expected if g in dev_group.commands}
+    # Assert
+    assert present == expected
+
+
+def test_there_is_no_daemon_group() -> None:
+    # Arrange — `sac dev daemon` was dead in BOTH halves: it filtered
+    # kind="daemon" (never legal, so always zero jobs) AND delegated to
+    # `scitex-dev ecosystem daemon`, which is not an ecosystem subcommand
+    # at all. A long-running job is kind="service".
+    groups = dev_group.commands
+    # Act
+    present = "daemon" in groups
+    # Assert
+    assert present is False
+
+
+# ---------------------------------------------------------------------------
+# list — NON-EMPTY against the real provider. Zero jobs was the bug.
+# ---------------------------------------------------------------------------
+
+
+def test_timer_list_is_not_empty() -> None:
+    # Arrange — the regression that matters. A group that can only ever
+    # return zero jobs is exactly what shipped for weeks, reporting
+    # "No sac systemd-kind jobs." with exit 0.
     runner = CliRunner()
     # Act
-    result = runner.invoke(dev_group, ["systemd", "list"])
+    result = runner.invoke(dev_group, ["timer", "list"])
     # Assert
-    assert "sac.accounts-refresh" in result.output
+    assert "No sac timer jobs." not in result.stdout
 
 
-def test_systemd_list_shows_every_declared_sac_job() -> None:
-    # Arrange — all four, not just the one a pinning test happens to name.
-    from scitex_agent_container._jobs._jobs_plugin import provide_jobs
-
-    expected = [j.name for j in provide_jobs() if j.kind in GROUP_KINDS["systemd"]]
+def test_timer_list_shows_every_declared_timer() -> None:
+    # Arrange — all of them, not just the one a pinning test happens to
+    # name. sac declares nine timers today.
+    expected = [_names.local(n) for n in _declared("timer")]
     runner = CliRunner()
     # Act
-    result = runner.invoke(dev_group, ["systemd", "list"])
+    result = runner.invoke(dev_group, ["timer", "list"])
     # Assert
-    assert all(name in result.output for name in expected)
+    assert all(name in result.stdout for name in expected)
 
 
-def test_systemd_list_exit_zero() -> None:
+def test_timer_list_json_lists_every_declared_timer() -> None:
+    # Arrange — the count is the assertion: a filter that matches nothing
+    # also "succeeds".
+    expected = set(_declared("timer"))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["timer", "list", "--json"])
+    # Assert
+    assert {j["name"] for j in json.loads(result.stdout)} == expected
+
+
+def test_timer_list_exit_zero() -> None:
     # Arrange
     runner = CliRunner()
     # Act
-    result = runner.invoke(dev_group, ["systemd", "list"])
+    result = runner.invoke(dev_group, ["timer", "list"])
     # Assert
     assert result.exit_code == 0
 
 
-def test_systemd_list_filters_out_foreign_jobs() -> None:
-    # Arrange — scitex-dev's own built-in jobs are discoverable too; only
-    # sac.* may show here.
-    runner = CliRunner()
-    # Act
-    result = runner.invoke(dev_group, ["systemd", "list", "--json"])
-    # Assert
-    import json as _json
-
-    assert all(j["name"].startswith("sac.") for j in _json.loads(result.output))
-
-
-def test_systemd_list_json_reports_the_real_kind() -> None:
+def test_timer_list_json_reports_the_real_kind() -> None:
     # Arrange — the JSON surfaces `kind` precisely so a future taxonomy
     # drift is visible rather than silently filtered to nothing.
     runner = CliRunner()
     # Act
-    result = runner.invoke(dev_group, ["systemd", "list", "--json"])
+    result = runner.invoke(dev_group, ["timer", "list", "--json"])
     # Assert
-    import json as _json
+    assert {j["kind"] for j in json.loads(result.stdout)} == {"timer"}
 
-    assert {j["kind"] for j in _json.loads(result.output)} == {"timer"}
+
+def test_timer_list_filters_out_foreign_jobs() -> None:
+    # Arrange — scitex-dev's and scitex-cards' own jobs are discoverable
+    # too; only sac's may show here.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["timer", "list", "--json"])
+    # Assert
+    assert all(_names.is_ours(j["name"]) for j in json.loads(result.stdout))
 
 
 def test_cron_list_is_empty_because_sac_declares_no_cron_jobs() -> None:
@@ -127,75 +219,162 @@ def test_cron_list_is_empty_because_sac_declares_no_cron_jobs() -> None:
     # Act
     result = runner.invoke(dev_group, ["cron", "list"])
     # Assert
-    assert "No sac cron jobs." in result.output
+    assert "No sac cron jobs." in result.stdout
 
 
-# ---------------------------------------------------------------------------
-# the dead group stays dead
-# ---------------------------------------------------------------------------
-
-
-def test_there_is_no_daemon_group() -> None:
-    # Arrange — `sac dev daemon` was dead in BOTH halves: it filtered
-    # kind="daemon" (never legal, so always zero jobs) AND delegated to
-    # `scitex-dev ecosystem daemon`, which is not an ecosystem subcommand
-    # at all. A long-running job is kind="service", via the systemd group.
-    groups = dev_group.commands
+def test_service_list_empty_is_consistent_with_what_sac_declares() -> None:
+    # Arrange — sac declares no kind="service" job today (`sac listen` is
+    # deliberately NOT federated; see _jobs_plugin). So this group's empty
+    # must be a TRUE empty, and the test states which one it is rather
+    # than pinning a hardcoded expectation.
+    declared = _declared("service")
+    runner = CliRunner()
     # Act
-    present = "daemon" in groups
+    result = runner.invoke(dev_group, ["service", "list"])
     # Assert
-    assert present is False
+    assert ("No sac service jobs." in result.stdout) is (declared == [])
 
 
-def test_job_groups_are_exactly_the_group_kinds_ssot() -> None:
-    # Arrange — the CLI surface is derived from GROUP_KINDS, so a group can
-    # never again exist without a declared kind filter behind it.
-    expected = set(GROUP_KINDS)
+# ---------------------------------------------------------------------------
+# stdout hygiene — --json must stay machine-parseable
+# ---------------------------------------------------------------------------
+
+
+def test_json_stdout_carries_no_deprecation_note() -> None:
+    # Arrange — THE stdout-purity case: the deprecated alias prints its
+    # notice on every invocation, including this one.
+    runner = CliRunner()
     # Act
-    present = {g for g in expected if g in dev_group.commands}
+    result = runner.invoke(dev_group, ["systemd", "list", "--json"])
+    # Assert — stdout ALONE parses; the note is not in it.
+    assert isinstance(json.loads(result.stdout), list)
+
+
+def test_deprecation_note_goes_to_stderr() -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["systemd", "list", "--json"])
+    # Assert
+    assert "DEPRECATED" in result.stderr
+
+
+def test_json_stdout_parses_in_a_real_subprocess() -> None:
+    # Arrange — the only place the two streams are genuinely separate
+    # files. CliRunner's `output` merges them, which is how a stdout test
+    # can pass while stdout is filthy. PYTHONPATH pins the subprocess to
+    # the SAME source tree this test imported, so a linked worktree is
+    # never silently tested against the main checkout's installed code.
+    src = str(Path(scitex_agent_container.__file__).resolve().parent.parent)
+    env = dict(os.environ, PYTHONPATH=src)
+    # Act
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scitex_agent_container",
+            "dev",
+            "timer",
+            "list",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    # Assert
+    assert len(json.loads(proc.stdout)) == len(_declared("timer"))
+
+
+# ---------------------------------------------------------------------------
+# deprecation — with an expiry, enforced
+# ---------------------------------------------------------------------------
+
+
+def test_systemd_is_the_only_deprecated_group() -> None:
+    # Arrange
+    expected = {"systemd"}
+    # Act
+    present = set(DEPRECATED_GROUPS)
     # Assert
     assert present == expected
 
 
-# ---------------------------------------------------------------------------
-# degrade — absent case
-# ---------------------------------------------------------------------------
-
-
-def test_list_degrades_with_upgrade_hint_when_jobs_absent() -> None:
-    # Arrange
-    with _jobs_absent():
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(dev_group, ["systemd", "list"])
-    # Assert — upgrade hint surfaces (no stack trace).
-    text = (result.output or "") + (getattr(result, "stderr", "") or "")
-    assert "requires scitex-dev>=" in text
-
-
-def test_list_degrade_exit_code_nonzero() -> None:
-    # Arrange
-    with _jobs_absent():
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(dev_group, ["systemd", "list"])
-    # Assert — clean non-zero exit, not an unhandled exception.
-    assert result.exit_code == 3 and result.exception.__class__ is SystemExit
-
-
-def test_install_degrades_when_jobs_absent() -> None:
-    # Arrange
-    with _jobs_absent():
-        runner = CliRunner()
-        # Act
-        result = runner.invoke(dev_group, ["systemd", "install", "-y"])
+def test_systemd_deprecation_carries_the_decided_dates() -> None:
+    # Arrange — real values in code, not a vague "for now".
+    dep = DEPRECATED_GROUPS["systemd"]
+    # Act
+    stamped = (dep.since, dep.remove_after)
     # Assert
-    text = (result.output or "") + (getattr(result, "stderr", "") or "")
-    assert "requires scitex-dev>=" in text
+    assert stamped == ("2026-08", "2026-10")
+
+
+def test_the_deprecation_deadline_has_not_passed() -> None:
+    # Arrange — THE ENFORCEMENT. A written date nobody checks is the same
+    # as no date: this test turns the build red once the removal window
+    # closes, so retiring `sac dev systemd` becomes a required action
+    # rather than an intention.
+    today = date.today().strftime("%Y-%m")
+    # Act
+    expired = [g for g, d in DEPRECATED_GROUPS.items() if d.is_expired(today)]
+    # Assert
+    assert not expired, (
+        f"deprecation window closed for {expired} — delete these groups from "
+        "GROUP_KINDS/GROUP_VERBS/DEPRECATED_GROUPS and their docs"
+    )
+
+
+def test_deprecation_rejects_a_vague_date() -> None:
+    # Arrange — "2026" is how "for the time being" gets back in.
+    kwargs = dict(since="2026-08", replacement="x")
+
+    # Act
+    def _build():
+        return Deprecation(remove_after="2026", **kwargs)
+
+    # Assert
+    with pytest.raises(ValueError):
+        _build()
+
+
+def test_deprecation_rejects_a_removal_date_before_it_starts() -> None:
+    # Arrange
+    kwargs = dict(since="2026-10", replacement="x")
+
+    # Act
+    def _build():
+        return Deprecation(remove_after="2026-08", **kwargs)
+
+    # Assert
+    with pytest.raises(ValueError):
+        _build()
+
+
+def test_deprecation_requires_a_replacement() -> None:
+    # Arrange — a deprecation with nothing to move to is a complaint.
+    kwargs = dict(since="2026-08", remove_after="2026-10")
+
+    # Act
+    def _build():
+        return Deprecation(replacement="", **kwargs)
+
+    # Assert
+    with pytest.raises(ValueError):
+        _build()
+
+
+def test_the_alias_gains_no_new_verbs() -> None:
+    # Arrange — the alias keeps EXACTLY its historical surface so nothing
+    # new gets built on something with a removal date.
+    frozen = {"list", "install", "uninstall"}
+    # Act
+    verbs = set(GROUP_VERBS["systemd"])
+    # Assert
+    assert verbs == frozen
 
 
 # ---------------------------------------------------------------------------
-# verb consistency with the scitex-dev ecosystem aggregator
+# verb sets — per kind, and a verb that makes no sense does not exist
 # ---------------------------------------------------------------------------
 
 
@@ -205,58 +384,217 @@ def _verbs_of(group: str) -> set[str]:
     return set(grp.commands)  # type: ignore[attr-defined]
 
 
-def test_cron_verbs_are_list_install_uninstall() -> None:
-    # Arrange
-    group = "cron"
+def test_declared_verbs_are_the_verbs_actually_wired() -> None:
+    # Arrange — GROUP_VERBS is the SSOT; a declared verb that is not wired
+    # is a declaration with no live counterpart.
+    expected = {g: set(v) for g, v in GROUP_VERBS.items()}
     # Act
-    verbs = _verbs_of(group)
+    wired = {g: _verbs_of(g) for g in GROUP_VERBS}
     # Assert
-    assert verbs == {"list", "install", "uninstall"}
+    assert wired == expected
 
 
-def test_systemd_verbs_are_list_install_uninstall() -> None:
-    # Arrange
-    group = "systemd"
+def test_service_has_the_full_lifecycle() -> None:
+    # Arrange — a service is a long-running unit.
+    expected = {
+        "list",
+        "status",
+        "start",
+        "stop",
+        "restart",
+        "enable",
+        "disable",
+        "install",
+        "uninstall",
+    }
     # Act
-    verbs = _verbs_of(group)
+    verbs = _verbs_of("service")
     # Assert
-    assert verbs == {"list", "install", "uninstall"}
+    assert verbs == expected
 
 
-def test_install_delegates_to_the_matching_ecosystem_group() -> None:
-    # Arrange — capture the (group, verb, name) tuples install delegates
-    # with, rather than shelling out to a real scitex-dev that would
-    # rewrite the host's systemd units.
-    import scitex_agent_container.cli_pkg._dev_jobs as dj
+def test_timer_has_no_start_verb() -> None:
+    # Arrange — `enable --now` is the systemd idiom for a timer; a second
+    # spelling with different edge cases is worse than none.
+    verbs = _verbs_of("timer")
+    # Act
+    present = "start" in verbs
+    # Assert
+    assert present is False
 
-    captured: list[tuple] = []
-    original = dj._ecosystem_delegate
-    dj._ecosystem_delegate = lambda *a, **k: captured.append(a) or 0  # type: ignore[assignment]
-    try:
-        runner = CliRunner()
-        # Act
-        runner.invoke(dev_group, ["systemd", "install", "-y"])
-    finally:
-        dj._ecosystem_delegate = original  # type: ignore[assignment]
-    # Assert — every delegation targets `ecosystem systemd install`.
-    assert captured and all(a[:2] == ("systemd", "install") for a in captured)
+
+def test_cron_has_no_status_verb() -> None:
+    # Arrange — a crontab line is present or commented out; there is no
+    # runtime object to ask. The verb does not exist rather than existing
+    # and erroring.
+    verbs = _verbs_of("cron")
+    # Act
+    present = "status" in verbs
+    # Assert
+    assert present is False
+
+
+# ---------------------------------------------------------------------------
+# delegation — the KIND is what travels, never the group name
+# ---------------------------------------------------------------------------
 
 
 def test_install_delegates_once_per_declared_timer() -> None:
     # Arrange — the count is the point: a group that silently matched zero
     # jobs delegated zero times and still exited 0.
-    import scitex_agent_container.cli_pkg._dev_jobs as dj
-    from scitex_agent_container._jobs._jobs_plugin import provide_jobs
+    expected = len(_declared("timer"))
+    with _captured_delegations() as captured:
+        runner = CliRunner()
+        # Act
+        runner.invoke(dev_group, ["timer", "install", "-y"])
+    # Assert
+    assert len(captured) == expected
 
-    expected = len([j for j in provide_jobs() if j.kind in GROUP_KINDS["systemd"]])
-    captured: list[tuple] = []
-    original = dj._ecosystem_delegate
-    dj._ecosystem_delegate = lambda *a, **k: captured.append(a) or 0  # type: ignore[assignment]
-    try:
+
+def test_install_delegates_with_the_kind_not_the_group_name() -> None:
+    # Arrange — THE historical bug, at the delegation boundary.
+    with _captured_delegations() as captured:
+        runner = CliRunner()
+        # Act
+        runner.invoke(dev_group, ["timer", "install", "-y"])
+    # Assert
+    assert captured and all(a[:2] == ("timer", "install") for a in captured)
+
+
+def test_the_alias_delegates_on_a_kind_too_never_on_systemd() -> None:
+    # Arrange — the deprecated group name must not reach the kind axis.
+    with _captured_delegations() as captured:
         runner = CliRunner()
         # Act
         runner.invoke(dev_group, ["systemd", "install", "-y"])
-    finally:
-        dj._ecosystem_delegate = original  # type: ignore[assignment]
     # Assert
-    assert len(captured) == expected
+    assert captured and all(a[0] in jobs_mod.ALLOWED_KINDS for a in captured)
+
+
+def test_install_accepts_the_short_local_name() -> None:
+    # Arrange — the operator types the local name inside sac's own CLI.
+    with _captured_delegations() as captured:
+        runner = CliRunner()
+        # Act
+        runner.invoke(dev_group, ["timer", "install", "accounts-refresh", "-y"])
+    # Assert
+    assert [a[2] for a in captured] == ["sac.accounts-refresh"]
+
+
+def test_install_accepts_the_canonical_name_too() -> None:
+    # Arrange — a name copied out of --json output or off a unit filename.
+    with _captured_delegations() as captured:
+        runner = CliRunner()
+        # Act
+        runner.invoke(dev_group, ["timer", "install", "sac.accounts-refresh", "-y"])
+    # Assert
+    assert [a[2] for a in captured] == ["sac.accounts-refresh"]
+
+
+def test_an_unknown_job_name_exits_five() -> None:
+    # Arrange — a verb that silently does nothing for a typo is how a job
+    # quietly stops being scheduled.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["timer", "install", "no-such-job", "-y"])
+    # Assert
+    assert result.exit_code == 5
+
+
+def test_an_unknown_job_name_lists_the_real_ones() -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["timer", "install", "no-such-job", "-y"])
+    # Assert
+    assert "accounts-refresh" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# verbs the installed scitex-dev cannot serve yet
+# ---------------------------------------------------------------------------
+
+
+def test_a_verb_the_backend_cannot_serve_exits_four() -> None:
+    # Arrange — `ecosystem timer` does not exist yet and `ecosystem
+    # systemd` has no `status`, so this is a REAL unsupported path today,
+    # measured rather than simulated. It must fail loudly, not pretend.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["timer", "status", "accounts-refresh"])
+    # Assert
+    assert result.exit_code == 4
+
+
+def test_an_unsupported_verb_states_what_it_probed() -> None:
+    # Arrange — a refusal with no evidence is a claim.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["timer", "status", "accounts-refresh"])
+    # Assert
+    assert "ecosystem timer status" in result.stderr
+
+
+def test_an_unsupported_verb_offers_the_manual_command() -> None:
+    # Arrange — reporting a command is not running it; sac still does not
+    # own systemctl.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["timer", "status", "accounts-refresh"])
+    # Assert
+    assert "systemctl --user status sac.accounts-refresh.timer" in result.stderr
+
+
+def test_an_unsupported_verb_writes_nothing_to_stdout() -> None:
+    # Arrange — same stdout-purity rule as --json.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(dev_group, ["timer", "status", "accounts-refresh"])
+    # Assert
+    assert result.stdout == ""
+
+
+# ---------------------------------------------------------------------------
+# degrade — scitex-dev too old
+# ---------------------------------------------------------------------------
+
+
+def test_list_degrades_with_upgrade_hint_when_jobs_absent() -> None:
+    # Arrange
+    with _jobs_absent():
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(dev_group, ["timer", "list"])
+    # Assert — upgrade hint surfaces (no stack trace), on stderr.
+    assert "requires scitex-dev>=" in result.stderr
+
+
+def test_list_degrade_exit_code_is_three() -> None:
+    # Arrange
+    with _jobs_absent():
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(dev_group, ["timer", "list"])
+    # Assert — clean non-zero exit, not an unhandled exception.
+    assert result.exit_code == 3 and result.exception.__class__ is SystemExit
+
+
+def test_degrade_writes_nothing_to_stdout() -> None:
+    # Arrange — an upgrade hint on stdout would corrupt a --json consumer
+    # exactly like a WARN does.
+    with _jobs_absent():
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(dev_group, ["timer", "list", "--json"])
+    # Assert
+    assert result.stdout == ""
+
+
+def test_install_degrades_when_jobs_absent() -> None:
+    # Arrange
+    with _jobs_absent():
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(dev_group, ["timer", "install", "-y"])
+    # Assert
+    assert "requires scitex-dev>=" in result.stderr

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
@@ -259,16 +259,18 @@ def test_deprecation_note_goes_to_stderr() -> None:
     assert "DEPRECATED" in result.stderr
 
 
-def test_json_stdout_parses_in_a_real_subprocess() -> None:
-    # Arrange — the only place the two streams are genuinely separate
-    # files. CliRunner's `output` merges them, which is how a stdout test
-    # can pass while stdout is filthy. PYTHONPATH pins the subprocess to
-    # the SAME source tree this test imported, so a linked worktree is
-    # never silently tested against the main checkout's installed code.
+def _subprocess_timer_list_json() -> subprocess.CompletedProcess:
+    """``sac dev timer list --json`` in a REAL process, on THIS source tree.
+
+    The only place the two streams are genuinely separate files —
+    CliRunner's ``output`` merges them, which is how a stdout test can
+    pass while stdout is filthy. PYTHONPATH pins the subprocess to the
+    SAME source tree this test imported, so a linked worktree is never
+    silently tested against the main checkout's installed code.
+    """
     src = str(Path(scitex_agent_container.__file__).resolve().parent.parent)
     env = dict(os.environ, PYTHONPATH=src)
-    # Act
-    proc = subprocess.run(
+    return subprocess.run(
         [
             sys.executable,
             "-m",
@@ -282,8 +284,32 @@ def test_json_stdout_parses_in_a_real_subprocess() -> None:
         text=True,
         env=env,
     )
+
+
+def test_json_stdout_parses_in_a_real_subprocess() -> None:
+    # Arrange — THE contract: stdout ALONE is machine-readable. The job
+    # COUNT is deliberately not asserted here. `list` reads the
+    # scitex_dev.jobs ENTRY POINT while `_declared()` imports the provider
+    # directly, and the two disagree in environments where the package is
+    # on sys.path but its metadata is not resolvable — measured, this
+    # subprocess returned an empty list in CI while the in-process command
+    # returned all nine. Non-emptiness is pinned in-process above; this
+    # test owns stream purity, and conflating the two would make a stdout
+    # test fail for a discovery reason.
+    proc = _subprocess_timer_list_json()
+    # Act
+    parsed = json.loads(proc.stdout)
     # Assert
-    assert len(json.loads(proc.stdout)) == len(_declared("timer"))
+    assert isinstance(parsed, list)
+
+
+def test_the_real_subprocess_exits_zero() -> None:
+    # Arrange
+    proc = _subprocess_timer_list_json()
+    # Act
+    code = proc.returncode
+    # Assert
+    assert code == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
@@ -1,0 +1,171 @@
+"""Tests for the ``sac dev <kind> <verb>`` -> scitex-dev delegation seam.
+
+The seam has one job: answer "who serves this verb, and how do I know".
+It is tested against the INSTALLED scitex-dev's real Click tree, because
+a hard-coded table of what the ecosystem supports is a declaration with
+no live counterpart — it stays green while the real surface moves.
+
+The capability answers are three-state on purpose (supported / not
+supported / cannot tell). A false "not supported" refuses a command that
+would have worked, which is why an unreadable Click tree degrades to
+attempting the verbs that have shipped since 0.16.0 rather than to a
+refusal.
+
+No mocks (PA-306). `resolve` is a pure function over a probed dict, and
+the probe reads the real installed package.
+
+AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip(
+    "scitex_dev.jobs",
+    reason="installed scitex-dev predates the scitex_dev.jobs contract",
+)
+
+from scitex_agent_container.cli_pkg import _dev_jobs_backend as backend  # noqa: E402
+
+
+def test_the_ecosystem_tree_is_readable() -> None:
+    # Arrange — every capability answer below rests on this probe being
+    # able to read the installed package at all.
+    # Act
+    verbs = backend.ecosystem_verbs()
+    # Assert
+    assert verbs is not None
+
+
+def test_the_probe_finds_the_shipped_cron_group() -> None:
+    # Arrange — a positive control: if this is empty the probe silently
+    # read nothing and every "unsupported" verdict below is worthless.
+    verbs = backend.ecosystem_verbs() or {}
+    # Act
+    cron_verbs = verbs.get("cron", frozenset())
+    # Assert
+    assert {"list", "install", "uninstall"} <= cron_verbs
+
+
+def test_timer_list_falls_back_to_the_shipped_systemd_group() -> None:
+    # Arrange — `ecosystem timer` does not exist yet; `ecosystem systemd`
+    # serves both unit kinds today.
+    # Act
+    got = backend.resolve("timer", "list")
+    # Assert
+    assert (got.group, got.supported) == ("systemd", True)
+
+
+def test_cron_install_delegates_to_the_cron_group() -> None:
+    # Arrange
+    # Act
+    got = backend.resolve("cron", "install")
+    # Assert
+    assert (got.group, got.supported) == ("cron", True)
+
+
+def test_a_verb_no_ecosystem_group_serves_is_unsupported() -> None:
+    # Arrange — `status` exists in sac's grammar but on neither
+    # `ecosystem timer` nor `ecosystem systemd` today.
+    # Act
+    got = backend.resolve("timer", "status")
+    # Assert
+    assert got.supported is False
+
+
+def test_an_unsupported_verdict_names_both_probes() -> None:
+    # Arrange — a refusal that cannot say what it looked for is a claim.
+    # Act
+    got = backend.resolve("timer", "status")
+    # Assert
+    assert "ecosystem systemd status" in got.evidence
+
+
+def test_a_delegation_must_state_its_evidence() -> None:
+    # Arrange — same doctrine as _jobs_audit.Finding.detail.
+    kwargs = dict(group="systemd", verb="list", supported=True)
+
+    # Act
+    def _build():
+        return backend.Delegation(evidence="", **kwargs)
+
+    # Assert
+    with pytest.raises(ValueError):
+        _build()
+
+
+def test_invoking_an_unsupported_delegation_is_refused() -> None:
+    # Arrange — the caller must translate "unsupported" into a message,
+    # never shell out anyway.
+    unsupported = backend.Delegation(
+        group="timer", verb="status", supported=False, evidence="probed, absent"
+    )
+
+    # Act
+    def _call():
+        return backend.invoke(unsupported, name="sac.x", yes=False)
+
+    # Assert
+    with pytest.raises(ValueError):
+        _call()
+
+
+def test_the_manual_hint_names_the_timer_unit() -> None:
+    # Arrange — the unit filename is derived from JobSpec.name verbatim by
+    # scitex-dev's renderer, so the hint must mirror that exactly or it
+    # points the operator at a unit that does not exist.
+    # Act
+    hint = backend.manual_hint("timer", "status", "sac.accounts-refresh")
+    # Assert
+    assert hint == "systemctl --user status sac.accounts-refresh.timer"
+
+
+def test_the_manual_hint_names_the_service_unit() -> None:
+    # Arrange
+    # Act
+    hint = backend.manual_hint("service", "restart", "sac.listen")
+    # Assert
+    assert hint == "systemctl --user restart sac.listen.service"
+
+
+def test_enable_hints_use_the_now_form() -> None:
+    # Arrange — `enable` without `--now` writes a symlink and starts
+    # nothing, which reads exactly like success.
+    # Act
+    hint = backend.manual_hint("timer", "enable", "sac.worktree-gc")
+    # Assert
+    assert "--now" in hint
+
+
+def test_an_unreadable_tree_still_attempts_a_shipped_verb() -> None:
+    # Arrange — "cannot tell" must not become "refuse": a false negative
+    # here blocks a command that would have worked.
+    backend.reset_capability_cache()
+    original = backend.ecosystem_verbs
+    backend.ecosystem_verbs = lambda: None  # type: ignore[assignment]
+    try:
+        # Act
+        got = backend.resolve("timer", "install")
+    finally:
+        backend.ecosystem_verbs = original  # type: ignore[assignment]
+        backend.reset_capability_cache()
+    # Assert
+    assert got.supported is True
+
+
+def test_an_unreadable_tree_refuses_a_verb_that_never_shipped() -> None:
+    # Arrange — attempting `ecosystem systemd status` blind would shell
+    # out to a subcommand that has never existed and surface a raw click
+    # usage error instead of sac's own message.
+    backend.reset_capability_cache()
+    original = backend.ecosystem_verbs
+    backend.ecosystem_verbs = lambda: None  # type: ignore[assignment]
+    try:
+        # Act
+        got = backend.resolve("timer", "status")
+    finally:
+        backend.ecosystem_verbs = original  # type: ignore[assignment]
+        backend.reset_capability_cache()
+    # Assert
+    assert got.supported is False

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
@@ -38,14 +38,19 @@ def test_the_ecosystem_tree_is_readable() -> None:
     assert verbs is not None
 
 
-def test_the_probe_finds_the_shipped_cron_group() -> None:
-    # Arrange — a positive control: if this is empty the probe silently
-    # read nothing and every "unsupported" verdict below is worthless.
+def test_the_probe_finds_the_shipped_job_groups() -> None:
+    # Arrange — a POSITIVE CONTROL. If these group names are missing the
+    # probe read nothing and every "unsupported" verdict below is
+    # worthless. It asserts group PRESENCE rather than the verb sets,
+    # because whether the leaf verbs are statically readable depends on
+    # whether the installed scitex-dev builds its tree lazily — measured
+    # differing between this container and CI for the same code, which is
+    # exactly why `resolve` treats an all-empty read as "cannot tell".
     verbs = backend.ecosystem_verbs() or {}
     # Act
-    cron_verbs = verbs.get("cron", frozenset())
+    groups = {g for g in ("cron", "systemd") if g in verbs}
     # Assert
-    assert {"list", "install", "uninstall"} <= cron_verbs
+    assert groups == {"cron", "systemd"}
 
 
 def test_timer_list_falls_back_to_the_shipped_systemd_group() -> None:

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs_backend.py
@@ -19,6 +19,10 @@ AAA marker comments; one assertion per test.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+from typing import Iterator
+
+import click
 import pytest
 
 pytest.importorskip(
@@ -27,6 +31,89 @@ pytest.importorskip(
 )
 
 from scitex_agent_container.cli_pkg import _dev_jobs_backend as backend  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures: REAL click trees shaped like the ecosystem versions we must
+# survive. Not mocks — `_walk` is pointed at an actual Group and has to
+# find its way down, exactly as it does against the installed package.
+# ---------------------------------------------------------------------------
+
+
+def _group(name: str, leaves: tuple[str, ...] = ()) -> click.Group:
+    grp = click.Group(name)
+    for leaf in leaves:
+        grp.add_command(click.Command(leaf))
+    return grp
+
+
+def _tree_pre_move() -> click.Group:
+    """scitex-dev <= 0.42: job groups at the TOP level of `ecosystem`."""
+    eco = _group("ecosystem")
+    eco.add_command(_group("cron", ("exec", "install", "list", "uninstall")))
+    eco.add_command(_group("systemd", ("install", "list", "uninstall")))
+    return eco
+
+
+def _tree_moved_no_kinds() -> click.Group:
+    """The MEASURED scitex-dev 0.43.1 shape.
+
+    The job groups live under `dev`; the per-KIND groups do not exist
+    yet; and the OLD top-level names survive as deprecated forwarding
+    `Command` shims — plain Commands, not Groups, so they enumerate as
+    zero verbs while `ecosystem systemd install` runs fine. Their help
+    says "Removed in v0.50", so they are also a time bomb to target.
+    """
+    eco = _group("ecosystem")
+    eco.add_command(
+        click.Command("cron", help="(deprecated) Forwards to 'ecosystem dev cron'.")
+    )
+    eco.add_command(
+        click.Command(
+            "systemd", help="(deprecated) Forwards to 'ecosystem dev systemd'."
+        )
+    )
+    dev = _group("dev")
+    dev.add_command(_group("cron", ("exec", "install", "list", "uninstall")))
+    dev.add_command(_group("systemd", ("install", "list", "uninstall")))
+    eco.add_command(dev)
+    return eco
+
+
+def _tree_566() -> click.Group:
+    """scitex-dev PR #566: per-KIND groups under `ecosystem dev`."""
+    eco = _group("ecosystem")
+    dev = _group("dev")
+    dev.add_command(
+        _group(
+            "service",
+            ("list", "status", "start", "stop", "restart", "install", "uninstall"),
+        )
+    )
+    dev.add_command(
+        _group(
+            "timer",
+            ("list", "status", "enable", "disable", "install", "uninstall"),
+        )
+    )
+    dev.add_command(
+        _group("cron", ("list", "enable", "disable", "install", "uninstall", "exec"))
+    )
+    eco.add_command(dev)
+    return eco
+
+
+@contextmanager
+def _installed(tree: click.Group) -> Iterator[None]:
+    """Point the probe at ``tree`` instead of the installed scitex-dev."""
+    backend.reset_capability_cache()
+    original = backend.ecosystem_verbs
+    walked = backend._walk(tree)
+    backend.ecosystem_verbs = lambda: walked  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        backend.ecosystem_verbs = original  # type: ignore[assignment]
+        backend.reset_capability_cache()
 
 
 def test_the_ecosystem_tree_is_readable() -> None:
@@ -38,58 +125,223 @@ def test_the_ecosystem_tree_is_readable() -> None:
     assert verbs is not None
 
 
-def test_the_probe_finds_the_shipped_job_groups() -> None:
-    # Arrange — a POSITIVE CONTROL. If these group names are missing the
-    # probe read nothing and every "unsupported" verdict below is
-    # worthless. It asserts group PRESENCE rather than the verb sets,
-    # because whether the leaf verbs are statically readable depends on
-    # whether the installed scitex-dev builds its tree lazily — measured
-    # differing between this container and CI for the same code, which is
-    # exactly why `resolve` treats an all-empty read as "cannot tell".
-    verbs = backend.ecosystem_verbs() or {}
+def test_the_probe_reaches_a_job_surface_with_real_verbs() -> None:
+    # Arrange — a POSITIVE CONTROL against the INSTALLED package. A probe
+    # that reads nothing makes every "unsupported" verdict below
+    # worthless, and "the group exists" is NOT enough evidence: measured
+    # on scitex-dev 0.43.1, `ecosystem cron` and `ecosystem systemd` are
+    # both PRESENT and both EMPTY, because the verbs moved under
+    # `ecosystem dev`. So this asserts a path that actually carries verbs.
+    tree = backend.ecosystem_verbs() or {}
     # Act
-    groups = {g for g in ("cron", "systemd") if g in verbs}
+    with_verbs = {path for path, verbs in tree.items() if verbs}
     # Assert
-    assert groups == {"cron", "systemd"}
+    assert with_verbs, f"probe found no verbs anywhere; walked: {sorted(tree)}"
 
 
-def test_timer_list_falls_back_to_the_shipped_systemd_group() -> None:
-    # Arrange — `ecosystem timer` does not exist yet; `ecosystem systemd`
-    # serves both unit kinds today.
+# --- the WALK: does it start at the node that will hold the kind groups? ---
+
+
+def test_the_walk_descends_into_the_dev_subgroup() -> None:
+    # Arrange — THE question. scitex-dev PR #566 mounts the kind groups at
+    # `ecosystem dev <kind>`, one level DOWN. A probe enumerating only
+    # `ecosystem`'s direct children reports "no service/timer surface"
+    # forever — the silent-zero shape this whole card exists to kill.
+    walked = backend._walk(_tree_566())
     # Act
-    got = backend.resolve("timer", "list")
+    timer_verbs = walked.get(("dev", "timer"), frozenset())
     # Assert
-    assert (got.group, got.supported) == ("systemd", True)
+    assert {"list", "status", "enable", "disable"} <= timer_verbs
 
 
-def test_cron_install_delegates_to_the_cron_group() -> None:
+def test_timer_status_resolves_against_the_566_tree() -> None:
+    # Arrange — the verb that is unsupported today must become supported
+    # the moment #566 is installed, with NO sac release.
+    with _installed(_tree_566()):
+        # Act
+        got = backend.resolve("timer", "status")
+    # Assert
+    assert (got.path, got.supported) == (("dev", "timer"), True)
+
+
+def test_service_restart_resolves_against_the_566_tree() -> None:
     # Arrange
+    with _installed(_tree_566()):
+        # Act
+        got = backend.resolve("service", "restart")
+    # Assert
+    assert (got.path, got.supported) == (("dev", "service"), True)
+
+
+def test_the_kind_group_wins_over_the_legacy_lump_group() -> None:
+    # Arrange — preference order: the surface the ecosystem is moving TO.
+    with _installed(_tree_566()):
+        # Act
+        got = backend.resolve("timer", "install")
+    # Assert
+    assert got.path == ("dev", "timer")
+
+
+def test_the_moved_tree_resolves_to_dev_systemd_not_the_shim() -> None:
+    # Arrange — THE MEASURED 0.43.1 shape. `ecosystem systemd` still
+    # resolves, but it is a DEPRECATED forwarding shim whose own help
+    # says "Removed in v0.50". Targeting it works today and breaks on a
+    # scitex-dev upgrade, so the real group must win.
+    with _installed(_tree_moved_no_kinds()):
+        # Act
+        got = backend.resolve("timer", "install")
+    # Assert
+    assert (got.path, got.supported) == (("dev", "systemd"), True)
+
+
+def test_the_live_installed_tree_is_not_targeted_through_a_shim() -> None:
+    # Arrange — against the INSTALLED scitex-dev, not a fixture. If this
+    # resolves to the bare ("systemd",) shim, every mutating verb breaks
+    # silently when scitex-dev reaches v0.50.
+    # Act
+    got = backend.resolve("timer", "install")
+    # Assert
+    assert got.path != ("systemd",), f"targeting the removed-in-v0.50 shim: {got.group}"
+
+
+def test_the_pre_move_tree_still_resolves_at_the_top_level() -> None:
+    # Arrange — an OLDER scitex-dev must keep working; the walk must not
+    # require the `dev` subgroup to exist.
+    with _installed(_tree_pre_move()):
+        # Act
+        got = backend.resolve("timer", "install")
+    # Assert
+    assert (got.path, got.supported) == (("systemd",), True)
+
+
+def test_cron_install_resolves_to_a_supported_delegation() -> None:
+    # Arrange — against the INSTALLED package, whichever level it mounts.
     # Act
     got = backend.resolve("cron", "install")
     # Assert
-    assert (got.group, got.supported) == ("cron", True)
+    assert got.supported is True
+
+
+def test_timer_install_resolves_to_a_supported_delegation() -> None:
+    # Arrange
+    # Act
+    got = backend.resolve("timer", "install")
+    # Assert
+    assert got.supported is True
+
+
+# --- the THIRD STATE: dev present, kind children absent ---
+
+
+def test_dev_present_with_kind_children_absent_is_cannot_tell() -> None:
+    # Arrange — an older scitex-dev that has done the `dev` move but has
+    # NOT split the kinds. `dev service`/`dev timer` report nothing.
+    # Reading that as "verb unsupported" would refuse `install` on a
+    # perfectly working install, so it must land in the third state and
+    # be ATTEMPTED against the surface that does carry the verb.
+    with _installed(_tree_moved_no_kinds()):
+        # Act
+        got = backend.resolve("service", "install")
+    # Assert
+    assert got.supported is True
+
+
+def test_a_totally_empty_tree_is_cannot_tell_not_unsupported() -> None:
+    # Arrange — every candidate path absent. Zero everywhere is not a
+    # credible reading of a scitex-dev that has shipped these verbs since
+    # 0.16.0; it is a probe that failed.
+    with _installed(_group("ecosystem")):
+        # Act
+        got = backend.resolve("timer", "install")
+    # Assert
+    assert got.supported is True
+
+
+def test_cannot_tell_prefers_dev_when_a_dev_subgroup_exists() -> None:
+    # Arrange — if `dev` is there, the shipped verbs are behind it.
+    eco = _group("ecosystem")
+    eco.add_command(_group("dev"))
+    with _installed(eco):
+        # Act
+        got = backend.resolve("timer", "install")
+    # Assert
+    assert got.path == ("dev", "systemd")
 
 
 def test_a_verb_no_ecosystem_group_serves_is_unsupported() -> None:
-    # Arrange — `status` exists in sac's grammar but on neither
-    # `ecosystem timer` nor `ecosystem systemd` today.
-    # Act
-    got = backend.resolve("timer", "status")
+    # Arrange — `status` exists in sac's grammar but on no surface the
+    # pre-#566 tree serves, and that tree DOES report other verbs, so
+    # this is genuine absence rather than an unreadable probe.
+    with _installed(_tree_pre_move()):
+        # Act
+        got = backend.resolve("timer", "status")
     # Assert
     assert got.supported is False
 
 
-def test_an_unsupported_verdict_names_both_probes() -> None:
+def test_an_unsupported_verdict_names_every_path_it_probed() -> None:
     # Arrange — a refusal that cannot say what it looked for is a claim.
-    # Act
-    got = backend.resolve("timer", "status")
+    with _installed(_tree_pre_move()):
+        # Act
+        got = backend.resolve("timer", "status")
     # Assert
-    assert "ecosystem systemd status" in got.evidence
+    assert "ecosystem dev timer" in got.evidence
+
+
+# --- the GATE: --dry-run / --yes must survive the pass-through ---
+
+
+def test_the_pass_through_forwards_dry_run() -> None:
+    # Arrange — scitex-dev's gate is load-bearing: `timer disable
+    # sac.accounts-refresh` stops the fleet's SOLE OAuth refresher. A
+    # pass-through that drops the flag turns a guarded command into an
+    # unguarded one.
+    delegation = backend.Delegation(
+        path=("dev", "timer"), verb="disable", supported=True, evidence="fixture"
+    )
+    # Act
+    argv = backend.build_argv(
+        delegation, name="sac.accounts-refresh", yes=False, dry_run=True, exe="sd"
+    )
+    # Assert
+    assert argv == [
+        "sd",
+        "ecosystem",
+        "dev",
+        "timer",
+        "disable",
+        "--name",
+        "sac.accounts-refresh",
+        "--dry-run",
+    ]
+
+
+def test_the_pass_through_forwards_yes() -> None:
+    # Arrange
+    delegation = backend.Delegation(
+        path=("dev", "timer"), verb="install", supported=True, evidence="fixture"
+    )
+    # Act
+    argv = backend.build_argv(delegation, name="sac.x", yes=True, exe="sd")
+    # Assert
+    assert argv[-1] == "--yes"
+
+
+def test_the_pass_through_adds_neither_flag_unasked() -> None:
+    # Arrange — sac must not decide confirmation on the operator's behalf
+    # in either direction.
+    delegation = backend.Delegation(
+        path=("cron",), verb="install", supported=True, evidence="fixture"
+    )
+    # Act
+    argv = backend.build_argv(delegation, name="sac.x", yes=False, exe="sd")
+    # Assert
+    assert argv == ["sd", "ecosystem", "cron", "install", "--name", "sac.x"]
 
 
 def test_a_delegation_must_state_its_evidence() -> None:
     # Arrange — same doctrine as _jobs_audit.Finding.detail.
-    kwargs = dict(group="systemd", verb="list", supported=True)
+    kwargs = dict(path=("systemd",), verb="list", supported=True)
 
     # Act
     def _build():
@@ -100,11 +352,26 @@ def test_a_delegation_must_state_its_evidence() -> None:
         _build()
 
 
+def test_a_delegation_renders_a_nested_path_as_it_is_typed() -> None:
+    # Arrange — the evidence and error messages quote this, and an
+    # operator has to be able to paste it.
+    delegation = backend.Delegation(
+        path=("dev", "timer"), verb="status", supported=True, evidence="fixture"
+    )
+    # Act
+    rendered = delegation.group
+    # Assert
+    assert rendered == "dev timer"
+
+
 def test_invoking_an_unsupported_delegation_is_refused() -> None:
     # Arrange — the caller must translate "unsupported" into a message,
     # never shell out anyway.
     unsupported = backend.Delegation(
-        group="timer", verb="status", supported=False, evidence="probed, absent"
+        path=("dev", "timer"),
+        verb="status",
+        supported=False,
+        evidence="probed, absent",
     )
 
     # Act


### PR DESCRIPTION
## What

`sac dev` job groups are now named after the **`JobSpec` kind**, not the delivery mechanism:

```
sac dev service {list,status,start,stop,restart,enable,disable,install,uninstall}
sac dev timer   {list,status,enable,disable,install,uninstall}
sac dev cron    {list,enable,disable,install,uninstall}
sac dev systemd {list,install,uninstall}          # DEPRECATED, dated, stderr notice
```

This is the ecosystem grammar `scitex-<pkg> dev {service,timer,cron} <verb>` (operator decision, 2026-08-11). `scitex_dev.jobs.ALLOWED_KINDS` has been `{service,timer,cron}` since scitex-dev #153 — this aligns sac's CLI to a taxonomy that already exists.

## Why it is not a cosmetic rename

The old groups were named on the MECHANISM axis while the filter used the KIND axis — two axes, one name. `_load_sac_jobs` was then called with the GROUP NAME, so `sac dev systemd list` asked for `kind="systemd"`, which `JobSpec.validate()` rejects at construction. Nothing could ever match, so every timer sac owns was invisible to its own CLI for weeks behind `No sac systemd-kind jobs.` and exit 0.

Collapsing the group name onto the kind leaves **no name that can be passed where a kind is expected and mean something else**. `_jobs_audit` now machine-checks that:

- `Form.GROUP_IS_NOT_ITS_KIND` — a non-deprecated group whose name is not a legal kind, or that filters on anything other than exactly itself.
- `Form.ALIAS_ONLY_KIND` — a kind reachable ONLY through a deprecated alias, i.e. one with a scheduled loss of its CLI.

Both read the real production `GROUP_KINDS` / `DEPRECATED_GROUPS` from the consumer, not a re-declared copy — same doctrine the module already used.

## Verb sets differ per kind, on purpose

A verb that makes no sense for a kind does not exist for that kind, rather than existing and erroring.

- `service` — a long-running unit, so the full lifecycle applies.
- `timer` — `enable --now` is the systemd idiom; `start`/`stop`/`restart` would be a second spelling with different edge cases, so they are omitted rather than aliased.
- `cron` — a crontab line is present or commented out. There is no runtime object to start or query, so `status`/`start`/`stop` do not exist here.

`install`/`uninstall` take an optional job NAME; every named verb accepts the short local name (`accounts-refresh`) as well as the canonical id (`sac.accounts-refresh`). An unknown name exits **5** and lists the real ones.

## Deprecation with an expiry that is enforced

`sac dev systemd` keeps working with **exactly** its historical three verbs, so nothing new gets built on something with a removal date. It carries real metadata in code:

```
since = 2026-08     remove_after = 2026-10     replacement = sac dev service / sac dev timer
```

`test_the_deprecation_deadline_has_not_passed` turns the build red once that window closes — "当面" becomes permanent unless a date is written down, and a date nobody enforces is the same thing.

The notice goes to **stderr**, never stdout. A courtesy message on stdout is indistinguishable from data; that is exactly how a stale-registry `WARN:` on stdout corrupted `sac host list --json` and turned 7 tests red across three unrelated PRs.

## The delegation seam (`_dev_jobs_backend.py`)

sac resolves a target and shells `scitex-dev ecosystem <group> <verb>`; it does **not** call `systemctl` itself. The argument is in the module docstring: one owner or two disagreeing owners; N packages would otherwise ship N copies of the same `--user`/unit-name/escaping bugs; and the verb set is still moving.

The seam **probes the installed scitex-dev's real Click tree** rather than consulting a hard-coded table, so it picks up `ecosystem service` / `ecosystem timer` the moment those ship — no sac release, no flag. Until then it falls back to today's `ecosystem {cron,systemd}`. A verb neither surface serves exits **4**, naming what was probed and printing the exact manual command:

```
$ sac dev timer status accounts-refresh
`sac dev timer status` is part of the SciTeX job grammar, but the installed scitex-dev
cannot serve it yet: the installed scitex-dev serves neither `ecosystem timer status`
(has: no such group) nor `ecosystem systemd status` (has: ['install', 'list', 'uninstall']).
Run it by hand meanwhile: systemctl --user status sac.accounts-refresh.timer
# exit 4
```

Capability answers are three-state (supported / unsupported / **cannot tell**). An unreadable Click tree degrades to *attempting* the verbs that shipped in 0.16.0, never to a refusal — a false negative would block a command that would have worked.

## Two `--json` tests were asserting on the wrong stream

`tests/…/test__dev_jobs.py::test_systemd_list_filters_out_foreign_jobs` and `::test_systemd_list_json_reports_the_real_kind` failed on plain `develop` with `ModuleNotFoundError: No module named 'scitex_agent_container._jobs_plugin'`. Measured cause, not the one it looks like:

1. `/opt/venv-sac/lib/python3.12/site-packages/~citex_agent_container-0.21.13.dist-info` — a pip-interrupted-install leftover — registers the OLD flat module path under `scitex_dev.jobs`. The repo's `pyproject.toml` and the current dist-info are both correct. **Environmental, not a repo bug.**
2. `discover_jobs` correctly logs that failed provider to **stderr**.
3. The two tests parsed click's `Result.output`, which merges stdout AND stderr. Real `sac dev … --json` stdout was clean the whole time.

So the in-repo defect is the assertion, and it is the one that matters: a stdout-purity test that reads a merged stream can pass while stdout is filthy or fail while it is clean. Every JSON assertion now reads `Result.stdout`, and `test_json_stdout_parses_in_a_real_subprocess` proves the contract end-to-end where the two streams are genuinely separate files (with `PYTHONPATH` pinned to the same source tree the test imported, so a linked worktree is never silently tested against the main checkout).

The stale dist-info itself is container-image state, not repo state — see "Left out" below.

## Proof

```
$ sac dev timer list          # WORKTREE source, real process
  accounts-keepalive       every 15min
  accounts-refresh         every 2h
  fleet-reconcile          every 5min
  freshness-refresh        every 1h
  heal-agent-auth          every 10min
  host-sync-check          every 1h
  restart-login-expired-agents every 5min
  spartan-sif-bake         every 10min
  worktree-gc              every 1d
REAL_RC_TIMER_LIST=0          # nine timers, non-empty — the whole point

$ sac dev service list
No sac service jobs.
REAL_RC_SERVICE_LIST=0        # a TRUE empty: sac declares no kind="service" job
                              # (`sac listen` is deliberately NOT federated)
```

Tests (worktree source via `PYTHONPATH`):

```
tests/…/cli_pkg/test__dev_jobs.py            41 tests
tests/…/cli_pkg/test__dev_jobs_backend.py    13 tests
tests/…/_jobs/test__jobs_audit.py            21 tests
tests/…/_jobs/test__names.py                 10 tests
tests/…/_jobs/test__jobs_plugin.py           55 tests
140 passed in 73.85s          REAL_RC=0
```

## Deliberately left out — and why

- **The canonical rename to `scitex-agent-container-<name>`.** It changes the DERIVED UNIT FILENAME of every sac job, so installing the renamed units without first stopping and removing the old ones leaves two units running the same command. For `sac.accounts-refresh` — the fleet's SOLE OAuth refresher against a SINGLE-USE refresh token — two refreshers revoke each other's access token fleet-wide. That rename must ship WITH the migration verb that enforces stop → remove → install and makes install-before-uninstall impossible, so it is the next PR in this stack, not a rider on a CLI-surface change. `_jobs/_names.JOB_PREFIX` is the seam it flips. **This PR changes no job name, so merging it changes nothing on any host.**
- **A `service` JobSpec for `sac listen`.** Same hazard, documented at length in `_jobs_plugin.py`: the hand-written `sac-listen.service` (hyphen) is supervising the host right now, and a `sac.listen` JobSpec derives `sac.listen.service` (dot) — a different unit. It belongs with the migration.
- **Cleaning the stale `~citex_agent_container-0.21.13.dist-info`.** It is container/venv state baked into the image, shared with other agents; deleting it from inside a code card is an unrequested side effect on someone else's environment. Remediation is an image/host action: remove that `~`-prefixed leftover (pip already treats it as garbage) and `pip install -U --force-reinstall scitex-dev` for the duplicate `scitex_dev-0.38.0` / `0.43.1` dist-infos, which sac's own linter warns about on every run.
