### PR TITLE
feat(acl): group authority is configuration — read the spec, not a per-host cache (ADR-0022: states→PostgreSQL, configuration→git)

### DIFF
--- a/docs/adr/0022-state-in-postgres-configuration-in-git.md
+++ b/docs/adr/0022-state-in-postgres-configuration-in-git.md
@@ -1,0 +1,367 @@
+# ADR-0022 — States → PostgreSQL, Configuration → files under Git
+
+* **Status**: Proposed (first slice implemented)
+* **Date**: 2026-08-12
+* **Operator rulings**: 「state.db というものは使ってはいけません」/
+  「sqlite 使った瞬間負けだと思った方が良いです」/
+  「今 5432 を scitex のために使ってるものはすべて間違い」/
+  「今他のホストと連絡が取れてないっていうのはまぁ正常です。正しいです」
+* **Consumers**: scitex-agent-container, scitex-cards, scitex-scholar,
+  scitex-writer, scitex-plt (figrecipe), scitex-hub, scitex-ui,
+  scitex-app —「いろんなパッケージから使う」
+
+---
+
+## 1. The failure this must make impossible
+
+Three incidents, all the same bug wearing different clothes:
+
+1. **`sac agents relocate --to scitex-compute-03` → nine simultaneous
+   `403 ACL deny`.** `host_exec` resolves a caller's group from
+   `node_comms_policy`, written at `agent_start`. compute-03 had never
+   started that caller, so it had no row. *Authorization became a
+   function of where an agent had previously happened to run.*
+2. **A relocated agent's registry row does not exist on the target**, so
+   `sac agents list <name>` fails there while `list --json` includes it.
+3. **`sac agents list` returns 111 agents inside a container and 126 on
+   the bare host.** On 2026-08-09 three agents concluded the fleet
+   registry had been wiped and two escalated it as P1. The host DB was
+   healthy.
+
+The common shape is not "SQLite is slow". It is: **a fact was cached
+into a store whose identity depends on where the reader is standing.**
+
+---
+
+## 2. The intended topology
+
+Corrected per the operator, 2026-08-12. This ADR previously proposed a
+single central primary; that was wrong.
+
+* **Port 5432 is never used for scitex.** Any code, spec, or default
+  naming it is a defect. (Purging it from specs is Wave A2's task, not
+  this one.)
+* **Port 55432 — the containerized PostgreSQL 18 — runs on every
+  registered host, deliberately.** Per-host instances are the design,
+  not an accident to be collapsed. A node must remain fully functional
+  while isolated: writes are local and never block on a peer.
+* **The per-host instances are then SYNCHRONIZED.** That synchroniser is
+  this primitive. It lives in scitex-dev and is consumed by the leaves.
+* **Today's cross-host isolation is therefore EXPECTED, not a bug.** The
+  gap is the absence of the sync layer, not the presence of separate
+  databases.
+
+### Measured, 2026-08-11 — what isolation currently costs
+
+Four `scitex_cards` stores, all descended from one `pg_restore`, all
+still live, none synchronised (0 publications, 0 subscriptions):
+
+| endpoint | `count(*) FROM tasks` | `max(last_activity)` |
+|---|---|---|
+| ywata-note-win `:55432` | 3843 | 2026-08-11T18:28:28Z |
+| scitex-compute-03 `:55432` | 3719 | 2026-08-10T11:25:12Z |
+| scitex-compute-04 `:55432` | 3743 | 2026-08-11T18:59:58Z |
+| nas via `:5442` | 3425 | 2026-08-11T21:48:15Z |
+
+Three findings that must shape the design:
+
+* **The existing identity check cannot see a fork.** All four carry the
+  same `schema_meta.store_uuid` (`1d55dd6e-…`) because they are clones
+  of one dump. The PostgreSQL **cluster** identifier does differ —
+  `SELECT system_identifier FROM pg_control_system()` gives
+  `7671108644284358700` vs `7672112238472680366` where `store_uuid` is
+  identical. Identity must be the **pair**.
+* **The divergence reaches inside a single agent, and that part is a
+  real defect.** In this container `$SCITEX_CARDS_DB` names `:55432`
+  while the cards MCP server process resolved `:5442` (the NAS tunnel).
+  Verified by writing a card through the MCP tool: it appeared in
+  `:5442` (3424 rows) and was absent from `:55432` (3743 rows). One
+  agent, two stores, no error. This is not the expected cross-host
+  isolation — it is one process disagreeing with its own sibling.
+* **Same-host counting, this host**: of 116 `spec.yaml` files, 92 set
+  `SCITEX_CARDS_DB` — 90 at `:55432`, 2 at the closed `:5432`.
+
+Also correcting the brief: on **scitex-compute-04** the state DB is
+3.97 MB (the 271 MB figure is ywata-note-win's), there are 4012
+`state.db` files, and `~/.scitex/agent-container/state.db` does not
+exist here. The `resolves to group ''` message was already rewritten on
+2026-08-09 to distinguish "no row here" from "registered and ungrouped";
+the *diagnostic* improved, the *cause* did not.
+
+---
+
+## 3. The cut: three kinds of fact, three homes
+
+Not everything in `state.db` is state. Classifying first is what makes
+both the migration and the sync rules small — **and note that each class
+gets a different conflict rule in §5, so this table is not bookkeeping,
+it is the sync design.**
+
+### CONFIGURATION → files under Git (never synced by us — git is the sync)
+
+| Table | Why it is configuration |
+|---|---|
+| `node_comms_policy` | A projection of `spec.yaml`'s `metadata.labels` / `spec.comms` / `spec.lineage`. Both writers derive it from the spec. |
+| `comms_grants` | Operator-declared cross-group permissions. |
+| `comms_blocks` | Operator-declared receiver-side vetoes. |
+| `definitions` | Content-addressed cache of git-resident YAML. |
+
+### STATE → PostgreSQL, single-writer per row
+
+`instances`, `comms_nodes`, `lineage`, `a2a_ports`, `node_tokens`
+(secret — §7), `inbound_dispatches`, `pending_prompts`,
+`acl_deny_notify_log`, `agent_residency`, `relocation_leases`.
+
+Almost all of these are **facts about a host, authored by that host**.
+That is what makes them safely syncable (§5).
+
+### LOG / EVENT → PostgreSQL, append-only
+
+`events`, `attempts`, `turns`, `errors`, `heartbeats`,
+`instance_heartbeats`, `channel_events`, `dispatches`,
+`relocation_journal`, `verdict_delivered`. Bulk of the bytes, least
+urgent, and the easiest to sync (pure union).
+
+---
+
+## 4. The primitive
+
+### Where it lives
+
+`scitex_dev.state`, a new subpackage of **scitex-dev**. That is the
+right home because scitex-dev *already owns the node registry*:
+`scitex_dev.hosts` provides `HostRecord` / `list_hosts()` /
+`resolve(name)` over `~/.scitex/dev/hosts.yaml`, with a write-guard
+(`resolve_hosts_yaml_for_write`) that already refuses when several
+candidate files are visible — the container-shadow trap, solved.
+
+It must **not** be built on `scitex-db`: measured, that package is
+psycopg2-based, is not installed in `/opt/venv-sac`, pulls `scitex-core`,
+and has no pooling, no upsert/`ON CONFLICT`, and no multi-host notion.
+`psycopg` 3.3.4 is already present, and scitex-cards' psycopg3 layer is
+proven in production — copy that driver layer.
+
+### API
+
+```python
+from scitex_dev.state import connect, dsn_for, register_node, store_identity
+
+with connect(dsn_for()) as conn:        # this node's own :55432
+    with write_transaction(conn):       # pg_advisory_xact_lock(<fixed int64>)
+        conn.execute("INSERT INTO instances ... ON CONFLICT ...")
+```
+
+* `dsn_for(node=None) -> str` — resolves from `hosts.yaml`. **Never
+  returns a `Path`**; raises `StoreTargetNotConfigured` rather than
+  guessing (servers must not guess). Never emits `5432`.
+* Password **never** in the DSN — libpq reads `$PGPASSFILE`. Both reach
+  a container through the spec's `--env` list.
+* Schema asserted **once per store**, not once per `connect`. sac's
+  current `init_schema`-on-every-`open_db` would become a per-open
+  network DDL storm; scitex-cards already hit exactly that.
+* `store_identity(conn) -> (store_uuid, system_identifier)` — the pair,
+  because `store_uuid` alone provably cannot detect a clone (§2).
+
+### How a host registers
+
+`HostRecord` gains a `pg` block in `~/.scitex/dev/hosts.yaml`:
+
+```yaml
+hosts:
+  - name: scitex-compute-04
+    kind: compute
+    pg: {port: 55432, node_id: compute-04, sync_peers: [ywata-note-win]}
+```
+
+`node_id` is the stable identity stamped into every row this host
+authors (§5). It must never be reused or renamed — it is the partition
+key that makes single-writer ownership work.
+
+---
+
+## 5. Synchronisation — the answers Wave-lead asked for
+
+### 5.1 Is sync part of this primitive, or layered on it?
+
+**Layered — a separate component — but it cannot be added later unless
+the state primitive mandates a schema contract NOW.**
+
+Separate, because sync has its own failure modes (partial, resumable,
+auditable) and different packages will want different cadences and
+per-table policies; and because a node must work fully while isolated,
+so nothing on the write path may depend on sync being reachable.
+
+Joined, because sync is impossible to retrofit onto rows that lack
+identity and provenance. **Every synced table MUST carry:**
+
+| Column | Purpose |
+|---|---|
+| `origin_node TEXT NOT NULL` | which node authored the row — the ownership partition key |
+| `row_uuid UUID NOT NULL` | globally unique row identity, minted at insert |
+| `revision BIGINT NOT NULL DEFAULT 1` | monotonic, bumped by the owner on every update |
+| `updated_at TIMESTAMPTZ NOT NULL` | reporting and ordering for humans — **never** the conflict rule |
+| `deleted_at TIMESTAMPTZ NULL` | tombstone; rows are never `DELETE`d |
+
+**A table created without these can never be synchronised without a
+rewrite.** That is the one sentence every consumer stream needs tonight,
+because tables are being created right now.
+
+### 5.2 The conflict-resolution rule
+
+Grounded in a measured incident: a one-time `pg_dump` replication
+between two card stores diverged silently **in both directions**, and a
+repair with `ON CONFLICT DO UPDATE` would have destroyed the other
+side's newer work. `DO NOTHING` was the difference between repair and
+data loss (card
+`sac-card-store-split-brain-two-instances-two-databases-20260807`).
+
+The rule is therefore **per class, and never a wall clock**:
+
+1. **CONFIGURATION — not synced at all.** Git is the sync. This is the
+   cheapest win available: it removes rows from the problem entirely,
+   and it is what §6 implements.
+2. **LOG / append-only — union; conflict impossible by construction.**
+   The primary key includes `origin_node`, so two nodes can never author
+   the same key. `ON CONFLICT DO NOTHING` is correct here precisely
+   because a collision means the identical row arrived twice.
+3. **STATE — single-writer, partitioned by `origin_node`.** A node may
+   `UPDATE` only rows where `origin_node = <its own node_id>`. Every
+   other node's rows are **read-only replicas**. Conflict is impossible
+   by construction, not by arbitration. This works because almost all
+   sac state is a fact about a host authored by that host.
+4. **SHARED-MUTABLE (the hard case — scitex-cards `tasks`, which any
+   agent on any host edits) — no automatic merge.** Accept a remote row
+   only when it is a newer version *from that row's own owner*:
+   `remote.origin_node == local.origin_node AND remote.revision >
+   local.revision`. In every other case **DO NOTHING and write a
+   divergence record** for operator adjudication. `tasks` already
+   carries a `revision` column, so the hook exists.
+5. **Deletes are tombstones**, never `DELETE` — consistent with "nothing
+   is ever deleted".
+6. **Fail loud, never guess.** A sync run that cannot decide reports and
+   stops. Ambiguity resolves to DO NOTHING plus a report, which is
+   exactly the posture that saved the data on 2026-08-07.
+
+Blind last-write-wins on `updated_at` is **prohibited**: clocks skew
+across hosts, and the measured incident was bidirectional, so either
+direction of blind update loses work.
+
+### 5.3 What happens when an agent relocates?
+
+Nine agents are queued to move to compute-04, so this is concrete.
+
+* **After the move the agent writes to its NEW host's `:55432`.** That
+  is the point of per-host instances — local writes, no cross-host
+  dependency at write time.
+* **Rows it wrote on the old host stay on the old host**, tagged
+  `origin_node = <old host>`. They are history; they are never rewritten
+  in place and never deleted. Only the old host could rewrite them
+  anyway, under rule 3.
+* **What moves is residency, not rows.** `agent_residency` (already
+  present) flips to the new host, and that flip is the authoritative
+  statement of who may now author rows about the agent. **Exactly one
+  current residency row per agent** — enforced, not assumed.
+* **Ordering matters, and it is a trap for the nine queued moves.** The
+  old host must close its `instances` row (`ended_at`) *before*
+  residency flips. Flip first and the agent is simultaneously live on
+  two hosts, with two `a2a_ports` claims — which is failure #2 of §1
+  wearing a new hat.
+* **Fleet-wide reads become a union over synced replicas**, not a query
+  against one node. `sac agents list` answering identically everywhere
+  is delivered by the *sync layer*, not by PostgreSQL itself. This is
+  the crux: moving to PostgreSQL alone would not have fixed §1.
+
+---
+
+## 6. First slice, implemented
+
+**`node_comms_policy` is configuration, and the fix is to stop caching
+it — not to move the cache to PostgreSQL.** Under §5.2 rule 1 it then
+never enters the sync problem at all.
+
+Group membership is authored by a human in `spec.yaml`, read by a pure
+function (`config/_group_resolver.py`), and changed by nobody at
+runtime. Persisting it into a per-host table and then trusting that
+table is the whole of failure #1 — and a per-host *PostgreSQL* table
+would have reproduced it exactly, because per-host is the intended
+topology.
+
+So `resolve_group_names` / `resolve_group_name` now read the **spec**,
+falling back to the persisted row only for nodes with no visible spec
+(remote / federated peers). New module: `config/_group_authority.py`.
+
+Four properties make it safe:
+
+* **Tri-state.** `None` = "no spec visible from this process" (fall
+  back); `frozenset()` / `""` = "the spec answered, and the answer is
+  none". Collapsing those two is the original sin — it is what let a
+  missing row read as a legitimate "ungrouped" and deny an agent that
+  held authority.
+* **Spec replaces the row, never unions with it**, so deleting a group
+  from a spec actually revokes it. Sound because the column has no
+  non-spec writer.
+* **Never raises into an ACL path.** A missing / malformed / non-mapping
+  spec yields `None` and falls back; it never fabricates a grant.
+* **Fleet scope only — never project-local.** The general spec resolver
+  searches `<repo>/.scitex/agent-container/agents/` *first*, which is
+  right for `sac agents start` and dangerous for a permission check: an
+  agent's workdir is a repository it edits, so a project-local spec
+  would put self-elevation one `git add` away. Authority reads only
+  `$SCITEX_AGENT_CONTAINER_YAML_DIRS` (operator-controlled, and already
+  injected into every container) and the user-scope agents dir.
+
+### The reproduction, and the fix, measured on this container
+
+```
+store consulted: /state/scitex-agent-container/state.db
+
+BEFORE  resolve_group_names('scitex-agent-container') -> []
+        resolve_group_names('grant')                  -> []
+
+AFTER   resolve_group_names('scitex-agent-container') -> [active, developer, infra]
+        resolve_group_names('grant')  -> [active, developer, generalist,
+                                          privileged, researcher]
+```
+
+Every agent resolved to *no groups at all* from inside the container,
+including itself, while `spec.yaml` on the same filesystem — resolvable
+in the same process — said `groups: [developer, infra, active]`.
+`host_exec`'s `ELIGIBLE_GROUPS` is `{developer, researcher, privileged}`,
+so the spec said ALLOW and the cache said DENY for the same agent at the
+same moment on the same machine. That is the 403.
+
+`tests/scitex_agent_container/config/test__group_authority.py` builds two
+**real** SQLite stores — a populated one (bare host) and an empty one
+(the SIF's private `/state/<agent>/state.db` shard) — asserts they still
+genuinely differ as databases, then asserts the group set, the primary
+group, and `is_developer` are **identical** from both. No mocks; the
+spec path is exercised through the real
+`$SCITEX_AGENT_CONTAINER_YAML_DIRS` port containers already use.
+
+---
+
+## 7. Deferred — explicitly not done
+
+1. **No STATE table has moved to PostgreSQL.** The primitive is
+   specified here, not implemented.
+2. **`scitex_dev.state` is not written**, and neither is the sync
+   engine. No code exists in scitex-dev.
+3. **The sync schema contract (§5.1) is not enforced anywhere** — no
+   linter rule, no base-table helper. Until it exists, new tables will
+   keep being created unsyncable.
+4. **The four-way scitex-cards divergence is measured, not repaired.**
+   Repair needs the sync engine plus an operator call on adjudication.
+5. **The in-container `:55432` vs `:5442` disagreement is unfixed** —
+   reported here; it is a live defect distinct from expected cross-host
+   isolation.
+6. **`hosts.yaml` `pg:` block is not implemented**, and `hosts.yaml` is
+   not itself under git. "Configuration → files" is done for specs;
+   "→ **under Git**" remains a separate step for both.
+7. **`comms_grants` / `comms_blocks` / `definitions`** are classified as
+   configuration but still live in SQLite.
+8. **`node_tokens` is a secret** and must never follow
+   `node_comms_policy` into git; its migration needs a credential story
+   first.
+9. **`~/.scitex/agent-container/runtime/state.db` on ywata-note-win is
+   untouched**, deliberately: nine remaining relocations read it.
+10. **Six of the eight named consumers are unsurveyed.**

--- a/src/scitex_agent_container/_state/state_db_groups.py
+++ b/src/scitex_agent_container/_state/state_db_groups.py
@@ -61,8 +61,64 @@ __all__ = [
     "is_developer",
     "is_privileged",
     "is_researcher",
+    "resolve_group_name",
     "resolve_group_names",
+    "same_named_group",
 ]
+
+
+def resolve_group_name(
+    *,
+    name: str,
+    db_path: Path | None = None,
+) -> str:
+    """Return ``name``'s PRIMARY named group, or ``""`` if ungrouped.
+
+    The single-bucket projection the default-ACL mesh resolves through
+    (first-of + role derivation), as opposed to the any-of authority set
+    :func:`resolve_group_names` returns. The distinction is load-bearing:
+    a solver authored as ``groups: [solver]`` must stay outside the fleet
+    mesh.
+
+    Reads the SPEC first, for the same reasons and with the same
+    tri-state contract as :func:`resolve_group_names` — the two
+    projections must resolve through one source or they start
+    disagreeing about the same agent, which is precisely the
+    2026-08-10 ``grant`` incident. Falls back to
+    ``node_comms_policy.group_name`` only when no spec is visible from
+    this process (foreign / remote nodes).
+    """
+    if not name:
+        return ""
+    from ..config._group_authority import group_name_from_spec
+
+    from_spec = group_name_from_spec(name)
+    if from_spec is not None:
+        return from_spec
+    from .state_db_acl_policy import read_comms_policy
+
+    policy = read_comms_policy(name=name, db_path=db_path)
+    return str(policy.get("group_name", "") or "")
+
+
+def same_named_group(
+    *,
+    sender: str,
+    target: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return ``True`` iff ``sender`` and ``target`` share a NAMED group.
+
+    Both groups must be NON-EMPTY and equal. Two ungrouped agents
+    (empty group) do NOT match — that keeps absence byte-equivalent to
+    the pre-group-name behaviour (an ungrouped fleet falls through to
+    the lineage-mesh + explicit-grant ACL exactly as before).
+    """
+    sender_group = resolve_group_name(name=sender, db_path=db_path)
+    if not sender_group:
+        return False
+    target_group = resolve_group_name(name=target, db_path=db_path)
+    return target_group == sender_group
 
 
 def resolve_group_names(
@@ -88,9 +144,43 @@ def resolve_group_names(
     Group names are returned verbatim (whitespace already trimmed at
     write time); compare through :func:`in_named_group`, which folds
     case. An unknown / empty name yields the empty set.
+
+    **The spec answers first** (operator 2026-08-12, "configuration →
+    files under git"). Named groups are configuration: a human writes
+    them in ``spec.yaml`` and nothing at runtime changes them. When that
+    file is visible from this process it IS the answer, and the DB row
+    is not consulted — see
+    :mod:`scitex_agent_container.config._group_authority` for the full
+    argument. The persisted row remains the fallback for names with no
+    visible spec (foreign / remote nodes registered through
+    ``comms_nodes``, and any host that has the row but not the file).
+
+    This is what makes the answer identical in a container and on the
+    bare host. The DB could not do that: in a SIF,
+    ``$SCITEX_AGENT_CONTAINER_STATE_DB`` is a private per-agent shard
+    holding no policy row for anyone, so this function returned the
+    empty set for EVERY agent — measured on scitex-compute-04
+    2026-08-11 — while the spec on the same filesystem said
+    ``['active', 'developer', 'infra']``. Empty means "denied" at every
+    authority gate, so the cache turned a readable fact into a 403.
+
+    The spec's answer REPLACES the row rather than unioning with it, so
+    deleting a group from a spec actually revokes it. That is sound only
+    because no writer puts non-spec-derived groups in the column:
+    ``record_comms_policy`` is reached solely from ``persist_acl_policy``
+    (at ``agent_start``) and ``sac agents refresh-acl``, and both derive
+    the value from ``metadata.labels`` through the same pure resolver.
     """
     if not name:
         return frozenset()
+    from ..config._group_authority import group_names_from_spec
+
+    # Tri-state: None = no spec visible here (fall through to the row);
+    # frozenset() = the spec IS visible and names no groups, which is a
+    # final answer, not an absence.
+    from_spec = group_names_from_spec(name)
+    if from_spec is not None:
+        return from_spec
     from .state_db_acl_policy import read_comms_policy
 
     policy = read_comms_policy(name=name, db_path=db_path)

--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -223,42 +223,13 @@ def derive_group(
 # ---------------------------------------------------------------------------
 
 
-def resolve_group_name(
-    *,
-    name: str,
-    db_path: Path | None = None,
-) -> str:
-    """Return ``name``'s persisted NAMED group, or ``""`` if ungrouped.
-
-    Reads ``node_comms_policy.group_name`` (written at ``agent_start``
-    from the resolved ``metadata.labels.group`` / role default). An
-    agent with no policy row, or a row with an empty ``group_name``,
-    is "ungrouped" and shares a named group with no one.
-    """
-    if not name:
-        return ""
-    policy = read_comms_policy(name=name, db_path=db_path)
-    return str(policy.get("group_name", "") or "")
-
-
-def same_named_group(
-    *,
-    sender: str,
-    target: str,
-    db_path: Path | None = None,
-) -> bool:
-    """Return ``True`` iff ``sender`` and ``target`` share a NAMED group.
-
-    Both groups must be NON-EMPTY and equal. Two ungrouped agents
-    (empty group) do NOT match — that keeps absence byte-equivalent to
-    the pre-group-name behaviour (an ungrouped fleet falls through to
-    the lineage-mesh + explicit-grant ACL exactly as before).
-    """
-    sender_group = resolve_group_name(name=sender, db_path=db_path)
-    if not sender_group:
-        return False
-    target_group = resolve_group_name(name=target, db_path=db_path)
-    return target_group == sender_group
+# ``resolve_group_name`` (the PRIMARY / mesh projection) and
+# ``same_named_group`` moved into the sibling group module alongside the
+# MULTI-value readers: both projections now resolve through the SPEC
+# first (operator 2026-08-12, "configuration → files under git"), and
+# keeping the two in one file is what stops them drifting onto different
+# sources again. Re-exported here so the long-standing import path
+# ``from ..._state.state_db_nodes import resolve_group_name`` keeps working.
 
 
 # The AUTHORITY predicates (``is_developer`` / ``is_researcher`` /
@@ -271,7 +242,9 @@ from .state_db_groups import (  # noqa: E402
     is_developer,
     is_privileged,
     is_researcher,
+    resolve_group_name,
     resolve_group_names,
+    same_named_group,
 )
 
 # ---------------------------------------------------------------------------

--- a/src/scitex_agent_container/config/_group_authority.py
+++ b/src/scitex_agent_container/config/_group_authority.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Group authority read STRAIGHT FROM THE SPEC — configuration, not state.
+
+Operator ruling 2026-08-12: **"states → PostgreSQL, configuration →
+files under git"**, and, about the SQLite state layer, ``state.db という
+ものは使ってはいけません`` / ``sqlite 使った瞬間負けだと思った方が良い
+です``.
+
+An agent's named groups are **configuration**. They are authored by a
+human in ``spec.yaml``::
+
+    metadata:
+      labels:
+        groups: [developer, infra, active]
+
+Nothing at runtime discovers, negotiates, or mutates them. They are a
+pure function of a file. Yet until this module they reached every
+authority gate through a **cache in a per-host, per-agent SQLite file**:
+
+    spec.yaml ──agent_start──▶ node_comms_policy (state.db) ──ACL──▶ gate
+               (persist_acl_policy)          ↑
+                                    the only thing a gate ever read
+
+That cache is the entire bug surface. It is written once, on this host,
+at ``agent_start``; every gate then trusts it. So authority became a
+function of *where an agent had previously been started* rather than of
+what its spec says:
+
+* **Inside a container** ``$SCITEX_AGENT_CONTAINER_STATE_DB`` points at
+  ``/state/<name>/state.db`` — a private overlay shard holding only what
+  that one agent wrote, and no ``node_comms_policy`` row for anybody.
+  Measured on scitex-compute-04, 2026-08-11, from inside this very
+  container: ``resolve_group_names`` returned ``[]`` for *every* agent
+  including itself, while the spec on the same filesystem, resolvable in
+  the same process, said ``['active', 'developer', 'infra']``. Since
+  ``host_exec``'s ``ELIGIBLE_GROUPS`` is ``{developer, researcher,
+  privileged}``, the spec says ALLOW and the cache says DENY.
+* **On a host the agent never ran on** there is likewise no row — which
+  is how ``sac agents relocate … --to scitex-compute-03`` produced
+  ``403 ACL deny`` on nine probes at once.
+
+Reading the spec makes both impossible, because the spec is the same
+file everywhere: it is bind-mounted into the container (hence
+``$SCITEX_AGENT_CONTAINER_YAML_DIRS``, which is why
+:func:`..config._resolve.resolve_config` already works in-container) and
+carried between hosts as a file. Two contexts that disagree about a
+file's contents is a filesystem bug; two contexts that disagree about a
+cache of it is Tuesday.
+
+Tri-state, deliberately
+-----------------------
+Every function here returns ``None`` for **"no spec is visible from this
+process"**, which is emphatically NOT the same fact as "the spec exists
+and names no groups" (an empty set / empty string). Collapsing the two
+is the original sin this module refuses to repeat — it is what let a
+missing row read as a legitimate "ungrouped" and silently deny an agent
+that holds authority. ``None`` means *"I could not answer; ask the
+fallback"*; an empty result means *"I answered, and the answer is none"*.
+
+Precedence, and why the spec WINS
+---------------------------------
+When a spec IS visible it is authoritative and the DB row is not
+consulted at all — not unioned with. Union would mean a stale row could
+keep granting a group the operator has since deleted from the spec, i.e.
+revocation would silently not take effect. Removing ``developer`` from a
+spec must remove developer authority. That is only sound because the DB
+column has exactly one non-spec-derived writer — there is none:
+``record_comms_policy`` is reached solely via
+:func:`.._lifecycle._spawn_gate.persist_acl_policy` (at ``agent_start``)
+and ``sac agents refresh-acl``, and **both derive the groups from
+``metadata.labels`` through this same pure resolver**. So the DB can only
+ever hold a possibly-stale copy of what this module reads fresh.
+
+This module does the file I/O; the *interpretation* of the labels is
+unchanged and still lives in the pure resolver
+(:mod:`._group_resolver`) — ``all_named_groups`` for the MULTI-value
+authority set, ``group_from_labels`` for the single PRIMARY mesh bucket.
+The two projections keep their existing, deliberately different
+semantics (any-of vs first-of); this module only changes *where the
+labels are read from*.
+
+Failure posture
+---------------
+Never raises into an ACL path. A missing, unreadable, non-YAML, or
+structurally surprising spec yields ``None`` (fall back to the DB — the
+previous behaviour), never an exception and never a fabricated grant.
+The only thing that can produce a non-``None`` answer here is a spec
+that parsed into a mapping.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+__all__ = [
+    "group_name_from_spec",
+    "group_names_from_spec",
+    "spec_labels_for",
+]
+
+_logger = logging.getLogger(__name__)
+
+
+def _default_spec_path(name: str) -> str | None:
+    """Resolve ``name`` to its FLEET ``spec.yaml`` path, or ``None``.
+
+    Deliberately NOT :func:`.._resolve.resolve_config`. That resolver
+    searches **project-local scope first** (``<repo>/.scitex/
+    agent-container/agents/<name>/spec.yaml``), which is right for
+    ``sac agents start`` — an operator standing in a repo means the
+    repo's spec — and wrong for a permission check. An agent's workdir
+    is a repository it edits; letting a file inside that repository
+    decide the agent's own ACL groups would make self-elevation a
+    ``git add`` away, and would hand any repo the agent clones a say in
+    fleet authority.
+
+    So authority reads only the two FLEET-scope sources:
+
+      1. ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` — the operator-controlled
+         search path, and the one that is injected into every container
+         (pointing back at the host's real agents dir), which is what
+         makes this work identically inside a SIF and on bare metal.
+      2. the user-scope agents dir (``$SCITEX_DIR/agent-container/agents``).
+
+    Returns the first hit, or ``None`` when neither holds the agent —
+    the tri-state "no spec visible from here", not an error.
+    """
+    from ._resolve import _operator_env_dirs, _try_dir, _user_agents_dir
+
+    try:
+        candidates = list(_operator_env_dirs())
+        candidates.append(_user_agents_dir())
+        for base in candidates:
+            hit = _try_dir(base, name)
+            if hit:
+                return hit
+    except Exception:
+        # An unreadable / unresolvable search dir means "cannot answer",
+        # which the caller must treat as fall-back — never as an error to
+        # propagate into a permission check.
+        return None
+    return None
+
+
+def spec_labels_for(
+    name: str,
+    *,
+    spec_path_resolver: Callable[[str], str | None] | None = None,
+) -> dict[str, Any] | None:
+    """Return ``metadata.labels`` from ``name``'s spec, or ``None``.
+
+    ``None`` means "no spec is visible from this process" — the caller
+    must fall back to another source. A spec that exists but declares no
+    labels yields ``{}`` (an answer, not an absence).
+
+    ``spec_path_resolver`` is the injection seam used by the tests to
+    point at a fixture tree without touching process env; it defaults to
+    the standard spec search path (project scope → user scope →
+    ``$SCITEX_AGENT_CONTAINER_YAML_DIRS``), which is exactly the path
+    that already resolves specs correctly inside a container.
+
+    Reads the YAML directly rather than going through ``load_config``:
+    an authority answer must not depend on the whole spec validating.
+    A spec with an unrelated schema error elsewhere in the file still has
+    perfectly readable group labels, and stripping an agent's authority
+    because of it would turn a cosmetic validation failure into a
+    fleet-wide permission outage.
+    """
+    if not name:
+        return None
+    resolver = spec_path_resolver or _default_spec_path
+    path = resolver(name)
+    if not path:
+        return None
+    try:
+        import yaml
+
+        with open(path, "r", encoding="utf-8") as fh:
+            doc = yaml.safe_load(fh)
+    except Exception as exc:  # unreadable / malformed / not YAML
+        _logger.warning(
+            "group authority: spec for %r at %s is unreadable (%s); "
+            "falling back to the persisted policy row",
+            name,
+            path,
+            exc,
+        )
+        return None
+    if not isinstance(doc, dict):
+        return None
+    metadata = doc.get("metadata")
+    if not isinstance(metadata, dict):
+        return {}
+    labels = metadata.get("labels")
+    if labels is None:
+        return {}
+    if not isinstance(labels, dict):
+        # e.g. ``labels: [a, b]`` — structurally wrong. Treat as "the
+        # spec answered, and it names nothing", not as a hard error.
+        return {}
+    return labels
+
+
+def group_names_from_spec(
+    name: str,
+    *,
+    spec_path_resolver: Callable[[str], str | None] | None = None,
+) -> frozenset[str] | None:
+    """Return EVERY named group ``name``'s spec authors, or ``None``.
+
+    The MULTI-value AUTHORITY projection — the set the
+    developer/researcher/privileged gates ask membership questions of.
+    Delegates the label interpretation to
+    :func:`._group_resolver.all_named_groups`, so the singular
+    ``labels.group`` string and every element of the plural
+    ``labels.groups`` list are honoured exactly as before.
+
+    ``None`` = no spec visible (fall back). ``frozenset()`` = the spec
+    is visible and names no groups (a real, final answer: ungrouped).
+    """
+    labels = spec_labels_for(name, spec_path_resolver=spec_path_resolver)
+    if labels is None:
+        return None
+    from ._group_resolver import all_named_groups
+
+    return all_named_groups(labels)
+
+
+def group_name_from_spec(
+    name: str,
+    *,
+    spec_path_resolver: Callable[[str], str | None] | None = None,
+) -> str | None:
+    """Return the PRIMARY named group from ``name``'s spec, or ``None``.
+
+    The single-bucket projection the default-ACL mesh resolves through
+    (first-of, with role derivation), via
+    :func:`._group_resolver.group_from_labels`. Kept distinct from
+    :func:`group_names_from_spec` on purpose: an agent authored as
+    ``groups: [solver]`` must stay OUT of the fleet mesh, and that
+    isolation guarantee depends on the mesh reading one bucket rather
+    than any-of the set.
+
+    ``None`` = no spec visible (fall back). ``""`` = the spec is visible
+    and the agent is ungrouped.
+    """
+    labels = spec_labels_for(name, spec_path_resolver=spec_path_resolver)
+    if labels is None:
+        return None
+    from ._group_resolver import group_from_labels
+
+    return group_from_labels(labels)

--- a/tests/scitex_agent_container/config/test__group_authority.py
+++ b/tests/scitex_agent_container/config/test__group_authority.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for spec-sourced group authority.
+
+The headline is the ``identical_from_both_stores`` pair — one caller,
+one spec, two genuinely different stores, one answer. That is the
+assertion that would have caught the 2026-08-11 relocation incident
+(nine ``403 ACL deny`` probes at once, because the target host held no
+``node_comms_policy`` row for the caller) and the 2026-08-09 escalation
+(three agents read an empty per-agent shard and concluded the fleet
+registry had been wiped, while the host DB was healthy).
+
+Real SQLite files and real spec files throughout — no mocks, and no
+fixture that rewrites production internals. The "container" store is a
+genuinely empty database, which is exactly what ``/state/<agent>/state.db``
+is inside a SIF; the "bare host" store is a genuinely populated one. Two
+tests below assert that the stores really do still differ, so the
+equality tests can never quietly decay into comparing one store with
+itself and proving nothing.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state.state_db_acl_policy import (
+    read_comms_policy,
+    record_comms_policy,
+)
+from scitex_agent_container._state.state_db_groups import (
+    is_developer,
+    resolve_group_name,
+    resolve_group_names,
+)
+from scitex_agent_container.config._group_authority import (
+    group_name_from_spec,
+    group_names_from_spec,
+    spec_labels_for,
+)
+
+_YAML_DIRS_ENV = "SCITEX_AGENT_CONTAINER_YAML_DIRS"
+
+SPEC_TEMPLATE = """\
+apiVersion: sac/v1
+kind: Agent
+metadata:
+  name: {name}
+  labels:
+    role: {role}
+    groups: [{groups}]
+spec:
+  workdir: /tmp
+"""
+
+
+def _write_spec(root: Path, name: str, groups: str, role: str = "worker") -> None:
+    """Author a real ``spec.yaml`` under ``root/<name>/``."""
+    agent_dir = root / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "spec.yaml").write_text(
+        SPEC_TEMPLATE.format(name=name, groups=groups, role=role)
+    )
+
+
+def _write_raw_spec(root: Path, name: str, text: str) -> None:
+    agent_dir = root / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "spec.yaml").write_text(text)
+
+
+@pytest.fixture()
+def spec_root(tmp_path):
+    """A real spec search dir, wired in through the documented env port.
+
+    Sets ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` directly (restoring the
+    prior value on teardown) rather than patching the resolver: that env
+    var is precisely the mechanism that makes specs resolvable inside a
+    container, so exercising it IS exercising the production path.
+    """
+    root = tmp_path / "agents"
+    root.mkdir()
+    previous = os.environ.get(_YAML_DIRS_ENV)
+    os.environ[_YAML_DIRS_ENV] = str(root)
+    yield root
+    if previous is None:
+        os.environ.pop(_YAML_DIRS_ENV, None)
+    else:
+        os.environ[_YAML_DIRS_ENV] = previous
+
+
+@dataclass(frozen=True)
+class RelocateCase:
+    """One agent, its spec, and the two stores that used to disagree."""
+
+    name: str
+    host_db: Path
+    container_db: Path
+
+
+@pytest.fixture()
+def relocate_case(spec_root, tmp_path) -> RelocateCase:
+    """An agent whose spec is visible but whose policy row is host-only.
+
+    ``host_db`` stands for the bare host's populated
+    ``~/.scitex/agent-container/runtime/state.db``; ``container_db``
+    stands for the private ``/state/<agent>/state.db`` shard a SIF gets,
+    which holds no ``node_comms_policy`` row for anybody. This is the
+    exact shape of the relocation 403.
+    """
+    name = "t-auth-relocate"
+    _write_spec(spec_root, name, groups="developer, infra")
+    host_db = tmp_path / "host-state.db"
+    container_db = tmp_path / "container-state.db"
+    record_comms_policy(
+        name=name,
+        outbound_siblings="allow",
+        outbound_parent="allow",
+        inbound_siblings="allow",
+        inbound_parent="allow",
+        lineage_group="",
+        may_spawn=True,
+        group_name="developer",
+        group_names=frozenset({"developer", "infra"}),
+        db_path=host_db,
+    )
+    return RelocateCase(name=name, host_db=host_db, container_db=container_db)
+
+
+# ---------------------------------------------------------------------------
+# the two stores really do differ — the fault condition, asserted
+# ---------------------------------------------------------------------------
+
+
+def test_host_store_holds_the_policy_row(relocate_case):
+    # Arrange
+    case = relocate_case
+    # Act
+    policy = read_comms_policy(name=case.name, db_path=case.host_db)
+    # Assert
+    assert policy["group_name"] == "developer"
+
+
+def test_container_store_holds_no_policy_row(relocate_case):
+    # Arrange
+    case = relocate_case
+    # Act
+    policy = read_comms_policy(name=case.name, db_path=case.container_db)
+    # Assert
+    assert policy["group_name"] == ""
+
+
+# ---------------------------------------------------------------------------
+# the headline — one caller, two stores, one answer
+# ---------------------------------------------------------------------------
+
+
+def test_group_set_is_identical_from_container_and_host(relocate_case):
+    # Arrange
+    case = relocate_case
+    # Act
+    from_host = resolve_group_names(name=case.name, db_path=case.host_db)
+    from_container = resolve_group_names(name=case.name, db_path=case.container_db)
+    # Assert
+    assert from_host == from_container
+
+
+def test_group_set_from_the_container_is_the_spec_answer(relocate_case):
+    # Arrange
+    case = relocate_case
+    # Act
+    from_container = resolve_group_names(name=case.name, db_path=case.container_db)
+    # Assert
+    assert from_container == frozenset({"developer", "infra"})
+
+
+def test_primary_group_is_identical_from_container_and_host(relocate_case):
+    # Arrange
+    case = relocate_case
+    # Act
+    from_host = resolve_group_name(name=case.name, db_path=case.host_db)
+    from_container = resolve_group_name(name=case.name, db_path=case.container_db)
+    # Assert
+    assert from_host == from_container
+
+
+def test_developer_authority_holds_from_the_container_store(relocate_case):
+    """The gate itself agrees — this is what the 403 actually turned on."""
+    # Arrange
+    case = relocate_case
+    # Act
+    allowed = is_developer(name=case.name, db_path=case.container_db)
+    # Assert
+    assert allowed is True
+
+
+# ---------------------------------------------------------------------------
+# tri-state: "no spec here" is never the same fact as "spec says none"
+# ---------------------------------------------------------------------------
+
+
+def test_absent_spec_yields_none_labels(spec_root):
+    # Arrange
+    name = "t-auth-absent"
+    # Act
+    labels = spec_labels_for(name)
+    # Assert
+    assert labels is None
+
+
+def test_absent_spec_yields_none_group_set(spec_root):
+    # Arrange
+    name = "t-auth-absent"
+    # Act
+    groups = group_names_from_spec(name)
+    # Assert
+    assert groups is None
+
+
+def test_absent_spec_yields_none_primary_group(spec_root):
+    # Arrange
+    name = "t-auth-absent"
+    # Act
+    primary = group_name_from_spec(name)
+    # Assert
+    assert primary is None
+
+
+def test_spec_without_labels_yields_empty_group_set(spec_root):
+    # Arrange
+    name = "t-auth-bare"
+    _write_raw_spec(
+        spec_root,
+        name,
+        "apiVersion: sac/v1\nkind: Agent\nmetadata:\n  name: t-auth-bare\n"
+        "spec:\n  workdir: /tmp\n",
+    )
+    # Act
+    groups = group_names_from_spec(name)
+    # Assert
+    assert groups == frozenset()
+
+
+def test_spec_without_labels_yields_empty_primary_group(spec_root):
+    # Arrange
+    name = "t-auth-bare2"
+    _write_raw_spec(
+        spec_root,
+        name,
+        "apiVersion: sac/v1\nkind: Agent\nmetadata:\n  name: t-auth-bare2\n"
+        "spec:\n  workdir: /tmp\n",
+    )
+    # Act
+    primary = group_name_from_spec(name)
+    # Assert
+    assert primary == ""
+
+
+# ---------------------------------------------------------------------------
+# label interpretation is unchanged — still the pure resolver's job
+# ---------------------------------------------------------------------------
+
+
+def test_every_authored_group_is_returned(spec_root):
+    # Arrange
+    name = "t-auth-multi"
+    _write_spec(spec_root, name, groups="generalist, privileged, developer")
+    # Act
+    groups = group_names_from_spec(name)
+    # Assert
+    assert groups == frozenset({"generalist", "privileged", "developer"})
+
+
+def test_primary_group_stays_first_of_the_authored_list(spec_root):
+    """First-of, so an isolated solver stays OUT of the fleet mesh."""
+    # Arrange
+    name = "t-auth-multi2"
+    _write_spec(spec_root, name, groups="generalist, privileged, developer")
+    # Act
+    primary = group_name_from_spec(name)
+    # Assert
+    assert primary == "generalist"
+
+
+def test_role_derivation_still_applies_when_no_groups_authored(spec_root):
+    # Arrange
+    name = "t-auth-role"
+    _write_raw_spec(
+        spec_root,
+        name,
+        "apiVersion: sac/v1\nkind: Agent\nmetadata:\n  name: t-auth-role\n"
+        "  labels:\n    role: project-maintainer\nspec:\n  workdir: /tmp\n",
+    )
+    # Act
+    primary = group_name_from_spec(name)
+    # Assert
+    assert primary == "developer"
+
+
+def test_spec_outside_the_fleet_dirs_is_not_consulted(spec_root, tmp_path):
+    """Authority reads fleet scope ONLY.
+
+    A spec that exists on disk but in a directory the operator did not
+    put on the fleet search path must not grant anything. This is what
+    keeps a project-local ``.scitex/agent-container/agents/<self>/spec.yaml``
+    — a file inside a repository the agent itself edits — from deciding
+    that agent's own ACL groups.
+    """
+    # Arrange
+    elsewhere = tmp_path / "not-the-fleet-dir"
+    elsewhere.mkdir()
+    _write_spec(elsewhere, "t-auth-elsewhere", groups="developer")
+    # Act
+    groups = group_names_from_spec("t-auth-elsewhere")
+    # Assert
+    assert groups is None
+
+
+def test_malformed_spec_falls_back_instead_of_raising(spec_root):
+    """A broken spec must never raise into an ACL path nor invent a grant."""
+    # Arrange
+    name = "t-auth-broken"
+    _write_raw_spec(spec_root, name, "metadata: [this is not: a mapping\n")
+    # Act
+    groups = group_names_from_spec(name)
+    # Assert
+    assert groups is None
+
+
+# ---------------------------------------------------------------------------
+# precedence — spec replaces the row; foreign nodes still use the row
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def stale_row_case(spec_root, tmp_path) -> RelocateCase:
+    """A spec that has DROPPED developer, over a row that still grants it."""
+    name = "t-auth-revoked"
+    _write_spec(spec_root, name, groups="generalist")
+    db = tmp_path / "stale.db"
+    record_comms_policy(
+        name=name,
+        outbound_siblings="allow",
+        outbound_parent="allow",
+        inbound_siblings="allow",
+        inbound_parent="allow",
+        lineage_group="",
+        may_spawn=True,
+        group_name="developer",
+        group_names=frozenset({"developer"}),
+        db_path=db,
+    )
+    return RelocateCase(name=name, host_db=db, container_db=db)
+
+
+def test_stale_row_still_records_the_revoked_group(stale_row_case):
+    # Arrange
+    case = stale_row_case
+    # Act
+    policy = read_comms_policy(name=case.name, db_path=case.host_db)
+    # Assert
+    assert policy["group_name"] == "developer"
+
+
+def test_spec_revocation_beats_the_stale_row(stale_row_case):
+    """Deleting a group from the spec actually revokes it."""
+    # Arrange
+    case = stale_row_case
+    # Act
+    groups = resolve_group_names(name=case.name, db_path=case.host_db)
+    # Assert
+    assert groups == frozenset({"generalist"})
+
+
+def test_revoked_developer_authority_is_actually_denied(stale_row_case):
+    # Arrange
+    case = stale_row_case
+    # Act
+    allowed = is_developer(name=case.name, db_path=case.host_db)
+    # Assert
+    assert allowed is False
+
+
+@pytest.fixture()
+def foreign_node_case(spec_root, tmp_path) -> RelocateCase:
+    """A node with a policy row but NO spec — a remote / federated peer."""
+    name = "t-auth-foreign"
+    db = tmp_path / "foreign.db"
+    record_comms_policy(
+        name=name,
+        outbound_siblings="allow",
+        outbound_parent="allow",
+        inbound_siblings="allow",
+        inbound_parent="allow",
+        lineage_group="",
+        may_spawn=True,
+        group_name="researcher",
+        group_names=frozenset({"researcher"}),
+        db_path=db,
+    )
+    return RelocateCase(name=name, host_db=db, container_db=db)
+
+
+def test_foreign_node_has_no_visible_spec(foreign_node_case):
+    # Arrange
+    case = foreign_node_case
+    # Act
+    groups = group_names_from_spec(case.name)
+    # Assert
+    assert groups is None
+
+
+def test_foreign_node_falls_back_to_its_policy_row(foreign_node_case):
+    # Arrange
+    case = foreign_node_case
+    # Act
+    groups = resolve_group_names(name=case.name, db_path=case.host_db)
+    # Assert
+    assert groups == frozenset({"researcher"})
+
+
+def test_foreign_node_primary_group_falls_back_to_its_row(foreign_node_case):
+    # Arrange
+    case = foreign_node_case
+    # Act
+    primary = resolve_group_name(name=case.name, db_path=case.host_db)
+    # Assert
+    assert primary == "researcher"


### PR DESCRIPTION
Wave A1. Operator, 2026-08-12: 「state.db というものは使ってはいけません」/
「sqlite 使った瞬間負けだと思った方が良いです」 — **states → PostgreSQL,
configuration → files under Git.**

This is the design plus the first migration slice. It deliberately does **not**
attempt a table move, and §"Deferred" below says exactly what it leaves.

## The finding that changed the design

Moving to PostgreSQL does not by itself fix "same question, two answers" —
**the failure is already live in the PostgreSQL layer.** scitex-cards migrated
to PG on 55432 and reproduced it, measured 2026-08-11:

| endpoint | `count(*) FROM tasks` | `max(last_activity)` |
|---|---|---|
| ywata-note-win `:55432` | 3843 | 2026-08-11T18:28:28Z |
| scitex-compute-03 `:55432` | 3719 | 2026-08-10T11:25:12Z |
| scitex-compute-04 `:55432` | 3743 | 2026-08-11T18:59:58Z |
| nas via `:5442` | 3425 | 2026-08-11T21:48:15Z |

Per the operator this cross-host isolation is **expected** — per-host instances
are the intended topology and the sync layer simply does not exist yet. Two
things in that table are *not* expected, though:

* **The identity check cannot see a fork.** All four carry the same
  `schema_meta.store_uuid` (clones of one dump). The PostgreSQL *cluster*
  identifier does differ — `pg_control_system().system_identifier` gives
  `7671108644284358700` vs `7672112238472680366` where `store_uuid` is
  identical. **Identity must be the pair.**
* **One agent, two stores.** In this container `$SCITEX_CARDS_DB` names
  `:55432` while the cards MCP server process resolved `:5442`. Verified by
  writing a card through the MCP tool: it landed in `:5442` (3424 rows) and was
  absent from `:55432` (3743 rows). That is a live defect, distinct from the
  expected cross-host isolation.

## The slice: `node_comms_policy` is configuration, so stop caching it

Group membership is authored by a human in `spec.yaml`, read by a pure function,
and changed by nobody at runtime. sac persisted that pure function of a file
into a per-host SQLite row at `agent_start` and trusted the row at every ACL
gate. **Measured from inside this container on scitex-compute-04:**

```
store consulted: /state/scitex-agent-container/state.db

BEFORE  resolve_group_names('scitex-agent-container') -> []
        resolve_group_names('grant')                  -> []

AFTER   scitex-agent-container -> [active, developer, infra]   primary developer
        grant -> [active, developer, generalist, privileged, researcher]
```

Every agent resolved to **no groups at all**, including this one, while
`spec.yaml` on the same filesystem — resolvable in the same process — said
`groups: [developer, infra, active]`. `host_exec`'s `ELIGIBLE_GROUPS` is
`{developer, researcher, privileged}`, so the spec said ALLOW and the cache said
DENY for the same agent at the same moment on the same machine. That is the
`403 ACL deny` that hit nine relocation probes at once.

Note a per-host **PostgreSQL** table would have reproduced this exactly, since
per-host is the intended topology. The fix is to not cache it.

Four properties make reading the file safe where reading the row was not:
tri-state (`None` = "no spec visible here" ≠ `frozenset()` = "spec says none",
so foreign/remote nodes still fall back to the row); the spec **replaces** the
row rather than unioning, so revocation actually revokes; it never raises into
an ACL path; and it reads **fleet scope only, never project-local** — an agent's
workdir is a repo it edits, so a project-local spec would put self-elevation one
`git add` away.

## ADR-0022 — what the other streams need

`docs/adr/0022-state-in-postgres-configuration-in-git.md` carries the
CONFIG/STATE/LOG classification, the `scitex_dev.state` primitive (psycopg3, not
scitex-db — that package is psycopg2, uninstalled, no pooling, no upsert), and
the answers on synchronisation:

* **Sync is a separate component, but cannot be retrofitted.** Every synced
  table must already carry `origin_node`, `row_uuid`, `revision`, `updated_at`,
  `deleted_at`. **A table created without them can never be synced without a
  rewrite** — which matters because tables are being created right now.
* **Conflict rules are per class and never a wall clock.** CONFIG is not synced
  (git is the sync); append-only LOG unions on a PK including `origin_node`;
  STATE is single-writer partitioned by `origin_node` (replicas read-only,
  conflict impossible by construction); shared-mutable rows accept a remote only
  when it is a newer `revision` **from that row's own owner**, else DO NOTHING
  plus a divergence record. Blind `ON CONFLICT DO UPDATE` on `updated_at` is
  prohibited — the 2026-08-07 split diverged in *both* directions, so either
  direction of blind update destroys work.
* **Relocation**: the agent writes to its new host's `:55432`; rows on the old
  host stay there tagged `origin_node`, never rewritten, never deleted. What
  moves is **residency**, not rows — and the old host must close its `instances`
  row *before* residency flips, or the agent is live on two hosts at once.

## Verification

```
3054 passed, 3 skipped, 1 warning in 163.51s     rc 0
tests/scitex_agent_container/{_state,config,_listen}   # the whole blast radius
```

22 of those are the new `test__group_authority.py`, which builds two **real**
SQLite stores — populated (bare host) and empty (the SIF's private
`/state/<agent>/state.db` shard) — asserts they still genuinely differ as
databases, and only then asserts the group set, primary group and `is_developer`
are identical from both. Without that first pair the equality could decay into
comparing one store with itself. No mocks.

**Two pre-existing failures, not from this change**, both reproduced on
unmodified `develop`:
* `tests/develop/test_audit.py::test_audit_all_clean` — 2 errors, both env-var
  prefixes (`CODEX_HOME`, `LOG_PATH`). No PS-204 violation; the new test file
  mirrors `_group_authority.py` correctly.
* A wider run showed 93 failures, **all** `async def` tests. Cause is plugin
  autoload flake in the shared venv: those runs report
  `plugins: anyio, scitex-dev` with **pytest-asyncio absent**, while the same
  files pass standalone in this worktree (`test__off_loop.py` → 9 passed) with
  `asyncio-1.4.0` loaded. Environmental, intermittent, and worth its own look.

## Deferred — explicitly not done

No STATE table has moved to PostgreSQL; `scitex_dev.state` and the sync engine
are specified, not written; the sync schema contract is not enforced by any
linter; the four-way cards divergence is measured, not repaired (that is an
operator call); the in-container `:55432`/`:5442` disagreement is unfixed;
`hosts.yaml` `pg:` block is unimplemented and `hosts.yaml` is not itself under
git; `comms_grants`/`comms_blocks`/`definitions` are classified as configuration
but still in SQLite; `node_tokens` is secret and needs a credential story;
ywata-note-win's `runtime/state.db` is untouched (nine relocations still read
it); six of the eight named consumers are unsurveyed.

Cards: `waveA1-states-to-postgres` and four children. One further card (the sync
primitive + schema contract) could not be written — the card store's write path
is currently refusing on a poisoned `notifications` row (`n_d826dea57cd1`, no
`record_json`), so that content lives in ADR-0022 §5 instead, which is in git.

Boundary with Wave A2: A2 owns purging `5432`/sqlite out of specs; this PR owns
schema and sync. Nothing here edits specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcDz9gLL2Ct24FXqX2SF9T
