### PR TITLE
feat(jobs): the canonical rename, and the migration that keeps one supervisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,76 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Changed
 
+- **Every job sac owns is renamed to the ecosystem canonical form
+  `scitex-agent-container-<name>`, and the migration that makes that safe
+  ships with it** (`sac dev migrate-job-names`, `_jobs/_migrate/`). The rename
+  is not cosmetic: scitex-dev derives the unit FILENAME from `JobSpec.name`
+  verbatim, so `sac.worktree-gc` and `scitex-agent-container-worktree-gc` are
+  two unrelated units with independent enablement, state and triggers. Install
+  before uninstall therefore leaves TWO supervisors running the same command —
+  the shape that already put a crontab line and a systemd unit on `sac listen`
+  against different venvs, dormant only because a `pgrep` guard happened to
+  match. A rename is exactly what wakes that up.
+
+  So the migration is ordered by construction — stop → disable → carry
+  drop-ins → displace → daemon-reload → install → logging → verify — with
+  `install` unable to precede `displace` because each step's action indexes
+  into `ACTION_ORDER` and a test asserts the ranks are non-decreasing for every
+  job. Nothing is deleted (displaced units go to `.old/<timestamp>/`), a unit's
+  `<unit>.d/` drop-ins are CARRIED across the rename rather than orphaned under
+  a name the new unit never reads, and `sac-listen.service` is in `NEVER_TOUCH`
+  with the guard running on every plan the planner returns.
+
+  Verification counts BOTH names: "the new unit exists" is not the claim, "ONLY
+  the new unit exists" is, and a surviving old unit fails however healthy the
+  new one looks.
+
+  **`sac.accounts-refresh` deliberately keeps its legacy name.** It is the
+  fleet's sole OAuth refresher against a single-use refresh token (two racing
+  refreshers revoke each other; zero stalls the fleet within hours — measured
+  2026-07-09/10) and the only sac timer actually enabled and active. A spec
+  renamed AHEAD of its unit would make `sac dev timer status accounts-refresh`
+  report the refresher as ABSENT while it refreshes, so the declared name
+  tracks the DEPLOYED unit until an operator-supervised cutover renames both
+  together. `_names` recognises both prefixes for exactly that window;
+  `--include-held` requires `--only`, so a bulk run cannot sweep it up.
+
+### Added
+
+- **A run-selection knob** (`_jobs/_migrate/_selection.py`): `SAC_JOBS_ENABLED`
+  or `~/.scitex/agent-container/jobs-enabled.txt` selects which declared jobs
+  run on THIS host. `JobSpec` has no host axis, so every discovered job was a
+  candidate everywhere while constraints like "`restart-login-expired-agents`
+  and `heal-agent-auth` are mutually exclusive" lived only in docstring prose.
+  UNSTATED is a third state distinct from "nothing selected": arriving
+  machinery must not disarm a host that never opted in, and a host that
+  deliberately selected nothing must not be armed. The knob gates ARMING, never
+  installing — an inert unit file stays inspectable with `systemctl cat`.
+
+- **Predictable logging for sac's jobs**, as a `10-logging.conf` drop-in on
+  scitex-dev's own path convention
+  (`~/.scitex/agent-container/runtime/logs/<kind>-<name>.log`). sac's jobs are
+  not dispatched through `ecosystem cron exec`, so upstream's log sink never
+  installed for them and their output went to the journal under a unit name
+  that changed with every rename. A drop-in rather than a unit edit because
+  scitex-dev REGENERATES the unit on every install; `append:` rather than
+  `file:` so a restart does not truncate the history. A test calls the real
+  upstream resolver, so an upstream convention change fails sac's build instead
+  of silently splitting the log tree in two.
+
+- **A host-capability refusal on the migration verb.** `sac dev` had none —
+  contrary to a widely-repeated assumption, there is no `systemctl` probe
+  anywhere in `_dev_jobs.py` or `_dev_jobs_backend.py`, and `manual_hint` will
+  still print a `systemctl` line on a QNAP. nas-01 (armv7l) and nas-02 have no
+  `systemctl` and mba uses launchd, so `service`/`timer` are unimplementable on
+  three of nine hosts; the migration now exits 3 there rather than running its
+  whole plan, failing every step, and reporting "NO supervisor" for a host that
+  was never going to have one.
+
+- `docs/adr/0022-listen-is-not-a-jobspec.md` — the "`sac listen` must never be
+  federated" argument, moved out of a function docstring into the ADR tree
+  where this project keeps architectural rationale.
+
 - **`sac dev` job groups are now named after the `JobSpec` KIND, not the
   delivery mechanism** — `sac dev {service,timer,cron} <verb>`, the
   ecosystem-wide grammar every SciTeX package adopts (operator decision,

--- a/docs/adr/0022-listen-is-not-a-jobspec.md
+++ b/docs/adr/0022-listen-is-not-a-jobspec.md
@@ -1,0 +1,68 @@
+# ADR-0022 — `sac listen` is not a JobSpec
+
+Status: accepted (2026-07-05, re-affirmed 2026-08-12)
+
+## Context
+
+`scitex-dev` derives a systemd unit FILENAME from `JobSpec.name` verbatim:
+
+```python
+def systemd_unit_name(job: JobSpec) -> str:
+    return f"{job.name}.timer" if job.kind == "timer" else f"{job.name}.service"
+```
+
+The `sac listen` that actually runs on the host is `sac-listen.service` — a
+HYPHEN — hand-written 2026-07-05 14:38, `Restart=always`, with `10-venv-path`
+and `20-hardening` drop-ins (and, on compute-04, a `50-secrets-envrc.conf`
+carrying 28 secret paths).
+
+## Decision
+
+`sac listen` is **deliberately not declared** in `_jobs_plugin.provide_jobs()`,
+and re-adding it as `sac.listen` would take the fleet's control plane down.
+
+A `sac.listen` JobSpec materialises `sac.listen.service`. The two names differ
+by one character and systemd treats them as unrelated units, so
+`scitex-dev service ensure sac.listen` does not adopt the running supervisor —
+it installs a SECOND one. Two units, both `Restart=always`, both running
+`sac listen`, both binding 127.0.0.1:7878: they fight for the port forever, and
+every lost round destroys the in-memory Broker, which deafens EVERY agent's
+inbox at once.
+
+## What was measured
+
+PR #543 declared it on the premise that `sac listen` "had NO SUPERVISOR". That
+premise was **false by the time it merged** — the hand-written unit was created
+the SAME DAY the PR was opened, and had been supervising listen for nine days
+(`NRestarts=0`). The PR was obsolete on arrival and nobody re-checked before
+merging it.
+
+The clew incident (`clew-incident-sac-host-listen-down`, 2026-07-05) that
+motivated federating listen was ALREADY fixed on the day it happened, by that
+hand-written `sac-listen.service` — not by a JobSpec. The fragile
+`sac-listen-watch.sh` `*/2` cron it replaced is gone. Re-federating it does not
+fix that incident again; it only adds a second supervisor to fight the first.
+
+## Consequences
+
+* If listen is ever federated, it must be named `sac-listen` (hyphen) so the
+  derived unit is the one that already exists — and even then, `ensure` must be
+  **shown to ADOPT** the running unit rather than overwrite its drop-ins. Do not
+  re-add it without measuring that.
+* The canonical-name migration
+  (`sac dev migrate-job-names`, `_jobs/_migrate/`) lists `sac-listen.service`,
+  `sac-listen.timer`, `sac.listen.service` and `sac.listen.timer` in
+  `NEVER_TOUCH`, and `assert_never_touches_listen` runs on every plan the
+  planner returns — so the guard is enforced, not documented.
+* Under the ecosystem naming convention (PS-226/PS-227) a future federated
+  listen would be `scitex-agent-container-listen`, which is a THIRD name again.
+  That rename is only safe through the same stop → remove → install →
+  verify-exactly-one ordering the migration package implements.
+
+## Related
+
+* ADR-0017 — credential rotation and the refresh race (the other
+  single-supervisor invariant in this repo).
+* `src/scitex_agent_container/_jobs/_migrate/_renames.py` — `NEVER_TOUCH`.
+* `src/scitex_agent_container/systemd/sac-listen.service.template` — the tracked
+  template for the hand-written unit.

--- a/src/scitex_agent_container/_jobs/_jobs_audit.py
+++ b/src/scitex_agent_container/_jobs/_jobs_audit.py
@@ -81,6 +81,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 
+from . import _names
+
 
 class Verdict(str, Enum):
     """Three states. UNKNOWN is not a soft INERT — it is a refusal to guess."""
@@ -378,12 +380,24 @@ def _deprecated_groups() -> frozenset[str]:
     return frozenset(DEPRECATED_GROUPS)
 
 
-def _discovered_sac_names(prefix: str) -> frozenset[str] | None:
+def _discovered_sac_names(prefix: str | None) -> frozenset[str] | None:
+    """Names sac owns among everything scitex-dev discovers.
+
+    ``prefix=None`` — the default — asks :func:`_names.is_ours`, which
+    knows BOTH live prefixes. A single prefix string cannot express the
+    transition state: while ``sac.accounts-refresh`` is held at the legacy
+    name and the other eight carry ``scitex-agent-container-``, filtering
+    on either one alone silently drops the other set, and a job that
+    vanishes from the audit reads as "not declared" rather than "not
+    looked for". An explicit string is still accepted so a test can pin
+    one side deliberately.
+    """
     try:
         from scitex_dev.jobs import discover_jobs
     except ImportError:  # stx-allow: fallback (reason: old scitex-dev has no jobs contract — UNKNOWN, not INERT)
         return None
-    return frozenset(j.name for j in discover_jobs() if j.name.startswith(prefix))
+    keep = _names.is_ours if prefix is None else (lambda n: n.startswith(prefix))
+    return frozenset(j.name for j in discover_jobs() if keep(j.name))
 
 
 def _allowed_kinds() -> frozenset[str] | None:
@@ -394,7 +408,7 @@ def _allowed_kinds() -> frozenset[str] | None:
     return frozenset(ALLOWED_KINDS)
 
 
-def audit_jobs(*, prefix: str = "sac.") -> InertReport:
+def audit_jobs(*, prefix: str | None = None) -> InertReport:
     """Run every covered form against the REAL declarations and consumers."""
     declared = _declared_jobs()
     declared_names = frozenset(j.name for j in declared)

--- a/src/scitex_agent_container/_jobs/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs/_jobs_plugin.py
@@ -134,30 +134,15 @@ def provide_jobs() -> "list[JobSpec]":
       ``spec.workdir``, so the command is correct as written.
 
     ``sac listen`` is DELIBERATELY NOT declared here, and adding it back
-    would take the fleet's control plane down. scitex-dev derives a unit
-    name from the job name VERBATIM (``scitex-todo.dashboard`` ->
-    ``scitex-todo.dashboard.service``), so a ``sac.listen`` JobSpec
-    materialises ``sac.listen.service`` — while the listen that actually
-    runs on the host is ``sac-listen.service`` (a HYPHEN), hand-written
-    2026-07-05 14:38, ``Restart=always``, with ``10-venv-path`` and
-    ``20-hardening`` drop-ins. The two names differ by one character and
-    systemd treats them as unrelated units, so ``scitex-dev service ensure
-    sac.listen`` does not adopt the running supervisor — it installs a
-    SECOND one. Two units, both ``Restart=always``, both running
-    ``sac listen``, both binding 127.0.0.1:7878: they fight for the port
-    forever, and every lost round destroys the in-memory Broker, which
-    deafens EVERY agent's inbox at once.
-
-    PR #543 declared it on the premise that ``sac listen`` "had NO
-    SUPERVISOR". That premise was false by the time it merged — the
-    hand-written unit was created the SAME DAY the PR was opened, and had
-    been supervising listen for nine days (``NRestarts=0``). The PR was
-    obsolete on arrival and nobody re-checked before merging it.
-
-    If this is ever federated, it must be named ``sac-listen`` (hyphen) so
-    the derived unit is the one that already exists — and even then,
-    ``ensure`` must be shown to ADOPT the running unit rather than
-    overwrite its drop-ins. Do not re-add it without measuring that.
+    would take the fleet's control plane down: scitex-dev derives the unit
+    filename from the job name VERBATIM, so a ``sac.listen`` JobSpec
+    materialises ``sac.listen.service`` while the unit that really runs is
+    ``sac-listen.service`` (a HYPHEN) — a second ``Restart=always``
+    supervisor fighting the first for 127.0.0.1:7878. The full argument,
+    the PR that shipped on a premise already false, and the conditions
+    under which it could ever be federated are recorded in
+    ``docs/adr/0022-listen-is-not-a-jobspec.md``. The migration enforces it:
+    ``_jobs._migrate.NEVER_TOUCH`` + ``assert_never_touches_listen``.
 
     Why ``sac.accounts-refresh`` is not ``--skip-active``: under the
     pre-2026-07-08 two-refresher model both the host timer and the
@@ -171,17 +156,27 @@ def provide_jobs() -> "list[JobSpec]":
     ``--sync-active-login`` keeps the operator's live session valid across
     the single-use refresh_token rotation.
 
-    The clew incident (``clew-incident-sac-host-listen-down``, 2026-07-05)
-    that motivated federating listen was ALREADY fixed on the day it
-    happened, by the hand-written ``sac-listen.service`` above — not by a
-    JobSpec. The fragile ``sac-listen-watch.sh`` ``*/2`` cron it replaced
-    is gone. Re-federating it does not fix that incident again; it only
-    adds a second supervisor to fight the first.
     """
     from scitex_dev.jobs import JobSpec
 
     return [
         JobSpec(
+            # THE ONE NAME STILL ON THE LEGACY PREFIX, AND IT IS ON PURPOSE.
+            # Every other job here was cut over to `scitex-agent-container-*`;
+            # this one is HELD, with the reason recorded in
+            # `_migrate._renames.RENAMES` (the SSoT for the cutover).
+            #
+            # A spec renamed AHEAD of its unit is the one shape that must not
+            # ship. The live, enabled, actively-refreshing unit is
+            # `sac.accounts-refresh.timer`; if this said
+            # `scitex-agent-container-accounts-refresh` while that unit ran,
+            # `sac dev timer status accounts-refresh` would resolve to a name
+            # no unit carries and report the fleet's SOLE OAuth refresher as
+            # ABSENT while it refreshes. A name that does not match the
+            # convention yet is a PS-227 warning; a CLI that reports the
+            # credential machinery as missing when it is healthy is an
+            # incident. So the declared name tracks the DEPLOYED unit until
+            # the supervised cutover renames both together.
             name="sac.accounts-refresh",
             schedule="0 */2 * * *",  # every 2h
             command=("sac accounts refresh --all --include-active --sync-active-login"),
@@ -206,7 +201,7 @@ def provide_jobs() -> "list[JobSpec]":
             timeout_sec=120,
         ),
         JobSpec(
-            name="sac.accounts-keepalive",
+            name="scitex-agent-container-accounts-keepalive",
             schedule="*/15 * * * *",  # every 15min (cron form; timer below)
             command=(
                 "sac accounts keepalive --all "
@@ -268,7 +263,7 @@ def provide_jobs() -> "list[JobSpec]":
             timeout_sec=300,
         ),
         JobSpec(
-            name="sac.host-sync-check",
+            name="scitex-agent-container-host-sync-check",
             schedule="0 * * * *",  # hourly (cron form; timer cadence below)
             command="sac host sync --check --all --alarm",
             description=(
@@ -290,7 +285,7 @@ def provide_jobs() -> "list[JobSpec]":
             timeout_sec=600,
         ),
         JobSpec(
-            name="sac.worktree-gc",
+            name="scitex-agent-container-worktree-gc",
             schedule="30 4 * * *",  # daily 04:30 (cron form; timer cadence below)
             command="sac worktree gc --apply --all",
             description=(
@@ -317,7 +312,7 @@ def provide_jobs() -> "list[JobSpec]":
             timeout_sec=900,
         ),
         JobSpec(
-            name="sac.spartan-sif-bake",
+            name="scitex-agent-container-spartan-sif-bake",
             schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)
             command="sac image bake-remote --yes",
             description=(
@@ -361,7 +356,7 @@ def provide_jobs() -> "list[JobSpec]":
             timeout_sec=14_400,
         ),
         JobSpec(
-            name="sac.freshness-refresh",
+            name="scitex-agent-container-freshness-refresh",
             schedule="7 * * * *",  # hourly (cron form; timer cadence below)
             command="sac freshness refresh",
             description=(
@@ -389,7 +384,7 @@ def provide_jobs() -> "list[JobSpec]":
             timeout_sec=300,
         ),
         JobSpec(
-            name="sac.fleet-reconcile",
+            name="scitex-agent-container-fleet-reconcile",
             schedule="*/5 * * * *",  # every 5min (cron form; timer cadence below)
             command="sac agents reconcile --apply",
             description=(
@@ -425,7 +420,7 @@ def provide_jobs() -> "list[JobSpec]":
             timeout_sec=300,
         ),
         JobSpec(
-            name="sac.restart-login-expired-agents",
+            name="scitex-agent-container-restart-login-expired-agents",
             schedule="*/5 * * * *",  # every 5min (cron form; timer cadence below)
             command="sac agents restart-login-expired --apply",
             description=(
@@ -459,7 +454,7 @@ def provide_jobs() -> "list[JobSpec]":
             timeout_sec=300,
         ),
         JobSpec(
-            name="sac.heal-agent-auth",
+            name="scitex-agent-container-heal-agent-auth",
             schedule="*/10 * * * *",  # every 10min (cron form; timer cadence below)
             # ABSOLUTE by design, both tokens. `resolve_execstart` passes a
             # command whose head starts with "/" through VERBATIM, so this is

--- a/src/scitex_agent_container/_jobs/_migrate/__init__.py
+++ b/src/scitex_agent_container/_jobs/_migrate/__init__.py
@@ -1,0 +1,97 @@
+"""The one-time cutover from ``sac.<job>`` to ``scitex-agent-container-<job>``.
+
+The ecosystem decided (operator, 2026-08-11) that every federated job is
+named ``scitex-<pkg>-<name>`` with hyphens only — no ``.`` and no ``_`` —
+because ``JobSpec.name`` becomes a systemd unit FILENAME verbatim and a
+dot in a unit name reads as systemd's template/instance separator to every
+human who has ever typed ``systemctl``. scitex-dev's auditor enforces it
+as PS-226 (charset, error) and PS-227 (package qualification, warning).
+
+Renaming a job therefore RENAMES ITS UNIT, and that is a live
+double-supervisor hazard rather than a cosmetic change. This package is
+the migration that makes the rename safe:
+
+* :mod:`._renames`   — the table: old name, new name, and the stated
+                       reason for any job deliberately held back.
+* :mod:`._plan`      — the ORDER (stop -> disable -> carry drop-ins ->
+                       displace -> reload -> install -> logging ->
+                       verify), enforced by construction.
+* :mod:`._verify`    — exactly-one-supervisor, counted over BOTH names.
+* :mod:`._logsink`   — predictable logging, as a drop-in, on scitex-dev's
+                       own path convention.
+* :mod:`._selection` — the knob for which declared jobs run on this host.
+
+Everything here is pure except the ``systemctl`` probe; the executor lives
+in ``cli_pkg/_dev_jobs_migrate.py``, so the planning half is testable
+against real specs without touching a host.
+"""
+
+from __future__ import annotations
+
+from ._logsink import (
+    LOG_DIR,
+    LOG_PACKAGE,
+    LOGGING_DROPIN,
+    log_path,
+    log_slug,
+    logging_dropin_text,
+)
+from ._plan import (
+    ACTION_ORDER,
+    Step,
+    assert_never_touches_listen,
+    default_install_argv,
+    plan,
+    plan_one,
+)
+from ._renames import (
+    KIND_UNIT_SUFFIXES,
+    NEVER_TOUCH,
+    RENAMES,
+    Rename,
+    by_local,
+    units_for,
+)
+from ._selection import (
+    SELECT_ALL,
+    SELECTION_ENV,
+    SELECTION_FILE,
+    explain,
+    is_selected,
+    parse_selection,
+    selection,
+    selection_path,
+)
+from ._verify import Supervisors, systemd_user_available, verify_exactly_one
+
+__all__ = [
+    "ACTION_ORDER",
+    "KIND_UNIT_SUFFIXES",
+    "LOGGING_DROPIN",
+    "LOG_DIR",
+    "LOG_PACKAGE",
+    "NEVER_TOUCH",
+    "RENAMES",
+    "SELECTION_ENV",
+    "SELECTION_FILE",
+    "SELECT_ALL",
+    "Rename",
+    "Step",
+    "Supervisors",
+    "assert_never_touches_listen",
+    "by_local",
+    "default_install_argv",
+    "explain",
+    "is_selected",
+    "log_path",
+    "log_slug",
+    "logging_dropin_text",
+    "parse_selection",
+    "plan",
+    "plan_one",
+    "selection",
+    "selection_path",
+    "systemd_user_available",
+    "units_for",
+    "verify_exactly_one",
+]

--- a/src/scitex_agent_container/_jobs/_migrate/_logsink.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_logsink.py
@@ -1,0 +1,109 @@
+"""Predictable logging for sac's federated jobs — as a systemd DROP-IN.
+
+THE GAP THIS CLOSES
+===================
+scitex-dev already owns a job-logging convention
+(``scitex_dev.jobs._logsink``): ``~/.scitex/<package>/runtime/logs/<slug>.log``,
+rotated at 1 MiB, installed at fd level so a job's children are captured
+too. But it is installed by ``ecosystem cron exec <name>``, which
+dispatches jobs scitex-dev itself declares. sac's jobs are not dispatched
+that way — their ``ExecStart`` is the real command (``sac worktree gc
+--apply --all``), so nothing installs that sink and their output goes to
+the journal under a unit name that CHANGES WITH EVERY RENAME.
+
+That is the whole failure: "where did last night's worktree-gc go" had no
+answer that survived a migration. The operator's TODO asks for exactly
+this — "logging periodic jobs can be predictable for this".
+
+WHY A DROP-IN, AND WHY NOT A NEW CONVENTION
+===========================================
+Two constraints point at the same answer.
+
+*Not the unit file.* scitex-dev owns it and REGENERATES it on every
+``install``. Anything written into the unit is erased by the next install
+without a word — the difference between a convention and a wish. A
+``<unit>.d/`` drop-in is systemd's sanctioned extension point and survives
+regeneration, so sac extends the unit without becoming a second owner of
+it.
+
+*Not a new path.* Inventing ``~/.scitex/agent-container/logs/jobs/`` would
+make sac's logs predictable and the ECOSYSTEM's logs inconsistent — a
+second convention is just a second thing to look in. So the path here is
+scitex-dev's convention, spelled for a unit file: ``%h`` rather than a
+resolved home, because a drop-in must be correct for whichever user
+systemd expands it as. ``test_the_dropin_path_matches_scitex_devs_own``
+asserts the two agree by calling the REAL ``scitex_dev`` resolver, so a
+convention change upstream fails sac's build instead of silently splitting
+the tree in two.
+"""
+
+from __future__ import annotations
+
+from .. import _names
+
+#: sac's package directory under ``~/.scitex``. Short form, matching the
+#: tree sac already uses (``~/.scitex/agent-container/bin/auth-heal.py``)
+#: and mirroring scitex-dev's own ``dev``.
+LOG_PACKAGE = "agent-container"
+
+#: The runtime log directory as a systemd specifier path. ``%h`` is
+#: expanded by systemd to the unit's home, so one drop-in text is correct
+#: for every user and can be asserted verbatim in a test.
+LOG_DIR = f"%h/.scitex/{LOG_PACKAGE}/runtime/logs"
+
+#: The drop-in filename carrying the logging directives. Numbered low so
+#: an operator's own drop-in (``50-``, ``90-``) always wins, and named for
+#: what it does so ``ls <unit>.d/`` explains itself.
+LOGGING_DROPIN = "10-logging.conf"
+
+
+def log_slug(name: str, kind: str) -> str:
+    """The log basename for a job, without ``.log``.
+
+    ``<kind>-<local name>``, following scitex-dev's own slugs
+    (``timer-ecosystem-self-pull``, ``cron-pr-expire``). The kind is in the
+    slug because it is in theirs, and because a directory listing that
+    says what KIND of thing wrote each file is worth one hyphen.
+    """
+    if not kind:
+        raise ValueError("job kind must be non-empty")
+    local = _names.local(name)
+    if not local:
+        raise ValueError(f"job name {name!r} has no local part")
+    return f"{kind}-{local}"
+
+
+def log_path(name: str, kind: str) -> str:
+    """The predictable log file for a job, as a systemd specifier path."""
+    return f"{LOG_DIR}/{log_slug(name, kind)}.log"
+
+
+def logging_dropin_text(name: str, kind: str) -> str:
+    """The ``10-logging.conf`` body that makes ``name``'s output predictable.
+
+    ``append:`` rather than ``file:`` so a restart does not truncate the
+    history the operator came to read. systemd creates the parent
+    directory for ``append:`` targets, so nothing here has to mkdir.
+    """
+    path = log_path(name, kind)
+    return (
+        "# Managed by `sac dev migrate-job-names`.\n"
+        "#\n"
+        "# scitex-dev owns this unit file and rewrites it on every install,\n"
+        "# so these directives live in a drop-in that survives. The path is\n"
+        "# scitex-dev's own convention (~/.scitex/<pkg>/runtime/logs/<slug>.log)\n"
+        "# spelled with %h for a unit file — not a second convention.\n"
+        "[Service]\n"
+        f"StandardOutput=append:{path}\n"
+        f"StandardError=append:{path}\n"
+    )
+
+
+__all__ = [
+    "LOGGING_DROPIN",
+    "LOG_DIR",
+    "LOG_PACKAGE",
+    "log_path",
+    "log_slug",
+    "logging_dropin_text",
+]

--- a/src/scitex_agent_container/_jobs/_migrate/_plan.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_plan.py
@@ -1,0 +1,321 @@
+"""The ordered plan. THE ORDER IS THE WHOLE MODULE.
+
+WHAT INSTALL-BEFORE-UNINSTALL COSTS
+===================================
+A rename derives a DIFFERENT unit filename, so installing the new unit
+before removing the old one leaves BOTH on the host. Both are enabled,
+both fire, both run the same command, and neither knows about the other.
+
+This is not hypothetical. On the head node a crontab line and a systemd
+unit were both supervising ``sac listen`` against DIFFERENT venvs, and the
+cron one was dormant only because its ``pgrep`` guard happened to match
+systemd's process. A rename is precisely the event that WAKES a dormant
+second supervisor, because the guard stops matching the moment the name
+changes.
+
+So every plan is, per job::
+
+    stop old -> disable old -> carry drop-ins -> displace old
+             -> daemon-reload -> install new -> logging -> verify
+
+built in that order BY CONSTRUCTION: each step's ``action`` indexes into
+:data:`ACTION_ORDER` and ``test_install_never_precedes_displace`` asserts
+the resulting ranks are non-decreasing for every job in the table. An edit
+that reorders the steps fails the build instead of quietly arming a race.
+
+Two orderings inside that sequence are also load-bearing:
+
+*stop before disable* — ``disable`` only drops the ``.wants`` symlink. A
+disable-first order leaves a RUNNING unit that nothing will start again
+but nothing has stopped either.
+
+*carry drop-ins before displace* — a ``<unit>.d/`` directory is host state
+no PR can reproduce (on compute-04, 28 secret paths). Displacing the unit
+first orphans its drop-ins under a name the new unit never reads: the
+config silently stops applying while everything still looks installed.
+
+WHY SAC RUNS ``systemctl`` HERE, HAVING ARGUED IT MUST NOT
+==========================================================
+``_dev_jobs_backend`` argues that sac must never shell ``systemctl`` for a
+job, because scitex-dev owns the unit file and two owners with no arbiter
+is the disease. That argument holds for every STEADY-STATE verb and
+nothing here weakens it.
+
+It does not reach this case, and the reason is exact: the units stopped
+and displaced here carry the PRE-rename names, which after the rename NO
+PACKAGE DECLARES. scitex-dev cannot uninstall them — its ``uninstall``
+iterates the declared specs, and an undeclared unit is invisible to it. An
+orphan with no owner is not a second owner; it is a leak. sac made these
+names, so sac retires them — and the ``install`` step DELEGATES, so
+ownership returns to scitex-dev the moment the new name exists.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Sequence
+
+from ._logsink import LOGGING_DROPIN
+from ._renames import NEVER_TOUCH, RENAMES, Rename
+
+#: Actions a step can be, in the ONLY order they may appear for one job.
+#: :func:`plan_one` emits a subsequence of this tuple, so "install after
+#: displace" is a property of the data rather than of reviewer attention.
+ACTION_ORDER: tuple[str, ...] = (
+    "stop",
+    "disable",
+    "carry-dropins",
+    "displace",
+    "daemon-reload",
+    "install",
+    "logging",
+    "verify",
+)
+
+
+@dataclass(frozen=True)
+class Step:
+    """One concrete action, with the evidence for why it is in the plan.
+
+    ``why`` is mandatory for the same reason ``Delegation.evidence`` is: a
+    step that cannot say what was observed is a step nobody can review,
+    and this plan mutates the supervision of the fleet's credential
+    machinery.
+    """
+
+    action: str
+    target: str
+    why: str
+    argv: tuple[str, ...] | None = None
+    path: str | None = None
+    dest: str | None = None
+    body: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.action not in ACTION_ORDER:
+            raise ValueError(f"Step.action={self.action!r} not in {list(ACTION_ORDER)}")
+        if not self.target:
+            raise ValueError("Step needs a target")
+        if not self.why:
+            raise ValueError(
+                f"Step({self.action}, {self.target!r}) must state its evidence"
+            )
+
+    @property
+    def rank(self) -> int:
+        """Position in :data:`ACTION_ORDER` — the orderedness invariant."""
+        return ACTION_ORDER.index(self.action)
+
+    def render(self) -> str:
+        """One human-readable line, for ``--dry-run`` and the log."""
+        if self.argv is not None:
+            detail = " ".join(self.argv)
+        elif self.dest is not None:
+            detail = f"{self.path} -> {self.dest}"
+        elif self.path is not None:
+            detail = str(self.path)
+        else:
+            detail = self.target
+        return f"{self.action:14s} {detail}"
+
+
+def default_install_argv(rename: Rename) -> tuple[str, ...]:
+    """The delegation that hands the new name back to scitex-dev.
+
+    ``ecosystem dev systemd`` rather than ``ecosystem dev timer``: the
+    per-KIND groups arrive in scitex-dev #566, and the scitex-dev
+    INSTALLED here is 0.47.0, which predates it and serves only
+    ``{cron, systemd}`` under ``dev``. Targeting the group that exists is
+    the difference between a migration that runs and one that exits 4 on
+    every job.
+
+    The CLI overrides this with the capability-probed delegation from
+    ``_dev_jobs_backend``, so a host with a newer scitex-dev uses the
+    per-kind group without a sac release.
+    """
+    return (
+        "scitex-dev",
+        "ecosystem",
+        "dev",
+        "systemd",
+        "install",
+        "--name",
+        rename.new,
+        "--yes",
+    )
+
+
+def plan_one(
+    rename: Rename,
+    *,
+    present: Iterable[str] = (),
+    dropin_dirs: Iterable[str] = (),
+    install_argv: Callable[[Rename], tuple[str, ...]] = default_install_argv,
+) -> tuple[Step, ...]:
+    """Build the ordered plan for ONE job.
+
+    ``present`` is the unit FILENAMES currently on the host and
+    ``dropin_dirs`` the ``<unit>.d`` directory names; both are MEASURED by
+    the caller and passed in, so this stays pure and the plan is a
+    function of observed state rather than of hope.
+
+    A held job plans nothing — see ``Rename.hold``.
+
+    A job whose old units are absent still gets ``install``, ``logging``
+    and ``verify``: the rename may have half-completed on this host, and
+    saying so is what ``verify`` is for.
+    """
+    if rename.held:
+        return ()
+
+    on_host = frozenset(present)
+    have_dropins = frozenset(dropin_dirs)
+    live = [u for u in rename.old_units() if u in on_host]
+    steps: list[Step] = []
+
+    for unit in live:
+        steps.append(
+            Step(
+                action="stop",
+                target=unit,
+                why=f"{unit} is on this host and must not outlive its name",
+                argv=("systemctl", "--user", "stop", unit),
+            )
+        )
+    for unit in live:
+        steps.append(
+            Step(
+                action="disable",
+                target=unit,
+                why=f"drop {unit}'s .wants symlink so nothing re-triggers it",
+                argv=("systemctl", "--user", "disable", unit),
+            )
+        )
+
+    for old_unit, new_unit in zip(rename.old_units(), rename.new_units()):
+        old_dir = old_unit + ".d"
+        if old_unit in live and old_dir in have_dropins:
+            steps.append(
+                Step(
+                    action="carry-dropins",
+                    target=old_dir,
+                    why=(
+                        f"{old_dir} holds host configuration no PR can "
+                        "reproduce; orphaning it under the old name stops it "
+                        "applying while everything still looks installed"
+                    ),
+                    path=old_dir,
+                    dest=new_unit + ".d",
+                )
+            )
+
+    for unit in live:
+        steps.append(
+            Step(
+                action="displace",
+                target=unit,
+                why=f"retire {unit} to .old/<timestamp>/ — displaced, never deleted",
+                path=unit,
+            )
+        )
+
+    if live:
+        steps.append(
+            Step(
+                action="daemon-reload",
+                target=rename.old,
+                why=(
+                    "make systemd forget the displaced units before the new "
+                    "ones arrive, so `verify` counts what really exists"
+                ),
+                argv=("systemctl", "--user", "daemon-reload"),
+            )
+        )
+
+    steps.append(
+        Step(
+            action="install",
+            target=rename.new,
+            why=(
+                "hand ownership back to scitex-dev, which renders and writes "
+                "the unit for the declared spec"
+            ),
+            argv=tuple(install_argv(rename)),
+        )
+    )
+    for new_unit in rename.new_units():
+        if new_unit.endswith(".service"):
+            steps.append(
+                Step(
+                    action="logging",
+                    target=new_unit + ".d/" + LOGGING_DROPIN,
+                    why=(
+                        "make this job's output land at a path that survives "
+                        "the next install, which rewrites the unit file"
+                    ),
+                    path=new_unit + ".d/" + LOGGING_DROPIN,
+                )
+            )
+    steps.append(
+        Step(
+            action="verify",
+            target=rename.new,
+            why="prove exactly one supervisor survives this job's cutover",
+        )
+    )
+    return tuple(steps)
+
+
+def plan(
+    renames: Sequence[Rename] = RENAMES,
+    *,
+    present: Iterable[str] = (),
+    dropin_dirs: Iterable[str] = (),
+    install_argv: Callable[[Rename], tuple[str, ...]] = default_install_argv,
+) -> tuple[Step, ...]:
+    """The full ordered plan across every non-held job in ``renames``."""
+    on_host = frozenset(present)
+    dirs = frozenset(dropin_dirs)
+    steps: list[Step] = []
+    for rename in renames:
+        steps.extend(
+            plan_one(
+                rename,
+                present=on_host,
+                dropin_dirs=dirs,
+                install_argv=install_argv,
+            )
+        )
+    out = tuple(steps)
+    assert_never_touches_listen(out)
+    return out
+
+
+def assert_never_touches_listen(steps: Iterable[Step]) -> None:
+    """Raise if any step names a unit this migration must never touch.
+
+    A GUARD, not a comment. ``sac-listen.service`` supervises the fleet's
+    control plane; a plan that reached it would be discovered at the worst
+    possible moment. Called by :func:`plan` on every plan it returns, so
+    the check cannot be forgotten at a call site.
+    """
+    for step in steps:
+        for forbidden in NEVER_TOUCH:
+            if step.target in (forbidden, forbidden + ".d") or step.target.startswith(
+                forbidden + ".d/"
+            ):
+                raise ValueError(
+                    f"migration step {step.action!r} targets {step.target!r}, "
+                    "which this migration must NEVER touch — it is the "
+                    "fleet's control plane and is deliberately not a JobSpec"
+                )
+
+
+__all__ = [
+    "ACTION_ORDER",
+    "Step",
+    "assert_never_touches_listen",
+    "default_install_argv",
+    "plan",
+    "plan_one",
+]

--- a/src/scitex_agent_container/_jobs/_migrate/_renames.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_renames.py
@@ -1,0 +1,211 @@
+"""THE MIGRATION TABLE: every old job name, and what it becomes.
+
+A rename here is not cosmetic. ``scitex_dev.jobs._systemd.systemd_unit_name``
+derives the unit FILENAME from ``JobSpec.name`` verbatim::
+
+    return f"{job.name}.timer" if job.kind == "timer" else f"{job.name}.service"
+
+so renaming a job renames its unit, and systemd treats
+``sac.worktree-gc.timer`` and ``scitex-agent-container-worktree-gc.timer``
+as two unrelated units with independent enablement, state and triggers.
+That is why this table exists at all, and why it is the one place the old
+names survive.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .. import _names
+
+#: The unit suffixes a job of each kind materialises.
+#:
+#: A ``timer`` job is TWO units — a systemd timer triggers a companion
+#: service, and scitex-dev's renderer writes both. A migration that
+#: displaced only the ``.timer`` would leave the old ``.service`` behind as
+#: a runnable orphan: the two-supervisor bug wearing a different hat.
+KIND_UNIT_SUFFIXES: dict[str, tuple[str, ...]] = {
+    "timer": (".service", ".timer"),
+    "service": (".service",),
+    "cron": (),
+}
+
+
+def units_for(name: str, kind: str) -> tuple[str, ...]:
+    """Every unit filename ``name`` materialises for ``kind``."""
+    if kind not in KIND_UNIT_SUFFIXES:
+        raise ValueError(f"kind={kind!r} not in {sorted(KIND_UNIT_SUFFIXES)}")
+    if not name:
+        raise ValueError("job name must be non-empty")
+    return tuple(name + suffix for suffix in KIND_UNIT_SUFFIXES[kind])
+
+
+@dataclass(frozen=True)
+class Rename:
+    """One job's old name, new name, and whether it is cut over now.
+
+    ``hold`` is a REASON, not a flag. A held job is one whose cutover is
+    deliberately deferred to a supervised window; stating why, in the
+    table, is what stops the next reader from "finishing the job" and
+    taking the fleet down. A blank hold is rejected for the same reason a
+    park with no reason is not a park — it is indistinguishable from an
+    oversight.
+    """
+
+    old: str
+    new: str
+    kind: str
+    hold: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.old or not self.new:
+            raise ValueError("Rename needs both an old and a new name")
+        if self.old == self.new:
+            raise ValueError(f"Rename({self.old!r}) renames nothing")
+        if self.kind not in KIND_UNIT_SUFFIXES:
+            raise ValueError(
+                f"Rename({self.old!r}).kind={self.kind!r} not in "
+                f"{sorted(KIND_UNIT_SUFFIXES)}"
+            )
+        if self.hold is not None and not self.hold.strip():
+            raise ValueError(
+                f"Rename({self.old!r}).hold must state WHY the cutover is "
+                "deferred — a hold with no reason is indistinguishable from "
+                "an oversight"
+            )
+
+    @property
+    def held(self) -> bool:
+        """True when this job is left for an operator-supervised cutover."""
+        return self.hold is not None
+
+    @property
+    def local(self) -> str:
+        """The short name an operator types for this job."""
+        return _names.local(self.new)
+
+    def old_units(self) -> tuple[str, ...]:
+        """Unit filenames the PRE-rename name materialises."""
+        return units_for(self.old, self.kind)
+
+    def new_units(self) -> tuple[str, ...]:
+        """Unit filenames the POST-rename name materialises."""
+        return units_for(self.new, self.kind)
+
+
+#: Every job sac declared under the legacy prefix, and what it becomes.
+#:
+#: EXPLICIT, NOT DERIVED, and that is the point. After the rename lands,
+#: ``provide_jobs()`` no longer mentions a single old name — so a table
+#: computed from the declared specs would compute the IDENTITY mapping,
+#: and the migration would become a no-op that reports success while eight
+#: orphaned units keep firing on every host. The old names survive ONLY
+#: here, which makes this table the historical record as well as the plan.
+#:
+#: The cost of explicitness is drift, so drift is machine-checked:
+#: ``test_table_covers_exactly_the_declared_jobs`` asserts these ``new``
+#: names are exactly what ``provide_jobs()`` declares, reading the REAL
+#: provider through the REAL validator. Adding a job without a row, or a
+#: row without a job, fails the build.
+RENAMES: tuple[Rename, ...] = (
+    Rename(
+        old="sac.accounts-refresh",
+        new="scitex-agent-container-accounts-refresh",
+        kind="timer",
+        hold=(
+            "THE FLEET'S SOLE OAUTH REFRESHER, against a SINGLE-USE refresh "
+            "token. Two racing refreshers revoke each other's access token; "
+            "zero expires every account within hours (measured 2026-07-09/10, "
+            "a total fleet stall). It is also the ONLY sac timer actually "
+            "enabled and active on compute-04, so this cutover has a live "
+            "blast radius the other eight do not have. OPERATOR-SUPERVISED: "
+            "run `sac dev migrate-job-names --only accounts-refresh "
+            "--include-held --yes` in a watched window, then confirm "
+            "`sac accounts status` still resolves every account BEFORE "
+            "walking away. Until then the spec keeps its legacy name ON "
+            "PURPOSE, so every CLI verb keeps naming the unit that is really "
+            "running — a spec renamed ahead of its unit would report the "
+            "refresher as absent while it refreshes."
+        ),
+    ),
+    Rename(
+        old="sac.accounts-keepalive",
+        new="scitex-agent-container-accounts-keepalive",
+        kind="timer",
+    ),
+    Rename(
+        old="sac.fleet-reconcile",
+        new="scitex-agent-container-fleet-reconcile",
+        kind="timer",
+    ),
+    Rename(
+        old="sac.freshness-refresh",
+        new="scitex-agent-container-freshness-refresh",
+        kind="timer",
+    ),
+    Rename(
+        old="sac.heal-agent-auth",
+        new="scitex-agent-container-heal-agent-auth",
+        kind="timer",
+    ),
+    Rename(
+        old="sac.host-sync-check",
+        new="scitex-agent-container-host-sync-check",
+        kind="timer",
+    ),
+    Rename(
+        old="sac.restart-login-expired-agents",
+        new="scitex-agent-container-restart-login-expired-agents",
+        kind="timer",
+    ),
+    Rename(
+        old="sac.spartan-sif-bake",
+        new="scitex-agent-container-spartan-sif-bake",
+        kind="timer",
+    ),
+    Rename(
+        old="sac.worktree-gc",
+        new="scitex-agent-container-worktree-gc",
+        kind="timer",
+    ),
+)
+
+#: Units this migration must NEVER touch.
+#:
+#: ``sac-listen.service`` is hand-written host state that brokers
+#: ``host_exec`` / spawn / restart for every agent in the fleet. It is
+#: deliberately not a JobSpec (see ``_jobs_plugin.provide_jobs``) and on
+#: compute-04 it carries ``sac-listen.service.d/50-secrets-envrc.conf``
+#: with 28 secret paths — host state no PR can reproduce. ``sac.listen``
+#: is listed too: it is the name a JobSpec WOULD have derived, and the
+#: near-miss between the two is exactly what once put two supervisors on
+#: 127.0.0.1:7878.
+NEVER_TOUCH: frozenset[str] = frozenset(
+    {
+        "sac-listen.service",
+        "sac-listen.timer",
+        "sac.listen.service",
+        "sac.listen.timer",
+    }
+)
+
+
+def by_local(local: str) -> Rename:
+    """Look up one row by its short name; raise naming the real ones."""
+    for rename in RENAMES:
+        if rename.local == local or rename.new == local or rename.old == local:
+            return rename
+    raise KeyError(
+        f"no job named {local!r} in the migration table; available: "
+        + ", ".join(sorted(r.local for r in RENAMES))
+    )
+
+
+__all__ = [
+    "KIND_UNIT_SUFFIXES",
+    "NEVER_TOUCH",
+    "RENAMES",
+    "Rename",
+    "by_local",
+    "units_for",
+]

--- a/src/scitex_agent_container/_jobs/_migrate/_selection.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_selection.py
@@ -1,0 +1,146 @@
+"""The run-selection knob: WHICH declared jobs actually run on this host.
+
+WHY THIS IS NEEDED AT ALL
+=========================
+A JobSpec is a fleet-wide declaration with no host axis — measured on the
+real model, ``JobSpec`` has ``name/kind/schedule/command/description/
+on_boot_sec/on_unit_active_sec/timeout_sec/restart_policy/watchdog_sec/
+venv`` and nothing else. So every discovered job is a candidate on every
+host, and "which of these should run HERE" has, until now, been answered
+only by the host's systemd enablement — invisible state, on nine hosts,
+with no declaration to compare it against.
+
+sac's own specs are full of jobs that must NOT all run together:
+``restart-login-expired-agents`` and ``heal-agent-auth`` are explicitly
+mutually exclusive (two restarters with independent debounce state), and
+``accounts-keepalive`` must run ONLY on the host holding refresh material.
+Today those constraints live in prose inside docstrings. This makes the
+answer a file.
+
+THE THIRD STATE IS THE WHOLE DESIGN
+===================================
+:func:`selection` returns ``None`` for UNSTATED, which is different from
+"nothing selected". A host that has never been configured must not have
+its timers silently disarmed by the arrival of this feature; a host that
+deliberately selected nothing must not have them armed. Collapsing those
+two into an empty set is how a safety feature becomes an outage — the
+same three-state discipline ``_dev_jobs_backend.resolve`` uses for
+"cannot tell".
+
+IT GATES ARMING, NOT INSTALLING
+===============================
+Selection decides what is ENABLED (armed to fire), never what is
+installed. Install writes an inert unit file; that is cheap, reversible,
+and makes the unit inspectable with ``systemctl cat``. Refusing to install
+would instead hide the job from the very command an operator uses to ask
+what this host could run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .. import _names
+
+#: Env override for which jobs run here. Comma- or newline-separated LOCAL
+#: names. Primarily the test seam, and the way a one-off host states its
+#: selection without committing a file.
+SELECTION_ENV = "SAC_JOBS_ENABLED"
+
+#: Per-host selection file, relative to ``$HOME``. Configuration, so it is
+#: a FILE under the operator's control (Wave A1: "states -> PostgreSQL,
+#: configuration -> files"). One local name per line, ``#`` comments,
+#: blank lines ignored.
+SELECTION_FILE = ".scitex/agent-container/jobs-enabled.txt"
+
+#: The token selecting every declared job. Spelled out rather than implied
+#: by an empty file, because an empty file and an absent one MUST NOT mean
+#: opposite things — and without this token "run everything" would have no
+#: way to be written down at all.
+SELECT_ALL = "*"
+
+
+def parse_selection(text: str) -> frozenset[str]:
+    """Parse a selection body into local job names.
+
+    Commas are accepted as separators alongside newlines so the env form
+    and the file form parse identically — one grammar, not two.
+    """
+    out: set[str] = set()
+    for raw in text.replace(",", "\n").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            out.add(line)
+    return frozenset(out)
+
+
+def selection_path(home: Path) -> Path:
+    """Where this host's selection file lives."""
+    return home / SELECTION_FILE
+
+
+def selection(*, env: dict[str, str], home: Path) -> frozenset[str] | None:
+    """Which jobs are selected to run here, or ``None`` when UNSTATED.
+
+    Precedence: the env override, then the file, then unstated. An
+    unreadable file reads as unstated rather than as empty, for the reason
+    in the module docstring.
+    """
+    raw = env.get(SELECTION_ENV)
+    if raw is not None and raw.strip():
+        return parse_selection(raw)
+    try:
+        body = selection_path(home).read_text(encoding="utf-8")
+    except OSError:  # stx-allow: fallback (reason: an absent or unreadable selection file means UNSTATED, a third state the caller must be able to tell from "empty")
+        return None
+    return parse_selection(body)
+
+
+def is_selected(name: str, chosen: frozenset[str] | None) -> bool:
+    """True when ``name`` is selected to run here.
+
+    An UNSTATED selection answers True for every job: arriving machinery
+    must not disarm a host that never opted into it. Both the local and
+    the canonical spelling match, so a name copied out of ``--json`` or
+    off a unit filename works as typed.
+    """
+    if chosen is None or SELECT_ALL in chosen:
+        return True
+    return name in chosen or _names.local(name) in chosen
+
+
+def explain(chosen: frozenset[str] | None) -> str:
+    """One line describing the selection, for the CLI to print.
+
+    A knob whose current setting cannot be read back is a knob nobody
+    trusts, so every command that consults the selection says what it
+    found.
+    """
+    if chosen is None:
+        return (
+            "run-selection: UNSTATED (no "
+            + SELECTION_ENV
+            + ", no ~/"
+            + SELECTION_FILE
+            + ") — every declared job is eligible here"
+        )
+    if SELECT_ALL in chosen:
+        return f"run-selection: {SELECT_ALL} — every declared job is eligible here"
+    if not chosen:
+        return (
+            "run-selection: EMPTY — this host has deliberately selected NO "
+            "jobs; nothing will be armed"
+        )
+    return "run-selection: " + ", ".join(sorted(chosen))
+
+
+__all__ = [
+    "SELECTION_ENV",
+    "SELECTION_FILE",
+    "SELECT_ALL",
+    "explain",
+    "is_selected",
+    "parse_selection",
+    "selection",
+    "selection_path",
+]

--- a/src/scitex_agent_container/_jobs/_migrate/_verify.py
+++ b/src/scitex_agent_container/_jobs/_migrate/_verify.py
@@ -1,0 +1,89 @@
+"""EXACTLY ONE SUPERVISOR — the claim the migration exists to make good on.
+
+"The new unit exists" is not the claim. "ONLY the new unit exists" is.
+A migration that installed the new name and left the old one behind would
+report success while doubling the supervision of the fleet's credential
+machinery, which is the precise failure this whole change is written to
+prevent. So verification counts BOTH names and treats any survivor of the
+old one as a failure, however healthy the new one looks.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from ._renames import Rename
+
+
+@dataclass(frozen=True)
+class Supervisors:
+    """What is supervising one job after its cutover."""
+
+    job: str
+    expected: tuple[str, ...]
+    found_new: tuple[str, ...]
+    found_old: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        """True only when the new set is complete and NOTHING old survives."""
+        return not self.found_old and set(self.found_new) == set(self.expected)
+
+    @property
+    def verdict(self) -> str:
+        """One line an operator can act on, naming what was actually found."""
+        if self.ok:
+            return f"OK   {self.job}: exactly one supervisor {list(self.found_new)}"
+        if self.found_old and self.found_new:
+            return (
+                f"FAIL {self.job}: TWO SUPERVISORS — old {list(self.found_old)} "
+                f"and new {list(self.found_new)} are both present"
+            )
+        if self.found_old:
+            return (
+                f"FAIL {self.job}: still on the OLD name {list(self.found_old)}; "
+                "the cutover did not happen"
+            )
+        missing = sorted(set(self.expected) - set(self.found_new))
+        return f"FAIL {self.job}: NO supervisor — missing {missing}"
+
+
+def verify_exactly_one(rename: Rename, *, present: Iterable[str]) -> Supervisors:
+    """Count the supervisors for one job against the host's unit files."""
+    on_host = frozenset(present)
+    return Supervisors(
+        job=rename.new,
+        expected=rename.new_units(),
+        found_new=tuple(u for u in rename.new_units() if u in on_host),
+        found_old=tuple(u for u in rename.old_units() if u in on_host),
+    )
+
+
+def systemd_user_available(*, which: Callable[[str], str | None] = shutil.which) -> bool:
+    """True when this host can supervise ``--user`` units at all.
+
+    MEASURED 2026-08-11: nas-01 (armv7l) and nas-02 have no ``systemctl``
+    at all, and mba uses launchd — so ``service`` and ``timer`` are
+    unimplementable on three of the fleet's nine hosts.
+
+    Without this probe the migration would run its whole plan there, fail
+    every ``systemctl`` call, and still reach ``verify`` — reporting "NO
+    supervisor" for a host that was never going to have one, which reads
+    as a broken migration rather than an inapplicable one. Refusing up
+    front says the true thing.
+
+    NOTE, because the brief that commissioned this work assumed otherwise:
+    ``sac dev`` did NOT already refuse on those hosts. There is no
+    ``systemctl`` probe anywhere in ``_dev_jobs.py`` or
+    ``_dev_jobs_backend.py`` — the only refusal either can emit is about
+    the installed scitex-dev's capabilities, never the host's, and
+    ``manual_hint`` will still cheerfully print a ``systemctl`` line on a
+    QNAP. This function is that missing guard, wired into the one verb
+    here that mutates.
+    """
+    return which("systemctl") is not None
+
+
+__all__ = ["Supervisors", "systemd_user_available", "verify_exactly_one"]

--- a/src/scitex_agent_container/_jobs/_names.py
+++ b/src/scitex_agent_container/_jobs/_names.py
@@ -30,6 +30,26 @@ The rename therefore does not ride along with a CLI-surface change; it
 ships with the migration verb that enforces stop -> remove -> install and
 makes install-before-uninstall impossible. Flipping this one constant is
 the code half of that change.
+
+WHY TWO PREFIXES ARE LIVE AT ONCE, AND WHY THAT IS THE SAFE SHAPE
+=================================================================
+:data:`JOB_PREFIX` is now the canonical ``scitex-agent-container-``, but
+:data:`LEGACY_JOB_PREFIX` (``sac.``) is still RECOGNISED, because one job
+deliberately keeps its old name until an operator-supervised cutover:
+``sac.accounts-refresh``, the fleet's sole OAuth refresher.
+
+The alternative — rename the SPEC now and cut the UNIT over later — is
+the one shape that must not ship. The live, enabled, actively-refreshing
+unit is ``sac.accounts-refresh.timer``; if the spec said
+``scitex-agent-container-accounts-refresh`` while that unit ran, then
+``sac dev timer status accounts-refresh`` would resolve to a name no unit
+carries and report the refresher as absent — WHILE IT IS RUNNING. A CLI
+that reports the fleet's most critical job as missing when it is healthy
+is worse than a name that does not match a convention yet.
+
+So the declared name tracks the DEPLOYED unit, always. Both prefixes are
+readable until :mod:`._migrate` records that cutover as done, and
+``JOB_PREFIX`` alone is what new names are minted with.
 """
 
 from __future__ import annotations
@@ -38,11 +58,23 @@ from typing import Iterable
 
 #: Canonical-name prefix for every job sac owns.
 #:
-#: Kept as a constant so the ecosystem rename to
-#: ``scitex-agent-container-`` is a one-line change guarded by the
-#: migration verb (see the module docstring), rather than a literal
-#: scattered across the CLI, the provider and the audit.
-JOB_PREFIX = "sac."
+#: The ecosystem-wide form decided 2026-08-11: ``scitex-<pkg>-<name>``,
+#: hyphens only — no ``.`` and no ``_``, because the systemd renderer
+#: derives the unit filename from this verbatim and a dot in a unit name
+#: reads as a systemd template/instance separator to every human who has
+#: ever typed ``systemctl``.
+JOB_PREFIX = "scitex-agent-container-"
+
+#: The pre-2026-08-11 prefix. Still RECOGNISED (never minted) so the one
+#: job awaiting a supervised cutover keeps a name that matches its live
+#: unit — see the module docstring for why that direction is the safe one.
+LEGACY_JOB_PREFIX = "sac."
+
+#: Every prefix a name of ours may carry, longest first so ``local()``
+#: strips the most specific match rather than a prefix of a prefix.
+_PREFIXES: tuple[str, ...] = tuple(
+    sorted((JOB_PREFIX, LEGACY_JOB_PREFIX), key=len, reverse=True)
+)
 
 
 def canonical(name: str) -> str:
@@ -50,21 +82,41 @@ def canonical(name: str) -> str:
 
     Idempotent: an already-canonical name is returned unchanged, so a
     value copied out of ``--json`` output or off a unit filename resolves
-    to itself instead of being prefixed twice.
+    to itself instead of being prefixed twice. A LEGACY-prefixed name is
+    likewise returned unchanged rather than re-prefixed — it names a real
+    deployed unit, and rewriting it here would point every verb at a unit
+    that does not exist.
     """
     if not name:
         raise ValueError("job name must be non-empty")
-    return name if name.startswith(JOB_PREFIX) else JOB_PREFIX + name
+    return name if is_ours(name) else JOB_PREFIX + name
 
 
 def local(name: str) -> str:
     """Return the short name an operator types, for a canonical name."""
-    return name[len(JOB_PREFIX) :] if name.startswith(JOB_PREFIX) else name
+    for prefix in _PREFIXES:
+        if name.startswith(prefix):
+            return name[len(prefix) :]
+    return name
 
 
 def is_ours(name: str) -> bool:
-    """True when ``name`` is a job THIS package owns."""
-    return name.startswith(JOB_PREFIX)
+    """True when ``name`` is a job THIS package owns, under either prefix."""
+    return any(name.startswith(p) for p in _PREFIXES)
+
+
+def candidates(typed: str) -> tuple[str, ...]:
+    """Every canonical form ``typed`` could mean, preferred first.
+
+    A local name is ambiguous while two prefixes are live, so resolution
+    tries the canonical form first and the legacy form second. An input
+    that already carries a prefix is unambiguous and yields exactly one.
+    """
+    if not typed:
+        raise ValueError("job name must be non-empty")
+    if is_ours(typed):
+        return (typed,)
+    return tuple(dict.fromkeys((JOB_PREFIX + typed, LEGACY_JOB_PREFIX + typed)))
 
 
 def resolve(typed: str, declared: Iterable[str]) -> str:
@@ -76,13 +128,21 @@ def resolve(typed: str, declared: Iterable[str]) -> str:
     being scheduled.
     """
     names = list(declared)
-    want = canonical(typed)
-    if want in names:
-        return want
+    for want in candidates(typed):
+        if want in names:
+            return want
     raise KeyError(
         f"no job named {typed!r} here; available: "
         + (", ".join(sorted(local(n) for n in names)) or "(none)")
     )
 
 
-__all__ = ["JOB_PREFIX", "canonical", "is_ours", "local", "resolve"]
+__all__ = [
+    "JOB_PREFIX",
+    "LEGACY_JOB_PREFIX",
+    "candidates",
+    "canonical",
+    "is_ours",
+    "local",
+    "resolve",
+]

--- a/src/scitex_agent_container/cli_pkg/_dev_jobs_migrate.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs_migrate.py
@@ -1,0 +1,302 @@
+"""``sac dev migrate-job-names`` — execute the canonical-name cutover.
+
+A TRANSITION TOOL, NOT PART OF THE GRAMMAR
+==========================================
+The steady-state surface is ``sac dev {service,timer,cron} <verb>``, whose
+verbs match scitex-dev's counterpart exactly so nothing sac exposes is a
+permanent exit-4. This command is deliberately NOT one of those verbs: it
+is a one-time migration, it has no counterpart in the shared layer, and it
+will be removed once every host is cut over. Putting it inside a kind
+group would make it look like a verb the ecosystem serves, which is the
+same "declaration with no live counterpart" disease ``_jobs_audit`` exists
+to detect. It sits at ``sac dev`` as its own dated, one-shot verb.
+
+WHAT IT REFUSES, AND WHY EACH REFUSAL EARNS ITS PLACE
+====================================================
+* **No ``systemctl``** — exit 3. nas-01 (armv7l), nas-02 and mba (launchd)
+  cannot supervise ``--user`` units at all. Running the plan there would
+  fail every step and then report "NO supervisor", which reads as a broken
+  migration rather than an inapplicable host.
+* **No ``--yes``** — exit 2, after printing the whole plan. The default is
+  a dry run because the thing being migrated is the supervision of the
+  fleet's credential machinery.
+* **Held jobs** — skipped unless ``--include-held``, which additionally
+  requires naming them with ``--only``. ``sac.accounts-refresh`` is the
+  fleet's SOLE OAuth refresher against a single-use refresh token; a
+  bulk ``--include-held --yes`` that swept it up by accident is precisely
+  the accident worth two flags.
+
+Exit codes: ``0`` clean, ``2`` refusing to mutate without ``--yes``,
+``3`` this host cannot supervise units, ``6`` a step failed, ``7`` the
+verification found something other than exactly one supervisor.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import click
+
+from .._jobs import _migrate
+
+#: Where systemd looks for ``--user`` units. Overridable for tests.
+UNIT_DIR = Path.home() / ".config" / "systemd" / "user"
+
+EXIT_NO_YES = 2
+EXIT_UNSUPPORTED_HOST = 3
+EXIT_STEP_FAILED = 6
+EXIT_VERIFY_FAILED = 7
+
+
+def _measure(unit_dir: Path) -> tuple[frozenset[str], frozenset[str]]:
+    """Read the host: which unit files exist, and which have drop-in dirs.
+
+    Measured, never assumed — the plan is a function of this.
+    """
+    if not unit_dir.is_dir():
+        return frozenset(), frozenset()
+    files: set[str] = set()
+    dirs: set[str] = set()
+    for child in unit_dir.iterdir():
+        if child.is_dir() and child.name.endswith(".d"):
+            dirs.add(child.name)
+        elif child.is_file() or child.is_symlink():
+            files.add(child.name)
+    return frozenset(files), frozenset(dirs)
+
+
+def _displace_dir(unit_dir: Path, stamp: str) -> Path:
+    """``.old/<timestamp>/`` beside the units. NOTHING is ever deleted."""
+    return unit_dir / ".old" / stamp
+
+
+def _run_step(step: _migrate.Step, *, unit_dir: Path, stamp: str) -> tuple[bool, str]:
+    """Perform one step. Returns ``(ok, detail)``; never raises for a
+    step's own failure, so the report can show every outcome rather than
+    stopping at the first."""
+    if step.action == "verify":
+        return True, "deferred to the verification pass"
+
+    if step.argv is not None:
+        exe = step.argv[0]
+        if shutil.which(exe) is None:
+            return False, f"{exe!r} not found on PATH"
+        proc = subprocess.run(  # noqa: S603
+            list(step.argv), capture_output=True, text=True
+        )
+        detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+        tail = detail[-1] if detail else f"exit {proc.returncode}"
+        # `systemctl stop/disable` on a unit systemd never loaded is a
+        # no-op we asked for, not a failure: the file is on disk and the
+        # daemon has not read it. Treating that as fatal would abort a
+        # migration over the very state it is there to clean up.
+        if proc.returncode != 0 and step.action in ("stop", "disable"):
+            return True, f"already inert ({tail})"
+        return proc.returncode == 0, tail
+
+    if step.action == "carry-dropins":
+        src = unit_dir / str(step.path)
+        dest = unit_dir / str(step.dest)
+        if not src.is_dir():
+            return True, "no drop-ins to carry"
+        dest.mkdir(parents=True, exist_ok=True)
+        carried = []
+        for conf in sorted(src.iterdir()):
+            if conf.is_file():
+                target = dest / conf.name
+                if target.exists():
+                    # ADOPT, never overwrite. A drop-in already at the new
+                    # name is the operator's, and it wins.
+                    continue
+                shutil.copy2(conf, target)
+                carried.append(conf.name)
+        return True, f"carried {carried or 'nothing (all already present)'}"
+
+    if step.action == "displace":
+        src = unit_dir / str(step.path)
+        if not src.exists():
+            return True, "already gone"
+        dest_dir = _displace_dir(unit_dir, stamp)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(dest_dir / src.name))
+        return True, f"-> {dest_dir / src.name}"
+
+    if step.action == "logging":
+        rel = Path(str(step.path))
+        target = unit_dir / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        unit = rel.parent.name[: -len(".d")]
+        job = unit[: -len(".service")]
+        target.write_text(
+            _migrate.logging_dropin_text(job, "timer"), encoding="utf-8"
+        )
+        return True, f"wrote {target}"
+
+    return False, f"no executor for action {step.action!r}"
+
+
+def _install_argv_factory():
+    """Resolve the install delegation through the capability probe.
+
+    So a host with a newer scitex-dev uses the per-kind ``dev timer``
+    group and an older one uses ``dev systemd``, with no sac release
+    either way. Falls through to the module default when the probe cannot
+    decide, which is the same third-state discipline ``resolve`` uses.
+    """
+    from . import _dev_jobs_backend as backend
+
+    def _argv(rename: _migrate.Rename) -> tuple[str, ...]:
+        delegation = backend.resolve(rename.kind, "install")
+        if not delegation.supported:
+            return _migrate.default_install_argv(rename)
+        return tuple(
+            backend.build_argv(delegation, name=rename.new, yes=True, dry_run=False)
+        )
+
+    return _argv
+
+
+def _select(only: tuple[str, ...], include_held: bool) -> list[_migrate.Rename]:
+    """Which table rows this invocation acts on."""
+    if only:
+        chosen = [_migrate.by_local(name) for name in only]
+    else:
+        chosen = list(_migrate.RENAMES)
+    out = []
+    for rename in chosen:
+        if rename.held and not (include_held and only):
+            continue
+        out.append(rename)
+    return out
+
+
+def register_migrate_command(dev_group: click.Group) -> None:
+    """Attach ``sac dev migrate-job-names`` onto ``sac dev``."""
+
+    @dev_group.command(name="migrate-job-names")
+    @click.option(
+        "--only",
+        multiple=True,
+        help="Migrate only these jobs (short local names). Repeatable.",
+    )
+    @click.option(
+        "--include-held",
+        is_flag=True,
+        default=False,
+        help=(
+            "Also migrate jobs held for a supervised cutover. Requires "
+            "--only, so a held job can never be swept up by a bulk run."
+        ),
+    )
+    @click.option(
+        "-y",
+        "--yes",
+        is_flag=True,
+        default=False,
+        help="Actually perform the migration. Without it this is a dry run.",
+    )
+    @click.option(
+        "--unit-dir",
+        type=click.Path(path_type=Path),
+        default=None,
+        help="systemd --user unit directory. Defaults to the real one.",
+    )
+    def _migrate_job_names(only, include_held, yes, unit_dir):
+        """Cut sac's jobs over to their canonical `scitex-<pkg>-<name>` names.
+
+        \b
+        Order is stop -> disable -> carry drop-ins -> displace -> reload ->
+        install -> logging -> verify, and install can never precede
+        displace: a rename derives a DIFFERENT unit filename, so the two
+        would otherwise both supervise the same command.
+
+        \b
+        Nothing is deleted. Displaced units go to `.old/<timestamp>/`
+        beside them, and a unit's drop-ins are carried across the rename
+        rather than orphaned under the old name.
+        """
+        directory = unit_dir if unit_dir is not None else UNIT_DIR
+
+        if not _migrate.systemd_user_available():
+            click.echo(
+                "this host has no `systemctl`, so it cannot supervise --user "
+                "units at all (measured 2026-08-11: nas-01 is armv7l, nas-02 "
+                "has none, mba uses launchd). Nothing to migrate here.",
+                err=True,
+            )
+            raise SystemExit(EXIT_UNSUPPORTED_HOST)
+
+        if include_held and not only:
+            click.echo(
+                "--include-held requires --only: a held job states a reason it "
+                "must be cut over under supervision, and a bulk run that swept "
+                "one up by accident is exactly what the hold prevents.",
+                err=True,
+            )
+            raise SystemExit(EXIT_NO_YES)
+
+        renames = _select(tuple(only), include_held)
+        present, dropins = _measure(directory)
+        steps = _migrate.plan(
+            renames,
+            present=present,
+            dropin_dirs=dropins,
+            install_argv=_install_argv_factory(),
+        )
+
+        chosen = _migrate.selection(env=dict(__import__("os").environ), home=Path.home())
+        click.echo(_migrate.explain(chosen))
+        click.echo(f"unit dir: {directory}")
+
+        held = [r for r in _migrate.RENAMES if r.held and r not in renames]
+        for rename in held:
+            click.echo(f"HELD {rename.local}: {rename.hold}")
+
+        if not steps:
+            click.echo("Nothing to migrate.")
+            return
+
+        click.echo(f"\nPlan ({len(steps)} steps):")
+        for step in steps:
+            click.echo("  " + step.render())
+
+        if not yes:
+            click.echo(
+                "\nDry run — nothing changed. Re-run with --yes to apply.", err=True
+            )
+            raise SystemExit(EXIT_NO_YES)
+
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        click.echo("\nApplying:")
+        failed = 0
+        for step in steps:
+            ok, detail = _run_step(step, unit_dir=directory, stamp=stamp)
+            click.echo(f"  {'ok  ' if ok else 'FAIL'} {step.render()}  # {detail}")
+            if not ok:
+                failed += 1
+
+        subprocess.run(  # noqa: S603
+            ["systemctl", "--user", "daemon-reload"], capture_output=True, text=True
+        )
+
+        after, _ = _measure(directory)
+        click.echo("\nVerification (exactly one supervisor per job):")
+        bad = 0
+        for rename in renames:
+            if rename.held:
+                continue
+            result = _migrate.verify_exactly_one(rename, present=after)
+            click.echo("  " + result.verdict)
+            if not result.ok:
+                bad += 1
+
+        if failed:
+            raise SystemExit(EXIT_STEP_FAILED)
+        if bad:
+            raise SystemExit(EXIT_VERIFY_FAILED)
+
+
+__all__ = ["UNIT_DIR", "register_migrate_command"]

--- a/src/scitex_agent_container/cli_pkg/dev_group.py
+++ b/src/scitex_agent_container/cli_pkg/dev_group.py
@@ -177,6 +177,14 @@ from ._dev_jobs import register_dev_jobs_commands
 
 register_dev_jobs_commands(dev_group)
 
+# The one-time canonical-name cutover. Deliberately NOT a verb inside a
+# kind group: it has no counterpart in scitex-dev's grammar and retires
+# once every host is migrated, so exposing it as a kind verb would
+# advertise a verb the ecosystem does not serve.
+from ._dev_jobs_migrate import register_migrate_command
+
+register_migrate_command(dev_group)
+
 
 @dev_group.command(name="extract-apikey-from-credentials")
 @click.option(

--- a/tests/scitex_agent_container/_jobs/_migrate/test__logsink.py
+++ b/tests/scitex_agent_container/_jobs/_migrate/test__logsink.py
@@ -1,0 +1,161 @@
+"""Tests for predictable job logging.
+
+The gap being closed: sac's jobs are not dispatched through
+``ecosystem cron exec``, so scitex-dev's log sink never installs for them
+and their output goes to the journal under a unit name that CHANGES WITH
+EVERY RENAME. "Where did last night's worktree-gc go" had no answer that
+survived a migration.
+
+The load-bearing test here is
+``test_the_dropin_path_matches_scitex_devs_own``, which calls the REAL
+scitex-dev resolver. Inventing a second log-tree convention would make
+sac's logs predictable and the ecosystem's inconsistent — a second place
+to look is not an improvement. That test makes an upstream convention
+change fail sac's build instead of silently splitting the tree in two.
+
+No mocks (PA-306): pure string arithmetic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._jobs._migrate import _logsink
+
+
+def test_the_slug_strips_the_canonical_package_prefix() -> None:
+    # Arrange
+    name = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _logsink.log_slug(name, "timer")
+    # Assert
+    assert got == "timer-worktree-gc"
+
+
+def test_the_slug_strips_the_legacy_prefix_too() -> None:
+    # Arrange — the held refresher still carries `sac.`, and its log must
+    # land beside the others rather than under a mangled name.
+    name = "sac.accounts-refresh"
+    # Act
+    got = _logsink.log_slug(name, "timer")
+    # Assert
+    assert got == "timer-accounts-refresh"
+
+
+def test_the_slug_carries_the_kind() -> None:
+    # Arrange — following scitex-dev's own slugs (timer-…, cron-…), so a
+    # directory listing says what kind of thing wrote each file.
+    name = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _logsink.log_slug(name, "cron")
+    # Assert
+    assert got.startswith("cron-")
+
+
+def test_an_empty_kind_is_rejected() -> None:
+    # Arrange
+    # Act
+    def _call():
+        return _logsink.log_slug("scitex-agent-container-x", "")
+
+    # Assert
+    with pytest.raises(ValueError):
+        _call()
+
+
+def test_a_name_with_no_local_part_is_rejected() -> None:
+    # Arrange — a bare prefix would produce `timer-.log`, which names
+    # nothing and silently collides with every other such job.
+    # Act
+    def _call():
+        return _logsink.log_slug("scitex-agent-container-", "timer")
+
+    # Assert
+    with pytest.raises(ValueError):
+        _call()
+
+
+def test_the_log_dir_uses_the_systemd_home_specifier() -> None:
+    # Arrange — a drop-in must be correct for whichever user systemd
+    # expands it as, so a resolved home would be wrong on every other host.
+    # Act
+    got = _logsink.LOG_DIR
+    # Assert
+    assert got.startswith("%h/")
+
+
+def test_the_log_path_composes_the_dir_and_the_slug() -> None:
+    # Arrange
+    name = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _logsink.log_path(name, "timer")
+    # Assert
+    assert got == _logsink.LOG_DIR + "/timer-worktree-gc.log"
+
+
+def test_the_dropin_path_matches_scitex_devs_own() -> None:
+    # Arrange — THE test that keeps one convention instead of two. Calls
+    # the REAL upstream resolver; if scitex-dev moves its log tree, this
+    # fails here rather than splitting the tree silently.
+    from scitex_dev.jobs._logsink import log_path as upstream_log_path
+
+    expected = upstream_log_path(
+        _logsink.LOG_PACKAGE, "timer-worktree-gc", home=Path("/h")
+    )
+    # Act
+    got = _logsink.log_path("scitex-agent-container-worktree-gc", "timer").replace(
+        "%h", "/h"
+    )
+    # Assert
+    assert got == str(expected)
+
+
+def test_the_dropin_declares_a_service_section() -> None:
+    # Arrange
+    name = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _logsink.logging_dropin_text(name, "timer")
+    # Assert
+    assert "[Service]" in got
+
+
+def test_the_dropin_appends_rather_than_truncating() -> None:
+    # Arrange — `file:` would truncate on every restart, discarding the
+    # history the operator came to read.
+    name = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _logsink.logging_dropin_text(name, "timer")
+    # Assert
+    assert "StandardOutput=append:" in got
+
+
+def test_the_dropin_never_uses_the_truncating_file_directive() -> None:
+    # Arrange
+    name = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _logsink.logging_dropin_text(name, "timer")
+    # Assert
+    assert "=file:" not in got
+
+
+def test_stdout_and_stderr_land_in_the_same_file() -> None:
+    # Arrange — a job's error output is worthless separated from the
+    # output that led to it.
+    name = "scitex-agent-container-worktree-gc"
+    path = _logsink.log_path(name, "timer")
+    # Act
+    got = _logsink.logging_dropin_text(name, "timer")
+    # Assert
+    assert got.count(path) == 2
+
+
+def test_the_dropin_says_what_manages_it() -> None:
+    # Arrange — an unexplained file under <unit>.d/ is one an operator
+    # deletes.
+    name = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _logsink.logging_dropin_text(name, "timer")
+    # Assert
+    assert "migrate-job-names" in got

--- a/tests/scitex_agent_container/_jobs/_migrate/test__plan.py
+++ b/tests/scitex_agent_container/_jobs/_migrate/test__plan.py
@@ -1,0 +1,318 @@
+"""Tests for the migration plan — above all, its ORDER.
+
+Install-before-uninstall is the failure this module exists to make
+impossible: a rename derives a DIFFERENT unit filename, so installing the
+new unit before removing the old one leaves BOTH on the host, both
+enabled, both firing the same command with no shared lock. On the head
+node a crontab line and a systemd unit were already both supervising
+``sac listen`` against different venvs, dormant only because a ``pgrep``
+guard happened to match. A rename is exactly what wakes that up.
+
+So the ordering assertions here are not style checks. They are the
+countermeasure.
+
+No mocks (PA-306): the planner is pure, and the host state it plans
+against is passed in as plain sets of filenames.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._jobs._migrate import _plan, _renames
+
+WORKTREE_GC = _renames.by_local("worktree-gc")
+
+#: The host state as measured on compute-04 for one job: both units of a
+#: timer present on disk.
+BOTH_UNITS = frozenset(WORKTREE_GC.old_units())
+
+
+def _actions(steps) -> list[str]:
+    return [s.action for s in steps]
+
+
+def test_a_plan_for_a_job_already_on_the_host_stops_it_first() -> None:
+    # Arrange
+    steps = _plan.plan_one(WORKTREE_GC, present=BOTH_UNITS)
+    # Act
+    first = _actions(steps)[0]
+    # Assert
+    assert first == "stop"
+
+
+def test_stop_precedes_disable_for_every_unit() -> None:
+    # Arrange — disable only drops the .wants symlink, so a disable-first
+    # order leaves a RUNNING unit nothing will restart and nothing stopped.
+    steps = _plan.plan_one(WORKTREE_GC, present=BOTH_UNITS)
+    actions = _actions(steps)
+    # Act
+    ok = actions.index("stop") < actions.index("disable")
+    # Assert
+    assert ok is True
+
+
+def test_displace_precedes_install() -> None:
+    # Arrange — THE invariant. Two units both supervising one command is
+    # the whole hazard.
+    steps = _plan.plan_one(WORKTREE_GC, present=BOTH_UNITS)
+    actions = _actions(steps)
+    # Act
+    ok = actions.index("displace") < actions.index("install")
+    # Assert
+    assert ok is True
+
+
+def test_every_step_rank_is_non_decreasing_for_every_tabled_job() -> None:
+    # Arrange — the ordering is a property of the DATA: each action indexes
+    # into ACTION_ORDER, so an edit that reorders the emission fails here
+    # rather than quietly arming a race on nine hosts.
+    present = frozenset(
+        u for r in _renames.RENAMES for u in r.old_units()
+    )
+    offenders = []
+    # Act
+    for rename in _renames.RENAMES:
+        ranks = [s.rank for s in _plan.plan_one(rename, present=present)]
+        if ranks != sorted(ranks):
+            offenders.append(rename.local)
+    # Assert
+    assert offenders == []
+
+
+def test_carry_dropins_precedes_displace() -> None:
+    # Arrange — displacing first orphans the drop-in under the old name,
+    # where the new unit never reads it: the config silently stops applying
+    # while everything still looks installed.
+    dropins = frozenset({WORKTREE_GC.old_units()[0] + ".d"})
+    steps = _plan.plan_one(WORKTREE_GC, present=BOTH_UNITS, dropin_dirs=dropins)
+    actions = _actions(steps)
+    # Act
+    ok = actions.index("carry-dropins") < actions.index("displace")
+    # Assert
+    assert ok is True
+
+
+def test_a_carry_step_names_the_new_dropin_directory_as_its_destination() -> None:
+    # Arrange
+    old_service = WORKTREE_GC.old_units()[0]
+    dropins = frozenset({old_service + ".d"})
+    steps = _plan.plan_one(WORKTREE_GC, present=BOTH_UNITS, dropin_dirs=dropins)
+    # Act
+    carried = [s for s in steps if s.action == "carry-dropins"]
+    # Assert
+    assert carried[0].dest == WORKTREE_GC.new_units()[0] + ".d"
+
+
+def test_no_carry_step_is_planned_when_there_are_no_dropins() -> None:
+    # Arrange
+    steps = _plan.plan_one(WORKTREE_GC, present=BOTH_UNITS, dropin_dirs=frozenset())
+    # Act
+    carried = [s for s in steps if s.action == "carry-dropins"]
+    # Assert
+    assert carried == []
+
+
+def test_a_held_job_plans_nothing() -> None:
+    # Arrange — the refresher's cutover is operator-supervised; a bulk run
+    # must not touch it at all.
+    held = [r for r in _renames.RENAMES if r.held][0]
+    # Act
+    steps = _plan.plan_one(held, present=frozenset(held.old_units()))
+    # Assert
+    assert steps == ()
+
+
+def test_a_job_absent_from_the_host_still_plans_an_install() -> None:
+    # Arrange — the rename may have half-completed here.
+    steps = _plan.plan_one(WORKTREE_GC, present=frozenset())
+    # Act
+    actions = _actions(steps)
+    # Assert
+    assert "install" in actions
+
+
+def test_a_job_absent_from_the_host_plans_no_stop() -> None:
+    # Arrange
+    steps = _plan.plan_one(WORKTREE_GC, present=frozenset())
+    # Act
+    actions = _actions(steps)
+    # Assert
+    assert "stop" not in actions
+
+
+def test_a_job_absent_from_the_host_still_plans_a_verify() -> None:
+    # Arrange — saying "no supervisor" out loud is what verify is for.
+    steps = _plan.plan_one(WORKTREE_GC, present=frozenset())
+    # Act
+    actions = _actions(steps)
+    # Assert
+    assert actions[-1] == "verify"
+
+
+def test_the_install_step_names_the_new_canonical_name() -> None:
+    # Arrange
+    steps = _plan.plan_one(WORKTREE_GC, present=BOTH_UNITS)
+    # Act
+    install = [s for s in steps if s.action == "install"][0]
+    # Assert
+    assert WORKTREE_GC.new in install.argv
+
+
+def test_the_default_install_delegates_rather_than_writing_the_unit() -> None:
+    # Arrange — ownership returns to scitex-dev the moment the new name
+    # exists; sac only retires the orphans it made.
+    argv = _plan.default_install_argv(WORKTREE_GC)
+    # Act
+    exe = argv[0]
+    # Assert
+    assert exe == "scitex-dev"
+
+
+def test_the_default_install_targets_a_group_the_installed_scitex_dev_has() -> None:
+    # Arrange — the per-KIND groups arrive in scitex-dev #566; 0.47.0 is
+    # installed here and serves only {cron, systemd} under `dev`.
+    argv = _plan.default_install_argv(WORKTREE_GC)
+    # Act
+    path = argv[1:4]
+    # Assert
+    assert path == ("ecosystem", "dev", "systemd")
+
+
+def test_a_logging_step_is_planned_for_the_service_unit() -> None:
+    # Arrange
+    steps = _plan.plan_one(WORKTREE_GC, present=BOTH_UNITS)
+    # Act
+    logging_steps = [s for s in steps if s.action == "logging"]
+    # Assert
+    assert len(logging_steps) == 1
+
+
+def test_the_logging_step_targets_a_dropin_not_the_unit_file() -> None:
+    # Arrange — scitex-dev rewrites the unit on every install; anything
+    # written into it is erased without a word.
+    steps = _plan.plan_one(WORKTREE_GC, present=BOTH_UNITS)
+    # Act
+    logging_step = [s for s in steps if s.action == "logging"][0]
+    # Assert
+    assert logging_step.target.endswith(".service.d/10-logging.conf")
+
+
+def test_install_is_the_last_mutating_step_before_logging_and_verify() -> None:
+    # Arrange
+    steps = _plan.plan_one(WORKTREE_GC, present=BOTH_UNITS)
+    # Act
+    tail = _actions(steps)[-3:]
+    # Assert
+    assert tail == ["install", "logging", "verify"]
+
+
+def test_a_daemon_reload_separates_displacement_from_installation() -> None:
+    # Arrange — so `verify` counts unit files that really exist.
+    steps = _plan.plan_one(WORKTREE_GC, present=BOTH_UNITS)
+    actions = _actions(steps)
+    # Act
+    ok = actions.index("displace") < actions.index("daemon-reload") < actions.index(
+        "install"
+    )
+    # Assert
+    assert ok is True
+
+
+def test_the_full_plan_covers_every_unheld_job() -> None:
+    # Arrange
+    unheld = [r for r in _renames.RENAMES if not r.held]
+    steps = _plan.plan(present=frozenset())
+    # Act
+    installed = {s.target for s in steps if s.action == "install"}
+    # Assert
+    assert installed == {r.new for r in unheld}
+
+
+def test_the_full_plan_never_names_a_held_job() -> None:
+    # Arrange
+    held = [r for r in _renames.RENAMES if r.held]
+    steps = _plan.plan(present=frozenset())
+    # Act
+    leaked = [s.target for s in steps if s.target in {r.new for r in held}]
+    # Assert
+    assert leaked == []
+
+
+def test_a_step_must_state_its_evidence() -> None:
+    # Arrange — a step that cannot say what was observed is a step nobody
+    # can review, and this plan mutates credential machinery.
+    # Act
+    def _call():
+        return _plan.Step(action="stop", target="x.timer", why="")
+
+    # Assert
+    with pytest.raises(ValueError):
+        _call()
+
+
+def test_a_step_with_an_unknown_action_is_rejected() -> None:
+    # Arrange
+    # Act
+    def _call():
+        return _plan.Step(action="frobnicate", target="x", why="because")
+
+    # Assert
+    with pytest.raises(ValueError):
+        _call()
+
+
+def test_a_plan_touching_the_listen_unit_is_refused() -> None:
+    # Arrange — sac-listen.service supervises the fleet's control plane.
+    forbidden = [
+        _plan.Step(action="stop", target="sac-listen.service", why="should never happen")
+    ]
+
+    # Act
+    def _call():
+        return _plan.assert_never_touches_listen(forbidden)
+
+    # Assert
+    with pytest.raises(ValueError, match="NEVER touch"):
+        _call()
+
+
+def test_a_plan_touching_a_listen_dropin_is_refused() -> None:
+    # Arrange — the 50-secrets-envrc.conf drop-in on compute-04.
+    forbidden = [
+        _plan.Step(
+            action="carry-dropins",
+            target="sac-listen.service.d/50-secrets-envrc.conf",
+            why="should never happen",
+        )
+    ]
+
+    # Act
+    def _call():
+        return _plan.assert_never_touches_listen(forbidden)
+
+    # Assert
+    with pytest.raises(ValueError, match="NEVER touch"):
+        _call()
+
+
+def test_the_real_plan_passes_the_listen_guard() -> None:
+    # Arrange — plan() runs the guard on everything it returns, so this
+    # would raise rather than return if a row ever named a listen unit.
+    present = frozenset(u for r in _renames.RENAMES for u in r.old_units())
+    # Act
+    steps = _plan.plan(present=present)
+    # Assert
+    assert len(steps) > 0
+
+
+def test_a_step_renders_its_argv_for_the_dry_run() -> None:
+    # Arrange — the dry run is the review surface; a step that cannot print
+    # what it would do is not reviewable.
+    step = _plan.Step(
+        action="stop", target="x.timer", why="because", argv=("systemctl", "stop", "x")
+    )
+    # Act
+    rendered = step.render()
+    # Assert
+    assert "systemctl stop x" in rendered

--- a/tests/scitex_agent_container/_jobs/_migrate/test__renames.py
+++ b/tests/scitex_agent_container/_jobs/_migrate/test__renames.py
@@ -1,0 +1,315 @@
+"""Tests for the migration table, checked against the REAL declared specs.
+
+The warning that shaped this file: ``sac dev systemd list`` filtered on
+``kind="systemd"`` — not a legal kind — matched nothing and printed "No sac
+systemd-kind jobs." with exit 0 for WEEKS, hiding all four of sac's timers
+including the OAuth refresher. The tests passed the whole time because the
+fixture hand-rolled a fake whose ``_Job`` defaulted to ``kind="systemd"``,
+a shape no real spec can have. A test double that accepts what the real
+validator rejects is not a test.
+
+So nothing here builds a fake spec. The coverage tests call the REAL
+``provide_jobs()``, which constructs REAL ``JobSpec`` objects through the
+REAL validator.
+
+No mocks (PA-306). AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from scitex_agent_container._jobs import _names
+from scitex_agent_container._jobs._jobs_plugin import provide_jobs
+from scitex_agent_container._jobs._migrate import _renames
+
+#: scitex-dev's PS-226 charset rule, restated because the auditor lives
+#: behind a private module path. A name failing this derives a unit
+#: filename with a dot in it.
+PS226 = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+
+def _declared_names() -> frozenset[str]:
+    return frozenset(j.name for j in provide_jobs())
+
+
+def test_no_tabled_row_names_an_undeclared_job() -> None:
+    # Arrange — a row's DECLARED name is `old` while it is held and `new`
+    # once it has been cut over. A row naming neither is a row that
+    # migrates something no provider offers.
+    declared = _declared_names()
+    # Act
+    orphans = [
+        r.local
+        for r in _renames.RENAMES
+        if (r.old if r.held else r.new) not in declared
+    ]
+    # Assert
+    assert orphans == []
+
+
+def test_every_declared_job_has_a_row() -> None:
+    # Arrange — a job added without a row would never migrate.
+    tabled = frozenset(r.new for r in _renames.RENAMES) | frozenset(
+        r.old for r in _renames.RENAMES
+    )
+    # Act
+    uncovered = _declared_names() - tabled
+    # Assert
+    assert uncovered == frozenset()
+
+
+def test_a_held_job_still_declares_its_legacy_name() -> None:
+    # Arrange — the invariant stopping the CLI from reporting a running
+    # refresher as absent: a held spec must keep the name its unit has.
+    held = [r for r in _renames.RENAMES if r.held]
+    declared = _declared_names()
+    # Act
+    mismatched = [r.local for r in held if r.old not in declared]
+    # Assert
+    assert mismatched == []
+
+
+def test_a_held_job_does_not_yet_declare_its_new_name() -> None:
+    # Arrange
+    held = [r for r in _renames.RENAMES if r.held]
+    declared = _declared_names()
+    # Act
+    premature = [r.local for r in held if r.new in declared]
+    # Assert
+    assert premature == []
+
+
+def test_every_tabled_kind_is_one_the_real_validator_accepts() -> None:
+    # Arrange
+    from scitex_dev.jobs import ALLOWED_KINDS
+
+    # Act
+    illegal = [r.new for r in _renames.RENAMES if r.kind not in ALLOWED_KINDS]
+    # Assert
+    assert illegal == []
+
+
+def test_the_tabled_kind_matches_what_the_spec_declares() -> None:
+    # Arrange
+    by_name = {j.name: j for j in provide_jobs()}
+    # Act
+    wrong = [
+        r.local
+        for r in _renames.RENAMES
+        if by_name[r.old if r.held else r.new].kind != r.kind
+    ]
+    # Assert
+    assert wrong == []
+
+
+@pytest.mark.parametrize("rename", _renames.RENAMES, ids=lambda r: r.new)
+def test_every_new_name_is_hyphen_separated_lowercase(rename) -> None:
+    # Arrange — PS-226 (error severity).
+    name = rename.new
+    # Act
+    matched = PS226.match(name)
+    # Assert
+    assert matched is not None
+
+
+@pytest.mark.parametrize("rename", _renames.RENAMES, ids=lambda r: r.new)
+def test_every_new_name_is_package_qualified(rename) -> None:
+    # Arrange — PS-227 expects `scitex-<pkg>-<name>`.
+    name = rename.new
+    # Act
+    qualified = name.startswith("scitex-agent-container-")
+    # Assert
+    assert qualified is True
+
+
+def test_the_old_names_are_exactly_what_ps226_rejects() -> None:
+    # Arrange — a POSITIVE CONTROL. If the old names already passed the
+    # rule, this whole migration would be a no-op wearing a migration's
+    # clothes, and every other test here would pass anyway.
+    olds = [r.old for r in _renames.RENAMES]
+    # Act
+    already_clean = [name for name in olds if PS226.match(name)]
+    # Assert
+    assert already_clean == []
+
+
+def test_a_timer_job_materialises_two_units() -> None:
+    # Arrange — displacing only the .timer leaves a runnable .service orphan.
+    name = "x"
+    # Act
+    got = _renames.units_for(name, "timer")
+    # Assert
+    assert got == ("x.service", "x.timer")
+
+
+def test_a_service_job_materialises_one_unit() -> None:
+    # Arrange
+    name = "x"
+    # Act
+    got = _renames.units_for(name, "service")
+    # Assert
+    assert got == ("x.service",)
+
+
+def test_a_cron_job_materialises_no_units() -> None:
+    # Arrange
+    name = "x"
+    # Act
+    got = _renames.units_for(name, "cron")
+    # Assert
+    assert got == ()
+
+
+def test_units_for_rejects_a_kind_the_validator_would_reject() -> None:
+    # Arrange — "systemd" is a delivery mechanism, never a kind.
+    # Act
+    def _call():
+        return _renames.units_for("x", "systemd")
+
+    # Assert
+    with pytest.raises(ValueError):
+        _call()
+
+
+def test_old_and_new_units_never_overlap() -> None:
+    # Arrange — the premise of the whole migration: the rename really does
+    # derive a different filename, so both could coexist.
+    overlaps = [
+        r.local
+        for r in _renames.RENAMES
+        if set(r.old_units()) & set(r.new_units())
+    ]
+    # Act
+    count = len(overlaps)
+    # Assert
+    assert count == 0
+
+
+def test_a_rename_that_renames_nothing_is_rejected() -> None:
+    # Arrange
+    # Act
+    def _call():
+        return _renames.Rename(old="a", new="a", kind="timer")
+
+    # Assert
+    with pytest.raises(ValueError):
+        _call()
+
+
+def test_a_hold_with_no_stated_reason_is_rejected() -> None:
+    # Arrange — a hold with no reason is indistinguishable from an oversight.
+    # Act
+    def _call():
+        return _renames.Rename(old="a", new="b", kind="timer", hold="   ")
+
+    # Assert
+    with pytest.raises(ValueError):
+        _call()
+
+
+def test_a_hold_with_a_reason_marks_the_row_held() -> None:
+    # Arrange
+    rename = _renames.Rename(old="a", new="b", kind="timer", hold="because X")
+    # Act
+    got = rename.held
+    # Assert
+    assert got is True
+
+
+def test_a_row_with_no_hold_is_not_held() -> None:
+    # Arrange
+    rename = _renames.Rename(old="a", new="b", kind="timer")
+    # Act
+    got = rename.held
+    # Assert
+    assert got is False
+
+
+def test_a_rename_rejects_a_kind_outside_the_taxonomy() -> None:
+    # Arrange
+    # Act
+    def _call():
+        return _renames.Rename(old="a", new="b", kind="systemd")
+
+    # Assert
+    with pytest.raises(ValueError):
+        _call()
+
+
+def test_by_local_finds_a_row_by_its_short_name() -> None:
+    # Arrange
+    typed = "worktree-gc"
+    # Act
+    got = _renames.by_local(typed).new
+    # Assert
+    assert got == "scitex-agent-container-worktree-gc"
+
+
+def test_by_local_accepts_the_canonical_spelling() -> None:
+    # Arrange — a name copied out of --json output must work as typed.
+    typed = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _renames.by_local(typed).local
+    # Assert
+    assert got == "worktree-gc"
+
+
+def test_by_local_accepts_the_legacy_spelling() -> None:
+    # Arrange — a name copied off an old unit filename must work too.
+    typed = "sac.worktree-gc"
+    # Act
+    got = _renames.by_local(typed).local
+    # Assert
+    assert got == "worktree-gc"
+
+
+def test_by_local_names_the_real_jobs_when_it_misses() -> None:
+    # Arrange — a verb that silently does nothing for a typo is how a
+    # scheduled job quietly stops being scheduled.
+    # Act
+    def _call():
+        return _renames.by_local("wroktree-gc")
+
+    # Assert
+    with pytest.raises(KeyError, match="worktree-gc"):
+        _call()
+
+
+def test_the_hyphen_listen_unit_is_never_touchable() -> None:
+    # Arrange
+    unit = "sac-listen.service"
+    # Act
+    listed = unit in _renames.NEVER_TOUCH
+    # Assert
+    assert listed is True
+
+
+def test_the_dotted_listen_unit_is_never_touchable() -> None:
+    # Arrange — the name a JobSpec WOULD have derived; the near-miss
+    # between the two is what once put two supervisors on port 7878.
+    unit = "sac.listen.service"
+    # Act
+    listed = unit in _renames.NEVER_TOUCH
+    # Assert
+    assert listed is True
+
+
+def test_no_tabled_row_names_a_never_touch_unit() -> None:
+    # Arrange
+    units = [u for r in _renames.RENAMES for u in r.old_units() + r.new_units()]
+    # Act
+    forbidden = [u for u in units if u in _renames.NEVER_TOUCH]
+    # Assert
+    assert forbidden == []
+
+
+def test_local_names_round_trip_through_the_name_grammar() -> None:
+    # Arrange
+    rows = _renames.RENAMES
+    # Act
+    mismatched = [r.new for r in rows if _names.local(r.new) != r.local]
+    # Assert
+    assert mismatched == []

--- a/tests/scitex_agent_container/_jobs/_migrate/test__selection.py
+++ b/tests/scitex_agent_container/_jobs/_migrate/test__selection.py
@@ -1,0 +1,199 @@
+"""Tests for the run-selection knob.
+
+THE THIRD STATE IS THE POINT. ``selection()`` returns ``None`` for
+UNSTATED, which must never collapse into "nothing selected". A host that
+has never been configured must not have its timers disarmed by the mere
+arrival of this feature; a host that deliberately selected nothing must
+not have them armed. Those two are one line apart in the code and a fleet
+outage apart in effect, so each has its own test.
+
+No mocks (PA-306): ``selection`` takes its env as a plain dict and its
+home as a ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._jobs._migrate import _selection
+
+
+def _write(home, body: str):
+    path = _selection.selection_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_blank_lines_are_ignored() -> None:
+    # Arrange
+    body = "worktree-gc\n\n\nfleet-reconcile\n"
+    # Act
+    got = _selection.parse_selection(body)
+    # Assert
+    assert got == frozenset({"worktree-gc", "fleet-reconcile"})
+
+
+def test_a_full_line_comment_is_ignored() -> None:
+    # Arrange
+    body = "# not a job\nworktree-gc\n"
+    # Act
+    got = _selection.parse_selection(body)
+    # Assert
+    assert got == frozenset({"worktree-gc"})
+
+
+def test_a_trailing_comment_is_stripped() -> None:
+    # Arrange
+    body = "worktree-gc  # daily GC\n"
+    # Act
+    got = _selection.parse_selection(body)
+    # Assert
+    assert got == frozenset({"worktree-gc"})
+
+
+def test_commas_separate_names_exactly_like_newlines() -> None:
+    # Arrange — one grammar for the env form and the file form, so an
+    # operator who learns one has learned the other.
+    body = "worktree-gc,fleet-reconcile"
+    # Act
+    got = _selection.parse_selection(body)
+    # Assert
+    assert got == frozenset({"worktree-gc", "fleet-reconcile"})
+
+
+def test_the_env_override_wins_over_the_file(tmp_path) -> None:
+    # Arrange
+    _write(tmp_path, "fleet-reconcile\n")
+    env = {_selection.SELECTION_ENV: "worktree-gc"}
+    # Act
+    got = _selection.selection(env=env, home=tmp_path)
+    # Assert
+    assert got == frozenset({"worktree-gc"})
+
+
+def test_the_file_is_read_when_the_env_is_absent(tmp_path) -> None:
+    # Arrange
+    _write(tmp_path, "fleet-reconcile\n")
+    # Act
+    got = _selection.selection(env={}, home=tmp_path)
+    # Assert
+    assert got == frozenset({"fleet-reconcile"})
+
+
+def test_a_blank_env_falls_through_to_the_file(tmp_path) -> None:
+    # Arrange — an exported-but-empty variable is not a statement.
+    _write(tmp_path, "fleet-reconcile\n")
+    env = {_selection.SELECTION_ENV: "   "}
+    # Act
+    got = _selection.selection(env=env, home=tmp_path)
+    # Assert
+    assert got == frozenset({"fleet-reconcile"})
+
+
+def test_an_absent_file_is_unstated_not_empty(tmp_path) -> None:
+    # Arrange — THE distinction. Returning an empty set here would disarm
+    # every host that never opted in.
+    # Act
+    got = _selection.selection(env={}, home=tmp_path)
+    # Assert
+    assert got is None
+
+
+def test_an_empty_file_is_a_deliberate_empty_selection(tmp_path) -> None:
+    # Arrange — the operator wrote the file and listed nothing. That is a
+    # statement, and it must not read as "unstated".
+    _write(tmp_path, "# nothing runs here\n")
+    # Act
+    got = _selection.selection(env={}, home=tmp_path)
+    # Assert
+    assert got == frozenset()
+
+
+def test_an_unstated_selection_treats_every_job_as_eligible() -> None:
+    # Arrange
+    name = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _selection.is_selected(name, None)
+    # Assert
+    assert got is True
+
+
+def test_a_deliberately_empty_selection_selects_nothing() -> None:
+    # Arrange
+    name = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _selection.is_selected(name, frozenset())
+    # Assert
+    assert got is False
+
+
+def test_the_star_token_selects_every_job() -> None:
+    # Arrange — "run everything" must be writable down, not only implied.
+    name = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _selection.is_selected(name, frozenset({_selection.SELECT_ALL}))
+    # Assert
+    assert got is True
+
+
+def test_a_local_name_in_the_selection_matches_the_canonical_job() -> None:
+    # Arrange
+    name = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _selection.is_selected(name, frozenset({"worktree-gc"}))
+    # Assert
+    assert got is True
+
+
+def test_a_canonical_name_in_the_selection_matches() -> None:
+    # Arrange — a name pasted out of --json output must work as typed.
+    name = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _selection.is_selected(name, frozenset({name}))
+    # Assert
+    assert got is True
+
+
+def test_a_job_absent_from_a_stated_selection_is_not_selected() -> None:
+    # Arrange
+    name = "scitex-agent-container-worktree-gc"
+    # Act
+    got = _selection.is_selected(name, frozenset({"fleet-reconcile"}))
+    # Assert
+    assert got is False
+
+
+def test_explain_says_unstated_when_nothing_is_configured() -> None:
+    # Arrange — a knob whose setting cannot be read back is a knob nobody
+    # trusts, so every command that consults it says what it found.
+    chosen = None
+    # Act
+    got = _selection.explain(chosen)
+    # Assert
+    assert "UNSTATED" in got
+
+
+def test_explain_says_empty_when_the_selection_is_deliberately_empty() -> None:
+    # Arrange
+    chosen = frozenset()
+    # Act
+    got = _selection.explain(chosen)
+    # Assert
+    assert "EMPTY" in got
+
+
+def test_explain_names_the_star_token_when_everything_is_selected() -> None:
+    # Arrange
+    chosen = frozenset({_selection.SELECT_ALL})
+    # Act
+    got = _selection.explain(chosen)
+    # Assert
+    assert _selection.SELECT_ALL in got
+
+
+def test_explain_lists_the_selected_jobs() -> None:
+    # Arrange
+    chosen = frozenset({"worktree-gc", "fleet-reconcile"})
+    # Act
+    got = _selection.explain(chosen)
+    # Assert
+    assert "fleet-reconcile, worktree-gc" in got

--- a/tests/scitex_agent_container/_jobs/_migrate/test__verify.py
+++ b/tests/scitex_agent_container/_jobs/_migrate/test__verify.py
@@ -1,0 +1,147 @@
+"""Tests for the exactly-one-supervisor check.
+
+"The new unit exists" is not the claim the migration makes. "ONLY the new
+unit exists" is. A verification that accepted the first would report
+success while doubling the supervision of the fleet's credential
+machinery — which is the precise outcome the whole change exists to
+prevent.
+
+The two-supervisor case therefore gets its own test, and so does the
+case where the old name survives ALONE (a cutover that silently did not
+happen), because those two failures need different fixes and a single
+"not ok" would not tell them apart.
+
+No mocks (PA-306): the checker is pure over a set of filenames, and the
+host-capability probe takes its ``which`` as a parameter.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._jobs._migrate import _renames, _verify
+
+WORKTREE_GC = _renames.by_local("worktree-gc")
+
+
+def test_only_the_new_units_present_is_ok() -> None:
+    # Arrange
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    got = _verify.verify_exactly_one(WORKTREE_GC, present=present).ok
+    # Assert
+    assert got is True
+
+
+def test_both_names_present_is_not_ok() -> None:
+    # Arrange — THE hazard: two units, both enabled, both firing.
+    present = frozenset(WORKTREE_GC.new_units() + WORKTREE_GC.old_units())
+    # Act
+    got = _verify.verify_exactly_one(WORKTREE_GC, present=present).ok
+    # Assert
+    assert got is False
+
+
+def test_both_names_present_is_reported_as_two_supervisors() -> None:
+    # Arrange — the verdict must name the actual failure, because the fix
+    # differs from "the cutover did not happen".
+    present = frozenset(WORKTREE_GC.new_units() + WORKTREE_GC.old_units())
+    # Act
+    verdict = _verify.verify_exactly_one(WORKTREE_GC, present=present).verdict
+    # Assert
+    assert "TWO SUPERVISORS" in verdict
+
+
+def test_only_the_old_units_present_is_not_ok() -> None:
+    # Arrange
+    present = frozenset(WORKTREE_GC.old_units())
+    # Act
+    got = _verify.verify_exactly_one(WORKTREE_GC, present=present).ok
+    # Assert
+    assert got is False
+
+
+def test_only_the_old_units_present_is_reported_as_a_cutover_that_did_not_happen() -> (
+    None
+):
+    # Arrange
+    present = frozenset(WORKTREE_GC.old_units())
+    # Act
+    verdict = _verify.verify_exactly_one(WORKTREE_GC, present=present).verdict
+    # Assert
+    assert "did not happen" in verdict
+
+
+def test_nothing_present_is_not_ok() -> None:
+    # Arrange — an install that failed leaves the job unsupervised, which
+    # for `accounts-refresh` means the fleet expires within hours.
+    present = frozenset()
+    # Act
+    got = _verify.verify_exactly_one(WORKTREE_GC, present=present).ok
+    # Assert
+    assert got is False
+
+
+def test_nothing_present_is_reported_as_no_supervisor() -> None:
+    # Arrange
+    present = frozenset()
+    # Act
+    verdict = _verify.verify_exactly_one(WORKTREE_GC, present=present).verdict
+    # Assert
+    assert "NO supervisor" in verdict
+
+
+def test_a_half_installed_timer_is_not_ok() -> None:
+    # Arrange — the .service written but not the .timer. The job exists and
+    # can be run by hand, but nothing schedules it: silently never firing.
+    present = frozenset({WORKTREE_GC.new_units()[0]})
+    # Act
+    got = _verify.verify_exactly_one(WORKTREE_GC, present=present).ok
+    # Assert
+    assert got is False
+
+
+def test_a_half_installed_timer_names_the_missing_unit() -> None:
+    # Arrange
+    present = frozenset({WORKTREE_GC.new_units()[0]})
+    # Act
+    verdict = _verify.verify_exactly_one(WORKTREE_GC, present=present).verdict
+    # Assert
+    assert WORKTREE_GC.new_units()[1] in verdict
+
+
+def test_an_unrelated_unit_on_the_host_does_not_affect_the_verdict() -> None:
+    # Arrange — the host has many units; only this job's names count.
+    present = frozenset(WORKTREE_GC.new_units()) | {"sac-listen.service"}
+    # Act
+    got = _verify.verify_exactly_one(WORKTREE_GC, present=present).ok
+    # Assert
+    assert got is True
+
+
+def test_the_ok_verdict_names_the_surviving_units() -> None:
+    # Arrange
+    present = frozenset(WORKTREE_GC.new_units())
+    # Act
+    verdict = _verify.verify_exactly_one(WORKTREE_GC, present=present).verdict
+    # Assert
+    assert verdict.startswith("OK")
+
+
+def test_a_host_with_systemctl_can_supervise_units() -> None:
+    # Arrange
+    which = {"systemctl": "/usr/bin/systemctl"}.get
+    # Act
+    got = _verify.systemd_user_available(which=which)
+    # Assert
+    assert got is True
+
+
+def test_a_host_without_systemctl_cannot_supervise_units() -> None:
+    # Arrange — measured 2026-08-11: nas-01 (armv7l) and nas-02 have no
+    # systemctl, and mba uses launchd. Three of nine hosts.
+    def which(_name):
+        return None
+
+    # Act
+    got = _verify.systemd_user_available(which=which)
+    # Assert
+    assert got is False

--- a/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/_jobs/test__jobs_plugin.py
@@ -70,14 +70,14 @@ def test_provider_returns_every_expected_job() -> None:
     # Assert
     assert names == {
         "sac.accounts-refresh",
-        "sac.accounts-keepalive",
-        "sac.host-sync-check",
-        "sac.worktree-gc",
-        "sac.spartan-sif-bake",
-        "sac.fleet-reconcile",
-        "sac.restart-login-expired-agents",
-        "sac.heal-agent-auth",
-        "sac.freshness-refresh",
+        "scitex-agent-container-accounts-keepalive",
+        "scitex-agent-container-host-sync-check",
+        "scitex-agent-container-worktree-gc",
+        "scitex-agent-container-spartan-sif-bake",
+        "scitex-agent-container-fleet-reconcile",
+        "scitex-agent-container-restart-login-expired-agents",
+        "scitex-agent-container-heal-agent-auth",
+        "scitex-agent-container-freshness-refresh",
     }
 
 
@@ -176,9 +176,9 @@ def test_provider_job_cadence_is_two_hours() -> None:
 def test_accounts_keepalive_job_name_is_package_prefixed() -> None:
     # Arrange — the distribution half of the single-refresher model.
     # Act
-    job = _job("sac.accounts-keepalive")
+    job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
-    assert job.name == "sac.accounts-keepalive"
+    assert job.name == "scitex-agent-container-accounts-keepalive"
 
 
 def test_accounts_keepalive_job_kind_is_timer() -> None:
@@ -188,7 +188,7 @@ def test_accounts_keepalive_job_kind_is_timer() -> None:
     # — taking the OAuth refresh, the drift check, the worktree GC and both
     # heal enforcers down with it.
     # Act
-    job = _job("sac.accounts-keepalive")
+    job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
     assert job.kind == "timer"
 
@@ -200,7 +200,7 @@ def test_accounts_keepalive_command_pushes_to_every_access_only_peer() -> None:
     # end. Pin the whole command so dropping a `--to` is a red test, not a
     # host nobody notices is dead.
     # Act
-    job = _job("sac.accounts-keepalive")
+    job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
     assert job.command == (
         "sac accounts keepalive --all "
@@ -219,7 +219,7 @@ def test_accounts_keepalive_command_runs_the_copying_verb_not_a_minting_one() ->
     # verb itself rather than trusting the full-command assertion above to be
     # re-read whenever someone edits the peer list.
     # Act
-    job = _job("sac.accounts-keepalive")
+    job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
     assert job.command.split()[:3] == ["sac", "accounts", "keepalive"]
 
@@ -232,7 +232,7 @@ def test_accounts_keepalive_cadence_bounds_the_follower_outage() -> None:
     # converged peer is verified rather than rewritten, so the extra ticks are
     # near free — which is what makes 15min affordable.
     # Act
-    job = _job("sac.accounts-keepalive")
+    job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
     assert job.on_unit_active_sec == "15min"
 
@@ -242,7 +242,7 @@ def test_accounts_keepalive_schedule_mirrors_the_timer_cadence() -> None:
     # sibling does) so `ecosystem cron` could derive an equivalent line, and
     # so the two spellings cannot silently disagree about how often this runs.
     # Act
-    job = _job("sac.accounts-keepalive")
+    job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
     assert job.schedule == "*/15 * * * *"
 
@@ -253,7 +253,7 @@ def test_accounts_keepalive_timeout_outlives_a_three_peer_pass() -> None:
     # including a slow one. A pass killed here is SAFE — nothing is published
     # unverified, so the peer keeps its previous credential.
     # Act
-    job = _job("sac.accounts-keepalive")
+    job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
     assert job.timeout_sec == 300
 
@@ -262,7 +262,7 @@ def test_accounts_keepalive_constructs_as_a_real_jobspec() -> None:
     # Arrange — construction must not raise (a bad field would drop the whole
     # provider). Assert it is the canonical contract type, not a look-alike.
     # Act
-    job = _job("sac.accounts-keepalive")
+    job = _job("scitex-agent-container-accounts-keepalive")
     # Assert
     assert isinstance(job, jobs_mod.JobSpec)
 
@@ -276,7 +276,7 @@ def test_accounts_keepalive_and_accounts_refresh_are_both_declared() -> None:
     # Act
     names = {job.name for job in provide_jobs()}
     # Assert
-    assert {"sac.accounts-refresh", "sac.accounts-keepalive"} <= names
+    assert {"sac.accounts-refresh", "scitex-agent-container-accounts-keepalive"} <= names
 
 
 def test_provider_does_not_federate_listen_it_would_duplicate_the_supervisor() -> None:
@@ -306,15 +306,15 @@ def test_provider_does_not_federate_listen_it_would_duplicate_the_supervisor() -
 def test_host_sync_check_job_name_is_package_prefixed() -> None:
     # Arrange — the drift-alarm timer that makes the Stage-0 detector run.
     # Act
-    job = _job("sac.host-sync-check")
+    job = _job("scitex-agent-container-host-sync-check")
     # Assert
-    assert job.name == "sac.host-sync-check"
+    assert job.name == "scitex-agent-container-host-sync-check"
 
 
 def test_host_sync_check_job_kind_is_timer() -> None:
     # Arrange — a periodic systemd --user timer (hourly), so kind="timer".
     # Act
-    job = _job("sac.host-sync-check")
+    job = _job("scitex-agent-container-host-sync-check")
     # Assert
     assert job.kind == "timer"
 
@@ -323,7 +323,7 @@ def test_host_sync_check_command_is_the_readonly_check() -> None:
     # Arrange — the scheduled command MUST carry --check. A timer that could
     # fast-forward a peer unattended is Stage 1, explicitly out of scope.
     # Act
-    job = _job("sac.host-sync-check")
+    job = _job("scitex-agent-container-host-sync-check")
     # Assert
     assert "--check" in job.command
 
@@ -332,7 +332,7 @@ def test_host_sync_check_command_routes_to_a_seen_card() -> None:
     # Arrange — --alarm is what turns the exit code into a SEEN board card
     # instead of a journald line nobody reads.
     # Act
-    job = _job("sac.host-sync-check")
+    job = _job("scitex-agent-container-host-sync-check")
     # Assert
     assert "--alarm" in job.command
 
@@ -342,7 +342,7 @@ def test_host_sync_check_command_never_runs_the_mutating_remedy() -> None:
     # <peer>` (no --check) must never be what this timer runs. The command
     # is the read-only detector, full stop.
     # Act
-    job = _job("sac.host-sync-check")
+    job = _job("scitex-agent-container-host-sync-check")
     # Assert — the command is precisely the read-only check+alarm form.
     assert job.command == "sac host sync --check --all --alarm"
 
@@ -350,7 +350,7 @@ def test_host_sync_check_command_never_runs_the_mutating_remedy() -> None:
 def test_host_sync_check_cadence_is_hourly() -> None:
     # Arrange — drift is slow-moving; hourly is ample and gentle on ssh.
     # Act
-    job = _job("sac.host-sync-check")
+    job = _job("scitex-agent-container-host-sync-check")
     # Assert
     assert job.on_unit_active_sec == "1h"
 
@@ -360,16 +360,16 @@ def test_worktree_gc_job_name_is_package_prefixed() -> None:
     # PERIODIC. A GC nobody schedules is a script, not a countermeasure —
     # which is exactly how one repo reached 105 worktrees.
     # Act
-    job = _job("sac.worktree-gc")
+    job = _job("scitex-agent-container-worktree-gc")
     # Assert
-    assert job.name == "sac.worktree-gc"
+    assert job.name == "scitex-agent-container-worktree-gc"
 
 
 def test_worktree_gc_job_kind_is_timer() -> None:
     # Arrange — a periodic systemd --user timer (daily), so kind="timer".
     # A bad kind makes `ecosystem up` silently drop sac's WHOLE provider.
     # Act
-    job = _job("sac.worktree-gc")
+    job = _job("scitex-agent-container-worktree-gc")
     # Assert
     assert job.kind == "timer"
 
@@ -380,7 +380,7 @@ def test_worktree_gc_command_is_the_apply_form() -> None:
     # sprawl kept growing. The safety lives in the predicate, not in
     # withholding --apply.
     # Act
-    job = _job("sac.worktree-gc")
+    job = _job("scitex-agent-container-worktree-gc")
     # Assert
     assert job.command == "sac worktree gc --apply --all"
 
@@ -390,7 +390,7 @@ def test_worktree_gc_command_sweeps_every_declared_repo() -> None:
     # agent spec.workdir that is a local git repo toplevel). If that source
     # ever disappears, this command silently sweeps nothing.
     # Act
-    job = _job("sac.worktree-gc")
+    job = _job("scitex-agent-container-worktree-gc")
     # Assert
     assert "--all" in job.command
 
@@ -399,7 +399,7 @@ def test_worktree_gc_cadence_is_daily() -> None:
     # Arrange — sprawl accumulates over days and the age gate is 24h, so a
     # faster pass could not remove anything a daily one would miss.
     # Act
-    job = _job("sac.worktree-gc")
+    job = _job("scitex-agent-container-worktree-gc")
     # Assert
     assert job.on_unit_active_sec == "1d"
 
@@ -407,9 +407,9 @@ def test_worktree_gc_cadence_is_daily() -> None:
 def test_fleet_reconcile_job_name_is_package_prefixed() -> None:
     # Arrange — the enforcer of "should be running => is running".
     # Act
-    job = _job("sac.fleet-reconcile")
+    job = _job("scitex-agent-container-fleet-reconcile")
     # Assert
-    assert job.name == "sac.fleet-reconcile"
+    assert job.name == "scitex-agent-container-fleet-reconcile"
 
 
 def test_fleet_reconcile_job_kind_is_timer() -> None:
@@ -418,7 +418,7 @@ def test_fleet_reconcile_job_kind_is_timer() -> None:
     # sac's whole provider (provider-isolated, WARN-only) — taking the OAuth
     # refresh, the drift check and the worktree GC down with it.
     # Act
-    job = _job("sac.fleet-reconcile")
+    job = _job("scitex-agent-container-fleet-reconcile")
     # Assert
     assert job.kind == "timer"
 
@@ -430,7 +430,7 @@ def test_fleet_reconcile_command_is_the_applying_form() -> None:
     # the supervisor dies with the process that promised it. A scheduled
     # DRY-RUN would restore nothing — the whole point is `--apply`.
     # Act
-    job = _job("sac.fleet-reconcile")
+    job = _job("scitex-agent-container-fleet-reconcile")
     # Assert
     assert job.command == "sac agents reconcile --apply"
 
@@ -440,7 +440,7 @@ def test_fleet_reconcile_cadence_is_five_minutes() -> None:
     # pass is one batched `tmux list-sessions` plus a spec read each, so it
     # is cheap enough to run often.
     # Act
-    job = _job("sac.fleet-reconcile")
+    job = _job("scitex-agent-container-fleet-reconcile")
     # Assert
     assert job.on_unit_active_sec == "5min"
 
@@ -451,7 +451,7 @@ def test_fleet_reconcile_timeout_outlives_a_capped_pass() -> None:
     # history is persisted per restart, not at the end), but the timeout must
     # still comfortably exceed a normal pass or the enforcer never finishes.
     # Act
-    job = _job("sac.fleet-reconcile")
+    job = _job("scitex-agent-container-fleet-reconcile")
     # Assert
     assert job.timeout_sec == 300
 
@@ -460,16 +460,16 @@ def test_spartan_sif_bake_job_name_is_package_prefixed() -> None:
     # Arrange — the daily remote SIF bake (operator directive 2026-07-17:
     # bake on Spartan, rsync to the master, zero master CPU).
     # Act
-    job = _job("sac.spartan-sif-bake")
+    job = _job("scitex-agent-container-spartan-sif-bake")
     # Assert
-    assert job.name == "sac.spartan-sif-bake"
+    assert job.name == "scitex-agent-container-spartan-sif-bake"
 
 
 def test_spartan_sif_bake_job_kind_is_timer() -> None:
     # Arrange — a periodic systemd --user timer (*/10), so kind="timer".
     # A bad kind makes `ecosystem up` silently drop sac's WHOLE provider.
     # Act
-    job = _job("sac.spartan-sif-bake")
+    job = _job("scitex-agent-container-spartan-sif-bake")
     # Assert
     assert job.kind == "timer"
 
@@ -488,9 +488,9 @@ def test_spartan_sif_bake_job_kind_is_timer() -> None:
 def test_restart_login_expired_job_name_is_package_prefixed() -> None:
     # Arrange — the auto-restarter for auth-dead-but-live agents.
     # Act
-    job = _job("sac.restart-login-expired-agents")
+    job = _job("scitex-agent-container-restart-login-expired-agents")
     # Assert
-    assert job.name == "sac.restart-login-expired-agents"
+    assert job.name == "scitex-agent-container-restart-login-expired-agents"
 
 
 def test_restart_login_expired_job_kind_is_timer() -> None:
@@ -499,7 +499,7 @@ def test_restart_login_expired_job_kind_is_timer() -> None:
     # provider (provider-isolated, WARN-only) — taking the OAuth refresh, the
     # drift check, the worktree GC AND the fleet-reconcile enforcer down too.
     # Act
-    job = _job("sac.restart-login-expired-agents")
+    job = _job("scitex-agent-container-restart-login-expired-agents")
     # Assert
     assert job.kind == "timer"
 
@@ -510,7 +510,7 @@ def test_spartan_sif_bake_command_is_the_confirmed_form() -> None:
     # scheduled command missing --yes would fail every single night —
     # a timer that fires and does nothing, the inert-feature shape.
     # Act
-    job = _job("sac.spartan-sif-bake")
+    job = _job("scitex-agent-container-spartan-sif-bake")
     # Assert
     assert job.command == "sac image bake-remote --yes"
 
@@ -524,7 +524,7 @@ def test_spartan_sif_bake_cadence_is_every_10_minutes() -> None:
     # round-trip instead of a multi-GB transfer, and the script's `flock -n`
     # single-flights the overlaps a 10min interval necessarily causes.
     # Act
-    job = _job("sac.spartan-sif-bake")
+    job = _job("scitex-agent-container-spartan-sif-bake")
     # Assert
     assert job.on_unit_active_sec == "10min"
 
@@ -535,7 +535,7 @@ def test_spartan_sif_bake_timeout_outlives_two_bakes_and_a_pull() -> None:
     # cap must exceed the worst legitimate chain or the timer kills its
     # own successful runs.
     # Act
-    job = _job("sac.spartan-sif-bake")
+    job = _job("scitex-agent-container-spartan-sif-bake")
     # Assert
     assert job.timeout_sec == 14_400
 
@@ -545,7 +545,7 @@ def test_restart_login_expired_command_is_the_applying_form() -> None:
     # The whole point is `--apply`. Detection stays read-only; the restart is
     # the only mutation.
     # Act
-    job = _job("sac.restart-login-expired-agents")
+    job = _job("scitex-agent-container-restart-login-expired-agents")
     # Assert
     assert job.command == "sac agents restart-login-expired --apply"
 
@@ -554,7 +554,7 @@ def test_restart_login_expired_cadence_is_five_minutes() -> None:
     # Arrange — the cadence IS the window a login-expired agent stays wedged,
     # matched to fleet-reconcile so the two enforcers sweep on the same beat.
     # Act
-    job = _job("sac.restart-login-expired-agents")
+    job = _job("scitex-agent-container-restart-login-expired-agents")
     # Assert
     assert job.on_unit_active_sec == "5min"
 
@@ -563,7 +563,7 @@ def test_restart_login_expired_constructs_as_a_real_jobspec() -> None:
     # Arrange — construction must not raise (a bad field would drop the whole
     # provider). Assert it is the canonical contract type, not a look-alike.
     # Act
-    job = _job("sac.restart-login-expired-agents")
+    job = _job("scitex-agent-container-restart-login-expired-agents")
     # Assert
     assert isinstance(job, jobs_mod.JobSpec)
 
@@ -589,9 +589,9 @@ def test_restart_login_expired_constructs_as_a_real_jobspec() -> None:
 def test_heal_agent_auth_job_name_is_package_prefixed() -> None:
     # Arrange — the incumbent auth healer, now declared rather than hand-cronned.
     # Act
-    job = _job("sac.heal-agent-auth")
+    job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
-    assert job.name == "sac.heal-agent-auth"
+    assert job.name == "scitex-agent-container-heal-agent-auth"
 
 
 def test_heal_agent_auth_job_kind_is_timer() -> None:
@@ -601,7 +601,7 @@ def test_heal_agent_auth_job_kind_is_timer() -> None:
     # job exists to escape, and a kind outside {"service","timer","cron"} raises
     # at construction, silently dropping sac's WHOLE provider.
     # Act
-    job = _job("sac.heal-agent-auth")
+    job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
     assert job.kind == "timer"
 
@@ -611,7 +611,7 @@ def test_heal_agent_auth_cadence_preserves_the_incumbent_ten_minutes() -> None:
     # ticks 15:20 → 15:30 → 15:40 → 15:50 → 16:00, matching the `*/10` cron line.
     # Migrating a schedule is the wrong moment to also retune it.
     # Act
-    job = _job("sac.heal-agent-auth")
+    job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
     assert job.on_unit_active_sec == "10min"
 
@@ -621,7 +621,7 @@ def test_heal_agent_auth_schedule_mirrors_the_retired_cron_expression() -> None:
     # sibling does) so the expression the crontab line used stays legible in the
     # spec, and so `ecosystem cron` could still derive an equivalent line.
     # Act
-    job = _job("sac.heal-agent-auth")
+    job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
     assert job.schedule == "*/10 * * * *"
 
@@ -631,7 +631,7 @@ def test_heal_agent_auth_interpreter_token_is_absolute() -> None:
     # through VERBATIM. An absolute head is therefore the only form that depends
     # on neither the ambient PATH nor which interpreter ran `ecosystem up`.
     # Act
-    job = _job("sac.heal-agent-auth")
+    job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
     assert job.command.split()[0].startswith("/")
 
@@ -641,7 +641,7 @@ def test_heal_agent_auth_script_token_is_absolute() -> None:
     # so the script argument must be absolute too; a relative path would exec
     # fine under cron's $HOME cwd and fail as status=127 under systemd.
     # Act
-    job = _job("sac.heal-agent-auth")
+    job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
     assert job.command.split()[1].startswith("/")
 
@@ -652,7 +652,7 @@ def test_heal_agent_auth_runs_the_venv_python_not_the_system_one() -> None:
     # runs on. Naming the venv interpreter outright is what carries the "PATH
     # prefixed with .env-3.11/bin" requirement into a unit that has no PATH.
     # Act
-    job = _job("sac.heal-agent-auth")
+    job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
     assert job.command.startswith("/home/ywatanabe/.env-3.11/bin/python ")
 
@@ -664,7 +664,7 @@ def test_heal_agent_auth_targets_the_real_auth_heal_entrypoint() -> None:
     # that script writes. It takes no arguments — its `main()` has no argparse,
     # only a `--selftest` branch — so the bare script path is the whole command.
     # Act
-    job = _job("sac.heal-agent-auth")
+    job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
     assert job.command.endswith(
         "/home/ywatanabe/.scitex/agent-container/bin/auth-heal.py"
@@ -676,7 +676,7 @@ def test_heal_agent_auth_timeout_outlives_a_restarting_pass() -> None:
     # at 15:30:04 settling by 15:32:08) ~2min. A pass killed here is SAFE (state
     # is persisted per restart), but the timeout must still outlive a real one.
     # Act
-    job = _job("sac.heal-agent-auth")
+    job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
     assert job.timeout_sec == 300
 
@@ -685,7 +685,7 @@ def test_heal_agent_auth_constructs_as_a_real_jobspec() -> None:
     # Arrange — construction must not raise (a bad field would drop the whole
     # provider). Assert it is the canonical contract type, not a look-alike.
     # Act
-    job = _job("sac.heal-agent-auth")
+    job = _job("scitex-agent-container-heal-agent-auth")
     # Assert
     assert isinstance(job, jobs_mod.JobSpec)
 
@@ -701,4 +701,4 @@ def test_heal_agent_auth_and_restart_login_expired_are_both_declared() -> None:
     # Act
     names = {job.name for job in provide_jobs()}
     # Assert
-    assert {"sac.heal-agent-auth", "sac.restart-login-expired-agents"} <= names
+    assert {"scitex-agent-container-heal-agent-auth", "scitex-agent-container-restart-login-expired-agents"} <= names

--- a/tests/scitex_agent_container/_jobs/test__names.py
+++ b/tests/scitex_agent_container/_jobs/test__names.py
@@ -24,17 +24,77 @@ def test_a_local_name_becomes_canonical() -> None:
     # Act
     got = _names.canonical(typed)
     # Assert
-    assert got == "sac.accounts-refresh"
+    assert got == "scitex-agent-container-accounts-refresh"
 
 
 def test_canonicalising_is_idempotent() -> None:
-    # Arrange — a name copied out of --json output or a unit filename
-    # must resolve to itself, not to `sac.sac.accounts-refresh`.
+    # Arrange — a name copied out of --json output or a unit filename must
+    # resolve to itself, not to a double prefix.
+    typed = "scitex-agent-container-accounts-refresh"
+    # Act
+    got = _names.canonical(typed)
+    # Assert
+    assert got == "scitex-agent-container-accounts-refresh"
+
+
+def test_a_legacy_name_is_not_re_prefixed() -> None:
+    # Arrange — THE dangerous direction. A legacy name still names a real
+    # deployed unit; rewriting it here would point every verb at a unit
+    # that does not exist, and for the held OAuth refresher that means
+    # reporting the fleet's credential machinery as absent while it runs.
     typed = "sac.accounts-refresh"
     # Act
     got = _names.canonical(typed)
     # Assert
     assert got == "sac.accounts-refresh"
+
+
+def test_a_legacy_name_is_recognised_as_ours() -> None:
+    # Arrange — the ownership filter must not drop the held job, or
+    # `sac dev timer list` stops showing the refresher entirely.
+    typed = "sac.accounts-refresh"
+    # Act
+    got = _names.is_ours(typed)
+    # Assert
+    assert got is True
+
+
+def test_local_strips_the_legacy_prefix_too() -> None:
+    # Arrange
+    typed = "sac.accounts-refresh"
+    # Act
+    got = _names.local(typed)
+    # Assert
+    assert got == "accounts-refresh"
+
+
+def test_a_local_name_offers_the_canonical_form_first() -> None:
+    # Arrange — resolution order decides which of two live prefixes wins
+    # for a bare short name.
+    typed = "worktree-gc"
+    # Act
+    got = _names.candidates(typed)
+    # Assert
+    assert got[0] == "scitex-agent-container-worktree-gc"
+
+
+def test_a_local_name_still_offers_the_legacy_form() -> None:
+    # Arrange — without this the held refresher is unreachable by its
+    # short name, which is the name every runbook uses.
+    typed = "accounts-refresh"
+    # Act
+    got = _names.candidates(typed)
+    # Assert
+    assert "sac.accounts-refresh" in got
+
+
+def test_an_already_prefixed_name_is_unambiguous() -> None:
+    # Arrange — a name that carries a prefix means exactly one thing.
+    typed = "sac.worktree-gc"
+    # Act
+    got = _names.candidates(typed)
+    # Assert
+    assert got == ("sac.worktree-gc",)
 
 
 def test_an_empty_name_is_rejected() -> None:


### PR DESCRIPTION
## What this is

The ecosystem canonical-name rename (`scitex-<pkg>-<name>`, operator decision
2026-08-11, auditor rules PS-226/PS-227) for every job sac owns — **plus the
migration that makes it safe**, because those two must not ship apart.

## Why a rename is a live hazard

scitex-dev derives a unit FILENAME from `JobSpec.name` verbatim:

```python
return f"{job.name}.timer" if job.kind == "timer" else f"{job.name}.service"
```

So `sac.worktree-gc.timer` and `scitex-agent-container-worktree-gc.timer` are
**two unrelated units** with independent enablement, state and triggers.
Install-before-uninstall leaves both on the host, both firing the same command.

That has already happened here: a crontab line and a systemd unit were both
supervising `sac listen` against *different venvs*, dormant only because a
`pgrep` guard happened to match systemd's process. **A rename is precisely the
event that stops the guard matching.**

## The ordering, enforced by construction

```
stop → disable → carry drop-ins → displace → daemon-reload → install → logging → verify
```

Each step's action indexes into `ACTION_ORDER`, and a test asserts the ranks
are non-decreasing for every job in the table — so an edit that reorders the
emission fails the build rather than quietly arming a race on nine hosts.

Two inner orderings are also load-bearing and separately tested:

- **stop before disable** — `disable` only drops the `.wants` symlink, so
  disable-first leaves a *running* unit nothing will restart and nothing stopped.
- **carry drop-ins before displace** — displacing first orphans `<unit>.d/`
  under a name the new unit never reads: the config silently stops applying
  while everything still looks installed. On compute-04 that directory holds 28
  secret paths.

Nothing is deleted (`.old/<timestamp>/`). `sac-listen.service` is in
`NEVER_TOUCH`, and the guard runs inside `plan()` on everything it returns —
not at call sites that can forget it.

Verification counts **both** names: "the new unit exists" is not the claim,
"only the new unit exists" is, and a surviving old unit fails however healthy
the new one looks. Two-supervisors, cutover-did-not-happen and no-supervisor
are distinguished, because they need different fixes.

## What was NOT done, deliberately

`sac.accounts-refresh` keeps its legacy name. It is the fleet's sole OAuth
refresher against a **single-use** refresh token (two racing refreshers revoke
each other; zero stalls the fleet within hours — measured 2026-07-09/10) and it
is the only sac timer actually enabled and active.

A spec renamed *ahead of* its unit is the one shape that must not ship: it
would make `sac dev timer status accounts-refresh` resolve to a name no unit
carries and report the refresher as **absent while it refreshes**. So the
declared name tracks the DEPLOYED unit until an operator-supervised cutover
renames both together. `_names` recognises both prefixes for exactly that
window, and `--include-held` requires `--only` so a bulk run cannot sweep it up.

## Executed on scitex-compute-04

8 of 9 jobs cut over, `exit 0`, each verified as exactly one supervisor.
Confirmed independently of the tool's own report:

- only `sac.accounts-refresh.{service,timer}` remain dotted (the held job)
- 16 new canonical unit files; all 8 timers `LoadState=loaded`
- `sac-listen.service` and its `50-secrets-envrc.conf` untouched, still applied
- the refresher still `enabled` + `active`
- 14 displaced files in `.old/20260811T221129Z/`
- `StandardOutput=append` confirmed live via `systemctl show`

Arming state is preserved — the migration renames, it does not arm.

## Also lands

- **A run-selection knob.** `JobSpec` has no host axis, so every discovered job
  was a candidate everywhere while "`restart-login-expired-agents` and
  `heal-agent-auth` are mutually exclusive" lived only in docstring prose.
  UNSTATED is a third state distinct from "nothing selected" — arriving
  machinery must not disarm a host that never opted in. Gates ARMING, never
  installing.
- **Predictable logging**, as a drop-in on **scitex-dev's own** path convention
  rather than a rival one. sac's jobs are not dispatched through
  `ecosystem cron exec`, so upstream's sink never installed for them. A drop-in
  because scitex-dev regenerates the unit on every install; `append:` so a
  restart does not truncate history. A test calls the real upstream resolver,
  so a convention change upstream fails sac's build instead of silently
  splitting the log tree in two.
- **A host-capability refusal**, which `sac dev` did **not** already have —
  contrary to a widely repeated assumption, there is no `systemctl` probe in
  `_dev_jobs.py` or `_dev_jobs_backend.py`, and `manual_hint` will still print
  a `systemctl` line on a QNAP. nas-01 (armv7l) / nas-02 have no `systemctl`
  and mba uses launchd, so the verb exits 3 there.
- `docs/adr/0022-listen-is-not-a-jobspec.md` — the "never federate listen"
  argument moved out of a function docstring, which also brings
  `_jobs_plugin.py` back under the per-file line cap it had already exceeded.

## On test doubles

The table is checked against the **real** `provide_jobs()` through the **real**
validator, and includes a positive control asserting the old names are exactly
what PS-226 rejects — so the suite cannot pass on a migration that migrates
nothing. This is deliberate: `sac dev systemd list` once filtered on
`kind="systemd"` and hid four live timers for weeks while its tests passed,
because the fixture hand-rolled a fake whose `_Job` defaulted to that
impossible kind.
