### PR TITLE
fix(test-harness): a run that lost pytest-asyncio must abort, not invent 93 failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -427,6 +427,48 @@ exclude = [".git"]
 # "." is the rootdir, so rootdir-relative imports (`tests.*`) resolve the same
 # way from any cwd.
 pythonpath = [".", "src"]
+
+# A RUN THAT LOST ITS PLUGINS MUST SAY SO, NOT INVENT 93 FAILURES.
+#
+# 2026-08-11: a wide run in an agent container produced 93 failures that were
+# ALL `async def` tests, each reading "async def functions are not natively
+# supported". The code was fine. The header was the whole story:
+#
+#     plugins: anyio-4.14.2, scitex-dev-0.47.0        <- broken run
+#     plugins: anyio-4.14.2, asyncio-1.4.0, ...       <- same tests, passing
+#
+# pytest-asyncio was simply not installed in that interpreter. Without it every
+# coroutine test is COLLECTED, never awaited, and reported as a failure — so a
+# missing dependency is indistinguishable from a code regression, and two
+# agents spent the evening attributing it to their own changes.
+#
+# The cause was environmental, and that class of cause recurs: the sac base SIF
+# installs `/opt/scitex-agent-container-src[openai]`, NOT `[dev]`, so a fresh
+# container has no pytest and no pytest-asyncio at all (measured 2026-08-11:
+# 19 of 20 agent overlays on scitex-compute-04 had neither). Each agent
+# hand-installs what it needs into its own persistent overlay, so two agents
+# running the same tests legitimately hold different plugin sets. CI has its
+# own path to the same state: .github/ci/run-in-sif.sh falls back
+# `[all,dev]` -> `[dev]` -> `-e .`, and that last leg installs no test plugins
+# while still running the suite.
+#
+# `required_plugins` closes all of it the only way that is trustworthy — the
+# run REFUSES to start. Missing plugin => exit 4 and one line naming it:
+#
+#     ERROR: Missing required plugins: pytest-asyncio
+#
+# instead of a red suite that looks like someone's bug. Measured: fires on a
+# genuinely absent dist (rc=4) and does NOT false-positive on CI's
+# `uv pip install --target` + PYTHONPATH layout (rc=0), which is how CI
+# supplies these plugins today.
+#
+# Both entries are declared in the [dev] extra, which is the documented way to
+# run this suite. pytest-asyncio is the one that fails SILENTLY (wrong answers,
+# not an error); pytest-xdist is listed because CI's own command hard-depends
+# on `-n`, and "Missing required plugins: pytest-xdist" beats pytest's own
+# "unrecognized arguments: -n" for naming what to install.
+required_plugins = ["pytest-asyncio", "pytest-xdist"]
+
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = "-v --tb=short -m 'not integration and not docker_smoke'"

--- a/tests/develop/test_pytest_plugin_gate.py
+++ b/tests/develop/test_pytest_plugin_gate.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""A run that lost pytest-asyncio must ABORT, not report async tests as failures.
+
+2026-08-11 incident. A wide run in an agent container produced 93 failures that
+were all ``async def`` tests, every one of them "async def functions are not
+natively supported". Nothing was wrong with the code: pytest-asyncio was not
+installed in that interpreter, so each coroutine test was collected, never
+awaited, and counted as a failure. Two agents attributed it to their own
+changes before the header gave it away::
+
+    plugins: anyio-4.14.2, scitex-dev-0.47.0        # broken
+    plugins: anyio-4.14.2, asyncio-1.4.0, ...       # same tests, passing
+
+The environmental cause recurs by construction — the base SIF installs the
+``[openai]`` extra, not ``[dev]``, so a fresh container has neither pytest nor
+pytest-asyncio, and CI's install chain in ``.github/ci/run-in-sif.sh`` has a
+final ``-e .`` leg that likewise carries no test plugins. So the harness itself
+has to refuse to run rather than produce numbers nobody can trust.
+
+``required_plugins`` in ``[tool.pytest.ini_options]`` is that refusal. These
+tests hold it in place: one asserts the declaration is still there, the rest
+drive REAL pytest against THIS repo's REAL config file and prove the abort
+still happens — a gate that cannot fail is not a gate, so it is exercised, not
+described.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+# The plugins whose absence must abort a run. pytest-asyncio is the one that
+# fails SILENTLY (async tests turn red instead of erroring), which is what made
+# the incident so expensive to diagnose.
+_MUST_REQUIRE = ("pytest-asyncio", "pytest-xdist")
+
+# The message a run WITHOUT the gate produces — 93 of these was the incident.
+_UNGATED_SYMPTOM = "async def functions are not natively supported"
+
+
+def _declared_required_plugins() -> list[str]:
+    with _PYPROJECT.open("rb") as handle:
+        doc = tomllib.load(handle)
+    ini = doc["tool"]["pytest"]["ini_options"]
+    declared = ini.get("required_plugins", [])
+    # pytest accepts either a list or a whitespace-separated string.
+    if isinstance(declared, str):
+        return declared.split()
+    return list(declared)
+
+
+@pytest.fixture
+def blocked_run(tmp_path: Path) -> str:
+    """Run REAL pytest against THIS repo's REAL config, with asyncio blocked.
+
+    ``-p no:asyncio`` blocks the plugin exactly as an uninstalled distribution
+    would: ``required_plugins`` is validated against the plugins that actually
+    loaded, so both routes reach the same check. ``-c <pyproject>`` points the
+    subprocess at the repo's real configuration rather than a fixture copy, so
+    these tests fail if the declaration is weakened in any way.
+
+    Returns the combined output with the exit code appended on its own line, so
+    each behaviour below can assert exactly one thing about it. Function-scoped
+    on purpose: each run aborts before collection, so re-running it per test
+    costs a fraction of a second and keeps the fixture free of shared state.
+    """
+    probe = tmp_path / "test_probe.py"
+    probe.write_text(
+        "import pytest\n\n\n"
+        "@pytest.mark.asyncio\n"
+        "async def test_async_probe():\n"
+        "    assert True\n",
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-c",
+            str(_PYPROJECT),
+            "-p",
+            "no:asyncio",
+            "-p",
+            "no:cacheprovider",
+            str(probe),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        timeout=120,
+    )
+    return f"{completed.stdout}{completed.stderr}\nexit_code={completed.returncode}"
+
+
+@pytest.mark.parametrize("plugin", _MUST_REQUIRE)
+def test_pyproject_requires_the_plugin(plugin: str) -> None:
+    """The declaration exists, so a missing plugin is a startup error."""
+    # Arrange
+    expected = plugin
+    # Act
+    declared = _declared_required_plugins()
+    # Assert
+    assert expected in declared, (
+        f"{_PYPROJECT} no longer requires {expected!r} "
+        f"(required_plugins={declared!r}). Without it, a run in an "
+        f"environment that lacks {expected} does not abort — it reports every "
+        f"async test as a failure, which reads as a code regression. "
+        f"See this module's docstring for the 2026-08-11 incident."
+    )
+
+
+def test_missing_plugin_aborts_with_the_usage_error_exit_code(
+    blocked_run: str,
+) -> None:
+    """Exit 4 is pytest's USAGE_ERROR — the session never starts."""
+    # Arrange
+    expected = "exit_code=4"
+    # Act
+    output = blocked_run
+    # Assert
+    assert expected in output, (
+        "a run without pytest-asyncio must abort with pytest's usage-error "
+        f"exit code 4.\n{output}"
+    )
+
+
+def test_missing_plugin_abort_says_a_required_plugin_is_missing(
+    blocked_run: str,
+) -> None:
+    """The one line a reader needs, instead of a wall of async failures."""
+    # Arrange
+    expected = "Missing required plugins"
+    # Act
+    output = blocked_run
+    # Assert
+    assert expected in output, f"the abort must state what went wrong.\n{output}"
+
+
+def test_missing_plugin_abort_names_pytest_asyncio(blocked_run: str) -> None:
+    """Naming the plugin is what makes the error actionable."""
+    # Arrange
+    expected = "pytest-asyncio"
+    # Act
+    output = blocked_run
+    # Assert
+    assert expected in output, (
+        f"the abort must name the missing plugin.\n{output}"
+    )
+
+
+def test_missing_plugin_never_reaches_collection(blocked_run: str) -> None:
+    """The incident's symptom must be unreachable once the gate is in place."""
+    # Arrange
+    forbidden = _UNGATED_SYMPTOM
+    # Act
+    output = blocked_run
+    # Assert
+    assert forbidden not in output, (
+        "the run reached collection instead of aborting — required_plugins is "
+        f"not taking effect.\n{output}"
+    )
+
+
+def test_the_required_plugins_are_installed_in_this_environment() -> None:
+    """This very session loaded them — otherwise the gate above is untested."""
+    # Arrange
+    from importlib.metadata import distributions
+
+    # Act
+    installed = {
+        dist.metadata["Name"] for dist in distributions() if dist.metadata["Name"]
+    }
+    # Assert
+    assert not [name for name in _MUST_REQUIRE if name not in installed], (
+        f"missing from this interpreter ({sys.executable}): "
+        f"{[name for name in _MUST_REQUIRE if name not in installed]}. "
+        "Install the declared test extra: pip install -e '.[dev]'"
+    )


### PR DESCRIPTION
## The observation

A wide run on scitex-compute-04 produced **93 failures that were all `async def` tests**, each one "async def functions are not natively supported". The same files passed standalone. The header was the whole story:

```
plugins: anyio-4.14.2, scitex-dev-0.47.0        # the broken run
plugins: anyio-4.14.2, asyncio-1.4.0, ...       # same tests, passing
```

pytest-asyncio was not installed in that interpreter. Every coroutine test was collected, never awaited, and counted as a failure — so a missing dependency was indistinguishable from a code regression, and two agents spent the evening attributing it to their own changes.

## Mechanism (measured, not inferred)

Not a flake and not a shared-venv race. `/opt/venv-sac` is per-agent: apptainer runs with `--overlay .../containers/overlays/<agent>/`, a persistent host directory, so one agent's install is invisible to the others.

dist-info mtimes in this container's overlay:

| when | what |
|---|---|
| 16:04 | SIF build — venv has anyio + scitex-dev, **no pytest** |
| 21:48:15 | `pytest-9.1.1.dist-info` + `/opt/venv-sac/bin/pytest` created |
| 22:02:09 | `pytest_asyncio-1.4.0.dist-info` written (with xdist/execnet, same 33 ms) |

Fourteen minutes in which pytest existed and pytest-asyncio did not — exactly the broken header, which also lacked xdist because both arrived together.

The gap is structural. `apptainer-base.def` installs `/opt/scitex-agent-container-src[openai]`, **not `[dev]`**, and pytest-asyncio is declared in `[dev]`. A pristine SIF answers:

```
NO_PYTEST_ON_PATH
/opt/venv-sac/bin/python: No module named pytest
```

**19 of 20 agent overlays on this host have neither pytest nor pytest-asyncio.** Each agent hand-installs, so agents legitimately disagree about the plugin set.

CI reaches the same state by its own route: `.github/ci/run-in-sif.sh` installs `[all,dev]` → `[dev]` → `-e .`, and that last leg carries no test plugins while still running the suite.

## The fix

`required_plugins` makes the harness refuse to start rather than produce numbers nobody can trust:

```
ERROR: Missing required plugins: pytest-asyncio        (exit 4)
```

One line naming what to install, instead of 93 failures that read like a regression. It closes the local route and the CI route at once.

`tests/develop/test_pytest_plugin_gate.py` drives real pytest against this repo's real `pyproject.toml` — the gate is exercised, not described.

## PASS/FAIL

| check | result |
|---|---|
| suite target, plugin blocked → aborts | **PASS** `rc=4`, `ERROR: Missing required plugins: pytest-asyncio` |
| suite target, plugin present → unchanged | **PASS** |
| `test__off_loop.py` (the reported file) | **PASS** 9 passed, `rc=0` |
| new gate tests | **PASS** 7 passed, `rc=0` |
| CI's `uv pip install --target` + PYTHONPATH layout | **PASS** `rc=0` — no false positive |
| truly-absent dist (clean venv, no plugin anywhere) | **PASS** `rc=4` |
| `tests/develop/` | 58 passed, 1 skipped, 1 failed — `test_audit_all_clean`, **pre-existing** |

`test_audit_all_clean` fails identically with this diff stashed (verified): 2 unmasked errors, `CODEX_HOME` and `LOG_PATH` env-var prefixes, both untouched by this PR. Reported separately rather than folded in here.

## Not fixed here, deliberately

- **The image ships no test plugins.** The real determinism fix is baking `[dev]` into the base SIF so every container starts test-capable. That is a fleet-wide image decision requiring a rebuild I cannot verify in-container, so it is flagged for the operator rather than changed blind. The gate makes the current state legible in the meantime.
- **Version skew.** `[dev]` declares `pytest>=7.0.0,<9.0.0`; this container has a hand-installed **pytest 9.1.1**, outside the declared range. Local agents and CI are therefore on different major pytest versions.
