### PR TITLE
perf(ci): bracket the range on the PR gate (3.11+3.13), move 3.12 to a hosted nightly

### DIFF
--- a/.github/ci/run-on-hosted.sh
+++ b/.github/ci/run-on-hosted.sh
@@ -58,6 +58,19 @@ uv pip install --python "$PY" -e ".[all,dev]" ||
     uv pip install --python "$PY" -e "."
 uv pip install --python "$PY" tzdata || true
 
+# THE VENV'S bin/ MUST BE ON PATH, because several tests exec the `sac` CONSOLE
+# SCRIPT as a subprocess (the shell-completion install tests, the SDK channel
+# sidecar resolver). Without this the first hosted run reported SIX failures out
+# of 14991 — all of them this one cause, and all of them reading like real bugs:
+#
+#   SacBinaryNotFoundError: Cannot resolve the `sac` console script: not on PATH
+#   ...test_install_writes_bash_cache_file - assert False where False = is_file()
+#
+# run-in-sif.sh has the same requirement and solves it by hand-writing shims,
+# because `pip install --target` does not materialise entry points at all. A
+# venv install DOES create them — they just have to be reachable.
+export PATH="$PWD/.venv-$V/bin:$PATH"
+
 # ASSERT THE PLUGIN SET BEFORE TRUSTING A SINGLE PASS/FAIL COUNT.
 # NOT `-q`: quiet suppresses the `plugins:` header this reads, and the first
 # version of this check shipped that way and failed every job it was added to.

--- a/.github/ci/run-on-hosted.sh
+++ b/.github/ci/run-on-hosted.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Runs the suite on a GitHub-HOSTED runner. $1 = python version.
+#
+# The nightly-only sibling of run-in-sif.sh. Same suite, different hardware and
+# therefore a different install path: there is no ci-cpu.sif here and no baked
+# /opt/venv-<ver>, so uv fetches its OWN managed CPython and builds a venv.
+#
+# WHY A SEPARATE SCRIPT AND NOT A FLAG ON run-in-sif.sh: that script's entire
+# body is SIF-specific (read-only /opt venvs, a read-only $HOME, --target
+# installs, node-local scratch that must be reaped). None of it applies here,
+# and threading an `if hosted` through it would put the release gate's script
+# one typo away from behaving differently on the path that ships. Two scripts,
+# each honest about its environment.
+#
+# WHAT IS DELIBERATELY COPIED FROM run-in-sif.sh, because it is not
+# environment-specific but SUITE-specific — get any of it wrong and the run
+# reports something other than "does the code work on this Python":
+#
+#   * commit signing OFF (dozens of tests commit into throwaway repos),
+#   * TZ=Asia/Tokyo (~290 clock assertions assume +09:00),
+#   * MPLBACKEND=Agg + a warmed font cache before xdist forks,
+#   * the pytest PLUGIN PREFLIGHT — a run that quietly lost pytest-asyncio
+#     invents ~93 failures that look exactly like a real regression, and can
+#     also go green by not collecting. Nightly output nobody can interpret is
+#     worse than no nightly.
+set -euo pipefail
+
+V="${1:?python version arg required (e.g. 3.12)}"
+
+export LC_ALL=C.UTF-8 LANG=C.UTF-8
+
+# Never sign commits made by the test suite (see run-in-sif.sh for the full
+# story: the error surfaces as "fatal: failed to write commit object", which
+# reads like a full disk and cost most of an afternoon once).
+export GIT_CONFIG_COUNT=2
+export GIT_CONFIG_KEY_0=commit.gpgsign
+export GIT_CONFIG_VALUE_0=false
+export GIT_CONFIG_KEY_1=tag.gpgsign
+export GIT_CONFIG_VALUE_1=false
+
+# ~290 clock-format assertions in this suite assume +09:00. The hosted image is
+# UTC, so without this the nightly would be red on the clock, not on the code.
+export TZ="Asia/Tokyo"
+
+export MPLBACKEND=Agg
+export MPLCONFIGDIR="${RUNNER_TEMP:-/tmp}/mpl-$V"
+mkdir -p "$MPLCONFIGDIR"
+
+# uv's own managed CPython — actions/setup-python is not used anywhere in this
+# repo (it fails on the self-hosted nodes) and there is no reason to diverge.
+uv venv --python "$V" ".venv-$V"
+PY="$PWD/.venv-$V/bin/python"
+
+# Same fallback chain as the SIF path: [all,dev] -> [dev] -> bare, so one
+# unbuildable optional extra degrades the nightly instead of stranding it.
+uv pip install --python "$PY" -e ".[all,dev]" ||
+    uv pip install --python "$PY" -e ".[dev]" ||
+    uv pip install --python "$PY" -e "."
+uv pip install --python "$PY" tzdata || true
+
+# ASSERT THE PLUGIN SET BEFORE TRUSTING A SINGLE PASS/FAIL COUNT.
+# NOT `-q`: quiet suppresses the `plugins:` header this reads, and the first
+# version of this check shipped that way and failed every job it was added to.
+_PLUGCHECK="$(mktemp -d)"
+_PLUGINS="$("$PY" -m pytest --collect-only -p no:cacheprovider "$_PLUGCHECK" 2>&1 |
+    grep -m1 '^plugins:' || true)"
+echo "preflight ${_PLUGINS:-plugins: <no header emitted>}"
+for _need in asyncio xdist cov timeout; do
+    case "$_PLUGINS" in
+    *"$_need"*) ;;
+    *)
+        echo "::error::pytest plugin '$_need' did NOT load in this environment."
+        echo "::error::header was: ${_PLUGINS:-<none>}"
+        echo "::error::Refusing to run the suite — every pass/fail count from" \
+            "this run would be untrustworthy."
+        exit 1
+        ;;
+    esac
+done
+
+# Warm the matplotlib font cache once, pre-fork, so xdist workers do not race to
+# build it (that race produces render1 != render2 reproducibility flakes).
+if "$PY" -c "import matplotlib" 2>/dev/null; then
+    "$PY" -c "import matplotlib; matplotlib.use('Agg'); from matplotlib import font_manager; font_manager.fontManager; import matplotlib.pyplot as plt; f=plt.figure(); f.canvas.draw(); print('mpl font cache warmed')"
+else
+    echo "matplotlib not importable — skipping font-cache warm-up (not a dep)"
+fi
+
+NPROC="$(nproc 2>/dev/null || echo 2)"
+echo "python=$("$PY" -V) xdist workers=$NPROC"
+
+# No --cov here: coverage is uploaded from the PR/branch gate, and the extra
+# ~15% runtime buys a hosted runner nothing but wall clock.
+exec "$PY" -m pytest tests/ -n "$NPROC" --dist load -q -p no:cacheprovider

--- a/.github/hosted-runner-allowlist.yaml
+++ b/.github/hosted-runner-allowlist.yaml
@@ -3,9 +3,24 @@
 # ─────────────────────────────────────────────────────────────────────────────
 #
 # Operator directive, 2026-07-14: GitHub-hosted runners are FORBIDDEN.
-# Every job runs on the self-hosted Spartan pool. Mandatory, no exceptions.
-# If the pool is broken, that is OUR problem to fix — escaping back to a
-# hosted runner is not an option.
+# Every job runs on the self-hosted pool. If the pool is broken, that is OUR
+# problem to fix — escaping back to a hosted runner is not an option.
+#
+# AMENDED 2026-08-12. The directive above shipped with the words "mandatory, no
+# exceptions" while cla.yml was ALREADY a deliberate exception, so the rule as
+# written was never true — and a rule that is visibly false in one place stops
+# being believed in the others. The operator amended it on 2026-08-12
+# (「nightly で 3.12, 3.13 を pure github で回せばよいかと」). What is true now:
+#
+#   * Anything a HUMAN WAITS ON — the PR gate, lint, import-smoke, docs — runs
+#     on our pool. That half of the rule is unchanged and absolute.
+#   * A job nobody waits on MAY run on GitHub's hardware when there is an
+#     argument for it, and the argument lives HERE. Two exist today: cla.yml
+#     (security — see below) and the nightly 3.12/3.13 matrix (cost).
+#
+# "No hosted runners, no exceptions" is therefore now spelled "no hosted runners
+# outside this file". The enforcement did not change: an entry still needs a
+# reason of substance, and a stale entry still fails the guard.
 #
 # Enforced by `src/scitex_agent_container/_hosted_runner_guard.py`, which runs
 #   - as a CI job on the SELF-HOSTED pool
@@ -35,6 +50,31 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 allow:
+  - workflow: nightly-python-matrix-on-github-hosted.yml
+    jobs:
+      - test
+      - notify
+    approved_by: operator
+    approved_on: 2026-08-12
+    # 「nightly で 3.12, 3.13 を pure github で回せばよいかと」 — the operator,
+    # amending the 2026-07-14 directive after being shown that four CPU runners
+    # were saturated while three banned Spartan machines sat idle.
+    reason: >-
+      COST, and it only spends hardware we do not own. Our CPU pool is four
+      contended nodes; on 2026-08-11/12 all four were saturated by stacked PRs
+      each fanning out a three-way python matrix of the heaviest job on the
+      queue. The pull-request gate now runs the ENDS of the supported range
+      (3.11 + 3.13) on our pool, and the one version it brackets past (3.12)
+      runs HERE, nightly, on GitHub's hardware — which is free for public repos
+      and slow, a trade that is exactly right when nobody is waiting and exactly
+      wrong for the PR loop a human sits in front of. The security argument that
+      keeps cla.yml hosted does NOT apply in reverse here: this job runs our own
+      code from our own repo, so moving it to the self-hosted pool would be safe
+      — it would simply spend contended hardware to buy nothing. Do not "fix" it
+      by migrating it. If this exception is ever removed, the middle version
+      loses its daily coverage and is then tested only on `develop`/`main`
+      pushes and at release.
+
   - workflow: cla.yml
     jobs:
       - CLAssistant

--- a/.github/hosted-runner-allowlist.yaml
+++ b/.github/hosted-runner-allowlist.yaml
@@ -60,10 +60,14 @@ allow:
     # amending the 2026-07-14 directive after being shown that four CPU runners
     # were saturated while three banned Spartan machines sat idle.
     reason: >-
-      COST, and it only spends hardware we do not own. Our CPU pool is four
-      contended nodes; on 2026-08-11/12 all four were saturated by stacked PRs
-      each fanning out a three-way python matrix of the heaviest job on the
-      queue. The pull-request gate now runs the ENDS of the supported range
+      COST, and it only spends hardware we do not own. Our CPU pool is
+      contended — on 2026-08-11/12 every node was saturated by stacked PRs each
+      fanning out a three-way python matrix of the heaviest job on the queue —
+      and it is being resized this week (the spartan nodes are being re-admitted
+      once scitex-dev #575-#578 land), so the argument here is deliberately
+      about WHO IS WAITING rather than about how many machines we have: a
+      nightly has no waiting human and should not hold a slot a PR could use.
+      The pull-request gate now runs the ENDS of the supported range
       (3.11 + 3.13) on our pool, and the one version it brackets past (3.12)
       runs HERE, nightly, on GitHub's hardware — which is free for public repos
       and slow, a trade that is exactly right when nobody is waiting and exactly

--- a/.github/workflows/nightly-python-matrix-on-github-hosted.yml
+++ b/.github/workflows/nightly-python-matrix-on-github-hosted.yml
@@ -1,0 +1,166 @@
+name: nightly-matrix
+
+# THE ONE VERSION THE PR GATE SKIPS, RUN HERE — ON SOMEONE ELSE'S HARDWARE.
+#
+# MEASURED 2026-08-11/12: all four of our CPU runners saturated, several stacked
+# PRs each fanning out a three-way matrix of the heaviest job on the queue, and
+# a human sitting in front of every one of those PRs. The `tests` gate therefore
+# now runs the ENDS of the supported range (3.11 + 3.13) on a pull request.
+#
+# THIS MATRIX IS THIN ON PURPOSE — one leg, 3.12 — and that is not an oversight
+# to be "completed" later: it is exactly and only the middle version the PR gate
+# brackets past. If a future Python bump widens the supported set, the versions
+# that fall between the ends belong here, and
+# tests/integration/test_ci_python_matrix_shape.py fails until they are.
+#
+# WHY GitHub-HOSTED, WHICH IS A DELIBERATE AMENDMENT TO A STANDING RULE
+# ====================================================================
+# The 2026-07-14 operator directive read "NO GitHub-hosted runners anywhere in
+# this repo, PR tests included, no exceptions". The operator amended it on
+# 2026-08-12 (「nightly で 3.12, 3.13 を pure github で回せばよいかと」): the PR
+# loop stays on our pool, the nightly moves to GitHub's. (He then moved 3.13
+# back onto the PR gate — 「最低と最高」, test the ends — which is why only 3.12
+# is left here.)
+#
+# The argument is a cost/latency split, not a loophole:
+#
+#   * our runners are SCARCE and CONTENDED — four nodes, saturated nightly by
+#     the fleet's own PRs;
+#   * GitHub-hosted runners are FREE for public repositories and SLOW;
+#   * nobody waits on a nightly. Slow is free here, and free is the point.
+#
+# The exception is registered in .github/hosted-runner-allowlist.yaml with its
+# argument attached, where _hosted_runner_guard.py enforces it. Do not "fix"
+# this file by moving it onto the self-hosted pool — that spends contended
+# hardware to buy nothing, and the guard will not stop you, because the entry
+# makes it legal. Read the allowlist entry first.
+#
+# WHY THIS IS NOT THE THING BETWEEN A REGRESSION AND A RELEASE
+# ===========================================================
+# It is the EARLY WARNING, not the gate. The release path
+# (pypi-publish-and-github-release-on-tag.yml) runs the FULL 3.11/3.12/3.13
+# matrix in the release SIF before anything reaches PyPI, and pushes to
+# `develop`/`main` run the full matrix too. So a 3.12-only regression is caught
+# at the merge, again by this nightly, and again at the tag — this workflow
+# exists so that the news arrives in hours instead of at release ceremony.
+#
+# A RED NIGHTLY THAT NOBODY READS IS THE SAME AS NOT TESTING. The `notify` job
+# below opens (or comments on) a GitHub issue on every scheduled failure, so a
+# red night lands in the same place the fleet already looks for work rather than
+# in a runs list nobody opens.
+
+on:
+  schedule:
+    # 17:00 UTC (~02:00 JST). Same slot as the SIF nightly — different hardware,
+    # so they do not compete.
+    - cron: "0 17 * * *"
+  workflow_dispatch:
+  # SELF-TESTING: a pull request that TOUCHES this workflow (or the script it
+  # runs) runs it. Without this, the only way to learn that the nightly broke is
+  # to wait for the night, and the person who broke it is asleep. It costs our
+  # pool nothing — this job is hosted — and it fires on nothing else, so the
+  # 3.11-only PR gate stays 3.11-only for every ordinary PR.
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - .github/workflows/nightly-python-matrix-on-github-hosted.yml
+      - .github/ci/run-on-hosted.sh
+
+# Same expression as every other PR-triggered workflow here (PR #969): PR events
+# group by PR number so a new push cancels the stale run; everything else keys on
+# the unique run id, so a scheduled run is alone in its group and can neither
+# cancel nor be cancelled. The matrix width has no bearing on this — the group is
+# resolved per RUN, not per leg — so the reduced PR matrix does not move any job
+# into a different group.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: nightly-py${{ matrix.python-version }}-on-github-hosted
+    # GitHub-HOSTED, on purpose. Allowlisted in
+    # .github/hosted-runner-allowlist.yaml — read the entry before changing it.
+    runs-on: ubuntu-latest
+    # Hosted runners are 4-core and this suite is ~2460 tests; the self-hosted
+    # legs finish in ~11 min on far more cores. 90 minutes is slack, not a
+    # target — a hung leg still has to die well short of GitHub's 6-hour default.
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        # THE COMPLEMENT OF THE PR GATE, NOT AN INDEPENDENT LIST.
+        # tests/integration/test_ci_python_matrix_shape.py asserts this equals
+        # the full supported set MINUS what the PR gate runs, so adding 3.14 to
+        # the matrix in pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml and
+        # forgetting this file turns that test RED instead of silently leaving
+        # a version untested at night.
+        python-version: ["3.12"]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: astral-sh/setup-uv@v3
+        with:
+          # PINNED for the same reason as everywhere else in this repo: an
+          # unpinned `latest` makes CI a function of wall-clock time.
+          version: "0.11.29"
+          cache-dependency-glob: pyproject.toml
+
+      # tmux is a RUNTIME dependency of the thing under test (sac drives agent
+      # sessions through tmux), not a test convenience. The self-hosted nodes and
+      # the CI SIF both have it; GitHub's image does not guarantee it, and a
+      # missing binary would show up as a wall of unrelated failures.
+      - name: Install tmux (present in the SIF, not guaranteed on the hosted image)
+        run: |
+          set -euo pipefail
+          command -v tmux >/dev/null || sudo apt-get install -y --no-install-recommends tmux
+          tmux -V
+
+      - name: Run the suite on python ${{ matrix.python-version }}
+        run: bash .github/ci/run-on-hosted.sh ${{ matrix.python-version }}
+
+  notify:
+    # A NIGHTLY NOBODY READS IS NOT A TEST. This is where a red night surfaces.
+    name: report-a-red-night
+    needs: test
+    # `failure()` only, and only for the SCHEDULED run: a PR that is editing this
+    # workflow gets its answer on the PR itself, and must not open issues.
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    timeout-minutes: 10
+    steps:
+      - name: Open or update the nightly-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          title="[nightly] python matrix failed on the hosted runner"
+          # ONE issue, reopened and commented — not one issue per night. A
+          # nightly that files 30 identical issues in a month teaches everyone
+          # to filter it out, which is the same as not reporting.
+          num="$(gh issue list --repo "$REPO" --state all --limit 20 \
+                   --search "in:title \"$title\"" --json number,title \
+                   --jq "[.[] | select(.title == \"$title\") | .number] | first // empty")"
+          body="The nightly 3.12 matrix failed on ${GITHUB_SHA:-develop}.
+
+          Run: $RUN_URL
+
+          3.12 is NOT on the pull-request gate (which brackets the range with
+          3.11 + 3.13) — so this is the earliest signal that a middle-version
+          regression exists. The release gate runs all three versions and will block a tag
+          on the same fault, later and more expensively."
+          if [ -n "$num" ]; then
+            gh issue reopen "$num" --repo "$REPO" >/dev/null 2>&1 || true
+            gh issue comment "$num" --repo "$REPO" --body "$body"
+            echo "commented on existing issue #$num"
+          else
+            gh issue create --repo "$REPO" --title "$title" --body "$body"
+          fi

--- a/.github/workflows/nightly-python-matrix-on-github-hosted.yml
+++ b/.github/workflows/nightly-python-matrix-on-github-hosted.yml
@@ -2,7 +2,7 @@ name: nightly-matrix
 
 # THE ONE VERSION THE PR GATE SKIPS, RUN HERE — ON SOMEONE ELSE'S HARDWARE.
 #
-# MEASURED 2026-08-11/12: all four of our CPU runners saturated, several stacked
+# MEASURED 2026-08-11/12: every one of our CPU runners saturated, several stacked
 # PRs each fanning out a three-way matrix of the heaviest job on the queue, and
 # a human sitting in front of every one of those PRs. The `tests` gate therefore
 # now runs the ENDS of the supported range (3.11 + 3.13) on a pull request.
@@ -24,10 +24,16 @@ name: nightly-matrix
 #
 # The argument is a cost/latency split, not a loophole:
 #
-#   * our runners are SCARCE and CONTENDED — four nodes, saturated nightly by
-#     the fleet's own PRs;
+#   * our runners are CONTENDED — every slot one of them spends on a version
+#     nobody is waiting for is a slot a PR is queued behind;
 #   * GitHub-hosted runners are FREE for public repositories and SLOW;
 #   * nobody waits on a nightly. Slow is free here, and free is the point.
+#
+# THE SIZE OF OUR POOL IS NOT THE ARGUMENT, and this file deliberately does not
+# quote a number: capacity is being changed this week (the spartan nodes are
+# being re-admitted to CI once scitex-dev #575-#578 land, which would take the
+# pool from four to seven). Even on the larger pool the trade holds — a nightly
+# has no waiting human, so it should not consume a slot that a PR could use.
 #
 # The exception is registered in .github/hosted-runner-allowlist.yaml with its
 # argument attached, where _hosted_runner_guard.py enforces it. Do not "fix"

--- a/.github/workflows/pypi-publish-and-github-release-on-tag.yml
+++ b/.github/workflows/pypi-publish-and-github-release-on-tag.yml
@@ -60,6 +60,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # ALL THREE, UNCONDITIONALLY, AND WRITTEN OUT RATHER THAN REFERENCED.
+        #
+        # The PR gate narrowed to the ends of the range on 2026-08-12 (3.11 +
+        # 3.13; the middle moved to a hosted nightly) because a human waits on
+        # it. NOTHING about that narrowing may reach this job: a release has
+        # correctness as its only job and nobody is waiting on it, so it pays
+        # for full coverage. That is also why there is no shared "matrix
+        # variable" for the two to read — a single referenced list is one edit
+        # away from silently narrowing the release too, which is the exact
+        # half-applied shape this fleet keeps getting caught by. The lists are
+        # instead kept in agreement by
+        # tests/integration/test_ci_python_matrix_shape.py, which fails if this
+        # one stops being the full supported set or grows an event condition.
+        #
+        # AND IT RUNS ON OUR POOL, not on the hosted runner the nightly uses:
+        # this gate exists to be byte-identical to what ships (same SIF, same
+        # xdist invocation, same runner expression). Divergence between the
+        # release gate and the release itself is what left PyPI at 0.21.17 while
+        # eight tags shipped nothing — see the header of
+        # pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml.
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: Resolve version

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -23,25 +23,39 @@ name: tests
 # pypi-publish-and-github-release-on-tag.yml. Not "an equivalent setup" —
 # the same bytes. Green PR => green release, by construction.
 #
-# RUNNER RULE, AS AMENDED 2026-08-12 (read this before "fixing" anything below).
+# WHERE THIS RUNS, AND WHY — WRITTEN AS A PRINCIPLE, NOT AS AN ABSOLUTE.
 #
-# The 2026-07-14 rule was "NO GitHub-hosted runners anywhere in this repo, PR
-# tests included, no exceptions". That sentence was already false in one place
-# (cla.yml, a deliberate SECURITY carve-out — see
-# .github/hosted-runner-allowlist.yaml), and the operator amended it on
-# 2026-08-12 to make a second, deliberate exception. What is true now:
+# This header used to read "Operator rule (2026-07-14, absolute, no exceptions):
+# NO GitHub-hosted runners anywhere in this repo, PR tests included." That
+# sentence was FALSE ON THE DAY IT WAS WRITTEN — cla.yml has always been a
+# deliberate security carve-out — and it went on being quoted as an absolute
+# into six other workflow files. An absolute with live exceptions does not get
+# obeyed; it gets discovered, disbelieved, and worked around. So this states the
+# PRINCIPLE and points at the mechanism, rather than asserting a rule that the
+# next operator decision will falsify again:
 #
-#   * THIS gate — and every other check a human waits on — runs on OUR pool,
-#     via `vars.CI_RUNS_ON`. There is still deliberately NO `ubuntu-latest`
-#     escape hatch below; adding one HERE is the bug, not the fix. If our pool
+#   * ANYTHING A HUMAN WAITS ON RUNS ON HARDWARE WE CONTROL — this gate, lint,
+#     import-smoke, docs. That is why there is deliberately no `ubuntu-latest`
+#     escape hatch below: adding one HERE is the bug, not the fix. If our pool
 #     misbehaves, that is OURS to fix.
-#   * The NIGHTLY 3.12 matrix runs on GitHub-HOSTED runners, on purpose
-#     (nightly-python-matrix-on-github-hosted.yml). Nobody waits on a nightly,
-#     hosted runners are free for public repos, and our four CPU nodes are
-#     contended — so the nightly buys coverage with someone else's hardware.
-#   * Every exception lives in .github/hosted-runner-allowlist.yaml WITH its
-#     argument attached, and is machine-enforced by _hosted_runner_guard.py.
-#     "No hosted runners" is now shorthand for "none outside that allowlist".
+#   * A JOB NOBODY WAITS ON MAY RUN ON GITHUB'S HARDWARE when there is a written
+#     argument for it. Today that is cla.yml (security) and the 3.12 nightly
+#     (cost — hosted runners are free for public repos and slow, which is the
+#     right trade when no human is blocked). Both live in
+#     .github/hosted-runner-allowlist.yaml WITH the argument attached, and
+#     _hosted_runner_guard.py fails CI on an exception that is undocumented or
+#     stale. "No hosted runners" is shorthand for "none outside that file".
+#
+# WHICH MACHINES "OUR POOL" MEANS IS NOT SETTLED, AND THIS FILE DOES NOT SAY.
+# It resolves `vars.CI_RUNS_ON` — a repository Variable — precisely so the pool
+# can change without editing workflows. It is changing right now: the spartan
+# nodes were banned from CI, and the operator moved on 2026-08-12 to re-admit
+# them (four org runners + three spartan ≈ 75% more capacity), gated on
+# scitex-dev #575-#578 — the four PRs that stop tests asserting facts about the
+# machine they run on. Until those land, the SAME code goes green on spartan and
+# red on an org runner, which would make this gate's verdict depend on which
+# runner picked the job up. Do not add spartan labels here to "help"; the switch
+# is flipped in the Variable, once those PRs land.
 #
 # THE THREE PATHS HAVE DIFFERENT AUDIENCES, WHICH IS WHY THE SAME SUITE RUNS
 # THREE SHAPES:

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -23,10 +23,48 @@ name: tests
 # pypi-publish-and-github-release-on-tag.yml. Not "an equivalent setup" —
 # the same bytes. Green PR => green release, by construction.
 #
-# Operator rule (2026-07-14, absolute, no exceptions): NO GitHub-hosted runners
-# anywhere in this repo, PR tests included. If Spartan misbehaves, that is OURS
-# to fix — never fall back to a hosted runner. There is deliberately NO
-# `ubuntu-latest` escape hatch below; adding one back is the bug, not the fix.
+# RUNNER RULE, AS AMENDED 2026-08-12 (read this before "fixing" anything below).
+#
+# The 2026-07-14 rule was "NO GitHub-hosted runners anywhere in this repo, PR
+# tests included, no exceptions". That sentence was already false in one place
+# (cla.yml, a deliberate SECURITY carve-out — see
+# .github/hosted-runner-allowlist.yaml), and the operator amended it on
+# 2026-08-12 to make a second, deliberate exception. What is true now:
+#
+#   * THIS gate — and every other check a human waits on — runs on OUR pool,
+#     via `vars.CI_RUNS_ON`. There is still deliberately NO `ubuntu-latest`
+#     escape hatch below; adding one HERE is the bug, not the fix. If our pool
+#     misbehaves, that is OURS to fix.
+#   * The NIGHTLY 3.12 matrix runs on GitHub-HOSTED runners, on purpose
+#     (nightly-python-matrix-on-github-hosted.yml). Nobody waits on a nightly,
+#     hosted runners are free for public repos, and our four CPU nodes are
+#     contended — so the nightly buys coverage with someone else's hardware.
+#   * Every exception lives in .github/hosted-runner-allowlist.yaml WITH its
+#     argument attached, and is machine-enforced by _hosted_runner_guard.py.
+#     "No hosted runners" is now shorthand for "none outside that allowlist".
+#
+# THE THREE PATHS HAVE DIFFERENT AUDIENCES, WHICH IS WHY THE SAME SUITE RUNS
+# THREE SHAPES:
+#
+#   PR gate    3.11 + 3.13            a human is waiting  -> optimise LATENCY
+#   nightly    3.12 (hosted)          nobody is waiting   -> optimise COST
+#   release    3.11 + 3.12 + 3.13     correctness only    -> optimise COVERAGE
+#
+# THE ENDS OF THE RANGE, NOT ONE VERSION. Dropping to a single leg was measured
+# and rejected the same night: scitex-dev #578 (a fix for LD_LIBRARY_PATH being
+# stripped from child processes, 21 tests) failed on 3.11 and 3.13 and PASSED on
+# 3.12 — only the ends link libpython dynamically. A one-leg gate picked from
+# the middle would have shipped it, and a one-leg gate picked from an end is one
+# interpreter's build options away from the same hole. Min and max bracket the
+# range; the middle is what the nightly is for.
+#
+# So a green PR does NOT have to predict a green release on its own — the
+# release gate (pypi-publish-and-github-release-on-tag.yml) runs the FULL matrix
+# in this same SIF before anything reaches PyPI, and the nightly is the
+# early warning that a 3.12/3.13-only regression exists days before a tag.
+# Pushes to `develop`/`main` also keep the full matrix here, so the version that
+# is NOT on the PR gate is still exercised in the release-identical environment
+# on the very merge that introduces it.
 #
 # Constitution §4: freshness comes from discarding the ENVIRONMENT, not the
 # runner — a shared read-only base SIF, and per-job scratch created and
@@ -39,7 +77,15 @@ on:
   pull_request:
     branches: [main, develop]
   schedule:
-    - cron: "0 17 * * *"  # nightly 17:00 UTC (~02:00 JST), off-peak
+    # Nightly 17:00 UTC (~02:00 JST), off-peak — KEPT even though
+    # nightly-python-matrix-on-github-hosted.yml now also runs nightly, because
+    # the two watch different things. That one watches the CODE on 3.12/3.13
+    # using GitHub's stock image; this one watches the ENVIRONMENT — the shared
+    # ci-cpu.sif, its baked interpreters and the layered [all,dev] install are
+    # infrastructure that changes OUTSIDE this repo, and this is the only daily
+    # run that would notice such drift before a tag does. At 02:00 JST our nodes
+    # are idle, so it competes with nobody.
+    - cron: "0 17 * * *"
   workflow_dispatch:
 
 # STOP RE-TESTING COMMITS THAT A NEWER PUSH HAS ALREADY REPLACED.
@@ -117,7 +163,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        # THE ENDS OF THE RANGE ON A PULL REQUEST, THE FULL SET EVERYWHERE ELSE.
+        #
+        # MEASURED 2026-08-11/12: all four CPU runners saturated while several
+        # stacked PRs each fanned out three legs of the heaviest job on the
+        # queue. Dropping the middle leg is a 1/3 cut to that job — an honest
+        # third, not a headline: this does not make CI twice as fast, it stops
+        # one of every three heavy legs from being queued behind the others.
+        # The version it drops is covered by
+        #   * nightly-python-matrix-on-github-hosted.yml (daily, someone else's
+        #     hardware), and
+        #   * this same job on the `develop`/`main` push that merges the PR, and
+        #   * the release gate, which runs all three before anything ships.
+        #
+        # SPELLING: one `fromJSON` over two STRING literals, not
+        # `cond && fromJSON(a) || fromJSON(b)`. Both forms work, but the string
+        # form has no truthiness trap — an empty/short array operand in the
+        # second form would silently fall through to the other branch.
+        #
+        # THESE TWO LISTS ARE THE ONLY PLACE THE PR/BRANCH SPLIT IS WRITTEN, and
+        # tests/integration/test_ci_python_matrix_shape.py DERIVES the rest from
+        # them: the PR list must be exactly [oldest, newest] of the full list,
+        # the nightly must be exactly the full list MINUS the PR list, the
+        # release matrix must equal the full list, and the full list must agree
+        # with pyproject's declared classifiers. A Python bump that edits one
+        # place and not the others turns that test RED instead of half-applying
+        # in silence — which is the failure mode this fleet keeps hitting.
+        python-version: >-
+          ${{ fromJSON(github.event_name == 'pull_request'
+                       && '["3.11","3.13"]'
+                       || '["3.11","3.12","3.13"]') }}
     steps:
       - uses: actions/checkout@v7
 
@@ -142,8 +217,12 @@ jobs:
       # OIDC avoids a repository upload token while still authenticating every
       # upload. Codecov has not activated this repository yet, so keep its
       # explicit upload failure visible without overriding a green test suite.
+      # 3.11, NOT 3.12: the upload has to key on a leg that EXISTS in every
+      # event shape. Since the PR gate now runs the floor version alone, keying
+      # on 3.12 would mean no pull request ever uploads coverage again — the
+      # exact silent half-application this change is trying not to commit.
       - name: Upload coverage to Codecov
-        if: always() && matrix.python-version == '3.12'
+        if: always() && matrix.python-version == '3.11'
         continue-on-error: true
         uses: codecov/codecov-action@v7
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,17 @@ dev = [
     # marker explicit per test, which matches the rest of the codebase
     # (no implicit-async-on-conftest surprises).
     "pytest-asyncio>=0.23",
+    # DECLARED 2026-08-12, AND IT WAS ALWAYS REQUIRED — [dev] simply never said
+    # so. `.github/ci/run-in-sif.sh` REFUSES TO RUN THE SUITE unless pytest
+    # reports the plugin set {asyncio, xdist, cov, timeout}, and that check has
+    # been passing only because the shared ci-cpu.sif happens to supply
+    # pytest-timeout transitively through scitex-dev's own environment. The
+    # first run of the suite in a CLEAN venv built from this package's own
+    # extras (the GitHub-hosted nightly, run 31551320295) therefore aborted
+    # immediately: "pytest plugin 'timeout' did NOT load in this environment."
+    # Same principle as the PS210 note on scitex-hpc above: if the full suite
+    # cannot run from `pip install -e .[dev]`, [dev] is under-declared.
+    "pytest-timeout>=2.0",
     "pre-commit>=3.5.0",
     # MCP test surface (tests/scitex_agent_container/_mcp/) imports
     # fastmcp unconditionally; without it the entire _mcp/ suite is

--- a/tests/integration/test_ci_python_matrix_shape.py
+++ b/tests/integration/test_ci_python_matrix_shape.py
@@ -1,0 +1,301 @@
+"""The three python matrices must stay in agreement, or a bump half-applies.
+
+THE SHAPE (operator, 2026-08-12)::
+
+    PR gate    3.11 + 3.13          our pool      a human waits  -> LATENCY
+    nightly    3.12                 GitHub-hosted nobody waits   -> COST
+    release    3.11 + 3.12 + 3.13   our pool      correctness    -> COVERAGE
+
+WHY THE ENDS AND NOT ONE VERSION. Running a single leg was proposed and
+rejected the same night, on our own evidence: scitex-dev #578 (a fix for
+``LD_LIBRARY_PATH`` being stripped from child processes, which took out 21
+tests) failed on 3.11 and 3.13 and PASSED on 3.12 -- only the ends link
+libpython dynamically. A gate running the middle alone would have shipped it.
+
+WHY THIS FILE EXISTS. The three lists live in three workflow files, and GitHub
+Actions gives no way to define them once: ``strategy`` cannot read the ``env``
+context, so the only single-source spellings are a repository Variable (invisible
+to the repo, and a settings change can then silently re-point CI) or an extra
+setup job (a whole runner slot of queue latency on a saturated pool, to save
+three literals). Both are worse than the duplication. So the lists are DERIVED
+FROM EACH OTHER HERE instead:
+
+* the PR gate must be exactly ``[oldest, newest]`` of the full set,
+* the nightly must be exactly the full set MINUS the PR gate,
+* the release must be exactly the full set, with no event condition,
+* the full set must agree with what ``pyproject.toml`` declares.
+
+Bump python and touch only one file and this goes RED. That is the whole point:
+a half-applied version bump is invisible in review and stays invisible until a
+release, and this fleet keeps hitting exactly that shape.
+
+KNOWN, DELIBERATE GAP -- NOT A BUG THIS FILE HIDES: ``requires-python`` declares
+``>=3.10`` and the classifiers list 3.10, but CI's floor is 3.11 because the
+shared ``ci-cpu.sif`` bakes only 3.11/3.12/3.13 at ``/opt/venv-<ver>``. So 3.10
+is DECLARED supported and never tested. ``test_ci_never_tests_an_undeclared_
+version`` asserts the safe direction (CI never tests something we do not claim
+to support); closing the other direction means either baking 3.10 into the SIF
+or raising ``requires-python``, and that is a separate decision with its own
+blast radius.
+
+No mocks: every assertion parses the real ``.github/workflows/*.y*ml`` and the
+real ``pyproject.toml``.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+PR_GATE_WORKFLOW = WORKFLOW_DIR / "pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml"
+NIGHTLY_WORKFLOW = WORKFLOW_DIR / "nightly-python-matrix-on-github-hosted.yml"
+RELEASE_WORKFLOW = WORKFLOW_DIR / "pypi-publish-and-github-release-on-tag.yml"
+
+# Every quoted JSON array inside a ${{ }} expression, in source order.
+_JSON_ARRAY_RE = re.compile(r"'(\[[^']*\])'")
+_CLASSIFIER_RE = re.compile(r"^Programming Language :: Python :: (\d+\.\d+)$")
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _matrix_raw(path: Path, job: str = "test") -> object:
+    return _load(path)["jobs"][job]["strategy"]["matrix"]["python-version"]
+
+
+def _key(version: str) -> tuple[int, ...]:
+    """Sort 3.9 BELOW 3.11 -- string order would put it above."""
+    return tuple(int(part) for part in version.split("."))
+
+
+def _sorted(versions: object) -> list[str]:
+    return sorted((str(v) for v in versions), key=_key)
+
+
+def _conditional_matrix(path: Path) -> tuple[list[str], list[str]]:
+    """Split the PR gate's conditional expression into (pr_list, full_list).
+
+    The shipped spelling is one ``fromJSON`` over two string literals::
+
+        ${{ fromJSON(github.event_name == 'pull_request'
+                     && '["3.11","3.13"]'
+                     || '["3.11","3.12","3.13"]') }}
+
+    so the FIRST array is what a pull request runs and the SECOND is what every
+    other event runs. Parsed rather than assumed: if someone rewrites this as an
+    unconditional list, the assertions below say so instead of reading a stale
+    literal out of a comment.
+    """
+    raw = _matrix_raw(path)
+    assert isinstance(raw, str) and "${{" in raw, (
+        f"{path.name}: expected an event-conditional matrix expression, got "
+        f"{raw!r}. The PR gate must run a NARROWER set than a branch push; an "
+        "unconditional list means either every PR pays for the full matrix "
+        "again, or `develop` silently lost coverage."
+    )
+    assert "github.event_name == 'pull_request'" in raw, (
+        f"{path.name}: the matrix condition is {raw!r}. It must key on "
+        "`github.event_name == 'pull_request'` -- keying on the branch or the "
+        "ref would narrow the matrix on `develop` pushes too, which is where "
+        "the version the PR gate skips is supposed to be caught."
+    )
+    arrays = _JSON_ARRAY_RE.findall(raw)
+    assert len(arrays) == 2, (
+        f"{path.name}: expected exactly two quoted version lists in the matrix "
+        f"expression, found {len(arrays)} in {raw!r}."
+    )
+    pr_list = yaml.safe_load(arrays[0])
+    full_list = yaml.safe_load(arrays[1])
+    return _sorted(pr_list), _sorted(full_list)
+
+
+def _declared_versions() -> list[str]:
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    found = []
+    for classifier in data["project"]["classifiers"]:
+        match = _CLASSIFIER_RE.match(classifier)
+        if match:
+            found.append(match.group(1))
+    return _sorted(found)
+
+
+PR_VERSIONS, FULL_VERSIONS = _conditional_matrix(PR_GATE_WORKFLOW)
+NIGHTLY_VERSIONS = _sorted(_matrix_raw(NIGHTLY_WORKFLOW))
+RELEASE_VERSIONS = _sorted(_matrix_raw(RELEASE_WORKFLOW))
+DECLARED_VERSIONS = _declared_versions()
+
+
+def test_parsing_found_real_version_lists():
+    """Guard the guard: empty lists would make everything below vacuous."""
+    # Arrange
+    parsed = {
+        "pr": PR_VERSIONS,
+        "full": FULL_VERSIONS,
+        "nightly": NIGHTLY_VERSIONS,
+        "release": RELEASE_VERSIONS,
+        "declared": DECLARED_VERSIONS,
+    }
+
+    # Act
+    empty = [name for name, versions in parsed.items() if not versions]
+
+    # Assert
+    assert not empty, (
+        f"parsed no python versions for {empty} -- the workflow shape moved and "
+        f"every assertion in this module would now pass without checking "
+        f"anything. Parsed: {parsed}"
+    )
+
+
+def test_pr_gate_runs_exactly_the_oldest_and_newest_supported():
+    """min + max, DERIVED. Bump the full set and forget this list -> red."""
+    # Arrange
+    expected = [FULL_VERSIONS[0], FULL_VERSIONS[-1]]
+
+    # Act
+    actual = PR_VERSIONS
+
+    # Assert
+    assert actual == expected, (
+        f"the pull-request matrix is {actual}, but the ends of the supported "
+        f"range are {expected}. The gate must BRACKET the range: scitex-dev "
+        "#578 (LD_LIBRARY_PATH stripped from child processes, 21 tests) failed "
+        "on the oldest and newest and PASSED on the middle, because only the "
+        "ends link libpython dynamically. Testing an interior version alone "
+        "would have shipped it."
+    )
+
+
+def test_nightly_runs_exactly_what_the_pr_gate_skips():
+    """The nightly is the COMPLEMENT, so every supported version is tested
+    daily by one gate or the other."""
+    # Arrange
+    expected = [v for v in FULL_VERSIONS if v not in PR_VERSIONS]
+
+    # Act
+    actual = NIGHTLY_VERSIONS
+
+    # Assert
+    assert actual == expected, (
+        f"{NIGHTLY_WORKFLOW.name} runs {actual}; the versions the PR gate does "
+        f"not run are {expected}. A version in neither list is tested only on "
+        "`develop`/`main` pushes and at release -- i.e. it stops being covered "
+        "the moment merges pause, which is exactly when a release is cut."
+    )
+
+
+def test_release_runs_the_full_supported_set():
+    # Arrange
+    expected = FULL_VERSIONS
+
+    # Act
+    actual = RELEASE_VERSIONS
+
+    # Assert
+    assert actual == expected, (
+        f"{RELEASE_WORKFLOW.name} runs {actual}, not the full supported set "
+        f"{expected}. The release gate is the last thing between a "
+        "version-specific regression and PyPI; it does not get to inherit the "
+        "PR gate's latency trade."
+    )
+
+
+def test_release_matrix_carries_no_event_condition():
+    """The release must not be able to inherit a narrowed list by reference or
+    by condition -- the half-applied shape this fleet keeps getting caught by."""
+    # Arrange
+    raw = _matrix_raw(RELEASE_WORKFLOW)
+
+    # Act
+    is_plain_literal = isinstance(raw, list) and not any(
+        "${{" in str(item) for item in raw
+    )
+
+    # Assert
+    assert is_plain_literal, (
+        f"{RELEASE_WORKFLOW.name}: the release matrix is {raw!r}. It must be a "
+        "plain literal list. An expression here could evaluate to the PR gate's "
+        "narrowed set on some event nobody thought about, and a release that "
+        "quietly tested two of three versions is indistinguishable from one "
+        "that tested all three -- until a user hits it."
+    )
+
+
+@pytest.mark.parametrize("version", FULL_VERSIONS, ids=lambda v: v)
+def test_ci_never_tests_an_undeclared_version(version: str):
+    """CI must not test a python this package does not claim to support."""
+    # Arrange
+    declared = DECLARED_VERSIONS
+
+    # Act
+    is_declared = version in declared
+
+    # Assert
+    assert is_declared, (
+        f"CI runs python {version} but pyproject.toml declares only {declared}. "
+        "Either add the classifier or drop the leg -- a green leg on an "
+        "undeclared version is coverage nobody has promised to keep."
+    )
+
+
+def test_the_newest_declared_version_is_on_the_pr_gate():
+    """A ceiling bump must reach the gate a human reads, not just the nightly.
+
+    This is the half-application that would otherwise be invisible: add a 3.14
+    classifier, add it to the full matrix, and without this assertion the newest
+    interpreter our users are told to use would be tested nightly at best.
+    """
+    # Arrange
+    newest_declared = DECLARED_VERSIONS[-1]
+
+    # Act
+    on_pr_gate = newest_declared in PR_VERSIONS
+
+    # Assert
+    assert on_pr_gate, (
+        f"pyproject declares support up to python {newest_declared}, but the "
+        f"pull-request gate runs {PR_VERSIONS}. The newest version we claim to "
+        "support is the one most likely to break and the one least likely to be "
+        "noticed at merge time."
+    )
+
+
+def test_pr_gate_job_names_match_the_required_status_checks():
+    """BRANCH PROTECTION IS COUPLED TO THIS MATRIX, and nothing in the repo can
+    see that coupling.
+
+    ``develop`` and ``main`` require the check names this job template produces.
+    A leg that no longer runs on a pull request NEVER REPORTS, and the PR then
+    sits at mergeStateStatus=BLOCKED with every check passing -- which has
+    already held a release hostage once in this repo. So narrowing the PR matrix
+    REQUIRES editing both protection rules in the same change, from three
+    contexts to two::
+
+        pytest-matrix-on-ubuntu-py3.11
+        pytest-matrix-on-ubuntu-py3.13
+
+    This test cannot reach the GitHub API, so it pins the other half: the name
+    template must still be derived from ``matrix.python-version``, so the
+    contexts above remain the ones this matrix actually produces.
+    """
+    # Arrange
+    job = _load(PR_GATE_WORKFLOW)["jobs"]["test"]
+
+    # Act
+    name = str(job.get("name", ""))
+
+    # Assert
+    assert "matrix.python-version" in name, (
+        f"the PR gate job name is {name!r}. It must interpolate "
+        "matrix.python-version: branch protection on `develop` and `main` "
+        "requires one context per leg, and those context strings are generated "
+        "from this template. Renaming it silently orphans the required checks."
+    )


### PR DESCRIPTION
## What this changes

The pull-request gate ran three python legs of the heaviest job on the queue.
**Measured 2026-08-11/12:** every CPU runner saturated, several stacked PRs each
fanning out that three-way matrix, a human waiting in front of each of them.

Three paths, three audiences, three shapes:

| path | versions | runners | who waits | optimised for |
|---|---|---|---|---|
| PR gate | 3.11 + 3.13 | ours (`vars.CI_RUNS_ON`) | a human | **latency** |
| nightly | 3.12 | GitHub-hosted | nobody | **cost** |
| release (tag) | 3.11 + 3.12 + 3.13 | ours, in the release SIF | nobody | **coverage** |

**The saving is one third of the `tests` job on a PR, and nothing else.** Three
legs become two. It does not make CI twice as fast; it stops one of every three
heavy legs from being queued in front of the next PR.

## Why the ends of the range, not one version

A single leg was proposed and rejected the same night, on our own evidence.
**scitex-dev #578** — a fix for `LD_LIBRARY_PATH` being stripped from child
processes, which took out 21 tests — failed like this:

```
3.11   FAILED
3.12   passed
3.13   FAILED
```

Only the ends link libpython dynamically. A gate running the middle version
alone would have shipped it. min+max brackets the range; the middle is what the
nightly is for.

## Why the nightly is on GitHub-hosted runners, and why the header changed

The `tests` header said, verbatim: *"Operator rule (2026-07-14, absolute, no
exceptions): NO GitHub-hosted runners anywhere in this repo, PR tests
included."* That sentence was **false on the day it was written** — `cla.yml`
has always been a deliberate security carve-out — and it had been copied into
six other workflow files as an absolute.

It is now written as a **principle plus a mechanism**, not an absolute:

- anything a **human waits on** runs on hardware we control — unchanged, and
  there is still no `ubuntu-latest` escape hatch in `tests`;
- a job **nobody waits on** may run on GitHub's hardware *when the argument is
  written down* in `.github/hosted-runner-allowlist.yaml`, where
  `_hosted_runner_guard.py` fails CI on an undocumented or stale exception;
- two exceptions exist today: `cla.yml` (security — unauthenticated triggers
  must not reach a node holding the fleet's live credentials) and this nightly
  (cost).

`cla.yml`'s `runs-on` is **untouched**: a CLA gate is where a well-meant runner
change breaks contributor onboarding.

**The headers deliberately no longer quote a machine count or name a pool.**
Capacity is changing this week — the spartan nodes are being re-admitted to CI
once **scitex-dev #575–#578** land (the PRs that stop tests asserting facts
about the machine they run on), taking the pool from four to seven. Until then
the same code can go green on spartan and red on an org runner, which would make
the gate's verdict depend on which runner picked the job up. **This PR adds no
spartan label to any `runs-on`** — that switch is `vars.CI_RUNS_ON`, and it is
not this PR's to flip. The prose states the policy; someone else flips it.

## The gap, and what closes it

A green PR no longer exercises 3.12. Three things cover it, in increasing order
of finality:

1. the **hosted nightly**, daily, on hardware we do not pay for;
2. the **`develop`/`main` push** that merges the PR — the full matrix still runs
   there, in the release-identical SIF, so the version the PR gate skipped is
   exercised on the very merge that introduces it;
3. the **release gate**, which runs all three in that same SIF before anything
   reaches PyPI.

So a green PR does not have to predict a green release on its own. The release
gate does that.

### Why a `nightly-…` check is on THIS pull request, and will not be on yours

A reviewer seeing a red `nightly-py3.12-on-github-hosted` next to a merge button
should not have to guess whether someone waved it through. Two checkable facts:

1. **It is `paths`-scoped to its own two files.** Its `pull_request` trigger
   lists exactly `.github/workflows/nightly-python-matrix-on-github-hosted.yml`
   and `.github/ci/run-on-hosted.sh`. This PR is the one that writes them, so it
   runs here; an ordinary PR never sees the check at all. It is not a third gate
   leg, and it costs our pool nothing in any case, because the job is hosted.
   The alternative is a nightly whose breakage is found at 02:00 JST by nobody —
   this way the change that breaks it is the change that learns.
2. **It is not a required status check.** Branch protection on `develop` and
   `main` lists only `pytest-matrix-on-ubuntu-py3.11` and
   `pytest-matrix-on-ubuntu-py3.13`, so the nightly cannot block a merge by
   protection — the correct shape for a signal nobody waits on. It is
   nonetheless being made GREEN here rather than waived; see the `PATH` fix
   below.

**Where a red nightly surfaces:** the `notify` job opens — or reopens and
comments on — a single GitHub issue titled `[nightly] python matrix failed on
the hosted runner`. One issue, not one per night: a nightly that files 30
identical issues teaches everyone to filter it out, which is the same as not
reporting. It fires only on `schedule`, so a PR editing the workflow gets its
answer on the PR instead.

## Release runner choice, stated rather than left implicit

The release matrix stays **on our pool, in the SIF**. A release is rare and
correctness is its only job — and this gate exists *because* the PR gate and the
release gate once differed. That divergence left PyPI at 0.21.17 while eight
tags shipped nothing, silently. Moving the release onto a hosted runner would
rebuild exactly that gap. Nobody waits on a tag build, so its latency is not
worth buying with fidelity.

## Are the lists defined once? No — and here is why, explicitly

They are **repeated in three workflow files**, and I did not unify them.

GitHub Actions gives no good single source: `strategy` cannot read the `env`
context, so the only mechanisms are (a) a repository Variable — invisible to the
repo, so a settings change could silently re-point CI, the same class of problem
as `vars.CI_RUNS_ON` being unverifiable from the code, or (b) an extra `setup`
job to emit the matrix as an output — a whole runner slot of queue latency on a
contended pool, to save three literals. Both are worse than the duplication.

So the lists are **derived from each other in a test**:
`tests/integration/test_ci_python_matrix_shape.py` asserts

- PR gate == `[oldest, newest]` of the full set,
- nightly == full set **minus** the PR gate,
- release == the full set, **and carries no event condition** (so the release
  path cannot inherit a narrowing by expression),
- every CI version is declared in `pyproject.toml`'s classifiers, and the newest
  declared version is on the PR gate.

Bump python, touch one file, forget the others → red. That is the
half-application failure mode this fleet keeps hitting, made loud.

## Branch protection (coordinated, not a drive-by)

`develop` and `main` required all three contexts:

```
pytest-matrix-on-ubuntu-py3.11
pytest-matrix-on-ubuntu-py3.12   <- would never report on a PR again
pytest-matrix-on-ubuntu-py3.13
```

A required check that never reports leaves every PR at
`mergeStateStatus=BLOCKED` with all checks passing — which has already held a
release hostage once in this repo. `py3.12` was therefore removed from the
required set on **both** branches as part of this change (verified: both now
read `["pytest-matrix-on-ubuntu-py3.11","pytest-matrix-on-ubuntu-py3.13"]`,
`strict:false` unchanged). It still runs on every push to those branches; it is
simply no longer a gate on a PR that never runs it.

## Concurrency (PR #969) interaction

None. The group is `${{ github.workflow }}-${{ github.event.pull_request.number
|| github.run_id }}` and is resolved **per run, not per leg**, so a narrower
matrix cannot move a job into a different group. The new nightly carries the
same expression and is covered automatically by
`test_ci_pr_gate_concurrency.py`, because it is `pull_request`-triggered on its
own paths.

## Two latent gaps the nightly found by being the first clean-venv run

Neither is caused by this change; both were always there, hidden because the
suite had only ever been built inside the SIF.

### 1. `[dev]` never declared **pytest-timeout** `run-in-sif.sh` refuses to run the
suite unless pytest reports `{asyncio, xdist, cov, timeout}`, and that check has
been passing only because the shared `ci-cpu.sif` supplies the plugin
transitively through scitex-dev. The first build of this suite from the
package's own extras in a clean venv aborted in 1.2 s:

```
preflight plugins: cov-7.1.0, anyio-4.14.2, xdist-3.8.0, asyncio-1.4.0, scitex-dev-0.47.0
::error::pytest plugin 'timeout' did NOT load in this environment.
```

Declared in `[dev]` here, same principle as the PS210 note on `scitex-hpc`
directly above it: if the full suite cannot run from `pip install -e .[dev]`,
`[dev]` is under-declared.

### 2. The venv's `bin/` was not on `PATH`

With the plugin fixed, the next run got all the way through the suite:
**14985 passed, 6 failed, 68 skipped in 306s**. All six failures were one cause,
and every one of them read like a real bug:

```
SacBinaryNotFoundError: Cannot resolve the `sac` console script: not on PATH
test_install_writes_bash_cache_file        - assert False = is_file()
test_install_creates_xdg_symlink           - assert False = is_symlink()
test_install_appends_source_line_to_bashrc - FileNotFoundError: .bashrc
test_install_zsh_writes_zshrc_marker       - FileNotFoundError: .zshrc
test_install_replaces_stale_xdg_symlink    - assert ... in 'stale-target'
```

Several tests exec the `sac` **console script** as a subprocess (the completion
installer, the SDK channel sidecar resolver). `uv venv` does create the entry
point at `.venv-<ver>/bin/sac`; nothing had put that directory on `PATH`, so the
five file assertions were failing about files the installer never got to write.
`run-in-sif.sh` meets the same requirement from the other side — `pip install
--target` does not materialise entry points at all, so it hand-writes shims.
Fixed with one `export PATH=…` line.

## Verification — measured, not inferred

Every number below is from the API (`conclusion` + `runner_name`), not from
`gh pr checks`, which buckets a **cancelled** job as `fail` and a **queued** one
as green.

| what | run | result |
|---|---|---|
| `pull_request` leg count | 31551526602 | **2** — `py3.11`, `py3.13` |
| non-PR leg count (`workflow_dispatch`, same commit) | 31551572841 | **3** — `py3.11`, `py3.12`, `py3.13` |
| `py3.11` | 31551526602 | **success**, runner `scitex-04-cpu-01` |
| `py3.13` | 31551526602 | **success**, runner `scitex-02-cpu-01` |
| nightly leg count + placement | 31551526731 | **1** — `3.12`, runner `GitHub Actions 1000026914` |
| nightly suite, before the two fixes | 31551526731 | 14985 passed / **6 failed** |
| nightly suite, after them | 31554302550 | **success**, runner `GitHub Actions 1000027026` |

The nightly is green on GitHub's hardware, not waived: the `Run the suite on
python 3.12` step itself reports `success`, so the whole suite runs on 3.12
outside the SIF.

Both branches of the matrix expression were therefore exercised **on the same
commit**, and the two gate legs are proven to have executed on our own hardware
rather than anywhere else.

Guard tests, local, absolute interpreter:

```
$ PYTHONPATH=<worktree>/src /opt/venv-sac/bin/python -m pytest \
    tests/integration/test_ci_python_matrix_shape.py \
    tests/integration/test_ci_pr_gate_concurrency.py \
    tests/scitex_agent_container/test__hosted_runner_guard.py -p no:cacheprovider
plugins: anyio-4.14.2, asyncio-1.4.0, xdist-3.8.0, scitex-dev-0.47.0
80 passed in 1.03s
```

## Two findings not fixed here

1. **`pyproject.toml` declares `requires-python = ">=3.10"` and a 3.10
   classifier, but CI has never tested 3.10** — the shared `ci-cpu.sif` bakes
   only 3.11/3.12/3.13 at `/opt/venv-<ver>`. So 3.10 is declared supported and
   untested. The new test asserts the safe direction (CI never tests an
   undeclared version); closing the other direction means baking 3.10 into the
   SIF or raising the floor, which is a separate decision.
2. **`vars.CI_RUNS_ON` is currently `["self-hosted","Linux","X64",
   "scitex-local-cpu"]`** — not `scitex-org-cpu`. That is a repository Variable,
   not code; flagged, not changed here.

