### PR TITLE
docs(adr-0022): a spec is the CONTRACT for an agent not yet started, never its state

### DIFF
--- a/docs/adr/0022-state-in-postgres-configuration-in-git.md
+++ b/docs/adr/0022-state-in-postgres-configuration-in-git.md
@@ -5,7 +5,16 @@
 * **Operator rulings**: 「state.db というものは使ってはいけません」/
   「sqlite 使った瞬間負けだと思った方が良いです」/
   「今 5432 を scitex のために使ってるものはすべて間違い」/
-  「今他のホストと連絡が取れてないっていうのはまぁ正常です。正しいです」
+  「今他のホストと連絡が取れてないっていうのはまぁ正常です。正しいです」/
+  2026-08-11, and called universal
+  (「これはどんな時も従うべき話だと思います」):
+  「スペックというのは今動いてるエージェントの状態を表すのではなくて、未来に
+  動くエージェントの規約」/「その状態に関しては必ずデータベースに入れなきゃ
+  いけないし、その起動されたタイミングのスペックというのは、エージェントの中に
+  焼き込まれないといけない情報です」/「スペックは設計書、実際に動いてる
+  エージェントの状況はデータベース」 — recorded in §3 as a fourth class of
+  fact, and as a sac skill
+  (`_skills/scitex-agent-container/34_spec-is-a-contract-not-state.md`).
 * **Consumers**: scitex-agent-container, scitex-cards, scitex-scholar,
   scitex-writer, scitex-plt (figrecipe), scitex-hub, scitex-ui,
   scitex-app —「いろんなパッケージから使う」
@@ -90,12 +99,29 @@ the *diagnostic* improved, the *cause* did not.
 
 ---
 
-## 3. The cut: three kinds of fact, three homes
+## 3. The cut: four kinds of fact, four homes
 
 Not everything in `state.db` is state. Classifying first is what makes
 both the migration and the sync rules small — **and note that each class
 gets a different conflict rule in §5, so this table is not bookkeeping,
 it is the sync design.**
+
+**The classifying question is about TENSE, not about file format.** A
+spec is written in the future tense: it is **the contract for an agent
+that has not started yet**, and it stays a contract for the whole life of
+the process it launched. It is never a description of a running agent.
+The three consequences, per the operator's 2026-08-11 ruling:
+
+1. **Design document → git.** The spec says what an agent *shall* be.
+2. **What is actually true of a running agent → the database** (per-host
+   PostgreSQL on `:55432`, §2).
+3. **What the contract said AT LAUNCH → burned into the agent as a
+   file**, so the agent can answer "how was I actually born" without
+   asking a store, and without being told a later edit's answer.
+
+Piece 3 is a distinct class of fact, not a copy of piece 1: the git-side
+spec is **live and mutable**, and editing it does not retroactively
+change how a running agent was started.
 
 ### CONFIGURATION → files under Git (never synced by us — git is the sync)
 
@@ -121,6 +147,60 @@ That is what makes them safely syncable (§5).
 `instance_heartbeats`, `channel_events`, `dispatches`,
 `relocation_journal`, `verdict_delivered`. Bulk of the bytes, least
 urgent, and the easiest to sync (pure union).
+
+### LAUNCH SNAPSHOT → a file burned into the agent
+
+The spec **as it stood at the moment of launch**, frozen and carried
+inside the agent. Not synced, not mutable, not authoritative about the
+present — it answers exactly one question, and only the agent asks it:
+*how was I actually born?*
+
+It is needed because neither of the other homes can answer it:
+
+* The **git-side spec is live**. Measured on this container: the bound
+  spec dir is `…/agents/scitex-agent-container/`, the same directory the
+  operator edits, and it holds `.old/20260812T190500Z/` and
+  `.old/20260812T222000Z/` — two rewrites of this agent's own spec in one
+  evening. Reading it answers "what would I be if started NOW".
+* The **database holds the present**, not the terms of a past launch.
+
+Deliberately a file, not a row: it must remain readable by an agent whose
+store is unreachable, and it must be immune to the class of bug in §1
+(an answer that changes with where the reader stands).
+
+### The failure this forbids: reading a promise as a fact
+
+A spec field may legitimately declare a **promise to resolve later**.
+Reading such a field as though it were a value yields a sentinel, and a
+sentinel silently fails every numeric or identity test applied to it.
+
+Measured on scitex-compute-04, 2026-08-11 — `spec.a2a.port` across every
+`agents/*/spec.yaml` (107 files, of which 3 are `_template_*` scaffolds,
+so **104 real agent specs**):
+
+| what the spec declares | agents |
+|---|---|
+| `port: auto` | 93 |
+| `port: null` (sidecar deliberately off) | 11 |
+| **a concrete int** | **0** |
+
+The near-miss, same night: the tui turn-bridge supervisor (PR #973) must
+know which port an agent's bridge should serve. Had it read
+`config.a2a.port`, it would have received the literal string `"auto"`,
+found no number, concluded there was nothing to supervise, and supervised
+**nothing — on every agent in the fleet**, while reporting healthy. It
+reads the port allocator's **claim** instead (`a2a_ports`, which is
+state): `sac agents list scitex-agent-container` answers `19016`, a fact
+that exists only because a start already happened.
+
+`session_id` is the same split and is not yet resolved: what a spec
+declares (`session: continue` / `fresh`) is a promise about how to
+resume; *which conversation actually resumed* is state. Card
+`sac-pin-session-id-at-start-removes-f34-20260812` tracks it.
+
+**The rule, stated so it can be applied without this ADR in hand:** if
+answering a question requires knowing that a start has already happened,
+the spec cannot answer it. Ask the database.
 
 ---
 
@@ -365,3 +445,43 @@ spec path is exercised through the real
 9. **`~/.scitex/agent-container/runtime/state.db` on ywata-note-win is
    untouched**, deliberately: nine remaining relocations read it.
 10. **Six of the eight named consumers are unsurveyed.**
+11. **The launch snapshot (§3) is specified, not implemented.** No file
+    is burned into an agent today. What a container can read is the LIVE
+    spec dir, bind-mounted at `$SCITEX_AGENT_CONTAINER_YAML_DIRS` — so an
+    agent asking "how was I born" currently gets "how you would be born
+    if started now". Design constraints when it is built: written once at
+    start, never rewritten, readable with the store unreachable, and
+    carrying the RESOLVED values (the claimed port, not `auto`) beside
+    the declared ones.
+12. **`session_id` is not pinned at start.** `sac agents list <name>` can
+    report `session_id: null` for an agent with a live session — the
+    promise is recorded, the fact is not. Card
+    `sac-pin-session-id-at-start-removes-f34-20260812`.
+13. **The mechanical check is deliberately narrow, and the general rule
+    is NOT mechanised.** `STX-SAC004` (this package's linter plugin,
+    severity *warning*) fires only when a listed sentinel-bearing spec
+    field is `return`ed or passed as a call argument without the
+    enclosing function narrowing the sentinel; `_SENTINEL_FIELDS` holds
+    exactly one entry (`a2a.port`). Comparisons are not flagged —
+    asserting what a contract says is the correct way to read one.
+    "This code is reading a spec to learn a running agent's state" is not
+    mechanically decidable, and a rule that fired on every `config.`
+    access would be noise; the fleet has a precedent for what happens
+    then (a rule shipped at error severity turned 44 repositories red on
+    day one and was restaged to warning the next day). A new
+    resolve-at-runtime field is invisible to the rule until it is added
+    to that list.
+14. **The spec header is emitted by the GENERATORS only.** Every spec
+    scaffolded by `sac agents create` (minimal + full) and by the
+    contributor renderer now opens with two lines — "this is a design
+    document / a running agent's state lives in the database". The 113
+    specs already on disk are NOT swept by this change, the operator's
+    `_template_*/` dir-templates live outside this repo, and nothing
+    enforces the header's presence: a YAML comment is not schema, and
+    making it one would turn a note for humans into a validator's
+    business. Accepted — its audience is a person with the file open.
+    The three `_template_*/` dir-templates on scitex-compute-04 were
+    given the header by hand (backups under
+    `~/.scitex/agent-container/.old/20260811T235819Z/dir-templates/` with
+    a manifest); the remaining 104 are carded as
+    `sac-sweep-design-doc-header-into-existing-specs-20260812`.

--- a/src/scitex_agent_container/_linter_plugin.py
+++ b/src/scitex_agent_container/_linter_plugin.py
@@ -83,11 +83,44 @@ def get_plugin():
     # config object before invoking plugin checkers. Once that lands, SAC003
     # can be re-enabled by re-adding it to the returned dict.
 
+    SAC004 = Rule(
+        id="STX-SAC004",
+        # WARNING, not error, on purpose. The rule fires zero times across
+        # sac's own src/ + tests/ today, but plugin rules load into EVERY
+        # repo linted on a machine where sac is installed, and a fleet
+        # precedent stands: a rule shipped at error severity turned 44
+        # repositories red on day one and was restaged to warning the next
+        # day. A warning still surfaces the next occurrence at review time.
+        severity="warning",
+        category="spec-vs-state",
+        message=(
+            "A spec field that may hold a resolve-at-runtime SENTINEL "
+            "(e.g. ``spec.a2a.port: auto``) is returned or passed on as if "
+            "it were a concrete value. A spec is the CONTRACT for an agent "
+            "that has not started yet — it declares a PROMISE here, not a "
+            "fact, so the caller receives the string ``\"auto\"`` and every "
+            "numeric test on it silently fails (ADR-0022 §3)."
+        ),
+        suggestion=(
+            "Read the STATE that a start actually produced: "
+            "``_state.port_allocator.get_port(name)`` for the a2a port "
+            "(the ``a2a_ports`` claim). If this code legitimately handles "
+            "the sentinel, narrow it in this function first — "
+            "``a2a.is_auto`` / ``a2a.is_disabled`` / ``== 'auto'`` / "
+            "``isinstance(port, int)`` — or suppress with "
+            "``# stx-allow: STX-SAC004``."
+        ),
+    )
+
     return {
-        "rules": [SAC001, SAC002],
+        "rules": [SAC001, SAC002, SAC004],
         "call_rules": {},
         "axes_hints": {},
-        "checkers": [_SacCardChecker, _SacMethodChecker],
+        "checkers": [
+            _SacCardChecker,
+            _SacMethodChecker,
+            _SacSpecSentinelChecker,
+        ],
     }
 
 
@@ -183,6 +216,108 @@ class _SacMethodChecker(ast.NodeVisitor):
                 if issue is not None:
                     self.issues.append(issue)
         self.generic_visit(node)
+
+
+#: Spec attribute paths whose declared value may be a resolve-at-runtime
+#: SENTINEL rather than a value. Each entry is ``(parent_attr, attr)`` and
+#: matches any expression ending ``….<parent>.<attr>`` — ``config.a2a.port``,
+#: ``self.config.a2a.port``, ``cfg.a2a.port`` alike.
+#:
+#: KEEP THIS LIST HONEST: a runtime-resolved spec field that is not listed
+#: here is invisible to the rule. ``a2a.port`` is the only one today —
+#: measured on scitex-compute-04 2026-08-11, 0 of 104 registered fleet
+#: specs declare a concrete port (93 ``auto``, 11 ``null``).
+_SENTINEL_FIELDS: frozenset[tuple[str, str]] = frozenset({("a2a", "port")})
+
+#: Substrings whose presence anywhere in the enclosing function means that
+#: function is already sentinel-AWARE, so its reads are deliberate. Kept
+#: coarse on purpose: a false negative (missing a real bug) is far cheaper
+#: than a false positive on correct code, which is how rules get disabled.
+_SENTINEL_NARROWERS: tuple[str, ...] = (
+    "is_auto",
+    "is_disabled",
+    "auto",
+    "isinstance",
+    "resolve_a2a_port",
+    "resolved_a2a_port",
+    "get_port",
+    "claim_port",
+)
+
+
+def _is_sentinel_field(node: ast.AST) -> bool:
+    """True iff *node* is an attribute read of a listed sentinel field."""
+    if not isinstance(node, ast.Attribute):
+        return False
+    parent = node.value
+    if not isinstance(parent, ast.Attribute):
+        return False
+    return (parent.attr, node.attr) in _SENTINEL_FIELDS
+
+
+class _SacSpecSentinelChecker(ast.NodeVisitor):
+    """SAC004 — a sentinel-bearing spec field used as a concrete value.
+
+    Deliberately NARROW. Only two positions are flagged, because only
+    these two make the sentinel escape into code that cannot see where it
+    came from:
+
+    * ``return <x>.a2a.port`` — the value leaves the function.
+    * ``f(<x>.a2a.port)`` / ``f(port=<x>.a2a.port)`` — it becomes someone
+      else's argument.
+
+    A COMPARISON is never flagged (``assert cfg.a2a.port == 7901``,
+    ``if cfg.a2a.port is None``): asserting or branching on what the
+    contract SAYS is the correct way to read a contract, and those are the
+    only reads sac's own tests perform.
+
+    The enclosing function is exempt when it mentions any
+    :data:`_SENTINEL_NARROWERS` token, so resolvers and sentinel-aware
+    branches are silent without needing an allowlist of file paths — which
+    is exactly the plumbing gap that keeps SAC003 deferred.
+    """
+
+    def __init__(self, source_lines, config):
+        self.source_lines = source_lines
+        self.config = config
+        self.issues: list = []
+        self._narrowing_depth = 0
+
+    # -- scope tracking: a sentinel-aware function silences its whole body
+
+    def _visit_scope(self, node) -> None:
+        aware = any(tok in ast.unparse(node) for tok in _SENTINEL_NARROWERS)
+        self._narrowing_depth += 1 if aware else 0
+        self.generic_visit(node)
+        self._narrowing_depth -= 1 if aware else 0
+
+    visit_FunctionDef = _visit_scope
+    visit_AsyncFunctionDef = _visit_scope
+
+    # -- flow-out positions
+
+    def visit_Return(self, node: ast.Return) -> None:
+        if node.value is not None:
+            self._flag(node.value)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        for arg in node.args:
+            self._flag(arg)
+        for kw in node.keywords:
+            self._flag(kw.value)
+        self.generic_visit(node)
+
+    def _flag(self, node: ast.AST) -> None:
+        if self._narrowing_depth or not _is_sentinel_field(node):
+            return
+        rule = _get_rule("STX-SAC004")
+        if rule is None:
+            return
+        src = _source_at(self.source_lines, node.lineno)
+        issue = _make_issue(rule, node.lineno, node.col_offset, src)
+        if issue is not None:
+            self.issues.append(issue)
 
 
 # NOTE: _SacEnvChecker (for STX-SAC003) is intentionally not shipped in

--- a/src/scitex_agent_container/_mcp/_tools/_template.py
+++ b/src/scitex_agent_container/_mcp/_tools/_template.py
@@ -21,6 +21,9 @@ from typing import Any
 # canonical chunk-A variable surface (project, branch_kind, branch_short,
 # a2a_port, startup_command).
 _CONTRIBUTOR_TEMPLATE = """\
+# THIS IS A DESIGN DOCUMENT — the contract for an agent not yet started.
+# The state of a RUNNING agent lives in the database, never in this file.
+
 apiVersion: scitex-agent-container/v3
 kind: Agent
 metadata:

--- a/src/scitex_agent_container/_skills/scitex-agent-container/34_spec-is-a-contract-not-state.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/34_spec-is-a-contract-not-state.md
@@ -1,0 +1,135 @@
+---
+description: |
+  [TOPIC] A spec is the CONTRACT for an agent that has not started yet — never the state of a running one.
+  [DETAILS] The operator's universal ruling (2026-08-11): `spec.yaml` is a design document about the FUTURE; what is actually true of a RUNNING agent lives in the database (per-host PostgreSQL `:55432`); the spec as it stood AT LAUNCH is burned into the agent as a file so it can answer "how was I born". Covers the tense test, the sentinel trap (`a2a.port: auto` — 0 of 104 fleet specs carry a concrete port), where to read each fact instead, the `session_id` case, and the `STX-SAC004` lint rule that catches the mechanical half.
+tags: [scitex-agent-container-spec-is-a-contract-not-state, spec, state, postgres, a2a-port, session-id, adr-0022]
+---
+
+# A spec is a contract, not a state
+
+**Operator ruling, 2026-08-11, called universal**
+(「これはどんな時も従うべき話だと思います」):
+
+> 「スペックというのは今動いてるエージェントの状態を表すのではなくて、未来に
+> 動くエージェントの規約」
+> 「スペックは設計書、実際に動いてるエージェントの状況はデータベース」
+
+Three homes, decided by **tense**:
+
+| Question | Home |
+|---|---|
+| What *shall* an agent be? | `spec.yaml`, under git — the design document |
+| What *is* true of a running agent? | the database (per-host PostgreSQL `:55432`) |
+| What did the contract say *at launch*? | a file burned into the agent |
+
+The third is not a copy of the first. The git-side spec is **live**: an
+operator edit does not retroactively change how a running agent started,
+so a spec read at 23:00 does not describe an agent launched at 19:00.
+
+## The tense test — the one thing to remember
+
+> **If answering the question requires knowing that a start has already
+> happened, the spec cannot answer it. Ask the database.**
+
+Ports bound, session resumed, host actually running on, pid, uptime,
+group membership *as enforced* — all of these exist only because a start
+happened. None of them is in the spec, no matter how much the spec looks
+like it is talking about them.
+
+## The trap: a spec field may be a PROMISE, not a value
+
+A field can legitimately declare *"resolve this at start"*. Read it as a
+value and you get a **sentinel**, which then silently fails every numeric
+or identity test you apply to it — no exception, no log line, just a
+branch that never fires.
+
+`spec.a2a.port` is the live example. Measured on scitex-compute-04,
+2026-08-11, over every `agents/*/spec.yaml` (107 files, 3 of them
+`_template_*` scaffolds → **104 real agent specs**):
+
+| declared | agents |
+|---|---|
+| `port: auto` | 93 |
+| `port: null` (sidecar deliberately off) | 11 |
+| **a concrete int** | **0** |
+
+The near-miss that produced this skill: the tui turn-bridge supervisor
+(PR #973) has to know which port an agent's bridge should serve. Had it
+read `config.a2a.port`, it would have received the string `"auto"`, found
+no number, concluded there was nothing to check, and supervised
+**nothing — on every agent in the fleet**, while reporting healthy.
+
+It reads the port allocator's **claim** instead — `a2a_ports`, which is
+state, written when a start actually happened:
+
+```python
+# WRONG — the spec declares a promise; you get the string "auto"
+port = config.a2a.port
+
+# RIGHT — the claim is a fact, and exists only because a start happened
+from scitex_agent_container._state import port_allocator
+port = port_allocator.get_port(name)          # int, or None if never started
+```
+
+`sac agents list scitex-agent-container` answers `a2a_port: 19016` for
+exactly this reason: it reports the claim, not the declaration.
+
+## Where to read each fact instead
+
+| You want | Do NOT read | Read |
+|---|---|---|
+| the port an agent actually serves | `spec.a2a.port` | `port_allocator.get_port(name)` (`a2a_ports`) |
+| which conversation resumed | `spec.claude.session` | the instance row / session state — **not yet pinned**, see below |
+| whether an agent is running | any spec field | `instances` / heartbeats |
+| the host it runs on now | `spec.host` | `agent_residency` (relocation moves residency, not the spec) |
+| the groups an ACL enforces | the persisted policy cache | `config/_group_authority.py` — spec IS authority here (ADR-0022 §6) |
+
+The last row is the deliberate exception and shows the rule is about
+tense, not about file format: group membership is **configuration** —
+authored by a human, changed by nobody at runtime — so the spec is the
+right answer and the cached row was the bug.
+
+## `session_id` — the same split, still open
+
+What a spec declares (`claude.session: continue` / `fresh`) is a
+*promise about how to resume*. **Which conversation actually resumed** is
+state. Today `sac agents list <name>` can report `session_id: null` for
+an agent with a live session — the promise is recorded, the fact is not.
+Tracked by card `sac-pin-session-id-at-start-removes-f34-20260812`.
+
+## What is mechanically enforced (and what is not)
+
+**`STX-SAC004`** (severity: *warning*, this package's linter plugin)
+fires when a sentinel-bearing spec field — `<x>.a2a.port` today — is
+`return`ed from a function or passed as a call argument **without the
+enclosing function narrowing the sentinel** (`is_auto`, `is_disabled`,
+`== "auto"`, `isinstance(..., int)`, or a resolver call). That is exactly
+the shape the near-miss would have had. Suppress a deliberate case with
+`# stx-allow: STX-SAC004`.
+
+It is deliberately narrow. **Nothing checks the general rule** — "this
+code is reading a spec to learn a running agent's state" is not
+mechanically decidable, and a check that fired on every `config.` access
+would be noise and would be switched off within a week. Comparisons
+(`assert cfg.a2a.port == 7901`) are *not* flagged: asserting what the
+contract says is the correct way to read a contract.
+
+New spec fields that resolve at runtime must be added to
+`_SENTINEL_FIELDS` in `_linter_plugin.py`, or the rule cannot see them.
+
+## When you write a spec
+
+Every scaffolded spec now opens with two lines saying so:
+
+```yaml
+# THIS IS A DESIGN DOCUMENT — the contract for an agent not yet started.
+# The state of a RUNNING agent lives in the database, never in this file.
+```
+
+Emitted by `sac agents create` (minimal + full templates) and by the
+contributor-spec renderer. Nothing enforces its presence — a YAML comment
+is not schema — and that is accepted: its audience is a human with the
+file open, not a validator.
+
+Full reasoning, the sync design and the deferred work: **ADR-0022**
+(`docs/adr/0022-state-in-postgres-configuration-in-git.md`), §3.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -54,16 +54,17 @@ session inside Apptainer (local or remote via SSH), observe via
 - [08_templates.md](08_templates.md) — six pattern templates
 - [14_claude-session-state.md](14_claude-session-state.md) — state-dir layout, auth precedence
 - [15_claude-session.md](15_claude-session.md) — SDK runner + `POST /v1/turn` inbound
-- [16_claude-session-migration.md](16_claude-session-migration.md) — historical claude-code→SDK migration
+- [16](16_claude-session-migration.md) — historical claude-code→SDK migration
 - [17_inbound-turn-endpoint.md](17_inbound-turn-endpoint.md) — `POST /v1/turn` wire format
 - [18_full-agent-delegation.md](18_full-agent-delegation.md) — delegate to another *full* agent
 - [19_full-agent-troubleshooting.md](19_full-agent-troubleshooting.md) — stuck-peer recovery + reaper
 - [33](33_twin-spawning.md) — context-inheriting twin
+- [34](34_spec-is-a-contract-not-state.md) — spec = contract; state = DB
 
 ### Workflows
 - [10_cli.md](10_cli.md) — CLI commands and Python API
 - [11_remote-deploy.md](11_remote-deploy.md) — SSH deployment, src files, venv
-- [12_wsl-connectivity.md](12_wsl-connectivity.md) — WSL connectivity notes
+- [12](12_wsl-connectivity.md) — WSL connectivity notes
 - [24_image-build.md](24_image-build.md) — apptainer `.sif` build/rebuild, rebuild-to-ship gotcha
 - [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — `to_home`→`$HOME`, overlay, settings hook
 - [26_credentials-rotation.md](26_credentials-rotation.md) — OAuth + auth mechanics
@@ -86,7 +87,7 @@ session inside Apptainer (local or remote via SSH), observe via
 
 ### Lessons
 - [40_troubleshooting.md](40_troubleshooting.md) — Common issues and debugging
-- [40_periodic-drive-consumer.md](40_periodic-drive-consumer.md)
+- [40b](40_periodic-drive-consumer.md)
 - [41](41_claude-worktree-relocation.md)
 
 ## Environment

--- a/src/scitex_agent_container/cli_pkg/_create_templates.py
+++ b/src/scitex_agent_container/cli_pkg/_create_templates.py
@@ -14,13 +14,14 @@ hunts for missing keys.
 from __future__ import annotations
 
 _MINIMAL_TEMPLATE = """\
-# {name} — fresh v3 spec scaffolded by ``sac agents create``.
+# THIS IS A DESIGN DOCUMENT — the contract for an agent not yet started.
+# The state of a RUNNING agent lives in the database, never in this file.
 #
+# {name} — fresh v3 spec scaffolded by ``sac agents create``.
 # EVERY field is written explicitly (red-start ruling 2026-07-21: an
 # omitted field is a load ERROR whose hint lists the whole missing set
-# with paste-ready defaults). The values below are those defaults except
-# the handful this template curates (runtime / model / health / restart).
-# See ``examples/agents/full-agent/spec.yaml`` for the annotated tour.
+# with paste-ready defaults); the values are those defaults except the
+# handful curated here. See ``examples/agents/full-agent/spec.yaml``.
 
 apiVersion: scitex-agent-container/v3
 kind: Agent
@@ -160,6 +161,9 @@ spec:
 
 
 _FULL_TEMPLATE = """\
+# THIS IS A DESIGN DOCUMENT — the contract for an agent not yet started.
+# The state of a RUNNING agent lives in the database, never in this file.
+#
 # {name} — fresh v3 DEVELOPER spec scaffolded by ``sac agents create --template full``.
 #
 # This is the PROVEN developer shape the fleet's live dev agents use

--- a/tests/scitex_agent_container/_mcp/_tools/test__template.py
+++ b/tests/scitex_agent_container/_mcp/_tools/test__template.py
@@ -224,3 +224,41 @@ def test_register_template_tools_invokes_mcp_tool_decorator() -> None:
     register_template_tools(mcp)
     # Assert
     assert registered == [template_render_contributor_spec]
+
+
+def test_rendered_contributor_spec_opens_with_the_design_document_line(
+    dry_run_result: dict,
+) -> None:
+    # Arrange — operator ruling 2026-08-11 (ADR-0022 §3): a spec is the
+    # contract for an agent not yet started; a running agent's state lives
+    # in the database. The header says so where a reader will see it.
+    expected = (
+        "# THIS IS A DESIGN DOCUMENT — the contract for an agent not yet started."
+    )
+    # Act
+    first_line = dry_run_result["yaml"].splitlines()[0]
+    # Assert
+    assert first_line == expected
+
+
+def test_rendered_contributor_spec_sends_state_to_the_database(
+    dry_run_result: dict,
+) -> None:
+    # Arrange
+    expected = (
+        "# The state of a RUNNING agent lives in the database, never in this file."
+    )
+    # Act
+    second_line = dry_run_result["yaml"].splitlines()[1]
+    # Assert
+    assert second_line == expected
+
+
+def test_contributor_header_is_a_comment_and_does_not_change_the_spec(
+    dry_run_result: dict,
+) -> None:
+    # Arrange
+    # Act
+    doc = yaml.safe_load(dry_run_result["yaml"])
+    # Assert
+    assert doc["apiVersion"] == "scitex-agent-container/v3"

--- a/tests/scitex_agent_container/cli_pkg/test__create_templates.py
+++ b/tests/scitex_agent_container/cli_pkg/test__create_templates.py
@@ -1,0 +1,110 @@
+"""Tests for the inline ``sac agents create`` spec templates.
+
+The header assertions encode an operator ruling (2026-08-11, called
+universal): a spec is the CONTRACT for an agent that has not started yet,
+and the state of a RUNNING agent lives in the database. The header exists
+because the moment people get this wrong is the moment they have the spec
+file open in front of them — see ADR-0022 §3 and skill leaf
+``34_spec-is-a-contract-not-state.md``.
+
+Nothing can enforce the header's presence in a spec on disk (a YAML
+comment is not schema), so the enforcement point is the generator: a spec
+born with the header never needs a sweep.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from scitex_agent_container.cli_pkg._create_templates import (
+    _FULL_TEMPLATE,
+    _MINIMAL_TEMPLATE,
+    _TEMPLATES,
+)
+
+_DESIGN_DOC_LINE = (
+    "# THIS IS A DESIGN DOCUMENT — the contract for an agent not yet started."
+)
+_STATE_LINE = (
+    "# The state of a RUNNING agent lives in the database, never in this file."
+)
+
+
+def _render(template: str) -> str:
+    """Fill the same placeholder set ``sac agents create`` fills."""
+    return template.format(
+        name="alpha",
+        host="scitex-compute-04",
+        home="/home/agent",
+        credentials_files="[]",
+    )
+
+
+# ---------------------------------------------------------------------------
+# The header is the FIRST thing a spec reader sees
+# ---------------------------------------------------------------------------
+
+
+def test_minimal_template_opens_with_the_design_document_line():
+    # Arrange
+    # Act
+    first_line = _render(_MINIMAL_TEMPLATE).splitlines()[0]
+    # Assert
+    assert first_line == _DESIGN_DOC_LINE
+
+
+def test_minimal_template_second_line_sends_state_to_the_database():
+    # Arrange
+    # Act
+    second_line = _render(_MINIMAL_TEMPLATE).splitlines()[1]
+    # Assert
+    assert second_line == _STATE_LINE
+
+
+def test_full_template_opens_with_the_design_document_line():
+    # Arrange
+    # Act
+    first_line = _render(_FULL_TEMPLATE).splitlines()[0]
+    # Assert
+    assert first_line == _DESIGN_DOC_LINE
+
+
+def test_full_template_second_line_sends_state_to_the_database():
+    # Arrange
+    # Act
+    second_line = _render(_FULL_TEMPLATE).splitlines()[1]
+    # Assert
+    assert second_line == _STATE_LINE
+
+
+def test_every_registered_template_carries_the_header():
+    # Arrange
+    # Act
+    missing = [
+        key
+        for key, tmpl in _TEMPLATES.items()
+        if _DESIGN_DOC_LINE not in _render(tmpl)
+    ]
+    # Assert
+    assert missing == []
+
+
+# ---------------------------------------------------------------------------
+# The header must stay a COMMENT — it may not change what the spec means
+# ---------------------------------------------------------------------------
+
+
+def test_minimal_template_still_parses_as_a_v3_agent_spec():
+    # Arrange
+    # Act
+    doc = yaml.safe_load(_render(_MINIMAL_TEMPLATE))
+    # Assert
+    assert doc["apiVersion"] == "scitex-agent-container/v3"
+
+
+def test_full_template_still_parses_as_a_v3_agent_spec():
+    # Arrange
+    # Act
+    doc = yaml.safe_load(_render(_FULL_TEMPLATE))
+    # Assert
+    assert doc["apiVersion"] == "scitex-agent-container/v3"

--- a/tests/scitex_agent_container/test__linter_plugin.py
+++ b/tests/scitex_agent_container/test__linter_plugin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -12,6 +13,7 @@ from scitex_agent_container._linter_plugin import (
     _make_issue,
     _SacCardChecker,
     _SacMethodChecker,
+    _SacSpecSentinelChecker,
     _source_at,
     get_plugin,
 )
@@ -40,22 +42,32 @@ def test_get_plugin_returns_canonical_keys():
     assert set(plugin) == expected
 
 
-def test_get_plugin_registers_sac001_and_sac002():
+def test_get_plugin_registers_sac001_sac002_and_sac004():
     # Arrange
     # SAC003 is drafted but deferred until scitex-dev exposes filepath
     # to plugin checkers — see _linter_plugin.py docstring.
     # Act
     ids = sorted(r.id for r in get_plugin()["rules"])
     # Assert
-    assert ids == ["STX-SAC001", "STX-SAC002"]
+    assert ids == ["STX-SAC001", "STX-SAC002", "STX-SAC004"]
 
 
-def test_get_plugin_exposes_two_active_checkers():
+def test_get_plugin_exposes_three_active_checkers():
     # Arrange
     # Act
     checkers = get_plugin()["checkers"]
     # Assert
-    assert len(checkers) == 2
+    assert len(checkers) == 3
+
+
+def test_sac004_ships_at_warning_severity_not_error():
+    # Arrange — a fleet precedent: a rule shipped at error severity turned
+    # 44 repositories red on day one. SAC004 loads into every repo linted
+    # on a machine with sac installed, so it ships as a warning.
+    # Act
+    rule = next(r for r in get_plugin()["rules"] if r.id == "STX-SAC004")
+    # Assert
+    assert rule.severity == "warning"
 
 
 # ---------------------------------------------------------------------------
@@ -204,3 +216,163 @@ def test_sac002_skips_constant_when_source_line_carries_stx_allow():
     issues = _run(_SacMethodChecker, src)
     # Assert
     assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# SAC004 — a spec sentinel used as a concrete value
+#
+# The near-miss this rule encodes (2026-08-11): the tui turn-bridge
+# supervisor had to know which port an agent's bridge serves. Reading it
+# from the spec would have returned the literal string "auto" on every
+# agent in the fleet — 0 of 104 registered specs declare a concrete port —
+# so it would have supervised NOTHING while reporting healthy. PR #973
+# reads the port allocator's claim, which is state, instead.
+# ---------------------------------------------------------------------------
+
+# Assembled from parts so this test module's own source does not read as a
+# sentinel field to a lint pass over tests/.
+_SENTINEL_READ = "cfg." + "a2a." + "port"
+
+
+def test_sac004_flags_sentinel_field_returned_from_function():
+    # Arrange — the exact shape the near-miss would have had.
+    src = f"def resolve_bridge_port(cfg):\n    return {_SENTINEL_READ}\n"
+    # Act
+    issues = _run(_SacSpecSentinelChecker, src)
+    # Assert
+    assert [i.rule.id for i in issues] == ["STX-SAC004"]
+
+
+def test_sac004_flags_sentinel_field_passed_as_positional_argument():
+    # Arrange
+    src = f"def probe(cfg):\n    return bind('127.0.0.1', {_SENTINEL_READ})\n"
+    # Act
+    issues = _run(_SacSpecSentinelChecker, src)
+    # Assert
+    assert [i.rule.id for i in issues] == ["STX-SAC004"]
+
+
+def test_sac004_flags_sentinel_field_passed_as_keyword_argument():
+    # Arrange
+    src = f"def probe(cfg):\n    return bind(port={_SENTINEL_READ})\n"
+    # Act
+    issues = _run(_SacSpecSentinelChecker, src)
+    # Assert
+    assert [i.rule.id for i in issues] == ["STX-SAC004"]
+
+
+def test_sac004_ignores_comparison_against_the_declared_value():
+    # Arrange — asserting what the CONTRACT says is the correct way to read
+    # a contract; this is the only shape sac's own tests use.
+    src = f"def check(cfg):\n    assert {_SENTINEL_READ} == 7901\n"
+    # Act
+    issues = _run(_SacSpecSentinelChecker, src)
+    # Assert
+    assert issues == []
+
+
+def test_sac004_ignores_identity_test_against_none():
+    # Arrange
+    src = f"def check(cfg):\n    assert {_SENTINEL_READ} is None\n"
+    # Act
+    issues = _run(_SacSpecSentinelChecker, src)
+    # Assert
+    assert issues == []
+
+
+def test_sac004_stays_silent_in_a_sentinel_aware_function():
+    # Arrange — a function that narrows the sentinel first is deliberate.
+    src = (
+        "def resolve(cfg):\n"
+        "    if cfg.a2a.is_auto:\n"
+        "        return None\n"
+        f"    return {_SENTINEL_READ}\n"
+    )
+    # Act
+    issues = _run(_SacSpecSentinelChecker, src)
+    # Assert
+    assert issues == []
+
+
+def test_sac004_stays_silent_when_function_calls_the_state_side_resolver():
+    # Arrange — reading the a2a_ports CLAIM is the prescribed fix.
+    src = (
+        "def resolve(cfg, name):\n"
+        "    claimed = port_allocator.get_port(name)\n"
+        f"    return claimed if claimed else {_SENTINEL_READ}\n"
+    )
+    # Act
+    issues = _run(_SacSpecSentinelChecker, src)
+    # Assert
+    assert issues == []
+
+
+def test_sac004_ignores_a_non_sentinel_field_of_the_same_name():
+    # Arrange — ``listen.port`` is not on the sentinel list.
+    src = "def probe(cfg):\n    return bind(cfg.listen.port)\n"
+    # Act
+    issues = _run(_SacSpecSentinelChecker, src)
+    # Assert
+    assert issues == []
+
+
+def test_sac004_skips_line_carrying_stx_allow():
+    # Arrange
+    src = (
+        "def resolve_bridge_port(cfg):\n"
+        f"    return {_SENTINEL_READ}  # stx-allow: STX-SAC004\n"
+    )
+    # Act
+    issues = _run(_SacSpecSentinelChecker, src)
+    # Assert
+    assert issues == []
+
+
+def test_sac004_fires_at_module_level_outside_any_function():
+    # Arrange — no enclosing function means no narrowing scope.
+    src = f"PORT = bind({_SENTINEL_READ})\n"
+    # Act
+    issues = _run(_SacSpecSentinelChecker, src)
+    # Assert
+    assert [i.rule.id for i in issues] == ["STX-SAC004"]
+
+
+# ---------------------------------------------------------------------------
+# SAC004 — the honesty check: measure the rule against the REAL tree.
+#
+# A rule with a noisy floor gets disabled within a week. This asserts the
+# floor is zero on sac's own source AND its own tests, so the first time it
+# speaks, it is speaking about new code.
+# ---------------------------------------------------------------------------
+
+
+def _scan_tree(root):
+    """Run the SAC004 checker over every .py under *root*; return hits.
+
+    Raises rather than returning an empty list when *root* is missing, so a
+    layout change can never turn this into a vacuous pass.
+    """
+    if not root.is_dir():
+        raise FileNotFoundError(f"expected a real tree at {root}")
+    hits = []
+    for py in sorted(root.rglob("*.py")):
+        try:
+            source = py.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover
+            continue
+        config = SimpleNamespace(disable=set(), per_rule_severity={})
+        checker = _SacSpecSentinelChecker(source.splitlines(), config)
+        checker.visit(tree)
+        hits.extend(f"{py}:{i.line}" for i in checker.issues)
+    return hits
+
+
+@pytest.mark.parametrize("subtree", ["src", "tests"])
+def test_sac004_noise_floor_is_zero_on_the_real_tree(subtree):
+    # Arrange
+    repo_root = Path(__file__).resolve().parents[2]
+    # Act
+    hits = _scan_tree(repo_root / subtree)
+    # Assert
+    assert hits == []


### PR DESCRIPTION
Records an operator ruling of 2026-08-11, which he called universal
(「これはどんな時も従うべき話だと思います」), in the three places he named — all
inside sac (「ADR も SAC かなぁ」).

> 「スペックというのは今動いてるエージェントの状態を表すのではなくて、未来に動く
> エージェントの規約」
> 「その状態に関しては必ずデータベースに入れなきゃいけないし、その起動された
> タイミングのスペックというのは、エージェントの中に焼き込まれないといけない情報です」
> 「スペックは設計書、実際に動いてるエージェントの状況はデータベース」

## The near-miss that makes it concrete

Measured on scitex-compute-04 over every `agents/*/spec.yaml` — 107 files, 3 of
them `_template_*` scaffolds, so **104 real agent specs**:

| `spec.a2a.port` declares | agents |
|---|---|
| `auto` | 93 |
| `null` (sidecar deliberately off) | 11 |
| **a concrete int** | **0** |

`auto` is a **promise**, not a fact. A supervisor reading the port from the spec
receives the literal string `"auto"`, finds no number, concludes there is nothing
to check, and supervises **nothing — on every agent in the fleet** — while
reporting healthy. PR #973 reads the port allocator's **claim** (`a2a_ports`)
instead: state, which exists only because a start already happened.

## What changed

**1. ADR-0022 §3 → "four kinds of fact, four homes."** A tense preamble (a spec
is written in the future tense; it stays a contract for the whole life of the
process it launched), the new **LAUNCH SNAPSHOT** class, and a worked-example
section *"The failure this forbids: reading a promise as a fact."* §7 gains four
deferred items — the snapshot is **specified, not implemented** (a container
reads the LIVE spec dir today; this agent's own spec was rewritten twice
tonight, `.old/20260812T190500Z` and `.old/20260812T222000Z`), `session_id` is
not pinned at start, exactly what the lint rule does and does not cover, and
what the spec header does not sweep.

**2. A skill leaf** — `_skills/scitex-agent-container/34_spec-is-a-contract-not-state.md`,
linked from `SKILL.md`. A memory file is read by one agent; a skill is read by
every agent. `SKILL.md` had 8 bytes of headroom under SK-301's 6 KB budget, so
three link labels were shortened to the abbreviated form the file already uses.
`scitex-dev ecosystem audit-skills` → **no violations**.

**3. The header that finds you.** Every scaffolded spec now opens with two lines:

```yaml
# THIS IS A DESIGN DOCUMENT — the contract for an agent not yet started.
# The state of a RUNNING agent lives in the database, never in this file.
```

Emitted by `sac agents create` (minimal + full) and the contributor-spec
renderer — the generators, because a spec born with the header never needs a
sweep. The minimal template's preamble was compressed by three lines so
`apiVersion` stays inside the first ten, which
`test_create_emits_canonical_apiversion_header` guards (it caught the drift).

**4. `STX-SAC004`, at *warning* severity.** Fires only when a listed
sentinel-bearing spec field is `return`ed or passed as a call argument **without
the enclosing function narrowing the sentinel** — the exact shape the near-miss
would have had. Comparisons are never flagged: asserting what a contract *says*
is the correct way to read a contract, and it is the only shape sac's own tests
use. Warning rather than error because plugin rules load into every repo linted
on a machine with sac installed, and this fleet has a precedent — a rule shipped
at error severity turned 44 repositories red on day one.

## Judgement: is a mechanical check honest here?

**Partly, and only narrowly — stated rather than overreached.**

The general rule is **not** mechanisable. "This code is reading a spec to learn a
running agent's state" is not decidable, and a check firing on every `config.`
access would be noise and would be switched off within a week.

What *is* decidable is the sentinel half, and it was worth measuring before
shipping. An AST scan of the real trees found **9** attribute reads of
`.a2a.port` across `src/` + `tests/`; every one in `src/` is already
sentinel-aware, and the only two "bare" reads are `assert cfg.a2a.port == 7901`
and `assert cfg.a2a.port is None` — correct contract assertions. Restricting the
rule to flow-out positions (return / call-argument) therefore gives a **noise
floor of exactly zero** on both trees, asserted by a test that scans them, so the
first time the rule speaks it is speaking about new code.

`_SENTINEL_FIELDS` holds one entry today. A new resolve-at-runtime field is
invisible to the rule until it is added — said in the code, in the skill and in
the ADR, because a list that silently rots is worse than no list.

## Verification

```
$ PYTHONPATH=<worktree>/src /opt/venv-sac/bin/python -m pytest \
    tests/scitex_agent_container/test__linter_plugin.py \
    tests/scitex_agent_container/cli_pkg/ \
    tests/scitex_agent_container/_mcp/_tools/test__template.py -p no:randomly -q
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
plugins: anyio-4.14.2, asyncio-1.4.0, xdist-3.8.0, scitex-dev-0.47.0
========== 2653 passed, 1 skipped, 16 deselected in 142.02s (0:02:22) ==========
PYTEST_EXIT=0

$ /opt/venv-sac/bin/scitex-dev ecosystem audit-skills scitex-agent-container --path <worktree>
SUCC: scitex-agent-container: no skills violations   (exit 0)
```

## Not done, deliberately

The 104 existing specs are **not** swept — they are live specs of running agents,
outside this repo, and the fleet just cleaned 449 `.bak-*` files left by in-place
rewrite scripts. Carded as
`sac-sweep-design-doc-header-into-existing-specs-20260812` with the safe recipe
(idempotent, backups to `.old/<timestamp>/` with a manifest, re-parse each file).
The three operator `_template_*/` dir-templates *were* headed by hand, backed up
to `~/.scitex/agent-container/.old/20260811T235819Z/dir-templates/` with a
manifest, and re-verified to still `yaml.safe_load()`.

Nothing enforces the header's presence, and that is accepted: a YAML comment is
not schema, and making it one would turn a note for humans into a validator's
business.

Card: `sac-adr0022-spec-is-contract-state-in-db-20260811`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcDz9gLL2Ct24FXqX2SF9T
