### PR TITLE
feat(relocate-preflight): ask whether the spec HOLDS on the target, and say what would fix it

### DIFF
--- a/docs/relocate.md
+++ b/docs/relocate.md
@@ -54,21 +54,36 @@ first one, so you do not have to run it N times to find N problems.
 sac agents relocate <name> --to <host> --dry-run
 ```
 
-### The eleven checks
+Several names preflight together and print a combined summary, so the shape of a
+queued batch is visible before anything is touched:
 
-| check | what it catches | the 2026-08-07 instance |
+```bash
+sac agents relocate scitex-dev scitex-hpc scitex-db --to scitex-compute-04
+```
+
+That form is read-only by construction. `--no-dry-run` takes exactly one name:
+the journal that makes a relocation resumable is per-agent, and a batch
+interrupted halfway would leave several agents half-moved across two hosts.
+
+### The fifteen checks
+
+| check | what it catches | the instance |
 |---|---|---|
 | `target_reachable` | host does not answer | — nothing else in the report means anything until this passes |
 | `image_present` | SIF absent on the target | a missing image fails at boot, **after** the lease has moved |
 | `binds_exist_on_target` | bind source paths absent there | the spec bound `/mnt/c`, a Windows drive that does not exist on the nas |
-| `card_store_reachable` | agent cannot reach its board | `SCITEX_CARDS_DB` is port 5432 here, 5442 there |
+| `workdir_exists_on_target` | `spec.workdir` absent there | it becomes apptainer's `--pwd`; there is no `spec.repo`, the workdir **is** the checkout |
+| `card_store_dsn_correct` | the DSN itself is wrong | `5432` is wrong on every host with no exceptions, and a port-less DSN means the same thing to libpq |
+| `card_store_reachable` | agent cannot reach its board | the fleet's endpoint is `55432`; an agent that cannot reach its board runs and records nothing |
 | `credentials_valid` | **validity, not presence** | the nas had a file expired 2026-05-23 with an empty `refreshToken`, and sac loaded it *in preference to* the good one — every turn 401'd while `sac agents health` still said healthy |
 | `runtime_supported` | target's sac rejects the runtime | nas's sac 0.21.9 rejects `tui` |
 | `spec_schema_accepted` | target's validator rejects a key | a top-level `provider:` key, same older validator |
 | `ports_free` | port already bound there | reassign in the spec before moving |
+| `groups_resolvable_on_target` | the target's sac cannot read this spec's group labels | three hosts resolve `[]` for every agent regardless of `spec.yaml`; nine relocation probes were refused 403 by exactly that on 2026-08-11 |
 | `hub_reachable_from_target` | hub unreachable **from there** | the nas's services bind `127.0.0.1`, so reaching them from HERE proves nothing about THERE |
 | `sac_present_on_target` | remote `sac` calls will fail | on scitex-compute-04 sac lives at `/home/ywatanabe/.env-sac/bin/sac` and is **not** on the non-interactive ssh PATH, so `ssh host sac …` answers "No such file or directory" while sac is installed and working (2026-08-11) |
 | `source_work_committed` | uncommitted/unpushed work on the host being **left** | a relocation carries the spec and the transcript and nothing else; a half-finished branch stays on a machine nobody is watching |
+| `session_resolvable` | which conversation would travel cannot be named | asked HERE because the phase that needs the answer runs *after* the agent has been stopped; ten agents passed every other check on 2026-08-12 and could not complete |
 
 **Read the credentials row twice.** A presence check passes on an expired file.
 The failure it prevents is silent.
@@ -80,6 +95,36 @@ and "installed but invisible to ssh" produce the *identical* error and need
 and by absolute path, so nobody is sent to install a second copy of something
 that already works. When it can see that sac is off the PATH but cannot
 establish whether it exists at all, the answer is UNKNOWN, not a guess.
+
+**A missing bind is never one problem.** Fifteen fleet specs bind paths that do
+not exist on scitex-compute-04, and every one of those specs is *correct for the
+machine it currently pins*. Nine are Spartan agents binding shared cluster storage
+a workstation cannot provide at all; six are laptop agents binding a dataset and a
+local checkout that exist on exactly one machine because that machine made them.
+Printed as "path not found" they look identical, so the check classifies each path
+and splits the hint by what you have to do about it:
+
+- **provision on the target** — host infrastructure (`/data`, `/mnt`, `/gpfs`, …).
+  If the filesystem does not exist there at all, this spec belongs on a host that
+  has it; re-pointing the bind produces a *different agent*, not a relocated one.
+- **must travel with the agent** — anything under or beside the agent's own
+  workdir, and any `dataset` directory. A relocation carries the spec and the
+  transcript and nothing else, so this data does not follow by itself.
+- **provision there, never copy** — credential paths (`.ssh`, `.config/gh`,
+  `accounts/*/.credentials.json`, `.pgpass`). Key material must not travel
+  between hosts, so the hint says so instead of "move it with the agent".
+
+Where the path's shape cannot settle it, the answer is `unclassified` and the
+hint states both possibilities. A confident wrong category sends you to provision
+a directory that should have travelled.
+
+**`groups_resolvable_on_target` distinguishes "refused" from "no".** A target that
+resolves a non-empty group set and omits one this spec declares has *answered*,
+and that is a FAIL. A target that resolves nothing has not — that is the shape of
+a daemon too old to read spec labels, and reporting it as a failure sends you to
+edit a spec that is already correct. Likewise a 403 from the **local** listen
+daemon brokering the probe is about this container's authorization, not about the
+target; the report says so in those words and leaves every target fact UNKNOWN.
 
 **`source_work_committed` is the only check about the source.** Its facts are
 gathered locally rather than over ssh, and an unscanned repo is UNKNOWN — never
@@ -106,6 +151,29 @@ probe raises -> None    preflight reports UNKNOWN, refuses, names the check.
 
 An unobserved fact folded into "pass" is precisely how the 08-07 move reported
 healthy.
+
+Whether an unknown *refuses* is relocation's policy, not a property of the
+three-valued answer — a dashboard may paint the same unknown amber and carry on,
+and be right to. It lives as one named constant
+(`UNKNOWN_BLOCKS_RELOCATION`) at the aggregation site rather than as an `if`
+inside fifteen checks, so it can be read, and by a different consumer replaced,
+in one place.
+
+### Every problem in one pass, ordered by what to do about it
+
+No check is skipped because an earlier one failed. All fifteen run, always, and
+the refusal is one block rather than a sentence about the first thing that broke.
+
+Two things make a complete list readable:
+
+- **Root causes are stated once.** An unreachable target turns eleven checks
+  UNKNOWN, and every one of them carries the *same* probe-error text — so
+  identical reasons are recognised as one cause, printed once, with the blocked
+  checks named under it. They still block; they are just not eleven tasks.
+- **The rest are ordered by action**, not by check index: what the target must be
+  provisioned with, what must travel with the agent, what is a spec correction,
+  what still has to be measured. Each entry names *what* is wrong concretely,
+  *where* it was checked, and *what would fix it*.
 
 ### Do not skip the unknowns
 

--- a/src/scitex_agent_container/_lifecycle/_relocate_bind_kind.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_bind_kind.py
@@ -1,0 +1,283 @@
+"""A missing path is not one problem — it is three, and they need opposite fixes.
+
+``binds_exist_on_target`` used to answer with a list of paths and one sentence:
+"remove or re-point these binds in the spec". That sentence is right for exactly
+one of the shapes a missing bind actually takes, and misleading for the others.
+
+Measured across the fleet's specs on 2026-08-11: fifteen agents bind paths that
+do not exist on scitex-compute-04, and every one of those specs is CORRECT for
+the machine it currently pins. Nine are Spartan agents binding
+``/data/gpfs/projects/punim0264/...`` — shared cluster storage that has no
+counterpart on a workstation and cannot be moved to one. Six are laptop agents
+binding a dataset under the agent's own project root and a local ``scitex-clew``
+checkout — data that exists on exactly one machine because that machine made it.
+
+Those look identical when printed as "path not found", and the operator's action
+differs completely:
+
+    host infra    provision or mount it on the target. It may be immovable, in
+                  which case the answer is a different target, not a fix.
+    agent-local   it exists only where the agent has been living. MOVE IT WITH
+                  THE AGENT (a relocation carries the spec and the transcript and
+                  nothing else), or re-point the bind, or — if it is a checkout —
+                  clone it there.
+    credential    NEVER copy it. Provision the target's own, or bind the account
+                  file that host already holds.
+
+The credential case is the one worth the separate kind. "This path is missing;
+copy it with the agent" is a correct-sounding instruction that, applied to
+``~/.ssh`` or an ``accounts/*/.credentials.json``, means copying key material
+between machines. A hint that suggests it is worse than a hint that says nothing.
+
+PURE AND PATH-SHAPE ONLY. No stat, no git, no network — classification runs
+against paths that by definition do NOT exist on the target, and half the time
+do not exist on the machine doing the classifying either. Where the shape cannot
+settle it, the answer is :data:`KIND_UNCLASSIFIED`, which states both
+possibilities rather than picking the likelier one. A confident wrong category
+sends the operator to provision a directory that should have travelled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+__all__ = [
+    "ACTION_CARRY",
+    "ACTION_DECIDE",
+    "ACTION_PROVISION",
+    "KIND_AGENT_LOCAL",
+    "KIND_CREDENTIAL",
+    "KIND_HOST_INFRA",
+    "KIND_UNCLASSIFIED",
+    "BindPath",
+    "classify_bind",
+    "classify_binds",
+    "group_by_action",
+]
+
+#: What the operator has to DO. Ordered as the plan orders them: things the
+#: target needs first, things that must travel second.
+ACTION_PROVISION: Final = "provision on the target"
+ACTION_CARRY: Final = "must travel with the agent"
+ACTION_DECIDE: Final = "decide: provision or carry"
+
+KIND_CREDENTIAL: Final = "credential"
+KIND_AGENT_LOCAL: Final = "agent-local"
+KIND_HOST_INFRA: Final = "host-infra"
+KIND_UNCLASSIFIED: Final = "unclassified"
+
+#: Path components that mean "this is key material". Matched as whole components
+#: (or the file's own name), never as substrings: a directory called
+#: ``ssh-notes`` is not ``.ssh``, and a project named ``accounts-service`` is not
+#: an account store.
+_CREDENTIAL_COMPONENTS: Final = frozenset(
+    {
+        ".ssh",
+        ".gnupg",
+        ".aws",
+        ".azure",
+        ".docker",
+        "accounts",
+        "gh",
+        "secrets",
+    }
+)
+_CREDENTIAL_NAMES: Final = frozenset(
+    {
+        ".credentials.json",
+        "credentials.json",
+        ".pgpass",
+        ".netrc",
+        ".env",
+        ".envrc",
+        "id_rsa",
+        "id_ed25519",
+    }
+)
+
+#: First components that mean a mounted filesystem the HOST provides. These are
+#: the roots that exist because a machine was set up that way, not because an
+#: agent wrote something.
+_INFRA_ROOTS: Final = frozenset(
+    {
+        "data",
+        "gpfs",
+        "mnt",
+        "media",
+        "scratch",
+        "nfs",
+        "net",
+        "srv",
+        "share",
+        "shared",
+        "opt",
+        "usr",
+        "var",
+        "etc",
+        "proc",
+        "sys",
+        "dev",
+        "run",
+    }
+)
+
+#: Components that mean "the agent's own material" wherever they appear. A
+#: ``dataset`` directory under ``.scitex`` is the 2026-08-11 laptop case
+#: verbatim, and it can sit under a home OR under cluster storage.
+_AGENT_DATA_COMPONENTS: Final = frozenset({"dataset", "datasets"})
+
+
+@dataclass(frozen=True)
+class BindPath:
+    """One missing bind source, with what it IS and what to do about it."""
+
+    path: str
+    kind: str
+    action: str
+    #: Why it was put in this category — the evidence, so a wrong call is
+    #: arguable rather than mysterious.
+    because: str
+    #: The concrete thing to do, naming the path and the host.
+    fix: str
+
+
+def _parts(path: str) -> tuple[str, ...]:
+    return tuple(p for p in path.strip().split("/") if p and p != ".")
+
+
+def _under(path: str, root: str) -> bool:
+    """True when ``path`` IS ``root`` or lies beneath it, component-wise.
+
+    Compared as components rather than with ``startswith``, which would call
+    ``/home/ywatanabe/proj-old`` a child of ``/home/ywatanabe/proj``.
+    """
+    if not root:
+        return False
+    p, r = _parts(path), _parts(root)
+    return len(p) >= len(r) and p[: len(r)] == r
+
+
+def classify_bind(path: str, *, workdir: str = "", from_host: str = "") -> BindPath:
+    """Decide what a missing bind source is, from its shape alone.
+
+    ``workdir`` is the agent's own working directory as the spec declares it. It
+    is what separates "the agent's material" from "the machine's": anything at or
+    beneath the workdir was made by this agent, and anything beside it — same
+    parent — belongs to the same person's project tree on the same machine, which
+    is equally absent on a target that has never hosted them.
+
+    The order of the rules is load-bearing. Credentials are decided FIRST, so an
+    ``accounts/`` directory under the agent's own home is never labelled
+    agent-local and never attracts "move it with the agent".
+    """
+    where = from_host or "the source"
+    parts = _parts(path)
+    name = parts[-1] if parts else ""
+
+    if name in _CREDENTIAL_NAMES or (set(parts) & _CREDENTIAL_COMPONENTS):
+        return BindPath(
+            path=path,
+            kind=KIND_CREDENTIAL,
+            action=ACTION_PROVISION,
+            because="the path names key material (an ssh/gh/account/secret location)",
+            fix=(
+                f"provision the TARGET's own copy of {path} there — do NOT copy it "
+                f"from {where}. Credential material must not travel between hosts; "
+                "if the target already holds an equivalent account file, re-point "
+                "the bind at it instead"
+            ),
+        )
+
+    if set(parts) & _AGENT_DATA_COMPONENTS:
+        return BindPath(
+            path=path,
+            kind=KIND_AGENT_LOCAL,
+            action=ACTION_CARRY,
+            because="the path holds a dataset directory, which exists where it was made",
+            fix=(
+                f"move {path} to the target with the agent, or re-point the bind at "
+                "a copy that already exists there. A relocation carries the spec and "
+                "the transcript and nothing else, so this data does not follow by itself"
+            ),
+        )
+
+    if workdir and (_under(path, workdir) or _beside(path, workdir)):
+        rel = "under" if _under(path, workdir) else "beside"
+        return BindPath(
+            path=path,
+            kind=KIND_AGENT_LOCAL,
+            action=ACTION_CARRY,
+            because=f"the path sits {rel} the agent's own workdir ({workdir})",
+            fix=(
+                f"move {path} to the target with the agent, or — if it is a git "
+                f"checkout — clone it there. It exists on {where} because the agent "
+                "works there; nothing on the target creates it"
+            ),
+        )
+
+    if parts and parts[0] in _INFRA_ROOTS:
+        return BindPath(
+            path=path,
+            kind=KIND_HOST_INFRA,
+            action=ACTION_PROVISION,
+            because=f"the path is under /{parts[0]}, a filesystem the host provides",
+            fix=(
+                f"provision or mount {path} on the target. If that filesystem does "
+                "not exist there at all (shared cluster storage usually does not), "
+                "this spec belongs on a host that has it — re-pointing the bind is a "
+                "different agent, not a relocated one"
+            ),
+        )
+
+    return BindPath(
+        path=path,
+        kind=KIND_UNCLASSIFIED,
+        action=ACTION_DECIDE,
+        because="the path's shape does not say whether it is host infrastructure or the agent's own material",
+        fix=(
+            f"look at {path} on {where} and decide: if the host provides it, "
+            "provision it on the target; if the agent made it, move it with the "
+            "agent or re-point the bind. This preflight will not guess between the two"
+        ),
+    )
+
+
+def _beside(path: str, workdir: str) -> bool:
+    """True when ``path`` shares the workdir's parent — the same project tree.
+
+    A sibling of the workdir is not host infrastructure by construction: it is
+    one directory in the same person's project root on the same machine. That is
+    exactly the Spartan shape (``.../ywatanabe/scitex-clew/src`` next to
+    ``.../ywatanabe/paper-scitex-clew``), and treating it as a mount to provision
+    would send the operator to the wrong place.
+    """
+    parent = "/".join(_parts(workdir)[:-1])
+    if not parent:
+        return False
+    return _under(path, "/" + parent) and not _under(path, workdir)
+
+
+def classify_binds(
+    paths: tuple[str, ...] | list[str], *, workdir: str = "", from_host: str = ""
+) -> tuple[BindPath, ...]:
+    """Classify every missing path, in the order given."""
+    return tuple(
+        classify_bind(p, workdir=workdir, from_host=from_host) for p in paths
+    )
+
+
+def group_by_action(classified: tuple[BindPath, ...]) -> tuple[tuple[str, tuple[BindPath, ...]], ...]:
+    """Bucket by action, in the order the operator works: provision, carry, decide.
+
+    Returned as pairs rather than a dict so the ORDER is part of the value. The
+    operator asked for failures ordered by what he has to do about them, and a
+    dict hands that ordering to whatever iterates it next.
+    """
+    order = (ACTION_PROVISION, ACTION_CARRY, ACTION_DECIDE)
+    out = []
+    for action in order:
+        members = tuple(b for b in classified if b.action == action)
+        if members:
+            out.append((action, members))
+    return tuple(out)

--- a/src/scitex_agent_container/_lifecycle/_relocate_checks.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_checks.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 from typing import Final
 
+from ._relocate_bind_kind import classify_binds, group_by_action
 from ._relocate_preflight_facts import Check, SourceFacts, TargetFacts
 from ._relocate_session_choice import CODE_UNKNOWN as SESSION_UNKNOWN
 from ._relocate_session_choice import choose_session
@@ -126,18 +127,45 @@ def check_image(facts: TargetFacts, to_host: str) -> Check:
     return Check(name=CHECK_IMAGE, ok=True, detail="image present")
 
 
-def check_binds(facts: TargetFacts, to_host: str) -> Check:
+def check_binds(
+    facts: TargetFacts, to_host: str, *, workdir: str = "", from_host: str = ""
+) -> Check:
+    """Missing binds are never ONE problem, and the hint must not pretend they are.
+
+    The old hint said "remove or re-point these binds in the spec", which is the
+    right instruction for a Windows drive on a NAS and the wrong one for the
+    fifteen fleet specs measured on 2026-08-11: nine bind Spartan cluster storage
+    that a workstation cannot provide at all, and six bind a dataset and a
+    checkout that exist only on the laptop that made them. Printed as one list of
+    absent paths those look identical; the actions are provision, carry, and
+    (for anything under an account or key directory) provision-and-never-copy.
+
+    ``workdir`` and ``from_host`` are what make the split possible — see
+    :mod:`_relocate_bind_kind`. Without them every path falls to "unclassified",
+    which states both possibilities rather than guessing.
+    """
     if facts.missing_bind_sources is None:
         return _unobserved(CHECK_BINDS, "bind sources")
     if facts.missing_bind_sources:
         missing = ", ".join(facts.missing_bind_sources)
+        classified = classify_binds(
+            facts.missing_bind_sources, workdir=workdir, from_host=from_host
+        )
+        parts = [
+            f"{action}: " + ", ".join(b.path for b in members)
+            for action, members in group_by_action(classified)
+        ]
         return Check(
             name=CHECK_BINDS,
             ok=False,
             detail=f"bind sources absent on {to_host}: {missing}",
             hint=(
-                "remove or re-point these binds in the spec for the target host "
-                "(2026-08-07: /mnt/c is a Windows drive that does not exist on the nas)"
+                "these are not one problem — "
+                + "; ".join(parts)
+                + ". A path the host provides is provisioned on the target; a path the "
+                "agent made exists only where it ran and must travel with it (a "
+                "relocation carries the spec and the transcript and nothing else); a "
+                "credential path is provisioned there and NEVER copied between hosts"
             ),
         )
     return Check(

--- a/src/scitex_agent_container/_lifecycle/_relocate_checks_spec.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_checks_spec.py
@@ -1,0 +1,248 @@
+"""Three more promises the spec makes, asked of the machine that must keep them.
+
+:mod:`_relocate_checks` holds the twelve predicates learned by moving an agent by
+hand. These three were learned on 2026-08-11 from the opposite direction — the
+operator's question 「スペックが相手方でバリデーションが通るか」, does this spec
+VALIDATE on the other side — and each covers a promise the original twelve never
+asked about:
+
+    workdir     the directory the container runs in (``--pwd``). There is no
+                ``spec.repo``: ``spec.workdir`` IS the checkout, and it is a HOST
+                path that must be mounted by a bind. A missing one fails at boot,
+                which under relocation means after the source has been stopped.
+    card store  the DSN itself, not merely whether something answers on it. 5432
+                is wrong on every host in this fleet with no exceptions, and a
+                DSN carrying it can still PASS a reachability probe — some other
+                postgres answers, and the agent quietly records its work into a
+                database nobody reads.
+    groups      whether the TARGET's own sac can resolve the group labels this
+                spec declares. Measured 2026-08-11: three hosts run a listen
+                daemon whose group resolution returns ``[]`` no matter what
+                ``spec.yaml`` says, and nine relocation probes were refused 403
+                because of it. An agent moved onto such a host holds its groups
+                on paper and is refused by every group-gated call.
+
+THE 5432 RULE IS ABSOLUTE AND THE ABSENT PORT IS THE SAME BUG. libpq defaults a
+port-less DSN to 5432, so ``postgresql://scitex_cards@127.0.0.1/scitex_cards``
+means the identical wrong endpoint while looking like it names nothing. Both fail
+here.
+
+A PORT THAT IS NEITHER PASSES, AND SAYS SO. Thirty fleet specs name 55432 and
+that is the convention, but a host may legitimately map its own; this preflight
+states the deviation in the detail rather than inventing a failure it cannot
+justify. The hard rule is enforced where the evidence is unambiguous, and nowhere
+else.
+
+Pure predicates over observed facts, like their twelve neighbours. No I/O.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+from urllib.parse import urlparse
+
+from ._relocate_preflight_facts import Check, TargetFacts
+
+__all__ = [
+    "CHECK_CARD_STORE_DSN",
+    "CHECK_GROUPS",
+    "CHECK_WORKDIR",
+    "FLEET_CARD_STORE_PORT",
+    "WRONG_CARD_STORE_PORT",
+    "check_card_store_dsn",
+    "check_target_groups",
+    "check_workdir",
+]
+
+CHECK_WORKDIR: Final = "workdir_exists_on_target"
+CHECK_CARD_STORE_DSN: Final = "card_store_dsn_correct"
+CHECK_GROUPS: Final = "groups_resolvable_on_target"
+
+#: postgres's own default, and the one port that is never right here.
+WRONG_CARD_STORE_PORT: Final = 5432
+#: What every spec in this fleet names (thirty of thirty, measured 2026-08-11).
+FLEET_CARD_STORE_PORT: Final = 55432
+
+
+def check_workdir(facts: TargetFacts, to_host: str) -> Check:
+    """The container's ``--pwd`` must exist THERE, not merely here.
+
+    ``missing_workdir_paths`` carries the same three-valued shape as the binds
+    fact: ``None`` is nobody-looked, ``()`` is looked-and-nothing-missing (which
+    a spec declaring no workdir satisfies by construction), and a non-empty tuple
+    names what is absent.
+    """
+    if facts.missing_workdir_paths is None:
+        return Check(
+            name=CHECK_WORKDIR,
+            ok=None,
+            detail=f"whether the agent's workdir exists on {to_host} was not observed",
+            hint=(
+                f"test it before deciding: ssh {to_host} '[ -d <workdir> ]'. The workdir "
+                "is the container's --pwd, so an absent one fails at boot — which under "
+                "relocation is after the source has already been stopped"
+            ),
+        )
+    if facts.missing_workdir_paths:
+        missing = ", ".join(facts.missing_workdir_paths)
+        return Check(
+            name=CHECK_WORKDIR,
+            ok=False,
+            detail=f"the agent's workdir does not exist on {to_host}: {missing}",
+            hint=(
+                f"create it on {to_host} before relocating — if it is a git checkout, "
+                "clone it there and check out the branch the agent works on. sac passes "
+                "spec.workdir to apptainer as --pwd and also needs a bind that mounts "
+                "it; a workdir that exists but is unbound fails the same way"
+            ),
+        )
+    return Check(
+        name=CHECK_WORKDIR,
+        ok=True,
+        detail=f"the agent's workdir exists on {to_host}",
+    )
+
+
+def _port_of(url: str) -> int | None:
+    """The DSN's explicit port, or ``None`` when it names none."""
+    try:
+        return urlparse(url).port
+    except ValueError:
+        return None
+
+
+def check_card_store_dsn(facts: TargetFacts) -> Check:
+    """The DSN the agent WOULD dial — judged as a string, before anything answers.
+
+    Separate from ``card_store_reachable`` because they are different questions
+    with different fixes, and because reachability can PASS on a wrong endpoint:
+    something is listening on 5432 on most machines, so a spec that names it gets
+    a green light and then writes the fleet's cards into a database nobody reads.
+    """
+    url = facts.card_store_url
+    if url is None:
+        return Check(
+            name=CHECK_CARD_STORE_DSN,
+            ok=None,
+            detail="the card-store DSN this agent would use was not established",
+            hint=(
+                "declare SCITEX_CARDS_DB for this agent (spec.apptainer.env, or an "
+                "--env pair in spec.apptainer.raw_args) — an agent with no board "
+                f"records nothing. The fleet's endpoint is port {FLEET_CARD_STORE_PORT}"
+            ),
+        )
+    port = _port_of(url)
+    if port is None:
+        return Check(
+            name=CHECK_CARD_STORE_DSN,
+            ok=False,
+            detail=f"the card-store DSN names no port: {url}",
+            hint=(
+                f"give it :{FLEET_CARD_STORE_PORT} explicitly. A port-less DSN is not "
+                f"neutral — libpq defaults it to {WRONG_CARD_STORE_PORT}, which is the "
+                "wrong database on every host in this fleet, and it fails silently "
+                "because something usually answers there"
+            ),
+        )
+    if port == WRONG_CARD_STORE_PORT:
+        return Check(
+            name=CHECK_CARD_STORE_DSN,
+            ok=False,
+            detail=f"the card-store DSN names port {WRONG_CARD_STORE_PORT}: {url}",
+            hint=(
+                f"change it to :{FLEET_CARD_STORE_PORT}. {WRONG_CARD_STORE_PORT} is "
+                "postgres's default and is wrong on every host here with no exceptions; "
+                "a reachability probe still passes on it, so this must be caught by "
+                "reading the DSN rather than by dialling it"
+            ),
+        )
+    if port != FLEET_CARD_STORE_PORT:
+        return Check(
+            name=CHECK_CARD_STORE_DSN,
+            ok=True,
+            detail=(
+                f"the card-store DSN names port {port}, not the fleet's "
+                f"{FLEET_CARD_STORE_PORT} — passing because {port} is not the forbidden "
+                f"{WRONG_CARD_STORE_PORT}; confirm the deviation is deliberate"
+            ),
+        )
+    return Check(
+        name=CHECK_CARD_STORE_DSN,
+        ok=True,
+        detail=f"the card-store DSN names the fleet's port {FLEET_CARD_STORE_PORT}",
+    )
+
+
+def check_target_groups(
+    facts: TargetFacts, declared_groups: tuple[str, ...], to_host: str
+) -> Check:
+    """Would the TARGET's own sac recognise the groups this spec declares?
+
+    The distinction this check exists to preserve is the operator's: "the target
+    refused me" is not "the target says no". A resolver that answers with a
+    NON-EMPTY set and omits a declared group has made a statement — that is a
+    FAIL. A resolver that answers with nothing, or that could not be asked at
+    all, has made none, and on 2026-08-11 exactly that shape (three hosts whose
+    group resolution returns ``[]`` regardless of spec.yaml) refused nine
+    relocation probes with a 403. Reporting it as a FAIL would send the operator
+    to edit a spec that is already correct.
+    """
+    if not declared_groups:
+        return Check(
+            name=CHECK_GROUPS,
+            ok=True,
+            detail="the spec declares no groups, so none has to hold on the target",
+        )
+    if facts.target_resolved_groups is None:
+        return Check(
+            name=CHECK_GROUPS,
+            ok=None,
+            detail=(
+                f"whether {to_host}'s sac resolves this spec's groups "
+                f"({', '.join(declared_groups)}) was not observed"
+            ),
+            hint=(
+                f"ask the target's own sac to resolve them before relocating. If it "
+                "cannot — an older listen daemon resolves every caller to [] no matter "
+                "what spec.yaml declares — the agent arrives holding its groups on paper "
+                "and is refused 403 by every group-gated call it makes"
+            ),
+        )
+    resolved = facts.target_resolved_groups
+    if not resolved:
+        return Check(
+            name=CHECK_GROUPS,
+            ok=None,
+            detail=(
+                f"{to_host}'s sac resolved NO groups from this spec's labels "
+                f"({', '.join(declared_groups)}) — which is what a daemon too old to "
+                "read spec labels answers for every agent, so it is not a verdict about "
+                "this spec"
+            ),
+            hint=(
+                f"upgrade sac on {to_host} and re-run. An empty resolution cannot be "
+                "told apart from 'this agent genuinely holds no groups', and the two "
+                "have opposite fixes; on 2026-08-11 this exact shape refused nine "
+                "relocation probes with a 403 while every spec involved was correct"
+            ),
+        )
+    absent = tuple(g for g in declared_groups if g not in resolved)
+    if absent:
+        return Check(
+            name=CHECK_GROUPS,
+            ok=False,
+            detail=(
+                f"{to_host}'s sac resolves {', '.join(sorted(resolved))} for this spec "
+                f"and does not recognise: {', '.join(absent)}"
+            ),
+            hint=(
+                "the target answered, and the answer is no — so this is a spec/target "
+                f"disagreement, not an outage. Either drop those labels or teach {to_host} "
+                "about them; an unrecognised group is silently no group at the ACL gate"
+            ),
+        )
+    return Check(
+        name=CHECK_GROUPS,
+        ok=True,
+        detail=f"{to_host}'s sac resolves every declared group: {', '.join(declared_groups)}",
+    )

--- a/src/scitex_agent_container/_lifecycle/_relocate_plan.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_plan.py
@@ -1,0 +1,303 @@
+"""Turn a refusal into a work list — ordered by what to DO, root causes named once.
+
+The operator's requirement, 2026-08-11: 「なるべく多くのヒントを1回で出す」— emit as
+many hints as possible in ONE pass. :mod:`_relocate_preflight` already runs every
+check regardless of earlier failures, so the hints all exist; this module is about
+the two ways a complete list still fails its reader.
+
+ORDER. A report ordered by check index is the code's structure leaking into the
+operator's afternoon. He works by action: what the target must be given, then what
+has to travel with the agent, then what is a spec edit, then what is still
+unmeasured. Those are four different places to stand, and grouping by them is the
+difference between one trip to a machine and four.
+
+ROOT CAUSES. An unreachable target turns eleven checks UNKNOWN, and printing
+eleven problems where there is one is worse than printing none: the real cause is
+buried in its own consequences. The grouping is not a guess — every fact gathered
+through a failed transport carries the SAME reason string (:mod:`_relocate_probe`
+keeps the exception text per fact), so identical reasons ARE one cause, and that
+is the whole rule. Two checks that failed for genuinely different reasons never
+merge, because their text differs.
+
+WHAT A CONSEQUENCE IS NOT. A check swallowed by a root cause is not dropped and
+not downgraded — it is listed BY NAME under the cause that blocked it, and it
+still blocks. This is the three-valued rule applied to the dependency itself: "I
+could not check whether the port is free, because the host never answered" is an
+unknown with a known reason, not a pass and not a fail.
+
+Pure: a report and a dict of probe errors in, dataclasses out. The renderer turns
+these into lines; nothing here prints.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from ._relocate_bind_kind import (
+    ACTION_CARRY,
+    ACTION_DECIDE,
+    ACTION_PROVISION,
+    classify_binds,
+)
+from ._relocate_checks import (
+    CHECK_BINDS,
+    CHECK_CARD_STORE,
+    CHECK_CREDENTIALS,
+    CHECK_HUB_FROM_TARGET,
+    CHECK_IMAGE,
+    CHECK_PORTS,
+    CHECK_REACHABLE,
+    CHECK_RUNTIME,
+    CHECK_SAC_PRESENT,
+    CHECK_SCHEMA,
+    CHECK_SESSION,
+    CHECK_SOURCE_WORK,
+)
+from ._relocate_checks_spec import CHECK_CARD_STORE_DSN, CHECK_GROUPS, CHECK_WORKDIR
+from ._relocate_preflight_facts import Check, PreflightReport
+
+__all__ = [
+    "ACTION_CARRY",
+    "ACTION_DECIDE",
+    "ACTION_MEASURE",
+    "ACTION_ORDER",
+    "ACTION_PROVISION",
+    "ACTION_SPEC",
+    "CHECK_FACTS",
+    "Plan",
+    "PlanItem",
+    "RootCause",
+    "build_plan",
+    "why_for_check",
+]
+
+#: A spec edit — the fix is in a file, not on a machine.
+ACTION_SPEC: Final = "correct the spec"
+#: Nothing is known to be wrong; something is not known at all.
+ACTION_MEASURE: Final = "go and measure"
+
+#: The order the operator works in. Provisioning first because it is usually
+#: somebody standing at another machine; measuring last because an unknown is not
+#: yet a task, it is a question.
+ACTION_ORDER: Final = (
+    ACTION_PROVISION,
+    ACTION_CARRY,
+    ACTION_SPEC,
+    ACTION_DECIDE,
+    ACTION_MEASURE,
+)
+
+#: Which FACTS feed each CHECK. ``gather_target_facts`` keys its failures by fact
+#: name and the report is written in checks; several are named differently on the
+#: two sides, and keying only by check name silently drops exactly those reasons —
+#: they are present, correct, and never shown (measured 2026-08-09 against a
+#: busybox NAS, where four of five unknowns lost their explanation on the way to
+#: the screen).
+CHECK_FACTS: Final[dict[str, tuple[str, ...]]] = {
+    CHECK_REACHABLE: ("reachable",),
+    CHECK_IMAGE: ("image_present",),
+    CHECK_BINDS: ("missing_bind_sources",),
+    CHECK_WORKDIR: ("missing_workdir_paths",),
+    CHECK_CARD_STORE_DSN: ("card_store_url",),
+    CHECK_CARD_STORE: ("card_store_reachable", "card_store_url"),
+    CHECK_CREDENTIALS: (
+        "credential_expires_in_s",
+        "credential_refresh_token_present",
+    ),
+    CHECK_RUNTIME: ("supported_runtimes",),
+    CHECK_SCHEMA: ("rejected_spec_keys",),
+    CHECK_PORTS: ("ports_in_use",),
+    CHECK_GROUPS: ("target_resolved_groups",),
+    CHECK_HUB_FROM_TARGET: ("hub_reachable_from_target",),
+    CHECK_SAC_PRESENT: ("sac_on_path", "sac_resolved_path"),
+    # Gathered locally rather than over ssh, so their failures are keyed by the
+    # check's own name; listed so the map covers every check and a reader does
+    # not have to wonder whether the omission means something.
+    CHECK_SOURCE_WORK: ("source_repos",),
+    CHECK_SESSION: ("source_transcripts",),
+}
+
+#: What a FAILING check asks the operator to do. Unknowns ignore this table
+#: entirely — an unmeasured check is a question, whatever it is about.
+_FAIL_ACTION: Final[dict[str, str]] = {
+    CHECK_REACHABLE: ACTION_PROVISION,
+    CHECK_IMAGE: ACTION_PROVISION,
+    CHECK_WORKDIR: ACTION_PROVISION,
+    CHECK_CARD_STORE: ACTION_PROVISION,
+    CHECK_CREDENTIALS: ACTION_PROVISION,
+    CHECK_PORTS: ACTION_PROVISION,
+    CHECK_HUB_FROM_TARGET: ACTION_PROVISION,
+    CHECK_SAC_PRESENT: ACTION_PROVISION,
+    CHECK_CARD_STORE_DSN: ACTION_SPEC,
+    CHECK_RUNTIME: ACTION_SPEC,
+    CHECK_SCHEMA: ACTION_SPEC,
+    CHECK_GROUPS: ACTION_SPEC,
+    CHECK_SOURCE_WORK: ACTION_CARRY,
+    CHECK_SESSION: ACTION_CARRY,
+}
+
+#: Checks measured on the machine being LEFT. Naming the vantage point is not
+#: decoration: "path absent" means opposite things depending on which host was
+#: asked, and a hint without its vantage point sends people to the wrong machine.
+_SOURCE_CHECKS: Final = frozenset({CHECK_SOURCE_WORK, CHECK_SESSION})
+
+
+@dataclass(frozen=True)
+class PlanItem:
+    """One thing to do, with the vantage point that makes it meaningful."""
+
+    action: str
+    check: str
+    verdict: str
+    what: str
+    where: str
+    fix: str
+
+
+@dataclass(frozen=True)
+class RootCause:
+    """One failure that made several checks unanswerable, with their names."""
+
+    reason: str
+    checks: tuple[str, ...]
+
+    @property
+    def summary(self) -> str:
+        return (
+            f"{len(self.checks)} checks could not be measured for one reason: "
+            f"{self.reason}"
+        )
+
+
+@dataclass(frozen=True)
+class Plan:
+    """Everything blocking this relocation, ordered as work rather than as code."""
+
+    causes: tuple[RootCause, ...] = ()
+    items: tuple[PlanItem, ...] = ()
+
+    @property
+    def empty(self) -> bool:
+        return not self.causes and not self.items
+
+    def by_action(self) -> tuple[tuple[str, tuple[PlanItem, ...]], ...]:
+        """Items bucketed in :data:`ACTION_ORDER`, empty buckets omitted."""
+        out = []
+        for action in ACTION_ORDER:
+            members = tuple(i for i in self.items if i.action == action)
+            if members:
+                out.append((action, members))
+        return tuple(out)
+
+
+def why_for_check(check_name: str, errors: dict[str, str]) -> str:
+    """The probe failure behind ``check_name``, by its own key or its facts'.
+
+    The check's own name wins, so a caller that already keyed by check name keeps
+    working; the fact names are the fallback that makes the adapter's reasons
+    reach the reader.
+    """
+    direct = errors.get(check_name)
+    if direct:
+        return direct
+    for fact in CHECK_FACTS.get(check_name, ()):
+        reason = errors.get(fact)
+        if reason:
+            return reason
+    return ""
+
+
+def _bind_items(check: Check, workdir: str, from_host: str, to_host: str):
+    """Explode a binds failure into one item per ACTION, not one per check.
+
+    A single check produced paths that need provisioning AND paths that must
+    travel. Reporting them under one heading is the exact collapse this feature
+    was asked to undo, so the plan splits them and the check keeps its single
+    verdict.
+    """
+    paths = _paths_from_detail(check.detail)
+    classified = classify_binds(paths, workdir=workdir, from_host=from_host)
+    for action in (ACTION_PROVISION, ACTION_CARRY, ACTION_DECIDE):
+        for bind in (b for b in classified if b.action == action):
+            yield PlanItem(
+                action=action,
+                check=check.name,
+                verdict="FAIL",
+                what=f"{bind.path} ({bind.kind}) — {bind.because}",
+                where=to_host,
+                fix=bind.fix,
+            )
+
+
+def _paths_from_detail(detail: str) -> tuple[str, ...]:
+    """The paths out of ``bind sources absent on <host>: /a, /b``.
+
+    Parsed from the detail rather than re-read from the facts because a plan is
+    built from a REPORT — the facts are gone by then, and threading them through
+    would let the two drift into describing different paths.
+    """
+    _, _, listed = detail.partition(": ")
+    return tuple(p.strip() for p in listed.split(",") if p.strip())
+
+
+def build_plan(
+    report: PreflightReport,
+    *,
+    errors: dict[str, str] | None = None,
+    workdir: str = "",
+    from_host: str = "",
+) -> Plan:
+    """Everything blocking ``report``, grouped by cause and ordered by action.
+
+    Failures come first within the ordering because they are known work; unknowns
+    land in :data:`ACTION_MEASURE` last. Both block — that decision belongs to
+    :data:`.._relocate_preflight_facts.UNKNOWN_BLOCKS_RELOCATION` and is not
+    re-made here; this module only decides how to SAY it.
+    """
+    errors = errors or {}
+    where = report.to_host
+
+    by_reason: dict[str, list[Check]] = {}
+    for check in report.unknown:
+        reason = why_for_check(check.name, errors)
+        if reason:
+            by_reason.setdefault(reason, []).append(check)
+
+    causes = tuple(
+        RootCause(reason=reason, checks=tuple(c.name for c in checks))
+        for reason, checks in by_reason.items()
+        if len(checks) > 1
+    )
+    swallowed = {name for cause in causes for name in cause.checks}
+
+    items: list[PlanItem] = []
+    for check in report.failed:
+        if check.name == CHECK_BINDS:
+            items += list(_bind_items(check, workdir, from_host, where))
+            continue
+        items.append(
+            PlanItem(
+                action=_FAIL_ACTION.get(check.name, ACTION_DECIDE),
+                check=check.name,
+                verdict="FAIL",
+                what=check.detail,
+                where=from_host or where if check.name in _SOURCE_CHECKS else where,
+                fix=check.hint,
+            )
+        )
+    for check in report.unknown:
+        if check.name in swallowed:
+            continue
+        reason = why_for_check(check.name, errors)
+        items.append(
+            PlanItem(
+                action=ACTION_MEASURE,
+                check=check.name,
+                verdict="UNKNOWN",
+                what=check.detail + (f" (probe error: {reason})" if reason else ""),
+                where=from_host or where if check.name in _SOURCE_CHECKS else where,
+                fix=check.hint,
+            )
+        )
+    return Plan(causes=causes, items=tuple(items))

--- a/src/scitex_agent_container/_lifecycle/_relocate_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_preflight.py
@@ -62,11 +62,29 @@ from ._relocate_checks import (
     check_session_resolvable,
     check_source_work,
 )
-from ._relocate_preflight_facts import Check, PreflightReport, SourceFacts, TargetFacts
+from ._relocate_checks_spec import (
+    CHECK_CARD_STORE_DSN,
+    CHECK_GROUPS,
+    CHECK_WORKDIR,
+    check_card_store_dsn,
+    check_target_groups,
+    check_workdir,
+)
+from ._relocate_preflight_facts import (
+    UNKNOWN_BLOCKS_RELOCATION,
+    Check,
+    PreflightReport,
+    SourceFacts,
+    TargetFacts,
+)
 
 __all__ = [
     "CHECK_BINDS",
     "CHECK_CARD_STORE",
+    "CHECK_CARD_STORE_DSN",
+    "CHECK_GROUPS",
+    "CHECK_WORKDIR",
+    "UNKNOWN_BLOCKS_RELOCATION",
     "CHECK_CREDENTIALS",
     "CHECK_HUB_FROM_TARGET",
     "CHECK_IMAGE",
@@ -81,6 +99,9 @@ __all__ = [
     "PreflightReport",
     "SourceFacts",
     "TargetFacts",
+    "check_card_store_dsn",
+    "check_target_groups",
+    "check_workdir",
     "preflight",
 ]
 
@@ -94,6 +115,8 @@ def preflight(
     required_ports: tuple[int, ...] = (),
     source_facts: SourceFacts | None = None,
     from_host: str = "",
+    workdir: str = "",
+    declared_groups: tuple[str, ...] = (),
 ) -> PreflightReport:
     """Evaluate every check against observed facts. Touches nothing.
 
@@ -105,16 +128,32 @@ def preflight(
     that has not looked at the source has not established the move is safe, and
     inheriting a pass for a check it never ran is the shape of every bug this
     module was written about.
+
+    ``workdir`` and ``declared_groups`` are the spec's own claims, passed in
+    rather than dug out of a spec here: this module evaluates facts and does not
+    parse yaml. ``workdir`` also gives the binds check the context it needs to
+    tell the agent's own material from the host's — without it every missing path
+    reads as "unclassified", which is honest but far less useful.
+
+    NO CHECK IS SKIPPED BECAUSE AN EARLIER ONE FAILED. All fifteen run, always.
+    An unreachable target makes most of them UNKNOWN — each carrying the same
+    probe error, which is how :mod:`_relocate_plan` recognises them as one root
+    cause rather than reporting twelve independent problems. Stopping early would
+    cost the operator a round trip to another machine per problem, and nine
+    agents are queued.
     """
     checks = (
         check_reachable(facts, to_host),
         check_image(facts, to_host),
-        check_binds(facts, to_host),
+        check_binds(facts, to_host, workdir=workdir, from_host=from_host),
+        check_workdir(facts, to_host),
+        check_card_store_dsn(facts),
         check_card_store(facts, to_host),
         check_credentials(facts),
         check_runtime(facts, runtime),
         check_schema(facts),
         check_ports(facts, required_ports),
+        check_target_groups(facts, declared_groups, to_host),
         check_hub_from_target(facts, to_host),
         check_sac_present(facts, to_host),
         check_source_work(source_facts or SourceFacts(), from_host),

--- a/src/scitex_agent_container/_lifecycle/_relocate_preflight_facts.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_preflight_facts.py
@@ -80,6 +80,18 @@ class TargetFacts:
     rejected_spec_keys: tuple[str, ...] | None = None
     ports_in_use: tuple[int, ...] | None = None
     hub_reachable_from_target: bool | None = None
+    #: Declared paths the agent must RUN IN that are absent on the target —
+    #: today just ``spec.workdir``, which is the container's ``--pwd``. There is
+    #: no ``spec.repo``: the workdir IS the checkout. Same three values as
+    #: ``missing_bind_sources``: ``None`` nobody looked, ``()`` looked and
+    #: nothing missing (which a spec declaring no workdir satisfies by
+    #: construction), non-empty names what is absent.
+    missing_workdir_paths: tuple[str, ...] | None = None
+    #: The groups the TARGET's own sac resolves from this spec's labels. ``()``
+    #: is a REAL answer and a damning one — it is what a daemon too old to read
+    #: spec labels returns for every agent — but it is not a verdict about the
+    #: spec, so the check treats it as undetermined rather than as a refusal.
+    target_resolved_groups: tuple[str, ...] | None = None
     #: Whether ``command -v sac`` finds it in the NON-INTERACTIVE ssh PATH —
     #: which is the PATH every remote sac call actually runs under.
     sac_on_path: bool | None = None
@@ -117,6 +129,20 @@ class SourceFacts:
     session_marker: str | None = None
 
 
+#: RELOCATION's rollup policy, stated once, here, at the aggregation site.
+#:
+#: Whether an undetermined check refuses is a property of the CONSUMER, not of
+#: the three-valued verdict: a dashboard paints an unknown amber and carries on,
+#: and it is right to. Relocation refuses, because proceeding means stopping an
+#: agent on one machine and starting it on another that nobody has verified.
+#:
+#: It is a named constant rather than an ``if`` inside twelve checks so that the
+#: policy can be read (and, by a different consumer, replaced) in one place. Each
+#: check's job ends at reporting pass / fail / undetermined; deciding what an
+#: undetermined one MEANS is this module's job and nothing else's.
+UNKNOWN_BLOCKS_RELOCATION = True
+
+
 @dataclass(frozen=True)
 class PreflightReport:
     """The whole answer, in one shape.
@@ -126,6 +152,12 @@ class PreflightReport:
     something is unknown, False when anything failed. Unknowns are reported
     SEPARATELY from failures so a reader can tell "this is wrong" from "I could
     not tell" — and neither reads as go.
+
+    The three-valued verdict is per-check (:class:`Check`) and the rollup is
+    derived from it; nothing anywhere carries a boolean plus a flag. That is
+    deliberate so the fleet-wide status type — ``{package, ok, checks:[{name, ok,
+    detail, hint}], summary}``, being extended to three values in scitex-dev — can
+    be adopted here as a rename rather than a rewrite.
     """
 
     agent: str
@@ -153,6 +185,18 @@ class PreflightReport:
         if self.unknown:
             return None
         return True
+
+    @property
+    def blocks(self) -> bool:
+        """Must this relocation be refused? The policy, APPLIED — not re-decided.
+
+        Reads :data:`UNKNOWN_BLOCKS_RELOCATION` rather than assuming it, so a
+        consumer that wants unknowns to be advisory changes one constant instead
+        of hunting down every ``is not True`` at the call sites.
+        """
+        if self.failed:
+            return True
+        return bool(self.unknown) and UNKNOWN_BLOCKS_RELOCATION
 
     def blocking_reasons(self) -> tuple[str, ...]:
         """Every reason this relocation must not proceed, each with its hint.

--- a/src/scitex_agent_container/_lifecycle/_relocate_probe.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe.py
@@ -81,6 +81,8 @@ class TargetProbes:
     reachable: Callable[[], bool] | None = None
     image_present: Callable[[], bool] | None = None
     missing_bind_sources: Callable[[], tuple[str, ...]] | None = None
+    missing_workdir_paths: Callable[[], tuple[str, ...]] | None = None
+    target_resolved_groups: Callable[[], tuple[str, ...]] | None = None
     card_store_url: Callable[[], str] | None = None
     card_store_reachable: Callable[[], bool] | None = None
     credential_expires_in_s: Callable[[], float] | None = None
@@ -114,6 +116,8 @@ _FIELDS: tuple[str, ...] = (
     "reachable",
     "image_present",
     "missing_bind_sources",
+    "missing_workdir_paths",
+    "target_resolved_groups",
     "card_store_url",
     "card_store_reachable",
     "credential_expires_in_s",

--- a/src/scitex_agent_container/_lifecycle/_relocate_probe_adapter.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe_adapter.py
@@ -63,6 +63,15 @@ from ._relocate_probe_ssh import (
     peer_preamble,
     run_probe_script,
 )
+from ._relocate_spec_reads import (
+    apptainer_section,
+    bind_sources_from_spec,
+    card_store_url_from_spec,
+    credential_paths_from_spec,
+    declared_groups_from_spec,
+    group_labels_from_spec,
+    workdirs_from_spec,
+)
 
 __all__ = [
     "FactUnavailable",
@@ -87,39 +96,6 @@ class FactUnavailable(RuntimeError):
     """
 
 
-def _body(spec: dict) -> dict:
-    inner = spec.get("spec")
-    return inner if isinstance(inner, dict) else spec
-
-
-def _apptainer(spec: dict) -> dict:
-    app = _body(spec).get("apptainer")
-    return app if isinstance(app, dict) else {}
-
-
-def card_store_url_from_spec(spec: dict) -> str:
-    """The ``SCITEX_CARDS_DB`` the agent would use, wherever the spec hides it.
-
-    Two places, both real: ``apptainer.env`` and the ``--env KEY=VALUE`` pairs in
-    ``apptainer.raw_args``. This repo's own spec uses the second and leaves the
-    first an empty mapping, so a reader of ``env`` alone concludes the agent has
-    no card store — and then the store check has nothing to check while looking
-    like it passed.
-    """
-    app = _apptainer(spec)
-    env = app.get("env")
-    if isinstance(env, dict):
-        value = env.get("SCITEX_CARDS_DB")
-        if isinstance(value, str) and value:
-            return value
-    raw = app.get("raw_args")
-    if isinstance(raw, list):
-        for item in raw:
-            if isinstance(item, str) and item.startswith("SCITEX_CARDS_DB="):
-                return item.split("=", 1)[1]
-    return ""
-
-
 def _endpoint(url: str) -> tuple[str, int]:
     """``postgresql://user@host:5432/db`` -> ``("host", 5432)``; ``("", 0)`` if unusable."""
     if not url:
@@ -131,29 +107,6 @@ def _endpoint(url: str) -> tuple[str, int]:
     except ValueError:
         return ("", 0)
     return (host, port) if host and port else ("", 0)
-
-
-def _credential_paths(spec: dict) -> tuple[str, ...]:
-    claude = _body(spec).get("claude")
-    if not isinstance(claude, dict):
-        return ()
-    paths: list[str] = []
-    single = claude.get("credentials_file")
-    if isinstance(single, str) and single.strip():
-        paths.append(single.strip())
-    listed = claude.get("credentials_files")
-    if isinstance(listed, list):
-        paths += [p.strip() for p in listed if isinstance(p, str) and p.strip()]
-    return tuple(dict.fromkeys(paths))
-
-
-def _bind_sources(spec: dict) -> tuple[str, ...]:
-    binds = _apptainer(spec).get("binds")
-    if not isinstance(binds, list):
-        return ()
-    return tuple(
-        b.split(":", 1)[0] for b in binds if isinstance(b, str) and b.split(":", 1)[0]
-    )
 
 
 def hub_address(env: dict[str, str] | None = None) -> tuple[str, int, str]:
@@ -206,15 +159,27 @@ def questions_from_spec(
     env: dict[str, str] | None = None,
 ) -> RemoteQuestions:
     """Turn the agent's spec into the set of questions to ask its future host."""
+    import json
+
     store_host, store_port = _endpoint(card_store_url_from_spec(spec))
     hub_host, hub_port, _ = hub_address(env)
-    image = _apptainer(spec).get("image")
+    image = apptainer_section(spec).get("image")
+    # Asked only when the spec actually claims a group. An empty labels blob
+    # would make the target answer "no groups", which is a real-looking verdict
+    # about a question nobody asked.
+    labels_json = (
+        json.dumps(group_labels_from_spec(spec))
+        if declared_groups_from_spec(spec)
+        else ""
+    )
     return RemoteQuestions(
         image=image if isinstance(image, str) else "",
-        bind_sources=_bind_sources(spec),
+        bind_sources=bind_sources_from_spec(spec),
+        workdirs=workdirs_from_spec(spec),
+        group_labels_json=labels_json,
         card_store_host=store_host,
         card_store_port=store_port,
-        credential_paths=_credential_paths(spec),
+        credential_paths=credential_paths_from_spec(spec),
         required_ports=tuple(required_ports),
         hub_host=hub_host,
         hub_port=hub_port,
@@ -325,6 +290,45 @@ class TargetBatch:
                 "sources; a partial sweep cannot distinguish 'present' from 'not reached'"
             )
         return self.readout().missing_binds
+
+    def missing_workdir_paths(self) -> tuple[str, ...]:
+        wanted = self.questions.workdirs
+        if not wanted:
+            # The spec declares no workdir, so no workdir can be missing.
+            # Observed by construction, not by defaulting.
+            return ()
+        checked = self._field("workdirs_checked", "workdir-check")
+        if checked != str(len(wanted)):
+            raise FactUnavailable(
+                f"the target reported checking {checked!r} of {len(wanted)} workdir(s); "
+                "a partial sweep cannot distinguish 'present' from 'not reached'"
+            )
+        return self.readout().missing_workdirs
+
+    def target_resolved_groups(self) -> tuple[str, ...]:
+        """What the TARGET's own sac makes of this spec's group labels.
+
+        An EMPTY value is a measurement, not a missing one: it is what a daemon
+        too old to read spec labels answers for every agent, and the check treats
+        it as undetermined for that reason — but it must reach the check as an
+        observed empty tuple, because "answered nothing" and "was never asked"
+        need different sentences. Only an absent line is unknown here.
+        """
+        if not self.questions.group_labels_json:
+            raise FactUnavailable(
+                "this spec declares no groups under metadata.labels, so nothing was "
+                "asked of the target about them"
+            )
+        value = self.readout().fields.get("groups")
+        if value is None:
+            raise FactUnavailable(
+                "the target's sac did not resolve group labels — it is not importable "
+                "there, or is too old to carry config._group_resolver.all_named_groups. "
+                "An agent moved onto such a host holds its groups on paper and is "
+                f"refused 403 by every group-gated call. Check with: ssh {self.host} "
+                "'sac --version'"
+            )
+        return tuple(v for v in value.split(",") if v)
 
     def card_store_url(self) -> str:
         url = card_store_url_from_spec(self.spec)
@@ -486,6 +490,8 @@ def build_target_probes(
         reachable=batch.reachable,
         image_present=batch.image_present,
         missing_bind_sources=batch.missing_bind_sources,
+        missing_workdir_paths=batch.missing_workdir_paths,
+        target_resolved_groups=batch.target_resolved_groups,
         card_store_url=batch.card_store_url,
         card_store_reachable=batch.card_store_reachable,
         credential_expires_in_s=batch.credential_expires_in_s,

--- a/src/scitex_agent_container/_lifecycle/_relocate_probe_script.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe_script.py
@@ -87,6 +87,15 @@ class RemoteQuestions:
     image: str = ""
     #: Bind SOURCE paths (the left half of ``src:dst:mode``).
     bind_sources: tuple[str, ...] = ()
+    #: Directories the agent must RUN IN — today just ``spec.workdir``, which
+    #: apptainer receives as ``--pwd``. Tested with ``-d`` rather than ``-e``: a
+    #: FILE where the workdir should be is not a workdir, and apptainer's failure
+    #: for that case is as opaque as for an absent one.
+    workdirs: tuple[str, ...] = ()
+    #: ``metadata.labels`` as JSON, for the target's own resolver to read. Sent
+    #: as one quoted argument so a label with a space or a quote in it cannot
+    #: reshape the remote command.
+    group_labels_json: str = ""
     #: Card store endpoint AS THE AGENT WOULD DIAL IT FROM THE TARGET. A
     #: loopback host is correct here and is deliberately probed: after the move
     #: the agent runs ON the target, so ``127.0.0.1:5432`` means the TARGET's
@@ -135,6 +144,7 @@ class RemoteReadout:
     complete: bool = False
     fields: dict[str, str] = field(default_factory=dict)
     missing_binds: tuple[str, ...] = ()
+    missing_workdirs: tuple[str, ...] = ()
     credentials: tuple[CredentialLine, ...] = ()
     ports_in_use: tuple[int, ...] = ()
 
@@ -197,6 +207,15 @@ def render_probe_script(questions: RemoteQuestions, *, preamble: str = "") -> st
             f'echo "$M binds_checked={len(questions.bind_sources)}"'
         )
 
+    if questions.workdirs:
+        listed = " ".join(_q(w) for w in questions.workdirs)
+        parts.append(
+            f"for w in {listed}; do\n"
+            '  if [ -d "$w" ]; then :; else echo "$M workdir_missing=$w"; fi\n'
+            "done\n"
+            f'echo "$M workdirs_checked={len(questions.workdirs)}"'
+        )
+
     card = _tcp_section(
         "cardstore", questions.card_store_host, questions.card_store_port
     )
@@ -241,8 +260,40 @@ def render_probe_script(questions: RemoteQuestions, *, preamble: str = "") -> st
 
     parts.append(_SAC_WHERE_SECTION)
     parts.append(_SAC_SECTION)
+    if questions.group_labels_json:
+        parts.append(_groups_section(questions.group_labels_json))
     parts.append('echo "$M end"')
     return "\n".join(parts) + "\n"
+
+
+# Ask the TARGET's own sac what groups it makes of this spec's labels. It runs
+# after _SAC_SECTION on purpose, reusing the `$py` that section resolved from the
+# `sac` console script's shebang — the interpreter that BACKS the installation,
+# not whatever python3 leads the PATH.
+#
+# A pure label read (`all_named_groups`), deliberately: resolving through the
+# state db would ask whether the target already knows this agent, and it does not
+# — it has never hosted it. The question that matters is whether the target's sac
+# can read group labels AT ALL. Measured 2026-08-11: three hosts answer [] for
+# every agent regardless of spec.yaml, and nine relocation probes were refused
+# 403 by exactly that.
+#
+# An old sac lacking the symbol prints NOTHING, the marker never arrives, and the
+# fact stays honestly unknown rather than becoming an empty set that reads as a
+# verdict.
+def _groups_section(labels_json: str) -> str:
+    return f"""
+SACRELOC_GROUPS_PY=$(cat <<'SACRELOCPY'
+import json, sys
+from scitex_agent_container.config._group_resolver import all_named_groups
+print(",".join(sorted(all_named_groups(json.loads(sys.argv[1])))))
+SACRELOCPY
+)
+if command -v "$py" >/dev/null 2>&1; then
+  gr=$("$py" -c "$SACRELOC_GROUPS_PY" {_q(labels_json)} 2>/dev/null)
+  if [ $? -eq 0 ]; then echo "$M groups=$gr"; fi
+fi
+"""
 
 
 # The remote helpers, kept out of the renderer so the shell is readable as
@@ -406,6 +457,7 @@ def parse_probe_output(stdout: str) -> RemoteReadout:
     """
     fields: dict[str, str] = {}
     missing_binds: list[str] = []
+    missing_workdirs: list[str] = []
     credentials: list[CredentialLine] = []
     ports: list[int] = []
     started = False
@@ -427,6 +479,8 @@ def parse_probe_output(stdout: str) -> RemoteReadout:
             continue
         if key == "bind_missing":
             missing_binds.append(value)
+        elif key == "workdir_missing":
+            missing_workdirs.append(value)
         elif key == "cred":
             parsed = _parse_cred(value)
             if parsed is not None:
@@ -444,6 +498,7 @@ def parse_probe_output(stdout: str) -> RemoteReadout:
         complete=complete,
         fields=fields,
         missing_binds=tuple(missing_binds),
+        missing_workdirs=tuple(missing_workdirs),
         credentials=tuple(credentials),
         ports_in_use=tuple(ports),
     )

--- a/src/scitex_agent_container/_lifecycle/_relocate_probe_ssh.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_probe_ssh.py
@@ -77,7 +77,22 @@ class ProbeTransportError(RuntimeError):
     Distinct from a target that answered badly. Raised only when the container
     could not get its command onto the host at all, which must leave EVERY fact
     unknown rather than any fact false.
+
+    ``status`` KEEPS THE HTTP CODE, and it is not decoration. The refusal that
+    actually happens here is a 403 from the LOCAL listen daemon — the one being
+    asked to broker the ssh — and that is a statement about this container's
+    authorization, not about the target. On 2026-08-11 nine relocation probes
+    were refused exactly that way while every target involved was healthy.
+    Flattening it into text lost the one bit that separates "I was refused
+    before I could ask" from "the target answered no".
     """
+
+    def __init__(
+        self, message: str, *, status: int | None = None, kind: str = ""
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.kind = kind
 
 
 @dataclass(frozen=True)
@@ -170,6 +185,44 @@ def _chain(spec) -> list[str]:
         return []
 
 
+def _transport_error(exc: Exception, host: str) -> ProbeTransportError:
+    """Wrap a broker failure, keeping WHO refused and saying so in words.
+
+    ``request_host_exec`` raises with ``.status`` and ``.body`` on an HTTP
+    rejection. A 403 there is the LOCAL daemon declining to broker — this
+    container's group could not be resolved, or resolves to nothing eligible —
+    and the message must not let that read as a verdict on ``host``. The
+    difference decides where the operator goes next: fix the daemon he is
+    standing next to, or fix the machine he was moving onto.
+
+    Read by duck-typing rather than by importing the client's exception class,
+    so this module keeps its "no transport knowledge" property.
+    """
+    status = getattr(exc, "status", None)
+    body = getattr(exc, "body", None)
+    kind = ""
+    reason = ""
+    if isinstance(body, dict):
+        kind = str(body.get("kind") or "")
+        reason = str(body.get("reason") or "")
+    if status == 403:
+        return ProbeTransportError(
+            "the LOCAL listen daemon refused to broker this probe (HTTP 403"
+            + (f" {kind}" if kind else "")
+            + (f": {reason}" if reason else "")
+            + f"). That is this container's authorization here, NOT a statement about "
+            f"{host} — nothing about the target was measured. Fix the broker's group "
+            "resolution (or run the probe from the bare host) and re-run",
+            status=403,
+            kind=kind or "acl_deny",
+        )
+    return ProbeTransportError(
+        f"could not run the probe on the host for {host}: {type(exc).__name__}: {exc}",
+        status=status if isinstance(status, int) else None,
+        kind=kind,
+    )
+
+
 def run_probe_script(
     host: str,
     script: str,
@@ -200,9 +253,7 @@ def run_probe_script(
     try:
         body = exec_fn(argv, timeout_s=timeout_s)
     except Exception as exc:  # stx-allow: fallback (reason: re-raised as ProbeTransportError so every fact stays UNKNOWN; nothing is swallowed and nothing degrades to False)
-        raise ProbeTransportError(
-            f"could not run the probe on the host for {host}: {type(exc).__name__}: {exc}"
-        ) from exc
+        raise _transport_error(exc, host) from exc
 
     if not isinstance(body, dict):
         raise ProbeTransportError(

--- a/src/scitex_agent_container/_lifecycle/_relocate_render.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_render.py
@@ -29,6 +29,7 @@ decides how to paint them, and tests can assert on exact lines.
 
 from __future__ import annotations
 
+from ._relocate_plan import Plan, build_plan, why_for_check
 from ._relocate_preflight import PreflightReport
 
 __all__ = [
@@ -38,6 +39,7 @@ __all__ = [
     "render_declared",
     "render_dry_run",
     "render_observed",
+    "render_plan",
     "verdict_line",
 ]
 
@@ -47,48 +49,15 @@ VERDICT_UNKNOWN = "REFUSED (undetermined)"
 
 _LABEL = {True: "PASS", False: "FAIL", None: "UNKNOWN"}
 
-#: Which FACTS feed each CHECK. ``gather_target_facts`` keys its failures by
-#: fact name, and four checks are named differently from the fact behind them
-#: (``credentials_valid`` is fed by ``credential_expires_in_s``, and so on).
-#: Without this map those four print a bare UNKNOWN while the reason for it sits
-#: unused in the errors dict — measured 2026-08-09 against a busybox NAS, where
-#: four of five unknowns lost their explanation on the way to the screen.
-_CHECK_FACTS: dict[str, tuple[str, ...]] = {
-    "target_reachable": ("reachable",),
-    "image_present": ("image_present",),
-    "binds_exist_on_target": ("missing_bind_sources",),
-    "card_store_reachable": ("card_store_reachable", "card_store_url"),
-    "credentials_valid": (
-        "credential_expires_in_s",
-        "credential_refresh_token_present",
-    ),
-    "runtime_supported": ("supported_runtimes",),
-    "spec_schema_accepted": ("rejected_spec_keys",),
-    "ports_free": ("ports_in_use",),
-    "hub_reachable_from_target": ("hub_reachable_from_target",),
-    "sac_present_on_target": ("sac_on_path", "sac_resolved_path"),
-    # Gathered locally rather than over ssh, so its failures are keyed by the
-    # check's own name; the tuple is here so the map covers every check and a
-    # reader does not have to wonder whether the omission means something.
-    "source_work_committed": ("source_repos",),
-}
-
-
 def _why(check_name: str, errors: dict[str, str]) -> str:
-    """The probe failure behind ``check_name``, by its own key or its facts'.
+    """The probe failure behind ``check_name``. See :func:`._relocate_plan.why_for_check`.
 
-    The check's own name wins, so a caller that already keyed by check name
-    keeps working; the fact names are the fallback that makes the adapter's
-    reasons reach the reader.
+    The check-to-fact map lives with the plan rather than here, because the plan
+    needs it to recognise several unknowns as ONE root cause. Two copies of that
+    map would eventually disagree, and the symptom would be a reason printed
+    inline while the same reason failed to group.
     """
-    direct = errors.get(check_name)
-    if direct:
-        return direct
-    for fact in _CHECK_FACTS.get(check_name, ()):
-        reason = errors.get(fact)
-        if reason:
-            return reason
-    return ""
+    return why_for_check(check_name, errors)
 
 
 def render_declared(declared: dict[str, object]) -> list[str]:
@@ -161,12 +130,48 @@ def verdict_line(report: PreflightReport) -> str:
     )
 
 
+def render_plan(plan: Plan) -> list[str]:
+    """The work list: root causes once, then items grouped by what to DO.
+
+    Replaces a flat "BLOCKING" dump ordered by check index. Two things changed
+    and both were asked for: several unknowns sharing one probe failure are
+    stated ONCE with the affected checks named, and the rest are bucketed by
+    action so the reader can work top-down instead of re-sorting the list in his
+    head.
+
+    Every entry carries its vantage point. "the workdir does not exist" is a
+    different sentence depending on which host was asked, and a fix without a
+    host attached is a fix somebody applies on the wrong machine.
+    """
+    if plan.empty:
+        return []
+    lines = ["BLOCKING — every problem this run found, in the order to work them:"]
+    for cause in plan.causes:
+        lines.append("")
+        lines.append(f"  ONE ROOT CAUSE — {cause.summary}")
+        lines.append(f"    blocked: {', '.join(cause.checks)}")
+        lines.append(
+            "    these are not separate problems; fix this one and re-run to learn "
+            "what the rest actually say"
+        )
+    for action, items in plan.by_action():
+        lines.append("")
+        lines.append(f"  [{action.upper()}]")
+        for item in items:
+            lines.append(f"    {item.verdict:<8} {item.check} (on {item.where})")
+            lines.append(f"      what: {item.what}")
+            lines.append(f"      fix:  {item.fix}")
+    return lines
+
+
 def render_dry_run(
     report: PreflightReport,
     *,
     declared: dict[str, object] | None = None,
     errors: dict[str, str] | None = None,
     dry_run: bool = True,
+    workdir: str = "",
+    from_host: str = "",
 ) -> list[str]:
     """The whole dry run, in the order a reader needs it.
 
@@ -197,13 +202,8 @@ def render_dry_run(
     lines += render_observed(report, errors)
     lines.append("")
     lines.append(verdict_line(report))
-    blocking = report.failed + report.unknown
-    if blocking:
+    plan = build_plan(report, errors=errors, workdir=workdir, from_host=from_host)
+    if not plan.empty:
         lines.append("")
-        lines.append("BLOCKING — fix or measure each of these, then re-run:")
-        # Names and details only. The hints are already printed inline above,
-        # and repeating nine identical "run the probe that supplies this fact"
-        # paragraphs turns the summary — the part that gets pasted into chat —
-        # into the least readable thing on screen.
-        lines += [f"  - {_LABEL[c.ok]:<8} {c.name}: {c.detail}" for c in blocking]
+        lines += render_plan(plan)
     return lines

--- a/src/scitex_agent_container/_lifecycle/_relocate_spec_reads.py
+++ b/src/scitex_agent_container/_lifecycle/_relocate_spec_reads.py
@@ -1,0 +1,147 @@
+"""Everything a preflight needs to READ out of an agent's spec, in one place.
+
+Split out of :mod:`_relocate_probe_adapter`, which had grown to hold two jobs:
+asking a host questions, and knowing where in a spec the questions live. The
+second is the one that keeps being got wrong, and it is worth reading on its own.
+
+WHY THIS IS NOT A ONE-LINE ``spec["apptainer"]["binds"]`` PER FIELD. Every reader
+below exists because the obvious lookup returned a plausible wrong answer:
+
+    binds/image   live under ``spec.apptainer``, not at the top of ``spec``. A
+                  top-level ``binds`` lookup reported "(none)" for a spec
+                  carrying nineteen of them (2026-08-08) — and "no binds" is
+                  exactly the answer that makes a bind check look satisfied when
+                  it was never asked.
+    card store    hides in TWO places: ``apptainer.env`` and the ``--env KEY=VALUE``
+                  pairs of ``apptainer.raw_args``. This repo's own spec uses the
+                  second and leaves the first empty, so a reader of ``env`` alone
+                  concludes the agent has no card store at all.
+    groups        are ``metadata.labels.groups`` / ``metadata.labels.group`` —
+                  NOT ``spec.lineage.group``, which is the Phase-3 isolation
+                  bucket and a different field wearing a similar name.
+    workdir       is the only checkout key there is. ``spec.repo`` does not exist
+                  and the validator rejects it; ``spec.workdir`` is what becomes
+                  apptainer's ``--pwd``.
+
+Every reader is DEFENSIVE and total: a missing, ``None`` or wrongly-typed key
+yields the empty answer rather than raising. A relocation must be able to report
+on a half-written spec — refusing to read because one field is malformed would
+hide the very thing the operator is trying to see.
+
+Pure dict traversal. No I/O, no yaml, no network.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "apptainer_section",
+    "bind_sources_from_spec",
+    "card_store_url_from_spec",
+    "credential_paths_from_spec",
+    "declared_groups_from_spec",
+    "group_labels_from_spec",
+    "spec_body",
+    "workdirs_from_spec",
+]
+
+
+def spec_body(spec: dict) -> dict:
+    """The ``spec:`` mapping, tolerating a spec handed in already unwrapped."""
+    inner = spec.get("spec")
+    return inner if isinstance(inner, dict) else spec
+
+
+def apptainer_section(spec: dict) -> dict:
+    app = spec_body(spec).get("apptainer")
+    return app if isinstance(app, dict) else {}
+
+
+def card_store_url_from_spec(spec: dict) -> str:
+    """The ``SCITEX_CARDS_DB`` the agent would use, wherever the spec hides it.
+
+    Two places, both real: ``apptainer.env`` and the ``--env KEY=VALUE`` pairs in
+    ``apptainer.raw_args``. Reading only the first is how the store check ends up
+    with nothing to check while looking like it passed.
+    """
+    app = apptainer_section(spec)
+    env = app.get("env")
+    if isinstance(env, dict):
+        value = env.get("SCITEX_CARDS_DB")
+        if isinstance(value, str) and value:
+            return value
+    raw = app.get("raw_args")
+    if isinstance(raw, list):
+        for item in raw:
+            if isinstance(item, str) and item.startswith("SCITEX_CARDS_DB="):
+                return item.split("=", 1)[1]
+    return ""
+
+
+def bind_sources_from_spec(spec: dict) -> tuple[str, ...]:
+    """The left half of every ``src:dst:mode`` bind."""
+    binds = apptainer_section(spec).get("binds")
+    if not isinstance(binds, list):
+        return ()
+    return tuple(
+        b.split(":", 1)[0] for b in binds if isinstance(b, str) and b.split(":", 1)[0]
+    )
+
+
+def credential_paths_from_spec(spec: dict) -> tuple[str, ...]:
+    """Candidate credential files, in the spec's own order, de-duplicated."""
+    claude = spec_body(spec).get("claude")
+    if not isinstance(claude, dict):
+        return ()
+    paths: list[str] = []
+    single = claude.get("credentials_file")
+    if isinstance(single, str) and single.strip():
+        paths.append(single.strip())
+    listed = claude.get("credentials_files")
+    if isinstance(listed, list):
+        paths += [p.strip() for p in listed if isinstance(p, str) and p.strip()]
+    return tuple(dict.fromkeys(paths))
+
+
+def workdirs_from_spec(spec: dict) -> tuple[str, ...]:
+    """The directories the agent must RUN IN — ``spec.workdir``, when it has one.
+
+    A TUPLE for a single value on purpose. There is no ``spec.repo`` today, but
+    the fact this feeds is shaped like the binds fact — empty means looked and
+    nothing missing — so a second such path later costs one list entry instead of
+    a new fact, a new probe section and a new check.
+    """
+    workdir = spec_body(spec).get("workdir")
+    if isinstance(workdir, str) and workdir.strip():
+        return (workdir.strip(),)
+    return ()
+
+
+def group_labels_from_spec(spec: dict) -> dict:
+    """``metadata.labels`` — where the ACL's group names are authored."""
+    meta = spec.get("metadata")
+    if not isinstance(meta, dict):
+        return {}
+    labels = meta.get("labels")
+    return labels if isinstance(labels, dict) else {}
+
+
+def declared_groups_from_spec(spec: dict) -> tuple[str, ...]:
+    """The group names this spec CLAIMS — singular and plural forms both.
+
+    Read here rather than through ``config._group_resolver`` deliberately. This
+    side of the comparison is what the spec says; the other side is what the
+    TARGET's own resolver makes of the same labels. Running both through the same
+    local function would make the check incapable of failing, and the case worth
+    catching is precisely when the two disagree.
+    """
+    labels = group_labels_from_spec(spec)
+    out: list[str] = []
+    single = labels.get("group")
+    if isinstance(single, str) and single.strip():
+        out.append(single.strip())
+    listed = labels.get("groups")
+    if isinstance(listed, str):
+        listed = [listed]
+    if isinstance(listed, list):
+        out += [g.strip() for g in listed if isinstance(g, str) and g.strip()]
+    return tuple(dict.fromkeys(out))

--- a/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
+++ b/src/scitex_agent_container/cli_pkg/_relocate_cmd.py
@@ -43,20 +43,18 @@ never eleven of either because one section failed.
 
 from __future__ import annotations
 
-import time
-
 import click
 
-from .._lifecycle._relocate_preflight import preflight
-from .._lifecycle._relocate_probe import gather_target_facts
-from .._lifecycle._relocate_probe_adapter import (
-    build_target_probes,
-    card_store_url_from_spec,
-)
 from .._lifecycle._relocate_render import render_dry_run
 from ._helpers import console
+from ._relocate_preflight_one import (
+    Prepared,
+    declared_from_spec,
+    prepare_one,
+    required_ports,
+)
 
-__all__ = ["declared_from_spec", "register", "relocate"]
+__all__ = ["declared_from_spec", "prepare_one", "register", "relocate"]
 
 #: Exit code when the dry run refuses (a failed or undetermined check). Distinct
 #: from click's own 2 (usage error) so a caller can tell "you asked wrongly"
@@ -165,291 +163,125 @@ def _readiness_notice() -> list[str]:
     return lines
 
 
-def _source_repo_facts(spec_body: dict, from_host: str):
-    """Scan the agent's workdir for un-saved work, or report that nobody looked.
+#: Re-exported so callers (and the tests written against them) keep one import
+#: site while the reading itself lives with the rest of the per-agent preflight.
+_required_ports = required_ports
 
-    ONLY the workdir, and only when it is a git repo. The alternative — walk and
-    guess at every repo an agent might touch — would produce a check whose PASS
-    means "the repos I happened to think of are clean", which is worse than the
-    UNKNOWN it replaces because it reads as an answer.
 
-    A workdir that is not a repo yields an OBSERVED empty scan: there is nothing
-    to strand, which is a real answer and passes. That is deliberately different
-    from passing no facts at all, which is "nobody looked" and refuses.
+def _print_one(prepared: Prepared, dry_run: bool) -> None:
+    """Print one agent's whole answer — notices, the report, or why there is none."""
+    for notice in prepared.notices:
+        console.print(f"[yellow]note:[/yellow] {notice}", soft_wrap=True)
+    if prepared.error:
+        colour = "yellow" if prepared.already_there else "red"
+        console.print(f"[{colour}]{prepared.name}:[/{colour}] {prepared.error}")
+        return
+    assert prepared.report is not None
+    for line in render_dry_run(
+        prepared.report,
+        declared=prepared.declared,
+        errors=prepared.errors,
+        dry_run=dry_run,
+        workdir=prepared.workdir,
+        from_host=prepared.from_host,
+    ):
+        console.print(line, soft_wrap=True)
+
+
+def _sweep_summary(results: list[Prepared], to_host: str) -> list[str]:
+    """One line per agent, so the SHAPE of the work is visible before any of it.
+
+    The operator's reason for wanting several agents in one command: nine are
+    queued, and learning "three need a dataset moved, four need an image, two are
+    ready" is a different conversation from discovering it one relocation at a
+    time, each costing a trip to another machine.
     """
-    from pathlib import Path
-
-    from .._lifecycle._relocate_source_scan import scan_source
-
-    workdir = str(spec_body.get("workdir") or "").strip()
-    if not workdir or not (Path(workdir) / ".git").exists():
-        return scan_source(())
-    return scan_source((workdir,))
-
-
-def _source_facts(spec: dict, spec_body: dict, agent: str, from_host: str):
-    """The repo scan PLUS which conversation would travel, both read locally.
-
-    ``session_resolvable`` is a preflight check for one reason: the phase that
-    needs the answer runs after the agent has been stopped. Ten agents on
-    ywata-note-win passed every check on 2026-08-12 and could not complete,
-    because each held more than one transcript and the transport only named a
-    session when there was exactly one. Answering it HERE is what turns that into
-    a refusal while the agent is still up.
-
-    The workdir is resolved against THIS filesystem, which is right precisely
-    because these are the SOURCE's facts and the coordinator is standing on the
-    source. When it is not, the directory is simply not there and
-    :func:`scan_session` reports NOT OBSERVED rather than inventing an empty one.
-    """
-    from pathlib import Path
-
-    from .._lifecycle._relocate_source_scan import scan_session
-    from .._lifecycle._relocate_transcript_home import transcript_home_from_spec
-    from .._lifecycle._relocate_transport_paths import derive_target_dir
-
-    facts = _source_repo_facts(spec_body, from_host)
-    home = transcript_home_from_spec(spec)
-    workdir = str(spec_body.get("workdir") or "").strip()
-    transcript_dir = ""
-    if home.path and workdir:
-        derived = derive_target_dir(
-            target_home=home.path,
-            target_resolved_workdir=str(Path(workdir).resolve()),
-        )
-        transcript_dir = derived.path or ""
-    state_dir = str(Path.home() / ".scitex" / "agent-container" / "runtime" / agent)
-    return scan_session(facts, transcript_dir=transcript_dir, state_dir=state_dir)
-
-
-def _dig(body: dict, *path: str) -> object:
-    """Follow ``path`` through nested dicts, yielding ``None`` at any break."""
-    cur: object = body
-    for key in path:
-        if not isinstance(cur, dict):
-            return None
-        cur = cur.get(key)
-    return cur
-
-
-def declared_from_spec(spec: dict) -> dict[str, object]:
-    """Pull the spec's own claims out for the DECLARED section.
-
-    ``host`` IS DELIBERATELY NOT HERE. It is an observation, not a declaration
-    (operator, 2026-08-11: 「設定ファイル、人が書くものはファイル、状態は db」), so
-    it comes from the state db and is printed under OBSERVED. Leaving it in this
-    dict would put a machine-owned fact under a heading that reads "from the
-    spec — not verified by this run", which is the same collapse that makes
-    `sac agents list` report a running agent as `defined`. The legacy field
-    still present in every spec on disk is reported by
-    :func:`.._lifecycle._relocate_host_record.legacy_spec_host_notice`, which
-    says out loud that it is ignored.
-
-    Reads defensively: a missing key yields ``None``, rendered as ``(unset)``. A
-    relocation must be able to report on a half-written spec — refusing to print
-    because a field is absent would hide the very thing the operator needs.
-
-    Binds and image live under ``spec.apptainer``, not at the top of ``spec``.
-    Reading them from the wrong level is the mistake this function exists to
-    make once, here, instead of at every call site: measured 2026-08-08, a
-    top-level ``binds`` lookup reported "(none)" for a spec carrying nineteen of
-    them — and "no binds" is exactly the answer that makes the `/mnt/c` check
-    look satisfied when it was never asked.
-    """
-    body = spec.get("spec") if isinstance(spec.get("spec"), dict) else spec
-    binds = _dig(body, "apptainer", "binds") or []
-    bind_sources = tuple(
-        b.split(":", 1)[0] if isinstance(b, str) else str(b)
-        for b in (binds if isinstance(binds, list) else [])
+    lines = ["", f"SWEEP — {len(results)} agent(s) against {to_host}", ""]
+    width = max((len(r.name) for r in results), default=0)
+    for r in results:
+        if r.already_there:
+            verdict, note = "SKIP", "already recorded there"
+        elif r.error:
+            verdict, note = "ERROR", r.error.split(".")[0]
+        elif r.report is None:
+            verdict, note = "ERROR", "no report was produced"
+        elif r.report.ok is True:
+            verdict, note = "GO", "every check passed"
+        else:
+            n_f, n_u = len(r.report.failed), len(r.report.unknown)
+            verdict = "REFUSED"
+            note = f"{n_f} failed, {n_u} undetermined"
+        lines.append(f"  {verdict:<8} {r.name:<{width}}  {note}")
+    blocked = [r for r in results if r.blocks]
+    lines.append("")
+    lines.append(
+        f"{len(results) - len(blocked)} of {len(results)} would proceed; "
+        f"{len(blocked)} are blocked. Nothing was touched."
     )
-    # Read through the SAME resolver the probe uses, so DECLARED and OBSERVED
-    # cannot disagree about which store this agent has. An ``apptainer.env``-only
-    # lookup printed "(unset)" for this repo's own spec — which carries the URL
-    # in a ``--env`` raw arg — while the probe went and successfully dialled it:
-    # two sections of one report describing the same agent differently.
-    card_store = card_store_url_from_spec(spec) or None
-    return {
-        "runtime": body.get("runtime"),
-        "image": _dig(body, "apptainer", "image"),
-        "a2a port": _dig(body, "a2a", "port"),
-        "bind sources": bind_sources,
-        "card store": card_store,
-    }
-
-
-def _residency_history(name: str):
-    """The agent's stays, read from the STATE DB — the only authority on host.
-
-    THERE IS NO RESIDENCY TABLE YET, and pretending otherwise would be the worse
-    of the two available lies. What exists is ``instances.host``, which
-    ``record_instance_start`` canonicalises and writes when a process starts —
-    an observation, and the right kind of one. So an active instance row becomes
-    a single OPEN stay and that is the whole history.
-
-    The cost is stated rather than hidden: with one row there is no audit trail,
-    so ``host_at(history, t)`` can answer "where does it live now" and cannot
-    answer "which host wrote this row in March". Closing that needs a residency
-    table; until then this returns the shortest history that is TRUE rather than
-    a longer one that is invented.
-
-    No row yields ``()`` — genuinely "the db knows nothing", which is what lets
-    a legacy spec ``host:`` seed it once.
-    """
-    from .._lifecycle._residency import Residency
-    from .._state.state_db_instances import list_active_instances
-
-    rows = [r for r in list_active_instances() if r.get("name") == name]
-    if not rows:
-        return ()
-    row = rows[0]
-    host = (row.get("host") or "").strip()
-    if not host:
-        return ()
-    return (Residency(host=host, from_ts=_epoch(row.get("started_at"))),)
-
-
-def _epoch(started_at: object) -> float:
-    """``instances.started_at`` is an ISO TEXT column; residency wants seconds.
-
-    An unparseable stamp yields ``0.0`` rather than raising. That is safe HERE
-    and only here: the stay is open, so ``current_host`` reads the host and
-    never consults the start time, and a relocation must not be blocked by a
-    malformed timestamp on a row whose host is perfectly legible. It would NOT
-    be safe for the attribution lookup, which is one more reason that needs a
-    real residency table rather than this row.
-    """
-    if not isinstance(started_at, str) or not started_at.strip():
-        return 0.0
-    from datetime import datetime
-
-    try:
-        return datetime.fromisoformat(started_at.strip()).timestamp()
-    except ValueError:  # stx-allow: fallback (reason: an open stay is read for its HOST; a malformed start time must not block a relocation whose host is legible)
-        return 0.0
-
-
-def _required_ports(declared: dict[str, object]) -> tuple[int, ...]:
-    """The ports preflight must find free — only when the spec PINS one.
-
-    ``a2a.port: auto`` is not a requirement, it is a deferral: sac picks a free
-    port at boot. Coercing it into a number here would invent a requirement the
-    spec never made, and then fail the relocation on a port clash that cannot
-    happen.
-    """
-    port = declared.get("a2a port")
-    if isinstance(port, bool):
-        return ()
-    if isinstance(port, int):
-        return (port,)
-    if isinstance(port, str) and port.isdigit():
-        return (int(port),)
-    return ()
+    return lines
 
 
 @click.command("relocate")
-@click.argument("name", required=True)
+@click.argument("names", nargs=-1, required=True)
 @click.option("--to", "to_host", required=True, help="Target host to relocate ONTO.")
 @click.option(
     "--dry-run/--no-dry-run",
     default=True,
     show_default=True,
-    help="Check the target and touch nothing. Currently the only supported mode.",
+    help="Check the target and touch nothing. Several NAMES require --dry-run.",
 )
-def relocate(name: str, to_host: str, dry_run: bool) -> None:
-    """Relocate agent NAME onto --to HOST. The AGENT moves, not the host.
+def relocate(names: tuple[str, ...], to_host: str, dry_run: bool) -> None:
+    """Relocate agent NAMES onto --to HOST. The AGENT moves, not the host.
 
     \b
-    Example:
+    Examples:
       $ sac agents relocate scitex-dev --to scitex-compute-03 --dry-run
+      $ sac agents relocate scitex-dev scitex-hpc scitex-db --to scitex-compute-04
 
     The dry run reports EVERY problem in one pass rather than stopping at the
     first, so you do not have to run it N times to find N problems. It answers
     in three values, never two: PASS, FAIL, and UNKNOWN. An UNKNOWN refuses just
     as firmly as a FAIL, but calls for a different action — go and measure it,
     rather than go and fix it.
+
+    SEVERAL NAMES preflight each in turn and print a combined summary, so the
+    whole shape of a queued batch is visible before any agent is touched. That
+    form is read-only by construction: --no-dry-run takes exactly one name,
+    because relocating several agents from one invocation would make a single
+    interruption leave several agents half-moved.
     """
-    # Resolve the spec from DISK, not from the instance registry. Measured
-    # 2026-08-08 while building this command: `Registry().get("scitex-agent-
-    # container")` returned None from inside a container — for the very agent
-    # running the query — because the registry it reads is the container's own
-    # private one. The spec files are bind-visible and the registry is not, so
-    # the DECLARED half of this report must come from the files.
-    import yaml
-
-    from ._helpers._agent_list_discover import _discover_defined_agents
-
-    spec_path = dict(_discover_defined_agents()).get(name)
-    if spec_path is None:
+    if len(names) > 1 and not dry_run:
         console.print(
-            f"[red]no spec found for agent {name!r}[/red]\n"
-            "Looked for <agents>/<name>/spec.yaml under the user (and project) scope."
+            "[red]refusing:[/red] --no-dry-run relocates ONE agent. A batch that is "
+            "interrupted halfway leaves several agents half-moved across two hosts, "
+            "and the journal that makes a relocation resumable is per-agent. Preflight "
+            "them together (the default --dry-run), then move them one at a time.",
+            soft_wrap=True,
         )
         raise SystemExit(2)
-    # The RAW yaml, not the parsed AgentConfig. DECLARED must show what the spec
-    # literally says: `AgentConfig` fills in defaults (runtime defaults to "tui",
-    # for one), and a default printed under a heading marked DECLARED would be a
-    # claim the operator never made.
-    spec = yaml.safe_load(spec_path.read_text()) or {}
 
-    declared = declared_from_spec(spec)
+    results: list[Prepared] = []
+    for index, name in enumerate(names):
+        if index:
+            console.print("")
+            console.print("─" * 72)
+            console.print("")
+        prepared = prepare_one(name, to_host)
+        results.append(prepared)
+        _print_one(prepared, dry_run)
 
-    # WHERE IT RUNS NOW comes from the STATE DB, never from the spec. The spec's
-    # `host:` is a legacy field: it is read at most ONCE, to seed a db that knows
-    # nothing, and is ignored from then on. Reading it here instead would make
-    # this command answer "where does it run" from a hand-written file that
-    # exists in one copy per machine — the confusion the 2026-08-11 ruling
-    # removed (「設定ファイル、人が書くものはファイル、状態は db」).
-    from .._lifecycle._relocate_host_record import (
-        legacy_spec_host_notice,
-        resolve_host,
-    )
+    if len(results) > 1:
+        for line in _sweep_summary(results, to_host):
+            console.print(line, soft_wrap=True)
+        raise SystemExit(EXIT_REFUSED if any(r.blocks for r in results) else 0)
 
-    body = spec.get("spec") if isinstance(spec.get("spec"), dict) else spec
-    legacy_host = body.get("host") if isinstance(body, dict) else None
-    where = resolve_host(
-        _residency_history(name),
-        legacy_spec_host=legacy_host if isinstance(legacy_host, str) else None,
-        now=time.time(),
-    )
-    notice = legacy_spec_host_notice(
-        spec_host=legacy_host if isinstance(legacy_host, str) else None,
-        db_host=where.host,
-    )
-    if notice:
-        console.print(f"[yellow]note:[/yellow] {notice}", soft_wrap=True)
-    if where.host == to_host:
-        console.print(
-            f"[yellow]{name} is already recorded on {to_host!r} — nothing to relocate.[/yellow]\n"
-            f"Source of that answer: {where.reason}"
-        )
-        raise SystemExit(EXIT_REFUSED)
-
-    # ONE batched ssh round trip answers all thirteen facts; each is parsed on
-    # its own marker line, so a section that fails costs only its own fact. See
-    # `.._lifecycle._relocate_probe_adapter` for how per-fact degradation
-    # survives the batching.
-    probes, _batch = build_target_probes(
-        to_host, spec, required_ports=_required_ports(declared)
-    )
-    gathered = gather_target_facts(probes)
-    report = preflight(
-        agent=name,
-        to_host=to_host,
-        facts=gathered.facts,
-        runtime=str(declared.get("runtime") or ""),
-        required_ports=_required_ports(declared),
-        source_facts=_source_facts(
-            spec, body if isinstance(body, dict) else {}, name, where.host or ""
-        ),
-        from_host=where.host or "",
-    )
-
-    for line in render_dry_run(
-        report, declared=declared, errors=gathered.errors, dry_run=dry_run
-    ):
-        console.print(line, soft_wrap=True)
-
-    if report.ok is not True:
+    only = results[0]
+    if only.error:
+        # A spec that cannot be found is a usage error (2); an agent already on
+        # the target is a refusal to act, not a failure to read.
+        raise SystemExit(EXIT_REFUSED if only.already_there else 2)
+    assert only.report is not None
+    if only.report.blocks:
         # The checks gate the executing path too, and that is the point rather
         # than a leftover: the dry run is what makes them load-bearing, and a
         # refusal that becomes advisory the moment there is something to execute
@@ -462,20 +294,20 @@ def relocate(name: str, to_host: str, dry_run: bool) -> None:
 
     from ._relocate_run import exit_code_for, run_relocation
 
-    if not where.host:
+    if not only.from_host:
         console.print(
             "[red]refusing to execute:[/red] the state db does not know which host "
-            f"{name} runs on, and the spec offered nothing to seed it with. A "
+            f"{only.name} runs on, and the spec offered nothing to seed it with. A "
             "relocation FROM an unknown host cannot stop the right source.",
             soft_wrap=True,
         )
         raise SystemExit(EXIT_REFUSED)
 
     outcome = run_relocation(
-        name=name,
-        spec=spec,
-        spec_path=str(spec_path),
-        from_host=where.host,
+        name=only.name,
+        spec=only.spec,
+        spec_path=only.spec_path,
+        from_host=only.from_host,
         to_host=to_host,
     )
     code = exit_code_for(outcome)

--- a/src/scitex_agent_container/cli_pkg/_relocate_preflight_one.py
+++ b/src/scitex_agent_container/cli_pkg/_relocate_preflight_one.py
@@ -1,0 +1,305 @@
+"""Preflight ONE agent: read its spec, probe its future host, decide. No printing.
+
+Split out of :mod:`_relocate_cmd` when the command learned to take several agent
+names. That is the whole reason this is a separate module and it is worth stating
+plainly: nine agents are queued for relocation, and learning the shape of the work
+one agent at a time costs a round trip to another machine per agent. A sweep needs
+the per-agent answer as a VALUE it can collect — not as something printed to a
+console halfway down a click command.
+
+So nothing here prints, and nothing here exits. A spec that cannot be found is a
+:class:`Prepared` carrying an ``error``, not a ``SystemExit``: in a sweep, one
+unreadable spec must not abort the other eight. The caller decides what an error
+means, which for a single agent is still exit 2.
+
+READ-ONLY, AND THAT IS A CONSTRAINT NOT AN ACCIDENT. Preflight touches nothing on
+either host — it reads a spec file, reads the state db, and runs one batched
+read-only probe over ssh. Nothing here may create, move, or modify anything; the
+moment it does, "just check whether this would work" stops being safe to run
+against nine live agents.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .._lifecycle._relocate_preflight import PreflightReport, preflight
+from .._lifecycle._relocate_probe import gather_target_facts
+from .._lifecycle._relocate_probe_adapter import (
+    build_target_probes,
+    card_store_url_from_spec,
+)
+from .._lifecycle._relocate_spec_reads import declared_groups_from_spec
+
+__all__ = [
+    "Prepared",
+    "declared_from_spec",
+    "prepare_one",
+    "required_ports",
+]
+
+
+@dataclass
+class Prepared:
+    """One agent's preflight, as data. ``error`` and ``report`` are exclusive."""
+
+    name: str
+    to_host: str
+    #: Non-empty when this agent could not be preflighted at all (no spec, or it
+    #: is already recorded on the target). The sweep prints it and moves on.
+    error: str = ""
+    #: True when ``error`` means "there is nothing to do", not "something broke".
+    already_there: bool = False
+    spec: dict = field(default_factory=dict)
+    spec_path: str = ""
+    declared: dict = field(default_factory=dict)
+    from_host: str = ""
+    workdir: str = ""
+    notices: tuple[str, ...] = ()
+    report: PreflightReport | None = None
+    errors: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def blocks(self) -> bool:
+        """Refused? An error or a missing report blocks as firmly as a failed check."""
+        if self.already_there:
+            return False
+        if self.error or self.report is None:
+            return True
+        return self.report.blocks
+
+
+def _dig(body: dict, *path: str) -> object:
+    """Follow ``path`` through nested dicts, yielding ``None`` at any break."""
+    cur: object = body
+    for key in path:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(key)
+    return cur
+
+
+def declared_from_spec(spec: dict) -> dict[str, object]:
+    """Pull the spec's own claims out for the DECLARED section.
+
+    ``host`` IS DELIBERATELY NOT HERE. It is an observation, not a declaration
+    (operator, 2026-08-11: 「設定ファイル、人が書くものはファイル、状態は db」), so
+    it comes from the state db and is printed under OBSERVED. Leaving it in this
+    dict would put a machine-owned fact under a heading that reads "from the spec
+    — not verified by this run", which is the same collapse that makes `sac agents
+    list` report a running agent as `defined`.
+
+    Reads defensively: a missing key yields ``None``, rendered as ``(unset)``. A
+    relocation must be able to report on a half-written spec — refusing to print
+    because a field is absent would hide the very thing the operator needs.
+
+    Binds and image live under ``spec.apptainer``, not at the top of ``spec``.
+    Measured 2026-08-08, a top-level ``binds`` lookup reported "(none)" for a spec
+    carrying nineteen of them — and "no binds" is exactly the answer that makes
+    the bind check look satisfied when it was never asked.
+    """
+    body = spec.get("spec") if isinstance(spec.get("spec"), dict) else spec
+    binds = _dig(body, "apptainer", "binds") or []
+    bind_sources = tuple(
+        b.split(":", 1)[0] if isinstance(b, str) else str(b)
+        for b in (binds if isinstance(binds, list) else [])
+    )
+    # Read through the SAME resolver the probe uses, so DECLARED and OBSERVED
+    # cannot disagree about which store this agent has.
+    return {
+        "runtime": body.get("runtime"),
+        "image": _dig(body, "apptainer", "image"),
+        "a2a port": _dig(body, "a2a", "port"),
+        "workdir": body.get("workdir"),
+        "groups": declared_groups_from_spec(spec),
+        "bind sources": bind_sources,
+        "card store": card_store_url_from_spec(spec) or None,
+    }
+
+
+def required_ports(declared: dict[str, object]) -> tuple[int, ...]:
+    """The ports preflight must find free — only when the spec PINS one.
+
+    ``a2a.port: auto`` is not a requirement, it is a deferral: sac picks a free
+    port at boot. Coercing it into a number here would invent a requirement the
+    spec never made, and then fail the relocation on a clash that cannot happen.
+    """
+    port = declared.get("a2a port")
+    if isinstance(port, bool):
+        return ()
+    if isinstance(port, int):
+        return (port,)
+    if isinstance(port, str) and port.isdigit():
+        return (int(port),)
+    return ()
+
+
+def _source_repo_facts(spec_body: dict):
+    """Scan the agent's workdir for un-saved work, or report that nobody looked.
+
+    ONLY the workdir, and only when it is a git repo. The alternative — walk and
+    guess at every repo an agent might touch — would produce a check whose PASS
+    means "the repos I happened to think of are clean", which is worse than the
+    UNKNOWN it replaces because it reads as an answer.
+
+    A workdir that is not a repo yields an OBSERVED empty scan: there is nothing
+    to strand, which is a real answer and passes. That is deliberately different
+    from passing no facts at all, which is "nobody looked" and refuses.
+    """
+    from .._lifecycle._relocate_source_scan import scan_source
+
+    workdir = str(spec_body.get("workdir") or "").strip()
+    if not workdir or not (Path(workdir) / ".git").exists():
+        return scan_source(())
+    return scan_source((workdir,))
+
+
+def source_facts(spec: dict, spec_body: dict, agent: str):
+    """The repo scan PLUS which conversation would travel, both read locally.
+
+    ``session_resolvable`` is a preflight check for one reason: the phase that
+    needs the answer runs after the agent has been stopped. Ten agents on
+    ywata-note-win passed every check on 2026-08-12 and could not complete,
+    because each held more than one transcript and the transport only named a
+    session when there was exactly one.
+
+    The workdir is resolved against THIS filesystem, which is right precisely
+    because these are the SOURCE's facts and the coordinator is standing on the
+    source. When it is not, the directory is simply not there and ``scan_session``
+    reports NOT OBSERVED rather than inventing an empty one.
+    """
+    from .._lifecycle._relocate_source_scan import scan_session
+    from .._lifecycle._relocate_transcript_home import transcript_home_from_spec
+    from .._lifecycle._relocate_transport_paths import derive_target_dir
+
+    facts = _source_repo_facts(spec_body)
+    home = transcript_home_from_spec(spec)
+    workdir = str(spec_body.get("workdir") or "").strip()
+    transcript_dir = ""
+    if home.path and workdir:
+        derived = derive_target_dir(
+            target_home=home.path,
+            target_resolved_workdir=str(Path(workdir).resolve()),
+        )
+        transcript_dir = derived.path or ""
+    state_dir = str(Path.home() / ".scitex" / "agent-container" / "runtime" / agent)
+    return scan_session(facts, transcript_dir=transcript_dir, state_dir=state_dir)
+
+
+def _residency_history(name: str):
+    """The agent's stays, read from the STATE DB — the only authority on host.
+
+    THERE IS NO RESIDENCY TABLE YET, and pretending otherwise would be the worse
+    of the two available lies. What exists is ``instances.host``, which
+    ``record_instance_start`` canonicalises and writes when a process starts — an
+    observation, and the right kind of one. So an active instance row becomes a
+    single OPEN stay and that is the whole history.
+    """
+    from .._lifecycle._residency import Residency
+    from .._state.state_db_instances import list_active_instances
+
+    rows = [r for r in list_active_instances() if r.get("name") == name]
+    if not rows:
+        return ()
+    row = rows[0]
+    host = (row.get("host") or "").strip()
+    if not host:
+        return ()
+    return (Residency(host=host, from_ts=_epoch(row.get("started_at"))),)
+
+
+def _epoch(started_at: object) -> float:
+    """``instances.started_at`` is an ISO TEXT column; residency wants seconds.
+
+    An unparseable stamp yields ``0.0`` rather than raising. Safe HERE and only
+    here: the stay is open, so ``current_host`` reads the host and never consults
+    the start time, and a relocation must not be blocked by a malformed timestamp
+    on a row whose host is perfectly legible.
+    """
+    if not isinstance(started_at, str) or not started_at.strip():
+        return 0.0
+    from datetime import datetime
+
+    try:
+        return datetime.fromisoformat(started_at.strip()).timestamp()
+    except ValueError:  # stx-allow: fallback (reason: an open stay is read for its HOST; a malformed start time must not block a relocation whose host is legible)
+        return 0.0
+
+
+def prepare_one(name: str, to_host: str) -> Prepared:
+    """Read the spec, probe ``to_host`` once, and return the whole answer.
+
+    ONE batched ssh round trip answers every target fact; each is parsed on its
+    own marker line, so a section that fails costs only its own fact.
+    """
+    import yaml
+
+    from .._lifecycle._relocate_host_record import (
+        legacy_spec_host_notice,
+        resolve_host,
+    )
+    from ._helpers._agent_list_discover import _discover_defined_agents
+
+    out = Prepared(name=name, to_host=to_host)
+    spec_path = dict(_discover_defined_agents()).get(name)
+    if spec_path is None:
+        out.error = (
+            f"no spec found for agent {name!r}. Looked for <agents>/<name>/spec.yaml "
+            "under the user (and project) scope."
+        )
+        return out
+
+    # The RAW yaml, not the parsed AgentConfig. DECLARED must show what the spec
+    # literally says: `AgentConfig` fills in defaults (runtime defaults to "tui",
+    # for one), and a default printed under a heading marked DECLARED would be a
+    # claim the operator never made.
+    spec = yaml.safe_load(spec_path.read_text()) or {}
+    body = spec.get("spec") if isinstance(spec.get("spec"), dict) else spec
+    body = body if isinstance(body, dict) else {}
+    out.spec = spec
+    out.spec_path = str(spec_path)
+    out.declared = declared_from_spec(spec)
+    out.workdir = str(body.get("workdir") or "").strip()
+
+    # WHERE IT RUNS NOW comes from the STATE DB, never from the spec. The spec's
+    # `host:` is a legacy field: read at most ONCE, to seed a db that knows
+    # nothing, and ignored from then on.
+    legacy_host = body.get("host")
+    where = resolve_host(
+        _residency_history(name),
+        legacy_spec_host=legacy_host if isinstance(legacy_host, str) else None,
+        now=time.time(),
+    )
+    out.from_host = where.host or ""
+    notice = legacy_spec_host_notice(
+        spec_host=legacy_host if isinstance(legacy_host, str) else None,
+        db_host=where.host,
+    )
+    if notice:
+        out.notices = (notice,)
+    if where.host == to_host:
+        out.already_there = True
+        out.error = (
+            f"{name} is already recorded on {to_host!r} — nothing to relocate. "
+            f"Source of that answer: {where.reason}"
+        )
+        return out
+
+    ports = required_ports(out.declared)
+    probes, _batch = build_target_probes(to_host, spec, required_ports=ports)
+    gathered = gather_target_facts(probes)
+    out.errors = gathered.errors
+    out.report = preflight(
+        agent=name,
+        to_host=to_host,
+        facts=gathered.facts,
+        runtime=str(out.declared.get("runtime") or ""),
+        required_ports=ports,
+        source_facts=source_facts(spec, body, name),
+        from_host=out.from_host,
+        workdir=out.workdir,
+        declared_groups=declared_groups_from_spec(spec),
+    )
+    return out

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_bind_kind.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_bind_kind.py
@@ -1,0 +1,290 @@
+"""Fifteen fleet specs bind paths absent on compute-04, and every one is correct.
+
+That is the fact this module was written against (measured 2026-08-11): nine
+Spartan agents binding shared cluster storage a workstation cannot provide, and
+six laptop agents binding a dataset and a checkout that exist on exactly one
+machine because that machine made them. Printed as "path not found" they are
+indistinguishable; the operator's action differs completely.
+
+The tests below are written per SHAPE rather than per path, because the shapes
+are what the classifier can actually see. The credential case gets the most
+attention: a hint that says "copy it with the agent" applied to ``~/.ssh`` is
+worse than no hint at all.
+
+Pure path shapes in, category out. No filesystem, no network, no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._lifecycle._relocate_bind_kind import (
+    ACTION_CARRY,
+    ACTION_DECIDE,
+    ACTION_PROVISION,
+    KIND_AGENT_LOCAL,
+    KIND_CREDENTIAL,
+    KIND_HOST_INFRA,
+    KIND_UNCLASSIFIED,
+    classify_bind,
+    classify_binds,
+    group_by_action,
+)
+
+WORKDIR = "/home/ywatanabe/proj/paper-scitex-clew"
+SPARTAN_WORKDIR = "/data/gpfs/projects/punim0264/ywatanabe/paper-scitex-clew"
+SRC = "ywata-note-win"
+
+
+def _kind(path: str, workdir: str = WORKDIR) -> str:
+    return classify_bind(path, workdir=workdir, from_host=SRC).kind
+
+
+# ---------------------------------------------------------------------------
+# credentials — the category that exists to prevent a HARMFUL hint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/home/ywatanabe/.ssh",
+        "/home/ywatanabe/.config/gh",
+        "/home/ywatanabe/.scitex/agent-container/accounts/x/.credentials.json",
+        "/home/ywatanabe/.pgpass",
+        "/home/ywatanabe/.gnupg",
+    ],
+)
+def test_key_material_is_recognised_as_a_credential(path: str) -> None:
+    # Arrange
+    workdir = WORKDIR
+    # Act
+    kind = _kind(path, workdir)
+    # Assert
+    assert kind == KIND_CREDENTIAL
+
+
+def test_a_credential_is_never_told_to_travel() -> None:
+    # Arrange: "move it with the agent" applied to ~/.ssh means copying key
+    # material between machines, which this fleet forbids outright.
+    result = classify_bind("/home/ywatanabe/.ssh", workdir=WORKDIR, from_host=SRC)
+    # Act
+    action = result.action
+    # Assert
+    assert action == ACTION_PROVISION
+
+
+def test_a_credential_hint_says_not_to_copy_it() -> None:
+    # Arrange
+    result = classify_bind("/home/ywatanabe/.ssh", workdir=WORKDIR, from_host=SRC)
+    # Act
+    fix = result.fix
+    # Assert
+    assert "do NOT copy it" in fix
+
+
+def test_an_account_file_under_the_agents_own_home_is_still_a_credential() -> None:
+    # Arrange: it sits under .scitex, which would otherwise read as agent data.
+    # Credentials are decided FIRST for exactly this collision.
+    path = "/home/ywatanabe/.scitex/agent-container/accounts/y/.credentials.json"
+    # Act
+    kind = _kind(path)
+    # Assert
+    assert kind == KIND_CREDENTIAL
+
+
+# ---------------------------------------------------------------------------
+# agent-local — the six laptop agents
+# ---------------------------------------------------------------------------
+
+
+def test_a_dataset_path_must_travel_with_the_agent() -> None:
+    # Arrange: the laptop shape — the dataset exists where it was made.
+    path = "/home/ywatanabe/proj/paper-scitex-clew/.scitex/dataset/bixbench/capsule-001"
+    # Act
+    action = classify_bind(path, workdir=WORKDIR, from_host=SRC).action
+    # Assert
+    assert action == ACTION_CARRY
+
+
+def test_a_path_under_the_workdir_must_travel() -> None:
+    # Arrange: results the agent produced inside its own working directory.
+    path = f"{WORKDIR}/runs/cohort_a/capsule-001"
+    # Act
+    action = classify_bind(path, workdir=WORKDIR, from_host=SRC).action
+    # Assert
+    assert action == ACTION_CARRY
+
+
+def test_a_sibling_of_the_workdir_is_agent_local_not_infrastructure() -> None:
+    # Arrange: THE Spartan shape — .../ywatanabe/scitex-clew/src sits beside
+    # .../ywatanabe/paper-scitex-clew. Under a /data root, so a naive
+    # first-component rule would call it a mount and send the operator to the
+    # storage team for a directory that is a git checkout.
+    path = "/data/gpfs/projects/punim0264/ywatanabe/scitex-clew/src/scitex_clew"
+    # Act
+    kind = _kind(path, workdir=SPARTAN_WORKDIR)
+    # Assert
+    assert kind == KIND_AGENT_LOCAL
+
+
+def test_the_agent_local_hint_mentions_cloning_when_it_might_be_a_checkout() -> None:
+    # Arrange: the classifier cannot stat the target, so it names both routes
+    # rather than asserting which one applies.
+    path = "/home/ywatanabe/proj/scitex-clew/src"
+    # Act
+    fix = classify_bind(path, workdir=WORKDIR, from_host=SRC).fix
+    # Assert
+    assert "clone it there" in fix
+
+
+def test_the_agent_local_hint_names_the_host_it_exists_on() -> None:
+    # Arrange: a fix without a vantage point is applied on the wrong machine.
+    path = f"{WORKDIR}/runs/x"
+    # Act
+    fix = classify_bind(path, workdir=WORKDIR, from_host=SRC).fix
+    # Assert
+    assert SRC in fix
+
+
+# ---------------------------------------------------------------------------
+# host-infra — the nine Spartan agents
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/data/gpfs/projects/punim0264/shared/corpus",
+        "/mnt/c",
+        "/scratch/ywatanabe/tmp",
+        "/srv/models",
+    ],
+)
+def test_a_mounted_filesystem_is_host_infrastructure(path: str) -> None:
+    # Arrange
+    workdir = WORKDIR
+    # Act
+    kind = _kind(path, workdir)
+    # Assert
+    assert kind == KIND_HOST_INFRA
+
+
+def test_host_infrastructure_is_provisioned_rather_than_carried() -> None:
+    # Arrange
+    result = classify_bind("/mnt/c", workdir=WORKDIR, from_host=SRC)
+    # Act
+    action = result.action
+    # Assert
+    assert action == ACTION_PROVISION
+
+
+def test_the_infra_hint_admits_the_filesystem_may_not_exist_there_at_all() -> None:
+    # Arrange: shared cluster storage has no counterpart on a workstation, and
+    # pretending a re-point fixes that produces a different agent, not a moved one.
+    result = classify_bind("/data/gpfs/projects/x", workdir=WORKDIR, from_host=SRC)
+    # Act
+    fix = result.fix
+    # Assert
+    assert "does not exist there at all" in fix
+
+
+# ---------------------------------------------------------------------------
+# unclassified — the honest answer, kept honest
+# ---------------------------------------------------------------------------
+
+
+def test_an_unrecognisable_path_is_not_guessed_at() -> None:
+    # Arrange: a confident wrong category sends the operator to provision a
+    # directory that should have travelled.
+    # Act
+    kind = _kind("/exports/thing", workdir=WORKDIR)
+    # Assert
+    assert kind == KIND_UNCLASSIFIED
+
+
+def test_an_unclassified_path_asks_for_a_decision_rather_than_an_action() -> None:
+    # Arrange
+    result = classify_bind("/exports/thing", workdir=WORKDIR, from_host=SRC)
+    # Act
+    action = result.action
+    # Assert
+    assert action == ACTION_DECIDE
+
+
+def test_an_unclassified_hint_states_both_possibilities() -> None:
+    # Arrange
+    result = classify_bind("/exports/thing", workdir=WORKDIR, from_host=SRC)
+    # Act
+    fix = result.fix
+    # Assert
+    assert "provision it on the target" in fix and "move it with the agent" in fix
+
+
+def test_a_missing_workdir_context_does_not_invent_a_category() -> None:
+    # Arrange: with no workdir, a home path cannot be told from infrastructure.
+    # Act
+    kind = _kind("/home/ywatanabe/proj/thing", workdir="")
+    # Assert
+    assert kind == KIND_UNCLASSIFIED
+
+
+# ---------------------------------------------------------------------------
+# the component comparison, which a startswith would get wrong
+# ---------------------------------------------------------------------------
+
+
+def test_a_prefix_sharing_sibling_is_not_treated_as_a_child() -> None:
+    # Arrange: /home/ywatanabe/proj-old starts with /home/ywatanabe/proj but is
+    # a different directory. Compared component-wise for exactly this.
+    # Act
+    result = classify_bind(
+        "/home/ywatanabe/proj-old/x", workdir="/home/ywatanabe/proj/a", from_host=SRC
+    )
+    # Assert
+    assert result.kind == KIND_UNCLASSIFIED
+
+
+def test_every_classification_carries_the_evidence_for_it() -> None:
+    # Arrange: a wrong call must be arguable rather than mysterious.
+    result = classify_bind("/mnt/c", workdir=WORKDIR, from_host=SRC)
+    # Act
+    because = result.because
+    # Assert
+    assert "/mnt" in because
+
+
+# ---------------------------------------------------------------------------
+# grouping — the order IS the value
+# ---------------------------------------------------------------------------
+
+
+def test_grouping_puts_provisioning_before_carrying() -> None:
+    # Arrange: the operator works target-first; provisioning is usually somebody
+    # standing at another machine.
+    classified = classify_binds(
+        (f"{WORKDIR}/runs/x", "/mnt/c"), workdir=WORKDIR, from_host=SRC
+    )
+    # Act
+    order = [action for action, _ in group_by_action(classified)]
+    # Assert
+    assert order == [ACTION_PROVISION, ACTION_CARRY]
+
+
+def test_grouping_omits_buckets_nothing_landed_in() -> None:
+    # Arrange
+    classified = classify_binds(("/mnt/c",), workdir=WORKDIR, from_host=SRC)
+    # Act
+    order = [action for action, _ in group_by_action(classified)]
+    # Assert
+    assert order == [ACTION_PROVISION]
+
+
+def test_grouping_keeps_every_path() -> None:
+    # Arrange: a split that drops a path is worse than no split.
+    paths = (f"{WORKDIR}/runs/x", "/mnt/c", "/home/ywatanabe/.ssh", "/exports/thing")
+    classified = classify_binds(paths, workdir=WORKDIR, from_host=SRC)
+    # Act
+    kept = {b.path for _, members in group_by_action(classified) for b in members}
+    # Assert
+    assert kept == set(paths)

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_plan.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_plan.py
@@ -1,0 +1,248 @@
+"""An unreachable host is ONE problem, not eleven, and the list must say so.
+
+Two failures of a complete-but-unreadable report are tested here, both of them
+things the operator asked for on 2026-08-11 (「なるべく多くのヒントを1回で出す」 —
+as many hints as possible in one pass):
+
+    ROOT CAUSES   every fact gathered through a failed transport carries the SAME
+                  reason string, so identical reasons ARE one cause. Printing
+                  eleven unknowns buries the one thing to fix inside its own
+                  consequences.
+    ORDER         a list ordered by check index is the code's structure leaking
+                  into the operator's afternoon. He works by action: what the
+                  target must be given, what has to travel, what is a spec edit,
+                  what is still unmeasured.
+
+A check swallowed by a root cause is never dropped and never downgraded — it is
+named under the cause, and it still blocks.
+
+Pure: a report and an errors dict in, dataclasses out. No I/O, no mocks.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._lifecycle._relocate_plan import (
+    ACTION_CARRY,
+    ACTION_MEASURE,
+    ACTION_PROVISION,
+    ACTION_SPEC,
+    build_plan,
+)
+from scitex_agent_container._lifecycle._relocate_preflight import (
+    CHECK_BINDS,
+    CHECK_IMAGE,
+    CHECK_PORTS,
+    Check,
+    PreflightReport,
+)
+
+AGENT = "scitex-hpc"
+DST = "scitex-compute-04"
+SRC = "ywata-note-win"
+WORKDIR = "/home/ywatanabe/proj/paper-scitex-clew"
+
+TRANSPORT_FAILURE = "ProbeTransportError: could not run the probe on the host"
+
+
+def _report(*checks: Check) -> PreflightReport:
+    return PreflightReport(agent=AGENT, to_host=DST, checks=checks)
+
+
+def _unknown(name: str) -> Check:
+    return Check(name=name, ok=None, detail=f"{name} was not observed", hint="measure it")
+
+
+def _fail(name: str, detail: str = "broken") -> Check:
+    return Check(name=name, ok=False, detail=detail, hint="fix it")
+
+
+# ---------------------------------------------------------------------------
+# root causes — one unreachable host is one problem
+# ---------------------------------------------------------------------------
+
+
+def test_unknowns_sharing_a_probe_failure_become_one_root_cause() -> None:
+    # Arrange: the shape of every unreachable target.
+    report = _report(_unknown(CHECK_IMAGE), _unknown(CHECK_PORTS))
+    errors = {"image_present": TRANSPORT_FAILURE, "ports_in_use": TRANSPORT_FAILURE}
+    # Act
+    plan = build_plan(report, errors=errors)
+    # Assert
+    assert len(plan.causes) == 1
+
+
+def test_a_root_cause_names_every_check_it_blocked() -> None:
+    # Arrange: swallowed is not dropped — the reader must still see what is
+    # unanswered, or a fixed transport is followed by a surprise.
+    report = _report(_unknown(CHECK_IMAGE), _unknown(CHECK_PORTS))
+    errors = {"image_present": TRANSPORT_FAILURE, "ports_in_use": TRANSPORT_FAILURE}
+    # Act
+    plan = build_plan(report, errors=errors)
+    # Assert
+    assert set(plan.causes[0].checks) == {CHECK_IMAGE, CHECK_PORTS}
+
+
+def test_a_root_caused_check_is_not_also_listed_as_its_own_problem() -> None:
+    # Arrange: presenting four consequences as four tasks is worse than
+    # presenting one cause.
+    report = _report(_unknown(CHECK_IMAGE), _unknown(CHECK_PORTS))
+    errors = {"image_present": TRANSPORT_FAILURE, "ports_in_use": TRANSPORT_FAILURE}
+    # Act
+    plan = build_plan(report, errors=errors)
+    # Assert
+    assert plan.items == ()
+
+
+def test_unknowns_with_different_reasons_are_never_merged() -> None:
+    # Arrange: two genuinely independent problems. Merging them would hide one.
+    report = _report(_unknown(CHECK_IMAGE), _unknown(CHECK_PORTS))
+    errors = {"image_present": "no image declared", "ports_in_use": "no ss on target"}
+    # Act
+    plan = build_plan(report, errors=errors)
+    # Assert
+    assert plan.causes == ()
+
+
+def test_independent_unknowns_are_listed_individually() -> None:
+    # Arrange
+    report = _report(_unknown(CHECK_IMAGE), _unknown(CHECK_PORTS))
+    errors = {"image_present": "no image declared", "ports_in_use": "no ss on target"}
+    # Act
+    plan = build_plan(report, errors=errors)
+    # Assert
+    assert len(plan.items) == 2
+
+
+def test_a_lone_unknown_is_not_promoted_into_a_root_cause() -> None:
+    # Arrange: a "cause" with one member is just the problem, said twice.
+    report = _report(_unknown(CHECK_IMAGE))
+    errors = {"image_present": TRANSPORT_FAILURE}
+    # Act
+    plan = build_plan(report, errors=errors)
+    # Assert
+    assert plan.causes == ()
+
+
+def test_an_unknown_carries_its_probe_error_into_the_item() -> None:
+    # Arrange: knowing a fact is missing without knowing why turns a five-second
+    # fix into an investigation.
+    report = _report(_unknown(CHECK_IMAGE))
+    errors = {"image_present": "SSHTimeout: after 60s"}
+    # Act
+    plan = build_plan(report, errors=errors)
+    # Assert
+    assert "SSHTimeout" in plan.items[0].what
+
+
+# ---------------------------------------------------------------------------
+# order — by what to DO, not by check index
+# ---------------------------------------------------------------------------
+
+
+def test_provisioning_comes_before_spec_edits() -> None:
+    # Arrange: deliberately supplied in the opposite order.
+    report = _report(
+        _fail("runtime_supported"),
+        _fail(CHECK_IMAGE),
+    )
+    # Act
+    plan = build_plan(report)
+    # Assert
+    assert [a for a, _ in plan.by_action()] == [ACTION_PROVISION, ACTION_SPEC]
+
+
+def test_unknowns_are_ordered_last_because_they_are_questions_not_tasks() -> None:
+    # Arrange
+    report = _report(_unknown(CHECK_PORTS), _fail(CHECK_IMAGE))
+    # Act
+    plan = build_plan(report)
+    # Assert
+    assert [a for a, _ in plan.by_action()] == [ACTION_PROVISION, ACTION_MEASURE]
+
+
+def test_source_side_work_is_ordered_as_something_that_must_travel() -> None:
+    # Arrange: uncommitted work is not a target problem; it is cargo.
+    report = _report(_fail("source_work_committed"), _fail(CHECK_IMAGE))
+    # Act
+    plan = build_plan(report, from_host=SRC)
+    # Assert
+    assert [a for a, _ in plan.by_action()] == [ACTION_PROVISION, ACTION_CARRY]
+
+
+def test_a_source_side_item_names_the_source_host_not_the_target() -> None:
+    # Arrange: a check is meaningless without its vantage point, and this one was
+    # measured on the machine being LEFT.
+    report = _report(_fail("source_work_committed"))
+    # Act
+    plan = build_plan(report, from_host=SRC)
+    # Assert
+    assert plan.items[0].where == SRC
+
+
+def test_a_target_side_item_names_the_target_host() -> None:
+    # Arrange
+    report = _report(_fail(CHECK_IMAGE))
+    # Act
+    plan = build_plan(report)
+    # Assert
+    assert plan.items[0].where == DST
+
+
+# ---------------------------------------------------------------------------
+# binds — ONE check, several actions
+# ---------------------------------------------------------------------------
+
+
+def test_a_mixed_bind_failure_produces_items_in_two_different_buckets() -> None:
+    # Arrange: the 2026-08-11 fleet shape — infrastructure and agent data absent
+    # from the same host, needing opposite fixes.
+    detail = f"bind sources absent on {DST}: /mnt/c, {WORKDIR}/runs/x"
+    report = _report(_fail(CHECK_BINDS, detail))
+    # Act
+    plan = build_plan(report, workdir=WORKDIR, from_host=SRC)
+    # Assert
+    assert [a for a, _ in plan.by_action()] == [ACTION_PROVISION, ACTION_CARRY]
+
+
+def test_each_bind_item_carries_its_own_path() -> None:
+    # Arrange
+    detail = f"bind sources absent on {DST}: /mnt/c, {WORKDIR}/runs/x"
+    report = _report(_fail(CHECK_BINDS, detail))
+    # Act
+    plan = build_plan(report, workdir=WORKDIR, from_host=SRC)
+    # Assert
+    assert {i.what.split(" ")[0] for i in plan.items} == {"/mnt/c", f"{WORKDIR}/runs/x"}
+
+
+def test_each_bind_item_carries_a_fix_naming_that_path() -> None:
+    # Arrange: the deliverable is the hint, and a hint that does not name the
+    # path it is about is a paragraph, not an instruction.
+    detail = f"bind sources absent on {DST}: /mnt/c"
+    report = _report(_fail(CHECK_BINDS, detail))
+    # Act
+    plan = build_plan(report, workdir=WORKDIR, from_host=SRC)
+    # Assert
+    assert "/mnt/c" in plan.items[0].fix
+
+
+# ---------------------------------------------------------------------------
+# the empty case
+# ---------------------------------------------------------------------------
+
+
+def test_a_clean_report_produces_no_plan_at_all() -> None:
+    # Arrange
+    report = _report(Check(name=CHECK_IMAGE, ok=True, detail="image present"))
+    # Act
+    plan = build_plan(report)
+    # Assert
+    assert plan.empty is True
+
+
+def test_every_item_carries_a_verdict_word() -> None:
+    # Arrange: FAIL and UNKNOWN call for different actions and must not blur.
+    report = _report(_fail(CHECK_IMAGE), _unknown(CHECK_PORTS))
+    # Act
+    plan = build_plan(report)
+    # Assert
+    assert {i.verdict for i in plan.items} == {"FAIL", "UNKNOWN"}

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_preflight.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_preflight.py
@@ -22,14 +22,20 @@ import pytest
 from scitex_agent_container._lifecycle._relocate_origin import RepoWork
 from scitex_agent_container._lifecycle._relocate_preflight import (
     CHECK_BINDS,
+    CHECK_CARD_STORE,
+    CHECK_CARD_STORE_DSN,
     CHECK_CREDENTIALS,
+    CHECK_GROUPS,
     CHECK_HUB_FROM_TARGET,
+    CHECK_IMAGE,
     CHECK_PORTS,
+    CHECK_REACHABLE,
     CHECK_RUNTIME,
     CHECK_SAC_PRESENT,
     CHECK_SCHEMA,
     CHECK_SESSION,
     CHECK_SOURCE_WORK,
+    CHECK_WORKDIR,
     Check,
     SourceFacts,
     TargetFacts,
@@ -49,7 +55,9 @@ def _healthy_facts(**overrides: object) -> TargetFacts:
         reachable=True,
         image_present=True,
         missing_bind_sources=(),
-        card_store_url="postgresql://scitex_cards@127.0.0.1:5442/scitex_cards",
+        missing_workdir_paths=(),
+        target_resolved_groups=("developer", "infra"),
+        card_store_url="postgresql://scitex_cards@127.0.0.1:55432/scitex_cards",
         card_store_reachable=True,
         credential_expires_in_s=3600.0,
         credential_refresh_token_present=True,
@@ -81,6 +89,10 @@ def _clean_source(**overrides: object) -> SourceFacts:
     return SourceFacts(**base)  # type: ignore[arg-type]
 
 
+WORKDIR = "/home/ywatanabe/proj/scitex-agent-container"
+GROUPS = ("developer", "infra")
+
+
 def _run(source_facts: SourceFacts | None = None, **overrides: object):
     return preflight(
         agent=AGENT,
@@ -90,6 +102,8 @@ def _run(source_facts: SourceFacts | None = None, **overrides: object):
         required_ports=PORTS,
         source_facts=source_facts if source_facts is not None else _clean_source(),
         from_host=SRC,
+        workdir=WORKDIR,
+        declared_groups=GROUPS,
     )
 
 
@@ -208,8 +222,15 @@ def test_an_agent_with_no_transcript_at_all_fails_the_session_check() -> None:
 
 
 def test_every_check_is_unknown_when_nothing_was_observed() -> None:
-    # Arrange
-    report = preflight(agent=AGENT, to_host=DST, facts=TargetFacts(), runtime=RUNTIME)
+    # Arrange: declared_groups is supplied so the groups check has something to
+    # be unknown ABOUT — a spec claiming no groups passes it by construction.
+    report = preflight(
+        agent=AGENT,
+        to_host=DST,
+        facts=TargetFacts(),
+        runtime=RUNTIME,
+        declared_groups=GROUPS,
+    )
     # Act
     unknown = report.unknown
     # Assert
@@ -636,5 +657,225 @@ def test_a_source_with_no_repos_at_all_passes_when_it_was_scanned() -> None:
     source = SourceFacts(repos=())
     # Act
     check = _named(_run(source_facts=source), CHECK_SOURCE_WORK)
+    # Assert
+    assert check.ok is True
+
+
+# ---------------------------------------------------------------------------
+# ONE CASE PER CHECK WHERE THE PROBE ITSELF FAILED
+#
+# The operator's requirement, 2026-08-11, and the bug this fleet ships most
+# often: a probe that could not answer must report UNKNOWN, must not read as a
+# pass, and must not be dressed up as a definite failure. Both mistakes have a
+# cost and they are different costs — treating unreachable-as-fine relocates into
+# a machine nobody verified; treating it as a fail sends somebody to debug a spec
+# that is perfectly correct.
+#
+# Parametrized over EVERY check so a new one cannot be added without an answer
+# here: the facts that feed it are blanked (which is exactly what
+# `_relocate_probe.probe` does when a prober raises) and the verdict is asserted.
+# ---------------------------------------------------------------------------
+
+#: check name -> the observations to blank so THAT check, and only that check,
+#: loses its evidence. Source-side checks are blanked on SourceFacts instead.
+_BLANKING: dict[str, dict[str, object]] = {
+    CHECK_REACHABLE: {"reachable": None},
+    CHECK_IMAGE: {"image_present": None},
+    CHECK_BINDS: {"missing_bind_sources": None},
+    CHECK_WORKDIR: {"missing_workdir_paths": None},
+    CHECK_CARD_STORE_DSN: {"card_store_url": None},
+    CHECK_CARD_STORE: {"card_store_reachable": None},
+    CHECK_CREDENTIALS: {
+        "credential_expires_in_s": None,
+        "credential_refresh_token_present": None,
+    },
+    CHECK_RUNTIME: {"supported_runtimes": None},
+    CHECK_SCHEMA: {"rejected_spec_keys": None},
+    CHECK_PORTS: {"ports_in_use": None},
+    CHECK_GROUPS: {"target_resolved_groups": None},
+    CHECK_HUB_FROM_TARGET: {"hub_reachable_from_target": None},
+    CHECK_SAC_PRESENT: {"sac_on_path": None, "sac_resolved_path": None},
+}
+
+_SOURCE_BLANKING: dict[str, dict[str, object]] = {
+    CHECK_SOURCE_WORK: {"repos": None},
+    CHECK_SESSION: {"transcripts": None},
+}
+
+
+def _with_failed_probe(check_name: str):
+    if check_name in _SOURCE_BLANKING:
+        return _run(source_facts=_clean_source(**_SOURCE_BLANKING[check_name]))
+    return _run(**_BLANKING[check_name])
+
+
+@pytest.mark.parametrize("check_name", sorted(_BLANKING) + sorted(_SOURCE_BLANKING))
+def test_a_probe_that_failed_makes_its_check_unknown(check_name: str) -> None:
+    # Arrange: the prober raised, so the fact is None — never False.
+    report = _with_failed_probe(check_name)
+    # Act
+    check = _named(report, check_name)
+    # Assert
+    assert check.ok is None
+
+
+@pytest.mark.parametrize("check_name", sorted(_BLANKING) + sorted(_SOURCE_BLANKING))
+def test_a_probe_that_failed_is_not_reported_as_a_failure(check_name: str) -> None:
+    # Arrange: an unknown dressed as a fail sends somebody to fix a correct spec.
+    report = _with_failed_probe(check_name)
+    # Act
+    failed = [c.name for c in report.failed]
+    # Assert
+    assert check_name not in failed
+
+
+@pytest.mark.parametrize("check_name", sorted(_BLANKING) + sorted(_SOURCE_BLANKING))
+def test_a_probe_that_failed_blocks_the_relocation(check_name: str) -> None:
+    # Arrange: unknown refuses as firmly as fail. That is RELOCATION's policy,
+    # applied at the aggregation site, not baked into each check.
+    report = _with_failed_probe(check_name)
+    # Act
+    blocks = report.blocks
+    # Assert
+    assert blocks is True
+
+
+@pytest.mark.parametrize("check_name", sorted(_BLANKING) + sorted(_SOURCE_BLANKING))
+def test_a_probe_that_failed_keeps_the_verdict_out_of_false(check_name: str) -> None:
+    # Arrange: the whole report must say "could not tell", not "no".
+    report = _with_failed_probe(check_name)
+    # Act
+    verdict = report.ok
+    # Assert
+    assert verdict is None
+
+
+@pytest.mark.parametrize("check_name", sorted(_BLANKING) + sorted(_SOURCE_BLANKING))
+def test_every_unknown_check_says_how_to_answer_it(check_name: str) -> None:
+    # Arrange: "I could not tell" is only useful with "here is how to tell".
+    report = _with_failed_probe(check_name)
+    # Act
+    check = _named(report, check_name)
+    # Assert
+    assert len(check.hint) > 20
+
+
+def test_the_blanking_table_covers_every_check_there_is() -> None:
+    # Arrange: a new check added without an unknown-case answer here is exactly
+    # the omission that lets an unmeasured question read as a pass.
+    report = _run()
+    covered = set(_BLANKING) | set(_SOURCE_BLANKING)
+    # Act
+    uncovered = {c.name for c in report.checks} - covered
+    # Assert
+    assert uncovered == set()
+
+
+# ---------------------------------------------------------------------------
+# the three checks added 2026-08-11: does the SPEC hold on the TARGET
+# ---------------------------------------------------------------------------
+
+
+def test_a_workdir_absent_on_the_target_fails() -> None:
+    # Arrange: spec.workdir becomes apptainer's --pwd. Absent, the agent fails at
+    # boot — which under relocation is after the source has been stopped.
+    report = _run(missing_workdir_paths=("/home/ywatanabe/proj/scitex-hpc",))
+    # Act
+    check = _named(report, CHECK_WORKDIR)
+    # Assert
+    assert check.ok is False
+
+
+def test_the_missing_workdir_is_named_with_its_host() -> None:
+    # Arrange: a path without a vantage point is a fix applied on the wrong machine.
+    report = _run(missing_workdir_paths=("/home/ywatanabe/proj/scitex-hpc",))
+    # Act
+    check = _named(report, CHECK_WORKDIR)
+    # Assert
+    assert "/home/ywatanabe/proj/scitex-hpc" in check.detail and DST in check.detail
+
+
+def test_a_card_store_dsn_naming_5432_fails_however_reachable_it_is() -> None:
+    # Arrange: THE point of this check. Something answers on 5432 nearly
+    # everywhere, so reachability passes while the agent writes its cards into a
+    # database nobody reads.
+    report = _run(
+        card_store_url="postgresql://scitex_cards@127.0.0.1:5432/scitex_cards",
+        card_store_reachable=True,
+    )
+    # Act
+    check = _named(report, CHECK_CARD_STORE_DSN)
+    # Assert
+    assert check.ok is False
+
+
+def test_a_port_less_dsn_fails_because_libpq_defaults_it_to_5432() -> None:
+    # Arrange: the same wrong endpoint, wearing no number at all.
+    report = _run(card_store_url="postgresql://scitex_cards@127.0.0.1/scitex_cards")
+    # Act
+    check = _named(report, CHECK_CARD_STORE_DSN)
+    # Assert
+    assert check.ok is False
+
+
+def test_the_dsn_hint_names_the_fleet_port() -> None:
+    # Arrange
+    report = _run(card_store_url="postgresql://scitex_cards@127.0.0.1:5432/scitex_cards")
+    # Act
+    check = _named(report, CHECK_CARD_STORE_DSN)
+    # Assert
+    assert "55432" in check.hint
+
+
+def test_the_fleet_dsn_passes() -> None:
+    # Arrange
+    report = _run()
+    # Act
+    check = _named(report, CHECK_CARD_STORE_DSN)
+    # Assert
+    assert check.ok is True
+
+
+def test_a_target_that_resolves_none_of_the_declared_groups_is_unknown() -> None:
+    # Arrange: THE 2026-08-11 shape — three hosts answer [] for every agent
+    # regardless of spec.yaml, and nine probes were refused 403 by it. Reporting
+    # that as a FAIL sends the operator to edit a correct spec.
+    report = _run(target_resolved_groups=())
+    # Act
+    check = _named(report, CHECK_GROUPS)
+    # Assert
+    assert check.ok is None
+
+
+def test_a_target_that_resolves_some_but_not_all_groups_fails() -> None:
+    # Arrange: the target ANSWERED, and the answer is no. That is a verdict.
+    report = _run(target_resolved_groups=("developer",))
+    # Act
+    check = _named(report, CHECK_GROUPS)
+    # Assert
+    assert check.ok is False
+
+
+def test_that_group_failure_names_the_group_the_target_does_not_know() -> None:
+    # Arrange
+    report = _run(target_resolved_groups=("developer",))
+    # Act
+    check = _named(report, CHECK_GROUPS)
+    # Assert
+    assert "infra" in check.detail
+
+
+def test_a_spec_declaring_no_groups_passes_the_group_check() -> None:
+    # Arrange: nothing claimed, nothing to hold. Observed by construction.
+    report = preflight(
+        agent=AGENT,
+        to_host=DST,
+        facts=_healthy_facts(target_resolved_groups=()),
+        runtime=RUNTIME,
+        source_facts=_clean_source(),
+        declared_groups=(),
+    )
+    # Act
+    check = _named(report, CHECK_GROUPS)
     # Assert
     assert check.ok is True

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe.py
@@ -215,6 +215,8 @@ def test_a_fully_healthy_probe_set_passes_preflight() -> None:
         reachable=lambda: True,
         image_present=lambda: True,
         missing_bind_sources=lambda: (),
+        missing_workdir_paths=lambda: (),
+        card_store_url=lambda: "postgresql://cards@127.0.0.1:55432/cards",
         card_store_reachable=lambda: True,
         credential_expires_in_s=lambda: 3600.0,
         credential_refresh_token_present=lambda: True,

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe_adapter.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe_adapter.py
@@ -44,6 +44,7 @@ HEALTHY = """SAC_RELOC begin
 SAC_RELOC epoch=1786246196
 SAC_RELOC image=present
 SAC_RELOC binds_checked=2
+SAC_RELOC workdirs_checked=1
 SAC_RELOC cardstore=yes
 SAC_RELOC cred=/creds/a.json|1786249796000|yes
 SAC_RELOC creds_checked=2
@@ -53,6 +54,7 @@ SAC_RELOC sac_path=/usr/local/bin/sac
 SAC_RELOC sac_found=/usr/local/bin/sac
 SAC_RELOC runtimes=apptainer,claude-agent-sdk,tui
 SAC_RELOC speckeys=apiVersion,kind,metadata,spec
+SAC_RELOC groups=developer
 SAC_RELOC end
 """
 
@@ -77,17 +79,21 @@ def spec():
     yield {
         "apiVersion": "scitex-agent-container/v3",
         "kind": "Agent",
-        "metadata": {},
+        "metadata": {"labels": {"groups": ["developer"]}},
         "spec": {
             "runtime": "tui",
             "host": "ywata-note-win",
+            "workdir": "/home/ywatanabe/proj/thing",
             "apptainer": {
                 "image": "/srv/sac-base.sif",
                 "binds": ["/home/ywatanabe:/home/ywatanabe:rw", "/mnt/c:/mnt/c:rw"],
                 "env": {},
+                # 55432, not postgres's 5432: the DSN check refuses the latter
+                # outright, so a fixture carrying it would make every "healthy
+                # target" test fail for a reason unrelated to what it measures.
                 "raw_args": [
                     "--env",
-                    "SCITEX_CARDS_DB=postgresql://cards@127.0.0.1:5432/cards",
+                    "SCITEX_CARDS_DB=postgresql://cards@127.0.0.1:55432/cards",
                 ],
             },
             "claude": {"credentials_files": ["/creds/a.json"]},
@@ -341,7 +347,13 @@ def test_a_truncated_batch_still_measures_most_of_the_checks(spec) -> None:
     # Act
     unobserved = set(gathered.errors)
     # Assert
-    assert unobserved == {"supported_runtimes", "rejected_spec_keys"}
+    assert unobserved == {
+        "supported_runtimes",
+        "rejected_spec_keys",
+        # asked through the target's own sac, after the two validator symbols,
+        # so a cut before them takes this with it
+        "target_resolved_groups",
+    }
 
 
 def test_an_old_sac_on_the_target_costs_only_its_own_two_facts(spec) -> None:
@@ -401,7 +413,7 @@ def test_the_card_store_url_is_found_in_a_raw_env_arg(spec) -> None:
     # Act
     url = card_store_url_from_spec(spec)
     # Assert
-    assert url == "postgresql://cards@127.0.0.1:5432/cards"
+    assert url == "postgresql://cards@127.0.0.1:55432/cards"
 
 
 def test_rejected_spec_keys_are_the_ones_the_target_does_not_know(spec) -> None:

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_probe_ssh.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_probe_ssh.py
@@ -181,6 +181,90 @@ def test_an_unreachable_listen_daemon_raises_rather_than_returning(peers) -> Non
         run()
 
 
+# ---------------------------------------------------------------------------
+# "I was refused" is not "the target said no"
+#
+# The refusal that actually happens is a 403 from the LOCAL listen daemon being
+# asked to broker the ssh — measured 2026-08-11, when nine relocation probes were
+# refused that way while every target involved was healthy. Flattening it into
+# text loses the one bit that separates the two, and sends the reader to debug
+# the wrong machine.
+# ---------------------------------------------------------------------------
+
+
+class _Refused(Exception):
+    """Shaped like ``_host_exec_client.HostExecRequestError``: status + body."""
+
+    def __init__(self) -> None:
+        super().__init__("host_exec rejected: listen returned HTTP 403")
+        self.status = 403
+        self.body = {
+            "error": "ACL deny",
+            "kind": "acl_deny",
+            "reason": "caller sac-x resolves to groups [], none of which is eligible",
+        }
+
+
+def _refused_error(peers) -> ProbeTransportError:
+    try:
+        run_probe_script("hop", SCRIPT, exec_fn=_exec_raising(_Refused()), peers=peers)
+    except ProbeTransportError as exc:
+        return exc
+    raise AssertionError("a 403 must still raise")
+
+
+def test_a_brokered_403_keeps_its_http_status(peers) -> None:
+    # Arrange: a caller that cannot read the status cannot tell the two apart.
+    error = _refused_error(peers)
+    # Act
+    status = error.status
+    # Assert
+    assert status == 403
+
+
+def test_a_brokered_403_says_the_refusal_was_local(peers) -> None:
+    # Arrange: the whole point — this is about THIS container's authorization.
+    error = _refused_error(peers)
+    # Act
+    message = str(error)
+    # Assert
+    assert "LOCAL listen daemon refused" in message
+
+
+def test_a_brokered_403_denies_being_a_statement_about_the_target(peers) -> None:
+    # Arrange: the target may be perfectly healthy; nothing about it was measured.
+    error = _refused_error(peers)
+    # Act
+    message = str(error)
+    # Assert
+    assert "NOT a statement about hop" in message
+
+
+def test_a_brokered_403_carries_the_daemons_own_reason(peers) -> None:
+    # Arrange: the daemon already distinguishes "no policy row" from "resolves to
+    # an ineligible group", and that sentence must survive to the reader.
+    error = _refused_error(peers)
+    # Act
+    message = str(error)
+    # Assert
+    assert "none of which is eligible" in message
+
+
+def test_an_ordinary_transport_failure_carries_no_status(peers) -> None:
+    # Arrange: a refusal and a dead socket are different, and only one of them
+    # is about permissions.
+    try:
+        run_probe_script(
+            "hop", SCRIPT, exec_fn=_exec_raising(OSError("refused")), peers=peers
+        )
+    except ProbeTransportError as exc:
+        error = exc
+    # Act
+    status = error.status
+    # Assert
+    assert status is None
+
+
 def test_a_timed_out_exec_raises_rather_than_returning_a_blank(peers) -> None:
     # Arrange
     body = {"exit_code": 124, "stdout": "", "stderr": "", "timed_out": True}

--- a/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
+++ b/tests/scitex_agent_container/_lifecycle/test__relocate_render.py
@@ -41,7 +41,11 @@ ALL_GOOD = TargetFacts(
     reachable=True,
     image_present=True,
     missing_bind_sources=(),
-    card_store_url="postgresql://localhost:5442/cards",
+    missing_workdir_paths=(),
+    target_resolved_groups=("developer",),
+    # 55432 — the fleet's port. 5432 is refused outright by the DSN check, so a
+    # fixture naming it would make "ALL_GOOD" mean "one guaranteed failure".
+    card_store_url="postgresql://localhost:55432/cards",
     card_store_reachable=True,
     credential_expires_in_s=3600.0,
     credential_refresh_token_present=True,

--- a/tests/scitex_agent_container/cli_pkg/test__relocate_cmd.py
+++ b/tests/scitex_agent_container/cli_pkg/test__relocate_cmd.py
@@ -43,6 +43,32 @@ FULL_SPEC = {
 }
 
 
+def test_a_batch_is_refused_when_it_would_actually_move_agents() -> None:
+    # Arrange: preflighting nine queued agents together is the point of taking
+    # several names, and it is safe because it touches nothing. EXECUTING several
+    # from one invocation is not: the journal that makes a relocation resumable
+    # is per-agent, so one interruption leaves several agents half-moved. The
+    # refusal must happen before anything is read, so this reaches no host.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        relocate, ["agent-a", "agent-b", "--to", "somewhere", "--no-dry-run"]
+    )
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_that_refusal_explains_why_a_batch_cannot_execute() -> None:
+    # Arrange: a bare "refusing" leaves the reader guessing whether it is a bug.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        relocate, ["agent-a", "agent-b", "--to", "somewhere", "--no-dry-run"]
+    )
+    # Assert
+    assert "half-moved" in result.output
+
+
 def test_declared_reads_the_runtime() -> None:
     # Arrange: runtime is the field whose mismatch stopped the 08-07 move
     # (the nas's sac 0.21.9 rejected 'tui').


### PR DESCRIPTION
## What this changes

Relocation's `preflight` phase now answers one question properly — **does this
agent's spec actually hold on the TARGET host?** — and when it does not, the
refusal says what is missing, where it was checked, and what would fix it.

Everything from `source_drain` onward has already begun taking the agent off the
source, so a spec incompatibility found at `target_standby` is an outage while the
same one found at `preflight` is a clean refusal that costs nobody anything. All
of this is therefore in `preflight`, and none of it is spread into later phases.

Twelve checks become fifteen, and the refusal becomes a work list.

### Three checks that did not exist

- **`workdir_exists_on_target`** — `spec.workdir` becomes apptainer's `--pwd`.
  There is no `spec.repo` (the validator rejects the key); the workdir *is* the
  checkout. An absent one fails at boot, which under relocation means after the
  source has been stopped. Measured on a real host during this work:
  `/home/ywatanabe/proj/scitex-os` does not exist on scitex-compute-04, and
  nothing before this change would have said so.
- **`card_store_dsn_correct`** — judges the DSN as a string, before anything
  answers it. `5432` is wrong on every host in this fleet with no exceptions, and
  a *port-less* DSN is the same bug wearing no number, because libpq defaults it
  to 5432. This has to be caught by reading rather than by dialling: something
  answers on 5432 nearly everywhere, so the existing reachability check passes
  while the agent writes its cards into a database nobody reads. Confirmed on
  scitex-compute-04: `55432` is listening, `5432` is not listening at all.
- **`groups_resolvable_on_target`** — asks the target's own sac what it makes of
  this spec's `metadata.labels.groups`. An agent that arrives holding groups the
  target cannot resolve is refused by every group-gated call it makes.

### A missing bind is not one problem

Fifteen fleet specs bind paths absent on scitex-compute-04 and every one of those
specs is *correct for the machine it currently pins*. Nine are Spartan agents
binding shared cluster storage a workstation cannot provide at all; six are laptop
agents binding a dataset and a local checkout that exist on one machine because
that machine made them. Printed as "path not found" those are indistinguishable,
and the old hint — "remove or re-point these binds" — is right for one of them.

Each missing path is now classified and the hint split by what you have to do:

- **provision on the target** — host infrastructure (`/data`, `/mnt`, `/gpfs`, …).
  If the filesystem does not exist there at all, the hint says so: this spec
  belongs on a host that has it, and re-pointing the bind produces a *different
  agent*, not a relocated one.
- **must travel with the agent** — anything under or beside the agent's own
  workdir, and any dataset directory. A relocation carries the spec and the
  transcript and nothing else.
- **provision there, never copy** — credential paths (`.ssh`, `.config/gh`,
  `accounts/*/.credentials.json`, `.pgpass`). Decided first, precisely so key
  material never attracts "move it with the agent".

Where the path's shape cannot settle it the answer is `unclassified` and the hint
states both possibilities. A confident wrong category sends somebody to provision
a directory that should have travelled.

### Refused, or unable to ask?

Nine relocation probes were refused 403 on 2026-08-11 by the *local* listen daemon
being asked to broker the ssh — not by any target. That status was being flattened
into free text, losing the one bit that separates "I was refused before I could
ask" from "the target answered no". `ProbeTransportError` now keeps it, and the
message says in words that the refusal is about this container's authorization and
that **nothing about the target was measured**. A separate upgrade of those hosts
is in flight and is not duplicated here.

### Every problem in one pass, ordered by what to do

No check is skipped because an earlier one failed; all fifteen always run. Two
things then make a complete list readable:

- **Root causes are stated once.** An unreachable target turns eleven checks
  UNKNOWN, and each carries the *same* probe-error text — so identical reasons are
  recognised as one cause and printed once, with the blocked checks named under
  it. They still block; they are simply not eleven tasks. (Verified live: eight
  unknowns collapsed to one `ONE ROOT CAUSE` line.)
- **The rest are ordered by action** — provision on the target, must travel with
  the agent, correct the spec, decide, go and measure — rather than by check
  index, which is the code's structure leaking into the operator's afternoon.

### Several agents in one read-only sweep

`sac agents relocate a b c --to host` preflights each and prints a combined
summary, so the shape of a queued batch is visible before anything is touched.
`--no-dry-run` still takes exactly one name and refuses a batch outright: the
journal that makes a relocation resumable is per-agent, so one interruption would
leave several agents half-moved.

## The three-valued rule

Unchanged in spirit and now enforced per check: `pass` / `fail` / `unknown`, where
`unknown` blocks and is never reported as either neighbour. What is new is that
**the rollup policy is named at the aggregation site** — `UNKNOWN_BLOCKS_RELOCATION`
— rather than baked into each predicate. Whether an unknown refuses is a property
of *relocation*, not of the verdict type: a dashboard may paint the same unknown
amber and be right to.

The per-check record stays `{name, ok, detail, hint}` with a three-valued `ok` and
no boolean-plus-flag anywhere, so adopting the fleet-wide status type being defined
in scitex-dev is a rename rather than a rewrite.

Tests include a case **per check** where the probe itself failed, asserting the
verdict is `unknown`, that it is not counted as a failure, and that the overall
preflight refuses — plus a guard that fails if a new check is added without one.

## Structure

Five new modules, three of them extractions forced by the 512-line limit and worth
doing on their own terms:

| module | what it owns |
|---|---|
| `_relocate_bind_kind` | classify a missing path; pure path shapes, no I/O |
| `_relocate_checks_spec` | the three new predicates |
| `_relocate_plan` | root-cause grouping and the action-ordered work list |
| `_relocate_spec_reads` | where in a spec each fact lives |
| `cli_pkg/_relocate_preflight_one` | one agent's preflight as a *value*, which is what makes a sweep possible |

Preflight remains read-only: it reads a spec file, reads the state db, and runs one
batched read-only probe. It creates, moves and modifies nothing on either host.
