### PR TITLE
fix(image): the base SIF must arrive able to run its own tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -468,15 +468,26 @@ pythonpath = [".", "src"]
 # missing dependency is indistinguishable from a code regression, and two
 # agents spent the evening attributing it to their own changes.
 #
-# The cause was environmental, and that class of cause recurs: the sac base SIF
-# installs `/opt/scitex-agent-container-src[openai]`, NOT `[dev]`, so a fresh
-# container has no pytest and no pytest-asyncio at all (measured 2026-08-11:
-# 19 of 20 agent overlays on scitex-compute-04 had neither). Each agent
-# hand-installs what it needs into its own persistent overlay, so two agents
-# running the same tests legitimately hold different plugin sets. CI has its
-# own path to the same state: .github/ci/run-in-sif.sh falls back
-# `[all,dev]` -> `[dev]` -> `-e .`, and that last leg installs no test plugins
-# while still running the suite.
+# The cause was environmental, and that class of cause recurs. It began in the
+# image: the sac base SIF installed `/opt/scitex-agent-container-src[openai]`,
+# NOT `[dev]`, so a fresh container had no pytest and no pytest-asyncio at all
+# (measured 2026-08-11: 19 of 20 agent overlays on scitex-compute-04 had
+# neither). Each agent hand-installed what it needed into its own persistent
+# overlay, so two agents running the same tests legitimately held different
+# plugin sets — and different pytest MAJORS.
+#
+# THAT ROOT CAUSE IS FIXED: apptainer-base.def now installs `[all]`, which
+# contains `[dev]`, so a pristine container arrives with pytest 8.4.2,
+# pytest-asyncio, pytest-xdist and pytest-cov and this gate never fires there.
+#
+# The gate is NOT thereby redundant, because the image is only one of the ways
+# an interpreter loses a plugin. CI has its own path to the same state:
+# .github/ci/run-in-sif.sh falls back `[all,dev]` -> `[dev]` -> `-e .`, and
+# that last leg installs no test plugins while still running the suite. So do
+# hand-made venvs, `--target` layouts, sandboxes mutated after a bake, and any
+# older image still on disk. The image fix removes the common case; this line
+# is what makes the remaining cases say so out loud instead of inventing
+# failures.
 #
 # `required_plugins` closes all of it the only way that is trustworthy — the
 # run REFUSES to start. Missing plugin => exit 4 and one line naming it:

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -452,15 +452,64 @@ From: ubuntu:24.04
     # release that drops it dies LOUD at bake rather than shipping silently.
     # That gate is the honest protection: verify the artifact you built,
     # do not freeze the input and call it safety.
-    # sac's [openai] extra (openai-agents — the `spec.provider: openai`
-    # agent-SDK family, openai-compat-3) is baked UNCONDITIONALLY: one
-    # image serves EVERY agent, so a per-spec conditional install is
-    # impossible at image-build time. Per-spec conditionality is a
-    # RUNTIME concern instead — only `provider: openai` launches get the
+    # sac is installed with ``[all]`` — the union aggregate — and NOT the
+    # narrower ``[openai]`` it carried until 2026-08-11.
+    #
+    # WHY THE WIDENING: ``[openai]`` left the image WITHOUT TEST TOOLING,
+    # because pytest and its plugins are declared in ``[dev]``. Measured on
+    # scitex-compute-04 the night of 2026-08-11, against the live SIF:
+    #
+    #   * a pristine container answered ``NO_PYTEST_ON_PATH`` and
+    #     ``/opt/venv-sac/bin/python: No module named pytest``;
+    #   * 19 of 20 agent overlays had NEITHER pytest NOR pytest-asyncio;
+    #   * so every agent that needed to run the suite hand-installed its own
+    #     tooling, and the fleet legitimately held DIFFERENT plugin sets and
+    #     different pytest MAJORS — one container ended up on pytest 9,
+    #     outside pyproject's declared ``>=7.0.0,<9.0.0``, while CI ran 8;
+    #   * and a 14-minute window in one overlay (pytest installed at 21:48,
+    #     pytest-asyncio not until 22:02) produced a run where 93 async tests
+    #     failed as pure ENVIRONMENT ARTEFACTS and were briefly read as a
+    #     regression in the code.
+    #
+    # An image that cannot run its own tests exports that cost to every agent
+    # booting it, and pays it again in wrong diagnoses. Operator ruling,
+    # 2026-08-11: 「デベロップメントは必ず SIF に入れないといけないっていうのは
+    # 当たり前だと思うんですけど、というか多分オールを入れておけばいいと思うん
+    # ですよね」— put dev IN the SIF; just install ``[all]``.
+    #
+    # ``[all]`` ALONE IS SUFFICIENT — ``[all,dev]`` would be redundant.
+    # pyproject's ``all`` is the union aggregate and lists
+    # ``scitex-agent-container[dev]`` explicitly (alongside mcp / telegram /
+    # notify / slurm / openai / codex / docs), so pytest, pytest-asyncio,
+    # pytest-xdist and pytest-cov ride in through it. Read ``all`` in
+    # pyproject.toml before narrowing this bracket: if a future edit drops
+    # ``[dev]`` from the aggregate, THIS line silently stops shipping test
+    # tooling again — which is why the contract test in
+    # tests/integration/test_apptainer_def_openai_agents.py asserts BOTH
+    # halves (the bracket here AND ``[dev]``'s membership in the aggregate).
+    #
+    # ``[all]`` IS A SUPERSET OF ``[openai]``, so nothing about the previous
+    # contract is lost: openai-agents (the `spec.provider: openai` agent-SDK
+    # family, openai-compat-3) is still baked UNCONDITIONALLY, which is the
+    # only option at image-build time — one image serves EVERY agent, so a
+    # per-spec conditional install is impossible here. Per-spec conditionality
+    # stays a RUNTIME concern: only `provider: openai` launches get the
     # OPENAI_* env injection + `openai_session` executor routing (see
-    # runtimes/_apptainer_provider.py). The extra's version floor lives
-    # in pyproject.toml (SSoT); the bracket syntax on the local source
-    # path resolves it through the bundled tree's own metadata.
+    # runtimes/_apptainer_provider.py).
+    #
+    # EVERY version floor stays in pyproject.toml (SSoT); the bracket syntax
+    # on the local source path resolves them through the bundled tree's own
+    # metadata. That is what keeps the image's pytest inside
+    # ``>=7.0.0,<9.0.0`` instead of drifting to a major CI does not run — a
+    # hand-install carries no such constraint, which is exactly how the
+    # pytest-9 container happened.
+    #
+    # COST, measured against the SIF this line replaces: the heavy scientific
+    # stack was ALREADY in the image (scitex-dev 0.47.0, playwright, numpy,
+    # scipy, matplotlib, pymupdf were all present under ``[openai]``), so
+    # ``[all]`` does not import a new ecosystem — it adds the test / docs /
+    # bridge leaves on top of one already paid for. Re-measure rather than
+    # assume if the aggregate grows.
     #
     # UV SEMANTICS, NOT PIP (INCIDENT 2026-07-18). ``--no-cache-dir`` and
     # ``--force-reinstall`` are PIP flags; uv does not honour them as a
@@ -492,7 +541,7 @@ From: ubuntu:24.04
         --reinstall-package scitex-agent-container \
         "claude-agent-sdk" \
         "scitex-cards>=0.32.0" \
-        "/opt/scitex-agent-container-src[openai]"
+        "/opt/scitex-agent-container-src[all]"
 
     # ---- 6c. FAIL-LOUD staleness gate — assert BY SYMBOL --------------
     # incident-fleet-drift-stale-scitex-todo (2026-07-12): the live SIFs

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -171,10 +171,23 @@ From: ./sac-base.sif
         # re-resolves to the newest published version. A FRESH-base bake
         # happens to work either way, which is precisely why this went
         # unnoticed — and why the timer-driven routine bake needs it.
+        #
+        # ``pytest`` CARRIES ITS FLOOR HERE, and the ``<9`` half is the
+        # load-bearing one. Base now installs sac's ``[all]`` (which includes
+        # ``[dev]``), so the inherited venv already holds a pytest inside
+        # pyproject's declared ``>=7.0.0,<9.0.0`` plus pytest-asyncio and
+        # pytest-xdist. An UNVERSIONED ``pytest`` on THIS ``-U`` line would
+        # then do real damage rather than nothing: ``-U`` re-resolves to the
+        # newest published pytest — a MAJOR CI does not run — while the
+        # plugins stay where base put them. That is the same split that cost
+        # an evening on 2026-08-11, when a hand-installed pytest 9 met a
+        # pytest-asyncio built for 8 and 93 async tests failed as pure
+        # environment artefacts. The floor mirrors pyproject.toml's ``[dev]``
+        # (SSoT) and must be bumped in lockstep with it.
         uv pip install --python /opt/venv-sac/bin/python -U \
             black flake8 \
             ipython ipdb \
-            pytest pytest-cov \
+            "pytest>=7.0.0,<9.0.0" pytest-cov \
             "claude-agent-sdk" \
             "openai-agents>=0.17.4" \
             "scitex[all]" \
@@ -300,10 +313,14 @@ From: ./sac-base.sif
             pip setuptools wheel
         # openai-agents: explicit for the same --no-deps reason as the
         # uv branch above; floor mirrors pyproject.toml's [openai] extra.
+        # pytest floor: MUST TRACK THE uv BRANCH ABOVE — see it for why the
+        # ``<9`` half is load-bearing (an unversioned pytest under
+        # ``--upgrade`` crosses a major the inherited pytest-asyncio was not
+        # built for, and the suite then fails as an environment artefact).
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             black flake8 \
             ipython ipdb \
-            pytest pytest-cov \
+            "pytest>=7.0.0,<9.0.0" pytest-cov \
             "claude-agent-sdk" \
             "openai-agents>=0.17.4" \
             "scitex[all]" \

--- a/tests/integration/test_apptainer_def_openai_agents.py
+++ b/tests/integration/test_apptainer_def_openai_agents.py
@@ -8,9 +8,14 @@ per-spec conditionality at RUNTIME (OPENAI_* env injection +
 
 Layer contracts pinned here:
 
-* ``apptainer-base.def`` installs sac WITH its ``[openai]`` extra
-  (``/opt/scitex-agent-container-src[openai]``) — the floor stays in
-  pyproject.toml (SSoT).
+* ``apptainer-base.def`` installs sac with the ``[all]`` aggregate
+  (``/opt/scitex-agent-container-src[all]``), which CONTAINS ``[openai]``
+  — the floor stays in pyproject.toml (SSoT). The bracket was widened
+  from ``[openai]`` on 2026-08-11 so the image also ships ``[dev]``'s
+  test tooling; because that makes openai-agents arrive INDIRECTLY, the
+  aggregate's membership is asserted here too. Without that second
+  assert, deleting ``scitex-agent-container[openai]`` from ``all`` would
+  silently stop baking the SDK while this file still passed.
 * ``apptainer-scitex.def`` lists ``openai-agents`` EXPLICITLY in BOTH
   resolver branches (uv + pip fallback), because its sac install is
   ``--force-reinstall --no-deps`` (an extra can never ride that) and
@@ -50,20 +55,54 @@ def scitex_def_text() -> str:
 
 
 # ---------------------------------------------------------------------------
-# base layer — sac's own [openai] extra rides the bundled-source install
+# base layer — the [all] aggregate rides the bundled-source install, and
+# [openai] + [dev] ride the aggregate
 # ---------------------------------------------------------------------------
 
 
-def test_base_def_installs_sac_with_openai_extra(base_def_text: str) -> None:
+def test_base_def_installs_sac_with_all_extra(base_def_text: str) -> None:
     # Arrange
-    needle = "/opt/scitex-agent-container-src[openai]"
+    needle = "/opt/scitex-agent-container-src[all]"
     # Act
     present = needle in base_def_text
     # Assert
     assert present, (
-        "apptainer-base.def must install the bundled sac source WITH the "
-        "[openai] extra (openai-agents for spec.provider: openai agents); "
+        "apptainer-base.def must install the bundled sac source with the "
+        "[all] aggregate — it carries BOTH openai-agents (spec.provider: "
+        "openai agents) and [dev]'s pytest tooling, without which a "
+        "pristine container cannot run the suite; "
         f"expected {needle!r} in the uv pip install block."
+    )
+
+
+def test_all_extra_carries_openai_agents(base_def_text: str) -> None:
+    # Arrange — base installs [all], so the SDK now arrives INDIRECTLY;
+    # dropping it from the aggregate would unbake it silently.
+    pyproject = (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text()
+    # Act
+    present = "scitex-agent-container[openai]" in pyproject
+    # Assert
+    assert present, (
+        "pyproject's [all] aggregate must keep listing "
+        "scitex-agent-container[openai]: apptainer-base.def reaches "
+        "openai-agents THROUGH [all], so removing it there unbakes the SDK "
+        "from every image while the .def line still looks correct."
+    )
+
+
+def test_all_extra_carries_dev_test_tooling(base_def_text: str) -> None:
+    # Arrange — the reason the bracket was widened: [dev] is where pytest
+    # and its plugins live, and [all] is how they reach the image.
+    pyproject = (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text()
+    # Act
+    present = "scitex-agent-container[dev]" in pyproject
+    # Assert
+    assert present, (
+        "pyproject's [all] aggregate must keep listing "
+        "scitex-agent-container[dev]: that is the ONLY route by which "
+        "pytest / pytest-asyncio / pytest-xdist reach the base image. "
+        "Drop it and a pristine container answers NO_PYTEST_ON_PATH again, "
+        "and every agent hand-installs a different pytest major."
     )
 
 


### PR DESCRIPTION
## The defect

`apptainer-base.def` installed `/opt/scitex-agent-container-src[openai]`.
`pytest` is declared in `[dev]`. So the base image — the one most agent specs
boot directly — shipped **without the ability to run its own tests**.

Measured on scitex-compute-04, 2026-08-11, against the live SIF:

| probe | result |
|---|---|
| `command -v pytest` in a pristine container | `NO_PYTEST_ON_PATH` |
| `/opt/venv-sac/bin/python -m pytest` | `No module named pytest` |
| agent overlays holding neither pytest nor pytest-asyncio | **19 of 20** |

The consequences are the interesting part. Every agent that needed to run the
suite hand-installed its own tooling, so the fleet legitimately held different
plugin sets and different pytest **majors** — one container ended up on pytest
9, outside pyproject's declared `>=7.0.0,<9.0.0`, while CI runs 8. And in a
14-minute window in one overlay (pytest installed 21:48, pytest-asyncio not
until 22:02) **93 async tests failed as pure environment artefacts** and were
briefly read as a code regression.

An image that cannot test itself does not merely inconvenience the agents
booting it. It manufactures false diagnoses.

Operator ruling, 2026-08-11: 「デベロップメントは必ず SIF に入れないといけない
っていうのは当たり前だと思うんですけど、というか多分オールを入れておけばいい
と思うんですよね」

## The change

`[openai]` → `[all]`, in one line of `apptainer-base.def`.

**`[all]` alone is sufficient; `[all,dev]` would be redundant.** pyproject's
`all` is the union aggregate and lists `scitex-agent-container[dev]`
explicitly, alongside mcp / telegram / notify / slurm / openai / codex / docs.
pytest, pytest-asyncio, pytest-xdist and pytest-cov ride in through it. It is
also a superset of `[openai]`, so openai-agents stays baked unconditionally and
the openai-compat-3 contract is untouched.

### Result, not side effect: local and CI stop disagreeing about pytest

Floors stay in `pyproject.toml` (SSoT), and that is the half that fixes the
version drift. Because the tooling now arrives *through the package's own
metadata*, the image resolves pytest to **8.4.2** — inside the declared
`>=7.0.0,<9.0.0`, and the same major CI runs. A hand-install carries no such
constraint, which is exactly how a container ended up on pytest 9.

This is worth stating as an outcome rather than a footnote. "Passes here, fails
there" becomes normal precisely when local and CI disagree about a test-runner
major, and that disagreement cost real diagnostic time on 2026-08-11. The cause
is removed here by construction — no pin, no lockfile, no per-agent discipline
required.

`apptainer-scitex.def` gets the same floor for the opposite reason. It bakes
ONTO base and its `-U` line listed a bare `pytest`; against an inherited venv
that would re-resolve to the newest major while pytest-asyncio stayed where
base put it, reproducing the very split that cost the evening. Both resolver
branches (uv and the pip fallback) now carry `pytest>=7.0.0,<9.0.0`.

## Cost, measured rather than assumed

`uv pip install --dry-run` for `[all]` against the live SIF's venv:

```
Resolved 213 packages in 3.39s
Would install 61 packages     (60 new + sac itself rebuilt from source)
```

**No new scientific stack.** scitex-dev 0.47.0, playwright 1.62.0, numpy 2.5.2,
scipy 1.18.0, matplotlib 3.11.1 and pymupdf 1.28.2 were *already in the image*
under `[openai]`. The added weight is the sphinx family (`[docs]`),
litellm + huggingface-hub + tokenizers + google-genai + groq (`[codex]` →
scitex-genai[gateway]), claude-code-telegrammer, pre-commit + virtualenv, and
the four pytest packages that are the point of the change.

SIF size and build-time delta are recorded in the PR discussion once the
compute-04 rebuild lands.

## The contract test grows a second half

openai-agents now arrives **indirectly**, through the aggregate. Asserting the
`.def` line alone would no longer be enough: deleting `scitex-agent-container[openai]`
from `all` would silently unbake the SDK while the `.def` still looked correct.
So the test asserts membership of both `[openai]` and `[dev]` in the aggregate,
the latter being the only route by which pytest reaches the image at all.

## Relationship to #974

#974 added `required_plugins = ["pytest-asyncio", "pytest-xdist"]` so a run
that has lost a plugin aborts in one line with exit 4 instead of inventing a
wall of failures. That is the right alarm, but an alarm is not a fix. This PR
is what makes the gate *never fire in a fresh container* — which is the
condition under which #974 becomes a guarantee rather than a better error
message.

## Rollout

Rebuilt and verified on scitex-compute-04 only. Propagation to the other hosts
is deliberately NOT in this PR — see the PR discussion for what it involves.
Running agents are undisturbed: the build is atomic (fresh timestamped SIF,
symlink swapped at the end), the previous SIF stays on disk, and agents pick
the new image up at their next start.
