### PR TITLE
fix(tui-turn-bridge): supervise the bridge instead of spawning it once and hoping

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_tui_bridge_supervisor.py
+++ b/src/scitex_agent_container/_lifecycle/_tui_bridge_supervisor.py
@@ -1,0 +1,332 @@
+"""Re-assert the TUI ``/v1/turn`` turn bridge on the existing heartbeat tick.
+
+THE INCIDENT (scitex-compute-04, 2026-08-11). ``runtime: tui`` agents serve
+``/v1/turn`` from a HOST-SIDE process (``python -m
+scitex_agent_container.runtimes._tui_turn_bridge``) that
+:func:`..runtimes._tui_turn_bridge_lifecycle.start_turn_bridge` spawns exactly
+ONCE, from ``TuiSessionRuntime.start`` via ``_maybe_start_turn_bridge``.
+NOTHING supervised it. When it died it stayed dead — and the agent still
+reported healthy. Measured that night: 15 ``tui-turn-bridge.pid`` files on the
+host, 14 pointing at dead PIDs; two of those agents (``canary-resume-test``
+port 19014, ``scitex-live-paper`` port 19015) had LIVE tmux sessions with
+NOTHING bound to their port, so their in-container channel subscriber POSTed
+wake turns into a closed socket — 40 attempts, 40 connection-refused, zero
+successes, a flat line at zero rather than a flap — while the operator saw 34
+"unavailable: connection refused" messages and replies limped in ~354 s late
+over an unrelated rail.
+
+Two defects, one fix:
+
+  D1 — NO SUPERVISION. Start path only, and every layer swallows failure:
+       ``_tui_bridge_seam`` catches and logs a warning, ``start_turn_bridge``
+       catches a spawn failure and returns ``None``. No systemd unit, no timer.
+  D2 — BOOT-ORDER RACE. ``_maybe_start_turn_bridge`` runs LAST in ``start()``
+       — after the container is up, after the boot drain, after the
+       startup-prompt injection — while the container's subscriber is ALREADY
+       POSTing. Measured 47 s and 8 operator-visible warnings on one boot.
+
+This module closes both WITHOUT a new daemon, a systemd unit or a timer. The
+centralized :func:`._tui_heartbeat_loop.tui_heartbeat_loop` already ticks every
+~30 s over exactly the right population (every ``runtime: tui`` agent) and
+already holds a fresh batched tmux snapshot naming which of them are ALIVE. On
+each tick we now additionally ask, per live agent, "is anything bound to the
+port this agent's bridge is supposed to serve?" and re-spawn when nothing is.
+The first tick after a boot repairs D2 as a side effect, bounding the
+connection-refused window at one tick instead of "forever".
+
+WHY THE HEARTBEAT TICK IS THE RIGHT HOME: it is the one loop that already
+enumerates TUI agents WITH their config, already runs on the host (where the
+bridge process lives), already runs off the event loop under a bounded budget,
+and already carries an overlap guard. A second supervisor would duplicate all
+four and add a lifecycle of its own to supervise — the exact regress this fixes.
+
+SAFETY — this only ever re-asserts, never stops. A deliberately-stopped agent
+has no tmux session, so it is absent from the snapshot and never touched; only
+an agent sac believes is RUNNING can have its bridge respawned.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# Kill switch, mirroring SAC_TUI_HEARTBEAT_DISABLED / SAC_SDK_HEARTBEAT_DISABLED.
+DISABLE_ENV = "SAC_TUI_BRIDGE_SUPERVISION_DISABLED"
+
+# tmux session-name prefix the heartbeat snapshot is keyed by (``tui-<name>``),
+# the same convention ``_tui_heartbeat_loop._beat_one`` looks agents up under.
+_SESSION_PREFIX = "tui-"
+
+# Pre-spawn port-free wait for a SUPERVISOR respawn, deliberately much shorter
+# than ``start_turn_bridge``'s 10 s default. We only ever call the launcher
+# after OBSERVING the port free, so the gate should confirm-and-go; the long
+# default exists for the restart path, where an old holder is still shutting
+# down. Keeping it short bounds the tick even if a foreign process grabs the
+# port in the microseconds between our probe and the launcher's.
+_RESPAWN_PORT_FREE_TIMEOUT_S = 2.0
+
+# Per-agent outcomes. Returned (not just logged) so the tick — and tests — can
+# assert what the supervisor actually decided for each agent.
+VERDICT_NO_SESSION = "no-session"
+VERDICT_NO_CONFIG = "no-config"
+VERDICT_NO_PORT = "no-port"
+VERDICT_SERVING = "serving"
+VERDICT_RESTARTED = "restarted"
+VERDICT_FAILED = "restart-failed"
+
+
+def _default_port_lookup(name: str) -> int | None:
+    """Production ``port_lookup_fn``: this agent's claimed a2a port, or None."""
+    from .._state import port_allocator
+
+    return port_allocator.get_port(name)
+
+
+def resolve_bridge_port(
+    config: Any,
+    *,
+    port_lookup_fn: Callable[[str], int | None] | None = None,
+) -> int | None:
+    """Return the port THIS agent's turn bridge is supposed to serve, else None.
+
+    Two sources, tried in the order the system itself resolves them:
+
+    1. A concrete int already on ``config.a2a.port`` — an operator PIN, or a
+       config object ``_a2a_port.resolve_a2a_port`` has already mutated. Read
+       via :func:`..runtimes._tui_turn_bridge_lifecycle.resolved_a2a_port`,
+       the SAME reader ``start_turn_bridge`` consults, so the supervisor and
+       the launcher agree about the port by construction rather than by luck.
+
+    2. The allocator's CLAIM for this agent name. This branch is what makes the
+       supervisor work at all: fleet specs declare ``a2a.port: auto`` (measured
+       on compute-04 — every TUI spec), which ``load_config`` hands back
+       verbatim as the string ``"auto"``. A freshly-loaded config therefore
+       knows NO port, so a spec-only reader would return None for the entire
+       fleet and this supervisor would be a silent no-op. ``sac agents start``
+       resolved that ``auto`` through ``_state.port_allocator.claim_port``, and
+       the claim is the durable record of the answer — it is what ``sac
+       listen`` routes on and what was threaded into the in-container
+       subscriber's ``--turn-url``. Verified against reality: the claim for
+       ``scitex-agent-container`` is 19016, which is both the ``--port`` of its
+       live bridge process and the URL its CCT poller POSTs to.
+
+    READ-ONLY on purpose: we look a claim UP, we never ``claim_port``. An agent
+    with no claim has no port anyone is POSTing to, so there is nothing to
+    supervise; inventing one would bind a port the subscriber never learned
+    about and burn a claim for an agent that is not even running.
+
+    ``a2a.port: None`` means the sidecar is DELIBERATELY disabled and must stay
+    that way, so it short-circuits BEFORE the claim lookup. The spec reader
+    alone cannot tell "disabled" from "auto" — both are simply "not an int" —
+    which is why that case is checked here explicitly.
+    """
+    from ..runtimes._tui_turn_bridge_lifecycle import resolved_a2a_port
+
+    pinned = resolved_a2a_port(config)
+    if pinned is not None:
+        return pinned
+    a2a = getattr(config, "a2a", None)
+    if a2a is None or getattr(a2a, "port", None) is None:
+        return None  # no a2a block, or sidecar explicitly disabled
+    lookup = port_lookup_fn if port_lookup_fn is not None else _default_port_lookup
+    claimed = lookup(str(getattr(config, "name", "") or ""))
+    if isinstance(claimed, bool):  # bool is an int subclass — reject explicitly
+        return None
+    if isinstance(claimed, int) and claimed > 0:
+        return claimed
+    return None
+
+
+def bridge_is_serving(
+    host: str, port: int, *, port_free_fn: Callable[[str, int], bool]
+) -> bool:
+    """True iff SOMETHING holds ``host:port`` — i.e. a bridge is up there.
+
+    Reuses the launcher's OWN
+    :func:`..runtimes._tui_turn_bridge_port.port_is_free` bind probe (the same
+    ``SO_REUSEADDR`` options ``_TurnBridgeServer`` sets), so "free" here means
+    exactly "the next ``start_turn_bridge`` would bind here". The supervisor
+    and the launcher can therefore never disagree about whether the port is
+    available, which is what keeps this from respawning into an EADDRINUSE.
+
+    A BIND PROBE, NOT AN HTTP PROBE, deliberately. It opens no connection,
+    cannot be delayed by a busy handler thread, and answers precisely the
+    question the respawn decision depends on. Whether a BOUND bridge is
+    actually *answering* is the HEALTH layer's question, and
+    :func:`.health._check_turn_bridge` asks it over real HTTP — the two probes
+    are complementary, and a bound-but-wedged or FOREIGN holder shows up red
+    there rather than being papered over here (re-spawning onto a held port
+    would only fail the launcher's own gate).
+    """
+    return not port_free_fn(host, port)
+
+
+def _pin_port(config: Any, port: int) -> None:
+    """Write the resolved ``port`` onto ``config.a2a`` for the launcher.
+
+    ``start_turn_bridge`` re-reads the port from the config it is handed, so a
+    config still carrying the literal ``"auto"`` would make it return None and
+    the respawn would silently do nothing. This is the same in-place mutation
+    ``_a2a_port.resolve_a2a_port`` performs at start; the config object is the
+    tick's own freshly-loaded copy, so nothing else observes it.
+    """
+    a2a = getattr(config, "a2a", None)
+    if a2a is not None:
+        a2a.port = port
+
+
+def _supervise_one(
+    agent: dict,
+    *,
+    name: str,
+    snapshot: dict,
+    port_free_fn: Callable[[str, int], bool],
+    start_fn: Callable[..., Any],
+    host_fn: Callable[[Any], str],
+    port_lookup_fn: Callable[[str], int | None] | None,
+) -> str:
+    """Re-assert one agent's bridge. Returns a ``VERDICT_*``. Never raises."""
+    if snapshot.get(f"{_SESSION_PREFIX}{name}") is None:
+        # No live tmux session: the agent is stopped/absent, so it must NOT
+        # have a bridge. Never resurrect one for a deliberately-stopped agent.
+        return VERDICT_NO_SESSION
+    config = agent.get("config")
+    if config is None:
+        return VERDICT_NO_CONFIG
+    try:
+        port = resolve_bridge_port(config, port_lookup_fn=port_lookup_fn)
+        if port is None:
+            return VERDICT_NO_PORT
+        host = host_fn(config)
+        if bridge_is_serving(host, port, port_free_fn=port_free_fn):
+            return VERDICT_SERVING
+    except Exception as exc:  # stx-allow: fallback (reason: per-agent best-effort — one agent's unreadable config / claim-DB hiccup must not abort supervision for the rest of the fleet; logged, skipped)
+        logger.warning(
+            "tui-bridge-supervisor: could not evaluate the bridge for %r "
+            "(skipped this tick): %s",
+            name,
+            exc,
+        )
+        return VERDICT_NO_PORT
+    # NOTHING IS BOUND but the agent is LIVE — this is the fault. Loud, because
+    # a silent self-heal would hide a crash-looping bridge behind a healthy
+    # port: every re-assertion is one death that went otherwise unexplained.
+    logger.warning(
+        "tui-bridge-supervisor: agent %r is LIVE but NOTHING is bound to its "
+        "turn-bridge port %s:%d — /v1/turn wake POSTs from its container are "
+        "being refused. Re-asserting the bridge now. (See "
+        "<runtime>/%s/tui-turn-bridge.log for why the previous one exited.)",
+        name,
+        host,
+        port,
+        name,
+    )
+    _pin_port(config, port)
+    try:
+        pid = start_fn(config, port_free_timeout_s=_RESPAWN_PORT_FREE_TIMEOUT_S)
+    except Exception as exc:  # stx-allow: fallback (reason: a respawn failure — e.g. a foreign process grabbing the port between probe and spawn — must not abort the tick for the other agents; surfaced at ERROR and retried next tick)
+        logger.error(
+            "tui-bridge-supervisor: FAILED to re-assert the turn bridge for %r "
+            "on %s:%d — this agent cannot be woken by a pushed message until "
+            "this succeeds. Retrying next tick. Cause: %s",
+            name,
+            host,
+            port,
+            exc,
+        )
+        return VERDICT_FAILED
+    if pid is None:
+        logger.error(
+            "tui-bridge-supervisor: re-assert for %r on %s:%d produced NO pid "
+            "(the launcher declined to spawn — missing config_path, or the "
+            "port went unresolvable). Retrying next tick.",
+            name,
+            host,
+            port,
+        )
+        return VERDICT_FAILED
+    logger.warning(
+        "tui-bridge-supervisor: re-asserted the turn bridge for %r on %s:%d "
+        "(pid=%s); /v1/turn is served again.",
+        name,
+        host,
+        port,
+        pid,
+    )
+    return VERDICT_RESTARTED
+
+
+def supervise_bridges(
+    agents: list,
+    *,
+    snapshot: dict,
+    port_free_fn: Callable[[str, int], bool] | None = None,
+    start_fn: Callable[..., Any] | None = None,
+    host_fn: Callable[[Any], str] | None = None,
+    port_lookup_fn: Callable[[str], int | None] | None = None,
+) -> dict:
+    """Re-assert the turn bridge for every LIVE TUI agent whose port is unbound.
+
+    ``agents`` are the records :func:`._tui_heartbeat_loop.list_tui_agents`
+    yields (``name`` / ``state_dir`` / ``config``); ``snapshot`` is the SAME
+    batched ``{session_name: activity_epoch}`` map the tick already fetched, so
+    supervision costs ZERO additional tmux calls — the only per-agent work is a
+    non-blocking bind probe.
+
+    Returns ``{agent_name: VERDICT_*}``. Never raises: every per-agent failure
+    is logged and converted to a verdict, so one bad agent cannot cost the rest
+    of the fleet its supervision.
+
+    Production defaults are bound when a seam is ``None``: ``port_free_fn`` →
+    ``runtimes._tui_turn_bridge_port.port_is_free``; ``start_fn`` →
+    ``runtimes._tui_turn_bridge_lifecycle.start_turn_bridge``; ``host_fn`` →
+    ``resolved_a2a_host``; ``port_lookup_fn`` →
+    ``_state.port_allocator.get_port``.
+    """
+    if os.environ.get(DISABLE_ENV, "") == "1":
+        return {}
+    if port_free_fn is None:
+        from ..runtimes._tui_turn_bridge_port import port_is_free as port_free_fn
+    if start_fn is None:
+        from ..runtimes._tui_turn_bridge_lifecycle import (
+            start_turn_bridge as start_fn,
+        )
+    if host_fn is None:
+        from ..runtimes._tui_turn_bridge_lifecycle import (
+            resolved_a2a_host as host_fn,
+        )
+
+    verdicts: dict = {}
+    for agent in list(agents):
+        if not isinstance(agent, dict):
+            continue
+        name = str(agent.get("name") or "")
+        if not name:
+            continue
+        verdicts[name] = _supervise_one(
+            agent,
+            name=name,
+            snapshot=snapshot,
+            port_free_fn=port_free_fn,
+            start_fn=start_fn,
+            host_fn=host_fn,
+            port_lookup_fn=port_lookup_fn,
+        )
+    return verdicts
+
+
+__all__ = [
+    "DISABLE_ENV",
+    "VERDICT_FAILED",
+    "VERDICT_NO_CONFIG",
+    "VERDICT_NO_PORT",
+    "VERDICT_NO_SESSION",
+    "VERDICT_RESTARTED",
+    "VERDICT_SERVING",
+    "bridge_is_serving",
+    "resolve_bridge_port",
+    "supervise_bridges",
+]

--- a/src/scitex_agent_container/_lifecycle/_tui_heartbeat_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_tui_heartbeat_loop.py
@@ -21,7 +21,15 @@ Every tick it:
   3. writes ``heartbeat.json`` for each agent present in that snapshot via
      :func:`_session_state.write_heartbeat`, stamping ``ts`` with the
      pane-activity epoch (the SAME liveness signal ``is_running`` keys
-     off) and ``state="running"``.
+     off) and ``state="running"``;
+  4. RE-ASSERTS each live agent's host-side ``/v1/turn`` turn bridge
+     (:mod:`._tui_bridge_supervisor`) — respawning it when nothing is bound
+     to the port it should serve. That bridge was spawned once at start and
+     supervised by nothing, so 14 of 15 on the host were dead PIDs while the
+     agents still read healthy and every pushed wake was refused. The tick
+     already enumerates exactly the right agents with a fresh liveness
+     snapshot, so it is the cheapest correct place to hold that promise —
+     no new daemon, no systemd unit.
 
 SCALING (the fleet-comms outage this shape fixes): step 1 used to be a
 per-agent probe — ``TmuxManager.exists`` (1 ``tmux`` spawn) plus
@@ -147,7 +155,11 @@ def list_tui_agents() -> list[dict]:
                 state_dir = state_dir_for_config(cfg)
             except Exception:  # stx-allow: fallback (resolver import/build may fail in a partial install)
                 state_dir = None
-        out.append({"name": name, "state_dir": state_dir})
+        # ``config`` rides along so the tick can supervise this agent's turn
+        # bridge without a SECOND ``load_config`` (we already paid for it
+        # above) — mirroring the record shape ``_sdk_heartbeat_loop`` already
+        # uses to hand its own tick a real config.
+        out.append({"name": name, "state_dir": state_dir, "config": cfg})
 
     try:
         for row in Registry().list_all():
@@ -223,6 +235,7 @@ async def tui_heartbeat_loop(
     write_fn: Any = None,
     tmux_check: Any = None,
     tick_timeout_s: float | None = None,
+    supervise_fn: Any = None,
 ) -> None:
     """Long-running TUI heartbeat-writer task for the listen lifespan.
 
@@ -231,7 +244,9 @@ async def tui_heartbeat_loop(
     :func:`_runners._tmux._tmux_probe.list_sessions_activity` (the ONE
     batched fleet probe); ``write_fn`` →
     :func:`_runners._session_state.write_heartbeat`; ``tmux_check`` →
-    :func:`_tmux_available`.
+    :func:`_tmux_available`; ``supervise_fn`` →
+    :func:`._tui_bridge_supervisor.supervise_bridges` (the turn-bridge
+    re-assertion — it reuses THIS tick's snapshot, so it adds no tmux calls).
 
     ``sessions_fn`` replaced the former per-agent ``session_exists_fn`` /
     ``activity_fn`` pair: those cost 3 ``tmux`` spawns per agent, so the
@@ -270,6 +285,9 @@ async def tui_heartbeat_loop(
         from .._runners._tmux._tmux_probe import list_sessions_activity as sessions_fn
     if write_fn is None:
         from .._runners._session_state import write_heartbeat as write_fn
+    if supervise_fn is None:
+        from ._tui_bridge_supervisor import supervise_bridges as supervise_fn
+    supervise = supervise_fn
 
     # OVERLAP GUARD. ``run_blocking_or`` abandons a tick that blows its
     # timeout, but the underlying THREAD keeps running (it is deliberately
@@ -306,8 +324,27 @@ async def tui_heartbeat_loop(
                     "(refusing to infer 'no sessions' from a failed probe)."
                 )
                 return
-            for agent in list(lister()):
+            agents = list(lister())
+            for agent in agents:
                 _beat_one(agent, snapshot=snapshot, write_fn=write_fn)
+            # RE-ASSERT THE TURN BRIDGE (2026-08-11 incident: 14 of 15
+            # host-side bridges were dead PIDs and nothing ever noticed — a
+            # live agent whose /v1/turn port is unbound silently refuses every
+            # pushed wake). Runs AFTER the beats so the primary duty is never
+            # delayed by a spawn, and reuses THIS tick's snapshot so it costs
+            # no extra tmux calls. Best-effort at the call site too: the
+            # supervisor already converts per-agent failures into verdicts, so
+            # anything escaping here is structural and must not cost the beats
+            # that were just written.
+            try:
+                supervise(agents, snapshot=snapshot)
+            except Exception as exc:  # stx-allow: fallback (reason: bridge supervision is additive to the heartbeat's primary duty — a failure in it must never abort a tick that already wrote fresh liveness data; logged, retried next tick)
+                logger.warning(
+                    "tui_heartbeat_loop: turn-bridge supervision failed this "
+                    "tick (%s); heartbeats were still written, retrying next "
+                    "tick",
+                    exc,
+                )
         finally:
             tick_lock.release()
 

--- a/src/scitex_agent_container/_lifecycle/health.py
+++ b/src/scitex_agent_container/_lifecycle/health.py
@@ -17,13 +17,31 @@ def health_check(
 ) -> tuple[bool, str]:
     """Run a single health check. Returns (is_healthy, message).
 
-    Two methods:
+    Three methods:
       * ``sdk-alive`` (default) — ask THE CONFIG'S runtime whether its
         process is up. The name is historical: it resolves through
         ``_get_runtime``, so a ``tui`` spec is asked via
         ``TuiSessionRuntime`` and an SDK spec via ``ClaudeSessionRuntime``.
+        For a ``tui`` agent this ALSO gates on the turn bridge — see below.
       * ``a2a-card`` — probe the A2A AgentCard endpoint (higher
         fidelity, confirms the HTTP surface is actually serving).
+      * ``turn-bridge`` — probe the TUI turn bridge's ``/health`` alone.
+
+    THE TURN-BRIDGE GATE (2026-08-11 incident). ``sdk-alive`` asks only "is
+    the tmux session alive?", so on the night 14 of 15 host-side turn bridges
+    were dead PIDs, every one of those agents reported GREEN while every
+    pushed ``/v1/turn`` wake was refused. Health could not see the fault, and
+    ``a2a-card`` — the only HTTP-fidelity option — was no help even when
+    opted into: it probes
+    ``/agents/<name>/.well-known/agent-card.json``, a route the TUI bridge
+    does NOT serve (``_tui_turn_bridge`` answers ``GET /health`` and 404s
+    everything else), so it fails against a perfectly healthy bridge. So the
+    DEFAULT path now additionally requires the bridge to answer on the route
+    it really serves. A dead bridge must not report green.
+
+    The gate applies ONLY to ``runtime: tui`` agents that actually have a
+    resolved a2a port — an agent with the sidecar disabled has no bridge to
+    miss, and a non-TUI agent serves ``/v1/turn`` from its own SDK runner.
 
     Parameters
     ----------
@@ -34,9 +52,16 @@ def health_check(
     """
     method = config.health.method or "sdk-alive"
     if method == "sdk-alive":
-        return _check_sdk_alive(config, runtime=runtime)
+        alive, message = _check_sdk_alive(config, runtime=runtime)
+        if not alive:
+            # A dead runtime dominates: reporting "bridge down" for an agent
+            # whose session is gone would name a symptom instead of the cause.
+            return alive, message
+        return _gate_on_turn_bridge(config, message)
     if method == "a2a-card":
         return _check_a2a_card(config)
+    if method == "turn-bridge":
+        return _check_turn_bridge(config)
     return False, f"Unknown health method: {method}"
 
 
@@ -88,6 +113,182 @@ def _check_sdk_alive(
     # SDK process that a tui agent never had.
     kind = (getattr(config, "runtime", "") or "tui").strip() or "tui"
     return False, f"unhealthy: {kind} runtime reports its process not running"
+
+
+def _is_tui_runtime(config: AgentConfig) -> bool:
+    """True iff this spec runs under the TUI runtime (the default when unset).
+
+    Mirrors ``_runtime_select._get_runtime``'s mapping — ``""`` and ``"tui"``
+    both mean TuiSessionRuntime — so the gate covers exactly the agents that
+    HAVE a host-side turn bridge.
+    """
+    return (getattr(config, "runtime", "") or "tui").strip() in ("", "tui")
+
+
+def _gate_on_turn_bridge(config: AgentConfig, healthy_message: str) -> tuple[bool, str]:
+    """Require a live turn bridge before an ALREADY-alive TUI agent reads green.
+
+    Returns ``healthy_message`` unchanged for anything with no bridge to miss
+    (a non-TUI runtime, or a TUI agent whose a2a sidecar is disabled /
+    unclaimed), so this can never invent a failure for an agent that never had
+    the endpoint in the first place.
+    """
+    if not _is_tui_runtime(config):
+        return True, healthy_message
+    from ._tui_bridge_supervisor import resolve_bridge_port
+
+    if resolve_bridge_port(config) is None:
+        return True, healthy_message
+    bridge_ok, bridge_message = _check_turn_bridge(config)
+    if not bridge_ok:
+        return False, bridge_message
+    return True, f"{healthy_message}; {bridge_message}"
+
+
+# How many times a FAILING bridge probe is repeated before the verdict stands,
+# and how long between attempts. See ``_check_turn_bridge`` for why a single
+# observation is not enough.
+_BRIDGE_PROBE_ATTEMPTS = 3
+_BRIDGE_PROBE_BACKOFF_S = 0.5
+
+
+def _probe_turn_bridge_once(
+    *, url: str, port: int, agent_name: str, remediation: str
+) -> tuple[bool, str, bool]:
+    """One GET of the bridge's ``/health``. Returns ``(ok, message, retryable)``.
+
+    ``retryable`` marks the verdicts a SECOND look could legitimately overturn
+    — a refused connection, a timeout, a transient non-200. An identity
+    mismatch is deliberately NOT retryable: a foreign process holding the port
+    is a settled fact, and re-asking only delays a report that will not change.
+    """
+    import json
+    import urllib.error
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            status = int(getattr(resp, "status", 0) or resp.getcode())
+            raw = resp.read()
+    except (
+        urllib.error.HTTPError
+    ) as exc:  # stx-allow: fallback (reason: expected failure — a non-200 from the bridge is a health verdict, not a crash)
+        return (
+            False,
+            f"unhealthy: turn bridge HTTP {exc.code} from {url} — {remediation}",
+            True,
+        )
+    except (
+        urllib.error.URLError,
+        OSError,
+    ) as exc:  # stx-allow: fallback (reason: connection refused / timeout IS the fault being detected — report it as a verdict, do not raise)
+        return (
+            False,
+            f"unhealthy: turn bridge unreachable at {url} ({exc}) — {remediation}",
+            True,
+        )
+    if status != 200:
+        return (
+            False,
+            f"unhealthy: turn bridge HTTP {status} from {url} — {remediation}",
+            True,
+        )
+    try:
+        payload = json.loads(raw or b"")
+    except (
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:  # stx-allow: fallback (reason: a non-JSON 200 means something that is NOT our bridge holds the port — a health verdict, not a crash)
+        return (
+            False,
+            f"unhealthy: {url} returned 200 but not our bridge's JSON ({exc}) — "
+            f"something else is holding port {port}",
+            False,
+        )
+    served = payload.get("agent") if isinstance(payload, dict) else None
+    if served != agent_name:
+        return (
+            False,
+            f"unhealthy: {url} is served by agent {served!r}, not {agent_name!r} "
+            f"— a FOREIGN process holds this agent's turn-bridge port {port}",
+            False,
+        )
+    return True, "", False
+
+
+def _check_turn_bridge(
+    config: AgentConfig,
+    *,
+    attempts: int = _BRIDGE_PROBE_ATTEMPTS,
+    backoff_s: float = _BRIDGE_PROBE_BACKOFF_S,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> tuple[bool, str]:
+    """Probe the TUI turn bridge's ``GET /health`` — the route it really serves.
+
+    The bridge answers ``200 {"status": "ok", "agent": "<name>"}`` on
+    ``/health`` and 404s every other GET (``_tui_turn_bridge._TurnBridgeHandler
+    .do_GET``), so this is the ONLY GET that can distinguish "serving" from
+    "dead" — which is why the pre-existing ``a2a-card`` probe (which asks for
+    ``/agents/<name>/.well-known/agent-card.json``) could not be reused: it
+    fails against a perfectly healthy bridge.
+
+    Address resolution goes through the SAME helpers the launcher uses
+    (``resolved_a2a_host`` + ``_tui_bridge_supervisor.resolve_bridge_port``,
+    which falls back to the allocator's claim because fleet specs declare
+    ``a2a.port: auto``), so health probes exactly where the bridge binds rather
+    than where the raw YAML appears to point.
+
+    CORROBORATED, NOT SINGLE-SHOT. A failing probe is repeated ``attempts``
+    times ``backoff_s`` apart and the agent is only failed when EVERY attempt
+    fails; any success returns healthy immediately. This is the same discipline
+    ``_agents_restart_login_expired`` already applies ("READ-ONLY +
+    2-run-corroborated"), and it is not optional here for a reason of our own
+    making: the heartbeat supervisor RESPAWNS a dead bridge, and a respawn has
+    a genuine sub-second window where the old process is gone and the new one
+    has not bound yet. A single-shot probe landing in that window would report
+    a self-healing system as broken. The cost is bounded and paid only by
+    already-failing agents — a truly dead bridge refuses instantly, so the
+    whole corroboration costs ~1s of sleeps, while a healthy bridge answers on
+    the first attempt and never sleeps at all.
+
+    The response IDENTITY is checked, not just the status code: a foreign
+    process holding this agent's port would answer 200 for something else, and
+    calling that healthy would be the same blindness in a new place.
+    """
+    from ..runtimes._tui_turn_bridge_lifecycle import resolved_a2a_host
+    from ._tui_bridge_supervisor import resolve_bridge_port
+
+    port = resolve_bridge_port(config)
+    if port is None:
+        return False, (
+            f"unhealthy: agent {config.name!r} has no resolved a2a port, so its "
+            "turn bridge cannot be probed (spec.a2a disabled, or no port claim "
+            "— has the agent been started?)"
+        )
+    host = resolved_a2a_host(config)
+    url = f"http://{host}:{port}/health"
+    remediation = (
+        f"the host-side turn bridge for {config.name!r} is NOT serving {url}, so "
+        "every pushed /v1/turn wake from its container is refused and the agent "
+        "cannot be driven by a message. `sac listen`'s TUI heartbeat tick "
+        "re-asserts it within ~30s; if this persists, read "
+        f"<runtime>/{config.name}/tui-turn-bridge.log for why it exits"
+    )
+    total = max(1, int(attempts))
+    t0 = time.time()
+    message = ""
+    for attempt in range(1, total + 1):
+        ok, message, retryable = _probe_turn_bridge_once(
+            url=url, port=port, agent_name=config.name, remediation=remediation
+        )
+        if ok:
+            elapsed_ms = int((time.time() - t0) * 1000)
+            return True, f"turn bridge healthy ({elapsed_ms} ms via {host}:{port})"
+        if not retryable:
+            return False, message
+        if attempt < total:
+            sleep_fn(backoff_s)
+    return False, f"{message} [confirmed by {total} probes {backoff_s}s apart]"
 
 
 def _check_a2a_card(config: AgentConfig) -> tuple[bool, str]:

--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -48,9 +48,12 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import signal
+import sys
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, Callable
+from typing import IO, Any, Callable
 
 from ..config import AgentConfig
 from ._tui_turn_bridge_lifecycle import (
@@ -194,6 +197,64 @@ class _TurnBridgeHandler(BaseHTTPRequestHandler):
         )
 
 
+# ---------------------------------------------------------------------------
+# Lifecycle log
+# ---------------------------------------------------------------------------
+def write_bridge_event(
+    stream: IO[str],
+    event: str,
+    *,
+    agent: str,
+    host: str,
+    port: int,
+    pid: int,
+    now_fn: Callable[[], float] = time.time,
+) -> str:
+    """Write ONE lifecycle line to ``stream``, flush it, and return it.
+
+    WHY THIS EXISTS: ``tui-turn-bridge.log`` was 0 bytes for 16 of the 17
+    agents on the host. The launcher opens it (``open(..., "ab")`` in
+    ``_tui_turn_bridge_lifecycle``) and hands it to the child as BOTH stdout
+    and stderr — but the bridge never wrote a single line of its own, so the
+    file only ever captured an UNHANDLED traceback. When 14 bridges were found
+    dead on 2026-08-11, the cause of not one of those deaths could be
+    recovered: no bind line to prove it ever served, no shutdown line to say
+    whether it exited on a signal or vanished. A log that is empty on the happy
+    path cannot bracket a failure.
+
+    Two lines is the whole contract — one after the bind, one on the way out —
+    so an operator reading the file can always answer "did it serve, and did it
+    leave cleanly?". The flush is load-bearing: the child's stdio is a
+    block-buffered pipe onto a file, so an unflushed bind line would be lost
+    in exactly the crash it is meant to explain.
+    """
+    stamp = time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime(now_fn()))
+    line = (
+        f"{stamp} tui-turn-bridge {event} "
+        f"agent={agent} host={host} port={port} pid={pid}\n"
+    )
+    stream.write(line)
+    stream.flush()
+    return line
+
+
+def _emit(
+    event: str, *, agent: str, host: str, port: int
+) -> None:  # pragma: no cover - thin best-effort wrapper over write_bridge_event, which is unit-tested directly
+    """Best-effort :func:`write_bridge_event` onto the launcher's log fd.
+
+    Swallows deliberately: the log is a DIAGNOSTIC, and a bridge that cannot
+    write its own log line must still serve turns — degrading wake-on-push to
+    restore a log file would trade the incident for a worse one.
+    """
+    try:
+        write_bridge_event(
+            sys.stderr, event, agent=agent, host=host, port=port, pid=os.getpid()
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: the lifecycle log is diagnostic only — an unwritable log fd must never stop the bridge from serving /v1/turn, which is the whole point of the process)
+        log.warning("tui-turn-bridge: could not write %s log line: %s", event, exc)
+
+
 def build_server(
     *, host: str, port: int, on_turn: Callable[..., None], agent_name: str
 ) -> _TurnBridgeServer:
@@ -225,10 +286,17 @@ def serve(  # pragma: no cover - integration entry: installs main-thread-only si
     signal.signal(signal.SIGTERM, _graceful)
     signal.signal(signal.SIGINT, _graceful)
     log.info("tui-turn-bridge: serving %s on %s:%d", agent_name, host, port)
+    # The bind SUCCEEDED — record it in the durable per-agent log. Emitted here
+    # rather than before ``build_server`` so the line is proof the socket is
+    # actually held, not merely that the process started.
+    _emit("bind", agent=agent_name, host=host, port=port)
     try:
         server.serve_forever()
     finally:
         server.server_close()
+        # Brackets the bind line: its ABSENCE next to a bind line is itself the
+        # diagnosis (the process was killed rather than signalled).
+        _emit("shutdown", agent=agent_name, host=host, port=port)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_lifecycle/test__tui_bridge_supervisor.py
+++ b/tests/scitex_agent_container/_lifecycle/test__tui_bridge_supervisor.py
@@ -1,0 +1,375 @@
+"""Tests for the TUI turn-bridge supervisor (the heartbeat-tick re-assertion).
+
+Guards the 2026-08-11 incident: 14 of 15 host-side turn bridges were dead
+PIDs, nothing supervised them, and live agents whose ``/v1/turn`` port was
+unbound refused every pushed wake while still reporting healthy.
+
+No mocks. Every collaborator is real:
+  * ``AgentConfig`` / ``A2ASpec`` are the production dataclasses.
+  * The port probe is the production ``port_is_free`` bind probe, run against
+    REAL sockets that are really bound / really free.
+  * The launcher seam is a hand-rolled recording callable with the real
+    ``start_turn_bridge`` shape (the module's documented DI seam).
+
+STX-TQ002 AAA-markers each on its own line + STX-TQ007 one-assert.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+import pytest
+
+from scitex_agent_container._lifecycle._tui_bridge_supervisor import (
+    DISABLE_ENV,
+    VERDICT_FAILED,
+    VERDICT_NO_CONFIG,
+    VERDICT_NO_SESSION,
+    VERDICT_RESTARTED,
+    VERDICT_SERVING,
+    bridge_is_serving,
+    resolve_bridge_port,
+    supervise_bridges,
+)
+from scitex_agent_container.config._types import A2ASpec, AgentConfig
+
+# The REAL bind probe the launcher itself uses — injected as the seam so the
+# supervisor's "is anything bound?" question is answered by production code.
+from scitex_agent_container.runtimes._tui_turn_bridge_port import port_is_free
+
+PINNED_ACTIVITY_TS = 1_750_000_000
+
+# The supervisor looks an agent up under its ``tui-<name>`` session key, the
+# same convention the heartbeat writer uses.
+LIVE_SNAPSHOT = {"tui-ag1": PINNED_ACTIVITY_TS, "tui-ag2": PINNED_ACTIVITY_TS}
+EMPTY_SNAPSHOT: dict = {}
+
+
+def _cfg(name: str = "ag1", *, port: Any = "auto", host: str = "127.0.0.1"):
+    """A real AgentConfig carrying a real A2ASpec."""
+    cfg = AgentConfig(name=name)
+    cfg.a2a = A2ASpec(host=host, port=port)
+    return cfg
+
+
+def _agent(name: str = "ag1", *, port: Any = "auto"):
+    """One record in the shape ``list_tui_agents`` yields."""
+    return {"name": name, "state_dir": None, "config": _cfg(name, port=port)}
+
+
+class RecordingStart:
+    """Real callable with ``start_turn_bridge``'s shape (the launcher seam).
+
+    Records every call so a test can assert WHETHER the bridge was respawned
+    and WITH WHAT port — the behaviour under test — without a mock framework.
+    """
+
+    def __init__(self, *, pid: int | None = 4242, raises: Exception | None = None):
+        self.calls: list[tuple[Any, dict]] = []
+        self.pid = pid
+        self.raises = raises
+
+    def __call__(self, config: Any, **kwargs: Any) -> int | None:
+        self.calls.append((config, kwargs))
+        if self.raises is not None:
+            raise self.raises
+        return self.pid
+
+
+@contextmanager
+def _really_bound_port() -> Iterator[int]:
+    """Yield a port with a REAL listening socket on it (bridge-is-up case)."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    try:
+        yield sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+def _really_free_port() -> int:
+    """Return a port nothing is bound to (bridge-is-dead case)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# resolve_bridge_port — where the supervisor believes the bridge lives
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_bridge_port_returns_the_operator_pinned_int() -> None:
+    # Arrange — a spec with a concrete port needs no claim lookup.
+    cfg = _cfg(port=19016)
+    # Act
+    port = resolve_bridge_port(cfg, port_lookup_fn=lambda _n: None)
+    # Assert
+    assert port == 19016
+
+
+def test_resolve_bridge_port_falls_back_to_the_allocator_claim_for_auto() -> None:
+    # Arrange — every fleet TUI spec declares "auto"; only the claim knows.
+    cfg = _cfg(name="scitex-live-paper", port="auto")
+    # Act
+    port = resolve_bridge_port(cfg, port_lookup_fn=lambda _n: 19015)
+    # Assert
+    assert port == 19015
+
+
+def test_resolve_bridge_port_looks_the_claim_up_under_the_agent_name() -> None:
+    # Arrange — record which name the claim table is asked about.
+    cfg = _cfg(name="scitex-live-paper", port="auto")
+    asked: list[str] = []
+
+    def _lookup(name: str) -> int | None:
+        asked.append(name)
+        return 19015
+
+    # Act
+    resolve_bridge_port(cfg, port_lookup_fn=_lookup)
+    # Assert
+    assert asked == ["scitex-live-paper"]
+
+
+def test_resolve_bridge_port_is_none_when_the_sidecar_is_disabled() -> None:
+    # Arrange — port: None means "no inbound HTTP", and must stay that way.
+    cfg = _cfg(port=None)
+    # Act
+    port = resolve_bridge_port(cfg, port_lookup_fn=lambda _n: 19015)
+    # Assert
+    assert port is None
+
+
+def test_resolve_bridge_port_never_consults_the_claim_when_disabled() -> None:
+    # Arrange — a disabled sidecar must short-circuit BEFORE the lookup.
+    cfg = _cfg(port=None)
+    asked: list[str] = []
+    # Act
+    resolve_bridge_port(cfg, port_lookup_fn=lambda n: asked.append(n) or 19015)
+    # Assert
+    assert asked == []
+
+
+def test_resolve_bridge_port_is_none_when_no_claim_exists() -> None:
+    # Arrange — an agent that never started has no port anyone POSTs to.
+    cfg = _cfg(port="auto")
+    # Act
+    port = resolve_bridge_port(cfg, port_lookup_fn=lambda _n: None)
+    # Assert
+    assert port is None
+
+
+# ---------------------------------------------------------------------------
+# bridge_is_serving — the real bind probe against real sockets
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_is_serving_is_true_for_a_really_bound_port() -> None:
+    # Arrange — a real listening socket stands in for a live bridge.
+    serving = None
+    # Act
+    with _really_bound_port() as port:
+        serving = bridge_is_serving("127.0.0.1", port, port_free_fn=port_is_free)
+    # Assert
+    assert serving is True
+
+
+def test_bridge_is_serving_is_false_for_a_really_free_port() -> None:
+    # Arrange — nothing is bound here: the dead-bridge case.
+    port = _really_free_port()
+    # Act
+    serving = bridge_is_serving("127.0.0.1", port, port_free_fn=port_is_free)
+    # Assert
+    assert serving is False
+
+
+# ---------------------------------------------------------------------------
+# supervise_bridges — the fix: a live agent with an unbound port is repaired
+# ---------------------------------------------------------------------------
+
+
+def test_supervisor_restarts_the_bridge_when_the_port_is_unbound() -> None:
+    # Arrange — live tmux session, nothing bound: the measured fault.
+    start = RecordingStart()
+    agents = [_agent("ag1", port=_really_free_port())]
+    # Act
+    supervise_bridges(
+        agents, snapshot=dict(LIVE_SNAPSHOT), start_fn=start, port_free_fn=port_is_free
+    )
+    # Assert
+    assert len(start.calls) == 1
+
+
+def test_supervisor_verdict_is_restarted_when_the_port_was_unbound() -> None:
+    # Arrange
+    start = RecordingStart()
+    agents = [_agent("ag1", port=_really_free_port())]
+    # Act
+    verdicts = supervise_bridges(
+        agents, snapshot=dict(LIVE_SNAPSHOT), start_fn=start, port_free_fn=port_is_free
+    )
+    # Assert
+    assert verdicts["ag1"] == VERDICT_RESTARTED
+
+
+def test_supervisor_pins_the_resolved_port_onto_the_config_it_relaunches() -> None:
+    # Arrange — an "auto" spec must reach the launcher as a concrete int, or
+    # start_turn_bridge re-reads "auto", returns None and repairs nothing.
+    start = RecordingStart()
+    free_port = _really_free_port()
+    agents = [_agent("ag1", port="auto")]
+    # Act
+    supervise_bridges(
+        agents,
+        snapshot=dict(LIVE_SNAPSHOT),
+        start_fn=start,
+        port_free_fn=port_is_free,
+        port_lookup_fn=lambda _n: free_port,
+    )
+    # Assert
+    assert start.calls[0][0].a2a.port == free_port
+
+
+def test_supervisor_does_not_relaunch_when_the_port_is_already_bound() -> None:
+    # Arrange — a healthy bridge must never be disturbed.
+    start = RecordingStart()
+    with _really_bound_port() as port:
+        agents = [_agent("ag1", port=port)]
+        # Act
+        supervise_bridges(
+            agents,
+            snapshot=dict(LIVE_SNAPSHOT),
+            start_fn=start,
+            port_free_fn=port_is_free,
+        )
+    # Assert
+    assert start.calls == []
+
+
+def test_supervisor_verdict_is_serving_when_the_port_is_bound() -> None:
+    # Arrange
+    start = RecordingStart()
+    with _really_bound_port() as port:
+        agents = [_agent("ag1", port=port)]
+        # Act
+        verdicts = supervise_bridges(
+            agents,
+            snapshot=dict(LIVE_SNAPSHOT),
+            start_fn=start,
+            port_free_fn=port_is_free,
+        )
+    # Assert
+    assert verdicts["ag1"] == VERDICT_SERVING
+
+
+def test_supervisor_never_relaunches_for_an_agent_with_no_tmux_session() -> None:
+    # Arrange — a deliberately-stopped agent must NOT get a resurrected bridge.
+    start = RecordingStart()
+    agents = [_agent("ag1", port=_really_free_port())]
+    # Act
+    supervise_bridges(
+        agents, snapshot=dict(EMPTY_SNAPSHOT), start_fn=start, port_free_fn=port_is_free
+    )
+    # Assert
+    assert start.calls == []
+
+
+def test_supervisor_verdict_is_no_session_for_a_stopped_agent() -> None:
+    # Arrange
+    start = RecordingStart()
+    agents = [_agent("ag1", port=_really_free_port())]
+    # Act
+    verdicts = supervise_bridges(
+        agents, snapshot=dict(EMPTY_SNAPSHOT), start_fn=start, port_free_fn=port_is_free
+    )
+    # Assert
+    assert verdicts["ag1"] == VERDICT_NO_SESSION
+
+
+def test_supervisor_reports_failed_when_the_launcher_raises() -> None:
+    # Arrange — e.g. a foreign process grabbed the port between probe and spawn.
+    start = RecordingStart(raises=RuntimeError("port busy"))
+    agents = [_agent("ag1", port=_really_free_port())]
+    # Act
+    verdicts = supervise_bridges(
+        agents, snapshot=dict(LIVE_SNAPSHOT), start_fn=start, port_free_fn=port_is_free
+    )
+    # Assert
+    assert verdicts["ag1"] == VERDICT_FAILED
+
+
+def test_supervisor_reports_failed_when_the_launcher_returns_no_pid() -> None:
+    # Arrange — start_turn_bridge swallows a spawn failure and returns None.
+    start = RecordingStart(pid=None)
+    agents = [_agent("ag1", port=_really_free_port())]
+    # Act
+    verdicts = supervise_bridges(
+        agents, snapshot=dict(LIVE_SNAPSHOT), start_fn=start, port_free_fn=port_is_free
+    )
+    # Assert
+    assert verdicts["ag1"] == VERDICT_FAILED
+
+
+def test_one_agents_failure_does_not_cost_the_next_agent_its_supervision() -> None:
+    # Arrange — the first agent's launcher raises; the second must still run.
+    calls: list[str] = []
+
+    def _start(config: Any, **_kw: Any) -> int:
+        calls.append(config.name)
+        if config.name == "ag1":
+            raise RuntimeError("boom")
+        return 4242
+
+    agents = [_agent("ag1", port=_really_free_port()), _agent("ag2", port=_really_free_port())]
+    # Act
+    supervise_bridges(
+        agents, snapshot=dict(LIVE_SNAPSHOT), start_fn=_start, port_free_fn=port_is_free
+    )
+    # Assert
+    assert calls == ["ag1", "ag2"]
+
+
+def test_supervisor_skips_a_record_that_carries_no_config() -> None:
+    # Arrange — a lister that could not load the spec yields no config.
+    start = RecordingStart()
+    agents = [{"name": "ag1", "state_dir": None}]
+    # Act
+    verdicts = supervise_bridges(
+        agents, snapshot=dict(LIVE_SNAPSHOT), start_fn=start, port_free_fn=port_is_free
+    )
+    # Assert
+    assert verdicts["ag1"] == VERDICT_NO_CONFIG
+
+
+@pytest.fixture
+def supervision_disabled() -> Iterator[None]:
+    """Set the REAL kill-switch env var, and really remove it on teardown."""
+    previous = os.environ.get(DISABLE_ENV)
+    os.environ[DISABLE_ENV] = "1"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(DISABLE_ENV, None)
+        else:
+            os.environ[DISABLE_ENV] = previous
+
+
+def test_supervisor_is_a_no_op_under_the_env_kill_switch(
+    supervision_disabled: None,
+) -> None:
+    # Arrange
+    start = RecordingStart()
+    agents = [_agent("ag1", port=_really_free_port())]
+    # Act
+    supervise_bridges(
+        agents, snapshot=dict(LIVE_SNAPSHOT), start_fn=start, port_free_fn=port_is_free
+    )
+    # Assert
+    assert start.calls == []

--- a/tests/scitex_agent_container/_lifecycle/test__tui_heartbeat_loop.py
+++ b/tests/scitex_agent_container/_lifecycle/test__tui_heartbeat_loop.py
@@ -433,3 +433,110 @@ async def test_default_interval_is_thirty_seconds():
     value = DEFAULT_TUI_HEARTBEAT_INTERVAL_S
     # Assert
     assert value == 30.0
+
+
+# ---------------------------------------------------------------------------
+# Turn-bridge supervision rides on the SAME tick (2026-08-11 incident)
+# ---------------------------------------------------------------------------
+# The host-side /v1/turn bridge is spawned once at start and was supervised by
+# nothing, so 14 of 15 on the host were dead PIDs while their agents still read
+# healthy and every pushed wake was refused. This tick already enumerates every
+# TUI agent with a fresh liveness snapshot, so it re-asserts the bridge too.
+
+
+class RecordingSupervisor:
+    """Real callable with ``supervise_bridges``' shape (the DI seam)."""
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def __call__(self, agents, *, snapshot):
+        self.calls.append((list(agents), dict(snapshot)))
+        return {}
+
+
+class ExplodingSupervisor:
+    """A supervisor that fails, to prove it cannot cost the heartbeat."""
+
+    def __call__(self, agents, *, snapshot):
+        raise RuntimeError("supervision blew up")
+
+
+@pytest.mark.asyncio
+async def test_the_tick_supervises_the_turn_bridge(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    supervisor = RecordingSupervisor()
+    # Act
+    await _run_one_tick(
+        settle_for=lambda: bool(supervisor.calls),
+        agent_lister=_one_tui_agent(state_dir),
+        sessions_fn=lambda: dict(LIVE_SNAPSHOT),
+        write_fn=write_heartbeat,
+        tmux_check=lambda: True,
+        supervise_fn=supervisor,
+    )
+    # Assert
+    assert len(supervisor.calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_supervision_reuses_this_ticks_snapshot(tmp_path: Path):
+    # Arrange — reusing the batched snapshot is what keeps supervision free of
+    # extra tmux subprocesses (the cost that got this tick abandoned once).
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    supervisor = RecordingSupervisor()
+    # Act
+    await _run_one_tick(
+        settle_for=lambda: bool(supervisor.calls),
+        agent_lister=_one_tui_agent(state_dir),
+        sessions_fn=lambda: dict(LIVE_SNAPSHOT),
+        write_fn=write_heartbeat,
+        tmux_check=lambda: True,
+        supervise_fn=supervisor,
+    )
+    # Assert
+    assert supervisor.calls[0][1] == LIVE_SNAPSHOT
+
+
+@pytest.mark.asyncio
+async def test_no_supervision_when_the_tmux_probe_failed(tmp_path: Path):
+    # Arrange — a failed probe means liveness is UNKNOWN, and respawning a
+    # bridge on a guess is the same "infer dead from unknown" mistake the
+    # heartbeat writer already refuses to make.
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    supervisor = RecordingSupervisor()
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_tui_agent(state_dir),
+        sessions_fn=lambda: None,
+        write_fn=write_heartbeat,
+        tmux_check=lambda: True,
+        supervise_fn=supervisor,
+    )
+    # Assert
+    assert supervisor.calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_failing_supervisor_still_leaves_the_heartbeat_written(
+    tmp_path: Path,
+):
+    # Arrange — liveness data is the tick's primary duty and must survive a
+    # supervision failure.
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    # Act
+    await _run_one_tick(
+        settle_for=lambda: (state_dir / "heartbeat.json").is_file(),
+        agent_lister=_one_tui_agent(state_dir),
+        sessions_fn=lambda: dict(LIVE_SNAPSHOT),
+        write_fn=write_heartbeat,
+        tmux_check=lambda: True,
+        supervise_fn=ExplodingSupervisor(),
+    )
+    # Assert
+    assert (state_dir / "heartbeat.json").is_file()

--- a/tests/scitex_agent_container/_lifecycle/test_health.py
+++ b/tests/scitex_agent_container/_lifecycle/test_health.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import socket
 import threading
+from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any, Iterator
@@ -25,10 +26,12 @@ import pytest
 from scitex_agent_container._lifecycle import health as health_mod
 from scitex_agent_container._state.registry import Registry
 from scitex_agent_container.config._types import (
+    A2ASpec,
     AgentConfig,
     HealthSpec,
     RestartSpec,
 )
+from scitex_agent_container.runtimes._tui_turn_bridge import build_server
 
 # ---------------------------------------------------------------------------
 # Real fakes & helpers (no unittest.mock)
@@ -593,3 +596,229 @@ def test_health_monitor_no_restart_fn_with_unhealthy_returns_cleanly(
     )
     # Assert: loop polled at least once with no restart callable and exited.
     assert len(check.calls) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Turn-bridge health gate (2026-08-11 incident)
+# ---------------------------------------------------------------------------
+# 14 of 15 host-side TUI turn bridges were dead PIDs and every one of those
+# agents still reported GREEN, because `sdk-alive` only asks whether the tmux
+# session is alive. These tests pin the gate that makes a dead bridge fail.
+#
+# The server under test is the PRODUCTION `_TurnBridgeServer` (via the real
+# `build_server`), so the `/health` route being probed is the actual route the
+# real bridge serves — not a stand-in that could drift away from it.
+
+
+@contextmanager
+def _real_turn_bridge(*, port: int, agent_name: str) -> Iterator[Any]:
+    """Run a REAL turn bridge on ``port`` in a background thread."""
+    server = build_server(
+        host="127.0.0.1",
+        port=port,
+        on_turn=lambda *_a, **_kw: None,
+        agent_name=agent_name,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _bridge_cfg(
+    name: str = "ag1",
+    *,
+    port: Any,
+    runtime: str = "tui",
+    method: str = "sdk-alive",
+) -> AgentConfig:
+    """A real config whose a2a port is pinned (no claim lookup needed)."""
+    cfg = _make_cfg(name=name, method=method)
+    cfg.runtime = runtime
+    cfg.a2a = A2ASpec(host="127.0.0.1", port=port)
+    return cfg
+
+
+def _no_delay(_seconds: float) -> None:
+    """Real sleep seam that does not actually sleep."""
+    return None
+
+
+def test_sdk_alive_fails_a_live_tui_agent_whose_turn_bridge_is_dead() -> None:
+    # Arrange — the measured fault: tmux session alive, nothing bound to the
+    # a2a port. This is the case that used to report healthy.
+    cfg = _bridge_cfg(port=_free_port())
+    # Act
+    healthy, _message = health_mod.health_check(cfg, runtime=FakeRuntime(running=True))
+    # Assert
+    assert healthy is False
+
+
+def test_dead_turn_bridge_message_names_the_unserved_url() -> None:
+    # Arrange
+    port = _free_port()
+    cfg = _bridge_cfg(port=port)
+    # Act
+    _healthy, message = health_mod.health_check(cfg, runtime=FakeRuntime(running=True))
+    # Assert
+    assert f"http://127.0.0.1:{port}/health" in message
+
+
+def test_sdk_alive_passes_a_tui_agent_whose_turn_bridge_is_serving() -> None:
+    # Arrange — a REAL bridge on the agent's port.
+    port = _free_port()
+    cfg = _bridge_cfg(port=port)
+    # Act
+    with _real_turn_bridge(port=port, agent_name="ag1"):
+        healthy, _message = health_mod.health_check(
+            cfg, runtime=FakeRuntime(running=True)
+        )
+    # Assert
+    assert healthy is True
+
+
+def test_healthy_message_reports_the_turn_bridge_alongside_the_runtime() -> None:
+    # Arrange
+    port = _free_port()
+    cfg = _bridge_cfg(port=port)
+    # Act
+    with _real_turn_bridge(port=port, agent_name="ag1"):
+        _healthy, message = health_mod.health_check(
+            cfg, runtime=FakeRuntime(running=True)
+        )
+    # Assert
+    assert "turn bridge healthy" in message
+
+
+def test_a_dead_runtime_dominates_the_bridge_verdict() -> None:
+    # Arrange — a stopped agent must be reported as a stopped RUNTIME, not as
+    # a missing bridge (naming the symptom would send the reader hunting).
+    cfg = _bridge_cfg(port=_free_port())
+    # Act
+    _healthy, message = health_mod.health_check(cfg, runtime=FakeRuntime(running=False))
+    # Assert
+    assert "runtime reports its process not running" in message
+
+
+def test_the_bridge_gate_is_skipped_when_the_a2a_sidecar_is_disabled() -> None:
+    # Arrange — port None means "no inbound HTTP": there is no bridge to miss.
+    cfg = _bridge_cfg(port=None)
+    # Act
+    healthy, _message = health_mod.health_check(cfg, runtime=FakeRuntime(running=True))
+    # Assert
+    assert healthy is True
+
+
+def test_the_bridge_gate_is_skipped_for_a_non_tui_runtime() -> None:
+    # Arrange — an SDK agent serves /v1/turn from its own runner, not a bridge.
+    cfg = _bridge_cfg(port=_free_port(), runtime="claude-agent-sdk")
+    # Act
+    healthy, _message = health_mod.health_check(cfg, runtime=FakeRuntime(running=True))
+    # Assert
+    assert healthy is True
+
+
+def test_turn_bridge_method_probes_the_bridge_directly() -> None:
+    # Arrange — the opt-in method, with a real bridge answering.
+    port = _free_port()
+    cfg = _bridge_cfg(port=port, method="turn-bridge")
+    # Act
+    with _real_turn_bridge(port=port, agent_name="ag1"):
+        healthy, _message = health_mod.health_check(cfg)
+    # Assert
+    assert healthy is True
+
+
+def test_turn_bridge_method_fails_when_nothing_is_bound() -> None:
+    # Arrange
+    cfg = _bridge_cfg(port=_free_port(), method="turn-bridge")
+    # Act
+    healthy, _message = health_mod.health_check(cfg)
+    # Assert
+    assert healthy is False
+
+
+# --- corroboration: one observation is not a verdict (issue #825's family) ---
+
+
+def test_a_bridge_that_binds_during_the_backoff_is_reported_healthy() -> None:
+    # Arrange — the respawn window our OWN supervisor creates: the first probe
+    # is genuinely refused, then a REAL bridge binds before the second.
+    port = _free_port()
+    cfg = _bridge_cfg(port=port)
+    running: dict = {}
+
+    def _bind_during_backoff(_seconds: float) -> None:
+        if "server" in running:
+            return
+        server = build_server(
+            host="127.0.0.1",
+            port=port,
+            on_turn=lambda *_a, **_kw: None,
+            agent_name="ag1",
+        )
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        running["server"] = server
+        running["thread"] = thread
+
+    # Act
+    try:
+        healthy, _message = health_mod._check_turn_bridge(
+            cfg, sleep_fn=_bind_during_backoff
+        )
+    finally:
+        if "server" in running:
+            running["server"].shutdown()
+            running["server"].server_close()
+            running["thread"].join(timeout=2)
+    # Assert
+    assert healthy is True
+
+
+def test_a_persistently_dead_bridge_is_failed_after_every_attempt() -> None:
+    # Arrange
+    cfg = _bridge_cfg(port=_free_port())
+    # Act
+    healthy, _message = health_mod._check_turn_bridge(cfg, sleep_fn=_no_delay)
+    # Assert
+    assert healthy is False
+
+
+def test_a_failed_verdict_states_how_many_probes_confirmed_it() -> None:
+    # Arrange
+    cfg = _bridge_cfg(port=_free_port())
+    # Act
+    _healthy, message = health_mod._check_turn_bridge(
+        cfg, attempts=3, sleep_fn=_no_delay
+    )
+    # Assert
+    assert "confirmed by 3 probes" in message
+
+
+def test_a_foreign_holder_is_failed_without_retrying() -> None:
+    # Arrange — a REAL bridge for a DIFFERENT agent holds this agent's port.
+    # That is settled, not transient, so it must not cost three probes.
+    port = _free_port()
+    cfg = _bridge_cfg(name="ag1", port=port)
+    naps: list[float] = []
+    # Act
+    with _real_turn_bridge(port=port, agent_name="someone-else"):
+        health_mod._check_turn_bridge(cfg, sleep_fn=lambda s: naps.append(s))
+    # Assert
+    assert naps == []
+
+
+def test_a_foreign_holder_message_names_the_agent_that_answered() -> None:
+    # Arrange
+    port = _free_port()
+    cfg = _bridge_cfg(name="ag1", port=port)
+    # Act
+    with _real_turn_bridge(port=port, agent_name="someone-else"):
+        _healthy, message = health_mod._check_turn_bridge(cfg, sleep_fn=_no_delay)
+    # Assert
+    assert "someone-else" in message

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -836,3 +836,114 @@ def test_start_turn_bridge_explicit_host_overrides_the_spec(
     bridge.start_turn_bridge(config, spawn=fake_spawn, host=DEFAULT_A2A_HOST)
     # Assert
     assert recorded["argv"][recorded["argv"].index("--host") + 1] == DEFAULT_A2A_HOST
+
+
+# ---------------------------------------------------------------------------
+# write_bridge_event — the lifecycle log (tui-turn-bridge.log was 0 bytes)
+# ---------------------------------------------------------------------------
+# Measured on the host 2026-08-11: 16 of 17 ``tui-turn-bridge.log`` files were
+# EMPTY. The launcher opens the file and hands it to the child as stdout+stderr,
+# but the bridge wrote nothing of its own, so the log only ever captured an
+# unhandled traceback — and when 14 bridges were found dead, not one death
+# could be explained. These tests pin the two lines that bracket a bridge's
+# life. Real files, real fds; no mocks.
+
+
+def test_write_bridge_event_records_the_event_name(tmp_path: Path) -> None:
+    # Arrange
+    log_path = tmp_path / "tui-turn-bridge.log"
+    # Act
+    with log_path.open("w", encoding="utf-8") as fh:
+        line = bridge.write_bridge_event(
+            fh, "bind", agent="figrecipe", host=DEFAULT_A2A_HOST, port=_PORT, pid=_PID
+        )
+    # Assert
+    assert " bind " in line
+
+
+def test_write_bridge_event_records_the_bound_port(tmp_path: Path) -> None:
+    # Arrange
+    log_path = tmp_path / "tui-turn-bridge.log"
+    # Act
+    with log_path.open("w", encoding="utf-8") as fh:
+        bridge.write_bridge_event(
+            fh, "bind", agent="figrecipe", host=DEFAULT_A2A_HOST, port=_PORT, pid=_PID
+        )
+    # Assert
+    assert f"port={_PORT}" in log_path.read_text(encoding="utf-8")
+
+
+def test_write_bridge_event_records_the_pid(tmp_path: Path) -> None:
+    # Arrange
+    log_path = tmp_path / "tui-turn-bridge.log"
+    # Act
+    with log_path.open("w", encoding="utf-8") as fh:
+        bridge.write_bridge_event(
+            fh, "bind", agent="figrecipe", host=DEFAULT_A2A_HOST, port=_PORT, pid=_PID
+        )
+    # Assert
+    assert f"pid={_PID}" in log_path.read_text(encoding="utf-8")
+
+
+def test_write_bridge_event_records_the_host(tmp_path: Path) -> None:
+    # Arrange
+    log_path = tmp_path / "tui-turn-bridge.log"
+    # Act
+    with log_path.open("w", encoding="utf-8") as fh:
+        bridge.write_bridge_event(
+            fh, "bind", agent="figrecipe", host=DEFAULT_A2A_HOST, port=_PORT, pid=_PID
+        )
+    # Assert
+    assert f"host={DEFAULT_A2A_HOST}" in log_path.read_text(encoding="utf-8")
+
+
+def test_write_bridge_event_flushes_so_a_crash_cannot_swallow_the_line(
+    tmp_path: Path,
+) -> None:
+    # Arrange — read the file through a SEPARATE handle while the writer is
+    # still open: only a real flush makes the bytes visible, which is what
+    # keeps the bind line readable after an abrupt death.
+    log_path = tmp_path / "tui-turn-bridge.log"
+    observed = ""
+    # Act
+    with log_path.open("w", encoding="utf-8") as fh:
+        bridge.write_bridge_event(
+            fh, "bind", agent="figrecipe", host=DEFAULT_A2A_HOST, port=_PORT, pid=_PID
+        )
+        observed = log_path.read_text(encoding="utf-8")
+    # Assert
+    assert "tui-turn-bridge bind" in observed
+
+
+def test_write_bridge_event_appends_two_lines_for_bind_then_shutdown(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the shutdown line must BRACKET the bind line in the same log.
+    log_path = tmp_path / "tui-turn-bridge.log"
+    # Act
+    with log_path.open("w", encoding="utf-8") as fh:
+        bridge.write_bridge_event(
+            fh, "bind", agent="figrecipe", host=DEFAULT_A2A_HOST, port=_PORT, pid=_PID
+        )
+        bridge.write_bridge_event(
+            fh,
+            "shutdown",
+            agent="figrecipe",
+            host=DEFAULT_A2A_HOST,
+            port=_PORT,
+            pid=_PID,
+        )
+    # Assert
+    assert log_path.read_text(encoding="utf-8").count("\n") == 2
+
+
+def test_write_bridge_event_names_the_agent(tmp_path: Path) -> None:
+    # Arrange
+    log_path = tmp_path / "tui-turn-bridge.log"
+    # Act
+    with log_path.open("w", encoding="utf-8") as fh:
+        bridge.write_bridge_event(
+            fh, "shutdown", agent="figrecipe", host=DEFAULT_A2A_HOST, port=_PORT, pid=_PID
+        )
+    # Assert
+    assert "agent=figrecipe" in log_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## The fault

MEASURED on scitex-compute-04, 2026-08-11: **15 `tui-turn-bridge.pid` files on the host, 14 pointing at DEAD pids.** Three agents with LIVE tmux sessions had nothing bound to their `/v1/turn` port, so every wake POST their container made was refused — 40 attempts, 40 connection-refused, **zero** successes, a flat line at zero rather than a flap. The operator saw 34 "unavailable: connection refused" messages while replies limped in ~354 s late over an unrelated rail. Every one of those agents reported **healthy** throughout.

`runtime: tui` agents serve `/v1/turn` from a host-side process. It is spawned from exactly one place — `tui_session.start()` via `_tui_bridge_seam` — and every layer swallows failure. There is **no systemd unit, no timer and no cron entry** for it; verified on the host rather than assumed.

Two defects, and they are the same mistake: *a point-in-time observation treated as settled truth.*

- **D1 — no supervision.** A bridge that died stayed dead.
- **D2 — boot-order race.** `_maybe_start_turn_bridge` runs LAST in `start()`, after the boot drain and prompt injection, while the container's subscriber is already POSTing. Measured 47 s and 8 operator-visible warnings on one boot.

## The fix

Converts a one-shot into a maintained invariant, with **no new daemon, unit or timer**. `tui_heartbeat_loop` already ticks every ~30 s over exactly the right population with a fresh batched tmux snapshot, so it now also re-asserts each live agent's bridge when nothing is bound to the port it should serve. The first tick after a boot repairs D2 as a side effect, bounding the connection-refused window at one tick instead of "forever".

**Port resolution is the load-bearing detail.** Every fleet TUI spec declares `a2a.port: auto`, so a freshly-loaded config knows *no* port — a spec-only reader would have made this a silent no-op fleet-wide. `resolve_bridge_port` falls back to the allocator's **claim**, the durable record `sac listen` routes on and the value threaded into the container's `--turn-url`. Verified against reality: claim `19016` for `scitex-agent-container` is both its live bridge's `--port` and the URL its poller POSTs to. The lookup is **read-only** — an agent with no claim has no port anyone is POSTing to, so we never allocate one. `a2a.port: None` (sidecar disabled) short-circuits and stays disabled. Only agents with a live tmux session are touched, so a deliberately-stopped agent never gets a resurrected bridge.

**Health could not see the fault either.** `sdk-alive` asks only whether the tmux session is alive; `a2a-card` — the one HTTP-fidelity option — probes `/agents/<name>/.well-known/agent-card.json`, a route the TUI bridge does *not* serve, so it fails against a perfectly healthy bridge. The default path now additionally requires `GET /health` (the route the bridge really serves) and checks the response **identity**, so a foreign process holding the port cannot answer 200 for something else and pass.

**The bridge log was 0 bytes for 16 of 17 agents.** The launcher opens it and hands it to the child as stdout+stderr, but the bridge never wrote a line of its own — which is why not one of the 14 deaths could be explained. It now writes one line after the bind and one on shutdown, flushed.

## On retrying (raised in review)

The health probe is **corroborated, not single-shot**: the supervisor's own respawn has a genuine sub-second window where the old process is gone and the new one has not bound, and a single-shot probe landing there would report a self-healing system as broken. Any success returns immediately, so a healthy bridge never sleeps; only an already-failing agent pays, and a dead bridge refuses instantly.

The supervisor's **bind probe is deliberately not retried**. It is a kernel-level bind attempt, so a live listener can never read as free — there is no transient window to corroborate away, and a spurious respawn would be refused by the launcher's own gate anyway. Retrying it would be cargo-cult.

## Verification

Live on the host, not just in tests. Three bridges killed and observed down, then **one real tick** of the loop restored all three:

| | before tick | after tick |
|---|---|---|
| `scitex-agent-container:19016` | UNBOUND, http 000 | BOUND, **http 200** |
| `scitex-live-paper:19015` | UNBOUND, http 000 | BOUND, **http 200** |
| `canary-resume-test:19014` | UNBOUND, http 000 | BOUND, **http 200** |
| bridge logs | 0 bytes | real `bind` lines |

Each `/health` returned the correct agent identity. The second and third ticks left them alone (no respawn storm). A SIGTERM then produced the shutdown line and the next tick restored the bridge, so the log reads `bind` → `shutdown` → `bind`.

Health checked against real specs (`port: auto` → claim): dead bridge `ok=False`, live bridge `ok=True`.

**Tests: 3526 collected, exit 0.** New file `test__tui_bridge_supervisor.py` (20 tests, PS-204 mirrors its source module); real sockets, real HTTP servers built from the production `build_server`, no mocks.

## Out of scope (deliberately)

- **sac #825** (`tui_session.py:381` single `exists()` probe feeding an unconditional failure) is the same failure family and was raised during review, but it is a distinct defect in a different function with its own test surface. It belongs in a follow-up PR rather than enlarging a gating fix.
- No retry/backoff changes to claude-code-telegrammer — different repo, different decision.
