### PR TITLE
fix(image): name dev explicitly — [all,dev], not [all]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -476,9 +476,11 @@ pythonpath = [".", "src"]
 # overlay, so two agents running the same tests legitimately held different
 # plugin sets — and different pytest MAJORS.
 #
-# THAT ROOT CAUSE IS FIXED: apptainer-base.def now installs `[all]`, which
-# contains `[dev]`, so a pristine container arrives with pytest 8.4.2,
-# pytest-asyncio, pytest-xdist and pytest-cov and this gate never fires there.
+# THAT ROOT CAUSE IS FIXED: apptainer-base.def now installs `[all,dev]`, so a
+# pristine container arrives with pytest 8.4.2, pytest-asyncio, pytest-xdist
+# and pytest-cov, and this gate never fires there (measured against the
+# 2026-08-12 bake: 0 occurrences of "Missing required plugins" in a 925-test
+# run, 0 of "async def functions are not natively supported").
 #
 # The gate is NOT thereby redundant, because the image is only one of the ways
 # an interpreter loses a plugin. CI has its own path to the same state:

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -452,8 +452,8 @@ From: ubuntu:24.04
     # release that drops it dies LOUD at bake rather than shipping silently.
     # That gate is the honest protection: verify the artifact you built,
     # do not freeze the input and call it safety.
-    # sac is installed with ``[all]`` — the union aggregate — and NOT the
-    # narrower ``[openai]`` it carried until 2026-08-11.
+    # sac is installed with ``[all,dev]`` — and NOT the narrower ``[openai]``
+    # it carried until 2026-08-11.
     #
     # WHY THE WIDENING: ``[openai]`` left the image WITHOUT TEST TOOLING,
     # because pytest and its plugins are declared in ``[dev]``. Measured on
@@ -475,20 +475,23 @@ From: ubuntu:24.04
     # booting it, and pays it again in wrong diagnoses. Operator ruling,
     # 2026-08-11: 「デベロップメントは必ず SIF に入れないといけないっていうのは
     # 当たり前だと思うんですけど、というか多分オールを入れておけばいいと思うん
-    # ですよね」— put dev IN the SIF; just install ``[all]``.
+    # ですよね」— put dev IN the SIF — and, on the bracket itself,
+    # 「オールとデブですね」: ``[all,dev]``.
     #
-    # ``[all]`` ALONE IS SUFFICIENT — ``[all,dev]`` would be redundant.
+    # ``dev`` IS NAMED EXPLICITLY EVEN THOUGH ``all`` CONTAINS IT TODAY.
     # pyproject's ``all`` is the union aggregate and lists
-    # ``scitex-agent-container[dev]`` explicitly (alongside mcp / telegram /
-    # notify / slurm / openai / codex / docs), so pytest, pytest-asyncio,
-    # pytest-xdist and pytest-cov ride in through it. Read ``all`` in
-    # pyproject.toml before narrowing this bracket: if a future edit drops
-    # ``[dev]`` from the aggregate, THIS line silently stops shipping test
-    # tooling again — which is why the contract test in
-    # tests/integration/test_apptainer_def_openai_agents.py asserts BOTH
-    # halves (the bracket here AND ``[dev]``'s membership in the aggregate).
+    # ``scitex-agent-container[dev]`` (alongside mcp / telegram / notify /
+    # slurm / openai / codex / docs), so ``[all]`` alone would resolve the
+    # same set right now. Naming ``dev`` anyway is not ceremony: it makes the
+    # REQUIREMENT — this image must arrive able to run its own tests — legible
+    # in the line that implements it, and it keeps that requirement satisfied
+    # if ``all`` is ever trimmed. An aggregate quietly losing a member is
+    # exactly the silent drift this whole change exists to end; the redundancy
+    # costs nothing and removes a way to lose it again. (The contract test in
+    # tests/integration/test_apptainer_def_openai_agents.py holds the same
+    # line from the other side.)
     #
-    # ``[all]`` IS A SUPERSET OF ``[openai]``, so nothing about the previous
+    # ``[all,dev]`` IS A SUPERSET OF ``[openai]``, so nothing about the previous
     # contract is lost: openai-agents (the `spec.provider: openai` agent-SDK
     # family, openai-compat-3) is still baked UNCONDITIONALLY, which is the
     # only option at image-build time — one image serves EVERY agent, so a
@@ -504,12 +507,15 @@ From: ubuntu:24.04
     # hand-install carries no such constraint, which is exactly how the
     # pytest-9 container happened.
     #
-    # COST, measured against the SIF this line replaces: the heavy scientific
-    # stack was ALREADY in the image (scitex-dev 0.47.0, playwright, numpy,
-    # scipy, matplotlib, pymupdf were all present under ``[openai]``), so
-    # ``[all]`` does not import a new ecosystem — it adds the test / docs /
-    # bridge leaves on top of one already paid for. Re-measure rather than
-    # assume if the aggregate grows.
+    # COST, MEASURED on scitex-compute-04 (2026-08-12 bake) rather than
+    # guessed: 161 -> 221 distributions (+60) and 1535.5 -> 1585.8 MB of SIF
+    # (+50.3 MB, +3.3%); the venv grows 1.1G -> 1.3G. It is that small because
+    # the heavy scientific stack was ALREADY in the image — scitex-dev 0.47.0,
+    # playwright, numpy, scipy, matplotlib and pymupdf were all present under
+    # ``[openai]`` — so this does not import a new ecosystem, it adds the test
+    # / docs / bridge leaves on top of one already paid for. Operator, shown
+    # the number: 「別に入れればいいじゃん…全部入れちゃえばいいと思う」.
+    # Re-measure rather than assume if the aggregate grows.
     #
     # UV SEMANTICS, NOT PIP (INCIDENT 2026-07-18). ``--no-cache-dir`` and
     # ``--force-reinstall`` are PIP flags; uv does not honour them as a
@@ -541,7 +547,7 @@ From: ubuntu:24.04
         --reinstall-package scitex-agent-container \
         "claude-agent-sdk" \
         "scitex-cards>=0.32.0" \
-        "/opt/scitex-agent-container-src[all]"
+        "/opt/scitex-agent-container-src[all,dev]"
 
     # ---- 6c. FAIL-LOUD staleness gate — assert BY SYMBOL --------------
     # incident-fleet-drift-stale-scitex-todo (2026-07-12): the live SIFs

--- a/tests/integration/test_apptainer_def_openai_agents.py
+++ b/tests/integration/test_apptainer_def_openai_agents.py
@@ -8,11 +8,11 @@ per-spec conditionality at RUNTIME (OPENAI_* env injection +
 
 Layer contracts pinned here:
 
-* ``apptainer-base.def`` installs sac with the ``[all]`` aggregate
-  (``/opt/scitex-agent-container-src[all]``), which CONTAINS ``[openai]``
-  — the floor stays in pyproject.toml (SSoT). The bracket was widened
-  from ``[openai]`` on 2026-08-11 so the image also ships ``[dev]``'s
-  test tooling; because that makes openai-agents arrive INDIRECTLY, the
+* ``apptainer-base.def`` installs sac with ``[all,dev]``
+  (``/opt/scitex-agent-container-src[all,dev]``) — the floors stay in
+  pyproject.toml (SSoT). The bracket was widened from ``[openai]`` on
+  2026-08-11 so the image also ships ``[dev]``'s test tooling; because
+  that makes openai-agents arrive INDIRECTLY through ``all``, the
   aggregate's membership is asserted here too. Without that second
   assert, deleting ``scitex-agent-container[openai]`` from ``all`` would
   silently stop baking the SDK while this file still passed.
@@ -60,15 +60,17 @@ def scitex_def_text() -> str:
 # ---------------------------------------------------------------------------
 
 
-def test_base_def_installs_sac_with_all_extra(base_def_text: str) -> None:
-    # Arrange
-    needle = "/opt/scitex-agent-container-src[all]"
+def test_base_def_installs_sac_with_all_and_dev_extras(base_def_text: str) -> None:
+    # Arrange — `dev` is named explicitly even though `all` contains it, so
+    # the requirement (the image must arrive able to run its own tests) is
+    # legible in the line that implements it and survives a trimmed aggregate.
+    needle = "/opt/scitex-agent-container-src[all,dev]"
     # Act
     present = needle in base_def_text
     # Assert
     assert present, (
         "apptainer-base.def must install the bundled sac source with the "
-        "[all] aggregate — it carries BOTH openai-agents (spec.provider: "
+        "[all,dev] extras — they carry BOTH openai-agents (spec.provider: "
         "openai agents) and [dev]'s pytest tooling, without which a "
         "pristine container cannot run the suite; "
         f"expected {needle!r} in the uv pip install block."
@@ -76,8 +78,8 @@ def test_base_def_installs_sac_with_all_extra(base_def_text: str) -> None:
 
 
 def test_all_extra_carries_openai_agents(base_def_text: str) -> None:
-    # Arrange — base installs [all], so the SDK now arrives INDIRECTLY;
-    # dropping it from the aggregate would unbake it silently.
+    # Arrange — base installs [all,dev], so the SDK now arrives INDIRECTLY
+    # through `all`; dropping it from the aggregate would unbake it silently.
     pyproject = (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text()
     # Act
     present = "scitex-agent-container[openai]" in pyproject
@@ -99,10 +101,12 @@ def test_all_extra_carries_dev_test_tooling(base_def_text: str) -> None:
     # Assert
     assert present, (
         "pyproject's [all] aggregate must keep listing "
-        "scitex-agent-container[dev]: that is the ONLY route by which "
-        "pytest / pytest-asyncio / pytest-xdist reach the base image. "
-        "Drop it and a pristine container answers NO_PYTEST_ON_PATH again, "
-        "and every agent hand-installs a different pytest major."
+        "scitex-agent-container[dev]: pytest / pytest-asyncio / "
+        "pytest-xdist reach the base image through the extras, and a "
+        "pristine container that loses them answers NO_PYTEST_ON_PATH "
+        "again while every agent hand-installs a different pytest major. "
+        "apptainer-base.def also names [dev] directly, so this assert is "
+        "the belt to that braces — keep BOTH."
     )
 
 


### PR DESCRIPTION
Follow-up to #975, which merged while the verification bake was running.

## The change

`apptainer-base.def` installs `[all,dev]` instead of `[all]`. Operator, on the
bracket: 「オールとデブですね」.

`all` contains `dev` today, so `[all]` alone resolves the same set — the
measured proof is below: the two bakes produced SIFs 8 KB apart out of 1.59 GB,
with an identical 221-distribution manifest. Naming `dev` anyway is not
redundancy for its own sake:

* it makes the **requirement** legible in the line that implements it. The
  reason the bracket is wide is *"this image must arrive able to run its own
  tests"*. `[all]` does not say that — it says "give me everything", a weaker
  and differently-motivated claim that happens to be sufficient right now;
* it stays correct if `all` is ever trimmed. An aggregate quietly losing a
  member is precisely the silent drift this whole change exists to end.

It also matches what CI already writes: `.github/ci/run-in-sif.sh` installs
`-e ".[all,dev]"`. The image and CI now name the same thing.

## Behavioural verification, on the image this branch produces

Baked on scitex-compute-04 via the sac verb — `sac image build base -y` — from
an isolated venv editable-installed from this branch, so the build read this
`.def`. Not a hand-rolled `apptainer build`.

**PRISTINE container off the new image, nothing hand-installed:**

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.4.2, pluggy-1.6.0
rootdir: /work
configfile: pyproject.toml
plugins: anyio-4.14.2, asyncio-1.4.0, cov-7.1.0, xdist-3.8.0, scitex-dev-0.47.0
asyncio: mode=Mode.STRICT, debug=False, ...
============ 27 failed, 904 passed, 1 warning in 149.08s (0:02:29) =============
```

* `Missing required plugins` — **0 occurrences**. #974's gate never fires.
* `async def functions are not natively supported` — **0 occurrences**. The
  93-failure artefact class is gone.
* pytest is **8.4.2**, inside the declared `>=7.0.0,<9.0.0` and the same major
  CI runs.

**The gate is armed, so that zero means something.** Same suite, same image
generation, with pytest-asyncio deliberately withheld:

```
ERROR: Missing required plugins: pytest-asyncio
GATE_RC=4
```

**The 27 failures are pre-existing and unrelated.** Controlled A/B: the OLD
`[openai]` image, given the same pytest 8.4.2 + asyncio/xdist/cov through
`uv pip install --target`, returns the *identical* 27 failed / 59 passed on the
same four files. They pass 66/66 inside a normal agent container, so they track
user state, not the image. Carded separately as
`sac-listen-tests-need-agent-home` — deliberately not gating this PR.

## Cost, measured

| | `[openai]` (before #975) | `[all,dev]` (this branch) |
|---|---|---|
| SIF | 1535.5 MB | 1585.8 MB (+50.3 MB, +3.3%) |
| `/opt/venv-sac` | 1.1 G | 1.3 G |
| distributions | 161 | 221 (+60) |
| pytest | absent | 8.4.2 |

The `[all]` bake measured 1662853120 bytes; `[all,dev]` measured 1662861312 —
**8 KB apart**, same 221 distributions. That is the empirical statement that
naming `dev` costs nothing.

Small overall because the heavy scientific stack was already in the image under
`[openai]` (scitex-dev 0.47.0, playwright 1.62.0, numpy 2.5.2, scipy 1.18.0,
matplotlib 3.11.1, pymupdf 1.28.2). The added weight is sphinx 9.1.0, litellm +
huggingface-hub + tokenizers + google-genai + groq (via `[codex]`),
claude-code-telegrammer, pre-commit + virtualenv, and the four pytest packages
that are the point.

Build time ~13 min at `nice 19` on a 32-core host.

## Rollout

scitex-compute-04 only. The swap is atomic — `sac-base.sif` now points at
`sac-base-2026-0812-090318.sif`; every prior SIF is still on disk and
`sac image rollback` undoes it. Running agents are undisturbed and pick the new
image up at their next start. Propagation to other hosts is deliberately not
done here.
