### PR TITLE
fix(audit): close the two §6a env-var ERRORs — rename ours, allowlist theirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,13 +312,26 @@ mcp_parity_exempt = true
 #     ``SAC_HOST_IDENTITY_PATH`` /
 #     ``SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S`` — operations knobs.
 #
+# ``CODEX_HOME`` is a THIRD-PARTY CONTRACT, not our namespace. It is
+# OpenAI Codex's own variable — the way Codex publishes where its
+# ``auth.json`` lives — and ``_account/codex_account.py:_auth_path()``
+# reads it to find the login Codex actually wrote. Renaming it would
+# not move a name into our namespace; it would simply stop reading
+# Codex's login, and do so SILENTLY, in the credential path that is
+# hardest to test. It belongs in the same category as the universal
+# list's ``GH_TOKEN`` / ``OPENAI_`` entries and is listed by EXACT
+# NAME (no trailing underscore) so it grants exactly one variable and
+# opens no ``CODEX_*`` namespace. Our own override alongside it,
+# ``SCITEX_GENAI_CODEX_HOMES``, is already canonically prefixed and
+# needs no entry.
+#
 # Spec: scitex_dev/_cli/audit/_summary/_env_allowlist.py — the entry
 # applies "equal-to-stripped or prefix-match", so ``"SAC_"`` matches
 # every ``SAC_*`` env var without listing them individually. New
 # code that does not need brand-compat MUST still use the canonical
 # ``SCITEX_AGENT_CONTAINER_*`` prefix — this allowlist closes the
 # audit-cli ERROR on the legacy surface, not on future regressions.
-env_allowlist = ["SAC_"]
+env_allowlist = ["SAC_", "CODEX_HOME"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/scitex_agent_container"]

--- a/src/scitex_agent_container/_baseline_assets/git_identity_hooks/enforce_commit_author_allowlist.sh
+++ b/src/scitex_agent_container/_baseline_assets/git_identity_hooks/enforce_commit_author_allowlist.sh
@@ -58,6 +58,10 @@
 set -u
 
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Shell-local path; exported to the inline python body below as the
+# namespaced SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH. Writer and reader are
+# both in THIS file, so the contract cannot drift. Unset/empty => no audit
+# log; the block decision itself is unaffected.
 LOG_PATH="$THIS_DIR/.$(basename "$0").log"
 
 # ------------------------------------------------------------------
@@ -196,7 +200,7 @@ printf '%s' "$INPUT" | grep -qF 'hook-bypass: cla-author' && exit 0
 # Main decision. The Python body is captured via a QUOTED heredoc so it
 # may contain arbitrary single/double quotes (the block message + git
 # fix commands need both); it is passed to `python3 -c`. INPUT arrives on
-# stdin, LOG_PATH via the environment.
+# stdin, SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH via the environment.
 # ------------------------------------------------------------------
 PYCODE=$(cat <<'PYEOF'
 import json, sys, re, os, shlex, subprocess, fnmatch
@@ -406,7 +410,7 @@ if not violations:
     sys.exit(0)
 
 # Block + log.
-log_path = os.environ.get("LOG_PATH", "")
+log_path = os.environ.get("SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH", "")
 if log_path:
     try:
         import datetime
@@ -481,7 +485,7 @@ sys.exit(2)
 PYEOF
 )
 
-printf '%s' "$INPUT" | LOG_PATH="$LOG_PATH" python3 -c "$PYCODE"
+printf '%s' "$INPUT" | SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH="$LOG_PATH" python3 -c "$PYCODE"
 exit $?
 
 # EOF

--- a/src/scitex_agent_container/_baseline_assets/heavy_job_hooks/enforce_heavy_job_demotion.sh
+++ b/src/scitex_agent_container/_baseline_assets/heavy_job_hooks/enforce_heavy_job_demotion.sh
@@ -44,6 +44,10 @@
 set -u
 
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Shell-local path; exported to the core below as the namespaced
+# SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH. Wrapper and core deploy as a pair,
+# so both halves of that contract are renamed together — a mismatched
+# deploy degrades to "no audit log", never to a hook that fails to gate.
 LOG_PATH="$THIS_DIR/.$(basename "$0").log"
 CORE="$THIS_DIR/heavy_job_demotion_core.py"
 
@@ -248,7 +252,7 @@ if [[ ! -f "$CORE" ]]; then
     echo "warn(enforce_heavy_job_demotion): core missing at $CORE; fail-open (allowing)." >&2
     exit 0
 fi
-printf '%s' "$INPUT" | LOG_PATH="$LOG_PATH" python3 "$CORE"
+printf '%s' "$INPUT" | SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH="$LOG_PATH" python3 "$CORE"
 exit $?
 
 # EOF

--- a/src/scitex_agent_container/_baseline_assets/heavy_job_hooks/heavy_job_demotion_core.py
+++ b/src/scitex_agent_container/_baseline_assets/heavy_job_hooks/heavy_job_demotion_core.py
@@ -48,7 +48,17 @@ import heavy_job_demotion_policy as policy  # noqa: E402
 
 SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "fish"}
 KEYWORD_SKIP = {
-    "do", "then", "else", "!", "{", "(", ")", "}", "if", "elif", "while",
+    "do",
+    "then",
+    "else",
+    "!",
+    "{",
+    "(",
+    ")",
+    "}",
+    "if",
+    "elif",
+    "while",
     "until",
 }
 KEYWORD_ALLOW_SEG = {"fi", "done", "esac", "for", "case"}
@@ -69,9 +79,23 @@ WRAPPER_VALUE_FLAGS = {
     "stdbuf": {"-i", "-o", "-e"},
     "timeout": {"-k", "--kill-after", "-s", "--signal"},
     "xargs": {
-        "-a", "-d", "-E", "-e", "-I", "-i", "-L", "-l", "-n", "-P", "-s",
-        "--arg-file", "--delimiter", "--max-args", "--max-procs",
-        "--max-chars", "--replace",
+        "-a",
+        "-d",
+        "-E",
+        "-e",
+        "-I",
+        "-i",
+        "-L",
+        "-l",
+        "-n",
+        "-P",
+        "-s",
+        "--arg-file",
+        "--delimiter",
+        "--max-args",
+        "--max-procs",
+        "--max-chars",
+        "--replace",
     },
 }
 _ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
@@ -364,15 +388,17 @@ def _judge_pipeline(s, depth=0):
 
 
 def _log_block(cls, word, cmd):
-    log_path = os.environ.get("LOG_PATH", "")
+    # Contract with the wrapper: `enforce_heavy_job_demotion.sh` sets
+    # SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH on THIS process only. The two ship
+    # and deploy as a pair, so the name is ours end-to-end. Unset/empty =>
+    # no audit log; the block decision itself is unaffected.
+    log_path = os.environ.get("SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH", "")
     if not log_path:
         return
     try:
         import datetime
 
-        ts = datetime.datetime.now(datetime.timezone.utc).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
+        ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         with open(log_path, "a") as fh:
             fh.write(
                 "[%s] BLOCK heavy-job :: class=%s word=%s :: %s\n"

--- a/src/scitex_agent_container/_baseline_assets/hpc_login_hooks/enforce_hpc_login_node_whitelist.sh
+++ b/src/scitex_agent_container/_baseline_assets/hpc_login_hooks/enforce_hpc_login_node_whitelist.sh
@@ -45,6 +45,10 @@
 set -u
 
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Shell-local path; exported to the core below as the namespaced
+# SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH. Wrapper and core deploy as a pair,
+# so both halves of that contract are renamed together — a mismatched
+# deploy degrades to "no audit log", never to a hook that fails to gate.
 LOG_PATH="$THIS_DIR/.$(basename "$0").log"
 CORE="$THIS_DIR/hpc_login_whitelist_core.py"
 
@@ -229,7 +233,7 @@ if [[ ! -f "$CORE" ]]; then
     echo "warn(enforce_hpc_login_node_whitelist): core missing at $CORE; fail-open (allowing)." >&2
     exit 0
 fi
-printf '%s' "$INPUT" | LOG_PATH="$LOG_PATH" python3 "$CORE"
+printf '%s' "$INPUT" | SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH="$LOG_PATH" python3 "$CORE"
 exit $?
 
 # EOF

--- a/src/scitex_agent_container/_baseline_assets/hpc_login_hooks/hpc_login_whitelist_core.py
+++ b/src/scitex_agent_container/_baseline_assets/hpc_login_hooks/hpc_login_whitelist_core.py
@@ -47,7 +47,17 @@ import hpc_login_whitelist_policy as policy  # noqa: E402
 
 SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "fish"}
 KEYWORD_SKIP = {
-    "do", "then", "else", "!", "{", "(", ")", "}", "if", "elif", "while",
+    "do",
+    "then",
+    "else",
+    "!",
+    "{",
+    "(",
+    ")",
+    "}",
+    "if",
+    "elif",
+    "while",
     "until",
 }
 KEYWORD_ALLOW_SEG = {"fi", "done", "esac", "for", "case"}
@@ -65,9 +75,23 @@ WRAPPER_VALUE_FLAGS = {
     "stdbuf": {"-i", "-o", "-e"},
     "timeout": {"-k", "--kill-after", "-s", "--signal"},
     "xargs": {
-        "-a", "-d", "-E", "-e", "-I", "-i", "-L", "-l", "-n", "-P", "-s",
-        "--arg-file", "--delimiter", "--max-args", "--max-procs",
-        "--max-chars", "--replace",
+        "-a",
+        "-d",
+        "-E",
+        "-e",
+        "-I",
+        "-i",
+        "-L",
+        "-l",
+        "-n",
+        "-P",
+        "-s",
+        "--arg-file",
+        "--delimiter",
+        "--max-args",
+        "--max-procs",
+        "--max-chars",
+        "--replace",
     },
 }
 _ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
@@ -325,15 +349,17 @@ def _judge_pipeline(s, depth=0):
 
 
 def _log_block(hostname, cls, word, cmd):
-    log_path = os.environ.get("LOG_PATH", "")
+    # Contract with the wrapper: `enforce_hpc_login_node_whitelist.sh` sets
+    # SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH on THIS process only. The two ship
+    # and deploy as a pair, so the name is ours end-to-end. Unset/empty =>
+    # no audit log; the block decision itself is unaffected.
+    log_path = os.environ.get("SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH", "")
     if not log_path:
         return
     try:
         import datetime
 
-        ts = datetime.datetime.now(datetime.timezone.utc).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
+        ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         with open(log_path, "a") as fh:
             fh.write(
                 "[%s] BLOCK hpc-login :: host=%s class=%s word=%s :: %s\n"
@@ -357,8 +383,7 @@ def main() -> int:
             return 0
     except re.error:
         _warn(
-            "invalid regex in $%s=%r; fail-open (allowing)."
-            % (policy.PAT_ENV, pattern)
+            "invalid regex in $%s=%r; fail-open (allowing)." % (policy.PAT_ENV, pattern)
         )
         return 0
 

--- a/tests/integration/test_hook_audit_log_env_contract.py
+++ b/tests/integration/test_hook_audit_log_env_contract.py
@@ -1,0 +1,243 @@
+"""The hook audit-log env contract — the wrapper writes it, the core reads it.
+
+Every enforcement hook under ``_baseline_assets`` ships as a WRAPPER (``.sh``)
+plus a decision CORE, and the wrapper hands the core its audit-log destination
+through ONE environment variable. Rename one half only and the hook still
+gates correctly — same exit code, same block message — while logging NOWHERE.
+Every other hook test asserts exit codes and stderr text, so not one of them
+can see that: the audit trail just disappears, silently.
+
+That failure mode is why this file exists. On 2026-08-12 the variable was
+renamed from the unnamespaced ``LOG_PATH`` to
+``SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH``, closing a scitex-dev §6a audit-cli
+ERROR ("env var 'LOG_PATH' has no recognized prefix"). Three wrapper/core
+pairs had to move together. These tests pin BOTH halves to the SAME name so a
+later edit cannot drift them apart without going red.
+
+The hooks are COPIED into ``tmp_path`` and run from there. That is how they
+are really deployed (every file of a pair lands in one directory), and it
+makes each wrapper resolve ``$THIS_DIR`` — and therefore its own log file —
+inside the temp dir. So the log assertion needs no repo write and no
+monkeypatching: the real ``.sh`` drives the real core over a real subprocess,
+which is the fleet rule for hook tests.
+
+``LOG_PATH`` remains perfectly fine as a shell-LOCAL variable inside a
+wrapper — it never leaves the process, and §6a governs the env-var surface,
+not shell locals. What it may not be again is the name crossing into the
+child's environment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+LOG_ENV = "SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH"
+
+_ASSETS = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "scitex_agent_container"
+    / "_baseline_assets"
+)
+
+# Env vars that would let the ambient environment decide a hook's verdict.
+# Scrubbed from every invocation so each case controls its own inputs.
+_SCRUB = (
+    "SAC_HPC_LOGIN_ALLOW",
+    "SAC_HPC_LOGIN_NODE_PATTERN",
+    "SAC_HPC_LOGIN_TEST_HOSTNAME",
+    "SAC_HPC_LOGIN_EXTRA_ALLOW",
+    "SAC_HPC_LOGIN_PYC_MAX",
+    "SAC_HEAVY_JOB_ALLOW",
+    "SAC_HEAVY_JOB_GUARD_DISABLE",
+    "SAC_HEAVY_JOB_JOBS_MAX",
+    "SAC_HEAVY_JOB_EXTRA_DENY",
+    LOG_ENV,
+)
+
+# (hook dir, files to deploy, wrapper, blocking command, extra env)
+_PAIRS = (
+    (
+        "hpc_login_hooks",
+        (
+            "enforce_hpc_login_node_whitelist.sh",
+            "hpc_login_whitelist_core.py",
+            "hpc_login_whitelist_policy.py",
+        ),
+        "enforce_hpc_login_node_whitelist.sh",
+        "pytest tests/ -x",
+        {"SAC_HPC_LOGIN_TEST_HOSTNAME": "spartan-login1.hpc.unimelb.edu.au"},
+    ),
+    (
+        "heavy_job_hooks",
+        (
+            "enforce_heavy_job_demotion.sh",
+            "heavy_job_demotion_core.py",
+            "heavy_job_demotion_policy.py",
+        ),
+        "enforce_heavy_job_demotion.sh",
+        "mksquashfs squashfs-root out.squashfs",
+        {},
+    ),
+)
+
+# Every wrapper that hands a log destination to a python child.
+_WRAPPERS = (
+    ("hpc_login_hooks", "enforce_hpc_login_node_whitelist.sh"),
+    ("heavy_job_hooks", "enforce_heavy_job_demotion.sh"),
+    ("git_identity_hooks", "enforce_commit_author_allowlist.sh"),
+)
+
+_GIT_IDENTITY_HOOK = (
+    _ASSETS / "git_identity_hooks" / "enforce_commit_author_allowlist.sh"
+)
+
+
+def _clean_env(extra: dict) -> dict:
+    env = {k: v for k, v in os.environ.items() if k not in _SCRUB}
+    env.update(extra)
+    return env
+
+
+@pytest.fixture(params=_PAIRS, ids=["hpc-login", "heavy-job"])
+def blocked_run(request, tmp_path):
+    """Deploy one hook pair into `tmp_path` and drive it to a BLOCK verdict.
+
+    Returns the completed process plus the log path the WRAPPER chose, so
+    each test below can assert exactly one thing about the outcome.
+    """
+    hook_dir, files, wrapper, command, extra = request.param
+
+    dest = tmp_path / hook_dir
+    dest.mkdir()
+    for name in files:
+        shutil.copy2(_ASSETS / hook_dir / name, dest / name)
+
+    log = dest / f".{wrapper}.log"
+    if log.exists():  # pragma: no cover  -- fresh tmp_path; guard, not a case
+        raise AssertionError(f"log unexpectedly pre-existed at {log}")
+
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": str(tmp_path),
+    }
+    res = subprocess.run(
+        ["bash", str(dest / wrapper)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=_clean_env(extra),
+    )
+    return SimpleNamespace(res=res, log=log, wrapper=wrapper)
+
+
+def test_heavy_command_is_blocked(blocked_run):
+    """Precondition for the log assertions: the hook really did block.
+
+    Without this the next test could pass vacuously in the other direction —
+    no log because nothing was ever blocked.
+    """
+    # Arrange — the fixture deployed the pair and fed it a heavy command.
+    run = blocked_run
+    # Act — the verdict is the process exit code.
+    verdict = run.res.returncode
+    # Assert
+    assert verdict == 2, (
+        f"expected a block (exit 2) from {blocked_run.wrapper}; got "
+        f"{blocked_run.res.returncode}. stderr:\n{blocked_run.res.stderr}"
+    )
+
+
+def test_block_is_recorded_in_the_wrapper_chosen_log_file(blocked_run):
+    """The core writes where the wrapper told it to — the whole contract.
+
+    Falsifiable, and precisely so: rename the variable in the wrapper but not
+    the core (or the reverse) and the hook still exits 2 — the block still
+    works — but this file is never created and this test goes red. That is
+    exactly the half-rename this module guards against.
+    """
+    # Arrange — the fixture blocked a command through the real wrapper.
+    run = blocked_run
+    # Act — ask whether the core wrote where the wrapper pointed it.
+    wrote_the_log = run.log.is_file()
+    # Assert
+    assert wrote_the_log, (
+        f"{blocked_run.wrapper} blocked the command but wrote no audit log "
+        f"at {blocked_run.log}. Wrapper and core disagree about {LOG_ENV}: "
+        f"the hook still gates, but its audit trail is silently gone."
+    )
+
+
+def test_audit_log_names_the_decision(blocked_run):
+    # Arrange
+    log = blocked_run.log
+    # Act
+    written = log.read_text(encoding="utf-8")
+    # Assert
+    assert "BLOCK" in written
+
+
+@pytest.mark.parametrize(("hook_dir", "wrapper"), _WRAPPERS)
+def test_wrapper_exports_the_namespaced_log_var(hook_dir, wrapper):
+    # Arrange
+    text = (_ASSETS / hook_dir / wrapper).read_text(encoding="utf-8")
+    # Act — the env-prefix assignment on the pipe into python.
+    exported = re.search(rf'\|\s*{LOG_ENV}="\$LOG_PATH"\s+python3', text)
+    # Assert
+    assert exported, (
+        f"{wrapper} does not pass {LOG_ENV} to its python child; the child "
+        f"then reads an unset variable and logs nowhere."
+    )
+
+
+@pytest.mark.parametrize(("hook_dir", "wrapper"), _WRAPPERS)
+def test_wrapper_does_not_export_bare_log_path(hook_dir, wrapper):
+    # Arrange
+    text = (_ASSETS / hook_dir / wrapper).read_text(encoding="utf-8")
+    # Act
+    bare = re.search(r'\|\s*LOG_PATH="\$LOG_PATH"\s+python3', text)
+    # Assert
+    assert bare is None, (
+        f"{wrapper} passes the unnamespaced LOG_PATH into the child "
+        f"environment — that re-opens the scitex-dev §6a audit-cli ERROR."
+    )
+
+
+def test_git_identity_inline_python_reads_the_namespaced_var():
+    """This hook's writer and reader both live in ONE file — pin them together.
+
+    `enforce_commit_author_allowlist.sh` carries its decision body as inline
+    python passed to `python3 -c`, so there is no separate core module to
+    drive. The contract is still two-sided, and a one-sided edit here is just
+    as silent, so the reader half is asserted directly.
+    """
+    # Arrange
+    text = _GIT_IDENTITY_HOOK.read_text(encoding="utf-8")
+    # Act
+    reads = re.search(rf'os\.environ\.get\("{LOG_ENV}", ""\)', text)
+    # Assert
+    assert reads, (
+        "the inline-python half no longer reads the log var the surrounding "
+        "shell exports"
+    )
+
+
+def test_git_identity_inline_python_does_not_read_bare_log_path():
+    # Arrange
+    text = _GIT_IDENTITY_HOOK.read_text(encoding="utf-8")
+    # Act
+    reads_bare = 'os.environ.get("LOG_PATH"' in text
+    # Assert
+    assert not reads_bare, (
+        "the inline python still reads the unnamespaced LOG_PATH — the two "
+        "halves of the contract have drifted apart."
+    )


### PR DESCRIPTION
Closes the two pre-existing `[§6a]` CLI-audit ERRORs on `develop`:

```
ERRO: [§6a] env var 'CODEX_HOME' has no recognized prefix — use 'SCITEX_AGENT_CONTAINER_*' or add to allowlist
ERRO: [§6a] env var 'LOG_PATH'   has no recognized prefix — use 'SCITEX_AGENT_CONTAINER_*' or add to allowlist
```

They look alike and are not, and the difference decides the fix.

## `LOG_PATH` → renamed (it is ours)

Three enforcement hooks ship as a **wrapper** (`.sh`) plus a **decision core**, and the wrapper hands the core its audit-log destination through this one variable. Both halves live in this repo, in the same shipped pair; nothing outside reads the name. So it is genuinely renamed — writer and reader **together** — to `SCITEX_AGENT_CONTAINER_HOOK_LOG_PATH`:

| pair | writer | reader |
|---|---|---|
| hpc-login | `enforce_hpc_login_node_whitelist.sh` | `hpc_login_whitelist_core.py` |
| heavy-job | `enforce_heavy_job_demotion.sh` | `heavy_job_demotion_core.py` |
| git-identity | `enforce_commit_author_allowlist.sh` | same file (inline `python3 -c` body) |

The shell-**local** `LOG_PATH="$THIS_DIR/…"` is unchanged: it never leaves the process, and §6a governs the env-var surface, not shell locals. What changed is the name crossing into the child's environment.

`_DEFAULT_LOG_PATH` (`_account/quota_watch.py`) and `_AUDIT_LOG_PATH` (`_listen/_host_exec.py`) are deliberately **untouched**. They are private Python identifiers, and the auditor's regex only matches `os.environ` / `os.getenv` string literals — measured, not assumed: with the allowlist forced empty the scan lists 37 findings and neither appears.

## `CODEX_HOME` → allowlisted (it is theirs)

It is **OpenAI Codex's own variable** — the way Codex publishes where its `auth.json` lives — and `_account/codex_account.py:_auth_path()` reads it to find the login Codex actually wrote. Renaming it would not move a name into our namespace; it would simply stop reading Codex's login, and do so *silently*, in the credential path hardest to test.

So it takes the audit's other sanctioned exit — `[tool.scitex_dev] env_allowlist` in `pyproject.toml`, where the `SAC_` brand-compat entry already lives — listed by **exact name** (no trailing underscore) so it grants exactly one variable and opens no `CODEX_*` namespace. The comment states *why* it is exempt: an allowlist entry with no stated reason is indistinguishable from someone silencing a warning. Our own override beside it, `SCITEX_GENAI_CODEX_HOMES`, is already canonically prefixed and is untouched.

## New test — the half-rename is worse than the error it fixes

Rename one half only and the hook **still gates correctly** (same exit code, same block message) while logging **nowhere**. No existing test could see that: they assert exit codes and stderr, never the log file.

`tests/integration/test_hook_audit_log_env_contract.py` pins both halves. It copies each pair into `tmp_path` (which is how they really deploy — one directory — and which makes the wrapper resolve `$THIS_DIR`, and its log, inside the temp dir), drives a real block through the real `.sh` over a real subprocess, and asserts the core wrote where the wrapper pointed it. No repo writes, no mocks, no patches.

Confirmed falsifiable outside the repo: reverting **only** the core to `LOG_PATH` leaves the hook exiting 2 with **no log file written** — i.e. the test goes red on exactly the failure it exists to catch.

## Verification

| check | result |
|---|---|
| `audit-all` summary | `scitex-agent-container: 0 unmasked error(s) (+3 warning/info finding(s)), 0 masked by skip-rules (0 declared); 17 line(s) inspected` |
| `tests/develop/test_audit.py` | `2 passed in 140.54s`, exit 0 |
| new contract test | `14 passed in 3.50s`, exit 0 |
| all hook suites (pre-existing) | `211 passed in 272.14s`, exit 0 |

### One measurement worth flagging to reviewers

**On a dev container the local audit cannot see a worktree fix**, and it fails in a way that looks like the fix did not work. `_scan_env_vars` (scitex_dev `_cli/audit/_summary/_audit.py:1187`) scans `importlib.metadata.distribution(pkg).files` — the **installed** distribution — and ignores the `--path` tree entirely; the allowlist is read via `_audited_repo_root`, which falls back to the ecosystem registry's `local_path`. On this container that resolves to the frozen non-editable install (`/opt/venv-sac/…`, v0.24.25, built 2026-07-20 from `/opt/scitex-agent-container-src`) plus the **main** checkout's `pyproject.toml`.

So `pytest tests/develop/test_audit.py` run plainly here still reports the original `2 unmasked error(s)` — it is grading the installed copy, not this branch. The numbers above were measured with the installed distribution pointed at **this worktree** (a dist-info shim whose `RECORD` locates through a symlink into `src/`, verified to resolve import, `files`, repo root and allowlist to the worktree before use).

**This does not affect CI**, where the checkout *is* the installed tree — that is precisely the condition the shim reproduces. Raising it only so a reviewer who re-runs the command locally is not misled by a red that belongs to the container, not the branch.
