### PR TITLE
fix(launch): the card DSN was emitted twice, and only argv order made it right

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_argv_finalize.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_argv_finalize.py
@@ -1,0 +1,152 @@
+"""The final assembly phase of the ``apptainer exec`` flag argv.
+
+Extracted from :mod:`._apptainer_build_argv` (which crossed the 512-line
+per-file cap). Everything here runs AFTER the last ``--env`` / ``--bind``
+contributor — including ``spec.apptainer.raw_args`` — and BEFORE the SIF
+path is appended.
+
+That is a real phase, not an arbitrary cut: every step in it exists
+because of an **ordering invariant** on the finished flag region, and
+those invariants only hold if the whole region is already present.
+
+1. **Reconcile duplicate ``--env`` keys.** Several layers contribute
+   ``--env`` and two of them routinely name the same key. Collapse to a
+   single occurrence so the launch stops depending on apptainer's
+   last-wins tie-break to be correct — see :mod:`._apptainer_env_dedup`.
+2. **Refuse a banned scitex DSN.** Once one value per key survives, check
+   the one that will actually reach the container (ADR-0022: port 5432 is
+   never used for scitex).
+3. **Bind the overlay upper-home** over the container ``$HOME``, after
+   ``raw_args`` so it wins over a raw-arg ``--home`` tmpfs.
+4. **Lift secret-shaped ``--env`` into a 0600 env-file**, after every
+   ``--env`` source so nothing is missed, before the creds bind so that
+   bind stays last.
+5. **Emit the designated credentials bind last**, so no earlier bind can
+   shadow it.
+6. **Validate the flag region** as a whole, which is only meaningful once
+   it is complete.
+
+``finalize_flag_argv`` is pure with respect to its ``argv`` argument (a
+new list is returned). It does touch the filesystem — writing the 0600
+secrets file and pre-creating the credentials bind target — because both
+must exist before apptainer runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ._apptainer_argv_guard import validate_flag_argv
+
+
+def finalize_flag_argv(
+    argv: list[str],
+    config: Any,
+    *,
+    state_dir: Path,
+    home_host: Path,
+    upper_home: Path | None,
+    spec_raw_args: list[str],
+) -> list[str]:
+    """Run the ordering-sensitive tail passes over the flag argv.
+
+    ``argv`` must already carry every contributed flag, ``raw_args``
+    included, and must NOT yet carry the SIF path or the inner command —
+    the passes below assume the list they walk is the flag region.
+
+    ``upper_home`` is the resolved overlay upper-home (``None`` for
+    non-overlay specs) and ``home_host`` the workspace home; both are
+    resolved by the caller, which needs them earlier for its own bind
+    decisions. ``spec_raw_args`` is passed through solely so the
+    malformed-flag guard can attribute a fault to the spec rather than
+    to sac.
+
+    Raises :class:`._apptainer_env_dedup.ForbiddenScitexDsnError` or
+    :class:`._apptainer_argv_guard.ApptainerArgvError` rather than
+    returning an argv that would misroute or misparse.
+    """
+    from ._apptainer_env_dedup import (
+        assert_no_forbidden_scitex_dsn,
+        collapse_duplicate_env,
+    )
+
+    agent = getattr(config, "name", None)
+
+    # The LAST ``--env`` contributor has now run, so reconcile the layers
+    # that can name the same key. The fleet/spec env layer and raw_args
+    # both declare SCITEX_CARDS_DB across this fleet, and until now the
+    # argv simply carried it twice — correct only because apptainer's
+    # ``--env`` is last-wins. Collapse to one occurrence per key (the
+    # last, i.e. the value apptainer already resolved) so reordering this
+    # assembly can never silently repoint an agent's card store, then
+    # refuse outright if what survives is a scitex DSN on the banned port
+    # 5432. See _apptainer_env_dedup and ADR-0022.
+    argv = collapse_duplicate_env(argv, agent=agent)
+    assert_no_forbidden_scitex_dsn(argv, agent=agent)
+
+    # Relaxed + directory-overlay + explicit ``--home`` shadows the
+    # to_home tree. ``deploy_to_home_overlay`` materialises the tree
+    # into ``<overlay>/upper/<container_home>/``, but a raw-arg
+    # ``--home /home/agent`` makes apptainer mount a FRESH tmpfs at
+    # that path (verified via `mount`: ``tmpfs on /home/agent``),
+    # which shadows the overlay's upper-home — so $HOME/.mcp.json,
+    # $HOME/CLAUDE.md, $HOME/.claude/ are all silently absent in the
+    # container. The SDK runner's ``merge_home_mcp_servers`` then
+    # reads an empty ``$HOME/.mcp.json`` and a per-agent MCP (e.g. an
+    # agent's own telegrammer bot) never reaches the SDK.
+    #
+    # Fix: bind the materialised upper-home OVER the container HOME,
+    # appended AFTER raw_args so it wins over the ``--home`` tmpfs
+    # (apptainer applies user binds after home setup). No-op for
+    # non-relaxed / non-directory-overlay specs (resolver returns
+    # None) and when the upper-home wasn't materialised.
+    if upper_home is not None and upper_home.is_dir():
+        from ._to_home_overlay import resolve_container_home
+
+        container_home = resolve_container_home(config)
+        argv += ["--bind", f"{upper_home}:{container_home}"]
+
+    # SECURITY (P1 credential fix): lift secret-shaped ``--env KEY=VALUE``
+    # pairs out of the WORLD-READABLE argv (it becomes a tmux ``bash -c``
+    # pane cmd; /proc/<pid>/cmdline leaks it to any local process) into a
+    # per-agent 0600 ``--env-file``. AFTER every ``--env`` source
+    # (auth/provider/listen/spec.env/raw_args) so any secret is caught, but
+    # BEFORE the creds bind below so that bind stays LAST (its last-wins
+    # shadowing invariant). apptainer still delivers every value; see
+    # _apptainer_secret_env.
+    from ._apptainer_secret_env import redact_secret_env_to_file
+
+    argv = redact_secret_env_to_file(argv, state_dir=state_dir)
+
+    # Designated credentials file (spec.claude.credentials_file) — bound
+    # writable at ``$HOME/.claude/.credentials.json``. Emitted LAST among
+    # binds (after the overlay-upper-home bind) so the relaxed ``--home``
+    # tmpfs / upper-home bind cannot shadow it; last bind to a path wins.
+    # apptainer FILE binds need the in-container destination to pre-exist,
+    # so first ensure an empty placeholder at the host path backing the
+    # container $HOME (overlay upper-home when relaxed-directory-overlay,
+    # else the workspace-home bind). Without it a fresh overlay agent FATALs
+    # at boot: "destination doesn't exist in container". The placeholder
+    # goes in the bind DESTINATION backing, never to_home (whose
+    # credential-leak guard refuses .credentials.json). No-op w/o a creds bind.
+    from ._apptainer_auth import credentials_file_bind, ensure_credentials_bind_target
+
+    creds_bind = credentials_file_bind(config)
+    ensure_credentials_bind_target(
+        config,
+        home_host=home_host,
+        overlay_upper_home=upper_home,
+        bind_flags=creds_bind,
+    )
+    argv += creds_bind
+
+    # Root-cause guard for the stray ``--fakeroot`` file in the project root
+    # (see _apptainer_argv_guard): a value-taking flag missing its value.
+    # raw_args + name let the message attribute the fault and name the spec.
+    validate_flag_argv(argv, raw_args=spec_raw_args, agent=agent)
+
+    return argv
+
+
+__all__ = ["finalize_flag_argv"]

--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from ..config import AgentConfig
-from ._apptainer_argv_guard import validate_flag_argv
 from ._apptainer_overlay import ensure_overlay_dirs, overlay_flags
 from ._apptainer_quota_cache import (
     QUOTA_CACHE_CONTAINER_PATH,
@@ -332,68 +331,21 @@ def build_run_argv(
     spec_raw_args = [str(a) for a in (getattr(_ap_raw, "raw_args", None) or [])]
     argv += spec_raw_args
 
-    # Relaxed + directory-overlay + explicit ``--home`` shadows the
-    # to_home tree. ``deploy_to_home_overlay`` materialises the tree
-    # into ``<overlay>/upper/<container_home>/``, but a raw-arg
-    # ``--home /home/agent`` makes apptainer mount a FRESH tmpfs at
-    # that path (verified via `mount`: ``tmpfs on /home/agent``),
-    # which shadows the overlay's upper-home — so $HOME/.mcp.json,
-    # $HOME/CLAUDE.md, $HOME/.claude/ are all silently absent in the
-    # container. The SDK runner's ``merge_home_mcp_servers`` then
-    # reads an empty ``$HOME/.mcp.json`` and a per-agent MCP (e.g. an
-    # agent's own telegrammer bot) never reaches the SDK.
-    #
-    # Fix: bind the materialised upper-home OVER the container HOME,
-    # appended AFTER raw_args so it wins over the ``--home`` tmpfs
-    # (apptainer applies user binds after home setup). No-op for
-    # non-relaxed / non-directory-overlay specs (resolver returns
-    # None) and when the upper-home wasn't materialised.
-    # resolve_container_home / resolve_overlay_upper_home already imported at
-    # the top of this function; reuse the up-front resolution.
-    upper_home = _upper_home
-    if upper_home is not None and upper_home.is_dir():
-        container_home = resolve_container_home(config)
-        argv += ["--bind", f"{upper_home}:{container_home}"]
+    # Every flag contributor has now run. The ordering-sensitive tail
+    # passes — duplicate-``--env`` collapse, the banned-port refusal, the
+    # overlay-upper-home bind, the secret lift, the last-wins credentials
+    # bind and the malformed-flag guard — live in _apptainer_argv_finalize,
+    # which documents why each one has to see the COMPLETE flag region.
+    # resolve_overlay_upper_home was already resolved up-front; reuse it.
+    from ._apptainer_argv_finalize import finalize_flag_argv
 
-    # SECURITY (P1 credential fix): lift secret-shaped ``--env KEY=VALUE``
-    # pairs out of the WORLD-READABLE argv (it becomes a tmux ``bash -c``
-    # pane cmd; /proc/<pid>/cmdline leaks it to any local process) into a
-    # per-agent 0600 ``--env-file``. AFTER every ``--env`` source
-    # (auth/provider/listen/spec.env/raw_args) so any secret is caught, but
-    # BEFORE the creds bind below so that bind stays LAST (its last-wins
-    # shadowing invariant). apptainer still delivers every value; see
-    # _apptainer_secret_env.
-    from ._apptainer_secret_env import redact_secret_env_to_file
-
-    argv = redact_secret_env_to_file(argv, state_dir=state_dir)
-
-    # Designated credentials file (spec.claude.credentials_file) — bound
-    # writable at ``$HOME/.claude/.credentials.json``. Emitted LAST among
-    # binds (after the overlay-upper-home bind) so the relaxed ``--home``
-    # tmpfs / upper-home bind cannot shadow it; last bind to a path wins.
-    # apptainer FILE binds need the in-container destination to pre-exist,
-    # so first ensure an empty placeholder at the host path backing the
-    # container $HOME (overlay upper-home when relaxed-directory-overlay,
-    # else the workspace-home bind). Without it a fresh overlay agent FATALs
-    # at boot: "destination doesn't exist in container". The placeholder
-    # goes in the bind DESTINATION backing, never to_home (whose
-    # credential-leak guard refuses .credentials.json). No-op w/o a creds bind.
-    from ._apptainer_auth import credentials_file_bind, ensure_credentials_bind_target
-
-    creds_bind = credentials_file_bind(config)
-    ensure_credentials_bind_target(
+    argv = finalize_flag_argv(
+        argv,
         config,
+        state_dir=state_dir,
         home_host=home_host,
-        overlay_upper_home=upper_home,
-        bind_flags=creds_bind,
-    )
-    argv += creds_bind
-
-    # Root-cause guard for the stray ``--fakeroot`` file in the project root
-    # (see _apptainer_argv_guard): a value-taking flag missing its value.
-    # raw_args + name let the message attribute the fault and name the spec.
-    validate_flag_argv(
-        argv, raw_args=spec_raw_args, agent=getattr(config, "name", None)
+        upper_home=_upper_home,
+        spec_raw_args=spec_raw_args,
     )
 
     argv.append(str(sif_path))
@@ -420,7 +372,7 @@ def build_run_argv(
     if tui:
         ch = resolve_container_home(config).rstrip("/")
         has_mcp = (home_host / ".mcp.json").is_file() or (
-            upper_home is not None and (upper_home / ".mcp.json").is_file()
+            _upper_home is not None and (_upper_home / ".mcp.json").is_file()
         )
         if has_mcp:
             tui_mcp_config = f"{ch}/.mcp.json"
@@ -445,7 +397,7 @@ def build_run_argv(
         # settings.json at materialize time).
         for _rel in (".claude/settings.json", ".claude/settings.local.json"):
             if (home_host / _rel).is_file() or (
-                upper_home is not None and (upper_home / _rel).is_file()
+                _upper_home is not None and (_upper_home / _rel).is_file()
             ):
                 tui_settings = f"{ch}/{_rel}"
                 break

--- a/src/scitex_agent_container/runtimes/_apptainer_env_dedup.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_env_dedup.py
@@ -1,0 +1,276 @@
+"""One ``--env KEY`` per key, and never a scitex DSN on port 5432.
+
+Why this module exists
+----------------------
+``build_run_argv`` collects ``--env`` flags from several independent
+layers. Two of them can legitimately name the SAME key:
+
+* the fleet/spec env layer — ``_fleet_env.effective_env`` (sac's
+  declared defaults, the operator's ``config.yaml``
+  ``spec.fleet_default_env``, then ``spec.env``), rendered early; and
+* ``spec.apptainer.raw_args`` — the §1 escape hatch, appended verbatim
+  and therefore LATE.
+
+Nothing reconciled them. The argv simply carried the key twice and the
+launch was correct only because apptainer's ``--env`` is last-wins, so
+the later ``raw_args`` occurrence masked the earlier one.
+
+Measured on scitex-compute-04 (2026-08-11), the fleet was running on
+exactly that accident::
+
+    --env SCITEX_CARDS_DB=postgresql://…@127.0.0.1:5432/scitex_cards
+    …
+    --env SCITEX_CARDS_DB=postgresql://…@127.0.0.1:55432/scitex_cards
+
+The agent resolved to ``:55432`` — the right database — purely because
+that occurrence sorted later in the list. Reorder the assembly for any
+unrelated reason and every agent on the host silently starts writing
+its cards somewhere else. Correctness that depends on argv ordering is
+not correctness, so this module resolves the duplicate BEFORE apptainer
+ever sees it: :func:`collapse_duplicate_env` leaves exactly one
+occurrence per key, and which one wins is a decision made here, in
+sac, with a log line naming it.
+
+The winner is still the LAST occurrence. That is deliberate: it is the
+value the fleet runs on today, and it is the same precedence
+``_board_identity_env.apply_board_identity_alias`` already documents
+and relies on (``raw_args`` overrides ``spec.env``). This module makes
+that rule explicit and structural rather than positional and implicit
+— it does not change which value an agent receives.
+
+The port rule
+-------------
+ADR-0022 (``docs/adr/0022-state-in-postgres-configuration-in-git.md``)
+rules that **port 5432 is never used for scitex** — the containerised
+PostgreSQL runs on ``55432`` on every node. A scitex DSN pointing at
+5432 is therefore always wrong, and "always wrong" deserves a check
+rather than a comment: :func:`assert_no_forbidden_scitex_dsn` refuses
+to launch rather than handing a container a store address that no peer
+reads. A DSN with no port at all is caught too, because an omitted
+port IS 5432 — the most invisible way to hit the same wall.
+
+Both passes are pure functions over the flag argv (a new list is
+returned; the input is never mutated) and neither ever logs an env
+VALUE — a DSN can carry a password, and this argv is world-readable
+until :mod:`._apptainer_secret_env` lifts secrets out of it.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urlsplit
+
+logger = logging.getLogger(__name__)
+
+#: apptainer's env flag, in both spellings that occur in real specs.
+_ENV_FLAG = "--env"
+_ENV_GLUED_PREFIX = "--env="
+
+#: The port ADR-0022 rules out for every scitex service, on every host.
+FORBIDDEN_SCITEX_PG_PORT = 5432
+
+#: The port the containerised PostgreSQL actually listens on.
+CANONICAL_SCITEX_PG_PORT = 55432
+
+_PG_SCHEMES = frozenset({"postgres", "postgresql"})
+
+
+class ForbiddenScitexDsnError(ValueError):
+    """Raised when a built argv would hand a container a scitex DSN on 5432.
+
+    Not a style complaint: nothing listens on 5432 on a scitex node, so
+    the agent would either fail its first card access with an opaque
+    connection error, or — worse, if something ever does listen there —
+    write its cards into a database no peer reads.
+    """
+
+
+def _env_pair_at(argv: list[str], index: int) -> tuple[str, str, int] | None:
+    """``(key, value, width)`` for the ``--env`` pair starting at ``index``.
+
+    ``width`` is how many argv tokens the pair occupies (2 for the split
+    spelling, 1 for the glued one). Returns ``None`` when ``index`` does
+    not start a well-formed ``--env`` pair — including a bare trailing
+    ``--env`` and a value with no ``=``, both of which are left exactly
+    where they are for :mod:`._apptainer_argv_guard` to report.
+
+    ``--env-file`` is NOT an ``--env`` pair and never matches here.
+    """
+    token = argv[index]
+    if token == _ENV_FLAG and index + 1 < len(argv):
+        pair = argv[index + 1]
+        width = 2
+    elif token.startswith(_ENV_GLUED_PREFIX):
+        pair = token[len(_ENV_GLUED_PREFIX) :]
+        width = 1
+    else:
+        return None
+    key, sep, value = pair.partition("=")
+    if not sep or not key:
+        return None
+    return key, value, width
+
+
+def _env_pair_spans(argv: list[str]) -> list[tuple[int, int, str, str]]:
+    """Every ``--env`` pair as ``(start, width, key, value)``, in argv order."""
+    spans: list[tuple[int, int, str, str]] = []
+    index = 0
+    while index < len(argv):
+        found = _env_pair_at(argv, index)
+        if found is None:
+            index += 1
+            continue
+        key, value, width = found
+        spans.append((index, width, key, value))
+        index += width
+    return spans
+
+
+def collapse_duplicate_env(
+    argv: list[str],
+    *,
+    agent: str | None = None,
+) -> list[str]:
+    """Return ``argv`` with each ``--env KEY`` appearing exactly once.
+
+    When a key is declared more than once the LAST occurrence is kept —
+    the same value apptainer would have resolved — and the earlier ones
+    are dropped, so the argv handed to apptainer can no longer depend on
+    flag ordering to be correct. Every other token keeps its position.
+
+    Pure: a NEW list is returned and the input is not mutated. A no-op
+    (a fresh copy) when no key is declared twice.
+
+    Call this AFTER every ``--env`` contributor — including
+    ``spec.apptainer.raw_args`` — and BEFORE the SIF is appended, so the
+    list it walks is the flag region only.
+
+    Only KEY names are logged. A value may be a DSN or a token, and this
+    argv is world-readable until the secret sweep lifts it out.
+    """
+    spans = _env_pair_spans(argv)
+    last_start: dict[str, int] = {}
+    for start, _width, key, _value in spans:
+        last_start[key] = start
+
+    superseded = {
+        start
+        for start, _width, key, _value in spans
+        if last_start[key] != start
+    }
+    if not superseded:
+        return list(argv)
+
+    dropped: dict[str, int] = {}
+    kept: list[str] = []
+    index = 0
+    while index < len(argv):
+        found = _env_pair_at(argv, index)
+        if found is None:
+            kept.append(argv[index])
+            index += 1
+            continue
+        key, _value, width = found
+        if index in superseded:
+            dropped[key] = dropped.get(key, 0) + 1
+            index += width
+            continue
+        kept.extend(argv[index : index + width])
+        index += width
+
+    who = f" for agent {agent!r}" if agent else ""
+    for key in sorted(dropped):
+        logger.info(
+            "apptainer argv%s declared --env %s %d extra time(s); kept the "
+            "LAST declaration and dropped the earlier one(s). Two layers "
+            "name this key — spec.apptainer.raw_args wins over the "
+            "fleet/spec env layer, as it already did via apptainer's "
+            "last-wins rule.",
+            who,
+            key,
+            dropped[key],
+        )
+    return kept
+
+
+def _forbidden_scitex_dsn(key: str, value: str) -> str | None:
+    """Why ``KEY=VALUE`` is a banned scitex DSN, or ``None`` if it is fine.
+
+    A value qualifies when it parses as a ``postgres(ql)://`` URL that
+    belongs to scitex — by variable name, connecting user, or database
+    name — and resolves to :data:`FORBIDDEN_SCITEX_PG_PORT`, whether the
+    port is written out or merely defaulted to by omission.
+    """
+    if "://" not in value:
+        return None
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return None
+    if parts.scheme not in _PG_SCHEMES:
+        return None
+    try:
+        port = parts.port
+    except ValueError:
+        # An unparseable port is a different fault; the connection will
+        # name it. Do not guess.
+        return None
+    database = (parts.path or "").lstrip("/")
+    is_scitex = (
+        key.upper().startswith("SCITEX_")
+        or "scitex" in (parts.username or "").lower()
+        or "scitex" in database.lower()
+    )
+    if not is_scitex:
+        return None
+    if port is None:
+        return (
+            "names no port, so it resolves to PostgreSQL's default "
+            f"{FORBIDDEN_SCITEX_PG_PORT}"
+        )
+    if port == FORBIDDEN_SCITEX_PG_PORT:
+        return f"names port {FORBIDDEN_SCITEX_PG_PORT}"
+    return None
+
+
+def assert_no_forbidden_scitex_dsn(
+    argv: list[str],
+    *,
+    agent: str | None = None,
+) -> None:
+    """Refuse an argv carrying a scitex PostgreSQL DSN on port 5432.
+
+    Raises :class:`ForbiddenScitexDsnError` naming the offending
+    variable, where such a DSN comes from, and the canonical port. The
+    DSN itself is NOT included in the message — it can carry a password,
+    and this message reaches logs.
+
+    A no-op for every other argv, including SQLite ``SCITEX_*_DB``
+    paths and non-scitex PostgreSQL URLs.
+    """
+    for _start, _width, key, value in _env_pair_spans(argv):
+        why = _forbidden_scitex_dsn(key, value)
+        if why is None:
+            continue
+        who = f" for agent {agent!r}" if agent else ""
+        raise ForbiddenScitexDsnError(
+            f"--env {key}{who} is a scitex PostgreSQL DSN that {why}. "
+            f"Port {FORBIDDEN_SCITEX_PG_PORT} is never used for scitex on "
+            "any host (ADR-0022); the containerised PostgreSQL listens on "
+            f"{CANONICAL_SCITEX_PG_PORT} on every node. Launching would "
+            "point this agent's store at an address no peer reads.\n"
+            f"  Fix the {key} declaration in the agent's spec "
+            "(spec.env / spec.apptainer.raw_args) or in the operator's "
+            "config.yaml spec.fleet_default_env — whichever names it. "
+            "The DSN value is withheld here because it may carry a "
+            "credential."
+        )
+
+
+__all__ = [
+    "CANONICAL_SCITEX_PG_PORT",
+    "FORBIDDEN_SCITEX_PG_PORT",
+    "ForbiddenScitexDsnError",
+    "assert_no_forbidden_scitex_dsn",
+    "collapse_duplicate_env",
+]

--- a/tests/scitex_agent_container/runtimes/test__apptainer_env_dedup.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_env_dedup.py
@@ -1,0 +1,457 @@
+"""One ``--env KEY`` per key, and no scitex DSN on the banned port 5432.
+
+Mirrors ``src/scitex_agent_container/runtimes/_apptainer_env_dedup.py``
+(PS-204 §2).
+
+Two properties, both measured as FAULTS on scitex-compute-04 (2026-08-11)
+before they were properties at all:
+
+* the built argv declared ``SCITEX_CARDS_DB`` TWICE — ``:5432`` from the
+  operator's ``config.yaml`` ``spec.fleet_default_env`` and ``:55432``
+  from ``spec.apptainer.raw_args`` — and reached the right database only
+  because apptainer's ``--env`` is last-wins; and
+* ``:5432`` is a port ADR-0022 rules out for every scitex service on
+  every host, which until now was written down but never checked.
+
+Both are asserted at the ARGV level as well as the unit level, because
+argv is what actually reaches the container — a rule that holds in a
+helper and not in the rendered flags would not be a rule.
+
+No mocks / no monkeypatch (PA-306/307). Real ``load_config`` on a tmp
+spec for the end-to-end cases; direct argv lists for the unit cases.
+AAA blocks, markers on their own line, one assert per test.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container.config import load_config
+from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
+from scitex_agent_container.runtimes._apptainer_env_dedup import (
+    CANONICAL_SCITEX_PG_PORT,
+    FORBIDDEN_SCITEX_PG_PORT,
+    ForbiddenScitexDsnError,
+    assert_no_forbidden_scitex_dsn,
+    collapse_duplicate_env,
+)
+from tests.scitex_agent_container._helpers.explicit_spec import explicitize_yaml
+
+CANONICAL_DSN = (
+    f"postgresql://scitex_cards@127.0.0.1:{CANONICAL_SCITEX_PG_PORT}/scitex_cards"
+)
+BANNED_DSN = (
+    f"postgresql://scitex_cards@127.0.0.1:{FORBIDDEN_SCITEX_PG_PORT}/scitex_cards"
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers (mirror test__apptainer_argv_guard.py).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path) -> Iterator[Path]:
+    # Arrange-side fixture: keep the bearer-token resolver off the real ~.
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+@pytest.fixture
+def listen_bearer_token(_isolate_home: Path) -> Path:
+    # Materialise a real listen bearer so build_run_argv's listen-env
+    # guard doesn't turn an argv-shape test into a RuntimeError.
+    token_dir = _isolate_home / ".scitex" / "agent-container" / "tokens"
+    token_dir.mkdir(parents=True, exist_ok=True)
+    token_path = token_dir / f"listen-{socket.gethostname()}.token"
+    token_path.write_text("test-bearer-token-not-a-secret\n", encoding="utf-8")
+    return token_path
+
+
+def _write_spec(tmp_path: Path, *, spec_env: str = "", raw_args: str = "") -> Path:
+    """A real v3 spec whose env layer and ``raw_args`` may both name a key.
+
+    ``spec_env`` is the ``spec.apptainer.env`` block (v3 realignment §3
+    moved it under ``apptainer``); ``raw_args`` the escape hatch appended
+    verbatim after every curated flag. Both are rendered at their real
+    indent so the two layers collide exactly as they do in the fleet.
+    """
+    spec_dir = tmp_path / "agents" / "agt"
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    spec = spec_dir / "spec.yaml"
+    spec.write_text(
+        explicitize_yaml(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            "metadata:\n"
+            "  labels:\n"
+            "    project: t\n"
+            '    sac-builtin: "off"\n'
+            "spec:\n"
+            "  runtime: tui\n"
+            "  host: ${HOSTNAME}\n"
+            "  workdir: /tmp/agt-work\n"
+            "  apptainer:\n"
+            "    image: /x.sif\n"
+            "    fakeroot: true\n"
+            "    binds: []\n"
+            f"{spec_env}"
+            f"{raw_args}"
+            "  health:\n"
+            "    enabled: true\n"
+            "    interval: 60\n"
+            "  restart:\n"
+            "    policy: on-failure\n"
+            "    max_retries: 3\n"
+            "  claude:\n"
+            "    model: claude-opus-4-8[1m]\n"
+        ),
+        encoding="utf-8",
+    )
+    return spec
+
+
+def _build(tmp_path: Path, spec: Path) -> list[str]:
+    return build_run_argv(
+        load_config(str(spec)),
+        state_dir=tmp_path / "st",
+        sif_path=tmp_path / "x.sif",
+        tui=True,
+    )
+
+
+def env_values(argv: list[str], key: str) -> list[str]:
+    """Every value ``argv`` declares for ``--env KEY``, in argv order.
+
+    Reads both spellings that occur in real specs — split
+    (``--env K=V``) and glued (``--env=K=V``) — so a duplicate hidden
+    behind the other spelling still shows up here.
+    """
+    found: list[str] = []
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token == "--env" and index + 1 < len(argv):
+            pair, width = argv[index + 1], 2
+        elif token.startswith("--env="):
+            pair, width = token[len("--env=") :], 1
+        else:
+            index += 1
+            continue
+        name, sep, value = pair.partition("=")
+        if sep and name == key:
+            found.append(value)
+        index += width
+    return found
+
+
+def env_keys(argv: list[str]) -> list[str]:
+    """Every ``--env`` key the argv declares, with duplicates preserved."""
+    keys: list[str] = []
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token == "--env" and index + 1 < len(argv):
+            pair, width = argv[index + 1], 2
+        elif token.startswith("--env="):
+            pair, width = token[len("--env=") :], 1
+        else:
+            index += 1
+            continue
+        name, sep, _value = pair.partition("=")
+        if sep and name:
+            keys.append(name)
+        index += width
+    return keys
+
+
+# ---------------------------------------------------------------------------
+# collapse_duplicate_env — unit cases (direct argv lists).
+# ---------------------------------------------------------------------------
+
+
+def test_a_key_declared_twice_survives_exactly_once() -> None:
+    # Arrange — the shape the fleet actually ran on.
+    argv = ["--env", "SCITEX_CARDS_DB=a", "--env", "SCITEX_CARDS_DB=b"]
+    # Act
+    collapsed = collapse_duplicate_env(argv)
+    # Assert
+    assert env_values(collapsed, "SCITEX_CARDS_DB") == ["b"]
+
+
+def test_the_surviving_value_is_the_one_apptainer_would_have_resolved() -> None:
+    # Arrange — last-wins is preserved deliberately: collapsing to the
+    # FIRST would repoint every agent's store, which is the accident this
+    # module exists to prevent, not to cause.
+    argv = ["--env", "K=first", "--env", "K=middle", "--env", "K=last"]
+    # Act
+    collapsed = collapse_duplicate_env(argv)
+    # Assert
+    assert env_values(collapsed, "K") == ["last"]
+
+
+def test_the_glued_spelling_is_the_same_key_as_the_split_one() -> None:
+    # Arrange — two specs in this fleet use ``--env=K=V``.
+    argv = ["--env", "K=split", "--env=K=glued"]
+    # Act
+    collapsed = collapse_duplicate_env(argv)
+    # Assert
+    assert env_values(collapsed, "K") == ["glued"]
+
+
+def test_distinct_keys_are_all_kept() -> None:
+    # Arrange — dedup is per-key, not a general thinning pass.
+    argv = ["--env", "A=1", "--env", "B=2", "--env", "C=3"]
+    # Act
+    collapsed = collapse_duplicate_env(argv)
+    # Assert
+    assert collapsed == argv
+
+
+def test_non_env_tokens_keep_their_positions() -> None:
+    # Arrange — binds and overlays carry their own ordering invariants.
+    argv = ["--bind", "/a:/a", "--env", "K=1", "--overlay", "/o", "--env", "K=2"]
+    # Act
+    collapsed = collapse_duplicate_env(argv)
+    # Assert
+    assert collapsed == ["--bind", "/a:/a", "--overlay", "/o", "--env", "K=2"]
+
+
+def test_env_file_is_not_an_env_pair() -> None:
+    # Arrange — ``--env-file`` shares a prefix with ``--env``.
+    argv = ["--env-file", "/home/agent/.env", "--env", "K=1"]
+    # Act
+    collapsed = collapse_duplicate_env(argv)
+    # Assert
+    assert collapsed == argv
+
+
+def test_the_input_list_is_not_mutated() -> None:
+    # Arrange — callers reuse the list they passed in.
+    argv = ["--env", "K=1", "--env", "K=2"]
+    # Act
+    collapse_duplicate_env(argv)
+    # Assert
+    assert argv == ["--env", "K=1", "--env", "K=2"]
+
+
+def test_a_malformed_orphan_env_is_left_for_the_flag_guard() -> None:
+    # Arrange — a trailing bare ``--env`` is _apptainer_argv_guard's to
+    # report; swallowing it here would delete its evidence.
+    argv = ["--env", "K=1", "--env"]
+    # Act
+    collapsed = collapse_duplicate_env(argv)
+    # Assert
+    assert collapsed[-1] == "--env"
+
+
+# ---------------------------------------------------------------------------
+# assert_no_forbidden_scitex_dsn — the operator's port rule.
+# ---------------------------------------------------------------------------
+
+
+def test_a_scitex_dsn_on_the_banned_port_is_refused() -> None:
+    # Arrange — ADR-0022: port 5432 is never used for scitex, on any host.
+    argv = ["--env", f"SCITEX_CARDS_DB={BANNED_DSN}"]
+    # Act
+    check = lambda: assert_no_forbidden_scitex_dsn(argv)
+    # Assert
+    with pytest.raises(ForbiddenScitexDsnError):
+        check()
+
+
+def test_the_refusal_names_the_offending_variable() -> None:
+    # Arrange — a reader must learn WHICH variable to open.
+    argv = ["--env", f"SCITEX_CARDS_DB={BANNED_DSN}"]
+    message = ""
+    try:
+        assert_no_forbidden_scitex_dsn(argv)
+    except ForbiddenScitexDsnError as exc:
+        message = str(exc)
+    # Act
+    names_variable = "SCITEX_CARDS_DB" in message
+    # Assert
+    assert names_variable is True
+
+
+def test_the_refusal_names_the_canonical_port() -> None:
+    # Arrange — naming the fault without naming the fix wastes the reader.
+    argv = ["--env", f"SCITEX_CARDS_DB={BANNED_DSN}"]
+    message = ""
+    try:
+        assert_no_forbidden_scitex_dsn(argv)
+    except ForbiddenScitexDsnError as exc:
+        message = str(exc)
+    # Act
+    names_canonical = str(CANONICAL_SCITEX_PG_PORT) in message
+    # Assert
+    assert names_canonical is True
+
+
+def test_the_refusal_never_prints_the_dsn_itself() -> None:
+    # Arrange — a DSN can carry a password and this message reaches logs.
+    secret = f"postgresql://scitex_cards:hunter2@127.0.0.1:{FORBIDDEN_SCITEX_PG_PORT}/scitex_cards"
+    argv = ["--env", f"SCITEX_CARDS_DB={secret}"]
+    message = ""
+    try:
+        assert_no_forbidden_scitex_dsn(argv)
+    except ForbiddenScitexDsnError as exc:
+        message = str(exc)
+    # Act
+    leaked = "hunter2" in message
+    # Assert
+    assert leaked is False
+
+
+def test_a_scitex_dsn_with_no_port_is_refused_too() -> None:
+    # Arrange — an omitted port IS 5432, the most invisible way to hit it.
+    argv = ["--env", "SCITEX_CARDS_DB=postgresql://scitex_cards@127.0.0.1/scitex_cards"]
+    # Act
+    check = lambda: assert_no_forbidden_scitex_dsn(argv)
+    # Assert
+    with pytest.raises(ForbiddenScitexDsnError):
+        check()
+
+
+def test_the_canonical_port_is_accepted() -> None:
+    # Arrange — the whole fleet runs on 55432.
+    argv = ["--env", f"SCITEX_CARDS_DB={CANONICAL_DSN}"]
+    # Act
+    result = assert_no_forbidden_scitex_dsn(argv)
+    # Assert — a no-op returns None (did not raise).
+    assert result is None
+
+
+def test_a_sqlite_store_path_is_not_a_dsn() -> None:
+    # Arrange — ``SCITEX_CARDS_DB`` is a filesystem path on SQLite.
+    argv = ["--env", "SCITEX_CARDS_DB=/home/agent/.scitex/cards/cards.db"]
+    # Act
+    result = assert_no_forbidden_scitex_dsn(argv)
+    # Assert
+    assert result is None
+
+
+def test_a_non_scitex_postgres_on_5432_is_none_of_our_business() -> None:
+    # Arrange — the rule is about scitex services, not about the port.
+    argv = ["--env", "OTHER_DB=postgresql://someone@127.0.0.1:5432/otherapp"]
+    # Act
+    result = assert_no_forbidden_scitex_dsn(argv)
+    # Assert
+    assert result is None
+
+
+def test_a_scitex_database_name_is_enough_to_claim_the_dsn() -> None:
+    # Arrange — the rule follows the SERVICE, not the variable's spelling.
+    argv = ["--env", "BOARD_URL=postgresql://someone@127.0.0.1:5432/scitex_cards"]
+    # Act
+    check = lambda: assert_no_forbidden_scitex_dsn(argv)
+    # Assert
+    with pytest.raises(ForbiddenScitexDsnError):
+        check()
+
+
+# ---------------------------------------------------------------------------
+# build_run_argv — end-to-end (what actually reaches the container).
+# ---------------------------------------------------------------------------
+
+
+def test_the_built_argv_declares_the_cards_dsn_exactly_once(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — spec.env AND raw_args both name SCITEX_CARDS_DB, the exact
+    # shape measured on scitex-compute-04.
+    spec = _write_spec(
+        tmp_path,
+        spec_env=f"    env:\n      SCITEX_CARDS_DB: {CANONICAL_DSN}\n",
+        raw_args=f"    raw_args:\n      - --env\n      - SCITEX_CARDS_DB={CANONICAL_DSN}\n",
+    )
+    # Act
+    argv = _build(tmp_path, spec)
+    # Assert
+    assert len(env_values(argv, "SCITEX_CARDS_DB")) == 1
+
+
+def test_no_key_at_all_is_declared_twice_in_a_built_argv(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — the fix is for the CLASS of bug, not for one key.
+    spec = _write_spec(
+        tmp_path,
+        spec_env=(
+            "    env:\n"
+            f"      SCITEX_CARDS_DB: {CANONICAL_DSN}\n"
+            "      SAC_PROBE: from-spec\n"
+        ),
+        raw_args=(
+            "    raw_args:\n"
+            "      - --env\n"
+            f"      - SCITEX_CARDS_DB={CANONICAL_DSN}\n"
+            "      - --env\n"
+            "      - SAC_PROBE=from-raw\n"
+        ),
+    )
+    argv = _build(tmp_path, spec)
+    # Act
+    keys = env_keys(argv)
+    # Assert
+    assert len(keys) == len(set(keys))
+
+
+def test_the_raw_args_value_is_the_one_that_survives(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — behaviour preservation: raw_args already won via last-wins.
+    spec = _write_spec(
+        tmp_path,
+        spec_env="    env:\n      SCITEX_CARDS_DB: /home/agent/from-spec-env.db\n",
+        raw_args=f"    raw_args:\n      - --env\n      - SCITEX_CARDS_DB={CANONICAL_DSN}\n",
+    )
+    # Act
+    argv = _build(tmp_path, spec)
+    # Assert
+    assert env_values(argv, "SCITEX_CARDS_DB") == [CANONICAL_DSN]
+
+
+def test_a_built_argv_never_carries_a_scitex_dsn_on_5432(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — ``:5432`` reached the fleet through a layer nobody re-read.
+    # Rendering it must fail the launch, not hand a container an address
+    # no peer reads.
+    spec = _write_spec(
+        tmp_path,
+        spec_env=f"    env:\n      SCITEX_CARDS_DB: {BANNED_DSN}\n",
+    )
+    # Act
+    build = lambda: _build(tmp_path, spec)
+    # Assert
+    with pytest.raises(ForbiddenScitexDsnError):
+        build()
+
+
+def test_a_banned_dsn_overridden_by_raw_args_still_launches(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — the live fleet's shape: a stale ``:5432`` default that
+    # every healthy agent already overrides. The bad value never reaches
+    # the container, so refusing here would ground 90 working agents.
+    spec = _write_spec(
+        tmp_path,
+        spec_env=f"    env:\n      SCITEX_CARDS_DB: {BANNED_DSN}\n",
+        raw_args=f"    raw_args:\n      - --env\n      - SCITEX_CARDS_DB={CANONICAL_DSN}\n",
+    )
+    # Act
+    argv = _build(tmp_path, spec)
+    # Assert
+    assert env_values(argv, "SCITEX_CARDS_DB") == [CANONICAL_DSN]


### PR DESCRIPTION
## What this is

Every apptainer launch line on scitex-compute-04 declared the card-store
address **twice**, and reached the right database only by accident of ordering.

Measured 2026-08-11:

```
--env SCITEX_CARDS_DB=postgresql://…@127.0.0.1:5432/scitex_cards     <- operator config.yaml
…
--env SCITEX_CARDS_DB=postgresql://…@127.0.0.1:55432/scitex_cards    <- the agent's spec raw_args
```

Two layers name the same key, nothing reconciled them, and apptainer's `--env`
is last-wins — so the correct value won because it happened to sort later.
Reorder this assembly for any unrelated reason and every agent on the host
silently starts writing its cards into a database no peer reads. That is not a
hypothetical: three PostgreSQL databases on this fleet currently answer the
same `store_uuid` while holding different cards.

## The two changes

**One declaration per key.** `collapse_duplicate_env` resolves duplicate
`--env` keys before apptainer sees them. The winner is still the last
occurrence — the value the fleet already runs on, and the precedence
`_board_identity_env` already documents — so **no agent's environment
changes**. What changes is that the decision is made here, in sac, with a log
line naming the key, instead of being inherited from a tie-break in someone
else's argument parser. It fixes the class of bug: any key declared by two
layers, not just this one.

**Port 5432 is refused, not merely discouraged.** ADR-0022 rules that port out
for every scitex service on every host — the containerised PostgreSQL is on
`55432` everywhere — and a rule with no check is a comment. A DSN with no port
is refused too, because an omitted port *is* 5432 and is the most invisible way
to hit the same wall. The message names the variable and the canonical port but
never prints the DSN, which may carry a password.

## Refactor carried along

`_apptainer_build_argv.py` was already 528 lines against a 512 cap, so it could
not be edited at all. Its **final assembly phase** — everything that happens to
the flag argv after the last contributor and before the SIF — moves to
`_apptainer_argv_finalize.finalize_flag_argv`.

That is a real phase, not an arbitrary cut: the upper-home bind, the secret
lift, the last-wins credentials bind and the malformed-flag guard each exist
because of an **ordering invariant** that only holds once the flag region is
complete. Naming the phase gives those invariants one owner, and it is where
the two new passes belong. `build_run_argv` keeps its signature, nothing is
deleted, and the file lands at 463 lines.

## Tests

`tests/scitex_agent_container/runtimes/test__apptainer_env_dedup.py` — 22
tests, no mocks, real specs on `tmp_path` through real `load_config`, asserted
at the **argv** level because argv is what reaches the container:

- the built argv declares `SCITEX_CARDS_DB` exactly once when `spec.env` and
  `raw_args` both name it (the measured shape);
- no key at all appears twice in a built argv;
- the `raw_args` value is the one that survives (behaviour preserved);
- a built argv never carries a scitex DSN on 5432;
- a banned DSN that `raw_args` overrides still launches — the bad value never
  reaches the container, and grounding 90 healthy agents over a variable they
  already override would be the worse outcome.

```
22 passed          test__apptainer_env_dedup.py
208 passed, 2 skipped, 1 failed    all affected runtime suites
```

The one failure is `test__mcp_spec_env.py::test_first_spawn_inheritance_alone_does_not_survive_the_respawn`
and is **pre-existing and unrelated**: that test does `environ = dict(os.environ)`,
so it inherits the ambient `SAC_SPEC_ENV_KEYS` of whatever container runs it.
Neutralise that one variable and the file is `16 passed`. Worth its own fix
(the test should build its environment rather than inherit one), not this PR's.

## Operator action still needed

The `:5432` lives in `~/.scitex/agent-container/config.yaml`
`spec.fleet_default_env` — **host config, not repo code**, so this PR cannot
correct it.

- 90 of 107 agent specs override it via `raw_args` and are unaffected.
- 17 do not, and today inherit the dead port silently. After this change they
  fail loudly at launch instead of failing confusingly at first card access.

Correcting that one line to `55432` fixes those 17 and makes the new guard a
no-op safety net. The affected specs are the `clew-*` capsules plus
`sac-remote-probe-spartan`, `scitex-hub-ui` and `scitex-priv-setup`.
