### PR TITLE
fix(test): the liveness-tick tests waited on a clock instead of on the loop

### DIFF
--- a/tests/scitex_agent_container/_listen/test__liveness_tick.py
+++ b/tests/scitex_agent_container/_listen/test__liveness_tick.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import time
 from datetime import datetime, timezone
 
 import pytest
@@ -461,23 +462,70 @@ class TestResolveLiveness:
 # ===========================================================================
 
 
-async def _run_one_tick(*, consumers, doc, liveness, **kw) -> None:
-    """Spin the loop briefly then cancel — forces ≥1 tick deterministically."""
+#: How long a barrier waits for the loop to make progress before failing.
+#: Generous on purpose: it is not a timing assertion, it is the point at
+#: which we stop believing the loop is merely slow.
+_BARRIER_TIMEOUT_S = 10.0
+
+
+async def _await_ticks(counter: "list[int]", wanted: int) -> None:
+    """Block until the loop has COMPLETED ``wanted`` ticks, or fail loudly.
+
+    ``counter[0]`` is bumped by the loop's own ``now_fn`` seam, which the
+    loop calls exactly once per tick — after the interval sleep, before
+    detection and emit. So the (N+1)-th call is proof that tick N ran all
+    the way through its emit: the loop cannot reach the next ``now_fn()``
+    without having finished the previous iteration.
+    """
+    deadline = time.monotonic() + _BARRIER_TIMEOUT_S
+    while counter[0] <= wanted:
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"loop completed {max(counter[0] - 1, 0)} of {wanted} ticks "
+                f"in {_BARRIER_TIMEOUT_S}s — it is not running, not slow"
+            )
+        await asyncio.sleep(0.001)
+
+
+async def _run_one_tick(*, consumers, doc, liveness, ticks: int = 1, **kw) -> None:
+    """Run the loop until ``ticks`` FULL ticks have completed, then cancel.
+
+    The barrier is the loop's own progress (see :func:`_await_ticks`), NOT
+    the wall clock. The previous version slept a fixed 0.15s against a
+    0.05s interval and called that "deterministic"; it is not. Wall time
+    keeps moving while the event loop is starved, so on a loaded CI runner
+    the whole budget can elapse before the loop is ever scheduled — which
+    is exactly what happened in #967: 151ms of wall time, zero ticks,
+    ``assert 0 >= 1``, on py3.12 only, while the same commit passed on
+    3.11 and 3.13.
+
+    This also makes the ``emits_nothing`` tests mean something. Under a
+    fixed sleep they passed whenever the loop had not run at all — an
+    empty list proves silence only once a tick has demonstrably happened.
+    """
+    counter = [0]
+
+    def _now() -> float:
+        counter[0] += 1
+        return NOW
+
     task = asyncio.create_task(
         liveness_tick_reconciler_loop(
-            interval_s=0.05,
+            interval_s=0.001,
             stale_s=STALE_S,
             tasks_doc_source=doc,
             liveness_source=liveness,
             consumers_source=consumers,
-            now_fn=lambda: NOW,
+            now_fn=_now,
             **kw,
         )
     )
-    await asyncio.sleep(0.15)
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    try:
+        await _await_ticks(counter, ticks)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
 
 
 @pytest.mark.asyncio
@@ -587,24 +635,16 @@ async def test_loop_dedups_within_renotify_cooldown() -> None:
     # Arrange — many ticks at fixed NOW within a long cooldown.
     events: list[dict] = []
     liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
-    task = asyncio.create_task(
-        liveness_tick_reconciler_loop(
-            interval_s=0.02,
-            stale_s=STALE_S,
-            renotify_s=10_000.0,  # huge → never re-notify in this test
-            tasks_doc_source=_stuck_doc(),
-            liveness_source=liveness,
-            consumers_source=[events.append],
-            now_fn=lambda: NOW,  # frozen clock → all ticks share one "now"
-        )
+    # Act — let SEVERAL ticks complete. Counted, not timed: "assert it fired
+    # once" is only a dedup claim if more than one tick actually ran, and a
+    # fixed sleep cannot promise that on a loaded runner (#967).
+    await _run_one_tick(
+        consumers=[events.append],
+        doc=_stuck_doc(),
+        liveness=liveness,
+        ticks=3,
+        renotify_s=10_000.0,  # huge → never re-notify in this test
     )
-    # Act — let several ticks run.
-    await asyncio.sleep(0.2)
-    task.cancel()
-    try:
-        await task
-    except asyncio.CancelledError:
-        pass
     # Assert — despite many ticks, the (agent, card) fired exactly once.
     assert len(events) == 1
 


### PR DESCRIPTION
## The red check this explains

`pytest-matrix-on-ubuntu-py3.12` failed on #967 — a PR whose entire diff is
`runtimes/_to_home_text.py` and that file's own test:

```
FAILED tests/scitex_agent_container/_listen/test__liveness_tick.py::
TestLoopEmits::test_loop_emits_anomaly_for_a_stuck_card - assert 0 >= 1
```

py3.11 and py3.13 passed on the same commit. Nothing in that diff can reach
the liveness loop, so the failure is the test's, and it is filed here rather
than on #967 because #967 is gating on it.

## What actually went wrong

`_run_one_tick` started the loop, slept a fixed 0.15s against a 0.05s
interval, cancelled, and asserted an event had landed — its docstring called
this "≥1 tick deterministically". The captured stderr shows the entire life
of the task inside 151ms of **wall** time with no tick in between:

```
22:05:54,352 liveness_tick: starting (interval_s=0.1 stale_s=900.0 ...)
22:05:54,503 liveness_tick: cancelled cleanly
```

(The `interval_s=0.1` is `%.1f` rounding of the 0.05 the helper passes.)

The warnings summary attributes four figrecipe `DeprecationWarning`s to this
same test, i.e. a heavy lazy import was running on that worker while the loop
waited. Wall time advances while the event loop is starved, so the budget
expired before the loop was ever scheduled. The assertion was measuring the
runner's load.

## The fix

Wait on the loop's own progress instead of on a clock. `now_fn` is already an
injected seam and the loop calls it exactly once per tick — after the interval
sleep, before detection and emit — so seeing call N+1 proves tick N ran all
the way through its emit. `_await_ticks` waits for that count with a 10s
ceiling and, when it expires, reports *the loop never ran* rather than
silently reporting *no events*.

Nothing is skipped, xfailed, or loosened. Every assertion is byte-identical,
and two things get **stricter**:

- the four `emits_nothing` tests stop being vacuous — under a fixed sleep an
  empty list also described a loop that had never started;
- `test_loop_dedups_within_renotify_cooldown` had the same defect ("fired
  exactly once" is only a dedup claim if more than one tick ran) and now goes
  through the same barrier with `ticks=3`.

`test_loop_honours_cancellation_cleanly` is deliberately untouched: it asserts
only that cancellation is honoured, which is true whether or not a tick ran.

## Measured

```
/opt/venv-sac/bin/python -m pytest tests/scitex_agent_container/_listen/test__liveness_tick.py -q
plugins: anyio-4.14.2, asyncio-1.4.0, xdist-3.8.0, scitex-dev-0.47.0
36 passed in 1.02s                       PYTEST_EXIT_CODE=0
```

The plugin line is quoted on purpose: pytest-asyncio intermittently fails to
autoload in the shared venv and every async test then fails at once, so a
green async run is only believable with `asyncio-1.4.0` visible in the header.
