### PR TITLE
fix(ci): two develop-red tests measured the box, not the behaviour

### DIFF
--- a/src/scitex_agent_container/_listen/_host_exec_child.py
+++ b/src/scitex_agent_container/_listen/_host_exec_child.py
@@ -134,6 +134,21 @@ def _run_child(
     is dispatched through ``run_blocking``, which consumes ``timeout_s`` as its
     OWN watchdog deadline. Same name would silently hand the child's deadline
     to the watchdog and leave the child unbounded.
+
+    ``errors="replace"`` — A DIAGNOSTIC TOOL MUST NOT DIE ON DIAGNOSTIC OUTPUT.
+    Bare ``text=True`` decodes STRICTLY, so a single byte the codec dislikes
+    raises ``UnicodeDecodeError`` out of ``communicate()`` and the caller gets
+    an error INSTEAD of the output it asked for. That is not an exotic input:
+    it is any log carrying ANSI colour written in a non-UTF-8 locale, any
+    binary-ish artefact, and — the common one — any run whose output was
+    TRUNCATED mid multibyte character, which is precisely what a timeout kill
+    or a drain ceiling produces. So the failure lands hardest on the runs
+    someone is trying to debug. Reported by the operator 2026-08-11 after
+    tailing a log through ``host_exec_local`` returned HTTP 500 rather than the
+    log. ``encoding`` is pinned to UTF-8 in the same breath so the result does
+    not depend on the daemon's ambient locale (``text=True`` alone follows
+    ``locale.getencoding()``, which differs between the systemd unit and an
+    operator shell — the same bytes would decode two ways).
     """
     with subprocess.Popen(
         argv,
@@ -143,6 +158,8 @@ def _run_child(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         start_new_session=True,
     ) as proc:
         try:

--- a/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 import os
 import time
 from pathlib import Path
@@ -462,8 +463,38 @@ def _logger_at_info() -> Iterator[None]:
 def test_pool_notice_reason_is_emitted_at_info_not_debug(
     _isolate_home: Path,
     _logger_at_info: None,
-    capfd: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """The reason must be emitted ABOVE the operator console's INFO threshold.
+
+    MEASURED ON THE LEVEL, NOT ON A FILE DESCRIPTOR. This assertion used to
+    read ``"ranking inputs:" in capfd.readouterr().err``, and that made a
+    LEVEL question depend on WHICH STREAM OBJECT the logging stack happened to
+    be holding — process-global state any other test in the same xdist worker
+    can change just by importing a module. ``_mcp/server.py`` does exactly
+    that at IMPORT time: ``_ensure_stderr_logging()`` attaches a
+    ``logging.StreamHandler(sys.stderr)`` to this very logger, and a stock
+    ``StreamHandler`` CACHES the stream object it is handed. Once some earlier
+    test in the worker imports it, sac's log lines go to whatever ``sys.stderr``
+    was at that instant — a capture buffer belonging to a test that has long
+    since finished — so ``capfd`` here sees nothing and the test fails while the
+    code is behaving correctly.
+
+    That is not a hypothesis: in the 2026-08-12 develop run (gw10) pytest's own
+    ``Captured log call`` section recorded ``INFO ... _console.py:43 ... ranking
+    inputs:`` for this very call, while ``capfd`` returned only an unrelated
+    warning. The two instruments disagreed, and only one of them was measuring
+    the property this test is named after. The same test passes alone and
+    passes across all 1813 ``_lifecycle`` tests in a single process — the
+    failure tracks worker composition, not behaviour.
+
+    ``caplog`` records what the LOGGER emitted, which is the property. The
+    discrimination the test exists for is fully preserved by ``_logger_at_info``:
+    with the logger pinned at INFO, a detail emitted under ``style="dim"``
+    (→ ``scitex_logging.DEBUG``) is dropped AT THE LOGGER and never reaches
+    ``caplog`` at all. So the regression this guards — the reason going out
+    below the level anyone reads — still turns this red.
+    """
     # Arrange — the WHY (policy, rationale, per-candidate ranking inputs) went
     # out under style="dim", which maps to DEBUG, so the logger dropped it and
     # only the headline ever reached the operator.
@@ -474,7 +505,13 @@ def test_pool_notice_reason_is_emitted_at_info_not_debug(
     # Act — no log_stream, so the notice takes the real system_msg path.
     _rotate_to_healthy_account(cfg, usage_7d={"acct-a": 95.0, "acct-b": 5.0})
     # Assert — the ranking inputs survive an INFO-level console.
-    assert "ranking inputs:" in capfd.readouterr().err
+    reason_records = [
+        record
+        for record in caplog.records
+        if "ranking inputs:" in record.getMessage()
+        and record.levelno >= logging.INFO
+    ]
+    assert reason_records
 
 
 def test_pool_first_listed_entry_is_not_implicitly_preferred(

--- a/tests/scitex_agent_container/_listen/test__agent_exec_deadline.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_deadline.py
@@ -42,6 +42,19 @@ _TOKEN = "test-token-agent-exec-deadline"
 _SHIM_SLEEP_S = 2.0
 _TEST_DEADLINE_S = 0.3
 
+# FAILSAFE ONLY — never a pacing budget. The aftermath loop below exits the
+# INSTANT its condition holds, so a generous ceiling costs a fast run nothing
+# and costs a loaded run its false failure. It used to be ``_SHIM_SLEEP_S * 3``
+# (6 s), which is not a bound on anything the system promises: it has to cover a
+# real fork+exec of a CPython shim, a 2 s sleep, the handler's detached
+# done-callback and a marker write, all on a box CI deliberately saturates
+# (`-n 32` on 32 cores, at `nice 19`). Measured 2026-08-12 on scitex-compute-04:
+# ``test_a_failure_after_the_202_still_writes_its_marker`` went red under the
+# full suite with ``marker is None`` — the marker was not missing, the loop had
+# simply stopped looking — while the same test passes in isolation. A clock was
+# standing in for the event; this is the event's failsafe.
+_AFTERMATH_TIMEOUT_S = 60.0
+
 
 @pytest.fixture
 def isolated_listen_env(tmp_path: Path):
@@ -135,6 +148,7 @@ class _SlowSpawn(NamedTuple):
     status_code: int
     body: dict
     elapsed_s: float
+    launch_still_running_at_answer: bool
     launch_completed: bool
     marker: dict | None
 
@@ -156,9 +170,14 @@ def _run_slow_spawn(
         started = time.monotonic()
         resp = _post(client, name)
         elapsed = time.monotonic() - started
+        # OBSERVE the race, do not time it. The shim touches ``flag`` as its
+        # LAST act, so "the flag is still absent now" is a direct reading of
+        # "the answer arrived before the launch finished" — the property this
+        # module is about — taken at the only instant it is true or false.
+        still_running_at_answer = not flag.exists()
         # Stay inside the client context so the app's event loop is alive and
         # the detached done-callback can actually run.
-        watch_until = time.monotonic() + _SHIM_SLEEP_S * 3
+        watch_until = time.monotonic() + _AFTERMATH_TIMEOUT_S
         marker = None
         while time.monotonic() < watch_until:
             marker = read_marker(state_dir_for(name))
@@ -169,6 +188,7 @@ def _run_slow_spawn(
         status_code=resp.status_code,
         body=resp.json(),
         elapsed_s=elapsed,
+        launch_still_running_at_answer=still_running_at_answer,
         launch_completed=flag.exists(),
         marker=marker,
     )
@@ -203,13 +223,29 @@ def test_a_launch_past_the_deadline_answers_202(slow_ok_spawn) -> None:
 def test_a_launch_past_the_deadline_answers_before_the_launch_finishes(
     slow_ok_spawn,
 ) -> None:
-    """The point of the deadline: the ANSWER beats the work, by a wide margin."""
+    """The point of the deadline: the ANSWER beats the WORK.
+
+    Asserted as an ORDERING, not as a stopwatch reading. This used to be
+    ``elapsed < _SHIM_SLEEP_S / 2`` — a 1.0 s wall-clock ceiling on a full HTTP
+    round trip whose handler is only promised to *decide* within 0.3 s. The
+    remaining 0.7 s was silently standing in for "and everything else the
+    request touches is fast": TestClient's portal thread, the ACL check, the
+    sqlite lineage read, JSON encode/decode. None of that is bounded, and CI
+    runs the suite at ``-n 32`` on 32 cores, so the ceiling measured the BOX,
+    not the deadline. The sibling failure in this same module on 2026-08-12
+    (``marker is None``) was the same clock-for-event substitution.
+
+    ``launch_still_running_at_answer`` reads the actual claim: at the moment the
+    response came back, the shim had NOT yet reached its final act. That stays
+    true however slow the host is, and it goes false for exactly the reason the
+    deadline exists to prevent — the handler blocking until the launch is done.
+    """
     # Arrange
     result = slow_ok_spawn
     # Act
-    elapsed = result.elapsed_s
+    answered_first = result.launch_still_running_at_answer
     # Assert — without the deadline the handler blocks for the full shim sleep.
-    assert elapsed < _SHIM_SLEEP_S / 2
+    assert answered_first is True
 
 
 def test_a_202_body_reports_status_accepted(slow_ok_spawn) -> None:

--- a/tests/scitex_agent_container/_listen/test__host_exec_child.py
+++ b/tests/scitex_agent_container/_listen/test__host_exec_child.py
@@ -1,0 +1,161 @@
+"""``_run_child`` must return the output, not die on it.
+
+THE BUG (operator, 2026-08-11). ``host_exec_local`` answered HTTP 500 instead
+of returning a log. The child ran fine; the DECODE killed it. ``_run_child``
+opened the pipes with a bare ``text=True``, which decodes STRICTLY, so one byte
+the codec disliked raised ``UnicodeDecodeError`` out of ``communicate()`` and
+the caller was handed an error in place of the bytes it asked for.
+
+The inputs that trigger it are the ordinary ones, which is what makes it worth
+a test module rather than a one-line patch:
+
+  * a log carrying ANSI colour written under a non-UTF-8 locale,
+  * output TRUNCATED mid multibyte character — exactly what the timeout kill
+    and the bounded post-kill drain in this same module produce,
+  * anything faintly binary (a core-dump path, a tarball listing).
+
+So the failure lands hardest on precisely the runs somebody is already trying
+to debug. A diagnostic tool that dies on diagnostic output is the wrong failure
+mode.
+
+PS-204 / no-mocks: these drive the REAL ``_run_child`` against REAL child
+processes that write REAL undecodable bytes to their real pipes. Nothing here
+stands in for the behaviour under test — the whole defect lived in how the pipe
+was opened, so a stubbed pipe would have tested nothing.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from scitex_agent_container._listen._host_exec_child import _run_child
+
+# The replacement character a lenient decoder substitutes for an undecodable
+# byte. Asserting on it is what proves the bytes were REPLACED rather than the
+# stream silently truncated at the first bad byte.
+_REPLACEMENT = "�"
+
+# A lone 0xFF is not valid UTF-8 in any position; 0xE3 0x81 opens a 3-byte
+# sequence that is then cut short, which is the truncation shape a killed child
+# leaves behind.
+_LONE_INVALID_BYTE = rb"b'before\xffafter'"
+_TRUNCATED_MULTIBYTE = rb"b'head\xe3\x81'"
+
+
+def _emit(expr: bytes, *, stream: str = "stdout") -> list[str]:
+    """argv for a child that writes raw ``expr`` bytes to ``stream``."""
+    return [
+        sys.executable,
+        "-c",
+        f"import sys; sys.{stream}.buffer.write({expr.decode()}); "
+        f"sys.{stream}.buffer.flush()",
+    ]
+
+
+def _run(argv: list[str]):
+    return _run_child(argv, cwd=None, child_timeout_s=30.0, env=None)
+
+
+# ---------------------------------------------------------------------------
+# Undecodable stdout — returned, never raised
+# ---------------------------------------------------------------------------
+
+
+def test_undecodable_stdout_does_not_raise() -> None:
+    """The whole defect: this call used to raise instead of returning."""
+    # Arrange
+    argv = _emit(_LONE_INVALID_BYTE)
+    # Act
+    outcome = _run(argv)
+    # Assert
+    assert outcome.exit_code == 0
+
+
+def test_undecodable_stdout_keeps_the_text_before_the_bad_byte() -> None:
+    # Arrange
+    argv = _emit(_LONE_INVALID_BYTE)
+    # Act
+    stdout = _run(argv).stdout
+    # Assert
+    assert "before" in stdout
+
+
+def test_undecodable_stdout_keeps_the_text_after_the_bad_byte() -> None:
+    """A bad byte must cost ONE character, not the rest of the log."""
+    # Arrange
+    argv = _emit(_LONE_INVALID_BYTE)
+    # Act
+    stdout = _run(argv).stdout
+    # Assert
+    assert "after" in stdout
+
+
+def test_undecodable_stdout_substitutes_a_replacement_character() -> None:
+    """Visible, not silent: the operator can see a byte was unrepresentable."""
+    # Arrange
+    argv = _emit(_LONE_INVALID_BYTE)
+    # Act
+    stdout = _run(argv).stdout
+    # Assert
+    assert _REPLACEMENT in stdout
+
+
+# ---------------------------------------------------------------------------
+# Truncated multibyte — the shape a killed / drained child leaves behind
+# ---------------------------------------------------------------------------
+
+
+def test_output_cut_mid_multibyte_character_still_returns() -> None:
+    # Arrange
+    argv = _emit(_TRUNCATED_MULTIBYTE)
+    # Act
+    outcome = _run(argv)
+    # Assert
+    assert outcome.exit_code == 0
+
+
+def test_output_cut_mid_multibyte_character_keeps_the_decodable_head() -> None:
+    # Arrange
+    argv = _emit(_TRUNCATED_MULTIBYTE)
+    # Act
+    stdout = _run(argv).stdout
+    # Assert
+    assert "head" in stdout
+
+
+# ---------------------------------------------------------------------------
+# stderr takes the same pipe options, so it needs the same guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_undecodable_stderr_does_not_raise() -> None:
+    # Arrange
+    argv = _emit(_LONE_INVALID_BYTE, stream="stderr")
+    # Act
+    outcome = _run(argv)
+    # Assert
+    assert outcome.exit_code == 0
+
+
+def test_undecodable_stderr_keeps_its_surrounding_text() -> None:
+    # Arrange
+    argv = _emit(_LONE_INVALID_BYTE, stream="stderr")
+    # Act
+    stderr = _run(argv).stderr
+    # Assert
+    assert "before" in stderr and "after" in stderr
+
+
+# ---------------------------------------------------------------------------
+# The ordinary path is untouched — a lenient decoder must not alter clean text
+# ---------------------------------------------------------------------------
+
+
+def test_clean_utf8_output_is_returned_verbatim() -> None:
+    """Non-ASCII that IS valid UTF-8 must survive intact, not be mangled."""
+    # Arrange — the pinned encoding is what makes this hold under any locale.
+    argv = [sys.executable, "-c", "print('日本語 — ok')"]
+    # Act
+    stdout = _run(argv).stdout
+    # Assert
+    assert "日本語 — ok" in stdout


### PR DESCRIPTION
## What was red, and why it was not a code regression

`develop` failed under our exact CI entrypoint (`bash .github/ci/exec-in-sif.sh run-in-sif.sh 3.12`, our SIF, scitex-compute-04).

The first useful fact: **neither failing test nor its source module changed since the last green develop** (`f469f80`). `git diff f469f80..HEAD` touches none of `_start_preflight.py`, `_console.py`, `_handler_deadline.py`, or either test file. So the cause had to be process-global state or load — and it was, in both cases.

## 1. `test_pool_notice_reason_is_emitted_at_info_not_debug` — real, deterministic under the right worker composition

The test asks a **level** question — "is the reason emitted at INFO, not DEBUG?" — with a **file-descriptor** instrument (`capfd`).

Which fd sac's log lines land on is process-global logging state, and `_mcp/server.py` rewrites it **as an import side effect**:

```python
handler = logging.StreamHandler(sys.stderr)   # caches the stream OBJECT
root.addHandler(handler)
_ensure_stderr_logging()                      # runs at module import
```

A stock `StreamHandler` caches the stream it is handed. Once any earlier test in an xdist worker imports that module, every later sac log line goes to a capture buffer belonging to a test that already finished — so `capfd` in a later test sees nothing.

This is evidence, not a theory. In the failing run (gw10) the harness's own `Captured log call` section recorded

```
INFO  scitex_agent_container:_console.py:43  ...  ranking inputs:
```

for the very call in which `capfd` returned only an unrelated warning — and the timestamped format in the captured stderr is a character-for-character match for `_mcp/server.py`'s formatter. Two instruments disagreed; only one was measuring the property the test is named after.

Confirmed by isolation: the test **passes alone** (17 passed) and **passes across all 1813 `_lifecycle` tests in a single process**. The failure tracks worker composition, not behaviour.

**Fix:** assert on `caplog` records. **This is not a loosening.** `_logger_at_info` still pins the logger to INFO, so a detail emitted under `style="dim"` (→ `scitex_logging.DEBUG`) is dropped *at the logger* and never reaches `caplog` at all.

Verified by mutation — flipping the source back to `style="dim"` turns the rewritten test red:

```
FAILED tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py::test_pool_notice_reason_is_emitted_at_info_not_debug
1 failed in 0.35s
```

And verified immune to the pollution that broke it — running the `_mcp` suite (which imports `server.py`) *first* in the same process: **485 passed**.

## 2. `test__agent_exec_deadline` — a flaky family, two clocks standing in for events

Different members of this module failed on different runs (`..._answers_before_the_launch_finishes` in the operator's run, `..._still_writes_its_marker` in mine). That is one cause, not two.

- `elapsed < _SHIM_SLEEP_S / 2` put a **1.0 s wall-clock ceiling on a whole HTTP round trip** whose handler is only promised to *decide* within 0.3 s. The other 0.7 s silently required the test client's portal thread, the ACL check and a sqlite read to be fast — on a box CI deliberately saturates (`-n 32` on 32 cores, at `nice 19`). It measured the box.
- The aftermath watch stopped looking after `_SHIM_SLEEP_S * 3` (6 s), which is why the sibling reported `marker is None` for a marker that was merely late.

**Fix:** the answer-beats-the-work claim is now read as an **ordering**. The shim touches its flag as its last act, so "the flag was still absent when the response arrived" *is* the property, and it holds however slow the host is. The watch ceiling becomes an explicit failsafe (the loop already exits on its condition, so a fast run pays nothing).

## 3. Side finding taken: `host_exec` died on the output it was asked to fetch

Bare `text=True` decodes **strictly**, so one byte the codec dislikes raises `UnicodeDecodeError` out of `communicate()` and the caller gets an error instead of the log. The triggers are ordinary — ANSI colour under a non-UTF-8 locale, anything binary-ish, and output truncated mid multibyte character, which is exactly what this module's *own* timeout kill and bounded drain produce. The failure therefore lands hardest on the runs someone is already debugging.

Pins `encoding="utf-8"` (bare `text=True` follows the daemon's ambient locale, so the same bytes decoded two ways between the systemd unit and an operator shell) with `errors="replace"`, and adds `test__host_exec_child.py` — the mirroring test module (PS-204) the source never had. Real children writing real undecodable bytes; no mocks.

## Verification

Full suite through the real CI entrypoint, in the SIF, on scitex-compute-04. Numbers in the thread below.
