### PR TITLE
fix(listen-clients): a client timeout must OUTLIVE the server's deadline, not equal it

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_in_sif_broker.py
+++ b/src/scitex_agent_container/_lifecycle/_in_sif_broker.py
@@ -45,6 +45,17 @@ import logging
 import os
 from typing import Any, Callable
 
+# Module level, NOT deferred into the function. The deferred ``_spawn_client``
+# import below is guarded by a "avoids a cycle if the spawn client ever grows
+# back-references" comment; that reasoning does not transfer here.
+# ``_listen/__init__.py`` is EMPTY and ``_handler_deadline`` imports nothing but
+# ``time``, so this can neither cycle nor drag the listen server in — and
+# ``_spawn_client``, which this module already calls on the production path,
+# imports the very same name at ITS module level. A function-local import here
+# would buy nothing and hide the coupling that is the whole point: this client's
+# timeout is DERIVED from the server's declared deadline.
+from .._listen._handler_deadline import client_timeout_for
+
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -122,7 +133,7 @@ def broker_start_to_host(
     overwrite: bool = False,
     base_url: str | None = None,
     bearer: str | None = None,
-    timeout_s: float = 30.0,
+    timeout_s: float | None = None,
     opener: Callable | None = None,
     foreground: bool = False,
     one_shot: bool = False,
@@ -165,9 +176,33 @@ def broker_start_to_host(
         ``""`` to force the unauthenticated branch; production passes
         ``None``.
     timeout_s
-        Per-request HTTP timeout (seconds). Defaults to 30 — long
-        enough for the host's ``sac agent start`` subprocess to return
-        on a healthy box.
+        Per-request HTTP timeout (seconds). ``None`` (the default)
+        DERIVES it from the server's declared answer-by deadline via
+        :func:`.._listen._handler_deadline.client_timeout_for` — the
+        deadline plus ``CLIENT_MARGIN_S``. Pass a number only to
+        override (tests do).
+
+        IT USED TO DEFAULT TO A HAND-PICKED ``30.0``, "long enough for
+        the host's ``sac agent start`` subprocess to return on a healthy
+        box". That reasoning predates the deadline model, and the number
+        landed EXACTLY on ``AGENT_START_DEADLINE_S``: the server is
+        entitled to spend the whole 30s before answering, and
+        ``client_timeout_for`` exists to add the margin that lets the
+        answer arrive. Hardcoding the deadline here cancelled that
+        margin, so the 202 "accepted, still in flight" — the message the
+        server sends PRECISELY so a slow spawn is not mistaken for a
+        dead one — lost the race by construction.
+
+        Measured 2026-08-11: a spawn over this path was reported as "no
+        response" while the host had ACCEPTED it and worked on it for
+        5m12s (``started_at`` 06:15:08Z, ``failed_at`` 06:20:20Z, phase
+        ``container_creation``). The caller read its own impatience as
+        the peer being dead and escalated a healthy route as wedged.
+
+        ``_spawn_client`` had already named this shape when it replaced
+        "TWO independently-picked constants ... that had to stay ordered
+        with no reviewer of either file able to see the other". This
+        module held a THIRD copy, and it was the one nobody noticed.
     opener
         Optional ``urllib.request.urlopen``-shaped callable. The
         in-SIF integration tests pass a fake opener so the wire shape
@@ -203,6 +238,14 @@ def broker_start_to_host(
     # surface lean and avoids a cycle if the spawn client ever grows
     # back-references to lifecycle modules.
     from ._spawn_client import SpawnRequestError, request_spawn
+
+    # Resolve at CALL time, not import time: ``client_timeout_for`` reads the
+    # server's deadline live, so a deployment that moves the deadline moves
+    # this with it. A module-level ``_DEFAULT = client_timeout_for()`` would
+    # snapshot the value once and quietly stop tracking — the same freeze that
+    # made a 30.0 sitting on top of a 30.0 deadline look correct for months.
+    if timeout_s is None:
+        timeout_s = client_timeout_for()
 
     try:
         return request_spawn(

--- a/src/scitex_agent_container/_lifecycle/_in_sif_http_client.py
+++ b/src/scitex_agent_container/_lifecycle/_in_sif_http_client.py
@@ -47,7 +47,21 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["HostListenTransportError", "host_listen_call"]
 
-_DEFAULT_TIMEOUT_S = 30.0
+# DERIVED from the server's declared answer-by deadline, never hand-picked —
+# same rule, same reason, same module as :mod:`._spawn_client`.
+#
+# This client is GENERIC (``/agents/<name>`` GET / DELETE / send / tail), and
+# for those routes a hand-picked number is harmless because the host answers in
+# milliseconds. But one caller uses it for ``POST /agents`` — the ONE route in
+# this system that DECLARES an answer-by deadline (``sac agents
+# spawn-from-here``, see :mod:`..cli_pkg._spawn_from_here`). The old default was
+# a flat ``30.0``, i.e. EXACTLY ``AGENT_START_DEADLINE_S``, so on that route the
+# client gave up at the precise moment the server was still entitled to be
+# working, and destroyed the 202 "accepted, still in flight" that exists to stop
+# a slow spawn being reported as a dead host. A shared default must satisfy the
+# STRICTEST route it is used on; the extra ~10s costs nothing on the fast ones,
+# where it only ever lengthens an already-failing wait.
+from .._listen._handler_deadline import client_timeout_for
 
 
 class HostListenTransportError(RuntimeError):
@@ -138,7 +152,7 @@ def host_listen_call(
     body: dict | None = None,
     base_url: str | None = None,
     bearer: str | None = None,
-    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    timeout_s: float | None = None,
     opener: Callable | None = None,
 ) -> tuple[int, Any]:
     """Call the host listen and return ``(http_status, parsed_body)``.
@@ -163,9 +177,14 @@ def host_listen_call(
             wins.
         bearer: Override ``SAC_LISTEN_BEARER``. Tests pass explicit
             values; production passes ``None``.
-        timeout_s: Per-request timeout. Default 30 seconds — enough
-            for the host's verb subprocess (a DELETE SIGTERMs a pid,
-            a GET reads a small JSON, neither should be slow).
+        timeout_s: Per-request timeout. ``None`` (the default) DERIVES
+            it from the server's declared answer-by deadline via
+            ``client_timeout_for()``, resolved at CALL time so it
+            follows the deadline instead of snapshotting it. Most
+            routes here are fast (a DELETE SIGTERMs a pid, a GET reads
+            a small JSON), but ``POST /agents`` is deadline-bounded and
+            a client that does not outlive that deadline manufactures a
+            failure out of a spawn that is merely still running.
         opener: Optional ``urllib.request.urlopen``-shaped callable.
             Default ``urlrequest.urlopen``; tests inject a fake
             opener that returns a urllib-response-shaped object so
@@ -183,6 +202,11 @@ def host_listen_call(
             ``url`` attribute carries the full URL so the outcome
             builder can echo it into stdout.
     """
+    # Resolved at CALL time so the number tracks the server's deadline rather
+    # than snapshotting whatever it happened to be at import.
+    if timeout_s is None:
+        timeout_s = client_timeout_for()
+
     resolved_base = _resolve_base_url(base_url)
     resolved_bearer = _resolve_bearer(bearer)
     rel = path if path.startswith("/") else f"/{path}"

--- a/src/scitex_agent_container/_lifecycle/_spawn_client.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_client.py
@@ -72,10 +72,15 @@ __all__ = ["SpawnRequestError", "request_spawn"]
 # the server's wait is unbounded by construction (the OAuth settle window is
 # held INSIDE an exclusive flock), so the fix had to be the server learning to
 # SAY "still in flight". ``_handler_deadline`` is import-free (stdlib only).
+#
+# Resolved per CALL (see ``request_spawn``), not once into a module constant.
+# ``_DEFAULT_TIMEOUT_S = client_timeout_for()`` used to live here and it read as
+# a derivation, but a module constant is computed at import and then holds still
+# — move ``AGENT_START_DEADLINE_S`` and the server follows it (it reads the name
+# inside the handler) while this snapshot does not. The ordering client > server
+# would invert silently, which is the bug this comment is about, arriving by way
+# of its own fix.
 from .._listen._handler_deadline import client_timeout_for
-
-_DEFAULT_TIMEOUT_S = client_timeout_for()
-
 
 # Request-construction plumbing — where do I send this, and as whom — now lives
 # in ._listen_client_resolve. It was never spawn-specific: _host_exec_client
@@ -132,7 +137,7 @@ def request_spawn(
     overwrite: bool = False,
     base_url: str | None = None,
     bearer: str | None = None,
-    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    timeout_s: float | None = None,
     opener: Callable | None = None,
     foreground: bool = False,
     one_shot: bool = False,
@@ -165,8 +170,11 @@ def request_spawn(
         Override ``SAC_LISTEN_BEARER``. Tests pass either an explicit
         value or ``""`` to force the unauthenticated branch.
     timeout_s
-        Per-request HTTP timeout (seconds). Defaults to 30 — long enough
-        for the server's ``sac agent start`` subprocess to return.
+        Per-request HTTP timeout (seconds). ``None`` (the default)
+        DERIVES it from the server's declared answer-by deadline via
+        ``client_timeout_for()`` — that deadline plus ``CLIENT_MARGIN_S``,
+        resolved on every call so it can never fall behind the deadline
+        it is supposed to outlive.
     opener
         Optional ``urllib.request.urlopen``-shaped callable. Default
         ``urlrequest.urlopen``; tests inject a fake opener that returns
@@ -240,6 +248,9 @@ def request_spawn(
         (including 403 ACL deny), or malformed-but-otherwise-OK body
         the server itself would reject.
     """
+    if timeout_s is None:
+        timeout_s = client_timeout_for()
+
     if not isinstance(child_name, str) or not child_name:
         raise SpawnRequestError("child_name must be a non-empty string")
 

--- a/src/scitex_agent_container/_listen/_handler_deadline.py
+++ b/src/scitex_agent_container/_listen/_handler_deadline.py
@@ -84,15 +84,30 @@ AGENT_START_DEADLINE_S = 30.0
 CLIENT_MARGIN_S = 10.0
 
 
-def client_timeout_for(server_deadline_s: float = AGENT_START_DEADLINE_S) -> float:
+def client_timeout_for(server_deadline_s: float | None = None) -> float:
     """Return the socket timeout a client should use against a bounded route.
 
     Derived, never guessed: a client MUST outlive the server's own answer-by
     deadline, otherwise it destroys the very 202 that tells it the work is
     still in flight — and then reports the timeout as a failure, which is the
     original bug wearing a new number.
+
+    ``None`` resolves ``AGENT_START_DEADLINE_S`` HERE, in the body, at call
+    time. It used to be the signature default — and a default argument is
+    evaluated ONCE, when this module is first imported, so that spelling
+    captured the VALUE and stopped tracking the NAME. The server does not:
+    :func:`._agent_exec.agents_start` imports ``AGENT_START_DEADLINE_S`` inside
+    the function and therefore reads it live. Move the deadline and the server
+    would honour the new number while every client still waited for the old
+    one — ``client > server`` silently inverts, which is precisely the failure
+    this module exists to prevent, reintroduced through the derivation itself.
+    ``CLIENT_MARGIN_S`` was already read live in the body; now both halves of
+    the sum are.
     """
-    return float(server_deadline_s) + CLIENT_MARGIN_S
+    deadline = (
+        AGENT_START_DEADLINE_S if server_deadline_s is None else server_deadline_s
+    )
+    return float(deadline) + CLIENT_MARGIN_S
 
 
 def accepted_payload(

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
@@ -26,8 +26,6 @@ markers (TQ002), one assertion (TQ007), 3+-word name.
 
 from __future__ import annotations
 
-from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
-
 import json
 import os
 from pathlib import Path
@@ -41,9 +39,14 @@ from scitex_agent_container._lifecycle._in_sif_broker import (
     is_in_sif,
 )
 from scitex_agent_container._lifecycle._start import agent_start
+from scitex_agent_container._listen._handler_deadline import (
+    AGENT_START_DEADLINE_S,
+    client_timeout_for,
+)
 from scitex_agent_container._state import state_db
 from scitex_agent_container._state.registry import Registry
 from scitex_agent_container.config import AgentConfig
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
 
 # ---------------------------------------------------------------------------
 # Real (non-mock) fake response + opener (urllib protocol)
@@ -286,6 +289,59 @@ def test_broker_raises_on_host_listen_acl_deny(listen_env) -> None:
 
 
 # ---------------------------------------------------------------------------
+# The client must OUTLIVE the server's declared deadline (incident 2026-08-11)
+#
+# ``broker_start_to_host`` hardcoded ``timeout_s=30.0`` — the SAME number as
+# ``AGENT_START_DEADLINE_S``, which is the budget the handler is ENTITLED to
+# spend before it answers. Equal is not enough. ``client_timeout_for`` adds
+# ``CLIENT_MARGIN_S`` precisely so the answer can still reach a client that is
+# listening — including the ``202`` "accepted, still in flight" the server sends
+# so a slow spawn is not mistaken for a dead host. Landing the client on the
+# deadline cancelled that margin and made the client give up at the exact moment
+# the server was still legitimately working.
+#
+# Measured that day: a spawn over this path was reported as "no response" while
+# the host had ACCEPTED it and worked for 5m12s (started_at 06:15:08Z,
+# failed_at 06:20:20Z, phase container_creation). A healthy route was escalated
+# as wedged on the strength of that false timeout.
+#
+# These assert the ORDERING against the real derivation, never a literal 40.0 —
+# pinning the number would re-freeze the same coupling one layer up and would
+# stay green through exactly the next drift it is meant to catch.
+# ---------------------------------------------------------------------------
+
+
+def test_broker_client_timeout_outlives_server_deadline(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"child","returncode":0}')
+    # Act
+    broker_start_to_host("child", opener=opener)
+    # Assert — STRICTLY greater. The old 30.0 sat exactly on the deadline.
+    assert captured["timeout"] > AGENT_START_DEADLINE_S
+
+
+def test_broker_client_timeout_equals_the_one_derivation(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"child","returncode":0}')
+    # Act
+    broker_start_to_host("child", opener=opener)
+    # Assert — derived from the server's deadline, not picked a third time.
+    assert captured["timeout"] == pytest.approx(client_timeout_for())
+
+
+def test_broker_honours_an_explicit_timeout_override(listen_env) -> None:
+    # Arrange — the derivation is the DEFAULT, not a lock; callers may override.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"child","returncode":0}')
+    # Act
+    broker_start_to_host("child", opener=opener, timeout_s=1.5)
+    # Assert
+    assert captured["timeout"] == pytest.approx(1.5)
+
+
+# ---------------------------------------------------------------------------
 # PR-α (lead msg d96a468c 2026-06-06): cohort one-shot diagnostic chain.
 # ``broker_start_to_host`` and ``maybe_broker_in_sif_spawn`` forward
 # ``foreground`` / ``one_shot`` to ``request_spawn`` → body fields → host
@@ -438,19 +494,21 @@ def _write_spec(yaml_root: Path, name: str) -> Path:
     agent_dir.mkdir(parents=True)
     spec = agent_dir / "spec.yaml"
     spec.write_text(
-        explicitize_yaml("apiVersion: scitex-agent-container/v3\n"
-        "kind: Agent\n"
-        "spec:\n"
-        "  runtime: apptainer\n"
-        "  host: ${HOSTNAME}\n"
-        f"  workdir: {yaml_root / (name + '-work')}\n"
-        "  apptainer:\n    image: /x.sif\n    binds: []\n"
-        "  restart:\n    policy: on-failure\n    max_retries: 3\n"
-        "  claude:\n"
-        "    model: sonnet\n"
-        "  health:\n"
-        "    enabled: false\n"
-        "    interval: 60\n")
+        explicitize_yaml(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            "spec:\n"
+            "  runtime: apptainer\n"
+            "  host: ${HOSTNAME}\n"
+            f"  workdir: {yaml_root / (name + '-work')}\n"
+            "  apptainer:\n    image: /x.sif\n    binds: []\n"
+            "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+            "  claude:\n"
+            "    model: sonnet\n"
+            "  health:\n"
+            "    enabled: false\n"
+            "    interval: 60\n"
+        )
     )
     return spec
 

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_http_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_http_client.py
@@ -20,6 +20,10 @@ from scitex_agent_container._lifecycle._in_sif_http_client import (
     _resolve_bearer,
     host_listen_call,
 )
+from scitex_agent_container._listen._handler_deadline import (
+    AGENT_START_DEADLINE_S,
+    client_timeout_for,
+)
 
 # ---------------------------------------------------------------------------
 # Test doubles — fake urlopen-shaped opener
@@ -280,6 +284,81 @@ def test_no_bearer_header_when_bearer_empty() -> None:
     )
     # Assert
     assert "Authorization" not in captured["headers"]
+
+
+# ---------------------------------------------------------------------------
+# Socket timeout — must OUTLIVE the server's declared deadline (2026-08-11)
+#
+# This client is generic, but ONE of its callers points it at ``POST /agents``
+# (``sac agents spawn-from-here``), the one route in this system that DECLARES
+# an answer-by deadline. The default here was a flat ``30.0`` — EXACTLY
+# ``AGENT_START_DEADLINE_S`` — so on that route the client gave up at the precise
+# moment the handler was still entitled to be working, and destroyed the ``202``
+# "accepted, still in flight" that exists to stop a slow spawn being reported as
+# a dead host. Measured that day on the sibling broker path: a spawn reported as
+# "no response" had been accepted and ran for 5m12s.
+#
+# A shared default has to satisfy the STRICTEST route it is used on. Asserted as
+# an ORDERING against the real derivation, never as a literal number.
+# ---------------------------------------------------------------------------
+
+
+def test_socket_timeout_outlives_the_server_deadline() -> None:
+    # Arrange
+    captured: dict[str, Any] = {}
+
+    def _opener(_req, timeout=None):  # noqa: ARG001
+        captured["timeout"] = timeout
+        return _FakeResponse(200, b"{}")
+
+    # Act
+    host_listen_call(
+        "POST",
+        "/agents",
+        body={"name": "c"},
+        base_url="http://x",
+        bearer="",
+        opener=_opener,
+    )
+    # Assert — STRICTLY greater; the old 30.0 sat exactly on the deadline.
+    assert captured["timeout"] > AGENT_START_DEADLINE_S
+
+
+def test_socket_timeout_equals_the_one_derivation() -> None:
+    # Arrange
+    captured: dict[str, Any] = {}
+
+    def _opener(_req, timeout=None):  # noqa: ARG001
+        captured["timeout"] = timeout
+        return _FakeResponse(200, b"{}")
+
+    # Act
+    host_listen_call(
+        "GET", "/v1/health", base_url="http://x", bearer="", opener=_opener
+    )
+    # Assert
+    assert captured["timeout"] == pytest.approx(client_timeout_for())
+
+
+def test_explicit_timeout_argument_is_honoured() -> None:
+    # Arrange — the derivation is the DEFAULT, not a lock.
+    captured: dict[str, Any] = {}
+
+    def _opener(_req, timeout=None):  # noqa: ARG001
+        captured["timeout"] = timeout
+        return _FakeResponse(200, b"{}")
+
+    # Act
+    host_listen_call(
+        "GET",
+        "/v1/health",
+        base_url="http://x",
+        bearer="",
+        timeout_s=2.5,
+        opener=_opener,
+    )
+    # Assert
+    assert captured["timeout"] == pytest.approx(2.5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_listen/test__agent_exec_deadline.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_deadline.py
@@ -317,6 +317,27 @@ def test_a_client_timeout_outlives_the_server_deadline() -> None:
     assert client > server
 
 
+def test_a_client_timeout_tracks_a_moved_deadline(short_deadline) -> None:
+    """The derivation must READ the deadline, not a copy taken at import.
+
+    ``client_timeout_for`` used to spell its default
+    ``server_deadline_s=AGENT_START_DEADLINE_S`` in the SIGNATURE, and a default
+    argument is evaluated once, when the module is first imported — so it held
+    the value and stopped tracking the name. The handler does not: it imports
+    ``AGENT_START_DEADLINE_S`` inside the function body and honours a moved
+    deadline on the next call. Move it and the server answers on the new budget
+    while every client still waits on the old one; ``client > server`` inverts
+    in silence, which is exactly the failure this module exists to prevent,
+    arriving through the derivation that was supposed to prevent it.
+    """
+    # Arrange — the fixture has moved the server's declared deadline.
+    moved = short_deadline
+    # Act
+    client = _handler_deadline.client_timeout_for()
+    # Assert
+    assert client == pytest.approx(moved + _handler_deadline.CLIENT_MARGIN_S)
+
+
 def test_a_deadline_never_reports_negative_remaining() -> None:
     """Callers hand this straight to asyncio.wait_for, which rejects negatives."""
     # Arrange


### PR DESCRIPTION
## The bug

`_in_sif_broker.broker_start_to_host` took `timeout_s: float = 30.0` — exactly
`AGENT_START_DEADLINE_S`. The handler is *entitled* to spend that whole window
before answering, and `client_timeout_for()` adds `CLIENT_MARGIN_S` precisely so
the answer can still reach a client that is listening — including the `202`
"accepted, still in flight" the server sends so a slow spawn is not mistaken for
a dead host. Landing the client on the deadline cancelled that margin: the client
gave up at the moment the server was still legitimately working, and reported a
failure for a request that had **not** failed.

**Measured 2026-08-11.** A spawn over this path was reported as "no response"
while the host had ACCEPTED it and worked on it for **5m12s** (`started_at`
06:15:08Z, `failed_at` 06:20:20Z, phase `container_creation`). A healthy route was
escalated as wedged on the strength of that false timeout.

## The class, not just the instance

Four copies of the same mistake; only the first was live:

| site | before | live bug? |
|---|---|---|
| `_in_sif_broker.broker_start_to_host` | `30.0`, **equal** to the deadline | **yes** — the incident above |
| `_in_sif_http_client.host_listen_call` | generic `30.0`, also **equal** — and `sac agents spawn-from-here` points it at the same deadline-bounded `POST /agents` | **yes** |
| `_spawn_client._DEFAULT_TIMEOUT_S` | derived (40.0), but computed **once at import** into a module constant | latent |
| `client_timeout_for` itself | `server_deadline_s=AGENT_START_DEADLINE_S` as a **signature default** — also evaluated once at import | latent |

The last two are the same defect wearing the derivation's clothes. The server
reads the deadline **live** (`agents_start` imports `AGENT_START_DEADLINE_S`
inside the function body); a frozen client copy does not. Move the deadline and
the server honours the new number while every client waits on the old one —
`client > server` inverts in silence, through the mechanism built to prevent it.

All four now resolve at **call** time. `timeout_s=None` means "ask
`client_timeout_for`"; an explicit value is still honoured.

## On the function-local import

Deliberately **module level**, not deferred. The deferred `_spawn_client` import
beside it carries a cycle-avoidance comment that does not transfer:
`_listen/__init__.py` is empty and `_handler_deadline` imports nothing but `time`,
so this can neither cycle nor drag the listen server in — and `_spawn_client`,
which `_in_sif_broker` already calls on the production path, imports the very same
name at its own module level.

## Tests

Assert the **ordering** against the real derivation (`> AGENT_START_DEADLINE_S`,
`== client_timeout_for()`), never the literal `40.0` — pinning the number would
re-freeze the same coupling one layer up and stay green through exactly the next
drift it is meant to catch. Plus one test that moves the deadline and checks the
derivation follows it.

**Measured against the pre-fix source** (fix stashed, same tests, same
interpreter): 5 assertions FAIL. They pass after.

```
FAILED test__in_sif_broker.py::test_broker_client_timeout_outlives_server_deadline
FAILED test__in_sif_broker.py::test_broker_client_timeout_equals_the_one_derivation
FAILED test__in_sif_http_client.py::test_socket_timeout_outlives_the_server_deadline
FAILED test__in_sif_http_client.py::test_socket_timeout_equals_the_one_derivation
FAILED test__agent_exec_deadline.py::test_a_client_timeout_tracks_a_moved_deadline
```

## Proof of the run

Every test file that imports or exercises a changed module — 22 files, 453 tests,
run against **this worktree's** source (`SOURCE_UNDER_TEST` printed and checked):

```
3 failed, 450 passed in 1206.33s      real rc=1
```

The three failures are **pre-existing on develop**, measured, not assumed:

- `test__broker_self.py` (2 here) — spawns a real `sac listen` subprocess and
  binds a port. Baselined on unmodified develop (its own tests, its own src):
  **5 failed, 7 passed**. Load-dependent; a different subset fails each run.
- `test__agent_exec_deadline.py::test_a_late_failure_marker_carries_the_real_exit_code`
  — the late-marker family. The develop baseline of that same file fails its
  sibling `test_a_failure_after_the_202_still_writes_its_marker`. Flaky, and
  independent of anything in this diff (it drives the server handler; this PR
  touches client socket timeouts).

## Not changed, but worth knowing

- `_restart_client._DEFAULT_TIMEOUT_S = 60.0` against `POST /agents/<name>/restart`,
  which declares **no** answer-by deadline at all. 60 > 30 so it is not the bug
  fixed here, but it is still a hand-picked client bound over an unbounded server
  operation — the original shape, one route over. Fixing it means giving that
  route a deadline first, which is a design change, not a one-liner.
- `cli_pkg/_send_broker._DEFAULT_TIMEOUT_S = 10.0` on `/agents/<name>/send`: same
  situation, smaller stakes.
- `test__in_sif_broker.py::test_agent_start_not_in_sif_uses_local_runtime` leaves
  `_session_state.DEFAULT_STATE_ROOT` outside the sandbox floor. Harmless in a full
  run (a later fixture repairs it) but running that file with only
  `test__in_sif_http_client.py` after it trips conftest's state-floor guard on
  every subsequent teardown. Pre-existing; also reproduces on develop's source.
