### PR TITLE
fix(relocate): the three refusals that arrived after the agent was already down

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_relocate_checks.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_checks.py
@@ -1,9 +1,9 @@
-"""The eleven predicates, one per thing that went wrong when this was done by hand.
+"""The predicates, one per thing that went wrong when this was done by hand.
 
-Every check here was learned by doing the move manually on 2026-08-07 (and the
-sac-present one on 2026-08-11). None of them is hypothetical: rewriting `host:`
-alone produced an agent that STARTED, reported HEALTHY, and did nothing, which
-is the worst failure shape available because it looks exactly like success.
+Every check here was learned by doing the move manually on 2026-08-07. None of
+them is hypothetical: rewriting `host:` alone produced an agent that STARTED,
+reported HEALTHY, and did nothing, which is the worst failure shape available
+because it looks exactly like success.
 
     binds        the spec bound /mnt/c — a Windows drive absent on the nas
     card store   SCITEX_CARDS_DB is 5432 here and 5442 there
@@ -12,10 +12,6 @@ is the worst failure shape available because it looks exactly like success.
                  every turn 401'd while `sac agents health` still said healthy
     runtime      `tui` is rejected by the nas's older sac
     schema       a top-level `provider:` key is rejected by that same validator
-    sac present  `sac` on compute-04 lives at /home/ywatanabe/.env-sac/bin/sac
-                 and is NOT on the non-interactive ssh PATH, so `ssh host sac …`
-                 answers "No such file or directory" while sac is installed and
-                 working
     source work  uncommitted or unpushed work on the machine being LEFT — the
                  one check here that is about the source rather than the target
   + reachability, image presence, free ports, and whether the hub is reachable
@@ -25,12 +21,11 @@ is the worst failure shape available because it looks exactly like success.
 CREDENTIALS IS THE ONE TO READ TWICE. Checking PRESENCE passes on an expired
 file. The check has to be about VALIDITY, and the failure it prevents is silent.
 
-SAC-PRESENT LOOKS LIKE ONE CHECK AND IS TWO. "not installed there" and
-"installed there and ssh cannot see it" produce the identical error and need
-opposite fixes — install it, versus put it on the PATH. A check that reports
-only "sac not found" sends the reader to install a second copy of something that
-is already working, which is why the two are separated here by evidence rather
-than merged into one message.
+TWO SIBLINGS HOLD THE REST, and they are separate files because each is one
+story rather than one predicate: :mod:`_relocate_checks_sac` owns whether sac on
+the target can be REACHED (three different PATHs, and which one the answer is
+about), and :mod:`_relocate_checks_late` owns the two questions the PHASES used
+to ask after the agent had already been stopped.
 
 NO I/O. These evaluate FACTS someone else gathered — facts in, :class:`Check`s
 out — so sac does not learn how to probe a host here, and every check is
@@ -55,7 +50,6 @@ __all__ = [
     "CHECK_PORTS",
     "CHECK_REACHABLE",
     "CHECK_RUNTIME",
-    "CHECK_SAC_PRESENT",
     "CHECK_SCHEMA",
     "CHECK_SESSION",
     "CHECK_SOURCE_WORK",
@@ -67,7 +61,6 @@ __all__ = [
     "check_ports",
     "check_reachable",
     "check_runtime",
-    "check_sac_present",
     "check_schema",
     "check_session_resolvable",
     "check_source_work",
@@ -82,7 +75,6 @@ CHECK_RUNTIME: Final = "runtime_supported"
 CHECK_SCHEMA: Final = "spec_schema_accepted"
 CHECK_PORTS: Final = "ports_free"
 CHECK_HUB_FROM_TARGET: Final = "hub_reachable_from_target"
-CHECK_SAC_PRESENT: Final = "sac_present_on_target"
 CHECK_SOURCE_WORK: Final = "source_work_committed"
 CHECK_SESSION: Final = "session_resolvable"
 
@@ -266,66 +258,6 @@ def check_hub_from_target(facts: TargetFacts, to_host: str) -> Check:
         )
     return Check(
         name=CHECK_HUB_FROM_TARGET, ok=True, detail=f"hub reachable from {to_host}"
-    )
-
-
-def check_sac_present(facts: TargetFacts, to_host: str) -> Check:
-    """Installed AND findable are two questions; the answer names which failed.
-
-    Measured 2026-08-11 on scitex-compute-04: sac lives at
-    ``/home/ywatanabe/.env-sac/bin/sac`` and is absent from the non-interactive
-    ssh PATH, so ``ssh compute-04 sac agents list`` answers "No such file or
-    directory" — the same words a machine with no sac at all produces. Every
-    remote step of a relocation runs under exactly that PATH.
-    """
-    if facts.sac_on_path is None:
-        return _unobserved(CHECK_SAC_PRESENT, "whether sac is on the target's ssh PATH")
-    if facts.sac_on_path:
-        where = f" at {facts.sac_resolved_path}" if facts.sac_resolved_path else ""
-        return Check(
-            name=CHECK_SAC_PRESENT,
-            ok=True,
-            detail=f"sac is on {to_host}'s non-interactive ssh PATH{where}",
-        )
-    if facts.sac_resolved_path is None:
-        return Check(
-            name=CHECK_SAC_PRESENT,
-            ok=None,
-            detail=(
-                f"sac is not on {to_host}'s non-interactive ssh PATH, and whether it is "
-                "installed there at all was not established"
-            ),
-            hint=(
-                "look for it directly before concluding anything: "
-                f"ssh {to_host} 'bash -lc \"command -v sac\"', and check the known venv "
-                "(~/.env-sac/bin/sac). 'Not on PATH' and 'not installed' produce the "
-                "same error and need opposite fixes"
-            ),
-        )
-    if not facts.sac_resolved_path:
-        return Check(
-            name=CHECK_SAC_PRESENT,
-            ok=False,
-            detail=f"sac is NOT INSTALLED on {to_host} — not on the ssh PATH and at no known location",
-            hint=(
-                f"install sac on {to_host} before relocating onto it. Every remote step "
-                "of the relocation — starting the target, verifying the source stopped — "
-                "is a sac call over ssh"
-            ),
-        )
-    return Check(
-        name=CHECK_SAC_PRESENT,
-        ok=False,
-        detail=(
-            f"sac IS INSTALLED on {to_host} at {facts.sac_resolved_path}, but is not on "
-            "the non-interactive ssh PATH that remote sac calls run under"
-        ),
-        hint=(
-            "do NOT install a second copy — set the peer's env_preamble in config.yaml "
-            "so it is on PATH (that is what env_preamble is for), or address it by "
-            f"absolute path. The evidence: ssh {to_host} 'command -v sac' printed "
-            f"nothing while {facts.sac_resolved_path} exists there"
-        ),
     )
 
 

--- a/src/scitex_agent_container/_lifecycle/_relocate_checks_late.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_checks_late.py
@@ -1,0 +1,206 @@
+"""The two checks that used to fire AFTER the agent was already stopped.
+
+:mod:`_relocate_checks` holds the predicates learned from doing the move by
+hand. These two were learned from watching the move RUN: on the 2026-08-11
+canary both of them refused correctly, both refused safely, and both refused
+late — one at ``handover``, one at the target's own ``sac agents start``, and by
+then ``source_stop`` had already happened. An agent whose relocation cannot
+succeed must be told so while it is still running, so the questions moved here
+and the phases now ask a decision that was already made.
+
+    lease_holdable        the handover's own precondition, asked before
+                          anything stops. Shares ONE predicate with the phase
+                          (:func:`.._relocate_lease.handoff_readiness`) so the
+                          gate cannot pass on a phase that will refuse.
+    target_start_accepts  whether the TARGET's ``sac agents start`` would take
+                          this agent at all. Preflight had eleven checks about
+                          the target and not one of them asked the target's own
+                          start command anything.
+
+WHY ``target_start_accepts`` IS NOT A REIMPLEMENTATION OF THE DRIFT GUARD. The
+guard is the code that will refuse the boot, so it is the only thing entitled to
+say whether it would; the probe asks the target's OWN sac and this file reads
+back its verdict. A second copy of the rule here would pass on exactly the day
+the real one changed. What this file does own is the CONSEQUENCE — the guard
+refuses on BEHIND and DIVERGED and never on AHEAD, and a relocation must refuse
+in exactly the same places or it has invented a different policy.
+
+NO I/O, like its sibling. Facts in, :class:`Check`s out.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from ._relocate_lease_readiness import handoff_readiness
+from ._relocate_preflight_facts import Check, LeaseFacts, TargetFacts
+
+__all__ = [
+    "CHECK_LEASE",
+    "CHECK_TARGET_START",
+    "STALE_STATES",
+    "check_lease_holdable",
+    "check_target_start",
+]
+
+CHECK_LEASE: Final = "lease_holdable"
+CHECK_TARGET_START: Final = "target_start_accepts"
+
+#: The :class:`.._drift._status.DriftState` values that make the target's start
+#: refuse. Mirrors ``DriftStatus.is_stale`` — BEHIND and DIVERGED only. AHEAD is
+#: deliberately absent: the spec about to launch is the newest one that exists,
+#: it merely has not propagated, and refusing on it would ground every host that
+#: legitimately carries local commits.
+STALE_STATES: Final[frozenset[str]] = frozenset({"behind", "diverged"})
+
+
+def check_lease_holdable(facts: LeaseFacts, from_host: str, agent: str) -> Check:
+    """Can the source hand the write lease over — asked before the source stops.
+
+    Measured 2026-08-11, the canary's RETURN leg: exit 5 at ``handover``, after
+    ``source_stop``, after the transport was byte-verified, after the standby
+    booted and after the handshake passed. The refusal itself was right. Its
+    TIMING left an agent down on a machine whose lease row had been written by a
+    relocation the day before.
+
+    The rule is :func:`.._relocate_lease.handoff_readiness` and it is not
+    restated here — this function only supplies the facts to it and turns the
+    verdict into a :class:`Check`, so the gate and the phase cannot disagree.
+    """
+    where = from_host or "the source"
+    if not facts.read:
+        return Check(
+            name=CHECK_LEASE,
+            ok=None,
+            detail="the lease store was not read",
+            hint=(
+                "read the agent's row from relocation_leases before deciding. The "
+                "handover needs a lease it can hand FROM, and discovering that after "
+                "the agent has been stopped is the one thing this check exists to stop"
+            ),
+        )
+    if not from_host:
+        return Check(
+            name=CHECK_LEASE,
+            ok=None,
+            detail="the host being LEFT is not known, so no lease question can be asked about it",
+            hint=(
+                "resolve the source host first — 'may this host hand the lease over' "
+                "has no answer until the host is named"
+            ),
+        )
+    if facts.now is None:
+        return Check(
+            name=CHECK_LEASE,
+            ok=None,
+            detail=f"the lease row for {agent} was read with no clock, so its expiry is undecidable",
+            hint=(
+                "supply the moment the store was read. A lease carries an absolute "
+                "deadline, and whether it has passed is not a property of the row alone"
+            ),
+        )
+
+    verdict = handoff_readiness(
+        facts.lease,  # type: ignore[arg-type]
+        from_holder=from_host,
+        now=facts.now,
+        recorded_holder_running=facts.recorded_holder_running,
+    )
+    store = f" (store: {facts.store})" if facts.store else ""
+    seen = f" Observed: {facts.recorded_holder_evidence}" if facts.recorded_holder_evidence else ""
+    if verdict.allowed is True:
+        return Check(
+            name=CHECK_LEASE,
+            ok=True,
+            detail=f"{verdict.reason}{store}",
+        )
+    if verdict.allowed is None:
+        return Check(
+            name=CHECK_LEASE,
+            ok=None,
+            detail=f"{verdict.reason}{store}",
+            hint=(
+                f"look at {verdict.holder!r} before moving {agent} off {where}: is that "
+                "host running this agent right now? A row naming another holder is a "
+                "record of a past handover — this fleet writes the lease to the "
+                "COORDINATOR's own db, and the coordinator is always the host being "
+                "LEFT, so the row on THIS machine was written by the move that brought "
+                "the agent here. It only becomes a split-brain when the other host is "
+                "actually running the agent"
+            ),
+        )
+    return Check(
+        name=CHECK_LEASE,
+        ok=False,
+        detail=f"{verdict.reason}{store}.{seen}",
+        hint=(
+            f"this is the split-brain the lease exists to catch, and it is now backed by "
+            f"an observation rather than a row: {verdict.holder!r} is running {agent}. "
+            f"Settle which host owns this identity — stop it on one of them — before "
+            f"relocating. Do NOT force the handover"
+        ),
+    )
+
+
+def check_target_start(facts: TargetFacts, to_host: str, agent: str) -> Check:
+    """Would the TARGET's own ``sac agents start`` accept this agent?
+
+    Measured 2026-08-11: preflight said GO on all eleven checks, ``source_stop``
+    ran, and then ``sac agents start`` on the target refused with ``sac-drift:
+    spec source is 1 commit(s) BEHIND``. Nothing in the preflight had asked the
+    one command the whole relocation depends on whether it would run.
+
+    Live and about to bite again: scitex-compute-04's ``.dotfiles`` checkout —
+    which is what ``~/.scitex/agent-container/agents`` is a symlink into — is five
+    commits behind with 2389 modified files, so the remedy the guard prints
+    (``git pull --ff-only``) aborts there. The hint says so, because a hint that
+    names a command which will not run costs the reader the same trip as no hint.
+    """
+    drift = facts.spec_source_drift
+    if drift is None:
+        return Check(
+            name=CHECK_TARGET_START,
+            ok=None,
+            detail=f"{to_host} was not asked whether its own sac would start {agent}",
+            hint=(
+                f"ask it: ssh {to_host} 'sac doctor' reports the spec-source drift its "
+                "start command gates on. An older sac there may not carry the symbol the "
+                "probe reads, in which case upgrade it — every remote step of a "
+                "relocation is a sac call on that host anyway"
+            ),
+        )
+    repo = drift.repo or "<the target's spec-source repo>"
+    dirty = "" if drift.dirty is None else f", {drift.dirty} modified file(s)"
+    if drift.state not in STALE_STATES:
+        return Check(
+            name=CHECK_TARGET_START,
+            ok=True,
+            detail=(
+                f"{to_host}'s sac reports its spec source {drift.state}"
+                f"{f' vs {drift.upstream}' if drift.upstream else ''}{dirty}; "
+                "the start-time drift guard would not refuse"
+            ),
+        )
+    return Check(
+        name=CHECK_TARGET_START,
+        ok=False,
+        detail=(
+            f"{to_host}'s sac would REFUSE to start {agent}: its spec source is "
+            f"{drift.state.upper()} ({drift.behind} behind / {drift.ahead} ahead of "
+            f"{drift.upstream or 'upstream'}){dirty} in {repo}"
+        ),
+        hint=(
+            f"fix it ON {to_host} before relocating, not after: git -C {repo} pull "
+            "--ff-only"
+            + (
+                f" — but that repo has {drift.dirty} modified file(s) and --ff-only "
+                "aborts on a dirty tree, so commit or stash them there first"
+                if drift.dirty
+                else ""
+            )
+            + ". The named override is --allow-stale-spec / SAC_ALLOW_STALE_SPEC=1, "
+            "which starts the agent from a spec that may be out of date; prefer the "
+            "pull. This refusal happens at boot on the target, which is AFTER the "
+            "agent has been stopped on the source — that is why it is asked here"
+        ),
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_checks_sac.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_checks_sac.py
@@ -1,0 +1,166 @@
+"""Can sac on the target be REACHED — and which of the three PATHs is that about?
+
+One check, and it takes a whole file because the question has been asked wrongly
+once already and the wrong answer was a hint that sent people to do something
+they had already done.
+
+    2026-08-11, scitex-compute-04: sac lives at ~/.env-sac/bin/sac and is absent
+    from the non-interactive ssh PATH, so `ssh compute-04 sac agents list`
+    answers "No such file or directory" — the same words a machine with no sac
+    at all produces. That is why the check separates INSTALLED from FINDABLE:
+    the two need opposite fixes and produce identical errors.
+
+    2026-08-12, ywata-note-win: the check FAILED and told the operator to set
+    the peer's `env_preamble`. It was already set, to a preamble that works, and
+    :class:`._relocate_shell.Shell` prepends it to every command a relocation
+    sends. So the check was reading a PATH that nothing in this feature uses,
+    and answering with a step that changes nothing.
+
+THREE PATHS, AND THE CHECK MUST SAY WHICH IT MEANS:
+
+    sac_on_path       the BARE non-interactive ssh PATH. What a person typing
+                      `ssh host sac …` gets. A true answer to a stricter
+                      question than this feature needs.
+    sac_usable_path   that PATH PLUS the peer's env_preamble — what every
+                      relocation command actually runs under. THE ONE THAT
+                      DECIDES.
+    sac_resolved_path found by looking harder (login shell, known venvs). Only
+                      ever used to tell "not installed" from "installed and
+                      unreachable".
+
+The hint is narrow for the same reason :mod:`.._state._remote_sac_hint` is
+narrow, and it states that reason where it branches: a peer that ALREADY
+declares a preamble has a different problem, and naming env_preamble there is a
+confident wrong answer.
+
+NO I/O, like its siblings. Facts in, a :class:`Check` out.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from ._relocate_checks import _unobserved
+from ._relocate_preflight_facts import Check, TargetFacts
+
+__all__ = ["CHECK_SAC_PRESENT", "check_sac_present"]
+
+CHECK_SAC_PRESENT: Final = "sac_present_on_target"
+
+
+def check_sac_present(facts: TargetFacts, to_host: str) -> Check:
+    """Installed AND findable are two questions; the answer names which failed.
+
+    The fact that DECIDES is ``sac_usable_path`` — where sac resolves under the
+    raw ssh PATH plus the peer's preamble, which is what the relocation uses.
+    ``sac_on_path`` is still read, because it is what an operator typing a bare
+    ssh command will get and it is the only answer an older probe supplies, and
+    it still PASSES on its own; it simply no longer FAILS on its own.
+    """
+    if facts.sac_usable_path:
+        via = (
+            " (via the peer's env_preamble)"
+            if facts.preamble_declared and not facts.sac_on_path
+            else ""
+        )
+        return Check(
+            name=CHECK_SAC_PRESENT,
+            ok=True,
+            detail=(
+                f"sac is reachable on {to_host} at {facts.sac_usable_path} under the PATH "
+                f"this relocation's own commands run under{via}"
+            ),
+        )
+    if facts.sac_on_path:
+        where = f" at {facts.sac_resolved_path}" if facts.sac_resolved_path else ""
+        return Check(
+            name=CHECK_SAC_PRESENT,
+            ok=True,
+            detail=f"sac is on {to_host}'s non-interactive ssh PATH{where}",
+        )
+    if facts.sac_usable_path is None and facts.sac_on_path is None:
+        return _unobserved(CHECK_SAC_PRESENT, "whether sac is on the target's ssh PATH")
+    if facts.sac_usable_path is None and facts.preamble_declared:
+        return Check(
+            name=CHECK_SAC_PRESENT,
+            ok=None,
+            detail=(
+                f"sac is not on {to_host}'s BARE ssh PATH, and this peer declares an "
+                "env_preamble whose effect on that PATH was not measured — so whether a "
+                "relocation command would find sac there is undetermined"
+            ),
+            hint=(
+                f"measure the PATH the relocation actually uses: ssh {to_host} "
+                "'<the peer's env_preamble>; command -v sac'. The bare PATH is a "
+                "stricter question than this feature needs answered"
+            ),
+        )
+    if facts.sac_resolved_path is None:
+        return Check(
+            name=CHECK_SAC_PRESENT,
+            ok=None,
+            detail=(
+                f"sac is not reachable on {to_host} under the PATH relocation commands "
+                "use, and whether it is installed there at all was not established"
+            ),
+            hint=(
+                "look for it directly before concluding anything: "
+                f"ssh {to_host} 'bash -lc \"command -v sac\"', and check the known venv "
+                "(~/.env-sac/bin/sac). 'Not on PATH' and 'not installed' produce the "
+                "same error and need opposite fixes"
+            ),
+        )
+    if not facts.sac_resolved_path:
+        return Check(
+            name=CHECK_SAC_PRESENT,
+            ok=False,
+            detail=f"sac is NOT INSTALLED on {to_host} — not on the ssh PATH and at no known location",
+            hint=(
+                f"install sac on {to_host} before relocating onto it. Every remote step "
+                "of the relocation — starting the target, verifying the source stopped — "
+                "is a sac call over ssh"
+            ),
+        )
+    return Check(
+        name=CHECK_SAC_PRESENT,
+        ok=False,
+        detail=(
+            f"sac IS INSTALLED on {to_host} at {facts.sac_resolved_path}, and is not "
+            "reachable under the PATH this relocation's commands run under"
+        ),
+        hint=_sac_path_hint(facts, to_host),
+    )
+
+
+def _sac_path_hint(facts: TargetFacts, to_host: str) -> str:
+    """What to actually do — which depends on whether a preamble is already set.
+
+    The narrowness is the point, and it is the same discipline
+    :mod:`.._state._remote_sac_hint` already states for the rc=127 case: a peer
+    that ALREADY declares an ``env_preamble`` has a different problem (a wrong
+    path in it, a venv that moved) and pointing it at ``env_preamble`` would be a
+    confident wrong answer. Measured 2026-08-12 on ywata-note-win, which declares
+    ``export PATH="$HOME/.env-3.11/bin:$PATH"`` and was told to declare one.
+    """
+    found = facts.sac_resolved_path or "the path it was found at"
+    if facts.preamble_declared:
+        return (
+            f"do NOT add an env_preamble — {to_host} already declares one, and it is "
+            "applied to every command this relocation sends. It is not putting "
+            f"{found} on PATH, so the preamble itself is what to fix: compare the "
+            f"directory it exports against $(dirname {found}) in "
+            "~/.scitex/agent-container/config.yaml"
+        )
+    if facts.preamble_declared is None:
+        return (
+            f"do NOT install a second copy — sac is at {found}. Check whether "
+            f"{to_host} declares an env_preamble in ~/.scitex/agent-container/config.yaml: "
+            "if it does, that preamble is not exporting this directory and is what to "
+            f"fix; if it does not, add one exporting $(dirname {found})"
+        )
+    return (
+        f"do NOT install a second copy — {to_host} declares NO env_preamble in "
+        "~/.scitex/agent-container/config.yaml, and ssh runs a non-login shell, so a "
+        f"venv install is invisible there. Add one exporting $(dirname {found}); "
+        "every script this relocation sends is prefixed with it"
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_effects.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_effects.py
@@ -89,6 +89,12 @@ class RelocateAdapters(
     #: that had to spend it too would either be slow or would not be written.
     sleep: Callable[[float], None] = time.sleep
     peers: object = None
+    #: The coordinator's own fleet name, kept because the two Shells above are
+    #: not always enough: a lease row can name a THIRD host, and reaching it
+    #: needs the same "am I already standing on this machine" answer
+    #: :func:`shell_for` was given for the source and the target. Decided once by
+    #: the caller from an observation, never re-discovered here.
+    local_host: str = ""
 
     #: The source-side ``spec.yaml`` this agent is defined by. Carried to the
     #: target by TARGET_STANDBY — a host cannot start an agent it has no spec
@@ -292,4 +298,5 @@ def adapters_for(
         target=shell_for(to_host, local_host=local_host),
         stamp=stamp or time.strftime("%Y%m%dT%H%M%SZ", time.gmtime()),
         exec_fn=exec_fn,
+        local_host=local_host or "",
     )

--- a/src/scitex_agent_container/_lifecycle/_relocate_effects_handover.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_effects_handover.py
@@ -15,13 +15,18 @@ comes back. This bootstraps, records the bootstrap in the journal detail so
 nobody later mistakes it for a lease the source had been holding all along, and
 starts the fence at 0 so the handoff lands at 1.
 
-A LEASE HELD BY A THIRD HOST IS A REFUSAL, NOT A BOOTSTRAP. A live lease naming
-someone other than the source is the exact condition the lease was written to
-detect, and helping past it would defeat the instrument. An EXPIRED one held by
-another host is different and is re-claimed for the source first, so the fence
-advances and the old holder is locked out by arithmetic rather than by trusting
-its clock — the distinction :mod:`_relocate_lease` draws between what a TTL
-decides and what a fence decides.
+A LEASE HELD BY A THIRD HOST THAT IS RUNNING THE AGENT IS A REFUSAL. That is the
+exact condition the lease was written to detect and helping past it would defeat
+the instrument. A row naming another host that is NOT running it is a different
+thing entirely — this fleet writes the lease to the COORDINATOR's own db and the
+coordinator is always the host being LEFT, so such a row is ordinarily the
+record of the move that brought the agent HERE. It is re-claimed for the source,
+the fence advances, and the old holder is locked out by arithmetic; the same is
+done for an EXPIRED one. Which of those applies is decided by
+:mod:`_relocate_lease_readiness`, and by the PREFLIGHT calling the same function
+before anything is stopped — because this phase runs last, and its refusal used
+to arrive with the agent already down (measured 2026-08-11, the canary's return
+leg, exit 5 at this phase).
 
 THE WRITE IS RE-READ. ``save_lease`` returning is the writer's opinion; who
 holds the lease is the row's. This is the one step where a wrong answer means
@@ -41,6 +46,9 @@ import secrets
 
 from ._relocate_execute import StepResult
 from ._relocate_lease import claim, handoff
+from ._relocate_lease_readiness import handoff_readiness
+from ._relocate_liveness import observe_running
+from ._relocate_shell import shell_for
 
 __all__ = ["LEASE_TTL_S", "HandoverEffects"]
 
@@ -125,32 +133,45 @@ class HandoverEffects:
         with the lease so the journal records HOW the source came to hold it —
         a bootstrapped claim and an inherited one are different facts, and a
         reader six months later cannot tell them apart from the fence alone.
+
+        THE RULE IS NOT WRITTEN HERE. It is
+        :func:`._relocate_lease_readiness.handoff_readiness`, and the preflight
+        asks the identical question with the identical function before anything
+        is stopped. That is the point: a gate that could pass while this phase
+        refuses would be a gate that guarantees the agent goes down first.
         """
         from .._state.state_db_relocation import load_lease, save_lease
 
         held = load_lease(self.agent)
-        if held is not None and held.holder == self.from_host:
-            return held, "", None
-
-        if held is not None and not held.is_expired(now):
+        holder_running = self._recorded_holder_running(held, now)
+        ready = handoff_readiness(
+            held,
+            from_holder=self.from_host,
+            now=now,
+            recorded_holder_running=holder_running,
+        )
+        if ready.allowed is not True:
             return (
                 None,
                 "",
                 StepResult(
-                    ok=False,
-                    detail=(
-                        f"the lease for {self.agent} is held by {held.holder!r} at fence "
-                        f"{held.fence}, not by the source {self.from_host!r}"
-                    ),
+                    ok=None if ready.allowed is None else False,
+                    detail=ready.reason,
                     hint=(
-                        "this is the split-brain the lease exists to catch. Find out what "
-                        f"{held.holder!r} is doing with this identity before relocating; "
-                        "do NOT force the handover"
+                        f"look at {ready.holder!r}: is it running {self.agent}? Until "
+                        "somebody does, this is undetermined rather than refused"
+                        if ready.allowed is None
+                        else "this is the split-brain the lease exists to catch, and it is "
+                        "backed by an observation rather than a row. Settle which host "
+                        "owns this identity before re-running; do NOT force the handover"
                     ),
                 ),
             )
+        if held is not None and held.holder == self.from_host:
+            return held, "", None
 
-        was_expired = held is not None
+        was_expired = held is not None and held.is_expired(now)
+        superseded = held is not None and not was_expired
         granted, verdict = claim(
             held,
             agent=self.agent,
@@ -158,6 +179,7 @@ class HandoverEffects:
             token=secrets.token_hex(16),
             now=now,
             ttl_s=LEASE_TTL_S,
+            holder_absent=superseded,
         )
         if verdict.allowed is not True or granted is None:
             return (
@@ -167,13 +189,20 @@ class HandoverEffects:
                     ok=False,
                     detail=(
                         f"the source's lease could not be "
-                        f"{'re-claimed' if was_expired else 'bootstrapped'}: {verdict.reason}"
+                        f"{'re-claimed' if held is not None else 'bootstrapped'}: {verdict.reason}"
                     ),
                     hint="nothing was handed over; read the lease row before re-running",
                 ),
             )
         save_lease(granted)
-        if was_expired:
+        if superseded:
+            note = (
+                f" The row named {held.holder!r} at fence {held.fence} and that host was "
+                f"OBSERVED not running {self.agent}, so the lease was re-claimed for the "
+                f"source at fence {granted.fence} — a record of a past handover, not a "
+                "live writer."
+            )
+        elif was_expired:
             note = (
                 f" An EXPIRED lease held by {held.holder!r} was re-claimed for the source "
                 f"at fence {granted.fence} before the handoff, so that holder is fenced "
@@ -187,3 +216,26 @@ class HandoverEffects:
             )
         self.log.append(f"handover:{note.strip()}")
         return granted, note, None
+
+    def _recorded_holder_running(self, held, now: float) -> bool | None:
+        """Is the agent running on the host the LEASE ROW names? ``None`` = nobody asked.
+
+        Only asked when the answer can change anything — a row naming the source
+        itself, or an expired one, needs no third host observed, and probing one
+        anyway would let an idle machine's ssh failure refuse a fine relocation.
+
+        Uses :func:`._relocate_liveness.observe_running`, the same tmux question
+        the runtime asks and the same one ``finish`` asks of both hosts. A probe
+        that could not answer returns ``None``, which refuses — this is the one
+        place where guessing "not running" would hand the lease away from a live
+        writer.
+        """
+        if held is None or held.holder == self.from_host or held.is_expired(now):
+            return None
+        shell = shell_for(held.holder, local_host=self.local_host or None)
+        running, why = observe_running(shell, self.agent, exec_fn=self.exec_fn)
+        self.log.append(
+            f"handover: the lease row names {held.holder}; {self.agent} there = "
+            f"{running!r} ({why})"
+        )
+        return running

--- a/src/scitex_agent_container/_lifecycle/_relocate_lease.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_lease.py
@@ -181,8 +181,9 @@ def claim(
     token: str,
     now: float,
     ttl_s: float,
+    holder_absent: bool = False,
 ) -> tuple[Lease | None, LeaseVerdict]:
-    """Take an unheld or EXPIRED lease. Returns ``(lease, verdict)``.
+    """Take an unheld, EXPIRED, or demonstrably ABANDONED lease. ``(lease, verdict)``.
 
     Refuses while another holder's lease is live — that refusal is the whole
     point, and it is why a second copy-and-start cannot quietly become a second
@@ -192,6 +193,25 @@ def claim(
     The fence advances on every successful claim, including a reclaim after
     expiry: the previous holder may still be alive and unaware, and must be
     locked out even if its clock disagrees about when the lease ended.
+
+    ``holder_absent`` IS AN OBSERVATION, NOT A FORCE FLAG, and the distinction is
+    the whole reason it is a parameter rather than a bypass. The caller passes it
+    only after LOOKING at the host the row names and finding the agent not
+    running there — the same tmux question the runtime itself asks. It is
+    strictly better evidence than the TTL, which is a guess about liveness
+    expressed as arithmetic on clocks that may disagree; this module's header
+    already draws that line ("the TTL decides when a lease may be RECLAIMED; the
+    fence decides who may WRITE"), and an observed absence is simply a better
+    answer to the first half. What excludes the old holder is unchanged: the
+    fence advances here exactly as it does after an expiry, so a holder that
+    wakes up is locked out by arithmetic either way.
+
+    It exists because the lease is written to the COORDINATOR's local store and
+    the coordinator is always the host being LEFT, so after A -> B the row on A
+    reads ``holder=B`` and B's own store never learns. Measured 2026-08-11: B's
+    store still held ``holder=A`` from an earlier move, and the return leg read
+    it as a live second writer. See :mod:`_relocate_lease_readiness`, which is
+    what decides whether this argument may be passed.
     """
     if lease is not None and lease.agent != agent:
         # UNKNOWN, not a refusal: this record says nothing about `agent` either
@@ -206,7 +226,12 @@ def claim(
                 "cannot answer for an agent this record is not about"
             ),
         )
-    if lease is not None and not lease.is_expired(now) and lease.holder != holder:
+    if (
+        lease is not None
+        and not lease.is_expired(now)
+        and lease.holder != holder
+        and not holder_absent
+    ):
         return lease, _no(
             CODE_HELD_BY_OTHER,
             f"{agent}: held by {lease.holder!r} until {lease.expires_at} — {holder!r} may not write",
@@ -220,11 +245,14 @@ def claim(
         expires_at=now + ttl_s,
         fence=next_fence,
     )
-    was = (
-        "unheld"
-        if lease is None
-        else ("expired" if lease.is_expired(now) else "already ours")
-    )
+    if lease is None:
+        was = "unheld"
+    elif lease.is_expired(now):
+        was = "expired"
+    elif lease.holder == holder:
+        was = "already ours"
+    else:
+        was = f"held by {lease.holder!r}, OBSERVED not running this agent"
     return granted, _ok(
         granted, f"{agent}: claimed by {holder!r} (previous state: {was})"
     )
@@ -326,6 +354,7 @@ def handoff(
         moved,
         f"{lease.agent}: handed {from_holder!r} -> {to_holder!r} at fence {moved.fence}",
     )
+
 
 
 def check_write(

--- a/src/scitex_agent_container/_lifecycle/_relocate_lease_facts.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_lease_facts.py
@@ -1,0 +1,140 @@
+"""Read the lease row, and go and LOOK at whatever host it names.
+
+The adapter behind :func:`._relocate_checks_late.check_lease_holdable`. The check
+is a pure predicate over facts; this is the part that opens the state db and, when
+the answer depends on it, spends one ssh asking a third machine whether it is
+running the agent.
+
+TWO SOURCES, AND THEY ARE NOT INTERCHANGEABLE. The row comes from the
+COORDINATOR's own store — which is the whole of the problem it exists to describe,
+since the coordinator is always the host being LEFT and the destination of a move
+never learns what happened. The liveness comes from the host the row NAMES, over
+the same tmux question the runtime asks. One without the other is exactly the
+material the 2026-08-11 canary refused on: a true row, read as a live writer,
+about a machine nobody had asked.
+
+WHAT ``read=False`` PROTECTS. An unreadable or absent store must leave ``read``
+false, NOT ``lease=None`` — because ``lease=None`` is a real and common answer
+("this store has never held a row for this agent") that BOOTSTRAPS a lease and
+proceeds. Collapsing "I could not open the db" into it would turn a broken store
+into a green light, at the one gate that stands between one live agent and two.
+
+THE OBSERVATION IS ONLY TAKEN WHEN IT CAN CHANGE THE ANSWER — no row, a row
+naming the source itself, or an expired row all decide without it. Probing anyway
+would let an idle machine's ssh timeout refuse a relocation that was fine, which
+is a new way to fail rather than a safer one.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+from ._relocate_preflight_facts import LeaseFacts
+
+__all__ = ["gather_lease_facts"]
+
+
+def gather_lease_facts(
+    agent: str,
+    *,
+    from_host: str,
+    local_host: str = "",
+    now: float | None = None,
+    exec_fn: Callable[..., dict] | None = None,
+    db_path=None,
+    load: Callable[[str], object] | None = None,
+    observe: Callable[[str, str], tuple[bool | None, str]] | None = None,
+) -> LeaseFacts:
+    """Read the agent's lease and, if it names a live third host, observe that host.
+
+    ``load`` and ``observe`` are the injection seams, and they take and return
+    real values rather than standing in for the behaviour under test: a test
+    passes a callable that returns a real :class:`._relocate_lease.Lease` and a
+    real ``(bool | None, str)``, so nothing about the decision is mocked.
+
+    Never raises. Every failure becomes ``read=False`` or an unobserved liveness,
+    both of which the check reports as UNKNOWN and refuses on.
+    """
+    moment = time.time() if now is None else float(now)
+    store = _store_path(db_path)
+
+    reader = load if load is not None else _default_load(db_path)
+    try:
+        lease = reader(agent)
+    except Exception as exc:  # stx-allow: fallback (reason: an unreadable lease store must leave the fact UNOBSERVED, never "no row", which would bootstrap a lease and proceed)
+        return LeaseFacts(
+            read=False,
+            store=store,
+            now=moment,
+            recorded_holder_evidence=(
+                f"the lease store could not be read: {type(exc).__name__}: {exc}"
+            ),
+        )
+
+    holder = getattr(lease, "holder", "") if lease is not None else ""
+    if not _needs_observing(lease, from_host, moment):
+        return LeaseFacts(read=True, lease=lease, store=store, now=moment)
+
+    watcher = observe if observe is not None else _default_observe(local_host, exec_fn)
+    try:
+        running, why = watcher(holder, agent)
+    except Exception as exc:  # stx-allow: fallback (reason: a failed probe is NOT MEASURED; folding it into "not running" would hand the lease away from a possibly-live writer)
+        running, why = None, f"the liveness probe of {holder} raised {type(exc).__name__}: {exc}"
+    return LeaseFacts(
+        read=True,
+        lease=lease,
+        recorded_holder_running=running,
+        recorded_holder_evidence=why,
+        store=store,
+        now=moment,
+    )
+
+
+def _needs_observing(lease, from_host: str, now: float) -> bool:
+    """Only a LIVE row naming somebody other than the source needs a third host asked.
+
+    An unnamed source is deliberately in the "no" set: the check refuses on that
+    alone, so an ssh spent here would buy nothing and could only add a way to
+    fail.
+    """
+    if lease is None or not from_host:
+        return False
+    if getattr(lease, "holder", "") == from_host:
+        return False
+    expired = getattr(lease, "is_expired", None)
+    return not (callable(expired) and expired(now))
+
+
+def _store_path(db_path) -> str:
+    """Which db was read. Reported because a lease answer is only as good as its store."""
+    if db_path is not None:
+        return str(db_path)
+    try:
+        from .._state.state_db import DEFAULT_DB_PATH
+
+        return str(DEFAULT_DB_PATH)
+    except Exception:  # stx-allow: fallback (reason: the store's NAME is for the report; failing to render it must not cost the reader the lease answer itself)
+        return ""
+
+
+def _default_load(db_path) -> Callable[[str], object]:
+    def load(agent: str):
+        from .._state.state_db_relocation import load_lease
+
+        return load_lease(agent, db_path=db_path)
+
+    return load
+
+
+def _default_observe(
+    local_host: str, exec_fn: Callable[..., dict] | None
+) -> Callable[[str, str], tuple[bool | None, str]]:
+    def observe(holder: str, agent: str) -> tuple[bool | None, str]:
+        from ._relocate_liveness import observe_running
+        from ._relocate_shell import shell_for
+
+        shell = shell_for(holder, local_host=local_host or None)
+        return observe_running(shell, agent, exec_fn=exec_fn)
+
+    return observe

--- a/src/scitex_agent_container/_lifecycle/_relocate_lease_readiness.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_lease_readiness.py
@@ -1,0 +1,162 @@
+"""Would the handover be allowed to run? The same question, asked before anything stops.
+
+:mod:`_relocate_lease` is the state machine — claim, renew, hand off, may-I-write.
+This is one PREDICATE ABOUT that machine, and it lives apart from it because it
+is read by a different layer at a different moment: the PREFLIGHT, while the
+agent is still up, about a phase that will not run for another five steps.
+
+WHY IT EXISTS AT ALL. Measured 2026-08-11, the canary's RETURN leg: the
+relocation refused at ``handover`` with exit 5 — correctly, safely, and after
+``source_stop``, after the transport was byte-verified, after the standby booted
+and after the handshake passed. The agent was down on the source and the answer
+had been knowable before any of it. So the rule moved here, and both the gate and
+the phase call it: two copies would be one refactor away from a preflight that
+passes on a handover that will refuse, which is worse than having no preflight.
+
+WHAT THE CANARY ACTUALLY HIT, because the fix follows from it. The lease is
+written to the COORDINATOR's local state db, and the coordinator is always the
+host being LEFT. So after A -> B, the row on A reads ``holder=B`` and B's own
+store never hears about it. When B later moves back, the coordinator stands on B,
+reads B's store, and finds a row from an EARLIER move that reads ``holder=A``.
+Nothing in that row says A is writing today; it says a relocation once handed A
+the lease, on a machine nobody has asked since.
+
+    ywata-note-win state db:    holder=scitex-compute-04  fence 1
+    scitex-compute-04 state db: holder=ywata-note-win     fence 1
+
+Both rows are true and neither is current. Reading either as "another host holds
+write authority" turns every SECOND move of every agent into a refusal.
+
+THE FIX IS EVIDENCE, NOT A FLAG. A live row naming another holder is not the
+split-brain by itself. The split-brain is another host RUNNING THIS AGENT — and
+that is a thing to go and LOOK at, with the same tmux probe the runtime uses,
+rather than something to infer from a row or to wave past with ``--force``. So
+the recorded holder's liveness is an INPUT here, three-valued like everything
+else in this feature, and "nobody looked" is an answer that refuses.
+
+This also settles where residency belongs, at least for now, and the answer is
+the honest one rather than the tidy one: the destination does NOT need to learn.
+Per-host postgres is the intended topology and the cross-host sync primitive does
+not exist yet, so a lease row means "what the last relocation I coordinated did",
+and it is only ever authoritative WHEN COMBINED with an observation of the host
+it names. Once a sync primitive exists the observation becomes a fast path rather
+than the proof; until then it is the proof, and it is a better one than a TTL —
+which is a guess about liveness — has ever been.
+
+Pure: a stored lease, a clock and an observation in, a verdict out.
+"""
+
+from __future__ import annotations
+
+from ._relocate_lease import (
+    CODE_HELD_BY_OTHER,
+    CODE_OK,
+    CODE_UNKNOWN,
+    Lease,
+    LeaseVerdict,
+    _no,
+    _ok,
+)
+
+__all__ = ["handoff_readiness"]
+
+
+def handoff_readiness(
+    lease: Lease | None,
+    *,
+    from_holder: str,
+    now: float,
+    recorded_holder_running: bool | None = None,
+) -> LeaseVerdict:
+    """Could :func:`.._relocate_lease.handoff` run right now, from ``from_holder``?
+
+    The branches, and what each one means for the move about to happen:
+
+        no row                          bootstrap. sac does not claim a lease
+                                        when an agent starts, so an agent that
+                                        has never relocated has no row at all.
+        the source already holds it     hand it over. The ordinary second move.
+        held by another, EXPIRED        re-claim for the source; the fence
+                                        advances and the old holder is locked
+                                        out by arithmetic rather than by
+                                        trusting anyone's clock.
+        held by another, RUNNING it     REFUSE. Two live loops under one
+                                        identity, now backed by an observation
+                                        instead of a row. A coordinator must not
+                                        settle that by out-voting another host.
+        held by another, NOT running    proceed, re-claiming as above. The row
+                                        records a past handover, not a present
+                                        writer.
+        held by another, unobserved     UNKNOWN. Go and look at that host.
+
+    ``recorded_holder_running`` defaults to ``None`` on purpose: a caller that
+    has not observed the other host has established nothing, and inheriting a
+    pass for a measurement it never took is the shape of every bug this feature
+    was written about. It is never consulted when the row names the source or
+    when the lease has expired — in both cases no third host needs observing,
+    and asking for one would make a fine relocation depend on an idle probe.
+
+    Reports READINESS only. It moves nothing, writes nothing, and takes no clock
+    of its own.
+    """
+    if not from_holder:
+        raise ValueError(
+            "handoff_readiness needs the source holder — 'may this host hand the "
+            "lease over' cannot be answered without naming the host"
+        )
+    if lease is None:
+        return LeaseVerdict(
+            allowed=True,
+            code=CODE_OK,
+            reason=(
+                f"no lease record exists; {from_holder!r}'s lease will be BOOTSTRAPPED "
+                "at fence 0 and handed over at fence 1 (sac does not claim a lease when "
+                "an agent starts)"
+            ),
+        )
+    if lease.holder == from_holder:
+        return _ok(
+            lease,
+            f"{lease.agent}: the source {from_holder!r} already holds the lease at fence "
+            f"{lease.fence}",
+        )
+    if lease.is_expired(now):
+        return _ok(
+            lease,
+            (
+                f"{lease.agent}: the lease is held by {lease.holder!r} but EXPIRED at "
+                f"{lease.expires_at}; it will be re-claimed for {from_holder!r} and the "
+                "fence will advance, locking the old holder out by arithmetic"
+            ),
+        )
+    if recorded_holder_running is None:
+        return LeaseVerdict(
+            allowed=None,
+            code=CODE_UNKNOWN,
+            reason=(
+                f"{lease.agent}: the lease is held by {lease.holder!r} at fence "
+                f"{lease.fence}, and whether {lease.holder!r} is RUNNING this agent was "
+                "not observed — a row naming another holder is a record of a past "
+                "handover until somebody looks at that host"
+            ),
+        )
+    if recorded_holder_running:
+        return _no(
+            CODE_HELD_BY_OTHER,
+            (
+                f"{lease.agent}: the lease is held by {lease.holder!r} at fence "
+                f"{lease.fence} AND {lease.holder!r} is running this agent — two live "
+                f"instances under one identity, not a stale row. {from_holder!r} may not "
+                "hand over what another live holder owns"
+            ),
+            lease,
+        )
+    return _ok(
+        lease,
+        (
+            f"{lease.agent}: the lease row names {lease.holder!r} at fence {lease.fence}, "
+            f"but {lease.holder!r} was OBSERVED not running this agent — the row records "
+            f"a past handover, not a present writer. It will be re-claimed for "
+            f"{from_holder!r} and the fence will advance"
+        ),
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_preflight.py
@@ -2,9 +2,10 @@
 
 This module is the entry point and nothing else: it runs every check against the
 observations it is given and returns the full report. The observable SHAPES live
-in :mod:`_relocate_preflight_facts` and the eleven predicates in
-:mod:`_relocate_checks`; both are re-exported here, so a caller keeps importing
-``TargetFacts`` / ``Check`` / ``CHECK_*`` from this one place.
+in :mod:`_relocate_preflight_facts`, the predicates learned from doing the move
+BY HAND in :mod:`_relocate_checks`, and the two learned from watching it RUN in
+:mod:`_relocate_checks_late`; all three are re-exported here, so a caller keeps
+importing ``TargetFacts`` / ``Check`` / ``CHECK_*`` from this one place.
 
 WHY EVERY CHECK, NOT THE FIRST FAILURE. The operator asked for a dry run, and a
 dry run that stops at the first problem makes him run it N times to find N
@@ -18,20 +19,34 @@ reader can tell "this is wrong" from "I could not tell". An unknown folded into
 pass is precisely how the 08-07 move reported healthy: the credential check had
 no answer, and something treated that as fine.
 
-TEN CHECKS ARE ABOUT THE TARGET AND TWO ARE ABOUT THE SOURCE. The odd ones out
-are ``source_work_committed`` — whether the machine being LEFT still holds
-uncommitted or unpushed work, because a relocation carries the spec and the
+ELEVEN CHECKS ARE ABOUT THE TARGET, TWO ABOUT THE SOURCE, ONE ABOUT NEITHER. The
+source pair is ``source_work_committed`` — whether the machine being LEFT still
+holds uncommitted or unpushed work, because a relocation carries the spec and the
 transcript and nothing else — and ``session_resolvable``, whether the
 conversation to resume can be NAMED. Their facts come in separately
 (:class:`SourceFacts`), gathered locally rather than over ssh, so a target probe
-can never accidentally fill a field about the source.
+can never accidentally fill a field about the source. The odd one out is
+``lease_holdable``, whose facts are read from the coordinator's own state db and
+from whichever host the stored row happens to name (:class:`LeaseFacts`).
 
-``session_resolvable`` IS HERE RATHER THAN IN THE PHASES FOR ONE REASON: the
-phase that needs the answer (TARGET_STANDBY) runs after the agent has been
-stopped. Measured 2026-08-12, ten agents on ywata-note-win passed all eleven
-checks and could not complete, every one of them holding more than one
-transcript. A gate that passes on an agent that cannot proceed is the bug, not
-merely a missing convenience.
+THREE CHECKS ARE HERE BECAUSE THE PHASE THAT NEEDS THEM RUNS TOO LATE, and they
+are one story told three times:
+
+    session_resolvable    TARGET_STANDBY refuses without a session id, and it
+                          runs after SOURCE_STOP. Measured 2026-08-12: ten
+                          agents on ywata-note-win passed every check and not
+                          one of them could complete.
+    target_start_accepts  the target's own ``sac agents start`` refuses a spec
+                          source that is BEHIND, and TARGET_STANDBY is what
+                          calls it — again after SOURCE_STOP. Measured
+                          2026-08-11; it cost the canary its first leg.
+    lease_holdable        HANDOVER refuses a lease held by another host, and it
+                          runs after SOURCE_STOP, TRANSPORT, TARGET_STANDBY and
+                          HANDSHAKE. Measured 2026-08-11 on the return leg: exit
+                          5, with the agent stopped and nothing running anywhere.
+
+A gate that passes on an agent that cannot proceed is the bug, not merely a
+missing convenience.
 """
 
 from __future__ import annotations
@@ -45,7 +60,6 @@ from ._relocate_checks import (
     CHECK_PORTS,
     CHECK_REACHABLE,
     CHECK_RUNTIME,
-    CHECK_SAC_PRESENT,
     CHECK_SCHEMA,
     CHECK_SESSION,
     CHECK_SOURCE_WORK,
@@ -57,12 +71,25 @@ from ._relocate_checks import (
     check_ports,
     check_reachable,
     check_runtime,
-    check_sac_present,
     check_schema,
     check_session_resolvable,
     check_source_work,
 )
-from ._relocate_preflight_facts import Check, PreflightReport, SourceFacts, TargetFacts
+from ._relocate_checks_late import (
+    CHECK_LEASE,
+    CHECK_TARGET_START,
+    check_lease_holdable,
+    check_target_start,
+)
+from ._relocate_checks_sac import CHECK_SAC_PRESENT, check_sac_present
+from ._relocate_preflight_facts import (
+    Check,
+    LeaseFacts,
+    PreflightReport,
+    SourceFacts,
+    SpecSourceDrift,
+    TargetFacts,
+)
 
 __all__ = [
     "CHECK_BINDS",
@@ -70,6 +97,7 @@ __all__ = [
     "CHECK_CREDENTIALS",
     "CHECK_HUB_FROM_TARGET",
     "CHECK_IMAGE",
+    "CHECK_LEASE",
     "CHECK_PORTS",
     "CHECK_REACHABLE",
     "CHECK_RUNTIME",
@@ -77,9 +105,12 @@ __all__ = [
     "CHECK_SCHEMA",
     "CHECK_SESSION",
     "CHECK_SOURCE_WORK",
+    "CHECK_TARGET_START",
     "Check",
+    "LeaseFacts",
     "PreflightReport",
     "SourceFacts",
+    "SpecSourceDrift",
     "TargetFacts",
     "preflight",
 ]
@@ -94,17 +125,19 @@ def preflight(
     required_ports: tuple[int, ...] = (),
     source_facts: SourceFacts | None = None,
     from_host: str = "",
+    lease_facts: LeaseFacts | None = None,
 ) -> PreflightReport:
     """Evaluate every check against observed facts. Touches nothing.
 
     Returns the full report rather than the first failure, so one run surfaces
     every problem.
 
-    ``source_facts`` defaults to nothing observed, which reports the source-work
-    check as UNKNOWN and therefore refuses. That default is deliberate: a caller
-    that has not looked at the source has not established the move is safe, and
-    inheriting a pass for a check it never ran is the shape of every bug this
-    module was written about.
+    ``source_facts`` and ``lease_facts`` both default to nothing observed, which
+    reports their checks as UNKNOWN and therefore refuses. That default is
+    deliberate: a caller that has not looked has not established the move is
+    safe, and inheriting a pass for a check it never ran is the shape of every
+    bug this module was written about. It is also why adding a check here can
+    only ever make a previously-passing run refuse — never the reverse.
     """
     checks = (
         check_reachable(facts, to_host),
@@ -117,7 +150,9 @@ def preflight(
         check_ports(facts, required_ports),
         check_hub_from_target(facts, to_host),
         check_sac_present(facts, to_host),
+        check_target_start(facts, to_host, agent),
         check_source_work(source_facts or SourceFacts(), from_host),
         check_session_resolvable(source_facts or SourceFacts(), agent),
+        check_lease_holdable(lease_facts or LeaseFacts(), from_host, agent),
     )
     return PreflightReport(agent=agent, to_host=to_host, checks=checks)

--- a/src/scitex_agent_container/_lifecycle/_relocate_preflight_facts.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_preflight_facts.py
@@ -23,8 +23,10 @@ from ._relocate_origin import RepoWork
 
 __all__ = [
     "Check",
+    "LeaseFacts",
     "PreflightReport",
     "SourceFacts",
+    "SpecSourceDrift",
     "TargetFacts",
 ]
 
@@ -54,6 +56,76 @@ class Check:
             raise ValueError(
                 f"Check {self.name!r}: a non-passing check must carry a hint saying what to do about it"
             )
+
+
+@dataclass(frozen=True)
+class SpecSourceDrift:
+    """The target's answer to "would MY OWN ``sac agents start`` accept this agent".
+
+    Not a re-implementation of the guard — the STATE here is what the target's
+    own :func:`.._drift._local.check_spec_source_drift` returned when asked on
+    that machine, because the code that will refuse the boot is the only thing
+    entitled to say whether it would. ``state`` carries a
+    :class:`.._drift._status.DriftState` VALUE (``"behind"``, ``"current"``, …)
+    rather than the enum, so the shape survives the ssh round trip as text and
+    an unfamiliar word from an older sac stays readable instead of raising.
+
+    ``dirty`` is evidence, NOT part of the verdict: the guard counts commits and
+    nothing else, so a dirty tree never refuses a start. It is carried because
+    the remedy the guard prints is ``git pull --ff-only``, and on the host this
+    was measured on that command aborts — 2389 modified files in the dotfiles
+    checkout on scitex-compute-04. A hint naming a command that will not run is
+    the same defect as a hint naming a setting that does nothing.
+    """
+
+    state: str
+    behind: int = 0
+    ahead: int = 0
+    repo: str = ""
+    upstream: str = ""
+    #: Files ``git status --porcelain`` reports in the spec-source repo, or
+    #: ``None`` when the count was not taken.
+    dirty: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.state:
+            raise ValueError(
+                "SpecSourceDrift.state must be non-empty — a drift answer with no "
+                "verdict is not one the start command could have given"
+            )
+
+
+@dataclass(frozen=True)
+class LeaseFacts:
+    """What the coordinator read out of the LEASE STORE, and about the row's holder.
+
+    A separate type from :class:`TargetFacts` and :class:`SourceFacts` because it
+    is neither: the lease is read from the coordinator's own state db, and the
+    liveness observation it carries is taken on whichever host that row happens
+    to name — a third machine, in the general case.
+
+    ``read`` IS THE OBSERVED FLAG AND ``lease`` IS THE ANSWER. They are separate
+    fields because ``lease=None`` is a real and common answer ("this store has
+    never held a row for this agent", which bootstraps) and it must not be
+    confused with "nobody opened the store", which refuses. One nullable field
+    cannot carry both without one of them silently becoming the other.
+    """
+
+    read: bool = False
+    #: The stored :class:`.._relocate_lease.Lease`, or ``None`` for no row.
+    lease: object | None = None
+    #: Whether the agent is running ON THE HOST THE ROW NAMES. ``None`` means
+    #: nobody looked — which is the honest answer whenever the row names the
+    #: source itself, because then no third host needs observing at all.
+    recorded_holder_running: bool | None = None
+    #: What that observation actually saw, for the report to quote.
+    recorded_holder_evidence: str = ""
+    #: WHICH store was read. A lease answer is worth exactly as much as the db it
+    #: came from, and this fleet has one db per host with no sync between them.
+    store: str = ""
+    #: The moment the store was read. Required to judge expiry; ``None`` means no
+    #: clock was supplied and the expiry question therefore has no answer.
+    now: float | None = None
 
 
 @dataclass(frozen=True)
@@ -88,6 +160,27 @@ class TargetFacts:
     #: distinction is the whole check: not-on-PATH plus found-at-a-path is a
     #: PATH problem, not-on-PATH plus found-nowhere is a missing install.
     sac_resolved_path: str | None = None
+    #: Where ``command -v sac`` resolves under THE PATH THIS RELOCATION'S OWN
+    #: COMMANDS RUN UNDER — the raw ssh PATH plus the peer's ``env_preamble``,
+    #: which :class:`.._relocate_shell.Shell` prepends to every script it sends.
+    #: ``""`` means looked-and-found-nothing; ``None`` means nobody looked.
+    #:
+    #: This is the fact the check should have been reading all along.
+    #: ``sac_on_path`` deliberately measures the BARE ssh PATH, which is a
+    #: stricter question than the relocation needs to answer, so a host whose
+    #: preamble already puts sac on PATH failed a check about a PATH nothing
+    #: here uses.
+    sac_usable_path: str | None = None
+    #: Whether an ``env_preamble`` was declared for this peer AND applied to the
+    #: probe. Observed by construction rather than measured on the target: the
+    #: prober knows what it sent. It qualifies the two facts above — "sac is not
+    #: reachable" means something different when a preamble is already in play —
+    #: and it is what keeps the failure hint from recommending a setting that is
+    #: already set.
+    preamble_declared: bool | None = None
+    #: What the TARGET'S OWN sac says about the spec source it would launch from.
+    #: ``None`` means it was not asked or could not answer.
+    spec_source_drift: SpecSourceDrift | None = None
 
 
 @dataclass(frozen=True)

--- a/src/scitex_agent_container/_lifecycle/_relocate_probe.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe.py
@@ -35,9 +35,30 @@ from typing import Callable, TypeVar
 
 from ._relocate_preflight import TargetFacts
 
-__all__ = ["ProbeOutcome", "TargetProbes", "gather_target_facts", "probe"]
+__all__ = [
+    "FactUnavailable",
+    "ProbeOutcome",
+    "TargetProbes",
+    "gather_target_facts",
+    "probe",
+]
 
 T = TypeVar("T")
+
+
+class FactUnavailable(RuntimeError):
+    """This fact was not observed, and here is the sentence explaining why.
+
+    Raised by an adapter's accessor — never returned as a falsy value.
+    :func:`probe` catches it, records the message, and leaves the fact ``None``.
+
+    IT LIVES IN THE PORT, not in one adapter, because it is the CONTRACT between
+    them: an accessor's only two legal moves are "return what the host said" and
+    "raise this, saying why not". A second adapter defining its own would be a
+    second contract, and the one rule this module exists to enforce — a failed
+    probe becomes UNKNOWN, never a falsy answer — would then hold only for
+    whichever adapter someone remembered to check.
+    """
 
 
 @dataclass(frozen=True)
@@ -91,6 +112,9 @@ class TargetProbes:
     hub_reachable_from_target: Callable[[], bool] | None = None
     sac_on_path: Callable[[], bool] | None = None
     sac_resolved_path: Callable[[], str] | None = None
+    sac_usable_path: Callable[[], str] | None = None
+    preamble_declared: Callable[[], bool] | None = None
+    spec_source_drift: Callable[[], object] | None = None
 
 
 @dataclass(frozen=True)
@@ -124,6 +148,9 @@ _FIELDS: tuple[str, ...] = (
     "hub_reachable_from_target",
     "sac_on_path",
     "sac_resolved_path",
+    "sac_usable_path",
+    "preamble_declared",
+    "spec_source_drift",
 )
 
 

--- a/src/scitex_agent_container/_lifecycle/_relocate_probe_adapter.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe_adapter.py
@@ -1,14 +1,16 @@
-"""The thirteen callables :class:`.._relocate_probe.TargetProbes` asks for.
+"""The sixteen callables :class:`.._relocate_probe.TargetProbes` asks for.
 
 :mod:`_relocate_probe` is the PORT — pure orchestration that turns any raising
 callable into ``None``. This is the ADAPTER: it reads the agent's spec, asks the
 target once (:mod:`_relocate_probe_ssh` + :mod:`_relocate_probe_script`), and
-hands back thirteen closures over that single answer.
+hands back sixteen closures over that single answer. Five of them — everything
+about sac ITSELF on that host — live in :mod:`_relocate_probe_sac` and arrive
+here as a mixin over the same memoized round trip.
 
 HOW PER-FACT DEGRADATION SURVIVES BATCHING — the design point of this file.
-One remote call answers all thirteen questions, which is the only way this is fast
+One remote call answers all sixteen questions, which is the only way this is fast
 enough to be run casually. The obvious way to do that is also the dangerous one:
-one blob, one status, thirteen facts that stand or fall together. Three rules keep
+one blob, one status, sixteen facts that stand or fall together. Three rules keep
 them independent, and they compose:
 
     the SCRIPT   prints each answer on its own marker line the moment it is
@@ -24,9 +26,9 @@ them independent, and they compose:
                  "credentials_valid: UNKNOWN (no credential file exists on the
                  target among: …)" rather than a bare UNKNOWN.
 
-So a run that answers ten of thirteen yields ten OBSERVED facts and three
-unknowns, each naming its own cause. A transport failure yields thirteen unknowns
-sharing one cause. Neither yields a single ``False``.
+So a run that answers thirteen of sixteen yields thirteen OBSERVED facts and
+three unknowns, each naming its own cause. A transport failure yields sixteen
+unknowns sharing one cause. Neither yields a single ``False``.
 
 NEVER ``False`` FOR "I COULD NOT TELL". Every accessor below either returns
 something the target actually said or raises. There is no ``except: return
@@ -34,12 +36,12 @@ False`` here, and there must never be: it would turn "no route to the host" into
 "the host has no image", and the relocation would then proceed on fiction — the
 exact 2026-08-07 failure this command exists to prevent.
 
-WHAT IS MEASURED VS WHAT IS READ. Twelve facts are measured on the target. One —
-``card_store_url`` — is READ FROM THE SPEC: it is the URL the agent WOULD dial
-after the move, and preflight uses it only to name the endpoint in a failure
-message. It is supplied because a failure that says "card store not reachable"
-without saying WHICH is an error message that starts an investigation instead of
-ending one.
+WHAT IS MEASURED VS WHAT IS READ. Fourteen facts are measured on the target. Two
+are not, and each says so: ``card_store_url`` is READ FROM THE SPEC — the URL the
+agent WOULD dial after the move, supplied only so a "card store not reachable"
+failure can name WHICH store rather than starting an investigation — and
+``preamble_declared`` is OBSERVED BY CONSTRUCTION, because what this prober
+prepended to its own script is not something the target has to be asked.
 """
 
 from __future__ import annotations
@@ -48,7 +50,8 @@ import os
 from typing import Callable
 from urllib.parse import urlparse
 
-from ._relocate_probe import TargetProbes
+from ._relocate_probe import FactUnavailable, TargetProbes
+from ._relocate_probe_sac import SacFacts
 from ._relocate_probe_script import (
     REMOTE_DEFAULT_CREDENTIAL,
     RemoteQuestions,
@@ -77,14 +80,6 @@ __all__ = [
 HUB_ADDR_ENV = "SAC_RELOCATE_HUB_ADDR"
 
 _LOOPBACK = frozenset({"127.0.0.1", "localhost", "::1", "0.0.0.0", ""})
-
-
-class FactUnavailable(RuntimeError):
-    """This fact was not observed, and here is the sentence explaining why.
-
-    Raised — never returned as a falsy value. :func:`.._relocate_probe.probe`
-    catches it, records the message, and leaves the fact ``None``.
-    """
 
 
 def _body(spec: dict) -> dict:
@@ -221,8 +216,14 @@ def questions_from_spec(
     )
 
 
-class TargetBatch:
-    """One ssh round trip, memoized, read thirteen different ways.
+class TargetBatch(SacFacts):
+    """One ssh round trip, memoized, read sixteen different ways.
+
+    The five facts about sac ITSELF — the three PATH lookups, whether a peer
+    preamble was in play, and whether the target's own start command would
+    accept this agent — arrive as :class:`._relocate_probe_sac.SacFacts`, so a
+    reader looking for "what did we learn about sac over there" finds a file
+    about that rather than five methods among the credentials and the ports.
 
     The run happens on first access and NOT in ``__init__``: a caller that
     builds probes but never gathers must not open a connection. The outcome —
@@ -437,25 +438,6 @@ class TargetBatch:
             raise FactUnavailable(self._hub_reason or "the hub address is unknown")
         return self._yes_no("hub", "hub")
 
-    def sac_on_path(self) -> bool:
-        """Whether ``command -v sac`` answers under the RAW ssh PATH.
-
-        An empty value is the ANSWER (nothing on PATH), not a missing one — the
-        script prints the line either way. Only a line that never arrived is
-        unknown, which :meth:`_field` raises for.
-        """
-        return bool(self._field("sac_path", "sac-on-PATH").strip())
-
-    def sac_resolved_path(self) -> str:
-        """Where sac actually is, or ``""`` for looked-and-found-nothing.
-
-        The empty string is load-bearing and must NOT be turned into a raise:
-        it is what separates "sac is not installed on this host" from "sac is
-        installed and the ssh PATH cannot see it", and those need opposite
-        fixes. Only an absent line is undetermined.
-        """
-        return self._field("sac_found", "sac-location").strip()
-
 
 def build_target_probes(
     to_host: str,
@@ -467,7 +449,7 @@ def build_target_probes(
     timeout_s: float = DEFAULT_TIMEOUT_S,
     env: dict[str, str] | None = None,
 ) -> tuple[TargetProbes, TargetBatch]:
-    """Bind the thirteen accessors of one :class:`TargetBatch` into a probe set.
+    """Bind the sixteen accessors of one :class:`TargetBatch` into a probe set.
 
     Returns the probes and the batch, so a caller that wants the raw readout
     (for diagnostics) does not have to run the probe twice.
@@ -496,5 +478,8 @@ def build_target_probes(
         hub_reachable_from_target=batch.hub_reachable_from_target,
         sac_on_path=batch.sac_on_path,
         sac_resolved_path=batch.sac_resolved_path,
+        sac_usable_path=batch.sac_usable_path,
+        preamble_declared=batch.preamble_declared,
+        spec_source_drift=batch.spec_source_drift,
     )
     return probes, batch

--- a/src/scitex_agent_container/_lifecycle/_relocate_probe_sac.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe_sac.py
@@ -1,0 +1,121 @@
+"""The five facts about sac ITSELF on the target: can it be reached, and would it start this agent.
+
+Split out of :mod:`_relocate_probe_adapter`, which owns the other eight, for the
+reason its own siblings were split: a reader asking "what did we learn about sac
+over there" should find a file about sac rather than five methods in the middle
+of a class about credentials and ports. They belong together because they answer
+ONE question in stages — is sac installed, can the PATH we use see it, and does
+its own start command have any objection to this agent — and because four of the
+five were added or changed by the same 2026-08-12 finding.
+
+WHY THREE PATH QUESTIONS AND NOT ONE. They are not redundancies, they are the
+three different PATHs a person or a program can mean, and the fleet has hosts
+where they disagree:
+
+    sac_path      ``command -v sac`` under the BARE non-interactive ssh PATH.
+                  What an operator typing ``ssh host sac …`` gets, and what
+                  scitex-compute-04 answers "No such file or directory" to.
+    sac_usable    the same lookup under the PATH THIS SCRIPT RAN WITH — raw plus
+                  the peer's ``env_preamble``, which is what
+                  :class:`._relocate_shell.Shell` prepends to every command a
+                  relocation sends. THE ONE THE CHECK NEEDS.
+    sac_found     found by looking harder: the login shell, then the venvs sac
+                  is installed into across this fleet. Separates "not installed"
+                  from "installed and unreachable", which need opposite fixes.
+
+Reading only the first is what failed ywata-note-win, which declares a working
+``env_preamble`` and was still told to declare one.
+
+THE START-ACCEPTANCE FACT IS THE TARGET'S OWN VERDICT, QUOTED. sac's spec-source
+drift guard refuses a boot from a repo that is BEHIND its upstream; that guard is
+the thing that will refuse, so it is asked, and its answer is parsed rather than
+recomputed. An older sac that cannot answer leaves the line absent, which is
+UNKNOWN — never "no drift".
+
+A mixin over :class:`._relocate_probe_adapter.TargetBatch`, so all five read the
+SAME memoized round trip. It expects that class's ``_field`` / ``readout`` /
+``_preamble``.
+"""
+
+from __future__ import annotations
+
+from ._relocate_probe import FactUnavailable
+
+__all__ = ["SacFacts"]
+
+
+class SacFacts:
+    """Mixin: the sac-on-the-target facts. Expects ``TargetBatch``'s attributes."""
+
+    def sac_on_path(self) -> bool:
+        """Whether ``command -v sac`` answers under the RAW ssh PATH.
+
+        An empty value is the ANSWER (nothing on PATH), not a missing one — the
+        script prints the line either way. Only a line that never arrived is
+        unknown, which ``_field`` raises for.
+        """
+        return bool(self._field("sac_path", "sac-on-PATH").strip())
+
+    def sac_resolved_path(self) -> str:
+        """Where sac actually is, or ``""`` for looked-and-found-nothing.
+
+        The empty string is load-bearing and must NOT be turned into a raise:
+        it is what separates "sac is not installed on this host" from "sac is
+        installed and the ssh PATH cannot see it", and those need opposite
+        fixes. Only an absent line is undetermined.
+        """
+        return self._field("sac_found", "sac-location").strip()
+
+    def sac_usable_path(self) -> str:
+        """Where sac resolves under the PATH THE PROBE ITSELF RAN WITH.
+
+        That PATH is the raw ssh one plus the peer's ``env_preamble`` — exactly
+        what every relocation command runs under — so this answers the question
+        the feature depends on, where :meth:`sac_on_path` answers a stricter one.
+        Empty is the ANSWER, not a missing one; only an absent line is unknown.
+        """
+        return self._field("sac_usable", "sac-under-relocation-PATH").strip()
+
+    def preamble_declared(self) -> bool:
+        """Whether a peer ``env_preamble`` was declared AND sent with this probe.
+
+        Observed by construction rather than measured on the target: the prober
+        knows what it prepended. It qualifies the three PATH facts, and it is
+        what stops the failure hint recommending a setting that is already set
+        (:func:`._relocate_checks._sac_path_hint`).
+        """
+        return bool(self._preamble.strip())
+
+    def spec_source_drift(self):
+        """What the TARGET'S OWN sac says about the spec source it would boot from.
+
+        Parsed from ``<state>|<behind>|<ahead>|<repo>|<upstream>``, printed by
+        the target's own :func:`.._drift._local.check_spec_source_drift`. A
+        missing line means its sac could not answer — an older one without the
+        symbol, or a section that timed out — and that is UNKNOWN, not "no
+        drift". The dirty count rides along on its own line and is optional:
+        it is evidence for the hint, never part of the verdict, so a target
+        without git still yields a usable drift answer.
+        """
+        from ._relocate_preflight_facts import SpecSourceDrift
+
+        parts = self._field("startdrift", "start-acceptance").split("|")
+        if not parts[0].strip():
+            raise FactUnavailable(
+                "the target's start-acceptance probe answered with no drift state; "
+                "its sac ran and could not name a verdict"
+            )
+
+        def _count(index: int) -> int:
+            raw = parts[index].strip() if len(parts) > index else ""
+            return int(raw) if raw.isdigit() else 0
+
+        dirty = (self.readout().fields.get("startdirty") or "").strip()
+        return SpecSourceDrift(
+            state=parts[0].strip(),
+            behind=_count(1),
+            ahead=_count(2),
+            repo=parts[3].strip() if len(parts) > 3 else "",
+            upstream=parts[4].strip() if len(parts) > 4 else "",
+            dirty=int(dirty) if dirty.isdigit() else None,
+        )

--- a/src/scitex_agent_container/_lifecycle/_relocate_probe_script.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe_script.py
@@ -241,6 +241,7 @@ def render_probe_script(questions: RemoteQuestions, *, preamble: str = "") -> st
 
     parts.append(_SAC_WHERE_SECTION)
     parts.append(_SAC_SECTION)
+    parts.append(_START_ACCEPT_SECTION)
     parts.append('echo "$M end"')
     return "\n".join(parts) + "\n"
 
@@ -304,10 +305,15 @@ sacreloc_cred() {{
 """
 
 
-# WHERE sac IS, asked twice on purpose. `sac_path` is `command -v sac` under the
-# RAW non-interactive PATH — the one a bare `ssh host sac …` gets. `sac_found`
-# looks harder: the login shell first (which is where a venv PATH comes from),
-# then the locations sac is actually installed in across this fleet.
+# WHERE sac IS, asked three times on purpose. `sac_path` is `command -v sac`
+# under the RAW non-interactive PATH — the one a bare `ssh host sac …` gets.
+# `sac_usable` is the same lookup under the PATH THIS SCRIPT IS RUNNING WITH,
+# i.e. after the peer's env_preamble, which is the PATH every command a
+# relocation sends actually runs under; that is the question the check needs
+# answered, and reading only the raw one failed hosts whose preamble already
+# works (ywata-note-win, measured 2026-08-12). `sac_found` looks harder still:
+# the login shell first (which is where a venv PATH comes from), then the
+# locations sac is actually installed in across this fleet.
 #
 # Measured 2026-08-11 on scitex-compute-04: sac_path is empty and sac_found is
 # /home/ywatanabe/.env-sac/bin/sac. Those two lines together say "installed, not
@@ -333,6 +339,7 @@ sacreloc_find_sac() {
 sacreloc_raw=$(PATH="$SACRELOC_PATH0" command -v sac 2>/dev/null)
 echo "$M sac_path=$sacreloc_raw"
 echo "$M sac_found=$(sacreloc_find_sac)"
+echo "$M sac_usable=$(command -v sac 2>/dev/null)"
 """
 
 
@@ -365,6 +372,50 @@ if command -v "$py" >/dev/null 2>&1; then
   if [ -n "$rt" ]; then echo "$M runtimes=$rt"; fi
   sk=$("$py" -c "$SACRELOC_KEYS_PY" 2>/dev/null)
   if [ -n "$sk" ]; then echo "$M speckeys=$sk"; fi
+fi
+"""
+
+
+# WOULD THE TARGET'S OWN `sac agents start` ACCEPT THIS AGENT? Asked of the
+# target's sac rather than answered here: the drift guard IS the code that
+# refuses the boot, and a second copy of its rule would pass on exactly the day
+# the real one changed. Reuses `$py` from _SAC_SECTION — the interpreter BACKING
+# the target's `sac`, not whatever python3 is first on PATH.
+#
+# BOUNDED, because this one does network I/O: the guard runs a `git fetch` and
+# the batch it lives in has ONE wall-clock budget for every fact, so a section
+# that hung would cost all the others their answers. `timeout` where one exists.
+#
+# The dirty count is EVIDENCE, NOT VERDICT: the guard counts commits and refuses
+# on those alone. It is taken because the remedy the guard prints is `git pull
+# --ff-only`, which aborts on a dirty tree — 25 modified files in the dotfiles
+# checkout backing ywata-note-win's agents dir, measured 2026-08-12.
+_START_ACCEPT_SECTION = """
+SACRELOC_DRIFT_PY=$(cat <<'SACRELOCPY'
+import os
+from scitex_agent_container._drift import check_spec_source_drift
+root = os.environ.get("SCITEX_DIR") or os.path.expanduser("~/.scitex")
+s = check_spec_source_drift(os.path.join(root, "agent-container", "agents"))
+print("%s|%d|%d|%s|%s" % (s.state.value, s.behind, s.ahead, s.repo, s.upstream))
+SACRELOCPY
+)
+sacreloc_bounded() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 25 "$@"
+  else
+    "$@"
+  fi
+}
+if command -v "$py" >/dev/null 2>&1; then
+  dr=$(sacreloc_bounded "$py" -c "$SACRELOC_DRIFT_PY" 2>/dev/null | tail -1)
+  if [ -n "$dr" ]; then
+    echo "$M startdrift=$dr"
+    dr_repo=$(printf '%s' "$dr" | cut -d'|' -f4)
+    if [ -n "$dr_repo" ] && command -v git >/dev/null 2>&1; then
+      dr_n=$(sacreloc_bounded git -C "$dr_repo" status --porcelain 2>/dev/null | wc -l)
+      echo "$M startdirty=$(printf '%s' "$dr_n" | tr -d ' ')"
+    fi
+  fi
 fi
 """
 

--- a/src/scitex_agent_container/_lifecycle/_relocate_render.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_render.py
@@ -32,14 +32,46 @@ from __future__ import annotations
 from ._relocate_preflight import PreflightReport
 
 __all__ = [
+    "COORDINATOR_ENV",
     "VERDICT_GO",
     "VERDICT_REFUSED",
     "VERDICT_UNKNOWN",
+    "render_coordinator_env",
     "render_declared",
     "render_dry_run",
     "render_observed",
     "verdict_line",
 ]
+
+#: What the COORDINATOR needs in its own environment, and what each one costs
+#: when it is missing. Named here rather than left to be discovered because the
+#: cost is not a partial report — it is nine of twelve checks coming back UNKNOWN
+#: at once, and an UNKNOWN refuses exactly as hard as a FAIL. Measured
+#: 2026-08-12: that output reads as a broken relocation, and the fault is a
+#: container that was started without four variables.
+COORDINATOR_ENV: tuple[tuple[str, str], ...] = (
+    (
+        "SAC_LISTEN_BASE_URL",
+        "the listen daemon this container asks to run ssh for it. Without it NO "
+        "target fact can be measured at all — every probe shares one transport",
+    ),
+    (
+        "SAC_LISTEN_BEARER",
+        "authenticates that request. Without it the daemon answers 403 and the "
+        "probe reports a transport failure rather than anything about the target",
+    ),
+    (
+        "SAC_NAME",
+        "the caller identity the daemon's ACL gate keys off; an unresolvable "
+        "caller is refused the same way a forbidden one is",
+    ),
+    (
+        "SAC_RELOCATE_HUB_ADDR",
+        "the hub as host:port AS THE TARGET WOULD REACH IT. Only this one check "
+        "depends on it — a loopback hub address is refused deliberately, because "
+        "probing it from the target measures the TARGET's loopback",
+    ),
+)
 
 VERDICT_GO = "GO"
 VERDICT_REFUSED = "REFUSED"
@@ -66,11 +98,17 @@ _CHECK_FACTS: dict[str, tuple[str, ...]] = {
     "spec_schema_accepted": ("rejected_spec_keys",),
     "ports_free": ("ports_in_use",),
     "hub_reachable_from_target": ("hub_reachable_from_target",),
-    "sac_present_on_target": ("sac_on_path", "sac_resolved_path"),
-    # Gathered locally rather than over ssh, so its failures are keyed by the
-    # check's own name; the tuple is here so the map covers every check and a
-    # reader does not have to wonder whether the omission means something.
+    "sac_present_on_target": (
+        "sac_usable_path",
+        "sac_on_path",
+        "sac_resolved_path",
+    ),
+    "target_start_accepts": ("spec_source_drift",),
+    # Gathered locally rather than over ssh, so their failures are keyed by the
+    # check's own name; the tuples are here so the map covers every check and a
+    # reader does not have to wonder whether an omission means something.
     "source_work_committed": ("source_repos",),
+    "lease_holdable": ("lease",),
 }
 
 
@@ -140,6 +178,35 @@ def render_observed(
     return lines
 
 
+def render_coordinator_env(env: dict[str, str] | None = None) -> list[str]:
+    """Name the coordinator's own missing environment — but only when some is missing.
+
+    Returns ``[]`` when all of :data:`COORDINATOR_ENV` is set, because four lines
+    saying "fine" on every run is noise that trains a reader to skip the section
+    on the run where it matters.
+
+    THE VALUE IS NEVER PRINTED, only whether it is set. One of these is a bearer
+    token, and a dry run pasted into a chat window must not be a credential leak
+    — the same rule :mod:`_relocate_probe_script` follows for the refreshToken it
+    reports the presence of and never the content.
+    """
+    import os
+
+    env = os.environ if env is None else env
+    missing = [(k, why) for k, why in COORDINATOR_ENV if not (env.get(k) or "").strip()]
+    if not missing:
+        return []
+    lines = [
+        "COORDINATOR ENVIRONMENT — unset here, and each one costs measurements",
+        "  An unmeasured check REFUSES exactly as firmly as a failed one, so a "
+        "missing variable below reads as a broken target unless it is named.",
+    ]
+    for key, why in missing:
+        lines.append(f"  UNSET    {key}")
+        lines.append(f"           {why}")
+    return lines
+
+
 def verdict_line(report: PreflightReport) -> str:
     """One sentence a reader can act on, with the counts that justify it.
 
@@ -167,6 +234,7 @@ def render_dry_run(
     declared: dict[str, object] | None = None,
     errors: dict[str, str] | None = None,
     dry_run: bool = True,
+    env: dict[str, str] | None = None,
 ) -> list[str]:
     """The whole dry run, in the order a reader needs it.
 
@@ -193,6 +261,10 @@ def render_dry_run(
         "",
     ]
     lines += render_declared(declared or {})
+    coordinator = render_coordinator_env(env)
+    if coordinator:
+        lines.append("")
+        lines += coordinator
     lines.append("")
     lines += render_observed(report, errors)
     lines.append("")

--- a/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
@@ -124,7 +124,9 @@ _PHASE_READINESS: tuple[tuple[str, str, str], ...] = (
         "_relocate_effects_handover: the source's lease is bootstrapped when the store "
         "holds none (sac still does not claim one at agent start-up — the bootstrap is "
         "recorded as such), handed to the target, and the row is RE-READ to confirm "
-        "the holder and the fence",
+        "the holder and the fence. A row naming a THIRD host is settled by OBSERVING "
+        "that host, through the same predicate the lease_holdable check already ran "
+        "before anything was stopped",
         "—",
     ),
     (
@@ -280,23 +282,35 @@ def declared_from_spec(spec: dict) -> dict[str, object]:
 def _residency_history(name: str):
     """The agent's stays, read from the STATE DB — the only authority on host.
 
-    THERE IS NO RESIDENCY TABLE YET, and pretending otherwise would be the worse
-    of the two available lies. What exists is ``instances.host``, which
-    ``record_instance_start`` canonicalises and writes when a process starts —
-    an observation, and the right kind of one. So an active instance row becomes
-    a single OPEN stay and that is the whole history.
+    THE RESIDENCY TABLE WINS, AND IT EXISTS NOW: ``agent_residency``, written by
+    a relocation's DONE phase, an append-only history of stays with at most one
+    open. The instance row is the FALLBACK — ``instances.host`` is where a
+    process was last recorded STARTING, which nothing closes if it dies without a
+    stop.
 
-    The cost is stated rather than hidden: with one row there is no audit trail,
-    so ``host_at(history, t)`` can answer "where does it live now" and cannot
-    answer "which host wrote this row in March". Closing that needs a residency
-    table; until then this returns the shortest history that is TRUE rather than
-    a longer one that is invented.
+    Measured 2026-08-12 on scitex-compute-04: residency said
+    ``canary-resume-test`` lives on ywata-note-win (written by the move that took
+    it there) while an instance row on scitex-compute-04 had never ended. Reading
+    the instance row first made this command answer with the host the agent had
+    LEFT, so relocating back was refused with "already recorded on that host —
+    nothing to relocate". The phantom row won over reality.
 
-    No row yields ``()`` — genuinely "the db knows nothing", which is what lets
-    a legacy spec ``host:`` seed it once.
+    The order also fixes the STOPPED case, which is the NORMAL one:
+    ``source_drain`` requires the agent stopped, a stopped agent has no active
+    instance row, and the next fallback is the spec's legacy ``host:`` — which a
+    relocation never updates. The residency table is the only one of the three a
+    relocation keeps current.
+
+    No row anywhere yields ``()`` — genuinely "the db knows nothing", which is
+    what lets a legacy spec ``host:`` seed it once.
     """
     from .._lifecycle._residency import Residency
     from .._state.state_db_instances import list_active_instances
+    from .._state.state_db_relocation import read_residency_history
+
+    stays = read_residency_history(name)
+    if stays:
+        return stays
 
     rows = [r for r in list_active_instances() if r.get("name") == name]
     if not rows:
@@ -432,6 +446,12 @@ def relocate(name: str, to_host: str, dry_run: bool) -> None:
         to_host, spec, required_ports=_required_ports(declared)
     )
     gathered = gather_target_facts(probes)
+    # THE LEASE IS READ HERE, not at the handover — which is the last phase
+    # before DONE and therefore runs with the agent already stopped, its
+    # transcript already carried and the target already booted. Measured
+    # 2026-08-11: exit 5 at that phase, correctly, with nothing running anywhere.
+    from .._lifecycle._relocate_lease_facts import gather_lease_facts
+
     report = preflight(
         agent=name,
         to_host=to_host,
@@ -442,6 +462,7 @@ def relocate(name: str, to_host: str, dry_run: bool) -> None:
             spec, body if isinstance(body, dict) else {}, name, where.host or ""
         ),
         from_host=where.host or "",
+        lease_facts=gather_lease_facts(name, from_host=where.host or ""),
     )
 
     for line in render_dry_run(

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_checks_late.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_checks_late.py
@@ -1,0 +1,367 @@
+"""Both of these refused correctly on the canary, and both refused after the agent was down.
+
+Two checks, one property: the phase that needs the answer runs late, so the
+question is asked here instead.
+
+    lease_holdable        HANDOVER is the last phase before DONE. Measured
+                          2026-08-11 on the canary's return leg: exit 5 there,
+                          after source_stop, after the transport was verified,
+                          after the standby booted and after the handshake
+                          passed. Nothing was running on either host.
+    target_start_accepts  TARGET_STANDBY calls the target's own ``sac agents
+                          start``, which refused with ``sac-drift: spec source
+                          is 1 commit(s) BEHIND``. Preflight had eleven checks
+                          about that host and none of them had asked its start
+                          command anything.
+
+The tests are written against those exact states. A check nobody has seen fail on
+the input that produced it is a check nobody knows would have caught it.
+
+Pure predicates over observed facts. No I/O, no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_checks_late import (
+    CHECK_LEASE,
+    CHECK_TARGET_START,
+    check_lease_holdable,
+    check_target_start,
+)
+from scitex_agent_container._lifecycle._relocate_lease import Lease
+from scitex_agent_container._lifecycle._relocate_preflight_facts import (
+    LeaseFacts,
+    SpecSourceDrift,
+    TargetFacts,
+)
+
+AGENT = "canary-resume-test"
+A = "scitex-compute-04"
+B = "ywata-note-win"
+NOW = 1_786_500_000.0
+TTL = 86_400.0
+
+
+def _row(holder: str, *, expires_at: float = NOW + TTL) -> Lease:
+    return Lease(
+        agent=AGENT, holder=holder, token="tok", expires_at=expires_at, fence=1
+    )
+
+
+@pytest.fixture
+def canary_return_leg() -> LeaseFacts:
+    """What the coordinator on ywata-note-win read out of its OWN db, unobserved.
+
+    The row was written 2026-08-11 13:20 UTC by an earlier move. It says
+    ``holder=scitex-compute-04`` and it says nothing whatever about today.
+    """
+    return LeaseFacts(read=True, lease=_row(A), store="/…/runtime/state.db", now=NOW)
+
+
+# ---------------------------------------------------------------------------
+# lease_holdable
+# ---------------------------------------------------------------------------
+
+
+def test_a_store_nobody_opened_is_unknown() -> None:
+    # Arrange: the default — a caller that has not looked has established nothing.
+    facts = LeaseFacts()
+    # Act
+    check = check_lease_holdable(facts, B, AGENT)
+    # Assert
+    assert check.ok is None
+
+
+def test_an_unread_store_names_the_table_to_read() -> None:
+    # Arrange
+    facts = LeaseFacts()
+    # Act
+    check = check_lease_holdable(facts, B, AGENT)
+    # Assert
+    assert "relocation_leases" in check.hint
+
+
+def test_a_read_store_with_no_row_passes() -> None:
+    # Arrange: no row is a real answer, and it bootstraps.
+    facts = LeaseFacts(read=True, lease=None, now=NOW)
+    # Act
+    check = check_lease_holdable(facts, B, AGENT)
+    # Assert
+    assert check.ok is True
+
+
+def test_a_row_read_with_no_clock_cannot_answer_expiry() -> None:
+    # Arrange
+    facts = LeaseFacts(read=True, lease=_row(B), now=None)
+    # Act
+    check = check_lease_holdable(facts, B, AGENT)
+    # Assert
+    assert check.ok is None
+
+
+def test_an_unresolved_source_host_is_unknown() -> None:
+    # Arrange: "may THIS host hand over" needs the host named.
+    facts = LeaseFacts(read=True, lease=_row(B), now=NOW)
+    # Act
+    check = check_lease_holdable(facts, "", AGENT)
+    # Assert
+    assert check.ok is None
+
+
+def test_the_canary_return_leg_is_unknown_rather_than_a_refusal(
+    canary_return_leg: LeaseFacts,
+) -> None:
+    # Arrange: the exact input that produced exit 5 at handover.
+    facts = canary_return_leg
+    # Act
+    check = check_lease_holdable(facts, B, AGENT)
+    # Assert
+    assert check.ok is None
+
+
+def test_the_unknown_explains_that_the_row_is_written_on_the_host_being_left(
+    canary_return_leg: LeaseFacts,
+) -> None:
+    # Arrange: without this sentence the reader cannot tell a stale row from a
+    # live second writer, which is the whole confusion.
+    facts = canary_return_leg
+    # Act
+    check = check_lease_holdable(facts, B, AGENT)
+    # Assert
+    assert "COORDINATOR" in check.hint
+
+
+def test_an_observed_absent_holder_passes(canary_return_leg: LeaseFacts) -> None:
+    # Arrange: somebody looked at scitex-compute-04 and it is not running it.
+    facts = LeaseFacts(
+        read=True,
+        lease=_row(A),
+        recorded_holder_running=False,
+        recorded_holder_evidence="tmux on scitex-compute-04 has NO session",
+        now=NOW,
+    )
+    # Act
+    check = check_lease_holdable(facts, B, AGENT)
+    # Assert
+    assert check.ok is True
+
+
+def test_an_observed_running_holder_fails() -> None:
+    # Arrange: this is the split-brain the lease exists to catch.
+    facts = LeaseFacts(
+        read=True,
+        lease=_row(A),
+        recorded_holder_running=True,
+        recorded_holder_evidence="tmux on scitex-compute-04 has session tui-…",
+        now=NOW,
+    )
+    # Act
+    check = check_lease_holdable(facts, B, AGENT)
+    # Assert
+    assert check.ok is False
+
+
+def test_the_split_brain_refusal_forbids_forcing_the_handover() -> None:
+    # Arrange
+    facts = LeaseFacts(
+        read=True, lease=_row(A), recorded_holder_running=True, now=NOW
+    )
+    # Act
+    check = check_lease_holdable(facts, B, AGENT)
+    # Assert
+    assert "Do NOT force" in check.hint
+
+
+def test_the_split_brain_refusal_quotes_what_was_seen() -> None:
+    # Arrange: a refusal on an observation must show the observation.
+    facts = LeaseFacts(
+        read=True,
+        lease=_row(A),
+        recorded_holder_running=True,
+        recorded_holder_evidence="tmux on scitex-compute-04 has session tui-canary",
+        now=NOW,
+    )
+    # Act
+    check = check_lease_holdable(facts, B, AGENT)
+    # Assert
+    assert "tui-canary" in check.detail
+
+
+def test_the_check_reports_which_store_it_read() -> None:
+    # Arrange: a lease answer is worth exactly as much as the db it came from,
+    # and this fleet has one db per host with no sync between them.
+    facts = LeaseFacts(read=True, lease=None, store="/state/x/state.db", now=NOW)
+    # Act
+    check = check_lease_holdable(facts, B, AGENT)
+    # Assert
+    assert "/state/x/state.db" in check.detail
+
+
+def test_the_lease_check_is_named_for_the_report() -> None:
+    # Arrange
+    facts = LeaseFacts(read=True, lease=None, now=NOW)
+    # Act
+    check = check_lease_holdable(facts, B, AGENT)
+    # Assert
+    assert check.name == CHECK_LEASE
+
+
+# ---------------------------------------------------------------------------
+# target_start_accepts
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def compute_04_dotfiles() -> SpecSourceDrift:
+    """The live state on scitex-compute-04, measured 2026-08-12.
+
+    Five commits behind with 2389 modified files — which matters because the
+    remedy the guard prints is ``git pull --ff-only``, and that aborts here.
+    """
+    return SpecSourceDrift(
+        state="behind",
+        behind=5,
+        ahead=0,
+        repo="/home/ywatanabe/.dotfiles",
+        upstream="origin/main",
+        dirty=2389,
+    )
+
+
+def test_an_unasked_target_is_unknown() -> None:
+    # Arrange: eleven checks about the target and none asked its start command.
+    facts = TargetFacts()
+    # Act
+    check = check_target_start(facts, B, AGENT)
+    # Assert
+    assert check.ok is None
+
+
+def test_the_unasked_answer_names_the_command_that_would_tell_us() -> None:
+    # Arrange
+    facts = TargetFacts()
+    # Act
+    check = check_target_start(facts, B, AGENT)
+    # Assert
+    assert "sac doctor" in check.hint
+
+
+def test_a_current_spec_source_passes() -> None:
+    # Arrange
+    facts = TargetFacts(
+        spec_source_drift=SpecSourceDrift(state="current", upstream="origin/main")
+    )
+    # Act
+    check = check_target_start(facts, B, AGENT)
+    # Assert
+    assert check.ok is True
+
+
+def test_an_AHEAD_spec_source_passes() -> None:
+    # Arrange: the guard refuses on staleness only. AHEAD means the spec about to
+    # launch is the newest one that exists — it merely has not propagated.
+    facts = TargetFacts(
+        spec_source_drift=SpecSourceDrift(state="ahead", ahead=3, repo="/r")
+    )
+    # Act
+    check = check_target_start(facts, B, AGENT)
+    # Assert
+    assert check.ok is True
+
+
+def test_a_not_a_repo_spec_source_passes() -> None:
+    # Arrange: drift is UNKNOWN to the guard there, and it never refuses on it.
+    facts = TargetFacts(spec_source_drift=SpecSourceDrift(state="not-a-repo"))
+    # Act
+    check = check_target_start(facts, B, AGENT)
+    # Assert
+    assert check.ok is True
+
+
+def test_a_BEHIND_spec_source_fails(compute_04_dotfiles: SpecSourceDrift) -> None:
+    # Arrange: what cost the canary its first leg, before source_stop this time.
+    facts = TargetFacts(spec_source_drift=compute_04_dotfiles)
+    # Act
+    check = check_target_start(facts, A, AGENT)
+    # Assert
+    assert check.ok is False
+
+
+def test_a_DIVERGED_spec_source_fails() -> None:
+    # Arrange: stale AND unpushed — the guard's other refusing state.
+    facts = TargetFacts(
+        spec_source_drift=SpecSourceDrift(
+            state="diverged", behind=2, ahead=1, repo="/r", upstream="origin/main"
+        )
+    )
+    # Act
+    check = check_target_start(facts, A, AGENT)
+    # Assert
+    assert check.ok is False
+
+
+def test_the_refusal_names_the_repo_to_pull_on_the_target(
+    compute_04_dotfiles: SpecSourceDrift,
+) -> None:
+    # Arrange
+    facts = TargetFacts(spec_source_drift=compute_04_dotfiles)
+    # Act
+    check = check_target_start(facts, A, AGENT)
+    # Assert
+    assert "git -C /home/ywatanabe/.dotfiles pull --ff-only" in check.hint
+
+
+def test_the_refusal_warns_that_ff_only_aborts_on_this_dirty_tree(
+    compute_04_dotfiles: SpecSourceDrift,
+) -> None:
+    # Arrange: a hint naming a command that will not run costs the same trip as
+    # no hint at all.
+    facts = TargetFacts(spec_source_drift=compute_04_dotfiles)
+    # Act
+    check = check_target_start(facts, A, AGENT)
+    # Assert
+    assert "2389 modified file(s) and --ff-only" in check.hint
+
+
+def test_a_clean_behind_repo_is_not_warned_about_a_dirty_tree() -> None:
+    # Arrange: the caveat must not appear where it does not apply.
+    facts = TargetFacts(
+        spec_source_drift=SpecSourceDrift(
+            state="behind", behind=1, repo="/r", upstream="origin/main", dirty=0
+        )
+    )
+    # Act
+    check = check_target_start(facts, A, AGENT)
+    # Assert
+    assert "--ff-only aborts" not in check.hint
+
+
+def test_the_refusal_names_the_override_without_recommending_it() -> None:
+    # Arrange
+    facts = TargetFacts(
+        spec_source_drift=SpecSourceDrift(state="behind", behind=1, repo="/r")
+    )
+    # Act
+    check = check_target_start(facts, A, AGENT)
+    # Assert
+    assert "prefer the pull" in check.hint
+
+
+def test_the_start_check_is_named_for_the_report() -> None:
+    # Arrange
+    facts = TargetFacts(spec_source_drift=SpecSourceDrift(state="current"))
+    # Act
+    check = check_target_start(facts, B, AGENT)
+    # Assert
+    assert check.name == CHECK_TARGET_START
+
+
+def test_a_drift_answer_with_no_state_is_refused_at_construction() -> None:
+    # Arrange / Act / Assert: a verdict with no verdict is not one the target's
+    # start command could have produced.
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="state must be non-empty"):
+        SpecSourceDrift(state="")

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_checks_sac.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_checks_sac.py
@@ -1,0 +1,222 @@
+"""The hint that told an operator to set a thing that was already set.
+
+Two measurements, and the check has to satisfy both:
+
+    2026-08-11, scitex-compute-04: sac is at ~/.env-sac/bin/sac and absent from
+    the non-interactive ssh PATH, so `ssh compute-04 sac …` says "No such file
+    or directory" — the same words a machine with no sac produces. INSTALLED and
+    FINDABLE must stay separable, because they need opposite fixes.
+
+    2026-08-12, ywata-note-win: the check FAILED and said "set the peer's
+    env_preamble". The peer declares `export PATH="$HOME/.env-3.11/bin:$PATH"`,
+    it works, and Shell prepends it to every command a relocation sends. So the
+    check was failing on a PATH nothing in this feature uses, and answering with
+    a step already taken.
+
+The property under test is therefore WHICH PATH THE ANSWER IS ABOUT, and that
+the hint branches on whether a preamble already exists rather than recommending
+one unconditionally — the same narrowness `_state._remote_sac_hint` documents.
+
+Pure predicates over observed facts. No I/O, no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_checks_sac import (
+    CHECK_SAC_PRESENT,
+    check_sac_present,
+)
+from scitex_agent_container._lifecycle._relocate_preflight_facts import TargetFacts
+
+HOST = "ywata-note-win"
+VENV_SAC = "/home/ywatanabe/.env-3.11/bin/sac"
+
+
+@pytest.fixture
+def preamble_host() -> TargetFacts:
+    """ywata-note-win as it actually is: not on the bare PATH, reachable anyway."""
+    return TargetFacts(
+        sac_on_path=False,
+        sac_resolved_path=VENV_SAC,
+        sac_usable_path=VENV_SAC,
+        preamble_declared=True,
+    )
+
+
+def test_a_host_reachable_only_via_its_preamble_passes(
+    preamble_host: TargetFacts,
+) -> None:
+    # Arrange: the ywata-note-win measurement. The old check FAILED here.
+    facts = preamble_host
+    # Act
+    check = check_sac_present(facts, HOST)
+    # Assert
+    assert check.ok is True
+
+
+def test_the_pass_says_the_preamble_is_what_makes_it_reachable(
+    preamble_host: TargetFacts,
+) -> None:
+    # Arrange: a pass that hides its reason cannot be audited later.
+    facts = preamble_host
+    # Act
+    check = check_sac_present(facts, HOST)
+    # Assert
+    assert "env_preamble" in check.detail
+
+
+def test_sac_on_the_bare_path_still_passes_on_its_own() -> None:
+    # Arrange: an older probe supplies only this fact, and it is a real answer.
+    facts = TargetFacts(sac_on_path=True, sac_resolved_path="/usr/local/bin/sac")
+    # Act
+    check = check_sac_present(facts, HOST)
+    # Assert
+    assert check.ok is True
+
+
+def test_nothing_observed_at_all_is_unknown() -> None:
+    # Arrange
+    facts = TargetFacts()
+    # Act
+    check = check_sac_present(facts, HOST)
+    # Assert
+    assert check.ok is None
+
+
+def test_an_unmeasured_preamble_effect_is_unknown_not_a_failure() -> None:
+    # Arrange: the bare PATH says no, a preamble is declared, and nobody measured
+    # what it does. That is a question, not a verdict.
+    facts = TargetFacts(
+        sac_on_path=False, sac_resolved_path=VENV_SAC, preamble_declared=True
+    )
+    # Act
+    check = check_sac_present(facts, HOST)
+    # Assert
+    assert check.ok is None
+
+
+def test_sac_installed_nowhere_fails_as_not_installed() -> None:
+    # Arrange: looked-and-found-nothing is the empty string, not None.
+    facts = TargetFacts(
+        sac_on_path=False, sac_usable_path="", sac_resolved_path="", preamble_declared=False
+    )
+    # Act
+    check = check_sac_present(facts, HOST)
+    # Assert
+    assert "NOT INSTALLED" in check.detail
+
+
+def test_not_installed_is_told_to_install_it() -> None:
+    # Arrange
+    facts = TargetFacts(
+        sac_on_path=False, sac_usable_path="", sac_resolved_path="", preamble_declared=False
+    )
+    # Act
+    check = check_sac_present(facts, HOST)
+    # Assert
+    assert "install sac" in check.hint
+
+
+def test_installed_but_unreachable_is_reported_as_installed_not_missing() -> None:
+    # Arrange: the two failures produce the same shell error and need opposite
+    # fixes, so the DETAIL has to say which one this is.
+    facts = TargetFacts(
+        sac_on_path=False,
+        sac_usable_path="",
+        sac_resolved_path="/home/ywatanabe/.env-sac/bin/sac",
+        preamble_declared=False,
+    )
+    # Act
+    check = check_sac_present(facts, "scitex-compute-04")
+    # Assert
+    assert "IS INSTALLED" in check.detail
+
+
+def test_installed_but_unreachable_names_where_it_actually_is() -> None:
+    # Arrange
+    facts = TargetFacts(
+        sac_on_path=False,
+        sac_usable_path="",
+        sac_resolved_path="/home/ywatanabe/.env-sac/bin/sac",
+        preamble_declared=False,
+    )
+    # Act
+    check = check_sac_present(facts, "scitex-compute-04")
+    # Assert
+    assert "/home/ywatanabe/.env-sac/bin/sac" in check.detail
+
+
+def test_installed_but_unreachable_with_no_preamble_is_told_to_add_one() -> None:
+    # Arrange: the 2026-08-11 scitex-compute-04 shape, on a peer with no preamble.
+    facts = TargetFacts(
+        sac_on_path=False,
+        sac_usable_path="",
+        sac_resolved_path="/home/ywatanabe/.env-sac/bin/sac",
+        preamble_declared=False,
+    )
+    # Act
+    check = check_sac_present(facts, "scitex-compute-04")
+    # Assert
+    assert "declares NO env_preamble" in check.hint
+
+
+def test_installed_but_unreachable_WITH_a_preamble_is_not_told_to_add_one() -> None:
+    # Arrange: THE 2026-08-12 DEFECT. A peer that already declares one has a
+    # different problem, and naming env_preamble as the fix is a wrong answer.
+    facts = TargetFacts(
+        sac_on_path=False,
+        sac_usable_path="",
+        sac_resolved_path=VENV_SAC,
+        preamble_declared=True,
+    )
+    # Act
+    check = check_sac_present(facts, HOST)
+    # Assert
+    assert "do NOT add an env_preamble" in check.hint
+
+
+def test_that_hint_points_at_the_preamble_itself_as_the_thing_to_fix() -> None:
+    # Arrange: a refusal must name the next step, and here the next step is
+    # comparing what the preamble exports against where sac actually is.
+    facts = TargetFacts(
+        sac_on_path=False,
+        sac_usable_path="",
+        sac_resolved_path=VENV_SAC,
+        preamble_declared=True,
+    )
+    # Act
+    check = check_sac_present(facts, HOST)
+    # Assert
+    assert "the preamble itself is what to fix" in check.hint
+
+
+def test_an_unknown_preamble_state_asks_before_recommending() -> None:
+    # Arrange: nobody recorded whether a preamble exists, so neither branch of
+    # the advice is safe to give outright.
+    facts = TargetFacts(
+        sac_on_path=False, sac_usable_path="", sac_resolved_path=VENV_SAC
+    )
+    # Act
+    check = check_sac_present(facts, HOST)
+    # Assert
+    assert "Check whether" in check.hint
+
+
+def test_an_uninspected_install_location_is_unknown_not_a_failure() -> None:
+    # Arrange: not reachable, and nobody looked for it anywhere else.
+    facts = TargetFacts(sac_on_path=False, sac_usable_path="", preamble_declared=False)
+    # Act
+    check = check_sac_present(facts, HOST)
+    # Assert
+    assert check.ok is None
+
+
+def test_the_check_is_named_for_the_report(preamble_host: TargetFacts) -> None:
+    # Arrange
+    facts = preamble_host
+    # Act
+    check = check_sac_present(facts, HOST)
+    # Assert
+    assert check.name == CHECK_SAC_PRESENT

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_effects_handover.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_effects_handover.py
@@ -1,0 +1,230 @@
+"""The phase and the preflight must reach the same verdict, or the gate is worthless.
+
+HANDOVER is the last phase before DONE. By the time it runs the agent is stopped
+on the source, its transcript has been copied and verified, the target has booted
+and answered a handshake. So a refusal here is a correct refusal delivered to an
+operator whose agent is already down — which is what the 2026-08-11 canary got on
+its return leg (exit 5, nothing running anywhere).
+
+The fix was to ask the question earlier. The risk that creates is the one these
+tests exist to close: a preflight that PASSES on a phase that will still REFUSE
+is worse than no preflight, because it converts a refusal into a surprise. So the
+rule lives in ONE function, :func:`._relocate_lease_readiness.handoff_readiness`,
+and both call it — and the tests below drive the PHASE against the same states
+:mod:`test__relocate_lease_readiness` drives the predicate against.
+
+NOT MOCKED. The lease store is the real sqlite one (the autouse fixture isolates
+it per test), and the liveness observation runs the real tmux script through
+``sh -c``: for an agent name no session exists under, tmux answers honestly and
+that answer is the machine's, not a canned one. Only the "another host IS running
+it" case is supplied as canned marker output, because creating a real second live
+agent is not something a unit test may do.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_effects import RelocateAdapters
+from scitex_agent_container._lifecycle._relocate_lease import Lease
+from scitex_agent_container._lifecycle._relocate_shell import Shell
+from scitex_agent_container._state.state_db_relocation import load_lease, save_lease
+
+AGENT = "relocate-handover-test-no-such-session"
+SRC = "src-host"
+DST = "dst-host"
+THIRD = "third-host"
+NOW = 1_786_500_000.0
+DAY = 86_400.0
+
+
+def _real_exec(argv, timeout_s=None):
+    """Run the rendered script for real. tmux answers for itself."""
+    done = subprocess.run(argv, capture_output=True, text=True, timeout=timeout_s)
+    return {
+        "exit_code": done.returncode,
+        "stdout": done.stdout,
+        "stderr": done.stderr,
+        "timed_out": False,
+    }
+
+
+def _says_running(argv, timeout_s=None):
+    """The one state a test may not create for real: another host running it."""
+    return {
+        "exit_code": 0,
+        "stdout": "TX-RUN=yes\n",
+        "stderr": "",
+        "timed_out": False,
+    }
+
+
+def _adapters(exec_fn=_real_exec):
+    """A handover whose THIRD host is reachable without ssh.
+
+    ``local_host`` is set to the host the lease row names, so the shell built for
+    it is LOCAL and its script runs through ``exec_fn`` rather than over the
+    network. The observation is still real — it is the same tmux question, asked
+    on this machine.
+    """
+    return RelocateAdapters(
+        agent=AGENT,
+        spec={},
+        from_host=SRC,
+        to_host=DST,
+        source=Shell(host=SRC, is_local=True),
+        target=Shell(host=DST, is_local=True),
+        stamp="20260812T000000Z",
+        exec_fn=exec_fn,
+        now=lambda: NOW,
+        local_host=THIRD,
+    )
+
+
+def _row(holder: str, *, fence: int = 1, expires_at: float = NOW + DAY) -> None:
+    save_lease(
+        Lease(
+            agent=AGENT,
+            holder=holder,
+            token="tok",
+            expires_at=expires_at,
+            fence=fence,
+        )
+    )
+
+
+@pytest.fixture
+def stale_row() -> None:
+    """The canary's return-leg input: a LIVE row naming a host that is not the source."""
+    _row(THIRD, fence=1)
+
+
+# ---------------------------------------------------------------------------
+# the row that is a record, not a writer
+# ---------------------------------------------------------------------------
+
+
+def test_a_stale_row_no_longer_refuses_the_handover(stale_row) -> None:
+    # Arrange: the lease names third-host, which is not running the agent — tmux
+    # on this machine answers that for itself.
+    adapters = _adapters()
+    # Act
+    result = adapters.hand_over_lease()
+    # Assert
+    assert result.ok is True
+
+
+def test_the_lease_actually_moves_to_the_target(stale_row) -> None:
+    # Arrange: "it did not refuse" is not "it worked".
+    adapters = _adapters()
+    # Act
+    adapters.hand_over_lease()
+    # Assert
+    assert load_lease(AGENT).holder == DST
+
+
+def test_the_fence_advances_twice_past_the_stale_holder(stale_row) -> None:
+    # Arrange: once to re-claim for the source, once to hand over. The fence is
+    # what locks third-host out if it ever wakes.
+    adapters = _adapters()
+    # Act
+    adapters.hand_over_lease()
+    # Assert
+    assert load_lease(AGENT).fence == 3
+
+
+def test_the_journal_records_that_the_holder_was_OBSERVED_absent(stale_row) -> None:
+    # Arrange: a reader six months later cannot tell a re-claim on evidence from
+    # a re-claim on a clock unless the entry says which it was.
+    adapters = _adapters()
+    # Act
+    result = adapters.hand_over_lease()
+    # Assert
+    assert "OBSERVED not running" in result.detail
+
+
+def test_the_evidence_reaches_the_adapter_log(stale_row) -> None:
+    # Arrange: the observation that permitted this must be auditable.
+    adapters = _adapters()
+    # Act
+    adapters.hand_over_lease()
+    # Assert
+    assert any("the lease row names third-host" in line for line in adapters.log)
+
+
+# ---------------------------------------------------------------------------
+# the row that IS a live writer
+# ---------------------------------------------------------------------------
+
+
+def test_a_holder_that_is_running_the_agent_still_refuses(stale_row) -> None:
+    # Arrange: the split-brain the lease exists to catch. Unchanged behaviour,
+    # and the point of the whole change is that THIS still refuses.
+    adapters = _adapters(exec_fn=_says_running)
+    # Act
+    result = adapters.hand_over_lease()
+    # Assert
+    assert result.ok is False
+
+
+def test_that_refusal_leaves_the_lease_where_it_was(stale_row) -> None:
+    # Arrange
+    adapters = _adapters(exec_fn=_says_running)
+    # Act
+    adapters.hand_over_lease()
+    # Assert
+    assert load_lease(AGENT).holder == THIRD
+
+
+def test_that_refusal_forbids_forcing_it(stale_row) -> None:
+    # Arrange
+    adapters = _adapters(exec_fn=_says_running)
+    # Act
+    result = adapters.hand_over_lease()
+    # Assert
+    assert "do NOT force the handover" in result.hint
+
+
+# ---------------------------------------------------------------------------
+# the ordinary paths, unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_store_still_bootstraps_and_hands_over() -> None:
+    # Arrange: sac claims no lease at agent start, so a first move finds no row.
+    adapters = _adapters()
+    # Act
+    result = adapters.hand_over_lease()
+    # Assert
+    assert result.ok is True
+
+
+def test_the_bootstrapped_handover_lands_at_fence_one() -> None:
+    # Arrange
+    adapters = _adapters()
+    # Act
+    adapters.hand_over_lease()
+    # Assert
+    assert load_lease(AGENT).fence == 1
+
+
+def test_a_row_already_held_by_the_source_hands_over_directly() -> None:
+    # Arrange: the ordinary second move.
+    _row(SRC, fence=4)
+    adapters = _adapters()
+    # Act
+    adapters.hand_over_lease()
+    # Assert
+    assert load_lease(AGENT).fence == 5
+
+
+def test_an_expired_row_is_reclaimed_without_observing_anyone() -> None:
+    # Arrange: the fence already settles this, so no third host is asked.
+    _row(THIRD, fence=1, expires_at=NOW - 1.0)
+    adapters = _adapters(exec_fn=_says_running)
+    # Act
+    result = adapters.hand_over_lease()
+    # Assert
+    assert result.ok is True

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_lease_facts.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_lease_facts.py
@@ -1,0 +1,220 @@
+"""An unreadable store must not look like an empty one, and an idle host must not be probed.
+
+The adapter behind the lease check. Two things it must never do, both of which
+would be easy and quiet:
+
+    * collapse "I could not open the db" into ``lease=None``. That is a REAL
+      answer meaning "this store has never held a row", and it BOOTSTRAPS a
+      lease and proceeds — so folding a broken store into it turns a fault into
+      a green light at the one gate standing between one live agent and two.
+    * probe a third host when the answer does not depend on it. A row naming the
+      source, or an expired row, decides without anyone observed; dialling a
+      machine anyway lets an ssh timeout refuse a relocation that was fine.
+
+The seams take and return REAL values — a real ``Lease``, a real three-valued
+liveness pair — so nothing about the decision is mocked.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_lease import Lease
+from scitex_agent_container._lifecycle._relocate_lease_facts import gather_lease_facts
+
+AGENT = "canary-resume-test"
+A = "scitex-compute-04"
+B = "ywata-note-win"
+NOW = 1_786_500_000.0
+TTL = 86_400.0
+
+
+def _row(holder: str, *, expires_at: float = NOW + TTL) -> Lease:
+    return Lease(
+        agent=AGENT, holder=holder, token="tok", expires_at=expires_at, fence=1
+    )
+
+
+class _Watcher:
+    """A real callable that records who it was asked about. No mocking library."""
+
+    def __init__(self, answer: tuple[bool | None, str]) -> None:
+        self.answer = answer
+        self.asked: list[str] = []
+
+    def __call__(self, holder: str, agent: str) -> tuple[bool | None, str]:
+        self.asked.append(holder)
+        return self.answer
+
+
+@pytest.fixture
+def absent_watcher() -> _Watcher:
+    """Answers the way tmux does when the server is up and holds no session."""
+    return _Watcher((False, "tmux on scitex-compute-04 answered and has NO session"))
+
+
+def test_an_unreadable_store_is_not_read(absent_watcher: _Watcher) -> None:
+    # Arrange: a loader that fails the way a locked or missing db does.
+    def explode(agent: str):
+        raise OSError("unable to open database file")
+
+    # Act
+    facts = gather_lease_facts(
+        AGENT, from_host=B, now=NOW, load=explode, observe=absent_watcher
+    )
+    # Assert
+    assert facts.read is False
+
+
+def test_an_unreadable_store_does_not_report_an_absent_row() -> None:
+    # Arrange: THE failure this guards. ``lease=None`` bootstraps and proceeds.
+    def explode(agent: str):
+        raise OSError("unable to open database file")
+
+    # Act
+    facts = gather_lease_facts(AGENT, from_host=B, now=NOW, load=explode)
+    # Assert
+    assert facts.lease is None and facts.read is False
+
+
+def test_an_unreadable_store_says_why() -> None:
+    # Arrange
+    def explode(agent: str):
+        raise OSError("unable to open database file")
+
+    # Act
+    facts = gather_lease_facts(AGENT, from_host=B, now=NOW, load=explode)
+    # Assert
+    assert "unable to open database file" in facts.recorded_holder_evidence
+
+
+def test_a_store_with_no_row_is_read_and_empty() -> None:
+    # Arrange
+    # Act
+    facts = gather_lease_facts(AGENT, from_host=B, now=NOW, load=lambda a: None)
+    # Assert
+    assert facts.read is True
+
+
+def test_no_row_asks_no_host_anything(absent_watcher: _Watcher) -> None:
+    # Arrange
+    # Act
+    gather_lease_facts(
+        AGENT, from_host=B, now=NOW, load=lambda a: None, observe=absent_watcher
+    )
+    # Assert
+    assert absent_watcher.asked == []
+
+
+def test_a_row_naming_the_source_asks_no_host_anything(
+    absent_watcher: _Watcher,
+) -> None:
+    # Arrange: the ordinary second move — nobody else is involved.
+    # Act
+    gather_lease_facts(
+        AGENT, from_host=B, now=NOW, load=lambda a: _row(B), observe=absent_watcher
+    )
+    # Assert
+    assert absent_watcher.asked == []
+
+
+def test_an_expired_row_asks_no_host_anything(absent_watcher: _Watcher) -> None:
+    # Arrange: the fence already settles this; a probe would only add a way to fail.
+    # Act
+    gather_lease_facts(
+        AGENT,
+        from_host=B,
+        now=NOW,
+        load=lambda a: _row(A, expires_at=NOW - 1.0),
+        observe=absent_watcher,
+    )
+    # Assert
+    assert absent_watcher.asked == []
+
+
+def test_a_live_row_naming_another_host_asks_THAT_host(
+    absent_watcher: _Watcher,
+) -> None:
+    # Arrange: the canary's return-leg input.
+    # Act
+    gather_lease_facts(
+        AGENT, from_host=B, now=NOW, load=lambda a: _row(A), observe=absent_watcher
+    )
+    # Assert
+    assert absent_watcher.asked == [A]
+
+
+def test_the_observation_travels_onto_the_facts(absent_watcher: _Watcher) -> None:
+    # Arrange
+    # Act
+    facts = gather_lease_facts(
+        AGENT, from_host=B, now=NOW, load=lambda a: _row(A), observe=absent_watcher
+    )
+    # Assert
+    assert facts.recorded_holder_running is False
+
+
+def test_the_evidence_travels_with_it(absent_watcher: _Watcher) -> None:
+    # Arrange: a verdict built on an observation must be able to show it.
+    # Act
+    facts = gather_lease_facts(
+        AGENT, from_host=B, now=NOW, load=lambda a: _row(A), observe=absent_watcher
+    )
+    # Assert
+    assert "NO session" in facts.recorded_holder_evidence
+
+
+def test_a_failed_probe_leaves_liveness_unobserved() -> None:
+    # Arrange: folding this into "not running" would hand the lease away from a
+    # host that may well be live.
+    def unreachable(holder: str, agent: str):
+        raise TimeoutError("ssh timed out")
+
+    # Act
+    facts = gather_lease_facts(
+        AGENT, from_host=B, now=NOW, load=lambda a: _row(A), observe=unreachable
+    )
+    # Assert
+    assert facts.recorded_holder_running is None
+
+
+def test_a_failed_probe_still_reports_the_row_it_read() -> None:
+    # Arrange: the row is a good measurement even when the probe was not.
+    def unreachable(holder: str, agent: str):
+        raise TimeoutError("ssh timed out")
+
+    # Act
+    facts = gather_lease_facts(
+        AGENT, from_host=B, now=NOW, load=lambda a: _row(A), observe=unreachable
+    )
+    # Assert
+    assert facts.read is True
+
+
+def test_the_clock_is_recorded_so_expiry_can_be_judged() -> None:
+    # Arrange
+    # Act
+    facts = gather_lease_facts(AGENT, from_host=B, now=NOW, load=lambda a: _row(B))
+    # Assert
+    assert facts.now == NOW
+
+
+def test_an_unnamed_source_asks_no_host_anything(absent_watcher: _Watcher) -> None:
+    # Arrange: the check refuses on an unnamed source alone, so an ssh spent
+    # here would buy nothing and could only add a way to fail.
+    # Act
+    gather_lease_facts(
+        AGENT, from_host="", now=NOW, load=lambda a: _row(A), observe=absent_watcher
+    )
+    # Assert
+    assert absent_watcher.asked == []
+
+
+def test_the_store_that_was_read_is_named() -> None:
+    # Arrange: one db per host, no sync — which one answered is part of the answer.
+    # Act
+    facts = gather_lease_facts(
+        AGENT, from_host=B, now=NOW, db_path="/state/x/state.db", load=lambda a: None
+    )
+    # Assert
+    assert facts.store == "/state/x/state.db"

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_lease_readiness.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_lease_readiness.py
@@ -1,0 +1,259 @@
+"""A row naming another host is a RECORD, not a writer — until somebody looks at that host.
+
+Written against the exact state the 2026-08-11 canary's return leg hit, because
+the whole design follows from it. The lease is written to the COORDINATOR's own
+state db and the coordinator is always the host being LEFT, so after A -> B the
+row on A reads ``holder=B`` and B's store never hears about it. When B moves
+back, the coordinator stands on B and reads a row from an EARLIER move:
+
+    ywata-note-win state db:    holder=scitex-compute-04  fence 1
+    scitex-compute-04 state db: holder=ywata-note-win     fence 1
+
+Both are true. Neither is current. The old rule read either as a live second
+writer and refused — at ``handover``, five phases after the agent was stopped.
+
+So the property pinned here is not "does it refuse" but WHAT IT REFUSES ON: an
+observation of the named host, three-valued, where "nobody looked" refuses as
+firmly as "it is running" and says something different.
+
+Pure predicates over real values. No mocks, no clock, no store.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_lease import (
+    CODE_HELD_BY_OTHER,
+    CODE_OK,
+    CODE_UNKNOWN,
+    Lease,
+    claim,
+)
+from scitex_agent_container._lifecycle._relocate_lease_readiness import (
+    handoff_readiness,
+)
+
+AGENT = "canary-resume-test"
+A = "scitex-compute-04"
+B = "ywata-note-win"
+NOW = 1_786_500_000.0
+TTL = 86_400.0
+
+
+def _lease(holder: str, *, fence: int = 1, expires_at: float = NOW + TTL) -> Lease:
+    return Lease(
+        agent=AGENT, holder=holder, token="tok", expires_at=expires_at, fence=fence
+    )
+
+
+@pytest.fixture
+def stale_row() -> Lease:
+    """The canary's input: a LIVE row naming the other host, written yesterday."""
+    return _lease(A, fence=1)
+
+
+# ---------------------------------------------------------------------------
+# the branches that proceed without needing anybody observed
+# ---------------------------------------------------------------------------
+
+
+def test_no_row_at_all_is_a_go() -> None:
+    # Arrange: sac claims no lease when an agent starts, so a first move finds none.
+    lease = None
+    # Act
+    verdict = handoff_readiness(lease, from_holder=A, now=NOW)
+    # Assert
+    assert verdict.allowed is True
+
+
+def test_no_row_says_the_lease_will_be_bootstrapped() -> None:
+    # Arrange
+    lease = None
+    # Act
+    verdict = handoff_readiness(lease, from_holder=A, now=NOW)
+    # Assert
+    assert "BOOTSTRAPPED" in verdict.reason
+
+
+def test_the_source_already_holding_it_is_a_go() -> None:
+    # Arrange
+    lease = _lease(A)
+    # Act
+    verdict = handoff_readiness(lease, from_holder=A, now=NOW)
+    # Assert
+    assert verdict.allowed is True
+
+
+def test_an_expired_row_is_a_go_without_observing_anyone() -> None:
+    # Arrange: the fence, not a probe, excludes a holder whose lease ran out.
+    lease = _lease(B, expires_at=NOW - 1.0)
+    # Act
+    verdict = handoff_readiness(lease, from_holder=A, now=NOW)
+    # Assert
+    assert verdict.allowed is True
+
+
+def test_an_expired_row_says_the_fence_will_advance() -> None:
+    # Arrange
+    lease = _lease(B, expires_at=NOW - 1.0)
+    # Act
+    verdict = handoff_readiness(lease, from_holder=A, now=NOW)
+    # Assert
+    assert "fence" in verdict.reason
+
+
+# ---------------------------------------------------------------------------
+# the live row naming somebody else — three answers, not two
+# ---------------------------------------------------------------------------
+
+
+def test_a_live_row_naming_another_host_is_UNKNOWN_when_unobserved(
+    stale_row: Lease,
+) -> None:
+    # Arrange: exactly what the return leg read out of ywata-note-win's db.
+    lease = stale_row
+    # Act
+    verdict = handoff_readiness(lease, from_holder=B, now=NOW)
+    # Assert
+    assert verdict.allowed is None
+
+
+def test_the_unobserved_answer_carries_the_unknown_code(stale_row: Lease) -> None:
+    # Arrange
+    lease = stale_row
+    # Act
+    verdict = handoff_readiness(lease, from_holder=B, now=NOW)
+    # Assert
+    assert verdict.code == CODE_UNKNOWN
+
+
+def test_the_unobserved_answer_names_the_host_to_go_and_look_at(
+    stale_row: Lease,
+) -> None:
+    # Arrange
+    lease = stale_row
+    # Act
+    verdict = handoff_readiness(lease, from_holder=B, now=NOW)
+    # Assert
+    assert A in verdict.reason
+
+
+def test_a_holder_that_IS_running_the_agent_refuses(stale_row: Lease) -> None:
+    # Arrange: this is the split-brain, now backed by an observation.
+    lease = stale_row
+    # Act
+    verdict = handoff_readiness(
+        lease, from_holder=B, now=NOW, recorded_holder_running=True
+    )
+    # Assert
+    assert verdict.allowed is False
+
+
+def test_a_running_holder_refuses_with_the_held_by_other_code(
+    stale_row: Lease,
+) -> None:
+    # Arrange
+    lease = stale_row
+    # Act
+    verdict = handoff_readiness(
+        lease, from_holder=B, now=NOW, recorded_holder_running=True
+    )
+    # Assert
+    assert verdict.code == CODE_HELD_BY_OTHER
+
+
+def test_a_holder_that_is_NOT_running_the_agent_proceeds(stale_row: Lease) -> None:
+    # Arrange: the 2026-08-11 return leg, measured.
+    lease = stale_row
+    # Act
+    verdict = handoff_readiness(
+        lease, from_holder=B, now=NOW, recorded_holder_running=False
+    )
+    # Assert
+    assert verdict.allowed is True
+
+
+def test_an_absent_holder_is_described_as_a_past_handover(stale_row: Lease) -> None:
+    # Arrange
+    lease = stale_row
+    # Act
+    verdict = handoff_readiness(
+        lease, from_holder=B, now=NOW, recorded_holder_running=False
+    )
+    # Assert
+    assert "past handover" in verdict.reason
+
+
+def test_unobserved_and_refused_do_not_say_the_same_thing(stale_row: Lease) -> None:
+    # Arrange: both stop the move; only one is about another host being alive.
+    unobserved = handoff_readiness(stale_row, from_holder=B, now=NOW)
+    # Act
+    running = handoff_readiness(
+        stale_row, from_holder=B, now=NOW, recorded_holder_running=True
+    )
+    # Assert
+    assert unobserved.reason != running.reason
+
+
+def test_an_unnamed_source_raises_rather_than_answering(stale_row: Lease) -> None:
+    # Arrange
+    lease = stale_row
+    # Act / Assert are one statement for a raise.
+    # Assert
+    with pytest.raises(ValueError, match="naming the host"):
+        handoff_readiness(lease, from_holder="", now=NOW)
+
+
+# ---------------------------------------------------------------------------
+# the gate and the primitive must agree, or the preflight is a lie
+# ---------------------------------------------------------------------------
+
+
+def test_the_go_it_reports_is_one_claim_will_actually_grant(stale_row: Lease) -> None:
+    # Arrange: a "proceed" on a live row held elsewhere is worthless unless
+    # claim() then takes it — with the same observation this verdict is made of.
+    # (That the verdict IS a go on this input is pinned by
+    # test_a_holder_that_is_NOT_running_the_agent_proceeds above.)
+    # Act
+    _granted, verdict = claim(
+        stale_row,
+        agent=AGENT,
+        holder=B,
+        token="new",
+        now=NOW,
+        ttl_s=TTL,
+        holder_absent=True,
+    )
+    # Assert
+    assert verdict.code == CODE_OK
+
+
+def test_that_claim_advances_the_fence(stale_row: Lease) -> None:
+    # Arrange: the fence is what actually locks the old holder out.
+    starting_fence = stale_row.fence
+    # Act
+    granted, _verdict = claim(
+        stale_row,
+        agent=AGENT,
+        holder=B,
+        token="new",
+        now=NOW,
+        ttl_s=TTL,
+        holder_absent=True,
+    )
+    # Assert
+    assert granted.fence == starting_fence + 1
+
+
+def test_claim_still_refuses_the_same_row_without_the_observation(
+    stale_row: Lease,
+) -> None:
+    # Arrange: ``holder_absent`` is evidence, and absent evidence changes nothing.
+    lease = stale_row
+    # Act
+    _granted, verdict = claim(
+        lease, agent=AGENT, holder=B, token="new", now=NOW, ttl_s=TTL
+    )
+    # Assert
+    assert verdict.code == CODE_HELD_BY_OTHER

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_preflight.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_preflight.py
@@ -31,7 +31,9 @@ from scitex_agent_container._lifecycle._relocate_preflight import (
     CHECK_SESSION,
     CHECK_SOURCE_WORK,
     Check,
+    LeaseFacts,
     SourceFacts,
+    SpecSourceDrift,
     TargetFacts,
     preflight,
 )
@@ -59,6 +61,9 @@ def _healthy_facts(**overrides: object) -> TargetFacts:
         hub_reachable_from_target=True,
         sac_on_path=True,
         sac_resolved_path="/usr/local/bin/sac",
+        sac_usable_path="/usr/local/bin/sac",
+        preamble_declared=False,
+        spec_source_drift=SpecSourceDrift(state="current", upstream="origin/main"),
     )
     base.update(overrides)
     return TargetFacts(**base)  # type: ignore[arg-type]
@@ -81,7 +86,23 @@ def _clean_source(**overrides: object) -> SourceFacts:
     return SourceFacts(**base)  # type: ignore[arg-type]
 
 
-def _run(source_facts: SourceFacts | None = None, **overrides: object):
+def _clean_lease(**overrides: object) -> LeaseFacts:
+    """A lease store that was READ and holds nothing for this agent.
+
+    That is a real answer, not an absence of one: sac claims no lease when an
+    agent starts, so the ordinary first relocation finds no row and bootstraps.
+    ``read=True`` is what separates it from "nobody opened the db", which refuses.
+    """
+    base = dict(read=True, lease=None, store="/state/state.db", now=1_786_500_000.0)
+    base.update(overrides)
+    return LeaseFacts(**base)  # type: ignore[arg-type]
+
+
+def _run(
+    source_facts: SourceFacts | None = None,
+    lease_facts: LeaseFacts | None = None,
+    **overrides: object,
+):
     return preflight(
         agent=AGENT,
         to_host=DST,
@@ -90,6 +111,7 @@ def _run(source_facts: SourceFacts | None = None, **overrides: object):
         required_ports=PORTS,
         source_facts=source_facts if source_facts is not None else _clean_source(),
         from_host=SRC,
+        lease_facts=lease_facts if lease_facts is not None else _clean_lease(),
     )
 
 
@@ -452,104 +474,32 @@ def test_an_unobserved_check_still_explains_what_to_run() -> None:
 
 
 # ---------------------------------------------------------------------------
-# sac_present_on_target — installed and findable are two questions
+# sac_present_on_target — WIRED here, decided in _relocate_checks_sac
 #
-# Measured 2026-08-11 on scitex-compute-04: sac lives at
-# /home/ywatanabe/.env-sac/bin/sac and is absent from the non-interactive ssh
-# PATH, so `ssh compute-04 sac …` answers "No such file or directory" — the same
-# words a machine with no sac at all produces, needing the opposite fix.
+# The predicate moved to its own module when the question it answers had to be
+# narrowed (which PATH is the answer about?), and its unit tests moved with it to
+# test__relocate_checks_sac.py. What belongs HERE is that the aggregate still
+# carries it, because a check that stops being run is indistinguishable from one
+# that always passes.
 # ---------------------------------------------------------------------------
 
 
-def test_sac_on_the_ssh_path_passes() -> None:
-    # Arrange
-    report = _run()
-    # Act
-    check = _named(report, CHECK_SAC_PRESENT)
-    # Assert
-    assert check.ok is True
-
-
-def test_sac_installed_but_off_the_ssh_path_fails() -> None:
-    # Arrange: the compute-04 case.
-    report = _run(
-        sac_on_path=False, sac_resolved_path="/home/ywatanabe/.env-sac/bin/sac"
-    )
+def test_the_sac_presence_check_is_part_of_the_aggregate() -> None:
+    # Arrange: not installed anywhere on the target.
+    report = _run(sac_on_path=False, sac_usable_path="", sac_resolved_path="")
     # Act
     check = _named(report, CHECK_SAC_PRESENT)
     # Assert
     assert check.ok is False
 
 
-def test_sac_off_the_path_is_reported_as_installed_rather_than_missing() -> None:
+def test_a_sac_presence_failure_refuses_the_whole_relocation() -> None:
     # Arrange
-    report = _run(
-        sac_on_path=False, sac_resolved_path="/home/ywatanabe/.env-sac/bin/sac"
-    )
+    report = _run(sac_on_path=False, sac_usable_path="", sac_resolved_path="")
     # Act
-    check = _named(report, CHECK_SAC_PRESENT)
+    verdict = report.ok
     # Assert
-    assert "IS INSTALLED" in check.detail
-
-
-def test_sac_off_the_path_names_where_it_actually_is() -> None:
-    # Arrange
-    report = _run(
-        sac_on_path=False, sac_resolved_path="/home/ywatanabe/.env-sac/bin/sac"
-    )
-    # Act
-    check = _named(report, CHECK_SAC_PRESENT)
-    # Assert
-    assert "/home/ywatanabe/.env-sac/bin/sac" in check.detail
-
-
-def test_sac_off_the_path_tells_the_reader_not_to_install_a_second_copy() -> None:
-    # Arrange: the wrong fix here is to install sac again, which is what a
-    # single "sac not found" message would send the reader off to do.
-    report = _run(
-        sac_on_path=False, sac_resolved_path="/home/ywatanabe/.env-sac/bin/sac"
-    )
-    # Act
-    check = _named(report, CHECK_SAC_PRESENT)
-    # Assert
-    assert "do NOT install a second copy" in check.hint
-
-
-def test_sac_absent_everywhere_fails_as_not_installed() -> None:
-    # Arrange: "" means looked and found nothing.
-    report = _run(sac_on_path=False, sac_resolved_path="")
-    # Act
-    check = _named(report, CHECK_SAC_PRESENT)
-    # Assert
-    assert "NOT INSTALLED" in check.detail
-
-
-def test_sac_absent_everywhere_asks_for_an_install() -> None:
-    # Arrange
-    report = _run(sac_on_path=False, sac_resolved_path="")
-    # Act
-    check = _named(report, CHECK_SAC_PRESENT)
-    # Assert
-    assert "install sac" in check.hint
-
-
-def test_sac_off_the_path_with_no_direct_lookup_is_unknown() -> None:
-    # Arrange: not-on-PATH alone cannot tell the two failures apart, and
-    # guessing either way sends the reader to the wrong fix.
-    report = _run(sac_on_path=False, sac_resolved_path=None)
-    # Act
-    check = _named(report, CHECK_SAC_PRESENT)
-    # Assert
-    assert check.ok is None
-
-
-def test_an_unprobed_sac_presence_is_unknown() -> None:
-    # Arrange
-    report = _run(sac_on_path=None, sac_resolved_path=None)
-    # Act
-    check = _named(report, CHECK_SAC_PRESENT)
-    # Assert
-    assert check.ok is None
+    assert verdict is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe.py
@@ -24,7 +24,12 @@ from __future__ import annotations
 import pytest
 
 from scitex_agent_container._lifecycle._relocate_origin import RepoWork
-from scitex_agent_container._lifecycle._relocate_preflight import SourceFacts, preflight
+from scitex_agent_container._lifecycle._relocate_preflight import (
+    LeaseFacts,
+    SourceFacts,
+    SpecSourceDrift,
+    preflight,
+)
 from scitex_agent_container._lifecycle._relocate_probe import (
     TargetProbes,
     gather_target_facts,
@@ -224,6 +229,9 @@ def test_a_fully_healthy_probe_set_passes_preflight() -> None:
         hub_reachable_from_target=lambda: True,
         sac_on_path=lambda: True,
         sac_resolved_path=lambda: "/usr/local/bin/sac",
+        sac_usable_path=lambda: "/usr/local/bin/sac",
+        preamble_declared=lambda: False,
+        spec_source_drift=lambda: SpecSourceDrift(state="current"),
     )
     gathered = gather_target_facts(probes)
     # Act
@@ -238,6 +246,7 @@ def test_a_fully_healthy_probe_set_passes_preflight() -> None:
             session_marker="bbb2",
         ),
         from_host="ywata-note-win",
+        lease_facts=LeaseFacts(read=True, lease=None, now=1_786_500_000.0),
     )
     # Assert
     assert report.ok is True
@@ -260,7 +269,11 @@ def test_an_observed_negative_still_reaches_preflight_as_a_refusal() -> None:
     gathered = gather_target_facts(probes)
     # Act
     report = preflight(
-        agent="a", to_host="nas-03", facts=gathered.facts, runtime="apptainer"
+        agent="a",
+        to_host="nas-03",
+        facts=gathered.facts,
+        runtime="apptainer",
+        lease_facts=LeaseFacts(read=True, lease=None, now=1_786_500_000.0)
     )
     # Assert
     assert report.ok is False

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe_adapter.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe_adapter.py
@@ -26,7 +26,11 @@ from __future__ import annotations
 import pytest
 
 from scitex_agent_container._lifecycle._relocate_origin import RepoWork
-from scitex_agent_container._lifecycle._relocate_preflight import SourceFacts, preflight
+from scitex_agent_container._lifecycle._relocate_preflight import (
+    LeaseFacts,
+    SourceFacts,
+    preflight,
+)
 from scitex_agent_container._lifecycle._relocate_probe import gather_target_facts
 from scitex_agent_container._lifecycle._relocate_probe_adapter import (
     build_target_probes,
@@ -51,8 +55,11 @@ SAC_RELOC ports_checked=0
 SAC_RELOC hub=yes
 SAC_RELOC sac_path=/usr/local/bin/sac
 SAC_RELOC sac_found=/usr/local/bin/sac
+SAC_RELOC sac_usable=/usr/local/bin/sac
 SAC_RELOC runtimes=apptainer,claude-agent-sdk,tui
 SAC_RELOC speckeys=apiVersion,kind,metadata,spec
+SAC_RELOC startdrift=current|0|0|/home/ywatanabe/.dotfiles|origin/main
+SAC_RELOC startdirty=0
 SAC_RELOC end
 """
 
@@ -341,7 +348,11 @@ def test_a_truncated_batch_still_measures_most_of_the_checks(spec) -> None:
     # Act
     unobserved = set(gathered.errors)
     # Assert
-    assert unobserved == {"supported_runtimes", "rejected_spec_keys"}
+    assert unobserved == {
+        "supported_runtimes",
+        "rejected_spec_keys",
+        "spec_source_drift",
+    }
 
 
 def test_an_old_sac_on_the_target_costs_only_its_own_two_facts(spec) -> None:
@@ -477,6 +488,9 @@ def test_a_healthy_target_reaches_preflight_as_a_go(spec) -> None:
             session_marker="bbb2",
         ),
         from_host="ywata-note-win",
+        # The lease is read from the coordinator's own db, not by this batch. A
+        # store that WAS read and holds no row is supplied for the same reason.
+        lease_facts=LeaseFacts(read=True, lease=None, now=1_786_500_000.0),
     )
     # Assert
     assert report.ok is True

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe_sac.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe_sac.py
@@ -1,0 +1,258 @@
+"""Three PATHs, one preamble, and a verdict quoted rather than recomputed.
+
+The five facts about sac ITSELF on the target. Two properties are pinned here.
+
+WHICH PATH THE ANSWER IS ABOUT. ``sac_path`` is the bare non-interactive ssh
+PATH; ``sac_usable`` is that PATH plus the peer's ``env_preamble``, which is what
+:class:`._relocate_shell.Shell` prepends to every command a relocation sends.
+Measured 2026-08-11 on scitex-compute-04 the two differ, and measured 2026-08-12
+on ywata-note-win reading only the first produced a FAILING check on a host where
+everything works.
+
+AN ABSENT ANSWER IS UNKNOWN, NEVER "NO DRIFT". The start-acceptance line is
+printed by the target's OWN drift guard. An older sac there prints nothing, and
+the fact must then be undetermined — folding it into "current" would restore
+exactly the late refusal this check was added to prevent, while looking like a
+pass.
+
+The transport is driven through the ``runner`` seam with real callables returning
+canned :class:`RemoteRun` values. Nothing is mocked.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_probe import gather_target_facts
+from scitex_agent_container._lifecycle._relocate_probe_adapter import (
+    build_target_probes,
+)
+from scitex_agent_container._lifecycle._relocate_probe_ssh import RemoteRun
+
+#: A readout in the shape the real script prints, from a host where sac is on
+#: the bare PATH and the spec source is current.
+PLAIN = """SAC_RELOC begin
+SAC_RELOC epoch=1786246196
+SAC_RELOC creds_checked=1
+SAC_RELOC ports_checked=0
+SAC_RELOC sac_path=/usr/local/bin/sac
+SAC_RELOC sac_found=/usr/local/bin/sac
+SAC_RELOC sac_usable=/usr/local/bin/sac
+SAC_RELOC startdrift=current|0|0|/home/ywatanabe/.dotfiles|origin/main
+SAC_RELOC startdirty=0
+SAC_RELOC end
+"""
+
+#: scitex-compute-04, measured 2026-08-11 and again 2026-08-12: sac is off the
+#: bare PATH, the preamble finds it, and the dotfiles checkout is five commits
+#: behind with 2389 modified files.
+COMPUTE_04 = """SAC_RELOC begin
+SAC_RELOC epoch=1786246196
+SAC_RELOC creds_checked=1
+SAC_RELOC ports_checked=0
+SAC_RELOC sac_path=
+SAC_RELOC sac_found=/home/ywatanabe/.env-sac/bin/sac
+SAC_RELOC sac_usable=/home/ywatanabe/.env-sac/bin/sac
+SAC_RELOC startdrift=behind|5|0|/home/ywatanabe/.dotfiles|origin/main
+SAC_RELOC startdirty=2389
+SAC_RELOC end
+"""
+
+
+def _runner(stdout: str):
+    """A real ``run_probe_script``-shaped callable returning canned output."""
+
+    def run(host, script, *, timeout_s=60.0, **kwargs):
+        return RemoteRun(stdout=stdout, stderr="", exit_code=0)
+
+    return run
+
+
+def _facts(stdout: str, *, preamble: str = ""):
+    probes, _batch = build_target_probes(
+        "target", {}, runner=_runner(stdout), preamble=preamble, env={}
+    )
+    return gather_target_facts(probes).facts
+
+
+@pytest.fixture
+def compute_04():
+    """The measured scitex-compute-04 readout, probed WITH its peer preamble."""
+    return _facts(COMPUTE_04, preamble='export PATH="$HOME/.env-sac/bin:$PATH"')
+
+
+# ---------------------------------------------------------------------------
+# the three PATH facts
+# ---------------------------------------------------------------------------
+
+
+def test_the_bare_ssh_path_is_still_reported(compute_04) -> None:
+    # Arrange: the measured readout, probed with its peer preamble.
+    facts = compute_04
+    # Act: what `ssh compute-04 sac …` would get.
+    fact = facts.sac_on_path
+    # Assert
+    assert fact is False
+
+
+def test_the_relocation_path_is_reported_separately(compute_04) -> None:
+    # Arrange
+    facts = compute_04
+    # Act: what every command this feature sends actually gets.
+    fact = facts.sac_usable_path
+    # Assert
+    assert fact == "/home/ywatanabe/.env-sac/bin/sac"
+
+
+def test_the_direct_lookup_is_reported_too(compute_04) -> None:
+    # Arrange
+    facts = compute_04
+    # Act: separates "not installed" from "installed and unreachable".
+    fact = facts.sac_resolved_path
+    # Assert
+    assert fact == "/home/ywatanabe/.env-sac/bin/sac"
+
+
+def test_a_probe_that_carried_a_preamble_says_so(compute_04) -> None:
+    # Arrange
+    facts = compute_04
+    # Act: observed by construction — the prober knows what it sent.
+    fact = facts.preamble_declared
+    # Assert
+    assert fact is True
+
+
+def test_a_probe_with_no_preamble_says_so() -> None:
+    # Arrange
+    facts = _facts(PLAIN)
+    # Act
+    fact = facts.preamble_declared
+    # Assert
+    assert fact is False
+
+
+def test_an_empty_usable_line_is_an_answer_not_a_gap() -> None:
+    # Arrange: looked-and-found-nothing. A raise here would report UNKNOWN for a
+    # question the target answered.
+    facts = _facts(PLAIN.replace("sac_usable=/usr/local/bin/sac", "sac_usable="))
+    # Act
+    fact = facts.sac_usable_path
+    # Assert
+    assert fact == ""
+
+
+def test_a_missing_usable_line_is_unknown() -> None:
+    # Arrange: an older probe script never printed it, so nobody looked.
+    facts = _facts(
+        "\n".join(
+            ln for ln in PLAIN.splitlines() if not ln.startswith("SAC_RELOC sac_usable")
+        )
+    )
+    # Act
+    fact = facts.sac_usable_path
+    # Assert
+    assert fact is None
+
+
+# ---------------------------------------------------------------------------
+# start acceptance — the target's own verdict, quoted
+# ---------------------------------------------------------------------------
+
+
+def test_the_drift_state_is_read_back_verbatim(compute_04) -> None:
+    # Arrange
+    facts = compute_04
+    # Act
+    drift = facts.spec_source_drift
+    # Assert
+    assert drift.state == "behind"
+
+
+def test_the_commit_count_is_read_back(compute_04) -> None:
+    # Arrange
+    facts = compute_04
+    # Act
+    drift = facts.spec_source_drift
+    # Assert
+    assert drift.behind == 5
+
+
+def test_the_repo_is_read_back_so_the_hint_can_name_it(compute_04) -> None:
+    # Arrange
+    facts = compute_04
+    # Act
+    drift = facts.spec_source_drift
+    # Assert
+    assert drift.repo == "/home/ywatanabe/.dotfiles"
+
+
+def test_the_upstream_is_read_back(compute_04) -> None:
+    # Arrange
+    facts = compute_04
+    # Act
+    drift = facts.spec_source_drift
+    # Assert
+    assert drift.upstream == "origin/main"
+
+
+def test_the_dirty_count_is_read_back(compute_04) -> None:
+    # Arrange: evidence for the hint, because `pull --ff-only` aborts here.
+    facts = compute_04
+    # Act
+    drift = facts.spec_source_drift
+    # Assert
+    assert drift.dirty == 2389
+
+
+def test_a_missing_drift_line_is_unknown_not_current() -> None:
+    # Arrange: THE one to get right. An older sac on the target prints nothing.
+    facts = _facts(
+        "\n".join(
+            ln for ln in PLAIN.splitlines() if not ln.startswith("SAC_RELOC startdrift")
+        )
+    )
+    # Act
+    drift = facts.spec_source_drift
+    # Assert
+    assert drift is None
+
+
+def test_a_drift_line_with_an_empty_state_is_unknown() -> None:
+    # Arrange: the section ran and named no verdict, which is not a verdict.
+    facts = _facts(
+        PLAIN.replace(
+            "startdrift=current|0|0|/home/ywatanabe/.dotfiles|origin/main",
+            "startdrift=|0|0||",
+        )
+    )
+    # Act
+    drift = facts.spec_source_drift
+    # Assert
+    assert drift is None
+
+
+def test_a_missing_dirty_count_still_yields_a_drift_answer() -> None:
+    # Arrange: no git on the target. The dirty count is evidence, never verdict,
+    # so its absence must not cost the verdict.
+    facts = _facts(
+        "\n".join(
+            ln for ln in PLAIN.splitlines() if not ln.startswith("SAC_RELOC startdirty")
+        )
+    )
+    # Act
+    drift = facts.spec_source_drift
+    # Assert
+    assert drift.state == "current"
+
+
+def test_a_missing_dirty_count_is_reported_as_not_taken() -> None:
+    # Arrange: 0 would claim a clean tree nobody counted.
+    facts = _facts(
+        "\n".join(
+            ln for ln in PLAIN.splitlines() if not ln.startswith("SAC_RELOC startdirty")
+        )
+    )
+    # Act
+    drift = facts.spec_source_drift
+    # Assert
+    assert drift.dirty is None

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 from scitex_agent_container._lifecycle._relocate_origin import RepoWork
 from scitex_agent_container._lifecycle._relocate_preflight import (
     Check,
+    LeaseFacts,
     PreflightReport,
     SourceFacts,
+    SpecSourceDrift,
     TargetFacts,
     preflight,
 )
@@ -28,6 +30,7 @@ from scitex_agent_container._lifecycle._relocate_render import (
     VERDICT_GO,
     VERDICT_REFUSED,
     VERDICT_UNKNOWN,
+    render_coordinator_env,
     render_declared,
     render_dry_run,
     render_observed,
@@ -51,7 +54,26 @@ ALL_GOOD = TargetFacts(
     hub_reachable_from_target=True,
     sac_on_path=True,
     sac_resolved_path="/usr/local/bin/sac",
+    sac_usable_path="/usr/local/bin/sac",
+    preamble_declared=False,
+    spec_source_drift=SpecSourceDrift(state="current", upstream="origin/main"),
 )
+
+#: The lease store READ and holding no row — a real answer that bootstraps, as
+#: distinct from "nobody opened the db", which refuses. Supplied on every render
+#: for the same reason CLEAN_SOURCE is: the RENDERING is what is under test.
+CLEAN_LEASE = LeaseFacts(
+    read=True, lease=None, store="/state/state.db", now=1_786_500_000.0
+)
+
+#: A coordinator whose own environment is complete, so the dry run renders the
+#: report rather than an explanation of what is missing from this container.
+FULL_ENV = {
+    "SAC_LISTEN_BASE_URL": "http://127.0.0.1:7878",
+    "SAC_LISTEN_BEARER": "x",
+    "SAC_NAME": "scitex-agent-container",
+    "SAC_RELOCATE_HUB_ADDR": "hub.example:7878",
+}
 
 #: The source scanned and clean. Supplied on every render so the rendering
 #: itself is what is under test — a report that refuses because nobody scanned
@@ -74,6 +96,7 @@ def _report(facts: TargetFacts, runtime: str = "tui") -> PreflightReport:
         runtime=runtime,
         source_facts=CLEAN_SOURCE,
         from_host="ywata-note-win",
+        lease_facts=CLEAN_LEASE,
     )
 
 
@@ -93,7 +116,7 @@ def test_declared_section_says_it_is_unverified() -> None:
 def test_declared_and_observed_are_separate_sections() -> None:
     # Arrange: collapsing them is the `agents list` defect this guards against.
     # Act
-    text = _text(render_dry_run(_report(ALL_GOOD), declared={"runtime": "tui"}))
+    text = _text(render_dry_run(_report(ALL_GOOD), declared={"runtime": "tui"}, env=FULL_ENV))
     # Assert
     assert text.index("DECLARED") < text.index("OBSERVED")
 
@@ -203,7 +226,7 @@ def test_every_problem_is_listed_not_just_the_first() -> None:
 def test_multiple_failures_produce_a_blocking_section() -> None:
     # Arrange: the summary at the end is what gets pasted into chat.
     # Act
-    text = _text(render_dry_run(_report(THREE_BROKEN)))
+    text = _text(render_dry_run(_report(THREE_BROKEN), env=FULL_ENV))
     # Assert
     assert "BLOCKING" in text
 
@@ -211,7 +234,7 @@ def test_multiple_failures_produce_a_blocking_section() -> None:
 def test_a_clean_run_has_no_blocking_section() -> None:
     # Arrange: a GO must not print an empty scary heading.
     # Act
-    text = _text(render_dry_run(_report(ALL_GOOD)))
+    text = _text(render_dry_run(_report(ALL_GOOD), env=FULL_ENV))
     # Assert
     assert "BLOCKING" not in text
 
@@ -219,7 +242,7 @@ def test_a_clean_run_has_no_blocking_section() -> None:
 def test_the_header_names_both_agent_and_target() -> None:
     # Arrange: a dry run pasted into chat must be unambiguous on its own.
     # Act
-    head = render_dry_run(_report(ALL_GOOD))[0]
+    head = render_dry_run(_report(ALL_GOOD), env=FULL_ENV)[0]
     # Assert
     assert AGENT in head and HOST in head
 
@@ -227,7 +250,7 @@ def test_the_header_names_both_agent_and_target() -> None:
 def test_the_header_says_nothing_was_touched() -> None:
     # Arrange: the whole point of the verb is that it is safe to run.
     # Act
-    head = render_dry_run(_report(ALL_GOOD))[0]
+    head = render_dry_run(_report(ALL_GOOD), env=FULL_ENV)[0]
     # Assert
     assert "nothing was touched" in head
 
@@ -271,7 +294,7 @@ def test_the_executing_header_does_not_claim_nothing_was_touched() -> None:
     # above a report of 3.6 MB moved between two hosts.
     report = _report(ALL_GOOD)
     # Act
-    head = render_dry_run(report, dry_run=False)[0]
+    head = render_dry_run(report, dry_run=False, env=FULL_ENV)[0]
     # Assert
     assert "nothing was touched" not in head
 
@@ -281,7 +304,7 @@ def test_the_executing_header_says_both_hosts_change() -> None:
     # modes they are looking at.
     report = _report(ALL_GOOD)
     # Act
-    head = render_dry_run(report, dry_run=False)[0]
+    head = render_dry_run(report, dry_run=False, env=FULL_ENV)[0]
     # Assert
     assert "EXECUTING" in head
 
@@ -290,6 +313,101 @@ def test_the_header_still_defaults_to_the_dry_run_wording() -> None:
     # Arrange: a caller that forgets the flag must OVER-warn, not under-warn.
     report = _report(ALL_GOOD)
     # Act
-    head = render_dry_run(report)[0]
+    head = render_dry_run(report, env=FULL_ENV)[0]
     # Assert
     assert "DRY RUN" in head
+
+
+# ---------------------------------------------------------------------------
+# COORDINATOR ENVIRONMENT — nine unknowns that are not about the target at all
+#
+# Measured 2026-08-12: a coordinator container started without these four
+# variables cannot reach the listen daemon, so every target fact comes back
+# unobserved at once. An UNKNOWN refuses exactly as hard as a FAIL, so the
+# report reads as a broken relocation rather than a missing environment.
+# ---------------------------------------------------------------------------
+
+
+def test_a_complete_coordinator_environment_prints_nothing() -> None:
+    # Arrange: four lines saying "fine" on every run train the reader to skip
+    # the section on the run where it matters.
+    env = FULL_ENV
+    # Act
+    lines = render_coordinator_env(env)
+    # Assert
+    assert lines == []
+
+
+def test_a_missing_listen_url_is_named() -> None:
+    # Arrange
+    env = {**FULL_ENV, "SAC_LISTEN_BASE_URL": ""}
+    # Act
+    text = _text(render_coordinator_env(env))
+    # Assert
+    assert "UNSET    SAC_LISTEN_BASE_URL" in text
+
+
+def test_a_missing_variable_says_what_it_costs() -> None:
+    # Arrange: naming the variable without naming the consequence leaves the
+    # reader unable to connect it to the unknowns further down the report.
+    env = {**FULL_ENV, "SAC_LISTEN_BASE_URL": ""}
+    # Act
+    text = _text(render_coordinator_env(env))
+    # Assert
+    assert "NO target fact can be measured" in text
+
+
+def test_the_section_says_an_unmeasured_check_still_refuses() -> None:
+    # Arrange
+    env = {**FULL_ENV, "SAC_NAME": ""}
+    # Act
+    text = _text(render_coordinator_env(env))
+    # Assert
+    assert "REFUSES exactly as firmly" in text
+
+
+def test_a_set_variable_is_not_listed() -> None:
+    # Arrange: only what is missing, so the section is short enough to read.
+    env = {**FULL_ENV, "SAC_RELOCATE_HUB_ADDR": ""}
+    # Act
+    text = _text(render_coordinator_env(env))
+    # Assert
+    assert "SAC_LISTEN_BASE_URL" not in text
+
+
+def test_the_bearer_value_is_never_printed() -> None:
+    # Arrange: a dry run gets pasted into chat windows. Whether it is SET is the
+    # measurement; the token itself must not travel.
+    env = {**FULL_ENV, "SAC_NAME": "", "SAC_LISTEN_BEARER": "s3cret-token-value"}
+    # Act
+    text = _text(render_coordinator_env(env))
+    # Assert
+    assert "s3cret-token-value" not in text
+
+
+def test_the_dry_run_carries_the_section_when_something_is_missing() -> None:
+    # Arrange
+    env = {**FULL_ENV, "SAC_LISTEN_BEARER": ""}
+    # Act
+    text = _text(render_dry_run(_report(ALL_GOOD), env=env))
+    # Assert
+    assert "COORDINATOR ENVIRONMENT" in text
+
+
+def test_the_dry_run_omits_the_section_when_nothing_is_missing() -> None:
+    # Arrange
+    env = FULL_ENV
+    # Act
+    text = _text(render_dry_run(_report(ALL_GOOD), env=env))
+    # Assert
+    assert "COORDINATOR ENVIRONMENT" not in text
+
+
+def test_the_section_is_printed_before_the_observations_it_explains() -> None:
+    # Arrange: a reader hitting nine unknowns needs the cause above them, not
+    # after they have already concluded the target is broken.
+    env = {**FULL_ENV, "SAC_LISTEN_BASE_URL": ""}
+    # Act
+    text = _text(render_dry_run(_report(ALL_GOOD), env=env))
+    # Assert
+    assert text.index("COORDINATOR ENVIRONMENT") < text.index("OBSERVED")

--- a/tests/scitex_agent_container/cli_pkg/test__relocate_cmd.py
+++ b/tests/scitex_agent_container/cli_pkg/test__relocate_cmd.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 import click
 from click.testing import CliRunner
 
+from scitex_agent_container._lifecycle._residency import current_host
+from scitex_agent_container._state.state_db_relocation import record_residency
 from scitex_agent_container.cli_pkg._relocate_cmd import (
+    _residency_history,
     EXIT_REFUSED,
     EXIT_RETIRED_UNIMPLEMENTED,
     _required_ports,
@@ -333,3 +336,58 @@ def test_the_notice_says_nothing_is_ever_deleted() -> None:
     text = "\n".join(_readiness_notice())
     # Assert
     assert "Nothing is deleted at any point" in text
+
+
+# ---------------------------------------------------------------------------
+# WHERE IT RUNS NOW — the residency table wins over a never-ended instance row
+#
+# Measured 2026-08-12 on scitex-compute-04: `agent_residency` said
+# canary-resume-test lives on ywata-note-win (written by the relocation that
+# moved it there), while an `instances` row on scitex-compute-04 had never been
+# ended. Reading the instance row first made the command answer with the host
+# the agent had LEFT — and a relocation back was then refused with "already
+# recorded on that host — nothing to relocate".
+#
+# The stopped case makes this the NORMAL path rather than an edge one:
+# source_drain requires the agent stopped, a stopped agent has no active
+# instance row at all, and the next fallback is the spec's legacy `host:` which
+# a relocation never updates.
+# ---------------------------------------------------------------------------
+
+
+def test_the_residency_table_answers_where_the_agent_runs() -> None:
+    # Arrange: a relocation's DONE phase wrote this stay.
+    record_residency(agent="canary", host="ywata-note-win", now=1_786_490_272.0)
+    # Act
+    history = _residency_history("canary")
+    # Assert
+    assert current_host(history) == "ywata-note-win"
+
+
+def test_a_closed_stay_is_carried_too() -> None:
+    # Arrange: two moves, so the history is more than "where is it now".
+    record_residency(agent="canary", host="scitex-compute-04", now=1_786_400_000.0)
+    record_residency(agent="canary", host="ywata-note-win", now=1_786_490_272.0)
+    # Act
+    history = _residency_history("canary")
+    # Assert
+    assert len(history) == 2
+
+
+def test_the_latest_stay_is_the_open_one() -> None:
+    # Arrange
+    record_residency(agent="canary", host="scitex-compute-04", now=1_786_400_000.0)
+    record_residency(agent="canary", host="ywata-note-win", now=1_786_490_272.0)
+    # Act
+    history = _residency_history("canary")
+    # Assert
+    assert current_host(history) == "ywata-note-win"
+
+
+def test_an_agent_the_table_never_heard_of_yields_no_history() -> None:
+    # Arrange: genuinely "the db knows nothing", which is what lets a legacy
+    # spec host: seed it ONCE. An invented answer here would defeat that.
+    # Act
+    history = _residency_history("never-relocated")
+    # Assert
+    assert history == ()


### PR DESCRIPTION
A canary round trip between scitex-compute-04 and ywata-note-win proved the
relocation fix works and then found three more ways to refuse LATE. Each refusal
was correct, each was safe, and each arrived with the agent already stopped. PR
#968 established the principle — *if a relocation cannot succeed, it must refuse
while the agent is still running* — and this applies it to what the canary found.

Preflight goes from 12 checks to 14, and the two new ones are the questions the
PHASES used to ask after `source_stop`.

## BLOCKER 1 — the lease refused at `handover`, five phases too late

**What it actually was.** The lease is written to the COORDINATOR's local state
db, and the coordinator is always the host being LEFT. So after A → B the row on
A reads `holder=B` and B's own store never learns. When B moves back, the
coordinator stands on B and reads a row from an EARLIER move:

```
ywata-note-win state db:    holder=scitex-compute-04  fence 1
scitex-compute-04 state db: holder=ywata-note-win     fence 1
```

Both rows are true. Neither is current. Reading either as "another host holds
write authority" turns the SECOND move of every agent into a refusal — and it
refused at `handover`, after `source_stop`, after the transport was byte-verified,
after the standby booted and after the handshake passed.

**The fix is evidence, not a flag.** A row naming another holder is not the
split-brain by itself. The split-brain is another host RUNNING THIS AGENT, and
that is a thing to go and LOOK at with the same tmux probe the runtime uses:

| lease row | verdict |
|---|---|
| no row | proceed (bootstrap) |
| names the source | proceed |
| names another host, EXPIRED | proceed — re-claim, fence advances |
| names another host, **observed running it** | **REFUSE** — real split-brain |
| names another host, **observed not running it** | proceed — a past handover, not a writer |
| names another host, **unobserved** | UNKNOWN — go and look |

`claim()` gains `holder_absent`, which is an OBSERVATION and not a force flag: the
caller may only pass it after looking at the host the row names. What excludes the
old holder is unchanged — the fence advances exactly as it does after an expiry.

The rule lives in **one** function, `handoff_readiness`, called by the preflight
check AND by the handover phase, so a gate that passes on a phase that will refuse
is unrepresentable rather than merely discouraged.

**On residency:** the destination does NOT need to learn, and that is the honest
answer rather than the tidy one. Per-host postgres is the intended topology and
the cross-host sync primitive does not exist yet, so a lease row means "what the
last relocation I coordinated did" and is authoritative only WHEN COMBINED with an
observation of the host it names. An observation is a better proof than a TTL —
which is a guess about liveness — has ever been. Once a sync primitive exists the
observation becomes a fast path rather than the proof.

## BLOCKER 2 — nothing asked whether the target's own `sac agents start` would run

Preflight had eleven checks about the target and not one of them asked the one
command the whole relocation depends on. New check `target_start_accepts` asks the
target's OWN sac for its spec-source drift — the guard that will refuse the boot is
the only thing entitled to say whether it would, so its verdict is parsed rather
than recomputed. BEHIND / DIVERGED refuse; AHEAD / NOT_A_REPO / UNREACHABLE pass,
mirroring `DriftStatus.is_stale` exactly. A missing line is UNKNOWN, never
"no drift".

The dirty count rides along as EVIDENCE, never verdict: the remedy the guard prints
is `git pull --ff-only`, and that aborts on a dirty tree.

## BLOCKER 3 — a hint naming a step that does nothing

`check_sac_present` failed on `sac_on_path`, which is the BARE non-interactive ssh
PATH — but `Shell` prepends the peer's `env_preamble` to every command a relocation
sends, so that is not the PATH anything here uses. Measured on ywata-note-win: the
preamble was ALREADY SET, working, and the check still failed and still recommended
setting it.

The probe now also measures `sac_usable` — `command -v sac` under the PATH the
relocation's own commands run under — and that is the fact that decides.
`sac_on_path` still passes on its own; it no longer FAILS on its own. The hint
branches on whether a preamble is already declared, which is the same narrowness
`_state/_remote_sac_hint.py` already documents for the rc=127 case.

Also: the dry run now prints a **COORDINATOR ENVIRONMENT** section naming any of
`SAC_LISTEN_BASE_URL` / `SAC_LISTEN_BEARER` / `SAC_NAME` / `SAC_RELOCATE_HUB_ADDR`
that are unset, and what each costs. It prints nothing when all four are set, and
it never prints the bearer's value.

## The residency read (the "smaller thing")

`_residency_history` read `instances.host` — where a process was last recorded
STARTING, which nothing closes if it dies without a stop — before the
`agent_residency` table a relocation actually maintains. Measured on the live
fleet db: residency said `canary-resume-test` lives on ywata-note-win while an
instance row on scitex-compute-04 had never ended, so the command answered with the
host the agent had LEFT and a relocation back was refused with *"already recorded
on that host — nothing to relocate"*. The phantom row won over reality. The
residency table now answers first.
