### PR TITLE
feat(relocate): carry the transcript across hosts, and tell the agent it moved

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_relocate_arrival.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_arrival.py
@@ -1,0 +1,136 @@
+"""The first thing a relocated agent is told — and the same message that proves it woke up.
+
+The operator's requirement, 2026-08-11:「tgt agent には『あなたは <src> から <tgt>
+に移動してきました；記憶はここで resume の id はこれです』みたいな説明もあった方が
+良さそうです。というか、ハンドシェイクが必要なはずで」
+
+An agent that resumes a carried transcript has a real problem no amount of
+transcript fixes: its conversation ends on the source host, mid-work, and nothing
+in it mentions that the machine underneath changed. Left unsaid, it will keep
+referring to paths, ports and peers that were true where the conversation
+happened and are not true where it is now — and it will do so confidently,
+because from the inside nothing looks different. So the move is stated
+explicitly, once, in the first turn after the resume.
+
+THE BRIEF IS THE HANDSHAKE CHALLENGE, NOT A SECOND MESSAGE. It carries the
+nonce and the proof-of-work question that :mod:`_relocate_handshake` evaluates,
+so the agent's answer to "where are you and what do you see" IS the B->A leg
+that gate requires. Two messages would have meant the explanation could be
+delivered to an agent that never proved it could reply — which is the
+"started, reported healthy, did nothing" shape with a friendly note attached.
+
+WHY IT IS NOT DELIVERED VIA ``startup_prompts``. That is how a TWIN gets its
+boot kick (:func:`._twin.build_twin_boot_kick`), and it works there because a
+twin is a NEW agent whose spec is being written anyway. A relocation writes
+NOTHING to a spec file — where an agent runs is an observation, and the spec is
+the human-authored intent (operator, 2026-08-11:「設定ファイル、人が書くものは
+ファイル、状態は db」). Editing ``startup_prompts`` to deliver this would put a
+one-time operational message into a git-tracked document that exists in one copy
+per machine, and it would still be there on the next boot, telling the agent it
+just relocated months after it did.
+
+WHAT THE PROOF-OF-WORK QUESTION IS FOR. An echo proves the message path. The
+question must be something the agent can only answer by looking at the machine it
+is now on, because the failure being ruled out is an agent whose loop runs and
+whose tools do not. The caller supplies both the question and the answer it
+computed independently; this module refuses to build a brief without them rather
+than letting the gate be weakened by an omission.
+
+Pure: text in, text out. No transport, no clock, no nonce generation.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "DEFAULT_HANDOVER_DOC",
+    "build_arrival_brief",
+]
+
+#: The relocation handover document — the operator's own notes for this move,
+#: pointed AT rather than inlined. The brief has to stay short enough to be read
+#: in full by an agent resuming mid-task; a pointer that is followed when needed
+#: beats a wall of context that is skimmed every time.
+DEFAULT_HANDOVER_DOC = "~/.scitex/agent-container/runtime/relocation-plan-20260811.md"
+
+
+def build_arrival_brief(
+    *,
+    agent: str,
+    from_host: str,
+    to_host: str,
+    resume_session_id: str,
+    nonce: str,
+    question: str,
+    handover_doc: str = DEFAULT_HANDOVER_DOC,
+) -> str:
+    """The message the relocated agent receives on the target, as its first new turn.
+
+    ``resume_session_id`` is the uuid whose transcript was carried and seeded —
+    the same id the target's ``session_id`` marker now holds. It is stated to the
+    agent because it is the one handle that lets it verify its own continuity:
+    an agent told "your memory was carried" and given no id cannot check the
+    claim, and this is the exact claim that was false on 2026-08-07.
+
+    ``nonce`` and ``question`` make the reply verifiable — see
+    :func:`._relocate_handshake.evaluate_handshake`, which reads both back out of
+    the answer. Both are required, and an empty one raises rather than silently
+    producing a brief whose reply proves nothing.
+    """
+    if not agent:
+        raise ValueError("build_arrival_brief needs the agent's name")
+    if not from_host or not to_host:
+        raise ValueError("build_arrival_brief needs both the source and target host")
+    if from_host == to_host:
+        raise ValueError(
+            f"build_arrival_brief: {from_host!r} to itself is not a relocation; a brief "
+            "announcing a move that did not happen would be a false statement to the agent"
+        )
+    if not resume_session_id:
+        raise ValueError(
+            "build_arrival_brief needs the resumed session id — an agent told its memory "
+            "was carried, with no id to check that against, cannot verify the one claim "
+            "that has silently been false before"
+        )
+    if not nonce:
+        raise ValueError(
+            "build_arrival_brief needs a nonce — without correlation, a reply left over "
+            "from an earlier turn satisfies 'the agent answered'"
+        )
+    if not question:
+        raise ValueError(
+            "build_arrival_brief needs a proof-of-work question — an echo proves the "
+            "message path, not the agent, and this message is the gate for the agent"
+        )
+
+    lines = [
+        f"You are {agent}, and you have RELOCATED from {from_host} to {to_host}.",
+        "",
+        "You are the same agent — same identity, same cards, same work in flight. "
+        "Only the machine underneath you changed.",
+        "",
+        "YOUR MEMORY WAS CARRIED.",
+        f"  - This session resumes transcript {resume_session_id}, copied from "
+        f"{from_host} and verified on {to_host} by byte and line count before you "
+        "were started.",
+        "  - So the conversation above this message happened on "
+        f"{from_host}. Anything it says about paths, ports, mounts, peers or "
+        f"running processes describes {from_host} and may not hold here. Re-check "
+        "before you rely on it; do not assume a path that existed there exists here.",
+        f"  - {from_host} has been stopped. You are the only instance of {agent}.",
+        "",
+        "WHERE YOUR STATE IS:",
+        f"  - Handover document: {handover_doc}",
+        "  - The scitex-todo card board is authoritative for what is in flight — "
+        "read your card slice before resuming work, not the transcript's memory of it.",
+        "",
+        "REPLY NOW, in this exact shape — this reply is the handshake that "
+        "completes the relocation, and until it is observed the move does not "
+        "proceed:",
+        f"  nonce={nonce}",
+        f"  answer=<your answer to: {question}>",
+        "",
+        "Answer it by actually looking on this host. An echoed or guessed answer "
+        "fails the check, and it fails it in the useful direction: it is how we "
+        "catch an agent whose loop runs but whose tools cannot reach anything.",
+    ]
+    return "\n".join(lines)

--- a/src/scitex_agent_container/_lifecycle/_relocate_execute.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_execute.py
@@ -9,15 +9,26 @@ that makes the sequence safe:
     BEFORE the handover, a non-yes ABORTS and nothing persistent has changed.
     AT or AFTER it, a non-yes STOPS AND REPORTS — it never rolls back.
 
-THERE IS NOTHING TO ROLL BACK BEFORE THE HANDOVER, and that is a property of the
-phase order rather than luck. No pre-handover phase writes anything durable: the
-target standby is a started process, the handshake is messages. The host is not
-written until DONE, because where an agent runs is an OBSERVATION and the
-residency record IS that write (operator, 2026-08-11: 「設定ファイル、人が書く
-ものはファイル、状態は db」). An earlier draft had a phase that rewrote the
-spec's ``host:`` and therefore needed an undo; removing it removed the only
-reversible-but-durable step, which is why ``abort`` here has no compensation to
-perform and none is offered.
+NO PRE-HANDOVER PHASE WRITES A DURABLE RECORD, and that is a property of the
+phase order rather than luck. The target standby is a started process, the
+handshake is messages, and the transport only ADDS a copy on the target (moving
+anything already there aside, never over it). The host is not written until DONE,
+because where an agent runs is an OBSERVATION and the residency record IS that
+write (operator, 2026-08-11: 「設定ファイル、人が書くものはファイル、状態は db」).
+An earlier draft had a phase that rewrote the spec's ``host:`` and therefore
+needed an undo; removing it removed the only reversible-but-durable step, which
+is why ``abort`` here has no compensation to perform and none is offered.
+
+ONE THING AN ABORT DOES LEAVE CHANGED, AND IT IS SAID OUT LOUD RATHER THAN
+COMPENSATED: from SOURCE_STOP onward the agent is stopped on the source host. The
+transport cannot read a transcript that is being appended to (see
+:mod:`._relocate_phases`), so the stop has to come first, and an abort after it
+leaves the agent down. Nothing here restarts it. Restarting a source during an
+abort is another lifecycle action taken at the moment least is known about the
+state of things, and it would race a re-run that is about to stop it again. The
+outcome's ``hint`` names the stopped agent and the one command that undoes it, so
+the operator decides — which is the same treatment ``standby_left_running``
+already gets, for the same reason.
 
 That asymmetry is not a choice made here; it is enforced by
 :func:`.._relocate_phases.abort`, which refuses at or past HANDOVER. This module
@@ -62,10 +73,12 @@ from ._relocate_phases import (
     SOURCE_DRAIN,
     SOURCE_STOP,
     TARGET_STANDBY,
+    TRANSPORT,
     Relocation,
     abort,
     advance,
     is_past_no_return,
+    leaves_source_stopped,
 )
 
 __all__ = [
@@ -150,15 +163,21 @@ class PhaseEffects:
     drain_source: Callable[[], StepResult] | None = None
     hand_over_lease: Callable[[], StepResult] | None = None
     stop_source: Callable[[], StepResult] | None = None
+    #: Copy the transcript to the target and CONFIRM it there. Required like the
+    #: rest: an omitted transport would journal as done having moved nothing, and
+    #: the agent would boot on the target with no memory — the exact 2026-08-07
+    #: failure, produced by the absence of an effect rather than a bad one.
+    transport_transcript: Callable[[], StepResult] | None = None
     finish: Callable[[], StepResult] | None = None
 
     def for_phase(self, phase: str) -> Callable[[], StepResult] | None:
         return {
+            SOURCE_DRAIN: self.drain_source,
+            SOURCE_STOP: self.stop_source,
+            TRANSPORT: self.transport_transcript,
             TARGET_STANDBY: self.start_target_standby,
             HANDSHAKE: self.handshake,
-            SOURCE_DRAIN: self.drain_source,
             HANDOVER: self.hand_over_lease,
-            SOURCE_STOP: self.stop_source,
             DONE: self.finish,
         }.get(phase)
 
@@ -183,6 +202,11 @@ class ExecuteOutcome:
     #: rather than cleaned up: stopping it would be another remote action taken
     #: at the moment least is known about the state of things.
     standby_left_running: bool = False
+    #: True when the agent is stopped on the SOURCE host and nothing restarted
+    #: it. The machine-readable half of the hint: a caller deciding whether to
+    #: page someone needs "the agent is down" as a field, not as prose it has to
+    #: match on.
+    source_left_stopped: bool = False
     log: tuple[str, ...] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
@@ -278,6 +302,7 @@ def execute(
                         f"holds the lease and {current.from_host} is fenced out. Finish "
                         "forward: re-run to resume from this phase"
                     ),
+                    source_left_stopped=leaves_source_stopped(current),
                     log=tuple(log),
                 )
             stopped, verdict = abort(
@@ -286,6 +311,10 @@ def execute(
                 reason=f"{phase}: {result.detail}",
             )
             left_running = _standby_running(current.phase, phase, unknown)
+            # Computed against the pre-abort record, for the same reason the
+            # phase machine does it: after the abort the phase is ABORTED, and
+            # the question is where it got to.
+            source_down = leaves_source_stopped(current)
             return ExecuteOutcome(
                 completed=None if unknown else False,
                 code=CODE_UNKNOWN if unknown else CODE_ABORTED,
@@ -296,6 +325,13 @@ def execute(
                     f"{result.hint} Nothing was handed over; the lease is still with "
                     f"{current.from_host}, and the host in the state db is unchanged."
                     + (
+                        f" {current.agent} is STOPPED on {current.from_host} — start "
+                        "it there to undo this, or leave it down for the re-run. Its "
+                        "transcript was copied, never moved, so it resumes intact."
+                        if source_down
+                        else ""
+                    )
+                    + (
                         f" The standby on {current.to_host} was started and is STILL "
                         "RUNNING — stop it deliberately, or leave it for the re-run."
                         if left_running
@@ -303,6 +339,7 @@ def execute(
                     )
                 ),
                 standby_left_running=left_running,
+                source_left_stopped=source_down,
                 log=tuple(log),
             )
 

--- a/src/scitex_agent_container/_lifecycle/_relocate_phases.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_phases.py
@@ -8,12 +8,46 @@ journal every transition, so that wherever it stops, the state on disk says
 where it stopped and re-running continues rather than restarts.
 
     PREFLIGHT       validate the target before touching anything
+    SOURCE_DRAIN    source finishes in-flight work, stops taking new
+    SOURCE_STOP     stop the source, VERIFY stopped
+    TRANSPORT       copy the transcript across, VERIFY it on the target
     TARGET_STANDBY  start the target WITHOUT the lease; it runs read-only
     HANDSHAKE       target -> source round trip; the source must OBSERVE a reply
-    SOURCE_DRAIN    source finishes in-flight work, stops taking new
     HANDOVER        the lease moves source -> target  <- THE atomic point
-    SOURCE_STOP     stop the source, VERIFY stopped
     DONE            append the residency record — WHICH IS the host write
+
+THE SOURCE STOPS BEFORE THE TARGET STARTS, AND THAT ORDER IS FORCED BY THE
+TRANSCRIPT rather than chosen for tidiness. Two physical constraints pin it:
+
+    a RUNNING source appends to its .jsonl while it is being read, so the copy
+    ends mid-line. jsonl carries no trailer and no length, so a torn transcript
+    is not detectably torn — it parses, it resumes, and the conversation just
+    stops early. Hence SOURCE_STOP precedes TRANSPORT.
+
+    a target that has already BOOTED owns its own session marker, and seeding
+    over it would discard whatever it did (see `_session_carry`, first-boot-only).
+    Hence TRANSPORT precedes TARGET_STANDBY.
+
+Between them there is exactly one legal slot, and it is this one. An earlier
+draft of this file ordered the target's standby first and the source's stop last,
+which reads safer — the source keeps running until the target has proven itself —
+and cannot carry a transcript at all. That version is what shipped before the
+transport existed; the reorder is the transport's precondition, not a preference.
+
+THE PRICE IS STATED RATHER THAN HIDDEN: from SOURCE_STOP onward the agent is
+DOWN on both hosts until the target comes up, and an abort in that window leaves
+it stopped. That is a real regression against the previous order and it is
+accepted, because the alternative is not "no downtime" but "no downtime and a
+silently truncated memory". The window is recoverable and named: nothing durable
+has been written, the source's own transcript is untouched (it was COPIED, never
+moved), and starting the source again restores the world exactly. `abort`'s
+verdict says so, so nobody has to infer it.
+
+WHERE AN AGENT LIVES IS STILL WRITTEN ONLY AT DONE. The source stopping early
+does NOT transfer residency: a stopped source is still the owner of record until
+the residency row is appended, so at no point do two hosts hold a claim to one
+identity. That is the invariant the reorder had to preserve, and it is preserved
+because stopping a process and owning a record are different things.
 
 THERE IS NO SPEC-EDITING PHASE, and its absence is a decision rather than an
 omission (operator, 2026-08-11: 「設定ファイル、人が書くものはファイル、状態は
@@ -32,11 +66,18 @@ though its process is still alive, so the only sane direction is forward. A
 crash on either side of that single point leaves exactly ONE writer — which is
 the property the whole sequence exists to produce (see :mod:`_relocate_lease`).
 
-THE ADDED PHASE IS BEFORE HANDOVER, and that placement is the whole reason it is
-safe to add: HANDSHAKE only sends messages and reads replies, so it moves no
-write authority and the reversible-before / forward-after asymmetry is
-unchanged. A new phase placed AFTER the handover would have broken it, because
-:func:`abort` would then be refused for a step that is trivially undoable.
+EVERY ADDED PHASE IS BEFORE HANDOVER, and that placement is the whole reason it
+is safe to add: HANDSHAKE only sends messages and reads replies and TRANSPORT
+only copies a file onto a host that is not yet serving, so neither moves write
+authority and the reversible-before / forward-after asymmetry is unchanged. A new
+phase placed AFTER the handover would have broken it, because :func:`abort` would
+then be refused for a step that is trivially undoable.
+
+TRANSPORT IS REVERSIBLE IN THE ONLY SENSE THAT MATTERS: it never modifies the
+source. The transcript is COPIED, and anything already at the destination is
+MOVED ASIDE to `.old/<ts>/` rather than overwritten, so an abort leaves both
+hosts holding everything they held before — the target merely holds an extra
+copy, which the next run overwrites by moving it aside again.
 
 WHY THE HANDSHAKE IS A PHASE AND NOT PART OF TARGET_STANDBY. "The process
 started" and "the agent can do agent work" are different measurements, and
@@ -89,30 +130,34 @@ __all__ = [
     "SOURCE_DRAIN",
     "SOURCE_STOP",
     "TARGET_STANDBY",
+    "TRANSPORT",
     "abort",
     "advance",
     "begin",
     "is_past_no_return",
+    "leaves_source_stopped",
     "resume_from",
 ]
 
 PREFLIGHT: Final = "preflight"
+SOURCE_DRAIN: Final = "source_drain"
+SOURCE_STOP: Final = "source_stop"
+TRANSPORT: Final = "transport"
 TARGET_STANDBY: Final = "target_standby"
 HANDSHAKE: Final = "handshake"
-SOURCE_DRAIN: Final = "source_drain"
 HANDOVER: Final = "handover"
-SOURCE_STOP: Final = "source_stop"
 DONE: Final = "done"
 
 #: The ordered sequence. Index in this tuple IS the ordering relation — there is
 #: no second place where the order is written, so the two cannot disagree.
 PHASES: Final[tuple[str, ...]] = (
     PREFLIGHT,
+    SOURCE_DRAIN,
+    SOURCE_STOP,
+    TRANSPORT,
     TARGET_STANDBY,
     HANDSHAKE,
-    SOURCE_DRAIN,
     HANDOVER,
-    SOURCE_STOP,
     DONE,
 )
 
@@ -229,6 +274,27 @@ def is_past_no_return(relocation: Relocation) -> bool:
     if relocation.phase == ABORTED:
         return False
     return PHASES.index(relocation.phase) >= PHASES.index(HANDOVER)
+
+
+def leaves_source_stopped(relocation: Relocation) -> bool:
+    """True when abandoning HERE leaves the agent DOWN on the source host.
+
+    The cost of ordering SOURCE_STOP before the transport (see the module
+    docstring). It is a predicate rather than a comment because the recovery
+    instruction depends on it: from SOURCE_STOP onward, "nothing was changed" is
+    true of every durable record and false of the thing the operator will
+    actually notice, and an abort that does not mention the stopped agent is a
+    reassurance that sends nobody to restart it.
+
+    ``ABORTED`` reports against the phase the relocation reached before it was
+    abandoned — the journal's last real step — because after an abort the
+    question being asked is precisely "what is still stopped".
+    """
+    phase = relocation.phase
+    if phase == ABORTED:
+        prior = [s.phase for s in relocation.steps if s.phase != ABORTED]
+        phase = prior[-1] if prior else PREFLIGHT
+    return PHASES.index(phase) >= PHASES.index(SOURCE_STOP)
 
 
 def begin(
@@ -359,13 +425,26 @@ def abort(
                 "Finish forward, or relocate back deliberately — do not undo a handover"
             ),
         )
+    # Computed BEFORE the transition, against the phase actually reached: after
+    # the replace() below the phase is ABORTED, and the question "is the agent
+    # still running" is about where it got to, not about the abort.
+    source_down = leaves_source_stopped(relocation)
     stopped = replace(
         relocation,
         phase=ABORTED,
         steps=relocation.steps + (Step(phase=ABORTED, at=now, detail=reason),),
     )
+    note = (
+        (
+            f" {relocation.agent} is STOPPED on {relocation.from_host} and nothing "
+            "restarted it — start it there to return to the pre-relocation state. "
+            "Its own transcript was never moved, only copied, so it resumes intact."
+        )
+        if source_down
+        else ""
+    )
     return stopped, PhaseVerdict(
         allowed=True,
         code=CODE_OK,
-        reason=f"{relocation.agent}: aborted at {relocation.phase} — {reason}",
+        reason=f"{relocation.agent}: aborted at {relocation.phase} — {reason}.{note}",
     )

--- a/src/scitex_agent_container/_lifecycle/_relocate_transport.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_transport.py
@@ -1,0 +1,487 @@
+"""Move the conversation across two hosts, and PROVE what landed is what left.
+
+:mod:`_relocate_transcript` verifies ONE payload by digest. This is the phase
+around it: what is allowed to travel, what to do about a target that already
+holds something, and how arrival is confirmed for a SET of files where each one
+can fail on its own.
+
+FOUR RULES, EACH FROM A WAY THIS GOES WRONG SILENTLY.
+
+1. THE SOURCE MUST BE STOPPED. A running agent appends to its ``.jsonl`` while it
+   is being read, so the copy is a prefix ending mid-line. jsonl has no trailer
+   and no length header, so a torn file is not detectably torn — it parses, it
+   resumes, and the conversation simply stops early. That is worse than no
+   transfer, because no transfer is visible and this is not. An unobserved
+   "is it running" is UNKNOWN and refuses just as firmly: the question is
+   cheap to ask and the failure is silent.
+
+2. ONLY TRANSCRIPTS TRAVEL — AN ALLOWLIST, NOT A DENYLIST. Just ``*.jsonl`` from
+   the project directory. A denylist is a list of the secrets somebody thought
+   of; the first credential file named something new travels. The one that
+   matters here is ``~/.claude/.credentials.json``, which sits one level ABOVE
+   the projects store and so is already outside the transfer root — the
+   allowlist refuses it a second time, and :data:`CREDENTIAL_BASENAMES` names it
+   so the refusal is greppable and can be asserted by name rather than inferred
+   from a suffix rule.
+
+3. NOTHING IS OVERWRITTEN AND NOTHING IS DELETED. A relocation target may well
+   have been this agent's home before, and what is there is the only copy of
+   whatever it is. An existing target directory is MOVED ASIDE to
+   ``.old/<timestamp>/`` first. Move-aside also makes a retry idempotent: the
+   second run finds a clean destination instead of merging into a half-written
+   one.
+
+4. ARRIVAL IS CONFIRMED BY CONTENT, PER FILE. ``scp`` exiting 0 says the process
+   exited 0. Bytes AND lines are compared for every file, because the two catch
+   different things: bytes catch a truncated write, lines catch the case where a
+   transport rewrote line endings and left the size plausible. A file the target
+   does not have at all is its own outcome, distinct from one that arrived short
+   — the first means the copy did not happen, the second means it happened
+   badly, and they call for different next moves.
+
+AN EXTRA FILE ON THE TARGET IS NOT A FAILURE. The destination is the agent's own
+projects directory and may legitimately hold other conversations. Every file that
+LEFT must have ARRIVED intact; nothing is claimed about files that were already
+there, and treating them as corruption would refuse a healthy relocation.
+
+Pure. No filesystem, no ssh, no clock — observations in, a verdict out, so every
+refusal path is a test with real values rather than a second machine.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Sequence
+
+__all__ = [
+    "CODE_ARRIVED",
+    "CODE_MISSING_ON_TARGET",
+    "CODE_NOTHING_TO_CARRY",
+    "CODE_READY",
+    "CODE_SOURCE_RUNNING",
+    "CODE_TRUNCATED",
+    "CODE_UNKNOWN",
+    "CREDENTIAL_BASENAMES",
+    "TRANSCRIPT_SUFFIX",
+    "ArrivalVerdict",
+    "MoveAside",
+    "TranscriptFile",
+    "TransportPlan",
+    "is_transferable",
+    "plan_transport",
+    "refusal_for",
+    "select_transferable",
+    "verify_arrival",
+]
+
+#: The ONLY suffix that travels. An allowlist — see rule 2 in the module docstring.
+TRANSCRIPT_SUFFIX: Final = ".jsonl"
+
+#: Credential files, named so the exclusion can be asserted BY NAME. These live
+#: at ``~/.claude/.credentials.json``, above the projects store, so they are
+#: already outside the transfer root; naming them makes the second refusal
+#: explicit rather than an inference from the suffix rule. A credential is
+#: re-issued on the target, never carried — a copied token means two hosts
+#: holding one identity's secret, and the source's copy outliving the source.
+CREDENTIAL_BASENAMES: Final = frozenset(
+    {".credentials.json", "credentials.json", ".credentials.json.bak"}
+)
+
+#: Everything that must travel was selected and the source is quiesced.
+CODE_READY: Final = 200
+#: There is no transcript to move. A decided no, not a failure.
+CODE_NOTHING_TO_CARRY: Final = 204
+#: The source agent is still running; copying now yields a torn transcript.
+CODE_SOURCE_RUNNING: Final = 409
+#: Every file that left arrived with matching bytes and lines.
+CODE_ARRIVED: Final = 200
+#: A file that left is absent on the target. The copy did not happen.
+CODE_MISSING_ON_TARGET: Final = 404
+#: A file arrived with fewer bytes or lines than it left with.
+CODE_TRUNCATED: Final = 422
+#: Something was not observed. Refuses as firmly as a failure, differently.
+CODE_UNKNOWN: Final = 503
+
+
+def is_transferable(name: str) -> bool:
+    """True only for a conversation transcript. Everything else stays put."""
+    base = name.rsplit("/", 1)[-1]
+    if base in CREDENTIAL_BASENAMES:
+        return False
+    return base.endswith(TRANSCRIPT_SUFFIX) and len(base) > len(TRANSCRIPT_SUFFIX)
+
+
+def refusal_for(name: str) -> str:
+    """Why ``name`` is not travelling, in words a report can print."""
+    base = name.rsplit("/", 1)[-1]
+    if base in CREDENTIAL_BASENAMES:
+        return (
+            "a credential is never carried — the target re-issues its own; copying "
+            "one would leave two hosts holding one identity's secret"
+        )
+    return (
+        f"only conversation transcripts ({TRANSCRIPT_SUFFIX}) travel; this is not one"
+    )
+
+
+@dataclass(frozen=True)
+class TranscriptFile:
+    """One transcript, as MEASURED on one side of the copy.
+
+    ``byte_count`` and ``line_count`` are ``| None`` for NOT MEASURED, which is
+    deliberately distinct from ``0``. An empty file and a measurement that did
+    not run look identical to a caller that collapses them, and the second must
+    refuse where the first may not.
+    """
+
+    name: str
+    byte_count: int | None = None
+    line_count: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("TranscriptFile.name must be non-empty")
+
+    @property
+    def measured(self) -> bool:
+        return self.byte_count is not None and self.line_count is not None
+
+
+@dataclass(frozen=True)
+class MoveAside:
+    """Whether something is already at the destination, and where it goes.
+
+    ``required`` is three-valued. ``None`` means nobody looked — and proceeding
+    on an unchecked destination is how the only copy of an earlier conversation
+    gets overwritten, so it refuses rather than assuming an empty target.
+    """
+
+    required: bool | None
+    destination: str | None
+    reason: str
+
+    def __post_init__(self) -> None:
+        if not self.reason:
+            raise ValueError("MoveAside.reason must be non-empty")
+        if self.required is True and not self.destination:
+            raise ValueError(
+                "MoveAside: a required move must name where the existing directory goes"
+            )
+
+
+@dataclass(frozen=True)
+class TransportPlan:
+    """What will be copied, where the old contents go, or why nothing happens.
+
+    ``proceed`` is three-valued and there is no ``__bool__``: a plan that could
+    not be decided must not read as permission, because the next thing that
+    happens is a write onto another machine.
+    """
+
+    proceed: bool | None
+    code: int
+    reason: str
+    files: tuple[str, ...] = ()
+    refused: tuple[tuple[str, str], ...] = ()
+    move_aside: MoveAside | None = None
+    hint: str = ""
+
+    def __post_init__(self) -> None:
+        if self.proceed not in (True, False, None):
+            raise ValueError(
+                f"TransportPlan.proceed must be True/False/None, got {self.proceed!r}"
+            )
+        if not self.reason:
+            raise ValueError("TransportPlan.reason must be non-empty")
+        if self.proceed is True and self.code != CODE_READY:
+            raise ValueError(
+                f"TransportPlan: proceed=True must carry CODE_READY, got {self.code}"
+            )
+        if self.proceed is True and not self.files:
+            raise ValueError(
+                "TransportPlan: a plan that proceeds must name at least one file — "
+                "a transport that copies nothing and reports success is the failure "
+                "shape this whole feature exists to prevent"
+            )
+        if self.proceed is not True and not self.hint:
+            raise ValueError(
+                "TransportPlan: a plan that does not proceed must say what to do next"
+            )
+
+
+@dataclass(frozen=True)
+class ArrivalVerdict:
+    """Whether everything that left arrived intact, with the evidence attached.
+
+    ``arrived`` is three-valued, no ``__bool__``. ``mismatches`` carries one line
+    per offending file so a report names WHICH file and BY HOW MUCH, rather than
+    saying the transfer failed and leaving the reader to go and diff two hosts.
+    """
+
+    arrived: bool | None
+    code: int
+    reason: str
+    mismatches: tuple[str, ...] = ()
+    verified: tuple[str, ...] = ()
+    hint: str = ""
+
+    def __post_init__(self) -> None:
+        if self.arrived not in (True, False, None):
+            raise ValueError(
+                f"ArrivalVerdict.arrived must be True/False/None, got {self.arrived!r}"
+            )
+        if not self.reason:
+            raise ValueError("ArrivalVerdict.reason must be non-empty")
+        if self.arrived is True and self.code != CODE_ARRIVED:
+            raise ValueError(
+                f"ArrivalVerdict: arrived=True must carry CODE_ARRIVED, got {self.code}"
+            )
+        if self.arrived is True and self.mismatches:
+            raise ValueError(
+                "ArrivalVerdict: an arrival with mismatches is unrepresentable"
+            )
+        if self.arrived is not True and not self.hint:
+            raise ValueError("ArrivalVerdict: a non-arrival must say what to do next")
+
+
+def select_transferable(
+    names: Sequence[str],
+) -> tuple[tuple[str, ...], tuple[tuple[str, str], ...]]:
+    """Split ``names`` into what travels and what is refused, with reasons.
+
+    Returns ``(carried, refused)`` where ``refused`` pairs each name with the
+    sentence explaining it. The refusals are RETURNED rather than dropped so a
+    report can show that a credential was seen and declined — a filter whose
+    output is only the survivors cannot be told from one that never ran.
+    """
+    carried: list[str] = []
+    refused: list[tuple[str, str]] = []
+    for name in names:
+        if is_transferable(name):
+            carried.append(name)
+        else:
+            refused.append((name, refusal_for(name)))
+    return tuple(carried), tuple(refused)
+
+
+def plan_transport(
+    *,
+    source_running: bool | None,
+    source_files: Sequence[str] | None,
+    target_dir_exists: bool | None,
+    target_dir: str | None,
+    stamp: str,
+) -> TransportPlan:
+    """Decide whether the copy may run, and what it moves aside first.
+
+    ``source_running`` is the OBSERVED state of the source agent's process.
+    ``source_files`` is what is in the source's project directory (``None`` =
+    not listed). ``target_dir`` is the destination derived from the TARGET's
+    workdir — see :mod:`_relocate_transport_paths`; passing the source's path
+    here is the mistake that module exists to prevent, so an absent one refuses.
+    ``stamp`` names the move-aside directory and must be supplied by the caller
+    (this module owns no clock).
+
+    The checks are ordered cheapest-and-most-dangerous first: a running source
+    is refused before anything is listed, because that refusal holds regardless
+    of what the listing would have said.
+    """
+    if source_running is None:
+        return TransportPlan(
+            proceed=None,
+            code=CODE_UNKNOWN,
+            reason="whether the source agent is still running was not observed",
+            hint=(
+                "ask the source host before copying. A live agent appends to its "
+                "transcript mid-read, and a jsonl truncated mid-line still parses "
+                "and still resumes — the conversation just stops early, with nothing "
+                "anywhere reporting a problem"
+            ),
+        )
+    if source_running:
+        return TransportPlan(
+            proceed=False,
+            code=CODE_SOURCE_RUNNING,
+            reason=(
+                "the source agent is still running; copying now would read a "
+                "transcript that is being appended to"
+            ),
+            hint=(
+                "stop the source and verify it stopped, then re-run. The resulting "
+                "torn transcript would not look torn: it parses, it resumes, and the "
+                "conversation simply ends early"
+            ),
+        )
+
+    if not target_dir:
+        return TransportPlan(
+            proceed=None,
+            code=CODE_UNKNOWN,
+            reason="the target-side destination directory was not derived",
+            hint=(
+                "derive it from the TARGET's resolved workdir "
+                "(_relocate_transport_paths.derive_target_dir). A transcript under "
+                "the SOURCE's encoded directory name is present, intact and invisible "
+                "to the target's runner"
+            ),
+        )
+
+    if source_files is None:
+        return TransportPlan(
+            proceed=None,
+            code=CODE_UNKNOWN,
+            reason="the source's transcript directory was not listed",
+            hint=(
+                "list the source project directory before copying; an unreadable "
+                "listing is not an empty one, and treating it as empty relocates an "
+                "agent with no memory"
+            ),
+        )
+
+    carried, refused = select_transferable(source_files)
+    if not carried:
+        return TransportPlan(
+            proceed=False,
+            code=CODE_NOTHING_TO_CARRY,
+            reason=(
+                "the source project directory holds no conversation transcript to move"
+            ),
+            refused=refused,
+            hint=(
+                "confirm this is right before continuing — the agent will start on "
+                "the target with no memory. If it should have had one, the source's "
+                "workdir encoding is the first thing to check"
+            ),
+        )
+
+    if target_dir_exists is None:
+        return TransportPlan(
+            proceed=None,
+            code=CODE_UNKNOWN,
+            reason="whether the target already holds a transcript directory was not observed",
+            files=carried,
+            refused=refused,
+            hint=(
+                "check the destination before writing to it. A relocation target may "
+                "have been this agent's home before, and what is there is the only "
+                "copy of it"
+            ),
+        )
+
+    if target_dir_exists:
+        move = MoveAside(
+            required=True,
+            destination=f"{target_dir.rstrip('/')}/.old/{stamp}",
+            reason=(
+                "the target already holds a transcript directory for this agent; it "
+                "is moved aside, never overwritten and never deleted"
+            ),
+        )
+    else:
+        move = MoveAside(
+            required=False,
+            destination=None,
+            reason="the destination is empty; nothing to preserve",
+        )
+
+    return TransportPlan(
+        proceed=True,
+        code=CODE_READY,
+        reason=(
+            f"{len(carried)} transcript(s) to copy into {target_dir}; source is stopped"
+        ),
+        files=carried,
+        refused=refused,
+        move_aside=move,
+    )
+
+
+def verify_arrival(
+    *,
+    sent: Sequence[TranscriptFile],
+    landed: Sequence[TranscriptFile],
+) -> ArrivalVerdict:
+    """Compare what left with what the TARGET now holds, per file.
+
+    ``sent`` is measured on the source, ``landed`` on the target, each carrying
+    a byte count and a line count. Every file in ``sent`` must appear in
+    ``landed`` with both numbers equal. Files present only in ``landed`` are
+    ignored — the destination is the agent's own projects directory and may hold
+    other conversations, which is not evidence of a bad copy.
+
+    An unmeasured count on either side is UNKNOWN, not a pass. "I could not
+    count it" and "it counted the same" are the two answers this function exists
+    to keep apart.
+    """
+    if not sent:
+        return ArrivalVerdict(
+            arrived=None,
+            code=CODE_UNKNOWN,
+            reason="nothing was recorded as sent, so there is nothing to confirm",
+            hint=(
+                "measure the source files before the copy; without a baseline the "
+                "target's contents cannot be checked against anything"
+            ),
+        )
+
+    by_name = {f.name: f for f in landed}
+    mismatches: list[str] = []
+    verified: list[str] = []
+    unmeasured: list[str] = []
+
+    for src in sent:
+        if not src.measured:
+            unmeasured.append(f"{src.name}: not measured on the source")
+            continue
+        tgt = by_name.get(src.name)
+        if tgt is None:
+            mismatches.append(f"{src.name}: absent on the target")
+            continue
+        if not tgt.measured:
+            unmeasured.append(f"{src.name}: not measured on the target")
+            continue
+        if tgt.byte_count != src.byte_count or tgt.line_count != src.line_count:
+            mismatches.append(
+                f"{src.name}: sent {src.byte_count} bytes / {src.line_count} lines, "
+                f"target holds {tgt.byte_count} bytes / {tgt.line_count} lines"
+            )
+            continue
+        verified.append(src.name)
+
+    if unmeasured:
+        return ArrivalVerdict(
+            arrived=None,
+            code=CODE_UNKNOWN,
+            reason="the copy could not be confirmed: " + "; ".join(unmeasured),
+            mismatches=tuple(mismatches),
+            verified=tuple(verified),
+            hint=(
+                "count bytes and lines on BOTH sides and compare again. A copy that "
+                "cannot be checked has not succeeded — do not hand over the lease on it"
+            ),
+        )
+
+    if mismatches:
+        absent = all("absent on the target" in m for m in mismatches)
+        return ArrivalVerdict(
+            arrived=False,
+            code=CODE_MISSING_ON_TARGET if absent else CODE_TRUNCATED,
+            reason="the target's copy does not match what was sent",
+            mismatches=tuple(mismatches),
+            verified=tuple(verified),
+            hint=(
+                "do NOT continue the relocation. Move the target's partial copy aside "
+                "and re-run the transport; a short transcript resumes without error "
+                "and simply forgets the end of the conversation"
+            ),
+        )
+
+    return ArrivalVerdict(
+        arrived=True,
+        code=CODE_ARRIVED,
+        reason=(
+            f"all {len(verified)} transcript(s) verified on the target by byte and "
+            "line count"
+        ),
+        verified=tuple(verified),
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_transport_paths.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_transport_paths.py
@@ -1,0 +1,174 @@
+"""WHERE the transcript must land on the target — derived from the TARGET's workdir.
+
+Claude Code does not store a conversation under the agent's name. It stores it
+under an encoding of the RESOLVED WORKING DIRECTORY it was launched in::
+
+    $HOME/.claude/projects/<encoded-resolved-cwd>/<session-uuid>.jsonl
+
+So a transcript is found at boot only if it sits under the directory name the
+TARGET's runner will compute. Copy it under the SOURCE's directory name and the
+file is present, readable, byte-identical — and invisible. The agent starts,
+reports healthy, and has no memory of the conversation that moved it. That is the
+2026-08-07 failure shape exactly, reproduced by a copy that "worked".
+
+WHY THE TARGET'S WORKDIR MUST BE OBSERVED AND NOT ASSUMED. The two hosts run the
+same spec, so the workdir STRING is usually identical — which is precisely what
+makes the mistake cheap to commit and expensive to find. It is not reliably the
+same path after resolution: Claude Code encodes the RESOLVED cwd, and a workdir
+that is a symlink on one host and a real directory on the other resolves to two
+different strings from one spec. A relocation onto a host where the repo lives
+behind a different mount is the normal case in this fleet, not a corner one.
+
+Resolution therefore cannot be done here. ``Path.resolve()`` in this process
+resolves against the SOURCE's filesystem, and the answer would be confidently
+wrong in exactly the case that matters. The resolved workdir is an OBSERVATION
+the target-side probe supplies, and an unobserved one is UNKNOWN — never a
+locally-guessed substitute.
+
+THE ENCODING IS NOT REIMPLEMENTED HERE. ``_runners._session_candidates.
+encode_claude_project`` already replicates it (``/`` and ``.`` to ``-``, then
+triple-or-more dashes collapsed to ``--``) and the runner reads the store through
+that function. A second copy of the rule would be a second thing to keep correct,
+and the two would disagree on the first path nobody tested.
+
+WHAT THIS TELLS YOU THAT A STRING COMPARE DOES NOT. :func:`derive_target_dir`
+reports whether the target's directory name matches the source's. A MISMATCH IS
+NOT AN ERROR — it is the normal, correct outcome when the two hosts resolve the
+workdir differently, and it is the whole reason the name is recomputed rather
+than copied. It is surfaced because a relocation that silently changes where the
+transcript lives should say so out loud, and because a mismatch nobody expected
+is the first sign the target's workdir is not what the spec claims.
+
+Pure: no filesystem, no network, no clock. Strings in, a derivation out.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+__all__ = [
+    "CODE_DERIVED",
+    "CODE_UNKNOWN",
+    "TargetTranscriptDir",
+    "derive_target_dir",
+    "encode_workdir",
+]
+
+#: The target-side directory was derived from an observed resolved workdir.
+CODE_DERIVED: Final = 200
+#: The target's resolved workdir was not observed; nothing can be derived.
+CODE_UNKNOWN: Final = 503
+
+
+def encode_workdir(resolved_workdir: str) -> str:
+    """Claude Code's resolved-cwd -> ``projects/`` directory-name encoding.
+
+    Delegates to :func:`.._runners._session_candidates.encode_claude_project`,
+    which is the copy the runner itself reads the store through. Re-exported
+    under a name that says what it takes (a RESOLVED workdir), because the whole
+    class of bug this module guards against starts with someone passing the
+    unresolved one.
+    """
+    from .._runners._session_candidates import encode_claude_project
+
+    return encode_claude_project(resolved_workdir)
+
+
+@dataclass(frozen=True)
+class TargetTranscriptDir:
+    """The directory the target's runner will look in, and how it was reached.
+
+    ``path`` is ``None`` when the derivation could not be made, which is the
+    same discipline the rest of the relocate machinery uses: a value that was
+    not established is absent rather than guessed. There is deliberately no
+    ``__bool__`` — ``if target_dir:`` on an underived one would read as "we know
+    where to put it".
+
+    ``matches_source`` is three-valued on purpose. ``None`` means the source's
+    directory name was not supplied, so the question was never asked; that is
+    distinct from an observed ``False``, which is a real difference between the
+    two hosts and worth printing.
+    """
+
+    path: str | None
+    code: int
+    reason: str
+    encoded: str | None = None
+    matches_source: bool | None = None
+    hint: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.reason:
+            raise ValueError("TargetTranscriptDir.reason must be non-empty")
+        if self.path is not None and self.code != CODE_DERIVED:
+            raise ValueError(
+                f"TargetTranscriptDir: a derived path must carry CODE_DERIVED, got {self.code}"
+            )
+        if self.path is None and not self.hint:
+            raise ValueError(
+                "TargetTranscriptDir: a failed derivation must say what to measure next"
+            )
+
+
+def derive_target_dir(
+    *,
+    target_home: str | None,
+    target_resolved_workdir: str | None,
+    source_dir_name: str | None = None,
+) -> TargetTranscriptDir:
+    """Compute ``<target_home>/.claude/projects/<encoded>`` from OBSERVED facts.
+
+    ``target_home`` and ``target_resolved_workdir`` are what the target itself
+    reported — ``$HOME`` and the workdir after symlink resolution, both read on
+    the target. Either being ``None`` (not observed) yields an UNKNOWN, because
+    the alternative is to substitute this host's answer for the other host's, and
+    a plausible wrong path here produces a healthy agent with no memory.
+
+    ``source_dir_name`` is the bare directory name the transcript currently lives
+    under on the source (e.g. ``-home-ywatanabe-proj-lead``). Supplying it turns
+    on the comparison; omitting it leaves ``matches_source`` at ``None`` rather
+    than defaulting the answer to "same", which would be a claim nobody made.
+    """
+    if not target_home:
+        return TargetTranscriptDir(
+            path=None,
+            code=CODE_UNKNOWN,
+            reason="the target's $HOME was not observed",
+            hint=(
+                "probe the target for its $HOME before transporting; the transcript "
+                "store hangs off it, and this host's $HOME is not evidence about "
+                "the other host's"
+            ),
+        )
+    if not target_resolved_workdir:
+        return TargetTranscriptDir(
+            path=None,
+            code=CODE_UNKNOWN,
+            reason="the target's RESOLVED workdir was not observed",
+            hint=(
+                "probe the target for the workdir after symlink resolution "
+                "(readlink -f / realpath). Resolving it here would resolve against "
+                "the SOURCE's filesystem and name a directory the target's runner "
+                "will never read"
+            ),
+        )
+
+    encoded = encode_workdir(target_resolved_workdir)
+    path = f"{target_home.rstrip('/')}/.claude/projects/{encoded}"
+    matches = None if source_dir_name is None else (encoded == source_dir_name)
+    if matches is False:
+        reason = (
+            f"the target encodes its workdir as {encoded!r}, the source stores the "
+            f"transcript under {source_dir_name!r} — the two hosts resolve this "
+            "workdir differently, so the name is recomputed rather than copied"
+        )
+    else:
+        reason = f"the target's runner will read {path}"
+    return TargetTranscriptDir(
+        path=path,
+        code=CODE_DERIVED,
+        reason=reason,
+        encoded=encoded,
+        matches_source=matches,
+    )

--- a/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
@@ -67,6 +67,85 @@ EXIT_REFUSED = 3
 EXIT_UNIMPLEMENTED = 4
 
 
+#: What `--no-dry-run` still cannot do, phase by phase. THIS LIST IS THE REFUSAL
+#: — the message is generated from it, so the two cannot drift apart the way the
+#: previous hard-coded sentence did (it named the transcript transport as the one
+#: missing piece and went stale the moment that phase was built).
+#:
+#: Each entry is (phase, what is BUILT, what is MISSING). The split matters: the
+#: decision layers below are unit-tested and their refusal paths are the whole
+#: point, but a decision cannot move bytes or start a process. The I/O adapters
+#: are what remain, and they are the part that cannot be honestly claimed until
+#: it has been exercised against two real hosts.
+_PHASE_READINESS: tuple[tuple[str, str, str], ...] = (
+    (
+        "source_drain",
+        "—",
+        "no adapter: drain the source and confirm it took no new work",
+    ),
+    (
+        "source_stop",
+        "—",
+        "no adapter: stop the source and VERIFY stopped (the transport's precondition)",
+    ),
+    (
+        "transport",
+        "_relocate_transport (selection, move-aside, byte+line verification) and "
+        "_relocate_transport_paths (target-side project dir)",
+        "no adapter: the ssh/scp round trip that moves the bytes and counts them "
+        "on the far side",
+    ),
+    (
+        "target_standby",
+        "—",
+        "no adapter: start the target without the lease and seed its session marker",
+    ),
+    (
+        "handshake",
+        "_relocate_handshake (nonce + proof-of-work verdict) and _relocate_arrival "
+        "(the message the relocated agent receives)",
+        "no adapter: deliver the brief over a2a and observe the reply ON THE SOURCE",
+    ),
+    ("handover", "_relocate_lease", "no adapter: move the lease and bump the fence"),
+    ("done", "—", "no adapter: append the residency record to the state db"),
+)
+
+
+def _unimplemented_notice() -> list[str]:
+    """Say exactly which phases can and cannot run, rather than naming one.
+
+    An accurate refusal is worth more than a short one here: the operator's next
+    question is always "so what IS missing", and answering it in the refusal is
+    the difference between a blocked afternoon and a scoped piece of work.
+    """
+    lines = [
+        "",
+        "[red]refusing to execute:[/red] the phase driver has no I/O adapters wired, "
+        "so a relocation would journal its way to DONE having moved nothing — the "
+        "most convincing possible imitation of success.",
+        "",
+        "Phase by phase:",
+    ]
+    for phase, built, missing in _PHASE_READINESS:
+        lines.append(f"  [bold]{phase}[/bold]")
+        if built != "—":
+            lines.append(f"    built:   {built}")
+        lines.append(f"    missing: {missing}")
+    lines += [
+        "",
+        "The decision layers refuse correctly and are unit-tested; what is absent "
+        "is the code that talks to two machines. Until an adapter has been "
+        "exercised against real hosts it is not claimed to work — that claim, made "
+        "on 2026-08-07 without the evidence, is why this command exists.",
+        "",
+        "Use --dry-run to check the target. Move the transcript by hand meanwhile, "
+        "and read _relocate_transport_paths before choosing the destination: the "
+        "directory name comes from the TARGET's resolved workdir, and a transcript "
+        "under the source's name is invisible to the target's runner.",
+    ]
+    return lines
+
+
 def _dig(body: dict, *path: str) -> object:
     """Follow ``path`` through nested dicts, yielding ``None`` at any break."""
     cur: object = body
@@ -289,11 +368,8 @@ def relocate(name: str, to_host: str, dry_run: bool) -> None:
         console.print(line, soft_wrap=True)
 
     if not dry_run:
-        console.print(
-            "\n[red]refusing to execute:[/red] the cross-host transcript transport "
-            "is not built, so a relocation would arrive with no memory of the "
-            "conversation that moved it. See docs/relocate.md §5."
-        )
+        for line in _unimplemented_notice():
+            console.print(line, soft_wrap=True)
         raise SystemExit(EXIT_UNIMPLEMENTED)
     if report.ok is not True:
         raise SystemExit(EXIT_REFUSED)

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_arrival.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_arrival.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""An agent that resumed on a new host and was not told is confidently wrong.
+
+The operator's requirement (2026-08-11) is that the relocated agent be told three
+things: where it moved FROM, where it moved TO, and the session id its memory was
+resumed from. Each is asserted separately here rather than as one substring
+match, so a rewording that drops one of them fails on the one it dropped and
+names it.
+
+The resume-id assertions are the load-bearing ones. An agent told "your memory
+was carried" with no id cannot check the claim — and that exact claim was
+silently false on 2026-08-07, which is why this feature exists at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_arrival import (
+    DEFAULT_HANDOVER_DOC,
+    build_arrival_brief,
+)
+
+SESSION = "0f2c9c1e-7b3a-4d55-9e21-6b1c0a4f8e33"
+NONCE = "n-4417"
+QUESTION = "run `hostname` and report exactly what it printed"
+
+
+def _brief(**over) -> str:
+    kwargs = {
+        "agent": "scitex-lead",
+        "from_host": "ywata-note-win",
+        "to_host": "scitex-compute-04",
+        "resume_session_id": SESSION,
+        "nonce": NONCE,
+        "question": QUESTION,
+    }
+    kwargs.update(over)
+    return build_arrival_brief(**kwargs)
+
+
+def test_the_brief_names_the_source_host() -> None:
+    # Arrange: "you moved" without saying from where leaves the agent unable to
+    # judge which of its remembered facts are now stale.
+    # Act
+    text = _brief()
+    # Assert
+    assert "ywata-note-win" in text
+
+
+def test_the_brief_names_the_target_host() -> None:
+    # Arrange: the other half of the same sentence.
+    # Act
+    text = _brief()
+    # Assert
+    assert "scitex-compute-04" in text
+
+
+def test_the_brief_names_the_resumed_session_id() -> None:
+    # Arrange: THE one handle that lets the agent verify its own continuity.
+    # Act
+    text = _brief()
+    # Assert
+    assert SESSION in text
+
+
+def test_the_brief_names_the_agent() -> None:
+    # Arrange: it is delivered over a shared bus; an unaddressed instruction is
+    # one an agent can reasonably decide is not for it.
+    # Act
+    text = _brief()
+    # Assert
+    assert "scitex-lead" in text
+
+
+def test_the_brief_warns_that_the_transcript_describes_the_old_host() -> None:
+    # Arrange: the real failure mode. The conversation above the message is full
+    # of paths and ports that were true elsewhere, and nothing in it says so.
+    # Act
+    text = _brief()
+    # Assert
+    assert "may not hold here" in text
+
+
+def test_the_brief_points_at_the_handover_document() -> None:
+    # Arrange: the operator's own notes for this move are state the agent needs
+    # and cannot infer from its transcript.
+    # Act
+    text = _brief()
+    # Assert
+    assert DEFAULT_HANDOVER_DOC in text
+
+
+def test_the_handover_document_pointer_is_overridable() -> None:
+    # Arrange: the default names one dated migration; a later relocation must
+    # not be told to read a stale file.
+    # Act
+    text = _brief(handover_doc="~/notes/move-2027.md")
+    # Assert
+    assert "~/notes/move-2027.md" in text
+
+
+def test_the_brief_points_at_the_card_board_as_authoritative() -> None:
+    # Arrange: the transcript's memory of what is in flight is exactly the thing
+    # that is stale after a move; the board is not.
+    # Act
+    text = _brief()
+    # Assert
+    assert "scitex-todo" in text
+
+
+def test_the_brief_carries_the_handshake_nonce() -> None:
+    # Arrange: it IS the handshake challenge — without correlation, a reply left
+    # over from an earlier turn satisfies "the agent answered".
+    # Act
+    text = _brief()
+    # Assert
+    assert NONCE in text
+
+
+def test_the_brief_carries_the_proof_of_work_question() -> None:
+    # Arrange: an echo proves the message path, not the agent, and this message
+    # is the gate for the agent.
+    # Act
+    text = _brief()
+    # Assert
+    assert QUESTION in text
+
+
+def test_the_brief_says_the_source_has_been_stopped() -> None:
+    # Arrange: identity is 1 -> 1. An agent that believes a copy of it is still
+    # running elsewhere will coordinate with something that is not there.
+    # Act
+    text = _brief()
+    # Assert
+    assert "has been stopped" in text
+
+
+def test_a_brief_without_a_resume_id_is_refused() -> None:
+    # Arrange: "your memory was carried" with nothing to check it against is the
+    # claim that was silently false before. Refusing beats asserting it blindly.
+    # Act
+    build = lambda: _brief(resume_session_id="")  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_brief_without_a_nonce_is_refused() -> None:
+    # Arrange: a gate that can be disabled by passing nothing is a gate that
+    # will eventually be disabled by passing nothing.
+    # Act
+    build = lambda: _brief(nonce="")  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_brief_without_a_proof_of_work_question_is_refused() -> None:
+    # Arrange: same reasoning, the other requirement.
+    # Act
+    build = lambda: _brief(question="")  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_move_from_a_host_to_itself_is_refused() -> None:
+    # Arrange: a brief announcing a move that did not happen is a false
+    # statement made to the agent, in the message it is most likely to trust.
+    # Act
+    build = lambda: _brief(from_host="h", to_host="h")  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        build()

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_execute.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_execute.py
@@ -37,8 +37,10 @@ from scitex_agent_container._lifecycle._relocate_phases import (
     HANDOVER,
     HANDSHAKE,
     PHASES,
+    SOURCE_DRAIN,
     SOURCE_STOP,
     TARGET_STANDBY,
+    TRANSPORT,
     Relocation,
     advance,
     begin,
@@ -76,6 +78,7 @@ def _effects(**overrides) -> PhaseEffects:
         drain_source=lambda: _ok("source drained"),
         hand_over_lease=lambda: _ok("lease moved at fence 4"),
         stop_source=lambda: _ok("source stopped and verified"),
+        transport_transcript=lambda: _ok("transcript verified on the target"),
         finish=lambda: _ok("residency and origin recorded"),
     )
     base.update(overrides)
@@ -127,14 +130,87 @@ def test_a_completed_relocation_journals_every_phase_in_order() -> None:
     assert tuple(s.phase for s in outcome.relocation.steps) == PHASES
 
 
-def test_the_first_thing_a_relocation_does_is_start_the_standby() -> None:
+def test_the_first_thing_a_relocation_does_is_drain_the_source() -> None:
     # Arrange: the order is the design, so it is asserted rather than assumed.
-    # Nothing precedes the standby — in particular no spec is edited.
+    # Nothing precedes the drain — in particular no spec is edited. The source
+    # side goes first because the transcript cannot be copied out from under a
+    # running agent, and the target cannot start before the transcript lands.
     effects = _effects()
     # Act
     outcome = execute(_fresh(), effects=effects, now=_clock())
     # Assert
-    assert outcome.log[0].startswith(TARGET_STANDBY)
+    assert outcome.log[0].startswith(SOURCE_DRAIN)
+
+
+def test_the_source_is_stopped_before_the_transcript_is_transported() -> None:
+    # Arrange: THE ordering constraint the transport phase exists under. A live
+    # agent appends mid-read, and the resulting jsonl parses, resumes, and
+    # silently ends the conversation early.
+    effects = _effects()
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.log.index(
+        next(x for x in outcome.log if x.startswith(SOURCE_STOP))
+    ) < outcome.log.index(next(x for x in outcome.log if x.startswith(TRANSPORT)))
+
+
+def test_the_transcript_is_transported_before_the_target_starts() -> None:
+    # Arrange: the other half. Once the target has booted it owns its own
+    # session marker, and seeding over it would discard whatever it did.
+    effects = _effects()
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.log.index(
+        next(x for x in outcome.log if x.startswith(TRANSPORT))
+    ) < outcome.log.index(next(x for x in outcome.log if x.startswith(TARGET_STANDBY)))
+
+
+def test_a_transport_failure_aborts_before_the_target_is_ever_started() -> None:
+    # Arrange: a target started on a failed transport is the "healthy agent with
+    # no memory" shape. It must never get that far.
+    effects = _effects(
+        transport_transcript=lambda: _fail("the target's copy is 40 lines short")
+    )
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.standby_left_running is False
+
+
+def test_a_transport_failure_reports_the_source_as_left_stopped() -> None:
+    # Arrange: the price of the ordering, stated as a field rather than left for
+    # the operator to deduce — at this point the agent is down on both hosts.
+    effects = _effects(
+        transport_transcript=lambda: _fail("the target's copy is 40 lines short")
+    )
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.source_left_stopped is True
+
+
+def test_a_transport_failure_tells_the_operator_how_to_undo_it() -> None:
+    # Arrange: "nothing was changed" would be true of every durable record and
+    # false of the thing the operator will actually notice.
+    effects = _effects(
+        transport_transcript=lambda: _fail("the target's copy is 40 lines short")
+    )
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert f"is STOPPED on {SRC}" in outcome.hint
+
+
+def test_a_failure_before_the_source_is_stopped_leaves_it_running() -> None:
+    # Arrange: the counterpart — an abort at the drain must NOT tell the
+    # operator to restart an agent that never stopped.
+    effects = _effects(drain_source=lambda: _fail("in-flight work would be lost"))
+    # Act
+    outcome = execute(_fresh(), effects=effects, now=_clock())
+    # Assert
+    assert outcome.source_left_stopped is False
 
 
 def test_the_handshake_runs_before_the_handover() -> None:
@@ -163,12 +239,14 @@ def test_a_completed_relocation_carries_the_completed_code() -> None:
 
 
 def test_a_resumed_relocation_does_not_re_run_the_phases_already_journalled() -> None:
-    # Arrange: a coordinator that died after the handshake re-runs from drain.
+    # Arrange: a coordinator that died after stopping the source re-runs from
+    # the transport, NOT from the beginning — re-draining and re-stopping an
+    # already-stopped agent is wasted work at best.
     effects = _effects()
     # Act
-    outcome = execute(_at(HANDSHAKE), effects=effects, now=_clock())
+    outcome = execute(_at(SOURCE_STOP), effects=effects, now=_clock())
     # Assert
-    assert outcome.log[0].startswith("source_drain")
+    assert outcome.log[0].startswith(TRANSPORT)
 
 
 def test_a_resumed_relocation_still_reaches_done() -> None:
@@ -311,7 +389,7 @@ def test_an_unknown_step_keeps_the_measure_it_hint() -> None:
 
 def test_a_failure_after_the_handover_is_not_aborted() -> None:
     # Arrange: aborting would mean taking the lease back from a live holder.
-    effects = _effects(stop_source=lambda: _fail("the source is still running"))
+    effects = _effects(finish=lambda: _fail("the residency row could not be written"))
     # Act
     outcome = execute(_fresh(), effects=effects, now=_clock())
     # Assert
@@ -320,7 +398,7 @@ def test_a_failure_after_the_handover_is_not_aborted() -> None:
 
 def test_a_failure_after_the_handover_carries_the_past_no_return_code() -> None:
     # Arrange
-    effects = _effects(stop_source=lambda: _fail("the source is still running"))
+    effects = _effects(finish=lambda: _fail("the residency row could not be written"))
     # Act
     outcome = execute(_fresh(), effects=effects, now=_clock())
     # Assert
@@ -329,7 +407,7 @@ def test_a_failure_after_the_handover_carries_the_past_no_return_code() -> None:
 
 def test_a_failure_after_the_handover_says_it_cannot_be_rolled_back() -> None:
     # Arrange
-    effects = _effects(stop_source=lambda: _fail("the source is still running"))
+    effects = _effects(finish=lambda: _fail("the residency row could not be written"))
     # Act
     outcome = execute(_fresh(), effects=effects, now=_clock())
     # Assert
@@ -338,7 +416,7 @@ def test_a_failure_after_the_handover_says_it_cannot_be_rolled_back() -> None:
 
 def test_a_failure_after_the_handover_names_the_host_that_now_holds_the_lease() -> None:
     # Arrange
-    effects = _effects(stop_source=lambda: _fail("the source is still running"))
+    effects = _effects(finish=lambda: _fail("the residency row could not be written"))
     # Act
     outcome = execute(_fresh(), effects=effects, now=_clock())
     # Assert
@@ -350,7 +428,7 @@ def test_a_failure_after_the_handover_does_not_warn_about_an_abandoned_standby()
 ):
     # Arrange: past the atomic point the "standby" is the live agent. Calling it
     # something to clean up would invite stopping the only running instance.
-    effects = _effects(stop_source=lambda: _fail("the source is still running"))
+    effects = _effects(finish=lambda: _fail("the residency row could not be written"))
     # Act
     outcome = execute(_fresh(), effects=effects, now=_clock())
     # Assert
@@ -378,7 +456,7 @@ def test_a_failure_at_the_handover_says_the_host_record_is_untouched() -> None:
 
 def test_a_stopped_relocation_past_the_atomic_point_reports_it() -> None:
     # Arrange
-    effects = _effects(stop_source=lambda: _fail("the source is still running"))
+    effects = _effects(finish=lambda: _fail("the residency row could not be written"))
     # Act
     outcome = execute(_fresh(), effects=effects, now=_clock())
     # Assert

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_phases.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_phases.py
@@ -36,7 +36,7 @@ from scitex_agent_container._lifecycle._relocate_phases import (
     PREFLIGHT,
     SOURCE_DRAIN,
     SOURCE_STOP,
-    TARGET_STANDBY,
+    TRANSPORT,
     PhaseVerdict,
     Relocation,
     abort,
@@ -128,7 +128,7 @@ def test_the_next_phase_is_accepted(fresh: Relocation) -> None:
     # Arrange
     rel = fresh
     # Act
-    _, verdict = advance(rel, to_phase=TARGET_STANDBY, now=T0 + 1)
+    _, verdict = advance(rel, to_phase=SOURCE_DRAIN, now=T0 + 1)
     # Assert
     assert verdict.allowed is True
 
@@ -137,7 +137,7 @@ def test_advancing_appends_to_the_journal(fresh: Relocation) -> None:
     # Arrange
     rel = fresh
     # Act
-    moved, _ = advance(rel, to_phase=TARGET_STANDBY, now=T0 + 1, detail="target up")
+    moved, _ = advance(rel, to_phase=SOURCE_DRAIN, now=T0 + 1, detail="source drained")
     # Assert
     assert len(moved.steps) == len(rel.steps) + 1
 
@@ -219,7 +219,7 @@ def test_resume_points_at_the_next_phase(fresh: Relocation) -> None:
     # Act
     nxt = resume_from(rel)
     # Assert
-    assert nxt == TARGET_STANDBY
+    assert nxt == SOURCE_DRAIN
 
 
 def test_resume_after_a_partial_run_points_forward() -> None:
@@ -228,7 +228,7 @@ def test_resume_after_a_partial_run_points_forward() -> None:
     # Act
     nxt = resume_from(rel)
     # Assert
-    assert nxt == HANDOVER
+    assert nxt == SOURCE_STOP
 
 
 def test_a_completed_relocation_has_nothing_to_resume() -> None:
@@ -266,12 +266,23 @@ def test_at_the_handover_the_relocation_is_past_no_return(
 
 
 def test_after_the_handover_the_relocation_stays_past_no_return() -> None:
-    # Arrange
-    rel = _walk_to(SOURCE_STOP)
+    # Arrange: DONE is the only phase past the handover now that the source stop
+    # moved ahead of the transport.
+    rel = _walk_to(DONE)
     # Act
     past = is_past_no_return(rel)
     # Assert
     assert past is True
+
+
+def test_the_transport_is_still_on_the_reversible_side() -> None:
+    # Arrange: the phase was added BEFORE the handover deliberately — it copies
+    # a file onto a host that is not yet serving, so it moves no write authority.
+    rel = _walk_to(TRANSPORT)
+    # Act
+    past = is_past_no_return(rel)
+    # Assert
+    assert past is False
 
 
 # ---------------------------------------------------------------------------
@@ -325,13 +336,36 @@ def test_aborting_at_the_handover_is_refused(handed_over: Relocation) -> None:
     assert verdict.code == CODE_PAST_NO_RETURN
 
 
-def test_aborting_after_the_handover_is_refused() -> None:
-    # Arrange
+def test_aborting_after_the_source_stop_is_still_allowed() -> None:
+    # Arrange: SOURCE_STOP moved AHEAD of the handover so the transport has a
+    # quiesced source to read. It is still on the reversible side — stopping a
+    # process is not transferring ownership, and the residency row is untouched.
     rel = _walk_to(SOURCE_STOP)
     # Act
     _, verdict = abort(rel, now=T0 + 9, reason="changed my mind")
     # Assert
-    assert verdict.code == CODE_PAST_NO_RETURN
+    assert verdict.allowed is True
+
+
+def test_an_abort_after_the_source_stop_says_the_agent_is_down() -> None:
+    # Arrange: the price of that ordering. "Nothing was changed" is true of every
+    # durable record and false of the thing the operator will actually notice, so
+    # the verdict has to name the stopped agent and how to bring it back.
+    rel = _walk_to(SOURCE_STOP)
+    # Act
+    _, verdict = abort(rel, now=T0 + 9, reason="changed my mind")
+    # Assert
+    assert "is STOPPED on" in verdict.reason
+
+
+def test_an_abort_before_the_source_stop_does_not_claim_it_is_down() -> None:
+    # Arrange: the counterpart — telling an operator to restart an agent that
+    # never stopped sends them to do a pointless, disruptive thing.
+    rel = _walk_to(SOURCE_DRAIN)
+    # Act
+    _, verdict = abort(rel, now=T0 + 9, reason="changed my mind")
+    # Assert
+    assert "is STOPPED on" not in verdict.reason
 
 
 def test_aborting_a_completed_relocation_is_refused() -> None:

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_transport.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_transport.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""A transport that reports success having moved a torn transcript is the whole bug.
+
+The sharpest test in this file is the TRUNCATION one, and it is built from REAL
+files rather than hand-written numbers: a transcript is written to disk, a short
+copy is made of it, and both are measured with the same counting code. That
+matters because the failure being guarded against is not arithmetic — it is a
+copy that lands, exits 0, and holds fewer lines than it left with. jsonl carries
+no trailer, so the short file parses and resumes and simply forgets the end of
+the conversation.
+
+The credential test asserts the exclusion BY NAME. The allowlist already refuses
+anything that is not ``.jsonl``, so the assertion is technically redundant — and
+that is the point: it pins the property the operator asked for, so a future
+change that widens the filter has to fail a test that says "credentials" rather
+than quietly starting to carry one.
+
+Real values, real files. Nothing is mocked.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_transport import (
+    CODE_ARRIVED,
+    CODE_MISSING_ON_TARGET,
+    CODE_NOTHING_TO_CARRY,
+    CODE_READY,
+    CODE_SOURCE_RUNNING,
+    CODE_TRUNCATED,
+    CODE_UNKNOWN,
+    CREDENTIAL_BASENAMES,
+    ArrivalVerdict,
+    TranscriptFile,
+    is_transferable,
+    plan_transport,
+    select_transferable,
+    verify_arrival,
+)
+
+STAMP = "20260811-204500"
+TARGET_DIR = "/home/agent/.claude/projects/-home-ywatanabe-proj-lead"
+LINES = [
+    '{"type":"user","text":"the conversation that moved it"}',
+    '{"type":"assistant","text":"understood"}',
+    '{"type":"user","text":"continue on the new host"}',
+]
+
+
+def _measure(path) -> TranscriptFile:
+    """Count bytes and lines the way both sides of a real transfer would."""
+    data = path.read_bytes()
+    return TranscriptFile(
+        name=path.name,
+        byte_count=len(data),
+        line_count=len(data.splitlines()),
+    )
+
+
+def _ready_plan(**over):
+    kwargs = {
+        "source_running": False,
+        "source_files": ["a.jsonl"],
+        "target_dir_exists": False,
+        "target_dir": TARGET_DIR,
+        "stamp": STAMP,
+    }
+    kwargs.update(over)
+    return plan_transport(**kwargs)
+
+
+# --------------------------------------------------------------------------
+# The source must be stopped
+# --------------------------------------------------------------------------
+
+
+def test_a_quiesced_source_with_a_clean_target_is_ready() -> None:
+    # Arrange: the positive control. Without it every refusal below could pass
+    # because the fixture is broken rather than because the refusal works.
+    # Act
+    plan = _ready_plan()
+    # Assert
+    assert plan.proceed is True
+
+
+def test_the_ready_plan_carries_the_success_code() -> None:
+    # Arrange: callers branch on the code, never on prose.
+    # Act
+    plan = _ready_plan()
+    # Assert
+    assert plan.code == CODE_READY
+
+
+def test_a_running_source_is_refused() -> None:
+    # Arrange: THE rule. A live agent appends mid-read, and the resulting file
+    # is not detectably torn — it parses, resumes, and ends the conversation early.
+    # Act
+    plan = _ready_plan(source_running=True)
+    # Assert
+    assert plan.code == CODE_SOURCE_RUNNING
+
+
+def test_a_running_source_is_a_decided_no_not_an_unknown() -> None:
+    # Arrange: we DID observe it running. That is an answer, and it calls for a
+    # different action than "go and measure it".
+    # Act
+    plan = _ready_plan(source_running=True)
+    # Assert
+    assert plan.proceed is False
+
+
+def test_an_unobserved_source_state_refuses_as_unknown() -> None:
+    # Arrange: nobody asked whether the source was running. Proceeding would
+    # guess about the one condition that silently corrupts the payload.
+    # Act
+    plan = _ready_plan(source_running=None)
+    # Assert
+    assert plan.proceed is None
+
+
+def test_a_running_source_is_refused_before_anything_is_listed() -> None:
+    # Arrange: the refusal holds regardless of what the listing would say, so it
+    # must not depend on the listing having succeeded.
+    # Act
+    plan = _ready_plan(source_running=True, source_files=None, target_dir_exists=None)
+    # Assert
+    assert plan.code == CODE_SOURCE_RUNNING
+
+
+def test_the_running_source_refusal_says_to_stop_it() -> None:
+    # Arrange: a refusal whose hint does not name the next action turns a
+    # one-command fix into an investigation.
+    # Act
+    plan = _ready_plan(source_running=True)
+    # Assert
+    assert "stop the source" in plan.hint.lower()
+
+
+# --------------------------------------------------------------------------
+# Nothing is overwritten
+# --------------------------------------------------------------------------
+
+
+def test_an_existing_target_directory_is_moved_aside() -> None:
+    # Arrange: a relocation target may have been this agent's home before, and
+    # what is there is the only copy of it.
+    # Act
+    plan = _ready_plan(target_dir_exists=True)
+    # Assert
+    assert plan.move_aside.required is True
+
+
+def test_the_move_aside_destination_is_dot_old_under_the_timestamp() -> None:
+    # Arrange: the recovery path is "restore from .old/<ts>/", so the location
+    # has to be predictable rather than merely somewhere safe.
+    # Act
+    plan = _ready_plan(target_dir_exists=True)
+    # Assert
+    assert plan.move_aside.destination == f"{TARGET_DIR}/.old/{STAMP}"
+
+
+def test_a_move_aside_still_lets_the_transport_proceed() -> None:
+    # Arrange: an occupied destination is a thing to handle, not a reason to
+    # refuse — otherwise a second relocation onto a former home is impossible.
+    # Act
+    plan = _ready_plan(target_dir_exists=True)
+    # Assert
+    assert plan.proceed is True
+
+
+def test_an_empty_destination_needs_no_move_aside() -> None:
+    # Arrange: the common case must not manufacture an empty .old/ directory.
+    # Act
+    plan = _ready_plan(target_dir_exists=False)
+    # Assert
+    assert plan.move_aside.required is False
+
+
+def test_an_unchecked_destination_refuses_rather_than_assuming_it_is_empty() -> None:
+    # Arrange: assuming empty is how the only copy of an earlier conversation
+    # gets overwritten.
+    # Act
+    plan = _ready_plan(target_dir_exists=None)
+    # Assert
+    assert plan.proceed is None
+
+
+def test_a_required_move_aside_must_name_its_destination() -> None:
+    # Arrange: the invariant lives in the type — a move with nowhere to go is
+    # unrepresentable rather than merely discouraged.
+    from scitex_agent_container._lifecycle._relocate_transport import MoveAside
+
+    # Act
+    build = lambda: MoveAside(required=True, destination="", reason="x")  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+# --------------------------------------------------------------------------
+# Credentials never travel
+# --------------------------------------------------------------------------
+
+
+def test_the_credentials_file_is_not_transferable() -> None:
+    # Arrange: the operator's explicit requirement, pinned by NAME so a future
+    # widening of the filter has to argue with a test that says "credentials".
+    # Act
+    transferable = is_transferable(".credentials.json")
+    # Assert
+    assert transferable is False
+
+
+def test_every_named_credential_basename_is_refused() -> None:
+    # Arrange: the constant exists to be exhaustive, so assert over all of it
+    # rather than over the one example that happens to be on our minds.
+    # Act
+    allowed = [n for n in CREDENTIAL_BASENAMES if is_transferable(n)]
+    # Assert
+    assert allowed == []
+
+
+def test_a_credential_beside_a_transcript_is_dropped_from_the_selection() -> None:
+    # Arrange: the realistic shape — a directory listing containing both.
+    # Act
+    carried, _ = select_transferable([".credentials.json", "abc.jsonl"])
+    # Assert
+    assert carried == ("abc.jsonl",)
+
+
+def test_a_refused_credential_is_reported_rather_than_silently_dropped() -> None:
+    # Arrange: a filter whose output is only the survivors cannot be told from
+    # one that never ran.
+    # Act
+    _, refused = select_transferable([".credentials.json", "abc.jsonl"])
+    # Assert
+    assert refused[0][0] == ".credentials.json"
+
+
+def test_the_credential_refusal_explains_that_the_target_re_issues_its_own() -> None:
+    # Arrange: the reason matters — someone will eventually ask why their agent
+    # lost its login, and the answer must already be in the output.
+    # Act
+    _, refused = select_transferable([".credentials.json"])
+    # Assert
+    assert "re-issues its own" in refused[0][1]
+
+
+def test_a_non_transcript_file_does_not_travel() -> None:
+    # Arrange: the allowlist, stated positively.
+    # Act
+    carried, _ = select_transferable(["notes.md", "config.json", "x.jsonl"])
+    # Assert
+    assert carried == ("x.jsonl",)
+
+
+def test_a_bare_suffix_is_not_a_transcript() -> None:
+    # Arrange: ".jsonl" with no stem is not a session file; accepting it would
+    # let an oddly-named artefact through the one filter that guards this.
+    # Act
+    transferable = is_transferable(".jsonl")
+    # Assert
+    assert transferable is False
+
+
+def test_a_directory_holding_no_transcript_is_a_decided_no() -> None:
+    # Arrange: distinct from an unreadable listing — we looked, and there is
+    # nothing. The agent will start with no memory, which must be said out loud.
+    # Act
+    plan = _ready_plan(source_files=[".credentials.json", "notes.md"])
+    # Assert
+    assert plan.code == CODE_NOTHING_TO_CARRY
+
+
+def test_an_unlisted_source_directory_is_unknown_not_empty() -> None:
+    # Arrange: treating a failed listing as "no transcripts" relocates an agent
+    # with no memory and reports success doing it.
+    # Act
+    plan = _ready_plan(source_files=None)
+    # Assert
+    assert plan.code == CODE_UNKNOWN
+
+
+def test_a_plan_that_proceeds_must_name_at_least_one_file() -> None:
+    # Arrange: a transport that copies nothing and reports success is exactly
+    # the failure shape this feature exists to prevent, so the type refuses it.
+    from scitex_agent_container._lifecycle._relocate_transport import TransportPlan
+
+    # Act
+    build = lambda: TransportPlan(  # noqa: E731
+        proceed=True, code=CODE_READY, reason="x", files=()
+    )
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_missing_target_dir_refuses_rather_than_falling_back_to_the_source_path() -> (
+    None
+):
+    # Arrange: the whole point of deriving the destination from the TARGET. A
+    # source-shaped path here would produce an invisible transcript.
+    # Act
+    plan = _ready_plan(target_dir="")
+    # Assert
+    assert plan.proceed is None
+
+
+# --------------------------------------------------------------------------
+# Arrival is confirmed by content — the truncation case, from real files
+# --------------------------------------------------------------------------
+
+
+def test_an_identical_copy_is_confirmed(tmp_path) -> None:
+    # Arrange: the positive control for the verification half, built from real
+    # files so the counting code is exercised rather than assumed.
+    src = tmp_path / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
+    dst = tmp_path / "landed" / "sess.jsonl"
+    dst.parent.mkdir()
+    dst.write_bytes(src.read_bytes())
+    # Act
+    verdict = verify_arrival(sent=[_measure(src)], landed=[_measure(dst)])
+    # Assert
+    assert verdict.arrived is True
+
+
+def test_a_confirmed_arrival_carries_the_success_code(tmp_path) -> None:
+    # Arrange: same fixture, asserting the code callers branch on.
+    src = tmp_path / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
+    dst = tmp_path / "sess-copy.jsonl"
+    dst.write_bytes(src.read_bytes())
+    landed = TranscriptFile(
+        name="sess.jsonl",
+        byte_count=len(dst.read_bytes()),
+        line_count=len(dst.read_bytes().splitlines()),
+    )
+    # Act
+    verdict = verify_arrival(sent=[_measure(src)], landed=[landed])
+    # Assert
+    assert verdict.code == CODE_ARRIVED
+
+
+def test_a_truncated_copy_is_caught(tmp_path) -> None:
+    # Arrange: THE case. A real transcript, and a real short copy of it — the
+    # shape a partial transfer leaves behind. It parses; nothing else notices.
+    src = tmp_path / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
+    short = tmp_path / "landed" / "sess.jsonl"
+    short.parent.mkdir()
+    short.write_text(LINES[0] + "\n", encoding="utf-8")
+    # Act
+    verdict = verify_arrival(sent=[_measure(src)], landed=[_measure(short)])
+    # Assert
+    assert verdict.arrived is False
+
+
+def test_a_truncated_copy_names_the_truncation(tmp_path) -> None:
+    # Arrange: distinguishing "arrived short" from "never arrived" is what tells
+    # the operator whether to retry the copy or go and find out why it never ran.
+    src = tmp_path / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
+    short = tmp_path / "landed" / "sess.jsonl"
+    short.parent.mkdir()
+    short.write_text(LINES[0] + "\n", encoding="utf-8")
+    # Act
+    verdict = verify_arrival(sent=[_measure(src)], landed=[_measure(short)])
+    # Assert
+    assert verdict.code == CODE_TRUNCATED
+
+
+def test_the_truncation_report_names_the_file_and_both_counts(tmp_path) -> None:
+    # Arrange: "the transfer failed" without the numbers means going and diffing
+    # two hosts by hand.
+    src = tmp_path / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
+    short = tmp_path / "landed" / "sess.jsonl"
+    short.parent.mkdir()
+    short.write_text(LINES[0] + "\n", encoding="utf-8")
+    # Act
+    verdict = verify_arrival(sent=[_measure(src)], landed=[_measure(short)])
+    # Assert
+    assert "sess.jsonl" in verdict.mismatches[0] and "3 lines" in verdict.mismatches[0]
+
+
+def test_a_same_size_copy_with_a_different_line_count_is_caught() -> None:
+    # Arrange: why BOTH counts are compared. A transport that rewrote line
+    # endings can leave the byte count plausible while losing record boundaries.
+    sent = [TranscriptFile("s.jsonl", byte_count=120, line_count=3)]
+    landed = [TranscriptFile("s.jsonl", byte_count=120, line_count=1)]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert verdict.arrived is False
+
+
+def test_a_file_absent_on_the_target_is_its_own_outcome() -> None:
+    # Arrange: the copy did not happen at all, which is a different next move
+    # from a copy that happened badly.
+    sent = [TranscriptFile("s.jsonl", byte_count=10, line_count=1)]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=[])
+    # Assert
+    assert verdict.code == CODE_MISSING_ON_TARGET
+
+
+def test_an_unmeasured_target_file_is_unknown_not_a_pass() -> None:
+    # Arrange: "I could not count it" and "it counted the same" are the two
+    # answers this function exists to keep apart.
+    sent = [TranscriptFile("s.jsonl", byte_count=10, line_count=1)]
+    landed = [TranscriptFile("s.jsonl", byte_count=None, line_count=None)]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert verdict.arrived is None
+
+
+def test_an_unmeasured_source_file_is_unknown_not_a_pass() -> None:
+    # Arrange: the same rule on the other side — without a baseline there is
+    # nothing to compare the target against.
+    sent = [TranscriptFile("s.jsonl")]
+    landed = [TranscriptFile("s.jsonl", byte_count=10, line_count=1)]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert verdict.code == CODE_UNKNOWN
+
+
+def test_an_empty_sent_set_cannot_confirm_anything() -> None:
+    # Arrange: comparing nothing to nothing must not read as a successful
+    # transfer — that is a green light produced by the absence of evidence.
+    # Act
+    verdict = verify_arrival(sent=[], landed=[])
+    # Assert
+    assert verdict.arrived is None
+
+
+def test_an_extra_file_on_the_target_is_not_a_failure() -> None:
+    # Arrange: the destination is the agent's own projects directory and may
+    # legitimately hold other conversations. Refusing here would refuse a
+    # healthy relocation onto a host the agent lived on before.
+    sent = [TranscriptFile("s.jsonl", byte_count=10, line_count=1)]
+    landed = [
+        TranscriptFile("s.jsonl", byte_count=10, line_count=1),
+        TranscriptFile("older.jsonl", byte_count=999, line_count=42),
+    ]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert verdict.arrived is True
+
+
+def test_an_arrival_with_mismatches_is_unrepresentable() -> None:
+    # Arrange: a success may not disagree with its own evidence — the invariant
+    # lives in the type rather than in the discipline of every call site.
+    # Act
+    build = lambda: ArrivalVerdict(  # noqa: E731
+        arrived=True, code=CODE_ARRIVED, reason="x", mismatches=("s.jsonl: short",)
+    )
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_neither_outcome_defines_a_bool() -> None:
+    # Arrange: `if plan:` / `if verdict:` on an UNKNOWN would read as a yes, and
+    # the next thing that happens is a write onto another machine. Python falls
+    # back to truthy for any object, so the guard is that we never DEFINE
+    # __bool__ — pinned so a future convenience has to argue with a test.
+    from scitex_agent_container._lifecycle._relocate_transport import TransportPlan
+
+    # Act
+    defined = "__bool__" in vars(TransportPlan) or "__bool__" in vars(ArrivalVerdict)
+    # Assert
+    assert defined is False

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_transport_paths.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_transport_paths.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""A transcript under the wrong directory name is present, intact, and invisible.
+
+The encoding assertions here are not guesses at Claude Code's rules — they are
+pinned against directory names MEASURED on this fleet's own disk (2026-08-11,
+``~/.claude/projects``)::
+
+    /home/ywatanabe/proj/scitex-agent-container
+        -> -home-ywatanabe-proj-scitex-agent-container
+    /home/ywatanabe/proj/scitex-agent-container/.worktrees/fix-accounts-...
+        -> -home-ywatanabe-proj-scitex-agent-container--worktrees-fix-accounts-...
+    /home/ywatanabe/.dotfiles/src/.bash.d
+        -> -home-ywatanabe--dotfiles-src--bash-d
+
+Those three cover the rules that matter: ``/`` and ``.`` both become ``-``,
+hyphens already in a path segment survive, and a hidden directory produces the
+doubled dash rather than a tripled one.
+
+The load-bearing test in this file is the LAST one: resolving the workdir locally
+would resolve it against the SOURCE's filesystem, so an unobserved target workdir
+must be UNKNOWN rather than a confident local guess.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_transport_paths import (
+    CODE_DERIVED,
+    CODE_UNKNOWN,
+    TargetTranscriptDir,
+    derive_target_dir,
+    encode_workdir,
+)
+
+HOME = "/home/agent"
+
+
+def _derive(**over):
+    kwargs = {
+        "target_home": HOME,
+        "target_resolved_workdir": "/home/ywatanabe/proj/lead",
+        "source_dir_name": None,
+    }
+    kwargs.update(over)
+    return derive_target_dir(**kwargs)
+
+
+def test_a_plain_path_encodes_with_leading_dash() -> None:
+    # Arrange: measured on disk — the leading slash produces a leading dash, so
+    # the name is not simply the path with separators swapped.
+    # Act
+    encoded = encode_workdir("/home/ywatanabe/proj/scitex-agent-container")
+    # Assert
+    assert encoded == "-home-ywatanabe-proj-scitex-agent-container"
+
+
+def test_a_hidden_directory_produces_a_doubled_dash() -> None:
+    # Arrange: measured on disk. `/.worktrees` would naively give three dashes;
+    # Claude Code collapses them, and a transcript written to the naive name is
+    # invisible.
+    # Act
+    encoded = encode_workdir("/home/y/proj/repo/.worktrees/topic")
+    # Assert
+    assert encoded == "-home-y-proj-repo--worktrees-topic"
+
+
+def test_dots_inside_a_segment_also_become_dashes() -> None:
+    # Arrange: measured on disk (`/home/ywatanabe/.dotfiles/src/.bash.d`) — the
+    # rule is about the character, not about the leading position.
+    # Act
+    encoded = encode_workdir("/home/ywatanabe/.dotfiles/src/.bash.d")
+    # Assert
+    assert encoded == "-home-ywatanabe--dotfiles-src--bash-d"
+
+
+def test_hyphens_already_in_the_path_survive() -> None:
+    # Arrange: the fleet's repos are hyphenated, so this is every real path.
+    # Act
+    encoded = encode_workdir("/home/y/proj/scitex-agent-container")
+    # Assert
+    assert encoded == "-home-y-proj-scitex-agent-container"
+
+
+def test_the_destination_hangs_off_the_targets_home() -> None:
+    # Arrange: the store lives under $HOME; using this host's home would name a
+    # directory on the wrong machine.
+    # Act
+    derived = _derive()
+    # Assert
+    assert derived.path == f"{HOME}/.claude/projects/-home-ywatanabe-proj-lead"
+
+
+def test_a_successful_derivation_carries_the_derived_code() -> None:
+    # Arrange: callers branch on the code.
+    # Act
+    derived = _derive()
+    # Assert
+    assert derived.code == CODE_DERIVED
+
+
+def test_a_trailing_slash_on_the_home_does_not_double_up() -> None:
+    # Arrange: a probe that reports `$HOME` with a trailing slash must not yield
+    # a path with `//`, which some remote tools treat as a different path.
+    # Act
+    derived = _derive(target_home="/home/agent/")
+    # Assert
+    assert "//" not in derived.path
+
+
+def test_a_matching_encoding_is_reported_as_matching() -> None:
+    # Arrange: the common case — both hosts resolve the workdir identically.
+    # Act
+    derived = _derive(source_dir_name="-home-ywatanabe-proj-lead")
+    # Assert
+    assert derived.matches_source is True
+
+
+def test_a_differing_encoding_is_reported_rather_than_refused() -> None:
+    # Arrange: a mismatch is the NORMAL, correct outcome when the two hosts
+    # resolve the workdir differently — and it is the whole reason the name is
+    # recomputed. It must be surfaced, not treated as an error.
+    # Act
+    derived = _derive(source_dir_name="-mnt-c-elsewhere")
+    # Assert
+    assert derived.matches_source is False
+
+
+def test_a_differing_encoding_still_derives_a_usable_path() -> None:
+    # Arrange: refusing here would block exactly the relocation this module was
+    # written to make correct.
+    # Act
+    derived = _derive(source_dir_name="-mnt-c-elsewhere")
+    # Assert
+    assert derived.path == f"{HOME}/.claude/projects/-home-ywatanabe-proj-lead"
+
+
+def test_the_mismatch_reason_names_both_directory_names() -> None:
+    # Arrange: a reader seeing "the names differ" needs to know which is which
+    # to judge whether the target's workdir is what the spec claims.
+    # Act
+    derived = _derive(source_dir_name="-mnt-c-elsewhere")
+    # Assert
+    assert "-mnt-c-elsewhere" in derived.reason and "-home-ywatanabe-proj-lead" in (
+        derived.reason
+    )
+
+
+def test_an_unasked_comparison_stays_unknown_rather_than_defaulting_to_same() -> None:
+    # Arrange: defaulting to "same" would be a claim nobody made, and it is the
+    # claim that is false in exactly the case this module guards.
+    # Act
+    derived = _derive(source_dir_name=None)
+    # Assert
+    assert derived.matches_source is None
+
+
+def test_an_unobserved_target_home_refuses() -> None:
+    # Arrange: this host's $HOME is not evidence about the other host's.
+    # Act
+    derived = _derive(target_home=None)
+    # Assert
+    assert derived.code == CODE_UNKNOWN
+
+
+def test_an_unobserved_target_workdir_refuses_rather_than_resolving_locally() -> None:
+    # Arrange: THE test. Resolving the workdir in this process resolves it
+    # against the SOURCE's filesystem, so a local answer would be confidently
+    # wrong in precisely the case that matters — and the resulting transcript is
+    # readable, byte-identical, and invisible to the target's runner.
+    # Act
+    derived = _derive(target_resolved_workdir=None)
+    # Assert
+    assert derived.path is None
+
+
+def test_the_unobserved_workdir_hint_names_the_measurement_to_take() -> None:
+    # Arrange: an UNKNOWN calls for "go and measure it", so it must say what to
+    # measure — the RESOLVED workdir, not the declared one.
+    # Act
+    derived = _derive(target_resolved_workdir=None)
+    # Assert
+    assert "realpath" in derived.hint or "readlink" in derived.hint
+
+
+def test_a_failed_derivation_must_say_what_to_do_next() -> None:
+    # Arrange: the invariant lives in the type — an unhelpful UNKNOWN is
+    # unrepresentable rather than merely discouraged.
+    # Act
+    build = lambda: TargetTranscriptDir(  # noqa: E731
+        path=None, code=CODE_UNKNOWN, reason="nope", hint=""
+    )
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_the_derivation_defines_no_bool() -> None:
+    # Arrange: `if target_dir:` on an underived one would read as "we know where
+    # to put it". Pinned so a future convenience has to argue with a test.
+    # Act
+    defined = "__bool__" in vars(TargetTranscriptDir)
+    # Assert
+    assert defined is False

--- a/tests/scitex_agent_container/cli_pkg/test__relocate_cmd.py
+++ b/tests/scitex_agent_container/cli_pkg/test__relocate_cmd.py
@@ -192,3 +192,75 @@ def test_dry_run_is_the_default() -> None:
     default = param.default
     # Assert
     assert default is True
+
+
+# ---------------------------------------------------------------------------
+# the not-yet-built refusal — accurate, and generated rather than hard-coded
+# ---------------------------------------------------------------------------
+
+
+def test_the_refusal_covers_every_phase() -> None:
+    # Arrange: the previous refusal named ONE missing piece and went stale the
+    # moment that piece was built. Generating it from the phase table means it
+    # cannot claim less than the truth — but only if the table is complete.
+    from scitex_agent_container._lifecycle._relocate_phases import PHASES, PREFLIGHT
+    from scitex_agent_container.cli_pkg._relocate_cmd import _PHASE_READINESS
+
+    # Act
+    covered = tuple(phase for phase, _, _ in _PHASE_READINESS)
+    # Assert
+    assert covered == tuple(p for p in PHASES if p != PREFLIGHT)
+
+
+def test_the_refusal_names_the_transport_phase_as_built() -> None:
+    # Arrange: the operator's question is "what is missing", and answering it
+    # requires saying what is NOT. The transport decision layer exists now.
+    from scitex_agent_container.cli_pkg._relocate_cmd import _unimplemented_notice
+
+    # Act
+    text = "\n".join(_unimplemented_notice())
+    # Assert
+    assert "_relocate_transport" in text
+
+
+def test_the_refusal_names_the_arrival_brief_as_built() -> None:
+    # Arrange: the other half of this change, so the notice reflects it too.
+    from scitex_agent_container.cli_pkg._relocate_cmd import _unimplemented_notice
+
+    # Act
+    text = "\n".join(_unimplemented_notice())
+    # Assert
+    assert "_relocate_arrival" in text
+
+
+def test_the_refusal_no_longer_blames_the_transcript_transport() -> None:
+    # Arrange: THE stale sentence. It said the cross-host transcript transport
+    # was "not built"; that is now false, and a refusal that misstates its own
+    # cause sends the reader to build something that already exists.
+    from scitex_agent_container.cli_pkg._relocate_cmd import _unimplemented_notice
+
+    # Act
+    text = "\n".join(_unimplemented_notice())
+    # Assert
+    assert "transcript transport is not built" not in text
+
+
+def test_the_refusal_says_what_is_actually_missing() -> None:
+    # Arrange: the honest cause is the absent I/O adapters, not the decisions.
+    from scitex_agent_container.cli_pkg._relocate_cmd import _unimplemented_notice
+
+    # Act
+    text = "\n".join(_unimplemented_notice())
+    # Assert
+    assert "no I/O adapters wired" in text
+
+
+def test_the_refusal_warns_about_the_target_side_directory_name() -> None:
+    # Arrange: the operator will move the transcript by hand meanwhile, and the
+    # source-named directory is the trap that makes a hand move look successful.
+    from scitex_agent_container.cli_pkg._relocate_cmd import _unimplemented_notice
+
+    # Act
+    text = "\n".join(_unimplemented_notice())
+    # Assert
+    assert "invisible to the target's runner" in text


### PR DESCRIPTION
Adds the three pieces the operator asked for on 2026-08-11 —
「jsonl の機能付け加えてくださいね。しかも tgt agent には『あなたは <src> から <tgt> に
移動してきました；記憶はここで resume の id はこれです』みたいな説明もあった方が良さそう
です。というか、ハンドシェイクが必要なはずで」— on top of the phase driver merged in #958.

## What is new

**`_relocate_transport.py`** — the transport phase's decision and verification.
Selection is an ALLOWLIST (`*.jsonl` only, so a credential cannot travel by being
newly named), move-aside to `.old/<ts>/` when the target already holds a
transcript directory, and arrival confirmed per file by BYTE **and** LINE count.
Three-valued throughout, no `__bool__`.

**`_relocate_transport_paths.py`** — the destination, derived from the TARGET's
resolved workdir. This is the correctness constraint that makes the whole feature
work: a transcript copied under the SOURCE's encoded directory name is present,
byte-identical, and invisible to the target's runner — the "started, healthy,
does nothing" shape. Reuses `_runners._session_candidates.encode_claude_project`
rather than reimplementing the encoding, and refuses (UNKNOWN) when the target's
resolved workdir was not observed, because resolving it locally resolves it
against the *source's* filesystem.

**`_relocate_arrival.py`** — the message the relocated agent receives. It states
the move, the resumed session id, that the source is stopped, and that everything
above it in the transcript describes the other host. It IS the handshake
challenge (carries the nonce and the proof-of-work question), so the agent's
answer is the B→A leg `_relocate_handshake` already required.

## The phase order changed, and it was forced

    before  preflight → target_standby → handshake → source_drain → handover → source_stop → done
    after   preflight → source_drain → source_stop → TRANSPORT → target_standby → handshake → handover → done

Two physical constraints leave exactly one legal slot for the transport:

* a **running** source appends to its `.jsonl` mid-read, and a jsonl truncated
  mid-line is not detectably truncated — it parses, it resumes, the conversation
  just stops early. So `source_stop` must precede `transport`.
* a target that has **already booted** owns its own session marker, and seeding
  over it would discard whatever it did (`_session_carry`, first-boot-only). So
  `transport` must precede `target_standby`.

The previous order reads safer (source stays up until the target proves itself)
and cannot carry a transcript at all.

**The price, stated rather than hidden:** from `source_stop` onward the agent is
down on both hosts, and an abort in that window leaves it stopped. Nothing here
restarts it — that would be another lifecycle action taken when least is known,
racing a re-run about to stop it again. Instead `ExecuteOutcome.source_left_stopped`
(new field) and the abort verdict name the stopped agent and the one command that
undoes it. Residency is still written only at DONE, so a stopped source is still
the owner of record and two hosts never both claim one identity.

## The operator's four acceptance points

| # | point | status |
|---|---|---|
| 1 | src → tgt confirmation | **partly there.** #958 shipped `carry_transcript` (sha256 read-back, one payload). ADDED: per-file byte+line `verify_arrival`, and the target-side path derivation without which a verified copy can still be invisible. |
| 2 | tgt → src confirmation | **already there.** `_relocate_handshake.evaluate_handshake` requires accepted + reply OBSERVED BY THE SOURCE + nonce correlated + work proven, and UNKNOWN refuses. What was missing was the message; ADDED as `_relocate_arrival`. |
| 3 | src 退縮 (retirement) | **already there, reordered.** HANDOVER (lease) and DONE (residency record = the host write) existed; `abort` already refused at/past HANDOVER. Moving `source_stop` earlier is what makes "the source agent stays stopped" true at retirement. NOT DONE: moving the source's transcript dir aside — see below. |
| 4 | named recoverable failure states | **partly there.** #958 had three-valued outcomes, `standby_left_running`, the abort-before/report-after asymmetry, and free re-entry. ADDED: `leaves_source_stopped()` + the `source_left_stopped` field + abort text for the new window; move-aside makes a transport retry idempotent. Nothing is ever deleted and no compensation is ever performed automatically. |

## What I deliberately left out

* **The I/O adapters.** There is no ssh/scp/a2a code in this PR. `--no-dry-run`
  still exits `EXIT_UNIMPLEMENTED` — but the refusal is now generated from a
  per-phase table and no longer claims the transcript transport is the missing
  piece, which had become false. I did not ship an unverified transport: the
  fleet is mid-migration, I could not exercise it against two real hosts, and a
  transport that looks like it works is exactly the 2026-08-07 failure this
  command was written to prevent. **No end-to-end run against real hosts was
  performed, and none is claimed.**
* **Moving the SOURCE's transcript dir aside at retirement** (part of point 3).
  It belongs in the DONE effect, which is an adapter.
* **Wiring `plan_session_carry` / `carry_transcript`.** Both shipped in #958 with
  no production caller and still have none; they are the per-payload layer under
  this per-set layer, and the adapter is what joins them.

## Found while working, not asked about

**`_mcp/_tools/_subagent.py::_project_hash_for` computes the project directory
differently from the other three implementations** and is wrong for any path
containing a dot segment:

    _project_hash_for:            s.replace("/", "-")
    the other three:              .replace("/","-").replace(".","-") then -{3,} → --

`/home/y/proj/repo/.worktrees/topic` → `-home-y-proj-repo-.worktrees-topic`
instead of `-home-y-proj-repo--worktrees-topic`. Every agent working in a
`.worktrees/` checkout hits this, so subagent transcript lookup silently finds
nothing there. Not touched in this PR (different subsystem, and the sibling
agents' lane); worth its own card.

Also: `config/_loaders.py` defines `_DEFAULT_WORKDIR_RUNTIME` twice (lines 102
and 120, identical value), and the container image carries two `scitex-dev`
dist-infos (0.43.1 and 0.47.0) so every lint-hook run warns about ambiguous
metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcDz9gLL2Ct24FXqX2SF9T
