### PR TITLE
feat(image): call the reproducible round trip, and pin the base inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,69 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`sac image build --reproducible` — the build verb can finally express
+  "build reproducibly", and sac finally calls the round trip it has had access
+  to all along.** scitex-container has shipped the whole apparatus for months
+  (`build_reproducible`, `capture_lock`, `generate_locked_def`,
+  `compare_locks`, the `.verified` / `.unverified` markers, the use-time gate),
+  all publicly exported. sac referenced none of it — an `rg` over `src/` found
+  **zero** hits — and no `.lock` / `.verified` / `.unverified` had ever been
+  written on the fleet host. The round trip had never run.
+
+  It could not run. `build_reproducible()` took no build CONTEXT, and sac's
+  entire contribution to a build is a staged one: a copy of its own source
+  tree beside the `.def` plus a symlink to the prerequisite layer's SIF,
+  because the shipped recipes pull sac in by relative path
+  (`%files scitex-agent-container-src`, `From: ./sac-base.sif`) so the SIF
+  pins the source that shipped the recipe. Those paths exist only inside the
+  staging dir; resolved against the containers dir they do not exist, and
+  apptainer FATALs before running a line of `%post`. (Same mechanism as the
+  long-standing observation that rebuilding a SIF by hand goes wrong while
+  building through the `sac` verb works — a raw `apptainer build` on a shipped
+  recipe fails for exactly this reason. Always use the verb.)
+
+  scitex-container 0.4.0 adds that `cwd`; this release calls it. The new verb
+  captures the version set that actually landed into a `.lock`, emits a
+  version-pinned `.def`, rebuilds from it through the same staged context,
+  compares the two version sets, and marks `.verified` or `.unverified`
+  carrying the drift. A mismatch is a **finding, not a build failure** — the
+  image stays usable with its provenance honestly recorded as unproven.
+  `--skip-verify` captures the lock and pinned recipe without the second
+  build, and says plainly that the result is unmarked.
+
+  "Reproducible" here means **environment identity** (the same version set
+  comes back), the reading the operator chose. Byte-for-byte identical digests
+  are explicitly out of scope.
+
+- **`proxy` is buildable.** `_LAYERS` mapped only `base` and `scitex`, so the
+  shipped `apptainer-proxy.def` was a recipe nothing could build — even though
+  `build_layer_from_source` documents `base`/`scitex`/`proxy` and
+  `resolve_bootstrap_sif` already names `proxy` among the top-of-stack layers.
+  An oversight, not a policy.
+
 ### Changed
+
+- **The base inputs are pinned.** `ubuntu:24.04` is a moving tag — Canonical
+  republishes it for every point release — so `apptainer-base.def` and
+  `apptainer-proxy.def` now bootstrap from the digest of 24.04.4 LTS, the
+  exact base the live fleet image was built from. `yq` and `cargo-binstall`
+  move off `releases/latest/download` to v4.53.3 / v1.21.1, and rustup gains
+  `--default-toolchain 1.97.1`. Every one of those values is what the live
+  image *already carries* (verified in-image), so the pins freeze the current
+  state rather than moving it. `gdu` was already pinned for the same reason.
+
+  `@anthropic-ai/claude-code@latest` is deliberately **left floating**: the
+  recipe documents that float as an explicit operator directive (carry the
+  latest of all ecosystem packages; unlock the `fable[1m]` model). The
+  consequence, stated plainly: a `--reproducible` base build will report
+  `.unverified` whenever claude-code publishes between the two builds. That is
+  the round trip working — the drift was always there, it was just invisible.
+
+  Note the digest pins the STARTING layer only; `%post` still runs `apt-get
+  update`, so apt packages can move. That residual drift is now *detected*
+  (dpkg versions are in the `.lock` and compared) but not yet prevented.
 
 - **Every job sac owns is renamed to the ecosystem canonical form
   `scitex-agent-container-<name>`, and the migration that makes that safe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,13 +68,21 @@ dependencies = [
     # v0.3.0 was the release that split public from ecosystem-internal
     # and exposed both surfaces — that is our hard minimum.
     "scitex-config>=0.3.0",
-    # 0.3.0 floor: sac's source-bundled ``sac image build`` delegates to
-    # scitex-container's atomic ``build(...)`` (timestamped SIF + stable
-    # symlink swap; failed build leaves the prior image intact). That API
-    # — ``cwd`` (build context independent of ``output_dir``),
-    # ``image_name``, ``retain``, Path return — landed in 0.3.0. See
-    # cli_pkg/_image_source_build.py::_default_container_build.
-    "scitex-container>=0.3.0",
+    # 0.3.0 gave sac's source-bundled ``sac image build`` the atomic
+    # ``build(...)`` it delegates to (timestamped SIF + stable symlink
+    # swap; a failed build leaves the prior image intact) with ``cwd``
+    # (build context independent of ``output_dir``), ``image_name``,
+    # ``retain`` and a Path return.
+    #
+    # 0.4.0 is the HARD floor now: ``sac image build --reproducible``
+    # calls ``build_reproducible(..., cwd=...)``, and ``cwd`` reached the
+    # ROUND-TRIP entry points only in 0.4.0. Against 0.3.0 the call is a
+    # TypeError — and were the argument merely dropped, the build would
+    # FATAL, because sac's recipes resolve ``%files`` and
+    # ``From: ./sac-base.sif`` against the staged context. 0.4.0 also
+    # publishes the inner boot symlink the round trip previously left
+    # stale. See cli_pkg/_image_repro_build.py.
+    "scitex-container>=0.4.0",
     "scitex-logging>=0.1.5",
     "scitex-ssh>=1.0.0",
     # A2A protocol surface — Phase 1 SDK adoption (see GITIGNORED/A2A_MIGRATION.md).

--- a/src/scitex_agent_container/cli_pkg/_image_repro_build.py
+++ b/src/scitex_agent_container/cli_pkg/_image_repro_build.py
@@ -1,0 +1,273 @@
+"""Reproducible round-trip build for ``sac image build --reproducible``.
+
+``sac image build`` has always produced a SIF and nothing that PROVES the
+SIF can be produced again. scitex-container has shipped the proof machinery
+for months — rough build → freeze the actually-installed versions → emit a
+version-pinned ``.def`` → rebuild from it → compare the two version sets →
+mark ``.verified`` / ``.unverified`` — and sac never called it. This module
+is the call.
+
+Why it could not simply be called before: the round trip took no build
+CONTEXT. sac's whole contribution to a build is a STAGED context (a copy of
+its own source tree beside the ``.def``, plus a symlink to the prerequisite
+layer's SIF), because the shipped recipes pull sac in by a relative path::
+
+    %files
+        scitex-agent-container-src /opt/scitex-agent-container-src
+
+    Bootstrap: localimage
+    From: ./sac-base.sif
+
+Those paths exist only inside the staging directory ``stage_build_context``
+creates. Without a ``cwd`` argument reaching apptainer, the round trip
+resolved them against the containers dir, where they do not exist, and the
+build FATAL'd before running a line of ``%post``. That is also the
+mechanism behind the operator's long-standing observation that rebuilding
+by hand goes wrong while building through ``sac`` works: a raw ``apptainer
+build`` on a shipped ``.def`` fails immediately for exactly this reason.
+scitex-container grew the ``cwd`` parameter for this; here it is used.
+
+WHAT "REPRODUCIBLE" MEANS HERE — the operator chose, explicitly, between
+two readings:
+
+  A. ENVIRONMENT IDENTITY — the same version set comes back. CHOSEN.
+  B. Byte-for-byte identical digests. OUT OF SCOPE.
+
+So ``SOURCE_DATE_EPOCH`` and squashfs timestamp determinism are deliberately
+not attempted; scitex-container's own design calls byte-identity "an
+OPTIONAL stretch, deliberately NOT the default gate". A mismatch is NOT a
+build failure: the rough SIF stays usable and is marked ``.unverified``
+carrying the drift, because an image you can use with a known-unproven
+provenance is strictly better than no image and a red X.
+
+Testability follows the same seam pattern as ``_image_source_build``:
+``_container_build_reproducible`` is a module-level callable that tests
+reassign to a real (no MagicMock) recording fake.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from ._image_source_build import stage_build_context
+
+
+def _default_container_build_reproducible(
+    *,
+    def_path: Path,
+    output_dir: Path,
+    cwd: Path,
+    image_name: str,
+    force: bool,
+    verify: bool,
+) -> Any:
+    """Default round-trip builder — delegates to scitex-container.
+
+    ``cwd`` is the staged build context, forwarded to BOTH the rough build
+    and the verify rebuild so the replay resolves the same staged inputs
+    the rough build did. ``layer`` in scitex-container's vocabulary is the
+    artifact stem, which is sac's ``image_name`` (``sac-base`` etc.).
+
+    Returns scitex-container's ``RoundTripResult``: the kept artifact paths
+    plus ``verified`` (True / False / None when verify was skipped) and the
+    ``diff`` naming what drifted.
+    """
+    # Local import — scitex-container pulls its own deps and we don't want
+    # to pay that on the cold ``sac image`` startup path until a build runs.
+    from scitex_container import build_reproducible as _sc_build_reproducible
+
+    return _sc_build_reproducible(
+        layer=image_name,
+        root=output_dir,
+        def_path=def_path,
+        cwd=cwd,
+        verify=verify,
+        force=force,
+    )
+
+
+# Module-level overridable reference — same swap-and-restore pattern as
+# ``_image_source_build._container_build``. Tests reassign this to a real
+# recording callable so the unit suite never shells a real apptainer.
+_container_build_reproducible: Callable[..., Any] = (
+    _default_container_build_reproducible
+)
+
+
+def build_layer_reproducible(
+    *,
+    layer: str,
+    def_path: Path,
+    pkg_root: Path,
+    output_dir: Path,
+    force: bool = True,
+    bootstrap_sif: Path | None = None,
+    verify: bool = True,
+) -> Any:
+    """Build a sac SIF through scitex-container's reproducible round trip.
+
+    Stages the build context exactly as the plain source build does (same
+    ``stage_build_context``, same staging directory), then hands that
+    directory to the round trip as the build ``cwd``.
+
+    The staging directory must OUTLIVE the rough build, because the verify
+    rebuild replays the generated locked ``.def`` — which is the rough
+    ``.def`` plus a pin stanza and therefore carries the identical relative
+    ``%files`` / ``From:`` references — against the same context. It does:
+    nothing removes the staging dir between the two builds, and the next
+    build resets it.
+
+    Parameters
+    ----------
+    layer : str
+        Layer name (``base`` / ``scitex`` / ``proxy``), mapped to the
+        ``sac-<layer>`` artifact stem.
+    def_path : Path
+        Source .def file. Copied (not modified) into the staging dir.
+    pkg_root : Path
+        Package source root, staged as ``scitex-agent-container-src/``.
+    output_dir : Path
+        Containers dir. Artifacts land under ``<output_dir>/sac-<layer>/``.
+    force : bool
+        Force a rebuild even when the recipe hash is unchanged.
+    bootstrap_sif : Path | None
+        Prerequisite SIF for a layered .def, symlinked into the staging dir
+        so ``From: ./<name>.sif`` resolves. ``None`` for top-of-stack defs.
+    verify : bool
+        Run the verify rebuild + version-set comparison inline. False
+        captures the lock and the locked def but leaves the build UNMARKED
+        — useful when the second build is being scheduled separately, and
+        honest about it: an unmarked build is treated as unverified by the
+        use-time gate.
+
+    Returns
+    -------
+    RoundTripResult
+        scitex-container's result object: ``sif`` / ``lock`` / ``locked_def``
+        / ``verified`` / ``diff`` / ``marker``.
+
+    Raises
+    ------
+    RuntimeError
+        Propagated when the underlying apptainer build fails. A round-trip
+        MISMATCH does NOT raise — it marks ``.unverified`` and returns.
+    FileNotFoundError
+        Propagated from :func:`stage_build_context` if inputs are missing.
+    """
+    artifact_dir = output_dir / f"sac-{layer}"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    staging_dir = artifact_dir / "build-context"
+    staged_def = stage_build_context(
+        pkg_root, def_path, staging_dir, bootstrap_sif=bootstrap_sif
+    )
+
+    return _container_build_reproducible(
+        def_path=staged_def,
+        output_dir=output_dir,
+        cwd=staging_dir,
+        image_name=f"sac-{layer}",
+        force=force,
+        verify=verify,
+    )
+
+
+def describe_result(result: Any) -> list[str]:
+    """Render a round-trip result as operator-facing lines.
+
+    Kept beside the build so the CLI verb stays a thin dispatcher, and so
+    the *unverified* case reads as a finding rather than a stack trace: the
+    drift summary names what moved between the two builds.
+    """
+    lines = [f"artifact  {result.sif}", f"lock      {result.lock}"]
+    lines.append(f"recipe    {result.locked_def}")
+    if result.verified is None:
+        lines.append(
+            "verify    SKIPPED — build is UNMARKED, so the use-time gate "
+            "treats it as unverified"
+        )
+        return lines
+    if result.verified:
+        lines.append("verify    VERIFIED — rebuild produced the same version set")
+        lines.append(f"marker    {result.marker}")
+        return lines
+    detail = result.diff.summary() if result.diff is not None else "unknown drift"
+    lines.append(f"verify    MISMATCH — {detail}")
+    lines.append(f"marker    {result.marker}")
+    lines.append(
+        "          the image is USABLE but its reproducibility is unproven; "
+        "the drift above is what a rebuild changed"
+    )
+    return lines
+
+
+def validate_flags(
+    *, reproducible: bool, sandbox: bool, skip_verify: bool
+) -> str | None:
+    """Return an error message for an impossible flag combination, else None.
+
+    Kept out of the verb so ``sac image build`` stays a dispatcher, and out
+    of ``build_layer_reproducible`` so the refusal happens BEFORE any
+    staging work (a build context is an rm -rf + a full source copytree).
+    """
+    if reproducible and sandbox:
+        return (
+            "--reproducible and --sandbox are mutually exclusive. The round "
+            "trip compares two immutable SIFs; a sandbox is a mutable "
+            "directory with nothing to compare."
+        )
+    if skip_verify and not reproducible:
+        return "--skip-verify only applies with --reproducible."
+    return None
+
+
+def run_build(
+    *,
+    layer: str,
+    def_path: Path,
+    pkg_root: Path,
+    output_dir: Path,
+    bootstrap_sif: Path | None,
+    verify: bool,
+) -> Any:
+    """Run the round trip for the CLI and report it. Exits non-zero on failure.
+
+    This is the verb's whole reproducible branch, lifted here so
+    ``image_group`` stays a dispatcher. It owns the operator-facing
+    reporting because the interesting outcome is not "a file appeared" but
+    WHETHER THE VERSION SETS MATCHED — and, when they did not, what moved.
+    """
+    import sys
+
+    import click
+
+    from ._helpers import console
+
+    try:
+        result = build_layer_reproducible(
+            layer=layer,
+            def_path=def_path,
+            pkg_root=pkg_root,
+            output_dir=output_dir,
+            force=True,
+            bootstrap_sif=bootstrap_sif,
+            verify=verify,
+        )
+    except (FileNotFoundError, RuntimeError) as exc:
+        click.echo(f"error: apptainer build failed: {exc}", err=True)
+        sys.exit(1)
+    console.print(f"[green]built[/green] {result.sif}")
+    for line in describe_result(result):
+        click.echo(line)
+    return result
+
+
+__all__ = [
+    "build_layer_reproducible",
+    "describe_result",
+    "run_build",
+    "validate_flags",
+    "_default_container_build_reproducible",
+    "_container_build_reproducible",
+]

--- a/src/scitex_agent_container/cli_pkg/image_group.py
+++ b/src/scitex_agent_container/cli_pkg/image_group.py
@@ -25,7 +25,12 @@ from pathlib import Path
 import click
 
 from .. import _build_priority
-from . import _image_inventory_cmds, _image_remote_bake, _image_source_build
+from . import (
+    _image_inventory_cmds,
+    _image_remote_bake,
+    _image_repro_build,
+    _image_source_build,
+)
 from ._helpers import HelpRecursiveGroup, console
 from ._helpers._console import logger
 
@@ -34,6 +39,9 @@ from ._helpers._console import logger
 # pattern as ``_load_apptainer``); production code calls through it so
 # tests don't need to patch the cli_pkg._image_source_build module.
 _build_layer_from_source = _image_source_build.build_layer_from_source
+
+# Same seam for the reproducible round-trip path (``--reproducible``).
+_run_reproducible_build = _image_repro_build.run_build
 
 # Same seam pattern for the low-priority self-demotion
 # (incident-local-heavy-build) — tests swap in a recording fake so the
@@ -67,9 +75,17 @@ _CONTAINERS_DIR = Path.home() / ".scitex" / "agent-container" / "containers"
 _SCITEX_USER_STATE_ROOT = Path.home() / ".scitex"
 
 # Layer → .def filename mapping.
+#
+# ``proxy`` ships a recipe (containers/apptainer-proxy.def, force-included in
+# the wheel) and the source-build path already treats it as a first-class
+# layer — ``build_layer_from_source`` documents ``base``/``scitex``/``proxy``
+# and ``resolve_bootstrap_sif`` names ``proxy`` among the top-of-stack layers
+# that bootstrap off a registry image rather than a prior SIF. Only this map
+# omitted it, which left sac shipping one recipe nothing could build.
 _LAYERS = {
     "base": "apptainer-base.def",
     "scitex": "apptainer-scitex.def",
+    "proxy": "apptainer-proxy.def",
 }
 _DEFAULT_LAYER = "base"
 
@@ -179,8 +195,31 @@ image_group.add_command(_image_remote_bake.image_bake_remote)
     help="Build at normal priority (skip the default nice-19 + ionice "
     "best-effort-low self-demotion; for dedicated build machines / CI).",
 )
+@click.option(
+    "--reproducible",
+    is_flag=True,
+    default=False,
+    help="Run the reproducible round trip: capture this build's version "
+    "set into a .lock, emit a version-pinned .def, rebuild from it, "
+    "compare the two version sets, and mark .verified/.unverified. "
+    "Costs a SECOND full build.",
+)
+@click.option(
+    "--skip-verify",
+    is_flag=True,
+    default=False,
+    help="With --reproducible: capture the lock + pinned .def but skip the "
+    "verify rebuild. Leaves the build UNMARKED (the use-time gate reads "
+    "that as unverified).",
+)
 def image_build(
-    layer: str, sandbox: bool, dry_run: bool, yes: bool, no_nice: bool
+    layer: str,
+    sandbox: bool,
+    dry_run: bool,
+    yes: bool,
+    no_nice: bool,
+    reproducible: bool,
+    skip_verify: bool,
 ) -> None:
     """Build the :LAYER Apptainer SIF (default: base).
 
@@ -188,12 +227,27 @@ def image_build(
     Builds self-demote to low CPU/IO priority by default so a bake
     can't starve an interactive host; ``--no-nice`` restores full speed.
 
+    ``--reproducible`` additionally PROVES the image can be produced
+    again: it freezes the versions that actually landed, generates a
+    pinned recipe, rebuilds from that recipe, and compares the two
+    version sets. Identical → ``.verified``; drift → ``.unverified``
+    carrying the diff (the image stays usable — a mismatch is a finding,
+    not a build failure). "Reproducible" here means ENVIRONMENT IDENTITY
+    (same version set), not byte-identical digests.
+
     \b
     Examples:
       $ sac image build                # apptainer :base SIF (default; OS + dev tools, ~15-25 min)
       $ sac image build scitex         # apptainer :scitex SIF (FROM :base + scitex[all], ~10-20 min)
       $ sac image build --sandbox      # writable sandbox dir
+      $ sac image build --reproducible # round trip + .verified marker (~2x build time)
     """
+    flag_error = _image_repro_build.validate_flags(
+        reproducible=reproducible, sandbox=sandbox, skip_verify=skip_verify
+    )
+    if flag_error:
+        click.echo(f"error: {flag_error}", err=True)
+        sys.exit(2)
     out_dir = _ensure_containers_dir()
     # Existing-artefact notice. A SIF rebuild is now ATOMIC (delegated to
     # scitex-container's ``build``): it lands a fresh timestamped SIF and
@@ -279,6 +333,21 @@ def image_build(
     # under load (see _build_priority module docstring).
     for line in _demote_build_priority(skip=no_nice):
         click.echo(line)
+
+    if reproducible:
+        # Builds TWICE: the rough build, then a rebuild from the generated
+        # pinned recipe. Both go through the same staged build context —
+        # the reason scitex-container needed a ``cwd`` before sac could
+        # call this at all.
+        _run_reproducible_build(
+            layer=layer,
+            def_path=def_path,
+            pkg_root=pkg_root,
+            output_dir=out_dir,
+            bootstrap_sif=bootstrap_sif,
+            verify=not skip_verify,
+        )
+        return
 
     try:
         output = _build_layer_from_source(

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -19,7 +19,25 @@
 # Layer this with apptainer-scitex.def to add scitex[all] + claude-sdk + sac.
 
 Bootstrap: docker
-From: ubuntu:24.04
+# PINNED BY DIGEST, not by tag. ``ubuntu:24.04`` is a MOVING tag — Canonical
+# republishes it for every point release and security refresh, so two builds
+# a month apart start from different bytes and the version-set comparison has
+# no fixed floor to stand on. The digest below is 24.04.4 LTS, the exact base
+# the live fleet image was built from (verified in-image 2026-08-12).
+#
+# The trade this makes, stated plainly: a pinned base stops picking up
+# Canonical's refreshed layer on rebuild. BUMP IT DELIBERATELY (resolve with
+# ``curl`` against registry-1.docker.io, or ``skopeo inspect
+# docker://ubuntu:24.04``) rather than letting it drift silently.
+#
+# Note this pins the STARTING layer only. ``%post`` still runs ``apt-get
+# update``, which pulls whatever the Ubuntu archive currently holds, so apt
+# packages can still move. That residual drift is DETECTED — the reproducible
+# round trip (``sac image build --reproducible``) captures dpkg versions into
+# the .lock and reports any change — but not yet prevented; pinning apt needs
+# ``pkg=ver`` injection or snapshot.ubuntu.com, which scitex-container's
+# ``generate_locked_def`` explicitly defers.
+From: ubuntu@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea
 
 %files
     # Bundle the package's OWN source tree so the in-SIF sac is the
@@ -244,13 +262,26 @@ From: ubuntu:24.04
     # For the operator's hand-curated extra Rust-CLI set (per-host,
     # post-launch in an overlay) see ``~/.bin/installers/install_rust_clis.sh``
     # in the operator dotfiles.
+    # The rustup INSTALLER at sh.rustup.rs is unversioned, but the toolchain
+    # it lays down is what actually ends up in the image — so pin THAT with
+    # --default-toolchain. Without it, `sh.rustup.rs -y` installs whatever
+    # "stable" means on build day and the two halves of a round trip can
+    # land different rustc versions. 1.97.1 is what the live fleet image
+    # carries (verified in-image 2026-08-12).
     export RUSTUP_HOME=/opt/rust
     export CARGO_HOME=/opt/cargo
+    RUST_TOOLCHAIN=1.97.1
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-        | sh -s -- -y --profile minimal --no-modify-path
+        | sh -s -- -y --profile minimal --no-modify-path \
+              --default-toolchain "${RUST_TOOLCHAIN}"
     export PATH=/opt/cargo/bin:$PATH
+    # PINNED: ``releases/latest/download`` is a moving target, exactly like
+    # the yq fetch below and unlike the gdu fetch in 4c which has been
+    # pinned all along for the same reason. 1.21.1 is what the live fleet
+    # image carries (verified in-image 2026-08-12).
+    CARGO_BINSTALL_VERSION=1.21.1
     curl --proto '=https' --tlsv1.2 -sSfL \
-        https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz \
+        "https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-x86_64-unknown-linux-musl.tgz" \
         | tar xz -C /opt/cargo/bin/
     chmod +x /opt/cargo/bin/cargo-binstall
     cargo binstall --no-confirm --force sd du-dust
@@ -263,8 +294,13 @@ From: ubuntu:24.04
     # uses. Pull the Go binary directly to /usr/local/bin so callers
     # get the expected `.path | select(...)` syntax — non-interactive,
     # single static binary, no runtime deps.
+    # PINNED for the same reason gdu is pinned in 4c: callers depend on a
+    # stable CLI surface across rebuilds, and ``releases/latest/download``
+    # silently retargets whenever upstream tags. v4.53.3 is what the live
+    # fleet image carries (verified in-image 2026-08-12).
+    YQ_VERSION=4.53.3
     curl -fsSL \
-        https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+        "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" \
         -o /usr/local/bin/yq
     chmod +x /usr/local/bin/yq
 

--- a/src/scitex_agent_container/containers/apptainer-proxy.def
+++ b/src/scitex_agent_container/containers/apptainer-proxy.def
@@ -30,7 +30,11 @@
 #      worker hosts.
 
 Bootstrap: docker
-From: ubuntu:24.04
+# PINNED BY DIGEST — same reasoning as apptainer-base.def: ``ubuntu:24.04``
+# is a moving tag, so two builds a month apart start from different bytes.
+# Kept in lockstep with the base recipe's digest (24.04.4 LTS) so the two
+# top-of-stack layers share one floor.
+From: ubuntu@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea
 
 %files
     # Bundle the package's OWN source tree so the in-SIF sac is the

--- a/tests/scitex_agent_container/cli_pkg/test__image_repro_build.py
+++ b/tests/scitex_agent_container/cli_pkg/test__image_repro_build.py
@@ -1,0 +1,304 @@
+"""Tests for ``cli_pkg/_image_repro_build.py`` — the reproducible round trip.
+
+No MagicMock: the round-trip call is a hand-rolled real callable swapped in
+through the module-level ``_container_build_reproducible`` seam (the same
+save/restore pattern ``test__image_source_build`` and ``test_image_group``
+use), and the staging it exercises writes real files into tmp_path.
+
+The behaviour worth pinning is WHAT REACHES scitex-container — above all the
+build context (``cwd``). sac's whole contribution to a build is a staged
+directory holding its own source tree and the prerequisite layer's SIF; the
+shipped recipes reference both by RELATIVE path. If that directory does not
+arrive as the build cwd, apptainer FATALs before running a line of ``%post``.
+That missing argument is the entire reason the round trip shipped in
+scitex-container for months with zero callers.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container.cli_pkg import _image_repro_build as irb
+
+
+@pytest.fixture
+def fake_pkg_root(tmp_path: Path) -> Path:
+    """A real on-disk fake of the installed package tree (no MagicMock).
+
+    Mirrors a wheel-install layout closely enough for
+    ``stage_build_context``: the bundled build inputs pyproject NAMES must
+    all be present or staging refuses.
+    """
+    root = tmp_path / "scitex_agent_container"
+    root.mkdir()
+    (root / "__init__.py").write_text("__version__ = '0.0.0-test'\n")
+    bundled = root / "_bundled"
+    bundled.mkdir()
+    (bundled / "pyproject.toml").write_text(
+        "[project]\nname = 'scitex-agent-container'\nversion = '0.0.0-test'\n"
+    )
+    (bundled / "README.md").write_text("# fake readme for tests\n")
+    (bundled / "hatch_build.py").write_text("# fake build hook\n")
+    return root
+
+
+@pytest.fixture
+def recipe(tmp_path: Path) -> Path:
+    """A real .def file to stage."""
+    p = tmp_path / "apptainer-proxy.def"
+    p.write_text(
+        "Bootstrap: docker\nFrom: ubuntu:24.04\n\n%files\n"
+        "    scitex-agent-container-src /opt/scitex-agent-container-src\n"
+    )
+    return p
+
+
+@contextmanager
+def _use_roundtrip(*, result=None, raises=None) -> Iterator[list[dict]]:
+    """Swap ``_container_build_reproducible`` for a recording callable."""
+    calls: list[dict] = []
+
+    def _recording(**kw):
+        calls.append(kw)
+        if raises is not None:
+            raise raises
+        return result
+
+    saved = irb._container_build_reproducible
+    irb._container_build_reproducible = _recording  # type: ignore[assignment]
+    try:
+        yield calls
+    finally:
+        irb._container_build_reproducible = saved  # type: ignore[assignment]
+
+
+@dataclass
+class _FakeDiff:
+    text: str = "1 changed (pip:numpy: 2.1.0 -> 2.2.0)"
+
+    def summary(self) -> str:
+        return self.text
+
+
+@dataclass
+class _FakeResult:
+    """Stand-in for scitex-container's RoundTripResult (same attributes)."""
+
+    sif: Path = Path("/c/sac-proxy/sac-proxy-ts.sif")
+    lock: Path = Path("/c/sac-proxy/sac-proxy-ts.lock")
+    locked_def: Path = Path("/c/sac-proxy/sac-proxy-ts.def")
+    verified: bool | None = True
+    diff: object | None = None
+    marker: Path = field(default=Path("/c/sac-proxy/sac-proxy-ts.verified"))
+
+
+def _build(tmp_path, pkg_root, recipe, **kw):
+    return irb.build_layer_reproducible(
+        layer=kw.pop("layer", "proxy"),
+        def_path=recipe,
+        pkg_root=pkg_root,
+        output_dir=tmp_path / "containers",
+        **kw,
+    )
+
+
+class TestBuildContextReachesTheRoundTrip:
+    """The staged directory must arrive as the build ``cwd``."""
+
+    def test_passes_the_staging_dir_as_cwd(self, tmp_path, fake_pkg_root, recipe):
+        # Arrange
+        with _use_roundtrip(result=_FakeResult()) as calls:
+            # Act
+            _build(tmp_path, fake_pkg_root, recipe)
+        # Assert
+        assert calls[0]["cwd"] == tmp_path / "containers" / "sac-proxy" / "build-context"
+
+    def test_staged_source_tree_exists_at_that_cwd(
+        self, tmp_path, fake_pkg_root, recipe
+    ):
+        # Arrange
+        with _use_roundtrip(result=_FakeResult()) as calls:
+            # Act
+            _build(tmp_path, fake_pkg_root, recipe)
+        # Assert — the relative %files source the recipe names
+        assert (calls[0]["cwd"] / "scitex-agent-container-src").is_dir()
+
+    def test_staged_def_is_the_one_handed_to_the_round_trip(
+        self, tmp_path, fake_pkg_root, recipe
+    ):
+        # Arrange
+        with _use_roundtrip(result=_FakeResult()) as calls:
+            # Act
+            _build(tmp_path, fake_pkg_root, recipe)
+        # Assert — the staged copy, not the source recipe
+        assert calls[0]["def_path"] == calls[0]["cwd"] / recipe.name
+
+
+class TestRoundTripArguments:
+    """Layer naming, output root and the verify toggle."""
+
+    def test_maps_layer_to_sac_prefixed_image_name(
+        self, tmp_path, fake_pkg_root, recipe
+    ):
+        # Arrange
+        with _use_roundtrip(result=_FakeResult()) as calls:
+            # Act
+            _build(tmp_path, fake_pkg_root, recipe, layer="base")
+        # Assert
+        assert calls[0]["image_name"] == "sac-base"
+
+    def test_passes_the_containers_dir_as_root(self, tmp_path, fake_pkg_root, recipe):
+        # Arrange
+        with _use_roundtrip(result=_FakeResult()) as calls:
+            # Act
+            _build(tmp_path, fake_pkg_root, recipe)
+        # Assert
+        assert calls[0]["output_dir"] == tmp_path / "containers"
+
+    def test_verify_defaults_to_on(self, tmp_path, fake_pkg_root, recipe):
+        # Arrange
+        with _use_roundtrip(result=_FakeResult()) as calls:
+            # Act
+            _build(tmp_path, fake_pkg_root, recipe)
+        # Assert
+        assert calls[0]["verify"] is True
+
+    def test_verify_can_be_skipped(self, tmp_path, fake_pkg_root, recipe):
+        # Arrange
+        with _use_roundtrip(result=_FakeResult()) as calls:
+            # Act
+            _build(tmp_path, fake_pkg_root, recipe, verify=False)
+        # Assert
+        assert calls[0]["verify"] is False
+
+    def test_returns_the_round_trip_result(self, tmp_path, fake_pkg_root, recipe):
+        # Arrange
+        expected = _FakeResult()
+        with _use_roundtrip(result=expected):
+            # Act
+            got = _build(tmp_path, fake_pkg_root, recipe)
+        # Assert
+        assert got is expected
+
+
+class TestValidateFlags:
+    """Impossible combinations are refused BEFORE any staging work."""
+
+    def test_reproducible_with_sandbox_is_refused(self):
+        # Arrange
+        # Act
+        msg = irb.validate_flags(reproducible=True, sandbox=True, skip_verify=False)
+        # Assert
+        assert "mutually exclusive" in msg
+
+    def test_skip_verify_without_reproducible_is_refused(self):
+        # Arrange
+        # Act
+        msg = irb.validate_flags(reproducible=False, sandbox=False, skip_verify=True)
+        # Assert
+        assert "--skip-verify only applies with --reproducible." == msg
+
+    def test_reproducible_alone_is_allowed(self):
+        # Arrange
+        # Act
+        msg = irb.validate_flags(reproducible=True, sandbox=False, skip_verify=False)
+        # Assert
+        assert msg is None
+
+    def test_reproducible_with_skip_verify_is_allowed(self):
+        # Arrange
+        # Act
+        msg = irb.validate_flags(reproducible=True, sandbox=False, skip_verify=True)
+        # Assert
+        assert msg is None
+
+    def test_plain_sandbox_build_is_allowed(self):
+        # Arrange
+        # Act
+        msg = irb.validate_flags(reproducible=False, sandbox=True, skip_verify=False)
+        # Assert
+        assert msg is None
+
+
+class TestDescribeResult:
+    """The interesting outcome is whether the version sets matched."""
+
+    def test_verified_build_reports_verified(self):
+        # Arrange
+        result = _FakeResult(verified=True)
+        # Act
+        lines = irb.describe_result(result)
+        # Assert
+        assert any("VERIFIED" in line for line in lines)
+
+    def test_mismatch_reports_the_drift(self):
+        # Arrange
+        result = _FakeResult(verified=False, diff=_FakeDiff())
+        # Act
+        lines = irb.describe_result(result)
+        # Assert
+        assert any("pip:numpy: 2.1.0 -> 2.2.0" in line for line in lines)
+
+    def test_mismatch_says_the_image_is_still_usable(self):
+        # Arrange
+        result = _FakeResult(verified=False, diff=_FakeDiff())
+        # Act
+        lines = irb.describe_result(result)
+        # Assert
+        assert any("USABLE" in line for line in lines)
+
+    def test_skipped_verify_reports_unmarked(self):
+        # Arrange
+        result = _FakeResult(verified=None)
+        # Act
+        lines = irb.describe_result(result)
+        # Assert
+        assert any("SKIPPED" in line for line in lines)
+
+    def test_reports_the_lock_path(self):
+        # Arrange
+        result = _FakeResult()
+        # Act
+        lines = irb.describe_result(result)
+        # Assert
+        assert any(str(result.lock) in line for line in lines)
+
+
+class TestRunBuildFailure:
+    """A failed apptainer build exits non-zero rather than tracebacking."""
+
+    def test_build_failure_exits_nonzero(self, tmp_path, fake_pkg_root, recipe):
+        # Arrange
+        ctx = pytest.raises(SystemExit)
+        # Act
+        # Assert
+        with _use_roundtrip(raises=RuntimeError("apptainer died")), ctx:
+            irb.run_build(
+                layer="proxy",
+                def_path=recipe,
+                pkg_root=fake_pkg_root,
+                output_dir=tmp_path / "containers",
+                bootstrap_sif=None,
+                verify=True,
+            )
+
+    def test_successful_run_returns_the_result(self, tmp_path, fake_pkg_root, recipe):
+        # Arrange
+        expected = _FakeResult()
+        # Act
+        with _use_roundtrip(result=expected):
+            got = irb.run_build(
+                layer="proxy",
+                def_path=recipe,
+                pkg_root=fake_pkg_root,
+                output_dir=tmp_path / "containers",
+                bootstrap_sif=None,
+                verify=True,
+            )
+        # Assert
+        assert got is expected

--- a/tests/scitex_agent_container/cli_pkg/test_image_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_image_group.py
@@ -338,6 +338,102 @@ def test_build_sandbox_flag_forwarded_to_source_builder(home_tmp):
     assert calls[0][1]["sandbox"] is True
 
 
+@contextmanager
+def _use_reproducible_builder(*, result=None) -> Iterator[list[dict]]:
+    """Swap ``image_group._run_reproducible_build`` for a recording fake.
+
+    Same save/restore pattern as ``_use_source_builder``. The round trip
+    itself is covered in ``test__image_repro_build``; what matters here is
+    that ``--reproducible`` ROUTES to it instead of the plain build.
+    """
+    calls: list[dict] = []
+
+    def _fake(**kw):
+        calls.append(kw)
+        return result
+
+    saved = ig._run_reproducible_build
+    ig._run_reproducible_build = _fake  # type: ignore[assignment]
+    try:
+        yield calls
+    finally:
+        ig._run_reproducible_build = saved  # type: ignore[assignment]
+
+
+def test_build_reproducible_routes_to_the_round_trip(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _use_reproducible_builder() as calls:
+        runner.invoke(image_group, ["build", "base", "--yes", "--reproducible"])
+    # Assert
+    assert len(calls) == 1
+
+
+def test_build_reproducible_does_not_call_the_plain_builder(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _use_source_builder(result=Path("/tmp/x.sif")) as plain:
+        with _use_reproducible_builder():
+            runner.invoke(image_group, ["build", "base", "--yes", "--reproducible"])
+    # Assert
+    assert plain == []
+
+
+def test_build_reproducible_verifies_by_default(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _use_reproducible_builder() as calls:
+        runner.invoke(image_group, ["build", "base", "--yes", "--reproducible"])
+    # Assert
+    assert calls[0]["verify"] is True
+
+
+def test_build_skip_verify_turns_the_replay_off(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _use_reproducible_builder() as calls:
+        runner.invoke(
+            image_group,
+            ["build", "base", "--yes", "--reproducible", "--skip-verify"],
+        )
+    # Assert
+    assert calls[0]["verify"] is False
+
+
+def test_build_reproducible_with_sandbox_is_refused(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        image_group, ["build", "base", "--yes", "--reproducible", "--sandbox"]
+    )
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_build_skip_verify_without_reproducible_is_refused(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(image_group, ["build", "base", "--yes", "--skip-verify"])
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_build_accepts_the_proxy_layer(home_tmp):
+    # Arrange — proxy shipped a recipe that no layer mapping could reach
+    runner = CliRunner()
+    # Act
+    with _use_source_builder(result=Path("/tmp/sac-proxy.sif")) as calls:
+        runner.invoke(image_group, ["build", "proxy", "--yes"])
+    # Assert
+    assert calls[0][1]["def_path"].name == "apptainer-proxy.def"
+
+
 def test_build_reports_apptainer_failure_with_exit_code_1(home_tmp):
     # Arrange
     runner = CliRunner()


### PR DESCRIPTION
> **Sequenced.** Needs `scitex-container` 0.4.0 — scitex-ai/scitex-container#47
> — which adds the `cwd` this PR passes. The dependency floor is raised to
> `>=0.4.0` here; against 0.3.0 the call is a `TypeError`.
>
> That upstream PR also fixes something this consumer would have been the
> victim of: the round trip published only the TOP-level symlink, leaving the
> inner `<layer>/<layer>.sif` **boot** path — the one sac's runtime actually
> resolves images through — pointing at the *previous* build. Every layer of
> verification would have run correctly against an artifact nothing would
> load: reproducibility that is verifiably correct and completely inert, with
> a real `.verified` marker attached to the wrong image. Worth knowing when
> reviewing this PR, because it is the reason `--reproducible` here can be
> trusted to describe the image that boots.

## What this changes

`sac image build --reproducible` — sac now calls the reproducible round trip
it has had access to all along, and the base recipes stop bootstrapping from
moving targets.

## The measurement

The operator confirmed build reproducibility is still a live requirement for
an unsubmitted paper, and chose between two readings of the word:

- **A — environment identity: the same version set comes back. CHOSEN.**
- B — byte-for-byte identical digests. **Explicitly out of scope.**

So no `SOURCE_DATE_EPOCH` and no squashfs timestamp determinism here.
scitex-container's own design already calls byte-identity "an OPTIONAL
stretch, deliberately NOT the default gate"; that stays true.

scitex-container has shipped the entire apparatus for months —
`build_reproducible`, `capture_lock`, `generate_locked_def`, `compare_locks`,
the `.verified` / `.unverified` markers, the use-time gate — all publicly
exported. **sac referenced none of it.** An `rg` over `src/` found zero hits,
and a `find` for `*.lock` / `*.verified` / `*.unverified` under the containers
dir returned nothing: the round trip had never run on this host.

## Why it could not be called

`build_reproducible()` took no build **context**, and sac's whole contribution
to a build *is* a staged context — a copy of its own source tree beside the
`.def` plus a symlink to the prerequisite layer's SIF — because the shipped
recipes pull sac in by relative path:

```
%files
    scitex-agent-container-src /opt/scitex-agent-container-src
...
Bootstrap: localimage
From: ./sac-base.sif
```

Those paths exist only inside the staging directory. Resolved against the
containers dir they do not exist, and apptainer FATALs before running a line
of `%post`.

That is also the mechanism behind the long-standing observation that
**rebuilding a SIF by hand goes wrong while building through the `sac` verb
works**: a raw `apptainer build` on a shipped recipe fails for exactly this
reason, because only the verb creates the staging directory the relative paths
resolve against. Always use the verb.

## What landed

**`cli_pkg/_image_repro_build.py`** stages the build context exactly as the
plain source build does (same `stage_build_context`, same staging directory)
and hands that directory to the round trip as `cwd`, which forwards it to
*both* the rough build and the verify rebuild. The staging dir must outlive
the rough build, and does: the locked def is the rough def plus a pin stanza,
so it carries the identical relative references and must replay against the
same context.

**`--reproducible` / `--skip-verify` on the verb.** It previously had only
`--sandbox` / `--dry-run` / `-y` / `--no-nice` and so genuinely could not
express "build reproducibly" — a defect in its own right. A version-set
mismatch is reported as a **finding, not a build failure**: the rough SIF
stays usable and is marked `.unverified` carrying the drift, because an image
you can use with honestly-recorded unproven provenance beats no image and a
red X.

**`proxy` is buildable.** `_LAYERS` mapped only `base` and `scitex`, so the
shipped `apptainer-proxy.def` was a recipe nothing could build — even though
`build_layer_from_source` documents `base`/`scitex`/`proxy` and
`resolve_bootstrap_sif` already names `proxy` among the top-of-stack layers.
An oversight, not a policy.

## Pinning the base inputs

Replay only re-pins **pip** (`generate_locked_def` defers apt/node injection
by design), so these could not be fixed by the round trip and are done
directly:

| input | was | now |
|---|---|---|
| base image (base + proxy) | `ubuntu:24.04` (moving tag) | digest of 24.04.4 LTS |
| `yq` | `releases/latest/download` | v4.53.3 |
| `cargo-binstall` | `releases/latest/download` | v1.21.1 |
| rust toolchain | whatever `stable` meant on build day | `--default-toolchain 1.97.1` |

Every one of those values is **what the live fleet image already carries**
(verified by exec'ing into the running SIF), so the pins freeze the current
state rather than moving it. `gdu` was already pinned this way, for the
identical stated reason.

### `@anthropic-ai/claude-code@latest` is deliberately left floating

The recipe documents that float as an explicit operator directive — carry the
latest of all ecosystem packages, unlock the `fable[1m]` model. Pinning it
would contradict a stated decision and could cost the fleet its model access.

**The consequence, stated plainly so nobody is surprised by it: a
`--reproducible` base build will report `.unverified` whenever a claude-code
release lands between the rough build and the verify rebuild.**

That is not a flaw in the round trip. It is the round trip doing precisely its
job — making visible a drift that has been in every image we have ever built
and that nothing was watching. The version set genuinely differs between the
two builds; the honest report is `.unverified`, and the image stays usable.

**So do not "fix" that unverified result by weakening the check.** The
tempting repairs — excluding npm globals from the comparison, treating
node-tier drift as advisory, marking `.verified` when only the floating
package moved — all convert a true negative into a green light, which is
exactly the failure this whole apparatus exists to prevent. There are only two
legitimate moves: pin claude-code (a product decision that costs the fleet
`fable[1m]`), or accept the `.unverified` marker as the accurate description of
an image with one deliberately-floating input.

The drift was always there. It was just invisible.

Note the digest pins the **starting layer only** — `%post` still runs
`apt-get update`, so apt packages can move. That residual drift is now
*detected* (dpkg versions are captured in the `.lock` and compared) but not
yet prevented.

## Proof

Run on scitex-compute-04 through the verb:

```
$ sac image build proxy -y --reproducible
built     .../sac-proxy/sac-proxy-2026-0812-094223.sif
artifact  .../sac-proxy/sac-proxy-2026-0812-094223.sif
lock      .../sac-proxy/sac-proxy-2026-0812-094223.lock
recipe    .../sac-proxy/sac-proxy-2026-0812-094223.def
verify    VERIFIED — rebuild produced the same version set
marker    .../sac-proxy/sac-proxy-2026-0812-094223.verified

$ cat .../sac-proxy-2026-0812-094223.verified
round-trip verified at 2026-08-12T09:47:09.063856
```

273-package lock captured host-isolated, pinned `.def` generated, verify
rebuild replayed it through the same staged context, version sets compared
identical, `.verified` written, throwaway verify SIF and scratch dir cleaned
up, and both stable symlinks repointed at the new build.

**Shared-image safety.** `proxy` was chosen deliberately: nothing boots off
it, and it did not exist on this host. `sac-base.sif` and `sac-scitex.sif` —
the images the six running agents use — were **not touched** (mtimes confirm
they predate the build). The shape is unchanged from the existing atomic
build: fresh timestamped SIF, symlink swapped only at the end, previous file
left on disk, rollback is one repoint.

```
$ .../python -m pytest tests/scitex_agent_container/cli_pkg/ -q
2614 passed, 1 skipped, 16 deselected in 144.85s (0:02:24)

$ .../python -m pytest test_image_group.py test__image_repro_build.py test__image_source_build.py -q
129 passed in 19.86s
```

## What I could not verify

- **Byte identity** — out of scope by the operator's choice, not attempted,
  not claimed.
- **A `base` or `scitex` round trip.** Only `proxy` was built. The other two
  layers exercise the same code path but cost ~2×20 min each and `scitex`
  would repoint the symlink the running fleet boots from. Notably, a `base`
  round trip is the one most likely to come back `.unverified`, for the
  floating-claude-code reason above.
- **Whether apt drift actually occurs across a rebuild** — the mechanism is
  now instrumented, but a drift event has not been observed.

## Pre-existing, not introduced here

`tests/integration/telegram_hooks/test_telegram_hooks_self_tests.py::test_encourage_telegram_terse_style_self_test_passes`
fails — and fails **identically on the untouched main checkout**. The cause is
visible in the output: a stale coverage `.pth` in the environment raises
`ModuleNotFoundError: No module named 'coverage'` into a subprocess's stderr,
so the self-test's `returncode` is 1. Environmental, unrelated to this change,
left for a separate fix rather than widening this PR.

One side effect worth naming: the round trip's existing
`_discard_stray_locks` deleted the old root-level `requirements-lock.txt` /
`dpkg-lock.txt` / `node-lock.txt` from the containers dir during the proof
run. That is upstream's pre-existing cleanup, not new behaviour, and those
files were the host-bleed records the artifact-scoped `.lock` replaces — but
they were removed rather than moved aside.
