### PR TITLE
feat(relocate): the ssh adapters, and what running them against two real hosts found

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_relocate_effects.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_effects.py
@@ -1,0 +1,446 @@
+"""The adapters that turn each decided phase into something that happens on two machines.
+
+:mod:`_relocate_execute` owns the ORDER and refuses to run without an effect for
+every phase; :mod:`_relocate_transport`, ``_relocate_transport_paths``,
+``_relocate_handshake`` and ``_relocate_lease`` own the DECISIONS and touch
+nothing. This module is the join: it measures, it acts, and it hands each
+decision module real observations instead of assumptions.
+
+EVERY PHASE THAT IS NOT BUILT REFUSES BY NAME — see
+:func:`._relocate_liveness.unimplemented`. The driver requires an effect per
+phase precisely so the tempting shortcut (omit one, let it pass as a no-op) is
+unavailable; a named UNKNOWN is what goes there instead, and the relocation stops
+at that phase in a state the journal records.
+
+THE FOUR CRITERIA, AND WHERE EACH IS ENFORCED RATHER THAN DESCRIBED:
+
+    src -> tgt confirmation is CONTENT-verified arrival. :meth:`transport`
+    measures every carried file ON THE TARGET with the target's own shell and
+    passes both sides to :func:`verify_arrival`. The copy pipeline's exit code is
+    recorded as evidence and is never the answer.
+
+    tgt -> src confirmation is an OBSERVED answer, and UNKNOWN refuses.
+    :meth:`handshake` builds the arrival brief (which IS the challenge) and hands
+    what was actually seen to :func:`evaluate_handshake`. Nothing here converts
+    "I saw no reply" into "there was none", nor an accepted send into a reply.
+
+    RETIREMENT HAPPENS ONLY AFTER BOTH. :meth:`finish` re-checks the two recorded
+    confirmations before writing residency or moving anything. The phase order
+    already guarantees it — the driver stops on any non-yes — but a guarantee
+    living only in another module's control flow is one refactor from untrue, and
+    this is the step that moves a human's conversation out from under them.
+
+    FAILURE LANDS IN A NAMED STATE, RETRY IS IDEMPOTENT, ROLLBACK IS DELIBERATE.
+    A stop re-stops nothing; a copy re-copies onto a destination moved aside
+    again; a residency write to the host already recorded is a no-op. NOTHING IS
+    EVER DELETED — the target's prior transcript directory and the source's
+    retired one both go to ``.old/<stamp>/``, so undoing a relocation is a human
+    moving a directory back, never this code deciding it should.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Callable
+
+from ._relocate_arrival import build_arrival_brief
+from ._relocate_execute import PhaseEffects, StepResult
+from ._relocate_handshake import HandshakeFacts, evaluate_handshake
+from ._relocate_effects_source import SourceEffects
+from ._relocate_liveness import observe_running, unimplemented
+from ._relocate_move_aside import move_aside_destination
+from ._relocate_shell import Shell, resolved_path, shell_for
+from ._relocate_transcript_home import transcript_home_from_spec
+from ._relocate_transport import TranscriptFile, plan_transport, verify_arrival
+from ._relocate_transport_paths import derive_target_dir
+from ._relocate_transport_ssh import (
+    copy_transcripts,
+    ensure_dir,
+    list_transcript_dir,
+    measure_transcripts,
+    move_dir_aside,
+)
+
+__all__ = ["RelocateAdapters", "adapters_for", "build_effects"]
+
+
+@dataclass
+class RelocateAdapters(SourceEffects):
+    """One relocation's worth of hosts, paths and RECORDED CONFIRMATIONS.
+
+    The confirmations are fields rather than local variables because
+    :meth:`finish` has to re-read them: "both legs were observed" is a
+    precondition of retiring the source, and a precondition that exists only as
+    control flow somewhere else is not one this module can check.
+    """
+
+    agent: str
+    spec: dict
+    from_host: str
+    to_host: str
+    source: Shell
+    target: Shell
+    stamp: str
+    exec_fn: Callable[..., dict] | None = None
+    now: Callable[[], float] = time.time
+    peers: object = None
+
+    source_dir: str = ""
+    target_dir: str = ""
+    carried: tuple[str, ...] = ()
+    sent: tuple[TranscriptFile, ...] = ()
+    landed: tuple[TranscriptFile, ...] = ()
+    arrival_confirmed: bool | None = None
+    handshake_confirmed: bool | None = None
+    session_uuid: str = ""
+    log: list[str] = field(default_factory=list)
+
+    # -- transport ---------------------------------------------------------
+
+    def _resolve_dirs(self) -> tuple[str | None, str | None, str]:
+        """Source and target transcript directories, or ``(None, None, why)``.
+
+        The target's directory name is RECOMPUTED from the target's own resolved
+        workdir rather than copied from the source's — see
+        :mod:`_relocate_transport_paths`. A mismatch is normal and is logged, not
+        refused: it is the whole reason the name is derived instead of reused.
+        """
+        home = transcript_home_from_spec(self.spec)
+        if home.path is None:
+            return None, None, f"{home.reason} — {home.hint}"
+
+        body = (
+            self.spec.get("spec")
+            if isinstance(self.spec.get("spec"), dict)
+            else self.spec
+        )
+        workdir = str((body or {}).get("workdir") or "").strip()
+        if not workdir:
+            return (
+                None,
+                None,
+                "the spec declares no workdir, so no project directory can be encoded",
+            )
+
+        src_resolved = resolved_path(self.source, workdir, exec_fn=self.exec_fn)
+        tgt_resolved = resolved_path(self.target, workdir, exec_fn=self.exec_fn)
+        if not src_resolved:
+            return (
+                None,
+                None,
+                f"the SOURCE's resolved workdir for {workdir} was not observed",
+            )
+
+        src = derive_target_dir(
+            target_home=home.path, target_resolved_workdir=src_resolved
+        )
+        tgt = derive_target_dir(
+            target_home=home.path,
+            target_resolved_workdir=tgt_resolved,
+            source_dir_name=src.encoded,
+        )
+        if tgt.path is None:
+            return None, None, f"{tgt.reason} — {tgt.hint}"
+        if tgt.matches_source is False:
+            self.log.append(f"transport: {tgt.reason}")
+        return src.path, tgt.path, tgt.reason
+
+    def transport(self) -> StepResult:
+        """Copy the transcript across and CONFIRM it on the target, per file.
+
+        List the source, let :func:`plan_transport` decide what may travel, move
+        aside anything already at the destination, measure the source, copy, then
+        measure THE TARGET and compare. The measurement after the copy is the
+        only statement this step makes about success.
+        """
+        source_dir, target_dir, why = self._resolve_dirs()
+        if source_dir is None or target_dir is None:
+            return StepResult(
+                ok=None,
+                detail=f"the transcript directories could not be derived: {why}",
+                hint=(
+                    "measure the target's resolved workdir and check the spec's bind for "
+                    "the container home. A transcript under the wrong directory name is "
+                    "present, intact and invisible to the runner"
+                ),
+            )
+        self.source_dir, self.target_dir = source_dir, target_dir
+
+        listing = list_transcript_dir(self.source, source_dir, exec_fn=self.exec_fn)
+        running, _ = observe_running(self.source, self.agent, exec_fn=self.exec_fn)
+        target_listing = list_transcript_dir(
+            self.target, target_dir, exec_fn=self.exec_fn
+        )
+
+        plan = plan_transport(
+            source_running=running,
+            source_files=None if listing is None else list(listing),
+            target_dir_exists=None if target_listing is None else bool(target_listing),
+            target_dir=target_dir,
+            stamp=self.stamp,
+        )
+        for name, reason in plan.refused:
+            self.log.append(f"transport: REFUSED {name} — {reason}")
+        if plan.proceed is not True:
+            return StepResult(
+                ok=False if plan.proceed is False else None,
+                detail=f"transport refused ({plan.code}): {plan.reason}",
+                hint=plan.hint,
+            )
+        self.carried = plan.files
+
+        if plan.move_aside is not None and plan.move_aside.required:
+            moved = move_dir_aside(
+                self.target,
+                target_dir,
+                plan.move_aside.destination or "",
+                exec_fn=self.exec_fn,
+            )
+            if moved is not True:
+                return StepResult(
+                    ok=None if moved is None else False,
+                    detail=(
+                        f"{self.to_host} already holds {target_dir} and it could not be "
+                        f"moved aside to {plan.move_aside.destination}"
+                    ),
+                    hint=(
+                        "move it aside by hand and re-run. Nothing is overwritten and "
+                        "nothing is deleted — what is there may be the only copy of an "
+                        "earlier conversation"
+                    ),
+                )
+            self.log.append(
+                f"transport: moved {self.to_host}:{target_dir} aside to {plan.move_aside.destination}"
+            )
+
+        made = ensure_dir(self.target, target_dir, exec_fn=self.exec_fn)
+        if made is not True:
+            return StepResult(
+                ok=None if made is None else False,
+                detail=f"the destination {target_dir} on {self.to_host} could not be created",
+                hint="check write permission on the target's transcript root, then re-run",
+            )
+
+        self.sent = measure_transcripts(
+            self.source, source_dir, plan.files, exec_fn=self.exec_fn
+        )
+        run = copy_transcripts(
+            source=self.source,
+            source_dir=source_dir,
+            target=self.target,
+            target_dir=target_dir,
+            files=plan.files,
+            exec_fn=self.exec_fn,
+            peers=self.peers,
+        )
+        self.log.append(
+            f"transport: copy pipeline exit {run.exit_code} — EVIDENCE ONLY; arrival is "
+            "decided by counting on the target"
+        )
+        if run.stderr.strip():
+            self.log.append(f"transport: copy stderr {run.stderr.strip()[:300]}")
+        self.landed = measure_transcripts(
+            self.target, target_dir, plan.files, exec_fn=self.exec_fn
+        )
+        verdict = verify_arrival(sent=self.sent, landed=self.landed)
+        self.arrival_confirmed = verdict.arrived
+        for line in verdict.mismatches:
+            self.log.append(f"transport: MISMATCH {line}")
+        for f in self.landed:
+            self.log.append(
+                f"transport: target holds {f.name} {f.byte_count} bytes / {f.line_count} lines"
+            )
+        if verdict.arrived is not True:
+            return StepResult(
+                ok=False if verdict.arrived is False else None,
+                detail=f"arrival not confirmed ({verdict.code}): {verdict.reason}",
+                hint=verdict.hint,
+            )
+        if len(plan.files) == 1:
+            self.session_uuid = plan.files[0].rsplit(".", 1)[0]
+        return StepResult(
+            ok=True,
+            detail=(
+                f"{verdict.reason}; {self.from_host}:{source_dir} -> {self.to_host}:{target_dir}"
+            ),
+        )
+
+    # -- target ------------------------------------------------------------
+
+    def start_target_standby(self) -> StepResult:
+        return unimplemented(
+            "target_standby",
+            (
+                "the target holds no spec for this agent and nothing here carries one; "
+                "no session_id marker is written on the target from the carried "
+                "transcript; and the standby is not started without the lease. The "
+                "transcript IS on the target and content-verified — what is missing is "
+                "the boot, not the memory"
+            ),
+        )()
+
+    def handshake(self) -> StepResult:
+        """Build the arrival brief, then refuse — nothing was delivered.
+
+        Built as far as it can honestly go. The brief IS the challenge, so it is
+        constructed here with a fresh nonce and the gate is run against what was
+        actually observed, which is nothing. THAT IS WHY THIS RETURNS UNKNOWN AND
+        NOT "no reply": a challenge sent to a standby nobody started would time
+        out and report the accepted-but-silent shape, which
+        :func:`evaluate_handshake` correctly treats as the 2026-08-11 failure —
+        and reporting it here would be a false accusation against a target that
+        was never booted.
+        """
+        if not self.session_uuid:
+            return unimplemented(
+                "handshake",
+                "the carried session id is not known (the transport carried none, or "
+                "carried more than one), so the brief cannot state the handle the agent "
+                "needs to verify its own continuity",
+            )()
+        nonce = secrets.token_hex(8)
+        brief = build_arrival_brief(
+            agent=self.agent,
+            from_host=self.from_host,
+            to_host=self.to_host,
+            resume_session_id=self.session_uuid,
+            nonce=nonce,
+            question="run `hostname` on the machine you are on now and report it verbatim",
+        )
+        self.log.append(f"handshake: brief built ({len(brief)} chars), nonce {nonce}")
+        verdict = evaluate_handshake(
+            HandshakeFacts(), nonce=nonce, expected_answer=self.to_host
+        )
+        self.handshake_confirmed = verdict.proven
+        return StepResult(
+            ok=None,
+            attempted=False,
+            detail=(
+                "handshake has no delivery adapter: the brief is built and the gate is "
+                f"wired, and nothing was sent because no standby was started ({verdict.reason})"
+            ),
+            hint=(
+                "start the standby, deliver the brief over a2a, and record what came back "
+                "ON THE SOURCE. Do not mark this proven from a send that returned "
+                "accepted — accepted-but-silent is the exact 2026-08-11 shape"
+            ),
+        )
+
+    def hand_over_lease(self) -> StepResult:
+        return unimplemented(
+            "handover",
+            (
+                "the lease decision module is built and its rows now have a home "
+                "(_state.state_db_relocation.save_lease), but nothing claims a lease on "
+                "the source's behalf at start-up, so there is no holder to hand FROM"
+            ),
+        )()
+
+    # -- done --------------------------------------------------------------
+
+    def finish(self) -> StepResult:
+        """Write residency, then retire the source's transcript — in that order.
+
+        BOTH CONFIRMATIONS ARE RE-CHECKED HERE; see the module docstring.
+
+        Residency is written BEFORE the retirement because the two failures are
+        not symmetric: a residency row with the source's transcript still in
+        place is a completed relocation that left a spare copy, while a retired
+        source with no residency row is an agent that lives nowhere.
+        """
+        if self.arrival_confirmed is not True:
+            return StepResult(
+                ok=False,
+                detail=(
+                    "refusing to retire the source: arrival on the target was not "
+                    f"confirmed (arrival_confirmed={self.arrival_confirmed!r})"
+                ),
+                hint="re-run the transport and confirm by byte and line count first",
+            )
+        if self.handshake_confirmed is not True:
+            return StepResult(
+                ok=False,
+                detail=(
+                    "refusing to retire the source: the target never proved, to the "
+                    f"source, that it can do agent work (handshake_confirmed="
+                    f"{self.handshake_confirmed!r})"
+                ),
+                hint=(
+                    "complete the handshake first. Retiring on an unproven target is the "
+                    "2026-08-07 failure with the source's memory moved out of reach"
+                ),
+            )
+
+        from .._state.state_db_relocation import record_residency
+
+        opened = record_residency(
+            agent=self.agent,
+            host=self.to_host,
+            now=self.now(),
+            note=f"relocated from {self.from_host}",
+        )
+        self.log.append(
+            f"done: residency {'opened' if opened else 'already recorded'} on {self.to_host}"
+        )
+
+        retired = move_aside_destination(self.source_dir, self.stamp)
+        moved = move_dir_aside(
+            self.source, self.source_dir, retired, exec_fn=self.exec_fn
+        )
+        if moved is not True:
+            return StepResult(
+                ok=None if moved is None else False,
+                detail=(
+                    f"residency now reads {self.to_host}, and the source's transcript at "
+                    f"{self.source_dir} could not be moved aside"
+                ),
+                hint=(
+                    "move it aside by hand. The relocation itself is complete — the source "
+                    "merely still holds a copy, which is safe and is never deleted"
+                ),
+            )
+        return StepResult(
+            ok=True,
+            detail=(
+                f"residency reads {self.to_host}; the source's transcript was moved aside "
+                f"to {retired} (moved, never deleted)"
+            ),
+        )
+
+
+def build_effects(adapters: RelocateAdapters) -> PhaseEffects:
+    """Bind one :class:`RelocateAdapters` to the driver's phase slots."""
+    return PhaseEffects(
+        drain_source=adapters.drain_source,
+        stop_source=adapters.stop_source,
+        transport_transcript=adapters.transport,
+        start_target_standby=adapters.start_target_standby,
+        handshake=adapters.handshake,
+        hand_over_lease=adapters.hand_over_lease,
+        finish=adapters.finish,
+    )
+
+
+def adapters_for(
+    *,
+    agent: str,
+    spec: dict,
+    from_host: str,
+    to_host: str,
+    local_host: str | None,
+    stamp: str | None = None,
+    exec_fn: Callable[..., dict] | None = None,
+) -> RelocateAdapters:
+    """The usual construction: two shells, one timestamp, nothing else decided."""
+    return RelocateAdapters(
+        agent=agent,
+        spec=spec,
+        from_host=from_host,
+        to_host=to_host,
+        source=shell_for(from_host, local_host=local_host),
+        target=shell_for(to_host, local_host=local_host),
+        stamp=stamp or time.strftime("%Y%m%dT%H%M%SZ", time.gmtime()),
+        exec_fn=exec_fn,
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_effects_source.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_effects_source.py
@@ -1,0 +1,110 @@
+"""The two phases that happen on the host being LEFT: drain, then stop.
+
+Split from :mod:`_relocate_effects` because they are the only steps whose subject
+is the source, and because their shared rule is worth stating once: BOTH are
+gated on an OBSERVED liveness answer, and an unobserved one refuses. A live agent
+appends to its transcript while it is being read, and a jsonl truncated mid-line
+still parses and still resumes — the conversation simply stops early, with
+nothing anywhere reporting a problem. That is the failure the whole ordering of
+this feature was rearranged to prevent, so it is not something to be optimistic
+about.
+
+DRAIN AND STOP ARE NOT THE SAME STEP, and collapsing them is the tempting
+shortcut. A stop mid-turn loses the turn — which is exactly the work a relocation
+exists to carry across. So for a RUNNING agent the drain refuses by name rather
+than quietly doing a stop and calling it drained; for a STOPPED one it is
+vacuously satisfied, and even that is MEASURED rather than assumed.
+"""
+
+from __future__ import annotations
+
+from ._relocate_execute import StepResult
+from ._relocate_liveness import observe_running
+
+__all__ = ["SourceEffects"]
+
+
+class SourceEffects:
+    """Mixin: the source-side phases. Expects the attributes of ``RelocateAdapters``."""
+
+    def drain_source(self) -> StepResult:
+        """Confirm the source is taking no new work.
+
+        FOR A STOPPED AGENT THIS IS VACUOUSLY TRUE, and it is measured rather
+        than assumed: an agent with no session cannot accept work. For a RUNNING
+        one there is no adapter — telling an agent to finish what it holds, take
+        nothing new, and confirming it did, is an agent-protocol question that
+        cannot be answered by looking at a process.
+        """
+        running, why = observe_running(self.source, self.agent, exec_fn=self.exec_fn)
+        if running is False:
+            return StepResult(ok=True, detail=f"nothing to drain — {why}")
+        if running is None:
+            return StepResult(
+                ok=None,
+                detail=f"whether {self.agent} runs on {self.from_host} was not measured: {why}",
+                hint=(
+                    "measure liveness on the source before draining; an unobserved 'is it "
+                    "running' is the precondition the transport depends on"
+                ),
+            )
+        return StepResult(
+            ok=None,
+            attempted=False,
+            detail=(
+                f"{self.agent} is RUNNING on {self.from_host} and there is no drain "
+                "adapter: nothing here can tell an agent to finish its in-flight work, "
+                "take no new work, and confirm that it did"
+            ),
+            hint=(
+                "drain it by hand (let the turn finish, stop dispatching to it), then "
+                "re-run. Do NOT substitute a stop for a drain — a stop mid-turn loses "
+                "the turn, which is exactly the work a relocation exists to carry"
+            ),
+        )
+
+    def stop_source(self) -> StepResult:
+        """Stop the agent on the source host and VERIFY it stopped.
+
+        Idempotent: an already-stopped agent is a success with nothing done. The
+        verification is a SECOND, independent observation after the stop, because
+        ``sac agents stop`` exiting 0 is the command's opinion and the
+        transport's precondition is the tmux server's.
+        """
+        running, why = observe_running(self.source, self.agent, exec_fn=self.exec_fn)
+        if running is False:
+            return StepResult(ok=True, detail=f"already stopped — {why}")
+        if running is None:
+            return StepResult(
+                ok=None,
+                detail=f"could not tell whether {self.agent} runs on {self.from_host}: {why}",
+                hint=(
+                    "measure it before copying. A live agent appends to its transcript "
+                    "mid-read, and a jsonl truncated mid-line still parses and still "
+                    "resumes — the conversation just stops early"
+                ),
+            )
+
+        run = self.source.run(
+            f"sac agents stop {self.agent} --json 2>&1 || true", exec_fn=self.exec_fn
+        )
+        self.log.append(f"stop_source: {run.stdout.strip()[:300]}")
+        after, after_why = observe_running(
+            self.source, self.agent, exec_fn=self.exec_fn
+        )
+        if after is False:
+            return StepResult(ok=True, detail=f"stopped and verified — {after_why}")
+        if after is None:
+            return StepResult(
+                ok=None,
+                detail=f"the stop was issued and the result was not observable: {after_why}",
+                hint="re-observe liveness on the source; do not copy until it reads stopped",
+            )
+        return StepResult(
+            ok=False,
+            detail=f"the stop was issued and {self.agent} is STILL running on {self.from_host}",
+            hint=(
+                "stop it by hand and confirm, then re-run. Copying now would read a "
+                "transcript that is being appended to"
+            ),
+        )

--- a/src/scitex_agent_container/_lifecycle/_relocate_execute.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_execute.py
@@ -123,6 +123,17 @@ class StepResult:
     ok: bool | None
     detail: str
     hint: str = ""
+    #: Whether the effect actually TRIED. Defaults to True, so every existing
+    #: caller keeps its meaning and a forgetful one over-warns.
+    #:
+    #: It exists because "I tried and could not tell whether it worked" and "I
+    #: never tried" are both ``ok=None`` and imply opposite things about the
+    #: world. Measured on the 2026-08-11 canary run: the unbuilt target_standby
+    #: returned UNKNOWN, :func:`_standby_running` conservatively read that as "a
+    #: standby may be running", and the outcome told the operator to go and stop
+    #: a process that had never been started. A false alarm in a recovery
+    #: instruction is not a safe default — it sends someone to the wrong host.
+    attempted: bool = True
 
     def __post_init__(self) -> None:
         if self.ok not in (True, False, None):
@@ -234,16 +245,23 @@ def _missing_effects(effects: PhaseEffects) -> tuple[str, ...]:
     return tuple(p for p in PHASES if p != PREFLIGHT and effects.for_phase(p) is None)
 
 
-def _standby_running(last_done: str, failing: str, unknown: bool) -> bool:
+def _standby_running(
+    last_done: str, failing: str, unknown: bool, attempted: bool = True
+) -> bool:
     """Whether an abort here leaves a started target behind.
 
     True once TARGET_STANDBY has completed, and also when the standby phase
-    ITSELF returned UNKNOWN: an effect that could not say whether the target
-    came up may well have started it, and reporting "nothing was left running"
-    on that basis is the kind of reassurance that sends nobody to look.
+    ITSELF returned UNKNOWN AFTER TRYING: an effect that could not say whether
+    the target came up may well have started it, and reporting "nothing was left
+    running" on that basis is the kind of reassurance that sends nobody to look.
+
+    An effect that never tried is the other case, and it is not the same one. It
+    also cannot have started anything, so claiming it might have sends an
+    operator to stop a process that does not exist — see
+    :attr:`StepResult.attempted`.
     """
     if failing == TARGET_STANDBY:
-        return unknown
+        return unknown and attempted
     return PHASES.index(last_done) >= PHASES.index(TARGET_STANDBY)
 
 
@@ -310,7 +328,9 @@ def execute(
                 now=now(),
                 reason=f"{phase}: {result.detail}",
             )
-            left_running = _standby_running(current.phase, phase, unknown)
+            left_running = _standby_running(
+                current.phase, phase, unknown, result.attempted
+            )
             # Computed against the pre-abort record, for the same reason the
             # phase machine does it: after the abort the phase is ABORTED, and
             # the question is where it got to.

--- a/src/scitex_agent_container/_lifecycle/_relocate_liveness.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_liveness.py
@@ -1,0 +1,136 @@
+"""Is the agent running on that host? Asked of tmux, answered in three values.
+
+The transport's precondition. A running source appends to its ``.jsonl`` while
+it is being read, and a jsonl truncated mid-line still parses and still resumes —
+the conversation simply stops early, with nothing anywhere reporting a problem.
+So this question has to be ASKED, and its unanswered form has to refuse.
+
+WHY tmux AND NOT ``sac agents list``. Three reasons, in order of weight:
+
+    tmux's answer is the same fact the runtime itself checks.
+    :class:`..runtimes.tui_session.TuiSessionRuntime.is_running` looks for the
+    session ``tui-<name>``; asking anything else introduces a second definition
+    of running that can disagree with the one that matters.
+
+    A tmux server that answered and holds no such session is POSITIVE EVIDENCE
+    OF ABSENCE, from tmux's own bookkeeping. That is a different and much
+    stronger thing than a query that failed, and the two must not collapse.
+
+    It needs no venv, no PATH and no sac on the far host. The fewer things that
+    have to be true for the measurement to happen, the fewer ways "I could not
+    tell" gets mistaken for "it is not running".
+
+NO tmux SERVER AT ALL is likewise positive absence, and is reported as such: an
+agent whose runtime IS a tmux session cannot be running where there is no tmux
+server. tmux not being INSTALLED is the opposite — nothing was measured — and
+refuses. Those two look similar in a shell and mean opposite things.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from ._relocate_execute import StepResult
+from ._relocate_shell import Shell
+
+__all__ = ["MARK_RUN", "observe_running", "unimplemented"]
+
+#: Marker line, parsed rather than read off the exit code, so a shell that also
+#: prints a warning cannot be mistaken for a measurement.
+MARK_RUN = "TX-RUN="
+
+
+def unimplemented(phase: str, missing: str) -> Callable[[], StepResult]:
+    """An effect that refuses, naming the piece that does not exist yet.
+
+    UNKNOWN rather than a failure, because nothing was attempted and therefore
+    nothing about the hosts was learned — the same distinction every decision
+    module in this feature makes, turned on our own absence. The driver requires
+    an effect for every phase precisely so that "leave it out and let it pass"
+    is unavailable; this is the honest thing to put there instead.
+    """
+
+    def effect() -> StepResult:
+        return StepResult(
+            ok=None,
+            # Nothing was attempted, so nothing can have been left behind. The
+            # driver reads this to decide whether to tell the operator a standby
+            # may still be running; without it the recovery instruction sends
+            # somebody to stop a process that was never started.
+            attempted=False,
+            detail=f"{phase} has no adapter: {missing}",
+            hint=(
+                f"build the {phase} adapter, or complete this phase by hand and re-run "
+                "— the journal records where this stopped and a re-run resumes from here"
+            ),
+        )
+
+    return effect
+
+
+def observe_running(
+    shell: Shell,
+    agent: str,
+    *,
+    exec_fn: Callable[..., dict] | None = None,
+) -> tuple[bool | None, str]:
+    """``(running, why)`` for ``agent`` on ``shell``. ``None`` means not measured.
+
+    The reason travels with the answer because every caller puts it in a journal
+    entry or a refusal, and "could not determine" with no account of what was
+    tried is not something anyone can act on.
+    """
+    session = f"tui-{agent}"
+    body = (
+        "if ! command -v tmux >/dev/null 2>&1; then "
+        f"printf '{MARK_RUN}no-tmux\\n'; exit 0; fi\n"
+        "if ! tmux list-sessions >/dev/null 2>&1; then "
+        f"printf '{MARK_RUN}no-server\\n'; exit 0; fi\n"
+        f"if tmux has-session -t '{session}' 2>/dev/null; then "
+        f"printf '{MARK_RUN}yes\\n'; else printf '{MARK_RUN}no\\n'; fi"
+    )
+    run = shell.run(body, exec_fn=exec_fn)
+    return interpret_liveness(
+        [
+            ln[len(MARK_RUN) :].strip()
+            for ln in run.stdout.splitlines()
+            if ln.startswith(MARK_RUN)
+        ],
+        host=shell.host,
+        session=session,
+        exit_code=run.exit_code,
+        stderr=run.stderr,
+    )
+
+
+def interpret_liveness(
+    answers: list[str],
+    *,
+    host: str,
+    session: str,
+    exit_code: int,
+    stderr: str,
+) -> tuple[bool | None, str]:
+    """Turn the probe's marker lines into a verdict. Pure, so it is testable."""
+    answer = answers[0] if answers else ""
+    if answer == "yes":
+        return True, f"tmux on {host} has session {session}"
+    if answer == "no":
+        return False, (
+            f"tmux on {host} answered and has NO session {session} — positive evidence "
+            "of absence, from tmux's own bookkeeping"
+        )
+    if answer == "no-server":
+        return False, (
+            f"no tmux server is running on {host}, so a tui-runtime agent cannot be "
+            "running there"
+        )
+    if answer == "no-tmux":
+        return None, f"tmux is not installed on {host}; liveness was not measured"
+    return None, (
+        f"the liveness probe on {host} produced no answer (exit {exit_code}): "
+        f"{stderr.strip()[:160]}"
+    )
+
+
+__all__.append("interpret_liveness")

--- a/src/scitex_agent_container/_lifecycle/_relocate_move_aside.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_move_aside.py
@@ -1,0 +1,48 @@
+"""Where a directory goes when it must be preserved: BESIDE itself, never inside itself.
+
+One rule, one function, because it is needed in two places — the target's prior
+transcript directory before a copy, and the source's own after a completed move —
+and the two must not drift.
+
+    <parent>/.old/<stamp>/<name>        correct
+    <directory>/.old/<stamp>            a path that cannot exist
+
+MEASURED 2026-08-11, on the canary run's SECOND pass. The first relocation
+copied 3.6 MB across two hosts and verified it by byte and line count. The
+second — the idempotency retry, run against a target that now held the previous
+copy — computed the move-aside destination inside the directory being moved.
+``mv`` refused with "cannot move a directory into itself", the transport stopped,
+and what should have been a clean retry was a dead end.
+
+A PURE MODULE COULD NOT HAVE CAUGHT THIS. The string was well-formed, the
+function returned, every unit test passed, and the test that pinned the value
+pinned the wrong value with full confidence. It took a real ``mv`` on a real
+host. That is the whole argument for not claiming an adapter works until it has
+been exercised against two machines — and it is the reason the second pass was
+run at all, rather than declaring victory after the first.
+
+``.old/`` sits beside the displaced directory rather than beside everything else
+in the parent, and each displacement gets its own stamp, so two runs do not merge
+their contents and a restore is unambiguous about which run it is undoing.
+"""
+
+from __future__ import annotations
+
+__all__ = ["move_aside_destination"]
+
+
+def move_aside_destination(directory: str, stamp: str) -> str:
+    """``<parent>/.old/<stamp>/<name>`` for ``directory``.
+
+    Raises on a path with no parent (``"/"``, ``""``): there is nowhere beside it
+    to move it to, and inventing somewhere would put the only copy of a
+    conversation in a directory nobody would think to look in.
+    """
+    trimmed = directory.rstrip("/")
+    parent, _, name = trimmed.rpartition("/")
+    if not name or not parent:
+        raise ValueError(
+            f"move_aside_destination cannot displace {directory!r} — it has no parent "
+            "to be moved aside within"
+        )
+    return f"{parent}/.old/{stamp}/{name}"

--- a/src/scitex_agent_container/_lifecycle/_relocate_render.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_render.py
@@ -166,6 +166,7 @@ def render_dry_run(
     *,
     declared: dict[str, object] | None = None,
     errors: dict[str, str] | None = None,
+    dry_run: bool = True,
 ) -> list[str]:
     """The whole dry run, in the order a reader needs it.
 
@@ -173,9 +174,22 @@ def render_dry_run(
     claims, then what the host showed, then the verdict — and the verdict is
     repeated as blocking reasons at the end, because the operator asked for a
     dry run that surfaces EVERY problem in one pass rather than one per run.
+
+    ``dry_run`` EXISTS BECAUSE THE HEADER WAS A LIE. The sentence "(nothing was
+    touched)" was unconditional, so the first real relocation printed it above a
+    report of 3.6 MB moved between two hosts — measured 2026-08-11 on the canary
+    run. A report that misstates whether it changed anything is precisely the
+    "looks exactly like success" failure this command exists to prevent, aimed
+    at the reader instead of the machine. It defaults to True so a caller that
+    forgets it over-warns rather than under-warns.
     """
     lines = [
-        f"relocate {report.agent} -> {report.to_host}   DRY RUN (nothing was touched)",
+        f"relocate {report.agent} -> {report.to_host}   "
+        + (
+            "DRY RUN (nothing was touched)"
+            if dry_run
+            else "EXECUTING (this run CHANGES both hosts)"
+        ),
         "",
     ]
     lines += render_declared(declared or {})

--- a/src/scitex_agent_container/_lifecycle/_relocate_shell.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_shell.py
@@ -1,0 +1,214 @@
+"""One way to run a script on a host — whichever host — and one way to read the answer.
+
+Everything a relocation does on a machine goes through here, so there is exactly
+one place where "how do we reach that host" can be wrong.
+
+THE ROUTE IS THE PROBE'S ROUTE, for the reason :mod:`_relocate_probe_ssh`
+documents at length: an agent runs inside a SIF whose ``$HOME/.ssh`` is a
+READ-ONLY bind, so OpenSSH there cannot create its ControlMaster socket and
+refuses outright. The container therefore does not ssh. It asks the ``sac
+listen`` daemon on the BARE HOST to run the command, and the host's ssh — with a
+writable home, the operator's ``~/.ssh/config`` and the fleet's keys — reaches
+the target.
+
+LOCAL IS NOT A SPECIAL CASE OF REMOTE. A command aimed at the coordinator's own
+host runs as ``sh -c <script>`` directly, not as ``ssh <myself> …``. That is one
+less connection that can fail, and it is the only way the SOURCE side works at
+all when the source IS where the coordinator runs, which is the ordinary case.
+It also removes the remote-shell re-parse hazard: for a local exec ``["sh",
+"-c", script]`` means what it reads like, because nothing re-parses it.
+
+MARKER LINES, NOT EXIT CODES. Every script prints its answers on prefixed lines
+and the parser reads those. A shell that also emits a warning, a peer preamble
+that prints a banner, an ``ls`` that partially failed — none of them can be
+mistaken for a measurement, and a section that fails costs only its own answer.
+
+AN EXEC THAT NEVER HAPPENED IS NOT A MEASUREMENT. Every path here raises
+:class:`.._relocate_probe_ssh.ProbeTransportError` when the command could not be
+run at all, and callers return "not measured" (``None``) when it ran and could
+not answer. A caller that cannot tell those apart will eventually read "no files"
+off a directory it never managed to list.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+from ._relocate_probe_ssh import (
+    ProbeTransportError,
+    RemoteRun,
+    peer_preamble,
+    run_probe_script,
+)
+
+__all__ = [
+    "DEFAULT_TIMEOUT_S",
+    "MARK_PATH",
+    "Shell",
+    "marked",
+    "one_marked",
+    "quote",
+    "resolved_path",
+    "run_argv_on_host",
+    "shell_for",
+]
+
+#: A directory listing, a handful of ``wc`` calls, a ``mv``. Generous enough for
+#: a loaded host, short enough that a wedged one does not hang a relocation.
+DEFAULT_TIMEOUT_S = 120.0
+
+MARK_PATH = "TX-PATH="
+
+
+def quote(value: str) -> str:
+    """Quote one path/name for a POSIX shell. Never interpolate a bare path."""
+    return shlex.quote(value)
+
+
+@dataclass(frozen=True)
+class Shell:
+    """One host to run scripts on, and whether reaching it needs ssh at all.
+
+    ``preamble`` is the peer's ``env_preamble`` from ``config.yaml``, prepended
+    INSIDE the script rather than rendered as ``bash -c``, for exactly the reason
+    :mod:`_relocate_probe_ssh` gives: ssh hands ONE string to the remote login
+    shell, and the fleet's targets do not all have bash. It is load-bearing on
+    the hosts being moved onto — sac lives in a venv on scitex-compute-03/-04 and
+    ssh runs a non-login shell, so without the preamble ``sac`` is not on PATH.
+    """
+
+    host: str
+    is_local: bool = False
+    preamble: str = ""
+    timeout_s: float = DEFAULT_TIMEOUT_S
+
+    def __post_init__(self) -> None:
+        if not self.host:
+            raise ValueError("Shell.host must be non-empty")
+
+    def script(self, body: str) -> str:
+        return f"{self.preamble}\n{body}" if self.preamble else body
+
+    def run(
+        self,
+        body: str,
+        *,
+        exec_fn: Callable[..., dict] | None = None,
+        timeout_s: float | None = None,
+    ) -> RemoteRun:
+        """Run ``body`` on this host and return what it said."""
+        script = self.script(body)
+        wait = self.timeout_s if timeout_s is None else timeout_s
+        if not self.is_local:
+            return run_probe_script(self.host, script, exec_fn=exec_fn, timeout_s=wait)
+        return run_argv_on_host(
+            ["sh", "-c", script],
+            exec_fn=exec_fn,
+            timeout_s=wait,
+            what=f"the local host ({self.host})",
+        )
+
+
+def run_argv_on_host(
+    argv: Sequence[str],
+    *,
+    exec_fn: Callable[..., dict] | None = None,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    what: str = "the host",
+) -> RemoteRun:
+    """Run ``argv`` on the BARE HOST through the listen daemon.
+
+    ``exec_fn`` is the seam: it takes the same arguments as
+    :func:`._host_exec_client.request_host_exec` and returns its documented body.
+    Tests pass a real callable returning canned output, so nothing is mocked and
+    no monkeypatching is needed.
+    """
+    if exec_fn is None:
+        from ._host_exec_client import request_host_exec
+
+        exec_fn = request_host_exec
+
+    try:
+        body = exec_fn(list(argv), timeout_s=timeout_s)
+    except Exception as exc:  # stx-allow: fallback (reason: re-raised as ProbeTransportError so the caller records NOT MEASURED rather than a false negative)
+        raise ProbeTransportError(
+            f"could not run the command on {what}: {type(exc).__name__}: {exc}"
+        ) from exc
+    if not isinstance(body, dict):
+        raise ProbeTransportError(
+            f"host_exec returned {type(body).__name__}, not the documented body"
+        )
+    if body.get("timed_out"):
+        raise ProbeTransportError(
+            f"the command on {what} timed out after {timeout_s:.0f}s; nothing was measured"
+        )
+    exit_code = body.get("exit_code")
+    if not isinstance(exit_code, int):
+        raise ProbeTransportError(
+            f"host_exec body carried no integer exit_code (got {exit_code!r})"
+        )
+    return RemoteRun(
+        stdout=str(body.get("stdout") or ""),
+        stderr=str(body.get("stderr") or ""),
+        exit_code=exit_code,
+    )
+
+
+def marked(run: RemoteRun, marker: str) -> list[str]:
+    """Every ``<marker><value>`` line's value, in the order printed."""
+    return [
+        ln[len(marker) :].strip()
+        for ln in run.stdout.splitlines()
+        if ln.startswith(marker)
+    ]
+
+
+def one_marked(run: RemoteRun, marker: str) -> str | None:
+    """The first value for ``marker``, or ``None`` when the line never appeared.
+
+    ``None`` is "the script did not answer", which every caller must treat as
+    UNKNOWN — distinct from an answer of ``"no"``.
+    """
+    values = marked(run, marker)
+    return values[0] if values else None
+
+
+def resolved_path(
+    shell: Shell,
+    path: str,
+    *,
+    exec_fn: Callable[..., dict] | None = None,
+) -> str | None:
+    """``readlink -f`` on ``shell``'s own filesystem, or ``None``.
+
+    The one question :mod:`_relocate_transport_paths` refuses to answer locally,
+    for the reason it states: resolving here would resolve against the SOURCE's
+    filesystem and name a directory the target's runner will never read. So it is
+    asked on the machine whose answer is wanted.
+    """
+    if not path:
+        return None
+    body = f"printf '{MARK_PATH}%s\\n' \"$(readlink -f {quote(path)} 2>/dev/null)\""
+    run = shell.run(body, exec_fn=exec_fn)
+    return one_marked(run, MARK_PATH) or None
+
+
+def shell_for(
+    host: str, *, local_host: str | None, timeout_s: float = DEFAULT_TIMEOUT_S
+) -> Shell:
+    """A :class:`Shell` for ``host``, local when it IS the coordinator's host.
+
+    ``local_host`` is passed in rather than discovered, so "am I already standing
+    on this machine" is decided ONCE by the caller from an observation, instead of
+    each call site consulting a hostname that a container answers differently
+    from the bare host it runs on.
+    """
+    is_local = bool(local_host) and host == local_host
+    return Shell(
+        host=host,
+        is_local=is_local,
+        preamble="" if is_local else peer_preamble(host),
+        timeout_s=timeout_s,
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_transcript_home.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_transcript_home.py
@@ -1,0 +1,240 @@
+"""A containerised agent's ``$HOME`` is not the ssh user's ``$HOME``, and the transcript follows the container's.
+
+:mod:`_relocate_transport_paths` derives ``<home>/.claude/projects/<encoded>``
+from an OBSERVED ``$HOME``. Ask the target host for ``$HOME`` over ssh and it
+answers with the ssh user's — ``/home/ywatanabe`` on this fleet. Ask the AGENT
+and the answer is ``/home/agent``, inside a SIF, which is a path that does not
+exist on the host at all. Neither is where the bytes have to land.
+
+WHAT THE BYTES ACTUALLY NEED. The agent writes its transcript to
+``$HOME/.claude/projects/`` INSIDE the container. Whether that write reaches a
+durable host path, and which one, is decided entirely by the spec: a bind
+mapping some host directory onto the container's home (or onto a subpath of it),
+or, with no such bind, the apptainer OVERLAY's upper layer. So the host-side
+answer is a property of the SPEC, not of the host, and it is derived here rather
+than probed — a probe would have to guess which of the two mechanisms is in play.
+
+MEASURED ON THIS FLEET, 2026-08-09, and the reason this module exists: an agent's
+transcript landed in ``overlays/<agent>/upper/home/agent/.claude/projects/`` and
+NOT in ``runtime/<agent>/home/``, which is the tree that looks like it should
+hold it and only ever receives the boot seed. A relocation that carried the
+runtime tree would have carried the agent's config and left its conversation
+behind — present, intact, and on the wrong machine. The canary that found this
+now carries an explicit leaf bind for exactly that reason, and both shapes are
+handled here because both are live in the fleet today.
+
+BIND ORDER IS PRECEDENCE, AND THE LAST ONE WINS. Apptainer applies binds in
+order, so a later bind over the same container path shadows an earlier one; the
+scan therefore walks the list and keeps the LAST match rather than the first.
+Getting this backwards would name a host directory that the running agent does
+not in fact write to, which is the same invisible-success failure by another
+route.
+
+A SUBPATH BIND IS ACCEPTED AND CONVERTED, NOT REJECTED. Binding
+``…/home/.claude/projects`` onto ``/home/agent/.claude/projects`` is the shape
+that demonstrably works (a bind OVER ``/home/agent`` itself loses to apptainer's
+own ``--home`` flag — measured the same day, writes kept going to the overlay).
+The container home it implies is the host path with ``/.claude/projects``
+removed, and that is what is returned, so
+:func:`.._relocate_transport_paths.derive_target_dir` keeps its single
+``<home>/.claude/projects/<encoded>`` rule instead of growing a special case.
+
+UNRESOLVABLE IS ``None``. There is no default and no "probably the overlay":
+a wrong answer here writes a real transcript to a real directory that nothing
+ever reads.
+
+Pure: a parsed spec in, a path out. No filesystem, no ssh.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+__all__ = [
+    "CODE_FROM_BIND",
+    "CODE_FROM_OVERLAY",
+    "CODE_UNKNOWN",
+    "CODE_UNCONTAINED",
+    "TranscriptHome",
+    "transcript_home_from_spec",
+]
+
+#: A bind maps a host directory onto the container's home (or a subpath of it).
+CODE_FROM_BIND: Final = 200
+#: No such bind; the writes land in the apptainer overlay's upper layer.
+CODE_FROM_OVERLAY: Final = 201
+#: The agent does not run in a container, so the host's own $HOME is the answer.
+CODE_UNCONTAINED: Final = 202
+#: Neither mechanism could be established. NOT a guess.
+CODE_UNKNOWN: Final = 503
+
+#: The container-side home every sac agent runs under (``--home /home/agent``).
+CONTAINER_HOME: Final = "/home/agent"
+
+#: Container paths that imply the home, longest first so the most specific bind
+#: is recognised before the coarser one that is a prefix of it.
+_HOME_SUFFIXES: Final[tuple[tuple[str, str], ...]] = (
+    (f"{CONTAINER_HOME}/.claude/projects", "/.claude/projects"),
+    (f"{CONTAINER_HOME}/.claude", "/.claude"),
+    (CONTAINER_HOME, ""),
+)
+
+
+@dataclass(frozen=True)
+class TranscriptHome:
+    """The HOST-side directory that backs the agent's container ``$HOME``.
+
+    ``path`` is ``None`` when it could not be established, and there is no
+    ``__bool__`` — the rest of the relocate machinery refuses to let an
+    undetermined value read as an answer, and this one decides where a
+    conversation is written.
+    """
+
+    path: str | None
+    code: int
+    reason: str
+    hint: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.reason:
+            raise ValueError("TranscriptHome.reason must be non-empty")
+        if self.path is None and self.code != CODE_UNKNOWN:
+            raise ValueError(
+                f"TranscriptHome: an unresolved home must carry CODE_UNKNOWN, got {self.code}"
+            )
+        if self.path is None and not self.hint:
+            raise ValueError(
+                "TranscriptHome: an unresolved home must say what to measure next"
+            )
+
+
+def _body(spec: dict) -> dict:
+    inner = spec.get("spec")
+    return inner if isinstance(inner, dict) else spec
+
+
+def _binds(spec: dict) -> list[str]:
+    apptainer = _body(spec).get("apptainer")
+    if not isinstance(apptainer, dict):
+        return []
+    binds = apptainer.get("binds")
+    return [b for b in binds if isinstance(b, str)] if isinstance(binds, list) else []
+
+
+def _overlay_dir(spec: dict) -> str:
+    """The ``--overlay <dir>`` from ``raw_args``, or ``""``.
+
+    Read out of ``raw_args`` rather than the ``apptainer.overlay`` field because
+    that is where every live spec actually carries it — the typed field is empty
+    on the specs in this fleet, and reading the empty one would report "no
+    overlay" for an agent that has one.
+    """
+    apptainer = _body(spec).get("apptainer")
+    if not isinstance(apptainer, dict):
+        return ""
+    typed = apptainer.get("overlay")
+    if isinstance(typed, str) and typed.strip():
+        return typed.strip().rstrip("/")
+    raw = apptainer.get("raw_args")
+    if not isinstance(raw, list):
+        return ""
+    args = [a for a in raw if isinstance(a, str)]
+    for index, arg in enumerate(args):
+        if arg == "--overlay" and index + 1 < len(args):
+            return args[index + 1].strip().rstrip("/")
+    return ""
+
+
+def transcript_home_from_spec(
+    spec: dict, *, ssh_home: str | None = None
+) -> TranscriptHome:
+    """Where this agent's ``~/.claude`` lands on the HOST, per its spec.
+
+    ``ssh_home`` is the host's own ``$HOME`` as OBSERVED (never assumed), used
+    only for an agent that runs no container at all. Passing it for a
+    containerised agent changes nothing: the bind and overlay branches are
+    checked first, because for those the ssh user's home is simply the wrong
+    answer rather than a fallback.
+    """
+    binds = _binds(spec)
+    found: tuple[str, str] | None = None
+    for entry in binds:
+        parts = entry.split(":")
+        if len(parts) < 2:
+            continue
+        host_side, container_side = parts[0].strip(), parts[1].strip()
+        if not host_side or not container_side:
+            continue
+        container_side = container_side.rstrip("/")
+        for candidate, suffix in _HOME_SUFFIXES:
+            if container_side != candidate:
+                continue
+            host_side = host_side.rstrip("/")
+            if suffix and not host_side.endswith(suffix):
+                # The bind's two halves disagree about their own shape. Naming
+                # it is worth more than silently trimming something else off.
+                return TranscriptHome(
+                    path=None,
+                    code=CODE_UNKNOWN,
+                    reason=(
+                        f"the bind {entry!r} maps onto {container_side}, so its host side "
+                        f"should end in {suffix!r} and does not"
+                    ),
+                    hint=(
+                        "fix the bind or say explicitly where the transcript lands; a "
+                        "home guessed from a mismatched pair would name a directory the "
+                        "agent never writes to"
+                    ),
+                )
+            home = host_side[: -len(suffix)] if suffix else host_side
+            found = (home.rstrip("/"), entry)
+            break
+    if found is not None:
+        home, entry = found
+        return TranscriptHome(
+            path=home,
+            code=CODE_FROM_BIND,
+            reason=f"the spec binds {entry} — the container's home is {home} on the host",
+        )
+
+    overlay = _overlay_dir(spec)
+    if overlay:
+        home = f"{overlay}/upper{CONTAINER_HOME}"
+        return TranscriptHome(
+            path=home,
+            code=CODE_FROM_OVERLAY,
+            reason=(
+                f"no bind covers the container's home, so writes land in the overlay's "
+                f"upper layer at {home} (measured on this fleet 2026-08-09)"
+            ),
+        )
+
+    runtime = str(_body(spec).get("runtime") or "").strip().lower()
+    if runtime in ("", "none", "local") and not binds:
+        if ssh_home:
+            return TranscriptHome(
+                path=ssh_home.rstrip("/"),
+                code=CODE_UNCONTAINED,
+                reason=f"no container in this spec; the host's own $HOME {ssh_home} is the home",
+            )
+        return TranscriptHome(
+            path=None,
+            code=CODE_UNKNOWN,
+            reason="no container in this spec and the host's $HOME was not observed",
+            hint="probe the host for $HOME; this host's is not evidence about that one's",
+        )
+
+    return TranscriptHome(
+        path=None,
+        code=CODE_UNKNOWN,
+        reason=(
+            "the spec has neither a bind covering the container's home nor an "
+            "--overlay, so where the transcript is written durably is undetermined"
+        ),
+        hint=(
+            "add the bind the agent actually uses, or state the host-side transcript "
+            "root explicitly. Copying to a guessed directory produces an agent that "
+            "starts, reports healthy, and has no memory — the 2026-08-07 failure"
+        ),
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_transport.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_transport.py
@@ -53,6 +53,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final, Sequence
 
+from ._relocate_move_aside import move_aside_destination
+
 __all__ = [
     "CODE_ARRIVED",
     "CODE_MISSING_ON_TARGET",
@@ -68,6 +70,7 @@ __all__ = [
     "TranscriptFile",
     "TransportPlan",
     "is_transferable",
+    "move_aside_destination",
     "plan_transport",
     "refusal_for",
     "select_transferable",
@@ -371,7 +374,7 @@ def plan_transport(
     if target_dir_exists:
         move = MoveAside(
             required=True,
-            destination=f"{target_dir.rstrip('/')}/.old/{stamp}",
+            destination=move_aside_destination(target_dir, stamp),
             reason=(
                 "the target already holds a transcript directory for this agent; it "
                 "is moved aside, never overwritten and never deleted"

--- a/src/scitex_agent_container/_lifecycle/_relocate_transport_ssh.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_transport_ssh.py
@@ -1,0 +1,323 @@
+"""The I/O half of the transport: move the bytes, and COUNT THEM ON THE FAR SIDE.
+
+:mod:`_relocate_transport` decides what may travel and whether what landed is
+what left. It owns no filesystem and no socket, deliberately, so every refusal
+path is a unit test rather than a second machine. This module is the other half:
+the adapters that list a directory, move bytes between two hosts, and measure the
+result WHERE IT LANDED. The plumbing they run on lives in
+:mod:`_relocate_shell` — one route, one place it can be wrong.
+
+WHY tar-OVER-ssh, AND NOT scp OR rsync. The decisive reason is the allowlist.
+:func:`.._relocate_transport.select_transferable` returns an EXACT set of names,
+and ``tar -C <dir> -cf - -- <name> <name>`` takes exactly those names as
+arguments. Nothing is expanded here and nothing is expanded on the far side, so
+what travels is the set that was decided. A glob like ``*.jsonl`` would be
+re-expanded by a shell at copy time, which turns an allowlist into "whatever
+matched the pattern a moment later" — including anything created in between.
+Two lesser reasons: rsync must exist on BOTH ends and does not on the fleet's
+busybox targets, and scp would need either one connection per file or a remote
+glob, which is the first problem again. tar is one connection, one exact file
+list, and it rides the same ``-J`` jump chain every other sac ssh call uses.
+
+A PIPELINE'S EXIT CODE IS EVIDENCE, NEVER PROOF. ``tar | ssh tar`` exiting 0 says
+two processes exited 0; it says nothing about what is on the disk at the other
+end. So the exit code is returned and reported, and the ANSWER comes from
+:func:`measure_transcripts` run ON THE TARGET — ``wc -c`` and ``wc -l`` executed
+by the target's own shell on the target's own files. Nothing here infers a
+target-side count from a local ``stat``, which is the shortcut that makes a
+truncated copy look verified.
+
+BOTH SIDES ARE MEASURED BY THE SAME SCRIPT TEXT. ``wc -l`` counts newlines, so a
+file with no trailing newline reads one short — identically on both hosts,
+because the identical command runs on both. A comparison between two different
+measuring methods produces mismatches that mean nothing and hides the ones that
+mean something.
+"""
+
+from __future__ import annotations
+
+import shlex
+from typing import Callable, Sequence
+
+from ._relocate_probe_ssh import RemoteRun, build_probe_argv
+from ._relocate_shell import (
+    Shell,
+    marked,
+    one_marked,
+    quote,
+    run_argv_on_host,
+)
+from ._relocate_transport import CREDENTIAL_BASENAMES, TranscriptFile
+
+__all__ = [
+    "MARK_ABSENT",
+    "MARK_DIR",
+    "MARK_ENTRY",
+    "MARK_FILE",
+    "MARK_MOVED",
+    "build_copy_argv",
+    "copy_transcripts",
+    "ensure_dir",
+    "list_transcript_dir",
+    "measure_transcripts",
+    "move_dir_aside",
+    "parse_measurements",
+]
+
+MARK_DIR = "TX-DIR="
+MARK_ENTRY = "TX-ENTRY="
+MARK_FILE = "TX-FILE="
+MARK_ABSENT = "TX-ABSENT="
+MARK_MOVED = "TX-MOVED="
+
+#: Moving a multi-megabyte transcript over a jump chain. Separate from the
+#: measurement timeout because the two fail for different reasons and want
+#: different patience.
+DEFAULT_COPY_TIMEOUT_S = 900.0
+
+
+def list_transcript_dir(
+    shell: Shell,
+    directory: str,
+    *,
+    exec_fn: Callable[..., dict] | None = None,
+) -> tuple[str, ...] | None:
+    """Every entry in ``directory`` on ``shell``, or ``None`` if it was not listed.
+
+    ``ls -A`` rather than a glob, so DOTFILES ARE SEEN. That is deliberate and it
+    is the point of :data:`.._relocate_transport.CREDENTIAL_BASENAMES`: a
+    credential that is never listed cannot be refused BY NAME, and a filter whose
+    input never contained the dangerous thing proves nothing about the filter.
+
+    A missing directory returns an empty tuple — an OBSERVED "nothing there",
+    which the plan turns into CODE_NOTHING_TO_CARRY. A listing that could not be
+    taken returns ``None``, which refuses. Those are different answers, and the
+    difference is the whole discipline.
+    """
+    body = (
+        f"if [ -d {quote(directory)} ]; then\n"
+        f"  printf '{MARK_DIR}yes\\n'\n"
+        f"  ls -A -- {quote(directory)} | sed 's/^/{MARK_ENTRY}/'\n"
+        f"else\n"
+        f"  printf '{MARK_DIR}no\\n'\n"
+        f"fi"
+    )
+    run = shell.run(body, exec_fn=exec_fn)
+    exists = one_marked(run, MARK_DIR)
+    if exists is None:
+        return None
+    if exists == "no":
+        return ()
+    return tuple(marked(run, MARK_ENTRY))
+
+
+def measure_transcripts(
+    shell: Shell,
+    directory: str,
+    names: Sequence[str],
+    *,
+    exec_fn: Callable[..., dict] | None = None,
+) -> tuple[TranscriptFile, ...]:
+    """Byte and line counts for ``names``, measured BY ``shell`` ON ``shell``.
+
+    Returns one :class:`TranscriptFile` per name that EXISTS there. A name that is
+    absent is simply not in the result, which is what makes
+    :func:`.._relocate_transport.verify_arrival` report "absent on the target"
+    rather than a size mismatch — the copy did not happen, versus it happened
+    badly, and those call for different next moves.
+
+    A file that exists but whose counts could not be taken comes back with
+    ``None`` counts, i.e. NOT MEASURED, which verification treats as UNKNOWN.
+    Counting it as zero would turn an unreadable file into an empty one.
+    """
+    if not names:
+        return ()
+    parts = [f"cd {quote(directory)} 2>/dev/null || exit 0"]
+    for name in names:
+        parts.append(
+            f"if [ -f {quote(name)} ]; then\n"
+            f"  __b=$(wc -c < {quote(name)} 2>/dev/null)\n"
+            f"  __l=$(wc -l < {quote(name)} 2>/dev/null)\n"
+            f'  printf \'{MARK_FILE}%s\\t%s\\t%s\\n\' {quote(name)} "$__b" "$__l"\n'
+            f"else\n"
+            f"  printf '{MARK_ABSENT}%s\\n' {quote(name)}\n"
+            f"fi"
+        )
+    return parse_measurements(shell.run("\n".join(parts), exec_fn=exec_fn))
+
+
+def parse_measurements(run: RemoteRun) -> tuple[TranscriptFile, ...]:
+    """Read ``TX-FILE=<name>\\t<bytes>\\t<lines>`` lines out of a run.
+
+    Split out so the parse is testable against captured output with no host at
+    all — the same seam the probe adapter uses.
+    """
+    files: list[TranscriptFile] = []
+    for raw in marked(run, MARK_FILE):
+        parts = raw.split("\t")
+        name = parts[0].strip() if parts else ""
+        if not name:
+            continue
+        files.append(
+            TranscriptFile(
+                name=name,
+                byte_count=_int_or_none(parts[1] if len(parts) > 1 else ""),
+                line_count=_int_or_none(parts[2] if len(parts) > 2 else ""),
+            )
+        )
+    return tuple(files)
+
+
+def _int_or_none(raw: str) -> int | None:
+    text = raw.strip()
+    return int(text) if text.isdigit() else None
+
+
+def ensure_dir(
+    shell: Shell,
+    directory: str,
+    *,
+    exec_fn: Callable[..., dict] | None = None,
+) -> bool | None:
+    """``mkdir -p`` the destination, then CONFIRM it is a directory.
+
+    Three-valued for the usual reason: ``mkdir`` exiting 0 and the directory
+    existing are two claims, and the second is the one the copy depends on. The
+    confirmation is a separate ``[ -d ]`` in the same round trip.
+    """
+    body = (
+        f"mkdir -p {quote(directory)} 2>/dev/null\n"
+        f"if [ -d {quote(directory)} ]; then printf '{MARK_DIR}yes\\n'; "
+        f"else printf '{MARK_DIR}no\\n'; fi"
+    )
+    answer = one_marked(shell.run(body, exec_fn=exec_fn), MARK_DIR)
+    return None if answer is None else answer == "yes"
+
+
+def move_dir_aside(
+    shell: Shell,
+    directory: str,
+    destination: str,
+    *,
+    exec_fn: Callable[..., dict] | None = None,
+) -> bool | None:
+    """Move ``directory`` to ``destination``. NEVER a delete, on either host.
+
+    ``True`` when the move happened and the old path is gone, ``False`` when it
+    did not, ``None`` when it could not be told. A directory that was not there
+    in the first place is ``True`` with nothing moved: the postcondition the
+    caller wants is "that path is clear", and it already is.
+
+    ``mv`` rather than ``cp`` + ``rm``, so there is no window in which two copies
+    exist and one of them is being deleted.
+    """
+    if not destination:
+        raise ValueError(
+            "move_dir_aside needs somewhere to move it TO — never a delete"
+        )
+    body = (
+        f"if [ ! -e {quote(directory)} ]; then printf '{MARK_MOVED}vacuous\\n'; exit 0; fi\n"
+        f'mkdir -p "$(dirname {quote(destination)})" 2>/dev/null\n'
+        f"if mv {quote(directory)} {quote(destination)} 2>/dev/null && "
+        f"[ ! -e {quote(directory)} ] && [ -e {quote(destination)} ]; then\n"
+        f"  printf '{MARK_MOVED}yes\\n'\n"
+        f"else\n"
+        f"  printf '{MARK_MOVED}no\\n'\n"
+        f"fi"
+    )
+    answer = one_marked(shell.run(body, exec_fn=exec_fn), MARK_MOVED)
+    return None if answer is None else answer in ("yes", "vacuous")
+
+
+def build_copy_argv(
+    *,
+    source: Shell,
+    source_dir: str,
+    target: Shell,
+    target_dir: str,
+    files: Sequence[str],
+    peers=None,
+) -> list[str]:
+    """The argv the BARE HOST runs to move exactly ``files`` and nothing else.
+
+    A pure function so the command itself can be asserted in a test — the thing
+    most worth pinning is that the file list is passed as ARGUMENTS and that no
+    glob character reaches either shell.
+
+    ``set -o pipefail`` is why this is ``bash -c`` and not ``sh -c``: without it
+    the pipeline reports only the LAST stage's status, so a source-side tar that
+    failed outright would be masked by an ssh that cheerfully extracted nothing.
+    The exit code is still only evidence — arrival is decided by counting on the
+    target — but evidence that lies is worse than none.
+    """
+    if not files:
+        raise ValueError(
+            "build_copy_argv refuses an empty file list — a copy that transfers "
+            "nothing and exits 0 is the failure shape this feature exists to prevent"
+        )
+    bad = [f for f in files if "/" in f or f in ("", ".", "..")]
+    if bad:
+        raise ValueError(
+            f"build_copy_argv takes bare file names, got {bad!r}. A path component here "
+            "would place the file outside the directory the allowlist was applied to"
+        )
+    # The credential refusal is repeated HERE, at the only place bytes actually
+    # move, rather than trusted to hold upstream. `select_transferable` already
+    # declines these, but this function is generic — it will carry any named file
+    # — and a transport that would copy a credential if asked is one that
+    # eventually does.
+    named_secrets = [f for f in files if f in CREDENTIAL_BASENAMES]
+    if named_secrets:
+        raise ValueError(
+            f"build_copy_argv refuses to carry {named_secrets!r}: a credential is never "
+            "copied — the target re-issues its own. Carrying one leaves two hosts holding "
+            "one identity's secret, and the source's copy outliving the source"
+        )
+
+    produce: list[str] = ["tar", "-C", source_dir, "-cf", "-", "--", *files]
+    if not source.is_local:
+        produce = build_probe_argv(
+            source.host, source.script(shlex.join(produce)), peers
+        )
+
+    extract = (
+        f"mkdir -p {quote(target_dir)} && tar -C {quote(target_dir)} -xf - && "
+        f"printf '{MARK_DIR}yes\\n'"
+    )
+    consume = build_probe_argv(target.host, target.script(extract), peers)
+
+    pipeline = f"set -o pipefail; {shlex.join(produce)} | {shlex.join(consume)}"
+    return ["bash", "-c", pipeline]
+
+
+def copy_transcripts(
+    *,
+    source: Shell,
+    source_dir: str,
+    target: Shell,
+    target_dir: str,
+    files: Sequence[str],
+    exec_fn: Callable[..., dict] | None = None,
+    timeout_s: float = DEFAULT_COPY_TIMEOUT_S,
+    peers=None,
+) -> RemoteRun:
+    """Stream ``files`` from ``source_dir`` into ``target_dir`` over one ssh.
+
+    Returns the pipeline's :class:`RemoteRun`. THE CALLER MUST STILL VERIFY: this
+    return value says two processes exited, and the only statement worth making
+    is the one :func:`measure_transcripts` makes afterwards, on the target.
+    """
+    argv = build_copy_argv(
+        source=source,
+        source_dir=source_dir,
+        target=target,
+        target_dir=target_dir,
+        files=files,
+        peers=peers,
+    )
+    return run_argv_on_host(
+        argv,
+        exec_fn=exec_fn,
+        timeout_s=timeout_s,
+        what=f"the host, copying {source.host}:{source_dir} -> {target.host}:{target_dir}",
+    )

--- a/src/scitex_agent_container/_state/state_db_relocation.py
+++ b/src/scitex_agent_container/_state/state_db_relocation.py
@@ -1,0 +1,320 @@
+"""Where an agent lives, who holds the write lease, and how far a relocation got.
+
+Three tables, one file, because they are written in one sequence and read
+together. Each is the durable half of a module that was deliberately left pure:
+
+    ``agent_residency``      :mod:`.._lifecycle._residency` — the stays
+    ``relocation_leases``    :mod:`.._lifecycle._relocate_lease` — the fence
+    ``relocation_journal``   :mod:`.._lifecycle._relocate_phases` — the steps
+
+WHY THE DECISION MODULES HAVE NO STORE OF THEIR OWN. Their entire value is that
+the rules can be tested with real values and no database; giving each one a
+connection would have made the rules reachable only through I/O. So the rules
+live there, the rows live here, and this module holds no policy — it does not
+decide whether a move is legal, only how the answer is written down.
+
+RESIDENCY IS THE HOST, AND THIS IS THE WRITE THAT MOVES IT. Before 2026-08-11
+``host`` was a field in a git-tracked spec file that existed in one copy per
+machine; the operator settled it (「設定ファイル、人が書くものはファイル、状態は
+db」) and :mod:`.._lifecycle._relocate_host_record` became the single reader.
+That reader has been answering from ``instances.host`` — the host of whichever
+process happens to be running — which is genuinely true and cannot answer "which
+host held this agent in March", because a stopped agent has no instance row and
+therefore no residency at all. THAT is the gap this table closes, and it is why
+a relocation can flip residency for an agent that is stopped on both hosts, which
+is precisely the state it is in between SOURCE_STOP and TARGET_STANDBY.
+
+AT MOST ONE OPEN STAY, ENFORCED BY THE WRITE RATHER THAN BY CONVENTION.
+:func:`record_residency` closes any open stay in the same transaction as it opens
+the new one, so "living on two hosts at once" is not a row combination that can
+exist. A unique index would have been the tidier statement and cannot express it
+— the constraint is on ``to_ts IS NULL`` per agent, and expressing that as a
+partial unique index would leave the closing write free to fail halfway.
+
+IDEMPOTENT, BECAUSE A COORDINATOR RE-RUNS. Recording a move to the host that is
+already the open stay is a no-op that returns the existing row rather than an
+error and rather than a second stay. A relocation that crashed after the write
+and before the journal must be able to re-run without littering the history with
+the evidence of its own retries.
+
+NOTHING IS EVER DELETED. A closed stay stays closed and stays present; a journal
+row is updated in place at its phase and keeps its steps. The migration fact is
+the point (item #9): after a relocation completes, the record that it happened is
+the only thing that can answer an attribution question later.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+__all__ = [
+    "current_residency",
+    "init_relocation_schema",
+    "load_journal",
+    "load_lease",
+    "read_residency_history",
+    "record_residency",
+    "save_journal",
+    "save_lease",
+]
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS agent_residency (
+    agent      TEXT NOT NULL,
+    host       TEXT NOT NULL,
+    from_ts    REAL NOT NULL,
+    to_ts      REAL,
+    seeded     INTEGER NOT NULL DEFAULT 0,
+    note       TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_agent_residency_agent
+    ON agent_residency (agent, from_ts);
+
+CREATE TABLE IF NOT EXISTS relocation_leases (
+    agent      TEXT PRIMARY KEY,
+    holder     TEXT NOT NULL,
+    fence      INTEGER NOT NULL,
+    expires_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS relocation_journal (
+    agent      TEXT PRIMARY KEY,
+    from_host  TEXT NOT NULL,
+    to_host    TEXT NOT NULL,
+    phase      TEXT NOT NULL,
+    steps      TEXT NOT NULL,
+    updated_at REAL NOT NULL
+);
+"""
+
+
+def init_relocation_schema(db_path: Path | None = None) -> Path:
+    """Create the three tables if missing. Idempotent."""
+    from .state_db import init_schema, open_db
+
+    with open_db(db_path) as conn:
+        conn.executescript(_SCHEMA)
+    return init_schema(db_path)
+
+
+def _ensure(conn: sqlite3.Connection) -> None:
+    conn.executescript(_SCHEMA)
+
+
+# --------------------------------------------------------------------------
+# residency
+# --------------------------------------------------------------------------
+
+
+def record_residency(
+    *,
+    agent: str,
+    host: str,
+    now: float | None = None,
+    seeded_from_spec: bool = False,
+    note: str = "",
+    db_path: Path | None = None,
+) -> bool:
+    """Open a stay for ``agent`` on ``host``, closing whatever was open.
+
+    Returns ``True`` when a new stay was opened and ``False`` when the agent was
+    already recorded on that host — the second is a successful no-op, not a
+    failure, and the caller distinguishes them only to report accurately.
+
+    ``seeded_from_spec`` travels into the row so a value that came from a legacy
+    spec field is not later mistaken for something that was measured. Provenance
+    that is dropped at the moment of writing cannot be recovered by reading.
+    """
+    if not agent or not agent.strip():
+        raise ValueError("record_residency needs the agent name")
+    if not host or not host.strip():
+        raise ValueError(
+            "record_residency needs the host — an empty destination would open a "
+            "residency that answers no question"
+        )
+    agent, host = agent.strip(), host.strip()
+    ts = float(now) if now is not None else time.time()
+
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure(conn)
+        row = conn.execute(
+            "SELECT rowid, host FROM agent_residency "
+            "WHERE agent=? AND to_ts IS NULL ORDER BY from_ts DESC LIMIT 1",
+            (agent,),
+        ).fetchone()
+        if row is not None and (row[1] or "") == host:
+            return False
+        if row is not None:
+            conn.execute(
+                "UPDATE agent_residency SET to_ts=? WHERE rowid=?", (ts, row[0])
+            )
+        conn.execute(
+            "INSERT INTO agent_residency (agent, host, from_ts, to_ts, seeded, note) "
+            "VALUES (?, ?, ?, NULL, ?, ?)",
+            (agent, host, ts, 1 if seeded_from_spec else 0, note or None),
+        )
+    return True
+
+
+def read_residency_history(agent: str, *, db_path: Path | None = None):
+    """The agent's stays, oldest first, as :class:`.._lifecycle._residency.Residency`.
+
+    Returns ``()`` for an agent this table has never heard of — genuinely "the db
+    knows nothing", which is what lets a legacy spec ``host:`` seed it once and
+    is deliberately distinct from a recorded stay that has since closed.
+    """
+    from .._lifecycle._residency import Residency
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure(conn)
+        rows = conn.execute(
+            "SELECT host, from_ts, to_ts FROM agent_residency "
+            "WHERE agent=? ORDER BY from_ts ASC, rowid ASC",
+            (agent,),
+        ).fetchall()
+    return tuple(
+        Residency(
+            host=r[0], from_ts=float(r[1]), to_ts=None if r[2] is None else float(r[2])
+        )
+        for r in rows
+    )
+
+
+def current_residency(agent: str, *, db_path: Path | None = None) -> str | None:
+    """The host of the open stay, or ``None``. ``None`` is not a hostname."""
+    from .._lifecycle._residency import current_host
+
+    return current_host(read_residency_history(agent, db_path=db_path))
+
+
+# --------------------------------------------------------------------------
+# lease
+# --------------------------------------------------------------------------
+
+
+def save_lease(lease, *, db_path: Path | None = None) -> None:
+    """Persist the single current lease for an agent, replacing any earlier one.
+
+    One row per agent by primary key, so a second holder cannot be inserted
+    alongside the first. The fence is what actually fences — an old holder that
+    comes back reads this row, sees a fence above its own, and knows it is out —
+    so the row is REPLACED rather than appended: there is exactly one answer to
+    "who holds it", and a history of holders would invite reading the wrong one.
+    """
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure(conn)
+        conn.execute(
+            "INSERT INTO relocation_leases (agent, holder, fence, expires_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(agent) DO UPDATE SET holder=excluded.holder, "
+            "fence=excluded.fence, expires_at=excluded.expires_at, "
+            "updated_at=excluded.updated_at",
+            (
+                lease.agent,
+                lease.holder,
+                int(lease.fence),
+                float(lease.expires_at),
+                time.time(),
+            ),
+        )
+
+
+def load_lease(agent: str, *, db_path: Path | None = None):
+    """The stored lease for ``agent``, or ``None`` if nobody has ever held it."""
+    from .._lifecycle._relocate_lease import Lease
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure(conn)
+        row = conn.execute(
+            "SELECT holder, fence, expires_at FROM relocation_leases WHERE agent=?",
+            (agent,),
+        ).fetchone()
+    if row is None:
+        return None
+    return Lease(
+        agent=agent, holder=row[0], fence=int(row[1]), expires_at=float(row[2])
+    )
+
+
+# --------------------------------------------------------------------------
+# journal
+# --------------------------------------------------------------------------
+
+
+def save_journal(relocation, *, db_path: Path | None = None) -> None:
+    """Write the relocation's phase and steps, replacing the previous row.
+
+    One row per agent: a relocation is a thing that is happening to an agent, and
+    two in flight at once is a state nobody should be able to represent, let
+    alone resume from. The steps are stored whole (JSON) rather than as rows,
+    because they are only ever read back as a unit and a partially-inserted
+    journal would be worse than none.
+    """
+    from .state_db import open_db
+
+    steps = json.dumps(
+        [{"phase": s.phase, "at": s.at, "detail": s.detail} for s in relocation.steps]
+    )
+    with open_db(db_path) as conn:
+        _ensure(conn)
+        conn.execute(
+            "INSERT INTO relocation_journal (agent, from_host, to_host, phase, steps, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(agent) DO UPDATE SET from_host=excluded.from_host, "
+            "to_host=excluded.to_host, phase=excluded.phase, steps=excluded.steps, "
+            "updated_at=excluded.updated_at",
+            (
+                relocation.agent,
+                relocation.from_host,
+                relocation.to_host,
+                relocation.phase,
+                steps,
+                time.time(),
+            ),
+        )
+
+
+def load_journal(agent: str, *, db_path: Path | None = None):
+    """The stored relocation for ``agent``, or ``None``.
+
+    A stored row whose JSON will not parse returns ``None`` rather than raising:
+    the caller's next move is to open a fresh relocation, and a corrupt journal
+    must not make the agent unrelocatable. Nothing is deleted — the bad row stays
+    for whoever wants to look at it.
+    """
+    from .._lifecycle._relocate_phases import Relocation, Step
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure(conn)
+        row = conn.execute(
+            "SELECT from_host, to_host, phase, steps FROM relocation_journal WHERE agent=?",
+            (agent,),
+        ).fetchone()
+    if row is None:
+        return None
+    try:
+        raw = json.loads(row[3])
+        steps = tuple(
+            Step(phase=s["phase"], at=float(s["at"]), detail=s.get("detail", ""))
+            for s in raw
+        )
+        return Relocation(
+            agent=agent,
+            from_host=row[0],
+            to_host=row[1],
+            phase=row[2],
+            steps=steps,
+        )
+    except Exception:  # stx-allow: fallback (reason: an unparseable journal must not make an agent unrelocatable; the row is kept, not deleted, and the caller opens a fresh relocation)
+        return None

--- a/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
@@ -62,88 +62,122 @@ __all__ = ["declared_from_spec", "register", "relocate"]
 #: from click's own 2 (usage error) so a caller can tell "you asked wrongly"
 #: from "the target is not ready".
 EXIT_REFUSED = 3
-#: Exit code for the not-yet-built executing path. Distinct again, so a script
-#: cannot mistake "unimplemented" for "the target failed preflight".
-EXIT_UNIMPLEMENTED = 4
+#: RETIRED. It meant "the executing path does not exist"; it does now, and the
+#: outcomes it used to cover are :data:`._relocate_run.EXIT_INCOMPLETE` (a phase
+#: refused, understood) and :data:`._relocate_run.EXIT_UNMEASURED` (a phase could
+#: not be measured). The number is not reused: a script written against the old
+#: meaning must not silently start reading a new one.
+EXIT_RETIRED_UNIMPLEMENTED = 4
 
 
-#: What `--no-dry-run` still cannot do, phase by phase. THIS LIST IS THE REFUSAL
-#: — the message is generated from it, so the two cannot drift apart the way the
-#: previous hard-coded sentence did (it named the transcript transport as the one
-#: missing piece and went stale the moment that phase was built).
+#: What `--no-dry-run` can and cannot do, phase by phase. THE NOTICE IS
+#: GENERATED FROM THIS LIST, so the two cannot drift apart the way the original
+#: hard-coded sentence did — it named the transcript transport as the one missing
+#: piece and went stale the moment that phase was built.
 #:
-#: Each entry is (phase, what is BUILT, what is MISSING). The split matters: the
-#: decision layers below are unit-tested and their refusal paths are the whole
-#: point, but a decision cannot move bytes or start a process. The I/O adapters
-#: are what remain, and they are the part that cannot be honestly claimed until
-#: it has been exercised against two real hosts.
+#: Each entry is (phase, what is BUILT, what is MISSING). A phase with nothing
+#: missing carries ``"—"`` there and RUNS. The split is the honest unit of
+#: progress: a decision layer being unit-tested says nothing about whether bytes
+#: move, and an adapter is not claimed to work until it has been exercised
+#: against two real hosts.
 _PHASE_READINESS: tuple[tuple[str, str, str], ...] = (
     (
         "source_drain",
-        "—",
-        "no adapter: drain the source and confirm it took no new work",
+        "_relocate_liveness (tmux is the same fact the runtime checks) — a STOPPED "
+        "source drains vacuously and that is measured, not assumed",
+        "no adapter for a RUNNING source: telling an agent to finish its in-flight "
+        "work and take no new work, and confirming it did",
     ),
     (
         "source_stop",
+        "_relocate_effects.stop_source: `sac agents stop` on the source, then a "
+        "SECOND independent liveness observation. Idempotent",
         "—",
-        "no adapter: stop the source and VERIFY stopped (the transport's precondition)",
     ),
     (
         "transport",
-        "_relocate_transport (selection, move-aside, byte+line verification) and "
-        "_relocate_transport_paths (target-side project dir)",
-        "no adapter: the ssh/scp round trip that moves the bytes and counts them "
-        "on the far side",
+        "_relocate_transport (selection, move-aside, byte+line verification), "
+        "_relocate_transport_paths (target-side project dir), "
+        "_relocate_transcript_home (the HOST path backing the container's $HOME) "
+        "and _relocate_transport_ssh (tar-over-ssh; counts taken ON the target)",
+        "—",
     ),
     (
         "target_standby",
         "—",
-        "no adapter: start the target without the lease and seed its session marker",
+        "no adapter: carry the spec to the target, write its session_id marker from "
+        "the carried transcript, and start it WITHOUT the lease",
     ),
     (
         "handshake",
         "_relocate_handshake (nonce + proof-of-work verdict) and _relocate_arrival "
-        "(the message the relocated agent receives)",
+        "(the brief, which IS the challenge) — built and evaluated against what was "
+        "actually observed",
         "no adapter: deliver the brief over a2a and observe the reply ON THE SOURCE",
     ),
-    ("handover", "_relocate_lease", "no adapter: move the lease and bump the fence"),
-    ("done", "—", "no adapter: append the residency record to the state db"),
+    (
+        "handover",
+        "_relocate_lease, and its rows now have a home in _state.state_db_relocation",
+        "no adapter: nothing claims a lease at start-up, so there is no holder to "
+        "hand FROM",
+    ),
+    (
+        "done",
+        "_relocate_effects.finish: residency written to _state.state_db_relocation, "
+        "then the source's transcript MOVED ASIDE — both gated on the two "
+        "confirmations being recorded True",
+        "—",
+    ),
 )
 
 
-def _unimplemented_notice() -> list[str]:
-    """Say exactly which phases can and cannot run, rather than naming one.
+def _readiness_notice() -> list[str]:
+    """Say exactly which phases can and cannot run, before running any of them.
 
-    An accurate refusal is worth more than a short one here: the operator's next
-    question is always "so what IS missing", and answering it in the refusal is
-    the difference between a blocked afternoon and a scoped piece of work.
+    Printed as a PREAMBLE now rather than as a refusal: the executing path
+    exists, so the operator's question has changed from "why won't it run" to
+    "how far will it get". Answering that up front is the difference between a
+    surprising stop and an expected one.
     """
-    lines = [
-        "",
-        "[red]refusing to execute:[/red] the phase driver has no I/O adapters wired, "
-        "so a relocation would journal its way to DONE having moved nothing — the "
-        "most convincing possible imitation of success.",
-        "",
-        "Phase by phase:",
-    ]
+    lines = ["", "[bold]PHASE READINESS[/bold]"]
     for phase, built, missing in _PHASE_READINESS:
-        lines.append(f"  [bold]{phase}[/bold]")
+        state = "[green]runs[/green]" if missing == "—" else "[yellow]refuses[/yellow]"
+        lines.append(f"  [bold]{phase}[/bold]  {state}")
         if built != "—":
             lines.append(f"    built:   {built}")
-        lines.append(f"    missing: {missing}")
+        if missing != "—":
+            lines.append(f"    missing: {missing}")
     lines += [
         "",
-        "The decision layers refuse correctly and are unit-tested; what is absent "
-        "is the code that talks to two machines. Until an adapter has been "
-        "exercised against real hosts it is not claimed to work — that claim, made "
-        "on 2026-08-07 without the evidence, is why this command exists.",
-        "",
-        "Use --dry-run to check the target. Move the transcript by hand meanwhile, "
-        "and read _relocate_transport_paths before choosing the destination: the "
-        "directory name comes from the TARGET's resolved workdir, and a transcript "
-        "under the source's name is invisible to the target's runner.",
+        "A phase with no adapter returns UNKNOWN and the relocation STOPS there, in "
+        "a state the journal records; it does not journal its way to DONE having "
+        "moved nothing. Nothing is deleted at any point — anything displaced goes "
+        "to .old/<stamp>/ on the host it was displaced on, so a rollback is you "
+        "moving it back, deliberately.",
     ]
     return lines
+
+
+def _source_repo_facts(spec_body: dict, from_host: str):
+    """Scan the agent's workdir for un-saved work, or report that nobody looked.
+
+    ONLY the workdir, and only when it is a git repo. The alternative — walk and
+    guess at every repo an agent might touch — would produce a check whose PASS
+    means "the repos I happened to think of are clean", which is worse than the
+    UNKNOWN it replaces because it reads as an answer.
+
+    A workdir that is not a repo yields an OBSERVED empty scan: there is nothing
+    to strand, which is a real answer and passes. That is deliberately different
+    from passing no facts at all, which is "nobody looked" and refuses.
+    """
+    from pathlib import Path
+
+    from .._lifecycle._relocate_source_scan import scan_source
+
+    workdir = str(spec_body.get("workdir") or "").strip()
+    if not workdir or not (Path(workdir) / ".git").exists():
+        return scan_source(())
+    return scan_source((workdir,))
 
 
 def _dig(body: dict, *path: str) -> object:
@@ -362,17 +396,45 @@ def relocate(name: str, to_host: str, dry_run: bool) -> None:
         facts=gathered.facts,
         runtime=str(declared.get("runtime") or ""),
         required_ports=_required_ports(declared),
+        source_facts=_source_repo_facts(
+            body if isinstance(body, dict) else {}, where.host or ""
+        ),
+        from_host=where.host or "",
     )
 
-    for line in render_dry_run(report, declared=declared, errors=gathered.errors):
+    for line in render_dry_run(
+        report, declared=declared, errors=gathered.errors, dry_run=dry_run
+    ):
         console.print(line, soft_wrap=True)
 
-    if not dry_run:
-        for line in _unimplemented_notice():
-            console.print(line, soft_wrap=True)
-        raise SystemExit(EXIT_UNIMPLEMENTED)
     if report.ok is not True:
+        # The checks gate the executing path too, and that is the point rather
+        # than a leftover: the dry run is what makes them load-bearing, and a
+        # refusal that becomes advisory the moment there is something to execute
+        # is not a refusal.
         raise SystemExit(EXIT_REFUSED)
+    for line in _readiness_notice():
+        console.print(line, soft_wrap=True)
+    if dry_run:
+        return
+
+    from ._relocate_run import exit_code_for, run_relocation
+
+    if not where.host:
+        console.print(
+            "[red]refusing to execute:[/red] the state db does not know which host "
+            f"{name} runs on, and the spec offered nothing to seed it with. A "
+            "relocation FROM an unknown host cannot stop the right source.",
+            soft_wrap=True,
+        )
+        raise SystemExit(EXIT_REFUSED)
+
+    outcome = run_relocation(
+        name=name, spec=spec, from_host=where.host, to_host=to_host
+    )
+    code = exit_code_for(outcome)
+    if code:
+        raise SystemExit(code)
 
 
 def register(agent_group) -> None:

--- a/src/scitex_agent_container/cli_pkg/_relocate_run.py
+++ b/src/scitex_agent_container/cli_pkg/_relocate_run.py
@@ -1,0 +1,194 @@
+"""``--no-dry-run``: open or resume the journal, drive the phases, print what happened.
+
+The dry run answers "may this move". This answers "what did it actually do", and
+the difference between the two is the entire risk surface, so the reporting here
+is deliberately not a summary — every phase prints its own line, and every line
+says whether that phase SUCCEEDED, FAILED or COULD NOT BE MEASURED.
+
+RESUME IS THE DEFAULT, NOT A FLAG. A relocation touches two hosts and will
+eventually be interrupted; :mod:`.._lifecycle._relocate_phases` was built around
+that, and the journal it produces is now persisted
+(:mod:`.._state.state_db_relocation`). So a second invocation LOADS the stored
+journal and continues from where the first stopped, rather than starting over —
+and because :func:`advance` treats "advance to the phase you are already in" as a
+no-op that succeeds, a coordinator that did the work and died before journalling
+re-runs harmlessly.
+
+A DIFFERENT DESTINATION IS A DIFFERENT RELOCATION. A stored journal moving the
+agent to some other host is not resumed; that would silently retarget a move
+someone else started. It is refused, and the refusal names the stored
+destination, because the operator's next question is "to where, then".
+
+THE PREFLIGHT STILL GATES. ``--no-dry-run`` runs exactly the same checks and
+refuses on the same verdict. It is a common instinct to treat the checks as
+advisory once the executing path exists; they are the opposite — the executing
+path is what makes them load-bearing.
+
+THE EXIT CODE IS THE OUTCOME, and the three ways this ends are three codes, so a
+script cannot mistake one for another: completed, stopped-and-understood, and
+stopped-because-something-could-not-be-measured.
+"""
+
+from __future__ import annotations
+
+import time
+
+from .._lifecycle._relocate_effects import adapters_for, build_effects
+from .._lifecycle._relocate_execute import (
+    CODE_COMPLETED,
+    ExecuteOutcome,
+    execute,
+)
+from .._lifecycle._relocate_phases import begin
+from .._state.state_db_relocation import load_journal, save_journal
+from ._helpers import console
+
+__all__ = ["EXIT_INCOMPLETE", "EXIT_UNMEASURED", "run_relocation"]
+
+#: A phase refused and the refusal is understood. The relocation stopped in a
+#: named state that the journal records; a re-run resumes from it.
+EXIT_INCOMPLETE = 5
+#: A phase could not be MEASURED. Refuses as firmly, and calls for a different
+#: action — go and measure it, rather than go and fix it — so it gets its own code.
+EXIT_UNMEASURED = 6
+
+
+def _local_host() -> str:
+    """The fleet name of the host this coordinator's commands land on.
+
+    Read through :func:`.._state.state_db_hostname.resolve_host`, the same
+    resolver every state-db write uses ($SAC_HOST, then ``config.yaml``'s
+    canonical, then the short hostname), rather than calling
+    ``socket.gethostname`` here. Two answers to "which host am I" is how a
+    relocation ends up ssh-ing to itself under one name and writing rows under
+    another.
+
+    It decides ONE thing — whether a command goes through ssh or runs directly —
+    so a wrong "this is not me" costs an extra hop and nothing else.
+    """
+    from .._state.state_db_hostname import resolve_host
+
+    return resolve_host(None)
+
+
+def run_relocation(
+    *, name: str, spec: dict, from_host: str, to_host: str
+) -> ExecuteOutcome:
+    """Drive the relocation and print each phase as it resolves."""
+    stored = load_journal(name)
+    if stored is not None and stored.to_host != to_host:
+        console.print(
+            f"[red]refusing:[/red] a relocation of {name} to {stored.to_host!r} is already "
+            f"in flight at phase {stored.phase!r}. Finish or abort that one before "
+            f"starting a move to {to_host!r} — resuming it under a new destination would "
+            "retarget a move somebody else started.",
+            soft_wrap=True,
+        )
+        raise SystemExit(EXIT_INCOMPLETE)
+
+    if stored is not None and not stored.is_terminal:
+        relocation = stored
+        console.print(
+            f"resuming the stored relocation of {name}: it reached [bold]{stored.phase}[/bold]",
+            soft_wrap=True,
+        )
+    else:
+        relocation = begin(
+            agent=name,
+            from_host=from_host,
+            to_host=to_host,
+            now=time.time(),
+            detail=f"opened by sac agents relocate --no-dry-run on {_safe_local()}",
+        )
+        save_journal(relocation)
+
+    adapters = adapters_for(
+        agent=name,
+        spec=spec,
+        from_host=from_host,
+        to_host=to_host,
+        local_host=_safe_local(),
+    )
+    outcome = execute(relocation, effects=build_effects(adapters), now=time.time)
+    save_journal(outcome.relocation)
+
+    _render(outcome, adapters)
+    return outcome
+
+
+def _safe_local() -> str:
+    try:
+        return _local_host()
+    except Exception as exc:  # stx-allow: fallback (reason: an unresolvable local name must not abort the run; it only decides ssh-vs-local, and a wrong "not local" merely costs one ssh hop)
+        console.print(
+            f"[yellow]note:[/yellow] the local host name could not be resolved "
+            f"({type(exc).__name__}); every command will go through ssh, including any "
+            "aimed at this machine",
+            soft_wrap=True,
+        )
+        return ""
+
+
+def _render(outcome: ExecuteOutcome, adapters) -> None:
+    console.print("")
+    console.print("[bold]PHASES[/bold]")
+    for line in outcome.log:
+        console.print(f"  {line}", soft_wrap=True)
+
+    if adapters.log:
+        console.print("")
+        console.print("[bold]EVIDENCE[/bold]")
+        for line in adapters.log:
+            console.print(f"  {line}", soft_wrap=True)
+
+    if adapters.sent:
+        console.print("")
+        console.print("[bold]MEASURED[/bold]  (source -> target, counted on each host)")
+        landed = {f.name: f for f in adapters.landed}
+        for f in adapters.sent:
+            there = landed.get(f.name)
+            console.print(
+                f"  {f.name}\n"
+                f"    {adapters.from_host}: {f.byte_count} bytes / {f.line_count} lines\n"
+                f"    {adapters.to_host}: "
+                + (
+                    f"{there.byte_count} bytes / {there.line_count} lines"
+                    if there is not None
+                    else "ABSENT"
+                ),
+                soft_wrap=True,
+            )
+
+    console.print("")
+    if outcome.completed is True:
+        console.print(f"[green]DONE[/green]  {outcome.reason}", soft_wrap=True)
+        return
+
+    label = "UNMEASURED" if outcome.completed is None else "STOPPED"
+    console.print(
+        f"[yellow]{label}[/yellow] at [bold]{outcome.stopped_at}[/bold]: {outcome.reason}",
+        soft_wrap=True,
+    )
+    console.print(f"  next: {outcome.hint}", soft_wrap=True)
+    console.print(
+        f"  state: phase={outcome.relocation.phase} "
+        f"source_left_stopped={outcome.source_left_stopped} "
+        f"standby_left_running={outcome.standby_left_running} "
+        f"past_no_return={outcome.past_no_return}",
+        soft_wrap=True,
+    )
+    console.print(
+        "  nothing was deleted. Anything moved went to a .old/<stamp>/ directory on the "
+        "host it was moved on; a rollback is you moving it back, deliberately.",
+        soft_wrap=True,
+    )
+
+
+def exit_code_for(outcome: ExecuteOutcome) -> int:
+    """0 completed, 6 unmeasured, 5 stopped-and-understood. Never collapsed."""
+    if outcome.completed is True and outcome.code == CODE_COMPLETED:
+        return 0
+    return EXIT_UNMEASURED if outcome.completed is None else EXIT_INCOMPLETE
+
+
+__all__.append("exit_code_for")

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_effects.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_effects.py
@@ -1,0 +1,94 @@
+"""The gate on the irreversible step: retirement happens only after BOTH confirmations.
+
+The driver already stops at the first non-yes, so reaching ``finish`` implies the
+two confirmations. Implication is not a check, and this is the step that moves a
+human's conversation out from under them — so it is re-checked, and that re-check
+is what these tests pin.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._lifecycle._relocate_effects import (
+    RelocateAdapters,
+    build_effects,
+)
+from scitex_agent_container._lifecycle._relocate_shell import Shell
+
+
+def _adapters(*, arrival, handshake) -> RelocateAdapters:
+    return RelocateAdapters(
+        agent="a",
+        spec={},
+        from_host="src",
+        to_host="tgt",
+        source=Shell(host="src", is_local=True),
+        target=Shell(host="tgt"),
+        stamp="20260811T000000Z",
+        source_dir="/src/projects/-p",
+        arrival_confirmed=arrival,
+        handshake_confirmed=handshake,
+    )
+
+
+def test_retirement_is_refused_when_arrival_was_never_confirmed() -> None:
+    # Arrange: the src -> tgt leg. Moving the source's transcript aside on an
+    # unconfirmed copy is how the only copy of a conversation goes missing.
+    adapters = _adapters(arrival=None, handshake=True)
+    # Act
+    result = adapters.finish()
+    # Assert
+    assert result.ok is False
+
+
+def test_retirement_is_refused_when_arrival_failed() -> None:
+    # Arrange: the same leg, observed negative rather than unobserved.
+    adapters = _adapters(arrival=False, handshake=True)
+    # Act
+    result = adapters.finish()
+    # Assert
+    assert result.ok is False
+
+
+def test_retirement_is_refused_when_the_handshake_was_never_observed() -> None:
+    # Arrange: the tgt -> src leg. UNKNOWN refuses exactly as firmly as a
+    # failure — retiring on an unproven target is the 2026-08-07 shape with the
+    # source's memory moved out of reach.
+    adapters = _adapters(arrival=True, handshake=None)
+    # Act
+    result = adapters.finish()
+    # Assert
+    assert result.ok is False
+
+
+def test_the_refusal_names_which_confirmation_was_missing() -> None:
+    # Arrange: two different gates, two different next actions. A refusal that
+    # says only "not confirmed" sends the reader to check both.
+    adapters = _adapters(arrival=True, handshake=None)
+    # Act
+    result = adapters.finish()
+    # Assert
+    assert "handshake_confirmed" in result.detail
+
+
+def test_nothing_is_written_when_the_gate_refuses() -> None:
+    # Arrange: the refusal must come BEFORE the residency write, not after it —
+    # a residency row for a relocation that then refused to finish would record
+    # a move that did not happen.
+    adapters = _adapters(arrival=True, handshake=None)
+    # Act
+    adapters.finish()
+    # Assert
+    assert adapters.log == []
+
+
+def test_the_driver_is_given_an_effect_for_every_phase() -> None:
+    # Arrange: the driver REFUSES to run with a phase missing, because an absent
+    # effect would journal as done having changed nothing — the most convincing
+    # possible imitation of a successful relocation.
+    from scitex_agent_container._lifecycle._relocate_execute import _missing_effects
+
+    effects = build_effects(_adapters(arrival=True, handshake=True))
+    # Act
+    missing = _missing_effects(effects)
+    # Assert
+    assert missing == ()

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_execute.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_execute.py
@@ -524,3 +524,48 @@ def test_an_incomplete_outcome_must_say_what_to_do_next() -> None:
     # Assert
     with caught:
         build()
+
+
+def test_an_unattempted_standby_is_not_reported_as_left_running() -> None:
+    # Arrange: measured 2026-08-11 on the canary run. The unbuilt target_standby
+    # returned UNKNOWN, the outcome read that as "a standby may be running", and
+    # the recovery instruction sent the operator to stop a process that had never
+    # been started. A false alarm in a recovery instruction is not a safe default.
+    from scitex_agent_container._lifecycle._relocate_execute import _standby_running
+    from scitex_agent_container._lifecycle._relocate_phases import (
+        TARGET_STANDBY,
+        TRANSPORT,
+    )
+
+    # Act
+    left = _standby_running(TRANSPORT, TARGET_STANDBY, unknown=True, attempted=False)
+    # Assert
+    assert left is False
+
+
+def test_an_attempted_standby_that_could_not_be_measured_is_still_reported() -> None:
+    # Arrange: the case the conservative default was written for and which must
+    # NOT be lost — an effect that tried and could not tell may well have started
+    # something, and "nothing was left running" there is the reassurance that
+    # sends nobody to look.
+    from scitex_agent_container._lifecycle._relocate_execute import _standby_running
+    from scitex_agent_container._lifecycle._relocate_phases import (
+        TARGET_STANDBY,
+        TRANSPORT,
+    )
+
+    # Act
+    left = _standby_running(TRANSPORT, TARGET_STANDBY, unknown=True, attempted=True)
+    # Assert
+    assert left is True
+
+
+def test_a_step_result_is_attempted_by_default() -> None:
+    # Arrange: every existing caller keeps its meaning, and a forgetful new one
+    # over-warns rather than under-warns.
+    from scitex_agent_container._lifecycle._relocate_execute import StepResult
+
+    # Act
+    result = StepResult(ok=True, detail="did a thing")
+    # Assert
+    assert result.attempted is True

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_liveness.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_liveness.py
@@ -1,0 +1,94 @@
+"""Positive absence, absence of evidence, and the gap between them.
+
+The transport's precondition is "the source is stopped". Getting it wrong in the
+permissive direction produces a transcript torn mid-line, which parses, resumes,
+and silently ends the conversation early — so a probe that could not answer must
+refuse exactly as firmly as one that answered "yes, still running".
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._lifecycle._relocate_liveness import (
+    interpret_liveness,
+    unimplemented,
+)
+
+
+def _read(answers):
+    return interpret_liveness(
+        answers, host="h", session="tui-a", exit_code=0, stderr=""
+    )
+
+
+def test_a_present_session_reads_as_running() -> None:
+    # Arrange: tmux is the same fact the tui runtime itself checks.
+    # Act
+    running, _ = _read(["yes"])
+    # Assert
+    assert running is True
+
+
+def test_an_answering_tmux_with_no_such_session_reads_as_stopped() -> None:
+    # Arrange: POSITIVE evidence of absence, from tmux's own bookkeeping — the
+    # strong answer, and the only one that licenses copying.
+    # Act
+    running, _ = _read(["no"])
+    # Assert
+    assert running is False
+
+
+def test_no_tmux_server_at_all_reads_as_stopped() -> None:
+    # Arrange: an agent whose runtime IS a tmux session cannot be running where
+    # there is no tmux server.
+    # Act
+    running, _ = _read(["no-server"])
+    # Assert
+    assert running is False
+
+
+def test_tmux_not_installed_is_not_measured() -> None:
+    # Arrange: the opposite of the previous case, and it looks nearly identical
+    # in a shell. Nothing was measured, so nothing may be concluded.
+    # Act
+    running, _ = _read(["no-tmux"])
+    # Assert
+    assert running is None
+
+
+def test_a_silent_probe_is_not_measured() -> None:
+    # Arrange: no marker line means the script did not answer. Reading silence as
+    # "not running" is how a live agent's transcript gets copied mid-write.
+    # Act
+    running, _ = _read([])
+    # Assert
+    assert running is None
+
+
+def test_every_answer_carries_the_evidence_for_it() -> None:
+    # Arrange: each caller puts this in a journal entry or a refusal, and "could
+    # not determine" with no account of what was tried is not actionable.
+    # Act
+    _, why = _read([])
+    # Assert
+    assert why
+
+
+def test_an_unbuilt_phase_refuses_as_unknown_rather_than_failing() -> None:
+    # Arrange: nothing was attempted, so nothing about the hosts was learned.
+    # Reporting it as a failure would accuse a host of something.
+    effect = unimplemented("target_standby", "no adapter: the boot")
+    # Act
+    result = effect()
+    # Assert
+    assert result.ok is None
+
+
+def test_an_unbuilt_phase_names_the_missing_piece() -> None:
+    # Arrange: the operator's next question is always "so what IS missing", and
+    # answering it in the refusal is the difference between a blocked afternoon
+    # and a scoped piece of work.
+    effect = unimplemented("target_standby", "no adapter: the boot")
+    # Act
+    result = effect()
+    # Assert
+    assert "no adapter: the boot" in result.detail

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
@@ -258,3 +258,33 @@ def test_render_observed_tolerates_a_report_with_one_check() -> None:
     lines = render_observed(report)
     # Assert
     assert any("PASS" in ln and "fine" in ln for ln in lines)
+
+
+def test_the_executing_header_does_not_claim_nothing_was_touched() -> None:
+    # Arrange: THE lie, measured 2026-08-11 on the canary run. The header was
+    # unconditional, so the first real relocation printed "(nothing was touched)"
+    # above a report of 3.6 MB moved between two hosts.
+    report = _report(ALL_GOOD)
+    # Act
+    head = render_dry_run(report, dry_run=False)[0]
+    # Assert
+    assert "nothing was touched" not in head
+
+
+def test_the_executing_header_says_both_hosts_change() -> None:
+    # Arrange: the reader needs to know, from the first line, which of the two
+    # modes they are looking at.
+    report = _report(ALL_GOOD)
+    # Act
+    head = render_dry_run(report, dry_run=False)[0]
+    # Assert
+    assert "EXECUTING" in head
+
+
+def test_the_header_still_defaults_to_the_dry_run_wording() -> None:
+    # Arrange: a caller that forgets the flag must OVER-warn, not under-warn.
+    report = _report(ALL_GOOD)
+    # Act
+    head = render_dry_run(report)[0]
+    # Assert
+    assert "DRY RUN" in head

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_transcript_home.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_transcript_home.py
@@ -1,0 +1,175 @@
+"""The host-side directory that backs a containerised agent's ``~/.claude``.
+
+The failure being pinned is the one measured on this fleet on 2026-08-09: a
+transcript that landed in the overlay's upper layer while the runtime tree — the
+one that LOOKS like it should hold it — held only the boot seed. Carrying the
+wrong tree relocates an agent's config and leaves its conversation behind.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._lifecycle._relocate_transcript_home import (
+    CODE_FROM_BIND,
+    CODE_FROM_OVERLAY,
+    CODE_UNCONTAINED,
+    CODE_UNKNOWN,
+    transcript_home_from_spec,
+)
+
+LEAF_BIND = {
+    "spec": {
+        "runtime": "tui",
+        "apptainer": {
+            "binds": [
+                "/host/runtime/a/home/.claude/projects:/home/agent/.claude/projects:rw",
+                "/home/ywatanabe:/home/ywatanabe:rw",
+            ],
+            "raw_args": ["--overlay", "/host/overlays/a/"],
+        },
+    }
+}
+
+OVERLAY_ONLY = {
+    "spec": {
+        "runtime": "tui",
+        "apptainer": {
+            "binds": ["/home/ywatanabe:/home/ywatanabe:rw"],
+            "raw_args": ["--home", "/home/agent", "--overlay", "/host/overlays/a/"],
+        },
+    }
+}
+
+
+def test_a_leaf_projects_bind_yields_the_container_home() -> None:
+    # Arrange: the shape that demonstrably works — bind the projects directory
+    # itself, because a bind OVER /home/agent loses to apptainer's --home.
+    # Act
+    answer = transcript_home_from_spec(LEAF_BIND)
+    # Assert
+    assert answer.path == "/host/runtime/a/home"
+
+
+def test_a_leaf_projects_bind_is_reported_as_coming_from_a_bind() -> None:
+    # Arrange: provenance matters — the same path could have been derived two
+    # ways, and which one it was decides whether it is still true tomorrow.
+    # Act
+    answer = transcript_home_from_spec(LEAF_BIND)
+    # Assert
+    assert answer.code == CODE_FROM_BIND
+
+
+def test_a_bind_wins_over_the_overlay_when_both_are_present() -> None:
+    # Arrange: LEAF_BIND carries BOTH a projects bind and an --overlay. The bind
+    # is where the writes actually go; preferring the overlay would name a
+    # directory the running agent does not write to.
+    # Act
+    answer = transcript_home_from_spec(LEAF_BIND)
+    # Assert
+    assert "overlays" not in (answer.path or "")
+
+
+def test_no_bind_falls_through_to_the_overlay_upper_layer() -> None:
+    # Arrange: the fleet's default shape, and the one that surprised everybody
+    # on 2026-08-09.
+    # Act
+    answer = transcript_home_from_spec(OVERLAY_ONLY)
+    # Assert
+    assert answer.path == "/host/overlays/a/upper/home/agent"
+
+
+def test_the_overlay_answer_is_labelled_as_such() -> None:
+    # Arrange: same reason as the bind case — the caller may want to know which
+    # mechanism it is relying on.
+    # Act
+    answer = transcript_home_from_spec(OVERLAY_ONLY)
+    # Assert
+    assert answer.code == CODE_FROM_OVERLAY
+
+
+def test_a_last_bind_over_the_same_container_path_wins() -> None:
+    # Arrange: apptainer applies binds in order, so a later one shadows an
+    # earlier one. Taking the FIRST match would name a directory that is mounted
+    # over and never written to.
+    spec = {
+        "spec": {
+            "apptainer": {
+                "binds": [
+                    "/first/home/.claude/projects:/home/agent/.claude/projects:rw",
+                    "/second/home/.claude/projects:/home/agent/.claude/projects:rw",
+                ]
+            }
+        }
+    }
+    # Act
+    answer = transcript_home_from_spec(spec)
+    # Assert
+    assert answer.path == "/second/home"
+
+
+def test_a_bind_whose_halves_disagree_is_refused_rather_than_trimmed() -> None:
+    # Arrange: host side does not end in the suffix the container side implies.
+    # Silently trimming something else off would name a real directory that is
+    # the wrong one, which is worse than refusing.
+    spec = {
+        "spec": {
+            "apptainer": {"binds": ["/somewhere/else:/home/agent/.claude/projects:rw"]}
+        }
+    }
+    # Act
+    answer = transcript_home_from_spec(spec)
+    # Assert
+    assert answer.path is None
+
+
+def test_a_mismatched_bind_carries_the_unknown_code() -> None:
+    # Arrange: the discipline the rest of the relocate machinery uses — an
+    # unresolved value is absent and carries CODE_UNKNOWN, never a guess.
+    spec = {
+        "spec": {
+            "apptainer": {"binds": ["/somewhere/else:/home/agent/.claude/projects:rw"]}
+        }
+    }
+    # Act
+    answer = transcript_home_from_spec(spec)
+    # Assert
+    assert answer.code == CODE_UNKNOWN
+
+
+def test_an_uncontained_agent_uses_the_observed_ssh_home() -> None:
+    # Arrange: no container at all, so the host's own $HOME IS the answer — but
+    # only because it was OBSERVED and passed in.
+    spec = {"spec": {"runtime": "none"}}
+    # Act
+    answer = transcript_home_from_spec(spec, ssh_home="/home/ywatanabe")
+    # Assert
+    assert answer.code == CODE_UNCONTAINED
+
+
+def test_an_uncontained_agent_with_no_observed_home_refuses() -> None:
+    # Arrange: this host's $HOME is not evidence about that host's, so an
+    # unobserved one must not be substituted.
+    spec = {"spec": {"runtime": "none"}}
+    # Act
+    answer = transcript_home_from_spec(spec)
+    # Assert
+    assert answer.path is None
+
+
+def test_a_containerised_spec_with_neither_mechanism_refuses() -> None:
+    # Arrange: no bind covering the home and no --overlay means nobody can say
+    # where the conversation is durably written. A guess here produces an agent
+    # that starts, reports healthy, and has no memory.
+    spec = {"spec": {"runtime": "tui", "apptainer": {"binds": ["/a:/b:rw"]}}}
+    # Act
+    answer = transcript_home_from_spec(spec)
+    # Assert
+    assert answer.path is None
+
+
+def test_an_unresolved_home_says_what_to_measure_next() -> None:
+    # Arrange: every refusal in this feature has to be actionable.
+    spec = {"spec": {"runtime": "tui", "apptainer": {"binds": ["/a:/b:rw"]}}}
+    # Act
+    answer = transcript_home_from_spec(spec)
+    # Assert
+    assert answer.hint

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_transport.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_transport.py
@@ -22,6 +22,9 @@ from __future__ import annotations
 
 import pytest
 
+from scitex_agent_container._lifecycle._relocate_move_aside import (
+    move_aside_destination,
+)
 from scitex_agent_container._lifecycle._relocate_transport import (
     CODE_ARRIVED,
     CODE_MISSING_ON_TARGET,
@@ -157,7 +160,7 @@ def test_the_move_aside_destination_is_dot_old_under_the_timestamp() -> None:
     # Act
     plan = _ready_plan(target_dir_exists=True)
     # Assert
-    assert plan.move_aside.destination == f"{TARGET_DIR}/.old/{STAMP}"
+    assert plan.move_aside.destination == move_aside_destination(TARGET_DIR, STAMP)
 
 
 def test_a_move_aside_still_lets_the_transport_proceed() -> None:
@@ -475,3 +478,42 @@ def test_neither_outcome_defines_a_bool() -> None:
     defined = "__bool__" in vars(TransportPlan) or "__bool__" in vars(ArrivalVerdict)
     # Assert
     assert defined is False
+
+
+def test_the_move_aside_destination_is_not_inside_the_directory_it_moves() -> None:
+    # Arrange: THE bug, measured 2026-08-11 on the canary run's idempotency pass.
+    # The destination was computed inside the directory being moved, so `mv`
+    # refused with "cannot move a directory into itself" and a clean retry was a
+    # dead end. The string was well-formed, so no pure test could have caught it —
+    # this one is written from the real `mv` that did.
+    plan = plan_transport(
+        source_running=False,
+        source_files=["a.jsonl"],
+        target_dir_exists=True,
+        target_dir=TARGET_DIR,
+        stamp=STAMP,
+    )
+    # Act
+    destination = plan.move_aside.destination
+    # Assert
+    assert not destination.startswith(TARGET_DIR.rstrip("/") + "/")
+
+
+def test_the_move_aside_destination_keeps_the_directory_name() -> None:
+    # Arrange: a restore is "move it back", so the displaced copy has to be
+    # recognisable as the thing it was rather than a bare timestamp.
+    # Act
+    destination = move_aside_destination("/a/b/-home-proj", "S")
+    # Assert
+    assert destination == "/a/b/.old/S/-home-proj"
+
+
+def test_a_path_with_no_parent_cannot_be_moved_aside() -> None:
+    # Arrange: there is nowhere beside it to move it to, and inventing somewhere
+    # would put the only copy of a conversation where nobody would look.
+    call = lambda: move_aside_destination("/", "S")
+    # Act
+    attempt = call
+    # Assert
+    with pytest.raises(ValueError):
+        attempt()

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_transport_ssh.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_transport_ssh.py
@@ -1,0 +1,173 @@
+"""The command that moves the bytes, and the parse that reads the counts back.
+
+Both halves are pinned WITHOUT a second machine: the argv is a pure rendering and
+the measurement parse is a pure read of captured output, which is the same seam
+the probe adapter uses. What cannot be tested here — that two real hosts agree —
+is exactly what the canary run is for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_probe_ssh import RemoteRun
+from scitex_agent_container._lifecycle._relocate_shell import Shell
+from scitex_agent_container._lifecycle._relocate_transport_ssh import (
+    MARK_FILE,
+    build_copy_argv,
+    parse_measurements,
+)
+
+LOCAL = Shell(host="src-host", is_local=True)
+REMOTE = Shell(host="tgt-host")
+
+
+def _argv(files):
+    return build_copy_argv(
+        source=LOCAL,
+        source_dir="/src/projects/-p",
+        target=REMOTE,
+        target_dir="/tgt/projects/-p",
+        files=files,
+    )
+
+
+def test_the_carried_names_are_passed_as_arguments_not_a_glob() -> None:
+    # Arrange: THE reason tar was chosen over scp/rsync. The allowlist decided an
+    # exact set; a glob would be re-expanded at copy time and carry whatever
+    # matched a moment later.
+    # Act
+    pipeline = _argv(["a.jsonl", "b.jsonl"])[-1]
+    # Assert
+    assert "-- a.jsonl b.jsonl" in pipeline
+
+
+def test_no_glob_character_reaches_either_shell() -> None:
+    # Arrange: the same rule, stated as the property that must hold rather than
+    # the string that happens to appear.
+    # Act
+    pipeline = _argv(["a.jsonl"])[-1]
+    # Assert
+    assert "*" not in pipeline
+
+
+def test_the_pipeline_uses_pipefail_so_a_failed_source_is_not_masked() -> None:
+    # Arrange: without it the pipeline reports only the LAST stage, so a tar that
+    # failed outright is hidden by an ssh that extracted nothing.
+    # Act
+    pipeline = _argv(["a.jsonl"])[-1]
+    # Assert
+    assert "set -o pipefail" in pipeline
+
+
+def test_the_destination_is_created_on_the_target_before_extracting() -> None:
+    # Arrange: the target's transcript root may not exist at all — it is the
+    # agent's own directory on a host it has never run on.
+    # Act
+    pipeline = _argv(["a.jsonl"])[-1]
+    # Assert
+    assert "mkdir -p /tgt/projects/-p" in pipeline
+
+
+def test_an_empty_file_list_is_refused() -> None:
+    # Arrange: a copy that transfers nothing and exits 0 is the exact failure
+    # shape this feature exists to prevent.
+    empty: list[str] = []
+    # Act
+    call = lambda: _argv(empty)
+    # Assert
+    with pytest.raises(ValueError):
+        call()
+
+
+def test_a_credential_is_refused_at_the_point_the_bytes_would_move() -> None:
+    # Arrange: select_transferable already declines these, but THIS function is
+    # generic and will carry any named file. A transport that would copy a
+    # credential if asked is one that eventually does.
+    named = [".credentials.json"]
+    # Act
+    call = lambda: _argv(named)
+    # Assert
+    with pytest.raises(ValueError):
+        call()
+
+
+def test_a_path_component_in_a_name_is_refused() -> None:
+    # Arrange: a "/" would place the file outside the directory the allowlist was
+    # applied to, which quietly widens the allowlist to the whole filesystem.
+    escaping = ["../elsewhere/a.jsonl"]
+    # Act
+    call = lambda: _argv(escaping)
+    # Assert
+    with pytest.raises(ValueError):
+        call()
+
+
+def test_a_local_source_is_read_without_an_intervening_ssh() -> None:
+    # Arrange: the source IS where the coordinator runs, in the ordinary case.
+    # ssh-ing to ourselves is one more connection that can fail.
+    # Act
+    pipeline = _argv(["a.jsonl"])[-1]
+    # Assert
+    assert pipeline.startswith("set -o pipefail; tar -C /src/projects/-p")
+
+
+def test_a_remote_source_is_read_over_ssh() -> None:
+    # Arrange: the general case — a coordinator relocating between two hosts that
+    # are both somebody else.
+    # Act
+    argv = build_copy_argv(
+        source=Shell(host="src-host"),
+        source_dir="/src/p",
+        target=REMOTE,
+        target_dir="/tgt/p",
+        files=["a.jsonl"],
+    )
+    # Assert
+    assert argv[-1].startswith("set -o pipefail; ssh ")
+
+
+def test_measurements_are_read_off_the_marker_lines() -> None:
+    # Arrange: parsed per line so a shell that also prints a warning cannot be
+    # mistaken for a measurement.
+    run = RemoteRun(
+        stdout=f"warning: something\n{MARK_FILE}a.jsonl\t120\t4\n",
+        stderr="",
+        exit_code=0,
+    )
+    # Act
+    files = parse_measurements(run)
+    # Assert
+    assert files[0].byte_count == 120
+
+
+def test_a_line_count_is_read_alongside_the_byte_count() -> None:
+    # Arrange: the two catch different things — bytes catch a truncated write,
+    # lines catch a transport that rewrote line endings and left the size
+    # plausible.
+    run = RemoteRun(stdout=f"{MARK_FILE}a.jsonl\t120\t4\n", stderr="", exit_code=0)
+    # Act
+    files = parse_measurements(run)
+    # Assert
+    assert files[0].line_count == 4
+
+
+def test_an_unreadable_count_is_not_measured_rather_than_zero() -> None:
+    # Arrange: an empty field means wc could not answer. Reading it as 0 turns an
+    # unreadable file into an empty one, and verification would then compare two
+    # zeros and pass.
+    run = RemoteRun(stdout=f"{MARK_FILE}a.jsonl\t\t\n", stderr="", exit_code=0)
+    # Act
+    files = parse_measurements(run)
+    # Assert
+    assert files[0].measured is False
+
+
+def test_output_with_no_marker_lines_yields_no_measurements() -> None:
+    # Arrange: a script that ran and said nothing measured nothing. The caller
+    # then sees the file as absent on that host, which refuses.
+    run = RemoteRun(stdout="ls: no such directory\n", stderr="", exit_code=1)
+    # Act
+    files = parse_measurements(run)
+    # Assert
+    assert files == ()

--- a/tests/scitex_agent_container/_state/test_state_db_relocation.py
+++ b/tests/scitex_agent_container/_state/test_state_db_relocation.py
@@ -1,0 +1,153 @@
+"""Residency rows: at most one open stay, idempotent on a re-run, nothing deleted.
+
+The invariant is not "we try not to write two open stays" — it is that living on
+two hosts at once must not be representable, so the closing write and the opening
+write happen in one transaction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._state.state_db_relocation import (
+    current_residency,
+    init_relocation_schema,
+    load_journal,
+    read_residency_history,
+    record_residency,
+    save_journal,
+)
+
+
+@pytest.fixture()
+def db(tmp_path):
+    """A real sqlite file in ``tmp_path``, addressed explicitly.
+
+    Every function under test takes ``db_path``, so the store is chosen by
+    passing it rather than by rewriting the environment out from under the
+    production resolver — which would test the resolver's absence, not the rows.
+    """
+    path = tmp_path / "state.db"
+    init_relocation_schema(path)
+    return path
+
+
+def test_an_agent_the_table_never_heard_of_has_no_history(db) -> None:
+    # Arrange: genuinely "the db knows nothing", which is what lets a legacy spec
+    # host: seed it once — deliberately distinct from a stay that has closed.
+    # Act
+    history = read_residency_history("nobody", db_path=db)
+    # Assert
+    assert history == ()
+
+
+def test_recording_a_move_opens_a_stay(db) -> None:
+    # Arrange: the DONE-phase write. This IS the thing that moves an agent's host.
+    record_residency(agent="a", host="h1", now=100.0, db_path=db)
+    # Act
+    host = current_residency("a", db_path=db)
+    # Assert
+    assert host == "h1"
+
+
+def test_a_second_move_closes_the_first_stay(db) -> None:
+    # Arrange: "living on two hosts at once" must be unrepresentable, not merely
+    # discouraged.
+    record_residency(agent="a", host="h1", now=100.0, db_path=db)
+    record_residency(agent="a", host="h2", now=200.0, db_path=db)
+    # Act
+    open_stays = [r for r in read_residency_history("a", db_path=db) if r.to_ts is None]
+    # Assert
+    assert len(open_stays) == 1
+
+
+def test_the_open_stay_after_a_move_is_the_new_host(db) -> None:
+    # Arrange: the answer the whole feature exists to change.
+    record_residency(agent="a", host="h1", now=100.0, db_path=db)
+    record_residency(agent="a", host="h2", now=200.0, db_path=db)
+    # Act
+    host = current_residency("a", db_path=db)
+    # Assert
+    assert host == "h2"
+
+
+def test_the_earlier_stay_is_kept_rather_than_deleted(db) -> None:
+    # Arrange: the migration fact is the point — after a relocation completes,
+    # the record that it happened is the only thing that answers an attribution
+    # question later.
+    record_residency(agent="a", host="h1", now=100.0, db_path=db)
+    record_residency(agent="a", host="h2", now=200.0, db_path=db)
+    # Act
+    hosts = [r.host for r in read_residency_history("a", db_path=db)]
+    # Assert
+    assert hosts == ["h1", "h2"]
+
+
+def test_re_recording_the_same_host_is_a_no_op(db) -> None:
+    # Arrange: a coordinator that wrote the row and died before journalling
+    # re-runs. It must not litter the history with the evidence of its retries.
+    record_residency(agent="a", host="h1", now=100.0, db_path=db)
+    # Act
+    opened = record_residency(agent="a", host="h1", now=200.0, db_path=db)
+    # Assert
+    assert opened is False
+
+
+def test_a_no_op_re_record_adds_no_row(db) -> None:
+    # Arrange: the same rule, checked on the table rather than the return value.
+    record_residency(agent="a", host="h1", now=100.0, db_path=db)
+    record_residency(agent="a", host="h1", now=200.0, db_path=db)
+    # Act
+    history = read_residency_history("a", db_path=db)
+    # Assert
+    assert len(history) == 1
+
+
+def test_an_empty_host_is_refused(db) -> None:
+    # Arrange: an empty destination would open a residency that answers no
+    # question, and would then be READ as an answer.
+    call = lambda: record_residency(agent="a", host="  ", now=1.0, db_path=db)
+    # Act
+    outcome = call
+    # Assert
+    with pytest.raises(ValueError):
+        outcome()
+
+
+def test_a_journal_round_trips_through_the_store(db) -> None:
+    # Arrange: this is what makes a crashed relocation RESUME rather than restart.
+    from scitex_agent_container._lifecycle._relocate_phases import advance, begin
+
+    reloc = begin(agent="a", from_host="h1", to_host="h2", now=1.0)
+    moved, _ = advance(reloc, to_phase="source_drain", now=2.0, detail="d")
+    save_journal(moved, db_path=db)
+    # Act
+    loaded = load_journal("a", db_path=db)
+    # Assert
+    assert loaded.phase == "source_drain"
+
+
+def test_a_journal_keeps_its_steps(db) -> None:
+    # Arrange: the record is self-describing — reading it tells you where the
+    # relocation is, how it got there, and when, without a log that may have
+    # rotated away.
+    from scitex_agent_container._lifecycle._relocate_phases import advance, begin
+
+    reloc = begin(agent="a", from_host="h1", to_host="h2", now=1.0)
+    moved, _ = advance(
+        reloc, to_phase="source_drain", now=2.0, detail="nothing to drain"
+    )
+    save_journal(moved, db_path=db)
+    # Act
+    loaded = load_journal("a", db_path=db)
+    # Assert
+    assert loaded.steps[-1].detail == "nothing to drain"
+
+
+def test_no_journal_for_an_unknown_agent(db) -> None:
+    # Arrange: the caller must open a fresh relocation, which it can only do if
+    # "never started" is distinguishable from "stored".
+    # Act
+    loaded = load_journal("nobody", db_path=db)
+    # Assert
+    assert loaded is None

--- a/tests/scitex_agent_container/cli_pkg/test__relocate_cmd.py
+++ b/tests/scitex_agent_container/cli_pkg/test__relocate_cmd.py
@@ -19,7 +19,7 @@ from click.testing import CliRunner
 
 from scitex_agent_container.cli_pkg._relocate_cmd import (
     EXIT_REFUSED,
-    EXIT_UNIMPLEMENTED,
+    EXIT_RETIRED_UNIMPLEMENTED,
     _required_ports,
     declared_from_spec,
     register,
@@ -157,13 +157,35 @@ def test_missing_to_is_a_usage_error_not_a_refusal() -> None:
 
 
 def test_the_exit_codes_are_distinct() -> None:
-    # Arrange: three outcomes a caller must be able to branch on — usage (2),
-    # target not ready (3), not built yet (4). Collapsing any two is how a
-    # script decides "it worked" from a failure.
+    # Arrange: four outcomes a caller must be able to branch on — usage (2),
+    # target not ready (3), a phase refused (5), a phase could not be measured
+    # (6). Collapsing any two is how a script decides "it worked" from a failure.
+    # 4 is retired rather than reused: a script written against its old meaning
+    # ("not built yet") must not silently start reading a new one.
+    from scitex_agent_container.cli_pkg._relocate_run import (
+        EXIT_INCOMPLETE,
+        EXIT_UNMEASURED,
+    )
+
     # Act
-    codes = {2, EXIT_REFUSED, EXIT_UNIMPLEMENTED}
+    codes = {2, EXIT_REFUSED, EXIT_INCOMPLETE, EXIT_UNMEASURED}
     # Assert
-    assert len(codes) == 3
+    assert len(codes) == 4
+
+
+def test_the_retired_exit_code_is_not_reused() -> None:
+    # Arrange: 4 meant "the executing path does not exist". It does now, so the
+    # number is retired rather than re-pointed — a script written against the old
+    # meaning must not silently start reading a new one.
+    from scitex_agent_container.cli_pkg._relocate_run import (
+        EXIT_INCOMPLETE,
+        EXIT_UNMEASURED,
+    )
+
+    # Act
+    live = (EXIT_INCOMPLETE, EXIT_UNMEASURED)
+    # Assert
+    assert EXIT_RETIRED_UNIMPLEMENTED not in live
 
 
 def test_register_attaches_the_verb_to_a_group() -> None:
@@ -212,55 +234,69 @@ def test_the_refusal_covers_every_phase() -> None:
     assert covered == tuple(p for p in PHASES if p != PREFLIGHT)
 
 
-def test_the_refusal_names_the_transport_phase_as_built() -> None:
+def test_the_notice_names_the_transport_adapter_as_built() -> None:
     # Arrange: the operator's question is "what is missing", and answering it
-    # requires saying what is NOT. The transport decision layer exists now.
-    from scitex_agent_container.cli_pkg._relocate_cmd import _unimplemented_notice
+    # requires saying what is NOT. The ssh adapter exists now.
+    from scitex_agent_container.cli_pkg._relocate_cmd import _readiness_notice
 
     # Act
-    text = "\n".join(_unimplemented_notice())
+    text = "\n".join(_readiness_notice())
     # Assert
-    assert "_relocate_transport" in text
+    assert "_relocate_transport_ssh" in text
 
 
-def test_the_refusal_names_the_arrival_brief_as_built() -> None:
-    # Arrange: the other half of this change, so the notice reflects it too.
-    from scitex_agent_container.cli_pkg._relocate_cmd import _unimplemented_notice
+def test_the_notice_names_the_arrival_brief_as_built() -> None:
+    # Arrange: the handshake's decision half exists; its delivery does not.
+    from scitex_agent_container.cli_pkg._relocate_cmd import _readiness_notice
 
     # Act
-    text = "\n".join(_unimplemented_notice())
+    text = "\n".join(_readiness_notice())
     # Assert
     assert "_relocate_arrival" in text
 
 
-def test_the_refusal_no_longer_blames_the_transcript_transport() -> None:
-    # Arrange: THE stale sentence. It said the cross-host transcript transport
-    # was "not built"; that is now false, and a refusal that misstates its own
-    # cause sends the reader to build something that already exists.
-    from scitex_agent_container.cli_pkg._relocate_cmd import _unimplemented_notice
+def test_the_notice_no_longer_claims_the_adapters_are_absent() -> None:
+    # Arrange: THE stale sentence, one generation on. It said the phase driver
+    # had no I/O adapters wired; that is now false for transport, source_stop and
+    # done, and a notice that misstates its own state sends the reader to build
+    # something that already exists.
+    from scitex_agent_container.cli_pkg._relocate_cmd import _readiness_notice
 
     # Act
-    text = "\n".join(_unimplemented_notice())
+    text = "\n".join(_readiness_notice())
     # Assert
-    assert "transcript transport is not built" not in text
+    assert "no I/O adapters wired" not in text
 
 
-def test_the_refusal_says_what_is_actually_missing() -> None:
-    # Arrange: the honest cause is the absent I/O adapters, not the decisions.
-    from scitex_agent_container.cli_pkg._relocate_cmd import _unimplemented_notice
+def test_the_notice_marks_the_transport_phase_as_running() -> None:
+    # Arrange: the readiness table is the thing that must not overclaim OR
+    # underclaim; transport now has nothing missing.
+    from scitex_agent_container.cli_pkg._relocate_cmd import _PHASE_READINESS
 
     # Act
-    text = "\n".join(_unimplemented_notice())
+    missing = {phase: gap for phase, _, gap in _PHASE_READINESS}
     # Assert
-    assert "no I/O adapters wired" in text
+    assert missing["transport"] == "—"
 
 
-def test_the_refusal_warns_about_the_target_side_directory_name() -> None:
-    # Arrange: the operator will move the transcript by hand meanwhile, and the
-    # source-named directory is the trap that makes a hand move look successful.
-    from scitex_agent_container.cli_pkg._relocate_cmd import _unimplemented_notice
+def test_the_notice_still_marks_target_standby_as_refusing() -> None:
+    # Arrange: the honest half. Nothing carries a spec to the target or writes
+    # its session marker, so this phase must not read as ready.
+    from scitex_agent_container.cli_pkg._relocate_cmd import _PHASE_READINESS
 
     # Act
-    text = "\n".join(_unimplemented_notice())
+    missing = {phase: gap for phase, _, gap in _PHASE_READINESS}
     # Assert
-    assert "invisible to the target's runner" in text
+    assert "no adapter" in missing["target_standby"]
+
+
+def test_the_notice_says_nothing_is_ever_deleted() -> None:
+    # Arrange: the operator's rollback story. A displaced directory goes to
+    # .old/<stamp>/ and a rollback is a human moving it back — never this code
+    # deciding to remove something.
+    from scitex_agent_container.cli_pkg._relocate_cmd import _readiness_notice
+
+    # Act
+    text = "\n".join(_readiness_notice())
+    # Assert
+    assert "Nothing is deleted at any point" in text


### PR DESCRIPTION
## What this is

#962 built the relocation DECISIONS and deliberately left them pure — what may
travel, where it must land, whether what landed is what left. This is the other
half: the **ssh I/O adapters**, the phase driver wired so `--no-dry-run`
executes, and the durable rows the lease/residency/journal never had.

It was then **run against two live hosts**, three times, and the run is the point
of the PR: everything below under "what running it found" was invisible to a unit
test and is fixed here.

## Transport: tar-over-ssh, and why

The decisive reason is the allowlist. `select_transferable` returns an EXACT set
of names, and `tar -C <dir> -cf - -- <name> <name>` takes exactly those as
arguments. A glob would be re-expanded by a shell at copy time — an allowlist
becomes "whatever matched the pattern a moment later", including anything created
in between. Secondary: rsync must exist on **both** ends and does not on the
fleet's busybox targets; scp would need one connection per file or a remote glob,
which is the first problem again. tar is one connection, one exact file list, and
rides the same `-J` jump chain as every other sac ssh call.

**A pipeline's exit code is evidence, never proof.** The copy's rc is recorded and
printed as evidence; the ANSWER comes from `wc -c` / `wc -l` run by the TARGET's
own shell on the target's own files, compared against the *same script text* run
on the source. Nothing infers a far-side count from a local `stat`.

## What running it found (none of which a pure test could catch)

| | |
|---|---|
| **The move-aside destination was inside the directory being moved** | `<dir>/.old/<ts>` instead of `<parent>/.old/<ts>/<name>`. The string is well-formed and the unit test pinned it confidently; `mv` refuses with *"cannot move a directory into itself"*, so the idempotent retry — the whole point of moving aside — was a dead end. Found on the canary's **second** pass. Now `_relocate_move_aside`, shared by both callers so they cannot drift. |
| **The report header said `DRY RUN (nothing was touched)` unconditionally** | So the first real relocation printed it above 3.6 MB moved between two hosts. A report that misstates whether it changed anything is this feature's own failure shape, aimed at the reader instead of the machine. |
| **"could not tell" and "never tried" were both `ok=None`** | An unbuilt phase made the outcome tell the operator a standby might be running on a host where nothing had been started. `StepResult.attempted` separates them; defaults `True` so a forgetful caller over-warns. |
| **A containerised agent's transcript does not live under the ssh user's `$HOME`** | It follows the *container's*, which the SPEC decides — a bind onto the container home (or a subpath), else the apptainer overlay's upper layer. Probing the target for `$HOME` would have named a real directory nothing reads. `_relocate_transcript_home` derives it (last-bind-wins, since apptainer applies binds in order) and refuses rather than defaulting. |
| **`source_work_committed` was never wired** | The check existed and nothing supplied its facts, so every dry run refused on a permanent UNKNOWN. Now scanned from the workdir; a non-repo workdir is an OBSERVED empty scan, which is a real answer, not a pass inherited from silence. |

## The operator's four handshake criteria

- **src → tgt is content-verified arrival** — `transport` measures every carried
  file ON the target and hands both sides to `verify_arrival`.
- **tgt → src is an OBSERVED answer, UNKNOWN refuses** — `handshake` builds the
  brief (which *is* the challenge, nonce + proof-of-work) and evaluates the gate
  against what was actually seen. There is no delivery adapter yet, so it returns
  UNKNOWN — deliberately **not** "no reply", which would be a false accusation
  against a target nobody booted.
- **Retirement flips residency only after both** — `finish` re-checks the two
  recorded confirmations before writing anything. The driver already stops at the
  first non-yes, but a guarantee living only in another module's control flow is
  one refactor from untrue, and this is the step that moves a human's
  conversation out from under them.
- **Failure lands in a NAMED state; retry idempotent; rollback deliberate** — the
  journal persists, so a re-run resumes from the stored phase. Nothing is ever
  deleted: displaced directories go to `.old/<stamp>/` on the host they were
  displaced on, and a rollback is a human moving one back.

## Phase readiness (printed by the command itself)

`source_drain` (stopped source only) · `source_stop` · `transport` · `done` **run**.
`target_standby`, `handshake`, `handover` **refuse by name**, so the relocation
stops there in a state the journal records rather than journalling its way to
DONE having moved nothing.

## Measured — canary-resume-test, ywata-note-win → scitex-compute-04, 2026-08-11

```
preflight                 11/11 PASS
source_drain              vacuous (tmux answered, no session — positive absence)
source_stop               already stopped, verified independently
transport                 3,645,260 bytes / 4,099 lines counted on EACH host
  md5 (source)            fc0ad02d58278873d51a8e4ec8b296ff
  md5 (target)            fc0ad02d58278873d51a8e4ec8b296ff
  md5 (moved-aside copy)  fc0ad02d58278873d51a8e4ec8b296ff
  refused by name         memory/  ("only conversation transcripts travel")
target_standby            UNKNOWN — no adapter (named), exit 6
residency                 NOT flipped   <- the gate working
source transcript         NOT retired   <- the gate working
```

Run three times: first proved the transport, second found the move-aside bug,
third proved the fixed move-aside plus the corrected `EXECUTING` header and
`standby_left_running=False`.

## Not in this PR, on purpose

`target_standby` needs the spec carried to the target and its `session_id` marker
written from the carried transcript; `handshake` needs a2a delivery observed on
the source; `handover` needs something to claim a lease at start-up. Each refuses
with exactly that sentence rather than being quietly skipped.

Base: `develop` (#962 squash-merged mid-work as `f0e52b75`; this branch is
cherry-picked onto the post-merge develop, so the diff is only the new work).
