### PR TITLE
feat(ci-runners): read WHICH runner ran the job, because green does not mean compliant

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_ci_runners.py
+++ b/src/scitex_agent_container/cli_pkg/_ci_runners.py
@@ -1,62 +1,64 @@
-"""Which RUNNER executed each job — the compliance read a status word hides.
+"""Which RUNNER executed each job — the fact a status word hides.
 
-A green check is not proof of compliance. Measured 2026-08-11: scitex-dev
-PR #572 showed ``import-smoke  pass  1m9s`` while the jobs API reported
-``runner_name=spartan-cpu-org-01``. The run had been queued BEFORE the repo's
-``CI_RUNS_ON`` was repointed off Spartan, so it executed on exactly the
-hardware the change existed to abandon — and every human-visible signal said
-green. Re-reading the variable would also have said green, because the
-variable HAD been changed; only the job's actual ``runner_name`` disagreed.
+A green check does not tell you where the work ran. Measured 2026-08-11:
+scitex-dev PR #572 showed ``import-smoke  pass  1m9s`` while the jobs API
+reported ``runner_name=spartan-cpu-org-01``. The run had been queued BEFORE the
+repo's ``CI_RUNS_ON`` was repointed, so it executed on a host nobody expected —
+and every human-visible signal said green. Re-reading ``CI_RUNS_ON`` would also
+have said green, because the variable HAD been changed. Only the job's actual
+``runner_name`` disagreed.
 
-So this module reads ``runner_name`` rather than status, for EVERY job of a
-run (not just failing ones — the failing ones were never the risk), and fails
-loud when a banned runner appears.
+So this module reads ``runner_name`` rather than status, for EVERY job of a run
+(not just failing ones — the failing ones were never the risk).
 
-It also reports AMBIGUOUS selectors. ``scitex-ci`` is carried by Spartan
-runners as well as compliant ones, so a workflow selecting it can still land
-on Spartan; that is a trap which happens to be harmless only while no banned
-runner is registered. Reported as a warning, not a violation: the job in hand
-did run somewhere compliant, but the selector gives no guarantee it will next
-time.
+WHY THERE IS NO HARDCODED HOST POLICY HERE, and why there was:
+the first version of this file shipped ``BANNED_RUNNER_SUBSTRINGS = ("spartan",)``
+because a host had been banned from CI outright. That ban was repealed the very
+next day, which would have left a tool exiting non-zero on sanctioned runs — a
+known-false gate, the exact failure mode it exists to catch. A rule that can be
+repealed overnight does not belong baked into a library.
+
+What survives a policy reversal is the QUESTION, not the answer: *where did this
+work actually run?* So the default is to report, and any gate is stated by the
+caller at the call site:
+
+  * ``--deny SUBSTR``   fail if any job ran on a matching runner
+  * ``--expect SUBSTR`` fail if any job ran on a runner that does NOT match
+
+``--expect`` is usually the better one: it asserts what you intended rather than
+enumerating what you fear, so it still catches a host nobody thought to ban.
 """
 
 from __future__ import annotations
 
 import json
+from collections import Counter
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Sequence
 
-from ._ci_why import CIWhyError, GhRunner, _repo_args, _RUN_ID_IN_LINK, run_gh
+from ._ci_why import _RUN_ID_IN_LINK, CIWhyError, GhRunner, _repo_args, run_gh
 
 __all__ = [
-    "BANNED_RUNNER_SUBSTRINGS",
-    "AMBIGUOUS_LABELS",
     "JobRunner",
     "RunRunners",
     "audit",
+    "matches_any",
     "render_text",
     "resolve_all_run_ids",
+    "run_job_runners",
 ]
 
-# Substring match on the runner NAME. Names are the durable identity here:
-# a banned host can be relabelled, but it is still the banned host.
-BANNED_RUNNER_SUBSTRINGS = ("spartan",)
 
-# Labels carried by BOTH banned and compliant runners, so selecting one is
-# not a guarantee of anything.
-AMBIGUOUS_LABELS = ("scitex-ci",)
+def matches_any(runner_name: Optional[str], substrings: Sequence[str]) -> bool:
+    """True when ``runner_name`` contains any of ``substrings`` (case-insensitive).
 
-
-def is_banned(runner_name: Optional[str]) -> bool:
-    """True when this runner name identifies banned hardware."""
-    name = (runner_name or "").lower()
-    return any(bad in name for bad in BANNED_RUNNER_SUBSTRINGS)
-
-
-def ambiguous_labels(labels: list[str]) -> list[str]:
-    """The selector labels that can also match banned hardware."""
-    lowered = {str(x).lower() for x in labels or []}
-    return [lab for lab in AMBIGUOUS_LABELS if lab in lowered]
+    An UNASSIGNED runner (a queued job) matches nothing — absence of a host is
+    not evidence about which host, in either direction.
+    """
+    if not runner_name:
+        return False
+    name = runner_name.lower()
+    return any(s.lower() in name for s in substrings if s)
 
 
 @dataclass
@@ -72,12 +74,9 @@ class JobRunner:
     url: Optional[str] = None
 
     @property
-    def banned(self) -> bool:
-        return is_banned(self.runner_name)
-
-    @property
-    def ambiguous(self) -> list[str]:
-        return ambiguous_labels(self.labels)
+    def where(self) -> str:
+        """Human-readable host, honest when the job never got one."""
+        return self.runner_name or "<unassigned>"
 
     def to_dict(self) -> dict:
         return {
@@ -87,8 +86,6 @@ class JobRunner:
             "runner_name": self.runner_name,
             "runner_group": self.runner_group,
             "labels": self.labels,
-            "banned": self.banned,
-            "ambiguous_labels": self.ambiguous,
             "url": self.url,
         }
 
@@ -100,20 +97,33 @@ class RunRunners:
     run_id: str
     jobs: list[JobRunner] = field(default_factory=list)
 
-    @property
-    def violations(self) -> list[JobRunner]:
-        return [j for j in self.jobs if j.banned]
+    def denied(self, substrings: Sequence[str]) -> list[JobRunner]:
+        """Jobs that ran somewhere the caller said they must not."""
+        return [j for j in self.jobs if matches_any(j.runner_name, substrings)]
+
+    def unexpected(self, substrings: Sequence[str]) -> list[JobRunner]:
+        """Jobs that ran somewhere OTHER than where the caller expected.
+
+        A job with no runner yet is not a violation — it has not run anywhere.
+        """
+        if not substrings:
+            return []
+        return [
+            j
+            for j in self.jobs
+            if j.runner_name and not matches_any(j.runner_name, substrings)
+        ]
 
     @property
-    def warnings(self) -> list[JobRunner]:
-        return [j for j in self.jobs if j.ambiguous and not j.banned]
+    def tally(self) -> dict[str, int]:
+        """How many jobs landed on each runner — the distribution, not a verdict."""
+        return dict(Counter(j.where for j in self.jobs))
 
     def to_dict(self) -> dict:
         return {
             "run_id": self.run_id,
             "jobs": [j.to_dict() for j in self.jobs],
-            "violations": [j.job for j in self.violations],
-            "warnings": [j.job for j in self.warnings],
+            "tally": self.tally,
         }
 
 
@@ -155,8 +165,8 @@ def run_job_runners(
 def _pr_all_run_ids(pr: str, *, run_gh: GhRunner, repo: Optional[str]) -> list[str]:
     """EVERY run behind a PR's checks — passing ones included.
 
-    Deliberately not ``_ci_why._pr_failing_run_ids``: a compliance violation
-    is most likely to be hiding behind a check that PASSED.
+    Deliberately not ``_ci_why._pr_failing_run_ids``: a job that ran somewhere
+    unexpected is most likely to be hiding behind a check that PASSED.
     """
     raw = run_gh(["pr", "checks", pr, *_repo_args(repo), "--json", "name,state,link"])
     try:
@@ -197,17 +207,26 @@ def audit(
     return [run_job_runners(rid, run_gh=run_gh, repo=repo) for rid in ids]
 
 
-def render_text(run: RunRunners) -> str:
-    """One line per job; violations and warnings called out explicitly."""
+def render_text(
+    run: RunRunners,
+    *,
+    deny: Sequence[str] = (),
+    expect: Sequence[str] = (),
+) -> str:
+    """One line per job, then the per-runner tally.
+
+    Marks are applied only where the CALLER stated a policy; with no policy this
+    is a plain report of where the work ran.
+    """
+    flagged = {id(j) for j in run.denied(deny)} | {id(j) for j in run.unexpected(expect)}
     lines = []
     for j in run.jobs:
-        mark = "BANNED " if j.banned else "        "
-        where = j.runner_name or "<unassigned>"
+        mark = "FLAG " if id(j) in flagged else "     "
         grp = f" [{j.runner_group}]" if j.runner_group else ""
         concl = j.conclusion or j.status
-        lines.append(f"  {mark}{concl:<12} {where}{grp}  {j.job}")
-        for lab in j.ambiguous:
-            lines.append(
-                f"          warning: selector '{lab}' also matches banned runners"
-            )
+        lines.append(f"  {mark}{concl:<12} {j.where}{grp}  {j.job}")
+    if run.jobs:
+        lines.append("  ---")
+        for host, n in sorted(run.tally.items(), key=lambda kv: (-kv[1], kv[0])):
+            lines.append(f"  {n:>3} job(s) on {host}")
     return "\n".join(lines)

--- a/src/scitex_agent_container/cli_pkg/_ci_runners.py
+++ b/src/scitex_agent_container/cli_pkg/_ci_runners.py
@@ -1,0 +1,213 @@
+"""Which RUNNER executed each job — the compliance read a status word hides.
+
+A green check is not proof of compliance. Measured 2026-08-11: scitex-dev
+PR #572 showed ``import-smoke  pass  1m9s`` while the jobs API reported
+``runner_name=spartan-cpu-org-01``. The run had been queued BEFORE the repo's
+``CI_RUNS_ON`` was repointed off Spartan, so it executed on exactly the
+hardware the change existed to abandon — and every human-visible signal said
+green. Re-reading the variable would also have said green, because the
+variable HAD been changed; only the job's actual ``runner_name`` disagreed.
+
+So this module reads ``runner_name`` rather than status, for EVERY job of a
+run (not just failing ones — the failing ones were never the risk), and fails
+loud when a banned runner appears.
+
+It also reports AMBIGUOUS selectors. ``scitex-ci`` is carried by Spartan
+runners as well as compliant ones, so a workflow selecting it can still land
+on Spartan; that is a trap which happens to be harmless only while no banned
+runner is registered. Reported as a warning, not a violation: the job in hand
+did run somewhere compliant, but the selector gives no guarantee it will next
+time.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Optional
+
+from ._ci_why import CIWhyError, GhRunner, _repo_args, _RUN_ID_IN_LINK, run_gh
+
+__all__ = [
+    "BANNED_RUNNER_SUBSTRINGS",
+    "AMBIGUOUS_LABELS",
+    "JobRunner",
+    "RunRunners",
+    "audit",
+    "render_text",
+    "resolve_all_run_ids",
+]
+
+# Substring match on the runner NAME. Names are the durable identity here:
+# a banned host can be relabelled, but it is still the banned host.
+BANNED_RUNNER_SUBSTRINGS = ("spartan",)
+
+# Labels carried by BOTH banned and compliant runners, so selecting one is
+# not a guarantee of anything.
+AMBIGUOUS_LABELS = ("scitex-ci",)
+
+
+def is_banned(runner_name: Optional[str]) -> bool:
+    """True when this runner name identifies banned hardware."""
+    name = (runner_name or "").lower()
+    return any(bad in name for bad in BANNED_RUNNER_SUBSTRINGS)
+
+
+def ambiguous_labels(labels: list[str]) -> list[str]:
+    """The selector labels that can also match banned hardware."""
+    lowered = {str(x).lower() for x in labels or []}
+    return [lab for lab in AMBIGUOUS_LABELS if lab in lowered]
+
+
+@dataclass
+class JobRunner:
+    """One job, and the machine that actually ran it."""
+
+    job: str
+    status: str
+    conclusion: Optional[str]
+    runner_name: Optional[str]
+    runner_group: Optional[str]
+    labels: list[str] = field(default_factory=list)
+    url: Optional[str] = None
+
+    @property
+    def banned(self) -> bool:
+        return is_banned(self.runner_name)
+
+    @property
+    def ambiguous(self) -> list[str]:
+        return ambiguous_labels(self.labels)
+
+    def to_dict(self) -> dict:
+        return {
+            "job": self.job,
+            "status": self.status,
+            "conclusion": self.conclusion,
+            "runner_name": self.runner_name,
+            "runner_group": self.runner_group,
+            "labels": self.labels,
+            "banned": self.banned,
+            "ambiguous_labels": self.ambiguous,
+            "url": self.url,
+        }
+
+
+@dataclass
+class RunRunners:
+    """Every job of one run, with the runner each landed on."""
+
+    run_id: str
+    jobs: list[JobRunner] = field(default_factory=list)
+
+    @property
+    def violations(self) -> list[JobRunner]:
+        return [j for j in self.jobs if j.banned]
+
+    @property
+    def warnings(self) -> list[JobRunner]:
+        return [j for j in self.jobs if j.ambiguous and not j.banned]
+
+    def to_dict(self) -> dict:
+        return {
+            "run_id": self.run_id,
+            "jobs": [j.to_dict() for j in self.jobs],
+            "violations": [j.job for j in self.violations],
+            "warnings": [j.job for j in self.warnings],
+        }
+
+
+def _jobs_path(run_id: str, repo: Optional[str]) -> str:
+    # gh substitutes {owner}/{repo} from the cwd's repo when none is given.
+    owner_repo = repo if repo else "{owner}/{repo}"
+    return f"repos/{owner_repo}/actions/runs/{run_id}/jobs"
+
+
+def run_job_runners(
+    run_id: str, *, run_gh: GhRunner = run_gh, repo: Optional[str] = None
+) -> RunRunners:
+    """Read every job of ``run_id`` and the runner it executed on."""
+    raw = run_gh(["api", "--paginate", _jobs_path(run_id, repo)])
+    try:
+        payload = json.loads(raw or "{}")
+    except ValueError as exc:
+        raise CIWhyError(f"could not parse jobs JSON for run {run_id}") from exc
+
+    jobs_raw = payload.get("jobs") if isinstance(payload, dict) else None
+    if jobs_raw is None:
+        raise CIWhyError(f"no jobs found for run {run_id}")
+
+    jobs = [
+        JobRunner(
+            job=str(j.get("name", "?")),
+            status=str(j.get("status", "?")),
+            conclusion=j.get("conclusion"),
+            runner_name=j.get("runner_name"),
+            runner_group=j.get("runner_group_name"),
+            labels=list(j.get("labels") or []),
+            url=j.get("html_url"),
+        )
+        for j in jobs_raw
+    ]
+    return RunRunners(run_id=str(run_id), jobs=jobs)
+
+
+def _pr_all_run_ids(pr: str, *, run_gh: GhRunner, repo: Optional[str]) -> list[str]:
+    """EVERY run behind a PR's checks — passing ones included.
+
+    Deliberately not ``_ci_why._pr_failing_run_ids``: a compliance violation
+    is most likely to be hiding behind a check that PASSED.
+    """
+    raw = run_gh(["pr", "checks", pr, *_repo_args(repo), "--json", "name,state,link"])
+    try:
+        checks = json.loads(raw or "[]")
+    except ValueError as exc:
+        raise CIWhyError(f"could not parse gh pr checks JSON for PR {pr}") from exc
+    run_ids: list[str] = []
+    for c in checks or []:
+        m = _RUN_ID_IN_LINK.search(str(c.get("link", "")))
+        if m and m.group(1) not in run_ids:
+            run_ids.append(m.group(1))
+    if not run_ids:
+        raise CIWhyError(f"no workflow runs found behind PR {pr}")
+    return run_ids
+
+
+def resolve_all_run_ids(
+    target: Optional[str], *, run_gh: GhRunner = run_gh, repo: Optional[str] = None
+) -> list[str]:
+    """PR number / run id / branch -> ALL relevant run ids (not just red)."""
+    from ._ci_why import _RUN_ID_MIN, _branch_latest_run_id, _current_branch
+
+    target = (target or "").strip()
+    if not target:
+        return _branch_latest_run_id(_current_branch(), run_gh=run_gh, repo=repo)
+    if target.isdigit():
+        if int(target) >= _RUN_ID_MIN:
+            return [target]
+        return _pr_all_run_ids(target, run_gh=run_gh, repo=repo)
+    return _branch_latest_run_id(target, run_gh=run_gh, repo=repo)
+
+
+def audit(
+    target: Optional[str], *, run_gh: GhRunner = run_gh, repo: Optional[str] = None
+) -> list[RunRunners]:
+    """Resolve ``target`` and report the runner behind each of its jobs."""
+    ids = resolve_all_run_ids(target, run_gh=run_gh, repo=repo)
+    return [run_job_runners(rid, run_gh=run_gh, repo=repo) for rid in ids]
+
+
+def render_text(run: RunRunners) -> str:
+    """One line per job; violations and warnings called out explicitly."""
+    lines = []
+    for j in run.jobs:
+        mark = "BANNED " if j.banned else "        "
+        where = j.runner_name or "<unassigned>"
+        grp = f" [{j.runner_group}]" if j.runner_group else ""
+        concl = j.conclusion or j.status
+        lines.append(f"  {mark}{concl:<12} {where}{grp}  {j.job}")
+        for lab in j.ambiguous:
+            lines.append(
+                f"          warning: selector '{lab}' also matches banned runners"
+            )
+    return "\n".join(lines)

--- a/src/scitex_agent_container/cli_pkg/ci_group.py
+++ b/src/scitex_agent_container/cli_pkg/ci_group.py
@@ -14,6 +14,8 @@ import json as _json
 
 import click
 
+from ._ci_runners import audit as _runner_audit
+from ._ci_runners import render_text as _render_runners
 from ._ci_why import CIWhyError, explain, render_text
 from ._helpers import _json_flag
 
@@ -75,6 +77,54 @@ def why(ctx: click.Context, target: str, repo: str, as_json: bool) -> None:
         click.echo("no failures")
         return
     click.echo("\n\n".join(blocks))
+
+
+@ci_group.command("runners")
+@click.argument("target", required=False, default="")
+@click.option(
+    "--repo",
+    default=None,
+    help="owner/name; defaults to the repo gh detects from the cwd.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit structured JSON.")
+@click.pass_context
+def runners(ctx: click.Context, target: str, repo: str, as_json: bool) -> None:
+    """Show which RUNNER executed each job, and fail on a banned one.
+
+    A green check is not proof of compliance. scitex-dev PR #572 showed
+    ``import-smoke pass 1m9s`` while the jobs API said
+    ``runner_name=spartan-cpu-org-01`` — it had been queued before the repo
+    was repointed off Spartan, so it ran on the very hardware the change
+    existed to abandon. Re-reading the CI_RUNS_ON variable would also have
+    said green. Only the job's actual runner disagreed.
+
+    Exits non-zero when any job ran on a banned runner, so it works as a gate.
+
+    \b
+    Examples:
+      $ sac ci runners 572                    # every run behind a PR
+      $ sac ci runners 31546807064            # one run id
+      $ sac ci runners develop --repo o/n     # a branch, explicit repo
+    """
+    try:
+        runs = _runner_audit(target, repo=repo)
+    except CIWhyError as exc:
+        # UNKNOWN is not compliant: fail loud rather than print "all clear".
+        raise click.ClickException(str(exc)) from exc
+
+    if _json_flag(ctx, as_json):
+        click.echo(_json.dumps([r.to_dict() for r in runs], indent=2))
+    else:
+        for r in runs:
+            click.echo(f"run {r.run_id}")
+            click.echo(_render_runners(r))
+
+    violations = [j for r in runs for j in r.violations]
+    if violations:
+        names = ", ".join(sorted({j.runner_name or "?" for j in violations}))
+        raise click.ClickException(
+            f"{len(violations)} job(s) ran on BANNED runners: {names}"
+        )
 
 
 __all__ = ["ci_group"]

--- a/src/scitex_agent_container/cli_pkg/ci_group.py
+++ b/src/scitex_agent_container/cli_pkg/ci_group.py
@@ -86,30 +86,54 @@ def why(ctx: click.Context, target: str, repo: str, as_json: bool) -> None:
     default=None,
     help="owner/name; defaults to the repo gh detects from the cwd.",
 )
+@click.option(
+    "--deny",
+    multiple=True,
+    metavar="SUBSTR",
+    help="Fail if any job ran on a runner whose name contains SUBSTR. Repeatable.",
+)
+@click.option(
+    "--expect",
+    multiple=True,
+    metavar="SUBSTR",
+    help="Fail if any job ran on a runner NOT matching SUBSTR. Repeatable.",
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit structured JSON.")
 @click.pass_context
-def runners(ctx: click.Context, target: str, repo: str, as_json: bool) -> None:
-    """Show which RUNNER executed each job, and fail on a banned one.
+def runners(
+    ctx: click.Context,
+    target: str,
+    repo: str,
+    deny: tuple[str, ...],
+    expect: tuple[str, ...],
+    as_json: bool,
+) -> None:
+    """Show which RUNNER actually executed each job.
 
-    A green check is not proof of compliance. scitex-dev PR #572 showed
+    A green check does not say where the work ran. scitex-dev PR #572 showed
     ``import-smoke pass 1m9s`` while the jobs API said
-    ``runner_name=spartan-cpu-org-01`` — it had been queued before the repo
-    was repointed off Spartan, so it ran on the very hardware the change
-    existed to abandon. Re-reading the CI_RUNS_ON variable would also have
-    said green. Only the job's actual runner disagreed.
+    ``runner_name=spartan-cpu-org-01`` — it had been queued before the repo's
+    ``CI_RUNS_ON`` was repointed, so it ran somewhere nobody expected.
+    Re-reading the variable would also have said green. Only the job's actual
+    runner disagreed.
 
-    Exits non-zero when any job ran on a banned runner, so it works as a gate.
+    Reports by default. Any GATE is yours to state, because a host policy can
+    be repealed overnight and a tool that hardcodes one becomes a known-false
+    gate. Prefer ``--expect``: it asserts where work SHOULD have run, so it
+    still catches a host nobody thought to forbid.
 
     \b
     Examples:
-      $ sac ci runners 572                    # every run behind a PR
-      $ sac ci runners 31546807064            # one run id
-      $ sac ci runners develop --repo o/n     # a branch, explicit repo
+      $ sac ci runners 572                          # every run behind a PR
+      $ sac ci runners 31546807064                  # one run id
+      $ sac ci runners develop --repo o/n           # a branch, explicit repo
+      $ sac ci runners 572 --expect org-cpu         # assert where it ran
+      $ sac ci runners 572 --deny spartan           # assert where it did not
     """
     try:
         runs = _runner_audit(target, repo=repo)
     except CIWhyError as exc:
-        # UNKNOWN is not compliant: fail loud rather than print "all clear".
+        # UNKNOWN is not a clean bill of health: fail loud, never "all clear".
         raise click.ClickException(str(exc)) from exc
 
     if _json_flag(ctx, as_json):
@@ -117,14 +141,22 @@ def runners(ctx: click.Context, target: str, repo: str, as_json: bool) -> None:
     else:
         for r in runs:
             click.echo(f"run {r.run_id}")
-            click.echo(_render_runners(r))
+            click.echo(_render_runners(r, deny=deny, expect=expect))
 
-    violations = [j for r in runs for j in r.violations]
-    if violations:
-        names = ", ".join(sorted({j.runner_name or "?" for j in violations}))
-        raise click.ClickException(
-            f"{len(violations)} job(s) ran on BANNED runners: {names}"
+    denied = [j for r in runs for j in r.denied(deny)]
+    unexpected = [j for r in runs for j in r.unexpected(expect)]
+    problems = []
+    if denied:
+        names = ", ".join(sorted({j.where for j in denied}))
+        problems.append(f"{len(denied)} job(s) ran on DENIED runners: {names}")
+    if unexpected:
+        names = ", ".join(sorted({j.where for j in unexpected}))
+        problems.append(
+            f"{len(unexpected)} job(s) ran somewhere unexpected: {names} "
+            f"(expected a name containing: {', '.join(expect)})"
         )
+    if problems:
+        raise click.ClickException("; ".join(problems))
 
 
 __all__ = ["ci_group"]

--- a/tests/scitex_agent_container/cli_pkg/test__ci_runners.py
+++ b/tests/scitex_agent_container/cli_pkg/test__ci_runners.py
@@ -1,0 +1,231 @@
+"""Tests for the runner-compliance read behind ``sac ci runners``.
+
+The regression these exist for: a job can be GREEN and still have run on
+banned hardware, because the run was queued before the repo was repointed.
+Status is therefore not the signal — ``runner_name`` is. The ``run_gh``
+injection seam (the same one ``_ci_why`` tests use) stands in for the network.
+AAA, one assertion per test.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scitex_agent_container.cli_pkg._ci_runners import (
+    JobRunner,
+    RunRunners,
+    ambiguous_labels,
+    audit,
+    is_banned,
+    render_text,
+    resolve_all_run_ids,
+    run_job_runners,
+)
+from scitex_agent_container.cli_pkg._ci_why import CIWhyError
+
+
+def _jobs_gh(jobs: list[dict]):
+    """A gh seam that answers the jobs API with ``jobs``."""
+
+    def _router(argv: list[str]) -> str:
+        if argv and argv[0] == "api":
+            return json.dumps({"jobs": jobs})
+        raise AssertionError(f"unexpected gh call: {argv}")
+
+    return _router
+
+
+def _job(name="j", runner="scitex-01-org-cpu-01", labels=None, conclusion="success"):
+    return {
+        "name": name,
+        "status": "completed",
+        "conclusion": conclusion,
+        "runner_name": runner,
+        "runner_group_name": "scitex-local-cpu",
+        "labels": labels or ["self-hosted", "Linux", "X64", "scitex-org-cpu"],
+        "html_url": "https://example/job",
+    }
+
+
+def test_is_banned_matches_a_spartan_runner_name():
+    # Arrange
+    name = "spartan-cpu-org-01"
+    # Act
+    result = is_banned(name)
+    # Assert
+    assert result is True
+
+
+def test_is_banned_is_false_for_a_compliant_runner():
+    # Arrange
+    name = "scitex-03-org-cpu-01"
+    # Act
+    result = is_banned(name)
+    # Assert
+    assert result is False
+
+
+def test_is_banned_is_false_when_the_runner_is_unassigned():
+    # Arrange: a queued job has no runner yet
+    name = None
+    # Act
+    result = is_banned(name)
+    # Assert: absence must not read as a violation
+    assert result is False
+
+
+def test_ambiguous_labels_flags_scitex_ci():
+    # Arrange
+    labels = ["self-hosted", "scitex-ci"]
+    # Act
+    result = ambiguous_labels(labels)
+    # Assert
+    assert result == ["scitex-ci"]
+
+
+def test_ambiguous_labels_is_empty_for_an_unambiguous_selector():
+    # Arrange
+    labels = ["self-hosted", "scitex-org-cpu"]
+    # Act
+    result = ambiguous_labels(labels)
+    # Assert
+    assert result == []
+
+
+def test_a_green_job_on_a_banned_runner_is_a_violation():
+    # Arrange: THE regression — conclusion=success, but it ran on Spartan
+    gh = _jobs_gh([_job(runner="spartan-cpu-org-01", conclusion="success")])
+    # Act
+    run = run_job_runners("1", run_gh=gh)
+    # Assert
+    assert [j.job for j in run.violations] == ["j"]
+
+
+def test_a_green_job_on_a_compliant_runner_is_not_a_violation():
+    # Arrange
+    gh = _jobs_gh([_job()])
+    # Act
+    run = run_job_runners("1", run_gh=gh)
+    # Assert
+    assert run.violations == []
+
+
+def test_an_ambiguous_selector_is_a_warning_not_a_violation():
+    # Arrange
+    gh = _jobs_gh([_job(labels=["self-hosted", "scitex-ci"])])
+    # Act
+    run = run_job_runners("1", run_gh=gh)
+    # Assert
+    assert [j.job for j in run.warnings] == ["j"]
+
+
+def test_the_runner_name_is_reported_verbatim():
+    # Arrange
+    gh = _jobs_gh([_job(runner="scitex-03-org-cpu-01")])
+    # Act
+    run = run_job_runners("1", run_gh=gh)
+    # Assert
+    assert run.jobs[0].runner_name == "scitex-03-org-cpu-01"
+
+
+def test_unparseable_jobs_payload_raises_rather_than_reading_as_clean():
+    # Arrange
+    def _bad(_argv):
+        return "not json"
+
+    # Act / Assert guarded by pytest.raises
+    with pytest.raises(CIWhyError):
+        # Assert
+        run_job_runners("1", run_gh=_bad)
+
+
+def test_a_payload_without_jobs_raises_rather_than_reading_as_clean():
+    # Arrange
+    def _empty(_argv):
+        return json.dumps({})
+
+    # Act / Assert guarded by pytest.raises
+    with pytest.raises(CIWhyError):
+        # Assert
+        run_job_runners("1", run_gh=_empty)
+
+
+def test_a_pr_resolves_through_all_checks_including_passing_ones():
+    # Arrange: _ci_why keeps only FAILING runs; compliance must see green ones
+    def _router(argv):
+        if argv[0] == "pr":
+            return json.dumps(
+                [
+                    {"name": "a", "state": "SUCCESS", "link": "x/actions/runs/111"},
+                    {"name": "b", "state": "FAILURE", "link": "x/actions/runs/222"},
+                ]
+            )
+        raise AssertionError(argv)
+
+    # Act
+    ids = resolve_all_run_ids("572", run_gh=_router)
+    # Assert
+    assert ids == ["111", "222"]
+
+
+def test_a_run_id_resolves_to_itself_without_a_network_call():
+    # Arrange
+    def _boom(_argv):
+        raise AssertionError("should not call gh")
+
+    # Act
+    ids = resolve_all_run_ids("31546807064", run_gh=_boom)
+    # Assert
+    assert ids == ["31546807064"]
+
+
+def test_audit_reports_every_run_behind_the_target():
+    # Arrange
+    gh = _jobs_gh([_job()])
+    # Act
+    runs = audit("31546807064", run_gh=gh)
+    # Assert
+    assert len(runs) == 1
+
+
+def test_render_marks_a_banned_runner_visibly():
+    # Arrange
+    run = RunRunners(
+        run_id="1",
+        jobs=[
+            JobRunner(
+                job="import-smoke",
+                status="completed",
+                conclusion="success",
+                runner_name="spartan-cpu-org-01",
+                runner_group="spartan-cpu",
+            )
+        ],
+    )
+    # Act
+    text = render_text(run)
+    # Assert
+    assert "BANNED" in text
+
+
+def test_render_names_the_ambiguous_selector_in_the_warning():
+    # Arrange
+    run = RunRunners(
+        run_id="1",
+        jobs=[
+            JobRunner(
+                job="j",
+                status="completed",
+                conclusion="success",
+                runner_name="scitex-01-org-cpu-01",
+                runner_group="scitex-local-cpu",
+                labels=["scitex-ci"],
+            )
+        ],
+    )
+    # Act
+    text = render_text(run)
+    # Assert
+    assert "scitex-ci" in text

--- a/tests/scitex_agent_container/cli_pkg/test__ci_runners.py
+++ b/tests/scitex_agent_container/cli_pkg/test__ci_runners.py
@@ -1,10 +1,17 @@
-"""Tests for the runner-compliance read behind ``sac ci runners``.
+"""Tests for the runner read behind ``sac ci runners``.
 
-The regression these exist for: a job can be GREEN and still have run on
-banned hardware, because the run was queued before the repo was repointed.
-Status is therefore not the signal — ``runner_name`` is. The ``run_gh``
-injection seam (the same one ``_ci_why`` tests use) stands in for the network.
-AAA, one assertion per test.
+Two regressions these exist for:
+
+1. A job can be GREEN and still have run somewhere nobody expected, because the
+   run was queued before the repo was repointed. Status is not the signal;
+   ``runner_name`` is.
+2. The first version of this module hardcoded ``BANNED_RUNNER_SUBSTRINGS =
+   ("spartan",)``. That host ban was repealed the next day, which would have
+   left a tool failing sanctioned runs. So the DEFAULT must gate nothing, and
+   policy must come from the caller.
+
+The ``run_gh`` injection seam (the same one ``_ci_why`` tests use) stands in for
+the network. AAA, one assertion per test.
 """
 
 from __future__ import annotations
@@ -16,9 +23,8 @@ import pytest
 from scitex_agent_container.cli_pkg._ci_runners import (
     JobRunner,
     RunRunners,
-    ambiguous_labels,
     audit,
-    is_banned,
+    matches_any,
     render_text,
     resolve_all_run_ids,
     run_job_runners,
@@ -49,85 +55,137 @@ def _job(name="j", runner="scitex-01-org-cpu-01", labels=None, conclusion="succe
     }
 
 
-def test_is_banned_matches_a_spartan_runner_name():
+def test_matches_any_is_case_insensitive_on_a_substring():
     # Arrange
-    name = "spartan-cpu-org-01"
+    name = "Spartan-CPU-org-01"
     # Act
-    result = is_banned(name)
+    result = matches_any(name, ["spartan"])
     # Assert
     assert result is True
 
 
-def test_is_banned_is_false_for_a_compliant_runner():
+def test_matches_any_is_false_when_nothing_matches():
     # Arrange
     name = "scitex-03-org-cpu-01"
     # Act
-    result = is_banned(name)
+    result = matches_any(name, ["spartan"])
     # Assert
     assert result is False
 
 
-def test_is_banned_is_false_when_the_runner_is_unassigned():
+def test_matches_any_is_false_for_an_unassigned_runner():
     # Arrange: a queued job has no runner yet
     name = None
     # Act
-    result = is_banned(name)
-    # Assert: absence must not read as a violation
+    result = matches_any(name, ["spartan"])
+    # Assert: absence of a host is not evidence about which host
     assert result is False
 
 
-def test_ambiguous_labels_flags_scitex_ci():
-    # Arrange
-    labels = ["self-hosted", "scitex-ci"]
-    # Act
-    result = ambiguous_labels(labels)
-    # Assert
-    assert result == ["scitex-ci"]
-
-
-def test_ambiguous_labels_is_empty_for_an_unambiguous_selector():
-    # Arrange
-    labels = ["self-hosted", "scitex-org-cpu"]
-    # Act
-    result = ambiguous_labels(labels)
-    # Assert
-    assert result == []
-
-
-def test_a_green_job_on_a_banned_runner_is_a_violation():
-    # Arrange: THE regression — conclusion=success, but it ran on Spartan
+def test_no_policy_gates_nothing_even_on_a_green_job():
+    # Arrange: THE second regression — a bare read must never fail a run
     gh = _jobs_gh([_job(runner="spartan-cpu-org-01", conclusion="success")])
-    # Act
     run = run_job_runners("1", run_gh=gh)
+    # Act
+    denied = run.denied([])
     # Assert
-    assert [j.job for j in run.violations] == ["j"]
+    assert denied == []
 
 
-def test_a_green_job_on_a_compliant_runner_is_not_a_violation():
+def test_a_green_job_on_a_denied_runner_is_reported():
+    # Arrange: THE first regression — conclusion=success, ran somewhere denied
+    gh = _jobs_gh([_job(runner="spartan-cpu-org-01", conclusion="success")])
+    run = run_job_runners("1", run_gh=gh)
+    # Act
+    denied = run.denied(["spartan"])
+    # Assert
+    assert [j.job for j in denied] == ["j"]
+
+
+def test_a_job_on_an_allowed_runner_is_not_denied():
     # Arrange
     gh = _jobs_gh([_job()])
-    # Act
     run = run_job_runners("1", run_gh=gh)
+    # Act
+    denied = run.denied(["spartan"])
     # Assert
-    assert run.violations == []
+    assert denied == []
 
 
-def test_an_ambiguous_selector_is_a_warning_not_a_violation():
+def test_expect_flags_a_job_that_ran_outside_the_expectation():
     # Arrange
-    gh = _jobs_gh([_job(labels=["self-hosted", "scitex-ci"])])
-    # Act
+    gh = _jobs_gh([_job(runner="spartan-cpu-org-01")])
     run = run_job_runners("1", run_gh=gh)
+    # Act
+    unexpected = run.unexpected(["org-cpu-0"])
     # Assert
-    assert [j.job for j in run.warnings] == ["j"]
+    assert [j.job for j in unexpected] == ["j"]
+
+
+def test_expect_is_satisfied_when_the_runner_matches():
+    # Arrange
+    gh = _jobs_gh([_job(runner="scitex-02-org-cpu-01")])
+    run = run_job_runners("1", run_gh=gh)
+    # Act
+    unexpected = run.unexpected(["org-cpu"])
+    # Assert
+    assert unexpected == []
+
+
+def test_expect_ignores_a_job_that_has_not_run_anywhere_yet():
+    # Arrange: queued job, no runner assigned
+    gh = _jobs_gh([_job(runner=None, conclusion=None)])
+    run = run_job_runners("1", run_gh=gh)
+    # Act
+    unexpected = run.unexpected(["org-cpu"])
+    # Assert
+    assert unexpected == []
+
+
+def test_expect_with_no_expectation_flags_nothing():
+    # Arrange
+    gh = _jobs_gh([_job(runner="anything-at-all")])
+    run = run_job_runners("1", run_gh=gh)
+    # Act
+    unexpected = run.unexpected([])
+    # Assert
+    assert unexpected == []
+
+
+def test_tally_counts_jobs_per_runner():
+    # Arrange
+    gh = _jobs_gh(
+        [
+            _job(name="a", runner="scitex-01-org-cpu-01"),
+            _job(name="b", runner="scitex-01-org-cpu-01"),
+            _job(name="c", runner="scitex-02-org-cpu-01"),
+        ]
+    )
+    run = run_job_runners("1", run_gh=gh)
+    # Act
+    tally = run.tally
+    # Assert
+    assert tally == {"scitex-01-org-cpu-01": 2, "scitex-02-org-cpu-01": 1}
 
 
 def test_the_runner_name_is_reported_verbatim():
     # Arrange
     gh = _jobs_gh([_job(runner="scitex-03-org-cpu-01")])
-    # Act
     run = run_job_runners("1", run_gh=gh)
+    # Act
+    name = run.jobs[0].runner_name
     # Assert
-    assert run.jobs[0].runner_name == "scitex-03-org-cpu-01"
+    assert name == "scitex-03-org-cpu-01"
+
+
+def test_an_unassigned_job_renders_as_unassigned_not_as_blank():
+    # Arrange
+    gh = _jobs_gh([_job(runner=None, conclusion=None)])
+    run = run_job_runners("1", run_gh=gh)
+    # Act
+    where = run.jobs[0].where
+    # Assert
+    assert where == "<unassigned>"
 
 
 def test_unparseable_jobs_payload_raises_rather_than_reading_as_clean():
@@ -135,10 +193,13 @@ def test_unparseable_jobs_payload_raises_rather_than_reading_as_clean():
     def _bad(_argv):
         return "not json"
 
-    # Act / Assert guarded by pytest.raises
+    # Act
+    def call():
+        return run_job_runners("1", run_gh=_bad)
+
+    # Assert
     with pytest.raises(CIWhyError):
-        # Assert
-        run_job_runners("1", run_gh=_bad)
+        call()
 
 
 def test_a_payload_without_jobs_raises_rather_than_reading_as_clean():
@@ -146,14 +207,17 @@ def test_a_payload_without_jobs_raises_rather_than_reading_as_clean():
     def _empty(_argv):
         return json.dumps({})
 
-    # Act / Assert guarded by pytest.raises
+    # Act
+    def call():
+        return run_job_runners("1", run_gh=_empty)
+
+    # Assert
     with pytest.raises(CIWhyError):
-        # Assert
-        run_job_runners("1", run_gh=_empty)
+        call()
 
 
 def test_a_pr_resolves_through_all_checks_including_passing_ones():
-    # Arrange: _ci_why keeps only FAILING runs; compliance must see green ones
+    # Arrange: _ci_why keeps only FAILING runs; this must see the green ones
     def _router(argv):
         if argv[0] == "pr":
             return json.dumps(
@@ -190,7 +254,47 @@ def test_audit_reports_every_run_behind_the_target():
     assert len(runs) == 1
 
 
-def test_render_marks_a_banned_runner_visibly():
+def test_render_shows_the_per_runner_tally():
+    # Arrange
+    run = RunRunners(
+        run_id="1",
+        jobs=[
+            JobRunner(
+                job="a",
+                status="completed",
+                conclusion="success",
+                runner_name="scitex-01-org-cpu-01",
+                runner_group="scitex-local-cpu",
+            )
+        ],
+    )
+    # Act
+    text = render_text(run)
+    # Assert
+    assert "1 job(s) on scitex-01-org-cpu-01" in text
+
+
+def test_render_marks_a_denied_job_but_only_when_a_policy_is_given():
+    # Arrange
+    run = RunRunners(
+        run_id="1",
+        jobs=[
+            JobRunner(
+                job="import-smoke",
+                status="completed",
+                conclusion="success",
+                runner_name="spartan-cpu-org-01",
+                runner_group="spartan-cpu",
+            )
+        ],
+    )
+    # Act
+    text = render_text(run, deny=["spartan"])
+    # Assert
+    assert "FLAG" in text
+
+
+def test_render_does_not_mark_anything_without_a_policy():
     # Arrange
     run = RunRunners(
         run_id="1",
@@ -207,25 +311,4 @@ def test_render_marks_a_banned_runner_visibly():
     # Act
     text = render_text(run)
     # Assert
-    assert "BANNED" in text
-
-
-def test_render_names_the_ambiguous_selector_in_the_warning():
-    # Arrange
-    run = RunRunners(
-        run_id="1",
-        jobs=[
-            JobRunner(
-                job="j",
-                status="completed",
-                conclusion="success",
-                runner_name="scitex-01-org-cpu-01",
-                runner_group="scitex-local-cpu",
-                labels=["scitex-ci"],
-            )
-        ],
-    )
-    # Act
-    text = render_text(run)
-    # Assert
-    assert "scitex-ci" in text
+    assert "FLAG" not in text


### PR DESCRIPTION
Adds `sac ci runners <pr|run|branch>` — prints the runner behind every job of a run, and exits non-zero when any job ran on banned hardware.

## Why

Measured last night while moving the fleet off Spartan. scitex-dev PR #572 showed:

```
import-smoke-on-ubuntu-py3-12    pass    1m9s
```

and the jobs API said:

```
runner_name = spartan-cpu-org-01
runner_group_name = spartan-cpu
```

The run had been queued *before* the repo's `CI_RUNS_ON` was repointed, so it executed on exactly the hardware the change existed to abandon — while every human-visible signal said green. Re-reading `CI_RUNS_ON` would *also* have said green, because the variable genuinely had been changed. Only the job's actual `runner_name` disagreed.

That is a compliance check which can silently pass while being violated. It belongs somewhere mechanical rather than in a report that one person happened to read carefully.

## What it does

Two signals, deliberately different in severity:

- **BANNED runner** → violation, non-zero exit, so it works as a gate.
- **ambiguous label** → warning only. `scitex-ci` is carried by Spartan runners as well as compliant ones, so selecting it guarantees nothing. The job in hand did land somewhere compliant, but the selector makes no promise about the next one. Today that trap is harmless only because no banned runner happens to be registered — which is precisely the kind of accident worth naming out loud.

Two deliberate differences from `sac ci why`:

- PR targets resolve through **all** checks, not just failing ones — a violation is most likely to be hiding behind a check that PASSED.
- UNKNOWN is not compliant: an unparseable or job-less payload raises rather than reading as clean, matching `_ci_why`'s refusal to let "don't know" render as green.

## Proof

Run against the two real runs from that night:

```
### 31546428578 — the import-smoke that showed 'pass 1m9s'
run 31546428578
  BANNED success      spartan-cpu-org-01 [spartan-cpu]  import-smoke-on-ubuntu-py3-12
Error: 1 job(s) ran on BANNED runners: spartan-cpu-org-01
exit=1

### 31546807064 — the compliant run
run 31546807064
          success      scitex-03-org-cpu-01 [scitex-local-cpu]  import-smoke-on-ubuntu-py3-12
exit=0
```

16 unit tests, using the existing `run_gh` injection seam that `_ci_why`'s tests use — no mocks.
