### PR TITLE
test(host): read --json payloads from stdout, not click 8.2's merged output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,15 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "click>=8.0",
+    # >=8.2, not >=8.0: the test suite asserts that a ``--json`` command's
+    # payload reaches STDOUT ALONE (``CliRunner`` ``result.stdout``), which
+    # is only a separate stream from 8.2 on. Before 8.2, ``CliRunner``
+    # defaulted to ``mix_stderr=True`` and ``result.stdout`` WAS the merged
+    # stream — so those assertions would silently pass on merged output and
+    # stop pinning anything. ``mix_stderr`` was removed in 8.2, so no single
+    # call spells "stdout only" on both sides of the boundary and a
+    # compatibility shim is not possible; the floor has to move instead.
+    "click>=8.2",
     "pyyaml>=6.0",
     # Round-trip YAML writer used by ``sac host add/remove/set`` so
     # operator-authored comments + key order in config.yaml survive a

--- a/tests/scitex_agent_container/_state/test_host_config.py
+++ b/tests/scitex_agent_container/_state/test_host_config.py
@@ -38,7 +38,19 @@ def _parse_probe_json(result, *, expect_exit: int = 0) -> dict:
 
     1. The CLI exit code matches ``expect_exit`` (probe payload is only
        trustworthy when the command ran to completion).
-    2. ``result.output`` parses as a JSON object.
+    2. ``result.stdout`` parses as a JSON object.
+
+    **stdout, not ``result.output``.** Since click 8.2 ``result.output``
+    is not a proxy for stdout — it is an independent stream that mixes
+    stdout and stderr in write order. Any library that logs a WARNING
+    while the command runs (scitex-logging's console handler resolves
+    ``sys.stderr`` per emit, so it follows click's isolated streams)
+    lands in ``.output`` and makes it unparseable, while the payload a
+    real ``sac host probe --json | jq`` consumer receives is untouched.
+    Asserting on ``.stdout`` is both the passing assertion and the
+    faithful one. Pinned by
+    ``test_json_payload_parses_from_stdout_despite_a_library_warning``
+    in ``tests/scitex_agent_container/cli_pkg/test_host_group.py``.
 
     Returns the parsed payload so callers assert on a structured field
     (``payload["remote_canonical"]``) rather than on exact / ordered
@@ -46,14 +58,15 @@ def _parse_probe_json(result, *, expect_exit: int = 0) -> dict:
     """
     assert result.exit_code == expect_exit, (
         f"host probe exit_code={result.exit_code} (expected {expect_exit}); "
-        f"exception={result.exception!r}; output={result.output!r}"
+        f"exception={result.exception!r}; output(stdout+stderr)={result.output!r}"
     )
     try:
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
     except ValueError as exc:  # JSONDecodeError subclasses ValueError
         raise AssertionError(
             f"host probe --json did not emit parseable JSON: {exc}; "
-            f"raw output={result.output!r}"
+            f"raw stdout={result.stdout!r}; "
+            f"stdout+stderr={result.output!r}"
         ) from exc
     assert isinstance(payload, dict), (
         f"host probe --json payload is not an object: {payload!r}"
@@ -290,7 +303,7 @@ def test_host_list_returns_empty_peers_with_no_config(cfg_path: Path):
     # Act
     result = CliRunner().invoke(host_list, ["--json"])
     # Assert
-    assert json.loads(result.output)["peers"] == []
+    assert json.loads(result.stdout)["peers"] == []
 
 
 def test_host_list_renders_configured_peers(cfg_path: Path):
@@ -309,7 +322,7 @@ peers:
     # Act
     result = CliRunner().invoke(host_list, ["--json"])
     # Assert
-    assert sorted(p["name"] for p in json.loads(result.output)["peers"]) == [
+    assert sorted(p["name"] for p in json.loads(result.stdout)["peers"]) == [
         "mba",
         "spartan",
     ]
@@ -323,7 +336,7 @@ def test_host_validate_passes_for_clean_config(cfg_path: Path):
     # Act
     result = CliRunner().invoke(host_validate, ["--json"])
     # Assert
-    assert json.loads(result.output)["errors"] == []
+    assert json.loads(result.stdout)["errors"] == []
 
 
 def test_host_validate_fails_for_unknown_via(cfg_path: Path):
@@ -341,7 +354,7 @@ peers:
     # Act
     result = CliRunner().invoke(host_validate, ["--json"])
     # Assert
-    assert "does-not-exist" in json.loads(result.output)["errors"][0]
+    assert "does-not-exist" in json.loads(result.stdout)["errors"][0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/cli_pkg/test_host_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_host_group.py
@@ -17,8 +17,10 @@ carries a 3+-word behaviour name (TQ003).
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -182,7 +184,7 @@ def test_host_probe_unknown_peer_json_reports_unreachable(cfg_path: Path):
     # Act
     result = CliRunner().invoke(host_probe, ["ghost", "--json"])
     # Assert
-    assert json.loads(result.output)["reachable"] is False
+    assert json.loads(result.stdout)["reachable"] is False
 
 
 def test_host_probe_unknown_peer_json_exits_with_code_2(cfg_path: Path):
@@ -252,4 +254,82 @@ def test_host_probe_malformed_remote_stdout_yields_null_canonical(
     # Act
     result = CliRunner().invoke(host_probe, ["mba", "--json"])
     # Assert
-    assert json.loads(result.output)["remote_canonical"] is None
+    assert json.loads(result.stdout)["remote_canonical"] is None
+
+
+# ---------------------------------------------------------------------------
+# `--json` payloads belong to STDOUT — the stream a `| jq` consumer reads.
+# ---------------------------------------------------------------------------
+
+
+_RETIRED_ALIAS_WARNING = (
+    "'nas' is a RETIRED host alias — use 'scitex-nas-03'. "
+    "The seeder cannot repair this on its own."
+)
+
+
+@pytest.fixture
+def json_run_with_library_warning(cfg_path: Path):
+    """Run sac's real ``host list --json`` while a library logs a WARNING.
+
+    Reproduces the condition that took ``pytest-matrix`` red across 18 open
+    PRs. ``sac host list --json`` resolves the host registry through
+    ``scitex_dev.hosts``, whose seeder logs a WARNING when it meets a RETIRED
+    host alias — it names the successor and explains why it cannot repair
+    itself. The warning is correctly on STDERR, so a real
+    ``sac host list --json | jq`` was never broken; what broke was every
+    ASSERTION written against ``result.output``. From click 8.2 that
+    attribute stopped proxying stdout and became an independent stream
+    MIXING stdout and stderr in write order, and scitex-logging's console
+    handler re-resolves ``sys.stderr`` on every emit — so it follows click's
+    isolated streams and its ``WARN:`` line interleaves ahead of the payload.
+
+    Everything is real (PA-306, no mocks): a real ``logging`` logger, a real
+    click command, and sac's real ``host list`` callback reached through
+    ``ctx.invoke``. ``cfg_path`` names a file that is never written, so the
+    payload's ``peers`` list is legitimately empty.
+    """
+
+    @click.command("warn-then-list")
+    @click.pass_context
+    def warn_then_list(ctx: click.Context) -> None:
+        logging.getLogger("scitex_dev.hosts._retired").warning(_RETIRED_ALIAS_WARNING)
+        ctx.invoke(host_list, all_interfaces=False, as_json=True)
+
+    return CliRunner().invoke(warn_then_list, [])
+
+
+def test_json_payload_parses_from_stdout_despite_a_library_warning(
+    json_run_with_library_warning,
+):
+    """The ``--json`` payload parses from STDOUT ALONE — what ``| jq`` gets.
+
+    ``result.stdout``, never ``result.output``: an assertion on the merged
+    stream passes while the bug is present, which is worse than no test. It
+    also fails loudly under click < 8.2, where ``mix_stderr=True`` made
+    ``result.stdout`` the merged stream too — that is what the ``click>=8.2``
+    floor in pyproject.toml exists to guarantee.
+    """
+    # Arrange
+    result = json_run_with_library_warning
+    # Act
+    payload = json.loads(result.stdout)
+    # Assert
+    assert payload["peers"] == []
+
+
+def test_library_warning_reaches_the_merged_cli_runner_output(
+    json_run_with_library_warning,
+):
+    """The warning IS emitted — so the sibling stdout test cannot pass vacuously.
+
+    Its presence in ``result.output`` is also the direct evidence for why
+    that attribute is unusable as a JSON source: click 8.2 interleaves the
+    stderr ``WARN:`` line into it, ahead of the payload.
+    """
+    # Arrange
+    result = json_run_with_library_warning
+    # Act
+    merged = result.output
+    # Assert
+    assert _RETIRED_ALIAS_WARNING in merged


### PR DESCRIPTION
## Why `pytest-matrix` is red

18 open PRs are blocked — including #958, which carries the fleet relocation to
scitex-compute-04 — by 7 failures, every one a `json.loads(...)` over a
`sac host list / probe / validate --json` payload:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

**Stdout is not corrupted, and `sac host list --json | jq` is not broken.**
scitex-dev's host-registry seeder logs a WARNING when it meets a retired host
alias — naming the successor and explaining why it cannot repair itself — and
that warning goes to **stderr**, where it belongs. It is `logger.warning(...)`
through `scitex_logging`, whose `create_console_handler` returns a
`LazyStderrStreamHandler`; there is no stdout handler on any path.

**What changed is click.** From 8.2, `CliRunner`'s `result.output` stopped being
a proxy for `result.stdout` and became an independent stream **mixing stdout and
stderr in write order**. `LazyStderrStreamHandler` re-resolves `sys.stderr` on
every emit, so it follows click's isolated streams and its `WARN:` line
interleaves ahead of the payload in `.output`. The failing assertions parsed
`.output`.

## The change

Assert on `result.stdout`. That is also the *more faithful* assertion — it is
exactly what a `| jq` consumer receives.

| site | status |
|---|---|
| `tests/.../\_state/test_host_config.py` `_parse_probe_json` helper | failing (4 of 7) |
| `tests/.../\_state/test_host_config.py:293`, `:312` | failing (2 of 7) |
| `tests/.../cli_pkg/test_host_group.py:255` | failing (1 of 7) |
| `test_host_config.py:326`, `:344`, `test_host_group.py:185` | latent — same path, same one-token fix |

Diagnostic strings in `_parse_probe_json` move with it: the parse-failure
message now shows the stdout that actually failed to parse (a message quoting
merged output would show the `WARN:` line and mislead the next reader), and the
exit-code message keeps the merged stream but labels it `output(stdout+stderr)`.

### `click>=8.0` → `click>=8.2` (required, not incidental)

`result.stdout` only means "stdout alone" on click ≥ 8.2. Before 8.2,
`CliRunner` defaulted to `mix_stderr=True` and `result.stdout` **was** the merged
stream — so under a resolution that `click>=8.0` still permits, this change would
be **inert while looking correct**. A constraint that permits a broken
configuration is not a constraint. `mix_stderr` was **removed** in 8.2, so no
single call spells "stdout only" on both sides of the boundary; a compatibility
shim is impossible and the floor has to move instead.

Checked safe: the package already requires Python ≥ 3.10, which is click 8.2's
own floor, and no installed dependency caps click below 8.2 (`httpx[cli]`'s
`click==8.*` is the tightest, and it is satisfied).

### Regression test

Built from real parts only (PA-306, no mocks): a real `logging` logger warns
while sac's real `host list` callback runs under `ctx.invoke`, and the payload
must parse from `result.stdout`. A sibling test asserts the warning **did** reach
the merged `result.output`, so the first cannot pass vacuously — a test reading
merged output would pass with the bug present and is worse than no test.

## Evidence

**A/B on one real invocation, click 8.4.2 measured in the venv the run used:**

```
test_a_unfixed_assertion_on_merged_output_fails   FAILED
    json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
    output = "WARN: 'nas' is a RETIRED host alias — use 'scitex-nas-03'.\n{\n  \"config_path\"...

test_b_fixed_assertion_on_stdout_passes           PASSED
    stdout = '{\n  "config_path": null, ...'
1 failed, 1 passed  ·  real rc 1
```

**The 7 target tests plus the 2 new ones:**

```
tests/scitex_agent_container/_state/test_host_config.py ....... 
tests/scitex_agent_container/cli_pkg/test_host_group.py .......
60 passed in 27.46s  ·  REAL_RC=0
```

`ruff check` and `ruff format --check` clean on both files.

**Note on local reproduction:** the installed `/opt/venv-sac` scitex-dev carries
no `hosts/_retired.py` (0.38.0, and two dist-info dirs — a dirty install), so the
emitter does not exist there and a bare local green proves nothing. The condition
above was therefore *injected*, not hoped for.

## Not touched

- **scitex-dev** — the warning is already on the correct stream, and its content
  is right (it names the retired alias, the successor, and why the seeder cannot
  self-repair).
- **PR #952** — shows the same three leg names but its only failure is
  `tests/develop/test_audit.py::test_audit_all_clean`, and its last run predates
  the scitex-dev change. Same legs ≠ same cause; it needs its own diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcDz9gLL2Ct24FXqX2SF9T
