### PR TITLE
fix(to_home): SCITEX_CARDS_DB is store IDENTITY — the launching shell must not decide which database an agent writes to

### DIFF
--- a/src/scitex_agent_container/runtimes/_to_home_text.py
+++ b/src/scitex_agent_container/runtimes/_to_home_text.py
@@ -83,6 +83,80 @@ _LEGACY_IDENTITY_VARS = frozenset(
     }
 )
 
+# STORE IDENTITY — the scitex-cards entries below, and WHY a name is being
+# ADDED to a list the paragraph above says is shrinking.
+#
+# WHY (INCIDENT 2026-08-12, card
+# sac-cards-db-store-identity-not-baked-20260812): this is the 2026-07-02
+# incident again, one variable over. An agent's own container shell and the
+# scitex-cards MCP server it talks to disagreed about which database they
+# were using — the container env and the agent's ``spec.yaml`` both said
+# ``postgresql://scitex_cards@127.0.0.1:55432/scitex_cards`` while the MCP
+# server had ``...:5442``. The agent WROTE cards to one postgres database and
+# READ them from another; three databases ended up holding fragments of one
+# board under a single ``store_uuid``.
+#
+# MECHANISM: the operator-authored shared template
+# ``agents/_shared/to_home/.mcp.json`` carries
+# ``"SCITEX_CARDS_DB": "${SCITEX_CARDS_DB}"``, and ``interpolate_env`` runs
+# HOST-SIDE inside ``sac agents start`` — so it substituted from the
+# LAUNCHING SHELL's environ. The operator's ``~/.bashrc`` exports
+# ``SCITEX_CARDS_DB=...:5442``, so starting an agent from that shell baked the
+# literal ``:5442`` into the materialized ``runtime/<agent>/home/.mcp.json``.
+# Claude Code spreads a server entry's ``env`` block LAST over the inherited
+# process env (see :mod:`._mcp_spec_env`), so the baked value WON inside the
+# MCP server even though the container env said ``:55432``.
+#
+# The measured tell was a clean natural experiment: of 19 materialized
+# ``.mcp.json`` files under ``runtime/``, 18 still held the literal
+# ``${SCITEX_CARDS_DB}`` (those agents were started from shells that did not
+# export it, so the ``os.environ.get(name, m.group(0))`` default kept the ref
+# intact) and exactly ONE held a hardcoded DSN — the agent that happened to be
+# started from the operator's interactive shell. Restated as the invariant it
+# violates: WHICHEVER SHELL THE OPERATOR HAPPENED TO TYPE ``sac agents start``
+# IN SILENTLY DECIDED WHICH DATABASE THAT AGENT'S MCP SERVER WROTE TO, AND A
+# RESTART FROM A DIFFERENT SHELL SILENTLY MOVED THE AGENT TO A DIFFERENT
+# STORE. A store target is per-agent IDENTITY in exactly the sense the module
+# header means it, so it must come from the agent's OWN runtime env.
+#
+# ``SCITEX_CARDS_STORE_UUID`` is included for the same reason and is if
+# anything sharper: scitex-cards reads it ONLY from the environment — never
+# from the database, never derived from a path, deliberately, so the
+# store-identity check cannot go circular — and it is the pin that decides
+# that check's ACCEPT / ADOPT / REFUSE verdict. A host-baked pin would let a
+# launching shell silently declare which store an agent considers legitimate,
+# turning a wrong-store launch into an *authorized* one.
+#
+# WHY NAME-BASED AND NOT ``${RUNTIME:VAR}``: the syntax-based escape is the
+# preferred mechanism and would be the right home for these, but it is the
+# TEMPLATE AUTHOR's to apply, and the scitex-cards ``.mcp.json`` template has
+# NOT migrated — it still writes a plain ``${SCITEX_CARDS_DB}``. Until it
+# does, this deprecated name-based fallback is the ONLY mechanism that can
+# protect the ref, which is precisely the "kept running IN PARALLEL ... until
+# downstream packages have migrated their OWN templates" case the paragraph
+# above describes. Adding here is therefore consistent with that paragraph,
+# not a reversal of it: the list shrinks by MIGRATION, not by leaving a known
+# live identity var unprotected.
+#
+# REMOVAL CONDITION: delete these two entries once the scitex-cards-authored
+# template references ``${RUNTIME:SCITEX_CARDS_DB}`` (and
+# ``${RUNTIME:SCITEX_CARDS_STORE_UUID}`` if it ever references the pin) —
+# same bar as the scitex-todo / claude-code-telegrammer entries above, and not
+# one moment sooner, since removing them first re-bakes the DSN.
+#
+# NOT in :data:`_LEGACY_IDENTITY_VARS`, deliberately: that subset is what the
+# ``.env`` fold in :mod:`._envrc` DROPS. ``SCITEX_CARDS_DB`` must REMAIN in
+# the container's ``--env-file`` — it is the value the materialized
+# ``.mcp.json``'s surviving ``${SCITEX_CARDS_DB}`` ref expands FROM at
+# runtime. Dropping it there would leave the ref unexpanded and take the
+# agent's store away entirely.
+_CARDS_STORE_IDENTITY_VARS = frozenset(
+    {
+        "SCITEX_CARDS_DB",
+        "SCITEX_CARDS_STORE_UUID",
+    }
+)
+
 _RUNTIME_ONLY_VARS = (
     frozenset(
         {
@@ -94,6 +168,9 @@ _RUNTIME_ONLY_VARS = (
             "CLAUDE_AGENT_ROLE",
         }
     )
+    # scitex-cards store identity (INCIDENT 2026-08-12) — see the comment on
+    # :data:`_CARDS_STORE_IDENTITY_VARS` above.
+    | _CARDS_STORE_IDENTITY_VARS
     # Legacy pre-0.7.30 names — kept as a GUARD only (never injected by sac
     # anymore): a stale deployer shell exporting the old names must still not
     # bake them into materialized files.

--- a/tests/scitex_agent_container/runtimes/test__to_home_text.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_text.py
@@ -130,6 +130,107 @@ def test_interpolate_env_runtime_escape_works_for_hardcoded_name_too(
     assert out == "agent=${SCITEX_TODO_AGENT_ID}"
 
 
+# interpolate_env — scitex-cards STORE IDENTITY stays literal (INCIDENT
+# 2026-08-12, card sac-cards-db-store-identity-not-baked-20260812). The
+# operator's shared to_home/.mcp.json template writes a plain
+# ``"SCITEX_CARDS_DB": "${SCITEX_CARDS_DB}"``, and ``interpolate_env`` runs
+# host-side inside ``sac agents start`` — so a launching shell that exported
+# the var baked its DSN into the materialized file, and Claude Code's MCP
+# ``env`` block (spread LAST over inherited env) made that baked value win
+# inside the server. The agent then wrote cards to one postgres database and
+# read them from another.
+def test_interpolate_env_keeps_cards_db_literal_even_when_set(env_save_restore):
+    # Arrange: the launching shell exports the operator's own DSN.
+    env_save_restore.set(
+        "SCITEX_CARDS_DB", "postgresql://scitex_cards@127.0.0.1:5442/scitex_cards"
+    )
+    # Act
+    out = interpolate_env("db=${SCITEX_CARDS_DB}")
+    # Assert: survives as a literal ref for runtime expansion from the
+    # container's OWN env.
+    assert out == "db=${SCITEX_CARDS_DB}"
+
+
+def test_interpolate_env_keeps_cards_store_uuid_literal_even_when_set(
+    env_save_restore,
+):
+    # The store-identity PIN: scitex-cards reads it ONLY from env (never from
+    # the DB, never from a path) and it decides the ACCEPT/ADOPT/REFUSE
+    # verdict, so a host-baked pin would let the launching shell declare which
+    # store the agent considers legitimate.
+    # Arrange
+    env_save_restore.set("SCITEX_CARDS_STORE_UUID", "deploy-shell-uuid")
+    # Act
+    out = interpolate_env("pin=${SCITEX_CARDS_STORE_UUID}")
+    # Assert
+    assert out == "pin=${SCITEX_CARDS_STORE_UUID}"
+
+
+#: The real ``SCITEX_CARDS_DB`` line from the operator-authored shared
+#: template ``agents/_shared/to_home/.mcp.json`` (line 16), verbatim.
+_CARDS_DB_TEMPLATE_LINE = '"SCITEX_CARDS_DB": "${SCITEX_CARDS_DB}",'
+
+#: The two DSNs that were live during the incident: the operator's
+#: interactive-shell export (``~/.bashrc``) and the agent's own container env.
+_SHELL_A_DSN = "postgresql://scitex_cards@127.0.0.1:5442/scitex_cards"
+_SHELL_B_DSN = "postgresql://scitex_cards@127.0.0.1:55432/scitex_cards"
+
+
+def _materialize_from_shell(env_save_restore, dsn: str) -> str:
+    """Interpolate the real template line as if launched from a shell
+    exporting ``dsn`` — i.e. one ``sac agents start`` invocation."""
+    env_save_restore.set("SCITEX_CARDS_DB", dsn)
+    return interpolate_env(_CARDS_DB_TEMPLATE_LINE)
+
+
+def test_interpolate_env_cards_db_materializes_identically_from_two_shells(
+    env_save_restore,
+):
+    # THE INVARIANT THE INCIDENT BROKE: whichever shell the operator happened
+    # to type `sac agents start` in silently decided which database that
+    # agent's MCP server wrote to, and a restart from a different shell
+    # silently moved the agent to a different store. Interpolating the SAME
+    # template under TWO different launching-shell environments must therefore
+    # produce the SAME materialized output. Before the fix this produced two
+    # different databases, silently.
+    # Arrange: shell A is the operator's ~/.bashrc export.
+    out_shell_a = _materialize_from_shell(env_save_restore, _SHELL_A_DSN)
+    # Act: the same template, materialized again from shell B.
+    out_shell_b = _materialize_from_shell(env_save_restore, _SHELL_B_DSN)
+    # Assert: the launching shell has no say at all.
+    assert out_shell_a == out_shell_b
+
+
+def test_interpolate_env_cards_db_materialized_output_leaks_no_shell_dsn(
+    env_save_restore,
+):
+    # The companion fact: the two outputs agree because the ref stays LITERAL,
+    # not because both collapsed to some other shared value. Equality with the
+    # untouched template line is what proves no DSN was baked in.
+    # Arrange: the launching shell exports the operator's own DSN.
+    env_save_restore.set("SCITEX_CARDS_DB", _SHELL_A_DSN)
+    # Act
+    out_shell_a = interpolate_env(_CARDS_DB_TEMPLATE_LINE)
+    # Assert
+    assert out_shell_a == _CARDS_DB_TEMPLATE_LINE
+
+
+def test_interpolate_env_runtime_escape_collapses_cards_db_to_plain_literal(
+    env_save_restore,
+):
+    # The migration target: once the scitex-cards-authored template writes
+    # ${RUNTIME:SCITEX_CARDS_DB}, the syntax mechanism alone must protect it —
+    # which is the condition for removing the name-based entry.
+    # Arrange
+    env_save_restore.set(
+        "SCITEX_CARDS_DB", "postgresql://scitex_cards@127.0.0.1:5442/scitex_cards"
+    )
+    # Act
+    out = interpolate_env("db=${RUNTIME:SCITEX_CARDS_DB}")
+    # Assert
+    assert out == "db=${SCITEX_CARDS_DB}"
+
+
 def test_interpolate_env_plain_var_form_unaffected_by_escape_marker_support(
     env_save_restore,
 ):


### PR DESCRIPTION
## The measured defect

An agent's MCP server and its own container shell disagreed about which card
database they were using:

| where | value |
| --- | --- |
| container shell + the agent's `spec.yaml` | `postgresql://scitex_cards@127.0.0.1:55432/scitex_cards` |
| the scitex-cards MCP server it actually talks to | `postgresql://scitex_cards@127.0.0.1:5442/scitex_cards` |

The agent therefore **wrote cards to one postgres database and read them from
another**. Three databases now hold fragments of one board under a single
`store_uuid`.

## Mechanism

`interpolate_env` in `runtimes/_to_home_text.py` substitutes `${VAR}` from
`os.environ` — and it runs **host-side inside the `sac agents start`
process**, so it substitutes from the **launching shell's** environment, not
the agent's.

1. The operator-authored shared template
   `agents/_shared/to_home/.mcp.json:16` carries a plain
   `"SCITEX_CARDS_DB": "${SCITEX_CARDS_DB}"`.
2. The operator's `~/.bashrc:124` exports
   `SCITEX_CARDS_DB=postgresql://scitex_cards@127.0.0.1:5442/scitex_cards`.
3. Starting an agent from that shell baked the literal `:5442` into the
   materialized `runtime/<agent>/home/.mcp.json`.
4. Claude Code spreads a server entry's `env` block **last** over the
   inherited process env (the same property `_mcp_spec_env` documents), so the
   baked value **won** inside the MCP server even though the container env
   said `:55432`.

**Whichever shell the operator happened to type `sac agents start` in silently
decided which database that agent's MCP server wrote to, and a restart from a
different shell silently moved the agent to a different store.**

### The tell was a clean natural experiment

Of the 19 materialized `.mcp.json` files under `runtime/`, **18 still hold the
literal `${SCITEX_CARDS_DB}`** — those agents were started from shells that did
not export the var, so `os.environ.get(name, m.group(0))` left the ref intact —
and **exactly one holds a hardcoded DSN**: the agent that happened to be
started from the operator's interactive shell.

Measured directly against the pre-fix module:

```
shell A -> "SCITEX_CARDS_DB": "postgresql://scitex_cards@127.0.0.1:5442/scitex_cards",
shell B -> "SCITEX_CARDS_DB": "postgresql://scitex_cards@127.0.0.1:55432/scitex_cards",
AGREE: False
```

## The fix

`SCITEX_CARDS_DB` is store **identity**. `_to_home_text.py` already carries
exactly the right doctrine for identity vars — see the long comment on
`_RUNTIME_ONLY_VARS` recording the 2026-07-02 wrong-identity incident: per-agent
identity must come from the agent's **own** runtime env, never from the
directory `sac agents start` was typed in. `SCITEX_CARDS_DB` was simply never
added to that set. This adds it, so the ref survives as a literal
`${SCITEX_CARDS_DB}` in the materialized file and is expanded at runtime from
the container's own environment.

`SCITEX_CARDS_STORE_UUID` is added for the same reason and is if anything
sharper: scitex-cards reads it **only** from the environment (never from the
database, never derived from a path — deliberately, so the store-identity check
cannot go circular), and it is the pin that decides that check's
`ACCEPT`/`ADOPT`/`REFUSE` verdict. A host-baked pin would let a launching shell
silently declare which store an agent considers legitimate, turning a
wrong-store launch into an *authorized* one.

### Why a name is being ADDED to a list that is otherwise shrinking

The module states the NAME-based list is deprecated in favour of the
syntax-based `${RUNTIME:VAR}` escape, and that entries must not be deleted
"until downstream packages have migrated their OWN templates". The
scitex-cards `.mcp.json` template has **not** migrated — it still writes a
plain `${SCITEX_CARDS_DB}` — so the name-based fallback is currently the only
mechanism that can protect the ref. Adding here is therefore the
"kept running IN PARALLEL" case that paragraph describes, not a reversal of it:
the list shrinks by **migration**, not by leaving a known live identity var
unprotected. The code comment records the incident, this reasoning, and the
removal condition (delete once the scitex-cards-authored template references
`${RUNTIME:SCITEX_CARDS_DB}`).

The entries deliberately go in `_RUNTIME_ONLY_VARS` and **not**
`_LEGACY_IDENTITY_VARS`: the latter is what the `.env` fold in `_envrc` drops,
and `SCITEX_CARDS_DB` must **remain** in the container's `--env-file` — it is
the value the surviving `${SCITEX_CARDS_DB}` ref expands *from* at runtime.

## Tests

Added to the existing `tests/.../test__to_home_text.py`, following its
established pattern and `env_save_restore` fixture (no mocks):

- the same template text interpolated under **two different launching-shell
  environments** (`:5442` vs `:55432`) must produce the **same** materialized
  output — the "a restart must not silently move an agent to a different store"
  property. Pre-fix this produced two different databases, silently.
- the companion fact that the outputs agree because the ref stays **literal**
  (equality with the untouched template line), not because both collapsed to
  some other shared value.
- `SCITEX_CARDS_DB` and `SCITEX_CARDS_STORE_UUID` each stay literal when set.
- the `${RUNTIME:SCITEX_CARDS_DB}` escape still collapses to
  `${SCITEX_CARDS_DB}` — the migration target that would let the name-based
  entry be removed.

## Verification

Target file, this branch:

```
15 passed in 0.12s
```
(exit 0; rootdir confirmed as this worktree, `configfile: pyproject.toml`)

Full `tests/scitex_agent_container/runtimes/` directory, run **twice** — once
on this branch and once with the worktree detached at the pre-fix parent commit
`a2cf999` — as a like-for-like control:

| | result |
| --- | --- |
| pre-fix (`a2cf999`) | `3 failed, 1770 passed, 20 skipped, 19 errors in 100.03s` |
| this branch | `3 failed, 1775 passed, 20 skipped, 19 errors in 141.34s` |

Identical failure and error counts, identical test names; the delta is exactly
the **+5 new passing tests**. The 22 pre-existing failures are one root cause
unrelated to this change: `build_sdk_options` / `bake_spec_env_into_servers`
read the **live** `os.environ`, whose `SAC_SPEC_ENV_KEYS` manifest (set by sac
for the agent running the suite) names `SCITEX_AGENT_CONTAINER_AGENT`, which
the tests' env fixtures do not carry — so `resolve_spec_env` raises
`SpecEnvUnresolvedError`. Reproduced on completely unmodified code in a
separate worktree (`test__mcp_spec_env.py` alone: 1 failed, 15 passed). Filed
as `sac-mcp-spec-env-tests-ambient-env-sensitive-20260812`; not fixed here.

## Operator follow-up (not done here — live config is out of scope)

The already-materialized `runtime/scitex-agent-container/home/.mcp.json` still
holds the baked `:5442` DSN; this change stops it being *re*-baked but does not
rewrite what is already on disk. Nothing under `~/.scitex/` was touched. The
durable follow-up is for scitex-cards to author its template with
`${RUNTIME:SCITEX_CARDS_DB}`, which would make this PR's name-based entry
removable.
