### PR TITLE
chore(gitignore): ignore the .old/ move-aside trashbin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ src/scitex_agent_container/_provenance/_build_info.py
 # this keeps it that way. (Two workers hit this independently, from different
 # artifacts, within a day — which is the argument for the ignore, not against.)
 tests/results/
+
+# The fleet-wide move-aside trashbin. Nothing is ever deleted in this fleet;
+# displaced files land in .old/<timestamp>/ and must never be committed back.
+.old/


### PR DESCRIPTION
The fleet never deletes — displaced files go to `.old/<timestamp>/`. But `.old/` was not ignored, so every correct displacement counted as untracked work.

That blocked a real operation. `sac agents relocate --dry-run` refuses on `source_work_committed`, which counts untracked files, so this repo's own agent could not relocate. Measured today: 7 untracked entries, one of them `.old/branch-bundle-20260809/` (38 MB) — a deliberate backup doing exactly what the convention asks.

Safe: gitignore never untracks, and `git log --all -- .old` is empty here.

Sibling PRs added the same rule to scitex-dev, scitex-hpc and figrecipe in the same sweep.