### PR TITLE
fix(telegram-hook): a number needs its description wherever it appears, not only alone

### DIFF
--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/README.md
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/README.md
@@ -18,10 +18,28 @@ was the OP-PRIO-2 bug fixed the same day; do not regress it.
 | Script | Rule | Behaviour | Escape env |
 |---|---|---|---|
 | `enforce_telegram_numbering.sh` | 1. Lettered options must be numbered (`1a/1b` or `1./2.`) | BLOCK | `CC_ALLOW_LETTERED_OPTIONS=1` |
-| `enforce_telegram_no_bare_issue.sh` | 2. A message can't be just `#162` (bare issue/PR number) | BLOCK | `CC_ALLOW_BARE_ISSUE=1` |
+| `enforce_telegram_no_bare_issue.sh` | 2. Every `#NNN` **anywhere** in the message needs a parenthetical description — `#970（説明）` / `#970 (description)` | BLOCK | `CC_ALLOW_BARE_ISSUE=1` |
 | `enforce_telegram_use_lists.sh` | 3. 3+ enumerated items must be a list, not run-on prose | BLOCK | `CC_ALLOW_PROSE_ENUM=1` |
 | `enforce_telegram_no_filler.sh` | 4. No filler / hedging words (`basically`, `actually`, `一旦`, `とりあえず`, ...) | BLOCK | `CC_ALLOW_FILLER=1` |
 | `encourage_telegram_terse_style.sh` | 5. Long sentences should end in a terse closer (`します/しました/done/...`) | REMINDER (stderr nudge, rc=0) | `CC_ALLOW_NON_TERSE=1` |
+
+### Rule 2 was tightened on 2026-08-11
+
+As shipped on 2026-06-09 the hook only refused a message that reduced
+ENTIRELY to bare `#NNN` tokens, so a number inside a sentence passed
+untouched — which is the common case. The operator noticed after being
+sent a line containing `#970` with no description and asked why his rule
+was not enforced. **A guard whose trigger condition is narrower than its
+stated rule reads as enforcement while enforcing almost nothing.**
+
+The hook now refuses any `#NNN` that is not immediately followed by a
+parenthetical description, with three documented decisions: URLs are
+blanked before scanning (a `…/pull/970` path segment and a `…#123`
+fragment are not references); a repeated `#NNN` inherits the description
+given EARLIER in the same message, left to right; and a repo name is not
+a description (`scitex-dev #578` still needs one). The rationale for
+each lives in the script header. Case table + mutation check:
+`tests/integration/telegram_hooks/test_telegram_no_bare_issue_rule.py`.
 
 Each script supports `--self-test` and emits a `pass=N fail=M` summary
 plus rc=0 (all pass) / rc=1 (any fail). The companion pytest at

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_no_bare_issue.sh
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_no_bare_issue.sh
@@ -1,21 +1,68 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
-# Timestamp: "2026-06-09 (OP-PRIO-FMT rule 2)"
+# Timestamp: "2026-08-12 (OP-PRIO-FMT rule 2, tightened)"
 # File: ~/.claude/hooks/pre-tool-use/enforce_telegram_no_bare_issue.sh
 #
-# OP-PRIO-FMT rule 2 (operator 2026-06-09): a Telegram message MUST NOT
-# be a bare issue/PR number ("#162") with no surrounding context. The
-# operator's phone shows the message itself; an opaque "#162" forces
-# the operator to open GitHub to learn what is being reported. Demand
-# at least a verb + the noun the issue describes.
+# OP-PRIO-FMT rule 2 (operator 2026-06-09, TIGHTENED 2026-08-11): a
+# Telegram message MUST NOT carry an issue/PR number the operator
+# cannot read. He reads on a phone: he cannot follow a link, and the
+# number alone tells him nothing about what changed.
 #
-# Detection: the WHOLE message text (trimmed of leading/trailing
-# whitespace and outer brackets) reduces to ONLY one or more bare
-# ``#\d+`` tokens. ``#162``, ``#162 #163``, ``[#162]`` → BLOCK.
-# ``#162 figrecipe caption overlap`` → ALLOW. ``fix #162`` → ALLOW.
+#   2026-08-11 「それだと何が何だか私にとってはわからないので、必ず
+#   中身を私がわかるようにディスクリプティブな説明をつけて欲しい」
+#   ... and the format, in his words: 「ナンバーの後に ( をつけて説明
+#   する、っていうのをルールにしてください」
 #
-# Fires on: tool_name matches the matcher in settings.local.json
-# (must be the FQ mcp__claude-code-telegrammer__reply name — operator
+# WHY THIS WAS REWRITTEN. The 2026-06-09 implementation only blocked a
+# message that reduced ENTIRELY to bare ``#NNN`` tokens. A number
+# embedded in a sentence — the overwhelmingly common case — passed
+# untouched. On 2026-08-11 an agent sent a line containing ``#970`` with
+# no description, it went through, and the operator asked why the rule
+# was not enforced. That is the recurring fleet shape: A GUARD WHOSE
+# TRIGGER CONDITION IS NARROWER THAN ITS STATED RULE READS AS
+# ENFORCEMENT WHILE ENFORCING ALMOST NOTHING.
+#
+# THE RULE NOW ENFORCED. Every ``#NNN`` token anywhere in the message
+# must be immediately followed by a parenthetical description. Both the
+# ASCII ``(`` and the full-width ``（`` are accepted — the operator
+# writes Japanese and a Japanese IME produces the full-width form. A
+# single run of spaces/tabs/ideographic-space between the number and the
+# paren is allowed, and the parenthetical must hold at least one
+# non-space character (``#970 ()`` describes nothing).
+#
+#   #970（グループ判定がスペックを読む）    accept
+#   #970 (group authority reads the spec)   accept
+#   #970 の話ではなく…                      REFUSE
+#   …見つかった #578、これは…                REFUSE
+#
+# THREE DELIBERATE DECISIONS (documented so a reader can disagree with
+# the choice rather than guess whether it was one):
+#
+#   1. URLs ARE NOT REFERENCES. A link is blanked out before scanning,
+#      so ``…/pull/970`` (a path segment, no ``#`` at all) and a real
+#      ``#`` fragment such as ``…/pull/970#issuecomment-123`` or
+#      ``…/page#123`` never trip the rule. The operator cannot follow a
+#      link on his phone either, but a URL is not a token pretending to
+#      be a description — it is self-evidently a link, and rewriting it
+#      is not what he asked for. Blanking preserves offsets (NUL fill)
+#      so the refusal can still quote the right part of the message.
+#
+#   2. A REPEATED REFERENCE INHERITS THE FIRST DESCRIPTION. If ``#970
+#      (…)`` is described once, a later bare ``#970`` in the SAME
+#      message is accepted. The rule exists so the operator can read the
+#      message and know what the number means; once the description is
+#      on the page he is already reading, demanding it again would force
+#      padding like ``#970（同じPR）`` — exactly the unreadable noise the
+#      rule was written to remove. The allowance is strictly
+#      LEFT-TO-RIGHT, because he reads top to bottom: a bare ``#970``
+#      BEFORE its description is still refused.
+#
+#   3. A REPO NAME IS NOT A DESCRIPTION. ``scitex-dev #578`` is refused
+#      exactly like a naked ``#578``; ``owner/repo#578`` likewise. The
+#      repo says where to look, not what happened.
+#
+# Fires on: tool_name matches the matcher in settings.local.json (must
+# be the FQ mcp__claude-code-telegrammer__reply name — operator
 # 2026-06-09 OP-PRIO-2 matcher fix is a hard prerequisite).
 # FAIL-OPEN on any parse error or unexpected payload shape.
 # Escape: CC_ALLOW_BARE_ISSUE=1.
@@ -36,25 +83,91 @@ if [[ "${1:-}" == "--self-test" ]]; then
         else echo "  FAIL got $rc want $want: $desc"; fail=$((fail+1)); fi
     }
     T="mcp__claude-code-telegrammer__reply"
-    run "bare single   #162                    -> block" "$T" "#162" 2
-    run "bare in brackets [#162]               -> block" "$T" "[#162]" 2
-    run "two bare      #162 #163               -> block" "$T" "#162 #163" 2
-    run "trimmed       \"  #162  \"            -> block" "$T" "  #162  " 2
-    run "verb + #      fix #162                -> allow" "$T" "fix #162" 0
-    run "noun + #      #162 figrecipe caption  -> allow" "$T" "#162 figrecipe caption" 0
-    run "prose only    we are looking at issue -> allow" "$T" "we are looking at issue" 0
-    run "non-telegram  Bash tool ignored       -> allow" "Bash" "#162" 0
-    run "empty text                            -> allow" "$T" "" 0
+
+    # --- the real messages this fleet actually sent -------------------
+    run "REAL the message that prompted the rule (bare #967)      -> block" "$T" \
+        "lead a2a のグループ判定を修正して #967 を出しました" 2
+    run "REAL tonight's #970 の話ではなく                          -> block" "$T" \
+        "#970 の話ではなく、その前段のスペック読みの話です" 2
+    run "REAL compliant #970（…）                                  -> allow" "$T" \
+        "#970（グループ判定がスペックではなくDBを読む）を出しました" 0
+    run "REAL github URL in the message                           -> allow" "$T" \
+        "マージしました https://github.com/ywatanabe1989/scitex-agent-container/pull/970" 0
+    run "REAL no numbers at all                                   -> allow" "$T" \
+        "CI is green, nothing blocking" 0
+
+    # --- the required form, both parens, both spacings ----------------
+    run "full-width paren  #970（説明）                            -> allow" "$T" "#970（説明）" 0
+    run "ascii paren       #970 (description here)                -> allow" "$T" "#970 (description here)" 0
+    run "no space + ascii  #970(description)                      -> allow" "$T" "#970(description)" 0
+    run "ideographic space #970　（説明）                          -> allow" "$T" "#970　（説明）" 0
+    run "empty paren       #970 ()                                -> block" "$T" "#970 ()" 2
+    run "blank paren       #970（　）                              -> block" "$T" "#970（　）" 2
+    run "paren after prose #970 は良い (説明)                      -> block" "$T" "#970 は良い (説明)" 2
+    run "newline before (  #970\\n(説明)                           -> block" "$T" "$(printf '#970\n(説明)')" 2
+
+    # --- embedded in a sentence: the whole point of the tightening ----
+    run "mid-sentence      …見つかった #578、これは…                -> block" "$T" \
+        "調べていて見つかった #578、これはまだ直っていません" 2
+    run "trailing          fix #162                               -> block" "$T" "fix #162" 2
+    run "leading + prose   #162 figrecipe caption                 -> block" "$T" "#162 figrecipe caption" 2
+
+    # --- cross-repo: the repo name is not a description ---------------
+    run "cross-repo bare   scitex-dev #578                        -> block" "$T" "scitex-dev #578" 2
+    run "owner/repo bare   ywatanabe1989/scitex-dev#578           -> block" "$T" "ywatanabe1989/scitex-dev#578" 2
+    run "cross-repo ok     scitex-dev #578（型が合わない）          -> allow" "$T" \
+        "scitex-dev #578（型が合わない）" 0
+
+    # --- URLs are not references --------------------------------------
+    run "url path segment  …/pull/970                             -> allow" "$T" \
+        "https://github.com/o/r/pull/970" 0
+    run "url # fragment    …/pull/970#issuecomment-123            -> allow" "$T" \
+        "https://github.com/o/r/pull/970#issuecomment-123" 0
+    run "url numeric frag  https://example.com/page#123           -> allow" "$T" \
+        "見てください https://example.com/page#123" 0
+    run "markdown link     [x](https://e.com/p#123)               -> allow" "$T" \
+        "[x](https://e.com/p#123)" 0
+    run "url + bare #      url then a naked #970                  -> block" "$T" \
+        "https://github.com/o/r/pull/970 と #970 の件" 2
+    run "url + described   url then #970（説明）                    -> allow" "$T" \
+        "https://github.com/o/r/pull/970 は #970（グループ判定の修正）です" 0
+    run "url cannot supply the paren across the blank             -> block" "$T" \
+        "#970 https://e.com/x (説明)" 2
+
+    # --- repeat: first occurrence carries it, later ones inherit ------
+    run "repeat described-then-bare                               -> allow" "$T" \
+        "#970（グループ判定の修正）を出した。#970 のCIは緑" 0
+    run "repeat bare-then-described (left-to-right)               -> block" "$T" \
+        "#970 のCIは緑。#970（グループ判定の修正）" 2
+    run "two numbers, only one described                          -> block" "$T" \
+        "#970（グループ判定の修正）と #971" 2
+    run "two numbers, both described                              -> allow" "$T" \
+        "#970（グループ判定の修正）と #971（テスト追加）" 0
+    run "nested bare inside a description                         -> block" "$T" \
+        "#970（#969 の続き）" 2
+
+    # --- the 2026-06-09 block cases must ALL still block ---------------
+    run "legacy bare single   #162                                -> block" "$T" "#162" 2
+    run "legacy brackets      [#162]                              -> block" "$T" "[#162]" 2
+    run "legacy two bare      #162 #163                           -> block" "$T" "#162 #163" 2
+    run "legacy trimmed       \"  #162  \"                        -> block" "$T" "  #162  " 2
+
+    # --- not a reference at all ---------------------------------------
+    run "markdown heading  '# 970 title'                          -> allow" "$T" "# 970 title" 0
+    run "prose only        we are looking at issue                -> allow" "$T" "we are looking at issue" 0
+    run "non-telegram      Bash tool ignored                      -> allow" "Bash" "#162" 0
+    run "empty text                                               -> allow" "$T" "" 0
+
     # Escape-var contract: when ``CC_ALLOW_BARE_ISSUE=1`` is exported the
     # script must early-exit 0 even on a bare ``#NNN``. Tested by invoking
     # the script in a child shell that exports the var first.
     if CC_ALLOW_BARE_ISSUE=1 \
         printf '%s' "{\"tool_name\":\"$T\",\"tool_input\":{\"chat_id\":\"1\",\"text\":\"#162\"}}" \
         | CC_ALLOW_BARE_ISSUE=1 "$0" >/dev/null 2>&1; then
-        echo "  PASS (0) escape var honored                    -> allow"
+        echo "  PASS (0) escape var honored                              -> allow"
         pass=$((pass+1))
     else
-        echo "  FAIL escape var honored                    -> allow"
+        echo "  FAIL escape var honored                              -> allow"
         fail=$((fail+1))
     fi
     echo "pass=$pass fail=$fail"
@@ -63,7 +176,6 @@ fi
 
 exec python3 -c '
 import json
-import os
 import re
 import sys
 
@@ -77,28 +189,59 @@ if "claude-code-telegrammer__reply" not in tool:
 text = (data.get("tool_input", {}) or {}).get("text", "") or ""
 if not text:
     sys.exit(0)
-stripped = text.strip()
-# Strip outer brackets if the WHOLE message is wrapped.
-inner = stripped
-if (inner.startswith("[") and inner.endswith("]")) or (inner.startswith("(") and inner.endswith(")")):
-    inner = inner[1:-1].strip()
-# Tokenise: are ALL tokens bare #NNN?
-tokens = inner.split()
-if not tokens:
+
+# Blank every URL to NULs before scanning. NUL (not space) so a link can
+# never bridge a number to a parenthesis that follows it, and same-length
+# so offsets into the ORIGINAL text stay valid for the excerpt.
+URL = re.compile(r"(?:https?://|ftp://|www\.)\S+", re.IGNORECASE)
+scan = URL.sub(lambda m: "\x00" * len(m.group(0)), text)
+
+REFERENCE = re.compile(r"#(\d+)")
+# ...immediately followed by (optional horizontal space then) an opening
+# paren, ASCII or full-width, holding at least one non-space character.
+DESCRIBED = re.compile(r"[ \t　]*[(（][ \t　]*[^\s)）]")
+
+described = set()
+offender = None
+for match in REFERENCE.finditer(scan):
+    number = match.group(1)
+    if DESCRIBED.match(scan, match.end()):
+        described.add(number)      # this occurrence carries its description
+        continue
+    if number in described:
+        continue                   # described earlier in this same message
+    offender = match
+    break
+
+if offender is None:
     sys.exit(0)
-bare_issue = re.compile(r"^#\d+$")
-if all(bare_issue.match(tok) for tok in tokens):
-    sys.stderr.write(
-        "BLOCKED by enforce_telegram_no_bare_issue.sh: the whole message "
-        f"is a bare issue/PR number ({inner!r}). The operator reads on a "
-        "phone; an opaque #NNN forces a GitHub round-trip just to learn "
-        "what is being reported.\n\n"
-        "  - Add the verb + noun: \"figrecipe #162 caption overlap "
-        "reproduced (3 bugs)\".\n"
-        "  - Or report the STATE: \"merged #343 (lead a2a auto-grant)\".\n\n"
-        "Rare one-off override: set env CC_ALLOW_BARE_ISSUE=1.\n"
-    )
-    sys.exit(2)
-sys.exit(0)
+
+token = "#" + offender.group(1)
+start = max(0, offender.start() - 24)
+end = min(len(text), offender.end() + 24)
+excerpt = " ".join(text[start:end].split())
+if start > 0:
+    excerpt = "..." + excerpt
+if end < len(text):
+    excerpt = excerpt + "..."
+
+sys.stderr.write(
+    "BLOCKED by enforce_telegram_no_bare_issue.sh: the message contains "
+    f"{token}, which is not followed by a description.\n\n"
+    f"  found: {excerpt}\n\n"
+    "The operator reads on a phone. He cannot follow a link, and a bare "
+    "number tells him nothing about what changed. His rule, 2026-08-11: "
+    "put a parenthesis after the number and explain inside it.\n\n"
+    f"  required:  {token}(what it is)   or   {token}（中身の説明）\n"
+    f"  you wrote: {token}\n"
+    f"  fix it to: {token}（グループ判定がスペック"
+    "を読む問題を修正）\n\n"
+    "Both ( and （ are accepted. A repo name is not a description "
+    "(scitex-dev #578 still needs one). Once a number is described, "
+    "later mentions of that SAME number in this message are fine. URLs "
+    "are exempt.\n\n"
+    "Rare one-off override: set env CC_ALLOW_BARE_ISSUE=1.\n"
+)
+sys.exit(2)
 '
 exit $?

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_no_bare_issue.sh
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_no_bare_issue.sh
@@ -187,8 +187,8 @@ tool = data.get("tool_name", "")
 if "claude-code-telegrammer__reply" not in tool:
     sys.exit(0)
 text = (data.get("tool_input", {}) or {}).get("text", "") or ""
-if not text:
-    sys.exit(0)
+if not isinstance(text, str) or not text:
+    sys.exit(0)   # FAIL-OPEN: an unexpected payload shape is not a violation
 
 # Blank every URL to NULs before scanning. NUL (not space) so a link can
 # never bridge a number to a parenthesis that follows it, and same-length

--- a/tests/integration/telegram_hooks/test_telegram_no_bare_issue_rule.py
+++ b/tests/integration/telegram_hooks/test_telegram_no_bare_issue_rule.py
@@ -267,6 +267,25 @@ def test_refusal_names_the_token_the_form_and_a_corrected_example():
     assert present == (True, True, True, True, True), stderr
 
 
+def test_unexpected_payload_shape_fails_open():
+    # Arrange — the header promises FAIL-OPEN on an unexpected payload; a
+    # non-string `text` must not crash the hook into a noisy non-zero.
+    # Kept out of the case table on purpose: it is a fail-open contract,
+    # not one of the tightening's newly-refused cases.
+    payload = json.dumps({"tool_name": _REPLY_TOOL, "tool_input": {"text": ["#970"]}})
+    # Act
+    result = subprocess.run(
+        ["bash", str(_HOOK)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_env_with_python_on_path(),
+    )
+    # Assert
+    assert result.returncode == _ALLOW, result.stderr[-600:]
+
+
 def test_mutation_old_narrow_predicate_flips_exactly_the_newly_enforced_cases(
     tmp_path: Path,
 ):

--- a/tests/integration/telegram_hooks/test_telegram_no_bare_issue_rule.py
+++ b/tests/integration/telegram_hooks/test_telegram_no_bare_issue_rule.py
@@ -1,0 +1,311 @@
+"""The operator's `#NNN(description)` rule, asserted on the real messages
+this fleet actually sent — plus a MUTATION CHECK against the predicate
+that used to be shipped.
+
+Rule (operator 2026-08-11): a Telegram message must never carry an
+issue/PR number he cannot read. He is on a phone; he cannot follow a
+link and the number alone tells him nothing. His format, his words:
+「ナンバーの後に ( をつけて説明する、っていうのをルールにしてください」
+— put a parenthesis after the number and explain inside it. Both `(`
+and the full-width `（` count, because a Japanese IME produces the
+latter.
+
+WHY A MUTATION CHECK IS PART OF THIS FILE. The hook already existed on
+2026-06-09 and was already "enforcing" the rule — but its trigger only
+fired when the WHOLE message reduced to bare `#NNN` tokens, so a number
+inside a sentence sailed through. That is the recurring shape this fleet
+keeps finding: A GUARD WHOSE TRIGGER CONDITION IS NARROWER THAN ITS
+STATED RULE READS AS ENFORCEMENT WHILE ENFORCING ALMOST NOTHING. A test
+suite that passes identically against the old and the new predicate
+would have documented the same illusion, so
+``test_mutation_old_narrow_predicate_flips_exactly_the_newly_enforced_cases``
+runs the historical predicate over the same table and pins the exact
+delta: seven cases flip refuse-ward, nothing flips the other way.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOK = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "scitex_agent_container"
+    / "_baseline_assets"
+    / "telegram_hooks"
+    / "enforce_telegram_no_bare_issue.sh"
+)
+
+_REPLY_TOOL = "mcp__claude-code-telegrammer__reply"
+
+_BLOCK = 2
+_ALLOW = 0
+
+# (case_id, tool_name, message_text, expected_rc_under_the_shipped_hook)
+_CASES: list[tuple[str, str, str, int]] = [
+    # --- the real messages, named in the operator's own complaint -----
+    (
+        "real_prompted_the_rule_967",
+        _REPLY_TOOL,
+        "lead a2a のグループ判定を修正して #967 を出しました",
+        _BLOCK,
+    ),
+    (
+        "real_tonight_970_no_description",
+        _REPLY_TOOL,
+        "#970 の話ではなく、その前段のスペック読みの話です",
+        _BLOCK,
+    ),
+    (
+        "real_compliant_970_fullwidth_paren",
+        _REPLY_TOOL,
+        "#970（グループ判定がスペックではなくDBを読む）を出しました",
+        _ALLOW,
+    ),
+    (
+        "real_github_url",
+        _REPLY_TOOL,
+        "マージしました "
+        "https://github.com/ywatanabe1989/scitex-agent-container/pull/970",
+        _ALLOW,
+    ),
+    ("real_no_numbers_at_all", _REPLY_TOOL, "CI is green, nothing blocking", _ALLOW),
+    # --- the required form ---------------------------------------------
+    (
+        "ascii_paren_with_space",
+        _REPLY_TOOL,
+        "#970 (group authority reads the spec)",
+        _ALLOW,
+    ),
+    ("empty_parenthetical_describes_nothing", _REPLY_TOOL, "#970 ()", _BLOCK),
+    # --- embedded in a sentence: the whole point of the tightening ------
+    (
+        "mid_sentence_578",
+        _REPLY_TOOL,
+        "調べていて見つかった #578、これはまだ直っていません",
+        _BLOCK,
+    ),
+    # --- a repo name is not a description --------------------------------
+    ("cross_repo_bare", _REPLY_TOOL, "scitex-dev #578", _BLOCK),
+    ("cross_repo_described", _REPLY_TOOL, "scitex-dev #578（型が合わない）", _ALLOW),
+    # --- URLs are not references -----------------------------------------
+    (
+        "url_numeric_fragment",
+        _REPLY_TOOL,
+        "見てください https://example.com/page#123",
+        _ALLOW,
+    ),
+    (
+        "url_issuecomment_fragment",
+        _REPLY_TOOL,
+        "https://github.com/o/r/pull/970#issuecomment-123",
+        _ALLOW,
+    ),
+    (
+        "url_then_bare_number",
+        _REPLY_TOOL,
+        "https://github.com/o/r/pull/970 と #970 の件",
+        _BLOCK,
+    ),
+    # --- a repeat inherits the first description, left to right ----------
+    (
+        "repeat_described_then_bare",
+        _REPLY_TOOL,
+        "#970（グループ判定の修正）を出した。#970 のCIは緑",
+        _ALLOW,
+    ),
+    (
+        "repeat_bare_then_described",
+        _REPLY_TOOL,
+        "#970 のCIは緑。#970（グループ判定の修正）",
+        _BLOCK,
+    ),
+    # --- everything the 2026-06-09 hook blocked must still block ---------
+    ("legacy_bare_single", _REPLY_TOOL, "#162", _BLOCK),
+    ("legacy_bare_in_brackets", _REPLY_TOOL, "[#162]", _BLOCK),
+    ("legacy_two_bare", _REPLY_TOOL, "#162 #163", _BLOCK),
+    # --- out of scope ----------------------------------------------------
+    ("non_telegram_tool_ignored", "Bash", "#162", _ALLOW),
+    ("empty_text", _REPLY_TOOL, "", _ALLOW),
+]
+
+# The cases the 2026-06-09 predicate let through and the tightened one
+# refuses. Frozen deliberately: if this set grows or shrinks, the
+# tightening changed scope and a human should say whether that is wanted.
+_NEWLY_ENFORCED = {
+    "real_prompted_the_rule_967",
+    "real_tonight_970_no_description",
+    "empty_parenthetical_describes_nothing",
+    "mid_sentence_578",
+    "cross_repo_bare",
+    "url_then_bare_number",
+    "repeat_bare_then_described",
+}
+
+# The predicate as it was shipped from 2026-06-09 to 2026-08-11, quoted
+# verbatim from the script it lived in (only the stderr copy is dropped —
+# it never influenced the exit code). This is the MUTANT: the test runs
+# the same table through it to prove the new cases are genuinely new.
+_OLD_NARROW_PREDICATE = '''
+import json
+import re
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+tool = data.get("tool_name", "")
+if "claude-code-telegrammer__reply" not in tool:
+    sys.exit(0)
+text = (data.get("tool_input", {}) or {}).get("text", "") or ""
+if not text:
+    sys.exit(0)
+stripped = text.strip()
+# Strip outer brackets if the WHOLE message is wrapped.
+inner = stripped
+if (inner.startswith("[") and inner.endswith("]")) or (
+    inner.startswith("(") and inner.endswith(")")
+):
+    inner = inner[1:-1].strip()
+# Tokenise: are ALL tokens bare #NNN?
+tokens = inner.split()
+if not tokens:
+    sys.exit(0)
+bare_issue = re.compile(r"^#\\d+$")
+if all(bare_issue.match(tok) for tok in tokens):
+    sys.stderr.write("BLOCKED (2026-06-09 predicate)\\n")
+    sys.exit(2)
+sys.exit(0)
+'''
+
+
+def _payload(tool: str, text: str) -> str:
+    return json.dumps({"tool_name": tool, "tool_input": {"chat_id": "1", "text": text}})
+
+
+def _env_with_python_on_path() -> dict[str, str]:
+    """The hook shells ``python3``; guarantee the running interpreter's
+    bin dir is reachable so the test measures the PREDICATE and never a
+    PATH accident."""
+    import os
+
+    env = dict(os.environ)
+    env["PATH"] = f"{Path(sys.executable).parent}{os.pathsep}{env.get('PATH', '')}"
+    env.pop("CC_ALLOW_BARE_ISSUE", None)
+    return env
+
+
+def _run_shipped_hook(tool: str, text: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(_HOOK)],
+        input=_payload(tool, text),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_env_with_python_on_path(),
+    )
+
+
+def _run_old_predicate(mutant: Path, tool: str, text: str) -> int:
+    return subprocess.run(
+        [sys.executable, str(mutant)],
+        input=_payload(tool, text),
+        capture_output=True,
+        text=True,
+        check=False,
+    ).returncode
+
+
+def test_hook_script_is_present_and_executable():
+    # Arrange — the deployment invariant the SDK depends on.
+    is_file = _HOOK.is_file()
+    is_executable = bool(_HOOK.stat().st_mode & 0o111) if is_file else False
+    state = (is_file, is_executable)
+    # Act — nothing to do; the filesystem is the measurement.
+    # Assert
+    assert state == (True, True), f"{_HOOK} must exist and be executable (is_file, +x)"
+
+
+@pytest.mark.parametrize(
+    ("case_id", "tool", "text", "want_rc"),
+    _CASES,
+    ids=[case[0] for case in _CASES],
+)
+def test_shipped_hook_enforces_the_parenthetical_rule(
+    case_id: str, tool: str, text: str, want_rc: int
+):
+    # Arrange — the hook is the deployable itself, run as the SDK runs it.
+    # Act
+    result = _run_shipped_hook(tool, text)
+    # Assert
+    assert result.returncode == want_rc, (
+        f"case {case_id}: got rc={result.returncode} want rc={want_rc}\n"
+        f"stderr:\n{result.stderr[-600:]}"
+    )
+
+
+def test_refusal_names_the_token_the_form_and_a_corrected_example():
+    # Arrange — a refusal that only says "blocked" costs the sender a
+    # round trip to work out what the hook wanted.
+    text = "#970 の話ではなく、その前段のスペック読みの話です"
+    # Act
+    stderr = _run_shipped_hook(_REPLY_TOOL, text).stderr
+    # Assert
+    present = (
+        "#970" in stderr,  # the offending token
+        "（" in stderr and "(" in stderr,  # both accepted paren forms
+        "required:" in stderr,  # the required form
+        "fix it to:" in stderr,  # a corrected example
+        "CC_ALLOW_BARE_ISSUE" in stderr,  # the escape hatch
+    )
+    assert present == (True, True, True, True, True), stderr
+
+
+def test_mutation_old_narrow_predicate_flips_exactly_the_newly_enforced_cases(
+    tmp_path: Path,
+):
+    """MUTATION CHECK. Restore the 2026-06-09 predicate and prove the
+    delta is exactly ``_NEWLY_ENFORCED`` — a test that passed both before
+    and after the tightening would be worth nothing."""
+    # Arrange
+    mutant = tmp_path / "old_narrow_predicate.py"
+    mutant.write_text(_OLD_NARROW_PREDICATE, encoding="utf-8")
+    # Act
+    flipped = {
+        case_id
+        for case_id, tool, text, want_rc in _CASES
+        if _run_old_predicate(mutant, tool, text) != want_rc
+    }
+    # Assert
+    assert flipped == _NEWLY_ENFORCED, (
+        "the old predicate's disagreement with the new expectations is not "
+        f"the intended tightening.\n  only-old-differs: {flipped - _NEWLY_ENFORCED}\n"
+        f"  expected-but-agreed: {_NEWLY_ENFORCED - flipped}"
+    )
+
+
+def test_mutation_tightening_never_permits_what_the_old_predicate_refused(
+    tmp_path: Path,
+):
+    """The neighbouring guarantee: this hook was TIGHTENED, so no case may
+    move from refuse to allow. A one-way delta is what makes the change
+    safe to deploy without re-auditing every message the fleet sends."""
+    # Arrange
+    mutant = tmp_path / "old_narrow_predicate.py"
+    mutant.write_text(_OLD_NARROW_PREDICATE, encoding="utf-8")
+    # Act
+    loosened = {
+        case_id
+        for case_id, tool, text, want_rc in _CASES
+        if _run_old_predicate(mutant, tool, text) == _BLOCK and want_rc == _ALLOW
+    }
+    # Assert
+    assert loosened == set(), (
+        f"these cases were refused by the old predicate and are now allowed: {loosened}"
+    )


### PR DESCRIPTION
## The rule, and why it was not being enforced

The operator set it on 2026-08-11 after being sent a message containing a
bare `#967`: 「それだと何が何だか私にとってはわからないので、必ず中身を私が
わかるようにディスクリプティブな説明をつけて欲しい」— and then gave the format
himself: 「ナンバーの後に ( をつけて説明する、っていうのをルールにしてくださ
い」. He reads on a phone. He cannot follow a link, and the number alone
tells him nothing about what changed.

A hook has existed since 2026-06-09 to enforce it. It only refused a
message that reduced **entirely** to bare `#NNN` tokens. A number inside a
sentence — the overwhelmingly common case — passed untouched. Last night
an agent sent him a line containing `#970` with no description, it went
through, and he asked why his rule was not enforced: 「なんでこれはPRの番号
が強制されてないんでしょうか すなわち括弧書きでディスクリプションがないといけ
ないと思うんですけど」.

**This is the general shape, and it is the point of the PR: a guard whose
trigger condition is narrower than its stated rule reads as enforcement
while enforcing almost nothing.** It is the same family as a gate
configured so it cannot fail, and a check whose negative answer is
indistinguishable from a broken check. All three were found in this fleet
on the same night. The defect is never in the rule; it is in the distance
between the rule as written down and the predicate that actually runs.

## What now happens

Every `#NNN` anywhere in an outbound Telegram message must be immediately
followed by a parenthetical description. Both `(` and the full-width `（`
are accepted — he writes Japanese and a Japanese IME produces the
full-width form. One run of spaces/tabs/ideographic-space between the
number and the paren is allowed, and the parenthetical must hold at least
one non-space character (`#970 ()` describes nothing).

```
#970（グループ判定がスペックを読む）    accept
#970 (group authority reads the spec)   accept
#970 の話ではなく…                      REFUSE
…見つかった #578、これは…                REFUSE
```

## Three decisions, made deliberately

**URLs are not references.** A link is blanked out before scanning, so a
`…/pull/970` path segment and a real `#` fragment (`…/pull/970#issuecomment-123`,
`…/page#123`) never trip the rule. He cannot follow a link on his phone
either, but a URL is not a token pretending to be a description — it is
self-evidently a link, and rewriting URLs is not what he asked for. The
blanking uses NUL fill rather than spaces so a link can never bridge a
number to a parenthesis that follows it (`#970 https://e.com/x (説明)` is
still refused), and it is length-preserving so the refusal can still quote
the right part of the message.

**A repeated reference inherits the first description.** If `#970 (…)` is
described once, a later bare `#970` in the same message is accepted. The
stricter rule is simpler, and simpler is usually right for a guard — but
here it works against the rule's own purpose: demanding the description
again forces padding like `#970（同じPR）`, which is exactly the unreadable
noise the rule exists to remove. The allowance is strictly left-to-right,
because he reads top to bottom: a bare `#970` **before** its description
is still refused.

**A repo name is not a description.** `scitex-dev #578` is refused exactly
like a naked `#578`, and so is `owner/repo#578`. The repo says where to
look, not what happened.

## The refusal tells the sender how to fix it

A hook that only says "blocked" costs the sender a round trip to work out
what it wanted. This one names the offending token, quotes the excerpt it
found it in, states the required form in both paren styles, and shows a
corrected example:

```
BLOCKED by enforce_telegram_no_bare_issue.sh: the message contains #970,
which is not followed by a description.

  found: #970 の話ではなく、その前段のスペック読みの話です

  required:  #970(what it is)   or   #970（中身の説明）
  you wrote: #970
  fix it to: #970（グループ判定がスペックを読む問題を修正）
```

## This guard fails OPEN, deliberately — do not "fix" that

The second commit makes the header's long-standing FAIL-OPEN promise
actually true: a `text` that is not a string used to reach the regex and
crash the hook into a noisy non-zero instead of quietly allowing.

The direction is the opposite of the usual default and it needs its reason
on the record, or someone will read it as a bug and close it. **This hook
sits on the send path of the operator's only channel to this fleet.** A
guard that errors while deciding does not merely fail to enforce a
formatting rule — it severs the channel, and an agent that cannot reach
him cannot even tell him why. A malformed payload is not a violation. So:
if the predicate can decide, it enforces strictly; if it cannot decide, the
message goes through. Enforcement is worth a lot here, and it is still
worth less than the channel staying up.

The test for it is kept OUT of the case table on purpose — it is a
fail-open contract, not one of the tightening's newly-refused cases, and
folding it in would blur what the frozen mutation delta means.

## Verification, on the real messages

`bash enforce_telegram_no_bare_issue.sh --self-test` → **pass=40 fail=0**,
covering the message that prompted the rule, last night's `#970 の話ではな
く`, both paren forms and all three spacings, the empty parenthetical, the
URL cases, the repeat cases in both orders, cross-repo references, and
every case the 2026-06-09 hook blocked (all still blocked).

`tests/integration/telegram_hooks/test_telegram_no_bare_issue_rule.py`
runs a 20-case table through the deployable itself, asserts the refusal
text carries token + form + example, and carries the **mutation check**:
the 2026-06-09 predicate is quoted verbatim, run over the same table, and
the delta is pinned to exactly seven cases. A test that passed both before
and after the tightening would be worth nothing, so the delta is an
equality assertion, not a superset one — if the tightening ever changes
scope, that set has to change with a human saying so. A second mutation
test pins the one-way direction: no case may move from refuse to allow.

Newly refused (old `rc 0` → new `rc 2`): the `#967` message, the `#970 の
話ではなく` message, a mid-sentence `#578`, `scitex-dev #578`, a URL
followed by a naked `#970`, a bare-then-described repeat, and `#970 ()`.
Nothing was loosened.

Full directory: **51 passed** — the 25 new tests plus the 26 pre-existing
ones, untouched.

## Not touched

No other Telegram hook changed. The matcher, the escape var
(`CC_ALLOW_BARE_ISSUE=1`) and the fail-open-on-bad-payload behaviour are
all as they were.

One finding to report rather than fix, per the brief: under this
container's `/opt/venv-sac` interpreter, `encourage_telegram_terse_style.sh`'s
self-test reports `pass=1 fail=5`. It decides "did the hook nudge?" by
testing whether stderr is non-empty, and that venv has a broken
`_scitex_dev_subprocess_coverage.pth` that writes a `ModuleNotFoundError`
traceback to stderr on every `python3` start — so every case looks like a
nudge. With `/usr/bin/python3` the same self-test is `pass=6 fail=0`. The
script is fine and the environment is the fault, but the detection is
measuring the wrong thing and will misreport under any stderr noise. Left
alone deliberately; worth its own card.
