### PR TITLE
perf(ci): stop re-testing commits a newer push already replaced (51.3% of CI machine time)

### DIFF
--- a/.github/ci/ci-status.py
+++ b/.github/ci/ci-status.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Where is CI right now — per COMMIT SHA, not "the latest result".
+
+WHY THIS EXISTS
+
+Nothing in this fleet notifies anyone when CI stalls. The only way to know is
+to look, so looking has to be cheap, repeatable and unambiguous. Operator,
+2026-08-11: 「何がボトルネックでどこで止まっているのか、どこでちゃんと動いて
+いるのかっていうのを逐一うるさい位確認してください」.
+
+AND IT MUST BE ATTRIBUTED TO A SHA. A PR was read as green tonight when it was
+not, and the operator named the cause exactly: 「コミットのIDとそれに対する CI
+とその結果というのが結びついていないので、最後の結果を見てしまう」 — the
+result was not tied to a commit, so the newest row won. That is a real hazard
+here: a push supersedes the previous gate, and the older run keeps reporting
+its own conclusion. A `cancelled` or `success` belonging to an abandoned commit
+says NOTHING about the one you are about to merge.
+
+So this tool resolves the head SHA FIRST and every verdict is scoped to it.
+Runs on any other SHA are printed under SUPERSEDED and never counted.
+
+USAGE
+    python .github/ci/ci-status.py            # develop
+    python .github/ci/ci-status.py --pr 969
+    python .github/ci/ci-status.py --branch my-topic
+    python .github/ci/ci-status.py --pr 969 --watch 60
+
+Exit status: 0 all green for the head SHA, 1 something failed, 2 still
+running/queued. That makes it usable as a gate as well as a report.
+
+Reads the API through `gh`, so it inherits the caller's auth and stores no
+token of its own.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+import time
+
+REPO = "scitex-ai/scitex-agent-container"
+TERMINAL_BAD = {"failure", "timed_out", "startup_failure", "action_required"}
+
+
+def gh_json(path: str):
+    p = subprocess.run(["gh", "api", path], capture_output=True, text=True)
+    if p.returncode != 0:
+        return None
+    try:
+        return json.loads(p.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def parse(ts: str | None):
+    return dt.datetime.fromisoformat(ts.replace("Z", "+00:00")) if ts else None
+
+
+def now():
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def resolve_head(repo: str, pr: int | None, branch: str):
+    """The SHA everything below is judged against. Resolved ONCE, up front."""
+    if pr:
+        d = gh_json(f"repos/{repo}/pulls/{pr}")
+        if not d:
+            sys.exit(f"cannot read PR #{pr} in {repo}")
+        return d["head"]["sha"], d["head"]["ref"], f"PR #{pr}"
+    d = gh_json(f"repos/{repo}/commits/{branch}")
+    if not d:
+        sys.exit(f"cannot resolve branch {branch} in {repo}")
+    return d["sha"], branch, f"branch {branch}"
+
+
+def collect(repo: str, ref: str):
+    runs = (gh_json(f"repos/{repo}/actions/runs?branch={ref}&per_page=60") or {}).get(
+        "workflow_runs", []
+    )
+    out = []
+    for r in runs:
+        jobs = (gh_json(f"repos/{repo}/actions/runs/{r['id']}/jobs?per_page=100") or {}).get(
+            "jobs", []
+        )
+        out.append((r, jobs))
+    return out
+
+
+def job_timing(j: dict):
+    created, started, done = parse(j.get("created_at")), parse(j.get("started_at")), parse(
+        j.get("completed_at")
+    )
+    if j["status"] == "queued" or not started:
+        return max(0.0, (now() - created).total_seconds()) if created else 0.0, None
+    queued = max(0.0, (started - created).total_seconds()) if created else 0.0
+    ran = ((done or now()) - started).total_seconds()
+    return queued, ran
+
+
+def report(repo: str, pr: int | None, branch: str) -> int:
+    head, ref, label = resolve_head(repo, pr, branch)
+    print("=" * 78)
+    print(f"CI STATUS  {repo}  {label}")
+    print(f"HEAD SHA   {head}   ({now().strftime('%Y-%m-%d %H:%M:%SZ')})")
+    print("Every verdict below is for THIS sha. Other shas are superseded and")
+    print("are NOT counted, however green they look.")
+    print("=" * 78)
+
+    current, superseded = [], {}
+    for r, jobs in collect(repo, ref):
+        for j in jobs:
+            if r["head_sha"] == head:
+                current.append((r, j))
+            else:
+                superseded.setdefault(r["head_sha"][:7], []).append(j["conclusion"])
+
+    if not current:
+        print("\nNO RUNS FOR THE HEAD SHA YET — the gate has not started.")
+
+    passed, failed, running, queued_jobs = [], [], [], []
+    for r, j in sorted(current, key=lambda x: x[1]["name"]):
+        q, run_s = job_timing(j)
+        concl, status = j.get("conclusion"), j["status"]
+        if status != "completed":
+            (queued_jobs if status == "queued" else running).append((j["name"], q, run_s))
+        elif concl == "success":
+            passed.append((j["name"], q, run_s))
+        elif concl in TERMINAL_BAD:
+            failed.append((j["name"], q, run_s, j.get("html_url")))
+        else:
+            running.append((f"{j['name']} [{concl}]", q, run_s))
+
+    print(f"\n--- WORKING ({len(passed)} PASS) ---")
+    for n, q, s in passed:
+        print(f"  PASS     {n[:46]:<46} queue={q:5.0f}s run={s or 0:5.0f}s")
+
+    print(f"\n--- BROKEN ({len(failed)} FAIL) ---")
+    for n, q, s, url in failed:
+        print(f"  FAIL     {n[:46]:<46} queue={q:5.0f}s run={s or 0:5.0f}s")
+        print(f"           {url}")
+    if not failed:
+        print("  (none)")
+
+    print(f"\n--- IN FLIGHT ({len(running)} running, {len(queued_jobs)} queued) ---")
+    for n, q, s in running:
+        print(f"  RUNNING  {n[:46]:<46} queue={q:5.0f}s run={s or 0:5.0f}s")
+    for n, q, _ in sorted(queued_jobs, key=lambda x: -x[1]):
+        print(f"  QUEUED   {n[:46]:<46} waiting={q:5.0f}s  <-- BLOCKED ON A RUNNER")
+
+    runners = gh_json(f"repos/{repo}/actions/runners") or {}
+    online = [x for x in runners.get("runners", []) if x["status"] == "online"]
+    busy = [x for x in online if x["busy"]]
+    local = [x for x in online if any(l["name"] == "scitex-local-cpu" for l in x["labels"])]
+    print("\n--- WHY (capacity) ---")
+    print(f"  runners online {len(online)}, busy {len(busy)}, "
+          f"local (scitex-local-cpu) {len(local)}")
+    for x in sorted(online, key=lambda x: x["name"]):
+        labs = ",".join(l["name"] for l in x["labels"])
+        flag = "SPARTAN-BANNED" if "spartan" in labs else ""
+        print(f"    {x['name'][:34]:<34} busy={str(x['busy']):<5} {flag}")
+    if queued_jobs and len(busy) >= len(local):
+        print(f"  => {len(queued_jobs)} job(s) are waiting because every local slot is busy.")
+
+    if superseded:
+        print("\n--- SUPERSEDED (other shas — NOT this PR's verdict) ---")
+        for sha, concls in superseded.items():
+            tally = {c: concls.count(c) for c in set(concls)}
+            print(f"  {sha}  {tally}")
+
+    print("\n" + "=" * 78)
+    if failed:
+        print(f"VERDICT: FAIL for {head[:7]} — {len(failed)} failing job(s).")
+        return 1
+    if running or queued_jobs or not current:
+        print(f"VERDICT: PENDING for {head[:7]} — "
+              f"{len(running)} running, {len(queued_jobs)} queued. NOT green yet.")
+        return 2
+    print(f"VERDICT: PASS for {head[:7]} — {len(passed)} job(s) green.")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", default=REPO)
+    ap.add_argument("--pr", type=int)
+    ap.add_argument("--branch", default="develop")
+    ap.add_argument("--watch", type=int, metavar="SECONDS",
+                    help="re-report every SECONDS until the head sha settles")
+    a = ap.parse_args()
+
+    while True:
+        rc = report(a.repo, a.pr, a.branch)
+        if not a.watch or rc != 2:
+            sys.exit(rc)
+        time.sleep(a.watch)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -190,6 +190,48 @@ for _prog in sac scitex-agent-container; do
 done
 export PATH="$TMPDIR/bin:$PATH"
 
+# ASSERT THE PLUGIN SET BEFORE TRUSTING A SINGLE PASS/FAIL COUNT.
+#
+# MEASURED 2026-08-11 in the fleet's shared /opt/venv-sac: a wide run produced
+# 93 failures that were ALL `async def` tests, under a header reading
+# `plugins: anyio, scitex-dev` — pytest-asyncio ABSENT. The same files pass
+# standalone with asyncio-1.4.0 loaded. Plugin autoload had silently dropped it.
+#
+# THAT FAILURE IS INDISTINGUISHABLE FROM A REAL REGRESSION by inspection, and
+# that is the whole problem: 93 red async tests look exactly like someone
+# breaking the event loop. It also poisons the opposite direction — a run that
+# quietly loses a plugin can go GREEN by not collecting what it should have.
+# Any tuning decision (worker counts, selection strategy, the version matrix)
+# taken against such a run is measuring the plugin lottery, not the code.
+#
+# So: fail LOUDLY and IMMEDIATELY when the set is incomplete, instead of handing
+# back a number nobody can interpret. One line of diagnosis beats an afternoon.
+#
+# The check asks PYTEST what it actually loaded rather than asking Python what
+# is importable — an installed-but-not-registered plugin is precisely the case
+# that bit us, and `import pytest_asyncio` would have said everything was fine.
+# An empty directory keeps it to a fraction of a second and collects nothing.
+_PLUGCHECK="$TMPDIR/plugcheck"
+mkdir -p "$_PLUGCHECK"
+_PLUGINS="$(python -m pytest --collect-only -q -p no:cacheprovider "$_PLUGCHECK" 2>&1 |
+    grep -m1 '^plugins:' || true)"
+echo "preflight ${_PLUGINS:-plugins: <no header emitted>}"
+for _need in asyncio xdist cov timeout; do
+    case "$_PLUGINS" in
+    *"$_need"*) ;;
+    *)
+        echo "::error::pytest plugin '$_need' did NOT load in this environment."
+        echo "::error::header was: ${_PLUGINS:-<none>}"
+        echo "::error::Every pass/fail count from this run would be untrustworthy" \
+            "— a missing pytest-asyncio turns every async test red, and a" \
+            "missing plugin can also turn a run green by not collecting." \
+            "Refusing to run the suite. Rebuild the CI SIF or fix the" \
+            "[all,dev] install rather than re-running and hoping."
+        exit 1
+        ;;
+    esac
+done
+
 # Parallelise with pytest-xdist (baked in [dev]/[all,dev] as pytest-xdist>=3).
 # scitex-agent-container's suite is ~2460 tests; single-process it overran the job's old
 # 30-min cap (2300 passed in ~28 min, cancelled at 96%). Each xdist worker is

--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -211,9 +211,16 @@ export PATH="$TMPDIR/bin:$PATH"
 # is importable — an installed-but-not-registered plugin is precisely the case
 # that bit us, and `import pytest_asyncio` would have said everything was fine.
 # An empty directory keeps it to a fraction of a second and collects nothing.
+#
+# NOT `-q`. THE FIRST VERSION OF THIS CHECK SHIPPED WITH `-q` AND FAILED EVERY
+# JOB IT WAS ADDED TO: `-q` SUPPRESSES THE `plugins:` HEADER, so the grep found
+# nothing, concluded the plugin set was empty, and refused to run the suite —
+# all three matrix legs red in ~35s, on the very PR that introduced it. A guard
+# whose sensor is switched off reports "broken" about a healthy environment,
+# which is worse than no guard. Default verbosity prints the header; keep it.
 _PLUGCHECK="$TMPDIR/plugcheck"
 mkdir -p "$_PLUGCHECK"
-_PLUGINS="$(python -m pytest --collect-only -q -p no:cacheprovider "$_PLUGCHECK" 2>&1 |
+_PLUGINS="$(python -m pytest --collect-only -p no:cacheprovider "$_PLUGCHECK" 2>&1 |
     grep -m1 '^plugins:' || true)"
 echo "preflight ${_PLUGINS:-plugins: <no header emitted>}"
 for _need in asyncio xdist cov timeout; do

--- a/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
+++ b/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
@@ -43,6 +43,13 @@ on:
     - cron: "0 17 * * *"  # nightly 17:00 UTC (~02:00 JST), off-peak
   workflow_dispatch:
 
+# Cancel a PR's superseded runs; strict no-op everywhere else (the nightly cron
+# included — a scheduled run keys on its own run_id and is alone in its group).
+# Argued once, in pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   install-check:
     # Kept byte-identical — see lint.yml. (Verified: not protection-pinned.)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,14 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+# Cancel a PR's superseded runs; strict no-op everywhere else. The measurement
+# (51.3% of this repo's CI machine time was spent on commits a newer push had
+# already replaced) and the reason the group is keyed on run_id for non-PR
+# events are argued once, in pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   ruff:
     # THE NAME IS A DELIBERATE MISNOMER — DO NOT "FIX" IT IN PASSING.

--- a/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
+++ b/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
@@ -3,9 +3,29 @@ name: no-hosted-runners
 # THE GUARD FOR THE RULE THAT HAS NO OTHER GUARD.
 #
 # Operator directive 2026-07-14 (absolute, no exceptions): NO GitHub-hosted
-# runners anywhere in this repo. Every job runs on the self-hosted Spartan
-# pool. If Spartan misbehaves, that is OURS to fix — never fall back to a
-# hosted runner.
+# runners anywhere in this repo. If a self-hosted runner misbehaves, that is
+# OURS to fix — never fall back to a hosted runner.
+#
+# "Every job runs on the self-hosted SPARTAN pool" is what this comment used to
+# say, and it is now wrong twice over. Correcting it, because a stale comment
+# about WHICH pool is the one thing that would send someone re-pointing
+# CI_RUNS_ON back at Spartan while "fixing" something else:
+#
+#   * FACTUALLY: `vars.CI_RUNS_ON` for this repo is
+#     ["self-hosted","Linux","X64","scitex-local-cpu"], which resolves to the
+#     scitex-compute nodes. No job here has run on Spartan since that variable
+#     was narrowed.
+#   * BY RULING: the operator banned Spartan from CI outright on 2026-08-11
+#     (「spartan を CI に使うのは全面禁止です」). The literal default below still
+#     spells `scitex-ci`, a label that EVERY Spartan runner also carries — it is
+#     a fallback for a missing variable, not a target. Do not widen it.
+#
+# NOTE WHAT THIS GUARD DOES AND DOES NOT COVER: it proves no job lands on a
+# GitHub-HOSTED image. It cannot see which self-hosted POOL a job reaches,
+# because that is decided by a repository variable this workflow cannot read at
+# parse time. Enforcing the Spartan ban needs its own mechanism; measured
+# 2026-08-11, 20 of the 22 self-hosted runners visible to this org still carry
+# `spartan-cpu`, and ten other repos still point at it.
 #
 # PR #694 migrated the 11 jobs. It did NOT build the guard. So until this
 # workflow existed, nothing stopped the next PR from quietly landing on

--- a/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
+++ b/.github/workflows/no-hosted-runners-guard-on-self-hosted.yml
@@ -34,6 +34,12 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+# Cancel a PR's superseded runs; strict no-op everywhere else. Argued once, in
+# pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   no-hosted-runners:
     name: no-hosted-runners-guard-on-self-hosted

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -42,6 +42,46 @@ on:
     - cron: "0 17 * * *"  # nightly 17:00 UTC (~02:00 JST), off-peak
   workflow_dispatch:
 
+# STOP RE-TESTING COMMITS THAT A NEWER PUSH HAS ALREADY REPLACED.
+#
+# MEASURED on this repo, 2026-08-11, over the last 276 push/pull_request runs:
+#
+#     runs a newer push obsoleted while they were still in flight   86  (31.2%)
+#     total CI machine time                                       3591  min
+#     machine time spent on those already-stale runs              1841  min  (51.3%)
+#
+# HALF of every minute this repo's runners spend is spent proving something
+# about a commit nobody will merge. It is not a capacity problem — the same
+# window measured queue at 72.2% of job latency on 2 runner slots, and the
+# cheapest way to buy back a slot is to stop occupying it with dead work.
+# An agent pushing three fixups to a PR fires three full gates and, until now,
+# all three ran to completion.
+#
+# THE GROUP EXPRESSION IS THE WHOLE DESIGN, so read it before simplifying it:
+#
+#   pull_request  ->  group = <workflow>-<PR number>. The PR's previous,
+#                     superseded run is cancelled the moment a new push lands.
+#                     This is the case the numbers above are about.
+#
+#   everything    ->  group = <workflow>-<run id>, which is UNIQUE PER RUN, so
+#   else              the run is alone in its group and NOTHING is ever
+#                     cancelled or queued behind anything.
+#
+# That second line is not padding — it is the guard. The obvious spelling,
+# `group: ${{ github.workflow }}-${{ github.ref }}`, puts every push to
+# `develop` into ONE group; with cancel-in-progress false they would then
+# SERIALISE (one active run per group), and with it true a push to `develop`
+# would CANCEL the in-flight run that autobump-release-sweep.yaml and
+# auto-merge-to-develop.yaml read the conclusion of. Keying non-PR events on
+# run_id makes this change a strict no-op for `main`, `develop`, the nightly
+# cron and every workflow_dispatch — it only ever removes work from PRs.
+#
+# `cancel-in-progress: true` is therefore safe unconditionally: only the
+# pull_request branch of the expression can ever produce a shared group.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 env:
   SCITEX_CI_APPTAINER: ${{ vars.SCITEX_CI_APPTAINER }}
   SCITEX_CI_SIF: ${{ vars.SCITEX_CI_SIF }}

--- a/.github/workflows/quality-audit-on-ubuntu-latest.yml
+++ b/.github/workflows/quality-audit-on-ubuntu-latest.yml
@@ -39,6 +39,13 @@ on:
     - cron: "0 6 * * 1"  # Mondays 06:00 UTC
   workflow_dispatch:
 
+# Cancel a PR's superseded runs; strict no-op everywhere else (the weekly cron
+# included — a scheduled run keys on its own run_id and is alone in its group).
+# Argued once, in pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   audit:
     # Deliberate misnomer, kept byte-identical — see lint.yml for the full

--- a/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
+++ b/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
@@ -30,6 +30,12 @@ on:
     branches: [main, develop]
   pull_request:
 
+# Cancel a PR's superseded runs; strict no-op everywhere else. Argued once, in
+# pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   sphinx:
     # Kept byte-identical — see lint.yml. (Verified: not protection-pinned.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,19 @@ scitex-agent-container = "scitex_agent_container._linter_plugin:get_plugin"
 [project.entry-points."scitex_dev.jobs"]
 scitex-agent-container = "scitex_agent_container._jobs._jobs_plugin:provide_jobs"
 
+# STX-S001/S003 require @stx.session on a SCRIPT's main(), because a script
+# produces DATA and that data needs lineage. `.github/ci/` produces none: it is
+# CI plumbing that reads the GitHub Actions API and prints a status report.
+# Wrapping it in @stx.session would record a provenance edge for an artefact
+# that does not exist, and would make CI tooling import scitex at a point where
+# the environment is exactly what is under suspicion.
+#
+# The list must RESTATE the defaults ("src", "tests", "apps", "config", "docs")
+# — this key replaces them, it does not extend them, and dropping one would
+# silently start demanding @stx.session of every module under it.
+[tool.scitex-linter]
+library_dirs = ["src", "tests", "apps", "config", "docs", ".github/ci"]
+
 # sac's SYSTEM (apt) dependency declarations, aggregated by
 # scitex_dev.system_deps.discover_system_deps. sac registered NOTHING here
 # until 2026-08-09 while apptainer-base.def hardcoded its apt list — so the

--- a/tests/integration/test_ci_pr_gate_concurrency.py
+++ b/tests/integration/test_ci_pr_gate_concurrency.py
@@ -1,0 +1,229 @@
+"""A superseded PR run must be CANCELLED, and nothing else may be.
+
+MEASURED on this repo 2026-08-11, over the last 276 push/pull_request runs:
+
+    runs a newer push obsoleted while they were still in flight   86  (31.2%)
+    total CI machine time                                       3591  min
+    machine time spent on those already-stale runs              1841  min  (51.3%)
+
+Half of every minute this repo's runners spent went to proving something about a
+commit nobody would merge. In the same window, queueing was 72.2% of job latency
+across only 2 runner slots -- so the dead work was not free, it was the thing the
+live work was waiting behind. An agent pushing three fixups to one PR fired three
+full gates and all three ran to completion.
+
+``concurrency:`` fixes that, and it is also the one knob here that can BREAK the
+release path, which is why these tests exist rather than a review comment. The
+obvious spelling --
+
+    group: ${{ github.workflow }}-${{ github.ref }}
+
+-- puts every push to ``develop`` into ONE group. With ``cancel-in-progress``
+false those pushes then SERIALISE (a group runs one at a time), and with it true
+a push to ``develop`` CANCELS the in-flight run whose conclusion
+``autobump-release-sweep.yaml`` and ``auto-merge-to-develop.yaml`` read. Either
+way the fix for a PR-latency problem lands squarely on the release path.
+
+The shipped expression keys NON-PR events on ``github.run_id``, which is unique
+per run, so such a run is alone in its group and can neither cancel nor be
+cancelled. ``test_non_pr_events_are_alone_in_their_group`` is the guard on that
+property; it fails on exactly the spelling above.
+
+No mocks: every assertion parses the real ``.github/workflows/*.y*ml``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+# cla.yml is the one PR-triggered workflow deliberately left alone: it is the
+# documented exception in .github/hosted-runner-allowlist.yaml and runs on a
+# GitHub-hosted runner, so it consumes none of the self-hosted capacity this
+# change exists to reclaim. Adding it here would be harmless but dishonest --
+# the rule is about our own runners.
+EXEMPT = {"cla.yml"}
+
+# The two workflows that already carry a DELIBERATE, non-cancelling group. They
+# serialise repository-wide side effects (a version bump, an auto-merge) where
+# two concurrent runs would race each other, and cancelling one mid-flight is
+# exactly what must not happen. They are asserted to STAY non-cancelling.
+DELIBERATELY_SERIAL = {
+    "autobump-release-sweep.yaml",
+    "auto-merge-to-develop.yaml",
+}
+
+PUBLISH_WORKFLOW = "pypi-publish-and-github-release-on-tag.yml"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _triggers(doc: dict) -> dict:
+    # PyYAML resolves the bare key `on:` to the boolean True (YAML 1.1), so a
+    # workflow's trigger block is reachable under `True`, not "on". Reading only
+    # "on" silently returns {} for every workflow and makes every test below
+    # vacuously pass.
+    raw = doc.get("on", doc.get(True))
+    if isinstance(raw, str):
+        return {raw: None}
+    if isinstance(raw, list):
+        return {k: None for k in raw}
+    return raw or {}
+
+
+def _concurrency(path: Path) -> dict:
+    value = _load(path).get("concurrency")
+    return value if isinstance(value, dict) else {}
+
+
+def _group(path: Path) -> str:
+    return str(_concurrency(path).get("group", ""))
+
+
+def _pr_gate_workflows() -> list[Path]:
+    out = []
+    for path in sorted(WORKFLOW_DIR.iterdir()):
+        if path.suffix not in (".yml", ".yaml"):
+            continue
+        if path.name in EXEMPT or path.name in DELIBERATELY_SERIAL:
+            continue
+        if "pull_request" in _triggers(_load(path)):
+            out.append(path)
+    return out
+
+
+PR_GATE = _pr_gate_workflows()
+
+
+def test_pr_gate_workflow_set_is_not_empty():
+    """Guard the guard: an empty set makes every test below vacuous."""
+    # Arrange
+    workflow_dir = WORKFLOW_DIR
+
+    # Act
+    found = _pr_gate_workflows()
+
+    # Assert
+    assert found, (
+        f"no pull_request-triggered workflows found under {workflow_dir} -- "
+        "either the trigger parsing broke or the gate moved; the tests below "
+        "would all pass without checking anything"
+    )
+
+
+@pytest.mark.parametrize("path", PR_GATE, ids=lambda p: p.name)
+def test_pr_gate_declares_a_concurrency_block(path: Path):
+    # Arrange
+    name = path.name
+
+    # Act
+    conc = _concurrency(path)
+
+    # Assert
+    assert conc, (
+        f"{name} runs on pull_request but declares no `concurrency:` mapping. "
+        "Every push to a PR then starts a full gate while the previous one "
+        "keeps running -- 51.3% of this repo's measured CI machine time went "
+        "to exactly that. See the module docstring for the expression to use."
+    )
+
+
+@pytest.mark.parametrize("path", PR_GATE, ids=lambda p: p.name)
+def test_superseded_pr_runs_are_cancelled(path: Path):
+    # Arrange
+    name = path.name
+
+    # Act
+    cancel = _concurrency(path).get("cancel-in-progress")
+
+    # Assert
+    assert cancel in (True, "true"), (
+        f"{name}: cancel-in-progress is {cancel!r}. A group without "
+        "cancellation does not free the runner slot -- it QUEUES the new run "
+        "behind the stale one, which is worse than no group at all."
+    )
+
+
+@pytest.mark.parametrize("path", PR_GATE, ids=lambda p: p.name)
+def test_pr_runs_are_grouped_by_pull_request_number(path: Path):
+    # Arrange
+    name = path.name
+
+    # Act
+    group = _group(path)
+
+    # Assert
+    assert "github.event.pull_request.number" in group, (
+        f"{name}: concurrency group is {group!r}. It must key PR events on the "
+        "PR number so that a new push to that PR -- and only that PR -- "
+        "cancels its own previous run."
+    )
+
+
+@pytest.mark.parametrize("path", PR_GATE, ids=lambda p: p.name)
+def test_non_pr_events_are_alone_in_their_group(path: Path):
+    """THE SAFETY PROPERTY. A push/schedule/dispatch run must key on something
+    unique to itself, so ``cancel-in-progress: true`` can never reach it.
+
+    Fails on ``${{ github.workflow }}-${{ github.ref }}``, the spelling that
+    would serialise or cancel ``develop`` pushes.
+    """
+    # Arrange
+    name = path.name
+
+    # Act
+    group = _group(path)
+
+    # Assert
+    assert "github.run_id" in group, (
+        f"{name}: concurrency group is {group!r}. Non-pull_request events must "
+        "fall back to github.run_id (unique per run). Falling back to "
+        "github.ref puts every push to `develop` in ONE group, where this "
+        "workflow would either serialise them or cancel the in-flight run that "
+        "autobump-release-sweep.yaml and auto-merge-to-develop.yaml read."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(DELIBERATELY_SERIAL), ids=lambda n: n)
+def test_deliberately_serial_workflows_still_do_not_cancel(name: str):
+    """These serialise repository-wide side effects. Cancelling one mid-flight
+    is the failure mode, not the fix."""
+    # Arrange
+    path = WORKFLOW_DIR / name
+
+    # Act
+    cancel = _concurrency(path).get("cancel-in-progress")
+
+    # Assert
+    assert cancel in (False, "false"), (
+        f"{name}: cancel-in-progress is {cancel!r}. This workflow mutates the "
+        "repository (version bump / auto-merge); a cancelled run can leave "
+        "that half-done."
+    )
+
+
+def test_tag_publish_workflow_has_no_shared_cancelling_group():
+    """A release must not be cancellable by anything. A shared cancelling group
+    would let a second tag push kill an in-flight publish partway through."""
+    # Arrange
+    conc = _concurrency(WORKFLOW_DIR / PUBLISH_WORKFLOW)
+
+    # Act
+    cancels_and_is_shared = (
+        conc.get("cancel-in-progress") in (True, "true")
+        and "github.run_id" not in str(conc.get("group", ""))
+    )
+
+    # Assert
+    assert not cancels_and_is_shared, (
+        f"{PUBLISH_WORKFLOW} declares a CANCELLING concurrency group "
+        f"({conc.get('group')!r}) that is not unique per run -- a second tag "
+        "push could cancel an in-flight publish."
+    )


### PR DESCRIPTION
## The measurement first

Everything below was measured on this repo tonight (2026-08-11) via the Actions API and by running the suite on the real runner hardware. No estimates.

### Where the time actually goes

Last 40 completed runs, n=48 jobs:

| | median | mean | p90 | max | total |
|---|---|---|---|---|---|
| **queue** | 50s | 162s | 513s | 710s | **129 min** |
| **run** | 29s | 62s | 234s | 263s | 50 min |

**Queue is 72.2% of job latency.** Per-PR wall clock over the last 12 merged PRs: min 444s, **median 1402s (23.4m)**, max 3316s, ~8 workflow runs per PR.

The light jobs are the tell — they queue 400-560s to execute for 12-32s:

| workflow | n | median queue | median run |
|---|---|---|---|
| lint | 4 | 559s | **12s** |
| quality | 4 | 433s | **32s** |
| no-hosted-runners | 4 | 418s | **12s** |
| docs | 4 | 246s | 32s |
| tests | 12 | 168s | 232s |
| import-smoke | 6 | 120s | 37s |

### The cause is not slowness, it is dead work

Over the last 276 push/pull_request runs:

- **86 runs (31.2%)** were obsoleted by a newer push *while still in flight*
- **1841 of 3591 minutes (51.3%)** of all CI machine time went to those already-stale runs

No PR-gate workflow declared a `concurrency:` group, so every fixup push started a full new gate while the old one kept holding runner slots. Half the fleet's CI time was proving things about commits nobody would merge.

## What this PR changes

A `concurrency:` block on the six PR-gate workflows:

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
cancel-in-progress: true
```

**The group expression is the whole design.** The obvious spelling, `${{ github.workflow }}-${{ github.ref }}`, puts every push to `develop` into ONE group: with `cancel-in-progress` false they serialise, with it true a push to `develop` cancels the in-flight run whose conclusion `autobump-release-sweep.yaml` and `auto-merge-to-develop.yaml` read. Either way a PR-latency fix lands on the release path.

Keying non-PR events on `github.run_id` — unique per run — leaves such a run alone in its group, so it can neither cancel nor be cancelled. **This change is a strict no-op for `main`, `develop`, the nightly cron, the weekly audit and every `workflow_dispatch`.** It only ever removes work from pull requests.

Untouched on purpose:
- `autobump-release-sweep.yaml`, `auto-merge-to-develop.yaml` — already carry deliberate NON-cancelling groups; they mutate the repository and a cancelled run leaves that half-done
- the tag publish workflow — a release must not be cancellable by anything
- `cla.yml` — hosted, so it consumes none of the self-hosted capacity this reclaims

## The guard

`tests/integration/test_ci_pr_gate_concurrency.py` — 28 tests, no mocks, parses the real workflow YAML:

- every `pull_request`-triggered workflow declares a group
- it cancels (a non-cancelling group *queues* the new run behind the stale one, which is worse than nothing)
- PR runs are keyed on the PR number
- **`test_non_pr_events_are_alone_in_their_group`** — the safety property; fails on exactly the `github.ref` spelling above
- the two deliberately-serial workflows stay non-cancelling
- the publish workflow never grows a shared cancelling group

The parser reads the trigger block under PyYAML's boolean `True` key as well as `"on"`: YAML 1.1 resolves a bare `on:` to `True`, and reading only `"on"` would return `{}` for every workflow and make the whole suite vacuously green.

## Why there are no new runners in this PR

I set out to add runner capacity on the compute nodes and **measured that it does not work**, so it is not here.

- Suite alone on scitex-compute-04 (nproc=32, the real `exec-in-sif.sh` → `run-in-sif.sh` path): **14472 passed, 65 skipped in 196.11s**, job wall 220s. Test execution is healthy; `xdist -n $(nproc) --dist load` is already in use.
- Three matrix legs run **concurrently on one node, each with its own checkout** — which is exactly what N runner slots on a node look like: **1489 errors** against **0** for the same suite alone on the same box. Reproduced twice (a first attempt that shared one checkout gave 2504 errors and was discarded as confounded — `uv pip install -e .` writes build metadata into the source tree).

One runner per node serialises the matrix legs, and that is why CI is green today. More slots per node would have traded PR latency for red CI. I provisioned two extra instances on `scitex-compute-03`, measured this, and **retired them again** (displaced to `~/.old/<ts>/`, nothing deleted).

Capacity has to come from more **nodes**, or from a heavy/light runner-label split — each a separate change with its own measurement.

## Also found, reported not acted on

- **Spartan is still the CI backbone fleet-wide**, against the operator's 2026-08-11 ruling. 22 self-hosted runners exist; 20 carry `spartan-cpu`. This repo is already compliant (`CI_RUNS_ON` = `scitex-local-cpu`), but 10 other repos are not: `scitex-io`, `scitex-writer`, `scitex-dev`, `scitex-hpc`, `scitex-db`, `scitex-logging`, `scitex-notification`, `scitex-storage` point at `spartan-cpu` explicitly, and `figrecipe`, `scitex-ui` point at `scitex-ci`, which every spartan runner also carries.
- `scitex-04-cpu-01` is registered **twice** — repo-level (online) and org-level (offline). The stale org-level row is worth reaping.
- `testmon` is installed nowhere in the ecosystem.

## Verification

- `test_ci_pr_gate_concurrency.py`: **28 passed** locally against this worktree
- the 6 PR-gate workflows are detected by the test's own trigger parser (6 × 4 parametrized + 4 = 28), so the suite is not vacuous
