### PR TITLE
fix(deps): develop's five failures are one upstream release, not five bugs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,49 @@ dev = [
     # audit-all` and reds the `test_audit_all_clean` gate; fixed by
     # 0.17.12. Also: tests/results/ accepted as a known tests subdir
     # (PS-302).
-    "scitex-dev>=0.31.1",
+    #
+    # <0.48 CEILING — 2026-08-12, and it is a DEADLINE, not a preference.
+    # scitex-dev 0.48.0 took develop red on all three matrix legs with five
+    # failures that no sac commit caused. Measured by A/B on ONE commit
+    # (00f7f96, same click 8.4.2, same interpreter): 69/69 green with
+    # 0.47.0 installed, 4 failed with only scitex-dev swapped to 0.48.0.
+    # Three independent incompatibilities, none of them cosmetic:
+    #
+    #  1. 0.48.0 SHIPPED the per-kind job surface sac had been probing for
+    #     (`ecosystem dev {service,timer} <verb>`), and its name argument is
+    #     MIXED: install/uninstall take `--name X`, while
+    #     status/enable/disable/start/stop/restart/exec take a POSITIONAL
+    #     NAME. `_dev_jobs_backend.build_argv` emits `--name` unconditionally,
+    #     so nine sac commands now die on `Error: No such option '--name'`
+    #     (exit 2) instead of running. That is a REAL sac bug, not a test
+    #     artifact — it is why the three test__dev_jobs cases fail, and it
+    #     needs an introspection-driven fix, not a version bump.
+    #  2. 0.48.0 changed where `scitex_dev.hosts._retired` emits its WARNING,
+    #     so it no longer reaches click's isolated stderr under CliRunner
+    #     (test_library_warning_reaches_the_merged_cli_runner_output).
+    #  3. 0.48.0 ADDED rule PS-226 `job-name-not-hyphenated`, which does not
+    #     exist anywhere in 0.47.0 (verified: 0 occurrences in the 0.47.0
+    #     wheel, 6 files in 0.48.0, implemented in
+    #     `_cli/audit/_project/_check_job_naming.py`). It is the single
+    #     unmasked error behind `test_audit_all_clean`, and it fires on
+    #     `JobSpec(name="sac.accounts-refresh")`.
+    #
+    # THE RENAME PS-226 ASKS FOR IS DELIBERATELY NOT DONE HERE, and the
+    # ceiling exists so that decision stays ours rather than the clock's.
+    # `systemd_unit_name` derives the unit filename from the job name
+    # VERBATIM, so renaming does NOT adopt the live `sac.accounts-refresh.timer`
+    # — it INSTALLS A SECOND UNIT beside it. That job is the fleet's sole
+    # OAuth refresher against a SINGLE-USE refresh token, and two racing
+    # refreshers revoke each other fleet-wide. It is therefore a supervised
+    # UNIT MIGRATION (stop-old -> remove-old -> install-new -> verify-exactly-one),
+    # which already has its migration verb and recorded rename in
+    # `src/scitex_agent_container/_jobs/_migrate/_renames.py` and its
+    # reasoning in `_jobs/_names.py`. A red audit rule is survivable; a
+    # revoked fleet credential is not.
+    #
+    # LIFT THIS CEILING by doing the adaptation (1) and (2) and running the
+    # migration for (3) — not by widening the specifier.
+    "scitex-dev>=0.31.1,<0.48",
     # PS210: tests import scitex_hpc unguarded, so [dev] must include it
     # (otherwise `pip install -e .[dev]` can't run the full suite).
     "scitex-hpc>=0.6.2",


### PR DESCRIPTION
`develop` has been red on all three matrix legs since `0c2ae7a`, and stayed red across the three commits after it. Every PR that merged develop inherited the failures, so authors have been diagnosing red that was never theirs. This turns it green **without changing a line of product code** and **without touching the `sac.accounts-refresh` unit**.

## The five failures are one upstream release

Measured by A/B on a single commit — same worktree, same interpreter, same `click` 8.4.2, only the `scitex-dev` version swapped:

| scitex-dev | result |
|---|---|
| 0.47.0 | `69 passed` |
| 0.48.0 | `4 failed, 65 passed` |

Those four are exactly develop's four non-audit failures. The fifth, `test_audit_all_clean`, is the same release: its single unmasked error is `PS-226 job-name-not-hyphenated`, a rule with **0 occurrences in the 0.47.0 wheel** and six files in 0.48.0 (`_cli/audit/_project/_check_job_naming.py`).

## Three distinct incompatibilities

1. **A real sac bug.** 0.48.0 shipped the per-kind job surface sac had been probing for, and its name argument is **mixed**: `install`/`uninstall` take `--name X`, while `status`/`enable`/`disable`/`start`/`stop`/`restart`/`exec` take a **positional NAME**. `build_argv` emits `--name` unconditionally, so nine sac commands now die on `Error: No such option '--name'` (exit 2) instead of running. The three `test__dev_jobs` failures are that bug surfacing — the tests assert sac *refuses* an unservable verb with exit 4; 0.48.0 made the verb servable, so sac delegates, and the subprocess's stderr goes to the inherited fd rather than to `CliRunner`, which is why `result.stderr` came back empty.
2. 0.48.0 changed where `scitex_dev.hosts._retired` emits its WARNING, so it no longer reaches click's isolated stderr under `CliRunner`.
3. 0.48.0 added `PS-226`, which fires on `JobSpec(name="sac.accounts-refresh")`.

## The rename is deliberately deferred

`systemd_unit_name` derives the unit filename from the job name **verbatim**, so renaming does not adopt the live `sac.accounts-refresh.timer` — it **installs a second unit beside it**. That job is the fleet's sole OAuth refresher against a single-use refresh token, and two racing refreshers revoke each other fleet-wide.

It is a supervised unit migration (`stop-old → remove-old → install-new → verify-exactly-one`) whose verb and recorded rename already exist in `_jobs/_migrate/_renames.py`, with the reasoning in `_jobs/_names.py`. **A red audit rule is survivable; a revoked fleet credential is not.** The ceiling exists so that decision stays ours rather than the clock's.

## Two attributions this refutes, both measured

- **Not a stale CI SIF.** A stale image means an *older* scitex-dev, under which `ecosystem dev timer status` does not exist, sac refuses, and the tests **pass**. The failure requires a scitex-dev *newer* than the tests. The run log also shows uv downloading and installing `scitex-dev==0.48.0` fresh during the job.
- **Not click 8.2's merged `result.output`.** click was 8.4.2 in both A/B runs; only scitex-dev differed.

Also recorded: `[§6a] LOG_PATH` / `CODEX_HOME` is a **local-environment artifact**, not develop's audit failure — it fires identically under 0.47.0 and 0.48.0 on a developer checkout and appears nowhere in CI's audit output, where `audit-cli` reports 0 errors.

## Not covered here

`test_cli_startup_budget.py::test_cli_help_under_budget` failed on develop's own run but not on PRs merging the same commit, and is unrelated to scitex-dev. It is load-sensitive — 0.48.0's own audit independently reports this class of node at a `325ms` bare-interpreter baseline against a `100ms` sanity bound. It needs characterising separately, not counting with these five.

## Follow-up

Lift the ceiling by doing the adaptation — `build_argv` name-shape by introspection, the logging assertion, and the supervised unit migration — never by widening the specifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
