### PR TITLE
fix(relocate): measure the source at the instant you read it, and name the session

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_relocate_checks.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_checks.py
@@ -43,6 +43,8 @@ from __future__ import annotations
 from typing import Final
 
 from ._relocate_preflight_facts import Check, SourceFacts, TargetFacts
+from ._relocate_session_choice import CODE_UNKNOWN as SESSION_UNKNOWN
+from ._relocate_session_choice import choose_session
 
 __all__ = [
     "CHECK_BINDS",
@@ -55,6 +57,7 @@ __all__ = [
     "CHECK_RUNTIME",
     "CHECK_SAC_PRESENT",
     "CHECK_SCHEMA",
+    "CHECK_SESSION",
     "CHECK_SOURCE_WORK",
     "check_binds",
     "check_card_store",
@@ -66,6 +69,7 @@ __all__ = [
     "check_runtime",
     "check_sac_present",
     "check_schema",
+    "check_session_resolvable",
     "check_source_work",
 ]
 
@@ -80,6 +84,7 @@ CHECK_PORTS: Final = "ports_free"
 CHECK_HUB_FROM_TARGET: Final = "hub_reachable_from_target"
 CHECK_SAC_PRESENT: Final = "sac_present_on_target"
 CHECK_SOURCE_WORK: Final = "source_work_committed"
+CHECK_SESSION: Final = "session_resolvable"
 
 
 def _unobserved(name: str, what: str) -> Check:
@@ -321,6 +326,55 @@ def check_sac_present(facts: TargetFacts, to_host: str) -> Check:
             f"absolute path. The evidence: ssh {to_host} 'command -v sac' printed "
             f"nothing while {facts.sac_resolved_path} exists there"
         ),
+    )
+
+
+def check_session_resolvable(source: SourceFacts, agent: str) -> Check:
+    """Can the conversation to resume be NAMED, before anything is stopped?
+
+    This check exists because the answer used to be discovered three phases too
+    late. TARGET_STANDBY refuses without a session id, and TARGET_STANDBY runs
+    after SOURCE_STOP — so an agent whose session could not be identified was
+    taken down, had its transcript copied and verified, and then aborted with the
+    marker unwritten and nothing running anywhere.
+
+    Measured 2026-08-12 on ywata-note-win: ten agents, every one holding between
+    two and five transcripts, every one reporting ``GO — every check passed``, and
+    not one of them able to complete. The guard was ``len(files) == 1``. A check
+    that passes on ten agents that cannot proceed is not a check; the gap is as
+    much the bug as the guard was.
+    """
+    if source.transcripts is None:
+        return Check(
+            name=CHECK_SESSION,
+            ok=None,
+            detail=f"the transcripts for {agent} on the source were not listed",
+            hint=(
+                "list the source's project directory before deciding. Which session "
+                "travels is settled here or it is settled after the agent has been "
+                "stopped, and only one of those is recoverable without an operator"
+            ),
+        )
+    choice = choose_session(
+        agent=agent,
+        carried=[name for name, _ in source.transcripts],
+        marker=source.session_marker,
+        mtimes=dict(source.transcripts),
+    )
+    if choice.session is not None:
+        return Check(
+            name=CHECK_SESSION,
+            ok=True,
+            detail=(
+                f"session {choice.session} would travel, chosen by {choice.chosen_by} "
+                f"from {len(choice.candidates)} candidate(s)"
+            ),
+        )
+    return Check(
+        name=CHECK_SESSION,
+        ok=None if choice.code == SESSION_UNKNOWN else False,
+        detail=f"{choice.reason} ({choice.code})",
+        hint=choice.hint,
     )
 
 

--- a/src/scitex_agent_container/_lifecycle/_relocate_effects.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_effects.py
@@ -48,27 +48,24 @@ from ._relocate_effects_handover import HandoverEffects
 from ._relocate_effects_handshake import HandshakeEffects
 from ._relocate_effects_source import SourceEffects
 from ._relocate_effects_standby import StandbyEffects
+from ._relocate_effects_transport import TransportEffects
 from ._relocate_execute import PhaseEffects, StepResult
 from ._relocate_liveness import observe_running
 from ._relocate_move_aside import move_aside_destination
-from ._relocate_shell import Shell, resolved_path, shell_for
-from ._relocate_transcript_home import transcript_home_from_spec
-from ._relocate_transport import TranscriptFile, plan_transport, verify_arrival
-from ._relocate_transport_paths import derive_target_dir
-from ._relocate_transport_ssh import (
-    copy_transcripts,
-    ensure_dir,
-    list_transcript_dir,
-    measure_transcripts,
-    move_dir_aside,
-)
+from ._relocate_shell import Shell, shell_for
+from ._relocate_transport import TranscriptFile
+from ._relocate_transport_ssh import move_dir_aside
 
 __all__ = ["RelocateAdapters", "adapters_for", "build_effects"]
 
 
 @dataclass
 class RelocateAdapters(
-    SourceEffects, StandbyEffects, HandshakeEffects, HandoverEffects
+    SourceEffects,
+    TransportEffects,
+    StandbyEffects,
+    HandshakeEffects,
+    HandoverEffects,
 ):
     """One relocation's worth of hosts, paths and RECORDED CONFIRMATIONS.
 
@@ -87,6 +84,10 @@ class RelocateAdapters(
     stamp: str
     exec_fn: Callable[..., dict] | None = None
     now: Callable[[], float] = time.time
+    #: Injected for the same reason as ``now``: SOURCE_STOP spends real
+    #: wall-clock time waiting for the transcript to go quiescent, and a test
+    #: that had to spend it too would either be slow or would not be written.
+    sleep: Callable[[float], None] = time.sleep
     peers: object = None
 
     #: The source-side ``spec.yaml`` this agent is defined by. Carried to the
@@ -112,181 +113,11 @@ class RelocateAdapters(
     lease_fence: int | None = None
     log: list[str] = field(default_factory=list)
 
-    # -- transport ---------------------------------------------------------
-
-    def _resolve_dirs(self) -> tuple[str | None, str | None, str]:
-        """Source and target transcript directories, or ``(None, None, why)``.
-
-        The target's directory name is RECOMPUTED from the target's own resolved
-        workdir rather than copied from the source's — see
-        :mod:`_relocate_transport_paths`. A mismatch is normal and is logged, not
-        refused: it is the whole reason the name is derived instead of reused.
-        """
-        home = transcript_home_from_spec(self.spec)
-        if home.path is None:
-            return None, None, f"{home.reason} — {home.hint}"
-
-        body = (
-            self.spec.get("spec")
-            if isinstance(self.spec.get("spec"), dict)
-            else self.spec
-        )
-        workdir = str((body or {}).get("workdir") or "").strip()
-        if not workdir:
-            return (
-                None,
-                None,
-                "the spec declares no workdir, so no project directory can be encoded",
-            )
-
-        src_resolved = resolved_path(self.source, workdir, exec_fn=self.exec_fn)
-        tgt_resolved = resolved_path(self.target, workdir, exec_fn=self.exec_fn)
-        if not src_resolved:
-            return (
-                None,
-                None,
-                f"the SOURCE's resolved workdir for {workdir} was not observed",
-            )
-
-        src = derive_target_dir(
-            target_home=home.path, target_resolved_workdir=src_resolved
-        )
-        tgt = derive_target_dir(
-            target_home=home.path,
-            target_resolved_workdir=tgt_resolved,
-            source_dir_name=src.encoded,
-        )
-        if tgt.path is None:
-            return None, None, f"{tgt.reason} — {tgt.hint}"
-        if tgt.matches_source is False:
-            self.log.append(f"transport: {tgt.reason}")
-        return src.path, tgt.path, tgt.reason
-
-    def transport(self) -> StepResult:
-        """Copy the transcript across and CONFIRM it on the target, per file.
-
-        List the source, let :func:`plan_transport` decide what may travel, move
-        aside anything already at the destination, measure the source, copy, then
-        measure THE TARGET and compare. The measurement after the copy is the
-        only statement this step makes about success.
-        """
-        source_dir, target_dir, why = self._resolve_dirs()
-        if source_dir is None or target_dir is None:
-            return StepResult(
-                ok=None,
-                detail=f"the transcript directories could not be derived: {why}",
-                hint=(
-                    "measure the target's resolved workdir and check the spec's bind for "
-                    "the container home. A transcript under the wrong directory name is "
-                    "present, intact and invisible to the runner"
-                ),
-            )
-        self.source_dir, self.target_dir = source_dir, target_dir
-
-        listing = list_transcript_dir(self.source, source_dir, exec_fn=self.exec_fn)
-        running, _ = observe_running(self.source, self.agent, exec_fn=self.exec_fn)
-        target_listing = list_transcript_dir(
-            self.target, target_dir, exec_fn=self.exec_fn
-        )
-
-        plan = plan_transport(
-            source_running=running,
-            source_files=None if listing is None else list(listing),
-            target_dir_exists=None if target_listing is None else bool(target_listing),
-            target_dir=target_dir,
-            stamp=self.stamp,
-        )
-        for name, reason in plan.refused:
-            self.log.append(f"transport: REFUSED {name} — {reason}")
-        if plan.proceed is not True:
-            return StepResult(
-                ok=False if plan.proceed is False else None,
-                detail=f"transport refused ({plan.code}): {plan.reason}",
-                hint=plan.hint,
-            )
-        self.carried = plan.files
-
-        if plan.move_aside is not None and plan.move_aside.required:
-            moved = move_dir_aside(
-                self.target,
-                target_dir,
-                plan.move_aside.destination or "",
-                exec_fn=self.exec_fn,
-            )
-            if moved is not True:
-                return StepResult(
-                    ok=None if moved is None else False,
-                    detail=(
-                        f"{self.to_host} already holds {target_dir} and it could not be "
-                        f"moved aside to {plan.move_aside.destination}"
-                    ),
-                    hint=(
-                        "move it aside by hand and re-run. Nothing is overwritten and "
-                        "nothing is deleted — what is there may be the only copy of an "
-                        "earlier conversation"
-                    ),
-                )
-            self.log.append(
-                f"transport: moved {self.to_host}:{target_dir} aside to {plan.move_aside.destination}"
-            )
-
-        made = ensure_dir(self.target, target_dir, exec_fn=self.exec_fn)
-        if made is not True:
-            return StepResult(
-                ok=None if made is None else False,
-                detail=f"the destination {target_dir} on {self.to_host} could not be created",
-                hint="check write permission on the target's transcript root, then re-run",
-            )
-
-        self.sent = measure_transcripts(
-            self.source, source_dir, plan.files, exec_fn=self.exec_fn
-        )
-        run = copy_transcripts(
-            source=self.source,
-            source_dir=source_dir,
-            target=self.target,
-            target_dir=target_dir,
-            files=plan.files,
-            exec_fn=self.exec_fn,
-            peers=self.peers,
-        )
-        self.log.append(
-            f"transport: copy pipeline exit {run.exit_code} — EVIDENCE ONLY; arrival is "
-            "decided by counting on the target"
-        )
-        if run.stderr.strip():
-            self.log.append(f"transport: copy stderr {run.stderr.strip()[:300]}")
-        self.landed = measure_transcripts(
-            self.target, target_dir, plan.files, exec_fn=self.exec_fn
-        )
-        verdict = verify_arrival(sent=self.sent, landed=self.landed)
-        self.arrival_confirmed = verdict.arrived
-        for line in verdict.mismatches:
-            self.log.append(f"transport: MISMATCH {line}")
-        for f in self.landed:
-            self.log.append(
-                f"transport: target holds {f.name} {f.byte_count} bytes / {f.line_count} lines"
-            )
-        if verdict.arrived is not True:
-            return StepResult(
-                ok=False if verdict.arrived is False else None,
-                detail=f"arrival not confirmed ({verdict.code}): {verdict.reason}",
-                hint=verdict.hint,
-            )
-        if len(plan.files) == 1:
-            self.session_uuid = plan.files[0].rsplit(".", 1)[0]
-        return StepResult(
-            ok=True,
-            detail=(
-                f"{verdict.reason}; {self.from_host}:{source_dir} -> {self.to_host}:{target_dir}"
-            ),
-        )
-
-    # -- target ------------------------------------------------------------
+    # -- the phases ---------------------------------------------------------
     #
-    # TARGET_STANDBY, HANDSHAKE and HANDOVER live in their own modules
-    # (_relocate_effects_standby / _handshake / _handover) and arrive here as
-    # mixins, exactly as the source-side pair does. Each is one phase's worth of
+    # TRANSPORT, TARGET_STANDBY, HANDSHAKE and HANDOVER live in their own modules
+    # (_relocate_effects_transport / _standby / _handshake / _handover) and arrive
+    # here as mixins, exactly as the source-side pair does. Each is one phase's worth of
     # decisions and each was a named refusal until it was built; keeping them
     # apart means a reader looking for "what does the handover do" finds a file
     # about the handover rather than a method in the middle of the transport.

--- a/src/scitex_agent_container/_lifecycle/_relocate_effects_source.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_effects_source.py
@@ -14,12 +14,23 @@ shortcut. A stop mid-turn loses the turn — which is exactly the work a relocat
 exists to carry across. So for a RUNNING agent the drain refuses by name rather
 than quietly doing a stop and calling it drained; for a STOPPED one it is
 vacuously satisfied, and even that is MEASURED rather than assumed.
+
+STOPPED IS NOT THE SAME EVENT AS QUIESCENT, AND THE STOP PHASE NOW WAITS FOR BOTH.
+Measured 2026-08-12: tmux answered that the session was gone — the strongest
+evidence of absence available, and true — and the transcript then grew 11,717
+bytes as the dying process finished flushing its last line. A tmux session
+disappearing is not the process exiting and releasing its file descriptor. So
+after the liveness answer, :mod:`_relocate_quiescence` watches the file until two
+consecutive readings agree, and a wait that runs out returns UNKNOWN naming what
+was still moving. BOTH exits from the liveness check go through it, including the
+"already stopped" one — that is the exit the failing run took.
 """
 
 from __future__ import annotations
 
 from ._relocate_execute import StepResult
 from ._relocate_liveness import observe_running
+from ._relocate_quiescence import await_quiescence
 
 __all__ = ["SourceEffects"]
 
@@ -63,17 +74,66 @@ class SourceEffects:
             ),
         )
 
+    def _quiesced(self, stopped_why: str) -> StepResult:
+        """Turn the liveness answer into a verdict only once the FILE has settled.
+
+        The liveness answer is necessary and not sufficient. Between tmux letting
+        go of the session and the process letting go of its descriptor there is a
+        window in which the transcript is still being written, and the whole
+        transport is built on reading it at rest — so this is where the phase
+        actually earns its "verified".
+
+        A wait that could not be taken, or that ran out with the file still
+        moving, is UNKNOWN. It is not folded into the stop's success: the agent
+        IS stopped, and saying so while the file is still growing is exactly the
+        report that let the 2026-08-12 relocation proceed to a 422.
+        """
+        directory, _, why = self.source_transcript_dir()
+        if directory is None:
+            return StepResult(
+                ok=None,
+                detail=(
+                    f"{self.agent} is stopped on {self.from_host} ({stopped_why}), and "
+                    f"its transcript directory could not be derived: {why}"
+                ),
+                hint=(
+                    "a stop cannot be called verified without watching what the stopped "
+                    "process was writing. Fix the derivation (spec workdir / container "
+                    "home bind) and re-run — the transport needs the same path"
+                ),
+            )
+        settled = await_quiescence(
+            self.source,
+            directory,
+            exec_fn=self.exec_fn,
+            now=self.now,
+            sleep=self.sleep,
+        )
+        if settled.settled is not True:
+            return StepResult(
+                ok=None,
+                detail=(
+                    f"{self.agent} is stopped on {self.from_host} ({stopped_why}), but "
+                    f"{settled.detail}"
+                ),
+                hint=settled.hint,
+            )
+        return StepResult(ok=True, detail=f"{stopped_why}; {settled.detail}")
+
     def stop_source(self) -> StepResult:
-        """Stop the agent on the source host and VERIFY it stopped.
+        """Stop the agent on the source host, VERIFY it stopped, and WAIT FOR THE FILE.
 
         Idempotent: an already-stopped agent is a success with nothing done. The
         verification is a SECOND, independent observation after the stop, because
         ``sac agents stop`` exiting 0 is the command's opinion and the
         transport's precondition is the tmux server's.
+
+        And the tmux server's opinion is not the last word either — see
+        :meth:`_quiesced`. Every path that would report success goes through it.
         """
         running, why = observe_running(self.source, self.agent, exec_fn=self.exec_fn)
         if running is False:
-            return StepResult(ok=True, detail=f"already stopped — {why}")
+            return self._quiesced(f"already stopped — {why}")
         if running is None:
             return StepResult(
                 ok=None,
@@ -93,7 +153,7 @@ class SourceEffects:
             self.source, self.agent, exec_fn=self.exec_fn
         )
         if after is False:
-            return StepResult(ok=True, detail=f"stopped and verified — {after_why}")
+            return self._quiesced(f"stopped and verified — {after_why}")
         if after is None:
             return StepResult(
                 ok=None,

--- a/src/scitex_agent_container/_lifecycle/_relocate_effects_standby.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_effects_standby.py
@@ -43,7 +43,7 @@ from ._relocate_target_ssh import (
     write_session_marker,
 )
 from ._relocate_transport import CREDENTIAL_BASENAMES
-from ._relocate_transport_ssh import copy_transcripts, ensure_dir, move_dir_aside
+from ._relocate_transport_ssh import copy_tree, ensure_dir, move_dir_aside
 
 __all__ = ["StandbyEffects"]
 
@@ -208,12 +208,17 @@ class StandbyEffects:
         # The DIRECTORY is the single name handed to tar, so tar recurses and
         # nothing is re-expanded by a shell on either side — the same property
         # the transcript allowlist relies on, applied to one entry.
-        run = copy_transcripts(
+        #
+        # `copy_tree`, NOT `copy_transcripts`: a spec directory has no
+        # last-newline to be snapshotted at, and half of one is not a shorter
+        # version of it. The two copies are different questions and are now two
+        # functions — see the note in _relocate_transport_ssh.
+        run = copy_tree(
             source=self.source,
             source_dir=agents_dir,
             target=self.target,
             target_dir=target_parent,
-            files=(entry,),
+            names=(entry,),
             exec_fn=self.exec_fn,
             peers=self.peers,
         )

--- a/src/scitex_agent_container/_lifecycle/_relocate_effects_transport.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_effects_transport.py
@@ -1,0 +1,347 @@
+"""The TRANSPORT phase: derive both directories, snapshot the source, copy, confirm.
+
+Split from :mod:`_relocate_effects` exactly as the source, standby, handshake and
+handover phases already are — one file per phase's worth of decisions, so a reader
+looking for "what does the transport do" finds a file about the transport rather
+than a method in the middle of the adapters.
+
+THE ORDER OF THE THREE MEASUREMENTS IS THE WHOLE DESIGN.
+
+    SNAPSHOT FIRST, ON THE SOURCE. :func:`.._relocate_transport_ssh.
+    snapshot_transcripts` records the offset of each file's LAST NEWLINE before
+    a byte moves. That number is the bound on the copy and the baseline for the
+    verdict, and once it is taken the source may grow freely without changing
+    the answer.
+
+    COPY, BOUNDED BY THAT NUMBER. Exactly the snapshotted bytes travel, so the
+    target receives whole lines and never a torn final record.
+
+    MEASURE THE TARGET, COMPARE AGAINST THE SNAPSHOT. Not against a fresh
+    reading of the source. Re-reading the source is the 2026-08-12 abort: the
+    file had grown 11,717 bytes on an identical line count between the
+    measurement and the copy, and the transport reported a corruption that had
+    not happened.
+
+The copy pipeline's exit code is recorded as EVIDENCE and is never the answer.
+"""
+
+from __future__ import annotations
+
+from ._relocate_execute import StepResult
+from ._relocate_liveness import observe_running
+from ._relocate_quiescence import sample_transcripts
+from ._relocate_session_choice import CODE_UNKNOWN, choose_session
+from ._relocate_shell import resolved_path
+from ._relocate_target_ssh import SID_ABSENT, read_session_marker, target_home
+from ._relocate_transcript_home import transcript_home_from_spec
+from ._relocate_transport import plan_transport, verify_arrival
+from ._relocate_transport_paths import derive_target_dir
+from ._relocate_transport_ssh import (
+    copy_transcripts,
+    ensure_dir,
+    list_transcript_dir,
+    measure_transcripts,
+    move_dir_aside,
+    snapshot_transcripts,
+)
+
+__all__ = ["TransportEffects"]
+
+
+class TransportEffects:
+    """Mixin: the transport phase. Expects the attributes of ``RelocateAdapters``."""
+
+    def _workdir(self) -> str:
+        body = (
+            self.spec.get("spec")
+            if isinstance(self.spec.get("spec"), dict)
+            else self.spec
+        )
+        return str((body or {}).get("workdir") or "").strip()
+
+    def source_transcript_dir(self) -> tuple[str | None, str | None, str]:
+        """``(path, encoded_name, why)`` for the SOURCE's transcript directory.
+
+        Derived by asking ONLY the source. Split out of :meth:`_resolve_dirs`
+        because SOURCE_STOP needs it before the target is involved in anything:
+        it waits for that directory to stop changing, and routing that through
+        the full derivation would make the source's quiescence depend on the
+        target answering a question about its own workdir — two hosts to fail
+        where one will do.
+
+        ``path`` is ``None`` when it could not be derived, and ``why`` then says
+        which of the three questions went unanswered.
+        """
+        home = transcript_home_from_spec(self.spec)
+        if home.path is None:
+            return None, None, f"{home.reason} — {home.hint}"
+        workdir = self._workdir()
+        if not workdir:
+            return (
+                None,
+                None,
+                "the spec declares no workdir, so no project directory can be encoded",
+            )
+        src_resolved = resolved_path(self.source, workdir, exec_fn=self.exec_fn)
+        if not src_resolved:
+            return (
+                None,
+                None,
+                f"the SOURCE's resolved workdir for {workdir} was not observed",
+            )
+        src = derive_target_dir(
+            target_home=home.path, target_resolved_workdir=src_resolved
+        )
+        return src.path, src.encoded, src.reason
+
+    def _resolve_dirs(self) -> tuple[str | None, str | None, str]:
+        """Source and target transcript directories, or ``(None, None, why)``.
+
+        The target's directory name is RECOMPUTED from the target's own resolved
+        workdir rather than copied from the source's — see
+        :mod:`_relocate_transport_paths`. A mismatch is normal and is logged, not
+        refused: it is the whole reason the name is derived instead of reused.
+        """
+        source_dir, source_encoded, why = self.source_transcript_dir()
+        if source_dir is None:
+            return None, None, why
+
+        home = transcript_home_from_spec(self.spec)
+        tgt_resolved = resolved_path(self.target, self._workdir(), exec_fn=self.exec_fn)
+        tgt = derive_target_dir(
+            target_home=home.path,
+            target_resolved_workdir=tgt_resolved,
+            source_dir_name=source_encoded,
+        )
+        if tgt.path is None:
+            return None, None, f"{tgt.reason} — {tgt.hint}"
+        if tgt.matches_source is False:
+            self.log.append(f"transport: {tgt.reason}")
+        return source_dir, tgt.path, tgt.reason
+
+    def _prepare_destination(self, plan, target_dir: str) -> StepResult | None:
+        """Move aside whatever is there, then make sure the directory exists.
+
+        ``None`` when the destination is ready. Nothing is overwritten and
+        nothing is deleted: what is at the destination may be the only copy of an
+        earlier conversation, and the move-aside is also what makes a retry
+        idempotent.
+        """
+        if plan.move_aside is not None and plan.move_aside.required:
+            moved = move_dir_aside(
+                self.target,
+                target_dir,
+                plan.move_aside.destination or "",
+                exec_fn=self.exec_fn,
+            )
+            if moved is not True:
+                return StepResult(
+                    ok=None if moved is None else False,
+                    detail=(
+                        f"{self.to_host} already holds {target_dir} and it could not be "
+                        f"moved aside to {plan.move_aside.destination}"
+                    ),
+                    hint=(
+                        "move it aside by hand and re-run. Nothing is overwritten and "
+                        "nothing is deleted — what is there may be the only copy of an "
+                        "earlier conversation"
+                    ),
+                )
+            self.log.append(
+                f"transport: moved {self.to_host}:{target_dir} aside to "
+                f"{plan.move_aside.destination}"
+            )
+
+        made = ensure_dir(self.target, target_dir, exec_fn=self.exec_fn)
+        if made is not True:
+            return StepResult(
+                ok=None if made is None else False,
+                detail=(
+                    f"the destination {target_dir} on {self.to_host} could not be created"
+                ),
+                hint="check write permission on the target's transcript root, then re-run",
+            )
+        return None
+
+    def _snapshot(self, source_dir: str, names) -> StepResult | None:
+        """Record the last-newline offset for every file that will travel.
+
+        ``None`` when every name was snapshotted. A name with no recorded offset
+        refuses BEFORE anything moves: carrying "however much is there now" is
+        precisely the race the offset exists to remove, and the mismatch it
+        eventually produces is reported against a source that has already moved.
+        """
+        self.sent = snapshot_transcripts(
+            self.source, source_dir, names, exec_fn=self.exec_fn
+        )
+        for f in self.sent:
+            self.log.append(
+                f"transport: snapshot {f.name} at {f.byte_count} bytes / "
+                f"{f.line_count} complete lines — the offset of its last newline; "
+                "the source may grow past this and the verdict does not change"
+            )
+        snapshotted = {f.name for f in self.sent if f.measured}
+        missing = [n for n in names if n not in snapshotted]
+        if not missing:
+            return None
+        return StepResult(
+            ok=None,
+            detail=(
+                f"no snapshot offset could be taken on {self.from_host} for: "
+                + ", ".join(missing)
+            ),
+            hint=(
+                "read the source's transcript directory again before copying. A file "
+                "with no recorded offset would have to be carried as 'however much is "
+                "there now', which is the race the snapshot removes"
+            ),
+        )
+
+    def _choose_session(self, source_dir: str, carried) -> StepResult | None:
+        """Name the conversation the target will resume. ``None`` when named.
+
+        RUN BEFORE ANY BYTES MOVE, deliberately. The old guard — take the session
+        id only when exactly one transcript was carried — deferred this question
+        to TARGET_STANDBY, which is AFTER ``source_stop`` has taken the agent
+        down. Measured 2026-08-12: every one of the ten agents left on
+        ywata-note-win has 2-5 transcripts, so every one of them passed preflight
+        and then stopped, copied, and refused with the agent already off.
+
+        The marker is read from the SOURCE's own sac tree, which is rooted at the
+        ssh user's ``$HOME`` there — the same home
+        :mod:`_relocate_effects_standby` writes the target's marker under, and
+        deliberately NOT the container home the transcripts follow.
+        """
+        home = target_home(self.source, exec_fn=self.exec_fn)
+        marker: str | None = None
+        if home:
+            state_dir = f"{home}/.scitex/agent-container/runtime/{self.agent}"
+            raw = read_session_marker(self.source, state_dir, exec_fn=self.exec_fn)
+            if raw is not None:
+                marker = "" if raw == SID_ABSENT else raw
+        sample = sample_transcripts(self.source, source_dir, exec_fn=self.exec_fn)
+        mtimes = {
+            f.name: int(f.mtime)
+            for f in (sample or ())
+            if f.mtime is not None and f.mtime.lstrip("-").isdigit()
+        }
+        choice = choose_session(
+            agent=self.agent, carried=carried, marker=marker, mtimes=mtimes
+        )
+        self.log.append(
+            f"transport: session marker on {self.from_host} reads {marker!r}; "
+            f"candidates {list(choice.candidates)}"
+        )
+        if choice.session is None:
+            return StepResult(
+                ok=None if choice.code == CODE_UNKNOWN else False,
+                detail=f"the session to resume could not be chosen ({choice.code}): {choice.reason}",
+                hint=choice.hint,
+            )
+        self.session_uuid = choice.session
+        self.log.append(
+            f"transport: resuming session {choice.session} — chosen by {choice.chosen_by}"
+        )
+        return None
+
+    def transport(self) -> StepResult:
+        """Copy the transcript across and CONFIRM it on the target, per file.
+
+        List the source, let :func:`plan_transport` decide what may travel, move
+        aside anything already at the destination, SNAPSHOT the source, copy
+        exactly that snapshot, then measure THE TARGET and compare it against the
+        snapshot. That last comparison is the only statement this step makes
+        about success.
+        """
+        source_dir, target_dir, why = self._resolve_dirs()
+        if source_dir is None or target_dir is None:
+            return StepResult(
+                ok=None,
+                detail=f"the transcript directories could not be derived: {why}",
+                hint=(
+                    "measure the target's resolved workdir and check the spec's bind for "
+                    "the container home. A transcript under the wrong directory name is "
+                    "present, intact and invisible to the runner"
+                ),
+            )
+        self.source_dir, self.target_dir = source_dir, target_dir
+
+        listing = list_transcript_dir(self.source, source_dir, exec_fn=self.exec_fn)
+        running, _ = observe_running(self.source, self.agent, exec_fn=self.exec_fn)
+        target_listing = list_transcript_dir(
+            self.target, target_dir, exec_fn=self.exec_fn
+        )
+
+        plan = plan_transport(
+            source_running=running,
+            source_files=None if listing is None else list(listing),
+            target_dir_exists=None if target_listing is None else bool(target_listing),
+            target_dir=target_dir,
+            stamp=self.stamp,
+        )
+        for name, reason in plan.refused:
+            self.log.append(f"transport: REFUSED {name} — {reason}")
+        if plan.proceed is not True:
+            return StepResult(
+                ok=False if plan.proceed is False else None,
+                detail=f"transport refused ({plan.code}): {plan.reason}",
+                hint=plan.hint,
+            )
+        self.carried = plan.files
+
+        # BEFORE anything moves: if the conversation to resume cannot be named,
+        # the relocation must stop here rather than at TARGET_STANDBY, which runs
+        # with the agent already stopped on the source.
+        refused = self._choose_session(source_dir, plan.files)
+        if refused is not None:
+            return refused
+
+        refused = self._prepare_destination(plan, target_dir)
+        if refused is not None:
+            return refused
+
+        refused = self._snapshot(source_dir, plan.files)
+        if refused is not None:
+            return refused
+
+        run = copy_transcripts(
+            source=self.source,
+            source_dir=source_dir,
+            target=self.target,
+            target_dir=target_dir,
+            files=self.sent,
+            exec_fn=self.exec_fn,
+            peers=self.peers,
+        )
+        self.log.append(
+            f"transport: copy pipeline exit {run.exit_code} — EVIDENCE ONLY; arrival is "
+            "decided by counting on the target"
+        )
+        if run.stderr.strip():
+            self.log.append(f"transport: copy stderr {run.stderr.strip()[:300]}")
+
+        self.landed = measure_transcripts(
+            self.target, target_dir, plan.files, exec_fn=self.exec_fn
+        )
+        verdict = verify_arrival(sent=self.sent, landed=self.landed)
+        self.arrival_confirmed = verdict.arrived
+        for line in verdict.mismatches:
+            self.log.append(f"transport: MISMATCH {line}")
+        for f in self.landed:
+            self.log.append(
+                f"transport: target holds {f.name} {f.byte_count} bytes / "
+                f"{f.line_count} lines"
+            )
+        if verdict.arrived is not True:
+            return StepResult(
+                ok=False if verdict.arrived is False else None,
+                detail=f"arrival not confirmed ({verdict.code}): {verdict.reason}",
+                hint=verdict.hint,
+            )
+        return StepResult(
+            ok=True,
+            detail=(
+                f"{verdict.reason}; {self.from_host}:{source_dir} -> "
+                f"{self.to_host}:{target_dir}"
+            ),
+        )

--- a/src/scitex_agent_container/_lifecycle/_relocate_effects_transport.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_effects_transport.py
@@ -36,8 +36,11 @@ from ._relocate_target_ssh import SID_ABSENT, read_session_marker, target_home
 from ._relocate_transcript_home import transcript_home_from_spec
 from ._relocate_transport import plan_transport, verify_arrival
 from ._relocate_transport_paths import derive_target_dir
+from ._relocate_provenance import PROVENANCE_FILENAME, render_provenance
+from ._relocate_target_ssh import list_tree, write_text_file
 from ._relocate_transport_ssh import (
     copy_transcripts,
+    copy_tree,
     ensure_dir,
     list_transcript_dir,
     measure_transcripts,
@@ -244,6 +247,127 @@ class TransportEffects:
         )
         return None
 
+    def _carry_directories(self, source_dir: str, target_dir: str, names) -> StepResult | None:
+        """Carry ``memory/`` and confirm it by listing the tree on BOTH hosts.
+
+        ``None`` when everything arrived. Measured 2026-08-11: a completed
+        relocation left nine memory files and 20,014 bytes on the source because
+        the allowlist was ``*.jsonl`` alone. The transcript is the conversation;
+        memory is the rules distilled from it, and an agent that kept the first
+        and lost the second can recall what was said and has forgotten every rule
+        it wrote for itself.
+
+        Verified by TREE COMPARISON rather than per-name checks, for the reason
+        the spec-directory copy already gives: a per-file check of the names you
+        thought to name says nothing about the file you forgot.
+        """
+        if not names:
+            return None
+        before = {
+            n: list_tree(self.source, f"{source_dir}/{n}", exec_fn=self.exec_fn)
+            for n in names
+        }
+        run = copy_tree(
+            source=self.source,
+            source_dir=source_dir,
+            target=self.target,
+            target_dir=target_dir,
+            names=names,
+            exec_fn=self.exec_fn,
+            peers=self.peers,
+        )
+        self.log.append(
+            f"transport: {', '.join(names)} copy pipeline exit {run.exit_code} — "
+            "EVIDENCE ONLY; arrival is decided by listing on the target"
+        )
+        # EVERY name is verified, not just the first. There is one entry on the
+        # allowlist today; a loop that checked only names[0] would carry a second
+        # one unverified on the day it is added, which is the shape of bug that
+        # put this method here.
+        for name in names:
+            source_tree = before.get(name)
+            target_tree = list_tree(
+                self.target, f"{target_dir}/{name}", exec_fn=self.exec_fn
+            )
+            if source_tree is None or target_tree is None:
+                where = "the source" if source_tree is None else self.to_host
+                return StepResult(
+                    ok=None,
+                    detail=f"{name}/ was copied and could not be listed on {where}",
+                    hint=(
+                        "list it on both hosts and compare. An unverified memory "
+                        "directory is the 2026-08-11 failure: the agent arrives able to "
+                        "recall the conversation and having lost the rules it drew from it"
+                    ),
+                )
+            if target_tree != source_tree:
+                missing = sorted(set(dict(source_tree)) - set(dict(target_tree)))
+                return StepResult(
+                    ok=False,
+                    detail=(
+                        f"{name}/ on {self.to_host} does not match the source: "
+                        f"{len(missing)} file(s) absent {missing[:5]}"
+                    ),
+                    hint=(
+                        "re-run the transport. Nothing was deleted on the source, so the "
+                        "originals are still there to copy by hand if this keeps failing"
+                    ),
+                )
+            total = sum(size or 0 for _, size in target_tree)
+            self.log.append(
+                f"transport: {self.to_host} holds {name}/ — {len(target_tree)} file(s), "
+                f"{total} bytes, tree identical to {self.from_host}"
+            )
+        return None
+
+    def _write_provenance(self, plan, source_dir: str, target_dir: str) -> None:
+        """Tell the arriving agent where it came from. Never fatal.
+
+        THE OPERATOR'S REQUIREMENT, and by his own account the only one that
+        matters here: 「エージェントがどこから来たのかっていうのが分かって、そこを
+        調査することができるならば、全く問題ない」. The merge policy he called
+        枝葉 — a leaf. This is the trunk.
+
+        A failure to write it is LOGGED, not returned. The relocation itself has
+        already succeeded by this point — the transcript is verified on the
+        target — and refusing the phase over a missing note would abort a move
+        that worked, leaving the agent stopped on one host and unstarted on the
+        other. The log says plainly if it did not land.
+        """
+        displaced = ""
+        if plan.move_aside is not None and plan.move_aside.required:
+            displaced = plan.move_aside.destination or ""
+        text = render_provenance(
+            agent=self.agent,
+            from_host=self.from_host,
+            source_dir=source_dir,
+            to_host=self.to_host,
+            target_dir=target_dir,
+            when=self.now(),
+            session=self.session_uuid,
+            transcripts=[(f.name, f.byte_count, f.line_count) for f in self.sent],
+            directories=plan.directories,
+            refused=plan.refused,
+            displaced_to=displaced,
+        )
+        written = write_text_file(
+            self.target,
+            f"{target_dir}/{PROVENANCE_FILENAME}",
+            text,
+            exec_fn=self.exec_fn,
+        )
+        if written is None:
+            self.log.append(
+                f"transport: WARNING the provenance record {PROVENANCE_FILENAME} could "
+                f"not be confirmed on {self.to_host}; the agent will not be able to read "
+                "where it came from"
+            )
+            return
+        self.log.append(
+            f"transport: wrote {target_dir}/{PROVENANCE_FILENAME} ({written} bytes) — "
+            f"names {self.from_host}:{source_dir} and everything NOT carried"
+        )
+
     def transport(self) -> StepResult:
         """Copy the transcript across and CONFIRM it on the target, per file.
 
@@ -338,10 +462,23 @@ class TransportEffects:
                 detail=f"arrival not confirmed ({verdict.code}): {verdict.reason}",
                 hint=verdict.hint,
             )
+
+        refused = self._carry_directories(source_dir, target_dir, plan.directories)
+        if refused is not None:
+            return refused
+
+        # LAST, and never fatal: the agent's own record of where it came from.
+        self._write_provenance(plan, source_dir, target_dir)
+
+        carried = f"{verdict.reason}" + (
+            f"; {', '.join(d + '/' for d in plan.directories)} carried whole"
+            if plan.directories
+            else ""
+        )
         return StepResult(
             ok=True,
             detail=(
-                f"{verdict.reason}; {self.from_host}:{source_dir} -> "
+                f"{carried}; {self.from_host}:{source_dir} -> "
                 f"{self.to_host}:{target_dir}"
             ),
         )

--- a/src/scitex_agent_container/_lifecycle/_relocate_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_preflight.py
@@ -18,12 +18,20 @@ reader can tell "this is wrong" from "I could not tell". An unknown folded into
 pass is precisely how the 08-07 move reported healthy: the credential check had
 no answer, and something treated that as fine.
 
-TEN CHECKS ARE ABOUT THE TARGET AND ONE IS ABOUT THE SOURCE. The odd one out —
-``source_work_committed`` — asks whether the machine being LEFT still holds
+TEN CHECKS ARE ABOUT THE TARGET AND TWO ARE ABOUT THE SOURCE. The odd ones out
+are ``source_work_committed`` — whether the machine being LEFT still holds
 uncommitted or unpushed work, because a relocation carries the spec and the
-transcript and nothing else. Its facts come in separately
+transcript and nothing else — and ``session_resolvable``, whether the
+conversation to resume can be NAMED. Their facts come in separately
 (:class:`SourceFacts`), gathered locally rather than over ssh, so a target probe
 can never accidentally fill a field about the source.
+
+``session_resolvable`` IS HERE RATHER THAN IN THE PHASES FOR ONE REASON: the
+phase that needs the answer (TARGET_STANDBY) runs after the agent has been
+stopped. Measured 2026-08-12, ten agents on ywata-note-win passed all eleven
+checks and could not complete, every one of them holding more than one
+transcript. A gate that passes on an agent that cannot proceed is the bug, not
+merely a missing convenience.
 """
 
 from __future__ import annotations
@@ -39,6 +47,7 @@ from ._relocate_checks import (
     CHECK_RUNTIME,
     CHECK_SAC_PRESENT,
     CHECK_SCHEMA,
+    CHECK_SESSION,
     CHECK_SOURCE_WORK,
     check_binds,
     check_card_store,
@@ -50,6 +59,7 @@ from ._relocate_checks import (
     check_runtime,
     check_sac_present,
     check_schema,
+    check_session_resolvable,
     check_source_work,
 )
 from ._relocate_preflight_facts import Check, PreflightReport, SourceFacts, TargetFacts
@@ -65,6 +75,7 @@ __all__ = [
     "CHECK_RUNTIME",
     "CHECK_SAC_PRESENT",
     "CHECK_SCHEMA",
+    "CHECK_SESSION",
     "CHECK_SOURCE_WORK",
     "Check",
     "PreflightReport",
@@ -107,5 +118,6 @@ def preflight(
         check_hub_from_target(facts, to_host),
         check_sac_present(facts, to_host),
         check_source_work(source_facts or SourceFacts(), from_host),
+        check_session_resolvable(source_facts or SourceFacts(), agent),
     )
     return PreflightReport(agent=agent, to_host=to_host, checks=checks)

--- a/src/scitex_agent_container/_lifecycle/_relocate_preflight_facts.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_preflight_facts.py
@@ -103,6 +103,18 @@ class SourceFacts:
     #: Every repo the agent works in, with its un-saved counts. ``None`` means
     #: no scan ran; an empty tuple means a scan ran and found no repos.
     repos: tuple[RepoWork, ...] | None = None
+    #: Every ``*.jsonl`` in the source's project directory as ``(name, mtime)``,
+    #: mtime in epoch seconds (``None`` for one that could not be read). The
+    #: TUPLE being ``None`` means nobody looked; an empty tuple means somebody
+    #: looked and the directory holds no transcript, which is a real answer and a
+    #: different one.
+    transcripts: tuple[tuple[str, int | None], ...] | None = None
+    #: The source's own ``runtime/<agent>/session_id`` — what its runtime last
+    #: resumed. ``""`` means LOOKED AND FOUND NOTHING; ``None`` means nobody
+    #: looked. The distinction decides a real case: with several transcripts and
+    #: no marker the newest travels, but an UNREAD marker may name a different
+    #: one, so it must not be treated as absent.
+    session_marker: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/scitex_agent_container/_lifecycle/_relocate_provenance.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_provenance.py
@@ -1,0 +1,157 @@
+"""Where this agent came from, written where the agent itself will find it.
+
+THE OPERATOR'S RULING, 2026-08-12, on being asked how a relocation should merge a
+``memory/`` directory that may have diverged on both hosts:
+
+    「エージェントがどこから来たのかっていうのが分かって、そこを調査することが
+    できるならば、全く問題ない」
+
+    — if the agent can tell where it came from and go and investigate there,
+      there is no problem at all.
+
+He called the merge policy 枝葉, a leaf detail. THE REQUIREMENT THAT MATTERS IS
+PROVENANCE. So this module writes the record: which host, which absolute path,
+when, what travelled, and — the half that is usually missing — WHAT DID NOT, with
+the reason for each. Nothing is ever deleted on the source, so every refused entry
+named here is still sitting where it was named, ready to be fetched by hand.
+
+WHY THE REFUSALS ARE THE IMPORTANT HALF. A relocation that carried nine tenths of
+an agent and said so is recoverable in a minute; one that carried nine tenths
+silently is discovered weeks later by someone who assumed it moved everything.
+That is exactly how ``memory/`` went missing: the refusal existed, as one line in
+a run log that nobody keeps. Here it lands in a file on the target, beside the
+conversation, where the agent that lost the memory is the one who reads it.
+
+WHY MARKDOWN AND NOT JSON. The reader is an agent with a filesystem and an
+operator over its shoulder, not a parser. It sits in the project directory, which
+the runner scans for ``*.jsonl`` and ignores everything else, so a ``.md`` there
+is inert.
+
+Pure: strings and numbers in, one document out. The writing is somebody else's
+job, so every line of this can be asserted without a second machine.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Final, Sequence
+
+__all__ = [
+    "PROVENANCE_FILENAME",
+    "render_provenance",
+]
+
+#: Named so an agent can be told to read it, and so a later relocation's listing
+#: shows it by a name that explains itself.
+PROVENANCE_FILENAME: Final = "RELOCATED-FROM.md"
+
+
+def _rule(text: str) -> str:
+    return f"- {text}"
+
+
+def render_provenance(
+    *,
+    agent: str,
+    from_host: str,
+    source_dir: str,
+    to_host: str,
+    target_dir: str,
+    when: float,
+    session: str = "",
+    transcripts: Sequence[tuple[str, int | None, int | None]] = (),
+    directories: Sequence[str] = (),
+    refused: Sequence[tuple[str, str]] = (),
+    displaced_to: str = "",
+) -> str:
+    """The record, as the target will hold it.
+
+    ``when`` is unix time, passed in rather than read here — this module owns no
+    clock, for the same reason every other decision module in this feature does
+    not. Both the epoch and a readable UTC rendering are printed: the first is
+    what survives comparison across hosts whose clocks differ, the second is what
+    a human reads. The operator's ruling on skew was 「そんなシビアじゃない」 —
+    plain unix time is enough — so nothing here tries to correct for it, and the
+    raw number is shown so anyone who cares can see it.
+
+    ``transcripts`` are ``(name, bytes, lines)`` AS CARRIED — the snapshot
+    numbers, which is what the target actually holds — so a reader comparing the
+    two hosts by hand knows what the target's file is supposed to weigh.
+    """
+    stamp = time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime(when))
+    lines: list[str] = [
+        f"# {agent} was relocated here",
+        "",
+        f"This agent moved from **{from_host}** to **{to_host}** on {stamp}",
+        f"(unix {when:.0f}).",
+        "",
+        "## Where it came from",
+        "",
+        _rule(f"source host: `{from_host}`"),
+        _rule(f"source path: `{source_dir}`"),
+        _rule(f"this path:   `{target_dir}`"),
+    ]
+    if session:
+        lines.append(_rule(f"session resumed: `{session}`"))
+    lines += [
+        "",
+        "NOTHING WAS DELETED ON THE SOURCE. Everything listed below — carried or "
+        "not — is still at the source path above, on that host, exactly as it was. "
+        "If something is missing here, go and look there.",
+        "",
+        "## What was carried",
+        "",
+    ]
+    if transcripts:
+        lines.append("Transcripts (bytes / lines as carried):")
+        lines.append("")
+        for name, byte_count, line_count in transcripts:
+            lines.append(_rule(f"`{name}` — {byte_count} bytes / {line_count} lines"))
+        lines.append("")
+        lines.append(
+            "Each transcript was carried up to the byte offset of its LAST COMPLETE "
+            "LINE at the moment the copy began, so a record that was still being "
+            "written when the source stopped is the one thing that may be missing "
+            "from the end."
+        )
+        lines.append("")
+    if directories:
+        lines.append("Directories, carried whole:")
+        lines.append("")
+        for name in directories:
+            lines.append(_rule(f"`{name}/`"))
+        lines.append("")
+    if not transcripts and not directories:
+        lines.append("Nothing. That is worth reading twice.")
+        lines.append("")
+
+    lines += ["## What was NOT carried", ""]
+    if refused:
+        lines.append(
+            "These were seen in the source directory and deliberately left there:"
+        )
+        lines.append("")
+        for name, reason in refused:
+            lines.append(_rule(f"`{name}` — {reason}"))
+    else:
+        lines.append(
+            "Nothing was refused: every entry in the source directory travelled."
+        )
+    lines.append("")
+
+    if displaced_to:
+        lines += [
+            "## What was already here",
+            "",
+            "This host already held a directory at the path above. It was MOVED "
+            "ASIDE, never overwritten and never deleted:",
+            "",
+            _rule(f"`{displaced_to}`"),
+            "",
+            "If that older copy holds memory or transcripts worth keeping, merging "
+            "it is a deliberate act — read both and decide. The source's copy won "
+            "here by default, which is the operator's rule "
+            "(「ソースの方が普通大切だろう」), not a judgement about the contents.",
+            "",
+        ]
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/scitex_agent_container/_lifecycle/_relocate_quiescence.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_quiescence.py
@@ -1,0 +1,290 @@
+"""Has the transcript stopped CHANGING? A different question from "did the agent stop?".
+
+THE 2026-08-12 FAILURE, IN ONE SENTENCE: a relocation stopped the agent, verified
+the stop, copied the transcript, and aborted 422 because the file had grown
+11,717 bytes on an IDENTICAL line count between the measurement and the read.
+
+Nothing was wrong with the stop. :mod:`_relocate_liveness` asked tmux and got the
+strongest answer available — *"tmux on ywata-note-win answered and has NO session
+tui-… — positive evidence of absence, from tmux's own bookkeeping"* — and that
+answer was true. A TMUX SESSION DISAPPEARING IS NOT THE SAME EVENT AS THE PROCESS
+EXITING AND RELEASING ITS FILE DESCRIPTOR. The dying process finished flushing its
+last line after the session was gone, so the source was MEASURED at one instant
+and READ at another with nothing guaranteeing it was unchanged in between.
+
+So SOURCE_STOP now waits for the file itself, not only for tmux. Two consecutive
+readings of ``(size, mtime)`` for every ``*.jsonl`` in the source's project
+directory must be IDENTICAL before the phase reports success. A flush in flight
+changes the size; a same-size rewrite changes the mtime; a new session file
+appearing changes the set. Any of the three restarts the wait.
+
+WHY NOT AN OPEN-DESCRIPTOR CHECK, WHICH WOULD BE STRONGER. It needs a tool that is
+not on every host in this fleet (``lsof``/``fuser`` are absent on the busybox
+targets), and where it exists it needs privileges to see another user's
+descriptors — so its unavailable case is UNKNOWN on hosts where the cheap check
+would have answered plainly. Two readings need nothing that is not already there.
+
+THE WAIT IS BOUNDED AND A TIMEOUT IS UNKNOWN, NEVER SUCCESS. A file that is still
+moving at the deadline is reported with the name of what was moving and by how
+much, because "not quiescent" without the evidence is not something anyone can
+act on — and because the alternative, proceeding anyway, is the exact bug above.
+
+The sampling touches a host; the comparison and the verdict are pure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Final, Sequence
+
+from ._relocate_shell import Shell, marked, one_marked, quote
+
+__all__ = [
+    "MARK_QUIET",
+    "MARK_QUIET_DIR",
+    "QUIESCENCE_INTERVAL_S",
+    "QUIESCENCE_TIMEOUT_S",
+    "FileState",
+    "Quiescence",
+    "await_quiescence",
+    "describe_change",
+    "sample_transcripts",
+]
+
+MARK_QUIET_DIR = "TX-QDIR="
+MARK_QUIET = "TX-QUIET="
+
+#: Seconds between the two readings that must agree. Long enough that a shutdown
+#: flush cannot span both and still look stable, short enough that it costs a
+#: healthy relocation one interval and no more.
+QUIESCENCE_INTERVAL_S: Final = 2.0
+
+#: The whole wait, bounded — about fifteen readings. Long enough for a process
+#: that is slow to let go of its descriptor, short enough that a wedged host
+#: fails the phase promptly instead of sitting in front of the copy's much
+#: larger budget.
+QUIESCENCE_TIMEOUT_S: Final = 30.0
+
+
+@dataclass(frozen=True)
+class FileState:
+    """One file at one INSTANT — enough to tell whether it has moved since.
+
+    ``byte_count`` is ``None`` for NOT MEASURED, and a sample containing one
+    refuses: two unmeasured readings compare equal, which would manufacture
+    exactly the false "it has settled" this module exists to prevent.
+
+    ``mtime`` is ``None`` when the host's ``stat`` answered neither the GNU nor
+    the BSD spelling. That is not fatal — the size is the signal for an
+    append-only jsonl, and the verdict says out loud that only the size was
+    compared — but it is recorded rather than silently treated as equal.
+    """
+
+    name: str
+    byte_count: int | None = None
+    mtime: str | None = None
+
+
+@dataclass(frozen=True)
+class Quiescence:
+    """Whether the transcript has stopped changing. Three-valued, no ``__bool__``.
+
+    ``settled=None`` is a wait that ran out or a reading that could not be taken.
+    It refuses as firmly as a failure: the next phase reads these files.
+    """
+
+    settled: bool | None
+    detail: str
+    hint: str = ""
+
+    def __post_init__(self) -> None:
+        if self.settled not in (True, False, None):
+            raise ValueError(
+                f"Quiescence.settled must be True/False/None, got {self.settled!r}"
+            )
+        if not self.detail:
+            raise ValueError("Quiescence.detail must be non-empty")
+        if self.settled is not True and not self.hint:
+            raise ValueError(
+                "Quiescence: a wait that did not settle must say what to do next"
+            )
+
+
+def sample_transcripts(
+    shell: Shell,
+    directory: str,
+    *,
+    exec_fn: Callable[..., dict] | None = None,
+) -> tuple[FileState, ...] | None:
+    """Size and mtime for every ``*.jsonl`` in ``directory``, at one instant.
+
+    ``None`` means the script produced no answer at all — not measured, which
+    refuses. A directory that does not exist is an OBSERVED empty sample: there
+    is no transcript there to still be moving.
+
+    Sorted by name so two readings of the same unchanged directory compare equal
+    regardless of the order the far-side shell happened to emit them in.
+
+    A glob is used here, unlike the copy, and deliberately: this asks "did
+    ANYTHING in the directory change", so a file that appeared between the two
+    readings must be seen. The allowlist governs what TRAVELS, which is a
+    different question and a different function.
+    """
+    body = (
+        f"if [ -d {quote(directory)} ]; then\n"
+        f"  printf '{MARK_QUIET_DIR}yes\\n'\n"
+        f"  cd {quote(directory)} || exit 0\n"
+        f"  for __f in *.jsonl; do\n"
+        f'    [ -f "$__f" ] || continue\n'
+        f'    __b=$(wc -c < "$__f" 2>/dev/null)\n'
+        f'    __m=$(stat -c %Y "$__f" 2>/dev/null || stat -f %m "$__f" 2>/dev/null)\n'
+        f"    printf '{MARK_QUIET}%s\\t%s\\t%s\\n' \"$__f\" \"$__b\" \"$__m\"\n"
+        f"  done\n"
+        f"else\n"
+        f"  printf '{MARK_QUIET_DIR}no\\n'\n"
+        f"fi"
+    )
+    run = shell.run(body, exec_fn=exec_fn)
+    if one_marked(run, MARK_QUIET_DIR) is None:
+        return None
+    states: list[FileState] = []
+    for raw in marked(run, MARK_QUIET):
+        parts = raw.split("\t")
+        name = parts[0].strip() if parts else ""
+        if not name:
+            continue
+        states.append(
+            FileState(
+                name=name,
+                byte_count=_int_or_none(parts[1] if len(parts) > 1 else ""),
+                mtime=(parts[2].strip() if len(parts) > 2 and parts[2].strip() else None),
+            )
+        )
+    return tuple(sorted(states, key=lambda f: f.name))
+
+
+def _int_or_none(raw: str) -> int | None:
+    text = raw.strip()
+    return int(text) if text.isdigit() else None
+
+
+def describe_change(
+    before: Sequence[FileState], after: Sequence[FileState]
+) -> str:
+    """What moved between two readings, in words a refusal can print.
+
+    Pure. Named per file and per direction, because "the transcript was still
+    changing" without the numbers is the same unhelpful sentence the 422 that
+    prompted this module produced.
+    """
+    was = {f.name: f for f in before}
+    now = {f.name: f for f in after}
+    notes: list[str] = []
+    for name in sorted(set(now) - set(was)):
+        notes.append(f"{name} appeared")
+    for name in sorted(set(was) - set(now)):
+        notes.append(f"{name} disappeared")
+    for name in sorted(set(was) & set(now)):
+        old, new = was[name], now[name]
+        if old.byte_count != new.byte_count:
+            grew = (new.byte_count or 0) - (old.byte_count or 0)
+            notes.append(
+                f"{name} went from {old.byte_count} to {new.byte_count} bytes ({grew:+d})"
+            )
+        elif old.mtime != new.mtime:
+            notes.append(
+                f"{name} was rewritten in place at the same size "
+                f"(mtime {old.mtime} -> {new.mtime})"
+            )
+    return "; ".join(notes)
+
+
+def _unmeasured(sample: Sequence[FileState]) -> tuple[str, ...]:
+    return tuple(f.name for f in sample if f.byte_count is None)
+
+
+def _mtime_note(sample: Sequence[FileState]) -> str:
+    blind = [f.name for f in sample if f.mtime is None]
+    if not blind:
+        return ""
+    return (
+        f" (size only for {', '.join(blind)} — this host's stat answered no mtime, "
+        "so a same-size rewrite there would not have been seen)"
+    )
+
+
+def _not_measured(directory: str, why: str) -> Quiescence:
+    return Quiescence(
+        settled=None,
+        detail=f"whether {directory} has stopped changing was not measured: {why}",
+        hint=(
+            "read the source's transcript directory before copying. A stop that was "
+            "confirmed by tmux is not evidence that the process has finished writing "
+            "— the two are different events, ~11.7 KB apart on 2026-08-12"
+        ),
+    )
+
+
+def await_quiescence(
+    shell: Shell,
+    directory: str,
+    *,
+    exec_fn: Callable[..., dict] | None = None,
+    now: Callable[[], float],
+    sleep: Callable[[float], None],
+    interval_s: float = QUIESCENCE_INTERVAL_S,
+    timeout_s: float = QUIESCENCE_TIMEOUT_S,
+) -> Quiescence:
+    """Wait until two consecutive readings of ``directory`` agree, or give up saying so.
+
+    ``now`` and ``sleep`` are injected for the usual reason: the wait is real
+    wall-clock time on a real relocation, and a test that had to spend it would
+    either be slow or would not be written.
+
+    Returns ``settled=True`` only on two IDENTICAL readings. A deadline reached
+    while the file is still moving returns ``settled=None`` naming what moved —
+    never ``True``, and never ``False``, because "it is still being written" is
+    an unfinished measurement rather than a verdict about the host.
+    """
+    first = sample_transcripts(shell, directory, exec_fn=exec_fn)
+    if first is None:
+        return _not_measured(directory, "the sampling script gave no answer")
+    blind = _unmeasured(first)
+    if blind:
+        return _not_measured(directory, f"no byte count for {', '.join(blind)}")
+
+    deadline = now() + timeout_s
+    while True:
+        sleep(interval_s)
+        second = sample_transcripts(shell, directory, exec_fn=exec_fn)
+        if second is None:
+            return _not_measured(directory, "a follow-up reading gave no answer")
+        blind = _unmeasured(second)
+        if blind:
+            return _not_measured(directory, f"no byte count for {', '.join(blind)}")
+
+        if second == first:
+            return Quiescence(
+                settled=True,
+                detail=(
+                    f"{len(second)} transcript(s) in {directory} read identically "
+                    f"twice, {interval_s:.0f}s apart{_mtime_note(second)}"
+                ),
+            )
+
+        changed = describe_change(first, second)
+        first = second
+        if now() >= deadline:
+            return Quiescence(
+                settled=None,
+                detail=(
+                    f"{directory} was STILL CHANGING at the {timeout_s:.0f}s "
+                    f"quiescence deadline: {changed}"
+                ),
+                hint=(
+                    "something is still writing to the transcript after the agent was "
+                    "reported stopped. Find it and let it finish (or stop it) before "
+                    "copying — this is the 2026-08-12 abort, where a shutdown flush "
+                    "landed between the measurement and the read"
+                ),
+            )

--- a/src/scitex_agent_container/_lifecycle/_relocate_session_choice.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_session_choice.py
@@ -1,0 +1,268 @@
+"""WHICH conversation moves, when the directory holds several. Chosen, never guessed.
+
+An agent's project directory holds one ``.jsonl`` per session it has ever run, and
+the relocation carries all of them. Exactly one of them is the LIVE conversation —
+the one the target must be seeded to resume — and until 2026-08-12 the transport
+identified it by a guard that read, in full::
+
+    if len(plan.files) == 1:
+        self.session_uuid = plan.files[0].rsplit(".", 1)[0]
+
+MEASURED THE SAME NIGHT, ON ywata-note-win: not one of the ten agents left to move
+has exactly one transcript (3, 4, 4, 5, 3, 2, 3, 2, 4, 4). Every one of them
+returned ``GO — every check passed (11 checks)`` from preflight and then could not
+complete: ``source_stop`` stopped the agent, TRANSPORT verified every byte, and
+TARGET_STANDBY refused with "the carried session id is not known" — after the
+agent was already down. Confirmed live on scitex-clew: three transcripts,
+10,243,042 / 4,722,667 / 30,698,234 bytes all verified, then ``phase='aborted'``,
+no marker seeded, target never started, source left stopped.
+
+THE ORDER OF PREFERENCE, AND WHY EACH STEP IS WHERE IT IS.
+
+1. THE SOURCE'S OWN MARKER. ``runtime/<agent>/session_id`` is what the source's
+   runtime itself last resumed. It is not an inference about which file looks
+   live; it is the answer, written by the thing that knows.
+
+2. THE MOST RECENTLY MODIFIED CARRIED TRANSCRIPT. Only when there is no marker at
+   all. The live conversation is the one that was being written, so mtime orders
+   them — but it is second because it REASONS about the files where the marker
+   REPORTS about the agent.
+
+NEITHER RESOLVING IS A REFUSAL THAT NAMES THE CANDIDATES. A marker pointing at a
+file that was not carried means the transport and the runtime disagree about which
+conversation this agent is having, and picking either one silently would start the
+target on an undefined session — the one failure a byte count cannot catch, and
+the reason ``start_standby`` names the session by id rather than saying "continue".
+Two files sharing the newest mtime is the same situation and gets the same answer.
+
+Pure. Names and timestamps in, a choice or a refusal out — so every path is a test
+with real values, and the same function answers at PREFLIGHT (before anything is
+stopped) and at TRANSPORT.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Mapping, Sequence
+
+__all__ = [
+    "CODE_AMBIGUOUS",
+    "CODE_CHOSEN",
+    "CODE_MARKER_NOT_CARRIED",
+    "CODE_NO_CANDIDATES",
+    "CODE_UNKNOWN",
+    "SessionChoice",
+    "choose_session",
+    "session_id_for",
+    "transcript_name_for",
+]
+
+#: One session was identified, and by what.
+CODE_CHOSEN: Final = 200
+#: Several candidates and nothing to choose between them.
+CODE_AMBIGUOUS: Final = 300
+#: Nothing was carried, so there is no conversation to resume.
+CODE_NO_CANDIDATES: Final = 404
+#: The runtime's marker names a session whose transcript did not travel.
+CODE_MARKER_NOT_CARRIED: Final = 409
+#: Something was not observed. Refuses as firmly as a failure, differently.
+CODE_UNKNOWN: Final = 503
+
+TRANSCRIPT_SUFFIX: Final = ".jsonl"
+
+
+def session_id_for(name: str) -> str:
+    """The session id a transcript file name carries."""
+    base = name.rsplit("/", 1)[-1]
+    return base[: -len(TRANSCRIPT_SUFFIX)] if base.endswith(TRANSCRIPT_SUFFIX) else base
+
+
+def transcript_name_for(session: str) -> str:
+    """The transcript file name a session id would be stored in."""
+    return f"{session}{TRANSCRIPT_SUFFIX}"
+
+
+@dataclass(frozen=True)
+class SessionChoice:
+    """Which session travels, or why one could not be named.
+
+    ``session`` is ``None`` when nothing was chosen; there is deliberately no
+    ``__bool__``, because the next thing that happens with a choice is a marker
+    written onto another machine and a boot that resumes it.
+
+    ``candidates`` always carries what was actually seen, including on success —
+    a choice among four that reports only the winner cannot be reviewed.
+    """
+
+    session: str | None
+    code: int
+    reason: str
+    chosen_by: str = ""
+    candidates: tuple[str, ...] = ()
+    hint: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.reason:
+            raise ValueError("SessionChoice.reason must be non-empty")
+        if self.session is not None and self.code != CODE_CHOSEN:
+            raise ValueError(
+                f"SessionChoice: a chosen session must carry CODE_CHOSEN, got {self.code}"
+            )
+        if self.session is not None and not self.chosen_by:
+            raise ValueError(
+                "SessionChoice: a chosen session must say WHAT chose it — 'the marker' "
+                "and 'the newest file' are different levels of evidence and a reader "
+                "must be able to tell which one they are trusting"
+            )
+        if self.session is None and not self.hint:
+            raise ValueError(
+                "SessionChoice: a refusal must say what to do next — an unresolved "
+                "session stops a relocation, and the operator is the one who resolves it"
+            )
+
+
+def _listed(candidates: Sequence[str]) -> str:
+    return ", ".join(candidates) if candidates else "(none)"
+
+
+def choose_session(
+    *,
+    agent: str,
+    carried: Sequence[str],
+    marker: str | None,
+    mtimes: Mapping[str, int | None] | None = None,
+) -> SessionChoice:
+    """Name the conversation to resume, or refuse naming what was seen.
+
+    ``carried`` are the transcript FILE NAMES that will travel. ``marker`` is the
+    source's ``runtime/<agent>/session_id``: a session id, ``""`` for LOOKED AND
+    FOUND NOTHING, or ``None`` for NOBODY LOOKED — three answers, kept apart,
+    because an unread marker could name a different file than the newest one and
+    is therefore not the same as an absent marker. ``mtimes`` maps each carried
+    name to its modification time in epoch seconds, and is only consulted when
+    there is no marker and more than one candidate.
+    """
+    names = tuple(carried)
+    if not names:
+        return SessionChoice(
+            session=None,
+            code=CODE_NO_CANDIDATES,
+            reason=(
+                f"no transcript was selected for {agent}, so there is no conversation "
+                "to resume on the target"
+            ),
+            hint=(
+                "check the source's project directory and the workdir encoding before "
+                "moving. An agent started with no session resumes nothing, which is the "
+                "2026-08-07 failure: it boots, reports healthy, and has no memory"
+            ),
+        )
+
+    if marker:
+        wanted = transcript_name_for(marker)
+        if wanted in names:
+            return SessionChoice(
+                session=marker,
+                code=CODE_CHOSEN,
+                reason=(
+                    f"{agent}'s own runtime marker names session {marker}, and "
+                    f"{wanted} is among the {len(names)} transcript(s) being carried"
+                ),
+                chosen_by="the source's runtime session marker",
+                candidates=names,
+            )
+        return SessionChoice(
+            session=None,
+            code=CODE_MARKER_NOT_CARRIED,
+            reason=(
+                f"{agent}'s runtime marker names session {marker}, whose transcript "
+                f"{wanted} is NOT among what would be carried: {_listed(names)}"
+            ),
+            candidates=names,
+            hint=(
+                "the runtime and the transport disagree about which conversation this "
+                f"agent is having. Check that {wanted} exists in the source's project "
+                "directory (the workdir encoding is the first thing to look at), or "
+                "correct the marker. Do not let it pick one — a target seeded with the "
+                "wrong session resumes a conversation nobody asked for, and no byte "
+                "count catches it"
+            ),
+        )
+
+    if len(names) == 1:
+        only = names[0]
+        return SessionChoice(
+            session=session_id_for(only),
+            code=CODE_CHOSEN,
+            reason=(
+                f"{only} is the only transcript being carried, so it is the "
+                "conversation to resume"
+            ),
+            chosen_by="the only carried transcript",
+            candidates=names,
+        )
+
+    if marker is None:
+        return SessionChoice(
+            session=None,
+            code=CODE_UNKNOWN,
+            reason=(
+                f"{agent}'s runtime session marker was not read, and there are "
+                f"{len(names)} candidates: {_listed(names)}"
+            ),
+            candidates=names,
+            hint=(
+                "read runtime/<agent>/session_id on the source before deciding. An "
+                "unread marker is not an absent one — it may well name a different "
+                "file from the most recent, and that is precisely the case where "
+                "guessing is wrong"
+            ),
+        )
+
+    times = {n: (mtimes or {}).get(n) for n in names}
+    unmeasured = sorted(n for n, t in times.items() if t is None)
+    if unmeasured:
+        return SessionChoice(
+            session=None,
+            code=CODE_UNKNOWN,
+            reason=(
+                f"{agent} has no session marker and the modification time of "
+                f"{_listed(tuple(unmeasured))} was not measured, so the most recent of "
+                f"{len(names)} candidates cannot be identified"
+            ),
+            candidates=names,
+            hint=(
+                "measure the mtimes on the source and try again, or seed "
+                "runtime/<agent>/session_id there with the session that should travel"
+            ),
+        )
+
+    newest = max(times.values())
+    tied = sorted(n for n, t in times.items() if t == newest)
+    if len(tied) > 1:
+        return SessionChoice(
+            session=None,
+            code=CODE_AMBIGUOUS,
+            reason=(
+                f"{agent} has no session marker and {len(tied)} transcripts share the "
+                f"newest modification time ({newest}): {_listed(tuple(tied))}"
+            ),
+            candidates=names,
+            hint=(
+                "seed runtime/<agent>/session_id on the source with the session that "
+                "should travel, then re-run. Picking either of a tie would start the "
+                "target on an undefined conversation"
+            ),
+        )
+
+    chosen = tied[0]
+    return SessionChoice(
+        session=session_id_for(chosen),
+        code=CODE_CHOSEN,
+        reason=(
+            f"{agent} has no runtime session marker; {chosen} is the most recently "
+            f"modified of {len(names)} carried transcript(s)"
+        ),
+        chosen_by="the most recently modified carried transcript",
+        candidates=names,
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_source_scan.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_source_scan.py
@@ -42,6 +42,7 @@ __all__ = [
     "CommandResult",
     "run_git",
     "scan_repo",
+    "scan_session",
     "scan_source",
 ]
 
@@ -140,3 +141,57 @@ def scan_source(
     function does not try to discover repos on its own.
     """
     return SourceFacts(repos=tuple(scan_repo(p, runner=runner) for p in repo_paths))
+
+
+def scan_session(
+    facts: SourceFacts,
+    *,
+    transcript_dir: str,
+    state_dir: str,
+) -> SourceFacts:
+    """Add the source's transcripts and its runtime session marker to ``facts``.
+
+    Read from the local filesystem for the same reason the repo scan is: the
+    source is where the coordinator runs, and going out to the network to measure
+    the machine the command is on adds ways to fail and no information.
+
+    A DIRECTORY THAT IS NOT THERE IS ``None``, NOT ``()``. The coordinator is
+    usually standing on the source, but it is not guaranteed to be, and a path
+    that does not exist HERE is not evidence that it does not exist THERE.
+    Reporting an empty scan would turn "I am on the wrong machine" into "this
+    agent has no conversation", which is a confident wrong answer about the one
+    thing the relocation exists to carry. A directory that IS there and holds no
+    transcript is ``()`` — that one is a real observation.
+
+    A missing marker file yields ``""`` (looked, absent) and NOT ``None`` (nobody
+    looked): with several transcripts those two lead to different answers, since
+    an unread marker may name a file other than the newest.
+    """
+    from pathlib import Path
+
+    transcripts: tuple[tuple[str, int | None], ...] | None = None
+    directory = Path(transcript_dir) if transcript_dir else None
+    if directory is not None and directory.is_dir():
+        found: list[tuple[str, int | None]] = []
+        for path in sorted(directory.glob("*.jsonl")):
+            try:
+                mtime: int | None = int(path.stat().st_mtime)
+            except OSError:  # stx-allow: fallback (reason: an unreadable mtime must stay UNMEASURED so the choice refuses, never default to 0 and win the "newest" comparison)
+                mtime = None
+            found.append((path.name, mtime))
+        transcripts = tuple(found)
+
+    marker: str | None = None
+    if state_dir:
+        marker_path = Path(state_dir) / "session_id"
+        if marker_path.is_file():
+            try:
+                marker = marker_path.read_text(encoding="utf-8").strip()
+            except OSError:  # stx-allow: fallback (reason: a marker that exists and cannot be read is NOT MEASURED; reading it as absent would silently promote the newest-file rule)
+                marker = None
+        else:
+            marker = ""
+
+    return SourceFacts(
+        repos=facts.repos, transcripts=transcripts, session_marker=marker
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_target_ssh.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_target_ssh.py
@@ -48,6 +48,7 @@ __all__ = [
     "target_home",
     "target_hostname",
     "write_session_marker",
+    "write_text_file",
 ]
 
 MARK_HOME = "TX-HOME="
@@ -215,6 +216,44 @@ def write_session_marker(
     if value is None:
         return None
     return value.strip() or None
+
+
+def write_text_file(
+    shell: Shell,
+    path: str,
+    text: str,
+    *,
+    exec_fn: Callable[..., dict] | None = None,
+) -> int | None:
+    """Write ``text`` to ``path`` on ``shell``; return the byte count IT reports.
+
+    base64 across the wire for the reason the module docstring gives at length:
+    ssh hands ONE string to a remote login shell that re-parses it, and this
+    payload is multi-line prose full of backticks, quotes and colons. base64 is a
+    single word of ``[A-Za-z0-9+/=]`` — there is nothing in it for a shell to
+    interpret, so the text that arrives is the text that left however the prose
+    is later edited.
+
+    The return is a READ-BACK, not the write's exit status: ``wc -c`` on the file
+    the target now holds. ``None`` when the script did not answer, which the
+    caller must treat as NOT MEASURED. A provenance record that cannot be
+    confirmed is one nobody will find when they need it.
+    """
+    encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
+    body = (
+        f'mkdir -p "$(dirname {quote(path)})" 2>/dev/null\n'
+        f"printf '%s' {quote(encoded)} | base64 -d > {quote(path)} 2>/dev/null\n"
+        f"if [ -f {quote(path)} ]; then\n"
+        f"  printf '{MARK_SID}%s\\n' \"$(wc -c < {quote(path)} 2>/dev/null)\"\n"
+        f"else\n"
+        f"  printf '{MARK_SID}{SID_ABSENT}\\n'\n"
+        f"fi"
+    )
+    value = one_marked(shell.run(body, exec_fn=exec_fn), MARK_SID)
+    if value is None:
+        return None
+    text_value = value.strip()
+    return int(text_value) if text_value.isdigit() else None
 
 
 def start_standby(

--- a/src/scitex_agent_container/_lifecycle/_relocate_transport.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_transport.py
@@ -18,14 +18,25 @@ FIVE RULES, EACH FROM A WAY THIS GOES WRONG SILENTLY.
 
    STOPPED IS NOT THE SAME INSTANT AS QUIESCENT, which is rule 5.
 
-2. ONLY TRANSCRIPTS TRAVEL — AN ALLOWLIST, NOT A DENYLIST. Just ``*.jsonl`` from
-   the project directory. A denylist is a list of the secrets somebody thought
-   of; the first credential file named something new travels. The one that
-   matters here is ``~/.claude/.credentials.json``, which sits one level ABOVE
-   the projects store and so is already outside the transfer root — the
-   allowlist refuses it a second time, and :data:`CREDENTIAL_BASENAMES` names it
-   so the refusal is greppable and can be asserted by name rather than inferred
-   from a suffix rule.
+2. THE ALLOWLIST IS ``*.jsonl`` AND ``memory/`` — AN ALLOWLIST, NOT A DENYLIST.
+   A denylist is a list of the secrets somebody thought of; the first credential
+   file named something new travels. The one that matters here is
+   ``~/.claude/.credentials.json``, which sits one level ABOVE the projects store
+   and so is already outside the transfer root — the allowlist refuses it a
+   second time, and :data:`CREDENTIAL_BASENAMES` names it so the refusal is
+   greppable and can be asserted by name rather than inferred from a suffix rule.
+
+   ``memory/`` WAS ADDED BECAUSE LEAVING IT BEHIND WAS MEASURED. On 2026-08-11 a
+   completed relocation logged ``REFUSED memory — only conversation transcripts
+   (.jsonl) travel; this is not one`` and landed an agent whose target ``memory/``
+   was EMPTY while nine files and 20,014 bytes stayed on the source — two of them
+   written that same evening from the operator's own corrections. THE TRANSCRIPT
+   IS THE CONVERSATION; MEMORY IS THE RULES DISTILLED FROM IT. Carrying only the
+   first moves an agent that can recall what was said and has lost every rule it
+   wrote for itself.
+
+   It travels WHOLE, by tar, not by the snapshot path: a memory note is not an
+   append-only log being flushed, so there is no last newline to cut at.
 
 3. NOTHING IS OVERWRITTEN AND NOTHING IS DELETED. A relocation target may well
    have been this agent's home before, and what is there is the only copy of
@@ -88,11 +99,13 @@ __all__ = [
     "CODE_TRUNCATED",
     "CODE_UNKNOWN",
     "CREDENTIAL_BASENAMES",
+    "MEMORY_DIRNAME",
     "TRANSCRIPT_SUFFIX",
     "ArrivalVerdict",
     "MoveAside",
     "TranscriptFile",
     "TransportPlan",
+    "is_carried_directory",
     "is_transferable",
     "move_aside_destination",
     "plan_transport",
@@ -101,8 +114,13 @@ __all__ = [
     "verify_arrival",
 ]
 
-#: The ONLY suffix that travels. An allowlist — see rule 2 in the module docstring.
+#: The ONLY suffix that travels as a transcript. See rule 2 in the module docstring.
 TRANSCRIPT_SUFFIX: Final = ".jsonl"
+
+#: The one DIRECTORY on the allowlist. The rules an agent distilled from its
+#: conversations, which a relocation carrying only the conversation leaves behind
+#: — measured 2026-08-11, nine files and 20,014 bytes stranded on the source.
+MEMORY_DIRNAME: Final = "memory"
 
 #: Credential files, named so the exclusion can be asserted BY NAME. These live
 #: at ``~/.claude/.credentials.json``, above the projects store, so they are
@@ -130,6 +148,11 @@ def is_transferable(name: str) -> bool:
     return base.endswith(TRANSCRIPT_SUFFIX) and len(base) > len(TRANSCRIPT_SUFFIX)
 
 
+def is_carried_directory(name: str) -> bool:
+    """True for the one directory on the allowlist. Travels whole, never snapshotted."""
+    return name.rsplit("/", 1)[-1] == MEMORY_DIRNAME
+
+
 def refusal_for(name: str) -> str:
     """Why ``name`` is not travelling, in words a report can print."""
     base = name.rsplit("/", 1)[-1]
@@ -139,7 +162,9 @@ def refusal_for(name: str) -> str:
             "one would leave two hosts holding one identity's secret"
         )
     return (
-        f"only conversation transcripts ({TRANSCRIPT_SUFFIX}) travel; this is not one"
+        f"the allowlist carries conversation transcripts ({TRANSCRIPT_SUFFIX}) and "
+        f"{MEMORY_DIRNAME}/; this is neither. It stays on the source, which is never "
+        "deleted, so it remains there to be inspected or fetched by hand"
     )
 
 
@@ -178,6 +203,9 @@ class TransportPlan:
     code: int
     reason: str
     files: tuple[str, ...] = ()
+    #: Whole directories on the allowlist (``memory/``). Carried by tar, never
+    #: snapshotted — see :func:`select_transferable`.
+    directories: tuple[str, ...] = ()
     refused: tuple[tuple[str, str], ...] = ()
     move_aside: MoveAside | None = None
     hint: str = ""
@@ -207,22 +235,33 @@ class TransportPlan:
 
 def select_transferable(
     names: Sequence[str],
-) -> tuple[tuple[str, ...], tuple[tuple[str, str], ...]]:
-    """Split ``names`` into what travels and what is refused, with reasons.
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[tuple[str, str], ...]]:
+    """Split ``names`` into transcripts, directories, and what is refused.
 
-    Returns ``(carried, refused)`` where ``refused`` pairs each name with the
-    sentence explaining it. The refusals are RETURNED rather than dropped so a
-    report can show that a credential was seen and declined — a filter whose
-    output is only the survivors cannot be told from one that never ran.
+    Returns ``(transcripts, directories, refused)``. The two carried kinds are
+    kept APART rather than merged into one list because they are carried by
+    different means and for different reasons: a transcript travels up to a
+    recorded byte offset, a directory travels whole. A caller holding one list
+    would have to re-derive which is which, and the first one to get that wrong
+    would either snapshot a directory or carry a live log unbounded.
+
+    ``refused`` pairs each remaining name with the sentence explaining it. The
+    refusals are RETURNED rather than dropped so a report — and now the
+    provenance record on the target — can show that something was seen and
+    declined. A filter whose output is only the survivors cannot be told from one
+    that never ran.
     """
-    carried: list[str] = []
+    transcripts: list[str] = []
+    directories: list[str] = []
     refused: list[tuple[str, str]] = []
     for name in names:
         if is_transferable(name):
-            carried.append(name)
+            transcripts.append(name)
+        elif is_carried_directory(name):
+            directories.append(name)
         else:
             refused.append((name, refusal_for(name)))
-    return tuple(carried), tuple(refused)
+    return tuple(transcripts), tuple(directories), tuple(refused)
 
 
 def plan_transport(
@@ -299,7 +338,7 @@ def plan_transport(
             ),
         )
 
-    carried, refused = select_transferable(source_files)
+    carried, directories, refused = select_transferable(source_files)
     if not carried:
         return TransportPlan(
             proceed=False,
@@ -307,6 +346,7 @@ def plan_transport(
             reason=(
                 "the source project directory holds no conversation transcript to move"
             ),
+            directories=directories,
             refused=refused,
             hint=(
                 "confirm this is right before continuing — the agent will start on "
@@ -321,6 +361,7 @@ def plan_transport(
             code=CODE_UNKNOWN,
             reason="whether the target already holds a transcript directory was not observed",
             files=carried,
+            directories=directories,
             refused=refused,
             hint=(
                 "check the destination before writing to it. A relocation target may "
@@ -345,13 +386,15 @@ def plan_transport(
             reason="the destination is empty; nothing to preserve",
         )
 
+    carrying = f"{len(carried)} transcript(s)" + (
+        f" and {'/, '.join(directories)}/" if directories else ""
+    )
     return TransportPlan(
         proceed=True,
         code=CODE_READY,
-        reason=(
-            f"{len(carried)} transcript(s) to copy into {target_dir}; source is stopped"
-        ),
+        reason=f"{carrying} to copy into {target_dir}; source is stopped",
         files=carried,
+        directories=directories,
         refused=refused,
         move_aside=move,
     )

--- a/src/scitex_agent_container/_lifecycle/_relocate_transport.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_transport.py
@@ -3,9 +3,10 @@
 :mod:`_relocate_transcript` verifies ONE payload by digest. This is the phase
 around it: what is allowed to travel, what to do about a target that already
 holds something, and how arrival is confirmed for a SET of files where each one
-can fail on its own.
+can fail on its own. The arrival half lives in
+:mod:`_relocate_transport_verify` and is re-exported here.
 
-FOUR RULES, EACH FROM A WAY THIS GOES WRONG SILENTLY.
+FIVE RULES, EACH FROM A WAY THIS GOES WRONG SILENTLY.
 
 1. THE SOURCE MUST BE STOPPED. A running agent appends to its ``.jsonl`` while it
    is being read, so the copy is a prefix ending mid-line. jsonl has no trailer
@@ -14,6 +15,8 @@ FOUR RULES, EACH FROM A WAY THIS GOES WRONG SILENTLY.
    transfer, because no transfer is visible and this is not. An unobserved
    "is it running" is UNKNOWN and refuses just as firmly: the question is
    cheap to ask and the failure is silent.
+
+   STOPPED IS NOT THE SAME INSTANT AS QUIESCENT, which is rule 5.
 
 2. ONLY TRANSCRIPTS TRAVEL — AN ALLOWLIST, NOT A DENYLIST. Just ``*.jsonl`` from
    the project directory. A denylist is a list of the secrets somebody thought
@@ -35,9 +38,19 @@ FOUR RULES, EACH FROM A WAY THIS GOES WRONG SILENTLY.
    exited 0. Bytes AND lines are compared for every file, because the two catch
    different things: bytes catch a truncated write, lines catch the case where a
    transport rewrote line endings and left the size plausible. A file the target
-   does not have at all is its own outcome, distinct from one that arrived short
-   — the first means the copy did not happen, the second means it happened
-   badly, and they call for different next moves.
+   does not have at all is its own outcome, distinct from one that arrived short,
+   which is distinct again from one that arrived LARGER — see
+   :mod:`_relocate_transport_verify`, which owns that half.
+
+5. WHAT TRAVELS IS A SNAPSHOT TAKEN AT ONE INSTANT, CUT AT THE LAST NEWLINE.
+   Before anything moves, each file's byte offset of its last COMPLETE line is
+   recorded; exactly that many bytes are carried; and arrival is checked against
+   THAT RECORDED NUMBER rather than against a fresh reading of a source that may
+   have moved since. That removes the race instead of narrowing it. Cutting at
+   the last newline specifically is what keeps the target's final line whole: an
+   arbitrary offset lands mid-record and produces malformed JSON inside an
+   otherwise valid JSONL file, which is worse than a shorter file. Losing at most
+   one partially-written record is the accepted trade.
 
 AN EXTRA FILE ON THE TARGET IS NOT A FAILURE. The destination is the agent's own
 projects directory and may legitimately hold other conversations. Every file that
@@ -54,6 +67,16 @@ from dataclasses import dataclass
 from typing import Final, Sequence
 
 from ._relocate_move_aside import move_aside_destination
+from ._relocate_transport_verify import (
+    CODE_ARRIVED,
+    CODE_MISSING_ON_TARGET,
+    CODE_TARGET_LARGER,
+    CODE_TRUNCATED,
+    CODE_UNKNOWN,
+    ArrivalVerdict,
+    TranscriptFile,
+    verify_arrival,
+)
 
 __all__ = [
     "CODE_ARRIVED",
@@ -61,6 +84,7 @@ __all__ = [
     "CODE_NOTHING_TO_CARRY",
     "CODE_READY",
     "CODE_SOURCE_RUNNING",
+    "CODE_TARGET_LARGER",
     "CODE_TRUNCATED",
     "CODE_UNKNOWN",
     "CREDENTIAL_BASENAMES",
@@ -96,14 +120,6 @@ CODE_READY: Final = 200
 CODE_NOTHING_TO_CARRY: Final = 204
 #: The source agent is still running; copying now yields a torn transcript.
 CODE_SOURCE_RUNNING: Final = 409
-#: Every file that left arrived with matching bytes and lines.
-CODE_ARRIVED: Final = 200
-#: A file that left is absent on the target. The copy did not happen.
-CODE_MISSING_ON_TARGET: Final = 404
-#: A file arrived with fewer bytes or lines than it left with.
-CODE_TRUNCATED: Final = 422
-#: Something was not observed. Refuses as firmly as a failure, differently.
-CODE_UNKNOWN: Final = 503
 
 
 def is_transferable(name: str) -> bool:
@@ -125,29 +141,6 @@ def refusal_for(name: str) -> str:
     return (
         f"only conversation transcripts ({TRANSCRIPT_SUFFIX}) travel; this is not one"
     )
-
-
-@dataclass(frozen=True)
-class TranscriptFile:
-    """One transcript, as MEASURED on one side of the copy.
-
-    ``byte_count`` and ``line_count`` are ``| None`` for NOT MEASURED, which is
-    deliberately distinct from ``0``. An empty file and a measurement that did
-    not run look identical to a caller that collapses them, and the second must
-    refuse where the first may not.
-    """
-
-    name: str
-    byte_count: int | None = None
-    line_count: int | None = None
-
-    def __post_init__(self) -> None:
-        if not self.name:
-            raise ValueError("TranscriptFile.name must be non-empty")
-
-    @property
-    def measured(self) -> bool:
-        return self.byte_count is not None and self.line_count is not None
 
 
 @dataclass(frozen=True)
@@ -210,41 +203,6 @@ class TransportPlan:
             raise ValueError(
                 "TransportPlan: a plan that does not proceed must say what to do next"
             )
-
-
-@dataclass(frozen=True)
-class ArrivalVerdict:
-    """Whether everything that left arrived intact, with the evidence attached.
-
-    ``arrived`` is three-valued, no ``__bool__``. ``mismatches`` carries one line
-    per offending file so a report names WHICH file and BY HOW MUCH, rather than
-    saying the transfer failed and leaving the reader to go and diff two hosts.
-    """
-
-    arrived: bool | None
-    code: int
-    reason: str
-    mismatches: tuple[str, ...] = ()
-    verified: tuple[str, ...] = ()
-    hint: str = ""
-
-    def __post_init__(self) -> None:
-        if self.arrived not in (True, False, None):
-            raise ValueError(
-                f"ArrivalVerdict.arrived must be True/False/None, got {self.arrived!r}"
-            )
-        if not self.reason:
-            raise ValueError("ArrivalVerdict.reason must be non-empty")
-        if self.arrived is True and self.code != CODE_ARRIVED:
-            raise ValueError(
-                f"ArrivalVerdict: arrived=True must carry CODE_ARRIVED, got {self.code}"
-            )
-        if self.arrived is True and self.mismatches:
-            raise ValueError(
-                "ArrivalVerdict: an arrival with mismatches is unrepresentable"
-            )
-        if self.arrived is not True and not self.hint:
-            raise ValueError("ArrivalVerdict: a non-arrival must say what to do next")
 
 
 def select_transferable(
@@ -399,92 +357,8 @@ def plan_transport(
     )
 
 
-def verify_arrival(
-    *,
-    sent: Sequence[TranscriptFile],
-    landed: Sequence[TranscriptFile],
-) -> ArrivalVerdict:
-    """Compare what left with what the TARGET now holds, per file.
-
-    ``sent`` is measured on the source, ``landed`` on the target, each carrying
-    a byte count and a line count. Every file in ``sent`` must appear in
-    ``landed`` with both numbers equal. Files present only in ``landed`` are
-    ignored — the destination is the agent's own projects directory and may hold
-    other conversations, which is not evidence of a bad copy.
-
-    An unmeasured count on either side is UNKNOWN, not a pass. "I could not
-    count it" and "it counted the same" are the two answers this function exists
-    to keep apart.
-    """
-    if not sent:
-        return ArrivalVerdict(
-            arrived=None,
-            code=CODE_UNKNOWN,
-            reason="nothing was recorded as sent, so there is nothing to confirm",
-            hint=(
-                "measure the source files before the copy; without a baseline the "
-                "target's contents cannot be checked against anything"
-            ),
-        )
-
-    by_name = {f.name: f for f in landed}
-    mismatches: list[str] = []
-    verified: list[str] = []
-    unmeasured: list[str] = []
-
-    for src in sent:
-        if not src.measured:
-            unmeasured.append(f"{src.name}: not measured on the source")
-            continue
-        tgt = by_name.get(src.name)
-        if tgt is None:
-            mismatches.append(f"{src.name}: absent on the target")
-            continue
-        if not tgt.measured:
-            unmeasured.append(f"{src.name}: not measured on the target")
-            continue
-        if tgt.byte_count != src.byte_count or tgt.line_count != src.line_count:
-            mismatches.append(
-                f"{src.name}: sent {src.byte_count} bytes / {src.line_count} lines, "
-                f"target holds {tgt.byte_count} bytes / {tgt.line_count} lines"
-            )
-            continue
-        verified.append(src.name)
-
-    if unmeasured:
-        return ArrivalVerdict(
-            arrived=None,
-            code=CODE_UNKNOWN,
-            reason="the copy could not be confirmed: " + "; ".join(unmeasured),
-            mismatches=tuple(mismatches),
-            verified=tuple(verified),
-            hint=(
-                "count bytes and lines on BOTH sides and compare again. A copy that "
-                "cannot be checked has not succeeded — do not hand over the lease on it"
-            ),
-        )
-
-    if mismatches:
-        absent = all("absent on the target" in m for m in mismatches)
-        return ArrivalVerdict(
-            arrived=False,
-            code=CODE_MISSING_ON_TARGET if absent else CODE_TRUNCATED,
-            reason="the target's copy does not match what was sent",
-            mismatches=tuple(mismatches),
-            verified=tuple(verified),
-            hint=(
-                "do NOT continue the relocation. Move the target's partial copy aside "
-                "and re-run the transport; a short transcript resumes without error "
-                "and simply forgets the end of the conversation"
-            ),
-        )
-
-    return ArrivalVerdict(
-        arrived=True,
-        code=CODE_ARRIVED,
-        reason=(
-            f"all {len(verified)} transcript(s) verified on the target by byte and "
-            "line count"
-        ),
-        verified=tuple(verified),
-    )
+# :func:`verify_arrival`, :class:`ArrivalVerdict`, :class:`TranscriptFile` and the
+# arrival codes now live in :mod:`_relocate_transport_verify` and are re-exported
+# above. They are the same public surface; the split is by QUESTION — what may
+# travel, versus did it arrive — because the second half grew a snapshot baseline
+# and a short/larger distinction, and the file has a line budget.

--- a/src/scitex_agent_container/_lifecycle/_relocate_transport_ssh.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_transport_ssh.py
@@ -71,7 +71,9 @@ __all__ = [
     "MARK_FILE",
     "MARK_MOVED",
     "build_copy_argv",
+    "build_tree_copy_argv",
     "copy_transcripts",
+    "copy_tree",
     "ensure_dir",
     "list_transcript_dir",
     "measure_transcripts",
@@ -378,6 +380,94 @@ def build_copy_argv(
         + f" && printf '{MARK_DIR}yes\\n'"
     )
     return ["bash", "-c", pipeline]
+
+
+def build_tree_copy_argv(
+    *,
+    source: Shell,
+    source_dir: str,
+    target: Shell,
+    target_dir: str,
+    names: Sequence[str],
+    peers=None,
+) -> list[str]:
+    """The argv that carries WHOLE entries — a directory, or a file in full.
+
+    THE SNAPSHOT DOES NOT APPLY HERE, and that is the distinction between this
+    and :func:`build_copy_argv`. A transcript is an append-only log being written
+    by a process that may still be flushing, so it is carried up to a recorded
+    offset. A spec directory and a ``memory/`` directory are neither append-only
+    nor open: there is no last-newline to cut at, and half of one is not a
+    shorter version of it. They travel whole, by tar.
+
+    tar's original argument still holds for these: ``tar -C <dir> -cf - -- <name>``
+    takes exactly the named entries, recursing into a directory as ONE name, and
+    nothing is re-expanded by a shell on either side. A glob would be re-expanded
+    at copy time, which turns an allowlist into "whatever matched a moment later".
+    """
+    if not names:
+        raise ValueError(
+            "build_tree_copy_argv refuses an empty list — a copy that transfers "
+            "nothing and exits 0 is the failure shape this feature exists to prevent"
+        )
+    bad = [n for n in names if "/" in n or n in ("", ".", "..")]
+    if bad:
+        raise ValueError(
+            f"build_tree_copy_argv takes bare entry names, got {bad!r}. A path component "
+            "here would place the copy outside the directory the allowlist was applied to"
+        )
+    named_secrets = [n for n in names if n in CREDENTIAL_BASENAMES]
+    if named_secrets:
+        raise ValueError(
+            f"build_tree_copy_argv refuses to carry {named_secrets!r}: a credential is "
+            "never copied — the target re-issues its own"
+        )
+
+    produce: list[str] = ["tar", "-C", source_dir, "-cf", "-", "--", *names]
+    if not source.is_local:
+        produce = build_probe_argv(
+            source.host, source.script(shlex.join(produce)), peers
+        )
+    extract = (
+        f"mkdir -p {quote(target_dir)} && tar -C {quote(target_dir)} -xf - && "
+        f"printf '{MARK_DIR}yes\\n'"
+    )
+    consume = build_probe_argv(target.host, target.script(extract), peers)
+    pipeline = f"set -o pipefail; {shlex.join(produce)} | {shlex.join(consume)}"
+    return ["bash", "-c", pipeline]
+
+
+def copy_tree(
+    *,
+    source: Shell,
+    source_dir: str,
+    target: Shell,
+    target_dir: str,
+    names: Sequence[str],
+    exec_fn: Callable[..., dict] | None = None,
+    timeout_s: float = DEFAULT_COPY_TIMEOUT_S,
+    peers=None,
+) -> RemoteRun:
+    """Carry whole entries between two hosts over one ssh. Caller must verify.
+
+    Used for the spec directory and for ``memory/``. Arrival is confirmed by
+    listing and sizing the tree on BOTH hosts (:func:`.._relocate_target_ssh.
+    list_tree`), never by this return value.
+    """
+    argv = build_tree_copy_argv(
+        source=source,
+        source_dir=source_dir,
+        target=target,
+        target_dir=target_dir,
+        names=names,
+        peers=peers,
+    )
+    return run_argv_on_host(
+        argv,
+        exec_fn=exec_fn,
+        timeout_s=timeout_s,
+        what=f"the host, copying {source.host}:{source_dir} -> {target.host}:{target_dir}",
+    )
 
 
 def copy_transcripts(

--- a/src/scitex_agent_container/_lifecycle/_relocate_transport_ssh.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_transport_ssh.py
@@ -7,19 +7,34 @@ the adapters that list a directory, move bytes between two hosts, and measure th
 result WHERE IT LANDED. The plumbing they run on lives in
 :mod:`_relocate_shell` — one route, one place it can be wrong.
 
-WHY tar-OVER-ssh, AND NOT scp OR rsync. The decisive reason is the allowlist.
-:func:`.._relocate_transport.select_transferable` returns an EXACT set of names,
-and ``tar -C <dir> -cf - -- <name> <name>`` takes exactly those names as
-arguments. Nothing is expanded here and nothing is expanded on the far side, so
-what travels is the set that was decided. A glob like ``*.jsonl`` would be
-re-expanded by a shell at copy time, which turns an allowlist into "whatever
-matched the pattern a moment later" — including anything created in between.
-Two lesser reasons: rsync must exist on BOTH ends and does not on the fleet's
-busybox targets, and scp would need either one connection per file or a remote
-glob, which is the first problem again. tar is one connection, one exact file
-list, and it rides the same ``-J`` jump chain every other sac ssh call uses.
+WHAT TRAVELS IS A SNAPSHOT, AND THE SNAPSHOT IS TAKEN FIRST. Before a byte moves,
+:func:`snapshot_transcripts` records, per file, the offset of the LAST NEWLINE and
+the number of complete lines at that instant. The copy carries exactly that many
+bytes and arrival is checked against exactly those numbers. The source is then
+free to grow underneath the transfer without changing the answer — which is the
+whole point, because on 2026-08-12 it did: the file was 11,717 bytes longer when
+it was read than when it was measured, on an identical line count, and the
+relocation aborted 422 over bytes that were never lost.
 
-A PIPELINE'S EXIT CODE IS EVIDENCE, NEVER PROOF. ``tar | ssh tar`` exiting 0 says
+WHY head -c PER FILE, AND NOT tar, scp OR rsync. tar was the earlier choice and
+its argument still holds for names: an allowlist decided an EXACT set, and a glob
+re-expanded by a shell at copy time would carry whatever matched a moment later.
+What tar cannot do is carry PART of a file, and a whole file is by definition not
+a snapshot. ``head -c <recorded-offset> -- <path>`` is the bounded read stated
+directly, it is present everywhere in this fleet (GNU, busybox and BSD all have
+it, unlike ``truncate``), it moves only the bytes that were promised, and the path
+is built here rather than expanded anywhere, so nothing globs on either side.
+
+THE COST IS ONE SSH PER FILE, AND IT IS PAID KNOWINGLY. tar was one connection for
+the whole set; this is one per transcript, chained under ``&&`` in a single
+host-side ``bash -c`` so the whole thing is still one ``host_exec`` and one exit
+code. Measured before choosing it: the busiest project directory on this fleet
+holds six transcripts, so the connection count is single digits. Truncating on the
+TARGET instead would keep one connection, but it would ship the extra bytes and
+then throw them away, and it would need ``truncate`` or a temp-file rewrite on
+hosts that may have neither.
+
+A PIPELINE'S EXIT CODE IS EVIDENCE, NEVER PROOF. ``head | ssh cat`` exiting 0 says
 two processes exited 0; it says nothing about what is on the disk at the other
 end. So the exit code is returned and reported, and the ANSWER comes from
 :func:`measure_transcripts` run ON THE TARGET — ``wc -c`` and ``wc -l`` executed
@@ -62,6 +77,7 @@ __all__ = [
     "measure_transcripts",
     "move_dir_aside",
     "parse_measurements",
+    "snapshot_transcripts",
 ]
 
 MARK_DIR = "TX-DIR="
@@ -138,6 +154,50 @@ def measure_transcripts(
             f"if [ -f {quote(name)} ]; then\n"
             f"  __b=$(wc -c < {quote(name)} 2>/dev/null)\n"
             f"  __l=$(wc -l < {quote(name)} 2>/dev/null)\n"
+            f'  printf \'{MARK_FILE}%s\\t%s\\t%s\\n\' {quote(name)} "$__b" "$__l"\n'
+            f"else\n"
+            f"  printf '{MARK_ABSENT}%s\\n' {quote(name)}\n"
+            f"fi"
+        )
+    return parse_measurements(shell.run("\n".join(parts), exec_fn=exec_fn))
+
+
+def snapshot_transcripts(
+    shell: Shell,
+    directory: str,
+    names: Sequence[str],
+    *,
+    exec_fn: Callable[..., dict] | None = None,
+) -> tuple[TranscriptFile, ...]:
+    """The PREFIX of each file that will travel: whole lines only, measured once.
+
+    Returns the same :class:`TranscriptFile` shape as :func:`measure_transcripts`,
+    but the counts describe the SNAPSHOT rather than the file: ``byte_count`` is
+    the offset of the last newline and ``line_count`` the number of complete lines
+    at the instant this ran. Those two numbers are the contract for everything
+    downstream — the copy is bounded by the first and arrival is checked against
+    both, so a source that grows afterwards does not change the answer.
+
+    The offset is computed as ``head -n <complete-lines> | wc -c``, which is the
+    definition rather than an approximation of it: the bytes of the first L lines
+    ARE the bytes up to and including the last newline. It is POSIX, it needs no
+    ``stat`` spelling, and it gives the same answer on every host in the fleet.
+    Deliberately NOT ``wc -c`` minus a guess: cutting anywhere but a newline hands
+    the target a torn final record, which is malformed JSON inside a file that
+    still parses as JSONL everywhere else.
+
+    A file whose line count could not be taken comes back with ``line_count=None``
+    — NOT MEASURED, which verification treats as UNKNOWN and which
+    :func:`build_copy_argv` refuses to carry.
+    """
+    if not names:
+        return ()
+    parts = [f"cd {quote(directory)} 2>/dev/null || exit 0"]
+    for name in names:
+        parts.append(
+            f"if [ -f {quote(name)} ]; then\n"
+            f"  __l=$(wc -l < {quote(name)} 2>/dev/null)\n"
+            f'  __b=$(head -n "$__l" < {quote(name)} 2>/dev/null | wc -c)\n'
             f'  printf \'{MARK_FILE}%s\\t%s\\t%s\\n\' {quote(name)} "$__b" "$__l"\n'
             f"else\n"
             f"  printf '{MARK_ABSENT}%s\\n' {quote(name)}\n"
@@ -229,33 +289,14 @@ def move_dir_aside(
     return None if answer is None else answer in ("yes", "vacuous")
 
 
-def build_copy_argv(
-    *,
-    source: Shell,
-    source_dir: str,
-    target: Shell,
-    target_dir: str,
-    files: Sequence[str],
-    peers=None,
-) -> list[str]:
-    """The argv the BARE HOST runs to move exactly ``files`` and nothing else.
-
-    A pure function so the command itself can be asserted in a test — the thing
-    most worth pinning is that the file list is passed as ARGUMENTS and that no
-    glob character reaches either shell.
-
-    ``set -o pipefail`` is why this is ``bash -c`` and not ``sh -c``: without it
-    the pipeline reports only the LAST stage's status, so a source-side tar that
-    failed outright would be masked by an ssh that cheerfully extracted nothing.
-    The exit code is still only evidence — arrival is decided by counting on the
-    target — but evidence that lies is worse than none.
-    """
+def _refuse_bad_snapshots(files: Sequence[TranscriptFile]) -> None:
+    """Every reason a named snapshot must not be carried, raised before anything runs."""
     if not files:
         raise ValueError(
             "build_copy_argv refuses an empty file list — a copy that transfers "
             "nothing and exits 0 is the failure shape this feature exists to prevent"
         )
-    bad = [f for f in files if "/" in f or f in ("", ".", "..")]
+    bad = [f.name for f in files if "/" in f.name or f.name in ("", ".", "..")]
     if bad:
         raise ValueError(
             f"build_copy_argv takes bare file names, got {bad!r}. A path component here "
@@ -266,27 +307,76 @@ def build_copy_argv(
     # declines these, but this function is generic — it will carry any named file
     # — and a transport that would copy a credential if asked is one that
     # eventually does.
-    named_secrets = [f for f in files if f in CREDENTIAL_BASENAMES]
+    named_secrets = [f.name for f in files if f.name in CREDENTIAL_BASENAMES]
     if named_secrets:
         raise ValueError(
             f"build_copy_argv refuses to carry {named_secrets!r}: a credential is never "
             "copied — the target re-issues its own. Carrying one leaves two hosts holding "
             "one identity's secret, and the source's copy outliving the source"
         )
-
-    produce: list[str] = ["tar", "-C", source_dir, "-cf", "-", "--", *files]
-    if not source.is_local:
-        produce = build_probe_argv(
-            source.host, source.script(shlex.join(produce)), peers
+    unbounded = [f.name for f in files if f.byte_count is None or f.byte_count < 0]
+    if unbounded:
+        raise ValueError(
+            f"build_copy_argv refuses to carry {unbounded!r} with no recorded byte "
+            "offset. The snapshot IS the bound: copying 'however much is there now' "
+            "restores the race the offset was introduced to remove, and the resulting "
+            "mismatch would be reported against a source that had already moved"
         )
 
-    extract = (
-        f"mkdir -p {quote(target_dir)} && tar -C {quote(target_dir)} -xf - && "
-        f"printf '{MARK_DIR}yes\\n'"
-    )
-    consume = build_probe_argv(target.host, target.script(extract), peers)
 
-    pipeline = f"set -o pipefail; {shlex.join(produce)} | {shlex.join(consume)}"
+def build_copy_argv(
+    *,
+    source: Shell,
+    source_dir: str,
+    target: Shell,
+    target_dir: str,
+    files: Sequence[TranscriptFile],
+    peers=None,
+) -> list[str]:
+    """The argv the BARE HOST runs to move exactly these SNAPSHOTS and nothing else.
+
+    ``files`` are snapshots from :func:`snapshot_transcripts`, not bare names:
+    each carries the byte offset that bounds its read. A pure function so the
+    command itself can be asserted in a test — the two things most worth pinning
+    are that no glob character reaches either shell and that every stage is
+    bounded by a number recorded before the copy began.
+
+    ``set -o pipefail`` is why this is ``bash -c`` and not ``sh -c``: without it
+    a pipeline reports only the LAST stage's status, so a source-side read that
+    failed outright would be masked by an ssh that cheerfully wrote nothing. The
+    stages are chained with ``&&`` so the first failure stops the rest. The exit
+    code is still only evidence — arrival is decided by counting on the target —
+    but evidence that lies is worse than none.
+    """
+    _refuse_bad_snapshots(files)
+
+    stages: list[str] = []
+    for snapshot in files:
+        read = [
+            "head",
+            "-c",
+            str(int(snapshot.byte_count or 0)),
+            "--",
+            f"{source_dir.rstrip('/')}/{snapshot.name}",
+        ]
+        produce = (
+            read
+            if source.is_local
+            else build_probe_argv(source.host, source.script(shlex.join(read)), peers)
+        )
+        landing = f"{target_dir.rstrip('/')}/{snapshot.name}"
+        write = (
+            f"mkdir -p {quote(target_dir)} && cat > {quote(landing)} && "
+            f"printf '{MARK_FILE}%s\\n' {quote(snapshot.name)}"
+        )
+        consume = build_probe_argv(target.host, target.script(write), peers)
+        stages.append(f"{shlex.join(produce)} | {shlex.join(consume)}")
+
+    pipeline = (
+        "set -o pipefail; "
+        + " && ".join(stages)
+        + f" && printf '{MARK_DIR}yes\\n'"
+    )
     return ["bash", "-c", pipeline]
 
 
@@ -296,16 +386,17 @@ def copy_transcripts(
     source_dir: str,
     target: Shell,
     target_dir: str,
-    files: Sequence[str],
+    files: Sequence[TranscriptFile],
     exec_fn: Callable[..., dict] | None = None,
     timeout_s: float = DEFAULT_COPY_TIMEOUT_S,
     peers=None,
 ) -> RemoteRun:
-    """Stream ``files`` from ``source_dir`` into ``target_dir`` over one ssh.
+    """Stream each snapshot from ``source_dir`` into ``target_dir``, bounded by its offset.
 
     Returns the pipeline's :class:`RemoteRun`. THE CALLER MUST STILL VERIFY: this
-    return value says two processes exited, and the only statement worth making
-    is the one :func:`measure_transcripts` makes afterwards, on the target.
+    return value says some processes exited, and the only statement worth making
+    is the one :func:`measure_transcripts` makes afterwards, on the target,
+    against the snapshot numbers.
     """
     argv = build_copy_argv(
         source=source,

--- a/src/scitex_agent_container/_lifecycle/_relocate_transport_verify.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_transport_verify.py
@@ -1,0 +1,323 @@
+"""Did what left arrive? Compared per file, against the numbers RECORDED BEFORE THE COPY.
+
+Split from :mod:`_relocate_transport`, which decides what may travel. This half
+decides whether it got there, and it is the only statement the transport makes
+about success — a pipeline's exit code says two processes exited.
+
+THE BASELINE IS A SNAPSHOT, NOT A SECOND LOOK AT THE SOURCE. ``sent`` is measured
+once, before anything moves, and the copy is bounded by that measurement (see
+:func:`.._relocate_transport_ssh.snapshot_transcripts`). Re-measuring the source
+afterwards and comparing THAT to the target is the race this feature was rewritten
+to remove: the source is entitled to change between the two readings, and when it
+does, the comparison reports a corruption that never happened.
+
+SHORT AND LARGER ARE DIFFERENT ANSWERS. Measured 2026-08-12, on a real relocation
+that aborted 422::
+
+    MISMATCH b68520e1-….jsonl:
+      sent   108,412,278 bytes / 58,325 lines
+      target 108,423,995 bytes / 58,325 lines
+
+Read the shape: identical LINE counts, 11,717 bytes apart, and the TARGET holds
+MORE. No record was appended — the last line got longer. The agent had already
+been stopped and the stop had been confirmed; what grew the file was the dying
+process's shutdown flush finishing its final line after tmux had let go of the
+session. The report called that "fewer bytes or lines than it left with", which
+sends the reader hunting for bytes lost in transit that were never lost.
+
+    ``target < sent``   bytes went missing; the copy is suspect.
+    ``target > sent``   nothing went missing; the source moved after we measured
+                        it, and the target's copy is the more complete one.
+
+Both refuse — a checker that cannot say WHY must stop — but they carry different
+codes and name different next moves.
+
+AN UNMEASURED COUNT ON EITHER SIDE IS UNKNOWN, NOT A PASS. "I could not count it"
+and "it counted the same" are the two answers this module exists to keep apart.
+
+Pure. No filesystem, no ssh, no clock — observations in, a verdict out, so every
+refusal path is a test with real values rather than a second machine.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Sequence
+
+__all__ = [
+    "CODE_ARRIVED",
+    "CODE_MISSING_ON_TARGET",
+    "CODE_TARGET_LARGER",
+    "CODE_TRUNCATED",
+    "CODE_UNKNOWN",
+    "ArrivalVerdict",
+    "TranscriptFile",
+    "verify_arrival",
+]
+
+#: Every file that left arrived with matching bytes and lines.
+CODE_ARRIVED: Final = 200
+#: A file that left is absent on the target. The copy did not happen.
+CODE_MISSING_ON_TARGET: Final = 404
+#: A file arrived with FEWER bytes or lines than the snapshot recorded. Bytes
+#: went missing between the two hosts; the copy itself is what to distrust.
+CODE_TRUNCATED: Final = 422
+#: A file arrived with MORE than the snapshot recorded. Nothing was lost — the
+#: source changed after it was measured (or something appended on the target).
+#: A conflict between two readings of the world, not a damaged payload, so it
+#: gets its own code rather than being reported as a truncation that ran
+#: backwards. It shares 409 with :data:`.._relocate_transport.CODE_SOURCE_RUNNING`
+#: because the two are the same sentence in different phases — the world moved
+#: under the decision — and the plan/arrival codes are separate families anyway
+#: (``CODE_READY`` and ``CODE_ARRIVED`` are both 200).
+CODE_TARGET_LARGER: Final = 409
+#: Something was not observed. Refuses as firmly as a failure, differently.
+CODE_UNKNOWN: Final = 503
+
+
+@dataclass(frozen=True)
+class TranscriptFile:
+    """One transcript, as MEASURED on one side of the copy.
+
+    ``byte_count`` and ``line_count`` are ``| None`` for NOT MEASURED, which is
+    deliberately distinct from ``0``. An empty file and a measurement that did
+    not run look identical to a caller that collapses them, and the second must
+    refuse where the first may not.
+
+    On the SOURCE side this carries the SNAPSHOT rather than the whole file:
+    ``byte_count`` is the offset of the last newline and ``line_count`` the
+    number of complete lines at the instant the snapshot was taken. That is the
+    contract the copy is bounded by and the number arrival is checked against.
+    """
+
+    name: str
+    byte_count: int | None = None
+    line_count: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("TranscriptFile.name must be non-empty")
+
+    @property
+    def measured(self) -> bool:
+        return self.byte_count is not None and self.line_count is not None
+
+
+@dataclass(frozen=True)
+class ArrivalVerdict:
+    """Whether everything that left arrived intact, with the evidence attached.
+
+    ``arrived`` is three-valued, no ``__bool__``. ``mismatches`` carries one line
+    per offending file so a report names WHICH file, BY HOW MUCH, and IN WHICH
+    DIRECTION — rather than saying the transfer failed and leaving the reader to
+    go and diff two hosts.
+    """
+
+    arrived: bool | None
+    code: int
+    reason: str
+    mismatches: tuple[str, ...] = ()
+    verified: tuple[str, ...] = ()
+    hint: str = ""
+
+    def __post_init__(self) -> None:
+        if self.arrived not in (True, False, None):
+            raise ValueError(
+                f"ArrivalVerdict.arrived must be True/False/None, got {self.arrived!r}"
+            )
+        if not self.reason:
+            raise ValueError("ArrivalVerdict.reason must be non-empty")
+        if self.arrived is True and self.code != CODE_ARRIVED:
+            raise ValueError(
+                f"ArrivalVerdict: arrived=True must carry CODE_ARRIVED, got {self.code}"
+            )
+        if self.arrived is True and self.mismatches:
+            raise ValueError(
+                "ArrivalVerdict: an arrival with mismatches is unrepresentable"
+            )
+        if self.arrived is not True and not self.hint:
+            raise ValueError("ArrivalVerdict: a non-arrival must say what to do next")
+
+
+def _counts(src: TranscriptFile, tgt: TranscriptFile) -> str:
+    return (
+        f"sent {src.byte_count} bytes / {src.line_count} lines, "
+        f"target holds {tgt.byte_count} bytes / {tgt.line_count} lines"
+    )
+
+
+def _short_line(src: TranscriptFile, tgt: TranscriptFile) -> str:
+    """The copy is suspect: bytes that left did not land."""
+    return (
+        f"{src.name}: arrived SHORT — {_counts(src, tgt)} "
+        f"(target {tgt.byte_count - src.byte_count:+d} bytes, "
+        f"{tgt.line_count - src.line_count:+d} lines). Bytes that were snapshotted "
+        "did not land"
+    )
+
+
+def _larger_line(src: TranscriptFile, tgt: TranscriptFile) -> str:
+    """Nothing was lost: the source moved after the snapshot was taken."""
+    same_lines = (
+        " on the SAME line count, so no record was appended — a line that was "
+        "already there simply got longer"
+        if tgt.line_count == src.line_count
+        else ""
+    )
+    return (
+        f"{src.name}: the target holds MORE — {_counts(src, tgt)} "
+        f"(target {tgt.byte_count - src.byte_count:+d} bytes, "
+        f"{tgt.line_count - src.line_count:+d} lines){same_lines}. Nothing went "
+        "missing; the source changed after it was measured"
+    )
+
+
+def verify_arrival(
+    *,
+    sent: Sequence[TranscriptFile],
+    landed: Sequence[TranscriptFile],
+) -> ArrivalVerdict:
+    """Compare the SNAPSHOT that was sent with what the TARGET now holds, per file.
+
+    ``sent`` is the snapshot recorded on the source before the copy started;
+    ``landed`` is measured on the target afterwards. Every file in ``sent`` must
+    appear in ``landed`` with both numbers equal. Files present only in ``landed``
+    are ignored — the destination is the agent's own projects directory and may
+    hold other conversations, which is not evidence of a bad copy.
+
+    An unmeasured count on either side is UNKNOWN, not a pass.
+    """
+    if not sent:
+        return ArrivalVerdict(
+            arrived=None,
+            code=CODE_UNKNOWN,
+            reason="nothing was recorded as sent, so there is nothing to confirm",
+            hint=(
+                "snapshot the source files before the copy; without a baseline the "
+                "target's contents cannot be checked against anything"
+            ),
+        )
+
+    by_name = {f.name: f for f in landed}
+    mismatches: list[str] = []
+    verified: list[str] = []
+    unmeasured: list[str] = []
+    absent: list[str] = []
+    short: list[str] = []
+    larger: list[str] = []
+
+    for src in sent:
+        if not src.measured:
+            unmeasured.append(f"{src.name}: not measured on the source")
+            continue
+        tgt = by_name.get(src.name)
+        if tgt is None:
+            absent.append(src.name)
+            mismatches.append(f"{src.name}: absent on the target")
+            continue
+        if not tgt.measured:
+            unmeasured.append(f"{src.name}: not measured on the target")
+            continue
+        if tgt.byte_count == src.byte_count and tgt.line_count == src.line_count:
+            verified.append(src.name)
+            continue
+        if tgt.byte_count < src.byte_count or tgt.line_count < src.line_count:
+            short.append(src.name)
+            mismatches.append(_short_line(src, tgt))
+        else:
+            larger.append(src.name)
+            mismatches.append(_larger_line(src, tgt))
+
+    if unmeasured:
+        return ArrivalVerdict(
+            arrived=None,
+            code=CODE_UNKNOWN,
+            reason="the copy could not be confirmed: " + "; ".join(unmeasured),
+            mismatches=tuple(mismatches),
+            verified=tuple(verified),
+            hint=(
+                "count bytes and lines on BOTH sides and compare again. A copy that "
+                "cannot be checked has not succeeded — do not hand over the lease on it"
+            ),
+        )
+
+    if mismatches:
+        return _refusal(
+            mismatches=mismatches,
+            verified=verified,
+            absent=absent,
+            short=short,
+            larger=larger,
+        )
+
+    return ArrivalVerdict(
+        arrived=True,
+        code=CODE_ARRIVED,
+        reason=(
+            f"all {len(verified)} transcript(s) verified on the target against the "
+            "byte and line counts snapshotted before the copy"
+        ),
+        verified=tuple(verified),
+    )
+
+
+def _refusal(
+    *,
+    mismatches: list[str],
+    verified: list[str],
+    absent: list[str],
+    short: list[str],
+    larger: list[str],
+) -> ArrivalVerdict:
+    """Which refusal this is. The order is worst-first, so a mix reports the worst.
+
+    Only when EVERY mismatch is a target holding more does the verdict say the
+    source moved — one short file in the set means bytes went missing, and that
+    is the finding worth acting on first.
+    """
+    if short:
+        return ArrivalVerdict(
+            arrived=False,
+            code=CODE_TRUNCATED,
+            reason=(
+                f"{len(short)} file(s) arrived SHORT of the snapshot that was sent"
+            ),
+            mismatches=tuple(mismatches),
+            verified=tuple(verified),
+            hint=(
+                "do NOT continue the relocation. Move the target's partial copy aside "
+                "and re-run the transport; a short transcript resumes without error "
+                "and simply forgets the end of the conversation"
+            ),
+        )
+    if absent:
+        return ArrivalVerdict(
+            arrived=False,
+            code=CODE_MISSING_ON_TARGET,
+            reason="the target's copy does not match what was sent",
+            mismatches=tuple(mismatches),
+            verified=tuple(verified),
+            hint=(
+                "do NOT continue the relocation. The copy did not happen at all for "
+                "these files, which is a different question from one that happened "
+                "badly — check that the copy command ran and re-run the transport"
+            ),
+        )
+    return ArrivalVerdict(
+        arrived=False,
+        code=CODE_TARGET_LARGER,
+        reason=(
+            f"the target holds MORE than was sent for {len(larger)} file(s); the "
+            "source changed after it was measured"
+        ),
+        mismatches=tuple(mismatches),
+        verified=tuple(verified),
+        hint=(
+            "do NOT continue the relocation, and do NOT treat the target's copy as "
+            "damaged — it holds more than the snapshot, which is the source settling "
+            "rather than bytes going missing. Confirm the source has gone quiescent "
+            "(SOURCE_STOP now waits for two identical readings of the file before it "
+            "reports success), then re-run the transport so the snapshot and the copy "
+            "describe the same instant"
+        ),
+    )

--- a/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
@@ -187,6 +187,41 @@ def _source_repo_facts(spec_body: dict, from_host: str):
     return scan_source((workdir,))
 
 
+def _source_facts(spec: dict, spec_body: dict, agent: str, from_host: str):
+    """The repo scan PLUS which conversation would travel, both read locally.
+
+    ``session_resolvable`` is a preflight check for one reason: the phase that
+    needs the answer runs after the agent has been stopped. Ten agents on
+    ywata-note-win passed every check on 2026-08-12 and could not complete,
+    because each held more than one transcript and the transport only named a
+    session when there was exactly one. Answering it HERE is what turns that into
+    a refusal while the agent is still up.
+
+    The workdir is resolved against THIS filesystem, which is right precisely
+    because these are the SOURCE's facts and the coordinator is standing on the
+    source. When it is not, the directory is simply not there and
+    :func:`scan_session` reports NOT OBSERVED rather than inventing an empty one.
+    """
+    from pathlib import Path
+
+    from .._lifecycle._relocate_source_scan import scan_session
+    from .._lifecycle._relocate_transcript_home import transcript_home_from_spec
+    from .._lifecycle._relocate_transport_paths import derive_target_dir
+
+    facts = _source_repo_facts(spec_body, from_host)
+    home = transcript_home_from_spec(spec)
+    workdir = str(spec_body.get("workdir") or "").strip()
+    transcript_dir = ""
+    if home.path and workdir:
+        derived = derive_target_dir(
+            target_home=home.path,
+            target_resolved_workdir=str(Path(workdir).resolve()),
+        )
+        transcript_dir = derived.path or ""
+    state_dir = str(Path.home() / ".scitex" / "agent-container" / "runtime" / agent)
+    return scan_session(facts, transcript_dir=transcript_dir, state_dir=state_dir)
+
+
 def _dig(body: dict, *path: str) -> object:
     """Follow ``path`` through nested dicts, yielding ``None`` at any break."""
     cur: object = body
@@ -403,8 +438,8 @@ def relocate(name: str, to_host: str, dry_run: bool) -> None:
         facts=gathered.facts,
         runtime=str(declared.get("runtime") or ""),
         required_ports=_required_ports(declared),
-        source_facts=_source_repo_facts(
-            body if isinstance(body, dict) else {}, where.host or ""
+        source_facts=_source_facts(
+            spec, body if isinstance(body, dict) else {}, name, where.host or ""
         ),
         from_host=where.host or "",
     )

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_effects_source.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_effects_source.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""A stop that tmux confirmed is not a file that has stopped being written.
+
+SOURCE_STOP used to report success on the liveness answer alone. On 2026-08-12 it
+did exactly that — tmux answered that session ``tui-…`` was gone, which was TRUE —
+and the transcript then grew 11,717 bytes as the dying process finished flushing
+its final line. The relocation aborted three phases later, blaming the copy.
+
+These tests drive the real phase against a real filesystem. The ``exec_fn`` seam
+hands each rendered script to ``sh -c`` through ``subprocess``, so ``tmux``,
+``wc``, ``stat`` and ``readlink`` actually run and the answers are the machine's.
+Nothing is mocked. The liveness probe answers honestly for an agent name no tmux
+session exists under, which is the state a stopped agent is in.
+
+The clock and the sleep are injected, which is not a mock: they are the two things
+a test must not spend. The fake sleep advances the fake clock by exactly the
+interval it was asked for, so the deadline arithmetic runs at full fidelity in no
+wall-clock time.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from scitex_agent_container._lifecycle._relocate_effects import RelocateAdapters
+from scitex_agent_container._lifecycle._relocate_shell import Shell
+
+
+def _real_exec(argv, timeout_s=None):
+    done = subprocess.run(argv, capture_output=True, text=True, timeout=timeout_s)
+    return {
+        "exit_code": done.returncode,
+        "stdout": done.stdout,
+        "stderr": done.stderr,
+        "timed_out": False,
+    }
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def now(self) -> float:
+        return self.t
+
+    def sleep(self, seconds: float) -> None:
+        self.t += seconds
+
+
+class _FlushingClock(_Clock):
+    """A clock whose every sleep appends to the transcript — a flush in flight."""
+
+    def __init__(self, path) -> None:
+        super().__init__()
+        self.path = path
+
+    def sleep(self, seconds: float) -> None:
+        super().sleep(seconds)
+        with open(self.path, "ab") as handle:
+            handle.write(b'{"type":"assistant","text":"still flushing"}\n')
+
+
+def _adapters(tmp_path, clock, agent="relocate-test-agent-no-such-session"):
+    """A real source whose transcript home and workdir are real directories.
+
+    The spec is the real shape: an apptainer bind supplies the container home,
+    and the workdir is what Claude Code encodes into the project directory name.
+    Both are under ``tmp_path``, so the derivation runs for real rather than
+    being handed a path.
+    """
+    home = tmp_path / "container-home"
+    workdir = tmp_path / "work"
+    workdir.mkdir(parents=True, exist_ok=True)
+    spec = {
+        "spec": {
+            "workdir": str(workdir),
+            "apptainer": {"binds": [f"{home}:/home/agent"]},
+        }
+    }
+    source = Shell(host="here", is_local=True)
+    return RelocateAdapters(
+        agent=agent,
+        spec=spec,
+        from_host="here",
+        to_host="there",
+        source=source,
+        target=Shell(host="there"),
+        stamp="20260812T000000Z",
+        exec_fn=_real_exec,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+
+
+def _transcript_dir(adapters):
+    directory, _, _ = adapters.source_transcript_dir()
+    return directory
+
+
+def _seed(adapters, lines=3):
+    from pathlib import Path
+
+    directory = Path(_transcript_dir(adapters))
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "sess.jsonl"
+    path.write_text(
+        "".join(f'{{"i":{i}}}\n' for i in range(lines)), encoding="utf-8"
+    )
+    return path
+
+
+# --------------------------------------------------------------------------
+# The stop now waits for the file
+# --------------------------------------------------------------------------
+
+
+def test_a_stopped_agent_with_a_settled_transcript_passes(tmp_path) -> None:
+    # Arrange: the ordinary case, and the positive control. Without it every
+    # refusal below could pass because the fixture is broken.
+    clock = _Clock()
+    adapters = _adapters(tmp_path, clock)
+    _seed(adapters)
+    # Act
+    result = adapters.stop_source()
+    # Assert
+    assert result.ok is True
+
+
+def test_the_pass_says_the_file_was_read_twice(tmp_path) -> None:
+    # Arrange: the whole change is that "stopped" is no longer the last word, so
+    # the journal line has to record what else was established.
+    clock = _Clock()
+    adapters = _adapters(tmp_path, clock)
+    _seed(adapters)
+    # Act
+    result = adapters.stop_source()
+    # Assert
+    assert "identically" in result.detail
+
+
+def test_a_transcript_still_being_written_is_unknown_not_a_pass(tmp_path) -> None:
+    # Arrange: THE 2026-08-12 failure. tmux has already reported the session
+    # gone — positive evidence of absence, and true — while the process is still
+    # flushing. The old code returned ok=True here and the transport read a file
+    # that had moved since it was measured.
+    clock = _Clock()
+    adapters = _adapters(tmp_path, clock)
+    path = _seed(adapters)
+    flushing = _FlushingClock(path)
+    adapters.now, adapters.sleep = flushing.now, flushing.sleep
+    # Act
+    result = adapters.stop_source()
+    # Assert
+    assert result.ok is None
+
+
+def test_that_refusal_is_never_reported_as_a_failure_of_the_stop(tmp_path) -> None:
+    # Arrange: the agent IS stopped. Calling this False would send someone to
+    # stop a process that is already down; it is an unfinished measurement, and
+    # UNKNOWN is the honest three-valued answer.
+    clock = _Clock()
+    adapters = _adapters(tmp_path, clock)
+    path = _seed(adapters)
+    flushing = _FlushingClock(path)
+    adapters.now, adapters.sleep = flushing.now, flushing.sleep
+    # Act
+    result = adapters.stop_source()
+    # Assert
+    assert result.ok is not False
+
+
+def test_the_refusal_names_what_was_still_changing(tmp_path) -> None:
+    # Arrange: "not quiescent" without the file and the numbers is not something
+    # anyone can act on — which was the complaint about the 422 it replaces.
+    clock = _Clock()
+    adapters = _adapters(tmp_path, clock)
+    path = _seed(adapters)
+    flushing = _FlushingClock(path)
+    adapters.now, adapters.sleep = flushing.now, flushing.sleep
+    # Act
+    result = adapters.stop_source()
+    # Assert
+    assert "sess.jsonl" in result.detail
+
+
+def test_the_refusal_still_reports_that_the_agent_is_stopped(tmp_path) -> None:
+    # Arrange: the driver's recovery advice depends on knowing the source is
+    # down. A refusal that omitted it would leave the operator guessing about the
+    # one thing that changed.
+    clock = _Clock()
+    adapters = _adapters(tmp_path, clock)
+    path = _seed(adapters)
+    flushing = _FlushingClock(path)
+    adapters.now, adapters.sleep = flushing.now, flushing.sleep
+    # Act
+    result = adapters.stop_source()
+    # Assert
+    assert "stopped" in result.detail
+
+
+def test_an_already_stopped_agent_still_waits_for_the_file(tmp_path) -> None:
+    # Arrange: THE exit the failing run actually took. tmux held no session at
+    # all, so `stop_source` returned "already stopped" without issuing anything —
+    # and that path has to go through the quiescence wait too, or the fix misses
+    # the case it was written for.
+    clock = _Clock()
+    adapters = _adapters(tmp_path, clock)
+    path = _seed(adapters)
+    flushing = _FlushingClock(path)
+    adapters.now, adapters.sleep = flushing.now, flushing.sleep
+    # Act
+    result = adapters.stop_source()
+    # Assert
+    assert result.ok is None and "already stopped" in result.detail
+
+
+def test_an_underivable_transcript_directory_refuses(tmp_path) -> None:
+    # Arrange: a stop cannot be called verified without watching what the stopped
+    # process was writing. With no workdir there is nothing to watch, and that is
+    # an unfinished measurement rather than a pass.
+    clock = _Clock()
+    adapters = _adapters(tmp_path, clock)
+    adapters.spec = {"spec": {"apptainer": {"binds": ["/x:/home/agent"]}}}
+    # Act
+    result = adapters.stop_source()
+    # Assert
+    assert result.ok is None
+
+
+# --------------------------------------------------------------------------
+# The drain, unchanged — a stop is not a drain
+# --------------------------------------------------------------------------
+
+
+def test_a_stopped_agent_has_nothing_to_drain(tmp_path) -> None:
+    # Arrange: vacuously true, and MEASURED rather than assumed — an agent with
+    # no session cannot accept work.
+    clock = _Clock()
+    adapters = _adapters(tmp_path, clock)
+    # Act
+    result = adapters.drain_source()
+    # Assert
+    assert result.ok is True

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_preflight.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_preflight.py
@@ -28,6 +28,7 @@ from scitex_agent_container._lifecycle._relocate_preflight import (
     CHECK_RUNTIME,
     CHECK_SAC_PRESENT,
     CHECK_SCHEMA,
+    CHECK_SESSION,
     CHECK_SOURCE_WORK,
     Check,
     SourceFacts,
@@ -63,11 +64,21 @@ def _healthy_facts(**overrides: object) -> TargetFacts:
     return TargetFacts(**base)  # type: ignore[arg-type]
 
 
-def _clean_source() -> SourceFacts:
-    """A source that was scanned and holds nothing un-saved."""
-    return SourceFacts(
-        repos=(RepoWork(path="/repo", branch="develop", uncommitted=0, unpushed=0),)
+def _clean_source(**overrides: object) -> SourceFacts:
+    """A source that was scanned, holds nothing un-saved, and names its session.
+
+    The transcripts and the marker are part of "fully observed" because the
+    session check reads them. Several transcripts is the ORDINARY shape — every
+    one of the ten agents measured on 2026-08-12 held between two and five — so
+    the healthy fixture holds three rather than the one the old guard required.
+    """
+    base = dict(
+        repos=(RepoWork(path="/repo", branch="develop", uncommitted=0, unpushed=0),),
+        transcripts=(("aaa1.jsonl", 1000), ("bbb2.jsonl", 3000), ("ccc3.jsonl", 2000)),
+        session_marker="aaa1",
     )
+    base.update(overrides)
+    return SourceFacts(**base)  # type: ignore[arg-type]
 
 
 def _run(source_facts: SourceFacts | None = None, **overrides: object):
@@ -126,6 +137,74 @@ def test_an_entirely_unobserved_target_is_unknown_not_ok() -> None:
     verdict = report.ok
     # Assert
     assert verdict is None
+
+
+# ---------------------------------------------------------------------------
+# session_resolvable — asked HERE because the phase that needs it runs late
+# ---------------------------------------------------------------------------
+
+
+def test_several_transcripts_with_a_marker_pass_the_session_check() -> None:
+    # Arrange: THE shape every remaining agent has. Three transcripts is normal,
+    # and the old `len(files) == 1` guard made it fatal.
+    report = _run()
+    # Act
+    check = _named(report, CHECK_SESSION)
+    # Assert
+    assert check.ok is True
+
+
+def test_an_agent_whose_session_cannot_be_resolved_fails_preflight() -> None:
+    # Arrange: THE gap. Ten agents returned "GO — every check passed" on
+    # 2026-08-12 and then aborted at TARGET_STANDBY with the agent stopped, the
+    # transcript copied and no marker written. The refusal has to happen while
+    # the agent is still up.
+    report = _run(source_facts=_clean_source(session_marker="not-carried"))
+    # Act
+    verdict = report.ok
+    # Assert
+    assert verdict is False
+
+
+def test_that_failure_is_reported_under_the_session_check() -> None:
+    # Arrange: a blocked relocation is only actionable if the report names WHICH
+    # question blocked it.
+    report = _run(source_facts=_clean_source(session_marker="not-carried"))
+    # Act
+    check = _named(report, CHECK_SESSION)
+    # Assert
+    assert check.ok is False
+
+
+def test_that_failure_names_the_transcripts_it_saw() -> None:
+    # Arrange: the operator resolves this by seeding the marker, which needs the
+    # candidate list in front of them.
+    report = _run(source_facts=_clean_source(session_marker="not-carried"))
+    # Act
+    check = _named(report, CHECK_SESSION)
+    # Assert
+    assert "bbb2.jsonl" in check.detail
+
+
+def test_a_source_whose_transcripts_were_never_listed_is_unknown() -> None:
+    # Arrange: nobody looked. That must not read as "there is one and it is
+    # fine", which is how this class of bug reaches the phase that stops things.
+    report = _run(source_facts=_clean_source(transcripts=None))
+    # Act
+    check = _named(report, CHECK_SESSION)
+    # Assert
+    assert check.ok is None
+
+
+def test_an_agent_with_no_transcript_at_all_fails_the_session_check() -> None:
+    # Arrange: an observed empty directory. The agent would boot on the target
+    # with no memory — the 2026-08-07 outcome, and it must be said out loud
+    # rather than discovered afterwards.
+    report = _run(source_facts=_clean_source(transcripts=(), session_marker=""))
+    # Act
+    check = _named(report, CHECK_SESSION)
+    # Assert
+    assert check.ok is False
 
 
 def test_every_check_is_unknown_when_nothing_was_observed() -> None:

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe.py
@@ -233,7 +233,9 @@ def test_a_fully_healthy_probe_set_passes_preflight() -> None:
         facts=gathered.facts,
         runtime="apptainer",
         source_facts=SourceFacts(
-            repos=(RepoWork(path="/proj/x", uncommitted=0, unpushed=0),)
+            repos=(RepoWork(path="/proj/x", uncommitted=0, unpushed=0),),
+            transcripts=(("aaa1.jsonl", 1000), ("bbb2.jsonl", 3000)),
+            session_marker="bbb2",
         ),
         from_host="ywata-note-win",
     )

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe_adapter.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe_adapter.py
@@ -468,10 +468,13 @@ def test_a_healthy_target_reaches_preflight_as_a_go(spec) -> None:
         to_host="target",
         facts=gathered.facts,
         runtime="tui",
-        # The source-work check is gathered locally, not by this batch. A scanned
-        # and clean source is supplied so the probe adapter is what is measured.
+        # The source-work and session checks are gathered locally, not by this
+        # batch. A scanned and clean source is supplied so the probe adapter is
+        # what is measured.
         source_facts=SourceFacts(
-            repos=(RepoWork(path="/proj/x", uncommitted=0, unpushed=0),)
+            repos=(RepoWork(path="/proj/x", uncommitted=0, unpushed=0),),
+            transcripts=(("aaa1.jsonl", 1000), ("bbb2.jsonl", 3000)),
+            session_marker="bbb2",
         ),
         from_host="ywata-note-win",
     )

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_provenance.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_provenance.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""The operator's actual requirement, and the half of it that is usually missing.
+
+    「エージェントがどこから来たのかっていうのが分かって、そこを調査することが
+    できるならば、全く問題ない」
+
+    — if the agent can tell where it came from and go and investigate there,
+      there is no problem at all.  (operator, 2026-08-12)
+
+He was answering a question about how to MERGE a `memory/` directory that may
+have diverged on two hosts, and his answer was that the merge is 枝葉 — a leaf —
+and provenance is the trunk. So the tests that matter here are: does the record
+name the source host and the source path, and does it name what did NOT travel.
+
+That second one is the half that goes missing. `memory/` was stranded on
+2026-08-11 with the refusal correctly logged — as one line in a run log nobody
+keeps. These tests pin it into a file on the target instead.
+
+Pure strings. Nothing is mocked because there is nothing to mock.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._lifecycle._relocate_provenance import (
+    PROVENANCE_FILENAME,
+    render_provenance,
+)
+
+WHEN = 1786492800.0
+REFUSED = (
+    ("b68520e1-78fb", "the allowlist carries transcripts and memory/; this is neither"),
+    (".credentials.json", "a credential is never carried — the target re-issues its own"),
+)
+
+
+def _record(**over) -> str:
+    kwargs = dict(
+        agent="scitex-agent-container",
+        from_host="ywata-note-win",
+        source_dir="/home/ywatanabe/.claude/projects/-home-ywatanabe-proj-sac",
+        to_host="scitex-compute-04",
+        target_dir="/home/agent/.claude/projects/-home-ywatanabe-proj-sac",
+        when=WHEN,
+        session="b68520e1-78fb-404f-a84d-b78cf7cf6e31",
+        transcripts=(("b68520e1.jsonl", 108412278, 58325),),
+        directories=("memory",),
+        refused=REFUSED,
+    )
+    kwargs.update(over)
+    return render_provenance(**kwargs)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# Provenance: where it came from
+# --------------------------------------------------------------------------
+
+
+def test_the_record_names_the_host_it_came_from() -> None:
+    # Arrange: THE requirement, in the operator's own words. Everything else in
+    # this module is secondary to an agent being able to answer "where was I".
+    # Act
+    text = _record()
+    # Assert
+    assert "ywata-note-win" in text
+
+
+def test_the_record_names_the_absolute_source_path() -> None:
+    # Arrange: a host name alone sends someone hunting. "Go and investigate
+    # there" needs a path they can cd to.
+    # Act
+    text = _record()
+    # Assert
+    assert "/home/ywatanabe/.claude/projects/-home-ywatanabe-proj-sac" in text
+
+
+def test_the_record_carries_the_raw_unix_time() -> None:
+    # Arrange: the operator ruled clock skew 「そんなシビアじゃない」 and plain
+    # unix time enough. The raw number is printed so anyone who does care about
+    # skew can see exactly what this host believed the time was.
+    # Act
+    text = _record()
+    # Assert
+    assert "1786492800" in text
+
+
+def test_the_record_says_the_source_still_holds_everything() -> None:
+    # Arrange: the sentence that makes "go and look there" true. Nothing is ever
+    # deleted on the source, and the reader must not have to know that already.
+    # Act
+    text = _record()
+    # Assert
+    assert "NOTHING WAS DELETED ON THE SOURCE" in text
+
+
+def test_the_record_names_the_session_that_was_resumed() -> None:
+    # Arrange: an agent reading this is one that may be asking which of several
+    # conversations it is now in.
+    # Act
+    text = _record()
+    # Assert
+    assert "b68520e1-78fb-404f-a84d-b78cf7cf6e31" in text
+
+
+# --------------------------------------------------------------------------
+# What did NOT travel — the half that goes missing
+# --------------------------------------------------------------------------
+
+
+def test_the_record_names_what_was_not_carried() -> None:
+    # Arrange: THE 2026-08-11 shape. The refusal existed and was correct; it
+    # lived in a run log. A relocation that carried nine tenths of an agent
+    # silently is discovered weeks later.
+    # Act
+    text = _record()
+    # Assert
+    assert "b68520e1-78fb" in text
+
+
+def test_each_refusal_carries_its_reason() -> None:
+    # Arrange: "not carried" without a reason reads as a bug rather than a
+    # decision, and sends someone to re-run the copy.
+    # Act
+    text = _record()
+    # Assert
+    assert "a credential is never carried" in text
+
+
+def test_an_empty_refusal_list_says_so_rather_than_printing_nothing() -> None:
+    # Arrange: a blank section is indistinguishable from a section that was
+    # never filled in. "Everything travelled" is a claim worth making.
+    # Act
+    text = _record(refused=())
+    # Assert
+    assert "Nothing was refused" in text
+
+
+# --------------------------------------------------------------------------
+# What did travel
+# --------------------------------------------------------------------------
+
+
+def test_the_record_lists_the_carried_memory_directory() -> None:
+    # Arrange: the thing that was missing. An agent that finds memory/ empty
+    # should be able to tell from this file whether it was supposed to be there.
+    # Act
+    text = _record()
+    # Assert
+    assert "`memory/`" in text
+
+
+def test_the_transcript_is_listed_with_the_counts_as_carried() -> None:
+    # Arrange: the SNAPSHOT numbers, not the source's current size — that is
+    # what the target's file is supposed to weigh, and the only figure a manual
+    # comparison can use.
+    # Act
+    text = _record()
+    # Assert
+    assert "108412278 bytes / 58325 lines" in text
+
+
+def test_the_record_warns_that_a_half_written_final_record_may_be_missing() -> None:
+    # Arrange: the accepted trade of the snapshot, said where the person who
+    # would notice it reads.
+    # Act
+    text = _record()
+    # Assert
+    assert "LAST COMPLETE" in text
+
+
+def test_carrying_nothing_is_stated_bluntly() -> None:
+    # Arrange: the failure shape this whole feature exists to prevent, arriving
+    # as a record. It must not read as an ordinary empty section.
+    # Act
+    text = _record(transcripts=(), directories=())
+    # Assert
+    assert "worth reading twice" in text
+
+
+# --------------------------------------------------------------------------
+# What was displaced
+# --------------------------------------------------------------------------
+
+
+def test_a_displaced_prior_directory_is_named() -> None:
+    # Arrange: the target may have been this agent's home before. Its previous
+    # contents were moved aside, never deleted, and the reader is the one who
+    # decides whether to merge them back.
+    # Act
+    text = _record(displaced_to="/home/agent/.claude/projects/.old/20260812T0000Z/-p")
+    # Assert
+    assert "/home/agent/.claude/projects/.old/20260812T0000Z/-p" in text
+
+
+def test_the_displacement_explains_that_source_won_by_rule_not_by_judgement() -> None:
+    # Arrange: 「ソースの方が普通大切だろう」 — a default, not an assessment of
+    # the contents. A reader must not conclude the older copy was worthless.
+    # Act
+    text = _record(displaced_to="/somewhere/.old/S/-p")
+    # Assert
+    assert "not a judgement about the contents" in text
+
+
+def test_no_displacement_section_when_the_destination_was_empty() -> None:
+    # Arrange: the common case must not manufacture a section about a directory
+    # that never existed.
+    # Act
+    text = _record()
+    # Assert
+    assert "What was already here" not in text
+
+
+def test_the_filename_is_the_one_the_transport_writes() -> None:
+    # Arrange: an agent can only be told "read RELOCATED-FROM.md" if that is
+    # actually where it lands. Pinned so the two cannot drift apart.
+    # Act
+    name = PROVENANCE_FILENAME
+    # Assert
+    assert name == "RELOCATED-FROM.md"

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_quiescence.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_quiescence.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""A stop that tmux confirmed, over a file that was still being written.
+
+Every test here runs the REAL sampling script against REAL files under
+``tmp_path``: the ``exec_fn`` seam hands the argv to ``subprocess.run``, so
+``wc -c`` and ``stat`` actually execute and the byte counts are the ones the
+filesystem reports. Nothing is mocked. That matters because the thing being
+pinned is not arithmetic — it is whether a file that grows between two readings
+can be mistaken for one that has settled.
+
+The clock and the sleep ARE injected, and that is not a mock: they are the two
+things a test must not spend. The fake sleep advances the fake clock by exactly
+the interval it was asked to wait, so the deadline arithmetic is exercised at
+full fidelity in no wall-clock time at all.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_quiescence import (
+    FileState,
+    Quiescence,
+    await_quiescence,
+    describe_change,
+    sample_transcripts,
+)
+from scitex_agent_container._lifecycle._relocate_shell import Shell
+
+LOCAL = Shell(host="here", is_local=True)
+
+
+def _real_exec(argv, timeout_s=None):
+    """Actually run the argv. The seam the production code already takes."""
+    done = subprocess.run(argv, capture_output=True, text=True, timeout=timeout_s)
+    return {
+        "exit_code": done.returncode,
+        "stdout": done.stdout,
+        "stderr": done.stderr,
+        "timed_out": False,
+    }
+
+
+class _Clock:
+    """A clock that only moves when something sleeps. Real arithmetic, no waiting."""
+
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def now(self) -> float:
+        return self.t
+
+    def sleep(self, seconds: float) -> None:
+        self.t += seconds
+
+
+class _GrowingClock(_Clock):
+    """A clock whose sleep also appends to a file — a flush still in flight."""
+
+    def __init__(self, path, chunk: bytes) -> None:
+        super().__init__()
+        self.path = path
+        self.chunk = chunk
+
+    def sleep(self, seconds: float) -> None:
+        super().sleep(seconds)
+        with open(self.path, "ab") as handle:
+            handle.write(self.chunk)
+
+
+def _transcript(tmp_path, name="sess.jsonl", lines=3):
+    directory = tmp_path / "projects" / "-home-agent-proj"
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(
+        "".join(f'{{"i":{i}}}\n' for i in range(lines)), encoding="utf-8"
+    )
+    return directory, path
+
+
+# --------------------------------------------------------------------------
+# Sampling: real sizes off a real filesystem
+# --------------------------------------------------------------------------
+
+
+def test_a_real_file_is_sampled_with_its_real_byte_count(tmp_path) -> None:
+    # Arrange: the positive control for the sampler. Without it every "it
+    # changed" below could pass because the script is broken rather than
+    # because the detection works.
+    directory, path = _transcript(tmp_path)
+    # Act
+    sample = sample_transcripts(LOCAL, str(directory), exec_fn=_real_exec)
+    # Assert
+    assert sample[0].byte_count == path.stat().st_size
+
+
+def test_a_directory_with_no_transcript_samples_empty_rather_than_unknown(
+    tmp_path,
+) -> None:
+    # Arrange: an observed "nothing here" is an answer. Collapsing it into
+    # "could not tell" would refuse a relocation of an agent that has not
+    # spoken yet.
+    directory = tmp_path / "empty"
+    directory.mkdir()
+    # Act
+    sample = sample_transcripts(LOCAL, str(directory), exec_fn=_real_exec)
+    # Assert
+    assert sample == ()
+
+
+def test_a_missing_directory_is_an_observed_empty_sample(tmp_path) -> None:
+    # Arrange: there is no transcript there to still be moving. Distinct from
+    # a script that never answered, which is the case below.
+    # Act
+    sample = sample_transcripts(LOCAL, str(tmp_path / "nope"), exec_fn=_real_exec)
+    # Assert
+    assert sample == ()
+
+
+def test_a_sample_ignores_files_that_are_not_transcripts(tmp_path) -> None:
+    # Arrange: a log file beside the transcript churns constantly and is not
+    # what the transport reads. Watching it would never settle.
+    directory, _ = _transcript(tmp_path)
+    (directory / "notes.md").write_text("x", encoding="utf-8")
+    # Act
+    sample = sample_transcripts(LOCAL, str(directory), exec_fn=_real_exec)
+    # Assert
+    assert [f.name for f in sample] == ["sess.jsonl"]
+
+
+def test_a_sample_is_ordered_by_name_so_two_readings_can_be_compared(
+    tmp_path,
+) -> None:
+    # Arrange: equality is the whole mechanism. Two readings of an unchanged
+    # directory that differ only in emission order would restart the wait
+    # forever.
+    directory, _ = _transcript(tmp_path)
+    _transcript(tmp_path, name="aaa.jsonl")
+    # Act
+    first = sample_transcripts(LOCAL, str(directory), exec_fn=_real_exec)
+    second = sample_transcripts(LOCAL, str(directory), exec_fn=_real_exec)
+    # Assert
+    assert first == second
+
+
+# --------------------------------------------------------------------------
+# The wait: settled, still moving, not measurable
+# --------------------------------------------------------------------------
+
+
+def test_a_file_that_is_not_changing_settles(tmp_path) -> None:
+    # Arrange: the ordinary case. A stopped agent's transcript reads the same
+    # twice and the phase may proceed.
+    directory, _ = _transcript(tmp_path)
+    clock = _Clock()
+    # Act
+    verdict = await_quiescence(
+        LOCAL,
+        str(directory),
+        exec_fn=_real_exec,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+    # Assert
+    assert verdict.settled is True
+
+
+def test_a_file_still_being_written_is_unknown_not_a_pass(tmp_path) -> None:
+    # Arrange: THE 2026-08-12 case, reproduced. tmux has already said the
+    # session is gone; the dying process is still flushing. Every sleep appends,
+    # so no two readings ever agree and the deadline arrives.
+    directory, path = _transcript(tmp_path)
+    clock = _GrowingClock(path, b'{"flush":1}\n')
+    # Act
+    verdict = await_quiescence(
+        LOCAL,
+        str(directory),
+        exec_fn=_real_exec,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+    # Assert
+    assert verdict.settled is None
+
+
+def test_a_file_still_being_written_is_never_reported_as_settled(tmp_path) -> None:
+    # Arrange: the same run, stated as the property that must hold. A timeout
+    # folded into success is what let the failing relocation reach the copy.
+    directory, path = _transcript(tmp_path)
+    clock = _GrowingClock(path, b'{"flush":1}\n')
+    # Act
+    verdict = await_quiescence(
+        LOCAL,
+        str(directory),
+        exec_fn=_real_exec,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+    # Assert
+    assert verdict.settled is not True
+
+
+def test_the_timeout_names_the_file_that_was_still_changing(tmp_path) -> None:
+    # Arrange: "not quiescent" without the evidence is not something anyone can
+    # act on — which was the complaint about the 422 that prompted this module.
+    directory, path = _transcript(tmp_path)
+    clock = _GrowingClock(path, b'{"flush":1}\n')
+    # Act
+    verdict = await_quiescence(
+        LOCAL,
+        str(directory),
+        exec_fn=_real_exec,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+    # Assert
+    assert "sess.jsonl" in verdict.detail
+
+
+def test_the_timeout_reports_the_size_it_grew_by(tmp_path) -> None:
+    # Arrange: the numbers are the point. A reader must be able to see that the
+    # file is gaining bytes rather than merely "changing".
+    directory, path = _transcript(tmp_path)
+    clock = _GrowingClock(path, b"0123456789\n")
+    # Act
+    verdict = await_quiescence(
+        LOCAL,
+        str(directory),
+        exec_fn=_real_exec,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+    # Assert
+    assert "+11" in verdict.detail
+
+
+def test_a_file_that_settles_after_a_late_flush_is_confirmed(tmp_path) -> None:
+    # Arrange: the realistic shutdown. One flush lands, then the process lets go
+    # and the next two readings agree — which must be a PASS, or the fix would
+    # simply move the failure from a bad 422 to a spurious timeout.
+    directory, path = _transcript(tmp_path)
+
+    class _OneFlush(_Clock):
+        def __init__(self) -> None:
+            super().__init__()
+            self.flushed = False
+
+        def sleep(self, seconds: float) -> None:
+            super().sleep(seconds)
+            if not self.flushed:
+                self.flushed = True
+                with open(path, "ab") as handle:
+                    handle.write(b'{"last":true}\n')
+
+    clock = _OneFlush()
+    # Act
+    verdict = await_quiescence(
+        LOCAL,
+        str(directory),
+        exec_fn=_real_exec,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+    # Assert
+    assert verdict.settled is True
+
+
+def test_a_new_transcript_appearing_counts_as_movement(tmp_path) -> None:
+    # Arrange: the SET is part of the reading. A session file created after the
+    # stop means something is still running, and comparing only the files we
+    # happened to see first would miss it.
+    directory, _ = _transcript(tmp_path)
+
+    class _Spawner(_Clock):
+        def __init__(self) -> None:
+            super().__init__()
+            self.n = 0
+
+        def sleep(self, seconds: float) -> None:
+            super().sleep(seconds)
+            self.n += 1
+            (directory / f"new-{self.n}.jsonl").write_text("{}\n", encoding="utf-8")
+
+    clock = _Spawner()
+    # Act
+    verdict = await_quiescence(
+        LOCAL,
+        str(directory),
+        exec_fn=_real_exec,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+    # Assert
+    assert verdict.settled is None
+
+
+def test_a_reading_that_could_not_be_taken_refuses(tmp_path) -> None:
+    # Arrange: a shell that ran and printed nothing measured nothing. Treating
+    # silence as "no files, therefore settled" is how an unreadable directory
+    # becomes a confident green light.
+    def _silent(argv, timeout_s=None):
+        return {"exit_code": 0, "stdout": "", "stderr": "", "timed_out": False}
+
+    clock = _Clock()
+    # Act
+    verdict = await_quiescence(
+        LOCAL,
+        str(tmp_path),
+        exec_fn=_silent,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+    # Assert
+    assert verdict.settled is None
+
+
+def test_an_unmeasured_byte_count_refuses_rather_than_comparing_two_blanks(
+    tmp_path,
+) -> None:
+    # Arrange: two unmeasured readings compare EQUAL, which would manufacture
+    # exactly the false "it has settled" this module exists to prevent.
+    def _blank_counts(argv, timeout_s=None):
+        return {
+            "exit_code": 0,
+            "stdout": "TX-QDIR=yes\nTX-QUIET=sess.jsonl\t\t\n",
+            "stderr": "",
+            "timed_out": False,
+        }
+
+    clock = _Clock()
+    # Act
+    verdict = await_quiescence(
+        LOCAL,
+        str(tmp_path),
+        exec_fn=_blank_counts,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+    # Assert
+    assert verdict.settled is None
+
+
+def test_the_wait_is_bounded(tmp_path) -> None:
+    # Arrange: a host whose transcript never settles must fail the phase, not
+    # sit in front of the copy's much larger budget forever.
+    directory, path = _transcript(tmp_path)
+    clock = _GrowingClock(path, b"x\n")
+    # Act
+    await_quiescence(
+        LOCAL,
+        str(directory),
+        exec_fn=_real_exec,
+        now=clock.now,
+        sleep=clock.sleep,
+        timeout_s=6.0,
+        interval_s=2.0,
+    )
+    # Assert
+    assert clock.t <= 1000.0 + 6.0 + 2.0
+
+
+# --------------------------------------------------------------------------
+# The pure parts
+# --------------------------------------------------------------------------
+
+
+def test_growth_is_described_with_both_sizes_and_the_delta() -> None:
+    # Arrange: the exact shape of the 2026-08-12 abort, as this module would
+    # have reported it BEFORE the copy rather than after.
+    before = [FileState("s.jsonl", byte_count=108412278, mtime="1")]
+    after = [FileState("s.jsonl", byte_count=108423995, mtime="2")]
+    # Act
+    described = describe_change(before, after)
+    # Assert
+    assert "+11717" in described
+
+
+def test_a_same_size_rewrite_is_still_movement() -> None:
+    # Arrange: why mtime is read at all. A file rewritten in place at the same
+    # length is not a file at rest, and size alone would call it settled.
+    before = [FileState("s.jsonl", byte_count=10, mtime="100")]
+    after = [FileState("s.jsonl", byte_count=10, mtime="200")]
+    # Act
+    described = describe_change(before, after)
+    # Assert
+    assert "rewritten in place" in described
+
+
+def test_an_unsettled_verdict_must_say_what_to_do_next() -> None:
+    # Arrange: the invariant lives in the type. A refusal with no next action
+    # turns a one-command fix into an investigation.
+    build = lambda: Quiescence(settled=None, detail="still moving")  # noqa: E731
+    # Act
+    attempt = build
+    # Assert
+    with pytest.raises(ValueError):
+        attempt()

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
@@ -55,9 +55,14 @@ ALL_GOOD = TargetFacts(
 
 #: The source scanned and clean. Supplied on every render so the rendering
 #: itself is what is under test — a report that refuses because nobody scanned
-#: the source would exercise the renderer's refusal path in every case.
+#: the source would exercise the renderer's refusal path in every case. The
+#: transcripts and marker are part of "scanned" since the session check reads
+#: them; three transcripts rather than one, because that is the ordinary shape
+#: (every agent measured on 2026-08-12 held between two and five).
 CLEAN_SOURCE = SourceFacts(
-    repos=(RepoWork(path="/proj/x", branch="develop", uncommitted=0, unpushed=0),)
+    repos=(RepoWork(path="/proj/x", branch="develop", uncommitted=0, unpushed=0),),
+    transcripts=(("aaa1.jsonl", 1000), ("bbb2.jsonl", 3000)),
+    session_marker="bbb2",
 )
 
 

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_session_choice.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_session_choice.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Ten agents that passed every check and could not move, because of one `== 1`.
+
+The guard this module replaces read ``if len(plan.files) == 1``. Measured on
+ywata-note-win on 2026-08-12, not one of the ten agents left to relocate has
+exactly one transcript — they hold 3, 4, 4, 5, 3, 2, 3, 2, 4 and 4 — so every one
+of them reported ``GO`` from preflight and then aborted at TARGET_STANDBY with the
+agent already stopped, the transcript already copied, and no marker written.
+
+The tests here are the two halves of the fix: a session is CHOSEN from real
+candidates by stated evidence, and an unresolvable one refuses NAMING what it saw
+rather than picking. The counts and file names are the real ones where the real
+ones are known.
+
+Pure values in, a choice out. Nothing is mocked because there is nothing to mock.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_session_choice import (
+    CODE_AMBIGUOUS,
+    CODE_CHOSEN,
+    CODE_MARKER_NOT_CARRIED,
+    CODE_NO_CANDIDATES,
+    CODE_UNKNOWN,
+    SessionChoice,
+    choose_session,
+    session_id_for,
+)
+
+# Three transcripts, as scitex-clew actually held them on the night this failed.
+CLEW = ("aaa1.jsonl", "bbb2.jsonl", "ccc3.jsonl")
+CLEW_TIMES = {"aaa1.jsonl": 1000, "bbb2.jsonl": 3000, "ccc3.jsonl": 2000}
+
+
+# --------------------------------------------------------------------------
+# The marker is preferred, because it REPORTS rather than infers
+# --------------------------------------------------------------------------
+
+
+def test_the_marked_session_is_chosen_from_several_transcripts() -> None:
+    # Arrange: THE case that could not complete. Three carried transcripts and a
+    # runtime that already knows which one it is having.
+    # Act
+    choice = choose_session(
+        agent="scitex-clew", carried=CLEW, marker="aaa1", mtimes=CLEW_TIMES
+    )
+    # Assert
+    assert choice.session == "aaa1"
+
+
+def test_the_marker_beats_the_newest_file() -> None:
+    # Arrange: the ordering matters and must be falsifiable. The marker names the
+    # OLDEST here, so a test that only had one candidate could not tell the two
+    # rules apart.
+    # Act
+    choice = choose_session(
+        agent="scitex-clew", carried=CLEW, marker="aaa1", mtimes=CLEW_TIMES
+    )
+    # Assert
+    assert choice.session != session_id_for("bbb2.jsonl")
+
+
+def test_a_chosen_session_says_what_chose_it() -> None:
+    # Arrange: "the marker said so" and "it looked newest" are different levels
+    # of evidence, and a reader must be able to tell which one they are trusting.
+    # Act
+    choice = choose_session(
+        agent="scitex-clew", carried=CLEW, marker="aaa1", mtimes=CLEW_TIMES
+    )
+    # Assert
+    assert "marker" in choice.chosen_by
+
+
+def test_a_choice_reports_every_candidate_it_saw() -> None:
+    # Arrange: a choice among four that prints only the winner cannot be
+    # reviewed, and reviewing it is the whole point of choosing deliberately.
+    # Act
+    choice = choose_session(
+        agent="scitex-clew", carried=CLEW, marker="aaa1", mtimes=CLEW_TIMES
+    )
+    # Assert
+    assert choice.candidates == CLEW
+
+
+# --------------------------------------------------------------------------
+# No marker: the most recently modified travels
+# --------------------------------------------------------------------------
+
+
+def test_the_newest_transcript_is_chosen_when_there_is_no_marker() -> None:
+    # Arrange: the second rule. The live conversation is the one being written,
+    # so mtime orders them — but only once the marker is known to be absent.
+    # Act
+    choice = choose_session(
+        agent="scitex-clew", carried=CLEW, marker="", mtimes=CLEW_TIMES
+    )
+    # Assert
+    assert choice.session == "bbb2"
+
+
+def test_the_newest_choice_says_it_reasoned_from_mtime() -> None:
+    # Arrange: weaker evidence than the marker, and it must say so rather than
+    # presenting itself as the same answer.
+    # Act
+    choice = choose_session(
+        agent="scitex-clew", carried=CLEW, marker="", mtimes=CLEW_TIMES
+    )
+    # Assert
+    assert "recently modified" in choice.chosen_by
+
+
+def test_a_single_transcript_still_resolves() -> None:
+    # Arrange: the case the old guard handled, which must not regress. One file
+    # is the conversation whether or not a marker was read.
+    # Act
+    choice = choose_session(agent="a", carried=("only.jsonl",), marker="")
+    # Assert
+    assert choice.session == "only"
+
+
+def test_a_single_transcript_resolves_even_with_no_marker_read() -> None:
+    # Arrange: an unread marker cannot contradict a set of one — the only file
+    # that travels is the only conversation that can be resumed.
+    # Act
+    choice = choose_session(agent="a", carried=("only.jsonl",), marker=None)
+    # Assert
+    assert choice.code == CODE_CHOSEN
+
+
+# --------------------------------------------------------------------------
+# The refusals — each names what it saw
+# --------------------------------------------------------------------------
+
+
+def test_a_marker_naming_a_file_that_was_not_carried_refuses() -> None:
+    # Arrange: the runtime and the transport disagree about which conversation
+    # this agent is having. Picking either one silently starts the target on an
+    # undefined session, which no byte count catches.
+    # Act
+    choice = choose_session(
+        agent="scitex-clew", carried=CLEW, marker="zzz9", mtimes=CLEW_TIMES
+    )
+    # Assert
+    assert choice.session is None
+
+
+def test_that_refusal_carries_its_own_code() -> None:
+    # Arrange: callers branch on the code, never on prose, and this one calls for
+    # a different action than "go and measure it".
+    # Act
+    choice = choose_session(
+        agent="scitex-clew", carried=CLEW, marker="zzz9", mtimes=CLEW_TIMES
+    )
+    # Assert
+    assert choice.code == CODE_MARKER_NOT_CARRIED
+
+
+def test_that_refusal_names_the_candidates_it_saw() -> None:
+    # Arrange: THE operator's requirement. A refusal that says only "could not
+    # choose" turns a one-command fix into an investigation across two hosts.
+    # Act
+    choice = choose_session(
+        agent="scitex-clew", carried=CLEW, marker="zzz9", mtimes=CLEW_TIMES
+    )
+    # Assert
+    assert all(name in choice.reason for name in CLEW)
+
+
+def test_that_refusal_also_names_the_session_the_marker_wanted() -> None:
+    # Arrange: half the disagreement is the marker's side of it, and the fix is
+    # usually to that side.
+    # Act
+    choice = choose_session(
+        agent="scitex-clew", carried=CLEW, marker="zzz9", mtimes=CLEW_TIMES
+    )
+    # Assert
+    assert "zzz9" in choice.reason
+
+
+def test_zero_transcripts_refuses() -> None:
+    # Arrange: existing behaviour that must not regress. An agent started with no
+    # session resumes nothing — it boots, reports healthy, and has no memory.
+    # Act
+    choice = choose_session(agent="a", carried=(), marker="x")
+    # Assert
+    assert choice.code == CODE_NO_CANDIDATES
+
+
+def test_an_unread_marker_with_several_candidates_is_unknown_not_newest() -> None:
+    # Arrange: an unread marker is NOT an absent one. It may well name a file
+    # other than the newest, which is exactly the case where guessing is wrong.
+    # Act
+    choice = choose_session(
+        agent="scitex-clew", carried=CLEW, marker=None, mtimes=CLEW_TIMES
+    )
+    # Assert
+    assert choice.code == CODE_UNKNOWN
+
+
+def test_an_unmeasured_mtime_refuses_rather_than_sorting_around_it() -> None:
+    # Arrange: a missing mtime read as 0 would lose every comparison silently and
+    # the file would simply never be chosen. Refusing names it instead.
+    # Act
+    choice = choose_session(
+        agent="a",
+        carried=("a.jsonl", "b.jsonl"),
+        marker="",
+        mtimes={"a.jsonl": 5, "b.jsonl": None},
+    )
+    # Assert
+    assert choice.code == CODE_UNKNOWN
+
+
+def test_two_transcripts_sharing_the_newest_mtime_refuse() -> None:
+    # Arrange: "the newest" is not an answer when two are equally newest. Picking
+    # either would be the silent guess this module exists to remove.
+    # Act
+    choice = choose_session(
+        agent="a",
+        carried=("a.jsonl", "b.jsonl"),
+        marker="",
+        mtimes={"a.jsonl": 9, "b.jsonl": 9},
+    )
+    # Assert
+    assert choice.code == CODE_AMBIGUOUS
+
+
+def test_the_tie_refusal_names_both_tied_files() -> None:
+    # Arrange: the operator resolves this by seeding the marker, and cannot do
+    # that without knowing which two are in contention.
+    # Act
+    choice = choose_session(
+        agent="a",
+        carried=("a.jsonl", "b.jsonl"),
+        marker="",
+        mtimes={"a.jsonl": 9, "b.jsonl": 9},
+    )
+    # Assert
+    assert "a.jsonl" in choice.reason and "b.jsonl" in choice.reason
+
+
+def test_every_refusal_says_what_to_do_next() -> None:
+    # Arrange: an unresolved session stops a relocation and the operator is the
+    # one who resolves it, so the invariant lives in the type.
+    # Act
+    build = lambda: SessionChoice(  # noqa: E731
+        session=None, code=CODE_NO_CANDIDATES, reason="nothing"
+    )
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_a_chosen_session_must_state_its_evidence() -> None:
+    # Arrange: the other half of the same invariant — a choice with no stated
+    # basis is indistinguishable from a guess.
+    # Act
+    build = lambda: SessionChoice(  # noqa: E731
+        session="x", code=CODE_CHOSEN, reason="because"
+    )
+    # Assert
+    with pytest.raises(ValueError):
+        build()

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_transport.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_transport.py
@@ -203,7 +203,7 @@ def test_every_named_credential_basename_is_refused() -> None:
 def test_a_credential_beside_a_transcript_is_dropped_from_the_selection() -> None:
     # Arrange: the realistic shape — a directory listing containing both.
     # Act
-    carried, _ = select_transferable([".credentials.json", "abc.jsonl"])
+    carried, _, _ = select_transferable([".credentials.json", "abc.jsonl"])
     # Assert
     assert carried == ("abc.jsonl",)
 
@@ -212,7 +212,7 @@ def test_a_refused_credential_is_reported_rather_than_silently_dropped() -> None
     # Arrange: a filter whose output is only the survivors cannot be told from
     # one that never ran.
     # Act
-    _, refused = select_transferable([".credentials.json", "abc.jsonl"])
+    _, _, refused = select_transferable([".credentials.json", "abc.jsonl"])
     # Assert
     assert refused[0][0] == ".credentials.json"
 
@@ -221,7 +221,7 @@ def test_the_credential_refusal_explains_that_the_target_re_issues_its_own() -> 
     # Arrange: the reason matters — someone will eventually ask why their agent
     # lost its login, and the answer must already be in the output.
     # Act
-    _, refused = select_transferable([".credentials.json"])
+    _, _, refused = select_transferable([".credentials.json"])
     # Assert
     assert "re-issues its own" in refused[0][1]
 
@@ -229,9 +229,82 @@ def test_the_credential_refusal_explains_that_the_target_re_issues_its_own() -> 
 def test_a_non_transcript_file_does_not_travel() -> None:
     # Arrange: the allowlist, stated positively.
     # Act
-    carried, _ = select_transferable(["notes.md", "config.json", "x.jsonl"])
+    carried, _, _ = select_transferable(["notes.md", "config.json", "x.jsonl"])
     # Assert
     assert carried == ("x.jsonl",)
+
+
+# --------------------------------------------------------------------------
+# memory/ travels — measured 2026-08-11, when it did not
+# --------------------------------------------------------------------------
+
+
+def test_the_memory_directory_travels() -> None:
+    # Arrange: THE 2026-08-11 defect. A completed relocation logged
+    # "REFUSED memory" and landed an agent whose target memory/ was EMPTY while
+    # nine files and 20,014 bytes stayed on the source.
+    # Act
+    _, directories, _ = select_transferable(["a.jsonl", "memory"])
+    # Assert
+    assert directories == ("memory",)
+
+
+def test_the_memory_directory_is_no_longer_reported_as_refused() -> None:
+    # Arrange: it used to appear in the refusal list with "only conversation
+    # transcripts travel". A carried entry that still reads as refused would put
+    # a false line in the provenance record on the target.
+    # Act
+    _, _, refused = select_transferable(["a.jsonl", "memory"])
+    # Assert
+    assert refused == ()
+
+
+def test_memory_is_kept_apart_from_the_transcripts() -> None:
+    # Arrange: they are carried by different means — a transcript up to a
+    # recorded byte offset, a directory whole — so a caller that received one
+    # merged list would have to re-derive which is which, and the first to get
+    # it wrong would snapshot a directory or carry a live log unbounded.
+    # Act
+    transcripts, directories, _ = select_transferable(["a.jsonl", "memory"])
+    # Assert
+    assert transcripts == ("a.jsonl",) and directories == ("memory",)
+
+
+def test_a_plan_carries_the_memory_directory_alongside_the_transcripts() -> None:
+    # Arrange: the selection is only useful if the PLAN passes it on — the
+    # earlier bug was one layer losing it, not the filter being wrong.
+    # Act
+    plan = _ready_plan(source_files=["a.jsonl", "memory"])
+    # Assert
+    assert plan.directories == ("memory",)
+
+
+def test_the_ready_plan_says_out_loud_that_memory_is_travelling() -> None:
+    # Arrange: the operator reads this line in the dry run. "1 transcript(s)"
+    # alone is what a relocation that silently drops memory also prints.
+    # Act
+    plan = _ready_plan(source_files=["a.jsonl", "memory"])
+    # Assert
+    assert "memory/" in plan.reason
+
+
+def test_a_directory_that_is_not_memory_still_does_not_travel() -> None:
+    # Arrange: an allowlist of one directory, not "directories travel". The
+    # session's own subdirectory is the realistic neighbour.
+    # Act
+    _, directories, refused = select_transferable(["b68520e1-78fb", "memory"])
+    # Assert
+    assert directories == ("memory",) and refused[0][0] == "b68520e1-78fb"
+
+
+def test_the_refusal_says_the_source_still_holds_it() -> None:
+    # Arrange: the operator's ruling — provenance is the point. Something left
+    # behind is only a problem if nobody can find it, and nothing on the source
+    # is ever deleted.
+    # Act
+    _, _, refused = select_transferable(["notes.md"])
+    # Assert
+    assert "never deleted" in refused[0][1]
 
 
 def test_a_bare_suffix_is_not_a_transcript() -> None:
@@ -248,6 +321,16 @@ def test_a_directory_holding_no_transcript_is_a_decided_no() -> None:
     # nothing. The agent will start with no memory, which must be said out loud.
     # Act
     plan = _ready_plan(source_files=[".credentials.json", "notes.md"])
+    # Assert
+    assert plan.code == CODE_NOTHING_TO_CARRY
+
+
+def test_memory_alone_is_still_nothing_to_carry() -> None:
+    # Arrange: memory without a conversation is not a relocation. The agent
+    # would arrive with its rules and no memory of applying them, and that is
+    # the case the operator has to see before it happens, not after.
+    # Act
+    plan = _ready_plan(source_files=["memory"])
     # Assert
     assert plan.code == CODE_NOTHING_TO_CARRY
 

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_transport.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_transport.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
-"""A transport that reports success having moved a torn transcript is the whole bug.
+"""What may travel, and what to do about a destination that is already occupied.
 
-The sharpest test in this file is the TRUNCATION one, and it is built from REAL
-files rather than hand-written numbers: a transcript is written to disk, a short
-copy is made of it, and both are measured with the same counting code. That
-matters because the failure being guarded against is not arithmetic — it is a
-copy that lands, exits 0, and holds fewer lines than it left with. jsonl carries
-no trailer, so the short file parses and resumes and simply forgets the end of
-the conversation.
+The arrival half — whether what landed is what left — moved to
+:mod:`_relocate_transport_verify` and is tested beside it. This file is the
+PLANNING half: the allowlist, the credential refusal, and the move-aside.
 
 The credential test asserts the exclusion BY NAME. The allowlist already refuses
 anything that is not ``.jsonl``, so the assertion is technically redundant — and
@@ -15,7 +11,7 @@ that is the point: it pins the property the operator asked for, so a future
 change that widens the filter has to fail a test that says "credentials" rather
 than quietly starting to carry one.
 
-Real values, real files. Nothing is mocked.
+Real values. Nothing is mocked.
 """
 
 from __future__ import annotations
@@ -26,39 +22,19 @@ from scitex_agent_container._lifecycle._relocate_move_aside import (
     move_aside_destination,
 )
 from scitex_agent_container._lifecycle._relocate_transport import (
-    CODE_ARRIVED,
-    CODE_MISSING_ON_TARGET,
     CODE_NOTHING_TO_CARRY,
     CODE_READY,
     CODE_SOURCE_RUNNING,
-    CODE_TRUNCATED,
     CODE_UNKNOWN,
     CREDENTIAL_BASENAMES,
     ArrivalVerdict,
-    TranscriptFile,
     is_transferable,
     plan_transport,
     select_transferable,
-    verify_arrival,
 )
 
 STAMP = "20260811-204500"
 TARGET_DIR = "/home/agent/.claude/projects/-home-ywatanabe-proj-lead"
-LINES = [
-    '{"type":"user","text":"the conversation that moved it"}',
-    '{"type":"assistant","text":"understood"}',
-    '{"type":"user","text":"continue on the new host"}',
-]
-
-
-def _measure(path) -> TranscriptFile:
-    """Count bytes and lines the way both sides of a real transfer would."""
-    data = path.read_bytes()
-    return TranscriptFile(
-        name=path.name,
-        byte_count=len(data),
-        line_count=len(data.splitlines()),
-    )
 
 
 def _ready_plan(**over):
@@ -311,160 +287,12 @@ def test_a_missing_target_dir_refuses_rather_than_falling_back_to_the_source_pat
 
 
 # --------------------------------------------------------------------------
-# Arrival is confirmed by content — the truncation case, from real files
+# Arrival
 # --------------------------------------------------------------------------
-
-
-def test_an_identical_copy_is_confirmed(tmp_path) -> None:
-    # Arrange: the positive control for the verification half, built from real
-    # files so the counting code is exercised rather than assumed.
-    src = tmp_path / "sess.jsonl"
-    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
-    dst = tmp_path / "landed" / "sess.jsonl"
-    dst.parent.mkdir()
-    dst.write_bytes(src.read_bytes())
-    # Act
-    verdict = verify_arrival(sent=[_measure(src)], landed=[_measure(dst)])
-    # Assert
-    assert verdict.arrived is True
-
-
-def test_a_confirmed_arrival_carries_the_success_code(tmp_path) -> None:
-    # Arrange: same fixture, asserting the code callers branch on.
-    src = tmp_path / "sess.jsonl"
-    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
-    dst = tmp_path / "sess-copy.jsonl"
-    dst.write_bytes(src.read_bytes())
-    landed = TranscriptFile(
-        name="sess.jsonl",
-        byte_count=len(dst.read_bytes()),
-        line_count=len(dst.read_bytes().splitlines()),
-    )
-    # Act
-    verdict = verify_arrival(sent=[_measure(src)], landed=[landed])
-    # Assert
-    assert verdict.code == CODE_ARRIVED
-
-
-def test_a_truncated_copy_is_caught(tmp_path) -> None:
-    # Arrange: THE case. A real transcript, and a real short copy of it — the
-    # shape a partial transfer leaves behind. It parses; nothing else notices.
-    src = tmp_path / "sess.jsonl"
-    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
-    short = tmp_path / "landed" / "sess.jsonl"
-    short.parent.mkdir()
-    short.write_text(LINES[0] + "\n", encoding="utf-8")
-    # Act
-    verdict = verify_arrival(sent=[_measure(src)], landed=[_measure(short)])
-    # Assert
-    assert verdict.arrived is False
-
-
-def test_a_truncated_copy_names_the_truncation(tmp_path) -> None:
-    # Arrange: distinguishing "arrived short" from "never arrived" is what tells
-    # the operator whether to retry the copy or go and find out why it never ran.
-    src = tmp_path / "sess.jsonl"
-    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
-    short = tmp_path / "landed" / "sess.jsonl"
-    short.parent.mkdir()
-    short.write_text(LINES[0] + "\n", encoding="utf-8")
-    # Act
-    verdict = verify_arrival(sent=[_measure(src)], landed=[_measure(short)])
-    # Assert
-    assert verdict.code == CODE_TRUNCATED
-
-
-def test_the_truncation_report_names_the_file_and_both_counts(tmp_path) -> None:
-    # Arrange: "the transfer failed" without the numbers means going and diffing
-    # two hosts by hand.
-    src = tmp_path / "sess.jsonl"
-    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
-    short = tmp_path / "landed" / "sess.jsonl"
-    short.parent.mkdir()
-    short.write_text(LINES[0] + "\n", encoding="utf-8")
-    # Act
-    verdict = verify_arrival(sent=[_measure(src)], landed=[_measure(short)])
-    # Assert
-    assert "sess.jsonl" in verdict.mismatches[0] and "3 lines" in verdict.mismatches[0]
-
-
-def test_a_same_size_copy_with_a_different_line_count_is_caught() -> None:
-    # Arrange: why BOTH counts are compared. A transport that rewrote line
-    # endings can leave the byte count plausible while losing record boundaries.
-    sent = [TranscriptFile("s.jsonl", byte_count=120, line_count=3)]
-    landed = [TranscriptFile("s.jsonl", byte_count=120, line_count=1)]
-    # Act
-    verdict = verify_arrival(sent=sent, landed=landed)
-    # Assert
-    assert verdict.arrived is False
-
-
-def test_a_file_absent_on_the_target_is_its_own_outcome() -> None:
-    # Arrange: the copy did not happen at all, which is a different next move
-    # from a copy that happened badly.
-    sent = [TranscriptFile("s.jsonl", byte_count=10, line_count=1)]
-    # Act
-    verdict = verify_arrival(sent=sent, landed=[])
-    # Assert
-    assert verdict.code == CODE_MISSING_ON_TARGET
-
-
-def test_an_unmeasured_target_file_is_unknown_not_a_pass() -> None:
-    # Arrange: "I could not count it" and "it counted the same" are the two
-    # answers this function exists to keep apart.
-    sent = [TranscriptFile("s.jsonl", byte_count=10, line_count=1)]
-    landed = [TranscriptFile("s.jsonl", byte_count=None, line_count=None)]
-    # Act
-    verdict = verify_arrival(sent=sent, landed=landed)
-    # Assert
-    assert verdict.arrived is None
-
-
-def test_an_unmeasured_source_file_is_unknown_not_a_pass() -> None:
-    # Arrange: the same rule on the other side — without a baseline there is
-    # nothing to compare the target against.
-    sent = [TranscriptFile("s.jsonl")]
-    landed = [TranscriptFile("s.jsonl", byte_count=10, line_count=1)]
-    # Act
-    verdict = verify_arrival(sent=sent, landed=landed)
-    # Assert
-    assert verdict.code == CODE_UNKNOWN
-
-
-def test_an_empty_sent_set_cannot_confirm_anything() -> None:
-    # Arrange: comparing nothing to nothing must not read as a successful
-    # transfer — that is a green light produced by the absence of evidence.
-    # Act
-    verdict = verify_arrival(sent=[], landed=[])
-    # Assert
-    assert verdict.arrived is None
-
-
-def test_an_extra_file_on_the_target_is_not_a_failure() -> None:
-    # Arrange: the destination is the agent's own projects directory and may
-    # legitimately hold other conversations. Refusing here would refuse a
-    # healthy relocation onto a host the agent lived on before.
-    sent = [TranscriptFile("s.jsonl", byte_count=10, line_count=1)]
-    landed = [
-        TranscriptFile("s.jsonl", byte_count=10, line_count=1),
-        TranscriptFile("older.jsonl", byte_count=999, line_count=42),
-    ]
-    # Act
-    verdict = verify_arrival(sent=sent, landed=landed)
-    # Assert
-    assert verdict.arrived is True
-
-
-def test_an_arrival_with_mismatches_is_unrepresentable() -> None:
-    # Arrange: a success may not disagree with its own evidence — the invariant
-    # lives in the type rather than in the discipline of every call site.
-    # Act
-    build = lambda: ArrivalVerdict(  # noqa: E731
-        arrived=True, code=CODE_ARRIVED, reason="x", mismatches=("s.jsonl: short",)
-    )
-    # Assert
-    with pytest.raises(ValueError):
-        build()
+#
+# The arrival half moved to `test__relocate_transport_verify.py` with the module
+# it tests. What stays here is the ONE property that spans both halves: neither
+# outcome type may define __bool__.
 
 
 def test_neither_outcome_defines_a_bool() -> None:

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_transport_ssh.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_transport_ssh.py
@@ -4,22 +4,49 @@ Both halves are pinned WITHOUT a second machine: the argv is a pure rendering an
 the measurement parse is a pure read of captured output, which is the same seam
 the probe adapter uses. What cannot be tested here — that two real hosts agree —
 is exactly what the canary run is for.
+
+THE SNAPSHOT HALF IS TESTED AGAINST REAL FILES. ``snapshot_transcripts`` renders a
+shell script, so the only honest way to know it finds the last newline is to run
+it: the ``exec_fn`` seam hands the argv to ``subprocess.run`` and ``wc``/``head``
+actually execute against files written to ``tmp_path``. Nothing is mocked.
 """
 
 from __future__ import annotations
+
+import subprocess
 
 import pytest
 
 from scitex_agent_container._lifecycle._relocate_probe_ssh import RemoteRun
 from scitex_agent_container._lifecycle._relocate_shell import Shell
+from scitex_agent_container._lifecycle._relocate_transport import TranscriptFile
 from scitex_agent_container._lifecycle._relocate_transport_ssh import (
     MARK_FILE,
     build_copy_argv,
+    measure_transcripts,
     parse_measurements,
+    snapshot_transcripts,
 )
 
 LOCAL = Shell(host="src-host", is_local=True)
 REMOTE = Shell(host="tgt-host")
+
+
+def _real_exec(argv, timeout_s=None):
+    """Actually run the argv. The seam the production code already takes."""
+    done = subprocess.run(argv, capture_output=True, text=True, timeout=timeout_s)
+    return {
+        "exit_code": done.returncode,
+        "stdout": done.stdout,
+        "stderr": done.stderr,
+        "timed_out": False,
+    }
+
+
+def _snap(*names, offset=120, lines=4):
+    return [
+        TranscriptFile(name=n, byte_count=offset, line_count=lines) for n in names
+    ]
 
 
 def _argv(files):
@@ -32,49 +59,107 @@ def _argv(files):
     )
 
 
-def test_the_carried_names_are_passed_as_arguments_not_a_glob() -> None:
-    # Arrange: THE reason tar was chosen over scp/rsync. The allowlist decided an
-    # exact set; a glob would be re-expanded at copy time and carry whatever
-    # matched a moment later.
+# --------------------------------------------------------------------------
+# The copy command: exact names, exact byte counts
+# --------------------------------------------------------------------------
+
+
+def test_the_carried_names_are_passed_as_paths_not_a_glob() -> None:
+    # Arrange: THE reason this is not scp-with-a-remote-glob. The allowlist
+    # decided an exact set; a glob would be re-expanded at copy time and carry
+    # whatever matched a moment later.
     # Act
-    pipeline = _argv(["a.jsonl", "b.jsonl"])[-1]
+    pipeline = _argv(_snap("a.jsonl", "b.jsonl"))[-1]
     # Assert
-    assert "-- a.jsonl b.jsonl" in pipeline
+    assert "/src/projects/-p/a.jsonl" in pipeline and "/src/projects/-p/b.jsonl" in pipeline
 
 
 def test_no_glob_character_reaches_either_shell() -> None:
     # Arrange: the same rule, stated as the property that must hold rather than
     # the string that happens to appear.
     # Act
-    pipeline = _argv(["a.jsonl"])[-1]
+    pipeline = _argv(_snap("a.jsonl"))[-1]
     # Assert
     assert "*" not in pipeline
 
 
-def test_the_pipeline_uses_pipefail_so_a_failed_source_is_not_masked() -> None:
-    # Arrange: without it the pipeline reports only the LAST stage, so a tar that
-    # failed outright is hidden by an ssh that extracted nothing.
+def test_the_read_is_bounded_by_the_recorded_offset() -> None:
+    # Arrange: the 2026-08-12 fix. The copy carries the number that was recorded
+    # BEFORE it started, so a source that grows underneath it changes nothing.
     # Act
-    pipeline = _argv(["a.jsonl"])[-1]
+    pipeline = _argv(_snap("a.jsonl", offset=108412278))[-1]
+    # Assert
+    assert "head -c 108412278" in pipeline
+
+
+def test_every_file_gets_its_own_bound() -> None:
+    # Arrange: one offset per file, because they were snapshotted independently
+    # and a shared bound would truncate one and overrun another.
+    files = [
+        TranscriptFile("a.jsonl", byte_count=10, line_count=1),
+        TranscriptFile("b.jsonl", byte_count=99, line_count=3),
+    ]
+    # Act
+    pipeline = _argv(files)[-1]
+    # Assert
+    assert "head -c 10" in pipeline and "head -c 99" in pipeline
+
+
+def test_a_file_with_no_recorded_offset_is_refused() -> None:
+    # Arrange: carrying "however much is there now" restores the exact race the
+    # snapshot removes, and the mismatch it produces is reported against a
+    # source that has already moved.
+    unbounded = [TranscriptFile("a.jsonl")]
+    # Act
+    call = lambda: _argv(unbounded)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        call()
+
+
+def test_the_pipeline_uses_pipefail_so_a_failed_source_is_not_masked() -> None:
+    # Arrange: without it a pipeline reports only the LAST stage, so a read that
+    # failed outright is hidden by an ssh that cheerfully wrote nothing.
+    # Act
+    pipeline = _argv(_snap("a.jsonl"))[-1]
     # Assert
     assert "set -o pipefail" in pipeline
 
 
-def test_the_destination_is_created_on_the_target_before_extracting() -> None:
+def test_the_stages_are_chained_so_the_first_failure_stops_the_rest() -> None:
+    # Arrange: one connection per file means several ways to fail. Carrying on
+    # after one has failed would leave a half-populated target that the count
+    # check then has to untangle.
+    # Act
+    pipeline = _argv(_snap("a.jsonl", "b.jsonl"))[-1]
+    # Assert
+    assert " && " in pipeline
+
+
+def test_the_destination_is_created_on_the_target_before_writing() -> None:
     # Arrange: the target's transcript root may not exist at all — it is the
     # agent's own directory on a host it has never run on.
     # Act
-    pipeline = _argv(["a.jsonl"])[-1]
+    pipeline = _argv(_snap("a.jsonl"))[-1]
     # Assert
     assert "mkdir -p /tgt/projects/-p" in pipeline
+
+
+def test_the_bytes_land_under_the_targets_own_directory() -> None:
+    # Arrange: the destination is recomputed from the TARGET's workdir, and a
+    # file written under the source's name is present, intact and invisible.
+    # Act
+    pipeline = _argv(_snap("a.jsonl"))[-1]
+    # Assert
+    assert "/tgt/projects/-p/a.jsonl" in pipeline
 
 
 def test_an_empty_file_list_is_refused() -> None:
     # Arrange: a copy that transfers nothing and exits 0 is the exact failure
     # shape this feature exists to prevent.
-    empty: list[str] = []
+    empty: list[TranscriptFile] = []
     # Act
-    call = lambda: _argv(empty)
+    call = lambda: _argv(empty)  # noqa: E731
     # Assert
     with pytest.raises(ValueError):
         call()
@@ -84,9 +169,9 @@ def test_a_credential_is_refused_at_the_point_the_bytes_would_move() -> None:
     # Arrange: select_transferable already declines these, but THIS function is
     # generic and will carry any named file. A transport that would copy a
     # credential if asked is one that eventually does.
-    named = [".credentials.json"]
+    named = _snap(".credentials.json")
     # Act
-    call = lambda: _argv(named)
+    call = lambda: _argv(named)  # noqa: E731
     # Assert
     with pytest.raises(ValueError):
         call()
@@ -95,9 +180,9 @@ def test_a_credential_is_refused_at_the_point_the_bytes_would_move() -> None:
 def test_a_path_component_in_a_name_is_refused() -> None:
     # Arrange: a "/" would place the file outside the directory the allowlist was
     # applied to, which quietly widens the allowlist to the whole filesystem.
-    escaping = ["../elsewhere/a.jsonl"]
+    escaping = _snap("../elsewhere/a.jsonl")
     # Act
-    call = lambda: _argv(escaping)
+    call = lambda: _argv(escaping)  # noqa: E731
     # Assert
     with pytest.raises(ValueError):
         call()
@@ -107,9 +192,9 @@ def test_a_local_source_is_read_without_an_intervening_ssh() -> None:
     # Arrange: the source IS where the coordinator runs, in the ordinary case.
     # ssh-ing to ourselves is one more connection that can fail.
     # Act
-    pipeline = _argv(["a.jsonl"])[-1]
+    pipeline = _argv(_snap("a.jsonl"))[-1]
     # Assert
-    assert pipeline.startswith("set -o pipefail; tar -C /src/projects/-p")
+    assert pipeline.startswith("set -o pipefail; head -c 120 -- /src/projects/-p/a.jsonl")
 
 
 def test_a_remote_source_is_read_over_ssh() -> None:
@@ -121,10 +206,118 @@ def test_a_remote_source_is_read_over_ssh() -> None:
         source_dir="/src/p",
         target=REMOTE,
         target_dir="/tgt/p",
-        files=["a.jsonl"],
+        files=_snap("a.jsonl"),
     )
     # Assert
     assert argv[-1].startswith("set -o pipefail; ssh ")
+
+
+# --------------------------------------------------------------------------
+# The snapshot: real files, real offsets
+# --------------------------------------------------------------------------
+
+
+def _write(tmp_path, body: str, name="sess.jsonl"):
+    directory = tmp_path / "projects"
+    directory.mkdir(exist_ok=True)
+    path = directory / name
+    path.write_text(body, encoding="utf-8")
+    return directory, path
+
+
+def test_a_file_ending_in_a_newline_snapshots_its_whole_length(tmp_path) -> None:
+    # Arrange: the ordinary case. Every record is complete, so the snapshot is
+    # the file and nothing is given up.
+    directory, path = _write(tmp_path, '{"a":1}\n{"b":2}\n')
+    # Act
+    snap = snapshot_transcripts(
+        Shell(host="h", is_local=True), str(directory), ["sess.jsonl"], exec_fn=_real_exec
+    )
+    # Assert
+    assert snap[0].byte_count == path.stat().st_size
+
+
+def test_a_half_written_record_is_cut_at_the_last_newline(tmp_path) -> None:
+    # Arrange: THE case. A record is mid-flight, so the snapshot stops at the
+    # last complete line. Cutting anywhere else hands the target malformed JSON
+    # inside a file that still parses as JSONL everywhere else.
+    directory, _ = _write(tmp_path, '{"a":1}\n{"b":2}\n{"half":')
+    # Act
+    snap = snapshot_transcripts(
+        Shell(host="h", is_local=True), str(directory), ["sess.jsonl"], exec_fn=_real_exec
+    )
+    # Assert
+    assert snap[0].byte_count == len('{"a":1}\n{"b":2}\n')
+
+
+def test_the_snapshot_counts_only_complete_lines(tmp_path) -> None:
+    # Arrange: the line count travels with the offset and is what arrival is
+    # checked against, so the partial record must not be counted as a line.
+    directory, _ = _write(tmp_path, '{"a":1}\n{"b":2}\n{"half":')
+    # Act
+    snap = snapshot_transcripts(
+        Shell(host="h", is_local=True), str(directory), ["sess.jsonl"], exec_fn=_real_exec
+    )
+    # Assert
+    assert snap[0].line_count == 2
+
+
+def test_a_file_with_no_newline_at_all_snapshots_nothing(tmp_path) -> None:
+    # Arrange: there is no complete record to carry. Zero is the honest answer —
+    # and it is a MEASURED zero, which verification can check the target against.
+    directory, _ = _write(tmp_path, '{"half":')
+    # Act
+    snap = snapshot_transcripts(
+        Shell(host="h", is_local=True), str(directory), ["sess.jsonl"], exec_fn=_real_exec
+    )
+    # Assert
+    assert snap[0].byte_count == 0
+
+
+def test_the_snapshot_is_smaller_than_the_file_when_the_file_is_still_growing(
+    tmp_path,
+) -> None:
+    # Arrange: the whole point. The source grows after the snapshot; the
+    # recorded offset does not follow it.
+    directory, path = _write(tmp_path, '{"a":1}\n')
+    snap = snapshot_transcripts(
+        Shell(host="h", is_local=True), str(directory), ["sess.jsonl"], exec_fn=_real_exec
+    )
+    # Act
+    with open(path, "ab") as handle:
+        handle.write(b'{"b":2}\n')
+    # Assert
+    assert snap[0].byte_count < path.stat().st_size
+
+
+def test_a_file_that_is_not_there_is_absent_rather_than_zero(tmp_path) -> None:
+    # Arrange: absent and empty are different answers, and only one of them
+    # means the copy has nothing to do.
+    directory, _ = _write(tmp_path, '{"a":1}\n')
+    # Act
+    snap = snapshot_transcripts(
+        Shell(host="h", is_local=True), str(directory), ["gone.jsonl"], exec_fn=_real_exec
+    )
+    # Assert
+    assert snap == ()
+
+
+def test_the_target_side_measurement_reads_the_whole_file(tmp_path) -> None:
+    # Arrange: the two measurements are deliberately different questions. The
+    # source is asked for its last COMPLETE line; the target is asked what it
+    # actually holds, and the comparison between them is the verdict.
+    directory, path = _write(tmp_path, '{"a":1}\n{"half":')
+    # Act
+    measured = measure_transcripts(
+        Shell(host="h", is_local=True), str(directory), ["sess.jsonl"], exec_fn=_real_exec
+    )
+    # Assert
+    assert measured[0].byte_count == path.stat().st_size
+
+
+# --------------------------------------------------------------------------
+# The parse
+# --------------------------------------------------------------------------
 
 
 def test_measurements_are_read_off_the_marker_lines() -> None:

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_transport_ssh.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_transport_ssh.py
@@ -23,6 +23,7 @@ from scitex_agent_container._lifecycle._relocate_transport import TranscriptFile
 from scitex_agent_container._lifecycle._relocate_transport_ssh import (
     MARK_FILE,
     build_copy_argv,
+    build_tree_copy_argv,
     measure_transcripts,
     parse_measurements,
     snapshot_transcripts,
@@ -210,6 +211,91 @@ def test_a_remote_source_is_read_over_ssh() -> None:
     )
     # Assert
     assert argv[-1].startswith("set -o pipefail; ssh ")
+
+
+# --------------------------------------------------------------------------
+# Whole trees: memory/ and the spec directory
+# --------------------------------------------------------------------------
+
+
+def _tree_argv(names):
+    return build_tree_copy_argv(
+        source=LOCAL,
+        source_dir="/src/projects/-p",
+        target=REMOTE,
+        target_dir="/tgt/projects/-p",
+        names=names,
+    )
+
+
+def test_a_directory_is_carried_by_tar_not_by_a_byte_bound() -> None:
+    # Arrange: a memory note is not an append-only log being flushed, so there
+    # is no last newline to cut at and half of one is not a shorter version of
+    # it. Directories travel whole.
+    # Act
+    pipeline = _tree_argv(["memory"])[-1]
+    # Assert
+    assert "tar -C /src/projects/-p -cf - -- memory" in pipeline
+
+
+def test_the_tree_copy_passes_names_as_arguments_not_a_glob() -> None:
+    # Arrange: tar's original argument, which still holds for this half — a glob
+    # would be re-expanded at copy time and carry whatever matched a moment later.
+    # Act
+    pipeline = _tree_argv(["memory"])[-1]
+    # Assert
+    assert "*" not in pipeline
+
+
+def test_the_tree_copy_uses_pipefail() -> None:
+    # Arrange: without it the pipeline reports only the last stage, so a tar
+    # that failed outright is masked by an ssh that extracted nothing.
+    # Act
+    pipeline = _tree_argv(["memory"])[-1]
+    # Assert
+    assert "set -o pipefail" in pipeline
+
+
+def test_the_tree_copy_creates_the_destination() -> None:
+    # Arrange: the target's projects directory may not exist at all — it is the
+    # agent's own directory on a host it has never run on.
+    # Act
+    pipeline = _tree_argv(["memory"])[-1]
+    # Assert
+    assert "mkdir -p /tgt/projects/-p" in pipeline
+
+
+def test_an_empty_tree_list_is_refused() -> None:
+    # Arrange: same rule as the transcript copy — a transfer of nothing that
+    # exits 0 is the failure shape this feature exists to prevent.
+    empty: list[str] = []
+    # Act
+    call = lambda: _tree_argv(empty)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        call()
+
+
+def test_the_tree_copy_refuses_a_credential_by_name() -> None:
+    # Arrange: this function is generic and will carry any named entry, and a
+    # DIRECTORY copy is exactly how one could be smuggled past a per-file check.
+    named = [".credentials.json"]
+    # Act
+    call = lambda: _tree_argv(named)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        call()
+
+
+def test_the_tree_copy_refuses_a_path_component() -> None:
+    # Arrange: a "/" would place the copy outside the directory the allowlist
+    # was applied to, quietly widening it to the whole filesystem.
+    escaping = ["../elsewhere"]
+    # Act
+    call = lambda: _tree_argv(escaping)  # noqa: E731
+    # Assert
+    with pytest.raises(ValueError):
+        call()
 
 
 # --------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_transport_verify.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_transport_verify.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""A transport that reports success having moved a torn transcript is the whole bug.
+
+The sharpest tests here are built from REAL files rather than hand-written
+numbers: a transcript is written to disk, a real short copy is made of it, and
+both are measured with the same counting code. That matters because the failure
+being guarded against is not arithmetic — it is a copy that lands, exits 0, and
+holds fewer lines than it left with. jsonl carries no trailer, so the short file
+parses and resumes and simply forgets the end of the conversation.
+
+The 2026-08-12 test is the mirror image and is the reason this module exists
+separately. The relocation that failed that night reported a mismatch in which the
+TARGET held 11,717 bytes MORE than the source measurement, on an IDENTICAL line
+count — a source that finished flushing its last line after being measured, not a
+copy that lost anything. It was reported in the words of a truncation. Two of the
+tests below assert that those two situations no longer produce the same message,
+and one asserts the fix that removes the situation altogether: verification is
+against the SNAPSHOT, so a source that grows afterwards still verifies.
+
+Real values, real files. Nothing is mocked.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_shell import Shell
+from scitex_agent_container._lifecycle._relocate_transport_ssh import (
+    measure_transcripts,
+    snapshot_transcripts,
+)
+from scitex_agent_container._lifecycle._relocate_transport_verify import (
+    CODE_ARRIVED,
+    CODE_MISSING_ON_TARGET,
+    CODE_TARGET_LARGER,
+    CODE_TRUNCATED,
+    CODE_UNKNOWN,
+    ArrivalVerdict,
+    TranscriptFile,
+    verify_arrival,
+)
+
+LOCAL = Shell(host="here", is_local=True)
+
+LINES = [
+    '{"type":"user","text":"the conversation that moved it"}',
+    '{"type":"assistant","text":"understood"}',
+    '{"type":"user","text":"continue on the new host"}',
+]
+
+
+def _real_exec(argv, timeout_s=None):
+    done = subprocess.run(argv, capture_output=True, text=True, timeout=timeout_s)
+    return {
+        "exit_code": done.returncode,
+        "stdout": done.stdout,
+        "stderr": done.stderr,
+        "timed_out": False,
+    }
+
+
+def _measure(path) -> TranscriptFile:
+    """Count bytes and lines the way both sides of a real transfer would."""
+    data = path.read_bytes()
+    return TranscriptFile(
+        name=path.name,
+        byte_count=len(data),
+        line_count=len(data.splitlines()),
+    )
+
+
+def _carry(source, destination, byte_offset: int) -> None:
+    """Copy exactly ``byte_offset`` bytes, with the real tool the transport uses."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    done = subprocess.run(
+        ["head", "-c", str(byte_offset), "--", str(source)],
+        capture_output=True,
+    )
+    destination.write_bytes(done.stdout)
+
+
+# --------------------------------------------------------------------------
+# The snapshot removes the race: a source that grows still verifies
+# --------------------------------------------------------------------------
+
+
+def test_a_source_that_grows_between_the_snapshot_and_the_copy_still_verifies(
+    tmp_path,
+) -> None:
+    # Arrange: THE 2026-08-12 fix, end to end with real files and the real
+    # tools. The offset is recorded, the source then grows exactly as the dying
+    # process's flush made it grow, and the copy is still bounded by the number
+    # taken first.
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    src = src_dir / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
+    snapshot = snapshot_transcripts(
+        LOCAL, str(src_dir), ["sess.jsonl"], exec_fn=_real_exec
+    )
+    with open(src, "ab") as handle:
+        handle.write(b'{"type":"assistant","text":"a late flush"}\n')
+    tgt_dir = tmp_path / "tgt"
+    _carry(src, tgt_dir / "sess.jsonl", snapshot[0].byte_count)
+    landed = measure_transcripts(
+        LOCAL, str(tgt_dir), ["sess.jsonl"], exec_fn=_real_exec
+    )
+    # Act
+    verdict = verify_arrival(sent=snapshot, landed=landed)
+    # Assert
+    assert verdict.arrived is True
+
+
+def test_the_growth_does_not_reach_the_target(tmp_path) -> None:
+    # Arrange: the other half of the same property. "It verifies" would be
+    # worthless if the copy had simply carried the extra bytes too — the bound
+    # has to be the recorded number, not whatever was there at read time.
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    src = src_dir / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
+    snapshot = snapshot_transcripts(
+        LOCAL, str(src_dir), ["sess.jsonl"], exec_fn=_real_exec
+    )
+    with open(src, "ab") as handle:
+        handle.write(b'{"type":"assistant","text":"a late flush"}\n')
+    landed_path = tmp_path / "tgt" / "sess.jsonl"
+    # Act
+    _carry(src, landed_path, snapshot[0].byte_count)
+    # Assert
+    assert landed_path.stat().st_size < src.stat().st_size
+
+
+def test_a_half_written_final_record_does_not_travel(tmp_path) -> None:
+    # Arrange: the reason the cut is at the last NEWLINE. Carrying a partial
+    # record would hand the target malformed JSON inside a file that still parses
+    # as JSONL everywhere else, which is worse than a shorter file.
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    src = src_dir / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n" + '{"type":"assis', encoding="utf-8")
+    snapshot = snapshot_transcripts(
+        LOCAL, str(src_dir), ["sess.jsonl"], exec_fn=_real_exec
+    )
+    landed_path = tmp_path / "tgt" / "sess.jsonl"
+    _carry(src, landed_path, snapshot[0].byte_count)
+    # Act
+    tail = landed_path.read_bytes()
+    # Assert
+    assert tail.endswith(b"\n")
+
+
+def test_the_carried_prefix_verifies_against_its_own_snapshot(tmp_path) -> None:
+    # Arrange: the same torn-record source, checked the way the transport checks
+    # it. A file cut at the last newline is a complete, verifiable payload.
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    src = src_dir / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n" + '{"type":"assis', encoding="utf-8")
+    snapshot = snapshot_transcripts(
+        LOCAL, str(src_dir), ["sess.jsonl"], exec_fn=_real_exec
+    )
+    tgt_dir = tmp_path / "tgt"
+    _carry(src, tgt_dir / "sess.jsonl", snapshot[0].byte_count)
+    landed = measure_transcripts(
+        LOCAL, str(tgt_dir), ["sess.jsonl"], exec_fn=_real_exec
+    )
+    # Act
+    verdict = verify_arrival(sent=snapshot, landed=landed)
+    # Assert
+    assert verdict.arrived is True
+
+
+# --------------------------------------------------------------------------
+# Arrival is confirmed by content — the truncation case, from real files
+# --------------------------------------------------------------------------
+
+
+def test_an_identical_copy_is_confirmed(tmp_path) -> None:
+    # Arrange: the positive control for the verification half, built from real
+    # files so the counting code is exercised rather than assumed.
+    src = tmp_path / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
+    dst = tmp_path / "landed" / "sess.jsonl"
+    dst.parent.mkdir()
+    dst.write_bytes(src.read_bytes())
+    # Act
+    verdict = verify_arrival(sent=[_measure(src)], landed=[_measure(dst)])
+    # Assert
+    assert verdict.arrived is True
+
+
+def test_a_confirmed_arrival_carries_the_success_code(tmp_path) -> None:
+    # Arrange: same fixture, asserting the code callers branch on.
+    src = tmp_path / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
+    dst = tmp_path / "sess-copy.jsonl"
+    dst.write_bytes(src.read_bytes())
+    landed = TranscriptFile(
+        name="sess.jsonl",
+        byte_count=len(dst.read_bytes()),
+        line_count=len(dst.read_bytes().splitlines()),
+    )
+    # Act
+    verdict = verify_arrival(sent=[_measure(src)], landed=[landed])
+    # Assert
+    assert verdict.code == CODE_ARRIVED
+
+
+def test_a_truncated_copy_is_caught(tmp_path) -> None:
+    # Arrange: THE case. A real transcript, and a real short copy of it — the
+    # shape a partial transfer leaves behind. It parses; nothing else notices.
+    src = tmp_path / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
+    short = tmp_path / "landed" / "sess.jsonl"
+    short.parent.mkdir()
+    short.write_text(LINES[0] + "\n", encoding="utf-8")
+    # Act
+    verdict = verify_arrival(sent=[_measure(src)], landed=[_measure(short)])
+    # Assert
+    assert verdict.arrived is False
+
+
+def test_a_truncated_copy_names_the_truncation(tmp_path) -> None:
+    # Arrange: distinguishing "arrived short" from "never arrived" is what tells
+    # the operator whether to retry the copy or go and find out why it never ran.
+    src = tmp_path / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
+    short = tmp_path / "landed" / "sess.jsonl"
+    short.parent.mkdir()
+    short.write_text(LINES[0] + "\n", encoding="utf-8")
+    # Act
+    verdict = verify_arrival(sent=[_measure(src)], landed=[_measure(short)])
+    # Assert
+    assert verdict.code == CODE_TRUNCATED
+
+
+def test_the_truncation_report_names_the_file_and_both_counts(tmp_path) -> None:
+    # Arrange: "the transfer failed" without the numbers means going and diffing
+    # two hosts by hand.
+    src = tmp_path / "sess.jsonl"
+    src.write_text("\n".join(LINES) + "\n", encoding="utf-8")
+    short = tmp_path / "landed" / "sess.jsonl"
+    short.parent.mkdir()
+    short.write_text(LINES[0] + "\n", encoding="utf-8")
+    # Act
+    verdict = verify_arrival(sent=[_measure(src)], landed=[_measure(short)])
+    # Assert
+    assert "sess.jsonl" in verdict.mismatches[0] and "3 lines" in verdict.mismatches[0]
+
+
+def test_a_same_size_copy_with_a_different_line_count_is_caught() -> None:
+    # Arrange: why BOTH counts are compared. A transport that rewrote line
+    # endings can leave the byte count plausible while losing record boundaries.
+    sent = [TranscriptFile("s.jsonl", byte_count=120, line_count=3)]
+    landed = [TranscriptFile("s.jsonl", byte_count=120, line_count=1)]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert verdict.arrived is False
+
+
+# --------------------------------------------------------------------------
+# Short and larger are different answers — the 2026-08-12 report
+# --------------------------------------------------------------------------
+
+
+def test_a_target_holding_more_is_not_reported_as_a_truncation() -> None:
+    # Arrange: the exact numbers from the 2026-08-12 abort. It fired on MORE and
+    # said "fewer bytes or lines than it left with", which sends the reader
+    # hunting for bytes lost in transit that were never lost.
+    sent = [TranscriptFile("b68520e1.jsonl", byte_count=108412278, line_count=58325)]
+    landed = [TranscriptFile("b68520e1.jsonl", byte_count=108423995, line_count=58325)]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert verdict.code == CODE_TARGET_LARGER
+
+
+def test_a_target_holding_more_still_refuses() -> None:
+    # Arrange: a checker that cannot say WHY must stop. The remedy differs; the
+    # refusal does not.
+    sent = [TranscriptFile("s.jsonl", byte_count=100, line_count=3)]
+    landed = [TranscriptFile("s.jsonl", byte_count=111, line_count=3)]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert verdict.arrived is False
+
+
+def test_short_and_larger_do_not_produce_the_same_message() -> None:
+    # Arrange: THE complaint. The two were reported identically, and they call
+    # for opposite next moves — distrust the copy, versus re-measure the source.
+    sent = [TranscriptFile("s.jsonl", byte_count=100, line_count=3)]
+    # Act
+    short = verify_arrival(
+        sent=sent, landed=[TranscriptFile("s.jsonl", byte_count=90, line_count=2)]
+    )
+    larger = verify_arrival(
+        sent=sent, landed=[TranscriptFile("s.jsonl", byte_count=111, line_count=3)]
+    )
+    # Assert
+    assert short.mismatches[0] != larger.mismatches[0] and short.hint != larger.hint
+
+
+def test_the_larger_report_says_nothing_went_missing() -> None:
+    # Arrange: the operator's first question on seeing a mismatch is "did I lose
+    # part of the conversation". The answer is in the line, not in an inference.
+    sent = [TranscriptFile("s.jsonl", byte_count=100, line_count=3)]
+    landed = [TranscriptFile("s.jsonl", byte_count=111, line_count=3)]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert "Nothing went\nmissing" in verdict.mismatches[0].replace(" ", "\n", 0) or (
+        "Nothing went missing" in verdict.mismatches[0]
+    )
+
+
+def test_an_identical_line_count_is_called_out_as_no_record_appended() -> None:
+    # Arrange: the diagnostic that identifies this shape. Same line count means
+    # a line that was already there simply got longer — a shutdown flush, not a
+    # continuing conversation.
+    sent = [TranscriptFile("s.jsonl", byte_count=100, line_count=3)]
+    landed = [TranscriptFile("s.jsonl", byte_count=111, line_count=3)]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert "no record was appended" in verdict.mismatches[0]
+
+
+def test_a_short_file_among_larger_ones_reports_the_short_one() -> None:
+    # Arrange: worst-first. One file missing bytes is the finding worth acting
+    # on, and a mixed set must not be softened into "the source moved".
+    sent = [
+        TranscriptFile("a.jsonl", byte_count=100, line_count=3),
+        TranscriptFile("b.jsonl", byte_count=100, line_count=3),
+    ]
+    landed = [
+        TranscriptFile("a.jsonl", byte_count=111, line_count=3),
+        TranscriptFile("b.jsonl", byte_count=50, line_count=1),
+    ]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert verdict.code == CODE_TRUNCATED
+
+
+def test_the_larger_hint_says_not_to_treat_the_targets_copy_as_damaged() -> None:
+    # Arrange: the remedy is the opposite of the truncation one. Discarding the
+    # target's copy here would throw away the MORE complete of the two.
+    sent = [TranscriptFile("s.jsonl", byte_count=100, line_count=3)]
+    landed = [TranscriptFile("s.jsonl", byte_count=111, line_count=3)]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert "damaged" in verdict.hint
+
+
+# --------------------------------------------------------------------------
+# Absent, unmeasured, and the type's own invariants
+# --------------------------------------------------------------------------
+
+
+def test_a_file_absent_on_the_target_is_its_own_outcome() -> None:
+    # Arrange: the copy did not happen at all, which is a different next move
+    # from a copy that happened badly.
+    sent = [TranscriptFile("s.jsonl", byte_count=10, line_count=1)]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=[])
+    # Assert
+    assert verdict.code == CODE_MISSING_ON_TARGET
+
+
+def test_an_unmeasured_target_file_is_unknown_not_a_pass() -> None:
+    # Arrange: "I could not count it" and "it counted the same" are the two
+    # answers this function exists to keep apart.
+    sent = [TranscriptFile("s.jsonl", byte_count=10, line_count=1)]
+    landed = [TranscriptFile("s.jsonl", byte_count=None, line_count=None)]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert verdict.arrived is None
+
+
+def test_an_unmeasured_source_file_is_unknown_not_a_pass() -> None:
+    # Arrange: the same rule on the other side — without a baseline there is
+    # nothing to compare the target against.
+    sent = [TranscriptFile("s.jsonl")]
+    landed = [TranscriptFile("s.jsonl", byte_count=10, line_count=1)]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert verdict.code == CODE_UNKNOWN
+
+
+def test_an_empty_sent_set_cannot_confirm_anything() -> None:
+    # Arrange: comparing nothing to nothing must not read as a successful
+    # transfer — that is a green light produced by the absence of evidence.
+    # Act
+    verdict = verify_arrival(sent=[], landed=[])
+    # Assert
+    assert verdict.arrived is None
+
+
+def test_an_extra_file_on_the_target_is_not_a_failure() -> None:
+    # Arrange: the destination is the agent's own projects directory and may
+    # legitimately hold other conversations. Refusing here would refuse a
+    # healthy relocation onto a host the agent lived on before.
+    sent = [TranscriptFile("s.jsonl", byte_count=10, line_count=1)]
+    landed = [
+        TranscriptFile("s.jsonl", byte_count=10, line_count=1),
+        TranscriptFile("older.jsonl", byte_count=999, line_count=42),
+    ]
+    # Act
+    verdict = verify_arrival(sent=sent, landed=landed)
+    # Assert
+    assert verdict.arrived is True
+
+
+def test_an_arrival_with_mismatches_is_unrepresentable() -> None:
+    # Arrange: a success may not disagree with its own evidence — the invariant
+    # lives in the type rather than in the discipline of every call site.
+    # Act
+    build = lambda: ArrivalVerdict(  # noqa: E731
+        arrived=True, code=CODE_ARRIVED, reason="x", mismatches=("s.jsonl: short",)
+    )
+    # Assert
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_the_verdict_defines_no_bool() -> None:
+    # Arrange: `if verdict:` on an UNKNOWN would read as a yes, and the next
+    # thing that happens is a write onto another machine. Python falls back to
+    # truthy for any object, so the guard is that we never DEFINE __bool__ —
+    # pinned so a future convenience has to argue with a test.
+    # Act
+    defined = "__bool__" in vars(ArrivalVerdict)
+    # Assert
+    assert defined is False


### PR DESCRIPTION
Five fixes, all from the relocation that failed on the night of 2026-08-12. Each was approved by the operator; none is a redesign.

## The abort that produced the first three

```
MISMATCH b68520e1-….jsonl:
  sent   108,412,278 bytes / 58,325 lines
  target 108,423,995 bytes / 58,325 lines
```

Identical **line** counts, 11,717 bytes apart, and the **target holds more**. No record was appended — the final line got longer. The agent had already been stopped and `source_stop` had confirmed it; what grew the file was the dying process's shutdown flush finishing its last line after tmux had let go of the session. The source was *measured* at one instant and *read* at another, and nothing guaranteed it was unchanged in between.

### 1. `source_stop` waits for the file, not only for tmux

A tmux session disappearing is not the process exiting and releasing its file descriptor. The stop phase now goes through `_relocate_quiescence`, which samples every `*.jsonl` in the source's project directory and requires **two consecutive identical `(size, mtime)` readings, 2 s apart, bounded at 30 s**.

- 2 s is long enough that a shutdown flush cannot span both readings and still look stable, and costs a healthy relocation one interval.
- 30 s is ~15 readings — long enough for a process slow to let go, short enough that a wedged host fails the phase promptly rather than sitting in front of the copy's 900 s budget.
- A wait that runs out returns **UNKNOWN naming what moved and by how much**, never success, and never `False` (the agent *is* stopped; that would send someone to stop a process already down).
- **Both** exits from the liveness check go through it, including `already stopped` — which is the exit the failing run actually took.

An open-descriptor check would be stronger and is deliberately not used: `lsof`/`fuser` are absent on the fleet's busybox targets and need privileges elsewhere, so its unavailable case is UNKNOWN on hosts where the cheap check answers plainly.

### 2. Transport snapshots a byte offset first

Before anything moves, `snapshot_transcripts` records each file's offset of its **last newline**; the copy carries exactly that many bytes; and arrival is verified against **that recorded number**, not a fresh reading of a source that may have moved. The source is now free to grow underneath the transfer without changing the answer.

The cut is at a newline specifically: an arbitrary offset lands mid-record and hands the target malformed JSON inside an otherwise valid JSONL file. Losing at most one partially-written record is the accepted trade — the module's own abort text already predicts it.

**The copy changed from tar to `head -c <offset>` per file.** tar cannot carry part of a file, and a whole file is by definition not a snapshot. The exact-names property tar was chosen for is kept (paths are built in Python; nothing globs on either side). The cost is one ssh per transcript, chained under `&&` inside a single host-side `bash -c`, so it is still one `host_exec` and one exit code. Measured before choosing it: the busiest project directory on this fleet holds six transcripts. Truncating on the *target* instead would keep one connection but ship the extra bytes and then discard them, and would need `truncate` or a temp-file rewrite on hosts that may have neither.

### 3. The mismatch message distinguishes growth from loss

`CODE_TRUNCATED` was documented as *"fewer bytes or lines"* and fired on **more**, reporting it identically.

| shape | code | what it means |
|---|---|---|
| `target < sent` | 422 | bytes went missing; the copy is suspect |
| `target > sent` | **409 (new)** | nothing went missing; the source settled after being measured |
| absent | 404 | the copy did not happen |

Both still refuse. The mismatch line now names the direction and the signed delta, and when the line count is unchanged it says out loud that no record was appended — a line that was already there simply got longer. Worst-first: one short file in a mixed set still reports 422.

## The fifth fix, which gates nine more agents

### 4. The session to resume is chosen, not assumed

The transport named it with `if len(plan.files) == 1`. Measured on ywata-note-win: **not one of the ten agents left to move has exactly one transcript** (3, 4, 4, 5, 3, 2, 3, 2, 4, 4). Every one returned `GO — every check passed (11 checks)` and then aborted at `TARGET_STANDBY` — *after* `source_stop` had taken it down. Confirmed live on scitex-clew: three transcripts, all byte-and-line verified, then `phase='aborted'`, no marker seeded, target never started, source left stopped.

`_relocate_session_choice` prefers, in order:

1. the source's own `runtime/<agent>/session_id` marker, when it names one of the carried files — the answer, written by the thing that knows;
2. otherwise the most recently modified carried `*.jsonl`.

Neither resolving is a refusal that **names the candidates**: a marker naming an uncarried file (409), a tie on the newest mtime (300), an unread marker with several candidates (503), no transcripts at all (404). An unread marker is deliberately not the same as an absent one — it may name a file other than the newest, which is exactly where guessing is wrong.

The same pure function answers at **preflight**, as the new `session_resolvable` check, so the refusal happens while the agent is still up rather than three phases later. The gap was as much the bug as the guard was: a check that passes on ten agents that cannot proceed is not a check.

## Module splits

Two files were split to stay under the 512-line cap, each along its own seam:

- `_relocate_transport_verify` (did it arrive) out of `_relocate_transport` (what may travel) — the public surface is unchanged and re-exported.
- `_relocate_effects_transport` out of `_relocate_effects`, as a per-phase mixin, following the convention the other four phases already use.

## Tests

Real files and real byte counts under `tmp_path`. The `exec_fn` seam runs the rendered scripts through `subprocess`, so `wc`, `head` and `stat` actually execute and the numbers are the filesystem's. Nothing is mocked. The clock and the sleep **are** injected — they are the two things a test must not spend; the fake sleep advances the fake clock by exactly the interval requested, so the deadline arithmetic runs at full fidelity in no wall-clock time.

Covered, at minimum:

- a file that **grows** between the snapshot and the copy still verifies, because verification is against the recorded offset — and the growth does not reach the target
- a file whose final record is half-written snapshots to the **last newline**; the carried prefix ends in `\n` and verifies
- `target < sent` and `target > sent` produce **different** mismatch lines and different hints
- `source_stop` returns **UNKNOWN, not PASS**, when the file is still changing at the deadline — including on the `already stopped` path
- multiple transcripts + a valid marker → the marked file (which is deliberately *not* the newest in the fixture, so the two rules are distinguishable)
- multiple transcripts + no marker → the newest
- a marker naming an uncarried file → refuses, naming both the marker and every candidate
- zero transcripts → refuses (existing behaviour, unregressed)
- an agent whose session cannot be resolved **fails preflight** rather than passing and aborting later

New test files mirror source modules of the same stem, per PS-204 §2: `test__relocate_quiescence`, `test__relocate_session_choice`, `test__relocate_transport_verify`, `test__relocate_effects_source`. No orphans.

## Not in this PR

`~/.scitex/agent-container/bin/self-relocate.sh` piped `sac agents relocate` through `tail` and never inspected its exit status, so it sailed past a 422 that said *"do NOT continue the relocation"* in plain text. It is fixed on **ywata-note-win** (where it actually lives — not on compute-04, contrary to the brief): the relocate output goes to a log, `$?` is read directly with no pipeline in the way, and anything other than 0 stops the script. The original was displaced to `bin/.old/20260811T220323Z/`, not deleted. It only auto-rolls back when the log shows `past_no_return=False`; otherwise it refuses to start the agent on either host and says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcDz9gLL2Ct24FXqX2SF9T

---

## Second commit: F-35 — `memory/` was left behind, plus a regression it exposed

On 2026-08-11 a relocation that ran end to end to DONE logged
`transport: REFUSED memory — only conversation transcripts (.jsonl) travel; this is not one`
and landed an agent whose target `memory/` was **empty** while nine files and 20,014 bytes stayed on the source — two of them written that evening from the operator's own corrections. The transcript is the conversation; memory is the rules distilled from it. Carrying only the first moves an agent that can recall what was said and has lost every rule it wrote for itself.

- `memory/` joins the allowlist and travels **whole, by tar** — not down the snapshot path. A memory note is not an append-only log being flushed, so there is no last newline to cut at, and half of one is not a shorter version of it.
- `select_transferable` now returns transcripts and directories **apart**, because they are carried by different means. One merged list would have to be re-derived by every caller, and the first to get it wrong would snapshot a directory or carry a live log unbounded.
- Arrival is confirmed by comparing the **whole tree** on both hosts — a per-file check of the names you thought to name says nothing about the file you forgot.

**A regression this PR's first commit introduced, caught here.** Making `copy_transcripts` snapshot-bounded broke `_relocate_effects_standby._carry_spec`, which hands it a bare *directory* name — it would have raised `AttributeError` at the phase that carries the spec. **No test caught it: there is no test file for the standby module.** The two copies are now two functions, `copy_tree` (whole entries) and `copy_transcripts` (bounded by a recorded offset).

### Provenance, which the operator ruled is the actual requirement

> 「エージェントがどこから来たのかっていうのが分かって、そこを調査することができるならば、全く問題ない」
> — if the agent can tell where it came from and go and investigate there, there is no problem at all.

He called the merge policy 枝葉, a leaf. So `_relocate_provenance` writes **`RELOCATED-FROM.md`** into the target's project directory: source host, source absolute path, raw unix time (skew ruled 「そんなシビアじゃない」), session resumed, what was carried with the counts as carried — and **what was not, with the reason for each**.

That last section is the half that goes missing, and it is exactly how `memory/` was lost: the refusal existed, as one line in a run log nobody keeps. It now lands beside the conversation, where the agent that lost the thing is the one who reads it.

**No mtime merge, and that is a consequence rather than a shortcut.** When the destination already holds a project directory, the existing transport moves the **whole** directory aside to `.old/<stamp>/` before anything is written — so there is no live directory to merge into and no file can be orphaned by a `MEMORY.md` that lost its lines. The source wins completely (「ソースの方が普通大切だろう」), and the target's previous copy is intact, named in the record, and a deliberate merge away.

The provenance write is **never fatal**: by the time it runs the transcript is verified on the target, and refusing the phase over a missing note would abort a move that worked, leaving the agent stopped on one host and unstarted on the other. A failure to confirm it logs a WARNING saying the agent will not be able to read where it came from.
