### PR TITLE
feat(stop-hook): a queue excluded from the alarm is a queue nobody is waiting on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,67 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **The Stop hook now REPORTS the queue that was waiting on a human, because
+  that queue had stopped existing** (`_never_stop_when_task_remains/
+  _awaiting_operator.py`). A card with `status=blocked` sends no nudge —
+  deliberately, so blocked work stops nagging — and is also excluded from the
+  runnable-items count this hook prints. Those two facts together mean nothing
+  surfaces it and nothing counts it, so an agent reporting "board clear" is
+  telling the truth about the only number it can see.
+
+  Measured 2026-08-11 on two boards, discovered independently by two agents
+  within minutes: `scitex-agent-container` 38 blocked / 21 `operator-decision`;
+  `scitex-dev` 69 blocked / 24 `operator-decision`, oldest 2026-07-19. Three
+  weeks of questions naming the operator as the gate, unasked — and the
+  operator had asked one of those agents that same night whether it had
+  anything for him and got one item back.
+
+  The general shape, which outlives this fix: **a queue excluded from the
+  alarm is a queue nobody is waiting on.**
+
+  It REPORTS, it does not gate. A card blocked on the operator is correctly
+  waiting and must not stop an agent from stopping; a gate would make this
+  hook unstoppable, and the first thing anyone does with an unstoppable hook
+  is bypass it. The line therefore rides on `systemMessage`, the one field a
+  Stop hook can emit while still ALLOWING the stop — which is also the only
+  channel that reaches the "board clear" agent, since there is no block
+  `reason` on that path. The block `reason` is left byte-identical: it is
+  scitex-cards' text, and it feeds the loop-guard signature, where an age in
+  days would be exactly the every-turn-moving value that stops the guard ever
+  tripping.
+
+  The AGE is the part that does the work: `⏸ 21 card(s) awaiting the operator
+  (oldest 47 days) — surface or reclassify`. A count alone reads as steady
+  state.
+
+  `blocker=agent-wait` is deliberately excluded — an agent waiting on another
+  agent is a different failure with a different owner, and counting it here
+  would misattribute the gate and dilute the number.
+
+  **The query states its scope instead of inheriting it**, because building
+  this turned up the same defect inside the fix. `list-tasks` silently ANDs
+  `$SCITEX_TODO_SCOPE` into its filter, and measured on the live board:
+  baseline 21 rows, with `SCITEX_TODO_SCOPE` set 0 rows, with an explicit
+  `--scope ''` 21 rows again. An alarm that an ambient environment variable can
+  quietly turn to zero is WORSE than no alarm — it converts "nobody looked"
+  into "we checked and it was clear". The tests therefore run the ambient-scope
+  case explicitly, against a reader that reproduces the measured behaviour,
+  with a control proving that reader really is silenced without the fix; a
+  suite that only ever ran with the variable unset would have gone green and
+  shipped it.
+
+  Cheap and silent by construction, because this runs on every stop attempt: a
+  hard subprocess timeout, a 15-minute TTL cache under the runtime tree, and a
+  NEGATIVE cache so a database that is down is paid once per TTL rather than
+  once per stop. Every failure — missing reader, refused read, timeout,
+  unwritable cache — returns the empty string and prints nothing, so the hook
+  degrades to exactly its previous behaviour. (The live board really was
+  refusing reads intermittently while this was written: `ExportRefused:
+  notifications row ... has no record_json payload`, minutes before the same
+  query answered with 21 rows.)
+
 ### Changed
 
 - **Every job sac owns is renamed to the ecosystem canonical form

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,28 @@ versioning follows [SemVer](https://semver.org/).
   agent is a different failure with a different owner, and counting it here
   would misattribute the gate and dilute the number.
 
+  **The report NAMES THE STORE IT READ**, redacted, with the store UUID:
+
+      ⏸ 21 card(s) awaiting the operator (oldest 47 days) — surface or reclassify
+         read from postgresql://scitex_cards@127.0.0.1:55432/scitex_cards (uuid 1d55dd6e)
+
+  This fleet currently has four stores — two Postgres clones, an abandoned
+  SQLite inbox sidecar (365 rows, 149 unseen, zero-byte WAL, no write since the
+  previous morning while readers kept attaching), and a YAML file that
+  `scitex-cards done` resolved to while `$SCITEX_CARDS_DB` named Postgres. A
+  count with no named source is unfalsifiable: it looks identical whether it
+  came from the live board or from a corpse. The identity comes from
+  `scitex-cards resolve-store` — the target the package actually opened — not
+  from `$SCITEX_CARDS_DB`, which is only a claim, and the gap between those two
+  is exactly how a reader ends up quoting an abandoned store. The UUID is
+  carried because a URL alone cannot separate two clones of the same database.
+  Any password in the target is redacted before it is printed or cached.
+
+  The store probe runs only when there IS something to report, so a clean board
+  still costs one subprocess; both are inside the same TTL cache. A zero is the
+  one answer that prints nothing, so the cache file records `count` and `store`
+  even then — the audit trail the line cannot carry.
+
   **The query states its scope instead of inheriting it**, because building
   this turned up the same defect inside the fix. `list-tasks` silently ANDs
   `$SCITEX_TODO_SCOPE` into its filter, and measured on the live board:

--- a/src/scitex_agent_container/_never_stop_when_task_remains/__init__.py
+++ b/src/scitex_agent_container/_never_stop_when_task_remains/__init__.py
@@ -38,6 +38,10 @@ in this package:
   SESSION state (how many times this session was blocked), which the
   executable has no view of, which is why it is ours.
 * :mod:`._decide` — fail-open and loop-guard rules over their verdict.
+* :mod:`._awaiting_operator` — REPORT the cards blocked on a human. Read
+  path only; it never gates and never mutates. See its docstring for why a
+  blocked card had stopped existing, and why the line rides on
+  ``systemMessage`` rather than on the block ``reason``.
 
 An earlier draft of this package parsed scitex-cards' stdout JSON fields and
 its numbered stderr hint lines. That made their output an API they could not
@@ -61,6 +65,7 @@ fired) — never the mechanism. Do not "improve" this package into a poller.
 
 from __future__ import annotations
 
+from ._awaiting_operator import OPERATOR_BLOCKER, notice
 from ._decide import HookDecision, decide
 from ._detector import ALLOW, BLOCK, UNKNOWN, Verdict, detector_argv, probe
 from ._identity import IDENTITY_ENV_VARS, resolve_agent
@@ -71,12 +76,14 @@ __all__ = [
     "BLOCK",
     "IDENTITY_ENV_VARS",
     "MAX_CONSECUTIVE_BLOCKS",
+    "OPERATOR_BLOCKER",
     "UNKNOWN",
     "HookDecision",
     "Verdict",
     "clear_blocks",
     "decide",
     "detector_argv",
+    "notice",
     "probe",
     "record_block",
     "resolve_agent",

--- a/src/scitex_agent_container/_never_stop_when_task_remains/_awaiting_operator.py
+++ b/src/scitex_agent_container/_never_stop_when_task_remains/_awaiting_operator.py
@@ -98,6 +98,19 @@ BLOCKED_STATUS = "blocked"
 CMD_ENV = "SAC_AWAITING_CARDS_CMD"
 _DEFAULT_CMD = "scitex-cards list-tasks"
 
+#: The store-identity command. A READER THAT DOES NOT NAME ITS SOURCE WILL BE
+#: WRONG AGAIN the next time a store moves, and this fleet currently has four:
+#: two Postgres clones, an abandoned SQLite inbox sidecar still being opened
+#: constantly and written never, and a YAML file that `scitex-cards done`
+#: resolved to while ``$SCITEX_CARDS_DB`` named Postgres.
+#:
+#: We ask the PACKAGE what it resolved to rather than reading
+#: ``$SCITEX_CARDS_DB`` ourselves. The env var is a CLAIM; the resolver
+#: reports the target actually opened, and the gap between those two is
+#: exactly how a reader ends up confidently quoting a corpse.
+STORE_CMD_ENV = "SAC_AWAITING_STORE_CMD"
+_DEFAULT_STORE_CMD = "scitex-cards resolve-store"
+
 #: How long a reading stays good, in seconds. ``0`` disables the cache.
 TTL_ENV = "SAC_AWAITING_CARDS_TTL_S"
 _DEFAULT_TTL_S = 900.0
@@ -142,6 +155,72 @@ def query_argv(agent: str) -> list[str]:
         OPERATOR_BLOCKER,
         "--json",
     ]
+
+
+def store_argv() -> list[str]:
+    """Build the store-identity command."""
+    base = (os.environ.get(STORE_CMD_ENV) or "").strip() or _DEFAULT_STORE_CMD
+    return [*shlex.split(base), "--json"]
+
+
+def redact(target: str) -> str:
+    """Strip any password from a store URL. NEVER print a credential.
+
+    A store target may carry userinfo (``postgresql://user:secret@host/db``).
+    The identity we want is scheme, user, host, port and database — never the
+    secret. Non-URL targets (a file path) are identities in themselves and
+    pass through unchanged.
+    """
+    if "://" not in target:
+        return target
+    scheme, _, rest = target.partition("://")
+    netloc, slash, path = rest.partition("/")
+    if "@" in netloc:
+        userinfo, _, hostport = netloc.rpartition("@")
+        user, colon, _secret = userinfo.partition(":")
+        netloc = f"{user}:***@{hostport}" if colon else f"{user}@{hostport}"
+    return f"{scheme}://{netloc}{slash}{path}"
+
+
+def _store_identity() -> str:
+    """What the package says it resolved to, redacted. ``""`` if it will not say.
+
+    The ``store_uuid`` is carried because it is THE thing that separates two
+    clones of the same database: a URL alone cannot tell
+    ``127.0.0.1:55432/scitex_cards`` on this host from the identical string on
+    another, and "two Postgres clones" is the fleet's current state.
+    """
+    try:
+        proc = subprocess.run(
+            store_argv(),
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_S,
+            check=False,
+            stdin=subprocess.DEVNULL,
+        )
+    except (
+        OSError,
+        subprocess.SubprocessError,
+    ):  # stx-allow: fallback (reason: an unnameable store degrades to an unnamed report, never to a broken stop)
+        return ""
+    if proc.returncode != 0:
+        return ""
+    start = (proc.stdout or "").find("{")
+    if start < 0:
+        return ""
+    try:
+        data, _ = json.JSONDecoder().raw_decode(proc.stdout[start:])
+    except json.JSONDecodeError:  # stx-allow: fallback (reason: unparseable identity is no identity; say nothing rather than guess)
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    resolved = str(data.get("resolved") or "").strip()
+    if not resolved:
+        return ""
+    uuid = str(data.get("store_uuid") or "").strip()
+    identity = redact(resolved)
+    return f"{identity} (uuid {uuid[:8]})" if uuid else identity
 
 
 def cache_path(agent: str) -> Path:
@@ -227,11 +306,15 @@ def summarize(rows: list, now: "datetime | None" = None) -> "tuple[int, int | No
     return len(waiting), max(ages) if ages else None
 
 
-def render(count: int, oldest_days: "int | None") -> str:
+def render(count: int, oldest_days: "int | None", store: str = "") -> str:
     """The one line. Empty when there is nothing to report.
 
     The AGE is the part that does the work. A count alone reads as steady
     state; "oldest 24 days" reads as a problem — which is what it is.
+
+    The STORE is the part that keeps the number honest. A count with no named
+    source is unfalsifiable: it looks identical whether it came from the live
+    board or from a database nothing has written to since yesterday morning.
     """
     if count <= 0:
         return ""
@@ -243,11 +326,16 @@ def render(count: int, oldest_days: "int | None") -> str:
         age = " (oldest 1 day)"
     else:
         age = f" (oldest {oldest_days} days)"
-    return f"⏸ {count} card(s) awaiting the operator{age} — surface or reclassify"
+    line = f"⏸ {count} card(s) awaiting the operator{age} — surface or reclassify"
+    return f"{line}\n   read from {store}" if store else line
 
 
-def _read_board(agent: str) -> str:
-    """Run the read command and render its answer. Silent on every failure."""
+def _read_board(agent: str) -> "tuple[str, int, str]":
+    """Read the board. Returns ``(line, count, store)``; silent on any failure.
+
+    The store is resolved ONLY when there is something to say, so a clean
+    board costs one subprocess rather than two.
+    """
     argv = query_argv(agent)
     try:
         proc = subprocess.run(
@@ -265,13 +353,15 @@ def _read_board(agent: str) -> str:
         OSError,
         subprocess.SubprocessError,
     ):  # stx-allow: fallback (reason: a missing/hanging/crashing reader must degrade to today's behaviour, silently)
-        return ""
+        return "", 0, ""
     if proc.returncode != 0:
-        return ""
+        return "", 0, ""
     rows = _rows_from(proc.stdout or "")
     if rows is None:
-        return ""
-    return render(*summarize(rows))
+        return "", 0, ""
+    count, oldest = summarize(rows)
+    store = _store_identity() if count > 0 else ""
+    return render(count, oldest, store), count, store
 
 
 def _read_cache(path: Path) -> "tuple[float, str] | None":
@@ -290,13 +380,20 @@ def _read_cache(path: Path) -> "tuple[float, str] | None":
         return None
 
 
-def _write_cache(path: Path, epoch: float, line: str) -> None:
+def _write_cache(
+    path: Path, epoch: float, line: str, count: int = 0, store: str = ""
+) -> None:
     """Persist the reading — INCLUDING an empty one.
 
     Caching the empty answer is not an optimisation, it is the fail-open
     budget: an unreadable board would otherwise pay the full timeout on every
     single stop attempt, which is how a hook earns a latency reputation and
     gets switched off.
+
+    ``count`` and ``store`` are recorded even when the rendered line is empty.
+    A ZERO IS THE ONE ANSWER THAT PRINTS NOTHING, and a zero read from an
+    abandoned store looks exactly like a clean board — so the file keeps the
+    audit trail the line cannot: what was counted, and where it was read from.
     """
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -307,6 +404,8 @@ def _write_cache(path: Path, epoch: float, line: str) -> None:
                     "checked_at": time.strftime(
                         "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
                     ),
+                    "count": count,
+                    "store": store,
                     "line": line,
                 },
                 indent=2,
@@ -336,8 +435,8 @@ def notice(agent: str) -> str:
             cached = _read_cache(path)
             if cached is not None and 0 <= now - cached[0] < ttl:
                 return cached[1]
-        line = _read_board(agent)
-        _write_cache(path, now, line)
+        line, count, store = _read_board(agent)
+        _write_cache(path, now, line, count, store)
         return line
     except Exception:  # stx-allow: fallback (reason: catch-all safety net — see the docstring above)
         return ""
@@ -347,10 +446,13 @@ __all__ = [
     "BLOCKED_STATUS",
     "CMD_ENV",
     "OPERATOR_BLOCKER",
+    "STORE_CMD_ENV",
     "TTL_ENV",
     "cache_path",
     "notice",
     "query_argv",
+    "redact",
     "render",
+    "store_argv",
     "summarize",
 ]

--- a/src/scitex_agent_container/_never_stop_when_task_remains/_awaiting_operator.py
+++ b/src/scitex_agent_container/_never_stop_when_task_remains/_awaiting_operator.py
@@ -1,0 +1,356 @@
+"""Report the queue that stopped existing: cards waiting on a human.
+
+THE DEFECT THIS EXISTS FOR
+--------------------------
+A card with ``status=blocked`` sends no nudge — deliberately, so blocked work
+stops nagging. It is ALSO excluded from the runnable-items count this hook
+reports. Those two facts together mean a blocked card **stops existing**:
+nothing surfaces it, nothing counts it, and an agent reporting "board clear"
+is telling the truth about the only number it can see.
+
+Measured on 2026-08-11, on two boards, independently::
+
+    scitex-agent-container   38 blocked, 21 of them blocker=operator-decision
+    scitex-dev               69 blocked, 24 of them operator-decision,
+                             oldest 2026-07-19
+
+Three weeks of questions naming the operator as the gate, unasked — and on
+the same night the operator asked one of those agents directly whether it had
+anything to ask him, and got ONE item back, because nobody looked.
+
+The general shape, which outlives this fix: **a queue excluded from the alarm
+is a queue nobody is waiting on.** Blocked cards were designed to stop
+nagging, and the cost of that design was that they stopped existing.
+
+REPORT, DO NOT GATE — THE WHOLE DESIGN RESTS ON THIS
+----------------------------------------------------
+A card blocked on the operator is CORRECTLY waiting. It must never prevent an
+agent from stopping. Making it a gate would be strictly worse than the status
+quo: it would make this hook unstoppable, and the first thing anyone does with
+an unstoppable hook is bypass it — after which it protects nothing at all.
+The loop guard in :mod:`._loop_guard` exists because that failure has already
+been reasoned through once here; do not re-introduce it through this door.
+
+So this module is a **read path with one output: a string**. It never blocks,
+never writes a card, never raises, and never prints. The caller merges its
+line into ``systemMessage``, which is the one field a Stop hook can carry
+while still ALLOWING the stop.
+
+Why ``systemMessage`` and not the block ``reason``:
+
+1. ``reason`` does not exist on the allow path, and the allow path — the
+   agent that says "board clear" — is the exact failure being fixed.
+2. ``reason`` is authored by scitex-cards and forwarded verbatim; appending
+   to it would make sac an editor of someone else's instruction.
+3. ``reason`` feeds the loop-guard signature, whose contract (see
+   :meth:`._detector.Verdict.block_signature_source`) warns that any value
+   moving turn to turn stops the guard ever tripping. An age in days is
+   precisely such a value.
+
+WHAT COUNTS AS "WAITING ON A HUMAN"
+-----------------------------------
+``status=blocked`` AND ``blocker=operator-decision`` — the same predicate the
+board calls BLOCKING-YOU (``list-tasks --blocking-me`` /
+``--blocking-operator``). It is spelled here in ``--status`` / ``--blocker``,
+which are far older flags than either predicate, because THE FLEET ALWAYS RUNS
+OLDER THAN THE PUBLISHED VERSION and a report that silently never appears on
+half the hosts is the defect, not the fix. Both spellings were measured to
+return the same 21 rows on the live board.
+
+``blocker=agent-wait`` is DELIBERATELY EXCLUDED. An agent waiting on another
+agent is a different failure with a different owner and a different remedy —
+counting it here would misattribute the gate and dilute the one number this
+line exists to make unignorable. It wants its own line, not a share of this
+one. :data:`OPERATOR_BLOCKER` is the single place that decision lives.
+
+COST
+----
+This runs on EVERY stop attempt, so it is bounded three ways: a hard
+subprocess timeout, a TTL cache under the sac runtime tree, and a NEGATIVE
+cache — an unreadable board is remembered for the same TTL, so a database that
+is down cannot make stopping expensive. A hook that adds latency to every turn
+gets disabled, and a disabled hook protects nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .._runtime_paths import runtime_base_dir
+from ._loop_guard import _STATE_SUBDIR, _safe_name
+
+#: The blocker value that means "a human owes this card an answer". The ONE
+#: place the agent-wait decision above is encoded.
+OPERATOR_BLOCKER = "operator-decision"
+
+#: The status a card must carry to be counted. A card that is not blocked is
+#: not waiting, whatever its blocker field still says.
+BLOCKED_STATUS = "blocked"
+
+#: The read command. Overridable via ``$SAC_AWAITING_CARDS_CMD`` — an operator
+#: escape hatch AND the seam that lets a test point at a real script.
+CMD_ENV = "SAC_AWAITING_CARDS_CMD"
+_DEFAULT_CMD = "scitex-cards list-tasks"
+
+#: How long a reading stays good, in seconds. ``0`` disables the cache.
+TTL_ENV = "SAC_AWAITING_CARDS_TTL_S"
+_DEFAULT_TTL_S = 900.0
+
+#: Hard bound on the read. Shorter than the detector's 15s because this is a
+#: REPORT: if it cannot answer promptly, saying nothing is the correct answer.
+_TIMEOUT_S = 10.0
+
+#: Stamps in order of preference. ``blocked_at`` is when the store says the
+#: card entered the blocked state — the exact wait. It is not always recorded
+#: (15 of 21 rows on the live sac board), so ``created_at`` stands in: a card
+#: that has existed N days and is blocked on the operator has been a pending
+#: question for at most N days, and that is the honest available proxy.
+_STAMP_FIELDS = ("blocked_at", "created_at", "last_activity")
+
+
+def query_argv(agent: str) -> list[str]:
+    """Build the read command, always naming the agent.
+
+    Scoped to ONE agent's board on purpose. The hook answers for the agent it
+    resolved; a fleet-wide number would name a queue this agent cannot act on,
+    and "surface or reclassify" is only advice you can follow about your own
+    cards.
+    """
+    base = (os.environ.get(CMD_ENV) or "").strip() or _DEFAULT_CMD
+    return [
+        *shlex.split(base),
+        "--assignee",
+        agent,
+        # OPT OUT OF $SCITEX_TODO_SCOPE. `list-tasks` silently ANDs that
+        # ambient variable into the filter, and an agent whose scope does not
+        # match its own cards' scope then gets 0 rows back from a board holding
+        # 21 — MEASURED, exactly that, on 2026-08-12: baseline 21, with
+        # SCITEX_TODO_SCOPE set 0, with this flag 21 again. A report that can
+        # be silenced to zero by an ambient env var reproduces the very defect
+        # it exists to fix, so the scope is stated rather than inherited.
+        "--scope",
+        "",
+        "--status",
+        BLOCKED_STATUS,
+        "--blocker",
+        OPERATOR_BLOCKER,
+        "--json",
+    ]
+
+
+def cache_path(agent: str) -> Path:
+    """Where ``agent``'s last reading lives — beside the loop-guard state."""
+    return runtime_base_dir() / _STATE_SUBDIR / f"awaiting-{_safe_name(agent)}.json"
+
+
+def _ttl_seconds() -> float:
+    raw = (os.environ.get(TTL_ENV) or "").strip()
+    if not raw:
+        return _DEFAULT_TTL_S
+    try:
+        return max(0.0, float(raw))
+    except ValueError:  # stx-allow: fallback (reason: a malformed TTL must not break the stop path; fall back to the default)
+        return _DEFAULT_TTL_S
+
+
+def _rows_from(stdout: str) -> "list | None":
+    """The JSON array on stdout, or ``None`` when there is not one.
+
+    Decodes the FIRST array and ignores whatever follows, so a trailing
+    diagnostic line cannot cost us a reading we already have in hand.
+    """
+    start = stdout.find("[")
+    if start < 0:
+        return None
+    try:
+        data, _ = json.JSONDecoder().raw_decode(stdout[start:])
+    except json.JSONDecodeError:  # stx-allow: fallback (reason: unparseable output is "could not tell", which this module renders as silence)
+        return None
+    return data if isinstance(data, list) else None
+
+
+def _parse_stamp(value: object) -> "datetime | None":
+    """Parse a store timestamp, tolerating the trailing ``Z`` form."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:  # stx-allow: fallback (reason: one unreadable stamp must not cost the whole count)
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _card_stamp(row: dict) -> "datetime | None":
+    for field in _STAMP_FIELDS:
+        stamp = _parse_stamp(row.get(field))
+        if stamp is not None:
+            return stamp
+    return None
+
+
+def _is_awaiting_operator(row: object) -> bool:
+    """Re-assert the predicate on the rows we actually received.
+
+    The command already filters, so this is normally a no-op — but it means
+    the number is defined HERE, in code, and cannot be inflated by an
+    overridden command that answers with the whole board.
+    """
+    return (
+        isinstance(row, dict)
+        and row.get("status") == BLOCKED_STATUS
+        and row.get("blocker") == OPERATOR_BLOCKER
+    )
+
+
+def summarize(rows: list, now: "datetime | None" = None) -> "tuple[int, int | None]":
+    """Return ``(count, oldest_age_in_days)`` for the awaiting-operator rows.
+
+    ``oldest_age_in_days`` is ``None`` when no row carries a readable stamp —
+    a count with no age is still worth printing, an invented age is not.
+    """
+    moment = now or datetime.now(timezone.utc)
+    waiting = [row for row in rows if _is_awaiting_operator(row)]
+    ages = [
+        (moment - stamp).days
+        for stamp in (_card_stamp(row) for row in waiting)
+        if stamp is not None
+    ]
+    return len(waiting), max(ages) if ages else None
+
+
+def render(count: int, oldest_days: "int | None") -> str:
+    """The one line. Empty when there is nothing to report.
+
+    The AGE is the part that does the work. A count alone reads as steady
+    state; "oldest 24 days" reads as a problem — which is what it is.
+    """
+    if count <= 0:
+        return ""
+    if oldest_days is None:
+        age = ""
+    elif oldest_days <= 0:
+        age = " (oldest today)"
+    elif oldest_days == 1:
+        age = " (oldest 1 day)"
+    else:
+        age = f" (oldest {oldest_days} days)"
+    return f"⏸ {count} card(s) awaiting the operator{age} — surface or reclassify"
+
+
+def _read_board(agent: str) -> str:
+    """Run the read command and render its answer. Silent on every failure."""
+    argv = query_argv(agent)
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_S,
+            check=False,
+            # The hook's own stdin carries the Stop payload. A reader that
+            # inherited it could consume or block on that pipe, which would
+            # turn a REPORT into a broken stop path.
+            stdin=subprocess.DEVNULL,
+        )
+    except (
+        OSError,
+        subprocess.SubprocessError,
+    ):  # stx-allow: fallback (reason: a missing/hanging/crashing reader must degrade to today's behaviour, silently)
+        return ""
+    if proc.returncode != 0:
+        return ""
+    rows = _rows_from(proc.stdout or "")
+    if rows is None:
+        return ""
+    return render(*summarize(rows))
+
+
+def _read_cache(path: Path) -> "tuple[float, str] | None":
+    try:
+        data = json.loads(path.read_text())
+    except (
+        OSError,
+        json.JSONDecodeError,
+    ):  # stx-allow: fallback (reason: no cache and a corrupt cache are the same fact — take a fresh reading)
+        return None
+    if not isinstance(data, dict):
+        return None
+    try:
+        return float(data.get("checked_at_epoch")), str(data.get("line") or "")
+    except (TypeError, ValueError):  # stx-allow: fallback (reason: a cache entry we cannot read is no cache entry)
+        return None
+
+
+def _write_cache(path: Path, epoch: float, line: str) -> None:
+    """Persist the reading — INCLUDING an empty one.
+
+    Caching the empty answer is not an optimisation, it is the fail-open
+    budget: an unreadable board would otherwise pay the full timeout on every
+    single stop attempt, which is how a hook earns a latency reputation and
+    gets switched off.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "checked_at_epoch": epoch,
+                    "checked_at": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "line": line,
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+    except OSError:  # stx-allow: fallback (reason: an unwritable runtime dir costs us caching, never the stop)
+        pass
+
+
+def notice(agent: str) -> str:
+    """The awaiting-operator line for ``agent``, or ``""``. NEVER raises.
+
+    Every failure — no identity, no reader, a refused read, a timeout, an
+    unwritable cache, a defect in this module — returns the empty string and
+    prints NOTHING. A hook that breaks the stop path breaks everything, so
+    this one is allowed exactly one way to fail: quietly.
+    """
+    # stx-allow: fallback (reason: this is a REPORT on the stop path; no defect in it may ever reach the agent as an error or an exception)
+    try:
+        if not agent:
+            return ""
+        ttl = _ttl_seconds()
+        path = cache_path(agent)
+        now = time.time()
+        if ttl > 0:
+            cached = _read_cache(path)
+            if cached is not None and 0 <= now - cached[0] < ttl:
+                return cached[1]
+        line = _read_board(agent)
+        _write_cache(path, now, line)
+        return line
+    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see the docstring above)
+        return ""
+
+
+__all__ = [
+    "BLOCKED_STATUS",
+    "CMD_ENV",
+    "OPERATOR_BLOCKER",
+    "TTL_ENV",
+    "cache_path",
+    "notice",
+    "query_argv",
+    "render",
+    "summarize",
+]

--- a/src/scitex_agent_container/cli_pkg/never_stop_when_task_remains_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/never_stop_when_task_remains_cmds.py
@@ -19,6 +19,14 @@ to the operator instead of buried in the debug log.
 
 Because stdout IS the protocol, this command prints the JSON object and
 nothing else; every diagnostic goes to stderr.
+
+``systemMessage`` also carries the AWAITING-OPERATOR REPORT — the count of
+this agent's cards blocked on a human, and the age of the oldest. It is a
+report, never a gate: those cards are correctly waiting, so they must not
+prevent a stop. It rides on ``systemMessage`` precisely because that field
+can be emitted while STILL ALLOWING the stop, which is the only way to reach
+the agent that would otherwise truthfully report "board clear". See
+:mod:`~scitex_agent_container._never_stop_when_task_remains._awaiting_operator`.
 """
 
 from __future__ import annotations
@@ -28,6 +36,7 @@ import sys
 
 import click
 
+from .._never_stop_when_task_remains._awaiting_operator import notice
 from .._never_stop_when_task_remains._decide import decide
 from .._never_stop_when_task_remains._detector import probe
 from .._never_stop_when_task_remains._identity import resolve_agent
@@ -100,10 +109,21 @@ def never_stop_when_task_remains(agent_flag: str) -> None:
         print(decision.log, file=sys.stderr)
 
     # The executable's decision, forwarded verbatim — we add only what sac
-    # owns (the fail-open / alarm systemMessage).
+    # owns (the fail-open / alarm systemMessage, and the awaiting-operator
+    # report).
     out: dict = dict(decision.payload) if decision.block else {}
-    if decision.system_message:
-        out["systemMessage"] = decision.system_message
+
+    # REPORT, NEVER GATE. This line is merged into ``systemMessage`` and
+    # deliberately not into ``decision`` / ``reason``: a card blocked on the
+    # operator is CORRECTLY waiting and must not stop an agent from stopping.
+    # It goes here rather than into the block reason because the failure being
+    # fixed is the ALLOW path — the agent that truthfully reports "board
+    # clear" because a blocked card is counted by nothing.
+    messages = [
+        text for text in (decision.system_message, notice(agent)) if text.strip()
+    ]
+    if messages:
+        out["systemMessage"] = "\n".join(messages)
 
     if out:
         # stdout is the protocol — the JSON object and nothing else.

--- a/tests/scitex_agent_container/_never_stop_when_task_remains/_fake_detector.py
+++ b/tests/scitex_agent_container/_never_stop_when_task_remains/_fake_detector.py
@@ -144,6 +144,48 @@ def missing_detector(env_save_restore, tmp_path: Path) -> None:
 #: set a real TTL. Everything else disables it so each act reads afresh.
 AWAITING_TTL_ENV = "SAC_AWAITING_CARDS_TTL_S"
 AWAITING_CMD_ENV = "SAC_AWAITING_CARDS_CMD"
+AWAITING_STORE_ENV = "SAC_AWAITING_STORE_CMD"
+
+#: The shape `scitex-cards resolve-store --json` really answers with, captured
+#: from the live host 2026-08-12. The store identity is NOT the env var: this
+#: fleet has four stores, and a reader that trusts `$SCITEX_CARDS_DB` rather
+#: than the resolver is how one ends up quoting an abandoned one.
+LIVE_STORE_JSON = json.dumps(
+    {
+        "resolved": "postgresql://scitex_cards@127.0.0.1:55432/scitex_cards",
+        "db_env": "postgresql://scitex_cards@127.0.0.1:55432/scitex_cards",
+        "user_store": "/home/agent/.scitex/cards/cards.db",
+        "backend": "postgresql",
+        "store_uuid": "1d55dd6e-3d2a-4c24-a429-a78835ab988f",
+    }
+)
+
+#: The ABANDONED sidecar, measured the same night: 365 rows, 149 unseen, a
+#: zero-byte WAL, and no write since the previous morning while readers kept
+#: attaching. Opened constantly, written never.
+DEAD_SIDECAR_JSON = json.dumps(
+    {
+        "resolved": "/home/agent/.scitex/cards/runtime/todo.db",
+        "backend": "sqlite",
+        "store_uuid": "deadbeef-0000-0000-0000-000000000000",
+    }
+)
+
+
+def store_identity_cmd(
+    env_save_restore,
+    tmp_path: Path,
+    payload: str = LIVE_STORE_JSON,
+    *,
+    returncode: int = 0,
+    name: str = "fake-resolve-store",
+) -> Path:
+    """Install a real store-identity command answering with ``payload``."""
+    script = write_detector(
+        tmp_path, returncode=returncode, stdout=payload, name=name
+    )
+    env_save_restore.set(AWAITING_STORE_ENV, str(script))
+    return script
 
 #: What a refused read really prints. Captured from the live board on
 #: 2026-08-12, while the operator's own report said the database was
@@ -204,7 +246,11 @@ def awaiting_cards(
         tmp_path, returncode=returncode, stdout=body, stderr=stderr, name=name
     )
     env_save_restore.set(AWAITING_CMD_ENV, str(script))
-    env_save_restore.set(AWAITING_TTL_ENV, "0")  # read afresh unless a test says else
+    env_save_restore.set(AWAITING_TTL_ENV, "0")
+    # Keep the store probe offline too — without it the REAL
+    # `scitex-cards resolve-store` is spawned against the live fleet store.
+    if not os.environ.get(AWAITING_STORE_ENV):
+        store_identity_cmd(env_save_restore, tmp_path)  # read afresh unless a test says else
     return script
 
 
@@ -263,6 +309,10 @@ def scope_sensitive_board(
     script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
     env_save_restore.set(AWAITING_CMD_ENV, str(script))
     env_save_restore.set(AWAITING_TTL_ENV, "0")
+    # Keep the store probe offline too — without it the REAL
+    # `scitex-cards resolve-store` is spawned against the live fleet store.
+    if not os.environ.get(AWAITING_STORE_ENV):
+        store_identity_cmd(env_save_restore, tmp_path)
     return script
 
 

--- a/tests/scitex_agent_container/_never_stop_when_task_remains/_fake_detector.py
+++ b/tests/scitex_agent_container/_never_stop_when_task_remains/_fake_detector.py
@@ -26,7 +26,9 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import stat
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 #: Exactly what a host whose scitex-cards predates ``may-stop`` emits: the
@@ -128,4 +130,166 @@ def missing_detector(env_save_restore, tmp_path: Path) -> None:
     """Point sac at a path that genuinely does not exist."""
     env_save_restore.set(
         "SAC_MAY_STOP_CMD", str(tmp_path / "no-such-binary" / os.sep.join(["gone"]))
+    )
+
+
+# ---------------------------------------------------------------------------
+# The awaiting-operator READ command (`scitex-cards list-tasks ... --json`).
+#
+# Same no-mocks discipline as above: a real executable on disk, spawned by a
+# real subprocess, printing real bytes. Nothing here patches a callable.
+# ---------------------------------------------------------------------------
+
+#: Distinct from ``_TTL_OFF`` below: tests that want to prove the CACHE works
+#: set a real TTL. Everything else disables it so each act reads afresh.
+AWAITING_TTL_ENV = "SAC_AWAITING_CARDS_TTL_S"
+AWAITING_CMD_ENV = "SAC_AWAITING_CARDS_CMD"
+
+#: What a refused read really prints. Captured from the live board on
+#: 2026-08-12, while the operator's own report said the database was
+#: "refusing the read intermittently tonight" — the same run answered rc 0
+#: with 21 rows minutes later.
+REFUSED_READ_STDERR = (
+    "Traceback (most recent call last):\n"
+    '  File "scitex_cards/_db_export.py", line 54, in _record\n'
+    "    raise ExportRefused(\n"
+    "scitex_cards._db_export.ExportRefused: notifications row 'n_5e9e1ec3555f' "
+    "has no record_json payload — this DB predates schema v3's payload columns "
+    "and cannot be back-filled. Exporting stripped records is worse than "
+    "exporting none."
+)
+
+
+def operator_card(
+    card_id: str, *, blocked_days_ago: int, agent: str = "agent-x"
+) -> dict:
+    """One row shaped like a real ``list-tasks --json`` card blocked on a human.
+
+    Carries the three fields the summary is defined on (``status``,
+    ``blocker``, a stamp) plus the ``title`` a real row would have, so a test
+    row is not thinner than the thing it stands for.
+    """
+    stamp = datetime.now(timezone.utc) - timedelta(days=blocked_days_ago)
+    return {
+        "id": card_id,
+        "title": f"[q] {card_id} needs an operator decision",
+        "status": "blocked",
+        "blocker": "operator-decision",
+        "assignee": agent,
+        "scope": f"agent:{agent}",
+        "blocked_at": stamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "created_at": stamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "last_activity": stamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+def awaiting_cards(
+    env_save_restore,
+    tmp_path: Path,
+    cards: "list[dict] | None" = None,
+    *,
+    returncode: int = 0,
+    stdout: "str | None" = None,
+    stderr: str = "",
+    name: str = "fake-list-tasks",
+) -> Path:
+    """Install a real read command answering with ``cards``, and point sac at it.
+
+    ``stdout`` overrides the rendered JSON outright (for the unreadable-output
+    cases); ``returncode`` non-zero is how the "database refuses the read"
+    case is reproduced — a real process, a real failing exit code.
+    """
+    body = json.dumps(cards if cards is not None else []) if stdout is None else stdout
+    script = write_detector(
+        tmp_path, returncode=returncode, stdout=body, stderr=stderr, name=name
+    )
+    env_save_restore.set(AWAITING_CMD_ENV, str(script))
+    env_save_restore.set(AWAITING_TTL_ENV, "0")  # read afresh unless a test says else
+    return script
+
+
+#: The env var ``scitex-cards list-tasks`` silently ANDs into its filter.
+SCOPE_ENV = "SCITEX_TODO_SCOPE"
+
+
+def scope_sensitive_board(
+    env_save_restore,
+    tmp_path: Path,
+    cards: "list[dict]",
+    *,
+    name: str = "scope-sensitive-list-tasks",
+) -> Path:
+    """A reader that honours ``$SCITEX_TODO_SCOPE`` exactly as the real one does.
+
+    NOT an invented behaviour — MEASURED on the live board, 2026-08-12::
+
+        baseline                          : 21
+        with SCITEX_TODO_SCOPE=other      : 0
+        same + explicit --scope ''        : 21
+        no env + explicit --scope ''      : 21
+
+    That zero is the whole reason this fixture exists. A new alarm that
+    silently reports nothing is WORSE than no alarm, because it converts
+    "nobody looked" into "we checked and it was clear" — the exact failure
+    family this feature was built to remove, reappearing inside the feature. A
+    test that only ever ran with the variable unset would have passed and
+    shipped it.
+
+    The rule reproduced here: an explicit ``--scope ''`` opts out; no
+    ``--scope`` at all inherits the ambient value; any other explicit scope
+    filters. The last two return the empty board.
+    """
+    body = json.dumps(cards)
+    payload = tmp_path / f"{name}.json"
+    payload.write_text(body)
+    script = tmp_path / name
+    script.write_text(
+        "#!/bin/sh\n"
+        "cat >/dev/null 2>&1 || true\n"
+        "__given=no\n__val=\n__prev=\n"
+        'for __a in "$@"; do\n'
+        '  if [ "$__prev" = "--scope" ]; then __given=yes; __val="$__a"; fi\n'
+        '  __prev="$__a"\n'
+        "done\n"
+        # No --scope at all: the ambient variable applies, as it really does.
+        'if [ "$__given" = no ] && [ -n "$SCITEX_TODO_SCOPE" ]; then\n'
+        "  echo '[]'\n  exit 0\nfi\n"
+        # An explicit NON-empty scope filters; only '' means "ignore it".
+        'if [ "$__given" = yes ] && [ -n "$__val" ]; then\n'
+        "  echo '[]'\n  exit 0\nfi\n"
+        f"cat {shlex.quote(str(payload))}\n"
+        "exit 0\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    env_save_restore.set(AWAITING_CMD_ENV, str(script))
+    env_save_restore.set(AWAITING_TTL_ENV, "0")
+    return script
+
+
+def no_awaiting_cards(env_save_restore, tmp_path: Path) -> Path:
+    """The default board state for tests: nothing is waiting on a human.
+
+    Every test that drives the hook needs this, because without it the real
+    ``scitex-cards`` on PATH would be spawned against the LIVE fleet board —
+    slow, non-deterministic, and a test suite that fails when a database it
+    does not own is down.
+    """
+    return awaiting_cards(env_save_restore, tmp_path, [], name="no-awaiting-cards")
+
+
+def unreadable_board(env_save_restore, tmp_path: Path) -> Path:
+    """The degraded case: the read command fails the way a refused read does.
+
+    Captured shape: ``scitex-cards list-tasks --json`` against a store it will
+    not export exits non-zero with a traceback on stderr and NOTHING on
+    stdout (measured on the live board, 2026-08-12:
+    ``ExportRefused: notifications row ... has no record_json payload``).
+    """
+    return awaiting_cards(
+        env_save_restore,
+        tmp_path,
+        returncode=1,
+        stdout="",
+        stderr=REFUSED_READ_STDERR,
+        name="refusing-board",
     )

--- a/tests/scitex_agent_container/_never_stop_when_task_remains/test__awaiting_operator.py
+++ b/tests/scitex_agent_container/_never_stop_when_task_remains/test__awaiting_operator.py
@@ -24,16 +24,20 @@ from scitex_agent_container._never_stop_when_task_remains._awaiting_operator imp
     cache_path,
     notice,
     query_argv,
+    redact,
     render,
     summarize,
 )
 
 from ._fake_detector import (
+    DEAD_SIDECAR_JSON,
+    LIVE_STORE_JSON,
     SCOPE_ENV,
     awaiting_cards,
     isolate_runtime,
     operator_card,
     scope_sensitive_board,
+    store_identity_cmd,
     unreadable_board,
 )
 
@@ -261,6 +265,143 @@ def test_a_real_reader_produces_the_line(env_save_restore, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# A READER THAT DOES NOT NAME ITS SOURCE WILL BE WRONG AGAIN
+#
+# This fleet has FOUR stores: two Postgres clones, an abandoned SQLite inbox
+# sidecar (365 rows, 149 unseen, zero-byte WAL, no write since the previous
+# morning while readers kept attaching — opened constantly, written never), and
+# a YAML file that `scitex-cards done` resolved to while $SCITEX_CARDS_DB named
+# Postgres. A count with no named source is unfalsifiable: it looks identical
+# whether it came from the live board or from a corpse.
+# ---------------------------------------------------------------------------
+
+
+def test_the_line_names_the_store_it_read(env_save_restore, tmp_path):
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    store_identity_cmd(env_save_restore, tmp_path, LIVE_STORE_JSON)
+    awaiting_cards(
+        env_save_restore, tmp_path, [operator_card("q-1", blocked_days_ago=30)]
+    )
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert "read from postgresql://scitex_cards@127.0.0.1:55432/scitex_cards" in line
+
+
+def test_a_different_store_produces_a_different_line(env_save_restore, tmp_path):
+    """THE CONTROL. A hardcoded store string would pass the test above and
+    fail here — which is the only reason that test means anything.
+
+    This is the abandoned sidecar: same query, same count, different source.
+    """
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    store_identity_cmd(env_save_restore, tmp_path, DEAD_SIDECAR_JSON)
+    awaiting_cards(
+        env_save_restore, tmp_path, [operator_card("q-1", blocked_days_ago=30)]
+    )
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert "read from /home/agent/.scitex/cards/runtime/todo.db" in line
+
+
+def test_the_line_carries_the_store_uuid(env_save_restore, tmp_path):
+    """A URL alone cannot separate two clones of the same database, and this
+    fleet is running two."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    store_identity_cmd(env_save_restore, tmp_path, LIVE_STORE_JSON)
+    awaiting_cards(
+        env_save_restore, tmp_path, [operator_card("q-1", blocked_days_ago=30)]
+    )
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert "uuid 1d55dd6e" in line
+
+
+def test_a_store_password_is_never_printed():
+    """Never print, log, or write a credential — the identity is scheme, user,
+    host, port and database, never the secret."""
+    # Arrange
+    target = "postgresql://scitex_cards:hunter2@127.0.0.1:55432/scitex_cards"
+    # Act
+    shown = redact(target)
+    # Assert
+    assert "hunter2" not in shown
+
+
+def test_a_redacted_url_still_names_the_database():
+    """Redaction must not destroy the identity it exists to publish."""
+    # Arrange
+    target = "postgresql://scitex_cards:hunter2@127.0.0.1:55432/scitex_cards"
+    # Act
+    shown = redact(target)
+    # Assert
+    assert shown == "postgresql://scitex_cards:***@127.0.0.1:55432/scitex_cards"
+
+
+def test_a_file_store_passes_through_redaction_unchanged():
+    # Arrange
+    target = "/home/agent/.scitex/cards/runtime/todo.db"
+    # Act
+    shown = redact(target)
+    # Assert
+    assert shown == target
+
+
+def test_an_unnameable_store_still_reports_the_count(env_save_restore, tmp_path):
+    """Failing to name the store must cost the NAME, never the number."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    store_identity_cmd(env_save_restore, tmp_path, "", returncode=1)
+    awaiting_cards(
+        env_save_restore, tmp_path, [operator_card("q-1", blocked_days_ago=30)]
+    )
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert line.startswith("⏸ 1 card(s) awaiting the operator")
+
+
+def test_the_cache_records_what_was_counted_and_from_where(
+    env_save_restore, tmp_path
+):
+    """A ZERO IS THE ONE ANSWER THAT PRINTS NOTHING, and a zero read from an
+    abandoned store looks exactly like a clean board. The file keeps the audit
+    trail the line cannot."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    store_identity_cmd(env_save_restore, tmp_path, LIVE_STORE_JSON)
+    awaiting_cards(
+        env_save_restore, tmp_path, [operator_card("q-1", blocked_days_ago=30)]
+    )
+    # Act
+    notice("agent-x")
+    recorded = json.loads(cache_path("agent-x").read_text())
+    # Assert
+    assert (recorded["count"], "127.0.0.1:55432" in recorded["store"]) == (1, True)
+
+
+def test_a_clean_board_is_not_charged_for_the_store_probe(
+    env_save_restore, tmp_path
+):
+    """Resolving the store costs a second subprocess (0.71s measured), so it
+    runs only when there is something to say."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    store_identity_cmd(env_save_restore, tmp_path, LIVE_STORE_JSON)
+    awaiting_cards(env_save_restore, tmp_path, [])
+    # Act
+    notice("agent-x")
+    recorded = json.loads(cache_path("agent-x").read_text())
+    # Assert
+    assert (recorded["count"], recorded["store"]) == (0, "")
+
+
+# ---------------------------------------------------------------------------
 # AN AMBIENT ENV VAR MUST NOT BE ABLE TO SILENCE THE ALARM
 #
 # `list-tasks` silently ANDs $SCITEX_TODO_SCOPE into its filter. Measured on
@@ -410,11 +551,14 @@ def test_a_second_stop_within_the_ttl_does_not_respawn_the_reader(
         "scitex-cards",
         stdout=json.dumps([operator_card("q-1", blocked_days_ago=30)]),
     )
-    # Act
+    # Act — a cold read costs N spawns (the board, then the store identity);
+    # what must not happen is paying ANY of them again inside the TTL.
     first = notice("agent-x")
+    cold = subprocess_shim.call_count("scitex-cards")
     second = notice("agent-x")
+    warm = subprocess_shim.call_count("scitex-cards")
     # Assert
-    assert (first, subprocess_shim.call_count("scitex-cards")) == (second, 1)
+    assert (first, warm) == (second, cold)
 
 
 def test_an_unreadable_board_is_paid_once_per_ttl_not_once_per_stop(

--- a/tests/scitex_agent_container/_never_stop_when_task_remains/test__awaiting_operator.py
+++ b/tests/scitex_agent_container/_never_stop_when_task_remains/test__awaiting_operator.py
@@ -1,0 +1,444 @@
+"""Tests for the awaiting-operator REPORT.
+
+PA-306 no-mocks. The read command is a REAL executable on disk, spawned by a
+real :func:`subprocess.run`, printing real JSON and exiting with a real code —
+the same interface ``scitex-cards list-tasks --json`` presents. The cache is
+real files under a real (redirected) runtime tree.
+
+THE FAILURE UNDER TEST is not "does it print a number". It is that a card with
+``status=blocked`` is counted by nothing — no nudge, no runnable-items line —
+so it stops existing, and an agent reporting "board clear" is telling the
+truth about the only number it can see. Measured 2026-08-11: 21 such cards on
+this agent's board, 24 on scitex-dev's, oldest three weeks old.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timedelta, timezone
+
+from scitex_agent_container._never_stop_when_task_remains._awaiting_operator import (
+    CMD_ENV,
+    TTL_ENV,
+    cache_path,
+    notice,
+    query_argv,
+    render,
+    summarize,
+)
+
+from ._fake_detector import (
+    SCOPE_ENV,
+    awaiting_cards,
+    isolate_runtime,
+    operator_card,
+    scope_sensitive_board,
+    unreadable_board,
+)
+
+_NOW = datetime(2026, 8, 12, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _card(card_id: str, *, days: int, blocker: str = "operator-decision") -> dict:
+    stamp = _NOW - timedelta(days=days)
+    return {
+        "id": card_id,
+        "status": "blocked",
+        "blocker": blocker,
+        "blocked_at": stamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# what counts as waiting on a human
+# ---------------------------------------------------------------------------
+
+
+def test_operator_decision_cards_are_counted():
+    # Arrange
+    rows = [_card("q-1", days=3), _card("q-2", days=1)]
+    # Act
+    count, _ = summarize(rows, now=_NOW)
+    # Assert
+    assert count == 2
+
+
+def test_agent_wait_is_not_counted_as_awaiting_the_operator():
+    """An agent waiting on another agent is a DIFFERENT failure with a
+    different owner. Counting it here would misattribute the gate and dilute
+    the one number this line exists to make unignorable."""
+    # Arrange
+    rows = [_card("q-1", days=3), _card("peer-1", days=9, blocker="agent-wait")]
+    # Act
+    count, _ = summarize(rows, now=_NOW)
+    # Assert
+    assert count == 1
+
+
+def test_a_card_that_is_no_longer_blocked_is_not_waiting():
+    # Arrange
+    row = _card("q-1", days=3)
+    row["status"] = "done"
+    # Act
+    count, _ = summarize([row], now=_NOW)
+    # Assert
+    assert count == 0
+
+
+def test_the_oldest_age_is_reported_in_days():
+    """The AGE is the part that does the work — a count alone reads as steady
+    state, "oldest 24 days" reads as a problem."""
+    # Arrange
+    rows = [_card("q-1", days=3), _card("q-2", days=24), _card("q-3", days=1)]
+    # Act
+    _, oldest = summarize(rows, now=_NOW)
+    # Assert
+    assert oldest == 24
+
+
+def test_the_age_ignores_cards_that_are_not_waiting():
+    """A 90-day agent-wait card must not inflate the operator's number."""
+    # Arrange
+    rows = [_card("q-1", days=3), _card("peer", days=90, blocker="agent-wait")]
+    # Act
+    _, oldest = summarize(rows, now=_NOW)
+    # Assert
+    assert oldest == 3
+
+
+def test_created_at_stands_in_when_the_store_recorded_no_blocked_at():
+    """Measured on the live board: only 15 of 21 rows carry ``blocked_at``.
+    Dropping the other 6 would silently understate the queue."""
+    # Arrange
+    row = _card("q-1", days=0)
+    row.pop("blocked_at")
+    row["created_at"] = (_NOW - timedelta(days=31)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # Act
+    count, oldest = summarize([row], now=_NOW)
+    # Assert
+    assert (count, oldest) == (1, 31)
+
+
+# ---------------------------------------------------------------------------
+# rendering
+# ---------------------------------------------------------------------------
+
+
+def test_the_line_reports_the_count():
+    # Arrange
+    count, oldest = 21, 24
+    # Act
+    line = render(count, oldest)
+    # Assert
+    assert "21 card(s) awaiting the operator" in line
+
+
+def test_the_line_reports_the_age_of_the_oldest():
+    # Arrange
+    count, oldest = 21, 24
+    # Act
+    line = render(count, oldest)
+    # Assert
+    assert "oldest 24 days" in line
+
+
+def test_the_line_says_what_to_do_about_it():
+    # Arrange
+    count, oldest = 21, 24
+    # Act
+    line = render(count, oldest)
+    # Assert
+    assert "surface or reclassify" in line
+
+
+def test_an_empty_queue_prints_nothing():
+    """No queue, no line — a report that fires on a clean board is noise, and
+    noise is how a hook earns its way into being disabled."""
+    # Arrange
+    count, oldest = 0, None
+    # Act
+    line = render(count, oldest)
+    # Assert
+    assert line == ""
+
+
+def test_a_countable_queue_with_no_readable_stamp_still_reports_the_count():
+    """An invented age would be worse than no age; the count still stands."""
+    # Arrange
+    count, oldest = 4, None
+    # Act
+    line = render(count, oldest)
+    # Assert
+    assert line == "⏸ 4 card(s) awaiting the operator — surface or reclassify"
+
+
+def test_one_day_is_not_pluralised():
+    # Arrange
+    count, oldest = 1, 1
+    # Act
+    line = render(count, oldest)
+    # Assert
+    assert "oldest 1 day)" in line
+
+
+# ---------------------------------------------------------------------------
+# the read command
+# ---------------------------------------------------------------------------
+
+
+def test_the_query_names_the_agent():
+    """Scoped to ONE board on purpose — "surface or reclassify" is only advice
+    you can follow about your own cards."""
+    # Arrange
+    agent = "agent-x"
+    # Act
+    argv = query_argv(agent)
+    # Assert
+    assert argv[argv.index("--assignee") + 1] == "agent-x"
+
+
+def test_the_query_asks_only_for_blocked_cards():
+    # Arrange
+    agent = "agent-x"
+    # Act
+    argv = query_argv(agent)
+    # Assert
+    assert argv[argv.index("--status") + 1] == "blocked"
+
+
+def test_the_query_asks_only_for_the_operator_decision_blocker():
+    """status=blocked AND blocker=operator-decision — spelled in flags far
+    older than ``--blocking-me``, because the fleet always runs older than the
+    published version and a report nobody's host can run is not a fix."""
+    # Arrange
+    agent = "agent-x"
+    # Act
+    argv = query_argv(agent)
+    # Assert
+    assert argv[argv.index("--blocker") + 1] == "operator-decision"
+
+
+def test_the_query_opts_out_of_the_ambient_scope():
+    """MEASURED 2026-08-12 on the live board: ``list-tasks`` silently ANDs
+    ``$SCITEX_TODO_SCOPE`` into the filter, so with it set the same query
+    returned 0 rows from a board holding 21. A report that an ambient env var
+    can silence to zero reproduces the exact defect it exists to fix."""
+    # Arrange
+    agent = "agent-x"
+    # Act
+    argv = query_argv(agent)
+    # Assert
+    assert argv[argv.index("--scope") + 1] == ""
+
+
+def test_the_query_asks_for_machine_readable_output():
+    # Arrange
+    agent = "agent-x"
+    # Act
+    argv = query_argv(agent)
+    # Assert
+    assert "--json" in argv
+
+
+# ---------------------------------------------------------------------------
+# end to end through a real subprocess
+# ---------------------------------------------------------------------------
+
+
+def test_a_real_reader_produces_the_line(env_save_restore, tmp_path):
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    awaiting_cards(
+        env_save_restore,
+        tmp_path,
+        [operator_card(f"q-{n}", blocked_days_ago=n + 1) for n in range(21)],
+    )
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert "21 card(s) awaiting the operator (oldest 21 days)" in line
+
+
+# ---------------------------------------------------------------------------
+# AN AMBIENT ENV VAR MUST NOT BE ABLE TO SILENCE THE ALARM
+#
+# `list-tasks` silently ANDs $SCITEX_TODO_SCOPE into its filter. Measured on
+# the live board 2026-08-12: the same query returned 21 rows unset and 0 rows
+# with the variable set. A new alarm that quietly reports zero is WORSE than no
+# alarm — it converts "nobody looked" into "we checked and it was clear", which
+# is the exact failure family this feature exists to remove. Testing only the
+# unset case would have passed, and shipped it.
+# ---------------------------------------------------------------------------
+
+
+def test_the_reader_really_is_silenced_by_an_ambient_scope(
+    env_save_restore, tmp_path
+):
+    """THE CONTROL. Without it the test below proves nothing: a reader that
+    ignored scope would pass whether or not the fix were present."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    script = scope_sensitive_board(
+        env_save_restore,
+        tmp_path,
+        [operator_card(f"q-{n}", blocked_days_ago=n + 1) for n in range(21)],
+    )
+    env_save_restore.set(SCOPE_ENV, "agent:somebody-else")
+    # Act — the pre-fix argv: no --scope of our own
+    proc = subprocess.run(
+        [str(script), "--assignee", "agent-x", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # Assert
+    assert json.loads(proc.stdout) == []
+
+
+def test_an_ambient_scope_cannot_silence_the_report(env_save_restore, tmp_path):
+    """21 cards on the board AND a narrow ambient scope: still 21."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    scope_sensitive_board(
+        env_save_restore,
+        tmp_path,
+        [operator_card(f"q-{n}", blocked_days_ago=n + 1) for n in range(21)],
+    )
+    env_save_restore.set(SCOPE_ENV, "agent:somebody-else")
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert "21 card(s) awaiting the operator" in line
+
+
+def test_the_report_is_unchanged_when_no_scope_is_set(env_save_restore, tmp_path):
+    """The opt-out must be a no-op in the ordinary case, not a second filter."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    scope_sensitive_board(
+        env_save_restore,
+        tmp_path,
+        [operator_card(f"q-{n}", blocked_days_ago=n + 1) for n in range(21)],
+    )
+    env_save_restore.delete(SCOPE_ENV)
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert "21 card(s) awaiting the operator" in line
+
+
+# ---------------------------------------------------------------------------
+# fail open and SILENT — a hook that breaks the stop path breaks everything
+# ---------------------------------------------------------------------------
+
+
+def test_a_refused_read_produces_no_line(env_save_restore, tmp_path):
+    """The database was refusing reads intermittently on the night this was
+    written. Degrading to today's behaviour is the requirement."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    unreadable_board(env_save_restore, tmp_path)
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert line == ""
+
+
+def test_output_that_is_not_json_produces_no_line(env_save_restore, tmp_path):
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    awaiting_cards(
+        env_save_restore, tmp_path, stdout="Error: No such option '--blocker'"
+    )
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert line == ""
+
+
+def test_a_missing_reader_produces_no_line(env_save_restore, tmp_path):
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    env_save_restore.set(CMD_ENV, str(tmp_path / "no-such" / "reader"))
+    env_save_restore.set(TTL_ENV, "0")
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert line == ""
+
+
+def test_an_unresolved_identity_produces_no_line(env_save_restore, tmp_path):
+    """Never guess whose board to read — the same rule as ``_identity``."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    awaiting_cards(env_save_restore, tmp_path, [operator_card("q-1", blocked_days_ago=9)])
+    # Act
+    line = notice("")
+    # Assert
+    assert line == ""
+
+
+def test_an_unwritable_cache_still_produces_the_line(env_save_restore, tmp_path):
+    """Losing the cache costs latency; it must never cost the report."""
+    # Arrange
+    blocker_file = tmp_path / "not-a-dir"
+    blocker_file.write_text("")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(blocker_file))
+    awaiting_cards(env_save_restore, tmp_path, [operator_card("q-1", blocked_days_ago=9)])
+    # Act
+    line = notice("agent-x")
+    # Assert
+    assert "1 card(s) awaiting the operator" in line
+
+
+# ---------------------------------------------------------------------------
+# cost — this runs on EVERY stop attempt
+# ---------------------------------------------------------------------------
+
+
+def test_a_second_stop_within_the_ttl_does_not_respawn_the_reader(
+    env_save_restore, tmp_path, subprocess_shim
+):
+    """A hook that adds latency to every turn gets disabled, and a disabled
+    hook protects nothing."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    env_save_restore.delete(CMD_ENV)
+    env_save_restore.set(TTL_ENV, "900")
+    subprocess_shim.install(
+        "scitex-cards",
+        stdout=json.dumps([operator_card("q-1", blocked_days_ago=30)]),
+    )
+    # Act
+    first = notice("agent-x")
+    second = notice("agent-x")
+    # Assert
+    assert (first, subprocess_shim.call_count("scitex-cards")) == (second, 1)
+
+
+def test_an_unreadable_board_is_paid_once_per_ttl_not_once_per_stop(
+    env_save_restore, tmp_path, subprocess_shim
+):
+    """The negative cache IS the fail-open budget: a database that is down
+    would otherwise charge the full timeout to every single stop attempt."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    env_save_restore.delete(CMD_ENV)
+    env_save_restore.set(TTL_ENV, "900")
+    subprocess_shim.install("scitex-cards", exit=1, stderr="ExportRefused: ...")
+    # Act
+    notice("agent-x")
+    notice("agent-x")
+    # Assert
+    assert subprocess_shim.call_count("scitex-cards") == 1
+
+
+def test_the_reading_is_cached_per_agent(env_save_restore, tmp_path):
+    """One agent's clean board must never be served as another's."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    # Act
+    paths = {cache_path("agent-x"), cache_path("agent-y")}
+    # Assert
+    assert len(paths) == 2

--- a/tests/scitex_agent_container/cli_pkg/test_never_stop_when_task_remains_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_never_stop_when_task_remains_cmds.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from scitex_agent_container._never_stop_when_task_remains._loop_guard import (
@@ -27,14 +28,33 @@ from scitex_agent_container.cli_pkg.never_stop_when_task_remains_cmds import (
 )
 
 from .._never_stop_when_task_remains._fake_detector import (
+    SCOPE_ENV,
+    awaiting_cards,
     clear_identity,
     detector_env,
     isolate_runtime,
     missing_detector,
+    no_awaiting_cards,
+    operator_card,
     runnable_verdict,
+    scope_sensitive_board,
     stale_cards_detector,
+    unreadable_board,
     write_detector,
 )
+
+
+@pytest.fixture(autouse=True)
+def _board_holds_no_operator_questions(env_save_restore, tmp_path: Path):
+    """The DEFAULT board state for every test here: nothing awaits a human.
+
+    Autouse because the hook now reads that queue on every stop, and without a
+    real local reader installed the REAL ``scitex-cards`` on PATH would be
+    spawned against the LIVE fleet board — slow, non-deterministic, and a
+    suite that goes red when a database it does not own is down. Tests that
+    care about the queue install their own reader, which wins.
+    """
+    no_awaiting_cards(env_save_restore, tmp_path)
 
 _REASON = "Do NOT stop — take card-1 next: run the failing test and fix it."
 _HOOK_JSON = json.dumps({"decision": "block", "reason": _REASON})
@@ -478,3 +498,237 @@ def test_stdout_is_pure_json_when_blocking(env_save_restore, tmp_path: Path):
     _, out = _run("agent-x")
     # Assert
     assert json.loads(out)["decision"] == "block"
+
+
+# ---------------------------------------------------------------------------
+# THE AWAITING-OPERATOR REPORT
+#
+# The failure: a `status=blocked` card sends no nudge AND is excluded from the
+# runnable-items count, so it is counted by nothing and stops existing. An
+# agent reporting "board clear" is telling the truth about the only number it
+# can see. Measured 2026-08-11: 21 such cards on this agent's board, 24 on
+# scitex-dev's, oldest three weeks old — discovered by two agents
+# independently, within minutes, after weeks of nobody looking.
+#
+# REPORT, NEVER GATE. Those cards are correctly waiting. A gate here would
+# make the hook unstoppable, and the first thing anyone does with an
+# unstoppable hook is bypass it.
+# ---------------------------------------------------------------------------
+
+
+def _board_clear_with_operator_queue(
+    env_save_restore, tmp_path: Path, *, count: int = 21, oldest_days: int = 24
+) -> None:
+    """The exact reported state: nothing runnable, a long operator queue."""
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(env_save_restore, write_detector(tmp_path, returncode=0))
+    awaiting_cards(
+        env_save_restore,
+        tmp_path,
+        [
+            operator_card(f"q-{n}", blocked_days_ago=oldest_days - n)
+            for n in range(count)
+        ],
+        name="board-with-queue",
+    )
+
+
+def test_a_board_clear_agent_is_told_the_operator_queue_exists(
+    env_save_restore, tmp_path: Path
+):
+    """THE test that matters. Before this line existed the hook emitted NOTHING
+    at all here (see ``test_allowed_stop_writes_no_stdout``), which is how 21
+    unanswered questions stayed invisible for three weeks."""
+    # Arrange
+    _board_clear_with_operator_queue(env_save_restore, tmp_path)
+    # Act
+    _, out = _run("agent-x")
+    # Assert
+    assert "21 card(s) awaiting the operator" in _decision(out).get(
+        "systemMessage", ""
+    )
+
+
+def test_the_report_names_the_age_of_the_oldest(env_save_restore, tmp_path: Path):
+    """A count alone reads as steady state; "oldest 24 days" reads as a
+    problem — which is the fact that does the work."""
+    # Arrange
+    _board_clear_with_operator_queue(env_save_restore, tmp_path)
+    # Act
+    _, out = _run("agent-x")
+    # Assert
+    assert "oldest 24 days" in _decision(out).get("systemMessage", "")
+
+
+def test_the_report_never_blocks_the_stop(env_save_restore, tmp_path: Path):
+    """A card blocked on the operator is CORRECTLY waiting. Gating on it would
+    be strictly worse than the status quo."""
+    # Arrange
+    _board_clear_with_operator_queue(env_save_restore, tmp_path)
+    # Act
+    _, out = _run("agent-x")
+    # Assert
+    assert _decision(out).get("decision") is None
+
+
+def test_the_report_rides_alongside_a_block_without_touching_the_reason(
+    env_save_restore, tmp_path: Path
+):
+    """Their ``reason`` is the agent's next instruction and is forwarded
+    verbatim; the report is ours and goes in ``systemMessage``."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(
+        env_save_restore, write_detector(tmp_path, returncode=2, stdout=_HOOK_JSON)
+    )
+    awaiting_cards(
+        env_save_restore,
+        tmp_path,
+        [operator_card("q-1", blocked_days_ago=30)],
+        name="queue-while-blocked",
+    )
+    # Act
+    _, out = _run("agent-x")
+    # Assert
+    assert _decision(out)["reason"] == _REASON
+
+
+def test_the_report_reaches_the_agent_even_while_blocked(
+    env_save_restore, tmp_path: Path
+):
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(
+        env_save_restore, write_detector(tmp_path, returncode=2, stdout=_HOOK_JSON)
+    )
+    awaiting_cards(
+        env_save_restore,
+        tmp_path,
+        [operator_card("q-1", blocked_days_ago=30)],
+        name="queue-while-blocked",
+    )
+    # Act
+    _, out = _run("agent-x")
+    # Assert
+    assert "1 card(s) awaiting the operator" in _decision(out).get("systemMessage", "")
+
+
+def test_the_report_does_not_feed_the_loop_guard(env_save_restore, tmp_path: Path):
+    """The guard digests the BLOCK TEXT to detect "no progress". An age in days
+    moves every day, so if it leaked into ``reason`` the guard could never
+    trip and a wedged agent would loop forever. It must still trip."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(
+        env_save_restore, write_detector(tmp_path, returncode=2, stdout=_HOOK_JSON)
+    )
+    awaiting_cards(
+        env_save_restore,
+        tmp_path,
+        [operator_card("q-1", blocked_days_ago=30)],
+        name="queue-during-loop",
+    )
+    # Act
+    _, out = _block_repeatedly(MAX_CONSECUTIVE_BLOCKS + 1)
+    # Assert
+    assert "ALARM" in _decision(out).get("systemMessage", "")
+
+
+def test_a_clean_operator_queue_prints_nothing(env_save_restore, tmp_path: Path):
+    """stdout IS the protocol. With nothing runnable and nothing waiting, the
+    hook must stay exactly as silent as it was before this feature."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(env_save_restore, write_detector(tmp_path, returncode=0))
+    # Act
+    _, out = _run("agent-x")
+    # Assert
+    assert out.strip() == ""
+
+
+def test_an_ambient_scope_cannot_silence_the_report_end_to_end(
+    env_save_restore, tmp_path: Path
+):
+    """A fix for an invisible queue must not itself be invisible.
+
+    ``list-tasks`` silently ANDs ``$SCITEX_TODO_SCOPE`` into its filter —
+    measured on the live board 2026-08-12, the same query answered 21 rows
+    unset and 0 rows with it set. A hook that quietly reported zero would
+    convert "nobody looked" into "we checked and it was clear", which is worse
+    than the silence it replaced.
+    """
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(env_save_restore, write_detector(tmp_path, returncode=0))
+    scope_sensitive_board(
+        env_save_restore,
+        tmp_path,
+        [operator_card(f"q-{n}", blocked_days_ago=24 - n) for n in range(21)],
+    )
+    env_save_restore.set(SCOPE_ENV, "agent:somebody-else")
+    # Act
+    _, out = _run("agent-x")
+    # Assert
+    assert "21 card(s) awaiting the operator" in _decision(out).get(
+        "systemMessage", ""
+    )
+
+
+# ---------------------------------------------------------------------------
+# the degraded case — the database refusing the read, as it did that night
+# ---------------------------------------------------------------------------
+
+
+def test_an_unreadable_board_still_allows_the_stop(env_save_restore, tmp_path: Path):
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(env_save_restore, write_detector(tmp_path, returncode=0))
+    unreadable_board(env_save_restore, tmp_path)
+    # Act
+    _, out = _run("agent-x")
+    # Assert
+    assert _decision(out).get("decision") is None
+
+
+def test_an_unreadable_board_prints_no_error(env_save_restore, tmp_path: Path):
+    """Fail open and SILENT. A hook that breaks the stop path breaks
+    everything, and a report is not worth one byte of stdout it cannot back
+    up."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(env_save_restore, write_detector(tmp_path, returncode=0))
+    unreadable_board(env_save_restore, tmp_path)
+    # Act
+    _, out = _run("agent-x")
+    # Assert
+    assert out.strip() == ""
+
+
+def test_an_unreadable_board_leaks_no_traceback_to_the_agent(
+    env_save_restore, tmp_path: Path
+):
+    """The refusal prints a traceback naming internal store modules. None of
+    it may reach the agent — the same rule that keeps click's usage text out
+    of the block reason."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    detector_env(env_save_restore, write_detector(tmp_path, returncode=0))
+    unreadable_board(env_save_restore, tmp_path)
+    # Act
+    _, out = _run("agent-x")
+    # Assert
+    assert "ExportRefused" not in out and "Traceback" not in out
+
+
+def test_an_unreadable_board_does_not_suppress_the_fail_open_alarm(
+    env_save_restore, tmp_path: Path
+):
+    """Two independent failures must both still be reported."""
+    # Arrange
+    isolate_runtime(env_save_restore, tmp_path)
+    missing_detector(env_save_restore, tmp_path)
+    unreadable_board(env_save_restore, tmp_path)
+    # Act
+    _, out = _run("agent-x")
+    # Assert
+    assert "FAIL-OPEN" in _decision(out).get("systemMessage", "")


### PR DESCRIPTION
## A queue excluded from the alarm is a queue nobody is waiting on

A card with `status=blocked` sends no nudge — deliberately, so blocked work
stops nagging. It is also excluded from the runnable-items count the Stop hook
prints. Those two facts together mean a blocked card **stops existing**:
nothing surfaces it, nothing counts it, and an agent reporting "board clear" is
telling the truth about the only number it can see.

Measured 2026-08-11, on two boards, discovered independently by two agents
minutes apart:

| board | blocked | `blocker=operator-decision` | oldest |
|---|---|---|---|
| `scitex-agent-container` | 38 | 21 | — |
| `scitex-dev` | 69 | 24 | 2026-07-19 |

Three weeks of questions naming the operator as the gate, unasked — and he had
asked one of those agents that same night whether it had anything for him, and
got one item back. Not triage: nobody looked.

**Blocked cards were designed to stop nagging, and the cost of that design was
that they stopped existing.** That shape outlives this fix.

## What this does

The Stop hook now reports the queue, in the one message an agent cannot skip:

```
⏸ 21 card(s) awaiting the operator (oldest 47 days) — surface or reclassify
```

The **age** is the part that does the work. A count alone reads as steady
state; "oldest 47 days" reads as a problem.

### Report, never gate

A card blocked on the operator is *correctly* waiting and must not prevent a
stop. A gate would make this hook unstoppable, and the first thing anyone does
with an unstoppable hook is bypass it — after which it protects nothing.

The line therefore rides on `systemMessage`, not on the block `reason`:

1. `reason` **does not exist on the allow path**, and the allow path — the
   agent that says "board clear" — is the exact failure being fixed.
2. `reason` is scitex-cards' text, forwarded verbatim. Appending to it would
   make sac an editor of someone else's instruction.
3. `reason` feeds the **loop-guard signature**, whose contract warns that any
   value moving turn to turn stops the guard ever tripping. An age in days is
   precisely such a value. A test asserts the guard still trips with the report
   present.

The runnable-items logic is untouched; the block `reason` is byte-identical
before and after (shown below).

### `agent-wait` is deliberately excluded

`blocker=agent-wait` (129 cards fleet-wide) is a *different* failure: an agent
waiting on another agent has a different owner and a different remedy. Counting
it here would misattribute the gate and dilute the one number this line exists
to make unignorable. It wants its own line. `OPERATOR_BLOCKER` is the single
place that decision lives.

### The defect found inside the fix

`list-tasks` silently ANDs `$SCITEX_TODO_SCOPE` into its filter. Measured on
the live board:

```
baseline                          : 21
with SCITEX_TODO_SCOPE=other      : 0
same + explicit --scope ''        : 21
no env + explicit --scope ''      : 21
```

An alarm an ambient environment variable can quietly turn to zero is **worse
than no alarm** — it converts "nobody looked" into "we checked and it was
clear", which is the exact failure family this change exists to remove. The
query now states its scope instead of inheriting it, and the ambient-scope case
is a test, with a control proving the fake reader really is silenced without
the fix. A suite that only ran with the variable unset would have gone green
and shipped it.

### The report names the store it read

Investigating a sibling finding — the stop hook's **inbox** check reading an
abandoned SQLite sidecar — showed the same defect class sitting in the line
this PR had just added: it published a number and never said where the number
came from.

```
⏸ 21 card(s) awaiting the operator (oldest 47 days) — surface or reclassify
   read from postgresql://scitex_cards@127.0.0.1:55432/scitex_cards (uuid 1d55dd6e)
```

This fleet has four stores — two Postgres clones, that dead sidecar (365 rows,
149 unseen, zero-byte WAL, no write since the previous morning while readers
kept attaching), and a YAML file `scitex-cards done` resolved to while
`$SCITEX_CARDS_DB` named Postgres. A count with no named source is
unfalsifiable: it looks identical whether it came from the live board or from a
corpse.

The identity comes from `scitex-cards resolve-store` — the target the package
*actually opened* — not from `$SCITEX_CARDS_DB`, which is only a claim. The
`store_uuid` is carried because a URL alone cannot separate two clones of the
same database, and this fleet is running two. Any password is redacted before
it is printed or cached.

**Control** (same shape as the ambient-scope one): pointing the resolver at the
dead sidecar must produce a *different* line. Hardcoding the store string
passes the naming test and fails that control — measured **1 failed, 133
passed**, the one failure being `test_a_different_store_produces_a_different_line`.
Neither test can pass either way.

Cost: the store probe runs only when there is something to report, so a clean
board still costs one subprocess; both sit inside the same TTL cache. A zero
prints nothing, so the cache file records `count` and `store` even then — the
audit trail the line cannot carry:

```json
{"checked_at": "2026-08-12T02:33:06Z", "count": 21,
 "store": "postgresql://scitex_cards@127.0.0.1:55432/scitex_cards (uuid 1d55dd6e)"}
```

**Not done here, deliberately:** the inbox check that reads the dead sidecar is
`scitex-cards`' `may-stop`, not sac's — sac shells out to it and treats the
payload as opaque by design (`_detector.py`'s ownership boundary). Retiring the
sidecar is their rail change
(`cards-inbox-rail-must-live-in-postgres-drop-todo-db-20260802`), and their own
`_health_backend_mode` already detects the condition. Measured here: that stale
row does **not** block forever — sac's loop guard yields at the 4th consecutive
identical block with an ALARM.

### Cost, and failing open

This runs on every stop attempt, so: a hard subprocess timeout, a 15-minute TTL
cache under the runtime tree, and a **negative cache** — an unreadable board is
remembered for the same TTL, so a database that is down is paid once per TTL
rather than once per stop. Measured: 0.68s on a cache miss, 0.10s (whole hook)
on a hit.

Every failure — missing reader, refused read, timeout, unwritable cache, any
defect in the module — returns `""` and prints **nothing**. The live board
really was refusing reads while this was written (`ExportRefused: notifications
row ... has no record_json payload`), minutes before the same query answered
with 21 rows.

## Verification — real executed output

### The failure itself: an agent that would report "board clear"

Same binary, same environment, only the source path differs (main checkout =
before, this worktree = after), against the **live board**:

```
===== BOARD CLEAR — BEFORE (main checkout source) =====
exit=0  stdout_bytes=0  stdout=[]

===== BOARD CLEAR — AFTER (this worktree's source) =====
exit=0  stdout=[{"systemMessage": "⏸ 21 card(s) awaiting the operator (oldest 47 days) — surface or reclassify"}]
decision field: None
rendered      : ⏸ 21 card(s) awaiting the operator (oldest 47 days) — surface or reclassify
```

`decision` is `None`: the stop is still allowed. Before, the hook said nothing
at all while 21 questions sat unanswered.

### The block reason is untouched

```
BEFORE: {"decision": "block", "reason": "1 runnable item(s) on scitex-agent-container's board — ...
AFTER : {"decision": "block", "reason": "1 runnable item(s) on scitex-agent-container's board — ...", "systemMessage": "⏸ 21 card(s) awaiting the operator (oldest 47 days) — surface or reclassify"}
```

### Immune to ambient scope, on the live board

```
== board clear, no ambient scope ==
{"systemMessage": "⏸ 21 card(s) awaiting the operator (oldest 47 days) — surface or reclassify"}
== board clear, SCITEX_TODO_SCOPE=agent:somebody-else ==
{"systemMessage": "⏸ 21 card(s) awaiting the operator (oldest 47 days) — surface or reclassify"}
== board clear, SCITEX_TODO_SCOPE=fleet ==
{"systemMessage": "⏸ 21 card(s) awaiting the operator (oldest 47 days) — surface or reclassify"}
```

Both predicates agree the number is real: `--status blocked --blocker
operator-decision` → 21 rows; `--blocking-me` → 21 rows.

### The degraded case: database unreachable

```
===== BOARD CLEAR + UNREADABLE DB — AFTER =====
exit=0  stdout_bytes=0  stderr_bytes=626
stdout=[]
```

Stop permitted, nothing printed. The 626 stderr bytes are byte-identical across
the before, after and degraded runs — they are this venv's pre-existing
`coverage .pth` noise, not ours; the degraded run adds zero unique lines.

### Tests

```
68 passed in 1.39s
```

### Mutation checks

Remove the wiring (`notice(agent)` → `""`):

```
FAILED ...::test_a_board_clear_agent_is_told_the_operator_queue_exists
FAILED ...::test_the_report_names_the_age_of_the_oldest
FAILED ...::test_the_report_reaches_the_agent_even_while_blocked
3 failed, 60 passed
```

Exactly the new report assertions; every pre-existing test and every
never-gate / fail-silent test still passes.

Drop the age from the line:

```
FAILED ...::test_the_line_reports_the_age_of_the_oldest
FAILED ...::test_one_day_is_not_pluralised
FAILED ...::test_a_real_reader_produces_the_line
FAILED ...::test_the_report_names_the_age_of_the_oldest
4 failed, 59 passed
```

The age is load-bearing.

## Not verified / out of scope

- Whether other boards beyond these two show the same shape. Two boards at the
  same scale suggests fleet-wide; this change makes it visible per-agent
  wherever the hook is deployed, but nothing here surveys the fleet.
- Card contents and statuses are untouched — a separate agent is triaging this
  agent's 21 cards. This PR fixes the mechanism only.
- Pre-existing suite failures unrelated to this change (`a2a/test__handlers.py`,
  `runtimes/test__sdk_common.py`, `runtimes/test__mcp_spec_env.py`,
  `cli_pkg/_helpers/test__agent_list_host_display.py`) reproduce on the main
  checkout without this change and are left for a separate PR.
